### PR TITLE
fix(personal-agent): buremba schema source of truth + prune

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,10 +650,13 @@ jobs:
 
   migrations:
     # Catches the class of bug that has now broken prod twice in one
-    # session: a migration file that's syntactically a SQL file but that
-    # `dbmate up` rejects (missing -- migrate:up directive, constraint
-    # violations against legacy data, etc.). Runs every migration in
-    # order against an empty Postgres on every PR.
+    # session: a migration file that's syntactically a SQL file but that the
+    # migration runner rejects (missing -- migrate:up directive, constraint
+    # violations against legacy data, etc.). Runs every migration in order
+    # against an empty Postgres on every PR using the SAME runner production
+    # uses (scripts/migrate-up.mjs), so a migration that only the prod runner
+    # can apply (e.g. transaction:false heal-DO + CONCURRENTLY) is validated
+    # here instead of silently diverging from `dbmate up`.
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     services:
@@ -785,7 +788,25 @@ jobs:
         # to a fresh DB. That's the only schema check left after the squash —
         # db/schema.sql + the drift-gate-vs-baseline diff are gone since the
         # baseline IS the canonical schema.
-        run: dbmate --migrations-dir db/migrations up
+        #
+        # Apply with the SAME runner production uses (scripts/migrate-up.mjs, via
+        # docker/app/start.sh), NOT `dbmate up`. dbmate Exec's a migration's
+        # whole up section as one simple-query batch, which Postgres runs in an
+        # implicit transaction; a `transaction:false` migration that pairs a heal
+        # DO with CREATE/DROP INDEX CONCURRENTLY then fails with "CREATE INDEX
+        # CONCURRENTLY cannot run inside a transaction block". migrate-up.mjs
+        # splits top-level statements so CONCURRENTLY runs on its own, and still
+        # records versions in the dbmate-compatible public.schema_migrations
+        # ledger (the `dbmate status` verify step below reads it). Its only
+        # runtime dep is `postgres`; npm can't install the workspace root
+        # (workspace: protocol), so install just that package in a scratch dir
+        # and expose it via a top-level node_modules entry the ESM loader resolves.
+        run: |
+          tmp="$(mktemp -d)"
+          (cd "$tmp" && npm init -y >/dev/null && npm install --no-audit --no-fund postgres@^3.4.7 >/dev/null)
+          mkdir -p node_modules
+          cp -r "$tmp/node_modules/postgres" node_modules/postgres
+          node scripts/migrate-up.mjs
 
       - name: Verify migrations are listed in the schema_migrations table
         env:

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1,11 +1,11 @@
 import {
   connectorFromFile,
   defineAgent,
+  defineBehavior,
   defineConfig,
   defineConnection,
   defineEntityType,
   defineRelationshipType,
-  defineWatcher,
 } from "@lobu/cli/config";
 import type GoogleTakeoutConnector from "./google-takeout.connector.ts";
 import type InstagramTakeoutConnector from "./instagram-takeout.connector.ts";
@@ -908,13 +908,13 @@ const mentions = defineRelationshipType({
   description: "Auto-discovered content reference",
 });
 
-// ── Watchers (must be declared under prune or apply deletes them) ─
+// ── Behaviors (must be declared under prune or apply deletes them) ─
 
-const hourlyTaskCollaborator = defineWatcher({
+const hourlyTaskCollaborator = defineBehavior({
   agent: personalAgent,
   slug: "hourly-task-collaborator",
   name: "Hourly Task Collaborator",
-  schedule: "0 * * * *",
+  triggers: [{ kind: "schedule", cron: "0 * * * *" }],
   notification: { channel: "both", priority: "normal" },
   minCooldownSeconds: 300,
   keyingConfig: {
@@ -937,7 +937,7 @@ const hourlyTaskCollaborator = defineWatcher({
     'Review the current hourly window in {{content}} and the collaborative task list in sources.task_list. The task_list source includes recently closed tasks (metadata status done or dismissed) for reference so you know what is already finished. Return a JSON object with a tasks array matching the provided task schema. Extract only concrete actions Burak or his personal agent should take; ignore advertisements, newsletters, automated notices, passive information, and vague ideas. Use concise imperative wording in action so equivalent requests deduplicate across runs. Preserve existing tasks instead of restating them. Never re-emit, reopen, or recreate any task whose status is done or dismissed in the task list, even if the originating message still appears in recent signals. Set status to backlog unless there is clear evidence work has started. Assign owner "Burak" unless the action can be safely completed by the personal agent. Use ISO-8601 due_date only when a real deadline is present. Include source_event_id and source when available, and a short rationale. Produce at most 12 tasks, ordered by priority.',
 });
 
-const duplicateEntityResolution = defineWatcher({
+const duplicateEntityResolution = defineBehavior({
   agent: personalAgent,
   slug: "duplicate-entity-resolution-real-v3-final",
   name: "Duplicate entity resolution — real contacts",
@@ -959,7 +959,7 @@ const duplicateEntityResolution = defineWatcher({
 
 export default defineConfig({
   // Source of truth for buremba definitions. Deletes org-owned entity /
-  // relationship types and watchers absent from this config (including
+  // relationship types and behaviors absent from this config (including
   // UI-created ones). Data rows, connections, auth profiles, and agents are
   // never pruned. Tax-graph types belong in examples/personal-finance only.
   prune: true,
@@ -1000,7 +1000,7 @@ export default defineConfig({
     learning,
   ],
   relationships: [worksAt, memberOf, mentions],
-  watchers: [hourlyTaskCollaborator, duplicateEntityResolution],
+  behaviors: [hourlyTaskCollaborator, duplicateEntityResolution],
   connections: [
     midasConnection,
     revolutConnection,

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -926,11 +926,15 @@ const hourlyTaskCollaborator = defineWatcher({
   sources: {
     recent_signals:
       "SELECT id, occurred_at, title, payload_text, semantic_type, connector_key, metadata FROM events WHERE semantic_type IN ('message','thread','reminder','calendar_event','note') ORDER BY occurred_at DESC LIMIT 200",
-    task_list:
-      "SELECT NULL::bigint AS id, t.name, t.metadata, t.updated_at FROM entities t WHERE t.entity_type = 'task' AND t.deleted_at IS NULL AND (COALESCE(t.metadata->>'status', 'backlog') NOT IN ('done', 'dismissed') OR t.updated_at > now() - interval '14 days') ORDER BY t.updated_at DESC LIMIT 100",
+    // context-only: existing tasks are dedup reference data, not window signal
+    task_list: {
+      context: true,
+      query:
+        "SELECT NULL::bigint AS id, t.name, t.metadata, t.updated_at FROM entities t WHERE t.entity_type = 'task' AND t.deleted_at IS NULL AND (COALESCE(t.metadata->>'status', 'backlog') NOT IN ('done', 'dismissed') OR t.updated_at > now() - interval '14 days') ORDER BY t.updated_at DESC LIMIT 100",
+    },
   },
   prompt:
-    'Review the current hourly window and the collaborative task list in {{content}}. The task_list source includes recently closed tasks (metadata status done or dismissed) for reference so you know what is already finished. Return a JSON object with a tasks array matching the provided task schema. Extract only concrete actions Burak or his personal agent should take; ignore advertisements, newsletters, automated notices, passive information, and vague ideas. Use concise imperative wording in action so equivalent requests deduplicate across runs. Preserve existing tasks instead of restating them. Never re-emit, reopen, or recreate any task whose status is done or dismissed in the task list, even if the originating message still appears in recent signals. Set status to backlog unless there is clear evidence work has started. Assign owner "Burak" unless the action can be safely completed by the personal agent. Use ISO-8601 due_date only when a real deadline is present. Include source_event_id and source when available, and a short rationale. Produce at most 12 tasks, ordered by priority.',
+    'Review the current hourly window in {{content}} and the collaborative task list in sources.task_list. The task_list source includes recently closed tasks (metadata status done or dismissed) for reference so you know what is already finished. Return a JSON object with a tasks array matching the provided task schema. Extract only concrete actions Burak or his personal agent should take; ignore advertisements, newsletters, automated notices, passive information, and vague ideas. Use concise imperative wording in action so equivalent requests deduplicate across runs. Preserve existing tasks instead of restating them. Never re-emit, reopen, or recreate any task whose status is done or dismissed in the task list, even if the originating message still appears in recent signals. Set status to backlog unless there is clear evidence work has started. Assign owner "Burak" unless the action can be safely completed by the personal agent. Use ISO-8601 due_date only when a real deadline is present. Include source_event_id and source when available, and a short rationale. Produce at most 12 tasks, ordered by priority.',
 });
 
 const duplicateEntityResolution = defineWatcher({

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -4,6 +4,8 @@ import {
   defineConfig,
   defineConnection,
   defineEntityType,
+  defineRelationshipType,
+  defineWatcher,
 } from "@lobu/cli/config";
 import type GoogleTakeoutConnector from "./google-takeout.connector.ts";
 import type InstagramTakeoutConnector from "./instagram-takeout.connector.ts";
@@ -19,7 +21,7 @@ const personalAgent = defineAgent({
   dir: ".",
   name: "personal-agent",
   description:
-    "A personal agent that tracks finances, people, companies, subscriptions, trips, and topics across the user's own data.",
+    "A personal agent that tracks finances, people, companies, tasks, subscriptions, and trips across the user's own data.",
   // No cloud provider key: runs on the local/Mac-app device worker and inherits
   // the org's default provider. No ANTHROPIC_API_KEY needed.
   //
@@ -42,22 +44,100 @@ const personalAgent = defineAgent({
 const person = defineEntityType({
   key: "person",
   name: "Person",
-  description: "Team member, contact, or stakeholder",
+  description:
+    "A real-world person linked across connectors via identities (x_user_id, x_handle, wa_jid, phone, email, linkedin_slug, …). Metadata holds connector traits and optional human notes — not a CRM form.",
   metadata: { icon: "user", color: "#8B5CF6" },
+  // Trait names must match connector EventAttributionRule.traits keys.
+  // Identity join keys live on entity identities/aliases, not as required props.
   properties: {
-    role: { type: "string" },
-    type: {
+    // X (packages/connectors x.ts + twitter takeout)
+    x_handle: {
       type: "string",
-      enum: ["employee", "client_contact", "partner", "external"],
+      description:
+        "X/Twitter @handle without @. Mutable secondary identity; primary join is x_user_id.",
+      "x-table-label": "X",
+      "x-table-column": true,
     },
-    email: { type: "string" },
-    company: { type: "string" },
-    session_prefix: { type: "string" },
+    x_display_name: {
+      type: "string",
+      description: "Display name from X profile/posts.",
+    },
+    last_x_interaction_at: {
+      type: "string",
+      format: "date-time",
+      description:
+        "Most recent X post/like/bookmark/reply involving this person.",
+      "x-table-label": "Last X",
+      "x-table-column": true,
+    },
+    last_x_dm_at: {
+      type: "string",
+      format: "date-time",
+      description: "Most recent X DM with this person.",
+    },
+    // WhatsApp
+    push_name: {
+      type: "string",
+      description: "WhatsApp push name.",
+      "x-table-label": "WA name",
+      "x-table-column": true,
+    },
+    last_seen_at: {
+      type: "string",
+      format: "date-time",
+      description: "Most recent WhatsApp message time for this contact.",
+    },
+    // LinkedIn
+    linkedin_url: {
+      type: "string",
+      description:
+        "LinkedIn profile URL (display trait; identity is linkedin_slug).",
+    },
+    position: {
+      type: "string",
+      description: "LinkedIn headline/position.",
+    },
+    company: {
+      type: "string",
+      description: "Company / employer (LinkedIn connection + manual).",
+      "x-table-label": "Company",
+      "x-table-column": true,
+    },
+    last_linkedin_message_at: {
+      type: "string",
+      format: "date-time",
+      description: "Most recent LinkedIn message with this person.",
+    },
+    // Instagram takeout
+    ig_username: {
+      type: "string",
+      description: "Instagram username.",
+    },
+    instagram_profile_url: {
+      type: "string",
+      description: "Instagram profile URL.",
+    },
+    // Gmail (match-only; traits accrete when identity already exists)
+    from_name: {
+      type: "string",
+      description: "Name as seen on inbound email.",
+    },
+    last_email_at: {
+      type: "string",
+      format: "date-time",
+      description: "Most recent email from/to this address.",
+    },
+    // Optional human-curated (email is also an identity namespace)
+    email: {
+      type: "string",
+      description: "Email address (also an identity namespace).",
+    },
     first_name: { type: "string" },
     last_name: { type: "string" },
-    linkedin_url: { type: "string" },
-    twitter_handle: { type: "string" },
-    instagram_handle: { type: "string" },
+    role: {
+      type: "string",
+      description: "Freeform role or relationship note (not a CRM enum).",
+    },
   },
   // WhatsApp + X identity metrics. Declared here so `apply` preserves them
   // rather than pruning — persons alias connector identities (wa_jid, x_handle).
@@ -116,10 +196,21 @@ const person = defineEntityType({
 const company = defineEntityType({
   key: "company",
   name: "Company",
-  description: "Portfolio company or deal pipeline company",
+  description:
+    "An organization the user cares about — own company, employer, customer, partner, or portfolio company. Link people via works_at.",
   metadata: { icon: "building", color: "#2563eb" },
   properties: {
-    mrr: { type: "number", description: "Monthly recurring revenue in USD" },
+    // Core identity / positioning
+    domain: { type: "string", description: "Primary web domain" },
+    one_liner: { type: "string", description: "One-line description" },
+    location: { type: "string" },
+    market: { type: "string", description: "Primary market vertical" },
+    main_market: { type: "string" },
+    platform_type: { type: "string" },
+    linkedin_url: { type: "string", format: "uri" },
+    founding_year: { type: "integer", maximum: 2030, minimum: 1900 },
+    team_size: { type: "integer", minimum: 0 },
+    // Optional growth / funding fields (portfolio / competitive tracking)
     stage: {
       type: "string",
       enum: [
@@ -131,22 +222,17 @@ const company = defineEntityType({
         "growth",
         "public",
       ],
-      description: "Current funding stage",
+      description: "Current funding stage when relevant",
     },
-    market: { type: "string", description: "Primary market vertical" },
-    thesis: { type: "string", description: "Investment thesis notes" },
+    mrr: { type: "number", description: "Monthly recurring revenue in USD" },
     revenue: { type: "number", description: "Annual revenue in USD" },
-    location: { type: "string" },
-    one_liner: { type: "string", description: "One-line pitch" },
-    team_size: { type: "integer", minimum: 0 },
     valuation: { type: "number", description: "Last known valuation in USD" },
     growth_rate: { type: "number", description: "YoY growth rate as decimal" },
-    linkedin_url: { type: "string", format: "uri" },
-    founding_year: { type: "integer", maximum: 2030, minimum: 1900 },
     funding_raised: {
       type: "number",
       description: "Total funding raised in USD",
     },
+    thesis: { type: "string", description: "Investment or relationship notes" },
     traction_score: {
       type: "number",
       maximum: 100,
@@ -164,6 +250,88 @@ const company = defineEntityType({
         app_store_growth: { type: "number" },
         review_sentiment: { type: "number" },
       },
+    },
+  },
+});
+
+// System chat-surface unit (Slack etc.). Declared so prune does not attempt to
+// delete the org's channel type while conversation ACL still depends on it.
+const channel = defineEntityType({
+  key: "channel",
+  name: "Channel",
+  description:
+    "A chat channel (Slack channel, etc.) — the unit of conversation access control",
+});
+
+// Collaborative actions for Burak + personal-agent (hourly-task-collaborator
+// keys + merges on `action`). Schema is owned here — the watcher does not
+// declare its own extraction schema.
+const task = defineEntityType({
+  key: "task",
+  name: "Task",
+  description:
+    "An actionable item collaboratively managed by Burak and his personal agent.",
+  metadata: { icon: "check-square", color: "#10B981" },
+  required: ["action", "status"],
+  properties: {
+    action: {
+      type: "string",
+      minLength: 1,
+      description: "Concrete action to perform",
+      "x-table-label": "Action",
+      "x-table-column": true,
+    },
+    status: {
+      type: "string",
+      enum: ["backlog", "active", "done", "dismissed"],
+      description: "Collaborative task state",
+      "x-table-label": "Status",
+      "x-table-column": true,
+    },
+    owner: {
+      type: "string",
+      description: "Person or agent responsible",
+      "x-table-label": "Owner",
+      "x-table-column": true,
+    },
+    priority: {
+      type: "string",
+      enum: ["high", "medium", "low"],
+      description: "Execution priority",
+      "x-table-label": "Priority",
+      "x-table-column": true,
+    },
+    due_date: {
+      type: "string",
+      format: "date-time",
+      description: "Due time when known",
+      "x-table-label": "Due",
+      "x-table-column": true,
+    },
+    source: {
+      type: "string",
+      description: "Where this task came from",
+    },
+    rationale: {
+      type: "string",
+      description: "Why this task is worth doing",
+    },
+    source_event_id: {
+      type: "string",
+      description: "Originating Lobu event id when applicable",
+    },
+    // Written by the entity-typed watcher keying pipeline
+    stable_key: {
+      type: "string",
+      description: "Stable dedupe key from the task watcher",
+    },
+    watcher_id: {
+      type: "string",
+      description: "Watcher that last wrote this task",
+    },
+    window_id: {
+      type: "string",
+      description: "Watcher window that produced this task",
     },
   },
 });
@@ -445,17 +613,6 @@ const subscription = defineEntityType({
   },
 });
 
-const topic = defineEntityType({
-  key: "topic",
-  name: "Topic",
-  description:
-    "Generic topic or category for organizing content and connections",
-  metadata: { icon: "📚", color: "#8B5CF6" },
-  properties: {
-    description: { type: "string" },
-  },
-});
-
 // Trips are stored from explicit travel evidence such as passport stamps.
 // Related transaction/photo windows are attached through event sets below.
 const trip = defineEntityType({
@@ -727,7 +884,81 @@ const midasConnection = defineConnection({
   feeds: [{ feed: "assets", config: {} }],
 });
 
+// ── Relationships (only those the personal agent uses) ──────────
+// Tax-graph relationship types (account_contains, for_tax_year, …) belong in
+// examples/personal-finance — not here. With prune:true they are removed from
+// buremba if present.
+
+const worksAt = defineRelationshipType({
+  key: "works_at",
+  name: "Works At",
+  description: "Person employed by / associated with a company",
+  rules: [{ source: person, target: company }],
+});
+
+const memberOf = defineRelationshipType({
+  key: "member_of",
+  name: "Member of",
+  description: "A person is a member of an organization or channel",
+});
+
+const mentions = defineRelationshipType({
+  key: "mentions",
+  name: "Mentions",
+  description: "Auto-discovered content reference",
+});
+
+// ── Watchers (must be declared under prune or apply deletes them) ─
+
+const hourlyTaskCollaborator = defineWatcher({
+  agent: personalAgent,
+  slug: "hourly-task-collaborator",
+  name: "Hourly Task Collaborator",
+  schedule: "0 * * * *",
+  notification: { channel: "both", priority: "normal" },
+  minCooldownSeconds: 300,
+  keyingConfig: {
+    entityType: "task",
+    entityPath: "tasks",
+    keyFields: ["action"],
+    keyOutputField: "task_key",
+  },
+  sources: {
+    recent_signals:
+      "SELECT id, occurred_at, title, payload_text, semantic_type, connector_key, metadata FROM events WHERE semantic_type IN ('message','thread','reminder','calendar_event','note') ORDER BY occurred_at DESC LIMIT 200",
+    task_list:
+      "SELECT NULL::bigint AS id, t.name, t.metadata, t.updated_at FROM entities t WHERE t.entity_type = 'task' AND t.deleted_at IS NULL AND (COALESCE(t.metadata->>'status', 'backlog') NOT IN ('done', 'dismissed') OR t.updated_at > now() - interval '14 days') ORDER BY t.updated_at DESC LIMIT 100",
+  },
+  prompt:
+    'Review the current hourly window and the collaborative task list in {{content}}. The task_list source includes recently closed tasks (metadata status done or dismissed) for reference so you know what is already finished. Return a JSON object with a tasks array matching the provided task schema. Extract only concrete actions Burak or his personal agent should take; ignore advertisements, newsletters, automated notices, passive information, and vague ideas. Use concise imperative wording in action so equivalent requests deduplicate across runs. Preserve existing tasks instead of restating them. Never re-emit, reopen, or recreate any task whose status is done or dismissed in the task list, even if the originating message still appears in recent signals. Set status to backlog unless there is clear evidence work has started. Assign owner "Burak" unless the action can be safely completed by the personal agent. Use ISO-8601 due_date only when a real deadline is present. Include source_event_id and source when available, and a short rationale. Produce at most 12 tasks, ordered by priority.',
+});
+
+const duplicateEntityResolution = defineWatcher({
+  agent: personalAgent,
+  slug: "duplicate-entity-resolution-real-v3-final",
+  name: "Duplicate entity resolution — real contacts",
+  tags: ["identity", "deduplication", "world-model"],
+  notification: { channel: "canvas", priority: "normal" },
+  sources: {
+    // context-only: duplicate candidates for analysis (not window body)
+    people: {
+      context: true,
+      query:
+        "SELECT * FROM (SELECT id AS id, name AS name, name_key AS name_key, match_reason AS match_reason, metadata AS metadata, created_at AS created_at, updated_at AS updated_at\nFROM (\n  SELECT id, name, metadata, created_at, updated_at,\n    regexp_replace(lower(trim(name)),'[^a-z0-9]','','g') AS name_key,\n    nullif(lower(trim(metadata->>'email')),'') AS em,\n    nullif(regexp_replace(coalesce(metadata->>'phone',''),'[^0-9]','','g'),'') AS ph,\n    COUNT(*) OVER (PARTITION BY regexp_replace(lower(trim(name)),'[^a-z0-9]','','g')) AS name_grp,\n    COUNT(*) OVER (PARTITION BY nullif(lower(trim(metadata->>'email')),'')) AS email_grp,\n    COUNT(*) OVER (PARTITION BY nullif(regexp_replace(coalesce(metadata->>'phone',''),'[^0-9]','','g'),'')) AS phone_grp,\n    CASE\n      WHEN nullif(lower(trim(metadata->>'email')),'') IS NOT NULL\n           AND COUNT(*) OVER (PARTITION BY nullif(lower(trim(metadata->>'email')),'')) > 1 THEN 'email:' || lower(trim(metadata->>'email'))\n      WHEN length(nullif(regexp_replace(coalesce(metadata->>'phone',''),'[^0-9]','','g'),'')) >= 7\n           AND COUNT(*) OVER (PARTITION BY nullif(regexp_replace(coalesce(metadata->>'phone',''),'[^0-9]','','g'),'')) > 1 THEN 'phone:' || regexp_replace(coalesce(metadata->>'phone',''),'[^0-9]','','g')\n      ELSE 'name:' || regexp_replace(lower(trim(name)),'[^a-z0-9]','','g')\n    END AS match_reason\n  FROM entities\n  WHERE entity_type='person' AND deleted_at IS NULL AND merged_into IS NULL\n    AND trim(coalesce(name,'')) <> ''\n) s\nWHERE (s.name_grp > 1 AND s.name_key <> '')\n   OR (s.em IS NOT NULL AND s.email_grp > 1)\n   OR (s.ph IS NOT NULL AND length(s.ph) >= 7 AND s.phone_grp > 1)\nORDER BY s.match_reason, s.id\nLIMIT 200) real_candidates WHERE COALESCE(metadata->>'email','') NOT LIKE '%@example.test'",
+    },
+  },
+  reactionsGuidance:
+    "Explain uncertainty; never decide identity from names, aliases, or handles. The server-side entity type policy is the only merge authority.",
+  prompt:
+    "Review every row in sources.people. Explain likely duplicate groups in analysis_summary and put name-only, alias-only, handle-only, oversized, or otherwise uncertain groups in uncertain_groups with why. Do not call entity tools or emit backlog tasks. After analysis, the deterministic reaction submits only candidate IDs to the server. The person entity type's x-lobu-resolution policy decides which normalized identities auto-merge and which require human review. Without that extension, normalized email and phone matches remain review-only and never auto-merge.\n",
+});
+
 export default defineConfig({
+  // Source of truth for buremba definitions. Deletes org-owned entity /
+  // relationship types and watchers absent from this config (including
+  // UI-created ones). Data rows, connections, auth profiles, and agents are
+  // never pruned. Tax-graph types belong in examples/personal-finance only.
+  prune: true,
   connectors: [
     connectorFromFile<typeof MidasConnector>("./midas.connector.ts"),
     connectorFromFile<typeof RevolutTransactionsConnector>(
@@ -751,9 +982,21 @@ export default defineConfig({
   org: "buremba",
   orgName: "Buremba Org",
   orgDescription:
-    "Personal agent tracking finances, people, companies, subscriptions, trips, and topics.",
+    "Personal agent tracking finances, people, companies, tasks, subscriptions, and trips.",
   agents: [personalAgent],
-  entities: [person, company, asset, subscription, topic, trip, goal, learning],
+  entities: [
+    person,
+    company,
+    task,
+    channel,
+    asset,
+    subscription,
+    trip,
+    goal,
+    learning,
+  ],
+  relationships: [worksAt, memberOf, mentions],
+  watchers: [hourlyTaskCollaborator, duplicateEntityResolution],
   connections: [
     midasConnection,
     revolutConnection,

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -370,7 +370,10 @@ describe("mapProjectToDesiredState", () => {
       agent: crm,
       slug: "health",
       prompt: "assess",
-      sources: { accounts: "SELECT 1" },
+      sources: {
+        accounts: "SELECT 1",
+        ctx: { query: "SELECT 2", context: true },
+      },
       notification: { channel: "both", priority: "high" },
       minCooldownSeconds: 1800,
       triggers: [
@@ -392,7 +395,10 @@ describe("mapProjectToDesiredState", () => {
     );
     const dw = state.watchers[0];
     expect(dw?.agent).toBe("crm");
-    expect(dw?.sources).toEqual([{ name: "accounts", query: "SELECT 1" }]);
+    expect(dw?.sources).toEqual([
+      { name: "accounts", query: "SELECT 1" },
+      { name: "ctx", query: "SELECT 2", context: true },
+    ]);
     expect(dw?.notificationChannel).toBe("both");
     expect(dw?.notificationPriority).toBe("high");
     expect(dw?.minCooldownSeconds).toBe(1800);

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -584,7 +584,14 @@ function normalizeKeyingConfig(
 function mapBehavior(behavior: Behavior): DesiredWatcher {
   const watcher = behavior;
   const sources = watcher.sources
-    ? Object.entries(watcher.sources).map(([name, query]) => ({ name, query }))
+    ? Object.entries(watcher.sources).map(([name, value]) => {
+        if (typeof value === "string") return { name, query: value };
+        return {
+          name,
+          query: value.query,
+          ...(value.context ? { context: true as const } : {}),
+        };
+      })
     : undefined;
   let hasSchedule = false;
   const triggers = watcher.triggers?.map((trigger) => {

--- a/packages/cli/src/commands/_lib/apply/shared.ts
+++ b/packages/cli/src/commands/_lib/apply/shared.ts
@@ -29,6 +29,8 @@ export interface RelationshipRule {
 export interface BehaviorSource {
   name: string;
   query: string;
+  /** When true, source is context-only (prompt template), not window body. */
+  context?: boolean;
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -396,8 +396,12 @@ export interface Behavior {
     keyOutputField?: string;
     [k: string]: unknown;
   };
-  /** Named SQL data sources (`name` -> query). */
-  sources?: Record<string, string>;
+  /**
+   * Named SQL data sources. Value is either a query string or
+   * `{ query, context? }` — `context: true` marks a context-only source
+   * (bound into the prompt template but not the watcher window body).
+   */
+  sources?: Record<string, string | { query: string; context?: boolean }>;
   notification?: BehaviorNotification;
   minCooldownSeconds?: number;
   tags?: string[];

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -245,7 +245,12 @@ const X_DM_COUNTERPARTY_ATTRIBUTIONS: EventAttributionRule[] = [
 		},
 		traits: {
 			x_handle: { eventPath: "metadata.sender_handle", behavior: "prefer_non_empty" },
-			display_name: { eventPath: "metadata.sender_name", behavior: "prefer_non_empty" },
+			// Same trait key as X_PERSON_AUTHOR_TRAITS / DM counterparty — keep
+			// person metadata vocabulary consistent across X attribution paths.
+			x_display_name: {
+				eventPath: "metadata.sender_name",
+				behavior: "prefer_non_empty",
+			},
 		},
 	},
 	{

--- a/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
@@ -344,4 +344,48 @@ describe("manage_behaviors source-id + cross-org guards", () => {
 		})) as { created: Array<{ watcher_id: string }> };
 		expect(result.created.length).toBe(1);
 	});
+
+	// ---- BUG C: delete/update must not archive/mutate cross-org rows ----
+	// requireWatcherAccess lets an id that is absent from the caller's org fall
+	// through to the per-id aggregate (so genuinely-missing ids report "not
+	// found"). Watcher ids are sequential integers, so a foreign-tenant row can
+	// occupy the id the caller aimed at. The mutation SQL is org-scoped so that
+	// foreign row is never archived — it only reports as a per-id failure.
+	it("delete cannot archive a watcher owned by another org", async () => {
+		const foreignOrg = await createTestOrganization({ name: "Delete Foreign Org" });
+		const foreignUser = await createTestUser({ email: "delete-foreign@test.com" });
+		await addUserToOrganization(foreignUser.id, foreignOrg.id, "owner");
+		const foreignClient = await TestApiClient.for({
+			organizationId: foreignOrg.id,
+			userId: foreignUser.id,
+			memberRole: "owner",
+		});
+		const foreignAgent = await createTestAgent({
+			organizationId: foreignOrg.id,
+			ownerUserId: foreignUser.id,
+		});
+		const foreignWatcher = (await foreignClient.behaviors.create({
+			slug: "foreign-del-target",
+			name: "Foreign Behavior",
+			prompt: "Track stuff.",
+			agent_id: foreignAgent.agentId,
+			sources: [{ name: "content", query: "SELECT id FROM events" }],
+		})) as { watcher_id: string };
+		const foreignId = String(foreignWatcher.watcher_id);
+
+		// The owner (a different org) targets the foreign row's id directly. It
+		// exists under another tenant, so requireWatcherAccess rejects it 403 —
+		// and even if that gate were bypassed, the org-scoped archive UPDATE
+		// leaves the foreign row untouched.
+		await expect(
+			owner.behaviors.delete({ watcher_ids: [foreignId] })
+		).rejects.toMatchObject({ httpStatus: 403 });
+
+		// The foreign row is untouched — still active, not archived.
+		const sql = getTestDb();
+		const [after] = await sql<{ status: string }[]>`
+      SELECT status FROM watchers WHERE id = ${foreignId}
+    `;
+		expect(after?.status).toBe("active");
+	});
 });

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -313,10 +313,11 @@ export function getLockDb(): Sql {
       max_lifetime: 60 * 30,
       connection: {
         application_name: 'server-locks',
-        // Startup GUC (milliseconds): bounds every lock wait on these
-        // sessions, advisory locks included. 55P03 (lock_not_available)
-        // on expiry.
-        lock_timeout: 30000,
+        // Do NOT set lock_timeout here as a startup GUC — Neon/PgBouncer and
+        // other poolers reject unsupported startup parameters and the whole
+        // reserve() fails with "unsupported startup parameter: lock_timeout".
+        // Callers SET lock_timeout on the reserved session instead
+        // (see withWatcherGroupLock).
       },
     });
     logger.info('[DB] PostgreSQL advisory-lock pool created');

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -272,6 +272,9 @@ async function withWatcherGroupLock<T>(
 
   const reserved = await getLockDb().reserve();
   try {
+    // Session GUC (not a startup parameter — poolers reject lock_timeout on
+    // connect). Bounds advisory-lock wait: 55P03 → coded 409 below.
+    await reserved`SELECT set_config('lock_timeout', '30s', false)`;
     try {
       await reserved`SELECT pg_advisory_lock(hashtext(${WATCHER_GROUP_LOCK_NS}), ${groupId})`;
     } catch (err) {

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -132,7 +132,11 @@ async function manageBehaviorsImpl(
   } else if (args.action === 'trigger' && args.watcher_id) {
     await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
   } else if (args.action === 'delete' && args.watcher_ids && args.watcher_ids.length > 0) {
-    await requireWatcherAccess(pgSql, args.watcher_ids, ctx, 'write');
+    // delete alone allows missing ids to fall through to its per-id aggregate
+    // ("not found or already archived"); every other action stays a hard 403.
+    await requireWatcherAccess(pgSql, args.watcher_ids, ctx, 'write', {
+      allowMissing: true,
+    });
   } else if (args.action === 'complete_window' && args.entity_id) {
     await requireWriteAccess(pgSql, args.entity_id, ctx);
   } else if (args.action === 'create_version' && args.watcher_id) {

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -525,7 +525,7 @@ export async function handleUpdate(
       notification_channel = CASE WHEN ${has('notification_channel')} THEN ${patch.notification_channel ?? 'canvas'} ELSE notification_channel END,
       notification_priority = CASE WHEN ${has('notification_priority')} THEN ${patch.notification_priority ?? 'normal'} ELSE notification_priority END,
       min_cooldown_seconds = CASE WHEN ${has('min_cooldown_seconds')} THEN ${patch.min_cooldown_seconds ?? 0} ELSE min_cooldown_seconds END
-    WHERE id = ${args.watcher_id}
+    WHERE id = ${args.watcher_id} AND organization_id = ${ctx.organizationId}
     RETURNING *
   `;
 
@@ -577,10 +577,16 @@ export async function handleDelete(
 
   for (const watcherId of args.watcher_ids) {
     try {
+      // Org-scope the mutation: requireWatcherAccess now lets ids that aren't
+      // in-org at check time fall through to this aggregate, and watcher ids are
+      // sequential integers — so a racing cross-tenant insert between check and
+      // write must not be archivable. organization_id fences that TOCTOU.
       const updated = await sql`
         UPDATE watchers
         SET status = 'archived', updated_at = NOW()
-        WHERE id = ${watcherId} AND status != 'archived'
+        WHERE id = ${watcherId}
+          AND organization_id = ${ctx.organizationId}
+          AND status != 'archived'
         RETURNING id, name, entity_ids, organization_id, triggers
       `;
 

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -3,7 +3,7 @@
  *   create, update, delete, create_from_version
  */
 
-import { getDb } from '../../../db/client';
+import { getDb, parsePgTextArray } from '../../../db/client';
 import type { Env } from '../../../index';
 import { ToolUserError } from '../../../utils/errors';
 import { isUniqueViolation } from '../../../utils/pg-errors';
@@ -775,9 +775,12 @@ export async function handleCreateFromVersion(
         // system:chat-link tag): those bind a live channel responder, and
         // cloning them would create a second agent turn for the same message.
         const cloneTriggers = stripChatLinkTriggers(version.triggers);
-        const cloneTags = ((version.tags as string[]) || []).filter(
-          (tag) => tag !== 'system:chat-link',
-        );
+        // `tags` is a text[] column read under fetch_types:false, so postgres.js
+        // hands back a raw array literal string (e.g. "{}" or "{system:chat-link}"),
+        // not a JS array. Parse it before filtering.
+        const cloneTags = parsePgTextArray(
+          version.tags as string | string[] | null,
+        ).filter((tag) => tag !== 'system:chat-link');
 
         await tx`
           INSERT INTO watchers (

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -307,21 +307,32 @@ export async function requireWatcherAccess(
   sql: DbClient,
   watcherIds: string[],
   ctx: ToolContext,
-  mode: WatcherAccessMode
+  mode: WatcherAccessMode,
+  opts?: { allowMissing?: boolean }
 ): Promise<void> {
   const uniqueWatcherIds = [...new Set(watcherIds)];
   const rows = await getWatcherAccessRows(uniqueWatcherIds, ctx.organizationId);
   if (rows.length !== uniqueWatcherIds.length) {
-    // Some requested ids are absent from the caller's org. A cross-org id
-    // (exists, but under another tenant) is a 403 access fault; an id that
-    // exists nowhere must instead fall through so the mutation handler reports
-    // it per-id (delete surfaces it in the all-failed aggregate as "Behavior
-    // not found or already archived"). Probe only bare existence here — the
-    // org-scoped load above still gates every real access decision.
+    // Some requested ids are absent from the caller's org. By default this is a
+    // hard 403 — the strict gate every action but delete relies on, so no
+    // action reaches a handler with an id it did not prove in-org.
+    //
+    // `allowMissing` (delete only) relaxes this ONE case: an id that exists
+    // nowhere may fall through so the handler reports it per-id (delete's
+    // all-failed "not found or already archived" aggregate). A cross-org id
+    // (exists under another tenant) is STILL a 403 — never fall through for it,
+    // or a caller could probe/hit foreign rows on the sequential id space.
     const foundIds = new Set(rows.map((row) => String(row.id)));
     const missingIds = uniqueWatcherIds.filter((id) => !foundIds.has(String(id)));
-    const existElsewhere = await findExistingWatcherIds(missingIds);
-    if (existElsewhere.size > 0) {
+    if (opts?.allowMissing) {
+      const existElsewhere = await findExistingWatcherIds(missingIds);
+      if (existElsewhere.size > 0) {
+        throw new ToolUserError(
+          'Access denied: one or more Behaviors were not found in your organization',
+          403,
+        );
+      }
+    } else {
       throw new ToolUserError(
         'Access denied: one or more Behaviors were not found in your organization',
         403,

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -283,6 +283,26 @@ async function getWatcherAccessRows(
   );
 }
 
+/**
+ * Existence probe across all orgs for the given watcher ids, reading ONLY the
+ * id column — never organization_id/entity_ids. The org-scoped
+ * {@link getWatcherAccessRows} load stays the single source of truth for every
+ * actual access decision (TOCTOU-safe); this probe exists purely to tell a
+ * cross-org id (exists under another tenant — a 403 access fault) apart from an
+ * id that exists nowhere (which a mutation handler must be allowed to report
+ * per-id, e.g. delete's all-failed "not found or already archived" aggregate).
+ */
+async function findExistingWatcherIds(watcherIds: string[]): Promise<Set<string>> {
+  if (watcherIds.length === 0) return new Set();
+  const sql = getDb();
+  const placeholders = watcherIds.map((_, idx) => `$${idx + 1}`).join(',');
+  const rows = await sql.unsafe<{ id: string | number }>(
+    `SELECT id FROM watchers WHERE id IN (${placeholders})`,
+    watcherIds,
+  );
+  return new Set(rows.map((row) => String(row.id)));
+}
+
 export async function requireWatcherAccess(
   sql: DbClient,
   watcherIds: string[],
@@ -292,10 +312,21 @@ export async function requireWatcherAccess(
   const uniqueWatcherIds = [...new Set(watcherIds)];
   const rows = await getWatcherAccessRows(uniqueWatcherIds, ctx.organizationId);
   if (rows.length !== uniqueWatcherIds.length) {
-    throw new ToolUserError(
-      'Access denied: one or more Behaviors were not found in your organization',
-      403,
-    );
+    // Some requested ids are absent from the caller's org. A cross-org id
+    // (exists, but under another tenant) is a 403 access fault; an id that
+    // exists nowhere must instead fall through so the mutation handler reports
+    // it per-id (delete surfaces it in the all-failed aggregate as "Behavior
+    // not found or already archived"). Probe only bare existence here — the
+    // org-scoped load above still gates every real access decision.
+    const foundIds = new Set(rows.map((row) => String(row.id)));
+    const missingIds = uniqueWatcherIds.filter((id) => !foundIds.has(String(id)));
+    const existElsewhere = await findExistingWatcherIds(missingIds);
+    if (existElsewhere.size > 0) {
+      throw new ToolUserError(
+        'Access denied: one or more Behaviors were not found in your organization',
+        403,
+      );
+    }
   }
 
   for (const row of rows) {


### PR DESCRIPTION
## Summary
- Align `person` metadata with connector identity traits (`x_handle`, WA/LinkedIn/Gmail traits) instead of the old CRM shape
- Make `examples/personal-agent` the durable schema for **buremba**: add `task` + `channel`, keep `company`, drop `topic`, enable `prune: true`, declare `works_at` / `member_of` / `mentions` and the two live personal-agent watchers
- Tax-graph types stay only in `examples/personal-finance` (do not re-apply onto buremba)
- CLI: `defineWatcher` sources can be `{ query, context }` so apply matches context-only sources
- X connector: DM author trait `display_name` → `x_display_name`
- Server: set `lock_timeout` after reserve (not as a startup GUC) so `manage_watchers` works behind Neon/PgBouncer

## Applied to buremba
- Entity/rel updates applied via `lobu apply --only memory`
- Empty tax entity + relationship types pruned; `gmail-tx` archived; smoke-test `topic` soft-deleted
- Live type inventory is now: `$member`, `person`, `task`, `company`, `channel`, `asset`, `subscription`, `trip`, `goal`, `learning`

## Test plan
- [x] `make pre-pr`
- [x] `bun test packages/connectors/src/__tests__/x.test.ts` (22 pass)
- [x] `lobu apply --only memory --dry-run --org buremba` (org aligned; only residual is watcher sources until this server fix deploys)
- [ ] After merge/deploy: `cd examples/personal-agent && lobu apply --only memory --org buremba` should be full noop

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Personal-agent configurations now support `channel` and collaborative `task` entity types, expanded `person`/`company` profiles, and added relationship types.
  - Watcher configuration now allows context-only SQL sources (template-style) alongside standard query sources.
  - Example personal-agent config enables automatic pruning.

- **Bug Fixes**
  - Improved X direct-message attribution by aligning DM sender display-name traits.
  - Watcher/group advisory locking now applies deterministic lock timeouts, improving reliability with connection poolers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->