### PR TITLE
refactor(entity-types): one $resource + $ system prefix

### DIFF
--- a/db/migrations/20260717120000_system_entity_type_slugs.sql
+++ b/db/migrations/20260717120000_system_entity_type_slugs.sql
@@ -1,0 +1,84 @@
+-- migrate:up
+
+-- Platform system types use a `$` slug prefix (users cannot create `$…`).
+--
+-- All ACL access units share ONE entity type: $resource (was channel / repo /
+-- $channel / $repo). Sources are distinguished by identity namespace, not type.
+-- $member is unchanged.
+
+-- 1) Per org: promote one legacy ACL type row to $resource (if $resource missing).
+UPDATE public.entity_types et
+SET
+  slug = '$resource',
+  name = 'Resource',
+  description = 'ACL-gated access unit (Slack channel, GitHub repository, …). Graph anchor only — empty metadata schema.',
+  icon = COALESCE(NULLIF(et.icon, ''), 'shield'),
+  updated_at = current_timestamp
+WHERE et.deleted_at IS NULL
+  AND et.slug IN ('channel', 'repo', '$channel', '$repo')
+  AND et.id = (
+    SELECT et2.id
+    FROM public.entity_types et2
+    WHERE et2.organization_id IS NOT DISTINCT FROM et.organization_id
+      AND et2.deleted_at IS NULL
+      AND et2.slug IN ('channel', 'repo', '$channel', '$repo')
+    ORDER BY
+      CASE et2.slug
+        WHEN '$channel' THEN 1
+        WHEN 'channel' THEN 2
+        WHEN '$repo' THEN 3
+        WHEN 'repo' THEN 4
+        ELSE 9
+      END,
+      et2.id
+    LIMIT 1
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.entity_types x
+    WHERE x.organization_id IS NOT DISTINCT FROM et.organization_id
+      AND x.slug = '$resource'
+      AND x.deleted_at IS NULL
+  );
+
+-- 2) Point every entity still on a legacy ACL type at the org's $resource type.
+UPDATE public.entities e
+SET
+  entity_type_id = r.id,
+  updated_at = current_timestamp
+FROM public.entity_types old
+JOIN public.entity_types r
+  ON r.organization_id IS NOT DISTINCT FROM old.organization_id
+ AND r.slug = '$resource'
+ AND r.deleted_at IS NULL
+WHERE e.entity_type_id = old.id
+  AND e.deleted_at IS NULL
+  AND old.deleted_at IS NULL
+  AND old.slug IN ('channel', 'repo', '$channel', '$repo');
+
+-- 3) Soft-delete leftover legacy ACL type rows (entities already re-pointed).
+UPDATE public.entity_types
+SET
+  deleted_at = current_timestamp,
+  updated_at = current_timestamp
+WHERE deleted_at IS NULL
+  AND slug IN ('channel', 'repo', '$channel', '$repo');
+
+-- migrate:down
+
+-- Best-effort reverse: rename $resource back to channel when no bare channel exists.
+-- Multi-source orgs that had both channel and repo cannot be fully restored.
+UPDATE public.entity_types et
+SET
+  slug = 'channel',
+  name = 'Channel',
+  updated_at = current_timestamp
+WHERE et.slug = '$resource'
+  AND et.deleted_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.entity_types x
+    WHERE x.organization_id IS NOT DISTINCT FROM et.organization_id
+      AND x.slug = 'channel'
+      AND x.deleted_at IS NULL
+  );

--- a/db/migrations/20260717120000_system_entity_type_slugs.sql
+++ b/db/migrations/20260717120000_system_entity_type_slugs.sql
@@ -5,8 +5,14 @@
 -- All ACL access units share ONE entity type: $resource (was channel / repo /
 -- $channel / $repo). Sources are distinguished by identity namespace, not type.
 -- $member is unchanged.
+--
+-- Only absorb *empty-schema* legacy rows so a domain knowledge type that
+-- happens to be named `channel` (with properties) is not destroyed.
 
--- 1) Per org: promote one legacy ACL type row to $resource (if $resource missing).
+-- Predicate helper (repeated): empty / missing properties bag = ACL anchor shape.
+-- (metadata_schema is jsonb; null, {}, {type:object}, or properties:{} count as empty.)
+
+-- 1) Per org: promote one empty-schema legacy ACL type to $resource.
 UPDATE public.entity_types et
 SET
   slug = '$resource',
@@ -16,12 +22,24 @@ SET
   updated_at = current_timestamp
 WHERE et.deleted_at IS NULL
   AND et.slug IN ('channel', 'repo', '$channel', '$repo')
+  AND (
+    et.metadata_schema IS NULL
+    OR et.metadata_schema = '{}'::jsonb
+    OR et.metadata_schema = '{"type":"object"}'::jsonb
+    OR COALESCE(et.metadata_schema->'properties', '{}'::jsonb) = '{}'::jsonb
+  )
   AND et.id = (
     SELECT et2.id
     FROM public.entity_types et2
     WHERE et2.organization_id IS NOT DISTINCT FROM et.organization_id
       AND et2.deleted_at IS NULL
       AND et2.slug IN ('channel', 'repo', '$channel', '$repo')
+      AND (
+        et2.metadata_schema IS NULL
+        OR et2.metadata_schema = '{}'::jsonb
+        OR et2.metadata_schema = '{"type":"object"}'::jsonb
+        OR COALESCE(et2.metadata_schema->'properties', '{}'::jsonb) = '{}'::jsonb
+      )
     ORDER BY
       CASE et2.slug
         WHEN '$channel' THEN 1
@@ -41,7 +59,7 @@ WHERE et.deleted_at IS NULL
       AND x.deleted_at IS NULL
   );
 
--- 2) Point every entity still on a legacy ACL type at the org's $resource type.
+-- 2) Re-point entities on empty-schema legacy ACL types onto $resource.
 UPDATE public.entities e
 SET
   entity_type_id = r.id,
@@ -54,15 +72,27 @@ JOIN public.entity_types r
 WHERE e.entity_type_id = old.id
   AND e.deleted_at IS NULL
   AND old.deleted_at IS NULL
-  AND old.slug IN ('channel', 'repo', '$channel', '$repo');
+  AND old.slug IN ('channel', 'repo', '$channel', '$repo')
+  AND (
+    old.metadata_schema IS NULL
+    OR old.metadata_schema = '{}'::jsonb
+    OR old.metadata_schema = '{"type":"object"}'::jsonb
+    OR COALESCE(old.metadata_schema->'properties', '{}'::jsonb) = '{}'::jsonb
+  );
 
--- 3) Soft-delete leftover legacy ACL type rows (entities already re-pointed).
+-- 3) Soft-delete leftover empty-schema legacy ACL type rows.
 UPDATE public.entity_types
 SET
   deleted_at = current_timestamp,
   updated_at = current_timestamp
 WHERE deleted_at IS NULL
-  AND slug IN ('channel', 'repo', '$channel', '$repo');
+  AND slug IN ('channel', 'repo', '$channel', '$repo')
+  AND (
+    metadata_schema IS NULL
+    OR metadata_schema = '{}'::jsonb
+    OR metadata_schema = '{"type":"object"}'::jsonb
+    OR COALESCE(metadata_schema->'properties', '{}'::jsonb) = '{}'::jsonb
+  );
 
 -- migrate:down
 

--- a/db/migrations/20260717120000_system_entity_type_slugs.sql
+++ b/db/migrations/20260717120000_system_entity_type_slugs.sql
@@ -19,6 +19,9 @@ SET
   name = 'Resource',
   description = 'ACL-gated access unit (Slack channel, GitHub repository, …). Graph anchor only — empty metadata schema.',
   icon = COALESCE(NULLIF(et.icon, ''), 'shield'),
+  -- Anchor has no property bag / event_kinds (matches ensureResourceEntityType).
+  metadata_schema = NULL,
+  event_kinds = NULL,
   updated_at = current_timestamp
 WHERE et.deleted_at IS NULL
   AND et.slug IN ('channel', 'repo', '$channel', '$repo')

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -1401,16 +1401,17 @@ describe("apply diff — prune", () => {
     expect(deletedIds.some((id) => id.includes("other"))).toBe(false);
   });
 
-  test("prune never deletes system ($-prefixed) definitions (e.g. $member)", () => {
-    // Regression: $member is a per-org SYSTEM entity type the server provisions;
-    // it can't be declared in config, so prune would mark it deleted and then
-    // HALT every apply (the delete is refused while member rows exist). System
-    // definitions must stay ignorable drift, never delete.
+  test("prune never deletes $ system entity types; domain still prune", () => {
+    // Sole signal is $ slug prefix.
     const remote: RemoteSnapshot = {
       ...emptyRemote(),
       entityTypes: [
         { slug: "lead", properties: {}, organization_id: "org_self" },
         { slug: "$member", organization_id: "org_self" },
+        { slug: "$resource", organization_id: "org_self" },
+        { slug: "goal", organization_id: "org_self" },
+        // bare channel/repo are not system (legacy names; pruneable)
+        { slug: "channel", organization_id: "org_self" },
       ],
       relationshipTypes: [{ slug: "$system-rel", organization_id: "org_self" }],
       watchers: [{ slug: "$system-watcher" }],
@@ -1422,12 +1423,12 @@ describe("apply diff — prune", () => {
     const verbOf = (kind: string, id: string) =>
       plan.rows.find((r) => r.kind === kind && r.id === id)?.verb;
     expect(verbOf("entity-type", "$member")).toBe("drift");
+    expect(verbOf("entity-type", "$resource")).toBe("drift");
+    expect(verbOf("entity-type", "goal")).toBe("delete");
+    expect(verbOf("entity-type", "channel")).toBe("delete");
+    // $ on rel/watcher still uses slug heuristic
     expect(verbOf("relationship-type", "$system-rel")).toBe("drift");
     expect(verbOf("watcher", "$system-watcher")).toBe("drift");
-    // No system definition is ever in the delete set.
-    expect(
-      plan.rows.some((r) => r.verb === "delete" && r.id.startsWith("$"))
-    ).toBe(false);
   });
 
   test("matching prefers the org's own type over a foreign public type with the same slug", () => {

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -1,4 +1,4 @@
-import type { AgentSettings } from "@lobu/core";
+import { isSystemEntityType, type AgentSettings } from "@lobu/core";
 import type {
   InferenceCapabilityBlock,
   InferenceModality,
@@ -995,12 +995,7 @@ export function computeDiff(
     orgId === undefined ||
     definitionOrgId === undefined ||
     definitionOrgId === orgId;
-  // `$`-prefixed definitions (e.g. the per-org `$member` entity type) are
-  // SYSTEM-managed — the server provisions them and rejects `$` slugs in
-  // create, so they can never appear in a user's config. They must NEVER be
-  // pruned (deleting `$member` corrupts the org; and because the delete is
-  // refused while member rows exist, an un-exempted prune HALTS every apply).
-  // They only ever surface as ignorable drift, in both prune and non-prune.
+  // Platform-owned entity types must NEVER be pruned (`$` slug prefix).
   const isSystemSlug = (slug: string): boolean => slug.startsWith("$");
 
   if (only !== "memory") {
@@ -1095,10 +1090,10 @@ export function computeDiff(
       if (!desiredEntitySlugs.has(remoteEntity.slug)) {
         // Code-managed: delete. The server refuses an entity-type delete while
         // instances exist (the data is exempt), surfacing a clear error.
-        // System (`$`) types are never user-declared → never pruned.
+        // `$…` system types are never pruned.
         rows.push({
           kind: "entity-type",
-          verb: prune && !isSystemSlug(remoteEntity.slug) ? "delete" : "drift",
+          verb: prune && !isSystemEntityType(remoteEntity) ? "delete" : "drift",
           id: remoteEntity.slug,
           remote: remoteEntity,
         });

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1410,6 +1410,9 @@ export type ManageEntitySchemaResponses = {
           metrics_config?: {
             [key: string]: unknown;
           } | null;
+          /**
+           * Platform system type when true (slug starts with `$`). Derived from slug.
+           */
           is_system: boolean;
           created_by?: string | null;
           organization_id?: string | null;
@@ -1456,6 +1459,9 @@ export type ManageEntitySchemaResponses = {
           metrics_config?: {
             [key: string]: unknown;
           } | null;
+          /**
+           * Platform system type when true (slug starts with `$`). Derived from slug.
+           */
           is_system: boolean;
           created_by?: string | null;
           organization_id?: string | null;
@@ -1500,6 +1506,9 @@ export type ManageEntitySchemaResponses = {
           metrics_config?: {
             [key: string]: unknown;
           } | null;
+          /**
+           * Platform system type when true (slug starts with `$`). Derived from slug.
+           */
           is_system: boolean;
           created_by?: string | null;
           organization_id?: string | null;
@@ -1544,6 +1553,9 @@ export type ManageEntitySchemaResponses = {
           metrics_config?: {
             [key: string]: unknown;
           } | null;
+          /**
+           * Platform system type when true (slug starts with `$`). Derived from slug.
+           */
           is_system: boolean;
           created_by?: string | null;
           organization_id?: string | null;

--- a/packages/connector-sdk/src/acl-source.ts
+++ b/packages/connector-sdk/src/acl-source.ts
@@ -10,9 +10,27 @@
  * departure reconcile) driven entirely by these DTOs. Core code never names a
  * specific connector — it iterates `AclSourceDef`s the connectors contribute.
  *
+ * All ACL resources share ONE entity type: {@link ACL_RESOURCE_TYPE_SLUG}
+ * (`$resource`). Sources are distinguished by identity namespace, not type slug.
+ *
  * These are pure data types (no server/db dependency) so they live in the SDK
  * and can be imported by both a connector package and the server engine.
  */
+
+/**
+ * Sole platform entity-type slug for ACL-gated units (Slack channels, GitHub
+ * repos, …). `$` prefix → system (hide rail, never prune, user-create blocked).
+ */
+export const ACL_RESOURCE_TYPE_SLUG = '$resource' as const;
+
+/** Shared name/icon for {@link ACL_RESOURCE_TYPE_SLUG} (all sources use this). */
+export const ACL_RESOURCE_TYPE_DEFAULTS = {
+  slug: ACL_RESOURCE_TYPE_SLUG,
+  name: 'Resource',
+  description:
+    'ACL-gated access unit (Slack channel, GitHub repository, …). Graph anchor only — empty metadata schema.',
+  icon: 'shield',
+} as const;
 
 /**
  * A claim that identifies a member, e.g. `{namespace:'slack_user_id', primary:true}`.
@@ -46,8 +64,11 @@ export interface AccessResource {
 
 /** The resource entity type to find-or-create and key resources under. */
 export interface AccessResourceType {
-  /** Entity-type slug, e.g. `channel` / `repo`. */
-  slug: string;
+  /**
+   * Must be {@link ACL_RESOURCE_TYPE_SLUG} (`$resource`). One type for every
+   * ACL source; identity `namespace` distinguishes channel vs repo vs …
+   */
+  slug: typeof ACL_RESOURCE_TYPE_SLUG | string;
   name: string;
   description: string;
   icon: string;
@@ -81,7 +102,7 @@ export interface AclSourceDef {
  *
  * A binding stores a bare channel id (`C…`) + a tenant/team id; the gate must
  * reconstruct the exact team-scoped key the ACL sync wrote (`T…:C…`) to match
- * the graphed `channel` entity. `channelKeySql` is the SAME construction as a
+ * the graphed `$resource` entity. `channelKeySql` is the SAME construction as a
  * SQL expression, for the message-visibility compiler that keys inside a query.
  */
 export interface ChannelReadIdentity {

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -152,6 +152,10 @@ export type {
   AclSourceDef,
   ChannelReadIdentity,
 } from './acl-source.js';
+export {
+  ACL_RESOURCE_TYPE_DEFAULTS,
+  ACL_RESOURCE_TYPE_SLUG,
+} from './acl-source.js';
 import {
   EVENT_RECALL_IDENTITY_NAMESPACES,
   getIdentityNamespaceDefinition,

--- a/packages/connectors/src/__tests__/slack-identity.test.ts
+++ b/packages/connectors/src/__tests__/slack-identity.test.ts
@@ -50,7 +50,7 @@ describe('slackChannelKey', () => {
 describe('slackAclSource', () => {
   it('declares the channel resource keyed on slack_channel_id with slack_user_id members', () => {
     expect(slackAclSource.key).toBe('slack');
-    expect(slackAclSource.resourceType.slug).toBe('channel');
+    expect(slackAclSource.resourceType.slug).toBe('$resource');
     expect(slackAclSource.resourceType.namespace).toBe(SLACK_IDENTITY.CHANNEL_ID);
     expect(slackAclSource.memberIdentities).toEqual([
       { namespace: SLACK_IDENTITY.USER_ID, primary: true },

--- a/packages/connectors/src/github-identity.ts
+++ b/packages/connectors/src/github-identity.ts
@@ -6,10 +6,11 @@
  * entity-link ingestion all import from here — not from connector-sdk.
  */
 
-import type {
-  AccessMember,
-  AccessResource,
-  AclSourceDef,
+import {
+  ACL_RESOURCE_TYPE_DEFAULTS,
+  type AccessMember,
+  type AccessResource,
+  type AclSourceDef,
 } from '@lobu/connector-sdk';
 import type { ConnectorIdentityModule } from './connector-identity-module.js';
 
@@ -125,10 +126,8 @@ export interface GithubRepoInput {
 export const githubAclSource: AclSourceDef = {
   key: 'github',
   resourceType: {
-    slug: 'repo',
-    name: 'Repository',
-    description: 'A code repository — the unit of repo access control',
-    icon: 'git-branch',
+    // One shared ACL type for every source; namespace keys GitHub repos.
+    ...ACL_RESOURCE_TYPE_DEFAULTS,
     namespace: GITHUB_IDENTITY.REPO_FULL_NAME,
   },
   memberIdentities: [

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -9,6 +9,7 @@
 
 import { randomBytes } from 'node:crypto';
 import {
+  ACL_RESOURCE_TYPE_SLUG,
   type ActionContext,
   type ActionResult,
   type ConnectorDefinition,
@@ -300,7 +301,7 @@ const GITHUB_REPO_ATTRIBUTION: EventAttributionRule = {
   role: 'belongs_to',
   autoCreate: true,
   target: {
-    entityType: '$resource',
+    entityType: ACL_RESOURCE_TYPE_SLUG,
     titlePath: 'metadata.github_repo_full_name',
     identities: [
     {

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -291,17 +291,16 @@ const GITHUB_PERSON_ATTRIBUTION: EventAttributionRule = {
   },
 };
 
-// Link each repo-scoped event to the `repo` entity it belongs to, so the authz
-// resource gate (authz/resource-visibility) can restrict recall to repos the
-// requester is `member_of`. Keyed on `github_repo_full_name` to match the repo
-// entities `buildGithubRepoGraph` materializes from collaborators — both sides
-// resolve to ONE repo entity. The full name is stamped on every event in
-// `sync()` (see stampRepoAttribution).
+// Link each repo-scoped event to the shared `$resource` entity it belongs to,
+// so the authz resource gate can restrict recall to repos the requester is
+// `member_of`. Keyed on `github_repo_full_name` to match entities
+// `buildGithubRepoGraph` materializes — both sides resolve to ONE entity.
+// The full name is stamped on every event in `sync()` (see stampRepoAttribution).
 const GITHUB_REPO_ATTRIBUTION: EventAttributionRule = {
   role: 'belongs_to',
   autoCreate: true,
   target: {
-    entityType: 'repo',
+    entityType: '$resource',
     titlePath: 'metadata.github_repo_full_name',
     identities: [
     {

--- a/packages/connectors/src/slack-identity.ts
+++ b/packages/connectors/src/slack-identity.ts
@@ -8,10 +8,11 @@
  * code never names Slack.
  */
 
-import type {
-  AccessResource,
-  AclSourceDef,
-  ChannelReadIdentity,
+import {
+  ACL_RESOURCE_TYPE_DEFAULTS,
+  type AccessResource,
+  type AclSourceDef,
+  type ChannelReadIdentity,
 } from '@lobu/connector-sdk';
 import type { ConnectorIdentityModule } from './connector-identity-module.js';
 
@@ -139,11 +140,8 @@ export interface SlackChannelInput {
 export const slackAclSource: AclSourceDef = {
   key: 'slack',
   resourceType: {
-    slug: 'channel',
-    name: 'Channel',
-    description:
-      'A chat channel (Slack channel, etc.) — the unit of conversation access control',
-    icon: 'hash',
+    // One shared ACL type for every source; namespace keys Slack channels.
+    ...ACL_RESOURCE_TYPE_DEFAULTS,
     namespace: SLACK_IDENTITY.CHANNEL_ID,
   },
   memberIdentities: [{ namespace: SLACK_IDENTITY.USER_ID, primary: true }],

--- a/packages/core/src/__tests__/reserved.test.ts
+++ b/packages/core/src/__tests__/reserved.test.ts
@@ -15,7 +15,9 @@ describe("isSystemEntityType", () => {
     expect(isSystemEntityType({})).toBe(false);
     // is_system field is ignored (legacy API noise)
     expect(isSystemEntityType({ slug: "goal", is_system: true })).toBe(false);
-    expect(isSystemEntityType({ slug: "$member", is_system: false })).toBe(true);
+    expect(isSystemEntityType({ slug: "$member", is_system: false })).toBe(
+      true
+    );
   });
 });
 

--- a/packages/core/src/__tests__/reserved.test.ts
+++ b/packages/core/src/__tests__/reserved.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isReservedEntityTypeSlug,
+  isSystemEntityType,
+  RESERVED_ENTITY_TYPE_SLUGS,
+  RESERVED_PATHS,
+} from "../reserved";
+
+describe("isSystemEntityType", () => {
+  it("is solely the $ slug prefix", () => {
+    expect(isSystemEntityType({ slug: "$member" })).toBe(true);
+    expect(isSystemEntityType({ slug: "$resource" })).toBe(true);
+    expect(isSystemEntityType({ slug: "channel" })).toBe(false);
+    expect(isSystemEntityType({ slug: "person" })).toBe(false);
+    expect(isSystemEntityType({})).toBe(false);
+    // is_system field is ignored (legacy API noise)
+    expect(isSystemEntityType({ slug: "goal", is_system: true })).toBe(false);
+    expect(isSystemEntityType({ slug: "$member", is_system: false })).toBe(true);
+  });
+});
+
+describe("isReservedEntityTypeSlug", () => {
+  it("blocks $ prefix and reserved names", () => {
+    expect(isReservedEntityTypeSlug("$member")).toBe(true);
+    expect(isReservedEntityTypeSlug("$resource")).toBe(true);
+    expect(isReservedEntityTypeSlug("memory")).toBe(true);
+    expect(isReservedEntityTypeSlug("person")).toBe(false);
+    expect(isReservedEntityTypeSlug("channel")).toBe(false);
+  });
+});
+
+describe("lists", () => {
+  it("exports path and entity-type reserved sets", () => {
+    expect(RESERVED_PATHS).toContain("memory");
+    expect(RESERVED_PATHS).toContain("www");
+    expect(RESERVED_ENTITY_TYPE_SLUGS).toContain("organization");
+  });
+});

--- a/packages/core/src/contracts/tools/manage-entity-schema.ts
+++ b/packages/core/src/contracts/tools/manage-entity-schema.ts
@@ -251,6 +251,11 @@ export const EntityTypeRowSchema = Type.Object({
   metrics_config: Type.Optional(
     Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])
   ),
+  /**
+   * Platform-owned type when true (slug starts with `$`: $member, $resource).
+   * Derived from slug — not a DB column, not created_by. true → hidden from
+   * rail, never pruned. Users cannot create `$…` types.
+   */
   is_system: Type.Boolean(),
   created_by: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   organization_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,8 @@ export {
   type SdkCompatProtocol,
 } from "./sdk-compat";
 export * from "./secret-refs";
+// Reserved path / entity-type slug lists + kind helpers (single source)
+export * from "./reserved";
 // Observability
 export { getSentry, initSentry } from "./sentry";
 export { extractTraceId, generateTraceId } from "./trace";

--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -1,0 +1,116 @@
+/**
+ * Canonical reserved names and entity-type classification helpers.
+ *
+ * Two separate jobs — do not collapse them:
+ * 1. System types — slug starts with `$` (`$member`, `$resource`, …)
+ * 2. Reserved slug lists — illegal *names* for user create / routes (may not be rows)
+ *
+ * Users cannot create `$…` types. Hide + prune use the `$` prefix only.
+ * `created_by` is audit only and must never be used as a stand-in for system.
+ */
+
+// ── Entity type classification ──────────────────────────────────────────────
+
+/**
+ * True when a type is platform-owned (hidden from rail, never pruned).
+ * Sole signal: slug starts with `$` (not created_by, not hide-slug denylists).
+ */
+export function isSystemEntityType(et: {
+  slug?: string | null;
+  /** @deprecated ignored — classification is slug `$` only */
+  is_system?: boolean | null;
+}): boolean {
+  return typeof et.slug === "string" && et.slug.startsWith("$");
+}
+
+/** @deprecated Use isSystemEntityType */
+export const isSystemResourceEntityType = isSystemEntityType;
+
+// ── Route / path reserved names ─────────────────────────────────────────────
+
+/**
+ * Owner-level route segments under /$owner/. Entity type slugs and org slugs
+ * must never collide with these.
+ */
+export const OWNER_ROUTE_SEGMENTS = [
+  "agents",
+  "connectors",
+  "devices",
+  "environments",
+  "infrastructure",
+  "memory",
+  "members",
+  "settings",
+] as const;
+
+/** Legacy page slugs removed from the UI router. */
+export const REMOVED_OWNER_SEGMENTS = [
+  "events",
+  "watchers",
+  "connections",
+  "sources",
+] as const;
+
+/**
+ * Reserved owner-slug / path names. Combines owner routes, removed legacy
+ * pages, global prefixes, and infra subdomains that must not be claimed as
+ * org slugs.
+ */
+export const RESERVED_PATHS = [
+  ...OWNER_ROUTE_SEGMENTS,
+  ...REMOVED_OWNER_SEGMENTS,
+  "auth",
+  "api",
+  "inbox",
+  "templates",
+  "help",
+  "account",
+  "admin",
+  "health",
+  "login",
+  "logout",
+  "signup",
+  "register",
+  "contents",
+  "entity-types",
+  "www",
+  "mcp",
+  "static",
+  "assets",
+  "cdn",
+  "docs",
+  "mail",
+] as const;
+
+export const RESERVED_PATHS_SET: ReadonlySet<string> = new Set(RESERVED_PATHS);
+
+// ── Entity type create denylist ─────────────────────────────────────────────
+
+/**
+ * Slugs users cannot use when *creating* an entity type. Route collisions plus
+ * product words that are not knowledge types. Create-time hygiene only — not
+ * hide/prune policy (that is `$` prefix only).
+ */
+export const RESERVED_ENTITY_TYPE_SLUGS = [
+  ...OWNER_ROUTE_SEGMENTS,
+  ...REMOVED_OWNER_SEGMENTS,
+  "organization",
+  "user",
+  "watcher",
+  "content",
+  "source",
+  "connector",
+] as const;
+
+/** @deprecated Use RESERVED_ENTITY_TYPE_SLUGS */
+export const RESERVED_ENTITY_TYPES = RESERVED_ENTITY_TYPE_SLUGS;
+
+/**
+ * Whether a proposed entity-type slug is illegal for user/API create.
+ * `$…` is reserved for platform-named types ($member, $resource).
+ */
+export function isReservedEntityTypeSlug(slug: string): boolean {
+  const s = slug.toLowerCase();
+  if (s.startsWith("$")) return true;
+  return (RESERVED_ENTITY_TYPE_SLUGS as readonly string[]).includes(s);
+}

--- a/packages/server/src/__tests__/integration/authz/github-repo-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/github-repo-graph.test.ts
@@ -123,7 +123,7 @@ describe('github repo graph', () => {
     // 3 edges: (alice,lobu), (bob,lobu), (bob,secret).
     expect(result.createdEdges).toBe(3);
 
-    expect(await entitiesOfType(org.id, 'repo')).toHaveLength(2);
+    expect(await entitiesOfType(org.id, '$resource')).toHaveLength(2);
     expect(await entitiesOfType(org.id, 'person')).toHaveLength(2); // alice + bob
 
     const sql = getTestDb();

--- a/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
@@ -278,7 +278,7 @@ describe('github repo visibility gate (e2e via search_memory content)', () => {
     // connector emits → server resolves: metadata.github_repo_full_name resolves
     // to the SAME repo entity the graph built (one entity, no forked duplicate).
     const githubRepoLinkRule = {
-      entityType: 'repo',
+      entityType: '$resource',
       autoCreate: true,
       titlePath: 'metadata.github_repo_full_name',
       identities: [

--- a/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
@@ -162,7 +162,7 @@ describe('slack channel graph', () => {
     // 3 edges: (alice,eng), (bob,eng), (bob,secret).
     expect(result.createdEdges).toBe(3);
 
-    const channels = await entitiesOfType(org.id, 'channel');
+    const channels = await entitiesOfType(org.id, '$resource');
     expect(channels).toHaveLength(2);
     const people = await entitiesOfType(org.id, 'person');
     expect(people).toHaveLength(2); // alice + bob (neither signed in here)
@@ -237,7 +237,7 @@ describe('slack channel graph', () => {
       ],
     });
     expect(second.createdEdges).toBe(1); // only bob is new
-    expect(await entitiesOfType(org.id, 'channel')).toHaveLength(1);
+    expect(await entitiesOfType(org.id, '$resource')).toHaveLength(1);
     expect(await memberOfEdges(org.id)).toHaveLength(2);
   });
 
@@ -280,8 +280,8 @@ describe('slack channel graph', () => {
         ],
       });
     }
-    const chA = await entitiesOfType(a.org.id, 'channel');
-    const chB = await entitiesOfType(b.org.id, 'channel');
+    const chA = await entitiesOfType(a.org.id, '$resource');
+    const chB = await entitiesOfType(b.org.id, '$resource');
     expect(chA).toHaveLength(1);
     expect(chB).toHaveLength(1);
     expect(chA[0].id).not.toBe(chB[0].id);

--- a/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
@@ -103,7 +103,7 @@ describe("channel streaming feeds", () => {
       DELETE FROM entities
       WHERE organization_id = ${orgId}
         AND entity_type_id IN (
-          SELECT id FROM entity_types WHERE organization_id = ${orgId} AND slug IN ('channel', '$member')
+          SELECT id FROM entity_types WHERE organization_id = ${orgId} AND slug IN ('$resource', '$member')
         )
     `;
   });

--- a/packages/server/src/__tests__/integration/db/system-entity-type-slugs-migration.test.ts
+++ b/packages/server/src/__tests__/integration/db/system-entity-type-slugs-migration.test.ts
@@ -1,0 +1,153 @@
+/**
+ * $resource system-slug migration (`20260717120000_system_entity_type_slugs.sql`).
+ *
+ * - Empty-schema legacy ACL types (channel / repo / $channel / $repo) promote to
+ *   `$resource` with schema columns cleared.
+ * - Domain types named `channel` that have properties are left alone.
+ *
+ * Global migration steps run inside a transaction we ROLL BACK so the shared
+ * integration DB is not permanently mutated.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { loadMigrationUpSection } from '../../../db/migration-loader';
+import { createTestOrganization } from '../../setup/test-fixtures';
+
+const MIGRATION = '20260717120000_system_entity_type_slugs.sql';
+
+function resolveMigrationsDir(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'db/migrations');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate db/migrations from the test directory');
+}
+
+interface Captured {
+  promoted: {
+    id: number;
+    slug: string;
+    metadata_schema: unknown;
+    event_kinds: unknown;
+  } | null;
+  /** True when the promoted $resource row is the same row we seeded as channel. */
+  promotedLegacyRow: boolean;
+  domainChannelSurvived: boolean;
+  domainChannelSlug: string | null;
+}
+
+class Rollback extends Error {}
+
+describe('$resource system-slug migration', () => {
+  let captured: Captured;
+
+  beforeAll(async () => {
+    const orgId = (await createTestOrganization()).id;
+    const sql = getDb();
+    const upSection = loadMigrationUpSection(resolveMigrationsDir(), MIGRATION);
+
+    const result: Captured = {
+      promoted: null,
+      promotedLegacyRow: false,
+      domainChannelSurvived: false,
+      domainChannelSlug: null,
+    };
+
+    try {
+      await sql.begin(async (tx: typeof sql) => {
+        // Empty-schema ACL anchor — must promote to $resource.
+        const [legacy] = await tx<{ id: number }[]>`
+          INSERT INTO entity_types
+            (organization_id, slug, name, description, icon, metadata_schema, event_kinds, created_at, updated_at)
+          VALUES (
+            ${orgId}, 'channel', 'Channel', 'legacy channel', 'hash',
+            NULL, NULL,
+            current_timestamp, current_timestamp
+          )
+          RETURNING id
+        `;
+
+        // Domain knowledge type that happens to be named `channel` but has
+        // properties — must NOT be absorbed.
+        await tx`
+          INSERT INTO entity_types
+            (organization_id, slug, name, description, metadata_schema, created_at, updated_at)
+          VALUES (
+            ${orgId}, 'channel-topic', 'Channel topic', 'domain',
+            ${tx.json({ type: 'object', properties: { topic: { type: 'string' } } })},
+            current_timestamp, current_timestamp
+          )
+        `;
+        // A *different org-style* slug that is still named channel with properties
+        // would conflict on unique (org, slug) — use a second org for domain channel.
+        const org2 = (await createTestOrganization()).id;
+        const [domainChannel] = await tx<{ id: number }[]>`
+          INSERT INTO entity_types
+            (organization_id, slug, name, description, metadata_schema, created_at, updated_at)
+          VALUES (
+            ${org2}, 'channel', 'Chat topic', 'domain knowledge channel',
+            ${tx.json({ type: 'object', properties: { topic: { type: 'string' } } })},
+            current_timestamp, current_timestamp
+          )
+          RETURNING id
+        `;
+
+        await tx.unsafe(upSection);
+
+        const promoted = await tx<
+          {
+            id: number;
+            slug: string;
+            metadata_schema: unknown;
+            event_kinds: unknown;
+          }[]
+        >`
+          SELECT id, slug, metadata_schema, event_kinds
+          FROM entity_types
+          WHERE organization_id = ${orgId}
+            AND slug = '$resource'
+            AND deleted_at IS NULL
+          LIMIT 1
+        `;
+        result.promoted = promoted[0] ?? null;
+        result.promotedLegacyRow = promoted[0]?.id === legacy.id;
+
+        const domain = await tx<{ id: number; slug: string; deleted_at: Date | null }[]>`
+          SELECT id, slug, deleted_at
+          FROM entity_types
+          WHERE id = ${domainChannel.id}
+          LIMIT 1
+        `;
+        result.domainChannelSurvived =
+          domain.length > 0 && domain[0].deleted_at === null && domain[0].slug === 'channel';
+        result.domainChannelSlug = domain[0]?.slug ?? null;
+
+        throw new Rollback();
+      });
+    } catch (err) {
+      if (!(err instanceof Rollback)) throw err;
+    }
+
+    captured = result;
+  });
+
+  it('promotes empty-schema channel to $resource and clears schema columns', () => {
+    expect(captured.promoted).not.toBeNull();
+    expect(captured.promotedLegacyRow).toBe(true);
+    expect(captured.promoted!.slug).toBe('$resource');
+    expect(captured.promoted!.metadata_schema).toBeNull();
+    expect(captured.promoted!.event_kinds).toBeNull();
+  });
+
+  it('does not absorb a domain channel type that has properties', () => {
+    expect(captured.domainChannelSurvived).toBe(true);
+    expect(captured.domainChannelSlug).toBe('channel');
+  });
+});

--- a/packages/server/src/__tests__/integration/events/save-content-channel-stamp.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-channel-stamp.test.ts
@@ -46,7 +46,7 @@ describe('saveContent > channel entity stamp', () => {
     // exactly as slack-channel-graph materializes it.
     const channel = await createTestEntity({
       name: 'eng',
-      entity_type: 'channel',
+      entity_type: '$resource',
       organization_id: org.id,
     });
     channelEntityId = channel.id;

--- a/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
@@ -59,7 +59,7 @@ describe("streaming feed as a watcher @feed source", () => {
       DELETE FROM entities
       WHERE organization_id = ${orgId}
         AND (metadata->>'source' = 'watcher_promotion' OR entity_type_id IN (
-          SELECT id FROM entity_types WHERE organization_id = ${orgId} AND slug IN ('channel', '$member')
+          SELECT id FROM entity_types WHERE organization_id = ${orgId} AND slug IN ('$resource', '$member')
         ))
     `;
   });

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -79,7 +79,8 @@ async function resolveOrgCreator(orgId: string): Promise<string | null> {
   return rows.length > 0 ? rows[0].userId : null;
 }
 
-/** Find-or-create the org-scoped resource entity type (reuse, no migration). */
+/** Find-or-create the org-scoped `$resource` entity type (reuse, no migration).
+ * All ACL sources share this one type; identity namespace distinguishes them. */
 export async function ensureResourceEntityType(orgId: string, type: AccessResourceType): Promise<void> {
   const sql = getDb();
   await sql`

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -116,7 +116,7 @@ async function ensureMemberOfType(orgId: string): Promise<number> {
 		INSERT INTO entity_relationship_types
 			(slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
 		VALUES
-			(${MEMBER_OF_TYPE_SLUG}, 'Member of', 'A person is a member of an organization or channel', ${orgId},
+			(${MEMBER_OF_TYPE_SLUG}, 'Member of', 'A member belongs to an ACL resource (channel, repo, …)', ${orgId},
 			 false, NULL, current_timestamp, current_timestamp)
 		ON CONFLICT (organization_id, slug) WHERE status = 'active'
 		DO UPDATE SET updated_at = EXCLUDED.updated_at

--- a/packages/server/src/authz/channel-entity.ts
+++ b/packages/server/src/authz/channel-entity.ts
@@ -13,15 +13,16 @@
  * looked up in the channel-read-identity registry; this file names no connector.
  */
 
+import { ACL_RESOURCE_TYPE_SLUG } from '@lobu/connector-sdk';
 import { type DbClient, getDb } from '../db/client.js';
 import { stripPlatformPrefix } from '../gateway/channels/bound-channels.js';
 import { channelReadIdentityFor } from './sources.js';
 
 /**
- * Resolve the `channel` resource-entity id for a (platform, team, channel) in an
- * org, or null when the platform has no enforced channel gate or the channel has
- * no graphed entity (never synced). Returns null rather than throwing — a missing
- * entity must NOT block the save; the memory is saved without the channel stamp
+ * Resolve the `$resource` entity id for a (platform, team, channel) in an org,
+ * or null when the platform has no enforced channel gate or the channel has no
+ * graphed entity (never synced). Returns null rather than throwing — a missing
+ * entity must NOT block the save; the memory is saved without the resource stamp
  * (falls back to the caller's existing org/$member scoping).
  */
 export async function resolveChannelEntityId(
@@ -35,7 +36,7 @@ export async function resolveChannelEntityId(
   const identity = channelReadIdentityFor(platform);
   if (!identity) return null;
   // The worker-token / sourceContext channelId arrives platform-PREFIXED
-  // (`slack:C0ENG`) — the Chat SDK's canonical form — while the graphed channel
+  // (`slack:C0ENG`) — the Chat SDK's canonical form — while the graphed resource
   // identity is the BARE team-scoped id (`T…:C…`). Strip the prefix so the key
   // matches; without this the lookup always misses and the stamp silently never
   // fires (channel memory would leak org-wide).
@@ -52,7 +53,7 @@ export async function resolveChannelEntityId(
     JOIN entity_types et
       ON et.id = e.entity_type_id
      AND et.organization_id = e.organization_id
-     AND et.slug = 'channel'
+     AND et.slug = ${ACL_RESOURCE_TYPE_SLUG}
     WHERE ei.organization_id = ${organizationId}
       AND ei.namespace = ${identity.channelNamespace}
       AND ei.identifier = ${key}

--- a/packages/server/src/authz/channel-messages-visibility.ts
+++ b/packages/server/src/authz/channel-messages-visibility.ts
@@ -94,7 +94,7 @@ export function compileChannelMessagesVisibility(
   )`;
 
   // One channel-membership EXISTS branch per registered chat platform: the
-  // requester is `member_of` the `channel` entity keyed by THIS platform's
+  // requester is `member_of` the `$resource` entity keyed by THIS platform's
   // channel identity + key expression, gated on the row's platform. OR-ed so a
   // multi-platform transcript table is covered without naming any connector.
   const membershipBranch = (

--- a/packages/server/src/authz/channel-visibility.ts
+++ b/packages/server/src/authz/channel-visibility.ts
@@ -171,7 +171,7 @@ const CHANNEL_KEY_NAMESPACES: string[] = [
 
 /**
  * The team-scoped channel keys the member can read, via `member_of` edges to
- * `channel` entities carrying any registered chat-channel identity (Slack:
+ * `$resource` entities carrying any registered chat-channel identity (Slack:
  * `slack_channel_id` = `T…:C…`). Unions across every registered chat platform's
  * channel namespace so a member spanning platforms sees all their channels.
  */

--- a/packages/server/src/authz/resource-visibility.ts
+++ b/packages/server/src/authz/resource-visibility.ts
@@ -14,7 +14,7 @@
  *     `freshness_state='fresh'`, synced within the freshness window) is visible
  *     ONLY when the requester is `member_of` one of the RESOURCE entities the
  *     event is linked to (`events.entity_ids`), where "resource" = an entity whose
- *     type is a registered ACL resource (`RESOURCE_TYPE_SLUGS`: repo, channel, …).
+ *     type is the shared ACL resource type (`$resource` via `RESOURCE_TYPE_SLUGS`).
  *     This is deliberately scoped to resource types so the coarse person→`company`
  *     (org) `member_of` edge never satisfies it — org membership must NOT grant
  *     repo-level read;
@@ -37,9 +37,9 @@ import { aclStateExistsSelectSql, enforcedConnectionsSelectSql } from './acl-sta
 import type { AuthzScope } from './scope.js';
 import { RESOURCE_TYPE_SLUGS } from './sources.js';
 
-/** Resource type slugs as a safe SQL `IN (...)` list. Slugs are validated to
- * simple identifiers in `./sources`, so inlining as literals is injection-safe
- * (and avoids binding a text[] param, which the fetch_types:false driver rejects). */
+/** Resource type slugs as a safe SQL `IN (...)` list. Registry enforces
+ * `$resource` only; inlining as literals is injection-safe (and avoids binding
+ * a text[] param, which the fetch_types:false driver rejects). */
 const RESOURCE_TYPE_IN_LIST = RESOURCE_TYPE_SLUGS.map((s) => `'${s}'`).join(', ');
 
 /**

--- a/packages/server/src/authz/sources.ts
+++ b/packages/server/src/authz/sources.ts
@@ -7,14 +7,29 @@
  *
  * Adding Linear/Jira/Drive = a connector that exports an `AclSourceDef` +
  * appending it here. No new gate code, no new engine code.
+ *
+ * All sources share entity type `$resource` ({@link ACL_RESOURCE_TYPE_SLUG}).
  */
 
-import type { AclSourceDef, ChannelReadIdentity } from '@lobu/connector-sdk';
+import {
+  ACL_RESOURCE_TYPE_SLUG,
+  type AclSourceDef,
+  type ChannelReadIdentity,
+} from '@lobu/connector-sdk';
 import { githubAclSource } from '@lobu/connectors/github-identity';
 import { slackAclSource, slackChannelReadIdentity } from '@lobu/connectors/slack-identity';
 
 /** Every registered ACL source (contributed by its connector package). */
 export const ACL_SOURCES: AclSourceDef[] = [slackAclSource, githubAclSource];
+
+// Hard invariant: one ACL entity type for every source (identity namespace differs).
+for (const source of ACL_SOURCES) {
+  if (source.resourceType.slug !== ACL_RESOURCE_TYPE_SLUG) {
+    throw new Error(
+      `ACL source '${source.key}' must use resource type '${ACL_RESOURCE_TYPE_SLUG}', got '${source.resourceType.slug}'`,
+    );
+  }
+}
 
 const ACL_SOURCE_BY_KEY = new Map<string, AclSourceDef>(ACL_SOURCES.map((s) => [s.key, s]));
 
@@ -27,15 +42,12 @@ export function aclSourceFor(key: string): AclSourceDef | null {
   return ACL_SOURCE_BY_KEY.get(key) ?? null;
 }
 
-/** Resource entity-type slugs that the read gate treats as access-controlled.
- * Validated to simple identifiers so they can be inlined as SQL literals. */
-export const RESOURCE_TYPE_SLUGS: string[] = ACL_SOURCES.map((s) => {
-  const slug = s.resourceType.slug;
-  if (!/^[a-z][a-z0-9_]*$/.test(slug)) {
-    throw new Error(`Invalid ACL resource type slug (must be a simple identifier): ${slug}`);
-  }
-  return slug;
-});
+/**
+ * Resource entity-type slugs the read gate treats as access-controlled.
+ * Always `$resource` only — kept as an array so the SQL `IN (...)` compiler
+ * stays generic if a second system type is ever needed.
+ */
+export const RESOURCE_TYPE_SLUGS: readonly string[] = [ACL_RESOURCE_TYPE_SLUG];
 
 /**
  * Chat platforms whose per-channel read gate is enforced, keyed by `platform`.

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -10,7 +10,7 @@ import {
 } from './utils/entity-management';
 import { escapeHtml } from './utils/html';
 import { getConfiguredPublicOrigin } from './utils/public-origin';
-import { RESERVED_PATHS } from './utils/reserved';
+import { RESERVED_PATHS_SET } from './utils/reserved';
 
 interface PublicOrganization {
   id: string;
@@ -923,7 +923,7 @@ export async function buildPublicPageModel(
 
   const ownerSlug = segments[0]!;
   if (ownerSlug.startsWith('@')) return null;
-  if (RESERVED_PATHS.includes(ownerSlug)) return null;
+  if (RESERVED_PATHS_SET.has(ownerSlug)) return null;
   if (segments[1] && PUBLIC_APP_ROUTE_PREFIXES.has(segments[1])) return null;
 
   const organization = await getPublicOrganizationBySlug(ownerSlug);

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -33,7 +33,10 @@ import type { Env } from '../../index';
 import logger from '../../utils/logger';
 import { compileRulesMetadata, ruleHashFor } from '../../identity/rules';
 import { ensureMemberEntityType } from '../../utils/member-entity-type';
-import { RESERVED_ENTITY_TYPES } from '../../utils/reserved';
+import {
+  isReservedEntityTypeSlug,
+  RESERVED_ENTITY_TYPE_SLUGS,
+} from '../../utils/reserved';
 import { resolveUsernames } from '../../utils/resolve-usernames';
 import { ToolUserError } from '../../utils/errors';
 import { isUniqueViolation } from '../../utils/pg-errors';
@@ -113,9 +116,11 @@ const ENTITY_TYPE_COLUMNS_WITH_ORG = `et.id, et.slug, et.name, et.description, e
   o.slug AS organization_slug`;
 
 function mapRowToEntityType(row: Record<string, unknown>): EntityTypeRow {
+  const slug = typeof row.slug === 'string' ? row.slug : '';
   return {
     ...(row as unknown as EntityTypeRow),
-    is_system: row.created_by === null || row.created_by === undefined,
+    // Sole platform signal: $ prefix ($member, $resource). Not created_by.
+    is_system: slug.startsWith('$'),
     entity_count: Number(row.entity_count) || 0,
   };
 }
@@ -431,18 +436,16 @@ async function etHandleCreate(
   if (!args.name) throw new ToolUserError('name is required for create action', 400);
   if (!ctx.userId) throw new ToolUserError('Authentication required to create entity types', 401);
 
-  if (args.slug.startsWith('$')) {
-    throw new ToolUserError("Entity type slugs starting with '$' are reserved for system types", 422);
-  }
-
-  const slug = args.slug.toLowerCase().replace(/[^a-z0-9-]/g, '-');
-
-  if (RESERVED_ENTITY_TYPES.includes(slug)) {
+  // Preserve `$` for the reserved-slug check (isReservedEntityTypeSlug); domain
+  // creates still get a normalized slug for storage when not reserved.
+  if (isReservedEntityTypeSlug(args.slug)) {
     throw new ToolUserError(
-      `Cannot create entity type with reserved slug '${slug}'. Reserved: ${RESERVED_ENTITY_TYPES.join(', ')}`,
+      `Cannot create entity type with reserved slug '${args.slug}'. Reserved names: $…, ${RESERVED_ENTITY_TYPE_SLUGS.join(', ')}`,
       422
     );
   }
+
+  const slug = args.slug.toLowerCase().replace(/[^a-z0-9-]/g, '-');
 
   const sql = getDb();
 

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -24,7 +24,7 @@ import { stripMemberEmailsFromRows } from '../utils/member-redaction';
 import { derivedRowName, derivedRowSlug } from '../utils/entity-management';
 import { buildDefaultEntityTemplate } from '../utils/default-entity-template';
 import { measureColumns as inferMeasureColumns } from '../utils/infer-measures';
-import { RESERVED_PATHS } from '../utils/reserved';
+import { RESERVED_PATHS_SET } from '../utils/reserved';
 import { getWorkspaceProvider } from '../workspace';
 import { querySqlImpl } from './admin/query_sql';
 import { isAdminOrOwnerRole } from './access-control';
@@ -376,7 +376,7 @@ async function _resolvePath(
   const isUserSpace = ownerRaw.startsWith('@');
   const ownerSlug = isUserSpace ? ownerRaw.slice(1) : ownerRaw;
 
-  if (RESERVED_PATHS.includes(ownerSlug)) {
+  if (RESERVED_PATHS_SET.has(ownerSlug)) {
     throw new ToolUserError(`Owner '${ownerSlug}' is reserved`, 400);
   }
 

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -34,7 +34,7 @@ import { computeFieldMerge, type FieldControl } from "./entity-field-merge";
 import { type EntityHookContext, getEntityHooks } from "./entity-hooks";
 import { ToolUserError } from "./errors";
 import { requireWriteAccess } from "./organization-access";
-import { RESERVED_ENTITY_TYPES } from "./reserved";
+import { RESERVED_ENTITY_TYPE_SLUGS } from "./reserved";
 
 interface EntityCreateOptions {
 	skipHooks?: boolean;
@@ -269,10 +269,15 @@ export async function createEntity(
 		throw new Error("Entity type is required");
 	}
 
-	// Check for reserved entity types
-	if (RESERVED_ENTITY_TYPES.includes(data.entity_type.toLowerCase())) {
+	// Illegal type *names* that are not knowledge types (routes / product words).
+	// System types ($member, $resource) are valid entity instance types.
+	if (
+		(RESERVED_ENTITY_TYPE_SLUGS as readonly string[]).includes(
+			data.entity_type.toLowerCase(),
+		)
+	) {
 		throw new Error(
-			`Cannot create entity with reserved type '${data.entity_type}'. Reserved types: ${RESERVED_ENTITY_TYPES.join(", ")}`,
+			`Cannot create entity with reserved type '${data.entity_type}'. Reserved: ${RESERVED_ENTITY_TYPE_SLUGS.join(", ")}`,
 		);
 	}
 

--- a/packages/server/src/utils/member-entity-type.ts
+++ b/packages/server/src/utils/member-entity-type.ts
@@ -262,7 +262,8 @@ export async function ensureMemberEntityType(organizationId: string): Promise<vo
         current_timestamp,
         current_timestamp
       )
-      ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL DO NOTHING
+      ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+      DO NOTHING
     `;
     // Prime this pod's cache with the seeded registry. A prior read may have
     // cached a `null` (no $member yet); overwrite it so the next validation in
@@ -277,6 +278,7 @@ export async function ensureMemberEntityType(organizationId: string): Promise<vo
   }
 
   const existing = existingRows[0];
+
   const mergedMetadataSchema = mergeMemberMetadataSchema(
     (existing.metadata_schema as Record<string, unknown> | null | undefined) ?? null
   );

--- a/packages/server/src/utils/reserved.ts
+++ b/packages/server/src/utils/reserved.ts
@@ -1,80 +1,15 @@
 /**
- * Owner-level route segments that map to real app pages under /$owner/.
- * Entity type slugs must never collide with these.
+ * Re-export canonical reserved names from @lobu/core.
+ * Keep this file so existing server imports (`../utils/reserved`) stay stable.
  */
-const OWNER_ROUTE_SEGMENTS = [
-  'agents',
-  'connectors',
-  'devices',
-  'environments',
-  'infrastructure',
-  'memory',
-  'members',
-  'settings',
-] as const;
-
-/** Legacy page slugs removed from the UI router. */
-const REMOVED_OWNER_SEGMENTS = [
-  'events',
-  'watchers',
-  'connections',
-  'sources',
-] as const;
-
-/**
- * Reserved owner-slug names. Combines:
- * - System-level route prefixes (not under /$owner) — `auth`, `api`, …
- * - Infrastructure subdomains that must never be claimed as an org slug —
- *   `www`, `mcp`, `static`, `assets`, `cdn`, `docs`, `mail`. These mirror
- *   `RESERVED_SUBDOMAINS` in `packages/server/src/index.ts` so a name that
- *   resolves to infra at the routing layer cannot be claimed at the org layer.
- *
- * The DB-level `org_slug_not_reserved` CHECK constraint
- * (db/migrations/20260420120000_extend_reserved_org_slugs.sql) enforces a
- * subset of this list. Extra entries here are an intentional defense-in-depth
- * superset — losing one silently could allow squatting on a route.
- */
-export const RESERVED_PATHS = [
-  ...OWNER_ROUTE_SEGMENTS,
-  ...REMOVED_OWNER_SEGMENTS,
-  'auth',
-  'api',
-  'inbox',
-  'templates',
-  'help',
-  'account',
-  'admin',
-  'health',
-  'login',
-  'logout',
-  'signup',
-  'register',
-  'contents',
-  'entity-types',
-  'www',
-  'mcp',
-  'static',
-  'assets',
-  'cdn',
-  'docs',
-  'mail',
-];
-
-/** Set form for O(1) membership checks (e.g. personal-org slug derivation). */
-export const RESERVED_PATHS_SET: ReadonlySet<string> = new Set(RESERVED_PATHS);
-
-/**
- * Reserved entity type slugs that users cannot create.
- * Includes owner-level routes (to prevent URL collisions) and
- * internal system type names.
- */
-export const RESERVED_ENTITY_TYPES = [
-  ...OWNER_ROUTE_SEGMENTS,
-  ...REMOVED_OWNER_SEGMENTS,
-  'organization',
-  'user',
-  'watcher',
-  'content',
-  'source',
-  'connector',
-];
+export {
+  isReservedEntityTypeSlug,
+  isSystemEntityType,
+  isSystemResourceEntityType,
+  OWNER_ROUTE_SEGMENTS,
+  REMOVED_OWNER_SEGMENTS,
+  RESERVED_ENTITY_TYPE_SLUGS,
+  RESERVED_ENTITY_TYPES,
+  RESERVED_PATHS,
+  RESERVED_PATHS_SET,
+} from "@lobu/core";


### PR DESCRIPTION
## Summary

Full ACL entity-type consolidation + system naming.

### System model
- **`$…` slug prefix** = platform system type (user-create blocked; hide rail; never prune)
- **No `is_system` column** — API `is_system` is derived from `$` only

### ACL resource consolidation
One entity type for every ACL source:

| Before | After |
|--------|--------|
| `channel` / `$channel` | **`$resource`** |
| `repo` / `$repo` | **`$resource`** |
| `$member` | `$member` (unchanged) |

Sources differ by **identity namespace** (`slack_channel_id`, `github_repo_full_name`, …), not type slug.

- `ACL_RESOURCE_TYPE_SLUG` / `ACL_RESOURCE_TYPE_DEFAULTS` in `@lobu/connector-sdk`
- Registry asserts every `AclSourceDef` uses `$resource`
- `RESOURCE_TYPE_SLUGS = ['$resource']`
- Migration merges legacy types, re-points entities, soft-deletes leftovers
- Empty schema preserved (graph anchor only)

### Owletto
Rail hide via `$` ([#515](https://github.com/lobu-ai/owletto/pull/515), [#516](https://github.com/lobu-ai/owletto/pull/516))

## Test plan
- [x] `make pre-pr`
- [x] unit: reserved, prune, slack-identity
- [ ] After migrate: one `$resource` type; entities re-pointed
- [ ] Slack + GitHub ACL sync + visibility still work
- [ ] Rail hides `$member` / `$resource`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized ACL resources under the shared `$resource` entity type across Slack and GitHub integrations.
  * Added centralized reserved path and entity-type validation.
  * Added consistent protection for system entity types during pruning.

* **Bug Fixes**
  * Prevented platform-owned system entity types from being incorrectly deleted.
  * Improved handling of reserved owner paths and entity-type names.
  * Migrated legacy ACL entity types to the shared resource type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->