### PR TITLE
chore: drop unused reserved aliases and re-exports

### DIFF
--- a/packages/core/src/__tests__/reserved.test.ts
+++ b/packages/core/src/__tests__/reserved.test.ts
@@ -13,11 +13,6 @@ describe("isSystemEntityType", () => {
     expect(isSystemEntityType({ slug: "channel" })).toBe(false);
     expect(isSystemEntityType({ slug: "person" })).toBe(false);
     expect(isSystemEntityType({})).toBe(false);
-    // is_system field is ignored (legacy API noise)
-    expect(isSystemEntityType({ slug: "goal", is_system: true })).toBe(false);
-    expect(isSystemEntityType({ slug: "$member", is_system: false })).toBe(
-      true
-    );
   });
 });
 

--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -1,30 +1,21 @@
 /**
  * Canonical reserved names and entity-type classification helpers.
  *
- * Two separate jobs — do not collapse them:
  * 1. System types — slug starts with `$` (`$member`, `$resource`, …)
- * 2. Reserved slug lists — illegal *names* for user create / routes (may not be rows)
+ * 2. Reserved slug lists — illegal *names* for user create / routes
  *
  * Users cannot create `$…` types. Hide + prune use the `$` prefix only.
- * `created_by` is audit only and must never be used as a stand-in for system.
  */
 
 // ── Entity type classification ──────────────────────────────────────────────
 
 /**
  * True when a type is platform-owned (hidden from rail, never pruned).
- * Sole signal: slug starts with `$` (not created_by, not hide-slug denylists).
+ * Sole signal: slug starts with `$`.
  */
-export function isSystemEntityType(et: {
-  slug?: string | null;
-  /** @deprecated ignored — classification is slug `$` only */
-  is_system?: boolean | null;
-}): boolean {
+export function isSystemEntityType(et: { slug?: string | null }): boolean {
   return typeof et.slug === "string" && et.slug.startsWith("$");
 }
-
-/** @deprecated Use isSystemEntityType */
-export const isSystemResourceEntityType = isSystemEntityType;
 
 // ── Route / path reserved names ─────────────────────────────────────────────
 
@@ -101,9 +92,6 @@ export const RESERVED_ENTITY_TYPE_SLUGS = [
   "source",
   "connector",
 ] as const;
-
-/** @deprecated Use RESERVED_ENTITY_TYPE_SLUGS */
-export const RESERVED_ENTITY_TYPES = RESERVED_ENTITY_TYPE_SLUGS;
 
 /**
  * Whether a proposed entity-type slug is illegal for user/API create.

--- a/packages/server/src/utils/reserved.ts
+++ b/packages/server/src/utils/reserved.ts
@@ -1,15 +1,9 @@
 /**
- * Re-export canonical reserved names from @lobu/core.
- * Keep this file so existing server imports (`../utils/reserved`) stay stable.
+ * Re-export the reserved-name helpers the server actually uses.
+ * Canonical definitions live in `@lobu/core`.
  */
 export {
   isReservedEntityTypeSlug,
-  isSystemEntityType,
-  isSystemResourceEntityType,
-  OWNER_ROUTE_SEGMENTS,
-  REMOVED_OWNER_SEGMENTS,
   RESERVED_ENTITY_TYPE_SLUGS,
-  RESERVED_ENTITY_TYPES,
-  RESERVED_PATHS,
   RESERVED_PATHS_SET,
 } from "@lobu/core";


### PR DESCRIPTION
## Summary
- Delete deprecated aliases: \`isSystemResourceEntityType\`, \`RESERVED_ENTITY_TYPES\`, \`isHiddenEntityType\`
- Slim \`packages/server/src/utils/reserved.ts\` to only re-export used symbols
- Slim owletto reserved re-exports (owletto #517)
- \`isSystemEntityType\` no longer accepts ignored \`is_system\` field

Net-negative cleanup after #2014.

## Test plan
- [x] core + CLI prune + owletto reserved unit tests
- [x] make pre-pr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified system entity classification to rely on slug values.
  - Removed deprecated reserved-resource and reserved-entity aliases.
  - Streamlined server-facing reserved-route exports.
- **Tests**
  - Updated validation to reflect slug-based system entity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->