### PR TITLE
refactor(authz): collapse ACL source to resourceNamespace only

### DIFF
--- a/packages/connector-sdk/src/acl-source.ts
+++ b/packages/connector-sdk/src/acl-source.ts
@@ -2,29 +2,23 @@
  * ACL-source contract — the shared shape between a connector and the generic
  * access-graph engine.
  *
- * A connector that gates read access on membership (a Slack workspace's
- * channels, a GitHub org's repos, …) reduces to the same shape: a set of
- * RESOURCES, each with an AUDIENCE of MEMBERS who may read it. The connector
- * owns how its raw API data normalizes into that shape (`AclSourceDef`); the
- * server owns the generic materialization (resolve entities, member_of edges,
- * departure reconcile) driven entirely by these DTOs. Core code never names a
- * specific connector — it iterates `AclSourceDef`s the connectors contribute.
+ * A connector that gates read access on membership (Slack channels, GitHub
+ * repos, …) reduces to: RESOURCES × AUDIENCE of MEMBERS. The connector owns
+ * normalization into that shape; the server materializes entities, identities,
+ * and `member_of` edges. Core never names a connector.
  *
- * All ACL resources share ONE entity type: {@link ACL_RESOURCE_TYPE_SLUG}
- * (`$resource`). Sources are distinguished by identity namespace, not type slug.
- *
- * These are pure data types (no server/db dependency) so they live in the SDK
- * and can be imported by both a connector package and the server engine.
+ * All ACL resources are entity type `$resource`. Sources differ only by
+ * resource identity namespace and member identity namespaces.
  */
 
 /**
- * Sole platform entity-type slug for ACL-gated units (Slack channels, GitHub
- * repos, …). `$` prefix → system (hide rail, never prune, user-create blocked).
+ * Sole platform entity-type slug for ACL-gated units.
+ * `$` prefix → system (hide rail, never prune, user-create blocked).
  */
 export const ACL_RESOURCE_TYPE_SLUG = '$resource' as const;
 
-/** Shared name/icon for {@link ACL_RESOURCE_TYPE_SLUG} (all sources use this). */
-export const ACL_RESOURCE_TYPE_DEFAULTS = {
+/** Columns used when ensuring the platform `$resource` entity type. */
+export const ACL_RESOURCE_TYPE = {
   slug: ACL_RESOURCE_TYPE_SLUG,
   name: 'Resource',
   description:
@@ -44,51 +38,39 @@ export interface AccessIdentitySpec {
 
 /** One member of a resource's audience. */
 export interface AccessMember {
-  /** Stable dedupe key for this member across resources (the primary identity
-   * value is the natural choice: `T…:U…` for Slack, the numeric id for GitHub). */
+  /** Stable dedupe key (e.g. `T…:U…` for Slack, numeric id for GitHub). */
   key: string;
   /** Display name for an auto-created `person`. Falls back to `key`. */
   name?: string;
-  /** This member's identity claims (namespaces declared in `memberIdentities`). */
+  /** This member's identity claims (namespaces in `memberIdentities`). */
   identities: { namespace: string; value: string }[];
 }
 
 /** One resource (channel/repo/…) and the members who may read it. */
 export interface AccessResource {
-  /** Stored as the resource entity's identity under `resourceType.namespace`
-   * (`T…:C…` for Slack, `owner/repo` or the numeric id for GitHub). */
+  /**
+   * Stored under the source's `resourceNamespace`
+   * (`T…:C…` for Slack, `owner/repo` for GitHub).
+   */
   key: string;
   name?: string;
   members: AccessMember[];
 }
 
-/** The resource entity type to find-or-create and key resources under. */
-export interface AccessResourceType {
-  /**
-   * Must be {@link ACL_RESOURCE_TYPE_SLUG} (`$resource`). One type for every
-   * ACL source; identity `namespace` distinguishes channel vs repo vs …
-   */
-  slug: typeof ACL_RESOURCE_TYPE_SLUG | string;
-  name: string;
-  description: string;
-  icon: string;
-  /** Identity namespace the resource key is stored/looked-up under. */
-  namespace: string;
-}
-
 /**
  * A connector's ACL-source descriptor — the ONE thing a connector declares to
- * become access-controlled. Says "this connector produces resources of THIS
- * entity type, keyed on THIS identity namespace, whose members are identified
- * by THESE namespaces." The generic server materializer reads it; no new gate
- * or engine code per connector.
+ * become access-controlled. All resources materialize as `$resource`; only the
+ * identity namespaces are source-specific.
  */
 export interface AclSourceDef {
   /** Connector/platform key (`slack`, `github`, …). */
   key: string;
-  /** The resource entity type this source's resources materialize as. */
-  resourceType: AccessResourceType;
-  /** How a member of one of this source's resources is identified. */
+  /**
+   * Identity namespace for resource keys (e.g. `slack_channel_id`,
+   * `github_repo_full_name`).
+   */
+  resourceNamespace: string;
+  /** How a member of a resource is identified. */
   memberIdentities: AccessIdentitySpec[];
 }
 
@@ -96,14 +78,11 @@ export interface AclSourceDef {
  * A chat platform's READ-gate identity model — how the per-channel visibility
  * gate keys a channel and a requester for THIS platform. Unlike `AclSourceDef`
  * (pure data, persisted, replayed generically) this carries key-BUILDER
- * functions, so it is used only in-process at the server's authz edge (the read
- * gate runs live and may import connector code). It is what lets the fail-closed
- * channel gate be platform-parametric instead of Slack-hardcoded.
+ * functions, so it is used only in-process at the server's authz edge.
  *
  * A binding stores a bare channel id (`C…`) + a tenant/team id; the gate must
  * reconstruct the exact team-scoped key the ACL sync wrote (`T…:C…`) to match
- * the graphed `$resource` entity. `channelKeySql` is the SAME construction as a
- * SQL expression, for the message-visibility compiler that keys inside a query.
+ * the graphed `$resource` entity.
  */
 export interface ChannelReadIdentity {
   /** Platform key (`slack`, …) — matched against a binding's `platform`. */
@@ -114,8 +93,7 @@ export interface ChannelReadIdentity {
   userNamespace: string;
   /**
    * Build the team-scoped channel key (`T…:C…`) from a tenant/team id and a
-   * BARE channel id. Returns null when the inputs can't form a valid key (→ the
-   * gate drops the channel fail-closed).
+   * BARE channel id. Returns null when the inputs can't form a valid key.
    */
   buildChannelKey(teamId: string | null | undefined, bareChannelId: string): string | null;
   /**
@@ -124,10 +102,8 @@ export interface ChannelReadIdentity {
    */
   buildUserKey(teamId: string | null | undefined, userId: string | null | undefined): string | null;
   /**
-   * The same channel-key construction as a SQL expression, given the SQL column
-   * references (already-safe identifiers, NOT user input) for the team id and
-   * the bare channel id. Must produce a value byte-identical to
-   * `buildChannelKey` so an in-query match agrees with the TS path.
+   * The same channel-key construction as a SQL expression, given safe SQL
+   * column expressions for team id and bare channel id.
    */
   channelKeySql(teamColExpr: string, channelColExpr: string): string;
 }

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -148,12 +148,11 @@ export type {
   AccessIdentitySpec,
   AccessMember,
   AccessResource,
-  AccessResourceType,
   AclSourceDef,
   ChannelReadIdentity,
 } from './acl-source.js';
 export {
-  ACL_RESOURCE_TYPE_DEFAULTS,
+  ACL_RESOURCE_TYPE,
   ACL_RESOURCE_TYPE_SLUG,
 } from './acl-source.js';
 import {

--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -78,6 +78,11 @@ export function connectorSdkMock() {
     throw new Error(`${name} is not used in connector unit tests`);
   };
   return {
+    // Sole platform entity-type slug for ACL-gated resources. Inlined (not
+    // imported from connector-sdk/src) to keep this mock valid when copied
+    // verbatim into the cli's dist/ (see the file header). Must stay in step
+    // with ACL_RESOURCE_TYPE_SLUG in packages/connector-sdk/src/acl-source.ts.
+    ACL_RESOURCE_TYPE_SLUG: '$resource',
     acquireBrowser: notUsed('acquireBrowser'),
     captureErrorArtifacts: notUsed('captureErrorArtifacts'),
     HttpStatusError,

--- a/packages/connectors/src/__tests__/slack-identity.test.ts
+++ b/packages/connectors/src/__tests__/slack-identity.test.ts
@@ -50,8 +50,7 @@ describe('slackChannelKey', () => {
 describe('slackAclSource', () => {
   it('declares the channel resource keyed on slack_channel_id with slack_user_id members', () => {
     expect(slackAclSource.key).toBe('slack');
-    expect(slackAclSource.resourceType.slug).toBe('$resource');
-    expect(slackAclSource.resourceType.namespace).toBe(SLACK_IDENTITY.CHANNEL_ID);
+    expect(slackAclSource.resourceNamespace).toBe(SLACK_IDENTITY.CHANNEL_ID);
     expect(slackAclSource.memberIdentities).toEqual([
       { namespace: SLACK_IDENTITY.USER_ID, primary: true },
     ]);

--- a/packages/connectors/src/github-identity.ts
+++ b/packages/connectors/src/github-identity.ts
@@ -6,11 +6,10 @@
  * entity-link ingestion all import from here — not from connector-sdk.
  */
 
-import {
-  ACL_RESOURCE_TYPE_DEFAULTS,
-  type AccessMember,
-  type AccessResource,
-  type AclSourceDef,
+import type {
+  AccessMember,
+  AccessResource,
+  AclSourceDef,
 } from '@lobu/connector-sdk';
 import type { ConnectorIdentityModule } from './connector-identity-module.js';
 
@@ -125,11 +124,7 @@ export interface GithubRepoInput {
 /** The GitHub connector's ACL-source descriptor. */
 export const githubAclSource: AclSourceDef = {
   key: 'github',
-  resourceType: {
-    // One shared ACL type for every source; namespace keys GitHub repos.
-    ...ACL_RESOURCE_TYPE_DEFAULTS,
-    namespace: GITHUB_IDENTITY.REPO_FULL_NAME,
-  },
+  resourceNamespace: GITHUB_IDENTITY.REPO_FULL_NAME,
   memberIdentities: [
     { namespace: GITHUB_IDENTITY.USER_ID, primary: true },
     { namespace: GITHUB_IDENTITY.LOGIN },

--- a/packages/connectors/src/slack-identity.ts
+++ b/packages/connectors/src/slack-identity.ts
@@ -8,11 +8,10 @@
  * code never names Slack.
  */
 
-import {
-  ACL_RESOURCE_TYPE_DEFAULTS,
-  type AccessResource,
-  type AclSourceDef,
-  type ChannelReadIdentity,
+import type {
+  AccessResource,
+  AclSourceDef,
+  ChannelReadIdentity,
 } from '@lobu/connector-sdk';
 import type { ConnectorIdentityModule } from './connector-identity-module.js';
 
@@ -139,11 +138,7 @@ export interface SlackChannelInput {
 /** The Slack connector's ACL-source descriptor. */
 export const slackAclSource: AclSourceDef = {
   key: 'slack',
-  resourceType: {
-    // One shared ACL type for every source; namespace keys Slack channels.
-    ...ACL_RESOURCE_TYPE_DEFAULTS,
-    namespace: SLACK_IDENTITY.CHANNEL_ID,
-  },
+  resourceNamespace: SLACK_IDENTITY.CHANNEL_ID,
   memberIdentities: [{ namespace: SLACK_IDENTITY.USER_ID, primary: true }],
 };
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -135,6 +135,12 @@
       "bun": "./src/contracts/tools/manage-watchers.ts",
       "import": "./dist/contracts/tools/manage-watchers.js",
       "require": "./dist/contracts/tools/manage-watchers.js"
+    },
+    "./reserved": {
+      "types": "./dist/reserved.d.ts",
+      "bun": "./src/reserved.ts",
+      "import": "./dist/reserved.js",
+      "require": "./dist/reserved.js"
     }
   },
   "scripts": {

--- a/packages/core/src/__tests__/reserved.test.ts
+++ b/packages/core/src/__tests__/reserved.test.ts
@@ -13,11 +13,6 @@ describe("isSystemEntityType", () => {
     expect(isSystemEntityType({ slug: "channel" })).toBe(false);
     expect(isSystemEntityType({ slug: "person" })).toBe(false);
     expect(isSystemEntityType({})).toBe(false);
-    // is_system field is ignored (legacy API noise)
-    expect(isSystemEntityType({ slug: "goal", is_system: true })).toBe(false);
-    expect(isSystemEntityType({ slug: "$member", is_system: false })).toBe(
-      true
-    );
   });
 });
 

--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -1,30 +1,21 @@
 /**
  * Canonical reserved names and entity-type classification helpers.
  *
- * Two separate jobs — do not collapse them:
  * 1. System types — slug starts with `$` (`$member`, `$resource`, …)
- * 2. Reserved slug lists — illegal *names* for user create / routes (may not be rows)
+ * 2. Reserved slug lists — illegal *names* for user create / routes
  *
  * Users cannot create `$…` types. Hide + prune use the `$` prefix only.
- * `created_by` is audit only and must never be used as a stand-in for system.
  */
 
 // ── Entity type classification ──────────────────────────────────────────────
 
 /**
  * True when a type is platform-owned (hidden from rail, never pruned).
- * Sole signal: slug starts with `$` (not created_by, not hide-slug denylists).
+ * Sole signal: slug starts with `$`.
  */
-export function isSystemEntityType(et: {
-  slug?: string | null;
-  /** @deprecated ignored — classification is slug `$` only */
-  is_system?: boolean | null;
-}): boolean {
+export function isSystemEntityType(et: { slug?: string | null }): boolean {
   return typeof et.slug === "string" && et.slug.startsWith("$");
 }
-
-/** @deprecated Use isSystemEntityType */
-export const isSystemResourceEntityType = isSystemEntityType;
 
 // ── Route / path reserved names ─────────────────────────────────────────────
 
@@ -101,9 +92,6 @@ export const RESERVED_ENTITY_TYPE_SLUGS = [
   "source",
   "connector",
 ] as const;
-
-/** @deprecated Use RESERVED_ENTITY_TYPE_SLUGS */
-export const RESERVED_ENTITY_TYPES = RESERVED_ENTITY_TYPE_SLUGS;
 
 /**
  * Whether a proposed entity-type slug is illegal for user/API create.

--- a/packages/server/src/__tests__/integration/auth/slack-signin-identity-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/slack-signin-identity-e2e.test.ts
@@ -340,7 +340,7 @@ describe("slack sign-in slack_user_id e2e (real BetterAuth handler)", () => {
 			organizationId: org.id,
 			connectionId: CONN,
 			connectorKey: slackAclSource.key,
-			resourceType: slackAclSource.resourceType,
+			resourceNamespace: slackAclSource.resourceNamespace,
 			memberIdentities: slackAclSource.memberIdentities,
 			resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: [SLACK_USER] },

--- a/packages/server/src/__tests__/integration/authz/channel-about.test.ts
+++ b/packages/server/src/__tests__/integration/authz/channel-about.test.ts
@@ -100,7 +100,7 @@ describe("channel about edges", () => {
 			organizationId: org.id,
 			connectionId,
 			connectorKey: slackAclSource.key,
-			resourceType: slackAclSource.resourceType,
+			resourceNamespace: slackAclSource.resourceNamespace,
 			memberIdentities: slackAclSource.memberIdentities,
 			resources: slackChannelsToResources(TEAM, [
 				{

--- a/packages/server/src/__tests__/integration/authz/github-repo-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/github-repo-graph.test.ts
@@ -31,7 +31,7 @@ function buildGithubRepoGraph(params: {
     organizationId: params.organizationId,
     connectionId: params.connectionId,
     connectorKey: githubAclSource.key,
-    resourceType: githubAclSource.resourceType,
+    resourceNamespace: githubAclSource.resourceNamespace,
     memberIdentities: githubAclSource.memberIdentities,
     resources: githubReposToResources(params.repos),
   });

--- a/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
@@ -34,7 +34,7 @@ function buildGithubRepoGraph(params: {
     organizationId: params.organizationId,
     connectionId: params.connectionId,
     connectorKey: githubAclSource.key,
-    resourceType: githubAclSource.resourceType,
+    resourceNamespace: githubAclSource.resourceNamespace,
     memberIdentities: githubAclSource.memberIdentities,
     resources: githubReposToResources(params.repos),
   });

--- a/packages/server/src/__tests__/integration/authz/signin-slack-identity-collapse.test.ts
+++ b/packages/server/src/__tests__/integration/authz/signin-slack-identity-collapse.test.ts
@@ -136,7 +136,7 @@ describe("sign-in slack_user_id collapse (e2e via channel graph)", () => {
 			organizationId: org.id,
 			connectionId: CONN,
 			connectorKey: slackAclSource.key,
-			resourceType: slackAclSource.resourceType,
+			resourceNamespace: slackAclSource.resourceNamespace,
 			memberIdentities: slackAclSource.memberIdentities,
 			resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: [SLACK_USER] },

--- a/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
@@ -35,7 +35,7 @@ function buildSlackChannelGraph(params: {
     organizationId: params.organizationId,
     connectionId: params.connectionId,
     connectorKey: slackAclSource.key,
-    resourceType: slackAclSource.resourceType,
+    resourceNamespace: slackAclSource.resourceNamespace,
     memberIdentities: slackAclSource.memberIdentities,
     resources: slackChannelsToResources(params.teamId, params.channels),
   });

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -167,7 +167,7 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
       organizationId: org.id,
       connectionId: CONN,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
       resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: ["U01ALICE"] },
@@ -194,7 +194,7 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
       organizationId: org.id,
       connectionId: CONN,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
       resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: ["U01ALICE"] },
@@ -219,7 +219,7 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
       organizationId: org.id,
       connectionId: CONN,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
 			resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: ["U01ALICE"] },
@@ -235,7 +235,7 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
       organizationId: org.id,
       connectionId: CONN,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
 			resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: ["U01BOB"] },
@@ -265,7 +265,7 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
       organizationId: org.id,
       connectionId: CONN,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
 			resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: ["U01ALICE"] },
@@ -693,7 +693,7 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
       organizationId: org.id,
       connectionId: CONN,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
       resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: ["U01CAROL"] },
@@ -841,7 +841,7 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
       organizationId: org.id,
       connectionId: CONN,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
       resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: ["U01DAVE"] },
@@ -875,7 +875,7 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
       organizationId: org.id,
       connectionId: CONN,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
       resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: ["U01ALICE"] },

--- a/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
@@ -395,7 +395,7 @@ describe("channel streaming feeds", () => {
       organizationId: orgId,
       connectionId: runtimeConnId,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
       resources: slackChannelsToResources("TENF", [
         { channelId: "CENF", name: "secret", memberSlackUserIds: [] },

--- a/packages/server/src/__tests__/integration/events/resource-gate-stale-acl.test.ts
+++ b/packages/server/src/__tests__/integration/events/resource-gate-stale-acl.test.ts
@@ -36,7 +36,7 @@ function buildGithubRepoGraph(params: {
     organizationId: params.organizationId,
     connectionId: params.connectionId,
     connectorKey: githubAclSource.key,
-    resourceType: githubAclSource.resourceType,
+    resourceNamespace: githubAclSource.resourceNamespace,
     memberIdentities: githubAclSource.memberIdentities,
     resources: githubReposToResources(params.repos),
   });

--- a/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
@@ -182,7 +182,7 @@ describe("streaming feed as a watcher @feed source", () => {
       organizationId: orgId,
       connectionId: conn.runtimeId,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
       resources: slackChannelsToResources(TEAM_ID, [
         { channelId: CHANNEL, name: "general", memberSlackUserIds: ["UMEMBER"] },
@@ -231,7 +231,7 @@ describe("streaming feed as a watcher @feed source", () => {
       organizationId: orgId,
       connectionId: conn.runtimeId,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
       resources: slackChannelsToResources(TEAM_ID, [
         { channelId: CHANNEL, name: "general", memberSlackUserIds: [] },

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -32,21 +32,23 @@
  */
 
 import { createLogger } from '@lobu/core';
-import type {
-  AccessIdentitySpec,
-  AccessMember,
-  AccessResource,
-  AccessResourceType,
+import {
+  ACL_RESOURCE_TYPE_SLUG,
+  type AccessIdentitySpec,
+  type AccessMember,
+  type AccessResource,
 } from '@lobu/connector-sdk';
 import { getDb, pgBigintArray, pgTextArray } from '../db/client.js';
 import { runtimeConnectionIdToSlug } from '../lobu/stores/connections-projection.js';
 import { resolveEventAttributionsForItems } from '../utils/entity-link-upsert.js';
+import { ensureResourceEntityType } from './acl-resource-type.js';
 
 const logger = createLogger('access-graph');
 
 const MEMBER_OF_TYPE_SLUG = 'member_of';
 
-export type { AccessIdentitySpec, AccessMember, AccessResource, AccessResourceType };
+export type { AccessIdentitySpec, AccessMember, AccessResource };
+export { ensureResourceEntityType } from './acl-resource-type.js';
 
 export interface AccessGraphResult {
   /** Resource key → the entity id that now represents it. */
@@ -77,21 +79,6 @@ async function resolveOrgCreator(orgId: string): Promise<string | null> {
 		LIMIT 1
 	`;
   return rows.length > 0 ? rows[0].userId : null;
-}
-
-/** Find-or-create the org-scoped `$resource` entity type (reuse, no migration).
- * All ACL sources share this one type; identity namespace distinguishes them. */
-export async function ensureResourceEntityType(orgId: string, type: AccessResourceType): Promise<void> {
-  const sql = getDb();
-  await sql`
-		INSERT INTO entity_types (slug, name, description, icon, organization_id, created_at, updated_at)
-		VALUES (
-			${type.slug}, ${type.name}, ${type.description}, ${type.icon},
-			${orgId}, current_timestamp, current_timestamp
-		)
-		ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
-		DO NOTHING
-	`;
 }
 
 /** Ensure the org has a `person` entity type — the type new (genuinely-unknown)
@@ -243,11 +230,13 @@ export async function buildAccessGraph(params: {
   organizationId: string;
   connectionId: string;
   connectorKey: string;
-  resourceType: AccessResourceType;
+  /** Identity namespace for resource keys (e.g. `slack_channel_id`). */
+  resourceNamespace: string;
   memberIdentities: AccessIdentitySpec[];
   resources: AccessResource[];
 }): Promise<AccessGraphResult> {
-  const { organizationId, connectionId, connectorKey, resourceType, memberIdentities } = params;
+  const { organizationId, connectionId, connectorKey, resourceNamespace, memberIdentities } =
+    params;
   const resources = params.resources.filter((r) => r.key);
   if (resources.length === 0) return EMPTY_RESULT;
 
@@ -260,7 +249,7 @@ export async function buildAccessGraph(params: {
     return EMPTY_RESULT;
   }
 
-  await ensureResourceEntityType(organizationId, resourceType);
+  await ensureResourceEntityType(organizationId);
   await ensurePersonEntityType(organizationId);
 
   // ACL state uses a runtime connection id, while identity provenance references
@@ -296,11 +285,15 @@ export async function buildAccessGraph(params: {
       access_resource: [
         {
           role: 'belongs_to',
-          entityType: resourceType.slug,
+          entityType: ACL_RESOURCE_TYPE_SLUG,
           autoCreate: true,
           titlePath: 'metadata.resource_name',
           identities: [
-            { namespace: resourceType.namespace, eventPath: 'metadata.resource_key', primary: true },
+            {
+              namespace: resourceNamespace,
+              eventPath: 'metadata.resource_key',
+              primary: true,
+            },
           ],
         },
       ],
@@ -417,7 +410,8 @@ export async function buildAccessGraph(params: {
       organization_id: organizationId,
       connection_id: connectionId,
       connector: connectorKey,
-      resource_type: resourceType.slug,
+      resource_type: ACL_RESOURCE_TYPE_SLUG,
+      resource_namespace: resourceNamespace,
       resources: Object.keys(resourceEntityIds).length,
       members: memberEntityIds.size,
       created_edges: createdEdges,

--- a/packages/server/src/authz/acl-resource-type.ts
+++ b/packages/server/src/authz/acl-resource-type.ts
@@ -1,0 +1,29 @@
+/**
+ * Platform `$resource` entity type ensure — shared by the access-graph engine
+ * and attribution auto-create so a missing type never blocks a resource write.
+ */
+
+import { ACL_RESOURCE_TYPE } from '@lobu/connector-sdk';
+import { getDb } from '../db/client.js';
+
+/**
+ * Find-or-create the org-scoped `$resource` entity type. Idempotent; empty
+ * metadata schema (graph anchor only).
+ */
+export async function ensureResourceEntityType(orgId: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+    INSERT INTO entity_types (slug, name, description, icon, organization_id, created_at, updated_at)
+    VALUES (
+      ${ACL_RESOURCE_TYPE.slug},
+      ${ACL_RESOURCE_TYPE.name},
+      ${ACL_RESOURCE_TYPE.description},
+      ${ACL_RESOURCE_TYPE.icon},
+      ${orgId},
+      current_timestamp,
+      current_timestamp
+    )
+    ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+    DO NOTHING
+  `;
+}

--- a/packages/server/src/authz/channel-about.ts
+++ b/packages/server/src/authz/channel-about.ts
@@ -8,6 +8,7 @@
  */
 
 import { createLogger } from "@lobu/core";
+import { ACL_RESOURCE_TYPE_SLUG } from "@lobu/connector-sdk";
 import {
 	type DbClient,
 	getDb,
@@ -134,18 +135,17 @@ export async function ensureChannelResourceEntity(opts: {
 	if (readIdentity && readIdentity.buildChannelKey(opts.teamId, bare) === null) {
 		return null;
 	}
-	// The resource entity type comes from the connector's ACL source. A connector
-	// that declares none produces no access-controlled channel resource, so there
-	// is nothing to materialize — skip rather than fabricate a type.
-	const resourceType = aclSourceFor(opts.connectorKey)?.resourceType;
-	if (!resourceType) return null;
+	// Connector must register an ACL source; otherwise there is no resource to
+	// materialize.
+	const aclSource = aclSourceFor(opts.connectorKey);
+	if (!aclSource) return null;
 
 	const { namespace, key } = channelResourceIdentity(
 		opts.connectorKey,
 		opts.teamId,
 		opts.channelId,
 	);
-	await ensureResourceEntityType(opts.organizationId, resourceType);
+	await ensureResourceEntityType(opts.organizationId);
 
 	const resolved = await resolveEventAttributionsForItems(
 		{
@@ -164,7 +164,7 @@ export async function ensureChannelResourceEntity(opts: {
 				channel_about: [
 					{
 						role: "about",
-						entityType: resourceType.slug,
+						entityType: ACL_RESOURCE_TYPE_SLUG,
 						autoCreate: true,
 						titlePath: "metadata.resource_name",
 						identities: [

--- a/packages/server/src/authz/github-acl-sync.ts
+++ b/packages/server/src/authz/github-acl-sync.ts
@@ -92,7 +92,7 @@ export async function syncGithubConnectionAcl(
       organizationId,
       connectionId,
       connectorKey: githubAclSource.key,
-      resourceType: githubAclSource.resourceType,
+      resourceNamespace: githubAclSource.resourceNamespace,
       memberIdentities: githubAclSource.memberIdentities,
       resources: githubReposToResources(repoInputs),
     });

--- a/packages/server/src/authz/resource-visibility.ts
+++ b/packages/server/src/authz/resource-visibility.ts
@@ -14,9 +14,8 @@
  *     `freshness_state='fresh'`, synced within the freshness window) is visible
  *     ONLY when the requester is `member_of` one of the RESOURCE entities the
  *     event is linked to (`events.entity_ids`), where "resource" = an entity whose
- *     type is the shared ACL resource type (`$resource` via `RESOURCE_TYPE_SLUGS`).
- *     This is deliberately scoped to resource types so the coarse person→`company`
- *     (org) `member_of` edge never satisfies it — org membership must NOT grant
+ *     type is `$resource`. Scoped so the coarse person→`company` (org)
+ *     `member_of` edge never satisfies it — org membership must NOT grant
  *     repo-level read;
  *   - an event on an onboarded-but-STALE connection (a row exists but is
  *     partial/failed/stale/aged-out — i.e. NOT in the enforced set) FAILS CLOSED:
@@ -33,14 +32,12 @@
  * resource entity.
  */
 
+import { ACL_RESOURCE_TYPE_SLUG } from '@lobu/connector-sdk';
 import { aclStateExistsSelectSql, enforcedConnectionsSelectSql } from './acl-state.js';
 import type { AuthzScope } from './scope.js';
-import { RESOURCE_TYPE_SLUGS } from './sources.js';
 
-/** Resource type slugs as a safe SQL `IN (...)` list. Registry enforces
- * `$resource` only; inlining as literals is injection-safe (and avoids binding
- * a text[] param, which the fetch_types:false driver rejects). */
-const RESOURCE_TYPE_IN_LIST = RESOURCE_TYPE_SLUGS.map((s) => `'${s}'`).join(', ');
+/** Sole ACL resource type slug, inlined as a SQL string literal (constant). */
+const RESOURCE_TYPE_SQL = `'${ACL_RESOURCE_TYPE_SLUG}'`;
 
 /**
  * Predicate for a table holding events (alias has `connection_id` + `entity_ids`).
@@ -55,12 +52,6 @@ export function compileResourceVisibility(
 ): { sql: string; params: Array<string | null> } {
   const orgParam = `$${baseParamIndex}::text`;
   const userParam = `$${baseParamIndex + 1}::text`;
-
-  // No registered resource types → nothing to enforce (defensive; the registry
-  // is non-empty today).
-  if (RESOURCE_TYPE_SLUGS.length === 0) {
-    return { sql: '', params: [] };
-  }
 
   // `events.connection_id` is the bigint `connections.id`, but
   // `authz_source_acl_state.connection_id` is text — the ACL sync stamps it as
@@ -94,7 +85,7 @@ export function compileResourceVisibility(
         JOIN public.entity_types ret
           ON ret.id = re.entity_type_id
          AND ret.organization_id = re.organization_id
-         AND ret.slug IN (${RESOURCE_TYPE_IN_LIST})
+         AND ret.slug = ${RESOURCE_TYPE_SQL}
         WHERE rr.organization_id = ${orgParam}
           AND rr.deleted_at IS NULL
           AND rr.to_entity_id = ANY(${tableAlias}.entity_ids)

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -239,7 +239,7 @@ export async function syncSlackConnectionAcl(
         organizationId,
         connectionId,
         connectorKey: slackAclSource.key,
-        resourceType: slackAclSource.resourceType,
+        resourceNamespace: slackAclSource.resourceNamespace,
         memberIdentities: slackAclSource.memberIdentities,
         resources: slackChannelsToResources(teamId, channels),
       });

--- a/packages/server/src/authz/sources.ts
+++ b/packages/server/src/authz/sources.ts
@@ -1,64 +1,32 @@
 /**
- * The ACL source registry — the ONE place core code COLLECTS the
- * access-controlled sources. Each descriptor is owned by its connector
- * (`@lobu/connectors/<key>-identity` exports the `AclSourceDef`); this file only
- * gathers them so the generic read gate (`./resource-visibility`) and sync loop
- * (`./acl-sync`) can iterate every source without naming a connector.
+ * The ACL source registry — the ONE place core code COLLECTS access-controlled
+ * sources. Each descriptor is owned by its connector; this file only gathers
+ * them so the generic gate and sync loop iterate without naming connectors.
  *
- * Adding Linear/Jira/Drive = a connector that exports an `AclSourceDef` +
- * appending it here. No new gate code, no new engine code.
- *
- * All sources share entity type `$resource` ({@link ACL_RESOURCE_TYPE_SLUG}).
+ * All sources materialize as entity type `$resource`. Identity namespaces
+ * distinguish Slack channels, GitHub repos, etc.
  */
 
-import {
-  ACL_RESOURCE_TYPE_SLUG,
-  type AclSourceDef,
-  type ChannelReadIdentity,
-} from '@lobu/connector-sdk';
+import type { AclSourceDef, ChannelReadIdentity } from '@lobu/connector-sdk';
 import { githubAclSource } from '@lobu/connectors/github-identity';
 import { slackAclSource, slackChannelReadIdentity } from '@lobu/connectors/slack-identity';
 
 /** Every registered ACL source (contributed by its connector package). */
 export const ACL_SOURCES: AclSourceDef[] = [slackAclSource, githubAclSource];
 
-// Hard invariant: one ACL entity type for every source (identity namespace differs).
-for (const source of ACL_SOURCES) {
-  if (source.resourceType.slug !== ACL_RESOURCE_TYPE_SLUG) {
-    throw new Error(
-      `ACL source '${source.key}' must use resource type '${ACL_RESOURCE_TYPE_SLUG}', got '${source.resourceType.slug}'`,
-    );
-  }
-}
-
 const ACL_SOURCE_BY_KEY = new Map<string, AclSourceDef>(ACL_SOURCES.map((s) => [s.key, s]));
 
 /**
  * The ACL source descriptor for a connector key, or null when that connector
- * contributes no access-controlled resource type. Lets a caller read a
- * connector's `resourceType` (namespace + slug) without naming the connector.
+ * contributes no access-controlled resources.
  */
 export function aclSourceFor(key: string): AclSourceDef | null {
   return ACL_SOURCE_BY_KEY.get(key) ?? null;
 }
 
 /**
- * Resource entity-type slugs the read gate treats as access-controlled.
- * Always `$resource` only — kept as an array so the SQL `IN (...)` compiler
- * stays generic if a second system type is ever needed.
- */
-export const RESOURCE_TYPE_SLUGS: readonly string[] = [ACL_RESOURCE_TYPE_SLUG];
-
-/**
  * Chat platforms whose per-channel read gate is enforced, keyed by `platform`.
- * Each descriptor (owned by its connector) tells the gate how to key a channel
- * and a requester for that platform, so `channel-visibility` /
- * `channel-messages-visibility` / `channel-entity` / `acl-state` name no
- * connector. GitHub is NOT here — its resource gate is repo-based, not the
- * team-scoped chat-channel model.
- *
- * Adding Telegram/Discord chat ACL = the connector exports a
- * `ChannelReadIdentity` + appending it here. No gate code changes.
+ * GitHub is NOT here — its resource gate is repo-based, not chat-channel.
  */
 export const CHANNEL_READ_IDENTITIES: ChannelReadIdentity[] = [slackChannelReadIdentity];
 
@@ -68,8 +36,7 @@ const CHANNEL_READ_IDENTITY_BY_PLATFORM = new Map<string, ChannelReadIdentity>(
 
 /**
  * The read-gate identity model for a chat platform, or null when that platform
- * has no enforced channel gate (→ the caller falls back to non-enforced /
- * passthrough behavior). Never throws.
+ * has no enforced channel gate.
  */
 export function channelReadIdentityFor(platform: string): ChannelReadIdentity | null {
   return CHANNEL_READ_IDENTITY_BY_PLATFORM.get(platform) ?? null;

--- a/packages/server/src/tools/__tests__/search-managed-recall-and-acl.test.ts
+++ b/packages/server/src/tools/__tests__/search-managed-recall-and-acl.test.ts
@@ -240,7 +240,7 @@ describe("managed-install recall (Item 2) + author attribution surfacing (Item 3
       organizationId: org.id,
       connectionId: CONN,
       connectorKey: slackAclSource.key,
-      resourceType: slackAclSource.resourceType,
+      resourceNamespace: slackAclSource.resourceNamespace,
       memberIdentities: slackAclSource.memberIdentities,
       resources: slackChannelsToResources(TEAM, [
 				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: ["U01ALICE"] },

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -17,13 +17,15 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import type {
-  EntityIdentitySpec,
-  EntityLinkPredicate,
-  EntityTraitSpec,
-  EventAttributionRule,
+import {
+  ACL_RESOURCE_TYPE_SLUG,
+  type EntityIdentitySpec,
+  type EntityLinkPredicate,
+  type EntityTraitSpec,
+  type EventAttributionRule,
 } from '@lobu/connector-sdk';
 import { normalizeIdentifier } from '@lobu/connector-sdk/identity-normalize';
+import { ensureResourceEntityType } from '../authz/acl-resource-type';
 import { type DbClient, getDb, pgTextArray } from '../db/client';
 import { normalizeConnectorIdentityValue } from '../identity/connector-identity-modules';
 import logger from './logger';
@@ -390,7 +392,7 @@ async function createEntityWithIdentities(
   // Resolve entity_type slug → entity_types(id). Same schema search path as
   // createEntity: try the entity's own org first, then any visibility='public'
   // catalog. First match wins. See createEntity for the slug-poisoning caveat.
-  const typeRow = await sql<{ id: number; backing_sql: string | null }>`
+  let typeRow = await sql<{ id: number; backing_sql: string | null }>`
     SELECT et.id, et.backing_sql
     FROM entity_types et
     LEFT JOIN organization o ON o.id = et.organization_id
@@ -404,11 +406,32 @@ async function createEntityWithIdentities(
     LIMIT 1
   `;
   if (typeRow.length === 0) {
-    logger.warn(
-      { entityType: params.entityType, orgId: params.orgId },
-      'entity create failed: unknown entity type'
-    );
-    return null;
+    // Platform ACL type is ensured on the fly so event attribution can race
+    // ahead of the first ACL sync without failing closed on a missing type.
+    if (params.entityType === ACL_RESOURCE_TYPE_SLUG) {
+      await ensureResourceEntityType(params.orgId);
+      typeRow = await sql<{ id: number; backing_sql: string | null }>`
+        SELECT et.id, et.backing_sql
+        FROM entity_types et
+        WHERE et.slug = ${params.entityType}
+          AND et.deleted_at IS NULL
+          AND et.organization_id = ${params.orgId}
+        LIMIT 1
+      `;
+      if (typeRow.length === 0) {
+        logger.warn(
+          { entityType: params.entityType, orgId: params.orgId },
+          'entity create failed: $resource type ensure did not materialize'
+        );
+        return null;
+      }
+    } else {
+      logger.warn(
+        { entityType: params.entityType, orgId: params.orgId },
+        'entity create failed: unknown entity type'
+      );
+      return null;
+    }
   }
   // Derived (view-backed) types have no stored rows — skip auto-create (the
   // view ignores any row this would insert). Mirrors createEntity's guard for

--- a/packages/server/src/utils/reserved.ts
+++ b/packages/server/src/utils/reserved.ts
@@ -1,15 +1,9 @@
 /**
- * Re-export canonical reserved names from @lobu/core.
- * Keep this file so existing server imports (`../utils/reserved`) stay stable.
+ * Re-export the reserved-name helpers the server actually uses.
+ * Canonical definitions live in `@lobu/core`.
  */
 export {
   isReservedEntityTypeSlug,
-  isSystemEntityType,
-  isSystemResourceEntityType,
-  OWNER_ROUTE_SEGMENTS,
-  REMOVED_OWNER_SEGMENTS,
   RESERVED_ENTITY_TYPE_SLUGS,
-  RESERVED_ENTITY_TYPES,
-  RESERVED_PATHS,
   RESERVED_PATHS_SET,
 } from "@lobu/core";


### PR DESCRIPTION
## Summary

Maximum simplification of the ACL resource model after #2014:

### SDK
\`\`\`ts
// Before
AclSourceDef { key, resourceType: { slug, name, description, icon, namespace }, memberIdentities }

// After
AclSourceDef { key, resourceNamespace, memberIdentities }
\`\`\`

- All resources are always entity type \`\$resource\` (\`ACL_RESOURCE_TYPE\`)
- Dropped \`AccessResourceType\` interface
- Dropped \`ACL_RESOURCE_TYPE_DEFAULTS\` alias

### Server
- \`ensureResourceEntityType(orgId)\` only (shared \`acl-resource-type.ts\`)
- Gate: \`ret.slug = '\$resource'\` — no \`RESOURCE_TYPE_SLUGS\` array / empty-list branch
- Attribution auto-ensures \`\$resource\` when the type is missing (race with ACL sync)
- Slim reserved re-exports (supersedes #2015)

### Connector author surface
\`\`\`ts
export const slackAclSource: AclSourceDef = {
  key: 'slack',
  resourceNamespace: 'slack_channel_id',
  memberIdentities: [{ namespace: 'slack_user_id', primary: true }],
};
// + normalizer → AccessResource[]
// + register in authz/sources.ts
// + events: entityType: ACL_RESOURCE_TYPE_SLUG
\`\`\`

No \`lobu.config\` entity type for ACL.

## Test plan
- [x] unit: slack-identity, reserved
- [x] pre-commit typecheck
- [ ] CI integration (ACL graph / visibility suites)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized authorization resource handling across Slack and GitHub connections.
  - Improved consistency when building access graphs and enforcing resource visibility.
  - Added clearer handling for reserved entity-type slugs, including case-insensitive validation.
  - Improved automatic setup of authorization resource types when needed.

- **Bug Fixes**
  - Improved reliability of channel and repository access checks during synchronization and visibility enforcement.
  - Preserved access behavior across identity linking, membership updates, and managed recall flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->