### PR TITLE
fix(web): process-not-defined + SPA artifact gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,11 +287,14 @@ jobs:
       - name: CLI command-coverage smoke (every command runs)
         run: bash scripts/cli-smoke.sh
 
-  # Frontend tests run under jsdom via vitest. owletto is a submodule;
-  # forks without the deploy key get a stub package and skip these.
+  # Frontend: vitest (jsdom) + prod SPA build + Chromium cold-boot smoke.
+  # The boot smoke is the SPA equivalent of connector-parity-smoke: unit tests
+  # run in Node (where `process` exists) and cannot catch "CI green, browser
+  # white-screen" packaging bugs. Build uses the same `bun run build` path as
+  # docker/app/Dockerfile. Forks without the deploy key get a stub and skip.
   frontend:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
 
@@ -310,19 +313,45 @@ jobs:
 
       - name: Build core + connector-sdk (owletto imports their compiled dist)
         # connector-sdk imports @lobu/core; resolving the type-only barrel
-        # import needs core/dist on disk first.
+        # import needs core/dist on disk first. core/reserved subpath is what
+        # the SPA imports at runtime — must be on disk for the prod build.
         if: steps.submodule.outputs.stubbed != 'true'
         run: |
           cd packages/core && bun run build && cd ../..
           cd packages/connector-sdk && bun run build && cd ../..
 
       - name: owletto tests (vitest)
-        # owletto doesn't define a `test` script in its package.json yet
-        # (that change ships as a separate submodule PR). Invoke vitest
-        # directly via the workspace-installed binary so this works on
-        # whatever submodule SHA the parent repo points at.
         if: steps.submodule.outputs.stubbed != 'true'
         run: cd packages/owletto && ../../node_modules/.bin/vitest run
+
+      - name: SPA prod build (barrel ban + vite + bundle tripwire)
+        # Same command docker/app uses. Fails on runtime `@lobu/core` barrel
+        # imports, untransformed CJS, Node contamination markers, entry bloat.
+        if: steps.submodule.outputs.stubbed != 'true'
+        run: cd packages/owletto && bun run build
+
+      - name: Install system Chromium (SPA boot smoke)
+        # Prefer apt Chromium over Playwright's versioned browser download so
+        # we don't fight patchright/playwright package skew in the monorepo.
+        if: steps.submodule.outputs.stubbed != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends chromium-browser \
+            || sudo apt-get install -y --no-install-recommends chromium
+          # Point the smoke at whatever binary apt gave us.
+          for b in /usr/bin/chromium-browser /usr/bin/chromium /usr/bin/google-chrome; do
+            if [ -x "$b" ]; then
+              echo "SPA_SMOKE_CHROME=$b" >> "$GITHUB_ENV"
+              echo "Using $b"
+              break
+            fi
+          done
+
+      - name: SPA cold-boot smoke (Chromium)
+        # Loads dist/ in a real browser; fails on pageerror (e.g. process is
+        # not defined). Network API failures are ignored — no backend here.
+        if: steps.submodule.outputs.stubbed != 'true'
+        run: cd packages/owletto && bun run smoke:boot
 
   # Backend integration tests need a real Postgres + pgvector. We run them
   # under Node (not bun) for two reasons: (1) the vitest suite uses Node-only

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,12 @@
       "import": "./dist/errors.js",
       "require": "./dist/errors.js"
     },
+    "./reserved": {
+      "types": "./dist/reserved.d.ts",
+      "bun": "./src/reserved.ts",
+      "import": "./dist/reserved.js",
+      "require": "./dist/reserved.js"
+    },
     "./ajv": {
       "types": "./dist/utils/ajv.d.ts",
       "bun": "./src/utils/ajv.ts",


### PR DESCRIPTION
## Summary
**Prod white-screen:** `Uncaught ReferenceError: process is not defined`

### Root cause
Owletto #514 imported reserved helpers from the `@lobu/core` **package root**. The CJS barrel re-exports logger/otel/Node Sentry; Rollup cannot tree-shake them → SPA entry evaluated `process` and crashed.

### Fix
- Export browser-safe `@lobu/core/reserved`
- Owletto imports that subpath (+ Vite source alias) — **#519 merged**
- Bump submodule

### Prevention (this PR + owletto #520)
| Gate | What it catches |
|------|-----------------|
| `check:core-barrel` | Runtime `from "@lobu/core"` in SPA source |
| `check-browser-bundle` | Node markers, CJS leaks, entry size budget |
| Chromium cold-boot smoke | Any `pageerror` on loading `dist/` |
| CI `frontend` job | Runs prod `bun run build` + smoke (same idea as connector-parity-smoke) |

## Test plan
- [x] Barrel ban green / red on value import
- [x] `bun run build` + bundle check (1.6MB entry, clean)
- [x] `smoke:boot` against system Chrome
- [ ] CI green → merge → deploy → hard-refresh app.lobu.ai