### PR TITLE
fix(feeds): omit schedule means manual-only, clear default 6h

### DIFF
--- a/db/migrations/20260718020000_feeds_clear_default_schedule.sql
+++ b/db/migrations/20260718020000_feeds_clear_default_schedule.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+--
+-- Platform used to invent `0 */6 * * *` when create_feed omitted schedule.
+-- That is removed: omit/null = manual-only. Clear the historical default so
+-- existing feeds stop auto-polling until an explicit cron is set again
+-- (UI or lobu.config schedule: "...").
+--
+-- Also clear next_run_at so CheckDueFeeds will not re-enqueue them.
+
+UPDATE public.feeds
+SET
+  schedule = NULL,
+  next_run_at = NULL,
+  updated_at = NOW()
+WHERE schedule = '0 */6 * * *'
+  AND deleted_at IS NULL;
+
+-- migrate:down
+-- Irreversible data cleanup: cannot restore which feeds had the default vs
+-- an intentional 6-hour cron. No-op on down.
+SELECT 1;

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -560,6 +560,20 @@ describe("mapProjectToDesiredState", () => {
     ).toThrow(/connection slug/);
   });
 
+  test("omitted feed schedule maps to null (manual-only, no platform default)", () => {
+    const conn = defineConnection({
+      slug: "gh",
+      connector: "github",
+      feeds: [{ feed: "stars" }],
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ agents: [], connections: [conn] })
+    );
+    expect(state.connectors.connections[0]?.feeds).toEqual([
+      { feedKey: "stars", schedule: null },
+    ]);
+  });
+
   test("rejects an invalid cron schedule", () => {
     const crm = defineAgent({ id: "crm" });
     const watcher = defineWatcher({
@@ -637,6 +651,7 @@ describe("mapProjectToDesiredState", () => {
       {
         feedKey: "query",
         name: "Churn rollup (live)",
+        schedule: null,
         config: { query: "SELECT 1" },
         virtual: true,
       },

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -1019,7 +1019,8 @@ export async function executePlan(
     if (remoteFeed && row.verb === "update") {
       await ctx.client.updateFeed(remoteFeed.id, {
         name: feed.name,
-        schedule: feed.schedule,
+        // null clears remote cron (manual-only); string sets it.
+        schedule: feed.schedule ?? null,
         config: feed.config ?? {},
       });
     } else {
@@ -1027,7 +1028,7 @@ export async function executePlan(
         connectionId,
         feedKey: feed.feedKey,
         name: feed.name,
-        schedule: feed.schedule,
+        schedule: feed.schedule ?? null,
         config: feed.config,
         virtual: feed.virtual,
       });

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -1406,7 +1406,8 @@ export class ApplyClient {
     connectionId: number;
     feedKey: string;
     name?: string;
-    schedule?: string;
+    /** Cron string, or null for manual-only. */
+    schedule?: string | null;
     config?: Record<string, unknown>;
     virtual?: boolean;
   }): Promise<RemoteFeed> {
@@ -1415,7 +1416,9 @@ export class ApplyClient {
       connection_id: payload.connectionId,
       feed_key: payload.feedKey,
       ...(payload.name ? { display_name: payload.name } : {}),
-      ...(payload.schedule ? { schedule: payload.schedule } : {}),
+      // Always send schedule when provided (including null) so the server does
+      // not have to invent a default.
+      ...(payload.schedule !== undefined ? { schedule: payload.schedule } : {}),
       ...(payload.config ? { config: payload.config } : {}),
       ...(payload.virtual ? { virtual: true } : {}),
     });
@@ -1431,7 +1434,8 @@ export class ApplyClient {
     feedId: number,
     payload: {
       name?: string;
-      schedule?: string;
+      /** Cron string, or null to clear (manual-only). */
+      schedule?: string | null;
       config?: Record<string, unknown>;
     }
   ): Promise<RemoteFeed> {

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -139,7 +139,11 @@ export interface DesiredFeed {
   /** Feed key from the connector definition (`FeedDefinition.key`). */
   feedKey: string;
   name?: string;
-  schedule?: string;
+  /**
+   * Cron for automatic sync. `null` / omitted after map-config means manual-only
+   * (no platform default). Virtual feeds always null.
+   */
+  schedule?: string | null;
   config?: Record<string, unknown>;
   /** Federated (live-pushdown, no-copy) feed — never synced; schedule is NULL. */
   virtual?: boolean;

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -713,7 +713,8 @@ function mapConnection(connection: Connection): DesiredConnection {
     return {
       feedKey: feed.feed,
       ...(feed.name ? { name: feed.name } : {}),
-      ...(feed.schedule ? { schedule: feed.schedule } : {}),
+      // Omit in config → manual-only (null). Never invent a default cron.
+      schedule: feed.virtual ? null : (feed.schedule ?? null),
       ...(feed.config ? { config: feed.config } : {}),
       ...(feed.virtual ? { virtual: true } : {}),
     };

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -362,6 +362,7 @@ describe("lobu init --from-org", () => {
       {
         feedKey: "query",
         name: "Churn rollup (live)",
+        schedule: null,
         config: { query: "SELECT 1" },
         virtual: true,
       },

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2885,9 +2885,9 @@ export type ManageFeedsData = {
           [key: string]: unknown;
         };
         /**
-         * Cron expression for sync schedule (default: every 6 hours)
+         * Cron expression for automatic sync. Omit or null for manual-only.
          */
-        schedule?: string;
+        schedule?: string | null;
         /**
          * IANA timezone the schedule is evaluated in (e.g. 'Asia/Taipei'), DST-aware. Omit for server time (UTC).
          */
@@ -2920,9 +2920,9 @@ export type ManageFeedsData = {
          */
         replace_config?: boolean;
         /**
-         * Cron expression for sync schedule
+         * Cron expression for automatic sync. Null clears the schedule (manual-only).
          */
-        schedule?: string;
+        schedule?: string | null;
         /**
          * IANA timezone the schedule is evaluated in. Null clears it (server time / UTC).
          */

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -112,8 +112,9 @@ export const CreateFeedAction = Type.Object({
     })
   ),
   schedule: Type.Optional(
-    Type.String({
-      description: "Cron expression for sync schedule (default: every 6 hours)",
+    Type.Union([Type.String({ minLength: 1 }), Type.Null()], {
+      description:
+        "Cron expression for automatic sync. Omit or null for manual-only (trigger_feed); no platform default cadence.",
     })
   ),
   timezone: Type.Optional(
@@ -148,7 +149,10 @@ export const UpdateFeedAction = Type.Object({
     })
   ),
   schedule: Type.Optional(
-    Type.String({ description: "Cron expression for sync schedule" })
+    Type.Union([Type.String({ minLength: 1 }), Type.Null()], {
+      description:
+        "Cron expression for automatic sync. Null clears the schedule (manual-only).",
+    })
   ),
   timezone: Type.Optional(
     Type.Union([Type.String({ minLength: 1, maxLength: 64 }), Type.Null()], {

--- a/packages/server/src/__tests__/integration/feeds-manual-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-manual-schedule.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Collected feeds with no schedule are manual-only (no platform default cron).
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { cleanupTestDatabase } from "../setup/test-db";
+import {
+	createTestConnection,
+	createTestOrganization,
+	createTestUser,
+} from "../setup/test-fixtures";
+import { TestApiClient } from "../setup/test-mcp-client";
+
+describe("manage_feeds schedule (manual default)", () => {
+	let owner: TestApiClient;
+	let connectionId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "Manual Schedule Org" });
+		const user = await createTestUser({ email: "manual-sched@test.com" });
+		owner = await TestApiClient.for({
+			organizationId: org.id,
+			userId: user.id,
+			memberRole: "owner",
+		});
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: "github",
+			created_by: user.id,
+			createDefaultFeed: false,
+		});
+		connectionId = Number(conn.id);
+	});
+
+	it("create_feed without schedule persists schedule/next_run_at NULL", async () => {
+		const result = (await owner.feeds.create({
+			connection_id: connectionId,
+			feed_key: "issues",
+			display_name: "Issues manual",
+		})) as {
+			error?: string;
+			feed?: {
+				id: number;
+				schedule: string | null;
+				next_run_at: string | null;
+			};
+		};
+
+		expect(result.error).toBeUndefined();
+		expect(result.feed?.schedule).toBeNull();
+		expect(result.feed?.next_run_at).toBeNull();
+	});
+
+	it("create_feed with an explicit cron still schedules", async () => {
+		const result = (await owner.feeds.create({
+			connection_id: connectionId,
+			feed_key: "pulls",
+			display_name: "Pulls daily",
+			schedule: "0 9 * * *",
+		})) as {
+			error?: string;
+			feed?: {
+				id: number;
+				schedule: string | null;
+				next_run_at: string | null;
+			};
+		};
+
+		expect(result.error).toBeUndefined();
+		expect(result.feed?.schedule).toBe("0 9 * * *");
+		expect(result.feed?.next_run_at).toBeTruthy();
+	});
+
+	it("update_feed schedule null clears auto-poll", async () => {
+		const created = (await owner.feeds.create({
+			connection_id: connectionId,
+			feed_key: "commits",
+			display_name: "Commits",
+			schedule: "0 */12 * * *",
+		})) as { error?: string; feed?: { id: number; schedule: string | null } };
+
+		expect(created.error).toBeUndefined();
+		const feedId = created.feed!.id;
+
+		const updated = (await owner.feeds.update({
+			feed_id: feedId,
+			schedule: null,
+		})) as {
+			error?: string;
+			feed?: { schedule: string | null; next_run_at: string | null };
+		};
+
+		expect(updated.error).toBeUndefined();
+		expect(updated.feed?.schedule).toBeNull();
+		expect(updated.feed?.next_run_at).toBeNull();
+	});
+});

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -250,11 +250,11 @@ async function createSyncRunWithClient(sql: DbClient, feedId: number): Promise<n
   }
   const connectorVersion = resolved.version;
 
-  const nextRunAt = nextRunAtFromCron(
-    feed.schedule ?? '0 */6 * * *',
-    new Date(),
-    feed.timezone
-  );
+  // Manual feeds (schedule null) keep next_run_at null after enqueue so they
+  // are not re-picked by the due-feed scheduler.
+  const nextRunAt = feed.schedule
+    ? nextRunAtFromCron(feed.schedule, new Date(), feed.timezone)
+    : null;
   const inserted = await sql`
     WITH inserted AS (
       INSERT INTO runs (

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -6,7 +6,6 @@
 
 import { getScopedConnectorDefinition } from '../../../catalog/connector-definitions';
 import { getDb } from '../../../db/client';
-import type { Env } from '../../../index';
 import {
   type AuthProfileKind,
   type AuthProfileRow,
@@ -20,7 +19,6 @@ import {
   summarizeBrowserSessionAuthData,
   updateAuthProfile,
 } from '../../../utils/auth-profiles';
-import { DEFAULT_SCHEDULE } from '../../../utils/cron';
 import { createConnectToken } from '../../../utils/connect-tokens';
 import { getConfiguredPublicGatewayUrl } from '../../../utils/public-origin';
 import {
@@ -417,10 +415,6 @@ export async function upsertConnectorAuthProfiles(params: {
 // ============================================
 // Shared Helpers
 // ============================================
-
-export function getDefaultSchedule(env: Env): string {
-  return env.DEFAULT_SYNC_SCHEDULE ?? DEFAULT_SCHEDULE;
-}
 
 export function mapConnectionStatusToFeedStatus(status: string): 'active' | 'paused' {
   return status === 'active' ? 'active' : 'paused';

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -52,7 +52,6 @@ import { createSyncRun } from '../../runs/queue-service';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../../utils/run-statuses';
 import type { ToolContext } from '../registry';
 import { action, defineActionTool } from './action-tool';
-import { getDefaultSchedule } from './helpers/connection-helpers';
 import { assertEntityIdsInOrg, callerIsAdmin } from './helpers/db-helpers';
 import {
   resolveFeedDisplayName,
@@ -388,8 +387,7 @@ async function handleReadFeeds(
 
 async function handleCreateFeed(
   args: Static<typeof CreateFeedAction>,
-  ctx: ToolContext,
-  env: Env
+  ctx: ToolContext
 ): Promise<ManageFeedsResult> {
   const sql = getDb();
   const { organizationId } = ctx;
@@ -455,12 +453,15 @@ async function handleCreateFeed(
     if (configError) return { error: configError };
   }
 
-  // Only validate the sync schedule for non-virtual feeds — a virtual feed
-  // persists schedule = NULL, so a (possibly defaulted) schedule string must not
-  // gate its creation.
-  const schedule = isVirtual ? null : (args.schedule ?? getDefaultSchedule(env));
-  if (!isVirtual) {
-    const scheduleError = validateSchedule(schedule as string);
+  // Omit / empty schedule = manual only (no automatic poll). Virtual feeds
+  // always persist schedule = NULL. Do not invent a default cron.
+  const rawSchedule = isVirtual ? null : (args.schedule ?? null);
+  const schedule =
+    rawSchedule == null || String(rawSchedule).trim() === ''
+      ? null
+      : String(rawSchedule).trim();
+  if (schedule) {
+    const scheduleError = validateSchedule(schedule);
     if (scheduleError) {
       return { error: scheduleError };
     }
@@ -557,10 +558,19 @@ async function handleUpdateFeed(
         : '{}'
       : null;
 
-  if (args.schedule) {
-    const scheduleError = validateSchedule(args.schedule);
-    if (scheduleError) {
-      return { error: scheduleError };
+  // `schedule` is tri-state: undefined = leave alone, null/"" = clear (manual),
+  // string = set cron. Mirror timezone / repair_agent_id.
+  const hasScheduleArg = Object.hasOwn(args, 'schedule');
+  let nextSchedule: string | null | undefined;
+  if (hasScheduleArg) {
+    const raw = args.schedule;
+    nextSchedule =
+      raw == null || String(raw).trim() === '' ? null : String(raw).trim();
+    if (nextSchedule) {
+      const scheduleError = validateSchedule(nextSchedule);
+      if (scheduleError) {
+        return { error: scheduleError };
+      }
     }
   }
   if (args.timezone) {
@@ -570,7 +580,7 @@ async function handleUpdateFeed(
     }
   }
   const hasTimezoneArg = args.timezone !== undefined;
-  const touchesCadence = args.schedule !== undefined || hasTimezoneArg;
+  const touchesCadence = hasScheduleArg || hasTimezoneArg;
 
   // `repair_agent_id` is tri-state: undefined = leave alone, null = clear, string = set.
   // Use Object.hasOwn so an explicit null overwrites instead of being skipped.
@@ -629,8 +639,11 @@ async function handleUpdateFeed(
 
     // Recompute next_run_at when the cadence OR its zone changes; the effective
     // pair mixes the incoming args with the stored row for whichever side was
-    // omitted, so a timezone-only update re-anchors the pending sync.
-    const effectiveSchedule = args.schedule ?? (feedRow.schedule as string | null);
+    // omitted, so a timezone-only update re-anchors the pending sync. Clearing
+    // schedule (null) clears next_run_at — manual feeds do not auto-poll.
+    const effectiveSchedule = hasScheduleArg
+      ? (nextSchedule ?? null)
+      : (feedRow.schedule as string | null);
     const effectiveTimezone = hasTimezoneArg
       ? (args.timezone ?? null)
       : (feedRow.timezone as string | null);
@@ -645,7 +658,7 @@ async function handleUpdateFeed(
           status = COALESCE(${args.status ?? null}::text, status),
           entity_ids = COALESCE(${entityIdsValue}::bigint[], entity_ids),
           config = CASE WHEN ${hasConfigArg} THEN ${tx.json(effectiveConfig ?? {})}::jsonb ELSE config END,
-          schedule = COALESCE(${args.schedule ?? null}::text, schedule),
+          schedule = CASE WHEN ${hasScheduleArg} THEN ${nextSchedule ?? null} ELSE schedule END,
           timezone = CASE WHEN ${hasTimezoneArg} THEN ${args.timezone ?? null} ELSE timezone END,
           next_run_at = CASE WHEN ${touchesCadence} THEN ${nextRunAtVal}::timestamptz ELSE next_run_at END,
           repair_agent_id = CASE WHEN ${hasRepairAgentArg} THEN ${repairAgentValue}::text ELSE repair_agent_id END,

--- a/packages/server/src/utils/cron.ts
+++ b/packages/server/src/utils/cron.ts
@@ -1,10 +1,13 @@
 /**
  * Cron scheduling utilities shared by feed and watcher schedulers.
+ *
+ * Collected feeds with schedule = NULL are manual-only (trigger_feed). There is
+ * no platform default cadence — callers that want a poll must pass an explicit
+ * cron (e.g. app-install AUTO_FEED_SCHEDULE).
  */
 
 import { CronExpressionParser } from 'cron-parser';
 
-const DEFAULT_SCHEDULE = '0 */6 * * *'; // every 6 hours
 const MIN_INTERVAL_MS = 60_000; // 1 minute minimum between runs
 
 /**
@@ -51,4 +54,3 @@ export function validateSchedule(schedule: string): string | null {
   }
 }
 
-export { DEFAULT_SCHEDULE };

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -442,8 +442,11 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
       SELECT schedule, timezone FROM feeds WHERE id = ${feedId}
     `) as unknown as Array<{ schedule: string | null; timezone: string | null }>;
 
-			const schedule = feedRows[0]?.schedule ?? "0 */6 * * *";
-			const nextRun = nextRunAtFromCron(schedule, new Date(), feedRows[0]?.timezone ?? null);
+			// Manual feeds (no schedule) stay unscheduled after completion.
+			const schedule = feedRows[0]?.schedule ?? null;
+			const nextRun = schedule
+				? nextRunAtFromCron(schedule, new Date(), feedRows[0]?.timezone ?? null)
+				: null;
 			const isSuccess = req.status === "success";
 
 			await sql`


### PR DESCRIPTION
## Summary

- **Stop inventing** `0 */6 * * *` when `create_feed` omits `schedule`. Omit/null = **manual-only** (`trigger_feed` only).
- **`update_feed`**: `schedule: null` clears cron + `next_run_at` (no more `COALESCE` trap).
- **Apply**: config omit maps to desired `schedule: null` so re-apply can clear remote 6h defaults.
- **Queue / run-lifecycle**: never re-default `next_run_at` for manual feeds.
- **Migration**: clear all existing non-deleted feeds still on `0 */6 * * *` (historical platform default).

Explicit crons in config (e.g. ecommerce/lobu-crm `schedule: "0 */6 * * *"`) should be re-applied after migrate to restore intentional 6h polls. App-install auto-feeds still set an **explicit** `AUTO_FEED_SCHEDULE`.

## Test plan

- [x] map-config tests (omit → null, virtual → null)
- [x] server tsc
- [ ] integration: `feeds-manual-schedule.test.ts` (create omit / clear null)
- [ ] migrate prod/staging → feeds with old default have `schedule` null
- [ ] re-apply configs that intentionally want 6h

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->