### PR TITLE
feat: list_activity feed + Home + agent attention inject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v7
         with:
-          files: coverage/core-cli.lcov.info,coverage/plugin-runtime.lcov.info,coverage/agent-worker.lcov.info,coverage/server-units.lcov.info,coverage/server-units-auth.lcov.info,coverage/connector-worker.lcov.info,coverage/client-promptfoo.lcov.info,coverage/connector-sdk.lcov.info,coverage/connectors.lcov.info
+          files: coverage/core-cli.lcov.info,coverage/plugin-runtime.lcov.info,coverage/agent-worker.lcov.info,coverage/server-units.lcov.info,coverage/server-units-auth.lcov.info,coverage/server-units-activity.lcov.info,coverage/connector-worker.lcov.info,coverage/client-promptfoo.lcov.info,coverage/connector-sdk.lcov.info,coverage/connectors.lcov.info
           flags: unit
           fail_ci_if_error: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,12 @@ jobs:
           mv coverage/lcov.info coverage/server-units.lcov.info
           bun test packages/server/src/auth/__tests__/tool-access.test.ts packages/server/src/auth/__tests__/system-provider-resolution.test.ts --coverage
           mv coverage/lcov.info coverage/server-units-auth.lcov.info
+          # Pure-unit bun:test files that live outside src/__tests__/unit: the
+          # device-pin tombstone helpers and the activity-feed collapse logic.
+          # No Postgres needed (DB imports in the module graph are lazy), so they
+          # run here rather than in the integration job.
+          bun test packages/server/src/utils/__tests__/device-pin-tombstones.test.ts packages/server/src/tools/admin/manage_operations/__tests__/activity-feed-collapse.test.ts --coverage
+          mv coverage/lcov.info coverage/server-units-activity.lcov.info
 
       - name: connector-worker (bun:test)
         run: |

--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -136,6 +136,35 @@ export const GetRunAction = Type.Object({
   run_id: Type.Number(),
 });
 
+/**
+ * Unified workspace attention feed for Home UI + agent context.
+ * Member-readable (same tier as list_runs). Optionally collapses adjacent
+ * same-connection/same-status runs; always returns deep-links (`href`).
+ */
+export const ListActivityAction = Type.Object({
+  action: Type.Literal("list_activity", {
+    description:
+      "Org attention feed: notifications + recent user-facing runs (watcher/sync/action/internal), with optional adjacent aggregation and deep-links for the UI and agent context.",
+  }),
+  limit: Type.Optional(
+    Type.Number({
+      description: "Max cards after aggregation (default 24, max 50)",
+      default: 24,
+    }),
+  ),
+  /** Include notifications (default true when user is authenticated). */
+  include_notifications: Type.Optional(Type.Boolean({ default: true })),
+  /** Include runs (default true). */
+  include_runs: Type.Optional(Type.Boolean({ default: true })),
+  /**
+   * Collapse adjacent same-connection (or watcher) runs that share status.
+   * Failures never merge with successes. Default true.
+   */
+  aggregate: Type.Optional(Type.Boolean({ default: true })),
+  /** Restrict run kinds: watcher | sync | action | notification (default all). */
+  kinds: Type.Optional(Type.Array(Type.String())),
+});
+
 export const ApproveAction = Type.Object({
   action: Type.Literal("approve", {
     description:
@@ -251,6 +280,29 @@ export const ManageOperationsResultSchema = Type.Union([
     run: Type.Record(Type.String(), Type.Unknown()),
   }),
   Type.Object({
+    action: Type.Literal("list_activity"),
+    items: Type.Array(
+      Type.Object({
+        id: Type.String(),
+        kind: Type.String(),
+        title: Type.String(),
+        body: Type.Union([Type.String(), Type.Null()]),
+        at: Type.String(),
+        status: Type.Union([Type.String(), Type.Null()]),
+        count: Type.Integer(),
+        href: Type.Union([Type.String(), Type.Null()]),
+        unread: Type.Optional(Type.Boolean()),
+        notification_id: Type.Optional(Type.Integer()),
+        run_id: Type.Optional(Type.Integer()),
+        member_run_ids: Type.Optional(Type.Array(Type.Integer())),
+        connection_id: Type.Optional(Type.Integer()),
+        watcher_id: Type.Optional(Type.Integer()),
+      }),
+    ),
+    total: Type.Integer(),
+    limit: Type.Integer(),
+  }),
+  Type.Object({
     action: Type.Literal("approve"),
     approved: Type.Literal(true),
     run_id: Type.Integer(),
@@ -288,6 +340,7 @@ export const ManageOperationsSchema = Type.Union([
   ExecuteAction,
   ListRunsAction,
   GetRunAction,
+  ListActivityAction,
   ApproveAction,
   RejectAction,
   ApproveBatchAction,

--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -147,9 +147,11 @@ export const ListActivityAction = Type.Object({
       "Org attention feed: notifications + recent user-facing runs (watcher/sync/action/internal), with optional adjacent aggregation and deep-links for the UI and agent context.",
   }),
   limit: Type.Optional(
-    Type.Number({
+    Type.Integer({
       description: "Max cards after aggregation (default 24, max 50)",
       default: 24,
+      minimum: 1,
+      maximum: 50,
     })
   ),
   /** Include notifications (default true when user is authenticated). */

--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -150,7 +150,7 @@ export const ListActivityAction = Type.Object({
     Type.Number({
       description: "Max cards after aggregation (default 24, max 50)",
       default: 24,
-    }),
+    })
   ),
   /** Include notifications (default true when user is authenticated). */
   include_notifications: Type.Optional(Type.Boolean({ default: true })),
@@ -297,7 +297,7 @@ export const ManageOperationsResultSchema = Type.Union([
         member_run_ids: Type.Optional(Type.Array(Type.Integer())),
         connection_id: Type.Optional(Type.Integer()),
         watcher_id: Type.Optional(Type.Integer()),
-      }),
+      })
     ),
     total: Type.Integer(),
     limit: Type.Integer(),

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -709,7 +709,7 @@ manage_agents: list=admin get=admin create=admin update=admin delete=admin set_s
 manage_conversations: list=read get=read send=write ?=read
 manage_feeds: list_feeds=read+public read_feed=read+public read_feeds=read+public create_feed=admin update_feed=admin delete_feed=admin trigger_feed=admin ?=read
 manage_auth_profiles: list_auth_profiles=read+public get_auth_profile=admin test_auth_profile=admin create_auth_profile=write update_auth_profile=write delete_auth_profile=admin set_default_auth_profile=admin ?=read
-manage_operations: list_available=read+public execute=admin list_runs=read+public get_run=read+public approve=write reject=write approve_batch=write reject_batch=write ?=read
+manage_operations: list_available=read+public execute=admin list_runs=read+public get_run=read+public list_activity=read+public approve=write reject=write approve_batch=write reject_batch=write ?=read
 notify: send=admin ?=admin
 manage_schedules: create=admin list=admin update=admin pause=admin cancel=admin ?=admin
 manage_watchers: create=admin update=admin create_version=admin complete_window=write trigger=admin delete=admin set_reaction_script=admin get_versions=read+public get_version_details=read+public get_component_reference=read+public submit_feedback=admin get_feedback=read+public list_promoted=read create_from_version=admin ?=read

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -539,6 +539,7 @@ export async function createAuth(
 								userId,
 								orgName,
 								inviterName,
+								invitationId: data.id,
 							});
 						}
 					} catch (err) {

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -258,11 +258,16 @@ function assertLoopbackClient(
     c.req.header('x-forwarded-proto') ||
     c.req.header('x-real-ip') ||
     c.req.header('forwarded');
-  if (proxied) {
+  // Tailscale Serve / local reverse proxies connect to 127.0.0.1 (peer is
+  // loopback) but inject Forwarded-*. Public tunnels (Funnel, ngrok) look the
+  // same — refuse by default so a misconfigured public frontend can't mint
+  // passwordless sessions. Operators who intentionally reach a single-user
+  // install over private Tailscale Serve set LOBU_LOCAL_INIT_ALLOW_PROXY=1.
+  if (proxied && c.env.LOBU_LOCAL_INIT_ALLOW_PROXY !== '1') {
     return {
       error: 'proxied_request_refused',
       error_description:
-        'This endpoint is for loopback callers only. Forwarded-* headers are not allowed.',
+        'This endpoint is for loopback callers only. Forwarded-* headers are not allowed. For private Tailscale Serve, set LOBU_LOCAL_INIT_ALLOW_PROXY=1 on the host (single-user installs only).',
     };
   }
   if (!c.req.header('x-lobu-client')) {
@@ -604,10 +609,12 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
  * point the caller at /sign-up.
  *
  * Trust model:
- *   - Refuses when any `x-forwarded-*` / `forwarded` header is present. A
- *     Tailscale Funnel / ngrok / cloudflared / nginx proxy fronting a
- *     loopback bind sets these — the bind looks local but the *exposure*
- *     isn't, so a public client could otherwise reach this endpoint.
+ *   - Requires a loopback TCP peer (the server must be reached via 127.0.0.1
+ *     on the host — Tailscale Serve qualifies; a remote TCP peer does not).
+ *   - Refuses when any `x-forwarded-*` / `forwarded` header is present,
+ *     unless `LOBU_LOCAL_INIT_ALLOW_PROXY=1` (opt-in for private Tailscale
+ *     Serve). Public tunnels (Funnel, ngrok) must not set this — the bind
+ *     looks local but the exposure isn't.
  *   - Refuses when the deployment has more than one user.
  *   - Refuses when the single user has no personal org (shouldn't happen —
  *     databaseHooks.user.create.after provisions one).

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -168,7 +168,12 @@ export const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {
 	manage_catalog: new Set(["list_catalog", "list_installed"]),
 	manage_feeds: new Set(["list_feeds", "read_feed", "read_feeds"]),
 	manage_auth_profiles: new Set(["list_auth_profiles"]),
-	manage_operations: new Set(["list_available", "list_runs", "get_run"]),
+	manage_operations: new Set([
+		"list_available",
+		"list_runs",
+		"get_run",
+		"list_activity",
+	]),
 	manage_watchers: new Set([
 		"get_versions",
 		"get_version_details",

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1516,17 +1516,27 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         (session.turnCount ?? 0) === 0 &&
         !ephemeralForTurn &&
         session.intent?.kind !== "watcher_run" &&
-        messageOrganizationId &&
-        session.userId
+        messageOrganizationId
       ) {
         try {
+          // Notifications are per-recipient, so scope the read to the
+          // AUTHENTICATED principal, never `session.userId`, which is
+          // client-supplied via CreateAgentRequestSchema.userId (an agent owner
+          // could stamp a session with another member's id and siphon their
+          // notifications). Fall back to null (org runs only, no notifications)
+          // when no trusted human principal is present (e.g. worker token).
+          const attentionUserId =
+            msgAccess.callerUserId ??
+            (c.get("authContext")?.userId as string | undefined) ??
+            (await verifySettingsSessionOrToken(c))?.userId ??
+            null;
           const orgRow = (await getDb()`
             SELECT slug FROM organization WHERE id = ${messageOrganizationId} LIMIT 1
           `) as unknown as Array<{ slug: string }>;
           const ownerSlug = orgRow[0]?.slug ?? messageOrganizationId;
           const { items } = await listOrgActivity({
             organizationId: messageOrganizationId,
-            userId: session.userId,
+            userId: attentionUserId,
             ownerSlug,
             limit: 12,
             aggregate: true,

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -48,6 +48,10 @@ import { verifyOwnedAgentAccess } from "../shared/agent-ownership.js";
 import { errorResponse } from "../shared/helpers.js";
 import { errorResponses } from "../shared/openapi-responses.js";
 import { verifySettingsSessionOrToken } from "./settings-auth.js";
+import {
+  formatActivityAttentionBlock,
+  listOrgActivity,
+} from "../../../tools/admin/manage_operations/activity-feed.js";
 
 const logger = createLogger("agent-api");
 
@@ -1505,8 +1509,35 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         ...remainingOptions
       } = agentOptions;
 
+      // First turn only: client ephemeralContext wins; otherwise auto-inject a
+      // short workspace attention digest (same cards as manage_operations.list_activity).
+      let ephemeralForTurn = rawEphemeralContext;
+      if (
+        (session.turnCount ?? 0) === 0 &&
+        !ephemeralForTurn &&
+        session.intent?.kind !== "watcher_run" &&
+        messageOrganizationId &&
+        session.userId
+      ) {
+        try {
+          const orgRow = (await getDb()`
+            SELECT slug FROM organization WHERE id = ${messageOrganizationId} LIMIT 1
+          `) as unknown as Array<{ slug: string }>;
+          const ownerSlug = orgRow[0]?.slug ?? messageOrganizationId;
+          const { items } = await listOrgActivity({
+            organizationId: messageOrganizationId,
+            userId: session.userId,
+            ownerSlug,
+            limit: 12,
+            aggregate: true,
+          });
+          ephemeralForTurn = formatActivityAttentionBlock(items);
+        } catch {
+          // Attention is best-effort — never block chat on feed failure.
+        }
+      }
       const applyEphemeralContext =
-        rawEphemeralContext.length > 0 && (session.turnCount ?? 0) === 0;
+        ephemeralForTurn.length > 0 && (session.turnCount ?? 0) === 0;
 
       // Inbound attachments: publish each uploaded file as a signed gateway
       // artifact and forward the worker-facing `files` array in
@@ -1561,7 +1592,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         platform: "api",
         messageText: messageTextForTranscript,
         ...(applyEphemeralContext
-          ? { ephemeralContext: rawEphemeralContext.slice(0, 2048) }
+          ? { ephemeralContext: ephemeralForTurn.slice(0, 2048) }
           : {}),
         platformMetadata: {
           agentId: realAgentId,

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -442,6 +442,16 @@ export async function notifyActionApprovalNeeded(params: {
 	});
 }
 
+/** Deep-link into a single connection (settings / re-auth), not the connectors list. */
+function connectionDetailUrl(
+	orgSlug: string | null | undefined,
+	connectorKey: string,
+	connectionId: number,
+): string | undefined {
+	if (!orgSlug) return undefined;
+	return `/${orgSlug}/connectors/${connectorKey}/${connectionId}`;
+}
+
 export async function notifyConnectionPermissionRequest(params: {
 	orgId: string;
 	connectionId: number;
@@ -458,7 +468,12 @@ export async function notifyConnectionPermissionRequest(params: {
 			body: `A new connection was created and requires OAuth authorization.${urlLine}`,
 			resourceType: "connection",
 			resourceId: String(params.connectionId),
-			resourceUrl: orgSlug ? `/${orgSlug}/connectors` : undefined,
+			// Land on the connection that needs OAuth — not the bare connectors index.
+			resourceUrl: connectionDetailUrl(
+				orgSlug,
+				params.connectorKey,
+				params.connectionId,
+			),
 		};
 	});
 }
@@ -486,7 +501,13 @@ export async function notifyBrowserAuthExpired(params: {
 				`Open ${params.connectorKey} in the browser where your Owletto extension runs and sign in to resume.`,
 		resourceType: "connection",
 		resourceId: String(params.connectionId),
-		resourceUrl: orgSlug ? `/${orgSlug}/connectors` : undefined,
+		// Connection detail is where re-auth / browser profile is managed —
+		// not Infrastructure (devices) or a bare connectors list.
+		resourceUrl: connectionDetailUrl(
+			orgSlug,
+			params.connectorKey,
+			params.connectionId,
+		),
 	}));
 }
 
@@ -495,13 +516,18 @@ export async function notifyInvitationReceived(params: {
 	userId: string;
 	orgName: string;
 	inviterName?: string;
+	/** Invitation row id — required for the accept deep-link. */
+	invitationId: string;
 }): Promise<void> {
 	const inviterLabel = params.inviterName ? ` by ${params.inviterName}` : "";
+	// Same path the invite email uses — members list is NOT the accept UI.
+	const acceptPath = `/auth/accept-invitation?invitationId=${encodeURIComponent(params.invitationId)}`;
 	await sendNotification(params.orgId, [params.userId], {
 		type: "invitation_received",
 		title: `You've been invited to ${params.orgName}`,
 		body: `You were invited${inviterLabel} to join the organization.`,
-		resourceType: "organization",
-		resourceId: params.orgId,
+		resourceType: "invitation",
+		resourceId: params.invitationId,
+		resourceUrl: acceptPath,
 	});
 }

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -11,6 +11,7 @@ import {
 	getDb,
 	parsePgNumberArray,
 	pgBigintArray,
+	pgTextArray,
 	type DbClient,
 } from "../../../../db/client";
 import { recordToolConfigChange } from "../../helpers/config-audit";
@@ -29,6 +30,11 @@ import {
   getAuthProfileBySlug,
   getBrowserSessionReadiness,
 } from "../../../../utils/auth-profiles";
+import {
+	DEVICE_PIN_TOMBSTONE_MESSAGES,
+	effectiveConnectionErrorMessage,
+	isDevicePinTombstone,
+} from "../../../../utils/device-pin-tombstones";
 import {
   ConnectionSlugConflictError,
   connectionSlugFormatError,
@@ -377,6 +383,16 @@ export async function handleList(
       // Postgres returns bigint[] as a literal string ('{2}'); parse to number[]
       // so the API contract matches the typed entity_ids the UI picker expects.
       entity_ids: parsePgNumberArray(row.entity_ids),
+			// Pin-tombstone self-heal for display: device re-paired but error_message
+			// still says "Device was removed" (write paths clear on pin; this covers
+			// already-stuck rows until the next reconcile).
+			error_message: effectiveConnectionErrorMessage({
+				error_message: row.error_message as string | null,
+				device_worker_id: row.device_worker_id as string | null,
+				device_last_seen_at: row.device_last_seen_at as string | null,
+				device_worker_handle: row.device_worker_handle as string | null,
+				device_label: row.device_label as string | null,
+			}),
       operations_summary: operationsSummary,
       has_operations: hasOperations,
       facets: deriveConnectionFacets({
@@ -516,6 +532,13 @@ export async function handleGet(
 		action: "get",
     connection: {
       ...resolved,
+			error_message: effectiveConnectionErrorMessage({
+				error_message: getRow.error_message as string | null,
+				device_worker_id: getRow.device_worker_id as string | null,
+				device_last_seen_at: getRow.device_last_seen_at as string | null,
+				device_worker_handle: getRow.device_worker_handle as string | null,
+				device_label: getRow.device_label as string | null,
+			}),
       ...(connectToken ? { connect_token: connectToken } : {}),
       operations_summary: operationsSummary,
       has_operations: hasOperations,
@@ -1718,22 +1741,26 @@ export async function handleUpdate(
 		hasDeviceWorkerArg ||
 		(updateProfileDeviceWorkerId && !hasDeviceWorkerArg)
 	) {
-    // Re-pinning (or clearing) the device also clears the "Device was removed"
-    // tombstone left by DELETE /api/me/devices — otherwise the connection stays
-    // active but UI-flagged error forever after the user picks a new device.
-		const previousError = (updated[0] as Record<string, unknown>).error_message;
-		clearedDeviceTombstone =
-			previousError === "Device was removed" ||
-			previousError === "Device was moved to another workspace";
-    await sql`
+		// Any change to the pin (set or clear) drops DELETE/move tombstones.
+		// Re-pinning a live device also un-pauses so the connection can run again.
+		const previousError = (updated[0] as Record<string, unknown>)
+			.error_message as string | null;
+		const pinningDevice = nextDeviceWorkerId != null;
+		clearedDeviceTombstone = isDevicePinTombstone(previousError);
+		await sql`
       UPDATE connections
       SET device_worker_id = ${nextDeviceWorkerId},
           error_message = CASE
-            WHEN error_message IN (
-              'Device was removed',
-              'Device was moved to another workspace'
-            ) THEN NULL
+            WHEN error_message = ANY(${pgTextArray([...DEVICE_PIN_TOMBSTONE_MESSAGES])}::text[])
+            THEN NULL
             ELSE error_message
+          END,
+          status = CASE
+            WHEN ${pinningDevice}
+             AND status = 'paused'
+             AND error_message = ANY(${pgTextArray([...DEVICE_PIN_TOMBSTONE_MESSAGES])}::text[])
+            THEN 'active'
+            ELSE status
           END,
           updated_at = NOW()
       WHERE id = ${args.connection_id}
@@ -1744,6 +1771,12 @@ export async function handleUpdate(
 			nextDeviceWorkerId;
 		if (clearedDeviceTombstone) {
 			(updated[0] as Record<string, unknown>).error_message = null;
+			if (
+				pinningDevice &&
+				(updated[0] as Record<string, unknown>).status === "paused"
+			) {
+				(updated[0] as Record<string, unknown>).status = "active";
+			}
 		}
   }
 

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -13,6 +13,7 @@ import {
 	ApproveBatchAction,
 	ExecuteAction,
 	GetRunAction,
+	ListActivityAction,
 	ListAvailableAction,
 	ListRunsAction,
 	type ManageOperationsResult,
@@ -80,6 +81,11 @@ import { action, defineActionTool } from "./action-tool";
 // (breaks a circular init cycle that left MANAGE_WATCHERS_ACTION_KEY in TDZ).
 import { waitForDeviceActionRun } from "./device-action-wait";
 export { waitForDeviceActionRun };
+import { listOrgActivity } from "./manage_operations/activity-feed";
+export {
+	formatActivityAttentionBlock,
+	listOrgActivity,
+} from "./manage_operations/activity-feed";
 import {
 	applyEntityChangeProposal,
 	ENTITY_CHANGE_ACTION_KEYS,
@@ -164,6 +170,7 @@ const manageOperationsTool = defineActionTool("manage_operations", {
   execute: action(ExecuteAction, handleExecute),
   list_runs: action(ListRunsAction, handleListRuns),
   get_run: action(GetRunAction, handleGetRun),
+  list_activity: action(ListActivityAction, handleListActivity),
   approve: action(ApproveAction, handleApprove),
   reject: action(RejectAction, handleReject),
   approve_batch: action(ApproveBatchAction, handleApproveBatch),
@@ -1173,6 +1180,33 @@ async function handleExecute(
 		run_id: runId,
 		status: "failed",
 		error_message: result.error_message,
+	};
+}
+
+async function handleListActivity(
+	args: Static<typeof ListActivityAction>,
+	ctx: ToolContext,
+): Promise<ManageOperationsResult> {
+	const sql = getDb();
+	const orgRows = (await sql`
+    SELECT slug FROM organization WHERE id = ${ctx.organizationId} LIMIT 1
+  `) as unknown as Array<{ slug: string }>;
+	const ownerSlug = orgRows[0]?.slug ?? ctx.organizationId;
+	const result = await listOrgActivity({
+		organizationId: ctx.organizationId,
+		userId: ctx.userId,
+		ownerSlug,
+		limit: args.limit,
+		includeNotifications: args.include_notifications,
+		includeRuns: args.include_runs,
+		aggregate: args.aggregate,
+		kinds: args.kinds,
+	});
+	return {
+		action: "list_activity",
+		items: result.items,
+		total: result.total,
+		limit: result.limit,
 	};
 }
 

--- a/packages/server/src/tools/admin/manage_operations/__tests__/activity-feed-collapse.test.ts
+++ b/packages/server/src/tools/admin/manage_operations/__tests__/activity-feed-collapse.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { collapseAdjacentActivityCards } from "../activity-feed";
+
+function card(
+	partial: Partial<Parameters<typeof collapseAdjacentActivityCards>[0][number]> & {
+		id: string;
+	},
+) {
+	return {
+		kind: "sync",
+		title: "Chrome downloads",
+		body: "completed · 0 items",
+		at: new Date().toISOString(),
+		atMs: 0,
+		status: "completed",
+		count: 1,
+		href: "/acme/connectors/chrome.downloads/1",
+		collapseKey: "conn:1",
+		itemsCollected: 0,
+		run_id: 1,
+		...partial,
+	};
+}
+
+describe("collapseAdjacentActivityCards", () => {
+	it("merges adjacent same-connection completed syncs and keeps latest href", () => {
+		const out = collapseAdjacentActivityCards([
+			card({ id: "r:1", atMs: 1, run_id: 1, itemsCollected: 0 }),
+			card({ id: "r:2", atMs: 2, run_id: 2, itemsCollected: 0 }),
+			card({ id: "r:3", atMs: 3, run_id: 3, itemsCollected: 2 }),
+		]);
+		expect(out).toHaveLength(1);
+		expect(out[0]?.count).toBe(3);
+		expect(out[0]?.body).toContain("3×");
+		expect(out[0]?.member_run_ids).toEqual([1, 2, 3]);
+		expect(out[0]?.href).toBe("/acme/connectors/chrome.downloads/1");
+	});
+
+	it("does not merge failed with completed", () => {
+		const out = collapseAdjacentActivityCards([
+			card({ id: "r:1", status: "completed" }),
+			card({ id: "r:2", status: "failed" }),
+		]);
+		expect(out).toHaveLength(2);
+	});
+});

--- a/packages/server/src/tools/admin/manage_operations/__tests__/activity-feed-collapse.test.ts
+++ b/packages/server/src/tools/admin/manage_operations/__tests__/activity-feed-collapse.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { collapseAdjacentActivityCards } from "../activity-feed";
+import type { ActivityCard } from "../activity-feed";
+import {
+	collapseAdjacentActivityCards,
+	formatActivityAttentionBlock,
+} from "../activity-feed";
 
 function card(
 	partial: Partial<Parameters<typeof collapseAdjacentActivityCards>[0][number]> & {
@@ -42,5 +46,44 @@ describe("collapseAdjacentActivityCards", () => {
 			card({ id: "r:2", status: "failed" }),
 		]);
 		expect(out).toHaveLength(2);
+	});
+});
+
+describe("formatActivityAttentionBlock (worker-safe projection)", () => {
+	const notif = (partial: Partial<ActivityCard> & { id: string }): ActivityCard => ({
+		kind: "notification",
+		title: "Notification",
+		body: null,
+		at: new Date().toISOString(),
+		status: "generic",
+		count: 1,
+		href: null,
+		...partial,
+	});
+
+	it("strips query params and fragments from deep-links", () => {
+		const block = formatActivityAttentionBlock([
+			notif({
+				id: "n:1",
+				title: "Reconnect Chrome",
+				href: "/auth/accept-invitation?invitationId=secret-token#frag",
+			}),
+		]);
+		expect(block).toContain("/auth/accept-invitation");
+		expect(block).not.toContain("secret-token");
+		expect(block).not.toContain("invitationId");
+	});
+
+	it("redacts query strings from URLs embedded in notification bodies", () => {
+		const block = formatActivityAttentionBlock([
+			notif({
+				id: "n:2",
+				title: "Re-authorize",
+				body: "Re-auth here: https://provider.example/oauth/authorize?code=abc123&state=xyz",
+			}),
+		]);
+		expect(block).toContain("https://provider.example/oauth/authorize");
+		expect(block).not.toContain("abc123");
+		expect(block).not.toContain("code=");
 	});
 });

--- a/packages/server/src/tools/admin/manage_operations/activity-feed.ts
+++ b/packages/server/src/tools/admin/manage_operations/activity-feed.ts
@@ -1,0 +1,447 @@
+/**
+ * Workspace attention feed — shared by manage_operations.list_activity,
+ * Home UI, and first-turn agent ephemeral context.
+ *
+ * Multi-replica safe: pure SQL reads + deterministic collapse (no in-memory
+ * shared state).
+ */
+
+import { getDb, pgTextArray } from "../../../db/client";
+import { listNotifications } from "../../../notifications/service";
+import { buildResourcePermalink } from "../../../utils/url-builder";
+
+const USER_FACING_RUN_TYPES = ["watcher", "sync", "action", "internal"] as const;
+
+export type ActivityCard = {
+	id: string;
+	kind: string;
+	title: string;
+	body: string | null;
+	at: string;
+	status: string | null;
+	count: number;
+	href: string | null;
+	unread?: boolean;
+	notification_id?: number;
+	run_id?: number;
+	member_run_ids?: number[];
+	connection_id?: number;
+	watcher_id?: number;
+};
+
+type RawCard = ActivityCard & {
+	collapseKey: string | null;
+	itemsCollected: number | null;
+	atMs: number;
+};
+
+function isFailedStatus(status: string | null | undefined): boolean {
+	return (
+		status === "failed" || status === "timeout" || status === "error"
+	);
+}
+
+function resolveNotifHref(
+	ownerSlug: string,
+	n: {
+		type?: unknown;
+		resource_url?: unknown;
+		resource_type?: unknown;
+		resource_id?: unknown;
+	},
+): string | null {
+	const explicit =
+		typeof n.resource_url === "string" ? n.resource_url.trim() : "";
+	if (explicit) {
+		// Invitation: never land on /members
+		if (
+			n.type === "invitation_received" &&
+			(explicit.endsWith("/members") || explicit.includes("/members?"))
+		) {
+			const id =
+				typeof n.resource_id === "string" ? n.resource_id.trim() : "";
+			if (id) {
+				return `/auth/accept-invitation?invitationId=${encodeURIComponent(id)}`;
+			}
+		}
+		// Weak dumps for auth types → connectors index
+		if (
+			(n.type === "browser_auth_expired" ||
+				n.type === "connection_permission_request") &&
+			(explicit.endsWith("/infrastructure") ||
+				explicit.endsWith("/connectors") ||
+				explicit.endsWith("/connectors/"))
+		) {
+			// Keep explicit if it already has connector/id depth
+			if (!/\/connectors\/[^/]+\/\d+/.test(explicit)) {
+				return `/${ownerSlug}/connectors`;
+			}
+		}
+		return explicit;
+	}
+	if (n.type === "invitation_received" && typeof n.resource_id === "string") {
+		return `/auth/accept-invitation?invitationId=${encodeURIComponent(n.resource_id.trim())}`;
+	}
+	if (n.resource_type === "run" && n.resource_id) {
+		const runId = Number(n.resource_id);
+		if (Number.isFinite(runId) && runId > 0) {
+			return (
+				buildResourcePermalink(ownerSlug, { kind: "run", runId }) ?? null
+			);
+		}
+	}
+	if (
+		n.type === "connection_permission_request" ||
+		n.type === "browser_auth_expired"
+	) {
+		return `/${ownerSlug}/connectors`;
+	}
+	return `/${ownerSlug}/memory`;
+}
+
+function runHref(
+	ownerSlug: string,
+	row: {
+		id: number;
+		run_type: string;
+		watcher_id: number | null;
+		connection_id: number | null;
+		connector_key: string | null;
+		approval_status: string | null;
+		agent_id: string | null;
+	},
+): string | null {
+	if (row.run_type === "watcher" && row.watcher_id != null && row.agent_id) {
+		return `/${ownerSlug}/agents/${row.agent_id}/watchers/${row.watcher_id}`;
+	}
+	if (
+		(row.run_type === "sync" || row.run_type === "action") &&
+		row.connection_id != null &&
+		row.connector_key
+	) {
+		if (
+			row.run_type === "action" &&
+			(row.approval_status === "pending" ||
+				row.approval_status === "pending_approval")
+		) {
+			return (
+				buildResourcePermalink(ownerSlug, {
+					kind: "run",
+					runId: row.id,
+				}) ?? null
+			);
+		}
+		return `/${ownerSlug}/connectors/${row.connector_key}/${row.connection_id}`;
+	}
+	return (
+		buildResourcePermalink(ownerSlug, { kind: "run", runId: row.id }) ?? null
+	);
+}
+
+function runTitle(row: {
+	run_type: string;
+	watcher_name: string | null;
+	watcher_id: number | null;
+	feed_display_name: string | null;
+	feed_key: string | null;
+	connection_display_name: string | null;
+	operation_key: string | null;
+	connector_key: string | null;
+	id: number;
+}): string {
+	if (row.run_type === "watcher") {
+		return (
+			row.watcher_name ??
+			(row.watcher_id != null
+				? `Watcher #${row.watcher_id}`
+				: `Run #${row.id}`)
+		);
+	}
+	if (row.run_type === "sync") {
+		return (
+			row.feed_display_name ??
+			row.feed_key ??
+			row.connection_display_name ??
+			`Feed sync #${row.id}`
+		);
+	}
+	if (row.operation_key) {
+		const last = row.operation_key.includes(".")
+			? (row.operation_key.split(".").pop() ?? row.operation_key)
+			: row.operation_key;
+		const pretty = last.replace(/[_-]+/g, " ");
+		return row.connection_display_name
+			? `${pretty} · ${row.connection_display_name}`
+			: pretty;
+	}
+	return (
+		row.connection_display_name ??
+		row.connector_key ??
+		`Run #${row.id}`
+	);
+}
+
+function collapseKeyForRun(row: {
+	run_type: string;
+	connection_id: number | null;
+	watcher_id: number | null;
+	connector_key: string | null;
+	feed_id: number | null;
+}): string | null {
+	if (row.run_type === "sync" || row.run_type === "action") {
+		if (row.connection_id != null) return `conn:${row.connection_id}`;
+		if (row.connector_key && row.feed_id != null) {
+			return `feed:${row.connector_key}:${row.feed_id}`;
+		}
+		return null;
+	}
+	if (row.run_type === "watcher" && row.watcher_id != null) {
+		return `watcher:${row.watcher_id}`;
+	}
+	return null;
+}
+
+/** Adjacent collapse — same rules as Owletto client (oldest→newest input). */
+export function collapseAdjacentActivityCards(items: RawCard[]): RawCard[] {
+	if (items.length <= 1) return items;
+	const out: RawCard[] = [];
+	let i = 0;
+	while (i < items.length) {
+		const head = items[i]!;
+		if (
+			head.kind === "notification" ||
+			!head.collapseKey ||
+			!head.status ||
+			isFailedStatus(head.status)
+		) {
+			out.push(head);
+			i += 1;
+			continue;
+		}
+		let j = i + 1;
+		let itemsSum =
+			typeof head.itemsCollected === "number" ? head.itemsCollected : null;
+		const memberIds = head.run_id != null ? [head.run_id] : [];
+		while (j < items.length) {
+			const next = items[j]!;
+			if (
+				next.kind === "notification" ||
+				next.collapseKey !== head.collapseKey ||
+				next.status !== head.status ||
+				isFailedStatus(next.status)
+			) {
+				break;
+			}
+			if (typeof next.itemsCollected === "number") {
+				itemsSum = (itemsSum ?? 0) + next.itemsCollected;
+			} else if (itemsSum != null) {
+				itemsSum = null;
+			}
+			if (next.run_id != null) memberIds.push(next.run_id);
+			j += 1;
+		}
+		const count = j - i;
+		if (count === 1) {
+			out.push(head);
+		} else {
+			const latest = items[j - 1]!;
+			const status = latest.status ?? "run";
+			const body =
+				itemsSum != null
+					? `${count}× ${status} · ${itemsSum} items total`
+					: `${count}× ${status}`;
+			out.push({
+				...latest,
+				id: `group:${head.collapseKey}:${latest.id}`,
+				kind:
+					latest.kind === "sync"
+						? "sync_group"
+						: latest.kind === "watcher_run"
+							? "watcher_run_group"
+							: `${latest.kind}_group`,
+				body,
+				count,
+				member_run_ids: memberIds,
+			});
+		}
+		i = j;
+	}
+	return out;
+}
+
+export async function listOrgActivity(opts: {
+	organizationId: string;
+	userId: string | null;
+	ownerSlug: string;
+	limit?: number;
+	includeNotifications?: boolean;
+	includeRuns?: boolean;
+	aggregate?: boolean;
+	kinds?: string[];
+}): Promise<{ items: ActivityCard[]; total: number; limit: number }> {
+	const limit = Math.min(Math.max(opts.limit ?? 24, 1), 50);
+	const includeNotifications =
+		opts.includeNotifications !== false && !!opts.userId;
+	const includeRuns = opts.includeRuns !== false;
+	const aggregate = opts.aggregate !== false;
+	const kindFilter = opts.kinds?.length ? new Set(opts.kinds) : null;
+
+	const raw: RawCard[] = [];
+
+	if (includeNotifications && opts.userId) {
+		if (!kindFilter || kindFilter.has("notification")) {
+			const { notifications } = await listNotifications({
+				organizationId: opts.organizationId,
+				userId: opts.userId,
+				limit: 30,
+			});
+			for (const n of notifications) {
+				const type = String(n.type ?? "generic");
+				const created = String(n.created_at ?? new Date().toISOString());
+				const atMs = new Date(created).getTime();
+				const runIdFromResource =
+					n.resource_type === "run" && n.resource_id != null
+						? Number(n.resource_id)
+						: NaN;
+				raw.push({
+					id: `n:${n.id}`,
+					kind: "notification",
+					title: String(n.title ?? "Notification"),
+					body: n.body != null ? String(n.body) : null,
+					at: created,
+					atMs: Number.isFinite(atMs) ? atMs : 0,
+					status: type,
+					count: 1,
+					href: resolveNotifHref(opts.ownerSlug, n),
+					unread: n.is_read === false || n.is_read === "f",
+					notification_id: Number(n.id),
+					run_id: Number.isFinite(runIdFromResource)
+						? runIdFromResource
+						: undefined,
+					collapseKey: null,
+					itemsCollected: null,
+				});
+			}
+		}
+	}
+
+	if (includeRuns) {
+		const runKinds = kindFilter
+			? USER_FACING_RUN_TYPES.filter((k) => kindFilter.has(k) || kindFilter.has("run"))
+			: [...USER_FACING_RUN_TYPES];
+		if (runKinds.length > 0) {
+			const sql = getDb();
+			const rows = (await sql`
+        SELECT r.id, r.run_type, r.watcher_id, r.connection_id, r.feed_id,
+               r.connector_key, r.action_key AS operation_key,
+               r.approval_status, r.status, r.error_message, r.items_collected,
+               r.created_at, r.completed_at,
+               f.feed_key, f.display_name AS feed_display_name,
+               c.display_name AS connection_display_name,
+               w.name AS watcher_name, w.agent_id
+        FROM runs r
+        LEFT JOIN feeds f ON f.id = r.feed_id
+        LEFT JOIN connections c ON c.id = r.connection_id
+        LEFT JOIN watchers w ON w.id = r.watcher_id
+        WHERE r.organization_id = ${opts.organizationId}
+          AND r.run_type = ANY(${pgTextArray(runKinds)}::text[])
+        ORDER BY r.created_at DESC, r.id DESC
+        LIMIT 60
+      `) as unknown as Array<{
+				id: number;
+				run_type: string;
+				watcher_id: number | null;
+				connection_id: number | null;
+				feed_id: number | null;
+				connector_key: string | null;
+				operation_key: string | null;
+				approval_status: string | null;
+				status: string;
+				error_message: string | null;
+				items_collected: number | null;
+				created_at: string | Date;
+				feed_key: string | null;
+				feed_display_name: string | null;
+				connection_display_name: string | null;
+				watcher_name: string | null;
+				agent_id: string | null;
+			}>;
+
+			for (const r of rows) {
+				const created =
+					r.created_at instanceof Date
+						? r.created_at.toISOString()
+						: String(r.created_at);
+				const atMs = new Date(created).getTime();
+				const kind =
+					r.run_type === "watcher"
+						? "watcher_run"
+						: r.run_type === "sync"
+							? "sync"
+							: "run";
+				const body = r.error_message
+					? r.error_message.slice(0, 120)
+					: r.items_collected != null
+						? `${r.status} · ${r.items_collected} items`
+						: r.status;
+				raw.push({
+					id: `r:${r.id}`,
+					kind,
+					title: runTitle(r),
+					body,
+					at: created,
+					atMs: Number.isFinite(atMs) ? atMs : 0,
+					status: r.status,
+					count: 1,
+					href: runHref(opts.ownerSlug, r),
+					run_id: r.id,
+					connection_id: r.connection_id ?? undefined,
+					watcher_id: r.watcher_id ?? undefined,
+					collapseKey: collapseKeyForRun(r),
+					itemsCollected: r.items_collected,
+				});
+			}
+		}
+	}
+
+	// Newest window → chronological → optional adjacent collapse → cap.
+	raw.sort((a, b) => b.atMs - a.atMs);
+	const windowed = raw.slice(0, 60);
+	windowed.reverse();
+	const collapsed = aggregate
+		? collapseAdjacentActivityCards(windowed)
+		: windowed;
+	const items = collapsed.slice(-limit).map(({ collapseKey, itemsCollected, atMs, ...card }) => card);
+
+	return { items, total: items.length, limit };
+}
+
+/** Compact prompt block for first-turn agent context (≤ ~2k chars). */
+export function formatActivityAttentionBlock(
+	items: ActivityCard[],
+	maxLines = 10,
+): string {
+	if (items.length === 0) return "";
+	const lines: string[] = ["## Workspace attention (recent)"];
+	const slice = items.slice(-maxLines);
+	for (const it of slice) {
+		const status = it.status ? ` [${it.status}]` : "";
+		const count = it.count > 1 ? ` ×${it.count}` : "";
+		const body = it.body ? ` — ${it.body.replace(/\s+/g, " ").slice(0, 120)}` : "";
+		const href = it.href ? ` (${it.href})` : "";
+		let line = `- ${it.title}${count}${status}${body}${href}`;
+		// Sanitize control chars like buildRunContextBlock
+		line = [...line]
+			.map((ch) => {
+				const code = ch.codePointAt(0) ?? 0;
+				return code < 0x20 || (code >= 0x7f && code <= 0x9f) ? " " : ch;
+			})
+			.join("")
+			.replace(/\s+/g, " ")
+			.trim()
+			.slice(0, 280);
+		if (line.length > 2) lines.push(line);
+	}
+	const block = lines.join("\n");
+	return block.length > 2000 ? block.slice(0, 2000) : block;
+}

--- a/packages/server/src/tools/admin/manage_operations/activity-feed.ts
+++ b/packages/server/src/tools/admin/manage_operations/activity-feed.ts
@@ -293,7 +293,9 @@ export async function listOrgActivity(opts: {
 			const { notifications } = await listNotifications({
 				organizationId: opts.organizationId,
 				userId: opts.userId,
-				limit: 30,
+				// Match the run window (60) so notifications can survive the
+				// merge into the final chronological slice even at limit: 50.
+				limit: 60,
 			});
 			for (const n of notifications) {
 				const type = String(n.type ?? "generic");
@@ -416,7 +418,30 @@ export async function listOrgActivity(opts: {
 	return { items, total: items.length, limit };
 }
 
-/** Compact prompt block for first-turn agent context (≤ ~2k chars). */
+/** Drop the query string + fragment from a deep-link (absolute or relative).
+ * Notification hrefs can carry OAuth authorization codes and invitation ids as
+ * query params; those must never reach worker context. Kept out of the UI path
+ * on purpose: listOrgActivity still returns full hrefs for the trusted client. */
+function stripUrlParams(url: string): string {
+	const cut = url.search(/[?#]/);
+	return cut >= 0 ? url.slice(0, cut) : url;
+}
+
+/** Redact query strings from any URL embedded in free-form body text, so a
+ * notification body like "re-auth here: https://…?code=…" cannot smuggle a
+ * credential into worker context. */
+function redactBodyUrls(text: string): string {
+	return text.replace(/(https?:\/\/[^\s?#]+)[^\s]*/g, "$1");
+}
+
+/**
+ * Compact prompt block for first-turn agent context (≤ ~2k chars).
+ *
+ * This feeds worker `ephemeralContext`, an untrusted-prompt surface, so it
+ * emits an allowlisted, worker-safe projection only: query params are stripped
+ * from links and body URLs (OAuth codes, invitation ids), and titles, errors,
+ * and names are forwarded solely as sanitized untrusted text.
+ */
 export function formatActivityAttentionBlock(
 	items: ActivityCard[],
 	maxLines = 10,
@@ -427,8 +452,10 @@ export function formatActivityAttentionBlock(
 	for (const it of slice) {
 		const status = it.status ? ` [${it.status}]` : "";
 		const count = it.count > 1 ? ` ×${it.count}` : "";
-		const body = it.body ? ` — ${it.body.replace(/\s+/g, " ").slice(0, 120)}` : "";
-		const href = it.href ? ` (${it.href})` : "";
+		const body = it.body
+			? ` — ${redactBodyUrls(it.body).replace(/\s+/g, " ").slice(0, 120)}`
+			: "";
+		const href = it.href ? ` (${stripUrlParams(it.href)})` : "";
 		let line = `- ${it.title}${count}${status}${body}${href}`;
 		// Sanitize control chars like buildRunContextBlock
 		line = [...line]

--- a/packages/server/src/utils/__tests__/device-pin-tombstones.test.ts
+++ b/packages/server/src/utils/__tests__/device-pin-tombstones.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	connectionHasLiveDevicePin,
+	DEVICE_MOVED_TOMBSTONE,
+	DEVICE_PIN_TOMBSTONE_MESSAGES,
+	DEVICE_REMOVED_TOMBSTONE,
+	effectiveConnectionErrorMessage,
+	isDevicePinTombstone,
+} from '../device-pin-tombstones';
+
+describe('device-pin-tombstones', () => {
+	it('recognizes only the canonical stamp strings', () => {
+		expect(isDevicePinTombstone(DEVICE_REMOVED_TOMBSTONE)).toBe(true);
+		expect(isDevicePinTombstone(DEVICE_MOVED_TOMBSTONE)).toBe(true);
+		expect(isDevicePinTombstone('Authentication failed')).toBe(false);
+		expect(isDevicePinTombstone(null)).toBe(false);
+		expect(isDevicePinTombstone(undefined)).toBe(false);
+		expect(DEVICE_PIN_TOMBSTONE_MESSAGES).toContain(DEVICE_REMOVED_TOMBSTONE);
+		expect(DEVICE_PIN_TOMBSTONE_MESSAGES).toContain(DEVICE_MOVED_TOMBSTONE);
+	});
+
+	it('detects a live pin from device join fields', () => {
+		expect(
+			connectionHasLiveDevicePin({
+				device_worker_id: 'uuid',
+				device_last_seen_at: new Date().toISOString(),
+			}),
+		).toBe(true);
+		expect(
+			connectionHasLiveDevicePin({
+				device_worker_id: 'uuid',
+				device_worker_handle: 'chrome-abc',
+			}),
+		).toBe(true);
+		expect(
+			connectionHasLiveDevicePin({
+				device_worker_id: 'uuid',
+				device_label: 'MacBook',
+			}),
+		).toBe(true);
+		expect(
+			connectionHasLiveDevicePin({
+				device_worker_id: 'uuid',
+				device_last_seen_at: null,
+				device_worker_handle: null,
+				device_label: null,
+			}),
+		).toBe(false);
+		expect(
+			connectionHasLiveDevicePin({
+				device_worker_id: null,
+				device_last_seen_at: new Date().toISOString(),
+			}),
+		).toBe(false);
+	});
+
+	it('suppresses tombstone when device is re-pinned (the UI gap)', () => {
+		expect(
+			effectiveConnectionErrorMessage({
+				error_message: DEVICE_REMOVED_TOMBSTONE,
+				device_worker_id: '709f0d3a-56d6-4f70-b778-4ba10afa8985',
+				device_last_seen_at: '2026-07-18T13:51:00Z',
+				device_label: "Burak's MacBook Chrome",
+			}),
+		).toBeNull();
+
+		// Still torn down: tombstone + no live device row
+		expect(
+			effectiveConnectionErrorMessage({
+				error_message: DEVICE_REMOVED_TOMBSTONE,
+				device_worker_id: null,
+			}),
+		).toBe(DEVICE_REMOVED_TOMBSTONE);
+
+		// Unrelated errors still surface even when pinned
+		expect(
+			effectiveConnectionErrorMessage({
+				error_message: 'OAuth token expired',
+				device_worker_id: 'uuid',
+				device_last_seen_at: '2026-07-18T13:51:00Z',
+			}),
+		).toBe('OAuth token expired');
+	});
+});

--- a/packages/server/src/utils/__tests__/public-origin.test.ts
+++ b/packages/server/src/utils/__tests__/public-origin.test.ts
@@ -39,6 +39,24 @@ describe('getCanonicalRedirectUrl', () => {
     ).toBeNull();
   });
 
+  it('does not redirect remote hosts when the canonical origin is loopback', () => {
+    // PUBLIC_GATEWAY_URL=http://127.0.0.1:8811/lobu + Tailscale Serve would
+    // otherwise bounce https://mac-mini.ts.net/ → http://127.0.0.1:8811/ and
+    // break every other machine on the tailnet.
+    expect(
+      getCanonicalRedirectUrl(
+        'https://buraks-mac-mini.brill-kanyu.ts.net/',
+        'http://127.0.0.1:8811'
+      )
+    ).toBeNull();
+    expect(
+      getCanonicalRedirectUrl(
+        'https://buraks-mac-mini.brill-kanyu.ts.net/dev',
+        'http://localhost:8811'
+      )
+    ).toBeNull();
+  });
+
   it('preserves sibling subdomains under the auth cookie zone', () => {
     expect(
       getCanonicalRedirectUrl('https://acme.lobu.ai/dashboard', 'https://app.lobu.ai', '.lobu.ai')

--- a/packages/server/src/utils/device-pin-tombstones.ts
+++ b/packages/server/src/utils/device-pin-tombstones.ts
@@ -1,0 +1,105 @@
+/**
+ * Device-pin tombstones on `connections.error_message`.
+ *
+ * DELETE /api/me/devices and PATCH device org-move un-pin connections and
+ * stamp a fixed error string so the UI can explain why a connector stopped.
+ * When a device re-registers / is re-pinned, every restore path MUST clear
+ * those strings — otherwise the connection is `active` + green while the
+ * header still shows red "Device was removed".
+ *
+ * Keep stamp and clear sites on these exact literals (single source of truth).
+ */
+
+import { pgTextArray, type DbClient } from '../db/client';
+
+/** Exact `connections.error_message` values written when a device pin is torn down. */
+export const DEVICE_PIN_TOMBSTONE_MESSAGES = [
+	'Device was removed',
+	'Device was moved to another workspace',
+] as const;
+
+export type DevicePinTombstoneMessage =
+	(typeof DEVICE_PIN_TOMBSTONE_MESSAGES)[number];
+
+export const DEVICE_REMOVED_TOMBSTONE: DevicePinTombstoneMessage =
+	'Device was removed';
+export const DEVICE_MOVED_TOMBSTONE: DevicePinTombstoneMessage =
+	'Device was moved to another workspace';
+
+export function isDevicePinTombstone(
+	message: string | null | undefined,
+): message is DevicePinTombstoneMessage {
+	return (
+		typeof message === 'string' &&
+		(DEVICE_PIN_TOMBSTONE_MESSAGES as readonly string[]).includes(message)
+	);
+}
+
+/**
+ * True when a listed connection still has a live device_workers row for its pin
+ * (join populated `device_last_seen_at` / handle). Tombstone should not be shown.
+ */
+export function connectionHasLiveDevicePin(row: {
+	device_worker_id?: string | null;
+	device_last_seen_at?: string | Date | null;
+	device_worker_handle?: string | null;
+	device_label?: string | null;
+}): boolean {
+	if (!row.device_worker_id) return false;
+	// Any of these being set means the LEFT JOIN to device_workers matched.
+	return (
+		row.device_last_seen_at != null ||
+		row.device_worker_handle != null ||
+		row.device_label != null
+	);
+}
+
+/**
+ * Effective error for API responses: suppress pin-tombstones once a device is
+ * pinned again (even if a write path forgot to clear the column).
+ */
+export function effectiveConnectionErrorMessage(row: {
+	error_message?: string | null;
+	device_worker_id?: string | null;
+	device_last_seen_at?: string | Date | null;
+	device_worker_handle?: string | null;
+	device_label?: string | null;
+}): string | null {
+	const msg = row.error_message ?? null;
+	if (isDevicePinTombstone(msg) && connectionHasLiveDevicePin(row)) {
+		return null;
+	}
+	return msg;
+}
+
+/**
+ * Clear device-pin tombstones (and un-pause if needed) when a connection is
+ * pinned to one of `matchingDeviceIds` (fresh devices that can serve it).
+ *
+ * Safe no-op when the connection has no such pin or a different error.
+ */
+export async function clearDevicePinTombstoneIfPinned(
+	db: DbClient,
+	params: {
+		connectionId: number;
+		/** Device worker ids currently allowed to hold this pin (fresh fleet). */
+		matchingDeviceIds: string[];
+	},
+): Promise<void> {
+	if (params.matchingDeviceIds.length === 0) return;
+	await db`
+    UPDATE connections
+    SET error_message = NULL,
+        status = CASE
+          WHEN status = 'paused' THEN 'active'
+          ELSE status
+        END,
+        updated_at = NOW()
+    WHERE id = ${params.connectionId}
+      AND device_worker_id IS NOT NULL
+      AND device_worker_id::text = ANY(${pgTextArray(params.matchingDeviceIds)}::text[])
+      AND error_message = ANY(${pgTextArray([...DEVICE_PIN_TOMBSTONE_MESSAGES])}::text[])
+      AND deleted_at IS NULL
+  `;
+}
+

--- a/packages/server/src/utils/public-origin.ts
+++ b/packages/server/src/utils/public-origin.ts
@@ -196,6 +196,11 @@ export function getCanonicalRedirectUrl(
   const requestHost = request.hostname;
   const canonicalHost = canonical.hostname;
 
+  // Never force-redirect TO loopback. Local PUBLIC_GATEWAY_URL (127.0.0.1 /
+  // localhost) is for on-box dev; bouncing Tailscale/LAN hosts there breaks
+  // every other machine (the client's localhost is not this server).
+  if (LOCALHOST_HOSTNAMES.has(canonicalHost)) return null;
+  // On-box loopback traffic is already on the right host — leave it alone.
   if (LOCALHOST_HOSTNAMES.has(requestHost)) return null;
   if (request.origin === canonical.origin) return null;
   if (requestHost === canonicalHost || requestHost.endsWith(`.${canonicalHost}`)) {

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -21,6 +21,10 @@ import { captureServerError } from '../sentry';
 import { errorMessage } from '../utils/errors';
 import { recordLifecycleEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
+import {
+  DEVICE_MOVED_TOMBSTONE,
+  DEVICE_REMOVED_TOMBSTONE,
+} from '../utils/device-pin-tombstones';
 import { getWorkspaceRole } from '../utils/organization-access';
 import { parseJsonBody } from '../gateway/routes/shared/helpers';
 
@@ -454,7 +458,7 @@ export async function updateDeviceWorkerOrg(c: Context<{ Bindings: Env }>) {
           UPDATE connections
           SET device_worker_id = NULL,
               status = 'paused',
-              error_message = 'Device was moved to another workspace',
+              error_message = ${DEVICE_MOVED_TOMBSTONE},
               updated_at = NOW()
           WHERE device_worker_id = ${deviceWorkerId}
           RETURNING id
@@ -525,7 +529,7 @@ export async function deleteDeviceWorker(c: Context<{ Bindings: Env }>) {
         UPDATE connections
         SET device_worker_id = NULL,
             status = 'paused',
-            error_message = 'Device was removed',
+            error_message = ${DEVICE_REMOVED_TOMBSTONE},
             updated_at = NOW()
         WHERE device_worker_id = ${deviceWorkerId}
         RETURNING id

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -21,6 +21,7 @@ import {
 import { extractConnectorMetadata, type ConnectorMetadata } from '../utils/connector-compiler';
 import { upsertConnectorDefinitionRecords } from '../utils/connector-definition-install';
 import { ensureUniqueConnectionSlug } from '../utils/connections';
+import { clearDevicePinTombstoneIfPinned } from '../utils/device-pin-tombstones';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { getDeviceManifestSourcesForUser, sortJson, type DeviceConnectorSource } from './device-manifests';
@@ -77,6 +78,12 @@ async function ensureDeviceConnectorWired(
         AND device_worker_id IS DISTINCT FROM ${target}::uuid
         AND (device_worker_id IS NULL OR NOT (device_worker_id::text = ANY(${pgTextArray(matchingDeviceIds)}::text[])))
     `;
+    // Pin restore (or already-valid pin): drop DELETE/move tombstones so the
+    // connection is not stuck as active + red "Device was removed".
+    await clearDevicePinTombstoneIfPinned(db, {
+      connectionId,
+      matchingDeviceIds,
+    });
   };
 
   try {

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -21,9 +21,10 @@
 
 import type { DispatchChromeActionRequest } from '@lobu/core/contracts/worker/protocol';
 import type { Context } from 'hono';
-import { getDb } from '../db/client';
+import { getDb, pgTextArray } from '../db/client';
 import type { Env } from '../index';
 import { waitForDeviceActionRun } from '../tools/admin/device-action-wait';
+import { DEVICE_PIN_TOMBSTONE_MESSAGES } from '../utils/device-pin-tombstones';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { isUniqueViolation } from '../utils/pg-errors';
@@ -296,7 +297,13 @@ export async function resolveOnlineChromeConnection(
 
         const updated = (await tx`
           UPDATE connections
-          SET device_worker_id = ${deviceWorkerId}::uuid, updated_at = now()
+          SET device_worker_id = ${deviceWorkerId}::uuid,
+              error_message = CASE
+                WHEN error_message = ANY(${pgTextArray([...DEVICE_PIN_TOMBSTONE_MESSAGES])}::text[])
+                THEN NULL
+                ELSE error_message
+              END,
+              updated_at = now()
           WHERE id = ${connIdNum}
             AND deleted_at IS NULL
             AND status = 'active'

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -42,6 +42,16 @@ export default defineConfig({
       // test job). Do NOT broaden to src/auth/__tests__/** — that orphans the
       // vitest files. (tool-access is framework-less and runs fine in both.)
       "src/auth/__tests__/system-provider-resolution.test.ts",
+      // src/tools/admin/manage_operations/__tests__ is a bun:test-only dir
+      // (activity-feed collapse unit suite). Keep it off vitest; it runs via the
+      // server bun:test units job. (Sibling src/tools/admin/__tests__ is handled
+      // by its own exclude above.)
+      "src/tools/admin/manage_operations/__tests__/**",
+      // src/utils/__tests__ is a MIXED dir: most files are vitest-style. Only
+      // device-pin-tombstones imports bun:test, so exclude just that file (it
+      // runs via the server bun:test units job). Do NOT broaden to
+      // src/utils/__tests__/** — that orphans the vitest files.
+      "src/utils/__tests__/device-pin-tombstones.test.ts",
       "**/node_modules/**",
       "**/dist/**",
     ],

--- a/scripts/dev-native.sh
+++ b/scripts/dev-native.sh
@@ -127,6 +127,8 @@ export ENVIRONMENT="${ENVIRONMENT:-development}"
 export HOST="${HOST:-127.0.0.1}"
 export PORT="${PORT:-8787}"
 export WORKER_PROXY_PORT="${WORKER_PROXY_PORT:-8118}"
+# Agent API base (mounted at /lobu). SPA is pathless at the origin — see
+# scripts/lib/dev-app-url.sh. Do not open …/lobu in a browser for the UI.
 export PUBLIC_GATEWAY_URL="${PUBLIC_GATEWAY_URL:-http://localhost:${PORT}/lobu}"
 export LOBU_PROVIDER_REGISTRY_PATH="${LOBU_PROVIDER_REGISTRY_PATH:-$REPO_ROOT/config/providers.json}"
 export LOBU_DEV_PROJECT_PATH="${LOBU_DEV_PROJECT_PATH:-$REPO_ROOT}"

--- a/scripts/lib/__tests__/dev-app-url.test.sh
+++ b/scripts/lib/__tests__/dev-app-url.test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/lib/dev-app-url.sh (pathless SPA origin).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+# shellcheck source=scripts/lib/dev-app-url.sh
+. "$ROOT/scripts/lib/dev-app-url.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+assert_eq() {
+  local got="$1" want="$2" label="$3"
+  [[ "$got" == "$want" ]] || fail "$label: got='$got' want='$want'"
+}
+
+assert_eq "$(lobu_dev_spa_origin_from_gateway_url 'http://127.0.0.1:8811/lobu')" \
+  'http://127.0.0.1:8811' 'strip /lobu'
+assert_eq "$(lobu_dev_spa_origin_from_gateway_url 'http://127.0.0.1:8811/lobu/')" \
+  'http://127.0.0.1:8811' 'strip /lobu/'
+assert_eq "$(lobu_dev_spa_origin_from_gateway_url 'http://127.0.0.1:8811')" \
+  'http://127.0.0.1:8811' 'already pathless'
+assert_eq "$(lobu_dev_spa_origin_from_gateway_url 'https://app.example.com/lobu')" \
+  'https://app.example.com' 'https strip'
+
+PUBLIC_GATEWAY_URL='http://127.0.0.1:8811/lobu'
+assert_eq "$(lobu_dev_app_url)" 'http://127.0.0.1:8811' 'lobu_dev_app_url from gateway'
+
+unset PUBLIC_GATEWAY_URL
+HOST=127.0.0.1 PORT=9999
+assert_eq "$(lobu_dev_app_url)" 'http://127.0.0.1:9999' 'fallback without /lobu'
+
+echo "OK dev-app-url tests"

--- a/scripts/lib/dev-app-url.sh
+++ b/scripts/lib/dev-app-url.sh
@@ -1,14 +1,34 @@
-# dev-app-url.sh — local dev UI URL (PUBLIC_GATEWAY_URL) for logs and OPEN=1.
+# dev-app-url.sh — local dev UI URL for logs and OPEN=1.
 # Sourced after .env / .env.local are loaded; REPO_ROOT must be set.
+#
+# PUBLIC_GATEWAY_URL is the *Agent API* base (mounted at /lobu on the wrapper
+# app — see server-lifecycle.ts). The SPA is pathless at the origin. Never open
+# …/lobu in a browser; that mount is API + docs, not the UI.
+
+# Strip a trailing /lobu path (and trailing slashes) so a gateway URL becomes
+# the pathless SPA origin. Leaves other path suffixes alone.
+lobu_dev_spa_origin_from_gateway_url() {
+  local raw="${1:-}"
+  # Drop query/fragment if present.
+  raw="${raw%%\?*}"
+  raw="${raw%%#*}"
+  # Strip trailing slashes, then a final /lobu segment.
+  while [[ "$raw" == */ ]]; do raw="${raw%/}"; done
+  if [[ "$raw" == */lobu ]]; then
+    raw="${raw%/lobu}"
+  fi
+  while [[ "$raw" == */ ]]; do raw="${raw%/}"; done
+  printf '%s' "$raw"
+}
 
 lobu_dev_app_url() {
   if [[ -n "${PUBLIC_GATEWAY_URL:-}" ]]; then
-    printf '%s' "$PUBLIC_GATEWAY_URL"
+    lobu_dev_spa_origin_from_gateway_url "$PUBLIC_GATEWAY_URL"
     return 0
   fi
   local host="${HOST:-127.0.0.1}"
   local port="${PORT:-8787}"
-  printf 'http://%s:%s/lobu' "$host" "$port"
+  printf 'http://%s:%s' "$host" "$port"
 }
 
 lobu_dev_print_app_url() {

--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -190,13 +190,16 @@ fi
 # server hands the SPA absolute sse/messages URLs on the wrong port, so the chat
 # silently fails ("Failed to fetch") in every non-default-port worktree. .env.local
 # is sourced after .env, so these win.
+#
+# …/lobu is the Agent API mount (wrapper.route("/lobu", lobuApp)), not the SPA.
+# The browser app is pathless at http://127.0.0.1:$port .
 cat > "$worktree_dir/.env.local" <<EOF
 PORT=$port
 WORKER_PROXY_PORT=$proxy
 PUBLIC_GATEWAY_URL=http://127.0.0.1:$port/lobu
 LOBU_TASK_NAME=$name
 EOF
-echo "→ .env.local: PORT=$port WORKER_PROXY_PORT=$proxy PUBLIC_GATEWAY_URL=http://127.0.0.1:$port/lobu"
+echo "→ .env.local: PORT=$port WORKER_PROXY_PORT=$proxy PUBLIC_GATEWAY_URL=http://127.0.0.1:$port/lobu (API; SPA is pathless at :$port)"
 
 echo "$name" > "$worktree_dir/.task"
 
@@ -228,7 +231,8 @@ cat <<EOF
   owletto branch:    $branch (real named branch, not detached HEAD)
   PORT:              $port
   WORKER_PROXY_PORT: $proxy
-  App (browser):     http://127.0.0.1:$port/lobu
+  App (browser):     http://127.0.0.1:$port
+  Agent API:         http://127.0.0.1:$port/lobu
 
   make dev              # in this worktree
   OPEN=1 make dev       # same, opens the app URL in your browser after ~5s


### PR DESCRIPTION
## Summary
- Add `manage_operations.list_activity` (member-readable): notifications + user-facing runs with **adjacent aggregation** and **deep-links** (`href`).
- Home attention timeline consumes `list_activity` (no more client-only stitch of notifs + list_runs for the feed).
- Auto-inject `## Workspace attention` into **first-turn web chat** via `ephemeralContext` when the client does not supply one.
- Device pin tombstones: clear stale `Device was removed` when devices re-pin; mask on list/get/UI.
- Notification deep-links (invitation accept, connection re-auth) and Tailscale `summaries-db-ts` selector fix in owletto deploy.

## Access
`list_activity` is **read+public** (same tier as `list_runs`), not admin-only.

## Test plan
- [x] Server unit: activity collapse, device tombstones, tool-access matrix
- [x] Owletto unit: activity-links collapse, notification targets, display error mask
- [ ] Manual: Home activity loads aggregated syncs with working links
- [ ] Manual: New web conversation first message gets attention context
- [ ] Manual: Chrome connection no longer shows stale Device was removed after re-pair

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified operations activity feed with filtering, pagination, notifications, run history, and optional aggregation.
  * Agent conversations can now receive an auto-generated “ephemeral context” digest on the first turn.
* **Bug Fixes**
  * Improved device-pin tombstone handling to clear stale errors and restore correct connection status.
  * Fixed local redirect behavior and updated dev URLs so the browser opens the UI correctly.
  * Notification links now target invitations and connection-specific pages.
* **Security**
  * Proxy support for private local initialization remains available only via an explicit opt-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->