### PR TITLE
fix: resolve Claude PreToolUse hooks from project root

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/block-dist.sh"
+            "command": "bash -c 's=\"${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.claude/hooks/block-dist.sh}\"; [ -n \"$s\" ] && [ -f \"$s\" ] || s=\"$(git rev-parse --show-toplevel)/.claude/hooks/block-dist.sh\"; exec bash \"$s\"'"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/enforce-bun.sh"
+            "command": "bash -c 's=\"${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-bun.sh}\"; [ -n \"$s\" ] && [ -f \"$s\" ] || s=\"$(git rev-parse --show-toplevel)/.claude/hooks/enforce-bun.sh\"; exec bash \"$s\"'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Anchor Claude Code PreToolUse hooks (`enforce-bun`, `block-dist`) so they resolve from `$CLAUDE_PROJECT_DIR` when the script exists, otherwise fall back to `git rev-parse --show-toplevel`.
- Fixes non-blocking `bash: .claude/hooks/enforce-bun.sh: No such file or directory` when the session cwd drifts off the repo root (e.g. `packages/*`).

## Test plan
- [x] `make pre-pr` clean
- [x] Hook resolves with `CLAUDE_PROJECT_DIR` set and cwd under `packages/`
- [x] Hook falls back to git toplevel when env unset
- [x] Hook falls back when `CLAUDE_PROJECT_DIR` is stale/missing the script
- [x] npm block and `/dist/` block still exit 2 with expected messages

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool hook execution across different project locations by dynamically resolving the repository path.
  * Added a fallback mechanism to ensure hooks continue running when the project directory is not explicitly available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->