### PR TITLE
fix(gateway): heartbeat-only ACKs no longer pin the worker idle clock (#1999)

### DIFF
--- a/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
@@ -223,7 +223,7 @@ describe("POST /worker/response — deployment idle clock (#12)", () => {
     expect(touched).toContain(DEPLOYMENT);
   });
 
-  test("a delivery ACK also refreshes the deployment activity tracker", async () => {
+  test("a delivery ACK (not a heartbeat) refreshes the deployment activity tracker", async () => {
     await armLiveTurn("m1");
     const touched: string[] = [];
     const tracker = {
@@ -232,12 +232,45 @@ describe("POST /worker/response — deployment idle clock (#12)", () => {
       },
     };
 
-    const res = await postWorkerResponse(
+    // A delivery receipt (received, no `heartbeat` flag) is real worker
+    // progress and must still refresh the idle clock — only pure heartbeats
+    // are excluded.
+    const res = await postWorkerResponse({ received: true }, { tracker });
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(touched).toContain(DEPLOYMENT);
+  });
+
+  test("heartbeat-only ACK does not refresh the idle clock; real work does", async () => {
+    await armLiveTurn("m1");
+    const touched: string[] = [];
+    const tracker = {
+      updateDeploymentActivity: async (d: string) => {
+        touched.push(d);
+      },
+    };
+
+    // A pure heartbeat ACK must not pin the deployment as active — otherwise
+    // WORKER_IDLE_CLEANUP_MINUTES never reaps a warm idle child.
+    const heartbeatRes = await postWorkerResponse(
       { received: true, heartbeat: true },
       { tracker }
     );
-    expect(res.status).toBe(200);
+    expect(heartbeatRes.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(touched).not.toContain(DEPLOYMENT);
 
+    // Non-heartbeat work still refreshes the idle clock (mid-turn safety).
+    const statusRes = await postWorkerResponse(
+      {
+        messageId: "m1",
+        conversationId: "conv-1",
+        statusUpdate: { elapsedSeconds: 40, state: "working" },
+      },
+      { tracker }
+    );
+    expect(statusRes.status).toBe(200);
     await new Promise((r) => setTimeout(r, 20));
     expect(touched).toContain(DEPLOYMENT);
   });

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -356,25 +356,9 @@ export class WorkerGateway {
 
     const { deploymentName } = auth.tokenData;
 
-    // Update connection activity (SSE stale-cleanup clock).
+    // SSE stale-cleanup clock: every worker HTTP response (including pure
+    // heartbeats) proves the SSE connection is still alive.
     this.connectionManager.touchConnection(deploymentName);
-    // Also refresh the DEPLOYMENT manager's idle clock. `touchConnection` above
-    // only feeds the connection manager's stale-SSE sweep — it does NOT touch
-    // `EmbeddedWorkerEntry.lastActivity`, which the idle reaper
-    // (reconcileDeployments → buildDeploymentInfoSummary.isIdle) reads. Without
-    // this, that timestamp stays frozen at the last dispatch, so a worker
-    // running a single long turn (no new inbound message) past
-    // WORKER_IDLE_CLEANUP_MINUTES is scaled to 0 and killed mid-turn. Every
-    // worker-driven HTTP response (delta, status_update, ACK, terminal reply)
-    // hits this path, so any liveness signal keeps the idle clock fresh; a
-    // truly silent worker still stops POSTing and ages out as intended.
-    void this.deploymentActivityTracker
-      ?.updateDeploymentActivity(deploymentName)
-      .catch((err) => {
-        logger.warn(
-          `[WORKER-GATEWAY] Failed to refresh deployment activity for ${deploymentName}: ${err}`
-        );
-      });
 
     try {
       const body = await c.req.json();
@@ -401,6 +385,29 @@ export class WorkerGateway {
             }
           : orgEnriched;
 
+      // Deployment idle clock (`EmbeddedWorkerEntry.lastActivity`) feeds the
+      // idle reaper (WORKER_IDLE_CLEANUP_MINUTES). Mid-turn liveness still
+      // needs refresh (status_update / deltas / terminal / delivery ACKs) so a
+      // long turn is not scaled to 0. Pure SSE heartbeat ACKs do NOT prove the
+      // worker is doing useful work — they fire forever on warm idle children
+      // and made idle cleanup a no-op (16× ~180MB children stuck forever, the
+      // dominant prod OOM cost). So a heartbeat-only ACK no longer refreshes the
+      // idle clock: WORKER_IDLE_CLEANUP_MINUTES is now the single dial that reaps
+      // warm idle children. Turn-liveness deadlines still extend via
+      // extendTurnDeadlines below, so a live-but-slow mid-turn worker is safe.
+      const isHeartbeatOnlyAck = !!(
+        enrichedResponse.received && enrichedResponse.heartbeat
+      );
+      if (!isHeartbeatOnlyAck) {
+        void this.deploymentActivityTracker
+          ?.updateDeploymentActivity(deploymentName)
+          .catch((err) => {
+            logger.warn(
+              `[WORKER-GATEWAY] Failed to refresh deployment activity for ${deploymentName}: ${err}`
+            );
+          });
+      }
+
       // Acknowledge job completion if jobId provided
       if (jobId) {
         this.jobRouter.acknowledgeJob(jobId);
@@ -409,8 +416,6 @@ export class WorkerGateway {
       // Delivery receipts (worker ACKs) have no message payload — just acknowledge and return
       if (enrichedResponse.received) {
         if (enrichedResponse.heartbeat) {
-          // touchConnection already ran above for all /worker/response calls,
-          // keeping this worker alive in stale-cleanup.
           logger.debug(
             `[WORKER-GATEWAY] Received heartbeat ACK from ${deploymentName}`
           );


### PR DESCRIPTION
## What

Phase 0 of #1999, minimal. **One behavior fix, no new flags.**

A heartbeat-only worker ACK (`received && heartbeat`) no longer refreshes the deployment idle clock, so the **existing** `WORKER_IDLE_CLEANUP_MINUTES` reaper can finally do its job and scale idle workers to 0.

## Why

Prod OOM root cause (measured): ~16 warm `bun --smol` agent-worker children × ~180 MB RSS each — the Bun+Pi baseline, **not** transcript size (PG snapshots avg ~33 KB). They stayed resident because the idle reaper never fired: it's gated on `EmbeddedWorkerEntry.lastActivity`, but a pure SSE heartbeat ACK refreshed `lastActivity` on every beat, so a warm idle child looked perpetually active. Fixing that one refresh makes idle cleanup work.

## Design: no knob sprawl

An earlier spike carried three flags (`LOBU_IDLE_CLOCK_SKIP_HEARTBEAT`, `LOBU_WORKER_EVICT_AFTER_TURN`, plus a short TTL). Collapsed to the single root-cause fix:

- The heartbeat refresh was a **bug** — heartbeats were never meant to count as activity — so it's fixed by default, not behind an opt-in flag.
- `WORKER_IDLE_CLEANUP_MINUTES` (already exists, default 60) is the **only** dial. Lower it to reap sooner.
- Hard evict-after-turn is dropped: it overlapped with short-idle-TTL and added a second eviction concept for no clear win over "let the reaper run."

## Safety

- Mid-turn liveness is unaffected: real progress (`status_update`, deltas, terminal, non-heartbeat delivery ACKs) still refreshes the idle clock, and turn-liveness deadlines still extend via `extendTurnDeadlines`. A live-but-slow mid-turn worker is never falsely reaped.
- Subprocess isolation unchanged (scrubbed/placeholder env via proxy — the "workers never receive real credentials" invariant holds).
- Multi-replica safe: no new shared in-memory state; the idle clock is per-pod deployment state as before.

## Measured (bench, in #1999)

- 10 warm workers ≈ 1880 MB (10 × ~188 MB baseline) vs 10 sessions in one process ≈ 184 MB — reaping idle children reclaims ~180 MB each.
- Cold respawn ~230 ms steady-state (import-dominated); session open/hydrate <1 ms — respawn cost is negligible and doesn't touch live-turn RAM.

## Tests

`worker-response-liveness.test.ts`: heartbeat-only ACK does **not** refresh the idle clock; a delivery ACK (no heartbeat flag) and status updates **do**.

## Follow-ups (#1999)

- Tune `WORKER_IDLE_CLEANUP_MINUTES` down in the owletto prod overlay once this merges (separate PR).
- Phase 2/3 (separate): reset/epoch PG-authoritative; distributed-FS workspace durability design.
