### PR TITLE
feat(gmail): mint contacts on outbound send, not receive-only

### DIFF
--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -15,6 +15,10 @@ interface FakeMessage {
   id: string;
   labelIds?: string[];
   from?: string;
+  to?: string;
+  cc?: string;
+  listId?: string;
+  precedence?: string;
   date?: string;
 }
 
@@ -26,7 +30,7 @@ interface FakeThread {
 /**
  * Fake Gmail HTTP client: serves threads.list (one page) and threads/<id>
  * lookups from the given fixtures. Header values come from the per-message
- * `from`/`date` fields; snippets are constant.
+ * fields; snippets are constant.
  */
 function fakeHttp(threads: FakeThread[], onRequest?: () => void) {
   const byId = new Map(threads.map((t) => [t.id, t]));
@@ -53,21 +57,25 @@ function toThreadResponse(thread: FakeThread | undefined) {
   return {
     id: thread.id,
     historyId: '1',
-    messages: thread.messages.map((m) => ({
-      id: m.id,
-      threadId: thread.id,
-      labelIds: m.labelIds ?? [],
-      snippet: 'snippet',
-      internalDate: String(Date.parse(m.date ?? '2026-07-01T10:00:00Z')),
-      payload: {
-        mimeType: 'text/plain',
-        headers: [
-          { name: 'Subject', value: `subject ${thread.id}` },
-          { name: 'From', value: m.from ?? 'Some One <someone@example.com>' },
-          { name: 'Date', value: m.date ?? '2026-07-01T10:00:00Z' },
-        ],
-      },
-    })),
+    messages: thread.messages.map((m) => {
+      const headers = [
+        { name: 'Subject', value: `subject ${thread.id}` },
+        { name: 'From', value: m.from ?? 'Some One <someone@example.com>' },
+        { name: 'Date', value: m.date ?? '2026-07-01T10:00:00Z' },
+      ];
+      if (m.to) headers.push({ name: 'To', value: m.to });
+      if (m.cc) headers.push({ name: 'Cc', value: m.cc });
+      if (m.listId) headers.push({ name: 'List-Id', value: m.listId });
+      if (m.precedence) headers.push({ name: 'Precedence', value: m.precedence });
+      return {
+        id: m.id,
+        threadId: thread.id,
+        labelIds: m.labelIds ?? [],
+        snippet: 'snippet',
+        internalDate: String(Date.parse(m.date ?? '2026-07-01T10:00:00Z')),
+        payload: { mimeType: 'text/plain', headers },
+      };
+    }),
   };
 }
 
@@ -100,8 +108,38 @@ test('the checkpoint precedes sync requests so messages arriving during sync rem
   expect(new Date(result.checkpoint.last_sync_at).getTime()).toBeLessThanOrEqual(firstRequestAt);
 });
 
-describe('Gmail replied signal (promote-on-interaction)', () => {
-  test('an inbound-only thread is NOT replied — a bulk sender/brand never clears the bar', async () => {
+test('thread sync includes sent mail and requests the headers mintability depends on', async () => {
+  const connector = new GmailConnector();
+  const urls: string[] = [];
+  connector.createClient = () => ({
+    raw: async (url: string) => {
+      urls.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          url.includes('/threads/')
+            ? { id: 't1', historyId: '1', messages: [] }
+            : { threads: [{ id: 't1', historyId: '1', snippet: 's' }] },
+        text: async () => '',
+      } as unknown as Response;
+    },
+  });
+
+  await connector.sync({ config: {}, credentials: { accessToken: 'tok' }, checkpoint: {} });
+
+  const listQuery = new URL(urls[0]).searchParams.get('q');
+  expect(listQuery).toContain('{label:INBOX in:sent}');
+
+  const threadUrl = urls.find((u) => u.includes('/threads/t1'));
+  expect(threadUrl).toBeDefined();
+  for (const header of ['To', 'Cc', 'Reply-To', 'List-Id', 'Precedence']) {
+    expect(threadUrl).toContain(`metadataHeaders=${header}`);
+  }
+});
+
+describe('Gmail mint-on-send gate', () => {
+  test('an inbound-only thread never mints — receipt alone is not a relationship', async () => {
     const events = await syncThreads([
       {
         id: 't-brand',
@@ -112,43 +150,347 @@ describe('Gmail replied signal (promote-on-interaction)', () => {
       },
     ]);
     expect(events).toHaveLength(1);
+    expect(events[0].metadata.outbound).toBe(false);
     expect(events[0].metadata.replied).toBe(false);
+    expect(events[0].metadata.mintable).toBe(false);
     expect(events[0].metadata.from_email).toBe('promo@brand.example');
   });
 
-  test('a counterparty-started thread the owner replied in IS replied', async () => {
+  test('they wrote and we replied — mintable, and attribution stays on the counterparty', async () => {
     const events = await syncThreads([
       {
         id: 't-alice',
         messages: [
-          { id: 'm1', labelIds: ['INBOX'], from: 'Alice <alice@example.com>' },
-          { id: 'm2', labelIds: ['SENT'], from: 'Me <me@example.com>' },
+          {
+            id: 'm1',
+            labelIds: ['INBOX'],
+            from: 'Alice <alice@example.com>',
+            to: 'Me <me@example.com>',
+          },
+          {
+            id: 'm2',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Alice <alice@example.com>',
+          },
         ],
       },
     ]);
     expect(events).toHaveLength(1);
+    expect(events[0].metadata.outbound).toBe(true);
     expect(events[0].metadata.replied).toBe(true);
+    expect(events[0].metadata.mintable).toBe(true);
     expect(events[0].metadata.from_email).toBe('alice@example.com');
   });
 
-  test('an owner-started thread with a counterparty reply is bidirectional and attributes the counterparty', async () => {
+  test('cold outbound to a single external recipient mints from the To line', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-cold',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Dana Fox <dana@acme.example>',
+          },
+        ],
+      },
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.outbound).toBe(true);
+    expect(events[0].metadata.replied).toBe(false);
+    expect(events[0].metadata.mintable).toBe(true);
+    expect(events[0].metadata.from_email).toBe('dana@acme.example');
+    expect(events[0].metadata.from_name).toBe('Dana Fox');
+  });
+
+  test('outbound to a role mailbox is a ticket, not a contact', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-support',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Support@stripe.com',
+          },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.outbound).toBe(true);
+    expect(events[0].metadata.mintable).toBe(false);
+  });
+
+  test('list mail never mints, even when we replied into the list', async () => {
+    const listId = await syncThreads([
+      {
+        id: 't-list',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['INBOX'],
+            from: 'Poster <poster@lists.example>',
+            to: 'devs@lists.example',
+            listId: '<devs.lists.example>',
+          },
+          {
+            id: 'm2',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Poster <poster@lists.example>',
+          },
+        ],
+      },
+    ]);
+    expect(listId[0].metadata.mintable).toBe(false);
+
+    const precedence = await syncThreads([
+      {
+        id: 't-bulk',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Carol <carol@acme.example>',
+            precedence: 'Bulk',
+          },
+        ],
+      },
+    ]);
+    expect(precedence[0].metadata.mintable).toBe(false);
+  });
+
+  test('a wide unanswered blast is capped — over three external recipients does not mint', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-blast',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'a@x.example, b@x.example, c@x.example',
+            cc: 'd@x.example, e@x.example',
+          },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.outbound).toBe(true);
+    expect(events[0].metadata.replied).toBe(false);
+    expect(events[0].metadata.mintable).toBe(false);
+  });
+
+  test('three distinct external recipients is within the broadcast cap', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-cap',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Me <me@example.com>, a@x.example, b@x.example',
+            cc: 'a@x.example, c@x.example',
+          },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.mintable).toBe(true);
+    expect(events[0].metadata.from_email).toBe('a@x.example');
+  });
+
+  test('a SENT-only Cc recipient is not a direct counterparty', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-cc-only',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Me <me@example.com>',
+            cc: 'Casey <casey@acme.example>',
+          },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.mintable).toBe(false);
+    expect(events[0].metadata.from_email).toBeUndefined();
+  });
+
+  test('the same wide thread mints once a recipient writes back', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-blast-reply',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'a@x.example, b@x.example, c@x.example',
+            cc: 'd@x.example, e@x.example',
+          },
+          { id: 'm2', labelIds: ['INBOX'], from: 'B Person <b@x.example>' },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.replied).toBe(true);
+    expect(events[0].metadata.mintable).toBe(true);
+    expect(events[0].metadata.from_email).toBe('b@x.example');
+  });
+
+  test('an owner-started thread attributes the counterparty, never the mailbox owner', async () => {
     const events = await syncThreads([
       {
         id: 't-self',
         messages: [
-          { id: 'm1', labelIds: ['SENT'], from: 'Me <me@example.com>' },
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Bob <bob@example.com>',
+          },
           { id: 'm2', labelIds: ['INBOX'], from: 'Bob <bob@example.com>' },
         ],
       },
     ]);
-    expect(events).toHaveLength(1);
-    expect(events[0].metadata.replied).toBe(true);
+    expect(events[0].metadata.mintable).toBe(true);
     expect(events[0].metadata.from_email).toBe('bob@example.com');
+  });
+
+  test('a self-addressed thread (note to self) never mints the owner', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-note',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Me <me@example.com>',
+          },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.outbound).toBe(true);
+    expect(events[0].metadata.mintable).toBe(false);
+    expect(events[0].metadata.from_email).toBeUndefined();
+  });
+
+  test('an alias-case copy of our own send is not a counterparty reply', async () => {
+    // Gmail drops our own sends into the mailbox, and send-as aliases vary in
+    // case. Counting that as `replied` would wrongly relax the broadcast cap.
+    const events = await syncThreads([
+      {
+        id: 't-alias',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <ME@Example.com>',
+            to: 'a@x.example, b@x.example, c@x.example, d@x.example, e@x.example',
+          },
+          { id: 'm2', labelIds: ['INBOX'], from: 'me@example.COM' },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.replied).toBe(false);
+    expect(events[0].metadata.mintable).toBe(false);
+  });
+
+  test('a role address on the To line does not sink a real human beside it', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-mixed',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'support@stripe.com, Real Human <human@acme.example>',
+          },
+        ],
+      },
+    ]);
+    // Attribution skips the role mailbox rather than attributing it and failing.
+    expect(events[0].metadata.mintable).toBe(true);
+    expect(events[0].metadata.from_email).toBe('human@acme.example');
+  });
+
+  test('a bot-opened thread attributes the human who replied, not the bot', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-jira',
+        messages: [
+          { id: 'm1', labelIds: ['INBOX'], from: 'Jira <notifications@atlassian.com>' },
+          { id: 'm2', labelIds: ['INBOX'], from: 'Real Human <human@acme.example>' },
+          {
+            id: 'm3',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'Real Human <human@acme.example>',
+          },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.mintable).toBe(true);
+    expect(events[0].metadata.from_email).toBe('human@acme.example');
+  });
+
+  test('a bot-only thread we answered still does not mint the bot', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-bot-only',
+        messages: [
+          { id: 'm1', labelIds: ['INBOX'], from: 'Jira <notifications@atlassian.com>' },
+          {
+            id: 'm2',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: 'notifications@atlassian.com',
+          },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.replied).toBe(true);
+    expect(events[0].metadata.mintable).toBe(false);
+  });
+
+  test('a SENT message with no parseable From fails closed — self is unknowable', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-nofrom',
+        messages: [{ id: 'm1', labelIds: ['SENT'], from: '', to: 'Dana <dana@acme.example>' }],
+      },
+    ]);
+    expect(events[0].metadata.outbound).toBe(true);
+    expect(events[0].metadata.mintable).toBe(false);
+  });
+
+  test('a display name containing a comma does not split into two recipients', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-comma',
+        messages: [
+          {
+            id: 'm1',
+            labelIds: ['SENT'],
+            from: 'Me <me@example.com>',
+            to: '"Doe, Jane" <jane@acme.example>',
+          },
+        ],
+      },
+    ]);
+    expect(events[0].metadata.mintable).toBe(true);
+    expect(events[0].metadata.from_email).toBe('jane@acme.example');
   });
 });
 
 describe('Gmail person attribution rule', () => {
-  test('autoCreate is on but gated on metadata.replied — promotion is interaction-driven', () => {
+  test('autoCreate is gated on metadata.mintable — promotion follows the send, not the receipt', () => {
     const connector = new GmailConnector();
     const rules = connector.definition.feeds.threads.eventKinds.thread.attributions;
     expect(rules).toHaveLength(1);
@@ -156,7 +498,7 @@ describe('Gmail person attribution rule', () => {
     expect(rule.role).toBe('authored_by');
     expect(rule.autoCreate).toBe(true);
     expect(rule.target.entityType).toBe('person');
-    expect(rule.target.createWhen).toEqual({ path: 'metadata.replied', equals: true });
+    expect(rule.target.createWhen).toEqual({ path: 'metadata.mintable', equals: true });
     expect(rule.target.identities).toEqual([
       { namespace: 'email', eventPath: 'metadata.from_email' },
     ]);

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -86,6 +86,62 @@ const GMAIL_SEARCH_COLUMNS = [
   { name: 'url', type: 'string' },
 ];
 
+/**
+ * Local-parts that identify a role/system mailbox rather than a human. Sending
+ * to one of these is a support ticket or a signup, not a relationship, so it
+ * must never mint a `person`.
+ */
+const ROLE_LOCAL_PARTS = new Set([
+  'noreply',
+  'no-reply',
+  'donotreply',
+  'do-not-reply',
+  'no_reply',
+  'mailer-daemon',
+  'postmaster',
+  'support',
+  'help',
+  'info',
+  'hello',
+  'contact',
+  'billing',
+  'invoices',
+  'invoice',
+  'receipts',
+  'receipt',
+  'notifications',
+  'notification',
+  'newsletter',
+  'news',
+  'updates',
+  'marketing',
+  'team',
+  'jobs',
+  'careers',
+  'hr',
+  'sales',
+  'abuse',
+  'security',
+]);
+
+/** `Precedence` values that mark automated bulk mail. */
+const BULK_PRECEDENCE = new Set(['bulk', 'list', 'junk']);
+
+/**
+ * Above this many distinct external recipients on the opening SENT message the
+ * thread reads as a blast, not a one-to-one reach-out. Such threads only mint
+ * once the counterparty writes back (`replied`).
+ */
+const BROADCAST_RECIPIENT_CAP = 3;
+
+const isSentMessage = (m: GmailMessage): boolean => (m.labelIds ?? []).includes('SENT');
+
+const normalizeEmail = (email: string | null | undefined): string =>
+  (email ?? '').trim().toLowerCase();
+
+const isRoleAddress = (email: string): boolean =>
+  ROLE_LOCAL_PARTS.has(normalizeEmail(email).split('@')[0] ?? '');
+
 // ---------------------------------------------------------------------------
 // Connector
 // ---------------------------------------------------------------------------
@@ -127,7 +183,8 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
             label: {
               type: 'string',
               default: 'INBOX',
-              description: 'Gmail label to sync (e.g. "INBOX", "SENT", "STARRED").',
+              description:
+                'Gmail label to sync alongside sent mail (e.g. "INBOX" or "STARRED").',
             },
             max_results: {
               type: 'integer',
@@ -156,29 +213,32 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
                 snippet: { type: 'string' },
                 from_email: { type: 'string' },
                 from_name: { type: 'string' },
+                outbound: {
+                  type: 'boolean',
+                  description:
+                    'True when the thread contains at least one mailbox-authored SENT-labeled message.',
+                },
                 replied: {
                   type: 'boolean',
                   description:
-                    'True when the thread contains both a counterparty message and a mailbox-authored SENT-labeled message — the interaction signal that gates contact promotion.',
+                    'True when the thread contains both a counterparty message and a mailbox-authored SENT-labeled message — a bidirectional exchange. Quality/metadata signal only; it relaxes the broadcast cap but does not itself gate contact promotion.',
+                },
+                mintable: {
+                  type: 'boolean',
+                  description:
+                    'True when we sent into the thread and attributed a direct, non-self, non-list, non-role counterparty.',
                 },
               },
             },
             attributions: [
               {
                 role: 'authored_by',
-                // Promote on interaction, never on receipt. Every from-address is
-                // a sender — overwhelmingly brands, newsletters, and no-reply
-                // system addresses, all of which carry a from_name — so receipt
-                // alone must not mint a contact. `replied` (computed in sync from
-                // per-message SENT labels) marks a genuine bidirectional exchange.
-                // Only those senders materialize a `person`; everything else still
-                // links to an existing contact on identity match. A thread replied
-                // to after its first sync re-syncs (the reply is a new message
-                // inside the `after:` window), so promotion follows the reply.
+                // Receive-only senders may still link to an existing contact,
+                // but only a vetted counterparty we sent to can create one.
                 autoCreate: true,
                 target: {
                   entityType: 'person',
-                  createWhen: { path: 'metadata.replied', equals: true },
+                  createWhen: { path: 'metadata.mintable', equals: true },
                   titlePath: 'metadata.from_name',
                   identities: [{ namespace: 'email', eventPath: 'metadata.from_email' }],
                 },
@@ -324,7 +384,9 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     // precision. Using `YYYY/MM/DD` (day granularity, host timezone) meant every
     // sync within the same day re-fetched the whole day's threads as duplicates.
     const afterEpochSeconds = Math.floor(afterDate.getTime() / 1000);
-    const query = `after:${afterEpochSeconds} label:${label}`;
+    // Include SENT explicitly so a new outbound-only thread is discoverable
+    // even when the configured feed label is INBOX (the default).
+    const query = `after:${afterEpochSeconds} {label:${label} in:sent}`;
 
     const http = this.createClient(token);
     const events: EventEnvelope[] = [];
@@ -361,7 +423,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       // Fetch each thread with metadata format
       for (const threadStub of threads) {
         try {
-          const threadUrl = `${this.BASE_URL}/threads/${threadStub.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date`;
+          const threadUrl = `${this.BASE_URL}/threads/${threadStub.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date&metadataHeaders=To&metadataHeaders=Cc&metadataHeaders=Reply-To&metadataHeaders=List-Id&metadataHeaders=Precedence`;
           const threadResponse = await http.raw(threadUrl);
 
           if (!threadResponse.ok) continue;
@@ -371,25 +433,20 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
           if (!thread.messages || thread.messages.length === 0) continue;
 
           const firstMessage = thread.messages[0];
-          const isSent = (m: GmailMessage) => (m.labelIds ?? []).includes('SENT');
-          const counterpartyMessage = thread.messages.find((message) => !isSent(message));
+          const counterpartyMessage = thread.messages.find((message) => !isSentMessage(message));
           const subject = this.getHeader(firstMessage, 'Subject') || '(no subject)';
           const from = counterpartyMessage
             ? this.getHeader(counterpartyMessage, 'From') || 'Unknown'
             : 'Unknown';
-          const { name: fromName, email: fromEmail } = this.parseFromHeader(from);
+          const mint = this.computeMintability(thread.messages);
+          const fromName = mint.fromName;
+          const fromEmail = mint.fromEmail;
           const dateHeader = this.getHeader(firstMessage, 'Date');
           const occurredAt = dateHeader
             ? new Date(dateHeader)
             : new Date(parseInt(firstMessage.internalDate, 10));
 
           if (Number.isNaN(occurredAt.getTime())) continue;
-
-          // A bidirectional exchange has at least one mailbox-authored message
-          // and one counterparty-authored message, regardless of who started it.
-          // Attribute the event to the first counterparty message so an
-          // owner-started thread never promotes the mailbox owner's own address.
-          const replied = counterpartyMessage !== undefined && thread.messages.some(isSent);
 
           const event: EventEnvelope = {
             origin_id: thread.id,
@@ -403,7 +460,9 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
               message_count: thread.messages.length,
               label_ids: firstMessage.labelIds ?? [],
               snippet: firstMessage.snippet,
-              replied,
+              outbound: mint.outbound,
+              replied: mint.replied,
+              mintable: mint.mintable,
               ...(fromEmail ? { from_email: fromEmail } : {}),
               ...(fromName ? { from_name: fromName } : {}),
             },
@@ -855,6 +914,139 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
+
+  /**
+   * Compute event attribution and the create-on-miss gate. SENT-message From
+   * headers are the available self-address set; aliases absent from the thread
+   * cannot be recognized as self.
+   */
+  private computeMintability(messages: GmailMessage[]): {
+    outbound: boolean;
+    replied: boolean;
+    mintable: boolean;
+    fromName: string | null;
+    fromEmail: string | null;
+  } {
+    const sentMessages = messages.filter(isSentMessage);
+    const nonSentMessages = messages.filter((message) => !isSentMessage(message));
+    const outbound = sentMessages.length > 0;
+
+    const selfAddresses = new Set(
+      sentMessages
+        .map((m) => normalizeEmail(this.parseFromHeader(this.getHeader(m, 'From') ?? '').email))
+        .filter(Boolean)
+    );
+    const isSelf = (email: string) => selfAddresses.has(normalizeEmail(email));
+
+    // A bidirectional exchange needs a message from someone OTHER than us.
+    // Gmail drops our own sends into the mailbox too (and send-as aliases vary
+    // in case), so counting any non-SENT message would score a note-to-self as
+    // `replied` — which would then wrongly relax the broadcast cap below.
+    const counterpartyMessage = nonSentMessages.find(
+      (m) => !isSelf(this.parseFromHeader(this.getHeader(m, 'From') ?? '').email ?? '')
+    );
+    // Prefer an inbound message from a real human over one from a role mailbox:
+    // a thread a Jira notification opened, a colleague replied to, and we then
+    // answered is a relationship with the colleague — attributing the bot
+    // address would sink it. Falls back to the role sender when that is all
+    // there is, which the role filter below then correctly refuses to mint.
+    const humanCounterpartyMessage =
+      nonSentMessages.find((m) => {
+        const email = this.parseFromHeader(this.getHeader(m, 'From') ?? '').email ?? '';
+        return email && !isSelf(email) && !isRoleAddress(email);
+      }) ?? counterpartyMessage;
+    const replied = outbound && counterpartyMessage !== undefined;
+    const earliestSent = sentMessages[0];
+    let fromName: string | null = null;
+    let fromEmail: string | null = null;
+    if (humanCounterpartyMessage) {
+      const parsed = this.parseFromHeader(this.getHeader(humanCounterpartyMessage, 'From') ?? '');
+      fromName = parsed.name;
+      fromEmail = parsed.email;
+    } else if (earliestSent) {
+      // Skip role mailboxes rather than attributing one: a message addressed to
+      // `support@vendor, Real Human <human@acme>` is still a real reach-out to
+      // the human, and attributing the role address would sink the whole thread.
+      const recipient = this.parseAddressList(this.getHeader(earliestSent, 'To')).find(
+        (address) => !isSelf(address.email) && !isRoleAddress(address.email)
+      );
+      fromName = recipient?.name ?? null;
+      fromEmail = recipient?.email ?? null;
+    }
+    const addressedDirectly = sentMessages.some((message) =>
+      this.parseAddressList(this.getHeader(message, 'To')).some(
+        (address) => normalizeEmail(address.email) === normalizeEmail(fromEmail)
+      )
+    );
+
+    const mintable =
+      outbound &&
+      // A SENT message with no parseable From leaves us unable to tell self from
+      // counterparty, so every self-check below would silently pass. Fail closed.
+      selfAddresses.size > 0 &&
+      !!fromEmail &&
+      !isSelf(fromEmail) &&
+      !isRoleAddress(fromEmail) &&
+      !this.isListThread(messages) &&
+      (addressedDirectly || replied) &&
+      // Broadcast cap: a wide opening blast only mints once someone writes back.
+      (replied || this.externalRecipientCount(earliestSent, isSelf) <= BROADCAST_RECIPIENT_CAP);
+
+    return { outbound, replied, mintable, fromName, fromEmail };
+  }
+
+  private isListThread(messages: GmailMessage[]): boolean {
+    return messages.some((m) => {
+      if ((this.getHeader(m, 'List-Id') ?? '').trim()) return true;
+      const precedence = (this.getHeader(m, 'Precedence') ?? '').trim().toLowerCase();
+      return BULK_PRECEDENCE.has(precedence);
+    });
+  }
+
+  private externalRecipientCount(
+    message: GmailMessage | undefined,
+    isSelf: (email: string) => boolean
+  ): number {
+    if (!message) return 0;
+    const recipients = [
+      ...this.parseAddressList(this.getHeader(message, 'To')),
+      ...this.parseAddressList(this.getHeader(message, 'Cc')),
+    ];
+    const distinct = new Set(
+      recipients
+        .map((a) => normalizeEmail(a.email))
+        .filter((email) => email && !isSelf(email))
+    );
+    return distinct.size;
+  }
+
+  /**
+   * Split an RFC 5322 address-list header into individual addresses. Commas
+   * inside a quoted display name (`"Doe, Jane" <jane@x>`) do not separate.
+   */
+  private parseAddressList(raw: string | undefined): Array<{ name: string | null; email: string }> {
+    if (!raw?.trim()) return [];
+    const parts: string[] = [];
+    let current = '';
+    let inQuotes = false;
+    let inAngle = false;
+    for (const char of raw) {
+      if (char === '"') inQuotes = !inQuotes;
+      else if (char === '<' && !inQuotes) inAngle = true;
+      else if (char === '>' && !inQuotes) inAngle = false;
+      if (char === ',' && !inQuotes && !inAngle) {
+        parts.push(current);
+        current = '';
+        continue;
+      }
+      current += char;
+    }
+    parts.push(current);
+
+    return parts
+      .map((part) => this.parseFromHeader(part))
+      .filter((parsed): parsed is { name: string | null; email: string } => !!parsed.email);
+  }
 
   private getHeader(message: GmailMessage, name: string): string | undefined {
     const header = message.payload.headers.find((h) => h.name.toLowerCase() === name.toLowerCase());

--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -830,7 +830,7 @@ describe('gmail promote-on-interaction (real connector rule)', () => {
     `;
   }
 
-  it('promotes only replied-to counterparties: no raw-sender rows, bidirectional contact minted with metric aliases', async () => {
+  it('promotes only mintable counterparties: no raw-sender rows, minted contact carries metric aliases', async () => {
     const { org, sql } = await setupGmailOrg();
 
     await applyEventAttributions({
@@ -839,9 +839,9 @@ describe('gmail promote-on-interaction (real connector rule)', () => {
       orgId: org.id,
       items: [
         // Inbound-only brand blast — has a from_name, still must NOT mint.
-        thread({ from_email: 'promo@brand.example', from_name: 'Brand', replied: false }),
-        // Genuine bidirectional exchange — promotes.
-        thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: true }),
+        thread({ from_email: 'promo@brand.example', from_name: 'Brand', outbound: false, replied: false, mintable: false }),
+        // We sent into this thread and attributed a real counterparty — promotes.
+        thread({ from_email: 'alice@example.com', from_name: 'Alice', outbound: true, replied: true, mintable: true }),
       ],
     });
 
@@ -859,9 +859,32 @@ describe('gmail promote-on-interaction (real connector rule)', () => {
     expect(brandIdent[0].count).toBe('0');
   });
 
-  it('promotion is idempotent: re-syncing the same replied thread never duplicates the contact', async () => {
+  it('mints cold outbound: we sent, nobody replied yet, contact still promoted', async () => {
     const { org, sql } = await setupGmailOrg();
-    const items = [thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: true })];
+
+    await applyEventAttributions({
+      connectorKey: GMAIL_KEY,
+      feedKey: GMAIL_FEED,
+      orgId: org.id,
+      items: [
+        thread({
+          from_email: 'dana@acme.example',
+          from_name: 'Dana Fox',
+          outbound: true,
+          replied: false,
+          mintable: true,
+        }),
+      ],
+    });
+
+    // The old `replied` gate refused this thread; sending is now enough.
+    const people = await personRows(sql, org.id);
+    expect(people.map((p) => p.name)).toEqual(['Dana Fox']);
+  });
+
+  it('promotion is idempotent: re-syncing the same mintable thread never duplicates the contact', async () => {
+    const { org, sql } = await setupGmailOrg();
+    const items = [thread({ from_email: 'alice@example.com', from_name: 'Alice', outbound: true, replied: true, mintable: true })];
 
     await applyEventAttributions({ connectorKey: GMAIL_KEY, feedKey: GMAIL_FEED, orgId: org.id, items });
     await applyEventAttributions({ connectorKey: GMAIL_KEY, feedKey: GMAIL_FEED, orgId: org.id, items });
@@ -873,14 +896,14 @@ describe('gmail promote-on-interaction (real connector rule)', () => {
   it('an inbound-only thread from an already-promoted contact still links to it (match is never gated)', async () => {
     const { org, sql } = await setupGmailOrg();
 
-    // Promote Alice via a replied thread, then receive an inbound-only one.
+    // Promote Alice via a mintable thread, then receive an inbound-only one.
     await applyEventAttributions({
       connectorKey: GMAIL_KEY,
       feedKey: GMAIL_FEED,
       orgId: org.id,
-      items: [thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: true })],
+      items: [thread({ from_email: 'alice@example.com', from_name: 'Alice', outbound: true, replied: true, mintable: true })],
     });
-    const later = thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: false });
+    const later = thread({ from_email: 'alice@example.com', from_name: 'Alice', outbound: false, replied: false, mintable: false });
     await applyEventAttributions({
       connectorKey: GMAIL_KEY,
       feedKey: GMAIL_FEED,


### PR DESCRIPTION
## Why

Gmail minted a `person` whenever a thread was bidirectional (`metadata.replied`). Two problems with that gate:

- **Under-mints cold outbound.** You email someone new, they haven't replied yet — no contact. The most deliberate signal there is (you chose to write to them) produced nothing.
- **Inbound shapes the graph.** Receipt is a firehose of brands, newsletters, and no-reply senders. Even gated on `replied`, attribution was driven off the inbound `From`.

User intent: "gmail received we don't want but if we're sending we can mint."

## What

Promotion gates on `metadata.mintable`, computed entirely in the connector during sync. It is true only when we sent into the thread **and** a direct, non-self, non-list, non-role counterparty could be attributed.

Filters applied:
- **Self** — mailbox-owner addresses derived from the `From` of SENT messages
- **Role mailboxes** — `noreply`, `support`, `billing`, `notifications`, … (local-part, case-insensitive)
- **List mail** — any `List-Id`, or `Precedence` in {bulk, list, junk}
- **Broadcast cap** — >3 distinct external To+Cc on the opening SENT message does not mint unless someone replied
- **Directness** — must be on a To line of something we sent, or have written back to us

Attribution *skips* role mailboxes rather than attributing one and then failing on it. Emailing `support@vendor.com, Real Human <human@acme.com>` mints the human; a thread a bot opened and a colleague replied to mints the colleague.

The sync query now covers sent mail (`{label:X in:sent}`). Without this the feature ships dead — a cold outbound thread has no INBOX label, so it would never be fetched and `mintable` would never be computed for it.

`replied` is kept as a quality/metadata signal (it still relaxes the broadcast cap) but no longer gates creation. New `outbound` and `mintable` fields are documented in `metadataSchema`.

## Non-goals

- `send_email` / `reply` actions still do not mint — sync stays the sole mint path
- No SQL backfill; **re-sync is the backfill story**
- No changes to WhatsApp or other connectors, entity resolution, duplicate merge, `createWhen` language, or frontend
- The live `query()`/`search()` pushdown path is untouched and has no `mintable` notion

## Tests

**Connector unit — 20 passing** (`packages/connectors/src/__tests__/google_gmail.test.ts`). Each behavioral fix was verified red→green by individually reverting it and confirming the matching test fails:

- Inbound-only → never mints; cold single-recipient outbound → mints
- Role mailbox, List-Id, `Precedence: Bulk`, >3-recipient blast → refused; blast **with** a reply → mints
- Role address beside a human → mints the human
- Bot-opened thread with a human reply → attributes the human; bot-only → still refused
- Alias-case copy of our own send is not counted as a reply (would otherwise bypass the broadcast cap)
- SENT with no parseable `From` fails closed
- `createWhen` path asserted as `metadata.mintable`; checkpoint-before-request test still green

**End-to-end — 17 passing against a real Postgres** (`packages/server/src/utils/__tests__/entity-link-upsert.test.ts`). This suite drives the real connector definition through `applyEventAttributions`, so it proves `mintable` actually produces a `person` row rather than just a boolean. It encoded the old `replied` gate and is updated here, plus a new cold-outbound case the previous gate could not express. Verified red→green by reverting `createWhen` to `metadata.replied`.

`make pre-pr` clean. `make review-fix` run on the settled diff.

## CI note

`migrations` fails on this branch **and on `main`** with `CREATE INDEX CONCURRENTLY cannot run inside a transaction block` — pre-existing, unrelated to this diff (no migration files touched); `fix/drop-concurrently-from-migration` is already open for it. The 4 failing `integration` files (`watchers-*`, `client-sdk-business-errors`) likewise fail identically on `main`.

## Residual risk / follow-ups

- **Alias gap.** Self-detection derives from SENT `From` headers within the sync window. An alias you never sent from in that window isn't recognized as self, so a thread addressed to it could attribute you as your own contact.
- **Verify the feed is not virtual.** Minting happens via `entity-link-upsert` on the synced path. If a Gmail `threads` feed row is configured `virtual = true`, it is read live, no events persist, `createWhen` is never evaluated, and this change mints nothing. Unchanged from the previous `replied` gate, but confirm on buremba before expecting contacts: `SELECT virtual, schedule, checkpoint IS NOT NULL FROM feeds ...`.
- **Re-sync Gmail on buremba** to backfill, once the above is confirmed.
- Residual of closed #1626.
- No live-mailbox probe was run; all Gmail API interaction is fake-fixture tested.