### PR TITLE
fix(behaviors): parse raw text[] tags in create_from_version + align delete authz test

### DIFF
--- a/packages/server/src/__tests__/integration/client-sdk-business-errors.test.ts
+++ b/packages/server/src/__tests__/integration/client-sdk-business-errors.test.ts
@@ -108,14 +108,16 @@ describe("ClientSDK business failure boundary", () => {
 		});
 	});
 
-	it("throws when watchers.delete returns an all-failed aggregate", async () => {
+	it("throws 403 when watchers.delete targets an id outside the org", async () => {
+		// delete runs requireWatcherAccess as a preflight: an id that isn't in the
+		// caller's org (999999 here) is rejected 403 before the per-item aggregate,
+		// so existence never leaks across orgs.
 		await expect(
 			workspace.owner.behaviors.delete({ watcher_ids: ["999999"] })
 		).rejects.toMatchObject({
-			name: "ClientSdkActionError",
-			action: "delete",
-			message: "Behavior not found or already archived",
-			httpStatus: 400,
+			name: "ToolUserError",
+			message: "Access denied: one or more Behaviors were not found in your organization",
+			httpStatus: 403,
 		});
 	});
 });

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -3,7 +3,7 @@
  *   create, update, delete, create_from_version
  */
 
-import { getDb } from '../../../db/client';
+import { getDb, parsePgTextArray } from '../../../db/client';
 import type { Env } from '../../../index';
 import { ToolUserError } from '../../../utils/errors';
 import { isUniqueViolation } from '../../../utils/pg-errors';
@@ -775,7 +775,10 @@ export async function handleCreateFromVersion(
         // system:chat-link tag): those bind a live channel responder, and
         // cloning them would create a second agent turn for the same message.
         const cloneTriggers = stripChatLinkTriggers(version.triggers);
-        const cloneTags = ((version.tags as string[]) || []).filter(
+        // getDb() runs with fetch_types:false, so a text[] column arrives as a
+        // raw Postgres array literal (`{a,b}`), not a JS array — parse before
+        // filtering or `.filter` throws.
+        const cloneTags = parsePgTextArray(version.tags as string | string[]).filter(
           (tag) => tag !== 'system:chat-link',
         );
 


### PR DESCRIPTION
## Summary
Two regressions from the Watchers→Behaviors consolidation (#2023) that turned `main`'s CI red on the `integration` gate:

1. **`create_from_version` crashed on tags.** It reads `w.tags` via `getDb()` (which runs with `fetch_types:false`), so the `text[]` column arrives as a raw Postgres array literal (`{a,b}`), not a JS array. `(version.tags as string[]).filter(...)` therefore threw `filter is not a function`. Fixed by parsing with the existing `parsePgTextArray` helper before filtering.
2. **`delete` authz test was stale.** `delete` now runs `requireWatcherAccess` as a preflight, so deleting an id outside the caller's org returns `403 Access denied` (no cross-org existence oracle) instead of the old graceful per-item `400` aggregate. Updated the test to assert the new secure contract.

## Test plan (red→green)
- [x] `group-edit.test.ts`: 4 fail → 10 pass
- [x] `client-sdk-business-errors.test.ts`: 1 fail → 6 pass
- [x] Full watcher + business-error integration suite: 156 pass (was 10 failing)
- [x] `make pre-pr` (typecheck + knip + lint) clean

Unblocks the `integration` required check on #2013 and #2018.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->