### PR TITLE
refactor(behaviors): rename public watcher_id -> behavior_id + steer telemetry

### DIFF
--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -557,8 +557,21 @@ export class GatewayClient {
         data.messageId
       );
       if (steered) {
+        // Telemetry: tag whether this steer came from a Behavior (active_run:
+        // "steer") vs an ordinary human follow-up, so usage of the steer policy
+        // can be measured downstream (decide keep/drop of the knob on data).
         logger.info(
-          { traceId, messageId: data.messageId, conversationId },
+          {
+            traceId,
+            messageId: data.messageId,
+            conversationId,
+            steerSource: data.platformMetadata?.behaviorId
+              ? "behavior"
+              : "human",
+            behaviorId: data.platformMetadata?.behaviorId ?? null,
+            behaviorActiveRunPolicy:
+              data.platformMetadata?.behaviorActiveRunPolicy ?? null,
+          },
           "Message steered into active agent turn"
         );
         return;

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -162,7 +162,7 @@ describe("ApplyClient — prune", () => {
     });
   });
 
-  test("deleteBehavior POSTs manage_behaviors delete with watcher_ids array", async () => {
+  test("deleteBehavior POSTs manage_behaviors delete with behavior_ids array", async () => {
     const { calls, client } = recordingClient();
     await client.deleteBehavior("42");
     expect(calls[0]?.url).toBe(
@@ -170,7 +170,7 @@ describe("ApplyClient — prune", () => {
     );
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
       action: "delete",
-      watcher_ids: ["42"],
+      behavior_ids: ["42"],
     });
   });
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -1336,7 +1336,7 @@ describe("apply diff — prune", () => {
       ...emptyRemote(),
       entityTypes: [{ slug: "lead", properties: {} }, { slug: "stale-entity" }],
       relationshipTypes: [{ slug: "stale-rel" }],
-      watchers: [{ slug: "stale-watcher", watcher_id: "42" }],
+      watchers: [{ slug: "stale-watcher", behavior_id: "42" }],
       // stale-conn is dropped from config but exempt (drift); the connector "x"
       // it still uses must therefore be spared from prune.
       connections: [

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -859,13 +859,13 @@ export async function executePlan(
           keying_config: w.keyingConfig,
           classifiers: w.classifiers,
         });
-        watcherId = created.watcher_id;
+        watcherId = created.behavior_id;
       } else if (row.verb === "update") {
         const remote = remoteWatcherBySlug.get(w.slug);
-        watcherId = remote?.watcher_id;
+        watcherId = remote?.behavior_id;
         if (!watcherId) {
           throw new ApiError(
-            `update behavior "${w.slug}" failed: remote row is missing watcher_id (refetch may be stale)`
+            `update behavior "${w.slug}" failed: remote row is missing behavior_id (refetch may be stale)`
           );
         }
         const versionBound = new Set(row.versionBoundFields ?? []);
@@ -876,7 +876,7 @@ export async function executePlan(
         // a) Scalar fields → manage_behaviors update
         if (scalarChanges.length > 0) {
           await ctx.client.updateBehavior({
-            watcher_id: watcherId,
+            behavior_id: watcherId,
             ...(scalarChanges.includes("triggers")
               ? { triggers: w.triggers ?? [] }
               : {}),
@@ -914,7 +914,7 @@ export async function executePlan(
         //    send the desired-side values for the changed keys).
         if (row.versionBoundFields && row.versionBoundFields.length > 0) {
           await ctx.client.createBehaviorVersion({
-            watcher_id: watcherId,
+            behavior_id: watcherId,
             ...(versionBound.has("prompt") ? { prompt: w.prompt } : {}),
             ...(versionBound.has("sources") && w.sources !== undefined
               ? { sources: w.sources }
@@ -1129,7 +1129,7 @@ async function deleteRemovedDefinitions(ctx: ApplyContext): Promise<void> {
   const deletes = ctx.plan.rows.filter((r) => r.verb === "delete");
   if (deletes.length === 0) return;
   const watcherIdBySlug = new Map(
-    ctx.remote.watchers.map((w) => [w.slug, w.watcher_id])
+    ctx.remote.watchers.map((w) => [w.slug, w.behavior_id])
   );
   const steps: Array<[DiffRow["kind"], (id: string) => Promise<void>]> = [
     [
@@ -1138,7 +1138,7 @@ async function deleteRemovedDefinitions(ctx: ApplyContext): Promise<void> {
         const wid = watcherIdBySlug.get(id);
         if (!wid) {
           throw new ApiError(
-            `delete behavior "${id}": remote watcher_id missing`
+            `delete behavior "${id}": remote behavior_id missing`
           );
         }
         await ctx.client.deleteBehavior(wid);

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -94,7 +94,7 @@ export interface RemoteInferenceProvider {
 export interface RemoteBehavior {
   slug: string;
   name?: string;
-  watcher_id?: string;
+  behavior_id?: string;
   agent_id?: string | null;
   triggers?: import("@lobu/core/contracts/tools/manage-behaviors").BehaviorTrigger[];
   device_worker_id?: string | null;
@@ -894,7 +894,7 @@ export class ApplyClient {
         };
       }>(
         "GET",
-        `/api/${this.orgSlug}/behaviors?watcher_id=${encodeURIComponent(watcherId)}`
+        `/api/${this.orgSlug}/behaviors?behavior_id=${encodeURIComponent(watcherId)}`
       );
       return body.behavior ?? null;
     } catch (err) {
@@ -936,8 +936,8 @@ export class ApplyClient {
     agent_kind?: string;
     keying_config?: Record<string, unknown>;
     classifiers?: unknown[];
-  }): Promise<{ watcher_id?: string }> {
-    const { body } = await this.request<{ watcher_id?: string }>(
+  }): Promise<{ behavior_id?: string }> {
+    const { body } = await this.request<{ behavior_id?: string }>(
       "POST",
       `/api/${this.orgSlug}/manage_behaviors`,
       {
@@ -981,7 +981,7 @@ export class ApplyClient {
           : {}),
       }
     );
-    return { ...(body.watcher_id ? { watcher_id: body.watcher_id } : {}) };
+    return { ...(body.behavior_id ? { behavior_id: body.behavior_id } : {}) };
   }
 
   /**
@@ -994,7 +994,7 @@ export class ApplyClient {
    * agent_kind) per the server contract.
    */
   async updateBehavior(payload: {
-    watcher_id: string;
+    behavior_id: string;
     triggers?: import("@lobu/core/contracts/tools/manage-behaviors").BehaviorTrigger[];
     agent_id?: string;
     device_worker_id?: string | null;
@@ -1007,7 +1007,7 @@ export class ApplyClient {
   }): Promise<void> {
     await this.request("POST", `/api/${this.orgSlug}/manage_behaviors`, {
       action: "update",
-      watcher_id: payload.watcher_id,
+      behavior_id: payload.behavior_id,
       ...(payload.triggers !== undefined ? { triggers: payload.triggers } : {}),
       ...(payload.agent_id !== undefined ? { agent_id: payload.agent_id } : {}),
       ...(payload.device_worker_id !== undefined
@@ -1038,7 +1038,7 @@ export class ApplyClient {
    * inherits unset fields from the previous version row.
    */
   async createBehaviorVersion(payload: {
-    watcher_id: string;
+    behavior_id: string;
     prompt?: string;
     sources?: BehaviorSource[];
     keying_config?: Record<string, unknown>;
@@ -1051,7 +1051,7 @@ export class ApplyClient {
       `/api/${this.orgSlug}/manage_behaviors`,
       {
         action: "create_version",
-        watcher_id: payload.watcher_id,
+        behavior_id: payload.behavior_id,
         set_as_current: true,
         ...(payload.prompt !== undefined ? { prompt: payload.prompt } : {}),
         ...(payload.sources !== undefined ? { sources: payload.sources } : {}),
@@ -1082,20 +1082,20 @@ export class ApplyClient {
   ): Promise<void> {
     await this.request("POST", `/api/${this.orgSlug}/manage_behaviors`, {
       action: "set_reaction_script",
-      watcher_id: watcherId,
+      behavior_id: watcherId,
       reaction_script: reactionScript,
     });
   }
 
   /**
-   * Delete a watcher by its numeric `watcher_id` (code-managed prune). The
-   * admin tool takes an array; we delete one slug's watcher at a time so a
+   * Delete a Behavior by its numeric `behavior_id` (code-managed prune). The
+   * admin tool takes an array; we delete one slug's Behavior at a time so a
    * failure is attributable.
    */
   async deleteBehavior(watcherId: string): Promise<void> {
     await this.request("POST", `/api/${this.orgSlug}/manage_behaviors`, {
       action: "delete",
-      watcher_ids: [watcherId],
+      behavior_ids: [watcherId],
     });
   }
 

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -106,7 +106,7 @@ function fullOrgRoutes(): Record<string, () => unknown> {
         { agentId: "sales", name: "Sales", description: "Revenue agent" },
       ],
     }),
-    "behaviors?watcher_id": () => ({
+    "behaviors?behavior_id": () => ({
       behavior: {
         reaction_script:
           "export default async (ctx, client) => {\n  await client.knowledge.save({ content: 'ok', semantic_type: 'digest' });\n};\n",
@@ -117,7 +117,7 @@ function fullOrgRoutes(): Record<string, () => unknown> {
       behaviors: [
         {
           slug: "account-health",
-          watcher_id: "1",
+          behavior_id: "1",
           name: "Account health",
           agent_id: "sales",
           prompt: "Poll CRM data.",

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -879,8 +879,8 @@ async function fetchOrgState(
       .sort((a, b) => a.slug.localeCompare(b.slug))
       .map(async (watcher) => {
         let reactionScript: string | null = null;
-        if (watcher.watcher_id) {
-          const detail = await client.getBehaviorDetail(watcher.watcher_id);
+        if (watcher.behavior_id) {
+          const detail = await client.getBehaviorDetail(watcher.behavior_id);
           reactionScript = detail?.reaction_script ?? null;
           if (detail?.description && !watcher.description) {
             watcher.description = detail.description;

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3806,11 +3806,11 @@ export type ManageBehaviorsData = {
     /**
      * [update/upgrade/get_versions/get_version_details/set_reaction_script/trigger] Behavior ID (numeric string)
      */
-    watcher_id?: string;
+    behavior_id?: string;
     /**
      * [delete] Array of Behavior IDs (numeric strings)
      */
-    watcher_ids?: Array<string>;
+    behavior_ids?: Array<string>;
     /**
      * [create] Unique Behavior identifier
      */
@@ -4110,7 +4110,7 @@ export type ManageBehaviorsResponses = {
       }
     | {
         action: "create";
-        watcher_id: string;
+        behavior_id: string;
         version: number;
         status: string;
         sources?: Array<{
@@ -4122,19 +4122,19 @@ export type ManageBehaviorsResponses = {
       }
     | {
         action: "update";
-        watcher_id: string;
+        behavior_id: string;
         updated_fields: Array<string>;
       }
     | {
         action: "create_version";
-        watcher_id: string;
+        behavior_id: string;
         version_id: string;
         version: number;
         previous_version: number;
       }
     | {
         action: "complete_window";
-        watcher_id: string;
+        behavior_id: string;
         window_id: number;
         window_start: string;
         window_end: string;
@@ -4142,14 +4142,14 @@ export type ManageBehaviorsResponses = {
       }
     | {
         action: "trigger";
-        watcher_id: string;
+        behavior_id: string;
         run_id: number;
         status: string;
       }
     | {
         action: "delete";
         results: Array<{
-          watcher_id: string;
+          behavior_id: string;
           success: boolean;
           message: string;
           version?: number;
@@ -4162,18 +4162,18 @@ export type ManageBehaviorsResponses = {
       }
     | {
         action: "set_reaction_script";
-        watcher_id: string;
+        behavior_id: string;
         has_script: boolean;
         message: string;
       }
     | {
         action: "get_versions";
-        watcher_id: string;
+        behavior_id: string;
         versions: Array<unknown>;
       }
     | ({
         action: "get_version_details";
-        watcher_id: string;
+        behavior_id: string;
       } & {
         [key: string]: unknown;
       })
@@ -4183,13 +4183,13 @@ export type ManageBehaviorsResponses = {
       }
     | {
         action: "submit_feedback";
-        watcher_id: string;
+        behavior_id: string;
         window_id: number;
         feedback_ids: Array<number>;
       }
     | {
         action: "get_feedback";
-        watcher_id: string;
+        behavior_id: string;
         feedback: Array<{
           id: number;
           window_id: number;
@@ -4205,7 +4205,7 @@ export type ManageBehaviorsResponses = {
       }
     | {
         action: "list_promoted";
-        watcher_id: string;
+        behavior_id: string;
         entities: Array<{
           id: number;
           name: string;
@@ -4223,7 +4223,7 @@ export type ManageBehaviorsResponses = {
     | {
         action: "create_from_version";
         created: Array<{
-          watcher_id: string;
+          behavior_id: string;
           entity_id: number;
           name: string;
         }>;
@@ -4255,7 +4255,7 @@ export type GetBehaviorData = {
     /**
      * Behavior ID to query
      */
-    watcher_id: string;
+    behavior_id: string;
     /**
      * Optional entity ID for access validation and URL context
      */
@@ -4335,7 +4335,7 @@ export type GetBehaviorResponses = {
   200: {
     windows: Array<{
       window_id: number;
-      watcher_id: string;
+      behavior_id: string;
       watcher_name: string;
       granularity: string;
       window_start: string;
@@ -4376,7 +4376,7 @@ export type GetBehaviorResponses = {
       }>;
     }>;
     behavior?: {
-      watcher_id: string;
+      behavior_id: string;
       watcher_name: string;
       slug: string;
       status: "active" | "archived";

--- a/packages/core/src/__tests__/behavior-event-trigger.test.ts
+++ b/packages/core/src/__tests__/behavior-event-trigger.test.ts
@@ -80,7 +80,7 @@ describe("behavior event trigger", () => {
     expect(
       Value.Check(ManageBehaviorsSchema, {
         action: "update",
-        watcher_id: "1",
+        behavior_id: "1",
         schedule: "0 9 * * *",
         timezone: "Europe/London",
       })

--- a/packages/core/src/__tests__/normalize-watcher-update-patch.test.ts
+++ b/packages/core/src/__tests__/normalize-watcher-update-patch.test.ts
@@ -12,7 +12,7 @@ import {
  * server tools/admin/manage_behaviors/crud.ts handleUpdate.
  */
 const update = (extra: Partial<ManageBehaviorsArgs>): ManageBehaviorsArgs =>
-  ({ action: "update", watcher_id: "1", ...extra }) as ManageBehaviorsArgs;
+  ({ action: "update", behavior_id: "1", ...extra }) as ManageBehaviorsArgs;
 
 describe("normalizeBehaviorUpdatePatch", () => {
   it("only emits keys PRESENT in args (a PATCH — absent keys keep current)", () => {
@@ -97,7 +97,7 @@ describe("normalizeBehaviorUpdatePatch", () => {
     });
   });
 
-  it("excludes version-owned + routing fields (name/prompt/watcher_id/etc.)", () => {
+  it("excludes version-owned + routing fields (name/prompt/behavior_id/etc.)", () => {
     const p = normalizeBehaviorUpdatePatch(
       update({
         name: "X",
@@ -107,7 +107,7 @@ describe("normalizeBehaviorUpdatePatch", () => {
     );
     expect("name" in p).toBe(false);
     expect("prompt" in p).toBe(false);
-    expect("watcher_id" in p).toBe(false);
+    expect("behavior_id" in p).toBe(false);
     expect("action" in p).toBe(false);
     expect(p.triggers).toEqual([{ kind: "schedule", cron: "0 9 * * *" }]);
   });

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -240,14 +240,14 @@ export const ManageBehaviorsSchema = Type.Object(
       { description: "Action to perform" }
     ),
 
-    // Behavior identity (the persisted identifier is watcher_id)
-    watcher_id: Type.Optional(
+    // Behavior identity (the persisted DB column is watcher_id)
+    behavior_id: Type.Optional(
       Type.String({
         description:
           "[list/update/upgrade/get_versions/get_version_details/set_reaction_script/trigger] Behavior ID (numeric string)",
       })
     ),
-    watcher_ids: Type.Optional(
+    behavior_ids: Type.Optional(
       Type.Array(Type.String(), {
         description: "[delete] Array of Behavior IDs (numeric strings)",
       })
@@ -573,7 +573,7 @@ export type ManageBehaviorsArgs = Static<typeof ManageBehaviorsSchema>;
  *
  * EXCLUDES: name/description/prompt/sources (version-owned — an update can't
  * change them, changing them needs create_version) and routing keys
- * (action/watcher_id/entity_id/version_id). `next_run_at` is omitted too — a
+ * (action/behavior_id/entity_id/version_id). `next_run_at` is omitted too — a
  * DERIVED column, not a proposable field.
  */
 export type BehaviorUpdatePatch = Pick<
@@ -666,7 +666,7 @@ export function normalizeBehaviorUpdatePatch(
  * honest rather than a brittle mirror of shapes that are intentionally open.
  */
 export const ManageBehaviorsDeleteResultSchema = Type.Object({
-  watcher_id: Type.String(),
+  behavior_id: Type.String(),
   success: Type.Boolean(),
   message: Type.String(),
   version: Type.Optional(Type.Integer()),
@@ -706,7 +706,7 @@ export const ManageBehaviorsResultSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("create"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     version: Type.Integer(),
     status: Type.String(),
     sources: Type.Optional(Type.Array(BehaviorSourceSchema)),
@@ -714,19 +714,19 @@ export const ManageBehaviorsResultSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("update"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     updated_fields: Type.Array(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("create_version"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     version_id: Type.String(),
     version: Type.Integer(),
     previous_version: Type.Integer(),
   }),
   Type.Object({
     action: Type.Literal("complete_window"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     window_id: Type.Integer(),
     window_start: Type.String(),
     window_end: Type.String(),
@@ -734,7 +734,7 @@ export const ManageBehaviorsResultSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("trigger"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     run_id: Type.Integer(),
     status: Type.String(),
   }),
@@ -749,14 +749,14 @@ export const ManageBehaviorsResultSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("set_reaction_script"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     has_script: Type.Boolean(),
     message: Type.String(),
   }),
   // Intentionally permissive: version rows are arbitrary config snapshots.
   Type.Object({
     action: Type.Literal("get_versions"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     versions: Type.Array(Type.Unknown()),
   }),
   // Intentionally permissive: carries an open `[key: string]: any` index sig
@@ -766,7 +766,7 @@ export const ManageBehaviorsResultSchema = Type.Union([
   Type.Intersect([
     Type.Object({
       action: Type.Literal("get_version_details"),
-      watcher_id: Type.String(),
+      behavior_id: Type.String(),
     }),
     Type.Record(Type.String(), Type.Unknown()),
   ]),
@@ -779,25 +779,25 @@ export const ManageBehaviorsResultSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("submit_feedback"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     window_id: Type.Integer(),
     feedback_ids: Type.Array(Type.Integer()),
   }),
   Type.Object({
     action: Type.Literal("get_feedback"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     feedback: Type.Array(ManageBehaviorsFeedbackItemSchema),
   }),
   Type.Object({
     action: Type.Literal("list_promoted"),
-    watcher_id: Type.String(),
+    behavior_id: Type.String(),
     entities: Type.Array(ManageBehaviorsPromotedEntitySchema),
   }),
   Type.Object({
     action: Type.Literal("create_from_version"),
     created: Type.Array(
       Type.Object({
-        watcher_id: Type.String(),
+        behavior_id: Type.String(),
         entity_id: Type.Integer(),
         name: Type.String(),
       })
@@ -853,7 +853,7 @@ export interface ManageBehaviorsProposal {
 // The REST/list helper is a projection of the canonical flattened tool schema,
 // not a second hand-maintained contract that can drift from manage_behaviors.
 export const ListBehaviorsSchema = Type.Pick(ManageBehaviorsSchema, [
-  "watcher_id",
+  "behavior_id",
   "entity_id",
   "agent_id",
   "status",

--- a/packages/server/src/__tests__/integration/behaviors/agent-delete-archives-behaviors.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/agent-delete-archives-behaviors.test.ts
@@ -62,10 +62,10 @@ describe("agent delete archives its Behaviors", () => {
 				{} as Env,
 				ctx
 			);
-			if (result.action !== "create" || !("watcher_id" in result)) {
+			if (result.action !== "create" || !("behavior_id" in result)) {
 				throw new Error("Behavior creation did not complete");
 			}
-			return Number(result.watcher_id);
+			return Number(result.behavior_id);
 		};
 		const doomedBehavior = await create(agent.agentId, "doomed-chat-link");
 		const survivorBehavior = await create(
@@ -146,10 +146,10 @@ describe("agent delete archives its Behaviors", () => {
 				{} as Env,
 				ctx,
 			);
-			if (result.action !== "create" || !("watcher_id" in result)) {
+			if (result.action !== "create" || !("behavior_id" in result)) {
 				throw new Error("Behavior creation did not complete");
 			}
-			return Number(result.watcher_id);
+			return Number(result.behavior_id);
 		};
 
 		const behaviorA = await create(

--- a/packages/server/src/__tests__/integration/behaviors/channel-subscription-migration.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/channel-subscription-migration.test.ts
@@ -92,7 +92,7 @@ describe("Behavior channel-subscription migration", () => {
 			{} as Env,
 			ctx,
 		);
-		if (silent.action !== "create" || !("watcher_id" in silent)) {
+		if (silent.action !== "create" || !("behavior_id" in silent)) {
 			throw new Error("Silent Behavior creation did not complete");
 		}
 		const scheduled = await manageBehaviors(
@@ -113,10 +113,10 @@ describe("Behavior channel-subscription migration", () => {
 			{} as Env,
 			ctx,
 		);
-		if (scheduled.action !== "create" || !("watcher_id" in scheduled)) {
+		if (scheduled.action !== "create" || !("behavior_id" in scheduled)) {
 			throw new Error("Scheduled Behavior creation did not complete");
 		}
-		const scheduledBehaviorId = Number(scheduled.watcher_id);
+		const scheduledBehaviorId = Number(scheduled.behavior_id);
 		await sql`
 			UPDATE watchers SET triggers = '[]'::jsonb
 			WHERE id = ${scheduledBehaviorId}

--- a/packages/server/src/__tests__/integration/behaviors/event-activation-transaction.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/event-activation-transaction.test.ts
@@ -67,10 +67,10 @@ describe("Behavior activation transactionality", () => {
 			{} as Env,
 			ctx
 		);
-		if (created.action !== "create" || !("watcher_id" in created)) {
+		if (created.action !== "create" || !("behavior_id" in created)) {
 			throw new Error("Behavior creation did not complete");
 		}
-		const behaviorId = Number(created.watcher_id);
+		const behaviorId = Number(created.behavior_id);
 		const baseSignal = {
 			connector_key: "github",
 			connection_id: connection.id,

--- a/packages/server/src/__tests__/integration/behaviors/event-activation.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/event-activation.test.ts
@@ -59,10 +59,10 @@ describe("Behavior connector-event activation", () => {
 			{} as Env,
 			ctx
 		);
-		if (created.action !== "create" || !("watcher_id" in created)) {
+		if (created.action !== "create" || !("behavior_id" in created)) {
 			throw new Error("Behavior creation did not complete");
 		}
-		const behaviorId = Number(created.watcher_id);
+		const behaviorId = Number(created.behavior_id);
 
 		const signal = {
 			connector_key: "github",
@@ -112,7 +112,7 @@ describe("Behavior connector-event activation", () => {
 		`;
 		expect(stored?.triggers).toEqual([trigger]);
 		const detail = await getBehavior(
-			{ watcher_id: String(behaviorId) },
+			{ behavior_id: String(behaviorId) },
 			{} as Env,
 			ctx
 		);
@@ -165,10 +165,10 @@ describe("Behavior connector-event activation", () => {
 			{} as Env,
 			ctx
 		);
-		if (created.action !== "create" || !("watcher_id" in created)) {
+		if (created.action !== "create" || !("behavior_id" in created)) {
 			throw new Error("Behavior creation did not complete");
 		}
-		const behaviorId = Number(created.watcher_id);
+		const behaviorId = Number(created.behavior_id);
 		const baseSignal = {
 			connector_key: "github",
 			connection_id: connection.id,
@@ -248,10 +248,10 @@ describe("Behavior connector-event activation", () => {
 			{} as Env,
 			ctx
 		);
-		if (created.action !== "create" || !("watcher_id" in created)) {
+		if (created.action !== "create" || !("behavior_id" in created)) {
 			throw new Error("Behavior creation did not complete");
 		}
-		const behaviorId = Number(created.watcher_id);
+		const behaviorId = Number(created.behavior_id);
 		const signal = {
 			connector_key: "github",
 			connection_id: connection.id,
@@ -340,10 +340,10 @@ describe("Behavior connector-event activation", () => {
 			{} as Env,
 			ctx
 		);
-		if (created.action !== "create" || !("watcher_id" in created)) {
+		if (created.action !== "create" || !("behavior_id" in created)) {
 			throw new Error("Behavior creation did not complete");
 		}
-		const behaviorId = Number(created.watcher_id);
+		const behaviorId = Number(created.behavior_id);
 		const sql = getTestDb();
 		await sql`
 			UPDATE watchers
@@ -419,10 +419,10 @@ describe("Behavior connector-event activation", () => {
 				{} as Env,
 				ctx,
 			);
-			if (result.action !== "create" || !("watcher_id" in result)) {
+			if (result.action !== "create" || !("behavior_id" in result)) {
 				throw new Error("Behavior creation did not complete");
 			}
-			return Number(result.watcher_id);
+			return Number(result.behavior_id);
 		};
 		await create("skip-unchanged-deliveries", true);
 		const alwaysRunId = await create("run-unchanged-deliveries", false);

--- a/packages/server/src/__tests__/integration/behaviors/schedule-skip-unchanged.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/schedule-skip-unchanged.test.ts
@@ -48,10 +48,10 @@ describe("scheduled Behavior unchanged gate", () => {
 			{} as Env,
 			ctx,
 		);
-		if (created.action !== "create" || !("watcher_id" in created)) {
+		if (created.action !== "create" || !("behavior_id" in created)) {
 			throw new Error("Behavior creation did not complete");
 		}
-		const behaviorId = Number(created.watcher_id);
+		const behaviorId = Number(created.behavior_id);
 		const sql = getTestDb();
 		await sql`
 			UPDATE watchers
@@ -142,10 +142,10 @@ describe("scheduled Behavior unchanged gate", () => {
 			{} as Env,
 			ctx,
 		);
-		if (created.action !== "create" || !("watcher_id" in created)) {
+		if (created.action !== "create" || !("behavior_id" in created)) {
 			throw new Error("Behavior creation did not complete");
 		}
-		const behaviorId = Number(created.watcher_id);
+		const behaviorId = Number(created.behavior_id);
 		const sql = getTestDb();
 		const makeDue = () => sql`
 			UPDATE watchers

--- a/packages/server/src/__tests__/integration/classifiers/classifiers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifiers-crud.test.ts
@@ -47,8 +47,8 @@ describe('classifier CRUD', () => {
       name: 'Classifier Watcher',
       prompt: 'gather signals.',
       agent_id: agent.agentId,
-    })) as { watcher_id: string };
-    watcherId = w.watcher_id;
+    })) as { behavior_id: string };
+    watcherId = w.behavior_id;
   });
 
   it('creates → reads back → deletes a classifier', async () => {

--- a/packages/server/src/__tests__/integration/classifiers/classifiers-isolation.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifiers-isolation.test.ts
@@ -46,13 +46,13 @@ async function seedClassifier(workspace: TestWorkspace, slug: string): Promise<S
     name: `${slug} Watcher`,
     prompt: 'collect signals.',
     agent_id: agent.agentId,
-  })) as { watcher_id: string };
+  })) as { behavior_id: string };
 
   const created = (await workspace.owner.classifiers.create({
     slug,
     name: `${slug} Classifier`,
     attribute_key: slug,
-    watcher_id: watcher.watcher_id,
+    watcher_id: watcher.behavior_id,
     attribute_values: {
       positive: {
         description: 'positive signal',
@@ -77,7 +77,7 @@ async function seedClassifier(workspace: TestWorkspace, slug: string): Promise<S
   return {
     workspace,
     entityId: entity.entity.id,
-    watcherId: Number(watcher.watcher_id),
+    watcherId: Number(watcher.behavior_id),
     classifierId: created.data!.classifier_id,
     eventId: event.id,
   };

--- a/packages/server/src/__tests__/integration/client-sdk-business-errors.test.ts
+++ b/packages/server/src/__tests__/integration/client-sdk-business-errors.test.ts
@@ -110,7 +110,7 @@ describe("ClientSDK business failure boundary", () => {
 
 	it("throws when watchers.delete returns an all-failed aggregate", async () => {
 		await expect(
-			workspace.owner.behaviors.delete({ watcher_ids: ["999999"] })
+			workspace.owner.behaviors.delete({ behavior_ids: ["999999"] })
 		).rejects.toMatchObject({
 			name: "ClientSdkActionError",
 			action: "delete",

--- a/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
@@ -218,7 +218,7 @@ describe("channel streaming feeds", () => {
       prompt: "Respond to channel messages.",
       agent_id: agentId,
       triggers: [],
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
     const messageTrigger = {
       kind: "event" as const,
       connector_key: "slack",
@@ -232,7 +232,7 @@ describe("channel streaming feeds", () => {
     };
 
     await workspace.owner.behaviors.createVersion({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
       triggers: [messageTrigger],
     });
 
@@ -246,7 +246,7 @@ describe("channel streaming feeds", () => {
     expect(active[0]?.deleted_at).toBeNull();
 
     await workspace.owner.behaviors.createVersion({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
       triggers: [],
     });
 

--- a/packages/server/src/__tests__/integration/corrections/feedback-steady-state.test.ts
+++ b/packages/server/src/__tests__/integration/corrections/feedback-steady-state.test.ts
@@ -49,7 +49,7 @@ describe('feedback correction-events steady state (P1 phase 4)', () => {
 
     const submitted = await handleSubmitFeedback(
       {
-        watcher_id: watcherId,
+        behavior_id: watcherId,
         window_id: windowId,
         corrections: [
           { field_path: 'a', mutation: 'set', value: 'v', note: 'n' },
@@ -67,7 +67,7 @@ describe('feedback correction-events steady state (P1 phase 4)', () => {
     expect(reg[0].t).toBeNull();
 
     // get_feedback returns both, from events, with recovered ids + org scoping.
-    const got = (await handleGetFeedback({ watcher_id: watcherId } as never, ctx)) as {
+    const got = (await handleGetFeedback({ behavior_id: watcherId } as never, ctx)) as {
       feedback: Array<{ id: number; field_path: string; mutation: string; created_by: string }>;
     };
     expect(got.feedback).toHaveLength(2);

--- a/packages/server/src/__tests__/integration/prune.test.ts
+++ b/packages/server/src/__tests__/integration/prune.test.ts
@@ -170,11 +170,11 @@ describe('prune (server gate)', () => {
         slug: 'prune-watcher',
         agent_id: agent.agentId,
         prompt: 'Watch for things.',
-      })) as { watcher_id?: string };
-      expect(created.watcher_id).toBeTruthy();
+      })) as { behavior_id?: string };
+      expect(created.behavior_id).toBeTruthy();
 
       await owner.behaviors.delete({
-        watcher_ids: [created.watcher_id as string],
+        behavior_ids: [created.behavior_id as string],
       });
       const list = (await owner.behaviors.list({})) as {
         behaviors?: Array<{ slug: string }>;

--- a/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
@@ -235,7 +235,7 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 				note: "lists the seeded Behavior attached to the entity",
 			},
 			get_behavior: {
-				args: () => ({ watcher_id: watcherId, entity_id: entityId }),
+				args: () => ({ behavior_id: watcherId, entity_id: entityId }),
 				coverage: "round-trip",
 				note: "reads back the Behavior seeded in beforeAll",
 			},
@@ -349,9 +349,9 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 			},
 			TEST_ENV,
 			authCtx
-		)) as { watcher_id: string };
-		expect(watcher.watcher_id).toBeDefined();
-		watcherId = watcher.watcher_id;
+		)) as { behavior_id: string };
+		expect(watcher.behavior_id).toBeDefined();
+		watcherId = watcher.behavior_id;
 	});
 
 	it("covers every registry tool in the args fixture (catches new uncovered tools)", () => {

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
@@ -138,10 +138,10 @@ describe("manage_behaviors — builder gate e2e", () => {
 			},
 			TEST_ENV,
 			ownerCtx
-		)) as { action: string; watcher_id?: string; status?: string };
+		)) as { action: string; behavior_id?: string; status?: string };
 		// Immediate apply returns the watcher status ('active'), not pending_approval.
 		expect(res.status).not.toBe("pending_approval");
-		expect(res.watcher_id).toBeDefined();
+		expect(res.behavior_id).toBeDefined();
 		expect(await watcherExists(orgId, "human-watcher")).toBe(true);
 
 		const sql = getTestDb();
@@ -321,9 +321,9 @@ describe("manage_behaviors — builder gate e2e", () => {
 			},
 			TEST_ENV,
 			ownerCtx
-		)) as { watcher_id?: string; status?: string };
-		expect(created.watcher_id).toBeDefined();
-		const watcherId = created.watcher_id!;
+		)) as { behavior_id?: string; status?: string };
+		expect(created.behavior_id).toBeDefined();
+		const watcherId = created.behavior_id!;
 
 		// Agent proposes an update with a bad timezone — queues for approval.
 		// handleUpdate returns `{ error }` (does not throw); the apply boundary
@@ -332,7 +332,7 @@ describe("manage_behaviors — builder gate e2e", () => {
 			"manage_behaviors",
 			{
 				action: "update",
-				watcher_id: watcherId,
+				behavior_id: watcherId,
 				triggers: [
 					{
 						kind: "schedule",
@@ -386,12 +386,12 @@ describe("manage_behaviors — builder gate e2e", () => {
 			},
 			TEST_ENV,
 			ownerCtx
-		)) as { watcher_id?: string };
-		const watcherId = created.watcher_id!;
+		)) as { behavior_id?: string };
+		const watcherId = created.behavior_id!;
 		await expect(
 			executeTool(
 				"manage_behaviors",
-				{ action: "update", watcher_id: watcherId },
+				{ action: "update", behavior_id: watcherId },
 				TEST_ENV,
 				agentCtx
 			)
@@ -410,12 +410,12 @@ describe("manage_behaviors — builder gate e2e", () => {
 			},
 			TEST_ENV,
 			ownerCtx
-		)) as { watcher_id?: string };
-		const watcherId = created.watcher_id!;
+		)) as { behavior_id?: string };
+		const watcherId = created.behavior_id!;
 		await expect(
 			executeTool(
 				"manage_behaviors",
-				{ action: "set_reaction_script", watcher_id: watcherId },
+				{ action: "set_reaction_script", behavior_id: watcherId },
 				TEST_ENV,
 				agentCtx
 			)
@@ -435,8 +435,8 @@ describe("manage_behaviors — builder gate e2e", () => {
 			},
 			TEST_ENV,
 			ownerCtx
-		)) as { watcher_id?: string };
-		const watcherId = created.watcher_id!;
+		)) as { behavior_id?: string };
+		const watcherId = created.behavior_id!;
 		expect(watcherId).toBeDefined();
 
 		// Agent A queues an update. The proposal captures A as the acting agent.
@@ -444,7 +444,7 @@ describe("manage_behaviors — builder gate e2e", () => {
 			"manage_behaviors",
 			{
 				action: "update",
-				watcher_id: watcherId,
+				behavior_id: watcherId,
 				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
 			},
 			TEST_ENV,

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
@@ -119,8 +119,8 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 			},
 			TEST_ENV,
 			ownerCtx
-		)) as { watcher_id?: string };
-		watcherId = created.watcher_id!;
+		)) as { behavior_id?: string };
+		watcherId = created.behavior_id!;
 	});
 
 	async function fetchWatcherName(): Promise<string> {
@@ -161,7 +161,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 		await expect(
 			executeTool(
 				"manage_behaviors",
-				{ action: "update", watcher_id: watcherId, name: "Renamed" },
+				{ action: "update", behavior_id: watcherId, name: "Renamed" },
 				TEST_ENV,
 				ownerCtx
 			)
@@ -174,7 +174,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 		await expect(
 			executeTool(
 				"manage_behaviors",
-				{ action: "update", watcher_id: watcherId, description: "New desc" },
+				{ action: "update", behavior_id: watcherId, description: "New desc" },
 				TEST_ENV,
 				ownerCtx
 			)
@@ -185,7 +185,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 		await expect(
 			executeTool(
 				"manage_behaviors",
-				{ action: "update", watcher_id: watcherId, prompt: "New prompt" },
+				{ action: "update", behavior_id: watcherId, prompt: "New prompt" },
 				TEST_ENV,
 				ownerCtx
 			)
@@ -198,7 +198,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 				"manage_behaviors",
 				{
 					action: "update",
-					watcher_id: watcherId,
+					behavior_id: watcherId,
 					sources: [{ name: "content", query: "SELECT 1" }],
 				},
 				TEST_ENV,
@@ -216,7 +216,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 				"manage_behaviors",
 				{
 					action: "update",
-					watcher_id: watcherId,
+					behavior_id: watcherId,
 					name: "Should Not Apply",
 					triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
 				},
@@ -233,7 +233,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 			"manage_behaviors",
 			{
 				action: "update",
-				watcher_id: watcherId,
+				behavior_id: watcherId,
 				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
 			},
 			TEST_ENV,
@@ -248,7 +248,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 			"manage_behaviors",
 			{
 				action: "create_version",
-				watcher_id: watcherId,
+				behavior_id: watcherId,
 				name: "Renamed Via Version",
 				set_as_current: true,
 			},
@@ -263,7 +263,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 			"manage_behaviors",
 			{
 				action: "update",
-				watcher_id: previewUpdate.watcherId,
+				behavior_id: previewUpdate.watcherId,
 				triggers: previewUpdate.triggers,
 				tags: ["system:chat-link", "edited"],
 			},
@@ -285,7 +285,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 				"manage_behaviors",
 				{
 					action: "update",
-					watcher_id: previewUpdate.watcherId,
+					behavior_id: previewUpdate.watcherId,
 					triggers: changedTriggers,
 				},
 				TEST_ENV,
@@ -299,7 +299,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 			"manage_behaviors",
 			{
 				action: "create_version",
-				watcher_id: previewVersion.watcherId,
+				behavior_id: previewVersion.watcherId,
 				prompt: "Updated preview response instructions.",
 			},
 			TEST_ENV,

--- a/packages/server/src/__tests__/integration/watchers-feeds-timezone.test.ts
+++ b/packages/server/src/__tests__/integration/watchers-feeds-timezone.test.ts
@@ -67,8 +67,8 @@ describe('watchers/feeds timezone-aware schedules', () => {
       prompt: 'Summarize {{entities}}.',
       triggers: [{ kind: 'schedule', cron: '0 9 * * *', timezone: 'Asia/Taipei' }],
       agent_id: 'tz-watcher-agent',
-    })) as { watcher_id: string };
-    const watcherId = Number(created.watcher_id);
+    })) as { behavior_id: string };
+    const watcherId = Number(created.behavior_id);
 
     const sql = getTestDb();
     const [row] = await sql`
@@ -97,15 +97,15 @@ describe('watchers/feeds timezone-aware schedules', () => {
       prompt: 'Summarize {{entities}}.',
       triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
       agent_id: 'tz-watcher-agent',
-    })) as { watcher_id: string };
-    const watcherId = Number(created.watcher_id);
+    })) as { behavior_id: string };
+    const watcherId = Number(created.behavior_id);
 
     const sql = getTestDb();
     const [before] = await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
     expect(utcHour(before.next_run_at)).toBe(serverTimeNineAmUtcHour());
 
     await workspace.owner.behaviors.update({
-      watcher_id: watcherId,
+      behavior_id: watcherId,
       triggers: [{ kind: 'schedule', cron: '0 9 * * *', timezone: 'Asia/Taipei' }],
     });
     const [after] = await sql`

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -102,8 +102,8 @@ async function createAutomatedWatcher() {
 			},
 		],
 		agent_id: agent.agentId,
-	})) as { watcher_id: string };
-	const watcherId = Number(watcher.watcher_id);
+	})) as { behavior_id: string };
+	const watcherId = Number(watcher.behavior_id);
 
 	await sql`
     UPDATE watchers
@@ -265,7 +265,7 @@ describe("watcher automation contract", () => {
 		).toContain("Summarize content for Automation Entity.");
 
 		const completion = (await api.behaviors.completeWindow({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 			window_token: content.window_token,
 			extracted_data: { summary: "Automated watcher summary" },
 			run_metadata: {
@@ -415,7 +415,7 @@ describe("watcher automation contract", () => {
 		expect(page2.page.has_more).toBe(true);
 
 		const completion = (await api.behaviors.completeWindow({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 			window_tokens: [page1.window_token, page2.window_token],
 			extracted_data: { summary: "Summary across two pages" },
 		})) as { action: string; window_id: number; content_linked: number };
@@ -464,7 +464,7 @@ describe("watcher automation contract", () => {
 		);
 
 		const completion = (await api.behaviors.completeWindow({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 			window_token: windowToken,
 			extracted_data: { summary: "Summary from exact content IDs" },
 		})) as { action: string; window_id: number; content_linked: number };
@@ -573,7 +573,7 @@ describe("watcher automation contract", () => {
 				window_token: string;
 			};
 			const completion = (await api.behaviors.completeWindow({
-				watcher_id: String(watcherId),
+				behavior_id: String(watcherId),
 				window_token: content.window_token,
 				extracted_data: { summary: "Looked at 5 events, no anomalies." },
 				model: "device-cli:claude-code",
@@ -703,7 +703,7 @@ describe("watcher automation contract", () => {
 				window_token: string;
 			};
 			await api.behaviors.completeWindow({
-				watcher_id: String(watcherId),
+				behavior_id: String(watcherId),
 				window_token: content.window_token,
 				extracted_data: { summary: "No-duration exit report case." },
 				run_metadata: {
@@ -745,7 +745,7 @@ describe("watcher automation contract", () => {
 			const { sql, dbClient, workspace, api, watcherId, agent } =
 				await createAutomatedWatcher();
 			await api.behaviors.setReactionScript({
-				watcher_id: String(watcherId),
+				behavior_id: String(watcherId),
 				reaction_script: "export default async function reaction() { return; }",
 			});
 
@@ -775,7 +775,7 @@ describe("watcher automation contract", () => {
 				window_token: string;
 			};
 			const completion = (await api.behaviors.completeWindow({
-				watcher_id: String(watcherId),
+				behavior_id: String(watcherId),
 				window_token: content.window_token,
 				extracted_data: { summary: "Device-run result, no server content." },
 				run_metadata: { source: "device_worker", watcher_run_id: queued.runId },
@@ -802,7 +802,7 @@ describe("watcher automation contract", () => {
 
 			// The window surfaces its reaction log through get_behavior.
 			const detail = (await api.behaviors.get({
-				watcher_id: String(watcherId),
+				behavior_id: String(watcherId),
 			})) as {
 				windows: Array<{
 					window_id: number;
@@ -824,7 +824,7 @@ describe("watcher automation contract", () => {
 		it("fires the reaction script on a zero-content replace_existing (head_superseded gate)", async () => {
 			const { api, watcherId } = await createAutomatedWatcher();
 			await api.behaviors.setReactionScript({
-				watcher_id: String(watcherId),
+				behavior_id: String(watcherId),
 				reaction_script: "export default async function reaction() { return; }",
 			});
 			const windowStart = new Date(
@@ -846,13 +846,13 @@ describe("watcher automation contract", () => {
 				);
 
 			const first = (await api.behaviors.completeWindow({
-				watcher_id: String(watcherId),
+				behavior_id: String(watcherId),
 				window_token: await mint(),
 				extracted_data: { summary: "v1" },
 			})) as { window_id: number };
 
 			const replaced = (await api.behaviors.completeWindow({
-				watcher_id: String(watcherId),
+				behavior_id: String(watcherId),
 				window_token: await mint(),
 				extracted_data: { summary: "v2 re-analysis" },
 				replace_existing: true,
@@ -1616,8 +1616,8 @@ describe("watcher automation contract", () => {
 					},
 				],
 				agent_id: agent.agentId,
-			})) as { watcher_id: string };
-			const watcherBId = Number(watcherB.watcher_id);
+			})) as { behavior_id: string };
+			const watcherBId = Number(watcherB.behavior_id);
 			await sql`UPDATE watchers SET next_run_at = NOW() - INTERVAL '10 minutes' WHERE id = ${watcherBId}`;
 
 			const result = await runWatcherAutomationTick({} as Env);
@@ -1917,7 +1917,7 @@ describe("canvas-on-events window completion", () => {
 			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env
 		);
 		const completion = (await api.behaviors.completeWindow({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 			window_token: windowToken,
 			extracted_data: overrides.extracted_data ?? {
 				summary: "v1 canvas summary",
@@ -2001,7 +2001,7 @@ describe("canvas-on-events window completion", () => {
 			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env
 		);
 		const retry = (await api.behaviors.completeWindow({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 			window_token: retryToken,
 			extracted_data: { summary: "v2 changed but not a replace" },
 		})) as { window_id: number; window_created: boolean };
@@ -2049,7 +2049,7 @@ describe("canvas-on-events window completion", () => {
 			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env
 		);
 		await api.behaviors.completeWindow({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 			window_token: windowToken,
 			extracted_data: { summary: "v2" },
 			replace_existing: true,
@@ -2081,7 +2081,7 @@ describe("canvas-on-events window completion", () => {
 
 		// The read flip surfaces the HEAD payload via get_behavior.
 		const view = (await api.behaviors.get({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 		})) as {
 			windows: Array<{ extracted_data: Record<string, unknown> }>;
 		};
@@ -2123,7 +2123,7 @@ describe("canvas-on-events window completion", () => {
 			env
 		);
 		const first = (await api.behaviors.completeWindow({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 			window_token: tokenA,
 			extracted_data: { summary: "v1 over A" },
 		})) as { window_id: number };
@@ -2140,7 +2140,7 @@ describe("canvas-on-events window completion", () => {
 			env
 		);
 		const second = (await api.behaviors.completeWindow({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 			window_token: tokenB,
 			extracted_data: { summary: "v2 over B" },
 			replace_existing: true,
@@ -2175,7 +2175,7 @@ describe("canvas-on-events window completion", () => {
 			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env
 		);
 		await api.behaviors.completeWindow({
-			watcher_id: String(watcherId),
+			behavior_id: String(watcherId),
 			window_token: windowToken,
 			extracted_data: { summary: "v2" },
 			replace_existing: true,

--- a/packages/server/src/__tests__/integration/watchers/backfill-reaction-input-schema.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/backfill-reaction-input-schema.test.ts
@@ -56,12 +56,12 @@ async function seedReactionWatcher(workspace: TestWorkspace, suffix: string, scr
     prompt: 'Summarize {{entities}}.',
     triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
     agent_id: agent.agentId,
-  })) as { watcher_id: string };
-  const watcherId = Number(watcher.watcher_id);
+  })) as { behavior_id: string };
+  const watcherId = Number(watcher.behavior_id);
   await manageBehaviors(
     {
       action: 'set_reaction_script',
-      watcher_id: String(watcherId),
+      behavior_id: String(watcherId),
       reaction_script: script,
     } as never,
     {} as Env,

--- a/packages/server/src/__tests__/integration/watchers/feedback-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/feedback-contract.test.ts
@@ -47,12 +47,12 @@ async function seedWatcher(workspace: TestWorkspace, suffix: string) {
     name: `Feedback Watcher ${suffix}`,
     prompt: 'Analyze inputs.',
     agent_id: agent.agentId,
-  })) as { watcher_id: string };
+  })) as { behavior_id: string };
 
   // Canvas-on-events: the window is a canvas_state chain root; its event id is
   // the window_id the feedback API keys on.
   const windowId = await createCanvasWindow({
-    watcherId: Number(watcher.watcher_id),
+    watcherId: Number(watcher.behavior_id),
     organizationId: workspace.org.id,
     granularity: 'weekly',
     windowStart: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
@@ -62,7 +62,7 @@ async function seedWatcher(workspace: TestWorkspace, suffix: string) {
     entityIds: [entity.id],
   });
 
-  return { watcherId: watcher.watcher_id, windowId };
+  return { watcherId: watcher.behavior_id, windowId };
 }
 
 describe('watcher feedback contract', () => {
@@ -95,7 +95,7 @@ describe('watcher feedback contract', () => {
     const result = (await manageBehaviors(
       {
         action: 'submit_feedback',
-        watcher_id: watcherId,
+        behavior_id: watcherId,
         window_id: windowId,
         corrections: [
           {
@@ -147,7 +147,7 @@ describe('watcher feedback contract', () => {
     const result = (await manageBehaviors(
       {
         action: 'submit_feedback',
-        watcher_id: watcherId,
+        behavior_id: watcherId,
         window_id: windowId,
         corrections: [{ field_path: 'summary', value: 'id-contract', note: 'id check' }],
       } as never,
@@ -174,7 +174,7 @@ describe('watcher feedback contract', () => {
     const feedback = (await manageBehaviors(
       {
         action: 'get_feedback',
-        watcher_id: watcherId,
+        behavior_id: watcherId,
         window_id: windowId,
       } as never,
       {} as never,
@@ -200,7 +200,7 @@ describe('watcher feedback contract', () => {
     await manageBehaviors(
       {
         action: 'submit_feedback',
-        watcher_id: watcherId,
+        behavior_id: watcherId,
         window_id: windowId,
         corrections: [{ field_path: 'current', value: 1 }],
       } as never,
@@ -210,7 +210,7 @@ describe('watcher feedback contract', () => {
     await manageBehaviors(
       {
         action: 'submit_feedback',
-        watcher_id: watcherId,
+        behavior_id: watcherId,
         window_id: otherWindowId,
         corrections: [{ field_path: 'other', value: 2 }],
       } as never,
@@ -221,7 +221,7 @@ describe('watcher feedback contract', () => {
     const filtered = (await manageBehaviors(
       {
         action: 'get_feedback',
-        watcher_id: watcherId,
+        behavior_id: watcherId,
         window_id: otherWindowId,
       } as never,
       {} as never,
@@ -237,7 +237,7 @@ describe('watcher feedback contract', () => {
       manageBehaviors(
         {
           action: 'submit_feedback',
-          watcher_id: watcherId,
+          behavior_id: watcherId,
           window_id: windowId,
           corrections: [],
         } as never,
@@ -250,7 +250,7 @@ describe('watcher feedback contract', () => {
       manageBehaviors(
         {
           action: 'submit_feedback',
-          watcher_id: watcherId,
+          behavior_id: watcherId,
           window_id: windowId,
           corrections: [{ field_path: 'problems[0]', mutation: 'patch', value: 'x' }],
         } as never,
@@ -267,7 +267,7 @@ describe('watcher feedback contract', () => {
       manageBehaviors(
         {
           action: 'submit_feedback',
-          watcher_id: foreign.watcherId,
+          behavior_id: foreign.watcherId,
           window_id: foreign.windowId,
           corrections: [{ field_path: 'problems[0]', value: 'x' }],
         } as never,
@@ -296,7 +296,7 @@ describe('watcher feedback contract', () => {
     const result = (await manageBehaviors(
       {
         action: 'submit_feedback',
-        watcher_id: seeded.watcherId,
+        behavior_id: seeded.watcherId,
         window_id: seeded.windowId,
         corrections: [{ field_path: 'problems[0].severity', value: 'high' }],
       } as never,
@@ -339,7 +339,7 @@ describe('watcher feedback contract', () => {
     await manageBehaviors(
       {
         action: 'submit_feedback',
-        watcher_id: seeded.watcherId,
+        behavior_id: seeded.watcherId,
         window_id: seeded.windowId,
         corrections: [{ field_path: 'problems[0].severity', value: 'high' }],
       } as never,
@@ -394,7 +394,7 @@ describe('watcher feedback contract', () => {
     const result = (await manageBehaviors(
       {
         action: 'submit_feedback',
-        watcher_id: seeded.watcherId,
+        behavior_id: seeded.watcherId,
         window_id: seeded.windowId,
         corrections: [
           { field_path: '__proto__.polluted', value: 'evil' },
@@ -439,7 +439,7 @@ describe('watcher feedback contract', () => {
       manageBehaviors(
         {
           action: 'submit_feedback',
-          watcher_id: seeded.watcherId,
+          behavior_id: seeded.watcherId,
           window_id: 999_999_999,
           corrections: [{ field_path: 'problems[0].severity', value: 'high' }],
         } as never,

--- a/packages/server/src/__tests__/integration/watchers/group-edit.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/group-edit.test.ts
@@ -57,8 +57,8 @@ async function seedRootWatcher(workspace: TestWorkspace, suffix: string) {
     prompt: 'Summarize content for {{entities}}.',
     triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
     agent_id: agent.agentId,
-  })) as { watcher_id: string };
-  return { watcherId: Number(watcher.watcher_id), entityId: entity.id };
+  })) as { behavior_id: string };
+  return { watcherId: Number(watcher.behavior_id), entityId: entity.id };
 }
 
 async function assignToEntity(
@@ -74,8 +74,8 @@ async function assignToEntity(
     } as never,
     {} as Env,
     ownerCtx(workspace)
-  )) as { created: Array<{ watcher_id: string }> };
-  return Number(result.created[0].watcher_id);
+  )) as { created: Array<{ behavior_id: string }> };
+  return Number(result.created[0].behavior_id);
 }
 
 describe('watcher group edit contract', () => {
@@ -138,7 +138,7 @@ describe('watcher group edit contract', () => {
     await manageBehaviors(
       {
         action: 'set_reaction_script',
-        watcher_id: String(rootId),
+        behavior_id: String(rootId),
         // Declares an `input` contract → reaction_input_schema is populated. A
         // clone must carry BOTH the script and the schema, else the cloned
         // reaction silently loses its extraction contract (runs free-form).
@@ -184,7 +184,7 @@ describe('watcher group edit contract', () => {
     await manageBehaviors(
       {
         action: 'set_reaction_script',
-        watcher_id: String(rootId),
+        behavior_id: String(rootId),
         // `input` is a PLAIN JSON Schema (no typebox — it breaks the isolate
         // client). The host validates extracted_data against it.
         reaction_script:
@@ -207,7 +207,7 @@ describe('watcher group edit contract', () => {
     await manageBehaviors(
       {
         action: 'set_reaction_script',
-        watcher_id: String(rootId),
+        behavior_id: String(rootId),
         reaction_script: '',
       } as never,
       {} as Env,
@@ -251,7 +251,7 @@ describe('watcher group edit contract', () => {
     const result = (await manageBehaviors(
       {
         action: 'create_version',
-        watcher_id: String(sibling1Id),
+        behavior_id: String(sibling1Id),
         prompt: 'Cascaded prompt v2.',
         name: 'Cascaded Name v2',
         change_notes: 'group cascade',
@@ -302,7 +302,7 @@ describe('watcher group edit contract', () => {
     await manageBehaviors(
       {
         action: 'set_reaction_script',
-        watcher_id: String(rootId),
+        behavior_id: String(rootId),
         reaction_script: 'export default async function reaction() { /* v1 */ }',
       } as never,
       {} as Env,
@@ -319,7 +319,7 @@ describe('watcher group edit contract', () => {
     await manageBehaviors(
       {
         action: 'set_reaction_script',
-        watcher_id: String(siblingId),
+        behavior_id: String(siblingId),
         reaction_script: '',
       } as never,
       {} as Env,
@@ -357,7 +357,7 @@ describe('watcher group edit contract', () => {
     await manageBehaviors(
       {
         action: 'create_version',
-        watcher_id: String(rootId),
+        behavior_id: String(rootId),
         prompt: 'Post-run edit.',
         change_notes: 'after run created',
       } as never,
@@ -434,7 +434,7 @@ describe('watcher group edit contract', () => {
     await manageBehaviors(
       {
         action: 'create_version',
-        watcher_id: String(aId),
+        behavior_id: String(aId),
         prompt: "A's v2",
         change_notes: 'bump A',
       } as never,
@@ -473,7 +473,7 @@ describe('watcher group edit contract', () => {
       manageBehaviors(
         {
           action: 'create_version',
-          watcher_id: String(rootId),
+          behavior_id: String(rootId),
           prompt: 'edit A',
           change_notes: 'A',
         } as never,
@@ -483,7 +483,7 @@ describe('watcher group edit contract', () => {
       manageBehaviors(
         {
           action: 'create_version',
-          watcher_id: String(rootId),
+          behavior_id: String(rootId),
           prompt: 'edit B',
           change_notes: 'B',
         } as never,

--- a/packages/server/src/__tests__/integration/watchers/manual-trigger.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/manual-trigger.test.ts
@@ -109,8 +109,8 @@ async function setupDevicePinnedWatcher(opts: { workerId: string }): Promise<{
     prompt: 'Summarize {{entities}}.',
     triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
     agent_id: agent.agentId,
-  })) as { watcher_id: string };
-  const watcherId = Number(watcher.watcher_id);
+  })) as { behavior_id: string };
+  const watcherId = Number(watcher.behavior_id);
 
   // Pin the watcher to the device. `WatcherCreateInput` doesn't expose
   // device_worker_id / agent_kind, so set them directly — matches how
@@ -476,7 +476,7 @@ describe('POST /api/workers/me/behaviors/:watcher_id/trigger', () => {
     const v2 = (await manageBehaviors(
       {
         action: 'create_version',
-        watcher_id: String(ctx.watcherId),
+        behavior_id: String(ctx.watcherId),
         prompt: 'EDITED-AFTER-QUEUE prompt v2.',
         change_notes: 'edit after queue',
       } as never,

--- a/packages/server/src/__tests__/integration/watchers/ownership-gate.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/ownership-gate.test.ts
@@ -103,9 +103,9 @@ async function seedWatcherAndWindow(workspace: TestWorkspace, suffix: string) {
     name: `Gate Watcher ${suffix}`,
     prompt: 'Analyze inputs.',
     agent_id: agent.agentId,
-  })) as { watcher_id: string };
+  })) as { behavior_id: string };
   const windowId = await createCanvasWindow({
-    watcherId: Number(watcher.watcher_id),
+    watcherId: Number(watcher.behavior_id),
     organizationId: workspace.org.id,
     granularity: 'weekly',
     windowStart: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
@@ -116,7 +116,7 @@ async function seedWatcherAndWindow(workspace: TestWorkspace, suffix: string) {
   });
   return {
     entity,
-    watcherId: Number(watcher.watcher_id),
+    watcherId: Number(watcher.behavior_id),
     windowId,
     agentId: agent.agentId,
   };

--- a/packages/server/src/__tests__/integration/watchers/pending-non-event-uniq.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/pending-non-event-uniq.test.ts
@@ -73,12 +73,12 @@ async function setupWatcher() {
     prompt: 'Summarize {{entities}}.',
     triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
     agent_id: agent.agentId,
-  })) as { watcher_id: string };
+  })) as { behavior_id: string };
 
   return {
     sql,
     workspace,
-    watcherId: Number(watcher.watcher_id),
+    watcherId: Number(watcher.behavior_id),
     agentId: agent.agentId,
   };
 }

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -118,8 +118,8 @@ async function setupKeyedWatcher() {
     keying_config: KEYING_CONFIG,
     triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
     agent_id: agent.agentId,
-  })) as { watcher_id: string };
-  const watcherId = Number(watcher.watcher_id);
+  })) as { behavior_id: string };
+  const watcherId = Number(watcher.behavior_id);
 
   await sql`UPDATE watchers SET next_run_at = NOW() - INTERVAL '10 minutes' WHERE id = ${watcherId}`;
 
@@ -186,7 +186,7 @@ async function completeWithToken(
   extractedData: Record<string, unknown> = KEYED_EXTRACTED_DATA
 ): Promise<number> {
   const completion = (await ctx.api.behaviors.completeWindow({
-    watcher_id: String(ctx.watcherId),
+    behavior_id: String(ctx.watcherId),
     window_token: windowToken,
     extracted_data: extractedData,
     run_metadata: { watcher_run_id: runId },
@@ -406,7 +406,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
 
     // Run 1: a non-key `severity` field is synced into the promoted entity's metadata.
     await ctx.api.behaviors.completeWindow({
-      watcher_id: String(ctx.watcherId),
+      behavior_id: String(ctx.watcherId),
       window_token: token,
       run_metadata: { watcher_run_id: runId },
       extracted_data: {
@@ -446,7 +446,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
 
     // Run 2 (replay) proposes a different severity for the SAME key.
     await ctx.api.behaviors.completeWindow({
-      watcher_id: String(ctx.watcherId),
+      behavior_id: String(ctx.watcherId),
       window_token: token,
       run_metadata: { watcher_run_id: runId },
       extracted_data: {
@@ -481,7 +481,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     // Idempotency: replaying the SAME window again must NOT stack a second
     // pending approval card (complete_window is replay-safe under retries/replicas).
     await ctx.api.behaviors.completeWindow({
-      watcher_id: String(ctx.watcherId),
+      behavior_id: String(ctx.watcherId),
       window_token: token,
       run_metadata: { watcher_run_id: runId },
       extracted_data: {
@@ -530,7 +530,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
 
     // Run 1 seeds the entity; human then owns `severity` at 'high'.
     await ctx.api.behaviors.completeWindow({
-      watcher_id: String(watcherId),
+      behavior_id: String(watcherId),
       window_token: token,
       run_metadata: { watcher_run_id: runId },
       extracted_data: {
@@ -553,7 +553,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
 
     // Run 2: watcher proposes 'critical' against the 'high' snapshot → pending approval.
     await ctx.api.behaviors.completeWindow({
-      watcher_id: String(watcherId),
+      behavior_id: String(watcherId),
       window_token: token,
       run_metadata: { watcher_run_id: runId },
       extracted_data: {
@@ -609,7 +609,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     const runId = await queueRunningRun(ctx);
     const token = await readWindowToken(ctx);
     const windowId = await ctx.api.behaviors.completeWindow({
-      watcher_id: String(watcherId),
+      behavior_id: String(watcherId),
       window_token: token,
       run_metadata: { watcher_run_id: runId },
       extracted_data: {
@@ -635,7 +635,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
 
     const res = (await workspace.owner.behaviors.manage({
       action: 'list_promoted',
-      watcher_id: String(watcherId),
+      behavior_id: String(watcherId),
     })) as {
       action: string;
       entities: Array<{
@@ -681,7 +681,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
 
     // Run 1 seeds `severity: 'low'` (watcher-owned, no field_controls yet).
     await ctx.api.behaviors.completeWindow({
-      watcher_id: String(watcherId),
+      behavior_id: String(watcherId),
       window_token: token,
       run_metadata: { watcher_run_id: runId },
       extracted_data: {
@@ -719,7 +719,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     // affirmed the field, the watcher must be BLOCKED and queue an approval —
     // proving the affirm actually locked the value.
     await ctx.api.behaviors.completeWindow({
-      watcher_id: String(watcherId),
+      behavior_id: String(watcherId),
       window_token: token,
       run_metadata: { watcher_run_id: runId },
       extracted_data: {

--- a/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
@@ -102,8 +102,8 @@ describe("manage_behaviors source-id + cross-org guards", () => {
 					query: "SELECT id, origin_id, payload_text FROM events",
 				},
 			],
-		})) as { watcher_id?: string };
-		expect(created.watcher_id).toBeDefined();
+		})) as { behavior_id?: string };
+		expect(created.behavior_id).toBeDefined();
 	});
 
 	it("resolves source refs and only signs event-backed content ids", async () => {
@@ -141,10 +141,10 @@ describe("manage_behaviors source-id + cross-org guards", () => {
 				{ name: "content", query: "@feed:default" },
 				{ name: "customers", query: "@entity:customer" },
 			],
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 
 		const result = (await owner.knowledge.read({
-			watcher_id: created.watcher_id,
+			watcher_id: created.behavior_id,
 			since: "today",
 			until: "today",
 		})) as {
@@ -174,10 +174,10 @@ describe("manage_behaviors source-id + cross-org guards", () => {
 			prompt: "Track {{content}}.",
 			agent_id: agentId,
 			sources: [{ name: "content", query: "@feed:default" }],
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 
 		const orgResult = (await owner.knowledge.read({
-			watcher_id: orgScoped.watcher_id,
+			watcher_id: orgScoped.behavior_id,
 			since: "today",
 			until: "today",
 		})) as {
@@ -201,11 +201,11 @@ describe("manage_behaviors source-id + cross-org guards", () => {
 			prompt: "Track stuff.",
 			agent_id: agentId,
 			sources: [{ name: "content", query: "SELECT id FROM events" }],
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 
 		await expect(
 			owner.behaviors.createVersion({
-				watcher_id: created.watcher_id,
+				behavior_id: created.behavior_id,
 				prompt: "Track stuff v2.",
 				change_notes: "omit id",
 				sources: [
@@ -253,8 +253,8 @@ describe("manage_behaviors source-id + cross-org guards", () => {
 			prompt: "Track stuff.",
 			agent_id: agentId,
 			sources: [{ name: "content", query: "@feed:slack:C123" }],
-		})) as { watcher_id: string };
-		expect(created.watcher_id).toBeTruthy();
+		})) as { behavior_id: string };
+		expect(created.behavior_id).toBeTruthy();
 	});
 
 	it("rejects create when an @entity ref is not a type in the org", async () => {
@@ -298,11 +298,11 @@ describe("manage_behaviors source-id + cross-org guards", () => {
 			prompt: "Track stuff.",
 			agent_id: agentId,
 			sources: [{ name: "content", query: "SELECT id FROM events" }],
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 
 		const sql = getTestDb();
 		const [row] = await sql<{ current_version_id: number }[]>`
-      SELECT current_version_id FROM watchers WHERE id = ${base.watcher_id}
+      SELECT current_version_id FROM watchers WHERE id = ${base.behavior_id}
     `;
 		const versionId = Number(row?.current_version_id);
 		expect(versionId).toBeGreaterThan(0);
@@ -330,18 +330,18 @@ describe("manage_behaviors source-id + cross-org guards", () => {
 			prompt: "Track stuff.",
 			agent_id: agentId,
 			sources: [{ name: "content", query: "SELECT id FROM events" }],
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 
 		const sql = getTestDb();
 		const [row] = await sql<{ current_version_id: number }[]>`
-      SELECT current_version_id FROM watchers WHERE id = ${base.watcher_id}
+      SELECT current_version_id FROM watchers WHERE id = ${base.behavior_id}
     `;
 		const versionId = Number(row?.current_version_id);
 
 		const result = (await owner.behaviors.createFromVersion({
 			version_id: versionId,
 			entity_ids: [inOrgEntityId],
-		})) as { created: Array<{ watcher_id: string }> };
+		})) as { created: Array<{ behavior_id: string }> };
 		expect(result.created.length).toBe(1);
 	});
 

--- a/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
@@ -370,15 +370,15 @@ describe("manage_behaviors source-id + cross-org guards", () => {
 			prompt: "Track stuff.",
 			agent_id: foreignAgent.agentId,
 			sources: [{ name: "content", query: "SELECT id FROM events" }],
-		})) as { watcher_id: string };
-		const foreignId = String(foreignWatcher.watcher_id);
+		})) as { behavior_id: string };
+		const foreignId = String(foreignWatcher.behavior_id);
 
 		// The owner (a different org) targets the foreign row's id directly. It
 		// exists under another tenant, so requireWatcherAccess rejects it 403 —
 		// and even if that gate were bypassed, the org-scoped archive UPDATE
 		// leaves the foreign row untouched.
 		await expect(
-			owner.behaviors.delete({ watcher_ids: [foreignId] })
+			owner.behaviors.delete({ behavior_ids: [foreignId] })
 		).rejects.toMatchObject({ httpStatus: 403 });
 
 		// The foreign row is untouched — still active, not archived.

--- a/packages/server/src/__tests__/integration/watchers/watcher-owner-escalation.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-owner-escalation.test.ts
@@ -100,8 +100,8 @@ describe("manage_behaviors owner-escalation guard", () => {
 			name: "human-assigns-b",
 			prompt: "Track things.",
 			agent_id: agentB,
-		})) as { watcher_id: string };
-		expect(created.watcher_id).toBeDefined();
+		})) as { behavior_id: string };
+		expect(created.behavior_id).toBeDefined();
 	});
 
 	it("blocks agent A from CLONING agent B's watcher via create_from_version (inherited owner)", async () => {
@@ -119,9 +119,9 @@ describe("manage_behaviors owner-escalation guard", () => {
 			name: "b-owned-source",
 			prompt: "Track things.",
 			agent_id: agentB,
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 		const [ver] = await getTestDb()<{ id: number }>`
-      SELECT id FROM watcher_versions WHERE watcher_id = ${Number(bWatcher.watcher_id)} ORDER BY id ASC LIMIT 1
+      SELECT id FROM watcher_versions WHERE watcher_id = ${Number(bWatcher.behavior_id)} ORDER BY id ASC LIMIT 1
     `;
 		// Agent A clones it WITHOUT supplying agent_id — the clone would inherit B's
 		// owner. The guard resolves the effective (inherited) owner and blocks it.
@@ -147,7 +147,7 @@ describe("manage_behaviors owner-escalation guard", () => {
 			name: "b-owned-edit",
 			prompt: "Track things.",
 			agent_id: agentB,
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 		// Agent A updates it WITHOUT agent_id — ownership stays B. Blocked because the
 		// preserved effective owner (B) isn't A.
 		await expect(
@@ -155,7 +155,7 @@ describe("manage_behaviors owner-escalation guard", () => {
 				"manage_behaviors",
 				{
 					action: "update",
-					watcher_id: bWatcher.watcher_id,
+					behavior_id: bWatcher.behavior_id,
 					triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
 				},
 				TEST_ENV,
@@ -180,9 +180,9 @@ describe("manage_behaviors owner-escalation guard", () => {
 			name: "b-owned-source-2",
 			prompt: "Track things.",
 			agent_id: agentB,
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 		const [ver] = await getTestDb()<{ id: number }>`
-      SELECT id FROM watcher_versions WHERE watcher_id = ${Number(bWatcher.watcher_id)} ORDER BY id ASC LIMIT 1
+      SELECT id FROM watcher_versions WHERE watcher_id = ${Number(bWatcher.behavior_id)} ORDER BY id ASC LIMIT 1
     `;
 		// A supplies agent_id=A to try to satisfy the guard — but handleCreateFromVersion
 		// IGNORES it and clones B's owner, so the guard must resolve the SOURCE owner.
@@ -212,7 +212,7 @@ describe("manage_behaviors owner-escalation guard", () => {
 			name: "a-owned-grouproot",
 			prompt: "Track things.",
 			agent_id: agentA,
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 		// Add a B-owned sibling into wA's group. Create it via the normal CRUD path
 		// (so all its rows/triggers are consistent), then move it into wA's group with
 		// a direct UPDATE — a raw watcher INSERT trips unrelated sequence collisions.
@@ -221,20 +221,20 @@ describe("manage_behaviors owner-escalation guard", () => {
 			name: "b-sibling",
 			prompt: "Track things.",
 			agent_id: agentB,
-		})) as { watcher_id: string };
+		})) as { behavior_id: string };
 		const [grp] = await getTestDb()<{ watcher_group_id: number }>`
-      SELECT watcher_group_id FROM watchers WHERE id = ${Number(wA.watcher_id)} LIMIT 1
+      SELECT watcher_group_id FROM watchers WHERE id = ${Number(wA.behavior_id)} LIMIT 1
     `;
 		await getTestDb()`
       UPDATE watchers SET watcher_group_id = ${Number(grp.watcher_group_id)}
-      WHERE id = ${Number(bSibling.watcher_id)}
+      WHERE id = ${Number(bSibling.behavior_id)}
     `;
 		await expect(
 			executeTool(
 				"manage_behaviors",
 				{
 					action: "set_reaction_script",
-					watcher_id: wA.watcher_id,
+					behavior_id: wA.behavior_id,
 					reaction_script: "export default async () => {};",
 				},
 				TEST_ENV,

--- a/packages/server/src/__tests__/integration/watchers/watcher-schema-from-entity.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-schema-from-entity.test.ts
@@ -119,8 +119,8 @@ async function setupEntityTypedWatcher() {
     keying_config: KEYING_CONFIG,
     triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
     agent_id: agent.agentId,
-  })) as { watcher_id: string };
-  const watcherId = Number(watcher.watcher_id);
+  })) as { behavior_id: string };
+  const watcherId = Number(watcher.behavior_id);
 
   await sql`UPDATE watchers SET next_run_at = NOW() - INTERVAL '10 minutes' WHERE id = ${watcherId}`;
 
@@ -202,7 +202,7 @@ describe('complete_window derives its schema from the entity type', () => {
     // 'name' is required by topic's metadata_schema but missing here.
     await expect(
       ctx.api.behaviors.completeWindow({
-        watcher_id: String(ctx.watcherId),
+        behavior_id: String(ctx.watcherId),
         window_token: token,
         extracted_data: { problems: [{ category: 'Stability' }] },
         run_metadata: { watcher_run_id: runId },
@@ -222,7 +222,7 @@ describe('complete_window derives its schema from the entity type', () => {
     const token = await readWindowToken(ctx);
 
     const completion = (await ctx.api.behaviors.completeWindow({
-      watcher_id: String(ctx.watcherId),
+      behavior_id: String(ctx.watcherId),
       window_token: token,
       extracted_data: {
         problems: [{ category: 'Stability', name: 'App Crashes' }],

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -76,20 +76,20 @@ describe('watcher CRUD', () => {
       prompt: 'Track product launches.',
       triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
       agent_id: agentId,
-    })) as { watcher_id: string };
-    const watcherId = created.watcher_id;
+    })) as { behavior_id: string };
+    const watcherId = created.behavior_id;
     expect(watcherId).toBeDefined();
 
-    const got = (await owner.behaviors.get({ watcher_id: watcherId })) as {
+    const got = (await owner.behaviors.get({ behavior_id: watcherId })) as {
       behavior?: { watcher_name: string };
     };
     expect(got.behavior?.watcher_name).toBe('Lifecycle Watcher');
 
     await owner.behaviors.update({
-      watcher_id: watcherId,
+      behavior_id: watcherId,
       triggers: [{ kind: 'schedule', cron: '0 10 * * *' }],
     });
-    const after = (await owner.behaviors.get({ watcher_id: watcherId })) as {
+    const after = (await owner.behaviors.get({ behavior_id: watcherId })) as {
       behavior?: { triggers: Array<{ kind: string; cron?: string }> };
     };
     expect(after.behavior).not.toHaveProperty('schedule');
@@ -100,15 +100,15 @@ describe('watcher CRUD', () => {
     const listed = (await owner.behaviors.list({ entity_id: entityId })) as {
       behaviors?: Array<Record<string, unknown>>;
     };
-    const listedBehavior = listed.behaviors?.find((behavior) => behavior.watcher_id === watcherId);
+    const listedBehavior = listed.behaviors?.find((behavior) => behavior.behavior_id === watcherId);
     expect(listedBehavior).not.toHaveProperty('schedule');
     expect(listedBehavior?.triggers).toEqual(after.behavior?.triggers);
 
-    await owner.behaviors.delete({ watcher_ids: [watcherId] });
+    await owner.behaviors.delete({ behavior_ids: [watcherId] });
     const list = (await owner.behaviors.list({ entity_id: entityId })) as {
-      behaviors?: Array<{ watcher_id: string }>;
+      behaviors?: Array<{ behavior_id: string }>;
     };
-    expect(list.behaviors?.some((w) => w.watcher_id === watcherId)).toBe(false);
+    expect(list.behaviors?.some((w) => w.behavior_id === watcherId)).toBe(false);
   });
 
   it('creates a watcher and its reaction contract atomically', async () => {
@@ -120,7 +120,7 @@ describe('watcher CRUD', () => {
       prompt: 'Return merge proposals.',
       agent_id: agentId,
       reaction_script: reaction,
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
 
     const [row] = await sql<
       {
@@ -130,7 +130,7 @@ describe('watcher CRUD', () => {
       }[]
     >`
       SELECT reaction_script, reaction_script_compiled, reaction_input_schema
-      FROM watchers WHERE id = ${created.watcher_id}
+      FROM watchers WHERE id = ${created.behavior_id}
     `;
     expect(row?.reaction_script).toBe(reaction);
     expect(row?.reaction_script_compiled).toContain('merge_proposals');
@@ -196,8 +196,8 @@ describe('watcher CRUD', () => {
       agent_id: agentId,
       sources: template.detail.sources,
       reaction_script: reactionScript,
-    })) as { watcher_id: string };
-    const watcherId = Number(created.watcher_id);
+    })) as { behavior_id: string };
+    const watcherId = Number(created.behavior_id);
 
     const [installed] = await sql<{ reaction_script_compiled: string | null }[]>`
       SELECT reaction_script_compiled FROM watchers WHERE id = ${watcherId}
@@ -282,7 +282,7 @@ describe('watcher CRUD', () => {
     expect(duplicateRows.every((row) => row.merged_into === null)).toBe(true);
     expect(duplicateRows.every((row) => row.deleted_at === null)).toBe(true);
 
-    await owner.behaviors.delete({ watcher_ids: [created.watcher_id] });
+    await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
   it('does not create a watcher when its reaction fails compilation', async () => {
@@ -327,8 +327,8 @@ describe('watcher CRUD', () => {
       expect(e.message).not.toMatch(/23505|duplicate key value/);
       expect(e.httpStatus).toBe(409);
     }
-    const winner = (fulfilled[0] as PromiseFulfilledResult<{ watcher_id: string }>).value;
-    await owner.behaviors.delete({ watcher_ids: [winner.watcher_id] });
+    const winner = (fulfilled[0] as PromiseFulfilledResult<{ behavior_id: string }>).value;
+    await owner.behaviors.delete({ behavior_ids: [winner.behavior_id] });
   });
 
   it('concurrent creates of DISTINCT slugs all succeed with unique ids (no PK collision)', async () => {
@@ -347,10 +347,10 @@ describe('watcher CRUD', () => {
         })
       )
     );
-    const ids = results.map((r) => (r as { watcher_id: string }).watcher_id);
+    const ids = results.map((r) => (r as { behavior_id: string }).behavior_id);
     expect(ids.length).toBe(N);
     expect(new Set(ids).size).toBe(N); // all unique — no PK collision
-    await owner.behaviors.delete({ watcher_ids: ids });
+    await owner.behaviors.delete({ behavior_ids: ids });
   });
 
   it('concurrent group-locked writes on DISTINCT groups do not exhaust the pool (holder starvation)', async () => {
@@ -374,10 +374,10 @@ describe('watcher CRUD', () => {
         prompt: 'Track things.',
         agent_id: agentId,
         sources: [{ name: 'content', query: 'SELECT id FROM events' }],
-      })) as { watcher_id: string };
-      baseIds.push(base.watcher_id);
+      })) as { behavior_id: string };
+      baseIds.push(base.behavior_id);
       const [row] = await sql<{ current_version_id: number }[]>`
-        SELECT current_version_id FROM watchers WHERE id = ${base.watcher_id}
+        SELECT current_version_id FROM watchers WHERE id = ${base.behavior_id}
       `;
       versionIds.push(Number(row?.current_version_id));
     }
@@ -402,11 +402,11 @@ describe('watcher CRUD', () => {
       )
     );
     const createdIds = results.flatMap((r) =>
-      (r as { created: Array<{ watcher_id: string }> }).created.map((c) => c.watcher_id)
+      (r as { created: Array<{ behavior_id: string }> }).created.map((c) => c.behavior_id)
     );
     expect(createdIds.length).toBe(N);
     expect(new Set(createdIds).size).toBe(N); // all unique — the cross-group id race
-    await owner.behaviors.delete({ watcher_ids: [...baseIds, ...createdIds] });
+    await owner.behaviors.delete({ behavior_ids: [...baseIds, ...createdIds] });
   });
 
   it('concurrent create_from_version fan-outs allocate unique ids (no PK collision)', async () => {
@@ -423,9 +423,9 @@ describe('watcher CRUD', () => {
       prompt: 'Track things.',
       agent_id: agentId,
       sources: [{ name: 'content', query: 'SELECT id FROM events' }],
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
     const [row] = await sql<{ current_version_id: number }[]>`
-      SELECT current_version_id FROM watchers WHERE id = ${base.watcher_id}
+      SELECT current_version_id FROM watchers WHERE id = ${base.behavior_id}
     `;
     const versionId = Number(row?.current_version_id);
 
@@ -449,12 +449,12 @@ describe('watcher CRUD', () => {
       )
     );
     const createdIds = results.flatMap((r) =>
-      (r as { created: Array<{ watcher_id: string }> }).created.map((c) => c.watcher_id)
+      (r as { created: Array<{ behavior_id: string }> }).created.map((c) => c.behavior_id)
     );
     expect(createdIds.length).toBe(N);
     expect(new Set(createdIds).size).toBe(N); // all unique — no PK collision
     await owner.behaviors.delete({
-      watcher_ids: [base.watcher_id, ...createdIds],
+      behavior_ids: [base.behavior_id, ...createdIds],
     });
   });
 
@@ -473,9 +473,9 @@ describe('watcher CRUD', () => {
       prompt: 'Track things.',
       agent_id: agentId,
       sources: [{ name: 'content', query: 'SELECT id FROM events' }],
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
     const [row] = await sql<{ current_version_id: number }[]>`
-      SELECT current_version_id FROM watchers WHERE id = ${base.watcher_id}
+      SELECT current_version_id FROM watchers WHERE id = ${base.behavior_id}
     `;
     const versionId = Number(row?.current_version_id);
 
@@ -503,11 +503,11 @@ describe('watcher CRUD', () => {
     }
     const winnerIds = (
       fulfilled[0] as PromiseFulfilledResult<{
-        created: Array<{ watcher_id: string }>;
+        created: Array<{ behavior_id: string }>;
       }>
-    ).value.created.map((c) => c.watcher_id);
+    ).value.created.map((c) => c.behavior_id);
     await owner.behaviors.delete({
-      watcher_ids: [base.watcher_id, ...winnerIds],
+      behavior_ids: [base.behavior_id, ...winnerIds],
     });
   });
 
@@ -525,9 +525,9 @@ describe('watcher CRUD', () => {
       prompt: 'Track things.',
       agent_id: agentId,
       sources: [{ name: 'content', query: 'SELECT id FROM events' }],
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
     const [row] = await sql<{ current_version_id: number }[]>`
-      SELECT current_version_id FROM watchers WHERE id = ${base.watcher_id}
+      SELECT current_version_id FROM watchers WHERE id = ${base.behavior_id}
     `;
     const versionId = Number(row?.current_version_id);
 
@@ -545,7 +545,7 @@ describe('watcher CRUD', () => {
     const seed = (await owner.behaviors.createFromVersion({
       version_id: versionId,
       entity_ids: [collidingTarget.entity.id],
-    })) as { created: Array<{ watcher_id: string }> };
+    })) as { created: Array<{ behavior_id: string }> };
     expect(seed.created.length).toBe(1);
 
     // Now fan out to [fresh, colliding]. The colliding insert hits the seeded
@@ -565,7 +565,7 @@ describe('watcher CRUD', () => {
     expect(leaked.length).toBe(0);
 
     await owner.behaviors.delete({
-      watcher_ids: [base.watcher_id, ...seed.created.map((c) => c.watcher_id)],
+      behavior_ids: [base.behavior_id, ...seed.created.map((c) => c.behavior_id)],
     });
   });
 
@@ -576,10 +576,10 @@ describe('watcher CRUD', () => {
       prompt: 'Summarize recent workspace activity.',
       triggers: [{ kind: 'schedule', cron: '0 12 * * *' }],
       agent_id: agentId,
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
 
     const got = (await owner.behaviors.get({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
     })) as {
       behavior?: { entity_id?: number | null };
     };
@@ -606,16 +606,16 @@ describe('watcher CRUD', () => {
       prompt,
       agent_id: agentId,
       // NOTE: no `sources` — the backend must derive them from the prompt token.
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
 
     const got = (await owner.behaviors.get({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
     })) as {
       behavior?: { sources?: Array<{ name: string; query: string }> | null };
     };
     expect(got.behavior?.sources).toEqual([{ name: 'recent_events', query }]);
 
-    await owner.behaviors.delete({ watcher_ids: [created.watcher_id] });
+    await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
   it('re-derives sources on a version bump — an edited SQL chip replaces (not strands) the old query', async () => {
@@ -637,17 +637,17 @@ describe('watcher CRUD', () => {
       name: 'SQL Edit Rederive Watcher',
       prompt: `Watch @[sql:recent:Recent](${enc(oldQuery)}).`,
       agent_id: agentId,
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
 
     // Edit the SQL chip: same label/name, new query — a new prompt version.
     await owner.behaviors.createVersion({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
       prompt: `Watch @[sql:recent:Recent](${enc(newQuery)}).`,
       change_notes: 'edit sql',
     });
 
     const got = (await owner.behaviors.get({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
     })) as {
       behavior?: { sources?: Array<{ name: string; query: string }> | null };
     };
@@ -655,7 +655,7 @@ describe('watcher CRUD', () => {
     // stranded under `recent`, and there is no `recent_2`.
     expect(got.behavior?.sources).toEqual([{ name: 'recent', query: newQuery }]);
 
-    await owner.behaviors.delete({ watcher_ids: [created.watcher_id] });
+    await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
   it('clears sources when an edited prompt removes every @-mention chip', async () => {
@@ -674,23 +674,23 @@ describe('watcher CRUD', () => {
       name: 'Clear Sources On Edit Watcher',
       prompt: `Watch @[sql:recent:Recent](${enc('SELECT id FROM events')}).`,
       agent_id: agentId,
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
 
     // New prompt with the chip removed → sources must become empty.
     await owner.behaviors.createVersion({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
       prompt: 'Just watch everything, no specific source.',
       change_notes: 'remove chip',
     });
 
     const got = (await owner.behaviors.get({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
     })) as {
       behavior?: { sources?: Array<{ name: string; query: string }> | null };
     };
     expect(got.behavior?.sources ?? []).toEqual([]);
 
-    await owner.behaviors.delete({ watcher_ids: [created.watcher_id] });
+    await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
   it('round-trips execution_config through create → list → update', async () => {
@@ -707,22 +707,22 @@ describe('watcher CRUD', () => {
         permission_mode: 'acceptEdits',
         effort: 'high',
       },
-    })) as { watcher_id: string };
-    const watcherId = created.watcher_id;
+    })) as { behavior_id: string };
+    const watcherId = created.behavior_id;
 
     const findRow = (
       res: {
         behaviors?: Array<{
-          watcher_id: string;
+          behavior_id: string;
           execution_config?: Record<string, unknown> | null;
         }>;
       },
       id: string
-    ) => res.behaviors?.find((w) => String(w.watcher_id) === String(id));
+    ) => res.behaviors?.find((w) => String(w.behavior_id) === String(id));
 
     const list = (await owner.behaviors.list({ entity_id: entityId })) as {
       behaviors?: Array<{
-        watcher_id: string;
+        behavior_id: string;
         execution_config?: Record<string, unknown>;
       }>;
     };
@@ -736,12 +736,12 @@ describe('watcher CRUD', () => {
 
     // Update replaces the whole jsonb; a partial object is stored verbatim.
     await owner.behaviors.update({
-      watcher_id: watcherId,
+      behavior_id: watcherId,
       execution_config: { timeout_seconds: 300 },
     });
     const after = (await owner.behaviors.list({ entity_id: entityId })) as {
       behaviors?: Array<{
-        watcher_id: string;
+        behavior_id: string;
         execution_config?: Record<string, unknown>;
       }>;
     };
@@ -751,18 +751,18 @@ describe('watcher CRUD', () => {
 
     // Passing null clears the saved config back to NULL/defaults.
     await owner.behaviors.update({
-      watcher_id: watcherId,
+      behavior_id: watcherId,
       execution_config: null,
     });
     const cleared = (await owner.behaviors.list({ entity_id: entityId })) as {
       behaviors?: Array<{
-        watcher_id: string;
+        behavior_id: string;
         execution_config?: Record<string, unknown> | null;
       }>;
     };
     expect(findRow(cleared, watcherId)?.execution_config ?? null).toBeNull();
 
-    await owner.behaviors.delete({ watcher_ids: [watcherId] });
+    await owner.behaviors.delete({ behavior_ids: [watcherId] });
   });
 
   it('leaves execution_config null when unset', async () => {
@@ -772,19 +772,19 @@ describe('watcher CRUD', () => {
       name: 'No Exec Config',
       prompt: 'Track things.',
       agent_id: agentId,
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
 
     const list = (await owner.behaviors.list({ entity_id: entityId })) as {
       behaviors?: Array<{
-        watcher_id: string;
+        behavior_id: string;
         execution_config?: Record<string, unknown> | null;
       }>;
     };
-    const row = list.behaviors?.find((w) => String(w.watcher_id) === String(created.watcher_id));
+    const row = list.behaviors?.find((w) => String(w.behavior_id) === String(created.behavior_id));
     expect(row).toBeDefined();
     expect(row?.execution_config ?? null).toBeNull();
 
-    await owner.behaviors.delete({ watcher_ids: [created.watcher_id] });
+    await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
   it('rejects an invalid execution_config (type/range/unknown-key)', async () => {
@@ -836,17 +836,17 @@ describe('watcher CRUD', () => {
       name: 'Org Scoped',
       prompt: 'Track org-wide signals.',
       agent_id: agentId,
-    })) as { watcher_id: string };
-    expect(created.watcher_id).toBeDefined();
+    })) as { behavior_id: string };
+    expect(created.behavior_id).toBeDefined();
 
     const got = (await owner.behaviors.get({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
     })) as {
       behavior?: { entity_ids?: number[] };
     };
     expect(got.behavior?.entity_ids ?? []).toEqual([]);
 
-    await owner.behaviors.delete({ watcher_ids: [created.watcher_id] });
+    await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
   it('rejects an org-scoped watcher when there is no organization context', async () => {
@@ -867,29 +867,29 @@ describe('watcher CRUD', () => {
       name: 'Cross Org Protected',
       prompt: 'Track org-wide signals.',
       agent_id: agentId,
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
 
-    await expect(intruder.behaviors.get({ watcher_id: created.watcher_id })).rejects.toThrow(
+    await expect(intruder.behaviors.get({ behavior_id: created.behavior_id })).rejects.toThrow(
       /access|organization/i
     );
     await expect(
       intruder.behaviors.update({
-        watcher_id: created.watcher_id,
+        behavior_id: created.behavior_id,
         triggers: [{ kind: 'schedule', cron: '0 11 * * *' }],
       })
     ).rejects.toThrow(/access|organization/i);
-    await expect(intruder.behaviors.delete({ watcher_ids: [created.watcher_id] })).rejects.toThrow(
+    await expect(intruder.behaviors.delete({ behavior_ids: [created.behavior_id] })).rejects.toThrow(
       /access|organization/i
     );
 
     const got = (await owner.behaviors.get({
-      watcher_id: created.watcher_id,
+      behavior_id: created.behavior_id,
     })) as {
       behavior?: { triggers: unknown[] };
     };
     expect(got.behavior?.triggers).toEqual([]);
 
-    await owner.behaviors.delete({ watcher_ids: [created.watcher_id] });
+    await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
   it('blocks a member from deleting watchers (admin-only)', async () => {
@@ -899,10 +899,10 @@ describe('watcher CRUD', () => {
       name: 'Protected',
       prompt: 'guarded.',
       agent_id: agentId,
-    })) as { watcher_id: string };
+    })) as { behavior_id: string };
 
     const member = owner.withAuth({ memberRole: 'member' });
-    await expect(member.behaviors.delete({ watcher_ids: [created.watcher_id] })).rejects.toThrow(
+    await expect(member.behaviors.delete({ behavior_ids: [created.behavior_id] })).rejects.toThrow(
       /admin|owner|access/i
     );
   });
@@ -944,16 +944,16 @@ describe('watcher CRUD', () => {
         prompt: 'x',
         agent_id: agentId,
         device_worker_id: deviceId,
-      })) as { watcher_id: string };
-      expect(created.watcher_id).toBeDefined();
+      })) as { behavior_id: string };
+      expect(created.behavior_id).toBeDefined();
 
       const got = (await owner.behaviors.get({
-        watcher_id: created.watcher_id,
+        behavior_id: created.behavior_id,
       })) as {
         behavior?: { device_worker_id?: string | null };
       };
       expect(got.behavior?.device_worker_id).toBe(deviceId);
-      await owner.behaviors.delete({ watcher_ids: [created.watcher_id] });
+      await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
     });
 
     it('rejects pinning to a device in another org (create)', async () => {
@@ -998,7 +998,7 @@ describe('watcher CRUD', () => {
         name: 'Device Pin Update',
         prompt: 'x',
         agent_id: agentId,
-      })) as { watcher_id: string };
+      })) as { behavior_id: string };
 
       const foreignDeviceId = await seedDevice({
         userId: otherUserId,
@@ -1008,12 +1008,12 @@ describe('watcher CRUD', () => {
       await expect(
         owner.behaviors.manage({
           action: 'update',
-          watcher_id: created.watcher_id,
+          behavior_id: created.behavior_id,
           device_worker_id: foreignDeviceId,
         })
       ).rejects.toThrow(/device you own|not found or not accessible/i);
 
-      await owner.behaviors.delete({ watcher_ids: [created.watcher_id] });
+      await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
     });
   });
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -96,9 +96,9 @@ describe("sdkSearch", () => {
 		["feeds.delete", "client.feeds.delete({ feed_id: 42 })"],
 		["classifiers.delete", "client.classifiers.delete({ classifier_id: 42 })"],
 		["schedules.cancel", "client.schedules.cancel({ id: 'schedule-id' })"],
-		["behaviors.get", "client.behaviors.get({ watcher_id: '42' })"],
-		["behaviors.trigger", "client.behaviors.trigger({ watcher_id: '42' })"],
-		["behaviors.delete", "client.behaviors.delete({ watcher_ids: ['42'] })"],
+		["behaviors.get", "client.behaviors.get({ behavior_id: '42' })"],
+		["behaviors.trigger", "client.behaviors.trigger({ behavior_id: '42' })"],
+		["behaviors.delete", "client.behaviors.delete({ behavior_ids: ['42'] })"],
 	])("renders the current %s signature in exact drill-down", async (path, snippet) => {
 		const result = await sdkSearch({ query: path }, stubEnv, adminCtx);
 

--- a/packages/server/src/__tests__/unit/watcher-execution-config.test.ts
+++ b/packages/server/src/__tests__/unit/watcher-execution-config.test.ts
@@ -24,7 +24,7 @@ import { ToolUserError } from '../../utils/errors';
 function validateUpdateWith(executionConfig: unknown): unknown {
   return validateToolArgs('manage_behaviors', ManageBehaviorsSchema, {
     action: 'update',
-    watcher_id: '1',
+    behavior_id: '1',
     execution_config: executionConfig,
   });
 }

--- a/packages/server/src/catalog/installed.ts
+++ b/packages/server/src/catalog/installed.ts
@@ -103,7 +103,7 @@ export async function listOrgInstalled(
 		result.behaviors = {
 			kind: "behaviors",
 			items: behaviors.map((watcher: Record<string, unknown>) => ({
-				id: String(watcher.watcher_id ?? watcher.id ?? ""),
+				id: String(watcher.behavior_id ?? ""),
 				name: String(watcher.name ?? watcher.watcher_name ?? "Behavior"),
 				detail: {
 					slug: watcher.slug,

--- a/packages/server/src/formatting/__tests__/markdown-formatter.test.ts
+++ b/packages/server/src/formatting/__tests__/markdown-formatter.test.ts
@@ -190,7 +190,7 @@ describe('formatToolResult', () => {
     it('should format create result', () => {
       const result = {
         action: 'create',
-        watcher_id: 42,
+        behavior_id: 42,
         template_version: 1,
         status: 'active',
       };
@@ -204,7 +204,7 @@ describe('formatToolResult', () => {
         action: 'list',
         behaviors: [
           {
-            watcher_id: 1,
+            behavior_id: 1,
             template_slug: 'sentiment',
             status: 'active',
             entity_name: 'Acme',

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -750,7 +750,7 @@ function formatGetBehaviorResult(result: any, _options: FormatterOptions): strin
   });
 
   if (pending_analysis?.unprocessed_ranges?.length > 0) {
-    md += formatUnprocessedRanges(pending_analysis.unprocessed_ranges, behavior?.watcher_id);
+    md += formatUnprocessedRanges(pending_analysis.unprocessed_ranges, behavior?.behavior_id);
   }
 
   return md;
@@ -855,7 +855,7 @@ function formatManageBehaviorsResult(result: any, _options: FormatterOptions): s
     return md;
   }
 
-  if (action === 'create' && result.template_id && !result.watcher_id) {
+  if (action === 'create' && result.template_id && !result.behavior_id) {
     md += '## New Template Created\n\n';
     md += `- **ID**: \`${result.template_id}\`\n`;
     md += `- **Slug**: ${result.slug}\n`;
@@ -875,7 +875,7 @@ function formatManageBehaviorsResult(result: any, _options: FormatterOptions): s
 
   if (action === 'set_reaction_script') {
     md += '## Reaction Script\n\n';
-    md += `- **Behavior ID**: \`${result.watcher_id}\`\n`;
+    md += `- **Behavior ID**: \`${result.behavior_id}\`\n`;
     md += `- **Installed**: ${result.has_script ? 'Yes' : 'No'}\n`;
     if (result.message) md += `- **Message**: ${result.message}\n`;
     return md;
@@ -896,7 +896,7 @@ function formatManageBehaviorsResult(result: any, _options: FormatterOptions): s
     if (failedResults.length > 0) {
       md += '## ❌ Failed Operations\n\n';
       for (const r of failedResults) {
-        md += `- **Behavior ID**: \`${r.watcher_id}\`\n`;
+        md += `- **Behavior ID**: \`${r.behavior_id}\`\n`;
         md += `  - **Error**: ${r.message}\n\n`;
       }
     }
@@ -904,15 +904,15 @@ function formatManageBehaviorsResult(result: any, _options: FormatterOptions): s
     if (successfulResults.length > 0) {
       md += '## ✅ Successful Operations\n\n';
       for (const r of successfulResults) {
-        md += `- **Behavior ID**: \`${r.watcher_id}\`\n`;
+        md += `- **Behavior ID**: \`${r.behavior_id}\`\n`;
         md += `  - **Status**: ${r.message}\n\n`;
       }
     }
   }
 
-  if (action === 'create' && result.watcher_id) {
+  if (action === 'create' && result.behavior_id) {
     md += '## New Behavior Created\n\n';
-    md += `- **ID**: \`${result.watcher_id}\`\n`;
+    md += `- **ID**: \`${result.behavior_id}\`\n`;
     md += `- **Template Version**: ${result.template_version}\n`;
     md += `- **Status**: ${result.status}\n`;
     if (result.view_url) {
@@ -932,7 +932,7 @@ function formatManageBehaviorsResult(result: any, _options: FormatterOptions): s
 
   if (action === 'complete_window') {
     md += '## ✅ Window Completed\n\n';
-    md += `- **Behavior ID**: \`${result.watcher_id}\`\n`;
+    md += `- **Behavior ID**: \`${result.behavior_id}\`\n`;
     md += `- **Window ID**: \`${result.window_id}\`\n`;
     md += `- **Period**: ${result.window_start?.substring(0, 10)} - ${result.window_end?.substring(0, 10)}\n`;
     md += `- **Content Linked**: ${result.content_linked}\n`;
@@ -942,7 +942,7 @@ function formatManageBehaviorsResult(result: any, _options: FormatterOptions): s
     md += `## Behaviors (${behaviors.length})\n\n`;
     for (const watcher of behaviors) {
       md += `### ${watcher.name || watcher.template_slug}\n`;
-      md += `- **ID**: \`${watcher.watcher_id}\`\n`;
+      md += `- **ID**: \`${watcher.behavior_id}\`\n`;
       md += `- **Template**: ${watcher.template_slug} (v${watcher.template_version})\n`;
       md += `- **Status**: ${watcher.status}\n`;
       md += `- **Entity**: ${watcher.entity_name} (${watcher.entity_type})\n`;

--- a/packages/server/src/lobu/__tests__/agent-routes-pending-proposal.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-pending-proposal.test.ts
@@ -181,7 +181,7 @@ describe("GET /:agentId/config/pending/:runId", () => {
 			proposal: {
 				args: {
 					action: "update",
-					watcher_id: "w1",
+					behavior_id: "w1",
 					agent_id: AGENT,
 					prompt: "x",
 				},
@@ -238,11 +238,11 @@ describe("GET /:agentId/config/pending/:runId", () => {
 const WATCHER_ID = 501;
 
 // The endpoint reads the watcher's owner + target from the held proposal/event
-// metadata (`current.agent_id`, `args.watcher_id`), NOT from the `watchers`
+// metadata (`current.agent_id`, `args.behavior_id`), NOT from the `watchers`
 // table — so no watcher row needs seeding; the proposal fixtures carry it all.
 
 /** A real ManageBehaviorsProposal: `{ args: {...}, actingAgentId, actingWatcherId }`
- *  with watcher_id / agent_id nested INSIDE args. */
+ *  with behavior_id / agent_id nested INSIDE args. */
 function watcherProposal(
 	args: Record<string, unknown>
 ): Record<string, unknown> {
@@ -256,7 +256,7 @@ describe("GET /:agentId/behaviors/:watcherId/pending/:runId", () => {
 			tool: "manage_behaviors",
 			proposal: watcherProposal({
 				action: "update",
-				watcher_id: WATCHER_ID,
+				behavior_id: WATCHER_ID,
 				name: "New Watcher Name",
 				prompt: "Watch for X",
 			}),
@@ -286,13 +286,13 @@ describe("GET /:agentId/behaviors/:watcherId/pending/:runId", () => {
 	test("returns a normalized proposedAfter (displayed == applied)", async () => {
 		// The endpoint computes proposedAfter with the SAME normalizer handleUpdate
 		// uses, so the review shows the canonical trigger values that are stored,
-		// and version-owned/routing keys (name/watcher_id/action) are excluded.
+		// and version-owned/routing keys (name/behavior_id/action) are excluded.
 		const app = await importAgentRoutes();
 		const runId = await insertPendingProposal({
 			tool: "manage_behaviors",
 			proposal: watcherProposal({
 				action: "update",
-				watcher_id: WATCHER_ID,
+				behavior_id: WATCHER_ID,
 				triggers: [
 					{
 						kind: "schedule",
@@ -325,7 +325,7 @@ describe("GET /:agentId/behaviors/:watcherId/pending/:runId", () => {
 		});
 		// version-owned/routing keys never appear in the applied patch
 		expect(body.proposedAfter && "name" in body.proposedAfter).toBe(false);
-		expect(body.proposedAfter && "watcher_id" in body.proposedAfter).toBe(
+		expect(body.proposedAfter && "behavior_id" in body.proposedAfter).toBe(
 			false
 		);
 	});
@@ -339,7 +339,7 @@ describe("GET /:agentId/behaviors/:watcherId/pending/:runId", () => {
 			tool: "manage_behaviors",
 			proposal: watcherProposal({
 				action: "update",
-				watcher_id: WATCHER_ID,
+				behavior_id: WATCHER_ID,
 				agent_id: AGENT,
 				name: "N",
 			}),
@@ -357,7 +357,7 @@ describe("GET /:agentId/behaviors/:watcherId/pending/:runId", () => {
 			tool: "manage_behaviors",
 			proposal: watcherProposal({
 				action: "create",
-				watcher_id: WATCHER_ID,
+				behavior_id: WATCHER_ID,
 				agent_id: AGENT,
 			}),
 		});
@@ -385,7 +385,7 @@ describe("GET /:agentId/behaviors/:watcherId/pending/:runId", () => {
 			tool: "manage_behaviors",
 			proposal: watcherProposal({
 				action: "update",
-				watcher_id: 999,
+				behavior_id: 999,
 				name: "X",
 			}),
 			current: { id: 999, agent_id: AGENT },
@@ -402,7 +402,7 @@ describe("GET /:agentId/behaviors/:watcherId/pending/:runId", () => {
 			tool: "manage_behaviors",
 			proposal: watcherProposal({
 				action: "update",
-				watcher_id: WATCHER_ID,
+				behavior_id: WATCHER_ID,
 				name: "X",
 			}),
 			current: { id: WATCHER_ID, agent_id: "other-agent" },
@@ -428,7 +428,7 @@ describe("GET /:agentId/behaviors/:watcherId/pending/:runId", () => {
 			tool: "manage_behaviors",
 			proposal: watcherProposal({
 				action: "update",
-				watcher_id: WATCHER_ID,
+				behavior_id: WATCHER_ID,
 				name: "X",
 			}),
 			current: { id: WATCHER_ID, agent_id: AGENT },

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1483,8 +1483,8 @@ routes.get("/:agentId/behaviors/:watcherId/pending/:runId", async (c) => {
 	if (!args || typeof args !== "object") {
 		return c.json({ error: "No pending proposal for this run" }, 404);
 	}
-	const targetWatcherId = args.watcher_id ?? null;
-	if (String(targetWatcherId) !== String(watcherId)) {
+	const targetBehaviorId = args.behavior_id ?? null;
+	if (String(targetBehaviorId) !== String(watcherId)) {
 		return c.json({ error: "No pending proposal for this run" }, 404);
 	}
 	const current = row.current ?? null;

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -133,14 +133,14 @@ async function withPublicOrg<T>(
  */
 export async function restGetBehaviors(c: Context<{ Bindings: Env }>) {
 	try {
-		const watcherId = c.req.query("watcher_id");
+		const behaviorId = c.req.query("behavior_id");
 		const entityId = safeParseInt(c.req.query("entity_id"), { min: 1 });
 
-		if (!watcherId) {
+		if (!behaviorId) {
 			const result = await manageBehaviors(
 				{
 					action: "list",
-					watcher_id: watcherId,
+					behavior_id: behaviorId,
 					entity_id: entityId,
 					status: c.req.query("status") || undefined,
 					include_details: c.req.query("include_details") === "true",
@@ -152,7 +152,7 @@ export async function restGetBehaviors(c: Context<{ Bindings: Env }>) {
 		}
 
 		const params = {
-			watcher_id: watcherId,
+			behavior_id: behaviorId,
 			entity_id: entityId,
 			content_since: c.req.query("content_since"),
 			content_until: c.req.query("content_until"),
@@ -180,11 +180,11 @@ export async function restGetBehaviors(c: Context<{ Bindings: Env }>) {
 
 export async function publicRestGetBehaviors(c: Context<{ Bindings: Env }>) {
 	return withPublicOrg(c, async (organizationId) => {
-		const watcherId = c.req.query("watcher_id");
+		const behaviorId = c.req.query("behavior_id");
 		const entityId = safeParseInt(c.req.query("entity_id"), { min: 1 });
 		const ctx = publicToolContext(c.req.url, organizationId);
 		const detailRequested =
-			!!watcherId ||
+			!!behaviorId ||
 			[
 				"content_since",
 				"content_until",
@@ -212,7 +212,7 @@ export async function publicRestGetBehaviors(c: Context<{ Bindings: Env }>) {
 
 		return getBehavior(
 			{
-				watcher_id: watcherId,
+				behavior_id: behaviorId,
 				entity_id: entityId,
 				content_since: c.req.query("content_since"),
 				content_until: c.req.query("content_until"),
@@ -227,7 +227,7 @@ export async function publicRestGetBehaviors(c: Context<{ Bindings: Env }>) {
 				include_versions: c.req.query("include_versions") === "true",
 				include_pending_ranges:
 					c.req.query("include_pending_ranges") === "true",
-				include_template_details: watcherId ? true : undefined,
+				include_template_details: behaviorId ? true : undefined,
 			} as any,
 			c.env,
 			ctx

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -432,13 +432,13 @@ export default async (_ctx, client) => {
 			"Send a notification to org users. Writes an `agent_message` notification (in-app inbox) and fans it out to the org's active bot connections (Slack/Telegram) — the way a Behavior reaction surfaces its digest to a chat channel. Pass an optional `card` (a `chat` CardElement) for rich cross-platform rendering, and `watcher_source` when firing from a reaction.",
 		access: "write",
 		example:
-			"await client.notifications.send({ title: 'Weekly funnel digest', body: '3 new leads...', watcher_source: { watcher_id: ctx.window.behavior_id, window_id: ctx.window.id } });",
+			"await client.notifications.send({ title: 'Weekly funnel digest', body: '3 new leads...', watcher_source: { watcher_id: ctx.window.watcher_id, window_id: ctx.window.id } });",
 		usageExample: `// Push a Behavior digest to the org's Slack/Telegram connections + inbox.
 export default async (ctx, client) => {
   await client.notifications.send({
     title: 'Weekly funnel digest',
     body: 'Top action: send the Acme pilot offer\\nNew leads: 3',
-    watcher_source: { watcher_id: ctx.window.behavior_id, window_id: ctx.window.id },
+    watcher_source: { watcher_id: ctx.window.watcher_id, window_id: ctx.window.id },
   });
 };`,
 	},

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -432,13 +432,13 @@ export default async (_ctx, client) => {
 			"Send a notification to org users. Writes an `agent_message` notification (in-app inbox) and fans it out to the org's active bot connections (Slack/Telegram) — the way a Behavior reaction surfaces its digest to a chat channel. Pass an optional `card` (a `chat` CardElement) for rich cross-platform rendering, and `watcher_source` when firing from a reaction.",
 		access: "write",
 		example:
-			"await client.notifications.send({ title: 'Weekly funnel digest', body: '3 new leads...', watcher_source: { watcher_id: ctx.window.watcher_id, window_id: ctx.window.id } });",
+			"await client.notifications.send({ title: 'Weekly funnel digest', body: '3 new leads...', watcher_source: { watcher_id: ctx.window.behavior_id, window_id: ctx.window.id } });",
 		usageExample: `// Push a Behavior digest to the org's Slack/Telegram connections + inbox.
 export default async (ctx, client) => {
   await client.notifications.send({
     title: 'Weekly funnel digest',
     body: 'Top action: send the Acme pilot offer\\nNew leads: 3',
-    watcher_source: { watcher_id: ctx.window.watcher_id, window_id: ctx.window.id },
+    watcher_source: { watcher_id: ctx.window.behavior_id, window_id: ctx.window.id },
   });
 };`,
 	},
@@ -449,7 +449,7 @@ export default async (ctx, client) => {
 			"Raw manage_behaviors action wrapper. Prefer named methods such as behaviors.trigger or behaviors.createVersion.",
 		access: "external",
 		example:
-			"await client.behaviors.manage({ action: 'trigger', watcher_id: '42' });",
+			"await client.behaviors.manage({ action: 'trigger', behavior_id: '42' });",
 	},
 	"behaviors.list": {
 		summary:
@@ -467,7 +467,7 @@ export default async (ctx, client) => {
 		access: "read",
 		throws: ["BehaviorNotFound"],
 		example:
-			"const behavior = await client.behaviors.get({ watcher_id: '42' });",
+			"const behavior = await client.behaviors.get({ behavior_id: '42' });",
 	},
 	"behaviors.create": {
 		summary:
@@ -508,15 +508,15 @@ export default async (_ctx, client) => {
 		summary:
 			"Trigger an immediate Behavior run and dispatch it to its assigned agent.",
 		access: "external",
-		example: "await client.behaviors.trigger({ watcher_id: '42' });",
+		example: "await client.behaviors.trigger({ behavior_id: '42' });",
 		usageExample: `export default async (_ctx, client) => {
-  return client.behaviors.trigger({ watcher_id: '42' });
+  return client.behaviors.trigger({ behavior_id: '42' });
 };`,
 	},
 	"behaviors.delete": {
 		summary: "Delete one or more Behaviors.",
 		access: "admin",
-		example: "await client.behaviors.delete({ watcher_ids: ['42'] });",
+		example: "await client.behaviors.delete({ behavior_ids: ['42'] });",
 	},
 	"behaviors.setReactionScript": {
 		summary:

--- a/packages/server/src/sandbox/namespaces/behaviors.ts
+++ b/packages/server/src/sandbox/namespaces/behaviors.ts
@@ -23,8 +23,8 @@ import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
 type BehaviorId = string;
-type BehaviorActionInput = Omit<ManageBehaviorsArgs, "action" | "watcher_id"> & {
-	watcher_id?: BehaviorId;
+type BehaviorActionInput = Omit<ManageBehaviorsArgs, "action" | "behavior_id"> & {
+	behavior_id?: BehaviorId;
 };
 
 export type BehaviorListFilter = ListBehaviorsArgs;
@@ -50,7 +50,7 @@ export interface BehaviorCreateInput {
 }
 
 export interface BehaviorUpdateInput {
-	watcher_id: BehaviorId;
+	behavior_id: BehaviorId;
 	triggers?: BehaviorTrigger[];
 	agent_id?: string;
 	scheduler_client_id?: string;
@@ -60,7 +60,7 @@ export interface BehaviorUpdateInput {
 }
 
 export interface BehaviorCompleteWindowInput {
-	watcher_id: BehaviorId;
+	behavior_id: BehaviorId;
 	/** JWT obtained from read_knowledge(watcher_id, since, until). */
 	window_token?: string;
 	/** Multiple page JWTs obtained from read_knowledge for the same watcher window. */
@@ -74,16 +74,16 @@ export interface BehaviorCompleteWindowInput {
 }
 
 export interface BehaviorCreateVersionInput extends BehaviorActionInput {
-	watcher_id: BehaviorId;
+	behavior_id: BehaviorId;
 }
 
 export interface BehaviorVersionDetailsInput {
-	watcher_id: BehaviorId;
+	behavior_id: BehaviorId;
 	version?: number;
 }
 
 export interface BehaviorSubmitFeedbackInput {
-	watcher_id: BehaviorId;
+	behavior_id: BehaviorId;
 	window_id: number;
 	corrections: Array<{
 		field_path: string;
@@ -94,7 +94,7 @@ export interface BehaviorSubmitFeedbackInput {
 }
 
 export interface BehaviorGetFeedbackInput {
-	watcher_id: BehaviorId;
+	behavior_id: BehaviorId;
 	window_id?: number;
 	limit?: number;
 }
@@ -109,20 +109,20 @@ export interface BehaviorsNamespace {
 	/** Raw escape hatch for any manage_behaviors action. Prefer named methods. */
 	manage(input: ManageBehaviorsArgs): Promise<unknown>;
 	list(filter?: BehaviorListFilter): Promise<unknown>;
-	get(input: { watcher_id: BehaviorId }): Promise<unknown>;
+	get(input: { behavior_id: BehaviorId }): Promise<unknown>;
 	create(input: BehaviorCreateInput): Promise<unknown>;
 	update(input: BehaviorUpdateInput): Promise<unknown>;
 	createVersion(input: BehaviorCreateVersionInput): Promise<unknown>;
 	completeWindow(input: BehaviorCompleteWindowInput): Promise<unknown>;
-	trigger(input: { watcher_id: BehaviorId }): Promise<unknown>;
+	trigger(input: { behavior_id: BehaviorId }): Promise<unknown>;
 	/** Delete one or more Behaviors. */
-	delete(input: { watcher_ids: BehaviorId[] }): Promise<unknown>;
+	delete(input: { behavior_ids: BehaviorId[] }): Promise<unknown>;
 	setReactionScript(input: {
-		watcher_id: BehaviorId;
+		behavior_id: BehaviorId;
 		/** TypeScript source. Empty string removes it. */
 		reaction_script: string;
 	}): Promise<unknown>;
-	getVersions(watcher_id: BehaviorId): Promise<unknown>;
+	getVersions(behavior_id: BehaviorId): Promise<unknown>;
 	getVersionDetails(
 		input: BehaviorId | BehaviorVersionDetailsInput,
 	): Promise<unknown>;
@@ -134,9 +134,9 @@ export interface BehaviorsNamespace {
 
 function normalizeVersionDetailsInput(
 	input: BehaviorId | BehaviorVersionDetailsInput,
-): { watcher_id: string; version?: number } {
+): { behavior_id: string; version?: number } {
 	if (typeof input === "string") {
-		return { watcher_id: input };
+		return { behavior_id: input };
 	}
 	return input;
 }
@@ -164,7 +164,7 @@ export function buildBehaviorsNamespace(
 		trigger: (input) => action("trigger", input),
 		delete: (input) => action("delete", input),
 		setReactionScript: (input) => action("set_reaction_script", input),
-		getVersions: (watcher_id) => action("get_versions", { watcher_id }),
+		getVersions: (behavior_id) => action("get_versions", { behavior_id }),
 		getVersionDetails: (input) =>
 			action("get_version_details", normalizeVersionDetailsInput(input)),
 		getComponentReference: () => action("get_component_reference"),

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -127,32 +127,32 @@ async function manageBehaviorsImpl(
     } else {
       await requireOrgReadAccess(pgSql, ctx);
     }
-  } else if (args.action === 'update' && args.watcher_id) {
-    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
-  } else if (args.action === 'trigger' && args.watcher_id) {
-    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
-  } else if (args.action === 'delete' && args.watcher_ids && args.watcher_ids.length > 0) {
+  } else if (args.action === 'update' && args.behavior_id) {
+    await requireWatcherAccess(pgSql, [args.behavior_id], ctx, 'write');
+  } else if (args.action === 'trigger' && args.behavior_id) {
+    await requireWatcherAccess(pgSql, [args.behavior_id], ctx, 'write');
+  } else if (args.action === 'delete' && args.behavior_ids && args.behavior_ids.length > 0) {
     // delete alone allows missing ids to fall through to its per-id aggregate
     // ("not found or already archived"); every other action stays a hard 403.
-    await requireWatcherAccess(pgSql, args.watcher_ids, ctx, 'write', {
+    await requireWatcherAccess(pgSql, args.behavior_ids, ctx, 'write', {
       allowMissing: true,
     });
   } else if (args.action === 'complete_window' && args.entity_id) {
     await requireWriteAccess(pgSql, args.entity_id, ctx);
-  } else if (args.action === 'create_version' && args.watcher_id) {
-    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
-  } else if (args.action === 'set_reaction_script' && args.watcher_id) {
-    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
-  } else if (args.action === 'submit_feedback' && args.watcher_id) {
-    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
-  } else if (args.action === 'get_feedback' && args.watcher_id) {
-    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
-  } else if (args.action === 'list_promoted' && args.watcher_id) {
-    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
-  } else if (args.action === 'get_versions' && args.watcher_id) {
-    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
-  } else if (args.action === 'get_version_details' && args.watcher_id) {
-    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
+  } else if (args.action === 'create_version' && args.behavior_id) {
+    await requireWatcherAccess(pgSql, [args.behavior_id], ctx, 'write');
+  } else if (args.action === 'set_reaction_script' && args.behavior_id) {
+    await requireWatcherAccess(pgSql, [args.behavior_id], ctx, 'write');
+  } else if (args.action === 'submit_feedback' && args.behavior_id) {
+    await requireWatcherAccess(pgSql, [args.behavior_id], ctx, 'write');
+  } else if (args.action === 'get_feedback' && args.behavior_id) {
+    await requireWatcherAccess(pgSql, [args.behavior_id], ctx, 'read');
+  } else if (args.action === 'list_promoted' && args.behavior_id) {
+    await requireWatcherAccess(pgSql, [args.behavior_id], ctx, 'read');
+  } else if (args.action === 'get_versions' && args.behavior_id) {
+    await requireWatcherAccess(pgSql, [args.behavior_id], ctx, 'read');
+  } else if (args.action === 'get_version_details' && args.behavior_id) {
+    await requireWatcherAccess(pgSql, [args.behavior_id], ctx, 'read');
   } else if (args.action === 'create_from_version' && args.entity_ids) {
     for (const eid of args.entity_ids) {
       await requireWriteAccess(pgSql, eid, ctx);
@@ -203,8 +203,8 @@ const WATCHER_GROUP_LOCK_NS = 'watcher_group_ownership';
  * escalation guard reads and the mutation writes must not have its owner changed
  * underneath us. Returns null when there is no pre-existing group to race on:
  *   - `create` mints a brand-new row (no target yet).
- *   - `update` targets args.watcher_id → its group.
- *   - `create_version` / `set_reaction_script` write GROUP-WIDE off args.watcher_id.
+ *   - `update` targets args.behavior_id → its group.
+ *   - `create_version` / `set_reaction_script` write GROUP-WIDE off args.behavior_id.
  *   - `create_from_version` reads a SOURCE version → lock the source watcher's group
  *     so a concurrent reassign of the source can't change the owner we clone.
  * All lookups are org-scoped.
@@ -219,10 +219,10 @@ async function resolveTargetWatcherGroupId(
     args.action === 'create_version' ||
     args.action === 'set_reaction_script'
   ) {
-    if (args.watcher_id == null) return null;
+    if (args.behavior_id == null) return null;
     const rows = await sql<{ watcher_group_id: number | null }>`
       SELECT watcher_group_id FROM watchers
-      WHERE id = ${Number(args.watcher_id)} AND organization_id = ${ctx.organizationId}
+      WHERE id = ${Number(args.behavior_id)} AND organization_id = ${ctx.organizationId}
       LIMIT 1
     `;
     const gid = rows.length > 0 ? rows[0].watcher_group_id : null;
@@ -362,24 +362,24 @@ async function resolveEffectiveWatcherOwners(
     }
     case 'update': {
       if (args.agent_id != null) return [args.agent_id];
-      if (args.watcher_id == null) return [];
+      if (args.behavior_id == null) return [];
       const rows = await sql<{ agent_id: string | null }>`
         SELECT agent_id FROM watchers
-        WHERE id = ${Number(args.watcher_id)} AND organization_id = ${ctx.organizationId}
+        WHERE id = ${Number(args.behavior_id)} AND organization_id = ${ctx.organizationId}
         LIMIT 1
       `;
       return rows.length > 0 ? [rows[0].agent_id ?? null] : [];
     }
     case 'create_version':
     case 'set_reaction_script': {
-      if (args.watcher_id == null) return [];
+      if (args.behavior_id == null) return [];
       // Group-wide: EVERY owner in the target watcher's group is affected.
       const rows = await sql<{ agent_id: string | null }>`
         SELECT DISTINCT agent_id FROM watchers
         WHERE organization_id = ${ctx.organizationId}
           AND watcher_group_id = (
             SELECT watcher_group_id FROM watchers
-            WHERE id = ${Number(args.watcher_id)} AND organization_id = ${ctx.organizationId}
+            WHERE id = ${Number(args.behavior_id)} AND organization_id = ${ctx.organizationId}
             LIMIT 1
           )
       `;
@@ -398,13 +398,13 @@ function watcherActionLabel(args: ManageBehaviorsArgs): string {
     case 'create_from_version':
       return `Create Behaviors from version ${args.version_id ?? '?'}`;
     case 'update':
-      return `Update Behavior ${args.watcher_id ?? '?'}`;
+      return `Update Behavior ${args.behavior_id ?? '?'}`;
     case 'create_version':
-      return `Create version for Behavior ${args.watcher_id ?? '?'}`;
+      return `Create version for Behavior ${args.behavior_id ?? '?'}`;
     case 'set_reaction_script':
-      return `Set reaction script on Behavior ${args.watcher_id ?? '?'}`;
+      return `Set reaction script on Behavior ${args.behavior_id ?? '?'}`;
     case 'delete':
-      return `Delete Behavior(s) ${(args.watcher_ids ?? []).join(', ') || '?'}`;
+      return `Delete Behavior(s) ${(args.behavior_ids ?? []).join(', ') || '?'}`;
     default:
       return `Behavior ${args.action}`;
   }
@@ -418,12 +418,12 @@ async function fetchCurrentWatcher(
   organizationId: string,
   args: ManageBehaviorsArgs
 ): Promise<Record<string, unknown> | null> {
-  if (args.watcher_id == null) return null;
+  if (args.behavior_id == null) return null;
   const sql = getDb();
   const rows = await sql`
     SELECT id, slug, name, description, agent_id, schedule, timezone, triggers, status
     FROM watchers
-    WHERE organization_id = ${organizationId} AND id = ${Number(args.watcher_id)}
+    WHERE organization_id = ${organizationId} AND id = ${Number(args.behavior_id)}
     LIMIT 1
   `;
   return (rows[0] as Record<string, unknown> | undefined) ?? null;
@@ -456,14 +456,14 @@ function buildWatcherProposal(
       );
     }
   }
-  if (args.action === 'delete' && (!args.watcher_ids || args.watcher_ids.length === 0)) {
-    throw new ToolUserError('watcher_ids is required for delete action');
+  if (args.action === 'delete' && (!args.behavior_ids || args.behavior_ids.length === 0)) {
+    throw new ToolUserError('behavior_ids is required for delete action');
   }
   if (
     (args.action === 'create_version' || args.action === 'set_reaction_script') &&
-    args.watcher_id == null
+    args.behavior_id == null
   ) {
-    throw new ToolUserError(`watcher_id is required for ${args.action} action`);
+    throw new ToolUserError(`behavior_id is required for ${args.action} action`);
   }
   if (args.action === 'set_reaction_script' && args.reaction_script === undefined) {
     // An omitted script silently REMOVES the existing reaction (handleSetReactionScript
@@ -535,8 +535,8 @@ const WATCHER_PATCHABLE_FIELDS = [
  * silent `updated_fields: []`).
  */
 function assertWatcherUpdateArgs(args: ManageBehaviorsArgs): void {
-  if (args.watcher_id == null) {
-    throw new ToolUserError('watcher_id is required for update action');
+  if (args.behavior_id == null) {
+    throw new ToolUserError('behavior_id is required for update action');
   }
   const present = (keys: readonly string[]): string[] =>
     keys.filter((k) => args[k as keyof ManageBehaviorsArgs] !== undefined);
@@ -576,7 +576,7 @@ function pickWatcherApprovalDisplayFields(args: ManageBehaviorsArgs): Record<str
       continue;
     }
     if (Array.isArray(value)) {
-      // Primitive arrays (watcher_ids, entity_ids, tags) collapse to a readable
+      // Primitive arrays (behavior_ids, entity_ids, tags) collapse to a readable
       // list; object arrays (sources) serialize to JSON so the schema's string
       // field renders the actual structure, not "[object Object]".
       out[key] = value.every(
@@ -607,8 +607,8 @@ const WATCHER_APPROVAL_FIELD_TITLES: Record<string, string> = {
   triggers: 'Triggers',
   timezone: 'Timezone',
   agent_id: 'Agent',
-  watcher_id: 'Behavior ID',
-  watcher_ids: 'Behavior IDs',
+  behavior_id: 'Behavior ID',
+  behavior_ids: 'Behavior IDs',
   version_id: 'Version ID',
   entity_id: 'Entity ID',
   entity_ids: 'Entity IDs',
@@ -689,7 +689,7 @@ async function queueWatcherWriteForApproval(
 
   const current = await fetchCurrentWatcher(ctx.organizationId, args);
   if (args.action === 'update' && !current) {
-    throw new ToolUserError(`Behavior "${args.watcher_id}" not found`, 404);
+    throw new ToolUserError(`Behavior "${args.behavior_id}" not found`, 404);
   }
 
   const sql = getDb();
@@ -729,7 +729,7 @@ async function queueWatcherWriteForApproval(
       action_key: MANAGE_BEHAVIORS_ACTION_KEY,
       action: args.action,
       resourceKind: 'watcher',
-      watcher_id: args.watcher_id ?? null,
+      watcher_id: args.behavior_id ?? null,
       proposal,
       current: current ?? null,
       status: 'pending_approval',
@@ -751,8 +751,8 @@ async function queueWatcherWriteForApproval(
   // so they keep the run permalink (valid across the supersede chain on approve).
   const ownerAgentId = args.agent_id ?? (current?.agent_id as string | null | undefined) ?? null;
   const settingsReviewUrl =
-    args.action === 'update' && args.watcher_id != null && ownerAgentId
-      ? await buildBehaviorSettingsUrl(baseUrl, ctx.organizationId, ownerAgentId, args.watcher_id, {
+    args.action === 'update' && args.behavior_id != null && ownerAgentId
+      ? await buildBehaviorSettingsUrl(baseUrl, ctx.organizationId, ownerAgentId, args.behavior_id, {
           runId,
         }).catch(() => null)
       : null;

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -48,7 +48,7 @@ export async function handleCompleteWindow(
   ctx: ToolContext
 ): Promise<{
   action: 'complete_window';
-  watcher_id: string;
+  behavior_id: string;
   window_id: number;
   window_start: string;
   window_end: string;
@@ -655,7 +655,7 @@ export async function handleCompleteWindow(
 
     return {
       action: 'complete_window' as const,
-      watcher_id: String(watcherId),
+      behavior_id: String(watcherId),
       window_id: windowId,
       window_start,
       window_end,
@@ -698,7 +698,7 @@ export async function handleCompleteWindow(
            wv.version as watcher_version
     FROM watchers w
     LEFT JOIN watcher_versions wv ON w.current_version_id = wv.id
-    WHERE w.id = ${result.watcher_id}
+    WHERE w.id = ${result.behavior_id}
   `;
 
   try {
@@ -730,7 +730,7 @@ export async function handleCompleteWindow(
                COALESCE(w.slug, 'watcher-' || w.id) as slug
         FROM watchers w
         LEFT JOIN watcher_versions wv ON w.current_version_id = wv.id
-        WHERE w.id = ${result.watcher_id}
+        WHERE w.id = ${result.behavior_id}
       `;
 
       const reactionContext = {
@@ -744,16 +744,16 @@ export async function handleCompleteWindow(
         window: {
           id: result.window_id,
           run_id: watcherRunId,
-          watcher_id: Number(result.watcher_id),
+          watcher_id: Number(result.behavior_id),
           window_start: result.window_start,
           window_end: result.window_end,
           granularity: timeGranularity,
           content_analyzed: batchContentIds.length,
         },
         behavior: {
-          id: Number(result.watcher_id),
-          slug: (watcherMeta[0]?.slug ?? `watcher-${result.watcher_id}`) as string,
-          name: (watcherMeta[0]?.name ?? `watcher-${result.watcher_id}`) as string,
+          id: Number(result.behavior_id),
+          slug: (watcherMeta[0]?.slug ?? `watcher-${result.behavior_id}`) as string,
+          name: (watcherMeta[0]?.name ?? `watcher-${result.behavior_id}`) as string,
           version: Number(row.watcher_version ?? 1),
         },
         organization_id: orgId,
@@ -769,7 +769,7 @@ export async function handleCompleteWindow(
 
         await trackWatcherReaction({
           organizationId: orgId,
-          watcherId: Number(result.watcher_id),
+          watcherId: Number(result.behavior_id),
           windowId: result.window_id,
           reactionType: 'script_execution',
           toolName: 'reaction_executor',
@@ -781,7 +781,7 @@ export async function handleCompleteWindow(
           reactionStatus = 'success';
           logger.info(
             {
-              watcher_id: result.watcher_id,
+              watcher_id: result.behavior_id,
               window_id: result.window_id,
               attempt,
             },
@@ -791,7 +791,7 @@ export async function handleCompleteWindow(
         }
         if (attempt < MAX_ATTEMPTS) {
           logger.warn(
-            { watcher_id: result.watcher_id, attempt, error: execResult.error },
+            { watcher_id: result.behavior_id, attempt, error: execResult.error },
             'Reaction script failed, retrying...'
           );
           await new Promise((r) => setTimeout(r, 1000));
@@ -799,7 +799,7 @@ export async function handleCompleteWindow(
           reactionStatus = 'failed';
           reactionError = execResult.error;
           logger.error(
-            { watcher_id: result.watcher_id, error: execResult.error },
+            { watcher_id: result.behavior_id, error: execResult.error },
             'Reaction script failed after all retries'
           );
         }

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -83,7 +83,7 @@ export async function handleCreate(
   ctx: ToolContext
 ): Promise<{
   action: 'create';
-  watcher_id: string;
+  behavior_id: string;
   version: number;
   status: string;
   sources?: Array<{ name: string; query: string }>;
@@ -395,7 +395,7 @@ export async function handleCreate(
 
   return {
     action: 'create',
-    watcher_id: String(watcherId),
+    behavior_id: String(watcherId),
     version: 1,
     status: 'active',
     sources,
@@ -411,11 +411,11 @@ export async function handleUpdate(
   args: ManageBehaviorsArgs,
   _env: Env,
   ctx: ToolContext
-): Promise<{ action: 'update'; watcher_id: string; updated_fields: string[] }> {
+): Promise<{ action: 'update'; behavior_id: string; updated_fields: string[] }> {
   const sql = getDb();
 
-  if (!args.watcher_id) {
-    throw new Error('watcher_id is required for update action');
+  if (!args.behavior_id) {
+    throw new Error('behavior_id is required for update action');
   }
   assertValidExecutionConfig(args.execution_config, ctx);
   // Re-pinning to a device targets that device owner's machine — validate the
@@ -423,11 +423,11 @@ export async function handleUpdate(
   // undefined = unchanged and null = clear the pin both pass without a lookup.
   await assertDeviceWorkerAccess(sql, args.device_worker_id, ctx);
 
-  await requireExists(sql, 'watchers', args.watcher_id, 'Behavior');
+  await requireExists(sql, 'watchers', args.behavior_id, 'Behavior');
   const currentRows = await sql`
     SELECT organization_id, agent_id, schedule, timezone, triggers
     FROM watchers
-    WHERE id = ${args.watcher_id}
+    WHERE id = ${args.behavior_id}
     LIMIT 1
   `;
   const currentRow = currentRows[0] as {
@@ -482,7 +482,7 @@ export async function handleUpdate(
   if (updatedFields.length === 0) {
     return {
       action: 'update',
-      watcher_id: args.watcher_id,
+      behavior_id: args.behavior_id,
       updated_fields: [],
     };
   }
@@ -525,11 +525,11 @@ export async function handleUpdate(
       notification_channel = CASE WHEN ${has('notification_channel')} THEN ${patch.notification_channel ?? 'canvas'} ELSE notification_channel END,
       notification_priority = CASE WHEN ${has('notification_priority')} THEN ${patch.notification_priority ?? 'normal'} ELSE notification_priority END,
       min_cooldown_seconds = CASE WHEN ${has('min_cooldown_seconds')} THEN ${patch.min_cooldown_seconds ?? 0} ELSE min_cooldown_seconds END
-    WHERE id = ${args.watcher_id} AND organization_id = ${ctx.organizationId}
+    WHERE id = ${args.behavior_id} AND organization_id = ${ctx.organizationId}
     RETURNING *
   `;
 
-  logger.info(`[manage_behaviors] Updated watcher ${args.watcher_id}: ${updatedFields.join(', ')}`);
+  logger.info(`[manage_behaviors] Updated watcher ${args.behavior_id}: ${updatedFields.join(', ')}`);
 
   const updatedRow = (updatedRows[0] ?? null) as Record<string, unknown> | null;
   await syncBehaviorChannelFeedsBestEffort({
@@ -541,16 +541,16 @@ export async function handleUpdate(
   recordToolConfigChange(ctx, {
     organizationId: (updatedRow?.organization_id as string | null) ?? ctx.organizationId,
     resourceKind: 'watcher',
-    resourceId: args.watcher_id,
+    resourceId: args.behavior_id,
     op: 'updated',
-    summary: `Behavior '${updatedRow?.name ?? args.watcher_id}' updated`,
+    summary: `Behavior '${updatedRow?.name ?? args.behavior_id}' updated`,
     state: updatedRow,
     changedFields: updatedFields,
   });
 
   return {
     action: 'update',
-    watcher_id: args.watcher_id,
+    behavior_id: args.behavior_id,
     updated_fields: updatedFields,
   };
 }
@@ -569,13 +569,13 @@ export async function handleDelete(
 }> {
   const sql = getDb();
 
-  if (!args.watcher_ids || args.watcher_ids.length === 0) {
-    throw new Error('watcher_ids is required and cannot be empty');
+  if (!args.behavior_ids || args.behavior_ids.length === 0) {
+    throw new Error('behavior_ids is required and cannot be empty');
   }
 
   const results: WatcherOperationResult[] = [];
 
-  for (const watcherId of args.watcher_ids) {
+  for (const watcherId of args.behavior_ids) {
     try {
       // Org-scope the mutation: requireWatcherAccess now lets ids that aren't
       // in-org at check time fall through to this aggregate, and watcher ids are
@@ -592,7 +592,7 @@ export async function handleDelete(
 
       if (updated.length === 0) {
         results.push({
-          watcher_id: watcherId,
+          behavior_id: watcherId,
           success: false,
           message: 'Behavior not found or already archived',
         });
@@ -639,14 +639,14 @@ export async function handleDelete(
         }
 
         results.push({
-          watcher_id: watcherId,
+          behavior_id: watcherId,
           success: true,
           message: 'Behavior archived successfully',
         });
       }
     } catch (error) {
       results.push({
-        watcher_id: watcherId,
+        behavior_id: watcherId,
         success: false,
         message: getErrorMessage(error),
       });
@@ -670,7 +670,7 @@ export async function handleCreateFromVersion(
   ctx: ToolContext
 ): Promise<{
   action: 'create_from_version';
-  created: Array<{ watcher_id: string; entity_id: number; name: string }>;
+  created: Array<{ behavior_id: string; entity_id: number; name: string }>;
 }> {
   const sql = getDb();
 
@@ -730,7 +730,7 @@ export async function handleCreateFromVersion(
 
   const createdBy = ctx.userId ?? 'system';
   const created: Array<{
-    watcher_id: string;
+    behavior_id: string;
     entity_id: number;
     name: string;
   }> = [];
@@ -811,7 +811,7 @@ export async function handleCreateFromVersion(
         `;
 
         created.push({
-          watcher_id: String(watcherId),
+          behavior_id: String(watcherId),
           entity_id: entityId,
           name: watcherName,
         });

--- a/packages/server/src/tools/admin/manage_behaviors/feedback.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/feedback.ts
@@ -170,7 +170,7 @@ export async function handleSubmitFeedback(
   args: ManageBehaviorsArgs,
   ctx: ToolContext
 ): Promise<ManageBehaviorsResult> {
-  if (!args.watcher_id) throw new Error('watcher_id is required');
+  if (!args.behavior_id) throw new Error('behavior_id is required');
   if (!args.window_id) throw new Error('window_id is required');
   if (!ctx.userId) {
     throw new Error('Authentication required to submit feedback');
@@ -194,7 +194,7 @@ export async function handleSubmitFeedback(
   }
 
   const sql = getDb();
-  const watcherId = Number(args.watcher_id);
+  const watcherId = Number(args.behavior_id);
 
   // Scope to the caller's current org so a member of org A can't write
   // feedback against a watcher in org B by passing its watcher_id. window_id is
@@ -347,7 +347,7 @@ export async function handleSubmitFeedback(
 
   return {
     action: 'submit_feedback',
-    watcher_id: args.watcher_id,
+    behavior_id: args.behavior_id,
     window_id: args.window_id,
     feedback_ids: feedbackIds,
   };
@@ -361,10 +361,10 @@ export async function handleGetFeedback(
   args: ManageBehaviorsArgs,
   ctx: ToolContext
 ): Promise<ManageBehaviorsResult> {
-  if (!args.watcher_id) throw new Error('watcher_id is required');
+  if (!args.behavior_id) throw new Error('behavior_id is required');
 
   const sql = getDb();
-  const watcherId = Number(args.watcher_id);
+  const watcherId = Number(args.behavior_id);
   const limit = args.limit ?? 50;
 
   // Scope to the caller's current org so a member of org A can't enumerate feedback for a watcher
@@ -410,7 +410,7 @@ export async function handleGetFeedback(
 
   return {
     action: 'get_feedback',
-    watcher_id: args.watcher_id,
+    behavior_id: args.behavior_id,
     feedback: feedback.map((row) => ({
       id: Number(row.id),
       window_id: Number(row.window_id),
@@ -445,10 +445,10 @@ export async function handleListPromoted(
   args: ManageBehaviorsArgs,
   ctx: ToolContext
 ): Promise<ManageBehaviorsResult> {
-  if (!args.watcher_id) throw new Error('watcher_id is required');
+  if (!args.behavior_id) throw new Error('behavior_id is required');
 
   const sql = getDb();
-  const watcherId = String(Number(args.watcher_id));
+  const watcherId = String(Number(args.behavior_id));
   const limit = args.limit ?? 200;
 
   const rows = await sql`
@@ -465,7 +465,7 @@ export async function handleListPromoted(
 
   return {
     action: 'list_promoted',
-    watcher_id: args.watcher_id,
+    behavior_id: args.behavior_id,
     entities: rows.map((row) => {
       const metadata = parseJsonObject(row.metadata);
       const fieldControls = parseJsonObject(row.field_controls);

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -42,7 +42,7 @@ export async function handleList(
 
 	let query = `
     SELECT
-      i.id as watcher_id,
+      i.id as behavior_id,
       i.name,
       i.slug,
       i.status,
@@ -120,9 +120,9 @@ export async function handleList(
 		paramCount++;
 	}
 
-	if (args.watcher_id) {
+	if (args.behavior_id) {
 		conditions.push(`i.id = $${paramCount}`);
-		params.push(args.watcher_id);
+		params.push(args.behavior_id);
 		paramCount++;
 	}
 
@@ -159,7 +159,7 @@ export async function handleList(
 	const result = await sql.unsafe(query, params);
 
 	const baseUrl = getPublicWebUrl(ctx.requestUrl, ctx.baseUrl);
-	const watcherIds = (result as any[]).map((i) => Number(i.watcher_id));
+	const watcherIds = (result as any[]).map((i) => Number(i.behavior_id));
 
 	let counts: Map<number, { pending: number; historical: number }>;
 	try {
@@ -184,7 +184,7 @@ export async function handleList(
 	}
 
 	const watchersWithPendingCount = (result as any[]).map((watcher) => {
-		const watcherId = Number(watcher.watcher_id);
+		const watcherId = Number(watcher.behavior_id);
 		const countData = counts.get(watcherId) || { pending: 0, historical: 0 };
 		const orgSlug = orgSlugMap.get(watcher.organization_id as string) ?? null;
 
@@ -201,17 +201,17 @@ export async function handleList(
 			delete (rest as Record<string, unknown>).description;
 		}
 
-		// Stringify `watcher_id` to match the rest of the manage_behaviors
+		// Stringify `behavior_id` to match the rest of the manage_behaviors
 		// contract: `handleCreate` returns `String(watcherId)`, the input schema
-		// declares `watcher_id` as a string, and downstream callers (CLI
+		// declares `behavior_id` as a string, and downstream callers (CLI
 		// `apply-cmd.ts` → `updateWatcher`, MCP tools) forward whatever they
 		// receive straight back. Without the cast the raw integer leaks through
 		// and a follow-up `update`/`upgrade` call fails the schema gate with
-		// `/watcher_id: Expected string`. Same bug pattern for `current_version_id`
+		// `/behavior_id: Expected string`. Same bug pattern for `current_version_id`
 		// (kept as-is — no consumer feeds it back into manage_behaviors today).
-		if ((rest as Record<string, unknown>).watcher_id != null) {
-			(rest as Record<string, unknown>).watcher_id = String(
-				(rest as Record<string, unknown>).watcher_id
+		if ((rest as Record<string, unknown>).behavior_id != null) {
+			(rest as Record<string, unknown>).behavior_id = String(
+				(rest as Record<string, unknown>).behavior_id
 			);
 		}
 

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -25,7 +25,7 @@ import { normalizeBehaviorTags } from '@lobu/core/contracts/tools/manage-behavio
 // ============================================
 
 export interface WatcherOperationResult {
-  watcher_id: string;
+  behavior_id: string;
   success: boolean;
   message: string;
   version?: number;

--- a/packages/server/src/tools/admin/manage_behaviors/trigger.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/trigger.ts
@@ -29,21 +29,21 @@ export async function handleTrigger(
   _env: Env,
 ): Promise<{
   action: "trigger";
-  watcher_id: string;
+  behavior_id: string;
   run_id: number;
   status: string;
 }> {
   const sql = getDb();
 
-  if (!args.watcher_id) {
-    throw new Error("watcher_id is required for trigger action");
+  if (!args.behavior_id) {
+    throw new Error("behavior_id is required for trigger action");
   }
 
   if (!isLobuGatewayRunning()) {
     throw new Error("Embedded Lobu is not available.");
   }
   const dispatchResult = await queueAndDispatchWatcherRun(
-    Number(args.watcher_id),
+    Number(args.behavior_id),
     "manual",
     sql,
   );
@@ -57,7 +57,7 @@ export async function handleTrigger(
 
   return {
     action: "trigger",
-    watcher_id: args.watcher_id,
+    behavior_id: args.behavior_id,
     run_id: dispatchResult.runId,
     status: dispatchResult.status,
   };
@@ -73,23 +73,23 @@ export async function handleSetReactionScript(
   ctx: ToolContext,
 ): Promise<{
   action: "set_reaction_script";
-  watcher_id: string;
+  behavior_id: string;
   has_script: boolean;
   message: string;
 }> {
   const sql = getDb();
 
-  if (!args.watcher_id) {
-    throw new Error("watcher_id is required for set_reaction_script");
+  if (!args.behavior_id) {
+    throw new Error("behavior_id is required for set_reaction_script");
   }
 
-  await requireExists(sql, "watchers", args.watcher_id, "Behavior");
+  await requireExists(sql, "watchers", args.behavior_id, "Behavior");
 
   // Reaction script is a group-shared field — every assignment in the
   // group runs the same reactions on its windows. Resolve the group once
   // and cascade across all assignments so we don't silently fork.
   const groupRows = await sql`
-    SELECT watcher_group_id FROM watchers WHERE id = ${args.watcher_id} LIMIT 1
+    SELECT watcher_group_id FROM watchers WHERE id = ${args.behavior_id} LIMIT 1
   `;
   const groupId = Number(groupRows[0].watcher_group_id);
 
@@ -104,11 +104,11 @@ export async function handleSetReactionScript(
     `;
     recordToolConfigChange(ctx, {
       resourceKind: "watcher",
-      resourceId: args.watcher_id,
+      resourceId: args.behavior_id,
       op: "updated",
-      summary: `Behavior ${args.watcher_id} reaction script removed`,
+      summary: `Behavior ${args.behavior_id} reaction script removed`,
       state: {
-        id: args.watcher_id,
+        id: args.behavior_id,
         watcher_group_id: groupId,
         reaction_script: null,
         reaction_input_schema: null,
@@ -117,7 +117,7 @@ export async function handleSetReactionScript(
     });
     return {
       action: "set_reaction_script",
-      watcher_id: String(args.watcher_id),
+      behavior_id: String(args.behavior_id),
       has_script: false,
       message: "Reaction script removed.",
     };
@@ -137,18 +137,18 @@ export async function handleSetReactionScript(
   `;
 
   logger.info(
-    `[manage_behaviors] Set reaction script for watcher ${args.watcher_id}`,
+    `[manage_behaviors] Set reaction script for watcher ${args.behavior_id}`,
   );
 
   recordToolConfigChange(ctx, {
     resourceKind: "watcher",
-    resourceId: args.watcher_id,
+    resourceId: args.behavior_id,
     op: "updated",
-    summary: `Behavior ${args.watcher_id} reaction script updated`,
+    summary: `Behavior ${args.behavior_id} reaction script updated`,
     // Snapshot of the fields just written (row not refetched); compiled code
     // is intentionally omitted to keep the state small.
     state: {
-      id: args.watcher_id,
+      id: args.behavior_id,
       watcher_group_id: groupId,
       reaction_script: script,
       reaction_input_schema: reactionInputSchema ?? null,
@@ -158,7 +158,7 @@ export async function handleSetReactionScript(
 
   return {
     action: "set_reaction_script",
-    watcher_id: String(args.watcher_id),
+    behavior_id: String(args.behavior_id),
     has_script: true,
     message:
       "Reaction script compiled and saved. It will auto-execute on future complete_window calls.",

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -35,15 +35,15 @@ export async function handleCreateVersion(
   ctx: ToolContext
 ): Promise<{
   action: 'create_version';
-  watcher_id: string;
+  behavior_id: string;
   version_id: string;
   version: number;
   previous_version: number;
 }> {
   const sql = getDb();
 
-  if (!args.watcher_id) {
-    throw new Error('watcher_id is required for create_version action');
+  if (!args.behavior_id) {
+    throw new Error('behavior_id is required for create_version action');
   }
 
   // Get current watcher + resolve the group root. Versioned config
@@ -55,10 +55,10 @@ export async function handleCreateVersion(
   const watcherRows = await sql`
     SELECT i.id, i.version, i.current_version_id, i.watcher_group_id, i.sources, i.organization_id,
            i.schedule, i.timezone, i.triggers
-    FROM watchers i WHERE i.id = ${args.watcher_id}
+    FROM watchers i WHERE i.id = ${args.behavior_id}
   `;
   if (watcherRows.length === 0) {
-    throw new Error(`Behavior ${args.watcher_id} not found`);
+    throw new Error(`Behavior ${args.behavior_id} not found`);
   }
 
   const groupId = Number(watcherRows[0].watcher_group_id);
@@ -236,7 +236,7 @@ export async function handleCreateVersion(
           timezone = CASE WHEN ${touchesCadence} THEN ${timezoneValue} ELSE timezone END,
           triggers = CASE WHEN ${touchesCadence} THEN ${tx.json(triggerWrite.triggers)} ELSE triggers END,
           next_run_at = CASE WHEN ${touchesCadence} THEN ${nextRunAtVal}::timestamptz ELSE next_run_at END
-        WHERE id = ${args.watcher_id}
+        WHERE id = ${args.behavior_id}
       `;
     }
   });
@@ -254,13 +254,13 @@ export async function handleCreateVersion(
     recordToolConfigChange(ctx, {
       organizationId: versionOrganizationId,
       resourceKind: 'watcher',
-      resourceId: args.watcher_id,
+      resourceId: args.behavior_id,
       op: 'updated',
-      summary: `Behavior '${args.name ?? (prev.name as string) ?? args.watcher_id}' version ${lockedNextVersion} created`,
+      summary: `Behavior '${args.name ?? (prev.name as string) ?? args.behavior_id}' version ${lockedNextVersion} created`,
       // Composed from the values just written (watcher row not refetched);
       // carries the new version-bound fields.
       state: {
-        id: args.watcher_id,
+        id: args.behavior_id,
         name: args.name ?? (prev.name as string) ?? 'Behavior',
         version: lockedNextVersion,
         current_version_id: setAsCurrent ? versionId : undefined,
@@ -290,7 +290,7 @@ export async function handleCreateVersion(
 
   return {
     action: 'create_version',
-    watcher_id: args.watcher_id,
+    behavior_id: args.behavior_id,
     version_id: String(versionId),
     version: lockedNextVersion,
     previous_version: previousVersion,
@@ -303,20 +303,20 @@ export async function handleCreateVersion(
 
 export async function handleGetVersions(args: ManageBehaviorsArgs): Promise<{
   action: 'get_versions';
-  watcher_id: string;
+  behavior_id: string;
   versions: any[];
 }> {
   const sql = getDb();
 
-  if (!args.watcher_id) {
-    throw new Error('watcher_id is required for get_versions action');
+  if (!args.behavior_id) {
+    throw new Error('behavior_id is required for get_versions action');
   }
 
   const watcherRows = await sql`
-    SELECT id, name, slug, current_version_id, watcher_group_id FROM watchers WHERE id = ${args.watcher_id}
+    SELECT id, name, slug, current_version_id, watcher_group_id FROM watchers WHERE id = ${args.behavior_id}
   `;
   if (watcherRows.length === 0) {
-    throw new Error(`Behavior ${args.watcher_id} not found`);
+    throw new Error(`Behavior ${args.behavior_id} not found`);
   }
 
   const currentVersionId = watcherRows[0].current_version_id;
@@ -357,7 +357,7 @@ export async function handleGetVersions(args: ManageBehaviorsArgs): Promise<{
 
   return {
     action: 'get_versions',
-    watcher_id: args.watcher_id,
+    behavior_id: args.behavior_id,
     versions,
   };
 }
@@ -371,8 +371,8 @@ export async function handleGetVersionDetails(
 ): Promise<ManageBehaviorsResult> {
   const sql = getDb();
 
-  if (!args.watcher_id) {
-    throw new Error('watcher_id is required for get_version_details action');
+  if (!args.behavior_id) {
+    throw new Error('behavior_id is required for get_version_details action');
   }
 
   let rows;
@@ -384,7 +384,7 @@ export async function handleGetVersionDetails(
         keying_config, classifiers,
         reactions_guidance
       FROM watcher_versions
-      WHERE watcher_id = ${args.watcher_id} AND version = ${args.version}
+      WHERE watcher_id = ${args.behavior_id} AND version = ${args.version}
       LIMIT 1
     `;
   } else {
@@ -396,14 +396,14 @@ export async function handleGetVersionDetails(
         v.reactions_guidance
       FROM watcher_versions v
       JOIN watchers w ON v.id = w.current_version_id
-      WHERE w.id = ${args.watcher_id}
+      WHERE w.id = ${args.behavior_id}
       LIMIT 1
     `;
   }
 
   if (rows.length === 0) {
     throw new Error(
-      `Version ${args.version ?? 'current'} not found for Behavior ${args.watcher_id}`
+      `Version ${args.version ?? 'current'} not found for Behavior ${args.behavior_id}`
     );
   }
 
@@ -411,7 +411,7 @@ export async function handleGetVersionDetails(
 
   return {
     action: 'get_version_details',
-    watcher_id: args.watcher_id,
+    behavior_id: args.behavior_id,
     version_id: String(v.id),
     version: Number(v.version),
     name: v.name as string | undefined,

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -67,7 +67,7 @@ import { withValidatedArgs } from './validate-args';
 // ============================================
 
 export const GetBehaviorSchema = Type.Object({
-  watcher_id: Type.String({ description: 'Behavior ID to query' }),
+  behavior_id: Type.String({ description: 'Behavior ID to query' }),
   entity_id: Type.Optional(
     Type.Number({
       description: 'Optional entity ID for access validation and URL context',
@@ -344,13 +344,13 @@ async function getBehaviorImpl(
   // Step 1: Validate inputs
   // ============================================
 
-  if (!args.watcher_id) {
+  if (!args.behavior_id) {
     throw new Error(
-      "watcher_id is required. Use manage_behaviors with action='list' to discover Behaviors."
+      "behavior_id is required. Use manage_behaviors with action='list' to discover Behaviors."
     );
   }
 
-  await requireWatcherReadAccess(pgSql, args.watcher_id, ctx);
+  await requireWatcherReadAccess(pgSql, args.behavior_id, ctx);
 
   // Entity resolution is deferred — for the typical case (only watcher_id
   // given), the watcher metadata query below already returns the watcher's
@@ -411,8 +411,8 @@ async function getBehaviorImpl(
     return `$${params.length}`;
   };
 
-  if (args.watcher_id) {
-    whereClauses.push(`iw.watcher_id = ${addParam(args.watcher_id)}`);
+  if (args.behavior_id) {
+    whereClauses.push(`iw.watcher_id = ${addParam(args.behavior_id)}`);
   } else if (args.entity_id) {
     whereClauses.push(`${addParam(args.entity_id)} = ANY(i.entity_ids)`);
     whereClauses.push(`i.status = 'active'`);
@@ -575,7 +575,7 @@ async function getBehaviorImpl(
   const requestedVersion = args.template_version ?? null;
   const requestedVersionId = args.template_version_id ?? null;
   const namespacesLiteral = STANDARD_IDENTITY_NAMESPACES.map((n) => `'${n}'`).join(',');
-  const watcherQueryPromise = args.watcher_id
+  const watcherQueryPromise = args.behavior_id
     ? sql.unsafe(
         `
       SELECT
@@ -650,7 +650,7 @@ async function getBehaviorImpl(
       ${buildLatestWatcherRunJoinSql('i', 'wr')}
       WHERE i.id = $1
     `,
-        [args.watcher_id, requestedVersion, requestedVersionId]
+        [args.behavior_id, requestedVersion, requestedVersionId]
       )
     : null;
 
@@ -744,7 +744,7 @@ async function getBehaviorImpl(
       : undefined;
     return {
       window_id: ensureNumber(w.window_id),
-      watcher_id: w.watcher_id,
+      behavior_id: w.watcher_id,
       watcher_name: w.watcher_name,
       granularity: w.granularity,
       // window_start/end and created_at come back from postgres.js as Date
@@ -773,7 +773,7 @@ async function getBehaviorImpl(
 
   let watcherMetadata: WatcherMetadata | undefined;
 
-  if (args.watcher_id && watcherRow) {
+  if (args.behavior_id && watcherRow) {
     const pinnedVersion = watcherRow.version;
 
     // The selected version row (prompt/schema/template) was folded into the
@@ -793,7 +793,7 @@ async function getBehaviorImpl(
             (wv.id = ${watcherRow.current_version_id}) as is_current
           FROM watcher_versions wv
           WHERE wv.watcher_id = (
-            SELECT watcher_group_id FROM watchers WHERE id = ${args.watcher_id}
+            SELECT watcher_group_id FROM watchers WHERE id = ${args.behavior_id}
           )
           ORDER BY wv.version DESC
         `
@@ -833,7 +833,7 @@ async function getBehaviorImpl(
     const watcherSources = parseWatcherSources(watcherRow.sources);
 
     watcherMetadata = {
-      watcher_id: watcherRow.watcher_id,
+      behavior_id: watcherRow.watcher_id,
       watcher_name: watcherRow.name || (version?.name as string) || 'Behavior',
       slug: watcherRow.slug || '',
       status: watcherRow.status as 'active' | 'archived',
@@ -884,7 +884,7 @@ async function getBehaviorImpl(
 
   let pendingAnalysis: PendingAnalysis | undefined;
 
-  if (args.watcher_id && watcherRow) {
+  if (args.behavior_id && watcherRow) {
     const watcherEntityIds = parseBigintArray(watcherRow.entity_ids);
     const watcherEntityId = watcherEntityIds[0] ?? 0;
     const timeGranularity = inferWatcherGranularityFromSchedule(watcherRow.schedule);
@@ -935,7 +935,7 @@ async function getBehaviorImpl(
       new Date(Date.now() - FRESH_WATCHER_LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString();
     const occurredAtBound = `f.occurred_at >= $${2 + entityLinkParams.length}::timestamptz`;
     const occurredAtBoundNoWatcher = `f.occurred_at >= $${1 + entityLinkOnlyParams.length}::timestamptz`;
-    const watcherScopedParams = [args.watcher_id, ...entityLinkParams, effectiveBound];
+    const watcherScopedParams = [args.behavior_id, ...entityLinkParams, effectiveBound];
     const noWatcherParams = [...entityLinkOnlyParams, effectiveBound];
 
     const notInWindowClause = `NOT EXISTS (
@@ -1021,7 +1021,7 @@ async function getBehaviorImpl(
             FROM current_event_records f
             WHERE ${entityScopeCondition}
               AND ${notInWindowClause}`,
-          [args.watcher_id, ...entityLinkParams]
+          [args.behavior_id, ...entityLinkParams]
         );
         const earliest = earliestResult[0]?.earliest as string | null;
         windowStart = earliest ? new Date(earliest) : now;
@@ -1055,7 +1055,7 @@ async function getBehaviorImpl(
       ? {
           tool: 'read_knowledge',
           params: {
-            watcher_id: args.watcher_id,
+            watcher_id: args.behavior_id,
             since: nextWindow.start.split('T')[0],
             until: nextWindow.end.split('T')[0],
           },
@@ -1073,7 +1073,7 @@ async function getBehaviorImpl(
 
     if (unprocessedCount > 0) {
       logger.info(
-        `[get_behavior] Found ${unprocessedCount} unprocessed content items for Behavior ${args.watcher_id}`
+        `[get_behavior] Found ${unprocessedCount} unprocessed content items for Behavior ${args.behavior_id}`
       );
     }
   }
@@ -1092,9 +1092,9 @@ async function getBehaviorImpl(
 
   if (formattedWindows.length === 0 && watcherRow) {
     if (watcherRow.status === 'archived') {
-      warnings.push(`Behavior "${watcherRow.name ?? args.watcher_id}" is archived.`);
+      warnings.push(`Behavior "${watcherRow.name ?? args.behavior_id}" is archived.`);
     } else {
-      warnings.push(`Behavior "${watcherRow.name ?? args.watcher_id}" has no windows yet.`);
+      warnings.push(`Behavior "${watcherRow.name ?? args.behavior_id}" has no windows yet.`);
     }
   }
 
@@ -1110,7 +1110,7 @@ async function getBehaviorImpl(
 
   // Detect gaps between consecutive windows (single-watcher queries only)
   let windowGaps: WindowGap[] | undefined;
-  if (args.watcher_id && formattedWindows.length > 1) {
+  if (args.behavior_id && formattedWindows.length > 1) {
     const sorted = [...formattedWindows].sort(
       (a, b) => new Date(a.window_start).getTime() - new Date(b.window_start).getTime()
     );
@@ -1133,7 +1133,7 @@ async function getBehaviorImpl(
     : null;
   const viewUrl =
     organizationSlug && watcherRow?.agent_id
-      ? buildBehaviorUrl(organizationSlug, watcherRow.agent_id, args.watcher_id, baseUrl)
+      ? buildBehaviorUrl(organizationSlug, watcherRow.agent_id, args.behavior_id, baseUrl)
       : undefined;
 
   const result: GetBehaviorResult = {
@@ -1147,7 +1147,7 @@ async function getBehaviorImpl(
       total: totalCount,
     },
     metadata: {
-      query_type: args.watcher_id ? 'specific' : 'all_for_entity',
+      query_type: args.behavior_id ? 'specific' : 'all_for_entity',
       date_range: {
         content_since: parsedSince || null,
         content_until: parsedUntil || null,

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -744,7 +744,7 @@ async function getBehaviorImpl(
       : undefined;
     return {
       window_id: ensureNumber(w.window_id),
-      behavior_id: w.watcher_id,
+      behavior_id: String(w.watcher_id),
       watcher_name: w.watcher_name,
       granularity: w.granularity,
       // window_start/end and created_at come back from postgres.js as Date
@@ -833,7 +833,7 @@ async function getBehaviorImpl(
     const watcherSources = parseWatcherSources(watcherRow.sources);
 
     watcherMetadata = {
-      behavior_id: watcherRow.watcher_id,
+      behavior_id: String(watcherRow.watcher_id),
       watcher_name: watcherRow.name || (version?.name as string) || 'Behavior',
       slug: watcherRow.slug || '',
       status: watcherRow.status as 'active' | 'archived',

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -52,7 +52,7 @@ export type WatcherWindowReaction = Static<typeof WatcherWindowReactionSchema>;
  */
 export const WatcherWindowSchema = Type.Object({
   window_id: Type.Integer(),
-  watcher_id: Type.String(),
+  behavior_id: Type.String(),
   watcher_name: Type.String(),
   granularity: Type.String(),
   window_start: Type.String(),
@@ -131,7 +131,7 @@ const WatcherRunSchema = Type.Object({
 });
 
 export const WatcherMetadataSchema = Type.Object({
-  watcher_id: Type.String(),
+  behavior_id: Type.String(),
   watcher_name: Type.String(),
   slug: Type.String(),
   status: Type.Union([Type.Literal('active'), Type.Literal('archived')]),

--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -592,7 +592,7 @@ echo "✓ connector sync ran the compiled connector and emitted events (items=$R
 #    produce a complete_window tool-call). The reaction saves SDKE2E_REACTION_OK.
 BEHAVIORS="$RUN_DIR/behaviors.json"
 api manage_behaviors '{"action":"list"}' > "$BEHAVIORS" 2>/dev/null || fail "could not list Behaviors"
-WATCHER_ID="$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const j=JSON.parse(s);const arr=j.behaviors||j.items||(Array.isArray(j)?j:[]);const w=arr.find(x=>x.slug==="digest")||arr[0];const id=w?(w.watcher_id??w.id):null;process.stdout.write(id!=null?String(id):"")})' < "$BEHAVIORS")"
+WATCHER_ID="$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const j=JSON.parse(s);const arr=j.behaviors||j.items||(Array.isArray(j)?j:[]);const w=arr.find(x=>x.slug==="digest")||arr[0];const id=w?(w.behavior_id??w.watcher_id??w.id):null;process.stdout.write(id!=null?String(id):"")})' < "$BEHAVIORS")"
 [ -n "$WATCHER_ID" ] || { cat "$BEHAVIORS" >&2; fail "no 'digest' Behavior found after apply"; }
 echo "✓ apply created the digest Behavior (id=$WATCHER_ID)"
 
@@ -621,7 +621,7 @@ echo "✓ apply set entity-type view template (company default v$VT_V1)"
 # token (the regression this guards — a missing `lobu-internal` client fails
 # every watcher run), and that a watcher worker session actually started.
 TW="$RUN_DIR/trigger-watcher.json"
-api manage_behaviors "{\"action\":\"trigger\",\"watcher_id\":\"$WATCHER_ID\"}" > "$TW" 2>/dev/null \
+api manage_behaviors "{\"action\":\"trigger\",\"behavior_id\":\"$WATCHER_ID\"}" > "$TW" 2>/dev/null \
   || { cat "$TW" >&2; fail "watcher trigger failed"; }
 TRIG_RUN_ID="$(jget run_id < "$TW" 2>/dev/null || echo)"
 [ -n "$TRIG_RUN_ID" ] || { cat "$TW" >&2; fail "watcher trigger did not dispatch a run (no run_id)"; }
@@ -647,7 +647,7 @@ WINDOW_TOKEN="$(jget window_token < "$RK")"
 [ -n "$WINDOW_TOKEN" ] || { cat "$RK" >&2; fail "read_knowledge returned no window_token (no content in window — connector events missing?)"; }
 
 CW="$RUN_DIR/complete-window.json"
-api manage_behaviors "$(node -e 'const t=process.argv[1],w=process.argv[2];process.stdout.write(JSON.stringify({action:"complete_window",watcher_id:w,window_token:t,extracted_data:{s:"SDKE2E_REACTION_OK"},run_metadata:{executor:"sdk-e2e"}}))' "$WINDOW_TOKEN" "$WATCHER_ID")" > "$CW" 2>/dev/null \
+api manage_behaviors "$(node -e 'const t=process.argv[1],w=process.argv[2];process.stdout.write(JSON.stringify({action:"complete_window",behavior_id:w,window_token:t,extracted_data:{s:"SDKE2E_REACTION_OK"},run_metadata:{executor:"sdk-e2e"}}))' "$WINDOW_TOKEN" "$WATCHER_ID")" > "$CW" 2>/dev/null \
   || { cat "$CW" >&2; fail "complete_window failed"; }
 grep -q '"action":"complete_window"\|"action": "complete_window"' "$CW" || { cat "$CW" >&2; fail "complete_window did not return the expected action"; }
 


### PR DESCRIPTION
## What changed

Renames the **public** Behavior API field `watcher_id`/`watcher_ids` → `behavior_id`/`behavior_ids` so the field name matches the `Behavior` resource, and adds telemetry to measure real usage of the `active_run: "steer"` policy.

### Rename (public field only — DB untouched)
- `manage_behaviors` + `get_behavior` tool contracts, SDK namespace (`client.behaviors.*`), and handlers now use `behavior_id`. The internal DB column stays `watchers.id`/`watcher_id`; handlers map at the boundary. **No migration.**
- REST `/api/.../behaviors` query param + payloads, the pending-proposal target check, and `get_behavior` output (`WatcherWindowSchema`/`WatcherMetadataSchema`) all emit `behavior_id`.
- Regenerated `client/types.gen.ts` for the manage_behaviors/get_behavior I/O; SDK doc examples updated.
- owletto: Behavior API client (`use-watchers.ts`), response types, React-Query keys, and consumers renamed (submodule bumped to `fdd3ac57`).

**Intentionally NOT renamed** (separate contracts): the `watcher_source` provenance object (`notify`/`save_content`/`execute`), `get_content`/`manage_classifiers` `watcher_id` fields, event-metadata `watcher_id`, and all DB columns.

### Steer telemetry
The steer log (`sse-client.ts`) now carries `steerSource` (behavior|human), `behaviorId`, and `behaviorActiveRunPolicy`, so we can measure how often `active_run: "steer"` actually fires a live interrupt before deciding whether to keep the knob. (Investigation confirmed steer, coalesce, and queue are all load-bearing and distinct — steer is *not* redundant with any auto-steer; the batcher queues by default.)

### Deferred to a follow-up PR
- The owletto `$watcherId` URL route param (a URL-vocabulary concern, camelCase, not the wire-breaking field).
- Renaming the shared `watcher_source` provenance object.

## Validation
- `make pre-pr` clean (typecheck + knip + lint).
- Package typechecks: core, server, client, agent-worker, owletto all 0 errors.
- Focused unit suites pass (behavior trigger, update-patch normalization, owletto model/activity-links).
- Generated types: verified number-typed non-Behavior `watcher_id` fields (9) untouched; 18 Behavior fields renamed.

## Note
`make review` (local codex reviewer) could not run — codex CLI is not authenticated in this env. Relying on the GitHub codex connector review on this PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Behavior management APIs and SDK methods now use `behavior_id` / `behavior_ids` instead of `watcher_id` / `watcher_ids`.
  * Updated create, update, delete, trigger, versioning, feedback, reaction-script, and lookup operations to use the new identifier fields.
  * REST endpoints and CLI apply/init workflows now consistently return and accept `behavior_id`.
* **Bug Fixes**
  * Improved pending-approval target validation to match the updated identifier.
  * Enhanced steering telemetry to include additional steer-origin and behavior metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->