### PR TITLE
fix(sdk): consistent knowledge delete key, honor include_deleted, expose enums, read-mode admin lists (#2033)

### DIFF
--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -1152,6 +1152,13 @@ export interface ContentItem {
   interaction_output?: Record<string, unknown> | null;
   interaction_error?: string | null;
   supersedes_event_id?: number | null;
+  /** The newer event that superseded this one, when this row is the stale/
+   *  tombstone side of a supersede chain (denormalized forward edge). */
+  superseded_by?: number | null;
+  /** True when a newer row in the same supersede chain replaced this one — i.e.
+   *  this is not the live head. Lets callers reading the full chain (content_ids
+   *  resolution returns the whole lineage) tell the head from the history. */
+  is_superseded?: boolean;
   /** The run this event belongs to, when it originated from one (operation
    *  chains, approval notifications). Lets the client group a run's satellite
    *  events (the "needs approval" notification) onto the same timeline node as

--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -273,7 +273,8 @@ export const ManageEntitySchema = Type.Object({
   ),
   include_deleted: Type.Optional(
     Type.Boolean({
-      description: "[list_links] Include soft-deleted relationships",
+      description:
+        "[get] Return the entity even if it is soft-deleted (deleted_at set). [list_links] Include soft-deleted relationships.",
     })
   ),
   watcher_source: Type.Optional(

--- a/packages/server/src/__tests__/integration/entities/entity-crud.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-crud.test.ts
@@ -123,6 +123,30 @@ describe('entity CRUD', () => {
     await expect(owner.entities.get({ entity_id: created.entity.id })).rejects.toThrow(/not found/i);
   });
 
+  it('get honors include_deleted: soft-deleted entity is hidden by default, returned with the flag', async () => {
+    const sql = getTestDb();
+    const created = (await owner.entities.create({
+      type: 'company',
+      name: 'Soft Deleted Co',
+    })) as { entity: { id: number } };
+    const id = created.entity.id;
+
+    // Soft-delete directly (stamp deleted_at) so getEntity's default
+    // `AND e.deleted_at IS NULL` filters it out.
+    await sql`UPDATE entities SET deleted_at = NOW() WHERE id = ${id}`;
+
+    // Default read: the soft-deleted row is invisible → not-found.
+    await expect(owner.entities.get({ entity_id: id })).rejects.toThrow(/not found/i);
+
+    // With include_deleted: the row comes back.
+    const got = (await owner.entities.get({
+      entity_id: id,
+      include_deleted: true,
+    })) as { entity?: { id: number; name: string } };
+    expect(got.entity?.id).toBe(id);
+    expect(got.entity?.name).toBe('Soft Deleted Co');
+  });
+
   describe('access control', () => {
     it('lets a member create + list (write scope is enough)', async () => {
       const created = (await member.entities.create({

--- a/packages/server/src/__tests__/integration/events/delete-content-tombstone.test.ts
+++ b/packages/server/src/__tests__/integration/events/delete-content-tombstone.test.ts
@@ -73,7 +73,7 @@ describe('deleteContent (tombstone) > end-to-end', () => {
     });
 
     const result = await deleteContent(
-      { event_id: target.id } as never,
+      { content_id: target.id } as never,
       {} as never,
       callerCtx
     );
@@ -115,7 +115,7 @@ describe('deleteContent (tombstone) > end-to-end', () => {
     });
 
     const result = await deleteContent(
-      { event_id: foreign.id } as never,
+      { content_id: foreign.id } as never,
       {} as never,
       callerCtx
     );
@@ -138,7 +138,7 @@ describe('deleteContent (tombstone) > end-to-end', () => {
     });
 
     const first = await deleteContent(
-      { event_id: target.id } as never,
+      { content_id: target.id } as never,
       {} as never,
       callerCtx
     );
@@ -147,7 +147,7 @@ describe('deleteContent (tombstone) > end-to-end', () => {
 
     // Second delete — already superseded by the first tombstone.
     const second = await deleteContent(
-      { event_id: target.id } as never,
+      { content_id: target.id } as never,
       {} as never,
       callerCtx
     );
@@ -174,7 +174,7 @@ describe('deleteContent (tombstone) > end-to-end', () => {
       content: 'Will be tombstoned before the batch runs',
     });
     await deleteContent(
-      { event_id: supersededTarget.id } as never,
+      { content_id: supersededTarget.id } as never,
       {} as never,
       callerCtx
     );
@@ -186,7 +186,7 @@ describe('deleteContent (tombstone) > end-to-end', () => {
 
     const result = await deleteContent(
       {
-        event_ids: [own.id, supersededTarget.id, foreign.id, ghostId],
+        content_ids: [own.id, supersededTarget.id, foreign.id, ghostId],
         reason: 'batch test',
       } as never,
       {} as never,

--- a/packages/server/src/__tests__/integration/events/get-content-chain-resolve.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-chain-resolve.test.ts
@@ -139,8 +139,16 @@ describe('getContent > content_ids resolves the full supersede chain', () => {
 
     // Whole lineage comes back, chronological, not a 404.
     expect(ids).toEqual([pending, executing, completed]);
-    // total counts the chain as ONE unit, not three rows.
-    expect(result.total).toBe(1);
+    // total is now ROW-accurate: three rows returned -> total 3 (the old
+    // chain-count `total:1` lied about how many rows the caller got).
+    expect(result.total).toBe(3);
+    // chain_total still reports the atomic-unit (one lineage) count.
+    expect(result.chain_total).toBe(1);
+    // The superseded history is flagged so callers can find the live head.
+    const byId = new Map(result.content.map((c) => [c.id, c]));
+    expect(byId.get(pending)?.is_superseded).toBe(true);
+    expect(byId.get(executing)?.is_superseded).toBe(true);
+    expect(byId.get(completed)?.is_superseded).toBe(false);
   });
 
   it('walk arm: a run_id-less superseded id resolves via superseded_by/supersedes_event_id', async () => {
@@ -169,7 +177,11 @@ describe('getContent > content_ids resolves the full supersede chain', () => {
     );
     const ids = result.content.map((c) => c.id).sort((a, b) => a - b);
     expect(ids).toEqual([v1, v2].sort((a, b) => a - b));
-    expect(result.total).toBe(1);
+    expect(result.total).toBe(2);
+    expect(result.chain_total).toBe(1);
+    const walkById = new Map(result.content.map((c) => [c.id, c]));
+    expect(walkById.get(v1)?.is_superseded).toBe(true);
+    expect(walkById.get(v2)?.is_superseded).toBe(false);
   });
 
   it('walk arm: entering from the HEAD id still returns the full history (backward walk)', async () => {
@@ -207,7 +219,8 @@ describe('getContent > content_ids resolves the full supersede chain', () => {
     );
     const ids = result.content.map((c) => c.id).sort((a, b) => a - b);
     expect(ids).toEqual([v1, v2, v3].sort((a, b) => a - b));
-    expect(result.total).toBe(1);
+    expect(result.total).toBe(3);
+    expect(result.chain_total).toBe(1);
   });
 
   it('two ids from the same chain do not double-return the lineage', async () => {
@@ -242,6 +255,8 @@ describe('getContent > content_ids resolves the full supersede chain', () => {
     const ids = result.content.map((c) => c.id);
     // Each chain row appears exactly once even though both its ids were asked for.
     expect(ids.sort((x, y) => x - y)).toEqual([a, b].sort((x, y) => x - y));
-    expect(result.total).toBe(1);
+    // Two rows, still one lineage — the dedup keeps rows unique.
+    expect(result.total).toBe(2);
+    expect(result.chain_total).toBe(1);
   });
 });

--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -155,6 +155,48 @@ describe("sandbox runtime", () => {
     });
   });
 
+  it("read mode: a known-but-hidden namespace throws a structured error, not undefined", async () => {
+    // `notifications` has only a write method (`send`), so read mode filters the
+    // whole namespace out of the manifest. Before the stub, `client.notifications`
+    // was undefined and the guest died with the opaque "Cannot read properties of
+    // undefined (reading 'send')". Now it must throw a NamespaceNotAvailable error
+    // naming the namespace, so discovery and runtime agree.
+    const stubSdk = {
+      query: async () => [],
+      log: () => undefined,
+    } as unknown as ClientSDK;
+
+    const result = await runScript({
+      source:
+        "export default async (_ctx, client) => client.notifications.send({ title: 'x' });",
+      sdk: stubSdk,
+      sdkMode: "read",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain("NamespaceNotAvailable");
+    expect(result.error?.message).toContain("notifications");
+    // The stub must NOT dispatch to the host — it fails guest-side.
+    expect(result.sdkCalls).toBe(0);
+  });
+
+  it("read mode: a genuinely unknown namespace stays undefined (not a false stub)", async () => {
+    const stubSdk = {
+      query: async () => [],
+      log: () => undefined,
+    } as unknown as ClientSDK;
+
+    const result = await runScript({
+      source:
+        "export default async (_ctx, client) => ({ t: typeof client.totallyMadeUp });",
+      sdk: stubSdk,
+      sdkMode: "read",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.returnValue).toEqual({ t: "undefined" });
+  });
+
   it("enforces wall-clock timeout while awaiting SDK calls", async () => {
     const stubSdk = {
       entities: {

--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -577,7 +577,7 @@ describe('org-wide guidance context', () => {
 
     // Real delete path: inserts an empty-payload tombstone that supersedes it.
     const del = (await deleteContent(
-      { event_id: saved.id } as never,
+      { content_id: saved.id } as never,
       env,
       ctx
     )) as { tombstone_ids: number[] };
@@ -648,7 +648,7 @@ describe('org-wide guidance context', () => {
     )) as { id: number };
 
     await expect(
-      deleteContent({ event_id: guarded.id } as never, env, memberCtx)
+      deleteContent({ content_id: guarded.id } as never, env, memberCtx)
     ).rejects.toThrow(/only organization owners\/admins/i);
 
     expect(await loadOrgGuidanceBlock(org.id)).toContain('Do not delete me.');

--- a/packages/server/src/__tests__/unit/delete-content-access.test.ts
+++ b/packages/server/src/__tests__/unit/delete-content-access.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { deleteContent } from '../../tools/delete_content';
 import type { ToolContext } from '../../tools/registry';
 
-const args = { event_id: 1 } as never;
+const args = { content_id: 1 } as never;
 const baseCtx: ToolContext = {
   organizationId: 'org_test',
   userId: 'user_visitor',
@@ -67,21 +67,21 @@ describe('deleteContent auth gate', () => {
 describe('deleteContent input validation', () => {
   const writingCtx = ctx({ memberRole: 'member', scopes: ['mcp:write'] });
 
-  it('rejects when neither event_id nor event_ids is provided', async () => {
+  it('rejects when neither content_id nor content_ids is provided', async () => {
     await expect(
       deleteContent({} as never, {} as never, writingCtx)
-    ).rejects.toThrow(/event_id or a non-empty event_ids/i);
+    ).rejects.toThrow(/content_id or a non-empty content_ids/i);
   });
 
-  it('rejects when event_ids is empty', async () => {
+  it('rejects when content_ids is empty', async () => {
     await expect(
-      deleteContent({ event_ids: [] } as never, {} as never, writingCtx)
-    ).rejects.toThrow(/event_id or a non-empty event_ids/i);
+      deleteContent({ content_ids: [] } as never, {} as never, writingCtx)
+    ).rejects.toThrow(/content_id or a non-empty content_ids/i);
   });
 
   it('rejects when ids are non-positive', async () => {
     await expect(
-      deleteContent({ event_ids: [0, -3] } as never, {} as never, writingCtx)
-    ).rejects.toThrow(/event_id or a non-empty event_ids/i);
+      deleteContent({ content_ids: [0, -3] } as never, {} as never, writingCtx)
+    ).rejects.toThrow(/content_id or a non-empty content_ids/i);
   });
 });

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -107,6 +107,37 @@ describe("method-metadata", () => {
 		expect(METHOD_METADATA["organizations.list"].access).toBe("read");
 	});
 
+	it("exposes org-read admin lists in read mode (agents.list/get, schedules.list)", () => {
+		// These are org-read-gated at runtime (requireOrgReadAccess / org-scoped
+		// query) but were tagged access:"admin", so query_sdk read mode dropped the
+		// whole namespace → opaque "Cannot read properties of undefined". Reclassify
+		// ONLY the reads; the mutating siblings must stay admin.
+		expect(METHOD_METADATA["agents.list"].access).toBe("read");
+		expect(METHOD_METADATA["agents.get"].access).toBe("read");
+		expect(METHOD_METADATA["schedules.list"].access).toBe("read");
+		// Mutations stay admin-gated — reclassifying reads must not leak writes.
+		expect(METHOD_METADATA["agents.create"].access).toBe("admin");
+		expect(METHOD_METADATA["agents.update"].access).toBe("admin");
+		expect(METHOD_METADATA["agents.delete"].access).toBe("admin");
+		expect(METHOD_METADATA["agents.setSystemAgent"].access).toBe("admin");
+		expect(METHOD_METADATA["schedules.create"].access).toBe("admin");
+		expect(METHOD_METADATA["schedules.update"].access).toBe("admin");
+		expect(METHOD_METADATA["schedules.pause"].access).toBe("admin");
+		expect(METHOD_METADATA["schedules.cancel"].access).toBe("admin");
+	});
+
+	it("spells the runtime-enforced enums into entities.link / entities.listLinks signatures", () => {
+		// The enums are validated at runtime (contract manage-entity.ts) but weren't
+		// in the search_sdk signatures, so a client had no way to discover the legal
+		// values before a call rejected.
+		const linkSig = METHOD_METADATA["entities.link"].signature ?? "";
+		expect(linkSig).toContain("source?: 'ui' | 'llm' | 'feed' | 'api'");
+		const listLinksSig = METHOD_METADATA["entities.listLinks"].signature ?? "";
+		expect(listLinksSig).toContain(
+			"direction?: 'outbound' | 'inbound' | 'both'",
+		);
+	});
+
 	it("does not claim SQL positional parameters in the query example", () => {
 		const example = METHOD_METADATA.query.example ?? "";
 		expect(example).not.toMatch(/\$\d+/);

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -140,9 +140,33 @@ describe("sdkSearch", () => {
 	});
 
 	it("hides admin methods from write-tier callers", async () => {
-		const result = await sdkSearch({ query: "agents.list" }, stubEnv, writeCtx);
+		// agents.setSystemAgent stays admin (a mutation); a write-tier caller must
+		// not see it. (agents.list/get are now `read` and intentionally visible —
+		// see the read-mode test below.)
+		const result = await sdkSearch(
+			{ query: "agents.setSystemAgent" },
+			stubEnv,
+			writeCtx
+		);
 		expect(result.match_count).toBe(0);
 		expect(result.notes).toContain("mcp:admin");
+	});
+
+	it("shows the reclassified org-read agent lists in read mode", async () => {
+		// agents.list/get were mistagged admin, so query_sdk read mode dropped the
+		// whole `agents` namespace → opaque "Cannot read properties of undefined".
+		// They are org-read-gated at runtime, so read mode must surface them.
+		const result = await sdkSearch(
+			{ query: "agents", mode: "read" },
+			stubEnv,
+			readCtx
+		);
+		const joined = result.results.join("\n");
+		expect(joined).toContain("agents.list");
+		expect(joined).toContain("agents.get");
+		// The mutating siblings stay hidden in read mode.
+		expect(joined).not.toContain("agents.create");
+		expect(joined).not.toContain("agents.setSystemAgent");
 	});
 
 	it("lists a camelCase namespace from a lowercased query without a false hidden note", async () => {
@@ -159,16 +183,16 @@ describe("sdkSearch", () => {
 		expect(result.notes ?? "").not.toContain("none are visible");
 	});
 
-	it("names an admin-only namespace in read mode instead of a silent dead end", async () => {
-		// Live failure: search_sdk query='agents' mode='read' returned unrelated
-		// matches with no hint that agents.* exists behind run_sdk — the client
-		// concluded the namespace does not exist.
+	it("names a write-only namespace in read mode instead of a silent dead end", async () => {
+		// A namespace whose methods are ALL non-read (notifications = send only) is
+		// filtered out of read mode. search_sdk must still hint that it exists behind
+		// run_sdk, not return an empty dead end that reads as "does not exist".
 		const result = await sdkSearch(
-			{ query: "agents", mode: "read" },
+			{ query: "notifications", mode: "read" },
 			stubEnv,
 			readCtx
 		);
-		expect(result.notes ?? "").toContain("agents.*");
+		expect(result.notes ?? "").toContain("notifications.*");
 		expect(result.notes ?? "").toContain("run_sdk");
 	});
 

--- a/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
+++ b/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
@@ -150,13 +150,19 @@ describe("access-model cross-check", () => {
 
 	it("the agents.* triple agrees (AGENTS_SDK_ACTION ↔ METHOD_METADATA ↔ manage_agents)", () => {
 		// AGENTS_SDK_ACTION enumerates the agents.* SDK paths gated by
-		// agent_config policy. Every such path must also have METHOD_METADATA,
-		// and (excluding the raw `.manage` passthrough) map to a manage_agents
-		// action declared owner-admin — agents administration is admin-tier.
-		const managedAgentActions = OWNER_ADMIN_ACTIONS.manage_agents;
-		expect(managedAgentActions).toBeDefined();
+		// agent_config policy, each mapped to the agent_config verb it needs.
+		// `read`-verb paths (list/get) are org-read: METHOD_METADATA tier `read`,
+		// runtime declared in PUBLIC_READ_ACTIONS.manage_agents (the handler gates
+		// them with requireOrgReadAccess). Write-verb paths (create/update/delete/
+		// setSystemAgent) are administration: METHOD_METADATA tier `admin`, runtime
+		// owner-admin. The raw `.manage` passthrough carries the namespace's
+		// most-privileged tier (admin) and maps to no single action.
+		const adminAgentActions = OWNER_ADMIN_ACTIONS.manage_agents;
+		const readAgentActions = PUBLIC_READ_ACTIONS.manage_agents;
+		expect(adminAgentActions).toBeDefined();
+		expect(readAgentActions).toBeDefined();
 
-		for (const path of Object.keys(AGENTS_SDK_ACTION)) {
+		for (const [path, verb] of Object.entries(AGENTS_SDK_ACTION)) {
 			// Index directly, not `toHaveProperty(path)`: the dotted keys
 			// ("agents.list") are LITERAL keys, but toHaveProperty parses a dotted
 			// string as a nested traversal (METHOD_METADATA.agents.list) — behavior
@@ -165,19 +171,30 @@ describe("access-model cross-check", () => {
 				METHOD_METADATA[path],
 				`${path} missing METHOD_METADATA`,
 			).toBeDefined();
-			// Every agents.* SDK method is admin-tier in metadata.
+
+			// A `read` agent_config verb is an org-read method; anything else
+			// (create/update/delete/any) is admin-tier administration.
+			const isRead = verb === "read";
+			const expectedTier = isRead ? "read" : "admin";
 			expect(
 				METHOD_METADATA[path]?.access,
-				`${path} should be admin in METHOD_METADATA`,
-			).toBe("admin");
+				`${path} should be ${expectedTier} in METHOD_METADATA`,
+			).toBe(expectedTier);
 
 			const method = path.split(".")[1];
 			if (method === "manage") continue;
 			const action = method.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
-			expect(
-				managedAgentActions?.has(action),
-				`agents.${method} → manage_agents.${action} must be owner-admin`,
-			).toBe(true);
+			if (isRead) {
+				expect(
+					readAgentActions?.has(action),
+					`agents.${method} → manage_agents.${action} must be public-read`,
+				).toBe(true);
+			} else {
+				expect(
+					adminAgentActions?.has(action),
+					`agents.${method} → manage_agents.${action} must be owner-admin`,
+				).toBe(true);
+			}
 		}
 	});
 });

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -709,7 +709,7 @@ manage_entity: create=write update=write list=read+public get=read+public delete
 manage_entity_schema: list=read+public get=read+public create=admin update=admin delete=admin audit=read+public add_rule=admin remove_rule=admin list_rules=read+public ?=read
 manage_connections: list_connector_groups=read+public list=read+public get=read+public create=write connect=admin update=write apply_chat_connection=admin delete=admin reauthenticate=write test=admin install_connector=admin uninstall_connector=admin toggle_connector_login=admin update_connector_auth=admin update_connector_default_config=admin update_connector_default_repair_agent=admin set_channel_about=admin ?=read
 manage_catalog: list_catalog=read+public list_installed=read+public ?=read
-manage_agents: list=admin get=admin create=admin update=admin delete=admin set_system_agent=admin ?=read
+manage_agents: list=read+public get=read+public create=admin update=admin delete=admin set_system_agent=admin ?=read
 manage_conversations: list=read get=read send=write ?=read
 manage_feeds: list_feeds=read+public read_feed=read+public read_feeds=read+public create_feed=admin update_feed=admin delete_feed=admin trigger_feed=admin ?=read
 manage_auth_profiles: list_auth_profiles=read+public get_auth_profile=admin test_auth_profile=admin create_auth_profile=write update_auth_profile=write delete_auth_profile=admin set_default_auth_profile=admin ?=read

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -123,8 +123,9 @@ export const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
 		"create_from_version",
 	]),
 	manage_agents: new Set([
-		"list",
-		"get",
+		// `list`/`get` are org-read (the handler gates them with
+		// requireOrgReadAccess) and live in PUBLIC_READ_ACTIONS — agent
+		// ADMINISTRATION (create/update/delete/set_system_agent) stays owner-admin.
 		"create",
 		"update",
 		"delete",
@@ -169,6 +170,10 @@ export const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {
 	]),
 	manage_classifiers: new Set(["list"]),
 	manage_view_templates: new Set(["get"]),
+	// `list`/`get` are org-read-gated in the handler (requireOrgReadAccess);
+	// their METHOD_METADATA tier is `read` so query_sdk read mode surfaces them.
+	// The mutating siblings stay owner-admin (OWNER_ADMIN_ACTIONS).
+	manage_agents: new Set(["list", "get"]),
 };
 
 function getAction(args: unknown): string | null {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -78,6 +78,8 @@ export default async (_ctx, client) => {
 	"entities.get": {
 		summary: "Fetch a single entity by id.",
 		access: "read",
+		signature:
+			"entities.get(input: { entity_id: number; include_deleted?: boolean }): Promise<unknown>",
 		throws: ["EntityNotFound"],
 		example: "const entity = await client.entities.get({ entity_id: 42 });",
 		usageExample: `export default async (_ctx, client) => {
@@ -122,6 +124,8 @@ export default async (_ctx, client) => {
 	"entities.delete": {
 		summary: "Delete an entity, optionally cascading to descendants.",
 		access: "admin",
+		signature:
+			"entities.delete(input: { entity_id: number; force_delete_tree?: boolean }): Promise<unknown>",
 		example:
 			"await client.entities.delete({ entity_id: 42, force_delete_tree: true });",
 	},
@@ -129,6 +133,8 @@ export default async (_ctx, client) => {
 		summary:
 			"Create a relationship between two entities. Needs the two entity IDs AND a relationship TYPE that already exists — if the relationship type is new, call `entitySchema.createRelType` first; list existing ones with `entitySchema.listRelTypes()`. (`entitySchema.addRule` does NOT create a type; it restricts the allowed source/target entity-type pairs on a type that already exists.)",
 		access: "write",
+		signature:
+			"entities.link(input: { from_entity_id: number; to_entity_id: number; relationship_type_slug: string; source?: 'ui' | 'llm' | 'feed' | 'api'; confidence?: number; metadata?: object }): Promise<unknown>",
 		example:
 			"await client.entities.link({ from_entity_id: 42, to_entity_id: 43, relationship_type_slug: 'customer_of' });",
 		usageExample: `// Two-hop: the relationship TYPE must exist before linking. Ensure it
@@ -165,6 +171,8 @@ export default async (_ctx, client) => {
 	"entities.listLinks": {
 		summary: "List relationships for an entity.",
 		access: "read",
+		signature:
+			"entities.listLinks(input: { entity_id: number; direction?: 'outbound' | 'inbound' | 'both'; relationship_type_slug?: string; confidence_min?: number; include_deleted?: boolean }): Promise<unknown>",
 	},
 	"entities.search": {
 		summary:
@@ -289,7 +297,7 @@ export default async (_ctx, client) => {
 		usageExample: `// Hide a smoke-test write that should not have landed.
 export default async (_ctx, client) => {
   const result = await client.knowledge.delete({
-    event_ids: [2321593, 2321594],
+    content_ids: [2321593, 2321594],
     reason: 'smoke test cleanup',
   });
   return result;
@@ -304,14 +312,14 @@ export default async (_ctx, client) => {
 	},
 	"agents.list": {
 		summary:
-			"List agents the principal may read (agent_config read; default all). Requires admin tier.",
-		access: "admin",
+			"List agents the principal may read (agent_config read; default all). Org-read gated via requireOrgReadAccess.",
+		access: "read",
 		example: "const { agents } = await client.agents.list();",
 	},
 	"agents.get": {
 		summary:
-			"Fetch one agent by id when agent_config read allows that target. Requires admin tier.",
-		access: "admin",
+			"Fetch one agent by id when agent_config read allows that target. Org-read gated via requireOrgReadAccess.",
+		access: "read",
 		example: "const { agent } = await client.agents.get('builder');",
 	},
 	"agents.create": {
@@ -384,8 +392,9 @@ export default async (ctx, client) => {
 		access: "admin",
 	},
 	"schedules.list": {
-		summary: "List scheduled jobs with optional filters. Requires admin.",
-		access: "admin",
+		summary:
+			"List scheduled jobs with optional filters. Results are scoped to the caller's organization.",
+		access: "read",
 		example:
 			"const { schedules } = await client.schedules.list({ agent_id: 'builder' });",
 	},

--- a/packages/server/src/sandbox/namespaces/entities.ts
+++ b/packages/server/src/sandbox/namespaces/entities.ts
@@ -49,13 +49,18 @@ export interface EntityLinkInput {
 	from_entity_id: number;
 	to_entity_id: number;
 	relationship_type_slug: string;
+	source?: "ui" | "llm" | "feed" | "api";
+	confidence?: number;
 	metadata?: Record<string, unknown>;
 }
 
 export interface EntitiesNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
 	list(filter?: EntityListFilter): Promise<unknown>;
-	get(input: { entity_id: number }): Promise<unknown>;
+	get(input: {
+		entity_id: number;
+		include_deleted?: boolean;
+	}): Promise<unknown>;
 	create(input: EntityCreateInput): Promise<unknown>;
 	update(input: EntityUpdateInput): Promise<unknown>;
 	delete(input: {
@@ -76,7 +81,10 @@ export interface EntitiesNamespace {
 	}): Promise<unknown>;
 	listLinks(input: {
 		entity_id: number;
+		direction?: "outbound" | "inbound" | "both";
 		relationship_type_slug?: string;
+		confidence_min?: number;
+		include_deleted?: boolean;
 		limit?: number;
 		offset?: number;
 	}): Promise<unknown>;

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -51,7 +51,7 @@ export interface KnowledgeReadInput {
 
 export type KnowledgeDeleteInput =
 	| number
-	| { event_id?: number; event_ids?: number[]; reason?: string };
+	| { content_id?: number; content_ids?: number[]; reason?: string };
 
 export interface KnowledgeNamespace {
 	search(input: KnowledgeSearchInput): Promise<unknown>;
@@ -76,7 +76,7 @@ export function buildKnowledgeNamespace(
 		},
 		delete(input) {
 			const args =
-				typeof input === "number" ? { event_id: input } : (input ?? {});
+				typeof input === "number" ? { content_id: input } : (input ?? {});
 			return deleteContent(args as never, env, ctx) as Promise<unknown>;
 		},
 	};

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -385,6 +385,13 @@ const __manifest = JSON.parse(__sdk_manifest_json);
 const __namespaceMethods = __manifest.byNamespace;
 const __topLevelKeys = new Set(__manifest.topLevel);
 const __namespaceKeys = new Set(Object.keys(__namespaceMethods));
+// Namespaces that EXIST in the SDK but are hidden by the current mode/tier
+// (e.g. \`agents\` when running below admin). Accessing one should throw a
+// structured "not available in this mode" error, not return undefined and fail
+// later with the opaque "Cannot read properties of undefined (reading 'list')".
+const __hiddenNamespaceKeys = new Set(
+  (__manifest.allNamespaces || []).filter((ns) => !__namespaceKeys.has(ns))
+);
 
 // Skip awaitable/coercion probes (\`then\`, \`toJSON\`, etc.) before they hit the
 // host. Otherwise an accidental \`JSON.stringify(client.x)\` consumes quota.
@@ -428,8 +435,24 @@ function __makeNamespaceProxy(ns, orgPath) {
   });
 }
 
+// A namespace known to the SDK but filtered out of THIS mode. Every method
+// access returns a thunk that throws the same structured error the host would,
+// so discovery (search_sdk) and runtime agree instead of the guest hitting an
+// undefined property. Mirrors the client.org stub pattern above.
+function __makeHiddenNamespaceProxy(ns) {
+  const err = () => {
+    throw new Error('NamespaceNotAvailable: the \\'' + ns + '\\' namespace is not available in this SDK mode (read-only or restricted tier). Re-run with a session that has the required access, or use a namespace listed by search_sdk in this mode.');
+  };
+  return new Proxy({}, {
+    get: (_, k) => __isReservedKey(k) ? undefined : err,
+    has: () => true,
+    ownKeys: () => [],
+    getOwnPropertyDescriptor: () => undefined,
+  });
+}
+
 function __makeClient(orgPath) {
-  const allKeys = new Set([...__topLevelKeys, ...__namespaceKeys]);
+  const allKeys = new Set([...__topLevelKeys, ...__namespaceKeys, ...__hiddenNamespaceKeys]);
   return new Proxy({}, {
     get(_, key) {
       if (__isReservedKey(key)) return undefined;
@@ -447,6 +470,7 @@ function __makeClient(orgPath) {
         : () => { throw new Error('CrossOrgAccessDenied: cross-org access is not available on this connection. Use the unscoped /mcp endpoint with an OAuth session, or reconnect to the target workspace.'); };
       if (__topLevelKeys.has(k)) return __dispatchCall(k, orgPath);
       if (__namespaceKeys.has(k)) return __makeNamespaceProxy(k, orgPath);
+      if (__hiddenNamespaceKeys.has(k)) return __makeHiddenNamespaceProxy(k);
       return undefined;
     },
     has: (_, k) => typeof k === 'string' && allKeys.has(k),

--- a/packages/server/src/sandbox/sdk-manifest.ts
+++ b/packages/server/src/sandbox/sdk-manifest.ts
@@ -13,7 +13,25 @@ export type SDKMode = "read" | "full";
 type SDKManifest = {
 	topLevel: string[];
 	byNamespace: Record<string, string[]>;
+	/**
+	 * Every namespace that exists in METHOD_METADATA, regardless of this mode's
+	 * access filter. Lets the guest tell a KNOWN namespace hidden by the current
+	 * mode (e.g. `agents` in a lower tier) from a genuinely unknown key, so it can
+	 * throw a structured "not available in this mode" error instead of the opaque
+	 * "Cannot read properties of undefined".
+	 */
+	allNamespaces: string[];
 };
+
+/** Every namespace present in METHOD_METADATA, mode-independent. */
+function allKnownNamespaces(): string[] {
+	const set = new Set<string>();
+	for (const path of Object.keys(METHOD_METADATA)) {
+		const dot = path.indexOf(".");
+		if (dot !== -1) set.add(path.slice(0, dot));
+	}
+	return [...set];
+}
 
 const manifestCache = new Map<string, SDKManifest>();
 
@@ -36,7 +54,7 @@ function buildSDKManifest(
 		const ns = path.slice(0, dot);
 		(byNamespace[ns] ??= []).push(path.slice(dot + 1));
 	}
-	return { topLevel, byNamespace };
+	return { topLevel, byNamespace, allNamespaces: allKnownNamespaces() };
 }
 
 export function enumerateSDKManifest(

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -153,9 +153,13 @@ const runManageEntity = defineFlatActionTool<
 		},
 	),
 	list: flatAction((args, ctx, env) => handleList(args, env, ctx)),
-	get: flatAction((args, ctx, env) => handleGet(args.entity_id!, env, ctx), {
-		requires: ["entity_id"],
-	}),
+	get: flatAction(
+		(args, ctx, env) =>
+			handleGet(args.entity_id!, env, ctx, args.include_deleted ?? false),
+		{
+			requires: ["entity_id"],
+		},
+	),
 	delete: flatAction(
 		(args, ctx, env) =>
 			handleDelete(
@@ -1230,8 +1234,9 @@ async function handleGet(
 	entityId: number,
 	env: Env,
 	ctx: ToolContext,
+	includeDeleted = false,
 ): Promise<ManageEntityResult> {
-	const entity = await getEntity(entityId, env, ctx);
+	const entity = await getEntity(entityId, env, ctx, { includeDeleted });
 
 	if (!entity) {
 		throw new Error(`Entity with ID ${entityId} not found`);

--- a/packages/server/src/tools/delete_content.ts
+++ b/packages/server/src/tools/delete_content.ts
@@ -30,14 +30,14 @@ import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
 
 const DeleteContentSchema = Type.Object({
-  event_id: Type.Optional(
+  content_id: Type.Optional(
     Type.Number({
-      description: 'Single event id to delete. Provide either this or `event_ids`.',
+      description: 'Single content id to delete. Provide either this or `content_ids`.',
     })
   ),
-  event_ids: Type.Optional(
+  content_ids: Type.Optional(
     Type.Array(Type.Number(), {
-      description: 'Batch of event ids to delete. Provide either this or `event_id`.',
+      description: 'Batch of content ids to delete. Provide either this or `content_id`.',
     })
   ),
   reason: Type.Optional(
@@ -79,7 +79,7 @@ async function deleteContentImpl(
 
   const requested = collectIds(args);
   if (requested.length === 0) {
-    throw new Error('Provide event_id or a non-empty event_ids array');
+    throw new Error('Provide content_id or a non-empty content_ids array');
   }
 
   const sql = getDb();
@@ -155,7 +155,7 @@ async function deleteContentImpl(
 
 function collectIds(args: DeleteContentArgs): number[] {
   const ids: number[] = [];
-  if (typeof args.event_id === 'number') ids.push(args.event_id);
-  if (Array.isArray(args.event_ids)) ids.push(...args.event_ids);
+  if (typeof args.content_id === 'number') ids.push(args.content_id);
+  if (Array.isArray(args.content_ids)) ids.push(...args.content_ids);
   return Array.from(new Set(ids.filter((id) => Number.isFinite(id) && id > 0)));
 }

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -304,6 +304,11 @@ async function getContentImpl(
     // 3. If no query + sort_by=date -> use searchContentByText with date sorting
     let rawContent: ContentRow[];
     let total: number;
+    // Distinct-lineage count from the content_ids branch (one requested id can
+    // resolve to a whole supersede chain). Surfaced as `chain_total` so callers
+    // can distinguish "how many rows" (`total`) from "how many things I asked
+    // resolved to" (`chain_total`).
+    let chainTotal: number | undefined;
     let pageInfo: GetContentResult['page'] = {
       limit,
       offset,
@@ -347,7 +352,7 @@ async function getContentImpl(
     }
 
     if (args.content_ids && args.content_ids.length > 0) {
-      ({ rawContent, total, pageInfo } = await fetchByContentIds({
+      ({ rawContent, total, chainTotal, pageInfo } = await fetchByContentIds({
         args,
         sql,
         organizationId: ctx.organizationId,
@@ -553,6 +558,10 @@ async function getContentImpl(
       total,
       page: pageInfo,
     };
+
+    if (chainTotal !== undefined) {
+      result.chain_total = chainTotal;
+    }
 
     if (classificationStats) {
       result.classification_stats = classificationStats;

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -25,6 +25,12 @@ interface VisibilityScope {
 interface ListPageResult {
   rawContent: ContentRow[];
   total: number;
+  /**
+   * Distinct-lineage count, set only by the content_ids branch where one id can
+   * expand to a whole supersede chain. `total` counts returned rows; this counts
+   * the atomic chains those rows collapse into.
+   */
+  chainTotal?: number;
   pageInfo: GetContentResult['page'];
 }
 
@@ -73,6 +79,7 @@ function buildContentQuery(opts: {
       ${a}.interaction_output,
       ${a}.interaction_error,
       ${a}.supersedes_event_id,
+      ${a}.superseded_by,
       ${a}.run_id,
       oc.client_name,
       -- classifications was sourced from latest_event_classifications, a denormalized cache that was
@@ -228,14 +235,20 @@ export async function fetchByContentIds(opts: {
     queryParams
   );
 
-  // Count distinct chains via the resolver's stable `chain_key`, not expanded
-  // rows: a chain is an atomic unit and paging must never split it. Joining
-  // resolved_ids also re-applies the same org/entity/visibility WHERE to the
-  // counted set, so it can't drift from the list above.
+  // `total` counts the returned ROWS, not chains: a chain expands to its whole
+  // supersede lineage (original + tombstone), so a chain-count `total` under-
+  // reports (says 1 when 2 rows return) — a lying count. `total` and the
+  // row-wise `has_more` below now agree with what the caller actually receives.
+  // `chain_total` is kept as the atomic-unit count (distinct lineages), for
+  // callers that want "how many things did my ids resolve to". Both re-apply the
+  // same org/entity/visibility WHERE via the resolved_ids join, so neither can
+  // drift from the list above.
   const countResult = await sql.unsafe(
     `
     WITH ${RESOLVED_IDS_CTE}
-    SELECT COUNT(DISTINCT ri.chain_key) as total
+    SELECT
+      COUNT(*) as total,
+      COUNT(DISTINCT ri.chain_key) as chain_total
     FROM events f
     JOIN resolved_ids ri ON ri.id = f.id
     LEFT JOIN connections c ON c.id = f.connection_id
@@ -246,9 +259,11 @@ export async function fetchByContentIds(opts: {
 
   const rawContent = result as unknown as ContentRow[];
   const total = Number(countResult[0]?.total ?? 0);
+  const chainTotal = Number(countResult[0]?.chain_total ?? 0);
   return {
     rawContent,
     total,
+    chainTotal,
     pageInfo: {
       limit,
       offset,

--- a/packages/server/src/tools/get_content/render.ts
+++ b/packages/server/src/tools/get_content/render.ts
@@ -172,6 +172,13 @@ export async function buildContentItems(opts: {
         : undefined,
       interaction_error: f.interaction_error ?? undefined,
       supersedes_event_id: f.supersedes_event_id == null ? null : Number(f.supersedes_event_id),
+      // `superseded_by` is the denormalized forward edge (the newer row that
+      // replaced this one). Its presence is exactly what makes a row the
+      // tombstone/stale side of a supersede chain, so `is_superseded` lets a
+      // caller reading the full chain (content_ids resolution) tell the live
+      // head from the superseded history without re-deriving it.
+      superseded_by: f.superseded_by == null ? null : Number(f.superseded_by),
+      is_superseded: f.superseded_by != null,
       run_id: f.run_id == null ? null : Number(f.run_id),
       parent_context:
         parentContextMap.get(f.origin_parent_id as string) ??

--- a/packages/server/src/tools/get_content/types.ts
+++ b/packages/server/src/tools/get_content/types.ts
@@ -38,6 +38,12 @@ export interface ClassifierConfig {
 export const GetContentResultSchema = Type.Object({
   content: Type.Array(Type.Unknown()),
   total: Type.Integer(),
+  /**
+   * content_ids reads only. `total` counts returned rows (a supersede chain
+   * expands to all its rows); `chain_total` counts the distinct lineages those
+   * rows collapse into — i.e. how many of the requested ids resolved to a thing.
+   */
+  chain_total: Type.Optional(Type.Integer()),
   page: Type.Object({
     limit: Type.Integer(),
     offset: Type.Integer(),
@@ -148,6 +154,7 @@ export interface ContentRow {
   interaction_output?: Record<string, unknown> | null;
   interaction_error?: string | null;
   supersedes_event_id?: number | null;
+  superseded_by?: number | string | null;
   run_id?: number | string | null;
   parent_context?: Record<string, unknown> | null;
   root_context?: Record<string, unknown> | null;

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -694,9 +694,11 @@ export async function getEntity(
 	entityId: number,
 	_env: Env,
 	ctx: ToolContext,
+	opts?: { includeDeleted?: boolean },
 ): Promise<CreatedEntity | null> {
   const sql = getDb();
   if (!ctx.organizationId) return null;
+  const includeDeleted = opts?.includeDeleted ?? false;
 
   // Operational counts always scope to the caller's org. When `e` is a
   // public-catalog entity, totals reflect the caller's events/feeds/watchers/
@@ -746,7 +748,7 @@ export async function getEntity(
         e.organization_id = ${ctx.organizationId}
         OR (eo.visibility = 'public' AND et.slug <> '$member')
       )
-      AND e.deleted_at IS NULL
+      ${includeDeleted ? sql`` : sql`AND e.deleted_at IS NULL`}
   `;
 
   return result.length > 0 ? result[0] : null;


### PR DESCRIPTION
Fixes SDK contract inconsistencies reported in #2033. Each item has red→green test coverage.

## What changed

- **knowledge.delete key rename (breaking)** — `delete_knowledge` now takes `content_ids` / `content_id` instead of `event_ids` / `event_id`, matching `knowledge.read` and `save`'s read-back hint. The physical row is the same (`events.id`); this is a public MCP-tool break, accepted per the issue.
- **entities.get honors include_deleted** — `getEntity` takes an `includeDeleted` option that drops the `deleted_at IS NULL` clause; `handleGet` threads `args.include_deleted` through. The schema field is now scoped `[get, list_links]`. Member-redaction / public-visibility branches still apply to a deleted row.
- **read_knowledge content_ids count + is_superseded** — exact reads expand a requested id to its full supersede lineage. `total` now counts the returned ROWS (was `COUNT(DISTINCT chain_key)`, which reported `1` for a 2-row chain — a lying count). A new `chain_total` reports the distinct-lineage count for callers that want it. Each item carries `is_superseded` (derived from `superseded_by`) plus `superseded_by`, so callers can tell the live head from the tombstone. Chain expansion behavior is unchanged.
- **enums in signatures** — `entities.link` signature spells out `source?: 'ui' | 'llm' | 'feed' | 'api'`; `entities.listLinks` spells out `direction?: 'outbound' | 'inbound' | 'both'`. `entities.get` / `entities.delete` get explicit signatures. SDK interfaces updated to type the pass-through fields.
- **read-mode admin lists** — `agents.list`, `agents.get`, `schedules.list` reclassified `admin` → `read` (they are org-read gated at runtime via `requireOrgReadAccess` / org-scoped query), so `query_sdk` read mode no longer drops the whole namespace. Mutating siblings stay `admin`. Defensive: `run_script` now returns a structured `NamespaceNotAvailable` stub for a KNOWN-but-hidden namespace instead of `undefined` (mirrors the existing `client.org` stub), so callers get a clear error instead of "Cannot read properties of undefined".

Item 6 (entities.get/delete accept only entity_id) is working-as-designed — added explicit signatures, no `id` alias. Item 11 (metrics.series) was not-a-bug — skipped.

## Test evidence (red→green)

- `delete-content-access.test.ts` (bun) — 8 pass, now asserting `content_id`/`content_ids` errors.
- `delete-content-tombstone.test.ts` (vitest) — 4 pass with `content_id`/`content_ids` args.
- `get-content-chain-resolve.test.ts` (vitest) — 4 pass; `total` expectations flipped from chain-count `1` to row counts, plus `chain_total` and `is_superseded` assertions.
- `entity-crud.test.ts` (vitest) — new test: soft-deleted entity hidden by default `get`, returned with `include_deleted: true`.
- `method-metadata.test.ts` (bun) — new asserts: agents.list/get + schedules.list are `read`, mutations stay `admin`, and link/listLinks signatures carry the enums.
- `sdk-search.test.ts` (bun) — updated: agents.list/get now visible in read mode; write-only namespace (notifications) still hints at run_sdk; admin-mutation still hidden from write tier.
- `run-script-runtime.test.ts` (vitest) — new: read-mode hidden namespace throws structured `NamespaceNotAvailable`; genuinely-unknown namespace stays `undefined`.

Full events + entities integration suites: 158 pass / 32 files. Sandbox unit suites: 98 pass.

## Notes

- Root `tsc --noEmit` (pre-commit gate) passes. Per-package scoped `tsc` shows unrelated pre-existing errors from stale sibling `dist` (e.g. `@lobu/core/contracts/tools/manage-behaviors`, `COMPILE_CONFIG_HASH`) that reproduce on a clean `main`; none reference symbols this PR introduces.
- Stacks logically after #2034 (the watcher→behavior rename) but should be independently mergeable if the rename merges first — base is `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->