### PR TITLE
fix(p0): classifier value round-trip + repair migration, atomic approval-event tx, readiness capability probe (#2033)

### DIFF
--- a/db/migrations/20260720120000_repair_array_shaped_attribute_values.sql
+++ b/db/migrations/20260720120000_repair_array_shaped_attribute_values.sql
@@ -1,0 +1,119 @@
+-- migrate:up
+
+-- Repair classifier `attribute_values` that were persisted as a JSON ARRAY
+-- instead of the expected object-MAP keyed by value string (#2033 item 4).
+--
+-- The read-side `stripEmbeddingsFromAttributeValues` fed such arrays straight
+-- into Object.entries, minting numeric keys `{"0":…}` and — once elements only
+-- carried `embedding` — the corrupted `{"0":{},"1":{}}` that `generate_embeddings`
+-- then re-persisted. The read guard now REJECTS array roots so no NEW corruption
+-- lands; this migration heals data already at rest.
+--
+-- Recovery rule (per array element, an ExtractedValue-shaped object
+-- `{value, description?, examples?, embedding?}`):
+--   * key  = element->>'value' (the sole stable identity for the value)
+--   * body = the element MINUS `value` and `embedding` (embedding is
+--            regenerable via generate_embeddings; value became the key)
+-- Elements with no usable `value` are dropped. If NO element yields a value the
+-- map collapses to `'{}'::jsonb`, flagging the row for regeneration.
+--
+-- Applies to BOTH classify_facet.attribute_values (jsonb map) and
+-- watcher_versions.classifiers[*].attribute_values (array of defs).
+--
+-- Guarantees:
+--   * IDEMPOTENT — predicates only match array-typed values, and the rebuilt
+--     shape is an OBJECT, so a re-run matches 0 rows.
+--   * Object-map rows are NEVER touched (predicate is jsonb_typeof = 'array').
+--
+-- No pg_temp helper is used: the harness applies migrations statement-by-
+-- statement over a connection pool, where a session-local pg_temp function
+-- would not survive to the next statement. The transform is inlined instead.
+
+-- ---------------------------------------------------------------------------
+-- Blast-radius log (visible in migration output; harmless if 0).
+-- ---------------------------------------------------------------------------
+DO $blast$
+DECLARE
+  facet_count int;
+  version_count int;
+BEGIN
+  SELECT count(*) INTO facet_count
+  FROM classify_facet
+  WHERE attribute_values IS NOT NULL
+    AND jsonb_typeof(attribute_values) = 'array';
+
+  SELECT count(*) INTO version_count
+  FROM watcher_versions
+  WHERE classifiers IS NOT NULL
+    AND jsonb_typeof(classifiers) = 'array'
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(classifiers) AS c
+      WHERE jsonb_typeof(c->'attribute_values') = 'array'
+    );
+
+  RAISE NOTICE '[repair_array_attribute_values] classify_facet array rows: %, watcher_versions rows with array classifier attribute_values: %',
+    facet_count, version_count;
+END
+$blast$;
+
+-- ---------------------------------------------------------------------------
+-- 1) classify_facet.attribute_values
+-- ---------------------------------------------------------------------------
+UPDATE classify_facet cf
+SET attribute_values = (
+      SELECT COALESCE(
+        jsonb_object_agg(elem->>'value', elem - 'value' - 'embedding')
+          FILTER (WHERE elem ? 'value' AND coalesce(elem->>'value', '') <> ''),
+        '{}'::jsonb
+      )
+      FROM jsonb_array_elements(cf.attribute_values) AS elem
+      WHERE jsonb_typeof(elem) = 'object'
+    ),
+    updated_at = NOW()
+WHERE cf.attribute_values IS NOT NULL
+  AND jsonb_typeof(cf.attribute_values) = 'array';
+
+-- ---------------------------------------------------------------------------
+-- 2) watcher_versions.classifiers[*].attribute_values
+--    Rebuild each classifier def's attribute_values in place, preserving every
+--    other field of the def and the array order.
+-- ---------------------------------------------------------------------------
+UPDATE watcher_versions wv
+SET classifiers = (
+      SELECT jsonb_agg(
+               CASE
+                 WHEN jsonb_typeof(def->'attribute_values') = 'array' THEN
+                   jsonb_set(
+                     def,
+                     '{attribute_values}',
+                     COALESCE(
+                       (
+                         SELECT jsonb_object_agg(elem->>'value', elem - 'value' - 'embedding')
+                                  FILTER (WHERE elem ? 'value' AND coalesce(elem->>'value', '') <> '')
+                         FROM jsonb_array_elements(def->'attribute_values') AS elem
+                         WHERE jsonb_typeof(elem) = 'object'
+                       ),
+                       '{}'::jsonb
+                     )
+                   )
+                 ELSE def
+               END
+               ORDER BY ord
+             )
+      FROM jsonb_array_elements(wv.classifiers) WITH ORDINALITY AS t(def, ord)
+    )
+WHERE wv.classifiers IS NOT NULL
+  AND jsonb_typeof(wv.classifiers) = 'array'
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(wv.classifiers) AS c
+    WHERE jsonb_typeof(c->'attribute_values') = 'array'
+  );
+
+-- migrate:down
+
+-- No-op: the pre-repair array shape was corrupt-on-read (it minted numeric-keyed
+-- maps and destroyed value identity). Reconstructing it would reintroduce the
+-- data-loss bug, and the original arrays are not retained. Nothing to revert.
+SELECT 1;

--- a/db/migrations/20260720120100_connector_definitions_supports_execute.sql
+++ b/db/migrations/20260720120100_connector_definitions_supports_execute.sql
@@ -1,0 +1,31 @@
+-- migrate:up
+
+-- Persisted capability flag so operations READINESS uses the SAME signal as
+-- EXECUTION (#2033 item 2). Readiness derives from `actions_schema` (the catalog
+-- metadata), but execution loads the compiled connector runtime and throws
+-- "Actions not supported" when the runtime does NOT override execute(). The base
+-- ConnectorRuntime defines execute() (rejecting), so declaring actions does NOT
+-- imply the code implements them — metadata and code can disagree.
+--
+-- We compute the real capability ONCE at compile/install time (does the concrete
+-- runtime class own an `execute` method, i.e. override the base?) and persist it
+-- here. Readiness reads it cheaply on the hot list_available path — no
+-- per-listing compilation.
+--
+-- Semantics:
+--   TRUE   → the runtime overrides execute(): local_action ops are executable.
+--   FALSE  → the runtime does NOT override execute(): local_action ops report
+--            readiness='unsupported', executable=false.
+--   NULL   → legacy row installed before this flag existed. Treated as "assume
+--            supported" so no existing connector regresses; the flag is stamped
+--            precisely on the next (re)install.
+ALTER TABLE connector_definitions
+  ADD COLUMN IF NOT EXISTS supports_execute boolean;
+
+COMMENT ON COLUMN connector_definitions.supports_execute IS
+  'Whether the compiled connector runtime overrides execute() (local_action capability). NULL = legacy/unknown, treated as supported. Set at install time.';
+
+-- migrate:down
+
+ALTER TABLE connector_definitions
+  DROP COLUMN IF EXISTS supports_execute;

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -192,6 +192,38 @@ export const SourceSchema = Type.Object({
   ),
 });
 
+/**
+ * A single classifier definition embedded in a Behavior version. The key
+ * invariant for #2033 item 4 is `attribute_values`: it MUST be an object-MAP
+ * keyed by value string, never an array. An array read back through
+ * `Object.entries` becomes numeric keys `{"0":…}` and, after embedding
+ * stripping, the corrupted `{"0":{},"1":{}}` — so we forbid the array shape at
+ * the contract boundary. Other fields are extraction config and stay open
+ * (`additionalProperties` allowed) to avoid breaking authored connectors.
+ */
+const BehaviorClassifierDefinitionSchema = Type.Object(
+  {
+    slug: Type.Optional(Type.String()),
+    name: Type.Optional(Type.String()),
+    source_path: Type.Optional(Type.String()),
+    value_field: Type.Optional(Type.String()),
+    description_field: Type.Optional(Type.String()),
+    examples_field: Type.Optional(Type.String()),
+    attribute_key: Type.Optional(Type.String()),
+    attribute_values: Type.Optional(
+      Type.Record(Type.String({ minLength: 1 }), Type.Unknown(), {
+        description:
+          "Object MAP keyed by value string. An array here corrupts on read (#2033).",
+      })
+    ),
+  },
+  {
+    additionalProperties: true,
+    description:
+      "Classifier definition. attribute_values MUST be an object map, not an array.",
+  }
+);
+
 // Flattened schema for MCP compatibility (MCP doesn't support top-level unions)
 export const ManageBehaviorsSchema = Type.Object(
   {
@@ -310,10 +342,19 @@ export const ManageBehaviorsSchema = Type.Object(
       })
     ),
     classifiers: Type.Optional(
-      Type.Any({
-        description:
-          "[create/create_version] Classifier definitions for extraction.",
-      })
+      Type.Union(
+        [
+          // Callers may pass a pre-serialized JSON string (coerced by
+          // parseJsonInput) or the array directly. Either way, the array shape
+          // enforces `attribute_values` is a map, not an array (#2033 item 4).
+          Type.String(),
+          Type.Array(BehaviorClassifierDefinitionSchema),
+        ],
+        {
+          description:
+            "[create/create_version] Classifier definitions for extraction. Each attribute_values MUST be an object map keyed by value, never an array.",
+        }
+      )
     ),
     triggers: Type.Optional(
       Type.Array(BehaviorTriggerSchema, {

--- a/packages/server/src/__tests__/integration/classifiers/classifier-attribute-values-repair.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifier-attribute-values-repair.test.ts
@@ -1,0 +1,261 @@
+/**
+ * #2033 item 4 — classifier `attribute_values` corruption.
+ *
+ * Covers:
+ *  1. Read guard round-trip: rich object-map values survive list() exactly
+ *     (description/examples preserved, embedding stripped) and a seeded
+ *     ARRAY-shaped row NEVER surfaces the corrupted `{"0":{}}` numeric-key shape.
+ *  2. Repair migration: converts array-shaped rows to a keyed map (or `{}` when
+ *     unrecoverable), is idempotent, and NEVER touches valid object-map rows —
+ *     for both classify_facet.attribute_values and watcher_versions.classifiers.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { loadMigrationUpSection, splitSqlStatements } from '../../../db/migration-loader';
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+
+const REPAIR_MIGRATION = '20260720120000_repair_array_shaped_attribute_values.sql';
+
+function resolveMigrationsDir(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'db/migrations');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate db/migrations from the test directory');
+}
+
+async function runRepairMigration(): Promise<void> {
+  const migrationsDir = resolveMigrationsDir();
+  const up = loadMigrationUpSection(migrationsDir, REPAIR_MIGRATION);
+  const sql = getDb();
+  for (const statement of splitSqlStatements(up)) {
+    await sql.unsafe(statement);
+  }
+}
+
+describe('classifier attribute_values corruption (item 4)', () => {
+  let owner: TestApiClient;
+  let orgId: string;
+  let userId: string;
+  let entityId: number;
+  let watcherId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Attr Repair Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'attr-repair@test.com' });
+    userId = user.id;
+    await addUserToOrganization(user.id, org.id, 'owner');
+    owner = await TestApiClient.for({
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+    });
+
+    await owner.entity_schema.createType({ slug: 'company', name: 'Company' });
+    const entity = (await owner.entities.create({
+      type: 'company',
+      name: 'Attr Target',
+    })) as { entity: { id: number } };
+    entityId = entity.entity.id;
+
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const w = (await owner.behaviors.create({
+      entity_id: entityId,
+      slug: 'attr-watcher',
+      name: 'Attr Watcher',
+      prompt: 'gather signals.',
+      agent_id: agent.agentId,
+    })) as { behavior_id: string };
+    watcherId = w.behavior_id;
+  });
+
+  it('round-trips rich object-map values through list() exactly (embedding stripped)', async () => {
+    const stubEmbedding = Array.from({ length: 768 }, () => 0.1);
+    const created = (await owner.classifiers.create({
+      slug: 'quality',
+      name: 'Quality',
+      attribute_key: 'quality',
+      watcher_id: watcherId,
+      attribute_values: {
+        high: { description: 'high quality', examples: ['excellent', 'superb'], embedding: stubEmbedding },
+        low: { description: 'low quality', examples: ['poor'], embedding: stubEmbedding },
+      },
+    })) as { data?: { classifier_id: number } };
+    const classifierId = created.data!.classifier_id;
+
+    const list = (await owner.classifiers.list({})) as {
+      data?: { classifiers?: Array<{ id: number; attribute_values: Record<string, unknown> }> };
+    };
+    const row = list.data?.classifiers?.find((c) => c.id === classifierId);
+    expect(row).toBeDefined();
+    const av = row!.attribute_values as Record<string, { description: string; examples: string[]; embedding?: unknown }>;
+
+    // Keys are the value strings — NOT numeric indices.
+    expect(Object.keys(av).sort()).toEqual(['high', 'low']);
+    expect(av.high.description).toBe('high quality');
+    expect(av.high.examples).toEqual(['excellent', 'superb']);
+    expect(av.low.description).toBe('low quality');
+    // Embedding dropped on the wire.
+    expect(av.high.embedding).toBeUndefined();
+    expect(av.low.embedding).toBeUndefined();
+  });
+
+  it('never emits {"0":{}} for a seeded ARRAY-shaped row', async () => {
+    const sql = getTestDb();
+    // Seed a legacy corrupt row directly: attribute_values is a jsonb ARRAY.
+    const inserted = await sql`
+      INSERT INTO classify_facet (
+        organization_id, slug, name, attribute_key, status, created_by,
+        entity_id, entity_ids, watcher_id, attribute_values, min_similarity
+      ) VALUES (
+        ${orgId}, 'legacy-array', 'Legacy Array', 'legacy', 'active', ${userId},
+        ${entityId}, ARRAY[${entityId}]::bigint[], ${Number(watcherId)},
+        ${sql.json([{ embedding: [0.1, 0.2] }, { embedding: [0.3, 0.4] }])},
+        0.7
+      )
+      RETURNING id
+    `;
+    const legacyId = Number(inserted[0].id);
+
+    const list = (await owner.classifiers.list({})) as {
+      data?: { classifiers?: Array<{ id: number; attribute_values: unknown }> };
+    };
+    const row = list.data?.classifiers?.find((c) => c.id === legacyId);
+    expect(row).toBeDefined();
+    // The read guard rejects the array root → null, NEVER the numeric-keyed
+    // `{"0":{},"1":{}}` corruption the old code emitted.
+    expect(row!.attribute_values).toBeNull();
+    if (row!.attribute_values !== null) {
+      expect(Object.keys(row!.attribute_values as object)).not.toContain('0');
+    }
+  });
+
+  it('repair migration converts array rows, is idempotent, and skips valid rows', async () => {
+    const sql = getTestDb();
+
+    // (a) Recoverable array: elements carry `value` → rebuild keyed map.
+    const recoverable = await sql`
+      INSERT INTO classify_facet (
+        organization_id, slug, name, attribute_key, status, created_by,
+        entity_id, entity_ids, watcher_id, attribute_values, min_similarity
+      ) VALUES (
+        ${orgId}, 'recoverable-array', 'Recoverable', 'rec', 'active', ${userId},
+        ${entityId}, ARRAY[${entityId}]::bigint[], ${Number(watcherId)},
+        ${sql.json([
+          { value: 'alpha', description: 'A', examples: ['a'], embedding: [0.1] },
+          { value: 'beta', description: 'B', examples: ['b'], embedding: [0.2] },
+        ])},
+        0.7
+      )
+      RETURNING id
+    `;
+    const recoverableId = Number(recoverable[0].id);
+
+    // (b) Unrecoverable array: elements only carry embedding → collapse to {}.
+    const unrecoverable = await sql`
+      INSERT INTO classify_facet (
+        organization_id, slug, name, attribute_key, status, created_by,
+        entity_id, entity_ids, watcher_id, attribute_values, min_similarity
+      ) VALUES (
+        ${orgId}, 'unrecoverable-array', 'Unrecoverable', 'unrec', 'active', ${userId},
+        ${entityId}, ARRAY[${entityId}]::bigint[], ${Number(watcherId)},
+        ${sql.json([{ embedding: [0.1] }, { embedding: [0.2] }])},
+        0.7
+      )
+      RETURNING id
+    `;
+    const unrecoverableId = Number(unrecoverable[0].id);
+
+    // (c) A VALID object-map row that must NOT be touched.
+    const validMap = { good: { description: 'g', examples: ['g'] } };
+    const valid = await sql`
+      INSERT INTO classify_facet (
+        organization_id, slug, name, attribute_key, status, created_by,
+        entity_id, entity_ids, watcher_id, attribute_values, min_similarity
+      ) VALUES (
+        ${orgId}, 'valid-map', 'Valid', 'valid', 'active', ${userId},
+        ${entityId}, ARRAY[${entityId}]::bigint[], ${Number(watcherId)},
+        ${sql.json(validMap)}, 0.7
+      )
+      RETURNING id
+    `;
+    const validId = Number(valid[0].id);
+
+    // (d) Seed an array-shaped classifier into the behavior version created by
+    // behaviors.create above (UPDATE avoids hand-crafting the version row's
+    // NOT NULL columns, which drift across migrations).
+    const versionRow = await sql`
+      UPDATE watcher_versions
+      SET classifiers = ${sql.json([
+        {
+          slug: 'vclass',
+          attribute_values: [
+            { value: 'x', description: 'X', embedding: [0.1] },
+            { value: 'y', description: 'Y' },
+          ],
+        },
+      ])}
+      WHERE watcher_id = ${Number(watcherId)}
+      RETURNING id
+    `;
+    const versionId = Number(versionRow[0].id);
+
+    await runRepairMigration();
+
+    const afterFirst = await sql`
+      SELECT id, attribute_values FROM classify_facet
+      WHERE id IN (${recoverableId}, ${unrecoverableId}, ${validId})
+      ORDER BY id
+    `;
+    const byId = new Map(afterFirst.map((r) => [Number(r.id), r.attribute_values]));
+
+    // Recoverable → keyed map, embedding + value dropped from bodies.
+    expect(byId.get(recoverableId)).toEqual({
+      alpha: { description: 'A', examples: ['a'] },
+      beta: { description: 'B', examples: ['b'] },
+    });
+    // Unrecoverable → {} (flagged for regeneration).
+    expect(byId.get(unrecoverableId)).toEqual({});
+    // Valid row untouched.
+    expect(byId.get(validId)).toEqual(validMap);
+
+    // Behavior-version classifier repaired in place, def fields preserved.
+    const versionAfter = await sql`
+      SELECT classifiers FROM watcher_versions WHERE id = ${versionId}
+    `;
+    const classifiers = versionAfter[0].classifiers as Array<Record<string, unknown>>;
+    expect(classifiers[0].slug).toBe('vclass');
+    expect(classifiers[0].attribute_values).toEqual({
+      x: { description: 'X' },
+      y: { description: 'Y' },
+    });
+
+    // Idempotency: a second run changes nothing (predicate no longer matches).
+    await runRepairMigration();
+    const afterSecond = await sql`
+      SELECT id, attribute_values FROM classify_facet
+      WHERE id IN (${recoverableId}, ${unrecoverableId}, ${validId})
+      ORDER BY id
+    `;
+    const byId2 = new Map(afterSecond.map((r) => [Number(r.id), r.attribute_values]));
+    expect(byId2.get(recoverableId)).toEqual(byId.get(recoverableId));
+    expect(byId2.get(unrecoverableId)).toEqual({});
+    expect(byId2.get(validId)).toEqual(validMap);
+  });
+});

--- a/packages/server/src/__tests__/integration/operations-approval-event-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-event-atomicity.test.ts
@@ -1,0 +1,210 @@
+/**
+ * #2033 item 16 — cross-org approval event never persisted → stranded pending run.
+ *
+ * The queued approval path must write the run and its pending approval EVENT in
+ * ONE transaction. If the event write fails, the run must NOT exist (no stranded
+ * pending run that the events-only /memory page can never surface). The happy
+ * path must durably create both and the event must be readable by run id.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import type { ToolContext } from "../../tools/registry";
+import { createAuthProfile } from "../../utils/auth-profiles";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestConnection,
+	createTestConnectorDefinition,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
+
+const CONNECTOR = "demo.ops.approval.atomic";
+
+// Force a REAL failure of the approval-event INSERT from inside the tx by
+// installing a BEFORE INSERT trigger on `events` that raises. This exercises
+// the exact atomicity path (insertEvent throws inside sql.begin) without module
+// mocking — which is unsafe under this suite's `isolate:false` shared registry.
+const FAIL_TRIGGER = `
+CREATE OR REPLACE FUNCTION test_fail_approval_event() RETURNS trigger AS $fn$
+BEGIN
+  IF NEW.interaction_type = 'approval' THEN
+    RAISE EXCEPTION 'simulated approval-event write failure';
+  END IF;
+  RETURN NEW;
+END;
+$fn$ LANGUAGE plpgsql;
+CREATE TRIGGER test_fail_approval_event_trg
+  BEFORE INSERT ON events
+  FOR EACH ROW EXECUTE FUNCTION test_fail_approval_event();
+`;
+const DROP_FAIL_TRIGGER = `
+DROP TRIGGER IF EXISTS test_fail_approval_event_trg ON events;
+DROP FUNCTION IF EXISTS test_fail_approval_event();
+`;
+
+describe("approval-event atomicity (item 16)", () => {
+	let orgId: string;
+	let userId: string;
+	let ctx: ToolContext;
+	let connectionId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, user, ctx: ownerCtx } = await seedOwnerContext({
+			orgName: "Approval Atomicity Org",
+		});
+		ownerCtx.baseUrl = "https://gateway.test/lobu";
+		orgId = org.id;
+		userId = user.id;
+		ctx = ownerCtx;
+
+		await createTestConnectorDefinition({
+			key: CONNECTOR,
+			name: "Approval Atomic",
+			organization_id: orgId,
+			auth_schema: { methods: [{ type: "oauth", provider: "test" }] },
+		});
+
+		const sql = getTestDb();
+		await sql`
+			UPDATE connector_definitions
+			SET actions_schema = ${sql.json({
+				needs_approval: {
+					name: "Needs approval",
+					kind: "write",
+					requiresApproval: true,
+				},
+			})},
+			supports_execute = true
+			WHERE organization_id = ${orgId} AND key = ${CONNECTOR}
+		`;
+		await sql`
+			UPDATE connector_versions
+			SET compiled_code = ${`
+				class ConnectorRuntime {
+					async sync() { return { items: [] }; }
+					async execute(ctx) { return { success: true, output: {} }; }
+				}
+				export { ConnectorRuntime };
+			`}
+			WHERE connector_key = ${CONNECTOR}
+		`;
+
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: CONNECTOR,
+			created_by: userId,
+			visibility: "private",
+		});
+		connectionId = conn.id;
+
+		const accountId = `acct_${connectionId}_approval`;
+		await sql`
+			INSERT INTO "account" (
+			  id, "accountId", "providerId", "userId",
+			  "accessToken", "accessTokenExpiresAt", scope, "createdAt", "updatedAt"
+			) VALUES (
+			  ${accountId}, ${accountId}, 'test', ${userId},
+			  'tok', ${new Date(Date.now() + 3_600_000).toISOString()}, 'read write', NOW(), NOW()
+			)
+		`;
+		const profile = await createAuthProfile({
+			organizationId: orgId,
+			connectorKey: CONNECTOR,
+			displayName: "approval test OAuth",
+			profileKind: "oauth_account",
+			provider: "test",
+			accountId,
+			status: "active",
+			createdBy: userId,
+		});
+		await sql`UPDATE connections SET auth_profile_id = ${profile.id} WHERE id = ${connectionId}`;
+	});
+
+	afterEach(async () => {
+		// Always drop the failure trigger so it can't leak into other tests that
+		// share this DB under the suite's single-fork registry.
+		await getTestDb().unsafe(DROP_FAIL_TRIGGER);
+	});
+
+	afterAll(async () => {
+		await getTestDb().unsafe(DROP_FAIL_TRIGGER);
+	});
+
+	it("happy path: run + approval event committed atomically and event is readable by run id", async () => {
+		const sql = getTestDb();
+		const before = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;
+
+		const result = (await manageOperations(
+			{ action: "execute", connection_id: connectionId, operation_key: "needs_approval", input: {} },
+			{} as Env,
+			ctx,
+		)) as { status: string; run_id: number; event_id: number; approval_url?: string };
+
+		expect(result.status).toBe("pending_approval");
+		expect(result.run_id).toBeGreaterThan(0);
+		expect(result.event_id).toBeGreaterThan(0);
+		expect(result.approval_url).toBeTruthy();
+
+		// The run exists and is pending.
+		const runRows = await sql`
+			SELECT status, approval_status FROM runs WHERE id = ${result.run_id} AND organization_id = ${orgId}
+		`;
+		expect(runRows).toHaveLength(1);
+		expect(runRows[0].status).toBe("pending");
+		expect(runRows[0].approval_status).toBe("pending");
+
+		// The approval event exists, is org-scoped, and joins to the run — this is
+		// what the /memory?run_ids= page reads. A stranded run would have none.
+		const eventRows = await sql`
+			SELECT id, interaction_type, interaction_status, organization_id
+			FROM events
+			WHERE run_id = ${result.run_id} AND organization_id = ${orgId}
+		`;
+		expect(eventRows).toHaveLength(1);
+		expect(eventRows[0].id).toBe(result.event_id);
+		expect(eventRows[0].interaction_type).toBe("approval");
+		expect(eventRows[0].interaction_status).toBe("pending");
+		expect(eventRows[0].organization_id).toBe(orgId);
+
+		const after = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;
+		expect(after[0].n).toBe(before[0].n + 1);
+	});
+
+	it("event write failure rolls back the run — no orphaned pending run, no event", async () => {
+		const sql = getTestDb();
+		const before = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;
+		const eventsBefore = await sql`
+			SELECT count(*)::int AS n FROM events
+			WHERE organization_id = ${orgId}
+			  AND interaction_type = 'approval'
+			  AND connector_key = ${CONNECTOR}
+		`;
+
+		await sql.unsafe(FAIL_TRIGGER);
+		await expect(
+			manageOperations(
+				{ action: "execute", connection_id: connectionId, operation_key: "needs_approval", input: {} },
+				{} as Env,
+				ctx,
+			),
+		).rejects.toThrow(/approval-event write failure/);
+
+		// The run INSERT shared the rolled-back transaction: no new run row.
+		const after = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;
+		expect(after[0].n).toBe(before[0].n);
+
+		// And NO new approval event was written (the failed insert rolled back with
+		// the run; the only pre-existing one is the happy-path event from test 1).
+		const eventsAfter = await sql`
+			SELECT count(*)::int AS n FROM events
+			WHERE organization_id = ${orgId}
+			  AND interaction_type = 'approval'
+			  AND connector_key = ${CONNECTOR}
+		`;
+		expect(eventsAfter[0].n).toBe(eventsBefore[0].n);
+	});
+});

--- a/packages/server/src/__tests__/integration/operations-execute-capability-readiness.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-capability-readiness.test.ts
@@ -1,0 +1,163 @@
+/**
+ * #2033 item 2 — operations readiness must use the SAME capability signal as
+ * execution. A local_action op whose compiled runtime does NOT override
+ * execute() would report "ready" then throw "Actions not supported". The install
+ * pipeline now computes `supportsExecute` at compile time and readiness reads it.
+ *
+ * Part A proves the compile-time probe (does the class override execute()?).
+ * Part B proves readiness maps supports_execute=false → "unsupported" and
+ * true → "ready".
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import {
+	compileConnectorSource,
+	extractConnectorMetadata,
+} from "../../utils/connector-compiler";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import type { ToolContext } from "../../tools/registry";
+import { createAuthProfile } from "../../utils/auth-profiles";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestConnection,
+	createTestConnectorDefinition,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
+
+const WITH_EXECUTE = "demo.cap.with_execute";
+const WITHOUT_EXECUTE = "demo.cap.no_execute";
+
+// A runtime that OVERRIDES execute().
+const SOURCE_WITH_EXECUTE = `
+export class MyConnector {
+  definition = { key: '${WITH_EXECUTE}', name: 'With Execute', version: '1.0.0', actions: { doit: { name: 'Do it', kind: 'write' } } };
+  async sync() { return { items: [] }; }
+  async execute(ctx) { return { success: true, output: {} }; }
+}
+`;
+
+// A runtime that declares actions but does NOT override execute() — it inherits
+// the base default and would throw "Actions not supported" at runtime.
+const SOURCE_WITHOUT_EXECUTE = `
+class Base {
+  async execute(ctx) { return { success: false, error: 'Actions not supported' }; }
+}
+export class MyConnector extends Base {
+  definition = { key: '${WITHOUT_EXECUTE}', name: 'No Execute', version: '1.0.0', actions: { doit: { name: 'Do it', kind: 'write' } } };
+  async sync() { return { items: [] }; }
+}
+`;
+
+describe("execute capability readiness (item 2)", () => {
+	describe("compile-time capability probe", () => {
+		it("detects an overridden execute() as supportsExecute=true", async () => {
+			const compiled = await compileConnectorSource(SOURCE_WITH_EXECUTE);
+			const metadata = await extractConnectorMetadata(compiled.compiledCode);
+			expect(metadata.supportsExecute).toBe(true);
+		});
+
+		it("detects an inherited (non-overridden) execute() as supportsExecute=false", async () => {
+			const compiled = await compileConnectorSource(SOURCE_WITHOUT_EXECUTE);
+			const metadata = await extractConnectorMetadata(compiled.compiledCode);
+			expect(metadata.supportsExecute).toBe(false);
+		});
+	});
+
+	describe("readiness reflects the capability flag", () => {
+		let orgId: string;
+		let userId: string;
+		let ctx: ToolContext;
+
+		beforeAll(async () => {
+			await cleanupTestDatabase();
+			await initWorkspaceProvider();
+			const { org, user, ctx: ownerCtx } = await seedOwnerContext({
+				orgName: "Capability Readiness Org",
+			});
+			ownerCtx.baseUrl = "https://gateway.test/lobu";
+			orgId = org.id;
+			userId = user.id;
+			ctx = ownerCtx;
+
+			const sql = getTestDb();
+			for (const [key, name, supports] of [
+				[WITH_EXECUTE, "With Execute", true],
+				[WITHOUT_EXECUTE, "No Execute", false],
+			] as const) {
+				await createTestConnectorDefinition({
+					key,
+					name,
+					organization_id: orgId,
+					auth_schema: { methods: [{ type: "oauth", provider: "test" }] },
+				});
+				await sql`
+					UPDATE connector_definitions
+					SET actions_schema = ${sql.json({ doit: { name: "Do it", kind: "write" } })},
+					    supports_execute = ${supports}
+					WHERE organization_id = ${orgId} AND key = ${key}
+				`;
+				await sql`
+					UPDATE connector_versions
+					SET compiled_code = ${`class R { async sync(){return {items:[]};} async execute(ctx){return {success:true,output:{}};} } export { R };`}
+					WHERE connector_key = ${key}
+				`;
+
+				// Wire an active, authenticated connection so status readiness would
+				// otherwise be "ready" — isolating the capability signal.
+				const conn = await createTestConnection({
+					organization_id: orgId,
+					connector_key: key,
+					created_by: userId,
+					visibility: "private",
+					config: { action_modes: { doit: "auto" } },
+				});
+				const accountId = `acct_${conn.id}_${key}`;
+				await sql`
+					INSERT INTO "account" (
+					  id, "accountId", "providerId", "userId",
+					  "accessToken", "accessTokenExpiresAt", scope, "createdAt", "updatedAt"
+					) VALUES (
+					  ${accountId}, ${accountId}, 'test', ${userId},
+					  'tok', ${new Date(Date.now() + 3_600_000).toISOString()}, 'read write', NOW(), NOW()
+					)
+				`;
+				const profile = await createAuthProfile({
+					organizationId: orgId,
+					connectorKey: key,
+					displayName: `${key} OAuth`,
+					profileKind: "oauth_account",
+					provider: "test",
+					accountId,
+					status: "active",
+					createdBy: userId,
+				});
+				await sql`UPDATE connections SET auth_profile_id = ${profile.id} WHERE id = ${conn.id}`;
+			}
+		});
+
+		async function readiness(connectorKey: string): Promise<{ readiness: string; executable: boolean }> {
+			const listed = (await manageOperations(
+				{ action: "list_available", connector_key: connectorKey },
+				{} as Env,
+				ctx,
+			)) as { operations: Array<{ operation_key: string; readiness: string; executable: boolean }> };
+			const op = listed.operations.find((o) => o.operation_key === "doit");
+			if (!op) throw new Error(`doit op not listed for ${connectorKey}`);
+			return { readiness: op.readiness, executable: op.executable };
+		}
+
+		it("reports 'ready' when the runtime supports execute()", async () => {
+			const r = await readiness(WITH_EXECUTE);
+			expect(r.readiness).toBe("ready");
+			expect(r.executable).toBe(true);
+		});
+
+		it("reports 'unsupported' when the runtime lacks execute()", async () => {
+			const r = await readiness(WITHOUT_EXECUTE);
+			expect(r.readiness).toBe("unsupported");
+			expect(r.executable).toBe(false);
+		});
+	});
+});

--- a/packages/server/src/operations/connector-operations.ts
+++ b/packages/server/src/operations/connector-operations.ts
@@ -14,6 +14,9 @@ type ConnectorRow = {
 	actions_schema: Record<string, any> | null;
 	mcp_config: Record<string, unknown> | null;
 	openapi_config: Record<string, unknown> | null;
+	// #2033 item 2: NULL (legacy) is treated as supported; only an explicit
+	// `false` marks local_action ops unsupported.
+	supports_execute?: boolean | null;
 };
 
 const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head"] as const;
@@ -413,8 +416,13 @@ function getLocalActionOperations(
 	connectorKey: string,
 	connectorName: string,
 	actionsSchema: Record<string, any> | null,
+	supportsExecute: boolean | null | undefined,
 ): OperationDescriptor[] {
 	if (!actionsSchema) return [];
+	// NULL/undefined (legacy definition installed before the flag) is treated as
+	// supported so nothing regresses; only an explicit `false` marks the op
+	// unsupported (#2033 item 2).
+	const executeSupported = supportsExecute !== false;
 	return Object.entries(actionsSchema).map(([key, def]) => ({
 		connector_key: connectorKey,
 		connector_name: connectorName,
@@ -429,6 +437,7 @@ function getLocalActionOperations(
 			((def.requiresApproval ?? false) ? { destructiveHint: true } : undefined),
 		input_schema: def.input_schema ?? def.inputSchema,
 		output_schema: def.output_schema ?? def.outputSchema,
+		supports_execute: executeSupported,
 		backend_config: {
 			backend: "local_action",
 			actionKey: key,
@@ -464,6 +473,7 @@ async function buildConnectorOperations(
 				connector.key,
 				connector.name,
 				connector.actions_schema,
+				connector.supports_execute,
 			),
 		),
 		getMcpOperations(
@@ -491,7 +501,7 @@ async function getConnectorsForListing(params: {
 
 	if (params.connectionId) {
 		const rows = await sql`
-      SELECT cd.key, cd.name, cd.actions_schema, cd.mcp_config, cd.openapi_config
+      SELECT cd.key, cd.name, cd.actions_schema, cd.mcp_config, cd.openapi_config, cd.supports_execute
       FROM connections c
       JOIN connector_definitions cd
         ON cd.key = c.connector_key
@@ -509,7 +519,7 @@ async function getConnectorsForListing(params: {
 	if (params.entityId) {
 		const rows = await sql`
       SELECT DISTINCT ON (cd.key)
-        cd.key, cd.name, cd.actions_schema, cd.mcp_config, cd.openapi_config
+        cd.key, cd.name, cd.actions_schema, cd.mcp_config, cd.openapi_config, cd.supports_execute
       FROM connections c
       JOIN feeds f ON f.connection_id = c.id
       JOIN connector_definitions cd
@@ -528,7 +538,7 @@ async function getConnectorsForListing(params: {
 
 	let query = sql`
     SELECT DISTINCT ON (cd.key)
-      cd.key, cd.name, cd.actions_schema, cd.mcp_config, cd.openapi_config
+      cd.key, cd.name, cd.actions_schema, cd.mcp_config, cd.openapi_config, cd.supports_execute
     FROM connector_definitions cd
     WHERE cd.status = 'active'
       AND cd.organization_id = ${params.organizationId}

--- a/packages/server/src/operations/types.ts
+++ b/packages/server/src/operations/types.ts
@@ -20,6 +20,14 @@ export interface AvailableOperation {
   annotations?: OperationAnnotations;
   input_schema?: Record<string, unknown>;
   output_schema?: Record<string, unknown>;
+  /**
+   * For `local_action` operations: whether the compiled connector runtime
+   * actually overrides execute(). `false` means the op is declared in the
+   * catalog but the code would throw "Actions not supported" — readiness must
+   * report it as unsupported (#2033 item 2). `undefined`/`true` = supported
+   * (or a backend where this does not apply, e.g. mcp_tool / http_operation).
+   */
+  supports_execute?: boolean;
 }
 
 interface LocalActionBackendConfig {

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -888,8 +888,16 @@ export async function createConnectorOperationRun(params: {
    */
   policyPrincipalKind?: 'agent' | 'watcher' | 'user' | null;
   policyPrincipalId?: string | null;
+  /**
+   * Optional transaction handle. When passed, the run INSERT (and its
+   * connector-version read) execute on the caller's transaction instead of the
+   * singleton pool, so the caller can bind run creation atomically to a sibling
+   * write (e.g. the pending approval EVENT — #2033 item 16). If the caller's tx
+   * rolls back, the run never exists.
+   */
+  db?: DbClient;
 }): Promise<number> {
-  const sql = getDb();
+  const sql = params.db ?? getDb();
 
   const approvalStatus = params.approvalMode === 'queued' ? 'pending' : 'auto';
   const status = params.approvalMode === 'inline' ? 'running' : 'pending';

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -174,6 +174,26 @@ function validateWatcherConfig(input: {
     if (!Array.isArray(input.classifiers)) {
       return 'classifiers must be an array';
     }
+    // Guard the write hole behind the classifier corruption bug (#2033 item 4):
+    // a classifier's `attribute_values` MUST be a keyed object-MAP, never an
+    // array. An array shape read back through Object.entries becomes numeric
+    // keys `{"0":…}` and, after embedding-stripping, the corrupted
+    // `{"0":{},"1":{}}`. Reject the array shape at save time so it can never be
+    // persisted into a behavior version's `classifiers` blob.
+    for (let i = 0; i < input.classifiers.length; i++) {
+      const def = input.classifiers[i];
+      if (def === null || typeof def !== 'object' || Array.isArray(def)) {
+        return `classifiers[${i}]: each classifier definition must be an object`;
+      }
+      const attributeValues = (def as Record<string, unknown>).attribute_values;
+      if (attributeValues !== undefined && attributeValues !== null) {
+        if (typeof attributeValues !== 'object' || Array.isArray(attributeValues)) {
+          return `classifiers[${i}].attribute_values: must be an object map keyed by value (got ${
+            Array.isArray(attributeValues) ? 'array' : typeof attributeValues
+          }). An array shape corrupts on read.`;
+        }
+      }
+    }
   }
 
   if (input.sources) {

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -77,21 +77,48 @@ async function hydrateAttributeEmbeddings(
   return { attributeValues: updated, generatedCount: valuesToEmbed.length };
 }
 
+/**
+ * Drop `embedding` from a classifier's `attribute_values` map for wire
+ * responses while preserving every other field (`description`, `examples`, …).
+ *
+ * The stored shape is an object-MAP keyed by value string. A malformed row can
+ * hold a JSON ARRAY (or any non-record root) — historically these were fed
+ * straight into `Object.entries`, which turned `[a, b]` into a map with numeric
+ * keys `{"0":a,"1":b}` and, once the array elements only carried `embedding`,
+ * into the corrupted `{"0":{},"1":{}}` that then got re-persisted. Guard the
+ * root: an array or non-record never becomes a numeric-keyed map here — it is
+ * rejected (returned as `null`) so callers surface "needs repair" rather than
+ * silently emitting and re-saving corruption. Valid object-maps round-trip
+ * exactly (plain-string entries and rich `{description, examples}` entries
+ * alike), minus `embedding`.
+ */
 function stripEmbeddingsFromAttributeValues(
   attributeValues: unknown
 ): Record<string, { description: string; examples: string[] }> | null {
   if (!attributeValues) return null;
-  const parsed =
-    typeof attributeValues === 'string' ? JSON.parse(attributeValues) : attributeValues;
-  if (typeof parsed !== 'object' || parsed === null) return null;
+  let parsed: unknown = attributeValues;
+  if (typeof attributeValues === 'string') {
+    try {
+      parsed = JSON.parse(attributeValues);
+    } catch {
+      return null;
+    }
+  }
+  // Reject non-record roots. A jsonb array would otherwise be coerced by
+  // Object.entries into `{"0":…}` numeric keys — the corruption this guards.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
 
   const stripped: Record<string, { description: string; examples: string[] }> = {};
-  for (const [key, value] of Object.entries(parsed as Record<string, any>)) {
-    if (value && typeof value === 'object') {
-      const { embedding, ...rest } = value;
-      stripped[key] = rest;
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const { embedding, ...rest } = value as Record<string, unknown>;
+      void embedding;
+      stripped[key] = rest as { description: string; examples: string[] };
     } else {
-      stripped[key] = value;
+      // Plain-string (or other scalar) entries round-trip untouched.
+      stripped[key] = value as unknown as { description: string; examples: string[] };
     }
   }
   return stripped;

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -458,6 +458,9 @@ function operationReadinessReason(
 	executable: boolean,
 ): string {
 	if (executable) return "At least one visible connection is ready.";
+	if (readiness === "unsupported") {
+		return "This connector's installed code does not implement this action (declared in the catalog but not executable).";
+	}
 	if (readiness === "disconnected") {
 		return "No visible connection exists for this connector.";
 	}
@@ -598,6 +601,15 @@ function buildOperationNextAction(args: {
 			],
 		};
 	}
+	if (readiness === "unsupported") {
+		// Not a connection/auth problem the caller can fix by wiring — the
+		// installed connector code simply lacks an execute() for this action.
+		return {
+			action: "unsupported",
+			manual: true,
+			...(viewUrl ? { view_url: viewUrl } : {}),
+		};
+	}
 	if (
 		["pending_auth", "error", "revoked"].includes(readiness) &&
 		["interactive", "oauth_account"].includes(remediationAuthKind ?? "")
@@ -642,8 +654,16 @@ function buildAvailableOperation(args: {
 			reason: "This operation is disabled on the connection.",
 		};
 	});
-	const { readyTarget, executable, readiness } =
-		resolveOperationReadiness(targets);
+	// Capability gate (#2033 item 2): a local_action op whose compiled runtime
+	// does NOT override execute() is declared in the catalog but would throw
+	// "Actions not supported" at execution. Report it unsupported here so
+	// readiness agrees with execution — regardless of connection status.
+	const executeUnsupported =
+		operation.backend === "local_action" &&
+		(operation as OperationDescriptor).supports_execute === false;
+	const { readyTarget, executable, readiness } = executeUnsupported
+		? { readyTarget: undefined, executable: false, readiness: "unsupported" }
+		: resolveOperationReadiness(targets);
 	const remediationTarget =
 		targets.find((target) => target.status === readiness) ?? targets[0];
 	const remediationInternalTarget = internalTargets.find(
@@ -1007,38 +1027,12 @@ async function handleExecute(
 			? "device"
 			: "inline";
 
-	const runId = await createConnectorOperationRun({
-		organizationId: ctx.organizationId,
-		connectionId: connection.id,
-		connectorKey: connection.connector_key,
-		operationKey: operation.operation_key,
-		operationInput: input,
-		approvalMode,
-		requireCompiledCode: operation.backend === "local_action",
-		// Persist the TRUSTED principal so a queued run's policy is re-evaluated
-		// at approve time against who queued it, not who approves it (sol #5) —
-		// and in the SAME acting mode, so an autonomous run's tighter autonomous
-		// rule isn't lost to an attended recheck.
-		policyPrincipalKind: actor.kind,
-		policyPrincipalId: actor.id,
-	});
-
-	if (args.watcher_source) {
-		await trackWatcherReaction({
-			organizationId: ctx.organizationId,
-			watcherId: args.watcher_source.watcher_id,
-			windowId: args.watcher_source.window_id,
-			reactionType: "action_executed",
-			toolName: "manage_operations",
-			toolArgs: {
-				operation_key: args.operation_key,
-				connection_id: args.connection_id,
-				input,
-			},
-			runId,
-		});
-	}
-
+	// Queued (approval) runs bind run creation to the pending approval EVENT in
+	// ONE transaction (#2033 item 16): if the event write fails, the run must
+	// not exist — otherwise the run is durably pending but the /memory approval
+	// page (events-only) shows nothing and the agent can never approve it.
+	// Device/inline runs have no approval event, so they create the run on the
+	// pool as before.
 	if (shouldQueue) {
 		const feedRows = await sql`
       SELECT entity_ids FROM feeds
@@ -1053,43 +1047,89 @@ async function handleExecute(
 				? rawEntityIds
 				: `{${(rawEntityIds as number[]).join(",")}}`
 			: null;
-		const event = await insertEvent({
-			entityIds:
-				entityIdsLiteral && typeof entityIdsLiteral === "string"
-					? entityIdsLiteral
-							.replace(/[{}]/g, "")
-							.split(",")
-							.filter(Boolean)
-							.map(Number)
-					: [],
-			organizationId: ctx.organizationId,
-			originId: `run_${runId}_pending`,
-			title: `${operation.name} — pending approval`,
-			content: `Agent requested operation: ${operation.name}`,
-			semanticType: "operation",
-			connectorKey: connection.connector_key,
-			connectionId: args.connection_id,
-			runId,
-			interactionType: "approval",
-			interactionStatus: "pending",
-			interactionInputSchema:
-				(operation.input_schema as Record<string, unknown> | undefined) ?? null,
-			interactionInput: input,
-			metadata: {
-				operation_key: operation.operation_key,
-				operation_name: operation.name,
-				action_key: operation.operation_key,
-				action_name: operation.name,
-				operation_input: input,
-				action_input: input,
-				input_schema: operation.input_schema ?? null,
-				status: "pending_approval",
-				connection_name: connection.display_name ?? connection.connector_key,
-				run_id: runId,
+		const entityIds =
+			entityIdsLiteral && typeof entityIdsLiteral === "string"
+				? entityIdsLiteral
+						.replace(/[{}]/g, "")
+						.split(",")
+						.filter(Boolean)
+						.map(Number)
+				: [];
+
+		// Atomic: run + approval event commit together or not at all. Both writes
+		// run on `tx`; insertEvent threads it via options.sql, and
+		// createConnectorOperationRun via its db param (which also carries its
+		// connector-version read into the same tx — safe, it is a read).
+		const { runId, eventId } = await sql.begin(async (tx) => {
+			const createdRunId = await createConnectorOperationRun({
+				organizationId: ctx.organizationId,
+				connectionId: connection.id,
+				connectorKey: connection.connector_key,
+				operationKey: operation.operation_key,
+				operationInput: input,
+				approvalMode,
+				requireCompiledCode: operation.backend === "local_action",
+				// Persist the TRUSTED principal so a queued run's policy is
+				// re-evaluated at approve time against who queued it, not who
+				// approves it (sol #5) — and in the SAME acting mode, so an
+				// autonomous run's tighter autonomous rule isn't lost to an
+				// attended recheck.
+				policyPrincipalKind: actor.kind,
+				policyPrincipalId: actor.id,
+				db: tx,
+			});
+			const event = await insertEvent({
+				entityIds,
+				organizationId: ctx.organizationId,
+				originId: `run_${createdRunId}_pending`,
+				title: `${operation.name} — pending approval`,
+				content: `Agent requested operation: ${operation.name}`,
+				semanticType: "operation",
+				connectorKey: connection.connector_key,
+				connectionId: args.connection_id,
+				runId: createdRunId,
+				interactionType: "approval",
+				interactionStatus: "pending",
+				interactionInputSchema:
+					(operation.input_schema as Record<string, unknown> | undefined) ??
+					null,
+				interactionInput: input,
+				metadata: {
+					operation_key: operation.operation_key,
+					operation_name: operation.name,
+					action_key: operation.operation_key,
+					action_name: operation.name,
+					operation_input: input,
+					action_input: input,
+					input_schema: operation.input_schema ?? null,
+					status: "pending_approval",
+					connection_name: connection.display_name ?? connection.connector_key,
+					run_id: createdRunId,
+				},
+				authorName: ctx.clientId ?? "agent",
 			},
-			authorName: ctx.clientId ?? "agent",
+			{ sql: tx });
+			return { runId: createdRunId, eventId: Number(event.id) };
 		});
-		const eventId = Number(event.id);
+
+		// Telemetry + notification run AFTER the run+event are durably committed,
+		// so they never reference a rolled-back run and stay off the hot path.
+		if (args.watcher_source) {
+			await trackWatcherReaction({
+				organizationId: ctx.organizationId,
+				watcherId: args.watcher_source.watcher_id,
+				windowId: args.watcher_source.window_id,
+				reactionType: "action_executed",
+				toolName: "manage_operations",
+				toolArgs: {
+					operation_key: args.operation_key,
+					connection_id: args.connection_id,
+					input,
+				},
+				runId,
+			});
+		}
+
 		const { ownerSlug: orgSlug, baseUrl } = await getOrgUrlContext(ctx);
 		// Run-scoped, not event-scoped: the pending event is superseded on
 		// approve→complete and drops out of the live view, but a run_ids permalink
@@ -1120,6 +1160,36 @@ async function handleExecute(
 			status: "pending_approval",
 			message: `Operation '${operation.name}' requires approval. Share the approval_url with the user to confirm.`,
 		};
+	}
+
+	// Non-queued (device / inline) runs carry no approval event, so there is no
+	// second write to bind atomically — create the run on the pool.
+	const runId = await createConnectorOperationRun({
+		organizationId: ctx.organizationId,
+		connectionId: connection.id,
+		connectorKey: connection.connector_key,
+		operationKey: operation.operation_key,
+		operationInput: input,
+		approvalMode,
+		requireCompiledCode: operation.backend === "local_action",
+		policyPrincipalKind: actor.kind,
+		policyPrincipalId: actor.id,
+	});
+
+	if (args.watcher_source) {
+		await trackWatcherReaction({
+			organizationId: ctx.organizationId,
+			watcherId: args.watcher_source.watcher_id,
+			windowId: args.watcher_source.window_id,
+			reactionType: "action_executed",
+			toolName: "manage_operations",
+			toolArgs: {
+				operation_key: args.operation_key,
+				connection_id: args.connection_id,
+				input,
+			},
+			runId,
+		});
 	}
 
 	// Device-bound branch: the run is pending; a device worker (chrome

--- a/packages/server/src/utils/connector-compiler.ts
+++ b/packages/server/src/utils/connector-compiler.ts
@@ -30,6 +30,17 @@ export interface ConnectorMetadata {
     platforms: Array<'ios' | 'android' | 'macos' | 'windows' | 'linux' | 'chrome-extension'>;
     scopes?: string[];
   } | null;
+  /**
+   * Whether the concrete runtime class OVERRIDES `execute()` (i.e. owns its own
+   * `execute` on its prototype rather than inheriting the base class's rejecting
+   * default). This is the capability signal readiness uses so it agrees with
+   * execution — a connector that declares actions but never overrides execute()
+   * would otherwise report "ready" and then throw "Actions not supported"
+   * (#2033 item 2). Computed once at compile time. Absent for metadata sources
+   * with no local runtime (e.g. MCP-proxy connectors) — persisted as NULL,
+   * treated as "assume supported".
+   */
+  supportsExecute?: boolean;
 }
 
 const CONNECTOR_RUNNER_CODE = `
@@ -78,6 +89,14 @@ async function main() {
       throw new Error('ConnectorRuntime class must expose a definition property.');
     }
 
+    // Capability probe (#2033 item 2): does the concrete class OVERRIDE execute()?
+    // The base ConnectorRuntime defines execute() (which rejects), so
+    // \`typeof prototype.execute === 'function'\` is always true and can't tell an
+    // override from the inherited default. An OWN \`execute\` on the class's own
+    // prototype means the connector actually implements execution.
+    const supportsExecute =
+      Object.getOwnPropertyNames(RuntimeClass.prototype).includes('execute');
+
     const metadata = {
       key: def.key || null,
       name: def.name || null,
@@ -95,6 +114,7 @@ async function main() {
       openapiConfig: def.openapiConfig || null,
       requiredCapability: def.requiredCapability || null,
       runtime: def.runtime || null,
+      supportsExecute,
     };
 
     process.send({ success: true, metadata });

--- a/packages/server/src/utils/connector-definition-install.ts
+++ b/packages/server/src/utils/connector-definition-install.ts
@@ -299,6 +299,10 @@ export async function upsertConnectorDefinitionRecords(params: {
   const mcpConfigJson = metadata.mcpConfig ? sql.json(metadata.mcpConfig) : null;
   const openapiConfigJson = metadata.openapiConfig ? sql.json(metadata.openapiConfig) : null;
   const runtimeJson = metadata.runtime ? sql.json(metadata.runtime) : null;
+  // Capability flag (#2033 item 2): readiness reads this instead of assuming a
+  // declared action is executable. Older metadata (no field) stays NULL =
+  // "assume supported" so nothing regresses.
+  const supportsExecute = metadata.supportsExecute ?? null;
 
   const existing = await sql`
     SELECT id, status, login_enabled
@@ -335,6 +339,7 @@ export async function upsertConnectorDefinitionRecords(params: {
           favicon_domain = ${metadata.faviconDomain ?? null},
           required_capability = ${metadata.requiredCapability ?? null},
           runtime = ${runtimeJson},
+          supports_execute = ${supportsExecute},
           login_enabled = ${preservedLoginEnabled},
           updated_at = NOW()
       WHERE id = ${existingRow.id}
@@ -352,7 +357,7 @@ export async function upsertConnectorDefinitionRecords(params: {
         organization_id, key, name, description, version,
         auth_schema, feeds_schema, actions_schema, behavior_events, options_schema,
         mcp_config, openapi_config, favicon_domain, required_capability,
-        runtime, status, login_enabled
+        runtime, supports_execute, status, login_enabled
       ) VALUES (
         ${params.organizationId}, ${metadata.key}, ${metadata.name},
         ${metadata.description ?? null}, ${metadata.version},
@@ -360,7 +365,7 @@ export async function upsertConnectorDefinitionRecords(params: {
         ${optionsSchemaJson},
         ${mcpConfigJson}, ${openapiConfigJson},
         ${metadata.faviconDomain ?? null}, ${metadata.requiredCapability ?? null},
-        ${runtimeJson}, 'active', ${preservedLoginEnabled}
+        ${runtimeJson}, ${supportsExecute}, 'active', ${preservedLoginEnabled}
       )
       ON CONFLICT (organization_id, key)
         WHERE organization_id IS NOT NULL AND status = 'active'
@@ -388,6 +393,7 @@ export async function upsertConnectorDefinitionRecords(params: {
             favicon_domain = ${metadata.faviconDomain ?? null},
             required_capability = ${metadata.requiredCapability ?? null},
             runtime = ${runtimeJson},
+            supports_execute = ${supportsExecute},
             updated_at = NOW()
         WHERE key = ${metadata.key}
           AND organization_id = ${params.organizationId}

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -366,7 +366,8 @@ export const QUERYABLE_SCHEMA = {
         'default_repair_agent_id',
         'required_capability',
         'runtime',
-        'behavior_events'
+        'behavior_events',
+        'supports_execute'
       ),
     },
   ],

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -69,6 +69,11 @@ export function deviceManifestToConnectorMetadata(manifest: DeviceConnectorManif
     openapiConfig: null,
     requiredCapability: manifest.required_capability,
     runtime: manifest.runtime as ConnectorMetadata['runtime'],
+    // Device connectors execute on the paired device. A manifest that declares
+    // actions is asserting it implements them there, so support tracks the
+    // presence of an actions schema (#2033 item 2). Device-online is a separate
+    // readiness axis handled elsewhere.
+    supportsExecute: manifest.actions_schema != null,
   };
 }
 


### PR DESCRIPTION
Fixes three P0 data-integrity / transaction / connector-capability bugs from #2033.

## Item 4 — classifier `attribute_values` corrupted to `{"0":{},"1":{}}` on read (DATA LOSS)
Root cause: `stripEmbeddingsFromAttributeValues` ran `Object.entries` on any root. When a row's `attribute_values` jsonb was an ARRAY, that minted numeric keys `{"0":...}`, and once the elements only carried `embedding`, the corrupted `{"0":{},"1":{}}` — then re-persisted by `generate_embeddings`.

- **Read guard**: the strip helper now rejects array/non-record roots (returns `null`) instead of coercing them; valid object-maps round-trip exactly (only `embedding` dropped).
- **Write enforcement**: `validateWatcherConfig` rejects a classifier whose `attribute_values` is an array; the `manage-behaviors` contract replaces `classifiers: Type.Any()` with a typed classifier-def array that forbids the array shape.
- **Repair migration** (`20260720120000`): heals data at rest for `classify_facet.attribute_values` AND `watcher_versions.classifiers[*].attribute_values` — array-of-value-objects → keyed map (value field as key, embedding dropped), or `{}` when unrecoverable (flagged for regeneration). Idempotent; never touches valid object-map rows; logs blast radius. No `pg_temp` (harness applies migrations statement-by-statement over a pool — inlined transform).

## Item 16 — cross-org approval event never persisted → stranded pending run
The queued-approval run INSERT and its pending approval EVENT now commit in ONE `sql.begin` transaction. `createConnectorOperationRun` takes an optional tx handle; `insertEvent` threads the same tx. If the event write fails, the run rolls back — no durable pending run without an approval event. Notification/telemetry stay outside the tx.

## Item 2 — readiness says "ready" but execute returns "Actions not supported"
The base `ConnectorRuntime` defines `execute()`, so a declared action doesn't imply the code implements it. A capability probe at compile time records whether the concrete runtime class OVERRIDES `execute()` (own prototype property), persisted as `connector_definitions.supports_execute` (migration `20260720120100`). Readiness reads it cheaply on the hot `list_available` path and reports `readiness:"unsupported"`/`executable:false` for `local_action` ops whose runtime lacks `execute()`. Legacy `NULL` = supported (no regression; stamped precisely on next install). Chosen over per-listing compilation to keep `list_available` cheap.

## Tests (red→green)
- `classifier-attribute-values-repair.test.ts`: rich object round-trip; seeded array-shaped row proves read guard no longer emits `{"0":{}}` (verified RED reproduces `{"0":{},"1":{}}`); migration idempotency + valid-row skip; behavior-version classifier repair.
- `operations-approval-event-atomicity.test.ts`: real event-insert failure (BEFORE-INSERT trigger) rolls back the run (0 new runs, 0 new events); happy path creates run+event atomically and the event is readable by run id.
- `operations-execute-capability-readiness.test.ts`: real compile-time probe distinguishes overridden vs inherited `execute()`; readiness maps `supports_execute=false`→`unsupported`, `true`→`ready`.

All 66 tests across the touched suites pass; no regressions.

## Note
`packages/server` scoped `tsc` shows 2 pre-existing `COMPILE_CONFIG_HASH` resolution errors that predate this branch (worktree build-state artifact); the repo pre-commit `tsc` gate passed clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->