### PR TITLE
list_activity: optional agent_id to scope the feed to one agent

### DIFF
--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -165,6 +165,14 @@ export const ListActivityAction = Type.Object({
   aggregate: Type.Optional(Type.Boolean({ default: true })),
   /** Restrict run kinds: watcher | sync | action | notification (default all). */
   kinds: Type.Optional(Type.Array(Type.String())),
+  /**
+   * Scope the feed to a single agent: only that agent's Behavior runs are
+   * returned and notifications are excluded (they are org/user-scoped, not
+   * per-agent). Omit for the org-wide feed (Home).
+   */
+  agent_id: Type.Optional(
+    Type.String({ description: "Scope activity to a single agent's runs" })
+  ),
 });
 
 export const ApproveAction = Type.Object({

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1201,6 +1201,7 @@ async function handleListActivity(
 		includeRuns: args.include_runs,
 		aggregate: args.aggregate,
 		kinds: args.kinds,
+		agentId: args.agent_id,
 	});
 	return {
 		action: "list_activity",

--- a/packages/server/src/tools/admin/manage_operations/activity-feed.ts
+++ b/packages/server/src/tools/admin/manage_operations/activity-feed.ts
@@ -278,10 +278,17 @@ export async function listOrgActivity(opts: {
 	includeRuns?: boolean;
 	aggregate?: boolean;
 	kinds?: string[];
+	/**
+	 * Scope to one agent: filter runs to that agent's Behaviors and drop
+	 * notifications (org/user-scoped, not attributable to an agent).
+	 */
+	agentId?: string;
 }): Promise<{ items: ActivityCard[]; total: number; limit: number }> {
 	const limit = Math.min(Math.max(opts.limit ?? 24, 1), 50);
+	// Notifications are not agent-attributable, so an agent-scoped feed omits
+	// them entirely and shows only that agent's runs.
 	const includeNotifications =
-		opts.includeNotifications !== false && !!opts.userId;
+		opts.includeNotifications !== false && !!opts.userId && !opts.agentId;
 	const includeRuns = opts.includeRuns !== false;
 	const aggregate = opts.aggregate !== false;
 	const kindFilter = opts.kinds?.length ? new Set(opts.kinds) : null;
@@ -333,6 +340,13 @@ export async function listOrgActivity(opts: {
 			: [...USER_FACING_RUN_TYPES];
 		if (runKinds.length > 0) {
 			const sql = getDb();
+			// When agent-scoped, restrict to that agent's Behavior runs. The join to
+			// `watchers` already exposes `w.agent_id`; a non-null agentId turns the
+			// LEFT JOIN into an effective inner filter (runs with no watcher, i.e.
+			// bare syncs/actions, are dropped — they aren't agent-owned).
+			const agentFilter = opts.agentId
+				? sql`AND w.agent_id = ${opts.agentId}`
+				: sql``;
 			const rows = (await sql`
         SELECT r.id, r.run_type, r.watcher_id, r.connection_id, r.feed_id,
                r.connector_key, r.action_key AS operation_key,
@@ -347,6 +361,7 @@ export async function listOrgActivity(opts: {
         LEFT JOIN watchers w ON w.id = r.watcher_id
         WHERE r.organization_id = ${opts.organizationId}
           AND r.run_type = ANY(${pgTextArray(runKinds)}::text[])
+          ${agentFilter}
         ORDER BY r.created_at DESC, r.id DESC
         LIMIT 60
       `) as unknown as Array<{


### PR DESCRIPTION
Adds an optional `agent_id` to the `list_activity` action so the feed can be scoped to a single agent's Behavior runs. Backs the owletto change where clicking an agent lands on an empty composer with that agent's recent activity.

- `agent_id` on `ListActivityAction` (core contract).
- `listOrgActivity` gains `agentId?`: when set, drops notifications (org/user-scoped, not agent-attributable) and filters the runs query to `w.agent_id` via the existing `watchers` LEFT JOIN (non-null agentId → effective inner filter; bare syncs/actions with no watcher are dropped).
- Org-wide Home feed is unchanged when `agent_id` is omitted.

Bumps owletto pointer to include the paired frontend change + notifications-first Home filter (lobu-ai/owletto#534).

`make pre-pr` clean. `make review` (Claude reviewer): 0 bugs, 0 blockers, bug_free 87 / simplicity 92 / slop 8; reviewer ran activity-feed tests (5/5 pass).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->