### PR TITLE
fix(behaviors): read renamed behavior_run_* columns in manage_behaviors list health

### DIFF
--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -221,9 +221,9 @@ export async function handleList(
 		const behaviorHealth = computeBehaviorHealth({
 			status: watcher.status,
 			nextRunAt: watcher.next_run_at,
-			latestRunStatus: watcher.watcher_run_status,
-			latestRunCreatedAt: watcher.watcher_run_created_at,
-			latestRunError: watcher.watcher_run_error,
+			latestRunStatus: watcher.behavior_run_status,
+			latestRunCreatedAt: watcher.behavior_run_created_at,
+			latestRunError: watcher.behavior_run_error,
 		});
 
 		return {


### PR DESCRIPTION
Follow-up to #2035, which was merged with an incomplete manual conflict resolution against #2034.

#2034 renamed the `manage_behaviors list` SQL run-column aliases from `watcher_run_*` to `behavior_run_*`. #2035 added `computeBehaviorHealth(...)` to the same map callback but read the old `watcher.watcher_run_*` fields. Because the query row is typed `any`, this compiled fine but the three run fields resolve to `undefined` at runtime, so the `list` health surfacing (item 3.1) is silently broken:

- a stuck-`pending` latest run is never flagged `degraded` (the `latestRunStatus === 'pending'` branch can't fire),
- `last_scheduling_error` is always `null`,
- a behavior that is actually mid-dispatch (`claimed`/`running`) can be false-degraded as a missed firing, since `runInFlight` is computed from the always-`undefined` status.

`get_behavior.ts` is unaffected: its query kept the `watcher_run_*` aliases, so its identical health read is already consistent. Only the `list` path regressed.

Fix reads the renamed columns:

```ts
const behaviorHealth = computeBehaviorHealth({
  status: watcher.status,
  nextRunAt: watcher.next_run_at,
  latestRunStatus: watcher.behavior_run_status,
  latestRunCreatedAt: watcher.behavior_run_created_at,
  latestRunError: watcher.behavior_run_error,
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->