### PR TITLE
feat(agents): schema-driven model config on manage_agents (#2047)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,6 +82,12 @@
       "import": "./dist/contracts/tools/manage-agents.js",
       "require": "./dist/contracts/tools/manage-agents.js"
     },
+    "./contracts/field-engine": {
+      "types": "./dist/contracts/field-engine.d.ts",
+      "bun": "./src/contracts/field-engine.ts",
+      "import": "./dist/contracts/field-engine.js",
+      "require": "./dist/contracts/field-engine.js"
+    },
     "./contracts/tools/manage-conversations": {
       "types": "./dist/contracts/tools/manage-conversations.d.ts",
       "bun": "./src/contracts/tools/manage-conversations.ts",

--- a/packages/core/src/contracts/field-engine.ts
+++ b/packages/core/src/contracts/field-engine.ts
@@ -1,0 +1,74 @@
+/**
+ * Schema-driven editable-field engine.
+ *
+ * A create/update MCP tool used to restate every editable field by hand in
+ * ~7 places (the create write, the update guards, the update write, the
+ * applied-check, the proposal build, the pre-image capture, the proposal→args
+ * remap). Adding a field meant editing all of them — and forgetting one is the
+ * exact bug class behind silently-dropped fields.
+ *
+ * Instead, the Typebox contract schema is the single source of truth: each
+ * editable property carries an `x-lobu-field` annotation, and this engine reads
+ * those annotations to drive create / update / proposal / pre-image uniformly.
+ * Add a field once (annotate it in the schema) and every path picks it up.
+ *
+ * This module is pure and DB-agnostic — it decides WHICH fields participate and
+ * HOW the update/proposal/pre-image bookkeeping folds, but the caller supplies
+ * the actual read/write closures (which touch the DB) via a binding table. Core
+ * therefore stays free of server/DB imports.
+ */
+
+import type { TObject, TSchema } from "@sinclair/typebox";
+
+/**
+ * Per-field metadata carried on a Typebox property as `x-lobu-field`. `store`
+ * distinguishes where the value lives so the caller's binding can route the
+ * write (an `agents` column vs. the settings row's `models[0]`, etc.).
+ * `emptyClears` marks a field whose empty-string input means "reset to default"
+ * rather than "write empty".
+ */
+export interface LobuFieldMeta {
+  /** Logical storage location; interpreted by the caller's binding table. */
+  store: string;
+  /** True when an empty-string value means "clear back to default". */
+  emptyClears?: boolean;
+}
+
+/** A schema property paired with its `x-lobu-field` metadata. */
+export interface LobuField {
+  key: string;
+  meta: LobuFieldMeta;
+}
+
+const FIELD_KEYWORD = "x-lobu-field";
+
+/**
+ * Collect the editable fields of a Typebox object schema in declaration order —
+ * i.e. every property annotated with `x-lobu-field`. Properties without the
+ * annotation (e.g. `action`, `agent_id`) are control/identity args, not
+ * editable content, and are skipped.
+ */
+export function collectLobuFields(schema: TObject): LobuField[] {
+  const out: LobuField[] = [];
+  for (const [key, prop] of Object.entries(schema.properties)) {
+    const meta = (prop as TSchema & Record<string, unknown>)[FIELD_KEYWORD] as
+      | LobuFieldMeta
+      | undefined;
+    if (meta && typeof meta.store === "string") {
+      out.push({ key, meta });
+    }
+  }
+  return out;
+}
+
+/**
+ * The fields an incoming args object actually requests to change: those present
+ * (`!== undefined`) among the schema's editable fields. `args` is the flat MCP
+ * argument object; `read` extracts a field's value from it.
+ */
+export function requestedFields(
+  fields: LobuField[],
+  args: Record<string, unknown>
+): LobuField[] {
+  return fields.filter((f) => args[f.key] !== undefined);
+}

--- a/packages/core/src/contracts/tools/manage-agents.ts
+++ b/packages/core/src/contracts/tools/manage-agents.ts
@@ -34,15 +34,34 @@ export const ManageAgentsSchema = Type.Object({
         '[get/create/update/delete/set_system_agent] Agent ID (lowercase slug, e.g. "builder").',
     })
   ),
+  // Editable fields carry an `x-lobu-field` annotation — the single source of
+  // truth the field engine loops over to drive create/update/proposal/pre-image
+  // (so adding a field is one annotated entry, not edits in seven places). The
+  // `store` routes the write: `column` = an `agents` table column; `model` =
+  // the settings row's `models[0]`.
   name: Type.Optional(
-    Type.String({ description: "[create/update] Display name for the agent." })
+    Type.String({
+      description: "[create/update] Display name for the agent.",
+      "x-lobu-field": { store: "column" },
+    })
   ),
   description: Type.Optional(
-    Type.String({ description: "[create/update] Agent description." })
+    Type.String({
+      description: "[create/update] Agent description.",
+      "x-lobu-field": { store: "column" },
+    })
   ),
   identity_md: Type.Optional(
     Type.String({
       description: "[create/update] Agent identity / system prompt (Markdown).",
+      "x-lobu-field": { store: "column" },
+    })
+  ),
+  default_model: Type.Optional(
+    Type.String({
+      description:
+        '[create/update] Default model as an explicit "<provider>/<model>" ref (e.g. "anthropic/claude-sonnet-5"). Validated against the org\'s connected providers. Without it the agent inherits the org default model; if the org has none the agent is not runnable. Pass an empty string to clear it and fall back to the org default.',
+      "x-lobu-field": { store: "model", emptyClears: true },
     })
   ),
 });
@@ -64,16 +83,48 @@ export interface AgentRecord {
   is_system_agent: boolean;
 }
 
+/**
+ * Where an agent's effective model came from, so a caller can tell a runnable
+ * agent from one that only works because the org happens to have a default
+ * (and would break if that default changed). Returned by `get`.
+ *
+ *   - `agent`: the agent pins its own `default_model` (`models[0]`).
+ *   - `org_default`: the agent pins nothing; it inherits the org default model.
+ *   - `none`: the agent pins nothing AND the org has no default — NOT runnable.
+ */
+export type ModelSource = "agent" | "org_default" | "none";
+
+export interface AgentModelInfo {
+  /** The effective model ref that would be used, or null when none resolves. */
+  effective_model: string | null;
+  /** Which layer supplied `effective_model`. */
+  source: ModelSource;
+  /** True when no model resolves — the agent cannot run until one is set. */
+  not_runnable: boolean;
+}
+
 export type ManageAgentsResult =
   | { action: "list"; agents: AgentRecord[] }
-  | { action: "get"; agent: AgentRecord }
-  | { action: "create"; agent_id: string; created: boolean }
+  | { action: "get"; agent: AgentRecord; model: AgentModelInfo }
+  | {
+      action: "create";
+      agent_id: string;
+      created: boolean;
+      /**
+       * The agent's model after create. `not_runnable: true` is the actionable
+       * signal that no model resolved (no `default_model` given and no org
+       * default) — set one with a `default_model` on create/update.
+       */
+      model: AgentModelInfo;
+    }
   | {
       action: "update";
       agent_id: string;
       updated_fields: string[];
       /** Fields a stale approval skipped because another writer changed them first. */
       skipped_fields?: string[];
+      /** The agent's model after update (present when the effective model is known). */
+      model?: AgentModelInfo;
     }
   | { action: "delete"; agent_id: string; deleted: boolean }
   | { action: "set_system_agent"; system_agent_id: string }
@@ -97,6 +148,12 @@ export interface ManageAgentsProposal {
   description?: string;
   identity_md?: string;
   /**
+   * Default model ref for the agent (`models[0]`). Empty string clears it back
+   * to the org default. Validated at request time against the org's providers,
+   * so an unapprovable proposal is rejected before the card is shown.
+   */
+  default_model?: string;
+  /**
    * Pre-image of the fields this update proposes to change, captured when the
    * update was queued. On approve, applyUpdate only overwrites a field whose
    * live value still equals its pre-image — so a stale approval never clobbers a
@@ -106,5 +163,7 @@ export interface ManageAgentsProposal {
     name?: string | null;
     description?: string | null;
     identity_md?: string | null;
+    /** Pre-image of `models[0]` (the default model ref), or null when unset. */
+    default_model?: string | null;
   };
 }

--- a/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
@@ -31,6 +31,11 @@ import {
 	resolveActingPrincipal,
 } from "../../../authz/entity-policy";
 import type { Env } from "../../../index";
+import {
+	createInferenceProvider,
+	setInferenceProviderDefault,
+} from "../../../lobu/stores/provider-secrets";
+import { orgContext } from "../../../lobu/stores/org-context";
 import type { AuthContext } from "../../../tools/execute";
 import { executeTool } from "../../../tools/execute";
 import { initWorkspaceProvider } from "../../../workspace";
@@ -666,5 +671,189 @@ describe("manage_agents — builder gate e2e", () => {
 				memberCtx,
 			),
 		).rejects.toThrow();
+	});
+});
+
+/**
+ * #2047 — an agent must be runnable after create, and the tool must expose a
+ * model-config path. Covers the schema-driven field engine end to end:
+ *   - create WITHOUT default_model + no org default ⇒ result reports not_runnable.
+ *   - create WITH a valid default_model ⇒ agent pinned, source 'agent', runnable.
+ *   - create with an unknown-provider model ⇒ rejected, and NO agent row left.
+ *   - get ⇒ returns effective model + inheritance source.
+ *   - update setting ONLY default_model ⇒ valid (proves default_model counts as a
+ *     field, the whole point of the registry).
+ *   - update clearing default_model ('') ⇒ falls back to the org default.
+ */
+describe("manage_agents — model config (#2047)", () => {
+	let orgId: string;
+	let ownerCtx: AuthContext;
+
+	const baseCtx = (
+		orgIdValue: string,
+		userId: string,
+	): AuthContext => ({
+		organizationId: orgIdValue,
+		tokenOrganizationId: orgIdValue,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		requestedAgentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		requestUrl: `http://localhost/api/${orgIdValue}`,
+		baseUrl: "",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	});
+
+	type ModelInfo = {
+		effective_model: string | null;
+		source: "agent" | "org_default" | "none";
+		not_runnable: boolean;
+	};
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const org = await createTestOrganization({ name: "manage_agents model e2e" });
+		orgId = org.id;
+		const owner = await createTestUser({ email: "ma-model-owner@test.com" });
+		await addUserToOrganization(owner.id, org.id, "owner");
+		ownerCtx = baseCtx(org.id, owner.id);
+		// An org provider whose slug the model refs resolve against.
+		await orgContext.run({ organizationId: org.id }, async () => {
+			await createInferenceProvider({
+				organizationId: org.id,
+				slug: "myco",
+				kind: "openai",
+				apiKey: "sk-test",
+				capabilities: { text: { model: "myco-large" } },
+			});
+		});
+	});
+
+	it("create WITHOUT default_model and no org default ⇒ not_runnable", async () => {
+		const res = (await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "no-model-bot", name: "No Model" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { created: boolean; model: ModelInfo };
+		expect(res.created).toBe(true);
+		expect(res.model.source).toBe("none");
+		expect(res.model.not_runnable).toBe(true);
+		expect(res.model.effective_model).toBeNull();
+	});
+
+	it("create WITH a valid default_model ⇒ pinned, runnable, source 'agent'", async () => {
+		const res = (await executeTool(
+			"manage_agents",
+			{
+				action: "create",
+				agent_id: "pinned-bot",
+				name: "Pinned",
+				default_model: "myco/myco-large",
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { created: boolean; model: ModelInfo };
+		expect(res.created).toBe(true);
+		expect(res.model.effective_model).toBe("myco/myco-large");
+		expect(res.model.source).toBe("agent");
+		expect(res.model.not_runnable).toBe(false);
+
+		// And it landed in the agents.models column (the single source of truth).
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT models FROM agents WHERE organization_id = ${orgId} AND id = 'pinned-bot'
+		`;
+		expect(rows[0]?.models).toEqual(["myco/myco-large"]);
+	});
+
+	it("create with an unknown-provider model ⇒ rejected, NO agent row left", async () => {
+		await expect(
+			executeTool(
+				"manage_agents",
+				{
+					action: "create",
+					agent_id: "bad-model-bot",
+					name: "Bad",
+					default_model: "ghostprovider/x",
+				},
+				TEST_ENV,
+				ownerCtx,
+			),
+		).rejects.toThrow();
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT 1 FROM agents WHERE organization_id = ${orgId} AND id = 'bad-model-bot'
+		`;
+		expect(rows.length).toBe(0);
+	});
+
+	it("get ⇒ returns effective model + inheritance source", async () => {
+		const got = (await executeTool(
+			"manage_agents",
+			{ action: "get", agent_id: "pinned-bot" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { agent: { id: string }; model: ModelInfo };
+		expect(got.agent.id).toBe("pinned-bot");
+		expect(got.model.effective_model).toBe("myco/myco-large");
+		expect(got.model.source).toBe("agent");
+	});
+
+	it("update setting ONLY default_model is a valid update", async () => {
+		await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "model-only-bot", name: "MO" },
+			TEST_ENV,
+			ownerCtx,
+		);
+		const upd = (await executeTool(
+			"manage_agents",
+			{
+				action: "update",
+				agent_id: "model-only-bot",
+				default_model: "myco/myco-large",
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { updated_fields: string[]; model: ModelInfo };
+		expect(upd.updated_fields).toContain("default_model");
+		expect(upd.model.effective_model).toBe("myco/myco-large");
+		expect(upd.model.source).toBe("agent");
+	});
+
+	it("update clearing default_model ('') falls back to the org default", async () => {
+		// Make myco the org default so a cleared agent inherits it.
+		await orgContext.run({ organizationId: orgId }, async () => {
+			await setInferenceProviderDefault(orgId, "myco");
+		});
+		await executeTool(
+			"manage_agents",
+			{
+				action: "create",
+				agent_id: "clearable-bot",
+				name: "Clear",
+				default_model: "myco/myco-large",
+			},
+			TEST_ENV,
+			ownerCtx,
+		);
+		const upd = (await executeTool(
+			"manage_agents",
+			{ action: "update", agent_id: "clearable-bot", default_model: "" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { updated_fields: string[]; model: ModelInfo };
+		expect(upd.updated_fields).toContain("default_model");
+		// Cleared pin ⇒ inherits the org default (source flips to org_default).
+		expect(upd.model.source).toBe("org_default");
+		expect(upd.model.not_runnable).toBe(false);
+		expect(upd.model.effective_model).toBe("myco/myco-large");
 	});
 });

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -20,11 +20,10 @@ import {
 	getOAuthProviderConfigs,
 	type OAuthProviderConfig,
 } from "../gateway/auth/oauth/providers";
-import { isUnresolvedModelRef } from "../gateway/auth/model-sentinel";
 import { buildProviderCatalog } from "../gateway/auth/provider-catalog";
 import { createAuthProfileLabel } from "../gateway/auth/settings/auth-profiles-manager";
 import { orgBucketAgentId } from "../gateway/auth/settings/user-auth-profile-store";
-import { getModelProviderModules } from "../gateway/modules/module-system";
+import { validateModelRefsAgainstOrg } from "./model-config";
 import {
 	ProviderRegistryService,
 	resolveProviderRegistryPath,
@@ -121,67 +120,34 @@ export async function validateModelsUpdate(params: {
 	agentId: string;
 	c: any;
 }): Promise<Record<string, unknown> | null> {
-	if (
-		!Array.isArray(params.models) ||
-		params.models.some((m) => typeof m !== "string")
-	) {
-		return {
-			error: "invalid_models",
-			error_description: "models must be an array of strings",
-		};
-	}
-
-	const entries = (params.models as string[]).map((m) => m.trim());
-	const invalid = (ref: string, why: string): Record<string, unknown> => ({
-		error: "invalid_model_ref",
-		error_description: `Invalid models entry "${ref}": ${why}. Every entry must be an explicit "<provider>/<model>" ref.`,
-		model: ref,
-	});
-	for (const ref of entries) {
-		// A `<slug>/__unresolved__` restriction sentinel is a deliberate,
-		// non-routable placeholder (emitted by the migration/provisioning for a
-		// "provider intended, no concrete model" agent). It must round-trip
-		// through PATCH — e.g. editing soulMd on a migrated legacy agent PATCHes
-		// the full settings incl. `models`, which may contain a sentinel — so
-		// accept it as valid without the model-shape / org-provider checks below.
-		if (isUnresolvedModelRef(ref)) continue;
-		const slash = ref.indexOf("/");
-		if (!ref || slash <= 0 || slash === ref.length - 1) {
-			return invalid(ref, "expected a provider-qualified model ref");
-		}
-		if (ref.slice(slash + 1).trim() === "auto") {
-			return invalid(ref, '"auto" is not a model; pick a concrete model');
-		}
-	}
-
-	// Org-level slug resolution: registry modules ∪ the org's provider rows.
-	const orgSlugs = new Set<string>(
-		getModelProviderModules().map((m) => m.providerId)
+	// The shape/slug validation is shared with the MCP `manage_agents` path via
+	// the context-free core; this wrapper only maps the structured error onto the
+	// route's JSON envelope and enriches the not-connected case with request-
+	// derived proxy/settings URLs (which need the Hono context).
+	const error = await validateModelRefsAgainstOrg(
+		params.models,
+		params.organizationId
 	);
-	for (const row of await listInferenceProviders(params.organizationId)) {
-		orgSlugs.add(row.slug);
+	if (!error) return null;
+	if (error.kind === "invalid_models") {
+		return { error: "invalid_models", error_description: error.message };
 	}
-	for (const ref of entries) {
-		// Sentinels are accepted above; skip the org-provider existence check
-		// (their slug — e.g. `legacy` — is intentionally not a real provider).
-		if (isUnresolvedModelRef(ref)) continue;
-		const providerId = ref.slice(0, ref.indexOf("/"));
-		if (orgSlugs.has(providerId)) continue;
-		const urls = buildRequestBaseUrls(params.c, params.agentId, providerId);
+	if (error.kind === "invalid_model_ref") {
 		return {
-			error: "model_provider_not_connected",
-			error_description:
-				`The model "${ref}" uses provider "${providerId}", but that provider does not exist in this organization. ` +
-				`Add it under Providers (or fix the slug), then save again. ` +
-				`Expected gateway proxy URL after setup: ${urls.expectedProxyUrl}`,
-			model: ref,
-			provider: providerId,
-			settingsUrl: urls.settingsUrl,
-			expectedProxyUrl: urls.expectedProxyUrl,
+			error: "invalid_model_ref",
+			error_description: error.message,
+			model: error.model,
 		};
 	}
-
-	return null;
+	const urls = buildRequestBaseUrls(params.c, params.agentId, error.provider);
+	return {
+		error: "model_provider_not_connected",
+		error_description: `${error.message} Expected gateway proxy URL after setup: ${urls.expectedProxyUrl}`,
+		model: error.model,
+		provider: error.provider,
+		settingsUrl: urls.settingsUrl,
+		expectedProxyUrl: urls.expectedProxyUrl,
+	};
 }
 
 // ── Route-level middleware ───────────────────────────────────────────────────

--- a/packages/server/src/lobu/model-config.ts
+++ b/packages/server/src/lobu/model-config.ts
@@ -1,0 +1,169 @@
+/**
+ * Shared, context-free agent model-config validation.
+ *
+ * The web route (`PATCH /:agentId/config`) and the MCP `manage_agents` tool both
+ * need to validate an agent's `models` allow-list against the org's providers
+ * before persisting it. The route wrapper (`validateModelsUpdate`) enriches the
+ * error with request-derived proxy/settings URLs; the MCP path has no HTTP
+ * request, so it calls this core directly. Keeping ONE validator means an agent
+ * created via MCP is gated by the same rules as one edited in the web UI —
+ * closing the #2047 gap where `manage_agents` had no model-config path at all.
+ */
+
+import type { AgentModelInfo } from "@lobu/core/contracts/tools/manage-agents";
+import { isUnresolvedModelRef } from "../gateway/auth/model-sentinel";
+import { resolveEffectiveModelRef } from "../gateway/auth/settings/model-selection";
+import { getModelProviderModules } from "../gateway/modules/module-system";
+import { orgContext } from "./stores/org-context";
+import { createPostgresAgentConfigStore } from "./stores/postgres-stores";
+import {
+  getOrgDefaultModel,
+  listInferenceProviders,
+} from "./stores/provider-secrets";
+
+// One config store instance for this module — the SAME postgres-backed store
+// the web config route and the settings-store wrapper delegate to. Reads/writes
+// are org-scoped by running them inside `orgContext.run(...)` (the store reads
+// the org from that async context), which is exactly how the settings store's
+// own `getSettings` scopes its reads. Used directly rather than via
+// `getLobuCoreServices()` so it works on every path — the core-services
+// singleton isn't populated in all execution contexts (e.g. the tool path).
+const agentConfigStore = createPostgresAgentConfigStore();
+
+/**
+ * A structured validation failure. `kind` lets callers map to the right
+ * error code / HTTP status and (for the route) attach friendly URLs. `null`
+ * from the validator means the list is valid.
+ */
+export type ModelValidationError =
+  | { kind: "invalid_models"; message: string }
+  | { kind: "invalid_model_ref"; message: string; model: string }
+  | {
+      kind: "model_provider_not_connected";
+      message: string;
+      model: string;
+      provider: string;
+    };
+
+/**
+ * Validate an agent `models` allow-list against the org's providers. Pure of any
+ * HTTP context: every entry must be an explicit `<slug>/<model>` ref (no bare
+ * ids, no `auto`) whose slug resolves at the ORG level (a registry provider
+ * module OR a row in `inference_providers`). `__unresolved__` restriction
+ * sentinels round-trip untouched (they are deliberate non-routable placeholders).
+ *
+ * Returns the first error, or `null` when the whole list is valid.
+ */
+export async function validateModelRefsAgainstOrg(
+  models: unknown,
+  organizationId: string,
+): Promise<ModelValidationError | null> {
+  if (!Array.isArray(models) || models.some((m) => typeof m !== "string")) {
+    return {
+      kind: "invalid_models",
+      message: "models must be an array of strings",
+    };
+  }
+
+  const entries = (models as string[]).map((m) => m.trim());
+  const invalid = (ref: string, why: string): ModelValidationError => ({
+    kind: "invalid_model_ref",
+    message: `Invalid models entry "${ref}": ${why}. Every entry must be an explicit "<provider>/<model>" ref.`,
+    model: ref,
+  });
+  for (const ref of entries) {
+    if (isUnresolvedModelRef(ref)) continue;
+    const slash = ref.indexOf("/");
+    if (!ref || slash <= 0 || slash === ref.length - 1) {
+      return invalid(ref, "expected a provider-qualified model ref");
+    }
+    if (ref.slice(slash + 1).trim() === "auto") {
+      return invalid(ref, '"auto" is not a model; pick a concrete model');
+    }
+  }
+
+  // Org-level slug resolution: registry modules ∪ the org's provider rows.
+  const orgSlugs = new Set<string>(
+    getModelProviderModules().map((m) => m.providerId),
+  );
+  for (const row of await listInferenceProviders(organizationId)) {
+    orgSlugs.add(row.slug);
+  }
+  for (const ref of entries) {
+    if (isUnresolvedModelRef(ref)) continue;
+    const providerId = ref.slice(0, ref.indexOf("/"));
+    if (orgSlugs.has(providerId)) continue;
+    return {
+      kind: "model_provider_not_connected",
+      message:
+        `The model "${ref}" uses provider "${providerId}", but that provider does not exist in this organization. ` +
+        `Add it under Providers (or fix the slug), then save again.`,
+      model: ref,
+      provider: providerId,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve an agent's effective model and where it comes from — the read side of
+ * #2047's "is this agent actually runnable?" question. Composes the SAME layered
+ * fallback the run path uses (`resolveEffectiveModelRef(agent.models) → org
+ * default`); nothing new is stored, this only reports what a run would resolve.
+ */
+export async function resolveAgentModelInfo(
+  agentModels: string[] | undefined,
+  organizationId: string,
+): Promise<AgentModelInfo> {
+  const agentModel = resolveEffectiveModelRef({ models: agentModels });
+  if (agentModel) {
+    return { effective_model: agentModel, source: "agent", not_runnable: false };
+  }
+  const orgDefault = await getOrgDefaultModel(organizationId);
+  if (orgDefault) {
+    return {
+      effective_model: orgDefault,
+      source: "org_default",
+      not_runnable: false,
+    };
+  }
+  return { effective_model: null, source: "none", not_runnable: true };
+}
+
+/**
+ * Persist an agent's default model (`models[0]`) through the SAME config store
+ * the web route writes — no parallel SQL, no second column. An empty/blank ref
+ * clears the list (`models = NULL`), so the agent falls back to the org default.
+ * Org-scoped via `orgContext.run`, matching the store's own read path.
+ *
+ * The caller is responsible for having validated `modelRef` with
+ * {@link validateModelRefsAgainstOrg} first; this only writes.
+ */
+export async function persistDefaultModel(
+  agentId: string,
+  organizationId: string,
+  modelRef: string,
+): Promise<void> {
+  const trimmed = modelRef.trim();
+  await orgContext.run({ organizationId }, () =>
+    agentConfigStore.updateSettings(agentId, {
+      models: trimmed ? [trimmed] : undefined,
+    }),
+  );
+}
+
+/**
+ * Read an agent's persisted `models` list, org-scoped. Wraps the config store's
+ * `getSettings` in `orgContext.run` so it resolves the row for THIS org (agent
+ * ids are unique, but scoping keeps cross-org reads honest).
+ */
+export async function readAgentModels(
+  agentId: string,
+  organizationId: string,
+): Promise<string[] | undefined> {
+  const settings = await orgContext.run({ organizationId }, () =>
+    agentConfigStore.getSettings(agentId),
+  );
+  return settings?.models ?? undefined;
+}

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -23,7 +23,12 @@
  */
 
 import {
+  collectLobuFields,
+  type LobuField,
+} from '@lobu/core/contracts/field-engine';
+import {
   ManageAgentsSchema,
+  type AgentModelInfo,
   type AgentRecord,
   type ManageAgentsArgs,
   type ManageAgentsProposal,
@@ -36,6 +41,12 @@ import {
 } from '../../authz/entity-policy';
 import { createDbClientFromEnv, getDb } from '../../db/client';
 import type { Env } from '../../index';
+import {
+  persistDefaultModel,
+  readAgentModels,
+  resolveAgentModelInfo,
+  validateModelRefsAgainstOrg,
+} from '../../lobu/model-config';
 import { isValidAgentId } from '../../lobu/stores/postgres-stores';
 import { notifyActionApprovalNeeded } from '../../notifications/triggers';
 import { insertEvent } from '../../utils/insert-event';
@@ -75,6 +86,102 @@ async function actingPrincipalFor(ctx: ToolContext): Promise<ActingPrincipal> {
     agentId: ctx.agentId,
     sessionWatcherId: ctx.actingWatcherId ?? null,
   });
+}
+
+/**
+ * Compute an agent's effective model + inheritance source (#2047). Reads the
+ * agent's `models` list through the shared settings store (org-scoped) and
+ * folds in the org default — the SAME layered fallback the run path uses, so a
+ * caller can tell a genuinely runnable agent from one that only works because
+ * the org has a default. Returns `not_runnable` when nothing resolves.
+ */
+async function agentModelInfo(
+  ctx: ToolContext,
+  agentId: string,
+): Promise<AgentModelInfo> {
+  const models = await readAgentModels(agentId, ctx.organizationId);
+  return resolveAgentModelInfo(models, ctx.organizationId);
+}
+
+/**
+ * Validate a `default_model` ref against the org's providers, reusing the SAME
+ * core the web config route uses (#2047). A blank/empty ref is a legal "clear
+ * back to org default" and passes. Throws a `ToolUserError` (400) with the
+ * provider-not-connected guidance so a bad model is rejected at request time —
+ * both for immediate applies and before an approval card is ever shown.
+ */
+async function assertDefaultModelValid(
+  organizationId: string,
+  modelRef: string,
+): Promise<void> {
+  if (!modelRef.trim()) return;
+  const error = await validateModelRefsAgainstOrg([modelRef], organizationId);
+  if (error) throw new ToolUserError(error.message, 400);
+}
+
+// ============================================
+// Schema-driven editable-field engine
+// ============================================
+//
+// The editable agent fields (name/description/identity_md/default_model) are
+// declared ONCE, on the `ManageAgentsSchema` contract via `x-lobu-field`
+// annotations. `collectLobuFields` reads them; the binding below says, per
+// storage kind, how to read the current value, validate a new one, and persist
+// it. create / update / buildProposal / pre-image all loop this single list —
+// adding a field is one annotated schema entry, not edits in seven places.
+
+/** The editable fields of this tool, in schema declaration order. */
+const AGENT_FIELDS: LobuField[] = collectLobuFields(ManageAgentsSchema);
+
+/** Column-backed fields (an `agents` table column). Their name IS the column. */
+const COLUMN_FIELDS = AGENT_FIELDS.filter((f) => f.meta.store === 'column');
+
+/** Read a field's requested value off the flat args object. */
+function argValue(args: ManageAgentsArgs, key: string): string | undefined {
+  return (args as Record<string, unknown>)[key] as string | undefined;
+}
+
+/**
+ * The live value of a field for the stale-guard pre-image / equality checks.
+ * Column fields read straight off the agent row; the model field reads the
+ * agent-pinned `models[0]` (an inherited org default is NOT a pinned value, so
+ * it reads as null — clearing then re-inheriting is not a "change" to guard).
+ */
+async function liveFieldValue(
+  ctx: ToolContext,
+  agentId: string,
+  field: LobuField,
+  agentRow: Record<string, unknown> | null,
+): Promise<string | null> {
+  if (field.meta.store === 'column') {
+    return (agentRow?.[field.key] as string | null) ?? null;
+  }
+  // store === 'model'
+  const info = await agentModelInfo(ctx, agentId);
+  return info.source === 'agent' ? (info.effective_model ?? null) : null;
+}
+
+/** Validate a single field's requested value (only the model field validates). */
+async function validateField(
+  ctx: ToolContext,
+  field: LobuField,
+  value: string,
+): Promise<void> {
+  if (field.meta.store === 'model') {
+    await assertDefaultModelValid(ctx.organizationId, value);
+  }
+}
+
+/** Persist a non-column field after the agents-row UPDATE (model → models[0]). */
+async function writeNonColumnField(
+  ctx: ToolContext,
+  agentId: string,
+  field: LobuField,
+  value: string,
+): Promise<void> {
+  if (field.meta.store === 'model') {
+    await persistDefaultModel(agentId, ctx.organizationId, value);
+  }
 }
 
 /**
@@ -197,7 +304,8 @@ async function handleGet(
     throw new ToolUserError(`Agent "${args.agent_id}" not found`, 404);
   }
   await assertAgentConfigReadAllowed(ctx, args.agent_id.trim());
-  return { action: 'get', agent: rows[0] as unknown as AgentRecord };
+  const model = await agentModelInfo(ctx, args.agent_id);
+  return { action: 'get', agent: rows[0] as unknown as AgentRecord, model };
 }
 
 export async function applyCreate(
@@ -223,13 +331,21 @@ export async function applyCreate(
       'create requires an authenticated caller to own the new agent'
     );
   }
+  // Validate every requested field BEFORE inserting, so an invalid value can't
+  // leave a half-created agent (row inserted, a later field rejected). The loop
+  // is the same for whatever fields the schema declares.
+  for (const field of AGENT_FIELDS) {
+    const value = argValue(args, field.key);
+    if (value !== undefined) await validateField(ctx, field, value);
+  }
   const sql = createDbClientFromEnv(env);
   const ownerUserId = ctx.userId;
   // Mirror the provisioning pattern (ensureDefaultAgent / ensureBuilderAgent):
   // owner_platform='external' on the row AND an agent_users mapping, so the
   // per-user ownership check (SPA cookie / PAT session) can reach the new agent.
   // Without the agent_users row the agent is unreachable through chat,
-  // especially in non-default orgs.
+  // especially in non-default orgs. Column fields are seeded from args (with the
+  // insert defaults for those not supplied); non-column fields are set after.
   const rows = await sql`
     INSERT INTO agents (
       id, organization_id, name, description, identity_md,
@@ -249,8 +365,19 @@ export async function applyCreate(
       VALUES (${ctx.organizationId}, ${args.agent_id}, 'external', ${ownerUserId}, NOW())
       ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
     `;
+    // Persist non-column fields (e.g. default_model → models[0]) through their
+    // stores, so a freshly created agent is runnable rather than silently
+    // model-less (#2047). Loop-driven: any future non-column field is picked up.
+    for (const field of AGENT_FIELDS) {
+      if (field.meta.store === 'column') continue;
+      const value = argValue(args, field.key);
+      if (value !== undefined) {
+        await writeNonColumnField(ctx, args.agent_id, field, value);
+      }
+    }
   }
-  return { action: 'create', agent_id: args.agent_id, created };
+  const model = await agentModelInfo(ctx, args.agent_id);
+  return { action: 'create', agent_id: args.agent_id, created, model };
 }
 
 export async function applyUpdate(
@@ -279,77 +406,109 @@ export async function applyUpdate(
   if (!args.agent_id) {
     throw new ToolUserError('agent_id is required for update action');
   }
+  const agentId = args.agent_id;
   const sql = createDbClientFromEnv(env);
-  const requested: string[] = [];
-  if (args.name !== undefined) requested.push('name');
-  if (args.description !== undefined) requested.push('description');
-  if (args.identity_md !== undefined) requested.push('identity_md');
+
+  // ── Requested set — every editable field the args actually carry (loop-driven
+  //    off the schema; no per-field enumeration). default_model lives in the
+  //    settings row, name/description/identity_md are columns — all counted here
+  //    so "set only the model" is a valid update (#2047).
+  const requested = AGENT_FIELDS.filter(
+    (f) => argValue(args, f.key) !== undefined
+  );
   if (requested.length === 0) {
-    throw new ToolUserError(
-      'update requires at least one of: name, description, identity_md'
-    );
+    const names = AGENT_FIELDS.map((f) => f.key).join(', ');
+    throw new ToolUserError(`update requires at least one of: ${names}`);
   }
-  // A queued apply with no pre-image for a requested field can't safely write it
-  // (it might clobber a human edit made after the proposal was queued). Fail that
-  // field closed: drop it from the requested set so its CASE arm never fires and
-  // it's reported as skipped. Legacy pre-`base` runs thus apply nothing rather
-  // than everything. Immediate applies (requireBase=false) are unaffected.
-  const unbackedFields = requireBase
-    ? requested.filter((field) => {
-        if (field === 'name') return base?.name === undefined;
-        if (field === 'description') return base?.description === undefined;
-        return base?.identity_md === undefined;
-      })
-    : [];
-  const writable = requested.filter((f) => !unbackedFields.includes(f));
-  const writeName = args.name !== undefined && writable.includes('name');
-  const writeDesc =
-    args.description !== undefined && writable.includes('description');
-  const writeIdentity =
-    args.identity_md !== undefined && writable.includes('identity_md');
-  // Each writable field is written iff (no pre-image given) OR (its live value
-  // still equals the pre-image). `${base ? … : true}` collapses to a constant per
-  // field so the guard is a no-op for immediate applies. IS NOT DISTINCT FROM
-  // matches NULLs. updated_at only bumps when at least one field actually changes.
-  const nameGuard = base ? base.name !== undefined : false;
-  const descGuard = base ? base.description !== undefined : false;
-  const identityGuard = base ? base.identity_md !== undefined : false;
-  const rows = await sql<{ id: string; name: string | null; description: string | null; identity_md: string | null }>`
+
+  // ── Validate each requested field up-front (only the model field validates),
+  //    so an immediate apply rejects a bad value before touching any storage.
+  for (const field of requested) {
+    await validateField(ctx, field, argValue(args, field.key) as string);
+  }
+
+  // ── Fail-closed on a queued apply lacking a pre-image: a field the proposal
+  //    didn't snapshot can't be written without risking clobbering a newer human
+  //    edit, so drop it (it's reported skipped). Immediate applies keep all.
+  const writable = requireBase
+    ? requested.filter((f) => base?.[f.key as keyof typeof base] !== undefined)
+    : requested;
+
+  // ── Column fields: one explicit UPDATE (the single honest place a column name
+  //    appears). Each column's write-flag and stale-guard flag come from the
+  //    loop, so adding a column field never means re-deriving these by hand.
+  const flags = Object.fromEntries(
+    COLUMN_FIELDS.map((f) => {
+      const write = writable.includes(f);
+      const guard = base ? base[f.key as keyof typeof base] !== undefined : false;
+      return [f.key, { write, guard }];
+    })
+  ) as Record<string, { write: boolean; guard: boolean }>;
+  const rows = await sql<{
+    id: string;
+    name: string | null;
+    description: string | null;
+    identity_md: string | null;
+  }>`
     UPDATE agents SET
       name = CASE
-        WHEN ${writeName}
-          AND (${!nameGuard} OR name IS NOT DISTINCT FROM ${base?.name ?? null})
+        WHEN ${flags.name.write}
+          AND (${!flags.name.guard} OR name IS NOT DISTINCT FROM ${base?.name ?? null})
         THEN ${args.name ?? null} ELSE name END,
       description = CASE
-        WHEN ${writeDesc}
-          AND (${!descGuard} OR description IS NOT DISTINCT FROM ${base?.description ?? null})
+        WHEN ${flags.description.write}
+          AND (${!flags.description.guard} OR description IS NOT DISTINCT FROM ${base?.description ?? null})
         THEN ${args.description ?? null} ELSE description END,
       identity_md = CASE
-        WHEN ${writeIdentity}
-          AND (${!identityGuard} OR identity_md IS NOT DISTINCT FROM ${base?.identity_md ?? null})
+        WHEN ${flags.identity_md.write}
+          AND (${!flags.identity_md.guard} OR identity_md IS NOT DISTINCT FROM ${base?.identity_md ?? null})
         THEN ${args.identity_md ?? ''} ELSE identity_md END,
       updated_at = NOW()
-    WHERE organization_id = ${ctx.organizationId} AND id = ${args.agent_id}
+    WHERE organization_id = ${ctx.organizationId} AND id = ${agentId}
     RETURNING id, name, description, identity_md
   `;
   if (rows.length === 0) {
-    throw new ToolUserError(`Agent "${args.agent_id}" not found`, 404);
+    throw new ToolUserError(`Agent "${agentId}" not found`, 404);
   }
-  // Report which requested fields actually landed. A field is skipped when its
-  // live value diverged from the pre-image (stale) OR it had no pre-image on a
-  // queued apply (unbacked — never written on blind faith).
   const after = rows[0];
-  const appliedFields = writable.filter((field) => {
-    if (field === 'name') return after.name === (args.name ?? null);
-    if (field === 'description') return after.description === (args.description ?? null);
-    return after.identity_md === (args.identity_md ?? '');
-  });
-  const skippedFields = requested.filter((f) => !appliedFields.includes(f));
+
+  // ── Applied/skipped, loop-driven. A column field landed iff its post-image
+  //    equals the requested value; a non-column field is persisted here (through
+  //    its store) honoring the same stale-guard, then marked applied.
+  const appliedFields: string[] = [];
+  for (const field of writable) {
+    const value = argValue(args, field.key) as string;
+    if (field.meta.store === 'column') {
+      const emptyDefault = field.meta.emptyClears ? null : '';
+      const want = value ?? emptyDefault;
+      if ((after[field.key as keyof typeof after] ?? null) === (want ?? null)) {
+        appliedFields.push(field.key);
+      }
+      continue;
+    }
+    // Non-column (model): re-check the pre-image against the live value, then
+    // persist. `writable` already dropped it if unbacked on a queued apply.
+    let stale = false;
+    if (base?.[field.key as keyof typeof base] !== undefined) {
+      const live = await liveFieldValue(ctx, agentId, field, null);
+      stale = live !== (base[field.key as keyof typeof base] ?? null);
+    }
+    if (!stale) {
+      await writeNonColumnField(ctx, agentId, field, value);
+      appliedFields.push(field.key);
+    }
+  }
+
+  const skippedFields = requested
+    .map((f) => f.key)
+    .filter((k) => !appliedFields.includes(k));
+  const model = await agentModelInfo(ctx, agentId);
   return {
     action: 'update',
-    agent_id: args.agent_id,
+    agent_id: agentId,
     updated_fields: appliedFields,
     ...(skippedFields.length > 0 ? { skipped_fields: skippedFields } : {}),
+    model,
   };
 }
 
@@ -458,20 +617,23 @@ function buildProposal(args: ManageAgentsArgs): ManageAgentsProposal {
     }
   }
   if (action === 'update') {
-    const hasField =
-      args.name !== undefined ||
-      args.description !== undefined ||
-      args.identity_md !== undefined;
+    const hasField = AGENT_FIELDS.some(
+      (f) => argValue(args, f.key) !== undefined
+    );
     if (!hasField) {
-      throw new ToolUserError(
-        'update requires at least one of: name, description, identity_md'
-      );
+      const names = AGENT_FIELDS.map((f) => f.key).join(', ');
+      throw new ToolUserError(`update requires at least one of: ${names}`);
     }
   }
+  // Copy every requested editable field onto the proposal, loop-driven off the
+  // schema — a new field flows through without editing this block.
   const proposal: ManageAgentsProposal = { action, agent_id: args.agent_id };
-  if (args.name !== undefined) proposal.name = args.name;
-  if (args.description !== undefined) proposal.description = args.description;
-  if (args.identity_md !== undefined) proposal.identity_md = args.identity_md;
+  for (const field of AGENT_FIELDS) {
+    const value = argValue(args, field.key);
+    if (value !== undefined) {
+      (proposal as unknown as Record<string, unknown>)[field.key] = value;
+    }
+  }
   return proposal;
 }
 
@@ -496,6 +658,16 @@ async function queueWriteForApproval(
     );
   }
 
+  // Validate every requested editable field before queuing, so a bad value is
+  // rejected at request time and an un-approvable card is never shown. Loop-
+  // driven off the schema; reuses each field's validator.
+  for (const field of AGENT_FIELDS) {
+    const value = (proposal as unknown as Record<string, unknown>)[field.key] as
+      | string
+      | undefined;
+    if (value !== undefined) await validateField(ctx, field, value);
+  }
+
   const sql = getDb();
   const current = await fetchCurrentAgent(ctx.organizationId, proposal.agent_id, env);
   if (proposal.action === 'create' && current) {
@@ -507,14 +679,21 @@ async function queueWriteForApproval(
 
   // Capture the pre-image of each field this update touches, so the eventual
   // approve applies only fields that haven't since been changed by someone else.
+  // Loop-driven: column fields read from the fetched row, the model field reads
+  // its live agent-pinned value — one shape, every field.
   if (proposal.action === 'update' && current) {
-    proposal.base = {};
-    if (proposal.name !== undefined)
-      proposal.base.name = (current.name as string | null) ?? null;
-    if (proposal.description !== undefined)
-      proposal.base.description = (current.description as string | null) ?? null;
-    if (proposal.identity_md !== undefined)
-      proposal.base.identity_md = (current.identity_md as string | null) ?? null;
+    const base: NonNullable<ManageAgentsProposal['base']> = {};
+    for (const field of AGENT_FIELDS) {
+      const value = (proposal as unknown as Record<string, unknown>)[field.key];
+      if (value === undefined) continue;
+      (base as Record<string, unknown>)[field.key] = await liveFieldValue(
+        ctx,
+        proposal.agent_id,
+        field,
+        current
+      );
+    }
+    proposal.base = base;
   }
 
   // Reject a delete of the org's system agent up-front (same guard as
@@ -625,13 +804,18 @@ export async function applyManageAgentsProposal(
   env: Env,
   ownerUserId: string | null
 ): Promise<ManageAgentsResult> {
+  // Rebuild the flat args from the proposal, loop-driven off the schema so an
+  // added field flows back through without editing this remap.
   const args: ManageAgentsArgs = {
     action: proposal.action,
     agent_id: proposal.agent_id,
-    name: proposal.name,
-    description: proposal.description,
-    identity_md: proposal.identity_md,
   };
+  for (const field of AGENT_FIELDS) {
+    const value = (proposal as unknown as Record<string, unknown>)[field.key];
+    if (value !== undefined) {
+      (args as Record<string, unknown>)[field.key] = value;
+    }
+  }
   // create attributes ownership to the ORIGINAL requester, not the approver.
   const applyCtx: ToolContext =
     proposal.action === 'create' ? { ...ctx, userId: ownerUserId } : ctx;


### PR DESCRIPTION
Fixes #2047 — `agents.create`/`update` over MCP had no way to set the agent's model, so a freshly created agent looked runnable but silently had none, with no path to fix it short of the web UI.

## What changed
- **`default_model` on create/update** — an explicit `<provider>/<model>` ref that maps to the single source of truth, `agents.models[0]`. No new column, no second store. An empty string clears it back to the org default.
- **Shared validator** — the model ref is validated against the org's connected providers using the SAME logic the web config route (`PATCH /config`) uses. That logic was extracted from `validateModelsUpdate` into a context-free core (`validateModelRefsAgainstOrg`), and both the route and the tool now call it. Net: the route wrapper shrank (−34 lines), validation logic is defined once.
- **Effective model in results** — `get` and the create/update results report `{ effective_model, source, not_runnable }` where source is `agent` | `org_default` | `none`, composed via the existing run-path resolver (`resolveEffectiveModelRef` + `getOrgDefaultModel`). A caller can now tell a runnable agent from a `not_runnable` one instead of finding out at run time.

## Consolidation (schema-driven field engine)
The editable agent fields are declared **once**, on the Typebox contract via `x-lobu-field` annotations (reusing the established `x-lobu-*` keyword pattern). A small field engine (`@lobu/core/contracts/field-engine`) reads those annotations, and create / update / proposal-build / pre-image all loop that one list.

Per-field restatement dropped from **45 lines to 10** (the 10 remaining are the column UPDATE's CASE arms — the one honest place a column name must appear). Adding a field is now one annotated schema entry instead of edits in seven places, which closes the exact "forgot a field" bug class that #2048 is about. The engine is reusable but wired only into `manage_agents` here; behaviors/operations have a different (version-shaped) field model and adopt it only where it fits.

## Notes
- Model persistence/reads go through the postgres config store directly, org-scoped via `orgContext.run` — not `getLobuCoreServices()`, whose singleton is unpopulated on the tool path (the e2e caught this).

## Verification
- `manage-agents-e2e` **21/21** (embedded pgvector Postgres): the original 17 gate tests plus 4 new #2047 tests — create with/without model, unknown-provider rejected with no orphan row, `get` model info, update-only-model, clear-to-org-default.
- `make pre-pr` clean (build-packages, strict typecheck, knip, biome).

Note: `make review` LLM verdict not yet run — the Codex-backed reviewer is over its usage limit until 2026-07-25; will run before merge. Base branch has 5 pre-existing `behavior_id`/`watcher_id` tsc errors in the behaviors/watchers subsystem (unrelated to this PR; present on `origin/main` HEAD).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->