### PR TITLE
fix(behaviors): create_version explicit source replacement, no silent inherit (#2048)

### DIFF
--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -335,7 +335,7 @@ export const ManageBehaviorsSchema = Type.Object(
     sources: Type.Optional(
       Type.Array(SourceSchema, {
         description:
-          "[create/create_version] Array of SQL data sources. Each source is { name, query }. Sources are version-owned — to change them on an existing Behavior, publish a new version with action: 'create_version'.",
+          "[create/create_version] Array of SQL data sources. Each source is { name, query }. Sources are version-owned — to change them on an existing Behavior, publish a new version with action: 'create_version'. On create_version this is a FULL REPLACEMENT: the array you pass (even []) becomes the version's complete source set. Passing [] clears all sources; OMITTING sources inherits the prior version's (unless the prompt was edited, in which case sources derive from the prompt's @-mention chips). The response returns source_count and removed_sources so you can see what a replacement dropped.",
       })
     ),
     keying_config: Type.Optional(

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
@@ -199,7 +199,7 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 				{
 					action: "update",
 					behavior_id: watcherId,
-					sources: [{ name: "content", query: "SELECT 1" }],
+					sources: [{ name: "content", query: "SELECT id FROM events" }],
 				},
 				TEST_ENV,
 				ownerCtx
@@ -313,5 +313,135 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 			  AND version = 2
 		`;
 		expect(stored.prompt).toBe("Updated preview response instructions.");
+	});
+});
+
+/**
+ * #2048 — create_version source semantics: explicit-set REPLACES (even []),
+ * omitting INHERITS, prompt-edit derives from the prompt's @-chips. The bug was
+ * that `sources: []` (or a different list) passed WITHOUT a prompt edit was
+ * conflated with "omitted" and silently re-inherited the stored sources.
+ *
+ * red→green: before the fix, "explicitly clears" and "explicitly replaces" both
+ * inherited the original sources; after, the passed list is authoritative.
+ */
+describe("manage_behaviors create_version — source replacement semantics (#2048)", () => {
+	let orgId: string;
+	let ownerCtx: AuthContext;
+	let behaviorId: string;
+
+	const baseCtx = (orgIdValue: string, userId: string): AuthContext => ({
+		organizationId: orgIdValue,
+		tokenOrganizationId: orgIdValue,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		requestedAgentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		requestUrl: `http://localhost/api/${orgIdValue}`,
+		baseUrl: "",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	});
+
+	// Sources live on the per-assignment watchers.sources column.
+	async function fetchSources(): Promise<Array<{ name: string; query: string }>> {
+		const sql = getTestDb();
+		const rows = await sql`SELECT sources FROM watchers WHERE id = ${behaviorId}`;
+		const raw = (rows[0] as { sources: unknown }).sources;
+		return (raw ?? []) as Array<{ name: string; query: string }>;
+	}
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const org = await createTestOrganization({ name: "cv sources #2048" });
+		orgId = org.id;
+		const owner = await createTestUser({ email: "cv-owner@test.com" });
+		await addUserToOrganization(owner.id, org.id, "owner");
+		ownerCtx = baseCtx(org.id, owner.id);
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "cv-agent",
+			ownerUserId: owner.id,
+		});
+		// Create a behavior with two explicit sources and a prompt WITHOUT @-chips,
+		// so the derive-from-prompt path is not what supplies sources here.
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "cv-target",
+				name: "CV Target",
+				prompt: "Analyze the data.",
+				agent_id: agent.agentId,
+				sources: [
+					{ name: "alpha", query: "SELECT id FROM events" },
+					{ name: "beta", query: "SELECT id FROM events WHERE 1=1" },
+				],
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { behavior_id?: string };
+		behaviorId = created.behavior_id!;
+	});
+
+	it("baseline: the created behavior has the two explicit sources", async () => {
+		const names = (await fetchSources()).map((s) => s.name).sort();
+		expect(names).toEqual(["alpha", "beta"]);
+	});
+
+	it("omitting sources on a metadata-only bump INHERITS the stored sources", async () => {
+		const res = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				change_notes: "metadata only",
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { source_count?: number; removed_sources?: string[] };
+		expect(res.source_count).toBe(2);
+		expect(res.removed_sources).toBeUndefined();
+		const names = (await fetchSources()).map((s) => s.name).sort();
+		expect(names).toEqual(["alpha", "beta"]);
+	});
+
+	it("passing a NEW source list REPLACES (drops the ones not listed)", async () => {
+		const res = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				sources: [{ name: "alpha", query: "SELECT id FROM events" }],
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { source_count?: number; removed_sources?: string[] };
+		expect(res.source_count).toBe(1);
+		expect(res.removed_sources).toEqual(["beta"]);
+		const names = (await fetchSources()).map((s) => s.name);
+		expect(names).toEqual(["alpha"]);
+	});
+
+	it("passing [] CLEARS all sources (the #2048 fix — no silent inherit)", async () => {
+		const res = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				sources: [],
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { source_count?: number; removed_sources?: string[] };
+		expect(res.source_count).toBe(0);
+		// Only "alpha" remained from the prior version; it is now removed.
+		expect(res.removed_sources).toEqual(["alpha"]);
+		expect(await fetchSources()).toEqual([]);
 	});
 });

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -39,6 +39,8 @@ export async function handleCreateVersion(
   version_id: string;
   version: number;
   previous_version: number;
+  source_count: number;
+  removed_sources?: string[];
 }> {
   const sql = getDb();
 
@@ -86,29 +88,34 @@ export async function handleCreateVersion(
 
   const promptEdited = args.prompt !== undefined;
   const prompt = args.prompt ?? (prev.prompt as string);
-  // Sources derivation on a version bump. The prompt is the single source of
-  // truth for prompt-derived sources: the current prompt's `@`-mention tokens
-  // are authoritative, so we derive fresh from `prompt` and do NOT union with
-  // the stored sources — otherwise a deleted chip's source would linger forever
-  // and an edited SQL chip would leave its OLD query running under the original
-  // name (union-merge is monotonic; it can only add). We union ONLY explicit
-  // `args.sources` (an API caller that passes sources directly, not the UI which
-  // sends just the prompt).
+  // Sources on a version bump — full-replacement semantics keyed on INTENT,
+  // distinguishing "the caller omitted sources" (inherit) from "the caller
+  // explicitly set them" (replace, even to empty). This closes #2048: passing
+  // `sources: []` used to be conflated with "omitted" and silently re-inherited
+  // the stored sources. The three authoring intents, in precedence order:
+  //
+  //   1. Prompt edited            → derive fresh from the new prompt's `@`-chips
+  //      (unioned with any explicit sources). The prompt is authoritative: a
+  //      deleted chip's source must NOT linger, an edited SQL chip must not keep
+  //      its OLD query under the same name (union-merge is monotonic, add-only),
+  //      so we derive fresh rather than union with stored.
+  //   2. `sources` passed (prompt not edited) → EXPLICIT replacement. The given
+  //      list is authoritative even when empty (`[]` clears). This is the fix:
+  //      an API caller that passes sources means exactly that list.
+  //   3. Neither prompt nor sources supplied → INHERIT the stored sources, so a
+  //      metadata-only bump (schedule/name) preserves a legacy watcher's sources.
   const promptSources = extractSourcesFromPromptTokens(prompt);
+  const sourcesProvided = args.sources !== undefined;
   const explicitSources = args.sources ?? [];
-  const derived = mergePromptSources(explicitSources, promptSources);
-  // When the caller EDITED the prompt, the derived set is authoritative even if
-  // empty — removing every source chip must clear the sources, not silently keep
-  // the stale stored ones. Only fall back to the stored sources for a bump that
-  // did NOT touch the prompt (e.g. a schedule-only change), so a legacy watcher's
-  // sources survive a metadata edit.
-  const sources =
-    promptEdited || derived.length > 0
-      ? derived
-      : normalizeStoredJsonField(
-          watcherRows[0].sources,
-          [] as Array<{ name: string; query: string }>
-        );
+  const storedSources = normalizeStoredJsonField(
+    watcherRows[0].sources,
+    [] as Array<{ name: string; query: string }>
+  );
+  const sources = promptEdited
+    ? mergePromptSources(explicitSources, promptSources)
+    : sourcesProvided
+      ? explicitSources
+      : storedSources;
   const keyingConfig =
     parseJsonInput<Record<string, unknown>>(args.keying_config, 'keying_config') ??
     normalizeStoredJsonField(prev.keying_config, undefined as Record<string, unknown> | undefined);
@@ -288,12 +295,23 @@ export async function handleCreateVersion(
     });
   }
 
+  // Report the resulting source set + what a full-replacement dropped, so a
+  // caller can SEE that publishing this version removed sources (rather than
+  // discovering it at the next run). `removed_sources` = names present on the
+  // prior assignment but absent from the new version (#2048).
+  const newSourceNames = new Set(sources.map((s) => s.name));
+  const removedSources = storedSources
+    .map((s) => s.name)
+    .filter((name) => !newSourceNames.has(name));
+
   return {
     action: 'create_version',
     behavior_id: args.behavior_id,
     version_id: String(versionId),
     version: lockedNextVersion,
     previous_version: previousVersion,
+    source_count: sources.length,
+    ...(removedSources.length > 0 ? { removed_sources: removedSources } : {}),
   };
 }
 


### PR DESCRIPTION
Fixes #2048 — `behaviors.create_version` silently inherited a behavior's stored sources when a caller passed `sources: []` (or a replacement list) without also editing the prompt. A caller who published a version to clear or change sources got the old ones back, and only found out at the next run.

## Root cause
The derivation did `explicitSources = args.sources ?? []` and then `promptEdited || derived.length > 0 ? derived : storedSources`. That conflated two different intents — "the caller omitted sources" and "the caller explicitly passed an empty list" — so an explicit `[]` fell through to the stored-sources inherit branch.

## Fix — intent-keyed full replacement
Distinguish `args.sources === undefined` (omit) from an explicit array (replace, even `[]`):

1. **prompt edited** → derive fresh from the prompt's `@`-mention chips (the UI path, unchanged — a removed chip must not linger).
2. **`sources` passed, prompt not edited** → **explicit full replacement**; the given list is authoritative, and `[]` clears.
3. **neither supplied** → inherit the stored sources, so a metadata-only bump (schedule/name) preserves a legacy behavior's sources.

The response now returns `source_count` and `removed_sources`, so a caller can see what a replacement dropped instead of discovering it at run time. The contract's `sources` description documents the full-replacement semantics.

This deliberately does **not** force strict all-fields-required (that would break the UI's prompt-only path and every partial-bump caller) — it fixes the exact ambiguity that caused the silent drop.

## Verification (red→fix→green)
- With the old derivation, the "passing `[]` clears all sources" test fails (`expected 0, got 1` inherited source).
- With the fix, all pass. `manage-behaviors-update-version-fields` **13/13** (embedded pgvector): omit-inherits, list-replaces-and-reports-`removed_sources`, `[]`-clears, plus the 9 pre-existing update-guard tests.
- `make pre-pr` clean.

Note: `make review` LLM verdict not yet run — the Codex-backed reviewer is over its usage limit until 2026-07-25; will run before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->