### PR TITLE
fix(runs): stale-run reaper must not time out human-approval-pending runs (#2044)

### DIFF
--- a/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
+++ b/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
@@ -6,31 +6,38 @@
  * is held no-ops instead of double-failing the row.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
-import postgres from 'postgres';
-import { getDb } from '../../db/client';
 import {
-  ensureDbForGatewayTests,
-  resetTestDatabase,
-} from '../../gateway/__tests__/helpers/db-setup';
-import { reapStaleRuns } from '../check-stalled-executions';
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import postgres from "postgres";
+import { getDb } from "../../db/client";
+import {
+	ensureDbForGatewayTests,
+	resetTestDatabase,
+} from "../../gateway/__tests__/helpers/db-setup";
+import { reapStaleRuns } from "../check-stalled-executions";
 
-const ORG_ID = 'reaper-org';
+const ORG_ID = "reaper-org";
 const STALE_THRESHOLD_SECONDS = 60;
 
 beforeAll(async () => {
-  await ensureDbForGatewayTests();
-  process.env.RUNS_REAPER_STALE_AFTER_SECONDS = String(STALE_THRESHOLD_SECONDS);
+	await ensureDbForGatewayTests();
+	process.env.RUNS_REAPER_STALE_AFTER_SECONDS = String(STALE_THRESHOLD_SECONDS);
 });
 
 afterAll(() => {
-  delete process.env.RUNS_REAPER_STALE_AFTER_SECONDS;
+	delete process.env.RUNS_REAPER_STALE_AFTER_SECONDS;
 });
 
 beforeEach(async () => {
-  await resetTestDatabase();
-  const sql = getDb();
-  await sql`
+	await resetTestDatabase();
+	const sql = getDb();
+	await sql`
     INSERT INTO organization (id, name, slug)
     VALUES (${ORG_ID}, ${ORG_ID}, ${ORG_ID})
     ON CONFLICT (id) DO NOTHING
@@ -38,445 +45,493 @@ beforeEach(async () => {
 });
 
 interface SeedRunOpts {
-  status: 'pending' | 'claimed' | 'running' | 'completed';
-  lastHeartbeatAgoSeconds: number | null;
-  claimedAtAgoSeconds?: number | null;
-  runType?: 'sync' | 'action' | 'embed_backfill' | 'auth' | 'behavior';
-  feedId?: number | null;
-  createdAtAgoSeconds?: number;
+	status: "pending" | "claimed" | "running" | "completed";
+	lastHeartbeatAgoSeconds: number | null;
+	claimedAtAgoSeconds?: number | null;
+	runType?: "sync" | "action" | "embed_backfill" | "auth" | "behavior";
+	feedId?: number | null;
+	createdAtAgoSeconds?: number;
+	/** Defaults to 'auto' (worker-claimable). Set 'pending' for a human-approval run. */
+	approvalStatus?: "auto" | "pending" | "approved" | "rejected";
 }
 
 async function seedRun(opts: SeedRunOpts): Promise<number> {
-  const sql = getDb();
-  const runType = opts.runType ?? 'sync';
-  const hbInterval =
-    opts.lastHeartbeatAgoSeconds !== null
-      ? `current_timestamp - interval '${opts.lastHeartbeatAgoSeconds} seconds'`
-      : 'NULL';
-  const claimInterval =
-    opts.claimedAtAgoSeconds !== null && opts.claimedAtAgoSeconds !== undefined
-      ? `current_timestamp - interval '${opts.claimedAtAgoSeconds} seconds'`
-      : 'NULL';
-  const createdAt = `current_timestamp - interval '${opts.createdAtAgoSeconds ?? 0} seconds'`;
-  const rows = (await sql.unsafe(
-    `INSERT INTO runs (
+	const sql = getDb();
+	const runType = opts.runType ?? "sync";
+	const hbInterval =
+		opts.lastHeartbeatAgoSeconds !== null
+			? `current_timestamp - interval '${opts.lastHeartbeatAgoSeconds} seconds'`
+			: "NULL";
+	const claimInterval =
+		opts.claimedAtAgoSeconds !== null && opts.claimedAtAgoSeconds !== undefined
+			? `current_timestamp - interval '${opts.claimedAtAgoSeconds} seconds'`
+			: "NULL";
+	const createdAt = `current_timestamp - interval '${opts.createdAtAgoSeconds ?? 0} seconds'`;
+	const rows = (await sql.unsafe(
+		`INSERT INTO runs (
        organization_id, run_type, feed_id, status, approval_status,
        claimed_at, last_heartbeat_at, claimed_by, created_at
      ) VALUES (
-       $1, $2, $3, $4, 'auto',
+       $1, $2, $3, $4, $5,
        ${claimInterval}, ${hbInterval}, 'test-worker', ${createdAt}
      )
      RETURNING id`,
-    [ORG_ID, runType, opts.feedId ?? null, opts.status],
-  )) as unknown as Array<{ id: number | string }>;
-  return Number(rows[0].id);
+		[
+			ORG_ID,
+			runType,
+			opts.feedId ?? null,
+			opts.status,
+			opts.approvalStatus ?? "auto",
+		],
+	)) as unknown as Array<{ id: number | string }>;
+	return Number(rows[0].id);
 }
 
 async function seedFeed(feedId: number): Promise<void> {
-  const sql = getDb();
-  // Seed an org-scoped connection + feed at the requested id so the
-  // runs.feed_id FK is satisfied. Each test bumps the id so the
-  // partial-unique-index dedup logic exercises real rows.
-  await sql.unsafe(
-    `INSERT INTO connections (id, organization_id, connector_key, slug, status, created_at)
+	const sql = getDb();
+	// Seed an org-scoped connection + feed at the requested id so the
+	// runs.feed_id FK is satisfied. Each test bumps the id so the
+	// partial-unique-index dedup logic exercises real rows.
+	await sql.unsafe(
+		`INSERT INTO connections (id, organization_id, connector_key, slug, status, created_at)
      VALUES ($1, $2, 'fake', $3, 'active', current_timestamp)
      ON CONFLICT (id) DO NOTHING`,
-    [feedId, ORG_ID, `fake-${feedId}`],
-  );
-  await sql.unsafe(
-    `INSERT INTO feeds (id, organization_id, connection_id, feed_key, status, created_at, updated_at)
+		[feedId, ORG_ID, `fake-${feedId}`],
+	);
+	await sql.unsafe(
+		`INSERT INTO feeds (id, organization_id, connection_id, feed_key, status, created_at, updated_at)
      VALUES ($1, $2, $1, 'data', 'active', current_timestamp, current_timestamp)
      ON CONFLICT (id) DO NOTHING`,
-    [feedId, ORG_ID],
-  );
+		[feedId, ORG_ID],
+	);
 }
 
 async function statusOf(runId: number): Promise<string> {
-  const sql = getDb();
-  const rows = (await sql`SELECT status FROM runs WHERE id = ${runId}`) as unknown as Array<{
-    status: string;
-  }>;
-  return rows[0]?.status ?? 'missing';
+	const sql = getDb();
+	const rows =
+		(await sql`SELECT status FROM runs WHERE id = ${runId}`) as unknown as Array<{
+			status: string;
+		}>;
+	return rows[0]?.status ?? "missing";
 }
 
-describe('reapStaleRuns — connector lanes', () => {
-  test('a stale never-claimed sync is finalized without an immediate retry', async () => {
-    const feedId = 3131;
-    await seedFeed(feedId);
-    const sql = getDb();
-    await sql`
+describe("reapStaleRuns — connector lanes", () => {
+	test("a stale never-claimed sync is finalized without an immediate retry", async () => {
+		const feedId = 3131;
+		await seedFeed(feedId);
+		const sql = getDb();
+		await sql`
       UPDATE feeds
       SET last_sync_status = 'pending',
           next_run_at = current_timestamp + INTERVAL '1 hour'
       WHERE id = ${feedId}
     `;
-    const pendingId = await seedRun({
-      status: 'pending',
-      lastHeartbeatAgoSeconds: null,
-      runType: 'sync',
-      feedId,
-      createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-    });
+		const pendingId = await seedRun({
+			status: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "sync",
+			feedId,
+			createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
 
-    const result = await reapStaleRuns();
+		const result = await reapStaleRuns();
 
-    expect(result.reaped).toBe(1);
-    expect(result.retriesCreated).toBe(0);
-    expect(await statusOf(pendingId)).toBe('timeout');
+		expect(result.reaped).toBe(1);
+		expect(result.retriesCreated).toBe(0);
+		expect(await statusOf(pendingId)).toBe("timeout");
 
-    const pending = await sql`
+		const pending = await sql`
       SELECT id FROM runs
       WHERE feed_id = ${feedId} AND run_type = 'sync' AND status = 'pending'
     `;
-    expect(pending).toHaveLength(0);
-    const [feed] = await sql`
+		expect(pending).toHaveLength(0);
+		const [feed] = await sql`
       SELECT last_sync_status, last_error, consecutive_failures, next_run_at
       FROM feeds WHERE id = ${feedId}
     `;
-    expect(String(feed.last_sync_status)).toBe('failed');
-    expect(String(feed.last_error)).toBe('worker_claim_timeout');
-    expect(Number(feed.consecutive_failures)).toBe(1);
-    expect(new Date(String(feed.next_run_at)).getTime()).toBeGreaterThan(Date.now());
-  });
+		expect(String(feed.last_sync_status)).toBe("failed");
+		expect(String(feed.last_error)).toBe("worker_claim_timeout");
+		expect(Number(feed.consecutive_failures)).toBe(1);
+		expect(new Date(String(feed.next_run_at)).getTime()).toBeGreaterThan(
+			Date.now(),
+		);
+	});
 
-  test('a fresh never-claimed sync remains pending', async () => {
-    const pendingId = await seedRun({
-      status: 'pending',
-      lastHeartbeatAgoSeconds: null,
-      runType: 'sync',
-      createdAtAgoSeconds: 5,
-    });
+	test("a fresh never-claimed sync remains pending", async () => {
+		const pendingId = await seedRun({
+			status: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "sync",
+			createdAtAgoSeconds: 5,
+		});
 
-    const result = await reapStaleRuns();
+		const result = await reapStaleRuns();
 
-    expect(result.reaped).toBe(0);
-    expect(await statusOf(pendingId)).toBe('pending');
-  });
+		expect(result.reaped).toBe(0);
+		expect(await statusOf(pendingId)).toBe("pending");
+	});
 
-  test('a worker claim holding the row lock wins over pending expiration', async () => {
-    const pendingId = await seedRun({
-      status: 'pending',
-      lastHeartbeatAgoSeconds: null,
-      runType: 'sync',
-      createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-    });
-    const locker = postgres(process.env.DATABASE_URL as string, { max: 1 });
-    try {
-      await locker.begin(async (tx) => {
-        await tx`SELECT id FROM runs WHERE id = ${pendingId} FOR UPDATE`;
+	// #2044: a queued connector action awaiting HUMAN approval sits in
+	// status='pending', approval_status='pending'. No worker will ever claim it,
+	// so the claim-timeout must NOT reap it — otherwise the run is force-timed-out
+	// before anyone can approve, and the approval URL points at a dead run.
+	test("a stale action run awaiting human approval is NOT reaped", async () => {
+		const approvalId = await seedRun({
+			status: "pending",
+			approvalStatus: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "action",
+			createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
 
-        const result = await reapStaleRuns();
-        expect(result.reaped).toBe(0);
+		const result = await reapStaleRuns();
 
-        await tx`
+		expect(result.reaped).toBe(0);
+		expect(await statusOf(approvalId)).toBe("pending");
+	});
+
+	// Control: the guard is narrow. An auto-approved (worker-claimable) action run
+	// that never got claimed IS still reaped once stale — approval-gating is the
+	// ONLY exemption, so genuinely-stuck worker runs still time out.
+	test("a stale auto-approval action run IS still reaped", async () => {
+		const autoId = await seedRun({
+			status: "pending",
+			approvalStatus: "auto",
+			lastHeartbeatAgoSeconds: null,
+			runType: "action",
+			createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
+
+		const result = await reapStaleRuns();
+
+		expect(result.reaped).toBe(1);
+		expect(await statusOf(autoId)).toBe("timeout");
+	});
+
+	test("a worker claim holding the row lock wins over pending expiration", async () => {
+		const pendingId = await seedRun({
+			status: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "sync",
+			createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
+		const locker = postgres(process.env.DATABASE_URL as string, { max: 1 });
+		try {
+			await locker.begin(async (tx) => {
+				await tx`SELECT id FROM runs WHERE id = ${pendingId} FOR UPDATE`;
+
+				const result = await reapStaleRuns();
+				expect(result.reaped).toBe(0);
+
+				await tx`
           UPDATE runs
           SET status = 'claimed', claimed_at = current_timestamp, claimed_by = 'winning-worker'
           WHERE id = ${pendingId}
         `;
-      });
-    } finally {
-      await locker.end();
-    }
+			});
+		} finally {
+			await locker.end();
+		}
 
-    expect(await statusOf(pendingId)).toBe('claimed');
-    const afterClaim = await reapStaleRuns();
-    expect(afterClaim.reaped).toBe(0);
-    expect(await statusOf(pendingId)).toBe('claimed');
-  });
+		expect(await statusOf(pendingId)).toBe("claimed");
+		const afterClaim = await reapStaleRuns();
+		expect(afterClaim.reaped).toBe(0);
+		expect(await statusOf(pendingId)).toBe("claimed");
+	});
 
-  test('only the stale in-progress connector run is timed out', async () => {
-    // 1. Fresh heartbeat — should be left alone.
-    const freshId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: 5,
-      claimedAtAgoSeconds: 120,
-    });
-    // 2. Stale heartbeat — should be reaped.
-    const staleId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-    });
-    // 3. Terminal state (completed) — must never be touched even if it had a
-    //    stale heartbeat at the moment it completed.
-    const terminalId = await seedRun({
-      status: 'completed',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
-    });
+	test("only the stale in-progress connector run is timed out", async () => {
+		// 1. Fresh heartbeat — should be left alone.
+		const freshId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: 5,
+			claimedAtAgoSeconds: 120,
+		});
+		// 2. Stale heartbeat — should be reaped.
+		const staleId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
+		// 3. Terminal state (completed) — must never be touched even if it had a
+		//    stale heartbeat at the moment it completed.
+		const terminalId = await seedRun({
+			status: "completed",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
+		});
 
-    const result = await reapStaleRuns();
+		const result = await reapStaleRuns();
 
-    expect(result.acquired).toBe(true);
-    expect(result.reaped).toBe(1);
+		expect(result.acquired).toBe(true);
+		expect(result.reaped).toBe(1);
 
-    expect(await statusOf(freshId)).toBe('running');
-    expect(await statusOf(staleId)).toBe('timeout');
-    expect(await statusOf(terminalId)).toBe('completed');
+		expect(await statusOf(freshId)).toBe("running");
+		expect(await statusOf(staleId)).toBe("timeout");
+		expect(await statusOf(terminalId)).toBe("completed");
 
-    const sql = getDb();
-    const reaped = (await sql`
+		const sql = getDb();
+		const reaped = (await sql`
       SELECT error_message FROM runs WHERE id = ${staleId}
     `) as unknown as Array<{ error_message: string | null }>;
-    expect(reaped[0].error_message).toBe('worker_heartbeat_lost');
-  });
+		expect(reaped[0].error_message).toBe("worker_heartbeat_lost");
+	});
 
-  test('claimed rows that never sent any heartbeat are reaped via claimed_at', async () => {
-    const id = await seedRun({
-      status: 'claimed',
-      lastHeartbeatAgoSeconds: null,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-    });
-    const result = await reapStaleRuns();
-    expect(result.reaped).toBe(1);
-    expect(await statusOf(id)).toBe('timeout');
-  });
+	test("claimed rows that never sent any heartbeat are reaped via claimed_at", async () => {
+		const id = await seedRun({
+			status: "claimed",
+			lastHeartbeatAgoSeconds: null,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
+		const result = await reapStaleRuns();
+		expect(result.reaped).toBe(1);
+		expect(await statusOf(id)).toBe("timeout");
+	});
 
-  test('watcher lane is excluded from this reaper', async () => {
-    // Watcher runs have their own dedicated 2h sweep in watchers/automation.ts.
-    const watcherId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
-      runType: 'behavior',
-    });
-    const result = await reapStaleRuns();
-    expect(result.reaped).toBe(0);
-    expect(await statusOf(watcherId)).toBe('running');
-  });
+	test("watcher lane is excluded from this reaper", async () => {
+		// Watcher runs have their own dedicated 2h sweep in watchers/automation.ts.
+		const watcherId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
+			runType: "behavior",
+		});
+		const result = await reapStaleRuns();
+		expect(result.reaped).toBe(0);
+		expect(await statusOf(watcherId)).toBe("running");
+	});
 
-  test('back-to-back calls do not double-fail the same row', async () => {
-    // The advisory-lock guards cross-pod contention. Rather than simulate two
-    // pods literally racing the SELECT-then-UPDATE, this proves the
-    // function-level invariant the lock enforces: a row that's already been
-    // reaped doesn't get reaped a second time even if the sweeper fires again.
-    const staleId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-    });
+	test("back-to-back calls do not double-fail the same row", async () => {
+		// The advisory-lock guards cross-pod contention. Rather than simulate two
+		// pods literally racing the SELECT-then-UPDATE, this proves the
+		// function-level invariant the lock enforces: a row that's already been
+		// reaped doesn't get reaped a second time even if the sweeper fires again.
+		const staleId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+		});
 
-    const first = await reapStaleRuns();
-    expect(first.acquired).toBe(true);
-    expect(first.reaped).toBe(1);
-    expect(await statusOf(staleId)).toBe('timeout');
+		const first = await reapStaleRuns();
+		expect(first.acquired).toBe(true);
+		expect(first.reaped).toBe(1);
+		expect(await statusOf(staleId)).toBe("timeout");
 
-    // Second pass — same lock acquired, but the row is now `timeout` so the
-    // WHERE clause excludes it. No double-fail, no parallel retry inserted.
-    const second = await reapStaleRuns();
-    expect(second.acquired).toBe(true);
-    expect(second.reaped).toBe(0);
-    expect(second.retriesCreated).toBe(0);
-    expect(await statusOf(staleId)).toBe('timeout');
-  });
+		// Second pass — same lock acquired, but the row is now `timeout` so the
+		// WHERE clause excludes it. No double-fail, no parallel retry inserted.
+		const second = await reapStaleRuns();
+		expect(second.acquired).toBe(true);
+		expect(second.reaped).toBe(0);
+		expect(second.retriesCreated).toBe(0);
+		expect(await statusOf(staleId)).toBe("timeout");
+	});
 
-  test('action, embed_backfill, auth lanes are reaped (parity with sync)', async () => {
-    // All four connector lanes now emit `client.heartbeat()` from the
-    // out-of-process executor (lobu#860 wired action + embed_backfill;
-    // sync + auth already did). The reaper's WHERE clause covers all
-    // four; staleness on `last_heartbeat_at` is a real failure signal
-    // everywhere.
-    const actionId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'action',
-    });
-    const embedId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'embed_backfill',
-    });
-    const authId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'auth',
-    });
+	test("action, embed_backfill, auth lanes are reaped (parity with sync)", async () => {
+		// All four connector lanes now emit `client.heartbeat()` from the
+		// out-of-process executor (lobu#860 wired action + embed_backfill;
+		// sync + auth already did). The reaper's WHERE clause covers all
+		// four; staleness on `last_heartbeat_at` is a real failure signal
+		// everywhere.
+		const actionId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "action",
+		});
+		const embedId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "embed_backfill",
+		});
+		const authId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "auth",
+		});
 
-    const result = await reapStaleRuns();
-    expect(result.reaped).toBe(3);
-    expect(await statusOf(actionId)).toBe('timeout');
-    expect(await statusOf(embedId)).toBe('timeout');
-    expect(await statusOf(authId)).toBe('timeout');
-  });
+		const result = await reapStaleRuns();
+		expect(result.reaped).toBe(3);
+		expect(await statusOf(actionId)).toBe("timeout");
+		expect(await statusOf(embedId)).toBe("timeout");
+		expect(await statusOf(authId)).toBe("timeout");
+	});
 });
 
-describe('reapStaleRuns — atomic timeout + retry (lobu#862)', () => {
-  test('a stale sync run gets timed out AND a retry queued in one statement', async () => {
-    // Seed a stale sync run for a feed. After reapStaleRuns runs, we
-    // should see exactly one timeout + one pending retry for the same
-    // feed — both written in the same CTE so a process crash cannot
-    // leave the row timed out with no retry queued.
-    const feedId = 4242;
-    await seedFeed(feedId);
-    const staleId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'sync',
-      feedId,
-    });
+describe("reapStaleRuns — atomic timeout + retry (lobu#862)", () => {
+	test("a stale sync run gets timed out AND a retry queued in one statement", async () => {
+		// Seed a stale sync run for a feed. After reapStaleRuns runs, we
+		// should see exactly one timeout + one pending retry for the same
+		// feed — both written in the same CTE so a process crash cannot
+		// leave the row timed out with no retry queued.
+		const feedId = 4242;
+		await seedFeed(feedId);
+		const staleId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "sync",
+			feedId,
+		});
 
-    const result = await reapStaleRuns();
-    expect(result.reaped).toBe(1);
-    expect(result.retriesCreated).toBe(1);
-    expect(await statusOf(staleId)).toBe('timeout');
+		const result = await reapStaleRuns();
+		expect(result.reaped).toBe(1);
+		expect(result.retriesCreated).toBe(1);
+		expect(await statusOf(staleId)).toBe("timeout");
 
-    const sql = getDb();
-    const retries = (await sql`
+		const sql = getDb();
+		const retries = (await sql`
       SELECT id, status FROM runs
       WHERE feed_id = ${feedId} AND run_type = 'sync' AND status = 'pending'
     `) as unknown as Array<{ id: number | string; status: string }>;
-    expect(retries.length).toBe(1);
-  });
+		expect(retries.length).toBe(1);
+	});
 
-  test('non-sync stale runs do NOT produce retries (action/embed_backfill/auth)', async () => {
-    // Only sync runs need a re-queue; the other lanes are reaped but
-    // not retried.
-    await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'action',
-    });
-    await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'embed_backfill',
-    });
-    await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'auth',
-    });
+	test("non-sync stale runs do NOT produce retries (action/embed_backfill/auth)", async () => {
+		// Only sync runs need a re-queue; the other lanes are reaped but
+		// not retried.
+		await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "action",
+		});
+		await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "embed_backfill",
+		});
+		await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "auth",
+		});
 
-    const result = await reapStaleRuns();
-    expect(result.reaped).toBe(3);
-    expect(result.retriesCreated).toBe(0);
-  });
+		const result = await reapStaleRuns();
+		expect(result.reaped).toBe(3);
+		expect(result.retriesCreated).toBe(0);
+	});
 
-  test('two stale sync runs on the SAME feed produce exactly one retry (dedup via NOT EXISTS)', async () => {
-    // Two stale runs that share a feed_id can only exist if one is in a
-    // terminal status — the partial unique index `idx_runs_active_sync_per_feed`
-    // forbids two simultaneously active syncs per feed. Simulate the
-    // realistic case: a previously-completed sync, plus a stale running
-    // one. The reaper should reap the running one and queue exactly
-    // ONE retry for that feed (not two — the completed one is not
-    // touched).
-    //
-    // This also exercises the dedup-against-itself trap: if the NOT
-    // EXISTS predicate didn't exclude `timed_out.id`, the running row
-    // would dedupe against itself and no retries would be queued.
-    const feedId = 5151;
-    await seedFeed(feedId);
-    // First run already finished — terminal, not in the active set.
-    await seedRun({
-      status: 'completed',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
-      runType: 'sync',
-      feedId,
-    });
-    const staleId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'sync',
-      feedId,
-    });
+	test("two stale sync runs on the SAME feed produce exactly one retry (dedup via NOT EXISTS)", async () => {
+		// Two stale runs that share a feed_id can only exist if one is in a
+		// terminal status — the partial unique index `idx_runs_active_sync_per_feed`
+		// forbids two simultaneously active syncs per feed. Simulate the
+		// realistic case: a previously-completed sync, plus a stale running
+		// one. The reaper should reap the running one and queue exactly
+		// ONE retry for that feed (not two — the completed one is not
+		// touched).
+		//
+		// This also exercises the dedup-against-itself trap: if the NOT
+		// EXISTS predicate didn't exclude `timed_out.id`, the running row
+		// would dedupe against itself and no retries would be queued.
+		const feedId = 5151;
+		await seedFeed(feedId);
+		// First run already finished — terminal, not in the active set.
+		await seedRun({
+			status: "completed",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
+			runType: "sync",
+			feedId,
+		});
+		const staleId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "sync",
+			feedId,
+		});
 
-    const result = await reapStaleRuns();
-    expect(result.reaped).toBe(1);
-    expect(result.retriesCreated).toBe(1);
-    expect(await statusOf(staleId)).toBe('timeout');
+		const result = await reapStaleRuns();
+		expect(result.reaped).toBe(1);
+		expect(result.retriesCreated).toBe(1);
+		expect(await statusOf(staleId)).toBe("timeout");
 
-    // Exactly one pending row queued.
-    const sql = getDb();
-    const pending = (await sql`
+		// Exactly one pending row queued.
+		const sql = getDb();
+		const pending = (await sql`
       SELECT id FROM runs
       WHERE feed_id = ${feedId} AND run_type = 'sync' AND status = 'pending'
     `) as unknown as Array<{ id: number | string }>;
-    expect(pending.length).toBe(1);
-  });
+		expect(pending.length).toBe(1);
+	});
 
-  test('a pending sync that pre-exists prevents a duplicate retry being inserted', async () => {
-    // Edge case: a pending sync exists for the feed, and an unrelated
-    // stale auth run (no feed) is reaped in the same sweep. We should
-    // reap the auth row, and NOT insert any sync retry — the pending
-    // sync already covers the feed.
-    //
-    // (We can't co-exist a stale sync + a pending sync on the same
-    // feed; the partial unique index forbids it. This test uses a
-    // different lane to exercise the negative path.)
-    const feedId = 6262;
-    await seedFeed(feedId);
-    await seedRun({
-      status: 'pending',
-      lastHeartbeatAgoSeconds: null,
-      runType: 'sync',
-      feedId,
-    });
-    const authId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'auth',
-    });
+	test("a pending sync that pre-exists prevents a duplicate retry being inserted", async () => {
+		// Edge case: a pending sync exists for the feed, and an unrelated
+		// stale auth run (no feed) is reaped in the same sweep. We should
+		// reap the auth row, and NOT insert any sync retry — the pending
+		// sync already covers the feed.
+		//
+		// (We can't co-exist a stale sync + a pending sync on the same
+		// feed; the partial unique index forbids it. This test uses a
+		// different lane to exercise the negative path.)
+		const feedId = 6262;
+		await seedFeed(feedId);
+		await seedRun({
+			status: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "sync",
+			feedId,
+		});
+		const authId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "auth",
+		});
 
-    const result = await reapStaleRuns();
-    expect(result.reaped).toBe(1);
-    // No retry insert: auth lane doesn't queue retries.
-    expect(result.retriesCreated).toBe(0);
-    expect(await statusOf(authId)).toBe('timeout');
+		const result = await reapStaleRuns();
+		expect(result.reaped).toBe(1);
+		// No retry insert: auth lane doesn't queue retries.
+		expect(result.retriesCreated).toBe(0);
+		expect(await statusOf(authId)).toBe("timeout");
 
-    // The pre-existing pending sync stays intact, no duplicates.
-    const sql = getDb();
-    const pending = (await sql`
+		// The pre-existing pending sync stays intact, no duplicates.
+		const sql = getDb();
+		const pending = (await sql`
       SELECT id FROM runs
       WHERE feed_id = ${feedId} AND run_type = 'sync' AND status = 'pending'
     `) as unknown as Array<{ id: number | string }>;
-    expect(pending.length).toBe(1);
-  });
+		expect(pending.length).toBe(1);
+	});
 
-  test('reaper output count and DB state agree (no UPDATE-without-INSERT gap)', async () => {
-    // Reproducer for lobu#862: the previous shape (bulk UPDATE RETURNING
-    // followed by a per-row INSERT loop) could leave a row timed-out
-    // with no retry queued if the process crashed mid-loop. The CTE
-    // version writes both in the same statement, so the SQL engine
-    // guarantees they land together or not at all.
-    //
-    // Seed three stale sync runs for three different feeds. After the
-    // reap there must be exactly three timeouts AND three retries —
-    // observable atomicity from the caller's perspective.
-    const feedIds = [9001, 9002, 9003];
-    for (const feedId of feedIds) {
-      await seedFeed(feedId);
-      await seedRun({
-        status: 'running',
-        lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-        claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-        runType: 'sync',
-        feedId,
-      });
-    }
+	test("reaper output count and DB state agree (no UPDATE-without-INSERT gap)", async () => {
+		// Reproducer for lobu#862: the previous shape (bulk UPDATE RETURNING
+		// followed by a per-row INSERT loop) could leave a row timed-out
+		// with no retry queued if the process crashed mid-loop. The CTE
+		// version writes both in the same statement, so the SQL engine
+		// guarantees they land together or not at all.
+		//
+		// Seed three stale sync runs for three different feeds. After the
+		// reap there must be exactly three timeouts AND three retries —
+		// observable atomicity from the caller's perspective.
+		const feedIds = [9001, 9002, 9003];
+		for (const feedId of feedIds) {
+			await seedFeed(feedId);
+			await seedRun({
+				status: "running",
+				lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+				claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+				runType: "sync",
+				feedId,
+			});
+		}
 
-    const result = await reapStaleRuns();
-    expect(result.reaped).toBe(3);
-    expect(result.retriesCreated).toBe(3);
+		const result = await reapStaleRuns();
+		expect(result.reaped).toBe(3);
+		expect(result.retriesCreated).toBe(3);
 
-    const sql = getDb();
-    const counts = (await sql`
+		const sql = getDb();
+		const counts = (await sql`
       SELECT status, count(*)::int AS n FROM runs
       WHERE feed_id IN ${sql(feedIds)} AND run_type = 'sync'
       GROUP BY status
       ORDER BY status
     `) as unknown as Array<{ status: string; n: number }>;
-    const byStatus = Object.fromEntries(counts.map((r) => [r.status, r.n]));
-    expect(byStatus.pending).toBe(3);
-    expect(byStatus.timeout).toBe(3);
-  });
+		const byStatus = Object.fromEntries(counts.map((r) => [r.status, r.n]));
+		expect(byStatus.pending).toBe(3);
+		expect(byStatus.timeout).toBe(3);
+	});
 });

--- a/packages/server/src/scheduled/stale-run-sweeper.ts
+++ b/packages/server/src/scheduled/stale-run-sweeper.ts
@@ -22,75 +22,90 @@
  * so every input is validated against a strict literal pattern first.
  */
 
-import { PG_INTERVAL_PATTERN } from '../config/intervals';
-import type { DbClient } from '../db/client';
+import { PG_INTERVAL_PATTERN } from "../config/intervals";
+import type { DbClient } from "../db/client";
 
 interface StaleRunSweepSpec {
-  /** `runs.run_type` values covered by this sweep. */
-  runTypes: readonly string[];
-  /**
-   * Which rows count as "heartbeating":
-   *  - 'any-heartbeat': any non-NULL `last_heartbeat_at` (connector lanes —
-   *    the claim doesn't stamp a heartbeat, so presence means the executor
-   *    beat at least once).
-   *  - 'beat-after-claim': only rows whose `last_heartbeat_at` advanced past
-   *    `claimed_at` (watcher lane — the claim seeds
-   *    `last_heartbeat_at = claimed_at`, so equality means "never beat" and
-   *    a non-heartbeating client falls through to the coarse path).
-   */
-  heartbeatSemantics: 'any-heartbeat' | 'beat-after-claim';
-  /** Postgres interval literal (e.g. '3 minutes'). Heartbeating rows whose
-   *  last beat is older than this are reaped. */
-  heartbeatStaleInterval: string;
-  /** Postgres interval literal. Non-heartbeating rows whose
-   *  `COALESCE(claimed_at, created_at)` is older than this are reaped. */
-  coarseStaleInterval: string;
-  /** Include never-claimed pending rows, judged solely on created_at. */
-  includePending?: boolean;
+	/** `runs.run_type` values covered by this sweep. */
+	runTypes: readonly string[];
+	/**
+	 * Which rows count as "heartbeating":
+	 *  - 'any-heartbeat': any non-NULL `last_heartbeat_at` (connector lanes —
+	 *    the claim doesn't stamp a heartbeat, so presence means the executor
+	 *    beat at least once).
+	 *  - 'beat-after-claim': only rows whose `last_heartbeat_at` advanced past
+	 *    `claimed_at` (watcher lane — the claim seeds
+	 *    `last_heartbeat_at = claimed_at`, so equality means "never beat" and
+	 *    a non-heartbeating client falls through to the coarse path).
+	 */
+	heartbeatSemantics: "any-heartbeat" | "beat-after-claim";
+	/** Postgres interval literal (e.g. '3 minutes'). Heartbeating rows whose
+	 *  last beat is older than this are reaped. */
+	heartbeatStaleInterval: string;
+	/** Postgres interval literal. Non-heartbeating rows whose
+	 *  `COALESCE(claimed_at, created_at)` is older than this are reaped. */
+	coarseStaleInterval: string;
+	/**
+	 * Include never-claimed pending rows, judged solely on created_at.
+	 *
+	 * Only rows a worker is actually allowed to claim are reaped: a run with
+	 * `approval_status = 'pending'` is parked waiting for a HUMAN to approve it —
+	 * no worker will ever claim it, so the claim-timeout must NOT apply, or a
+	 * queued-approval run is force-timed-out before anyone can approve it (#2044).
+	 * Approval flips it to `approval_status = 'approved', status = 'running'`,
+	 * after which the normal in-progress heartbeat/coarse predicate governs it.
+	 */
+	includePending?: boolean;
 }
 
 const RUN_TYPE_PATTERN = /^[a-z_]+$/;
 
 /** Validate + quote a `<n> <unit>` literal as a SQL interval expression. */
 function intervalSql(literal: string): string {
-  if (!PG_INTERVAL_PATTERN.test(literal)) {
-    throw new Error(`Invalid Postgres interval literal: ${JSON.stringify(literal)}`);
-  }
-  return `interval '${literal}'`;
+	if (!PG_INTERVAL_PATTERN.test(literal)) {
+		throw new Error(
+			`Invalid Postgres interval literal: ${JSON.stringify(literal)}`,
+		);
+	}
+	return `interval '${literal}'`;
 }
 
 function runTypeListSql(runTypes: readonly string[]): string {
-  if (runTypes.length === 0) {
-    throw new Error('StaleRunSweepSpec.runTypes must not be empty');
-  }
-  return runTypes
-    .map((runType) => {
-      if (!RUN_TYPE_PATTERN.test(runType)) {
-        throw new Error(`Invalid run_type literal: ${JSON.stringify(runType)}`);
-      }
-      return `'${runType}'`;
-    })
-    .join(', ');
+	if (runTypes.length === 0) {
+		throw new Error("StaleRunSweepSpec.runTypes must not be empty");
+	}
+	return runTypes
+		.map((runType) => {
+			if (!RUN_TYPE_PATTERN.test(runType)) {
+				throw new Error(`Invalid run_type literal: ${JSON.stringify(runType)}`);
+			}
+			return `'${runType}'`;
+		})
+		.join(", ");
 }
 
 /** SQL boolean expr: this row has a live heartbeat signal per the spec. */
-function hasHeartbeatSql(semantics: StaleRunSweepSpec['heartbeatSemantics']): string {
-  return semantics === 'beat-after-claim'
-    ? `(last_heartbeat_at IS NOT NULL
+function hasHeartbeatSql(
+	semantics: StaleRunSweepSpec["heartbeatSemantics"],
+): string {
+	return semantics === "beat-after-claim"
+		? `(last_heartbeat_at IS NOT NULL
        AND claimed_at IS NOT NULL
        AND last_heartbeat_at > claimed_at)`
-    : 'last_heartbeat_at IS NOT NULL';
+		: "last_heartbeat_at IS NOT NULL";
 }
 
 /** Exact complement of {@link hasHeartbeatSql}, spelled out (De Morgan) so
  *  the SQL is two-valued even when `claimed_at` / `last_heartbeat_at` are
  *  NULL. */
-function neverHeartbeatedSql(semantics: StaleRunSweepSpec['heartbeatSemantics']): string {
-  return semantics === 'beat-after-claim'
-    ? `(last_heartbeat_at IS NULL
+function neverHeartbeatedSql(
+	semantics: StaleRunSweepSpec["heartbeatSemantics"],
+): string {
+	return semantics === "beat-after-claim"
+		? `(last_heartbeat_at IS NULL
        OR claimed_at IS NULL
        OR last_heartbeat_at <= claimed_at)`
-    : 'last_heartbeat_at IS NULL';
+		: "last_heartbeat_at IS NULL";
 }
 
 /**
@@ -99,7 +114,7 @@ function neverHeartbeatedSql(semantics: StaleRunSweepSpec['heartbeatSemantics'])
  * `UPDATE public.runs`) without an alias.
  */
 export function buildStaleRunWhereSql(spec: StaleRunSweepSpec): string {
-  const inProgressPredicate = `
+	const inProgressPredicate = `
       (status IN ('claimed', 'running')
        AND (
          -- Fast path: the executor was heartbeating, then went silent.
@@ -114,13 +129,17 @@ export function buildStaleRunWhereSql(spec: StaleRunSweepSpec): string {
           AND COALESCE(claimed_at, created_at)
               < current_timestamp - ${intervalSql(spec.coarseStaleInterval)})
        ))`;
-  const statusPredicate = spec.includePending
-    ? `((status = 'pending'
+	const statusPredicate = spec.includePending
+		? `((status = 'pending'
+         -- A run awaiting HUMAN approval is not worker-claimable; the
+         -- claim-timeout must never reap it (#2044). Only 'auto'/'approved'
+         -- pending rows are genuinely waiting for a worker.
+         AND approval_status <> 'pending'
          AND created_at < current_timestamp - ${intervalSql(spec.coarseStaleInterval)})
         OR ${inProgressPredicate})`
-    : inProgressPredicate;
+		: inProgressPredicate;
 
-  return `
+	return `
     run_type IN (${runTypeListSql(spec.runTypes)})
     AND ${statusPredicate}
   `;
@@ -132,16 +151,16 @@ export function buildStaleRunWhereSql(spec: StaleRunSweepSpec): string {
  * rows transitioned.
  */
 export async function markStaleRunsAsTimeout(
-  sql: DbClient,
-  spec: StaleRunSweepSpec & {
-    /** error_message for rows reaped via the heartbeat-stale fast path. */
-    heartbeatErrorMessage: string;
-    /** error_message for rows reaped via the coarse TTL backstop. */
-    coarseErrorMessage: string;
-  }
+	sql: DbClient,
+	spec: StaleRunSweepSpec & {
+		/** error_message for rows reaped via the heartbeat-stale fast path. */
+		heartbeatErrorMessage: string;
+		/** error_message for rows reaped via the coarse TTL backstop. */
+		coarseErrorMessage: string;
+	},
 ): Promise<number> {
-  const result = await sql.unsafe(
-    `UPDATE runs
+	const result = await sql.unsafe(
+		`UPDATE runs
      SET status = 'timeout',
          completed_at = current_timestamp,
          error_message = CASE
@@ -149,7 +168,7 @@ export async function markStaleRunsAsTimeout(
            ELSE $2
          END
      WHERE ${buildStaleRunWhereSql(spec)}`,
-    [spec.heartbeatErrorMessage, spec.coarseErrorMessage]
-  );
-  return Number(result.count ?? 0);
+		[spec.heartbeatErrorMessage, spec.coarseErrorMessage],
+	);
+	return Number(result.count ?? 0);
 }


### PR DESCRIPTION
Closes #2044.

## What #2044 actually is

The issue title says "pending_approval returns a URL but no durable approval event exists." Investigating the production repro (run 681192, lobu-team org, GitHub create_issue) against the live prod DB showed the opposite: **the approval event is durable and readable** — event 4653785, `run_id=681192`, same org, `interaction_type=approval`, `interaction_status=pending`, created at the exact same timestamp as the run. The atomic run+event transaction from #2033 is deployed and working; every read path (run_ids list, content_ids, common-branch org-scope) returns it on `main`.

The real defect is a **lifecycle bug**: the run was killed out from under the pending human decision.

## Root cause

A queued connector operation awaiting human approval sits in `status='pending', approval_status='pending'`. No worker will ever claim it — it's parked waiting for a person. But the connector-lane stale-run reaper (`check-stalled-executions.ts`) sweeps with `includePending: true` over `run_type='action'`, and `buildStaleRunWhereSql`'s pending branch had **no approval guard**:

```sql
status = 'pending' AND created_at < now() - '120 seconds'
```

So ~120s after creation the reaper force-transitions the approval-pending run to `status='timeout'` (`worker_claim_timeout`). Once `timeout`, the run is **permanently un-approvable** (approve requires `status='pending'`), so the approval URL resolves to a dead run and the operation is stranded.

Prod evidence:
- Run 681192: created `21:07:46`, reaped `21:09:52` (~2 min later), still `approval_status='pending'`.
- **11 runs** at rest in `approval_status='pending', status='timeout'` — all wrongly reaped this way.

## Fix

The `includePending` pending predicate now excludes `approval_status='pending'`. Approval flips the run to `approval_status='approved', status='running'`, after which the normal in-progress heartbeat/coarse predicate governs it. The guard lives in the shared `buildStaleRunWhereSql`, so every `includePending` caller inherits it. The connector auto-claim path (`approval_status='auto'`) is unaffected — genuinely-stuck worker runs still time out.

## Not resurrecting the 11 stranded runs

They span 2026-07-06..20; most are stale device actions (screenshots, mouse moves). Re-arming week-old queued writes for silent execution is riskier than leaving them terminal. The forward fix prevents new stranding; a user re-issues if a specific one is still wanted.

## Verification

- **red→fix→green** in `stale-run-reaper.test.ts`:
  - new "a stale action run awaiting human approval is NOT reaped" — fails without the guard (`reaped=1`), passes with it.
  - new control "a stale auto-approval action run IS still reaped" — proves the guard is narrow.
  - full suite 15/15 pass.
- Prod-data simulation confirmed broken vs fixed predicate (0 vs correctly-excluded).
- `make review` (LLM verdict) owed — Codex usage limit resets 2026-07-25.

Note: `packages/server` has **pre-existing** tsc errors on `main` from the watcher→behavior rename fallout (`manage_entity.ts`, `manage_classifiers.ts`, etc.) — unrelated to this change; the two files here typecheck clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented connector-lane action runs awaiting human approval (`approval_status='pending'`) from being incorrectly marked as timed out when pending is included.
  * Ensured correct behavior for `approval_status='auto'` and `approval_status=NULL`, allowing eligible stale runs to be reaped to timeout.
  * Maintained atomic “timeout + retry queued” handling and avoided duplicate retries.
* **Tests**
  * Expanded the stale-run reaper integration coverage with new connector-lane scenarios for approval-gated reaping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->