### PR TITLE
fix(knowledge): exact content_ids read surfaces applied classifications (#2050)

### DIFF
--- a/packages/server/src/__tests__/integration/events/get-content-chain-resolve.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-chain-resolve.test.ts
@@ -259,4 +259,59 @@ describe('getContent > content_ids resolves the full supersede chain', () => {
     expect(result.total).toBe(2);
     expect(result.chain_total).toBe(1);
   });
+
+  // #2050: a manual `classifiers.classify` writes to event_classifications, but
+  // the exact content_ids read hard-coded `'{}'::jsonb as classifications`, so
+  // the applied classification was invisible on read-back. It must now surface.
+  it('content_ids exact read surfaces the applied classification', async () => {
+    const sql = getTestDb();
+    const t0 = new Date('2026-07-05T00:00:00Z');
+    const eventId = await insertChainRow({
+      organizationId: org.id,
+      title: 'note to classify',
+      content: 'a disposable note with a classifiable value',
+      runId: null,
+      occurredAt: t0,
+    });
+
+    // Seed a classifier + a manual (source='user') classification, mirroring
+    // what classifiers.classify commits.
+    const [facet] = await sql<{ id: number }[]>`
+      INSERT INTO classify_facet (
+        organization_id, slug, name, attribute_key, status, created_by,
+        entity_ids, attribute_values, min_similarity
+      ) VALUES (
+        ${org.id}, 'sentiment-2050', 'Sentiment 2050', 'sentiment', 'active', ${user.id},
+        ARRAY[]::bigint[], ${sql.json({ positive: { description: 'p', examples: ['great'] } })}, 0.7
+      ) RETURNING id`;
+    const classifierId = Number(facet.id);
+
+    await sql`
+      INSERT INTO event_classifications (
+        event_id, classifier_id, watcher_id, window_id, "values", confidences,
+        source, is_manual, reasoning
+      ) VALUES (
+        ${eventId}, ${classifierId}, NULL, NULL, ${'{positive}'}::text[],
+        ${sql.json({ positive: 1.0 })}, 'user', true, 'looks positive'
+      )`;
+
+    const result = await getContent(
+      { content_ids: [eventId], limit: 10 } as never,
+      {} as never,
+      ctx
+    );
+
+    const item = result.content.find((c) => c.id === eventId);
+    expect(item).toBeDefined();
+    const classifications = item?.classifications as Record<
+      string,
+      { values: string[]; source: string; is_manual: boolean }
+    > | null;
+    expect(classifications).toBeTruthy();
+    // Keyed by the classifier's attribute_key, carrying the applied value + provenance.
+    expect(classifications?.sentiment).toBeDefined();
+    expect(classifications?.sentiment.values).toEqual(['positive']);
+    expect(classifications?.sentiment.source).toBe('user');
+    expect(classifications?.sentiment.is_manual).toBe(true);
+  });
 });

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -82,10 +82,43 @@ function buildContentQuery(opts: {
       ${a}.superseded_by,
       ${a}.run_id,
       oc.client_name,
-      -- classifications was sourced from latest_event_classifications, a denormalized cache that was
-      -- never populated (no writer) — so this field has always been '{}'. Kept empty for response-shape
-      -- stability now that the dead table is dropped.
-      '{}'::jsonb as classifications
+      -- Per-event classifications keyed by classifier attribute, matching the
+      -- list/search path shape so exact reads (content_ids / include_superseded)
+      -- surface a manual classifiers.classify immediately (#2050). One row per
+      -- (event, classifier): source priority user then llm then embedding,
+      -- newest first -- the same dedup rule as buildLatestClassificationsCteSql.
+      COALESCE(
+        (
+          SELECT jsonb_object_agg(
+            lc.attribute_key,
+            jsonb_build_object(
+              'values', lc.values,
+              'confidences', lc.confidences,
+              'source', lc.source,
+              'is_manual', lc.is_manual
+            )
+          )
+          FROM (
+            SELECT
+              fcl.attribute_key,
+              cc."values" AS values,
+              cc.confidences,
+              cc.source,
+              cc.is_manual,
+              ROW_NUMBER() OVER (
+                PARTITION BY cc.event_id, cc.classifier_id
+                ORDER BY
+                  CASE cc.source WHEN 'user' THEN 1 WHEN 'llm' THEN 2 ELSE 3 END,
+                  cc.created_at DESC
+              ) AS rn
+            FROM event_classifications cc
+            JOIN classify_facet fcl ON fcl.id = cc.classifier_id
+            WHERE cc.event_id = ${a}.id AND cc.classifier_id IS NOT NULL
+          ) lc
+          WHERE lc.rn = 1
+        ),
+        '{}'::jsonb
+      ) as classifications
     FROM ${table} ${a}
     ${join}
     LEFT JOIN connections c ON c.id = ${a}.connection_id


### PR DESCRIPTION
Closes #2050.

## Root cause

`classifiers.classify` writes to `event_classifications` inside a committed transaction — the reported success is real, the row is durable. But the **exact-read** path (`knowledge.read` by `content_ids`, and the `include_superseded` history listing) shares `buildContentQuery` in `get_content/query.ts`, which hard-coded:

```sql
'{}'::jsonb as classifications
```

with a stale comment claiming the source was "never populated (no writer)". That's wrong: `event_classifications` is the **live** table — both manual classify and the embedding classifier write it. So an exact read-back always returned an empty `classifications` object even though the classification was applied. That's #2050: classify reports `updated: 1`, but the immediate exact read shows nothing.

The list/search read path was fine — it joins `event_classifications` via `buildLatestClassificationsCteSql`. Only the exact-read path had the dead `'{}'`.

## Fix

`buildContentQuery` now builds the `classifications` object inline from `event_classifications`, keyed by the classifier's `attribute_key`, carrying `{ values, confidences, source, is_manual }`. It uses the **same dedup rule** as the list path (one row per `(event, classifier)`; source priority `user > llm > embedding`, newest first), so both read paths agree on what "current" means. Both content_ids and include_superseded inherit it since they share `buildContentQuery`.

## Verification

- **red→fix→green** in `get-content-chain-resolve.test.ts`: a new test seeds a manual (`source='user'`) classification and asserts the `content_ids` exact read returns it keyed by `attribute_key` with correct provenance. Fails against the `'{}'` hard-code (`classifications.sentiment` undefined), passes with the fix. Full suite 5/5 (embedded pgvector).
- `make review` (LLM verdict) owed — Codex usage limit resets 2026-07-25.

## Scope note

This closes the core #2050 acceptance criterion (classify visible on immediate exact read). The issue also lists lifecycle/discovery asks (classifier_id vs slug aliases, `classifiers.list` exclude-deprecated filter, search_sdk schema docs, hard test cleanup) — those overlap with the SDK-contract work in #2046 and are better handled there than bundled into this read-path fix. Flagging so they aren't lost.

Note: `packages/server` has pre-existing tsc + one pre-existing biome `noAssignInExpressions` finding on `main` (unrelated to this change); the two files here are minimal, space-indented diffs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->