### PR TITLE
fix(entities): force_delete_tree detaches event references instead of blocking, adds dry_run preflight (#2049)

### DIFF
--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -217,7 +217,14 @@ export const ManageEntitySchema = Type.Object({
   // Delete options
   force_delete_tree: Type.Optional(
     Type.Boolean({
-      description: "[delete] Force delete entity and all descendants",
+      description:
+        "[delete] Hard delete entity and all descendants. Event history is never deleted (append-only) — event rows referencing the tree are detached instead.",
+    })
+  ),
+  dry_run: Type.Optional(
+    Type.Boolean({
+      description:
+        "[delete] Preflight only: report what the delete would remove/detach without mutating anything",
     })
   ),
 
@@ -459,6 +466,20 @@ export const ManageEntityResultSchema = Type.Union([
     success: Type.Boolean(),
     message: Type.String(),
     deleted_count: Type.Integer(),
+    dry_run: Type.Optional(Type.Boolean()),
+    // Force-delete dependency report: what the delete removed/detached (or,
+    // with dry_run, would). Events are never deleted — only detached.
+    tree: Type.Optional(
+      Type.Object({
+        entities: Type.Integer(),
+        relationships: Type.Integer(),
+        behaviors_deleted: Type.Integer(),
+        behaviors_detached: Type.Integer(),
+        feeds_deleted: Type.Integer(),
+        feeds_detached: Type.Integer(),
+        events_detached: Type.Integer(),
+      })
+    ),
     approval_queued: Type.Optional(Type.Boolean()),
     approval_url: Type.Optional(Type.String()),
     approval_run_id: Type.Optional(Type.Integer()),

--- a/packages/server/src/__tests__/integration/entities/entity-history-contract.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-history-contract.test.ts
@@ -1,9 +1,9 @@
 /**
  * Compact entity history contracts kept from the old broad entity suites.
  *
- * These are high-value because they protect auditability and the no-data-loss
- * delete guard: entity updates must emit change events, and deleting a tree
- * must not erase descendants that already have content history.
+ * These are high-value because they protect auditability and the append-only
+ * event invariant: entity updates must emit change events, and force-deleting
+ * a tree must detach — never delete — the event history that references it.
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -80,38 +80,122 @@ describe('entity history contracts', () => {
     expect(after[0].count).toBe(before[0].count);
   });
 
-  it('blocks force-deleting an entity tree when any descendant has event history', async () => {
-    const root = (await workspace.owner.entities.create({ type: 'brand', name: 'Protected Root' })) as {
+  it('force-deletes a tree with event history by detaching event references, not deleting events', async () => {
+    const root = (await workspace.owner.entities.create({ type: 'brand', name: 'Purged Root' })) as {
       entity: { id: number };
     };
     const child = (await workspace.owner.entities.create({
       type: 'brand',
-      name: 'Protected Child',
+      name: 'Purged Child',
       parent_id: root.entity.id,
     })) as { entity: { id: number } };
     const grandchild = (await workspace.owner.entities.create({
       type: 'brand',
-      name: 'Protected Grandchild',
+      name: 'Purged Grandchild',
       parent_id: child.entity.id,
     })) as { entity: { id: number } };
 
-    await createTestEvent({
+    const event = await createTestEvent({
       entity_id: grandchild.entity.id,
       organization_id: workspace.org.id,
-      content: 'Historical knowledge that must be preserved',
+      content: 'Historical knowledge that must survive the purge',
     });
 
-    await expect(
-      workspace.owner.entities.delete({ entity_id: root.entity.id, force_delete_tree: true })
-    ).rejects.toThrow(/preserve event history/i);
+    // Preflight: dry_run reports what the delete would touch without mutating.
+    const preview = (await workspace.owner.entities.delete({
+      entity_id: root.entity.id,
+      force_delete_tree: true,
+      dry_run: true,
+    })) as { action: string; deleted_count: number; dry_run?: boolean; tree?: Record<string, number> };
+    expect(preview.dry_run).toBe(true);
+    expect(preview.deleted_count).toBe(0);
+    expect(preview.tree).toMatchObject({ entities: 3, events_detached: 1 });
 
-    const remaining = await getTestDb()`
+    const afterPreview = await getTestDb()`
       SELECT COUNT(*)::int AS count
       FROM entities
       WHERE id = ANY(${`{${root.entity.id},${child.entity.id},${grandchild.entity.id}}`}::bigint[])
         AND deleted_at IS NULL
     `;
-    expect(remaining[0].count).toBe(3);
+    expect(afterPreview[0].count).toBe(3);
+
+    const result = (await workspace.owner.entities.delete({
+      entity_id: root.entity.id,
+      force_delete_tree: true,
+    })) as { action: string; deleted_count?: number; tree?: Record<string, number> };
+    expect(result.action).toBe('delete');
+    expect(result.deleted_count).toBe(3);
+    expect(result.tree).toMatchObject({ entities: 3, events_detached: 1 });
+
+    const remaining = await getTestDb()`
+      SELECT COUNT(*)::int AS count
+      FROM entities
+      WHERE id = ANY(${`{${root.entity.id},${child.entity.id},${grandchild.entity.id}}`}::bigint[])
+    `;
+    expect(remaining[0].count).toBe(0);
+
+    // The event row survives as append-only history; only its entity linkage is gone.
+    const eventRows = await getTestDb()`
+      SELECT (${grandchild.entity.id} = ANY(entity_ids)) AS still_linked
+      FROM events WHERE id = ${event.id}
+    `;
+    expect(eventRows).toHaveLength(1);
+    expect(eventRows[0].still_linked).toBe(false);
+  });
+
+  it('force-deletes fresh entities whose own lifecycle produced platform change events (#2049)', async () => {
+    await workspace.owner.entity_schema.createRelType({
+      slug: 'related-brand',
+      name: 'Related Brand',
+    });
+
+    const a = (await workspace.owner.entities.create({ type: 'brand', name: 'Disposable A' })) as {
+      entity: { id: number };
+    };
+    const b = (await workspace.owner.entities.create({ type: 'brand', name: 'Disposable B' })) as {
+      entity: { id: number };
+    };
+
+    // Normal lifecycle activity: a metadata update emits a platform change
+    // event, and a temporary relationship is created then removed.
+    await workspace.owner.entities.update({
+      entity_id: a.entity.id,
+      metadata: { domain: 'disposable.example' },
+    });
+    await waitForChangeEvent(a.entity.id);
+    const linked = (await workspace.owner.entities.link({
+      from_entity_id: a.entity.id,
+      to_entity_id: b.entity.id,
+      relationship_type_slug: 'related-brand',
+    })) as { relationship: { id: number } };
+    await workspace.owner.entities.manage({
+      action: 'unlink',
+      relationship_id: linked.relationship.id,
+    });
+
+    for (const id of [a.entity.id, b.entity.id]) {
+      const result = (await workspace.owner.entities.delete({
+        entity_id: id,
+        force_delete_tree: true,
+      })) as { action: string; deleted_count?: number };
+      expect(result.action).toBe('delete');
+      expect(result.deleted_count).toBe(1);
+    }
+
+    const remaining = await getTestDb()`
+      SELECT COUNT(*)::int AS count
+      FROM entities
+      WHERE id = ANY(${`{${a.entity.id},${b.entity.id}}`}::bigint[])
+    `;
+    expect(remaining[0].count).toBe(0);
+
+    // The change event history is preserved (append-only), just detached.
+    const changeEvents = await getTestDb()`
+      SELECT entity_ids FROM events
+      WHERE semantic_type = 'change'
+        AND ${a.entity.id} = ANY(entity_ids)
+    `;
+    expect(changeEvents).toHaveLength(0);
   });
 
   it('hard-deletes a descendant tree with no event history', async () => {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -122,12 +122,13 @@ export default async (_ctx, client) => {
 		access: "write",
 	},
 	"entities.delete": {
-		summary: "Delete an entity, optionally cascading to descendants.",
+		summary:
+			"Delete an entity. force_delete_tree hard-deletes the whole descendant tree (event history is kept, only detached); dry_run previews what would be removed/detached without mutating.",
 		access: "admin",
 		signature:
-			"entities.delete(input: { entity_id: number; force_delete_tree?: boolean }): Promise<unknown>",
+			"entities.delete(input: { entity_id: number; force_delete_tree?: boolean; dry_run?: boolean }): Promise<unknown>",
 		example:
-			"await client.entities.delete({ entity_id: 42, force_delete_tree: true });",
+			"await client.entities.delete({ entity_id: 42, force_delete_tree: true, dry_run: true });",
 	},
 	"entities.link": {
 		summary:

--- a/packages/server/src/sandbox/namespaces/entities.ts
+++ b/packages/server/src/sandbox/namespaces/entities.ts
@@ -66,6 +66,8 @@ export interface EntitiesNamespace {
 	delete(input: {
 		entity_id: number;
 		force_delete_tree?: boolean;
+		/** Preflight only: report what would be removed/detached, mutate nothing. */
+		dry_run?: boolean;
 	}): Promise<unknown>;
 	link(input: EntityLinkInput): Promise<unknown>;
 	unlink(input: {

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -1334,6 +1334,25 @@ async function handleDelete(
 	if (deleteDecision.outcome === "deny") {
 		throw new ToolUserError(deleteDecision.reason, 403);
 	}
+	// Preflight: report what the delete would remove/detach without mutating.
+	// Runs after the gate's deny check (a denied principal gets no preview) but
+	// before defer queues anything — a dry run must never create an approval.
+	if (args?.dry_run) {
+		const preview = await deleteEntity(entityId, force, env, ctx, {
+			dryRun: true,
+		});
+		return {
+			action: "delete",
+			success: true,
+			message:
+				deleteDecision.outcome === "defer"
+					? `${preview.message} (a real delete would be queued for approval)`
+					: preview.message,
+			deleted_count: 0,
+			dry_run: true,
+			tree: preview.tree,
+		};
+	}
 	if (deleteDecision.outcome === "defer") {
 		const res = await deleteDecision.deferred.queue(ctx, env);
 		return {
@@ -1363,6 +1382,7 @@ async function handleDelete(
 		success: true,
 		message: result.message,
 		deleted_count: result.deleted,
+		tree: result.tree,
 	};
 }
 

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -755,8 +755,27 @@ export async function getEntity(
 }
 
 /**
+ * Force-delete dependency report: what a hard delete of the tree removes or
+ * detaches. Computed up front so `dry_run` can return it without mutating and
+ * the real delete can echo exactly what it touched. Event rows are append-only
+ * and are only ever detached, never deleted.
+ */
+export interface ForceDeleteTreeReport {
+  entities: number;
+  relationships: number;
+  behaviors_deleted: number;
+  behaviors_detached: number;
+  feeds_deleted: number;
+  feeds_detached: number;
+  events_detached: number;
+}
+
+/**
  * Delete entity
  * Soft delete by default (sets deleted_at), hard delete with force=true.
+ * A hard delete removes the tree + its relationships, deletes/detaches
+ * dependent behaviors and feeds, and detaches (never deletes) event rows that
+ * reference the tree. `dryRun` returns the dependency report without mutating.
  * Requires write access (entity must belong to user's organization)
  */
 export async function deleteEntity(
@@ -764,16 +783,21 @@ export async function deleteEntity(
 	force: boolean = false,
 	env: Env,
 	ctx: ToolContext,
-	opts?: { skipHooks?: boolean },
-): Promise<{ message: string; deleted: number }> {
+	opts?: { skipHooks?: boolean; dryRun?: boolean },
+): Promise<{
+  message: string;
+  deleted: number;
+  dry_run?: boolean;
+  tree?: ForceDeleteTreeReport;
+}> {
   const pgSql = createDbClientFromEnv(env);
   const sql = getDb();
 
   // Validate write access (uses PG for auth tables)
   await requireWriteAccess(pgSql, entityId, ctx);
 
-  // Run beforeDelete hook
-  if (!opts?.skipHooks) {
+  // Run beforeDelete hook (a dry run mutates nothing, so hooks stay silent)
+  if (!opts?.skipHooks && !opts?.dryRun) {
     const entityRow = await sql`
       SELECT et.slug AS entity_type, e.metadata
       FROM entities e
@@ -816,19 +840,56 @@ export async function deleteEntity(
     const entityTreeIds = await loadEntityTreeIds(sql, entityId);
     const entityTreeIdsLiteral = pgBigintArray(entityTreeIds);
 
-    const eventHistory = await sql`
-      SELECT COUNT(*) as count
-      FROM current_event_records ev
-      WHERE ev.entity_ids && ${entityTreeIdsLiteral}::bigint[]
+    // Preflight dependency report: what this delete removes vs. detaches.
+    // A behavior/feed whose entities all live inside the tree is deleted with
+    // it; one that also spans outside entities is detached (tree ids pruned
+    // from its entity_ids). Event rows are append-only history — they are
+    // counted here and DETACHED below, never deleted.
+    const preflight = await sql<Record<string, number>>`
+      SELECT
+        (SELECT COUNT(*) FROM entity_relationships r
+          WHERE r.from_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
+             OR r.to_entity_id = ANY(${entityTreeIdsLiteral}::bigint[]))::int AS relationships,
+        (SELECT COUNT(*) FROM watchers w
+          WHERE w.entity_ids && ${entityTreeIdsLiteral}::bigint[]
+            AND w.entity_ids <@ ${entityTreeIdsLiteral}::bigint[])::int AS behaviors_deleted,
+        (SELECT COUNT(*) FROM watchers w
+          WHERE w.entity_ids && ${entityTreeIdsLiteral}::bigint[]
+            AND NOT (w.entity_ids <@ ${entityTreeIdsLiteral}::bigint[]))::int AS behaviors_detached,
+        (SELECT COUNT(*) FROM feeds f
+          WHERE f.entity_ids && ${entityTreeIdsLiteral}::bigint[]
+            AND f.entity_ids <@ ${entityTreeIdsLiteral}::bigint[])::int AS feeds_deleted,
+        (SELECT COUNT(*) FROM feeds f
+          WHERE f.entity_ids && ${entityTreeIdsLiteral}::bigint[]
+            AND NOT (f.entity_ids <@ ${entityTreeIdsLiteral}::bigint[]))::int AS feeds_detached,
+        (SELECT COUNT(*) FROM events e
+          WHERE e.entity_ids && ${entityTreeIdsLiteral}::bigint[])::int AS events_detached
     `;
+    const report: ForceDeleteTreeReport = {
+      entities: entityTreeIds.length,
+      relationships: Number(preflight[0]?.relationships || 0),
+      behaviors_deleted: Number(preflight[0]?.behaviors_deleted || 0),
+      behaviors_detached: Number(preflight[0]?.behaviors_detached || 0),
+      feeds_deleted: Number(preflight[0]?.feeds_deleted || 0),
+      feeds_detached: Number(preflight[0]?.feeds_detached || 0),
+      events_detached: Number(preflight[0]?.events_detached || 0),
+    };
 
-    const eventCount = Number(eventHistory[0]?.count || 0);
-    if (eventCount > 0) {
-      throw new Error(
-        `Cannot hard delete entity tree: ${eventCount} event rows reference this entity tree. Soft delete the entity instead to preserve event history.`
-      );
+    if (opts?.dryRun) {
+      return {
+        message: `Dry run: force delete would remove ${report.entities} entities and detach ${report.events_detached} event rows`,
+        deleted: 0,
+        dry_run: true,
+        tree: report,
+      };
     }
 
+    // Deletion predicate for behaviors/feeds: only rows whose entity set is
+    // non-empty AND fully inside the tree. Requiring the overlap (&&) first is
+    // load-bearing — a bare `entity_ids <@ tree` (or a COALESCE to '{}') also
+    // matches every empty/NULL-linked row IN EVERY ORG (empty set ⊂ anything),
+    // and lets the GIN index on entity_ids drive the scan instead of a
+    // full-table pass.
     await sql.begin(async (tx) => {
       await tx`
         DELETE FROM entity_relationships
@@ -843,7 +904,8 @@ export async function deleteEntity(
         WHERE watcher_id IN (
           SELECT id
           FROM watchers
-          WHERE COALESCE(entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+          WHERE entity_ids && ${entityTreeIdsLiteral}::bigint[]
+            AND entity_ids <@ ${entityTreeIdsLiteral}::bigint[]
         )
       `;
       // Before hard-deleting watchers: if any of those rows are group roots
@@ -860,12 +922,16 @@ export async function deleteEntity(
             SELECT w.id AS old_root
             FROM watchers w
             WHERE w.id = w.watcher_group_id
-              AND COALESCE(w.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+              AND w.entity_ids && ${entityTreeIdsLiteral}::bigint[]
+              AND w.entity_ids <@ ${entityTreeIdsLiteral}::bigint[]
           ) r
           JOIN watchers s
             ON s.watcher_group_id = r.old_root
            AND s.id <> r.old_root
-           AND NOT (COALESCE(s.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[])
+           AND NOT (
+             COALESCE(s.entity_ids, '{}'::bigint[]) && ${entityTreeIdsLiteral}::bigint[]
+             AND COALESCE(s.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+           )
            AND NOT EXISTS (
              SELECT 1 FROM watcher_versions vv WHERE vv.watcher_id = s.id
            )
@@ -883,12 +949,16 @@ export async function deleteEntity(
             SELECT w.id AS old_root
             FROM watchers w
             WHERE w.id = w.watcher_group_id
-              AND COALESCE(w.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+              AND w.entity_ids && ${entityTreeIdsLiteral}::bigint[]
+              AND w.entity_ids <@ ${entityTreeIdsLiteral}::bigint[]
           ) r
           JOIN watchers s
             ON s.watcher_group_id = r.old_root
            AND s.id <> r.old_root
-           AND NOT (COALESCE(s.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[])
+           AND NOT (
+             COALESCE(s.entity_ids, '{}'::bigint[]) && ${entityTreeIdsLiteral}::bigint[]
+             AND COALESCE(s.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+           )
            AND NOT EXISTS (
              SELECT 1 FROM watcher_versions vv WHERE vv.watcher_id = s.id
            )
@@ -898,96 +968,62 @@ export async function deleteEntity(
       `;
       await tx`
         DELETE FROM watchers
-        WHERE COALESCE(entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+        WHERE entity_ids && ${entityTreeIdsLiteral}::bigint[]
+          AND entity_ids <@ ${entityTreeIdsLiteral}::bigint[]
       `;
+      // Detach survivors: prune tree ids from watchers that also span entities
+      // outside the tree. Fully-contained rows were deleted above, so pruning
+      // can never leave an empty entity set behind — no orphan sweep needed.
       await tx`
         UPDATE watchers
         SET entity_ids = ARRAY(
           SELECT linked_id
-          FROM unnest(COALESCE(entity_ids, '{}'::bigint[])) AS linked_id
+          FROM unnest(entity_ids) AS linked_id
           WHERE NOT (linked_id = ANY(${entityTreeIdsLiteral}::bigint[]))
         )
         WHERE entity_ids && ${entityTreeIdsLiteral}::bigint[]
       `;
-      // Canvas-on-events: key link-row cleanup on the denormalized watcher_id.
-      await tx`
-        DELETE FROM watcher_window_events
-        WHERE watcher_id IN (
-          SELECT id
-          FROM watchers
-          WHERE cardinality(COALESCE(entity_ids, '{}'::bigint[])) = 0
-        )
-      `;
-      // Same group-root ownership transfer as above — predicate here is
-      // "now-orphaned watcher rows" (entity_ids is empty after the array
-      // pruning a few statements up).
-      await tx`
-        UPDATE watcher_versions wv
-        SET watcher_id = s.new_root
-        FROM (
-          SELECT r.old_root, MIN(s.id) AS new_root
-          FROM (
-            SELECT w.id AS old_root
-            FROM watchers w
-            WHERE w.id = w.watcher_group_id
-              AND cardinality(COALESCE(w.entity_ids, '{}'::bigint[])) = 0
-          ) r
-          JOIN watchers s
-            ON s.watcher_group_id = r.old_root
-           AND s.id <> r.old_root
-           AND cardinality(COALESCE(s.entity_ids, '{}'::bigint[])) > 0
-           AND NOT EXISTS (
-             SELECT 1 FROM watcher_versions vv WHERE vv.watcher_id = s.id
-           )
-          GROUP BY r.old_root
-        ) s
-        WHERE wv.watcher_id = s.old_root
-      `;
-      await tx`
-        UPDATE watchers w
-        SET watcher_group_id = s.new_root,
-            source_watcher_id = CASE WHEN w.source_watcher_id = s.old_root THEN s.new_root ELSE w.source_watcher_id END
-        FROM (
-          SELECT r.old_root, MIN(s.id) AS new_root
-          FROM (
-            SELECT w.id AS old_root
-            FROM watchers w
-            WHERE w.id = w.watcher_group_id
-              AND cardinality(COALESCE(w.entity_ids, '{}'::bigint[])) = 0
-          ) r
-          JOIN watchers s
-            ON s.watcher_group_id = r.old_root
-           AND s.id <> r.old_root
-           AND cardinality(COALESCE(s.entity_ids, '{}'::bigint[])) > 0
-           AND NOT EXISTS (
-             SELECT 1 FROM watcher_versions vv WHERE vv.watcher_id = s.id
-           )
-          GROUP BY r.old_root
-        ) s
-        WHERE w.watcher_group_id = s.old_root
-      `;
-      await tx`
-        DELETE FROM watchers
-        WHERE cardinality(COALESCE(entity_ids, '{}'::bigint[])) = 0
-      `;
 
       await tx`
         DELETE FROM feeds
-        WHERE COALESCE(entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+        WHERE entity_ids && ${entityTreeIdsLiteral}::bigint[]
+          AND entity_ids <@ ${entityTreeIdsLiteral}::bigint[]
       `;
       await tx`
         UPDATE feeds
         SET entity_ids = ARRAY(
           SELECT linked_id
-          FROM unnest(COALESCE(entity_ids, '{}'::bigint[])) AS linked_id
+          FROM unnest(entity_ids) AS linked_id
           WHERE NOT (linked_id = ANY(${entityTreeIdsLiteral}::bigint[]))
         )
         WHERE entity_ids && ${entityTreeIdsLiteral}::bigint[]
       `;
-      await tx`
-        DELETE FROM feeds
-        WHERE cardinality(COALESCE(entity_ids, '{}'::bigint[])) = 0
-      `;
+
+      // Detach event references instead of blocking on them: `events` is
+      // append-only (never DELETE), but the platform's own lifecycle events
+      // (change audits etc.) reference fresh entities immediately, so a hard
+      // delete must prune the tree ids out of events.entity_ids — the rows
+      // survive as history, they just stop pointing at deleted entities.
+      // Batched so a large history can't push one UPDATE past
+      // statement_timeout; still atomic (all batches share this transaction).
+      const EVENT_DETACH_BATCH = 5000;
+      for (;;) {
+        const detached = await tx<{ id: number }>`
+          UPDATE events e
+          SET entity_ids = ARRAY(
+            SELECT linked_id
+            FROM unnest(e.entity_ids) AS linked_id
+            WHERE NOT (linked_id = ANY(${entityTreeIdsLiteral}::bigint[]))
+          )
+          WHERE e.id IN (
+            SELECT id FROM events
+            WHERE entity_ids && ${entityTreeIdsLiteral}::bigint[]
+            LIMIT ${EVENT_DETACH_BATCH}
+          )
+          RETURNING e.id
+        `;
+        if (detached.length < EVENT_DETACH_BATCH) break;
+      }
 
       await tx`
         DELETE FROM entities
@@ -996,8 +1032,20 @@ export async function deleteEntity(
     });
 
     return {
-      message: 'Entity and all descendants deleted successfully',
+      message:
+        report.events_detached > 0
+          ? `Entity and all descendants deleted; ${report.events_detached} event rows kept as history and detached`
+          : 'Entity and all descendants deleted successfully',
       deleted: entityTreeIds.length,
+      tree: report,
+    };
+  }
+
+  if (opts?.dryRun) {
+    return {
+      message: 'Dry run: entity would be soft-deleted',
+      deleted: 0,
+      dry_run: true,
     };
   }
 


### PR DESCRIPTION
Fixes #2049.

## Root cause

Two independent failures made the documented hard-delete path unusable:

1. `deleteEntity(force=true)` counted `current_event_records` referencing the tree and refused if any existed. The platform's own lifecycle events (metadata-change audits, etc.) reference a fresh entity immediately, so a disposable entity became un-hard-deletable the moment it was touched — the exact repro in the issue.
2. The cascade statements used `COALESCE(entity_ids, '{}'::bigint[]) <@ tree` predicates on `watchers`/`feeds`. Those force full-table scans (statement-timeout risk on large tables) **and** — since an empty array is a subset of anything — matched every empty/NULL-linked behavior and feed in **every org**. The trailing `cardinality(...) = 0` sweeps deleted all zero-entity behaviors/feeds DB-wide as a side effect of one org's entity delete.

## The fix

- **Detach, never delete, events** (respects the `events` append-only invariant): the force path now prunes the tree ids out of `events.entity_ids` in bounded batches of 5000 (each statement gets its own `statement_timeout` budget; all batches share one transaction so the delete stays atomic). Event rows survive as history — they just stop pointing at deleted entities.
- **`dry_run` preflight**: `entities.delete({ entity_id, force_delete_tree: true, dry_run: true })` returns a dependency report (`tree`: entities, relationships, behaviors/feeds deleted vs detached, events to detach) without mutating anything — it runs after the mutation gate's deny check but never queues an approval. The real delete echoes the same report.
- **Scoped, GIN-indexable cascade predicates**: behavior/feed deletion now requires `entity_ids && tree AND entity_ids <@ tree` (overlap first). Empty-linked rows in any org are untouched, and the GIN index on `entity_ids` drives the scan. With the subset-delete correctly scoped, pruning survivors can never leave an empty entity set behind, so the now-dead second orphan sweep (duplicate group-transfer pass + `cardinality = 0` deletes) is removed.

## Red → green evidence

Red (tests written first, run against unmodified `origin/main` code):

```
FAIL ... > force-deletes fresh entities whose own lifecycle produced platform change events (#2049)
Error: Cannot hard delete entity tree: 1 event rows reference this entity tree. Soft delete the entity instead to preserve event history.
 ❯ Module.deleteEntity src/utils/entity-management.ts:827:13

FAIL ... > force-deletes a tree with event history by detaching event references, not deleting events
ToolUserError: Invalid arguments for client.entities.delete: unknown argument(s): dry_run
```

Green (after fix):

```
✓ src/__tests__/integration/entities/entity-history-contract.test.ts (4 tests) 489ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Also green: full `integration/entities/` suite (29/29), `integration/relationships/` (3/3), `integration/cross-org/isolation` (4/4), `integration/tools/all-tools-e2e` (29/29), bun unit suites `sdk-signature-contract` + `approval-notification-render` + `method-metadata` + `read-only` (37/37). `tsc --noEmit` clean in `packages/server` and `packages/core`; biome finding counts on the touched files identical to `origin/main` (no new findings).

## Notes

- The old integration test asserting the block ("blocks force-deleting ... when any descendant has event history") encoded the contract this issue redefines; it is replaced by the detach + dry-run contracts.
- Dangling ids in `event_classifiers.entity_ids` / `connections.entity_ids` arrays were already possible on every previously-successful force delete and are unchanged here (no FK; arrays match nothing after delete). Worth a follow-up if we want full detachment symmetry.
- make review (LLM verdict) owed — Codex limit resets 2026-07-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->