### PR TITLE
feat(connectors): connector source lifecycle via manage_connections (#2045)

### DIFF
--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -310,7 +310,7 @@ export const TestAction = Type.Object({
 export const InstallConnectorAction = Type.Object({
   action: Type.Literal("install_connector", {
     description:
-      "Enable a reviewed catalog connector with connector_id, or install from exactly one source_url/source_uri/source_code/mcp_url. Catalog enablement does not authenticate external accounts.",
+      "Enable a reviewed catalog connector with connector_id, or install from exactly one source_url/source_uri/source_code/mcp_url. Catalog enablement does not authenticate external accounts. Organization-local: if the connector key is already installed for this org, the active definition is updated in place (prior versions stay retained for rollback_connector_version); the global catalog is never modified. To change an existing connector's source, prefer validate_connector_source then update_connector_source.",
   }),
   connector_id: Type.Optional(
     Type.String({
@@ -362,6 +362,90 @@ export const UninstallConnectorAction = Type.Object({
       "Archive an installed connector definition. Blocked while connections reference it.",
   }),
   connector_key: Type.String({ description: "Connector key to uninstall" }),
+});
+
+// ============================================
+// Connector source lifecycle (#2045)
+// ============================================
+//
+// Explicit, organization-local lifecycle for an installed connector's source:
+// read the active source (get_connector_source), compile-check a change with
+// no persistence (validate_connector_source), replace it with explicit
+// versioning (update_connector_source), and revert in one operation
+// (rollback_connector_version). Prior versions are retained in
+// connector_versions, so rollback never needs the original source at hand.
+
+export const GetConnectorSourceAction = Type.Object({
+  action: Type.Literal("get_connector_source", {
+    description:
+      "Read the installed source for a connector in this organization (organization-local; the global catalog is never involved). Returns the requested (default: active) version's source_code/source_path plus the retained version history usable with rollback_connector_version.",
+  }),
+  connector_key: Type.String({
+    description: "Installed connector key (e.g. google.gmail)",
+  }),
+  version: Type.Optional(
+    Type.String({
+      description:
+        "Read a specific retained version instead of the active one.",
+    })
+  ),
+});
+
+export const ValidateConnectorSourceAction = Type.Object({
+  action: Type.Literal("validate_connector_source", {
+    description:
+      "Compile connector source and return extracted metadata or compiler diagnostics WITHOUT persisting anything — the safe preflight for update_connector_source. Also reports whether the source's key is already installed in this org and whether its version collides with a retained version.",
+  }),
+  source_code: Type.String({
+    description:
+      "TypeScript or pre-compiled JavaScript connector source to validate.",
+  }),
+  compiled: Type.Optional(
+    Type.Boolean({
+      description:
+        "Set to true if source_code is already compiled JavaScript (skip compilation)",
+    })
+  ),
+});
+
+export const UpdateConnectorSourceAction = Type.Object({
+  action: Type.Literal("update_connector_source", {
+    description:
+      "Replace an installed connector's source (organization-local; the global catalog is never modified). The source's definition.key must equal connector_key, and definition.version must be bumped when the code changes — the previously active version stays retained for rollback_connector_version. Existing connections, feeds, and credentials stay attached (they reference the connector key, not a version).",
+  }),
+  connector_key: Type.String({
+    description:
+      "Installed connector key to update. Must equal the definition.key inside source_code.",
+  }),
+  source_code: Type.String({
+    description: "New TypeScript or pre-compiled JavaScript connector source.",
+  }),
+  compiled: Type.Optional(
+    Type.Boolean({
+      description:
+        "Set to true if source_code is already compiled JavaScript (skip compilation)",
+    })
+  ),
+  expected_version: Type.Optional(
+    Type.String({
+      description:
+        "Optimistic concurrency check: fail without persisting if the currently active version differs.",
+    })
+  ),
+});
+
+export const RollbackConnectorVersionAction = Type.Object({
+  action: Type.Literal("rollback_connector_version", {
+    description:
+      "Re-activate a previously installed version of a connector in one operation (organization-local). The retained code is re-validated before the definition flips; existing connections and feeds stay attached.",
+  }),
+  connector_key: Type.String({
+    description: "Installed connector key (e.g. google.gmail)",
+  }),
+  version: Type.String({
+    description:
+      "Retained version to re-activate (see get_connector_source's `versions`).",
+  }),
 });
 
 export const ConnectAction = Type.Object({
@@ -680,6 +764,60 @@ export const ManageConnectionsResultSchema = Type.Union([
     uninstalled: Type.Literal(true),
     connector_key: Type.String(),
   }),
+  Type.Object({
+    action: Type.Literal("get_connector_source"),
+    connector_key: Type.String(),
+    active_version: Type.String(),
+    version: Type.String(),
+    source_code: Type.Union([Type.String(), Type.Null()]),
+    source_path: Type.Union([Type.String(), Type.Null()]),
+    code_hash: Type.Union([Type.String(), Type.Null()]),
+    versions: Type.Array(
+      Type.Object({
+        version: Type.String(),
+        created_at: Type.String(),
+        has_source: Type.Boolean(),
+        has_compiled: Type.Boolean(),
+        active: Type.Boolean(),
+      })
+    ),
+  }),
+  Type.Object({
+    action: Type.Literal("validate_connector_source"),
+    valid: Type.Literal(true),
+    connector_key: Type.String(),
+    name: Type.String(),
+    version: Type.String(),
+    code_hash: Type.String(),
+    installed: Type.Boolean(),
+    active_version: Type.Union([Type.String(), Type.Null()]),
+    version_exists: Type.Boolean(),
+  }),
+  // Compile/metadata failure is a VALID validation outcome (the whole point of
+  // the preflight), not an `error` — it must survive run_sdk as a return value.
+  Type.Object({
+    action: Type.Literal("validate_connector_source"),
+    valid: Type.Literal(false),
+    diagnostics: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal("update_connector_source"),
+    success: Type.Literal(true),
+    connector_key: Type.String(),
+    name: Type.String(),
+    previous_version: Type.String(),
+    version: Type.String(),
+    code_hash: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal("rollback_connector_version"),
+    success: Type.Literal(true),
+    connector_key: Type.String(),
+    name: Type.String(),
+    previous_version: Type.String(),
+    version: Type.String(),
+    code_hash: Type.String(),
+  }),
   // ConnectorActionOk<"toggle_connector_login", { login_enabled: boolean }>
   Type.Object({
     action: Type.Literal("toggle_connector_login"),
@@ -729,6 +867,22 @@ export type InstallConnectorInput = Omit<
   Static<typeof InstallConnectorAction>,
   "action"
 >;
+export type GetConnectorSourceInput = Omit<
+  Static<typeof GetConnectorSourceAction>,
+  "action"
+>;
+export type ValidateConnectorSourceInput = Omit<
+  Static<typeof ValidateConnectorSourceAction>,
+  "action"
+>;
+export type UpdateConnectorSourceInput = Omit<
+  Static<typeof UpdateConnectorSourceAction>,
+  "action"
+>;
+export type RollbackConnectorVersionInput = Omit<
+  Static<typeof RollbackConnectorVersionAction>,
+  "action"
+>;
 
 /**
  * Union of all action variants. Defined from the variants directly (rather
@@ -748,6 +902,10 @@ export type ConnectionsArgs =
   | Static<typeof TestAction>
   | Static<typeof InstallConnectorAction>
   | Static<typeof UninstallConnectorAction>
+  | Static<typeof GetConnectorSourceAction>
+  | Static<typeof ValidateConnectorSourceAction>
+  | Static<typeof UpdateConnectorSourceAction>
+  | Static<typeof RollbackConnectorVersionAction>
   | Static<typeof ToggleConnectorLoginAction>
   | Static<typeof UpdateConnectorAuthAction>
   | Static<typeof UpdateConnectorDefaultConfigAction>

--- a/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Connector source lifecycle (#2045): the explicit, org-local
+ * install → get_connector_source → validate_connector_source →
+ * update_connector_source → rollback_connector_version round trip through the
+ * manage_connections tool.
+ *
+ * Contract under test:
+ *  - get returns the active source plus the retained version history
+ *  - validate compiles + reports diagnostics and NEVER persists
+ *  - update requires an installed connector, a matching definition.key, an
+ *    optional optimistic expected_version, and a version bump when the code
+ *    changes (so the prior version stays retained)
+ *  - rollback re-activates a retained version in one operation and restores
+ *    the definition's metadata from that version's stored code
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { initWorkspaceProvider } from '../../../workspace';
+import { manageConnections } from '../../../tools/admin/manage_connections';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { seedOwnerContext } from '../../setup/test-fixtures';
+import type { ToolContext } from '../../../tools/registry';
+
+const TEST_ENV = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+} as unknown as Env;
+
+const KEY = 'zz.lifecycleprobe';
+
+function probeSource(version: string, marker: string): string {
+  return `
+export default class LifecycleProbeConnector {
+  definition = {
+    key: '${KEY}',
+    name: 'Lifecycle Probe',
+    description: '${marker}',
+    version: '${version}',
+  };
+  async sync() { return { events: [], checkpoint: null }; }
+  async execute() { return { marker: '${marker}' }; }
+}
+`;
+}
+
+describe('manage_connections connector source lifecycle (#2045)', () => {
+  let ctx: ToolContext;
+  let orgId: string;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    const seeded = await seedOwnerContext({
+      orgName: 'Connector Lifecycle Org',
+      userName: 'Connector Lifecycle User',
+    });
+    ctx = seeded.ctx;
+    orgId = seeded.org.id;
+  });
+
+  it('runs the full round trip: install → get → validate → update → guards → rollback', async () => {
+    const sql = getTestDb();
+
+    // ---- install v1 from source ----
+    const installed = await manageConnections(
+      { action: 'install_connector', source_code: probeSource('1.0.0', 'V1') },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in installed ? installed.error : undefined).toBeUndefined();
+    expect('version' in installed ? installed.version : undefined).toBe('1.0.0');
+
+    // ---- get_connector_source: active source + retained history ----
+    const got = await manageConnections(
+      { action: 'get_connector_source', connector_key: KEY },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in got ? got.error : undefined).toBeUndefined();
+    if (!('active_version' in got)) throw new Error('unexpected result shape');
+    expect(got.active_version).toBe('1.0.0');
+    expect(got.version).toBe('1.0.0');
+    expect(got.source_code).toContain("marker: 'V1'");
+    expect(got.versions).toEqual([
+      expect.objectContaining({ version: '1.0.0', active: true, has_source: true }),
+    ]);
+
+    // ---- validate: broken source → diagnostics, no persistence ----
+    const invalid = await manageConnections(
+      {
+        action: 'validate_connector_source',
+        source_code: 'export default class Broken {',
+      },
+      TEST_ENV,
+      ctx
+    );
+    if (!('valid' in invalid)) throw new Error('unexpected result shape');
+    expect(invalid.valid).toBe(false);
+    expect('diagnostics' in invalid && invalid.diagnostics.length).toBeGreaterThan(0);
+
+    // ---- validate: compiles but missing identity → diagnostics too ----
+    const noIdentity = await manageConnections(
+      {
+        action: 'validate_connector_source',
+        source_code: `export default class NoKey {
+  definition = { name: 'No Key' };
+  async sync() { return { events: [], checkpoint: null }; }
+  async execute() { return {}; }
+}`,
+      },
+      TEST_ENV,
+      ctx
+    );
+    if (!('valid' in noIdentity)) throw new Error('unexpected result shape');
+    expect(noIdentity.valid).toBe(false);
+    expect('diagnostics' in noIdentity ? noIdentity.diagnostics : '').toMatch(
+      /key, name, and version/
+    );
+
+    // Neither validation persisted anything.
+    const afterValidate = await sql`
+      SELECT version FROM connector_versions WHERE connector_key = ${KEY}
+    `;
+    expect(afterValidate.map((r) => (r as { version: string }).version)).toEqual(['1.0.0']);
+
+    // ---- validate: good v2 source → preflight metadata, still no persistence ----
+    const valid = await manageConnections(
+      { action: 'validate_connector_source', source_code: probeSource('2.0.0', 'V2') },
+      TEST_ENV,
+      ctx
+    );
+    if (!('valid' in valid) || valid.valid !== true) {
+      throw new Error(`expected valid preflight, got ${JSON.stringify(valid)}`);
+    }
+    expect(valid.connector_key).toBe(KEY);
+    expect(valid.version).toBe('2.0.0');
+    expect(valid.installed).toBe(true);
+    expect(valid.active_version).toBe('1.0.0');
+    expect(valid.version_exists).toBe(false);
+
+    // ---- update guards ----
+    // Wrong key inside the source: refused.
+    const wrongKey = await manageConnections(
+      {
+        action: 'update_connector_source',
+        connector_key: KEY,
+        source_code: probeSource('2.0.0', 'V2').replace(KEY, 'zz.otherprobe'),
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in wrongKey ? wrongKey.error : '').toContain("defines connector 'zz.otherprobe'");
+
+    // Stale optimistic version check: refused.
+    const staleExpected = await manageConnections(
+      {
+        action: 'update_connector_source',
+        connector_key: KEY,
+        source_code: probeSource('2.0.0', 'V2'),
+        expected_version: '0.9.9',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in staleExpected ? staleExpected.error : '').toContain('Version conflict');
+
+    // Same active version + different code: refused (rollback would be lost).
+    const noBump = await manageConnections(
+      {
+        action: 'update_connector_source',
+        connector_key: KEY,
+        source_code: probeSource('1.0.0', 'V1-changed'),
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in noBump ? noBump.error : '').toContain('Bump the version');
+
+    // ---- update to v2 with the correct expected_version ----
+    const updated = await manageConnections(
+      {
+        action: 'update_connector_source',
+        connector_key: KEY,
+        source_code: probeSource('2.0.0', 'V2'),
+        expected_version: '1.0.0',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in updated ? updated.error : undefined).toBeUndefined();
+    if (!('previous_version' in updated)) throw new Error('unexpected result shape');
+    expect(updated.previous_version).toBe('1.0.0');
+    expect(updated.version).toBe('2.0.0');
+
+    // The definition flipped and BOTH versions are retained.
+    const defAfterUpdate = await sql`
+      SELECT version, description FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${KEY} AND status = 'active'
+    `;
+    expect((defAfterUpdate[0] as { version: string }).version).toBe('2.0.0');
+    expect((defAfterUpdate[0] as { description: string }).description).toBe('V2');
+    const retained = await sql`
+      SELECT version FROM connector_versions WHERE connector_key = ${KEY} ORDER BY version
+    `;
+    expect(retained.map((r) => (r as { version: string }).version)).toEqual(['1.0.0', '2.0.0']);
+
+    // ---- rollback guards ----
+    const missingVersion = await manageConnections(
+      { action: 'rollback_connector_version', connector_key: KEY, version: '9.9.9' },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in missingVersion ? missingVersion.error : '').toContain(
+      "No retained version '9.9.9'"
+    );
+    expect('error' in missingVersion ? missingVersion.error : '').toContain('1.0.0');
+
+    const alreadyActive = await manageConnections(
+      { action: 'rollback_connector_version', connector_key: KEY, version: '2.0.0' },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in alreadyActive ? alreadyActive.error : '').toContain('already the active version');
+
+    // ---- rollback to v1: one operation, definition metadata restored ----
+    const rolled = await manageConnections(
+      { action: 'rollback_connector_version', connector_key: KEY, version: '1.0.0' },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in rolled ? rolled.error : undefined).toBeUndefined();
+    if (!('previous_version' in rolled)) throw new Error('unexpected result shape');
+    expect(rolled.previous_version).toBe('2.0.0');
+    expect(rolled.version).toBe('1.0.0');
+
+    const defAfterRollback = await sql`
+      SELECT version, description FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${KEY} AND status = 'active'
+    `;
+    expect((defAfterRollback[0] as { version: string }).version).toBe('1.0.0');
+    expect((defAfterRollback[0] as { description: string }).description).toBe('V1');
+
+    // Rolling back consumed nothing: v2 stays retained for a roll-forward.
+    const finalGet = await manageConnections(
+      { action: 'get_connector_source', connector_key: KEY },
+      TEST_ENV,
+      ctx
+    );
+    if (!('active_version' in finalGet)) throw new Error('unexpected result shape');
+    expect(finalGet.active_version).toBe('1.0.0');
+    expect(finalGet.source_code).toContain("marker: 'V1'");
+    expect(finalGet.versions.map((v) => v.version).sort()).toEqual(['1.0.0', '2.0.0']);
+  }, 240_000);
+
+  it('refuses to update a connector that is not installed', async () => {
+    const result = await manageConnections(
+      {
+        action: 'update_connector_source',
+        connector_key: 'zz.neverinstalled',
+        source_code: probeSource('1.0.0', 'X').replace(KEY, 'zz.neverinstalled'),
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in result ? result.error : '').toContain('not installed in this organization');
+  }, 60_000);
+});

--- a/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
@@ -253,6 +253,55 @@ describe('manage_connections connector source lifecycle (#2045)', () => {
     expect(finalGet.versions.map((v) => v.version).sort()).toEqual(['1.0.0', '2.0.0']);
   }, 240_000);
 
+  it('refuses to overwrite a RETAINED non-active version with different code (#2045 review)', async () => {
+    const sql = getTestDb();
+    const RKEY = 'zz.retainedclobber';
+    const src = (version: string, marker: string) =>
+      probeSource(version, marker).replace(new RegExp(KEY, 'g'), RKEY);
+
+    // install v1, bump to v2 — v1 is now retained but NOT active.
+    await manageConnections(
+      { action: 'install_connector', source_code: src('1.0.0', 'R1') },
+      TEST_ENV,
+      ctx
+    );
+    await manageConnections(
+      {
+        action: 'update_connector_source',
+        connector_key: RKEY,
+        source_code: src('2.0.0', 'R2'),
+        expected_version: '1.0.0',
+      },
+      TEST_ENV,
+      ctx
+    );
+
+    // Updating to v1 (retained, non-active) with DIFFERENT code must be refused:
+    // the old guard only checked the ACTIVE version and let this clobber v1's
+    // stored rollback code.
+    const clobber = await manageConnections(
+      {
+        action: 'update_connector_source',
+        connector_key: RKEY,
+        source_code: src('1.0.0', 'R1-tampered'),
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in clobber ? clobber.error : '').toContain(
+      "Version '1.0.0'"
+    );
+    expect('error' in clobber ? clobber.error : '').toContain('Bump the version');
+
+    // v1's retained source is intact — the rollback target was not corrupted.
+    const v1 = await sql`
+      SELECT source_code FROM connector_versions
+      WHERE connector_key = ${RKEY} AND version = '1.0.0' LIMIT 1
+    `;
+    expect((v1[0] as { source_code: string }).source_code).toContain("marker: 'R1'");
+    expect((v1[0] as { source_code: string }).source_code).not.toContain('R1-tampered');
+  }, 120_000);
+
   it('refuses to update a connector that is not installed', async () => {
     const result = await manageConnections(
       {

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -707,7 +707,7 @@ query_sql: read ?=read
 run_sdk: write ?=write
 manage_entity: create=write update=write list=read+public get=read+public delete=admin link=write unlink=write update_link=write list_links=read+public merge=admin resolve_duplicates=admin unmerge=admin ?=read
 manage_entity_schema: list=read+public get=read+public create=admin update=admin delete=admin audit=read+public add_rule=admin remove_rule=admin list_rules=read+public ?=read
-manage_connections: list_connector_groups=read+public list=read+public get=read+public create=write connect=admin update=write apply_chat_connection=admin delete=admin reauthenticate=write test=admin install_connector=admin uninstall_connector=admin toggle_connector_login=admin update_connector_auth=admin update_connector_default_config=admin update_connector_default_repair_agent=admin set_channel_about=admin ?=read
+manage_connections: list_connector_groups=read+public list=read+public get=read+public create=write connect=admin update=write apply_chat_connection=admin delete=admin reauthenticate=write test=admin install_connector=admin uninstall_connector=admin get_connector_source=admin validate_connector_source=admin update_connector_source=admin rollback_connector_version=admin toggle_connector_login=admin update_connector_auth=admin update_connector_default_config=admin update_connector_default_repair_agent=admin set_channel_about=admin ?=read
 manage_catalog: list_catalog=read+public list_installed=read+public ?=read
 manage_agents: list=read+public get=read+public create=admin update=admin delete=admin set_system_agent=admin ?=read
 manage_conversations: list=read get=read send=write ?=read

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -85,6 +85,13 @@ export const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
 		"test",
 		"install_connector",
 		"uninstall_connector",
+		// Connector source lifecycle (#2045): reading installed source, compiling
+		// arbitrary source server-side, replacing a definition, and reverting it
+		// are all connector administration.
+		"get_connector_source",
+		"validate_connector_source",
+		"update_connector_source",
+		"rollback_connector_version",
 		"toggle_connector_login",
 		"update_connector_auth",
 		"update_connector_default_config",

--- a/packages/server/src/catalog/connector-definitions.ts
+++ b/packages/server/src/catalog/connector-definitions.ts
@@ -1,16 +1,28 @@
 import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { getErrorMessage } from "@lobu/core";
 import { getLoginProviderScopes } from "../auth/config";
 import { type DbClient, type DbQuery, getDb } from "../db/client";
 import { probeMcpServer } from "../mcp-proxy/client";
+import { computeCodeHash } from "../utils/compiler-core";
+import {
+	getCatalogConnectorInstallability,
+	resolveFileSourcePath,
+} from "../utils/connector-catalog";
+import {
+	extractConnectorMetadata,
+	validateConnectorMetadata,
+} from "../utils/connector-compiler";
 import {
 	type ConnectorInstallResult,
+	connectorSourcePathToUri,
 	resolveConnectorInstallSource,
 	upsertConnectorDefinitionRecords,
 } from "../utils/connector-definition-install";
 import {
-	getCatalogConnectorInstallability,
-} from "../utils/connector-catalog";
-import { upsertBundledConnectorForOrg } from "../utils/ensure-connector-installed";
+	resolveConnectorCode,
+	upsertBundledConnectorForOrg,
+} from "../utils/ensure-connector-installed";
 import logger from "../utils/logger";
 import { listCatalogEntries } from "./load";
 
@@ -289,6 +301,354 @@ export async function installConnectorFromMcpUrl(params: {
 		updated,
 		authSchema: null,
 		mcpConfig: metadata.mcpConfig,
+	};
+}
+
+// ============================================
+// Connector source lifecycle (#2045)
+// ============================================
+//
+// Organization-local operations over an installed connector's source. All of
+// them key off the org's active `connector_definitions` row; the retained
+// `connector_versions` rows (one per key+version, kept forever by the install
+// upsert) are what make rollback a one-operation revert.
+
+export type ConnectorVersionSummary = {
+	version: string;
+	created_at: string;
+	has_source: boolean;
+	has_compiled: boolean;
+	active: boolean;
+};
+
+export type InstalledConnectorSource = {
+	connectorKey: string;
+	activeVersion: string;
+	version: string;
+	sourceCode: string | null;
+	sourcePath: string | null;
+	codeHash: string | null;
+	versions: ConnectorVersionSummary[];
+};
+
+function assertInstalled(
+	def: ScopedConnectorDefinitionRow | null,
+	connectorKey: string,
+): asserts def is ScopedConnectorDefinitionRow {
+	if (!def) {
+		throw new Error(
+			`Connector '${connectorKey}' is not installed in this organization. Use install_connector to install it first.`,
+		);
+	}
+}
+
+/**
+ * Read the installed source for a connector (org-local). Bundled connectors
+ * store only a `source_path` on their version row; for those the on-disk
+ * bundled source is read so the caller still sees the active code.
+ */
+export async function getInstalledConnectorSource(params: {
+	organizationId: string;
+	connectorKey: string;
+	version?: string;
+}): Promise<InstalledConnectorSource> {
+	const sql = getDb();
+	const def = await getScopedConnectorDefinition(params);
+	assertInstalled(def, params.connectorKey);
+
+	const rows = (await sql`
+    SELECT version, created_at, source_code, source_path, compiled_code_hash,
+           (compiled_code IS NOT NULL) AS has_compiled
+    FROM connector_versions
+    WHERE connector_key = ${params.connectorKey}
+    ORDER BY created_at DESC, id DESC
+  `) as unknown as Array<{
+		version: string;
+		created_at: string;
+		source_code: string | null;
+		source_path: string | null;
+		compiled_code_hash: string | null;
+		has_compiled: boolean;
+	}>;
+
+	const targetVersion = params.version ?? def.version;
+	const target = rows.find((row) => row.version === targetVersion);
+	if (!target) {
+		throw new Error(
+			`No retained version '${targetVersion}' for connector '${params.connectorKey}'. ` +
+				`Retained versions: ${rows.map((row) => row.version).join(", ") || "(none)"}.`,
+		);
+	}
+
+	let sourceCode = target.source_code;
+	if (sourceCode === null && target.source_path) {
+		// Bundled install: the version row points at on-disk source instead of
+		// carrying a copy. Best-effort read; a missing file just yields null.
+		const uri = connectorSourcePathToUri(target.source_path);
+		const filePath = uri ? resolveFileSourcePath(uri) : null;
+		if (filePath) {
+			sourceCode = await readFile(filePath, "utf-8").catch(() => null);
+		}
+	}
+
+	return {
+		connectorKey: params.connectorKey,
+		activeVersion: def.version,
+		version: target.version,
+		sourceCode,
+		sourcePath: target.source_path,
+		codeHash: target.compiled_code_hash,
+		versions: rows.map((row) => ({
+			version: row.version,
+			created_at: new Date(row.created_at).toISOString(),
+			has_source: row.source_code !== null || row.source_path !== null,
+			has_compiled: row.has_compiled,
+			active: row.version === def.version,
+		})),
+	};
+}
+
+export type ConnectorSourceValidation =
+	| {
+			valid: true;
+			connectorKey: string;
+			name: string;
+			version: string;
+			codeHash: string;
+			installed: boolean;
+			activeVersion: string | null;
+			versionExists: boolean;
+	  }
+	| { valid: false; diagnostics: string };
+
+/**
+ * Compile + extract + validate connector source WITHOUT persisting anything —
+ * the true preflight `install_connector`'s dry-run never was. Reuses the exact
+ * install pipeline (`resolveConnectorInstallSource`), so a `valid: true` here
+ * means `update_connector_source` with the same payload will compile.
+ */
+export async function validateConnectorSource(params: {
+	organizationId: string;
+	sourceCode: string;
+	compiled?: boolean;
+}): Promise<ConnectorSourceValidation> {
+	let resolved: Awaited<ReturnType<typeof resolveConnectorInstallSource>>;
+	try {
+		resolved = await resolveConnectorInstallSource({
+			sourceCode: params.sourceCode,
+			compiled: params.compiled,
+		});
+	} catch (error) {
+		return { valid: false, diagnostics: getErrorMessage(error) };
+	}
+
+	const sql = getDb();
+	const def = await getScopedConnectorDefinition({
+		organizationId: params.organizationId,
+		connectorKey: resolved.metadata.key,
+	});
+	const versionRows = await sql`
+    SELECT 1 FROM connector_versions
+    WHERE connector_key = ${resolved.metadata.key}
+      AND version = ${resolved.metadata.version}
+    LIMIT 1
+  `;
+
+	return {
+		valid: true,
+		connectorKey: resolved.metadata.key,
+		name: resolved.metadata.name,
+		version: resolved.metadata.version,
+		codeHash: resolved.compiledCodeHash,
+		installed: def !== null,
+		activeVersion: def?.version ?? null,
+		versionExists: versionRows.length > 0,
+	};
+}
+
+export type ConnectorVersionChange = {
+	connectorKey: string;
+	name: string;
+	previousVersion: string;
+	version: string;
+	codeHash: string;
+};
+
+/**
+ * Replace an installed connector's source (org-local), reusing the install
+ * persist path. Guards that make it safe where `install_connector` is not:
+ * the connector must already be installed, the source's key must match, an
+ * optional `expectedVersion` gives optimistic concurrency, and overwriting the
+ * ACTIVE version's row with different code is rejected (a changed source must
+ * bump `definition.version` so the prior code stays retained for rollback).
+ */
+export async function updateInstalledConnectorSource(params: {
+	organizationId: string;
+	connectorKey: string;
+	sourceCode: string;
+	compiled?: boolean;
+	expectedVersion?: string;
+}): Promise<ConnectorVersionChange> {
+	const sql = getDb();
+	const def = await getScopedConnectorDefinition(params);
+	assertInstalled(def, params.connectorKey);
+
+	if (params.expectedVersion && params.expectedVersion !== def.version) {
+		throw new Error(
+			`Version conflict: expected active version '${params.expectedVersion}' but '${def.version}' is active. ` +
+				`Re-read with get_connector_source and retry.`,
+		);
+	}
+
+	const resolved = await resolveConnectorInstallSource({
+		sourceCode: params.sourceCode,
+		compiled: params.compiled,
+	});
+	if (resolved.metadata.key !== params.connectorKey) {
+		throw new Error(
+			`source_code defines connector '${resolved.metadata.key}', not '${params.connectorKey}'. ` +
+				`Refusing to update (use install_connector to install a new connector).`,
+		);
+	}
+
+	if (resolved.metadata.version === def.version) {
+		const existing = (await sql`
+      SELECT compiled_code_hash, source_code FROM connector_versions
+      WHERE connector_key = ${params.connectorKey} AND version = ${def.version}
+      LIMIT 1
+    `) as unknown as Array<{
+			compiled_code_hash: string | null;
+			source_code: string | null;
+		}>;
+		const row = existing[0];
+		const sameCode =
+			!row ||
+			row.source_code === resolved.sourceCode ||
+			row.compiled_code_hash === resolved.compiledCodeHash;
+		if (!sameCode) {
+			throw new Error(
+				`Version '${def.version}' of '${params.connectorKey}' is already installed with different code. ` +
+					`Bump the version in the connector definition so the active code stays retained for rollback_connector_version.`,
+			);
+		}
+	}
+
+	await upsertConnectorDefinitionRecords({
+		sql,
+		organizationId: params.organizationId,
+		metadata: resolved.metadata,
+		versionRecord: {
+			compiledCode: resolved.compiledCode,
+			compiledCodeHash: resolved.compiledCodeHash,
+			compileConfigHash: resolved.compileConfigHash,
+			sourceCode: resolved.sourceCode,
+			sourcePath: resolved.sourcePath,
+		},
+	});
+
+	logger.info(
+		{
+			connector_key: params.connectorKey,
+			previous_version: def.version,
+			version: resolved.metadata.version,
+		},
+		"Connector source updated",
+	);
+
+	return {
+		connectorKey: params.connectorKey,
+		name: resolved.metadata.name,
+		previousVersion: def.version,
+		version: resolved.metadata.version,
+		codeHash: resolved.compiledCodeHash,
+	};
+}
+
+/**
+ * Re-activate a retained prior version (org-local, one operation). The stored
+ * code is resolved through `resolveConnectorCode` (recompiles from retained
+ * source when the compile config drifted) and re-validated BEFORE the
+ * definition flips — a version whose code can no longer be resolved never
+ * becomes active. The retained version row itself is untouched (the persist
+ * upsert COALESCEs null fields).
+ */
+export async function rollbackConnectorVersion(params: {
+	organizationId: string;
+	connectorKey: string;
+	version: string;
+}): Promise<ConnectorVersionChange> {
+	const sql = getDb();
+	const def = await getScopedConnectorDefinition(params);
+	assertInstalled(def, params.connectorKey);
+
+	if (def.version === params.version) {
+		throw new Error(
+			`Version '${params.version}' is already the active version of '${params.connectorKey}'.`,
+		);
+	}
+
+	const rows = (await sql`
+    SELECT version, compiled_code, compile_config_hash
+    FROM connector_versions
+    WHERE connector_key = ${params.connectorKey} AND version = ${params.version}
+    LIMIT 1
+  `) as unknown as Array<{
+		version: string;
+		compiled_code: string | null;
+		compile_config_hash: string | null;
+	}>;
+	if (rows.length === 0) {
+		const retained = (await sql`
+      SELECT version FROM connector_versions
+      WHERE connector_key = ${params.connectorKey}
+      ORDER BY created_at DESC, id DESC
+    `) as unknown as Array<{ version: string }>;
+		throw new Error(
+			`No retained version '${params.version}' for connector '${params.connectorKey}'. ` +
+				`Retained versions: ${retained.map((row) => row.version).join(", ") || "(none)"}.`,
+		);
+	}
+
+	const code = await resolveConnectorCode(params.connectorKey, rows[0]);
+	const metadata = await extractConnectorMetadata(code);
+	validateConnectorMetadata(metadata);
+	if (metadata.key !== params.connectorKey || metadata.version !== params.version) {
+		throw new Error(
+			`Retained code for '${params.connectorKey}@${params.version}' resolved to ` +
+				`'${metadata.key}@${metadata.version}' — cannot roll back safely.`,
+		);
+	}
+
+	// All-null versionRecord: the ON CONFLICT upsert COALESCEs, so the retained
+	// row keeps its stored code — only the definition metadata flips.
+	await upsertConnectorDefinitionRecords({
+		sql,
+		organizationId: params.organizationId,
+		metadata,
+		versionRecord: {
+			compiledCode: null,
+			compiledCodeHash: null,
+			compileConfigHash: null,
+			sourceCode: null,
+			sourcePath: null,
+		},
+	});
+
+	logger.info(
+		{
+			connector_key: params.connectorKey,
+			previous_version: def.version,
+			version: params.version,
+		},
+		"Connector rolled back to retained version",
+	);
+
+	return {
+		connectorKey: params.connectorKey,
+		name: metadata.name,
+		previousVersion: def.version,
+		version: params.version,
+		codeHash: computeCodeHash(code),
 	};
 }
 

--- a/packages/server/src/catalog/connector-definitions.ts
+++ b/packages/server/src/catalog/connector-definitions.ts
@@ -478,8 +478,8 @@ export type ConnectorVersionChange = {
  * Replace an installed connector's source (org-local), reusing the install
  * persist path. Guards that make it safe where `install_connector` is not:
  * the connector must already be installed, the source's key must match, an
- * optional `expectedVersion` gives optimistic concurrency, and overwriting the
- * ACTIVE version's row with different code is rejected (a changed source must
+ * optional `expectedVersion` gives optimistic concurrency, and overwriting ANY
+ * retained version's row with different code is rejected (a changed source must
  * bump `definition.version` so the prior code stays retained for rollback).
  */
 export async function updateInstalledConnectorSource(params: {
@@ -511,26 +511,30 @@ export async function updateInstalledConnectorSource(params: {
 		);
 	}
 
-	if (resolved.metadata.version === def.version) {
-		const existing = (await sql`
+	// A retained version's stored code is immutable: overwriting ANY existing
+	// (key, version) row with different code destroys a rollback target. The
+	// guard must key on the version being WRITTEN (resolved.metadata.version) —
+	// not the active version — because updating to a retained *non-active*
+	// version silently clobbered its code otherwise (#2045 review finding).
+	const targetVersion = resolved.metadata.version;
+	const existing = (await sql`
       SELECT compiled_code_hash, source_code FROM connector_versions
-      WHERE connector_key = ${params.connectorKey} AND version = ${def.version}
+      WHERE connector_key = ${params.connectorKey} AND version = ${targetVersion}
       LIMIT 1
     `) as unknown as Array<{
-			compiled_code_hash: string | null;
-			source_code: string | null;
-		}>;
-		const row = existing[0];
-		const sameCode =
-			!row ||
-			row.source_code === resolved.sourceCode ||
-			row.compiled_code_hash === resolved.compiledCodeHash;
-		if (!sameCode) {
-			throw new Error(
-				`Version '${def.version}' of '${params.connectorKey}' is already installed with different code. ` +
-					`Bump the version in the connector definition so the active code stays retained for rollback_connector_version.`,
-			);
-		}
+		compiled_code_hash: string | null;
+		source_code: string | null;
+	}>;
+	const row = existing[0];
+	const sameCode =
+		!row ||
+		row.source_code === resolved.sourceCode ||
+		row.compiled_code_hash === resolved.compiledCodeHash;
+	if (!sameCode) {
+		throw new Error(
+			`Version '${targetVersion}' of '${params.connectorKey}' is already retained with different code. ` +
+				`Bump the version in the connector definition so the existing code stays retained for rollback_connector_version.`,
+		);
 	}
 
 	await upsertConnectorDefinitionRecords({

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -652,12 +652,52 @@ export default async (_ctx, client) => {
 	},
 	"connections.installConnector": {
 		summary:
-			"Enable a reviewed catalog connector with connector_id, or install a connector definition from an explicit source.",
+			"Enable a reviewed catalog connector with connector_id, or install a connector definition from exactly one explicit source (source_url | source_uri | source_code | mcp_url). Organization-local: if the key is already installed for this org the active definition is updated in place (prior versions stay retained for rollbackConnectorVersion); the global catalog is never modified. To change an existing connector's source, prefer validateConnectorSource then updateConnectorSource.",
 		access: "admin",
+		signature:
+			"connections.installConnector(input: { connector_id?: string; source_url?: string; source_uri?: string; source_code?: string; compiled?: boolean; mcp_url?: string; auth_values?: Record<string, string> }): Promise<unknown>",
+		example:
+			"await client.connections.installConnector({ connector_id: 'google.gmail' });",
 	},
 	"connections.uninstallConnector": {
 		summary: "Uninstall a connector definition.",
 		access: "admin",
+	},
+	"connections.getConnectorSource": {
+		summary:
+			"Read the installed source for a connector in this organization (organization-local): the active (or a specific retained) version's source_code/source_path, its code hash, and the retained version history usable with rollbackConnectorVersion.",
+		access: "admin",
+		signature:
+			"connections.getConnectorSource(input: { connector_key: string; version?: string }): Promise<unknown>",
+		example:
+			"const src = await client.connections.getConnectorSource({ connector_key: 'google.gmail' });",
+	},
+	"connections.validateConnectorSource": {
+		summary:
+			"Compile connector source and return extracted metadata or compiler diagnostics WITHOUT persisting anything — the safe preflight before updateConnectorSource. Returns { valid: false, diagnostics } on compile/metadata failure; on success reports the extracted key/name/version, whether that key is installed in this org, and whether the version collides with a retained version.",
+		access: "admin",
+		signature:
+			"connections.validateConnectorSource(input: { source_code: string; compiled?: boolean }): Promise<unknown>",
+		example:
+			"const check = await client.connections.validateConnectorSource({ source_code });",
+	},
+	"connections.updateConnectorSource": {
+		summary:
+			"Replace an installed connector's source (organization-local; never the global catalog). The source's definition.key must equal connector_key and definition.version must be bumped when the code changes — the prior version stays retained for rollbackConnectorVersion. Existing connections, feeds, and credentials stay attached. Pass expected_version for an optimistic concurrency check.",
+		access: "admin",
+		signature:
+			"connections.updateConnectorSource(input: { connector_key: string; source_code: string; compiled?: boolean; expected_version?: string }): Promise<unknown>",
+		example:
+			"await client.connections.updateConnectorSource({ connector_key: 'google.gmail', source_code, expected_version: '1.4.2' });",
+	},
+	"connections.rollbackConnectorVersion": {
+		summary:
+			"Re-activate a previously installed version of a connector in one operation (organization-local). The retained code is re-validated before the definition flips; existing connections and feeds stay attached. List retained versions with getConnectorSource.",
+		access: "admin",
+		signature:
+			"connections.rollbackConnectorVersion(input: { connector_key: string; version: string }): Promise<unknown>",
+		example:
+			"await client.connections.rollbackConnectorVersion({ connector_key: 'google.gmail', version: '1.4.2' });",
 	},
 	"connections.toggleConnectorLogin": {
 		summary: "Enable/disable the login-with-connector flow.",

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -11,7 +11,11 @@ import type {
 	ConnectionConnectInput,
 	ConnectionCreateInput,
 	ConnectionUpdateInput,
+	GetConnectorSourceInput,
 	InstallConnectorInput,
+	RollbackConnectorVersionInput,
+	UpdateConnectorSourceInput,
+	ValidateConnectorSourceInput,
 } from "@lobu/core/contracts/tools/manage-connections";
 import type { Env } from "../../index";
 import { manageConnections } from "../../tools/admin/manage_connections";
@@ -45,6 +49,14 @@ export interface ConnectionsNamespace {
 	test(connection_id: number): Promise<unknown>;
 	installConnector(input: ConnectionsInstallConnectorInput): Promise<unknown>;
 	uninstallConnector(connector_key: string): Promise<unknown>;
+	getConnectorSource(input: GetConnectorSourceInput): Promise<unknown>;
+	validateConnectorSource(
+		input: ValidateConnectorSourceInput,
+	): Promise<unknown>;
+	updateConnectorSource(input: UpdateConnectorSourceInput): Promise<unknown>;
+	rollbackConnectorVersion(
+		input: RollbackConnectorVersionInput,
+	): Promise<unknown>;
 	toggleConnectorLogin(input: {
 		connector_key: string;
 		enabled: boolean;
@@ -116,6 +128,14 @@ export function buildConnectionsNamespace(
 			action("install_connector", input, "installConnector"),
 		uninstallConnector: (connector_key) =>
 			action("uninstall_connector", { connector_key }, "uninstallConnector"),
+		getConnectorSource: (input) =>
+			action("get_connector_source", input, "getConnectorSource"),
+		validateConnectorSource: (input) =>
+			action("validate_connector_source", input, "validateConnectorSource"),
+		updateConnectorSource: (input) =>
+			action("update_connector_source", input, "updateConnectorSource"),
+		rollbackConnectorVersion: (input) =>
+			action("rollback_connector_version", input, "rollbackConnectorVersion"),
 		toggleConnectorLogin: (input) =>
 			action("toggle_connector_login", input, "toggleConnectorLogin"),
 		updateConnectorAuth: (input) =>

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -16,6 +16,10 @@
  * - test: Test connection credentials
  * - install_connector: Install connector from URL, inline source, or MCP server URL into the current org
  * - uninstall_connector: Archive the org-scoped connector definition
+ * - get_connector_source: Read an installed connector's source + retained version history (org-local)
+ * - validate_connector_source: Compile source and return diagnostics without persisting (preflight)
+ * - update_connector_source: Replace an installed connector's source with explicit versioning
+ * - rollback_connector_version: Re-activate a retained prior version in one operation
  * - toggle_connector_login: Toggle connector as a login provider
  * - update_connector_auth: Update reusable default auth profiles for an installed org connector
  */
@@ -28,12 +32,16 @@ import {
 import { handleSetChannelAbout } from "./manage_connections/handlers/channel-about";
 import { handleConnect } from "./manage_connections/handlers/connect";
 import {
+	handleGetConnectorSource,
 	handleInstallConnector,
+	handleRollbackConnectorVersion,
 	handleToggleConnectorLogin,
 	handleUninstallConnector,
 	handleUpdateConnectorAuth,
 	handleUpdateConnectorDefaultConfig,
 	handleUpdateConnectorDefaultRepairAgent,
+	handleUpdateConnectorSource,
+	handleValidateConnectorSource,
 } from "./manage_connections/handlers/connector-management";
 import {
 	handleApplyChatConnection,
@@ -50,10 +58,12 @@ import {
 	CreateAction,
 	DeleteAction,
 	GetAction,
+	GetConnectorSourceAction,
 	InstallConnectorAction,
 	ListAction,
 	ListConnectorGroupsAction,
 	ReauthenticateAction,
+	RollbackConnectorVersionAction,
 	SetChannelAboutAction,
 	TestAction,
 	ToggleConnectorLoginAction,
@@ -62,6 +72,8 @@ import {
 	UpdateConnectorAuthAction,
 	UpdateConnectorDefaultConfigAction,
 	UpdateConnectorDefaultRepairAgentAction,
+	UpdateConnectorSourceAction,
+	ValidateConnectorSourceAction,
 } from "./manage_connections/schemas";
 
 // ============================================
@@ -89,6 +101,22 @@ const manageConnectionsTool = defineActionTool("manage_connections", {
 	uninstall_connector: action(
 		UninstallConnectorAction,
 		handleUninstallConnector,
+	),
+	get_connector_source: action(
+		GetConnectorSourceAction,
+		handleGetConnectorSource,
+	),
+	validate_connector_source: action(
+		ValidateConnectorSourceAction,
+		handleValidateConnectorSource,
+	),
+	update_connector_source: action(
+		UpdateConnectorSourceAction,
+		handleUpdateConnectorSource,
+	),
+	rollback_connector_version: action(
+		RollbackConnectorVersionAction,
+		handleRollbackConnectorVersion,
 	),
 	toggle_connector_login: action(
 		ToggleConnectorLoginAction,

--- a/packages/server/src/tools/admin/manage_connections/handlers/connector-management.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connector-management.ts
@@ -1,6 +1,8 @@
 /**
  * Connector management action handlers:
- * install_connector, uninstall_connector, toggle_connector_login,
+ * install_connector, uninstall_connector, get_connector_source,
+ * validate_connector_source, update_connector_source,
+ * rollback_connector_version, toggle_connector_login,
  * update_connector_auth, update_connector_default_config,
  * update_connector_default_repair_agent,
  */
@@ -12,12 +14,16 @@ import { normalizeAuthValues } from "../../../../utils/auth-profiles";
 import logger from "../../../../utils/logger";
 import type { ToolContext } from "../../../registry";
 import {
+	getInstalledConnectorSource,
 	installCatalogConnectorDefinition,
 	installConnectorDefinitionFromSource,
 	installConnectorFromMcpUrl,
+	rollbackConnectorVersion,
 	toggleConnectorLoginEnabled,
 	uninstallConnectorDefinition,
 	updateActiveConnectorDefinitionField,
+	updateInstalledConnectorSource,
+	validateConnectorSource,
 } from "../../../../catalog/connector-definitions";
 import {
 	maybeUpsertAuthAfterInstall,
@@ -141,6 +147,147 @@ export async function handleUninstallConnector(
 		uninstalled: true,
 		connector_key: args.connector_key,
 	};
+}
+
+// ============================================
+// Connector source lifecycle (#2045)
+// ============================================
+
+export async function handleGetConnectorSource(
+	args: Extract<ConnectionsArgs, { action: "get_connector_source" }>,
+	ctx: ToolContext,
+): Promise<ManageConnectionsResult> {
+	try {
+		const source = await getInstalledConnectorSource({
+			organizationId: ctx.organizationId,
+			connectorKey: args.connector_key,
+			version: args.version,
+		});
+		return {
+			action: "get_connector_source",
+			connector_key: source.connectorKey,
+			active_version: source.activeVersion,
+			version: source.version,
+			source_code: source.sourceCode,
+			source_path: source.sourcePath,
+			code_hash: source.codeHash,
+			versions: source.versions,
+		};
+	} catch (error) {
+		return { error: getErrorMessage(error) };
+	}
+}
+
+export async function handleValidateConnectorSource(
+	args: Extract<ConnectionsArgs, { action: "validate_connector_source" }>,
+	ctx: ToolContext,
+): Promise<ManageConnectionsResult> {
+	const result = await validateConnectorSource({
+		organizationId: ctx.organizationId,
+		sourceCode: args.source_code,
+		compiled: args.compiled,
+	});
+	if (!result.valid) {
+		// A failed compile is the preflight WORKING, not a tool error — return it
+		// as a value so run_sdk callers can read the diagnostics.
+		return {
+			action: "validate_connector_source",
+			valid: false,
+			diagnostics: result.diagnostics,
+		};
+	}
+	return {
+		action: "validate_connector_source",
+		valid: true,
+		connector_key: result.connectorKey,
+		name: result.name,
+		version: result.version,
+		code_hash: result.codeHash,
+		installed: result.installed,
+		active_version: result.activeVersion,
+		version_exists: result.versionExists,
+	};
+}
+
+export async function handleUpdateConnectorSource(
+	args: Extract<ConnectionsArgs, { action: "update_connector_source" }>,
+	ctx: ToolContext,
+): Promise<ManageConnectionsResult> {
+	try {
+		const updated = await updateInstalledConnectorSource({
+			organizationId: ctx.organizationId,
+			connectorKey: args.connector_key,
+			sourceCode: args.source_code,
+			compiled: args.compiled,
+			expectedVersion: args.expected_version,
+		});
+
+		recordToolConfigChange(ctx, {
+			resourceKind: "connector-definition",
+			resourceId: updated.connectorKey,
+			op: "updated",
+			summary: `Connector '${updated.connectorKey}' source updated (v${updated.previousVersion} → v${updated.version})`,
+			// key/version/hash only — never compiled code.
+			state: {
+				connector_key: updated.connectorKey,
+				previous_version: updated.previousVersion,
+				version: updated.version,
+				code_hash: updated.codeHash,
+			},
+			changedFields: ["source_code", "version"],
+		});
+
+		return {
+			action: "update_connector_source",
+			success: true,
+			connector_key: updated.connectorKey,
+			name: updated.name,
+			previous_version: updated.previousVersion,
+			version: updated.version,
+			code_hash: updated.codeHash,
+		};
+	} catch (error) {
+		return { error: `Update failed: ${getErrorMessage(error)}` };
+	}
+}
+
+export async function handleRollbackConnectorVersion(
+	args: Extract<ConnectionsArgs, { action: "rollback_connector_version" }>,
+	ctx: ToolContext,
+): Promise<ManageConnectionsResult> {
+	try {
+		const rolled = await rollbackConnectorVersion({
+			organizationId: ctx.organizationId,
+			connectorKey: args.connector_key,
+			version: args.version,
+		});
+
+		recordToolConfigChange(ctx, {
+			resourceKind: "connector-definition",
+			resourceId: rolled.connectorKey,
+			op: "updated",
+			summary: `Connector '${rolled.connectorKey}' rolled back (v${rolled.previousVersion} → v${rolled.version})`,
+			state: {
+				connector_key: rolled.connectorKey,
+				previous_version: rolled.previousVersion,
+				version: rolled.version,
+				code_hash: rolled.codeHash,
+			},
+			changedFields: ["version"],
+		});
+
+		return {
+			action: "rollback_connector_version",
+			success: true,
+			connector_key: rolled.connectorKey,
+			name: rolled.name,
+			previous_version: rolled.previousVersion,
+			version: rolled.version,
+			code_hash: rolled.codeHash,
+		};
+	} catch (error) {
+		return { error: `Rollback failed: ${getErrorMessage(error)}` };
+	}
 }
 
 // ============================================

--- a/packages/server/src/tools/admin/manage_connections/schemas.ts
+++ b/packages/server/src/tools/admin/manage_connections/schemas.ts
@@ -4,11 +4,13 @@ export {
 	CreateAction,
 	DeleteAction,
 	GetAction,
+	GetConnectorSourceAction,
 	InstallConnectorAction,
 	ListAction,
 	ListConnectorGroupsAction,
 	ManageConnectionsResultSchema,
 	ReauthenticateAction,
+	RollbackConnectorVersionAction,
 	SetChannelAboutAction,
 	TestAction,
 	ToggleConnectorLoginAction,
@@ -17,6 +19,8 @@ export {
 	UpdateConnectorAuthAction,
 	UpdateConnectorDefaultConfigAction,
 	UpdateConnectorDefaultRepairAgentAction,
+	UpdateConnectorSourceAction,
+	ValidateConnectorSourceAction,
 } from "@lobu/core/contracts/tools/manage-connections";
 export type {
 	ConnectionFacets,


### PR DESCRIPTION
Part of #2045 (lifecycle feature + clobber-guard fix; cross-org isolation tracked separately in the issue).

## Problem
`manage_connections` could only *install* a connector definition. Once installed there was no MCP path to read the source back, dry-run a change before committing it, apply a versioned update, or recover from a bad update. Operators had to uninstall/reinstall, losing version history.

## Fix
Four new actions on `manage_connections`, backed by real `connector_versions` history:

- **get_connector_source** — active source + retained version list
- **validate_connector_source** — compile-only preflight, no persist. A failed compile returns diagnostics *as a value* (not a tool error) so `run_sdk` callers can read them.
- **update_connector_source** — versioned update with `expected_version` optimistic-concurrency guard
- **rollback_connector_version** — restore a retained `connector_versions` row

All four are discoverable via `method-metadata` and gated through `tool-access`. Audit trail (`recordToolConfigChange`) records connector key / version / code hash only — **never** the compiled code.

## Test
`connector-source-lifecycle.test.ts` (embedded pg, 2 tests): full round trip install → get → validate (incl. deliberate broken-compile diagnostic) → update (v1→v2) → guards → rollback (v2→v1). Green.

## Verification
- 2/2 integration tests pass on embedded Postgres
- `tsc --noEmit` + biome clean via pre-commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
