### PR TITLE
feat(server): operational list_runs filters + metric_series time bounds (#2051)

### DIFF
--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -86,9 +86,20 @@ export const ExecuteAction = Type.Object({
   ),
 });
 
+/**
+ * Run types excluded from `list_runs` when the caller does not name run types
+ * explicitly. Every chat reply AND every non-terminal streaming delta is
+ * persisted as a `runs` row with run_type='chat_message' (the thread_response
+ * queue lane), so an unfiltered list buries real operational history under
+ * tens of thousands of streaming fragments (#2051). Pass
+ * `run_types: ['chat_message']` to get the low-level trace view.
+ */
+export const LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES = ["chat_message"] as const;
+
 export const ListRunsAction = Type.Object({
   action: Type.Literal("list_runs", {
-    description: "Paginated run list with keyset cursor support.",
+    description:
+      "Paginated operational run list with keyset cursor support. Chat-message transport runs (complete replies + streaming deltas, run_type='chat_message') are excluded unless explicitly requested via run_types.",
   }),
   connection_id: Type.Optional(
     Type.Number({ description: "Filter by connection ID" })
@@ -102,6 +113,9 @@ export const ListRunsAction = Type.Object({
   device_worker_id: Type.Optional(
     Type.String({ description: "Filter by device worker ID" })
   ),
+  connector_key: Type.Optional(
+    Type.String({ description: "Filter by connector key (e.g. 'github')" })
+  ),
   operation_key: Type.Optional(
     Type.String({ description: "Filter by operation key" })
   ),
@@ -109,9 +123,26 @@ export const ListRunsAction = Type.Object({
   approval_status: Type.Optional(
     Type.String({ description: "Filter by approval status" })
   ),
-  /** Filter by run_type. Omit to list every run type (sync, action, auth, …). */
+  /**
+   * Filter by run_type. Omit to list every OPERATIONAL run type (sync, action,
+   * behavior, auth, …) — chat-message transport runs are excluded by default
+   * (see LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES); name 'chat_message' explicitly
+   * to inspect that low-level trace lane.
+   */
   run_types: Type.Optional(
     Type.Array(Type.String({ description: "Filter by run types" }))
+  ),
+  created_after: Type.Optional(
+    Type.String({
+      description:
+        "Only runs created at or after this ISO 8601 timestamp (inclusive)",
+    })
+  ),
+  created_before: Type.Optional(
+    Type.String({
+      description:
+        "Only runs created before this ISO 8601 timestamp (exclusive)",
+    })
   ),
   /** Filter behavior runs by behavior id(s). */
   behavior_ids: Type.Optional(

--- a/packages/server/src/__tests__/integration/mcp/list-runs-operational-filters.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/list-runs-operational-filters.test.ts
@@ -1,0 +1,171 @@
+/**
+ * operations.list_runs — operational filters + streaming-noise exclusion (#2051).
+ *
+ * A production MCP run showed list_runs mixing connector actions, feed syncs,
+ * behavior runs, AND every chat-message transport row (complete replies and
+ * per-delta streaming fragments are each a `runs` row with
+ * run_type='chat_message'). Real operation history was buried under tens of
+ * thousands of streaming fragments.
+ *
+ * Proves:
+ *  - default list EXCLUDES 'chat_message' transport runs;
+ *  - explicit run_types:['chat_message'] still returns them (trace view);
+ *  - new connector_key filter narrows to one connector;
+ *  - new created_after / created_before date-range filters work;
+ *  - invalid date input is a clean error, not a SQL failure.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import { manageOperations } from "../../../tools/admin/manage_operations";
+import type { ToolContext } from "../../../tools/registry";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestConnection,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+const env = {} as Env;
+
+describe("manage_operations list_runs — operational filters (#2051)", () => {
+	let orgId: string;
+	let githubConnId: number;
+	let slackConnId: number;
+
+	const ctx = (): ToolContext => ({
+		organizationId: orgId,
+		userId: "list-runs-owner",
+		memberRole: "owner",
+		isAuthenticated: true,
+		tokenType: "oauth",
+		scopes: ["mcp:admin"],
+		scopedToOrg: false,
+		allowCrossOrg: false,
+	});
+
+	const insertRun = async (opts: {
+		run_type: string;
+		connection_id?: number | null;
+		connector_key?: string | null;
+		action_key?: string | null;
+		status?: string;
+		created_at?: string;
+	}): Promise<number> => {
+		const db = getTestDb();
+		const [row] = (await db`
+      INSERT INTO runs (organization_id, run_type, connection_id, connector_key, action_key, status, created_at, run_at)
+      VALUES (
+        ${orgId}, ${opts.run_type}, ${opts.connection_id ?? null},
+        ${opts.connector_key ?? null}, ${opts.action_key ?? null},
+        ${opts.status ?? "completed"},
+        ${opts.created_at ?? new Date().toISOString()},
+        ${opts.created_at ?? new Date().toISOString()}
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+		return Number(row.id);
+	};
+
+	const listRuns = async (
+		extra: Record<string, unknown> = {},
+	): Promise<{ runs: Array<Record<string, unknown>>; total: number }> => {
+		const res = (await manageOperations(
+			{ action: "list_runs", limit: 100, ...extra },
+			env,
+			ctx(),
+		)) as { runs?: Array<Record<string, unknown>>; total?: number };
+		expect(res.runs, JSON.stringify(res)).toBeDefined();
+		return { runs: res.runs ?? [], total: Number(res.total ?? 0) };
+	};
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "ListRuns Filters" });
+		orgId = org.id;
+		const github = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "github",
+		});
+		githubConnId = github.id;
+		const slack = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "slack",
+		});
+		slackConnId = slack.id;
+
+		// Operational runs.
+		await insertRun({
+			run_type: "action",
+			connection_id: githubConnId,
+			connector_key: "github",
+			action_key: "create_issue",
+			created_at: "2026-07-10T12:00:00Z",
+		});
+		await insertRun({
+			run_type: "sync",
+			connection_id: slackConnId,
+			connector_key: "slack",
+			created_at: "2026-07-12T12:00:00Z",
+		});
+		await insertRun({
+			run_type: "behavior",
+			created_at: "2026-07-14T12:00:00Z",
+		});
+		// Chat transport noise: complete reply + streaming fragments all land as
+		// run_type='chat_message' rows via the thread_response queue.
+		for (let i = 0; i < 5; i++) {
+			await insertRun({
+				run_type: "chat_message",
+				action_key: "thread_response",
+				created_at: `2026-07-15T12:00:0${i}Z`,
+			});
+		}
+	});
+
+	it("excludes chat_message transport runs from the default operational list", async () => {
+		const { runs } = await listRuns();
+		const types = new Set(runs.map((r) => r.run_type));
+		expect(types.has("chat_message")).toBe(false);
+		// Operational lanes still present.
+		expect(types.has("action")).toBe(true);
+		expect(types.has("sync")).toBe(true);
+		expect(types.has("behavior")).toBe(true);
+	});
+
+	it("default total also excludes the transport noise", async () => {
+		const { total } = await listRuns();
+		expect(total).toBe(3);
+	});
+
+	it("explicit run_types:['chat_message'] still exposes the trace view", async () => {
+		const { runs, total } = await listRuns({ run_types: ["chat_message"] });
+		expect(total).toBe(5);
+		expect(runs.every((r) => r.run_type === "chat_message")).toBe(true);
+	});
+
+	it("filters by connector_key", async () => {
+		const { runs, total } = await listRuns({ connector_key: "github" });
+		expect(total).toBe(1);
+		expect(runs[0]?.connector_key).toBe("github");
+		expect(runs[0]?.operation_key).toBe("create_issue");
+	});
+
+	it("filters by created_after / created_before date range", async () => {
+		const { runs, total } = await listRuns({
+			created_after: "2026-07-11T00:00:00Z",
+			created_before: "2026-07-13T00:00:00Z",
+		});
+		expect(total).toBe(1);
+		expect(runs[0]?.run_type).toBe("sync");
+	});
+
+	it("rejects an unparseable date bound cleanly", async () => {
+		await expect(
+			manageOperations(
+				{ action: "list_runs", created_after: "not-a-date" },
+				env,
+				ctx(),
+			),
+		).rejects.toThrow(/created_after/i);
+	});
+});

--- a/packages/server/src/__tests__/integration/mcp/metric-series-bounds.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/metric-series-bounds.test.ts
@@ -1,0 +1,122 @@
+/**
+ * metric_series — bounded time range + invalid-timestamp reporting (#2051).
+ *
+ * A production run of a basic time-bucketed count returned a NULL bucket, a
+ * 1970 epoch bucket, and future buckets through 2056 with no warning. The tool
+ * must surface data quality (null / out-of-range bucket counts against a
+ * bounded default range) and offer exclude_invalid_timestamps + strict modes.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { metricSeries } from "../../../tools/admin/metric_series";
+import type { ToolContext } from "../../../tools/registry";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestEvent,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+const BUCKET_SQL =
+	"SELECT date_trunc('day', occurred_at) AS bucket, COUNT(*)::int AS n FROM events GROUP BY 1 ORDER BY 1";
+
+describe("metric_series — bounds + data quality (#2051)", () => {
+	let orgId: string;
+
+	const ctx = (): ToolContext => ({
+		organizationId: orgId,
+		userId: "metric-bounds-user",
+		memberRole: "owner",
+		isAuthenticated: true,
+		tokenType: "oauth",
+		scopedToOrg: false,
+		allowCrossOrg: false,
+	});
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "Metric Bounds" });
+		orgId = org.id;
+		const db = getTestDb();
+
+		const seed = async (occurredAt: string | null) => {
+			const ev = await createTestEvent({
+				organization_id: orgId,
+				content: `bucket-${occurredAt ?? "null"}`,
+			});
+			await db`UPDATE events SET occurred_at = ${occurredAt} WHERE id = ${ev.id}`;
+		};
+
+		await seed(null); // null timestamp
+		await seed("1970-01-01T00:00:00Z"); // epoch outlier (before range floor)
+		await seed("2056-01-01T00:00:00Z"); // future outlier (past range ceiling)
+		await seed(new Date().toISOString()); // valid, today
+		await seed(new Date().toISOString()); // valid, today (same bucket)
+	});
+
+	it("reports null and out-of-range buckets without dropping rows by default", async () => {
+		const res = await metricSeries({ sql: BUCKET_SQL }, {}, ctx());
+		expect(res.columns).toEqual(["bucket", "n"]);
+		// All 4 buckets still returned (null, 1970, 2056, today).
+		expect(res.rows.length).toBe(4);
+		expect(res.data_quality).toBeDefined();
+		expect(res.data_quality?.time_column).toBe("bucket");
+		expect(res.data_quality?.null_timestamps).toBe(1);
+		expect(res.data_quality?.out_of_range).toBe(2);
+		expect(res.data_quality?.excluded).toBe(false);
+		expect(res.data_quality?.range?.start).toBeTruthy();
+		expect(res.data_quality?.range?.end).toBeTruthy();
+	});
+
+	it("exclude_invalid_timestamps drops null + out-of-range buckets", async () => {
+		const res = await metricSeries(
+			{ sql: BUCKET_SQL, exclude_invalid_timestamps: true },
+			{},
+			ctx(),
+		);
+		expect(res.rows.length).toBe(1); // only today's bucket survives
+		expect(res.rows[0]?.[1]).toBe(2); // both valid events counted
+		expect(res.data_quality?.excluded).toBe(true);
+		expect(res.data_quality?.null_timestamps).toBe(1);
+		expect(res.data_quality?.out_of_range).toBe(2);
+	});
+
+	it("strict mode fails the call when invalid timestamps exist", async () => {
+		await expect(
+			metricSeries({ sql: BUCKET_SQL, strict: true }, {}, ctx()),
+		).rejects.toThrow(/invalid|out-of-range/i);
+	});
+
+	it("caller-supplied start/end bounds narrow the valid range", async () => {
+		// A range in 2055 makes even today's bucket out-of-range.
+		const res = await metricSeries(
+			{
+				sql: BUCKET_SQL,
+				start: "2055-01-01T00:00:00Z",
+				end: "2057-01-01T00:00:00Z",
+				exclude_invalid_timestamps: true,
+			},
+			{},
+			ctx(),
+		);
+		expect(res.rows.length).toBe(1); // only the 2056 bucket is in range now
+		expect(res.data_quality?.out_of_range).toBe(2); // 1970 + today
+	});
+
+	it("rejects an unknown explicit time_column", async () => {
+		await expect(
+			metricSeries({ sql: BUCKET_SQL, time_column: "nope" }, {}, ctx()),
+		).rejects.toThrow(/time_column/i);
+	});
+
+	it("returns no data-quality flags for a series without a time column", async () => {
+		const res = await metricSeries(
+			{ sql: "SELECT COUNT(*)::int AS n FROM events" },
+			{},
+			ctx(),
+		);
+		expect(res.rows.length).toBe(1);
+		expect(res.data_quality?.time_column).toBeNull();
+		expect(res.data_quality?.null_timestamps).toBe(0);
+		expect(res.data_quality?.out_of_range).toBe(0);
+	});
+});

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -695,8 +695,11 @@ export default async (_ctx, client) => {
 			"await client.operations.execute({ connection_id: 42, operation_key: 'create_issue', input: { title: 'Follow up' } });",
 	},
 	"operations.listRuns": {
-		summary: "List past operation runs.",
+		summary:
+			"List past operational runs. Filters: run_types, connector_key, operation_key, connection_id(s), feed_ids, behavior_ids, status, created_after/created_before. Chat-message transport runs (streaming deltas) are excluded by default — pass run_types: ['chat_message'] for the low-level trace view.",
 		access: "read",
+		example:
+			"await client.operations.listRuns({ connector_key: 'github', status: 'failed', created_after: '2026-07-01T00:00:00Z' });",
 	},
 	"operations.getRun": {
 		summary: "Get a single run by id.",
@@ -897,10 +900,10 @@ export default async (_ctx, client) => {
 	},
 	"metrics.series": {
 		summary:
-			"Run read-only time-bucketed SQL for sparklines. Returns { columns, rows } tabular output. Member-safe column allowlist; 5s timeout, 2000-row cap.",
+			"Run read-only time-bucketed SQL for sparklines. Returns { columns, rows, data_quality } tabular output; data_quality flags NULL/unparseable/out-of-range bucket timestamps against a bounded range (default 2000-01-01 … now+1d; override with start/end). Pass exclude_invalid_timestamps to drop flagged rows or strict to fail on them. Member-safe column allowlist; 5s timeout, 2000-row cap.",
 		access: "read",
 		example:
-			"await client.metrics.series({ sql: \"SELECT date_trunc(\\'day\\', created_at) AS bucket, COUNT(*)::int AS n FROM events GROUP BY 1 ORDER BY 1\" });",
+			"await client.metrics.series({ sql: \"SELECT date_trunc(\\'day\\', created_at) AS bucket, COUNT(*)::int AS n FROM events GROUP BY 1 ORDER BY 1\", exclude_invalid_timestamps: true });",
 	},
 
 	// top-level

--- a/packages/server/src/sandbox/namespaces/operations.ts
+++ b/packages/server/src/sandbox/namespaces/operations.ts
@@ -42,11 +42,21 @@ export interface OperationsNamespace {
 		connection_ids?: number[];
 		feed_ids?: number[];
 		device_worker_id?: string;
+		connector_key?: string;
 		operation_key?: string;
 		status?: string;
 		approval_status?: string;
-		/** Omit to list every run type (sync, action, auth, …). */
+		/**
+		 * Omit to list every OPERATIONAL run type (sync, action, behavior, auth,
+		 * …). Chat-message transport runs (streaming deltas) are excluded by
+		 * default; pass run_types: ['chat_message'] for the trace view.
+		 */
 		run_types?: string[];
+		behavior_ids?: number[];
+		/** ISO 8601 inclusive lower bound on created_at. */
+		created_after?: string;
+		/** ISO 8601 exclusive upper bound on created_at. */
+		created_before?: string;
 		before_id?: number;
 		before_created_at?: string;
 		limit?: number;

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -13,6 +13,7 @@ import {
 	ApproveBatchAction,
 	ExecuteAction,
 	GetRunAction,
+	LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES,
 	ListActivityAction,
 	ListAvailableAction,
 	ListRunsAction,
@@ -64,6 +65,7 @@ import type {
 } from "../../operations/types";
 import { createConnectorOperationRun } from "../../runs/queue-service";
 import { resolveConnectorCodeForKey } from "../../utils/ensure-connector-installed";
+import { ToolUserError } from "../../utils/errors";
 import { resolveExecutionAuth } from "../../utils/execution-context";
 import { insertEvent } from "../../utils/insert-event";
 import logger from "../../utils/logger";
@@ -1291,12 +1293,29 @@ async function handleListRuns(
   const hasCursor = args.before_id != null && args.before_created_at != null;
   const offset = hasCursor ? 0 : (args.offset ?? 0);
 
+  // Date-range bounds are validated up front so a bad value is a clean caller
+  // error instead of a mid-query Postgres cast failure.
+  for (const field of ["created_after", "created_before"] as const) {
+    const value = args[field];
+    if (value != null && Number.isNaN(Date.parse(value))) {
+      throw new ToolUserError(
+        `${field} must be an ISO 8601 timestamp (got '${value}')`,
+        400,
+      );
+    }
+  }
+
   // Shared WHERE fragment so the count and page queries can't drift apart.
   let where = sql`r.organization_id = ${ctx.organizationId}`;
   if (args.run_types && args.run_types.length > 0) {
     // fetch_types:false means JS arrays aren't auto-serialized — use the
     // PG array-literal helpers (see db/client.ts).
     where = sql`${where} AND r.run_type = ANY(${pgTextArray(args.run_types)}::text[])`;
+  } else {
+    // Default operational view: hide the chat-message transport lane (complete
+    // replies + per-delta streaming fragments) that otherwise buries real run
+    // history (#2051). Naming run_types explicitly opts back in.
+    where = sql`${where} AND r.run_type <> ALL(${pgTextArray([...LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES])}::text[])`;
   }
   // connection scope: scalar connection_id (REST/SDK), an explicit id list, or
   // every connection pinned to a device.
@@ -1317,11 +1336,20 @@ async function handleListRuns(
         AND deleted_at IS NULL
     )`;
   }
+  if (args.connector_key) {
+    where = sql`${where} AND r.connector_key = ${args.connector_key}`;
+  }
   if (args.operation_key) {
     where = sql`${where} AND r.action_key = ${args.operation_key}`;
   }
   if (args.status) {
     where = sql`${where} AND r.status = ${args.status}`;
+  }
+  if (args.created_after) {
+    where = sql`${where} AND r.created_at >= ${args.created_after}::timestamptz`;
+  }
+  if (args.created_before) {
+    where = sql`${where} AND r.created_at < ${args.created_before}::timestamptz`;
   }
   if (args.approval_status) {
     where = sql`${where} AND r.approval_status = ${args.approval_status}`;

--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -15,7 +15,11 @@
  *   - statement timeout: 5s, enforced via SET LOCAL inside a transaction
  *   - hard row cap: queries returning more than MAX_ROWS rows are rejected
  *
- * Returns `{ columns: string[], rows: unknown[][] }`. Also exposed as
+ * Returns `{ columns: string[], rows: unknown[][], data_quality }`, where
+ * `data_quality` reports NULL/unparseable/out-of-range bucket timestamps
+ * against a bounded valid range (default 2000-01-01 … now+1d, overridable via
+ * `start`/`end`). `exclude_invalid_timestamps` drops the flagged rows and
+ * `strict` fails the call instead (#2051). Also exposed as
  * `client.metrics.series` in the ClientSDK and on the MCP agent surface.
  */
 
@@ -34,6 +38,38 @@ export const MetricSeriesSchema = Type.Object({
     description:
       'A single SELECT (or WITH … SELECT) returning a bucket column plus one or more numeric stat columns. Table references are auto-scoped to the caller\'s organization; `$1` is the organization id (injected — do not pass it).',
   }),
+  time_column: Type.Optional(
+    Type.String({
+      description:
+        'Name of the time-bucket column to run data-quality checks against. Defaults to the first column whose name looks temporal (bucket, time, date, *_at, …).',
+    })
+  ),
+  start: Type.Optional(
+    Type.String({
+      description:
+        'Inclusive lower bound (ISO 8601) of the valid time range for the bucket column. Buckets before this are counted as out-of-range. Default 2000-01-01T00:00:00Z.',
+    })
+  ),
+  end: Type.Optional(
+    Type.String({
+      description:
+        'Exclusive upper bound (ISO 8601) of the valid time range for the bucket column. Buckets at/after this are counted as out-of-range. Default now + 1 day.',
+    })
+  ),
+  exclude_invalid_timestamps: Type.Optional(
+    Type.Boolean({
+      default: false,
+      description:
+        'Drop rows whose bucket timestamp is NULL, unparseable, or outside the valid range instead of returning them. Counts are still reported in data_quality.',
+    })
+  ),
+  strict: Type.Optional(
+    Type.Boolean({
+      default: false,
+      description:
+        'Fail the call if any NULL/unparseable/out-of-range bucket timestamps are found.',
+    })
+  ),
 });
 
 type MetricSeriesArgs = Static<typeof MetricSeriesSchema>;
@@ -47,9 +83,57 @@ const STATEMENT_TIMEOUT_MS = 5000;
 const MAX_ROWS = 2000;
 
 
+/**
+ * Default floor of the valid bucket range. Org operational data predating 2000
+ * is, in practice, a NULL-ish sentinel (epoch timestamps from unset fields) —
+ * the production incident behind #2051 charted a 1970 bucket and future buckets
+ * through 2056 without any warning.
+ */
+const DEFAULT_RANGE_START_MS = Date.parse('2000-01-01T00:00:00Z');
+/** Default ceiling slack: buckets more than a day in the future are outliers. */
+const DEFAULT_FUTURE_SLACK_MS = 24 * 60 * 60 * 1000;
+
+/** Column names that plausibly hold the series' time bucket. */
+const TIME_COLUMN_PATTERN =
+  /^(bucket|time|date|day|week|month|hour|minute|ts|timestamp)$|(_at|_date|_time|_day|_ts|_bucket)$/i;
+
+/** Data-quality report for the detected/declared time-bucket column. */
+export interface MetricSeriesDataQuality {
+  /** Column the checks ran against; null when no temporal column was found. */
+  time_column: string | null;
+  /** Rows whose bucket value is NULL. */
+  null_timestamps: number;
+  /** Rows whose bucket value could not be parsed as a timestamp. */
+  invalid_timestamps: number;
+  /** Rows whose bucket falls outside [range.start, range.end). */
+  out_of_range: number;
+  /** Valid range the buckets were checked against. */
+  range: { start: string; end: string } | null;
+  /** True when flagged rows were dropped (exclude_invalid_timestamps). */
+  excluded: boolean;
+}
+
 interface MetricSeriesResult {
   columns: string[];
   rows: unknown[][];
+  data_quality: MetricSeriesDataQuality;
+}
+
+/**
+ * Parse a bucket cell into epoch ms. postgres.js runs with `fetch_types:false`,
+ * so timestamptz values arrive as strings like `2026-07-20 00:00:00+00`;
+ * normalize to ISO before falling back to raw Date.parse.
+ */
+function parseBucketValue(value: unknown): number | null {
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isNaN(ms) ? null : ms;
+  }
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const direct = Date.parse(value);
+  if (!Number.isNaN(direct)) return direct;
+  const normalized = Date.parse(value.replace(' ', 'T'));
+  return Number.isNaN(normalized) ? null : normalized;
 }
 
 export const metricSeries = withValidatedArgs('metric_series', MetricSeriesSchema, metricSeriesImpl);
@@ -66,6 +150,20 @@ async function metricSeriesImpl(
 
   if (!isReadQuery(args.sql)) {
     throw new ToolUserError('metric_series: only SELECT or WITH … SELECT queries are accepted');
+  }
+
+  // Resolve the valid bucket range up front so a bad bound is a clean caller
+  // error before any SQL runs.
+  const rangeStartMs = args.start != null ? Date.parse(args.start) : DEFAULT_RANGE_START_MS;
+  const rangeEndMs = args.end != null ? Date.parse(args.end) : Date.now() + DEFAULT_FUTURE_SLACK_MS;
+  if (Number.isNaN(rangeStartMs)) {
+    throw new ToolUserError(`metric_series: start must be an ISO 8601 timestamp (got '${args.start}')`);
+  }
+  if (Number.isNaN(rangeEndMs)) {
+    throw new ToolUserError(`metric_series: end must be an ISO 8601 timestamp (got '${args.end}')`);
+  }
+  if (rangeEndMs <= rangeStartMs) {
+    throw new ToolUserError('metric_series: end must be after start');
   }
 
   // Members may chart their org's operational data; the auth/identity tables
@@ -106,12 +204,76 @@ async function metricSeriesImpl(
     );
   }
 
+  const emptyQuality = (timeColumn: string | null): MetricSeriesDataQuality => ({
+    time_column: timeColumn,
+    null_timestamps: 0,
+    invalid_timestamps: 0,
+    out_of_range: 0,
+    range: timeColumn
+      ? { start: new Date(rangeStartMs).toISOString(), end: new Date(rangeEndMs).toISOString() }
+      : null,
+    excluded: false,
+  });
+
   // postgres.js returns Array<Record<column, value>>. Flatten to a tabular
   // result so the frontend doesn't have to know column order.
   if (rows.length === 0) {
-    return { columns: [], rows: [] };
+    return { columns: [], rows: [], data_quality: emptyQuality(args.time_column ?? null) };
   }
   const columns = Object.keys(rows[0]);
-  const tabular = rows.map((r) => columns.map((c) => r[c]));
-  return { columns, rows: tabular };
+
+  // Identify the bucket column: explicit `time_column` wins; otherwise the
+  // first column whose name looks temporal. Series without one (plain stat
+  // chips) skip the timestamp checks entirely.
+  let timeColumn: string | null = null;
+  if (args.time_column != null) {
+    if (!columns.includes(args.time_column)) {
+      throw new ToolUserError(
+        `metric_series: time_column '${args.time_column}' is not in the result columns (${columns.join(', ')})`
+      );
+    }
+    timeColumn = args.time_column;
+  } else {
+    timeColumn = columns.find((c) => TIME_COLUMN_PATTERN.test(c)) ?? null;
+  }
+
+  const quality = emptyQuality(timeColumn);
+  let keptRows = rows;
+  if (timeColumn) {
+    const col = timeColumn;
+    const isValidBucket = (row: Record<string, unknown>): boolean => {
+      const raw = row[col];
+      if (raw == null) {
+        quality.null_timestamps++;
+        return false;
+      }
+      const ms = parseBucketValue(raw);
+      if (ms == null) {
+        quality.invalid_timestamps++;
+        return false;
+      }
+      if (ms < rangeStartMs || ms >= rangeEndMs) {
+        quality.out_of_range++;
+        return false;
+      }
+      return true;
+    };
+    const valid = rows.filter(isValidBucket);
+    const flagged = quality.null_timestamps + quality.invalid_timestamps + quality.out_of_range;
+    if (flagged > 0 && args.strict) {
+      throw new ToolUserError(
+        `metric_series: strict mode — ${flagged} bucket timestamp(s) are NULL, unparseable, or out-of-range ` +
+          `(null: ${quality.null_timestamps}, invalid: ${quality.invalid_timestamps}, out-of-range: ${quality.out_of_range}; ` +
+          `valid range ${quality.range?.start} … ${quality.range?.end}). ` +
+          'Fix the query bounds or pass exclude_invalid_timestamps to drop them.'
+      );
+    }
+    if (args.exclude_invalid_timestamps) {
+      keptRows = valid;
+      quality.excluded = true;
+    }
+  }
+
+  const tabular = keptRows.map((r) => columns.map((c) => r[c]));
+  return { columns, rows: tabular, data_quality: quality };
 }


### PR DESCRIPTION
Partial fix for #2051 — ships the two most self-contained items (run-history noise + metrics bounds) with red→green integration tests; the rest of the issue is explicitly deferred (see below).

## Fixed

### Item 3 — operations.listRuns is too noisy
- **Streaming chunks no longer appear as top-level operational runs by default.** Every chat reply AND every non-terminal streaming delta is persisted as a `runs` row with `run_type='chat_message'` (thread_response queue lane); the default `list_runs` view now excludes that lane (`LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES` in the core contract). Passing `run_types: ['chat_message']` explicitly restores the low-level trace view — nothing is hidden, just no longer the default.
- **New filters:** `connector_key`, `created_after` / `created_before` (validated ISO bounds → clean 400 instead of a mid-query Postgres cast failure). `run_type(s)`, `operation_key`, `connection_id(s)`, `feed_id(s)`, `behavior_ids`, `status`, `approval_status` already existed on main — verified, not duplicated.
- Sandbox `client.operations.listRuns` typings + `search_sdk` metadata updated to match (behavior_ids was also missing from the sandbox typing).
- Owletto's runs UI checked: its "All" bucket omits `run_types` (now benefits from the exclusion); its explicit sync/action/auth/behavior buckets are unaffected.

### Item 4 — metrics.series unsafe default bounds
- `metric_series` now returns `{ columns, rows, data_quality }` where `data_quality` reports `null_timestamps`, `invalid_timestamps` (unparseable), and `out_of_range` bucket counts against a bounded valid range — default `2000-01-01 … now+1d`, overridable via new `start`/`end` args. This directly flags the 1970-epoch and 2056-future buckets from the incident.
- New `exclude_invalid_timestamps` mode drops flagged rows (counts still reported); new `strict` mode fails the call with a remediation message. Default behavior still returns all rows (additive — no dashboard breakage; frontend reads only `columns`/`rows`).
- Bucket column auto-detected by name heuristic or pinned via new `time_column` arg (unknown column → clean error).

## Deferred (still open on #2051)
- **Item 1 (knowledge consistency/supersession read modes, durable_at/searchable status):** partially superseded by the content_ids supersede-chain resolve already on main; the explicit read-mode surface (current/exact/lineage/audit) and indexing-completion check remain undone.
- **Item 2 (connector diagnostics error taxonomy):** empty-vs-unsupported-vs-compiler-failure distinction across connector test/query paths is a cross-cutting change (query_sql pushdown, virtual-feed execution, connection test warnings) — not attempted here; should reuse the existing AGENT_ERRORS catalog.
- **Item 5 (read latency budgets)** and **Item 6 (archive lifecycle)**: untouched.

## Test evidence (red→fix→green)
New suites, run against origin/main code first (red), then against this branch (green):
- `packages/server/src/__tests__/integration/mcp/list-runs-operational-filters.test.ts` — red on main: 5/6 failed (chat_message rows present in default list, `connector_key`/`created_after` rejected as unknown args). Green here: 6/6.
- `packages/server/src/__tests__/integration/mcp/metric-series-bounds.test.ts` — red on main: 4/6 failed (no `data_quality`, new args rejected). Green here: 6/6.

Regression suites (green): `metric-series-column-safety.test.ts` (2/2), `auth/__tests__/tool-access.test.ts` (64/64), `integration/tools/all-tools-e2e.test.ts` (29/29). `make pre-pr` clean (typecheck + knip + lint); packages/server `tsc --noEmit` clean.

make review (LLM verdict) owed — Codex limit resets 2026-07-25.

Closes nothing — #2051 stays open for the deferred items.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->