### PR TITLE
fix(sandbox): make SDK discovery match runtime contract (#2046)

### DIFF
--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -4,6 +4,7 @@ import {
 	METHOD_METADATA,
 	type MethodAccess,
 } from "../../../sandbox/method-metadata";
+import { SDK_FIELD_ALIASES } from "../../../sandbox/sdk-aliases";
 import { buildClientSDK } from "../../../sandbox/client-sdk";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
@@ -293,5 +294,95 @@ describe("method-metadata", () => {
 		const read = METHOD_METADATA["knowledge.read"];
 		expect(read.summary).toContain("content_ids");
 		expect(read.example ?? "").toContain("content_ids: [");
+	});
+
+	it("documents the exact positional signature AND the accepted object form for every positional-id method", () => {
+		// #2046: these methods take a positional id at runtime but were described
+		// like named-object methods, so discovery and runtime disagreed. Every one
+		// must now document `path(field: type)` and the `{ field }` object form the
+		// runtime also accepts.
+		const positional: Array<[string, string]> = [
+			["connections.get", "connection_id"],
+			["connections.test", "connection_id"],
+			["connections.delete", "connection_id"],
+			["connections.reauthenticate", "connection_id"],
+			["agents.get", "agent_id"],
+			["agents.delete", "agent_id"],
+			["agents.setSystemAgent", "agent_id"],
+			["entitySchema.getType", "slug"],
+			["entitySchema.getRelType", "slug"],
+			["entitySchema.auditType", "slug"],
+			["operations.getRun", "run_id"],
+			["behaviors.getVersions", "behavior_id"],
+			["authProfiles.get", "auth_profile_slug"],
+			["authProfiles.test", "auth_profile_slug"],
+			["authProfiles.delete", "auth_profile_slug"],
+		];
+		for (const [path, field] of positional) {
+			const sig = METHOD_METADATA[path]?.signature ?? "";
+			expect(sig, path).toStartWith(`${path}(${field}:`);
+			expect(sig, path).toContain(`{ ${field} }`);
+		}
+	});
+
+	it("documents the exact runtime field names for the #2046 wrong-field mismatches", () => {
+		const expectations: Array<[string, string[]]> = [
+			["schedules.update", ["id: string"]],
+			["schedules.pause", ["id: string"]],
+			["schedules.cancel", ["id: string"]],
+			["viewTemplates.rollback", ["version: number"]],
+			["behaviors.setReactionScript", ["reaction_script: string"]],
+			[
+				"notifications.send",
+				["title: string", "body?: string", "'admins' | 'all' | string[]"],
+			],
+			["connections.update", ["display_name?: string"]],
+			["classifiers.classify", ["classifier_slug: string", "'llm' | 'user'"]],
+			[
+				"classifiers.create",
+				["behavior_id: string", "attribute_values", "examples: string[]"],
+			],
+		];
+		for (const [path, fragments] of expectations) {
+			const sig = METHOD_METADATA[path]?.signature ?? "";
+			for (const fragment of fragments) {
+				expect(sig, `${path} signature documents ${fragment}`).toContain(
+					fragment,
+				);
+			}
+		}
+	});
+
+	it("documents that view-template text nodes carry their string in `content` (not `text`)", () => {
+		expect(METHOD_METADATA["viewTemplates.set"].summary).toContain(
+			"`content`",
+		);
+	});
+
+	it("exposes authProfiles.get at read tier (it returns sanitized data only)", () => {
+		// The handler serializes via serializeAuthProfile — no raw credentials or
+		// auth_data — so hiding it from query_sdk was an access-tier mismatch.
+		expect(METHOD_METADATA["authProfiles.get"].access).toBe("read");
+		// Credential-bearing siblings stay gated.
+		expect(METHOD_METADATA["authProfiles.create"].access).toBe("write");
+		expect(METHOD_METADATA["authProfiles.update"].access).toBe("write");
+		expect(METHOD_METADATA["authProfiles.test"].access).toBe("external");
+	});
+
+	it("keeps the alias registry aligned with runtime methods and their docs", () => {
+		const { namespaceMethods } = enumerateSdkMethods();
+		for (const [path, aliases] of Object.entries(SDK_FIELD_ALIASES)) {
+			expect(namespaceMethods, path).toContain(path);
+			const meta = METHOD_METADATA[path];
+			expect(meta, path).toBeDefined();
+			const doc = `${meta?.signature ?? ""} ${meta?.example ?? ""}`;
+			for (const [alias, canonical] of Object.entries(aliases)) {
+				// an alias that equals its canonical field is a registry bug
+				expect(alias, path).not.toBe(canonical);
+				expect(doc, `${path} documents canonical field ${canonical}`).toContain(
+					canonical,
+				);
+			}
+		}
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -310,10 +310,57 @@ describe("sdkSearch", () => {
 			"client.authProfiles.get('google-calendar-account')",
 		],
 		["authProfiles.update", "reconnect?: boolean", "reconnect: true"],
+		[
+			"agents.get",
+			"agents.get(agent_id: string)",
+			"client.agents.get('builder')",
+		],
+		[
+			"entitySchema.getType",
+			"entitySchema.getType(slug: string)",
+			"client.entitySchema.getType('company')",
+		],
+		[
+			"behaviors.getVersions",
+			"behaviors.getVersions(behavior_id: string)",
+			"client.behaviors.getVersions('42')",
+		],
 	])("documents the exact %s call shape", async (path, signature, example) => {
 		const result = await sdkSearch({ query: path }, stubEnv, adminCtx);
 		expect(result.match_count).toBe(1);
 		expect(result.results[0]).toContain(signature);
 		expect(result.results[0]).toContain(example);
+	});
+
+	it("renders accepted aliases from the runtime alias registry (one source)", async () => {
+		const entitiesGet = await sdkSearch(
+			{ query: "entities.get" },
+			stubEnv,
+			readCtx
+		);
+		expect(entitiesGet.results[0]).toContain(
+			"accepted aliases: id → entity_id"
+		);
+		const send = await sdkSearch(
+			{ query: "notifications.send" },
+			stubEnv,
+			writeCtx
+		);
+		expect(send.results[0]).toContain("accepted aliases: message → body");
+	});
+
+	it("exposes authProfiles.get in read mode with its exact signature", async () => {
+		// authProfiles.get returns serializeAuthProfile output (no raw
+		// credentials/auth_data) — hiding it from query_sdk was an access-tier
+		// mismatch (#2046).
+		const result = await sdkSearch(
+			{ query: "authProfiles.get", mode: "read" },
+			stubEnv,
+			readCtx
+		);
+		expect(result.match_count).toBe(1);
+		expect(result.results[0]).toContain(
+			"authProfiles.get(auth_profile_slug: string)"
+		);
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, mock } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
 
@@ -32,6 +32,15 @@ mock.module("../../../tools/admin/manage_connections", () => ({
 mock.module("../../../tools/admin/manage_auth_profiles", () => ({
 	manageAuthProfiles: captureAction,
 }));
+mock.module("../../../tools/admin/manage_agents", () => ({
+	manageAgents: captureAction,
+}));
+mock.module("../../../tools/admin/manage_operations", () => ({
+	manageOperations: captureAction,
+}));
+mock.module("../../../tools/admin/notify", () => ({
+	notify: captureAction,
+}));
 
 mock.module("../../../tools/get_behavior", () => ({
 	getBehavior: async (input: Record<string, unknown>) => {
@@ -57,6 +66,9 @@ describe("ClientSDK object signature contract", () => {
 		entitySchema: typeof import("../../../sandbox/namespaces/entity-schema").buildEntitySchemaNamespace;
 		connections: typeof import("../../../sandbox/namespaces/connections").buildConnectionsNamespace;
 		authProfiles: typeof import("../../../sandbox/namespaces/auth-profiles").buildAuthProfilesNamespace;
+		agents: typeof import("../../../sandbox/namespaces/agents").buildAgentsNamespace;
+		operations: typeof import("../../../sandbox/namespaces/operations").buildOperationsNamespace;
+		notifications: typeof import("../../../sandbox/namespaces/notifications").buildNotificationsNamespace;
 	};
 
 	beforeAll(async () => {
@@ -69,6 +81,9 @@ describe("ClientSDK object signature contract", () => {
 			entitySchema,
 			connections,
 			authProfiles,
+			agents,
+			operations,
+			notifications,
 		] = await Promise.all([
 			import("../../../sandbox/namespaces/entities"),
 			import("../../../sandbox/namespaces/feeds"),
@@ -78,6 +93,9 @@ describe("ClientSDK object signature contract", () => {
 			import("../../../sandbox/namespaces/entity-schema"),
 			import("../../../sandbox/namespaces/connections"),
 			import("../../../sandbox/namespaces/auth-profiles"),
+			import("../../../sandbox/namespaces/agents"),
+			import("../../../sandbox/namespaces/operations"),
+			import("../../../sandbox/namespaces/notifications"),
 		]);
 		builders = {
 			entities: entities.buildEntitiesNamespace,
@@ -88,7 +106,15 @@ describe("ClientSDK object signature contract", () => {
 			entitySchema: entitySchema.buildEntitySchemaNamespace,
 			connections: connections.buildConnectionsNamespace,
 			authProfiles: authProfiles.buildAuthProfilesNamespace,
+			agents: agents.buildAgentsNamespace,
+			operations: operations.buildOperationsNamespace,
+			notifications: notifications.buildNotificationsNamespace,
 		};
+	});
+
+	beforeEach(() => {
+		calls.length = 0;
+		behaviorGets.length = 0;
 	});
 
 	it("forwards named id objects instead of treating them as positional ids", async () => {
@@ -106,14 +132,14 @@ describe("ClientSDK object signature contract", () => {
 		await feeds.delete({ feed_id: 23 });
 		await classifiers.delete({ classifier_id: 31 });
 		await schedules.cancel({ id: "schedule-41" });
-		await behaviors.get({ watcher_id: "51" });
-		await behaviors.trigger({ watcher_id: "52" });
-		await behaviors.delete({ watcher_ids: ["53", "54"] });
+		await behaviors.get({ behavior_id: "51" });
+		await behaviors.trigger({ behavior_id: "52" });
+		await behaviors.delete({ behavior_ids: ["53", "54"] });
 		await entitySchema.deleteType({ slug: "company" });
 		await entitySchema.deleteRelType({ slug: "works-at" });
 		await entitySchema.listRules({ slug: "works-at" });
 
-		expect(behaviorGets).toEqual([{ watcher_id: "51" }]);
+		expect(behaviorGets).toEqual([{ behavior_id: "51" }]);
 		expect(calls).toEqual([
 			{ action: "get", input: { entity_id: 11 } },
 			{
@@ -128,8 +154,8 @@ describe("ClientSDK object signature contract", () => {
 			{ action: "delete_feed", input: { feed_id: 23 } },
 			{ action: "delete", input: { classifier_id: 31 } },
 			{ action: "cancel", input: { id: "schedule-41" } },
-			{ action: "trigger", input: { watcher_id: "52" } },
-			{ action: "delete", input: { watcher_ids: ["53", "54"] } },
+			{ action: "trigger", input: { behavior_id: "52" } },
+			{ action: "delete", input: { behavior_ids: ["53", "54"] } },
 			{
 				action: "delete",
 				input: { schema_type: "entity_type", slug: "company" },
@@ -145,23 +171,134 @@ describe("ClientSDK object signature contract", () => {
 		]);
 	});
 
-	it("explains positional connection and auth-profile arguments", async () => {
+	it("rewrites documented field aliases to the canonical runtime fields", async () => {
+		const entities = builders.entities(ctx, env);
+		const feeds = builders.feeds(ctx, env);
+		const schedules = builders.schedules(ctx, env);
+		const behaviors = builders.behaviors(ctx, env);
+		const connections = builders.connections(ctx, env);
+		const notifications = builders.notifications(ctx, env);
+
+		await entities.get({ id: 11 } as never);
+		await entities.delete({ id: 12 } as never);
+		await feeds.get({ id: 21 } as never);
+		await schedules.update({ schedule_id: "s-1", description: "d" } as never);
+		await schedules.pause({ schedule_id: "s-2" } as never);
+		await schedules.cancel({ schedule_id: "s-3" } as never);
+		await behaviors.setReactionScript({
+			behavior_id: "42",
+			script: "export default async () => {};",
+		} as never);
+		await connections.update({ connection_id: 9, name: "Renamed" } as never);
+		await notifications.send({ title: "T", message: "hello" } as never);
+
+		expect(calls).toEqual([
+			{ action: "get", input: { entity_id: 11 } },
+			{ action: "delete", input: { entity_id: 12 } },
+			{ action: "read_feed", input: { feed_id: 21 } },
+			{ action: "update", input: { id: "s-1", description: "d" } },
+			{ action: "pause", input: { id: "s-2" } },
+			{ action: "cancel", input: { id: "s-3" } },
+			{
+				action: "set_reaction_script",
+				input: {
+					behavior_id: "42",
+					reaction_script: "export default async () => {};",
+				},
+			},
+			{ action: "update", input: { connection_id: 9, display_name: "Renamed" } },
+			{ action: "send", input: { title: "T", body: "hello" } },
+		]);
+	});
+
+	it("lets the canonical field win when both alias and canonical are supplied", async () => {
+		const entities = builders.entities(ctx, env);
+		await entities.get({ id: 99, entity_id: 11 } as never);
+		expect(calls).toEqual([{ action: "get", input: { entity_id: 11 } }]);
+	});
+
+	it("accepts the canonical single-field object form on positional methods", async () => {
+		const connections = builders.connections(ctx, env);
+		const authProfiles = builders.authProfiles(ctx, env);
+		const agents = builders.agents(ctx, env);
+		const entitySchema = builders.entitySchema(ctx, env);
+		const operations = builders.operations(ctx, env);
+		const behaviors = builders.behaviors(ctx, env);
+
+		await connections.get({ connection_id: 418 } as never);
+		await connections.test({ connection_id: 419 } as never);
+		await connections.delete({ connection_id: 420 } as never);
+		await connections.reauthenticate({ connection_id: 421 } as never);
+		await authProfiles.get({ auth_profile_slug: "acct" } as never);
+		await agents.get({ agent_id: "builder" } as never);
+		await agents.delete({ agent_id: "builder" } as never);
+		await entitySchema.getType({ slug: "company" } as never);
+		await entitySchema.getRelType({ slug: "works-at" } as never);
+		await entitySchema.auditType({ slug: "company" } as never);
+		await operations.getRun({ run_id: 7 } as never);
+		await behaviors.getVersions({ behavior_id: "42" } as never);
+
+		expect(calls).toEqual([
+			{ action: "get", input: { connection_id: 418 } },
+			{ action: "test", input: { connection_id: 419 } },
+			{ action: "delete", input: { connection_id: 420 } },
+			{ action: "reauthenticate", input: { connection_id: 421 } },
+			{ action: "get_auth_profile", input: { auth_profile_slug: "acct" } },
+			{ action: "get", input: { agent_id: "builder" } },
+			{ action: "delete", input: { agent_id: "builder" } },
+			{ action: "get", input: { schema_type: "entity_type", slug: "company" } },
+			{
+				action: "get",
+				input: { schema_type: "relationship_type", slug: "works-at" },
+			},
+			{ action: "audit", input: { schema_type: "entity_type", slug: "company" } },
+			{ action: "get_run", input: { run_id: 7 } },
+			{ action: "get_versions", input: { behavior_id: "42" } },
+		]);
+	});
+
+	it("still accepts the positional form on those methods", async () => {
+		const connections = builders.connections(ctx, env);
+		const agents = builders.agents(ctx, env);
+		const entitySchema = builders.entitySchema(ctx, env);
+		const operations = builders.operations(ctx, env);
+		const behaviors = builders.behaviors(ctx, env);
+
+		await connections.get(1);
+		await agents.get("builder");
+		await entitySchema.getType("company");
+		await operations.getRun(7);
+		await behaviors.getVersions("42");
+
+		expect(calls).toEqual([
+			{ action: "get", input: { connection_id: 1 } },
+			{ action: "get", input: { agent_id: "builder" } },
+			{ action: "get", input: { schema_type: "entity_type", slug: "company" } },
+			{ action: "get_run", input: { run_id: 7 } },
+			{ action: "get_versions", input: { behavior_id: "42" } },
+		]);
+	});
+
+	it("rejects unrecognized shapes with guidance naming both accepted forms", async () => {
 		const connections = builders.connections(ctx, env);
 		const authProfiles = builders.authProfiles(ctx, env);
 
-		// Placeholders are neutral (`<connection_id>`, `<auth_profile_slug>`), NOT
-		// real-looking ids — a fresh agent must not copy a fabricated id verbatim.
-		await expect(
-			connections.reauthenticate({ connection_id: 418 } as never)
-		).rejects.toThrow(
-			"connections.reauthenticate expects a positional number. Call client.connections.reauthenticate(<connection_id>); do not pass an object."
+		// Placeholders are neutral (`<connection_id>`), NOT real-looking ids — a
+		// fresh agent must not copy a fabricated id verbatim.
+		await expect(connections.get(true as never)).rejects.toThrow(
+			"connections.get expects the connection_id. Call client.connections.get(<connection_id>) or client.connections.get({ connection_id: <connection_id> }).",
 		);
+		// A wrong field name inside the object form still fails with the guidance.
+		await expect(
+			connections.reauthenticate({ id: 418 } as never),
+		).rejects.toThrow("client.connections.reauthenticate({ connection_id:");
+		// Extra keys in the object form are rejected, never silently dropped.
 		await expect(
 			authProfiles.get({
-				auth_profile_slug: "google-calendar-account",
-			} as never)
-		).rejects.toThrow(
-			"authProfiles.get expects a positional string. Call client.authProfiles.get('<auth_profile_slug>'); do not pass an object."
-		);
+				auth_profile_slug: "acct",
+				verbose: true,
+			} as never),
+		).rejects.toThrow("client.authProfiles.get({ auth_profile_slug:");
+		expect(calls).toEqual([]);
 	});
 });

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -201,6 +201,9 @@ export default async (_ctx, client) => {
 	"entitySchema.getType": {
 		summary: "Get an entity type by slug.",
 		access: "read",
+		signature:
+			"entitySchema.getType(slug: string): Promise<unknown> // or entitySchema.getType({ slug })",
+		example: "const t = await client.entitySchema.getType('company');",
 	},
 	"entitySchema.createType": {
 		summary:
@@ -221,6 +224,9 @@ export default async (_ctx, client) => {
 	"entitySchema.auditType": {
 		summary: "List historical changes to an entity type.",
 		access: "read",
+		signature:
+			"entitySchema.auditType(slug: string): Promise<unknown> // or entitySchema.auditType({ slug })",
+		example: "const audit = await client.entitySchema.auditType('company');",
 	},
 	"entitySchema.listRelTypes": {
 		summary:
@@ -232,6 +238,9 @@ export default async (_ctx, client) => {
 	"entitySchema.getRelType": {
 		summary: "Get a relationship type by slug.",
 		access: "read",
+		signature:
+			"entitySchema.getRelType(slug: string): Promise<unknown> // or entitySchema.getRelType({ slug })",
+		example: "const t = await client.entitySchema.getRelType('works-at');",
 	},
 	"entitySchema.createRelType": {
 		summary: "Create a relationship type.",
@@ -320,6 +329,8 @@ export default async (_ctx, client) => {
 		summary:
 			"Fetch one agent by id when agent_config read allows that target. Org-read gated via requireOrgReadAccess.",
 		access: "read",
+		signature:
+			"agents.get(agent_id: string): Promise<unknown> // or agents.get({ agent_id })",
 		example: "const { agent } = await client.agents.get('builder');",
 	},
 	"agents.create": {
@@ -338,10 +349,15 @@ export default async (_ctx, client) => {
 		summary:
 			"Delete an agent (may queue for approval). Requires admin tier + agent_config delete.",
 		access: "admin",
+		signature:
+			"agents.delete(agent_id: string): Promise<unknown> // or agents.delete({ agent_id })",
+		example: "await client.agents.delete('researcher');",
 	},
 	"agents.setSystemAgent": {
 		summary: "Point organization.system_agent_id at an agent. Requires admin.",
 		access: "admin",
+		signature:
+			"agents.setSystemAgent(agent_id: string): Promise<unknown> // or agents.setSystemAgent({ agent_id })",
 		example: "await client.agents.setSystemAgent('builder');",
 	},
 
@@ -422,16 +438,26 @@ export default async (_ctx, client) => {
 	},
 	"schedules.update": {
 		summary:
-			"Patch a schedule (next run, cron, wake_agent prompt). Requires admin.",
+			"Patch a schedule (next run, cron, wake_agent prompt). The schedule is addressed by `id` (not `schedule_id`). Requires admin.",
 		access: "admin",
+		signature:
+			"schedules.update(input: { id: string; description?: string; run_at?: string; cron?: string | null; prompt?: string; model?: string }): Promise<unknown>",
+		example:
+			"await client.schedules.update({ id: 'schedule-id', run_at: '2026-07-22T09:00:00Z' });",
 	},
 	"schedules.pause": {
-		summary: "Pause or resume a schedule. Requires admin.",
+		summary:
+			"Pause or resume a schedule, addressed by `id` (not `schedule_id`). Requires admin.",
 		access: "admin",
+		signature:
+			"schedules.pause(input: { id: string; paused?: boolean }): Promise<unknown>",
+		example: "await client.schedules.pause({ id: 'schedule-id' });",
 	},
 	"schedules.cancel": {
-		summary: "Permanently delete a schedule. Requires admin.",
+		summary:
+			"Permanently delete a schedule, addressed by `id` (not `schedule_id`). Requires admin.",
 		access: "admin",
+		signature: "schedules.cancel(input: { id: string }): Promise<unknown>",
 		example: "await client.schedules.cancel({ id: 'schedule-id' });",
 	},
 
@@ -440,6 +466,8 @@ export default async (_ctx, client) => {
 		summary:
 			"Send a notification to org users. Writes an `agent_message` notification (in-app inbox) and fans it out to the org's active bot connections (Slack/Telegram) — the way a Behavior reaction surfaces its digest to a chat channel. Pass an optional `card` (a `chat` CardElement) for rich cross-platform rendering, and `behavior_source` when firing from a reaction.",
 		access: "write",
+		signature:
+			"notifications.send(input: { title: string; body?: string; card?: CardElement; recipients?: 'admins' | 'all' | string[]; resource_url?: string; connection_id?: string; data?: object; behavior_source?: { behavior_id: number; window_id: number } }): Promise<{ notified_count: number }>",
 		example:
 			"await client.notifications.send({ title: 'Weekly funnel digest', body: '3 new leads...', behavior_source: { behavior_id: ctx.window.behavior_id, window_id: ctx.window.id } });",
 		usageExample: `// Push a Behavior digest to the org's Slack/Telegram connections + inbox.
@@ -531,8 +559,12 @@ export default async (_ctx, client) => {
 	},
 	"behaviors.setReactionScript": {
 		summary:
-			"Attach a raw TS reaction script (fires on window completion). Empty string removes it.",
+			"Attach a raw TS reaction script (fires on window completion). The source goes in `reaction_script`; empty string removes it.",
 		access: "admin",
+		signature:
+			"behaviors.setReactionScript(input: { behavior_id: string; reaction_script: string }): Promise<unknown>",
+		example:
+			"await client.behaviors.setReactionScript({ behavior_id: '42', reaction_script: 'export default async (ctx, client) => { /* … */ };' });",
 		throws: ["CompileError"],
 	},
 	"behaviors.completeWindow": {
@@ -543,6 +575,9 @@ export default async (_ctx, client) => {
 	"behaviors.getVersions": {
 		summary: "List template versions for a Behavior.",
 		access: "read",
+		signature:
+			"behaviors.getVersions(behavior_id: string): Promise<unknown> // or behaviors.getVersions({ behavior_id })",
+		example: "const versions = await client.behaviors.getVersions('42');",
 	},
 	"behaviors.getVersionDetails": {
 		summary: "Fetch a specific Behavior template version.",
@@ -593,7 +628,8 @@ export default async (_ctx, client) => {
 	"connections.get": {
 		summary: "Get a connection by id.",
 		access: "read",
-		signature: "connections.get(connection_id: number): Promise<unknown>",
+		signature:
+			"connections.get(connection_id: number): Promise<unknown> // or connections.get({ connection_id })",
 		example: "await client.connections.get(42);",
 	},
 	"connections.create": {
@@ -627,13 +663,19 @@ export default async (_ctx, client) => {
 };`,
 	},
 	"connections.update": {
-		summary: "Update connection config or auth profile.",
+		summary:
+			"Update connection config or auth profile. The label field is `display_name` (not `name`).",
 		access: "write",
+		signature:
+			"connections.update(input: { connection_id: number; display_name?: string; slug?: string; status?: string; agent_id?: string | null; auth_profile_slug?: string | null; app_auth_profile_slug?: string | null; config?: object; entity_ids?: number[] }): Promise<unknown>",
+		example:
+			"await client.connections.update({ connection_id: 42, display_name: 'Team calendar' });",
 	},
 	"connections.delete": {
 		summary: "Delete a connection.",
 		access: "admin",
-		signature: "connections.delete(connection_id: number): Promise<unknown>",
+		signature:
+			"connections.delete(connection_id: number): Promise<unknown> // or connections.delete({ connection_id })",
 		example: "await client.connections.delete(42);",
 	},
 	"connections.reauthenticate": {
@@ -641,13 +683,14 @@ export default async (_ctx, client) => {
 			"Start a fresh auth flow for an existing OAuth-account or interactive connection. Returns connect_url for OAuth or auth_run_id for interactive pairing.",
 		access: "write",
 		signature:
-			"connections.reauthenticate(connection_id: number): Promise<unknown>",
+			"connections.reauthenticate(connection_id: number): Promise<unknown> // or connections.reauthenticate({ connection_id })",
 		example: "await client.connections.reauthenticate(42);",
 	},
 	"connections.test": {
 		summary: "Test connection credentials (sends an external probe).",
 		access: "external",
-		signature: "connections.test(connection_id: number): Promise<unknown>",
+		signature:
+			"connections.test(connection_id: number): Promise<unknown> // or connections.test({ connection_id })",
 		example: "await client.connections.test(42);",
 	},
 	"connections.installConnector": {
@@ -701,7 +744,8 @@ export default async (_ctx, client) => {
 	"operations.getRun": {
 		summary: "Get a single run by id.",
 		access: "read",
-		signature: "operations.getRun(run_id: number): Promise<unknown>",
+		signature:
+			"operations.getRun(run_id: number): Promise<unknown> // or operations.getRun({ run_id })",
 		example: "const run = await client.operations.getRun(123);",
 	},
 	"operations.approve": {
@@ -774,15 +818,18 @@ export default async (_ctx, client) => {
 			"authProfiles.list(input?: { connector_key?: string; provider?: string; profile_kind?: AuthProfileKind }): Promise<unknown> // not paginated",
 	},
 	"authProfiles.get": {
-		summary: "Get an auth profile by slug.",
-		access: "admin",
-		signature: "authProfiles.get(auth_profile_slug: string): Promise<unknown>",
+		summary:
+			"Get an auth profile by slug. Returns the sanitized serialization only — never raw credentials or auth_data.",
+		access: "read",
+		signature:
+			"authProfiles.get(auth_profile_slug: string): Promise<unknown> // or authProfiles.get({ auth_profile_slug })",
 		example: "await client.authProfiles.get('google-calendar-account');",
 	},
 	"authProfiles.test": {
 		summary: "Test auth-profile credentials.",
 		access: "external",
-		signature: "authProfiles.test(auth_profile_slug: string): Promise<unknown>",
+		signature:
+			"authProfiles.test(auth_profile_slug: string): Promise<unknown> // or authProfiles.test({ auth_profile_slug })",
 		example: "await client.authProfiles.test('google-calendar-account');",
 	},
 	"authProfiles.create": {
@@ -802,7 +849,7 @@ export default async (_ctx, client) => {
 		summary: "Delete an auth profile.",
 		access: "write",
 		signature:
-			"authProfiles.delete(auth_profile_slug: string, options?: { force?: boolean }): Promise<unknown>",
+			"authProfiles.delete(auth_profile_slug: string, options?: { force?: boolean }): Promise<unknown> // or authProfiles.delete({ auth_profile_slug })",
 		example: "await client.authProfiles.delete('google-calendar-account');",
 	},
 
@@ -818,8 +865,13 @@ export default async (_ctx, client) => {
 			"classifiers.list(input?: { entity_id?: number; status?: string }): Promise<unknown> // not paginated",
 	},
 	"classifiers.create": {
-		summary: "Create a classifier template.",
+		summary:
+			"Create a classifier template. REQUIRES `behavior_id` (the owning Behavior) plus `slug`, `name`, and `attribute_key`. `attribute_values` is an OBJECT keyed by value slug — each entry needs a `description` and `examples` (string array), not a flat list.",
 		access: "admin",
+		signature:
+			"classifiers.create(input: { slug: string; name: string; attribute_key: string; behavior_id: string; attribute_values?: Record<string, { description: string; examples: string[] }>; entity_id?: number; min_similarity?: number; fallback_value?: unknown; description?: string }): Promise<unknown>",
+		example:
+			"await client.classifiers.create({ slug: 'sentiment', name: 'Sentiment', attribute_key: 'sentiment', behavior_id: '42', attribute_values: { positive: { description: 'Positive tone', examples: ['Great work!'] } } });",
 	},
 	"classifiers.generateEmbeddings": {
 		summary: "Generate embeddings for attribute values (cost-heavy).",
@@ -833,8 +885,12 @@ export default async (_ctx, client) => {
 	},
 	"classifiers.classify": {
 		summary:
-			"Apply a manual classification to one or many content records (single or batch).",
+			"Apply a manual classification to one or many content records (single or batch). The classifier is addressed by `classifier_slug` (a string — NOT the numeric `classifier_id` other CRUD methods use); `source` accepts only 'llm' or 'user'.",
 		access: "admin",
+		signature:
+			"classifiers.classify(input: { classifier_slug: string; content_id?: number; value?: string | null; reasoning?: string; classifications?: Array<{ content_id: number; value: string | null; reasoning?: string }>; source?: 'llm' | 'user' }): Promise<unknown>",
+		example:
+			"await client.classifiers.classify({ classifier_slug: 'sentiment', content_id: 101, value: 'positive', source: 'user' });",
 	},
 
 	// viewTemplates
@@ -851,14 +907,19 @@ export default async (_ctx, client) => {
 	},
 	"viewTemplates.set": {
 		summary:
-			"Create or update a view template version. Params: { resource_type: 'entity' | 'entity_type', resource_id, json_template, tab_name?, tab_order?, change_notes? }. json_template is a DSL node tree (nodes: text | data | if | each | component; a `data` node takes an optional `format`: currency|date|url|enum|boolean|number|auto|text) and may nest a `data_sources` key of named read-only SQL queries. The node tree is validated on set — a malformed template is rejected, not stored.",
+			"Create or update a view template version. Params: { resource_type: 'entity' | 'entity_type', resource_id, json_template, tab_name?, tab_order?, change_notes? }. json_template is a DSL node tree (nodes: text | data | if | each | component; a `text` node carries its string in `content` — not `text`; a `data` node takes an optional `format`: currency|date|url|enum|boolean|number|auto|text) and may nest a `data_sources` key of named read-only SQL queries. The node tree is validated on set — a malformed template is rejected, not stored.",
 		access: "admin",
 		example:
 			"await client.viewTemplates.set({ resource_type: 'entity_type', resource_id: 'deal', tab_name: 'Pipeline', json_template: { type: 'div', data_sources: { rows: { query: \"SELECT name, metadata->>'arr' AS arr FROM entities WHERE entity_type = 'deal'\" } }, children: [ { type: 'each', items: 'rows', as: 'r', render: { type: 'card', children: [ { type: 'data', path: 'r.name' }, { type: 'data', path: 'r.arr', format: 'currency' } ] } } ] } });",
 	},
 	"viewTemplates.rollback": {
-		summary: "Roll back to a previous template version.",
+		summary:
+			"Roll back to a previous template version. Takes `version` — the version NUMBER, not a `version_id` row id.",
 		access: "admin",
+		signature:
+			"viewTemplates.rollback(input: { resource_type: 'entity' | 'entity_type'; resource_id: string | number; version: number; tab_name?: string }): Promise<unknown>",
+		example:
+			"await client.viewTemplates.rollback({ resource_type: 'entity_type', resource_id: 'deal', version: 3 });",
 	},
 	"viewTemplates.removeTab": {
 		summary: "Remove a named tab from a template.",

--- a/packages/server/src/sandbox/namespaces/action-call.ts
+++ b/packages/server/src/sandbox/namespaces/action-call.ts
@@ -1,6 +1,7 @@
 import type { Env } from "../../index";
 import type { ToolContext } from "../../tools/registry";
 import { ToolUserError } from "../../utils/errors";
+import { applyFieldAliases } from "../sdk-aliases";
 
 type AdminHandler = (args: any, env: Env, ctx: ToolContext) => Promise<unknown>;
 
@@ -26,25 +27,36 @@ export class ClientSdkActionError extends ToolUserError {
 	}
 }
 
-export function requirePositionalNumber(
+/**
+ * Resolve a single-id argument for a method documented as
+ * `path(field: type)` — the canonical positional form — while also accepting
+ * the intuitive object form `path({ field: value })` (#2046 contract-alias
+ * window). The object form is strict: exactly the canonical field, no extra
+ * keys, so options are never silently dropped. Anything else fails with
+ * guidance naming BOTH accepted call shapes and a neutral placeholder (never
+ * a real-looking id an agent might copy verbatim).
+ */
+export function idArg(
 	method: string,
+	field: string,
 	value: unknown,
-	example: string,
-): number {
-	if (typeof value === "number" && Number.isFinite(value)) return value;
+	kind: "number" | "string",
+): number | string {
+	const matches = (v: unknown): boolean =>
+		kind === "number"
+			? typeof v === "number" && Number.isFinite(v)
+			: typeof v === "string";
+	if (matches(value)) return value as number | string;
+	if (value && typeof value === "object" && !Array.isArray(value)) {
+		const record = value as Record<string, unknown>;
+		const keys = Object.keys(record);
+		if (keys.length === 1 && keys[0] === field && matches(record[field])) {
+			return record[field] as number | string;
+		}
+	}
+	const placeholder = kind === "number" ? `<${field}>` : `'<${field}>'`;
 	throw new ToolUserError(
-		`${method} expects a positional number. Call ${example}; do not pass an object.`,
-	);
-}
-
-export function requirePositionalString(
-	method: string,
-	value: unknown,
-	example: string,
-): string {
-	if (typeof value === "string") return value;
-	throw new ToolUserError(
-		`${method} expects a positional string. Call ${example}; do not pass an object.`,
+		`${method} expects the ${field}. Call client.${method}(${placeholder}) or client.${method}({ ${field}: ${placeholder} }).`,
 	);
 }
 
@@ -176,9 +188,14 @@ export function createActionCaller(
 		// `action` key (e.g. from a read-only query_sdk script) can never override
 		// the discriminator and reach a write/delete handler.
 		const { action: _ignored, ...rest } = input as Record<string, unknown>;
+		// Rewrite accepted field aliases (sdk-aliases.ts) to their canonical
+		// names — the same registry search_sdk renders, so discovery == runtime.
+		const canonical = sdkNamespace
+			? applyFieldAliases(`${sdkNamespace}.${publicMethod}`, rest)
+			: rest;
 		let result: T;
 		try {
-			result = await manage<T>({ ...rest, action: actionName });
+			result = await manage<T>({ ...canonical, action: actionName });
 		} catch (err) {
 			throw rewriteInternalToolName(err, sdkNamespace, publicMethod);
 		}

--- a/packages/server/src/sandbox/namespaces/agents.ts
+++ b/packages/server/src/sandbox/namespaces/agents.ts
@@ -5,7 +5,7 @@
 import type { Env } from "../../index";
 import { manageAgents } from "../../tools/admin/manage_agents";
 import type { ToolContext } from "../../tools/registry";
-import { createActionCaller } from "./action-call";
+import { createActionCaller, idArg } from "./action-call";
 
 export interface AgentsCreateInput {
 	agent_id: string;
@@ -40,11 +40,24 @@ export function buildAgentsNamespace(
 	return {
 		manage,
 		list: () => action("list", {}),
-		get: (agent_id) => action("get", { agent_id }),
+		get: (agent_id) =>
+			action("get", {
+				agent_id: idArg("agents.get", "agent_id", agent_id, "string"),
+			}),
 		create: (input) => action("create", input),
 		update: (input) => action("update", input),
-		delete: (agent_id) => action("delete", { agent_id }),
+		delete: (agent_id) =>
+			action("delete", {
+				agent_id: idArg("agents.delete", "agent_id", agent_id, "string"),
+			}),
 		setSystemAgent: (agent_id) =>
-			action("set_system_agent", { agent_id }),
+			action("set_system_agent", {
+				agent_id: idArg(
+					"agents.setSystemAgent",
+					"agent_id",
+					agent_id,
+					"string",
+				),
+			}),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/auth-profiles.ts
+++ b/packages/server/src/sandbox/namespaces/auth-profiles.ts
@@ -15,7 +15,7 @@ import type { Env } from "../../index";
 import { manageAuthProfiles } from "../../tools/admin/manage_auth_profiles";
 import type { ToolContext } from "../../tools/registry";
 import type { AuthProfileKind as StoredAuthProfileKind } from "../../utils/auth-profiles";
-import { createActionCaller, requirePositionalString } from "./action-call";
+import { createActionCaller, idArg } from "./action-call";
 
 /** Kinds manageable through the SDK — the stored kinds minus the internal-only `interactive`. */
 export type AuthProfileKind = Exclude<StoredAuthProfileKind, "interactive">;
@@ -79,10 +79,11 @@ export function buildAuthProfilesNamespace(
 			action(
 				"get_auth_profile",
 				{
-					auth_profile_slug: requirePositionalString(
+					auth_profile_slug: idArg(
 						"authProfiles.get",
+						"auth_profile_slug",
 						auth_profile_slug,
-						"client.authProfiles.get('<auth_profile_slug>')",
+						"string",
 					),
 				},
 				"get",
@@ -91,10 +92,11 @@ export function buildAuthProfilesNamespace(
 			action(
 				"test_auth_profile",
 				{
-					auth_profile_slug: requirePositionalString(
+					auth_profile_slug: idArg(
 						"authProfiles.test",
+						"auth_profile_slug",
 						auth_profile_slug,
-						"client.authProfiles.test('<auth_profile_slug>')",
+						"string",
 					),
 				},
 				"test",
@@ -105,10 +107,11 @@ export function buildAuthProfilesNamespace(
 			action(
 				"delete_auth_profile",
 				{
-					auth_profile_slug: requirePositionalString(
+					auth_profile_slug: idArg(
 						"authProfiles.delete",
+						"auth_profile_slug",
 						auth_profile_slug,
-						"client.authProfiles.delete('<auth_profile_slug>')",
+						"string",
 					),
 					...options,
 				},

--- a/packages/server/src/sandbox/namespaces/behaviors.ts
+++ b/packages/server/src/sandbox/namespaces/behaviors.ts
@@ -20,7 +20,7 @@ import {
 } from "../../tools/admin/manage_behaviors";
 import { getBehavior } from "../../tools/get_behavior";
 import type { ToolContext } from "../../tools/registry";
-import { createActionCaller } from "./action-call";
+import { createActionCaller, idArg } from "./action-call";
 
 type BehaviorId = string;
 type BehaviorActionInput = Omit<ManageBehaviorsArgs, "action" | "behavior_id"> & {
@@ -166,7 +166,15 @@ export function buildBehaviorsNamespace(
 		trigger: (input) => action("trigger", input),
 		delete: (input) => action("delete", input),
 		setReactionScript: (input) => action("set_reaction_script", input),
-		getVersions: (behavior_id) => action("get_versions", { behavior_id }),
+		getVersions: (behavior_id) =>
+			action("get_versions", {
+				behavior_id: idArg(
+					"behaviors.getVersions",
+					"behavior_id",
+					behavior_id,
+					"string",
+				),
+			}),
 		getVersionDetails: (input) =>
 			action("get_version_details", normalizeVersionDetailsInput(input)),
 		getComponentReference: () => action("get_component_reference"),

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -16,7 +16,7 @@ import type {
 import type { Env } from "../../index";
 import { manageConnections } from "../../tools/admin/manage_connections";
 import type { ToolContext } from "../../tools/registry";
-import { createActionCaller, requirePositionalNumber } from "./action-call";
+import { createActionCaller, idArg } from "./action-call";
 
 export type ConnectionsConnectInput = ConnectionConnectInput;
 export type ConnectionsCreateInput = ConnectionCreateInput;
@@ -79,10 +79,11 @@ export function buildConnectionsNamespace(
 		list: (input) => action("list", input),
 		get: async (connection_id) =>
 			action("get", {
-				connection_id: requirePositionalNumber(
+				connection_id: idArg(
 					"connections.get",
+					"connection_id",
 					connection_id,
-					"client.connections.get(<connection_id>)",
+					"number",
 				),
 			}),
 		create: (input) => action("create", input),
@@ -90,26 +91,29 @@ export function buildConnectionsNamespace(
 		update: (input) => action("update", input),
 		delete: async (connection_id) =>
 			action("delete", {
-				connection_id: requirePositionalNumber(
+				connection_id: idArg(
 					"connections.delete",
+					"connection_id",
 					connection_id,
-					"client.connections.delete(<connection_id>)",
+					"number",
 				),
 			}),
 		reauthenticate: async (connection_id) =>
 			action("reauthenticate", {
-				connection_id: requirePositionalNumber(
+				connection_id: idArg(
 					"connections.reauthenticate",
+					"connection_id",
 					connection_id,
-					"client.connections.reauthenticate(<connection_id>)",
+					"number",
 				),
 			}),
 		test: async (connection_id) =>
 			action("test", {
-				connection_id: requirePositionalNumber(
+				connection_id: idArg(
 					"connections.test",
+					"connection_id",
 					connection_id,
-					"client.connections.test(<connection_id>)",
+					"number",
 				),
 			}),
 		installConnector: (input) =>

--- a/packages/server/src/sandbox/namespaces/entity-schema.ts
+++ b/packages/server/src/sandbox/namespaces/entity-schema.ts
@@ -11,7 +11,7 @@
 import type { Env } from "../../index";
 import { manageEntitySchema } from "../../tools/admin/manage_entity_schema";
 import type { ToolContext } from "../../tools/registry";
-import { createActionCaller } from "./action-call";
+import { createActionCaller, idArg } from "./action-call";
 
 export interface EntitySchemaAddRuleInput {
 	slug: string;
@@ -112,14 +112,35 @@ export function buildEntitySchemaNamespace(
 	return {
 		manage,
 		listTypes: (input) => callEntity({ action: "list", ...input }, "listTypes"),
-		getType: (slug) => callEntity({ action: "get", slug }, "getType"),
+		getType: (slug) =>
+			callEntity(
+				{
+					action: "get",
+					slug: idArg("entitySchema.getType", "slug", slug, "string"),
+				},
+				"getType",
+			),
 		createType: (input) => callEntity({ action: "create", ...input }, "createType"),
 		updateType: (input) => callEntity({ action: "update", ...input }, "updateType"),
 		deleteType: (input) => callEntity({ action: "delete", ...input }, "deleteType"),
-		auditType: (slug) => callEntity({ action: "audit", slug }, "auditType"),
+		auditType: (slug) =>
+			callEntity(
+				{
+					action: "audit",
+					slug: idArg("entitySchema.auditType", "slug", slug, "string"),
+				},
+				"auditType",
+			),
 
 		listRelTypes: (input) => callRel({ action: "list", ...input }, "listRelTypes"),
-		getRelType: (slug) => callRel({ action: "get", slug }, "getRelType"),
+		getRelType: (slug) =>
+			callRel(
+				{
+					action: "get",
+					slug: idArg("entitySchema.getRelType", "slug", slug, "string"),
+				},
+				"getRelType",
+			),
 		createRelType: (input) => callRel({ action: "create", ...input }, "createRelType"),
 		updateRelType: (input) => callRel({ action: "update", ...input }, "updateRelType"),
 		deleteRelType: (input) => callRel({ action: "delete", ...input }, "deleteRelType"),

--- a/packages/server/src/sandbox/namespaces/operations.ts
+++ b/packages/server/src/sandbox/namespaces/operations.ts
@@ -8,7 +8,7 @@
 import type { Env } from "../../index";
 import { manageOperations } from "../../tools/admin/manage_operations";
 import type { ToolContext } from "../../tools/registry";
-import { createActionCaller } from "./action-call";
+import { createActionCaller, idArg } from "./action-call";
 
 export interface OperationsExecuteInput {
 	connection_id: number;
@@ -76,7 +76,12 @@ export function buildOperationsNamespace(
 		listAvailable: (input) => action("list_available", input, "listAvailable"),
 		execute: (input) => action("execute", input, "execute"),
 		listRuns: (input) => action("list_runs", input, "listRuns"),
-		getRun: (run_id) => action("get_run", { run_id }, "getRun"),
+		getRun: (run_id) =>
+			action(
+				"get_run",
+				{ run_id: idArg("operations.getRun", "run_id", run_id, "number") },
+				"getRun",
+			),
 		approve: (input) => action("approve", input, "approve"),
 		reject: (input) => action("reject", input, "reject"),
 	};

--- a/packages/server/src/sandbox/sdk-aliases.ts
+++ b/packages/server/src/sandbox/sdk-aliases.ts
@@ -1,0 +1,50 @@
+/**
+ * Accepted input-field aliases for ClientSDK methods, keyed by public dotted
+ * path. ONE source: the sandbox dispatch layer (`createActionCaller`) rewrites
+ * these at runtime, and `search_sdk` renders the same table into discovery —
+ * so the documented aliases can never drift from what the runtime accepts.
+ *
+ * Only clean, unambiguous renames belong here (an alias must mean exactly the
+ * canonical field, never a different concept). The canonical field always wins
+ * when both are supplied.
+ */
+
+export const SDK_FIELD_ALIASES: Readonly<
+	Record<string, Readonly<Record<string, string>>>
+> = {
+	// intuitive `id` for the entity/feed id field
+	"entities.get": { id: "entity_id" },
+	"entities.delete": { id: "entity_id" },
+	"feeds.get": { id: "feed_id" },
+	// schedules use plain `id`; callers guess `schedule_id`
+	"schedules.update": { schedule_id: "id" },
+	"schedules.pause": { schedule_id: "id" },
+	"schedules.cancel": { schedule_id: "id" },
+	// runtime field is `reaction_script`; callers guess `script`
+	"behaviors.setReactionScript": { script: "reaction_script" },
+	// runtime field is `body`; callers guess `message`
+	"notifications.send": { message: "body" },
+	// runtime field is `display_name`; callers guess `name`
+	"connections.update": { name: "display_name" },
+};
+
+/**
+ * Rewrite accepted alias fields to their canonical names for one method path.
+ * The canonical field wins when both are present (the alias is then dropped);
+ * inputs without aliases pass through unchanged.
+ */
+export function applyFieldAliases(
+	path: string,
+	input: Record<string, unknown>,
+): Record<string, unknown> {
+	const aliases = SDK_FIELD_ALIASES[path];
+	if (!aliases) return input;
+	let out: Record<string, unknown> | null = null;
+	for (const [alias, canonical] of Object.entries(aliases)) {
+		if (!(alias in input)) continue;
+		out ??= { ...input };
+		if (!(canonical in out)) out[canonical] = out[alias];
+		delete out[alias];
+	}
+	return out ?? input;
+}

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -18,6 +18,7 @@ import {
 	RUNTIME_HELPER_METADATA,
 	type MethodMetadata,
 } from "../sandbox/method-metadata";
+import { SDK_FIELD_ALIASES } from "../sandbox/sdk-aliases";
 import {
 	sdkMethodVisible,
 	type SdkDiscoveryMode,
@@ -206,6 +207,16 @@ function renderDrillDown(path: string, meta: MethodMetadata): string {
 	);
 	if (meta.signature) {
 		lines.push(`  signature: ${meta.signature}`);
+	}
+	// Rendered from the SAME registry the sandbox dispatch rewrites at runtime
+	// (sdk-aliases.ts), so documented aliases can never drift from accepted ones.
+	const aliases = SDK_FIELD_ALIASES[path];
+	if (aliases) {
+		lines.push(
+			`  accepted aliases: ${Object.entries(aliases)
+				.map(([alias, canonical]) => `${alias} → ${canonical}`)
+				.join(", ")}`,
+		);
 	}
 	if (meta.throws && meta.throws.length > 0) {
 		lines.push(`  throws: ${meta.throws.join(", ")}`);


### PR DESCRIPTION
Closes #2046.

## Problem
`search_sdk` / `method-metadata` advertised SDK method signatures that didn't match what the sandbox dispatch actually accepted: positional-vs-object call shape, field names (`script` vs `reaction_script`, `message` vs `body`, `id` vs `entity_id`), enum values, and `authProfiles.get`'s access tier. Agents wrote calls straight from discovery that the runtime then rejected.

## Fix
- **`SDK_FIELD_ALIASES` (new `sdk-aliases.ts`)** — ONE table of accepted input-field aliases, consumed by **both** `createActionCaller` (runtime rewrite via `applyFieldAliases`) **and** `search_sdk` (rendered into the discovery output). Single source ⇒ documented aliases can never drift from accepted ones. The canonical field always wins when both are supplied; only clean, unambiguous renames are included (no concept-changing aliases, no deprecated-field shims).
- **`method-metadata`** — corrected signatures/enums, fixed `authProfiles.get` access tier, documented positional-vs-object shape per method.
- **Contract tests** — assert discovery == runtime: alias rewrite, canonical-wins precedence, both positional and object forms accepted, and unknown shapes rejected with guidance that names both accepted forms.

## Test
Sandbox `method-metadata` + `sdk-signature-contract` + `sdk-search` suites: **606 pass / 0 fail** (`bun test src/__tests__/unit/`). `tsc --noEmit` + biome clean via pre-commit.

## Verification
- 606/0 unit green
- typecheck + biome clean
- `make review` owed (Codex limit resets 2026-07-25)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SDK method discovery now shows accepted field aliases and canonical field names.
  - Many SDK methods provide clearer signatures, examples, and parameter guidance.
  - Methods accepting identifiers support both positional values and documented object forms.
  - Read-only access to authentication profile details is now available through SDK search.

- **Bug Fixes**
  - SDK requests now translate supported aliases automatically while preserving canonical values.
  - Improved validation and guidance for invalid argument shapes across identifier-based methods.
  - Corrected documentation for view-template content fields and several method parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->