### PR TITLE
fix(gmail): require gmail.compose so create_draft is authorized

### DIFF
--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -162,3 +162,24 @@ describe('Gmail person attribution rule', () => {
     ]);
   });
 });
+
+describe('Gmail write scope', () => {
+  // create_draft POSTs to /drafts, which the Gmail API authorizes only under
+  // gmail.compose (or the broader gmail.modify) — gmail.readonly and gmail.send
+  // are both insufficient for drafts.create. compose must be REQUIRED, not
+  // optional: optional scopes are only sent when the caller explicitly requests
+  // them, so an unadorned connect() would omit it and create_draft would 403.
+  test('compose is a required scope so create_draft/reply/send_email are authorized', () => {
+    const connector = new GmailConnector();
+    const oauth = connector.definition.authSchema.methods.find(
+      (m: { type: string }) => m.type === 'oauth'
+    );
+    expect(oauth.requiredScopes).toContain('https://www.googleapis.com/auth/gmail.compose');
+
+    const actions = connector.definition.actions;
+    for (const key of ['create_draft', 'reply', 'send_email']) {
+      expect(actions[key]).toBeDefined();
+      expect(actions[key].key).toBe(key);
+    }
+  });
+});

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -95,15 +95,22 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     key: 'google.gmail',
     name: 'Gmail',
     description: 'Syncs email threads from Gmail and supports sending emails.',
-    version: '1.0.1',
+    version: '1.0.2',
     faviconDomain: 'mail.google.com',
     authSchema: {
       methods: [
         {
           type: 'oauth',
           provider: 'google',
-          requiredScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
-          optionalScopes: ['https://www.googleapis.com/auth/gmail.send'],
+          requiredScopes: [
+            'https://www.googleapis.com/auth/gmail.readonly',
+            // compose covers drafts.create AND messages.send, so it is the single
+            // write scope for create_draft/reply/send_email. It must be required
+            // (not optional) — optional scopes are only requested when the caller
+            // explicitly asks for them, so an unadorned connect() would omit it
+            // and every write op would 403 insufficient-scope.
+            'https://www.googleapis.com/auth/gmail.compose',
+          ],
           loginScopes: ['openid', 'email', 'profile'],
           clientIdKey: 'GOOGLE_CLIENT_ID',
           clientSecretKey: 'GOOGLE_CLIENT_SECRET',


### PR DESCRIPTION
## Problem

The Gmail connector's OAuth `authSchema` declared `requiredScopes: [gmail.readonly]` + `optionalScopes: [gmail.send]`, but `create_draft` POSTs to `/drafts`, which the Gmail API authorizes only under **`gmail.compose`** (or the broader `gmail.modify`). `gmail.readonly` and `gmail.send` are both insufficient for `drafts.create`.

Worse, optional scopes are only requested when the caller explicitly passes them (`resolveRequestedOAuthScopes` only appends `requestedOptionalScopes`), so an unadorned `connect()` dropped even `gmail.send`. A live connect requested **only** `gmail.readonly`.

Net effect: `create_draft` (and `reply`/`send_email`) would 403 with insufficient scope — breaking the email-drafting flow.

## Fix

Make `gmail.compose` a **required** scope. It covers `drafts.create` **and** `messages.send`, so it is the single write scope and replaces the redundant optional `gmail.send`. Bump the connector version (1.0.1 → 1.0.2) so the catalog re-installs. Existing Gmail connections must re-consent to gain the new scope.

## Test

Adds a regression test pinning `gmail.compose` as required + asserting the three write actions exist. Verified red→green (removing compose fails the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->