### PR TITLE
feat(connectors): org-preferring resolution + cross-org fence (#2045, step 2/3)

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/connector-version-org-isolation.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-version-org-isolation.test.ts
@@ -129,8 +129,11 @@ describe('connector_versions org isolation (#2045 read cutover)', () => {
       TEST_ENV,
       ctxB
     );
+    expect('error' in gotB ? gotB.error : undefined).toBeUndefined();
     const versions = 'versions' in gotB ? gotB.versions : [];
-    expect(versions.map((v: { version: string }) => v.version)).not.toContain('3.0.0');
+    const versionStrings = versions.map((v: { version: string }) => v.version);
+    expect(versionStrings).toContain('1.0.0');
+    expect(versionStrings).not.toContain('3.0.0');
 
     // …nor activate it.
     const rolled = await manageConnections(

--- a/packages/server/src/__tests__/integration/connectors/connector-version-org-isolation.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-version-org-isolation.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Org-preferring connector_versions resolution + the #2045 cross-org fence
+ * (PR 2 of the isolation rollout).
+ *
+ * The regression this locks in: two orgs installing DIFFERENT code under the
+ * same custom (connector_key, version) used to last-writer-win on one global
+ * row — org A would silently EXECUTE org B's code. With org-preferring
+ * resolution each org's own row shadows the shared row for that org only.
+ *
+ * Transitional note (dual-write phase): custom installs still ALSO write the
+ * legacy shared row, so a shared-row copy of custom code remains visible as a
+ * fallback until step 3 (backfill + stop legacy writes) retires it — identical
+ * exposure to the pre-rollout behavior, no worse. The tests below assert the
+ * guarantees PR 2 owns; where the end state differs from the transitional
+ * state they simulate step 3 with direct SQL.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { initWorkspaceProvider } from '../../../workspace';
+import { manageConnections } from '../../../tools/admin/manage_connections';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { seedOwnerContext } from '../../setup/test-fixtures';
+import type { ToolContext } from '../../../tools/registry';
+import {
+  ensureConnectorInstalled,
+  resolveConnectorCodeForKey,
+} from '../../../utils/ensure-connector-installed';
+
+const TEST_ENV = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+} as unknown as Env;
+
+function sourceFor(key: string, version: string, marker: string): string {
+  return `
+export default class IsolationProbeConnector {
+  definition = {
+    key: '${key}',
+    name: 'Isolation Probe',
+    description: '${marker}',
+    version: '${version}',
+  };
+  async sync() { return { events: [], checkpoint: null }; }
+  async execute() { return { marker: '${marker}' }; }
+}
+`;
+}
+
+describe('connector_versions org isolation (#2045 read cutover)', () => {
+  let ctxA: ToolContext;
+  let ctxB: ToolContext;
+  let orgA: string;
+  let orgB: string;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    const a = await seedOwnerContext({ orgName: 'Isolation Org A', userName: 'Iso User A' });
+    const b = await seedOwnerContext({ orgName: 'Isolation Org B', userName: 'Iso User B' });
+    ctxA = a.ctx;
+    ctxB = b.ctx;
+    orgA = a.org.id;
+    orgB = b.org.id;
+  });
+
+  it('resolves each org its OWN code when two orgs collide on (key, version)', async () => {
+    const KEY = 'zz.isocollide';
+    for (const [ctx, marker] of [
+      [ctxA, 'CODE-A'],
+      [ctxB, 'CODE-B'],
+    ] as const) {
+      const res = await manageConnections(
+        { action: 'install_connector', source_code: sourceFor(KEY, '1.0.0', marker) },
+        TEST_ENV,
+        ctx
+      );
+      expect('error' in res ? res.error : undefined).toBeUndefined();
+    }
+
+    // Pre-cutover this returned CODE-B for BOTH orgs (B's install clobbered
+    // the single global row). Each org now executes its own bytes.
+    const codeA = await resolveConnectorCodeForKey(KEY, orgA, '1.0.0');
+    const codeB = await resolveConnectorCodeForKey(KEY, orgB, '1.0.0');
+    expect(codeA).toContain('CODE-A');
+    expect(codeA).not.toContain('CODE-B');
+    expect(codeB).toContain('CODE-B');
+    expect(codeB).not.toContain('CODE-A');
+
+    // Read isolation through the tool surface: each org reads back its own
+    // source from get_connector_source.
+    const gotA = await manageConnections(
+      { action: 'get_connector_source', connector_key: KEY },
+      TEST_ENV,
+      ctxA
+    );
+    const gotB = await manageConnections(
+      { action: 'get_connector_source', connector_key: KEY },
+      TEST_ENV,
+      ctxB
+    );
+    expect('source_code' in gotA ? gotA.source_code : '').toContain('CODE-A');
+    expect('source_code' in gotA ? gotA.source_code : '').not.toContain('CODE-B');
+    expect('source_code' in gotB ? gotB.source_code : '').toContain('CODE-B');
+  });
+
+  it("cannot read or roll back to a version that exists only as another org's private row", async () => {
+    const KEY = 'zz.isofence';
+    const install = await manageConnections(
+      { action: 'install_connector', source_code: sourceFor(KEY, '1.0.0', 'FENCE-BASE') },
+      TEST_ENV,
+      ctxB
+    );
+    expect('error' in install ? install.error : undefined).toBeUndefined();
+
+    // Simulate the post-rollout end state: org A retains a PRIVATE 3.0.0 row
+    // (no shared copy — as after step 3 stops legacy writes).
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO connector_versions (
+        connector_key, version, organization_id, compiled_code, compiled_code_hash,
+        compile_config_hash, source_code, source_path
+      ) VALUES (${KEY}, '3.0.0', ${orgA}, '// private A', 'hash-a3', NULL, '// private A', NULL)
+    `;
+
+    // Org B must not see 3.0.0 in history…
+    const gotB = await manageConnections(
+      { action: 'get_connector_source', connector_key: KEY },
+      TEST_ENV,
+      ctxB
+    );
+    const versions = 'versions' in gotB ? gotB.versions : [];
+    expect(versions.map((v: { version: string }) => v.version)).not.toContain('3.0.0');
+
+    // …nor activate it.
+    const rolled = await manageConnections(
+      { action: 'rollback_connector_version', connector_key: KEY, version: '3.0.0' },
+      TEST_ENV,
+      ctxB
+    );
+    expect('error' in rolled ? rolled.error : '').toContain("No retained version '3.0.0'");
+  });
+
+  it('branching a bundled connector shadows it for the branching org only', async () => {
+    // Org B runs the stock bundled connector.
+    const installed = await ensureConnectorInstalled({
+      organizationId: orgB,
+      connectorKey: 'hackernews',
+    });
+    expect(installed).toBe(true);
+
+    // Org A branches it: same key, custom code under its own version.
+    const branch = await manageConnections(
+      {
+        action: 'install_connector',
+        source_code: sourceFor('hackernews', '99.0.0-acme', 'ACME-BRANCH'),
+      },
+      TEST_ENV,
+      ctxA
+    );
+    expect('error' in branch ? branch.error : undefined).toBeUndefined();
+
+    // Simulate step 3 (no legacy shared copy of the branch).
+    const sql = getTestDb();
+    await sql`
+      DELETE FROM connector_versions
+      WHERE connector_key = 'hackernews' AND version = '99.0.0-acme' AND organization_id IS NULL
+    `;
+
+    // Org A resolves its branch (org row shadows the bundled row)…
+    const codeA = await resolveConnectorCodeForKey('hackernews', orgA);
+    expect(codeA).toContain('ACME-BRANCH');
+
+    // …while org B still resolves the stock bundled connector.
+    const codeB = await resolveConnectorCodeForKey('hackernews', orgB);
+    expect(codeB).not.toContain('ACME-BRANCH');
+    expect(codeB.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/catalog/connector-definitions.ts
+++ b/packages/server/src/catalog/connector-definitions.ts
@@ -120,8 +120,14 @@ export async function listScopedConnectorDefinitions(params: {
       d.updated_at,
       cv.source_path
     FROM connector_definitions d
-    LEFT JOIN connector_versions cv ON cv.connector_key = d.key AND cv.version = d.version
-      AND cv.organization_id IS NULL
+    LEFT JOIN LATERAL (
+      SELECT source_path
+      FROM connector_versions
+      WHERE connector_key = d.key AND version = d.version
+        AND (organization_id = d.organization_id OR organization_id IS NULL)
+      ORDER BY organization_id NULLS LAST
+      LIMIT 1
+    ) cv ON TRUE
     WHERE d.status = 'active'
       AND d.organization_id = ${params.organizationId}
     ORDER BY d.name ASC
@@ -362,12 +368,20 @@ export async function getInstalledConnectorSource(params: {
 	const def = await getScopedConnectorDefinition(params);
 	assertInstalled(def, params.connectorKey);
 
+	// Org fence (#2045): only this org's own rows and the shared rows are
+	// visible — never another org's private artifact. When a version exists as
+	// both (post-dual-write), the org's own row wins.
 	const rows = (await sql`
-    SELECT version, created_at, source_code, source_path, compiled_code_hash,
-           (compiled_code IS NOT NULL) AS has_compiled
-    FROM connector_versions
-    WHERE connector_key = ${params.connectorKey}
-      AND organization_id IS NULL
+    SELECT version, created_at, source_code, source_path, compiled_code_hash, has_compiled
+    FROM (
+      SELECT DISTINCT ON (version)
+             version, created_at, id, source_code, source_path, compiled_code_hash,
+             (compiled_code IS NOT NULL) AS has_compiled
+      FROM connector_versions
+      WHERE connector_key = ${params.connectorKey}
+        AND (organization_id = ${params.organizationId} OR organization_id IS NULL)
+      ORDER BY version, organization_id NULLS LAST
+    ) v
     ORDER BY created_at DESC, id DESC
   `) as unknown as Array<{
 		version: string;
@@ -458,7 +472,7 @@ export async function validateConnectorSource(params: {
     SELECT 1 FROM connector_versions
     WHERE connector_key = ${resolved.metadata.key}
       AND version = ${resolved.metadata.version}
-      AND organization_id IS NULL
+      AND (organization_id = ${params.organizationId} OR organization_id IS NULL)
     LIMIT 1
   `;
 
@@ -528,7 +542,8 @@ export async function updateInstalledConnectorSource(params: {
 	const existing = (await sql`
       SELECT compiled_code_hash, source_code FROM connector_versions
       WHERE connector_key = ${params.connectorKey} AND version = ${targetVersion}
-        AND organization_id IS NULL
+        AND (organization_id = ${params.organizationId} OR organization_id IS NULL)
+      ORDER BY organization_id NULLS LAST
       LIMIT 1
     `) as unknown as Array<{
 		compiled_code_hash: string | null;
@@ -601,23 +616,28 @@ export async function rollbackConnectorVersion(params: {
 		);
 	}
 
+	// Org fence (#2045): a rollback target must be this org's own retained row
+	// or a shared row — another org's private artifact is never activatable.
 	const rows = (await sql`
-    SELECT version, compiled_code, compile_config_hash
+    SELECT id, version, compiled_code, compile_config_hash
     FROM connector_versions
     WHERE connector_key = ${params.connectorKey} AND version = ${params.version}
-      AND organization_id IS NULL
+      AND (organization_id = ${params.organizationId} OR organization_id IS NULL)
+    ORDER BY organization_id NULLS LAST
     LIMIT 1
   `) as unknown as Array<{
+		id: number;
 		version: string;
 		compiled_code: string | null;
 		compile_config_hash: string | null;
 	}>;
 	if (rows.length === 0) {
 		const retained = (await sql`
-      SELECT version FROM connector_versions
+      SELECT DISTINCT ON (version) version, created_at, id
+      FROM connector_versions
       WHERE connector_key = ${params.connectorKey}
-        AND organization_id IS NULL
-      ORDER BY created_at DESC, id DESC
+        AND (organization_id = ${params.organizationId} OR organization_id IS NULL)
+      ORDER BY version, organization_id NULLS LAST
     `) as unknown as Array<{ version: string }>;
 		throw new Error(
 			`No retained version '${params.version}' for connector '${params.connectorKey}'. ` +

--- a/packages/server/src/connect/webhook-registration.ts
+++ b/packages/server/src/connect/webhook-registration.ts
@@ -140,7 +140,10 @@ export async function registerConnectorWebhook(params: {
       if (config.webhook_external_id) return;
       if (!connectionWantsWebhook(config)) return;
 
-      const compiledCode = await resolveConnectorCodeForKey(connection.connector_key);
+      const compiledCode = await resolveConnectorCodeForKey(
+        connection.connector_key,
+        organizationId
+      );
 
       const { credentials, connectionCredentials, sessionState } = await resolveExecutionAuth({
         organizationId,
@@ -243,7 +246,10 @@ export async function unregisterConnectorWebhook(params: {
       const externalId = config.webhook_external_id;
       if (!externalId) return;
 
-      const compiledCode = await resolveConnectorCodeForKey(connection.connector_key);
+      const compiledCode = await resolveConnectorCodeForKey(
+        connection.connector_key,
+        organizationId
+      );
       const { credentials, connectionCredentials, sessionState } = await resolveExecutionAuth({
         organizationId,
         connectionId,

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -73,7 +73,10 @@ export async function runConnectorQuery(p: ConnectorQueryParams): Promise<Connec
   // existing raw-DB connection must not run pushdown under LOBU_CLOUD_MODE either.
   assertConnectorAllowedInCloud(conn.connector_key);
 
-  const compiledCode = await resolveConnectorCodeForKey(conn.connector_key);
+  const compiledCode = await resolveConnectorCodeForKey(
+    conn.connector_key,
+    p.scope.organizationId
+  );
 
   const { credentials, connectionCredentials, sessionState } = await resolveExecutionAuth({
     organizationId: p.scope.organizationId,
@@ -209,7 +212,10 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
   // Execution-time cloud gate, identical to the slug pushdown above.
   assertConnectorAllowedInCloud(feed.connector_key);
 
-  const compiledCode = await resolveConnectorCodeForKey(feed.connector_key);
+  const compiledCode = await resolveConnectorCodeForKey(
+    feed.connector_key,
+    p.scope.organizationId
+  );
 
   const { credentials, connectionCredentials, sessionState } = await resolveExecutionAuth({
     organizationId: p.scope.organizationId,

--- a/packages/server/src/lib/feed-sync.ts
+++ b/packages/server/src/lib/feed-sync.ts
@@ -23,6 +23,7 @@ export interface FeedRecord {
   config: Record<string, unknown>;
   connection_config: Record<string, unknown>;
   checkpoint: Record<string, unknown> | null;
+  connector_version_row_id: number | null;
   connector_version: string | null;
   compiled_code: string | null;
   compile_config_hash: string | null;
@@ -50,6 +51,7 @@ export async function fetchFeeds(filter?: FeedFilter): Promise<FeedRecord[]> {
       COALESCE(f.config, '{}'::jsonb) AS config,
       COALESCE(c.config, '{}'::jsonb) AS connection_config,
       f.checkpoint,
+      cv.id AS connector_version_row_id,
       cv.version AS connector_version,
       cv.compiled_code,
       cv.compile_config_hash,
@@ -66,10 +68,15 @@ export async function fetchFeeds(filter?: FeedFilter): Promise<FeedRecord[]> {
       ORDER BY d.updated_at DESC
       LIMIT 1
     ) resolved_def ON TRUE
-    LEFT JOIN connector_versions cv
-      ON cv.connector_key = c.connector_key
-     AND cv.version = COALESCE(f.pinned_version, resolved_def.version)
-     AND cv.organization_id IS NULL
+    LEFT JOIN LATERAL (
+      SELECT id, version, compiled_code, compile_config_hash
+      FROM connector_versions
+      WHERE connector_key = c.connector_key
+        AND version = COALESCE(f.pinned_version, resolved_def.version)
+        AND (organization_id = f.organization_id OR organization_id IS NULL)
+      ORDER BY organization_id NULLS LAST
+      LIMIT 1
+    ) cv ON TRUE
     WHERE f.status = 'active'
       AND c.status = 'active'
       AND c.deleted_at IS NULL
@@ -112,6 +119,7 @@ export async function runFeed(feed: FeedRecord): Promise<{ itemCount: number }> 
   assertConnectorAllowedInCloud(feed.connector_key);
 
   const compiledCode = await resolveConnectorCode(feed.connector_key, {
+    id: feed.connector_version_row_id,
     version: feed.connector_version,
     compiled_code: feed.compiled_code,
     compile_config_hash: feed.compile_config_hash,

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -214,7 +214,8 @@ async function resolveActiveConnectorVersion(
   const versionRows = await sql`
     SELECT compiled_code, source_path FROM connector_versions
     WHERE connector_key = ${params.connectorKey} AND version = ${version}
-      AND organization_id IS NULL
+      AND (organization_id = ${params.orgId} OR organization_id IS NULL)
+    ORDER BY organization_id NULLS LAST
     LIMIT 1
   `;
   if (versionRows.length === 0) {

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -245,6 +245,7 @@ async function executeLocalActionInline(
 	try {
 		compiledCode = await resolveConnectorCodeForKey(
 			connection.connector_key,
+			organizationId,
 			connectorVersion ?? null,
 		);
 	} catch (err) {

--- a/packages/server/src/utils/__tests__/connector-stale-artifact.test.ts
+++ b/packages/server/src/utils/__tests__/connector-stale-artifact.test.ts
@@ -51,8 +51,12 @@ let storedSourceCode: string | null = STORED_SOURCE;
 function fakeSql(strings: TemplateStringsArray, ...params: unknown[]): Promise<unknown[]> {
   const text = strings.join('?').replace(/\s+/g, ' ').trim();
   queries.push({ text, params });
-  if (/source_code FROM connector_versions/i.test(text)) {
-    return Promise.resolve(storedSourceCode === null ? [] : [{ id: 1, source_code: storedSourceCode }]);
+  if (/SELECT source_code.* FROM connector_versions/i.test(text)) {
+    return Promise.resolve(
+      storedSourceCode === null
+        ? []
+        : [{ id: 1, source_code: storedSourceCode, version: '1.0.0' }]
+    );
   }
   return Promise.resolve([]);
 }
@@ -73,6 +77,7 @@ describe('resolveConnectorCode compile-config staleness', () => {
     // 'zz.staleprobe' has no bundled source on disk, so the ONLY valid escape
     // hatch is recompiling connector_versions.source_code.
     const code = await resolveConnectorCode('zz.staleprobe', {
+      id: 1,
       version: '1.0.0',
       compiled_code: STALE_BUNDLE,
       compile_config_hash: null,
@@ -94,6 +99,7 @@ describe('resolveConnectorCode compile-config staleness', () => {
     const { resolveConnectorCode } = await import('../ensure-connector-installed');
 
     const code = await resolveConnectorCode('zz.staleprobe', {
+      id: 1,
       version: '1.0.0',
       compiled_code: STALE_BUNDLE,
       compile_config_hash: COMPILE_CONFIG_HASH,
@@ -115,6 +121,7 @@ describe('resolveConnectorCode compile-config staleness', () => {
 
     const { resolveConnectorCode } = await import('../ensure-connector-installed');
     const code = await resolveConnectorCode('zz.staleprobe', {
+      id: 1,
       version: '1.0.0',
       compiled_code: precompiled.compiledCode,
       compile_config_hash: null,
@@ -131,6 +138,7 @@ describe('resolveConnectorCode compile-config staleness', () => {
 
     await expect(
       resolveConnectorCode('zz.staleprobe', {
+        id: 1,
         version: '1.0.0',
         compiled_code: STALE_BUNDLE,
         compile_config_hash: 'fingerprint-of-a-previous-pipeline',

--- a/packages/server/src/utils/ensure-connector-installed.ts
+++ b/packages/server/src/utils/ensure-connector-installed.ts
@@ -35,6 +35,13 @@ import logger from './logger';
  * produced `compiled_code`.
  */
 export type StoredConnectorVersion = {
+  /**
+   * Primary key of the row the columns came from. (connector_key, version) no
+   * longer identifies one row — an org-scoped copy may share the pair with
+   * the shared bundled row — so the recompile-repersist path must address the
+   * exact row it resolved. NULL when the reader's LEFT JOIN found no row.
+   */
+  id: number | null;
   version: string | null;
   compiled_code: string | null;
   compile_config_hash: string | null;
@@ -67,9 +74,9 @@ export async function resolveConnectorCode(
 ): Promise<string> {
   if (stored?.compiled_code) {
     if (stored.compile_config_hash === COMPILE_CONFIG_HASH) return stored.compiled_code;
-    if (stored.version) {
+    if (stored.id != null) {
       try {
-        const recompiled = await recompileStoredConnectorVersion(connectorKey, stored.version);
+        const recompiled = await recompileStoredConnectorVersion(connectorKey, stored.id);
         if (recompiled) return recompiled;
       } catch (err) {
         // The stored source no longer compiles under the current compile
@@ -109,23 +116,28 @@ export async function resolveConnectorCode(
  */
 export async function resolveConnectorCodeForKey(
   connectorKey: string,
+  organizationId: string,
   version?: string | null
 ): Promise<string> {
   const sql = getDb();
-  // organization_id IS NULL: reads stay pinned to the shared row until the
-  // per-org read cutover (#2045 follow-up) — the dual-write phase writes
-  // org-scoped copies this query must not accidentally resolve.
+  // Org-preferring resolution (#2045): the org's own artifact row shadows the
+  // shared bundled/legacy row for that org only; shared rows stay every org's
+  // fallback. The no-version variant prefers ANY org row over a newer shared
+  // row — an org that branched a bundled connector stays on its branch until
+  // it updates or rolls back.
   const rows = version
     ? await sql`
-        SELECT version, compiled_code, compile_config_hash FROM connector_versions
+        SELECT id, version, compiled_code, compile_config_hash FROM connector_versions
         WHERE connector_key = ${connectorKey} AND version = ${version}
-          AND organization_id IS NULL
+          AND (organization_id = ${organizationId} OR organization_id IS NULL)
+        ORDER BY organization_id NULLS LAST
         LIMIT 1
       `
     : await sql`
-        SELECT version, compiled_code, compile_config_hash FROM connector_versions
-        WHERE connector_key = ${connectorKey} AND organization_id IS NULL
-        ORDER BY created_at DESC
+        SELECT id, version, compiled_code, compile_config_hash FROM connector_versions
+        WHERE connector_key = ${connectorKey}
+          AND (organization_id = ${organizationId} OR organization_id IS NULL)
+        ORDER BY (organization_id IS NULL), created_at DESC
         LIMIT 1
       `;
   return resolveConnectorCode(connectorKey, (rows[0] as StoredConnectorVersion | undefined) ?? null);
@@ -138,19 +150,15 @@ export async function resolveConnectorCodeForKey(
  */
 async function recompileStoredConnectorVersion(
   connectorKey: string,
-  version: string
+  rowId: number
 ): Promise<string | null> {
   const sql = getDb();
-  // Pinned to the shared row while reads are: the org-scoped copies written by
-  // the dual-write phase (#2045 follow-up) converge when the read cutover
-  // scopes this resolution per org.
   const rows = await sql`
-    SELECT id, source_code FROM connector_versions
-    WHERE connector_key = ${connectorKey} AND version = ${version}
-      AND organization_id IS NULL
+    SELECT source_code, version FROM connector_versions
+    WHERE id = ${rowId}
     LIMIT 1
   `;
-  const row = rows[0] as { id: number; source_code: string | null } | undefined;
+  const row = rows[0] as { source_code: string | null; version: string } | undefined;
   const sourceCode = row?.source_code ?? null;
   if (!row || !sourceCode) return null;
 
@@ -158,15 +166,17 @@ async function recompileStoredConnectorVersion(
   // By primary key, never (connector_key, version): that pair no longer
   // identifies one row — an org-scoped copy may share it with the shared row,
   // and the fresh artifact belongs only to the row whose source produced it.
+  // Each row converges independently across replicas (Postgres-mediated),
+  // exactly as the single shared row did before org scoping.
   await sql`
     UPDATE connector_versions
     SET compiled_code = ${compiledCode},
         compiled_code_hash = ${compiledCodeHash},
         compile_config_hash = ${COMPILE_CONFIG_HASH}
-    WHERE id = ${row.id}
+    WHERE id = ${rowId}
   `;
   logger.info(
-    { connector_key: connectorKey, version },
+    { connector_key: connectorKey, version: row.version, row_id: rowId },
     'Recompiled stale connector artifact (compile configuration changed)'
   );
   return compiledCode;

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -114,9 +114,14 @@ async function ensureDeviceConnectorWired(
           '[]'::jsonb
         ) AS active_feed_keys
       FROM connector_definitions cd
-      LEFT JOIN connector_versions cv
-        ON cv.connector_key = cd.key AND cv.version = cd.version
-        AND cv.organization_id IS NULL
+      LEFT JOIN LATERAL (
+        SELECT connector_key
+        FROM connector_versions
+        WHERE connector_key = cd.key AND version = cd.version
+          AND (organization_id = cd.organization_id OR organization_id IS NULL)
+        ORDER BY organization_id NULLS LAST
+        LIMIT 1
+      ) cv ON TRUE
       LEFT JOIN connections c
         ON c.organization_id = cd.organization_id
        AND c.connector_key = cd.key

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -588,6 +588,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         conn.app_auth_profile_id,
         conn.config AS connection_config,
         conn.device_worker_id AS connection_device_worker_id,
+        cv.id AS connector_version_row_id,
         cv.compiled_code,
         cv.compile_config_hash,
         cd.runtime AS connector_runtime,
@@ -604,9 +605,15 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       FROM runs r
       LEFT JOIN feeds f ON f.id = r.feed_id
       LEFT JOIN connections conn ON conn.id = r.connection_id
-      LEFT JOIN connector_versions cv ON cv.connector_key = r.connector_key
-        AND cv.version = r.connector_version
-        AND cv.organization_id IS NULL
+      LEFT JOIN LATERAL (
+        SELECT id, compiled_code, compile_config_hash
+        FROM connector_versions
+        WHERE connector_key = r.connector_key
+          AND version = r.connector_version
+          AND (organization_id = r.organization_id OR organization_id IS NULL)
+        ORDER BY organization_id NULLS LAST
+        LIMIT 1
+      ) cv ON TRUE
       LEFT JOIN connector_definitions cd ON cd.key = r.connector_key
         AND cd.organization_id = r.organization_id
         AND cd.status = 'active'
@@ -667,6 +674,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     app_auth_profile_id: number | null;
     connection_config: Record<string, unknown> | null;
     connection_device_worker_id: string | null;
+    connector_version_row_id: number | null;
     compiled_code: string | null;
     compile_config_hash: string | null;
     connector_runtime: { nix?: { packages?: string[] } | null } | null;
@@ -834,6 +842,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   if (row.connector_key && !workerWillResolveLocally && !deviceWillExecuteBridgeOnlyConnector) {
     try {
       compiledCode = await resolveConnectorCode(row.connector_key, {
+        id: row.connector_version_row_id,
         version: row.connector_version,
         compiled_code: row.compiled_code,
         compile_config_hash: row.compile_config_hash,


### PR DESCRIPTION
## What

Step 2 of the `connector_versions` isolation rollout (stacked on #2064). Every read resolves the caller org's own row first, falling back to the shared bundled/legacy row — an org's branch of a connector shadows the shared copy **for that org only**.

- `resolveConnectorCodeForKey` takes the organization; no-version resolution prefers ANY org row over a newer shared row (a branched bundled connector stays on its branch until updated/rolled back).
- Recompile-repersist addresses rows by primary key via `StoredConnectorVersion.id` supplied by every executing reader — per-row replica convergence preserved, no recompile loops (the #2042 CPU-DoS trap).
- Worker claim (poll), feed-sync, queue-service, device-reconcile, catalog list → org-preferring LATERAL/ordered lookups.
- **The #2045 fence**: `get_connector_source`, the update clobber guard, and `rollback_connector_version` see only the caller org's rows + shared rows — another org's private artifact is never readable or activatable.

## Red→green

With the old resolution pin, the collide test resolves **org B's compiled code for org A** (the execution leak, reproduced in CI-identical conditions). With the fence, each org executes its own bytes.

## Transitional (documented in-test)

Custom installs still dual-write the legacy shared row, so shared-row fallback exposure is unchanged from today until step 3 (backfill + stop legacy custom writes) retires it. Not a regression — strictly better than main.

## Testing
- New `connector-version-org-isolation.test.ts`: collide isolation (execution + read), org-row-only fence (history + rollback refusal), branch-a-bundled shadowing (hackernews).
- Full `integration/connectors`: 42 files / 295 tests green. Device + operations suites green. `make pre-pr` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connector versions are now isolated by organization, preventing one organization’s installed code from overriding another’s.
  * Organization-specific connector versions are preferred, with shared versions used as a fallback.
  * Connector actions, webhooks, feeds, queries, device operations, and background runs now execute the correct organization-specific connector code.
  * Version discovery and rollback no longer expose private versions belonging to other organizations.
* **Tests**
  * Added integration coverage for organization isolation, private versions, and organization-specific connector branching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->