### PR TITLE
feat(connectors): backfill org ownership + retire shared custom writes (#2045, step 3/3)

### DIFF
--- a/db/migrations/20260721130000_connector_versions_org_backfill.sql
+++ b/db/migrations/20260721130000_connector_versions_org_backfill.sql
@@ -1,0 +1,51 @@
+-- migrate:up
+
+-- Step 3 of the connector_versions isolation rollout (#2045 follow-up).
+--
+-- Attribute retained custom artifacts to their owning organizations: every
+-- shared row carrying org-supplied content (source_code / compiled_code —
+-- bundled catalog rows carry only a source_path pointer and stay shared) is
+-- copied to each organization holding a connector_definitions row for that
+-- key, so every installer keeps its full retained history on its own rows.
+-- No status filter: a disabled connector's history must survive for
+-- rollback_connector_version after re-enable.
+INSERT INTO public.connector_versions (
+  connector_key, version, organization_id, compiled_code, compiled_code_hash,
+  compile_config_hash, source_code, source_path, created_at
+)
+SELECT DISTINCT ON (d.organization_id, cv.connector_key, cv.version)
+  cv.connector_key, cv.version, d.organization_id, cv.compiled_code,
+  cv.compiled_code_hash, cv.compile_config_hash, cv.source_code,
+  cv.source_path, cv.created_at
+FROM public.connector_versions cv
+JOIN public.connector_definitions d ON d.key = cv.connector_key
+WHERE cv.organization_id IS NULL
+  AND (cv.source_code IS NOT NULL OR cv.compiled_code IS NOT NULL)
+ORDER BY d.organization_id, cv.connector_key, cv.version
+ON CONFLICT (organization_id, connector_key, version) WHERE organization_id IS NOT NULL
+DO NOTHING;
+
+-- Retire the shared copies of custom content: with every definition-holder
+-- carrying its own row, a shared custom row is only a cross-org read/activate
+-- surface (the #2045 leak tail). Delete only rows some org now retains —
+-- orphans (no definition anywhere, so no copy landed) stay shared rather than
+-- destroying the sole copy. Old replicas still dual-writing during this
+-- deploy's rolling window may recreate a few shared custom rows; they carry
+-- code their org row also carries and can be pruned by re-running this
+-- statement later.
+DELETE FROM public.connector_versions cv
+WHERE cv.organization_id IS NULL
+  AND (cv.source_code IS NOT NULL OR cv.compiled_code IS NOT NULL)
+  AND EXISTS (
+    SELECT 1 FROM public.connector_versions oc
+    WHERE oc.connector_key = cv.connector_key
+      AND oc.version = cv.version
+      AND oc.organization_id IS NOT NULL
+  );
+
+-- migrate:down
+
+-- The copy is additive and the delete removed rows whose bytes live on org
+-- rows; recreating the exact pre-migration shared namespace is not possible
+-- (nor needed — reads fall back to shared rows only when no org row exists).
+SELECT 1;

--- a/packages/server/src/__tests__/integration/connectors/connector-definition-upsert.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-definition-upsert.test.ts
@@ -76,8 +76,8 @@ describe('upsertConnectorDefinitionRecords', () => {
     });
     expect(second.updated).toBe(true);
 
-    // Dual-write phase (#2045 follow-up): org-supplied content lands on the
-    // legacy shared row (reads' pin) AND the org's own row.
+    // Org-scoped writes (#2045): org-supplied content lands only on the org's
+    // own rows — the shared namespace holds bundled pointers alone.
     const versions = await sql<
       {
         version: string;
@@ -88,19 +88,14 @@ describe('upsertConnectorDefinitionRecords', () => {
     >`
       SELECT version, organization_id, source_code, compile_config_hash FROM connector_versions
       WHERE connector_key = 'upsert-probe'
-      ORDER BY version, organization_id NULLS FIRST
+      ORDER BY version
     `;
-    const shared = versions.filter((v) => v.organization_id === null);
-    const orgRows = versions.filter((v) => v.organization_id === orgId);
-    const byVersion = new Map(shared.map((v) => [v.version, v.source_code]));
+    expect(versions.every((v) => v.organization_id === orgId)).toBe(true);
+    const byVersion = new Map(versions.map((v) => [v.version, v.source_code]));
     // Both versions' executable source rows exist — the definition never points
     // at a version with no source record.
     expect(byVersion.has('1.0.0')).toBe(true);
     expect(byVersion.get('1.1.0')).toBe('// source 1.1.0');
-    // The org copies mirror the shared rows byte-for-byte.
-    expect(orgRows.map((v) => [v.version, v.source_code])).toEqual(
-      shared.map((v) => [v.version, v.source_code])
-    );
     // Every installed artifact carries the compile-config fingerprint —
     // resolveConnectorCode refuses unstamped/mismatched artifacts as stale.
     for (const v of versions) {

--- a/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
@@ -118,12 +118,10 @@ describe('manage_connections connector source lifecycle (#2045)', () => {
       /key, name, and version/
     );
 
-    // Neither validation persisted anything (shared namespace — the org copy
-    // from the dual-write phase mirrors it and is asserted by the dual-write
-    // suite).
+    // Neither validation persisted anything.
     const afterValidate = await sql`
       SELECT version FROM connector_versions
-      WHERE connector_key = ${KEY} AND organization_id IS NULL
+      WHERE connector_key = ${KEY} AND organization_id = ${orgId}
     `;
     expect(afterValidate.map((r) => (r as { version: string }).version)).toEqual(['1.0.0']);
 
@@ -205,7 +203,7 @@ describe('manage_connections connector source lifecycle (#2045)', () => {
     expect((defAfterUpdate[0] as { description: string }).description).toBe('V2');
     const retained = await sql`
       SELECT version FROM connector_versions
-      WHERE connector_key = ${KEY} AND organization_id IS NULL
+      WHERE connector_key = ${KEY} AND organization_id = ${orgId}
       ORDER BY version
     `;
     expect(retained.map((r) => (r as { version: string }).version)).toEqual(['1.0.0', '2.0.0']);

--- a/packages/server/src/__tests__/integration/connectors/connector-version-org-backfill-migration.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-version-org-backfill-migration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Backfill migration 20260721130000_connector_versions_org_backfill (#2045
+ * step 3): shared rows carrying org-supplied content are copied to every
+ * organization holding a connector_definitions row for the key, then the
+ * shared custom copies are deleted; bundled pointer rows and orphan custom
+ * rows (no definition anywhere) stay shared.
+ *
+ * Replays the migration's up section against seeded legacy-shaped rows — the
+ * test database has already run it at setup, so this exercises the SQL
+ * against data the prod run will actually see.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { loadMigrationUpSection } from '../../../db/migration-loader';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestOrganization } from '../../setup/test-fixtures';
+
+const MIGRATION = '20260721130000_connector_versions_org_backfill.sql';
+
+function resolveMigrationsDir(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'db/migrations');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate db/migrations from the test directory');
+}
+
+describe('connector_versions org backfill migration', () => {
+  let orgC: string;
+  let orgD: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    orgC = (await createTestOrganization({ name: 'Backfill Org C' })).id;
+    orgD = (await createTestOrganization({ name: 'Backfill Org D' })).id;
+  });
+
+  it('copies custom shared rows to every definition-holder and retires the shared copies', async () => {
+    const sql = getTestDb();
+    const upSection = loadMigrationUpSection(resolveMigrationsDir(), MIGRATION);
+
+    await sql.begin(async (tx: typeof sql) => {
+      // Both orgs installed 'zz.bf.custom' (the prod shape: 16 keys shared by
+      // >1 org). Org D's definition is archived — history must still follow it.
+      for (const [org, status] of [
+        [orgC, 'active'],
+        [orgD, 'archived'],
+      ] as const) {
+        await tx`
+          INSERT INTO connector_definitions
+            (key, name, version, organization_id, status, created_at, updated_at)
+          VALUES ('zz.bf.custom', 'BF Custom', '1.0.0', ${org}, ${status}, NOW(), NOW())
+        `;
+      }
+      // Legacy shared custom rows (pre-rollout shape).
+      await tx`
+        INSERT INTO connector_versions (connector_key, version, organization_id, source_code, created_at)
+        VALUES ('zz.bf.custom', '1.0.0', NULL, '// custom v1', NOW() - interval '2 days')
+      `;
+      // A pair org C ALREADY retains privately (dual-write era) with its own
+      // bytes — the copy must not clobber them.
+      await tx`
+        INSERT INTO connector_versions (connector_key, version, organization_id, source_code, created_at)
+        VALUES ('zz.bf.custom', '2.0.0', NULL, '// shared v2', NOW() - interval '1 day'),
+               ('zz.bf.custom', '2.0.0', ${orgC}, '// org-c own v2', NOW() - interval '1 day')
+      `;
+      // Bundled pointer row: source_path only — must stay shared, untouched.
+      await tx`
+        INSERT INTO connector_definitions
+          (key, name, version, organization_id, status, created_at, updated_at)
+        VALUES ('zz.bf.bundled', 'BF Bundled', '1.0.0', ${orgC}, 'active', NOW(), NOW())
+      `;
+      await tx`
+        INSERT INTO connector_versions (connector_key, version, organization_id, source_path, created_at)
+        VALUES ('zz.bf.bundled', '1.0.0', NULL, 'zz_bf_bundled.ts', NOW())
+      `;
+      // Orphan custom row: no definition anywhere — the sole copy must survive.
+      await tx`
+        INSERT INTO connector_versions (connector_key, version, organization_id, source_code, created_at)
+        VALUES ('zz.bf.orphan', '1.0.0', NULL, '// orphan', NOW())
+      `;
+
+      await tx.unsafe(upSection);
+
+      const rows = (await tx`
+        SELECT connector_key, version, organization_id, source_code, source_path
+        FROM connector_versions
+        WHERE connector_key LIKE 'zz.bf.%'
+        ORDER BY connector_key, version, organization_id NULLS FIRST
+      `) as unknown as Array<{
+        connector_key: string;
+        version: string;
+        organization_id: string | null;
+        source_code: string | null;
+        source_path: string | null;
+      }>;
+
+      const byKey = (k: string, v: string) =>
+        rows.filter((r) => r.connector_key === k && r.version === v);
+
+      // v1 copied to BOTH orgs (including the disabled definition); shared copy gone.
+      const v1 = byKey('zz.bf.custom', '1.0.0');
+      expect(v1.map((r) => r.organization_id).sort()).toEqual([orgC, orgD].sort());
+      expect(v1.every((r) => r.source_code === '// custom v1')).toBe(true);
+
+      // v2: org C keeps its OWN bytes (no clobber); org D got the shared copy;
+      // shared copy gone.
+      const v2 = byKey('zz.bf.custom', '2.0.0');
+      expect(v2.find((r) => r.organization_id === orgC)?.source_code).toBe('// org-c own v2');
+      expect(v2.find((r) => r.organization_id === orgD)?.source_code).toBe('// shared v2');
+      expect(v2.some((r) => r.organization_id === null)).toBe(false);
+
+      // Bundled pointer stays exactly one shared row.
+      const bundled = byKey('zz.bf.bundled', '1.0.0');
+      expect(bundled).toHaveLength(1);
+      expect(bundled[0]?.organization_id).toBeNull();
+      expect(bundled[0]?.source_path).toBe('zz_bf_bundled.ts');
+
+      // Orphan custom row survives as the sole copy.
+      const orphan = byKey('zz.bf.orphan', '1.0.0');
+      expect(orphan).toHaveLength(1);
+      expect(orphan[0]?.organization_id).toBeNull();
+
+      // Roll the seeds back — this test must not leak state into the suite.
+      throw new Error('__rollback__');
+    }).catch((err: unknown) => {
+      if ((err as Error).message !== '__rollback__') throw err;
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration/connectors/connector-version-org-isolation.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-version-org-isolation.test.ts
@@ -7,12 +7,9 @@
  * row — org A would silently EXECUTE org B's code. With org-preferring
  * resolution each org's own row shadows the shared row for that org only.
  *
- * Transitional note (dual-write phase): custom installs still ALSO write the
- * legacy shared row, so a shared-row copy of custom code remains visible as a
- * fallback until step 3 (backfill + stop legacy writes) retires it — identical
- * exposure to the pre-rollout behavior, no worse. The tests below assert the
- * guarantees PR 2 owns; where the end state differs from the transitional
- * state they simulate step 3 with direct SQL.
+ * Step 3 (org-only custom writes + backfill) is in: custom installs write no
+ * shared rows at all, so the guarantees below hold with no transitional
+ * exposure.
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -113,15 +110,20 @@ describe('connector_versions org isolation (#2045 read cutover)', () => {
     );
     expect('error' in install ? install.error : undefined).toBeUndefined();
 
-    // Simulate the post-rollout end state: org A retains a PRIVATE 3.0.0 row
-    // (no shared copy — as after step 3 stops legacy writes).
+    // Org A retains a private 3.0.0 of the same key — a real install now
+    // produces exactly an org-only row.
+    const installA = await manageConnections(
+      { action: 'install_connector', source_code: sourceFor(KEY, '3.0.0', 'PRIVATE-A') },
+      TEST_ENV,
+      ctxA
+    );
+    expect('error' in installA ? installA.error : undefined).toBeUndefined();
     const sql = getTestDb();
-    await sql`
-      INSERT INTO connector_versions (
-        connector_key, version, organization_id, compiled_code, compiled_code_hash,
-        compile_config_hash, source_code, source_path
-      ) VALUES (${KEY}, '3.0.0', ${orgA}, '// private A', 'hash-a3', NULL, '// private A', NULL)
+    const sharedRows = await sql`
+      SELECT 1 FROM connector_versions
+      WHERE connector_key = ${KEY} AND version = '3.0.0' AND organization_id IS NULL
     `;
+    expect(sharedRows).toHaveLength(0);
 
     // Org B must not see 3.0.0 in history…
     const gotB = await manageConnections(
@@ -162,13 +164,6 @@ describe('connector_versions org isolation (#2045 read cutover)', () => {
       ctxA
     );
     expect('error' in branch ? branch.error : undefined).toBeUndefined();
-
-    // Simulate step 3 (no legacy shared copy of the branch).
-    const sql = getTestDb();
-    await sql`
-      DELETE FROM connector_versions
-      WHERE connector_key = 'hackernews' AND version = '99.0.0-acme' AND organization_id IS NULL
-    `;
 
     // Org A resolves its branch (org row shadows the bundled row)…
     const codeA = await resolveConnectorCodeForKey('hackernews', orgA);

--- a/packages/server/src/__tests__/integration/connectors/connector-version-org-writes.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-version-org-writes.test.ts
@@ -1,24 +1,18 @@
 /**
- * connector_versions org-scoping dual-write (#2045 follow-up, PR 1 of the
+ * connector_versions org-scoped writes (#2045 follow-up, step 3 of the
  * isolation rollout).
  *
- * The table is transitioning from one global (connector_key, version)
- * namespace to shared bundled rows (organization_id IS NULL) + org-scoped
- * rows. In the dual-write phase the legacy shared row is still written and
- * stays authoritative for every read (all reads pin organization_id IS NULL);
- * org-supplied content is ADDITIONALLY copied onto the caller org's own row so
- * the later read cutover can prefer it.
- *
+ * End state: org-supplied content lands ONLY on the caller org's own
+ * (organization_id, connector_key, version) row; the shared
+ * organization_id-IS-NULL namespace holds bundled catalog pointers alone.
  * Locks in:
- * 1. 'organization' scope with content → shared row + org row, same bytes.
+ * 1. 'organization' scope with content → the org's row, NO shared row.
  * 2. 'shared' scope (bundled source_path pointer) → NULL row only.
- * 3. Content-empty 'organization' records (rollback / mcp_url shape) never
- *    create an org row — an empty org row would shadow the code-bearing
- *    shared row once reads prefer org rows.
- * 4. Two orgs writing different code under the same (key, version): the
- *    shared row keeps its legacy last-writer-wins behavior (unchanged, the
- *    pre-existing collision this rollout retires), but each org's OWN row
- *    keeps that org's bytes — the seed of isolation the read cutover serves.
+ * 3. Content-empty 'organization' records: the rollback shape (rows exist)
+ *    writes nothing; the first-mcp_url-install shape (no rows at all)
+ *    creates a marker org row.
+ * 4. Two orgs writing different code under the same (key, version): two
+ *    private rows, each org keeps its own bytes, no shared surface.
  */
 
 import { COMPILE_CONFIG_HASH } from '@lobu/connector-worker/compile';
@@ -60,14 +54,14 @@ const EMPTY_RECORD = {
   sourcePath: null,
 };
 
-describe('connector_versions org-scoping dual-write', () => {
+describe('connector_versions org-scoped writes', () => {
   let orgA: string;
   let orgB: string;
 
   beforeAll(async () => {
     await cleanupTestDatabase();
-    orgA = (await createTestOrganization({ name: 'Dual Write Org A' })).id;
-    orgB = (await createTestOrganization({ name: 'Dual Write Org B' })).id;
+    orgA = (await createTestOrganization({ name: 'Org Write Org A' })).id;
+    orgB = (await createTestOrganization({ name: 'Org Write Org B' })).id;
   });
 
   async function rowsFor(key: string) {
@@ -87,22 +81,21 @@ describe('connector_versions org-scoping dual-write', () => {
     `;
   }
 
-  it("copies org-supplied content onto the org's own row next to the shared row", async () => {
+  it("writes org-supplied content to the org's own row only — never the shared namespace", async () => {
     await upsertConnectorDefinitionRecords({
       sql: getTestDb(),
       organizationId: orgA,
-      metadata: metadataFor('zz.dualwrite', '1.0.0'),
+      metadata: metadataFor('zz.orgwrite', '1.0.0'),
       versionRecord: contentRecord('a-1.0.0'),
       versionScope: 'organization',
     });
 
-    const rows = await rowsFor('zz.dualwrite');
-    expect(rows.map((r) => r.organization_id)).toEqual([null, orgA]);
-    // Same bytes on both rows.
-    expect(new Set(rows.map((r) => r.source_code))).toEqual(new Set(['// source a-1.0.0']));
+    const rows = await rowsFor('zz.orgwrite');
+    expect(rows.map((r) => r.organization_id)).toEqual([orgA]);
+    expect(rows[0]?.source_code).toBe('// source a-1.0.0');
   });
 
-  it("keeps a bundled source_path pointer on the shared row only", async () => {
+  it('keeps a bundled source_path pointer on the shared row only', async () => {
     await upsertConnectorDefinitionRecords({
       sql: getTestDb(),
       organizationId: orgA,
@@ -117,9 +110,9 @@ describe('connector_versions org-scoping dual-write', () => {
     expect(rows[0]?.source_path).toBe('zz_bundledptr.ts');
   });
 
-  it('never creates an org row from a content-empty record (rollback / mcp_url shape)', async () => {
-    // Seed the shared row with content, then send the all-NULL record shape
-    // rollbackConnectorVersion uses (COALESCE keeps stored code).
+  it('content-empty records: rollback shape writes nothing, first-install shape creates a marker', async () => {
+    // Rollback shape: rows for the pair exist → the all-NULL record must not
+    // create anything (an empty org row would shadow a code-bearing row).
     await upsertConnectorDefinitionRecords({
       sql: getTestDb(),
       organizationId: orgA,
@@ -129,18 +122,43 @@ describe('connector_versions org-scoping dual-write', () => {
     });
     await upsertConnectorDefinitionRecords({
       sql: getTestDb(),
+      organizationId: orgA,
+      metadata: metadataFor('zz.emptyrec', '1.0.0'),
+      versionRecord: EMPTY_RECORD,
+      versionScope: 'organization',
+    });
+    const kept = await rowsFor('zz.emptyrec');
+    expect(kept.map((r) => [r.organization_id, r.source_code])).toEqual([
+      [orgA, '// source seed-1.0.0'],
+    ]);
+    // Cross-org: B's all-NULL upsert against a pair only A holds privately
+    // creates B's OWN marker (isolated namespaces — B legitimately installing
+    // an mcp connector under a key A also uses) and never touches A's row.
+    await upsertConnectorDefinitionRecords({
+      sql: getTestDb(),
       organizationId: orgB,
       metadata: metadataFor('zz.emptyrec', '1.0.0'),
       versionRecord: EMPTY_RECORD,
       versionScope: 'organization',
     });
+    const afterB = new Map(
+      (await rowsFor('zz.emptyrec')).map((r) => [r.organization_id, r.source_code])
+    );
+    expect(afterB.size).toBe(2);
+    expect(afterB.get(orgA)).toBe('// source seed-1.0.0');
+    expect(afterB.get(orgB)).toBeNull();
 
-    const rows = await rowsFor('zz.emptyrec');
-    // Shared row + orgA's copy — but NO empty orgB row shadowing the code.
-    expect(rows.map((r) => r.organization_id)).toEqual([null, orgA]);
-    for (const r of rows) {
-      expect(r.source_code).toBe('// source seed-1.0.0');
-    }
+    // First-install shape (mcp_url): no rows at all → a marker org row.
+    await upsertConnectorDefinitionRecords({
+      sql: getTestDb(),
+      organizationId: orgB,
+      metadata: metadataFor('zz.mcpmarker', '1.0.0'),
+      versionRecord: EMPTY_RECORD,
+      versionScope: 'organization',
+    });
+    const marker = await rowsFor('zz.mcpmarker');
+    expect(marker.map((r) => r.organization_id)).toEqual([orgB]);
+    expect(marker[0]?.source_code).toBeNull();
   });
 
   it("keeps each org's bytes on its own row when two orgs collide on (key, version)", async () => {
@@ -162,10 +180,9 @@ describe('connector_versions org-scoping dual-write', () => {
 
     const rows = await rowsFor(key);
     const byOrg = new Map(rows.map((r) => [r.organization_id, r.source_code]));
-    // Legacy shared row: last writer wins (pre-existing behavior, retired by
-    // the read cutover — reads still pin it during dual-write).
-    expect(byOrg.get(null)).toBe('// source b-2.0.0');
-    // Each org's own row keeps its own bytes — the isolation seed.
+    // No shared surface at all — the pre-rollout last-writer-wins clobber row
+    // no longer exists.
+    expect(byOrg.has(null)).toBe(false);
     expect(byOrg.get(orgA)).toBe('// source a-2.0.0');
     expect(byOrg.get(orgB)).toBe('// source b-2.0.0');
   });

--- a/packages/server/src/utils/connector-definition-install.ts
+++ b/packages/server/src/utils/connector-definition-install.ts
@@ -303,14 +303,15 @@ export async function upsertConnectorDefinitionRecords(params: {
    * - 'shared': a pointer at bundled on-disk source (source_path, no code) —
    *   identical for every org, deduped on one organization_id-IS-NULL row.
    * - 'organization': org-supplied bytes (install_connector / source_url /
-   *   source_code / mcp_url). Dual-write phase (#2045 follow-up): the legacy
-   *   shared row is still written and stays authoritative for reads; a
-   *   content-bearing copy is additionally written to the caller org's own
-   *   (organization_id, connector_key, version) row so the read cutover can
-   *   prefer it without cross-org collisions. Content-empty records (rollback
-   *   and mcp_url upserts pass all-NULL and rely on COALESCE keeping stored
-   *   code) never create an org row: an empty org row would shadow the
-   *   code-bearing shared row once reads prefer org rows.
+   *   source_code / mcp_url) land ONLY on the caller org's own
+   *   (organization_id, connector_key, version) row — never the shared
+   *   namespace (#2045: a shared row of custom code is a cross-org
+   *   read/activate surface). Content-empty records (rollback and mcp_url
+   *   upserts pass all-NULL and rely on COALESCE keeping stored code) never
+   *   overwrite anything; they create a marker org row only when NO row
+   *   exists for the pair at all (first mcp_url install) — a rollback target
+   *   always exists, and an empty org row must never shadow a code-bearing
+   *   shared row.
    */
   versionScope: 'shared' | 'organization';
 }): Promise<{ updated: boolean }> {
@@ -429,46 +430,50 @@ export async function upsertConnectorDefinitionRecords(params: {
   }
 
   // Persist the version's executable source for BOTH the create and the
-  // active-update paths — a definition must never point at a version row that
-  // has no compiled/source record. Pipeline-compiled artifacts arrive stamped
-  // with the fingerprint of the compile configuration that produced them
+  // active-update paths — a definition must never point at a version with no
+  // compiled/source record. Pipeline-compiled artifacts arrive stamped with
+  // the fingerprint of the compile configuration that produced them
   // (versionRecord.compileConfigHash), so a later change to
   // EXTERNAL_RUNTIME_DEPS / the compile pipeline invalidates them
   // (resolveConnectorCode recompiles instead of executing a stale bundle).
-  await sql`
-    INSERT INTO connector_versions (
-      connector_key, version, organization_id, compiled_code, compiled_code_hash,
-      compile_config_hash, source_code, source_path
-    ) VALUES (
-      ${metadata.key}, ${metadata.version}, NULL, ${params.versionRecord.compiledCode},
-      ${params.versionRecord.compiledCodeHash}, ${params.versionRecord.compileConfigHash},
-      ${params.versionRecord.sourceCode}, ${params.versionRecord.sourcePath}
-    )
-    ON CONFLICT (connector_key, version) WHERE organization_id IS NULL DO UPDATE
-    SET compiled_code = COALESCE(EXCLUDED.compiled_code, connector_versions.compiled_code),
-        compiled_code_hash = COALESCE(
-          EXCLUDED.compiled_code_hash,
-          connector_versions.compiled_code_hash
-        ),
-        -- The fingerprint rides with the artifact, never independently: when a
-        -- reinstall REPLACES compiled_code, take the incoming fingerprint even
-        -- when it is NULL (a pre-compiled upload replacing a pipeline-compiled
-        -- artifact must not inherit the old row's "current" attestation).
-        compile_config_hash = CASE
-          WHEN EXCLUDED.compiled_code IS NOT NULL THEN EXCLUDED.compile_config_hash
-          ELSE connector_versions.compile_config_hash
-        END,
-        source_code = COALESCE(EXCLUDED.source_code, connector_versions.source_code),
-        source_path = COALESCE(EXCLUDED.source_path, connector_versions.source_path)
-  `;
-
-  // Dual-write (#2045 follow-up): org-supplied bytes additionally land on the
-  // caller org's own row so the read cutover can prefer it. Content-empty
-  // records never create an org row (see versionScope doc above).
   const record = params.versionRecord;
+  if (params.versionScope === 'shared') {
+    // Bundled catalog pointer: identical for every org, deduped on the one
+    // shared organization_id-IS-NULL row.
+    await sql`
+      INSERT INTO connector_versions (
+        connector_key, version, organization_id, compiled_code, compiled_code_hash,
+        compile_config_hash, source_code, source_path
+      ) VALUES (
+        ${metadata.key}, ${metadata.version}, NULL, ${record.compiledCode},
+        ${record.compiledCodeHash}, ${record.compileConfigHash},
+        ${record.sourceCode}, ${record.sourcePath}
+      )
+      ON CONFLICT (connector_key, version) WHERE organization_id IS NULL DO UPDATE
+      SET compiled_code = COALESCE(EXCLUDED.compiled_code, connector_versions.compiled_code),
+          compiled_code_hash = COALESCE(
+            EXCLUDED.compiled_code_hash,
+            connector_versions.compiled_code_hash
+          ),
+          -- The fingerprint rides with the artifact, never independently: when a
+          -- reinstall REPLACES compiled_code, take the incoming fingerprint even
+          -- when it is NULL (a pre-compiled upload replacing a pipeline-compiled
+          -- artifact must not inherit the old row's "current" attestation).
+          compile_config_hash = CASE
+            WHEN EXCLUDED.compiled_code IS NOT NULL THEN EXCLUDED.compile_config_hash
+            ELSE connector_versions.compile_config_hash
+          END,
+          source_code = COALESCE(EXCLUDED.source_code, connector_versions.source_code),
+          source_path = COALESCE(EXCLUDED.source_path, connector_versions.source_path)
+    `;
+    return { updated: wasActive };
+  }
+
+  // Org-supplied bytes land ONLY on the caller org's own row (#2045: a shared
+  // row of custom code is a cross-org read/activate surface).
   const hasContent =
     record.compiledCode !== null || record.sourceCode !== null || record.sourcePath !== null;
-  if (params.versionScope === 'organization' && hasContent) {
+  if (hasContent) {
     await sql`
       INSERT INTO connector_versions (
         connector_key, version, organization_id, compiled_code, compiled_code_hash,
@@ -491,6 +496,22 @@ export async function upsertConnectorDefinitionRecords(params: {
           END,
           source_code = COALESCE(EXCLUDED.source_code, connector_versions.source_code),
           source_path = COALESCE(EXCLUDED.source_path, connector_versions.source_path)
+    `;
+  } else {
+    // Content-empty record (rollback / mcp_url shapes). A rollback target
+    // always exists (validated by the caller), so this only creates the
+    // marker row a first mcp_url install needs — and never when ANY row
+    // (this org's or shared) already holds the pair, so an empty org row
+    // can never shadow a code-bearing row.
+    await sql`
+      INSERT INTO connector_versions (connector_key, version, organization_id)
+      SELECT ${metadata.key}, ${metadata.version}, ${params.organizationId}
+      WHERE NOT EXISTS (
+        SELECT 1 FROM connector_versions
+        WHERE connector_key = ${metadata.key} AND version = ${metadata.version}
+          AND (organization_id = ${params.organizationId} OR organization_id IS NULL)
+      )
+      ON CONFLICT DO NOTHING
     `;
   }
 


### PR DESCRIPTION
## What

Final step of the `connector_versions` isolation rollout (stacked on #2065 → #2064). Closes the remaining leak tail: after this, org-supplied connector content lives ONLY on the owning org's rows and the shared namespace holds bundled catalog pointers alone.

- **Backfill migration**: copies every shared row carrying custom content to each org holding a `connector_definitions` row for the key (no status filter — an archived connector's history survives re-enable), then deletes the shared custom copies some org now retains. Bundled pointer rows and orphans (sole copies) stay shared. Old replicas dual-writing during the rolling window may recreate a few shared custom rows — bytes their org row also carries; prunable by re-running the statement.
- **Write path**: `'organization'` scope stops writing the legacy shared row. Content-empty records (rollback / mcp_url shapes) never overwrite; they create a marker org row only when NO row exists for the pair (first mcp_url install) — a rollback target always exists by validation, so an empty org row can never shadow code.
- **Tests**: migration replayed against seeded legacy-shaped rows (multi-org copy, no-clobber of existing org bytes, bundled/orphan untouched); org-writes suite covers all four write shapes; isolation tests drop their "simulate step 3" scaffolding — a real install now produces exactly an org-only row.

Closes the cross-org read/activate exposure of #2045 end-to-end: install/update/get/validate/rollback and every execution path (poll, feed-sync, pushdown, webhooks, queue) are org-fenced with shared-bundled fallback.

## Testing
Full `integration/connectors`: 43 files / 296 tests green. Device + operations suites green. `make pre-pr` + squawk clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->