### PR TITLE
feat(deploy): deployment snapshots + lobu rollback + promotions pause (#2045 capstone)

### DIFF
--- a/db/migrations/20260721140000_deployment_pause.sql
+++ b/db/migrations/20260721140000_deployment_pause.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+
+-- Org-level "promotions paused" flag for config deployments (#2045 follow-up,
+-- Vercel-style paused auto-promotion). `lobu rollback` sets it; a subsequent
+-- `lobu apply` refuses while it is set until the operator passes --resume
+-- (which clears it) — so a CI apply can never silently re-promote over a
+-- deliberate rollback. One row per organization; Postgres-mediated so every
+-- replica and every operator sees the same state.
+CREATE TABLE IF NOT EXISTS public.deployment_pause (
+  organization_id text PRIMARY KEY,
+  paused_at timestamp with time zone NOT NULL DEFAULT now(),
+  -- The rollback deployment that set the pause, and the deployment it
+  -- restored — the apply error message points operators at both.
+  apply_id text,
+  rollback_of text,
+  paused_by text
+);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS public.deployment_pause;

--- a/db/migrations/20260721140000_deployment_pause.sql
+++ b/db/migrations/20260721140000_deployment_pause.sql
@@ -18,4 +18,5 @@ CREATE TABLE IF NOT EXISTS public.deployment_pause (
 
 -- migrate:down
 
+-- squawk-ignore ban-drop-table
 DROP TABLE IF EXISTS public.deployment_pause;

--- a/packages/cli/src/commands/_lib/apply/__tests__/rollback-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/rollback-cmd.test.ts
@@ -1,0 +1,130 @@
+/**
+ * `lobu rollback` snapshot handling: the stored manifest is redacted and
+ * byte-free, and sanitization converts every redaction sentinel into
+ * "keep current" — a rollback restores intent and structurally cannot push a
+ * secret (or the literal sentinel) anywhere.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { REDACTED_SENTINEL } from "@lobu/core";
+import type { DesiredState } from "../desired-state.js";
+import { buildDeploymentManifest } from "../deployment.js";
+import { sanitizeSnapshotState } from "../rollback-cmd.js";
+
+function stateWithSecrets(): DesiredState {
+  return {
+    agents: [
+      {
+        metadata: { agentId: "a1", name: "A1" },
+        settings: null,
+        platforms: [
+          {
+            platform: "telegram",
+            config: { botToken: "1234:real-token", chatId: "42" },
+          },
+          { platform: "slack", config: { channel: "#general" } },
+        ],
+        providerKeys: [{ providerId: "anthropic", value: "sk-ant-real" }],
+      },
+    ],
+    prune: false,
+    memorySchema: { entityTypes: [], relationshipTypes: [] },
+    watchers: [],
+    connectors: {
+      definitions: [
+        {
+          key: "zz.probe",
+          sourceFile: "probe.connector.ts",
+          sourceCode: "export default class Probe {}",
+        },
+      ],
+      authProfiles: [
+        {
+          slug: "gh-main",
+          connector: "github",
+          credentials: { token: "ghp_real" },
+        },
+      ],
+      connections: [],
+    },
+    providers: [
+      { slug: "z-ai", kind: "z-ai", apiKey: "sk-live-1", capabilities: {} },
+    ],
+    requiredSecrets: [],
+  } as unknown as DesiredState;
+}
+
+describe("buildDeploymentManifest", () => {
+  test("redacts secrets, drops connector source bytes, keeps version pins", () => {
+    const manifest = buildDeploymentManifest(stateWithSecrets(), {
+      "zz.probe": "1.2.0",
+    });
+    expect(manifest.version).toBe(1);
+    expect(manifest.connector_versions).toEqual({ "zz.probe": "1.2.0" });
+
+    const raw = JSON.stringify(manifest);
+    // No secret VALUE and no source byte survives into the stored snapshot.
+    expect(raw).not.toContain("sk-ant-real");
+    expect(raw).not.toContain("ghp_real");
+    expect(raw).not.toContain("sk-live-1");
+    expect(raw).not.toContain("1234:real-token");
+    expect(raw).not.toContain("export default class Probe");
+    // The declaration shape survives for labels.
+    expect(raw).toContain("probe.connector.ts");
+    // Non-secret platform config survives (rollback restores it).
+    expect(raw).toContain("#general");
+  });
+});
+
+describe("sanitizeSnapshotState", () => {
+  function snapshotState() {
+    return buildDeploymentManifest(stateWithSecrets(), {}).state;
+  }
+
+  test("converts sentinels to keep-current: credentials, provider keys, connector defs", () => {
+    const { state } = sanitizeSnapshotState(snapshotState(), new Map());
+    // Connector definitions ride the version pins, never the diff.
+    expect(state.connectors.definitions).toEqual([]);
+    // Credentials undeclared → the diff never re-pushes them.
+    expect(
+      (state.connectors.authProfiles[0] as { credentials?: unknown })
+        .credentials
+    ).toBeUndefined();
+    // Provider keys: nothing to push.
+    expect(state.agents[0]?.providerKeys).toEqual([]);
+    // Org provider key empty → keyDeclared=false → no rotate.
+    expect(state.providers?.[0]?.apiKey).toBe("");
+  });
+
+  test("pins a sentinel-bearing platform to its live remote config, drops it when none", () => {
+    const remote = new Map([
+      ["a1:telegram", { botToken: "secret://live", chatId: "42" }],
+    ]);
+    const pinned = sanitizeSnapshotState(snapshotState(), remote);
+    const platforms = pinned.state.agents[0]?.platforms as Array<{
+      platform: string;
+      config?: Record<string, unknown>;
+    }>;
+    // telegram (sentinel-bearing) pinned to the remote config verbatim…
+    expect(platforms.find((p) => p.platform === "telegram")?.config).toEqual({
+      botToken: "secret://live",
+      chatId: "42",
+    });
+    // …slack (no secrets) restored from the snapshot untouched.
+    expect(platforms.find((p) => p.platform === "slack")?.config).toEqual({
+      channel: "#general",
+    });
+    expect(pinned.notes.some((n) => n.includes("a1:telegram"))).toBe(true);
+
+    // No live platform to pin to → dropped with a note, never pushed.
+    const dropped = sanitizeSnapshotState(snapshotState(), new Map());
+    const droppedPlatforms = dropped.state.agents[0]?.platforms as Array<{
+      platform: string;
+    }>;
+    expect(droppedPlatforms.map((p) => p.platform)).toEqual(["slack"]);
+    expect(dropped.notes.some((n) => n.includes("skipped"))).toBe(true);
+    // The sentinel itself never survives sanitization anywhere.
+    expect(JSON.stringify(pinned.state)).not.toContain(REDACTED_SENTINEL);
+    expect(JSON.stringify(dropped.state)).not.toContain(REDACTED_SENTINEL);
+  });
+});

--- a/packages/cli/src/commands/_lib/apply/__tests__/rollback-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/rollback-cmd.test.ts
@@ -45,7 +45,14 @@ function stateWithSecrets(): DesiredState {
           credentials: { token: "ghp_real" },
         },
       ],
-      connections: [],
+      connections: [
+        {
+          slug: "pg-main",
+          connector: "postgres",
+          config: { api_key: "conn-secret", database: "prod" },
+        },
+        { slug: "hn-main", connector: "hackernews", config: { top: 10 } },
+      ],
     },
     providers: [
       { slug: "z-ai", kind: "z-ai", apiKey: "sk-live-1", capabilities: {} },
@@ -124,6 +131,39 @@ describe("sanitizeSnapshotState", () => {
     expect(droppedPlatforms.map((p) => p.platform)).toEqual(["slack"]);
     expect(dropped.notes.some((n) => n.includes("skipped"))).toBe(true);
     // The sentinel itself never survives sanitization anywhere.
+    expect(JSON.stringify(pinned.state)).not.toContain(REDACTED_SENTINEL);
+    expect(JSON.stringify(dropped.state)).not.toContain(REDACTED_SENTINEL);
+  });
+
+  test("pins a sentinel-bearing connection config to remote, drops it when none", () => {
+    const remoteConnections = new Map([
+      ["pg-main", { api_key: "***live", database: "prod" }],
+    ]);
+    const pinned = sanitizeSnapshotState(
+      snapshotState(),
+      new Map(),
+      remoteConnections
+    );
+    const connections = pinned.state.connectors.connections as Array<{
+      slug: string;
+      config?: Record<string, unknown>;
+    }>;
+    // pg-main (denylisted api_key redacted in the snapshot) pinned to live…
+    expect(connections.find((c) => c.slug === "pg-main")?.config).toEqual({
+      api_key: "***live",
+      database: "prod",
+    });
+    // …hn-main (no secrets) restored from the snapshot untouched.
+    expect(connections.find((c) => c.slug === "hn-main")?.config).toEqual({
+      top: 10,
+    });
+
+    // No live connection to pin to → dropped with a note.
+    const dropped = sanitizeSnapshotState(snapshotState(), new Map());
+    const droppedSlugs = (
+      dropped.state.connectors.connections as Array<{ slug: string }>
+    ).map((c) => c.slug);
+    expect(droppedSlugs).toEqual(["hn-main"]);
     expect(JSON.stringify(pinned.state)).not.toContain(REDACTED_SENTINEL);
     expect(JSON.stringify(dropped.state)).not.toContain(REDACTED_SENTINEL);
   });

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -43,6 +43,7 @@ import {
 } from "./render.js";
 import {
   buildCountsByKind,
+  buildDeploymentManifest,
   collectGitInfo,
   computeManifestHash,
   type DeploymentSummary,
@@ -59,13 +60,19 @@ interface ApplyOptions {
   url?: string;
   /** Bypass the project-link guard. */
   force?: boolean;
+  /**
+   * Clear the promotions pause a `lobu rollback` set and proceed. Without it,
+   * apply refuses while the org is paused — CI must never silently re-promote
+   * over a deliberate rollback.
+   */
+  resume?: boolean;
   /** CLI version stamped into the deployment summary. */
   cliVersion?: string;
   /** Test seam — inject a stubbed fetch. */
   fetchImpl?: typeof fetch;
 }
 
-interface PendingAuthEntry {
+export interface PendingAuthEntry {
   slug: string;
   kind: string;
   connectUrl?: string;
@@ -302,7 +309,7 @@ function hasDesiredConnectors(state: DesiredState): boolean {
   );
 }
 
-async function fetchRemoteSnapshot(
+export async function fetchRemoteSnapshot(
   client: ApplyClient,
   state: DesiredState,
   only?: "agents" | "memory",
@@ -430,7 +437,15 @@ async function installConnectorDefinitions(
   state: DesiredState,
   catalog: RemoteConnectorDefinition[],
   plan: DiffPlan
-): Promise<RemoteConnectorDefinition[]> {
+): Promise<{
+  catalog: RemoteConnectorDefinition[];
+  /**
+   * Active version per config-relevant connector key AFTER this apply — the
+   * deployment manifest's retained-version pins (`lobu rollback` repoints to
+   * these via `rollback_connector_version`, no source re-push).
+   */
+  connectorVersions: Record<string, string>;
+}> {
   const installedKeys = new Set(
     catalog.filter((d) => d.installed).map((d) => d.key)
   );
@@ -522,7 +537,18 @@ async function installConnectorDefinitions(
     );
   }
 
-  return mutated ? await client.listConnectors(true) : catalog;
+  const finalCatalog = mutated ? await client.listConnectors(true) : catalog;
+
+  // Pin the versions that are active NOW for every key this config declares
+  // or references — the self-contained part of the deployment snapshot.
+  const pinKeys = new Set([...locallySuppliedKeys, ...referenced]);
+  const connectorVersions: Record<string, string> = {};
+  for (const def of finalCatalog) {
+    if (def.installed && def.version && pinKeys.has(def.key)) {
+      connectorVersions[def.key] = def.version;
+    }
+  }
+  return { catalog: finalCatalog, connectorVersions };
 }
 
 // ── Connector config validation (against a given catalog) ──────────────────
@@ -640,6 +666,28 @@ export function locallyDeclaredConnectorKeys(state: DesiredState): Set<string> {
   return keys;
 }
 
+/**
+ * Active-version pins for every config-relevant connector key, read from a
+ * catalog snapshot. Used when the apply didn't (re)install connectors (all-noop
+ * plans) and as the fallback layer under a partial failure's install results.
+ */
+export function connectorVersionPins(
+  state: DesiredState,
+  catalog: RemoteConnectorDefinition[]
+): Record<string, string> {
+  const pinKeys = new Set([
+    ...locallyDeclaredConnectorKeys(state),
+    ...referencedConnectorKeys(state.connectors),
+  ]);
+  const pins: Record<string, string> = {};
+  for (const def of catalog) {
+    if (def.installed && def.version && pinKeys.has(def.key)) {
+      pins[def.key] = def.version;
+    }
+  }
+  return pins;
+}
+
 // ── Apply executor ─────────────────────────────────────────────────────────
 
 interface ApplyContext {
@@ -690,11 +738,13 @@ export async function pushProviderApiKeys(
 export async function executePlan(
   ctx: ApplyContext,
   pendingAuth: PendingAuthEntry[]
-): Promise<void> {
+): Promise<{ connectorVersions: Record<string, string> }> {
   const rowsByKind = (kind: DiffRow["kind"]) =>
     ctx.plan.rows.filter(
       (row) => row.kind === kind && row.verb !== "noop" && row.verb !== "drift"
     );
+
+  let connectorVersions: Record<string, string> = {};
 
   // 0) Connector definitions FIRST — install/update them (the plan was already
   //    confirmed), refetch the catalog, then re-validate connection/feed config
@@ -702,12 +752,14 @@ export async function executePlan(
   //    means a post-install schema rejection halts apply before mutating
   //    anything unrelated.
   if (hasDesiredConnectors(ctx.state)) {
-    const freshCatalog = await installConnectorDefinitions(
+    const installed = await installConnectorDefinitions(
       ctx.client,
       ctx.state,
       ctx.remote.connectorDefinitions,
       ctx.plan
     );
+    const freshCatalog = installed.catalog;
+    connectorVersions = installed.connectorVersions;
     for (const warning of validateConnectorState(ctx.state, freshCatalog, {
       requireInstalled: true,
     })) {
@@ -1117,6 +1169,8 @@ export async function executePlan(
   //     rows for definitions). The server refuses an entity-type delete while
   //     instances exist, so the data stays safe.
   await deleteRemovedDefinitions(ctx);
+
+  return { connectorVersions };
 }
 
 /**
@@ -1269,6 +1323,32 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
     fetchImpl: opts.fetchImpl,
   });
   printText(chalk.dim(`Org: ${orgSlug}`));
+
+  // Promotions-pause gate: a `lobu rollback` pauses applies for the org so a
+  // CI run can't silently re-promote the config that was just rolled back.
+  // `--resume` is the explicit acknowledgment that the config repo has been
+  // reconciled (or the newer state is wanted after all). Tolerate a failing
+  // pause endpoint (older server) — the gate is a workflow guard.
+  const pause = await client.getDeploymentPause().catch(() => null);
+  if (pause?.paused && !opts.dryRun) {
+    if (!opts.resume) {
+      printError(
+        [
+          "",
+          `Deployments are paused for "${orgSlug}" — a rollback restored deployment ${pause.rollbackOf ?? "?"}${pause.pausedAt ? ` on ${pause.pausedAt}` : ""}.`,
+          "Applying now would re-promote the config that was just rolled back.",
+          "",
+          "  Reconcile your config repo (e.g. `git revert` the bad change), then:",
+          "    lobu apply --resume",
+        ].join("\n")
+      );
+      throw new ValidationError(
+        "deployments paused by rollback — pass --resume to proceed"
+      );
+    }
+    await client.clearDeploymentPause();
+    printText(chalk.yellow("Resumed deployments (pause cleared)."));
+  }
 
   // Refuse if .lobu/project.json points at a different (context, org).
   const link = await loadProjectLink(cwd);
@@ -1456,6 +1536,12 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
         git_sha: gitInfo.sha,
         git_dirty: gitInfo.dirty,
         cli_version: opts.cliVersion ?? null,
+        // All-noop plan: the installed catalog IS this config's connector
+        // state — pin from the remote snapshot.
+        manifest: buildDeploymentManifest(
+          state,
+          connectorVersionPins(state, remote.connectorDefinitions)
+        ),
       });
     } else {
       printText(chalk.green("\nNothing to apply."));
@@ -1490,13 +1576,18 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
 
   const pendingAuth: PendingAuthEntry[] = [];
   let applyErr: unknown;
+  let connectorVersions: Record<string, string> = {};
   try {
     // Resources first, then provider keys. Keys are org-scoped
     // (inference_providers rows), so there is no agent-existence ordering
     // constraint anymore — the order is kept for stable output only.
     if (hasResourceWork) {
       printText(chalk.bold("\nApplying:"));
-      await executePlan({ client, state, plan, remote }, pendingAuth);
+      const executed = await executePlan(
+        { client, state, plan, remote },
+        pendingAuth
+      );
+      connectorVersions = executed.connectorVersions;
     }
     // Provider keys live outside the resource diff (idempotent PUT), so push
     // them on any confirmed apply (including a pending-auth-only plan). Done
@@ -1522,6 +1613,15 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   // x-lobu-apply-id header; this summary row is what groups them in the UI.
   {
     const gitInfo = collectGitInfo(cwd);
+    // A partial failure's snapshot could pin connectors that never installed
+    // this run — fall back to the CURRENT remote pins for any missing key so
+    // rollback restores what was actually live, never a phantom.
+    const pins = hasResourceWork
+      ? {
+          ...connectorVersionPins(state, remote.connectorDefinitions),
+          ...connectorVersions,
+        }
+      : connectorVersionPins(state, remote.connectorDefinitions);
     await postDeploymentSummarySafe(client, {
       apply_id: applyId,
       status: applyErr ? "partial_failure" : "succeeded",
@@ -1531,6 +1631,7 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
       git_sha: gitInfo.sha,
       git_dirty: gitInfo.dirty,
       cli_version: opts.cliVersion ?? null,
+      manifest: buildDeploymentManifest(state, pins),
       ...(applyErr
         ? {
             error:

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -29,6 +29,32 @@ export interface RemoteAgent {
   description?: string;
 }
 
+export interface RemoteDeployment {
+  id: number;
+  applyId: string;
+  createdAt: string;
+  title: string | null;
+  status: string | null;
+  gitSha: string | null;
+  gitDirty: boolean | null;
+  manifestHash: string | null;
+  rollbackOf: string | null;
+  /** Stored snapshot ({version, state, connector_versions}); null on legacy deployments. */
+  manifest: {
+    version: number;
+    state: Record<string, unknown>;
+    connector_versions: Record<string, string>;
+  } | null;
+}
+
+export interface DeploymentPauseState {
+  paused: boolean;
+  pausedAt?: string;
+  applyId?: string | null;
+  rollbackOf?: string | null;
+  pausedBy?: string | null;
+}
+
 export interface RemotePlatform {
   id: string;
   platform: string;
@@ -463,6 +489,43 @@ export class ApplyClient {
    */
   async postDeploymentSummary(summary: DeploymentSummary): Promise<void> {
     await this.request("POST", `/api/${this.orgSlug}/deployments`, summary);
+  }
+
+  /** Fetch one deployment's record, including its stored manifest snapshot. */
+  async getDeployment(applyId: string): Promise<RemoteDeployment | null> {
+    try {
+      const { body } = await this.request<{ deployment?: RemoteDeployment }>(
+        "GET",
+        `/api/${this.orgSlug}/deployments/${encodeURIComponent(applyId)}`
+      );
+      return body.deployment ?? null;
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) return null;
+      throw err;
+    }
+  }
+
+  /** Promotions-pause state (set by `lobu rollback`). */
+  async getDeploymentPause(): Promise<DeploymentPauseState> {
+    const { body } = await this.request<DeploymentPauseState>(
+      "GET",
+      `/api/${this.orgSlug}/deployments/pause`
+    );
+    return body;
+  }
+
+  async setDeploymentPause(params: {
+    applyId: string;
+    rollbackOf: string;
+  }): Promise<void> {
+    await this.request("PUT", `/api/${this.orgSlug}/deployments/pause`, {
+      apply_id: params.applyId,
+      rollback_of: params.rollbackOf,
+    });
+  }
+
+  async clearDeploymentPause(): Promise<void> {
+    await this.request("DELETE", `/api/${this.orgSlug}/deployments/pause`);
   }
 
   // ── Org inference providers ────────────────────────────────────────────────
@@ -1196,6 +1259,22 @@ export class ApplyClient {
     await this.connectionsTool({
       action: "uninstall_connector",
       connector_key: connectorKey,
+    });
+  }
+
+  /**
+   * Re-activate a retained connector version (org-local pointer flip — the
+   * bytes already live in the org's `connector_versions` rows). The engine
+   * behind `lobu rollback`'s connector pins.
+   */
+  async rollbackConnectorVersion(
+    connectorKey: string,
+    version: string
+  ): Promise<void> {
+    await this.connectionsTool({
+      action: "rollback_connector_version",
+      connector_key: connectorKey,
+      version,
     });
   }
 

--- a/packages/cli/src/commands/_lib/apply/deployment.ts
+++ b/packages/cli/src/commands/_lib/apply/deployment.ts
@@ -3,9 +3,12 @@
  *
  * Each apply run mints an `apply_id`, sends it as `x-lobu-apply-id` on every
  * mutation (the server stamps its config-audit events with it), and posts a
- * summary to `POST /api/<org>/deployments` at the end. Rollback stays
- * git-first: the summary records the config repo's HEAD SHA so the
- * Deployments UI can point at the commit to revert.
+ * summary to `POST /api/<org>/deployments` at the end — including the
+ * redacted desired-state snapshot (`manifest`) that makes the deployment
+ * self-contained: `lobu rollback <apply_id>` re-applies it through the same
+ * diff/execute engine, repointing connectors to their retained versions. The
+ * summary still records the config repo's HEAD SHA so git-first rollback
+ * (revert commit → re-apply) stays first-class for config-as-code orgs.
  */
 
 import { execFileSync } from "node:child_process";
@@ -46,16 +49,17 @@ export function collectGitInfo(cwd: string): GitInfo {
 }
 
 /**
- * sha256 of the redacted, canonicalized desired state. Beyond the key-name
- * denylist, the fields that hold RESOLVED secret values in process memory are
- * stripped structurally: agent `providerKeys[].value`, org provider `apiKey`,
- * auth-profile `credentials`, and platform `config` values (resolved from
- * `$VAR`/`secret()` at map time). The hash identifies a config revision; two
- * applies of the same config (same secrets or not) hash identically because
- * secret VALUES never participate.
+ * Structurally redact the fields that hold RESOLVED secret values in process
+ * memory — agent `providerKeys[].value`, org provider `apiKey`, auth-profile
+ * `credentials`, and platform `config` values (resolved from `$VAR`/`secret()`
+ * at map time) — then deep-redact by key-name denylist. Shared by the
+ * manifest hash and the stored deployment snapshot: a snapshot NEVER carries
+ * a secret value, so `lobu rollback` structurally cannot re-apply one.
  */
-export function computeManifestHash(state: DesiredState): string {
-  const redacted = deepRedactSecrets({
+export function redactDesiredState(
+  state: DesiredState
+): Record<string, unknown> {
+  return deepRedactSecrets({
     ...state,
     agents: state.agents.map((agent) => ({
       ...agent,
@@ -86,8 +90,65 @@ export function computeManifestHash(state: DesiredState): string {
         credentials: REDACTED_SENTINEL,
       })),
     },
-  });
-  return `sha256:${createHash("sha256").update(canonical(redacted)).digest("hex")}`;
+  }) as Record<string, unknown>;
+}
+
+/**
+ * sha256 of the redacted, canonicalized desired state. The hash identifies a
+ * config revision; two applies of the same config (same secrets or not) hash
+ * identically because secret VALUES never participate.
+ */
+export function computeManifestHash(state: DesiredState): string {
+  return `sha256:${createHash("sha256")
+    .update(canonical(redactDesiredState(state)))
+    .digest("hex")}`;
+}
+
+export const SNAPSHOT_VERSION = 1;
+
+export interface DeploymentManifest {
+  version: typeof SNAPSHOT_VERSION;
+  /**
+   * The redacted desired state, minus connector source bytes: connector
+   * definitions are stripped to declaration metadata, and the artifacts they
+   * resolved to ride `connector_versions` below as retained
+   * (org, key, version) pins — a deployment is self-contained without ever
+   * embedding code or secrets.
+   */
+  state: Record<string, unknown>;
+  /** Active connector version per declared key, recorded post-install. */
+  connector_versions: Record<string, string>;
+}
+
+/**
+ * Build the stored deployment snapshot. `connectorVersions` maps each
+ * config-declared connector key to the version active AFTER this apply
+ * (`install_connector` responses / the refreshed catalog) — the pins
+ * `lobu rollback` repoints to via `rollback_connector_version`.
+ */
+export function buildDeploymentManifest(
+  state: DesiredState,
+  connectorVersions: Record<string, string>
+): DeploymentManifest {
+  const redacted = redactDesiredState(state);
+  const connectors = (redacted.connectors ?? {}) as Record<string, unknown>;
+  const definitions = Array.isArray(connectors.definitions)
+    ? (connectors.definitions as Array<Record<string, unknown>>)
+    : [];
+  return {
+    version: SNAPSHOT_VERSION,
+    state: {
+      ...redacted,
+      connectors: {
+        ...connectors,
+        // Keep the declaration shape for display/diff labels; drop the bytes.
+        definitions: definitions.map(
+          ({ sourceCode: _sourceCode, ...def }) => def
+        ),
+      },
+    },
+    connector_versions: connectorVersions,
+  };
 }
 
 export type CountsByKind = Record<
@@ -118,4 +179,8 @@ export interface DeploymentSummary {
   git_dirty: boolean | null;
   cli_version: string | null;
   error?: string;
+  /** Self-contained snapshot for `lobu rollback` (absent on legacy CLIs). */
+  manifest?: DeploymentManifest;
+  /** Set on rollback deployments: the deployment this one restored. */
+  rollback_of?: string;
 }

--- a/packages/cli/src/commands/_lib/apply/rollback-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/rollback-cmd.ts
@@ -1,0 +1,335 @@
+/**
+ * `lobu rollback <apply_id>` — restore a previous deployment from its stored
+ * snapshot, through the SAME diff/preview/execute engine as `lobu apply`.
+ *
+ * A deployment's manifest is self-contained: the redacted desired state plus
+ * retained connector-version pins ({key: version} → the org's own
+ * `connector_versions` rows). Rollback therefore never re-uploads source,
+ * never fetches URLs, and structurally cannot touch a secret:
+ *
+ *  - connectors: pointer flips via `rollback_connector_version` against the
+ *    recorded pins — the bytes already live org-scoped server-side;
+ *  - config resources: the snapshot state runs through computeDiff/executePlan
+ *    with a plan preview and confirm, exactly like an apply;
+ *  - secrets: the snapshot carries structural redaction sentinels, which
+ *    sanitization converts to "keep current" (credentials undeclared, provider
+ *    keys unpushed, sentinel-bearing platform configs pinned to their current
+ *    remote values) — rollback restores INTENT, never rotates a secret.
+ *
+ * Completing a rollback pauses deployments for the org (Vercel-style paused
+ * promotions): the next `lobu apply` refuses until `--resume`, so a CI run
+ * can't silently re-promote the config that was just rolled back.
+ */
+
+import chalk from "chalk";
+import { REDACTED_SENTINEL } from "@lobu/core";
+import { printError, printText } from "../../../internal/output.js";
+import { ValidationError } from "../../memory/_lib/errors.js";
+import { resolveApplyClient } from "./client.js";
+import type { DesiredState } from "./desired-state.js";
+import { computeDiff } from "./diff.js";
+import { confirmPlan } from "./prompt.js";
+import { renderPlan, renderProgress } from "./render.js";
+import {
+  buildCountsByKind,
+  buildDeploymentManifest,
+  collectGitInfo,
+  computeManifestHash,
+  mintApplyId,
+} from "./deployment.js";
+import {
+  connectorVersionPins,
+  executePlan,
+  fetchRemoteSnapshot,
+  type PendingAuthEntry,
+} from "./apply-cmd.js";
+
+interface RollbackOptions {
+  applyId: string;
+  cwd?: string;
+  yes?: boolean;
+  org?: string;
+  url?: string;
+  cliVersion?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** True when any nested value equals the structural redaction sentinel. */
+function containsSentinel(value: unknown): boolean {
+  if (typeof value === "string") return value === REDACTED_SENTINEL;
+  if (Array.isArray(value)) return value.some(containsSentinel);
+  if (value && typeof value === "object") {
+    return Object.values(value).some(containsSentinel);
+  }
+  return false;
+}
+
+/**
+ * Convert the snapshot's redaction sentinels into "keep current" semantics.
+ * Returns the sanitized state plus operator-facing notes for anything pinned.
+ */
+export function sanitizeSnapshotState(
+  raw: Record<string, unknown>,
+  remotePlatformConfigs: Map<string, Record<string, unknown>>
+): { state: DesiredState; notes: string[] } {
+  const notes: string[] = [];
+  const state = structuredClone(raw) as unknown as DesiredState;
+
+  // The key-name denylist redacts `requiredSecrets` (secret NAMES, not
+  // values) into a sentinel string; a snapshot re-apply never gates on it.
+  state.requiredSecrets = [];
+
+  // Connector definitions ride the pins, not the diff: no source, no installs.
+  state.connectors.definitions = [];
+
+  for (const profile of state.connectors.authProfiles) {
+    // Redacted credentials → undeclared → the diff never re-pushes them and
+    // the profile keeps its live secrets (non-secret fields still reconcile).
+    (profile as { credentials?: unknown }).credentials = undefined;
+  }
+
+  for (const agent of state.agents) {
+    // Provider keys are write-only pushes; a snapshot has no values to push.
+    agent.providerKeys = [];
+    agent.platforms = agent.platforms.filter((platform) => {
+      const p = platform as unknown as {
+        platform?: string;
+        config?: Record<string, unknown>;
+      };
+      if (!containsSentinel(p.config)) return true;
+      // A sentinel inside platform config would be PUSHED verbatim by the
+      // idempotent platform upsert, clobbering the live secret. Pin the whole
+      // platform to its current remote config instead (diff → noop).
+      const key = `${agent.metadata.agentId}:${p.platform ?? "?"}`;
+      const remote = remotePlatformConfigs.get(key);
+      if (remote) {
+        p.config = remote;
+        notes.push(
+          `platform ${key}: secret-bearing config left at current values (rollback never rotates secrets)`
+        );
+        return true;
+      }
+      notes.push(
+        `platform ${key}: secret-bearing config and no live platform to pin to — skipped (re-declare it via lobu apply)`
+      );
+      return false;
+    });
+  }
+
+  state.providers = (state.providers ?? []).map((provider) => ({
+    ...provider,
+    // Empty key → keyDeclared=false → no rotate push; config reconciles.
+    apiKey: "",
+  }));
+
+  return { state, notes };
+}
+
+export async function rollbackCommand(opts: RollbackOptions): Promise<void> {
+  const cwd = opts.cwd ?? process.cwd();
+  const newApplyId = mintApplyId();
+  const { client, orgSlug } = await resolveApplyClient({
+    url: opts.url,
+    org: opts.org,
+    applyId: newApplyId,
+    fetchImpl: opts.fetchImpl,
+  });
+  printText(chalk.dim(`Org: ${orgSlug}`));
+
+  const deployment = await client.getDeployment(opts.applyId);
+  if (!deployment) {
+    throw new ValidationError(
+      `Deployment ${opts.applyId} not found in org "${orgSlug}".`
+    );
+  }
+  if (!deployment.manifest) {
+    throw new ValidationError(
+      [
+        `Deployment ${opts.applyId} predates stored snapshots — no manifest to restore.`,
+        deployment.gitSha
+          ? `Roll back via git instead: revert to ${deployment.gitSha.slice(0, 12)} in your config repo and run \`lobu apply\`.`
+          : "Roll back via git: revert the config repo to the matching commit and run `lobu apply`.",
+      ].join("\n")
+    );
+  }
+
+  const manifest = deployment.manifest;
+  printText(
+    chalk.bold(
+      `\nRolling back to deployment ${opts.applyId}${deployment.createdAt ? ` (${deployment.createdAt})` : ""}`
+    )
+  );
+
+  // ── Connector pins: pointer flips against retained versions ──────────────
+  const catalog = await client.listConnectors(true);
+  const activeByKey = new Map(
+    catalog
+      .filter((d) => d.installed && d.version)
+      .map((d) => [d.key, d.version as string])
+  );
+  const repoints: Array<{ key: string; from: string | undefined; to: string }> =
+    [];
+  for (const [key, version] of Object.entries(
+    manifest.connector_versions ?? {}
+  )) {
+    const current = activeByKey.get(key);
+    if (current !== version) {
+      repoints.push({ key, from: current, to: version });
+    }
+  }
+
+  // ── Config resources: snapshot state through the standard diff ───────────
+  // Two-pass sanitize: the first pass (no remote configs yet) yields a state
+  // shaped well enough to fetch the remote snapshot; the second pins
+  // sentinel-bearing platform configs to the live remote values it found.
+  const prelim = sanitizeSnapshotState(manifest.state, new Map());
+  const remote = await fetchRemoteSnapshot(
+    client,
+    prelim.state,
+    undefined,
+    false
+  );
+  const remotePlatformConfigs = new Map<string, Record<string, unknown>>();
+  for (const [agentId, platforms] of remote.platformsByAgent) {
+    for (const platform of platforms) {
+      if (platform.config) {
+        remotePlatformConfigs.set(
+          `${agentId}:${platform.platform}`,
+          platform.config
+        );
+      }
+    }
+  }
+  const sanitized = sanitizeSnapshotState(
+    manifest.state,
+    remotePlatformConfigs
+  );
+  const plan = computeDiff(sanitized.state, remote, {});
+
+  // ── Preview ───────────────────────────────────────────────────────────────
+  if (repoints.length > 0) {
+    printText(chalk.bold("\nConnector rollbacks:"));
+    for (const r of repoints) {
+      printText(`  ↺ ${r.key}: ${r.from ?? "(not installed)"} → ${r.to}`);
+    }
+  }
+  printText(renderPlan(plan));
+  for (const note of sanitized.notes) {
+    printText(chalk.yellow(`Note: ${note}`));
+  }
+
+  const totalChanges =
+    repoints.length +
+    plan.counts.create +
+    plan.counts.update +
+    plan.counts.delete;
+  if (totalChanges === 0) {
+    printText(
+      chalk.green("\nAlready at this deployment — nothing to roll back.")
+    );
+    return;
+  }
+
+  const approved = await confirmPlan({
+    yes: opts.yes ?? false,
+    summaryLine: `${repoints.length} connector rollback${repoints.length === 1 ? "" : "s"}, ${plan.counts.create} create, ${plan.counts.update} update, ${plan.counts.delete} delete`,
+  });
+  if (!approved) {
+    printText(chalk.dim("\nCancelled."));
+    return;
+  }
+
+  // ── Execute: pins first (catalog correctness for everything after) ────────
+  let rollbackErr: unknown;
+  try {
+    for (const r of repoints) {
+      await client.rollbackConnectorVersion(r.key, r.to);
+      printText(
+        renderProgress(
+          "update",
+          "connector-definition",
+          r.key,
+          `(rolled back to ${r.to})`
+        )
+      );
+    }
+    const hasResourceWork =
+      plan.counts.create > 0 ||
+      plan.counts.update > 0 ||
+      plan.counts.delete > 0;
+    if (hasResourceWork) {
+      printText(chalk.bold("\nApplying snapshot:"));
+      const pendingAuth: PendingAuthEntry[] = [];
+      await executePlan(
+        { client, state: sanitized.state, plan, remote },
+        pendingAuth
+      );
+    }
+    printText(chalk.green("\nRollback complete."));
+  } catch (err) {
+    rollbackErr = err;
+    printError(`\n${err instanceof Error ? err.message : String(err)}`);
+    printError(
+      "Rollback halted on first failure. Re-run once the underlying issue is resolved — every step is idempotent."
+    );
+  }
+
+  // ── Record as a deployment + pause promotions ─────────────────────────────
+  const gitInfo = collectGitInfo(cwd);
+  try {
+    await client.postDeploymentSummary({
+      apply_id: newApplyId,
+      status: rollbackErr ? "partial_failure" : "succeeded",
+      counts: plan.counts,
+      counts_by_kind: {
+        ...buildCountsByKind(plan.rows),
+        ...(repoints.length > 0
+          ? { "connector-version": { update: repoints.length } }
+          : {}),
+      },
+      manifest_hash: computeManifestHash(sanitized.state),
+      git_sha: gitInfo.sha,
+      git_dirty: gitInfo.dirty,
+      cli_version: opts.cliVersion ?? null,
+      rollback_of: opts.applyId,
+      // Re-post the restored snapshot so rolling FORWARD to this deployment
+      // works the same way. Pins reflect what the rollback set.
+      manifest: buildDeploymentManifest(sanitized.state, {
+        ...connectorVersionPins(sanitized.state, catalog),
+        ...Object.fromEntries(repoints.map((r) => [r.key, r.to])),
+        ...manifest.connector_versions,
+      }),
+    });
+  } catch (err) {
+    printText(
+      chalk.yellow(
+        `Warning: could not record the rollback deployment (${err instanceof Error ? err.message : String(err)}).`
+      )
+    );
+  }
+
+  if (!rollbackErr) {
+    try {
+      await client.setDeploymentPause({
+        applyId: newApplyId,
+        rollbackOf: opts.applyId,
+      });
+      printText(
+        [
+          "",
+          chalk.yellow("Deployments are now PAUSED for this org."),
+          "Reconcile your config repo (e.g. `git revert` the bad change), then run:",
+          "  lobu apply --resume",
+        ].join("\n")
+      );
+    } catch (err) {
+      printText(
+        chalk.yellow(
+          `Warning: could not pause deployments (${err instanceof Error ? err.message : String(err)}) — a CI apply may re-promote the rolled-back config.`
+        )
+      );
+    }
+  }
+
+  if (rollbackErr) throw rollbackErr;
+}

--- a/packages/cli/src/commands/_lib/apply/rollback-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/rollback-cmd.ts
@@ -42,6 +42,7 @@ import {
   executePlan,
   fetchRemoteSnapshot,
   type PendingAuthEntry,
+  resolveBehaviorConnectionRefs,
 } from "./apply-cmd.js";
 
 interface RollbackOptions {
@@ -70,7 +71,8 @@ function containsSentinel(value: unknown): boolean {
  */
 export function sanitizeSnapshotState(
   raw: Record<string, unknown>,
-  remotePlatformConfigs: Map<string, Record<string, unknown>>
+  remotePlatformConfigs: Map<string, Record<string, unknown>>,
+  remoteConnectionConfigs: Map<string, Record<string, unknown>> = new Map()
 ): { state: DesiredState; notes: string[] } {
   const notes: string[] = [];
   const state = structuredClone(raw) as unknown as DesiredState;
@@ -87,6 +89,31 @@ export function sanitizeSnapshotState(
     // the profile keeps its live secrets (non-secret fields still reconcile).
     (profile as { credentials?: unknown }).credentials = undefined;
   }
+
+  // Connection configs can carry denylisted keys (an api_key option, etc.):
+  // same rule as platforms — pin the sentinel-bearing config to the live
+  // remote value, or skip the connection when there is none to pin to.
+  state.connectors.connections = state.connectors.connections.filter(
+    (connection) => {
+      const c = connection as unknown as {
+        slug?: string;
+        config?: Record<string, unknown>;
+      };
+      if (!containsSentinel(c.config)) return true;
+      const remote = c.slug ? remoteConnectionConfigs.get(c.slug) : undefined;
+      if (remote) {
+        c.config = remote;
+        notes.push(
+          `connection ${c.slug}: secret-bearing config left at current values (rollback never rotates secrets)`
+        );
+        return true;
+      }
+      notes.push(
+        `connection ${c.slug ?? "?"}: secret-bearing config and no live connection to pin to — skipped (re-declare it via lobu apply)`
+      );
+      return false;
+    }
+  );
 
   for (const agent of state.agents) {
     // Provider keys are write-only pushes; a snapshot has no values to push.
@@ -200,9 +227,24 @@ export async function rollbackCommand(opts: RollbackOptions): Promise<void> {
       }
     }
   }
+  const remoteConnectionConfigs = new Map<string, Record<string, unknown>>();
+  for (const connection of remote.connections) {
+    if (connection.config) {
+      remoteConnectionConfigs.set(connection.slug, connection.config);
+    }
+  }
   const sanitized = sanitizeSnapshotState(
     manifest.state,
-    remotePlatformConfigs
+    remotePlatformConfigs,
+    remoteConnectionConfigs
+  );
+  // Behaviors declare event triggers by connection SLUG; the API contract
+  // wants integer ids — resolve against the live connections, exactly as
+  // apply does.
+  resolveBehaviorConnectionRefs(
+    sanitized.state.watchers,
+    new Map(remote.connections.map((c) => [c.slug, c.id])),
+    false
   );
   const plan = computeDiff(sanitized.state, remote, {});
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -303,6 +303,10 @@ Memory:
       "--force",
       "Bypass the project-link guard if context/org don't match"
     )
+    .option(
+      "--resume",
+      "Clear the promotions pause a `lobu rollback` set and proceed"
+    )
     .action(
       async (options: {
         dryRun?: boolean;
@@ -311,6 +315,7 @@ Memory:
         org?: string;
         url?: string;
         force?: boolean;
+        resume?: boolean;
       }) => {
         if (
           options.only !== undefined &&
@@ -333,6 +338,35 @@ Memory:
           org: options.org,
           url: options.url,
           force: options.force,
+          resume: options.resume,
+          cliVersion: version,
+        });
+      }
+    );
+
+  // ─── rollback ───────────────────────────────────────────────────────────
+  program
+    .command("rollback")
+    .argument("<applyId>", "Deployment to restore (apl_… from `Deployments`)")
+    .description(
+      "Restore a previous deployment from its stored snapshot (pauses future applies until --resume)"
+    )
+    .option("--yes", "Skip the confirmation prompt (CI mode)")
+    .option("--org <slug>", "Org slug override (defaults to active session)")
+    .option("--url <url>", "Server URL override")
+    .action(
+      async (
+        applyId: string,
+        options: { yes?: boolean; org?: string; url?: string }
+      ) => {
+        const { rollbackCommand } = await import(
+          "./commands/_lib/apply/rollback-cmd.js"
+        );
+        await rollbackCommand({
+          applyId,
+          yes: options.yes,
+          org: options.org,
+          url: options.url,
           cliVersion: version,
         });
       }

--- a/packages/server/src/lobu/__tests__/deployment-routes.test.ts
+++ b/packages/server/src/lobu/__tests__/deployment-routes.test.ts
@@ -396,3 +396,100 @@ describe('x-lobu-apply-id end-to-end through a real mutation', () => {
     expect(metadata2.actor_source).toBe('ui');
   });
 });
+
+describe('deployment snapshots + promotions pause (lobu rollback)', () => {
+  test('stores the manifest, returns it from detail, and stamps rollback_of', async () => {
+    const app = await importDeploymentRoutes();
+    const manifest = {
+      version: 1,
+      state: { agents: [], connectors: { definitions: [], authProfiles: [], connections: [] } },
+      connector_versions: { 'zz.probe': '1.2.0' },
+    };
+
+    const posted = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(summaryBody({ manifest })),
+    });
+    expect(posted.status).toBe(201);
+
+    const detail = await app.request(`/${APPLY_ID}`);
+    expect(detail.status).toBe(200);
+    const body = (await detail.json()) as { deployment: Record<string, any> };
+    expect(body.deployment.manifest).toEqual(manifest);
+    expect(body.deployment.rollbackOf).toBeNull();
+
+    // A rollback deployment references what it restored, in detail AND feed.
+    const rollbackId = 'apl_99999999-8888-7777-6666-555555555555';
+    const rolled = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(
+        summaryBody({ apply_id: rollbackId, rollback_of: APPLY_ID, manifest })
+      ),
+    });
+    expect(rolled.status).toBe(201);
+    const rolledDetail = (await (await app.request(`/${rollbackId}`)).json()) as {
+      deployment: Record<string, any>;
+    };
+    expect(rolledDetail.deployment.rollbackOf).toBe(APPLY_ID);
+    const feed = (await (await app.request('/')).json()) as {
+      items: Array<Record<string, any>>;
+    };
+    const feedRow = feed.items.find((i) => i.applyId === rollbackId);
+    expect(feedRow?.rollbackOf).toBe(APPLY_ID);
+  });
+
+  test('rejects a non-object manifest and an oversized manifest', async () => {
+    const app = await importDeploymentRoutes();
+    const notObject = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(summaryBody({ manifest: [1, 2, 3] })),
+    });
+    expect(notObject.status).toBe(400);
+
+    const oversized = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(
+        summaryBody({ manifest: { blob: 'x'.repeat(1_000_001) } })
+      ),
+    });
+    expect(oversized.status).toBe(400);
+  });
+
+  test('pause lifecycle: unpaused → PUT → paused (org-scoped) → DELETE → unpaused', async () => {
+    const app = await importDeploymentRoutes();
+
+    const initial = (await (await app.request('/pause')).json()) as {
+      paused: boolean;
+    };
+    expect(initial.paused).toBe(false);
+
+    const set = await app.request('/pause', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        apply_id: 'apl_99999999-8888-7777-6666-555555555555',
+        rollback_of: APPLY_ID,
+      }),
+    });
+    expect(set.status).toBe(200);
+
+    const paused = (await (await app.request('/pause')).json()) as Record<string, any>;
+    expect(paused.paused).toBe(true);
+    expect(paused.rollbackOf).toBe(APPLY_ID);
+
+    // Pause is org-scoped: another org is unaffected.
+    authStash.organizationId = OTHER_ORG;
+    const otherOrg = (await (await app.request('/pause')).json()) as { paused: boolean };
+    expect(otherOrg.paused).toBe(false);
+    authStash.organizationId = ORG;
+
+    const cleared = await app.request('/pause', { method: 'DELETE' });
+    expect(cleared.status).toBe(200);
+    const after = (await (await app.request('/pause')).json()) as { paused: boolean };
+    expect(after.paused).toBe(false);
+  });
+});

--- a/packages/server/src/lobu/deployment-routes.ts
+++ b/packages/server/src/lobu/deployment-routes.ts
@@ -43,6 +43,12 @@ routes.use("*", async (c, next) => {
 
 const DEPLOYMENT_STATUSES = new Set(["succeeded", "partial_failure"]);
 
+// Stored manifest ceiling. The manifest is the REDACTED desired-state
+// snapshot minus connector source bytes (those live in connector_versions and
+// the manifest references them as {key: version} pins), so real configs are
+// tens of KBs; the cap only guards against a pathological payload.
+const MANIFEST_MAX_BYTES = 1_000_000;
+
 function clampLimit(raw: string | undefined, fallback: number, max: number) {
 	const parsed = Number.parseInt(raw ?? String(fallback), 10);
 	return Number.isFinite(parsed) ? Math.min(Math.max(parsed, 1), max) : fallback;
@@ -88,6 +94,26 @@ routes.post("/", async (c) => {
 			? body.counts_by_kind
 			: {};
 	const errorText = typeof body.error === "string" ? body.error : null;
+	// Rollback deployments reference the deployment they restored.
+	const rollbackOf = parseApplyId(
+		typeof body.rollback_of === "string" ? body.rollback_of : null,
+	);
+	// The self-contained desired-state snapshot (secrets structurally redacted
+	// CLI-side; connector bytes referenced as retained {key: version} pins, not
+	// embedded) — what `lobu rollback` re-applies.
+	let manifest: Record<string, unknown> | null = null;
+	if (body.manifest !== undefined && body.manifest !== null) {
+		if (typeof body.manifest !== "object" || Array.isArray(body.manifest)) {
+			return c.json({ error: "manifest must be an object" }, 400);
+		}
+		if (JSON.stringify(body.manifest).length > MANIFEST_MAX_BYTES) {
+			return c.json(
+				{ error: `manifest exceeds ${MANIFEST_MAX_BYTES} bytes` },
+				400,
+			);
+		}
+		manifest = body.manifest as Record<string, unknown>;
+	}
 
 	const sql = getDb();
 	// Retried POSTs (CLI network blip) must not create a second deployment row.
@@ -120,6 +146,7 @@ routes.post("/", async (c) => {
 		payloadData: {
 			counts_by_kind: countsByKind,
 			...(errorText ? { error: errorText } : {}),
+			...(manifest ? { manifest } : {}),
 		},
 		metadata: {
 			category: "deployment",
@@ -130,6 +157,7 @@ routes.post("/", async (c) => {
 			git_dirty: gitDirty,
 			cli_version: cliVersion,
 			counts,
+			...(rollbackOf ? { rollback_of: rollbackOf } : {}),
 		},
 		createdBy: applyCtx.createdBy,
 		clientId: applyCtx.clientId,
@@ -184,6 +212,7 @@ routes.get("/", async (c) => {
 				gitSha: metadata.git_sha ?? null,
 				gitDirty: metadata.git_dirty ?? null,
 				cliVersion: metadata.cli_version ?? null,
+				rollbackOf: metadata.rollback_of ?? null,
 				createdBy: row.created_by ?? null,
 			};
 		}
@@ -282,6 +311,72 @@ routes.get("/changes/:eventId", async (c) => {
 	return c.json({ change: toChangeDetail(rows[0]) });
 });
 
+// ── Promotions pause (set by `lobu rollback`, cleared by `lobu apply --resume`) ──
+// Registered before `/:applyId` so the literal segment wins the match. A
+// workflow guard for the org's own operators (CI must not silently re-promote
+// over a deliberate rollback), not a security boundary.
+
+routes.get("/pause", async (c) => {
+	const organizationId = c.get("organizationId") as string;
+	const sql = getDb();
+	const rows = await sql`
+		SELECT paused_at, apply_id, rollback_of, paused_by
+		FROM deployment_pause
+		WHERE organization_id = ${organizationId}
+		LIMIT 1
+	`;
+	if (rows.length === 0) return c.json({ paused: false });
+	const row = rows[0];
+	return c.json({
+		paused: true,
+		pausedAt: row.paused_at,
+		applyId: row.apply_id ?? null,
+		rollbackOf: row.rollback_of ?? null,
+		pausedBy: row.paused_by ?? null,
+	});
+});
+
+routes.put("/pause", async (c) => {
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const organizationId = c.get("organizationId") as string;
+
+	let body: Record<string, unknown>;
+	try {
+		body = await c.req.json();
+	} catch {
+		body = {};
+	}
+	const applyId = parseApplyId(
+		typeof body.apply_id === "string" ? body.apply_id : null,
+	);
+	const rollbackOf = parseApplyId(
+		typeof body.rollback_of === "string" ? body.rollback_of : null,
+	);
+	const applyCtx = getApplyContext(c);
+
+	const sql = getDb();
+	await sql`
+		INSERT INTO deployment_pause (organization_id, apply_id, rollback_of, paused_by)
+		VALUES (${organizationId}, ${applyId}, ${rollbackOf}, ${applyCtx.createdBy ?? null})
+		ON CONFLICT (organization_id) DO UPDATE
+		SET paused_at = now(),
+		    apply_id = EXCLUDED.apply_id,
+		    rollback_of = EXCLUDED.rollback_of,
+		    paused_by = EXCLUDED.paused_by
+	`;
+	return c.json({ paused: true });
+});
+
+routes.delete("/pause", async (c) => {
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const organizationId = c.get("organizationId") as string;
+	const sql = getDb();
+	await sql`DELETE FROM deployment_pause WHERE organization_id = ${organizationId}`;
+	return c.json({ paused: false });
+});
+
 // ── Deployment detail ────────────────────────────────────────────────────────
 
 routes.get("/:applyId", async (c) => {
@@ -325,6 +420,8 @@ routes.get("/:applyId", async (c) => {
 			gitSha: summaryMeta.git_sha ?? null,
 			gitDirty: summaryMeta.git_dirty ?? null,
 			cliVersion: summaryMeta.cli_version ?? null,
+			rollbackOf: summaryMeta.rollback_of ?? null,
+			manifest: summaryPayload.manifest ?? null,
 			createdBy: summary.created_by ?? null,
 		},
 		changes: changeRows.map(toChangeDetail),


### PR DESCRIPTION
## What

Caps the #2045 stack (on #2066 → #2065 → #2064) with the Vercel-model deployment story, sized to lobu:

**Deployments become self-contained.** `lobu apply` uploads a manifest with its summary: the **redacted** desired state (secrets structurally stripped — the exact object `computeManifestHash` already canonicalizes, factored as `redactDesiredState`) minus connector source bytes, plus retained connector-version pins (`{key: version}` recorded post-install against the org-scoped rows the earlier PRs guarantee).

**`lobu rollback <apply_id>`** restores a deployment from its stored snapshot through the **same diff/preview/execute engine as apply**:
- connectors: pointer flips via `rollback_connector_version` — no source re-push, no fetches, no compiles;
- config resources: `computeDiff`/`executePlan` with plan preview + confirm;
- secrets: sanitization converts every redaction sentinel to *keep-current* (credentials undeclared, provider keys unpushed, sentinel-bearing platform configs pinned to live remote values or skipped with a note) — rollback restores intent and **structurally cannot rotate or clobber a secret**;
- recorded as a NEW deployment with `rollback_of` (append-only history, shows in the Deployments feed).

**Promotions pause** (Vercel's paused-promotions): rollback sets an org-scoped flag (`deployment_pause` table, Postgres-mediated); the next `lobu apply` refuses until `--resume` — CI can never silently re-promote the config that was just rolled back. Pre-snapshot deployments error with the git-first instruction (revert + re-apply), which stays fully supported.

## Server
`POST /deployments` accepts `manifest` (1MB cap) + `rollback_of`; detail route returns them; `GET/PUT/DELETE /deployments/pause`.

## Testing
- deployment-routes (bun): manifest round-trip + `rollback_of` in feed/detail, size/shape caps, org-scoped pause lifecycle — 11 pass.
- CLI (bun): snapshot carries no secret values or source bytes; sentinel→keep-current sanitization incl. platform pin/drop — 228 pass across apply suite.
- Server `integration/connectors`: 296 pass. `make pre-pr` + squawk clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->