### PR TITLE
fix(connectors): skip bundled (NULL-org) definitions in connector_versions backfill (#2067)

### DIFF
--- a/db/migrations/20260721130000_connector_versions_org_backfill.sql
+++ b/db/migrations/20260721130000_connector_versions_org_backfill.sql
@@ -9,6 +9,14 @@
 -- key, so every installer keeps its full retained history on its own rows.
 -- No status filter: a disabled connector's history must survive for
 -- rollback_connector_version after re-enable.
+--
+-- Only ORG-OWNED definitions are backfill targets (d.organization_id IS NOT
+-- NULL). A connector_definitions row with organization_id IS NULL is a
+-- bundled catalog definition, not an org install — copying a shared custom
+-- row to it re-emits a shared (organization_id IS NULL) row that collides
+-- with the source row on the connector_versions_shared_key_version arbiter,
+-- which this INSERT's org-only ON CONFLICT clause does not cover, aborting
+-- the migration. Bundled definitions own nothing; their shared rows stay put.
 INSERT INTO public.connector_versions (
   connector_key, version, organization_id, compiled_code, compiled_code_hash,
   compile_config_hash, source_code, source_path, created_at
@@ -20,6 +28,7 @@ SELECT DISTINCT ON (d.organization_id, cv.connector_key, cv.version)
 FROM public.connector_versions cv
 JOIN public.connector_definitions d ON d.key = cv.connector_key
 WHERE cv.organization_id IS NULL
+  AND d.organization_id IS NOT NULL
   AND (cv.source_code IS NOT NULL OR cv.compiled_code IS NOT NULL)
 ORDER BY d.organization_id, cv.connector_key, cv.version
 ON CONFLICT (organization_id, connector_key, version) WHERE organization_id IS NOT NULL

--- a/packages/server/src/__tests__/integration/connectors/connector-version-org-backfill-migration.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-version-org-backfill-migration.test.ts
@@ -86,6 +86,24 @@ describe('connector_versions org backfill migration', () => {
         VALUES ('zz.bf.orphan', '1.0.0', NULL, '// orphan', NOW())
       `;
 
+      // Regression for #2067: a BUNDLED definition (organization_id IS NULL)
+      // whose key also carries a shared custom row — the exact prod shape
+      // (e.g. capterra, github: a NULL-org catalog definition alongside a
+      // shared source_code row). The backfill must NOT treat the bundled
+      // definition as an owner: copying to it re-emits a shared row that
+      // collides with the source row on connector_versions_shared_key_version
+      // (uncovered by the org-only ON CONFLICT), which aborted the migration.
+      // Expected: the shared custom row stays put, no error.
+      await tx`
+        INSERT INTO connector_definitions
+          (key, name, version, organization_id, status, created_at, updated_at)
+        VALUES ('zz.bf.bundledcustom', 'BF Bundled Custom', '1.0.0', NULL, 'active', NOW(), NOW())
+      `;
+      await tx`
+        INSERT INTO connector_versions (connector_key, version, organization_id, source_code, created_at)
+        VALUES ('zz.bf.bundledcustom', '1.0.0', NULL, '// bundled custom v1', NOW())
+      `;
+
       await tx.unsafe(upSection);
 
       const rows = (await tx`
@@ -126,6 +144,13 @@ describe('connector_versions org backfill migration', () => {
       const orphan = byKey('zz.bf.orphan', '1.0.0');
       expect(orphan).toHaveLength(1);
       expect(orphan[0]?.organization_id).toBeNull();
+
+      // #2067: bundled (NULL-org) definition is not an owner — no copy made,
+      // shared custom row stays exactly one shared row, migration did not abort.
+      const bundledCustom = byKey('zz.bf.bundledcustom', '1.0.0');
+      expect(bundledCustom).toHaveLength(1);
+      expect(bundledCustom[0]?.organization_id).toBeNull();
+      expect(bundledCustom[0]?.source_code).toBe('// bundled custom v1');
 
       // Roll the seeds back — this test must not leak state into the suite.
       throw new Error('__rollback__');


### PR DESCRIPTION
## What

Fixes the migration that blocked the #2045 connector-isolation rollout from deploying. The #2066 backfill migration (`20260721130000_connector_versions_org_backfill.sql`) **aborts in prod** with a duplicate-key error, so the pre-upgrade `summaries-app-lobu-migrate` job fails (`BackoffLimitExceeded`), Helm rolls back every attempt, and the whole #2045 stack never ships.

## Root cause

The backfill `INSERT ... SELECT` joins `connector_definitions` to copy each shared custom `connector_versions` row to its owning orgs, inserting `d.organization_id`. **Bundled catalog definitions carry `organization_id IS NULL`.** For those, the INSERT re-emits a *shared* (`organization_id IS NULL`) row that collides with the existing source row on the `connector_versions_shared_key_version` arbiter — which the INSERT's org-only `ON CONFLICT (...) WHERE organization_id IS NOT NULL` clause does **not** cover — so it raises `23505` instead of `DO NOTHING`:

```
duplicate key value violates unique constraint "connector_versions_shared_key_version"
detail: Key (connector_key, version)=(capterra, 1.0.0) already exists.
```

In prod (`owletto`) there are **21 bundled definitions with `organization_id IS NULL`** whose keys also carry shared custom rows (`capterra`, `github`, `google_photos`, `revolut`, …), so the migration is guaranteed to hit this.

## Fix

Add `AND d.organization_id IS NOT NULL` to the backfill INSERT's WHERE. Bundled definitions are not org installs — they own nothing, so they should never be backfill targets. Their shared rows stay put; only real org installs get org-scoped copies. The DELETE is unchanged (still retires only shared rows some org now retains).

## Verification

- **Replayed the fixed migration against real prod data** in a rolled-back transaction on the prod primary — no error; `116 rows / 116 shared / 0 org-scoped` → `163 / 34 shared / 129 org-scoped`; the orphan-check query leaves only one genuine orphan (`microsoft.outlook 1.0.0`, no definition anywhere).
- **New regression test** seeds a NULL-org bundled definition alongside a shared custom row (the exact prod shape). It reproduces the `23505` without the fix and passes with it.
- **Full `integration/connectors` suite: 43 files / 296 tests green.**
- Server package `tsc --noEmit`: clean.

## After merge

This unblocks the stuck deploy. Once an image built from this commit rolls out and the migrate job succeeds, the two remaining boxes on #2067 can be checked (prune re-run is a no-op — 0 rows currently match; orphan-check will then return only the true orphan).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed connector version migrations failing when bundled connector definitions shared keys with custom versions.
  * Ensured bundled/shared connector data remains intact during organization-specific backfills.

* **Tests**
  * Added coverage for migration scenarios involving shared connector definitions and version collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->