### PR TITLE
feat(errors): structured connector/query error taxonomy + auto-retry (#2051)

### DIFF
--- a/packages/connector-worker/src/__tests__/http-status-extract.test.ts
+++ b/packages/connector-worker/src/__tests__/http-status-extract.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Near-end of the connector-side taxonomy pipe (lobu#2051 Item 2): the child
+ * runner serializes a thrown error to IPC and must forward a numeric HTTP status
+ * (from the SDK's HttpStatusError) so the gateway can classify 429/5xx honestly.
+ * This tests that extraction directly — the IPC transport in between is Node's
+ * process.send, not our code.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { extractHttpStatus } from '../executor/http-status.js';
+
+// Mirror of the SDK's HttpStatusError shape (name + numeric status).
+class HttpStatusErrorLike extends Error {
+  status: number;
+  constructor(status: number) {
+    super(`request failed (${status})`);
+    this.name = 'HttpStatusError';
+    this.status = status;
+  }
+}
+
+describe('extractHttpStatus', () => {
+  test('pulls the numeric status off an HttpStatusError-shaped error', () => {
+    expect(extractHttpStatus(new HttpStatusErrorLike(429))).toBe(429);
+    expect(extractHttpStatus(new HttpStatusErrorLike(503))).toBe(503);
+    expect(extractHttpStatus(new HttpStatusErrorLike(404))).toBe(404);
+  });
+
+  test('reads a plain object carrying status', () => {
+    expect(extractHttpStatus({ status: 500 })).toBe(500);
+  });
+
+  test('returns undefined when there is no plausible status', () => {
+    expect(extractHttpStatus(new Error('boom'))).toBeUndefined();
+    expect(extractHttpStatus({ status: 'nope' })).toBeUndefined();
+    expect(extractHttpStatus({ status: 42 })).toBeUndefined(); // out of HTTP range
+    expect(extractHttpStatus({ status: 700 })).toBeUndefined();
+    expect(extractHttpStatus(null)).toBeUndefined();
+    expect(extractHttpStatus(undefined)).toBeUndefined();
+    expect(extractHttpStatus('429')).toBeUndefined(); // string, not object
+  });
+});

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -11,6 +11,7 @@ import { rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { EventEnvelope, SyncResult } from '@lobu/connector-sdk';
+import { extractHttpStatus } from './http-status.js';
 import type { ExecutorJob, ExecutorResult } from './interface.js';
 
 const EVENT_CHUNK_SIZE = 100;
@@ -403,6 +404,7 @@ function installUncaughtHandlers(): void {
     handled = true;
     const e =
       err instanceof Error ? err : new Error(typeof err === 'string' ? err : safeStringify(err));
+    const httpStatus = extractHttpStatus(err);
     try {
       await sendIPC({
         type: 'error',
@@ -410,6 +412,11 @@ function installUncaughtHandlers(): void {
           message: e.message,
           stack: e.stack,
           name: e.name,
+          // Propagate a structured HTTP status (e.g. from the SDK's HttpStatusError)
+          // so the gateway can classify 429/5xx honestly instead of re-parsing the
+          // redacted message string (lobu#2051 Item 2). A plain number carries no
+          // secret, so it survives redaction unmodified.
+          ...(httpStatus !== undefined ? { httpStatus } : {}),
         },
       });
     } catch {
@@ -539,6 +546,9 @@ async function main() {
           message: error.message,
           stack: error.stack,
           name: error.name,
+          ...(extractHttpStatus(error) !== undefined
+            ? { httpStatus: extractHttpStatus(error) }
+            : {}),
         },
       });
     } finally {

--- a/packages/connector-worker/src/executor/http-status.ts
+++ b/packages/connector-worker/src/executor/http-status.ts
@@ -1,0 +1,20 @@
+/**
+ * Extract a structured HTTP status from a connector-thrown error (lobu#2051 Item 2).
+ *
+ * Lives in its own side-effect-free module (child-runner.ts runs `main()` at import
+ * time, so it's not a safe import target for tests). The connector SDK's
+ * `HttpStatusError` sets a numeric `status`; carrying that number to the gateway
+ * lets it classify 429/5xx honestly instead of keyword-matching the redacted
+ * message string.
+ */
+
+/**
+ * Pull a numeric HTTP status off a thrown error when the connector used the SDK's
+ * `HttpStatusError` (or any error carrying a numeric `status`). Returns undefined
+ * when there's no plausible status, so callers can omit the field entirely.
+ */
+export function extractHttpStatus(err: unknown): number | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const status = (err as { status?: unknown }).status;
+  return typeof status === 'number' && status >= 100 && status < 600 ? status : undefined;
+}

--- a/packages/connector-worker/src/executor/subprocess.ts
+++ b/packages/connector-worker/src/executor/subprocess.ts
@@ -60,6 +60,12 @@ interface SubprocessDiagnostics {
   exitSignal: string | null;
   outputTail: string;
   exitReason: SubprocessExitReason;
+  /**
+   * Upstream HTTP status when the connector threw the SDK's HttpStatusError, so
+   * the gateway can classify 429/5xx honestly rather than by keyword-matching the
+   * redacted message (lobu#2051 Item 2). Undefined for non-HTTP failures.
+   */
+  httpStatus?: number;
 }
 
 export class SubprocessError extends Error implements SubprocessDiagnostics {
@@ -67,6 +73,7 @@ export class SubprocessError extends Error implements SubprocessDiagnostics {
   exitSignal: string | null;
   outputTail: string;
   exitReason: SubprocessExitReason;
+  httpStatus?: number;
 
   constructor(
     message: string,
@@ -79,6 +86,7 @@ export class SubprocessError extends Error implements SubprocessDiagnostics {
     this.exitSignal = diagnostics.exitSignal;
     this.outputTail = diagnostics.outputTail;
     this.exitReason = diagnostics.exitReason;
+    this.httpStatus = diagnostics.httpStatus;
   }
 }
 
@@ -437,11 +445,17 @@ export class SubprocessExecutor implements SyncExecutor {
         if (msg.type === 'error') {
           terminalMessageReceived = true;
           const tail = redactOutput(combinedTail());
+          // A numeric HTTP status (from the SDK's HttpStatusError) is not
+          // secret-bearing, so it rides alongside the redacted message and lets
+          // the gateway classify 429/5xx honestly (lobu#2051 Item 2).
+          const ipcHttpStatus =
+            typeof msg.error?.httpStatus === 'number' ? msg.error.httpStatus : undefined;
           const diagnostics: SubprocessDiagnostics = {
             exitCode: null,
             exitSignal: null,
             outputTail: tail,
             exitReason: 'error_message',
+            httpStatus: ipcHttpStatus,
           };
           // Connector code is allowed to throw with the offending value
           // embedded — `throw new Error('failed with api_key=sk_live_…')`.

--- a/packages/core/src/__tests__/connector-query-errors.test.ts
+++ b/packages/core/src/__tests__/connector-query-errors.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import {
+  classifyToolError,
+  isRetryable,
+  isToolError,
+  TOOL_ERRORS,
+  ToolError,
+  type ToolErrorCode,
+  toToolErrorCode,
+} from "../connector-query-errors";
+
+describe("TOOL_ERRORS catalog", () => {
+  test("every code has a spec with a message", () => {
+    for (const [code, spec] of Object.entries(TOOL_ERRORS)) {
+      expect(typeof spec.retryable).toBe("boolean");
+      expect(spec.message.length).toBeGreaterThan(0);
+      // isRetryable agrees with the spec
+      expect(isRetryable(code as ToolErrorCode)).toBe(spec.retryable);
+    }
+  });
+
+  test("permanent codes are not retryable", () => {
+    for (const code of [
+      "AUTH_MISSING",
+      "AUTH_INVALID",
+      "NOT_FOUND",
+      "VALIDATION",
+      "PERMISSION",
+      "INTERNAL",
+    ] as ToolErrorCode[]) {
+      expect(isRetryable(code)).toBe(false);
+    }
+  });
+
+  test("transient codes are retryable", () => {
+    for (const code of [
+      "RATE_LIMITED",
+      "UPSTREAM_TIMEOUT",
+      "UPSTREAM_5XX",
+      "NETWORK",
+      "UPSTREAM_UNAVAILABLE",
+    ] as ToolErrorCode[]) {
+      expect(isRetryable(code)).toBe(true);
+    }
+  });
+});
+
+describe("toToolErrorCode", () => {
+  test("accepts known codes, rejects everything else", () => {
+    expect(toToolErrorCode("RATE_LIMITED")).toBe("RATE_LIMITED");
+    expect(toToolErrorCode("NOPE")).toBeUndefined();
+    expect(toToolErrorCode(429)).toBeUndefined();
+    expect(toToolErrorCode(null)).toBeUndefined();
+    expect(toToolErrorCode(undefined)).toBeUndefined();
+  });
+});
+
+describe("ToolError", () => {
+  test("derives retryable + default message from the code", () => {
+    const e = new ToolError("RATE_LIMITED");
+    expect(e.code).toBe("RATE_LIMITED");
+    expect(e.retryable).toBe(true);
+    expect(e.message).toBe(TOOL_ERRORS.RATE_LIMITED.message);
+    expect(e.name).toBe("ToolError");
+    expect(isToolError(e)).toBe(true);
+    expect(isToolError(new Error("plain"))).toBe(false);
+  });
+
+  test("honors a custom message and callId, preserves cause", () => {
+    const cause = new Error("root");
+    const e = new ToolError("AUTH_MISSING", "connector X needs auth", {
+      cause,
+      callId: "abc-123",
+    });
+    expect(e.retryable).toBe(false);
+    expect(e.message).toBe("connector X needs auth");
+    expect(e.callId).toBe("abc-123");
+    expect(e.cause).toBe(cause);
+  });
+
+  test("toJSON emits code/retryable/message and call_id only when set", () => {
+    expect(new ToolError("NOT_FOUND").toJSON()).toEqual({
+      code: "NOT_FOUND",
+      retryable: false,
+      message: TOOL_ERRORS.NOT_FOUND.message,
+    });
+    const withId = new ToolError("NETWORK", undefined, { callId: "c1" }).toJSON();
+    expect(withId.call_id).toBe("c1");
+  });
+});
+
+describe("classifyToolError", () => {
+  test("HTTP status precedence", () => {
+    expect(classifyToolError({ httpStatus: 429 })).toBe("RATE_LIMITED");
+    expect(classifyToolError({ httpStatus: 401 })).toBe("AUTH_INVALID");
+    expect(classifyToolError({ httpStatus: 403 })).toBe("AUTH_INVALID");
+    expect(classifyToolError({ httpStatus: 404 })).toBe("NOT_FOUND");
+    expect(classifyToolError({ httpStatus: 408 })).toBe("UPSTREAM_TIMEOUT");
+    expect(classifyToolError({ httpStatus: 504 })).toBe("UPSTREAM_TIMEOUT");
+    expect(classifyToolError({ httpStatus: 500 })).toBe("UPSTREAM_5XX");
+    expect(classifyToolError({ httpStatus: 502 })).toBe("UPSTREAM_5XX");
+    expect(classifyToolError({ httpStatus: 400 })).toBe("VALIDATION");
+    expect(classifyToolError({ httpStatus: 422 })).toBe("VALIDATION");
+  });
+
+  test("PG codes", () => {
+    expect(classifyToolError({ pgCode: "57014" })).toBe("UPSTREAM_TIMEOUT");
+    expect(classifyToolError({ pgCode: "08006" })).toBe("NETWORK");
+    expect(classifyToolError({ pgCode: "40001" })).toBe("NETWORK");
+    expect(classifyToolError({ pgCode: "40P01" })).toBe("NETWORK");
+    expect(classifyToolError({ pgCode: "42601" })).toBe("VALIDATION"); // syntax_error
+  });
+
+  test("subprocess exit reasons", () => {
+    expect(classifyToolError({ exitReason: "timeout" })).toBe("UPSTREAM_TIMEOUT");
+    expect(classifyToolError({ exitReason: "oom" })).toBe("UPSTREAM_UNAVAILABLE");
+    expect(classifyToolError({ exitReason: "crash" })).toBe("UPSTREAM_UNAVAILABLE");
+  });
+
+  test("error_message exit reason falls through to message matching", () => {
+    expect(
+      classifyToolError({ exitReason: "error_message", message: "429 too many requests" })
+    ).toBe("RATE_LIMITED");
+    expect(
+      classifyToolError({ exitReason: "error_message", message: "ECONNRESET" })
+    ).toBe("NETWORK");
+    // no structured hint and an opaque message → INTERNAL
+    expect(
+      classifyToolError({ exitReason: "error_message", message: "something odd" })
+    ).toBe("INTERNAL");
+  });
+
+  test("explicit transient flag wins when no status/pgCode", () => {
+    expect(classifyToolError({ transient: true })).toBe("NETWORK");
+  });
+
+  test("structured fields win over the message string", () => {
+    // message says 'timeout' (would keyword-match) but 404 is authoritative → NOT_FOUND
+    expect(classifyToolError({ httpStatus: 404, message: "timeout while fetching" })).toBe(
+      "NOT_FOUND"
+    );
+  });
+
+  test("message fallback", () => {
+    expect(classifyToolError({ message: "rate limit exceeded" })).toBe("RATE_LIMITED");
+    expect(classifyToolError({ message: "fetch failed: ENOTFOUND" })).toBe("NETWORK");
+    expect(classifyToolError({})).toBe("INTERNAL");
+    expect(classifyToolError({ message: "totally unrelated" })).toBe("INTERNAL");
+  });
+});

--- a/packages/core/src/__tests__/connector-query-errors.test.ts
+++ b/packages/core/src/__tests__/connector-query-errors.test.ts
@@ -103,12 +103,26 @@ describe("classifyToolError", () => {
     expect(classifyToolError({ httpStatus: 422 })).toBe("VALIDATION");
   });
 
-  test("PG codes", () => {
+  test("PG SQLSTATE codes", () => {
     expect(classifyToolError({ pgCode: "57014" })).toBe("UPSTREAM_TIMEOUT");
     expect(classifyToolError({ pgCode: "08006" })).toBe("NETWORK");
     expect(classifyToolError({ pgCode: "40001" })).toBe("NETWORK");
     expect(classifyToolError({ pgCode: "40P01" })).toBe("NETWORK");
     expect(classifyToolError({ pgCode: "42601" })).toBe("VALIDATION"); // syntax_error
+  });
+
+  test("non-SQLSTATE driver codes fall through to message matching (not VALIDATION)", () => {
+    // postgres.js surfaces connection-level failures with a non-SQLSTATE `code`.
+    // These must NOT be swallowed by the pgCode branch's VALIDATION catch-all —
+    // they should classify from the message as the transient failures they are.
+    expect(
+      classifyToolError({ pgCode: "ECONNREFUSED", message: "write ECONNREFUSED 127.0.0.1:5432" })
+    ).toBe("NETWORK");
+    expect(
+      classifyToolError({ pgCode: "CONNECTION_CLOSED", message: "connection terminated" })
+    ).toBe("NETWORK");
+    // A non-SQLSTATE code with no transient message hint → INTERNAL, not VALIDATION.
+    expect(classifyToolError({ pgCode: "SOME_DRIVER_CODE", message: "weird" })).toBe("INTERNAL");
   });
 
   test("subprocess exit reasons", () => {

--- a/packages/core/src/connector-query-errors.ts
+++ b/packages/core/src/connector-query-errors.ts
@@ -208,7 +208,11 @@ export function classifyToolError(signal: ToolErrorSignal): ToolErrorCode {
     if (httpStatus >= 400) return "VALIDATION";
   }
 
-  if (pgCode) {
+  // Only a real 5-char SQLSTATE is authoritative here. The postgres.js driver also
+  // surfaces connection-level failures with a non-SQLSTATE `code` (e.g.
+  // 'ECONNREFUSED', 'CONNECTION_CLOSED') — those must fall through to the message
+  // matching below so a transient DB-connection drop stays NETWORK, not VALIDATION.
+  if (pgCode && /^[0-9A-Z]{5}$/.test(pgCode)) {
     if (pgCode === "57014") return "UPSTREAM_TIMEOUT"; // query_canceled / statement_timeout
     // 08xxx = connection exceptions (transient); 40001 = serialization failure; 40P01 = deadlock.
     if (pgCode.startsWith("08") || pgCode === "40001" || pgCode === "40P01") return "NETWORK";

--- a/packages/core/src/connector-query-errors.ts
+++ b/packages/core/src/connector-query-errors.ts
@@ -1,0 +1,235 @@
+/**
+ * Structured error taxonomy for connector and query (read) tool paths — lobu#2051 (Item 2).
+ *
+ * This is a *separate* catalog from `AGENT_ERRORS` (errors.ts), which is
+ * agent-turn/worker-scoped and wired to `classifyError → renderAgentError → CTA`.
+ * Connector/query tools (query_sql, query_sdk, run_sdk, manage_connections.test,
+ * connector pushdown) do not go through that pipeline, so folding these codes into
+ * `AgentErrorCode` would couple two unrelated flows. Instead this mirrors the
+ * `OrchestratorError` precedent (a typed `code` + a `retryable` flag).
+ *
+ * Two consumers:
+ *  - the caller / auto-retry layer branches on `retryable` (retry transient codes,
+ *    never retry permanent ones) and correlates a failure via `call_id`;
+ *  - the human/agent reads a stable `code` instead of a flaky message string.
+ *
+ * `retryable` is a *static property of the code*, not something each throw site
+ * decides: `RATE_LIMITED` is always retryable, `AUTH_MISSING` never is. Throw sites
+ * pick the right code; the catalog is the single source of truth for retryability.
+ */
+
+export type ToolErrorCode =
+  // ── permanent: retrying the identical call cannot succeed ──
+  /** No auth profile configured for a connector that requires one. */
+  | "AUTH_MISSING"
+  /** Credentials were rejected by the upstream (HTTP 401/403). */
+  | "AUTH_INVALID"
+  /** Connector / feed / connection / resource does not exist (HTTP 404). */
+  | "NOT_FOUND"
+  /** Malformed args or SQL, or a read-only violation. */
+  | "VALIDATION"
+  /** Denied by org-scope / cross-org visibility rules. */
+  | "PERMISSION"
+  // ── transient: the same call may succeed on retry ──
+  /** Upstream throttled the request (HTTP 429 / too many requests). */
+  | "RATE_LIMITED"
+  /** Upstream request or DB statement timed out (e.g. PG 57014). */
+  | "UPSTREAM_TIMEOUT"
+  /** Upstream server error (HTTP 500/502/503/504). */
+  | "UPSTREAM_5XX"
+  /** Network-level failure reaching the upstream (econnrefused/reset/dns/socket). */
+  | "NETWORK"
+  /** Connector subprocess was unavailable (oom/crash) — retry once. */
+  | "UPSTREAM_UNAVAILABLE"
+  // ── fallback ──
+  /** Unclassified failure. Non-retryable by default (don't mask real bugs behind retries). */
+  | "INTERNAL";
+
+export interface ToolErrorSpec {
+  /** Whether retrying the identical call (no other change) may succeed. */
+  retryable: boolean;
+  /** Default human-facing message when the throw site supplies none. */
+  message: string;
+}
+
+export const TOOL_ERRORS: Record<ToolErrorCode, ToolErrorSpec> = {
+  AUTH_MISSING: {
+    retryable: false,
+    message: "No auth profile is configured for this connector.",
+  },
+  AUTH_INVALID: {
+    retryable: false,
+    message: "The connector's credentials were rejected.",
+  },
+  NOT_FOUND: {
+    retryable: false,
+    message: "The requested resource was not found.",
+  },
+  VALIDATION: {
+    retryable: false,
+    message: "The request was malformed.",
+  },
+  PERMISSION: {
+    retryable: false,
+    message: "Not permitted in this organization scope.",
+  },
+  RATE_LIMITED: {
+    retryable: true,
+    message: "The upstream rate limit was hit; retry shortly.",
+  },
+  UPSTREAM_TIMEOUT: {
+    retryable: true,
+    message: "The upstream request timed out.",
+  },
+  UPSTREAM_5XX: {
+    retryable: true,
+    message: "The upstream server returned an error.",
+  },
+  NETWORK: {
+    retryable: true,
+    message: "A network error occurred reaching the upstream.",
+  },
+  UPSTREAM_UNAVAILABLE: {
+    retryable: true,
+    message: "The connector process was unavailable.",
+  },
+  INTERNAL: {
+    retryable: false,
+    message: "An internal error occurred.",
+  },
+};
+
+/** Whether a code is retryable, per the catalog. */
+export function isRetryable(code: ToolErrorCode): boolean {
+  return TOOL_ERRORS[code].retryable;
+}
+
+/** Parse a `ToolErrorCode` from an unknown value (payload/DB boundary). */
+export function toToolErrorCode(value: unknown): ToolErrorCode | undefined {
+  if (typeof value !== "string") return undefined;
+  return value in TOOL_ERRORS ? (value as ToolErrorCode) : undefined;
+}
+
+/**
+ * A typed error for connector/query paths that already *throw* (as opposed to the
+ * soft-error paths, which carry `{ code, retryable }` on their result object).
+ *
+ * `callId` is stamped at the `executeTool` boundary so a thrown failure can be
+ * correlated across logs/audit with the single tool invocation that produced it.
+ */
+export class ToolError extends Error {
+  readonly name = "ToolError";
+  readonly code: ToolErrorCode;
+  readonly retryable: boolean;
+  /** Per-invocation correlation id, stamped at the executeTool boundary. */
+  callId?: string;
+
+  constructor(
+    code: ToolErrorCode,
+    message?: string,
+    options?: { cause?: unknown; callId?: string }
+  ) {
+    super(message ?? TOOL_ERRORS[code].message, { cause: options?.cause });
+    this.code = code;
+    this.retryable = TOOL_ERRORS[code].retryable;
+    this.callId = options?.callId;
+  }
+
+  toJSON(): { code: ToolErrorCode; retryable: boolean; message: string; call_id?: string } {
+    return {
+      code: this.code,
+      retryable: this.retryable,
+      message: this.message,
+      ...(this.callId ? { call_id: this.callId } : {}),
+    };
+  }
+}
+
+/** Narrow an unknown thrown value to a `ToolError`. */
+export function isToolError(error: unknown): error is ToolError {
+  return error instanceof ToolError;
+}
+
+/**
+ * A structured signal describing an upstream/subprocess failure. Any field that is
+ * present is trusted over the message string. `message` is the last-resort input:
+ * keyword matching is fragile (a user's data can contain "429" or "timeout"), so it
+ * only runs when no structured field classifies the error.
+ */
+export interface ToolErrorSignal {
+  /** HTTP status from an upstream call (connector remote API). */
+  httpStatus?: number;
+  /** PostgreSQL SQLSTATE, e.g. "57014" (query_canceled / statement timeout). */
+  pgCode?: string;
+  /** Connector subprocess exit reason, when the failure came from the executor. */
+  exitReason?: "timeout" | "oom" | "crash" | "error_message";
+  /** Whether an upstream HTTP layer already judged this transient (from withHttpRetry). */
+  transient?: boolean;
+  /** Raw message — used only as a fallback when nothing above classifies. */
+  message?: string;
+}
+
+const RATE_LIMIT_MESSAGE_KEYWORDS = ["429", "rate limit", "too many requests"];
+
+const NETWORK_MESSAGE_KEYWORDS = [
+  "network",
+  "econnrefused",
+  "etimedout",
+  "enotfound",
+  "econnreset",
+  "fetch failed",
+  "socket",
+  "connection reset",
+  "connection refused",
+  "connection terminated",
+  "connection timeout",
+  "service unavailable",
+  "gateway timeout",
+  "server closed",
+];
+
+/**
+ * Map a structured signal (preferred) — or, as a last resort, a message string —
+ * to a `ToolErrorCode`. Precedence: explicit `transient` HTTP judgment → HTTP
+ * status → PG code → subprocess exit reason → message keywords → `INTERNAL`.
+ *
+ * This replaces the duplicated keyword lists in connector-sdk/src/retry.ts; those
+ * should source their retry decision from `isRetryable(classifyToolError(...))`.
+ */
+export function classifyToolError(signal: ToolErrorSignal): ToolErrorCode {
+  const { httpStatus, pgCode, exitReason, transient, message } = signal;
+
+  if (typeof httpStatus === "number") {
+    if (httpStatus === 429) return "RATE_LIMITED";
+    if (httpStatus === 401 || httpStatus === 403) return "AUTH_INVALID";
+    if (httpStatus === 404) return "NOT_FOUND";
+    if (httpStatus === 408 || httpStatus === 504) return "UPSTREAM_TIMEOUT";
+    if (httpStatus >= 500) return "UPSTREAM_5XX";
+    if (httpStatus >= 400) return "VALIDATION";
+  }
+
+  if (pgCode) {
+    if (pgCode === "57014") return "UPSTREAM_TIMEOUT"; // query_canceled / statement_timeout
+    // 08xxx = connection exceptions (transient); 40001 = serialization failure; 40P01 = deadlock.
+    if (pgCode.startsWith("08") || pgCode === "40001" || pgCode === "40P01") return "NETWORK";
+    // Everything else (syntax, constraint, etc.) is the caller's fault → not retryable.
+    return "VALIDATION";
+  }
+
+  if (exitReason) {
+    if (exitReason === "timeout") return "UPSTREAM_TIMEOUT";
+    if (exitReason === "oom" || exitReason === "crash") return "UPSTREAM_UNAVAILABLE";
+    // "error_message" is the connector-thrown case with no structured signal —
+    // fall through to message matching below.
+  }
+
+  if (transient === true) return "NETWORK";
+
+  if (message) {
+    const lower = message.toLowerCase();
+    if (RATE_LIMIT_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw))) return "RATE_LIMITED";
+    if (NETWORK_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw))) return "NETWORK";
+  }
+
+  return "INTERNAL";
+}

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -749,6 +749,18 @@ export const ManageConnectionsResultSchema = Type.Union([
     has_token: Type.Optional(Type.Boolean()),
     has_refresh: Type.Optional(Type.Boolean()),
     expires_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    // Structured error taxonomy (lobu#2051 Item 2), present on error/warning results.
+    error_code: Type.Optional(
+      Type.String({
+        description:
+          "Structured error code when status is error/warning, e.g. AUTH_MISSING / AUTH_INVALID.",
+      }),
+    ),
+    retryable: Type.Optional(
+      Type.Boolean({
+        description: "Whether re-running the test may succeed. Advisory; not auto-retried.",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("install_connector"),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export * from "./capabilities";
 export type { CommandContext, CommandDefinition } from "./command-registry";
 // Command registry
 export { CommandRegistry } from "./command-registry";
+export * from "./connector-query-errors";
 export * from "./constants";
 // Shared credential-store primitives (CLI + embedded server share one impl)
 export * from "./credentials";

--- a/packages/server/src/__tests__/integration/connectors/connection-test-auth-free.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-test-auth-free.test.ts
@@ -109,5 +109,30 @@ describe('connections.test — auth-free connectors', () => {
     expect(res.action).toBe('test');
     expect(res.status).toBe('warning');
     expect(String(res.message)).toMatch(/No auth profile configured/i);
+    // Structured taxonomy (lobu#2051 Item 2): a missing-auth warning is a stable,
+    // non-retryable AUTH_MISSING — the agent shouldn't retry the identical test.
+    expect(res.error_code).toBe('AUTH_MISSING');
+    expect(res.retryable).toBe(false);
+  });
+
+  it('the auth-free ok result carries no error taxonomy', async () => {
+    const { org, user, ctx } = await seedOwnerContext({ orgName: 'Auth-Free No-Code Org' });
+    await createTestConnectorDefinition({
+      key: CONNECTORS.none,
+      name: 'Auth-free connector',
+      organization_id: org.id,
+      auth_schema: { methods: [{ type: 'none' }] },
+    });
+    const connectionId = await seedConnection(org.id, user.id, CONNECTORS.none, 'rss-ok');
+
+    const res = (await manageConnections(
+      { action: 'test', connection_id: connectionId },
+      TEST_ENV,
+      ctx
+    )) as Record<string, unknown>;
+
+    expect(res.status).toBe('ok');
+    expect(res.error_code).toBeUndefined();
+    expect(res.retryable).toBeUndefined();
   });
 });

--- a/packages/server/src/__tests__/integration/tools/query-sql-error-taxonomy.test.ts
+++ b/packages/server/src/__tests__/integration/tools/query-sql-error-taxonomy.test.ts
@@ -1,0 +1,94 @@
+/**
+ * query_sql structured error taxonomy (lobu#2051 Item 2).
+ *
+ * The soft-error path (a `{ rows: [], error }` result the agent reads as a normal
+ * outcome, NOT a throw — deliberate per #2042) now also carries `error_code` +
+ * `retryable`, so an agent can tell a transient timeout from a permanent SQL fault
+ * without parsing the message string. The hard-throw path (missing feed) carries
+ * the code on the thrown ToolUserError.
+ *
+ * Red on origin/main (no `error_code`/`retryable` fields exist there); green here.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { querySql } from '../../../tools/admin/query_sql';
+import type { ToolContext } from '../../../tools/registry';
+import { ToolUserError } from '../../../utils/errors';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('query_sql error taxonomy', () => {
+  let orgId: string;
+  let ctx: ToolContext;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const org = await createTestOrganization({ name: 'Query Taxonomy Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'query-taxonomy@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    ctx = {
+      organizationId: orgId,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: false,
+    };
+  }, 120_000);
+
+  afterAll(async () => {
+    await getTestDb()`SELECT 1`; // keep the pool warm for teardown ordering
+  });
+
+  it('tags a write query (read-only violation) as VALIDATION, not retryable', async () => {
+    // A CTE that mutates is the read-only-violation shape query_sql guards against.
+    const res = await querySql(
+      { sql: 'WITH x AS (DELETE FROM events RETURNING id) SELECT count(*) AS n FROM x' },
+      {},
+      ctx
+    );
+    expect(res.error).toBeTruthy();
+    expect(res.error_code).toBe('VALIDATION');
+    expect(res.retryable).toBe(false);
+  }, 60_000);
+
+  it('tags a disallowed table reference as a non-retryable code', async () => {
+    const res = await querySql(
+      { sql: 'SELECT access_token FROM oauth_tokens LIMIT 1' },
+      {},
+      ctx
+    );
+    expect(res.error).toBeTruthy();
+    // A rejected/unscopable table is the caller's problem — never retryable.
+    expect(res.retryable).toBe(false);
+    expect(res.error_code).toBeTruthy();
+  }, 60_000);
+
+  it('throws NOT_FOUND (with code) for an unknown feed reference', async () => {
+    let caught: unknown;
+    try {
+      await querySql({ feed: 'no-such-feed-xyz' }, {}, ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    expect((caught as ToolUserError).code).toBe('NOT_FOUND');
+    expect((caught as ToolUserError).retryable).toBe(false);
+    expect((caught as ToolUserError).httpStatus).toBe(404);
+  }, 60_000);
+
+  it('a successful query carries no error_code/retryable', async () => {
+    const res = await querySql({ sql: 'SELECT id FROM events LIMIT 1' }, {}, ctx);
+    expect(res.error).toBeUndefined();
+    expect(res.error_code).toBeUndefined();
+    expect(res.retryable).toBeUndefined();
+  }, 60_000);
+});

--- a/packages/server/src/__tests__/unit/pushdown-failure-classify.test.ts
+++ b/packages/server/src/__tests__/unit/pushdown-failure-classify.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Far-end of the connector-side taxonomy pipe (lobu#2051 Item 2): when a connector
+ * subprocess fails, query_sql re-throws with a code derived from the structured
+ * `httpStatus` the executor propagates (from the SDK's HttpStatusError) — not from
+ * keyword-matching the redacted message. This pins that classification.
+ *
+ * `classifyPushdownFailure` is the exact function query_sql's 502 throw sites call.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { isRetryable } from '@lobu/core';
+import { classifyPushdownFailure } from '../../tools/admin/query_sql';
+
+// Mirror of SubprocessError's surface: a message plus the propagated httpStatus.
+class SubprocessErrorLike extends Error {
+  httpStatus?: number;
+  constructor(message: string, httpStatus?: number) {
+    super(message);
+    this.name = 'SubprocessError';
+    this.httpStatus = httpStatus;
+  }
+}
+
+describe('classifyPushdownFailure', () => {
+  it('classifies a propagated 429 as RATE_LIMITED (retryable)', () => {
+    const code = classifyPushdownFailure(new SubprocessErrorLike('redacted', 429));
+    expect(code).toBe('RATE_LIMITED');
+    expect(isRetryable(code)).toBe(true);
+  });
+
+  it('classifies a propagated 503 as UPSTREAM_5XX (retryable)', () => {
+    const code = classifyPushdownFailure(new SubprocessErrorLike('redacted', 503));
+    expect(code).toBe('UPSTREAM_5XX');
+    expect(isRetryable(code)).toBe(true);
+  });
+
+  it('classifies a propagated 404 as NOT_FOUND (not retryable)', () => {
+    const code = classifyPushdownFailure(new SubprocessErrorLike('redacted', 404));
+    expect(code).toBe('NOT_FOUND');
+    expect(isRetryable(code)).toBe(false);
+  });
+
+  it('prefers the structured status over a misleading message', () => {
+    // Message contains "timeout" (would keyword-match) but the real status is 429.
+    const code = classifyPushdownFailure(
+      new SubprocessErrorLike('connection timeout while fetching', 429)
+    );
+    expect(code).toBe('RATE_LIMITED');
+  });
+
+  it('falls back to UPSTREAM_5XX for an opaque failure with no status', () => {
+    // A broken feed/connector with no HTTP status and an unclassifiable message:
+    // default to a retryable server-side error rather than INTERNAL.
+    const code = classifyPushdownFailure(new SubprocessErrorLike('feed exploded', undefined));
+    expect(code).toBe('UPSTREAM_5XX');
+  });
+
+  it('still keyword-classifies a transient message when no status is present', () => {
+    const code = classifyPushdownFailure(new SubprocessErrorLike('ECONNRESET', undefined));
+    expect(code).toBe('NETWORK');
+    expect(isRetryable(code)).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/unit/tool-error-retry.test.ts
+++ b/packages/server/src/__tests__/unit/tool-error-retry.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Retry-decision contract for the connector/query error taxonomy (lobu#2051 Item 2).
+ *
+ * The `executeTool` auto-retry wrapper drives `retryWithBackoff` with a
+ * `shouldRetry` predicate that fires only for *retryable thrown* ToolErrors /
+ * ToolUserErrors. This test pins that decision matrix directly against the same
+ * primitive the wrapper uses, so a regression in the catalog's `retryable` flags
+ * or the predicate shape is caught without spinning up the whole tool path.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { isToolError, retryWithBackoff, ToolError } from "@lobu/core";
+import { ToolUserError } from "../../utils/errors";
+
+// Mirror of the predicate in executeTool (kept in sync intentionally — the wrapper
+// uses this exact shape). If executeTool's gate changes, this test should too.
+function isRetryableToolError(err: Error): boolean {
+  if (isToolError(err)) return err.retryable;
+  if (err instanceof ToolUserError) return err.retryable;
+  return false;
+}
+
+async function runWithRetry(fn: () => Promise<unknown>) {
+  let calls = 0;
+  const wrapped = async () => {
+    calls++;
+    return fn();
+  };
+  try {
+    const result = await retryWithBackoff(wrapped, {
+      maxRetries: 2,
+      baseDelay: 1, // keep the test fast; behavior is identical
+      shouldRetry: (err) => isRetryableToolError(err),
+    });
+    return { calls, result, threw: undefined as unknown };
+  } catch (err) {
+    return { calls, result: undefined, threw: err };
+  }
+}
+
+describe("auto-retry decision", () => {
+  it("retries a transient ToolError until it succeeds", async () => {
+    let attempt = 0;
+    const { calls, result } = await runWithRetry(async () => {
+      attempt++;
+      if (attempt < 3) throw new ToolError("RATE_LIMITED");
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(calls).toBe(3); // 1 initial + 2 retries
+  });
+
+  it("does NOT retry a permanent ToolError", async () => {
+    const { calls, threw } = await runWithRetry(async () => {
+      throw new ToolError("AUTH_MISSING");
+    });
+    expect(calls).toBe(1);
+    expect(isToolError(threw)).toBe(true);
+    expect((threw as ToolError).code).toBe("AUTH_MISSING");
+  });
+
+  it("retries a retryable ToolUserError", async () => {
+    let attempt = 0;
+    const { calls, result } = await runWithRetry(async () => {
+      attempt++;
+      if (attempt < 2) throw new ToolUserError("upstream 502", 502, "UPSTREAM_5XX");
+      return "recovered";
+    });
+    expect(result).toBe("recovered");
+    expect(calls).toBe(2);
+  });
+
+  it("does NOT retry a ToolUserError with no code (retryable=false)", async () => {
+    const { calls, threw } = await runWithRetry(async () => {
+      throw new ToolUserError("bad input", 400);
+    });
+    expect(calls).toBe(1);
+    expect((threw as ToolUserError).retryable).toBe(false);
+  });
+
+  it("does NOT retry a NOT_FOUND ToolUserError", async () => {
+    const { calls } = await runWithRetry(async () => {
+      throw new ToolUserError("missing feed", 404, "NOT_FOUND");
+    });
+    expect(calls).toBe(1);
+  });
+
+  it("does NOT retry a plain Error", async () => {
+    const { calls } = await runWithRetry(async () => {
+      throw new Error("boom");
+    });
+    expect(calls).toBe(1);
+  });
+
+  it("gives up after maxRetries when a transient error never clears", async () => {
+    const { calls, threw } = await runWithRetry(async () => {
+      throw new ToolError("UPSTREAM_TIMEOUT");
+    });
+    expect(calls).toBe(3); // 1 initial + 2 retries, then rethrow
+    expect((threw as ToolError).code).toBe("UPSTREAM_TIMEOUT");
+  });
+});
+
+describe("ToolUserError taxonomy fields", () => {
+  it("derives retryable from the code via the catalog", () => {
+    expect(new ToolUserError("x", 429, "RATE_LIMITED").retryable).toBe(true);
+    expect(new ToolUserError("x", 401, "AUTH_INVALID").retryable).toBe(false);
+    expect(new ToolUserError("x", 400).retryable).toBe(false);
+  });
+});

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -318,6 +318,18 @@ function createServerForContext(
       }
       return { content: [{ type: 'text' as const, text }] };
     } catch (error: any) {
+      // Surface the structured taxonomy (lobu#2051 Item 2) when the thrown error
+      // carries a code, so the client/agent gets a stable code + retryability +
+      // per-call correlation id alongside the human message.
+      const code = error?.code as string | undefined;
+      const structuredError =
+        typeof code === 'string' && typeof error?.retryable === 'boolean'
+          ? {
+              code,
+              retryable: error.retryable as boolean,
+              ...(error.callId ? { call_id: error.callId as string } : {}),
+            }
+          : undefined;
       return {
         content: [
           {
@@ -326,6 +338,7 @@ function createServerForContext(
           },
         ],
         isError: true,
+        ...(structuredError ? { structuredContent: { error: structuredError } } : {}),
       };
     }
   });

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -119,12 +119,29 @@ async function withPublicOrg<T>(
 	} catch (error) {
 		if (error instanceof ToolUserError) {
 			return c.json(
-				{ error: error.message },
+				toolUserErrorBody(error),
 				error.httpStatus as 400 | 403 | 404 | 409 | 422
 			);
 		}
 		return c.json({ error: errorMessage(error) }, 400);
 	}
+}
+
+/**
+ * Build the JSON body for a ToolUserError, including the structured taxonomy
+ * (lobu#2051 Item 2) — `code`/`retryable`/`call_id` — when the error carries a code.
+ */
+function toolUserErrorBody(error: ToolUserError): Record<string, unknown> {
+	return {
+		error: error.message,
+		...(error.code
+			? {
+					code: error.code,
+					retryable: error.retryable,
+					...(error.callId ? { call_id: error.callId } : {}),
+				}
+			: {}),
+	};
 }
 
 /**
@@ -272,7 +289,7 @@ export async function restToolProxy(
 	} catch (error) {
 		if (error instanceof ToolUserError) {
 			return c.json(
-				{ error: error.message },
+				toolUserErrorBody(error),
 				error.httpStatus as 400 | 403 | 404 | 409 | 422
 			);
 		}

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -2,6 +2,7 @@
  * Auth-related action handlers: reauthenticate, test.
  */
 
+import { isRetryable, type ToolErrorCode } from '@lobu/core';
 import { getDb } from '../../../../db/client';
 import {
   getAuthProfileById,
@@ -208,7 +209,12 @@ export async function handleTest(
     `;
 
     if (accountRows.length === 0) {
-      return { action: 'test', status: 'error', message: 'Linked OAuth account not found' };
+      return {
+        action: 'test',
+        status: 'error',
+        message: 'Linked OAuth account not found',
+        ...testErrorFields('NOT_FOUND'),
+      };
     }
 
     const account = accountRows[0] as any;
@@ -217,15 +223,17 @@ export async function handleTest(
         action: 'test',
         status: 'error',
         message: 'No access token available. Re-authenticate.',
+        ...testErrorFields('AUTH_MISSING'),
       };
     }
 
     const expiresAt = account.accessTokenExpiresAt ? new Date(account.accessTokenExpiresAt) : null;
     const isExpired = expiresAt && expiresAt.getTime() < Date.now();
+    const hardExpired = isExpired && !account.has_refresh;
 
     return {
       action: 'test',
-      status: isExpired && !account.has_refresh ? 'error' : 'ok',
+      status: hardExpired ? 'error' : 'ok',
       message: isExpired
         ? account.has_refresh
           ? 'Token expired but refresh token available'
@@ -234,6 +242,7 @@ export async function handleTest(
       has_token: account.has_token,
       has_refresh: account.has_refresh,
       expires_at: expiresAt?.toISOString() ?? null,
+      ...(hardExpired ? testErrorFields('AUTH_INVALID') : {}),
     };
   }
 
@@ -254,6 +263,7 @@ export async function handleTest(
       message: hasKeys
         ? `${label} profile '${profileToTest.slug}' configured`
         : `${label} profile '${profileToTest.slug}' has no credentials`,
+      ...(hasKeys ? {} : testErrorFields('AUTH_MISSING')),
     };
   }
 
@@ -261,6 +271,8 @@ export async function handleTest(
     const summary = summarizeBrowserSessionAuthData(authProfile.auth_data, conn.connector_key);
     if (summary.cdp_url) {
       const readiness = await getBrowserSessionReadiness(authProfile.auth_data, conn.connector_key);
+      // A configured-but-unreachable CDP endpoint is transient (the browser may
+      // come back), so this warning is retryable — unlike the missing-cookie ones.
       return {
         action: 'test',
         status: readiness.usable ? 'ok' : 'warning',
@@ -268,6 +280,7 @@ export async function handleTest(
           ? `Browser auth profile '${authProfile.slug}' CDP endpoint reachable`
           : `Browser auth profile '${authProfile.slug}' CDP configured but endpoint not responding at ${summary.cdp_url}`,
         expires_at: summary.expires_at,
+        ...(readiness.usable ? {} : testErrorFields('NETWORK')),
       };
     }
     if (summary.cookie_count === 0) {
@@ -276,6 +289,7 @@ export async function handleTest(
         status: 'warning',
         message: `Browser auth profile '${authProfile.slug}' has no cookies`,
         expires_at: summary.expires_at,
+        ...testErrorFields('AUTH_MISSING'),
       };
     }
     if (!summary.auth_cookie_name) {
@@ -284,6 +298,7 @@ export async function handleTest(
         status: 'warning',
         message: `Browser auth profile '${authProfile.slug}' has no likely auth cookie`,
         expires_at: summary.expires_at,
+        ...testErrorFields('AUTH_MISSING'),
       };
     }
     return {
@@ -293,6 +308,7 @@ export async function handleTest(
         ? `${summary.auth_cookie_name} expired`
         : `${summary.auth_cookie_name} valid`,
       expires_at: summary.expires_at,
+      ...(summary.is_expired ? testErrorFields('AUTH_INVALID') : {}),
     };
   }
 
@@ -308,7 +324,20 @@ export async function handleTest(
     };
   }
 
-  return { action: 'test', status: 'warning', message: 'No auth profile configured' };
+  return {
+    action: 'test',
+    status: 'warning',
+    message: 'No auth profile configured',
+    ...testErrorFields('AUTH_MISSING'),
+  };
+}
+
+/**
+ * Structured error fields for a connection-test error/warning result (lobu#2051
+ * Item 2). `retryable` comes from the catalog so it can't drift from the code.
+ */
+function testErrorFields(code: ToolErrorCode): { error_code: ToolErrorCode; retryable: boolean } {
+  return { error_code: code, retryable: isRetryable(code) };
 }
 
 /**

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -20,7 +20,7 @@ import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 import { SortOrderField } from './schemas/common-fields';
 import { isAdminOrOwnerRole } from '../access-control';
-import { getErrorMessage } from "@lobu/core";
+import { classifyToolError, getErrorMessage, isRetryable, type ToolErrorCode } from "@lobu/core";
 import { ToolUserError } from '../../utils/errors';
 
 export const QuerySqlSchema = Type.Object({
@@ -120,6 +120,10 @@ interface QuerySqlResult {
   execution_time_ms: number;
   coverage?: QuerySqlCoverage;
   error?: string;
+  /** Structured error code (lobu#2051 Item 2), set alongside `error`. */
+  error_code?: ToolErrorCode;
+  /** Whether retrying the identical query may succeed. Advisory for the agent. */
+  retryable?: boolean;
 }
 
 interface SuggestedVirtualFeed {
@@ -209,7 +213,33 @@ async function resolveVirtualFeedId(ref: string, scope: AuthzScope): Promise<num
   return rows[0].id;
 }
 
-function errorResult(message: string, startTime: number): QuerySqlResult {
+/**
+ * Classify a connector/pushdown failure for a hard (thrown) error. Prefers the
+ * structured `httpStatus` the connector executor propagates (from the SDK's
+ * HttpStatusError, lobu#2051 Item 2) over message matching, so a 429/5xx is
+ * honestly retryable. Falls back to the message; an otherwise-unclassifiable
+ * broken feed/connector run is UPSTREAM_5XX by default.
+ */
+export function classifyPushdownFailure(err: unknown): ToolErrorCode {
+  const httpStatus =
+    err && typeof err === 'object' && typeof (err as { httpStatus?: unknown }).httpStatus === 'number'
+      ? (err as { httpStatus: number }).httpStatus
+      : undefined;
+  const code = classifyToolError({ httpStatus, message: getErrorMessage(err) });
+  return code === 'INTERNAL' ? 'UPSTREAM_5XX' : code;
+}
+
+/**
+ * A soft-error result (lobu#2051 Item 2). `code` defaults to `VALIDATION` because
+ * every non-DB-catch call site here is an argument/scope fault (bad column, unknown
+ * org, malformed query) — none of those are retryable. The DB catch and the
+ * timeout path pass explicit codes.
+ */
+function errorResult(
+  message: string,
+  startTime: number,
+  code: ToolErrorCode = 'VALIDATION'
+): QuerySqlResult {
   return {
     rows: [],
     columns: [],
@@ -217,6 +247,8 @@ function errorResult(message: string, startTime: number): QuerySqlResult {
     has_more: false,
     execution_time_ms: Date.now() - startTime,
     error: message,
+    error_code: code,
+    retryable: isRetryable(code),
   };
 }
 
@@ -311,7 +343,7 @@ export async function querySqlImpl(
   // but it stays a hard REJECT (throw), not a structured { error }, preserving the
   // "missing sql rejects at the tool boundary, naming the field" contract.
   if (!baseSql && !args.feed) {
-    throw new ToolUserError('query_sql requires `sql` (or a `feed` to read).', 400);
+    throw new ToolUserError('query_sql requires `sql` (or a `feed` to read).', 400, 'VALIDATION');
   }
 
   // The base query is wrapped as `SELECT * FROM (<sql>) _t [ORDER BY …] LIMIT …`,
@@ -405,7 +437,7 @@ export async function querySqlImpl(
     try {
       feedId = await resolveVirtualFeedId(args.feed, scope);
     } catch (err) {
-      throw new ToolUserError(getErrorMessage(err), 404);
+      throw new ToolUserError(getErrorMessage(err), 404, 'NOT_FOUND');
     }
     try {
       const r = await readVirtualFeed({
@@ -432,7 +464,8 @@ export async function querySqlImpl(
         `virtual feed read failed (feed=${args.feed}): ${getErrorMessage(err)}. ` +
           'The feed itself is broken or its connector cannot run — this is not an empty result. ' +
           'Check the connector with client.connections.test, or client.feeds.get for feed config.',
-        502
+        502,
+        classifyPushdownFailure(err)
       );
     }
   }
@@ -476,7 +509,8 @@ export async function querySqlImpl(
       throw new ToolUserError(
         `connection pushdown failed (connection=${args.connection}): ${getErrorMessage(err)}. ` +
           'The query did not run against the source — this is not an empty result.',
-        502
+        502,
+        classifyPushdownFailure(err)
       );
     }
   }
@@ -566,12 +600,20 @@ export async function querySqlImpl(
     const msg = getErrorMessage(error);
     logger.error({ error }, 'query_sql error');
 
-    if (msg.includes('timeout') || msg.includes('statement timeout')) {
-      return errorResult('QUERY_TIMEOUT: Query exceeded 5 second timeout.', startTime);
+    // Classify via SQLSTATE where available (57014 = statement timeout), falling
+    // back to message matching. The `error_code`/`retryable` fields let the agent
+    // distinguish a transient timeout (worth retrying) from a permanent SQL fault.
+    const pgCode = (error as { code?: string } | null)?.code;
+    if (pgCode === '57014' || msg.includes('timeout') || msg.includes('statement timeout')) {
+      return errorResult('Query exceeded the 5 second timeout.', startTime, 'UPSTREAM_TIMEOUT');
     }
     if (msg.includes('read-only')) {
-      return errorResult('READ_ONLY_VIOLATION: Only read-only queries are allowed.', startTime);
+      return errorResult('Only read-only queries are allowed.', startTime, 'VALIDATION');
     }
-    return errorResult(`SQL_ERROR: ${msg}`, startTime);
+    return errorResult(
+      msg,
+      startTime,
+      classifyToolError({ pgCode: pgCode ?? undefined, message: msg })
+    );
   }
 }

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -4,7 +4,9 @@
  * Used by both the MCP Streamable HTTP handler and the REST API proxy.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { Context } from 'hono';
+import { isToolError, retryWithBackoff, ToolError } from '@lobu/core';
 import {
   getRequiredAccessLevel,
   hasRequiredMcpScope,
@@ -14,7 +16,7 @@ import {
 import type { Env } from '../index';
 import { trackMCPToolCall } from '../sentry';
 import { parseApplyId } from '../utils/apply-context';
-import { ToolNotRegisteredError } from '../utils/errors';
+import { ToolNotRegisteredError, ToolUserError } from '../utils/errors';
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
 import { enforceRoleScopeAccess } from './access-control';
 import { recordToolInvocationAudit } from './audit';
@@ -211,8 +213,29 @@ export async function executeTool(
   const toolContext = toToolContext(authCtx);
   const startTime = Date.now();
 
+  // Per-invocation correlation id (lobu#2051 Item 2). Distinct from the
+  // background-run `run_id` (a bigint on the runs table) — this identifies a
+  // single tool call so a failure can be traced across logs/audit/response.
+  const callId = randomUUID();
+
+  const runHandler = () =>
+    trackMCPToolCall(toolName, args, () => tool.handler(args, env, toolContext));
+
   try {
-    const result = await trackMCPToolCall(toolName, args, () => tool.handler(args, env, toolContext));
+    // Auto-retry (lobu#2051 Item 2): only transient thrown ToolErrors, and only
+    // for read/test tools on the allowlist. Mutations and run_sdk are never
+    // retried here — re-running them could double-write. Soft-error results
+    // (query_sql/query_sdk `{error, retryable}`) never throw, so they're never
+    // auto-retried; their `retryable` flag is advisory for the agent.
+    const result = RETRYABLE_TOOLS.has(toolName)
+      ? await retryWithBackoff(runHandler, {
+          maxRetries: 2,
+          baseDelay: 500,
+          maxDelay: 4000,
+          jitter: 'full',
+          shouldRetry: (err) => isRetryableToolError(err),
+        })
+      : await runHandler();
     await recordToolInvocationAudit({
       toolName,
       args,
@@ -222,6 +245,11 @@ export async function executeTool(
     });
     return result;
   } catch (error) {
+    // Stamp the correlation id onto typed errors so the response boundaries can
+    // surface `call_id` alongside the structured `code`/`retryable`.
+    if (error instanceof ToolError || error instanceof ToolUserError) {
+      error.callId = callId;
+    }
     await recordToolInvocationAudit({
       toolName,
       args,
@@ -231,6 +259,26 @@ export async function executeTool(
     });
     throw error;
   }
+}
+
+/**
+ * Tools safe to auto-retry on a transient failure (lobu#2051 Item 2): read-only,
+ * with no side effects. Mutations and `run_sdk` (arbitrary user script) are
+ * excluded — retrying them risks a double-write.
+ *
+ * `manage_connections.test` is deliberately NOT here: it's a *sub-action* of a
+ * tool that also mutates, and putting the whole tool on the allowlist would
+ * auto-retry those mutations too. `handleTest` never throws (it returns a soft
+ * `{status,message,error_code}` result), so it gains nothing from auto-retry
+ * anyway — its `retryable` flag is advisory for the agent.
+ */
+const RETRYABLE_TOOLS = new Set(['query_sql', 'query_sdk']);
+
+/** True when a thrown value is a retryable typed error. */
+function isRetryableToolError(err: Error): boolean {
+  if (isToolError(err)) return err.retryable;
+  if (err instanceof ToolUserError) return err.retryable;
+  return false;
 }
 
 /**

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import { classifyToolError, isRetryable } from "@lobu/core";
 import { resolveMaxAccessLevel } from "../auth/tool-access";
 import type { Env } from "../index";
 import { buildClientSDK, type SDKMode } from "../sandbox/client-sdk";
@@ -92,6 +93,18 @@ export const SdkScriptResultSchema = Type.Object({
         stack: Type.Optional(Type.String()),
         line: Type.Optional(Type.Number()),
         column: Type.Optional(Type.Number()),
+        code: Type.Optional(
+          Type.String({
+            description:
+              "Structured error code (lobu#2051 Item 2), e.g. UPSTREAM_TIMEOUT / RATE_LIMITED / VALIDATION.",
+          }),
+        ),
+        retryable: Type.Optional(
+          Type.Boolean({
+            description:
+              "Whether re-running the identical script may succeed. Advisory — run_sdk is never auto-retried (may have side effects).",
+          }),
+        ),
       },
       { description: "Present when success=false: the thrown error, with script position." },
     ),
@@ -129,11 +142,21 @@ async function runSandbox(
     },
     limits: args.timeout_ms ? { timeoutMs: args.timeout_ms } : undefined,
   });
+  // Attach a structured code/retryable to a script error so the agent can tell a
+  // transient upstream failure (worth re-running) from a permanent script fault.
+  // run_sdk is never auto-retried by the wrapper (arbitrary side effects), so this
+  // is purely advisory.
+  const error = result.error
+    ? (() => {
+        const code = classifyToolError({ message: result.error?.message });
+        return { ...result.error, code, retryable: isRetryable(code) };
+      })()
+    : result.error;
   return {
     success: result.success,
     return_value: result.returnValue,
     logs: result.logs,
-    error: result.error,
+    error,
     duration_ms: result.durationMs,
     sdk_calls: result.sdkCalls,
     sdk_call_trace: result.sdkCallTrace,

--- a/packages/server/src/utils/errors.ts
+++ b/packages/server/src/utils/errors.ts
@@ -1,3 +1,6 @@
+import type { ToolErrorCode } from '@lobu/core';
+import { isRetryable } from '@lobu/core';
+
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -7,14 +10,24 @@ export function errorMessage(error: unknown): string {
  * not-found, validation errors). Carries an HTTP status so the REST proxy
  * can return the right code, and is recognised by `trackMCPToolCall` to
  * avoid noisy Sentry alerts on 4xx-class outcomes.
+ *
+ * Optionally carries a structured `ToolErrorCode` (lobu#2051 Item 2). When a
+ * throw site supplies one, the MCP/REST boundaries surface `{ code, retryable,
+ * call_id }` and the auto-retry wrapper can honor `retryable`. `callId` is
+ * stamped at the `executeTool` boundary.
  */
 export class ToolUserError extends Error {
   readonly httpStatus: number;
+  readonly code?: ToolErrorCode;
+  readonly retryable: boolean;
+  callId?: string;
 
-  constructor(message: string, httpStatus = 400) {
+  constructor(message: string, httpStatus = 400, code?: ToolErrorCode) {
     super(message);
     this.name = 'ToolUserError';
     this.httpStatus = httpStatus;
+    this.code = code;
+    this.retryable = code ? isRetryable(code) : false;
   }
 }
 


### PR DESCRIPTION
Item 2 of the #2051 umbrella — a **structured connector/query error taxonomy** with stable codes, a per-code `retryable` flag, and a per-invocation `call_id`, plus an **auto-retry wrapper** that honors `retryable` for read-only tools. Partial fix for #2051 (closes nothing).

## New catalog

`packages/core/src/connector-query-errors.ts` — parallel to the agent-turn-scoped `AGENT_ERRORS` (deliberately **not** folded in; that catalog is wired to the worker `classifyError → renderAgentError → CTA` pipeline):

- **`ToolErrorCode`** enum, split by retryability:
  - permanent → `AUTH_MISSING`, `AUTH_INVALID`, `NOT_FOUND`, `VALIDATION`, `PERMISSION`, `INTERNAL`
  - transient → `RATE_LIMITED`, `UPSTREAM_TIMEOUT`, `UPSTREAM_5XX`, `NETWORK`, `UPSTREAM_UNAVAILABLE`
- `retryable` is a **static property of the code** (catalog is the single source of truth) — throw sites pick a code, they don't decide retryability.
- **`ToolError`** class (for paths that throw) + **`classifyToolError()`** with precedence `httpStatus → pgCode → exitReason → transient flag → message keywords`. This replaces the fragile duplicated keyword lists in `connector-sdk/src/retry.ts`.

## Wiring

- **`call_id`** — minted once in `executeTool` (the single choke point every MCP + REST call funnels through). Deliberately **not** named `run_id`: that's already a Postgres `bigint` for background runs, and reusing the name would collide in logs/audit. Stamped onto thrown `ToolError`/`ToolUserError`.
- **Auto-retry** — reuses the existing `retryWithBackoff` (already has a `shouldRetry` predicate), wrapped in `executeTool`, gated to a **read-only allowlist** (`query_sql`, `query_sdk`). `run_sdk` (arbitrary user script) and every mutation are **never** auto-retried — no double-write hazard.
- **Soft-error paths enriched in place** — `query_sql`, `query_sdk`/`run_sdk`, and `manage_connections.test` keep returning soft result objects (agents read them as normal outcomes — deliberate per #2042), now carrying `error_code`/`retryable`. Only the already-throwing paths become typed `ToolError` throws.
- **Executor typed signal** (the load-bearing part) — the connector SDK's `HttpStatusError.status` now propagates through the subprocess IPC (`child-runner` → `SubprocessError.httpStatus` → `classifyPushdownFailure`), so a connector 429/5xx is **honestly** retryable rather than guessed from the redacted message string. The status is a plain number, so it rides alongside the redacted message without a leak.
- **Both response boundaries** (`mcp-handler.ts`, `rest-api.ts`) surface `{ code, retryable, call_id }`.

## Test evidence (red→green)

Reverting the source to `origin/main` makes the behavior-asserting tests fail; on this branch all pass.

- `packages/core/src/__tests__/connector-query-errors.test.ts` — catalog + classifier (14; one caught a real classifier ordering bug during development)
- `packages/server/src/__tests__/unit/tool-error-retry.test.ts` — retry decision matrix (8)
- `packages/connector-worker/src/__tests__/http-status-extract.test.ts` — IPC status extraction, near end of the pipe (3)
- `packages/server/src/__tests__/unit/pushdown-failure-classify.test.ts` — `httpStatus`→code, far end of the pipe (6)
- `packages/server/src/__tests__/integration/tools/query-sql-error-taxonomy.test.ts` — end-to-end soft/hard codes on embedded PG (4)
- `packages/server/src/__tests__/integration/connectors/connection-test-auth-free.test.ts` — extended with taxonomy assertions (3)

`packages/core`, `packages/connector-worker` builds clean; `packages/server` `tsc --noEmit` clean; full server unit suite (620) + core (362) + connector-worker (59) green.

## Known limitation

The auto-retry wiring into the real `executeTool` control flow is proven by an isolated run (real backoff observed) + the decision-matrix unit tests, but is **not** left as a standing in-situ test: driving `executeTool` requires globally mocking the tool registry, and this codebase deliberately avoids `mock.module` for that (process-global in Bun; corrupts sibling suites — see `connector-discovery.test.ts`). The wiring itself is ~8 typechecked lines over the well-tested `retryWithBackoff`.

## Still open on #2051

- **Item 1 read modes** — the named `read_mode: current|exact|lineage|audit` enum (its own API-surface PR).
- **Item 5 read latency** — needs net-new tool-latency telemetry before budgets are meaningful.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured error codes and retryability details to connector, query, connection-test, and script responses.
  * Improved HTTP failure reporting, including rate limits, upstream failures, authentication issues, and missing resources.
  * Added automatic retries for selected transient tool failures.
  * Included call identifiers and structured error details in API and tool responses.
* **Bug Fixes**
  * Improved failure classification using HTTP statuses and database error information.
  * Prevented misleading message text from overriding structured error classifications.
* **Tests**
  * Added comprehensive coverage for error classification, retry behavior, authentication outcomes, and HTTP status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->