### PR TITLE
style(errors): biome-format core taxonomy files (fix format-lint on main)

### DIFF
--- a/packages/core/src/__tests__/connector-query-errors.test.ts
+++ b/packages/core/src/__tests__/connector-query-errors.test.ts
@@ -84,7 +84,9 @@ describe("ToolError", () => {
       retryable: false,
       message: TOOL_ERRORS.NOT_FOUND.message,
     });
-    const withId = new ToolError("NETWORK", undefined, { callId: "c1" }).toJSON();
+    const withId = new ToolError("NETWORK", undefined, {
+      callId: "c1",
+    }).toJSON();
     expect(withId.call_id).toBe("c1");
   });
 });
@@ -116,31 +118,51 @@ describe("classifyToolError", () => {
     // These must NOT be swallowed by the pgCode branch's VALIDATION catch-all —
     // they should classify from the message as the transient failures they are.
     expect(
-      classifyToolError({ pgCode: "ECONNREFUSED", message: "write ECONNREFUSED 127.0.0.1:5432" })
+      classifyToolError({
+        pgCode: "ECONNREFUSED",
+        message: "write ECONNREFUSED 127.0.0.1:5432",
+      })
     ).toBe("NETWORK");
     expect(
-      classifyToolError({ pgCode: "CONNECTION_CLOSED", message: "connection terminated" })
+      classifyToolError({
+        pgCode: "CONNECTION_CLOSED",
+        message: "connection terminated",
+      })
     ).toBe("NETWORK");
     // A non-SQLSTATE code with no transient message hint → INTERNAL, not VALIDATION.
-    expect(classifyToolError({ pgCode: "SOME_DRIVER_CODE", message: "weird" })).toBe("INTERNAL");
+    expect(
+      classifyToolError({ pgCode: "SOME_DRIVER_CODE", message: "weird" })
+    ).toBe("INTERNAL");
   });
 
   test("subprocess exit reasons", () => {
-    expect(classifyToolError({ exitReason: "timeout" })).toBe("UPSTREAM_TIMEOUT");
-    expect(classifyToolError({ exitReason: "oom" })).toBe("UPSTREAM_UNAVAILABLE");
-    expect(classifyToolError({ exitReason: "crash" })).toBe("UPSTREAM_UNAVAILABLE");
+    expect(classifyToolError({ exitReason: "timeout" })).toBe(
+      "UPSTREAM_TIMEOUT"
+    );
+    expect(classifyToolError({ exitReason: "oom" })).toBe(
+      "UPSTREAM_UNAVAILABLE"
+    );
+    expect(classifyToolError({ exitReason: "crash" })).toBe(
+      "UPSTREAM_UNAVAILABLE"
+    );
   });
 
   test("error_message exit reason falls through to message matching", () => {
     expect(
-      classifyToolError({ exitReason: "error_message", message: "429 too many requests" })
+      classifyToolError({
+        exitReason: "error_message",
+        message: "429 too many requests",
+      })
     ).toBe("RATE_LIMITED");
     expect(
       classifyToolError({ exitReason: "error_message", message: "ECONNRESET" })
     ).toBe("NETWORK");
     // no structured hint and an opaque message → INTERNAL
     expect(
-      classifyToolError({ exitReason: "error_message", message: "something odd" })
+      classifyToolError({
+        exitReason: "error_message",
+        message: "something odd",
+      })
     ).toBe("INTERNAL");
   });
 
@@ -150,15 +172,21 @@ describe("classifyToolError", () => {
 
   test("structured fields win over the message string", () => {
     // message says 'timeout' (would keyword-match) but 404 is authoritative → NOT_FOUND
-    expect(classifyToolError({ httpStatus: 404, message: "timeout while fetching" })).toBe(
-      "NOT_FOUND"
-    );
+    expect(
+      classifyToolError({ httpStatus: 404, message: "timeout while fetching" })
+    ).toBe("NOT_FOUND");
   });
 
   test("message fallback", () => {
-    expect(classifyToolError({ message: "rate limit exceeded" })).toBe("RATE_LIMITED");
-    expect(classifyToolError({ message: "fetch failed: ENOTFOUND" })).toBe("NETWORK");
+    expect(classifyToolError({ message: "rate limit exceeded" })).toBe(
+      "RATE_LIMITED"
+    );
+    expect(classifyToolError({ message: "fetch failed: ENOTFOUND" })).toBe(
+      "NETWORK"
+    );
     expect(classifyToolError({})).toBe("INTERNAL");
-    expect(classifyToolError({ message: "totally unrelated" })).toBe("INTERNAL");
+    expect(classifyToolError({ message: "totally unrelated" })).toBe(
+      "INTERNAL"
+    );
   });
 });

--- a/packages/core/src/connector-query-errors.ts
+++ b/packages/core/src/connector-query-errors.ts
@@ -135,7 +135,12 @@ export class ToolError extends Error {
     this.callId = options?.callId;
   }
 
-  toJSON(): { code: ToolErrorCode; retryable: boolean; message: string; call_id?: string } {
+  toJSON(): {
+    code: ToolErrorCode;
+    retryable: boolean;
+    message: string;
+    call_id?: string;
+  } {
     return {
       code: this.code,
       retryable: this.retryable,
@@ -215,14 +220,16 @@ export function classifyToolError(signal: ToolErrorSignal): ToolErrorCode {
   if (pgCode && /^[0-9A-Z]{5}$/.test(pgCode)) {
     if (pgCode === "57014") return "UPSTREAM_TIMEOUT"; // query_canceled / statement_timeout
     // 08xxx = connection exceptions (transient); 40001 = serialization failure; 40P01 = deadlock.
-    if (pgCode.startsWith("08") || pgCode === "40001" || pgCode === "40P01") return "NETWORK";
+    if (pgCode.startsWith("08") || pgCode === "40001" || pgCode === "40P01")
+      return "NETWORK";
     // Everything else (syntax, constraint, etc.) is the caller's fault → not retryable.
     return "VALIDATION";
   }
 
   if (exitReason) {
     if (exitReason === "timeout") return "UPSTREAM_TIMEOUT";
-    if (exitReason === "oom" || exitReason === "crash") return "UPSTREAM_UNAVAILABLE";
+    if (exitReason === "oom" || exitReason === "crash")
+      return "UPSTREAM_UNAVAILABLE";
     // "error_message" is the connector-thrown case with no structured signal —
     // fall through to message matching below.
   }
@@ -231,8 +238,10 @@ export function classifyToolError(signal: ToolErrorSignal): ToolErrorCode {
 
   if (message) {
     const lower = message.toLowerCase();
-    if (RATE_LIMIT_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw))) return "RATE_LIMITED";
-    if (NETWORK_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw))) return "NETWORK";
+    if (RATE_LIMIT_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw)))
+      return "RATE_LIMITED";
+    if (NETWORK_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw)))
+      return "NETWORK";
   }
 
   return "INTERNAL";

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -754,12 +754,13 @@ export const ManageConnectionsResultSchema = Type.Union([
       Type.String({
         description:
           "Structured error code when status is error/warning, e.g. AUTH_MISSING / AUTH_INVALID.",
-      }),
+      })
     ),
     retryable: Type.Optional(
       Type.Boolean({
-        description: "Whether re-running the test may succeed. Advisory; not auto-retried.",
-      }),
+        description:
+          "Whether re-running the test may succeed. Advisory; not auto-retried.",
+      })
     ),
   }),
   Type.Object({


### PR DESCRIPTION
Follow-up to #2074. That merge landed with biome formatting violations in the scoped **core** files (line-wrapping + trailing commas), so `format-lint` is red on main. All other checks on main are green.

**Cause:** the pre-commit hook runs `biome check --write .`, which biome resolves to **0 files** in this worktree layout and then **exits 1 on "No files were processed"** — a fail-closed on a benign condition. That's why #2074 was committed with `--no-verify`, and it's how the formatting slipped through.

**Fix:** ran `biome check --write` on the four scoped core files. Pure formatting — verified token-identical (only `toJSON` return-type + a few `if` statements reflowed onto multiple lines) and confirmed with the same **file-scoped** `format:check` + `lint` that CI runs. Core builds + the 15 catalog tests still pass.

Note: the underlying pre-commit 0-files quirk is a separate repo issue worth fixing (scope biome at `packages/core` or add `--no-errors-on-unmatched`), but that's out of scope here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->