### PR TITLE
style(core): fix biome formatting in connector query error taxonomy

### DIFF
--- a/packages/core/src/__tests__/connector-query-errors.test.ts
+++ b/packages/core/src/__tests__/connector-query-errors.test.ts
@@ -84,7 +84,9 @@ describe("ToolError", () => {
       retryable: false,
       message: TOOL_ERRORS.NOT_FOUND.message,
     });
-    const withId = new ToolError("NETWORK", undefined, { callId: "c1" }).toJSON();
+    const withId = new ToolError("NETWORK", undefined, {
+      callId: "c1",
+    }).toJSON();
     expect(withId.call_id).toBe("c1");
   });
 });
@@ -116,31 +118,51 @@ describe("classifyToolError", () => {
     // These must NOT be swallowed by the pgCode branch's VALIDATION catch-all —
     // they should classify from the message as the transient failures they are.
     expect(
-      classifyToolError({ pgCode: "ECONNREFUSED", message: "write ECONNREFUSED 127.0.0.1:5432" })
+      classifyToolError({
+        pgCode: "ECONNREFUSED",
+        message: "write ECONNREFUSED 127.0.0.1:5432",
+      })
     ).toBe("NETWORK");
     expect(
-      classifyToolError({ pgCode: "CONNECTION_CLOSED", message: "connection terminated" })
+      classifyToolError({
+        pgCode: "CONNECTION_CLOSED",
+        message: "connection terminated",
+      })
     ).toBe("NETWORK");
     // A non-SQLSTATE code with no transient message hint → INTERNAL, not VALIDATION.
-    expect(classifyToolError({ pgCode: "SOME_DRIVER_CODE", message: "weird" })).toBe("INTERNAL");
+    expect(
+      classifyToolError({ pgCode: "SOME_DRIVER_CODE", message: "weird" })
+    ).toBe("INTERNAL");
   });
 
   test("subprocess exit reasons", () => {
-    expect(classifyToolError({ exitReason: "timeout" })).toBe("UPSTREAM_TIMEOUT");
-    expect(classifyToolError({ exitReason: "oom" })).toBe("UPSTREAM_UNAVAILABLE");
-    expect(classifyToolError({ exitReason: "crash" })).toBe("UPSTREAM_UNAVAILABLE");
+    expect(classifyToolError({ exitReason: "timeout" })).toBe(
+      "UPSTREAM_TIMEOUT"
+    );
+    expect(classifyToolError({ exitReason: "oom" })).toBe(
+      "UPSTREAM_UNAVAILABLE"
+    );
+    expect(classifyToolError({ exitReason: "crash" })).toBe(
+      "UPSTREAM_UNAVAILABLE"
+    );
   });
 
   test("error_message exit reason falls through to message matching", () => {
     expect(
-      classifyToolError({ exitReason: "error_message", message: "429 too many requests" })
+      classifyToolError({
+        exitReason: "error_message",
+        message: "429 too many requests",
+      })
     ).toBe("RATE_LIMITED");
     expect(
       classifyToolError({ exitReason: "error_message", message: "ECONNRESET" })
     ).toBe("NETWORK");
     // no structured hint and an opaque message → INTERNAL
     expect(
-      classifyToolError({ exitReason: "error_message", message: "something odd" })
+      classifyToolError({
+        exitReason: "error_message",
+        message: "something odd",
+      })
     ).toBe("INTERNAL");
   });
 
@@ -150,15 +172,21 @@ describe("classifyToolError", () => {
 
   test("structured fields win over the message string", () => {
     // message says 'timeout' (would keyword-match) but 404 is authoritative → NOT_FOUND
-    expect(classifyToolError({ httpStatus: 404, message: "timeout while fetching" })).toBe(
-      "NOT_FOUND"
-    );
+    expect(
+      classifyToolError({ httpStatus: 404, message: "timeout while fetching" })
+    ).toBe("NOT_FOUND");
   });
 
   test("message fallback", () => {
-    expect(classifyToolError({ message: "rate limit exceeded" })).toBe("RATE_LIMITED");
-    expect(classifyToolError({ message: "fetch failed: ENOTFOUND" })).toBe("NETWORK");
+    expect(classifyToolError({ message: "rate limit exceeded" })).toBe(
+      "RATE_LIMITED"
+    );
+    expect(classifyToolError({ message: "fetch failed: ENOTFOUND" })).toBe(
+      "NETWORK"
+    );
     expect(classifyToolError({})).toBe("INTERNAL");
-    expect(classifyToolError({ message: "totally unrelated" })).toBe("INTERNAL");
+    expect(classifyToolError({ message: "totally unrelated" })).toBe(
+      "INTERNAL"
+    );
   });
 });

--- a/packages/core/src/connector-query-errors.ts
+++ b/packages/core/src/connector-query-errors.ts
@@ -135,7 +135,12 @@ export class ToolError extends Error {
     this.callId = options?.callId;
   }
 
-  toJSON(): { code: ToolErrorCode; retryable: boolean; message: string; call_id?: string } {
+  toJSON(): {
+    code: ToolErrorCode;
+    retryable: boolean;
+    message: string;
+    call_id?: string;
+  } {
     return {
       code: this.code,
       retryable: this.retryable,
@@ -215,14 +220,16 @@ export function classifyToolError(signal: ToolErrorSignal): ToolErrorCode {
   if (pgCode && /^[0-9A-Z]{5}$/.test(pgCode)) {
     if (pgCode === "57014") return "UPSTREAM_TIMEOUT"; // query_canceled / statement_timeout
     // 08xxx = connection exceptions (transient); 40001 = serialization failure; 40P01 = deadlock.
-    if (pgCode.startsWith("08") || pgCode === "40001" || pgCode === "40P01") return "NETWORK";
+    if (pgCode.startsWith("08") || pgCode === "40001" || pgCode === "40P01")
+      return "NETWORK";
     // Everything else (syntax, constraint, etc.) is the caller's fault → not retryable.
     return "VALIDATION";
   }
 
   if (exitReason) {
     if (exitReason === "timeout") return "UPSTREAM_TIMEOUT";
-    if (exitReason === "oom" || exitReason === "crash") return "UPSTREAM_UNAVAILABLE";
+    if (exitReason === "oom" || exitReason === "crash")
+      return "UPSTREAM_UNAVAILABLE";
     // "error_message" is the connector-thrown case with no structured signal —
     // fall through to message matching below.
   }
@@ -231,8 +238,10 @@ export function classifyToolError(signal: ToolErrorSignal): ToolErrorCode {
 
   if (message) {
     const lower = message.toLowerCase();
-    if (RATE_LIMIT_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw))) return "RATE_LIMITED";
-    if (NETWORK_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw))) return "NETWORK";
+    if (RATE_LIMIT_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw)))
+      return "RATE_LIMITED";
+    if (NETWORK_MESSAGE_KEYWORDS.some((kw) => lower.includes(kw)))
+      return "NETWORK";
   }
 
   return "INTERNAL";

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -754,12 +754,13 @@ export const ManageConnectionsResultSchema = Type.Union([
       Type.String({
         description:
           "Structured error code when status is error/warning, e.g. AUTH_MISSING / AUTH_INVALID.",
-      }),
+      })
     ),
     retryable: Type.Optional(
       Type.Boolean({
-        description: "Whether re-running the test may succeed. Advisory; not auto-retried.",
-      }),
+        description:
+          "Whether re-running the test may succeed. Advisory; not auto-retried.",
+      })
     ),
   }),
   Type.Object({


### PR DESCRIPTION
The structured connector/query error taxonomy landed on `main` (`db67b7b`) with three files that violate the repo's biome config (`lineWidth: 80`, `trailingCommas: es5`), so `format-lint` is red on `main` itself and consequently on every open PR, including the release-please PR #2063.

The release PR can't carry this fix: release-please owns and force-pushes `release-please--branches--main`, so any commit there is discarded on the next regeneration (and would pollute the release). Fixing it on `main` is the correct place; once merged, `format-lint` goes green on `main` and on #2063 after release-please regenerates.

Purely a `biome format` pass over the three offending files (line wrapping and es5 trailing-comma normalization); no logic changes. Formatted with the lockfile-pinned biome `2.4.13` to match CI exactly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->