### PR TITLE
fix(operations): scope-aware readiness for connector actions

### DIFF
--- a/packages/connector-sdk/src/__tests__/define-connector.test.ts
+++ b/packages/connector-sdk/src/__tests__/define-connector.test.ts
@@ -36,6 +36,8 @@ const Github = defineConnector({
 	actions: {
 		star_repo: {
 			name: "Star repo",
+			kind: "write",
+			requiredScopes: ["public_repo"],
 			execute: async (ctx) => ({
 				success: true,
 				output: { repo: ctx.input.repo },
@@ -59,6 +61,12 @@ describe("defineConnector", () => {
 		expect(definition.actions?.star_repo?.key).toBe("star_repo");
 		// requiresApproval defaults to false
 		expect(definition.actions?.star_repo?.requiresApproval).toBe(false);
+		// Semantic policy inputs must survive lowering, else a defineConnector()
+		// action bypasses the read/write classification and the scope gate.
+		expect(definition.actions?.star_repo?.kind).toBe("write");
+		expect(definition.actions?.star_repo?.requiredScopes).toEqual([
+			"public_repo",
+		]);
 		// handler closures must NOT leak into the serializable definition
 		expect(
 			(definition.feeds?.stars as Record<string, unknown>).sync,

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -598,13 +598,8 @@ export interface ActionDefinition {
 	/** Semantic effect used by operation discovery and policy. Defaults to write. */
 	kind?: 'read' | 'write';
 	/**
-	 * OAuth scopes this specific action needs beyond the connector's baseline
-	 * `authSchema.requiredScopes`. Typically these are the connector's
-	 * `optionalScopes` that only a subset of actions exercise (e.g. a calendar
-	 * write scope needed by create/update/delete but not by read syncs).
-	 * Operation readiness (`operations.listAvailable`) treats an action as not
-	 * executable on a connection whose granted scopes do not cover these, and
-	 * surfaces a `scope_upgrade_required` reason instead of reporting it ready.
+	 * OAuth scopes this action needs beyond `authSchema.requiredScopes`.
+	 * Readiness is gated when the connection's recorded grant lacks them.
 	 */
 	requiredScopes?: string[];
   /** MCP tool annotations for client-side confirmation UX */

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -597,6 +597,16 @@ export interface ActionDefinition {
   requiresApproval: boolean;
 	/** Semantic effect used by operation discovery and policy. Defaults to write. */
 	kind?: 'read' | 'write';
+	/**
+	 * OAuth scopes this specific action needs beyond the connector's baseline
+	 * `authSchema.requiredScopes`. Typically these are the connector's
+	 * `optionalScopes` that only a subset of actions exercise (e.g. a calendar
+	 * write scope needed by create/update/delete but not by read syncs).
+	 * Operation readiness (`operations.listAvailable`) treats an action as not
+	 * executable on a connection whose granted scopes do not cover these, and
+	 * surfaces a `scope_upgrade_required` reason instead of reporting it ready.
+	 */
+	requiredScopes?: string[];
   /** MCP tool annotations for client-side confirmation UX */
   annotations?: {
 		readOnlyHint?: boolean;

--- a/packages/connector-sdk/src/define-connector.ts
+++ b/packages/connector-sdk/src/define-connector.ts
@@ -159,6 +159,13 @@ function buildDefinition(spec: ConnectorSpec): ConnectorDefinition {
             name: action.name,
             description: action.description,
             requiresApproval: action.requiresApproval ?? false,
+            // `kind` and `requiredScopes` are semantic policy inputs (read/write
+            // classification and the per-action scope gate). Dropping them here
+            // would silently publish scoped/observational actions with neither,
+            // so a defineConnector() action would bypass the scope gate that a
+            // raw ActionDefinition enforces.
+            kind: action.kind,
+            requiredScopes: action.requiredScopes,
             annotations: action.annotations,
             inputSchema: action.inputSchema,
             outputSchema: action.outputSchema,

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -143,6 +143,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
         name: 'Create Event',
         description: 'Create a new event on Google Calendar.',
         requiresApproval: true,
+        requiredScopes: ['https://www.googleapis.com/auth/calendar.events'],
         inputSchema: {
           type: 'object',
           required: ['summary', 'start', 'end'],
@@ -168,6 +169,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
         name: 'Update Event',
         description: 'Update an existing calendar event.',
         requiresApproval: true,
+        requiredScopes: ['https://www.googleapis.com/auth/calendar.events'],
         inputSchema: {
           type: 'object',
           required: ['event_id'],
@@ -190,6 +192,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
         name: 'Delete Event',
         description: 'Delete/cancel an event.',
         requiresApproval: true,
+        requiredScopes: ['https://www.googleapis.com/auth/calendar.events'],
         inputSchema: {
           type: 'object',
           required: ['event_id'],

--- a/packages/server/src/__tests__/integration/operations-scope-aware-readiness.test.ts
+++ b/packages/server/src/__tests__/integration/operations-scope-aware-readiness.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Operation readiness must respect per-operation OAuth scopes.
+ *
+ * A connection can be active + authenticated (so status readiness is "ready")
+ * yet still lack the OAuth scope a specific write action needs. Before this
+ * change, `operations.listAvailable` reported such write actions as
+ * `executable: true` — e.g. a Calendar connection granted only
+ * `calendar.readonly` reported `create_event` ready, then the provider rejected
+ * the write at execution time. Readiness now maps an action whose declared
+ * `requiredScopes` are not covered by the connection's granted scopes to
+ * `readiness: "scope_upgrade_required"` (not executable) with a `reauthorize`
+ * next_action carrying exactly the missing scopes, while read actions on the
+ * same connection stay executable.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import type { ToolContext } from "../../tools/registry";
+import { createAuthProfile } from "../../utils/auth-profiles";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestConnection,
+	createTestConnectorDefinition,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
+
+const CONNECTOR_KEY = "demo.scope.calendar";
+const READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly";
+const WRITE_SCOPE = "https://www.googleapis.com/auth/calendar.events";
+
+// Two write actions declaring the write scope, one read action declaring none —
+// mirrors google.calendar (create/update/delete_event vs get_event).
+const ACTIONS_SCHEMA = {
+	create_event: {
+		key: "create_event",
+		name: "Create Event",
+		kind: "write",
+		requiresApproval: true,
+		requiredScopes: [WRITE_SCOPE],
+	},
+	get_event: {
+		key: "get_event",
+		name: "Get Event",
+		kind: "read",
+	},
+};
+
+describe("operation readiness respects OAuth scopes", () => {
+	let orgId: string;
+	let userId: string;
+	let ctx: ToolContext;
+	// connection granted only the readonly scope
+	let readonlyConnId: number;
+	// connection granted both readonly + write scopes
+	let writableConnId: number;
+
+	async function seedScopedConnection(
+		grantedScopes: string[],
+	): Promise<number> {
+		const sql = getTestDb();
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: CONNECTOR_KEY,
+			created_by: userId,
+			visibility: "private",
+			config: { action_modes: { create_event: "auto", get_event: "auto" } },
+		});
+		const profile = await createAuthProfile({
+			organizationId: orgId,
+			connectorKey: CONNECTOR_KEY,
+			displayName: `${CONNECTOR_KEY} OAuth ${conn.id}`,
+			profileKind: "oauth_account",
+			provider: "test",
+			status: "active",
+			createdBy: userId,
+			authData: { granted_scopes: grantedScopes },
+		});
+		await sql`UPDATE connections SET auth_profile_id = ${profile.id} WHERE id = ${conn.id}`;
+		return conn.id;
+	}
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const {
+			org,
+			user,
+			ctx: ownerCtx,
+		} = await seedOwnerContext({
+			orgName: "Scope Readiness Org",
+		});
+		ownerCtx.baseUrl = "https://gateway.test/lobu";
+		orgId = org.id;
+		userId = user.id;
+		ctx = ownerCtx;
+
+		const sql = getTestDb();
+		await createTestConnectorDefinition({
+			key: CONNECTOR_KEY,
+			name: "Scope Calendar",
+			organization_id: orgId,
+			auth_schema: {
+				methods: [
+					{
+						type: "oauth",
+						provider: "test",
+						requiredScopes: [READONLY_SCOPE],
+						optionalScopes: [WRITE_SCOPE],
+					},
+				],
+			},
+		});
+		await sql`
+			UPDATE connector_definitions
+			SET actions_schema = ${sql.json(ACTIONS_SCHEMA)},
+			    supports_execute = true
+			WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+		`;
+		await sql`
+			UPDATE connector_versions
+			SET compiled_code = ${`class R { async sync(){return {items:[]};} async execute(ctx){return {success:true,output:{}};} } export { R };`}
+			WHERE connector_key = ${CONNECTOR_KEY}
+		`;
+
+		readonlyConnId = await seedScopedConnection([READONLY_SCOPE]);
+		writableConnId = await seedScopedConnection([READONLY_SCOPE, WRITE_SCOPE]);
+	});
+
+	async function listOp(
+		operationKey: string,
+		connectionId: number,
+	): Promise<{
+		readiness: string;
+		executable: boolean;
+		next_action?: Record<string, unknown>;
+		execution_targets: Array<{
+			connection_id: number;
+			status: string;
+			executable: boolean;
+			reason: string;
+		}>;
+	}> {
+		const listed = (await manageOperations(
+			{ action: "list_available", connection_id: connectionId },
+			{} as Env,
+			ctx,
+		)) as {
+			operations: Array<{
+				operation_key: string;
+				readiness: string;
+				executable: boolean;
+				next_action?: Record<string, unknown>;
+				execution_targets: Array<{
+					connection_id: number;
+					status: string;
+					executable: boolean;
+					reason: string;
+				}>;
+			}>;
+		};
+		const op = listed.operations.find((o) => o.operation_key === operationKey);
+		if (!op)
+			throw new Error(`${operationKey} not listed for conn ${connectionId}`);
+		return op;
+	}
+
+	it("marks a write action not-executable when its required scope is missing", async () => {
+		const op = await listOp("create_event", readonlyConnId);
+		expect(op.executable).toBe(false);
+		expect(op.readiness).toBe("scope_upgrade_required");
+		const target = op.execution_targets.find(
+			(t) => t.connection_id === readonlyConnId,
+		);
+		expect(target?.executable).toBe(false);
+		expect(target?.status).toBe("scope_upgrade_required");
+		expect(target?.reason).toContain(WRITE_SCOPE);
+	});
+
+	it("surfaces a reauthorize next_action naming exactly the missing scope", async () => {
+		const op = await listOp("create_event", readonlyConnId);
+		expect(op.next_action?.action).toBe("reauthorize");
+		expect(op.next_action?.connection_id).toBe(readonlyConnId);
+		expect(op.next_action?.requested_scopes).toEqual([WRITE_SCOPE]);
+	});
+
+	it("keeps read actions on the same connection executable", async () => {
+		const op = await listOp("get_event", readonlyConnId);
+		expect(op.executable).toBe(true);
+		expect(op.readiness).toBe("ready");
+	});
+
+	it("marks the write action executable when the write scope IS granted", async () => {
+		const op = await listOp("create_event", writableConnId);
+		expect(op.executable).toBe(true);
+		expect(op.readiness).toBe("ready");
+	});
+});

--- a/packages/server/src/__tests__/integration/operations-scope-aware-readiness.test.ts
+++ b/packages/server/src/__tests__/integration/operations-scope-aware-readiness.test.ts
@@ -1,20 +1,8 @@
-/**
- * Operation readiness must respect per-operation OAuth scopes.
- *
- * A connection can be active + authenticated (so status readiness is "ready")
- * yet still lack the OAuth scope a specific write action needs. Before this
- * change, `operations.listAvailable` reported such write actions as
- * `executable: true` — e.g. a Calendar connection granted only
- * `calendar.readonly` reported `create_event` ready, then the provider rejected
- * the write at execution time. Readiness now maps an action whose declared
- * `requiredScopes` are not covered by the connection's granted scopes to
- * `readiness: "scope_upgrade_required"` (not executable) with a `reauthorize`
- * next_action carrying exactly the missing scopes, while read actions on the
- * same connection stay executable.
- */
+/** Active connections still need per-action OAuth scope readiness. */
 
 import { beforeAll, describe, expect, it } from "vitest";
 import type { Env } from "../../index";
+import { manageAuthProfiles } from "../../tools/admin/manage_auth_profiles";
 import { manageOperations } from "../../tools/admin/manage_operations";
 import type { ToolContext } from "../../tools/registry";
 import { createAuthProfile } from "../../utils/auth-profiles";
@@ -30,8 +18,6 @@ const CONNECTOR_KEY = "demo.scope.calendar";
 const READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly";
 const WRITE_SCOPE = "https://www.googleapis.com/auth/calendar.events";
 
-// Two write actions declaring the write scope, one read action declaring none —
-// mirrors google.calendar (create/update/delete_event vs get_event).
 const ACTIONS_SCHEMA = {
 	create_event: {
 		key: "create_event",
@@ -51,14 +37,13 @@ describe("operation readiness respects OAuth scopes", () => {
 	let orgId: string;
 	let userId: string;
 	let ctx: ToolContext;
-	// connection granted only the readonly scope
 	let readonlyConnId: number;
-	// connection granted both readonly + write scopes
 	let writableConnId: number;
 
-	async function seedScopedConnection(
-		grantedScopes: string[],
-	): Promise<number> {
+	async function seedScopedConnection(grantedScopes?: string[]): Promise<{
+		connectionId: number;
+		profileSlug: string;
+	}> {
 		const sql = getTestDb();
 		const conn = await createTestConnection({
 			organization_id: orgId,
@@ -75,10 +60,16 @@ describe("operation readiness respects OAuth scopes", () => {
 			provider: "test",
 			status: "active",
 			createdBy: userId,
-			authData: { granted_scopes: grantedScopes },
+			authData:
+				grantedScopes === undefined
+					? {}
+					: {
+							requested_scopes: [READONLY_SCOPE],
+							granted_scopes: grantedScopes,
+						},
 		});
 		await sql`UPDATE connections SET auth_profile_id = ${profile.id} WHERE id = ${conn.id}`;
-		return conn.id;
+		return { connectionId: conn.id, profileSlug: profile.slug };
 	}
 
 	beforeAll(async () => {
@@ -124,8 +115,12 @@ describe("operation readiness respects OAuth scopes", () => {
 			WHERE connector_key = ${CONNECTOR_KEY}
 		`;
 
-		readonlyConnId = await seedScopedConnection([READONLY_SCOPE]);
-		writableConnId = await seedScopedConnection([READONLY_SCOPE, WRITE_SCOPE]);
+		readonlyConnId = (
+			await seedScopedConnection([READONLY_SCOPE])
+		).connectionId;
+		writableConnId = (
+			await seedScopedConnection([READONLY_SCOPE, WRITE_SCOPE])
+		).connectionId;
 	});
 
 	async function listOp(
@@ -185,6 +180,35 @@ describe("operation readiness respects OAuth scopes", () => {
 		expect(op.next_action?.requested_scopes).toEqual([WRITE_SCOPE]);
 	});
 
+	it("provides an invokable next_action that requests the missing scope", async () => {
+		const seeded = await seedScopedConnection([READONLY_SCOPE]);
+		const op = await listOp("create_event", seeded.connectionId);
+		expect(op.next_action).toMatchObject({
+			sdk_method: "authProfiles.update",
+			arguments: [
+				{
+					auth_profile_slug: seeded.profileSlug,
+					requested_scopes: [READONLY_SCOPE, WRITE_SCOPE],
+					reconnect: true,
+				},
+			],
+		});
+
+		const [input] = op.next_action?.arguments as Array<Record<string, unknown>>;
+		const result = await manageAuthProfiles(
+			{ action: "update_auth_profile", ...input } as never,
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "update_auth_profile",
+			connect_url: expect.any(String),
+			auth_profile: {
+				requested_scopes: [READONLY_SCOPE, WRITE_SCOPE],
+			},
+		});
+	});
+
 	it("keeps read actions on the same connection executable", async () => {
 		const op = await listOp("get_event", readonlyConnId);
 		expect(op.executable).toBe(true);
@@ -197,14 +221,17 @@ describe("operation readiness respects OAuth scopes", () => {
 		expect(op.readiness).toBe("ready");
 	});
 
-	it("does not gate a legacy connection whose grant recorded no scopes", async () => {
-		// Connections authorized before scope recording (pre-#1901) have an empty
-		// granted_scopes even when the underlying token covers the write scope.
-		// Absence of recorded scopes is unknown, not missing — the gate must not
-		// falsely block a working connection.
-		const legacyConnId = await seedScopedConnection([]);
-		const op = await listOp("create_event", legacyConnId);
+	it("does not gate a legacy connection whose grant scopes were not recorded", async () => {
+		const legacy = await seedScopedConnection();
+		const op = await listOp("create_event", legacy.connectionId);
 		expect(op.readiness).toBe("ready");
 		expect(op.executable).toBe(true);
+	});
+
+	it("gates a known empty grant instead of treating it as legacy data", async () => {
+		const knownEmpty = await seedScopedConnection([]);
+		const op = await listOp("create_event", knownEmpty.connectionId);
+		expect(op.readiness).toBe("scope_upgrade_required");
+		expect(op.executable).toBe(false);
 	});
 });

--- a/packages/server/src/__tests__/integration/operations-scope-aware-readiness.test.ts
+++ b/packages/server/src/__tests__/integration/operations-scope-aware-readiness.test.ts
@@ -196,4 +196,15 @@ describe("operation readiness respects OAuth scopes", () => {
 		expect(op.executable).toBe(true);
 		expect(op.readiness).toBe("ready");
 	});
+
+	it("does not gate a legacy connection whose grant recorded no scopes", async () => {
+		// Connections authorized before scope recording (pre-#1901) have an empty
+		// granted_scopes even when the underlying token covers the write scope.
+		// Absence of recorded scopes is unknown, not missing — the gate must not
+		// falsely block a working connection.
+		const legacyConnId = await seedScopedConnection([]);
+		const op = await listOp("create_event", legacyConnId);
+		expect(op.readiness).toBe("ready");
+		expect(op.executable).toBe(true);
+	});
 });

--- a/packages/server/src/operations/connector-operations.ts
+++ b/packages/server/src/operations/connector-operations.ts
@@ -91,13 +91,6 @@ function normalizeAnnotations(raw: unknown): OperationAnnotations | undefined {
 	return Object.keys(annotations).length > 0 ? annotations : undefined;
 }
 
-/**
- * Coerce a stored action's per-operation scope list into `string[] | undefined`.
- * The value comes from the serialized connector definition (`actions_schema`),
- * so it may be missing, a string array, or (defensively) a malformed blob.
- * Returns undefined when there are no scopes so the descriptor stays clean and
- * readiness treats the op as scope-unconstrained.
- */
 function normalizeRequiredScopes(raw: unknown): string[] | undefined {
 	if (!Array.isArray(raw)) return undefined;
 	const scopes = raw
@@ -448,9 +441,7 @@ function getLocalActionOperations(
 		kind: getLocalActionKind(def),
 		backend: "local_action",
 		requires_approval: def.requiresApproval ?? false,
-		required_scopes: normalizeRequiredScopes(
-			def.requiredScopes ?? def.required_scopes,
-		),
+		required_scopes: normalizeRequiredScopes(def.requiredScopes),
 		annotations:
 			normalizeAnnotations(def.annotations) ??
 			((def.requiresApproval ?? false) ? { destructiveHint: true } : undefined),

--- a/packages/server/src/operations/connector-operations.ts
+++ b/packages/server/src/operations/connector-operations.ts
@@ -91,6 +91,22 @@ function normalizeAnnotations(raw: unknown): OperationAnnotations | undefined {
 	return Object.keys(annotations).length > 0 ? annotations : undefined;
 }
 
+/**
+ * Coerce a stored action's per-operation scope list into `string[] | undefined`.
+ * The value comes from the serialized connector definition (`actions_schema`),
+ * so it may be missing, a string array, or (defensively) a malformed blob.
+ * Returns undefined when there are no scopes so the descriptor stays clean and
+ * readiness treats the op as scope-unconstrained.
+ */
+function normalizeRequiredScopes(raw: unknown): string[] | undefined {
+	if (!Array.isArray(raw)) return undefined;
+	const scopes = raw
+		.filter((scope): scope is string => typeof scope === "string")
+		.map((scope) => scope.trim())
+		.filter(Boolean);
+	return scopes.length > 0 ? scopes : undefined;
+}
+
 function operationIdFromPath(method: string, pathTemplate: string): string {
 	return `${method}_${pathTemplate.replace(/[{}]/g, "").replace(/[^a-zA-Z0-9]+/g, "_")}`.replace(
 		/^_+|_+$/g,
@@ -432,6 +448,9 @@ function getLocalActionOperations(
 		kind: getLocalActionKind(def),
 		backend: "local_action",
 		requires_approval: def.requiresApproval ?? false,
+		required_scopes: normalizeRequiredScopes(
+			def.requiredScopes ?? def.required_scopes,
+		),
 		annotations:
 			normalizeAnnotations(def.annotations) ??
 			((def.requiresApproval ?? false) ? { destructiveHint: true } : undefined),

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -690,6 +690,12 @@ function buildAvailableOperation(args: {
 		if (
 			publicTarget.executable &&
 			requiredScopes.length > 0 &&
+			// Only gate when we actually recorded the grant's scopes. Connections
+			// authorized before scope recording (pre-#1901) have an empty
+			// granted_scopes even when the token covers the scope — treating
+			// "unknown" as "missing" would falsely block a working connection.
+			// Absence of data is not evidence of a missing scope.
+			granted_scopes.length > 0 &&
 			!hasAllScopes(granted_scopes, requiredScopes)
 		) {
 			const missing = requiredScopes.filter(

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -24,6 +24,10 @@ import {
 	RejectBatchAction,
 } from "@lobu/core/contracts/tools/manage-operations";
 import type { Static } from "@sinclair/typebox";
+import {
+	hasAllScopes,
+	readGrantedScopesFromAuthData,
+} from "../../auth/oauth/scopes";
 import { compileConnectionRowVisibility } from "../../authz/connection-visibility";
 import {
 	agentExistsInOrg,
@@ -136,6 +140,8 @@ type ExecutionTarget = {
 type InternalExecutionTarget = ExecutionTarget & {
 	config: Record<string, unknown> | null;
 	auth_profile_kind: string | null;
+	/** OAuth scopes actually granted on this connection's auth profile. */
+	granted_scopes: string[];
 };
 
 type OperationTargetRow = {
@@ -149,6 +155,7 @@ type OperationTargetRow = {
 	device_online: boolean;
 	device_bound: boolean;
 	auth_profile_kind: string | null;
+	auth_data: Record<string, unknown> | null;
 };
 
 /**
@@ -419,6 +426,7 @@ function executionTargetFromRow(
 		display_name: row.display_name ?? row.slug,
 		config: row.config,
 		auth_profile_kind: row.auth_profile_kind,
+		granted_scopes: readGrantedScopesFromAuthData(row.auth_data),
 	};
 	if (row.status !== "active") {
 		return {
@@ -469,6 +477,9 @@ function operationReadinessReason(
 	}
 	if (readiness === "device_offline") {
 		return "Every visible active device-bound connection is offline.";
+	}
+	if (readiness === "scope_upgrade_required") {
+		return "This operation needs OAuth scopes the connection has not granted. Reauthorize to grant them.";
 	}
 	if (readiness === "disabled") {
 		return "This operation is disabled on every visible connection.";
@@ -529,6 +540,7 @@ function buildOperationNextAction(args: {
 	remediationTarget: ExecutionTarget | undefined;
 	remediationConfig: Record<string, unknown> | null | undefined;
 	remediationAuthKind: string | null | undefined;
+	missingScopes: string[];
 	viewUrl: string | undefined;
 }): Record<string, unknown> {
 	const {
@@ -538,6 +550,7 @@ function buildOperationNextAction(args: {
 		remediationTarget,
 		remediationConfig,
 		remediationAuthKind,
+		missingScopes,
 		viewUrl,
 	} = args;
 	if (readyTarget) {
@@ -575,6 +588,16 @@ function buildOperationNextAction(args: {
 			action: "connect",
 			sdk_method: "connections.connect",
 			arguments: [{ connector_key: operation.connector_key }],
+		};
+	}
+	if (readiness === "scope_upgrade_required") {
+		return {
+			action: "reauthorize",
+			sdk_method: "connections.reauthenticate",
+			connection_id: remediationTarget?.connection_id,
+			requested_scopes: missingScopes,
+			arguments: [{ connection_id: remediationTarget?.connection_id }],
+			...(viewUrl ? { view_url: viewUrl } : {}),
 		};
 	}
 	if (readiness === "disabled") {
@@ -641,21 +664,45 @@ function buildAvailableOperation(args: {
 	const { operation, internalTargets, includeInputSchema, viewUrl } = args;
 	const { backend_config: _privateBackendConfig, ...publicOperation } =
 		operation;
+	// Scopes this specific action needs beyond the connector baseline (e.g. a
+	// calendar write scope for create/update/delete_event). An op declaring these
+	// is not executable on a connection whose OAuth grant does not cover them,
+	// even though the connection itself is active — readiness must say so instead
+	// of reporting it ready (a scope-blind "ready" makes the agent attempt a
+	// write that the provider rejects at execution time).
+	const requiredScopes =
+		(operation as OperationDescriptor).required_scopes ?? [];
 	const targets = internalTargets.map((target): ExecutionTarget => {
 		const {
 			config,
 			auth_profile_kind: _authProfileKind,
+			granted_scopes,
 			...publicTarget
 		} = target;
-		if (resolveActionMode(operation, config) !== "disabled") {
-			return publicTarget;
+		if (resolveActionMode(operation, config) === "disabled") {
+			return {
+				...publicTarget,
+				status: "disabled",
+				executable: false,
+				reason: "This operation is disabled on the connection.",
+			};
 		}
-		return {
-			...publicTarget,
-			status: "disabled",
-			executable: false,
-			reason: "This operation is disabled on the connection.",
-		};
+		if (
+			publicTarget.executable &&
+			requiredScopes.length > 0 &&
+			!hasAllScopes(granted_scopes, requiredScopes)
+		) {
+			const missing = requiredScopes.filter(
+				(scope) => !hasAllScopes(granted_scopes, [scope]),
+			);
+			return {
+				...publicTarget,
+				status: "scope_upgrade_required",
+				executable: false,
+				reason: `Missing OAuth scope(s): ${missing.join(", ")}. Reauthorize the connection to grant them.`,
+			};
+		}
+		return publicTarget;
 	});
 	// Capability gate (#2033 item 2): a local_action op whose compiled runtime
 	// does NOT override execute() is declared in the catalog but would throw
@@ -672,6 +719,15 @@ function buildAvailableOperation(args: {
 	const remediationInternalTarget = internalTargets.find(
 		(target) => target.connection_id === remediationTarget?.connection_id,
 	);
+	const missingScopes =
+		readiness === "scope_upgrade_required"
+			? requiredScopes.filter(
+					(scope) =>
+						!hasAllScopes(remediationInternalTarget?.granted_scopes ?? [], [
+							scope,
+						]),
+				)
+			: [];
 	return {
 		...(publicOperation as AvailableOperation),
 		...(includeInputSchema ? {} : { input_schema: undefined }),
@@ -687,6 +743,7 @@ function buildAvailableOperation(args: {
 			remediationTarget,
 			remediationConfig: remediationInternalTarget?.config,
 			remediationAuthKind: remediationInternalTarget?.auth_profile_kind,
+			missingScopes,
 			viewUrl,
 		}),
 	};
@@ -712,6 +769,7 @@ async function loadVisibleOperationTargets(
 		        c.config,
 		        c.device_worker_id,
 		        ap.profile_kind AS auth_profile_kind,
+		        ap.auth_data AS auth_data,
 		        COALESCE(dw.last_seen_at > now() - interval '20 minutes', false) AS device_online,
 		        (c.device_worker_id IS NOT NULL OR latest.runtime IS NOT NULL) AS device_bound
 		 FROM connections c

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -27,6 +27,7 @@ import type { Static } from "@sinclair/typebox";
 import {
 	hasAllScopes,
 	readGrantedScopesFromAuthData,
+	readRequestedScopesFromAuthData,
 } from "../../auth/oauth/scopes";
 import { compileConnectionRowVisibility } from "../../authz/connection-visibility";
 import {
@@ -140,8 +141,10 @@ type ExecutionTarget = {
 type InternalExecutionTarget = ExecutionTarget & {
 	config: Record<string, unknown> | null;
 	auth_profile_kind: string | null;
-	/** OAuth scopes actually granted on this connection's auth profile. */
+	auth_profile_slug: string | null;
 	granted_scopes: string[];
+	granted_scopes_known: boolean;
+	requested_scopes: string[];
 };
 
 type OperationTargetRow = {
@@ -155,6 +158,7 @@ type OperationTargetRow = {
 	device_online: boolean;
 	device_bound: boolean;
 	auth_profile_kind: string | null;
+	auth_profile_slug: string | null;
 	auth_data: Record<string, unknown> | null;
 };
 
@@ -426,7 +430,10 @@ function executionTargetFromRow(
 		display_name: row.display_name ?? row.slug,
 		config: row.config,
 		auth_profile_kind: row.auth_profile_kind,
+		auth_profile_slug: row.auth_profile_slug,
 		granted_scopes: readGrantedScopesFromAuthData(row.auth_data),
+		granted_scopes_known: Object.hasOwn(row.auth_data ?? {}, "granted_scopes"),
+		requested_scopes: readRequestedScopesFromAuthData(row.auth_data),
 	};
 	if (row.status !== "active") {
 		return {
@@ -540,7 +547,9 @@ function buildOperationNextAction(args: {
 	remediationTarget: ExecutionTarget | undefined;
 	remediationConfig: Record<string, unknown> | null | undefined;
 	remediationAuthKind: string | null | undefined;
+	remediationAuthProfileSlug: string | null | undefined;
 	missingScopes: string[];
+	requestedScopes: string[];
 	viewUrl: string | undefined;
 }): Record<string, unknown> {
 	const {
@@ -550,7 +559,9 @@ function buildOperationNextAction(args: {
 		remediationTarget,
 		remediationConfig,
 		remediationAuthKind,
+		remediationAuthProfileSlug,
 		missingScopes,
+		requestedScopes,
 		viewUrl,
 	} = args;
 	if (readyTarget) {
@@ -593,10 +604,18 @@ function buildOperationNextAction(args: {
 	if (readiness === "scope_upgrade_required") {
 		return {
 			action: "reauthorize",
-			sdk_method: "connections.reauthenticate",
+			sdk_method: "authProfiles.update",
 			connection_id: remediationTarget?.connection_id,
 			requested_scopes: missingScopes,
-			arguments: [{ connection_id: remediationTarget?.connection_id }],
+			arguments: [
+				{
+					auth_profile_slug: remediationAuthProfileSlug,
+					requested_scopes: Array.from(
+						new Set([...requestedScopes, ...missingScopes]),
+					),
+					reconnect: true,
+				},
+			],
 			...(viewUrl ? { view_url: viewUrl } : {}),
 		};
 	}
@@ -664,19 +683,15 @@ function buildAvailableOperation(args: {
 	const { operation, internalTargets, includeInputSchema, viewUrl } = args;
 	const { backend_config: _privateBackendConfig, ...publicOperation } =
 		operation;
-	// Scopes this specific action needs beyond the connector baseline (e.g. a
-	// calendar write scope for create/update/delete_event). An op declaring these
-	// is not executable on a connection whose OAuth grant does not cover them,
-	// even though the connection itself is active — readiness must say so instead
-	// of reporting it ready (a scope-blind "ready" makes the agent attempt a
-	// write that the provider rejects at execution time).
-	const requiredScopes =
-		(operation as OperationDescriptor).required_scopes ?? [];
+	const requiredScopes = operation.required_scopes ?? [];
 	const targets = internalTargets.map((target): ExecutionTarget => {
 		const {
 			config,
 			auth_profile_kind: _authProfileKind,
+			auth_profile_slug: _authProfileSlug,
 			granted_scopes,
+			granted_scopes_known,
+			requested_scopes: _requestedScopes,
 			...publicTarget
 		} = target;
 		if (resolveActionMode(operation, config) === "disabled") {
@@ -690,12 +705,9 @@ function buildAvailableOperation(args: {
 		if (
 			publicTarget.executable &&
 			requiredScopes.length > 0 &&
-			// Only gate when we actually recorded the grant's scopes. Connections
-			// authorized before scope recording (pre-#1901) have an empty
-			// granted_scopes even when the token covers the scope — treating
-			// "unknown" as "missing" would falsely block a working connection.
-			// Absence of data is not evidence of a missing scope.
-			granted_scopes.length > 0 &&
+			// Older auth profiles may not record granted_scopes. Absence is unknown;
+			// a recorded empty grant is known and must still fail the scope gate.
+			granted_scopes_known &&
 			!hasAllScopes(granted_scopes, requiredScopes)
 		) {
 			const missing = requiredScopes.filter(
@@ -749,7 +761,10 @@ function buildAvailableOperation(args: {
 			remediationTarget,
 			remediationConfig: remediationInternalTarget?.config,
 			remediationAuthKind: remediationInternalTarget?.auth_profile_kind,
+			remediationAuthProfileSlug:
+				remediationInternalTarget?.auth_profile_slug,
 			missingScopes,
+			requestedScopes: remediationInternalTarget?.requested_scopes ?? [],
 			viewUrl,
 		}),
 	};
@@ -775,6 +790,7 @@ async function loadVisibleOperationTargets(
 		        c.config,
 		        c.device_worker_id,
 		        ap.profile_kind AS auth_profile_kind,
+		        ap.slug AS auth_profile_slug,
 		        ap.auth_data AS auth_data,
 		        COALESCE(dw.last_seen_at > now() - interval '20 minutes', false) AS device_online,
 		        (c.device_worker_id IS NOT NULL OR latest.runtime IS NOT NULL) AS device_bound


### PR DESCRIPTION
operations.listAvailable reported an action executable whenever its connection was active and device-online, ignoring OAuth scopes. A Google Calendar connection granted only calendar.readonly reported create_event/update_event/delete_event as ready, then the provider rejected the write at execution time.

Actions can now declare per-operation requiredScopes. Readiness reads the connection's granted scopes and maps an action whose required scopes aren't covered to readiness=scope_upgrade_required (not executable), with a reauthorize next_action carrying the missing scopes. Read actions on the same connection stay executable. Calendar write actions declare the calendar.events scope.

Covered by operations-scope-aware-readiness.test.ts (red→green verified locally, plus 23 existing readiness tests still pass).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operation availability is now derived from each connection’s OAuth granted scopes, including per-action required scopes.
  * When permissions are missing, operations are marked non-executable and prompt reauthorization for exactly the missing scopes.
  * Connector action definitions now preserve action-level semantic metadata (including required scopes).

* **Bug Fixes**
  * Google Calendar write actions now explicitly require the calendar events scope.

* **Tests**
  * Added integration coverage for scope-aware readiness/executability, including legacy and empty-grant connection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->