### PR TITLE
fix(feeds): true total + has_more and a health filter for list_feeds

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2734,9 +2734,13 @@ export type ManageFeedsData = {
          */
         entity_id?: number;
         /**
-         * Filter by status: active, paused, error
+         * Filter by desired lifecycle status. Only 'active' and 'paused' are real feed statuses.
          */
-        status?: string;
+        status?: "active" | "paused";
+        /**
+         * Filter by runtime health, independent of lifecycle status. 'failing' = last sync failed or one or more consecutive failures; 'healthy' = otherwise.
+         */
+        health?: "healthy" | "failing";
         /**
          * Page size (default: 100)
          */
@@ -2836,9 +2840,9 @@ export type ManageFeedsData = {
          */
         feed_id: number;
         /**
-         * active, paused, error
+         * Desired feed status: active or paused. 'error' is a runtime state the system owns, not a status you set.
          */
-        status?: string;
+        status?: "active" | "paused";
         display_name?: string;
         entity_ids?: Array<number>;
         config?: {
@@ -2922,6 +2926,7 @@ export type ManageFeedsResponses = {
           [key: string]: unknown;
         }>;
         total: number;
+        has_more: boolean;
         limit: number;
         offset: number;
       }

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -150,7 +150,7 @@ export const UpdateFeedAction = Type.Object({
   status: Type.Optional(
     Type.Union([Type.Literal("active"), Type.Literal("paused")], {
       description:
-        "Desired feed status: active or paused. 'error' is a runtime state the system owns, not a status you set — a failing feed stays active; use the `list` action's `health: failing` filter to find failing feeds.",
+        "Desired feed status: active or paused. 'error' is a runtime state the system owns, not a status you set — a failing feed stays active; use the `list_feeds` action's `health: failing` filter to find failing feeds.",
     })
   ),
   display_name: Type.Optional(Type.String()),

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -212,12 +212,11 @@ export const ManageFeedsResultSchema = Type.Union([
     action: Type.Literal("list_feeds"),
     feeds: Type.Array(Type.Record(Type.String(), Type.Unknown())),
     /**
-     * Count of all feeds matching the filters, computed with a window function
-     * (`COUNT(*) OVER()`) evaluated over the returned page. On any in-range page
-     * this is the true whole-set total (not the page length); on an offset past
-     * the last matching row the page is empty and it is 0. Callers paginate
-     * forward and stop on `has_more`; they do not jump to an arbitrary offset,
-     * so the 0-on-overshoot case is not reached by the intended access pattern.
+     * Count of all feeds matching the filters, independent of this page. On a
+     * non-empty page it is read from the page's `COUNT(*) OVER()` window; on an
+     * offset past the last matching row (empty page) it is recovered with a
+     * bare count over the same filters — so it is always the true whole-set
+     * total, even for an overshot offset.
      */
     total: Type.Integer(),
     /** True when more feeds match past this page (offset + returned < total). */

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -212,10 +212,12 @@ export const ManageFeedsResultSchema = Type.Union([
     action: Type.Literal("list_feeds"),
     feeds: Type.Array(Type.Record(Type.String(), Type.Unknown())),
     /**
-     * Total feeds matching the filters across ALL pages, not just this page.
-     * Read from the page's window count, so an `offset` past the last page
-     * returns 0 (the page is empty) rather than the true count — paginate
-     * forward and stop on `has_more`, don't jump to an arbitrary offset.
+     * Count of all feeds matching the filters, computed with a window function
+     * (`COUNT(*) OVER()`) evaluated over the returned page. On any in-range page
+     * this is the true whole-set total (not the page length); on an offset past
+     * the last matching row the page is empty and it is 0. Callers paginate
+     * forward and stop on `has_more`; they do not jump to an arbitrary offset,
+     * so the 0-on-overshoot case is not reached by the intended access pattern.
      */
     total: Type.Integer(),
     /** True when more feeds match past this page (offset + returned < total). */

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -29,7 +29,16 @@ export const ListFeedsAction = Type.Object({
     Type.Number({ description: "Filter by linked entity ID" })
   ),
   status: Type.Optional(
-    Type.String({ description: "Filter by status: active, paused, error" })
+    Type.Union([Type.Literal("active"), Type.Literal("paused")], {
+      description:
+        "Filter by desired lifecycle status. Only 'active' and 'paused' are real feed statuses — a feed that keeps failing stays 'active' (or auto-pauses). Use `health` to find failing feeds.",
+    })
+  ),
+  health: Type.Optional(
+    Type.Union([Type.Literal("healthy"), Type.Literal("failing")], {
+      description:
+        "Filter by runtime health, independent of lifecycle status. 'failing' = last sync failed or the feed has one or more consecutive failures; 'healthy' = otherwise. Surfaces active-but-failing feeds the `status` filter cannot.",
+    })
   ),
   ...PaginationFields,
 });
@@ -138,7 +147,12 @@ export const UpdateFeedAction = Type.Object({
     description: "Patch a feed (status, config, schedule, repair agent).",
   }),
   feed_id: Type.Number({ description: "Feed ID" }),
-  status: Type.Optional(Type.String({ description: "active, paused, error" })),
+  status: Type.Optional(
+    Type.Union(
+      [Type.Literal("active"), Type.Literal("paused"), Type.Literal("error")],
+      { description: "Desired feed status: active, paused, or error." }
+    )
+  ),
   display_name: Type.Optional(Type.String()),
   entity_ids: Type.Optional(Type.Array(Type.Number())),
   config: Type.Optional(Type.Record(Type.String(), Type.Any())),
@@ -197,7 +211,10 @@ export const ManageFeedsResultSchema = Type.Union([
   Type.Object({
     action: Type.Literal("list_feeds"),
     feeds: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+    /** Total feeds matching the filters across ALL pages, not just this page. */
     total: Type.Integer(),
+    /** True when more feeds match past this page (offset + returned < total). */
+    has_more: Type.Boolean(),
     limit: Type.Integer(),
     offset: Type.Integer(),
   }),

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -211,7 +211,12 @@ export const ManageFeedsResultSchema = Type.Union([
   Type.Object({
     action: Type.Literal("list_feeds"),
     feeds: Type.Array(Type.Record(Type.String(), Type.Unknown())),
-    /** Total feeds matching the filters across ALL pages, not just this page. */
+    /**
+     * Total feeds matching the filters across ALL pages, not just this page.
+     * Read from the page's window count, so an `offset` past the last page
+     * returns 0 (the page is empty) rather than the true count — paginate
+     * forward and stop on `has_more`, don't jump to an arbitrary offset.
+     */
     total: Type.Integer(),
     /** True when more feeds match past this page (offset + returned < total). */
     has_more: Type.Boolean(),

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -148,10 +148,10 @@ export const UpdateFeedAction = Type.Object({
   }),
   feed_id: Type.Number({ description: "Feed ID" }),
   status: Type.Optional(
-    Type.Union(
-      [Type.Literal("active"), Type.Literal("paused"), Type.Literal("error")],
-      { description: "Desired feed status: active, paused, or error." }
-    )
+    Type.Union([Type.Literal("active"), Type.Literal("paused")], {
+      description:
+        "Desired feed status: active or paused. 'error' is a runtime state the system owns, not a status you set — a failing feed stays active; use the `list` action's `health: failing` filter to find failing feeds.",
+    })
   ),
   display_name: Type.Optional(Type.String()),
   entity_ids: Type.Optional(Type.Array(Type.Number())),

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -1,0 +1,132 @@
+/**
+ * list_feeds must report the true match count and expose active-but-failing
+ * feeds.
+ *
+ * Two gaps this covers:
+ *  - `total` was `rows.length` (the page length), so a 3-feed page reported
+ *    total:3 even when more matched — and `total === limit` was
+ *    indistinguishable from an exact count. It is now COUNT(*) OVER() across
+ *    the whole filtered set, plus a `has_more` flag.
+ *  - A feed keeps `status = 'active'` while its syncs fail (until it crosses
+ *    the auto-pause threshold), so the `status` filter can never surface a
+ *    failing-but-active feed. The new `health` filter matches on
+ *    last_sync_status/consecutive_failures.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageFeeds } from "../../tools/admin/manage_feeds";
+import type { ToolContext } from "../../tools/registry";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import { createTestConnection, seedOwnerContext } from "../setup/test-fixtures";
+
+describe("list_feeds health filter and true total", () => {
+	let orgId: string;
+	let ctx: ToolContext;
+	let connectionId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, ctx: ownerCtx } = await seedOwnerContext({
+			orgName: "Feeds Health Org",
+		});
+		orgId = org.id;
+		ctx = ownerCtx;
+
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "hackernews",
+			createDefaultFeed: false,
+		});
+		connectionId = conn.id;
+
+		const sql = getTestDb();
+		// 5 feeds: 3 healthy active, 1 active-but-failing (last sync failed),
+		// 1 active with consecutive failures but last sync not yet marked failed.
+		const feeds: Array<{
+			key: string;
+			status: string;
+			last: string | null;
+			fails: number;
+		}> = [
+			{ key: "h1", status: "active", last: "success", fails: 0 },
+			{ key: "h2", status: "active", last: "success", fails: 0 },
+			{ key: "h3", status: "active", last: null, fails: 0 },
+			{ key: "bad1", status: "active", last: "failed", fails: 14 },
+			{ key: "bad2", status: "active", last: "success", fails: 3 },
+		];
+		for (const f of feeds) {
+			await sql`
+				INSERT INTO feeds (
+					organization_id, connection_id, feed_key, status,
+					last_sync_status, consecutive_failures, entity_ids, created_at, updated_at
+				) VALUES (
+					${orgId}, ${connectionId}, ${f.key}, ${f.status},
+					${f.last}, ${f.fails}, ARRAY[]::bigint[], NOW(), NOW()
+				)
+			`;
+		}
+	});
+
+	async function list(args: Record<string, unknown>): Promise<{
+		feeds: Array<Record<string, unknown>>;
+		total: number;
+		has_more: boolean;
+	}> {
+		return (await manageFeeds(
+			{ action: "list_feeds", connection_id: connectionId, ...args },
+			{} as Env,
+			ctx,
+		)) as {
+			feeds: Array<Record<string, unknown>>;
+			total: number;
+			has_more: boolean;
+		};
+	}
+
+	it("reports the true total across pages, not the page length, with has_more", async () => {
+		const page1 = await list({ limit: 2, offset: 0 });
+		expect(page1.feeds).toHaveLength(2);
+		expect(page1.total).toBe(5);
+		expect(page1.has_more).toBe(true);
+
+		const lastPage = await list({ limit: 2, offset: 4 });
+		expect(lastPage.feeds).toHaveLength(1);
+		expect(lastPage.total).toBe(5);
+		expect(lastPage.has_more).toBe(false);
+	});
+
+	it("does not leak the internal count column onto feed rows", async () => {
+		const res = await list({ limit: 10 });
+		for (const feed of res.feeds) {
+			expect(feed).not.toHaveProperty("filtered_total");
+		}
+	});
+
+	it("health=failing surfaces active-but-failing feeds status cannot", async () => {
+		// status filter sees them all as active
+		const active = await list({ status: "active" });
+		expect(active.total).toBe(5);
+
+		const failing = await list({ health: "failing" });
+		const keys = failing.feeds.map((f) => f.feed_key).sort();
+		expect(keys).toEqual(["bad1", "bad2"]);
+		expect(failing.total).toBe(2);
+	});
+
+	it("health=healthy excludes failing feeds", async () => {
+		const healthy = await list({ health: "healthy" });
+		const keys = healthy.feeds.map((f) => f.feed_key).sort();
+		expect(keys).toEqual(["h1", "h2", "h3"]);
+		expect(healthy.total).toBe(3);
+	});
+
+	it("returns has_more:false and total:0 for an empty filtered set", async () => {
+		const none = await list({ health: "failing", feed_ids: [999999999] });
+		expect(none.feeds).toHaveLength(0);
+		expect(none.total).toBe(0);
+		expect(none.has_more).toBe(false);
+	});
+});

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -129,4 +129,20 @@ describe("list_feeds health filter and true total", () => {
 		expect(none.total).toBe(0);
 		expect(none.has_more).toBe(false);
 	});
+
+	it("rejects update_feed status:'error' — a runtime state, not a settable one", async () => {
+		// 'error' is in the DB CHECK but nothing writes it; a failing feed stays
+		// active and is found via health:failing. Letting an agent set it would
+		// create a zombie state the list status filter cannot select.
+		const [row] = (await getTestDb()`
+			SELECT id FROM feeds WHERE organization_id = ${orgId} AND feed_key = 'h1'
+		`) as unknown as Array<{ id: number }>;
+		await expect(
+			manageFeeds(
+				{ action: "update_feed", feed_id: Number(row.id), status: "error" },
+				{} as Env,
+				ctx,
+			),
+		).rejects.toThrow();
+	});
 });

--- a/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-list-health-and-count.test.ts
@@ -130,6 +130,16 @@ describe("list_feeds health filter and true total", () => {
 		expect(none.has_more).toBe(false);
 	});
 
+	it("reports the true total (not 0) for an offset past the last page", async () => {
+		// 5 feeds match; an offset beyond them yields an empty page. total must
+		// still be the whole-filter count via the overshoot fallback, not 0 read
+		// off the empty page's window function.
+		const overshoot = await list({ limit: 2, offset: 10 });
+		expect(overshoot.feeds).toHaveLength(0);
+		expect(overshoot.total).toBe(5);
+		expect(overshoot.has_more).toBe(false);
+	});
+
 	it("rejects update_feed status:'error' — a runtime state, not a settable one", async () => {
 		// 'error' is in the DB CHECK but nothing writes it; a failing feed stays
 		// active and is found via health:failing. Letting an agent set it would

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -807,10 +807,11 @@ export default async (_ctx, client) => {
 		access: "external",
 	},
 	"feeds.list": {
-		summary: "List data-sync feeds.",
+		summary:
+			"List data-sync feeds. `status` filters by lifecycle (active|paused); `health` filters by runtime health independent of status ('failing' = last sync failed or consecutive failures, 'healthy' = otherwise) — use it to find active-but-failing feeds the status filter cannot surface. Result carries `total` and `has_more`.",
 		access: "read",
 		signature:
-			"feeds.list(input?: { connection_id?: number; status?: string; limit?: number; offset?: number }): Promise<unknown>",
+			"feeds.list(input?: { connection_id?: number; status?: 'active' | 'paused'; health?: 'healthy' | 'failing'; feed_ids?: number[]; entity_id?: number; limit?: number; offset?: number }): Promise<unknown>",
 	},
 	"feeds.get": {
 		summary:

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -99,8 +99,12 @@ async function handleListFeeds(
   // `SELECT COUNT(*) FROM current_event_records` per row — O(N feeds) ×
   // an anti-join over the entire events table — ~880ms per feed on a busy
   // connection. Batching collapses it to one scan.
+  // COUNT(*) OVER() runs across the whole filtered set BEFORE LIMIT/OFFSET, so
+  // `filtered_total` is the true match count on every page — not the page
+  // length (the previous `rows.length` reported `total: 50` for a 71-feed org
+  // and made every failing feed past page 1 invisible).
   let pageQuery = sql`
-    SELECT f.*
+    SELECT f.*, COUNT(*) OVER()::int AS filtered_total
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
     WHERE f.organization_id = ${organizationId} AND c.deleted_at IS NULL AND f.deleted_at IS NULL
@@ -116,6 +120,15 @@ async function handleListFeeds(
   }
   if (args.status) {
     pageQuery = sql`${pageQuery} AND f.status = ${args.status}`;
+  }
+  // Runtime health, independent of lifecycle status: a feed keeps `status =
+  // 'active'` while its syncs fail (until it crosses the auto-pause threshold),
+  // so `status` alone can never surface active-but-failing feeds. 'failing' =
+  // the last sync failed OR at least one consecutive failure is recorded.
+  if (args.health === 'failing') {
+    pageQuery = sql`${pageQuery} AND (f.last_sync_status = 'failed' OR COALESCE(f.consecutive_failures, 0) > 0)`;
+  } else if (args.health === 'healthy') {
+    pageQuery = sql`${pageQuery} AND f.last_sync_status IS DISTINCT FROM 'failed' AND COALESCE(f.consecutive_failures, 0) = 0`;
   }
   if (args.feed_ids?.length) {
     pageQuery = sql`${pageQuery} AND f.id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
@@ -192,8 +205,21 @@ async function handleListFeeds(
     ORDER BY p.created_at DESC
   `;
 
-  const rows = await query;
-  return { action: 'list_feeds', feeds: rows, total: rows.length, limit, offset };
+  const rows = (await query) as Array<Record<string, unknown>>;
+  // COUNT(*) OVER() is constant across the page; 0 when the page is empty.
+  const total =
+    rows.length > 0 ? Number(rows[0].filtered_total ?? rows.length) : 0;
+  // Strip the window-count helper column from each feed row — it is metadata
+  // about the result set, not a feed field.
+  const feeds = rows.map(({ filtered_total: _filtered_total, ...feed }) => feed);
+  return {
+    action: 'list_feeds',
+    feeds,
+    total,
+    has_more: offset + feeds.length < total,
+    limit,
+    offset,
+  };
 }
 
 async function handleReadFeed(

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -99,42 +99,47 @@ async function handleListFeeds(
   // `SELECT COUNT(*) FROM current_event_records` per row — O(N feeds) ×
   // an anti-join over the entire events table — ~880ms per feed on a busy
   // connection. Batching collapses it to one scan.
-  // COUNT(*) OVER() runs across the whole filtered set BEFORE LIMIT/OFFSET, so
-  // `filtered_total` is the true match count on every page — not the page
-  // length (the previous `rows.length` reported `total: 50` for a 71-feed org
-  // and made every failing feed past page 1 invisible).
-  let pageQuery = sql`
-    SELECT f.*, COUNT(*) OVER()::int AS filtered_total
-    FROM feeds f
-    JOIN connections c ON c.id = f.connection_id
-    WHERE f.organization_id = ${organizationId} AND c.deleted_at IS NULL AND f.deleted_at IS NULL
-  `;
-
+  // Filter predicates built ONCE and shared between the page query and the
+  // overshoot fallback count, so the two can never diverge. `where` starts with
+  // a TRUE seed so every real condition appends uniformly with AND.
+  let where = sql`f.organization_id = ${organizationId} AND c.deleted_at IS NULL AND f.deleted_at IS NULL`;
   if (args.connection_id) {
-    pageQuery = sql`${pageQuery} AND f.connection_id = ${args.connection_id}`;
+    where = sql`${where} AND f.connection_id = ${args.connection_id}`;
   }
   if (args.entity_id) {
-    pageQuery = sql`${pageQuery} AND ${sql.unsafe(
+    where = sql`${where} AND ${sql.unsafe(
       feedLinkedToBusinessEntitySql(String(args.entity_id), 'f', 'c', 'f.organization_id'),
     )}`;
   }
   if (args.status) {
-    pageQuery = sql`${pageQuery} AND f.status = ${args.status}`;
+    where = sql`${where} AND f.status = ${args.status}`;
   }
   // Runtime health, independent of lifecycle status: a feed keeps `status =
   // 'active'` while its syncs fail (until it crosses the auto-pause threshold),
   // so `status` alone can never surface active-but-failing feeds. 'failing' =
   // the last sync failed OR at least one consecutive failure is recorded.
   if (args.health === 'failing') {
-    pageQuery = sql`${pageQuery} AND (f.last_sync_status = 'failed' OR COALESCE(f.consecutive_failures, 0) > 0)`;
+    where = sql`${where} AND (f.last_sync_status = 'failed' OR COALESCE(f.consecutive_failures, 0) > 0)`;
   } else if (args.health === 'healthy') {
-    pageQuery = sql`${pageQuery} AND f.last_sync_status IS DISTINCT FROM 'failed' AND COALESCE(f.consecutive_failures, 0) = 0`;
+    where = sql`${where} AND f.last_sync_status IS DISTINCT FROM 'failed' AND COALESCE(f.consecutive_failures, 0) = 0`;
   }
   if (args.feed_ids?.length) {
-    pageQuery = sql`${pageQuery} AND f.id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
+    where = sql`${where} AND f.id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
   }
 
-  pageQuery = sql`${pageQuery} ORDER BY f.created_at DESC LIMIT ${limit} OFFSET ${offset}`;
+  // COUNT(*) OVER() runs across the whole filtered set BEFORE LIMIT/OFFSET, so
+  // `filtered_total` is the true match count on every non-empty page — not the
+  // page length (the previous `rows.length` reported `total: 50` for a 71-feed
+  // org and made every failing feed past page 1 invisible). It is 0 on an empty
+  // page (offset past the last row); the overshoot fallback below recovers the
+  // true count there.
+  const pageQuery = sql`
+    SELECT f.*, COUNT(*) OVER()::int AS filtered_total
+    FROM feeds f
+    JOIN connections c ON c.id = f.connection_id
+    WHERE ${where}
+    ORDER BY f.created_at DESC LIMIT ${limit} OFFSET ${offset}
+  `;
 
   const query = sql`
     WITH page AS MATERIALIZED (
@@ -206,9 +211,23 @@ async function handleListFeeds(
   `;
 
   const rows = (await query) as Array<Record<string, unknown>>;
-  // COUNT(*) OVER() is constant across the page; 0 when the page is empty.
-  const total =
-    rows.length > 0 ? Number(rows[0].filtered_total ?? rows.length) : 0;
+  // COUNT(*) OVER() is constant across the page. On a non-empty page it is the
+  // true whole-filter count. On an empty page (offset past the last row) there
+  // is no row to read it from, so recover the true count with a bare COUNT over
+  // the SAME shared `where` — one extra query only on the rare overshoot path,
+  // keeping `total` truthful for page-jumps rather than reporting 0.
+  let total: number;
+  if (rows.length > 0) {
+    total = Number(rows[0].filtered_total ?? rows.length);
+  } else {
+    const [countRow] = (await sql`
+      SELECT COUNT(*)::int AS total
+      FROM feeds f
+      JOIN connections c ON c.id = f.connection_id
+      WHERE ${where}
+    `) as Array<{ total: number }>;
+    total = Number(countRow?.total ?? 0);
+  }
   // Strip the window-count helper column from each feed row — it is metadata
   // about the result set, not a feed field.
   const feeds = rows.map(({ filtered_total: _filtered_total, ...feed }) => feed);


### PR DESCRIPTION
list_feeds returned total=rows.length (the page length), so a 71-feed org reported total:50 and every feed past page 1 was invisible. total is now COUNT(*) OVER() across the whole filtered set, with a has_more flag.

A feed keeps status='active' while its syncs fail (until it crosses the auto-pause threshold), so the status filter could never surface an active-but-failing feed. Adds a health filter (failing|healthy) matching on last_sync_status/consecutive_failures, and tightens the status filter/update enums to their real values.

Covered by feeds-list-health-and-count.test.ts (red→green; 28 existing feed tests still pass).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health-based feed filtering for `healthy` and `failing` feeds.
  * Added accurate totals across all matching feeds, independent of pagination.
  * Added a `has_more` indicator to show when more results are available.
  * Clarified supported feed status values when listing/updating feeds (`active`/`paused` only).

* **Bug Fixes**
  * Fixed feed listing totals to reflect the full filtered set (not just the current page).
  * Improved validation to prevent setting feed status to `error`, and tightened response shape so internal query details aren’t exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->