### PR TITLE
feat(catalog): detail=summary|full projection for list_installed

### DIFF
--- a/packages/core/src/contracts/tools/manage-catalog.ts
+++ b/packages/core/src/contracts/tools/manage-catalog.ts
@@ -39,6 +39,12 @@ export const ListInstalledAction = Type.Object({
         "Merge global catalog entries for connectors (org) or skills (agent).",
     })
   ),
+  detail: Type.Optional(
+    Type.Union([Type.Literal("summary"), Type.Literal("full")], {
+      description:
+        "Response verbosity. 'summary' (default) returns identity + capability flags only. 'full' additionally inlines each connector's auth/feeds/actions/options schemas — large (100KB+ for a full org); request it only when you actually need the schemas.",
+    })
+  ),
 });
 
 export const ManageCatalogSchema = Type.Union([

--- a/packages/server/src/__tests__/integration/catalog-list-installed-detail.test.ts
+++ b/packages/server/src/__tests__/integration/catalog-list-installed-detail.test.ts
@@ -1,0 +1,92 @@
+/**
+ * list_installed must default to a compact projection.
+ *
+ * The connector projection inlined every connector's auth/feeds/actions/options
+ * schema unconditionally — 100KB+ for a full org when a caller only wanted to
+ * know what is installed. `detail: 'summary'` (the new default) omits those
+ * blobs; `detail: 'full'` restores them.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { listOrgInstalled } from "../../catalog/installed";
+import type { ToolContext } from "../../tools/registry";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestConnectorDefinition,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
+
+const CONNECTOR_KEY = "demo.catalog.detail";
+
+describe("list_installed detail projection", () => {
+	let orgId: string;
+	let ctx: ToolContext;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, ctx: ownerCtx } = await seedOwnerContext({
+			orgName: "Catalog Detail Org",
+		});
+		orgId = org.id;
+		ctx = ownerCtx;
+
+		await createTestConnectorDefinition({
+			key: CONNECTOR_KEY,
+			name: "Detail Demo",
+			organization_id: orgId,
+			auth_schema: { methods: [{ type: "oauth", provider: "test" }] },
+		});
+		const sql = getTestDb();
+		await sql`
+			UPDATE connector_definitions
+			SET feeds_schema = ${sql.json({ events: { key: "events" } })},
+			    actions_schema = ${sql.json({ do_it: { key: "do_it", name: "Do it" } })},
+			    options_schema = ${sql.json({ type: "object" })}
+			WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+		`;
+	});
+
+	function connectorDetail(
+		installed: Awaited<ReturnType<typeof listOrgInstalled>>,
+	): Record<string, unknown> {
+		const items = (installed.connectors?.items ?? []) as Array<{
+			id: string;
+			detail: Record<string, unknown>;
+		}>;
+		const item = items.find((i) => i.id === CONNECTOR_KEY);
+		if (!item) throw new Error("connector not in installed list");
+		return item.detail;
+	}
+
+	const SCHEMA_KEYS = [
+		"auth_schema",
+		"feeds_schema",
+		"actions_schema",
+		"options_schema",
+	];
+
+	it("summary (default) omits the schema blobs but keeps identity + capability flags", async () => {
+		const installed = await listOrgInstalled(orgId, ["connectors"], ctx);
+		const detail = connectorDetail(installed);
+		for (const key of SCHEMA_KEYS) {
+			expect(detail).not.toHaveProperty(key);
+		}
+		// capability flags survive
+		expect(detail).toHaveProperty("has_operations");
+		expect(detail).toHaveProperty("version");
+		expect(detail).toHaveProperty("source_uri");
+	});
+
+	it("detail: 'full' inlines the schema blobs", async () => {
+		const installed = await listOrgInstalled(orgId, ["connectors"], ctx, {
+			detail: "full",
+		});
+		const detail = connectorDetail(installed);
+		expect(detail).toHaveProperty("auth_schema");
+		expect(detail).toHaveProperty("feeds_schema");
+		expect(detail).toHaveProperty("actions_schema");
+		expect(detail).toHaveProperty("options_schema");
+	});
+});

--- a/packages/server/src/catalog/installed.ts
+++ b/packages/server/src/catalog/installed.ts
@@ -27,6 +27,13 @@ const configStore = createPostgresAgentConfigStore();
 
 export type ListInstalledOptions = {
 	includeCatalog?: boolean;
+	/**
+	 * 'summary' (default) omits the large per-connector auth/feeds/actions/
+	 * options schema blobs; 'full' inlines them. The summary keeps the response
+	 * compact for the common "what's installed / is it capable" query — the
+	 * schemas alone are 100KB+ for a full org.
+	 */
+	detail?: "summary" | "full";
 };
 
 export async function listOrgInstalled(
@@ -47,6 +54,7 @@ export async function listOrgInstalled(
 			organizationId,
 			rows.map((row) => row.key)
 		);
+		const full = options.detail === "full";
 		const installedItems = rows.map((row) => {
 			const operationsSummary = summaries.get(row.key) ?? {
 				...EMPTY_SUMMARY,
@@ -59,11 +67,18 @@ export async function listOrgInstalled(
 					description: row.description,
 					status: row.status,
 					login_enabled: Boolean(row.login_enabled),
-					auth_schema: row.auth_schema,
-					feeds_schema: row.feeds_schema,
-					actions_schema: row.actions_schema,
-					behavior_events: row.behavior_events ?? undefined,
-					options_schema: row.options_schema,
+					// The four schema blobs are the bulk of the payload (100KB+ for a
+					// full org). Inline them only for detail: 'full'; the default
+					// summary keeps identity + capability flags.
+					...(full
+						? {
+								auth_schema: row.auth_schema,
+								feeds_schema: row.feeds_schema,
+								actions_schema: row.actions_schema,
+								behavior_events: row.behavior_events ?? undefined,
+								options_schema: row.options_schema,
+							}
+						: {}),
 					favicon_domain: row.favicon_domain,
 					required_capability: row.required_capability,
 					runtime: row.runtime,

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -623,8 +623,13 @@ export default async (_ctx, client) => {
 		example: "await client.catalog.listCatalog({ kinds: ['connectors'] });",
 	},
 	"catalog.listInstalled": {
-		summary: "List installed org or agent resources.",
+		summary:
+			"List installed resources. Org kinds: 'connectors', 'behaviors'. Agent kinds (require agent_id): 'skills', 'providers', 'guardrails', 'channels'. Defaults to org connectors. `detail` defaults to 'summary' (compact); pass 'full' to inline connector schemas.",
 		access: "read",
+		signature:
+			"catalog.listInstalled(input?: { kinds?: string[]; agent_id?: string; include_catalog?: boolean; detail?: 'summary' | 'full' }): Promise<unknown>",
+		example:
+			"await client.catalog.listInstalled({ kinds: ['connectors'], detail: 'summary' });",
 	},
 	"connections.get": {
 		summary: "Get a connection by id.",

--- a/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
+++ b/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
@@ -61,7 +61,7 @@ describe("manage_catalog list_installed", () => {
 				memberRole: "owner",
 				isAuthenticated: true,
 			}),
-			{ includeCatalog: false }
+			{ includeCatalog: false, detail: "summary" }
 		);
 		expect(installed.listAgentInstalled).not.toHaveBeenCalled();
 		expect(result).toEqual({
@@ -85,7 +85,33 @@ describe("manage_catalog list_installed", () => {
 			"org-1",
 			["connectors"],
 			expect.any(Object),
-			{ includeCatalog: true }
+			{ includeCatalog: true, detail: "summary" }
+		);
+	});
+
+	it("defaults detail to summary and forwards an explicit detail: full", async () => {
+		await manageCatalog(
+			{ action: "list_installed", kinds: ["connectors"] },
+			{} as never,
+			ctx
+		);
+		expect(installed.listOrgInstalled).toHaveBeenLastCalledWith(
+			"org-1",
+			["connectors"],
+			expect.any(Object),
+			{ includeCatalog: false, detail: "summary" }
+		);
+
+		await manageCatalog(
+			{ action: "list_installed", kinds: ["connectors"], detail: "full" },
+			{} as never,
+			ctx
+		);
+		expect(installed.listOrgInstalled).toHaveBeenLastCalledWith(
+			"org-1",
+			["connectors"],
+			expect.any(Object),
+			{ includeCatalog: false, detail: "full" }
 		);
 	});
 });

--- a/packages/server/src/tools/admin/manage_catalog.ts
+++ b/packages/server/src/tools/admin/manage_catalog.ts
@@ -68,7 +68,10 @@ async function handleListInstalled(
 
 	const installed: Record<string, unknown> = {};
 
-	const listOptions = { includeCatalog: Boolean(args.include_catalog) };
+	const listOptions = {
+		includeCatalog: Boolean(args.include_catalog),
+		detail: args.detail ?? "summary",
+	};
 
 	if (resolvedOrgKinds.length > 0) {
 		Object.assign(


### PR DESCRIPTION
catalog.listInstalled inlined every connector's auth/feeds/actions/options schema unconditionally (100KB+ for a full org) when callers usually only need to know what's installed. Adds a detail param defaulting to 'summary' (omits the schema blobs, keeps identity + capability flags); 'full' restores them. Documents the full signature in search_sdk method metadata.

Covered by catalog-list-installed-detail.test.ts + manage_catalog forwarding tests (red→green).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->