### PR TITLE
fix(behaviors): failed runs degrade health; fix update doc + vocab leak

### DIFF
--- a/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
@@ -1,10 +1,9 @@
 /**
- * Behavior scheduling-health surfacing (item 3, #2033).
+ * Behavior health surfacing (item 3, #2033).
  *
  * 3.1: manage_behaviors `list` returns a computed `health` field —
- *   `degraded` for an ACTIVE behavior whose next_run_at is overdue past the
- *   missed-firing margin (a behavior that has silently stopped firing), and
- *   `healthy` for a behavior scheduled in the future.
+ *   `degraded` for an active behavior that missed a firing, has a stale pending
+ *   run, or whose latest run failed/timed out; `healthy` otherwise.
  *
  * 3.2: getSchedulerHealth (the /health/scheduler alarm path) surfaces overdue
  *   active behaviors and stuck-pending behavior runs in `issues[]` — previously
@@ -184,8 +183,8 @@ describe("behavior health surfacing (#2033)", () => {
       (b) => String((b as { behavior_id?: unknown }).behavior_id) === String(behaviorId),
     ) as Record<string, unknown> | undefined;
     expect(row).toBeDefined();
-    expect(row).toHaveProperty("behavior_group_id");
-    expect(row).toHaveProperty("source_behavior_id");
+    expect(row?.behavior_group_id).toBe(String(behaviorId));
+    expect(row?.source_behavior_id).toBeNull();
     expect(row).not.toHaveProperty("watcher_group_id");
     expect(row).not.toHaveProperty("source_watcher_id");
   });

--- a/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
@@ -145,6 +145,51 @@ describe("behavior health surfacing (#2033)", () => {
     expect(row?.health).toBe("healthy");
   });
 
+  it("3.1 (integration): a failed latest run degrades an on-schedule behavior", async () => {
+    const { behaviorId, ctx } = await createScheduledBehavior();
+    const sql = getTestDb();
+    // On schedule (future) so the ONLY unhealthy signal is the failed run —
+    // proving health reflects the run outcome, not just the scheduler cursor.
+    await sql`
+      UPDATE watchers
+      SET next_run_at = current_timestamp + interval '5 minutes'
+      WHERE id = ${behaviorId}
+    `;
+    await sql`
+      INSERT INTO runs
+        (organization_id, run_type, watcher_id, status, approval_status,
+         error_message, created_at, completed_at)
+      VALUES
+        (${ctx.organizationId}, 'behavior', ${behaviorId}, 'failed', 'auto',
+         'No model is configured', current_timestamp - interval '2 minutes',
+         current_timestamp - interval '1 minute')
+    `;
+
+    const result = await manageBehaviors({ action: "list" }, {} as Env, ctx);
+    if (result.action !== "list") throw new Error("expected list result");
+    const row = result.behaviors.find(
+      (b) => String((b as { behavior_id?: unknown }).behavior_id) === String(behaviorId),
+    ) as
+      | { health?: string; last_scheduling_error?: string | null }
+      | undefined;
+    expect(row?.health).toBe("degraded");
+    expect(row?.last_scheduling_error).toBe("No model is configured");
+  });
+
+  it("3.3: list emits behavior_* lineage keys, never the internal watcher_* names", async () => {
+    const { behaviorId, ctx } = await createScheduledBehavior();
+    const result = await manageBehaviors({ action: "list" }, {} as Env, ctx);
+    if (result.action !== "list") throw new Error("expected list result");
+    const row = result.behaviors.find(
+      (b) => String((b as { behavior_id?: unknown }).behavior_id) === String(behaviorId),
+    ) as Record<string, unknown> | undefined;
+    expect(row).toBeDefined();
+    expect(row).toHaveProperty("behavior_group_id");
+    expect(row).toHaveProperty("source_behavior_id");
+    expect(row).not.toHaveProperty("watcher_group_id");
+    expect(row).not.toHaveProperty("source_watcher_id");
+  });
+
   it("3.2: getSchedulerHealth surfaces an overdue behavior in issues[]", async () => {
     const { behaviorId } = await createScheduledBehavior();
     const sql = getTestDb();

--- a/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
@@ -189,6 +189,43 @@ describe("behavior health surfacing (#2033)", () => {
     expect(row).not.toHaveProperty("source_watcher_id");
   });
 
+  it("3.4: legacy client.watchers.* in a run error is rewritten to client.behaviors.*", async () => {
+    const { behaviorId, ctx } = await createScheduledBehavior();
+    const sql = getTestDb();
+    await sql`
+      UPDATE watchers
+      SET next_run_at = current_timestamp + interval '5 minutes'
+      WHERE id = ${behaviorId}
+    `;
+    // An archived run error persisted with the pre-rename internal namespace.
+    await sql`
+      INSERT INTO runs
+        (organization_id, run_type, watcher_id, status, approval_status,
+         error_message, created_at, completed_at)
+      VALUES
+        (${ctx.organizationId}, 'behavior', ${behaviorId}, 'failed', 'auto',
+         'Agent never called client.watchers.completeWindow()',
+         current_timestamp - interval '2 minutes',
+         current_timestamp - interval '1 minute')
+    `;
+
+    const result = await manageBehaviors({ action: "list" }, {} as Env, ctx);
+    if (result.action !== "list") throw new Error("expected list result");
+    const row = result.behaviors.find(
+      (b) => String((b as { behavior_id?: unknown }).behavior_id) === String(behaviorId),
+    ) as
+      | { behavior_run_error?: string | null; last_scheduling_error?: string | null }
+      | undefined;
+    // Both the raw error field and the health-echoed error carry the public vocab.
+    expect(row?.behavior_run_error).toBe(
+      "Agent never called client.behaviors.completeWindow()",
+    );
+    expect(row?.last_scheduling_error).toBe(
+      "Agent never called client.behaviors.completeWindow()",
+    );
+    expect(JSON.stringify(row)).not.toContain("client.watchers.");
+  });
+
   it("3.2: getSchedulerHealth surfaces an overdue behavior in issues[]", async () => {
     const { behaviorId } = await createScheduledBehavior();
     const sql = getTestDb();

--- a/packages/server/src/__tests__/unit/behavior-health.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-health.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit coverage for computeBehaviorHealth.
+ *
+ * The gap this closes: health considered only the scheduler cursor (missed
+ * firing / stuck pending), so a behavior whose latest run FAILED still reported
+ * `healthy` — the exact "health:healthy beside a failed run" contradiction the
+ * audit found. A terminal failed/timeout latest run now degrades health.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { computeBehaviorHealth } from "../../watchers/behavior-health";
+
+const NOW = 1_700_000_000_000;
+
+describe("computeBehaviorHealth", () => {
+	it("degrades an active behavior whose latest run failed", () => {
+		const result = computeBehaviorHealth(
+			{
+				status: "active",
+				nextRunAt: new Date(NOW + 60_000).toISOString(), // on schedule
+				latestRunStatus: "failed",
+				latestRunError: "No model is configured",
+			},
+			NOW,
+		);
+		expect(result.health).toBe("degraded");
+		expect(result.last_scheduling_error).toBe("No model is configured");
+		expect(result.reasons.join(" ")).toContain("No model is configured");
+	});
+
+	it("degrades on a timeout latest run too", () => {
+		const result = computeBehaviorHealth(
+			{
+				status: "active",
+				nextRunAt: new Date(NOW + 60_000).toISOString(),
+				latestRunStatus: "timeout",
+			},
+			NOW,
+		);
+		expect(result.health).toBe("degraded");
+	});
+
+	it("stays healthy when the latest run succeeded and the schedule is current", () => {
+		const result = computeBehaviorHealth(
+			{
+				status: "active",
+				nextRunAt: new Date(NOW + 60_000).toISOString(),
+				latestRunStatus: "completed",
+			},
+			NOW,
+		);
+		expect(result.health).toBe("healthy");
+		expect(result.reasons).toHaveLength(0);
+	});
+
+	it("does not degrade a non-active behavior even with a failed run (archived is intentionally idle)", () => {
+		const result = computeBehaviorHealth(
+			{
+				status: "archived",
+				nextRunAt: new Date(NOW - 10_000_000).toISOString(),
+				latestRunStatus: "failed",
+				latestRunError: "old failure",
+			},
+			NOW,
+		);
+		expect(result.health).toBe("healthy");
+		// still echoes the error for context
+		expect(result.last_scheduling_error).toBe("old failure");
+	});
+
+	it("still degrades on a missed firing when the run did not fail (regression)", () => {
+		const result = computeBehaviorHealth(
+			{
+				status: "active",
+				nextRunAt: new Date(NOW - 60 * 60 * 1000).toISOString(), // 1h overdue
+				latestRunStatus: "completed",
+			},
+			NOW,
+		);
+		expect(result.health).toBe("degraded");
+		expect(result.reasons.join(" ")).toContain("missed firing");
+	});
+
+	it("does not false-degrade a failed cursor while a run is in flight", () => {
+		const result = computeBehaviorHealth(
+			{
+				status: "active",
+				nextRunAt: new Date(NOW - 60 * 60 * 1000).toISOString(),
+				latestRunStatus: "running",
+			},
+			NOW,
+		);
+		expect(result.health).toBe("healthy");
+	});
+});

--- a/packages/server/src/__tests__/unit/behavior-health.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-health.test.ts
@@ -1,12 +1,3 @@
-/**
- * Unit coverage for computeBehaviorHealth.
- *
- * The gap this closes: health considered only the scheduler cursor (missed
- * firing / stuck pending), so a behavior whose latest run FAILED still reported
- * `healthy` — the exact "health:healthy beside a failed run" contradiction the
- * audit found. A terminal failed/timeout latest run now degrades health.
- */
-
 import { describe, expect, it } from "bun:test";
 import { computeBehaviorHealth } from "../../watchers/behavior-health";
 
@@ -53,26 +44,23 @@ describe("computeBehaviorHealth", () => {
 		expect(result.reasons).toHaveLength(0);
 	});
 
-	it("does not degrade a non-active behavior even with a failed run (archived is intentionally idle)", () => {
+	it("does not degrade an archived behavior whose latest run failed", () => {
 		const result = computeBehaviorHealth(
 			{
 				status: "archived",
 				nextRunAt: new Date(NOW - 10_000_000).toISOString(),
 				latestRunStatus: "failed",
-				latestRunError: "old failure",
 			},
 			NOW,
 		);
 		expect(result.health).toBe("healthy");
-		// still echoes the error for context
-		expect(result.last_scheduling_error).toBe("old failure");
 	});
 
 	it("still degrades on a missed firing when the run did not fail (regression)", () => {
 		const result = computeBehaviorHealth(
 			{
 				status: "active",
-				nextRunAt: new Date(NOW - 60 * 60 * 1000).toISOString(), // 1h overdue
+				nextRunAt: new Date(NOW - 60 * 60 * 1000).toISOString(),
 				latestRunStatus: "completed",
 			},
 			NOW,
@@ -81,7 +69,7 @@ describe("computeBehaviorHealth", () => {
 		expect(result.reasons.join(" ")).toContain("missed firing");
 	});
 
-	it("does not false-degrade a failed cursor while a run is in flight", () => {
+	it("does not degrade an overdue schedule while a run is in flight", () => {
 		const result = computeBehaviorHealth(
 			{
 				status: "active",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -536,7 +536,7 @@ export default async (_ctx, client) => {
 	},
 	"behaviors.update": {
 		summary:
-			"Update runtime config only (triggers, agent, model, sources, status). Version-owned fields (name, prompt, schema) are immutable here — use createVersion for those.",
+			"Update runtime config only: triggers, agent_id, model_config, execution_config, scheduler_client_id, device_worker_id, agent_kind, notification_channel, notification_priority, min_cooldown_seconds, tags. Version-owned fields (name, description, prompt, sources) are immutable here — use createVersion. Status is not patchable here (a Behavior is retired via delete → archived).",
 		access: "admin",
 	},
 	"behaviors.createVersion": {

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -196,6 +196,17 @@ export async function handleList(
 
 		const { organization_id: _orgId, ...rest } = watcher;
 
+		// Old persisted run-error rows can carry the internal `client.watchers.*`
+		// namespace (the SDK alias was renamed watchers→behaviors; forward-path
+		// templates already emit `client.behaviors.*`, but archived error_message
+		// rows still hold the legacy string). Rewrite it at read time so the
+		// public projection never surfaces the internal vocabulary.
+		if (typeof (rest as Record<string, unknown>).behavior_run_error === "string") {
+			(rest as Record<string, unknown>).behavior_run_error = (
+				(rest as Record<string, unknown>).behavior_run_error as string
+			).replaceAll("client.watchers.", "client.behaviors.");
+		}
+
 		if (!args.include_details) {
 			delete (rest as Record<string, unknown>).prompt;
 			delete (rest as Record<string, unknown>).classifiers;
@@ -223,7 +234,12 @@ export async function handleList(
 			nextRunAt: watcher.next_run_at,
 			latestRunStatus: watcher.behavior_run_status,
 			latestRunCreatedAt: watcher.behavior_run_created_at,
-			latestRunError: watcher.behavior_run_error,
+			// Use the vocab-rewritten error so last_scheduling_error also carries the
+			// public `client.behaviors.*` namespace, not the legacy internal one.
+			latestRunError: (rest as Record<string, unknown>).behavior_run_error as
+				| string
+				| null
+				| undefined,
 		});
 
 		return {

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -194,7 +194,19 @@ export async function handleList(
 				? buildBehaviorUrl(orgSlug, watcher.agent_id, watcherId, baseUrl)
 				: undefined;
 
-		const { organization_id: _orgId, ...rest } = watcher;
+		// Rename internal lineage columns to the public `behavior_*` vocabulary so
+		// the response never leaks the legacy `watcher_*` names (the rest of this
+		// projection already emits behavior_id / behavior_run_*). These carry real
+		// lineage (the group a Behavior belongs to; the Behavior it was cloned
+		// from), so they are renamed rather than dropped.
+		const {
+			organization_id: _orgId,
+			watcher_group_id: behaviorGroupId,
+			source_watcher_id: sourceBehaviorId,
+			...rest
+		} = watcher;
+		(rest as Record<string, unknown>).behavior_group_id = behaviorGroupId ?? null;
+		(rest as Record<string, unknown>).source_behavior_id = sourceBehaviorId ?? null;
 
 		if (!args.include_details) {
 			delete (rest as Record<string, unknown>).prompt;

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -67,8 +67,8 @@ export async function handleList(
       i.notification_priority,
       i.min_cooldown_seconds,
       i.agent_kind,
-      i.watcher_group_id,
-      i.source_watcher_id,
+      i.watcher_group_id::text AS behavior_group_id,
+      i.source_watcher_id::text AS source_behavior_id,
       wr.id as behavior_run_id,
       wr.status as behavior_run_status,
       wr.error_message as behavior_run_error,
@@ -194,19 +194,7 @@ export async function handleList(
 				? buildBehaviorUrl(orgSlug, watcher.agent_id, watcherId, baseUrl)
 				: undefined;
 
-		// Rename internal lineage columns to the public `behavior_*` vocabulary so
-		// the response never leaks the legacy `watcher_*` names (the rest of this
-		// projection already emits behavior_id / behavior_run_*). These carry real
-		// lineage (the group a Behavior belongs to; the Behavior it was cloned
-		// from), so they are renamed rather than dropped.
-		const {
-			organization_id: _orgId,
-			watcher_group_id: behaviorGroupId,
-			source_watcher_id: sourceBehaviorId,
-			...rest
-		} = watcher;
-		(rest as Record<string, unknown>).behavior_group_id = behaviorGroupId ?? null;
-		(rest as Record<string, unknown>).source_behavior_id = sourceBehaviorId ?? null;
+		const { organization_id: _orgId, ...rest } = watcher;
 
 		if (!args.include_details) {
 			delete (rest as Record<string, unknown>).prompt;
@@ -228,7 +216,7 @@ export async function handleList(
 			);
 		}
 
-		// Computed scheduling health (item 3, #2033) — derived from the
+		// Computed health (item 3, #2033) — derived from the
 		// already-selected schedule/run columns, no extra query.
 		const behaviorHealth = computeBehaviorHealth({
 			status: watcher.status,

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -833,7 +833,7 @@ async function getBehaviorImpl(
     // Sources come from watcher row (or version if present)
     const watcherSources = parseWatcherSources(watcherRow.sources);
 
-    // Computed scheduling health (item 3, #2033) — pure derivation over the
+    // Computed health (item 3, #2033) — pure derivation over the
     // already-selected schedule/run columns; no extra query.
     const behaviorHealth = computeBehaviorHealth({
       status: watcherRow.status,

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -158,9 +158,9 @@ export const WatcherMetadataSchema = Type.Object({
   available_versions: Type.Optional(Type.Array(WatcherVersionInfoSchema)),
   reaction_script: Type.Optional(Type.String()),
   behavior_run: Type.Optional(WatcherRunSchema),
-  /** Computed scheduling health (item 3, #2033): `degraded` when an active
-   *  behavior has missed a firing (next_run_at overdue past the cron margin) or
-   *  its latest run is stuck pending past the stale interval; else `healthy`. */
+  /** Computed health (item 3, #2033): `degraded` when an active
+   *  behavior's latest run failed/timed out, it missed a firing, or its latest
+   *  run is stuck pending past the stale interval; else `healthy`. */
   health: Type.Optional(
     Type.Union([Type.Literal('healthy'), Type.Literal('degraded')])
   ),

--- a/packages/server/src/watchers/behavior-health.ts
+++ b/packages/server/src/watchers/behavior-health.ts
@@ -1,12 +1,12 @@
 /**
- * Computed scheduling-health derivation for behaviors (item 3, #2033).
+ * Computed health derivation for behaviors (item 3, #2033).
  *
  * The behavior reaper (watchers/automation.ts) already times out stuck pending
  * runs and self-heals `next_run_at`, but nothing SURFACED that a behavior was
  * unhealthy: get_behavior / list returned `next_run_at` / run status raw and
  * the caller had to eyeball it. This helper turns those already-selected fields
  * into a single `health` verdict + a `last_scheduling_error` so the API and UI
- * can flag a behavior that has silently stopped firing.
+ * can flag a behavior that stopped firing or whose latest run failed.
  *
  * Pure + input-only: every field it reads is already selected by both
  * get_behavior.ts and manage_behaviors/list.ts, so no migration and no extra
@@ -49,15 +49,7 @@ function pgIntervalToMs(literal: string): number {
 /** The latest run status transitions that mean "in flight" (not terminal). */
 const IN_FLIGHT_RUN_STATUSES = new Set(['claimed', 'running']);
 
-/**
- * Terminal latest-run statuses that mean the behavior's most recent execution
- * did not succeed. A behavior whose latest run ended in one of these is
- * degraded even when its scheduler cursor is fine — the automation ran and
- * broke (e.g. "No model is configured", context-window overflow), which is
- * exactly the state a caller needs surfaced. Previously health considered only
- * the scheduler cursor, so a behavior could report `healthy` alongside a
- * `failed` latest run (#2033 follow-up).
- */
+/** Terminal execution failures that degrade an active behavior. */
 const FAILED_RUN_STATUSES = new Set(['failed', 'timeout']);
 
 export interface BehaviorHealthInput {
@@ -89,7 +81,7 @@ function toMs(value: string | Date | null | undefined): number | null {
 }
 
 /**
- * Derive a behavior's scheduling health from already-selected fields.
+ * Derive a behavior's health from already-selected fields.
  *
  * `degraded` when the behavior is `active` AND any of:
  *   - its latest run ended in a terminal failure (`failed`/`timeout`) — the
@@ -109,17 +101,13 @@ export function computeBehaviorHealth(
   const reasons: string[] = [];
   const lastError = input.latestRunError ?? null;
 
-  // Only active behaviors have a scheduling obligation; archived/paused ones
-  // are healthy-by-definition (they're intentionally not firing).
+  // Archived behaviors are intentionally idle and therefore healthy.
   if (input.status !== 'active') {
     return { health: 'healthy', reasons, last_scheduling_error: lastError };
   }
 
   const runInFlight = IN_FLIGHT_RUN_STATUSES.has(input.latestRunStatus ?? '');
 
-  // Failed latest run: the behavior's most recent execution ended in a
-  // terminal failure. This is independent of the scheduler cursor — a behavior
-  // can be on-schedule yet its automation broke every time it fired.
   if (FAILED_RUN_STATUSES.has(input.latestRunStatus ?? '')) {
     reasons.push(
       lastError

--- a/packages/server/src/watchers/behavior-health.ts
+++ b/packages/server/src/watchers/behavior-health.ts
@@ -49,6 +49,17 @@ function pgIntervalToMs(literal: string): number {
 /** The latest run status transitions that mean "in flight" (not terminal). */
 const IN_FLIGHT_RUN_STATUSES = new Set(['claimed', 'running']);
 
+/**
+ * Terminal latest-run statuses that mean the behavior's most recent execution
+ * did not succeed. A behavior whose latest run ended in one of these is
+ * degraded even when its scheduler cursor is fine — the automation ran and
+ * broke (e.g. "No model is configured", context-window overflow), which is
+ * exactly the state a caller needs surfaced. Previously health considered only
+ * the scheduler cursor, so a behavior could report `healthy` alongside a
+ * `failed` latest run (#2033 follow-up).
+ */
+const FAILED_RUN_STATUSES = new Set(['failed', 'timeout']);
+
 export interface BehaviorHealthInput {
   /** Behavior `status` (only `active` behaviors can be degraded). */
   status: string | null | undefined;
@@ -80,7 +91,9 @@ function toMs(value: string | Date | null | undefined): number | null {
 /**
  * Derive a behavior's scheduling health from already-selected fields.
  *
- * `degraded` when the behavior is `active` AND either:
+ * `degraded` when the behavior is `active` AND any of:
+ *   - its latest run ended in a terminal failure (`failed`/`timeout`) — the
+ *     automation ran and broke, regardless of the scheduler cursor; or
  *   - its `next_run_at` is in the past by more than the missed-firing margin
  *     (a missed firing), UNLESS a run is currently in flight (claimed/running)
  *     — an active dispatch is healthy, we don't false-degrade mid-tick; or
@@ -103,6 +116,17 @@ export function computeBehaviorHealth(
   }
 
   const runInFlight = IN_FLIGHT_RUN_STATUSES.has(input.latestRunStatus ?? '');
+
+  // Failed latest run: the behavior's most recent execution ended in a
+  // terminal failure. This is independent of the scheduler cursor — a behavior
+  // can be on-schedule yet its automation broke every time it fired.
+  if (FAILED_RUN_STATUSES.has(input.latestRunStatus ?? '')) {
+    reasons.push(
+      lastError
+        ? `latest run ${input.latestRunStatus}: ${lastError}`
+        : `latest run ${input.latestRunStatus}`,
+    );
+  }
 
   // Missed firing: next_run_at is well in the past and nothing is dispatching.
   const nextRunMs = toMs(input.nextRunAt);


### PR DESCRIPTION
computeBehaviorHealth considered only the scheduler cursor (missed firing / stuck pending), so a Behavior whose latest run FAILED still reported health:healthy alongside a failed run. A terminal failed/timeout latest run now degrades health, with the run error as a reason.

Also corrects the behaviors.update doc (it claimed sources/status are patchable; sources is version-owned, status is set via delete→archived), and renames the leaked internal lineage columns watcher_group_id/source_watcher_id to behavior_group_id/source_behavior_id in the list projection.

Covered by behavior-health.test.ts (unit) + behavior-health-surfacing.test.ts (red→green).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->