### PR TITLE
fix(connections): device-aware connections.test + accurate result types

### DIFF
--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -744,10 +744,15 @@ export const ManageConnectionsResultSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("test"),
-    status: Type.String(),
+    status: Type.Union(
+      [Type.Literal("ok"), Type.Literal("warning"), Type.Literal("error")],
+      { description: "Test outcome: ok, warning, or error." }
+    ),
     message: Type.String(),
     has_token: Type.Optional(Type.Boolean()),
     has_refresh: Type.Optional(Type.Boolean()),
+    /** Present for device-bound connections: whether the paired device is online. */
+    device_online: Type.Optional(Type.Boolean()),
     expires_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     // Structured error taxonomy (lobu#2051 Item 2), present on error/warning results.
     error_code: Type.Optional(

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -751,7 +751,7 @@ export const ManageConnectionsResultSchema = Type.Union([
     message: Type.String(),
     has_token: Type.Optional(Type.Boolean()),
     has_refresh: Type.Optional(Type.Boolean()),
-    /** Present for device-bound connections: whether the paired device is online. */
+    /** Present when an auth-free connection is pinned to a device. */
     device_online: Type.Optional(Type.Boolean()),
     expires_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     // Structured error taxonomy (lobu#2051 Item 2), present on error/warning results.

--- a/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
+++ b/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
@@ -1,11 +1,12 @@
 /**
- * connections.test must report device readiness for device-bound connections.
+ * connections.test must report device availability for auth-free, device-bound
+ * connections.
  *
- * A device-bound connection (e.g. apple.computer_use, a browser device worker)
- * has no auth profile — it runs on a paired device. The test handler used to
- * fall through to "No auth profile configured" for these, hiding the real
- * signal (is the device online?). It now reports device readiness: ok when the
- * device is online, a retryable warning when it is offline.
+ * An auth-free, device-bound connection such as apple.computer_use has no auth
+ * profile because it runs on a paired device. The test handler used to fall
+ * through to "No auth profile configured" for these, hiding the real signal
+ * (is the device online?). It now reports device availability: ok when the device
+ * is online, a retryable warning when it is offline.
  */
 
 import { beforeAll, describe, expect, it } from "vitest";
@@ -22,7 +23,7 @@ import {
 
 const CONNECTOR_KEY = "apple.computer_use";
 
-describe("connections.test device readiness", () => {
+describe("connections.test device availability", () => {
 	let orgId: string;
 	let userId: string;
 	let ctx: ToolContext;
@@ -30,17 +31,22 @@ describe("connections.test device readiness", () => {
 	beforeAll(async () => {
 		await cleanupTestDatabase();
 		await initWorkspaceProvider();
-		const { org, user, ctx: ownerCtx } = await seedOwnerContext({
+		const {
+			org,
+			user,
+			ctx: ownerCtx,
+		} = await seedOwnerContext({
 			orgName: "Device Test Org",
 		});
 		orgId = org.id;
 		userId = user.id;
 		ctx = ownerCtx;
 
-		// The real apple.computer_use connector declares `auth: none`, so an active
-		// connector_definition with methods:[{type:'none'}] must exist for this test
-		// to reproduce production: without it, the no-auth branch never fires and the
-		// device branch is falsely reachable regardless of ordering.
+		// The real apple.computer_use connector declares the `none` auth method, so
+		// an active connector_definition with `auth_schema.methods: [{ type: "none" }]`
+		// must exist for this test to reproduce production: without it, the no-auth
+		// branch never fires and the device branch is falsely reachable regardless
+		// of ordering.
 		await createTestConnectorDefinition({
 			key: CONNECTOR_KEY,
 			name: "Apple Computer Use",
@@ -71,7 +77,7 @@ describe("connections.test device readiness", () => {
 			created_by: userId,
 			createDefaultFeed: false,
 		});
-		// Attach the device; device-bound connections carry no auth profile.
+		// Attach the device; this auth-free connection carries no auth profile.
 		await sql`UPDATE connections SET device_worker_id = ${dw.id} WHERE id = ${conn.id}`;
 		return conn.id;
 	}

--- a/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
+++ b/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
@@ -14,7 +14,11 @@ import { manageConnections } from "../../tools/admin/manage_connections";
 import type { ToolContext } from "../../tools/registry";
 import { initWorkspaceProvider } from "../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
-import { createTestConnection, seedOwnerContext } from "../setup/test-fixtures";
+import {
+	createTestConnection,
+	createTestConnectorDefinition,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
 
 const CONNECTOR_KEY = "apple.computer_use";
 
@@ -32,6 +36,17 @@ describe("connections.test device readiness", () => {
 		orgId = org.id;
 		userId = user.id;
 		ctx = ownerCtx;
+
+		// The real apple.computer_use connector declares `auth: none`, so an active
+		// connector_definition with methods:[{type:'none'}] must exist for this test
+		// to reproduce production: without it, the no-auth branch never fires and the
+		// device branch is falsely reachable regardless of ordering.
+		await createTestConnectorDefinition({
+			key: CONNECTOR_KEY,
+			name: "Apple Computer Use",
+			organization_id: orgId,
+			auth_schema: { methods: [{ type: "none" }] },
+		});
 	});
 
 	async function seedDeviceConnection(online: boolean): Promise<number> {

--- a/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
+++ b/packages/server/src/__tests__/integration/connection-test-device-aware.test.ts
@@ -1,0 +1,89 @@
+/**
+ * connections.test must report device readiness for device-bound connections.
+ *
+ * A device-bound connection (e.g. apple.computer_use, a browser device worker)
+ * has no auth profile — it runs on a paired device. The test handler used to
+ * fall through to "No auth profile configured" for these, hiding the real
+ * signal (is the device online?). It now reports device readiness: ok when the
+ * device is online, a retryable warning when it is offline.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageConnections } from "../../tools/admin/manage_connections";
+import type { ToolContext } from "../../tools/registry";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import { createTestConnection, seedOwnerContext } from "../setup/test-fixtures";
+
+const CONNECTOR_KEY = "apple.computer_use";
+
+describe("connections.test device readiness", () => {
+	let orgId: string;
+	let userId: string;
+	let ctx: ToolContext;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, user, ctx: ownerCtx } = await seedOwnerContext({
+			orgName: "Device Test Org",
+		});
+		orgId = org.id;
+		userId = user.id;
+		ctx = ownerCtx;
+	});
+
+	async function seedDeviceConnection(online: boolean): Promise<number> {
+		const sql = getTestDb();
+		const lastSeen = online
+			? new Date().toISOString()
+			: new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago = offline
+		const [dw] = (await sql`
+			INSERT INTO device_workers (
+				user_id, worker_id, platform, capabilities, label, organization_id, last_seen_at
+			) VALUES (
+				${userId}, ${`wk_${online ? "on" : "off"}_${Date.now()}`}, 'macos',
+				${sql.json([])}, ${online ? "My Mac (online)" : "My Mac (offline)"},
+				${orgId}, ${lastSeen}
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: string }>;
+
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: CONNECTOR_KEY,
+			created_by: userId,
+			createDefaultFeed: false,
+		});
+		// Attach the device; device-bound connections carry no auth profile.
+		await sql`UPDATE connections SET device_worker_id = ${dw.id} WHERE id = ${conn.id}`;
+		return conn.id;
+	}
+
+	async function test(connectionId: number): Promise<Record<string, unknown>> {
+		return (await manageConnections(
+			{ action: "test", connection_id: connectionId },
+			{} as Env,
+			ctx,
+		)) as Record<string, unknown>;
+	}
+
+	it("reports ok for an online device instead of 'No auth profile configured'", async () => {
+		const id = await seedDeviceConnection(true);
+		const result = await test(id);
+		expect(result.status).toBe("ok");
+		expect(result.device_online).toBe(true);
+		expect(String(result.message)).not.toContain("No auth profile");
+		expect(String(result.message)).toMatch(/online/i);
+	});
+
+	it("reports a retryable warning for an offline device", async () => {
+		const id = await seedDeviceConnection(false);
+		const result = await test(id);
+		expect(result.status).toBe("warning");
+		expect(result.device_online).toBe(false);
+		expect(result.retryable).toBe(true);
+		expect(String(result.message)).toMatch(/offline/i);
+	});
+});

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -689,7 +689,7 @@ export default async (_ctx, client) => {
 	},
 	"connections.test": {
 		summary:
-			"Test a connection's readiness: OAuth token validity/expiry, env/app-auth presence, browser-session cookies, or (device-bound connectors) whether the paired device is online. Only the browser-session CDP path makes an outbound network probe; the rest are metadata checks.",
+			"Inspect a connection's authentication or device availability: OAuth token validity/expiry, env/app-auth presence, browser-session cookies, or (for an auth-free connection pinned to a device) whether the paired device is online. Only the browser-session CDP path makes an outbound network probe; the rest are metadata checks.",
 		access: "external",
 		signature:
 			"connections.test(connection_id: number): Promise<unknown> // or connections.test({ connection_id })",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -688,7 +688,8 @@ export default async (_ctx, client) => {
 		example: "await client.connections.reauthenticate(42);",
 	},
 	"connections.test": {
-		summary: "Test connection credentials (sends an external probe).",
+		summary:
+			"Test a connection's readiness: OAuth token validity/expiry, env/app-auth presence, browser-session cookies, or (device-bound connectors) whether the paired device is online. Only the browser-session CDP path makes an outbound network probe; the rest are metadata checks.",
 		access: "external",
 		signature:
 			"connections.test(connection_id: number): Promise<unknown> // or connections.test({ connection_id })",

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -171,8 +171,12 @@ export async function handleTest(
            c.auth_profile_id,
            c.app_auth_profile_id,
            c.status,
+           c.device_worker_id,
+           dw.label AS device_label,
+           COALESCE(dw.last_seen_at > now() - interval '20 minutes', false) AS device_online,
            cd.auth_schema
     FROM connections c
+    LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
     LEFT JOIN LATERAL (
       SELECT auth_schema
       FROM connector_definitions
@@ -322,6 +326,31 @@ export async function handleTest(
       status: 'ok',
       message: 'Connector requires no auth profile',
     };
+  }
+
+  // Device-bound connections (e.g. apple.computer_use, browser device workers)
+  // run on a paired device, not an auth profile — so a null profile is expected.
+  // Report the device's readiness (the actual execution blocker) instead of the
+  // misleading "No auth profile configured" warning. The 20-minute freshness
+  // window mirrors the readiness rule used across operations/feeds listings.
+  if (conn.device_worker_id) {
+    const deviceName = conn.device_label || 'paired device';
+    return conn.device_online
+      ? {
+          action: 'test',
+          status: 'ok',
+          message: `Device '${deviceName}' is online and ready`,
+          device_online: true,
+        }
+      : {
+          action: 'test',
+          status: 'warning',
+          // Offline is transient — the device may reconnect — so this is
+          // retryable, mirroring the CDP-unreachable branch above.
+          message: `Device '${deviceName}' is offline — bring it online to execute`,
+          device_online: false,
+          ...testErrorFields('NETWORK'),
+        };
   }
 
   return {

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -316,22 +316,22 @@ export async function handleTest(
     };
   }
 
-  // Device-bound connections (e.g. apple.computer_use, browser device workers)
-  // run on a paired device, not an auth profile — so a null profile is expected.
-  // Report the device's readiness (the actual execution blocker) instead of the
-  // misleading "No auth profile configured" warning. The 20-minute freshness
-  // window mirrors the readiness rule used across operations/feeds listings.
+  // Auth-free device connections such as apple.computer_use run on a paired
+  // device, not an auth profile — so a null profile is expected. Report whether
+  // the paired device is online instead of the misleading "No auth profile
+  // configured" warning. The 20-minute freshness window mirrors the readiness
+  // rule used across operations/feeds listings.
   //
   // This must precede the no-auth check: device connectors like apple.computer_use
-  // declare `authSchema.methods: [{ type: 'none' }]`, so testing no-auth first would
-  // mask an offline device behind a bogus "requires no auth profile" ok.
+  // declare `auth_schema.methods: [{ type: 'none' }]`, so testing no-auth first would
+  // mask an offline device behind a generic "requires no auth profile" ok.
   if (conn.device_worker_id) {
     const deviceName = conn.device_label || 'paired device';
     return conn.device_online
       ? {
           action: 'test',
           status: 'ok',
-          message: `Device '${deviceName}' is online and ready`,
+          message: `Device '${deviceName}' is online`,
           device_online: true,
         }
       : {

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -316,23 +316,15 @@ export async function handleTest(
     };
   }
 
-  // Auth-free connectors (e.g. RSS/Atom) declare `authSchema.methods: [{ type: 'none' }]`
-  // and legitimately have no auth profile. Reporting "No auth profile configured" for
-  // them is a false warning on a perfectly valid connection (#2051). If the connector
-  // supports the `none` auth method, an absent profile is expected — report ok.
-  if (connectorSupportsNoAuth(conn.auth_schema)) {
-    return {
-      action: 'test',
-      status: 'ok',
-      message: 'Connector requires no auth profile',
-    };
-  }
-
   // Device-bound connections (e.g. apple.computer_use, browser device workers)
   // run on a paired device, not an auth profile — so a null profile is expected.
   // Report the device's readiness (the actual execution blocker) instead of the
   // misleading "No auth profile configured" warning. The 20-minute freshness
   // window mirrors the readiness rule used across operations/feeds listings.
+  //
+  // This must precede the no-auth check: device connectors like apple.computer_use
+  // declare `authSchema.methods: [{ type: 'none' }]`, so testing no-auth first would
+  // mask an offline device behind a bogus "requires no auth profile" ok.
   if (conn.device_worker_id) {
     const deviceName = conn.device_label || 'paired device';
     return conn.device_online
@@ -351,6 +343,18 @@ export async function handleTest(
           device_online: false,
           ...testErrorFields('NETWORK'),
         };
+  }
+
+  // Auth-free connectors (e.g. RSS/Atom) declare `authSchema.methods: [{ type: 'none' }]`
+  // and legitimately have no auth profile. Reporting "No auth profile configured" for
+  // them is a false warning on a perfectly valid connection (#2051). If the connector
+  // supports the `none` auth method, an absent profile is expected — report ok.
+  if (connectorSupportsNoAuth(conn.auth_schema)) {
+    return {
+      action: 'test',
+      status: 'ok',
+      message: 'Connector requires no auth profile',
+    };
   }
 
   return {


### PR DESCRIPTION
connections.test never looked at the paired device, so a device-bound connection (apple.computer_use, browser device workers) with no auth profile fell through to a misleading 'No auth profile configured' warning. It now reports device readiness: ok when the device is online, a retryable warning when offline (device_online surfaced on the result).

Also tightens the result status type to ok|warning|error and corrects the method-metadata summary, which claimed every test 'sends an external probe' when only the browser-session CDP path makes a network call.

Covered by connection-test-device-aware.test.ts (red→green).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->