### PR TITLE
fix(operations): get_run can fetch internal runs, not only action runs

### DIFF
--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -162,7 +162,7 @@ export const ListRunsAction = Type.Object({
 
 export const GetRunAction = Type.Object({
   action: Type.Literal("get_run", {
-    description: "Fetch one action run.",
+    description: "Fetch one connector action or internal approval run.",
   }),
   run_id: Type.Number(),
 });

--- a/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
+++ b/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
@@ -1,10 +1,9 @@
 /**
- * operations.getRun must fetch internal (builder / entity-change) runs, not
- * just connector action runs.
- *
- * list_runs surfaces internal runs and approve/reject act on them, but getRun
- * filtered run_type='action' and returned "Run not found" for a run the same
- * principal could list and approve. It now accepts action + internal runs.
+ * get_run must fetch internal (builder / entity-change approval) runs, not just
+ * connector action runs. list_runs surfaces internal runs and approve/reject
+ * act on them, but get_run filtered run_type='action' and returned "Run not
+ * found" for a run the same principal could list and approve. It now accepts
+ * action + internal runs, and still rejects unrelated types (e.g. sync).
  */
 
 import { beforeAll, describe, expect, it } from "vitest";
@@ -30,11 +29,14 @@ describe("manage_operations get_run — internal runs", () => {
 		allowCrossOrg: false,
 	});
 
-	async function insertRun(run_type: string): Promise<number> {
+	async function insertRun(
+		runType: "action" | "internal" | "sync",
+		actionKey: string | null,
+	): Promise<number> {
 		const db = getTestDb();
 		const [row] = (await db`
       INSERT INTO runs (organization_id, run_type, action_key, status, created_at, run_at)
-      VALUES (${orgId}, ${run_type}, 'propose_entity_change', 'pending', now(), now())
+      VALUES (${orgId}, ${runType}, ${actionKey}, 'pending', now(), now())
       RETURNING id
     `) as unknown as Array<{ id: number }>;
 		return Number(row.id);
@@ -55,7 +57,7 @@ describe("manage_operations get_run — internal runs", () => {
 	});
 
 	it("fetches an internal run instead of reporting 'Run not found'", async () => {
-		const id = await insertRun("internal");
+		const id = await insertRun("internal", "manage_agents");
 		const result = await getRun(id);
 		expect(result.error).toBeUndefined();
 		expect(result.action).toBe("get_run");
@@ -65,7 +67,7 @@ describe("manage_operations get_run — internal runs", () => {
 	});
 
 	it("still fetches an action run", async () => {
-		const id = await insertRun("action");
+		const id = await insertRun("action", "test_action");
 		const result = await getRun(id);
 		const run = result.run as Record<string, unknown>;
 		expect(Number(run.id)).toBe(id);
@@ -73,7 +75,7 @@ describe("manage_operations get_run — internal runs", () => {
 	});
 
 	it("does not fetch an unrelated run_type (e.g. sync)", async () => {
-		const id = await insertRun("sync");
+		const id = await insertRun("sync", null);
 		const result = await getRun(id);
 		expect(result.error).toBe("Run not found");
 	});

--- a/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
+++ b/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
@@ -1,0 +1,80 @@
+/**
+ * operations.getRun must fetch internal (builder / entity-change) runs, not
+ * just connector action runs.
+ *
+ * list_runs surfaces internal runs and approve/reject act on them, but getRun
+ * filtered run_type='action' and returned "Run not found" for a run the same
+ * principal could list and approve. It now accepts action + internal runs.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import type { ToolContext } from "../../tools/registry";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import { createTestOrganization } from "../setup/test-fixtures";
+
+const env = {} as Env;
+
+describe("manage_operations get_run — internal runs", () => {
+	let orgId: string;
+
+	const ctx = (): ToolContext => ({
+		organizationId: orgId,
+		userId: "getrun-owner",
+		memberRole: "owner",
+		isAuthenticated: true,
+		tokenType: "oauth",
+		scopes: ["mcp:admin"],
+		scopedToOrg: false,
+		allowCrossOrg: false,
+	});
+
+	async function insertRun(run_type: string): Promise<number> {
+		const db = getTestDb();
+		const [row] = (await db`
+      INSERT INTO runs (organization_id, run_type, action_key, status, created_at, run_at)
+      VALUES (${orgId}, ${run_type}, 'propose_entity_change', 'pending', now(), now())
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+		return Number(row.id);
+	}
+
+	async function getRun(runId: number): Promise<Record<string, unknown>> {
+		return (await manageOperations(
+			{ action: "get_run", run_id: runId },
+			env,
+			ctx(),
+		)) as Record<string, unknown>;
+	}
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "GetRun Internal Org" });
+		orgId = org.id;
+	});
+
+	it("fetches an internal run instead of reporting 'Run not found'", async () => {
+		const id = await insertRun("internal");
+		const result = await getRun(id);
+		expect(result.error).toBeUndefined();
+		expect(result.action).toBe("get_run");
+		const run = result.run as Record<string, unknown>;
+		expect(Number(run.id)).toBe(id);
+		expect(run.run_type).toBe("internal");
+	});
+
+	it("still fetches an action run", async () => {
+		const id = await insertRun("action");
+		const result = await getRun(id);
+		const run = result.run as Record<string, unknown>;
+		expect(Number(run.id)).toBe(id);
+		expect(run.run_type).toBe("action");
+	});
+
+	it("does not fetch an unrelated run_type (e.g. sync)", async () => {
+		const id = await insertRun("sync");
+		const result = await getRun(id);
+		expect(result.error).toBe("Run not found");
+	});
+});

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1397,11 +1397,10 @@ async function handleGetRun(
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
   const sql = getDb();
-  // Include 'internal' runs (builder / entity-change proposals), not just
+  // Include 'internal' runs (builder / entity-change approvals), not just
   // connector 'action' runs: list_runs surfaces them and approve/reject act on
-  // them, so a caller that sees an internal run in the list must be able to
-  // getRun it too — an action-only filter returned "Run not found" for a run
-  // the same principal could list and approve.
+  // them, so a caller that can list and approve an internal run must be able to
+  // get_run it too. An action-only filter returned "Run not found" for it.
   const rows = await sql`
     SELECT r.id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1397,15 +1397,20 @@ async function handleGetRun(
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
   const sql = getDb();
+  // Include 'internal' runs (builder / entity-change proposals), not just
+  // connector 'action' runs: list_runs surfaces them and approve/reject act on
+  // them, so a caller that sees an internal run in the list must be able to
+  // getRun it too — an action-only filter returned "Run not found" for a run
+  // the same principal could list and approve.
   const rows = await sql`
     SELECT r.id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
-           r.approval_status, r.status, r.error_message,
+           r.approval_status, r.status, r.error_message, r.run_type,
            r.created_at, r.completed_at
     FROM runs r
     WHERE r.id = ${args.run_id}
       AND r.organization_id = ${ctx.organizationId}
-      AND r.run_type = 'action'
+      AND r.run_type IN ('action', 'internal')
     LIMIT 1
   `;
 	if (rows.length === 0) return { error: "Run not found" };


### PR DESCRIPTION
operations.getRun filtered run_type='action', so an internal (builder / entity-change) run that list_runs surfaces and approve/reject act on returned 'Run not found' when fetched directly. Widens the filter to action + internal and surfaces run_type on the result.

Covered by operations-getrun-internal.test.ts (red→green; list-runs suite still passes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->