### PR TITLE
docs(catalog): point agents at query_sql for connector schemas

### DIFF
--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -624,7 +624,7 @@ export default async (_ctx, client) => {
 	},
 	"catalog.listInstalled": {
 		summary:
-			"List installed resources. `kinds` values are plural: org kinds 'connectors'/'behaviors', agent kinds 'skills'/'providers'/'guardrails' (agent kinds need `agent_id`). Pass `include_catalog: true` to merge global catalog entries with installed/installable flags. Each connector entry carries identity + capability flags; for one connector's full auth/feeds/actions/options schema, query it directly with `query_sql` → `SELECT auth_schema, feeds_schema, actions_schema, options_schema FROM connector_definitions WHERE key = '<connector>' AND status = 'active'` instead of pulling every connector's schemas through this list.",
+			"List installed resources. `kinds` values are plural: org kinds 'connectors'/'behaviors', agent kinds 'skills'/'providers'/'guardrails' (agent kinds need `agent_id`). Pass `include_catalog: true` to merge global catalog entries with installed/installable flags. Each connector entry carries identity + capability flags. For an INSTALLED connector's full auth/feeds/actions/options schema, query it directly with `query_sql` → `SELECT auth_schema, feeds_schema, actions_schema, options_schema FROM connector_definitions WHERE key = '<connector>' AND status = 'active'` instead of pulling every connector's schemas through this list; for an AVAILABLE (not-yet-installed) connector, its schema is on the `list_catalog` entry's `detail`.",
 		access: "read",
 		signature:
 			"catalog.listInstalled(input?: { kinds?: string[]; agent_id?: string; include_catalog?: boolean }): Promise<unknown>",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -623,8 +623,13 @@ export default async (_ctx, client) => {
 		example: "await client.catalog.listCatalog({ kinds: ['connectors'] });",
 	},
 	"catalog.listInstalled": {
-		summary: "List installed org or agent resources.",
+		summary:
+			"List installed resources. `kinds` values are plural: org kinds 'connectors'/'behaviors', agent kinds 'skills'/'providers'/'guardrails'/'channels' (agent kinds need `agent_id`). Pass `include_catalog: true` to merge global catalog entries with installed/installable flags. Each connector entry carries identity + capability flags; for one connector's full auth/feeds/actions/options schema, query it directly with `query_sql` → `SELECT auth_schema, feeds_schema, actions_schema, options_schema FROM connector_definitions WHERE key = '<connector>' AND status = 'active'` instead of pulling every connector's schemas through this list.",
 		access: "read",
+		signature:
+			"catalog.listInstalled(input?: { kinds?: string[]; agent_id?: string; include_catalog?: boolean }): Promise<unknown>",
+		example:
+			"await client.catalog.listInstalled({ kinds: ['connectors'], include_catalog: true });",
 	},
 	"connections.get": {
 		summary: "Get a connection by id.",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -624,7 +624,7 @@ export default async (_ctx, client) => {
 	},
 	"catalog.listInstalled": {
 		summary:
-			"List installed resources. `kinds` values are plural: org kinds 'connectors'/'behaviors', agent kinds 'skills'/'providers'/'guardrails'/'channels' (agent kinds need `agent_id`). Pass `include_catalog: true` to merge global catalog entries with installed/installable flags. Each connector entry carries identity + capability flags; for one connector's full auth/feeds/actions/options schema, query it directly with `query_sql` → `SELECT auth_schema, feeds_schema, actions_schema, options_schema FROM connector_definitions WHERE key = '<connector>' AND status = 'active'` instead of pulling every connector's schemas through this list.",
+			"List installed resources. `kinds` values are plural: org kinds 'connectors'/'behaviors', agent kinds 'skills'/'providers'/'guardrails' (agent kinds need `agent_id`). Pass `include_catalog: true` to merge global catalog entries with installed/installable flags. Each connector entry carries identity + capability flags; for one connector's full auth/feeds/actions/options schema, query it directly with `query_sql` → `SELECT auth_schema, feeds_schema, actions_schema, options_schema FROM connector_definitions WHERE key = '<connector>' AND status = 'active'` instead of pulling every connector's schemas through this list.",
 		access: "read",
 		signature:
 			"catalog.listInstalled(input?: { kinds?: string[]; agent_id?: string; include_catalog?: boolean }): Promise<unknown>",

--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -150,7 +150,7 @@ const ENTRIES: AdminToolEntry[] = [
 	{
 		name: "manage_catalog",
 		description:
-			"Browse installable connectors, skills, and Behavior templates. Use `list_catalog` to see available (manifest) entries — each connector entry's `detail.source_uri` feeds into `manage_connections` action `install_connector`. Use `list_installed` with `include_catalog: true` to see installed + available with `installed`/`installable` flags. For a single connector's full auth/feeds/actions/options schema, query it directly: `query_sql` → `SELECT feeds_schema, actions_schema FROM connector_definitions WHERE key = '<connector>'` (targeted, instead of pulling every connector's schemas through this list). Read-only. SDK alternative: client.catalog.",
+			"Browse installable connectors, skills, and Behavior templates. Use `list_catalog` to see available (manifest) entries — each connector entry's `detail.source_uri` feeds into `manage_connections` action `install_connector`. Use `list_installed` with `include_catalog: true` to see installed + available with `installed`/`installable` flags. For a single installed connector's full auth/feeds/actions/options schema, query it directly: `query_sql` → `SELECT auth_schema, feeds_schema, actions_schema, options_schema FROM connector_definitions WHERE key = '<connector>'` (targeted, instead of pulling every connector's schemas through this list). Read-only. SDK alternative: client.catalog.",
 		schema: ManageCatalogSchema,
 		resultSchema: ManageCatalogResultSchema,
 		handler: manageCatalog,

--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -150,7 +150,7 @@ const ENTRIES: AdminToolEntry[] = [
 	{
 		name: "manage_catalog",
 		description:
-			"Browse installable connectors, skills, and Behavior templates. Use `list_catalog` to see available (manifest) entries — each connector entry's `detail.source_uri` feeds into `manage_connections` action `install_connector`. Use `list_installed` with `include_catalog: true` to see installed + available with `installed`/`installable` flags. For a single installed connector's full auth/feeds/actions/options schema, query it directly: `query_sql` → `SELECT auth_schema, feeds_schema, actions_schema, options_schema FROM connector_definitions WHERE key = '<connector>'` (targeted, instead of pulling every connector's schemas through this list). Read-only. SDK alternative: client.catalog.",
+			"Browse installable connectors, skills, and Behavior templates. Use `list_catalog` to see available (manifest) entries — each connector entry's `detail.source_uri` feeds into `manage_connections` action `install_connector`. Use `list_installed` with `include_catalog: true` to see installed + available with `installed`/`installable` flags. For a single installed connector's full auth/feeds/actions/options schema, query it directly: `query_sql` → `SELECT auth_schema, feeds_schema, actions_schema, options_schema FROM connector_definitions WHERE key = '<connector>' AND status = 'active'` (targeted, instead of pulling every connector's schemas through this list). Read-only. SDK alternative: client.catalog.",
 		schema: ManageCatalogSchema,
 		resultSchema: ManageCatalogResultSchema,
 		handler: manageCatalog,

--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -150,7 +150,7 @@ const ENTRIES: AdminToolEntry[] = [
 	{
 		name: "manage_catalog",
 		description:
-			"Browse installable connectors, skills, and Behavior templates. Use `list_catalog` to see available (manifest) entries — each connector entry's `detail.source_uri` feeds into `manage_connections` action `install_connector`. Use `list_installed` with `include_catalog: true` to see installed + available with `installed`/`installable` flags. For a single installed connector's full auth/feeds/actions/options schema, query it directly: `query_sql` → `SELECT auth_schema, feeds_schema, actions_schema, options_schema FROM connector_definitions WHERE key = '<connector>' AND status = 'active'` (targeted, instead of pulling every connector's schemas through this list). Read-only. SDK alternative: client.catalog.",
+			"Browse installable connectors, skills, and Behavior templates. Use `list_catalog` to see available (manifest) entries — each connector entry's `detail.source_uri` feeds into `manage_connections` action `install_connector`. Use `list_installed` with `include_catalog: true` to see installed + available with `installed`/`installable` flags. Read-only. SDK alternative: client.catalog.",
 		schema: ManageCatalogSchema,
 		resultSchema: ManageCatalogResultSchema,
 		handler: manageCatalog,

--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -150,7 +150,7 @@ const ENTRIES: AdminToolEntry[] = [
 	{
 		name: "manage_catalog",
 		description:
-			"Browse installable connectors, skills, and Behavior templates. Use `list_catalog` to see available (manifest) entries — each connector entry's `detail.source_uri` feeds into `manage_connections` action `install_connector`. Use `list_installed` with `include_catalog: true` to see installed + available with `installed`/`installable` flags. Read-only. SDK alternative: client.catalog.",
+			"Browse installable connectors, skills, and Behavior templates. Use `list_catalog` to see available (manifest) entries — each connector entry's `detail.source_uri` feeds into `manage_connections` action `install_connector`. Use `list_installed` with `include_catalog: true` to see installed + available with `installed`/`installable` flags. For a single connector's full auth/feeds/actions/options schema, query it directly: `query_sql` → `SELECT feeds_schema, actions_schema FROM connector_definitions WHERE key = '<connector>'` (targeted, instead of pulling every connector's schemas through this list). Read-only. SDK alternative: client.catalog.",
 		schema: ManageCatalogSchema,
 		resultSchema: ManageCatalogResultSchema,
 		handler: manageCatalog,


### PR DESCRIPTION
Replaces the closed #2081 with a much smaller change.

#2081 added a `detail: summary|full` toggle to `list_installed` to trim the four schema blobs (auth/feeds/actions/options) each connector carries. Two problems with that: the default flip to `summary` broke the Owletto connection/feed setup forms and the connector-discovery feed-key hints, and the toggle was largely redundant — `connector_definitions` is already an allowlisted `query_sql` table, so an agent that needs one connector's schema can already fetch exactly that.

So instead of a verbosity dial, this just documents the existing path: one line in the `manage_catalog` tool description pointing agents at `query_sql` on `connector_definitions` when they need a full schema, rather than pulling every connector's blobs through the list.

No behavior change — description text only.

Pagination on `list_installed` (unbounded row count) is a separate concern; deferred until connector counts justify it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->