### PR TITLE
fix(operations): get_run resolves any listed run_type, not just action+internal

### DIFF
--- a/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
+++ b/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
@@ -1,9 +1,11 @@
 /**
- * get_run must fetch internal (builder / entity-change approval) runs, not just
- * connector action runs. list_runs surfaces internal runs and approve/reject
- * act on them, but get_run filtered run_type='action' and returned "Run not
- * found" for a run the same principal could list and approve. It now accepts
- * action + internal runs, and still rejects unrelated types (e.g. sync).
+ * get_run must fetch ANY run_type that list_runs surfaces — action, internal,
+ * behavior, sync — not just action. list_runs shows every operational run
+ * (everything except the chat_message transport lane), and approve/reject act
+ * on them, but get_run filtered run_type IN ('action','internal') and returned
+ * "Run not found" for a behavior/sync run the same principal could list. It now
+ * shares the list's excluded-types set, so any listed run is fetchable; only
+ * chat_message (the list's default exclusion) stays unfetchable.
  */
 
 import { beforeAll, describe, expect, it } from "vitest";
@@ -30,7 +32,7 @@ describe("manage_operations get_run — internal runs", () => {
 	});
 
 	async function insertRun(
-		runType: "action" | "internal" | "sync",
+		runType: "action" | "internal" | "sync" | "behavior" | "chat_message",
 		actionKey: string | null,
 	): Promise<number> {
 		const db = getTestDb();
@@ -74,8 +76,24 @@ describe("manage_operations get_run — internal runs", () => {
 		expect(run.run_type).toBe("action");
 	});
 
-	it("does not fetch an unrelated run_type (e.g. sync)", async () => {
+	it("fetches a sync run (listed operationally, so must be gettable)", async () => {
 		const id = await insertRun("sync", null);
+		const result = await getRun(id);
+		const run = result.run as Record<string, unknown>;
+		expect(Number(run.id)).toBe(id);
+		expect(run.run_type).toBe("sync");
+	});
+
+	it("fetches a behavior run (listed operationally, so must be gettable)", async () => {
+		const id = await insertRun("behavior", "propose_entity_change");
+		const result = await getRun(id);
+		const run = result.run as Record<string, unknown>;
+		expect(Number(run.id)).toBe(id);
+		expect(run.run_type).toBe("behavior");
+	});
+
+	it("does NOT fetch a chat_message transport run (excluded from the operational list)", async () => {
+		const id = await insertRun("chat_message", "thread_response");
 		const result = await getRun(id);
 		expect(result.error).toBe("Run not found");
 	});

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1480,7 +1480,11 @@ async function handleGetRun(
   // Include 'internal' runs (builder / entity-change approvals), not just
   // connector 'action' runs: list_runs surfaces them and approve/reject act on
   // them, so a caller that can list and approve an internal run must be able to
-  // get_run it too. An action-only filter returned "Run not found" for it.
+  // get_run it too. get_run must resolve ANY run_type that list_runs surfaces —
+  // action, internal, behavior, sync — not just action+internal. It uses the
+  // SAME excluded-types set as the list_runs default so the two can never drift:
+  // a run visible in the list is always fetchable here. Only the chat-message
+  // transport lane (the list's default exclusion) stays unfetchable.
   const rows = await sql`
     SELECT r.id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
@@ -1489,7 +1493,7 @@ async function handleGetRun(
     FROM runs r
     WHERE r.id = ${args.run_id}
       AND r.organization_id = ${ctx.organizationId}
-      AND r.run_type IN ('action', 'internal')
+      AND r.run_type <> ALL(${pgTextArray([...LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES])}::text[])
     LIMIT 1
   `;
 	if (rows.length === 0) return { error: "Run not found" };


### PR DESCRIPTION
Follow-up to #2084, found by the live E2E sweep.

#2084 widened get_run from action-only to action+internal. But list_runs surfaces every operational run_type — behavior, sync, action, internal — everything except the chat_message transport lane. So a live behavior or sync run that shows up in list_runs still returned "Run not found" from get_run (reproduced live: getRun on behavior run 692782 → Run not found).

This shares the same LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES set that list_runs uses for its default exclusion, so the two can't drift: any run visible in the list is fetchable via get_run, and only the chat_message transport lane stays unfetchable.

Tests updated: behavior and sync runs are now fetchable; chat_message is correctly rejected. red→green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->