### PR TITLE
feat(connectors): validate_connector_source surfaces extracted action policy

### DIFF
--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -810,6 +810,18 @@ export const ManageConnectionsResultSchema = Type.Union([
     installed: Type.Boolean(),
     active_version: Type.Union([Type.String(), Type.Null()]),
     version_exists: Type.Boolean(),
+    // Extracted per-action semantic-policy summary (kind / requires_approval /
+    // required_scopes), keyed by action key, so an author can confirm those
+    // fields survived extraction before persisting. Plus the extracted feed keys.
+    actions: Type.Record(
+      Type.String(),
+      Type.Object({
+        kind: Type.Union([Type.Literal("read"), Type.Literal("write")]),
+        requires_approval: Type.Boolean(),
+        required_scopes: Type.Array(Type.String()),
+      }),
+    ),
+    feed_keys: Type.Array(Type.String()),
   }),
   // Compile/metadata failure is a VALID validation outcome (the whole point of
   // the preflight), not an `error` — it must survive run_sdk as a return value.

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -819,7 +819,7 @@ export const ManageConnectionsResultSchema = Type.Union([
         kind: Type.Union([Type.Literal("read"), Type.Literal("write")]),
         requires_approval: Type.Boolean(),
         required_scopes: Type.Array(Type.String()),
-      }),
+      })
     ),
     feed_keys: Type.Array(Type.String()),
   }),

--- a/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
@@ -140,6 +140,48 @@ describe('manage_connections connector source lifecycle (#2045)', () => {
     expect(valid.active_version).toBe('1.0.0');
     expect(valid.version_exists).toBe(false);
 
+    // ---- validate surfaces extracted per-action kind + requiredScopes ----
+    // Authors must be able to confirm these semantic-policy fields survived
+    // extraction BEFORE persisting (a validate-without-install step).
+    const withActions = await manageConnections(
+      {
+        action: 'validate_connector_source',
+        source_code: `
+export default class ActionProbeConnector {
+  definition = {
+    key: '${KEY}',
+    name: 'Action Probe',
+    version: '3.0.0',
+    feeds: { articles: { key: 'articles', name: 'Articles' } },
+    actions: {
+      read_thing: { key: 'read_thing', name: 'Read thing', kind: 'read', requiresApproval: false, requiredScopes: ['probe.read'] },
+      write_thing: { key: 'write_thing', name: 'Write thing', requiresApproval: true, requiredScopes: ['probe.write'] },
+    },
+  };
+  async sync() { return { events: [], checkpoint: null }; }
+  async execute() { return {}; }
+}
+`,
+      },
+      TEST_ENV,
+      ctx
+    );
+    if (!('valid' in withActions) || withActions.valid !== true) {
+      throw new Error(`expected valid preflight, got ${JSON.stringify(withActions)}`);
+    }
+    expect(withActions.actions.read_thing).toEqual({
+      kind: 'read',
+      requires_approval: false,
+      required_scopes: ['probe.read'],
+    });
+    // kind defaults to write when omitted (matches the runtime default).
+    expect(withActions.actions.write_thing).toEqual({
+      kind: 'write',
+      requires_approval: true,
+      required_scopes: ['probe.write'],
+    });
+    expect(withActions.feed_keys).toEqual(['articles']);
+
     // ---- update guards ----
     // Wrong key inside the source: refused.
     const wrongKey = await manageConnections(

--- a/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-source-lifecycle.test.ts
@@ -155,6 +155,7 @@ export default class ActionProbeConnector {
     feeds: { articles: { key: 'articles', name: 'Articles' } },
     actions: {
       read_thing: { key: 'read_thing', name: 'Read thing', kind: 'read', requiresApproval: false, requiredScopes: ['probe.read'] },
+      hinted_read: { key: 'hinted_read', name: 'Hinted read', requiresApproval: false, annotations: { readOnlyHint: true } },
       write_thing: { key: 'write_thing', name: 'Write thing', requiresApproval: true, requiredScopes: ['probe.write'] },
     },
   };
@@ -174,6 +175,9 @@ export default class ActionProbeConnector {
       requires_approval: false,
       required_scopes: ['probe.read'],
     });
+    // annotations.readOnlyHint:true classifies as read too — must match the
+    // runtime getLocalActionKind, not just an explicit kind field.
+    expect(withActions.actions.hinted_read.kind).toBe('read');
     // kind defaults to write when omitted (matches the runtime default).
     expect(withActions.actions.write_thing).toEqual({
       kind: 'write',

--- a/packages/server/src/catalog/connector-definitions.ts
+++ b/packages/server/src/catalog/connector-definitions.ts
@@ -429,6 +429,19 @@ export async function getInstalledConnectorSource(params: {
 	};
 }
 
+/**
+ * Compact per-action semantic-policy summary surfaced by the preflight so an
+ * author can confirm `kind` and `requiredScopes` survived extraction BEFORE
+ * persisting — the whole point of a validate-without-install step. Keyed by
+ * action key. Omits the (large) input/output schemas; those live in the
+ * installed definition's actions_schema.
+ */
+export type ValidatedActionSummary = {
+	kind: "read" | "write";
+	requires_approval: boolean;
+	required_scopes: string[];
+};
+
 export type ConnectorSourceValidation =
 	| {
 			valid: true;
@@ -439,8 +452,33 @@ export type ConnectorSourceValidation =
 			installed: boolean;
 			activeVersion: string | null;
 			versionExists: boolean;
+			actions: Record<string, ValidatedActionSummary>;
+			feedKeys: string[];
 	  }
 	| { valid: false; diagnostics: string };
+
+/**
+ * Reduce the extracted `actions` blob to the semantic-policy fields authors
+ * need to verify: kind (defaults to write, matching the runtime), whether it
+ * requires approval, and requiredScopes. Tolerant of missing/legacy shapes.
+ */
+function summarizeValidatedActions(
+	actions: Record<string, unknown> | null,
+): Record<string, ValidatedActionSummary> {
+	const out: Record<string, ValidatedActionSummary> = {};
+	for (const [key, raw] of Object.entries(actions ?? {})) {
+		const a = (raw ?? {}) as Record<string, unknown>;
+		const scopes = Array.isArray(a.requiredScopes)
+			? (a.requiredScopes.filter((s) => typeof s === "string") as string[])
+			: [];
+		out[key] = {
+			kind: a.kind === "read" ? "read" : "write",
+			requires_approval: a.requiresApproval === true,
+			required_scopes: scopes,
+		};
+	}
+	return out;
+}
 
 /**
  * Compile + extract + validate connector source WITHOUT persisting anything —
@@ -485,6 +523,8 @@ export async function validateConnectorSource(params: {
 		installed: def !== null,
 		activeVersion: def?.version ?? null,
 		versionExists: versionRows.length > 0,
+		actions: summarizeValidatedActions(resolved.metadata.actions),
+		feedKeys: Object.keys(resolved.metadata.feeds ?? {}),
 	};
 }
 

--- a/packages/server/src/catalog/connector-definitions.ts
+++ b/packages/server/src/catalog/connector-definitions.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { getErrorMessage } from "@lobu/core";
 import { getLoginProviderScopes } from "../auth/config";
 import { type DbClient, type DbQuery, getDb } from "../db/client";
+import { getLocalActionKind } from "../operations/connector-operations";
 import { probeMcpServer } from "../mcp-proxy/client";
 import { computeCodeHash } from "../utils/compiler-core";
 import {
@@ -472,7 +473,10 @@ function summarizeValidatedActions(
 			? (a.requiredScopes.filter((s) => typeof s === "string") as string[])
 			: [];
 		out[key] = {
-			kind: a.kind === "read" ? "read" : "write",
+			// Reuse the exact runtime classifier so the preflight can't disagree
+			// with how the action is actually treated (kind:'read' OR
+			// annotations.readOnlyHint:true → read; else write).
+			kind: getLocalActionKind(a),
 			requires_approval: a.requiresApproval === true,
 			required_scopes: scopes,
 		};

--- a/packages/server/src/tools/admin/manage_connections/handlers/connector-management.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connector-management.ts
@@ -206,6 +206,10 @@ export async function handleValidateConnectorSource(
 		installed: result.installed,
 		active_version: result.activeVersion,
 		version_exists: result.versionExists,
+		// Extracted per-action kind/requiredScopes + feed keys, so an author can
+		// confirm the semantic-policy fields survived extraction before persisting.
+		actions: result.actions,
+		feed_keys: result.feedKeys,
 	};
 }
 


### PR DESCRIPTION
Found by the live E2E sweep.

validate_connector_source is the preflight for updateConnectorSource — 'compile + extract + validate without persisting'. But its result dropped the extracted actions and feeds, returning only key/name/version + install state. So an author had no way to confirm — before persisting — that a defineConnector action's `kind` and `requiredScopes` survived extraction. Those are exactly the semantic-policy fields the scope-readiness gate (#2079) keys on, so being unable to verify them pre-install defeats the point of a preflight.

This adds a compact per-action summary to the valid result — `actions: { <key>: { kind, requires_approval, required_scopes } }` — plus `feed_keys`. kind defaults to write, matching the runtime default. The heavy input/output schemas are intentionally left out (they're on the installed definition's actions_schema; query_sql reads them).

Covered by the connector-source-lifecycle integration test (read survives, write is the default, requiredScopes come through).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connector source validation now reports extracted action metadata, including read/write behavior, approval requirements, and required scopes.
  * Validation results now include available feed keys.
  * Missing or invalid action details receive safe defaults during validation.
* **Tests**
  * Added coverage confirming action and feed metadata is surfaced before connector persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->