### PR TITLE
fix(behaviors): validate custom-SQL sources at save time

### DIFF
--- a/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
@@ -73,4 +73,14 @@ describe("behavior custom-SQL source validation", () => {
 		expect(created.action).toBe("create");
 		expect("behavior_id" in created).toBe(true);
 	});
+
+	it("accepts a valid source that uses the {{entityId}} template variable", async () => {
+		// Save-time validation must substitute template variables like the reader
+		// does, not reject them as "Unknown context variables".
+		const created = await createWithSource(
+			"SELECT id FROM events WHERE {{entityId}} = ANY(entity_ids)",
+		);
+		expect(created.action).toBe("create");
+		expect("behavior_id" in created).toBe(true);
+	});
 });

--- a/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Behavior custom-SQL source validation at save time.
+ *
+ * A Behavior source query referencing a non-existent COLUMN used to be accepted
+ * by behaviors.create with zero validation: the scoped-query layer swallows the
+ * Postgres 42703 error into an empty result at read time, so the Behavior ran
+ * "green" forever (health healthy, 0 content) with no operator signal. The
+ * create/update path now validates each custom-SQL source (plans it LIMIT 0 and
+ * throws on failure), so a broken column is rejected up front. A structurally
+ * valid query that merely matches 0 rows is still accepted.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageBehaviors } from "../../tools/admin/manage_behaviors";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase } from "../setup/test-db";
+import { createTestAgent, seedOwnerContext } from "../setup/test-fixtures";
+
+const env = {} as Env;
+
+describe("behavior custom-SQL source validation", () => {
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+	});
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	async function createWithSource(query: string) {
+		const { org, user, ctx } = await seedOwnerContext();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		return manageBehaviors(
+			{
+				action: "create",
+				slug: `src-validate-${Date.now()}`,
+				name: "Source validate",
+				prompt: "Summarize.",
+				agent_id: agent.agentId,
+				sources: [{ name: "src", query }],
+				triggers: [
+					{
+						kind: "schedule",
+						cron: "* * * * *",
+						execution: "window",
+						active_run: "coalesce",
+					},
+				],
+			},
+			env,
+			ctx,
+		);
+	}
+
+	it("rejects a source that references a non-existent column", async () => {
+		// Projects `id` (so it passes the id-projection guard) but references a
+		// bogus column — must be caught by the new scoped-query validation, not
+		// swallowed into 0 rows at read time.
+		await expect(
+			createWithSource(
+				"SELECT id, this_is_not_a_column FROM events",
+			),
+		).rejects.toThrow(/this_is_not_a_column|column|does not exist/i);
+	});
+
+	it("accepts a valid source that matches zero rows", async () => {
+		const created = await createWithSource(
+			"SELECT id FROM events WHERE 1=0",
+		);
+		expect(created.action).toBe("create");
+		expect("behavior_id" in created).toBe(true);
+	});
+});

--- a/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
@@ -15,7 +15,11 @@ import type { Env } from "../../index";
 import { manageBehaviors } from "../../tools/admin/manage_behaviors";
 import { initWorkspaceProvider } from "../../workspace";
 import { cleanupTestDatabase } from "../setup/test-db";
-import { createTestAgent, seedOwnerContext } from "../setup/test-fixtures";
+import {
+	createTestAgent,
+	createTestEntity,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
 
 const env = {} as Env;
 
@@ -27,12 +31,22 @@ describe("behavior custom-SQL source validation", () => {
 		await cleanupTestDatabase();
 	});
 
-	async function createWithSource(query: string) {
+	async function createWithSource(
+		query: string,
+		opts: { entityBound?: boolean } = {},
+	) {
 		const { org, user, ctx } = await seedOwnerContext();
 		const agent = await createTestAgent({
 			organizationId: org.id,
 			ownerUserId: user.id,
 		});
+		const entity = opts.entityBound
+			? await createTestEntity({
+					name: `src-validate-entity-${Date.now()}`,
+					organization_id: org.id,
+					created_by: user.id,
+				})
+			: null;
 		return manageBehaviors(
 			{
 				action: "create",
@@ -40,6 +54,7 @@ describe("behavior custom-SQL source validation", () => {
 				name: "Source validate",
 				prompt: "Summarize.",
 				agent_id: agent.agentId,
+				...(entity ? { entity_id: Number(entity.id) } : {}),
 				sources: [{ name: "src", query }],
 				triggers: [
 					{
@@ -74,13 +89,25 @@ describe("behavior custom-SQL source validation", () => {
 		expect("behavior_id" in created).toBe(true);
 	});
 
-	it("accepts a valid source that uses the {{entityId}} template variable", async () => {
-		// Save-time validation must substitute template variables like the reader
-		// does, not reject them as "Unknown context variables".
+	it("accepts a {{entityId}} source on an entity-bound behavior", async () => {
+		// The behavior has an entity_id, so {{entityId}} resolves at run time —
+		// validation must accept it (not trip the Unknown-context-variables guard).
 		const created = await createWithSource(
 			"SELECT id FROM events WHERE {{entityId}} = ANY(entity_ids)",
+			{ entityBound: true },
 		);
 		expect(created.action).toBe("create");
 		expect("behavior_id" in created).toBe(true);
+	});
+
+	it("rejects a {{entityId}} source on an org-scoped behavior", async () => {
+		// No entity binding → {{entityId}} never resolves at run time, so the
+		// source would fail on every read. Reject it at save instead of accepting
+		// a silently-broken source.
+		await expect(
+			createWithSource(
+				"SELECT id FROM events WHERE {{entityId}} = ANY(entity_ids)",
+			),
+		).rejects.toThrow();
 	});
 });

--- a/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
@@ -110,4 +110,53 @@ describe("behavior custom-SQL source validation", () => {
 			),
 		).rejects.toThrow();
 	});
+
+	it("validates custom SQL on create_version too, not only create", async () => {
+		// Create a valid behavior, then publish a new version whose source has a
+		// bad column — the create_version path (version-actions) must reject it,
+		// same as create.
+		const { org, user, ctx } = await seedOwnerContext();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		const created = await manageBehaviors(
+			{
+				action: "create",
+				slug: `src-cv-${Date.now()}`,
+				name: "Source create_version",
+				prompt: "Summarize.",
+				agent_id: agent.agentId,
+				sources: [{ name: "src", query: "SELECT id FROM events WHERE 1=0" }],
+				triggers: [
+					{
+						kind: "schedule",
+						cron: "* * * * *",
+						execution: "window",
+						active_run: "coalesce",
+					},
+				],
+			},
+			env,
+			ctx,
+		);
+		if (created.action !== "create" || !("behavior_id" in created)) {
+			throw new Error("setup: create failed");
+		}
+		const behaviorId = String(created.behavior_id);
+
+		await expect(
+			manageBehaviors(
+				{
+					action: "create_version",
+					behavior_id: behaviorId,
+					sources: [
+						{ name: "src", query: "SELECT id, this_is_not_a_column FROM events" },
+					],
+				},
+				env,
+				ctx,
+			),
+		).rejects.toThrow(/this_is_not_a_column|column|does not exist/i);
+	});
 });

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -194,7 +194,12 @@ export async function handleCreate(
   if (!organizationId) {
     throw new ToolUserError('Cannot resolve Behavior sources without an organization');
   }
-  await assertWatcherSourcesResolve(sql, organizationId, sources);
+  await assertWatcherSourcesResolve(
+    sql,
+    organizationId,
+    sources,
+    entityId ? [entityId] : [],
+  );
   const triggerWrite = resolveBehaviorTriggerWrite({
     triggers: args.triggers,
   });

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -188,9 +188,11 @@ export async function handleCreate(
     organizationSlug = await getOrganizationSlug(organizationId);
   }
 
-  // Resolve @ref sources against the org now so a typo fails at create (422)
-  // instead of producing silent empty context at read_knowledge. Custom-SQL
-  // sources are skipped here; their id projection is enforced above.
+  // Resolve every source against the org now so a broken source fails at create
+  // (422) instead of producing silent empty context at read_knowledge: @refs are
+  // existence-checked, and custom SQL is planned (LIMIT 0) to catch bad
+  // columns/syntax. Pass the Behavior's entity_ids so {{entityId}} validates as
+  // it runs.
   if (!organizationId) {
     throw new ToolUserError('Cannot resolve Behavior sources without an organization');
   }

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -255,10 +255,13 @@ export function assertWatcherVersionConfigValid(parsed: {
 export async function assertWatcherSourcesResolve(
   sql: DbClient,
   organizationId: string,
-  sources: Array<{ name: string; query: string }>
+  sources: Array<{ name: string; query: string }>,
+  // The Behavior's entity_ids (empty/omitted for an org-scoped Behavior), so
+  // {{entityId}} in a custom-SQL source validates exactly as it runs.
+  entityIds: number[] = []
 ): Promise<void> {
   try {
-    await resolveWatcherSourcesForSave(sql, organizationId, sources);
+    await resolveWatcherSourcesForSave(sql, organizationId, sources, entityIds);
   } catch (err) {
     throw new ToolUserError(
       `Behavior validation failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -3,7 +3,7 @@
  *   create_version, upgrade, get_versions, get_version_details
  */
 
-import { getDb } from '../../../db/client';
+import { getDb, parsePgNumberArray } from '../../../db/client';
 import { recordToolConfigChange } from '../helpers/config-audit';
 import { nextRunAt } from '../../../utils/cron';
 import { resolveUsernames } from '../../../utils/resolve-usernames';
@@ -56,7 +56,7 @@ export async function handleCreateVersion(
   // schedule, scheduler_client_id) to that specific row.
   const watcherRows = await sql`
     SELECT i.id, i.version, i.current_version_id, i.watcher_group_id, i.sources, i.organization_id,
-           i.schedule, i.timezone, i.triggers
+           i.entity_ids, i.schedule, i.timezone, i.triggers
     FROM watchers i WHERE i.id = ${args.behavior_id}
   `;
   if (watcherRows.length === 0) {
@@ -134,7 +134,12 @@ export async function handleCreateVersion(
   // sources are skipped (id projection is enforced by the config check above).
   const versionOrganizationId = watcherRows[0].organization_id as string | null;
   if (versionOrganizationId) {
-    await assertWatcherSourcesResolve(sql, versionOrganizationId, sources);
+    await assertWatcherSourcesResolve(
+      sql,
+      versionOrganizationId,
+      sources,
+      parsePgNumberArray(watcherRows[0].entity_ids),
+    );
   }
 
   const triggerWrite = resolveBehaviorTriggerWrite({

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -129,9 +129,10 @@ export async function handleCreateVersion(
   // the worker's free-form summary fallback.
   assertWatcherVersionConfigValid({ prompt, classifiers, sources });
 
-  // Resolve @ref sources against the org now (typo → 422, not silent empty
-  // context at read_knowledge). The watcher row carries the org; custom-SQL
-  // sources are skipped (id projection is enforced by the config check above).
+  // Resolve every source against the org now (broken source → 422, not silent
+  // empty context at read_knowledge): @refs are existence-checked, custom SQL is
+  // planned (LIMIT 0) for bad columns/syntax. The watcher row carries the org +
+  // entity_ids so {{entityId}} validates as it runs.
   const versionOrganizationId = watcherRows[0].organization_id as string | null;
   if (versionOrganizationId) {
     await assertWatcherSourcesResolve(

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -1,6 +1,32 @@
 import type { DbClient } from '../db/client';
 import { slugToRuntimeConnectionId } from '../lobu/stores/connections-projection';
 import type { WatcherSource } from '../types/watchers';
+import { executeDataSources } from '../utils/execute-data-sources';
+
+/**
+ * Validate a custom-SQL Behavior source at save time. Runs the SAME scoped
+ * query the reader uses, wrapped in `SELECT ... LIMIT 0` so Postgres plans and
+ * type-checks it (undefined column → 42703, syntax error, admin-table access)
+ * without materializing any rows, and throws on failure. A structurally valid
+ * query that merely matches 0 rows passes. Note: an unknown TABLE is rewritten
+ * by the scoped-query layer into a valid entity-type-slug CTE, so it is NOT
+ * caught here — only bad columns / syntax / restricted tables are.
+ */
+async function validateCustomSqlSource(
+  sql: DbClient,
+  organizationId: string,
+  source: WatcherSource
+): Promise<void> {
+  await executeDataSources(
+    { [source.name]: { query: source.query } },
+    { organizationId },
+    sql,
+    {
+      throwOnError: true,
+      wrapQuery: (scopedSql) => `SELECT * FROM (${scopedSql}) AS _validate LIMIT 0`,
+    }
+  );
+}
 
 // 'channel' is a chat-transcript source (streaming feed → channel_messages). It
 // is prompt CONTEXT, not events: its rows must never be signed as event
@@ -425,7 +451,17 @@ export async function resolveWatcherSourcesForSave(
 ): Promise<void> {
   for (const source of sources) {
     const ref = parseWatcherSourceRef(source.query);
-    if (!ref) continue; // custom SQL — id projection is enforced by the caller's config validation
+    if (!ref) {
+      // Custom SQL. The scoped-query layer swallows a bad column (Postgres
+      // 42703) into an empty result at read time, so a typo'd source ran green
+      // forever with no operator signal. Validate it here by planning the same
+      // scoped query with LIMIT 0 (structure only, no rows materialized) and
+      // throwing on failure — a valid query that merely matches 0 rows still
+      // passes. (An unknown TABLE becomes a valid entity-type-slug CTE rather
+      // than an error, so this catches bad columns/syntax, not typo'd tables.)
+      await validateCustomSqlSource(sql, organizationId, source);
+      continue;
+    }
 
     if (ref.type === 'entity') {
       const exists = await sql<{ id: number }>`

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -19,7 +19,15 @@ async function validateCustomSqlSource(
 ): Promise<void> {
   await executeDataSources(
     { [source.name]: { query: source.query } },
-    { organizationId },
+    {
+      organizationId,
+      // Supply placeholder context so template variables a legitimate source
+      // uses — {{entityId}}, {{query.*}} — substitute cleanly rather than
+      // tripping the "Unknown context variables" guard at validate time. The
+      // dummy entity id never affects results: the query runs LIMIT 0.
+      entityIds: [0],
+      query: {},
+    },
     sql,
     {
       throwOnError: true,

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -471,13 +471,9 @@ export async function resolveWatcherSourcesForSave(
   for (const source of sources) {
     const ref = parseWatcherSourceRef(source.query);
     if (!ref) {
-      // Custom SQL. The scoped-query layer swallows a bad column (Postgres
-      // 42703) into an empty result at read time, so a typo'd source ran green
-      // forever with no operator signal. Validate it here by planning the same
-      // scoped query with LIMIT 0 (structure only, no rows materialized) and
-      // throwing on failure — a valid query that merely matches 0 rows still
-      // passes. (An unknown TABLE becomes a valid entity-type-slug CTE rather
-      // than an error, so this catches bad columns/syntax, not typo'd tables.)
+      // Custom SQL — validate it (see validateCustomSqlSource for the mechanism
+      // and its limits) so a typo'd source fails here instead of silently
+      // returning 0 rows forever at read time.
       await validateCustomSqlSource(sql, organizationId, entityIds, source);
       continue;
     }

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -8,24 +8,32 @@ import { executeDataSources } from '../utils/execute-data-sources';
  * query the reader uses, wrapped in `SELECT ... LIMIT 0` so Postgres plans and
  * type-checks it (undefined column → 42703, syntax error, admin-table access)
  * without materializing any rows, and throws on failure. A structurally valid
- * query that merely matches 0 rows passes. Note: an unknown TABLE is rewritten
+ * query that merely matches 0 rows passes.
+ *
+ * `entityIds` mirrors what the runtime reader supplies (the Behavior's own
+ * entity_ids). It is passed through so `{{entityId}}` substitutes exactly as it
+ * will at run time: an entity-bound Behavior validates its `{{entityId}}` source
+ * cleanly, while an ORG-SCOPED Behavior (no entity_ids) leaves `{{entityId}}`
+ * unresolved and is rejected here — the same source would fail on every runtime
+ * read, so catching it at save is the point. Note: an unknown TABLE is rewritten
  * by the scoped-query layer into a valid entity-type-slug CTE, so it is NOT
- * caught here — only bad columns / syntax / restricted tables are.
+ * caught here — only bad columns / syntax / restricted tables / unresolved
+ * template variables are.
  */
 async function validateCustomSqlSource(
   sql: DbClient,
   organizationId: string,
+  entityIds: number[],
   source: WatcherSource
 ): Promise<void> {
   await executeDataSources(
     { [source.name]: { query: source.query } },
     {
       organizationId,
-      // Supply placeholder context so template variables a legitimate source
-      // uses — {{entityId}}, {{query.*}} — substitute cleanly rather than
-      // tripping the "Unknown context variables" guard at validate time. The
-      // dummy entity id never affects results: the query runs LIMIT 0.
-      entityIds: [0],
+      // Only supply entity ids the Behavior actually has, so {{entityId}} on an
+      // org-scoped Behavior stays unresolved and fails validation (matching the
+      // runtime). {{query.*}} substitutes to NULL with an empty query map.
+      entityIds: entityIds.length > 0 ? entityIds : undefined,
       query: {},
     },
     sql,
@@ -455,7 +463,10 @@ async function compileRefToQuery(
 export async function resolveWatcherSourcesForSave(
   sql: DbClient,
   organizationId: string,
-  sources: WatcherSource[]
+  sources: WatcherSource[],
+  // The Behavior's own entity_ids (empty for an org-scoped Behavior). Threaded
+  // into custom-SQL validation so {{entityId}} resolves exactly as at run time.
+  entityIds: number[] = []
 ): Promise<void> {
   for (const source of sources) {
     const ref = parseWatcherSourceRef(source.query);
@@ -467,7 +478,7 @@ export async function resolveWatcherSourcesForSave(
       // throwing on failure — a valid query that merely matches 0 rows still
       // passes. (An unknown TABLE becomes a valid entity-type-slug CTE rather
       // than an error, so this catches bad columns/syntax, not typo'd tables.)
-      await validateCustomSqlSource(sql, organizationId, source);
+      await validateCustomSqlSource(sql, organizationId, entityIds, source);
       continue;
     }
 


### PR DESCRIPTION
Found by the live E2E sweep (a fresh behavior with a typo'd source ran green forever).

A Behavior custom-SQL source that references a non-existent column was accepted by behaviors.create/update with zero validation. The scoped-query layer swallows the Postgres 42703 error into an empty result at read time, so the behavior ran green forever — health 'healthy', 0 content, no operator signal. resolveWatcherSourcesForSave already validated @entity/@metric refs (422 at create) but skipped custom SQL entirely (`if (!ref) continue`).

Now each custom-SQL source is planned through the same scoped query wrapped in `LIMIT 0` (structure/type-check only, no rows materialized) with throwOnError, so a bad column / syntax error / restricted-table access is rejected up front (422). A structurally valid query that matches 0 rows still passes — verified the existing behavior-health suite (whose sources use `WHERE 1=0`) stays green.

Scope note: an unknown TABLE is rewritten by the scoped-query layer into a valid entity-type-slug CTE (0 rows), so typo'd table names are not caught here — a follow-up can add a slug-existence check for that lower-frequency case (per the advisor analysis). This PR closes the common bad-column case with red→green evidence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->