### PR TITLE
fix(behaviors): clearer error when update has no patchable field

### DIFF
--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
@@ -395,7 +395,7 @@ describe("manage_behaviors — builder gate e2e", () => {
 				TEST_ENV,
 				agentCtx
 			)
-		).rejects.toThrow(/at least one field to change/i);
+		).rejects.toThrow(/runtime config only|at least one such field/i);
 	});
 
 	it("rejects set_reaction_script with no reaction_script (would silently clear)", async () => {

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -553,7 +553,7 @@ function assertWatcherUpdateArgs(args: ManageBehaviorsArgs): void {
   }
   if (present(WATCHER_PATCHABLE_FIELDS).length === 0) {
     throw new ToolUserError(
-      'update requires at least one field to change (e.g. triggers, agent_id, tags, model_config).'
+      "update changes runtime config only (e.g. triggers, agent_id, tags, model_config) and needs at least one such field. It cannot change status — a Behavior is retired via action: 'delete' (→ archived); name/description/prompt/sources are version-owned (action: 'create_version')."
     );
   }
 }


### PR DESCRIPTION
Found by the live E2E sweep.

behaviors.update with only a status change (or any non-patchable field) hit a generic 'update requires at least one field to change' that didn't explain WHY — the caller did pass a field, it just isn't patchable via update. The message now spells out that update changes runtime config only, status is changed via action:'delete' (→ archived), and name/description/prompt/sources are version-owned (action:'create_version'). Message-only change; existing assertion updated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->