### PR TITLE
fix(behaviors): reject custom-SQL sources referencing a non-existent table

### DIFF
--- a/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
@@ -14,10 +14,11 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../../index";
 import { manageBehaviors } from "../../tools/admin/manage_behaviors";
 import { initWorkspaceProvider } from "../../workspace";
-import { cleanupTestDatabase } from "../setup/test-db";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
 	createTestAgent,
 	createTestEntity,
+	createTestOrganization,
 	seedOwnerContext,
 } from "../setup/test-fixtures";
 
@@ -90,10 +91,8 @@ describe("behavior custom-SQL source validation", () => {
 	});
 
 	it("rejects a source referencing a non-existent table (typo, not a real slug)", async () => {
-		// A bad table name is NOT a Postgres error — the scoped-query layer rewrites
-		// any unknown name into an entity_type-slug CTE that matches 0 rows. Without
-		// the slug-existence check this would be accepted and run "healthy" forever
-		// with no content. `evetns` is neither a table nor an org entity-type slug.
+		// Unknown names compile as empty entity-type CTEs, so `evetns` would not
+		// otherwise produce a Postgres error.
 		await expect(
 			createWithSource("SELECT id FROM evetns"),
 		).rejects.toThrow(/unknown table or entity type|evetns/i);
@@ -121,6 +120,42 @@ describe("behavior custom-SQL source validation", () => {
 				prompt: "Summarize.",
 				agent_id: agent.agentId,
 				sources: [{ name: "src", query: "SELECT id FROM company" }],
+				triggers: [
+					{
+						kind: "schedule",
+						cron: "* * * * *",
+						execution: "window",
+						active_run: "coalesce",
+					},
+				],
+			},
+			env,
+			ctx,
+		);
+		expect(created.action).toBe("create");
+		expect("behavior_id" in created).toBe(true);
+	});
+
+	it("accepts a source referencing a public-catalog entity_type slug", async () => {
+		const { org, user, ctx } = await seedOwnerContext();
+		const catalogOrg = await createTestOrganization({ visibility: "public" });
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		await getTestDb()`
+			INSERT INTO entity_types (organization_id, slug, name)
+			VALUES (${catalogOrg.id}, 'catalog-company', 'Catalog Company')
+		`;
+
+		const created = await manageBehaviors(
+			{
+				action: "create",
+				slug: `src-public-slug-${Date.now()}`,
+				name: "Public slug source",
+				prompt: "Summarize.",
+				agent_id: agent.agentId,
+				sources: [{ name: "src", query: 'SELECT id FROM "catalog-company"' }],
 				triggers: [
 					{
 						kind: "schedule",

--- a/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
@@ -89,6 +89,54 @@ describe("behavior custom-SQL source validation", () => {
 		expect("behavior_id" in created).toBe(true);
 	});
 
+	it("rejects a source referencing a non-existent table (typo, not a real slug)", async () => {
+		// A bad table name is NOT a Postgres error — the scoped-query layer rewrites
+		// any unknown name into an entity_type-slug CTE that matches 0 rows. Without
+		// the slug-existence check this would be accepted and run "healthy" forever
+		// with no content. `evetns` is neither a table nor an org entity-type slug.
+		await expect(
+			createWithSource("SELECT id FROM evetns"),
+		).rejects.toThrow(/unknown table or entity type|evetns/i);
+	});
+
+	it("accepts a source referencing a real entity_type slug as a table", async () => {
+		// `company` is a valid entity_type slug (created below), so referencing it
+		// as a table compiles to the entity-slug CTE and must be accepted.
+		const { org, user, ctx } = await seedOwnerContext();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		await createTestEntity({
+			name: `slug-src-company-${Date.now()}`,
+			entity_type: "company",
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const created = await manageBehaviors(
+			{
+				action: "create",
+				slug: `src-slug-${Date.now()}`,
+				name: "Slug source",
+				prompt: "Summarize.",
+				agent_id: agent.agentId,
+				sources: [{ name: "src", query: "SELECT id FROM company" }],
+				triggers: [
+					{
+						kind: "schedule",
+						cron: "* * * * *",
+						execution: "window",
+						active_run: "coalesce",
+					},
+				],
+			},
+			env,
+			ctx,
+		);
+		expect(created.action).toBe("create");
+		expect("behavior_id" in created).toBe(true);
+	});
+
 	it("accepts a {{entityId}} source on an entity-bound behavior", async () => {
 		// The behavior has an entity_id, so {{entityId}} resolves at run time —
 		// validation must accept it (not trip the Unknown-context-variables guard).

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -875,15 +875,7 @@ export async function executeDataSources(
         // Unknown refs compile as entity-type CTEs instead of erroring. At save
         // time, resolve them through entity creation's local-or-public schema path.
         if (options?.validateEntitySlugs) {
-          const slugRefs = [
-            ...new Set(
-              tableRefs.filter(
-                (t) =>
-                  !QUERYABLE_TABLE_NAMES.has(t) &&
-                  !ADMIN_ONLY_QUERYABLE_TABLES.has(t)
-              )
-            ),
-          ];
+          const slugRefs = tableRefs.filter((t) => !QUERYABLE_TABLE_NAMES.has(t));
           if (slugRefs.length > 0) {
             const existing = await sql<{ slug: string }>`
               SELECT DISTINCT et.slug

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -16,7 +16,7 @@
  */
 
 import { Dialect, ast, parse as parseSql } from '@polyglot-sql/sdk';
-import type { DbClient } from '../db/client';
+import { type DbClient, pgTextArray } from '../db/client';
 import logger from './logger';
 import {
   compileConnectionFkVisibility,
@@ -845,6 +845,15 @@ export async function executeDataSources(
     ) => string | { sql: string; params: unknown[] };
     /** Fail the whole read when any source fails instead of treating it as empty. */
     throwOnError?: boolean;
+    /**
+     * Reject a table ref that is neither a known queryable table nor an existing
+     * entity_type slug for the org. Runtime reads leave this off (the scoped-query
+     * layer treats any unknown name as an entity-type slug → 0 rows, which is the
+     * right permissive behavior for a slug that may be created later). Save-time
+     * validation turns it ON so a TYPO'd table is rejected instead of silently
+     * yielding an empty, forever-"healthy" Behavior. Requires `throwOnError`.
+     */
+    validateEntitySlugs?: boolean;
   }
 ): Promise<Record<string, unknown[]>> {
   const results: Record<string, unknown[]> = {};
@@ -868,6 +877,39 @@ export async function executeDataSources(
           throw new Error(
             `Source '${name}': table(s) require admin access: ${[...new Set(restricted)].join(', ')}`
           );
+        }
+
+        // A ref that is neither a known table nor an admin table is compiled by
+        // buildScopedQuery into an entity_type-slug CTE (SELECT … FROM entities
+        // WHERE et.slug = <ref>). A TYPO'd table name therefore produces a valid
+        // query that matches 0 rows and never errors — masking the mistake. When
+        // validateEntitySlugs is set (save-time), require each such ref to be a
+        // real entity_type slug for the org and reject unknown ones up front.
+        if (options?.validateEntitySlugs) {
+          const slugRefs = [
+            ...new Set(
+              tableRefs.filter(
+                (t) =>
+                  !QUERYABLE_TABLE_NAMES.has(t) &&
+                  !ADMIN_ONLY_QUERYABLE_TABLES.has(t)
+              )
+            ),
+          ];
+          if (slugRefs.length > 0) {
+            const existing = await sql<{ slug: string }>`
+              SELECT slug FROM entity_types
+              WHERE organization_id = ${context.organizationId}
+                AND slug = ANY(${pgTextArray(slugRefs)}::text[])
+                AND deleted_at IS NULL
+            `;
+            const known = new Set(existing.map((r) => r.slug));
+            const missing = slugRefs.filter((s) => !known.has(s));
+            if (missing.length > 0) {
+              throw new Error(
+                `Source '${name}': unknown table or entity type: ${missing.join(', ')}`
+              );
+            }
+          }
         }
 
         // safeColumns masks each core-table CTE to its allowlisted columns, so

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -845,14 +845,7 @@ export async function executeDataSources(
     ) => string | { sql: string; params: unknown[] };
     /** Fail the whole read when any source fails instead of treating it as empty. */
     throwOnError?: boolean;
-    /**
-     * Reject a table ref that is neither a known queryable table nor an existing
-     * entity_type slug for the org. Runtime reads leave this off (the scoped-query
-     * layer treats any unknown name as an entity-type slug → 0 rows, which is the
-     * right permissive behavior for a slug that may be created later). Save-time
-     * validation turns it ON so a TYPO'd table is rejected instead of silently
-     * yielding an empty, forever-"healthy" Behavior. Requires `throwOnError`.
-     */
+    /** At save time, require unknown table refs to resolve to local or public entity types. */
     validateEntitySlugs?: boolean;
   }
 ): Promise<Record<string, unknown[]>> {
@@ -879,12 +872,8 @@ export async function executeDataSources(
           );
         }
 
-        // A ref that is neither a known table nor an admin table is compiled by
-        // buildScopedQuery into an entity_type-slug CTE (SELECT … FROM entities
-        // WHERE et.slug = <ref>). A TYPO'd table name therefore produces a valid
-        // query that matches 0 rows and never errors — masking the mistake. When
-        // validateEntitySlugs is set (save-time), require each such ref to be a
-        // real entity_type slug for the org and reject unknown ones up front.
+        // Unknown refs compile as entity-type CTEs instead of erroring. At save
+        // time, resolve them through entity creation's local-or-public schema path.
         if (options?.validateEntitySlugs) {
           const slugRefs = [
             ...new Set(
@@ -897,10 +886,15 @@ export async function executeDataSources(
           ];
           if (slugRefs.length > 0) {
             const existing = await sql<{ slug: string }>`
-              SELECT slug FROM entity_types
-              WHERE organization_id = ${context.organizationId}
-                AND slug = ANY(${pgTextArray(slugRefs)}::text[])
-                AND deleted_at IS NULL
+              SELECT DISTINCT et.slug
+              FROM entity_types et
+              LEFT JOIN organization o ON o.id = et.organization_id
+              WHERE et.slug = ANY(${pgTextArray(slugRefs)}::text[])
+                AND et.deleted_at IS NULL
+                AND (
+                  et.organization_id = ${context.organizationId}
+                  OR o.visibility = 'public'
+                )
             `;
             const known = new Set(existing.map((r) => r.slug));
             const missing = slugRefs.filter((s) => !known.has(s));

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -15,10 +15,11 @@ import { executeDataSources } from '../utils/execute-data-sources';
  * will at run time: an entity-bound Behavior validates its `{{entityId}}` source
  * cleanly, while an ORG-SCOPED Behavior (no entity_ids) leaves `{{entityId}}`
  * unresolved and is rejected here — the same source would fail on every runtime
- * read, so catching it at save is the point. Note: an unknown TABLE is rewritten
- * by the scoped-query layer into a valid entity-type-slug CTE, so it is NOT
- * caught here — only bad columns / syntax / restricted tables / unresolved
- * template variables are.
+ * read, so catching it at save is the point. `validateEntitySlugs` additionally
+ * rejects a table ref that is neither a known table nor an existing entity_type
+ * slug: without it, the scoped-query layer rewrites any unknown name into an
+ * entity-type-slug CTE that matches 0 rows and never errors, so a TYPO'd table
+ * would be accepted and run "healthy" forever with no content.
  */
 async function validateCustomSqlSource(
   sql: DbClient,
@@ -39,6 +40,7 @@ async function validateCustomSqlSource(
     sql,
     {
       throwOnError: true,
+      validateEntitySlugs: true,
       wrapQuery: (scopedSql) => `SELECT * FROM (${scopedSql}) AS _validate LIMIT 0`,
     }
   );

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -15,11 +15,8 @@ import { executeDataSources } from '../utils/execute-data-sources';
  * will at run time: an entity-bound Behavior validates its `{{entityId}}` source
  * cleanly, while an ORG-SCOPED Behavior (no entity_ids) leaves `{{entityId}}`
  * unresolved and is rejected here — the same source would fail on every runtime
- * read, so catching it at save is the point. `validateEntitySlugs` additionally
- * rejects a table ref that is neither a known table nor an existing entity_type
- * slug: without it, the scoped-query layer rewrites any unknown name into an
- * entity-type-slug CTE that matches 0 rows and never errors, so a TYPO'd table
- * would be accepted and run "healthy" forever with no content.
+ * read, so catching it at save is the point. `validateEntitySlugs` also rejects
+ * typoed table names that would otherwise compile as empty entity-type CTEs.
  */
 async function validateCustomSqlSource(
   sql: DbClient,


### PR DESCRIPTION
## Problem
PR #2088 validates a Behavior's custom-SQL source at save time by planning it `LIMIT 0` — that catches a bad **column** (Postgres raises 42703). But a typo'd **table** name slipped through: the scoped-query layer rewrites any unrecognized table name into an entity_type-slug CTE (`SELECT … FROM entities WHERE et.slug = <name>`), which is valid SQL that matches 0 rows and never errors. So a Behavior with `SELECT id FROM evetns` was accepted and ran "healthy" forever with no content and no operator signal — the exact silent-failure class #2088 set out to close.

## Fix
Add an opt-in `validateEntitySlugs` option to `executeDataSources`. When set, any table ref that is neither a known queryable table nor an admin table (i.e. one that would compile to a slug CTE) must exist as an `entity_type` slug for the org, else it's rejected. Save-time validation (`validateCustomSqlSource`) turns it on; **runtime reads keep the permissive behavior** so a slug created *after* the Behavior still resolves (no behavior change at fire time).

Reuses the existing table classification (`QUERYABLE_TABLE_NAMES` / `ADMIN_ONLY_QUERYABLE_TABLES`) already computed in `executeDataSources` — no duplicate SQL parsing.

## red→green
`behavior-source-validation.test.ts` (7 tests, integration, green):
- rejects `SELECT id FROM evetns` → `unknown table or entity type: evetns`
- accepts `SELECT id FROM company` when `company` is a real `entity_type` slug (no over-rejection)
- all prior cases (bad column, {{entityId}} org-scoped rejection, create_version) still pass

## Not in scope (deliberate, separate follow-up)
The run-*time* source-error → health-degrade gap (a source that errors only at fire time is swallowed to empty; the fingerprint path logs + advances schedule with no run row) touches the run lifecycle and warrants its own focused PR. This PR closes the save-time typo class, which is the proper root-cause fix for the common case.

pre-pr (typecheck + knip + lint) green; server typecheck green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->