### PR TITLE
fix(events): reject mis-bound handler props in agent-authored templates

### DIFF
--- a/packages/server/src/__tests__/integration/events/agent-interactive-event-roundtrip.test.ts
+++ b/packages/server/src/__tests__/integration/events/agent-interactive-event-roundtrip.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Integration test: an agent-authored INTERACTIVE event survives the full
+ * save → store → read-back chain with its render DSL intact.
+ *
+ * The existing neighbor (save-content-json-template.test.ts) pins the save-side
+ * *schema* checks (missing payload_template throws; a rootless template stores
+ * verbatim). What it does NOT cover is the thing that actually breaks in prod:
+ * a rich template authored by an agent — nested components, data bindings with
+ * `format` directives, `if`/`each` control flow — round-tripping through JSONB
+ * and back out of the read path with every node still byte-identical.
+ *
+ * WHY THIS MATTERS: payload_template is opaque JSONB. Any silent coercion
+ * (key reordering is fine; dropped keys, stringified numbers, or a collapsed
+ * `children` array are not) shows up only at render time in the browser, where
+ * the renderer degrades gracefully to *blank* — the failure is invisible
+ * server-side. Asserting deep-equality on read-back is what makes that class
+ * of regression fail here instead of silently rendering nothing.
+ *
+ * Vitest CI gap note (mirrors neighbors): runs locally / in the CI integration
+ * job against the pgvector DB via DATABASE_URL.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { ToolContext } from '../../../tools/registry';
+import { saveContent } from '../../../tools/save_content';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+/**
+ * A template shaped like something an agent would actually emit: a card with a
+ * header, a bound metric with a `format` directive, a conditional branch, and a
+ * loop over a list. Exercises every node kind the DSL defines (text, data, if,
+ * each, component) in one structure.
+ */
+const AGENT_TEMPLATE = {
+  root: {
+    type: 'card',
+    children: [
+      {
+        type: 'card-header',
+        children: [
+          { type: 'card-title', children: [{ type: 'text', content: 'Deal Review' }] },
+          {
+            type: 'card-description',
+            children: [{ type: 'data', path: 'company', fallback: 'Unknown' }],
+          },
+        ],
+      },
+      {
+        type: 'card-content',
+        children: [
+          // A bound scalar carrying an explicit display-format directive.
+          { type: 'data', path: 'valuation', format: 'currency' },
+          { type: 'data', path: 'closed_at', format: 'date' },
+          // Control flow: only render the badge when the deal is hot.
+          {
+            type: 'if',
+            condition: 'is_hot',
+            then: { type: 'badge', props: { variant: 'default' }, children: [{ type: 'text', content: 'Hot' }] },
+            else: { type: 'badge', props: { variant: 'secondary' }, children: [{ type: 'text', content: 'Cold' }] },
+          },
+          // Loop with the string-shorthand render form.
+          { type: 'each', items: 'signals', as: 'signal', render: '- {{signal}}' },
+          // Loop with a full node render form.
+          {
+            type: 'each',
+            items: 'owners',
+            as: 'owner',
+            render: { type: 'li', children: [{ type: 'data', path: 'owner.name' }] },
+          },
+        ],
+      },
+    ],
+  },
+} as const;
+
+const AGENT_DATA = {
+  company: 'Acme Corp',
+  valuation: 12_500_000,
+  closed_at: '2026-03-14',
+  is_hot: true,
+  signals: ['strong retention', 'net-new logos'],
+  owners: [{ name: 'Ada' }, { name: 'Grace' }],
+};
+
+describe('agent-authored interactive event > json_template round-trip', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let ctx: ToolContext;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Interactive Events Org' });
+    user = await createTestUser({ email: 'interactive-events@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:write'],
+    };
+  });
+
+  it('stores a rich agent template + data with every node preserved exactly', async () => {
+    const result = await saveContent(
+      {
+        payload_type: 'json_template',
+        payload_template: AGENT_TEMPLATE,
+        payload_data: AGENT_DATA,
+        semantic_type: 'content',
+        title: 'Deal Review card',
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx
+    );
+
+    expect(result.id).toBeGreaterThan(0);
+
+    const sql = getTestDb();
+    const rows = await sql`
+      SELECT payload_type, payload_template, payload_data FROM events WHERE id = ${result.id}
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].payload_type).toBe('json_template');
+
+    // The whole DSL tree survives JSONB verbatim — not merely "has a root".
+    // A dropped `children` array or a collapsed conditional would render blank
+    // in the browser with no server-side signal, so assert deep equality.
+    expect(rows[0].payload_template).toEqual(AGENT_TEMPLATE);
+
+    // Data must keep its TYPES: numbers must not come back stringified, or the
+    // `currency` format directive and any numeric comparison silently break.
+    const data = rows[0].payload_data as typeof AGENT_DATA;
+    expect(data).toEqual(AGENT_DATA);
+    expect(typeof data.valuation).toBe('number');
+    expect(data.is_hot).toBe(true);
+    expect(data.signals).toHaveLength(2);
+    expect(data.owners[0]?.name).toBe('Ada');
+  });
+
+  it('preserves an interactive button node with its action props', async () => {
+    // Buttons are the "interaction" half of the DSL: the props carry the action
+    // wiring, so a props object silently dropped or flattened would leave a
+    // dead button that still LOOKS rendered.
+    const template = {
+      root: {
+        type: 'card',
+        children: [
+          {
+            type: 'button',
+            props: { action: 'approve_deal', variant: 'default', dealId: '{{deal_id}}' },
+            children: [{ type: 'text', content: 'Approve' }],
+          },
+        ],
+      },
+    };
+
+    const result = await saveContent(
+      {
+        payload_type: 'json_template',
+        payload_template: template,
+        payload_data: { deal_id: 'deal-42' },
+        semantic_type: 'content',
+        title: 'Approval card',
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx
+    );
+
+    const sql = getTestDb();
+    const rows = await sql`
+      SELECT payload_template FROM events WHERE id = ${result.id}
+    `;
+    expect(rows[0].payload_template).toEqual(template);
+
+    // Drill into the exact props the click handler depends on.
+    const root = (rows[0].payload_template as { root: Record<string, any> }).root;
+    const button = root.children[0];
+    expect(button.type).toBe('button');
+    expect(button.props).toEqual({
+      action: 'approve_deal',
+      variant: 'default',
+      dealId: '{{deal_id}}',
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
@@ -2,18 +2,16 @@
  * Integration test: save_content payload_type='json_template' save-side schema.
  *
  * save_content (save_memory) validates the json_template contract at the
- * handler level (save_content.ts), AFTER the org write gate and after
- * `ensureMemberEntityType` (a DB write) — so this is necessarily a DB-backed
- * test, not a pure unit test.
+ * handler level after `ensureMemberEntityType` (a DB write), so this is
+ * necessarily a DB-backed test rather than a pure unit test.
  *
  * Pinned behavior:
  *   - payload_type='json_template' with NO payload_template → ToolUserError
  *     ("payload_template is required when payload_type is 'json_template'").
  *   - payload_type='json_template' WITH a payload_template that lacks a `root`
- *     key → the handler does NOT enforce template structure; the save
- *     SUCCEEDS and stores the template verbatim. (Structure is the renderer's
- *     problem — and the renderer degrades gracefully on malformed templates;
- *     see packages/owletto json-renderer/renderer.test.ts.)
+ *     key → the handler does not enforce template structure; the save succeeds
+ *     and stores the template verbatim.
+ *   - event-handler props must use the renderer's "@actionName" binding form.
  *
  * Vitest CI gap note (mirrors neighbors): runs locally / in the CI
  * integration job against the pgvector DB via DATABASE_URL.
@@ -73,9 +71,7 @@ describe('saveContent > json_template save-side schema', () => {
   });
 
   it('saves successfully when payload_template lacks a `root` key (no structural enforcement)', async () => {
-    // The handler only checks presence of payload_template, not its shape. A
-    // template missing `root` is accepted and stored verbatim; the renderer is
-    // responsible for graceful degradation at display time.
+    // A template missing `root` is accepted and stored verbatim.
     const result = await saveContent(
       {
         payload_type: 'json_template',
@@ -101,5 +97,23 @@ describe('saveContent > json_template save-side schema', () => {
     expect(rows[0].payload_type).toBe('json_template');
     expect(rows[0].payload_template).toMatchObject({ version: 1 });
     expect((rows[0].payload_template as Record<string, unknown>).root).toBeUndefined();
+  });
+
+  it('rejects a handler prop without an action binding', async () => {
+    await expect(
+      saveContent(
+        {
+          payload_type: 'json_template',
+          payload_template: {
+            root: { type: 'button', props: { onClick: 'approve' } },
+          },
+          payload_data: {},
+          semantic_type: 'content',
+          metadata: {},
+        } as never,
+        {} as never,
+        ctx
+      )
+    ).rejects.toThrow(/json_template\.root\.props\.onClick/);
   });
 });

--- a/packages/server/src/__tests__/unit/utils/validate-json-template.test.ts
+++ b/packages/server/src/__tests__/unit/utils/validate-json-template.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { validateJsonTemplate } from '../../../utils/validate-json-template';
+import {
+  validateJsonTemplate,
+  validateTemplateHandlers,
+} from '../../../utils/validate-json-template';
 
 describe('validateJsonTemplate', () => {
   describe('accepts valid templates', () => {
@@ -39,6 +42,7 @@ describe('validateJsonTemplate', () => {
         validateJsonTemplate({
           type: 'div',
           children: [
+            // biome-ignore lint/suspicious/noThenProperty: template DSL conditional branch.
             { type: 'if', condition: 'ok', then: { type: 'text', content: 'yes' } },
             { type: 'each', items: 'xs', as: 'x', render: '- {{x}}' },
           ],
@@ -99,6 +103,7 @@ describe('validateJsonTemplate', () => {
     });
 
     it('an if node without a condition or then', () => {
+      // biome-ignore lint/suspicious/noThenProperty: template DSL conditional branch.
       expect(() => validateJsonTemplate({ type: 'if', then: { type: 'text', content: 'a' } })).toThrow(/string `condition`/);
       expect(() => validateJsonTemplate({ type: 'if', condition: 'c' })).toThrow(/requires a `then`/);
     });
@@ -111,6 +116,50 @@ describe('validateJsonTemplate', () => {
       expect(() => validateJsonTemplate({ type: 'div', children: 'x' })).toThrow(/children must be an array/);
     });
 
+    it('a handler prop that does not bind an "@action"', () => {
+      expect(() =>
+        validateJsonTemplate({ type: 'button', props: { onClick: 'approve' } })
+      ).toThrow(/handler props must bind an action as "@actionName"/);
+      expect(() =>
+        validateJsonTemplate({ type: 'button', props: { onClick: '{{handler}}' } })
+      ).toThrow(/handler props must bind an action as "@actionName"/);
+      expect(() =>
+        validateJsonTemplate({ type: 'button', props: { onChange: 42 } })
+      ).toThrow(/handler props must bind an action as "@actionName"/);
+      expect(() =>
+        validateJsonTemplate({ type: 'button', props: { onClick: '@' } })
+      ).toThrow(/handler props must bind an action as "@actionName"/);
+      expect(() =>
+        validateJsonTemplate({ type: 'button', onClick: 'approve' })
+      ).toThrow(/json_template\.onClick/);
+    });
+
+    it('accepts a correctly bound handler prop', () => {
+      expect(() =>
+        validateJsonTemplate({ type: 'button', props: { onClick: '@approve' } })
+      ).not.toThrow();
+      expect(() =>
+        validateJsonTemplate({
+          type: 'button',
+          onClick: 'shadowed',
+          props: { onClick: '@approve' },
+        })
+      ).not.toThrow();
+      // Non-handler props are untouched — only /^on[A-Z]/ keys are constrained.
+      expect(() =>
+        validateJsonTemplate({ type: 'button', props: { once: 'yes', on: 'x' } })
+      ).not.toThrow();
+    });
+
+    it('reports the path of a nested handler failure', () => {
+      expect(() =>
+        validateJsonTemplate({
+          type: 'div',
+          children: [{ type: 'button', props: { onClick: 'nope' } }],
+        })
+      ).toThrow(/json_template\.children\[0\]\.props\.onClick/);
+    });
+
     it('reports the path of a nested failure', () => {
       expect(() =>
         validateJsonTemplate({
@@ -119,5 +168,32 @@ describe('validateJsonTemplate', () => {
         })
       ).toThrow(/json_template\.children\[0\]\.children\[0\]/);
     });
+  });
+});
+
+describe('validateTemplateHandlers', () => {
+  it('accepts wrapper and bare-root storage shapes', () => {
+    expect(() =>
+      validateTemplateHandlers({ root: { type: 'button', props: { onClick: '@approve' } } })
+    ).not.toThrow();
+    expect(() =>
+      validateTemplateHandlers({ type: 'button', onClick: '@approve' })
+    ).not.toThrow();
+  });
+
+  it('validates flat and nested component handler props', () => {
+    expect(() =>
+      validateTemplateHandlers({ root: { type: 'button', onClick: 'approve' } })
+    ).toThrow(/json_template\.root\.onClick/);
+    expect(() =>
+      validateTemplateHandlers({
+        root: {
+          type: 'if',
+          condition: 'ready',
+          // biome-ignore lint/suspicious/noThenProperty: template DSL conditional branch.
+          then: { type: 'button', props: { onClick: '@' } },
+        },
+      })
+    ).toThrow(/json_template\.root\.then\.props\.onClick/);
   });
 });

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -26,6 +26,7 @@ import {
 } from '../utils/org-guidance';
 import { ensureMemberEntityType } from '../utils/member-entity-type';
 import { requireWriteAccess } from '../utils/organization-access';
+import { validateTemplateHandlers } from '../utils/validate-json-template';
 import { trackWatcherReaction } from '../utils/watcher-reactions';
 import { isSystemContext } from './access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from './constants';
@@ -240,6 +241,15 @@ async function saveContentImpl(
   }
   if (payloadType === 'json_template' && !args.payload_template) {
     throw new ToolUserError("payload_template is required when payload_type is 'json_template'");
+  }
+  // Events retain their existing permissive template shape, but handler values
+  // must use the renderer's action-binding syntax.
+  if (payloadType === 'json_template') {
+    try {
+      validateTemplateHandlers(args.payload_template);
+    } catch (err) {
+      throw new ToolUserError((err as Error).message, 422);
+    }
   }
 
   // 1. Require write access for each entity

--- a/packages/server/src/utils/validate-json-template.ts
+++ b/packages/server/src/utils/validate-json-template.ts
@@ -5,8 +5,8 @@
  * WHY server-side: storage is opaque JSONB, so without this a malformed template
  * saves fine and fails silently at render (in the browser). This validates the
  * invariants that actually cause silent breakage — node shape, required fields
- * per node type, and the `format` enum on data bindings — so authoring fails
- * FAST with a path-qualified error.
+ * per node type, handler bindings, and the `format` enum on data bindings — so
+ * authoring fails FAST with a path-qualified error.
  *
  * WHAT IT DOESN'T DO (on purpose): it does NOT allowlist component `type`
  * strings. The renderer's component set is extended app-side (entity-board,
@@ -39,6 +39,38 @@ function fail(path: string, message: string): never {
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
 	return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function validateHandlerProps(
+	props: Record<string, unknown>,
+	path: string,
+	shadowedKeys?: Set<string>,
+): void {
+	for (const [key, value] of Object.entries(props)) {
+		if (shadowedKeys?.has(key) || !/^on[A-Z]/.test(key)) continue;
+		if (typeof value !== "string" || !value.startsWith("@") || value.length === 1) {
+			fail(
+				`${path}.${key}`,
+				`handler props must bind an action as "@actionName" (got ${
+					typeof value === "string" ? `"${value}"` : typeof value
+				})`,
+			);
+		}
+	}
+}
+
+function validateComponentHandlers(
+	node: Record<string, unknown>,
+	path: string,
+): void {
+	// The renderer accepts both flat props and an explicit `props` bag.
+	const explicitProps = isPlainObject(node.props) ? node.props : undefined;
+	validateHandlerProps(
+		node,
+		path,
+		explicitProps ? new Set(Object.keys(explicitProps)) : undefined,
+	);
+	if (explicitProps) validateHandlerProps(explicitProps, `${path}.props`);
 }
 
 function validateNode(node: unknown, path: string): void {
@@ -104,13 +136,14 @@ function validateNode(node: unknown, path: string): void {
 			if (node.props !== undefined && !isPlainObject(node.props)) {
 				fail(`${path}.props`, "props must be an object");
 			}
+			validateComponentHandlers(node, path);
 			if (node.children !== undefined) {
 				if (!Array.isArray(node.children)) {
 					fail(`${path}.children`, "children must be an array of nodes");
 				}
-				node.children.forEach((child, i) =>
-					validateNode(child, `${path}.children[${i}]`),
-				);
+				node.children.forEach((child, i) => {
+					validateNode(child, `${path}.children[${i}]`);
+				});
 			}
 			return;
 		}
@@ -138,6 +171,39 @@ export function validateJsonTemplate(template: unknown): void {
 		);
 	}
 	validateNode(template, "");
+}
+
+/** Validate handler bindings without imposing a storage shape on the template. */
+export function validateTemplateHandlers(template: unknown): void {
+	if (!isPlainObject(template)) return;
+	if ("type" in template) {
+		walkHandlers(template, "");
+	} else if (isPlainObject(template.root)) {
+		walkHandlers(template.root, ".root");
+	}
+}
+
+function walkHandlers(node: unknown, path: string): void {
+	if (!isPlainObject(node)) return;
+	if (node.type === "if") {
+		walkHandlers(node.then, `${path}.then`);
+		if (node.else !== undefined) walkHandlers(node.else, `${path}.else`);
+		return;
+	}
+	if (node.type === "each") {
+		if (typeof node.render !== "string") {
+			walkHandlers(node.render, `${path}.render`);
+		}
+		return;
+	}
+	if (node.type === "text" || node.type === "data") return;
+
+	validateComponentHandlers(node, path);
+	if (Array.isArray(node.children)) {
+		node.children.forEach((child, i) => {
+			walkHandlers(child, `${path}.children[${i}]`);
+		});
+	}
 }
 
 export { VALUE_FORMATS };


### PR DESCRIPTION
## What

Agents create interactive events via `save_content({ payload_type: 'json_template' })`. Two defects made a mis-bound handler fail silently — or loudly in the wrong way.

**1. The renderer crashed the card (owletto).** An `on*` prop that didn't resolve to a function was forwarded straight to the DOM. React threw `Expected onClick listener to be a function` on the first click, taking down the whole event card — the opposite of this renderer's degrade-gracefully contract. Non-function handlers are now dropped with a warning naming the fix.

**2. Nothing validated the binding at save time (server).** A template written `onClick: "approve"` (missing the `@` that names a host action) stored fine and rendered a control that silently did nothing.

## Where the rule lives

Handler binding is a *renderer contract*, not a view-template *storage convention*, so it went into a shared entrypoint rather than being duplicated:

- `validateJsonTemplate` (manage_view_templates) keeps enforcing view-template storage rules (bare root node) as before.
- `validateTemplateHandlers` is shape-agnostic — accepts a bare node **or** a `{ root }` wrapper and checks only the handler rule, so `save_content` adopts it **without** inheriting view-template storage rules.

The pinned "a rootless template still saves" behavior is unchanged. Covers flat props as well as the explicit `props` bag (the renderer accepts both) and rejects a bare `"@"`.

## Testing

Red→green verified: the validator tests fail against the unmodified validator (2 fail), pass after.

| Suite | Result |
|---|---|
| server events integration (DB-backed) | 136 passed |
| server unit | 2589 passed |
| owletto | 744 passed |
| `make pre-pr` | clean |

Also adds a DB-backed round-trip test asserting a rich agent template survives JSONB byte-identically. A dropped `children` array or a stringified number renders blank in the browser with **no server-side signal**, so deep equality is what makes that class of regression fail in CI rather than silently.

## Not included

Event cards still pass no `actions` map to `JsonRenderer`, so template buttons remain display-only. Wiring executable actions is a product decision with its own security surface (agent-authored JSONB triggering a state change) and nothing authors handler props today — deliberately left out of this fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->