### PR TITLE
test(server): bind proxy tests to ephemeral ports to kill EADDRINUSE flake

### DIFF
--- a/packages/server/src/__tests__/unit/http/proxy-ssrf-hardening.test.ts
+++ b/packages/server/src/__tests__/unit/http/proxy-ssrf-hardening.test.ts
@@ -9,6 +9,7 @@ import {
   startHttpProxy,
   stopHttpProxy,
 } from "../../../gateway/proxy/http-proxy.js";
+import { withFreePortRetry } from "../../setup/free-port.js";
 
 // SSRF / network-proxy hardening regression coverage.
 //
@@ -28,8 +29,13 @@ let proxyServer: http.Server;
 beforeAll(async () => {
   process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
   process.env.WORKER_ALLOWED_DOMAINS = "*";
-  proxyPort = 10000 + Math.floor(Math.random() * 50000);
-  proxyServer = await startHttpProxy(proxyPort, "127.0.0.1");
+  // Ask the OS for a free port and retry on collision instead of gambling on a
+  // random high port — concurrent test load otherwise races to EADDRINUSE (#976).
+  proxyServer = await withFreePortRetry(async (port) => {
+    const server = await startHttpProxy(port, "127.0.0.1");
+    proxyPort = port;
+    return server;
+  });
 });
 
 afterAll(async () => {

--- a/packages/server/src/gateway/__tests__/http-proxy-judge.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy-judge.test.ts
@@ -7,6 +7,7 @@ import type { GrantStore } from "../permissions/grant-store.js";
 import { PolicyStore } from "../permissions/policy-store.js";
 import { EgressJudge } from "../proxy/egress-judge/judge.js";
 import type { JudgeClient, JudgeVerdict } from "../proxy/egress-judge/types.js";
+import { withFreePortRetry } from "../../__tests__/setup/free-port.js";
 import {
   __testOnly,
   setProxyEgressJudge,
@@ -70,8 +71,13 @@ beforeAll(async () => {
     new EgressJudge({ client: fakeClient, defaultModel: "judge-test-model" })
   );
 
-  proxyPort = 10000 + Math.floor(Math.random() * 50000);
-  proxyServer = await startHttpProxy(proxyPort, "127.0.0.1");
+  // Ask the OS for a free port and retry on collision instead of gambling on a
+  // random high port — concurrent test load otherwise races to EADDRINUSE (#976).
+  proxyServer = await withFreePortRetry(async (port) => {
+    const server = await startHttpProxy(port, "127.0.0.1");
+    proxyPort = port;
+    return server;
+  });
 });
 
 afterAll(async () => {

--- a/packages/server/src/gateway/__tests__/http-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy.test.ts
@@ -24,6 +24,7 @@ import {
   startHttpProxy,
   stopHttpProxy,
 } from "../proxy/http-proxy.js";
+import { getFreePort, withFreePortRetry } from "../../__tests__/setup/free-port.js";
 
 // Generate a stable 32-byte encryption key for tests
 const TEST_ENCRYPTION_KEY = crypto.randomBytes(32).toString("base64");
@@ -46,8 +47,13 @@ beforeAll(async () => {
   // module/env — no ordering dependence, no reset needed.
   process.env.WORKER_ALLOWED_DOMAINS = "*";
 
-  proxyPort = 10000 + Math.floor(Math.random() * 50000);
-  proxyServer = await startHttpProxy(proxyPort, "127.0.0.1");
+  // Ask the OS for a free port and retry on collision instead of gambling on a
+  // random high port — concurrent test load otherwise races to EADDRINUSE (#976).
+  proxyServer = await withFreePortRetry(async (port) => {
+    const server = await startHttpProxy(port, "127.0.0.1");
+    proxyPort = port;
+    return server;
+  });
 });
 
 afterAll(async () => {
@@ -327,7 +333,7 @@ describe("HTTP Proxy Authentication", () => {
 
 describe("HTTP Proxy Startup", () => {
   test("rejects on port conflict (EADDRINUSE)", async () => {
-    const blockingPort = 10000 + Math.floor(Math.random() * 50000);
+    const blockingPort = await getFreePort("127.0.0.1");
     const blocker = http.createServer();
     await new Promise<void>((resolve) =>
       blocker.listen(blockingPort, "127.0.0.1", resolve)
@@ -345,13 +351,17 @@ describe("HTTP Proxy Startup", () => {
   });
 
   test("binds to specified host and port", async () => {
-    const port = 10000 + Math.floor(Math.random() * 50000);
-    const server = await startHttpProxy(port, "127.0.0.1");
+    let boundPort = 0;
+    const server = await withFreePortRetry(async (port) => {
+      const s = await startHttpProxy(port, "127.0.0.1");
+      boundPort = port;
+      return s;
+    });
     try {
       const addr = server.address();
       expect(addr).not.toBeNull();
       if (typeof addr === "object" && addr) {
-        expect(addr.port).toBe(port);
+        expect(addr.port).toBe(boundPort);
         expect(addr.address).toBe("127.0.0.1");
       }
     } finally {

--- a/packages/server/src/gateway/__tests__/multi-tenant-isolation-reproducers.test.ts
+++ b/packages/server/src/gateway/__tests__/multi-tenant-isolation-reproducers.test.ts
@@ -43,6 +43,7 @@ import {
   resetTestDatabase,
   seedAgentRow,
 } from "./helpers/db-setup.js";
+import { withFreePortRetry } from "../../__tests__/setup/free-port.js";
 
 // ─── Finding 3: PolicyStore cross-tenant clobbering ──────────────────────────
 
@@ -388,8 +389,14 @@ describe("[finding 2] GrantStore queries scope to caller's organization id", () 
     );
     setProxyGrantStore(store);
 
-    const proxyPort = 10000 + Math.floor(Math.random() * 50000);
-    const proxyServer = await startHttpProxy(proxyPort, "127.0.0.1");
+    // Ask the OS for a free port and retry on collision instead of gambling on
+    // a random high port — concurrent test load otherwise races to EADDRINUSE
+    // (#976).
+    let proxyPort = 0;
+    const proxyServer = await withFreePortRetry(async (port) => {
+      proxyPort = port;
+      return startHttpProxy(port, "127.0.0.1");
+    });
 
     try {
       // Mint an org-B token claiming `shared-agent-id`.

--- a/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
@@ -565,8 +565,14 @@ describe("CRLF injection prevention in judge-provided reason", () => {
       })
     );
 
-    proxyPort = 10000 + Math.floor(Math.random() * 50000);
-    proxyServer = await startHttpProxy(proxyPort, "127.0.0.1");
+    // Ask the OS for a free port and retry on collision instead of gambling on
+    // a random high port — concurrent test load otherwise races to EADDRINUSE
+    // (#976).
+    proxyServer = await withFreePortRetry(async (port) => {
+      const server = await startHttpProxy(port, "127.0.0.1");
+      proxyPort = port;
+      return server;
+    });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Why

The `integration` CI job flakes intermittently on the gateway proxy suites with `EADDRINUSE`. On release PR #2063 it failed in `http-proxy-judge.test.ts`; a prior autofix pass hit the same class in `multi-tenant-isolation-reproducers.test.ts`. It is a pure test-harness flake (issue #976), not a product bug.

The suites picked a random high port and bound `startHttpProxy` to it:

```ts
proxyPort = 10000 + Math.floor(Math.random() * 50000);
proxyServer = await startHttpProxy(proxyPort, "127.0.0.1");
```

Under concurrent `bun test` / `vitest` load, two suites roll the same port and the second `listen` throws `EADDRINUSE`. When start rejects, `afterAll`'s `stopHttpProxy(undefined)` then throws `undefined is not an object (evaluating 'server.close')`, so a single collision surfaces as two failures.

## What

The repo already codified the fix (`withFreePortRetry` / `getFreePort` in `src/__tests__/setup/free-port.ts`, asking the OS for a free port via `:0` and retrying on collision), but only one `beforeEach` in `proxy-hardening.test.ts` had been migrated. This extends that exact pattern to the remaining five sites so the whole class stops flaking:

```ts
proxyServer = await withFreePortRetry(async (port) => {
  const server = await startHttpProxy(port, "127.0.0.1");
  proxyPort = port;
  return server;
});
```

The two startup cases in `http-proxy.test.ts` keep their intent: the EADDRINUSE-conflict test now binds its blocker to a `getFreePort()` port before asserting `startHttpProxy` rejects on it, and the "binds to specified host and port" test asserts against the actual `withFreePortRetry`-assigned port.

No product code changes; test harness only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved HTTP proxy test reliability by allocating available ports through the operating system.
  * Added retry handling to reduce failures caused by port conflicts during concurrent test runs.
  * Preserved existing coverage for proxy security, authentication, startup, isolation, and request-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->