### PR TITLE
fix(behaviors): don't drop sources when only the prompt text is edited

### DIFF
--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -335,7 +335,7 @@ export const ManageBehaviorsSchema = Type.Object(
     sources: Type.Optional(
       Type.Array(SourceSchema, {
         description:
-          "[create/create_version] Array of SQL data sources. Each source is { name, query }. Sources are version-owned — to change them on an existing Behavior, publish a new version with action: 'create_version'. On create_version this is a FULL REPLACEMENT: the array you pass (even []) becomes the version's complete source set. Passing [] clears all sources; OMITTING sources inherits the prior version's (unless the prompt was edited, in which case sources derive from the prompt's @-mention chips). The response returns source_count and removed_sources so you can see what a replacement dropped.",
+          "[create/create_version] Array of SQL data sources. Each source is { name, query }. Sources are version-owned — to change them on an existing Behavior, publish a new version with action: 'create_version'. On create_version this is a FULL REPLACEMENT: the array you pass (even []) becomes the version's complete source set. Passing [] clears all sources; OMITTING sources inherits the prior version's — including when you edit the prompt as plain text, so rewording a prompt never drops its sources. Sources derive from the prompt's @-mention chips only when the new prompt contains such chips (or the previous prompt did, so removing the last chip clears its derived source). The response returns source_count and removed_sources so you can see what a replacement dropped.",
       })
     ),
     keying_config: Type.Optional(

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
@@ -318,15 +318,14 @@ describe("manage_behaviors update — version-owned fields are not silently drop
 
 /**
  * #2048 — create_version source semantics: explicit-set REPLACES (even []),
- * omitting INHERITS, prompt-edit derives from the prompt's @-chips. The bug was
- * that `sources: []` (or a different list) passed WITHOUT a prompt edit was
- * conflated with "omitted" and silently re-inherited the stored sources.
+ * omitting INHERITS, and edits to source-token prompts derive from those tokens.
+ * The bug was that `sources: []` (or a different list) passed WITHOUT a prompt
+ * edit was conflated with "omitted" and silently re-inherited the stored sources.
  *
  * red→green: before the fix, "explicitly clears" and "explicitly replaces" both
  * inherited the original sources; after, the passed list is authoritative.
  */
 describe("manage_behaviors create_version — source replacement semantics (#2048)", () => {
-	let orgId: string;
 	let ownerCtx: AuthContext;
 	let behaviorId: string;
 
@@ -359,7 +358,6 @@ describe("manage_behaviors create_version — source replacement semantics (#204
 		await cleanupTestDatabase();
 		await initWorkspaceProvider();
 		const org = await createTestOrganization({ name: "cv sources #2048" });
-		orgId = org.id;
 		const owner = await createTestUser({ email: "cv-owner@test.com" });
 		await addUserToOrganization(owner.id, org.id, "owner");
 		ownerCtx = baseCtx(org.id, owner.id);
@@ -392,6 +390,26 @@ describe("manage_behaviors create_version — source replacement semantics (#204
 	it("baseline: the created behavior has the two explicit sources", async () => {
 		const names = (await fetchSources()).map((s) => s.name).sort();
 		expect(names).toEqual(["alpha", "beta"]);
+	});
+
+	it("preserves stored sources when only plain prompt text changes", async () => {
+		const result = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				prompt: "Analyze the data concisely.",
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { source_count?: number; removed_sources?: string[] };
+
+		expect(result.source_count).toBe(2);
+		expect(result.removed_sources).toBeUndefined();
+		expect((await fetchSources()).map((source) => source.name).sort()).toEqual([
+			"alpha",
+			"beta",
+		]);
 	});
 
 	it("omitting sources on a metadata-only bump INHERITS the stored sources", async () => {
@@ -444,113 +462,10 @@ describe("manage_behaviors create_version — source replacement semantics (#204
 		expect(res.removed_sources).toEqual(["alpha"]);
 		expect(await fetchSources()).toEqual([]);
 	});
-});
 
-/**
- * Editing ONLY the prompt must not silently delete the sources.
- *
- * `promptEdited` keyed purely on `args.prompt !== undefined`, so any prompt edit
- * took the derive-from-`@`-chips branch. That branch is only meaningful for a
- * chip-authored prompt: for a plain-text prompt `extractSourcesFromPromptTokens`
- * returns [], so a caller bumping just the wording had every source wiped with no
- * error — the Behavior then ran forever against no data. Deriving may only
- * REPLACE sources when the new prompt actually carries chips; a chip-free prompt
- * edit is a metadata edit and inherits.
- */
-describe("manage_behaviors create_version — prompt-only edit preserves sources", () => {
-	let ownerCtx: AuthContext;
-	let behaviorId: string;
-
-	async function fetchSources(): Promise<Array<{ name: string; query: string }>> {
-		const sql = getTestDb();
-		const rows = await sql`SELECT sources FROM watchers WHERE id = ${behaviorId}`;
-		return ((rows[0] as { sources: unknown }).sources ?? []) as Array<{
-			name: string;
-			query: string;
-		}>;
-	}
-
-	beforeAll(async () => {
-		await cleanupTestDatabase();
-		await initWorkspaceProvider();
-		const org = await createTestOrganization({ name: "cv prompt-only" });
-		const owner = await createTestUser({ email: "cv-prompt@test.com" });
-		await addUserToOrganization(owner.id, org.id, "owner");
-		ownerCtx = {
-			organizationId: org.id,
-			tokenOrganizationId: org.id,
-			userId: owner.id,
-			memberRole: "owner",
-			agentId: null,
-			requestedAgentId: null,
-			isAuthenticated: true,
-			clientId: null,
-			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
-			tokenType: "oauth",
-			requestUrl: `http://localhost/api/${org.id}`,
-			baseUrl: "",
-			scopedToOrg: true,
-			allowCrossOrg: false,
-		};
-		const agent = await createTestAgent({
-			organizationId: org.id,
-			agentId: "cv-prompt-agent",
-			ownerUserId: owner.id,
-		});
-		const created = (await executeTool(
-			"manage_behaviors",
-			{
-				action: "create",
-				slug: "cv-prompt-target",
-				name: "CV Prompt Target",
-				prompt: "Summarize the data.",
-				agent_id: agent.agentId,
-				sources: [{ name: "alpha", query: "SELECT id FROM events" }],
-			},
-			TEST_ENV,
-			ownerCtx,
-		)) as { behavior_id?: string };
-		behaviorId = created.behavior_id!;
-	});
-
-	it("a chip-free prompt edit INHERITS the stored sources instead of clearing them", async () => {
-		const res = (await executeTool(
-			"manage_behaviors",
-			{
-				action: "create_version",
-				behavior_id: behaviorId,
-				prompt: "Summarize the data, but more concisely.",
-			},
-			TEST_ENV,
-			ownerCtx,
-		)) as { source_count?: number; removed_sources?: string[] };
-		expect(res.source_count).toBe(1);
-		expect(res.removed_sources).toBeUndefined();
-		expect((await fetchSources()).map((s) => s.name)).toEqual(["alpha"]);
-	});
-
-	it("a chip-free prompt edit WITH explicit sources still replaces", async () => {
-		const res = (await executeTool(
-			"manage_behaviors",
-			{
-				action: "create_version",
-				behavior_id: behaviorId,
-				prompt: "Summarize differently.",
-				sources: [{ name: "gamma", query: "SELECT id FROM events WHERE 1=0" }],
-			},
-			TEST_ENV,
-			ownerCtx,
-		)) as { source_count?: number; removed_sources?: string[] };
-		expect(res.source_count).toBe(1);
-		expect((await fetchSources()).map((s) => s.name)).toEqual(["gamma"]);
-	});
-
-	it("a prompt edit that REMOVES a chip still drops that chip's source", async () => {
-		// Chip-authored prompt: the chips are authoritative, so dropping one must
-		// drop its source. This is the behavior the derive branch exists for and
-		// must survive the fix.
+	it("removes the derived source when the last source token is removed", async () => {
 		const chip = `@[sql:s1:Recent](#sql=${encodeURIComponent("SELECT id FROM events WHERE 1=0")})`;
-		const withChip = (await executeTool(
+		await executeTool(
 			"manage_behaviors",
 			{
 				action: "create_version",
@@ -559,8 +474,7 @@ describe("manage_behaviors create_version — prompt-only edit preserves sources
 			},
 			TEST_ENV,
 			ownerCtx,
-		)) as { source_count?: number };
-		expect(withChip.source_count).toBe(1);
+		);
 		expect((await fetchSources()).map((s) => s.name)).toEqual(["recent"]);
 
 		const chipRemoved = (await executeTool(

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
@@ -445,3 +445,136 @@ describe("manage_behaviors create_version — source replacement semantics (#204
 		expect(await fetchSources()).toEqual([]);
 	});
 });
+
+/**
+ * Editing ONLY the prompt must not silently delete the sources.
+ *
+ * `promptEdited` keyed purely on `args.prompt !== undefined`, so any prompt edit
+ * took the derive-from-`@`-chips branch. That branch is only meaningful for a
+ * chip-authored prompt: for a plain-text prompt `extractSourcesFromPromptTokens`
+ * returns [], so a caller bumping just the wording had every source wiped with no
+ * error — the Behavior then ran forever against no data. Deriving may only
+ * REPLACE sources when the new prompt actually carries chips; a chip-free prompt
+ * edit is a metadata edit and inherits.
+ */
+describe("manage_behaviors create_version — prompt-only edit preserves sources", () => {
+	let ownerCtx: AuthContext;
+	let behaviorId: string;
+
+	async function fetchSources(): Promise<Array<{ name: string; query: string }>> {
+		const sql = getTestDb();
+		const rows = await sql`SELECT sources FROM watchers WHERE id = ${behaviorId}`;
+		return ((rows[0] as { sources: unknown }).sources ?? []) as Array<{
+			name: string;
+			query: string;
+		}>;
+	}
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const org = await createTestOrganization({ name: "cv prompt-only" });
+		const owner = await createTestUser({ email: "cv-prompt@test.com" });
+		await addUserToOrganization(owner.id, org.id, "owner");
+		ownerCtx = {
+			organizationId: org.id,
+			tokenOrganizationId: org.id,
+			userId: owner.id,
+			memberRole: "owner",
+			agentId: null,
+			requestedAgentId: null,
+			isAuthenticated: true,
+			clientId: null,
+			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+			tokenType: "oauth",
+			requestUrl: `http://localhost/api/${org.id}`,
+			baseUrl: "",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+		};
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "cv-prompt-agent",
+			ownerUserId: owner.id,
+		});
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "cv-prompt-target",
+				name: "CV Prompt Target",
+				prompt: "Summarize the data.",
+				agent_id: agent.agentId,
+				sources: [{ name: "alpha", query: "SELECT id FROM events" }],
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { behavior_id?: string };
+		behaviorId = created.behavior_id!;
+	});
+
+	it("a chip-free prompt edit INHERITS the stored sources instead of clearing them", async () => {
+		const res = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				prompt: "Summarize the data, but more concisely.",
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { source_count?: number; removed_sources?: string[] };
+		expect(res.source_count).toBe(1);
+		expect(res.removed_sources).toBeUndefined();
+		expect((await fetchSources()).map((s) => s.name)).toEqual(["alpha"]);
+	});
+
+	it("a chip-free prompt edit WITH explicit sources still replaces", async () => {
+		const res = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				prompt: "Summarize differently.",
+				sources: [{ name: "gamma", query: "SELECT id FROM events WHERE 1=0" }],
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { source_count?: number; removed_sources?: string[] };
+		expect(res.source_count).toBe(1);
+		expect((await fetchSources()).map((s) => s.name)).toEqual(["gamma"]);
+	});
+
+	it("a prompt edit that REMOVES a chip still drops that chip's source", async () => {
+		// Chip-authored prompt: the chips are authoritative, so dropping one must
+		// drop its source. This is the behavior the derive branch exists for and
+		// must survive the fix.
+		const chip = `@[sql:s1:Recent](#sql=${encodeURIComponent("SELECT id FROM events WHERE 1=0")})`;
+		const withChip = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				prompt: `Look at ${chip} closely.`,
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { source_count?: number };
+		expect(withChip.source_count).toBe(1);
+		expect((await fetchSources()).map((s) => s.name)).toEqual(["recent"]);
+
+		const chipRemoved = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				prompt: "Look at nothing in particular.",
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { source_count?: number; removed_sources?: string[] };
+		expect(chipRemoved.source_count).toBe(0);
+		expect(chipRemoved.removed_sources).toEqual(["recent"]);
+		expect(await fetchSources()).toEqual([]);
+	});
+});

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -94,16 +94,23 @@ export async function handleCreateVersion(
   // `sources: []` used to be conflated with "omitted" and silently re-inherited
   // the stored sources. The three authoring intents, in precedence order:
   //
-  //   1. Prompt edited            → derive fresh from the new prompt's `@`-chips
-  //      (unioned with any explicit sources). The prompt is authoritative: a
-  //      deleted chip's source must NOT linger, an edited SQL chip must not keep
-  //      its OLD query under the same name (union-merge is monotonic, add-only),
-  //      so we derive fresh rather than union with stored.
-  //   2. `sources` passed (prompt not edited) → EXPLICIT replacement. The given
-  //      list is authoritative even when empty (`[]` clears). This is the fix:
+  //   1. CHIP-authored prompt edited → derive fresh from the new prompt's
+  //      `@`-chips (unioned with any explicit sources). The prompt is
+  //      authoritative: a deleted chip's source must NOT linger, an edited SQL
+  //      chip must not keep its OLD query under the same name (union-merge is
+  //      monotonic, add-only), so we derive fresh rather than union with stored.
+  //   2. `sources` passed → EXPLICIT replacement. The given list is
+  //      authoritative even when empty (`[]` clears). This is the fix:
   //      an API caller that passes sources means exactly that list.
-  //   3. Neither prompt nor sources supplied → INHERIT the stored sources, so a
-  //      metadata-only bump (schedule/name) preserves a legacy watcher's sources.
+  //   3. Neither a chip-authored prompt nor sources supplied → INHERIT the
+  //      stored sources, so a metadata-only bump (schedule/name) preserves a
+  //      legacy watcher's sources.
+  //
+  // Deriving keys on whether the prompt CARRIES chips, not merely on whether
+  // `prompt` was passed. A plain-text prompt yields no chips, so keying on
+  // `promptEdited` alone made "reword the prompt" silently delete every source
+  // and leave the Behavior running against no data. A chip-free prompt edit is
+  // a metadata edit; only a chip-bearing prompt is authoritative over sources.
   const promptSources = extractSourcesFromPromptTokens(prompt);
   const sourcesProvided = args.sources !== undefined;
   const explicitSources = args.sources ?? [];
@@ -111,11 +118,18 @@ export async function handleCreateVersion(
     watcherRows[0].sources,
     [] as Array<{ name: string; query: string }>
   );
-  const sources = promptEdited
-    ? mergePromptSources(explicitSources, promptSources)
-    : sourcesProvided
-      ? explicitSources
-      : storedSources;
+  // Chips are authoritative when the PREVIOUS prompt had them too: that is how
+  // removing the last chip still clears its source, without a plain-text reword
+  // of a never-chipped prompt clearing anything.
+  const promptIsChipAuthored =
+    promptSources.length > 0 ||
+    extractSourcesFromPromptTokens((prev.prompt as string) ?? '').length > 0;
+  const sources =
+    promptEdited && promptIsChipAuthored
+      ? mergePromptSources(explicitSources, promptSources)
+      : sourcesProvided
+        ? explicitSources
+        : storedSources;
   const keyingConfig =
     parseJsonInput<Record<string, unknown>>(args.keying_config, 'keying_config') ??
     normalizeStoredJsonField(prev.keying_config, undefined as Record<string, unknown> | undefined);

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -94,23 +94,15 @@ export async function handleCreateVersion(
   // `sources: []` used to be conflated with "omitted" and silently re-inherited
   // the stored sources. The three authoring intents, in precedence order:
   //
-  //   1. CHIP-authored prompt edited → derive fresh from the new prompt's
+  //   1. Source-token prompt edited → derive fresh from the new prompt's
   //      `@`-chips (unioned with any explicit sources). The prompt is
   //      authoritative: a deleted chip's source must NOT linger, an edited SQL
   //      chip must not keep its OLD query under the same name (union-merge is
   //      monotonic, add-only), so we derive fresh rather than union with stored.
-  //   2. `sources` passed → EXPLICIT replacement. The given list is
-  //      authoritative even when empty (`[]` clears). This is the fix:
-  //      an API caller that passes sources means exactly that list.
-  //   3. Neither a chip-authored prompt nor sources supplied → INHERIT the
-  //      stored sources, so a metadata-only bump (schedule/name) preserves a
-  //      legacy watcher's sources.
-  //
-  // Deriving keys on whether the prompt CARRIES chips, not merely on whether
-  // `prompt` was passed. A plain-text prompt yields no chips, so keying on
-  // `promptEdited` alone made "reword the prompt" silently delete every source
-  // and leave the Behavior running against no data. A chip-free prompt edit is
-  // a metadata edit; only a chip-bearing prompt is authoritative over sources.
+  //   2. `sources` passed without a source-token edit → EXPLICIT replacement.
+  //      The given list is authoritative even when empty (`[]` clears).
+  //   3. Neither a source-token edit nor sources supplied → INHERIT the stored
+  //      sources, so a metadata-only bump (schedule/name) preserves them.
   const promptSources = extractSourcesFromPromptTokens(prompt);
   const sourcesProvided = args.sources !== undefined;
   const explicitSources = args.sources ?? [];
@@ -118,14 +110,13 @@ export async function handleCreateVersion(
     watcherRows[0].sources,
     [] as Array<{ name: string; query: string }>
   );
-  // Chips are authoritative when the PREVIOUS prompt had them too: that is how
-  // removing the last chip still clears its source, without a plain-text reword
-  // of a never-chipped prompt clearing anything.
-  const promptIsChipAuthored =
-    promptSources.length > 0 ||
-    extractSourcesFromPromptTokens((prev.prompt as string) ?? '').length > 0;
+  // Include the previous prompt so removing its last token clears its source.
+  const previousPromptHadSourceTokens =
+    promptEdited && extractSourcesFromPromptTokens((prev.prompt as string) ?? '').length > 0;
+  const shouldDerivePromptSources =
+    promptEdited && (promptSources.length > 0 || previousPromptHadSourceTokens);
   const sources =
-    promptEdited && promptIsChipAuthored
+    shouldDerivePromptSources
       ? mergePromptSources(explicitSources, promptSources)
       : sourcesProvided
         ? explicitSources


### PR DESCRIPTION
## The bug

`create_version` decided whether to re-derive `sources` from the prompt's `@`-chips using only `args.prompt !== undefined`. So **any** prompt edit took the derive branch — including a plain-text one.

For a chip-free prompt `extractSourcesFromPromptTokens` returns `[]`, so rewording a prompt **silently deleted every source**. No error, no warning, `health` stays green — the Behavior just runs forever against no data.

Found by probing production directly:

```
createVersion({ behavior_id, prompt: "Summarize {{src}} differently." })
→ { source_count: 0, removed_sources: ["src"] }
```

The behavior had one working source before that call and none after, from an edit that never mentioned sources.

## The fix

Derive only when the prompt actually **carries** chips — or when the previous prompt did, so removing the last chip still clears its source. A chip-free prompt edit is a metadata edit and inherits stored sources, matching the `omitted → inherit` intent already documented for metadata bumps.

Explicit `sources` still replace (including `[]` to clear), so #2048 semantics are untouched.

## Evidence

red→green on the final code, verified by reverting just the guard to `promptEdited`:

- with guard → **15/15 pass**
- without guard → **3 fail** (`preserves stored sources when only plain prompt text changes` + 2 others)

Wider regression run: **198/198 across 26 files** (`integration/watchers`, `integration/behaviors`, source-validation, health-surfacing, approval-e2e). `make pre-pr` clean.

Three cases are pinned so the derive path isn't weakened: chip-free edit inherits, chip-removal still clears, explicit sources still replace.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->