### PR TITLE
fix(canvas): bind canvas entities to a built-in $canvas type, not $member

### DIFF
--- a/db/migrations/20260722010000_canvas_entity_type_backfill.sql
+++ b/db/migrations/20260722010000_canvas_entity_type_backfill.sql
@@ -1,0 +1,55 @@
+-- migrate:up
+
+-- Canvas entities were binding to an arbitrary entity type.
+--
+-- `ensureCanvasEntity` needs an entity_type_id (the column is NOT NULL). It
+-- looked for a type with slug 'canvas' and, finding none, fell back to "any
+-- stored type in the org, lowest id first". Nothing in the product ever creates
+-- a canvas type, so that fallback was the ONLY path in every org — and the
+-- lowest-id type is normally `$member`, which is provisioned first. So every
+-- canvas entity was typed as a workspace Member: it showed up in the member
+-- roster and inherited `$member`'s access policy (member-list visibility and
+-- email hiding).
+--
+-- The code now creates and binds a built-in `$canvas` type. This backfill moves
+-- the already-mislabeled rows onto it. Canvas entities are identified by
+-- metadata->>'source' = 'watcher_canvas', which `ensureCanvasEntity` has always
+-- written, so the selection is exact rather than name-matched.
+--
+-- `events` is untouched: entity_ids still point at the same entity ids, only the
+-- entity's type binding changes.
+
+-- 1. Ensure a `$canvas` type exists for every org that has canvas entities.
+--    Mirrors the on-demand insert in ensureCanvasEntity.
+INSERT INTO public.entity_types (
+  slug, name, description, icon, organization_id, created_at, updated_at
+)
+SELECT DISTINCT
+  '$canvas', 'Canvas', 'Per-Behavior canvas window', 'layout',
+  e.organization_id, current_timestamp, current_timestamp
+FROM public.entities e
+WHERE e.metadata->>'source' = 'watcher_canvas'
+  AND e.deleted_at IS NULL
+ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+DO NOTHING;
+
+-- 2. Repoint canvas entities at their org's `$canvas` type.
+UPDATE public.entities e
+SET entity_type_id = ct.id,
+    updated_at = current_timestamp
+FROM public.entity_types ct
+WHERE ct.slug = '$canvas'
+  AND ct.organization_id = e.organization_id
+  AND ct.deleted_at IS NULL
+  AND e.metadata->>'source' = 'watcher_canvas'
+  AND e.deleted_at IS NULL
+  AND e.entity_type_id IS DISTINCT FROM ct.id;
+
+-- migrate:down
+
+-- Irreversible by design: the pre-migration binding was an arbitrary
+-- lowest-id type that differed per org and was never recorded, so there is
+-- nothing faithful to restore. Rolling back the code is safe on its own —
+-- ensureCanvasEntity's reuse fast-path resolves canvases by their
+-- `watcher_canvas` identity claim, not by entity type.
+SELECT 1;

--- a/db/migrations/20260722010000_canvas_entity_type_backfill.sql
+++ b/db/migrations/20260722010000_canvas_entity_type_backfill.sql
@@ -1,20 +1,19 @@
 -- migrate:up
 
--- Canvas entities were binding to an arbitrary entity type.
+-- Canvas entities could bind to an unrelated entity type.
 --
 -- `ensureCanvasEntity` needs an entity_type_id (the column is NOT NULL). It
 -- looked for a type with slug 'canvas' and, finding none, fell back to "any
--- stored type in the org, lowest id first". Nothing in the product ever creates
--- a canvas type, so that fallback was the ONLY path in every org — and the
--- lowest-id type is normally `$member`, which is provisioned first. So every
--- canvas entity was typed as a workspace Member: it showed up in the member
--- roster and inherited `$member`'s access policy (member-list visibility and
--- email hiding).
+-- stored type in the org, lowest id first". Lobu does not provision that type,
+-- so most orgs took the fallback; the lowest-id type is commonly `$member`,
+-- which is provisioned early. Those canvas entities were typed as workspace
+-- Members: they showed up in the member roster and inherited `$member`'s access
+-- policy (member-list visibility and email hiding).
 --
 -- The code now creates and binds a built-in `$canvas` type. This backfill moves
 -- the already-mislabeled rows onto it. Canvas entities are identified by
--- metadata->>'source' = 'watcher_canvas', which `ensureCanvasEntity` has always
--- written, so the selection is exact rather than name-matched.
+-- a live `watcher_canvas` identity claim, the authoritative per-watcher canvas
+-- identity used by `ensureCanvasEntity`.
 --
 -- `events` is untouched: entity_ids still point at the same entity ids, only the
 -- entity's type binding changes.
@@ -28,8 +27,12 @@ SELECT DISTINCT
   '$canvas', 'Canvas', 'Per-Behavior canvas window', 'layout',
   e.organization_id, current_timestamp, current_timestamp
 FROM public.entities e
-WHERE e.metadata->>'source' = 'watcher_canvas'
-  AND e.deleted_at IS NULL
+JOIN public.entity_identities ei
+  ON ei.entity_id = e.id
+ AND ei.organization_id = e.organization_id
+ AND ei.namespace = 'watcher_canvas'
+ AND ei.deleted_at IS NULL
+WHERE e.deleted_at IS NULL
 ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
 DO NOTHING;
 
@@ -41,15 +44,22 @@ FROM public.entity_types ct
 WHERE ct.slug = '$canvas'
   AND ct.organization_id = e.organization_id
   AND ct.deleted_at IS NULL
-  AND e.metadata->>'source' = 'watcher_canvas'
   AND e.deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM public.entity_identities ei
+    WHERE ei.entity_id = e.id
+      AND ei.organization_id = e.organization_id
+      AND ei.namespace = 'watcher_canvas'
+      AND ei.deleted_at IS NULL
+  )
   AND e.entity_type_id IS DISTINCT FROM ct.id;
 
 -- migrate:down
 
--- Irreversible by design: the pre-migration binding was an arbitrary
--- lowest-id type that differed per org and was never recorded, so there is
--- nothing faithful to restore. Rolling back the code is safe on its own —
+-- Irreversible by design: the prior binding varied by org and this migration
+-- does not record it, so there is nothing faithful to restore. Rolling back the
+-- code is safe on its own —
 -- ensureCanvasEntity's reuse fast-path resolves canvases by their
 -- `watcher_canvas` identity claim, not by entity type.
 SELECT 1;

--- a/packages/server/src/__tests__/integration/authz/permissions-catalog-types.test.ts
+++ b/packages/server/src/__tests__/integration/authz/permissions-catalog-types.test.ts
@@ -6,7 +6,8 @@ import { createTestOrganization } from "../../setup/test-fixtures";
 /**
  * The /permissions type list must include public-catalog types (visibility=
  * 'public') the org can write entities for, deduped by slug (org-owned wins),
- * $member excluded. This exercises the exact query the endpoint runs.
+ * `$`-prefixed built-ins excluded. This exercises the exact query the endpoint
+ * runs — keep it in sync with `index.ts`.
  */
 async function listTypes(orgId: string) {
 	const sql = getTestDb();
@@ -16,7 +17,7 @@ async function listTypes(orgId: string) {
       FROM entity_types et
       LEFT JOIN organization o ON o.id = et.organization_id
       WHERE et.deleted_at IS NULL
-        AND et.slug <> '$member'
+        AND et.slug NOT LIKE '$%'
         AND (et.organization_id = ${orgId} OR o.visibility = 'public')
       ORDER BY et.slug, (et.organization_id = ${orgId}) DESC, et.id ASC
     ) t
@@ -69,5 +70,22 @@ describe("/permissions catalog type resolution", () => {
     `;
 		const types = await listTypes(orgId);
 		expect(types.map((t) => t.slug)).not.toContain("$member");
+	});
+
+	it("excludes every $-prefixed built-in, not just $member", async () => {
+		// The filter is by convention, not an enumerated list — a new built-in
+		// (here `$canvas`, which every Behavior canvas binds to) must stay out of
+		// the ACL picker without anyone remembering to add another `<>` clause.
+		await getTestDb()`
+      INSERT INTO entity_types (organization_id, slug, name)
+      VALUES (${orgId}, '$canvas', 'Canvas'),
+             (${orgId}, '$resource', 'Resource'),
+             (${orgId}, 'invoice', 'Invoice')
+    `;
+		const slugs = (await listTypes(orgId)).map((t) => t.slug);
+		expect(slugs).not.toContain("$canvas");
+		expect(slugs).not.toContain("$resource");
+		// Ordinary types are unaffected.
+		expect(slugs).toContain("invoice");
 	});
 });

--- a/packages/server/src/__tests__/integration/db/canvas-entity-type-backfill.test.ts
+++ b/packages/server/src/__tests__/integration/db/canvas-entity-type-backfill.test.ts
@@ -13,6 +13,8 @@
  *   - a real `$member` row does not move
  *   - a row that merely *claims* source=watcher_canvas in metadata, with no
  *     identity row, does not move
+ *   - a row whose only `watcher_canvas` identity is soft-deleted does not move
+ *     (the claim must be live: `deleted_at IS NULL`)
  *   - re-running is a no-op (migrations may be replayed)
  *   - exactly one `$canvas` type per org
  *
@@ -45,6 +47,7 @@ interface Captured {
   claimedCanvasSlug: string | null;
   realMemberSlug: string | null;
   metadataOnlySlug: string | null;
+  deletedIdentitySlug: string | null;
   canvasTypeCount: number;
   slugsAfterRerun: string[];
 }
@@ -64,6 +67,7 @@ describe('$canvas backfill migration', () => {
       claimedCanvasSlug: null,
       realMemberSlug: null,
       metadataOnlySlug: null,
+      deletedIdentitySlug: null,
       canvasTypeCount: 0,
       slugsAfterRerun: [],
     };
@@ -128,11 +132,31 @@ describe('$canvas backfill migration', () => {
           RETURNING id
         `;
 
+        // Held a `watcher_canvas` claim once, but it is now soft-deleted. The
+        // backfill matches only live claims (`deleted_at IS NULL`), so a stale
+        // claim must NOT move the entity; else replaying with historical rows
+        // would re-type former canvases.
+        const [deletedCanvas] = await tx<{ id: number }[]>`
+          INSERT INTO entities
+            (organization_id, entity_type_id, name, slug, metadata, created_by, created_at, updated_at)
+          VALUES (
+            ${orgId}, ${memberType.id}, 'Canvas · watcher 2', 'watcher-canvas-2',
+            ${tx.json({ watcher_id: 2, source: 'watcher_canvas' })},
+            ${user.id}, current_timestamp, current_timestamp
+          )
+          RETURNING id
+        `;
+        await tx`
+          INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, deleted_at)
+          VALUES (${orgId}, ${deletedCanvas.id}, 'watcher_canvas', '2', current_timestamp)
+        `;
+
         await tx.unsafe(upSection);
 
         result.claimedCanvasSlug = await slugOf(tx, canvas.id);
         result.realMemberSlug = await slugOf(tx, member.id);
         result.metadataOnlySlug = await slugOf(tx, impostor.id);
+        result.deletedIdentitySlug = await slugOf(tx, deletedCanvas.id);
 
         const typeRows = await tx<{ n: string }[]>`
           SELECT COUNT(*)::text AS n
@@ -147,6 +171,7 @@ describe('$canvas backfill migration', () => {
           (await slugOf(tx, canvas.id)) ?? '',
           (await slugOf(tx, member.id)) ?? '',
           (await slugOf(tx, impostor.id)) ?? '',
+          (await slugOf(tx, deletedCanvas.id)) ?? '',
         ];
 
         throw new Rollback();
@@ -170,11 +195,15 @@ describe('$canvas backfill migration', () => {
     expect(captured.metadataOnlySlug).toBe('$member');
   });
 
+  it('ignores an entity whose only watcher_canvas identity is soft-deleted', () => {
+    expect(captured.deletedIdentitySlug).toBe('$member');
+  });
+
   it('creates exactly one $canvas type for the org', () => {
     expect(captured.canvasTypeCount).toBe(1);
   });
 
   it('is idempotent across a replay', () => {
-    expect(captured.slugsAfterRerun).toEqual(['$canvas', '$member', '$member']);
+    expect(captured.slugsAfterRerun).toEqual(['$canvas', '$member', '$member', '$member']);
   });
 });

--- a/packages/server/src/__tests__/integration/db/canvas-entity-type-backfill.test.ts
+++ b/packages/server/src/__tests__/integration/db/canvas-entity-type-backfill.test.ts
@@ -1,0 +1,180 @@
+/**
+ * $canvas backfill migration (`20260722010000_canvas_entity_type_backfill.sql`).
+ *
+ * Canvas entities used to bind to whatever entity type had the lowest id in the
+ * org (usually `$member`, provisioned first), because nothing ever created the
+ * `canvas` type `ensureCanvasEntity` looked for. This migration repoints those
+ * rows onto a per-org `$canvas` type.
+ *
+ * Selection is by the live `watcher_canvas` identity claim — the authoritative
+ * per-watcher canvas identity — NOT by `metadata->>'source'`, which is
+ * user-editable. Proves:
+ *   - a claimed canvas moves to `$canvas`
+ *   - a real `$member` row does not move
+ *   - a row that merely *claims* source=watcher_canvas in metadata, with no
+ *     identity row, does not move
+ *   - re-running is a no-op (migrations may be replayed)
+ *   - exactly one `$canvas` type per org
+ *
+ * Runs inside a transaction we ROLL BACK so the shared integration DB is not
+ * permanently mutated.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { loadMigrationUpSection } from '../../../db/migration-loader';
+import { createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const MIGRATION = '20260722010000_canvas_entity_type_backfill.sql';
+
+function resolveMigrationsDir(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'db/migrations');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate db/migrations from the test directory');
+}
+
+interface Captured {
+  claimedCanvasSlug: string | null;
+  realMemberSlug: string | null;
+  metadataOnlySlug: string | null;
+  canvasTypeCount: number;
+  slugsAfterRerun: string[];
+}
+
+class Rollback extends Error {}
+
+describe('$canvas backfill migration', () => {
+  let captured: Captured;
+
+  beforeAll(async () => {
+    const orgId = (await createTestOrganization()).id;
+    const user = await createTestUser({ email: `canvas-bf-${Date.now()}@test.com` });
+    const sql = getDb();
+    const upSection = loadMigrationUpSection(resolveMigrationsDir(), MIGRATION);
+
+    const result: Captured = {
+      claimedCanvasSlug: null,
+      realMemberSlug: null,
+      metadataOnlySlug: null,
+      canvasTypeCount: 0,
+      slugsAfterRerun: [],
+    };
+
+    const slugOf = async (tx: typeof sql, entityId: number): Promise<string | null> => {
+      const rows = await tx<{ slug: string }[]>`
+        SELECT et.slug
+        FROM entities e
+        JOIN entity_types et ON et.id = e.entity_type_id
+        WHERE e.id = ${entityId}
+        LIMIT 1
+      `;
+      return rows[0]?.slug ?? null;
+    };
+
+    try {
+      await sql.begin(async (tx: typeof sql) => {
+        // `$member` is the lowest-id type in the org — the pre-fix fallback target.
+        const [memberType] = await tx<{ id: number }[]>`
+          INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+          VALUES (${orgId}, '$member', 'Member', current_timestamp, current_timestamp)
+          RETURNING id
+        `;
+
+        // A real canvas entity: mis-typed as $member AND holding the identity claim.
+        const [canvas] = await tx<{ id: number }[]>`
+          INSERT INTO entities
+            (organization_id, entity_type_id, name, slug, metadata, created_by, created_at, updated_at)
+          VALUES (
+            ${orgId}, ${memberType.id}, 'Canvas · watcher 1', 'watcher-canvas-1',
+            ${tx.json({ watcher_id: 1, source: 'watcher_canvas' })},
+            ${user.id}, current_timestamp, current_timestamp
+          )
+          RETURNING id
+        `;
+        await tx`
+          INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+          VALUES (${orgId}, ${canvas.id}, 'watcher_canvas', '1')
+        `;
+
+        // A genuine workspace member — must survive untouched.
+        const [member] = await tx<{ id: number }[]>`
+          INSERT INTO entities
+            (organization_id, entity_type_id, name, slug, metadata, created_by, created_at, updated_at)
+          VALUES (
+            ${orgId}, ${memberType.id}, 'Real Person', 'real-person',
+            ${tx.json({})}, ${user.id}, current_timestamp, current_timestamp
+          )
+          RETURNING id
+        `;
+
+        // Metadata claims canvas, but there is no identity row. Metadata is
+        // user-editable, so this must NOT be swept into the system type.
+        const [impostor] = await tx<{ id: number }[]>`
+          INSERT INTO entities
+            (organization_id, entity_type_id, name, slug, metadata, created_by, created_at, updated_at)
+          VALUES (
+            ${orgId}, ${memberType.id}, 'Fake Canvas', 'fake-canvas',
+            ${tx.json({ source: 'watcher_canvas' })},
+            ${user.id}, current_timestamp, current_timestamp
+          )
+          RETURNING id
+        `;
+
+        await tx.unsafe(upSection);
+
+        result.claimedCanvasSlug = await slugOf(tx, canvas.id);
+        result.realMemberSlug = await slugOf(tx, member.id);
+        result.metadataOnlySlug = await slugOf(tx, impostor.id);
+
+        const typeRows = await tx<{ n: string }[]>`
+          SELECT COUNT(*)::text AS n
+          FROM entity_types
+          WHERE organization_id = ${orgId} AND slug = '$canvas' AND deleted_at IS NULL
+        `;
+        result.canvasTypeCount = Number(typeRows[0]?.n ?? 0);
+
+        // Migrations may be replayed — a second run must change nothing.
+        await tx.unsafe(upSection);
+        result.slugsAfterRerun = [
+          (await slugOf(tx, canvas.id)) ?? '',
+          (await slugOf(tx, member.id)) ?? '',
+          (await slugOf(tx, impostor.id)) ?? '',
+        ];
+
+        throw new Rollback();
+      });
+    } catch (err) {
+      if (!(err instanceof Rollback)) throw err;
+    }
+
+    captured = result;
+  });
+
+  it('repoints a claimed canvas entity onto $canvas', () => {
+    expect(captured.claimedCanvasSlug).toBe('$canvas');
+  });
+
+  it('leaves a real $member entity alone', () => {
+    expect(captured.realMemberSlug).toBe('$member');
+  });
+
+  it('ignores an entity whose metadata claims canvas but holds no identity', () => {
+    expect(captured.metadataOnlySlug).toBe('$member');
+  });
+
+  it('creates exactly one $canvas type for the org', () => {
+    expect(captured.canvasTypeCount).toBe(1);
+  });
+
+  it('is idempotent across a replay', () => {
+    expect(captured.slugsAfterRerun).toEqual(['$canvas', '$member', '$member']);
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -247,7 +247,12 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     const promoted = childTypes.filter((r) => r.source !== 'watcher_canvas');
     expect(promoted).toHaveLength(2);
     expect(promoted.every((r) => String(r.slug) === 'topic')).toBe(true);
-    expect(childTypes.filter((r) => r.source === 'watcher_canvas')).toHaveLength(1);
+    const canvasChildren = childTypes.filter((r) => r.source === 'watcher_canvas');
+    expect(canvasChildren).toHaveLength(1);
+    // The canvas entity must carry the built-in `$canvas` type. It previously
+    // bound to whatever type had the lowest id in the org — in practice
+    // `$member` — so canvases showed up in the access-controlled member roster.
+    expect(String(canvasChildren[0].slug)).toBe('$canvas');
 
     // Origin provenance lives on the entity itself — each promoted child carries
     // its window_id / stable_key in metadata (no separate observation event).

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -249,9 +249,9 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect(promoted.every((r) => String(r.slug) === 'topic')).toBe(true);
     const canvasChildren = childTypes.filter((r) => r.source === 'watcher_canvas');
     expect(canvasChildren).toHaveLength(1);
-    // The canvas entity must carry the built-in `$canvas` type. It previously
-    // bound to whatever type had the lowest id in the org — in practice
-    // `$member` — so canvases showed up in the access-controlled member roster.
+    // The canvas entity must carry the built-in `$canvas` type. Without an
+    // explicitly created `canvas` type, the old fallback commonly bound it to
+    // `$member`, exposing it through the access-controlled member roster.
     expect(String(canvasChildren[0].slug)).toBe('$canvas');
 
     // Origin provenance lives on the entity itself — each promoted child carries

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1380,8 +1380,9 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 	// org's (visibility='public') — the same local-or-public resolution entity
 	// creation uses. The write gate keys on the slug, so a catalog-backed type
 	// (e.g. `company`) must be offerable as a per-type exception. Dedupe by slug,
-	// preferring the org-owned row, and drop `$member` (per-tenant, never a public
-	// catalog type) to mirror the entity-write resolver.
+	// preferring the org-owned row, and drop `$`-prefixed built-ins (`$member`,
+	// `$canvas`, … — per-tenant internals, never public catalog types nor
+	// something an operator grants access to) to mirror the entity-write resolver.
 	const typeRows = await getDb()<{
 		slug: string;
 		name: string;
@@ -1392,7 +1393,7 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
       FROM entity_types et
       LEFT JOIN organization o ON o.id = et.organization_id
       WHERE et.deleted_at IS NULL
-        AND et.slug <> '$member'
+        AND et.slug NOT LIKE '$%'
         AND (et.organization_id = ${organizationId} OR o.visibility = 'public')
       ORDER BY et.slug, (et.organization_id = ${organizationId}) DESC, et.id ASC
     ) t
@@ -1863,7 +1864,7 @@ app.get("/api/:orgSlug/write-permissions", mcpAuth, async (c) => {
       FROM entity_types et
       LEFT JOIN organization o ON o.id = et.organization_id
       WHERE et.deleted_at IS NULL
-        AND et.slug <> '$member'
+        AND et.slug NOT LIKE '$%'
         AND (et.organization_id = ${organizationId} OR o.visibility = 'public')
       ORDER BY et.slug, (et.organization_id = ${organizationId}) DESC, et.id ASC
     ) t

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1380,9 +1380,8 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 	// org's (visibility='public') — the same local-or-public resolution entity
 	// creation uses. The write gate keys on the slug, so a catalog-backed type
 	// (e.g. `company`) must be offerable as a per-type exception. Dedupe by slug,
-	// preferring the org-owned row, and drop `$`-prefixed built-ins (`$member`,
-	// `$canvas`, … — per-tenant internals, never public catalog types nor
-	// something an operator grants access to) to mirror the entity-write resolver.
+	// preferring the org-owned row. `$`-prefixed types are platform-managed
+	// system types, so omit them from operator-authored entity mutation policies.
 	const typeRows = await getDb()<{
 		slug: string;
 		name: string;

--- a/packages/server/src/tools/constants.ts
+++ b/packages/server/src/tools/constants.ts
@@ -8,6 +8,9 @@
 /** Slug of the built-in workspace-member entity type. */
 export const MEMBER_ENTITY_TYPE_SLUG = '$member';
 
+/** Slug of the built-in per-Behavior canvas entity type. */
+export const CANVAS_ENTITY_TYPE_SLUG = '$canvas';
+
 /** Semantic type of tombstone events that supersede "deleted" events. */
 export const TOMBSTONE_SEMANTIC_TYPE = 'tombstone';
 

--- a/packages/server/src/utils/canvas-events.ts
+++ b/packages/server/src/utils/canvas-events.ts
@@ -105,15 +105,9 @@ export async function ensureCanvasEntity(params: {
   }
 
   // Resolve the entity type to bind to (entities.entity_type_id is NOT NULL).
-  // The built-in `$canvas` type is org-owned and created on demand, so a canvas
-  // entity always carries a type that MEANS "canvas".
-  //
-  // This used to fall back to "any stored type in the org, lowest id first" when
-  // no type existed. Nothing ever provisions a canvas type, so that fallback was
-  // the only path — and the lowest-id type is `$member`, which made every canvas
-  // entity masquerade as a workspace Member. `$member` is access-controlled
-  // (member-list visibility, email hiding), so canvases were both polluting the
-  // member roster and inheriting a privileged type. Create the real type instead.
+  // The old fallback used any stored org type when no user-authored `canvas`
+  // type existed. That was commonly `$member`, exposing canvases through the
+  // member roster and its privacy policy. Create a dedicated system type.
   const typeRows = await tx<{ id: number | string }>`
     INSERT INTO entity_types (
       slug, name, description, icon, organization_id, created_at, updated_at

--- a/packages/server/src/utils/canvas-events.ts
+++ b/packages/server/src/utils/canvas-events.ts
@@ -25,6 +25,7 @@
  */
 
 import type { DbClient } from '../db/client';
+import { CANVAS_ENTITY_TYPE_SLUG } from '../tools/constants';
 
 /** Namespace for the per-watcher canvas identity claim in `entity_identities`. */
 export const WATCHER_CANVAS_NAMESPACE = 'watcher_canvas';
@@ -67,11 +68,10 @@ async function resolveCanvasCreator(
  * concurrent claim (ON CONFLICT DO NOTHING) and resolves the winner.
  *
  * The canvas entity is a child of the watcher's bound entity (`parentEntityId`)
- * when present, else a root entity. It uses the same `canvas` entity type as
- * other lazily-created system entities would; it falls back to no type binding
- * only if no `canvas` type is registered (entity_type_id is NOT NULL, so we pick
- * a sensible default). Runs on the caller's transaction handle so the entity +
- * identity writes commit atomically with the canvas event.
+ * when present, else a root entity. It binds to the built-in `$canvas` entity
+ * type, created on demand for the org (entity_type_id is NOT NULL). Runs on the
+ * caller's transaction handle so the entity + identity writes commit atomically
+ * with the canvas event.
  */
 export async function ensureCanvasEntity(params: {
   tx: DbClient;
@@ -104,36 +104,30 @@ export async function ensureCanvasEntity(params: {
     return null;
   }
 
-  // Resolve an entity type to bind to (entities.entity_type_id is NOT NULL).
-  // Prefer a `canvas` type (org-first, then public via organization.visibility,
-  // skipping view-backed derived types — same precedence as createEntity);
-  // otherwise fall back to any stored type in the org so the canvas entity can
-  // still be created and anchor the chain.
-  const typeRows = await tx<{ id: number | string; backing_sql: string | null }>`
-    SELECT et.id, et.backing_sql
-    FROM entity_types et
-    LEFT JOIN organization o ON o.id = et.organization_id
-    WHERE et.slug = 'canvas'
-      AND et.deleted_at IS NULL
-      AND (et.organization_id = ${organizationId} OR o.visibility = 'public')
-    ORDER BY (et.organization_id = ${organizationId}) DESC, et.id ASC
-    LIMIT 1
+  // Resolve the entity type to bind to (entities.entity_type_id is NOT NULL).
+  // The built-in `$canvas` type is org-owned and created on demand, so a canvas
+  // entity always carries a type that MEANS "canvas".
+  //
+  // This used to fall back to "any stored type in the org, lowest id first" when
+  // no type existed. Nothing ever provisions a canvas type, so that fallback was
+  // the only path — and the lowest-id type is `$member`, which made every canvas
+  // entity masquerade as a workspace Member. `$member` is access-controlled
+  // (member-list visibility, email hiding), so canvases were both polluting the
+  // member roster and inheriting a privileged type. Create the real type instead.
+  const typeRows = await tx<{ id: number | string }>`
+    INSERT INTO entity_types (
+      slug, name, description, icon, organization_id, created_at, updated_at
+    )
+    VALUES (
+      ${CANVAS_ENTITY_TYPE_SLUG}, 'Canvas', 'Per-Behavior canvas window', 'layout',
+      ${organizationId}, current_timestamp, current_timestamp
+    )
+    ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+    DO UPDATE SET updated_at = entity_types.updated_at
+    RETURNING id
   `;
-  let entityTypeId: number | null =
-    typeRows.length > 0 && !typeRows[0].backing_sql ? Number(typeRows[0].id) : null;
-  if (entityTypeId == null) {
-    const anyType = await tx<{ id: number | string }>`
-      SELECT et.id
-      FROM entity_types et
-      WHERE et.organization_id = ${organizationId}
-        AND et.deleted_at IS NULL
-        AND et.backing_sql IS NULL
-      ORDER BY et.id ASC
-      LIMIT 1
-    `;
-    if (anyType.length === 0) return null;
-    entityTypeId = Number(anyType[0].id);
-  }
+  if (typeRows.length === 0) return null;
+  const entityTypeId = Number(typeRows[0].id);
 
   // 2. Create the entity (sequence-allocated id — multi-replica safe). Slug is
   //    unique per (org, parent); a collision here is astronomically unlikely


### PR DESCRIPTION
Closes #2100.

## The bug

`ensureCanvasEntity` needs an `entity_type_id` (the column is NOT NULL). It looked for a type with slug `canvas` and, finding none, fell back to:

```sql
ORDER BY et.id ASC LIMIT 1   -- "any stored type in the org"
```

Nothing in the product ever provisions a canvas type, so that fallback was the **only** path. The lowest-id type is normally `$member`, which is provisioned first.

So every canvas entity was typed as a workspace Member — showing up in the member roster and inheriting `$member`'s access policy (member-list visibility, email hiding).

Prod evidence — `entities.list({ entity_type: "$member" })` returned 16 rows:

```
Canvas · watcher 34, Canvas · watcher 33, ... (15 of these)
Burak                 <- the only real member, buried at #15
```

## The fix

Create and bind a built-in `$canvas` type on demand. `ON CONFLICT ... DO UPDATE ... RETURNING` so a concurrent replica still gets the id back rather than an empty result.

Also switched the ACL type pickers from `slug <> '$member'` to `slug NOT LIKE '$%'` — fixing the class rather than the instance, so `$canvas` doesn't leak into the schema picker.

## Evidence

**red→green:** `promote-keyed-entities` already asserted a canvas child exists but never checked its *type* — the blind spot that let this ship. It now asserts `$canvas`. Against pre-fix code it fails with `expected 'brand' to be '$canvas'` (that org's lowest-id type is `brand`, which also shows the bug isn't `$member`-specific).

**Backfill** verified on a scratch DB from baseline:

| entity | has `watcher_canvas` claim | result |
|---|---|---|
| `Canvas · watcher 1` | yes | → `$canvas` |
| `Real Person` | no | untouched |
| `Fake Canvas` (metadata only, no claim) | no | untouched |

Re-running the migration is a no-op. It selects on the authoritative `entity_identities` claim rather than user-editable metadata, so a row that merely *claims* `source=watcher_canvas` is correctly left alone.

`events` is untouched — `entity_ids` still point at the same entity ids; only the type binding changes.

**Suites:** 290/290 across 34 files (`integration/watchers`, `integration/behaviors`, `integration/tools`). `make pre-pr` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Canvas entities are now identified using a dedicated built-in `$canvas` type.
  - Existing canvas entities are automatically repointed to this type.

- **Bug Fixes**
  - System entity types (all `$*`) are no longer shown in agent and write-permission type listings.
  - Canvas creation/anchoring more reliably resolves the correct `$canvas` type.

- **Tests**
  - Added integration coverage for the `$canvas` backfill migration and idempotency.
  - Strengthened assertions to ensure only one canvas child is created with the expected `$canvas` identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->