### PR TITLE
fix(behaviors): validate cloned sources on create_from_version

### DIFF
--- a/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
@@ -194,6 +194,129 @@ describe("behavior custom-SQL source validation", () => {
 		).rejects.toThrow();
 	});
 
+	it("validates cloned sources on create_from_version too", async () => {
+		// Save-time validation never re-runs, so a version authored while a table
+		// existed can outlive it. Cloning that version used to copy its sources
+		// straight into N new Behaviors with no check, minting N silently-empty
+		// "healthy" Behaviors — the exact state save-time validation prevents.
+		const { org, user, ctx } = await seedOwnerContext();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		const entity = await createTestEntity({
+			name: `cfv-target-${Date.now()}`,
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const created = await manageBehaviors(
+			{
+				action: "create",
+				slug: `cfv-src-${Date.now()}`,
+				name: "Clone source",
+				prompt: "Summarize.",
+				agent_id: agent.agentId,
+				sources: [{ name: "src", query: "SELECT id FROM events WHERE 1=0" }],
+				triggers: [
+					{
+						kind: "schedule",
+						cron: "* * * * *",
+						execution: "window",
+						active_run: "coalesce",
+					},
+				],
+			},
+			env,
+			ctx,
+		);
+		if (created.action !== "create" || !("behavior_id" in created)) {
+			throw new Error("setup: create failed");
+		}
+		const [row] = await getTestDb()<{ current_version_id: number }[]>`
+			SELECT current_version_id FROM watchers WHERE id = ${String(created.behavior_id)}
+		`;
+
+		// Corrupt the STORED version so the clone reads an unresolvable source,
+		// mirroring a table/entity-type that was dropped after the version was
+		// authored. Writing it directly bypasses save-time validation, which is
+		// precisely how such a row comes to exist.
+		await getTestDb()`
+			UPDATE watcher_versions
+			SET version_sources = ${getTestDb().json([
+				{ name: "src", query: "SELECT id FROM evetns" },
+			])}
+			WHERE id = ${Number(row.current_version_id)}
+		`;
+
+		await expect(
+			manageBehaviors(
+				{
+					action: "create_from_version",
+					version_id: String(row.current_version_id),
+					entity_ids: [Number(entity.id)],
+				},
+				env,
+				ctx,
+			),
+		).rejects.toThrow(/unknown table or entity type|evetns/i);
+
+		// The fan-out must not have half-landed.
+		const [{ n }] = await getTestDb()<{ n: string }[]>`
+			SELECT COUNT(*)::text AS n FROM watchers
+			WHERE organization_id = ${org.id} AND ${Number(entity.id)} = ANY(entity_ids)
+		`;
+		expect(Number(n)).toBe(0);
+	});
+
+	it("still clones a version whose sources are valid", async () => {
+		const { org, user, ctx } = await seedOwnerContext();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		const entity = await createTestEntity({
+			name: `cfv-ok-${Date.now()}`,
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const created = await manageBehaviors(
+			{
+				action: "create",
+				slug: `cfv-ok-src-${Date.now()}`,
+				name: "Clone ok",
+				prompt: "Summarize.",
+				agent_id: agent.agentId,
+				sources: [{ name: "src", query: "SELECT id FROM events WHERE 1=0" }],
+				triggers: [
+					{
+						kind: "schedule",
+						cron: "* * * * *",
+						execution: "window",
+						active_run: "coalesce",
+					},
+				],
+			},
+			env,
+			ctx,
+		);
+		if (created.action !== "create" || !("behavior_id" in created)) {
+			throw new Error("setup: create failed");
+		}
+		const [row] = await getTestDb()<{ current_version_id: number }[]>`
+			SELECT current_version_id FROM watchers WHERE id = ${String(created.behavior_id)}
+		`;
+		const cloned = (await manageBehaviors(
+			{
+				action: "create_from_version",
+				version_id: String(row.current_version_id),
+				entity_ids: [Number(entity.id)],
+			},
+			env,
+			ctx,
+		)) as { created: Array<{ behavior_id: string }> };
+		expect(cloned.created).toHaveLength(1);
+	});
+
 	it("validates custom SQL on create_version too, not only create", async () => {
 		// Create a valid behavior, then publish a new version whose source has a
 		// bad column — the create_version path (version-actions) must reject it,

--- a/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-source-validation.test.ts
@@ -71,6 +71,57 @@ describe("behavior custom-SQL source validation", () => {
 		);
 	}
 
+	async function createCloneFixture(query: string) {
+		const { org, user, ctx } = await seedOwnerContext();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		const sourceEntity = await createTestEntity({
+			name: `cfv-source-${Date.now()}`,
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const targetEntity = await createTestEntity({
+			name: `cfv-target-${Date.now()}`,
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const created = await manageBehaviors(
+			{
+				action: "create",
+				slug: `cfv-src-${Date.now()}`,
+				name: "Clone source",
+				prompt: "Summarize.",
+				agent_id: agent.agentId,
+				entity_id: Number(sourceEntity.id),
+				sources: [{ name: "src", query }],
+				triggers: [
+					{
+						kind: "schedule",
+						cron: "* * * * *",
+						execution: "window",
+						active_run: "coalesce",
+					},
+				],
+			},
+			env,
+			ctx,
+		);
+		if (created.action !== "create" || !("behavior_id" in created)) {
+			throw new Error("setup: create failed");
+		}
+		const [row] = await getTestDb()<{ current_version_id: number }[]>`
+			SELECT current_version_id FROM watchers WHERE id = ${String(created.behavior_id)}
+		`;
+		return {
+			ctx,
+			organizationId: org.id,
+			targetEntityId: Number(targetEntity.id),
+			versionId: Number(row.current_version_id),
+		};
+	}
+
 	it("rejects a source that references a non-existent column", async () => {
 		// Projects `id` (so it passes the id-projection guard) but references a
 		// bogus column — must be caught by the new scoped-query validation, not
@@ -195,121 +246,46 @@ describe("behavior custom-SQL source validation", () => {
 	});
 
 	it("validates cloned sources on create_from_version too", async () => {
-		// Save-time validation never re-runs, so a version authored while a table
-		// existed can outlive it. Cloning that version used to copy its sources
-		// straight into N new Behaviors with no check, minting N silently-empty
-		// "healthy" Behaviors — the exact state save-time validation prevents.
-		const { org, user, ctx } = await seedOwnerContext();
-		const agent = await createTestAgent({
-			organizationId: org.id,
-			ownerUserId: user.id,
-		});
-		const entity = await createTestEntity({
-			name: `cfv-target-${Date.now()}`,
-			organization_id: org.id,
-			created_by: user.id,
-		});
-		const created = await manageBehaviors(
-			{
-				action: "create",
-				slug: `cfv-src-${Date.now()}`,
-				name: "Clone source",
-				prompt: "Summarize.",
-				agent_id: agent.agentId,
-				sources: [{ name: "src", query: "SELECT id FROM events WHERE 1=0" }],
-				triggers: [
-					{
-						kind: "schedule",
-						cron: "* * * * *",
-						execution: "window",
-						active_run: "coalesce",
-					},
-				],
-			},
-			env,
-			ctx,
-		);
-		if (created.action !== "create" || !("behavior_id" in created)) {
-			throw new Error("setup: create failed");
-		}
-		const [row] = await getTestDb()<{ current_version_id: number }[]>`
-			SELECT current_version_id FROM watchers WHERE id = ${String(created.behavior_id)}
-		`;
+		const { ctx, organizationId, targetEntityId, versionId } =
+			await createCloneFixture("SELECT id FROM events WHERE 1=0");
 
-		// Corrupt the STORED version so the clone reads an unresolvable source,
-		// mirroring a table/entity-type that was dropped after the version was
-		// authored. Writing it directly bypasses save-time validation, which is
-		// precisely how such a row comes to exist.
+		// Simulate a referenced table being dropped after the version was authored.
 		await getTestDb()`
 			UPDATE watcher_versions
 			SET version_sources = ${getTestDb().json([
 				{ name: "src", query: "SELECT id FROM evetns" },
 			])}
-			WHERE id = ${Number(row.current_version_id)}
+			WHERE id = ${versionId}
 		`;
 
 		await expect(
 			manageBehaviors(
 				{
 					action: "create_from_version",
-					version_id: String(row.current_version_id),
-					entity_ids: [Number(entity.id)],
+					version_id: String(versionId),
+					entity_ids: [targetEntityId],
 				},
 				env,
 				ctx,
 			),
 		).rejects.toThrow(/unknown table or entity type|evetns/i);
 
-		// The fan-out must not have half-landed.
 		const [{ n }] = await getTestDb()<{ n: string }[]>`
 			SELECT COUNT(*)::text AS n FROM watchers
-			WHERE organization_id = ${org.id} AND ${Number(entity.id)} = ANY(entity_ids)
+			WHERE organization_id = ${organizationId} AND ${targetEntityId} = ANY(entity_ids)
 		`;
 		expect(Number(n)).toBe(0);
 	});
 
-	it("still clones a version whose sources are valid", async () => {
-		const { org, user, ctx } = await seedOwnerContext();
-		const agent = await createTestAgent({
-			organizationId: org.id,
-			ownerUserId: user.id,
-		});
-		const entity = await createTestEntity({
-			name: `cfv-ok-${Date.now()}`,
-			organization_id: org.id,
-			created_by: user.id,
-		});
-		const created = await manageBehaviors(
-			{
-				action: "create",
-				slug: `cfv-ok-src-${Date.now()}`,
-				name: "Clone ok",
-				prompt: "Summarize.",
-				agent_id: agent.agentId,
-				sources: [{ name: "src", query: "SELECT id FROM events WHERE 1=0" }],
-				triggers: [
-					{
-						kind: "schedule",
-						cron: "* * * * *",
-						execution: "window",
-						active_run: "coalesce",
-					},
-				],
-			},
-			env,
-			ctx,
+	it("clones a valid source using the target entity context", async () => {
+		const { ctx, targetEntityId, versionId } = await createCloneFixture(
+			"SELECT id FROM events WHERE {{entityId}} = ANY(entity_ids)",
 		);
-		if (created.action !== "create" || !("behavior_id" in created)) {
-			throw new Error("setup: create failed");
-		}
-		const [row] = await getTestDb()<{ current_version_id: number }[]>`
-			SELECT current_version_id FROM watchers WHERE id = ${String(created.behavior_id)}
-		`;
 		const cloned = (await manageBehaviors(
 			{
 				action: "create_from_version",
-				version_id: String(row.current_version_id),
-				entity_ids: [Number(entity.id)],
+				version_id: String(versionId),
+				entity_ids: [targetEntityId],
 			},
 			env,
 			ctx,

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -735,6 +735,24 @@ export async function handleCreateFromVersion(
   `;
   const entityMap = new Map(entityRows.map((e: any) => [Number(e.id), e]));
 
+  // Resolve the cloned sources against the org BEFORE the fan-out, same as
+  // `create` does. Validation is save-time only and never re-runs, so a version
+  // that was valid when authored can reference a table or entity type that has
+  // since been dropped; cloning it would mint N Behaviors that silently read
+  // nothing and stay "healthy" forever. Validate per entity — the sources are
+  // shared, but `{{entityId}}` resolves per assignment, so a source valid for
+  // one target is not automatically valid for another. Outside the transaction:
+  // a 422 here must not roll back a partial fan-out, it must prevent one.
+  const clonedSources = (version.version_sources ?? version.sources ?? []) as Array<{
+    name: string;
+    query: string;
+  }>;
+  if (clonedSources.length > 0) {
+    for (const entityId of entityIds) {
+      await assertWatcherSourcesResolve(sql, organizationId, clonedSources, [entityId]);
+    }
+  }
+
   const createdBy = ctx.userId ?? 'system';
   const created: Array<{
     behavior_id: string;
@@ -775,7 +793,7 @@ export async function handleCreateFromVersion(
           .replace(/[^a-z0-9-]/g, '-');
 
         const watcherId = await getNextNumericId(tx, 'watchers');
-        const sources = version.version_sources ?? version.sources ?? [];
+        const sources = clonedSources;
         // The new assignment shares the source's existing watcher_versions row
         // rather than getting its own duplicate copy. version_id (the arg) is
         // the row in watcher_versions we're cloning from; that becomes the

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -735,14 +735,9 @@ export async function handleCreateFromVersion(
   `;
   const entityMap = new Map(entityRows.map((e: any) => [Number(e.id), e]));
 
-  // Resolve the cloned sources against the org BEFORE the fan-out, same as
-  // `create` does. Validation is save-time only and never re-runs, so a version
-  // that was valid when authored can reference a table or entity type that has
-  // since been dropped; cloning it would mint N Behaviors that silently read
-  // nothing and stay "healthy" forever. Validate per entity — the sources are
-  // shared, but `{{entityId}}` resolves per assignment, so a source valid for
-  // one target is not automatically valid for another. Outside the transaction:
-  // a 422 here must not roll back a partial fan-out, it must prevent one.
+  // A once-valid version can outlive a referenced table or entity type. Resolve
+  // its sources before fan-out, passing each assignment's entity context so
+  // `{{entityId}}` is validated the same way as at runtime.
   const clonedSources = (version.version_sources ?? version.sources ?? []) as Array<{
     name: string;
     query: string;
@@ -793,7 +788,6 @@ export async function handleCreateFromVersion(
           .replace(/[^a-z0-9-]/g, '-');
 
         const watcherId = await getNextNumericId(tx, 'watchers');
-        const sources = clonedSources;
         // The new assignment shares the source's existing watcher_versions row
         // rather than getting its own duplicate copy. version_id (the arg) is
         // the row in watcher_versions we're cloning from; that becomes the
@@ -825,7 +819,7 @@ export async function handleCreateFromVersion(
             ${`{${entityId}}`}::bigint[],
             ${version.schedule ?? null}, ${version.timezone ?? null}, ${version.schedule ? nextRunAt(version.schedule as string, new Date(), version.timezone as string | null) : null}, ${toJsonParam(tx, cloneTriggers)},
             ${version.agent_id ?? null}, ${version.scheduler_client_id ?? null},
-            ${toJsonParam(tx, version.model_config)}, ${toJsonParam(tx, version.execution_config)}, ${toJsonParam(tx, sources)},
+            ${toJsonParam(tx, version.model_config)}, ${toJsonParam(tx, version.execution_config)}, ${toJsonParam(tx, clonedSources)},
             ${(version.version as number) ?? 1}, ${sharedVersionId}, ${toTextArrayParam(cloneTags)}::text[],
             'active', ${createdBy}, NOW(), NOW(),
             ${groupId}, ${version.watcher_id},
@@ -845,7 +839,7 @@ export async function handleCreateFromVersion(
           watcherId,
           watcherName,
           watcherSlug,
-          sources,
+          sources: clonedSources,
           sharedVersionId,
           groupId,
         });


### PR DESCRIPTION
## The gap

`create_from_version` copied `version_sources` straight into every new assignment with no validation — the one save path that bypassed the source-resolution gate added in #2088/#2093.

```ts
const sources = version.version_sources ?? version.sources ?? [];   // ← no check
```

Save-time validation never re-runs, so a version authored while a table existed can outlive it. Fanning that version onto N entities minted N Behaviors whose sources resolve to nothing — they read empty forever and report `healthy`. That's exactly the silent-failure state save-time validation exists to prevent, reached through a different door.

## The fix

Validate before the fan-out, alongside the existing `assertEntityIdsInOrg` pre-flight — so a 422 *prevents* a partial fan-out rather than rolling one back.

Per entity, not once: the sources are shared across clones, but `{{entityId}}` resolves per assignment, so a source valid for one target isn't automatically valid for another.

## Evidence

red→green: the new test resolves instead of rejecting against `origin/main`'s `crud.ts`:

```
AssertionError: promise resolved "{ action: 'create_from_version', … }" instead of rejecting
```

After the fix it rejects, and the test also asserts the fan-out left **zero** watcher rows behind. A companion test proves a version with valid sources still clones fine, and (after review-fix) exercises a target-specific `{{entityId}}` source — the case that makes the per-entity loop necessary.

Suites: 10/10 focused, 173/173 across `integration/watchers` + `integration/behaviors`. `make pre-pr` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->