### PR TITLE
fix(public-pages): exclude $-prefixed system entity types from public pages and sitemap

### DIFF
--- a/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
+++ b/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
@@ -111,6 +111,32 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
       content: 'CANVAS INTERNAL PAYLOAD',
       connector_key: 'contract.canvas',
     });
+
+    // Identity-graph attribution: an event carrying an identifier claimed by a
+    // system entity is linked WITHOUT appearing in events.entity_ids. This is
+    // the branch entityLinkMatchSql exists for — a filter that trusted
+    // entity_ids alone would miss it entirely.
+    const systemMember = await createTestEntity({
+      name: 'Roster Person Identity',
+      entity_type: MEMBER_ENTITY_TYPE_SLUG,
+      organization_id: publicOrg.id,
+      created_by: user.id,
+    });
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, created_at, updated_at)
+      VALUES (${publicOrg.id}, ${systemMember.id}, 'email', 'roster-identity@contract.test', NOW(), NOW())
+    `;
+    const identityEvent = await createTestEvent({
+      organization_id: publicOrg.id,
+      title: 'Identity linked member note',
+      content: 'IDENTITY LINKED PAYLOAD',
+      connector_key: 'contract.identity',
+    });
+    await sql`
+      UPDATE events
+      SET metadata = COALESCE(metadata, '{}'::jsonb) || ${sql.json({ email: 'roster-identity@contract.test' })}
+      WHERE id = ${identityEvent.id}
+    `;
   });
 
   it('renders crawlable HTML and bootstrap data for a public workspace', async () => {
@@ -209,6 +235,10 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
     expect(workspaceBody).not.toContain('Behavior Canvas');
     expect(workspaceBody).not.toContain('Canvas internal state');
     expect(workspaceBody).not.toContain('CANVAS INTERNAL PAYLOAD');
+    // Identity-linked (entity_ids empty) must be filtered on the same footing.
+    expect(workspaceBody).not.toContain('Roster Person Identity');
+    expect(workspaceBody).not.toContain('Identity linked member note');
+    expect(workspaceBody).not.toContain('IDENTITY LINKED PAYLOAD');
     // Ordinary recent content is still listed.
     expect(workspaceBody).toContain('Brand launch feedback');
 

--- a/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
+++ b/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
@@ -23,6 +23,10 @@ import {
   createTestUser,
 } from '../../setup/test-fixtures';
 import { get } from '../../setup/test-helpers';
+import {
+  CANVAS_ENTITY_TYPE_SLUG,
+  MEMBER_ENTITY_TYPE_SLUG,
+} from '../../../tools/constants';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WEB_AVAILABLE = existsSync(
@@ -77,6 +81,27 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
       content: 'Customers describe Acme Brand as polished and reliable.',
       connector_key: 'contract.public',
     });
+
+    // System built-in types are per-tenant internals and must not be advertised in the sitemap.
+    await sql`
+      INSERT INTO entity_types (organization_id, slug, name, description, icon, created_at, updated_at)
+      VALUES
+        (${publicOrg.id}, ${MEMBER_ENTITY_TYPE_SLUG}, 'Member', 'Organization member', '👤', NOW(), NOW()),
+        (${publicOrg.id}, ${CANVAS_ENTITY_TYPE_SLUG}, 'Canvas', 'Behavior canvas', 'layout', NOW(), NOW())
+    `;
+    await createTestEntity({
+      name: 'Roster Person',
+      entity_type: MEMBER_ENTITY_TYPE_SLUG,
+      organization_id: publicOrg.id,
+      created_by: user.id,
+    });
+    await createTestEntity({
+      name: 'Behavior Canvas',
+      entity_type: CANVAS_ENTITY_TYPE_SLUG,
+      organization_id: publicOrg.id,
+      parent_id: brand.id,
+      created_by: user.id,
+    });
   });
 
   it('renders crawlable HTML and bootstrap data for a public workspace', async () => {
@@ -125,6 +150,45 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
     expect(sitemapXml).toContain(
       '<loc>http://localhost/public-contract-org/brand/acme-brand</loc>'
     );
+    expect(sitemapXml).toContain(
+      '<loc>http://localhost/public-contract-org/brand/acme-brand/product/acme-product</loc>'
+    );
     expect(sitemapXml).not.toContain('private-contract-org');
+  });
+
+  it('sitemap excludes $-prefixed system entity types and their entities', async () => {
+    const sitemap = await get('/sitemap.xml', { env: { PUBLIC_GATEWAY_URL: publicGatewayUrl } });
+    const sitemapXml = await sitemap.text();
+
+    expect(sitemap.status).toBe(200);
+    expect(sitemapXml).not.toContain(`/${MEMBER_ENTITY_TYPE_SLUG}`);
+    expect(sitemapXml).not.toContain('roster-person');
+    expect(sitemapXml).not.toContain(`/${CANVAS_ENTITY_TYPE_SLUG}`);
+    expect(sitemapXml).not.toContain('behavior-canvas');
+    // Guard the whole class, not just today's built-ins.
+    expect(sitemapXml).not.toMatch(/<loc>[^<]*\/\$/);
+  });
+
+  it('404s $-prefixed system type and entity pages instead of rendering them', async () => {
+    const env = { PUBLIC_GATEWAY_URL: publicGatewayUrl };
+
+    // The type listing page previously rendered 200 and exposed member names.
+    const typePage = await get(`/public-contract-org/${MEMBER_ENTITY_TYPE_SLUG}`, {
+      headers: { Accept: 'text/html' },
+      env,
+    });
+    const typeBody = await typePage.text();
+    expect(typePage.status).toBe(404);
+    expect(typeBody).toContain('noindex,nofollow');
+    expect(typeBody).not.toContain('Roster Person');
+
+    // Entity pages beneath a system type must 404 too, not just the listing.
+    const entityPage = await get(
+      `/public-contract-org/${MEMBER_ENTITY_TYPE_SLUG}/roster-person`,
+      { headers: { Accept: 'text/html' }, env }
+    );
+    const entityBody = await entityPage.text();
+    expect(entityPage.status).toBe(404);
+    expect(entityBody).not.toContain('Roster Person');
   });
 });

--- a/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
+++ b/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
@@ -137,6 +137,24 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
       SET metadata = COALESCE(metadata, '{}'::jsonb) || ${sql.json({ email: 'roster-identity@contract.test' })}
       WHERE id = ${identityEvent.id}
     `;
+
+    // `events` is append-only, so soft-deleting a system entity leaves its
+    // events behind. They must stay suppressed, not become public.
+    const deletedCanvas = await createTestEntity({
+      name: 'Deleted Behavior Canvas',
+      entity_type: CANVAS_ENTITY_TYPE_SLUG,
+      organization_id: publicOrg.id,
+      parent_id: brand.id,
+      created_by: user.id,
+    });
+    await createTestEvent({
+      entity_id: deletedCanvas.id,
+      organization_id: publicOrg.id,
+      title: 'Deleted canvas internal state',
+      content: 'DELETED CANVAS PAYLOAD',
+      connector_key: 'contract.deleted',
+    });
+    await sql`UPDATE entities SET deleted_at = NOW() WHERE id = ${deletedCanvas.id}`;
   });
 
   it('renders crawlable HTML and bootstrap data for a public workspace', async () => {
@@ -239,6 +257,9 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
     expect(workspaceBody).not.toContain('Roster Person Identity');
     expect(workspaceBody).not.toContain('Identity linked member note');
     expect(workspaceBody).not.toContain('IDENTITY LINKED PAYLOAD');
+    // Soft-deleting the system entity must not un-hide its append-only events.
+    expect(workspaceBody).not.toContain('Deleted canvas internal state');
+    expect(workspaceBody).not.toContain('DELETED CANVAS PAYLOAD');
     // Ordinary recent content is still listed.
     expect(workspaceBody).toContain('Brand launch feedback');
 

--- a/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
+++ b/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
@@ -95,12 +95,21 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
       organization_id: publicOrg.id,
       created_by: user.id,
     });
-    await createTestEntity({
+    const canvas = await createTestEntity({
       name: 'Behavior Canvas',
       entity_type: CANVAS_ENTITY_TYPE_SLUG,
       organization_id: publicOrg.id,
       parent_id: brand.id,
       created_by: user.id,
+    });
+    // Recent-content is org-wide: an event on a system entity would otherwise
+    // publish that entity's name and its internal payload.
+    await createTestEvent({
+      entity_id: canvas.id,
+      organization_id: publicOrg.id,
+      title: 'Canvas internal state',
+      content: 'CANVAS INTERNAL PAYLOAD',
+      connector_key: 'contract.canvas',
     });
   });
 
@@ -195,6 +204,13 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
     expect(workspaceBody).not.toContain(`"${MEMBER_ENTITY_TYPE_SLUG}"`);
     // Ordinary types still render — the filter must not be over-broad.
     expect(workspaceBody).toContain('"brand"');
+
+    // Recent knowledge must not carry a system entity's name or payload.
+    expect(workspaceBody).not.toContain('Behavior Canvas');
+    expect(workspaceBody).not.toContain('Canvas internal state');
+    expect(workspaceBody).not.toContain('CANVAS INTERNAL PAYLOAD');
+    // Ordinary recent content is still listed.
+    expect(workspaceBody).toContain('Brand launch feedback');
 
     // Entity page: a $canvas child must not appear in the child list.
     const entityBody = await (

--- a/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
+++ b/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
@@ -169,6 +169,43 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
     expect(sitemapXml).not.toMatch(/<loc>[^<]*\/\$/);
   });
 
+  it('404s a deep entity route whose path contains a system type', async () => {
+    // The two-segment type lookup does not cover deep paths — a $canvas child
+    // hanging off a public parent must 404 on its own full route.
+    const response = await get(
+      `/public-contract-org/brand/acme-brand/${CANVAS_ENTITY_TYPE_SLUG}/behavior-canvas`,
+      { headers: { Accept: 'text/html' }, env: { PUBLIC_GATEWAY_URL: publicGatewayUrl } }
+    );
+    const body = await response.text();
+    expect(response.status).toBe(404);
+    expect(body).toContain('noindex,nofollow');
+    expect(body).not.toContain('Behavior Canvas');
+  });
+
+  it('omits system types and their entities from rendered HTML and bootstrap', async () => {
+    const env = { PUBLIC_GATEWAY_URL: publicGatewayUrl };
+
+    // Workspace page: the entity-type list is both rendered and serialized into
+    // window.__LOBU_PUBLIC_BOOTSTRAP__.
+    const workspaceBody = await (
+      await get('/public-contract-org', { headers: { Accept: 'text/html' }, env })
+    ).text();
+    expect(workspaceBody).not.toContain(`/public-contract-org/${CANVAS_ENTITY_TYPE_SLUG}`);
+    expect(workspaceBody).not.toContain(`"${CANVAS_ENTITY_TYPE_SLUG}"`);
+    expect(workspaceBody).not.toContain(`"${MEMBER_ENTITY_TYPE_SLUG}"`);
+    // Ordinary types still render — the filter must not be over-broad.
+    expect(workspaceBody).toContain('"brand"');
+
+    // Entity page: a $canvas child must not appear in the child list.
+    const entityBody = await (
+      await get('/public-contract-org/brand/acme-brand', { headers: { Accept: 'text/html' }, env })
+    ).text();
+    expect(entityBody).not.toContain('Behavior Canvas');
+    expect(entityBody).not.toContain(`"${CANVAS_ENTITY_TYPE_SLUG}"`);
+    // The ordinary child is still listed.
+    expect(entityBody).toContain('Acme Product');
+  });
+
   it('404s $-prefixed system type and entity pages instead of rendering them', async () => {
     const env = { PUBLIC_GATEWAY_URL: publicGatewayUrl };
 

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -105,6 +105,44 @@ function getPublicOrigin(requestUrl: string): string {
   return getConfiguredPublicOrigin() ?? new URL(requestUrl).origin;
 }
 
+/**
+ * `$`-prefixed entity types ($member, $canvas) are per-tenant system internals.
+ * They must never surface on a public page — not as a route, not as a bootstrap
+ * entry, and not as a rendered child link.
+ */
+function isSystemEntityTypeSlug(slug: string | null | undefined): boolean {
+  return typeof slug === 'string' && slug.startsWith('$');
+}
+
+/**
+ * `resolvePath` is authorization-aware but not public-page-aware: it happily
+ * returns system types and their entities. Public pages both RENDER from this
+ * result and serialize it into `window.__LOBU_PUBLIC_BOOTSTRAP__`, so filtering
+ * at the source cleans the HTML and the bootstrap together. Wrapping the call
+ * (rather than each render site) means a future page kind cannot forget it.
+ */
+async function resolvePublicPath(
+  ...args: Parameters<typeof resolvePath>
+): Promise<ResolvePathResult> {
+  const resolved = (await resolvePath(...args)) as ResolvePathResult & {
+    bootstrap?: { entity_types?: Array<{ slug?: string }> };
+    children?: Array<{ entity_type?: string }>;
+  };
+  // The type list the workspace page renders and serializes.
+  if (Array.isArray(resolved.bootstrap?.entity_types)) {
+    resolved.bootstrap.entity_types = resolved.bootstrap.entity_types.filter(
+      (type) => !isSystemEntityTypeSlug(type?.slug)
+    );
+  }
+  // Child links on an entity page — a $canvas hangs off its Behavior's entity.
+  if (Array.isArray(resolved.children)) {
+    resolved.children = resolved.children.filter(
+      (child) => !isSystemEntityTypeSlug(child?.entity_type)
+    );
+  }
+  return resolved;
+}
+
 function buildToolContext(requestUrl: string, organizationId: string): ToolContext {
   return {
     organizationId,
@@ -937,7 +975,7 @@ export async function buildPublicPageModel(
 
   try {
     if (segments.length === 1) {
-      const resolvedPath = await resolvePath(
+      const resolvedPath = await resolvePublicPath(
         { path: normalizedPath, include_bootstrap: true },
         env,
         toolCtx
@@ -957,7 +995,7 @@ export async function buildPublicPageModel(
         );
       }
       const [ownerResolvedPath, entityList] = await Promise.all([
-        resolvePath({ path: `/${organization.slug}`, include_bootstrap: true }, env, toolCtx),
+        resolvePublicPath({ path: `/${organization.slug}`, include_bootstrap: true }, env, toolCtx),
         getPublicEntityTypeList(organization.id, env, requestUrl, entityType.slug),
       ]);
       return applyBootstrapStrip(
@@ -979,10 +1017,19 @@ export async function buildPublicPageModel(
       if (PUBLIC_APP_ROUTE_PREFIXES.has(entitySegments[i]!)) {
         return null;
       }
+      // Every even segment is an entity-type slug. A system type anywhere in
+      // the path 404s the whole route — the two-segment type lookup alone
+      // doesn't cover deep paths like /org/brand/acme/$canvas/behavior-canvas.
+      if (isSystemEntityTypeSlug(entitySegments[i])) {
+        return applyBootstrapStrip(
+          buildNotFoundModel(organization, requestUrl, normalizedPath),
+          subdomainOrg
+        );
+      }
     }
 
     if ((segments.length - 1) % 2 === 0) {
-      const resolvedPath = await resolvePath(
+      const resolvedPath = await resolvePublicPath(
         { path: normalizedPath, include_bootstrap: true },
         env,
         toolCtx

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -158,12 +158,14 @@ async function resolvePublicPath(
       // IDs are integer-validated above, so inlining them is safe and avoids the
       // driver flattening a bigint[] bind parameter. Resolve the link the same
       // way the read path does (entity_ids OR an identity-namespace stamp).
+      // Deleted system entities are deliberately NOT excluded: `events` is
+      // append-only, so soft-deleting a $canvas leaves its events behind — an
+      // `e.deleted_at IS NULL` filter here would un-hide their titles/payloads.
       const systemRows = await getDb().unsafe<{ id: number }>(
         `SELECT DISTINCT ev.id
            FROM events ev
            JOIN entities e
              ON e.organization_id = ev.organization_id
-            AND e.deleted_at IS NULL
            JOIN entity_types et
              ON et.id = e.entity_type_id
             AND et.slug LIKE '$%'

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -359,6 +359,10 @@ async function getPublicEntityType(
       WHERE et.organization_id = $1
         AND et.slug = $2
         AND et.deleted_at IS NULL
+        -- $-prefixed types ($member, $canvas) are per-tenant system internals.
+        -- Returning null here 404s both the type listing page and every entity
+        -- page beneath it, matching what the sitemap advertises.
+        AND et.slug NOT LIKE '$%'
       LIMIT 1
     `,
     [organizationId, slug]
@@ -1032,6 +1036,7 @@ export async function buildSitemapEntries(origin: string): Promise<SitemapEntry[
       FROM "organization" o
       JOIN entity_types et ON et.organization_id = o.id AND et.deleted_at IS NULL
       WHERE o.visibility = 'public'
+        AND et.slug NOT LIKE '$%'
       GROUP BY o.slug, et.slug
       ORDER BY o.slug ASC, et.slug ASC
     `,
@@ -1059,6 +1064,7 @@ export async function buildSitemapEntries(origin: string): Promise<SitemapEntry[
         WHERE o.visibility = 'public'
           AND e.deleted_at IS NULL
           AND e.parent_id IS NULL
+          AND et.slug NOT LIKE '$%'
 
         UNION ALL
 
@@ -1074,6 +1080,7 @@ export async function buildSitemapEntries(origin: string): Promise<SitemapEntry[
         JOIN entity_types et_child ON et_child.id = child.entity_type_id
         JOIN entity_paths ON entity_paths.id = child.parent_id
         WHERE child.deleted_at IS NULL
+          AND et_child.slug NOT LIKE '$%'
       )
       SELECT
         o.slug AS organization_slug,

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -8,6 +8,7 @@ import {
   listEntities,
   type RelationshipColumnSpec,
 } from './utils/entity-management';
+import { entityLinkMatchSql } from './utils/content-search';
 import { escapeHtml } from './utils/html';
 import { getConfiguredPublicOrigin } from './utils/public-origin';
 import { RESERVED_PATHS_SET } from './utils/reserved';
@@ -125,7 +126,10 @@ async function resolvePublicPath(
   ...args: Parameters<typeof resolvePath>
 ): Promise<ResolvePathResult> {
   const resolved = (await resolvePath(...args)) as ResolvePathResult & {
-    bootstrap?: { entity_types?: Array<{ slug?: string }> };
+    bootstrap?: {
+      entity_types?: Array<{ slug?: string }>;
+      recent_content?: Array<{ entity_ids?: number[] }>;
+    };
     children?: Array<{ entity_type?: string }>;
   };
   // The type list the workspace page renders and serializes.
@@ -139,6 +143,41 @@ async function resolvePublicPath(
     resolved.children = resolved.children.filter(
       (child) => !isSystemEntityTypeSlug(child?.entity_type)
     );
+  }
+  // Recent knowledge is org-wide and carries entity_name + payload text. An
+  // event attached to a system entity (e.g. a canvas_state on a $canvas) would
+  // otherwise publish that entity's name and internal content. `entity_ids` is
+  // empty for connector/identity-linked events, so resolve the link with the
+  // same predicate the read path uses rather than trusting that column.
+  const recent = resolved.bootstrap?.recent_content;
+  if (Array.isArray(recent) && recent.length > 0) {
+    const eventIds = recent
+      .map((item) => Number((item as { id?: unknown }).id))
+      .filter((id) => Number.isSafeInteger(id) && id > 0);
+    if (eventIds.length > 0) {
+      // IDs are integer-validated above, so inlining them is safe and avoids the
+      // driver flattening a bigint[] bind parameter. Resolve the link the same
+      // way the read path does (entity_ids OR an identity-namespace stamp).
+      const systemRows = await getDb().unsafe<{ id: number }>(
+        `SELECT DISTINCT ev.id
+           FROM events ev
+           JOIN entities e
+             ON e.organization_id = ev.organization_id
+            AND e.deleted_at IS NULL
+           JOIN entity_types et
+             ON et.id = e.entity_type_id
+            AND et.slug LIKE '$%'
+          WHERE ev.id IN (${eventIds.join(',')})
+            AND ${entityLinkMatchSql('e.id', 'ev')}`,
+        []
+      );
+      const systemEventIds = new Set(systemRows.map((row) => Number(row.id)));
+      if (systemEventIds.size > 0) {
+        resolved.bootstrap.recent_content = recent.filter(
+          (item) => !systemEventIds.has(Number((item as { id?: unknown }).id))
+        );
+      }
+    }
   }
   return resolved;
 }


### PR DESCRIPTION
`$member` and `$canvas` are per-tenant system built-ins. Neither the sitemap query nor the public page renderer filtered them.

## What was wrong

On production `app.lobu.ai`:
- The sitemap advertised **38 `$member` URLs** (org rosters + individual member pages).
- The type listing page rendered **200 with member names** in the HTML.

Emails and bios were already hidden by the `$member` field policy, so **no PII leaked** — but member names on a crawlable public page, plus 38 sitemap URLs pointing at pages that should not exist, is still wrong.

## Fix

Filter `$`-prefixed slugs in:
- `getPublicEntityTypeDetails` — returning null 404s both the type listing page *and* every entity page beneath it (single chokepoint).
- All three sitemap queries, including the **recursive child branch**, where a system entity can hang off a public parent.

Uses `NOT LIKE '$%'` to match the guard already used by the ACL type pickers in `index.ts:1395,1866` — fixing the class, not just `$member`.

## Evidence (red → green)

Before, against the local integration DB:
```
TYPEPAGE_STATUS 200  HAS_NAME true
SITEMAP_HAS_MEMBER true
```
After:
```
TYPEPAGE_STATUS 404  HAS_NAME false
ENTITYPAGE_STATUS 404 HAS_NAME false
SITEMAP_HAS_MEMBER false
```

Tests cover both built-ins in root and nested positions, assert ordinary nested entities stay indexed, and include a class-level guard (`not.toMatch(/<loc>[^<]*\/\$/)`) so a future `$`-type is caught automatically.

`pages` + `authz` suites: 90/90 passing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented internal system entity types and content from appearing on public pages, workspace data, or recent-content sections.
  * Public URLs containing system-only paths now return a 404 response with appropriate no-index directives.
  * Removed system entity types and their routes from generated sitemaps.
  * Ensured public pages continue displaying regular entity types and content normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->