### PR TITLE
fix(plugin-mcp): approval cards must emit resourceKind/attribution 'behavior', not 'watcher'

### DIFF
--- a/packages/agent-worker/src/__tests__/custom-tools.test.ts
+++ b/packages/agent-worker/src/__tests__/custom-tools.test.ts
@@ -154,11 +154,9 @@ describe("createLobuCustomTools", () => {
   });
 });
 
-// Builder gate: when a manage_agents write returns a `pending_approval` result,
-// the worker forwards it as a `tool_approval` interaction card so the SPA chat
-// renders the interactive Approve/Reject diff. Same /internal/interactions/create
-// emission point ask_user uses → owner-gated thread_response delivery.
-describe("maybePostApprovalCard (builder gate)", () => {
+// Approval gates return structured pending results that the worker forwards as
+// `tool_approval` interaction cards for owner-gated thread_response delivery.
+describe("maybePostApprovalCard", () => {
   const gw = {
     gatewayUrl: "http://gateway",
     workerToken: "worker-token",
@@ -219,7 +217,7 @@ describe("maybePostApprovalCard (builder gate)", () => {
           url,
           body: init?.body ? JSON.parse(String(init.body)) : null,
         });
-        return Response.json({ id: "appr-w1" });
+        return Response.json({ id: "appr-b1" });
       }
     ) as unknown as typeof fetch;
 
@@ -255,7 +253,7 @@ describe("maybePostApprovalCard (builder gate)", () => {
       interactionType: "tool_approval",
       runId: 77,
       action: "create",
-      resourceKind: "watcher",
+      resourceKind: "behavior",
       proposal: {
         action: "create",
         slug: "launch-tracker",
@@ -372,7 +370,7 @@ describe("maybePostApprovalCard (builder gate)", () => {
     });
   });
 
-  test("carries watcher attribution when a manage_entity update was watcher-sourced", async () => {
+  test("carries behavior attribution when a manage_entity update was Behavior-sourced", async () => {
     const posts: Array<{ body: any }> = [];
     globalThis.fetch = mock(
       async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -390,12 +388,12 @@ describe("maybePostApprovalCard (builder gate)", () => {
         approval_run_id: 43,
         approval_fields: { "metadata.stage": "won" },
         approval_current: { "metadata.stage": "lead" },
-        approval_attribution: "watcher",
+        approval_attribution: "behavior",
       })
     );
 
     expect(posted).toBe(true);
-    expect(posts[0]!.body.attribution).toBe("watcher");
+    expect(posts[0]!.body.attribution).toBe("behavior");
   });
 
   test("does nothing for a manage_entity update with no blocked fields", async () => {

--- a/packages/plugin-mcp/src/tools.ts
+++ b/packages/plugin-mcp/src/tools.ts
@@ -28,7 +28,7 @@ const TOOLS_REQUESTING_JSON_FORMAT = new Set([
   // not formatted markdown, to forward an approval card into the chat (see
   // maybePostApprovalCard / createMcpToolDefinitions).
   "manage_agents",
-  // Same shape as manage_agents: watcher definition create/update/delete may
+  // Same shape as manage_agents: behavior definition create/update/delete may
   // return pending_approval under the agent_config write-gate.
   "manage_behaviors",
   // manage_entity's update path queues a human-owned-field change for approval
@@ -43,13 +43,13 @@ const TOOLS_REQUESTING_JSON_FORMAT = new Set([
  * Approve/Reject diff. Handles three producers:
  *   - manage_agents write gate → `{ status: 'pending_approval', run_id,
  *     action, proposal, current }` (the builder agent's create/update/delete).
- *   - manage_behaviors write gate → same `pending_approval` shape (watcher
+ *   - manage_behaviors write gate → same `pending_approval` shape (behavior
  *     definition create/update/delete under agent_config).
  *   - manage_entity update gate → `{ approval_queued: true, approval_run_id,
  *     approval_fields, approval_current, approval_attribution }` (a human-owned
- *     entity field the agent proposed changing).
+ *     entity field an agent or Behavior proposed changing).
  *
- * Fire-and-forget — a failed post never breaks the tool call (the agent still
+ * Best-effort — a failed post never breaks the tool call (the agent still
  * narrates the result, and the events-tab approval card remains the fallback).
  * Returns true when a card was posted (caller logs at debug only).
  *
@@ -65,7 +65,7 @@ export async function maybePostApprovalCard(
   const body = buildApprovalCardBody(toolName, rawResultText);
   if (!body) return false;
 
-  // Fire-and-forget: a failed post must never break the tool call (the agent
+  // Best-effort: a failed post must never break the tool call (the agent
   // still narrates the result, and the events-tab approval card is the
   // fallback). gatewayFetch throws on a hard network error, so guard it too.
   let error: TextResult | undefined;
@@ -91,8 +91,8 @@ export async function maybePostApprovalCard(
  * Parse a gated tool result into the /internal/interactions/create body, or
  * null when the result is not a pending approval. entity_field_change carries
  * `fields`/`attribution` (the human-owned-field diff); manage_agents carries
- * `proposal` (the agent row diff); manage_behaviors carries flat watcher args
- * plus `resourceKind: "watcher"`. All share the `tool_approval` transport.
+ * `proposal` (the agent row diff); manage_behaviors carries flat behavior args
+ * plus `resourceKind: "behavior"`. All share the `tool_approval` transport.
  */
 function buildApprovalCardBody(
   toolName: string,
@@ -113,7 +113,7 @@ function buildApprovalCardBody(
       return null;
     }
     // Server proposal is `{ args: ManageBehaviorsArgs }`; SPA renderer needs the
-    // flat watcher fields (action, slug, prompt, schedule, …).
+    // flat behavior fields (action, slug, prompt, schedule, …).
     const rawProposal = parsed.proposal;
     const flatProposal =
       rawProposal &&
@@ -126,7 +126,7 @@ function buildApprovalCardBody(
       interactionType: "tool_approval",
       runId: parsed.run_id,
       action: typeof parsed.action === "string" ? parsed.action : "change",
-      resourceKind: "watcher",
+      resourceKind: "behavior",
       proposal: flatProposal,
       current: parsed.current ?? null,
     };
@@ -170,7 +170,7 @@ function buildApprovalCardBody(
       fields: parsed.approval_fields ?? null,
       current: parsed.approval_current ?? null,
       attribution:
-        parsed.approval_attribution === "watcher" ? "watcher" : "agent",
+        parsed.approval_attribution === "behavior" ? "behavior" : "agent",
     };
   }
 


### PR DESCRIPTION
## Summary
owletto #533 renamed the SPA wire check to `resourceKind === "behavior"` and server #2034 renamed the tool-side emissions, but plugin-mcp (extracted in #1936, before both renames) still tagged `manage_behaviors` approval cards `resourceKind: "watcher"` and matched `approval_attribution === "watcher"` — a value the server never sends anymore (`manage_entity` emits `"behavior"`).

**Live-path impact:** the interaction pipeline (`gateway/routes/internal/interactions.ts`) forwards `resourceKind` verbatim, so worker-agent-gated `manage_behaviors` approvals misrendered as generic agent cards in chat, and Behavior-sourced entity-field changes displayed as "An agent" instead of "A Behavior". History reads were unaffected — `agent-history.ts:569` and `watcher-run-thread.ts:238` already normalize legacy stored `watcher` values, which is what masked this on the events tab.

## Fix
Two literal flips in `plugin-mcp/src/tools.ts` (+ stale comments), and the existing `maybePostApprovalCard` tests in agent-worker — which had been pinning the buggy literals — now pin `"behavior"`.

## Validation
- Red→green: assertions on the old values reproduced the mismatch before the fix; 12/12 agent-worker + plugin-mcp tests pass after
- `make pre-pr` clean; `make review`: bug_free 95, 0 bugs, 0 blockers
- Legacy-event compatibility confirmed: read-path normalizers pass `"behavior"` through unchanged

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected approval cards for behavior-related actions to display the appropriate resource type and attribution.
  * Updated pending-approval details to consistently identify behavior-sourced requests.
  * Improved handling and messaging for approval-card posting failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->