### PR TITLE
fix(behaviors): bind promoted-entity provenance to the window's granted content

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -296,7 +296,7 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect(csChanges.every((c) => c.kind === 'created')).toBe(true);
   });
 
-  it('keeps an in-window source_event_id but drops one the window never read', async () => {
+  it('keeps an exact in-window source_event_id and drops ungranted claims', async () => {
     const ctx = await setupKeyedWatcher();
     const { sql, workspace, parentEntityId } = ctx;
 
@@ -332,6 +332,16 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
           name: 'Slow Loading',
           source_event_id: Number(outOfWindow.id),
         },
+        {
+          category: 'Stability',
+          name: 'Fractional Reference',
+          source_event_id: Number(inWindow.id) + 0.5,
+        },
+        {
+          category: 'Stability',
+          name: 'String Reference',
+          source_event_id: String(inWindow.id),
+        },
       ],
     });
 
@@ -347,11 +357,13 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
       rows.map((r) => [String(r.identifier).split('::').pop(), r.source_event_id])
     );
 
-    // The verifiable claim survives; the unverifiable one is stripped rather
-    // than stored as false provenance. Both rows still promote.
+    // The verifiable claim survives; unverifiable values are stripped rather
+    // than stored as false provenance. Every row still promotes.
     expect(bySlug['app-crashes']).toBe(String(inWindow.id));
+    expect(bySlug['fractional-reference']).toBeNull();
     expect(bySlug['slow-loading']).toBeNull();
-    expect(Object.keys(bySlug)).toHaveLength(2);
+    expect(bySlug['string-reference']).toBeNull();
+    expect(Object.keys(bySlug)).toHaveLength(4);
   });
 
   it("a create=deny policy on the watcher's OWNING AGENT blocks its promotions", async () => {

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -296,6 +296,64 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect(csChanges.every((c) => c.kind === 'created')).toBe(true);
   });
 
+  it('keeps an in-window source_event_id but drops one the window never read', async () => {
+    const ctx = await setupKeyedWatcher();
+    const { sql, workspace, parentEntityId } = ctx;
+
+    // Place the in-window event inside the behavior's pending daily window so
+    // read_knowledge actually grants it in the token's content_ids.
+    const granularity = inferBehaviorGranularityFromSchedule('0 9 * * *');
+    const { windowStart } = await computePendingWindow(
+      ctx.dbClient,
+      ctx.watcherId,
+      granularity
+    );
+    const inWindow = await createTestEvent({
+      entity_id: parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Users report the app crashing and loading slowly.',
+      occurred_at: new Date(windowStart.getTime() + 60 * 60 * 1000),
+    });
+    // Content that exists in the org but is NOT part of this window's token.
+    const outOfWindow = await createTestEvent({
+      entity_id: parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Unrelated content the agent must not be able to cite.',
+      occurred_at: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000),
+    });
+
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+    await completeWithToken(ctx, token, runId, {
+      problems: [
+        { category: 'Stability', name: 'App Crashes', source_event_id: Number(inWindow.id) },
+        {
+          category: 'Performance',
+          name: 'Slow Loading',
+          source_event_id: Number(outOfWindow.id),
+        },
+      ],
+    });
+
+    const rows = await sql`
+      SELECT ei.identifier, e.metadata->>'source_event_id' AS source_event_id
+      FROM entity_identities ei
+      JOIN entities e ON e.id = ei.entity_id
+      WHERE ei.organization_id = ${workspace.org.id}
+        AND ei.namespace = 'watcher_key'
+      ORDER BY ei.identifier
+    `;
+    const bySlug = Object.fromEntries(
+      rows.map((r) => [String(r.identifier).split('::').pop(), r.source_event_id])
+    );
+
+    // The verifiable claim survives; the unverifiable one is stripped rather
+    // than stored as false provenance. Both rows still promote.
+    expect(bySlug['app-crashes']).toBe(String(inWindow.id));
+    expect(bySlug['slow-loading']).toBeNull();
+    expect(Object.keys(bySlug)).toHaveLength(2);
+  });
+
   it("a create=deny policy on the watcher's OWNING AGENT blocks its promotions", async () => {
     // The v1.1 fix: a watcher is its agent's autonomous mode, so the agent's own
     // envelope binds the watcher. Pin entity create=deny to THIS watcher's agent;

--- a/packages/server/src/__tests__/integration/watchers/promotion-gate-fail-closed.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promotion-gate-fail-closed.test.ts
@@ -94,6 +94,7 @@ async function promote(
 			windowId: 1,
 			parentEntityId: ctx.parentId,
 			createdBy: ctx.createdBy,
+			validContentIds: new Set<number>(),
 		}),
 	);
 }

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -522,6 +522,11 @@ export async function handleCompleteWindow(
       );
     }
 
+    // The content this window_token actually granted. Both promotion (8.5) and
+    // classification (9) validate agent-supplied content references against it,
+    // so it is defined once here rather than per-consumer.
+    const validContentIds = new Set(batchContentIds);
+
     // ============================================
     // STEP 8.5: Promote keyed rows into child entities (P2 phase 1)
     // computeStableKeys (STEP 2.6) stamped a deterministic stable key onto each
@@ -542,6 +547,7 @@ export async function handleCompleteWindow(
         windowId,
         parentEntityId,
         createdBy: watcherCreatedBy,
+        validContentIds,
       });
       // Owned-field changes and policy-held creates the watcher couldn't apply —
       // flush each AFTER the window transaction commits (approvals must not ride
@@ -585,7 +591,6 @@ export async function handleCompleteWindow(
     // STEP 9: Process classifications
     // If this fails (e.g., embeddings service down), the transaction rolls back
     // ============================================
-    const validContentIds = new Set(batchContentIds);
     await processWatcherClassifications(
       tx,
       watcherId,

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -583,15 +583,15 @@ export async function promoteKeyedEntities(
     // applies to citations. An unverifiable id is worse than none: it reads like
     // proof of origin while pointing anywhere in the org.
     if (SOURCE_EVENT_ID_FIELD in fieldValues) {
-      const claimed = Number(fieldValues[SOURCE_EVENT_ID_FIELD]);
-      if (!Number.isFinite(claimed) || !validContentIds.has(Math.trunc(claimed))) {
+      const claimed = fieldValues[SOURCE_EVENT_ID_FIELD];
+      if (typeof claimed !== 'number' || !validContentIds.has(claimed)) {
         logger.warn(
           {
             watcherId,
             organizationId,
             windowId,
             stableKey,
-            claimedSourceEventId: fieldValues[SOURCE_EVENT_ID_FIELD],
+            claimedSourceEventId: claimed,
           },
           '[promote-keyed-entities] dropping source_event_id not present in this window'
         );

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -58,6 +58,9 @@ import { isUniqueViolation } from './pg-errors';
 /** Namespace for the stable-key identity claim in `entity_identities`. */
 const WATCHER_KEY_NAMESPACE = 'watcher_key';
 
+/** Agent-authored field naming the content a promoted row came from. */
+const SOURCE_EVENT_ID_FIELD = 'source_event_id';
+
 export interface PromoteKeyedEntitiesParams {
   /** Transaction-bound SQL handle (MUST be the window-write transaction). */
   tx: DbClient;
@@ -68,6 +71,14 @@ export interface PromoteKeyedEntitiesParams {
   organizationId: string;
   /** The finalized window identity (canvas ROOT event id) this completion produced/reused. */
   windowId: number;
+  /**
+   * The exact content IDs the window_token granted for this completion.
+   * A promoted row may cite its origin via `source_event_id`; that value comes
+   * from agent output and is otherwise stored verbatim, so an agent could point
+   * a promotion at content its window never read. Citations outside this set are
+   * dropped (the row still promotes — only the unverifiable claim is removed).
+   */
+  validContentIds: Set<number>;
   /** The watcher's bound parent entity (entity_ids[0]); null when unbound. */
   parentEntityId: number | null;
   /**
@@ -473,7 +484,9 @@ export async function promoteKeyedEntities(
     organizationId,
     windowId,
     parentEntityId,
+    validContentIds,
   } = params;
+  let droppedCitations = 0;
   const result: PromoteKeyedEntitiesResult = {
     promoted: 0,
     created: 0,
@@ -565,6 +578,27 @@ export async function promoteKeyedEntities(
     const fieldValues = Object.fromEntries(
       Object.entries(entityRecord).filter(([k]) => k !== keyingConfig.key_output_field)
     );
+    // `source_event_id` is an agent-authored provenance claim. Keep it only when
+    // it names content this window actually read — same rule the classifier
+    // applies to citations. An unverifiable id is worse than none: it reads like
+    // proof of origin while pointing anywhere in the org.
+    if (SOURCE_EVENT_ID_FIELD in fieldValues) {
+      const claimed = Number(fieldValues[SOURCE_EVENT_ID_FIELD]);
+      if (!Number.isFinite(claimed) || !validContentIds.has(Math.trunc(claimed))) {
+        logger.warn(
+          {
+            watcherId,
+            organizationId,
+            windowId,
+            stableKey,
+            claimedSourceEventId: fieldValues[SOURCE_EVENT_ID_FIELD],
+          },
+          '[promote-keyed-entities] dropping source_event_id not present in this window'
+        );
+        delete fieldValues[SOURCE_EVENT_ID_FIELD];
+        droppedCitations += 1;
+      }
+    }
     const metadata: Record<string, unknown> = {
       ...fieldValues,
       watcher_id: watcherId,
@@ -668,6 +702,7 @@ export async function promoteKeyedEntities(
       entityTypeSlug,
       promoted: result.promoted,
       created: result.created,
+      droppedCitations,
     },
     '[promote-keyed-entities] promoted keyed window rows into entities'
   );


### PR DESCRIPTION
`complete_window` validates `window_token` content_ids strictly — required, deduped, cross-checked against `content_count` — and passes the resulting set to the classifier, which drops citations outside it (`classifier-extraction.ts:932`).

Promotion never got the same treatment: `promoteKeyedEntities` had **no `validContentIds` parameter at all**. Not a bypassed check — one that was never wired in.

## Why it matters

A promoted row's `source_event_id` comes from agent output and was written verbatim into entity metadata. Nothing checked it named content the window actually read, so an agent could point a promotion at any event in the org. The stored id then reads like proof of origin.

In production, **10 of 16** promoted entities carry this field.

## Fix

Drop a `source_event_id` that is not in the window's granted content, and count the drops in the completion log. The row still promotes — only the unverifiable claim is removed. Same rule the classifier already applies.

`validContentIds` is now built once above STEP 8.5 and shared by promotion and classification, rather than defined mid-function for one consumer.

## Evidence (red → green)

With the guard removed, the out-of-window id persists:
```
AssertionError: expected '4' to be null
```
With it, the completion log shows the intended split:
```
promoted: 2, created: 2, droppedCitations: 1
[promote-keyed-entities] dropping source_event_id not present in this window
```
The in-window id is kept, the out-of-window id stripped, and **both rows still promote**.

Full `watchers` suite: 152/152 passing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->