### PR TITLE
docs(sdk): correct knowledge namespace comment — delete is SDK-only

### DIFF
--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -1,12 +1,9 @@
 /**
  * ClientSDK `knowledge` namespace.
  *
- * Wraps `search_memory`, `saveContent` (save_memory),
- * `getContent` (read_knowledge), and `deleteContent`.
- * Delete is SDK-only (`client.knowledge.delete` → unregistered
- * handler in `tools/delete_content.ts`; there is no registered
- * `delete_knowledge` MCP tool). Whether delete should also be a
- * registered tool (parity with `save_memory`) is an open product decision.
+ * Wraps the `search_memory`, `save_memory`, and `read_knowledge` handlers.
+ * `deleteContent` is SDK-only, exposed as `client.knowledge.delete` rather
+ * than as a registered MCP tool.
  */
 
 import type { Env } from "../../index";

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -2,8 +2,11 @@
  * ClientSDK `knowledge` namespace.
  *
  * Wraps `search_memory`, `saveContent` (save_memory),
- * `getContent` (read_knowledge), and `deleteContent` (delete_knowledge).
- * The SDK surface mirrors the MCP tool surface for consistency.
+ * `getContent` (read_knowledge), and `deleteContent`.
+ * Delete is SDK-only (`client.knowledge.delete` → unregistered
+ * handler in `tools/delete_content.ts`; there is no registered
+ * `delete_knowledge` MCP tool). Whether delete should also be a
+ * registered tool (parity with `save_memory`) is an open product decision.
  */
 
 import type { Env } from "../../index";


### PR DESCRIPTION
The `knowledge` namespace docblock claimed `deleteContent` wraps a `delete_knowledge` MCP tool. No such tool is registered — the delete path exists only as `client.knowledge.delete` → `tools/delete_content.ts`, an unregistered handler.

Found while auditing the MCP/SDK surface after the watcher→Behaviors consolidation. Pure comment correction, no behavior change.

## Validation
- `make pre-pr` clean
- `make review`: bug_free 98, 0 bugs, 0 blockers (reviewer independently confirmed `delete_knowledge` is absent from the registry; tool-registry-split 5/5)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that knowledge content deletion is available through the SDK rather than as an MCP tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->