### PR TITLE
docs(tools): fix stale SDK-namespace glossary in the tool registry

### DIFF
--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -6,10 +6,10 @@
  *
  * Glossary — "namespace" in tool descriptions below means three different things,
  * none of which is a memory-scope axis:
- *   1. `search_sdk`'s `namespace` param — a ClientSDK module name
+ *   1. A namespace passed in `search_sdk`'s `query` param — a ClientSDK property name
  *      (`behaviors`, `entities`, `knowledge`, ...).
  *   2. `resolve_path`'s "namespace-based URL path" — the first URL segment
- *      (org slug or entity-type slug).
+ *      (an organization slug or `@user` handle).
  *   3. `entity_identities.namespace` (deep in SQL) — the identifier type
  *      (`email`, `phone`, `wa_jid`); see `identity-normalize.ts`.
  *

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -7,7 +7,7 @@
  * Glossary — "namespace" in tool descriptions below means three different things,
  * none of which is a memory-scope axis:
  *   1. `search_sdk`'s `namespace` param — a ClientSDK module name
- *      (`watchers`, `entities`, `knowledge`, ...).
+ *      (`behaviors`, `entities`, `knowledge`, ...).
  *   2. `resolve_path`'s "namespace-based URL path" — the first URL segment
  *      (org slug or entity-type slug).
  *   3. `entity_identities.namespace` (deep in SQL) — the identifier type


### PR DESCRIPTION
The registry glossary still described the `search_sdk` namespace as `watchers`; the public ClientSDK namespace has been `behaviors` since #2034.

While in there, review-fix corrected two further inaccuracies I verified against the implementation:
- `search_sdk` takes a `query` param (a namespace is one accepted form), not a `namespace` param — see `sdk_search.ts:67`
- `resolve_path`'s first URL segment is an org slug or an `@user` handle (`resolve_path.ts:357`), not an entity-type slug

Comment-only, no behavior change.

## Validation
- `make pre-pr` clean
- `make review`: bug_free 97, 0 bugs, 0 blockers (reviewer independently verified both corrections against the schema and owner-parsing code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the meaning of “namespace” in tool descriptions.
  * Distinguished SDK property names from organization slugs or user handles used in URL paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->