### PR TITLE
feat(sdk): notifications.list + notifications.markRead

### DIFF
--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -155,16 +155,26 @@ describe("sandbox runtime", () => {
     });
   });
 
-  it("read mode: a known-but-hidden namespace throws a structured error, not undefined", async () => {
-    // `notifications` has only a write method (`send`), so read mode filters the
-    // whole namespace out of the manifest. Before the stub, `client.notifications`
-    // was undefined and the guest died with the opaque "Cannot read properties of
-    // undefined (reading 'send')". Now it must throw a NamespaceNotAvailable error
-    // naming the namespace, so discovery and runtime agree.
+  it("read mode: notifications.send is absent while list is callable", async () => {
+    // list/markRead are read-tier; send stays write-only. Guest-side manifest
+    // strips send so calling it is a TypeError (not a host dispatch). list still
+    // dispatches when the host SDK exposes it.
     const stubSdk = {
+      notifications: {
+        list: async () => ({ notifications: [], nextCursor: null }),
+      },
       query: async () => [],
       log: () => undefined,
     } as unknown as ClientSDK;
+
+    const listed = await runScript({
+      source:
+        "export default async (_ctx, client) => client.notifications.list({ unread_only: true });",
+      sdk: stubSdk,
+      sdkMode: "read",
+    });
+    expect(listed.success).toBe(true);
+    expect(listed.returnValue).toEqual({ notifications: [], nextCursor: null });
 
     const result = await runScript({
       source:
@@ -174,8 +184,7 @@ describe("sandbox runtime", () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error?.message).toContain("NamespaceNotAvailable");
-    expect(result.error?.message).toContain("notifications");
+    expect(result.error?.message ?? "").toMatch(/not a function|undefined/i);
     // The stub must NOT dispatch to the host — it fails guest-side.
     expect(result.sdkCalls).toBe(0);
   });

--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -155,10 +155,7 @@ describe("sandbox runtime", () => {
     });
   });
 
-  it("read mode: notifications.send is absent while list is callable", async () => {
-    // list/markRead are read-tier; send stays write-only. Guest-side manifest
-    // strips send so calling it is a TypeError (not a host dispatch). list still
-    // dispatches when the host SDK exposes it.
+  it("read mode: notification mutations are absent while list is callable", async () => {
     const stubSdk = {
       notifications: {
         list: async () => ({ notifications: [], nextCursor: null }),
@@ -176,17 +173,21 @@ describe("sandbox runtime", () => {
     expect(listed.success).toBe(true);
     expect(listed.returnValue).toEqual({ notifications: [], nextCursor: null });
 
-    const result = await runScript({
-      source:
-        "export default async (_ctx, client) => client.notifications.send({ title: 'x' });",
-      sdk: stubSdk,
-      sdkMode: "read",
-    });
+    for (const call of [
+      "client.notifications.markRead(1)",
+      "client.notifications.send({ title: 'x' })",
+    ]) {
+      const result = await runScript({
+        source: `export default async (_ctx, client) => ${call};`,
+        sdk: stubSdk,
+        sdkMode: "read",
+      });
 
-    expect(result.success).toBe(false);
-    expect(result.error?.message ?? "").toMatch(/not a function|undefined/i);
-    // The stub must NOT dispatch to the host — it fails guest-side.
-    expect(result.sdkCalls).toBe(0);
+      expect(result.success).toBe(false);
+      expect(result.error?.message ?? "").toMatch(/not a function|undefined/i);
+      // The mutation must fail guest-side without dispatching to the host.
+      expect(result.sdkCalls).toBe(0);
+    }
   });
 
   it("read mode: a genuinely unknown namespace stays undefined (not a false stub)", async () => {

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -317,6 +317,7 @@ describe("method-metadata", () => {
 			["authProfiles.get", "auth_profile_slug"],
 			["authProfiles.test", "auth_profile_slug"],
 			["authProfiles.delete", "auth_profile_slug"],
+			["notifications.markRead", "notification_id"],
 		];
 		for (const [path, field] of positional) {
 			const sig = METHOD_METADATA[path]?.signature ?? "";

--- a/packages/server/src/__tests__/unit/sandbox/notifications-namespace.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/notifications-namespace.test.ts
@@ -1,0 +1,120 @@
+/**
+ * notifications SDK namespace — list/markRead parity with REST.
+ *
+ * Proves the SDK methods call the same service layer as REST (listNotifications /
+ * markAsRead) rather than reimplementing SQL, and that list → markRead round-trips.
+ */
+
+import { beforeAll, describe, expect, it, mock } from "bun:test";
+import type { Env } from "../../../index";
+import type { ToolContext } from "../../../tools/registry";
+
+const listCalls: Array<Record<string, unknown>> = [];
+const markCalls: Array<{ organizationId: string; userId: string; id: number }> =
+	[];
+let listResult: {
+	notifications: Array<Record<string, unknown>>;
+	nextCursor: number | null;
+} = { notifications: [], nextCursor: null };
+let markResult = true;
+
+mock.module("../../../notifications/service", () => ({
+	listNotifications: async (opts: Record<string, unknown>) => {
+		listCalls.push(opts);
+		return listResult;
+	},
+	markAsRead: async (
+		organizationId: string,
+		userId: string,
+		notificationId: number,
+	) => {
+		markCalls.push({ organizationId, userId, id: notificationId });
+		return markResult;
+	},
+}));
+
+mock.module("../../../tools/admin/notify", () => ({
+	notify: async () => ({ notified_count: 0 }),
+}));
+
+const env = { ENVIRONMENT: "test" } as Env;
+const ctx = {
+	organizationId: "org-1",
+	userId: "user-1",
+} as ToolContext;
+
+let buildNotificationsNamespace: typeof import("../../../sandbox/namespaces/notifications").buildNotificationsNamespace;
+
+beforeAll(async () => {
+	({ buildNotificationsNamespace } = await import(
+		"../../../sandbox/namespaces/notifications"
+	));
+});
+
+describe("notifications namespace — list/markRead", () => {
+	it("list forwards org/user scope and pagination to the shared service", async () => {
+		listCalls.length = 0;
+		listResult = {
+			notifications: [{ id: 10, title: "Hello", is_read: false }],
+			nextCursor: null,
+		};
+		const ns = buildNotificationsNamespace(ctx, env);
+
+		const result = await ns.list({ cursor: 99, limit: 5, unread_only: true });
+
+		expect(listCalls).toEqual([
+			{
+				organizationId: "org-1",
+				userId: "user-1",
+				cursor: 99,
+				limit: 5,
+				unreadOnly: true,
+			},
+		]);
+		expect(result).toEqual({
+			notifications: [{ id: 10, title: "Hello", is_read: false }],
+			nextCursor: null,
+		});
+	});
+
+	it("list → markRead round-trip marks the listed notification as read", async () => {
+		listCalls.length = 0;
+		markCalls.length = 0;
+		listResult = {
+			notifications: [{ id: 42, title: "Ack me", is_read: false }],
+			nextCursor: null,
+		};
+		markResult = true;
+		const ns = buildNotificationsNamespace(ctx, env);
+
+		const listed = await ns.list({ unread_only: true });
+		const id = (listed.notifications[0] as { id: number }).id;
+		const marked = await ns.markRead({ notification_id: id });
+
+		expect(markCalls).toEqual([
+			{ organizationId: "org-1", userId: "user-1", id: 42 },
+		]);
+		expect(marked).toEqual({ success: true });
+	});
+
+	it("markRead accepts a positional notification id", async () => {
+		markCalls.length = 0;
+		markResult = true;
+		const ns = buildNotificationsNamespace(ctx, env);
+
+		await ns.markRead(7);
+
+		expect(markCalls).toEqual([
+			{ organizationId: "org-1", userId: "user-1", id: 7 },
+		]);
+	});
+
+	it("markRead throws when the target is missing or already read", async () => {
+		markResult = false;
+		const ns = buildNotificationsNamespace(ctx, env);
+
+		await expect(ns.markRead({ notification_id: 404 })).rejects.toThrow(
+			/not found or already read/i,
+		);
+	});
+});

--- a/packages/server/src/__tests__/unit/sandbox/notifications-namespace.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/notifications-namespace.test.ts
@@ -2,7 +2,7 @@
  * notifications SDK namespace — list/markRead parity with REST.
  *
  * Proves the SDK methods call the same service layer as REST (listNotifications /
- * markAsRead) rather than reimplementing SQL, and that list → markRead round-trips.
+ * markAsRead) rather than reimplementing SQL.
  */
 
 import { beforeAll, describe, expect, it, mock } from "bun:test";
@@ -77,7 +77,7 @@ describe("notifications namespace — list/markRead", () => {
 		});
 	});
 
-	it("list → markRead round-trip marks the listed notification as read", async () => {
+	it("markRead forwards an id returned by list", async () => {
 		listCalls.length = 0;
 		markCalls.length = 0;
 		listResult = {
@@ -116,5 +116,18 @@ describe("notifications namespace — list/markRead", () => {
 		await expect(ns.markRead({ notification_id: 404 })).rejects.toThrow(
 			/not found or already read/i,
 		);
+	});
+
+	it("rejects inbox access without an authenticated user", async () => {
+		listCalls.length = 0;
+		markCalls.length = 0;
+		const ns = buildNotificationsNamespace({ ...ctx, userId: null }, env);
+
+		await expect(ns.list()).rejects.toThrow(/authenticated user required/i);
+		await expect(ns.markRead(7)).rejects.toThrow(
+			/authenticated user required/i,
+		);
+		expect(listCalls).toEqual([]);
+		expect(markCalls).toEqual([]);
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -183,17 +183,26 @@ describe("sdkSearch", () => {
 		expect(result.notes ?? "").not.toContain("none are visible");
 	});
 
-	it("names a write-only namespace in read mode instead of a silent dead end", async () => {
-		// A namespace whose methods are ALL non-read (notifications = send only) is
-		// filtered out of read mode. search_sdk must still hint that it exists behind
-		// run_sdk, not return an empty dead end that reads as "does not exist".
-		const result = await sdkSearch(
+	it("discovers notifications.list / markRead in read mode; send needs run_sdk", async () => {
+		// Inbox read/ack are read-tier; send remains write-only.
+		const listed = await sdkSearch(
 			{ query: "notifications", mode: "read" },
 			stubEnv,
 			readCtx
 		);
-		expect(result.notes ?? "").toContain("notifications.*");
-		expect(result.notes ?? "").toContain("run_sdk");
+		expect(listed.match_count).toBeGreaterThan(0);
+		const joined = listed.results.join("\n");
+		expect(joined).toContain("notifications.list");
+		expect(joined).toContain("notifications.markRead");
+		expect(joined).not.toContain("notifications.send");
+
+		const send = await sdkSearch(
+			{ query: "notifications.send", mode: "read" },
+			stubEnv,
+			readCtx
+		);
+		expect(send.match_count).toBe(0);
+		expect(send.notes ?? "").toContain("run_sdk");
 	});
 
 	it("shows admin methods to admin-tier callers", async () => {

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -183,8 +183,7 @@ describe("sdkSearch", () => {
 		expect(result.notes ?? "").not.toContain("none are visible");
 	});
 
-	it("discovers notifications.list / markRead in read mode; send needs run_sdk", async () => {
-		// Inbox read/ack are read-tier; send remains write-only.
+	it("discovers notifications.list in read mode; mutations need run_sdk", async () => {
 		const listed = await sdkSearch(
 			{ query: "notifications", mode: "read" },
 			stubEnv,
@@ -193,16 +192,16 @@ describe("sdkSearch", () => {
 		expect(listed.match_count).toBeGreaterThan(0);
 		const joined = listed.results.join("\n");
 		expect(joined).toContain("notifications.list");
-		expect(joined).toContain("notifications.markRead");
+		expect(joined).not.toContain("notifications.markRead");
 		expect(joined).not.toContain("notifications.send");
 
-		const send = await sdkSearch(
-			{ query: "notifications.send", mode: "read" },
+		const markRead = await sdkSearch(
+			{ query: "notifications.markRead", mode: "read" },
 			stubEnv,
 			readCtx
 		);
-		expect(send.match_count).toBe(0);
-		expect(send.notes ?? "").toContain("run_sdk");
+		expect(markRead.match_count).toBe(0);
+		expect(markRead.notes ?? "").toContain("run_sdk");
 	});
 
 	it("shows admin methods to admin-tier callers", async () => {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -471,24 +471,22 @@ export default async (_ctx, client) => {
 			"notifications.list(input?: { cursor?: number | null; limit?: number; unread_only?: boolean }): Promise<{ notifications: object[]; nextCursor: number | null }>",
 		example:
 			"const { notifications, nextCursor } = await client.notifications.list({ unread_only: true, limit: 20 });",
-		usageExample: `// Read unread inbox items, then ack each.
+		usageExample: `// Read unread inbox items without changing their state.
 export default async (_ctx, client) => {
-  const { notifications } = await client.notifications.list({ unread_only: true });
-  for (const n of notifications) {
-    await client.notifications.markRead({ notification_id: n.id });
-  }
-  return { acked: notifications.length };
+  const { notifications, nextCursor } = await client.notifications.list({
+    unread_only: true,
+    limit: 20,
+  });
+  return { notifications, nextCursor };
 };`,
 	},
 	"notifications.markRead": {
 		summary:
-			"Mark one of the caller's notifications as read (same store as REST POST /notifications/:id/read). Accepts a positional id or `{ notification_id }`. Returns `{ success: true }` or throws when missing/already read.",
-		access: "read",
+			"Mark one of the caller's notifications as read (same store as REST PATCH /notifications/:id/read). Accepts a positional id or `{ notification_id }`. Returns `{ success: true }` or throws when missing/already read. Use via run_sdk because it changes inbox state.",
+		access: "write",
 		signature:
 			"notifications.markRead(notification_id: number): Promise<{ success: true }> // or notifications.markRead({ notification_id })",
-		throws: ["NotFound"],
-		example:
-			"await client.notifications.markRead({ notification_id: 42 });",
+		example: "await client.notifications.markRead({ notification_id: 42 });",
 	},
 	"notifications.send": {
 		summary:

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -463,6 +463,33 @@ export default async (_ctx, client) => {
 	},
 
 	// notifications
+	"notifications.list": {
+		summary:
+			"List the caller's in-app inbox notifications (same store as REST GET /notifications). Keyset-paginated by event id; optional unread_only filter. Returns `{ notifications, nextCursor }`.",
+		access: "read",
+		signature:
+			"notifications.list(input?: { cursor?: number | null; limit?: number; unread_only?: boolean }): Promise<{ notifications: object[]; nextCursor: number | null }>",
+		example:
+			"const { notifications, nextCursor } = await client.notifications.list({ unread_only: true, limit: 20 });",
+		usageExample: `// Read unread inbox items, then ack each.
+export default async (_ctx, client) => {
+  const { notifications } = await client.notifications.list({ unread_only: true });
+  for (const n of notifications) {
+    await client.notifications.markRead({ notification_id: n.id });
+  }
+  return { acked: notifications.length };
+};`,
+	},
+	"notifications.markRead": {
+		summary:
+			"Mark one of the caller's notifications as read (same store as REST POST /notifications/:id/read). Accepts a positional id or `{ notification_id }`. Returns `{ success: true }` or throws when missing/already read.",
+		access: "read",
+		signature:
+			"notifications.markRead(notification_id: number): Promise<{ success: true }> // or notifications.markRead({ notification_id })",
+		throws: ["NotFound"],
+		example:
+			"await client.notifications.markRead({ notification_id: 42 });",
+	},
 	"notifications.send": {
 		summary:
 			"Send a notification to org users. Writes an `agent_message` notification (in-app inbox) and fans it out to the org's active bot connections (Slack/Telegram) — the way a Behavior reaction surfaces its digest to a chat channel. Pass an optional `card` (a `chat` CardElement) for rich cross-platform rendering, and `behavior_source` when firing from a reaction.",

--- a/packages/server/src/sandbox/namespaces/notifications.ts
+++ b/packages/server/src/sandbox/namespaces/notifications.ts
@@ -1,14 +1,24 @@
 /**
- * ClientSDK `notifications` namespace — a thin wrapper over the `notify` tool
- * that lets reactions (and `run_sdk` scripts) write a notification to the inbox
- * and fan it out to the org's bot connections (Slack/Telegram).
+ * ClientSDK `notifications` namespace.
+ *
+ * `send` wraps the `notify` tool (in-app inbox + bot fan-out). `list` /
+ * `markRead` reuse the REST service layer (`listNotifications` / `markAsRead`)
+ * so agents can read and ack their own inbox without duplicate SQL.
+ *
+ * SDK-only by design — no `manage_notifications` MCP tool; agents compose
+ * through `query_sdk` / `run_sdk` like other admin namespaces.
  */
 
 import type { CardElement } from "chat";
 import type { Env } from "../../index";
+import {
+	listNotifications,
+	markAsRead,
+} from "../../notifications/service";
 import { notify } from "../../tools/admin/notify";
 import type { ToolContext } from "../../tools/registry";
-import { createActionCaller } from "./action-call";
+import { ToolUserError } from "../../utils/errors";
+import { createActionCaller, idArg } from "./action-call";
 
 export interface NotificationsSendInput {
 	/** Notification title (≤200 chars). */
@@ -35,8 +45,37 @@ export interface NotificationsSendInput {
 	behavior_source?: { behavior_id: number; window_id: number };
 }
 
+export interface NotificationsListInput {
+	/** Keyset cursor: return notifications with id strictly less than this. */
+	cursor?: number | null;
+	/** Page size (service caps at 50; default 20). */
+	limit?: number;
+	/** When true, only unread notifications. */
+	unread_only?: boolean;
+}
+
+export interface NotificationsListResult {
+	notifications: Record<string, unknown>[];
+	nextCursor: number | null;
+}
+
 export interface NotificationsNamespace {
 	send(input: NotificationsSendInput): Promise<{ notified_count: number }>;
+	list(input?: NotificationsListInput): Promise<NotificationsListResult>;
+	/**
+	 * Mark one of the caller's notifications as read. Accepts a positional id
+	 * or `{ notification_id }`.
+	 */
+	markRead(
+		notificationId: number | { notification_id: number },
+	): Promise<{ success: true }>;
+}
+
+function requireUserId(ctx: ToolContext): string {
+	if (!ctx.userId) {
+		throw new ToolUserError("Authenticated user required", 401);
+	}
+	return ctx.userId;
 }
 
 export function buildNotificationsNamespace(
@@ -47,5 +86,29 @@ export function buildNotificationsNamespace(
 
 	return {
 		send: (input) => action("send", input),
+		async list(input) {
+			const userId = requireUserId(ctx);
+			return listNotifications({
+				organizationId: ctx.organizationId,
+				userId,
+				cursor: input?.cursor ?? null,
+				limit: input?.limit,
+				unreadOnly: input?.unread_only ?? false,
+			});
+		},
+		async markRead(notificationId) {
+			const userId = requireUserId(ctx);
+			const id = idArg(
+				"notifications.markRead",
+				"notification_id",
+				notificationId,
+				"number",
+			) as number;
+			const updated = await markAsRead(ctx.organizationId, userId, id);
+			if (!updated) {
+				throw new ToolUserError("Not found or already read", 404);
+			}
+			return { success: true as const };
+		},
 	};
 }

--- a/packages/server/src/sandbox/namespaces/notifications.ts
+++ b/packages/server/src/sandbox/namespaces/notifications.ts
@@ -3,18 +3,14 @@
  *
  * `send` wraps the `notify` tool (in-app inbox + bot fan-out). `list` /
  * `markRead` reuse the REST service layer (`listNotifications` / `markAsRead`)
- * so agents can read and ack their own inbox without duplicate SQL.
- *
- * SDK-only by design — no `manage_notifications` MCP tool; agents compose
- * through `query_sdk` / `run_sdk` like other admin namespaces.
+ * so callers can read and ack their own inbox without duplicate SQL. Reading
+ * is available through `query_sdk`; acknowledging changes state and requires
+ * `run_sdk`.
  */
 
 import type { CardElement } from "chat";
 import type { Env } from "../../index";
-import {
-	listNotifications,
-	markAsRead,
-} from "../../notifications/service";
+import { listNotifications, markAsRead } from "../../notifications/service";
 import { notify } from "../../tools/admin/notify";
 import type { ToolContext } from "../../tools/registry";
 import { ToolUserError } from "../../utils/errors";


### PR DESCRIPTION
## Summary
The SDK `notifications` namespace was send-only while REST already had list / markAsRead / delete — so an agent could send a notification but never read or acknowledge one. Found while auditing SDK/MCP/REST/CLI parity after the Behaviors consolidation.

Adds `notifications.list` (keyset paging, `unread_only`) and `notifications.markRead`, both reusing the existing REST service layer (`listNotifications` / `markAsRead`) rather than duplicating SQL. Org- and user-scoped; throws 401 without an authenticated user.

## Access tiers
`list` is read-tier (`query_sdk`). `markRead` is **write**-tier — it mutates inbox state, and `sdkMethodVisible` gates purely on the metadata `access` field (`sdk-manifest.ts:53`), so tagging it `read` would have exposed a mutation through the read-only tier. Caught in review-fix.

## Validation
- `make pre-pr` clean; sandbox unit suites 117/117
- `run-script-runtime` vitest suite 10/10 (the reviewer's sandbox blocked Vite's temp config, so I ran it directly)
- `make review`: bug_free 87, 0 bugs, 0 blockers

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->