### PR TITLE
fix(core): single-source the interaction-envelope wire literals

### DIFF
--- a/packages/agent-worker/src/__tests__/custom-tools.test.ts
+++ b/packages/agent-worker/src/__tests__/custom-tools.test.ts
@@ -450,4 +450,17 @@ describe("maybePostApprovalCard", () => {
     expect(posted).toBe(false);
     expect(posts).toHaveLength(0);
   });
+
+  test("does nothing for a non-object JSON result", async () => {
+    const posts: string[] = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      posts.push(String(input));
+      return Response.json({});
+    }) as unknown as typeof fetch;
+
+    const posted = await maybePostApprovalCard(gw, "manage_agents", "null");
+
+    expect(posted).toBe(false);
+    expect(posts).toHaveLength(0);
+  });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,12 @@
       "import": "./dist/contracts/agent-settings.js",
       "require": "./dist/contracts/agent-settings.js"
     },
+    "./contracts/interaction-envelope": {
+      "types": "./dist/contracts/interaction-envelope.d.ts",
+      "bun": "./src/contracts/interaction-envelope.ts",
+      "import": "./dist/contracts/interaction-envelope.js",
+      "require": "./dist/contracts/interaction-envelope.js"
+    },
     "./contracts/worker/protocol": {
       "types": "./dist/contracts/worker/protocol.d.ts",
       "bun": "./src/contracts/worker/protocol.ts",

--- a/packages/core/src/__tests__/interaction-envelope-parity.test.ts
+++ b/packages/core/src/__tests__/interaction-envelope-parity.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Cross-side guard: SPA-accepted interaction-envelope literals must match the
+ * core TypeBox contract. Owletto is a git submodule and cannot import server
+ * packages at build time in every CI configuration, so we parse the SPA wire
+ * check sites with a regex (same pattern as subdomain-reserved-parity).
+ *
+ * A literal added only in core (or only in the SPA) fails this test — the
+ * recurrence-preventer for the resourceKind/attribution drift bug.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import {
+  APPROVAL_ATTRIBUTIONS,
+  INTERACTION_RESOURCE_KINDS,
+} from "../contracts/interaction-envelope";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+
+/** SPA files that hard-code accepted resourceKind / attribution wire values. */
+const SPA_WIRE_FILES = [
+  "packages/owletto/src/components/agents/agent-thread.tsx",
+  "packages/owletto/src/lib/api/runs.ts",
+  "packages/owletto/src/lib/api/agents.ts",
+] as const;
+
+function extractQuotedLiterals(
+  source: string,
+  field: "resourceKind" | "attribution"
+): string[] {
+  const found = new Set<string>();
+
+  // Comparisons: resourceKind === "behavior", attribution !== 'agent'
+  const cmp = new RegExp(`${field}\\s*(?:===|!==)\\s*['"]([^'"]+)['"]`, "g");
+  for (const m of source.matchAll(cmp)) {
+    found.add(m[1]!);
+  }
+
+  // Type / JSDoc unions: resourceKind: 'agent' | 'behavior' | null
+  // Also: attribution: 'agent' | 'behavior'
+  const union = new RegExp(
+    `${field}\\??\\s*:\\s*((?:['"][^'"]+['"]\\s*\\|\\s*)*['"][^'"]+['"](?:\\s*\\|\\s*null)?)`,
+    "g"
+  );
+  for (const m of source.matchAll(union)) {
+    for (const lit of m[1]!.matchAll(/['"]([^'"]+)['"]/g)) {
+      if (lit[1] !== "null") found.add(lit[1]!);
+    }
+  }
+
+  // JSDoc-only forms: attribution: 'agent' | 'behavior'.
+  const jsdoc = new RegExp(
+    `${field}[^\\n]*?((?:['"][^'"]+['"]\\s*\\|\\s*)+['"][^'"]+['"])`,
+    "g"
+  );
+  for (const m of source.matchAll(jsdoc)) {
+    for (const lit of m[1]!.matchAll(/['"]([^'"]+)['"]/g)) {
+      found.add(lit[1]!);
+    }
+  }
+
+  return [...found].sort();
+}
+
+function loadSpaLiterals(
+  field: "resourceKind" | "attribution"
+): string[] | null {
+  const found = new Set<string>();
+  let anyFile = false;
+  for (const rel of SPA_WIRE_FILES) {
+    const abs = join(REPO_ROOT, rel);
+    if (!existsSync(abs)) continue;
+    anyFile = true;
+    for (const lit of extractQuotedLiterals(readFileSync(abs, "utf8"), field)) {
+      found.add(lit);
+    }
+  }
+  if (!anyFile) return null; // submodule not checked out
+  return [...found].sort();
+}
+
+describe("interaction-envelope SPA/core parity", () => {
+  it("SPA resourceKind literals match INTERACTION_RESOURCE_KINDS", () => {
+    const spa = loadSpaLiterals("resourceKind");
+    if (spa === null) return; // skip when owletto is a stub
+    expect(spa).toEqual([...INTERACTION_RESOURCE_KINDS].sort());
+  });
+
+  it("SPA attribution literals match APPROVAL_ATTRIBUTIONS", () => {
+    const spa = loadSpaLiterals("attribution");
+    if (spa === null) return;
+    expect(spa).toEqual([...APPROVAL_ATTRIBUTIONS].sort());
+  });
+
+  it("core contract exports the expected canonical sets", () => {
+    // Pin the wire values so a silent rename in the const array is a test fail.
+    expect([...INTERACTION_RESOURCE_KINDS]).toEqual([
+      "agent",
+      "behavior",
+      "entity",
+    ]);
+    expect([...APPROVAL_ATTRIBUTIONS]).toEqual(["agent", "behavior"]);
+  });
+});

--- a/packages/core/src/__tests__/interaction-envelope-parity.test.ts
+++ b/packages/core/src/__tests__/interaction-envelope-parity.test.ts
@@ -14,6 +14,8 @@ import { describe, expect, it } from "bun:test";
 import {
   APPROVAL_ATTRIBUTIONS,
   INTERACTION_RESOURCE_KINDS,
+  isApprovalAttribution,
+  isInteractionResourceKind,
 } from "../contracts/interaction-envelope";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
@@ -46,17 +48,6 @@ function extractQuotedLiterals(
   for (const m of source.matchAll(union)) {
     for (const lit of m[1]!.matchAll(/['"]([^'"]+)['"]/g)) {
       if (lit[1] !== "null") found.add(lit[1]!);
-    }
-  }
-
-  // JSDoc-only forms: attribution: 'agent' | 'behavior'.
-  const jsdoc = new RegExp(
-    `${field}[^\\n]*?((?:['"][^'"]+['"]\\s*\\|\\s*)+['"][^'"]+['"])`,
-    "g"
-  );
-  for (const m of source.matchAll(jsdoc)) {
-    for (const lit of m[1]!.matchAll(/['"]([^'"]+)['"]/g)) {
-      found.add(lit[1]!);
     }
   }
 
@@ -94,12 +85,16 @@ describe("interaction-envelope SPA/core parity", () => {
   });
 
   it("core contract exports the expected canonical sets", () => {
-    // Pin the wire values so a silent rename in the const array is a test fail.
+    // Pin the wire values so a silent rename in the constants is a test fail.
     expect([...INTERACTION_RESOURCE_KINDS]).toEqual([
       "agent",
       "behavior",
       "entity",
     ]);
     expect([...APPROVAL_ATTRIBUTIONS]).toEqual(["agent", "behavior"]);
+    expect(isInteractionResourceKind("behavior")).toBe(true);
+    expect(isInteractionResourceKind("watcher")).toBe(false);
+    expect(isApprovalAttribution("agent")).toBe(true);
+    expect(isApprovalAttribution("watcher")).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/interaction-envelope-parity.test.ts
+++ b/packages/core/src/__tests__/interaction-envelope-parity.test.ts
@@ -27,11 +27,24 @@ const SPA_WIRE_FILES = [
   "packages/owletto/src/lib/api/agents.ts",
 ] as const;
 
+/**
+ * Blank out // and block comments, preserving newlines. JSDoc must NOT count as
+ * SPA support: a docblock saying `"agent" | "behavior"` while the code handles
+ * neither would otherwise satisfy this test (verified — deleting the SPA's only
+ * `attribution === "behavior"` branch still passed before this was added).
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/\/\/[^\n]*/g, "");
+}
+
 function extractQuotedLiterals(
-  source: string,
+  raw: string,
   field: "resourceKind" | "attribution"
 ): string[] {
   const found = new Set<string>();
+  const source = stripComments(raw);
 
   // Comparisons: resourceKind === "behavior", attribution !== 'agent'
   const cmp = new RegExp(`${field}\\s*(?:===|!==)\\s*['"]([^'"]+)['"]`, "g");
@@ -39,8 +52,7 @@ function extractQuotedLiterals(
     found.add(m[1]!);
   }
 
-  // Type / JSDoc unions: resourceKind: 'agent' | 'behavior' | null
-  // Also: attribution: 'agent' | 'behavior'
+  // Type unions: resourceKind: 'agent' | 'behavior' | null
   const union = new RegExp(
     `${field}\\??\\s*:\\s*((?:['"][^'"]+['"]\\s*\\|\\s*)*['"][^'"]+['"](?:\\s*\\|\\s*null)?)`,
     "g"
@@ -81,6 +93,9 @@ describe("interaction-envelope SPA/core parity", () => {
   it("SPA attribution literals match APPROVAL_ATTRIBUTIONS", () => {
     const spa = loadSpaLiterals("attribution");
     if (spa === null) return;
+    // The SPA declares the full union on the field type (agent | behavior) and
+    // branches explicitly on behavior. Requiring the whole set — from code, not
+    // JSDoc — is what makes a one-sided rename fail here.
     expect(spa).toEqual([...APPROVAL_ATTRIBUTIONS].sort());
   });
 

--- a/packages/core/src/contracts/interaction-envelope.ts
+++ b/packages/core/src/contracts/interaction-envelope.ts
@@ -1,0 +1,112 @@
+/**
+ * Interaction-envelope wire literals for durable approval cards
+ * (`tool_approval` transport via POST /internal/interactions/create).
+ *
+ * Why this exists: resourceKind / attribution were scattered string literals
+ * across plugin-mcp, server tools, gateway routes, and the SPA. A rename on
+ * one side (e.g. watcher → behavior) silently broke card routing on another
+ * (plugin-mcp kept emitting "watcher" while owletto routed on "behavior").
+ *
+ * Single source:
+ *  - Emitters import the const objects below (no bare string literals).
+ *  - TypeBox schemas derive Static<> types for compile-time checking.
+ *  - A parity test asserts SPA-side accepted literals match these unions.
+ *
+ * Config-audit `resourceKind` (deployments feed: connection, feed, …) is a
+ * separate vocabulary (`ConfigResourceKind` on the server) — do not mix it
+ * into this envelope.
+ */
+
+import { type Static, Type } from "@sinclair/typebox";
+
+// ── resourceKind (approval card / interaction payload) ──────────────────────
+
+/**
+ * Canonical resourceKind values on the tool_approval interaction envelope.
+ * Produced by plugin-mcp (card post) and manage_behaviors (event metadata);
+ * consumed by the SPA to pick the right approval card renderer.
+ */
+export const INTERACTION_RESOURCE_KINDS = [
+  "agent",
+  "behavior",
+  "entity",
+] as const;
+
+export type InteractionResourceKind =
+  (typeof INTERACTION_RESOURCE_KINDS)[number];
+
+export const InteractionResourceKindSchema = Type.Union(
+  INTERACTION_RESOURCE_KINDS.map((k) => Type.Literal(k))
+);
+
+/**
+ * Named constants for emitters. Prefer these over bare string literals so a
+ * typo is a type error and grep finds every producer via the import.
+ */
+export const InteractionResourceKind = {
+  Agent: "agent",
+  Behavior: "behavior",
+  Entity: "entity",
+} as const satisfies Record<string, InteractionResourceKind>;
+
+// ── attribution (who proposed a gated entity-field change) ──────────────────
+
+/**
+ * Who proposed a human-owned field change (entity_field_change cards).
+ * manage_entity emits this as approval_attribution; plugin-mcp forwards it as
+ * `attribution` on the interaction envelope; the SPA labels "An agent" vs
+ * "A Behavior".
+ */
+export const APPROVAL_ATTRIBUTIONS = ["agent", "behavior"] as const;
+
+export type ApprovalAttribution = (typeof APPROVAL_ATTRIBUTIONS)[number];
+
+export const ApprovalAttributionSchema = Type.Union(
+  APPROVAL_ATTRIBUTIONS.map((a) => Type.Literal(a))
+);
+
+export const ApprovalAttribution = {
+  Agent: "agent",
+  Behavior: "behavior",
+} as const satisfies Record<string, ApprovalAttribution>;
+
+/**
+ * Coerce a wire value to ApprovalAttribution. Unknown / missing → agent
+ * (matches the historical plugin-mcp default when attribution was absent).
+ */
+export function coerceApprovalAttribution(value: unknown): ApprovalAttribution {
+  return value === ApprovalAttribution.Behavior
+    ? ApprovalAttribution.Behavior
+    : ApprovalAttribution.Agent;
+}
+
+// ── tool_approval create body (worker → gateway) ────────────────────────────
+
+/**
+ * Body shape posted to POST /internal/interactions/create when
+ * interactionType === "tool_approval". Field optionality mirrors today's
+ * emitters (manage_agents omits fields/attribution; manage_entity may omit
+ * proposal). This is the shared type surface — runtime validation is still
+ * permissive at the route (legacy/malformed cards must not 500).
+ */
+export const ToolApprovalCreateBodySchema = Type.Object({
+  interactionType: Type.Literal("tool_approval"),
+  runId: Type.Number(),
+  action: Type.String(),
+  resourceKind: InteractionResourceKindSchema,
+  proposal: Type.Optional(
+    Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])
+  ),
+  current: Type.Optional(
+    Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])
+  ),
+  fields: Type.Optional(
+    Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])
+  ),
+  attribution: Type.Optional(
+    Type.Union([ApprovalAttributionSchema, Type.Null()])
+  ),
+});
+export type ToolApprovalCreateBody = Static<
+  typeof ToolApprovalCreateBodySchema
+>;

--- a/packages/core/src/contracts/interaction-envelope.ts
+++ b/packages/core/src/contracts/interaction-envelope.ts
@@ -7,9 +7,9 @@
  * one side (e.g. watcher → behavior) silently broke card routing on another
  * (plugin-mcp kept emitting "watcher" while owletto routed on "behavior").
  *
- * Single source:
- *  - Emitters import the const objects below (no bare string literals).
- *  - TypeBox schemas derive Static<> types for compile-time checking.
+ * Contract:
+ *  - Worker and server approval emitters import the named constants below.
+ *  - Literal arrays, TypeBox schemas, and Static<> types derive from them.
  *  - A parity test asserts SPA-side accepted literals match these unions.
  *
  * Config-audit `resourceKind` (deployments feed: connection, feed, …) is a
@@ -26,28 +26,28 @@ import { type Static, Type } from "@sinclair/typebox";
  * Produced by plugin-mcp (card post) and manage_behaviors (event metadata);
  * consumed by the SPA to pick the right approval card renderer.
  */
-export const INTERACTION_RESOURCE_KINDS = [
-  "agent",
-  "behavior",
-  "entity",
-] as const;
-
-export type InteractionResourceKind =
-  (typeof INTERACTION_RESOURCE_KINDS)[number];
-
-export const InteractionResourceKindSchema = Type.Union(
-  INTERACTION_RESOURCE_KINDS.map((k) => Type.Literal(k))
-);
-
-/**
- * Named constants for emitters. Prefer these over bare string literals so a
- * typo is a type error and grep finds every producer via the import.
- */
 export const InteractionResourceKind = {
   Agent: "agent",
   Behavior: "behavior",
   Entity: "entity",
-} as const satisfies Record<string, InteractionResourceKind>;
+} as const;
+
+export type InteractionResourceKind =
+  (typeof InteractionResourceKind)[keyof typeof InteractionResourceKind];
+
+export const INTERACTION_RESOURCE_KINDS = Object.freeze(
+  Object.values(InteractionResourceKind)
+);
+
+export const InteractionResourceKindSchema = Type.Union(
+  INTERACTION_RESOURCE_KINDS.map((kind) => Type.Literal(kind))
+);
+
+export function isInteractionResourceKind(
+  value: unknown
+): value is InteractionResourceKind {
+  return INTERACTION_RESOURCE_KINDS.some((kind) => kind === value);
+}
 
 // ── attribution (who proposed a gated entity-field change) ──────────────────
 
@@ -57,27 +57,34 @@ export const InteractionResourceKind = {
  * `attribution` on the interaction envelope; the SPA labels "An agent" vs
  * "A Behavior".
  */
-export const APPROVAL_ATTRIBUTIONS = ["agent", "behavior"] as const;
-
-export type ApprovalAttribution = (typeof APPROVAL_ATTRIBUTIONS)[number];
-
-export const ApprovalAttributionSchema = Type.Union(
-  APPROVAL_ATTRIBUTIONS.map((a) => Type.Literal(a))
-);
-
 export const ApprovalAttribution = {
   Agent: "agent",
   Behavior: "behavior",
-} as const satisfies Record<string, ApprovalAttribution>;
+} as const;
+
+export type ApprovalAttribution =
+  (typeof ApprovalAttribution)[keyof typeof ApprovalAttribution];
+
+export const APPROVAL_ATTRIBUTIONS = Object.freeze(
+  Object.values(ApprovalAttribution)
+);
+
+export const ApprovalAttributionSchema = Type.Union(
+  APPROVAL_ATTRIBUTIONS.map((attribution) => Type.Literal(attribution))
+);
+
+export function isApprovalAttribution(
+  value: unknown
+): value is ApprovalAttribution {
+  return APPROVAL_ATTRIBUTIONS.some((attribution) => attribution === value);
+}
 
 /**
  * Coerce a wire value to ApprovalAttribution. Unknown / missing → agent
  * (matches the historical plugin-mcp default when attribution was absent).
  */
 export function coerceApprovalAttribution(value: unknown): ApprovalAttribution {
-  return value === ApprovalAttribution.Behavior
-    ? ApprovalAttribution.Behavior
-    : ApprovalAttribution.Agent;
+  return isApprovalAttribution(value) ? value : ApprovalAttribution.Agent;
 }
 
 // ── tool_approval create body (worker → gateway) ────────────────────────────
@@ -86,8 +93,8 @@ export function coerceApprovalAttribution(value: unknown): ApprovalAttribution {
  * Body shape posted to POST /internal/interactions/create when
  * interactionType === "tool_approval". Field optionality mirrors today's
  * emitters (manage_agents omits fields/attribution; manage_entity may omit
- * proposal). This is the shared type surface — runtime validation is still
- * permissive at the route (legacy/malformed cards must not 500).
+ * proposal). The gateway normalizes unknown discriminators to null rather
+ * than rejecting the whole request, so malformed cards do not 500 the worker.
  */
 export const ToolApprovalCreateBodySchema = Type.Object({
   interactionType: Type.Literal("tool_approval"),

--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import { ApprovalAttributionSchema } from "../interaction-envelope";
 
 function SortOrderField(description: string) {
   return Type.Optional(
@@ -396,9 +397,7 @@ export const ManageEntityResultSchema = Type.Union([
       Type.Record(Type.String(), Type.Unknown())
     ),
     approval_current: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
-    approval_attribution: Type.Optional(
-      Type.Union([Type.Literal("agent"), Type.Literal("behavior")])
-    ),
+    approval_attribution: Type.Optional(ApprovalAttributionSchema),
   }),
   Type.Object({
     action: Type.Literal("update"),
@@ -419,9 +418,7 @@ export const ManageEntityResultSchema = Type.Union([
     /** Blocked field_path -> current human-owned value, for the diff. */
     approval_current: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
     /** Who proposed the blocked change: 'agent' | 'behavior'. */
-    approval_attribution: Type.Optional(
-      Type.Union([Type.Literal("agent"), Type.Literal("behavior")])
-    ),
+    approval_attribution: Type.Optional(ApprovalAttributionSchema),
   }),
   Type.Object({
     action: Type.Literal("list"),
@@ -488,9 +485,7 @@ export const ManageEntityResultSchema = Type.Union([
       Type.Record(Type.String(), Type.Unknown())
     ),
     approval_current: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
-    approval_attribution: Type.Optional(
-      Type.Union([Type.Literal("agent"), Type.Literal("behavior")])
-    ),
+    approval_attribution: Type.Optional(ApprovalAttributionSchema),
   }),
   Type.Object({
     action: Type.Literal("link"),
@@ -550,10 +545,7 @@ export const ManageEntityResultSchema = Type.Union([
         entity_ids: Type.Optional(Type.Array(Type.Integer())),
         winner_entity_id: Type.Integer(),
       }),
-      approval_attribution: Type.Union([
-        Type.Literal("agent"),
-        Type.Literal("behavior"),
-      ]),
+      approval_attribution: ApprovalAttributionSchema,
       next_steps: Type.Array(Type.String()),
       resolution: Type.Optional(
         Type.Object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,11 @@ export type { CommandContext, CommandDefinition } from "./command-registry";
 export { CommandRegistry } from "./command-registry";
 export * from "./connector-query-errors";
 export * from "./constants";
+// Interaction-envelope wire literals (tool_approval resourceKind / attribution).
+// Deep import `@lobu/core/contracts/interaction-envelope` also works under
+// bundler/NodeNext resolution; plugin packages with classic `moduleResolution:
+// "node"` must use this root re-export.
+export * from "./contracts/interaction-envelope";
 // Shared credential-store primitives (CLI + embedded server share one impl)
 export * from "./credentials";
 // Errors & logging

--- a/packages/plugin-mcp/src/tools.ts
+++ b/packages/plugin-mcp/src/tools.ts
@@ -1,4 +1,8 @@
-import { createLogger } from "@lobu/core";
+import {
+  coerceApprovalAttribution,
+  createLogger,
+  InteractionResourceKind,
+} from "@lobu/core";
 import {
   createGatewayClient,
   gatewayFetch,
@@ -28,7 +32,7 @@ const TOOLS_REQUESTING_JSON_FORMAT = new Set([
   // not formatted markdown, to forward an approval card into the chat (see
   // maybePostApprovalCard / createMcpToolDefinitions).
   "manage_agents",
-  // Same shape as manage_agents: behavior definition create/update/delete may
+  // Same shape as manage_agents: watcher definition create/update/delete may
   // return pending_approval under the agent_config write-gate.
   "manage_behaviors",
   // manage_entity's update path queues a human-owned-field change for approval
@@ -43,13 +47,13 @@ const TOOLS_REQUESTING_JSON_FORMAT = new Set([
  * Approve/Reject diff. Handles three producers:
  *   - manage_agents write gate → `{ status: 'pending_approval', run_id,
  *     action, proposal, current }` (the builder agent's create/update/delete).
- *   - manage_behaviors write gate → same `pending_approval` shape (behavior
+ *   - manage_behaviors write gate → same `pending_approval` shape (watcher
  *     definition create/update/delete under agent_config).
  *   - manage_entity update gate → `{ approval_queued: true, approval_run_id,
  *     approval_fields, approval_current, approval_attribution }` (a human-owned
- *     entity field an agent or Behavior proposed changing).
+ *     entity field the agent proposed changing).
  *
- * Best-effort — a failed post never breaks the tool call (the agent still
+ * Fire-and-forget — a failed post never breaks the tool call (the agent still
  * narrates the result, and the events-tab approval card remains the fallback).
  * Returns true when a card was posted (caller logs at debug only).
  *
@@ -65,7 +69,7 @@ export async function maybePostApprovalCard(
   const body = buildApprovalCardBody(toolName, rawResultText);
   if (!body) return false;
 
-  // Best-effort: a failed post must never break the tool call (the agent
+  // Fire-and-forget: a failed post must never break the tool call (the agent
   // still narrates the result, and the events-tab approval card is the
   // fallback). gatewayFetch throws on a hard network error, so guard it too.
   let error: TextResult | undefined;
@@ -92,7 +96,8 @@ export async function maybePostApprovalCard(
  * null when the result is not a pending approval. entity_field_change carries
  * `fields`/`attribution` (the human-owned-field diff); manage_agents carries
  * `proposal` (the agent row diff); manage_behaviors carries flat behavior args
- * plus `resourceKind: "behavior"`. All share the `tool_approval` transport.
+ * plus `resourceKind: behavior`. All share the `tool_approval` transport.
+ * Wire literals come from `@lobu/core` (`interaction-envelope` contract).
  */
 function buildApprovalCardBody(
   toolName: string,
@@ -126,7 +131,7 @@ function buildApprovalCardBody(
       interactionType: "tool_approval",
       runId: parsed.run_id,
       action: typeof parsed.action === "string" ? parsed.action : "change",
-      resourceKind: "behavior",
+      resourceKind: InteractionResourceKind.Behavior,
       proposal: flatProposal,
       current: parsed.current ?? null,
     };
@@ -143,7 +148,7 @@ function buildApprovalCardBody(
       interactionType: "tool_approval",
       runId: parsed.run_id,
       action: typeof parsed.action === "string" ? parsed.action : "change",
-      resourceKind: "agent",
+      resourceKind: InteractionResourceKind.Agent,
       proposal: parsed.proposal ?? null,
       current: parsed.current ?? null,
     };
@@ -163,14 +168,13 @@ function buildApprovalCardBody(
         typeof parsed.approval_action === "string"
           ? parsed.approval_action
           : "change",
-      resourceKind: "entity",
+      resourceKind: InteractionResourceKind.Entity,
       proposal: parsed.approval_proposal ?? null,
       // entity_field_change diff: field_path -> proposed / current. The SPA
       // routes on `fields` (non-empty) to the entity-field-change card.
       fields: parsed.approval_fields ?? null,
       current: parsed.approval_current ?? null,
-      attribution:
-        parsed.approval_attribution === "behavior" ? "behavior" : "agent",
+      attribution: coerceApprovalAttribution(parsed.approval_attribution),
     };
   }
 

--- a/packages/plugin-mcp/src/tools.ts
+++ b/packages/plugin-mcp/src/tools.ts
@@ -2,6 +2,7 @@ import {
   coerceApprovalAttribution,
   createLogger,
   InteractionResourceKind,
+  type ToolApprovalCreateBody,
 } from "@lobu/core";
 import {
   createGatewayClient,
@@ -32,7 +33,7 @@ const TOOLS_REQUESTING_JSON_FORMAT = new Set([
   // not formatted markdown, to forward an approval card into the chat (see
   // maybePostApprovalCard / createMcpToolDefinitions).
   "manage_agents",
-  // Same shape as manage_agents: watcher definition create/update/delete may
+  // Same shape as manage_agents: behavior definition create/update/delete may
   // return pending_approval under the agent_config write-gate.
   "manage_behaviors",
   // manage_entity's update path queues a human-owned-field change for approval
@@ -47,13 +48,13 @@ const TOOLS_REQUESTING_JSON_FORMAT = new Set([
  * Approve/Reject diff. Handles three producers:
  *   - manage_agents write gate → `{ status: 'pending_approval', run_id,
  *     action, proposal, current }` (the builder agent's create/update/delete).
- *   - manage_behaviors write gate → same `pending_approval` shape (watcher
+ *   - manage_behaviors write gate → same `pending_approval` shape (behavior
  *     definition create/update/delete under agent_config).
  *   - manage_entity update gate → `{ approval_queued: true, approval_run_id,
  *     approval_fields, approval_current, approval_attribution }` (a human-owned
- *     entity field the agent proposed changing).
+ *     entity field an agent or Behavior proposed changing).
  *
- * Fire-and-forget — a failed post never breaks the tool call (the agent still
+ * Best-effort — a failed post never breaks the tool call (the agent still
  * narrates the result, and the events-tab approval card remains the fallback).
  * Returns true when a card was posted (caller logs at debug only).
  *
@@ -69,7 +70,7 @@ export async function maybePostApprovalCard(
   const body = buildApprovalCardBody(toolName, rawResultText);
   if (!body) return false;
 
-  // Fire-and-forget: a failed post must never break the tool call (the agent
+  // Best-effort: a failed post must never break the tool call (the agent
   // still narrates the result, and the events-tab approval card is the
   // fallback). gatewayFetch throws on a hard network error, so guard it too.
   let error: TextResult | undefined;
@@ -102,13 +103,15 @@ export async function maybePostApprovalCard(
 function buildApprovalCardBody(
   toolName: string,
   rawResultText: string
-): Record<string, unknown> | null {
-  let parsed: Record<string, unknown>;
+): ToolApprovalCreateBody | null {
+  let raw: unknown;
   try {
-    parsed = JSON.parse(rawResultText);
+    raw = JSON.parse(rawResultText);
   } catch {
     return null;
   }
+  const parsed = recordOrNull(raw);
+  if (!parsed) return null;
 
   if (toolName === "manage_behaviors") {
     if (
@@ -119,21 +122,15 @@ function buildApprovalCardBody(
     }
     // Server proposal is `{ args: ManageBehaviorsArgs }`; SPA renderer needs the
     // flat behavior fields (action, slug, prompt, schedule, …).
-    const rawProposal = parsed.proposal;
-    const flatProposal =
-      rawProposal &&
-      typeof rawProposal === "object" &&
-      (rawProposal as { args?: unknown }).args &&
-      typeof (rawProposal as { args: unknown }).args === "object"
-        ? (rawProposal as { args: Record<string, unknown> }).args
-        : ((rawProposal as Record<string, unknown> | null) ?? null);
+    const rawProposal = recordOrNull(parsed.proposal);
+    const flatProposal = recordOrNull(rawProposal?.args) ?? rawProposal;
     return {
       interactionType: "tool_approval",
       runId: parsed.run_id,
       action: typeof parsed.action === "string" ? parsed.action : "change",
       resourceKind: InteractionResourceKind.Behavior,
       proposal: flatProposal,
-      current: parsed.current ?? null,
+      current: recordOrNull(parsed.current),
     };
   }
 
@@ -149,8 +146,8 @@ function buildApprovalCardBody(
       runId: parsed.run_id,
       action: typeof parsed.action === "string" ? parsed.action : "change",
       resourceKind: InteractionResourceKind.Agent,
-      proposal: parsed.proposal ?? null,
-      current: parsed.current ?? null,
+      proposal: recordOrNull(parsed.proposal),
+      current: recordOrNull(parsed.current),
     };
   }
 
@@ -169,16 +166,22 @@ function buildApprovalCardBody(
           ? parsed.approval_action
           : "change",
       resourceKind: InteractionResourceKind.Entity,
-      proposal: parsed.approval_proposal ?? null,
+      proposal: recordOrNull(parsed.approval_proposal),
       // entity_field_change diff: field_path -> proposed / current. The SPA
       // routes on `fields` (non-empty) to the entity-field-change card.
-      fields: parsed.approval_fields ?? null,
-      current: parsed.approval_current ?? null,
+      fields: recordOrNull(parsed.approval_fields),
+      current: recordOrNull(parsed.approval_current),
       attribution: coerceApprovalAttribution(parsed.approval_attribution),
     };
   }
 
   return null;
+}
+
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 export async function callMcpTool(

--- a/packages/server/src/authz/entity-mutation-gate.ts
+++ b/packages/server/src/authz/entity-mutation-gate.ts
@@ -37,6 +37,7 @@
  * (no shared mutable state affecting decisions).
  */
 
+import type { ApprovalAttribution } from "@lobu/core/contracts/interaction-envelope";
 import type { DbClient } from "../db/client";
 import type { Env } from "../index";
 import type { ToolContext } from "../tools/registry";
@@ -50,7 +51,7 @@ import {
 export type MutationPrincipalKind = "user" | "agent" | "watcher";
 
 /** Attribution for a deferred (queued-for-approval) mutation. */
-export type MutationAttribution = "behavior" | "agent";
+export type MutationAttribution = ApprovalAttribution;
 
 /** Field ownership as seen by an update request ("human" pins the value). */
 export type FieldOwner = "human" | "none";

--- a/packages/server/src/gateway/interactions.ts
+++ b/packages/server/src/gateway/interactions.ts
@@ -7,6 +7,10 @@ import {
   createLogger,
   type UserSuggestion,
 } from "@lobu/core";
+import type {
+  ApprovalAttribution,
+  InteractionResourceKind,
+} from "@lobu/core/contracts/interaction-envelope";
 
 const logger = createLogger("interactions");
 
@@ -127,9 +131,9 @@ export interface PostedDurableApproval extends BaseMessage {
    *  The SPA routes on this (non-empty) to the entity-field-change card. */
   fields: Record<string, unknown> | null;
   /** Who proposed the entity_field_change: 'agent' | 'behavior'. Null for manage_agents. */
-  attribution: string | null;
+  attribution: ApprovalAttribution | null;
   /** Discriminator for the SPA: "agent" | "behavior" | "entity". */
-  resourceKind: string | null;
+  resourceKind: InteractionResourceKind | null;
   /** Headless-origin marker (parity with PostedQuestion/PostedToolApproval). */
   source?: string;
 }
@@ -268,8 +272,8 @@ export class InteractionService extends EventEmitter {
     current: Record<string, unknown> | null,
     source?: string,
     fields: Record<string, unknown> | null = null,
-    attribution: string | null = null,
-    resourceKind: string | null = null
+    attribution: ApprovalAttribution | null = null,
+    resourceKind: InteractionResourceKind | null = null
   ): Promise<PostedDurableApproval> {
     assertRoutableInteraction(connectionId, platform, "approval card");
     if (this.beforeCreateHook) {

--- a/packages/server/src/gateway/routes/internal/interactions.ts
+++ b/packages/server/src/gateway/routes/internal/interactions.ts
@@ -4,9 +4,9 @@ import {
 	createLogger,
 	getErrorMessage,
 } from "@lobu/core";
-import type {
-	ApprovalAttribution,
-	InteractionResourceKind,
+import {
+	isApprovalAttribution,
+	isInteractionResourceKind,
 } from "@lobu/core/contracts/interaction-envelope";
 import { Hono } from "hono";
 import { getDb } from "../../../db/client.js";
@@ -95,15 +95,12 @@ export function createInteractionRoutes(
             // entity_field_change (manage_entity) carries a human-owned-field
             // diff + who proposed it; manage_agents leaves these null.
             (body.fields ?? null) as Record<string, unknown> | null,
-            // Emitters source these from @lobu/core/contracts/interaction-envelope.
-            // Pass-through stays permissive so a non-canonical string never 500s
-            // the worker; SPA routing only recognizes the contract union.
-            (typeof body.attribution === "string"
-              ? (body.attribution as ApprovalAttribution)
-              : null),
-            (typeof body.resourceKind === "string"
-              ? (body.resourceKind as InteractionResourceKind)
-              : null)
+            // Keep malformed/legacy cards non-fatal without lying to the
+            // downstream contract about their discriminator values.
+            isApprovalAttribution(body.attribution) ? body.attribution : null,
+            isInteractionResourceKind(body.resourceKind)
+              ? body.resourceKind
+              : null
           );
           // The live approval card is a one-shot SSE push, and the transcript
           // doesn't carry interaction parts — so on reload the card is lost.

--- a/packages/server/src/gateway/routes/internal/interactions.ts
+++ b/packages/server/src/gateway/routes/internal/interactions.ts
@@ -4,6 +4,10 @@ import {
 	createLogger,
 	getErrorMessage,
 } from "@lobu/core";
+import type {
+	ApprovalAttribution,
+	InteractionResourceKind,
+} from "@lobu/core/contracts/interaction-envelope";
 import { Hono } from "hono";
 import { getDb } from "../../../db/client.js";
 import type { InteractionService } from "../../interactions.js";
@@ -91,8 +95,15 @@ export function createInteractionRoutes(
             // entity_field_change (manage_entity) carries a human-owned-field
             // diff + who proposed it; manage_agents leaves these null.
             (body.fields ?? null) as Record<string, unknown> | null,
-            typeof body.attribution === "string" ? body.attribution : null,
-            typeof body.resourceKind === "string" ? body.resourceKind : null
+            // Emitters source these from @lobu/core/contracts/interaction-envelope.
+            // Pass-through stays permissive so a non-canonical string never 500s
+            // the worker; SPA routing only recognizes the contract union.
+            (typeof body.attribution === "string"
+              ? (body.attribution as ApprovalAttribution)
+              : null),
+            (typeof body.resourceKind === "string"
+              ? (body.resourceKind as InteractionResourceKind)
+              : null)
           );
           // The live approval card is a one-shot SSE push, and the transcript
           // doesn't carry interaction parts — so on reload the card is lost.

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -8,6 +8,10 @@
  */
 
 import { createHash } from "node:crypto";
+import {
+	ApprovalAttribution,
+	type ApprovalAttribution as ApprovalAttributionType,
+} from "@lobu/core/contracts/interaction-envelope";
 import { resolveEntityApprovalPolicy } from "../../authz/entity-policy";
 import { assertResolutionFingerprintCurrent } from "../../entity-resolution/staleness";
 import { type DbClient, getDb, pgBigintArray } from "../../db/client";
@@ -60,8 +64,8 @@ export interface EntityFieldChangeProposal {
 	 * into ONE batch approval card. Stripped from action_input before the insert.
 	 */
 	window_id?: number | null;
-	/** Who proposed the change — drives the card label/author. Defaults to 'watcher'. */
-	attribution?: "behavior" | "agent";
+	/** Who proposed the change — drives the card label/author. Defaults to 'behavior'. */
+	attribution?: ApprovalAttributionType;
 	reason?: string | null;
 	/**
 	 * The ONE human who owns every gated field (distinct
@@ -90,7 +94,7 @@ export interface EntityDeleteProposal {
 	watcher_id?: number | null;
 	/** See EntityFieldChangeProposal.window_id — batches proposals by run window. */
 	window_id?: number | null;
-	attribution?: "behavior" | "agent";
+	attribution?: ApprovalAttributionType;
 	reason?: string | null;
 }
 
@@ -101,7 +105,7 @@ export interface EntityCreateProposal {
 	watcher_id?: number | null;
 	/** See EntityFieldChangeProposal.window_id — batches proposals by run window. */
 	window_id?: number | null;
-	attribution?: "behavior" | "agent";
+	attribution?: ApprovalAttributionType;
 	reason?: string | null;
 }
 
@@ -128,7 +132,7 @@ export interface EntityMergeProposal {
 	source_run_id?: number | null;
 	policy_hash?: string | null;
 	resolution_fingerprint?: string | null;
-	attribution?: "behavior" | "agent";
+	attribution?: ApprovalAttributionType;
 	reason?: string | null;
 }
 
@@ -229,13 +233,13 @@ function entityChangeIdempotencyKey(
 async function loadWatcherLabel(
 	ctx: ToolContext,
 	watcherId: number | null | undefined,
-	attribution: "behavior" | "agent" | undefined,
+	attribution: ApprovalAttributionType | undefined,
 ): Promise<{
 	actorLabel: string;
 	watcherName: string | null;
 	watcherAgentId: string | null;
 }> {
-	if (attribution !== "behavior") {
+	if (attribution !== ApprovalAttribution.Behavior) {
 		return { actorLabel: "An agent", watcherName: null, watcherAgentId: null };
 	}
 	if (!watcherId) {
@@ -554,8 +558,9 @@ export async function proposeEntityChange(
 
 	const fieldKeys = updateProposal ? Object.keys(updateProposal.fields) : [];
 	const fieldList = fieldKeys.join(", ");
-	const attribution = proposal.attribution ?? "behavior";
-	const actorNoun = attribution === "agent" ? "An agent" : "A Behavior";
+	const attribution = proposal.attribution ?? ApprovalAttribution.Behavior;
+	const actorNoun =
+		attribution === ApprovalAttribution.Agent ? "An agent" : "A Behavior";
 	const [{ actorLabel, watcherName, watcherAgentId }, entity] =
 		await Promise.all([
 			loadWatcherLabel(ctx, proposal.watcher_id, attribution),

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -21,6 +21,7 @@
  * This file is the entry point only — action handlers live in ./manage_behaviors/.
  */
 
+import { InteractionResourceKind } from '@lobu/core/contracts/interaction-envelope';
 import {
   ListBehaviorsResultSchema,
   ListBehaviorsSchema,
@@ -728,7 +729,7 @@ async function queueWatcherWriteForApproval(
       tool: 'manage_behaviors',
       action_key: MANAGE_BEHAVIORS_ACTION_KEY,
       action: args.action,
-      resourceKind: 'behavior',
+      resourceKind: InteractionResourceKind.Behavior,
       watcher_id: args.behavior_id ?? null,
       proposal,
       current: current ?? null,

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -20,6 +20,10 @@
  */
 
 import {
+	ApprovalAttribution,
+	type ApprovalAttribution as ApprovalAttributionType,
+} from "@lobu/core/contracts/interaction-envelope";
+import {
 	type ManageEntityArgs,
 	type ManageEntityResult,
 	ManageEntityResultSchema,
@@ -302,8 +306,10 @@ async function handleCreate(
 		metadata: entityData.metadata ?? {},
 	};
 	const actor = await actingPrincipalFor(args, ctx);
-	const attribution: "agent" | "behavior" =
-		actor.kind === "watcher" ? "behavior" : "agent";
+	const attribution: ApprovalAttributionType =
+		actor.kind === "watcher"
+			? ApprovalAttribution.Behavior
+			: ApprovalAttribution.Agent;
 	const createDecision = await runMutationGate({
 		action: "create",
 		organizationId: ctx.organizationId,
@@ -466,7 +472,10 @@ async function handleUpdate(
 	const updateActor = await actingPrincipalFor(args, ctx);
 	const updatedEntity = await updateEntity(entityId, updateData, env, ctx, {
 		policyPrincipalKind: updateActor.kind,
-		attribution: updateActor.kind === "watcher" ? "behavior" : "agent",
+		attribution:
+			updateActor.kind === "watcher"
+				? ApprovalAttribution.Behavior
+				: ApprovalAttribution.Agent,
 		principalId: updateActor.id,
 		// Trusted reaction-session window WINS — see the create path.
 		windowId: ctx.actingWindowId ?? args.behavior_source?.window_id ?? null,
@@ -711,7 +720,10 @@ async function handleMerge(
 	}
 
 	if (actor.kind !== "user" && resolution?.decision === "review") {
-		const attribution = actor.kind === "watcher" ? "behavior" : "agent";
+		const attribution: ApprovalAttributionType =
+			actor.kind === "watcher"
+				? ApprovalAttribution.Behavior
+				: ApprovalAttribution.Agent;
 		if (
 			await wasResolutionRejected(sql, {
 				organizationId: ctx.organizationId,
@@ -1303,8 +1315,10 @@ async function handleDelete(
 	}
 
 	const deleteActor = await actingPrincipalFor(args, ctx);
-	const attribution: "agent" | "behavior" =
-		deleteActor.kind === "watcher" ? "behavior" : "agent";
+	const attribution: ApprovalAttributionType =
+		deleteActor.kind === "watcher"
+			? ApprovalAttribution.Behavior
+			: ApprovalAttribution.Agent;
 	const current = {
 		id: entity.id,
 		entity_type: entity.entity_type,

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -34,6 +34,7 @@
  */
 
 import { slugify } from '@lobu/core';
+import { ApprovalAttribution } from '@lobu/core/contracts/interaction-envelope';
 import {
   deferEntityCreate,
   deferEntityFieldChange,
@@ -358,7 +359,7 @@ async function upsertKeyedEntity(params: {
       // specific restriction is never loosened away.
       principalKind: 'watcher',
       sql: tx,
-      attribution: 'behavior',
+      attribution: ApprovalAttribution.Behavior,
       watcherId: params.watcherId,
       principalId: mutationPrincipalId({ watcherId: params.watcherId }),
       ownerAgentId: params.watcherAgentId,
@@ -540,7 +541,7 @@ export async function promoteKeyedEntities(
     // tighten further, never be loosened away.
     principalKind: 'watcher',
     sql: tx,
-    attribution: 'behavior',
+    attribution: ApprovalAttribution.Behavior,
     watcherId,
     principalId: mutationPrincipalId({ watcherId }),
     ownerAgentId: watcherOwner.ownerAgentId,
@@ -649,7 +650,7 @@ export async function promoteKeyedEntities(
                 metadata,
               },
               proposal: createProposal,
-              attribution: 'behavior',
+              attribution: ApprovalAttribution.Behavior,
               watcherId,
               windowId,
             })
@@ -674,7 +675,7 @@ export async function promoteKeyedEntities(
             entityId,
             fields: Object.fromEntries(blockedFields.map((f) => [f, blocked[f].proposed])),
             current: Object.fromEntries(blockedFields.map((f) => [f, blocked[f].current])),
-            attribution: 'behavior',
+            attribution: ApprovalAttribution.Behavior,
             watcherId,
             windowId,
           })


### PR DESCRIPTION
## Summary
`resourceKind` and `attribution` were scattered string literals across plugin-mcp, server tools, gateway routes, and the SPA. That is exactly how #2105 happened: plugin-mcp kept emitting `"watcher"` while the SPA routed on `"behavior"`, and nothing failed until a user saw the wrong approval card.

Adds `packages/core/src/contracts/interaction-envelope.ts` as the single source: named constants (`InteractionResourceKind.Behavior`), derived TypeBox unions, type guards, and a `ToolApprovalCreateBody` schema. Emitters import the constants instead of writing bare literals, so a typo is a compile error.

Deliberately does **not** fold in the config-audit `resourceKind` vocabulary (connection / feed / …) — that is a separate wire contract and mixing them would be wrong.

## The parity test earned its keep
The cross-side check initially scanned raw source, so a JSDoc block listing `"agent" | "behavior"` satisfied it. I proved the false-pass by deleting the SPA's entire `attribution === "behavior"` branch — the test still passed. Fixed by stripping comments before extracting literals, and typing the SPA fields as real unions (submodule bump) so the check reads executable evidence. Re-verified: the same deletion now fails.

## Validation
- Injected a core-only literal → parity test fails (2/3). Injected an SPA-only regression → fails. Clean tree → 3/3 pass.
- core 366/366, plugin-mcp 1/1, agent-worker 13/13
- `make pre-pr` clean; `make review`: bug_free 89, 0 bugs, 0 blockers

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->