### PR TITLE
ci: serialize image builds so concurrent merges cannot share a tag

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,22 +1,22 @@
 name: Build and Push Images
 
-# Serialize image builds on main. The shared tag is `date -u +%Y%m%d-%H%M%S`
-# (generate-tag below), and Flux's ImagePolicy matches that exact format
-# `^(\d{8})-(\d{6})$` — so the tag cannot carry a commit SHA without a
-# coordinated change in the owletto submodule's image-policies.yaml, and a
-# mismatch there stops every deploy.
+# Every run publishes images tagged `date -u +%Y%m%d-%H%M%S` (generate-tag
+# below), so concurrent runs — including manual dispatches from other refs —
+# can compute the SAME tag and overwrite each other. On 2026-07-22 five PRs
+# merged within 14s, all five runs stamped `20260722-121441`, and prod ended up
+# on whichever pushed last: two merged PRs never deployed, every workflow green.
 #
-# That makes same-second collisions the failure mode: on 2026-07-22 five PRs
-# merged within 14s, all five builds computed tag `20260722-121441`, and each
-# pushed it in turn. Prod ended up on whichever won the race — two merged PRs
-# silently never deployed, with all workflows green.
+# Serializing makes the tag unique in practice (runs are minutes apart, not
+# milliseconds). The tag cannot simply carry the commit SHA instead: Flux's
+# ImagePolicy matches '^(\d{8})-(\d{6})$' and lives in the owletto submodule, so
+# changing the format needs a coordinated two-repo change and a mismatch stops
+# every deploy.
 #
-# Serializing costs queue time on a burst of merges but guarantees distinct
-# timestamps, so the newest push is always the newest commit. Do NOT add
-# cancel-in-progress: a cancelled run leaves the chart pointing at a tag whose
-# images were never pushed.
+# cancel-in-progress stays false: a cancelled run can leave the chart pointing
+# at a tag whose sibling images were never pushed.
 concurrency:
-  group: build-images-${{ github.ref }}
+  group: build-images
+  cancel-in-progress: false
 
 on:
   push:
@@ -54,40 +54,12 @@ env:
 jobs:
   generate-tag:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: read
-      packages: read
     outputs:
       tag: ${{ steps.timestamp.outputs.tag }}
     steps:
-      # `docker manifest inspect` needs auth against ghcr; without it every
-      # lookup fails and the collision check below would pass vacuously.
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Generate shared timestamp tag
         id: timestamp
-        # Belt-and-braces on top of the workflow `concurrency` group: if a tag
-        # somehow already exists in the registry, this run would overwrite it and
-        # silently strand whichever commit built it (see the header comment).
-        # Wait out the second and re-stamp rather than clobbering.
-        run: |
-          set -euo pipefail
-          for _ in $(seq 1 30); do
-            tag="$(date -u +'%Y%m%d-%H%M%S')"
-            if ! docker manifest inspect "ghcr.io/${{ github.repository_owner }}/lobu-app:${tag}" >/dev/null 2>&1; then
-              echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "tag ${tag} already published — waiting 1s for a fresh timestamp"
-            sleep 1
-          done
-          echo "could not obtain an unused timestamp tag after 30s" >&2
-          exit 1
+        run: echo "tag=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
 
   # Connector-runtime parity smoke gate (main/deploy side). RUNS the built worker
   # artifact's self-check before any image is pushed, so the packaging/parity

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,5 +1,23 @@
 name: Build and Push Images
 
+# Serialize image builds on main. The shared tag is `date -u +%Y%m%d-%H%M%S`
+# (generate-tag below), and Flux's ImagePolicy matches that exact format
+# `^(\d{8})-(\d{6})$` — so the tag cannot carry a commit SHA without a
+# coordinated change in the owletto submodule's image-policies.yaml, and a
+# mismatch there stops every deploy.
+#
+# That makes same-second collisions the failure mode: on 2026-07-22 five PRs
+# merged within 14s, all five builds computed tag `20260722-121441`, and each
+# pushed it in turn. Prod ended up on whichever won the race — two merged PRs
+# silently never deployed, with all workflows green.
+#
+# Serializing costs queue time on a burst of merges but guarantees distinct
+# timestamps, so the newest push is always the newest commit. Do NOT add
+# cancel-in-progress: a cancelled run leaves the chart pointing at a tag whose
+# images were never pushed.
+concurrency:
+  group: build-images-${{ github.ref }}
+
 on:
   push:
     branches:
@@ -36,12 +54,40 @@ env:
 jobs:
   generate-tag:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: read
     outputs:
       tag: ${{ steps.timestamp.outputs.tag }}
     steps:
+      # `docker manifest inspect` needs auth against ghcr; without it every
+      # lookup fails and the collision check below would pass vacuously.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate shared timestamp tag
         id: timestamp
-        run: echo "tag=$(date -u +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
+        # Belt-and-braces on top of the workflow `concurrency` group: if a tag
+        # somehow already exists in the registry, this run would overwrite it and
+        # silently strand whichever commit built it (see the header comment).
+        # Wait out the second and re-stamp rather than clobbering.
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 30); do
+            tag="$(date -u +'%Y%m%d-%H%M%S')"
+            if ! docker manifest inspect "ghcr.io/${{ github.repository_owner }}/lobu-app:${tag}" >/dev/null 2>&1; then
+              echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "tag ${tag} already published — waiting 1s for a fresh timestamp"
+            sleep 1
+          done
+          echo "could not obtain an unused timestamp tag after 30s" >&2
+          exit 1
 
   # Connector-runtime parity smoke gate (main/deploy side). RUNS the built worker
   # artifact's self-check before any image is pushed, so the packaging/parity


### PR DESCRIPTION
## What

Adds a workflow-level `concurrency` group to `build-images.yml` so only one image build runs at a time.

## Why

Every run publishes images tagged `date -u +%Y%m%d-%H%M%S`. Concurrent runs can compute the **same** tag and overwrite each other.

This actually happened on 2026-07-22: five PRs were admin-merged within 14 seconds, all five runs stamped `20260722-121441`, and prod ended up on whichever pushed last. Two merged PRs (#2108, #2109) never deployed — with every workflow green and Flux healthy. There was no signal anything was wrong.

Serializing makes the tag unique in practice, since runs end up minutes apart rather than milliseconds.

## Why not put the SHA in the tag

That's the obvious fix, and it doesn't work here without a coordinated change. Flux's ImagePolicy matches `^(\d{8})-(\d{6})$` and does a numerical ordering on the extracted digits — and it lives in the **owletto submodule** (`deploy/k8s/infrastructure/image-automation/image-policies.yaml`). Changing the tag format without updating the policy first means no tag ever matches and every deploy silently freezes. Confirmed against the live cluster with `kubectl get imagepolicy` before ruling it out.

`cancel-in-progress` stays `false` deliberately: a cancelled run can leave the chart pointing at a tag whose sibling images were never pushed.

## Verification

- Prod was rolled forward manually by re-running the `06a5deb9` build; confirmed `revision: 06a5deb98` on `/api/health` and `APP_GIT_SHA` on the running pod.
- Workflow YAML parses; `concurrency` is top-level so it covers push and manual-dispatch runs alike.
- `make review`: `bug_free 86, simplicity 96, slop 0, bugs 0, 0 blockers`.

Also quotes `$GITHUB_OUTPUT` in the tag step while touching that line.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->