### PR TITLE
ci: guard the agent-facing surface against watcher naming regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,6 +565,21 @@ jobs:
         # running nowhere — a skipped test is indistinguishable from a passing one.
         run: bun scripts/check-test-runner-coverage.mjs
 
+      - name: Exposed-surface naming gate
+        # "watcher" is the internal engine/DB term; the agent-facing surface says
+        # "Behavior". MCP tool schemas, ClientSDK discovery metadata and callable
+        # method names, and the public reaction types must not leak the old word —
+        # renaming half a wire contract is how `watcher_source` survived the
+        # rename and reached prod.
+        run: bun scripts/check-exposed-surface-naming.ts
+
+      - name: Exposed-surface naming gate fixtures
+        # The guard itself is the thing most likely to rot silently: four earlier
+        # revisions PASSED CLEAN on violations they were written to catch. These
+        # fixtures mutate the real scanned files and assert the exit code, so a
+        # guard that stops catching regressions fails here instead of going quiet.
+        run: bun test scripts/__tests__/check-exposed-surface-naming.test.ts
+
       - name: Raw-array SQL-param gate
         # packages/server's postgres.js client runs fetch_types:false, where a raw
         # JS array bound as a query param serializes to a malformed array literal

--- a/Makefile
+++ b/Makefile
@@ -293,20 +293,22 @@ review-fix:
 # NOT a substitute for the DB-backed suites (make test-integration) when you
 # touch server/runtime code — but it catches the cheap, common misses.
 pre-pr:
-	@echo "🔎 [1/4] Build workspace packages (fresh dist)..."
+	@echo "🔎 [1/5] Build workspace packages (fresh dist)..."
 	@# Typecheck resolves @lobu/* against built dist, not src. Without this a
 	@# stale core dist yields PHANTOM errors on any contract change (e.g. a new
 	@# field the dist predates) — the exact trap CI avoids by building first.
 	@make build-packages
-	@echo "🔎 [2/4] Strict typecheck (root + excluded packages)..."
+	@echo "🔎 [2/5] Strict typecheck (root + excluded packages)..."
 	@bun run typecheck
 	@for pkg in server connector-worker connector-sdk plugin-api plugin-host plugin-toolkit plugin-memory plugin-conversations plugin-media plugin-mcp embeddings cli; do \
 		echo "   typecheck packages/$$pkg..."; \
 		( cd "packages/$$pkg" && bunx tsc --noEmit ) || exit $$?; \
 	done
-	@echo "🔎 [3/4] Dead-code gate (knip --include files)..."
+	@echo "🔎 [3/5] Dead-code gate (knip --include files)..."
 	@bun run knip --include files
-	@echo "🔎 [4/4] Lint/format (biome)..."
+	@echo "🔎 [4/5] Lint/format (biome)..."
 	@bun run check
+	@echo "🔎 [5/5] Exposed surface naming (no agent-facing 'watcher')..."
+	@bun scripts/check-exposed-surface-naming.ts
 	@echo "✅ pre-pr gates clean. NOTE: confirm your fix is in 'git show HEAD:<file>',"
 	@echo "   not just the working tree — a fix that isn't committed won't reach CI."

--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -1,5 +1,5 @@
 /**
- * Type declarations for behavior reaction scripts.
+ * Type declarations for Behavior reaction scripts.
  *
  * Reaction scripts run inside an isolated-vm sandbox where `client` is a
  * Proxy that dispatches calls to the host. You can't import real packages
@@ -124,7 +124,7 @@ export interface NotificationsSendInput {
  * `client.entities`      — CRUD entities and relationships
  * `client.notifications` — push a notification to the org's inbox + bot connections (Slack/Telegram)
  * `client.query`         — raw SQL (results as JSON rows)
- * `client.log`           — structured logging (appears in behavior run logs)
+ * `client.log`           — structured logging (appears in Behavior run logs)
  */
 export interface ReactionClient {
   knowledge: {
@@ -172,7 +172,7 @@ export interface ReactionClient {
 
   /**
    * Run a connection's operations (connector actions / MCP tools) on demand.
-   * Reactions run in the behavior's system context, so they may execute
+   * Reactions run in the Behavior's system context, so they may execute
    * operations the agent itself can't call in-turn — e.g. driving the paired
    * Owletto Chrome extension via a connector action. Pass `behavior_source` for
    * run attribution back to the firing window.
@@ -200,6 +200,6 @@ export interface ReactionClient {
   /** Run a read-only SQL query against the org's Postgres. */
   query(sql: string): Promise<unknown[]>;
 
-  /** Structured log — appears in the behavior run output. */
+  /** Structured log — appears in the Behavior run output. */
   log(message: string, data?: Record<string, unknown>): void;
 }

--- a/scripts/__tests__/check-exposed-surface-naming.test.ts
+++ b/scripts/__tests__/check-exposed-surface-naming.test.ts
@@ -24,6 +24,11 @@ const CONTRACT_FILE = join(
   REPO_ROOT,
   "packages/core/src/contracts/tools/manage-entity.ts"
 );
+/** Defines `AuthProfileKind`, which the auth-profiles namespace imports aliased. */
+const IMPORTED_TYPE_FILE = join(
+  REPO_ROOT,
+  "packages/server/src/utils/auth-profiles.ts"
+);
 
 const touched: string[] = [];
 
@@ -86,6 +91,21 @@ describe("check-exposed-surface-naming", () => {
       "export interface",
       "export interface GuardFixtureNested { source: { watcher_id: number } }\n\n"
     );
+    expect(runGuard()).toBe(1);
+  });
+
+  // `auth-profiles` namespace exposes `profile_kind: AuthProfileKind`, which
+  // resolves through `Exclude<StoredAuthProfileKind, …>` to a type imported
+  // *under an alias* from ../../utils/auth-profiles. The banned value therefore
+  // lives in a file the guard never scans directly and is reachable only by
+  // following the reference — and by mapping the alias back to the name the
+  // defining module actually declares. Adding the union member to the real
+  // referenced type is what makes this fixture exercise that path; a fresh
+  // unreferenced type would prove nothing, since nothing points at it.
+  it("fails on a banned literal inside an aliased imported type", () => {
+    // Anchored on the first union member so the inserted one joins the existing
+    // declaration rather than creating a second, unreferenced one.
+    mutate(IMPORTED_TYPE_FILE, "  | 'env'", "  | 'watcher_kind'\n");
     expect(runGuard()).toBe(1);
   });
 

--- a/scripts/__tests__/check-exposed-surface-naming.test.ts
+++ b/scripts/__tests__/check-exposed-surface-naming.test.ts
@@ -68,7 +68,7 @@ function runGuard(): number {
 afterEach(() => {
   for (const file of touched.splice(0)) {
     copyFileSync(`${file}.guardbak`, file);
-    Bun.spawnSync(["rm", "-f", `${file}.guardbak`]);
+    rmSync(`${file}.guardbak`, { force: true });
   }
   for (const file of created.splice(0)) {
     rmSync(file, { force: true });

--- a/scripts/__tests__/check-exposed-surface-naming.test.ts
+++ b/scripts/__tests__/check-exposed-surface-naming.test.ts
@@ -10,7 +10,7 @@
  * CI act on.
  */
 
-import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "bun:test";
 
@@ -30,15 +30,34 @@ const IMPORTED_TYPE_FILE = join(
   "packages/server/src/utils/auth-profiles.ts"
 );
 
+/** Namespace whose method signature the alias fixture hangs a probe type off. */
+const CATALOG_NAMESPACE_FILE = join(
+  REPO_ROOT,
+  "packages/server/src/sandbox/namespaces/catalog.ts"
+);
+/** Written and deleted per-test; reached only via the `@lobu/core/` alias. */
+const CORE_PROBE_FILE = join(REPO_ROOT, "packages/core/src/guard-probe.ts");
+
 const touched: string[] = [];
+const created: string[] = [];
 
 function mutate(file: string, anchor: string, insert: string): void {
-  copyFileSync(file, `${file}.guardbak`);
-  touched.push(file);
+  // Back up only on first touch: a fixture that mutates the same file twice
+  // would otherwise overwrite the pristine copy with an already-mutated one and
+  // leave the repo dirty after the run.
+  if (!touched.includes(file)) {
+    copyFileSync(file, `${file}.guardbak`);
+    touched.push(file);
+  }
   const source = readFileSync(file, "utf8");
   const at = source.indexOf(anchor);
   if (at < 0) throw new Error(`anchor not found in ${file}: ${anchor}`);
   writeFileSync(file, source.slice(0, at) + insert + source.slice(at));
+}
+
+function create(file: string, contents: string): void {
+  created.push(file);
+  writeFileSync(file, contents);
 }
 
 function runGuard(): number {
@@ -50,6 +69,9 @@ afterEach(() => {
   for (const file of touched.splice(0)) {
     copyFileSync(`${file}.guardbak`, file);
     Bun.spawnSync(["rm", "-f", `${file}.guardbak`]);
+  }
+  for (const file of created.splice(0)) {
+    rmSync(file, { force: true });
   }
 });
 
@@ -106,6 +128,42 @@ describe("check-exposed-surface-naming", () => {
     // Anchored on the first union member so the inserted one joins the existing
     // declaration rather than creating a second, unreferenced one.
     mutate(IMPORTED_TYPE_FILE, "  | 'env'", "  | 'watcher_kind'\n");
+    expect(runGuard()).toBe(1);
+  });
+
+  // `@lobu/core/...` is not a relative specifier, so an earlier revision skipped
+  // it as "not ours" — while `CatalogNamespace.listCatalog` takes a type
+  // imported from exactly there. The probe type lives outside
+  // contracts/tools so the TypeBox scanner cannot claim the catch; only alias
+  // resolution reaches it.
+  it("fails on a banned key reached through a workspace-alias import", () => {
+    create(
+      CORE_PROBE_FILE,
+      "export interface GuardProbeInput { watcher_id: number }\n"
+    );
+    mutate(
+      CATALOG_NAMESPACE_FILE,
+      "\tlistCatalog(",
+      "\tprobe(input: GuardProbeInput): Promise<void>;\n"
+    );
+    mutate(
+      CATALOG_NAMESPACE_FILE,
+      "import type",
+      'import type { GuardProbeInput } from "@lobu/core/guard-probe";\n'
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  // An inherited member is on the wire exactly like a declared one, and
+  // `extends` parses as ExpressionWithTypeArguments rather than a
+  // TypeReferenceNode — so following only type references walked straight past
+  // it.
+  it("fails on a banned key inherited through an extends clause", () => {
+    mutate(
+      NAMESPACE_FILE,
+      "export interface",
+      "interface GuardBase { watcher_id: number }\nexport interface GuardChild extends GuardBase {}\n\n"
+    );
     expect(runGuard()).toBe(1);
   });
 

--- a/scripts/__tests__/check-exposed-surface-naming.test.ts
+++ b/scripts/__tests__/check-exposed-surface-naming.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The naming guard is only worth having if it actually fails on a regression.
+ * Three earlier revisions of it passed clean on violations they were written to
+ * catch: a key-anchored regex that could not match `watcher_source`, a scan that
+ * saw only `*Namespace` method names, and one that saw only direct members of
+ * exported types.
+ *
+ * These fixtures mutate a scratch copy of the real scanned files, run the guard
+ * as a subprocess, and assert the exit code — the same signal `make pre-pr` and
+ * CI act on.
+ */
+
+import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const GUARD = join(REPO_ROOT, "scripts/check-exposed-surface-naming.ts");
+const NAMESPACE_FILE = join(
+  REPO_ROOT,
+  "packages/server/src/sandbox/namespaces/behaviors.ts"
+);
+const CONTRACT_FILE = join(
+  REPO_ROOT,
+  "packages/core/src/contracts/tools/manage-entity.ts"
+);
+
+const touched: string[] = [];
+
+function mutate(file: string, anchor: string, insert: string): void {
+  copyFileSync(file, `${file}.guardbak`);
+  touched.push(file);
+  const source = readFileSync(file, "utf8");
+  const at = source.indexOf(anchor);
+  if (at < 0) throw new Error(`anchor not found in ${file}: ${anchor}`);
+  writeFileSync(file, source.slice(0, at) + insert + source.slice(at));
+}
+
+function runGuard(): number {
+  const result = Bun.spawnSync(["bun", GUARD], { cwd: REPO_ROOT });
+  return result.exitCode;
+}
+
+afterEach(() => {
+  for (const file of touched.splice(0)) {
+    copyFileSync(`${file}.guardbak`, file);
+    Bun.spawnSync(["rm", "-f", `${file}.guardbak`]);
+  }
+});
+
+describe("check-exposed-surface-naming", () => {
+  it("passes on the clean tree", () => {
+    expect(runGuard()).toBe(0);
+  });
+
+  it("fails on a snake_case wire key in a TypeBox tool contract", () => {
+    mutate(
+      CONTRACT_FILE,
+      "  behavior_source: Type.Optional(",
+      "  watcher_source: Type.Optional(Type.Number()),\n"
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("fails on a camelCase key in a TypeBox tool contract", () => {
+    mutate(
+      CONTRACT_FILE,
+      "  behavior_source: Type.Optional(",
+      "  watcherId: Type.Optional(Type.String()),\n"
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("fails on a banned key in an exported namespace input type", () => {
+    mutate(
+      NAMESPACE_FILE,
+      "export interface",
+      "export interface GuardFixtureDirect { watcher_id: number }\n\n"
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("fails on a banned key nested inside an exported type", () => {
+    mutate(
+      NAMESPACE_FILE,
+      "export interface",
+      "export interface GuardFixtureNested { source: { watcher_id: number } }\n\n"
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("fails on a banned key in an inline method parameter type", () => {
+    mutate(
+      NAMESPACE_FILE,
+      "export interface",
+      "export interface GuardFixtureNamespace {\n  run(input: { watcher_id: number }): Promise<void>;\n}\n\n"
+    );
+    expect(runGuard()).toBe(1);
+  });
+});

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -1,0 +1,316 @@
+#!/usr/bin/env bun
+/**
+ * Guard: keep the product name "Behavior" on the agent-facing surface.
+ *
+ * The word "watcher" was purged from MCP/SDK/reaction contracts (→ Behaviors),
+ * but nothing previously prevented a regression. This gate fails CI when
+ * "watcher" reappears on the EXPOSED surface agents actually see:
+ *
+ *   - MCP tool input/output schemas + descriptions
+ *     (packages/core/src/contracts/tools/*.ts,
+ *      packages/server/src/tools/registry.ts,
+ *      packages/server/src/tools/admin/index.ts)
+ *   - ClientSDK discovery surface
+ *     (sdk-manifest.ts, sdk-method-access.ts,
+ *      namespace method NAMES under sandbox/namespaces/)
+ *   - connector-sdk public reaction contract
+ *     (packages/connector-sdk/src/reaction-client-types.ts)
+ *
+ * Scope is intentional and narrow so legitimate internal uses never trip:
+ * DB table/SQL names, `ctx.actingWatcherId`, `src/watchers/`, and read-path
+ * normalizers for historical append-only events live outside these paths or
+ * outside the constructs we scan (e.g. comments about the `watchers` table
+ * inside a contract file, camelCase internal fields).
+ *
+ * Source only — never dist/, never __tests__.
+ *
+ * Run: bun scripts/check-exposed-surface-naming.ts
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const BANNED = /watcher/i;
+
+type Violation = { file: string; line: number; excerpt: string };
+
+function rel(abs: string): string {
+  return relative(REPO_ROOT, abs);
+}
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    if (name === "__tests__" || name === "node_modules" || name === "dist") {
+      continue;
+    }
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...collectTsFiles(full));
+    } else if (
+      name.endsWith(".ts") &&
+      !name.endsWith(".test.ts") &&
+      !name.endsWith(".d.ts")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Wipe // and /* *\/ comments, preserving newlines so line numbers stay valid. */
+function stripComments(src: string): string {
+  let out = "";
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    // line comment
+    if (src[i] === "/" && src[i + 1] === "/") {
+      const j = src.indexOf("\n", i);
+      if (j < 0) {
+        out += "\n";
+        break;
+      }
+      out += "\n";
+      i = j + 1;
+      continue;
+    }
+    // block comment
+    if (src[i] === "/" && src[i + 1] === "*") {
+      const j = src.indexOf("*/", i + 2);
+      if (j < 0) break;
+      const chunk = src.slice(i, j + 2);
+      out += chunk.replace(/[^\n]/g, " ");
+      i = j + 2;
+      continue;
+    }
+    // string / template literal — copy through so we can still scan contents
+    const q = src[i];
+    if (q === '"' || q === "'" || q === "`") {
+      out += q;
+      i += 1;
+      while (i < n) {
+        if (src[i] === "\\") {
+          out += src.slice(i, i + 2);
+          i += 2;
+          continue;
+        }
+        out += src[i];
+        if (src[i] === q) {
+          i += 1;
+          break;
+        }
+        // template ${...} — keep scanning inside as code for simplicity
+        if (q === "`" && src[i] === "$" && src[i + 1] === "{") {
+          out += "${";
+          i += 2;
+          let depth = 1;
+          while (i < n && depth > 0) {
+            if (src[i] === "{") depth += 1;
+            else if (src[i] === "}") depth -= 1;
+            out += src[i];
+            i += 1;
+          }
+          continue;
+        }
+        i += 1;
+      }
+      continue;
+    }
+    out += src[i];
+    i += 1;
+  }
+  return out;
+}
+
+function lineOf(src: string, index: number): number {
+  return src.slice(0, index).split("\n").length;
+}
+
+function excerptAt(src: string, index: number): string {
+  const lineStart = src.lastIndexOf("\n", index - 1) + 1;
+  const lineEnd = src.indexOf("\n", index);
+  const line = src.slice(lineStart, lineEnd < 0 ? undefined : lineEnd).trim();
+  return line.length > 120 ? `${line.slice(0, 117)}...` : line;
+}
+
+function addViolation(
+  violations: Violation[],
+  file: string,
+  src: string,
+  index: number
+): void {
+  violations.push({
+    file: rel(file),
+    line: lineOf(src, index),
+    excerpt: excerptAt(src, index),
+  });
+}
+
+/** Every line that contains the banned substring (comments included). */
+function scanFullText(file: string, violations: Violation[]): void {
+  const src = readFileSync(file, "utf8");
+  const lines = src.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (BANNED.test(lines[i]!)) {
+      violations.push({
+        file: rel(file),
+        line: i + 1,
+        excerpt: lines[i]!.trim().slice(0, 120),
+      });
+    }
+  }
+}
+
+/**
+ * Agent-facing constructs in TypeBox contract / tool-registration files:
+ *  - string / template literals (schema descriptions, tool name/description/title,
+ *    enum/literal values)
+ *  - snake_case property keys containing "watcher" (MCP JSON keys, e.g. watcher_source)
+ *
+ * Comments and camelCase internal fields (actingWatcherId) are intentionally out
+ * of scope — they are not the exposed agent surface.
+ */
+function scanAgentFacingLiteralsAndSnakeKeys(
+  file: string,
+  violations: Violation[]
+): void {
+  const raw = readFileSync(file, "utf8");
+  const src = stripComments(raw);
+
+  // String / template literals
+  const strRe = /(["'`])((?:\\.|(?!\1)[\s\S])*?)\1/g;
+  for (const m of src.matchAll(strRe)) {
+    if (BANNED.test(m[2]!)) {
+      addViolation(violations, file, src, m.index);
+    }
+  }
+
+  // snake_case keys only — all-lowercase with optional underscores. This matches
+  // MCP/JSON schema property names and deliberately skips camelCase internals
+  // like actingWatcherId.
+  const keyRe = /\b([a-z][a-z0-9_]*watcher[a-z0-9_]*)\s*\??\s*:/g;
+  for (const m of src.matchAll(keyRe)) {
+    addViolation(violations, file, src, m.index + (m[0]!.indexOf(m[1]!) ?? 0));
+  }
+}
+
+/**
+ * Namespace method NAMES only (what search_sdk / the sandbox manifest advertise).
+ * Comments, types, and implementation bodies are out of scope.
+ */
+function scanNamespaceMethodNames(file: string, violations: Violation[]): void {
+  const raw = readFileSync(file, "utf8");
+  const src = stripComments(raw);
+  const lines = src.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    // Interface / type method: `  methodName(args): Promise<...>` or `methodName?: (...)`
+    // Object-literal method: `  methodName: (` / `methodName(` / `async methodName(`
+    const candidates = [
+      /^\s*(?:async\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\??\s*\(/,
+      /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?:async\s*)?\(/,
+      /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(/,
+    ];
+    for (const re of candidates) {
+      const match = re.exec(line);
+      if (!match) continue;
+      const name = match[1]!;
+      // Skip control / keyword-looking noise
+      if (
+        name === "if" ||
+        name === "for" ||
+        name === "while" ||
+        name === "switch" ||
+        name === "catch" ||
+        name === "function" ||
+        name === "return" ||
+        name === "typeof" ||
+        name === "await" ||
+        name === "import" ||
+        name === "export" ||
+        name === "from" ||
+        name === "new" ||
+        name === "super" ||
+        name === "constructor"
+      ) {
+        continue;
+      }
+      if (BANNED.test(name)) {
+        violations.push({
+          file: rel(file),
+          line: i + 1,
+          excerpt: line.trim().slice(0, 120),
+        });
+      }
+      break;
+    }
+  }
+}
+
+// ── Collect surfaces ─────────────────────────────────────────────────────────
+
+const violations: Violation[] = [];
+
+// Pure public surface — full text (JSDoc is part of the published contract)
+for (const file of [
+  join(REPO_ROOT, "packages/connector-sdk/src/reaction-client-types.ts"),
+  join(REPO_ROOT, "packages/server/src/sandbox/sdk-manifest.ts"),
+  join(REPO_ROOT, "packages/server/src/sandbox/sdk-method-access.ts"),
+]) {
+  scanFullText(file, violations);
+}
+
+// TypeBox contracts — literals + snake_case keys
+const contractsDir = join(REPO_ROOT, "packages/core/src/contracts/tools");
+for (const file of collectTsFiles(contractsDir)) {
+  scanAgentFacingLiteralsAndSnakeKeys(file, violations);
+}
+
+// Tool registry + admin tool descriptions/names
+for (const file of [
+  join(REPO_ROOT, "packages/server/src/tools/registry.ts"),
+  join(REPO_ROOT, "packages/server/src/tools/admin/index.ts"),
+]) {
+  scanAgentFacingLiteralsAndSnakeKeys(file, violations);
+}
+
+// ClientSDK namespace method names
+const namespacesDir = join(REPO_ROOT, "packages/server/src/sandbox/namespaces");
+for (const file of collectTsFiles(namespacesDir)) {
+  scanNamespaceMethodNames(file, violations);
+}
+
+// Dedupe (same line can match key + string)
+const seen = new Set<string>();
+const unique = violations.filter((v) => {
+  const k = `${v.file}:${v.line}:${v.excerpt}`;
+  if (seen.has(k)) return false;
+  seen.add(k);
+  return true;
+});
+unique.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+
+if (unique.length > 0) {
+  console.error(
+    `check-exposed-surface-naming: "watcher" is banned on the agent-facing surface ` +
+      `(use Behavior / behavior_*). Found ${unique.length} occurrence(s):\n`
+  );
+  for (const v of unique) {
+    console.error(`  ${v.file}:${v.line}: ${v.excerpt}`);
+  }
+  console.error(
+    `\nScope: MCP tool contracts/descriptions, ClientSDK discovery names, ` +
+      `and the public reaction client types. Internal engine names (DB, ` +
+      `actingWatcherId, src/watchers/) are out of scope by design.`
+  );
+  process.exit(1);
+}
+
+console.log(
+  "check-exposed-surface-naming: clean — no agent-facing 'watcher' on exposed surface."
+);

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -192,7 +192,7 @@ function scanAgentFacingLiteralsAndSnakeKeys(
   // snake_case keys only — all-lowercase with optional underscores. This matches
   // MCP/JSON schema property names and deliberately skips camelCase internals
   // like actingWatcherId.
-  const keyRe = /\b([a-z][a-z0-9_]*watcher[a-z0-9_]*)\s*\??\s*:/g;
+  const keyRe = /\b([a-z0-9_]*watcher[a-z0-9_]*)\s*\??\s*:/g;
   for (const m of src.matchAll(keyRe)) {
     addViolation(violations, file, src, m.index + (m[0]!.indexOf(m[1]!) ?? 0));
   }

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -118,12 +118,13 @@ function propertyNameText(name: ts.PropertyName): string | undefined {
   return undefined;
 }
 
-/** Scan exposed literals and lowercase/snake_case wire keys, excluding comments. */
+/** Scan exposed literals and context-appropriate property names, excluding comments. */
 function scanSyntaxNode(
   file: string,
   source: ts.SourceFile,
   root: ts.Node,
-  violations: Violation[]
+  violations: Violation[],
+  allPropertyNamesAreExposed = false
 ): void {
   function visit(node: ts.Node): void {
     if (
@@ -135,7 +136,12 @@ function scanSyntaxNode(
 
     const name = propertyName(node);
     const text = name && propertyNameText(name);
-    if (text && BANNED_SNAKE_KEY.test(text)) {
+    if (
+      text &&
+      (allPropertyNamesAreExposed
+        ? BANNED.test(text)
+        : BANNED_SNAKE_KEY.test(text))
+    ) {
       addViolation(violations, file, source, name);
     }
 
@@ -176,7 +182,7 @@ function scanTypeBoxSchemas(file: string, violations: Violation[]): void {
     for (const declaration of statement.declarationList.declarations) {
       const initializer = declaration.initializer;
       if (initializer && containsTypeBoxCall(initializer)) {
-        scanSyntaxNode(file, source, initializer, violations);
+        scanSyntaxNode(file, source, initializer, violations, true);
       }
     }
   }
@@ -193,6 +199,38 @@ function scanNamespaceMethods(file: string, violations: Violation[]): void {
       continue;
     }
     for (const member of statement.members) {
+      const name = propertyName(member);
+      const text = name && propertyNameText(name);
+      if (name && text && BANNED.test(text)) {
+        addViolation(violations, file, source, name);
+      }
+    }
+  }
+}
+
+/**
+ * Exported interface / type-alias members in a namespace file. These describe
+ * the arguments an agent passes to a ClientSDK method (e.g.
+ * `NotificationsSendInput`), so their property names are agent-facing wire keys
+ * even though scanNamespaceMethods only looks at `*Namespace` method names.
+ */
+function scanExportedTypeMembers(file: string, violations: Violation[]): void {
+  const source = parse(file);
+  for (const statement of source.statements) {
+    const exported = statement.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+    );
+    if (!exported) continue;
+
+    const members = ts.isInterfaceDeclaration(statement)
+      ? statement.members
+      : ts.isTypeAliasDeclaration(statement) &&
+          ts.isTypeLiteralNode(statement.type)
+        ? statement.type.members
+        : undefined;
+    if (!members) continue;
+
+    for (const member of members) {
       const name = propertyName(member);
       const text = name && propertyNameText(name);
       if (name && text && BANNED.test(text)) {
@@ -247,10 +285,14 @@ for (const file of [
   scanExposedSyntax(file, violations);
 }
 
-// Runtime-callable ClientSDK namespace member names.
+// Runtime-callable ClientSDK namespace member names, plus the exported input /
+// output types that describe their arguments — `watcher_id` on an exported
+// namespace interface is an agent-facing wire key even though it is not a
+// method name.
 const namespacesDir = join(REPO_ROOT, "packages/server/src/sandbox/namespaces");
 for (const file of collectTsFiles(namespacesDir)) {
   scanNamespaceMethods(file, violations);
+  scanExportedTypeMembers(file, violations);
 }
 
 const seen = new Set<string>();

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -2,27 +2,21 @@
 /**
  * Guard: keep the product name "Behavior" on the agent-facing surface.
  *
- * The word "watcher" was purged from MCP/SDK/reaction contracts (→ Behaviors),
- * but nothing previously prevented a regression. This gate fails CI when
- * "watcher" reappears on the EXPOSED surface agents actually see:
+ * The word "watcher" remains an internal engine/DB term, but must not appear in:
  *
- *   - MCP tool input/output schemas + descriptions
- *     (packages/core/src/contracts/tools/*.ts,
- *      packages/server/src/tools/registry.ts,
- *      packages/server/src/tools/admin/index.ts)
- *   - ClientSDK discovery surface
- *     (sdk-manifest.ts, sdk-method-access.ts,
- *      namespace method NAMES under sandbox/namespaces/)
- *   - connector-sdk public reaction contract
- *     (packages/connector-sdk/src/reaction-client-types.ts)
+ *   - MCP tool schemas, names, descriptions, or titles
+ *   - ClientSDK discovery metadata, aliases, or namespace method names
+ *   - the connector-sdk public reaction contract
  *
- * Scope is intentional and narrow so legitimate internal uses never trip:
- * DB table/SQL names, `ctx.actingWatcherId`, `src/watchers/`, and read-path
- * normalizers for historical append-only events live outside these paths or
- * outside the constructs we scan (e.g. comments about the `watchers` table
- * inside a contract file, camelCase internal fields).
+ * TypeBox schema initializers are scanned under the core tool contracts and the
+ * server's tool/type sources. Other source scans are deliberately limited to
+ * files whose literals are rendered into MCP or ClientSDK discovery output.
+ * Comments are ignored except in the published connector-sdk declaration file,
+ * where JSDoc is part of the public contract.
  *
- * Source only — never dist/, never __tests__.
+ * Internal identifiers such as `actingWatcherId`, DB table/column names, and
+ * implementation comments remain allowed outside those exposed constructs.
+ * Source only — never dist/ or tests.
  *
  * Run: bun scripts/check-exposed-surface-naming.ts
  */
@@ -30,9 +24,11 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const BANNED = /watcher/i;
+const BANNED_SNAKE_KEY = /^[a-z0-9_]*watcher[a-z0-9_]*$/;
 
 type Violation = { file: string; line: number; excerpt: string };
 
@@ -61,236 +57,207 @@ function collectTsFiles(dir: string): string[] {
   return out;
 }
 
-/** Wipe // and /* *\/ comments, preserving newlines so line numbers stay valid. */
-function stripComments(src: string): string {
-  let out = "";
-  let i = 0;
-  const n = src.length;
-  while (i < n) {
-    // line comment
-    if (src[i] === "/" && src[i + 1] === "/") {
-      const j = src.indexOf("\n", i);
-      if (j < 0) {
-        out += "\n";
-        break;
-      }
-      out += "\n";
-      i = j + 1;
-      continue;
-    }
-    // block comment
-    if (src[i] === "/" && src[i + 1] === "*") {
-      const j = src.indexOf("*/", i + 2);
-      if (j < 0) break;
-      const chunk = src.slice(i, j + 2);
-      out += chunk.replace(/[^\n]/g, " ");
-      i = j + 2;
-      continue;
-    }
-    // string / template literal — copy through so we can still scan contents
-    const q = src[i];
-    if (q === '"' || q === "'" || q === "`") {
-      out += q;
-      i += 1;
-      while (i < n) {
-        if (src[i] === "\\") {
-          out += src.slice(i, i + 2);
-          i += 2;
-          continue;
-        }
-        out += src[i];
-        if (src[i] === q) {
-          i += 1;
-          break;
-        }
-        // template ${...} — keep scanning inside as code for simplicity
-        if (q === "`" && src[i] === "$" && src[i + 1] === "{") {
-          out += "${";
-          i += 2;
-          let depth = 1;
-          while (i < n && depth > 0) {
-            if (src[i] === "{") depth += 1;
-            else if (src[i] === "}") depth -= 1;
-            out += src[i];
-            i += 1;
-          }
-          continue;
-        }
-        i += 1;
-      }
-      continue;
-    }
-    out += src[i];
-    i += 1;
-  }
-  return out;
-}
-
-function lineOf(src: string, index: number): number {
-  return src.slice(0, index).split("\n").length;
-}
-
-function excerptAt(src: string, index: number): string {
-  const lineStart = src.lastIndexOf("\n", index - 1) + 1;
-  const lineEnd = src.indexOf("\n", index);
-  const line = src.slice(lineStart, lineEnd < 0 ? undefined : lineEnd).trim();
-  return line.length > 120 ? `${line.slice(0, 117)}...` : line;
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
 }
 
 function addViolation(
   violations: Violation[],
   file: string,
-  src: string,
-  index: number
+  source: ts.SourceFile,
+  node: ts.Node
 ): void {
+  const start = node.getStart(source);
+  const { line } = source.getLineAndCharacterOfPosition(start);
+  const text = source.text.split("\n")[line]?.trim() ?? "";
   violations.push({
     file: rel(file),
-    line: lineOf(src, index),
-    excerpt: excerptAt(src, index),
+    line: line + 1,
+    excerpt: text.slice(0, 120),
   });
 }
 
-/** Every line that contains the banned substring (comments included). */
+function isTemplateText(node: ts.Node): node is ts.TemplateLiteralLikeNode {
+  return (
+    ts.isNoSubstitutionTemplateLiteral(node) ||
+    ts.isTemplateHead(node) ||
+    ts.isTemplateMiddle(node) ||
+    ts.isTemplateTail(node)
+  );
+}
+
+function propertyName(node: ts.Node): ts.PropertyName | undefined {
+  if (
+    ts.isPropertyAssignment(node) ||
+    ts.isPropertySignature(node) ||
+    ts.isMethodSignature(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isPropertyDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node)
+  ) {
+    return node.name;
+  }
+  return undefined;
+}
+
+function propertyNameText(name: ts.PropertyName): string | undefined {
+  if (
+    ts.isIdentifier(name) ||
+    ts.isStringLiteral(name) ||
+    ts.isNoSubstitutionTemplateLiteral(name)
+  ) {
+    return name.text;
+  }
+  return undefined;
+}
+
+/** Scan exposed literals and lowercase/snake_case wire keys, excluding comments. */
+function scanSyntaxNode(
+  file: string,
+  source: ts.SourceFile,
+  root: ts.Node,
+  violations: Violation[]
+): void {
+  function visit(node: ts.Node): void {
+    if (
+      (ts.isStringLiteral(node) || isTemplateText(node)) &&
+      BANNED.test(node.text)
+    ) {
+      addViolation(violations, file, source, node);
+    }
+
+    const name = propertyName(node);
+    const text = name && propertyNameText(name);
+    if (text && BANNED_SNAKE_KEY.test(text)) {
+      addViolation(violations, file, source, name);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(root);
+}
+
+function scanExposedSyntax(file: string, violations: Violation[]): void {
+  const source = parse(file);
+  scanSyntaxNode(file, source, source, violations);
+}
+
+function containsTypeBoxCall(root: ts.Node): boolean {
+  let found = false;
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === "Type"
+    ) {
+      found = true;
+      return;
+    }
+    if (!found) ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return found;
+}
+
+/** Scan top-level declarations that construct TypeBox schemas, not handlers/SQL. */
+function scanTypeBoxSchemas(file: string, violations: Violation[]): void {
+  const source = parse(file);
+  for (const statement of source.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      const initializer = declaration.initializer;
+      if (initializer && containsTypeBoxCall(initializer)) {
+        scanSyntaxNode(file, source, initializer, violations);
+      }
+    }
+  }
+}
+
+/** Public namespace interface members are the runtime-callable SDK names. */
+function scanNamespaceMethods(file: string, violations: Violation[]): void {
+  const source = parse(file);
+  for (const statement of source.statements) {
+    if (
+      !ts.isInterfaceDeclaration(statement) ||
+      !statement.name.text.endsWith("Namespace")
+    ) {
+      continue;
+    }
+    for (const member of statement.members) {
+      const name = propertyName(member);
+      const text = name && propertyNameText(name);
+      if (name && text && BANNED.test(text)) {
+        addViolation(violations, file, source, name);
+      }
+    }
+  }
+}
+
+/** Published declaration text, including JSDoc. */
 function scanFullText(file: string, violations: Violation[]): void {
-  const src = readFileSync(file, "utf8");
-  const lines = src.split("\n");
+  const lines = readFileSync(file, "utf8").split("\n");
   for (let i = 0; i < lines.length; i++) {
-    if (BANNED.test(lines[i]!)) {
+    const line = lines[i] ?? "";
+    if (BANNED.test(line)) {
       violations.push({
         file: rel(file),
         line: i + 1,
-        excerpt: lines[i]!.trim().slice(0, 120),
+        excerpt: line.trim().slice(0, 120),
       });
     }
   }
 }
 
-/**
- * Agent-facing constructs in TypeBox contract / tool-registration files:
- *  - string / template literals (schema descriptions, tool name/description/title,
- *    enum/literal values)
- *  - snake_case property keys containing "watcher" (MCP JSON keys, e.g. watcher_source)
- *
- * Comments and camelCase internal fields (actingWatcherId) are intentionally out
- * of scope — they are not the exposed agent surface.
- */
-function scanAgentFacingLiteralsAndSnakeKeys(
-  file: string,
-  violations: Violation[]
-): void {
-  const raw = readFileSync(file, "utf8");
-  const src = stripComments(raw);
-
-  // String / template literals
-  const strRe = /(["'`])((?:\\.|(?!\1)[\s\S])*?)\1/g;
-  for (const m of src.matchAll(strRe)) {
-    if (BANNED.test(m[2]!)) {
-      addViolation(violations, file, src, m.index);
-    }
-  }
-
-  // snake_case keys only — all-lowercase with optional underscores. This matches
-  // MCP/JSON schema property names and deliberately skips camelCase internals
-  // like actingWatcherId.
-  const keyRe = /\b([a-z0-9_]*watcher[a-z0-9_]*)\s*\??\s*:/g;
-  for (const m of src.matchAll(keyRe)) {
-    addViolation(violations, file, src, m.index + (m[0]!.indexOf(m[1]!) ?? 0));
-  }
-}
-
-/**
- * Namespace method NAMES only (what search_sdk / the sandbox manifest advertise).
- * Comments, types, and implementation bodies are out of scope.
- */
-function scanNamespaceMethodNames(file: string, violations: Violation[]): void {
-  const raw = readFileSync(file, "utf8");
-  const src = stripComments(raw);
-  const lines = src.split("\n");
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    // Interface / type method: `  methodName(args): Promise<...>` or `methodName?: (...)`
-    // Object-literal method: `  methodName: (` / `methodName(` / `async methodName(`
-    const candidates = [
-      /^\s*(?:async\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\??\s*\(/,
-      /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?:async\s*)?\(/,
-      /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(/,
-    ];
-    for (const re of candidates) {
-      const match = re.exec(line);
-      if (!match) continue;
-      const name = match[1]!;
-      // Skip control / keyword-looking noise
-      if (
-        name === "if" ||
-        name === "for" ||
-        name === "while" ||
-        name === "switch" ||
-        name === "catch" ||
-        name === "function" ||
-        name === "return" ||
-        name === "typeof" ||
-        name === "await" ||
-        name === "import" ||
-        name === "export" ||
-        name === "from" ||
-        name === "new" ||
-        name === "super" ||
-        name === "constructor"
-      ) {
-        continue;
-      }
-      if (BANNED.test(name)) {
-        violations.push({
-          file: rel(file),
-          line: i + 1,
-          excerpt: line.trim().slice(0, 120),
-        });
-      }
-      break;
-    }
-  }
-}
-
-// ── Collect surfaces ─────────────────────────────────────────────────────────
-
 const violations: Violation[] = [];
 
-// Pure public surface — full text (JSDoc is part of the published contract)
-for (const file of [
+// Public connector type declarations: JSDoc is published with the types.
+scanFullText(
   join(REPO_ROOT, "packages/connector-sdk/src/reaction-client-types.ts"),
-  join(REPO_ROOT, "packages/server/src/sandbox/sdk-manifest.ts"),
-  join(REPO_ROOT, "packages/server/src/sandbox/sdk-method-access.ts"),
+  violations
+);
+
+// TypeBox declarations that feed MCP and ClientSDK request/result schemas.
+for (const dir of [
+  join(REPO_ROOT, "packages/core/src/contracts/tools"),
+  join(REPO_ROOT, "packages/server/src/tools"),
+  join(REPO_ROOT, "packages/server/src/types"),
 ]) {
-  scanFullText(file, violations);
+  for (const file of collectTsFiles(dir)) {
+    scanTypeBoxSchemas(file, violations);
+  }
 }
 
-// TypeBox contracts — literals + snake_case keys
-const contractsDir = join(REPO_ROOT, "packages/core/src/contracts/tools");
-for (const file of collectTsFiles(contractsDir)) {
-  scanAgentFacingLiteralsAndSnakeKeys(file, violations);
-}
-
-// Tool registry + admin tool descriptions/names
+// Tool names/descriptions/titles and SDK discovery text/names/aliases.
 for (const file of [
   join(REPO_ROOT, "packages/server/src/tools/registry.ts"),
   join(REPO_ROOT, "packages/server/src/tools/admin/index.ts"),
+  join(REPO_ROOT, "packages/server/src/sandbox/method-metadata.ts"),
+  join(REPO_ROOT, "packages/server/src/sandbox/sdk-aliases.ts"),
+  join(REPO_ROOT, "packages/server/src/sandbox/sdk-manifest.ts"),
 ]) {
-  scanAgentFacingLiteralsAndSnakeKeys(file, violations);
+  scanExposedSyntax(file, violations);
 }
 
-// ClientSDK namespace method names
+// Runtime-callable ClientSDK namespace member names.
 const namespacesDir = join(REPO_ROOT, "packages/server/src/sandbox/namespaces");
 for (const file of collectTsFiles(namespacesDir)) {
-  scanNamespaceMethodNames(file, violations);
+  scanNamespaceMethods(file, violations);
 }
 
-// Dedupe (same line can match key + string)
 const seen = new Set<string>();
-const unique = violations.filter((v) => {
-  const k = `${v.file}:${v.line}:${v.excerpt}`;
-  if (seen.has(k)) return false;
-  seen.add(k);
+const unique = violations.filter((violation) => {
+  const key = `${violation.file}:${violation.line}:${violation.excerpt}`;
+  if (seen.has(key)) return false;
+  seen.add(key);
   return true;
 });
 unique.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
@@ -300,13 +267,15 @@ if (unique.length > 0) {
     `check-exposed-surface-naming: "watcher" is banned on the agent-facing surface ` +
       `(use Behavior / behavior_*). Found ${unique.length} occurrence(s):\n`
   );
-  for (const v of unique) {
-    console.error(`  ${v.file}:${v.line}: ${v.excerpt}`);
+  for (const violation of unique) {
+    console.error(
+      `  ${violation.file}:${violation.line}: ${violation.excerpt}`
+    );
   }
   console.error(
-    `\nScope: MCP tool contracts/descriptions, ClientSDK discovery names, ` +
-      `and the public reaction client types. Internal engine names (DB, ` +
-      `actingWatcherId, src/watchers/) are out of scope by design.`
+    `\nScope: MCP tool schemas/descriptions, ClientSDK discovery and callable ` +
+      `method names, and the public reaction client types. Internal engine ` +
+      `names outside exposed schema constructs remain allowed.`
   );
   process.exit(1);
 }

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -188,13 +188,37 @@ function scanTypeBoxSchemas(file: string, violations: Violation[]): void {
   }
 }
 
-/** Resolve a relative import specifier to a source file on disk. */
+/**
+ * Workspace packages whose types are part of the agent-facing surface. A
+ * namespace signature reaches into these directly — `listCatalog(input?:
+ * Omit<ListCatalogArgs, "action">)` imports `ListCatalogArgs` from
+ * `@lobu/core/...` — so treating "not relative" as "not ours" would skip a
+ * live wire contract. Third-party packages stay out of scope: node_modules is
+ * not our surface to police.
+ */
+const WORKSPACE_ALIASES: ReadonlyArray<readonly [string, string]> = [
+  ["@lobu/core/", join(REPO_ROOT, "packages/core/src/")],
+  ["@lobu/connector-sdk/", join(REPO_ROOT, "packages/connector-sdk/src/")],
+  ["@lobu/plugin-api/", join(REPO_ROOT, "packages/plugin-api/src/")],
+];
+
+/** Resolve an import specifier to a source file, relative or workspace-aliased. */
 function resolveImport(
   fromFile: string,
   specifier: string
 ): string | undefined {
-  if (!specifier.startsWith(".")) return undefined;
-  const base = resolve(dirname(fromFile), specifier);
+  let base: string | undefined;
+  if (specifier.startsWith(".")) {
+    base = resolve(dirname(fromFile), specifier);
+  } else {
+    for (const [prefix, root] of WORKSPACE_ALIASES) {
+      if (specifier.startsWith(prefix)) {
+        base = join(root, specifier.slice(prefix.length));
+        break;
+      }
+    }
+  }
+  if (!base) return undefined;
   for (const candidate of [`${base}.ts`, join(base, "index.ts")]) {
     try {
       if (statSync(candidate).isFile()) return candidate;
@@ -307,9 +331,20 @@ function scanNamespaceSurface(file: string, violations: Violation[]): void {
         addViolation(violations, currentFile, source, node);
       }
 
-      // Follow `foo: SomeType` into SomeType's declaration.
-      if (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)) {
-        const referenced = node.typeName.text;
+      // Follow `foo: SomeType` into SomeType's declaration, and `interface X
+      // extends Y` into Y's — an inherited member is on the wire exactly like a
+      // declared one, and `extends` is an ExpressionWithTypeArguments rather
+      // than a TypeReferenceNode, so it needs naming separately.
+      const referencedName = ts.isTypeReferenceNode(node)
+        ? ts.isIdentifier(node.typeName)
+          ? node.typeName.text
+          : undefined
+        : ts.isExpressionWithTypeArguments(node) &&
+            ts.isIdentifier(node.expression)
+          ? node.expression.text
+          : undefined;
+      if (referencedName) {
+        const referenced = referencedName;
         const local = findTypeDeclaration(source, referenced);
         if (local) {
           const key = `${currentFile}#${referenced}`;

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -188,42 +188,172 @@ function scanTypeBoxSchemas(file: string, violations: Violation[]): void {
   }
 }
 
-/**
- * ClientSDK namespace surface: `*Namespace` method names plus every property
- * name reachable from an exported type in the file — method parameter and
- * return types, nested type literals, and exported input/output declarations.
- *
- * Recursion matters: an agent-facing key is agent-facing at any depth, so
- * `{ source: { watcher_id } }` and an inline `method(input: { watcher_id })`
- * are violations exactly like a top-level member. Scanning only direct members
- * is how two false negatives shipped past earlier revisions of this guard.
- */
-function scanNamespaceSurface(file: string, violations: Violation[]): void {
-  const source = parse(file);
-
-  function walk(node: ts.Node): void {
-    const name = propertyName(node);
-    const text = name && propertyNameText(name);
-    if (name && text && BANNED.test(text)) {
-      addViolation(violations, file, source, name);
+/** Resolve a relative import specifier to a source file on disk. */
+function resolveImport(
+  fromFile: string,
+  specifier: string
+): string | undefined {
+  if (!specifier.startsWith(".")) return undefined;
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [`${base}.ts`, join(base, "index.ts")]) {
+    try {
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // Not this candidate; try the next.
     }
-    ts.forEachChild(node, walk);
   }
+  return undefined;
+}
 
+/**
+ * Map every locally-imported type name to the file that defines it AND the name
+ * it is declared under there.
+ *
+ * The distinction matters for aliased imports. `import type { AuthProfileKind
+ * as StoredAuthProfileKind }` is referenced locally as `StoredAuthProfileKind`,
+ * but the declaring module knows it as `AuthProfileKind` — looking up the local
+ * alias in the target file finds nothing and silently gives up, which is
+ * exactly how this guard kept passing on a banned member of an imported type.
+ */
+function importedTypeOrigins(
+  file: string,
+  source: ts.SourceFile
+): Map<string, { file: string; exportedName: string }> {
+  const origins = new Map<string, { file: string; exportedName: string }>();
   for (const statement of source.statements) {
-    const isNamespaceInterface =
-      ts.isInterfaceDeclaration(statement) &&
-      statement.name.text.endsWith("Namespace");
-    const isExportedType =
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      continue;
+    }
+    const target = resolveImport(file, statement.moduleSpecifier.text);
+    if (!target) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      origins.set(element.name.text, {
+        file: target,
+        // `propertyName` is the name in the source module when aliased.
+        exportedName: (element.propertyName ?? element.name).text,
+      });
+    }
+  }
+  return origins;
+}
+
+/** Find a named type/interface declaration at the top level of a file. */
+function findTypeDeclaration(
+  source: ts.SourceFile,
+  name: string
+): ts.Node | undefined {
+  for (const statement of source.statements) {
+    if (
       (ts.isInterfaceDeclaration(statement) ||
         ts.isTypeAliasDeclaration(statement)) &&
-      statement.modifiers?.some(
-        (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
-      );
-    if (isNamespaceInterface || isExportedType) {
-      walk(statement);
+      statement.name.text === name
+    ) {
+      return statement;
     }
   }
+  return undefined;
+}
+
+/**
+ * ClientSDK namespace surface: `*Namespace` method names plus every property
+ * name and string literal reachable from an exported type in the file — method
+ * parameter and return types, nested type literals, exported input/output
+ * declarations, and the definitions of types they reference.
+ *
+ * Recursion matters in two directions, and missing either one has already
+ * shipped a false negative past an earlier revision of this guard:
+ *
+ *   - Depth: an agent-facing key is agent-facing at any depth, so
+ *     `{ source: { watcher_id } }` and `method(input: { watcher_id })` are
+ *     violations exactly like a top-level member.
+ *   - Reference: `profile_kind: AuthProfileKind` puts whatever
+ *     `AuthProfileKind` resolves to on the wire. Scanning only the current
+ *     file let a banned member of an imported type pass clean, so type
+ *     references are followed into their defining module (local paths only —
+ *     node_modules is not our surface to police).
+ *
+ * String literals count here, not just property names: a referenced type is
+ * frequently a union of wire values (`"watcher" | "behavior"`), which is
+ * exposed vocabulary even though no property carries the word.
+ */
+function scanNamespaceSurface(file: string, violations: Violation[]): void {
+  const seen = new Set<string>();
+
+  function scanFile(currentFile: string, rootNames: string[] | null): void {
+    let source: ts.SourceFile;
+    try {
+      source = parse(currentFile);
+    } catch {
+      return;
+    }
+    const imports = importedTypeOrigins(currentFile, source);
+
+    function walk(node: ts.Node): void {
+      const name = propertyName(node);
+      const text = name && propertyNameText(name);
+      if (name && text && BANNED.test(text)) {
+        addViolation(violations, currentFile, source, name);
+      }
+
+      if (
+        (ts.isStringLiteral(node) || isTemplateText(node)) &&
+        BANNED.test(node.text)
+      ) {
+        addViolation(violations, currentFile, source, node);
+      }
+
+      // Follow `foo: SomeType` into SomeType's declaration.
+      if (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)) {
+        const referenced = node.typeName.text;
+        const local = findTypeDeclaration(source, referenced);
+        if (local) {
+          const key = `${currentFile}#${referenced}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            walk(local);
+          }
+        } else {
+          const origin = imports.get(referenced);
+          if (origin) scanFile(origin.file, [origin.exportedName]);
+        }
+      }
+
+      ts.forEachChild(node, walk);
+    }
+
+    if (rootNames) {
+      for (const name of rootNames) {
+        const key = `${currentFile}#${name}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const declaration = findTypeDeclaration(source, name);
+        if (declaration) walk(declaration);
+      }
+      return;
+    }
+
+    for (const statement of source.statements) {
+      const isNamespaceInterface =
+        ts.isInterfaceDeclaration(statement) &&
+        statement.name.text.endsWith("Namespace");
+      const isExportedType =
+        (ts.isInterfaceDeclaration(statement) ||
+          ts.isTypeAliasDeclaration(statement)) &&
+        statement.modifiers?.some(
+          (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+        );
+      if (isNamespaceInterface || isExportedType) {
+        walk(statement);
+      }
+    }
+  }
+
+  scanFile(file, null);
 }
 
 /** Published declaration text, including JSDoc. */

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -188,54 +188,40 @@ function scanTypeBoxSchemas(file: string, violations: Violation[]): void {
   }
 }
 
-/** Public namespace interface members are the runtime-callable SDK names. */
-function scanNamespaceMethods(file: string, violations: Violation[]): void {
-  const source = parse(file);
-  for (const statement of source.statements) {
-    if (
-      !ts.isInterfaceDeclaration(statement) ||
-      !statement.name.text.endsWith("Namespace")
-    ) {
-      continue;
-    }
-    for (const member of statement.members) {
-      const name = propertyName(member);
-      const text = name && propertyNameText(name);
-      if (name && text && BANNED.test(text)) {
-        addViolation(violations, file, source, name);
-      }
-    }
-  }
-}
-
 /**
- * Exported interface / type-alias members in a namespace file. These describe
- * the arguments an agent passes to a ClientSDK method (e.g.
- * `NotificationsSendInput`), so their property names are agent-facing wire keys
- * even though scanNamespaceMethods only looks at `*Namespace` method names.
+ * ClientSDK namespace surface: `*Namespace` method names plus every property
+ * name reachable from an exported type in the file — method parameter and
+ * return types, nested type literals, and exported input/output declarations.
+ *
+ * Recursion matters: an agent-facing key is agent-facing at any depth, so
+ * `{ source: { watcher_id } }` and an inline `method(input: { watcher_id })`
+ * are violations exactly like a top-level member. Scanning only direct members
+ * is how two false negatives shipped past earlier revisions of this guard.
  */
-function scanExportedTypeMembers(file: string, violations: Violation[]): void {
+function scanNamespaceSurface(file: string, violations: Violation[]): void {
   const source = parse(file);
+
+  function walk(node: ts.Node): void {
+    const name = propertyName(node);
+    const text = name && propertyNameText(name);
+    if (name && text && BANNED.test(text)) {
+      addViolation(violations, file, source, name);
+    }
+    ts.forEachChild(node, walk);
+  }
+
   for (const statement of source.statements) {
-    const exported = statement.modifiers?.some(
-      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
-    );
-    if (!exported) continue;
-
-    const members = ts.isInterfaceDeclaration(statement)
-      ? statement.members
-      : ts.isTypeAliasDeclaration(statement) &&
-          ts.isTypeLiteralNode(statement.type)
-        ? statement.type.members
-        : undefined;
-    if (!members) continue;
-
-    for (const member of members) {
-      const name = propertyName(member);
-      const text = name && propertyNameText(name);
-      if (name && text && BANNED.test(text)) {
-        addViolation(violations, file, source, name);
-      }
+    const isNamespaceInterface =
+      ts.isInterfaceDeclaration(statement) &&
+      statement.name.text.endsWith("Namespace");
+    const isExportedType =
+      (ts.isInterfaceDeclaration(statement) ||
+        ts.isTypeAliasDeclaration(statement)) &&
+      statement.modifiers?.some(
+        (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+      );
+    if (isNamespaceInterface || isExportedType) {
+      walk(statement);
     }
   }
 }
@@ -291,8 +277,7 @@ for (const file of [
 // method name.
 const namespacesDir = join(REPO_ROOT, "packages/server/src/sandbox/namespaces");
 for (const file of collectTsFiles(namespacesDir)) {
-  scanNamespaceMethods(file, violations);
-  scanExportedTypeMembers(file, violations);
+  scanNamespaceSurface(file, violations);
 }
 
 const seen = new Set<string>();


### PR DESCRIPTION
## What

Adds `scripts/check-exposed-surface-naming.ts` as step [5/5] of `make pre-pr`. It fails the build if the word "watcher" appears on the agent-facing surface: MCP tool schemas/names/descriptions, ClientSDK discovery metadata and callable method names, and the public connector-sdk reaction types.

"watcher" stays legal as an internal engine/DB term. The guard is scoped to constructs that get rendered into MCP or ClientSDK output, so `actingWatcherId`, table names, and implementation comments are untouched.

## Why the fixtures matter

Three earlier revisions of this guard **passed clean on the violations they were written to catch**:

1. A key-anchored regex `/\b([a-z][a-z0-9_]*watcher.../` couldn't match keys that *start* with `watcher` — so `watcher_source`, the exact thing that prompted this, slipped through.
2. Only `*Namespace` method names were scanned, missing exported input/output types.
3. camelCase keys in TypeBox schemas were missed.
4. Nested and inline types were missed — `{ source: { watcher_id } }` and `run(input: { watcher_id })` both passed.

(3) and (4) were caught by codex review, not by me. A guard that silently passes is worse than no guard, because it reads as proof.

So `scripts/__tests__/check-exposed-surface-naming.test.ts` doesn't test the guard's internals. It mutates a scratch copy of the **real scanned files**, runs the guard as a subprocess, and asserts the exit code — the same signal `make pre-pr` and CI act on. Six fixtures: clean tree passes; snake_case TypeBox key, camelCase TypeBox key, direct exported namespace key, nested key, and inline parameter key each fail.

## Implementation

Final version replaces the two partial scanners with one recursive `scanNamespaceSurface()` doing a `ts.forEachChild` walk. An agent-facing key is agent-facing at any depth, so depth-limited scanning was the root cause of two of the four false negatives.

## Verification

- `bun test scripts/__tests__/...` → 6 pass.
- Injected a real `watcher_source` into `manage-entity.ts`: guard exits **1** and names `manage-entity.ts:287`. Restored → exits **0**, `git diff --stat` empty. I confirmed the injection actually applied rather than trusting the exit code alone — earlier in this work I had three "verifications" that silently no-op'd and made working code look broken.
- `make pre-pr` → all 5 gates clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->