### PR TITLE
fix(events): canonicalize legacy watcher resourceKind on supersede

### DIFF
--- a/packages/server/src/__tests__/integration/events/approval-reviewer-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/events/approval-reviewer-attribution.test.ts
@@ -32,7 +32,8 @@ async function insertActionRun(organizationId: string): Promise<number> {
 
 async function insertPendingApprovalEvent(
   organizationId: string,
-  runId: number
+  runId: number,
+  extraMetadata: Record<string, unknown> = {}
 ): Promise<number> {
   const inserted = await insertEvent({
     entityIds: [],
@@ -45,7 +46,7 @@ async function insertPendingApprovalEvent(
     runId,
     interactionType: 'approval',
     interactionStatus: 'pending',
-    metadata: { status: 'pending_approval' },
+    metadata: { status: 'pending_approval', ...extraMetadata },
   });
   return Number(inserted.id);
 }
@@ -92,6 +93,53 @@ describe('approval reviewer attribution', () => {
     expect(approved.created_by).toBe(reviewer.id);
     expect(approved.metadata.reviewed_by_id).toBe(reviewer.id);
     expect(approved.metadata.reviewed_by_name).toBe('Ada Approver');
+  });
+
+  // Superseding spreads the prior row's metadata forward. A durable approval
+  // written before the Behaviors rename (#2034) therefore keeps minting NEW
+  // rows tagged `resourceKind: "watcher"` every time it is resolved — so the
+  // legacy set is open, not closed, and no one-shot backfill can drain it.
+  // The SPA matches `resourceKind === "behavior"` with no fallback, so such a
+  // row renders no approval card. Canonicalizing on write closes the source.
+  it('canonicalizes a legacy watcher resourceKind when superseding', async () => {
+    const org = await createTestOrganization();
+    const reviewer = await createTestUser({ name: 'Ada Approver' });
+    const runId = await insertActionRun(org.id);
+    await insertPendingApprovalEvent(org.id, runId, {
+      resourceKind: 'watcher',
+    });
+
+    const approvedId = await supersedeActionEvent(
+      runId,
+      org.id,
+      'confirmed',
+      'behavior — executing',
+      'Operation confirmed',
+      {},
+      { userId: reviewer.id, name: reviewer.name }
+    );
+
+    const approved = await metadataFor(approvedId!);
+    expect(approved.metadata.resourceKind).toBe('behavior');
+  });
+
+  it('leaves a non-legacy resourceKind untouched when superseding', async () => {
+    const org = await createTestOrganization();
+    const runId = await insertActionRun(org.id);
+    await insertPendingApprovalEvent(org.id, runId, {
+      resourceKind: 'entity',
+    });
+
+    const approvedId = await supersedeActionEvent(
+      runId,
+      org.id,
+      'confirmed',
+      'entity — executing',
+      'Operation confirmed'
+    );
+
+    const approved = await metadataFor(approvedId!);
+    expect(approved.metadata.resourceKind).toBe('entity');
   });
 
   it('records the reviewer + reason on a reject transition', async () => {

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1597,6 +1597,16 @@ export async function supersedeActionEvent(
 				? { error_message: extraMetadata.error_message }
 				: {}),
 			...extraMetadata,
+			// Superseding copies the prior metadata forward, so a durable approval
+			// written before the Behaviors rename (#2034) would keep minting NEW
+			// rows carrying `resourceKind: "watcher"` every time it is resolved.
+			// Canonicalize on write: history keeps whatever it recorded, but nothing
+			// emitted from here reintroduces the pre-rename value. Must stay below
+			// both spreads so neither the prior row nor a caller can restore it.
+			...(priorMetadata.resourceKind === "watcher" ||
+			extraMetadata.resourceKind === "watcher"
+				? { resourceKind: "behavior" }
+				: {}),
 		},
 		authorName: orig.author_name ?? null,
 	}, { sql });


### PR DESCRIPTION
## What

`supersedeActionEvent` spreads the prior event's metadata onto the new one. An approval written before the Behaviors rename (#2034) therefore keeps minting **new** events tagged `resourceKind: "watcher"` every time it's resolved.

That matters because the SPA matches `resourceKind === "behavior"` with no fallback (`agent-thread.tsx:995`), so such a row renders no approval card at all.

This canonicalizes on write. History keeps whatever it recorded; the read shims stay.

## What I removed from this branch, and why

I originally had this branch doing the "clean cut": a migration rewriting the legacy rows plus deletion of both read shims. `make review-fix` blocked it and was right on every count. I verified each finding against the source rather than taking them:

- **The legacy set is not closed.** My whole premise was "no writer emits `watcher` anymore." False — `supersedeActionEvent` is a writer, via `...priorMetadata`. A one-shot backfill could never drain a set that refills itself, so the shims could not have been safely removed even after migrating.
- **The migration mutated `events`,** which is append-only per AGENTS.md. I'd argued metadata-only edits don't count. That's a rationalization; the rubric treats it as a blocker and the reviewer was right to.
- **It conflated two different subsystems.** Both readers I was editing query camelCase `metadata->>'resourceKind'`. The snake_case `resource_kind` belongs to `deployment-routes.ts`, whose shim I was leaving in place — so that UPDATE rewrote rows for a subsystem this branch wasn't touching, and my comment mislabeled both as "config-audit".
- **The down-migration was not a true inverse** — it keyed on `origin_type LIKE 'config_watcher%'`, which cannot restore the camelCase approval rows and could rewrite native behavior events that were never legacy.
- **Migration + shim removal in one deploy is unsafe** regardless: during a rolling deploy, old pods and new pods disagree about which value is canonical.

Removing the shims is still the right end state. It just needs this fix to land and bake first, so the legacy set is actually closed — then a backfill, then the shims. Sequencing it as one PR was the error.

## Verification

Real red→fix→green against a scratch Postgres 18 + pgvector on :55432 (not prod — `DATABASE_URL` is unset in this repo and the harness refuses non-test DB names):

- **RED**, fix reverted: `expected 'watcher' to be 'behavior'` — 1 failed, 5 passed.
- **GREEN**, fix restored: 6 passed.
- Full `integration/events/` suite: **30 files, 138 tests, all pass.**
- `make pre-pr` clean; `git diff --name-only origin/main...HEAD` is exactly the 2 intended files.

Second test pins that a non-legacy kind (`entity`) passes through untouched, so the canonicalization can't over-reach.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized legacy “watcher” resource labels to “behavior” when approval events are superseded.
  * Preserved current resource labels for non-legacy resource types.
  * Maintained reviewer attribution across approval, rejection, and completed events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->