### PR TITLE
fix(rest): emit behavior_* on the public behavior-window route

### DIFF
--- a/packages/server/src/__tests__/integration/behaviors/rest-window-behavior-keys.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/rest-window-behavior-keys.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `GET /api/:orgSlug/behaviors/windows/:windowId` must speak the public
+ * Behavior vocabulary.
+ *
+ * The handler selects `iw.watcher_id`, `i.slug as watcher_slug` and
+ * `i.name as watcher_name` — sanctioned INTERNAL names (the table is still
+ * `watchers`) — and used to `c.json(row)` the raw result. That leaked
+ * `watcher_*` keys on a public org route while every sibling surface
+ * (get_behavior, MCP list/get, SDK, generated client types) emits `behavior_*`.
+ *
+ * The rename belongs at the wire boundary, not in the SQL, so this pins the
+ * response shape rather than the query.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import { manageBehaviors } from "../../../tools/admin/manage_behaviors";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestAccessToken,
+	createTestAgent,
+	createTestEntity,
+	createTestOAuthClient,
+	seedOwnerContext,
+} from "../../setup/test-fixtures";
+import { get } from "../../setup/test-helpers";
+
+describe("REST behavior window vocabulary", () => {
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+	});
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("returns behavior_* keys and no watcher_* keys", async () => {
+		const { org, user, ctx } = await seedOwnerContext();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		const created = (await manageBehaviors(
+			{
+				action: "create",
+				slug: "window-vocab",
+				name: "Window vocab",
+				prompt: "Summarize.",
+				agent_id: agent.agentId,
+				sources: [
+					{
+						name: "src",
+						query: "SELECT id FROM events WHERE connector_key = 'none'",
+					},
+				],
+			},
+			{} as Env,
+			ctx,
+		)) as { action?: string; behavior_id?: number | string };
+
+		if (created.action !== "create" || !("behavior_id" in created)) {
+			throw new Error("Behavior creation did not complete");
+		}
+		const behaviorId = Number(created.behavior_id);
+		expect(Number.isFinite(behaviorId)).toBe(true);
+
+		const sql = getTestDb();
+		// The route inner-joins `entities e ON e.id = ANY(i.entity_ids)`, so an
+		// org-scoped Behavior (entity_ids = {}) resolves no row and 404s. Bind one.
+		const entity = await createTestEntity({
+			name: "Window Vocab Co",
+			organization_id: org.id,
+		});
+		// postgres.js runs fetch_types:false here, so a raw JS array binds to a
+		// malformed array literal — build the value in SQL instead.
+		await sql`
+			UPDATE watchers
+			SET entity_ids = ARRAY[${entity.id}::bigint]
+			WHERE id = ${behaviorId}
+		`;
+
+		// `canvas_windows` is a VIEW over `events` (canvas-on-events): a window is
+		// a `canvas_state` root event — no supersedes_event_id — whose metadata
+		// carries watcher_id/granularity/window_start.
+		const windowRows = (await sql`
+			INSERT INTO events
+				(organization_id, payload_type, payload_data, semantic_type, created_at, metadata)
+			VALUES (
+				${org.id},
+				'text',
+				${sql.json({ summary: "window" })},
+				'canvas_state',
+				NOW(),
+				${sql.json({
+					watcher_id: behaviorId,
+					granularity: "day",
+					window_start: new Date(Date.now() - 86_400_000).toISOString(),
+					window_end: new Date().toISOString(),
+				})}
+			)
+			RETURNING id
+		`) as Array<{ id: number }>;
+		const windowId = windowRows[0].id;
+
+		const client = await createTestOAuthClient({ client_name: "Test" });
+		const login = await createTestAccessToken(user.id, org.id, client.client_id, {
+			scope: "mcp:read mcp:write",
+		});
+
+		const response = await get(
+			`/api/${org.slug}/behaviors/windows/${windowId}`,
+			{ token: login.token },
+		);
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as Record<string, unknown>;
+		expect(body).not.toHaveProperty("watcher_id");
+		expect(body).not.toHaveProperty("watcher_slug");
+		expect(body).not.toHaveProperty("watcher_name");
+		expect(String(body.behavior_id)).toBe(String(behaviorId));
+		expect(body.behavior_slug).toBe("window-vocab");
+		expect(body.behavior_name).toBe("Window vocab");
+	});
+});

--- a/packages/server/src/__tests__/integration/behaviors/rest-window-behavior-keys.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/rest-window-behavior-keys.test.ts
@@ -1,23 +1,10 @@
-/**
- * `GET /api/:orgSlug/behaviors/windows/:windowId` must speak the public
- * Behavior vocabulary.
- *
- * The handler selects `iw.watcher_id`, `i.slug as watcher_slug` and
- * `i.name as watcher_name` — sanctioned INTERNAL names (the table is still
- * `watchers`) — and used to `c.json(row)` the raw result. That leaked
- * `watcher_*` keys on a public org route while every sibling surface
- * (get_behavior, MCP list/get, SDK, generated client types) emits `behavior_*`.
- *
- * The rename belongs at the wire boundary, not in the SQL, so this pins the
- * response shape rather than the query.
- */
-
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../../../index";
 import { manageBehaviors } from "../../../tools/admin/manage_behaviors";
 import { initWorkspaceProvider } from "../../../workspace";
-import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { cleanupTestDatabase } from "../../setup/test-db";
 import {
+	createCanvasWindow,
 	createTestAccessToken,
 	createTestAgent,
 	createTestEntity,
@@ -37,13 +24,18 @@ describe("REST behavior window vocabulary", () => {
 
 	it("returns behavior_* keys and no watcher_* keys", async () => {
 		const { org, user, ctx } = await seedOwnerContext();
+		const entity = await createTestEntity({
+			name: "Window Vocab Co",
+			organization_id: org.id,
+		});
 		const agent = await createTestAgent({
 			organizationId: org.id,
 			ownerUserId: user.id,
 		});
-		const created = (await manageBehaviors(
+		const created = await manageBehaviors(
 			{
 				action: "create",
+				entity_id: entity.id,
 				slug: "window-vocab",
 				name: "Window vocab",
 				prompt: "Summarize.",
@@ -57,7 +49,7 @@ describe("REST behavior window vocabulary", () => {
 			},
 			{} as Env,
 			ctx,
-		)) as { action?: string; behavior_id?: number | string };
+		);
 
 		if (created.action !== "create" || !("behavior_id" in created)) {
 			throw new Error("Behavior creation did not complete");
@@ -65,48 +57,25 @@ describe("REST behavior window vocabulary", () => {
 		const behaviorId = Number(created.behavior_id);
 		expect(Number.isFinite(behaviorId)).toBe(true);
 
-		const sql = getTestDb();
-		// The route inner-joins `entities e ON e.id = ANY(i.entity_ids)`, so an
-		// org-scoped Behavior (entity_ids = {}) resolves no row and 404s. Bind one.
-		const entity = await createTestEntity({
-			name: "Window Vocab Co",
-			organization_id: org.id,
+		const windowId = await createCanvasWindow({
+			watcherId: behaviorId,
+			organizationId: org.id,
+			granularity: "day",
+			windowStart: "2026-07-21T00:00:00.000Z",
+			windowEnd: "2026-07-22T00:00:00.000Z",
+			entityIds: [entity.id],
+			extractedData: { summary: "window" },
 		});
-		// postgres.js runs fetch_types:false here, so a raw JS array binds to a
-		// malformed array literal — build the value in SQL instead.
-		await sql`
-			UPDATE watchers
-			SET entity_ids = ARRAY[${entity.id}::bigint]
-			WHERE id = ${behaviorId}
-		`;
-
-		// `canvas_windows` is a VIEW over `events` (canvas-on-events): a window is
-		// a `canvas_state` root event — no supersedes_event_id — whose metadata
-		// carries watcher_id/granularity/window_start.
-		const windowRows = (await sql`
-			INSERT INTO events
-				(organization_id, payload_type, payload_data, semantic_type, created_at, metadata)
-			VALUES (
-				${org.id},
-				'text',
-				${sql.json({ summary: "window" })},
-				'canvas_state',
-				NOW(),
-				${sql.json({
-					watcher_id: behaviorId,
-					granularity: "day",
-					window_start: new Date(Date.now() - 86_400_000).toISOString(),
-					window_end: new Date().toISOString(),
-				})}
-			)
-			RETURNING id
-		`) as Array<{ id: number }>;
-		const windowId = windowRows[0].id;
 
 		const client = await createTestOAuthClient({ client_name: "Test" });
-		const login = await createTestAccessToken(user.id, org.id, client.client_id, {
-			scope: "mcp:read mcp:write",
-		});
+		const login = await createTestAccessToken(
+			user.id,
+			org.id,
+			client.client_id,
+			{
+				scope: "mcp:read mcp:write",
+			},
+		);
 
 		const response = await get(
 			`/api/${org.slug}/behaviors/windows/${windowId}`,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1118,7 +1118,7 @@ app.get("/api/:orgSlug/behaviors/windows/:windowId", mcpAuth, async (c) => {
 		const windowResult = await sql`
       SELECT
         iw.id,
-        iw.watcher_id,
+        iw.watcher_id AS behavior_id,
         iw.granularity,
         iw.window_start,
         iw.window_end,
@@ -1130,8 +1130,8 @@ app.get("/api/:orgSlug/behaviors/windows/:windowId", mcpAuth, async (c) => {
         iw.model_used,
         iw.run_metadata,
         i.entity_ids,
-        i.slug as watcher_slug,
-        i.name as watcher_name,
+        i.slug AS behavior_slug,
+        i.name AS behavior_name,
         e.name as entity_name,
         et.slug AS entity_type,
         parent.name as parent_name,
@@ -1155,20 +1155,7 @@ app.get("/api/:orgSlug/behaviors/windows/:windowId", mcpAuth, async (c) => {
 			return c.json({ error: "Window not found" }, 404);
 		}
 
-		// Project to the public Behavior vocabulary. `watcher_id` / `watchers` are
-		// sanctioned INTERNAL names (table + column), so the rename belongs here at
-		// the wire boundary rather than in the SQL. Returning the raw row leaked
-		// watcher_id/watcher_slug/watcher_name on a public org route while every
-		// sibling surface — get_behavior, MCP list/get, SDK, client types — emits
-		// behavior_*; see get_behavior.ts, which canonicalizes the same columns.
-		const { watcher_id, watcher_slug, watcher_name, ...window } =
-			windowResult[0] as Record<string, unknown>;
-		return c.json({
-			...window,
-			behavior_id: watcher_id,
-			behavior_slug: watcher_slug,
-			behavior_name: watcher_name,
-		});
+		return c.json(windowResult[0]);
 	} catch (error) {
 		return c.json({ error: errorMessage(error) }, 500);
 	}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1155,7 +1155,20 @@ app.get("/api/:orgSlug/behaviors/windows/:windowId", mcpAuth, async (c) => {
 			return c.json({ error: "Window not found" }, 404);
 		}
 
-		return c.json(windowResult[0]);
+		// Project to the public Behavior vocabulary. `watcher_id` / `watchers` are
+		// sanctioned INTERNAL names (table + column), so the rename belongs here at
+		// the wire boundary rather than in the SQL. Returning the raw row leaked
+		// watcher_id/watcher_slug/watcher_name on a public org route while every
+		// sibling surface — get_behavior, MCP list/get, SDK, client types — emits
+		// behavior_*; see get_behavior.ts, which canonicalizes the same columns.
+		const { watcher_id, watcher_slug, watcher_name, ...window } =
+			windowResult[0] as Record<string, unknown>;
+		return c.json({
+			...window,
+			behavior_id: watcher_id,
+			behavior_slug: watcher_slug,
+			behavior_name: watcher_name,
+		});
 	} catch (error) {
 		return c.json({ error: errorMessage(error) }, 500);
 	}


### PR DESCRIPTION
## What

`GET /api/:orgSlug/behaviors/windows/:windowId` returned the raw SQL row via `c.json(windowResult[0])`, leaking `watcher_id` / `watcher_slug` / `watcher_name` on a **public org route** — while every sibling surface (`get_behavior`, MCP list/get, SDK, generated client types) emits `behavior_*`. `get_behavior.ts` already canonicalizes these exact columns; this handler was the one that missed #2034.

Projected at the wire boundary rather than renamed in SQL, since the table is still `watchers` and `watcher_id` is sanctioned internal vocabulary.

## How it was found, and what that says

An external audit pass over the surface turned this up. I'd told Burak earlier tonight that there was "no watcher anywhere on the public surface" — that claim was scoped to MCP/SDK and I never checked REST, so it was wrong.

**The naming guard I added in #2112 does not catch this.** It scopes to MCP tool schemas, SDK discovery metadata and namespace method names — not REST handlers. `make pre-pr` passes clean on the leaking code. That's a genuine coverage gap in the guard, not just in this route; worth a follow-up to extend it over `defineRoute`/handler response shapes, which I have not done here.

## Verification

Real red→green against scratch Postgres 18 + pgvector:

- **RED** (projection reverted): `expected { id: 3, watcher_id: 1, …(17) } to not have property "watcher_id"` — the leak reproduces exactly as described.
- **GREEN** (fix restored): passes.
- Whole `integration/behaviors/` suite: **7 files, all pass.**
- `make pre-pr` clean.

The test asserts both directions — absence of all three `watcher_*` keys and presence of the `behavior_*` values — so a partial rename can't satisfy it.

Building the fixture took several corrections worth noting for anyone extending it: `canvas_windows` is a **view** over `events` (canvas-on-events), not a table; `payload_type` is constrained to `text|markdown|json_template|media|empty`; the route inner-joins `entities` so an org-scoped Behavior with `entity_ids = {}` 404s; and binding a raw JS array hits the malformed-array-literal trap the repo has a CI gate for (`ARRAY[…::bigint]` instead).

No in-repo consumer reads this route, so the key rename is safe.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->