### PR TITLE
test(cli): lock apply plan labels to "behavior"

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
@@ -110,6 +110,17 @@ Summary: 2 create, 0 update, 0 noop, 0 drift"
 
 exports[`renderSummary renders zero-row plan 1`] = `"Summary: 0 create, 0 update, 0 noop, 0 drift"`;
 
+exports[`renderPlan — behavior labels (not watcher) plan create/update/drift rows print behavior, never watcher 1`] = `
+"
+Plan:
+
+  behaviors:
+  ~ behavior weekly-digest (prompt)
+  ? behavior orphaned-digest (drift — ignored in v1, not deleted)
+
+Summary: 0 create, 1 update, 0 noop, 1 drift"
+`;
+
 exports[`apply diff — connectors render includes the connectors sections 1`] = `
 "
 Plan:

--- a/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
@@ -115,10 +115,11 @@ exports[`renderPlan — behavior labels (not watcher) plan create/update/drift r
 Plan:
 
   behaviors:
-  ~ behavior weekly-digest (prompt)
+  ~ behavior weekly-digest
+  + behavior new-digest
   ? behavior orphaned-digest (drift — ignored in v1, not deleted)
 
-Summary: 0 create, 1 update, 0 noop, 1 drift"
+Summary: 1 create, 1 update, 0 noop, 1 drift"
 `;
 
 exports[`apply diff — connectors render includes the connectors sections 1`] = `

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import type { DesiredAgent, DesiredState } from "../desired-state.js";
 import { computeDiff, type RemoteSnapshot } from "../diff.js";
 import { mapProjectToDesiredState } from "../map-config.js";
-import { renderPlan, renderSummary } from "../render.js";
+import { renderPlan, renderProgress, renderSummary } from "../render.js";
 
 // Force chalk to render plain text in snapshots regardless of TTY detection.
 // `chalk.level = 0` strips colors so snapshot diffs aren't TTY-dependent.
@@ -801,6 +801,60 @@ describe("renderSummary", () => {
     const desired = buildState([]);
     const plan = computeDiff(desired, emptyRemote());
     expect(renderSummary(plan)).toMatchSnapshot();
+  });
+});
+
+/**
+ * Internal plan rows still use kind: "watcher" (DesiredState.watchers +
+ * counts_by_kind keys). User-facing apply output must say "behavior" —
+ * never the legacy "watcher" label or heading.
+ */
+describe("renderPlan — behavior labels (not watcher)", () => {
+  const desiredBehavior = {
+    slug: "weekly-digest",
+    agent: "triage",
+    name: "Weekly digest",
+    prompt: "Produce a digest.",
+    triggers: [{ kind: "schedule" as const, cron: "0 9 * * 1" }],
+  };
+
+  /** Labels/headings only — not substrings of resource slugs. */
+  function expectNoWatcherLabels(text: string): void {
+    expect(text).not.toMatch(/(?:^|\n)\s*watchers?:\s*(?:\n|$)/);
+    expect(text).not.toMatch(/[+=~?-]\s+watcher\s+\S/);
+  }
+
+  test("plan create/update/drift rows print behavior, never watcher", () => {
+    const desired = buildState([], { watchers: [desiredBehavior] });
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [
+        {
+          slug: "weekly-digest",
+          name: "Weekly digest",
+          agent_id: "triage",
+          prompt: "Old prompt",
+          triggers: [{ kind: "schedule", cron: "0 9 * * 1" }],
+        },
+        { slug: "orphaned-digest" },
+      ],
+    };
+    const plan = computeDiff(desired, remote);
+    // Sanity: internal kind is still "watcher" (not a wire field on manage_behaviors).
+    expect(plan.rows.some((r) => r.kind === "watcher")).toBe(true);
+
+    const text = renderPlan(plan);
+    expect(text).toContain("behaviors:");
+    expect(text).toContain("behavior weekly-digest");
+    expect(text).toContain("behavior orphaned-digest");
+    expectNoWatcherLabels(text);
+    expect(text).toMatchSnapshot();
+  });
+
+  test("renderProgress uses the behavior label for watcher-kind rows", () => {
+    const line = renderProgress("create", "watcher", "weekly-digest");
+    expect(line).toContain("behavior weekly-digest");
+    expectNoWatcherLabels(line);
   });
 });
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -3,7 +3,7 @@ import { defineAgent, defineBehavior, defineConfig } from "@lobu/cli/config";
 import type { AgentSettings } from "@lobu/core";
 import chalk from "chalk";
 import type { DesiredAgent, DesiredState } from "../desired-state.js";
-import { computeDiff, type RemoteSnapshot } from "../diff.js";
+import { computeDiff, type DiffPlan, type RemoteSnapshot } from "../diff.js";
 import { mapProjectToDesiredState } from "../map-config.js";
 import { renderPlan, renderProgress, renderSummary } from "../render.js";
 
@@ -804,20 +804,7 @@ describe("renderSummary", () => {
   });
 });
 
-/**
- * Internal plan rows still use kind: "watcher" (DesiredState.watchers +
- * counts_by_kind keys). User-facing apply output must say "behavior" —
- * never the legacy "watcher" label or heading.
- */
 describe("renderPlan — behavior labels (not watcher)", () => {
-  const desiredBehavior = {
-    slug: "weekly-digest",
-    agent: "triage",
-    name: "Weekly digest",
-    prompt: "Produce a digest.",
-    triggers: [{ kind: "schedule" as const, cron: "0 9 * * 1" }],
-  };
-
   /** Labels/headings only — not substrings of resource slugs. */
   function expectNoWatcherLabels(text: string): void {
     expect(text).not.toMatch(/(?:^|\n)\s*watchers?:\s*(?:\n|$)/);
@@ -825,26 +812,19 @@ describe("renderPlan — behavior labels (not watcher)", () => {
   }
 
   test("plan create/update/drift rows print behavior, never watcher", () => {
-    const desired = buildState([], { watchers: [desiredBehavior] });
-    const remote: RemoteSnapshot = {
-      ...emptyRemote(),
-      watchers: [
-        {
-          slug: "weekly-digest",
-          name: "Weekly digest",
-          agent_id: "triage",
-          prompt: "Old prompt",
-          triggers: [{ kind: "schedule", cron: "0 9 * * 1" }],
-        },
-        { slug: "orphaned-digest" },
+    const plan: DiffPlan = {
+      rows: [
+        { kind: "watcher", verb: "update", id: "weekly-digest" },
+        { kind: "watcher", verb: "create", id: "new-digest" },
+        { kind: "watcher", verb: "drift", id: "orphaned-digest" },
       ],
+      counts: { create: 1, update: 1, noop: 0, drift: 1, delete: 0 },
+      notes: [],
     };
-    const plan = computeDiff(desired, remote);
-    // Sanity: internal kind is still "watcher" (not a wire field on manage_behaviors).
-    expect(plan.rows.some((r) => r.kind === "watcher")).toBe(true);
 
     const text = renderPlan(plan);
     expect(text).toContain("behaviors:");
+    expect(text).toContain("behavior new-digest");
     expect(text).toContain("behavior weekly-digest");
     expect(text).toContain("behavior orphaned-digest");
     expectNoWatcherLabels(text);

--- a/packages/cli/src/commands/_lib/apply/render.ts
+++ b/packages/cli/src/commands/_lib/apply/render.ts
@@ -9,6 +9,13 @@ const VERB_PREFIX = {
   delete: chalk.red("-"),
 } as const;
 
+/**
+ * User-facing labels for plan/progress output.
+ *
+ * Diff rows keep an internal kind of `"watcher"` (DesiredState / counts_by_kind
+ * still use that key; manage_behaviors wire payloads never carry it). Printed
+ * text must say "behavior" so `lobu apply` never surfaces the old term.
+ */
 const KIND_LABEL: Record<DiffRow["kind"], string> = {
   agent: "agent",
   settings: "settings",

--- a/packages/cli/src/commands/_lib/apply/render.ts
+++ b/packages/cli/src/commands/_lib/apply/render.ts
@@ -9,13 +9,6 @@ const VERB_PREFIX = {
   delete: chalk.red("-"),
 } as const;
 
-/**
- * User-facing labels for plan/progress output.
- *
- * Diff rows keep an internal kind of `"watcher"` (DesiredState / counts_by_kind
- * still use that key; manage_behaviors wire payloads never carry it). Printed
- * text must say "behavior" so `lobu apply` never surfaces the old term.
- */
 const KIND_LABEL: Record<DiffRow["kind"], string> = {
   agent: "agent",
   settings: "settings",


### PR DESCRIPTION
## What

Adds a regression test covering the `watcher` → `behavior` label mapping in `apply` plan output. **Test-only — no production change.**

`render.ts` already maps `watcher: "behavior"` (`KIND_LABEL`) and `watcher: "behaviors"` (`KIND_HEADING`) on main. Nothing was user-visibly broken; this pins that behavior so it can't silently regress.

## Why this is worth a PR

`kind: "watcher"` is still the internal discriminant (sanctioned per the rename policy) and the DB/table vocabulary is unchanged. The only thing standing between that internal name and the user's terminal is a two-line lookup table with no test. The `#2112` naming guard does **not** cover this: it scopes to MCP tool schemas and SDK namespaces, not CLI render output.

## Verification (red→green)

Reverted both mappings back to `"watcher"`/`"watchers"` and confirmed the test genuinely fails:

```
Expected to contain: "behaviors:"
Received: "\nPlan:\n\n  watchers:\n  ~ watcher weekly-digest\n  + watcher new-digest\n ...
Expected to contain: "behavior weekly-digest"
Received: "  + watcher weekly-digest"
 50 pass, 2 fail
```

Restored → 52/52 pass. Covers create, update, and drift rows plus `renderProgress`.

Assertions are scoped to labels/headings only (`expectNoWatcherLabels`) so a resource whose *slug* legitimately contains "watcher" won't trip it.

`make pre-pr` clean (5/5). `make review-fix` found no defects.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for plan and progress display output.
  * Added checks to ensure behavior labels are shown correctly and watcher-specific labels do not appear in non-watcher contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->