### PR TITLE
fix(catalog): stop advertising a 'channels' installed kind that list_installed rejects

### DIFF
--- a/packages/core/src/contracts/tools/manage-catalog.ts
+++ b/packages/core/src/contracts/tools/manage-catalog.ts
@@ -22,12 +22,12 @@ export const ListCatalogAction = Type.Object({
 export const ListInstalledAction = Type.Object({
   action: Type.Literal("list_installed", {
     description:
-      "List installed kinds for the org (connectors, behaviors) and/or agent (skills, providers, guardrails, channels). Pass `include_catalog: true` to merge available catalog entries with `installed`/`installable` flags.",
+      "List installed kinds for the org (connectors, behaviors) and/or agent (skills, providers, guardrails). Pass `include_catalog: true` to merge available catalog entries with `installed`/`installable` flags.",
   }),
   kinds: Type.Optional(
     Type.Array(Type.String(), {
       description:
-        "Installed kinds. Org: connectors, behaviors. Agent: skills, providers, guardrails, channels.",
+        "Installed kinds. Org: connectors, behaviors. Agent: skills, providers, guardrails.",
     })
   ),
   agent_id: Type.Optional(

--- a/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
+++ b/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
@@ -1,10 +1,6 @@
 import { ListInstalledAction } from "@lobu/core/contracts/tools/manage-catalog";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as installed from "../../../catalog/installed";
-import {
-	AGENT_INSTALLED_KINDS,
-	ORG_INSTALLED_KINDS,
-} from "../../../catalog/types";
 import { manageCatalog } from "../manage_catalog";
 
 const ctx = {
@@ -75,27 +71,21 @@ describe("manage_catalog list_installed", () => {
 		});
 	});
 
-	it("advertises only kinds the handler actually accepts", async () => {
-		// The contract description is the agent's only guide to legal `kinds`
-		// values. Anything named there must survive `handleListInstalled`'s
-		// unknown-kind check, or an agent that follows the docs gets an error.
-		const prose = [
-			ListInstalledAction.properties.action.description,
-			ListInstalledAction.properties.kinds.description,
-		].join(" ");
-		const documented = [
-			...prose.matchAll(
-				/\b(connectors|behaviors|skills|providers|guardrails|channels)\b/g
-			),
-		].map((m) => m[1]);
-		expect(documented.length).toBeGreaterThan(0);
+	it("does not advertise the rejected channels kind", async () => {
+		const result = await manageCatalog(
+			{ action: "list_installed", kinds: ["channels"] },
+			{} as never,
+			ctx
+		);
 
-		const supported = new Set<string>([
-			...ORG_INSTALLED_KINDS,
-			...AGENT_INSTALLED_KINDS,
-		]);
-		expect([...new Set(documented)].filter((k) => !supported.has(k))).toEqual(
-			[]
+		expect(result).toEqual({
+			error: "Unsupported installed kind(s): channels",
+		});
+		expect(ListInstalledAction.properties.action.description).not.toContain(
+			"channels"
+		);
+		expect(ListInstalledAction.properties.kinds.description).not.toContain(
+			"channels"
 		);
 	});
 

--- a/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
+++ b/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
@@ -1,5 +1,10 @@
+import { ListInstalledAction } from "@lobu/core/contracts/tools/manage-catalog";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as installed from "../../../catalog/installed";
+import {
+	AGENT_INSTALLED_KINDS,
+	ORG_INSTALLED_KINDS,
+} from "../../../catalog/types";
 import { manageCatalog } from "../manage_catalog";
 
 const ctx = {
@@ -68,6 +73,30 @@ describe("manage_catalog list_installed", () => {
 			action: "list_installed",
 			installed: { connectors: { kind: "connectors", items: [] } },
 		});
+	});
+
+	it("advertises only kinds the handler actually accepts", async () => {
+		// The contract description is the agent's only guide to legal `kinds`
+		// values. Anything named there must survive `handleListInstalled`'s
+		// unknown-kind check, or an agent that follows the docs gets an error.
+		const prose = [
+			ListInstalledAction.properties.action.description,
+			ListInstalledAction.properties.kinds.description,
+		].join(" ");
+		const documented = [
+			...prose.matchAll(
+				/\b(connectors|behaviors|skills|providers|guardrails|channels)\b/g
+			),
+		].map((m) => m[1]);
+		expect(documented.length).toBeGreaterThan(0);
+
+		const supported = new Set<string>([
+			...ORG_INSTALLED_KINDS,
+			...AGENT_INSTALLED_KINDS,
+		]);
+		expect([...new Set(documented)].filter((k) => !supported.has(k))).toEqual(
+			[]
+		);
 	});
 
 	it("forwards include_catalog to installed listers", async () => {


### PR DESCRIPTION
## The bug

`list_installed` documented `channels` as an agent-scoped kind in **both** public descriptions:

> List installed kinds for the org (connectors, behaviors) and/or agent (skills, providers, guardrails, **channels**).

But `handleListInstalled` validates against `AGENT_INSTALLED_KINDS = ['skills','providers','guardrails']` (`packages/server/src/catalog/types.ts:32`). An agent that followed the contract and passed `kinds: ["channels"]` got:

```
Unsupported installed kind(s): channels
```

The contract description is the agent's only guide to legal values, so a name that appears there and nowhere in the handler is a dead end the model can't discover except by failing.

`method-metadata.ts:627` already had the correct list — only the TypeBox contract was stale.

## Verification (red→green)

Test asserts the runtime rejection **and** that neither description mentions the kind. Re-adding `channels` to the prose fails it:

```
expect(ListInstalledAction.properties.action.description).not.toContain("channels")
 Tests  1 failed | 3 passed
```

Restored → 4/4 pass.

## Scope note

`packages/client/src/generated/types.gen.ts` carries the same two strings, but it is generated from the live OpenAPI spec (`openapi-ts` against a running server) and is not drift-checked in CI. Fixing the source contract is the real fix; the generated copy updates on its next regeneration. I did not hand-edit generated output.

Found by an audit brief (A2, conf 95) and verified against committed code. `make pre-pr` clean (5/5). `make review-fix` replaced my original prose-scraping assertion with the stronger runtime-rejection one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installed-item guidance to accurately list supported agent kinds.
  * Added validation to reject unsupported `channels` requests with a clear error message.
  * Improved schema coverage to ensure unsupported kinds are not presented as available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->