### PR TITLE
ci: fail closed when the exec sandbox is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,38 +41,7 @@ jobs:
         # Ubuntu 24.04 (ubuntu-latest) blocks unprivileged user namespaces via
         # AppArmor by default; bwrap needs them, so flip the sysctl. See
         # https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
-        run: |
-          # apt mirrors flake. Enforcement (LOBU_REQUIRE_EXEC_SANDBOX) means a
-          # failed install is now a RED build rather than a silent skip, so
-          # retry to keep that rare, and exit non-zero when genuinely exhausted
-          # instead of falling through to the test steps.
-          installed=""
-          for attempt in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
-              installed=1
-              break
-            fi
-            echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
-            sleep $((attempt * 5))
-          done
-          if [ -z "$installed" ]; then
-            echo "::error::bubblewrap install failed after 3 attempts"
-            exit 1
-          fi
-          # Only flip the AppArmor userns restriction when the kernel exposes
-          # it (GitHub-hosted ubuntu-24.04). Blacksmith's Firecracker microVMs
-          # don't restrict unprivileged user namespaces and lack this sysctl key.
-          if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
-            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          fi
-          bwrap --version
-          ls -la /usr/bin/true /bin/true 2>&1 || true
-          # Probe with multiple bind mounts. /bin and /usr/bin are sometimes the
-          # same symlinked tree, sometimes not, depending on distro layout.
-          bwrap --unshare-user --unshare-pid \
-            --ro-bind / / \
-            --proc /proc --dev /dev \
-            -- /usr/bin/true && echo "bwrap userns OK"
+        run: bash scripts/install-bubblewrap.sh probe
 
       - name: Install dependencies
         run: bun install
@@ -235,42 +204,7 @@ jobs:
       # The worker's exec-sandbox uses bwrap on Linux; ubuntu-latest blocks
       # unprivileged user namespaces via AppArmor, so flip the sysctl too.
       - name: Install bubblewrap (worker exec-sandbox)
-        run: |
-          # apt mirrors flake. Enforcement (LOBU_REQUIRE_EXEC_SANDBOX) means a
-          # failed install is now a RED build rather than a silent skip, so
-          # retry to keep that rare, and exit non-zero when genuinely exhausted
-          # instead of falling through to the test steps.
-          installed=""
-          for attempt in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
-              installed=1
-              break
-            fi
-            echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
-            sleep $((attempt * 5))
-          done
-          if [ -z "$installed" ]; then
-            echo "::error::bubblewrap install failed after 3 attempts"
-            exit 1
-          fi
-          # Only flip the AppArmor userns restriction when the kernel exposes
-          # it (GitHub-hosted ubuntu-24.04). Blacksmith's Firecracker microVMs
-          # don't restrict unprivileged user namespaces and lack this sysctl key.
-          if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
-            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          fi
-          bwrap --version
-
-      # NOTE: `lobu run`'s embedded Postgres (PG18) is NEEDED-linked against
-      # ICU 60, which ubuntu-latest no longer carries. We do NOT install a
-      # system libicu60 (the old archive .deb was fragile and didn't help local
-      # Linux devs) — instead scripts/sdk-e2e.sh runs
-      # scripts/sdk-e2e/fix-embedded-pg-icu.mjs, which creates the missing
-      # `.so.60` SONAME symlinks in the embedded-postgres native/lib dir (it
-      # already ships libicu*.so.60.2). The binaries' `$ORIGIN/../lib` rpath then
-      # resolves their bundled ICU with zero system deps. Prod is unaffected
-      # (external Postgres; embedded-postgres pruned from the app image).
-
+        run: bash scripts/install-bubblewrap.sh
       - name: Build all packages (CLI + server bundle + sdk + pgvector-embedded)
         run: make build-packages
 
@@ -315,35 +249,7 @@ jobs:
       # The worker's exec-sandbox uses bwrap on Linux; ubuntu-latest blocks
       # unprivileged user namespaces via AppArmor, so flip the sysctl too.
       - name: Install bubblewrap (worker exec-sandbox)
-        run: |
-          # apt mirrors flake. Enforcement (LOBU_REQUIRE_EXEC_SANDBOX) means a
-          # failed install is now a RED build rather than a silent skip, so
-          # retry to keep that rare, and exit non-zero when genuinely exhausted
-          # instead of falling through to the test steps.
-          installed=""
-          for attempt in 1 2 3; do
-            if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
-              installed=1
-              break
-            fi
-            echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
-            sleep $((attempt * 5))
-          done
-          if [ -z "$installed" ]; then
-            echo "::error::bubblewrap install failed after 3 attempts"
-            exit 1
-          fi
-          # Only flip the AppArmor userns restriction when the kernel exposes
-          # it (GitHub-hosted ubuntu-24.04). Blacksmith's Firecracker microVMs
-          # don't restrict unprivileged user namespaces and lack this sysctl key.
-          if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
-            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          fi
-          bwrap --version
-
-      # Embedded Postgres (PG18) ICU shim — see the sdk-e2e job note above;
-      # scripts/cli-smoke.sh runs the same scripts/sdk-e2e/fix-embedded-pg-icu.mjs.
-
+        run: bash scripts/install-bubblewrap.sh
       - name: Build all packages (CLI + server bundle + sdk + pgvector-embedded)
         run: make build-packages
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,24 @@ jobs:
         # AppArmor by default; bwrap needs them, so flip the sysctl. See
         # https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
         run: |
-          sudo apt-get update
-          sudo apt-get install -y bubblewrap coreutils
+          # Retry: a transient apt mirror failure used to hand the job on to the
+          # test steps, where the bwrap escape matrix would silently auto-skip.
+          # The unit suite now fails closed via LOBU_REQUIRE_EXEC_SANDBOX, so a
+          # flake is a red build, not a false green — retry to keep that rare.
+          installed=""
+          for attempt in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
+              installed=1
+              break
+            fi
+            echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
+            sleep $((attempt * 5))
+          done
+          # Fail loudly rather than falling through to a green run without bwrap.
+          if [ -z "$installed" ]; then
+            echo "::error::bubblewrap install failed after 3 attempts"
+            exit 1
+          fi
           # Only flip the AppArmor userns restriction when the kernel exposes
           # it (GitHub-hosted ubuntu-24.04). Blacksmith's Firecracker microVMs
           # don't restrict unprivileged user namespaces and lack this sysctl key.
@@ -114,6 +130,13 @@ jobs:
         # passes; if Linux turns out different we'll narrow this back down,
         # but we own the WASM concern via run-script-runtime.test.ts under
         # Node + isolated-vm in the integration job below.
+        #
+        # LOBU_REQUIRE_EXEC_SANDBOX turns a missing/non-functional bwrap into a
+        # test failure. Without it the exec-sandbox escape matrix `describe.skip`s
+        # itself and the job still goes green — the one place we verify the
+        # sandbox actually contains a hostile command would vanish unnoticed.
+        env:
+          LOBU_REQUIRE_EXEC_SANDBOX: "1"
         run: |
           bun test packages/agent-worker --coverage
           mv coverage/lcov.info coverage/agent-worker.lcov.info
@@ -214,8 +237,24 @@ jobs:
       # unprivileged user namespaces via AppArmor, so flip the sysctl too.
       - name: Install bubblewrap (worker exec-sandbox)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y bubblewrap coreutils
+          # Retry: a transient apt mirror failure used to hand the job on to the
+          # test steps, where the bwrap escape matrix would silently auto-skip.
+          # The unit suite now fails closed via LOBU_REQUIRE_EXEC_SANDBOX, so a
+          # flake is a red build, not a false green — retry to keep that rare.
+          installed=""
+          for attempt in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
+              installed=1
+              break
+            fi
+            echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
+            sleep $((attempt * 5))
+          done
+          # Fail loudly rather than falling through to a green run without bwrap.
+          if [ -z "$installed" ]; then
+            echo "::error::bubblewrap install failed after 3 attempts"
+            exit 1
+          fi
           # Only flip the AppArmor userns restriction when the kernel exposes
           # it (GitHub-hosted ubuntu-24.04). Blacksmith's Firecracker microVMs
           # don't restrict unprivileged user namespaces and lack this sysctl key.
@@ -279,8 +318,24 @@ jobs:
       # unprivileged user namespaces via AppArmor, so flip the sysctl too.
       - name: Install bubblewrap (worker exec-sandbox)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y bubblewrap coreutils
+          # Retry: a transient apt mirror failure used to hand the job on to the
+          # test steps, where the bwrap escape matrix would silently auto-skip.
+          # The unit suite now fails closed via LOBU_REQUIRE_EXEC_SANDBOX, so a
+          # flake is a red build, not a false green — retry to keep that rare.
+          installed=""
+          for attempt in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
+              installed=1
+              break
+            fi
+            echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
+            sleep $((attempt * 5))
+          done
+          # Fail loudly rather than falling through to a green run without bwrap.
+          if [ -z "$installed" ]; then
+            echo "::error::bubblewrap install failed after 3 attempts"
+            exit 1
+          fi
           # Only flip the AppArmor userns restriction when the kernel exposes
           # it (GitHub-hosted ubuntu-24.04). Blacksmith's Firecracker microVMs
           # don't restrict unprivileged user namespaces and lack this sysctl key.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,10 @@ jobs:
         # AppArmor by default; bwrap needs them, so flip the sysctl. See
         # https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
         run: |
-          # Retry: a transient apt mirror failure used to hand the job on to the
-          # test steps, where the bwrap escape matrix would silently auto-skip.
-          # The unit suite now fails closed via LOBU_REQUIRE_EXEC_SANDBOX, so a
-          # flake is a red build, not a false green — retry to keep that rare.
+          # apt mirrors flake. Enforcement (LOBU_REQUIRE_EXEC_SANDBOX) means a
+          # failed install is now a RED build rather than a silent skip, so
+          # retry to keep that rare, and exit non-zero when genuinely exhausted
+          # instead of falling through to the test steps.
           installed=""
           for attempt in 1 2 3; do
             if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
@@ -55,7 +55,6 @@ jobs:
             echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
             sleep $((attempt * 5))
           done
-          # Fail loudly rather than falling through to a green run without bwrap.
           if [ -z "$installed" ]; then
             echo "::error::bubblewrap install failed after 3 attempts"
             exit 1
@@ -237,10 +236,10 @@ jobs:
       # unprivileged user namespaces via AppArmor, so flip the sysctl too.
       - name: Install bubblewrap (worker exec-sandbox)
         run: |
-          # Retry: a transient apt mirror failure used to hand the job on to the
-          # test steps, where the bwrap escape matrix would silently auto-skip.
-          # The unit suite now fails closed via LOBU_REQUIRE_EXEC_SANDBOX, so a
-          # flake is a red build, not a false green — retry to keep that rare.
+          # apt mirrors flake. Enforcement (LOBU_REQUIRE_EXEC_SANDBOX) means a
+          # failed install is now a RED build rather than a silent skip, so
+          # retry to keep that rare, and exit non-zero when genuinely exhausted
+          # instead of falling through to the test steps.
           installed=""
           for attempt in 1 2 3; do
             if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
@@ -250,7 +249,6 @@ jobs:
             echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
             sleep $((attempt * 5))
           done
-          # Fail loudly rather than falling through to a green run without bwrap.
           if [ -z "$installed" ]; then
             echo "::error::bubblewrap install failed after 3 attempts"
             exit 1
@@ -318,10 +316,10 @@ jobs:
       # unprivileged user namespaces via AppArmor, so flip the sysctl too.
       - name: Install bubblewrap (worker exec-sandbox)
         run: |
-          # Retry: a transient apt mirror failure used to hand the job on to the
-          # test steps, where the bwrap escape matrix would silently auto-skip.
-          # The unit suite now fails closed via LOBU_REQUIRE_EXEC_SANDBOX, so a
-          # flake is a red build, not a false green — retry to keep that rare.
+          # apt mirrors flake. Enforcement (LOBU_REQUIRE_EXEC_SANDBOX) means a
+          # failed install is now a RED build rather than a silent skip, so
+          # retry to keep that rare, and exit non-zero when genuinely exhausted
+          # instead of falling through to the test steps.
           installed=""
           for attempt in 1 2 3; do
             if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
@@ -331,7 +329,6 @@ jobs:
             echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
             sleep $((attempt * 5))
           done
-          # Fail loudly rather than falling through to a green run without bwrap.
           if [ -z "$installed" ]; then
             echo "::error::bubblewrap install failed after 3 attempts"
             exit 1

--- a/packages/agent-worker/src/__tests__/exec-sandbox.test.ts
+++ b/packages/agent-worker/src/__tests__/exec-sandbox.test.ts
@@ -392,6 +392,24 @@ const linuxBwrapWorks = (() => {
     return false;
   }
 })();
+// `describe.skip` is invisible in a green run: if the bubblewrap install step
+// flakes, every escape test below silently disappears and CI still reports
+// success — the sandbox would be unverified precisely when it matters. CI sets
+// LOBU_REQUIRE_EXEC_SANDBOX=1 to make that skip a hard failure instead.
+const requireSandbox =
+  process.env.LOBU_REQUIRE_EXEC_SANDBOX === "1" ||
+  process.env.LOBU_REQUIRE_EXEC_SANDBOX === "true";
+
+describe("bwrap escape matrix availability", () => {
+  test("a working bwrap is present when the environment requires one", () => {
+    if (!requireSandbox) return;
+    expect({
+      platform: process.platform,
+      bwrapDeliversIsolation: linuxBwrapWorks,
+    }).toEqual({ platform: "linux", bwrapDeliversIsolation: true });
+  });
+});
+
 const describeBwrap = linuxBwrapWorks ? describe : describe.skip;
 
 describeBwrap("bwrap escape matrix", () => {

--- a/packages/agent-worker/src/__tests__/exec-sandbox.test.ts
+++ b/packages/agent-worker/src/__tests__/exec-sandbox.test.ts
@@ -341,7 +341,7 @@ describeDarwin("sandbox-exec escape matrix", () => {
 });
 
 // Real escape-matrix tests against bwrap. Auto-skip when not on Linux, when
-// bwrap isn't on PATH, or when user namespaces are blocked at the OS level
+// bwrap isn't installed at a supported path, or when namespaces are blocked
 // (Ubuntu 24.04 / GitHub Actions default until apparmor sysctl is flipped).
 // Probed once at module load so each test starts with a known-good sandbox.
 const isLinux = process.platform === "linux";
@@ -365,6 +365,8 @@ const linuxBwrapWorks = (() => {
       [
         "--unshare-user",
         "--unshare-pid",
+        "--unshare-ipc",
+        "--unshare-uts",
         "--unshare-net",
         "--ro-bind",
         "/usr",
@@ -403,6 +405,9 @@ const requireSandbox =
 describe("bwrap escape matrix availability", () => {
   test("a working bwrap is present when the environment requires one", () => {
     if (!requireSandbox) return;
+    // Compared as an object so a failure names the platform too — on a
+    // non-Linux runner `false` alone reads as "bwrap broken" when the real
+    // cause is that the job is on the wrong OS.
     expect({
       platform: process.platform,
       bwrapDeliversIsolation: linuxBwrapWorks,

--- a/scripts/install-bubblewrap.sh
+++ b/scripts/install-bubblewrap.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Install bubblewrap for the worker exec-sandbox and prove it delivers real
+# isolation on this runner.
+#
+# Why this is a script and not three inline `run:` blocks: the `unit`,
+# `sdk-e2e`, and `cli-smoke` jobs all need bwrap, and the unit job now runs the
+# escape matrix under LOBU_REQUIRE_EXEC_SANDBOX=1 (a missing bwrap is a test
+# failure, not a silent skip). Keeping one copy means the retry policy and the
+# AppArmor workaround can't drift apart between jobs.
+set -euo pipefail
+
+# apt mirrors flake. Because a failed install is now a RED build rather than a
+# silent skip, retry to keep that rare — then fail loudly instead of falling
+# through to the test steps with no sandbox.
+installed=""
+for attempt in 1 2 3; do
+  if sudo apt-get update && sudo apt-get install -y bubblewrap coreutils; then
+    installed=1
+    break
+  fi
+  if [ "$attempt" -lt 3 ]; then
+    echo "apt-get failed (attempt $attempt/3); retrying in $((attempt * 5))s"
+    sleep $((attempt * 5))
+  fi
+done
+if [ -z "$installed" ]; then
+  echo "::error::bubblewrap install failed after 3 attempts"
+  exit 1
+fi
+
+# Only flip the AppArmor userns restriction when the kernel exposes it
+# (GitHub-hosted ubuntu-24.04). Blacksmith's Firecracker microVMs don't
+# restrict unprivileged user namespaces and lack this sysctl key.
+if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+fi
+
+bwrap --version
+
+# The userns probe is opt-in ($1 == "probe"). Only the unit job runs the escape
+# matrix, and only it probed before this script existed; sdk-e2e and cli-smoke
+# just need the binary present. Enabling the probe everywhere would newly fail
+# those jobs on any runner where unsharing is restricted — a behaviour change
+# this refactor has no business making.
+if [ "${1:-}" = "probe" ]; then
+  # Same unshare flags production uses (exec-sandbox.ts), so a runner that can
+  # install bwrap but not actually unshare fails here — loudly — rather than
+  # inside the escape matrix.
+  bwrap --unshare-user --unshare-pid --unshare-ipc --unshare-uts --unshare-net \
+    --ro-bind / / \
+    --proc /proc --dev /dev \
+    -- /usr/bin/true && echo "bwrap userns OK"
+fi


### PR DESCRIPTION
## The problem

The bwrap escape matrix (10 tests) is the only place we verify a spawned binary is *actually* contained — that it can't read outside the workspace, escape via symlink, etc. It was wrapped in `describe.skip` whenever bwrap was missing or user namespaces were blocked.

So when the `Install bubblewrap` step flaked on #2119, the job reported:

```
30 pass, 12 skip, 0 fail   ← green
```

The sandbox went unverified exactly when it was least likely to work, and nothing in the summary said so. This is the failure mode where a guard silently stops guarding.

## What changed

**1. The skip is now a hard failure under CI.** `LOBU_REQUIRE_EXEC_SANDBOX=1` makes a missing/non-functional bwrap fail the suite. Unset (local dev, macOS) keeps today's skip behaviour, so nothing changes for contributors.

**2. The availability probe now matches production.** It was missing `--unshare-ipc` and `--unshare-uts`, which `exec-sandbox.ts:101-105` *does* pass — so it could green-light a weaker sandbox than production actually requests. (Caught by `make review-fix`.)

**3. All three bubblewrap installs retry 3× and `exit 1` when exhausted.** With enforcement on, a flake is now a red build rather than a false green; retry keeps that rare. The naive `for … do … && break; done` exits **0** when every attempt fails, so the explicit `installed` check is load-bearing — verified in isolation.

## Verification

| flag | result |
|---|---|
| unset (macOS) | `31 pass, 12 skip, 0 fail` — green, unchanged |
| `=1` | `1 fail` — hard failure |
| `=true` | `1 fail` — both truthy spellings honoured |

Retry-exhausted path exits 1, verified separately.

## Not a runtime vulnerability

Worth stating plainly: **the runtime already fails closed.** `probeSandboxStrategy()` returning `"none"` leaves `registerSpawnedBinaries` false (`just-bash-bootstrap.ts:515`), so external CLIs are never registered without an explicit `LOBU_ALLOW_UNSANDBOXED_EXEC=1`. This PR is strictly about CI no longer *claiming* to verify something it skipped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->