### PR TITLE
fix(examples): strip social-context banners from LinkedIn home-feed authors

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -169,6 +169,21 @@ describe("buildHomeFeedEvents", () => {
     expect(ev.metadata).toEqual({ author: "DOM Author" });
   });
 
+  test("uses the post author when the DOM selector finds the reacting member", () => {
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post Deb Mukherjee likes this 🦔 james hawkins • 2nd self driving software and co-ceo at posthog 8h • Connect",
+          author: "Deb Mukherjee",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.author_name).toBe("🦔 james hawkins");
+    expect(ev.metadata).toEqual({ author: "🦔 james hawkins" });
+  });
+
   test("strips the connection-degree marker from a DOM-selector author", () => {
     const [ev] = buildHomeFeedEvents(
       [
@@ -280,6 +295,81 @@ describe("parseHomeFeedAuthor", () => {
         "Feed post Sabri Karagönen reposted this Hardal 17h • Follow Hardal is now integrated with Bruin"
       )
     ).toBe("Hardal");
+  });
+
+  test('strips a "likes this" social-context banner before the author', () => {
+    expect(
+      parseHomeFeedAuthor(
+        "Feed post Deb Mukherjee likes this 🦔 james hawkins • 2nd self driving software and co-ceo at posthog 8h • Connect this is what happens"
+      )
+    ).toBe("🦔 james hawkins");
+    expect(
+      parseHomeFeedAuthor(
+        "Feed post Onur Demirtaş likes this Erkan Ayan • 2nd erkanayan.net 8h • Connect 📍 something"
+      )
+    ).toBe("Erkan Ayan");
+  });
+
+  test('strips a "commented" social-context banner before the author', () => {
+    expect(
+      parseHomeFeedAuthor(
+        "Feed post Barry McCardel commented Caroline Haynes • 2nd GTM at Hex 20h • Follow After an incredible run"
+      )
+    ).toBe("Caroline Haynes");
+    expect(
+      parseHomeFeedAuthor(
+        "Feed post Joseph Jacks commented Roelof Botha • 3rd+ Investor 3h • Follow I am hiring"
+      )
+    ).toBe("Roelof Botha");
+  });
+
+  test('strips a "finds this insightful" banner before the author', () => {
+    expect(
+      parseHomeFeedAuthor(
+        "Feed post Arpit Choudhury finds this insightful Paul Walsh • 2nd Online safety & security 5h • Follow"
+      )
+    ).toBe("Paul Walsh");
+  });
+
+  test('strips a plural "and N others like this" banner before the author', () => {
+    expect(
+      parseHomeFeedAuthor(
+        "Feed post Ali Veli and 3 others like this Ayşe Yılmaz • 2nd Data engineer 4h • Connect"
+      )
+    ).toBe("Ayşe Yılmaz");
+  });
+
+  test('strips a "Recommended for you" banner before the author', () => {
+    expect(
+      parseHomeFeedAuthor(
+        "Feed post Recommended for you Rich Nicholls, MBA • 3rd+ Director of Operations & Compliance 1d • Follow"
+      )
+    ).toBe("Rich Nicholls, MBA");
+  });
+
+  test("takes the author after stacked social-context banners", () => {
+    expect(
+      parseHomeFeedAuthor(
+        "Feed post Alice likes this Bob reposted this Carol 5h • Follow"
+      )
+    ).toBe("Carol");
+  });
+
+  test('recovers the author from an expanded-post "Author" badge row without a degree marker', () => {
+    expect(
+      parseHomeFeedAuthor(
+        "Daniel Kravtsov Author CEO, Improvado | Building the Agentic Marketing OS | A revenue ecosystem"
+      )
+    ).toBe("Daniel Kravtsov");
+    expect(parseHomeFeedAuthor("Q Author Founder and CEO")).toBe("Q");
+  });
+
+  test('keeps only the leading name on a "Premium Profile" badge row', () => {
+    expect(
+      parseHomeFeedAuthor(
+        "Joseph Jacks Premium Profile 1st Joseph Jacks • 1st Autodidact. 2h Epic run at a16z"
+      )
+    ).toBe("Joseph Jacks");
   });
 
   test('returns empty string when no " • " marker is present', () => {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -295,32 +295,56 @@ const HOME_FEED_SCRAPE_CONFIG = {
 } as const;
 
 /**
- * Best-effort author extraction from a home-feed row's body text. The home
- * feed DOM obfuscates the actor classes, so the selector often misses and the
- * only reliable place the author name appears is the row's body text. This is
- * inherently heuristic — the feed can't use network capture, so there is no
- * structured author field to read.
+ * Best-effort author extraction from a home-feed row's body text. Social
+ * context such as "X likes this" appears before the post author, and stacked
+ * context can contain more than one banner. The author follows the last one.
  */
-export function parseHomeFeedAuthor(body: string): string {
-  if (!body) return "";
-  let text = body.replace(/^feed post\s+/i, "").trim();
+const HOME_FEED_SOCIAL_CONTEXT_RE =
+  /\b(?:(?:likes?|loves?|celebrates?|supports?) this|finds? this (?:insightful|funny)|commented(?: on this)?|reposted this|recommended for you)\s*/gi;
 
-  // A repost surfaces the resharer first, then "reposted this", then the
-  // original poster whose content this actually is — take the original poster.
-  const repostIdx = text.toLowerCase().indexOf("reposted this");
-  if (repostIdx !== -1) {
-    text = text.slice(repostIdx + "reposted this".length).trim();
+function parseHomeFeedAuthorDetails(body: string): {
+  author: string;
+  hasSocialContext: boolean;
+} {
+  if (!body) return { author: "", hasSocialContext: false };
+  const text = body.replace(/^feed post\s+/i, "").trim();
+
+  // Limit banner matching to the row header so post content cannot be mistaken
+  // for social context.
+  const sepIdx = text.indexOf(" • ");
+  let header = (sepIdx === -1 ? text : text.slice(0, sepIdx)).trim();
+
+  let lastBannerEnd = -1;
+  for (const match of header.matchAll(HOME_FEED_SOCIAL_CONTEXT_RE)) {
+    lastBannerEnd = match.index + match[0].length;
+  }
+  const hasSocialContext = lastBannerEnd !== -1;
+  if (hasSocialContext) header = header.slice(lastBannerEnd).trim();
+
+  if (sepIdx === -1) {
+    // Expanded-post cards can use "<Name> Author <headline>" without a degree
+    // marker; "Author" is LinkedIn's literal badge text.
+    const badge = header.match(/^(.{1,60}?)\s+Author\b/);
+    return {
+      author: badge ? badge[1].trim() : "",
+      hasSocialContext,
+    };
   }
 
-  // The author is the leading name before the " • " connection-degree marker.
-  const sepIdx = text.indexOf(" • ");
-  if (sepIdx === -1) return "";
-  let name = text.slice(0, sepIdx).trim();
+  let name = header;
+  // A "<Name> Premium Profile <degree> <Name>" badge row repeats the name —
+  // keep only the leading one.
+  const premiumIdx = name.indexOf(" Premium Profile");
+  if (premiumIdx !== -1) name = name.slice(0, premiumIdx);
   // A repost segment puts a relative-time token (e.g. "17h") right after the
   // original poster's name and before the marker — strip it so we keep just
   // the name.
   name = name.replace(/\s+\d+\s*[smhdwy]o?$/i, "").trim();
-  return name.slice(0, 60);
+  return { author: name.slice(0, 60), hasSocialContext };
+}
+
+export function parseHomeFeedAuthor(body: string): string {
+  return parseHomeFeedAuthorDetails(body).author;
 }
 
 /**
@@ -352,12 +376,15 @@ export function buildHomeFeedEvents(
     if (!row?.id || !row.body || seen.has(row.id)) continue;
     if (isHomeFeedNoise(row.body)) continue;
     seen.add(row.id);
-    // The DOM actor span often includes the connection-degree marker
-    // ("Julien Hurault • 1st"); strip it the same way body-parse does. Fall
-    // back to parsing the name out of the post body when the selector misses.
+    const parsedAuthor = parseHomeFeedAuthorDetails(row.body);
+    const domAuthor = (row.author ?? "").trim().split(" • ")[0].trim();
+    // The first profile link can belong to the reacting member on
+    // social-context cards, so prefer the body author there. Otherwise the DOM
+    // field is more reliable than the heuristic body parser.
     const author =
-      (row.author ?? "").trim().split(" • ")[0].trim() ||
-      parseHomeFeedAuthor(row.body ?? "");
+      (parsedAuthor.hasSocialContext ? parsedAuthor.author : "") ||
+      domAuthor ||
+      parsedAuthor.author;
     events.push({
       origin_id: `li_home_${row.id}`,
       payload_text: row.body,


### PR DESCRIPTION
## Problem

Production `home_feed` syncs emitted polluted `author_name` values:

- `Deb Mukherjee likes this 🦔 james hawkins` — the social-context banner fused into the author (body parser took everything before the first ` • `)
- `Barry McCardel commented Caroline Haynes`, `Recommended for you Rich Nicholls, MBA` — same class
- Expanded-post `<Name> Author <headline>` cards (no degree marker) emitted an **empty** author
- On social-context cards the DOM selector has the inverse bug: the first profile link is the *reacting member*, not the post author

## Fix

- Strip like/love/celebrate/support/finds-this-insightful/funny/commented/reposted/recommended-for-you banners from the row header before taking the author; the author follows the last banner
- Prefer the body-parsed author over the DOM selector when a banner is present (the selector finds the reactor there)
- Recover the author from expanded-post `Author`-badge cards
- Keep only the leading name on `Premium Profile` badge rows

## Evidence

Red→green: 7 regression tests using real bodies captured from a production sync of connection `linkedin-buremba` all failed on the old parser, pass now. Full personal-agent suite: 112/112. `make pre-pr` clean, `make review`: bug_free 93, 0 bugs, 0 blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LinkedIn home-feed author detection when posts include social-context banners such as likes, comments, reposts, or recommendations.
  - Ensured feed events correctly identify the reacting member when applicable.
  - Improved handling of stacked social-context labels while preserving the original author when no banner is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->