### PR TITLE
feat(examples): mint author and engager people from LinkedIn home-feed cards

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -181,7 +181,12 @@ describe("buildHomeFeedEvents", () => {
       new Date()
     );
     expect(ev.author_name).toBe("🦔 james hawkins");
-    expect(ev.metadata).toEqual({ author: "🦔 james hawkins" });
+    // No profile href on this row → engagement is named but not identified.
+    expect(ev.metadata).toEqual({
+      author: "🦔 james hawkins",
+      social_actor: "Deb Mukherjee",
+      social_action: "like",
+    });
   });
 
   test("strips the connection-degree marker from a DOM-selector author", () => {
@@ -212,6 +217,186 @@ describe("buildHomeFeedEvents", () => {
     );
     expect(ev.author_name).toBe("Hugo Lu");
     expect(ev.metadata).toEqual({ author: "Hugo Lu" });
+  });
+
+  test("attributes the profile href to the author on a plain card", () => {
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post Maria Malykh • 1st Founder & CTO | Automating R&D Tax 3h • I'm not an early planner",
+          profile_href:
+            "https://www.linkedin.com/in/maria-malykh-ilyina/?miniProfileUrn=abc",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.author_name).toBe("Maria Malykh");
+    expect(ev.metadata).toEqual({
+      author: "Maria Malykh",
+      author_linkedin_slug: "maria-malykh-ilyina",
+      author_profile_url: "https://www.linkedin.com/in/maria-malykh-ilyina",
+    });
+  });
+
+  test("attributes the profile href to the engager on a social-context card", () => {
+    // DOM order on engagement cards: the reacting member's link comes first,
+    // so the single captured href belongs to them — never to the author.
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post Deb Mukherjee likes this Adam Robinson • 2nd CEO @ MoltSets 8h • Connect unlimited contact data",
+          profile_href: "https://www.linkedin.com/in/debgotwired/",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.author_name).toBe("Adam Robinson");
+    expect(ev.metadata).toEqual({
+      author: "Adam Robinson",
+      social_actor: "Deb Mukherjee",
+      social_action: "like",
+      social_actor_slug: "debgotwired",
+      social_actor_profile_url: "https://www.linkedin.com/in/debgotwired",
+    });
+  });
+
+  test("preserves a comma suffix in the engager's display name", () => {
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post John Smith, MBA likes this Alice Jones • 2nd Founder 2h • Follow",
+          author: "John Smith, MBA",
+          profile_href: "https://www.linkedin.com/in/john-smith/",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.metadata).toMatchObject({
+      author: "Alice Jones",
+      social_actor: "John Smith, MBA",
+      social_actor_slug: "john-smith",
+    });
+  });
+
+  test("does not treat an action phrase in the DOM author's name as a banner", () => {
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post We Love This Company • 2nd Community 2h • Follow",
+          author: "We Love This Company",
+          profile_href: "https://www.linkedin.com/in/we-love-this-company/",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.author_name).toBe("We Love This Company");
+    expect(ev.metadata).toEqual({
+      author: "We Love This Company",
+      author_linkedin_slug: "we-love-this-company",
+      author_profile_url: "https://www.linkedin.com/in/we-love-this-company",
+    });
+  });
+
+  test("captures comment and repost engagement actions", () => {
+    const events = buildHomeFeedEvents(
+      [
+        {
+          id: "c",
+          body: "Feed post Barry McCardel commented Caroline Haynes • 2nd GTM at Hex 20h • Follow After an incredible year",
+          profile_href: "https://www.linkedin.com/in/barrymccardel/",
+        },
+        {
+          id: "r",
+          body: "Feed post Sabri Karagönen reposted this Hardal 17h • Follow Hardal is now integrated with Bruin",
+          profile_href: "https://www.linkedin.com/in/sabrikaragonen/",
+        },
+      ],
+      new Date()
+    );
+    expect(events[0].metadata).toMatchObject({
+      author: "Caroline Haynes",
+      social_actor: "Barry McCardel",
+      social_action: "comment",
+      social_actor_slug: "barrymccardel",
+    });
+    expect(events[1].metadata).toMatchObject({
+      author: "Hardal",
+      social_actor: "Sabri Karagönen",
+      social_action: "repost",
+      social_actor_slug: "sabrikaragonen",
+    });
+  });
+
+  test('keeps only the first engager name on an "and N others" banner', () => {
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post Ali Veli and 3 others like this Ayşe Yılmaz • 2nd Data engineer 4h • Connect",
+          profile_href: "https://www.linkedin.com/in/aliveli/",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.metadata).toMatchObject({
+      author: "Ayşe Yılmaz",
+      social_actor: "Ali Veli",
+      social_action: "like",
+      social_actor_slug: "aliveli",
+    });
+  });
+
+  test("attributes the href to the author on an actor-less banner card", () => {
+    // "Voices worth following" / "Recommended for you" have no engager link,
+    // so the first profile link is the author's.
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post Voices worth following Elizabeth Reid • 2nd VP, Search 13h • Follow Bonjour France!",
+          profile_href: "https://www.linkedin.com/in/elizabeth-reid-56356724/",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.author_name).toBe("Elizabeth Reid");
+    expect(ev.metadata).toEqual({
+      author: "Elizabeth Reid",
+      author_linkedin_slug: "elizabeth-reid-56356724",
+      author_profile_url: "https://www.linkedin.com/in/elizabeth-reid-56356724",
+    });
+  });
+
+  test("emits no slug fields when the row has no profile href", () => {
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post Hugo Lu • 1st Founder at Orchestra 4h • Yesterday Snowflake popped",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.metadata).toEqual({ author: "Hugo Lu" });
+  });
+
+  test("does not attribute a later person link to a company author", () => {
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post Acme Corp • 3rd+ Company update with a tagged member",
+          author: "Acme Corp",
+          profile_href: "https://www.linkedin.com/company/acme/",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.metadata).toEqual({ author: "Acme Corp" });
   });
 
   test("drops rows without id or body and dedupes by id", () => {
@@ -355,6 +540,14 @@ describe("parseHomeFeedAuthor", () => {
     ).toBe("Carol");
   });
 
+  test('strips a "Voices worth following" banner before the author', () => {
+    expect(
+      parseHomeFeedAuthor(
+        "Feed post Voices worth following Elizabeth Reid • 2nd VP, Search 13h • Follow Bonjour France!"
+      )
+    ).toBe("Elizabeth Reid");
+  });
+
   test('recovers the author from an expanded-post "Author" badge row without a degree marker', () => {
     expect(
       parseHomeFeedAuthor(
@@ -362,6 +555,11 @@ describe("parseHomeFeedAuthor", () => {
       )
     ).toBe("Daniel Kravtsov");
     expect(parseHomeFeedAuthor("Q Author Founder and CEO")).toBe("Q");
+    expect(
+      parseHomeFeedAuthor(
+        "Daniel Kravtsov Author CEO who likes this approach to marketing"
+      )
+    ).toBe("Daniel Kravtsov");
   });
 
   test('keeps only the leading name on a "Premium Profile" badge row', () => {
@@ -426,6 +624,47 @@ describe("LinkedInConnector home_feed", () => {
     expect(def.feeds.home_feed.configSchema.required).toBeUndefined();
   });
 
+  test("declares the slug/engagement fields on the post metadata schema", () => {
+    const def = new LinkedInConnector().definition;
+    const props = def.feeds.home_feed.eventKinds.post.metadataSchema.properties;
+    expect(props.author_linkedin_slug).toBeDefined();
+    expect(props.social_actor).toBeDefined();
+    expect(props.social_action).toBeDefined();
+    expect(props.social_actor_slug).toBeDefined();
+  });
+
+  test("declares author and engager attributions keyed on linkedin_slug", () => {
+    const def = new LinkedInConnector().definition;
+    const attributions = def.feeds.home_feed.eventKinds.post.attributions ?? [];
+    const authoredBy = attributions.find(
+      (rule: { role: string }) => rule.role === "authored_by"
+    );
+    const mentions = attributions.find(
+      (rule: { role: string }) => rule.role === "mentions"
+    );
+
+    expect(authoredBy).toBeDefined();
+    expect(authoredBy.autoCreate).toBe(true);
+    expect(authoredBy.target.entityType).toBe("person");
+    expect(authoredBy.target.identities).toEqual([
+      {
+        namespace: LINKEDIN_IDENTITY.SLUG,
+        eventPath: "metadata.author_linkedin_slug",
+      },
+    ]);
+
+    expect(mentions).toBeDefined();
+    expect(mentions.autoCreate).toBe(true);
+    expect(mentions.target.entityType).toBe("person");
+    expect(mentions.target.titlePath).toBe("metadata.social_actor");
+    expect(mentions.target.identities).toEqual([
+      {
+        namespace: LINKEDIN_IDENTITY.SLUG,
+        eventPath: "metadata.social_actor_slug",
+      },
+    ]);
+  });
+
   test("syncHomeFeed dispatches cs_scrape and maps rows to events", async () => {
     const calls: Array<{ action: string; input: Record<string, unknown> }> = [];
     const dispatcher = {
@@ -472,6 +711,13 @@ describe("LinkedInConnector home_feed", () => {
     expect(
       (calls[0].input.scrape_config as { scroll: { max: number } }).scroll.max
     ).toBe(4);
+    expect(
+      (
+        calls[0].input.scrape_config as {
+          fields: { profile_href: { selector: string } };
+        }
+      ).fields.profile_href.selector
+    ).toContain("/company/");
 
     expect(res.events).toHaveLength(2);
     expect(res.events[0].origin_id).toBe("li_home_tok1");

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -180,12 +180,34 @@ describe("buildHomeFeedEvents", () => {
       ],
       new Date()
     );
-    expect(ev.author_name).toBe("🦔 james hawkins");
+    // Leading emoji decoration on the actor name is stripped for a clean title.
+    expect(ev.author_name).toBe("james hawkins");
     // No profile href on this row → engagement is named but not identified.
     expect(ev.metadata).toEqual({
-      author: "🦔 james hawkins",
+      author: "james hawkins",
       social_actor: "Deb Mukherjee",
       social_action: "like",
+    });
+  });
+
+  test("strips Visit website CTA fused into the author after a repost banner", () => {
+    // Production body: company page CTA text sits next to the original author.
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post Emir Karabeg reposted this Sim Visit website 2h • Follow Sim Retreat Malibu ‘26 11 2 2",
+          profile_href: "https://www.linkedin.com/in/emirkarabeg/",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.author_name).toBe("Sim");
+    expect(ev.metadata).toMatchObject({
+      author: "Sim",
+      social_actor: "Emir Karabeg",
+      social_action: "repost",
+      social_actor_slug: "emirkarabeg",
     });
   });
 
@@ -487,7 +509,7 @@ describe("parseHomeFeedAuthor", () => {
       parseHomeFeedAuthor(
         "Feed post Deb Mukherjee likes this 🦔 james hawkins • 2nd self driving software and co-ceo at posthog 8h • Connect this is what happens"
       )
-    ).toBe("🦔 james hawkins");
+    ).toBe("james hawkins");
     expect(
       parseHomeFeedAuthor(
         "Feed post Onur Demirtaş likes this Erkan Ayan • 2nd erkanayan.net 8h • Connect 📍 something"
@@ -605,6 +627,20 @@ describe("isHomeFeedNoise", () => {
   test("drops suggested rows", () => {
     expect(
       isHomeFeedNoise("Feed post Suggested Matt Graham • 2nd CEO @ RapidDev")
+    ).toBe(true);
+  });
+
+  test("drops LinkedIn ad / boost promos without a real member header", () => {
+    // Production empties: no " • " degree marker, no Author badge — pure promo.
+    expect(
+      isHomeFeedNoise(
+        "Feed post Get more leads with boosting Boost your best content on LinkedIn to get more quality leads Learn more"
+      )
+    ).toBe(true);
+    expect(
+      isHomeFeedNoise(
+        "Feed post Try LinkedIn Ads Build your brand and drive quality leads. Spend €200 to get an extra"
+      )
     ).toBe(true);
   });
 

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -211,6 +211,30 @@ describe("buildHomeFeedEvents", () => {
     });
   });
 
+  test("matches emoji-prefixed DOM engager to banner actor (keeps engagement attribution)", () => {
+    // DOM text often keeps the leading emoji; banner parse strips it. Without
+    // normalizing both sides, the banner is discarded and the engager is
+    // mis-emitted as the post author with their slug.
+    const [ev] = buildHomeFeedEvents(
+      [
+        {
+          id: "tok",
+          body: "Feed post Deb Mukherjee likes this 🦔 james hawkins • 2nd self driving 8h • Connect",
+          author: "🦔 Deb Mukherjee",
+          profile_href: "https://www.linkedin.com/in/debgotwired/",
+        },
+      ],
+      new Date()
+    );
+    expect(ev.author_name).toBe("james hawkins");
+    expect(ev.metadata).toMatchObject({
+      author: "james hawkins",
+      social_actor: "Deb Mukherjee",
+      social_action: "like",
+      social_actor_slug: "debgotwired",
+    });
+  });
+
   test("strips the connection-degree marker from a DOM-selector author", () => {
     const [ev] = buildHomeFeedEvents(
       [
@@ -642,6 +666,14 @@ describe("isHomeFeedNoise", () => {
         "Feed post Try LinkedIn Ads Build your brand and drive quality leads. Spend €200 to get an extra"
       )
     ).toBe(true);
+  });
+
+  test("keeps a member post that discusses LinkedIn Ads in the body", () => {
+    expect(
+      isHomeFeedNoise(
+        "Feed post Jane Doe • 1st Growth lead 2h • Follow Why Try LinkedIn Ads still works for B2B pipelines"
+      )
+    ).toBe(false);
   });
 
   test("keeps a normal post", () => {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -810,7 +810,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files.",
-    version: "3.0.0",
+    version: "3.1.0",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -384,6 +384,26 @@ type HomeFeedBanner =
   | { kind: "actor"; actor: string; action: string }
   | { kind: "actorless" };
 
+/** Strip relative-time tokens, fused CTAs, and leading emoji from a name. */
+function cleanHomeFeedDisplayName(raw: string): string {
+  let name = raw.trim();
+  // A repost segment puts a relative-time token (e.g. "17h") right after the
+  // original poster's name and before the marker — strip it so we keep just
+  // the name.
+  name = name.replace(/\s+\d+\s*[smhdwy]o?$/i, "").trim();
+  // Feed cards sometimes fuse UI chrome into the name after a repost /
+  // company author: "Sim Visit website", "Acme View job".
+  name = name
+    .replace(
+      /\s+(?:Visit website|View (?:job|page|profile)|Apply now|Register now|Sign up)$/i,
+      ""
+    )
+    .trim();
+  // Leading emoji / symbol decorations on display names (e.g. "🦔 james").
+  name = name.replace(/^[^\p{L}\p{N}]+/u, "").trim();
+  return name.slice(0, 60);
+}
+
 function parseHomeFeedAuthorDetails(body: string): {
   author: string;
   banner: HomeFeedBanner | null;
@@ -399,7 +419,10 @@ function parseHomeFeedAuthorDetails(body: string): {
     // marker. Resolve that bounded prefix before scanning for banner phrases
     // so words in the post content cannot affect attribution.
     const badge = text.match(/^(.{1,60}?)\s+Author\b/);
-    return { author: badge ? badge[1].trim() : "", banner: null };
+    return {
+      author: badge ? cleanHomeFeedDisplayName(badge[1]) : "",
+      banner: null,
+    };
   }
   let header = text.slice(0, sepIdx).trim();
 
@@ -418,9 +441,9 @@ function parseHomeFeedAuthorDetails(body: string): {
     const pluralActors = actorGroup.match(/^(.*?)\s+and\s+\d+\s+others?$/i);
     // "A and 3 others" / "A, B and 22 others" use A's profile link. Preserve
     // commas in a single member's display name (for example, "A, MBA").
-    const actor = (
+    const actor = cleanHomeFeedDisplayName(
       pluralActors ? pluralActors[1].split(",")[0] : actorGroup
-    ).trim();
+    );
     banner = {
       kind: "actor",
       actor: actor.slice(0, 60),
@@ -434,11 +457,7 @@ function parseHomeFeedAuthorDetails(body: string): {
   // keep only the leading one.
   const premiumIdx = name.indexOf(" Premium Profile");
   if (premiumIdx !== -1) name = name.slice(0, premiumIdx);
-  // A repost segment puts a relative-time token (e.g. "17h") right after the
-  // original poster's name and before the marker — strip it so we keep just
-  // the name.
-  name = name.replace(/\s+\d+\s*[smhdwy]o?$/i, "").trim();
-  return { author: name.slice(0, 60), banner };
+  return { author: cleanHomeFeedDisplayName(name), banner };
 }
 
 export function parseHomeFeedAuthor(body: string): string {
@@ -455,6 +474,11 @@ export function isHomeFeedNoise(body: string): boolean {
   if (!body || body.trim().length < 30) return true;
   if (/\bPromoted\b/i.test(body.slice(0, 130))) return true;
   if (/\bSuggested\b/i.test(body.slice(0, 30))) return true;
+  // Platform self-promo cards (no real member header). Bodies from production
+  // syncs: "Get more leads with boosting…", "Try LinkedIn Ads…".
+  if (/\b(?:Try )?LinkedIn Ads\b/i.test(body)) return true;
+  if (/\bGet more leads with boosting\b/i.test(body)) return true;
+  if (/\bBoost your best content on LinkedIn\b/i.test(body)) return true;
   return false;
 }
 
@@ -810,7 +834,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files.",
-    version: "3.1.0",
+    version: "3.1.1",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -240,6 +240,54 @@ const LINKEDIN_POST_AUTHOR_ATTRIBUTIONS: EventAttributionRule[] = [
   },
 ];
 
+/**
+ * Attribute only people whose `linkedin_slug` came from the row's first
+ * profile link. The engine skips rules with no resolved identity, so an
+ * engagement card cannot create a name-only entity for its unlinked author.
+ */
+const LINKEDIN_HOME_FEED_ATTRIBUTIONS: EventAttributionRule[] = [
+  {
+    role: "authored_by",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      titlePath: "author_name",
+      identities: [
+        {
+          namespace: LINKEDIN_IDENTITY.SLUG,
+          eventPath: "metadata.author_linkedin_slug",
+        },
+      ],
+    },
+    traits: {
+      linkedin_url: {
+        eventPath: "metadata.author_profile_url",
+        behavior: "prefer_non_empty",
+      },
+    },
+  },
+  {
+    role: "mentions",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      titlePath: "metadata.social_actor",
+      identities: [
+        {
+          namespace: LINKEDIN_IDENTITY.SLUG,
+          eventPath: "metadata.social_actor_slug",
+        },
+      ],
+    },
+    traits: {
+      linkedin_url: {
+        eventPath: "metadata.social_actor_profile_url",
+        behavior: "prefer_non_empty",
+      },
+    },
+  },
+];
+
 // ── Home-feed content-script scrape contract ────────────────────
 //
 // The personalized home feed (linkedin.com/feed/) is the ONE feed that can't
@@ -255,6 +303,11 @@ interface HomeFeedRow {
   id?: string;
   body?: string;
   author?: string;
+  /**
+   * Href of the first profile or company link in the row. On engagement cards
+   * that is the reacting member's link; otherwise it is the author's link.
+   */
+  profile_href?: string;
 }
 
 /** LinkedIn origins the cs_scrape window is allowed to touch. */
@@ -291,44 +344,89 @@ const HOME_FEED_SCRAPE_CONFIG = {
       take: "text",
       firstLine: true,
     },
+    profile_href: {
+      // Include company authors so a later person mention cannot be mistaken
+      // for the author. normalizeLinkedInSlug rejects company URLs.
+      selector: 'a[href*="/in/"], a[href*="/company/"]',
+      take: "attr",
+      attr: "href",
+    },
   },
 } as const;
 
 /**
  * Best-effort author extraction from a home-feed row's body text. Social
- * context such as "X likes this" appears before the post author, and stacked
- * context can contain more than one banner. The author follows the last one.
+ * context appears before the post author in two shapes: actor banners name an
+ * engaging member ("X likes this", "X commented", "X reposted this") and
+ * actor-less banners are platform labels with no member ("Recommended for
+ * you", "Voices worth following"). Stacked context can contain more than one
+ * actor banner; the author follows the last one.
  */
-const HOME_FEED_SOCIAL_CONTEXT_RE =
-  /\b(?:(?:likes?|loves?|celebrates?|supports?) this|finds? this (?:insightful|funny)|commented(?: on this)?|reposted this|recommended for you)\s*/gi;
+const HOME_FEED_ACTOR_BANNER_RE =
+  /\b(?:(?:likes?|loves?|celebrates?|supports?) this|finds? this (?:insightful|funny)|commented(?: on this)?|reposted this)\s*/gi;
+const HOME_FEED_ACTORLESS_BANNER_RE =
+  /^(?:recommended for you|voices worth following)\s+/i;
+
+/** Normalize a matched actor-banner to a stable engagement verb. */
+function normalizeSocialAction(banner: string): string {
+  const b = banner.toLowerCase();
+  if (b.includes("comment")) return "comment";
+  if (b.includes("repost")) return "repost";
+  if (b.includes("insightful")) return "insightful";
+  if (b.includes("funny")) return "funny";
+  if (b.includes("love")) return "love";
+  if (b.includes("celebrate")) return "celebrate";
+  if (b.includes("support")) return "support";
+  return "like";
+}
+
+type HomeFeedBanner =
+  | { kind: "actor"; actor: string; action: string }
+  | { kind: "actorless" };
 
 function parseHomeFeedAuthorDetails(body: string): {
   author: string;
-  hasSocialContext: boolean;
+  banner: HomeFeedBanner | null;
 } {
-  if (!body) return { author: "", hasSocialContext: false };
+  if (!body) return { author: "", banner: null };
   const text = body.replace(/^feed post\s+/i, "").trim();
 
   // Limit banner matching to the row header so post content cannot be mistaken
   // for social context.
   const sepIdx = text.indexOf(" • ");
-  let header = (sepIdx === -1 ? text : text.slice(0, sepIdx)).trim();
-
-  let lastBannerEnd = -1;
-  for (const match of header.matchAll(HOME_FEED_SOCIAL_CONTEXT_RE)) {
-    lastBannerEnd = match.index + match[0].length;
-  }
-  const hasSocialContext = lastBannerEnd !== -1;
-  if (hasSocialContext) header = header.slice(lastBannerEnd).trim();
-
   if (sepIdx === -1) {
     // Expanded-post cards can use "<Name> Author <headline>" without a degree
-    // marker; "Author" is LinkedIn's literal badge text.
-    const badge = header.match(/^(.{1,60}?)\s+Author\b/);
-    return {
-      author: badge ? badge[1].trim() : "",
-      hasSocialContext,
+    // marker. Resolve that bounded prefix before scanning for banner phrases
+    // so words in the post content cannot affect attribution.
+    const badge = text.match(/^(.{1,60}?)\s+Author\b/);
+    return { author: badge ? badge[1].trim() : "", banner: null };
+  }
+  let header = text.slice(0, sepIdx).trim();
+
+  let banner: HomeFeedBanner | null = null;
+  const actorless = header.match(HOME_FEED_ACTORLESS_BANNER_RE);
+  if (actorless) {
+    header = header.slice(actorless[0].length).trim();
+    banner = { kind: "actorless" };
+  }
+
+  const matches = [...header.matchAll(HOME_FEED_ACTOR_BANNER_RE)];
+  if (matches.length > 0) {
+    const first = matches[0];
+    const last = matches[matches.length - 1];
+    const actorGroup = header.slice(0, first.index).trim();
+    const pluralActors = actorGroup.match(/^(.*?)\s+and\s+\d+\s+others?$/i);
+    // "A and 3 others" / "A, B and 22 others" use A's profile link. Preserve
+    // commas in a single member's display name (for example, "A, MBA").
+    const actor = (
+      pluralActors ? pluralActors[1].split(",")[0] : actorGroup
+    ).trim();
+    banner = {
+      kind: "actor",
+      actor: actor.slice(0, 60),
+      action: normalizeSocialAction(first[0]),
     };
+    header = header.slice(last.index + last[0].length).trim();
   }
 
   let name = header;
@@ -340,7 +438,7 @@ function parseHomeFeedAuthorDetails(body: string): {
   // original poster's name and before the marker — strip it so we keep just
   // the name.
   name = name.replace(/\s+\d+\s*[smhdwy]o?$/i, "").trim();
-  return { author: name.slice(0, 60), hasSocialContext };
+  return { author: name.slice(0, 60), banner };
 }
 
 export function parseHomeFeedAuthor(body: string): string {
@@ -378,13 +476,42 @@ export function buildHomeFeedEvents(
     seen.add(row.id);
     const parsedAuthor = parseHomeFeedAuthorDetails(row.body);
     const domAuthor = (row.author ?? "").trim().split(" • ")[0].trim();
+    const actorBanner =
+      parsedAuthor.banner?.kind === "actor" ? parsedAuthor.banner : null;
+    // If the DOM supplied a different member name, the body phrase was part of
+    // a plain author's name rather than a social-context banner.
+    const banner =
+      actorBanner &&
+      domAuthor &&
+      actorBanner.actor.localeCompare(domAuthor, undefined, {
+        sensitivity: "accent",
+      }) !== 0
+        ? null
+        : parsedAuthor.banner;
     // The first profile link can belong to the reacting member on
     // social-context cards, so prefer the body author there. Otherwise the DOM
     // field is more reliable than the heuristic body parser.
     const author =
-      (parsedAuthor.hasSocialContext ? parsedAuthor.author : "") ||
-      domAuthor ||
-      parsedAuthor.author;
+      (banner ? parsedAuthor.author : "") || domAuthor || parsedAuthor.author;
+
+    // The row's single captured profile href belongs to the engager on actor
+    // banners and to the author everywhere else (see HomeFeedRow.profile_href).
+    const slug = normalizeLinkedInSlug(row.profile_href);
+    const profileUrl = slug ? `https://www.linkedin.com/in/${slug}` : undefined;
+    const engagement = banner?.kind === "actor" ? banner : null;
+    const metadata: Record<string, unknown> = { author };
+    if (engagement) {
+      metadata.social_actor = engagement.actor;
+      metadata.social_action = engagement.action;
+      if (slug) {
+        metadata.social_actor_slug = slug;
+        metadata.social_actor_profile_url = profileUrl;
+      }
+    } else if (slug) {
+      metadata.author_linkedin_slug = slug;
+      metadata.author_profile_url = profileUrl;
+    }
+
     events.push({
       origin_id: `li_home_${row.id}`,
       payload_text: row.body,
@@ -395,7 +522,7 @@ export function buildHomeFeedEvents(
       // Token id is NOT a numeric activity id, so we cannot build a
       // urn:li:activity permalink — link to the feed itself.
       source_url: "https://www.linkedin.com/feed/",
-      metadata: { author },
+      metadata,
     });
   }
   return events;
@@ -712,10 +839,25 @@ export default class LinkedInConnector extends ConnectorRuntime<
         eventKinds: {
           post: {
             description: "A post from your personalized LinkedIn home feed",
+            attributions: LINKEDIN_HOME_FEED_ATTRIBUTIONS,
             metadataSchema: {
               type: "object",
               properties: {
                 author: { type: "string" },
+                author_linkedin_slug: { type: "string" },
+                author_profile_url: { type: "string" },
+                social_actor: {
+                  type: "string",
+                  description:
+                    "Member whose engagement surfaced this post (likes/commented/reposted banners).",
+                },
+                social_action: {
+                  type: "string",
+                  description:
+                    "Engagement verb: like, love, celebrate, support, insightful, funny, comment, repost.",
+                },
+                social_actor_slug: { type: "string" },
+                social_actor_profile_url: { type: "string" },
               },
             },
           },

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -474,11 +474,16 @@ export function isHomeFeedNoise(body: string): boolean {
   if (!body || body.trim().length < 30) return true;
   if (/\bPromoted\b/i.test(body.slice(0, 130))) return true;
   if (/\bSuggested\b/i.test(body.slice(0, 30))) return true;
-  // Platform self-promo cards (no real member header). Bodies from production
-  // syncs: "Get more leads with boosting…", "Try LinkedIn Ads…".
-  if (/\b(?:Try )?LinkedIn Ads\b/i.test(body)) return true;
-  if (/\bGet more leads with boosting\b/i.test(body)) return true;
-  if (/\bBoost your best content on LinkedIn\b/i.test(body)) return true;
+  // Platform self-promo cards only when there is no real member header
+  // (no connection-degree " • " and no expanded "Author" badge). A genuine
+  // post that *discusses* LinkedIn Ads must not be dropped.
+  const text = body.replace(/^feed post\s+/i, "").trim();
+  const hasMemberHeader = text.includes(" • ") || /^\S.+\s+Author\b/.test(text);
+  if (!hasMemberHeader) {
+    if (/\b(?:Try )?LinkedIn Ads\b/i.test(body)) return true;
+    if (/\bGet more leads with boosting\b/i.test(body)) return true;
+    if (/\bBoost your best content on LinkedIn\b/i.test(body)) return true;
+  }
   return false;
 }
 
@@ -499,7 +504,11 @@ export function buildHomeFeedEvents(
     if (isHomeFeedNoise(row.body)) continue;
     seen.add(row.id);
     const parsedAuthor = parseHomeFeedAuthorDetails(row.body);
-    const domAuthor = (row.author ?? "").trim().split(" • ")[0].trim();
+    // Clean DOM author the same way as banner actors so emoji-prefixed names
+    // still match (e.g. DOM "🦔 Deb" vs banner actor "Deb").
+    const domAuthor = cleanHomeFeedDisplayName(
+      (row.author ?? "").trim().split(" • ")[0] ?? ""
+    );
     const actorBanner =
       parsedAuthor.banner?.kind === "actor" ? parsedAuthor.banner : null;
     // If the DOM supplied a different member name, the body phrase was part of
@@ -834,7 +843,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files.",
-    version: "3.1.1",
+    version: "3.1.2",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com


### PR DESCRIPTION
## Summary

Stacked on #2122. Home-feed cards now mint real `person` entities (with LinkedIn slug identity) for authors and engagers, instead of only storing noisy author names on events.

## What changed

- Capture the row's first profile link `href` in the `cs_scrape` config (`profile_href`).
- Route that href by card shape:
  - plain / actor-less banners ("Recommended for you", "Voices worth following") → author slug
  - engagement banners ("X likes this" / commented / reposted) → engager slug + `social_actor` / `social_action`
- `home_feed` events get `authored_by` + `mentions` attribution rules keyed **only** on `linkedin_slug`. Rules with empty identity are skipped — no name-only ghost people.
- Minted people dedupe with takeout connections/messages on the shared `linkedin_slug`.

## Gaps still open (called out, not in this PR)

- On engagement cards the **post author** slug is still out of reach (first profile link is the engager). Author is name-only metadata until we scrape a second link.
- No graph edges like "engaged_with" yet — only `authored_by` / `mentions` event attributions.
- Existing polluted `author_name` events need a supersede backfill after #2122 merges.

## Test plan

- [x] Red→green unit tests against real production card bodies (121+ personal-agent tests)
- [x] `make pre-pr` clean
- [x] `make review` verdict: bug_free 88, 0 bugs, 0 blockers
- [ ] After merge: re-apply connector to `buremba`, fresh `home_feed` sync, confirm new people mint with slugs and dedupe against takeout connections

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->