### PR TITLE
feat(server): allowlist entity_relationships for sandbox/query_sql

### DIFF
--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, inject, it } from 'vitest';
+import { validateAndScopeQuery } from '../execute-data-sources';
 import {
   buildColumnList,
   QUERYABLE_SCHEMA,
@@ -104,27 +105,30 @@ describe('validateTableQuery', () => {
     const result = validateTableQuery('SELECT email FROM "user"');
     expect(result.valid).toBe(false);
   });
+});
 
-  it('should accept graph queries over entity_relationships', () => {
-    // The canonical mutual-connections / anti-join shapes that reactions,
-    // query_sql, and drain Behaviors need. The scoping CTE branches for these
-    // tables have existed in buildScopedQuery all along; only the schema
-    // allowlist kept them unreachable.
-    const antiJoin = validateTableQuery(
+describe('validateAndScopeQuery', () => {
+  it('should validate and scope graph queries', () => {
+    const scoped = validateAndScopeQuery(
       `SELECT e.id FROM entities e
        WHERE NOT EXISTS (
          SELECT 1 FROM entity_relationships er
-         WHERE er.from_entity_id = e.id AND er.relationship_type_id = 42)`
+         JOIN entity_relationship_types ert ON ert.id = er.relationship_type_id
+         WHERE er.from_entity_id = e.id AND ert.slug = 'works_at')`,
+      'org_test',
+      { safeColumns: SAFE_COLUMN_DEFS }
     );
-    expect(antiJoin.valid).toBe(true);
 
-    const typedJoin = validateTableQuery(
-      `SELECT er.from_entity_id, er.to_entity_id, ert.slug, er.metadata, er.confidence
-       FROM entity_relationships er
-       JOIN entity_relationship_types ert ON ert.id = er.relationship_type_id
-       WHERE ert.slug = 'works_at'`
+    expect(scoped.tableRefs).toEqual(
+      expect.arrayContaining(['entities', 'entity_relationships', 'entity_relationship_types'])
     );
-    expect(typedJoin.valid).toBe(true);
+    expect(scoped.params).toEqual(['org_test']);
+    expect(scoped.sql).toMatch(
+      /public\.entity_relationships WHERE organization_id = \$1 AND deleted_at IS NULL/
+    );
+    expect(scoped.sql).toMatch(
+      /public\.entity_relationship_types rt LEFT JOIN public\.organization o.*rt\.deleted_at IS NULL.*rt\.organization_id = \$1 OR o\.visibility = 'public'/
+    );
   });
 });
 
@@ -212,5 +216,46 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     expect(missing, `DB columns missing from QUERYABLE_SCHEMA:\n  ${missing.join('\n  ')}`).toEqual(
       []
     );
+  });
+
+  it('should execute graph CTEs with local and public relationship types only', async (ctx) => {
+    const databaseUrl = inject('databaseUrl');
+    if (!databaseUrl) {
+      ctx.skip();
+      return;
+    }
+    process.env.DATABASE_URL = databaseUrl;
+
+    const { getDb } = await import('../../db/client');
+    const sql = getDb();
+    await sql`
+      INSERT INTO organization (id, name, slug, visibility)
+      VALUES
+        ('schema-scope-local', 'Schema Scope Local', 'schema-scope-local', 'private'),
+        ('schema-scope-public', 'Schema Scope Public', 'schema-scope-public', 'public'),
+        ('schema-scope-private', 'Schema Scope Private', 'schema-scope-private', 'private')
+    `;
+    await sql`
+      INSERT INTO entity_relationship_types
+        (organization_id, slug, name, deleted_at)
+      VALUES
+        ('schema-scope-local', 'schema-scope-local', 'Local', NULL),
+        ('schema-scope-public', 'schema-scope-public', 'Public', NULL),
+        ('schema-scope-private', 'schema-scope-private', 'Private', NULL),
+        ('schema-scope-public', 'schema-scope-deleted', 'Deleted', NOW())
+    `;
+
+    const scoped = validateAndScopeQuery(
+      `SELECT ert.slug
+       FROM entity_relationship_types ert
+       LEFT JOIN entity_relationships er ON er.relationship_type_id = ert.id
+       WHERE ert.slug LIKE 'schema-scope-%'
+       ORDER BY ert.slug`,
+      'schema-scope-local',
+      { safeColumns: SAFE_COLUMN_DEFS }
+    );
+    const rows = await sql.unsafe(scoped.sql, scoped.params);
+
+    expect(rows.map((row) => row.slug)).toEqual(['schema-scope-local', 'schema-scope-public']);
   });
 });

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -21,6 +21,8 @@ describe('QUERYABLE_TABLE_NAMES', () => {
       'user',
       'feeds',
       'connector_definitions',
+      'entity_relationships',
+      'entity_relationship_types',
     ];
     for (const t of expected) {
       expect(QUERYABLE_TABLE_NAMES.has(t)).toBe(true);
@@ -101,6 +103,28 @@ describe('validateTableQuery', () => {
   it('should reject queries referencing excluded PII columns', () => {
     const result = validateTableQuery('SELECT email FROM "user"');
     expect(result.valid).toBe(false);
+  });
+
+  it('should accept graph queries over entity_relationships', () => {
+    // The canonical mutual-connections / anti-join shapes that reactions,
+    // query_sql, and drain Behaviors need. The scoping CTE branches for these
+    // tables have existed in buildScopedQuery all along; only the schema
+    // allowlist kept them unreachable.
+    const antiJoin = validateTableQuery(
+      `SELECT e.id FROM entities e
+       WHERE NOT EXISTS (
+         SELECT 1 FROM entity_relationships er
+         WHERE er.from_entity_id = e.id AND er.relationship_type_id = 42)`
+    );
+    expect(antiJoin.valid).toBe(true);
+
+    const typedJoin = validateTableQuery(
+      `SELECT er.from_entity_id, er.to_entity_id, ert.slug, er.metadata, er.confidence
+       FROM entity_relationships er
+       JOIN entity_relationship_types ert ON ert.id = er.relationship_type_id
+       WHERE ert.slug = 'works_at'`
+    );
+    expect(typedJoin.valid).toBe(true);
   });
 });
 

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -692,6 +692,7 @@ export function buildScopedQuery(
         `"${safeName}" AS (SELECT ${sel(table)} FROM public.entity_relationships WHERE organization_id = ${orgP} AND deleted_at IS NULL)`
       );
     } else if (table === 'entity_relationship_types') {
+      // security-allowed: see block comment above the for-loop
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table, 'rt')} FROM public.entity_relationship_types rt ` +
           'LEFT JOIN public.organization o ON o.id = rt.organization_id ' +

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -693,7 +693,9 @@ export function buildScopedQuery(
       );
     } else if (table === 'entity_relationship_types') {
       ctes.push(
-        `"${safeName}" AS (SELECT ${sel(table)} FROM public.entity_relationship_types WHERE organization_id = ${orgP})`
+        `"${safeName}" AS (SELECT ${sel(table, 'rt')} FROM public.entity_relationship_types rt ` +
+          'LEFT JOIN public.organization o ON o.id = rt.organization_id ' +
+          `WHERE rt.deleted_at IS NULL AND (rt.organization_id = ${orgP} OR o.visibility = 'public'))`
       );
     } else {
       // Treat as entity_type slug — uses entities columns

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -688,6 +688,7 @@ export function buildScopedQuery(
         `"${safeName}" AS (SELECT ${sel(table)} FROM public.connector_definitions WHERE organization_id = ${orgP})`
       );
     } else if (table === 'entity_relationships') {
+      // security-allowed: see block comment above the for-loop
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table)} FROM public.entity_relationships WHERE organization_id = ${orgP} AND deleted_at IS NULL)`
       );

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -370,6 +370,48 @@ export const QUERYABLE_SCHEMA = {
         'supports_execute'
       ),
     },
+    // entity_relationships — the graph edge instances. Org-scoped, live rows
+    // only (the CTE filters deleted_at IS NULL). Exposing this is what makes
+    // graph queries (mutual connections, drain anti-joins) expressible from
+    // query_sql / client.query; the scoping CTE existed before this entry did.
+    {
+      name: 'entity_relationships',
+      columns: cols(
+        'id',
+        'organization_id',
+        'from_entity_id',
+        'to_entity_id',
+        'relationship_type_id',
+        'metadata',
+        'confidence',
+        'source',
+        'created_by',
+        'updated_by',
+        'deleted_at',
+        'created_at',
+        'updated_at'
+      ),
+    },
+    // entity_relationship_types — needed alongside the edges to filter by slug.
+    {
+      name: 'entity_relationship_types',
+      columns: cols(
+        'id',
+        'slug',
+        'name',
+        'description',
+        'organization_id',
+        'created_by',
+        'metadata_schema',
+        'is_symmetric',
+        'inverse_type_id',
+        'status',
+        'deleted_at',
+        'created_at',
+        'updated_at',
+        'metadata'
+      ),
+    },
   ],
 };
 

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -370,10 +370,7 @@ export const QUERYABLE_SCHEMA = {
         'supports_execute'
       ),
     },
-    // entity_relationships — the graph edge instances. Org-scoped, live rows
-    // only (the CTE filters deleted_at IS NULL). Exposing this is what makes
-    // graph queries (mutual connections, drain anti-joins) expressible from
-    // query_sql / client.query; the scoping CTE existed before this entry did.
+    // entity_relationships — org-scoped, live graph edges.
     {
       name: 'entity_relationships',
       columns: cols(
@@ -392,7 +389,7 @@ export const QUERYABLE_SCHEMA = {
         'updated_at'
       ),
     },
-    // entity_relationship_types — needed alongside the edges to filter by slug.
+    // entity_relationship_types — local and public-catalog edge definitions.
     {
       name: 'entity_relationship_types',
       columns: cols(


### PR DESCRIPTION
## Summary

Expose `entity_relationships` and `entity_relationship_types` in the sandbox/`query_sql` allowlist so graph queries (mutual connections, typed joins like `works_at`, drain anti-joins) are expressible from reactions and admin SQL.

## What changed

- `QUERYABLE_SCHEMA`: add both tables with full column lists matching DDL
- `buildScopedQuery` for `entity_relationship_types`: exclude tombstones; include local **and** public-catalog types (same visibility pattern as other catalog tables). Edges stay org-scoped + `deleted_at IS NULL` (pre-existing CTE).
- Tests: `validateAndScopeQuery` asserts CTE SQL; embedded-Postgres test proves local+public visible, private-foreign and deleted excluded

## Why

The scoping CTEs already existed; only the allowlist blocked them. Without this, `listLinks` is the only graph read path (per-entity, slow) and mutual-connection SQL is impossible.

## Test plan

- [x] `table-schema.test.ts` 17/17 including DB drift + graph CTE execution
- [x] `make pre-pr` clean
- [x] `make review-fix` applied (CTE visibility) + re-verified
- [ ] CI + `make review` on PR
- [ ] After deploy: `query_sql` on buremba can join `entity_relationships` / types

## Out of scope

Company dedup, `engaged_with` edges, continuous pipeline — separate follow-ups.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for querying entity relationships and relationship types.
  * Relationship data now includes public records and records scoped to the requested organization.
* **Bug Fixes**
  * Improved scoped query behavior for relationship types, including correct visibility filtering and public fallbacks.
  * Excludes deleted relationship types from results.
* **Tests**
  * Added validation and integration-style coverage for scoped relationship queries and organization-specific outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->