### PR TITLE
feat(linkedin): prepare_comment stages draft (never auto-posts)

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -17,6 +17,13 @@ let parseCompanyUpdates: any;
 let normalizeLinkedInSlug: any;
 let normalizeLinkedInMemberId: any;
 let LINKEDIN_IDENTITY: any;
+let normalizeLinkedInPostUrl: any;
+let isLinkedInAuthWall: any;
+let pickCommentButtonRef: any;
+let pickCommentTextboxRef: any;
+let pickCommentSubmitRef: any;
+let prepareLinkedInComment: any;
+let buildFillCommentExpression: any;
 
 beforeAll(async () => {
   const mod = await import("../linkedin.connector");
@@ -26,6 +33,13 @@ beforeAll(async () => {
   isHomeFeedNoise = mod.isHomeFeedNoise;
   filterPostsSinceCheckpoint = mod.filterPostsSinceCheckpoint;
   parseCompanyUpdates = mod.parseCompanyUpdates;
+  normalizeLinkedInPostUrl = mod.normalizeLinkedInPostUrl;
+  isLinkedInAuthWall = mod.isLinkedInAuthWall;
+  pickCommentButtonRef = mod.pickCommentButtonRef;
+  pickCommentTextboxRef = mod.pickCommentTextboxRef;
+  pickCommentSubmitRef = mod.pickCommentSubmitRef;
+  prepareLinkedInComment = mod.prepareLinkedInComment;
+  buildFillCommentExpression = mod.buildFillCommentExpression;
   const identityMod = await import("../linkedin-identity");
   normalizeLinkedInSlug = identityMod.normalizeLinkedInSlug;
   normalizeLinkedInMemberId = identityMod.normalizeLinkedInMemberId;
@@ -1132,3 +1146,248 @@ describe("LinkedInConnector live post author identity (member id)", () => {
 function resolvePath(obj: any, dotPath: string): unknown {
   return dotPath.split(".").reduce((acc, key) => acc?.[key], obj);
 }
+
+describe("prepare_comment helpers", () => {
+  test("normalizeLinkedInPostUrl accepts urls, urns, and bare ids", () => {
+    expect(normalizeLinkedInPostUrl("7312345678901234567")).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567"
+    );
+    expect(normalizeLinkedInPostUrl("li_post_7312345678901234567")).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567"
+    );
+    expect(normalizeLinkedInPostUrl("urn:li:activity:7312345678901234567")).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567"
+    );
+    expect(
+      normalizeLinkedInPostUrl(
+        "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567/"
+      )
+    ).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567"
+    );
+    expect(normalizeLinkedInPostUrl("https://evil.example/x")).toBeNull();
+    expect(normalizeLinkedInPostUrl("")).toBeNull();
+  });
+
+  test("isLinkedInAuthWall detects login walls", () => {
+    expect(isLinkedInAuthWall("https://www.linkedin.com/login")).toBe(true);
+    expect(isLinkedInAuthWall("https://www.linkedin.com/authwall")).toBe(true);
+    expect(
+      isLinkedInAuthWall(
+        "https://www.linkedin.com/feed/update/urn:li:activity:1"
+      )
+    ).toBe(false);
+  });
+
+  test("pickComment*Ref finds composer controls and Post submit", () => {
+    const tree = [
+      { ref_id: 1, role: "button", name: "Like", tag: "button" },
+      { ref_id: 2, role: "button", name: "Comment", tag: "button" },
+      { ref_id: 3, role: "button", name: "Repost", tag: "button" },
+      { ref_id: 4, role: "textbox", name: "Add a comment…", tag: "div" },
+      { ref_id: 5, role: "button", name: "Post", tag: "button" },
+    ];
+    expect(pickCommentButtonRef(tree, 7)).toEqual({
+      document_epoch: 7,
+      ref_id: 2,
+    });
+    expect(pickCommentTextboxRef(tree, 7)).toEqual({
+      document_epoch: 7,
+      ref_id: 4,
+    });
+    expect(pickCommentSubmitRef(tree, 7)).toEqual({
+      document_epoch: 7,
+      ref_id: 5,
+    });
+  });
+
+  test("buildFillCommentExpression embeds body safely and never auto-submits", () => {
+    const expr = buildFillCommentExpression('hello "world"\nline2');
+    expect(expr).toContain("hello \\\"world\\\"");
+    expect(expr).toContain("insertText");
+    expect(expr).not.toMatch(/\.click\(\).*Post/i);
+    // Composer open may click "Comment", but expression must not target Post submit.
+    expect(expr).toContain("composer_not_found");
+  });
+
+  test("definition declares prepare_comment write action", () => {
+    const c = new LinkedInConnector();
+    const action = c.definition.actions?.prepare_comment;
+    expect(action?.key).toBe("prepare_comment");
+    expect(action?.requiresApproval).toBe(true);
+    expect(action?.kind).toBe("write");
+    expect(c.definition.version).toBe("3.2.0");
+  });
+
+  test("prepareLinkedInComment stages via evaluate (primary) and never clicks Post", async () => {
+    const log: Array<{ key: string; input: Record<string, unknown> }> = [];
+    const dispatcher = {
+      dispatch: async (key: string, input: Record<string, unknown>) => {
+        log.push({ key, input });
+        if (key === "navigate") {
+          return {
+            tab_id: 42,
+            current_url:
+              "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567",
+            title: "Post",
+          };
+        }
+        if (key === "wait_for_selector") return { found: true };
+        if (key === "evaluate") {
+          expect(String(input.expression)).toContain(
+            "Great insight — thanks for sharing."
+          );
+          return {
+            value: {
+              ok: true,
+              reason: "typed",
+              preview: "Great insight — thanks for sharing.",
+            },
+          };
+        }
+        if (key === "focus_tab") return { focused: true, tab_id: 42 };
+        if (key === "show_notification") return { shown: true };
+        throw new Error(`unexpected dispatch ${key}`);
+      },
+    };
+
+    const result = await prepareLinkedInComment(dispatcher, {
+      postUrl: "7312345678901234567",
+      body: "Great insight — thanks for sharing.",
+    });
+
+    expect(result).toMatchObject({
+      prepared: true,
+      tab_id: 42,
+      method: "evaluate",
+      body: "Great insight — thanks for sharing.",
+    });
+    expect(result.post_url).toContain("activity:7312345678901234567");
+
+    const keys = log.map((e) => e.key);
+    expect(keys).toEqual([
+      "navigate",
+      "wait_for_selector",
+      "evaluate",
+      "focus_tab",
+      "show_notification",
+    ]);
+    // Never click Post (no click_ref at all on the happy path).
+    expect(keys).not.toContain("click_ref");
+    expect(keys).not.toContain("type_ref");
+  });
+
+  test("prepareLinkedInComment falls back to type_ref when evaluate misses", async () => {
+    const log: string[] = [];
+    const dispatcher = {
+      dispatch: async (key: string, input: Record<string, unknown>) => {
+        log.push(key);
+        if (key === "navigate") {
+          return {
+            tab_id: 9,
+            current_url:
+              "https://www.linkedin.com/feed/update/urn:li:activity:99",
+          };
+        }
+        if (key === "wait_for_selector") return {};
+        if (key === "evaluate") {
+          return { value: { ok: false, reason: "composer_not_found" } };
+        }
+        if (key === "get_accessibility_tree") {
+          return {
+            document_epoch: 1,
+            tree: [
+              { ref_id: 1, role: "button", name: "Comment", tag: "button" },
+              {
+                ref_id: 2,
+                role: "textbox",
+                name: "Add a comment…",
+                tag: "div",
+              },
+              { ref_id: 3, role: "button", name: "Post", tag: "button" },
+            ],
+          };
+        }
+        if (key === "type_ref") {
+          expect((input.ref as { ref_id: number }).ref_id).toBe(2);
+          expect(input.text).toBe("hi");
+          return {};
+        }
+        if (key === "focus_tab" || key === "show_notification") return {};
+        throw new Error(`unexpected ${key} ${JSON.stringify(input)}`);
+      },
+    };
+
+    const result = await prepareLinkedInComment(dispatcher, {
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:99",
+      body: "hi",
+      notify: false,
+    });
+    expect(result.method).toBe("type_ref");
+    expect(result.prepared).toBe(true);
+    expect(log).toContain("evaluate");
+    expect(log).toContain("type_ref");
+    expect(log).not.toContain("show_notification");
+    // Must not click the Post submit control.
+    expect(log).not.toContain("click_ref");
+  });
+
+  test("prepareLinkedInComment fails closed on auth wall", async () => {
+    const dispatcher = {
+      dispatch: async (key: string) => {
+        if (key === "navigate") {
+          return {
+            tab_id: 1,
+            current_url: "https://www.linkedin.com/login",
+          };
+        }
+        throw new Error(`unexpected ${key}`);
+      },
+    };
+    await expect(
+      prepareLinkedInComment(dispatcher, {
+        postUrl: "1234567890123",
+        body: "x",
+      })
+    ).rejects.toThrow(/Not logged into LinkedIn/);
+  });
+
+  test("execute prepare_comment returns success output via dispatcher", async () => {
+    const connector = new LinkedInConnector();
+    const result = await connector.execute({
+      actionKey: "prepare_comment",
+      input: {
+        activity_id: "7312345678901234567",
+        body: "Nice post",
+        notify: false,
+      },
+      credentials: null,
+      config: {},
+      sessionState: {
+        chrome_dispatcher: {
+          dispatch: async (key: string) => {
+            if (key === "navigate") {
+              return {
+                tab_id: 5,
+                current_url:
+                  "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567",
+              };
+            }
+            if (key === "wait_for_selector") return {};
+            if (key === "evaluate") {
+              return {
+                value: { ok: true, reason: "typed", preview: "Nice post" },
+              };
+            }
+            if (key === "focus_tab") return {};
+            return {};
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.output?.prepared).toBe(true);
+    expect(result.output?.tab_id).toBe(5);
+    expect(result.output?.method).toBe("evaluate");
+  });
+});

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1223,7 +1223,9 @@ describe("prepare_comment helpers", () => {
     expect(expr).toContain("insertText");
     expect(expr).toContain("isSubmitLabel");
     expect(expr).toContain("submitted: false");
-    expect(expr).not.toMatch(/dispatchKeyEvent|key:\s*['\"]Enter['\"]|Meta\+Enter/i);
+    expect(expr).not.toMatch(
+      /dispatchKeyEvent|key:\s*['\"]Enter['\"]|Meta\+Enter/i
+    );
     expect(expr).toContain("composer_not_found");
   });
 

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1277,6 +1277,10 @@ describe("prepare_comment helpers", () => {
     // Never click Post (no click_ref at all on the happy path).
     expect(keys).not.toContain("click_ref");
     expect(keys).not.toContain("type_ref");
+    const focus = log.find((e) => e.key === "focus_tab");
+    expect(focus?.input.open_sidepanel).toBe(true);
+    const note = log.find((e) => e.key === "show_notification");
+    expect(note?.input.tab_id).toBe(42);
   });
 
   test("prepareLinkedInComment falls back to type_ref when evaluate misses", async () => {

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -24,6 +24,8 @@ let pickCommentTextboxRef: any;
 let pickCommentSubmitRef: any;
 let prepareLinkedInComment: any;
 let buildFillCommentExpression: any;
+let buildInjectHandoffBannerExpression: any;
+let truncateHandoffReason: any;
 
 beforeAll(async () => {
   const mod = await import("../linkedin.connector");
@@ -40,6 +42,8 @@ beforeAll(async () => {
   pickCommentSubmitRef = mod.pickCommentSubmitRef;
   prepareLinkedInComment = mod.prepareLinkedInComment;
   buildFillCommentExpression = mod.buildFillCommentExpression;
+  buildInjectHandoffBannerExpression = mod.buildInjectHandoffBannerExpression;
+  truncateHandoffReason = mod.truncateHandoffReason;
   const identityMod = await import("../linkedin-identity");
   normalizeLinkedInSlug = identityMod.normalizeLinkedInSlug;
   normalizeLinkedInMemberId = identityMod.normalizeLinkedInMemberId;
@@ -1212,6 +1216,26 @@ describe("prepare_comment helpers", () => {
     expect(expr).toContain("composer_not_found");
   });
 
+  test("truncateHandoffReason caps length for the banner", () => {
+    expect(truncateHandoffReason("  short  ")).toBe("short");
+    expect(truncateHandoffReason("")).toBeUndefined();
+    const long = "x".repeat(200);
+    const t = truncateHandoffReason(long, 40)!;
+    expect(t.length).toBeLessThanOrEqual(40);
+    expect(t.endsWith("…")).toBe(true);
+  });
+
+  test("buildInjectHandoffBannerExpression is Lobu-branded and not a submit", () => {
+    const expr = buildInjectHandoffBannerExpression({
+      reason: 'Met them at "AI" meetup',
+    });
+    expect(expr).toContain("lobu-handoff-banner");
+    expect(expr).toContain("Lobu staged this comment");
+    expect(expr).toContain("Owletto side panel");
+    expect(expr).toContain('Met them at \\"AI\\" meetup');
+    expect(expr).not.toMatch(/click\(\)\s*;[\s\S]*Post|Post[\s\S]*\.click\(/);
+  });
+
   test("definition declares prepare_comment write action", () => {
     const c = new LinkedInConnector();
     const action = c.definition.actions?.prepare_comment;
@@ -1223,6 +1247,7 @@ describe("prepare_comment helpers", () => {
 
   test("prepareLinkedInComment stages via evaluate (primary) and never clicks Post", async () => {
     const log: Array<{ key: string; input: Record<string, unknown> }> = [];
+    let evaluateCalls = 0;
     const dispatcher = {
       dispatch: async (key: string, input: Record<string, unknown>) => {
         log.push({ key, input });
@@ -1236,16 +1261,22 @@ describe("prepare_comment helpers", () => {
         }
         if (key === "wait_for_selector") return { found: true };
         if (key === "evaluate") {
-          expect(String(input.expression)).toContain(
-            "Great insight — thanks for sharing."
-          );
-          return {
-            value: {
-              ok: true,
-              reason: "typed",
-              preview: "Great insight — thanks for sharing.",
-            },
-          };
+          evaluateCalls += 1;
+          const expr = String(input.expression);
+          if (evaluateCalls === 1) {
+            expect(expr).toContain("Great insight — thanks for sharing.");
+            return {
+              value: {
+                ok: true,
+                reason: "typed",
+                preview: "Great insight — thanks for sharing.",
+              },
+            };
+          }
+          // Banner inject
+          expect(expr).toContain("lobu-handoff-banner");
+          expect(expr).toContain("Met at conference");
+          return { value: { ok: true, anchored: true } };
         }
         if (key === "focus_tab") return { focused: true, tab_id: 42 };
         if (key === "show_notification") return { shown: true };
@@ -1256,6 +1287,7 @@ describe("prepare_comment helpers", () => {
     const result = await prepareLinkedInComment(dispatcher, {
       postUrl: "7312345678901234567",
       body: "Great insight — thanks for sharing.",
+      reason: "Met at conference",
     });
 
     expect(result).toMatchObject({
@@ -1263,6 +1295,8 @@ describe("prepare_comment helpers", () => {
       tab_id: 42,
       method: "evaluate",
       body: "Great insight — thanks for sharing.",
+      banner_shown: true,
+      reason_preview: "Met at conference",
     });
     expect(result.post_url).toContain("activity:7312345678901234567");
 
@@ -1270,6 +1304,7 @@ describe("prepare_comment helpers", () => {
     expect(keys).toEqual([
       "navigate",
       "wait_for_selector",
+      "evaluate",
       "evaluate",
       "focus_tab",
       "show_notification",
@@ -1281,10 +1316,12 @@ describe("prepare_comment helpers", () => {
     expect(focus?.input.open_sidepanel).toBe(true);
     const note = log.find((e) => e.key === "show_notification");
     expect(note?.input.tab_id).toBe(42);
+    expect(String(note?.input.message)).toContain("Met at conference");
   });
 
   test("prepareLinkedInComment falls back to type_ref when evaluate misses", async () => {
     const log: string[] = [];
+    let evaluateCalls = 0;
     const dispatcher = {
       dispatch: async (key: string, input: Record<string, unknown>) => {
         log.push(key);
@@ -1297,7 +1334,12 @@ describe("prepare_comment helpers", () => {
         }
         if (key === "wait_for_selector") return {};
         if (key === "evaluate") {
-          return { value: { ok: false, reason: "composer_not_found" } };
+          evaluateCalls += 1;
+          // First call is fill; later is banner.
+          if (evaluateCalls === 1) {
+            return { value: { ok: false, reason: "composer_not_found" } };
+          }
+          return { value: { ok: true, anchored: false } };
         }
         if (key === "get_accessibility_tree") {
           return {
@@ -1331,6 +1373,7 @@ describe("prepare_comment helpers", () => {
     });
     expect(result.method).toBe("type_ref");
     expect(result.prepared).toBe(true);
+    expect(result.banner_shown).toBe(true);
     expect(log).toContain("evaluate");
     expect(log).toContain("type_ref");
     expect(log).not.toContain("show_notification");

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -21,7 +21,8 @@ let normalizeLinkedInPostUrl: any;
 let isLinkedInAuthWall: any;
 let pickCommentButtonRef: any;
 let pickCommentTextboxRef: any;
-let pickCommentSubmitRef: any;
+let isCommentSubmitLabel: any;
+let isCommentOpenLabel: any;
 let prepareLinkedInComment: any;
 let buildFillCommentExpression: any;
 let buildInjectHandoffBannerExpression: any;
@@ -39,7 +40,8 @@ beforeAll(async () => {
   isLinkedInAuthWall = mod.isLinkedInAuthWall;
   pickCommentButtonRef = mod.pickCommentButtonRef;
   pickCommentTextboxRef = mod.pickCommentTextboxRef;
-  pickCommentSubmitRef = mod.pickCommentSubmitRef;
+  isCommentSubmitLabel = mod.isCommentSubmitLabel;
+  isCommentOpenLabel = mod.isCommentOpenLabel;
   prepareLinkedInComment = mod.prepareLinkedInComment;
   buildFillCommentExpression = mod.buildFillCommentExpression;
   buildInjectHandoffBannerExpression = mod.buildInjectHandoffBannerExpression;
@@ -1185,7 +1187,18 @@ describe("prepare_comment helpers", () => {
     ).toBe(false);
   });
 
-  test("pickComment*Ref finds composer controls and Post submit", () => {
+  test("submit labels are never treated as open-composer controls", () => {
+    expect(isCommentSubmitLabel("Post")).toBe(true);
+    expect(isCommentSubmitLabel("Submit")).toBe(true);
+    expect(isCommentSubmitLabel("Send")).toBe(true);
+    expect(isCommentSubmitLabel("Post comment")).toBe(true);
+    expect(isCommentSubmitLabel("Comment")).toBe(false);
+    expect(isCommentOpenLabel("Comment")).toBe(true);
+    expect(isCommentOpenLabel("Post")).toBe(false);
+    expect(isCommentOpenLabel("Post a comment")).toBe(true);
+  });
+
+  test("pickComment*Ref finds composer controls without selecting Post", () => {
     const tree = [
       { ref_id: 1, role: "button", name: "Like", tag: "button" },
       { ref_id: 2, role: "button", name: "Comment", tag: "button" },
@@ -1201,18 +1214,16 @@ describe("prepare_comment helpers", () => {
       document_epoch: 7,
       ref_id: 4,
     });
-    expect(pickCommentSubmitRef(tree, 7)).toEqual({
-      document_epoch: 7,
-      ref_id: 5,
-    });
+    expect(pickCommentButtonRef(tree, 7)?.ref_id).not.toBe(5);
   });
 
   test("buildFillCommentExpression embeds body safely and never auto-submits", () => {
     const expr = buildFillCommentExpression('hello "world"\nline2');
     expect(expr).toContain('hello \\"world\\"');
     expect(expr).toContain("insertText");
-    expect(expr).not.toMatch(/\.click\(\).*Post/i);
-    // Composer open may click "Comment", but expression must not target Post submit.
+    expect(expr).toContain("isSubmitLabel");
+    expect(expr).toContain("submitted: false");
+    expect(expr).not.toMatch(/dispatchKeyEvent|key:\s*['\"]Enter['\"]|Meta\+Enter/i);
     expect(expr).toContain("composer_not_found");
   });
 
@@ -1236,13 +1247,15 @@ describe("prepare_comment helpers", () => {
     expect(expr).not.toMatch(/click\(\)\s*;[\s\S]*Post|Post[\s\S]*\.click\(/);
   });
 
-  test("definition declares prepare_comment write action", () => {
+  test("definition declares prepare_comment write action with human gate", () => {
     const c = new LinkedInConnector();
     const action = c.definition.actions?.prepare_comment;
     expect(action?.key).toBe("prepare_comment");
     expect(action?.requiresApproval).toBe(true);
     expect(action?.kind).toBe("write");
+    expect(action?.annotations?.destructiveHint).toBe(false);
     expect(c.definition.version).toBe("3.2.0");
+    expect(String(action?.description ?? "")).toMatch(/NEVER submits/i);
   });
 
   test("prepareLinkedInComment stages via evaluate (primary) and never clicks Post", async () => {

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1173,6 +1173,24 @@ describe("prepare_comment helpers", () => {
     ).toBe(
       "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567"
     );
+    expect(
+      normalizeLinkedInPostUrl(
+        "https://www.linkedin.com/feed/?updateEntityUrn=urn%3Ali%3Aactivity%3A7312345678901234567"
+      )
+    ).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567"
+    );
+    expect(
+      normalizeLinkedInPostUrl(
+        "http://www.linkedin.com/posts/example_activity-7312345678901234567-x"
+      )
+    ).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567"
+    );
+    expect(
+      normalizeLinkedInPostUrl("https://www.linkedin.com/feed/")
+    ).toBeNull();
+    expect(normalizeLinkedInPostUrl("ftp://linkedin.com/post")).toBeNull();
     expect(normalizeLinkedInPostUrl("https://evil.example/x")).toBeNull();
     expect(normalizeLinkedInPostUrl("")).toBeNull();
   });
@@ -1224,7 +1242,7 @@ describe("prepare_comment helpers", () => {
     expect(expr).toContain("isSubmitLabel");
     expect(expr).toContain("submitted: false");
     expect(expr).not.toMatch(
-      /dispatchKeyEvent|key:\s*['\"]Enter['\"]|Meta\+Enter/i
+      /dispatchKeyEvent|key:\s*['"]Enter['"]|Meta\+Enter/i
     );
     expect(expr).toContain("composer_not_found");
   });
@@ -1256,6 +1274,10 @@ describe("prepare_comment helpers", () => {
     expect(action?.requiresApproval).toBe(true);
     expect(action?.kind).toBe("write");
     expect(action?.annotations?.destructiveHint).toBe(false);
+    expect(action?.inputSchema?.anyOf).toEqual([
+      { required: ["post_url"] },
+      { required: ["activity_id"] },
+    ]);
     expect(c.definition.version).toBe("3.2.0");
     expect(String(action?.description ?? "")).toMatch(/NEVER submits/i);
   });
@@ -1327,14 +1349,12 @@ describe("prepare_comment helpers", () => {
     // Never click Post (no click_ref at all on the happy path).
     expect(keys).not.toContain("click_ref");
     expect(keys).not.toContain("type_ref");
-    const focus = log.find((e) => e.key === "focus_tab");
-    expect(focus?.input.open_sidepanel).toBe(true);
     const note = log.find((e) => e.key === "show_notification");
     expect(note?.input.tab_id).toBe(42);
     expect(String(note?.input.message)).toContain("Met at conference");
   });
 
-  test("prepareLinkedInComment falls back to type_ref when evaluate misses", async () => {
+  test("prepareLinkedInComment falls back to type_ref when evaluate is unavailable", async () => {
     const log: string[] = [];
     let evaluateCalls = 0;
     const dispatcher = {
@@ -1344,7 +1364,7 @@ describe("prepare_comment helpers", () => {
           return {
             tab_id: 9,
             current_url:
-              "https://www.linkedin.com/feed/update/urn:li:activity:99",
+              "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567",
           };
         }
         if (key === "wait_for_selector") return {};
@@ -1352,7 +1372,7 @@ describe("prepare_comment helpers", () => {
           evaluateCalls += 1;
           // First call is fill; later is banner.
           if (evaluateCalls === 1) {
-            return { value: { ok: false, reason: "composer_not_found" } };
+            throw new Error("evaluate unavailable");
           }
           return { value: { ok: true, anchored: false } };
         }
@@ -1382,7 +1402,8 @@ describe("prepare_comment helpers", () => {
     };
 
     const result = await prepareLinkedInComment(dispatcher, {
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:99",
+      postUrl:
+        "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567",
       body: "hi",
       notify: false,
     });

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1155,7 +1155,9 @@ describe("prepare_comment helpers", () => {
     expect(normalizeLinkedInPostUrl("li_post_7312345678901234567")).toBe(
       "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567"
     );
-    expect(normalizeLinkedInPostUrl("urn:li:activity:7312345678901234567")).toBe(
+    expect(
+      normalizeLinkedInPostUrl("urn:li:activity:7312345678901234567")
+    ).toBe(
       "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567"
     );
     expect(
@@ -1203,7 +1205,7 @@ describe("prepare_comment helpers", () => {
 
   test("buildFillCommentExpression embeds body safely and never auto-submits", () => {
     const expr = buildFillCommentExpression('hello "world"\nline2');
-    expect(expr).toContain("hello \\\"world\\\"");
+    expect(expr).toContain('hello \\"world\\"');
     expect(expr).toContain("insertText");
     expect(expr).not.toMatch(/\.click\(\).*Post/i);
     // Composer open may click "Comment", but expression must not target Post submit.

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -729,10 +729,7 @@ export function pickCommentTextboxRef(
     /text editor/i,
   ];
   const candidates = tree.filter(
-    (n) =>
-      n.role === "textbox" ||
-      n.tag === "textarea" ||
-      n.tag === "div" // contenteditable often role=textbox; keep div as weak fallthrough
+    (n) => n.role === "textbox" || n.tag === "textarea" || n.tag === "div" // contenteditable often role=textbox; keep div as weak fallthrough
   );
   for (const node of candidates) {
     if (node.role === "textbox" && nameMatches(node.name, goodName)) {
@@ -741,17 +738,13 @@ export function pickCommentTextboxRef(
   }
   // Any textbox whose name mentions comment.
   for (const node of candidates) {
-    if (
-      node.role === "textbox" &&
-      node.name &&
-      /comment/i.test(node.name)
-    ) {
+    if (node.role === "textbox" && node.name && /comment/i.test(node.name)) {
       return { document_epoch: documentEpoch, ref_id: node.ref_id };
     }
   }
   // Last resort: empty-named textboxes are common once the composer is open.
   const emptyTextboxes = candidates.filter(
-    (n) => n.role === "textbox" && (!n.name || !n.name.trim())
+    (n) => n.role === "textbox" && !n.name?.trim()
   );
   if (emptyTextboxes.length === 1) {
     return {
@@ -1011,9 +1004,7 @@ export async function prepareLinkedInComment(
       ...chromeOriginsInput(),
     });
     if (evalOut.exception) {
-      throw new Error(
-        `prepare_comment: evaluate failed: ${evalOut.exception}`
-      );
+      throw new Error(`prepare_comment: evaluate failed: ${evalOut.exception}`);
     }
     const value = evalOut.value;
     if (value?.ok) {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -614,6 +614,10 @@ export type PrepareCommentResult = {
   body: string;
   /** How the composer was filled: a11y type_ref vs evaluate fallback. */
   method: "type_ref" | "evaluate";
+  /** Whether the in-page handoff banner was injected. */
+  banner_shown?: boolean;
+  /** Truncated reason shown on the banner (if any). */
+  reason_preview?: string;
   message: string;
 };
 
@@ -809,6 +813,151 @@ async function snapshotTree(
   };
 }
 
+/** Cap reason text for in-page banner (full reason lives in the sidepanel). */
+export function truncateHandoffReason(
+  reason: string | undefined | null,
+  maxLen = 120
+): string | undefined {
+  if (reason == null) return undefined;
+  const t = reason.replace(/\s+/g, " ").trim();
+  if (!t) return undefined;
+  if (t.length <= maxLen) return t;
+  return `${t.slice(0, Math.max(0, maxLen - 1)).trimEnd()}…`;
+}
+
+/**
+ * JS expression: inject a small Lobu handoff banner on the page.
+ * Not the full reason UI — one short line + "details in side panel".
+ * Best-effort; LinkedIn re-renders may remove it.
+ */
+export function buildInjectHandoffBannerExpression(opts: {
+  reason?: string;
+  title?: string;
+}): string {
+  const title = opts.title ?? "Lobu staged this comment";
+  const reason = truncateHandoffReason(opts.reason);
+  const titleLit = JSON.stringify(title);
+  const reasonLit = JSON.stringify(reason ?? null);
+  return `(async()=>{
+  const TITLE = ${titleLit};
+  const REASON = ${reasonLit};
+  const ID = 'lobu-handoff-banner';
+  try {
+    const prev = document.getElementById(ID);
+    if (prev) prev.remove();
+  } catch (_) {}
+
+  const root = document.createElement('div');
+  root.id = ID;
+  root.setAttribute('role', 'status');
+  root.setAttribute('data-lobu', 'handoff-banner');
+  // Keep styles self-contained; avoid LinkedIn class collisions.
+  root.style.cssText = [
+    'position:fixed',
+    'top:12px',
+    'left:50%',
+    'transform:translateX(-50%)',
+    'z-index:2147483646',
+    'max-width:min(520px,calc(100vw - 24px))',
+    'font:13px/1.4 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif',
+    'color:#0f172a',
+    'background:#fff',
+    'border:1px solid #cbd5e1',
+    'border-left:4px solid #0ea5e9',
+    'border-radius:10px',
+    'box-shadow:0 8px 28px rgba(15,23,42,.18)',
+    'padding:10px 12px',
+    'display:flex',
+    'gap:10px',
+    'align-items:flex-start',
+    'pointer-events:auto',
+  ].join(';');
+
+  const body = document.createElement('div');
+  body.style.cssText = 'flex:1;min-width:0';
+
+  const head = document.createElement('div');
+  head.style.cssText = 'font-weight:600;margin:0 0 2px;color:#0c4a6e';
+  head.textContent = TITLE;
+
+  const line = document.createElement('div');
+  line.style.cssText = 'color:#334155;margin:0 0 2px';
+  line.textContent = 'Review the draft and click Post yourself — Lobu did not submit.';
+
+  body.appendChild(head);
+  body.appendChild(line);
+
+  if (REASON) {
+    const why = document.createElement('div');
+    why.style.cssText = 'color:#64748b;margin:4px 0 0;font-size:12px';
+    why.textContent = 'Why: ' + REASON;
+    body.appendChild(why);
+  }
+
+  const foot = document.createElement('div');
+  foot.style.cssText = 'color:#64748b;margin:4px 0 0;font-size:12px';
+  foot.textContent = 'Full context in the Owletto side panel.';
+  body.appendChild(foot);
+
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.setAttribute('aria-label', 'Dismiss');
+  close.textContent = '×';
+  close.style.cssText = [
+    'flex:none',
+    'border:0',
+    'background:transparent',
+    'color:#64748b',
+    'font:20px/1 sans-serif',
+    'cursor:pointer',
+    'padding:0 2px',
+  ].join(';');
+  close.onclick = function () { try { root.remove(); } catch (_) {} };
+
+  root.appendChild(body);
+  root.appendChild(close);
+
+  // Prefer anchoring near the comment composer when we can find it.
+  let anchored = false;
+  try {
+    const composer =
+      document.querySelector('.comments-comment-box-comment__text-editor .ql-editor') ||
+      document.querySelector('.comments-comment-box__form .ql-editor') ||
+      document.querySelector('div.ql-editor[contenteditable="true"]') ||
+      document.querySelector('div[role="textbox"][contenteditable="true"]');
+    if (composer) {
+      const host =
+        composer.closest('.comments-comment-box') ||
+        composer.closest('form') ||
+        composer.parentElement;
+      if (host && host.parentElement) {
+        root.style.position = 'relative';
+        root.style.top = '0';
+        root.style.left = '0';
+        root.style.transform = 'none';
+        root.style.margin = '8px 0 12px';
+        root.style.maxWidth = '100%';
+        host.parentElement.insertBefore(root, host);
+        anchored = true;
+      }
+    }
+  } catch (_) {}
+
+  if (!anchored) {
+    (document.body || document.documentElement).appendChild(root);
+  }
+
+  // Soft auto-dismiss after 90s so we don't leave permanent chrome on the page.
+  try {
+    setTimeout(function () {
+      try { if (root.isConnected) root.remove(); } catch (_) {}
+    }, 90000);
+  } catch (_) {}
+
+  return { ok: true, anchored: anchored, has_reason: !!REASON };
+})()`;
+}
+
 /** JS expression: open the comment composer if collapsed, then fill it. */
 export function buildFillCommentExpression(body: string): string {
   // JSON.stringify for safe embedding of the draft text.
@@ -932,8 +1081,12 @@ export async function prepareLinkedInComment(
   opts: {
     postUrl: string;
     body: string;
+    /** Short why for the in-page banner; full context stays in the sidepanel. */
+    reason?: string;
     focus?: boolean;
     notify?: boolean;
+    /** Inject in-page handoff banner (default true). */
+    banner?: boolean;
   }
 ): Promise<PrepareCommentResult> {
   const body = opts.body.trim();
@@ -948,6 +1101,8 @@ export async function prepareLinkedInComment(
   }
   const focus = opts.focus !== false;
   const notify = opts.notify !== false;
+  const banner = opts.banner !== false;
+  const reasonPreview = truncateHandoffReason(opts.reason);
 
   const nav = await dispatcher.dispatch<{
     tab_id?: number;
@@ -1064,6 +1219,26 @@ export async function prepareLinkedInComment(
     );
   }
 
+  let bannerShown = false;
+  if (banner) {
+    try {
+      const bannerOut = await dispatcher.dispatch<{
+        value?: { ok?: boolean; anchored?: boolean };
+        exception?: string;
+      }>("evaluate", {
+        tab_id: tabId,
+        expression: buildInjectHandoffBannerExpression({
+          reason: reasonPreview,
+        }),
+        await_promise: true,
+        ...chromeOriginsInput(),
+      });
+      bannerShown = bannerOut.value?.ok === true && !bannerOut.exception;
+    } catch {
+      // Banner is best-effort; draft is already staged.
+    }
+  }
+
   if (focus) {
     try {
       await dispatcher.dispatch("focus_tab", {
@@ -1081,10 +1256,12 @@ export async function prepareLinkedInComment(
 
   if (notify) {
     try {
+      const notifyMsg = reasonPreview
+        ? `Draft ready — ${reasonPreview}`
+        : "Draft is in the comment box — review and click Post yourself. Lobu did not submit.";
       await dispatcher.dispatch("show_notification", {
         title: "LinkedIn comment ready",
-        message:
-          "Draft is in the comment box — review and click Post yourself. Lobu did not submit.",
+        message: notifyMsg.slice(0, 240),
         tab_id: tabId,
         click_url: postUrl,
         ...chromeOriginsInput(),
@@ -1100,6 +1277,8 @@ export async function prepareLinkedInComment(
     post_url: postUrl,
     body,
     method,
+    banner_shown: bannerShown,
+    reason_preview: reasonPreview,
     message:
       "Comment staged in your browser. Review the draft and click Post yourself — Lobu did not submit.",
   };
@@ -1576,6 +1755,12 @@ export default class LinkedInConnector extends ConnectorRuntime<
               minLength: 1,
               maxLength: 3000,
             },
+            reason: {
+              type: "string",
+              description:
+                "Optional short why for the in-page banner (truncated). Full context stays in the Owletto side panel.",
+              maxLength: 500,
+            },
             focus: {
               type: "boolean",
               description:
@@ -1585,6 +1770,11 @@ export default class LinkedInConnector extends ConnectorRuntime<
               type: "boolean",
               description:
                 "Show a desktop notification when the draft is ready (default true).",
+            },
+            banner: {
+              type: "boolean",
+              description:
+                "Inject a small in-page Lobu handoff banner (default true).",
             },
           },
         },
@@ -1596,6 +1786,8 @@ export default class LinkedInConnector extends ConnectorRuntime<
             post_url: { type: "string" },
             body: { type: "string" },
             method: { type: "string" },
+            banner_shown: { type: "boolean" },
+            reason_preview: { type: "string" },
             message: { type: "string" },
           },
         },
@@ -1624,12 +1816,16 @@ export default class LinkedInConnector extends ConnectorRuntime<
           error: "post_url or activity_id is required",
         };
       }
+      const reason =
+        typeof ctx.input.reason === "string" ? ctx.input.reason.trim() : "";
       const dispatcher = requireExtensionDispatcher(ctx);
       const output = await prepareLinkedInComment(dispatcher, {
         postUrl: postUrlRaw,
         body,
+        reason: reason || undefined,
         focus: ctx.input.focus !== false,
         notify: ctx.input.notify !== false,
+        banner: ctx.input.banner !== false,
       });
       return { success: true, output };
     } catch (error) {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -21,7 +21,7 @@
  * dedups all people on the shared `linkedin_slug`/`email` identity: a person met
  * live and a person in the CSV export collapse to the same entity.
  *
- * Write handoff (spike): `prepare_comment` opens a post in the paired Chrome,
+ * Write handoff: `prepare_comment` opens a post in the paired Chrome,
  * fills the comment composer, focuses the tab, and stops. The human clicks
  * Post themselves — Lobu never submits the comment.
  */
@@ -594,7 +594,7 @@ function requireExtensionDispatcher(ctx: {
 // ── prepare_comment handoff (browser stage, human submits) ───────────
 
 /** Interactive a11y node from chrome `get_accessibility_tree`. */
-export type A11yNode = {
+type A11yNode = {
   ref_id: number;
   role?: string;
   name?: string;
@@ -602,17 +602,17 @@ export type A11yNode = {
   href?: string;
 };
 
-export type ElementRef = {
+type ElementRef = {
   document_epoch: number;
   ref_id: number;
 };
 
-export type PrepareCommentResult = {
+type PrepareCommentResult = {
   prepared: boolean;
   tab_id: number;
   post_url: string;
   body: string;
-  /** How the composer was filled: a11y type_ref vs evaluate fallback. */
+  /** How the composer was filled: evaluate or the a11y type_ref fallback. */
   method: "type_ref" | "evaluate";
   /** Whether the in-page handoff banner was injected. */
   banner_shown?: boolean;
@@ -651,20 +651,20 @@ export function normalizeLinkedInPostUrl(input: string): string | null {
           ? raw
           : `https://${raw}`;
     const u = new URL(withScheme);
+    if (u.protocol !== "https:" && u.protocol !== "http:") return null;
+    u.protocol = "https:";
     const host = u.hostname.toLowerCase().replace(/^www\./, "");
     if (host !== "linkedin.com" && !host.endsWith(".linkedin.com")) {
       return null;
     }
     // Prefer canonical feed/update URLs when we can extract an activity id.
-    const fromPath = u.pathname.match(/activity[:%3A](\d{6,})/i);
-    const fromQuery = u.search.match(/activity[:%3A-]?(\d{6,})/i);
-    const activityId = fromPath?.[1] ?? fromQuery?.[1];
+    const activityId = `${u.pathname}${u.search}`.match(
+      /(?:urn(?::|%3A)li(?::|%3A))?activity(?::|%3A|-)(\d{6,})/i
+    )?.[1];
     if (activityId) {
       return `https://www.linkedin.com/feed/update/urn:li:activity:${activityId}`;
     }
-    // Keep posts/… and other linkedin URLs as-is (strip hash only).
-    u.hash = "";
-    return u.toString();
+    return null;
   } catch {
     return null;
   }
@@ -716,7 +716,7 @@ export function isCommentOpenLabel(name: string | undefined | null): boolean {
 
 /**
  * Prefer the social-action "Comment" control (not "Add a comment…" textbox,
- * not "Post" submit). Names vary by locale; English-first for the spike.
+ * not "Post" submit). Names vary by locale; this path is English-first.
  */
 export function pickCommentButtonRef(
   tree: A11yNode[],
@@ -732,7 +732,6 @@ export function pickCommentButtonRef(
     if (!isCommentOpenLabel(node.name)) continue;
     // Skip textboxes that happen to have "comment" in the name.
     if (node.role === "textbox" || node.tag === "textarea") continue;
-    if (isCommentSubmitLabel(node.name)) continue;
     return { document_epoch: documentEpoch, ref_id: node.ref_id };
   }
   return null;
@@ -753,24 +752,20 @@ export function pickCommentTextboxRef(
     /^comment$/i,
     /text editor/i,
   ];
-  const candidates = tree.filter(
-    (n) => n.role === "textbox" || n.tag === "textarea" || n.tag === "div" // contenteditable often role=textbox; keep div as weak fallthrough
-  );
+  const candidates = tree.filter((n) => n.role === "textbox");
   for (const node of candidates) {
-    if (node.role === "textbox" && nameMatches(node.name, goodName)) {
+    if (nameMatches(node.name, goodName)) {
       return { document_epoch: documentEpoch, ref_id: node.ref_id };
     }
   }
   // Any textbox whose name mentions comment.
   for (const node of candidates) {
-    if (node.role === "textbox" && node.name && /comment/i.test(node.name)) {
+    if (node.name && /comment/i.test(node.name)) {
       return { document_epoch: documentEpoch, ref_id: node.ref_id };
     }
   }
   // Last resort: empty-named textboxes are common once the composer is open.
-  const emptyTextboxes = candidates.filter(
-    (n) => n.role === "textbox" && !n.name?.trim()
-  );
+  const emptyTextboxes = candidates.filter((n) => !n.name?.trim());
   if (emptyTextboxes.length === 1) {
     return {
       document_epoch: documentEpoch,
@@ -813,7 +808,7 @@ async function snapshotTree(
   };
 }
 
-/** Cap reason text for in-page banner (full reason lives in the sidepanel). */
+/** Cap the explanation shown in the in-page banner. */
 export function truncateHandoffReason(
   reason: string | undefined | null,
   maxLen = 120
@@ -827,7 +822,7 @@ export function truncateHandoffReason(
 
 /**
  * JS expression: inject a small Lobu handoff banner on the page.
- * Not the full reason UI — one short line + "details in side panel".
+ * The banner points the user to the side panel for the run details.
  * Best-effort; LinkedIn re-renders may remove it.
  */
 export function buildInjectHandoffBannerExpression(opts: {
@@ -896,7 +891,7 @@ export function buildInjectHandoffBannerExpression(opts: {
 
   const foot = document.createElement('div');
   foot.style.cssText = 'color:#64748b;margin:4px 0 0;font-size:12px';
-  foot.textContent = 'Full context in the Owletto side panel.';
+  foot.textContent = 'Open the Owletto side panel for run details.';
   body.appendChild(foot);
 
   const close = document.createElement('button');
@@ -1099,7 +1094,7 @@ export async function prepareLinkedInComment(
   opts: {
     postUrl: string;
     body: string;
-    /** Short why for the in-page banner; full context stays in the sidepanel. */
+    /** Short explanation for the in-page banner. */
     reason?: string;
     focus?: boolean;
     notify?: boolean;
@@ -1132,10 +1127,8 @@ export async function prepareLinkedInComment(
           );
         }
       }
-      const { allowed_click: _allowed, ...input } = action_input as Record<
-        string,
-        unknown
-      > & { allowed_click?: string };
+      const input = { ...action_input };
+      delete input.allowed_click;
       return dispatcher.dispatch(action_key, input);
     },
   };
@@ -1176,35 +1169,47 @@ export async function prepareLinkedInComment(
   let method: "type_ref" | "evaluate" = "evaluate";
   let typed = false;
 
-  // Live spike (2026-07): LinkedIn's current feed/post UI rarely exposes the
+  // LinkedIn's current feed/post UI rarely exposes the
   // Quill composer as an a11y textbox after clicking Comment, so evaluate
   // (contenteditable/ql-editor selectors + insertText) is the primary path.
   // type_ref remains a secondary attempt when the tree does surface a textbox.
   {
-    const evalOut = await safeDispatch.dispatch<{
-      value?: {
-        ok?: boolean;
-        reason?: string;
-        preview?: string;
-        submitted?: boolean;
-      };
-      exception?: string;
-    }>("evaluate", {
-      tab_id: tabId,
-      expression: buildFillCommentExpression(body),
-      await_promise: true,
-      ...chromeOriginsInput(),
-    });
-    if (evalOut.exception) {
-      throw new Error(`prepare_comment: evaluate failed: ${evalOut.exception}`);
+    let evalOut:
+      | {
+          value?: {
+            ok?: boolean;
+            reason?: string;
+            preview?: string;
+            submitted?: boolean;
+          };
+          exception?: string;
+        }
+      | undefined;
+    try {
+      evalOut = await safeDispatch.dispatch<{
+        value?: {
+          ok?: boolean;
+          reason?: string;
+          preview?: string;
+          submitted?: boolean;
+        };
+        exception?: string;
+      }>("evaluate", {
+        tab_id: tabId,
+        expression: buildFillCommentExpression(body),
+        await_promise: true,
+        ...chromeOriginsInput(),
+      });
+    } catch {
+      // The a11y path below can still stage the draft when evaluate is blocked.
     }
-    const value = evalOut.value;
+    const value = evalOut?.value;
     if (value?.submitted === true) {
       throw new Error(
         "prepare_comment: fill expression reported submitted=true — aborting (must never auto-post)"
       );
     }
-    if (value?.ok) {
+    if (!evalOut?.exception && value?.ok) {
       method = "evaluate";
       typed = true;
     }
@@ -1225,12 +1230,6 @@ export async function prepareLinkedInComment(
       if (!textbox) {
         const commentBtn = pickCommentButtonRef(snap.tree, snap.document_epoch);
         if (commentBtn) {
-          const btnNode = snap.tree.find((n) => n.ref_id === commentBtn.ref_id);
-          if (btnNode && isCommentSubmitLabel(btnNode.name)) {
-            throw new Error(
-              "prepare_comment: refused to click submit-labelled control"
-            );
-          }
           await safeDispatch.dispatch("click_ref", {
             tab_id: tabId,
             ref: commentBtn,
@@ -1257,7 +1256,6 @@ export async function prepareLinkedInComment(
       if (
         err instanceof Error &&
         (err.message.includes("Not logged into LinkedIn") ||
-          err.message.includes("refused to click") ||
           err.message.includes("blocked click_ref"))
       ) {
         throw err;
@@ -1296,7 +1294,6 @@ export async function prepareLinkedInComment(
       await safeDispatch.dispatch("focus_tab", {
         tab_id: tabId,
         draw_attention: true,
-        open_sidepanel: true,
         ...chromeOriginsInput(),
       });
     } catch {
@@ -1787,11 +1784,12 @@ export default class LinkedInConnector extends ConnectorRuntime<
         inputSchema: {
           type: "object",
           required: ["body"],
+          anyOf: [{ required: ["post_url"] }, { required: ["activity_id"] }],
           properties: {
             post_url: {
               type: "string",
               description:
-                'LinkedIn post URL, or activity id / URN (e.g. "https://www.linkedin.com/feed/update/urn:li:activity:123", "urn:li:activity:123", or "123").',
+                'LinkedIn post URL, or activity id / URN (e.g. "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567", "urn:li:activity:7312345678901234567", or "7312345678901234567").',
             },
             activity_id: {
               type: "string",
@@ -1808,7 +1806,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
             reason: {
               type: "string",
               description:
-                "Optional short why for the in-page banner (truncated). Full context stays in the Owletto side panel.",
+                "Optional short explanation for the in-page banner (truncated).",
               maxLength: 500,
             },
             focus: {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -20,9 +20,15 @@
  * Folding both into ONE connector (key "linkedin") means a single connection
  * dedups all people on the shared `linkedin_slug`/`email` identity: a person met
  * live and a person in the CSV export collapse to the same entity.
+ *
+ * Write handoff (spike): `prepare_comment` opens a post in the paired Chrome,
+ * fills the comment composer, focuses the tab, and stops. The human clicks
+ * Post themselves — Lobu never submits the comment.
  */
 
 import {
+  type ActionContext,
+  type ActionResult,
   type ChromeActionDispatcher,
   type ConnectorDefinition,
   ConnectorRuntime,
@@ -585,6 +591,524 @@ function requireExtensionDispatcher(ctx: {
   return handle;
 }
 
+// ── prepare_comment handoff (browser stage, human submits) ───────────
+
+/** Interactive a11y node from chrome `get_accessibility_tree`. */
+export type A11yNode = {
+  ref_id: number;
+  role?: string;
+  name?: string;
+  tag?: string;
+  href?: string;
+};
+
+export type ElementRef = {
+  document_epoch: number;
+  ref_id: number;
+};
+
+export type PrepareCommentResult = {
+  prepared: boolean;
+  tab_id: number;
+  post_url: string;
+  body: string;
+  /** How the composer was filled: a11y type_ref vs evaluate fallback. */
+  method: "type_ref" | "evaluate";
+  message: string;
+};
+
+/**
+ * Normalize a post URL or activity id into a linkedin.com update URL.
+ * Accepts full URLs, `urn:li:activity:…`, bare activity digits, or
+ * `/feed/update/…` paths.
+ */
+export function normalizeLinkedInPostUrl(input: string): string | null {
+  const raw = input.trim();
+  if (!raw) return null;
+
+  // Bare activity id (digits only, possibly with li_post_ prefix from events).
+  const bareId = raw.replace(/^li_post_/, "");
+  if (/^\d{6,}$/.test(bareId)) {
+    return `https://www.linkedin.com/feed/update/urn:li:activity:${bareId}`;
+  }
+
+  // urn:li:activity:123 or activity:123
+  const urnMatch = raw.match(/(?:urn:li:)?activity:(\d{6,})/i);
+  if (urnMatch && !raw.includes("://") && !raw.startsWith("/")) {
+    return `https://www.linkedin.com/feed/update/urn:li:activity:${urnMatch[1]}`;
+  }
+
+  try {
+    const withScheme = raw.startsWith("//")
+      ? `https:${raw}`
+      : raw.startsWith("/")
+        ? `https://www.linkedin.com${raw}`
+        : raw.includes("://")
+          ? raw
+          : `https://${raw}`;
+    const u = new URL(withScheme);
+    const host = u.hostname.toLowerCase().replace(/^www\./, "");
+    if (host !== "linkedin.com" && !host.endsWith(".linkedin.com")) {
+      return null;
+    }
+    // Prefer canonical feed/update URLs when we can extract an activity id.
+    const fromPath = u.pathname.match(/activity[:%3A](\d{6,})/i);
+    const fromQuery = u.search.match(/activity[:%3A-]?(\d{6,})/i);
+    const activityId = fromPath?.[1] ?? fromQuery?.[1];
+    if (activityId) {
+      return `https://www.linkedin.com/feed/update/urn:li:activity:${activityId}`;
+    }
+    // Keep posts/… and other linkedin URLs as-is (strip hash only).
+    u.hash = "";
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** True when navigate landed on login / authwall rather than the post. */
+export function isLinkedInAuthWall(url: string | null | undefined): boolean {
+  if (!url) return false;
+  const lower = url.toLowerCase();
+  return (
+    lower.includes("/login") ||
+    lower.includes("/authwall") ||
+    lower.includes("/checkpoint") ||
+    lower.includes("uas/login")
+  );
+}
+
+function nameMatches(name: string | undefined, patterns: RegExp[]): boolean {
+  if (!name) return false;
+  const n = name.trim();
+  return patterns.some((re) => re.test(n));
+}
+
+/**
+ * Prefer the social-action "Comment" control (not "Add a comment…" textbox,
+ * not "Post" submit). Names vary by locale; English-first for the spike.
+ */
+export function pickCommentButtonRef(
+  tree: A11yNode[],
+  documentEpoch: number
+): ElementRef | null {
+  const patterns = [
+    /^comment$/i,
+    /^comments$/i,
+    /^comment on /i,
+    /^leave a comment/i,
+  ];
+  // Prefer explicit buttons over links/generics.
+  const ranked = [...tree].sort((a, b) => {
+    const score = (n: A11yNode) =>
+      n.role === "button" || n.tag === "button" ? 0 : 1;
+    return score(a) - score(b);
+  });
+  for (const node of ranked) {
+    if (!nameMatches(node.name, patterns)) continue;
+    // Skip textboxes that happen to have "comment" in the name.
+    if (node.role === "textbox" || node.tag === "textarea") continue;
+    return { document_epoch: documentEpoch, ref_id: node.ref_id };
+  }
+  return null;
+}
+
+/**
+ * Find the comment composer textbox. LinkedIn uses contenteditable/Quill
+ * editors that surface as role=textbox with names like "Add a comment…".
+ */
+export function pickCommentTextboxRef(
+  tree: A11yNode[],
+  documentEpoch: number
+): ElementRef | null {
+  const goodName = [
+    /add a comment/i,
+    /write a comment/i,
+    /leave a comment/i,
+    /^comment$/i,
+    /text editor/i,
+  ];
+  const candidates = tree.filter(
+    (n) =>
+      n.role === "textbox" ||
+      n.tag === "textarea" ||
+      n.tag === "div" // contenteditable often role=textbox; keep div as weak fallthrough
+  );
+  for (const node of candidates) {
+    if (node.role === "textbox" && nameMatches(node.name, goodName)) {
+      return { document_epoch: documentEpoch, ref_id: node.ref_id };
+    }
+  }
+  // Any textbox whose name mentions comment.
+  for (const node of candidates) {
+    if (
+      node.role === "textbox" &&
+      node.name &&
+      /comment/i.test(node.name)
+    ) {
+      return { document_epoch: documentEpoch, ref_id: node.ref_id };
+    }
+  }
+  // Last resort: empty-named textboxes are common once the composer is open.
+  const emptyTextboxes = candidates.filter(
+    (n) => n.role === "textbox" && (!n.name || !n.name.trim())
+  );
+  if (emptyTextboxes.length === 1) {
+    return {
+      document_epoch: documentEpoch,
+      ref_id: emptyTextboxes[0]!.ref_id,
+    };
+  }
+  return null;
+}
+
+/**
+ * Never match the submit control — prepare_comment must not click these.
+ * Used only as a guard if we ever expand auto-click behavior.
+ */
+export function pickCommentSubmitRef(
+  tree: A11yNode[],
+  documentEpoch: number
+): ElementRef | null {
+  const patterns = [/^post$/i, /^comment$/i, /^submit$/i, /^send$/i];
+  for (const node of tree) {
+    if (node.role !== "button" && node.tag !== "button") continue;
+    if (!nameMatches(node.name, patterns)) continue;
+    // "Comment" social action is not the submit once the composer is open;
+    // submit is usually "Post" in English. Keep this helper for tests.
+    if (/^post$/i.test(node.name?.trim() ?? "")) {
+      return { document_epoch: documentEpoch, ref_id: node.ref_id };
+    }
+  }
+  return null;
+}
+
+function chromeOriginsInput(): { allowed_origins: string[] } {
+  return { allowed_origins: LINKEDIN_ALLOWED_ORIGINS };
+}
+
+type TreeSnapshot = {
+  document_epoch: number;
+  tree: A11yNode[];
+  current_url?: string;
+};
+
+async function snapshotTree(
+  dispatcher: ChromeActionDispatcher,
+  tabId: number
+): Promise<TreeSnapshot> {
+  const out = await dispatcher.dispatch<TreeSnapshot & Record<string, unknown>>(
+    "get_accessibility_tree",
+    {
+      tab_id: tabId,
+      filter: "interactive",
+      ...chromeOriginsInput(),
+    }
+  );
+  const tree = Array.isArray(out.tree) ? (out.tree as A11yNode[]) : [];
+  const document_epoch =
+    typeof out.document_epoch === "number" ? out.document_epoch : 0;
+  return {
+    document_epoch,
+    tree,
+    current_url:
+      typeof out.current_url === "string" ? out.current_url : undefined,
+  };
+}
+
+/** JS expression: open the comment composer if collapsed, then fill it. */
+export function buildFillCommentExpression(body: string): string {
+  // JSON.stringify for safe embedding of the draft text.
+  const textLit = JSON.stringify(body);
+  return `(async()=>{
+  const text = ${textLit};
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  function visible(el) {
+    if (!el) return false;
+    const s = window.getComputedStyle(el);
+    if (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0') return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  }
+
+  function findComposer() {
+    const selectors = [
+      '.comments-comment-box-comment__text-editor .ql-editor',
+      '.comments-comment-box__form .ql-editor',
+      'form.comments-comment-box__form div.ql-editor',
+      'div.comments-comment-texteditor .ql-editor',
+      'div.ql-editor[contenteditable="true"]',
+      'div[role="textbox"][contenteditable="true"]',
+      'div[contenteditable="true"][aria-label*="comment" i]',
+      'div[contenteditable="true"][data-placeholder*="comment" i]',
+    ];
+    for (const sel of selectors) {
+      try {
+        const el = document.querySelector(sel);
+        if (el && visible(el)) return el;
+      } catch (_) {}
+    }
+    // Broader: any visible contenteditable textbox in a comments region.
+    const regions = document.querySelectorAll(
+      '.comments-comment-box, .feed-shared-update-v2__comments-container, [class*="comments-comment"]'
+    );
+    for (const region of regions) {
+      const el = region.querySelector('[contenteditable="true"]');
+      if (el && visible(el)) return el;
+    }
+    return null;
+  }
+
+  function openComposer() {
+    if (findComposer()) return true;
+    const nodes = Array.from(
+      document.querySelectorAll('button, [role="button"]')
+    );
+    for (const el of nodes) {
+      if (!visible(el)) continue;
+      const label = (
+        el.getAttribute('aria-label') ||
+        el.innerText ||
+        el.textContent ||
+        ''
+      )
+        .replace(/\\s+/g, ' ')
+        .trim();
+      if (/^comment$/i.test(label) || /^comments$/i.test(label) || /^comment on /i.test(label)) {
+        el.click();
+        return true;
+      }
+    }
+    // Social-actions bar: button with "Comment" span.
+    for (const el of nodes) {
+      if (!visible(el)) continue;
+      const t = (el.innerText || '').replace(/\\s+/g, ' ').trim();
+      if (/^comment$/i.test(t)) {
+        el.click();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  openComposer();
+  await sleep(600);
+  let composer = findComposer();
+  if (!composer) {
+    openComposer();
+    await sleep(800);
+    composer = findComposer();
+  }
+  if (!composer) {
+    return { ok: false, reason: 'composer_not_found' };
+  }
+
+  composer.focus();
+  try {
+    document.execCommand('selectAll', false, undefined);
+    document.execCommand('delete', false, undefined);
+  } catch (_) {
+    composer.textContent = '';
+  }
+  // insertText fires beforeinput/input on most contenteditables (Quill-friendly).
+  const inserted = document.execCommand('insertText', false, text);
+  if (!inserted) {
+    composer.textContent = text;
+    composer.dispatchEvent(new InputEvent('input', { bubbles: true, data: text, inputType: 'insertText' }));
+  }
+  await sleep(100);
+  const got = (composer.innerText || composer.textContent || '').trim();
+  // Scroll composer into view so the human sees the draft.
+  try { composer.scrollIntoView({ block: 'center', behavior: 'smooth' }); } catch (_) {}
+  return {
+    ok: got.length > 0,
+    reason: got.length > 0 ? 'typed' : 'empty_after_type',
+    preview: got.slice(0, 120),
+    used_insert_text: !!inserted,
+  };
+})()`;
+}
+
+/**
+ * Stage a LinkedIn comment in the paired Chrome: navigate → fill composer →
+ * focus → notify. Never clicks Post/Submit.
+ */
+export async function prepareLinkedInComment(
+  dispatcher: ChromeActionDispatcher,
+  opts: {
+    postUrl: string;
+    body: string;
+    focus?: boolean;
+    notify?: boolean;
+  }
+): Promise<PrepareCommentResult> {
+  const body = opts.body.trim();
+  if (!body) {
+    throw new Error("prepare_comment: body must be non-empty");
+  }
+  const postUrl = normalizeLinkedInPostUrl(opts.postUrl);
+  if (!postUrl) {
+    throw new Error(
+      `prepare_comment: invalid post_url / activity_id: ${JSON.stringify(opts.postUrl)}`
+    );
+  }
+  const focus = opts.focus !== false;
+  const notify = opts.notify !== false;
+
+  const nav = await dispatcher.dispatch<{
+    tab_id?: number;
+    current_url?: string;
+    title?: string;
+  }>("navigate", {
+    url: postUrl,
+    open_in_new_tab: true,
+    wait_for_load: true,
+    ...chromeOriginsInput(),
+  });
+  const tabId = nav.tab_id;
+  if (typeof tabId !== "number") {
+    throw new Error("prepare_comment: navigate did not return tab_id");
+  }
+  if (isLinkedInAuthWall(nav.current_url)) {
+    throw new Error(
+      `Not logged into LinkedIn (landed on ${nav.current_url}). Sign in in the paired Chrome profile, then retry.`
+    );
+  }
+
+  // Give the post chrome a beat to hydrate the social-action bar.
+  try {
+    await dispatcher.dispatch("wait_for_selector", {
+      tab_id: tabId,
+      selector:
+        'button, [role="button"], .feed-shared-social-action-bar, .comments-comment-box',
+      timeout_ms: 8000,
+      ...chromeOriginsInput(),
+    });
+  } catch {
+    // Non-fatal — page may still be usable; fall through to a11y/evaluate.
+  }
+
+  let method: "type_ref" | "evaluate" = "evaluate";
+  let typed = false;
+
+  // Live spike (2026-07): LinkedIn's current feed/post UI rarely exposes the
+  // Quill composer as an a11y textbox after clicking Comment, so evaluate
+  // (contenteditable/ql-editor selectors + insertText) is the primary path.
+  // type_ref remains a secondary attempt when the tree does surface a textbox.
+  {
+    const evalOut = await dispatcher.dispatch<{
+      value?: {
+        ok?: boolean;
+        reason?: string;
+        preview?: string;
+      };
+      exception?: string;
+    }>("evaluate", {
+      tab_id: tabId,
+      expression: buildFillCommentExpression(body),
+      await_promise: true,
+      ...chromeOriginsInput(),
+    });
+    if (evalOut.exception) {
+      throw new Error(
+        `prepare_comment: evaluate failed: ${evalOut.exception}`
+      );
+    }
+    const value = evalOut.value;
+    if (value?.ok) {
+      method = "evaluate";
+      typed = true;
+    }
+  }
+
+  // Path B: a11y type_ref when evaluate missed the composer.
+  if (!typed) {
+    try {
+      let snap = await snapshotTree(dispatcher, tabId);
+      if (isLinkedInAuthWall(snap.current_url)) {
+        throw new Error(
+          `Not logged into LinkedIn (landed on ${snap.current_url}). Sign in in the paired Chrome profile, then retry.`
+        );
+      }
+
+      let textbox = pickCommentTextboxRef(snap.tree, snap.document_epoch);
+      if (!textbox) {
+        const commentBtn = pickCommentButtonRef(snap.tree, snap.document_epoch);
+        if (commentBtn) {
+          await dispatcher.dispatch("click_ref", {
+            tab_id: tabId,
+            ref: commentBtn,
+            ...chromeOriginsInput(),
+          });
+          snap = await snapshotTree(dispatcher, tabId);
+          textbox = pickCommentTextboxRef(snap.tree, snap.document_epoch);
+        }
+      }
+
+      if (textbox) {
+        await dispatcher.dispatch("type_ref", {
+          tab_id: tabId,
+          ref: textbox,
+          text: body,
+          clear_first: true,
+          ...chromeOriginsInput(),
+        });
+        method = "type_ref";
+        typed = true;
+      }
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        err.message.includes("Not logged into LinkedIn")
+      ) {
+        throw err;
+      }
+    }
+  }
+
+  if (!typed) {
+    throw new Error(
+      "prepare_comment: could not fill comment composer (evaluate + a11y both missed it). Is the post still available and commentable?"
+    );
+  }
+
+  if (focus) {
+    try {
+      await dispatcher.dispatch("focus_tab", {
+        tab_id: tabId,
+        draw_attention: true,
+        ...chromeOriginsInput(),
+      });
+    } catch {
+      // Focus is best-effort; the draft is still staged.
+    }
+  }
+
+  if (notify) {
+    try {
+      await dispatcher.dispatch("show_notification", {
+        title: "LinkedIn comment ready",
+        message:
+          "Draft is in the comment box — review and click Post yourself. Lobu did not submit.",
+        ...chromeOriginsInput(),
+      });
+    } catch {
+      // Notifications are optional (permission may be denied).
+    }
+  }
+
+  return {
+    prepared: true,
+    tab_id: tabId,
+    post_url: postUrl,
+    body,
+    method,
+    message:
+      "Comment staged in your browser. Review the draft and click Post yourself — Lobu did not submit.",
+  };
+}
+
 export function filterPostsSinceCheckpoint(
   posts: LinkedInPost[],
   checkpoint: LinkedInCheckpoint
@@ -842,8 +1366,8 @@ export default class LinkedInConnector extends ConnectorRuntime<
     key: "linkedin",
     name: "LinkedIn",
     description:
-      "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files.",
-    version: "3.1.2",
+      "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft in the browser for the human to Post.",
+    version: "3.2.0",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -1022,7 +1546,103 @@ export default class LinkedInConnector extends ConnectorRuntime<
         ),
       },
     },
+    actions: {
+      prepare_comment: {
+        key: "prepare_comment",
+        name: "Prepare comment",
+        description:
+          "Open a LinkedIn post in the paired Chrome browser, fill the comment box with a draft, focus the tab, and stop. The human must click Post — this action never submits.",
+        requiresApproval: true,
+        kind: "write",
+        annotations: {
+          openWorldHint: true,
+          destructiveHint: false,
+          idempotentHint: false,
+        },
+        inputSchema: {
+          type: "object",
+          required: ["body"],
+          properties: {
+            post_url: {
+              type: "string",
+              description:
+                'LinkedIn post URL, or activity id / URN (e.g. "https://www.linkedin.com/feed/update/urn:li:activity:123", "urn:li:activity:123", or "123").',
+            },
+            activity_id: {
+              type: "string",
+              description:
+                "Activity id when post_url is omitted (digits or urn:li:activity:…).",
+            },
+            body: {
+              type: "string",
+              description:
+                "Draft comment text. Left in the composer for the user to edit/send.",
+              minLength: 1,
+              maxLength: 3000,
+            },
+            focus: {
+              type: "boolean",
+              description:
+                "Bring the staged tab to the foreground (default true).",
+            },
+            notify: {
+              type: "boolean",
+              description:
+                "Show a desktop notification when the draft is ready (default true).",
+            },
+          },
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            prepared: { type: "boolean" },
+            tab_id: { type: "integer" },
+            post_url: { type: "string" },
+            body: { type: "string" },
+            method: { type: "string" },
+            message: { type: "string" },
+          },
+        },
+      },
+    },
   };
+
+  async execute(ctx: ActionContext): Promise<ActionResult> {
+    try {
+      if (ctx.actionKey !== "prepare_comment") {
+        return { success: false, error: `Unknown action: ${ctx.actionKey}` };
+      }
+      const body =
+        typeof ctx.input.body === "string" ? ctx.input.body.trim() : "";
+      if (!body) {
+        return { success: false, error: "body is required" };
+      }
+      const postUrlRaw =
+        (typeof ctx.input.post_url === "string" && ctx.input.post_url.trim()) ||
+        (typeof ctx.input.activity_id === "string" &&
+          ctx.input.activity_id.trim()) ||
+        "";
+      if (!postUrlRaw) {
+        return {
+          success: false,
+          error: "post_url or activity_id is required",
+        };
+      }
+      const dispatcher = requireExtensionDispatcher(ctx);
+      const output = await prepareLinkedInComment(dispatcher, {
+        postUrl: postUrlRaw,
+        body,
+        focus: ctx.input.focus !== false,
+        notify: ctx.input.notify !== false,
+      });
+      return { success: true, output };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
 
   async sync(
     ctx: SyncContext<LinkedInCheckpoint, LinkedInConfig>

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -689,6 +689,32 @@ function nameMatches(name: string | undefined, patterns: RegExp[]): boolean {
 }
 
 /**
+ * Labels that would *submit* a comment/post. prepare_comment must never click
+ * these — only the human hits Post.
+ */
+export function isCommentSubmitLabel(name: string | undefined | null): boolean {
+  if (!name) return false;
+  const n = name.replace(/\s+/g, " ").trim();
+  if (/^(post|submit|send|publish|share)$/i.test(n)) return true;
+  if (/^(post|submit|send)\s+(comment|reply)$/i.test(n)) return true;
+  return false;
+}
+
+/** Labels that open the composer (not submit). */
+export function isCommentOpenLabel(name: string | undefined | null): boolean {
+  if (!name) return false;
+  if (isCommentSubmitLabel(name)) return false;
+  const n = name.replace(/\s+/g, " ").trim();
+  return (
+    /^comment$/i.test(n) ||
+    /^comments$/i.test(n) ||
+    /^comment on /i.test(n) ||
+    /^leave a comment/i.test(n) ||
+    /^post a comment/i.test(n)
+  );
+}
+
+/**
  * Prefer the social-action "Comment" control (not "Add a comment…" textbox,
  * not "Post" submit). Names vary by locale; English-first for the spike.
  */
@@ -696,12 +722,6 @@ export function pickCommentButtonRef(
   tree: A11yNode[],
   documentEpoch: number
 ): ElementRef | null {
-  const patterns = [
-    /^comment$/i,
-    /^comments$/i,
-    /^comment on /i,
-    /^leave a comment/i,
-  ];
   // Prefer explicit buttons over links/generics.
   const ranked = [...tree].sort((a, b) => {
     const score = (n: A11yNode) =>
@@ -709,9 +729,10 @@ export function pickCommentButtonRef(
     return score(a) - score(b);
   });
   for (const node of ranked) {
-    if (!nameMatches(node.name, patterns)) continue;
+    if (!isCommentOpenLabel(node.name)) continue;
     // Skip textboxes that happen to have "comment" in the name.
     if (node.role === "textbox" || node.tag === "textarea") continue;
+    if (isCommentSubmitLabel(node.name)) continue;
     return { document_epoch: documentEpoch, ref_id: node.ref_id };
   }
   return null;
@@ -755,27 +776,6 @@ export function pickCommentTextboxRef(
       document_epoch: documentEpoch,
       ref_id: emptyTextboxes[0]!.ref_id,
     };
-  }
-  return null;
-}
-
-/**
- * Never match the submit control — prepare_comment must not click these.
- * Used only as a guard if we ever expand auto-click behavior.
- */
-export function pickCommentSubmitRef(
-  tree: A11yNode[],
-  documentEpoch: number
-): ElementRef | null {
-  const patterns = [/^post$/i, /^comment$/i, /^submit$/i, /^send$/i];
-  for (const node of tree) {
-    if (node.role !== "button" && node.tag !== "button") continue;
-    if (!nameMatches(node.name, patterns)) continue;
-    // "Comment" social action is not the submit once the composer is open;
-    // submit is usually "Post" in English. Keep this helper for tests.
-    if (/^post$/i.test(node.name?.trim() ?? "")) {
-      return { document_epoch: documentEpoch, ref_id: node.ref_id };
-    }
   }
   return null;
 }
@@ -1002,6 +1002,25 @@ export function buildFillCommentExpression(body: string): string {
     return null;
   }
 
+  // SAFETY: never click submit controls. Only the human posts.
+  function isSubmitLabel(label) {
+    const n = String(label || '').replace(/\\s+/g, ' ').trim();
+    if (/^(post|submit|send|publish|share)$/i.test(n)) return true;
+    if (/^(post|submit|send)\\s+(comment|reply)$/i.test(n)) return true;
+    return false;
+  }
+  function isOpenLabel(label) {
+    if (isSubmitLabel(label)) return false;
+    const n = String(label || '').replace(/\\s+/g, ' ').trim();
+    return (
+      /^comment$/i.test(n) ||
+      /^comments$/i.test(n) ||
+      /^comment on /i.test(n) ||
+      /^leave a comment/i.test(n) ||
+      /^post a comment/i.test(n)
+    );
+  }
+
   function openComposer() {
     if (findComposer()) return true;
     const nodes = Array.from(
@@ -1017,16 +1036,8 @@ export function buildFillCommentExpression(body: string): string {
       )
         .replace(/\\s+/g, ' ')
         .trim();
-      if (/^comment$/i.test(label) || /^comments$/i.test(label) || /^comment on /i.test(label)) {
-        el.click();
-        return true;
-      }
-    }
-    // Social-actions bar: button with "Comment" span.
-    for (const el of nodes) {
-      if (!visible(el)) continue;
-      const t = (el.innerText || '').replace(/\\s+/g, ' ').trim();
-      if (/^comment$/i.test(t)) {
+      if (isSubmitLabel(label)) continue;
+      if (isOpenLabel(label)) {
         el.click();
         return true;
       }
@@ -1053,7 +1064,7 @@ export function buildFillCommentExpression(body: string): string {
   } catch (_) {
     composer.textContent = '';
   }
-  // insertText fires beforeinput/input on most contenteditables (Quill-friendly).
+  // insertText only — never Enter / Cmd+Enter (those can submit on LinkedIn).
   const inserted = document.execCommand('insertText', false, text);
   if (!inserted) {
     composer.textContent = text;
@@ -1061,20 +1072,27 @@ export function buildFillCommentExpression(body: string): string {
   }
   await sleep(100);
   const got = (composer.innerText || composer.textContent || '').trim();
-  // Scroll composer into view so the human sees the draft.
+  // Scroll composer into view so the human sees the draft. Do NOT click Post.
   try { composer.scrollIntoView({ block: 'center', behavior: 'smooth' }); } catch (_) {}
   return {
     ok: got.length > 0,
     reason: got.length > 0 ? 'typed' : 'empty_after_type',
     preview: got.slice(0, 120),
     used_insert_text: !!inserted,
+    submitted: false,
   };
 })()`;
 }
 
 /**
  * Stage a LinkedIn comment in the paired Chrome: navigate → fill composer →
- * focus → notify. Never clicks Post/Submit.
+ * focus → notify.
+ *
+ * HARD RULE — never auto-post:
+ *  - never click Post / Submit / Send
+ *  - never press Enter / Cmd+Enter after typing
+ *  - only open the composer (Comment) + type draft text
+ * The human must click Post themselves.
  */
 export async function prepareLinkedInComment(
   dispatcher: ChromeActionDispatcher,
@@ -1104,7 +1122,25 @@ export async function prepareLinkedInComment(
   const banner = opts.banner !== false;
   const reasonPreview = truncateHandoffReason(opts.reason);
 
-  const nav = await dispatcher.dispatch<{
+  // Refuse accidental submit clicks through the chrome dispatcher.
+  const safeDispatch: ChromeActionDispatcher = {
+    dispatch: async (action_key, action_input) => {
+      if (action_key === "click_ref") {
+        if (action_input.allowed_click !== "comment_open") {
+          throw new Error(
+            "prepare_comment: blocked click_ref — only comment-open is allowed (never Post/submit)"
+          );
+        }
+      }
+      const { allowed_click: _allowed, ...input } = action_input as Record<
+        string,
+        unknown
+      > & { allowed_click?: string };
+      return dispatcher.dispatch(action_key, input);
+    },
+  };
+
+  const nav = await safeDispatch.dispatch<{
     tab_id?: number;
     current_url?: string;
     title?: string;
@@ -1126,7 +1162,7 @@ export async function prepareLinkedInComment(
 
   // Give the post chrome a beat to hydrate the social-action bar.
   try {
-    await dispatcher.dispatch("wait_for_selector", {
+    await safeDispatch.dispatch("wait_for_selector", {
       tab_id: tabId,
       selector:
         'button, [role="button"], .feed-shared-social-action-bar, .comments-comment-box',
@@ -1145,11 +1181,12 @@ export async function prepareLinkedInComment(
   // (contenteditable/ql-editor selectors + insertText) is the primary path.
   // type_ref remains a secondary attempt when the tree does surface a textbox.
   {
-    const evalOut = await dispatcher.dispatch<{
+    const evalOut = await safeDispatch.dispatch<{
       value?: {
         ok?: boolean;
         reason?: string;
         preview?: string;
+        submitted?: boolean;
       };
       exception?: string;
     }>("evaluate", {
@@ -1162,6 +1199,11 @@ export async function prepareLinkedInComment(
       throw new Error(`prepare_comment: evaluate failed: ${evalOut.exception}`);
     }
     const value = evalOut.value;
+    if (value?.submitted === true) {
+      throw new Error(
+        "prepare_comment: fill expression reported submitted=true — aborting (must never auto-post)"
+      );
+    }
     if (value?.ok) {
       method = "evaluate";
       typed = true;
@@ -1169,9 +1211,10 @@ export async function prepareLinkedInComment(
   }
 
   // Path B: a11y type_ref when evaluate missed the composer.
+  // Only click "Comment" open controls; never Post/submit.
   if (!typed) {
     try {
-      let snap = await snapshotTree(dispatcher, tabId);
+      let snap = await snapshotTree(safeDispatch, tabId);
       if (isLinkedInAuthWall(snap.current_url)) {
         throw new Error(
           `Not logged into LinkedIn (landed on ${snap.current_url}). Sign in in the paired Chrome profile, then retry.`
@@ -1182,18 +1225,25 @@ export async function prepareLinkedInComment(
       if (!textbox) {
         const commentBtn = pickCommentButtonRef(snap.tree, snap.document_epoch);
         if (commentBtn) {
-          await dispatcher.dispatch("click_ref", {
+          const btnNode = snap.tree.find((n) => n.ref_id === commentBtn.ref_id);
+          if (btnNode && isCommentSubmitLabel(btnNode.name)) {
+            throw new Error(
+              "prepare_comment: refused to click submit-labelled control"
+            );
+          }
+          await safeDispatch.dispatch("click_ref", {
             tab_id: tabId,
             ref: commentBtn,
+            allowed_click: "comment_open",
             ...chromeOriginsInput(),
           });
-          snap = await snapshotTree(dispatcher, tabId);
+          snap = await snapshotTree(safeDispatch, tabId);
           textbox = pickCommentTextboxRef(snap.tree, snap.document_epoch);
         }
       }
 
       if (textbox) {
-        await dispatcher.dispatch("type_ref", {
+        await safeDispatch.dispatch("type_ref", {
           tab_id: tabId,
           ref: textbox,
           text: body,
@@ -1206,7 +1256,9 @@ export async function prepareLinkedInComment(
     } catch (err) {
       if (
         err instanceof Error &&
-        err.message.includes("Not logged into LinkedIn")
+        (err.message.includes("Not logged into LinkedIn") ||
+          err.message.includes("refused to click") ||
+          err.message.includes("blocked click_ref"))
       ) {
         throw err;
       }
@@ -1222,7 +1274,7 @@ export async function prepareLinkedInComment(
   let bannerShown = false;
   if (banner) {
     try {
-      const bannerOut = await dispatcher.dispatch<{
+      const bannerOut = await safeDispatch.dispatch<{
         value?: { ok?: boolean; anchored?: boolean };
         exception?: string;
       }>("evaluate", {
@@ -1241,11 +1293,9 @@ export async function prepareLinkedInComment(
 
   if (focus) {
     try {
-      await dispatcher.dispatch("focus_tab", {
+      await safeDispatch.dispatch("focus_tab", {
         tab_id: tabId,
         draw_attention: true,
-        // Open Owletto sidepanel so Memory can show this parent run (holder_run_id
-        // is stamped on the tab by chrome navigate).
         open_sidepanel: true,
         ...chromeOriginsInput(),
       });
@@ -1259,7 +1309,7 @@ export async function prepareLinkedInComment(
       const notifyMsg = reasonPreview
         ? `Draft ready — ${reasonPreview}`
         : "Draft is in the comment box — review and click Post yourself. Lobu did not submit.";
-      await dispatcher.dispatch("show_notification", {
+      await safeDispatch.dispatch("show_notification", {
         title: "LinkedIn comment ready",
         message: notifyMsg.slice(0, 240),
         tab_id: tabId,
@@ -1726,7 +1776,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
         key: "prepare_comment",
         name: "Prepare comment",
         description:
-          "Open a LinkedIn post in the paired Chrome browser, fill the comment box with a draft, focus the tab, and stop. The human must click Post — this action never submits.",
+          "Stage a comment draft on LinkedIn in the paired Chrome browser (open post, fill composer, banner). NEVER submits — the human must click Post. No auto-post path exists.",
         requiresApproval: true,
         kind: "write",
         annotations: {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -1069,6 +1069,9 @@ export async function prepareLinkedInComment(
       await dispatcher.dispatch("focus_tab", {
         tab_id: tabId,
         draw_attention: true,
+        // Open Owletto sidepanel so Memory can show this parent run (holder_run_id
+        // is stamped on the tab by chrome navigate).
+        open_sidepanel: true,
         ...chromeOriginsInput(),
       });
     } catch {
@@ -1082,6 +1085,8 @@ export async function prepareLinkedInComment(
         title: "LinkedIn comment ready",
         message:
           "Draft is in the comment box — review and click Post yourself. Lobu did not submit.",
+        tab_id: tabId,
+        click_url: postUrl,
         ...chromeOriginsInput(),
       });
     } catch {

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -445,17 +445,29 @@ async function executeActionRun(
         // `executeLocalActionInline`, which merges the connection's own config
         // so an action can read e.g. a `restaurants_url`), this worker-fleet
         // action path does not yet receive per-connection config (the poll
-        // response doesn't carry it). Connectors whose actions need connection
-        // config — and the extension-driving ones, which also need an
-        // onChromeDispatch hook not wired here — run on the inline path. If a
-        // future connector needs config on the fleet path, plumb the
-        // connection config into the action poll response and merge it here.
+        // response doesn't carry it). If a future connector needs config on the
+        // fleet path, plumb the connection config into the action poll response
+        // and merge it here.
+        //
+        // Chrome: onChromeDispatch is wired the same as sync jobs so
+        // prepare_comment / other extension-driving actions can stage UI via
+        // the paired Owletto extension (parent_run_id = this action run).
         actionKey: action_key,
         actionInput: (action_input ?? {}) as Record<string, unknown>,
         config: mergeEnv(env, job.connection_credentials, null),
         env,
         sessionState: null,
         credentials: credentials ?? null,
+      },
+      hooks: {
+        onChromeDispatch: async (actionKey, actionInput) => {
+          return client.dispatchChromeAction({
+            parent_run_id: run_id,
+            worker_id: client.id,
+            action_key: actionKey,
+            action_input: actionInput,
+          });
+        },
       },
     });
 

--- a/packages/server/src/__tests__/integration/dispatch-chrome-action-parent.test.ts
+++ b/packages/server/src/__tests__/integration/dispatch-chrome-action-parent.test.ts
@@ -1,0 +1,44 @@
+import { Hono } from 'hono';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { dispatchChromeAction } from '../../worker-api/dispatch-chrome-action';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization } from '../setup/test-fixtures';
+
+const sql = getTestDb();
+const app = new Hono<{ Bindings: Env }>();
+app.post('/dispatch', dispatchChromeAction);
+
+describe('dispatchChromeAction parent run authorization', () => {
+  beforeEach(cleanupTestDatabase);
+  afterAll(cleanupTestDatabase);
+
+  it('accepts a claimed connector action parent', async () => {
+    const org = await createTestOrganization({ name: 'Chrome action parent' });
+    const [run] = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, action_key, status, claimed_by, claimed_at
+      ) VALUES (
+        ${org.id}, 'action', 'prepare_comment', 'running', 'connector-worker-1', NOW()
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    const response = await app.request('/dispatch', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        parent_run_id: Number(run.id),
+        worker_id: 'connector-worker-1',
+        action_key: 'navigate',
+        action_input: { url: 'https://www.linkedin.com/' },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'failed',
+      error_message: expect.stringContaining('No online paired Owletto'),
+    });
+  });
+});

--- a/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
@@ -90,6 +90,9 @@ describe('deep-link token exchange', () => {
     expect(html).toContain('sessionStorage');
     expect(html).toContain('location.hash');
     expect(html).toContain('replaceState');
+    // Browser-handoff deep link (sidepanel → Memory run).
+    expect(html).toContain('h.get("run")');
+    expect(html).toContain('/#run=');
   });
 
   // The load-bearing claim: the session token from /extension-session, sent as

--- a/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
@@ -90,10 +90,8 @@ describe('deep-link token exchange', () => {
     expect(html).toContain('sessionStorage');
     expect(html).toContain('location.hash');
     expect(html).toContain('replaceState');
-    // Browser-handoff deep link (sidepanel → Memory run / conversation).
+    // Browser-handoff deep link (sidepanel → Memory run).
     expect(html).toContain('h.get("run")');
-    expect(html).toContain('h.get("agent")');
-    expect(html).toContain('h.get("thread")');
     expect(html).toContain('/#run=');
   });
 

--- a/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
@@ -90,8 +90,10 @@ describe('deep-link token exchange', () => {
     expect(html).toContain('sessionStorage');
     expect(html).toContain('location.hash');
     expect(html).toContain('replaceState');
-    // Browser-handoff deep link (sidepanel → Memory run).
+    // Browser-handoff deep link (sidepanel → Memory run / conversation).
     expect(html).toContain('h.get("run")');
+    expect(html).toContain('h.get("agent")');
+    expect(html).toContain('h.get("thread")');
     expect(html).toContain('/#run=');
   });
 

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -536,23 +536,14 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
   var token = h.get("token") || "";
   var worker = h.get("worker") || "";
   var run = h.get("run") || "";
-  var agent = h.get("agent") || "";
-  var thread = h.get("thread") || "";
-  var event = h.get("event") || "";
-  var message = h.get("message") || "";
   // Strip the token out of the URL before doing anything else.
   history.replaceState(null, "", location.pathname);
-  // Chrome extension deep links (sidepanel): device page, Memory run, or chat.
+  // Chrome extension deep links (sidepanel): device page or Memory run.
   // Prefer run over worker when both are present — handoff panels care about
-  // the staged action, not the device. Optional agent/thread/event/message
-  // ride alongside run for conversation + scroll targets.
+  // the staged action, not the device.
   var next = "/";
   if (run) {
     next = "/#run=" + encodeURIComponent(run);
-    if (agent) next += "&agent=" + encodeURIComponent(agent);
-    if (thread) next += "&thread=" + encodeURIComponent(thread);
-    if (event) next += "&event=" + encodeURIComponent(event);
-    if (message) next += "&message=" + encodeURIComponent(message);
   } else if (worker) {
     next = "/#worker=" + encodeURIComponent(worker);
   }

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -536,16 +536,26 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
   var token = h.get("token") || "";
   var worker = h.get("worker") || "";
   var run = h.get("run") || "";
+  var agent = h.get("agent") || "";
+  var thread = h.get("thread") || "";
+  var event = h.get("event") || "";
+  var message = h.get("message") || "";
   // Strip the token out of the URL before doing anything else.
   history.replaceState(null, "", location.pathname);
-  // Chrome extension deep links (sidepanel): device page or a Memory run.
+  // Chrome extension deep links (sidepanel): device page, Memory run, or chat.
   // Prefer run over worker when both are present — handoff panels care about
-  // the staged action, not the device.
-  var next = run
-    ? "/#run=" + encodeURIComponent(run)
-    : worker
-      ? "/#worker=" + encodeURIComponent(worker)
-      : "/";
+  // the staged action, not the device. Optional agent/thread/event/message
+  // ride alongside run for conversation + scroll targets.
+  var next = "/";
+  if (run) {
+    next = "/#run=" + encodeURIComponent(run);
+    if (agent) next += "&agent=" + encodeURIComponent(agent);
+    if (thread) next += "&thread=" + encodeURIComponent(thread);
+    if (event) next += "&event=" + encodeURIComponent(event);
+    if (message) next += "&message=" + encodeURIComponent(message);
+  } else if (worker) {
+    next = "/#worker=" + encodeURIComponent(worker);
+  }
   if (!token) { location.replace("/"); return; }
   var retried = false;
   function fail(msg) {

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -535,9 +535,17 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
   var h = new URLSearchParams(location.hash.slice(1));
   var token = h.get("token") || "";
   var worker = h.get("worker") || "";
+  var run = h.get("run") || "";
   // Strip the token out of the URL before doing anything else.
   history.replaceState(null, "", location.pathname);
-  var next = worker ? "/#worker=" + encodeURIComponent(worker) : "/";
+  // Chrome extension deep links (sidepanel): device page or a Memory run.
+  // Prefer run over worker when both are present — handoff panels care about
+  // the staged action, not the device.
+  var next = run
+    ? "/#run=" + encodeURIComponent(run)
+    : worker
+      ? "/#worker=" + encodeURIComponent(worker)
+      : "/";
   if (!token) { location.replace("/"); return; }
   var retried = false;
   function fail(msg) {

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -5,7 +5,7 @@
  * call a chrome connector action against the paired Owletto extension in
  * the same org. We:
  *
- *   1. Look up the parent sync run's org (+ optional data connection) from runs.
+ *   1. Look up the parent connector run's org (+ optional data connection) from runs.
  *   2. Pick an online chrome connection / extension (prefer parent connection's
  *      chrome-extension pin when set — browser affinity for LinkedIn/X/etc.).
  *   3. Enqueue an action run via `createConnectorOperationRun` (the same
@@ -84,7 +84,7 @@ export type ResolveOnlineChromeOptions = {
    * Prefer this device_workers.id when it is an online debugger-capable
    * chrome-extension. Used for browser affinity: a LinkedIn/X/Revolut
    * connection may set device_worker_id to a chrome-extension worker to mean
-   * "scrape with this browser" (parent sync still runs on the fleet — see
+   * "scrape with this browser" (the parent connector run stays on the fleet — see
    * poll.ts browser-affinity claim rules).
    */
   preferredDeviceWorkerId?: string | null;
@@ -506,9 +506,9 @@ export async function resolveOnlineChromeConnection(
 }
 
 /**
- * Look up browser affinity for a parent sync: if the data connection is pinned
+ * Look up browser affinity for a parent connector run: if its data connection is pinned
  * to a chrome-extension worker, that pin means "use this browser" (not "run
- * the parent sync on the extension" — see poll.ts).
+ * the parent connector on the extension" — see poll.ts).
  */
 export async function preferredBrowserWorkerForConnection(
   connectionId: number | null | undefined,
@@ -538,10 +538,10 @@ export async function dispatchChromeActionToExtension(params: {
   organizationId: string;
   actionKey: string;
   actionInput: Record<string, unknown>;
-  /** Parent run id, for log correlation only. */
+  /** Parent connector run id, also used to scope extension-owned tabs. */
   parentRunId?: number;
   /**
-   * Data connection that owns the parent sync (e.g. LinkedIn). When pinned to
+   * Data connection that owns the parent connector run (e.g. LinkedIn). When pinned to
    * a chrome-extension, scrapes target that browser.
    */
   parentConnectionId?: number | null;
@@ -577,7 +577,7 @@ export async function dispatchChromeActionToExtension(params: {
   }
 
   // Stamp holder_run_id on every chrome action so the extension can scope
-  // scratch-tab ownership/cleanup to the parent sync run.
+  // scratch-tab ownership/cleanup to the parent connector run.
   const operationInput: Record<string, unknown> = { ...(actionInput ?? {}) };
   if (
     parentRunId != null &&
@@ -648,7 +648,8 @@ export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {
 
   const sql = getDb();
 
-  // Authorize: parent run must exist, be a running sync claimed by this worker.
+  // Authorize: parent run must exist, be a running connector execution claimed
+  // by this worker. Both sync() and execute() receive chrome_dispatcher.
   // connection_id drives browser affinity when pinned to a chrome-extension.
   const parentRows = (await sql`
     SELECT r.organization_id, r.status, r.claimed_by, r.run_type, r.connection_id
@@ -675,9 +676,9 @@ export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {
   if (parentRun.claimed_by !== body.worker_id) {
     return c.json({ error: 'parent_run is not claimed by this worker' }, 403);
   }
-  if (parentRun.run_type !== 'sync') {
+  if (parentRun.run_type !== 'sync' && parentRun.run_type !== 'action') {
     return c.json(
-      { error: `parent_run must be a sync run, got ${parentRun.run_type}` },
+      { error: `parent_run must be a sync or action run, got ${parentRun.run_type}` },
       400
     );
   }


### PR DESCRIPTION
## Summary

Browser-handoff for LinkedIn comments:

1. **`prepare_comment`** (example LinkedIn connector) — open post in paired Owletto Chrome, fill draft, show banner, focus/notify. **Never clicks Post** (hard guards + tests).
2. **Sidepanel** — owned tab with `holder_run_id` deep-links Memory with peek open (`?peek=1&peek_run_id=`).
3. **Peek URL sync** — activity click sticks namespaced peek keys so reload/share match click.
4. **Chrome dispatch** — claimed **action** parents allowed (not only `sync`), so connector execute() can drive chrome.

## Guarantees (no auto-post)

- Only open Comment composer + `insertText` (no Enter / Cmd+Enter)
- `click_ref` blocked unless `allowed_click=comment_open`
- Submit labels (Post/Send/…) never treated as open controls
- `requiresApproval: true` on the action

## Not in this PR

- Detect human Post / scrape verification of published comment (next: connection read action)
- Conversation-first deep-link when agent+thread stamped (simplified to Memory+peek)

## Test plan

- [x] `bun test examples/personal-agent/__tests__/linkedin.connector.test.ts` (74)
- [x] Owletto peek/activity unit tests
- [x] Live Chrome fill+banner (earlier spike)
- [ ] Reload Owletto extension from branch; activity click → URL gains peek params
- [ ] `lobu apply` LinkedIn; end-to-end prepare_comment via connection
- [ ] Confirm no auto-Post in real browser