### PR TITLE
fix(mcp): bind the worker token's verified agent identity to the MCP session

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/worker-agent-identity.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/worker-agent-identity.test.ts
@@ -1,0 +1,212 @@
+import { generateWorkerToken } from '@lobu/core';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+
+const AGENT_ID = 'personal-agent';
+const OTHER_AGENT_ID = 'other-agent';
+
+describe('worker MCP session agent identity', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let workerToken: string;
+  let otherWorkerToken: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({ name: 'Worker Identity Org' });
+    user = await createTestUser({});
+    await addUserToOrganization(user.id, org.id, 'owner');
+    await createTestAgent({
+      organizationId: org.id,
+      agentId: AGENT_ID,
+      ownerUserId: user.id,
+    });
+    await createTestAgent({
+      organizationId: org.id,
+      agentId: OTHER_AGENT_ID,
+      ownerUserId: user.id,
+    });
+    workerToken = generateWorkerToken(user.id, 'conv-agent-turn-1', 'test-deployment', {
+      channelId: 'api-conv-agent-turn-1',
+      agentId: AGENT_ID,
+      organizationId: org.id,
+      platform: 'api',
+      source: 'internal',
+    });
+    otherWorkerToken = generateWorkerToken(user.id, 'conv-agent-turn-2', 'test-deployment', {
+      channelId: 'api-conv-agent-turn-2',
+      agentId: OTHER_AGENT_ID,
+      organizationId: org.id,
+      platform: 'api',
+      source: 'internal',
+    });
+  });
+
+  /** Mirror the gateway proxy handshake, whose initialize metadata omits agentId. */
+  async function initWorkerMcpSession(options?: {
+    clientInfoAgentId?: string;
+  }): Promise<string> {
+    const initResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: {
+            name: 'lobu-gateway',
+            version: '1.0.0',
+            ...(options?.clientInfoAgentId ? { agentId: options.clientInfoAgentId } : {}),
+          },
+        },
+        id: 0,
+      },
+      token: workerToken,
+      headers: { 'X-Lobu-Memory-Direct-Auth': '1' },
+    });
+    expect(initResponse.status).toBe(200);
+    const sessionId = initResponse.headers.get('mcp-session-id');
+    if (!sessionId) {
+      throw new Error(
+        `initialize returned no mcp-session-id: ${JSON.stringify(await initResponse.json())}`
+      );
+    }
+    await post(`/mcp/${org.slug}`, {
+      body: { jsonrpc: '2.0', method: 'notifications/initialized' },
+      token: workerToken,
+      headers: {
+        'X-Lobu-Memory-Direct-Auth': '1',
+        'mcp-session-id': sessionId,
+      },
+    });
+    return sessionId;
+  }
+
+  async function callTool<T>(
+    sessionId: string,
+    name: string,
+    args: Record<string, unknown>,
+    token = workerToken
+  ): Promise<T> {
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name, arguments: args },
+      },
+      token,
+      headers: {
+        'X-Lobu-Memory-Direct-Auth': '1',
+        'X-MCP-Format': 'json',
+        'mcp-session-id': sessionId,
+      },
+    });
+    const json = await response.json();
+    if (json.error) {
+      throw new Error(`MCP error [${json.error.code}]: ${json.error.message}`);
+    }
+    if (json.result?.isError) {
+      throw new Error(json.result.content?.[0]?.text ?? 'tool call failed');
+    }
+    return JSON.parse(json.result.content[0].text) as T;
+  }
+
+  it('queues a person merge from an agent conversation turn for human approval instead of applying it', async () => {
+    const sessionId = await initWorkerMcpSession();
+    const winner = await createTestEntity({
+      name: 'Jane Doe',
+      entity_type: 'person',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    const loser = await createTestEntity({
+      name: 'J. Doe',
+      entity_type: 'person',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+
+    const result = await callTool<{
+      approval_queued?: boolean;
+      approval_run_id?: number;
+    }>(sessionId, 'manage_entity', {
+      action: 'merge',
+      entity_id: loser.id,
+      winner_entity_id: winner.id,
+    });
+
+    expect(result.approval_queued).toBe(true);
+    expect(result.approval_run_id).toEqual(expect.any(Number));
+
+    const sql = getTestDb();
+    const [entity] = await sql`
+      SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+    `;
+    expect(entity.merged_into).toBeNull();
+    expect(entity.deleted_at).toBeNull();
+    const [run] = await sql`
+      SELECT approval_status FROM runs WHERE id = ${result.approval_run_id}
+    `;
+    expect(run.approval_status).toBe('pending');
+  });
+
+  it('binds the token-verified agent even when initialize clientInfo names a different agent', async () => {
+    const sql = getTestDb();
+    await sql`
+      UPDATE agents SET last_used_at = NULL
+      WHERE organization_id = ${org.id} AND id IN (${AGENT_ID}, ${OTHER_AGENT_ID})
+    `;
+
+    // A compromised/misbehaving client could ask for another agent's identity
+    // in clientInfo — the worker JWT's binding must win.
+    const sessionId = await initWorkerMcpSession({ clientInfoAgentId: OTHER_AGENT_ID });
+    await callTool(sessionId, 'manage_entity', { action: 'list', entity_type: 'person' });
+
+    const rows = await sql<{ id: string; last_used_at: string | null }[]>`
+      SELECT id, last_used_at FROM agents
+      WHERE organization_id = ${org.id} AND id IN (${AGENT_ID}, ${OTHER_AGENT_ID})
+      ORDER BY id
+    `;
+    const byId = new Map(rows.map((r) => [r.id, r.last_used_at]));
+    expect(byId.get(AGENT_ID)).not.toBeNull();
+    expect(byId.get(OTHER_AGENT_ID)).toBeNull();
+  });
+
+  it('rejects switching an established live session to another worker agent', async () => {
+    const sessionId = await initWorkerMcpSession();
+
+    await expect(
+      callTool(sessionId, 'manage_entity', { action: 'list' }, otherWorkerToken)
+    ).rejects.toThrow('Session agent changed. Re-initialize.');
+  });
+
+  it('recovers a persisted worker session with the same verified agent', async () => {
+    const sessionId = await initWorkerMcpSession();
+    clearInMemoryMcpSessionsForTests();
+
+    await expect(
+      callTool(sessionId, 'manage_entity', { action: 'list' })
+    ).resolves.toBeDefined();
+  });
+
+  it('rejects switching a recovered session to another worker agent', async () => {
+    const sessionId = await initWorkerMcpSession();
+    clearInMemoryMcpSessionsForTests();
+
+    await expect(
+      callTool(sessionId, 'manage_entity', { action: 'list' }, otherWorkerToken)
+    ).rejects.toThrow('MCP session expired or not recognized.');
+  });
+});

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -550,7 +550,16 @@ async function recoverSessionAuthContext(
     }
   }
 
-  authCtx.requestedAgentId = persisted.requestedAgentId;
+  // A recovered session cannot move between agents. When the persisted row is
+  // unbound, verified request auth may supply one; conflicting bindings fail.
+  if (
+    authCtx.requestedAgentId &&
+    persisted.requestedAgentId &&
+    authCtx.requestedAgentId !== persisted.requestedAgentId
+  ) {
+    return null;
+  }
+  authCtx.requestedAgentId = persisted.requestedAgentId ?? authCtx.requestedAgentId;
   authCtx.instructions = authCtx.organizationId
     ? ((await buildWorkspaceInstructions(authCtx.organizationId)) ?? undefined)
     : undefined;
@@ -776,7 +785,9 @@ async function resolveAuthWithInstructions(
   const authCtx: AuthContext & { instructions?: string } = extractAuthContext(c);
   if (req) {
     const initialize = await readInitializeRequest(req);
-    authCtx.requestedAgentId = initialize?.requestedAgentId ?? null;
+    // Verified worker auth already supplies an agent. Only fall back to the
+    // initialize metadata used by ordinary MCP clients when auth has none.
+    authCtx.requestedAgentId = authCtx.requestedAgentId ?? initialize?.requestedAgentId ?? null;
   }
   if (authCtx.organizationId) {
     authCtx.instructions = (await buildWorkspaceInstructions(authCtx.organizationId)) ?? undefined;
@@ -931,6 +942,11 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
       // auth context current before tools read ToolContext.sourceContext.
       session.authCtx.sourceContext = freshCtx.sourceContext ?? null;
       session.authCtx.adminTools = freshCtx.adminTools ?? null;
+
+      if (freshCtx.agentId && freshCtx.agentId !== session.authCtx.agentId) {
+        clearSession();
+        return buildJsonRpcErrorResponse('Session agent changed. Re-initialize.', null, 400);
+      }
 
       if (session.authCtx.scopedToOrg) {
         if (freshCtx.organizationId !== session.authCtx.organizationId) {


### PR DESCRIPTION
An agent conversation turn (conversations.send -> agent-worker -> MCP tool calls) executed every SDK write classified as the human user, because resolveAuthWithInstructions overwrote the JWT-verified agent binding with the initialize body's clientInfo value — which the gateway proxy sends bare, so the binding became null. With ToolContext.agentId null, resolveActingPrincipal classified the actor as "user" and every approval gate keyed on actor.kind !== "user" was bypassed. Reproduced in prod: a personal-agent turn merged 8 person entities instantly with decision "human" instead of queuing review approvals.

Fix, all in mcp-handler.ts:
- Token-verified agent binding wins; initialize metadata only fills in when auth carries no agent (also blocks clientInfo spoofing a different agent id).
- Recovered sessions refuse a conflicting persisted-vs-token binding (404 -> client re-initializes); an unbound persisted row adopts the token binding.
- A live session whose caller agent changes is cleared with 400 "Session agent changed. Re-initialize.", matching the existing userId/clientId guards.

Evidence: new worker-agent-identity.test.ts reproduced the bypass red (merge applied instantly, no approval run) and passes green post-fix (merge queues a pending approval, entities stay unmerged; spoof + session-switch cases covered). Suites: integration/mcp + integration/entities + guardrails-runtime 128 pass; full make test-integration green against pgvector Postgres; make pre-pr clean; review verdict bug_free 94, 0 blockers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP session security by consistently binding sessions to the verified worker agent.
  * Prevented sessions from switching agents during active use or recovery.
  * Rejected conflicting agent identities and prompted re-initialization when necessary.
  * Ensured approval-based entity merges remain pending instead of being applied immediately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->