### PR TITLE
feat(linkedin): verify_staged_comment + conversation handoff stamps

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1298,24 +1298,39 @@ describe("prepare_comment helpers", () => {
     expect(action?.kind).toBe("read");
     expect(action?.annotations?.destructiveHint).toBe(false);
     expect(action?.annotations?.idempotentHint).toBe(true);
+    expect(
+      action?.outputSchema?.properties?.match?.properties?.match_kind?.enum
+    ).toEqual(["exact", "prefix", "contains"]);
   });
 
-  test("commentBodiesMatch normalizes and tolerates truncation", () => {
+  test("commentBodiesMatch normalizes without accepting weak partial matches", () => {
     expect(normalizeCommentMatchText("  Hello\nWorld  ")).toBe("hello world");
     expect(commentBodiesMatch("Hello world", "Hello world").ok).toBe(true);
     expect(commentBodiesMatch("Hello world", "Hello world").kind).toBe("exact");
     expect(
       commentBodiesMatch(
-        "Great insight thanks",
-        "Great insight thanks for more context"
-      ).ok
-    ).toBe(true);
+        "A sufficiently distinctive draft body that continues after truncation",
+        "A sufficiently distinctive draft body"
+      ).kind
+    ).toBe("prefix");
     expect(
       commentBodiesMatch(
         "a reasonably long draft body",
         "Prefix a reasonably long draft body suffix"
       ).kind
     ).toBe("contains");
+    expect(
+      commentBodiesMatch(
+        "Great insight followed by the rest of the staged draft",
+        "Great insight"
+      ).ok
+    ).toBe(false);
+    expect(
+      commentBodiesMatch(
+        "This staged draft has an embedded generic phrase",
+        "staged draft"
+      ).ok
+    ).toBe(false);
     expect(commentBodiesMatch("hello", "goodbye").ok).toBe(false);
   });
 
@@ -1350,7 +1365,7 @@ describe("prepare_comment helpers", () => {
         throw new Error(`unexpected ${key}`);
       },
     };
-    await prepareLinkedInComment(dispatcher, {
+    const result = await prepareLinkedInComment(dispatcher, {
       postUrl: "7312345678901234567",
       body: "hi there draft",
       agentId: "agent_abc",
@@ -1363,6 +1378,19 @@ describe("prepare_comment helpers", () => {
     expect(nav?.input.holder_agent_id).toBe("agent_abc");
     expect(nav?.input.holder_thread_id).toBe("thread_xyz");
     expect(nav?.input.holder_message_id).toBe("msg_1");
+    expect(result.agent_id).toBe("agent_abc");
+
+    log.length = 0;
+    const incomplete = await prepareLinkedInComment(dispatcher, {
+      postUrl: "7312345678901234567",
+      body: "another draft",
+      agentId: "agent_without_thread",
+      notify: false,
+      banner: false,
+    });
+    const incompleteNav = log.find((e) => e.key === "navigate");
+    expect(incompleteNav?.input.holder_agent_id).toBeUndefined();
+    expect(incomplete.agent_id).toBeUndefined();
   });
 
   test("verifyLinkedInStagedComment matches scraped comments", async () => {
@@ -1637,5 +1665,47 @@ describe("prepare_comment helpers", () => {
     expect(result.output?.prepared).toBe(true);
     expect(result.output?.tab_id).toBe(5);
     expect(result.output?.method).toBe("evaluate");
+  });
+
+  test("execute verify_staged_comment routes through the read path", async () => {
+    const connector = new LinkedInConnector();
+    const result = await connector.execute({
+      actionKey: "verify_staged_comment",
+      input: {
+        activity_id: "7312345678901234567",
+        body: "Nice post",
+        author_hint: "Burak",
+        focus: false,
+      },
+      credentials: null,
+      config: {},
+      sessionState: {
+        chrome_dispatcher: {
+          dispatch: async (key: string, input: Record<string, unknown>) => {
+            if (key === "navigate") {
+              return {
+                tab_id: 6,
+                current_url:
+                  "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567",
+              };
+            }
+            if (key === "wait_for_selector") return {};
+            if (key === "evaluate") {
+              const expr = String(input.expression);
+              if (expr.includes("load|show|view")) return { value: false };
+              return {
+                value: {
+                  comments: [{ author: "Burak", text: "Nice post" }],
+                },
+              };
+            }
+            throw new Error(`unexpected ${key}`);
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.output?.verified).toBe(true);
+    expect(result.output?.match?.author).toBe("Burak");
   });
 });

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1305,8 +1305,10 @@ describe("prepare_comment helpers", () => {
     expect(commentBodiesMatch("Hello world", "Hello world").ok).toBe(true);
     expect(commentBodiesMatch("Hello world", "Hello world").kind).toBe("exact");
     expect(
-      commentBodiesMatch("Great insight thanks", "Great insight thanks for more context")
-        .ok
+      commentBodiesMatch(
+        "Great insight thanks",
+        "Great insight thanks for more context"
+      ).ok
     ).toBe(true);
     expect(
       commentBodiesMatch(
@@ -1320,7 +1322,9 @@ describe("prepare_comment helpers", () => {
   test("buildScrapeCommentsExpression is read-only (no submit)", () => {
     const expr = buildScrapeCommentsExpression();
     expect(expr).toContain("comments-comment-item");
-    expect(expr).not.toMatch(/insertText|dispatchKeyEvent|key:\s*['"]Enter['"]/);
+    expect(expr).not.toMatch(
+      /insertText|dispatchKeyEvent|key:\s*['"]Enter['"]/
+    );
     expect(expr).not.toMatch(/Post[\s\S]*\.click\(/);
   });
 

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -27,6 +27,10 @@ let prepareLinkedInComment: any;
 let buildFillCommentExpression: any;
 let buildInjectHandoffBannerExpression: any;
 let truncateHandoffReason: any;
+let normalizeCommentMatchText: any;
+let commentBodiesMatch: any;
+let buildScrapeCommentsExpression: any;
+let verifyLinkedInStagedComment: any;
 
 beforeAll(async () => {
   const mod = await import("../linkedin.connector");
@@ -46,6 +50,10 @@ beforeAll(async () => {
   buildFillCommentExpression = mod.buildFillCommentExpression;
   buildInjectHandoffBannerExpression = mod.buildInjectHandoffBannerExpression;
   truncateHandoffReason = mod.truncateHandoffReason;
+  normalizeCommentMatchText = mod.normalizeCommentMatchText;
+  commentBodiesMatch = mod.commentBodiesMatch;
+  buildScrapeCommentsExpression = mod.buildScrapeCommentsExpression;
+  verifyLinkedInStagedComment = mod.verifyLinkedInStagedComment;
   const identityMod = await import("../linkedin-identity");
   normalizeLinkedInSlug = identityMod.normalizeLinkedInSlug;
   normalizeLinkedInMemberId = identityMod.normalizeLinkedInMemberId;
@@ -1278,8 +1286,159 @@ describe("prepare_comment helpers", () => {
       { required: ["post_url"] },
       { required: ["activity_id"] },
     ]);
-    expect(c.definition.version).toBe("3.2.0");
+    expect(c.definition.version).toBe("3.3.0");
     expect(String(action?.description ?? "")).toMatch(/NEVER submits/i);
+  });
+
+  test("definition declares verify_staged_comment as read-only", () => {
+    const c = new LinkedInConnector();
+    const action = c.definition.actions?.verify_staged_comment;
+    expect(action?.key).toBe("verify_staged_comment");
+    expect(action?.requiresApproval).toBe(false);
+    expect(action?.kind).toBe("read");
+    expect(action?.annotations?.destructiveHint).toBe(false);
+    expect(action?.annotations?.idempotentHint).toBe(true);
+  });
+
+  test("commentBodiesMatch normalizes and tolerates truncation", () => {
+    expect(normalizeCommentMatchText("  Hello\nWorld  ")).toBe("hello world");
+    expect(commentBodiesMatch("Hello world", "Hello world").ok).toBe(true);
+    expect(commentBodiesMatch("Hello world", "Hello world").kind).toBe("exact");
+    expect(
+      commentBodiesMatch("Great insight thanks", "Great insight thanks for more context")
+        .ok
+    ).toBe(true);
+    expect(
+      commentBodiesMatch(
+        "a reasonably long draft body",
+        "Prefix a reasonably long draft body suffix"
+      ).kind
+    ).toBe("contains");
+    expect(commentBodiesMatch("hello", "goodbye").ok).toBe(false);
+  });
+
+  test("buildScrapeCommentsExpression is read-only (no submit)", () => {
+    const expr = buildScrapeCommentsExpression();
+    expect(expr).toContain("comments-comment-item");
+    expect(expr).not.toMatch(/insertText|dispatchKeyEvent|key:\s*['"]Enter['"]/);
+    expect(expr).not.toMatch(/Post[\s\S]*\.click\(/);
+  });
+
+  test("prepareLinkedInComment stamps conversation handoff on navigate", async () => {
+    const log: Array<{ key: string; input: Record<string, unknown> }> = [];
+    const dispatcher = {
+      dispatch: async (key: string, input: Record<string, unknown>) => {
+        log.push({ key, input });
+        if (key === "navigate") {
+          return {
+            tab_id: 9,
+            current_url:
+              "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567",
+          };
+        }
+        if (key === "wait_for_selector") return { found: true };
+        if (key === "evaluate") {
+          return {
+            value: { ok: true, reason: "typed", preview: "hi" },
+          };
+        }
+        if (key === "focus_tab" || key === "show_notification") return {};
+        throw new Error(`unexpected ${key}`);
+      },
+    };
+    await prepareLinkedInComment(dispatcher, {
+      postUrl: "7312345678901234567",
+      body: "hi there draft",
+      agentId: "agent_abc",
+      threadId: "thread_xyz",
+      messageId: "msg_1",
+      notify: false,
+      banner: false,
+    });
+    const nav = log.find((e) => e.key === "navigate");
+    expect(nav?.input.holder_agent_id).toBe("agent_abc");
+    expect(nav?.input.holder_thread_id).toBe("thread_xyz");
+    expect(nav?.input.holder_message_id).toBe("msg_1");
+  });
+
+  test("verifyLinkedInStagedComment matches scraped comments", async () => {
+    const log: string[] = [];
+    const dispatcher = {
+      dispatch: async (key: string, input: Record<string, unknown>) => {
+        log.push(key);
+        if (key === "navigate") {
+          return {
+            tab_id: 3,
+            current_url:
+              "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567",
+          };
+        }
+        if (key === "wait_for_selector") return { found: true };
+        if (key === "evaluate") {
+          const expr = String(input.expression);
+          if (expr.includes("load more comments")) return { value: true };
+          return {
+            value: {
+              ok: true,
+              comments: [
+                { author: "Other", text: "unrelated" },
+                {
+                  author: "Burak",
+                  text: "Great insight — thanks for sharing.",
+                },
+              ],
+              count: 2,
+            },
+          };
+        }
+        if (key === "focus_tab") return {};
+        throw new Error(`unexpected ${key}`);
+      },
+    };
+    const result = await verifyLinkedInStagedComment(dispatcher, {
+      postUrl: "7312345678901234567",
+      body: "Great insight — thanks for sharing.",
+      author_hint: "Burak",
+    });
+    expect(result.verified).toBe(true);
+    expect(result.comments_scanned).toBe(2);
+    expect(result.match?.author).toBe("Burak");
+    expect(result.match?.match_kind).toBe("exact");
+    expect(log).not.toContain("click_ref");
+    expect(log).not.toContain("type_ref");
+  });
+
+  test("verifyLinkedInStagedComment reports no match cleanly", async () => {
+    const dispatcher = {
+      dispatch: async (key: string) => {
+        if (key === "navigate") {
+          return {
+            tab_id: 3,
+            current_url:
+              "https://www.linkedin.com/feed/update/urn:li:activity:7312345678901234567",
+          };
+        }
+        if (key === "wait_for_selector") return {};
+        if (key === "evaluate") {
+          return {
+            value: {
+              comments: [{ author: "A", text: "something else" }],
+              count: 1,
+            },
+          };
+        }
+        if (key === "focus_tab") return {};
+        return {};
+      },
+    };
+    const result = await verifyLinkedInStagedComment(dispatcher, {
+      postUrl: "7312345678901234567",
+      body: "the staged draft that was never posted",
+      focus: false,
+    });
+    expect(result.verified).toBe(false);
+    expect(result.reason).toBe("no_matching_comment");
+    expect(result.comments_scanned).toBe(1);
   });
 
   test("prepareLinkedInComment stages via evaluate (primary) and never clicks Post", async () => {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -1135,12 +1135,15 @@ export async function prepareLinkedInComment(
   const agentId = opts.agentId?.trim() || undefined;
   const threadId = opts.threadId?.trim() || undefined;
   const messageId = opts.messageId?.trim() || undefined;
-  // Conversation-first sidepanel needs both agent + thread; message is optional.
+  const handoff =
+    agentId && threadId ? { agentId, threadId, messageId } : undefined;
   const handoffFields: Record<string, string> = {};
-  if (agentId && threadId) {
-    handoffFields.holder_agent_id = agentId;
-    handoffFields.holder_thread_id = threadId;
-    if (messageId) handoffFields.holder_message_id = messageId;
+  if (handoff) {
+    handoffFields.holder_agent_id = handoff.agentId;
+    handoffFields.holder_thread_id = handoff.threadId;
+    if (handoff.messageId) {
+      handoffFields.holder_message_id = handoff.messageId;
+    }
   }
 
   // Refuse accidental submit clicks through the chrome dispatcher.
@@ -1353,9 +1356,9 @@ export async function prepareLinkedInComment(
     method,
     banner_shown: bannerShown,
     reason_preview: reasonPreview,
-    agent_id: agentId,
-    thread_id: threadId,
-    message_id: messageId,
+    agent_id: handoff?.agentId,
+    thread_id: handoff?.threadId,
+    message_id: handoff?.messageId,
     message:
       "Comment staged in your browser. Review the draft and click Post yourself — Lobu did not submit.",
   };
@@ -1407,11 +1410,12 @@ export function commentBodiesMatch(
   const a = normalizeCommentMatchText(actual);
   if (!e || !a) return { ok: false };
   if (a === e) return { ok: true, kind: "exact" };
-  // Scraped text truncated (See more) or expected slightly longer than DOM.
-  if (a.startsWith(e) || e.startsWith(a)) return { ok: true, kind: "prefix" };
-  // Longer card text that embeds the draft (min length guards false positives).
-  if (e.length >= 12 && a.includes(e)) return { ok: true, kind: "contains" };
-  if (a.length >= 12 && e.includes(a)) return { ok: true, kind: "contains" };
+  // Partial matches must be distinctive enough not to verify common phrases.
+  if (Math.min(e.length, a.length) < 24) return { ok: false };
+  // LinkedIn may truncate the visible comment before its "See more" control.
+  if (e.startsWith(a)) return { ok: true, kind: "prefix" };
+  // Some DOM variants wrap the comment body in a longer text block.
+  if (a.includes(e)) return { ok: true, kind: "contains" };
   return { ok: false };
 }
 
@@ -1453,7 +1457,6 @@ export function buildScrapeCommentsExpression(): string {
     out.push({ author, text: text.slice(0, 2000) });
     if (out.length >= 80) break;
   }
-  // Fallback: comment-like contenteditables are composers — skip those.
   return { ok: true, comments: out, count: out.length, url: location.href };
 })()`;
 }
@@ -1467,7 +1470,7 @@ export async function verifyLinkedInStagedComment(
   opts: {
     postUrl: string;
     body: string;
-    /** Prefer matches whose author display name includes this (case-insensitive). */
+    /** Require the author's display name to include this (case-insensitive). */
     author_hint?: string;
     focus?: boolean;
   }
@@ -1521,18 +1524,18 @@ export async function verifyLinkedInStagedComment(
     await dispatcher.dispatch("evaluate", {
       tab_id: tabId,
       expression: `(() => {
-        const labels = [/load more comments/i, /most relevant/i, /^\\d+\\s+comments?$/i, /^comments$/i];
+        const labels = [/^(load|show|view) more comments/i, /^\\d+\\s+comments?$/i, /^comments$/i];
         const clickables = [
           ...document.querySelectorAll('button, [role="button"], a'),
         ];
-        for (const el of clickables) {
+        const control = clickables.find((el) => {
           const n = (el.textContent || '').replace(/\\s+/g, ' ').trim();
-          if (!n || /^(post|submit|send)$/i.test(n)) continue;
-          if (labels.some((re) => re.test(n))) {
-            try { el.click(); } catch (_) {}
-          }
+          return n && labels.some((re) => re.test(n));
+        });
+        if (control) {
+          try { control.click(); } catch (_) {}
         }
-        return true;
+        return !!control;
       })()`,
       await_promise: false,
       ...chromeOriginsInput(),
@@ -1541,10 +1544,33 @@ export async function verifyLinkedInStagedComment(
     // Expand is optional.
   }
 
+  try {
+    await dispatcher.dispatch("wait_for_selector", {
+      tab_id: tabId,
+      selector: ".comments-comment-item, .comments-comment-entity",
+      timeout_ms: 3000,
+      ...chromeOriginsInput(),
+    });
+  } catch {
+    // A post can legitimately have no comments.
+  }
+
+  if (focus) {
+    try {
+      await dispatcher.dispatch("focus_tab", {
+        tab_id: tabId,
+        draw_attention: true,
+        ...chromeOriginsInput(),
+      });
+    } catch {
+      // Focus is best-effort.
+    }
+  }
+
   let comments: ScrapedComment[] = [];
   try {
     const scrape = await dispatcher.dispatch<{
-      value?: { comments?: ScrapedComment[]; count?: number };
+      value?: { comments?: unknown; count?: number };
       exception?: string;
     }>("evaluate", {
       tab_id: tabId,
@@ -1571,7 +1597,8 @@ export async function verifyLinkedInStagedComment(
           !!c &&
           typeof c === "object" &&
           typeof c.text === "string" &&
-          c.text.trim().length > 0
+          c.text.trim().length > 0 &&
+          (c.author === undefined || typeof c.author === "string")
       );
     }
   } catch (err) {
@@ -1586,37 +1613,15 @@ export async function verifyLinkedInStagedComment(
     };
   }
 
-  if (focus) {
-    try {
-      await dispatcher.dispatch("focus_tab", {
-        tab_id: tabId,
-        draw_attention: true,
-        ...chromeOriginsInput(),
-      });
-    } catch {
-      // optional
-    }
-  }
-
-  // Prefer author-hint matches when provided.
-  const ordered = authorHint
-    ? [
-        ...comments.filter((c) =>
-          (c.author ?? "").toLowerCase().includes(authorHint)
-        ),
-        ...comments.filter(
-          (c) => !(c.author ?? "").toLowerCase().includes(authorHint)
-        ),
-      ]
+  const candidates = authorHint
+    ? comments.filter((c) =>
+        (c.author ?? "").toLowerCase().includes(authorHint)
+      )
     : comments;
 
-  for (const c of ordered) {
+  for (const c of candidates) {
     const m = commentBodiesMatch(body, c.text);
     if (!m.ok) continue;
-    // If author_hint was given, only accept that author's matches.
-    if (authorHint && !(c.author ?? "").toLowerCase().includes(authorHint)) {
-      continue;
-    }
     return {
       verified: true,
       post_url: postUrl,
@@ -2216,7 +2221,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
             author_hint: {
               type: "string",
               description:
-                "Optional author display-name substring to prefer / require when matching.",
+                "Optional author display-name substring to require when matching.",
               maxLength: 200,
             },
             focus: {
@@ -2234,7 +2239,17 @@ export default class LinkedInConnector extends ConnectorRuntime<
             body: { type: "string" },
             tab_id: { type: "integer" },
             comments_scanned: { type: "integer" },
-            match: { type: "object" },
+            match: {
+              type: "object",
+              properties: {
+                author: { type: "string" },
+                text_preview: { type: "string" },
+                match_kind: {
+                  type: "string",
+                  enum: ["exact", "prefix", "contains"],
+                },
+              },
+            },
             reason: { type: "string" },
             message: { type: "string" },
           },

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -1508,7 +1508,7 @@ export async function verifyLinkedInStagedComment(
     await dispatcher.dispatch("wait_for_selector", {
       tab_id: tabId,
       selector:
-        '.comments-comment-item, .comments-comment-entity, .feed-shared-update-v2, article',
+        ".comments-comment-item, .comments-comment-entity, .feed-shared-update-v2, article",
       timeout_ms: 8000,
       ...chromeOriginsInput(),
     });
@@ -1568,7 +1568,10 @@ export async function verifyLinkedInStagedComment(
     if (Array.isArray(raw)) {
       comments = raw.filter(
         (c): c is ScrapedComment =>
-          !!c && typeof c === "object" && typeof c.text === "string" && c.text.trim().length > 0
+          !!c &&
+          typeof c === "object" &&
+          typeof c.text === "string" &&
+          c.text.trim().length > 0
       );
     }
   } catch (err) {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -24,6 +24,10 @@
  * Write handoff: `prepare_comment` opens a post in the paired Chrome,
  * fills the comment composer, focuses the tab, and stops. The human clicks
  * Post themselves — Lobu never submits the comment.
+ *
+ * Closed-loop (optional): `verify_staged_comment` re-opens the post and scrapes
+ * visible comments to check whether the human actually posted the draft.
+ * Staging ≠ verified posted.
  */
 
 import {
@@ -618,6 +622,10 @@ type PrepareCommentResult = {
   banner_shown?: boolean;
   /** Truncated reason shown on the banner (if any). */
   reason_preview?: string;
+  /** Optional agent chat handoff (stamped on the owned Chrome tab). */
+  agent_id?: string;
+  thread_id?: string;
+  message_id?: string;
   message: string;
 };
 
@@ -1100,6 +1108,14 @@ export async function prepareLinkedInComment(
     notify?: boolean;
     /** Inject in-page handoff banner (default true). */
     banner?: boolean;
+    /**
+     * Optional Owletto sidepanel deep-link: when set with threadId, the
+     * extension stamps agent+thread on the owned tab so the sidepanel opens
+     * the conversation (and optionally scrolls to messageId).
+     */
+    agentId?: string;
+    threadId?: string;
+    messageId?: string;
   }
 ): Promise<PrepareCommentResult> {
   const body = opts.body.trim();
@@ -1116,6 +1132,16 @@ export async function prepareLinkedInComment(
   const notify = opts.notify !== false;
   const banner = opts.banner !== false;
   const reasonPreview = truncateHandoffReason(opts.reason);
+  const agentId = opts.agentId?.trim() || undefined;
+  const threadId = opts.threadId?.trim() || undefined;
+  const messageId = opts.messageId?.trim() || undefined;
+  // Conversation-first sidepanel needs both agent + thread; message is optional.
+  const handoffFields: Record<string, string> = {};
+  if (agentId && threadId) {
+    handoffFields.holder_agent_id = agentId;
+    handoffFields.holder_thread_id = threadId;
+    if (messageId) handoffFields.holder_message_id = messageId;
+  }
 
   // Refuse accidental submit clicks through the chrome dispatcher.
   const safeDispatch: ChromeActionDispatcher = {
@@ -1141,6 +1167,7 @@ export async function prepareLinkedInComment(
     url: postUrl,
     open_in_new_tab: true,
     wait_for_load: true,
+    ...handoffFields,
     ...chromeOriginsInput(),
   });
   const tabId = nav.tab_id;
@@ -1326,8 +1353,300 @@ export async function prepareLinkedInComment(
     method,
     banner_shown: bannerShown,
     reason_preview: reasonPreview,
+    agent_id: agentId,
+    thread_id: threadId,
+    message_id: messageId,
     message:
       "Comment staged in your browser. Review the draft and click Post yourself — Lobu did not submit.",
+  };
+}
+
+// ── verify_staged_comment (read: did the human Post?) ────────────────
+
+export type ScrapedComment = {
+  author?: string;
+  text: string;
+};
+
+export type VerifyStagedCommentResult = {
+  /** True when a visible comment matches the expected body. */
+  verified: boolean;
+  post_url: string;
+  body: string;
+  tab_id?: number;
+  comments_scanned: number;
+  match?: {
+    author?: string;
+    text_preview: string;
+    match_kind: "exact" | "prefix" | "contains";
+  };
+  /** Why verification failed or was inconclusive. */
+  reason?: string;
+  message: string;
+};
+
+/** Collapse whitespace / case for comment body comparison. */
+export function normalizeCommentMatchText(text: string): string {
+  return text
+    .normalize("NFKC")
+    .replace(/\u00a0/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Match staged draft text against a scraped comment body.
+ * Allows LinkedIn "…more" truncation and longer surrounding blocks.
+ */
+export function commentBodiesMatch(
+  expected: string,
+  actual: string
+): { ok: true; kind: "exact" | "prefix" | "contains" } | { ok: false } {
+  const e = normalizeCommentMatchText(expected);
+  const a = normalizeCommentMatchText(actual);
+  if (!e || !a) return { ok: false };
+  if (a === e) return { ok: true, kind: "exact" };
+  // Scraped text truncated (See more) or expected slightly longer than DOM.
+  if (a.startsWith(e) || e.startsWith(a)) return { ok: true, kind: "prefix" };
+  // Longer card text that embeds the draft (min length guards false positives).
+  if (e.length >= 12 && a.includes(e)) return { ok: true, kind: "contains" };
+  if (a.length >= 12 && e.includes(a)) return { ok: true, kind: "contains" };
+  return { ok: false };
+}
+
+/**
+ * JS expression: scrape visible comments on a LinkedIn post/permalink page.
+ * Best-effort DOM selectors — LinkedIn class names churn.
+ */
+export function buildScrapeCommentsExpression(): string {
+  return `(() => {
+  const roots = [
+    ...document.querySelectorAll('article.comments-comment-item'),
+    ...document.querySelectorAll('.comments-comment-item'),
+    ...document.querySelectorAll('.comments-comment-entity'),
+    ...document.querySelectorAll('[class*="comments-comment-item"]'),
+  ];
+  const seen = new Set();
+  const out = [];
+  for (const root of roots) {
+    if (!(root instanceof HTMLElement)) continue;
+    if (seen.has(root)) continue;
+    seen.add(root);
+    const textEl =
+      root.querySelector('.update-components-text') ||
+      root.querySelector('.comments-comment-item__main-content') ||
+      root.querySelector('[class*="comment-item__main"]') ||
+      root.querySelector('.feed-shared-inline-show-more-text') ||
+      root.querySelector('[data-test-id="main-feed-activity-card"] span[dir="ltr"]') ||
+      root.querySelector('span[dir="ltr"]');
+    let text = (textEl?.innerText || textEl?.textContent || '').replace(/\\s+/g, ' ').trim();
+    // Drop "See more" / "…more" chrome.
+    text = text.replace(/\\s*…?\\s*see more\\s*$/i, '').replace(/\\s*…more\\s*$/i, '').trim();
+    if (!text || text.length < 2) continue;
+    const authorEl =
+      root.querySelector('.comments-post-meta__name-text') ||
+      root.querySelector('.comments-comment-meta__description-title') ||
+      root.querySelector('a[href*="/in/"] span[aria-hidden="true"]') ||
+      root.querySelector('a[href*="/in/"]');
+    const author = (authorEl?.textContent || '').replace(/\\s+/g, ' ').trim() || undefined;
+    out.push({ author, text: text.slice(0, 2000) });
+    if (out.length >= 80) break;
+  }
+  // Fallback: comment-like contenteditables are composers — skip those.
+  return { ok: true, comments: out, count: out.length, url: location.href };
+})()`;
+}
+
+/**
+ * Re-open a LinkedIn post and check whether a comment matching `body` is visible.
+ * Read-only — never types or submits. Matching is best-effort DOM scrape.
+ */
+export async function verifyLinkedInStagedComment(
+  dispatcher: ChromeActionDispatcher,
+  opts: {
+    postUrl: string;
+    body: string;
+    /** Prefer matches whose author display name includes this (case-insensitive). */
+    author_hint?: string;
+    focus?: boolean;
+  }
+): Promise<VerifyStagedCommentResult> {
+  const body = opts.body.trim();
+  if (!body) {
+    throw new Error("verify_staged_comment: body must be non-empty");
+  }
+  const postUrl = normalizeLinkedInPostUrl(opts.postUrl);
+  if (!postUrl) {
+    throw new Error(
+      `verify_staged_comment: invalid post_url / activity_id: ${JSON.stringify(opts.postUrl)}`
+    );
+  }
+  const authorHint = opts.author_hint?.trim().toLowerCase() || undefined;
+  const focus = opts.focus !== false;
+
+  const nav = await dispatcher.dispatch<{
+    tab_id?: number;
+    current_url?: string;
+  }>("navigate", {
+    url: postUrl,
+    open_in_new_tab: true,
+    wait_for_load: true,
+    ...chromeOriginsInput(),
+  });
+  const tabId = nav.tab_id;
+  if (typeof tabId !== "number") {
+    throw new Error("verify_staged_comment: navigate did not return tab_id");
+  }
+  if (isLinkedInAuthWall(nav.current_url)) {
+    throw new Error(
+      `Not logged into LinkedIn (landed on ${nav.current_url}). Sign in in the paired Chrome profile, then retry.`
+    );
+  }
+
+  try {
+    await dispatcher.dispatch("wait_for_selector", {
+      tab_id: tabId,
+      selector:
+        '.comments-comment-item, .comments-comment-entity, .feed-shared-update-v2, article',
+      timeout_ms: 8000,
+      ...chromeOriginsInput(),
+    });
+  } catch {
+    // Non-fatal — page may still expose comments.
+  }
+
+  // Best-effort: expand the comments section / load more (never Post).
+  try {
+    await dispatcher.dispatch("evaluate", {
+      tab_id: tabId,
+      expression: `(() => {
+        const labels = [/load more comments/i, /most relevant/i, /^\\d+\\s+comments?$/i, /^comments$/i];
+        const clickables = [
+          ...document.querySelectorAll('button, [role="button"], a'),
+        ];
+        for (const el of clickables) {
+          const n = (el.textContent || '').replace(/\\s+/g, ' ').trim();
+          if (!n || /^(post|submit|send)$/i.test(n)) continue;
+          if (labels.some((re) => re.test(n))) {
+            try { el.click(); } catch (_) {}
+          }
+        }
+        return true;
+      })()`,
+      await_promise: false,
+      ...chromeOriginsInput(),
+    });
+  } catch {
+    // Expand is optional.
+  }
+
+  let comments: ScrapedComment[] = [];
+  try {
+    const scrape = await dispatcher.dispatch<{
+      value?: { comments?: ScrapedComment[]; count?: number };
+      exception?: string;
+    }>("evaluate", {
+      tab_id: tabId,
+      expression: buildScrapeCommentsExpression(),
+      await_promise: true,
+      ...chromeOriginsInput(),
+    });
+    if (scrape.exception) {
+      return {
+        verified: false,
+        post_url: postUrl,
+        body,
+        tab_id: tabId,
+        comments_scanned: 0,
+        reason: `scrape_exception: ${scrape.exception}`,
+        message:
+          "Could not scrape comments on the page. Open the post in Chrome and confirm the comment is visible.",
+      };
+    }
+    const raw = scrape.value?.comments;
+    if (Array.isArray(raw)) {
+      comments = raw.filter(
+        (c): c is ScrapedComment =>
+          !!c && typeof c === "object" && typeof c.text === "string" && c.text.trim().length > 0
+      );
+    }
+  } catch (err) {
+    return {
+      verified: false,
+      post_url: postUrl,
+      body,
+      tab_id: tabId,
+      comments_scanned: 0,
+      reason: err instanceof Error ? err.message : String(err),
+      message: "Comment scrape failed (extension evaluate error).",
+    };
+  }
+
+  if (focus) {
+    try {
+      await dispatcher.dispatch("focus_tab", {
+        tab_id: tabId,
+        draw_attention: true,
+        ...chromeOriginsInput(),
+      });
+    } catch {
+      // optional
+    }
+  }
+
+  // Prefer author-hint matches when provided.
+  const ordered = authorHint
+    ? [
+        ...comments.filter((c) =>
+          (c.author ?? "").toLowerCase().includes(authorHint)
+        ),
+        ...comments.filter(
+          (c) => !(c.author ?? "").toLowerCase().includes(authorHint)
+        ),
+      ]
+    : comments;
+
+  for (const c of ordered) {
+    const m = commentBodiesMatch(body, c.text);
+    if (!m.ok) continue;
+    // If author_hint was given, only accept that author's matches.
+    if (authorHint && !(c.author ?? "").toLowerCase().includes(authorHint)) {
+      continue;
+    }
+    return {
+      verified: true,
+      post_url: postUrl,
+      body,
+      tab_id: tabId,
+      comments_scanned: comments.length,
+      match: {
+        author: c.author,
+        text_preview: c.text.slice(0, 160),
+        match_kind: m.kind,
+      },
+      message: `Verified: a visible comment matches the staged draft${
+        c.author ? ` (author: ${c.author})` : ""
+      }.`,
+    };
+  }
+
+  return {
+    verified: false,
+    post_url: postUrl,
+    body,
+    tab_id: tabId,
+    comments_scanned: comments.length,
+    reason:
+      comments.length === 0
+        ? "no_comments_visible"
+        : authorHint
+          ? "no_matching_comment_for_author"
+          : "no_matching_comment",
+    message:
+      comments.length === 0
+        ? "No comments visible on the post yet. The human may not have posted, comments may be collapsed, or the DOM selectors missed them."
+        : "Comments are visible but none matched the staged draft body. The human may have edited the text before posting.",
   };
 }
 
@@ -1588,8 +1907,8 @@ export default class LinkedInConnector extends ConnectorRuntime<
     key: "linkedin",
     name: "LinkedIn",
     description:
-      "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft in the browser for the human to Post.",
-    version: "3.2.0",
+      "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
+    version: "3.3.0",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -1824,6 +2143,21 @@ export default class LinkedInConnector extends ConnectorRuntime<
               description:
                 "Inject a small in-page Lobu handoff banner (default true).",
             },
+            agent_id: {
+              type: "string",
+              description:
+                "Optional agent id for Owletto sidepanel conversation deep-link (requires thread_id).",
+            },
+            thread_id: {
+              type: "string",
+              description:
+                "Optional agent chat thread id for sidepanel conversation deep-link (requires agent_id).",
+            },
+            message_id: {
+              type: "string",
+              description:
+                "Optional chat message id to scroll to when the sidepanel opens the conversation.",
+            },
           },
         },
         outputSchema: {
@@ -1836,6 +2170,69 @@ export default class LinkedInConnector extends ConnectorRuntime<
             method: { type: "string" },
             banner_shown: { type: "boolean" },
             reason_preview: { type: "string" },
+            agent_id: { type: "string" },
+            thread_id: { type: "string" },
+            message_id: { type: "string" },
+            message: { type: "string" },
+          },
+        },
+      },
+      verify_staged_comment: {
+        key: "verify_staged_comment",
+        name: "Verify staged comment",
+        description:
+          "Re-open a LinkedIn post in the paired Chrome browser and check whether a comment matching the draft body is visible. Read-only — never posts. Best-effort DOM scrape (not a guarantee of publication).",
+        requiresApproval: false,
+        kind: "read",
+        annotations: {
+          openWorldHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+        },
+        inputSchema: {
+          type: "object",
+          required: ["body"],
+          anyOf: [{ required: ["post_url"] }, { required: ["activity_id"] }],
+          properties: {
+            post_url: {
+              type: "string",
+              description:
+                "LinkedIn post URL, activity id, or URN (same shapes as prepare_comment).",
+            },
+            activity_id: {
+              type: "string",
+              description:
+                "Activity id when post_url is omitted (digits or urn:li:activity:…).",
+            },
+            body: {
+              type: "string",
+              description: "Expected comment text (the staged draft).",
+              minLength: 1,
+              maxLength: 3000,
+            },
+            author_hint: {
+              type: "string",
+              description:
+                "Optional author display-name substring to prefer / require when matching.",
+              maxLength: 200,
+            },
+            focus: {
+              type: "boolean",
+              description:
+                "Bring the post tab to the foreground (default true).",
+            },
+          },
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            verified: { type: "boolean" },
+            post_url: { type: "string" },
+            body: { type: "string" },
+            tab_id: { type: "integer" },
+            comments_scanned: { type: "integer" },
+            match: { type: "object" },
+            reason: { type: "string" },
             message: { type: "string" },
           },
         },
@@ -1845,7 +2242,10 @@ export default class LinkedInConnector extends ConnectorRuntime<
 
   async execute(ctx: ActionContext): Promise<ActionResult> {
     try {
-      if (ctx.actionKey !== "prepare_comment") {
+      if (
+        ctx.actionKey !== "prepare_comment" &&
+        ctx.actionKey !== "verify_staged_comment"
+      ) {
         return { success: false, error: `Unknown action: ${ctx.actionKey}` };
       }
       const body =
@@ -1864,9 +2264,34 @@ export default class LinkedInConnector extends ConnectorRuntime<
           error: "post_url or activity_id is required",
         };
       }
+      const dispatcher = requireExtensionDispatcher(ctx);
+
+      if (ctx.actionKey === "verify_staged_comment") {
+        const authorHint =
+          typeof ctx.input.author_hint === "string"
+            ? ctx.input.author_hint.trim()
+            : "";
+        const output = await verifyLinkedInStagedComment(dispatcher, {
+          postUrl: postUrlRaw,
+          body,
+          author_hint: authorHint || undefined,
+          focus: ctx.input.focus !== false,
+        });
+        return { success: true, output };
+      }
+
       const reason =
         typeof ctx.input.reason === "string" ? ctx.input.reason.trim() : "";
-      const dispatcher = requireExtensionDispatcher(ctx);
+      const agentId =
+        typeof ctx.input.agent_id === "string" ? ctx.input.agent_id.trim() : "";
+      const threadId =
+        typeof ctx.input.thread_id === "string"
+          ? ctx.input.thread_id.trim()
+          : "";
+      const messageId =
+        typeof ctx.input.message_id === "string"
+          ? ctx.input.message_id.trim()
+          : "";
       const output = await prepareLinkedInComment(dispatcher, {
         postUrl: postUrlRaw,
         body,
@@ -1874,6 +2299,9 @@ export default class LinkedInConnector extends ConnectorRuntime<
         focus: ctx.input.focus !== false,
         notify: ctx.input.notify !== false,
         banner: ctx.input.banner !== false,
+        agentId: agentId || undefined,
+        threadId: threadId || undefined,
+        messageId: messageId || undefined,
       });
       return { success: true, output };
     } catch (error) {

--- a/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
@@ -90,9 +90,19 @@ describe('deep-link token exchange', () => {
     expect(html).toContain('sessionStorage');
     expect(html).toContain('location.hash');
     expect(html).toContain('replaceState');
-    // Browser-handoff deep link (sidepanel → Memory run).
+    // Browser-handoff deep links (sidepanel → conversation or Memory run).
     expect(html).toContain('h.get("run")');
     expect(html).toContain('/#run=');
+    expect(html).toContain('h.get("agent")');
+    expect(html).toContain('h.get("thread")');
+    expect(html).toContain('/#agent=');
+    expect(html).toContain('&thread=');
+    expect(html).toContain('&message=');
+    // Conversation handoff must win over bare run when both are present.
+    const agentBranch = html.indexOf('if (agent && thread)');
+    const runBranch = html.indexOf('else if (run)');
+    expect(agentBranch).toBeGreaterThan(-1);
+    expect(runBranch).toBeGreaterThan(agentBranch);
   });
 
   // The load-bearing claim: the session token from /extension-session, sent as

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -536,13 +536,25 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
   var token = h.get("token") || "";
   var worker = h.get("worker") || "";
   var run = h.get("run") || "";
+  var agent = h.get("agent") || "";
+  var thread = h.get("thread") || "";
+  var message = h.get("message") || h.get("message_id") || "";
   // Strip the token out of the URL before doing anything else.
   history.replaceState(null, "", location.pathname);
-  // Chrome extension deep links (sidepanel): device page or Memory run.
-  // Prefer run over worker when both are present — handoff panels care about
-  // the staged action, not the device.
+  // Chrome extension deep links (sidepanel): conversation handoff, Memory run,
+  // or device page. Prefer agent+thread (browser handoff conversation) over
+  // run (Memory peek) over worker (device). SPA home (/) re-reads the hash.
   var next = "/";
-  if (run) {
+  if (agent && thread) {
+    next =
+      "/#agent=" +
+      encodeURIComponent(agent) +
+      "&thread=" +
+      encodeURIComponent(thread);
+    if (message) {
+      next += "&message=" + encodeURIComponent(message);
+    }
+  } else if (run) {
     next = "/#run=" + encodeURIComponent(run);
   } else if (worker) {
     next = "/#worker=" + encodeURIComponent(worker);


### PR DESCRIPTION
## Summary
Follow-ups after #2125 browser handoff:

1. **`verify_staged_comment`** (LinkedIn example, v3.3.0) — read-only: re-open post, scrape visible comments, match staged body. Never posts. Best-effort DOM (not a publication guarantee).
2. **`prepare_comment` optional handoff** — `agent_id` / `thread_id` / `message_id` stamped onto the Chrome owned tab so Owletto sidepanel can open the conversation.
3. **Owletto pin** — conversation stamps + `#agent/#thread/#message` bootstrap + `message_id` scroll.

## Guarantees
- verify is `kind: read`, `requiresApproval: false`, no type/click/submit
- prepare still never auto-posts
- staged ≠ verified posted

## Test plan
- [x] `bun test ./examples/personal-agent/__tests__/linkedin.connector.test.ts` (80)
- [x] Owletto chrome tools tests for handoff stamps
- [ ] Reload Owletto from submodule; smoke prepare_comment with agent/thread
- [ ] After human Post, run verify_staged_comment on same body
- [ ] `lobu apply` personal-agent LinkedIn so cloud connection exposes new ops

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->