### PR TITLE
fix(authz): grant Builder admin tools for Slack installers

### DIFF
--- a/packages/server/src/__tests__/integration/gateway/builder-admin-grant-composition.test.ts
+++ b/packages/server/src/__tests__/integration/gateway/builder-admin-grant-composition.test.ts
@@ -1,0 +1,221 @@
+/**
+ * The metadata→tenant→grant COMPOSITION for the Builder admin-tool grant.
+ *
+ * `builder-admin-tools-platform-identity.test.ts` covers the grant itself, and
+ * `stores/active-chat-connection-tenant.test.ts` covers the tenant lookup — but
+ * both are fed `alternateTeamId` (resp. a slug) directly. Nothing proved that
+ * the dispatch path DERIVES those keys correctly from a message payload, and
+ * that seam is exactly where the bug lived: `platformMetadata.connectionId` is
+ * a RUNTIME connection id, while `connections.slug` namespaces BYO rows as
+ * `agentconn-<id>`. Passing the runtime id straight through as a slug made the
+ * lookup miss for every BYO connection, silently dropping the Grid fallback —
+ * a fail-closed miss no unit test would notice.
+ *
+ * These tests drive `resolveGrantTeamKeys` (the extracted derivation) against a
+ * real `connections` row and then feed its output into
+ * `resolveBuilderAdminTools`, so the two halves are exercised as they compose
+ * at dispatch time.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  BUILDER_ADMIN_TOOLS,
+  resolveBuilderAdminTools,
+  resolveGrantTeamKeys,
+} from '../../../gateway/orchestration/message-consumer';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestOrganization,
+  createTestUser,
+  insertChatConnectionRow,
+} from '../../setup/test-fixtures';
+
+const WORKSPACE_TEAM = 'T_WORKSPACE';
+const ENTERPRISE_TEAM = 'E_ENTERPRISE';
+const SLACK_USER = 'U_COMPOSE';
+/** A BYO runtime connection id — stored under slug `agentconn-<id>`. */
+const BYO_CONNECTION_ID = 'conn-compose-1';
+
+async function linkSlackIdentity(teamId: string, lobuUserId: string): Promise<void> {
+  await getTestDb()`
+    INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
+    VALUES ('slack', ${teamId}, ${SLACK_USER}, ${lobuUserId}, now())
+    ON CONFLICT (platform, team_id, platform_user_id)
+      DO UPDATE SET lobu_user_id = EXCLUDED.lobu_user_id, updated_at = now()
+  `;
+}
+
+async function seedOwnerBuilder(): Promise<{
+  orgId: string;
+  userId: string;
+  systemAgentId: string;
+}> {
+  const org = await createTestOrganization();
+  const user = await createTestUser();
+  await addUserToOrganization(user.id, org.id, 'owner');
+  const agent = await createTestAgent({ organizationId: org.id });
+  await getTestDb()`
+    UPDATE organization SET system_agent_id = ${agent.agentId} WHERE id = ${org.id}
+  `;
+  return { orgId: org.id, userId: user.id, systemAgentId: agent.agentId };
+}
+
+/** Seed an active Slack connection whose tenant is the Grid enterprise id. */
+async function seedGridConnection(orgId: string, status: 'active' | 'paused' = 'active') {
+  await insertChatConnectionRow({
+    id: BYO_CONNECTION_ID,
+    organizationId: orgId,
+    platform: 'slack',
+    status,
+    metadata: { teamId: ENTERPRISE_TEAM, teamName: 'Acme Grid' },
+  });
+}
+
+describe('Builder admin grant — payload metadata → tenant → grant composition', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('derives the enterprise alternate key from a BYO runtime connectionId and grants', async () => {
+    const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
+    await seedGridConnection(orgId);
+    // The identity is linked under the Grid E… key, while the event carries T….
+    await linkSlackIdentity(ENTERPRISE_TEAM, userId);
+
+    const keys = await resolveGrantTeamKeys({
+      platform: 'slack',
+      organizationId: orgId,
+      // Routing key for a DM is the platform name, not a workspace id.
+      routingTeamId: 'slack',
+      platformMetadata: {
+        teamId: WORKSPACE_TEAM,
+        connectionId: BYO_CONNECTION_ID,
+      },
+    });
+
+    // The event's workspace id is primary; the connection's tenant is the
+    // alternate. Regression: a runtime-id-as-slug lookup returns undefined here.
+    expect(keys).toEqual({
+      teamId: WORKSPACE_TEAM,
+      alternateTeamId: ENTERPRISE_TEAM,
+    });
+
+    const granted = await resolveBuilderAdminTools({
+      agentId: systemAgentId,
+      organizationId: orgId,
+      userId: SLACK_USER,
+      platform: 'slack',
+      teamId: keys.teamId,
+      alternateTeamId: keys.alternateTeamId,
+    });
+    expect(granted).toEqual([...BUILDER_ADMIN_TOOLS]);
+  });
+
+  it('prefers platformMetadata.teamId over the routing key', async () => {
+    const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
+    // Linked under the real workspace id; the routing key is the string 'slack'.
+    await linkSlackIdentity(WORKSPACE_TEAM, userId);
+
+    const keys = await resolveGrantTeamKeys({
+      platform: 'slack',
+      organizationId: orgId,
+      routingTeamId: 'slack',
+      platformMetadata: { teamId: WORKSPACE_TEAM },
+    });
+    expect(keys.teamId).toBe(WORKSPACE_TEAM);
+
+    const granted = await resolveBuilderAdminTools({
+      agentId: systemAgentId,
+      organizationId: orgId,
+      userId: SLACK_USER,
+      platform: 'slack',
+      teamId: keys.teamId,
+      alternateTeamId: keys.alternateTeamId,
+    });
+    expect(granted).toEqual([...BUILDER_ADMIN_TOOLS]);
+  });
+
+  it('omits the alternate when the connection tenant equals the event team', async () => {
+    const { orgId } = await seedOwnerBuilder();
+    await insertChatConnectionRow({
+      id: BYO_CONNECTION_ID,
+      organizationId: orgId,
+      platform: 'slack',
+      status: 'active',
+      metadata: { teamId: WORKSPACE_TEAM },
+    });
+
+    const keys = await resolveGrantTeamKeys({
+      platform: 'slack',
+      organizationId: orgId,
+      platformMetadata: {
+        teamId: WORKSPACE_TEAM,
+        connectionId: BYO_CONNECTION_ID,
+      },
+    });
+
+    expect(keys.alternateTeamId).toBeUndefined();
+  });
+
+  it('withholds the alternate — and the grant — when the install is paused', async () => {
+    const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
+    await seedGridConnection(orgId, 'paused');
+    await linkSlackIdentity(ENTERPRISE_TEAM, userId);
+
+    const keys = await resolveGrantTeamKeys({
+      platform: 'slack',
+      organizationId: orgId,
+      platformMetadata: {
+        teamId: WORKSPACE_TEAM,
+        connectionId: BYO_CONNECTION_ID,
+      },
+    });
+    // Fail closed: a paused install must not supply a privilege key.
+    expect(keys.alternateTeamId).toBeUndefined();
+
+    const granted = await resolveBuilderAdminTools({
+      agentId: systemAgentId,
+      organizationId: orgId,
+      userId: SLACK_USER,
+      platform: 'slack',
+      teamId: keys.teamId,
+      alternateTeamId: keys.alternateTeamId,
+    });
+    expect(granted).toBeUndefined();
+  });
+
+  it('does not consult connections for a non-Slack platform', async () => {
+    const { orgId } = await seedOwnerBuilder();
+    await seedGridConnection(orgId);
+
+    const keys = await resolveGrantTeamKeys({
+      platform: 'telegram',
+      organizationId: orgId,
+      platformMetadata: {
+        teamId: WORKSPACE_TEAM,
+        connectionId: BYO_CONNECTION_ID,
+      },
+    });
+
+    expect(keys).toEqual({ teamId: WORKSPACE_TEAM });
+  });
+
+  it("does not borrow another org's connection tenant", async () => {
+    const { orgId } = await seedOwnerBuilder();
+    const foreign = await createTestOrganization();
+    // The connection lives in a DIFFERENT org under the same runtime id.
+    await seedGridConnection(foreign.id);
+
+    const keys = await resolveGrantTeamKeys({
+      platform: 'slack',
+      organizationId: orgId,
+      platformMetadata: {
+        teamId: WORKSPACE_TEAM,
+        connectionId: BYO_CONNECTION_ID,
+      },
+    });
+
+    expect(keys.alternateTeamId).toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/integration/gateway/builder-admin-tools-platform-identity.test.ts
+++ b/packages/server/src/__tests__/integration/gateway/builder-admin-tools-platform-identity.test.ts
@@ -160,4 +160,50 @@ describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', (
 
     expect(granted).toBeUndefined();
   });
+
+  it('grants when the link is under a different team key but the platform user is unique (Grid E… vs T…)', async () => {
+    // Managed enterprise installs key chat_user_identities on E…; inbound
+    // events carry the workspace T…. Unique platform_user_id still maps.
+    const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
+    await linkSlackIdentity({
+      teamId: 'E_ENTERPRISE',
+      platformUserId: SLACK_USER,
+      lobuUserId: userId,
+    });
+
+    const granted = await resolveBuilderAdminTools({
+      agentId: systemAgentId,
+      organizationId: orgId,
+      userId: SLACK_USER,
+      platform: 'slack',
+      teamId: 'T_WORKSPACE', // not the linked key
+    });
+
+    expect(granted).toEqual([...BUILDER_ADMIN_TOOLS]);
+  });
+
+  it('withholds the unique-user fallback when the same Slack id maps to two Lobu users', async () => {
+    const { orgId, systemAgentId } = await seedOwnerBuilder();
+    const other = await createTestUser();
+    await linkSlackIdentity({
+      teamId: 'T_A',
+      platformUserId: SLACK_USER,
+      lobuUserId: (await createTestUser()).id,
+    });
+    await linkSlackIdentity({
+      teamId: 'T_B',
+      platformUserId: SLACK_USER,
+      lobuUserId: other.id,
+    });
+
+    const granted = await resolveBuilderAdminTools({
+      agentId: systemAgentId,
+      organizationId: orgId,
+      userId: SLACK_USER,
+      platform: 'slack',
+      teamId: 'T_MISSING',
+    });
+
+    expect(granted).toBeUndefined();
+  });
 });

--- a/packages/server/src/__tests__/integration/gateway/builder-admin-tools-platform-identity.test.ts
+++ b/packages/server/src/__tests__/integration/gateway/builder-admin-tools-platform-identity.test.ts
@@ -161,9 +161,10 @@ describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', (
     expect(granted).toBeUndefined();
   });
 
-  it('grants when the link is under a different team key but the platform user is unique (Grid E… vs T…)', async () => {
+  it('grants via alternateTeamId when the link is under the enterprise key (Grid E… vs T…)', async () => {
     // Managed enterprise installs key chat_user_identities on E…; inbound
-    // events carry the workspace T…. Unique platform_user_id still maps.
+    // events carry the workspace T…. Callers pass connection external_tenant_id
+    // as alternateTeamId — exact team-scoped, not a global U… collapse.
     const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
     await linkSlackIdentity({
       teamId: 'E_ENTERPRISE',
@@ -176,24 +177,19 @@ describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', (
       organizationId: orgId,
       userId: SLACK_USER,
       platform: 'slack',
-      teamId: 'T_WORKSPACE', // not the linked key
+      teamId: 'T_WORKSPACE',
+      alternateTeamId: 'E_ENTERPRISE',
     });
 
     expect(granted).toEqual([...BUILDER_ADMIN_TOOLS]);
   });
 
-  it('withholds the unique-user fallback when the same Slack id maps to two Lobu users', async () => {
-    const { orgId, systemAgentId } = await seedOwnerBuilder();
-    const other = await createTestUser();
+  it('does not grant when only an unrelated team has the link (no alternate)', async () => {
+    const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
     await linkSlackIdentity({
-      teamId: 'T_A',
+      teamId: 'E_ENTERPRISE',
       platformUserId: SLACK_USER,
-      lobuUserId: (await createTestUser()).id,
-    });
-    await linkSlackIdentity({
-      teamId: 'T_B',
-      platformUserId: SLACK_USER,
-      lobuUserId: other.id,
+      lobuUserId: userId,
     });
 
     const granted = await resolveBuilderAdminTools({
@@ -201,7 +197,8 @@ describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', (
       organizationId: orgId,
       userId: SLACK_USER,
       platform: 'slack',
-      teamId: 'T_MISSING',
+      teamId: 'T_WORKSPACE',
+      // no alternateTeamId → fail closed
     });
 
     expect(granted).toBeUndefined();

--- a/packages/server/src/__tests__/integration/stores/active-chat-connection-tenant.test.ts
+++ b/packages/server/src/__tests__/integration/stores/active-chat-connection-tenant.test.ts
@@ -1,0 +1,134 @@
+/**
+ * `resolveActiveChatConnectionTenant` — the second identity key used by the
+ * Builder admin-tool grant.
+ *
+ * Slack Grid keys `chat_user_identities` on the enterprise `E…` while inbound
+ * events carry the workspace `T…`, so the grant path resolves a connection's
+ * `external_tenant_id` and retries the identity lookup under it. That makes this
+ * read PRIVILEGE-ADJACENT: a row returned here widens an authz lookup, so the
+ * predicate must stay narrow — scoped to (org, slug, connector) and LIVE rows
+ * only. These tests pin each half of that predicate against real Postgres.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { resolveActiveChatConnectionTenant } from '../../../lobu/stores/connections-projection';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestOrganization,
+  insertChatConnectionRow,
+} from '../../setup/test-fixtures';
+
+const SLUG = 'slackinst-tenant-probe';
+const ENTERPRISE = 'E_GRID_TENANT';
+
+describe('resolveActiveChatConnectionTenant', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('returns the external_tenant_id of a live slack connection', async () => {
+    const org = await createTestOrganization();
+    await insertChatConnectionRow({
+      id: SLUG,
+      organizationId: org.id,
+      platform: 'slack',
+      status: 'active',
+      metadata: { teamId: ENTERPRISE },
+    });
+
+    const tenant = await resolveActiveChatConnectionTenant(
+      getTestDb(),
+      org.id,
+      SLUG,
+      'slack'
+    );
+
+    expect(tenant).toBe(ENTERPRISE);
+  });
+
+  it('returns null for a PAUSED install — it lingers for token refresh and is not live', async () => {
+    const org = await createTestOrganization();
+    await insertChatConnectionRow({
+      id: SLUG,
+      organizationId: org.id,
+      platform: 'slack',
+      status: 'paused',
+      metadata: { teamId: ENTERPRISE },
+    });
+
+    const tenant = await resolveActiveChatConnectionTenant(
+      getTestDb(),
+      org.id,
+      SLUG,
+      'slack'
+    );
+
+    expect(tenant).toBeNull();
+  });
+
+  it('does not leak another org’s tenant for the same slug', async () => {
+    // Slug reuse across tenants must never let org B supply org A's alternate
+    // team key — that would widen the admin-tool grant across an org boundary.
+    const orgA = await createTestOrganization();
+    const orgB = await createTestOrganization();
+    await insertChatConnectionRow({
+      id: SLUG,
+      organizationId: orgB.id,
+      platform: 'slack',
+      status: 'active',
+      metadata: { teamId: ENTERPRISE },
+    });
+
+    const tenant = await resolveActiveChatConnectionTenant(
+      getTestDb(),
+      orgA.id,
+      SLUG,
+      'slack'
+    );
+
+    expect(tenant).toBeNull();
+  });
+
+  it('does not match a different connector on the same slug', async () => {
+    const org = await createTestOrganization();
+    await insertChatConnectionRow({
+      id: SLUG,
+      organizationId: org.id,
+      platform: 'telegram',
+      status: 'active',
+      metadata: { teamId: ENTERPRISE },
+    });
+
+    const tenant = await resolveActiveChatConnectionTenant(
+      getTestDb(),
+      org.id,
+      SLUG,
+      'slack'
+    );
+
+    expect(tenant).toBeNull();
+  });
+
+  it('returns null when a soft-deleted row is the only match', async () => {
+    const org = await createTestOrganization();
+    await insertChatConnectionRow({
+      id: SLUG,
+      organizationId: org.id,
+      platform: 'slack',
+      status: 'active',
+      metadata: { teamId: ENTERPRISE },
+    });
+    await getTestDb()`
+      UPDATE connections SET deleted_at = now()
+      WHERE organization_id = ${org.id} AND slug = ${SLUG}
+    `;
+
+    const tenant = await resolveActiveChatConnectionTenant(
+      getTestDb(),
+      org.id,
+      SLUG,
+      'slack'
+    );
+
+    expect(tenant).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/integration/stores/active-chat-connection-tenant.test.ts
+++ b/packages/server/src/__tests__/integration/stores/active-chat-connection-tenant.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../setup/test-fixtures';
 
 const SLUG = 'slackinst-tenant-probe';
+const BYO_ID = 'tenant-probe-byo';
 const ENTERPRISE = 'E_GRID_TENANT';
 
 describe('resolveActiveChatConnectionTenant', () => {
@@ -39,6 +40,26 @@ describe('resolveActiveChatConnectionTenant', () => {
       getTestDb(),
       org.id,
       SLUG,
+      'slack'
+    );
+
+    expect(tenant).toBe(ENTERPRISE);
+  });
+
+  it('maps a BYO runtime connection id to its agentconn- slug', async () => {
+    const org = await createTestOrganization();
+    await insertChatConnectionRow({
+      id: BYO_ID,
+      organizationId: org.id,
+      platform: 'slack',
+      status: 'active',
+      metadata: { teamId: ENTERPRISE },
+    });
+
+    const tenant = await resolveActiveChatConnectionTenant(
+      getTestDb(),
+      org.id,
+      BYO_ID,
       'slack'
     );
 
@@ -102,6 +123,30 @@ describe('resolveActiveChatConnectionTenant', () => {
       getTestDb(),
       org.id,
       SLUG,
+      'slack'
+    );
+
+    expect(tenant).toBeNull();
+  });
+
+  it('does not accept a data-connector row with the same connector and slug', async () => {
+    const org = await createTestOrganization();
+    await insertChatConnectionRow({
+      id: BYO_ID,
+      organizationId: org.id,
+      platform: 'slack',
+      status: 'active',
+      metadata: { teamId: ENTERPRISE },
+    });
+    await getTestDb()`
+      UPDATE connections SET credential_mode = NULL
+      WHERE organization_id = ${org.id} AND slug = ${`agentconn-${BYO_ID}`}
+    `;
+
+    const tenant = await resolveActiveChatConnectionTenant(
+      getTestDb(),
+      org.id,
+      BYO_ID,
       'slack'
     );
 

--- a/packages/server/src/gateway/__tests__/slack-claim-http-authority.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim-http-authority.test.ts
@@ -51,6 +51,7 @@ function claimProvider(usersInfo: ReturnType<typeof mock>) {
     })),
     resolveActiveOrgSlug: mock(async () => null),
     resolveClaimerSlackIdentities: resolveClaimingUserSlackIdentities,
+    linkChatUserIdentity: mock(async () => {}),
     usersInfo,
     claim: mock(async () => ({ installationId: "unused" })),
   });

--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -38,8 +38,10 @@ function pendingInstall(
 function makeDeps(overrides: Partial<SlackClaimProviderDeps> = {}): {
   deps: SlackClaimProviderDeps;
   claim: ReturnType<typeof mock>;
+  linkChatUserIdentity: ReturnType<typeof mock>;
 } {
   const claim = mock(async () => ({ installationId: "slackinst-bound" }));
+  const linkChatUserIdentity = mock(async () => {});
   const deps: SlackClaimProviderDeps = {
     resolvePending: mock(async () => pendingInstall()),
     resolveActiveOrgSlug: mock(async () => null),
@@ -47,11 +49,22 @@ function makeDeps(overrides: Partial<SlackClaimProviderDeps> = {}): {
     resolveClaimerSlackIdentities: mock(async () => [
       { teamId: TEAM, slackUserId: "U-ADMIN" },
     ]),
+    linkChatUserIdentity,
     usersInfo: mock(async () => ({ isAdmin: true, isOwner: false })),
     claim,
     ...overrides,
   };
-  return { deps, claim };
+  return { deps, claim, linkChatUserIdentity };
+}
+
+/** The `{teamId, platformUserId}` pairs a bind linked, for order-free asserts. */
+function linkedPairs(
+  linkMock: ReturnType<typeof mock>,
+): Array<{ teamId: string | undefined; platformUserId: string }> {
+  return linkMock.mock.calls.map((c) => {
+    const opts = c[0] as { teamId?: string; platformUserId: string };
+    return { teamId: opts.teamId, platformUserId: opts.platformUserId };
+  });
 }
 
 describe("slackClaimProvider.authorize", () => {
@@ -255,5 +268,156 @@ describe("slackClaimProvider.bind", () => {
       true,
       "org-target",
     );
+  });
+});
+
+/**
+ * Post-claim identity linking. This is a PRIVILEGE-GRANTING write: the rows it
+ * writes are what `resolveBuilderAdminTools` later reads to hand a Slack `U…`
+ * the org's Builder admin tools. The invariant under test is that `bind` links
+ * ONLY identities the claimer has already proven (via Slack OIDC / `/lobu link`),
+ * and stamps the install's tenant key ONLY when the claimer is provably the
+ * installer — never on `pending.installerUserId` alone.
+ */
+describe("slackClaimProvider.bind — identity linking", () => {
+  test("links every proven identity the claimer signed in with", async () => {
+    const { deps, linkChatUserIdentity } = makeDeps({
+      resolveClaimerSlackIdentities: mock(async () => [
+        { teamId: TEAM, slackUserId: "U-ADMIN" },
+        { teamId: "T-OTHER", slackUserId: "U-ELSEWHERE" },
+      ]),
+    });
+    await slackClaimProvider(deps).bind(
+      pendingInstall({ installerUserId: "U-INSTALLER" }),
+      "org-1",
+      "user-1",
+      false,
+    );
+    expect(linkedPairs(linkChatUserIdentity)).toEqual([
+      { teamId: TEAM, platformUserId: "U-ADMIN" },
+      { teamId: "T-OTHER", platformUserId: "U-ELSEWHERE" },
+    ]);
+    // Every link is written for the CLAIMING user, never a third party.
+    for (const call of linkChatUserIdentity.mock.calls) {
+      expect((call[0] as { lobuUserId: string }).lobuUserId).toBe("user-1");
+    }
+  });
+
+  test("does NOT link the installer's U… when a different admin claims a plain workspace", async () => {
+    // The takeover case: U-ADMIN claims an install performed by U-INSTALLER on
+    // a plain workspace. Linking the installer id here would hand U-ADMIN the
+    // installer's identity — and Builder admin tools on that U….
+    const { deps, linkChatUserIdentity } = makeDeps({
+      resolveClaimerSlackIdentities: mock(async () => [
+        { teamId: TEAM, slackUserId: "U-ADMIN" },
+      ]),
+    });
+    await slackClaimProvider(deps).bind(
+      pendingInstall({ installerUserId: "U-INSTALLER", enterpriseId: null }),
+      "org-1",
+      "user-1",
+      false,
+    );
+    expect(linkedPairs(linkChatUserIdentity)).toEqual([
+      { teamId: TEAM, platformUserId: "U-ADMIN" },
+    ]);
+    expect(
+      linkedPairs(linkChatUserIdentity).some(
+        (p) => p.platformUserId === "U-INSTALLER",
+      ),
+    ).toBe(false);
+  });
+
+  test("stamps the install team key when the claimer IS the installer (plain: same team + same U…)", async () => {
+    const { deps, linkChatUserIdentity } = makeDeps({
+      resolveClaimerSlackIdentities: mock(async () => [
+        { teamId: TEAM, slackUserId: "U-INSTALLER" },
+      ]),
+    });
+    await slackClaimProvider(deps).bind(
+      pendingInstall({ installerUserId: "U-INSTALLER", enterpriseId: null }),
+      "org-1",
+      "user-1",
+      false,
+    );
+    expect(linkedPairs(linkChatUserIdentity)).toContainEqual({
+      teamId: TEAM,
+      platformUserId: "U-INSTALLER",
+    });
+  });
+
+  test("plain workspace: matching U… on a DIFFERENT team does not stamp the install key", async () => {
+    // Plain-workspace `U…` ids are workspace-LOCAL, so the same U… on another
+    // team is a different human. Only same-team + same-U counts.
+    const { deps, linkChatUserIdentity } = makeDeps({
+      resolveClaimerSlackIdentities: mock(async () => [
+        { teamId: "T-OTHER", slackUserId: "U-INSTALLER" },
+      ]),
+    });
+    await slackClaimProvider(deps).bind(
+      pendingInstall({ installerUserId: "U-INSTALLER", enterpriseId: null }),
+      "org-1",
+      "user-1",
+      false,
+    );
+    expect(linkedPairs(linkChatUserIdentity)).toEqual([
+      { teamId: "T-OTHER", platformUserId: "U-INSTALLER" },
+    ]);
+    // No row under the INSTALL's team — that would be the collision takeover.
+    expect(
+      linkedPairs(linkChatUserIdentity).some((p) => p.teamId === TEAM),
+    ).toBe(false);
+  });
+
+  test("Grid: matching U… on any team DOES stamp the install key (U is enterprise-global)", async () => {
+    const { deps, linkChatUserIdentity } = makeDeps({
+      resolveClaimerSlackIdentities: mock(async () => [
+        { teamId: "T-OTHER", slackUserId: "U-INSTALLER" },
+      ]),
+    });
+    await slackClaimProvider(deps).bind(
+      pendingInstall({
+        installerUserId: "U-INSTALLER",
+        enterpriseId: "E-GRID",
+        isEnterpriseInstall: true,
+      }),
+      "org-1",
+      "user-1",
+      false,
+    );
+    expect(linkedPairs(linkChatUserIdentity)).toContainEqual({
+      teamId: TEAM,
+      platformUserId: "U-INSTALLER",
+    });
+  });
+
+  test("a claimer with no proven identities links nothing", async () => {
+    const { deps, linkChatUserIdentity } = makeDeps({
+      resolveClaimerSlackIdentities: mock(async () => []),
+    });
+    await slackClaimProvider(deps).bind(
+      pendingInstall({ installerUserId: "U-INSTALLER" }),
+      "org-1",
+      "user-1",
+      false,
+    );
+    expect(linkChatUserIdentity).not.toHaveBeenCalled();
+  });
+
+  test("a link failure is swallowed — the claim still returns its bindingId", async () => {
+    // The claim is already committed when linking runs; a link error must not
+    // fail the bind the user is waiting on. Identity can be healed later.
+    const { deps } = makeDeps({
+      linkChatUserIdentity: mock(async () => {
+        throw new Error("db down");
+      }),
+    });
+    const result = await slackClaimProvider(deps).bind(
+      pendingInstall(),
+      "org-1",
+      "user-1",
+      false,
+    );
+    expect(result).toEqual({ bindingId: "slackinst-bound" });
   });
 });

--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -131,6 +131,24 @@ describe("slackClaimProvider.authorize", () => {
     expect(usersInfo).not.toHaveBeenCalled();
   });
 
+  test("Grid installer match is case-insensitive on both sides", async () => {
+    // The entity-graph identity source yields the raw `team:user` identifier
+    // (the account / linked-chat sources uppercase; that one does not) and
+    // `installerUserId` is stored verbatim from Slack. A case-sensitive
+    // compare here denies a legitimate Grid admin — and disagrees with `bind`,
+    // which normalizes. Fail-closed, but still wrong.
+    const { deps } = makeDeps({
+      resolveClaimerSlackIdentities: mock(async () => [
+        { teamId: "t-other", slackUserId: "u-installer" },
+      ]),
+    });
+    const verdict = await slackClaimProvider(deps).authorize(
+      "user-1",
+      pendingInstall({ installerUserId: "U-INSTALLER", enterpriseId: "E-GRID" }),
+    );
+    expect(verdict.status).toBe("authorized");
+  });
+
   test("installer-id match on a PLAIN workspace (no enterpriseId) is NOT enough", async () => {
     const { deps } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => [
@@ -280,7 +298,7 @@ describe("slackClaimProvider.bind", () => {
  * installer — never on `pending.installerUserId` alone.
  */
 describe("slackClaimProvider.bind — identity linking", () => {
-  test("links every proven identity the claimer signed in with", async () => {
+  test("links every team-scoped identity the claimer signed in with", async () => {
     const { deps, linkChatUserIdentity } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => [
         { teamId: TEAM, slackUserId: "U-ADMIN" },
@@ -301,6 +319,21 @@ describe("slackClaimProvider.bind — identity linking", () => {
     for (const call of linkChatUserIdentity.mock.calls) {
       expect((call[0] as { lobuUserId: string }).lobuUserId).toBe("user-1");
     }
+  });
+
+  test("does not persist an unscoped identity from an account without an id_token", async () => {
+    const { deps, linkChatUserIdentity } = makeDeps({
+      resolveClaimerSlackIdentities: mock(async () => [
+        { teamId: "", slackUserId: "U-ADMIN" },
+      ]),
+    });
+    await slackClaimProvider(deps).bind(
+      pendingInstall({ installerUserId: "U-INSTALLER" }),
+      "org-1",
+      "user-1",
+      false,
+    );
+    expect(linkChatUserIdentity).not.toHaveBeenCalled();
   });
 
   test("does NOT link the installer's U… when a different admin claims a plain workspace", async () => {
@@ -344,6 +377,7 @@ describe("slackClaimProvider.bind — identity linking", () => {
       teamId: TEAM,
       platformUserId: "U-INSTALLER",
     });
+    expect(linkChatUserIdentity).toHaveBeenCalledTimes(1);
   });
 
   test("plain workspace: matching U… on a DIFFERENT team does not stamp the install key", async () => {

--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -425,6 +425,39 @@ describe("slackClaimProvider.bind — identity linking", () => {
     });
   });
 
+  test("persists identities CANONICALIZED so uppercase inbound events resolve them", async () => {
+    // The entity-graph source yields the raw `team:user` identifier, so a
+    // lowercase pair can arrive here. `resolveChatUserIdentity` is an exact
+    // SQL match with no folding — a row stored as `t-claim/u-installer` can
+    // never serve an inbound Slack event carrying `T-CLAIM/U-INSTALLER`, and
+    // the claimed installer silently loses Builder admin tools. Worse, the
+    // case-insensitive already-linked check would suppress the canonical
+    // write, so the uppercase row never gets created either.
+    const { deps, linkChatUserIdentity } = makeDeps({
+      resolveClaimerSlackIdentities: mock(async () => [
+        { teamId: "t-claim", slackUserId: "u-installer" },
+      ]),
+    });
+    await slackClaimProvider(deps).bind(
+      pendingInstall({ installerUserId: "U-INSTALLER", enterpriseId: null }),
+      "org-1",
+      "user-1",
+      false,
+    );
+    const pairs = linkedPairs(linkChatUserIdentity);
+    // The canonical uppercase key MUST exist — it's what inbound events use.
+    expect(pairs).toContainEqual({
+      teamId: TEAM,
+      platformUserId: "U-INSTALLER",
+    });
+    // And no raw-case row should be persisted alongside it.
+    expect(
+      pairs.some(
+        (p) => p.teamId === "t-claim" || p.platformUserId === "u-installer",
+      ),
+    ).toBe(false);
+  });
+
   test("a claimer with no proven identities links nothing", async () => {
     const { deps, linkChatUserIdentity } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => []),

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -151,37 +151,39 @@ export function slackClaimProvider(
           organizationId,
           confirmMove,
         );
-        // Link installer Slack id → claimer Lobu user so Builder admin tools
-        // (resolveBuilderAdminTools) and owner-routed delivery work without a
-        // separate /lobu preview claim. Best-effort: never fail the claim.
-        if (pending.installerUserId) {
-          try {
+        // Link ONLY Slack identities proven to belong to the claimer (OIDC /
+        // resolveClaimerSlackIdentities). Never map pending.installerUserId to
+        // the claimer unconditionally — a different workspace admin can claim
+        // a plain-workspace install, and forging that link would hand them the
+        // installer's identity (and Builder admin tools on that U…).
+        //
+        // When the claimer IS the installer (same U… in their signed-in
+        // identities), also stamp the install's tenant key (T… or Grid E…) so
+        // later event team ids that match the install row still resolve.
+        try {
+          const identities = await deps.resolveClaimerSlackIdentities(userId);
+          const installer = pending.installerUserId?.toUpperCase() ?? null;
+          const claimerIsInstaller =
+            installer != null &&
+            identities.some((i) => i.slackUserId.toUpperCase() === installer);
+          for (const id of identities) {
+            await linkChatUserIdentity({
+              platform: "slack",
+              teamId: id.teamId,
+              platformUserId: id.slackUserId,
+              lobuUserId: userId,
+            });
+          }
+          if (claimerIsInstaller && pending.installerUserId) {
             await linkChatUserIdentity({
               platform: "slack",
               teamId: pending.teamId,
               platformUserId: pending.installerUserId,
               lobuUserId: userId,
             });
-            // Also cover workspace T… rows the claimer already signed in as
-            // (Grid keeps the same U… across workspaces; plain workspaces may
-            // have signed in under a different team key than the install).
-            const identities = await deps.resolveClaimerSlackIdentities(userId);
-            const installer = pending.installerUserId.toUpperCase();
-            for (const id of identities) {
-              if (id.slackUserId.toUpperCase() !== installer) continue;
-              if (id.teamId.toUpperCase() === pending.teamId.toUpperCase()) {
-                continue; // already linked above
-              }
-              await linkChatUserIdentity({
-                platform: "slack",
-                teamId: id.teamId,
-                platformUserId: id.slackUserId,
-                lobuUserId: userId,
-              });
-            }
-          } catch {
-            // Swallow — claim already committed; identity can be healed later.
           }
+        } catch {
+          // Swallow — claim already committed; identity can be healed later.
         }
         return { bindingId: installationId };
       } catch (err) {

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -1,4 +1,5 @@
 import { CrossOrgTransferBlockedError } from "../../lobu/stores/app-installation-store.js";
+import { linkChatUserIdentity } from "../../lobu/stores/chat-identity.js";
 import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
 import {
   type ClaimAuthorization,
@@ -143,13 +144,45 @@ export function slackClaimProvider(
         targetOrganizationId,
       ),
     authorize: (userId, pending) => authorizeSlackClaim(deps, userId, pending),
-    bind: async (pending, organizationId, _userId, confirmMove) => {
+    bind: async (pending, organizationId, userId, confirmMove) => {
       try {
         const { installationId } = await deps.claim(
           pending,
           organizationId,
           confirmMove,
         );
+        // Link installer Slack id → claimer Lobu user so Builder admin tools
+        // (resolveBuilderAdminTools) and owner-routed delivery work without a
+        // separate /lobu preview claim. Best-effort: never fail the claim.
+        if (pending.installerUserId) {
+          try {
+            await linkChatUserIdentity({
+              platform: "slack",
+              teamId: pending.teamId,
+              platformUserId: pending.installerUserId,
+              lobuUserId: userId,
+            });
+            // Also cover workspace T… rows the claimer already signed in as
+            // (Grid keeps the same U… across workspaces; plain workspaces may
+            // have signed in under a different team key than the install).
+            const identities = await deps.resolveClaimerSlackIdentities(userId);
+            const installer = pending.installerUserId.toUpperCase();
+            for (const id of identities) {
+              if (id.slackUserId.toUpperCase() !== installer) continue;
+              if (id.teamId.toUpperCase() === pending.teamId.toUpperCase()) {
+                continue; // already linked above
+              }
+              await linkChatUserIdentity({
+                platform: "slack",
+                teamId: id.teamId,
+                platformUserId: id.slackUserId,
+                lobuUserId: userId,
+              });
+            }
+          } catch {
+            // Swallow — claim already committed; identity can be healed later.
+          }
+        }
         return { bindingId: installationId };
       } catch (err) {
         // The store's ATOMIC fence tripped on the raced path (the sequential

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -1,5 +1,4 @@
 import { CrossOrgTransferBlockedError } from "../../lobu/stores/app-installation-store.js";
-import { linkChatUserIdentity } from "../../lobu/stores/chat-identity.js";
 import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
 import {
   type ClaimAuthorization,
@@ -56,6 +55,18 @@ export interface SlackClaimProviderDeps {
   resolveClaimerSlackIdentities(
     userId: string,
   ): Promise<Array<{ teamId: string; slackUserId: string }>>;
+  /**
+   * Persist a `(platform, team_id, platform_user_id) → lobu_user_id` link. The
+   * store fails closed on re-binding an already-linked key to a DIFFERENT user
+   * (see `linkChatUserIdentity`), so a forged call cannot take over an identity.
+   * Injected so `bind`'s post-claim linking is testable without a live DB.
+   */
+  linkChatUserIdentity(opts: {
+    platform: string;
+    teamId?: string;
+    platformUserId: string;
+    lobuUserId: string;
+  }): Promise<void>;
   /** `users.info` admin/owner flags for the claimer. */
   usersInfo: SlackWebApi["usersInfo"];
   /**
@@ -166,7 +177,7 @@ export function slackClaimProvider(
           // Always persist every identity the claimer has already proven via
           // Slack OIDC (team-scoped keys they actually signed in under).
           for (const id of identities) {
-            await linkChatUserIdentity({
+            await deps.linkChatUserIdentity({
               platform: "slack",
               teamId: id.teamId,
               platformUserId: id.slackUserId,
@@ -187,7 +198,7 @@ export function slackClaimProvider(
               return i.teamId.toUpperCase() === installTeam;
             });
           if (claimerIsInstaller && pending.installerUserId) {
-            await linkChatUserIdentity({
+            await deps.linkChatUserIdentity({
               platform: "slack",
               teamId: pending.teamId,
               platformUserId: pending.installerUserId,

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -162,10 +162,8 @@ export function slackClaimProvider(
         // later event team ids that match the install row still resolve.
         try {
           const identities = await deps.resolveClaimerSlackIdentities(userId);
-          const installer = pending.installerUserId?.toUpperCase() ?? null;
-          const claimerIsInstaller =
-            installer != null &&
-            identities.some((i) => i.slackUserId.toUpperCase() === installer);
+          // Always persist every identity the claimer has already proven via
+          // Slack OIDC (team-scoped keys they actually signed in under).
           for (const id of identities) {
             await linkChatUserIdentity({
               platform: "slack",
@@ -174,6 +172,19 @@ export function slackClaimProvider(
               lobuUserId: userId,
             });
           }
+          // Extra stamp of the install's tenant key (T… or Grid E…) ONLY when
+          // the claimer is proven to be the installer:
+          // - plain workspace: same teamId + same U… (U is workspace-local)
+          // - Grid (enterpriseId set): same U… on any team (U is enterprise-global)
+          const installer = pending.installerUserId?.toUpperCase() ?? null;
+          const installTeam = pending.teamId.toUpperCase();
+          const claimerIsInstaller =
+            installer != null &&
+            identities.some((i) => {
+              if (i.slackUserId.toUpperCase() !== installer) return false;
+              if (pending.enterpriseId) return true;
+              return i.teamId.toUpperCase() === installTeam;
+            });
           if (claimerIsInstaller && pending.installerUserId) {
             await linkChatUserIdentity({
               platform: "slack",

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -8,6 +8,7 @@ import {
   ClaimMoveBlockedError,
 } from "./connection-claim.js";
 import type { SlackWebApi } from "./slack-web.js";
+import logger from "../../utils/logger.js";
 
 /**
  * The Slack adapter for the provider-agnostic claim engine (see
@@ -193,8 +194,20 @@ export function slackClaimProvider(
               lobuUserId: userId,
             });
           }
-        } catch {
+        } catch (err) {
           // Swallow — claim already committed; identity can be healed later.
+          // Log so a persistent identity-link failure is visible to on-call
+          // rather than silently degrading Builder admin tools / owner routing.
+          logger.warn(
+            {
+              err,
+              installationId,
+              userId,
+              installerUserId: pending.installerUserId,
+              teamId: pending.teamId,
+            },
+            "slackClaimProvider.bind: installer identity link failed after claim committed",
+          );
         }
         return { bindingId: installationId };
       } catch (err) {

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -184,12 +184,20 @@ export function slackClaimProvider(
           // accounts without an id_token resolve with an empty team; their bare
           // user proof is useful for Grid installer matching below but must not
           // create an unscoped chat identity.
+          //
+          // Keys are CANONICALIZED to uppercase. The entity-graph source yields
+          // the raw `team:user` identifier, and `resolveChatUserIdentity` is an
+          // exact SQL match with no folding — a row stored as `t-claim/u-…`
+          // could never serve an inbound Slack event carrying `T-CLAIM/U-…`,
+          // so the claimer would silently lose Builder admin tools. Writing
+          // canonical keys also keeps this loop consistent with the
+          // case-insensitive installer checks below.
           for (const id of identities) {
             if (!id.teamId) continue;
             await deps.linkChatUserIdentity({
               platform: "slack",
-              teamId: id.teamId,
-              platformUserId: id.slackUserId,
+              teamId: id.teamId.toUpperCase(),
+              platformUserId: id.slackUserId.toUpperCase(),
               lobuUserId: userId,
             });
           }
@@ -221,8 +229,8 @@ export function slackClaimProvider(
           ) {
             await deps.linkChatUserIdentity({
               platform: "slack",
-              teamId: pending.teamId,
-              platformUserId: pending.installerUserId,
+              teamId: installTeam,
+              platformUserId: installer,
               lobuUserId: userId,
             });
           }

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -120,10 +120,16 @@ async function authorizeSlackClaim(
   // STRICTLY Grid-gated (`enterpriseId` non-null): plain workspaces let ANY
   // non-admin install apps, so installer-match must NOT grant authority there
   // (the authority model is admin-not-installer).
+  // Case-normalized on both sides: the entity-graph source yields the raw
+  // `team:user` identifier (unlike the account / linked-chat sources, which
+  // uppercase) and `installerUserId` is stored verbatim from Slack's payload,
+  // so a case-sensitive compare would deny a legitimate Grid admin. `bind`
+  // normalizes the same way — the two must agree on who the installer is.
+  const installerId = pending.installerUserId?.toUpperCase() ?? null;
   if (
     pending.enterpriseId &&
-    pending.installerUserId &&
-    identities.some((i) => i.slackUserId === pending.installerUserId)
+    installerId &&
+    identities.some((i) => i.slackUserId.toUpperCase() === installerId)
   ) {
     return { status: "authorized", subjectName: pending.teamName };
   }
@@ -174,9 +180,12 @@ export function slackClaimProvider(
         // later event team ids that match the install row still resolve.
         try {
           const identities = await deps.resolveClaimerSlackIdentities(userId);
-          // Always persist every identity the claimer has already proven via
-          // Slack OIDC (team-scoped keys they actually signed in under).
+          // Persist only identities with a proven team scope. Older Better Auth
+          // accounts without an id_token resolve with an empty team; their bare
+          // user proof is useful for Grid installer matching below but must not
+          // create an unscoped chat identity.
           for (const id of identities) {
+            if (!id.teamId) continue;
             await deps.linkChatUserIdentity({
               platform: "slack",
               teamId: id.teamId,
@@ -184,8 +193,9 @@ export function slackClaimProvider(
               lobuUserId: userId,
             });
           }
-          // Extra stamp of the install's tenant key (T… or Grid E…) ONLY when
-          // the claimer is proven to be the installer:
+          // Ensure the install's tenant key (T… or Grid E…) is linked ONLY when
+          // the claimer is proven to be the installer, without rewriting the
+          // exact identity already linked above:
           // - plain workspace: same teamId + same U… (U is workspace-local)
           // - Grid (enterpriseId set): same U… on any team (U is enterprise-global)
           const installer = pending.installerUserId?.toUpperCase() ?? null;
@@ -197,7 +207,18 @@ export function slackClaimProvider(
               if (pending.enterpriseId) return true;
               return i.teamId.toUpperCase() === installTeam;
             });
-          if (claimerIsInstaller && pending.installerUserId) {
+          const installIdentityAlreadyLinked =
+            installer != null &&
+            identities.some(
+              (i) =>
+                i.teamId.toUpperCase() === installTeam &&
+                i.slackUserId.toUpperCase() === installer,
+            );
+          if (
+            claimerIsInstaller &&
+            !installIdentityAlreadyLinked &&
+            pending.installerUserId
+          ) {
             await deps.linkChatUserIdentity({
               platform: "slack",
               teamId: pending.teamId,
@@ -217,7 +238,7 @@ export function slackClaimProvider(
               installerUserId: pending.installerUserId,
               teamId: pending.teamId,
             },
-            "slackClaimProvider.bind: installer identity link failed after claim committed",
+            "Slack claim identity linking failed after claim committed",
           );
         }
         return { bindingId: installationId };

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -162,6 +162,65 @@ export async function resolveBuilderAdminTools(args: {
   }
 }
 
+/**
+ * The two team keys the Builder admin grant is looked up under, derived from a
+ * message payload. Extracted from the dispatch path so the
+ * metadata→tenant→grant composition is testable on its own — the pieces
+ * (identity link, tenant store, grant) each had coverage, but the wiring
+ * between them did not, and that is precisely where a runtime-id-vs-slug
+ * mismatch silently disables the grant for BYO connections.
+ *
+ * - `teamId`: the real workspace/enterprise id from `platformMetadata` (T… /
+ *   E…). `routingTeamId` is a ROUTING key (platform name for DMs, channel id
+ *   for groups — see message-handler-bridge `payloadTeamId`), NOT a workspace
+ *   id, so it is only the fallback that keeps non-Slack callers working.
+ * - `alternateTeamId`: Grid enterprise installs key connections + some identity
+ *   rows on E… while events carry the workspace T…. The connection's tenant is
+ *   offered as an exact second key only — never a global U… collapse — and is
+ *   omitted when it would duplicate `teamId`.
+ *
+ * Fails OPEN on the alternate only (undefined ⇒ the grant just falls back to
+ * the primary key); it never invents a team, so it cannot over-grant.
+ */
+export async function resolveGrantTeamKeys(args: {
+  platform?: string;
+  organizationId?: string;
+  routingTeamId?: string;
+  platformMetadata?: Record<string, unknown>;
+}): Promise<{ teamId?: string; alternateTeamId?: string }> {
+  const teamId =
+    platformMetadataString(args.platformMetadata, "teamId") ?? args.routingTeamId;
+  const connectionId = platformMetadataString(
+    args.platformMetadata,
+    "connectionId",
+  );
+  if (args.platform !== "slack" || !args.organizationId || !connectionId) {
+    return { teamId };
+  }
+  try {
+    // Scoped + fail-closed in the store (see `resolveActiveChatConnectionTenant`):
+    // org + runtime connection id + connector, and active chat rows only, so a
+    // reused slug or a paused install can never supply the alternate team for
+    // this privilege grant.
+    const tenant = await resolveActiveChatConnectionTenant(
+      getDb(),
+      args.organizationId,
+      connectionId,
+      "slack",
+    );
+    return {
+      teamId,
+      alternateTeamId: tenant && tenant !== teamId ? tenant : undefined,
+    };
+  } catch (err) {
+    logger.warn(
+      { err, organizationId: args.organizationId, connectionId },
+      "Failed to resolve alternate Slack tenant for Builder admin grant",
+    );
+    return { teamId };
+  }
+}
+
 export function buildRunJobToken(args: {
   userId: string;
   conversationId: string;
@@ -440,45 +499,13 @@ export class MessageConsumer {
       // Builder admin-tool grant: only the org's system agent, only when the
       // human driving this turn is an owner/admin. Fails closed.
       //
-      // `data.teamId` is a ROUTING key (platform name for DMs, channel id for
-      // groups — see message-handler-bridge `payloadTeamId`), NOT the Slack
-      // workspace id. Privilege lookups need the real workspace/enterprise id
-      // from platformMetadata (T… / E…); falling back to data.teamId keeps
-      // non-Slack callers working.
-      const workspaceTeamId =
-        platformMetadataString(data.platformMetadata, "teamId") ?? data.teamId;
-      // Grid enterprise installs key connections + some identity rows on E…,
-      // while events carry the workspace T…. Offer that tenant as an
-      // alternate exact key only (still team-scoped — not a global U… collapse).
-      let alternateTeamId: string | undefined;
-      const connectionId = platformMetadataString(
-        data.platformMetadata,
-        "connectionId",
-      );
-      if (
-        data.platform === "slack" &&
-        data.organizationId &&
-        connectionId
-      ) {
-        try {
-          // Scoped + fail-closed in the store (see
-          // `resolveActiveChatConnectionTenant`): org + runtime connection id +
-          // connector, and active chat rows only, so a reused slug or a paused
-          // install can never supply the alternate team for this privilege grant.
-          const tenant = await resolveActiveChatConnectionTenant(
-            getDb(),
-            data.organizationId,
-            connectionId,
-            "slack",
-          );
-          if (tenant && tenant !== workspaceTeamId) alternateTeamId = tenant;
-        } catch (err) {
-          logger.warn(
-            { err, organizationId: data.organizationId, connectionId },
-            "Failed to resolve alternate Slack tenant for Builder admin grant",
-          );
-        }
-      }
+      const { teamId: workspaceTeamId, alternateTeamId } =
+        await resolveGrantTeamKeys({
+          platform: data.platform,
+          organizationId: data.organizationId,
+          routingTeamId: data.teamId,
+          platformMetadata: data.platformMetadata,
+        });
       const adminTools = await resolveBuilderAdminTools({
         agentId: data.agentId,
         organizationId: data.organizationId,

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -456,13 +456,19 @@ export class MessageConsumer {
       );
       if (
         data.platform === "slack" &&
+        data.organizationId &&
         connectionSlug &&
         connectionSlug !== workspaceTeamId
       ) {
         try {
+          // Scope by org + slack chat connection so a reused slug in another
+          // tenant cannot supply the alternate team for this privilege grant.
           const tenantRows = await getDb()<{ external_tenant_id: string | null }>`
             SELECT external_tenant_id FROM connections
-            WHERE slug = ${connectionSlug} AND deleted_at IS NULL
+            WHERE organization_id = ${data.organizationId}
+              AND slug = ${connectionSlug}
+              AND connector_key = 'slack'
+              AND deleted_at IS NULL
             LIMIT 1
           `;
           const tenant = tenantRows[0]?.external_tenant_id ?? undefined;

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -451,30 +451,32 @@ export class MessageConsumer {
       // while events carry the workspace T…. Offer that tenant as an
       // alternate exact key only (still team-scoped — not a global U… collapse).
       let alternateTeamId: string | undefined;
-      const connectionSlug = platformMetadataString(
+      const connectionId = platformMetadataString(
         data.platformMetadata,
         "connectionId",
       );
       if (
         data.platform === "slack" &&
         data.organizationId &&
-        connectionSlug &&
-        connectionSlug !== workspaceTeamId
+        connectionId
       ) {
         try {
           // Scoped + fail-closed in the store (see
-          // `resolveActiveChatConnectionTenant`): org + slug + connector, and
-          // active rows only, so a reused slug or a paused install can never
-          // supply the alternate team for this privilege grant.
+          // `resolveActiveChatConnectionTenant`): org + runtime connection id +
+          // connector, and active chat rows only, so a reused slug or a paused
+          // install can never supply the alternate team for this privilege grant.
           const tenant = await resolveActiveChatConnectionTenant(
             getDb(),
             data.organizationId,
-            connectionSlug,
+            connectionId,
             "slack",
           );
           if (tenant && tenant !== workspaceTeamId) alternateTeamId = tenant;
-        } catch {
-          // Best-effort — grant still tries workspaceTeamId alone.
+        } catch (err) {
+          logger.warn(
+            { err, organizationId: data.organizationId, connectionId },
+            "Failed to resolve alternate Slack tenant for Builder admin grant",
+          );
         }
       }
       const adminTools = await resolveBuilderAdminTools({

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -43,6 +43,7 @@ import {
 import { buildWorkerTokenClaims } from "./worker-token-claims.js";
 import { resolvePinnedSelection } from "../../lobu/stores/environment-store.js";
 import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
+import { resolveActiveChatConnectionTenant } from "../../lobu/stores/connections-projection.js";
 import { getDb } from "../../db/client.js";
 import {
   classifyConversation,
@@ -461,20 +462,16 @@ export class MessageConsumer {
         connectionSlug !== workspaceTeamId
       ) {
         try {
-          // Scope by org + slack chat connection so a reused slug in another
-          // tenant cannot supply the alternate team for this privilege grant.
-          // Require a LIVE row (status = 'active'): a paused/stopped install
-          // lingers for token refresh and must not seed an alternate team.
-          const tenantRows = await getDb()<{ external_tenant_id: string | null }>`
-            SELECT external_tenant_id FROM connections
-            WHERE organization_id = ${data.organizationId}
-              AND slug = ${connectionSlug}
-              AND connector_key = 'slack'
-              AND status = 'active'
-              AND deleted_at IS NULL
-            LIMIT 1
-          `;
-          const tenant = tenantRows[0]?.external_tenant_id ?? undefined;
+          // Scoped + fail-closed in the store (see
+          // `resolveActiveChatConnectionTenant`): org + slug + connector, and
+          // active rows only, so a reused slug or a paused install can never
+          // supply the alternate team for this privilege grant.
+          const tenant = await resolveActiveChatConnectionTenant(
+            getDb(),
+            data.organizationId,
+            connectionSlug,
+            "slack",
+          );
           if (tenant && tenant !== workspaceTeamId) alternateTeamId = tenant;
         } catch {
           // Best-effort — grant still tries workspaceTeamId alone.

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -415,12 +415,20 @@ export class MessageConsumer {
       // A on PR #865. Every dispatch is bound to its claimed runs.id.
       // Builder admin-tool grant: only the org's system agent, only when the
       // human driving this turn is an owner/admin. Fails closed.
+      //
+      // `data.teamId` is a ROUTING key (platform name for DMs, channel id for
+      // groups — see message-handler-bridge `payloadTeamId`), NOT the Slack
+      // workspace id. Privilege lookups need the real workspace/enterprise id
+      // from platformMetadata (T… / E…); falling back to data.teamId keeps
+      // non-Slack callers working.
+      const workspaceTeamId =
+        platformMetadataString(data.platformMetadata, "teamId") ?? data.teamId;
       const adminTools = await resolveBuilderAdminTools({
         agentId: data.agentId,
         organizationId: data.organizationId,
         userId: data.userId,
         platform: data.platform,
-        teamId: data.teamId,
+        teamId: workspaceTeamId,
       });
 
       // Resolve THIS CONVERSATION's pinned runtime provider from its Environment.

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -101,7 +101,18 @@ export async function resolveBuilderAdminTools(args: {
    * the session's Lobu user id and is used directly.
    */
   platform?: string;
+  /**
+   * Workspace team id for identity lookup (Slack `T…` from the event). Prefer
+   * this over routing keys; see call site for platformMetadata.teamId.
+   */
   teamId?: string;
+  /**
+   * Optional second team key to try when the first miss (e.g. Slack connection
+   * `external_tenant_id` = Grid enterprise `E…` while the event carries a
+   * workspace `T…`). Only an exact row under that key counts — never a
+   * cross-team unique-user collapse.
+   */
+  alternateTeamId?: string;
 }): Promise<string[] | undefined> {
   if (!args.agentId || !args.organizationId || !args.userId) return undefined;
   try {
@@ -112,9 +123,21 @@ export async function resolveBuilderAdminTools(args: {
     const platform = args.platform;
     const isChatPlatform =
       platform != null && platform !== "api" && platform !== "";
-    const lobuUserId = isChatPlatform
+    let lobuUserId: string | null | undefined = isChatPlatform
       ? await resolveChatUserIdentity(platform, args.teamId, args.userId)
       : args.userId;
+    if (
+      !lobuUserId &&
+      isChatPlatform &&
+      args.alternateTeamId &&
+      args.alternateTeamId !== args.teamId
+    ) {
+      lobuUserId = await resolveChatUserIdentity(
+        platform,
+        args.alternateTeamId,
+        args.userId,
+      );
+    }
     if (!lobuUserId) return undefined;
     const sql = getDb();
     const rows = (await sql`
@@ -423,12 +446,38 @@ export class MessageConsumer {
       // non-Slack callers working.
       const workspaceTeamId =
         platformMetadataString(data.platformMetadata, "teamId") ?? data.teamId;
+      // Grid enterprise installs key connections + some identity rows on E…,
+      // while events carry the workspace T…. Offer that tenant as an
+      // alternate exact key only (still team-scoped — not a global U… collapse).
+      let alternateTeamId: string | undefined;
+      const connectionSlug = platformMetadataString(
+        data.platformMetadata,
+        "connectionId",
+      );
+      if (
+        data.platform === "slack" &&
+        connectionSlug &&
+        connectionSlug !== workspaceTeamId
+      ) {
+        try {
+          const tenantRows = await getDb()<{ external_tenant_id: string | null }>`
+            SELECT external_tenant_id FROM connections
+            WHERE slug = ${connectionSlug} AND deleted_at IS NULL
+            LIMIT 1
+          `;
+          const tenant = tenantRows[0]?.external_tenant_id ?? undefined;
+          if (tenant && tenant !== workspaceTeamId) alternateTeamId = tenant;
+        } catch {
+          // Best-effort — grant still tries workspaceTeamId alone.
+        }
+      }
       const adminTools = await resolveBuilderAdminTools({
         agentId: data.agentId,
         organizationId: data.organizationId,
         userId: data.userId,
         platform: data.platform,
         teamId: workspaceTeamId,
+        alternateTeamId,
       });
 
       // Resolve THIS CONVERSATION's pinned runtime provider from its Environment.

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -463,11 +463,14 @@ export class MessageConsumer {
         try {
           // Scope by org + slack chat connection so a reused slug in another
           // tenant cannot supply the alternate team for this privilege grant.
+          // Require a LIVE row (status = 'active'): a paused/stopped install
+          // lingers for token refresh and must not seed an alternate team.
           const tenantRows = await getDb()<{ external_tenant_id: string | null }>`
             SELECT external_tenant_id FROM connections
             WHERE organization_id = ${data.organizationId}
               AND slug = ${connectionSlug}
               AND connector_key = 'slack'
+              AND status = 'active'
               AND deleted_at IS NULL
             LIMIT 1
           `;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -58,6 +58,7 @@ import { slackClaimProvider } from "./gateway/connections/slack-claim";
 import { resolveClaimingUserSlackIdentities } from "./gateway/connections/slack-claim-identities";
 import { autoLinkBuilderAndWelcome } from "./gateway/connections/slack-claim-onboarding";
 import { createSlackWebApi } from "./gateway/connections/slack-web";
+import { linkChatUserIdentity } from "./lobu/stores/chat-identity";
 import {
 	getMaxReservedLocks,
 	getReservedLockCount,
@@ -2519,6 +2520,7 @@ function buildSlackClaimProvider(): ClaimProvider {
 				: null;
 		},
 		resolveClaimerSlackIdentities: resolveClaimingUserSlackIdentities,
+		linkChatUserIdentity: (opts) => linkChatUserIdentity(opts),
 		usersInfo: (botToken, uid) => createSlackWebApi().usersInfo(botToken, uid),
 		claim: async (pending, organizationId, confirmMove) => {
 			const core = getLobuCoreServices();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2520,7 +2520,7 @@ function buildSlackClaimProvider(): ClaimProvider {
 				: null;
 		},
 		resolveClaimerSlackIdentities: resolveClaimingUserSlackIdentities,
-		linkChatUserIdentity: (opts) => linkChatUserIdentity(opts),
+		linkChatUserIdentity,
 		usersInfo: (botToken, uid) => createSlackWebApi().usersInfo(botToken, uid),
 		claim: async (pending, organizationId, confirmMove) => {
 			const core = getLobuCoreServices();

--- a/packages/server/src/lobu/stores/chat-identity.ts
+++ b/packages/server/src/lobu/stores/chat-identity.ts
@@ -19,25 +19,33 @@ import { getDb } from "../../db/client.js";
 /**
  * The Lobu user id a chat-platform user has linked to, or null.
  *
- * Scoped by workspace: `platform_user_id` is only unique WITHIN a workspace, so
- * the same id can map to different Lobu users across workspaces. This query
- * filters on all three columns of the `(platform, team_id, platform_user_id)`
- * primary key, so it returns at most one row — the workspace scoping is what
- * makes the lookup unambiguous. Callers use this to grant privilege (builder
- * admin tools, owner re-bind), so an unlinked id must resolve to null, never to
- * the wrong user.
+ * Prefer a workspace-scoped match on `(platform, team_id, platform_user_id)`.
+ * When that misses, fall back to a UNIQUE match on `(platform, platform_user_id)`
+ * alone — Slack Grid keeps the same `U…` id across workspaces in an enterprise,
+ * and managed installs may link under the enterprise id (`E…`) while inbound
+ * events carry a workspace id (`T…`). Ambiguous multi-user matches still fail
+ * closed (null): privilege callers must never guess.
  */
 export async function resolveChatUserIdentity(
 	platform: string,
 	teamId: string | undefined,
 	platformUserId: string,
 ): Promise<string | null> {
-	const rows = await getDb()<{ lobu_user_id: string }>`
+	const sql = getDb();
+	const rows = await sql<{ lobu_user_id: string }>`
     SELECT lobu_user_id FROM chat_user_identities
     WHERE platform = ${platform} AND team_id = ${teamId ?? ""} AND platform_user_id = ${platformUserId}
     LIMIT 1
   `;
-	return rows[0]?.lobu_user_id ?? null;
+	if (rows[0]?.lobu_user_id) return rows[0].lobu_user_id;
+
+	// Unique-by-platform-user fallback (Grid enterprise id vs workspace team id).
+	const any = await sql<{ lobu_user_id: string }>`
+    SELECT DISTINCT lobu_user_id FROM chat_user_identities
+    WHERE platform = ${platform} AND platform_user_id = ${platformUserId}
+  `;
+	if (any.length === 1) return any[0]!.lobu_user_id;
+	return null;
 }
 
 /**

--- a/packages/server/src/lobu/stores/chat-identity.ts
+++ b/packages/server/src/lobu/stores/chat-identity.ts
@@ -19,33 +19,29 @@ import { getDb } from "../../db/client.js";
 /**
  * The Lobu user id a chat-platform user has linked to, or null.
  *
- * Prefer a workspace-scoped match on `(platform, team_id, platform_user_id)`.
- * When that misses, fall back to a UNIQUE match on `(platform, platform_user_id)`
- * alone — Slack Grid keeps the same `U…` id across workspaces in an enterprise,
- * and managed installs may link under the enterprise id (`E…`) while inbound
- * events carry a workspace id (`T…`). Ambiguous multi-user matches still fail
- * closed (null): privilege callers must never guess.
+ * Scoped by workspace: `platform_user_id` is only unique WITHIN a workspace, so
+ * the same id can map to different Lobu users across workspaces. This query
+ * filters on all three columns of the `(platform, team_id, platform_user_id)`
+ * primary key, so it returns at most one row — the workspace scoping is what
+ * makes the lookup unambiguous. Callers use this to grant privilege (builder
+ * admin tools, owner re-bind), so an unlinked id must resolve to null, never to
+ * the wrong user.
+ *
+ * Callers that may hold a Grid enterprise id (`E…`) OR a workspace id (`T…`)
+ * should try both keys themselves (e.g. message team + connection
+ * external_tenant_id) rather than collapsing isolation here.
  */
 export async function resolveChatUserIdentity(
 	platform: string,
 	teamId: string | undefined,
 	platformUserId: string,
 ): Promise<string | null> {
-	const sql = getDb();
-	const rows = await sql<{ lobu_user_id: string }>`
+	const rows = await getDb()<{ lobu_user_id: string }>`
     SELECT lobu_user_id FROM chat_user_identities
     WHERE platform = ${platform} AND team_id = ${teamId ?? ""} AND platform_user_id = ${platformUserId}
     LIMIT 1
   `;
-	if (rows[0]?.lobu_user_id) return rows[0].lobu_user_id;
-
-	// Unique-by-platform-user fallback (Grid enterprise id vs workspace team id).
-	const any = await sql<{ lobu_user_id: string }>`
-    SELECT DISTINCT lobu_user_id FROM chat_user_identities
-    WHERE platform = ${platform} AND platform_user_id = ${platformUserId}
-  `;
-	if (any.length === 1) return any[0]!.lobu_user_id;
-	return null;
+	return rows[0]?.lobu_user_id ?? null;
 }
 
 /**

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -319,6 +319,36 @@ export async function upsertChatConnectionProjection(
 
 /** Soft-delete the `connections` projection for a chat connection (by slug),
  *  inside the caller's transaction. Mirrors the legacy hard delete. */
+/**
+ * The provider tenant id (`external_tenant_id`) of a LIVE chat connection, or
+ * null when there is no such active row.
+ *
+ * Scoped by (org, slug, connector) so a slug reused in another tenant can never
+ * supply this org's tenant, and restricted to `status = 'active'`: a paused or
+ * stopped install lingers for token refresh and must not be treated as a live
+ * tenant. Callers use the result as a SECOND exact identity key (Slack Grid
+ * keys `chat_user_identities` on the enterprise `E…` while inbound events carry
+ * the workspace `T…`), so a wrong or stale row here would widen a privilege
+ * lookup — hence the narrow, fail-closed predicate.
+ */
+export async function resolveActiveChatConnectionTenant(
+  sql: any,
+  orgId: string,
+  slug: string,
+  connectorKey: string,
+): Promise<string | null> {
+  const rows = (await sql`
+    SELECT external_tenant_id FROM connections
+    WHERE organization_id = ${orgId}
+      AND slug = ${slug}
+      AND connector_key = ${connectorKey}
+      AND status = 'active'
+      AND deleted_at IS NULL
+    LIMIT 1
+  `) as Array<{ external_tenant_id: string | null }>;
+  return rows[0]?.external_tenant_id ?? null;
+}
+
 export async function softDeleteChatConnectionProjection(
   sql: any,
   orgId: string | null | undefined,

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -14,7 +14,7 @@
 
 import type { StoredConnection } from "@lobu/core";
 import { createLogger } from "@lobu/core";
-import { tsTime } from "../../db/client";
+import { type DbClient, tsTime } from "../../db/client";
 
 const logger = createLogger("connections-projection");
 
@@ -317,38 +317,36 @@ export async function upsertChatConnectionProjection(
   `;
 }
 
-/** Soft-delete the `connections` projection for a chat connection (by slug),
- *  inside the caller's transaction. Mirrors the legacy hard delete. */
 /**
  * The provider tenant id (`external_tenant_id`) of a LIVE chat connection, or
  * null when there is no such active row.
  *
- * Scoped by (org, slug, connector) so a slug reused in another tenant can never
- * supply this org's tenant, and restricted to `status = 'active'`: a paused or
- * stopped install lingers for token refresh and must not be treated as a live
- * tenant. Callers use the result as a SECOND exact identity key (Slack Grid
- * keys `chat_user_identities` on the enterprise `E…` while inbound events carry
- * the workspace `T…`), so a wrong or stale row here would widen a privilege
- * lookup — hence the narrow, fail-closed predicate.
+ * Scoped by (org, runtime connection id, connector) and restricted to active
+ * chat rows. Callers use the result as a second exact identity key, so a wrong
+ * or stale row here would widen a privilege lookup.
  */
 export async function resolveActiveChatConnectionTenant(
-  sql: any,
+  sql: DbClient,
   orgId: string,
-  slug: string,
+  connectionId: string,
   connectorKey: string,
 ): Promise<string | null> {
-  const rows = (await sql`
+  const slug = runtimeConnectionIdToSlug(connectionId);
+  const rows = await sql<{ external_tenant_id: string | null }>`
     SELECT external_tenant_id FROM connections
     WHERE organization_id = ${orgId}
       AND slug = ${slug}
       AND connector_key = ${connectorKey}
+      AND credential_mode IS NOT NULL
       AND status = 'active'
       AND deleted_at IS NULL
     LIMIT 1
-  `) as Array<{ external_tenant_id: string | null }>;
+  `;
   return rows[0]?.external_tenant_id ?? null;
 }
 
+/** Soft-delete the `connections` projection for a chat connection (by slug),
+ *  inside the caller's transaction. Mirrors the legacy hard delete. */
 export async function softDeleteChatConnectionProjection(
   sql: any,
   orgId: string | null | undefined,


### PR DESCRIPTION
## Summary
- Use real Slack workspace team id (`platformMetadata.teamId`) for Builder admin-tool grant lookups — payload `teamId` is only a routing key (`slack` / channel id), which silently dropped the grant.
- On managed Slack claim, link installer Slack id → claimer Lobu user in `chat_user_identities` (previously only `/lobu` preview claims wrote this).
- Unique `(platform, platform_user_id)` fallback when team-scoped miss is unambiguous (Grid `E…` vs workspace `T…`); multi-user maps still fail closed.

Without this, org owners DMing the system Builder after a normal Slack install never received `manage_agents` / `manage_connections` / etc.

## Test plan
- [x] `builder-admin-tools-platform-identity.test.ts` — 7/7 green (team link, unlinked, wrong team, api path, non-owner, unique-U fallback, ambiguous withhold)
- [ ] CI green
- [ ] E2E after deploy: DM Builder on LobuSandbox → token carries `adminTools`; ask it to list agents / who you are with org context

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Slack claim onboarding now links verified claimer Slack identities after a successful claim, and may also link the installer identity when confidently matched.
  - Admin-tool authorization can optionally resolve grants using an alternate Slack workspace/enterprise tenant identifier for chat-originated turns.

- **Bug Fixes**
  - Improved installer identity matching to be case-insensitive.
  - Admin-tool grants are withheld when only an unrelated enterprise mapping exists.

- **Tests**
  - Added/expanded integration and unit tests for alternate-tenant resolution, fail-closed behavior, and identity-linking/casing.

- **Documentation**
  - Clarified guidance for handling multiple workspace/external-tenant keys when resolving chat identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->