### PR TITLE
fix(memory): entity-type settings gear + derived entity_count

### DIFF
--- a/packages/server/src/__tests__/integration/entity-schema/derived-entity-routing.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/derived-entity-routing.test.ts
@@ -91,6 +91,7 @@ describe('derived entity routing (list + resolve_path)', () => {
         slug: string;
         metadata: Record<string, unknown>;
       }>;
+      metadata?: { total_count?: number };
     };
     const byName = Object.fromEntries(res.entities.map((e) => [e.name, e]));
     expect(Object.keys(byName).sort()).toEqual(['acme', 'globex']);
@@ -98,6 +99,29 @@ describe('derived entity routing (list + resolve_path)', () => {
     // Org B's $99 acme event must NOT leak into org A's aggregate.
     expect(Number(byName.acme.metadata.total_spend)).toBe(15);
     expect(Number(byName.acme.metadata.purchases)).toBe(2);
+  });
+
+  it('entity_type list/get entity_count matches derived list total (not stored-row COUNT)', async () => {
+    // Regression: Memory rail + schema list used COUNT(entities) only, so
+    // derived types always showed 0 even when list rows existed.
+    const list = (await api.entities.list({ entity_type: 'spend-vendor' })) as {
+      entities: unknown[];
+      metadata?: { total_count?: number };
+    };
+    const listTotal = list.metadata?.total_count ?? list.entities.length;
+    expect(listTotal).toBe(2);
+
+    const types = (await api.entity_schema.listTypes()) as {
+      entity_types?: Array<{ slug: string; entity_count?: number }>;
+    };
+    const spend = types.entity_types?.find((t) => t.slug === 'spend-vendor');
+    expect(spend?.entity_count).toBe(listTotal);
+
+    const got = (await api.entity_schema.getType('spend-vendor')) as {
+      entity_type?: { entity_count?: number; backing_sql?: string | null };
+    };
+    expect(got.entity_type?.backing_sql).toBeTruthy();
+    expect(got.entity_type?.entity_count).toBe(listTotal);
   });
 
   it('resolve_path resolves a derived row by slug into a read-only entity', async () => {

--- a/packages/server/src/__tests__/integration/entity-schema/derived-entity-routing.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/derived-entity-routing.test.ts
@@ -4,8 +4,8 @@
  * Derived ("view") entity types have no rows in `entities` — their rows come
  * from `backing_sql`. This proves the backend abstracts that away so the
  * frontend treats derived rows like stored entities:
- *   - `manage_entity` list returns derived rows in the standard entity shape
- *     (flagged `is_derived`), org-scoped.
+ *   - `manage_entity` list returns derived rows in the standard entity shape,
+ *     org-scoped.
  *   - `resolve_path` resolves a single derived row by slug into a read-only
  *     entity (with inferred `measure_columns`), and 404s an unknown slug.
  */
@@ -122,6 +122,45 @@ describe('derived entity routing (list + resolve_path)', () => {
     };
     expect(got.entity_type?.backing_sql).toBeTruthy();
     expect(got.entity_type?.entity_count).toBe(listTotal);
+
+    const resolved = (await resolvePath({
+      path: `/${orgSlug}`,
+      include_bootstrap: true,
+    })) as {
+      bootstrap?: { entity_types?: Array<{ slug: string; entity_count: number }> };
+    };
+    const bootstrapType = resolved.bootstrap?.entity_types?.find(
+      (type) => type.slug === 'spend-vendor'
+    );
+    expect(bootstrapType?.entity_count).toBe(listTotal);
+  });
+
+  it('keeps type lists available when a connector-backed derived count fails', async () => {
+    await api.entity_schema.createType({
+      slug: 'missing-derived-source',
+      name: 'Missing derived source',
+      backing: {
+        sql: 'SELECT id, name FROM missing_table',
+        connection: 'missing-connection',
+      },
+    });
+
+    const types = (await api.entity_schema.listTypes()) as {
+      entity_types?: Array<{ slug: string; entity_count?: number }>;
+    };
+    const missing = types.entity_types?.find((type) => type.slug === 'missing-derived-source');
+    expect(missing?.entity_count).toBe(0);
+
+    const resolved = (await resolvePath({
+      path: `/${orgSlug}`,
+      include_bootstrap: true,
+    })) as {
+      bootstrap?: { entity_types?: Array<{ slug: string; entity_count: number }> };
+    };
+    const bootstrapType = resolved.bootstrap?.entity_types?.find(
+      (type) => type.slug === 'missing-derived-source'
+    );
+    expect(bootstrapType?.entity_count).toBe(0);
   });
 
   it('resolve_path resolves a derived row by slug into a read-only entity', async () => {

--- a/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
+++ b/packages/server/src/__tests__/integration/pages/public-pages-contract.test.ts
@@ -61,6 +61,27 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
         (${publicOrg.id}, 'brand', 'Brand', 'Tracked public brands', '🏢', NOW(), NOW()),
         (${publicOrg.id}, 'product', 'Product', 'Tracked public products', '📦', NOW(), NOW())
     `;
+    const [brandType] = await sql`
+      SELECT id FROM entity_types
+      WHERE organization_id = ${publicOrg.id} AND slug = 'brand'
+    `;
+    const brandTypeId = Number(brandType?.id);
+    expect(brandTypeId).toBeGreaterThan(0);
+    await sql`
+      INSERT INTO entity_types (
+        organization_id, slug, name, description, icon, backing_sql, created_at, updated_at
+      )
+      VALUES (
+        ${publicOrg.id},
+        'brand-directory',
+        'Brand Directory',
+        'Derived public brand directory',
+        'list',
+        ${`SELECT id, slug, name FROM entities WHERE entity_type_id = ${brandTypeId}`},
+        NOW(),
+        NOW()
+      )
+    `;
 
     const brand = await createTestEntity({
       name: 'Acme Brand',
@@ -192,6 +213,18 @@ describe.skipIf(!WEB_AVAILABLE)('public page contract', () => {
     expect(missing.status).toBe(404);
     expect(missingBody).toContain('Page Not Found');
     expect(missingBody).toContain('noindex,nofollow');
+  });
+
+  it('uses the derived list total on public entity-type pages', async () => {
+    const response = await get('/public-contract-org/brand-directory', {
+      headers: { Accept: 'text/html' },
+      env: { PUBLIC_GATEWAY_URL: publicGatewayUrl },
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('>1 entity</dd>');
+    expect(body).toContain('"entity_count":1');
   });
 
   it('sitemap includes public routes and excludes private workspaces', async () => {

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -5,6 +5,7 @@ import type { ToolContext } from './tools/registry';
 import { type ResolvePathResult, resolvePath } from './tools/resolve_path';
 import {
   batchLoadRelationships,
+  countEntitiesOfType,
   listEntities,
   type RelationshipColumnSpec,
 } from './utils/entity-management';
@@ -414,10 +415,21 @@ async function getPublicOrganizationBySlug(slug: string): Promise<PublicOrganiza
 
 async function getPublicEntityType(
   organizationId: string,
-  slug: string
+  slug: string,
+  ctx: ToolContext
 ): Promise<PublicEntityTypeDetails | null> {
   const sql = getDb();
-  const rows = await sql.unsafe<PublicEntityTypeDetails>(
+  const rows = await sql.unsafe<{
+    id: number;
+    slug: string;
+    name: string;
+    description: string | null;
+    icon: string | null;
+    color: string | null;
+    metadata_schema: Record<string, unknown> | null;
+    backing_sql: string | null;
+    backing_source: string | null;
+  }>(
     `
       SELECT
         et.id,
@@ -427,13 +439,8 @@ async function getPublicEntityType(
         et.icon,
         et.color,
         et.metadata_schema,
-        (
-          SELECT COUNT(*)::int
-          FROM entities e
-          WHERE e.organization_id = et.organization_id
-            AND e.entity_type_id = et.id
-            AND e.deleted_at IS NULL
-        ) AS entity_count
+        et.backing_sql,
+        et.backing_source
       FROM entity_types et
       WHERE et.organization_id = $1
         AND et.slug = $2
@@ -446,7 +453,28 @@ async function getPublicEntityType(
     `,
     [organizationId, slug]
   );
-  return rows[0] ?? null;
+  const row = rows[0];
+  if (!row) return null;
+  // Same stored+derived count path as manage_entity_schema / bootstrap list.
+  const entity_count = await countEntitiesOfType(
+    {
+      id: Number(row.id),
+      slug: row.slug,
+      backing_sql: row.backing_sql,
+      backing_source: row.backing_source,
+    },
+    ctx
+  );
+  return {
+    id: Number(row.id),
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+    icon: row.icon,
+    color: row.color,
+    metadata_schema: row.metadata_schema,
+    entity_count,
+  };
 }
 
 async function getPublicEntityTypeList(
@@ -1028,7 +1056,7 @@ export async function buildPublicPageModel(
     }
 
     if (segments.length === 2) {
-      const entityType = await getPublicEntityType(organization.id, segments[1]!);
+      const entityType = await getPublicEntityType(organization.id, segments[1]!, toolCtx);
       if (!entityType) {
         return applyBootstrapStrip(
           buildNotFoundModel(organization, requestUrl, normalizedPath),

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -5,7 +5,6 @@ import type { ToolContext } from './tools/registry';
 import { type ResolvePathResult, resolvePath } from './tools/resolve_path';
 import {
   batchLoadRelationships,
-  countEntitiesOfType,
   listEntities,
   type RelationshipColumnSpec,
 } from './utils/entity-management';
@@ -32,6 +31,8 @@ interface PublicEntityTypeDetails {
   entity_count: number;
   metadata_schema: Record<string, unknown> | null;
 }
+
+type PublicEntityTypeDefinition = Omit<PublicEntityTypeDetails, 'entity_count'>;
 
 interface PublicEntityListItem {
   id: number;
@@ -415,21 +416,10 @@ async function getPublicOrganizationBySlug(slug: string): Promise<PublicOrganiza
 
 async function getPublicEntityType(
   organizationId: string,
-  slug: string,
-  ctx: ToolContext
-): Promise<PublicEntityTypeDetails | null> {
+  slug: string
+): Promise<PublicEntityTypeDefinition | null> {
   const sql = getDb();
-  const rows = await sql.unsafe<{
-    id: number;
-    slug: string;
-    name: string;
-    description: string | null;
-    icon: string | null;
-    color: string | null;
-    metadata_schema: Record<string, unknown> | null;
-    backing_sql: string | null;
-    backing_source: string | null;
-  }>(
+  const rows = await sql.unsafe<PublicEntityTypeDefinition>(
     `
       SELECT
         et.id,
@@ -438,9 +428,7 @@ async function getPublicEntityType(
         et.description,
         et.icon,
         et.color,
-        et.metadata_schema,
-        et.backing_sql,
-        et.backing_source
+        et.metadata_schema
       FROM entity_types et
       WHERE et.organization_id = $1
         AND et.slug = $2
@@ -453,28 +441,7 @@ async function getPublicEntityType(
     `,
     [organizationId, slug]
   );
-  const row = rows[0];
-  if (!row) return null;
-  // Same stored+derived count path as manage_entity_schema / bootstrap list.
-  const entity_count = await countEntitiesOfType(
-    {
-      id: Number(row.id),
-      slug: row.slug,
-      backing_sql: row.backing_sql,
-      backing_source: row.backing_source,
-    },
-    ctx
-  );
-  return {
-    id: Number(row.id),
-    slug: row.slug,
-    name: row.name,
-    description: row.description,
-    icon: row.icon,
-    color: row.color,
-    metadata_schema: row.metadata_schema,
-    entity_count,
-  };
+  return rows[0] ?? null;
 }
 
 async function getPublicEntityTypeList(
@@ -1056,8 +1023,8 @@ export async function buildPublicPageModel(
     }
 
     if (segments.length === 2) {
-      const entityType = await getPublicEntityType(organization.id, segments[1]!, toolCtx);
-      if (!entityType) {
+      const entityTypeDefinition = await getPublicEntityType(organization.id, segments[1]!);
+      if (!entityTypeDefinition) {
         return applyBootstrapStrip(
           buildNotFoundModel(organization, requestUrl, normalizedPath),
           subdomainOrg
@@ -1065,8 +1032,12 @@ export async function buildPublicPageModel(
       }
       const [ownerResolvedPath, entityList] = await Promise.all([
         resolvePublicPath({ path: `/${organization.slug}`, include_bootstrap: true }, env, toolCtx),
-        getPublicEntityTypeList(organization.id, env, requestUrl, entityType.slug),
+        getPublicEntityTypeList(organization.id, env, requestUrl, entityTypeDefinition.slug),
       ]);
+      const entityType: PublicEntityTypeDetails = {
+        ...entityTypeDefinition,
+        entity_count: entityList.metadata.total_count,
+      };
       return applyBootstrapStrip(
         buildEntityTypeModel({
           organization,

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -34,6 +34,11 @@ import logger from '../../utils/logger';
 import { compileRulesMetadata, ruleHashFor } from '../../identity/rules';
 import { ensureMemberEntityType } from '../../utils/member-entity-type';
 import {
+  countEntitiesOfType,
+  countStoredEntitiesOfType,
+  getEntityCountsByTypes,
+} from '../../utils/entity-management';
+import {
   isReservedEntityTypeSlug,
   RESERVED_ENTITY_TYPE_SLUGS,
 } from '../../utils/reserved';
@@ -196,34 +201,6 @@ function assertValidBacking(backing: ManageEntitySchemaArgs['backing']): void {
   }
 }
 
-async function getEntityCountsByType(organizationId: string): Promise<Map<number, number>> {
-  const sql = getDb();
-  const rows = await sql`
-    SELECT e.entity_type_id AS entity_type_id, COUNT(*)::int as entity_count
-    FROM entities e
-    WHERE e.organization_id = ${organizationId}
-      AND e.deleted_at IS NULL
-    GROUP BY e.entity_type_id
-  `;
-  const counts = new Map<number, number>();
-  for (const row of rows) {
-    counts.set(Number(row.entity_type_id), Number(row.entity_count));
-  }
-  return counts;
-}
-
-async function getEntityCountForType(typeId: number, organizationId: string): Promise<number> {
-  const sql = getDb();
-  const rows = await sql`
-    SELECT COUNT(*)::int as count
-    FROM entities e
-    WHERE e.entity_type_id = ${typeId}
-      AND e.organization_id = ${organizationId}
-      AND e.deleted_at IS NULL
-  `;
-  return Number(rows[0]?.count || 0);
-}
-
 async function getRelationshipCountForType(
   typeId: number,
   organizationId: string
@@ -281,15 +258,25 @@ async function etHandleList(
     [ctx.organizationId]
   );
 
-  const counts = await getEntityCountsByType(ctx.organizationId);
   const resolved = await resolveUsernames(
     rows as unknown as Record<string, unknown>[],
     'created_by'
   );
 
-  const entityTypes = resolved.map((row) => {
-    const mapped = mapRowToEntityType(row);
-    mapped.entity_count = counts.get(mapped.id) || 0;
+  const mappedTypes = resolved.map((row) => mapRowToEntityType(row));
+  // Stored + derived counts share one path with list/detail (entity-management).
+  const counts = await getEntityCountsByTypes(
+    mappedTypes.map((t) => ({
+      id: Number(t.id),
+      slug: t.slug,
+      backing_sql: t.backing_sql,
+      backing_source: t.backing_source,
+    })),
+    ctx
+  );
+
+  const entityTypes = mappedTypes.map((mapped) => {
+    mapped.entity_count = counts.get(Number(mapped.id)) || 0;
     return mapped;
   });
 
@@ -414,7 +401,15 @@ async function etHandleGet(
 
   const [resolved] = await resolveUsernames([rows[0] as Record<string, unknown>], 'created_by');
   const mapped = mapRowToEntityType(resolved);
-  mapped.entity_count = await getEntityCountForType(Number(mapped.id), ctx.organizationId);
+  mapped.entity_count = await countEntitiesOfType(
+    {
+      id: Number(mapped.id),
+      slug: mapped.slug,
+      backing_sql: mapped.backing_sql,
+      backing_source: mapped.backing_source,
+    },
+    ctx
+  );
   // Classify the view's measure columns on read (never persisted).
   if (mapped.backing_sql) mapped.measure_columns = measureColumns(mapped.backing_sql);
   // Authored type-level list-view templates, with their data_sources run live.
@@ -568,7 +563,10 @@ async function etHandleUpdate(
   // Converting a populated stored type to a derived (view-backed) type would
   // orphan its existing rows (the view ignores them). Reject it.
   if (args.backing?.sql) {
-    const existingCount = await getEntityCountForType(Number(current.id), ctx.organizationId);
+    const existingCount = await countStoredEntitiesOfType(
+      Number(current.id),
+      ctx.organizationId
+    );
     if (existingCount > 0) {
       throw new ToolUserError(
         `Cannot make entity type '${args.slug}' derived: ${existingCount} stored ${existingCount === 1 ? 'entity exists' : 'entities exist'}. Delete them first.`,
@@ -629,7 +627,15 @@ async function etHandleUpdate(
   if (updated.length === 0) throw new Error(`Entity type '${args.slug}' not found after update`);
 
   const result = mapRowToEntityType(updated[0] as Record<string, unknown>);
-  result.entity_count = await getEntityCountForType(Number(result.id), ctx.organizationId);
+  result.entity_count = await countEntitiesOfType(
+    {
+      id: Number(result.id),
+      slug: result.slug,
+      backing_sql: result.backing_sql,
+      backing_source: result.backing_source,
+    },
+    ctx
+  );
 
   await recordAudit(
     sql,
@@ -681,7 +687,8 @@ async function etHandleDelete(
   if (existing.length === 0) throw new ToolUserError(`Entity type '${slug}' not found`, 404);
 
   const current = existing[0];
-  const entityCount = await getEntityCountForType(Number(current.id), ctx.organizationId);
+  // Only stored rows block delete — derived views have no `entities` rows.
+  const entityCount = await countStoredEntitiesOfType(Number(current.id), ctx.organizationId);
   if (entityCount > 0) {
     throw new ToolUserError(
       `Cannot delete entity type '${slug}': ${entityCount} entities of this type exist. Remove or reassign them first.`,

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -21,12 +21,16 @@ import {
 import { ToolUserError } from '../utils/errors';
 import { resolveMemberSchemaFieldsFromSchema } from '../utils/member-entity-type';
 import { stripMemberEmailsFromRows } from '../utils/member-redaction';
-import { derivedRowName, derivedRowSlug } from '../utils/entity-management';
+import {
+  derivedRowName,
+  derivedRowSlug,
+  getEntityCountsByTypes,
+  queryDerivedEntityView,
+} from '../utils/entity-management';
 import { buildDefaultEntityTemplate } from '../utils/default-entity-template';
 import { measureColumns as inferMeasureColumns } from '../utils/infer-measures';
 import { RESERVED_PATHS_SET } from '../utils/reserved';
 import { getWorkspaceProvider } from '../workspace';
-import { querySqlImpl } from './admin/query_sql';
 import { isAdminOrOwnerRole } from './access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from './constants';
 import type { ToolContext } from './registry';
@@ -833,13 +837,12 @@ async function resolveMergedEntityRedirect(
  * falls back to the normal 404.
  *
  * Derived rows aren't stored in `entities`; the type's `backing_sql` produces
- * them with stable `id`/`slug` columns. We run that SQL through the same
- * executor the list view uses (`querySqlImpl` — internal org-scoping or
- * connection pushdown, both already validated for this view), then match the
- * requested slug in memory. We page through the view (not just the first page)
- * so a row past the first page still resolves; matching in memory — rather than
- * interpolating the slug into the view SQL — keeps the SQL injection-free for
- * both the internal and connection-backed paths.
+ * them with stable `id`/`slug` columns. We run that SQL through
+ * {@link queryDerivedEntityView} (same executor as list + type counts), then
+ * match the requested slug in memory. We page through the view (not just the
+ * first page) so a row past the first page still resolves; matching in memory —
+ * rather than interpolating the slug into the view SQL — keeps the SQL
+ * injection-free for both the internal and connection-backed paths.
  */
 async function resolveDerivedLeaf(
   sql: DbClient,
@@ -870,9 +873,10 @@ async function resolveDerivedLeaf(
   const MAX_PAGES = 40;
   let match: Record<string, unknown> | undefined;
   for (let pageNum = 0; pageNum < MAX_PAGES; pageNum += 1) {
-    const result = await querySqlImpl(
-      { sql: backingSql, connection: backingSource, limit: PAGE, offset: pageNum * PAGE },
-      undefined,
+    const result = await queryDerivedEntityView(
+      backingSql,
+      backingSource,
+      { limit: PAGE, offset: pageNum * PAGE },
       ctx
     );
     if (result.error) return null;
@@ -947,7 +951,7 @@ async function fetchBootstrap(
   }
 
   const [entityTypes, summary, recentContent, recentFeeds] = await Promise.all([
-    listEntityTypes(sql, workspace.id),
+    listEntityTypes(sql, ctx),
     fetchScopeSummary(sql, workspace.id, entity, ctx.userId),
     fetchRecentContent(sql, workspace.id, entity?.id ?? null),
     fetchRecentFeeds(sql, workspace.id, entity?.id ?? null),
@@ -968,7 +972,7 @@ async function fetchBootstrap(
 
 async function listEntityTypes(
   sql: DbClient,
-  organizationId: string
+  ctx: ToolContext
 ): Promise<BootstrapEntityTypeSummary[]> {
   const rows = await sql`
     SELECT
@@ -978,15 +982,24 @@ async function listEntityTypes(
       et.description,
       et.icon,
       et.color,
-      COUNT(e.id)::int AS entity_count
+      et.backing_sql,
+      et.backing_source
     FROM entity_types et
-    LEFT JOIN entities e
-      ON e.entity_type_id = et.id
     WHERE et.deleted_at IS NULL
-      AND et.organization_id = ${organizationId}
-    GROUP BY et.id, et.slug, et.name, et.description, et.icon, et.color
+      AND et.organization_id = ${ctx.organizationId}
     ORDER BY et.name ASC
   `;
+
+  // Same stored+derived count path as manage_entity_schema list / entity list.
+  const counts = await getEntityCountsByTypes(
+    rows.map((row) => ({
+      id: Number(row.id),
+      slug: String(row.slug),
+      backing_sql: (row.backing_sql as string | null) ?? null,
+      backing_source: (row.backing_source as string | null) ?? null,
+    })),
+    ctx
+  );
 
   return rows.map((row) => ({
     id: Number(row.id),
@@ -995,7 +1008,7 @@ async function listEntityTypes(
     description: row.description ? String(row.description) : null,
     icon: row.icon ? String(row.icon) : null,
     color: row.color ? String(row.color) : null,
-    entity_count: Number(row.entity_count) || 0,
+    entity_count: counts.get(Number(row.id)) || 0,
   }));
 }
 

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -33,8 +33,137 @@ import { entityLinkMatchSql } from "./content-search";
 import { computeFieldMerge, type FieldControl } from "./entity-field-merge";
 import { type EntityHookContext, getEntityHooks } from "./entity-hooks";
 import { ToolUserError } from "./errors";
+import logger from "./logger";
 import { requireWriteAccess } from "./organization-access";
 import { RESERVED_ENTITY_TYPE_SLUGS } from "./reserved";
+
+/** Minimal type shape needed to count stored vs derived entity rows. */
+export type EntityTypeCountInput = {
+	id: number;
+	slug: string;
+	backing_sql?: string | null;
+	backing_source?: string | null;
+};
+
+/**
+ * Count stored rows in `entities` for a type. Used where only physical rows
+ * matter (e.g. blocking conversion of a populated type to a derived view).
+ * Prefer {@link countEntitiesOfType} for display counts — that path also
+ * counts derived views via the same executor as list/detail.
+ */
+export async function countStoredEntitiesOfType(
+	typeId: number,
+	organizationId: string,
+): Promise<number> {
+	const sql = getDb();
+	const rows = await sql`
+    SELECT COUNT(*)::int as count
+    FROM entities e
+    WHERE e.entity_type_id = ${typeId}
+      AND e.organization_id = ${organizationId}
+      AND e.deleted_at IS NULL
+  `;
+	return Number(rows[0]?.count || 0);
+}
+
+/**
+ * Run a derived entity type's `backing_sql` through the shared `querySqlImpl`
+ * executor (org-scoped internal tables or connection pushdown). List, detail
+ * resolve, and type-level counts all go through this so pagination/total_count
+ * stay consistent.
+ */
+export async function queryDerivedEntityView(
+	backingSql: string,
+	backingSource: string | undefined,
+	page: { limit: number; offset: number; search?: string },
+	ctx: ToolContext,
+): Promise<Awaited<ReturnType<typeof querySqlImpl>>> {
+	// Search pushes down only on the internal path (the connection path rejects
+	// search_term); external derived views simply ignore the search box.
+	const search =
+		page.search && !backingSource
+			? { search_term: page.search, search_columns: ["name"] as string[] }
+			: {};
+	return querySqlImpl(
+		{
+			sql: backingSql,
+			connection: backingSource,
+			limit: page.limit,
+			offset: page.offset,
+			...search,
+		},
+		undefined,
+		ctx,
+	);
+}
+
+/**
+ * Display count for one entity type: stored `entities` rows, or the derived
+ * view's `total_count` from {@link queryDerivedEntityView} (same path as list).
+ * A failed derived query returns 0 so a broken view cannot poison type lists.
+ */
+export async function countEntitiesOfType(
+	type: EntityTypeCountInput,
+	ctx: ToolContext,
+): Promise<number> {
+	if (type.backing_sql) {
+		const result = await queryDerivedEntityView(
+			type.backing_sql,
+			type.backing_source ?? undefined,
+			{ limit: 1, offset: 0 },
+			ctx,
+		);
+		if (result.error) {
+			logger.warn(
+				{ err: result.error, entityType: type.slug },
+				"Failed to count derived entity type rows",
+			);
+			return 0;
+		}
+		return Number(result.total_count) || 0;
+	}
+	return countStoredEntitiesOfType(type.id, ctx.organizationId);
+}
+
+/**
+ * Batch display counts for entity-type list / bootstrap. One GROUP BY for all
+ * stored types, plus parallel derived view counts via
+ * {@link countEntitiesOfType}.
+ */
+export async function getEntityCountsByTypes(
+	types: EntityTypeCountInput[],
+	ctx: ToolContext,
+): Promise<Map<number, number>> {
+	const counts = new Map<number, number>();
+	if (types.length === 0) return counts;
+
+	const stored = types.filter((t) => !t.backing_sql);
+	const derived = types.filter((t) => !!t.backing_sql);
+
+	if (stored.length > 0) {
+		const sql = getDb();
+		const rows = await sql`
+      SELECT e.entity_type_id AS entity_type_id, COUNT(*)::int as entity_count
+      FROM entities e
+      WHERE e.organization_id = ${ctx.organizationId}
+        AND e.deleted_at IS NULL
+      GROUP BY e.entity_type_id
+    `;
+		for (const row of rows) {
+			counts.set(Number(row.entity_type_id), Number(row.entity_count));
+		}
+	}
+
+	if (derived.length > 0) {
+		await Promise.all(
+			derived.map(async (t) => {
+				counts.set(t.id, await countEntitiesOfType(t, ctx));
+			}),
+		);
+	}
+
+	return counts;
+}
 
 interface EntityCreateOptions {
 	skipHooks?: boolean;
@@ -1262,13 +1391,12 @@ export function derivedRowName(row: Record<string, unknown>, slug: string): stri
 
 /**
  * List rows of a derived ("view") entity type by running its `backing_sql`
- * through the same executor the detail/query paths use (`querySqlImpl` —
- * internal org-scoping or connection pushdown, both already validated for this
- * view). Maps each row to the standard `CreatedEntity` shape so the frontend
- * treats derived rows like any other entity. Rows have no stored numeric id;
- * the projected `slug` (or `id`) is the routing key, so the synthetic `id` is
- * page-local and used only for table keys. Rows that project no slug/id are
- * unroutable and dropped (they can't link to a detail page).
+ * through {@link queryDerivedEntityView} (same executor as detail resolve and
+ * type-level counts). Maps each row to the standard `CreatedEntity` shape so
+ * the frontend treats derived rows like any other entity. Rows have no stored
+ * numeric id; the projected `slug` (or `id`) is the routing key, so the
+ * synthetic `id` is page-local and used only for table keys. Rows that project
+ * no slug/id are unroutable and dropped (they can't link to a detail page).
  */
 async function listDerivedEntities(
 	entityType: string,
@@ -1285,21 +1413,10 @@ async function listDerivedEntities(
   sortBy: string;
   sortOrder: 'asc' | 'desc';
 }> {
-	// Search pushes down only on the internal path (the connection path rejects
-	// search_term); external derived views simply ignore the search box.
-	const search =
-		page.search && !backingSource
-			? { search_term: page.search, search_columns: ["name"] }
-			: {};
-	const result = await querySqlImpl(
-		{
-			sql: backingSql,
-			connection: backingSource,
-			limit: page.limit,
-			offset: page.offset,
-			...search,
-		},
-		undefined,
+	const result = await queryDerivedEntityView(
+		backingSql,
+		backingSource,
+		page,
 		ctx,
 	);
 	if (result.error) {

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -107,20 +107,25 @@ export async function countEntitiesOfType(
 	ctx: ToolContext,
 ): Promise<number> {
 	if (type.backing_sql) {
-		const result = await queryDerivedEntityView(
-			type.backing_sql,
-			type.backing_source ?? undefined,
-			{ limit: 1, offset: 0 },
-			ctx,
-		);
-		if (result.error) {
+		try {
+			const result = await queryDerivedEntityView(
+				type.backing_sql,
+				type.backing_source ?? undefined,
+				{ limit: 1, offset: 0 },
+				ctx,
+			);
+			if (!result.error) return Number(result.total_count) || 0;
 			logger.warn(
 				{ err: result.error, entityType: type.slug },
 				"Failed to count derived entity type rows",
 			);
-			return 0;
+		} catch (err) {
+			logger.warn(
+				{ err, entityType: type.slug },
+				"Failed to count derived entity type rows",
+			);
 		}
-		return Number(result.total_count) || 0;
+		return 0;
 	}
 	return countStoredEntitiesOfType(type.id, ctx.organizationId);
 }


### PR DESCRIPTION
## Summary
- **UI (owletto):** Restore hover settings gear on Memory entity-type rail via shared `MemoryRailSettingsLink` (also used by connectors). Gear is a sibling of the browse control, so scoping and settings never contend for the click.
- **Server:** Derived entity types (`backing_sql`) get real `entity_count` via the same `queryDerivedEntityView` / `querySqlImpl` path as list + detail — so Subscription no longer shows 0 on type lists, bootstrap, get, and public pages.
- **Public type page** reuses the entity list's `total_count` instead of issuing a second count query — one fewer derived-view execution, and the count is consistent with the list beside it.
- `countEntitiesOfType` degrades to 0 on a *thrown* derived query (not just a returned error), so one broken view can't 502 the bootstrap path.
- Stored-only guards (delete / convert-to-derived) still use `countStoredEntitiesOfType`.

Companion: https://github.com/lobu-ai/owletto/pull/556 (merged; submodule bumped to `87670e48`).

## Test plan
- [x] `make pre-pr`
- [x] `make review-fix` (findings applied and committed)
- [x] Integration suite locally against real Postgres — 14/14 (`derived-entity-routing`, `public-pages-contract`)
- [x] **Red→green proof:** reverting `countEntitiesOfType` to the stored-row count fails the regression with `expected +0 to be 2` — the exact reported symptom. Fix restores it to 2.
- [ ] Memory rail in browser: Subscription count matches Entity tab row count
- [ ] Hover gear on entity type → schema settings page
