### PR TITLE
Remove the legacy entityLinks contract

### DIFF
--- a/db/migrations/20260723010000_remove_legacy_entity_links.sql
+++ b/db/migrations/20260723010000_remove_legacy_entity_links.sql
@@ -1,0 +1,129 @@
+-- migrate:up
+
+-- `attributions` replaced `entityLinks` in the connector contract. A previous
+-- backfill converted definitions that existed at the time, but device manifests
+-- could still publish the removed field and later overwrite those rows. Convert
+-- every persisted definition again, then discard stored device manifests that
+-- would otherwise re-advertise the removed contract.
+
+DO $$
+DECLARE
+  def RECORD;
+  feed_key text;
+  feed_val jsonb;
+  kind_key text;
+  kind_val jsonb;
+  link jsonb;
+  new_attrs jsonb;
+  new_kinds jsonb;
+  new_feeds jsonb;
+  replacement jsonb;
+  changed boolean;
+BEGIN
+  FOR def IN
+    SELECT id, feeds_schema
+    FROM connector_definitions
+    WHERE jsonb_typeof(feeds_schema) = 'object'
+      AND jsonb_path_exists(feeds_schema, '$.*.eventKinds.*.entityLinks')
+  LOOP
+    new_feeds := def.feeds_schema;
+    changed := false;
+
+    FOR feed_key, feed_val IN SELECT * FROM jsonb_each(def.feeds_schema) LOOP
+      IF jsonb_typeof(feed_val -> 'eventKinds') <> 'object' THEN
+        CONTINUE;
+      END IF;
+
+      new_kinds := feed_val -> 'eventKinds';
+      FOR kind_key, kind_val IN SELECT * FROM jsonb_each(feed_val -> 'eventKinds') LOOP
+        IF jsonb_typeof(kind_val) <> 'object' OR NOT kind_val ? 'entityLinks' THEN
+          CONTINUE;
+        END IF;
+
+        -- A current attribution declaration is authoritative if both fields
+        -- somehow coexist. Otherwise convert every object-shaped removed rule
+        -- one-for-one. Malformed legacy values are discarded so they cannot
+        -- block the cleanup or survive it.
+        IF jsonb_typeof(kind_val -> 'attributions') = 'array' THEN
+          replacement := kind_val - 'entityLinks';
+        ELSIF jsonb_typeof(kind_val -> 'entityLinks') = 'array' THEN
+          new_attrs := '[]'::jsonb;
+          FOR link IN SELECT * FROM jsonb_array_elements(kind_val -> 'entityLinks') LOOP
+            IF jsonb_typeof(link) <> 'object' THEN
+              CONTINUE;
+            END IF;
+            new_attrs := new_attrs || jsonb_strip_nulls(jsonb_build_object(
+              'role', 'authored_by',
+              'autoCreate', link -> 'autoCreate',
+              'traits', link -> 'traits',
+              'target', jsonb_strip_nulls(jsonb_build_object(
+                'entityType', link -> 'entityType',
+                'createWhen', link -> 'createWhen',
+                'titlePath', link -> 'titlePath',
+                'identities', link -> 'identities'
+              ))
+            ));
+          END LOOP;
+          replacement :=
+            (kind_val - 'entityLinks') || jsonb_build_object('attributions', new_attrs);
+        ELSE
+          replacement := kind_val - 'entityLinks';
+        END IF;
+
+        new_kinds := jsonb_set(new_kinds, ARRAY[kind_key], replacement);
+        changed := true;
+      END LOOP;
+
+      new_feeds := jsonb_set(new_feeds, ARRAY[feed_key, 'eventKinds'], new_kinds);
+    END LOOP;
+
+    IF changed THEN
+      UPDATE connector_definitions
+      SET feeds_schema = new_feeds,
+          updated_at = current_timestamp
+      WHERE id = def.id;
+    END IF;
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1
+    FROM connector_definitions
+    WHERE jsonb_path_exists(feeds_schema, '$.*.eventKinds.*.entityLinks')
+  ) THEN
+    RAISE EXCEPTION 'connector definition still contains removed entityLinks';
+  END IF;
+
+  UPDATE device_workers dw
+  SET connector_manifests = COALESCE(
+    (
+      SELECT jsonb_object_agg(entry.key, entry.value)
+      FROM jsonb_each(dw.connector_manifests) AS entry
+      WHERE NOT jsonb_path_exists(
+        entry.value,
+        '$.manifest.feeds_schema.*.eventKinds.*.entityLinks'
+      )
+    ),
+    '{}'::jsonb
+  )
+  WHERE jsonb_typeof(dw.connector_manifests) = 'object'
+    AND jsonb_path_exists(
+      dw.connector_manifests,
+      '$.*.manifest.feeds_schema.*.eventKinds.*.entityLinks'
+    );
+
+  IF EXISTS (
+    SELECT 1
+    FROM device_workers
+    WHERE jsonb_path_exists(
+      connector_manifests,
+      '$.*.manifest.feeds_schema.*.eventKinds.*.entityLinks'
+    )
+  ) THEN
+    RAISE EXCEPTION 'stored device manifest still contains removed entityLinks';
+  END IF;
+END $$;
+
+-- migrate:down
+
+-- Irreversible by design: the application rejects the removed contract.
+SELECT 1;

--- a/packages/connector-sdk/src/metrics.ts
+++ b/packages/connector-sdk/src/metrics.ts
@@ -8,7 +8,7 @@
  *    (see config-isolation.test.ts) — it must NOT import `@lobu/core`'s heavy graph;
  *  - the server compiles/validates the stored metric JSON and must NOT import the CLI.
  * `connector-sdk` is the one shared package both can import, and it already
- * carries entity contract types (EntityIdentitySpec, EntityLinkRule, …).
+ * carries entity contract types (EntityIdentitySpec, EventAttributionRule, …).
  *
  * Plain interfaces for now. A runtime validator (zod, in the layer that
  * validates stored config) lands with the persistence path that uses it. The

--- a/packages/connectors/src/__tests__/github-commits.test.ts
+++ b/packages/connectors/src/__tests__/github-commits.test.ts
@@ -7,7 +7,7 @@
  * Proves:
  *   - a linked-account commit → stable per-sha origin_id, origin_type 'commit',
  *     author date as occurred_at, and author_login/author_id stamped for person
- *     attribution (entityLinks resolves these to a member),
+ *     attribution (the authored_by rule resolves these to a person),
  *   - an unlinked-email commit (author === null) → falls back to the git author
  *     name and carries no author_login/author_id (no false person link).
  */
@@ -102,7 +102,7 @@ describe("GitHub commits feed", () => {
 		const unlinked = result.events[1];
 		expect(unlinked.origin_id).toBe("commit_lobu-ai_lobu_def456");
 		expect(unlinked.author_name).toBe("dependabot"); // git author name fallback
-		// No GitHub account → no author_login/author_id so entityLinks can't
+		// No GitHub account → no author_login/author_id so attribution can't
 		// mis-attribute the commit to a person.
 		expect(unlinked.metadata.author_login).toBeUndefined();
 		expect(unlinked.metadata.author_id).toBeUndefined();

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -1753,7 +1753,7 @@ export default class GitHubConnector extends ConnectorRuntime {
    * Canonical author identity slot for attributions. Stamps `author_login`
    * (the mutable handle, indexed for read-time attribution) and `author_id`
    * (the immutable numeric GitHub user id, the PRIMARY match/dedupe key) into
-   * event metadata so the ingestion pipeline's `applyEntityLinks` resolves a
+   * event metadata so the ingestion pipeline's `applyEventAttributions` resolves a
    * `person` from REST payloads. Omitted keys when absent — bots/ghost authors
    * may lack an id; the login still matches.
    */

--- a/packages/server/src/__tests__/integration/db/remove-legacy-entity-links.test.ts
+++ b/packages/server/src/__tests__/integration/db/remove-legacy-entity-links.test.ts
@@ -1,0 +1,258 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { loadMigrationUpSection } from '../../../db/migration-loader';
+import { createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const MIGRATION = '20260723010000_remove_legacy_entity_links.sql';
+
+function resolveMigrationsDir(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'db/migrations');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate db/migrations from the test directory');
+}
+
+interface Captured {
+  convertedKind: Record<string, unknown>;
+  currentKind: Record<string, unknown>;
+  storedManifestKeys: string[];
+  lingeringDefinitions: number;
+  lingeringManifests: number;
+}
+
+class Rollback extends Error {}
+
+describe('removed entityLinks migration', () => {
+  let captured: Captured;
+
+  beforeAll(async () => {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    const sql = getDb();
+    const upSection = loadMigrationUpSection(resolveMigrationsDir(), MIGRATION);
+    const legacyRule = {
+      entityType: 'person',
+      autoCreate: true,
+      createWhen: { path: 'metadata.is_group', equals: false },
+      titlePath: 'metadata.push_name',
+      identities: [{ namespace: 'wa_jid', eventPath: 'metadata.sender_jid' }],
+      traits: {
+        push_name: { eventPath: 'metadata.push_name', behavior: 'prefer_non_empty' },
+      },
+    };
+    const currentAttribution = {
+      role: 'about',
+      autoCreate: false,
+      target: {
+        entityType: 'person',
+        identities: [{ namespace: 'email', eventPath: 'metadata.email' }],
+      },
+    };
+
+    const result: Captured = {
+      convertedKind: {},
+      currentKind: {},
+      storedManifestKeys: [],
+      lingeringDefinitions: -1,
+      lingeringManifests: -1,
+    };
+
+    try {
+      await sql.begin(async (tx: typeof sql) => {
+        await tx`
+          INSERT INTO connector_definitions
+            (organization_id, key, name, version, auth_schema, feeds_schema, status)
+          VALUES
+            (
+              ${org.id}, 'legacy-device', 'Legacy device', '0.1.0',
+              ${tx.json({ methods: [{ type: 'none' }] })},
+              ${tx.json({
+                messages: {
+                  eventKinds: {
+                    message: {
+                      metadataSchema: {
+                        type: 'object',
+                        properties: { reply_to: { type: ['string', 'null'], default: null } },
+                      },
+                      entityLinks: [legacyRule],
+                    },
+                  },
+                },
+              })},
+              'active'
+            ),
+            (
+              ${org.id}, 'mixed-device', 'Mixed device', '0.2.0',
+              ${tx.json({ methods: [{ type: 'none' }] })},
+              ${tx.json({
+                messages: {
+                  eventKinds: {
+                    message: {
+                      entityLinks: [legacyRule],
+                      attributions: [currentAttribution],
+                    },
+                  },
+                },
+              })},
+              'active'
+            ),
+            (
+              ${org.id}, 'malformed-device', 'Malformed device', '0.1.0',
+              ${tx.json({ methods: [{ type: 'none' }] })},
+              ${tx.json({
+                messages: { eventKinds: { message: { entityLinks: { invalid: true } } } },
+              })},
+              'active'
+            )
+        `;
+
+        await tx`
+          INSERT INTO device_workers
+            (user_id, worker_id, platform, app_version, capabilities, label, organization_id, connector_manifests)
+          VALUES (
+            ${user.id}, 'removed-entity-links-test', 'macos', '1.0.0',
+            ${tx.json(['whatsapp_local'])}, 'Migration test', ${org.id},
+            ${tx.json({
+              legacy: {
+                manifest_hash: 'legacy',
+                received_at: '2026-07-23T00:00:00.000Z',
+                manifest: {
+                  key: 'legacy-device',
+                  feeds_schema: {
+                    messages: { eventKinds: { message: { entityLinks: [legacyRule] } } },
+                  },
+                },
+              },
+              current: {
+                manifest_hash: 'current',
+                received_at: '2026-07-23T00:00:00.000Z',
+                manifest: {
+                  key: 'current-device',
+                  feeds_schema: {
+                    messages: {
+                      eventKinds: { message: { attributions: [currentAttribution] } },
+                    },
+                  },
+                },
+              },
+              malformed: {
+                manifest_hash: 'malformed',
+                received_at: '2026-07-23T00:00:00.000Z',
+                manifest: {
+                  key: 'malformed-device',
+                  feeds_schema: {
+                    messages: {
+                      eventKinds: { message: { entityLinks: { invalid: true } } },
+                    },
+                  },
+                },
+              },
+            })}
+          )
+        `;
+
+        await tx.unsafe(upSection);
+
+        const definitions = await tx<{ key: string; feeds_schema: Record<string, unknown> }[]>`
+          SELECT key, feeds_schema
+          FROM connector_definitions
+          WHERE organization_id = ${org.id}
+            AND key IN ('legacy-device', 'mixed-device')
+          ORDER BY key
+        `;
+        const byKey = new Map(definitions.map((row) => [row.key, row.feeds_schema]));
+        result.convertedKind = (
+          byKey.get('legacy-device') as {
+            messages: { eventKinds: { message: Record<string, unknown> } };
+          }
+        ).messages.eventKinds.message;
+        result.currentKind = (
+          byKey.get('mixed-device') as {
+            messages: { eventKinds: { message: Record<string, unknown> } };
+          }
+        ).messages.eventKinds.message;
+
+        const [device] = await tx<{ connector_manifests: Record<string, unknown> }[]>`
+          SELECT connector_manifests
+          FROM device_workers
+          WHERE worker_id = 'removed-entity-links-test'
+        `;
+        result.storedManifestKeys = Object.keys(device.connector_manifests).sort();
+
+        // A replay must be harmless and leave no removed contract in either store.
+        await tx.unsafe(upSection);
+        const [counts] = await tx<{ definitions: string; manifests: string }[]>`
+          SELECT
+            (SELECT count(*) FROM connector_definitions
+              WHERE jsonb_path_exists(feeds_schema, '$.*.eventKinds.*.entityLinks'))::text AS definitions,
+            (SELECT count(*) FROM device_workers
+              WHERE jsonb_path_exists(
+                connector_manifests,
+                '$.*.manifest.feeds_schema.*.eventKinds.*.entityLinks'
+              ))::text AS manifests
+        `;
+        result.lingeringDefinitions = Number(counts.definitions);
+        result.lingeringManifests = Number(counts.manifests);
+
+        throw new Rollback();
+      });
+    } catch (error) {
+      if (!(error instanceof Rollback)) throw error;
+    }
+
+    captured = result;
+  });
+
+  it('converts removed rules into authored_by attributions', () => {
+    expect(captured.convertedKind.entityLinks).toBeUndefined();
+    expect(captured.convertedKind.metadataSchema).toEqual({
+      type: 'object',
+      properties: { reply_to: { type: ['string', 'null'], default: null } },
+    });
+    expect(captured.convertedKind.attributions).toEqual([
+      {
+        role: 'authored_by',
+        autoCreate: true,
+        target: {
+          entityType: 'person',
+          createWhen: { path: 'metadata.is_group', equals: false },
+          titlePath: 'metadata.push_name',
+          identities: [{ namespace: 'wa_jid', eventPath: 'metadata.sender_jid' }],
+        },
+        traits: {
+          push_name: { eventPath: 'metadata.push_name', behavior: 'prefer_non_empty' },
+        },
+      },
+    ]);
+  });
+
+  it('preserves current attributions when both fields coexist', () => {
+    expect(captured.currentKind.entityLinks).toBeUndefined();
+    expect(captured.currentKind.attributions).toEqual([
+      {
+        role: 'about',
+        autoCreate: false,
+        target: {
+          entityType: 'person',
+          identities: [{ namespace: 'email', eventPath: 'metadata.email' }],
+        },
+      },
+    ]);
+  });
+
+  it('drops only stored manifests that advertise the removed contract', () => {
+    expect(captured.storedManifestKeys).toEqual(['current']);
+  });
+
+  it('is idempotent and leaves no removed contract in either store', () => {
+    expect(captured.lingeringDefinitions).toBe(0);
+    expect(captured.lingeringManifests).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -273,6 +273,42 @@ describe('device connector manifests', () => {
     expect(await readDefinition(orgId, 'chrome.history')).toBeNull();
   });
 
+  it('drops a manifest that still declares removed entityLinks rules', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const legacyManifest = manifest({
+      feeds_schema: {
+        snapshots: {
+          key: 'snapshots',
+          name: 'Snapshots',
+          eventKinds: {
+            snapshot: {
+              entityLinks: [
+                {
+                  entityType: 'person',
+                  identities: [{ namespace: 'email', eventPath: 'metadata.email' }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const res = await poll(workerId, [legacyManifest]);
+    expect(res.status).toBe(200);
+
+    expect(await readDefinition(orgId)).toBeNull();
+
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT connector_manifests
+      FROM device_workers
+      WHERE worker_id = ${workerId}
+      LIMIT 1
+    `) as unknown as Array<{ connector_manifests: Record<string, unknown> }>;
+    expect(rows[0]?.connector_manifests).toEqual({});
+  });
+
   it('keeps manifest inventory separate from live permission state so revoked capabilities pause feeds', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const connectorManifest = manifest();
@@ -297,6 +333,26 @@ describe('device connector manifests', () => {
     expect(await readDefinition(orgId, 'apple.computer_use')).not.toBeNull();
     expect(await readDefinition(orgId, 'local.directory')).not.toBeNull();
     expect(await readDefinition(orgId, 'chrome.history')).toBeNull();
+
+    const whatsapp = await readDefinition(orgId, 'whatsapp.local');
+    const feedsSchema = whatsapp?.feeds_schema as
+      | {
+          messages?: {
+            eventKinds?: {
+              message?: { entityLinks?: unknown; attributions?: unknown };
+            };
+          };
+        }
+      | undefined;
+    const messageKind = feedsSchema?.messages?.eventKinds?.message;
+    expect(messageKind?.entityLinks).toBeUndefined();
+    expect(messageKind?.attributions).toEqual([
+      expect.objectContaining({
+        role: 'authored_by',
+        autoCreate: true,
+        target: expect.objectContaining({ entityType: 'person' }),
+      }),
+    ]);
   });
 
   itWithOwlettoManifests('chrome')('accepts the actual Owletto Chrome manifests and installs their connector definitions', async () => {

--- a/packages/server/src/__tests__/unit/connectors/whatsapp.test.ts
+++ b/packages/server/src/__tests__/unit/connectors/whatsapp.test.ts
@@ -2,9 +2,9 @@
  * Unit tests for the WhatsApp connector's `toEvent` and `jidToPhone`.
  *
  * These cover the shape-translation path between real Baileys WAMessage
- * objects and the EventEnvelope metadata the entityLinks rule reads —
+ * objects and the EventEnvelope metadata the attribution rule reads —
  * multi-device JID suffix handling, group participant attribution, and
- * from_me suppression. The integration test (whatsapp-entity-links.test.ts)
+ * from_me suppression. The integration test (entity-links-contract.test.ts)
  * only exercises applyEventAttributions with synthetic metadata, so regressions
  * in toEvent would otherwise pass undetected.
  *

--- a/packages/server/src/gateway/routes/public/github-webhook-actor.ts
+++ b/packages/server/src/gateway/routes/public/github-webhook-actor.ts
@@ -1,7 +1,7 @@
 /**
  * GitHub App webhook actor → person resolution. The live App-webhook path used
  * to land deliveries with empty `events.entity_ids`; this resolves the authoring
- * actor to a tenant-scoped `person` (mirroring the poll path's entityLinks keys).
+ * actor to a tenant-scoped `person` through the same attribution target as polling.
  * Org-scoped via the caller's resolved install; resolution never crosses orgs.
  */
 

--- a/packages/server/src/utils/content-search/entity-link.ts
+++ b/packages/server/src/utils/content-search/entity-link.ts
@@ -12,9 +12,8 @@ import { CONNECTOR_RECALL_NAMESPACES } from '../../identity/connector-identity-m
  * Identity namespaces backed by partial BTREE indexes on `events.metadata`.
  *
  * The canonical registry lives in connector-sdk so connectors, the identity
- * engine, and read-time recall share one vocabulary. This server-side export is
- * kept for compatibility with existing imports while the legacy entityLinks
- * path is migrated to the identity engine + event attribution pipeline.
+ * engine, and read-time recall share one vocabulary. This server-side export
+ * assembles the registry used by event-attribution recall and its index invariant.
  *
  * Non-recall namespaces are intentionally unsupported here: without a matching
  * index the identity branch seq-scans `events`, which blows up the entire

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -1,8 +1,8 @@
 /**
  * Declarative entity-link resolver at event ingestion.
  *
- * A connector declares `eventKinds[kind].entityLinks[]` rules. Each rule maps
- * event identifier fields (phone, email, wa_jid, ...) to a target entity type.
+ * A connector declares `eventKinds[kind].attributions[]` rules. Each attribution
+ * maps event identifier fields (phone, email, wa_jid, ...) to a target entity.
  * The ingestion pipeline:
  *   1) Extracts + normalizes identifiers from each event.
  *   2) Looks them up in the normalized `entity_identities` table

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -194,6 +194,8 @@ function normalizeManifest(raw: unknown): DeviceConnectorManifest {
   }
   const platforms = runtime.platforms.filter((v): v is string => typeof v === 'string');
   if (platforms.length === 0) throw new Error('runtime.platforms cannot be empty');
+  const feedsSchema = optionalRecord(raw, 'feeds_schema') ?? {};
+  rejectRemovedEntityLinks(feedsSchema);
   return {
     key,
     version,
@@ -206,11 +208,24 @@ function normalizeManifest(raw: unknown): DeviceConnectorManifest {
       platforms,
     } as DeviceConnectorManifest['runtime'],
     auth_schema: optionalRecord(raw, 'auth_schema'),
-    feeds_schema: optionalRecord(raw, 'feeds_schema') ?? {},
+    feeds_schema: feedsSchema,
     actions_schema: optionalRecord(raw, 'actions_schema'),
     options_schema: optionalRecord(raw, 'options_schema'),
     manifest_hash: optionalStringField(raw, 'manifest_hash'),
   };
+}
+
+function rejectRemovedEntityLinks(feedsSchema: Record<string, unknown>): void {
+  for (const [feedKey, feedDefinition] of Object.entries(feedsSchema)) {
+    if (!isRecord(feedDefinition) || !isRecord(feedDefinition.eventKinds)) continue;
+    for (const [eventKind, eventDefinition] of Object.entries(feedDefinition.eventKinds)) {
+      if (isRecord(eventDefinition) && Object.hasOwn(eventDefinition, 'entityLinks')) {
+        throw new Error(
+          `feeds_schema.${feedKey}.eventKinds.${eventKind}.entityLinks was removed; use attributions`
+        );
+      }
+    }
+  }
 }
 
 function parseStoredManifest(raw: unknown): StoredDeviceManifest | null {

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -223,7 +223,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 			await materializeInlineAttachments(batch.items);
 		batch.items = materializedItems as typeof batch.items;
 
-		// Auto-create dimension entities declared via eventKinds[kind].entityLinks
+		// Resolve or create entities declared via eventKinds[kind].attributions
 		// before inserting events. One query per (entityType, matchField) per
 		// batch — cheap compared to the per-event inserts that follow.
 		await applyEventAttributions({


### PR DESCRIPTION
## What changed

- Adds a one-way migration that converts every persisted connector definition from `entityLinks` to `attributions` and removes stale device-manifest snapshots that could re-advertise the deleted field.
- Rejects incoming and stored device manifests that still declare `eventKinds[kind].entityLinks`.
- Records the Owletto manifest update from lobu-ai/owletto#557, where WhatsApp—the final live producer—moves to `attributions` and version `0.2.0`.
- Cleans active comments that still described the removed contract.
- Adds regression coverage for conversion, coexistence, malformed legacy JSON, replay safety, stored-manifest cleanup, hard rejection, and the actual Owletto manifests.

## Why

The earlier attribution backfill handled definitions present at that moment, but device manifests could still publish `entityLinks` afterward and overwrite the migrated definition. WhatsApp's native manifest was the final source of that field. This closes the producer and persistence paths together.

This is forward-only: there is no runtime fallback reader or compatibility shim. Old clients cannot restore the legacy contract; their already-installed definition is migrated, while manifest-driven refresh resumes after the app updates.

## Impact

Persisted attribution rules remain intact under the current shape. Legacy device manifest snapshots are discarded. `events` is untouched and remains append-only.

## Dependency

- lobu-ai/owletto#557 must land first so this gitlink points to a commit reachable from Owletto main.

## Validation

- Focused integration tests: 11/11 passed after the final rebase.
- `make pre-pr`: passed after the final rebase.
- `make review-fix`: completed; its fixes were inspected.
- `REVIEWER_CLI=codex make review`: bug-free 94, simplicity 92, 0 bugs, 0 blockers; tests adequate.
- Independent Claude Fable review: direction confirmed forward-only; manifest hash independently recomputed.
- `git diff --check`: clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->