### PR TITLE
fix(merge): make merge approval cards reviewable, and let the proposer explain itself

### DIFF
--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -99,6 +99,14 @@ export const ManageEntitySchema = Type.Object({
     )
   ),
 
+  merge_rationale: Type.Optional(
+    Type.String({
+      maxLength: 500,
+      description:
+        "[merge] Why you believe these are the same thing, in one sentence, for the human reviewing the approval card (e.g. 'Same phone digits; the shell is a WhatsApp handle for this contact.'). Shown as your claim, clearly separated from the workspace's own policy verdict — it never counts as proof and never affects whether the merge auto-applies.",
+    })
+  ),
+
   // Entity type (required for create, list)
   entity_type: Type.Optional(
     Type.String({

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -206,6 +206,13 @@ describe("manage_entity merge action", () => {
 		expect((pending.action_input as Record<string, unknown>).operation).toBe(
 			"merge",
 		);
+		const [approvalEvent] = await sql`
+			SELECT title FROM current_event_records
+			WHERE run_id = ${queued.approval_run_id} AND interaction_status = 'pending'
+		`;
+		expect(approvalEvent.title).toBe(
+			"Merge Loser into Winner — pending approval",
+		);
 
 		const approved = await manageOperations(
 			{ action: "approve", run_id: queued.approval_run_id },
@@ -816,9 +823,12 @@ describe("manage_entity merge action", () => {
 		});
 		expect(pending.idempotency_key).toMatch(/^entity-change:/);
 		const [approvalEvent] = await sql`
-      SELECT metadata FROM current_event_records
+      SELECT title, metadata FROM current_event_records
       WHERE run_id = ${queued.approval_run_id} AND interaction_status = 'pending'
     `;
+		expect(approvalEvent.title).toBe(
+			"Merge 2 person duplicates into Winner — pending approval",
+		);
 		const current = (approvalEvent.metadata as Record<string, unknown>)
 			.current as {
 			duplicates: Array<{

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -239,6 +239,52 @@ describe("manage_entity merge action", () => {
 		expect(completedEvent.interaction_status).toBe("completed");
 	});
 
+	it("carries the proposer's rationale to the card without letting it prove the merge", async () => {
+		const org = await createTestOrganization({ name: "Rationale Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+
+		const agentCtx = {
+			...ctx(org.id, user.id, "owner"),
+			userId: null,
+			agentId: "personal-agent",
+		} as ToolContext;
+		const queued = (await manageEntity(
+			{
+				action: "merge",
+				entity_id: loser.id,
+				winner_entity_id: winner.id,
+				merge_rationale: "  Same phone digits; shell is their WhatsApp handle.  ",
+			},
+			env,
+			agentCtx,
+		)) as unknown as {
+			approval_queued: boolean;
+			approval_run_id: number;
+			resolution: { decision: string; evidence: unknown[] };
+		};
+
+		// The rationale must not make the merge look proven: no shared email or
+		// phone exists, so the decision stays review and the evidence stays empty.
+		expect(queued.approval_queued).toBe(true);
+		expect(queued.resolution.decision).toBe("review");
+		expect(queued.resolution.evidence).toEqual([]);
+
+		const [approvalEvent] = await sql`
+			SELECT metadata FROM current_event_records
+			WHERE run_id = ${queued.approval_run_id} AND interaction_status = 'pending'
+		`;
+		const metadata = approvalEvent.metadata as Record<string, unknown>;
+		expect(metadata.proposer_rationale).toBe(
+			"Same phone digits; shell is their WhatsApp handle.",
+		);
+		// The policy verdict is stored separately and is not the proposer's text.
+		expect(metadata.reason).not.toBe(metadata.proposer_rationale);
+		expect(String(metadata.reason)).toContain("needs your judgement");
+	});
+
 	it("auto-merges an exact configured email match without human approval", async () => {
 		const org = await createTestOrganization({
 			name: "Strict Email Merge Org",

--- a/packages/server/src/entity-resolution/discovery.test.ts
+++ b/packages/server/src/entity-resolution/discovery.test.ts
@@ -99,7 +99,7 @@ describe("entity resolution module", () => {
 		});
 		expect(assessment.decision).toBe("review");
 		expect(assessment.reason).toBe(
-			"Matching email is evidence, but the proposal does not satisfy this entity type's automatic merge policy.",
+			"Matching email points to the same thing, but that is not enough to merge automatically under this entity type's policy, so it needs your judgement.",
 		);
 	});
 
@@ -181,7 +181,7 @@ describe("entity resolution module", () => {
 		});
 		expect(mixedMatch.decision).toBe("review");
 		expect(mixedMatch.reason).toBe(
-			"Matching email and phone is evidence, but the proposal does not satisfy this entity type's automatic merge policy.",
+			"Matching email and phone points to the same thing, but that is not enough to merge automatically under this entity type's policy, so it needs your judgement.",
 		);
 	});
 

--- a/packages/server/src/entity-resolution/discovery.test.ts
+++ b/packages/server/src/entity-resolution/discovery.test.ts
@@ -103,6 +103,40 @@ describe("entity resolution module", () => {
 		);
 	});
 
+	it("names the entity type's own resolution fields verbatim in the reason", () => {
+		// A custom field must survive intact — naive singularization turned
+		// "status" into "statu".
+		const customSchema = {
+			type: "object",
+			"x-lobu-resolution": {
+				rules: [
+					{ fields: ["status"], normalizer: "exact", onMatch: "review" },
+				],
+			},
+		};
+		const assessment = assessEntityResolution({
+			metadataSchema: customSchema,
+			winner: { id: 1, metadata: {} },
+			losers: [{ id: 2, metadata: {} }],
+		});
+		expect(assessment.reason).toBe(
+			"No matching status could be verified automatically, so this merge needs your judgement.",
+		);
+	});
+
+	it("coalesces only the known singular/plural field aliases", () => {
+		// person defaults are email/emails/phone/phones — a reader wants two names.
+		const assessment = assessEntityResolution({
+			metadataSchema: { type: "object" },
+			entityTypeSlug: "person",
+			winner: { id: 1, metadata: {} },
+			losers: [{ id: 2, metadata: {} }],
+		});
+		expect(assessment.reason).toBe(
+			"No matching email or phone could be verified automatically, so this merge needs your judgement.",
+		);
+	});
+
 	it("auto-merges a configured unique identity but reviews conflicting strict identities", () => {
 		const base = {
 			metadataSchema: schema,

--- a/packages/server/src/entity-resolution/policy.ts
+++ b/packages/server/src/entity-resolution/policy.ts
@@ -26,6 +26,16 @@ interface ResolutionRule {
 	onMatch: ResolutionDecision;
 }
 
+/**
+ * Plural rule fields that name the same thing as their singular form, so the
+ * human-facing reason says "email or phone" rather than listing all four.
+ * Deliberately an explicit map: any field not listed here is printed verbatim.
+ */
+const RULE_FIELD_ALIASES: Record<string, string> = {
+	emails: "email",
+	phones: "phone",
+};
+
 const DEFAULT_PERSON_RESOLUTION_RULES: ResolutionRule[] = [
 	{ fields: ["email"], normalizer: "email", onMatch: "review" },
 	{ fields: ["emails"], normalizer: "email", onMatch: "review" },
@@ -231,12 +241,13 @@ export function assessEntityResolution(input: {
 	];
 	// Name the fields this entity type actually resolves on ("email or phone"
 	// for person) rather than assuming — another type may key on something else,
-	// and a type with no rules at all resolves on nothing. Singular/plural
-	// variants of the same field (email/emails) are one field to a reader.
+	// and a type with no rules at all resolves on nothing. Only the known
+	// singular/plural aliases are coalesced: stripping a trailing "s" from
+	// arbitrary configured paths would mangle custom names like `status`.
 	const ruleFieldLabel = [
 		...new Set(
 			rules.flatMap((rule) =>
-				rule.fields.map((field) => field.replace(/s$/, "")),
+				rule.fields.map((field) => RULE_FIELD_ALIASES[field] ?? field),
 			),
 		),
 	].join(" or ");

--- a/packages/server/src/entity-resolution/policy.ts
+++ b/packages/server/src/entity-resolution/policy.ts
@@ -229,6 +229,17 @@ export function assessEntityResolution(input: {
 	const evidenceKinds = [
 		...new Set(deduplicatedEvidence.map((item) => item.kind)),
 	];
+	// Name the fields this entity type actually resolves on ("email or phone"
+	// for person) rather than assuming — another type may key on something else,
+	// and a type with no rules at all resolves on nothing. Singular/plural
+	// variants of the same field (email/emails) are one field to a reader.
+	const ruleFieldLabel = [
+		...new Set(
+			rules.flatMap((rule) =>
+				rule.fields.map((field) => field.replace(/s$/, "")),
+			),
+		),
+	].join(" or ");
 	const decision =
 		allLosersHaveAutoMatch && !conflictingAutoIdentity
 			? "auto_merge"
@@ -245,13 +256,18 @@ export function assessEntityResolution(input: {
 		evidence: deduplicatedEvidence,
 		policyHash,
 		fingerprint,
+		// Addressed to the human deciding the approval, so each branch says what
+		// the workspace could verify and what it now needs from them — not what
+		// the rules engine did internally.
 		reason:
 			decision === "auto_merge"
 				? "The entity type declares this normalized identity unique."
 				: conflictingAutoIdentity
-					? "Configured strict identities conflict, so a person must review the merge."
+					? "These records carry conflicting identities that are configured as unique, so merging them needs your judgement."
 					: deduplicatedEvidence.length > 0
-						? `Matching ${evidenceKinds.join(" and ")} is evidence, but the proposal does not satisfy this entity type's automatic merge policy.`
-						: "No configured deterministic identity rule proves this merge.",
+						? `Matching ${evidenceKinds.join(" and ")} points to the same thing, but that is not enough to merge automatically under this entity type's policy, so it needs your judgement.`
+						: ruleFieldLabel
+							? `No matching ${ruleFieldLabel} could be verified automatically, so this merge needs your judgement.`
+							: "This entity type has no automatic matching rules, so every merge needs your judgement.",
 	};
 }

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -134,6 +134,13 @@ export interface EntityMergeProposal {
 	resolution_fingerprint?: string | null;
 	attribution?: ApprovalAttributionType;
 	reason?: string | null;
+	/**
+	 * The proposer's own justification, in their words. Deliberately separate
+	 * from `reason` (the server-recomputed policy verdict): an agent can claim
+	 * anything here, so it is rendered as an attributed claim and never treated
+	 * as evidence or allowed to influence the auto-merge decision.
+	 */
+	proposer_rationale?: string | null;
 }
 
 export type EntityChangeProposal =
@@ -697,6 +704,7 @@ export async function proposeEntityChange(
 						: (entity?.parent_entity_type ?? null),
 					attribution,
 					reason: proposal.reason ?? null,
+					proposer_rationale: mergeProposal?.proposer_rationale ?? null,
 					status: "pending_approval",
 					run_id: runId,
 				},

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -576,13 +576,34 @@ export async function proposeEntityChange(
 	const entityName = createProposal
 		? createProposal.entity_data.name
 		: entity?.name;
+	// Merge titles name both sides — this string is the event title that shows up
+	// in timelines and notifications, where "Merge duplicate person" alone gives a
+	// reviewer nothing to judge.
+	const mergeLosers = mergeProposal
+		? (mergeProposal.current.duplicates ?? [mergeProposal.current.loser])
+				.map((duplicate) => duplicate.name)
+				.filter((name): name is string => Boolean(name))
+		: [];
+	const mergeWinnerName = mergeProposal?.current.winner.name;
+	const mergeLoserLabel =
+		mergeLosers.length === 1
+			? mergeLosers[0]
+			: mergeLosers.length > 1
+				? `${mergeLosers.length} ${formatLabel(entityType ?? "entity").toLowerCase()} duplicates`
+				: null;
+	const mergeLabel =
+		mergeLoserLabel && mergeWinnerName
+			? `Merge ${mergeLoserLabel} into ${mergeWinnerName}`
+			: mergeWinnerName
+				? `Merge duplicate into ${mergeWinnerName}`
+				: `Merge duplicate ${formatLabel(entityType ?? "entity").toLowerCase()}`;
 	const actionLabel =
 		operation === "update"
 			? formatFieldChangeAction(entityType, fieldKeys)
 			: operation === "delete"
 				? `Delete ${entityType ? formatLabel(entityType).toLowerCase() : "entity"}`
 				: operation === "merge"
-					? `Merge duplicate ${formatLabel(entityType ?? "entity").toLowerCase()}`
+					? mergeLabel
 					: `Create ${formatLabel(entityType ?? "entity").toLowerCase()}`;
 
 	const insertApprovalEvent = (runId: number, db: DbClient) =>

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -582,9 +582,16 @@ export async function proposeEntityChange(
 	const mergeLosers = mergeProposal
 		? (mergeProposal.current.duplicates ?? [mergeProposal.current.loser])
 				.map((duplicate) => duplicate.name)
-				.filter((name): name is string => Boolean(name))
+				.filter(
+					(name): name is string =>
+						typeof name === "string" && name.trim().length > 0,
+				)
 		: [];
 	const mergeWinnerName = mergeProposal?.current.winner.name;
+	const mergeWinnerLabel =
+		typeof mergeWinnerName === "string" && mergeWinnerName.trim().length > 0
+			? mergeWinnerName
+			: null;
 	const mergeLoserLabel =
 		mergeLosers.length === 1
 			? mergeLosers[0]
@@ -592,10 +599,10 @@ export async function proposeEntityChange(
 				? `${mergeLosers.length} ${formatLabel(entityType ?? "entity").toLowerCase()} duplicates`
 				: null;
 	const mergeLabel =
-		mergeLoserLabel && mergeWinnerName
-			? `Merge ${mergeLoserLabel} into ${mergeWinnerName}`
-			: mergeWinnerName
-				? `Merge duplicate into ${mergeWinnerName}`
+		mergeLoserLabel && mergeWinnerLabel
+			? `Merge ${mergeLoserLabel} into ${mergeWinnerLabel}`
+			: mergeWinnerLabel
+				? `Merge duplicate into ${mergeWinnerLabel}`
 				: `Merge duplicate ${formatLabel(entityType ?? "entity").toLowerCase()}`;
 	const actionLabel =
 		operation === "update"

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -754,6 +754,11 @@ async function handleMerge(
 			resolution_fingerprint: resolution.fingerprint,
 			attribution,
 			reason: resolution.reason,
+			// The proposer's own words, kept strictly separate from `reason` (the
+			// machine-computed policy verdict). Displayed as a claim attributed to
+			// whoever proposed the merge — it is never evidence and never affects
+			// the auto-merge decision, which is recomputed server-side above.
+			proposer_rationale: args.merge_rationale?.trim() || null,
 		});
 		return {
 			action: "merge",


### PR DESCRIPTION
Follow-up to #2128. That fix made agent merges queue for approval instead of applying silently — but the cards they queued were unreadable, so 24 of them have been sitting unactionable since July 16.

Frontend half: lobu-ai/owletto#558 (submodule pointer bumped here).

## The reason string

Cards showed *"No configured deterministic identity rule proves this merge."* Written from the rules engine's point of view, and actively misleading: it reads as "no evidence exists" on cards where a phone match is the entire reason the proposal was made.

All four branches reworded to say what could not be verified and that the decision is now the reviewer's:

> No matching email or phone could be verified automatically, so this merge needs your judgement.

The field names come from the entity type's own resolution rules rather than a hardcoded "email or phone" — another type may key on something else, and a type with no rules resolves on nothing.

## `merge_rationale`

The proposer could not explain itself at all. `merge_evidence` is recomputed server-side for agents and Behaviors (by design), and no reason input existed — so whatever rationale the proposer had was discarded and replaced with the canned policy string.

New optional input carrying the proposer's own sentence, rendered as an attributed claim ("The agent's reasoning") above the policy verdict.

**The safety boundary is structural, not conventional:** `merge_rationale` never reaches `assessEntityResolution`, so it cannot influence whether a merge auto-applies. An agent can write anything there and the decision is unaffected. Pinned by a test asserting the rationale lands on the card while the decision stays `review` with empty evidence.

## Also

Merge event titles name both sides ("Merge X into Y") — this string is what appears in timelines and notifications, where "Merge duplicate person" gives a reviewer nothing.

## Testing

16/16 merge tool integration tests, 33/33 across the merge suites, 11/11 policy tests, `make pre-pr` clean.

## Known follow-ups (not in this PR)

- `assessEntityResolution` reads only `entity.metadata` and never `entity_identities`, so any entity whose phone/email lives there is invisible to auto-merge. Likely why resolution almost never fires across ~4.7k persons.
- Stored reasons are frozen at proposal time, so the 24 existing cards keep the old wording until actioned.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->