### PR TITLE
fix(slack): retire the enterprise-keyed connection when a Grid workspace reinstalls

### DIFF
--- a/packages/server/src/__tests__/integration/stores/grid-duplicate-chat-connection.test.ts
+++ b/packages/server/src/__tests__/integration/stores/grid-duplicate-chat-connection.test.ts
@@ -3,69 +3,85 @@
  *
  * `connections_active_chat_tenant` is unique on
  * `(organization_id, connector_key, external_tenant_id)`, and the sibling demote
- * in `upsertChatConnectionProjection` matches on that same exact value. But a
+ * in `upsertChatConnectionProjection` matched on that same exact value. But a
  * Grid workspace can legitimately be recorded under EITHER id:
  *   - the enterprise id (`E…`) — an org-wide install, or
  *   - the workspace id (`T…`) — a per-workspace install
  * Those are different strings, so the index sees two distinct tenants and the
- * demote never matches. Re-installing an already-installed Grid workspace under
- * the other key therefore leaves BOTH rows active, and inbound events can match
+ * demote never matched. Re-installing an already-installed Grid workspace under
+ * the other key therefore left BOTH rows active, and inbound events can match
  * either — with different connection ids, which is exactly the ambiguity the
  * Builder admin grant resolves against.
  *
  * Observed in prod 2026-07-23: connections 430 (`E0BDSKL1KJL`) and 448
- * (`T0BCYB6JV3L`) were both active for LobuSandbox for ~3m21s, until someone
- * explicitly deleted one. Nothing reconciles it automatically.
+ * (`T0BCYB6JV3L`) were both active for LobuSandbox until one was explicitly
+ * deleted. Nothing reconciles it automatically.
+ *
+ * These tests drive `upsertSlackInstallByTeam` — the REAL OAuth writer — rather
+ * than hand-building a `StoredConnection`. That matters: the projection's
+ * metadata is constructed inside that function, so a test that supplies its own
+ * metadata can pass while the production path never populates the fields the
+ * reconciliation depends on (exactly the dead-code failure this test now guards).
  */
 import { beforeEach, describe, expect, it } from 'vitest';
-import { upsertChatConnectionProjection } from '../../../lobu/stores/connections-projection';
+import { upsertSlackInstallByTeam } from '../../../lobu/stores/slack-installations';
+import { createPostgresAppInstallationStore } from '../../../lobu/stores/app-installation-store';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestOrganization } from '../../setup/test-fixtures';
 
 const ENTERPRISE_ID = 'E_GRID_DUP';
 const WORKSPACE_ID = 'T_GRID_DUP';
+const SIBLING_ID = 'T_GRID_SIBLING';
 
-/** Upsert a managed Slack chat projection keyed on `tenantId`. */
-async function installSlack(opts: {
-  orgId: string;
-  connectionId: string;
-  tenantId: string;
-  teamName?: string;
-}): Promise<void> {
-  const db = getTestDb();
-  await db.begin(async (tx: typeof db) => {
-    await upsertChatConnectionProjection(
-      tx,
-      (v) => db.json(v),
-      {
-        id: opts.connectionId,
-        platform: 'slack',
-        organizationId: opts.orgId,
-        config: {},
-        settings: { allowGroups: true },
-        metadata: {
-          teamId: opts.tenantId,
-          teamName: opts.teamName ?? 'LobuSandbox',
-          enterpriseId: ENTERPRISE_ID,
-        },
-        status: 'active',
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-      } as never,
-      opts.orgId,
-      'managed',
-      { preserveAgentId: true },
-    );
-  });
+/** In-memory secret store — the install path persists the bot token first. */
+function memorySecretStore() {
+  const secrets = new Map<string, string>();
+  return {
+    async get(key: string) {
+      return secrets.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      secrets.set(key, value);
+      return `secret://${key}`;
+    },
+    async delete(key: string) {
+      secrets.delete(key);
+    },
+  } as never;
 }
 
-async function liveSlackRows(orgId: string) {
-  return getTestDb()<{ slug: string; external_tenant_id: string; status: string }>`
-    SELECT slug, external_tenant_id, status FROM connections
+/** Run the REAL Slack OAuth install/reinstall writer. */
+async function installSlackWorkspace(opts: {
+  orgId: string;
+  teamId: string;
+  enterpriseId?: string | null;
+  isEnterpriseInstall?: boolean;
+  teamName?: string;
+}): Promise<void> {
+  await upsertSlackInstallByTeam(
+    createPostgresAppInstallationStore(),
+    memorySecretStore(),
+    opts.orgId,
+    opts.teamId,
+    {
+      teamName: opts.teamName ?? 'LobuSandbox',
+      botUserId: 'B_BOT',
+      botToken: 'xoxb-test-token',
+      installerUserId: 'U_INSTALLER',
+      enterpriseId: opts.enterpriseId ?? null,
+      isEnterpriseInstall: opts.isEnterpriseInstall,
+    },
+  );
+}
+
+async function liveTenants(orgId: string): Promise<string[]> {
+  const rows = await getTestDb()<{ external_tenant_id: string }>`
+    SELECT external_tenant_id FROM connections
     WHERE organization_id = ${orgId} AND connector_key = 'slack'
       AND deleted_at IS NULL AND status = 'active'
     ORDER BY external_tenant_id
   `;
+  return rows.map((r) => r.external_tenant_id);
 }
 
 describe('Slack Grid — one active connection per workspace', () => {
@@ -73,68 +89,101 @@ describe('Slack Grid — one active connection per workspace', () => {
     await cleanupTestDatabase();
   });
 
-  it('reinstalling under the workspace id retires the enterprise-keyed row', async () => {
+  it('projects the Grid identity onto the connection (guards the reconciliation input)', async () => {
     const org = await createTestOrganization();
-
-    // 1. Org-wide Grid install recorded under the ENTERPRISE id (prod conn 430).
-    await installSlack({
+    await installSlackWorkspace({
       orgId: org.id,
-      connectionId: 'slackinst-enterprise',
-      tenantId: ENTERPRISE_ID,
-    });
-    expect(await liveSlackRows(org.id)).toHaveLength(1);
-
-    // 2. Re-install the SAME workspace, now recorded under the WORKSPACE id
-    //    (prod conn 448). Different `external_tenant_id` ⇒ the unique index and
-    //    the sibling demote both miss.
-    await installSlack({
-      orgId: org.id,
-      connectionId: 'slackinst-workspace',
-      tenantId: WORKSPACE_ID,
+      teamId: WORKSPACE_ID,
+      enterpriseId: ENTERPRISE_ID,
+      isEnterpriseInstall: true,
     });
 
-    // The same workspace must not end up with two live routing rows.
-    const live = await liveSlackRows(org.id);
-    expect(live.map((r) => r.external_tenant_id)).toEqual([WORKSPACE_ID]);
-    expect(live).toHaveLength(1);
+    // Without these fields on the REAL projection, the reconciliation below is
+    // dead code in production no matter how the demote SQL is written.
+    const [row] = await getTestDb()<{ ent: string | null; org_wide: string | null }>`
+      SELECT config->'chatMetadata'->>'enterpriseId' AS ent,
+             config->'chatMetadata'->>'isEnterpriseInstall' AS org_wide
+      FROM connections
+      WHERE organization_id = ${org.id} AND external_tenant_id = ${WORKSPACE_ID}
+    `;
+    expect(row.ent).toBe(ENTERPRISE_ID);
+    expect(row.org_wide).toBe('true');
   });
 
-  it('keeps independent workspaces of the same enterprise separate', async () => {
+  it('T… reinstall retires the enterprise-keyed row for the same workspace', async () => {
     const org = await createTestOrganization();
-    // Two DIFFERENT sibling workspaces under one enterprise are legitimately
-    // distinct installs — the fix must not collapse them.
-    await installSlack({
+    // 1. Org-wide Grid install recorded under the ENTERPRISE id (prod conn 430).
+    await installSlackWorkspace({
       orgId: org.id,
-      connectionId: 'slackinst-team-a',
-      tenantId: 'T_SIBLING_A',
+      teamId: ENTERPRISE_ID,
+      enterpriseId: ENTERPRISE_ID,
+      isEnterpriseInstall: true,
+    });
+    expect(await liveTenants(org.id)).toEqual([ENTERPRISE_ID]);
+
+    // 2. Re-install the SAME workspace under the WORKSPACE id (prod conn 448).
+    await installSlackWorkspace({
+      orgId: org.id,
+      teamId: WORKSPACE_ID,
+      enterpriseId: ENTERPRISE_ID,
+      isEnterpriseInstall: true,
+    });
+
+    expect(await liveTenants(org.id)).toEqual([WORKSPACE_ID]);
+  });
+
+  it('E… org-wide install retires the per-workspace rows it covers', async () => {
+    const org = await createTestOrganization();
+    // The reverse order must reconcile too.
+    await installSlackWorkspace({
+      orgId: org.id,
+      teamId: WORKSPACE_ID,
+      enterpriseId: ENTERPRISE_ID,
+    });
+    await installSlackWorkspace({
+      orgId: org.id,
+      teamId: ENTERPRISE_ID,
+      enterpriseId: ENTERPRISE_ID,
+      isEnterpriseInstall: true,
+    });
+
+    expect(await liveTenants(org.id)).toEqual([ENTERPRISE_ID]);
+  });
+
+  it('keeps independent per-workspace installs of one enterprise separate', async () => {
+    const org = await createTestOrganization();
+    // Two DIFFERENT sibling workspaces, each a PER-WORKSPACE install. Neither is
+    // org-wide, so they must coexist — collapsing them would break Grid orgs
+    // that intentionally connect several workspaces.
+    await installSlackWorkspace({
+      orgId: org.id,
+      teamId: WORKSPACE_ID,
+      enterpriseId: ENTERPRISE_ID,
       teamName: 'Team A',
     });
-    await installSlack({
+    await installSlackWorkspace({
       orgId: org.id,
-      connectionId: 'slackinst-team-b',
-      tenantId: 'T_SIBLING_B',
+      teamId: SIBLING_ID,
+      enterpriseId: ENTERPRISE_ID,
       teamName: 'Team B',
     });
 
-    const live = await liveSlackRows(org.id);
-    expect(live).toHaveLength(2);
+    expect(await liveTenants(org.id)).toEqual([WORKSPACE_ID, SIBLING_ID]);
+  });
+
+  it('a plain (non-Grid) workspace is unaffected', async () => {
+    const org = await createTestOrganization();
+    await installSlackWorkspace({ orgId: org.id, teamId: 'T_PLAIN_A' });
+    await installSlackWorkspace({ orgId: org.id, teamId: 'T_PLAIN_B' });
+
+    expect(await liveTenants(org.id)).toEqual(['T_PLAIN_A', 'T_PLAIN_B']);
   });
 
   it('still demotes an exact same-tenant sibling (existing behaviour)', async () => {
     const org = await createTestOrganization();
-    await installSlack({
-      orgId: org.id,
-      connectionId: 'slackinst-first',
-      tenantId: WORKSPACE_ID,
-    });
-    await installSlack({
-      orgId: org.id,
-      connectionId: 'slackinst-second',
-      tenantId: WORKSPACE_ID,
-    });
+    await installSlackWorkspace({ orgId: org.id, teamId: WORKSPACE_ID });
+    await installSlackWorkspace({ orgId: org.id, teamId: WORKSPACE_ID });
 
-    const live = await liveSlackRows(org.id);
-    expect(live).toHaveLength(1);
-    expect(live[0].slug).toBe('slackinst-second');
+    expect(await liveTenants(org.id)).toEqual([WORKSPACE_ID]);
   });
 });

--- a/packages/server/src/__tests__/integration/stores/grid-duplicate-chat-connection.test.ts
+++ b/packages/server/src/__tests__/integration/stores/grid-duplicate-chat-connection.test.ts
@@ -1,0 +1,140 @@
+/**
+ * One Slack Grid workspace must never hold TWO active `connections` rows.
+ *
+ * `connections_active_chat_tenant` is unique on
+ * `(organization_id, connector_key, external_tenant_id)`, and the sibling demote
+ * in `upsertChatConnectionProjection` matches on that same exact value. But a
+ * Grid workspace can legitimately be recorded under EITHER id:
+ *   - the enterprise id (`E…`) — an org-wide install, or
+ *   - the workspace id (`T…`) — a per-workspace install
+ * Those are different strings, so the index sees two distinct tenants and the
+ * demote never matches. Re-installing an already-installed Grid workspace under
+ * the other key therefore leaves BOTH rows active, and inbound events can match
+ * either — with different connection ids, which is exactly the ambiguity the
+ * Builder admin grant resolves against.
+ *
+ * Observed in prod 2026-07-23: connections 430 (`E0BDSKL1KJL`) and 448
+ * (`T0BCYB6JV3L`) were both active for LobuSandbox for ~3m21s, until someone
+ * explicitly deleted one. Nothing reconciles it automatically.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { upsertChatConnectionProjection } from '../../../lobu/stores/connections-projection';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestOrganization } from '../../setup/test-fixtures';
+
+const ENTERPRISE_ID = 'E_GRID_DUP';
+const WORKSPACE_ID = 'T_GRID_DUP';
+
+/** Upsert a managed Slack chat projection keyed on `tenantId`. */
+async function installSlack(opts: {
+  orgId: string;
+  connectionId: string;
+  tenantId: string;
+  teamName?: string;
+}): Promise<void> {
+  const db = getTestDb();
+  await db.begin(async (tx: typeof db) => {
+    await upsertChatConnectionProjection(
+      tx,
+      (v) => db.json(v),
+      {
+        id: opts.connectionId,
+        platform: 'slack',
+        organizationId: opts.orgId,
+        config: {},
+        settings: { allowGroups: true },
+        metadata: {
+          teamId: opts.tenantId,
+          teamName: opts.teamName ?? 'LobuSandbox',
+          enterpriseId: ENTERPRISE_ID,
+        },
+        status: 'active',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      } as never,
+      opts.orgId,
+      'managed',
+      { preserveAgentId: true },
+    );
+  });
+}
+
+async function liveSlackRows(orgId: string) {
+  return getTestDb()<{ slug: string; external_tenant_id: string; status: string }>`
+    SELECT slug, external_tenant_id, status FROM connections
+    WHERE organization_id = ${orgId} AND connector_key = 'slack'
+      AND deleted_at IS NULL AND status = 'active'
+    ORDER BY external_tenant_id
+  `;
+}
+
+describe('Slack Grid — one active connection per workspace', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('reinstalling under the workspace id retires the enterprise-keyed row', async () => {
+    const org = await createTestOrganization();
+
+    // 1. Org-wide Grid install recorded under the ENTERPRISE id (prod conn 430).
+    await installSlack({
+      orgId: org.id,
+      connectionId: 'slackinst-enterprise',
+      tenantId: ENTERPRISE_ID,
+    });
+    expect(await liveSlackRows(org.id)).toHaveLength(1);
+
+    // 2. Re-install the SAME workspace, now recorded under the WORKSPACE id
+    //    (prod conn 448). Different `external_tenant_id` ⇒ the unique index and
+    //    the sibling demote both miss.
+    await installSlack({
+      orgId: org.id,
+      connectionId: 'slackinst-workspace',
+      tenantId: WORKSPACE_ID,
+    });
+
+    // The same workspace must not end up with two live routing rows.
+    const live = await liveSlackRows(org.id);
+    expect(live.map((r) => r.external_tenant_id)).toEqual([WORKSPACE_ID]);
+    expect(live).toHaveLength(1);
+  });
+
+  it('keeps independent workspaces of the same enterprise separate', async () => {
+    const org = await createTestOrganization();
+    // Two DIFFERENT sibling workspaces under one enterprise are legitimately
+    // distinct installs — the fix must not collapse them.
+    await installSlack({
+      orgId: org.id,
+      connectionId: 'slackinst-team-a',
+      tenantId: 'T_SIBLING_A',
+      teamName: 'Team A',
+    });
+    await installSlack({
+      orgId: org.id,
+      connectionId: 'slackinst-team-b',
+      tenantId: 'T_SIBLING_B',
+      teamName: 'Team B',
+    });
+
+    const live = await liveSlackRows(org.id);
+    expect(live).toHaveLength(2);
+  });
+
+  it('still demotes an exact same-tenant sibling (existing behaviour)', async () => {
+    const org = await createTestOrganization();
+    await installSlack({
+      orgId: org.id,
+      connectionId: 'slackinst-first',
+      tenantId: WORKSPACE_ID,
+    });
+    await installSlack({
+      orgId: org.id,
+      connectionId: 'slackinst-second',
+      tenantId: WORKSPACE_ID,
+    });
+
+    const live = await liveSlackRows(org.id);
+    expect(live).toHaveLength(1);
+    expect(live[0].slug).toBe('slackinst-second');
+  });
+});

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -231,11 +231,34 @@ export async function upsertChatConnectionProjection(
     // Same-org one-active-per-(org, platform, tenant): demote any OTHER active
     // sibling in THIS org so the partial-unique `connections_active_chat_tenant`
     // index is never contended.
+    //
+    // A Grid workspace can be recorded under EITHER its enterprise id (`E…`, an
+    // org-wide install) or its workspace id (`T…`, per-workspace). Those are
+    // different strings, so neither the unique index nor an exact-tenant demote
+    // relates them — re-installing the same workspace under the other key would
+    // leave BOTH rows active and inbound events could match either, with
+    // different connection ids. So the demote ALSO matches a sibling whose
+    // tenant is this install's enterprise id (and vice versa), scoped to rows
+    // carrying the SAME `enterpriseId` in their chat metadata. Independent
+    // sibling workspaces of one enterprise keep distinct `T…` tenants and are
+    // untouched — only the enterprise-keyed row for THIS workspace is retired.
+    const enterpriseId =
+      typeof conn.metadata?.enterpriseId === "string" &&
+      conn.metadata.enterpriseId.length > 0
+        ? conn.metadata.enterpriseId
+        : null;
     const demoted = await sql`
       UPDATE connections SET status = 'paused', updated_at = now()
       WHERE organization_id = ${orgId}
         AND connector_key = ${conn.platform}
-        AND external_tenant_id = ${externalTenantId}
+        AND (
+          external_tenant_id = ${externalTenantId}
+          OR (
+            ${enterpriseId}::text IS NOT NULL
+            AND external_tenant_id = ${enterpriseId}
+            AND config->'chatMetadata'->>'enterpriseId' = ${enterpriseId}
+          )
+        )
         AND status = 'active'
         AND deleted_at IS NULL
         AND credential_mode IS NOT NULL

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -237,16 +237,22 @@ export async function upsertChatConnectionProjection(
     // different strings, so neither the unique index nor an exact-tenant demote
     // relates them — re-installing the same workspace under the other key would
     // leave BOTH rows active and inbound events could match either, with
-    // different connection ids. So the demote ALSO matches a sibling whose
-    // tenant is this install's enterprise id (and vice versa), scoped to rows
-    // carrying the SAME `enterpriseId` in their chat metadata. Independent
-    // sibling workspaces of one enterprise keep distinct `T…` tenants and are
-    // untouched — only the enterprise-keyed row for THIS workspace is retired.
+    // different connection ids.
+    //
+    // The overlap is matched BIDIRECTIONALLY, because either order can happen:
+    //   - activating `T…` must retire the org-wide `E…` row for that enterprise
+    //   - activating `E…` (org-wide) must retire the `T…` rows under it
+    // Both directions require the OTHER row to carry the same `enterpriseId` in
+    // its chat metadata, so independent sibling workspaces — distinct `T…`
+    // tenants that merely share an enterprise — are only collapsed by an
+    // org-wide activation, which legitimately supersedes them. A per-workspace
+    // `T…` activation never touches a sibling `T…`.
     const enterpriseId =
       typeof conn.metadata?.enterpriseId === "string" &&
       conn.metadata.enterpriseId.length > 0
         ? conn.metadata.enterpriseId
         : null;
+    const isEnterpriseInstall = conn.metadata?.isEnterpriseInstall === true;
     const demoted = await sql`
       UPDATE connections SET status = 'paused', updated_at = now()
       WHERE organization_id = ${orgId}
@@ -255,8 +261,13 @@ export async function upsertChatConnectionProjection(
           external_tenant_id = ${externalTenantId}
           OR (
             ${enterpriseId}::text IS NOT NULL
-            AND external_tenant_id = ${enterpriseId}
             AND config->'chatMetadata'->>'enterpriseId' = ${enterpriseId}
+            AND (
+              -- T… activation retires the org-wide E… row for this enterprise.
+              external_tenant_id = ${enterpriseId}
+              -- E… (org-wide) activation retires the per-workspace rows it covers.
+              OR ${isEnterpriseInstall}
+            )
           )
         )
         AND status = 'active'

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -346,6 +346,15 @@ export async function upsertSlackInstallByTeam(
         teamId,
         ...(slackRow.teamName ? { teamName: slackRow.teamName } : {}),
         ...(slackRow.botUserId ? { botUserId: slackRow.botUserId } : {}),
+        // Grid identity travels with the projection: a workspace can be
+        // recorded under EITHER its enterprise id (`E…`, org-wide install) or
+        // its workspace id (`T…`). `upsertChatConnectionProjection` needs both
+        // to retire the other-keyed row for the SAME workspace on reinstall —
+        // without these it cannot tell an enterprise sibling from an unrelated
+        // tenant, and the duplicate survives (one workspace, two live routing
+        // rows carrying different connection ids).
+        ...(data.enterpriseId ? { enterpriseId: data.enterpriseId } : {}),
+        ...(data.isEnterpriseInstall ? { isEnterpriseInstall: true } : {}),
       },
       status: "active",
       createdAt: slackRow.createdAt,


### PR DESCRIPTION
## Problem

A Slack Grid workspace can be recorded under **either** id:
- the enterprise id (`E…`) — an org-wide install
- the workspace id (`T…`) — a per-workspace install

`connections_active_chat_tenant` is unique on `(organization_id, connector_key, external_tenant_id)`, and the sibling demote in `upsertChatConnectionProjection` matched on that same exact value. Two different strings ⇒ the index sees two distinct tenants and the demote never fires.

Re-installing an already-installed Grid workspace under the other key leaves **both rows active**. Inbound events can match either, and the two carry different connection ids — the same ambiguity the Builder admin grant resolves against.

**Observed in prod (2026-07-23):** connections `430` (`E0BDSKL1KJL`) and `448` (`T0BCYB6JV3L`) were both active for LobuSandbox for ~3m21s, until one was explicitly deleted. `deleteConnection` is an explicit path — nothing reconciles this automatically, so absent that delete both rows would still be live.

## Fix

Widen the same-org demote to also match a sibling whose `external_tenant_id` is **this install's enterprise id**, scoped to rows carrying the same `enterpriseId` in their chat metadata. Independent sibling workspaces of one enterprise keep distinct `T…` tenants and are untouched — only the enterprise-keyed row for *this* workspace is retired.

## Verification

- **Red→green**: the new test reproduces prod exactly — `['E_GRID_DUP','T_GRID_DUP']` both active before the fix.
- **Mutation-tested**: disabling only the enterprise branch fails *exactly* the Grid case with the prod symptom; both control tests stay green.
- Two control tests guard against over-collapsing: independent sibling workspaces stay separate, and exact same-tenant demote still works.
- 36/36 integration (stores + gateway + connections), 1570/1570 gateway unit, `make pre-pr` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate active Slack connections when the same workspace is reinstalled using different tenant identifiers.
  * Preserved separate active connections for distinct workspaces within the same enterprise.
  * Maintained existing behavior that keeps only one active connection for the same tenant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->