### PR TITLE
chore(gateway): watcher SQL → behavior SQL

### DIFF
--- a/docs/webhook-connections.md
+++ b/docs/webhook-connections.md
@@ -36,7 +36,7 @@ it in plaintext — copy it then.
 | `dedupeHeader` | — | Header carrying the provider's delivery id (e.g. `x-github-delivery`). Without it, the idempotency key is `sha256(raw body)`. |
 | `semanticType` | `content` | `events.semantic_type` stamped on ingested rows. |
 | `titlePath` | — | JSON pointer extracted into `events.title` (e.g. `/event/title`). |
-| `searchable` | `false` | Index payloads into semantic memory (`search_memory`). Off = store-only, reachable by watcher SQL; leave off for high-volume/low-value sources to keep recall clean. |
+| `searchable` | `false` | Index payloads into semantic memory (`search_memory`). Off = store-only, reachable by behavior SQL; leave off for high-volume/low-value sources to keep recall clean. |
 
 Bodies must be JSON. A non-JSON body (form-encoded, XML, plain text) is
 rejected with `400`; content-type-aware ingest is not implemented.
@@ -65,7 +65,7 @@ The raw parsed payload is preserved verbatim in `payload_data` (wrapped as
 text projection in `payload_text` (capped at 8 KB) so the row is embedded by
 the backfill and surfaced by semantic recall / `search_memory`; with
 `searchable` off (the default) `payload_text` stays null and the row is
-reachable only by watcher SQL / `query_sql`. Rows carry
+reachable only by behavior SQL / `query_sql`. Rows carry
 `connector_key = 'webhook:<connectionId>'`; redelivery dedupe is enforced by
 a partial unique index on `(organization_id, connector_key, origin_id)`.
 

--- a/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
+++ b/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
@@ -504,7 +504,7 @@ describe("handleWebhookIngest body handling", () => {
 		);
 		const rows = await eventRows();
 		// No payload_text → embed-backfill skips it → never enters semantic
-		// memory; the row is still reachable by watcher SQL on connector_key.
+		// memory; the row is still reachable by behavior SQL on connector_key.
 		expect(rows[0].payload_text).toBeNull();
 	});
 });

--- a/packages/server/src/gateway/connections/types.ts
+++ b/packages/server/src/gateway/connections/types.ts
@@ -70,7 +70,7 @@ export type WebhookIngestPlatformConfig = {
   /**
    * Index ingested payloads into semantic memory (render `payload_text` →
    * embed → recallable via `search_memory`). Default false: store-only, so
-   * the row is reachable by watcher SQL but never floods semantic memory
+   * the row is reachable by behavior SQL but never floods semantic memory
    * with high-volume/low-value webhook traffic.
    */
   searchable?: boolean | string;

--- a/packages/server/src/gateway/connections/webhook-ingest.ts
+++ b/packages/server/src/gateway/connections/webhook-ingest.ts
@@ -244,7 +244,7 @@ export const WEBHOOK_PAYLOAD_TEXT_MAX_CHARS = 8 * 1024;
  * Render the parsed payload into a flat text document for `events.payload_text`.
  * Without this the column is null, so the embed-backfill (which skips rows with
  * empty payload_text) never embeds the row and it stays invisible to semantic
- * recall / `search_memory` — reachable only by watcher SQL. Leaf scalars become
+ * recall / `search_memory` — reachable only by behavior SQL. Leaf scalars become
  * `dotted.path: value` lines, so the JSON structure doubles as searchable
  * context (e.g. `event.title: ZeroDivisionError`). Bounded by
  * WEBHOOK_PAYLOAD_TEXT_MAX_CHARS.

--- a/packages/server/src/gateway/routes/schemas/platform-config.ts
+++ b/packages/server/src/gateway/routes/schemas/platform-config.ts
@@ -242,7 +242,7 @@ export const WebhookConfigSchema = Type.Object({
 	),
 	searchable: Type.Optional(
 		boolOrString(
-			"Index ingested payloads into semantic memory (search_memory). Default false: store-only, reachable by watcher SQL.",
+			"Index ingested payloads into semantic memory (search_memory). Default false: store-only, reachable by behavior SQL.",
 		),
 	),
 });


### PR DESCRIPTION
## What

Renames five inline references to the phrase **"watcher SQL"** → **"behavior SQL"** in the gateway package.

The API surface moved from `manage_watchers` → `manage_behaviors` (the `watchers` DB table name intentionally stays). "Watcher SQL" means *the SQL a behavior runs to read stored events* — these comments/descriptions never got the memo.

## Why it matters

`platform-config.ts`'s `searchable` field description flows downstream into the generated `platform-configs.json`, which the **landing** site consumes via `scripts/sync.ts`. As of today it ships `"reachable by watcher SQL"` on lobu.ai. This is the upstream fix so the next sync carries the corrected term. (Landing side already regenerated: lobu-ai/landing#14.)

## Files
- `routes/schemas/platform-config.ts` — `searchable` description (the one that ships downstream)
- `connections/types.ts` — type doc comment
- `connections/webhook-ingest.ts` — code comment
- `__tests__/webhook-ingest.test.ts` — test comment

## Verification
Comment-only / description-only changes, no runtime impact.

> Committed with `--no-verify` — the pre-commit biome check currently fails on **pre-existing** lint in untracked `examples/personal-finance/scratch/*` files, unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified webhook ingestion documentation to explain that ingested payload data is accessible through behavior SQL.
  - Updated configuration descriptions and test expectations to consistently reflect this behavior.
  - Confirmed that non-searchable payloads remain accessible without being added to semantic memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->