### PR TITLE
fix(resolution): read entity_identities, not just metadata, when proving duplicates

### DIFF
--- a/db/migrations/20260723120000_runs_initiator.sql
+++ b/db/migrations/20260723120000_runs_initiator.sql
@@ -1,0 +1,23 @@
+-- migrate:up
+
+-- Record the verified principal that requested a run. `initiator_kind` names
+-- the principal channel and `initiator_ref` carries its identifiers.
+--
+-- Kinds: 'user' | 'behavior' | 'agent_session' | 'system'. Keep this as text so
+-- adding a new principal channel does not require changing a database enum.
+--
+-- Existing watcher_id/window_id columns remain the operational keys used by
+-- behavior scheduling and approval batching.
+ALTER TABLE public.runs
+  ADD COLUMN IF NOT EXISTS initiator_kind text,
+  ADD COLUMN IF NOT EXISTS initiator_ref jsonb;
+
+-- Existing rows remain NULL because their initiator cannot be reconstructed
+-- reliably.
+
+-- migrate:down
+
+-- squawk-ignore ban-drop-column
+ALTER TABLE public.runs
+  DROP COLUMN IF EXISTS initiator_kind,
+  DROP COLUMN IF EXISTS initiator_ref;

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -239,6 +239,46 @@ describe("manage_entity merge action", () => {
 		expect(completedEvent.interaction_status).toBe("completed");
 	});
 
+	it("queues review evidence for a phone shared only through entity_identities", async () => {
+		// The prod-shaped gap: connectors write phones to entity_identities, not
+		// metadata, so the matcher must read identity rows to see the match.
+		const org = await createTestOrganization({ name: "Identity Evidence Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+      VALUES
+        (${org.id}, ${winner.id}, 'phone', '+90 506 788 88 45'),
+        (${org.id}, ${loser.id}, 'phone', '905067888845'),
+        (${org.id}, ${loser.id}, 'wa_jid', '905067888845@s.whatsapp.net')
+    `;
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+			} as ToolContext,
+		)) as unknown as {
+			approval_queued: boolean;
+			resolution: {
+				decision: string;
+				evidence: Array<{ kind: string; identifier: string }>;
+			};
+		};
+
+		expect(queued.approval_queued).toBe(true);
+		expect(queued.resolution.decision).toBe("review");
+		expect(queued.resolution.evidence).toContainEqual({
+			kind: "phone",
+			identifier: "905067888845",
+		});
+	});
+
 	it("carries the proposer's rationale to the card without letting it prove the merge", async () => {
 		const org = await createTestOrganization({ name: "Rationale Org" });
 		const user = await createTestUser();

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -5,7 +5,11 @@
  * The fusion mechanics themselves are proven in events/entity-merge.test.ts.
  */
 
+import postgres from "postgres";
 import { beforeEach, describe, expect, it } from "vitest";
+import { PROD_PG_VALUE_OPTIONS } from "../../../db/client";
+import { assessEntityResolution } from "../../../entity-resolution/policy";
+import { assertResolutionFingerprintCurrent } from "../../../entity-resolution/staleness";
 import type { Env } from "../../../index";
 import { manageEntity } from "../../../tools/admin/manage_entity";
 import { manageOperations } from "../../../tools/admin/manage_operations";
@@ -240,8 +244,6 @@ describe("manage_entity merge action", () => {
 	});
 
 	it("queues review evidence for a phone shared only through entity_identities", async () => {
-		// The prod-shaped gap: connectors write phones to entity_identities, not
-		// metadata, so the matcher must read identity rows to see the match.
 		const org = await createTestOrganization({ name: "Identity Evidence Org" });
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
@@ -250,9 +252,9 @@ describe("manage_entity merge action", () => {
 		await sql`
       INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
       VALUES
-        (${org.id}, ${winner.id}, 'phone', '+90 506 788 88 45'),
-        (${org.id}, ${loser.id}, 'phone', '905067888845'),
-        (${org.id}, ${loser.id}, 'wa_jid', '905067888845@s.whatsapp.net')
+        (${org.id}, ${winner.id}, 'phone', '+44 7700 900 123'),
+        (${org.id}, ${loser.id}, 'phone', '447700900123'),
+        (${org.id}, ${loser.id}, 'wa_jid', '447700900123@s.whatsapp.net')
     `;
 
 		const queued = (await manageEntity(
@@ -275,7 +277,7 @@ describe("manage_entity merge action", () => {
 		expect(queued.resolution.decision).toBe("review");
 		expect(queued.resolution.evidence).toContainEqual({
 			kind: "phone",
-			identifier: "905067888845",
+			identifier: "447700900123",
 		});
 	});
 
@@ -1019,9 +1021,6 @@ describe("manage_entity merge action", () => {
 	});
 
 	it("does not apply an approved merge when an identity row appeared after proposal", async () => {
-		// Identities are evidence inputs, so a new entity_identities row must
-		// change the resolution fingerprint and fail the staleness gate — the
-		// candidate has to be re-proposed with the wider evidence.
 		const org = await createTestOrganization({ name: "Identity Staleness Org" });
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
@@ -1050,7 +1049,7 @@ describe("manage_entity merge action", () => {
 
 		await sql`
       INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
-      VALUES (${org.id}, ${loser.id}, 'phone', '905067888845')
+      VALUES (${org.id}, ${loser.id}, 'phone', '447700900123')
     `;
 		const approved = await manageOperations(
 			{ action: "approve", run_id: queued.approval_run_id },
@@ -1064,6 +1063,60 @@ describe("manage_entity merge action", () => {
     `;
 		expect(after.merged_into).toBeNull();
 		expect(after.deleted_at).toBeNull();
+	});
+
+	it("locks identity evidence until the staleness-checked transaction finishes", async () => {
+		const org = await createTestOrganization({ name: "Identity Lock Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+			INSERT INTO entity_identities
+			  (organization_id, entity_id, namespace, identifier)
+			VALUES (${org.id}, ${loser.id}, 'phone', '447700900123')
+		`;
+		const assessment = assessEntityResolution({
+			metadataSchema: { type: "object" },
+			entityTypeSlug: "person",
+			winner: { id: winner.id, metadata: {} },
+			losers: [
+				{
+					id: loser.id,
+					metadata: {},
+					identities: [{ namespace: "phone", identifier: "447700900123" }],
+				},
+			],
+		});
+		const writer = postgres(process.env.DATABASE_URL as string, {
+			max: 1,
+			onnotice: () => {},
+			...PROD_PG_VALUE_OPTIONS,
+		});
+		try {
+			await sql.begin(async (tx) => {
+				await assertResolutionFingerprintCurrent(tx, {
+					organizationId: org.id,
+					winnerId: winner.id,
+					loserIds: [loser.id],
+					expectedFingerprint: assessment.fingerprint,
+				});
+				await expect(
+					writer.begin(async (writerTx) => {
+						await writerTx`SET LOCAL lock_timeout = '100ms'`;
+						await writerTx`
+							UPDATE entity_identities
+							SET identifier = '447700900124'
+							WHERE organization_id = ${org.id}
+							  AND entity_id = ${loser.id}
+							  AND deleted_at IS NULL
+						`;
+					}),
+				).rejects.toMatchObject({ code: "55P03" });
+			});
+		} finally {
+			await writer.end();
+		}
 	});
 
 	it("does not apply an approved watcher merge when the loser was deleted after proposal", async () => {

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -1018,6 +1018,54 @@ describe("manage_entity merge action", () => {
 		expect(approvalEvent.interaction_status).toBe("pending");
 	});
 
+	it("does not apply an approved merge when an identity row appeared after proposal", async () => {
+		// Identities are evidence inputs, so a new entity_identities row must
+		// change the resolution fingerprint and fail the staleness gate — the
+		// candidate has to be re-proposed with the wider evidence.
+		const org = await createTestOrganization({ name: "Identity Staleness Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO watchers
+        (id, organization_id, agent_id, created_by, watcher_group_id, name,
+         status, notification_channel, notification_priority, min_cooldown_seconds,
+         created_at, updated_at)
+      VALUES
+        (6015, ${org.id}, 'personal-agent', ${user.id}, 6015, 'Identity staleness',
+         'active', 'canvas', 'normal', 0, now(), now())
+    `;
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+				actingWatcherId: 6015,
+			} as ToolContext,
+		)) as unknown as { approval_run_id: number };
+
+		await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+      VALUES (${org.id}, ${loser.id}, 'phone', '905067888845')
+    `;
+		const approved = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+
+		expect("approved" in approved && approved.approved).toBe(false);
+		const [after] = await sql`
+      SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+    `;
+		expect(after.merged_into).toBeNull();
+		expect(after.deleted_at).toBeNull();
+	});
+
 	it("does not apply an approved watcher merge when the loser was deleted after proposal", async () => {
 		const org = await createTestOrganization({ name: "Stale Merge Org" });
 		const user = await createTestUser();

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -281,6 +281,115 @@ describe("manage_entity merge action", () => {
 		});
 	});
 
+	it("records the agent session that proposed the merge, not an orphan run", async () => {
+		const org = await createTestOrganization({ name: "Initiator Agent Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				agentId: "personal-agent",
+				clientId: "claude-ai",
+				sourceContext: { platform: "mcp", conversationId: "conv-abc" },
+			} as ToolContext,
+		)) as unknown as { approval_queued: boolean; approval_run_id: number };
+
+		expect(queued.approval_queued).toBe(true);
+		const [run] = await sql`
+			SELECT initiator_kind, initiator_ref, created_by_user_id, watcher_id
+			FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		expect(run.initiator_kind).toBe("agent_session");
+		expect(run.initiator_ref).toMatchObject({
+			agent_id: "personal-agent",
+			client_id: "claude-ai",
+			conversation_id: "conv-abc",
+		});
+		expect(run.created_by_user_id).toBe(user.id);
+		expect(run.watcher_id).toBeNull();
+	});
+
+	it("records a behavior initiator consistent with the legacy watcher columns", async () => {
+		const org = await createTestOrganization({ name: "Initiator Behavior Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO watchers
+        (id, organization_id, agent_id, created_by, watcher_group_id, name,
+         status, notification_channel, notification_priority, min_cooldown_seconds,
+         created_at, updated_at)
+      VALUES
+        (6021, ${org.id}, 'personal-agent', ${user.id}, 6021, 'Initiator behavior',
+         'active', 'canvas', 'normal', 0, now(), now())
+    `;
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+				actingWatcherId: 6021,
+			} as ToolContext,
+		)) as unknown as { approval_queued: boolean; approval_run_id: number };
+
+		const [run] = await sql`
+			SELECT initiator_kind, initiator_ref, watcher_id
+			FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		expect(run.initiator_kind).toBe("behavior");
+		expect((run.initiator_ref as { watcher_id: number }).watcher_id).toBe(6021);
+		expect(Number(run.watcher_id)).toBe(6021);
+	});
+
+	it("does not let a caller-supplied behavior_source forge the initiator", async () => {
+		const org = await createTestOrganization({ name: "Initiator Spoof Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO watchers
+        (id, organization_id, agent_id, created_by, watcher_group_id, name,
+         status, notification_channel, notification_priority, min_cooldown_seconds,
+         created_at, updated_at)
+      VALUES
+        (6022, ${org.id}, 'other-agent', ${user.id}, 6022, 'Someone elses behavior',
+         'active', 'canvas', 'normal', 0, now(), now())
+    `;
+
+		const queued = (await manageEntity(
+			{
+				action: "merge",
+				entity_id: loser.id,
+				winner_entity_id: winner.id,
+				behavior_source: { behavior_id: 6022, window_id: 1 },
+			},
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				agentId: "personal-agent",
+				clientId: "claude-ai",
+			} as ToolContext,
+		)) as unknown as { approval_run_id: number };
+
+		const [run] = await sql`
+			SELECT initiator_kind, initiator_ref FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		expect(run.initiator_kind).toBe("agent_session");
+		expect((run.initiator_ref as { agent_id: string }).agent_id).toBe(
+			"personal-agent",
+		);
+	});
+
 	it("carries the proposer's rationale to the card without letting it prove the merge", async () => {
 		const org = await createTestOrganization({ name: "Rationale Org" });
 		const user = await createTestUser();

--- a/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
@@ -307,7 +307,8 @@ describe("manage_agents — builder gate e2e", () => {
 
 		// Pending run, run_type='internal', held proposal in action_input.
 		const runRows = await sql`
-			SELECT run_type, action_key, approval_status, status, action_input, created_by_user_id
+			SELECT run_type, action_key, approval_status, status, action_input,
+			       created_by_user_id, initiator_kind, initiator_ref
 			FROM runs WHERE id = ${res.run_id} AND organization_id = ${orgId}
 		`;
 		expect(runRows.length).toBe(1);
@@ -316,6 +317,11 @@ describe("manage_agents — builder gate e2e", () => {
 		expect(runRows[0]?.approval_status).toBe("pending");
 		expect(runRows[0]?.status).toBe("pending");
 		expect(runRows[0]?.created_by_user_id).toBe(ownerId);
+		expect(runRows[0]?.initiator_kind).toBe("agent_session");
+		expect(runRows[0]?.initiator_ref).toMatchObject({
+			agent_id: "builder-agent",
+			user_id: ownerId,
+		});
 		const proposal = runRows[0]?.action_input as {
 			action: string;
 			agent_id: string;

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
@@ -191,13 +191,21 @@ describe("manage_behaviors — builder gate e2e", () => {
 		});
 
 		const eventRows = await sql`
-			SELECT interaction_type, interaction_status
+			SELECT interaction_type, interaction_status, metadata
 			FROM current_event_records
 			WHERE run_id = ${res.run_id} AND organization_id = ${orgId}
 				AND semantic_type = 'operation' AND interaction_type = 'approval'
 		`;
 		expect(eventRows.length).toBe(1);
 		expect(eventRows[0]?.interaction_status).toBe("pending");
+		expect(
+			(eventRows[0]?.metadata as { initiator?: Record<string, unknown> })
+				?.initiator
+		).toMatchObject({
+			kind: "agent_session",
+			agent_id: agentId,
+			user_id: ownerId,
+		});
 
 		expect(await watcherExists(orgId, "agent-proposed-watcher")).toBe(false);
 	});

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
@@ -174,7 +174,8 @@ describe("manage_behaviors — builder gate e2e", () => {
 
 		const sql = getTestDb();
 		const runRows = await sql`
-			SELECT run_type, action_key, approval_status, status, action_input, created_by_user_id
+			SELECT run_type, action_key, approval_status, status, action_input,
+			       created_by_user_id, initiator_kind, initiator_ref
 			FROM runs WHERE id = ${res.run_id} AND organization_id = ${orgId}
 		`;
 		expect(runRows.length).toBe(1);
@@ -183,6 +184,11 @@ describe("manage_behaviors — builder gate e2e", () => {
 		expect(runRows[0]?.approval_status).toBe("pending");
 		expect(runRows[0]?.status).toBe("pending");
 		expect(runRows[0]?.created_by_user_id).toBe(ownerId);
+		expect(runRows[0]?.initiator_kind).toBe("agent_session");
+		expect(runRows[0]?.initiator_ref).toMatchObject({
+			agent_id: agentId,
+			user_id: ownerId,
+		});
 
 		const eventRows = await sql`
 			SELECT interaction_type, interaction_status

--- a/packages/server/src/__tests__/unit/run-initiator.test.ts
+++ b/packages/server/src/__tests__/unit/run-initiator.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { resolveRunInitiator } from "../../tools/initiator";
+
+describe("resolveRunInitiator", () => {
+	it("records the agent session, client, and authorizing human", () => {
+		expect(
+			resolveRunInitiator({
+				userId: "user_1",
+				agentId: "personal-agent",
+				clientId: "claude-ai",
+				sourceContext: { platform: "mcp", conversationId: "conv-1" },
+			}),
+		).toEqual({
+			initiatorKind: "agent_session",
+			initiatorRef: {
+				agent_id: "personal-agent",
+				user_id: "user_1",
+				client_id: "claude-ai",
+				conversation_id: "conv-1",
+			},
+			createdByUserId: "user_1",
+		});
+	});
+
+	it("classifies a reaction as its behavior, not its owning agent", () => {
+		expect(
+			resolveRunInitiator({
+				userId: null,
+				agentId: "personal-agent",
+				actingWatcherId: 42,
+				actingWindowId: 7,
+				actingRunId: 99,
+			}),
+		).toEqual({
+			initiatorKind: "behavior",
+			initiatorRef: {
+				watcher_id: 42,
+				window_id: 7,
+				run_id: 99,
+			},
+			createdByUserId: null,
+		});
+	});
+
+	it("records a plain human session", () => {
+		expect(resolveRunInitiator({ userId: "user_1" })).toEqual({
+			initiatorKind: "user",
+			initiatorRef: { user_id: "user_1" },
+			createdByUserId: "user_1",
+		});
+	});
+
+	it("falls back to system for hand-built internal contexts", () => {
+		expect(resolveRunInitiator({})).toEqual({
+			initiatorKind: "system",
+			initiatorRef: {},
+			createdByUserId: null,
+		});
+	});
+});

--- a/packages/server/src/entity-resolution/discovery.test.ts
+++ b/packages/server/src/entity-resolution/discovery.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { discoverEntityResolutionGroups } from "./discovery";
-import { assessEntityResolution } from "./policy";
+import {
+	assessEntityResolution,
+	normalizedResolutionRuleKeys,
+} from "./policy";
 
 const schema = {
 	type: "object",
@@ -325,6 +328,163 @@ describe("entity resolution module", () => {
 		expect(assessment.evidence).toContainEqual({
 			kind: "phone",
 			identifier: "905067888845",
+		});
+	});
+
+	it("reads a JID-shell's phone identity but does not match a corrupted metadata phone", () => {
+		// Real prod pair (run 702088): the WhatsApp shell has its phone only in
+		// entity_identities; the named contact's metadata phone was double-split
+		// on import ("050-678-88845" → 05067888845, missing the 90 country code).
+		// The shell's identity must be read; the corrupted number still must NOT
+		// match — repairing import-mangled phones is a separate bug, and inventing
+		// a match here would paper over it.
+		const phoneRule: Parameters<typeof normalizedResolutionRuleKeys>[1] = {
+			fields: ["phone"],
+			normalizer: "phone",
+			onMatch: "review",
+		};
+		const jidShell = {
+			id: 519,
+			metadata: {},
+			identities: [
+				{ namespace: "wa_jid", identifier: "905067888845@s.whatsapp.net" },
+				{ namespace: "phone", identifier: "905067888845" },
+			],
+		};
+		expect(normalizedResolutionRuleKeys(jidShell, phoneRule)).toEqual([
+			"905067888845",
+		]);
+
+		const assessment = assessEntityResolution({
+			metadataSchema: { type: "object" },
+			entityTypeSlug: "person",
+			winner: {
+				id: 24002,
+				metadata: { phone: "050-678-88845", email: "" },
+			},
+			losers: [jidShell],
+		});
+		expect(assessment.decision).toBe("review");
+		expect(assessment.evidence).toEqual([]);
+	});
+
+	it("never treats an identity from another namespace as a rule-field value", () => {
+		// wa_jid rows must not feed the phone field: the namespace filter drops
+		// them, and even a rule field literally named wa_jid with a phone
+		// normalizer rejects the JID shape itself.
+		const jidOnly = {
+			id: 1,
+			metadata: {},
+			identities: [
+				{ namespace: "wa_jid", identifier: "905067888845@s.whatsapp.net" },
+			],
+		};
+		expect(
+			normalizedResolutionRuleKeys(jidOnly, {
+				fields: ["phone"],
+				normalizer: "phone",
+				onMatch: "review",
+			}),
+		).toEqual([]);
+		expect(
+			normalizedResolutionRuleKeys(jidOnly, {
+				fields: ["wa_jid"],
+				normalizer: "phone",
+				onMatch: "review",
+			}),
+		).toEqual([]);
+	});
+
+	it("folds identities into the fingerprint deterministically", () => {
+		const assess = (
+			identities: Array<{ namespace: string; identifier: string }>,
+		) =>
+			assessEntityResolution({
+				metadataSchema: { type: "object" },
+				entityTypeSlug: "person",
+				winner: { id: 1, metadata: { email: "same@example.com" } },
+				losers: [{ id: 2, metadata: {}, identities }],
+			});
+
+		const without = assess([]);
+		const withPhone = assess([
+			{ namespace: "phone", identifier: "905067888845" },
+			{ namespace: "email", identifier: "same@example.com" },
+		]);
+		// Identities are evidence inputs, so adding one must change the
+		// fingerprint — a pending review proposed before the identity existed
+		// fails the staleness check and is re-proposed with the wider evidence.
+		expect(withPhone.fingerprint).not.toBe(without.fingerprint);
+		// …but row order is not evidence: normalization sorts, so a reshuffled
+		// load produces the identical fingerprint.
+		const reordered = assess([
+			{ namespace: "email", identifier: "same@example.com" },
+			{ namespace: "phone", identifier: "905067888845" },
+		]);
+		expect(reordered.fingerprint).toBe(withPhone.fingerprint);
+	});
+
+	it("keeps discovery grouping and assessment in agreement on identity-only matches", () => {
+		const namedContact = {
+			id: 1,
+			metadata: { title: "Engineer" },
+			identities: [{ namespace: "phone", identifier: "+90 506 788 88 45" }],
+		};
+		const shell = {
+			id: 2,
+			metadata: {},
+			identities: [{ namespace: "phone", identifier: "905067888845" }],
+		};
+		const discovered = discoverEntityResolutionGroups({
+			metadataSchema: { type: "object" },
+			entityTypeSlug: "person",
+			candidates: [namedContact, shell],
+		});
+		expect(discovered.groups).toEqual([{ winnerId: 1, loserIds: [2] }]);
+
+		const assessment = assessEntityResolution({
+			metadataSchema: { type: "object" },
+			entityTypeSlug: "person",
+			winner: namedContact,
+			losers: [shell],
+		});
+		expect(assessment.evidence).toContainEqual({
+			kind: "phone",
+			identifier: "905067888845",
+		});
+	});
+
+	it("draws each field of a combination rule from metadata and identities alike", () => {
+		const comboSchema = {
+			"x-lobu-resolution": {
+				rules: [
+					{
+						fields: ["email", "phone"],
+						normalizer: "exact",
+						onMatch: "review",
+					},
+				],
+			},
+		};
+		// Winner: email in metadata, phone in identities. Loser: the reverse.
+		const assessment = assessEntityResolution({
+			metadataSchema: comboSchema,
+			winner: {
+				id: 1,
+				metadata: { email: "same@example.com" },
+				identities: [{ namespace: "phone", identifier: "905067888845" }],
+			},
+			losers: [
+				{
+					id: 2,
+					metadata: { phone: "905067888845" },
+					identities: [{ namespace: "email", identifier: "same@example.com" }],
+				},
+			],
+		});
+		expect(assessment.evidence).toContainEqual({
+			kind: "email + phone",
+			identifier: "same@example.com · 905067888845",
 		});
 	});
 

--- a/packages/server/src/entity-resolution/discovery.test.ts
+++ b/packages/server/src/entity-resolution/discovery.test.ts
@@ -301,6 +301,33 @@ describe("entity resolution module", () => {
 		expect(assess("two").fingerprint).not.toBe(assess("three").fingerprint);
 	});
 
+	it("reads rule-field values from entity_identities rows, not just metadata", () => {
+		// Connectors write phones/emails to entity_identities; metadata is often
+		// empty. Two persons sharing a phone only through identity rows must still
+		// produce that phone as evidence.
+		const assessment = assessEntityResolution({
+			metadataSchema: { type: "object" },
+			entityTypeSlug: "person",
+			winner: {
+				id: 1,
+				metadata: {},
+				identities: [{ namespace: "phone", identifier: "+90 506 788 88 45" }],
+			},
+			losers: [
+				{
+					id: 2,
+					metadata: {},
+					identities: [{ namespace: "phone", identifier: "905067888845" }],
+				},
+			],
+		});
+		expect(assessment.decision).toBe("review");
+		expect(assessment.evidence).toContainEqual({
+			kind: "phone",
+			identifier: "905067888845",
+		});
+	});
+
 	it("rejects oversized decision batches before returning partial work", () => {
 		const candidates = Array.from({ length: 400 }, (_, index) => ({
 			id: index + 1,

--- a/packages/server/src/entity-resolution/discovery.test.ts
+++ b/packages/server/src/entity-resolution/discovery.test.ts
@@ -305,39 +305,36 @@ describe("entity resolution module", () => {
 	});
 
 	it("reads rule-field values from entity_identities rows, not just metadata", () => {
-		// Connectors write phones/emails to entity_identities; metadata is often
-		// empty. Two persons sharing a phone only through identity rows must still
-		// produce that phone as evidence.
 		const assessment = assessEntityResolution({
 			metadataSchema: { type: "object" },
 			entityTypeSlug: "person",
 			winner: {
 				id: 1,
 				metadata: {},
-				identities: [{ namespace: "phone", identifier: "+90 506 788 88 45" }],
+				identities: [{ namespace: "phone", identifier: "+44 7700 900 123" }],
 			},
 			losers: [
 				{
 					id: 2,
 					metadata: {},
-					identities: [{ namespace: "phone", identifier: "905067888845" }],
+					identities: [{ namespace: "phone", identifier: "447700900123" }],
 				},
 			],
 		});
 		expect(assessment.decision).toBe("review");
 		expect(assessment.evidence).toContainEqual({
 			kind: "phone",
-			identifier: "905067888845",
+			identifier: "447700900123",
 		});
 	});
 
 	it("reads a JID-shell's phone identity but does not match a corrupted metadata phone", () => {
-		// Real prod pair (run 702088): the WhatsApp shell has its phone only in
-		// entity_identities; the named contact's metadata phone was double-split
-		// on import ("050-678-88845" → 05067888845, missing the 90 country code).
-		// The shell's identity must be read; the corrupted number still must NOT
-		// match — repairing import-mangled phones is a separate bug, and inventing
-		// a match here would paper over it.
+		// The run-702088 prod shape (numbers sanitized): the WhatsApp shell has
+		// its phone only in entity_identities; the named contact's metadata phone
+		// was double-split on import, losing the country code. The shell's
+		// identity must be read; the corrupted number still must NOT match —
+		// repairing import-mangled phones is a separate bug, and inventing a
+		// match here would paper over it.
 		const phoneRule: Parameters<typeof normalizedResolutionRuleKeys>[1] = {
 			fields: ["phone"],
 			normalizer: "phone",
@@ -347,12 +344,12 @@ describe("entity resolution module", () => {
 			id: 519,
 			metadata: {},
 			identities: [
-				{ namespace: "wa_jid", identifier: "905067888845@s.whatsapp.net" },
-				{ namespace: "phone", identifier: "905067888845" },
+				{ namespace: "wa_jid", identifier: "447700900123@s.whatsapp.net" },
+				{ namespace: "phone", identifier: "447700900123" },
 			],
 		};
 		expect(normalizedResolutionRuleKeys(jidShell, phoneRule)).toEqual([
-			"905067888845",
+			"447700900123",
 		]);
 
 		const assessment = assessEntityResolution({
@@ -360,7 +357,7 @@ describe("entity resolution module", () => {
 			entityTypeSlug: "person",
 			winner: {
 				id: 24002,
-				metadata: { phone: "050-678-88845", email: "" },
+				metadata: { phone: "070-090-0123", email: "" },
 			},
 			losers: [jidShell],
 		});
@@ -369,14 +366,11 @@ describe("entity resolution module", () => {
 	});
 
 	it("never treats an identity from another namespace as a rule-field value", () => {
-		// wa_jid rows must not feed the phone field: the namespace filter drops
-		// them, and even a rule field literally named wa_jid with a phone
-		// normalizer rejects the JID shape itself.
 		const jidOnly = {
 			id: 1,
 			metadata: {},
 			identities: [
-				{ namespace: "wa_jid", identifier: "905067888845@s.whatsapp.net" },
+				{ namespace: "wa_jid", identifier: "447700900123@s.whatsapp.net" },
 			],
 		};
 		expect(
@@ -408,18 +402,13 @@ describe("entity resolution module", () => {
 
 		const without = assess([]);
 		const withPhone = assess([
-			{ namespace: "phone", identifier: "905067888845" },
+			{ namespace: "phone", identifier: "447700900123" },
 			{ namespace: "email", identifier: "same@example.com" },
 		]);
-		// Identities are evidence inputs, so adding one must change the
-		// fingerprint — a pending review proposed before the identity existed
-		// fails the staleness check and is re-proposed with the wider evidence.
 		expect(withPhone.fingerprint).not.toBe(without.fingerprint);
-		// …but row order is not evidence: normalization sorts, so a reshuffled
-		// load produces the identical fingerprint.
 		const reordered = assess([
 			{ namespace: "email", identifier: "same@example.com" },
-			{ namespace: "phone", identifier: "905067888845" },
+			{ namespace: "phone", identifier: "447700900123" },
 		]);
 		expect(reordered.fingerprint).toBe(withPhone.fingerprint);
 	});
@@ -428,12 +417,12 @@ describe("entity resolution module", () => {
 		const namedContact = {
 			id: 1,
 			metadata: { title: "Engineer" },
-			identities: [{ namespace: "phone", identifier: "+90 506 788 88 45" }],
+			identities: [{ namespace: "phone", identifier: "+44 7700 900 123" }],
 		};
 		const shell = {
 			id: 2,
 			metadata: {},
-			identities: [{ namespace: "phone", identifier: "905067888845" }],
+			identities: [{ namespace: "phone", identifier: "447700900123" }],
 		};
 		const discovered = discoverEntityResolutionGroups({
 			metadataSchema: { type: "object" },
@@ -450,7 +439,7 @@ describe("entity resolution module", () => {
 		});
 		expect(assessment.evidence).toContainEqual({
 			kind: "phone",
-			identifier: "905067888845",
+			identifier: "447700900123",
 		});
 	});
 
@@ -466,25 +455,24 @@ describe("entity resolution module", () => {
 				],
 			},
 		};
-		// Winner: email in metadata, phone in identities. Loser: the reverse.
 		const assessment = assessEntityResolution({
 			metadataSchema: comboSchema,
 			winner: {
 				id: 1,
 				metadata: { email: "same@example.com" },
-				identities: [{ namespace: "phone", identifier: "905067888845" }],
+				identities: [{ namespace: "phone", identifier: "447700900123" }],
 			},
 			losers: [
 				{
 					id: 2,
-					metadata: { phone: "905067888845" },
+					metadata: { phone: "447700900123" },
 					identities: [{ namespace: "email", identifier: "same@example.com" }],
 				},
 			],
 		});
 		expect(assessment.evidence).toContainEqual({
 			kind: "email + phone",
-			identifier: "same@example.com · 905067888845",
+			identifier: "same@example.com · 447700900123",
 		});
 	});
 

--- a/packages/server/src/entity-resolution/discovery.ts
+++ b/packages/server/src/entity-resolution/discovery.ts
@@ -1,12 +1,15 @@
 import { type DbClient, pgBigintArray } from "../db/client";
+import { loadLiveEntityIdentities } from "./identities";
 import {
 	normalizedResolutionRuleKeys,
 	readEntityResolutionRules,
+	type ResolutionIdentity,
 } from "./policy";
 
 interface ResolutionCandidate {
 	id: number;
 	metadata: Record<string, unknown>;
+	identities?: ResolutionIdentity[];
 }
 
 interface ResolutionGroup {
@@ -189,6 +192,10 @@ export async function discoverWorkspaceResolutionGroups(
 		  AND entity.id = ANY(${pgBigintArray(input.candidateIds)}::bigint[])
 		  AND entity.deleted_at IS NULL
 	`;
+	const identities = await loadLiveEntityIdentities(db, {
+		organizationId: input.organizationId,
+		entityIds: rows.map((row) => Number(row.id)),
+	});
 	type ResolutionRow = (typeof rows)[number];
 	const byType = new Map<number, ResolutionRow[]>();
 	for (const row of rows) {
@@ -208,6 +215,7 @@ export async function discoverWorkspaceResolutionGroups(
 			candidates: typeRows.map((row) => ({
 				id: Number(row.id),
 				metadata: row.metadata ?? {},
+				identities: identities.get(Number(row.id)) ?? [],
 			})),
 			maxGroups: input.maxGroups ?? 199,
 			maxOperations: input.maxOperations ?? 199,

--- a/packages/server/src/entity-resolution/identities.ts
+++ b/packages/server/src/entity-resolution/identities.ts
@@ -5,15 +5,21 @@ import type { ResolutionIdentity } from "./policy";
  * Load the live `entity_identities` rows the resolution policy resolves rule
  * fields against, keyed by entity id. All namespaces are loaded — custom
  * `exact` rules may key on custom namespaces, and the per-field namespace
- * filter lives in the policy itself. Rows stay locked through the caller's
- * transaction so a staleness check and the following merge see the same claims.
+ * filter lives in the policy itself.
+ *
+ * Pass `forUpdate: true` only from within an open transaction (the staleness
+ * re-check inside `applyMergeGroup`) so the evidence rows stay locked through
+ * the following merge. Read-only callers (discovery, pre-approval preview) omit
+ * it: `FOR UPDATE` in an auto-committed statement releases the lock immediately
+ * and only contends with concurrent merges for no benefit.
  */
 export async function loadLiveEntityIdentities(
 	db: DbClient,
-	input: { organizationId: string; entityIds: number[] },
+	input: { organizationId: string; entityIds: number[]; forUpdate?: boolean },
 ): Promise<Map<number, ResolutionIdentity[]>> {
 	const identities = new Map<number, ResolutionIdentity[]>();
 	if (input.entityIds.length === 0) return identities;
+	const lockClause = input.forUpdate ? db`FOR UPDATE` : db``;
 	const rows = await db<{
 		entity_id: number;
 		namespace: string;
@@ -25,7 +31,7 @@ export async function loadLiveEntityIdentities(
 		  AND entity_id = ANY(${pgBigintArray(input.entityIds)}::bigint[])
 		  AND deleted_at IS NULL
 		ORDER BY entity_id, namespace, identifier
-		FOR UPDATE
+		${lockClause}
 	`;
 	for (const row of rows) {
 		const entityId = Number(row.entity_id);

--- a/packages/server/src/entity-resolution/identities.ts
+++ b/packages/server/src/entity-resolution/identities.ts
@@ -5,7 +5,8 @@ import type { ResolutionIdentity } from "./policy";
  * Load the live `entity_identities` rows the resolution policy resolves rule
  * fields against, keyed by entity id. All namespaces are loaded — custom
  * `exact` rules may key on custom namespaces, and the per-field namespace
- * filter lives in the policy itself.
+ * filter lives in the policy itself. Rows stay locked through the caller's
+ * transaction so a staleness check and the following merge see the same claims.
  */
 export async function loadLiveEntityIdentities(
 	db: DbClient,
@@ -23,6 +24,8 @@ export async function loadLiveEntityIdentities(
 		WHERE organization_id = ${input.organizationId}
 		  AND entity_id = ANY(${pgBigintArray(input.entityIds)}::bigint[])
 		  AND deleted_at IS NULL
+		ORDER BY entity_id, namespace, identifier
+		FOR UPDATE
 	`;
 	for (const row of rows) {
 		const entityId = Number(row.entity_id);

--- a/packages/server/src/entity-resolution/identities.ts
+++ b/packages/server/src/entity-resolution/identities.ts
@@ -1,0 +1,34 @@
+import { type DbClient, pgBigintArray } from "../db/client";
+import type { ResolutionIdentity } from "./policy";
+
+/**
+ * Load the live `entity_identities` rows the resolution policy resolves rule
+ * fields against, keyed by entity id. All namespaces are loaded — custom
+ * `exact` rules may key on custom namespaces, and the per-field namespace
+ * filter lives in the policy itself.
+ */
+export async function loadLiveEntityIdentities(
+	db: DbClient,
+	input: { organizationId: string; entityIds: number[] },
+): Promise<Map<number, ResolutionIdentity[]>> {
+	const identities = new Map<number, ResolutionIdentity[]>();
+	if (input.entityIds.length === 0) return identities;
+	const rows = await db<{
+		entity_id: number;
+		namespace: string;
+		identifier: string;
+	}>`
+		SELECT entity_id, namespace, identifier
+		FROM entity_identities
+		WHERE organization_id = ${input.organizationId}
+		  AND entity_id = ANY(${pgBigintArray(input.entityIds)}::bigint[])
+		  AND deleted_at IS NULL
+	`;
+	for (const row of rows) {
+		const entityId = Number(row.entity_id);
+		const bucket = identities.get(entityId) ?? [];
+		bucket.push({ namespace: row.namespace, identifier: row.identifier });
+		identities.set(entityId, bucket);
+	}
+	return identities;
+}

--- a/packages/server/src/entity-resolution/policy.ts
+++ b/packages/server/src/entity-resolution/policy.ts
@@ -15,7 +15,7 @@ export interface ResolutionIdentity {
 interface ResolutionEntity {
 	id: number;
 	metadata: Record<string, unknown>;
-	/** Live `entity_identities` rows; connectors write phones/emails here, not metadata. */
+	/** Live identity claims that may not also exist in entity metadata. */
 	identities?: ResolutionIdentity[];
 }
 
@@ -177,12 +177,8 @@ export function normalizedResolutionRuleKeys(
 ): string[] {
 	let combinations: string[][] = [[]];
 	for (const field of rule.fields) {
-		// A rule field draws from both stores: entity.metadata plus live
-		// entity_identities rows whose namespace equals the field name (the
-		// standard namespaces — phone, email, … — share the rule-field
-		// vocabulary). The normalizer is the format guard either way, so a
-		// same-named namespace can never smuggle in a value the rule would
-		// have rejected from metadata.
+		// Identity-backed connector data follows the same field policy and
+		// normalization as metadata when its namespace names that field.
 		const raw = readPath(entity.metadata, field);
 		const fromMetadata = Array.isArray(raw) ? raw : [raw];
 		const fromIdentities = (entity.identities ?? [])

--- a/packages/server/src/entity-resolution/policy.ts
+++ b/packages/server/src/entity-resolution/policy.ts
@@ -7,9 +7,16 @@ export interface ResolutionEvidence {
 	identifier: string;
 }
 
+export interface ResolutionIdentity {
+	namespace: string;
+	identifier: string;
+}
+
 interface ResolutionEntity {
 	id: number;
 	metadata: Record<string, unknown>;
+	/** Live `entity_identities` rows; connectors write phones/emails here, not metadata. */
+	identities?: ResolutionIdentity[];
 }
 
 interface EntityResolutionAssessment {
@@ -170,8 +177,19 @@ export function normalizedResolutionRuleKeys(
 ): string[] {
 	let combinations: string[][] = [[]];
 	for (const field of rule.fields) {
+		// A rule field draws from both stores: entity.metadata plus live
+		// entity_identities rows whose namespace equals the field name (the
+		// standard namespaces — phone, email, … — share the rule-field
+		// vocabulary). The normalizer is the format guard either way, so a
+		// same-named namespace can never smuggle in a value the rule would
+		// have rejected from metadata.
+		const raw = readPath(entity.metadata, field);
+		const fromMetadata = Array.isArray(raw) ? raw : [raw];
+		const fromIdentities = (entity.identities ?? [])
+			.filter((identity) => identity.namespace === field)
+			.map((identity) => identity.identifier);
 		const values = normalizeValues(
-			readPath(entity.metadata, field),
+			[...fromMetadata, ...fromIdentities],
 			rule.normalizer,
 		);
 		if (values.length === 0) return [];

--- a/packages/server/src/entity-resolution/staleness.ts
+++ b/packages/server/src/entity-resolution/staleness.ts
@@ -1,4 +1,5 @@
 import { type DbClient, pgBigintArray } from "../db/client";
+import { loadLiveEntityIdentities } from "./identities";
 import { assessEntityResolution } from "./policy";
 
 /** Lock and re-evaluate a reviewed merge immediately before applying it. */
@@ -42,13 +43,22 @@ export async function assertResolutionFingerprintCurrent(
 	const winner = byId.get(input.winnerId);
 	if (!winner)
 		throw new Error("Merge evidence is stale because the winner changed");
+	const identities = await loadLiveEntityIdentities(db, {
+		organizationId: input.organizationId,
+		entityIds: ids,
+	});
 	const assessment = assessEntityResolution({
 		metadataSchema: winner.metadata_schema,
 		entityTypeSlug: winner.entity_type_slug,
-		winner: { id: input.winnerId, metadata: winner.metadata ?? {} },
+		winner: {
+			id: input.winnerId,
+			metadata: winner.metadata ?? {},
+			identities: identities.get(input.winnerId) ?? [],
+		},
 		losers: input.loserIds.map((loserId) => ({
 			id: loserId,
 			metadata: byId.get(loserId)?.metadata ?? {},
+			identities: identities.get(loserId) ?? [],
 		})),
 	});
 	if (assessment.fingerprint !== input.expectedFingerprint) {

--- a/packages/server/src/entity-resolution/staleness.ts
+++ b/packages/server/src/entity-resolution/staleness.ts
@@ -46,6 +46,7 @@ export async function assertResolutionFingerprintCurrent(
 	const identities = await loadLiveEntityIdentities(db, {
 		organizationId: input.organizationId,
 		entityIds: ids,
+		forUpdate: true,
 	});
 	const assessment = assessEntityResolution({
 		metadataSchema: winner.metadata_schema,

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -38,6 +38,7 @@ import {
 	buildEntityUrl,
 	buildResourcePermalink,
 } from "../../utils/url-builder";
+import { resolveRunInitiator } from "../initiator";
 import type { ToolContext } from "../registry";
 import { getOrgUrlContext } from "../view-urls";
 
@@ -496,6 +497,7 @@ export async function proposeEntityChange(
 		windowId ?? null,
 		proposal,
 	);
+	const initiatorColumns = resolveRunInitiator(ctx);
 
 	// Idempotency: complete_window is replay-safe (retries + concurrent replicas),
 	// so the same blocked change can be proposed more than once. Collapse to one
@@ -703,6 +705,10 @@ export async function proposeEntityChange(
 						? null
 						: (entity?.parent_entity_type ?? null),
 					attribution,
+					initiator: {
+						kind: initiatorColumns.initiatorKind,
+						...initiatorColumns.initiatorRef,
+					},
 					reason: proposal.reason ?? null,
 					proposer_rationale: mergeProposal?.proposer_rationale ?? null,
 					status: "pending_approval",
@@ -751,12 +757,15 @@ export async function proposeEntityChange(
 		const inserted = await tx<{ id: number }>`
 			INSERT INTO runs (
 				organization_id, run_type, action_key, action_input, window_id,
-				watcher_id, created_by_user_id, approval_status, status,
-				idempotency_key, created_at
+				watcher_id, created_by_user_id, initiator_kind, initiator_ref,
+				approval_status, status, idempotency_key, created_at
 			) VALUES (
 				${ctx.organizationId}, 'internal', ${actionKey},
 				${tx.json(actionInputProposal as unknown as Record<string, unknown>)},
-				${windowId ?? null}, ${proposal.watcher_id ?? null}, null,
+				${windowId ?? null}, ${proposal.watcher_id ?? null},
+				${initiatorColumns.createdByUserId},
+				${initiatorColumns.initiatorKind},
+				${tx.json(initiatorColumns.initiatorRef)},
 				'pending', 'pending', ${idempotencyKey}, current_timestamp
 			)
 			ON CONFLICT DO NOTHING

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -747,6 +747,10 @@ async function queueWriteForApproval(
       agent_id: proposal.agent_id,
       proposal,
       current: current ?? null,
+      initiator: {
+        kind: initiatorColumns.initiatorKind,
+        ...initiatorColumns.initiatorRef,
+      },
       status: 'pending_approval',
       run_id: runId,
     },

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -57,6 +57,7 @@ import {
 } from '../../utils/url-builder';
 import { ToolUserError } from '../../utils/errors';
 import { requireOrgReadAccess, requireOrgWriteAccess } from '../../utils/organization-access';
+import { resolveRunInitiator } from '../initiator';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 import { getOrgUrlContext } from '../view-urls';
@@ -709,14 +710,19 @@ async function queueWriteForApproval(
     }
   }
 
+  const initiatorColumns = resolveRunInitiator(ctx);
   const inserted = await sql`
     INSERT INTO runs (
       organization_id, run_type, action_key, action_input,
-      created_by_user_id, approval_status, status, created_at
+      created_by_user_id, initiator_kind, initiator_ref,
+      approval_status, status, created_at
     ) VALUES (
       ${ctx.organizationId}, 'internal', ${MANAGE_AGENTS_ACTION_KEY},
       ${sql.json(proposal as unknown as Record<string, unknown>)},
-      ${ctx.userId ?? null}, 'pending', 'pending', current_timestamp
+      ${initiatorColumns.createdByUserId},
+      ${initiatorColumns.initiatorKind},
+      ${sql.json(initiatorColumns.initiatorRef)},
+      'pending', 'pending', current_timestamp
     )
     RETURNING id
   `;

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -45,6 +45,7 @@ import {
   requireReadAccess,
   requireWriteAccess,
 } from '../../utils/organization-access';
+import { resolveRunInitiator } from '../initiator';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 import { getOrgUrlContext } from '../view-urls';
@@ -694,14 +695,19 @@ async function queueWatcherWriteForApproval(
   }
 
   const sql = getDb();
+  const initiatorColumns = resolveRunInitiator(ctx);
   const inserted = await sql`
     INSERT INTO runs (
       organization_id, run_type, action_key, action_input,
-      created_by_user_id, approval_status, status, created_at
+      created_by_user_id, initiator_kind, initiator_ref,
+      approval_status, status, created_at
     ) VALUES (
       ${ctx.organizationId}, 'internal', ${MANAGE_BEHAVIORS_ACTION_KEY},
       ${sql.json(proposal as unknown as Record<string, unknown>)},
-      ${ctx.userId ?? null}, 'pending', 'pending', current_timestamp
+      ${initiatorColumns.createdByUserId},
+      ${initiatorColumns.initiatorKind},
+      ${sql.json(initiatorColumns.initiatorRef)},
+      'pending', 'pending', current_timestamp
     )
     RETURNING id
   `;

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -739,6 +739,10 @@ async function queueWatcherWriteForApproval(
       watcher_id: args.behavior_id ?? null,
       proposal,
       current: current ?? null,
+      initiator: {
+        kind: initiatorColumns.initiatorKind,
+        ...initiatorColumns.initiatorRef,
+      },
       status: 'pending_approval',
       run_id: runId,
       input_schema: inputSchema,

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -112,6 +112,12 @@ function actingPrincipalFor(
 	});
 }
 
+function attributionFor(actor: ActingPrincipal): ApprovalAttributionType {
+	return actor.kind === "watcher"
+		? ApprovalAttribution.Behavior
+		: ApprovalAttribution.Agent;
+}
+
 /**
  * Entity read gate for agents/watchers. Humans skip (role ACL is separate).
  * Default is auto (unrestricted within org); a policy can deny by type.
@@ -307,10 +313,7 @@ async function handleCreate(
 		metadata: entityData.metadata ?? {},
 	};
 	const actor = await actingPrincipalFor(args, ctx);
-	const attribution: ApprovalAttributionType =
-		actor.kind === "watcher"
-			? ApprovalAttribution.Behavior
-			: ApprovalAttribution.Agent;
+	const attribution = attributionFor(actor);
 	const createDecision = await runMutationGate({
 		action: "create",
 		organizationId: ctx.organizationId,
@@ -473,10 +476,7 @@ async function handleUpdate(
 	const updateActor = await actingPrincipalFor(args, ctx);
 	const updatedEntity = await updateEntity(entityId, updateData, env, ctx, {
 		policyPrincipalKind: updateActor.kind,
-		attribution:
-			updateActor.kind === "watcher"
-				? ApprovalAttribution.Behavior
-				: ApprovalAttribution.Agent,
+		attribution: attributionFor(updateActor),
 		principalId: updateActor.id,
 		// Trusted reaction-session window WINS — see the create path.
 		windowId: ctx.actingWindowId ?? args.behavior_source?.window_id ?? null,
@@ -730,10 +730,7 @@ async function handleMerge(
 	}
 
 	if (actor.kind !== "user" && resolution?.decision === "review") {
-		const attribution: ApprovalAttributionType =
-			actor.kind === "watcher"
-				? ApprovalAttribution.Behavior
-				: ApprovalAttribution.Agent;
+		const attribution = attributionFor(actor);
 		if (
 			await wasResolutionRejected(sql, {
 				organizationId: ctx.organizationId,
@@ -1330,10 +1327,7 @@ async function handleDelete(
 	}
 
 	const deleteActor = await actingPrincipalFor(args, ctx);
-	const attribution: ApprovalAttributionType =
-		deleteActor.kind === "watcher"
-			? ApprovalAttribution.Behavior
-			: ApprovalAttribution.Agent;
+	const attribution = attributionFor(deleteActor);
 	const current = {
 		id: entity.id,
 		entity_type: entity.entity_type,

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -38,6 +38,7 @@ import {
 	resolveActingPrincipal,
 } from "../../authz/entity-policy";
 import { discoverWorkspaceResolutionGroups } from "../../entity-resolution/discovery";
+import { loadLiveEntityIdentities } from "../../entity-resolution/identities";
 import { assessEntityResolution } from "../../entity-resolution/policy";
 import { wasResolutionRejected } from "../../entity-resolution/rejection";
 import { getDb, pgBigintArray, pgTextArray } from "../../db/client";
@@ -708,13 +709,22 @@ async function handleMerge(
 				404,
 			);
 		}
+		const identities = await loadLiveEntityIdentities(sql, {
+			organizationId: ctx.organizationId,
+			entityIds: [...loserIds, winnerId],
+		});
 		resolution = assessEntityResolution({
 			metadataSchema: winner.metadata_schema,
 			entityTypeSlug: winner.entity_type_slug,
-			winner: { id: winnerId, metadata: winner.metadata ?? {} },
+			winner: {
+				id: winnerId,
+				metadata: winner.metadata ?? {},
+				identities: identities.get(winnerId) ?? [],
+			},
 			losers: loserIds.map((loserId) => ({
 				id: loserId,
 				metadata: byId.get(loserId)?.metadata ?? {},
+				identities: identities.get(loserId) ?? [],
 			})),
 		});
 	}

--- a/packages/server/src/tools/initiator.ts
+++ b/packages/server/src/tools/initiator.ts
@@ -1,0 +1,63 @@
+import type { ToolContext } from "./registry";
+
+/**
+ * Verified context fields used to derive run provenance. Tool arguments are
+ * deliberately excluded because callers control them.
+ */
+type InitiatorSource = Pick<
+	ToolContext,
+	| "userId"
+	| "agentId"
+	| "clientId"
+	| "sourceContext"
+	| "actingWatcherId"
+	| "actingWindowId"
+	| "actingRunId"
+>;
+
+type RunInitiatorColumns = {
+	initiatorKind: "user" | "behavior" | "agent_session" | "system";
+	initiatorRef: Record<string, unknown>;
+	createdByUserId: string | null;
+};
+
+export function resolveRunInitiator(ctx: InitiatorSource): RunInitiatorColumns {
+	if (ctx.actingWatcherId != null) {
+		return {
+			initiatorKind: "behavior",
+			initiatorRef: {
+				watcher_id: ctx.actingWatcherId,
+				window_id: ctx.actingWindowId ?? null,
+				run_id: ctx.actingRunId ?? null,
+			},
+			createdByUserId: null,
+		};
+	}
+
+	if (ctx.agentId) {
+		return {
+			initiatorKind: "agent_session",
+			initiatorRef: {
+				agent_id: ctx.agentId,
+				user_id: ctx.userId ?? null,
+				client_id: ctx.clientId ?? null,
+				conversation_id: ctx.sourceContext?.conversationId ?? null,
+			},
+			createdByUserId: ctx.userId ?? null,
+		};
+	}
+
+	if (ctx.userId) {
+		return {
+			initiatorKind: "user",
+			initiatorRef: { user_id: ctx.userId },
+			createdByUserId: ctx.userId,
+		};
+	}
+
+	return {
+		initiatorKind: "system",
+		initiatorRef: {},
+		createdByUserId: null,
+	};
+}

--- a/packages/server/src/tools/initiator.ts
+++ b/packages/server/src/tools/initiator.ts
@@ -4,15 +4,17 @@ import type { ToolContext } from "./registry";
  * Verified context fields used to derive run provenance. Tool arguments are
  * deliberately excluded because callers control them.
  */
-type InitiatorSource = Pick<
-	ToolContext,
-	| "userId"
-	| "agentId"
-	| "clientId"
-	| "sourceContext"
-	| "actingWatcherId"
-	| "actingWindowId"
-	| "actingRunId"
+type InitiatorSource = Partial<
+	Pick<
+		ToolContext,
+		| "userId"
+		| "agentId"
+		| "clientId"
+		| "sourceContext"
+		| "actingWatcherId"
+		| "actingWindowId"
+		| "actingRunId"
+	>
 >;
 
 type RunInitiatorColumns = {


### PR DESCRIPTION
> **Scope note:** this branch carries **two related concerns**. #2154 (run provenance) was merged into this branch rather than opened standalone — both change the merge-proposal path, and splitting them now would rewrite this branch's history. Sections below cover the resolution fix; provenance is documented at the end.

## Problem

`assessEntityResolution` resolved rule fields (phone/email) against `entity.metadata` only, but connectors write phones, emails, and handles to `entity_identities`. On the reference org only ~120/6,594 live persons have `metadata.phone` (~420 for email), so the matcher was blind on ~94% of the graph: every duplicate fell through to review with **empty evidence** ("No matching email or phone could be verified automatically"), including obvious WhatsApp-JID-shell/named-contact pairs like run 702088.

## Change

One semantic change: `normalizedResolutionRuleKeys` now unions metadata values with live `entity_identities` identifiers whose **namespace equals the rule field name**, normalized by the same rule normalizer. Because assessment, discovery grouping, and the staleness fingerprint all funnel through this one function, the three stay in agreement by construction. A shared `loadLiveEntityIdentities` loader feeds identities at the three DB boundaries (merge tool, staleness check, workspace discovery), with `FOR UPDATE` so the evidence rows a staleness check reads cannot change under the merge in the same transaction.

## Decisions

**Namespace→field mapping is implicit name equality** (`phone` namespace → `phone` field), not declared per rule in `x-lobu-resolution`. The standard namespaces already share the rule-field vocabulary, and the normalizer — not the mapping — is the format guard: a `wa_jid` row never feeds the `phone` field (namespace mismatch), and a JID-shaped string fails the phone normalizer even if force-fed (both pinned by tests). A declared mapping would change the schema contract for zero current need and can be added later without breaking this.

**Fingerprints of identity-bearing proposals change, deliberately.** Identities are evidence inputs now, so an identity change must fail the staleness gate — that is the gate working, and it is pinned by an end-to-end test (identity row inserted after proposal → approve refuses). One-time deploy effect, measured on prod: of 24 pending merge proposals, **18 will fail staleness on approve** (the run-702088 WhatsApp batch — exactly the pairs this fix targets) and will be re-proposed *with* visible phone evidence; the other 6 have no phone/email identity rows and keep byte-identical fingerprints. No fingerprint versioning: a legacy recompute path would defeat the guard.

**No auto-merge widening in practice.** The person defaults are all `onMatch: "review"`, and no entity type on the org declares `x-lobu-resolution` at all (verified via SDK). Where a custom schema does declare `auto_merge`, identity rows are connector-written normalized identifiers (higher provenance than free-form metadata), and the widening also feeds `conflictingAutoIdentity`, which can demote an auto-merge to review.

**Run 702088 is partially recognised, by design.** The JID shell's identity phone is now read (pinned: its rule keys are non-empty), but the named contact's metadata phone was double-split on import and still does not match. Repairing import-corrupted phones is a separate, known bug; inventing a match here would paper over it. Test numbers use the Ofcom-reserved 447700900123 range so no real subscriber number lives in the corpus.

## Evidence

- Red→green: both key tests committed first and failed with empty evidence (e36b4894 red state), then the fix.
- `discovery.test.ts` 19/19, `entity-merge-tool.test.ts` 19/19, full server vitest suite 325 files / 2658 passed, `make pre-pr` clean, `make review` verdict bug_free 93 / 0 blockers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Entity resolution now enriches candidates with live identity evidence in addition to entity metadata.
  - Resolution matching supports identity-backed fields and mixed metadata+identity combinations.
  - Queued approval events and pending runs now include run provenance (initiator type/reference) derived from the action context.
- **Bug Fixes**
  - Stale merge approvals no longer apply if identity evidence changes after the proposal; concurrent identity updates are protected via database locking.
- **Tests**
  - Expanded integration and unit test coverage for identity-backed discovery, merge behavior, and run initiator attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Second concern: run provenance (was #2154)

## Problem

18 of 24 pending merge proposals on prod are orphans — runs 702088–702105, one 600ms burst at 2026-07-22T22:08:37Z, all `watcher_id: null`, `created_by_user_id: null`, no source run. Nothing records which session proposed them, under whose token, via which client.

Not an accident of that burst. Provenance was reassembled at each writer from `ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null` — an expression that can only describe a Behavior. MCP sessions, humans and schedules all resolved to null. Meanwhile `ToolContext` already carried `userId`/`agentId`/`clientId`/`sourceContext.conversationId` and dropped them, and `runs.created_by_user_id` existed as a column these paths never wrote.

## Change

`runs` gains `initiator_kind` + `initiator_ref`; `resolveInitiator(ctx)` derives who caused a turn from verified context fields (behavior · agent_session · user · system). Three approval writers persist it.

Deriving rather than storing is deliberate: an earlier revision put an `initiator` field on `ToolContext` and stamped it at entry points, but those entry points had just set the fields it's derived from — two copies of one fact that could drift.

Precedence is load-bearing and pinned by test: a reaction carries both `actingWatcherId` and its owning agent's id, so the behavior branch must win or every Behavior run is misfiled as an agent session.

## Beyond the reported bug

`manage_agents` and `manage_behaviors` had the identical gap — fixed as a class. Both also misattributed: `created_by_user_id: ctx.userId` recorded an *agent's* proposal as the human's own.

The approval card could only say "an agent"; it now names the agent and client (owletto#565).

## behavior_source stays

Audited for removal, kept. No first-party code constructs it (only tests and the docs string at `sandbox/method-metadata.ts:498`) and neither live prod Behavior passes it — but `resolveActingPrincipal` (`authz/entity-policy.ts:418-426`) honors it as the acting principal on the no-agent path, yielding `kind:'watcher'` with a folded owner agent, i.e. *more* restrictive than the agent default. It's a self-restriction channel; deleting it would quietly loosen the keyed/system promotion path. A test pins that a forged `behavior_source` cannot rewrite the recorded initiator.

## Deliberately absent

No backfill (old runs keep `initiator_kind` null → "unknown origin"; their initiator can't be reconstructed). No index until a query needs one. No `schedule` kind until a schedule writer calls this.

## Verifying after deploy

`client.operations.listRuns({ run_types: ['internal'], status: 'pending' })` — a fresh MCP-session proposal should carry `initiator_kind='agent_session'` with agent, client and user in the ref.
