### PR TITLE
fix(chat): retire streaming chat feeds leaked onto retired connections

### DIFF
--- a/db/migrations/20260723160000_retire_leaked_chat_feeds.sql
+++ b/db/migrations/20260723160000_retire_leaked_chat_feeds.sql
@@ -1,0 +1,66 @@
+-- Retire streaming chat feeds leaked onto retired connections.
+--
+-- A streaming feed is keyed by the numeric `connections.id` and is soft-deleted
+-- only when a Behavior is explicitly unlinked — no trigger retires feeds when a
+-- connection is. So whenever a Slack workspace was re-installed under a
+-- different tenant key (a Grid workspace is recorded under its enterprise `E…`
+-- id or its workspace `T…` id depending on how it was installed), the
+-- replacement connection got its own feed while the previous generation's feed
+-- stayed LIVE, pointing at a dead row. They accumulate one per install.
+--
+-- Prod (org_lobucrm) carries two such orphans for one DM channel — feeds 434
+-- (connection 419) and 437 (connection 430) — while feed 450 serves that same
+-- channel on the live connection 448.
+--
+-- Scoped by ORGANIZATION + CHANNEL, deliberately NOT by tenant key: the retired
+-- generations carry different `external_tenant_id`s (that key changing is what
+-- forked them in the first place), so a tenant match would retire nothing.
+-- Matching on `feed_key` alone is far too broad — unrelated connectors reuse
+-- feed keys (`reviews`, `content` and `home_feed` all collide in prod), and
+-- retiring those would silently stop their ingestion.
+--
+-- A feed is retired only when the SAME org already has a LIVE streaming feed for
+-- the SAME channel on a LIVE connection, so every row retired here is strictly a
+-- duplicate of one that keeps routing. An org whose only feeds for a channel sit
+-- on dead connections keeps them rather than losing its last one.
+--
+-- Behaviors are deliberately NOT repaired here. Prod's one archived chat-link
+-- Behavior (25, naming the retired connection 430) was already superseded by an
+-- identical ACTIVE Behavior (48, on the live connection 448) that the reinstall
+-- created three minutes before the archive — so archiving 25 was correct.
+-- Reviving it would leave two active Behaviors on one channel and, because
+-- resolution takes LIMIT 1 ordered by `updated_at DESC`, the revived row would
+-- displace the working one.
+--
+-- Scope: this cleans up existing rows. It does not change how feeds bind, and it
+-- does not stop a future tenant-key change from leaking another feed — that is
+-- an install-identity concern, tracked separately.
+
+-- migrate:up
+
+UPDATE feeds f
+SET deleted_at = current_timestamp, updated_at = current_timestamp
+FROM connections dead
+WHERE f.deleted_at IS NULL
+  AND f.kind = 'streaming'
+  AND f.connection_id = dead.id
+  AND dead.deleted_at IS NOT NULL
+  AND dead.credential_mode IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM feeds live_feed
+    JOIN connections live ON live.id = live_feed.connection_id
+    WHERE live_feed.deleted_at IS NULL
+      AND live_feed.kind = 'streaming'
+      AND live_feed.feed_key = f.feed_key
+      AND live.deleted_at IS NULL
+      AND live.credential_mode IS NOT NULL
+      AND live.organization_id = dead.organization_id
+      AND live.connector_key = dead.connector_key
+  );
+
+-- migrate:down
+
+-- Data cleanup: each retired row duplicated a live feed, so restoring them would
+-- only re-create the leak.
+SELECT 1;

--- a/db/migrations/20260723160000_retire_leaked_chat_feeds.sql
+++ b/db/migrations/20260723160000_retire_leaked_chat_feeds.sql
@@ -38,8 +38,14 @@
 
 -- migrate:up
 
+-- `status` is set alongside `deleted_at` only so a retired row does not read
+-- back as 'active'. Scheduling already filters on `deleted_at IS NULL` (and
+-- skips streaming feeds entirely, see `check-due-feeds`), so `deleted_at` alone
+-- is what actually retires the feed.
 UPDATE feeds f
-SET deleted_at = current_timestamp, updated_at = current_timestamp
+SET deleted_at = current_timestamp,
+    status = 'paused',
+    updated_at = current_timestamp
 FROM connections dead
 WHERE f.deleted_at IS NULL
   AND f.kind = 'streaming'

--- a/packages/server/src/gateway/channels/__tests__/retire-leaked-chat-feeds.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/retire-leaked-chat-feeds.test.ts
@@ -96,6 +96,13 @@ async function feedIsLive(feedId: number): Promise<boolean> {
   return rows.length > 0;
 }
 
+async function feedStatus(feedId: number): Promise<string | null> {
+  const rows = await getDb()<{ status: string }>`
+    SELECT status FROM feeds WHERE id = ${feedId}
+  `;
+  return rows[0]?.status ?? null;
+}
+
 describe("retiring leaked chat feeds", () => {
   beforeAll(async () => {
     await ensureDbForGatewayTests();
@@ -126,11 +133,17 @@ describe("retiring leaked chat feeds", () => {
     const orphan = await insertFeed(dead, CHANNEL);
     const serving = await insertFeed(live, CHANNEL);
 
+    // Run twice: a migration re-applied against already-cleaned data must not
+    // retire the surviving feed on the second pass.
+    await runCleanup();
     await runCleanup();
 
     expect(await feedIsLive(orphan)).toBe(false);
+    // A retired row must not read back as active.
+    expect(await feedStatus(orphan)).toBe("paused");
     // The feed that actually routes must survive.
     expect(await feedIsLive(serving)).toBe(true);
+    expect(await feedStatus(serving)).toBe("active");
   });
 
   test("retires every generation's orphan, not just the newest", async () => {

--- a/packages/server/src/gateway/channels/__tests__/retire-leaked-chat-feeds.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/retire-leaked-chat-feeds.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Streaming chat feeds leaked onto retired connections.
+ *
+ * A streaming feed is keyed by the numeric `connections.id` and is soft-deleted
+ * only on an explicit unlink — nothing retires feeds when a connection is. So a
+ * workspace re-installed under a different tenant key leaves the previous
+ * generation's feed LIVE on a dead connection, one per install.
+ *
+ * Prod 2026-07-23 (org_lobucrm): feeds 434 and 437 sit live on dead connections
+ * for one DM channel while feed 450 serves that channel on the live connection.
+ *
+ * The migration statement is sliced out of the shipped file and replayed here,
+ * so these tests cannot drift from the SQL that actually runs.
+ */
+import { readFile } from "node:fs/promises";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { getDb } from "../../../db/client.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "../../__tests__/helpers/db-setup.js";
+
+const ORG = "org-feedleak";
+const CHANNEL = "slack:D_LEAK";
+
+/** Replay the migration's `migrate:up` body against the seeded rows. */
+async function runCleanup(): Promise<void> {
+  const sql = await readFile(
+    new URL(
+      "../../../../../../db/migrations/20260723160000_retire_leaked_chat_feeds.sql",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const start = sql.indexOf("-- migrate:up");
+  const end = sql.indexOf("-- migrate:down");
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  await getDb().unsafe(sql.slice(start + "-- migrate:up".length, end));
+}
+
+async function insertConnection(opts: {
+  slug: string;
+  tenantId: string;
+  live: boolean;
+  organizationId?: string;
+  credentialMode?: string | null;
+}): Promise<number> {
+  const rows = await getDb()`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      credential_mode, external_tenant_id, config, deleted_at
+    ) VALUES (
+      ${opts.organizationId ?? ORG}, 'slack', ${opts.slug}, 'Workspace', 'active',
+      ${opts.credentialMode === undefined ? "managed" : opts.credentialMode},
+      ${opts.tenantId},
+      ${getDb().json({ chatMetadata: { teamId: opts.tenantId } })},
+      ${opts.live ? null : new Date()}
+    )
+    RETURNING id
+  `;
+  return Number(rows[0].id);
+}
+
+async function insertFeed(
+  connectionId: number,
+  feedKey: string,
+  organizationId = ORG,
+  kind = "streaming",
+): Promise<number> {
+  const rows = await getDb()`
+    INSERT INTO feeds (
+      organization_id, connection_id, feed_key, display_name,
+      status, kind, virtual, config
+    ) VALUES (
+      ${organizationId}, ${connectionId}, ${feedKey}, ${feedKey},
+      'active', ${kind}, false, '{"store":"channel_messages"}'
+    )
+    RETURNING id
+  `;
+  return Number(rows[0].id);
+}
+
+async function feedIsLive(feedId: number): Promise<boolean> {
+  const rows = await getDb()`
+    SELECT 1 FROM feeds WHERE id = ${feedId} AND deleted_at IS NULL
+  `;
+  return rows.length > 0;
+}
+
+describe("retiring leaked chat feeds", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  });
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedAgentRow("agent-feedleak", { organizationId: ORG });
+  });
+
+  afterAll(async () => {
+    await resetTestDatabase();
+  });
+
+  test("retires a duplicate feed left on a retired connection", async () => {
+    // The prod shape: retired under one tenant key, live under another, both
+    // serving the same channel.
+    const dead = await insertConnection({
+      slug: "slackinst-dead",
+      tenantId: "E_ENTERPRISE",
+      live: false,
+    });
+    const live = await insertConnection({
+      slug: "slackinst-live",
+      tenantId: "T_WORKSPACE",
+      live: true,
+    });
+    const orphan = await insertFeed(dead, CHANNEL);
+    const serving = await insertFeed(live, CHANNEL);
+
+    await runCleanup();
+
+    expect(await feedIsLive(orphan)).toBe(false);
+    // The feed that actually routes must survive.
+    expect(await feedIsLive(serving)).toBe(true);
+  });
+
+  test("retires every generation's orphan, not just the newest", async () => {
+    // Prod accumulated one orphan per install; all of them must go.
+    const live = await insertConnection({
+      slug: "slackinst-live-multi",
+      tenantId: "T_WORKSPACE",
+      live: true,
+    });
+    const serving = await insertFeed(live, CHANNEL);
+    const orphans: number[] = [];
+    for (const tenant of ["T_GEN1", "E_GEN2", "T_GEN3"]) {
+      const dead = await insertConnection({
+        slug: `slackinst-${tenant}`,
+        tenantId: tenant,
+        live: false,
+      });
+      orphans.push(await insertFeed(dead, CHANNEL));
+    }
+
+    await runCleanup();
+
+    for (const orphan of orphans) {
+      expect(await feedIsLive(orphan)).toBe(false);
+    }
+    expect(await feedIsLive(serving)).toBe(true);
+  });
+
+  test("keeps an orphan that is the org's only feed for the channel", async () => {
+    // Retiring this would remove the last feed for the channel rather than a
+    // duplicate — prod has exactly this case in a second organization.
+    const dead = await insertConnection({
+      slug: "slackinst-only",
+      tenantId: "E_ONLY",
+      live: false,
+    });
+    const orphan = await insertFeed(dead, CHANNEL);
+
+    await runCleanup();
+
+    expect(await feedIsLive(orphan)).toBe(true);
+  });
+
+  test("never retires a feed belonging to another organization", async () => {
+    const OTHER = "org-feedleak-other";
+    await seedAgentRow("agent-other", { organizationId: OTHER });
+    const deadOther = await insertConnection({
+      slug: "slackinst-other-dead",
+      tenantId: "E_OTHER",
+      live: false,
+      organizationId: OTHER,
+    });
+    const orphanOther = await insertFeed(deadOther, CHANNEL, OTHER);
+
+    // A live feed in THIS org must not license retiring the other org's.
+    const live = await insertConnection({
+      slug: "slackinst-mine",
+      tenantId: "T_MINE",
+      live: true,
+    });
+    await insertFeed(live, CHANNEL);
+
+    await runCleanup();
+
+    expect(await feedIsLive(orphanOther)).toBe(true);
+  });
+
+  test("never retires a non-streaming feed that shares a feed key", async () => {
+    // Unrelated connectors reuse feed keys (`reviews`, `content`, `home_feed`
+    // all collide in prod); retiring those would stop their ingestion.
+    const dead = await insertConnection({
+      slug: "slackinst-dead-collected",
+      tenantId: "E_COLLECTED",
+      live: false,
+    });
+    const live = await insertConnection({
+      slug: "slackinst-live-collected",
+      tenantId: "T_COLLECTED",
+      live: true,
+    });
+    const collected = await insertFeed(dead, "reviews", ORG, "collected");
+    await insertFeed(live, "reviews", ORG, "collected");
+
+    await runCleanup();
+
+    expect(await feedIsLive(collected)).toBe(true);
+  });
+
+  test("never retires a feed on a live connection", async () => {
+    const live = await insertConnection({
+      slug: "slackinst-both-live",
+      tenantId: "T_LIVE",
+      live: true,
+    });
+    const other = await insertConnection({
+      slug: "slackinst-second-live",
+      tenantId: "T_LIVE_TWO",
+      live: true,
+    });
+    const feedA = await insertFeed(live, CHANNEL);
+    const feedB = await insertFeed(other, CHANNEL);
+
+    await runCleanup();
+
+    expect(await feedIsLive(feedA)).toBe(true);
+    expect(await feedIsLive(feedB)).toBe(true);
+  });
+
+  test("never retires a non-chat connection's feed", async () => {
+    // `credential_mode IS NULL` marks a non-chat connection; those are outside
+    // this cleanup entirely.
+    const dead = await insertConnection({
+      slug: "agentconn-dead-nonchat",
+      tenantId: "T_NONCHAT",
+      live: false,
+      credentialMode: null,
+    });
+    const live = await insertConnection({
+      slug: "slackinst-live-nonchat",
+      tenantId: "T_NONCHAT_LIVE",
+      live: true,
+    });
+    const nonChat = await insertFeed(dead, CHANNEL);
+    await insertFeed(live, CHANNEL);
+
+    await runCleanup();
+
+    expect(await feedIsLive(nonChat)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

A streaming feed is keyed by the numeric `connections.id` and is soft-deleted **only** when a Behavior is explicitly unlinked — no trigger retires feeds when a connection is retired.

So each time a Slack workspace was re-installed under a different tenant key (a Grid workspace is recorded under its enterprise `E…` id or its workspace `T…` id depending on how it was installed), the replacement connection got its own feed while the previous generation's feed stayed **live**, pointing at a dead row. They accumulate one per install.

**Observed in prod** (`org_lobucrm`) — two orphans for one DM channel, while feed 450 serves that same channel on the live connection 448:

| feed | connection | connection state |
|---|---|---|
| 434 | 419 | dead |
| 437 | 430 | dead |
| 450 | 448 | **live — keeps routing** |

## Fix

One-shot cleanup, scoped by **organization + channel** rather than tenant key.

That scoping is the crux. The retired generations carry *different* `external_tenant_id`s — that key changing is what forked them in the first place — so a tenant match retires nothing. But matching on `feed_key` alone is far too broad: unrelated connectors reuse feed keys, and a dry-run of that version against prod would also have retired `reviews`, `content` and `home_feed` rows, silently stopping their ingestion.

A feed is retired **only** when the same org already has a live streaming feed for the same channel on a live connection — so every retired row is strictly a duplicate of one that keeps routing. An org whose only feeds for a channel sit on dead connections keeps them rather than losing its last one.

## Behaviors are deliberately not repaired

An earlier version of this branch also un-archived the stranded chat Behavior. That was wrong, and prod showed why:

- Behavior **25** is archived naming the retired connection 430.
- Behavior **48** is **active** on the live connection 448 — same agent, same channel, byte-identical trigger — created by the reinstall at 02:32:30, three minutes *before* 25 was archived at 02:35:50.

Archiving 25 was correct; it is the superseded row. Reviving it would leave two active Behaviors on one channel and, since resolution takes `LIMIT 1 ORDER BY updated_at DESC`, the revived row would have **displaced the working one**.

## Scope

This cleans up existing rows. It does not change how feeds bind, and it does not stop a future tenant-key change from leaking another feed — that is an install-identity concern, tracked separately.

## Verification

- **Prod dry-run** (read-only) of the final SQL matches exactly feeds 434 and 437 — nothing else, and the second org's orphans are correctly left alone since it has no live feed to fall back on.
- **Mutation-proven**, each failing exactly the tests that cover it: disabling the cleanup; dropping the duplicate-exists requirement; dropping the org scoping; dropping the streaming filters; dropping the dead-connection requirement; dropping the chat-connection filter.
- 7/7 new file, 24/24 channels, 1969/1969 gateway, `make pre-pr` clean, migration applied to a fresh database.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->