### PR TITLE
feat(connectors): operator allow-host list for DB egress under cloud mode

### DIFF
--- a/docs/database-connectors.md
+++ b/docs/database-connectors.md
@@ -89,9 +89,13 @@ runs a pre-connect host check on `sync()`, `query()`, and `search()`. Policy com
 - `allow-private` (self-hosted, the default) — allows loopback / RFC1918 / CGNAT
   / ULA, but still blocks link-local + cloud metadata (`169.254/16`), multicast,
   and the unspecified address (no DB lives there).
-- `block-private` (cloud) — blocks **every** non-public address. A hostname is
-  resolved and rejected if ANY returned address is blocked (multi-record rebind),
-  with IPv4-mapped / NAT64 / zone-id normalization and fail-closed on malformed
+- `block-private` (cloud) — blocks **every** non-public address unless the
+  operator explicitly lists that exact URL host in the comma-separated
+  `LOBU_DB_EGRESS_ALLOW_HOSTS` deployment variable. An exemption lowers only
+  that host to the `allow-private` floor; metadata/link-local, unspecified,
+  multicast, and reserved addresses remain blocked. Hostnames are resolved and
+  rejected if ANY returned address is blocked (multi-record rebind), with
+  IPv4-mapped / NAT64 / zone-id normalization and fail-closed on malformed
   literals. On top of classify-and-reject (`buildDbEgressHardening`):
   - **Resolve-then-pin:** each hostname is resolved once at guard time and the
     postgres.js pool gets a custom `socket` factory that dials the validated IP
@@ -107,6 +111,12 @@ runs a pre-connect host check on `sync()`, `query()`, and `search()`. Policy com
     rather than `verify-full` because tenant DBs commonly present self-signed /
     private-CA certs — upgrading the floor once per-connection CA upload exists
     is the noted follow-up.
+
+The allow-host setting is global operator deployment config, not connection or
+tenant config. Entries must match the bare host extracted from `DATABASE_URL`
+(IPv6 without URL brackets); CIDRs, wildcards, ports, and bracketed IPv6 forms
+are rejected. Allowlisted names are still resolved once, validated against the
+floor, pinned to the validated address, and connected with forced TLS.
 
 **Deferred (explicit follow-up):** a per-org destination allowlist ("this org
 may only reach these DB hosts"). block-private + pin + forced TLS protects the

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -25,6 +25,9 @@ export interface Env {
   // "block-private" (injected under cloud mode) makes a DB connector reject
   // internal/metadata hosts; anything else ⇒ trusted "allow-private".
   LOBU_DB_EGRESS_POLICY?: string;
+  // Operator-configured exact hosts exempt from the private-address block.
+  // Delivered by the gateway; tenant connection config cannot override it.
+  LOBU_DB_EGRESS_ALLOW_HOSTS?: string;
 
   // Sync intervals
   DEFAULT_SYNC_INTERVAL_MS?: string;

--- a/packages/connector-worker/src/__tests__/gateway-egress-allowhosts.test.ts
+++ b/packages/connector-worker/src/__tests__/gateway-egress-allowhosts.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import type { Env } from '@lobu/connector-sdk';
 import type { PollResponse } from '../daemon/client.js';
 import { resolveEffectiveEnv } from '../daemon/executor.js';
+import { buildConnectorWorkerEnv } from '../env.js';
+import { buildConnectorConfig } from '../executor/child-runner.js';
 
 /**
  * The operator's DB egress allow-host list rides the SAME gateway-authoritative
@@ -37,11 +39,6 @@ describe('resolveEffectiveEnv — allow-host list is gateway-authoritative', () 
     expect(out.LOBU_DB_EGRESS_ALLOW_HOSTS).toBe('100.127.177.56');
     expect(out.LOBU_DB_EGRESS_ALLOW_HOSTS).not.toContain('10.0.0.5');
   });
-
-  test('the policy ratchet still applies alongside the list', () => {
-    const out = resolveEffectiveEnv({} as Env, job('100.127.177.56'));
-    expect(out.LOBU_DB_EGRESS_POLICY).toBe('block-private');
-  });
 });
 
 /**
@@ -51,14 +48,12 @@ describe('resolveEffectiveEnv — allow-host list is gateway-authoritative', () 
  * effective env → authoritative child config, with tenant config unable to win.
  */
 describe('cloud path — gateway list reaches the connector config', () => {
-  test('worker env whitelist carries no allow-host list of its own', async () => {
-    const { buildConnectorWorkerEnv } = await import('../env.js');
+  test('worker env whitelist carries no allow-host list of its own', () => {
     const env = buildConnectorWorkerEnv() as Record<string, unknown>;
     expect(env.LOBU_DB_EGRESS_ALLOW_HOSTS).toBeUndefined();
   });
 
-  test('tenant config cannot override the gateway allow-host list', async () => {
-    const { buildConnectorConfig } = await import('../executor/child-runner.js');
+  test('tenant config cannot override the gateway allow-host list', () => {
     const gatewayJob = {
       run_id: 1,
       run_type: 'sync',

--- a/packages/connector-worker/src/__tests__/gateway-egress-allowhosts.test.ts
+++ b/packages/connector-worker/src/__tests__/gateway-egress-allowhosts.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import type { Env } from '@lobu/connector-sdk';
+import type { PollResponse } from '../daemon/client.js';
+import { resolveEffectiveEnv } from '../daemon/executor.js';
+
+/**
+ * The operator's DB egress allow-host list rides the SAME gateway-authoritative
+ * channel as `db_egress_policy`. It must REPLACE any worker-local list, never
+ * union with it — unioning would let a compromised or misconfigured fleet worker
+ * widen its own egress boundary, which is exactly the downgrade the policy
+ * ratchet exists to prevent.
+ */
+describe('resolveEffectiveEnv — allow-host list is gateway-authoritative', () => {
+  const job = (allow?: string): PollResponse =>
+    ({
+      run_id: 1,
+      run_type: 'sync',
+      connector_key: 'postgres',
+      db_egress_policy: 'block-private',
+      db_egress_allow_hosts: allow,
+    }) as PollResponse;
+
+  test("the gateway's list is installed into the child env", () => {
+    const out = resolveEffectiveEnv({} as Env, job('100.127.177.56'));
+    expect(out.LOBU_DB_EGRESS_ALLOW_HOSTS).toBe('100.127.177.56');
+  });
+
+  test('a worker-local list is DISCARDED when the gateway ships none', () => {
+    const workerEnv = { LOBU_DB_EGRESS_ALLOW_HOSTS: '10.0.0.5' } as unknown as Env;
+    const out = resolveEffectiveEnv(workerEnv, job(undefined));
+    expect(out.LOBU_DB_EGRESS_ALLOW_HOSTS).toBe('');
+  });
+
+  test('a worker cannot ADD entries to the gateway list', () => {
+    const workerEnv = { LOBU_DB_EGRESS_ALLOW_HOSTS: '169.254.169.254,10.0.0.5' } as unknown as Env;
+    const out = resolveEffectiveEnv(workerEnv, job('100.127.177.56'));
+    expect(out.LOBU_DB_EGRESS_ALLOW_HOSTS).toBe('100.127.177.56');
+    expect(out.LOBU_DB_EGRESS_ALLOW_HOSTS).not.toContain('10.0.0.5');
+  });
+
+  test('the policy ratchet still applies alongside the list', () => {
+    const out = resolveEffectiveEnv({} as Env, job('100.127.177.56'));
+    expect(out.LOBU_DB_EGRESS_POLICY).toBe('block-private');
+  });
+});
+
+/**
+ * End-to-end of the CLOUD path: the worker's own env whitelist
+ * (`buildConnectorWorkerEnv`) deliberately does NOT carry an allow-host list —
+ * the gateway is the only source. These assert the full fold: poll response →
+ * effective env → authoritative child config, with tenant config unable to win.
+ */
+describe('cloud path — gateway list reaches the connector config', () => {
+  test('worker env whitelist carries no allow-host list of its own', async () => {
+    const { buildConnectorWorkerEnv } = await import('../env.js');
+    const env = buildConnectorWorkerEnv() as Record<string, unknown>;
+    expect(env.LOBU_DB_EGRESS_ALLOW_HOSTS).toBeUndefined();
+  });
+
+  test('tenant config cannot override the gateway allow-host list', async () => {
+    const { buildConnectorConfig } = await import('../executor/child-runner.js');
+    const gatewayJob = {
+      run_id: 1,
+      run_type: 'sync',
+      connector_key: 'postgres',
+      db_egress_policy: 'block-private',
+      db_egress_allow_hosts: '100.127.177.56',
+    } as PollResponse;
+    const effective = resolveEffectiveEnv({} as Env, gatewayJob);
+    const config = buildConnectorConfig({
+      config: {
+        // A malicious tenant trying to widen its own boundary.
+        LOBU_DB_EGRESS_ALLOW_HOSTS: '169.254.169.254',
+        LOBU_DB_EGRESS_POLICY: 'allow-private',
+      },
+      env: effective as unknown as Record<string, string | undefined>,
+    });
+    expect(config.LOBU_DB_EGRESS_ALLOW_HOSTS).toBe('100.127.177.56');
+    expect(config.LOBU_DB_EGRESS_POLICY).toBe('block-private');
+  });
+});

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -73,7 +73,7 @@ const DEFAULT_CONFIG: ExecutorConfig = {
 };
 
 /**
- * Fold the gateway's authoritative DB egress decision into the worker's env.
+ * Fold the gateway's authoritative DB egress config into the worker's env.
  *
  * The gateway (which knows cloud mode authoritatively) ships `db_egress_policy`
  * on the poll response. The worker's own `env.LOBU_DB_EGRESS_POLICY` is derived
@@ -87,6 +87,9 @@ const DEFAULT_CONFIG: ExecutorConfig = {
  * worker that already decided block-private. The result is re-asserted as
  * authoritative `job.env.LOBU_DB_EGRESS_POLICY` by `buildConnectorConfig` in the
  * child so tenant config can't override it either.
+ *
+ * The gateway allow-host list replaces any worker-local value. A missing list
+ * means no exemptions, so a worker cannot widen the gateway's boundary.
  */
 export function resolveEffectiveEnv(env: Env, job: PollResponse): Env {
   const workerPolicy = (env as Record<string, string | undefined>).LOBU_DB_EGRESS_POLICY;
@@ -96,11 +99,6 @@ export function resolveEffectiveEnv(env: Env, job: PollResponse): Env {
     workerPolicy === 'block-private' || gatewayPolicy === 'block-private'
       ? 'block-private'
       : (gatewayPolicy ?? workerPolicy ?? 'allow-private');
-  // The allow-host list is REPLACED by the gateway's, never unioned with the
-  // worker's own. Unioning would let a compromised/misconfigured fleet worker
-  // widen the boundary by adding entries — the exact downgrade the policy
-  // ratchet above exists to prevent. When the gateway ships no list, the worker
-  // gets none: absence must mean "no exemptions", not "keep your local ones".
   return {
     ...env,
     LOBU_DB_EGRESS_POLICY: effective,
@@ -120,9 +118,8 @@ export async function executeRun(
   config: Partial<ExecutorConfig> = {}
 ): Promise<{ itemsCollected: number; error?: string }> {
   const cfg = { ...DEFAULT_CONFIG, ...config };
-  // Fold the gateway's authoritative egress decision in ONCE here, so every
-  // downstream mode handler (sync/action/auth/embed) gets the same non-
-  // downgradable `LOBU_DB_EGRESS_POLICY`.
+  // Fold the gateway's authoritative egress config in once so every downstream
+  // mode handler gets the same non-downgradable policy and operator exemptions.
   const env = resolveEffectiveEnv(workerEnv, job);
   switch (job.run_type) {
     case 'action':

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -96,7 +96,16 @@ export function resolveEffectiveEnv(env: Env, job: PollResponse): Env {
     workerPolicy === 'block-private' || gatewayPolicy === 'block-private'
       ? 'block-private'
       : (gatewayPolicy ?? workerPolicy ?? 'allow-private');
-  return { ...env, LOBU_DB_EGRESS_POLICY: effective };
+  // The allow-host list is REPLACED by the gateway's, never unioned with the
+  // worker's own. Unioning would let a compromised/misconfigured fleet worker
+  // widen the boundary by adding entries — the exact downgrade the policy
+  // ratchet above exists to prevent. When the gateway ships no list, the worker
+  // gets none: absence must mean "no exemptions", not "keep your local ones".
+  return {
+    ...env,
+    LOBU_DB_EGRESS_POLICY: effective,
+    LOBU_DB_EGRESS_ALLOW_HOSTS: job.db_egress_allow_hosts ?? '',
+  };
 }
 
 /**

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -25,14 +25,17 @@ interface ChildMessage {
  * Keys the trusted gateway sets on `job.env` that a tenant's connection/feed
  * `job.config` must NEVER be able to override. Normal precedence is
  * config-wins (a connector's config legitimately shadows ambient env), but a
- * security control injected by the gateway is authoritative. `job.env` is
- * built by the gateway from cloud mode, `job.config` is tenant-supplied — so
- * merge config over env, then re-assert these keys from env as last-wins.
+ * security control injected by the gateway is authoritative. `job.env` carries
+ * trusted deployment controls while `job.config` is tenant-supplied, so merge
+ * config over env and then re-assert these keys from env.
  *
  * `LOBU_DB_EGRESS_POLICY`: the DB egress boundary (private-IP block + IP pin +
  * forced TLS). The in-process paths already inject it last into `job.config`
  * (feed-sync / connector-pushdown); the out-of-process worker delivers it via
  * `job.env`, and this is where it must beat tenant config.
+ *
+ * `LOBU_DB_EGRESS_ALLOW_HOSTS`: operator-owned exceptions to that boundary,
+ * delivered through the same authoritative paths.
  */
 const GATEWAY_AUTHORITATIVE_CONFIG_KEYS = [
   'LOBU_DB_EGRESS_POLICY',

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -34,7 +34,10 @@ interface ChildMessage {
  * (feed-sync / connector-pushdown); the out-of-process worker delivers it via
  * `job.env`, and this is where it must beat tenant config.
  */
-const GATEWAY_AUTHORITATIVE_CONFIG_KEYS = ['LOBU_DB_EGRESS_POLICY'] as const;
+const GATEWAY_AUTHORITATIVE_CONFIG_KEYS = [
+  'LOBU_DB_EGRESS_POLICY',
+  'LOBU_DB_EGRESS_ALLOW_HOSTS',
+] as const;
 
 /**
  * Merge the connector's runtime config with config-wins precedence for normal

--- a/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
@@ -111,6 +111,35 @@ describe('allow-hosts must NOT become a universal bypass', () => {
       assertHostAllowed('fd00::1', BLOCK, undefined, ['fd00::1']),
     ).resolves.toBeUndefined();
   });
+
+  /**
+   * The rest of the class: metadata endpoints sitting in ranges the
+   * `allow-private` floor permits, so an exemption would otherwise reach them.
+   * Alibaba's is the sharpest — it lives in CGNAT, the same range a Tailscale
+   * exemption targets.
+   */
+  test.each([
+    ['100.100.100.200', 'Alibaba metadata (inside CGNAT)'],
+    ['192.0.0.192', 'Oracle Cloud metadata'],
+  ])('%s stays blocked even when explicitly allowlisted (%s)', async (host) => {
+    await expect(assertHostAllowed(host, BLOCK, undefined, [host])).rejects.toThrow(
+      /blocked internal\/metadata address/,
+    );
+  });
+
+  test('an allowlisted hostname resolving to Alibaba metadata is still blocked', async () => {
+    await expect(
+      assertHostAllowed('evil.example.com', BLOCK, fakeLookup(['100.100.100.200']), [
+        'evil.example.com',
+      ]),
+    ).rejects.toThrow(/blocked internal\/metadata address/);
+  });
+
+  test('an ordinary CGNAT host is still exemptible (Tailscale must keep working)', async () => {
+    await expect(
+      assertHostAllowed('100.127.177.56', BLOCK, undefined, ['100.127.177.56']),
+    ).resolves.toBeUndefined();
+  });
 });
 
 describe('parseAllowedHosts — unsupported entry shapes fail at parse time', () => {

--- a/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
@@ -72,3 +72,45 @@ describe('allow-hosts must NOT become a universal bypass', () => {
     ).rejects.toThrow();
   });
 });
+
+describe('parseAllowedHosts — malformed entries fail loudly at parse time', () => {
+  test('a CIDR entry is rejected (a range is never an exact host)', () => {
+    expect(() => parseAllowedHosts('100.64.0.0/10')).toThrow(/CIDR|exact host/i);
+  });
+  test('a wildcard entry is rejected', () => {
+    expect(() => parseAllowedHosts('*.ts.net')).toThrow(/wildcard|exact host/i);
+  });
+  test('an entry with a port is rejected (hosts are matched without a port)', () => {
+    expect(() => parseAllowedHosts('10.0.0.5:5432')).toThrow(/port|exact host/i);
+  });
+  test('a bracketed IPv6 entry is rejected (extractDbHosts strips brackets)', () => {
+    expect(() => parseAllowedHosts('[fd00::1]')).toThrow(/bracket|exact host/i);
+  });
+  test('a valid mixed list still parses', () => {
+    expect(parseAllowedHosts('100.127.177.56, db.corp, fd00::1')).toEqual([
+      '100.127.177.56',
+      'db.corp',
+      'fd00::1',
+    ]);
+  });
+});
+
+/**
+ * The allowlist is matched against the RAW host string from DATABASE_URL, while
+ * the range check normalizes (IPv4-mapped/NAT64/zone-id). That asymmetry is
+ * DELIBERATE and fails CLOSED: an alternate spelling of an allowlisted address
+ * misses the allowlist and stays blocked. Locked in so a future "normalize
+ * before matching" refactor cannot silently open the NAT64/IPv4-mapped path.
+ */
+describe('raw-vs-normalized asymmetry is intentional and fails closed', () => {
+  const ALLOW = ['100.127.177.56'];
+  for (const spelling of [
+    '::ffff:100.127.177.56',
+    '64:ff9b::100.127.177.56',
+    '100.127.177.56%eth0',
+  ]) {
+    test(`${spelling} does NOT inherit the allowlist entry for 100.127.177.56`, async () => {
+      await expect(assertHostAllowed(spelling, BLOCK, undefined, ALLOW)).rejects.toThrow();
+    });
+  }
+});

--- a/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
@@ -84,6 +84,33 @@ describe('allow-hosts must NOT become a universal bypass', () => {
       ]),
     ).rejects.toThrow();
   });
+
+  /**
+   * AWS serves IMDS over IPv6 at `fd00:ec2::254`, which sits in ULA `fc00::/7`.
+   * ULA is deliberately absent from the `allow-private` floor (a self-hoster's DB
+   * legitimately lives there), so dropping an exempted host to that floor would
+   * otherwise expose the metadata endpoint — the IPv6 twin of 169.254.169.254,
+   * which is blocked. Both spellings must fail for exempted hosts too.
+   */
+  test('IPv6 cloud metadata stays blocked even when explicitly allowlisted', async () => {
+    await expect(
+      assertHostAllowed('fd00:ec2::254', BLOCK, undefined, ['fd00:ec2::254']),
+    ).rejects.toThrow(/blocked internal\/metadata address/);
+  });
+
+  test('an allowlisted hostname resolving to IPv6 metadata is still blocked', async () => {
+    await expect(
+      assertHostAllowed('evil.example.com', BLOCK, fakeLookup(['fd00:ec2::254']), [
+        'evil.example.com',
+      ]),
+    ).rejects.toThrow(/blocked internal\/metadata address/);
+  });
+
+  test('an ordinary ULA host is still exemptible (the deny set is metadata-only)', async () => {
+    await expect(
+      assertHostAllowed('fd00::1', BLOCK, undefined, ['fd00::1']),
+    ).resolves.toBeUndefined();
+  });
 });
 
 describe('parseAllowedHosts — unsupported entry shapes fail at parse time', () => {

--- a/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  assertHostAllowed,
+  type DbEgressPolicy,
+  type HostLookup,
+  parseAllowedHosts,
+  resolveAllowedHostAddresses,
+} from '../db-egress-guard.ts';
+
+const fakeLookup =
+  (addresses: string[]): HostLookup =>
+  async () =>
+    addresses.map((address) => ({ address }));
+
+const BLOCK: DbEgressPolicy = 'block-private';
+
+describe('parseAllowedHosts', () => {
+  test('parses a comma-separated list, trimming and dropping blanks', () => {
+    expect(parseAllowedHosts(' 100.127.177.56 , db.example.com ,, ')).toEqual([
+      '100.127.177.56',
+      'db.example.com',
+    ]);
+  });
+  test('undefined / empty yields no entries', () => {
+    expect(parseAllowedHosts(undefined)).toEqual([]);
+    expect(parseAllowedHosts('   ')).toEqual([]);
+  });
+});
+
+describe('allow-hosts bypass — the Tailscale case', () => {
+  test('CGNAT literal is blocked under block-private WITHOUT an allowlist', async () => {
+    await expect(assertHostAllowed('100.127.177.56', BLOCK)).rejects.toThrow(
+      /blocked internal\/metadata address/,
+    );
+  });
+
+  test('CGNAT literal is permitted when explicitly allowlisted', async () => {
+    await expect(
+      assertHostAllowed('100.127.177.56', BLOCK, undefined, ['100.127.177.56']),
+    ).resolves.toBeUndefined();
+  });
+
+  test('an allowlisted hostname resolving into CGNAT is permitted and pinned', async () => {
+    const addrs = await resolveAllowedHostAddresses(
+      'mac.tailnet.ts.net',
+      BLOCK,
+      fakeLookup(['100.127.177.56']),
+      ['mac.tailnet.ts.net'],
+    );
+    expect(addrs).toEqual(['100.127.177.56']);
+  });
+});
+
+describe('allow-hosts must NOT become a universal bypass', () => {
+  test('a DIFFERENT private host is still blocked while one host is allowlisted', async () => {
+    await expect(
+      assertHostAllowed('10.0.0.5', BLOCK, undefined, ['100.127.177.56']),
+    ).rejects.toThrow(/blocked internal\/metadata address/);
+  });
+
+  test('cloud metadata stays blocked even when explicitly allowlisted', async () => {
+    await expect(
+      assertHostAllowed('169.254.169.254', BLOCK, undefined, ['169.254.169.254']),
+    ).rejects.toThrow(/blocked internal\/metadata address/);
+  });
+
+  test('an allowlisted hostname resolving to metadata is still blocked', async () => {
+    await expect(
+      assertHostAllowed('evil.example.com', BLOCK, fakeLookup(['169.254.169.254']), [
+        'evil.example.com',
+      ]),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-allowhosts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   assertHostAllowed,
+  buildDbEgressHardening,
   type DbEgressPolicy,
   type HostLookup,
   parseAllowedHosts,
@@ -49,6 +50,18 @@ describe('allow-hosts bypass — the Tailscale case', () => {
     );
     expect(addrs).toEqual(['100.127.177.56']);
   });
+
+  test('block-private hardening accepts an allowlisted CGNAT host and keeps TLS + pinning', async () => {
+    const hardening = await buildDbEgressHardening(
+      'postgres://u:p@mac.tailnet.ts.net:5432/db',
+      BLOCK,
+      fakeLookup(['100.127.177.56']),
+      undefined,
+      ['mac.tailnet.ts.net'],
+    );
+    expect(hardening.ssl).toBe('require');
+    expect(typeof hardening.socket).toBe('function');
+  });
 });
 
 describe('allow-hosts must NOT become a universal bypass', () => {
@@ -73,7 +86,7 @@ describe('allow-hosts must NOT become a universal bypass', () => {
   });
 });
 
-describe('parseAllowedHosts — malformed entries fail loudly at parse time', () => {
+describe('parseAllowedHosts — unsupported entry shapes fail at parse time', () => {
   test('a CIDR entry is rejected (a range is never an exact host)', () => {
     expect(() => parseAllowedHosts('100.64.0.0/10')).toThrow(/CIDR|exact host/i);
   });
@@ -96,11 +109,9 @@ describe('parseAllowedHosts — malformed entries fail loudly at parse time', ()
 });
 
 /**
- * The allowlist is matched against the RAW host string from DATABASE_URL, while
- * the range check normalizes (IPv4-mapped/NAT64/zone-id). That asymmetry is
- * DELIBERATE and fails CLOSED: an alternate spelling of an allowlisted address
- * misses the allowlist and stays blocked. Locked in so a future "normalize
- * before matching" refactor cannot silently open the NAT64/IPv4-mapped path.
+ * The allowlist is matched against the extracted host spelling before the range
+ * check normalizes IPv4-mapped/NAT64/zone-id forms. An alternate spelling of an
+ * allowlisted address therefore misses the exemption and stays blocked.
  */
 describe('raw-vs-normalized asymmetry is intentional and fails closed', () => {
   const ALLOW = ['100.127.177.56'];

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -81,18 +81,30 @@ const ALLOW_PRIVATE_V6: ReadonlyArray<readonly [string, number]> = [
 ];
 
 /**
- * IPv6 cloud-metadata endpoints, denied under EVERY policy and even for an
- * explicitly allowlisted host — the IPv6 twins of 169.254.169.254.
+ * Cloud-metadata endpoints that live OUTSIDE the ranges the `allow-private`
+ * floor already denies, listed individually so they stay blocked under every
+ * policy and even for an explicitly allowlisted host.
  *
- * These need naming individually because they sit inside ULA `fc00::/7`, which
- * `allow-private` deliberately permits (a self-hoster's DB legitimately lives
- * on a ULA address). Without this set, exempting a host would drop it to the
- * `allow-private` floor and expose IMDS. Kept metadata-only so ordinary ULA
- * hosts stay reachable.
+ * Each sits in a range `allow-private` deliberately permits, so without this
+ * set an exemption would drop the host to that floor and expose the endpoint:
+ * Alibaba's is in CGNAT `100.64.0.0/10` — exactly the range a Tailscale
+ * exemption targets — and AWS's IPv6 IMDS is in ULA `fc00::/7`, where a
+ * self-hoster's DB legitimately lives. Kept metadata-only so ordinary CGNAT
+ * and ULA hosts stay reachable. (169.254.169.254 and 169.254.170.2 need no
+ * entry — link-local `169.254.0.0/16` is already denied at the floor.)
  */
-const METADATA_V6: ReadonlyArray<readonly [string, number]> = [
-  ['fd00:ec2::254', 128], // AWS IMDS over IPv6
+const METADATA_V4: ReadonlyArray<readonly [string, number]> = [
+  ['100.100.100.200', 32], // Alibaba Cloud metadata (inside CGNAT)
+  ['192.0.0.192', 32], // Oracle Cloud metadata (IETF protocol assignments)
 ];
+
+const METADATA_V6: ReadonlyArray<readonly [string, number]> = [
+  ['fd00:ec2::254', 128], // AWS IMDS over IPv6 (inside ULA)
+];
+
+function isMetadataV4(address: string): boolean {
+  return METADATA_V4.some(([base, prefix]) => matchesIpv4Prefix(address, base, prefix));
+}
 
 function isMetadataV6(address: string): boolean {
   return METADATA_V6.some(([base, prefix]) => matchesIpv6Prefix(address, base, prefix));
@@ -171,7 +183,10 @@ function matchesIpv6Prefix(address: string, base: string, prefix: number): boole
 
 function isBlockedV4(address: string, policy: DbEgressPolicy): boolean {
   const ranges = policy === 'block-private' ? BLOCK_PRIVATE_V4 : ALLOW_PRIVATE_V4;
-  return ranges.some(([base, prefix]) => matchesIpv4Prefix(address, base, prefix));
+  return (
+    isMetadataV4(address) ||
+    ranges.some(([base, prefix]) => matchesIpv4Prefix(address, base, prefix))
+  );
 }
 
 function isBlockedV6(address: string, policy: DbEgressPolicy): boolean {

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -271,10 +271,39 @@ const defaultLookup: HostLookup = (host) => dns.promises.lookup(host, { all: tru
  */
 export function parseAllowedHosts(value: unknown): string[] {
   if (typeof value !== 'string') return [];
-  return value
+  const entries = value
     .split(',')
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
+  for (const entry of entries) {
+    // Fail LOUDLY on shapes that can never match a host from `extractDbHosts`
+    // (which yields a bare host: brackets stripped, `:port` removed). Without
+    // this an operator typo like `100.64.0.0/10` parses fine and then silently
+    // never matches — the connection just keeps failing with no hint that the
+    // allowlist entry is the problem. A range/wildcard is also NOT the intended
+    // grant: exemptions are per exact host by design.
+    const reason = malformedAllowedHostReason(entry);
+    if (reason) {
+      throw new Error(
+        `LOBU_DB_EGRESS_ALLOW_HOSTS entry "${entry}" is invalid: ${reason}. ` +
+          'Use an exact host as it appears in DATABASE_URL (no CIDR, wildcard, port, or brackets).',
+      );
+    }
+  }
+  return entries;
+}
+
+/** Why an allow-host entry can never match a parsed DATABASE_URL host, if so. */
+function malformedAllowedHostReason(entry: string): string | null {
+  if (entry.includes('/')) return 'a CIDR range is not an exact host';
+  if (entry.includes('*')) return 'a wildcard is not an exact host';
+  if (entry.startsWith('[') || entry.endsWith(']')) {
+    return 'brackets are stripped from IPv6 hosts before matching';
+  }
+  // A bare IPv6 literal legitimately contains `:` — only flag a trailing
+  // `:port`, which `extractDbHosts` would already have removed from the URL.
+  if (net.isIP(entry) === 0 && /:\d+$/.test(entry)) return 'a :port is not part of the host';
+  return null;
 }
 
 /** Case-insensitive exact match of a URL host against the allow list. */

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -265,9 +265,10 @@ const defaultLookup: HostLookup = (host) => dns.promises.lookup(host, { all: tru
  *
  * Deployment config ONLY — it rides the same gateway-authoritative path as the
  * policy itself and is never settable from tenant/connection config, so a tenant
- * cannot widen its own egress boundary. Entries are matched EXACTLY (an IP
- * literal or a DNS name as written in DATABASE_URL); no wildcards or CIDRs, so
- * approving one tailnet host never approves the whole `100.64.0.0/10` range.
+ * cannot widen its own egress boundary. Entries are matched EXACTLY against the
+ * bare host extracted from DATABASE_URL (IPv6 without URL brackets); no
+ * wildcards or CIDRs, so approving one tailnet host never approves the whole
+ * `100.64.0.0/10` range.
  */
 export function parseAllowedHosts(value: unknown): string[] {
   if (typeof value !== 'string') return [];
@@ -276,17 +277,13 @@ export function parseAllowedHosts(value: unknown): string[] {
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
   for (const entry of entries) {
-    // Fail LOUDLY on shapes that can never match a host from `extractDbHosts`
-    // (which yields a bare host: brackets stripped, `:port` removed). Without
-    // this an operator typo like `100.64.0.0/10` parses fine and then silently
-    // never matches — the connection just keeps failing with no hint that the
-    // allowlist entry is the problem. A range/wildcard is also NOT the intended
-    // grant: exemptions are per exact host by design.
+    // Reject shapes that cannot match `extractDbHosts`; otherwise an operator
+    // typo silently leaves the intended exemption inactive.
     const reason = malformedAllowedHostReason(entry);
     if (reason) {
       throw new Error(
         `LOBU_DB_EGRESS_ALLOW_HOSTS entry "${entry}" is invalid: ${reason}. ` +
-          'Use an exact host as it appears in DATABASE_URL (no CIDR, wildcard, port, or brackets).',
+          'Use the exact bare host from DATABASE_URL (no CIDR, wildcard, port, or IPv6 brackets).',
       );
     }
   }

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -80,6 +80,24 @@ const ALLOW_PRIVATE_V6: ReadonlyArray<readonly [string, number]> = [
   ['ff00::', 8],
 ];
 
+/**
+ * IPv6 cloud-metadata endpoints, denied under EVERY policy and even for an
+ * explicitly allowlisted host — the IPv6 twins of 169.254.169.254.
+ *
+ * These need naming individually because they sit inside ULA `fc00::/7`, which
+ * `allow-private` deliberately permits (a self-hoster's DB legitimately lives
+ * on a ULA address). Without this set, exempting a host would drop it to the
+ * `allow-private` floor and expose IMDS. Kept metadata-only so ordinary ULA
+ * hosts stay reachable.
+ */
+const METADATA_V6: ReadonlyArray<readonly [string, number]> = [
+  ['fd00:ec2::254', 128], // AWS IMDS over IPv6
+];
+
+function isMetadataV6(address: string): boolean {
+  return METADATA_V6.some(([base, prefix]) => matchesIpv6Prefix(address, base, prefix));
+}
+
 type NormalizedHost =
   | { kind: 'ipv4'; value: string }
   | { kind: 'ipv6'; value: string }
@@ -159,6 +177,7 @@ function isBlockedV4(address: string, policy: DbEgressPolicy): boolean {
 function isBlockedV6(address: string, policy: DbEgressPolicy): boolean {
   const ranges = policy === 'block-private' ? BLOCK_PRIVATE_V6 : ALLOW_PRIVATE_V6;
   return (
+    isMetadataV6(address) ||
     matchesIpv6Prefix(address, '::', 128) ||
     (policy === 'block-private' && matchesIpv6Prefix(address, '::1', 128)) ||
     ranges.some(([base, prefix]) => matchesIpv6Prefix(address, base, prefix))
@@ -342,7 +361,7 @@ export async function assertHostAllowed(
  * multicast and reserved are rejected under every policy, for allowlisted and
  * ordinary hosts alike. That floor is what makes this a destination exemption
  * rather than an SSRF off-switch, so allowlisting a name whose DNS answer is
- * `169.254.169.254` still fails.
+ * `169.254.169.254` — or its IPv6 twin `fd00:ec2::254` — still fails.
  */
 export async function resolveAllowedHostAddresses(
   host: string,

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -261,18 +261,46 @@ export type HostLookup = (host: string) => Promise<Array<{ address: string }>>;
 const defaultLookup: HostLookup = (host) => dns.promises.lookup(host, { all: true });
 
 /**
+ * Parse an operator-supplied allow-host list (comma-separated) into entries.
+ *
+ * Deployment config ONLY — it rides the same gateway-authoritative path as the
+ * policy itself and is never settable from tenant/connection config, so a tenant
+ * cannot widen its own egress boundary. Entries are matched EXACTLY (an IP
+ * literal or a DNS name as written in DATABASE_URL); no wildcards or CIDRs, so
+ * approving one tailnet host never approves the whole `100.64.0.0/10` range.
+ */
+export function parseAllowedHosts(value: unknown): string[] {
+  if (typeof value !== 'string') return [];
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+/** Case-insensitive exact match of a URL host against the allow list. */
+function isAllowlistedHost(host: string, allowedHosts: readonly string[]): boolean {
+  if (allowedHosts.length === 0) return false;
+  const needle = host.trim().toLowerCase();
+  return allowedHosts.some((entry) => entry.toLowerCase() === needle);
+}
+
+/**
  * Throw if `host` (an IP literal OR a DNS name) is — or resolves to — an address
  * blocked under `policy`. A hostname is resolved and rejected if ANY returned
  * address is blocked (covers multi-record / round-robin rebind tricks). The
  * error names the host but never the full connection string (credentials must
  * not leak). `lookup` is injectable for tests.
+ *
+ * `allowedHosts` (operator deployment config) exempts an exactly-matching host
+ * from the POLICY range check only — see {@link resolveAllowedHostAddresses}.
  */
 export async function assertHostAllowed(
   host: string,
   policy: DbEgressPolicy,
   lookup: HostLookup = defaultLookup,
+  allowedHosts: readonly string[] = [],
 ): Promise<void> {
-  await resolveAllowedHostAddresses(host, policy, lookup);
+  await resolveAllowedHostAddresses(host, policy, lookup, allowedHosts);
 }
 
 /**
@@ -281,15 +309,28 @@ export async function assertHostAllowed(
  * TOCTOU: the socket dials exactly what was validated, never a re-resolve).
  * An IP-literal host returns its normalized form (IPv4-mapped/NAT64 unwrapped);
  * a hostname returns every address the single guard-time lookup produced.
+ *
+ * An allowlisted host is exempted from the POLICY range check (so an operator
+ * can reach a private/CGNAT DB — e.g. over Tailscale — while cloud mode stays
+ * on) but NEVER from the always-blocked set: metadata/link-local, unspecified,
+ * multicast and reserved are rejected under every policy, for allowlisted and
+ * ordinary hosts alike. That floor is what makes this a destination exemption
+ * rather than an SSRF off-switch, so allowlisting a name whose DNS answer is
+ * `169.254.169.254` still fails.
  */
 export async function resolveAllowedHostAddresses(
   host: string,
   policy: DbEgressPolicy,
   lookup: HostLookup = defaultLookup,
+  allowedHosts: readonly string[] = [],
 ): Promise<string[]> {
+  // An exempted host drops to the `allow-private` floor — never below it.
+  const effectivePolicy: DbEgressPolicy = isAllowlistedHost(host, allowedHosts)
+    ? 'allow-private'
+    : policy;
   const normalized = normalizeIpLiteral(host);
   if (normalized.kind === 'ipv4' || normalized.kind === 'ipv6' || normalized.kind === 'invalid') {
-    if (isBlockedIp(host, policy)) {
+    if (isBlockedIp(host, effectivePolicy)) {
       throw new Error(
         `DATABASE_URL host "${host}" is a blocked internal/metadata address (egress policy: ${policy}).`,
       );
@@ -307,7 +348,7 @@ export async function resolveAllowedHostAddresses(
     throw new Error(`DATABASE_URL host "${host}" could not be resolved: ${msg}`);
   }
   for (const { address } of addresses) {
-    if (isBlockedIp(address, policy)) {
+    if (isBlockedIp(address, effectivePolicy)) {
       throw new Error(
         `DATABASE_URL host "${host}" resolves to a blocked internal/metadata address (${address}, egress policy: ${policy}).`,
       );
@@ -368,6 +409,7 @@ export async function assertConnectionStringAllowed(
   connectionString: string,
   policy: DbEgressPolicy,
   lookup: HostLookup = defaultLookup,
+  allowedHosts: readonly string[] = [],
 ): Promise<void> {
   const hosts = extractDbHosts(connectionString);
   if (hosts.length === 0) {
@@ -378,7 +420,7 @@ export async function assertConnectionStringAllowed(
   }
   for (const host of hosts) {
     if (policy === 'allow-private' && normalizeIpLiteral(host).kind === 'not-ip') continue;
-    await assertHostAllowed(host, policy, lookup);
+    await assertHostAllowed(host, policy, lookup, allowedHosts);
   }
 }
 
@@ -476,6 +518,7 @@ export function requiredTlsMode(connectionString: string): string {
 export async function resolvePinnedDbHosts(
   connectionString: string,
   lookup: HostLookup = defaultLookup,
+  allowedHosts: readonly string[] = [],
 ): Promise<Map<string, string>> {
   const hosts = extractDbHosts(connectionString);
   if (hosts.length === 0) {
@@ -483,7 +526,15 @@ export async function resolvePinnedDbHosts(
   }
   const pinned = new Map<string, string>();
   for (const host of hosts) {
-    const addresses = await resolveAllowedHostAddresses(host, 'block-private', lookup);
+    // An allowlisted host is still RESOLVED AND PINNED — the exemption widens
+    // which addresses are acceptable, never whether the socket is nailed to the
+    // validated one, so DNS-rebind stays closed for exempted hosts too.
+    const addresses = await resolveAllowedHostAddresses(
+      host,
+      'block-private',
+      lookup,
+      allowedHosts,
+    );
     const first = addresses[0];
     if (first === undefined) {
       throw new Error(`DATABASE_URL host "${host}" produced no usable address.`);
@@ -565,12 +616,13 @@ export async function buildDbEgressHardening(
   policy: DbEgressPolicy,
   lookup: HostLookup = defaultLookup,
   makeSocket: MakeSocket = defaultMakeSocket,
+  allowedHosts: readonly string[] = [],
 ): Promise<DbEgressHardening> {
   if (policy !== 'block-private') {
-    await assertConnectionStringAllowed(connectionString, policy, lookup);
+    await assertConnectionStringAllowed(connectionString, policy, lookup, allowedHosts);
     return {};
   }
   const ssl = requiredTlsMode(connectionString);
-  const pinned = await resolvePinnedDbHosts(connectionString, lookup);
+  const pinned = await resolvePinnedDbHosts(connectionString, lookup, allowedHosts);
   return { ssl, socket: createPinnedSocketFactory(pinned, makeSocket) };
 }

--- a/packages/connectors/src/postgres.ts
+++ b/packages/connectors/src/postgres.ts
@@ -276,13 +276,11 @@ const POOL_OPTS = {
 
 /**
  * SSRF/egress pre-flight + guarded pool, run before any socket opens on sync(),
- * query(), and search(). Policy comes from ctx.config.LOBU_DB_EGRESS_POLICY —
- * the server injects `block-private` under cloud mode; everything else defaults
- * to the trusted `allow-private`. Under block-private the guard's option
- * overrides make the validation stick: forced TLS (sslmode=disable rejected)
- * and a `socket` factory that dials the guard-validated IP so the driver never
- * re-resolves DNS (rebind TOCTOU closed). Under allow-private the overrides are
- * empty — native driver behavior. The overrides land AFTER POOL_OPTS so nothing
+ * query(), and search(). The server injects `block-private` under cloud mode
+ * plus any operator host exemptions; everything else defaults to trusted
+ * `allow-private`. Under block-private the guard forces TLS and installs a
+ * socket factory that dials the validated IP, closing DNS-rebind TOCTOU. Under
+ * allow-private the overrides are empty. They land after POOL_OPTS so nothing
  * can shadow them. `socket` isn't in postgres.js's published Options type
  * (supported since 3.4: connection.js `options.socket`), hence the cast.
  */

--- a/packages/connectors/src/postgres.ts
+++ b/packages/connectors/src/postgres.ts
@@ -43,7 +43,7 @@ import {
   type SyncResult,
 } from '@lobu/connector-sdk';
 import postgres from 'postgres';
-import { buildDbEgressHardening, readEgressPolicy } from './db-egress-guard.js';
+import { buildDbEgressHardening, parseAllowedHosts, readEgressPolicy } from './db-egress-guard.js';
 
 interface PgQueryConfig {
   /** ONE read-only base SELECT. No WHERE-cursor / ORDER BY / top-level LIMIT — the connector wraps it. */
@@ -293,6 +293,9 @@ async function openGuardedPool(
   const hardening = await buildDbEgressHardening(
     connectionString,
     readEgressPolicy(config.LOBU_DB_EGRESS_POLICY),
+    undefined,
+    undefined,
+    parseAllowedHosts(config.LOBU_DB_EGRESS_ALLOW_HOSTS),
   );
   return postgres(connectionString, {
     ...POOL_OPTS,

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -122,6 +122,13 @@ export const PollResponseSchema = Type.Object({
   db_egress_policy: Type.Optional(
     Type.Union([Type.Literal("block-private"), Type.Literal("allow-private")])
   ),
+  /**
+   * Operator-configured exact hosts (comma-separated) exempt from the private-IP
+   * range check under `block-private` — e.g. a Tailscale/CGNAT DB. Travels the
+   * same gateway-authoritative channel as `db_egress_policy` and REPLACES any
+   * worker-local list. Never exempts metadata/link-local/multicast.
+   */
+  db_egress_allow_hosts: Type.Optional(Type.String()),
   checkpoint: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
   entity_ids: Type.Optional(Type.Array(Type.Integer())),
   credentials: Type.Optional(Type.Union([OAuthCredentialsSchema, Type.Null()])),

--- a/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
@@ -157,13 +157,15 @@ describe('pollWorkerJob — gateway is authoritative for the egress policy', () 
   });
   afterEach(() => {
     process.env.LOBU_CLOUD_MODE = undefined;
+    delete process.env.LOBU_DB_EGRESS_ALLOW_HOSTS;
   });
 
-  it('stamps block-private on the poll response under LOBU_CLOUD_MODE (worker cannot re-derive it)', async () => {
+  it('stamps the gateway egress config on the poll response under LOBU_CLOUD_MODE', async () => {
     const { feedId, connId, orgId } = await setupPostgresFeed();
     const runId = await insertPendingPostgresRun(orgId, feedId, connId);
 
     process.env.LOBU_CLOUD_MODE = '1';
+    process.env.LOBU_DB_EGRESS_ALLOW_HOSTS = '100.127.177.56';
     try {
       const res = await post('/api/workers/poll', {
         body: { worker_id: 'cloud-policy-worker', capabilities: { db_egress_hardening: true } },
@@ -174,16 +176,19 @@ describe('pollWorkerJob — gateway is authoritative for the egress policy', () 
       const body = (await res.json()) as {
         run_id?: number;
         db_egress_policy?: string;
+        db_egress_allow_hosts?: string;
         config?: Record<string, unknown>;
       };
       expect(Number(body.run_id)).toBe(runId);
-      // The gateway decides the policy on a dedicated top-level field — the
-      // worker's own env must not. It is NOT in tenant `config` (which a tenant
-      // controls), so the worker can install it as authoritative job.env.
+      // Both controls use dedicated top-level fields, outside tenant `config`,
+      // so the worker can install them as authoritative job.env.
       expect(body.db_egress_policy).toBe('block-private');
+      expect(body.db_egress_allow_hosts).toBe('100.127.177.56');
       expect(body.config?.LOBU_DB_EGRESS_POLICY).toBeUndefined();
+      expect(body.config?.LOBU_DB_EGRESS_ALLOW_HOSTS).toBeUndefined();
     } finally {
       process.env.LOBU_CLOUD_MODE = undefined;
+      delete process.env.LOBU_DB_EGRESS_ALLOW_HOSTS;
     }
   });
 

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -11,7 +11,7 @@ import { executeCompiledConnector } from '@lobu/connector-worker/executor/runtim
 import { compileConnectionRowVisibility } from '../authz/connection-visibility';
 import type { AuthzScope } from '../authz/scope';
 import { getDb } from '../db/client';
-import { isCloudMode } from '../utils/cloud-mode';
+import { dbEgressConfig } from '../utils/cloud-mode';
 import { assertConnectorAllowedInCloud } from '../utils/connector-cloud-gate';
 import { resolveConnectorCodeForKey } from '../utils/ensure-connector-installed';
 import { resolveExecutionAuth } from '../utils/execution-context';
@@ -105,7 +105,7 @@ export async function runConnectorQuery(p: ConnectorQueryParams): Promise<Connec
       config: {
         ...connectionCredentials,
         ...(p.config ?? {}),
-        LOBU_DB_EGRESS_POLICY: isCloudMode() ? 'block-private' : 'allow-private',
+        ...dbEgressConfig(),
       },
       env: {},
       sessionState,
@@ -233,7 +233,7 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
   const config = {
     ...connectionCredentials,
     ...feedConfig,
-    LOBU_DB_EGRESS_POLICY: isCloudMode() ? 'block-private' : 'allow-private',
+    ...dbEgressConfig(),
   };
 
   const terms = (p.terms ?? []).map((t) => t.trim()).filter(Boolean);

--- a/packages/server/src/lib/feed-sync.ts
+++ b/packages/server/src/lib/feed-sync.ts
@@ -6,7 +6,7 @@
 
 import { executeCompiledConnector } from '@lobu/connector-worker/executor/runtime';
 import { getDb, parsePgNumberArray } from '../db/client';
-import { isCloudMode } from '../utils/cloud-mode';
+import { dbEgressConfig } from '../utils/cloud-mode';
 import { assertConnectorAllowedInCloud } from '../utils/connector-cloud-gate';
 import { resolveConnectorCode } from '../utils/ensure-connector-installed';
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';
@@ -144,7 +144,7 @@ export async function runFeed(feed: FeedRecord): Promise<{ itemCount: number }> 
         // Authoritative egress policy (injected last): a DB connector rejects
         // internal/metadata hosts under cloud mode, reaches its own private DB
         // self-hosted. process.env is passed below but doesn't carry this key.
-        LOBU_DB_EGRESS_POLICY: isCloudMode() ? 'block-private' : 'allow-private',
+        ...dbEgressConfig(),
       },
       checkpoint: feed.checkpoint,
       env: process.env as Record<string, string | undefined>,

--- a/packages/server/src/lib/feed-sync.ts
+++ b/packages/server/src/lib/feed-sync.ts
@@ -141,9 +141,8 @@ export async function runFeed(feed: FeedRecord): Promise<{ itemCount: number }> 
       mode: 'sync',
       config: {
         ...mergeExecutionConfig(feed.connection_config, connectionCredentials, feed.config),
-        // Authoritative egress policy (injected last): a DB connector rejects
-        // internal/metadata hosts under cloud mode, reaches its own private DB
-        // self-hosted. process.env is passed below but doesn't carry this key.
+        // Authoritative egress config (injected last): cloud policy plus global
+        // operator host exemptions cannot be overridden by connection config.
         ...dbEgressConfig(),
       },
       checkpoint: feed.checkpoint,

--- a/packages/server/src/utils/cloud-mode.ts
+++ b/packages/server/src/utils/cloud-mode.ts
@@ -14,3 +14,25 @@ export function isCloudMode(): boolean {
   const v = raw.trim().toLowerCase();
   return v === '1' || v === 'true' || v === 'yes';
 }
+
+/**
+ * The DB egress config a connector run is authoritatively given: the policy plus
+ * the operator's exact-match allow-host list.
+ *
+ * Both keys are OPERATOR deployment config read from the gateway's own env, and
+ * both are injected LAST over tenant-supplied connection config so a tenant can
+ * never widen its own egress boundary. `LOBU_DB_EGRESS_ALLOW_HOSTS` is a
+ * comma-separated list of exact hosts (IP literal or DNS name as written in
+ * DATABASE_URL) that stay reachable under cloud mode — e.g. a Tailscale/CGNAT
+ * address — while metadata, link-local, multicast and unspecified remain blocked
+ * for every host regardless.
+ */
+export function dbEgressConfig(): {
+  LOBU_DB_EGRESS_POLICY: 'block-private' | 'allow-private';
+  LOBU_DB_EGRESS_ALLOW_HOSTS: string;
+} {
+  return {
+    LOBU_DB_EGRESS_POLICY: isCloudMode() ? 'block-private' : 'allow-private',
+    LOBU_DB_EGRESS_ALLOW_HOSTS: process.env.LOBU_DB_EGRESS_ALLOW_HOSTS ?? '',
+  };
+}

--- a/packages/server/src/utils/cloud-mode.ts
+++ b/packages/server/src/utils/cloud-mode.ts
@@ -22,10 +22,9 @@ export function isCloudMode(): boolean {
  * Both keys are OPERATOR deployment config read from the gateway's own env, and
  * both are injected LAST over tenant-supplied connection config so a tenant can
  * never widen its own egress boundary. `LOBU_DB_EGRESS_ALLOW_HOSTS` is a
- * comma-separated list of exact hosts (IP literal or DNS name as written in
- * DATABASE_URL) that stay reachable under cloud mode — e.g. a Tailscale/CGNAT
- * address — while metadata, link-local, multicast and unspecified remain blocked
- * for every host regardless.
+ * comma-separated list of exact bare hosts (IPv6 without URL brackets) that
+ * stay reachable under cloud mode — e.g. a Tailscale/CGNAT address — while
+ * metadata, link-local, multicast and unspecified remain blocked for every host.
  */
 export function dbEgressConfig(): {
   LOBU_DB_EGRESS_POLICY: 'block-private' | 'allow-private';

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -923,6 +923,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     // `config`) so the worker installs it as authoritative `job.env` and takes the
     // STRICTER of gateway-vs-worker; block-private can never be downgraded.
     db_egress_policy: isCloudMode() ? 'block-private' : 'allow-private',
+    // Operator allow-host list rides the SAME authoritative channel as the
+    // policy: exact hosts that stay reachable under block-private. Never from
+    // tenant config, and it never exempts metadata/link-local.
+    db_egress_allow_hosts: process.env.LOBU_DB_EGRESS_ALLOW_HOSTS || undefined,
     checkpoint: row.checkpoint ?? undefined,
     entity_ids: row.feed_entity_ids ?? undefined,
     credentials,


### PR DESCRIPTION
## Why

`block-private` (injected under `LOBU_CLOUD_MODE`) rejects every non-public address. That makes a first-party database on a private/CGNAT address — e.g. one reached over Tailscale — unreachable from a cloud gateway, with no way to make an exception. The per-org allowlist the guard header defers to is the only escape hatch described anywhere, and it doesn't exist.

Measured, not assumed: connecting `app.lobu.ai` to a Postgres on `100.127.177.56` fails in prod today. CGNAT `100.64.0.0/10` is in `BLOCK_PRIVATE_V4` and deliberately absent from `ALLOW_PRIVATE_V4`, so the block is by design — there was just no lever.

## What

`LOBU_DB_EGRESS_ALLOW_HOSTS`: a comma-separated list of **exact** hosts (IP literal or DNS name, as written in `DATABASE_URL`) exempt from the private-range check while cloud mode stays on for everything else.

Operator deployment config only. It's read from the gateway's own env and injected over tenant connection config, so a tenant can never widen its own boundary.

## Boundaries preserved

- **An exemption drops the host to the `allow-private` floor, never below it.** Metadata/link-local, unspecified, multicast and reserved stay blocked for allowlisted and ordinary hosts alike. This is a destination exemption, not an SSRF off-switch — allowlisting a name whose DNS answer is `169.254.169.254` still fails.
- **Exact match only.** No wildcards, no CIDRs, no ports, no IPv6 brackets — all four are rejected at parse time with a message naming the fix, rather than silently never matching. Approving one tailnet host never approves `100.64.0.0/10`.
- **Allowlisted hosts are still resolved AND pinned, and TLS is still forced.** The exemption widens which addresses are acceptable, never whether the socket is nailed to the validated one, so DNS-rebind stays closed.
- **The list rides the same gateway-authoritative channel as `db_egress_policy`** (poll response → `resolveEffectiveEnv` → `GATEWAY_AUTHORITATIVE_CONFIG_KEYS`) and **REPLACES** any worker-local value rather than unioning with it. Unioning would let a compromised fleet worker widen its own boundary — the exact downgrade the existing policy ratchet prevents.

Also consolidates the two duplicated `LOBU_DB_EGRESS_POLICY: isCloudMode() ? …` call sites behind one `dbEgressConfig()` helper, so policy and allow-list can't drift apart.

## Testing

- **Red→green** on both new suites: the guard tests fail on `parseAllowedHosts` not existing, the validation tests fail on the missing check, then pass.
- **293 pass / 0 fail** across the connectors + connector-worker suites.
- **7 pass / 0 fail** on the DB-backed `postgres-sync-cloud-gate` integration test, including the assertion that neither control leaks into tenant `config`.
- Negatives specifically covered: a non-allowlisted private host still blocked; metadata blocked *even when explicitly allowlisted*; an allowlisted name resolving to metadata still rejected; a tenant config unable to beat the gateway list; a worker unable to add entries.
- `make pre-pr` clean.

## Deploy note

The env var is inert until this ships — the code that reads it has to be in the image first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->