### PR TITLE
feat(provenance): route a Behavior's run link to its drill-down

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -314,8 +314,10 @@ describe("manage_entity merge action", () => {
 		expect(run.watcher_id).toBeNull();
 	});
 
-	it("records a behavior initiator consistent with the legacy watcher columns", async () => {
-		const org = await createTestOrganization({ name: "Initiator Behavior Org" });
+	it("keeps a behavior initiator's drill-down link when another caller reuses the run", async () => {
+		const org = await createTestOrganization({
+			name: "Initiator Behavior Org",
+		});
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		const { winner, loser } = await twoEntities(org.id, user.id);
@@ -336,10 +338,14 @@ describe("manage_entity merge action", () => {
 			{
 				...ctx(org.id, user.id, "owner"),
 				userId: null,
-				agentId: "personal-agent",
 				actingWatcherId: 6021,
+				baseUrl: "https://app.lobu.test",
 			} as ToolContext,
-		)) as unknown as { approval_queued: boolean; approval_run_id: number };
+		)) as unknown as {
+			approval_queued: boolean;
+			approval_run_id: number;
+			approval_url: string;
+		};
 
 		const [run] = await sql`
 			SELECT initiator_kind, initiator_ref, watcher_id
@@ -348,6 +354,20 @@ describe("manage_entity merge action", () => {
 		expect(run.initiator_kind).toBe("behavior");
 		expect((run.initiator_ref as { watcher_id: number }).watcher_id).toBe(6021);
 		expect(Number(run.watcher_id)).toBe(6021);
+		const expectedUrl = `https://app.lobu.test/${org.slug}/memory?agent=personal-agent&behavior=6021&run_ids=${queued.approval_run_id}`;
+		expect(queued.approval_url).toBe(expectedUrl);
+
+		const replay = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				agentId: "personal-agent",
+				baseUrl: "https://app.lobu.test",
+			} as ToolContext,
+		)) as unknown as { approval_run_id: number; approval_url: string };
+		expect(replay.approval_run_id).toBe(queued.approval_run_id);
+		expect(replay.approval_url).toBe(expectedUrl);
 	});
 
 	it("does not let a caller-supplied behavior_source forge the initiator", async () => {

--- a/packages/server/src/__tests__/unit/run-initiator.test.ts
+++ b/packages/server/src/__tests__/unit/run-initiator.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveRunInitiator } from "../../tools/initiator";
+import {
+	resolveRunInitiator,
+	runPermalinkResource,
+} from "../../tools/initiator";
 
 describe("resolveRunInitiator", () => {
 	it("records the agent session, client, and authorizing human", () => {
@@ -56,5 +59,65 @@ describe("resolveRunInitiator", () => {
 			initiatorRef: {},
 			createdByUserId: null,
 		});
+	});
+});
+
+describe("runPermalinkResource", () => {
+	const behavior = {
+		initiatorKind: "behavior",
+		initiatorRef: { watcher_id: 42, window_id: 7, run_id: 99 },
+	};
+
+	it("sends a Behavior's run to that Behavior's drill-down", () => {
+		expect(runPermalinkResource(behavior, 500, "personal-agent")).toEqual({
+			kind: "behavior_run",
+			runId: 500,
+			agentId: "personal-agent",
+			behaviorId: 42,
+		});
+	});
+
+	it("falls back to the workspace log when the owning agent is unknown", () => {
+		expect(runPermalinkResource(behavior, 500, null)).toEqual({
+			kind: "run",
+			runId: 500,
+		});
+	});
+
+	it("leaves non-Behavior runs on the workspace log", () => {
+		expect(
+			runPermalinkResource(
+				{
+					initiatorKind: "agent_session",
+					initiatorRef: { agent_id: "personal-agent" },
+				},
+				500,
+				"personal-agent",
+			),
+		).toEqual({ kind: "run", runId: 500 });
+	});
+
+	it("falls back for runs recorded before provenance existed", () => {
+		expect(runPermalinkResource({}, 500, "personal-agent")).toEqual({
+			kind: "run",
+			runId: 500,
+		});
+	});
+
+	it.each([
+		null,
+		"",
+		0,
+		-1,
+		1.5,
+		"not-a-number",
+	])("falls back when a behavior ref carries watcher id %j", (watcherId) => {
+		expect(
+			runPermalinkResource(
+				{ initiatorKind: "behavior", initiatorRef: { watcher_id: watcherId } },
+				500,
+				"personal-agent",
+			),
+		).toEqual({ kind: "run", runId: 500 });
 	});
 });

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -13,8 +13,8 @@ import {
 	type ApprovalAttribution as ApprovalAttributionType,
 } from "@lobu/core/contracts/interaction-envelope";
 import { resolveEntityApprovalPolicy } from "../../authz/entity-policy";
-import { assertResolutionFingerprintCurrent } from "../../entity-resolution/staleness";
 import { type DbClient, getDb, pgBigintArray } from "../../db/client";
+import { assertResolutionFingerprintCurrent } from "../../entity-resolution/staleness";
 import type { Env } from "../../index";
 import {
 	formatFieldChangeAction,
@@ -38,7 +38,7 @@ import {
 	buildEntityUrl,
 	buildResourcePermalink,
 } from "../../utils/url-builder";
-import { resolveRunInitiator } from "../initiator";
+import { resolveRunInitiator, runPermalinkResource } from "../initiator";
 import type { ToolContext } from "../registry";
 import { getOrgUrlContext } from "../view-urls";
 
@@ -785,13 +785,33 @@ export async function proposeEntityChange(
 	});
 	const { runId, eventId } = persisted;
 
+	const [permalinkRun] = await sql<{
+		initiator_kind: string | null;
+		initiator_ref: Record<string, unknown> | null;
+		initiator_agent_id: string | null;
+	}>`
+		SELECT r.initiator_kind, r.initiator_ref, w.agent_id AS initiator_agent_id
+		FROM runs r
+		LEFT JOIN watchers w
+			ON w.id = r.watcher_id AND w.organization_id = r.organization_id
+		WHERE r.id = ${runId} AND r.organization_id = ${ctx.organizationId}
+	`;
 	const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
 	// Run-scoped: the pending event is superseded on approve→complete; a run link
 	// stays valid across the chain. (Read-side content_ids resolution also covers
 	// the event id below, carried for the notification's resourceId.)
+	// A Behavior-initiated proposal lands on that Behavior's drill-down instead
+	// of the workspace-wide log, so the link answers where it came from.
 	const approvalUrl = buildResourcePermalink(
 		ownerSlug,
-		{ kind: "run", runId },
+		runPermalinkResource(
+			{
+				initiatorKind: permalinkRun?.initiator_kind,
+				initiatorRef: permalinkRun?.initiator_ref,
+			},
+			runId,
+			permalinkRun?.initiator_agent_id,
+		),
 		baseUrl,
 	);
 	if (persisted.reused) return { runId, eventId, approvalUrl };

--- a/packages/server/src/tools/initiator.ts
+++ b/packages/server/src/tools/initiator.ts
@@ -1,3 +1,4 @@
+import type { MemoryResource } from "../utils/url-builder";
 import type { ToolContext } from "./registry";
 
 /**
@@ -61,5 +62,35 @@ export function resolveRunInitiator(ctx: InitiatorSource): RunInitiatorColumns {
 		initiatorKind: "system",
 		initiatorRef: {},
 		createdByUserId: null,
+	};
+}
+
+/** Map persisted provenance to a run link, falling back if the route is incomplete. */
+export function runPermalinkResource(
+	initiator: {
+		initiatorKind?: string | null;
+		initiatorRef?: Record<string, unknown> | null;
+	},
+	runId: number,
+	ownerAgentId: string | null | undefined,
+): MemoryResource {
+	if (initiator.initiatorKind !== "behavior" || !ownerAgentId) {
+		return { kind: "run", runId };
+	}
+	// Reject the empty cases before coercing: Number(null) and Number("") are
+	// both 0, a valid-looking id that would build a link to "Behavior 0".
+	const rawBehaviorId = initiator.initiatorRef?.watcher_id;
+	if (rawBehaviorId == null || rawBehaviorId === "") {
+		return { kind: "run", runId };
+	}
+	const behaviorId = Number(rawBehaviorId);
+	if (!Number.isSafeInteger(behaviorId) || behaviorId <= 0) {
+		return { kind: "run", runId };
+	}
+	return {
+		kind: "behavior_run",
+		runId,
+		agentId: ownerAgentId,
+		behaviorId,
 	};
 }

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -299,6 +299,18 @@ describe('buildResourcePermalink', () => {
     ).toBe('https://app.lobu.com/acme/memory?run_ids=536620');
   });
 
+  it('behavior run kind → agent and behavior drill-down scoped to the run', () => {
+    expect(
+      buildResourcePermalink(
+        'acme',
+        { kind: 'behavior_run', runId: 536620, agentId: 'agent/one', behaviorId: 42 },
+        'https://app.lobu.com'
+      )
+    ).toBe(
+      'https://app.lobu.com/acme/memory?agent=agent%2Fone&behavior=42&run_ids=536620'
+    );
+  });
+
   it('event kind → ?content_ids (chain-resolved on read)', () => {
     expect(
       buildResourcePermalink('acme', { kind: 'event', eventId: 4309390 }, 'https://app.lobu.com')

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -322,9 +322,12 @@ export function buildConnectionUrl(
  *    (get_content) resolves a superseded id to its full lineage, so a frozen
  *    event permalink still lands even after it's superseded.
  *  - `feed`  — a channel / conversational stream (all activity in #leads).
+ *  - `behavior_run` — one execution scoped to its Behavior drill-down. Requires
+ *    both route identifiers: the owning agent and the Behavior.
  */
 export type MemoryResource =
   | { kind: 'run'; runId: number }
+  | { kind: 'behavior_run'; runId: number; agentId: string; behaviorId: number }
   | { kind: 'event'; eventId: number }
   | { kind: 'feed'; feedId: number };
 
@@ -333,6 +336,8 @@ function memoryResourceQuery(resource: MemoryResource): string {
   switch (resource.kind) {
     case 'run':
       return `run_ids=${resource.runId}`;
+    case 'behavior_run':
+      return `agent=${encodeURIComponent(resource.agentId)}&behavior=${resource.behaviorId}&run_ids=${resource.runId}`;
     case 'event':
       return `content_ids=${resource.eventId}`;
     case 'feed':
@@ -342,7 +347,7 @@ function memoryResourceQuery(resource: MemoryResource): string {
 
 /**
  * Build a permalink into the memory/events log for a {@link MemoryResource}.
- * Pattern: /{ownerSlug}/memory?{run_ids|content_ids|feed_ids}={id}
+ * Pattern: /{ownerSlug}/memory?<resource query>
  *
  * This is the ONE place a memory permalink is assembled. `ownerSlug` empty →
  * returns undefined (no org context, can't build a usable link).


### PR DESCRIPTION
Stacked on #2152 — it needs the `initiator_kind`/`initiator_ref` columns and `resolveRunInitiator`. Base it there, or merge #2152 first and this retargets to main.

## The gap

Every run permalink went to the workspace-wide memory log — `/{owner}/memory?run_ids=<id>` for every run, regardless of what produced it. That answers "what happened" but not "where did this come from", which is exactly what you noticed clicking a Run # link earlier: it shows memory, not the thing that caused it.

## The change

`MemoryResource` gains a `behavior_run` variant. When a proposal's initiator is a Behavior, the approval link now routes to that Behavior's drill-down (`?agent&behavior&run_ids`) instead of the flat log — using plumbing that already exists at `memory-home-pane.tsx:141-149`. The URL shape is still decided in the one place the doc comment promises (`memoryResourceQuery`).

Only possible now that runs record their initiator (#2152's provenance work).

## Two things worth calling out

**The link is read back from the persisted run, not the incoming context.** `proposeEntityChange` is idempotent — a replayed proposal reuses the existing run. If the link were derived from the current caller, a replay would relabel it with whoever replayed it last. So it's read from the run row (joining `watchers` for the owning agent), and a test proves it: a Behavior creates the run, an agent replays the same change, the link still points at the Behavior's drill-down.

**Fails safe.** Falls back to the plain run slice whenever the drill-down route can't be built in full — no initiator (runs predating provenance), a non-Behavior initiator, or an unresolved owning agent. The route needs both ids; a half-built link is worse than the general one. A test also pins that a null/empty watcher id doesn't coerce to "Behavior 0" (`Number(null) === 0`).

## Evidence

run-initiator unit 14/14 · url-builder 12/12 (incl. the new `behavior_run` URL-shape + agent-id encoding case) · merge-tool 22/22 (incl. the replay-stability test). `make pre-pr` clean.

## Not verified

The generated URL matches what `memory-home-pane.tsx` reads by inspection, but no one has clicked one in a running app — that's the one check tests can't close. Worth doing before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval links now preserve behavior drill-down context, including the related agent and behavior.
  * Reused queued runs retain the same approval link and run identifier.
  * Permalinks support behavior-specific run details while safely falling back to standard run links when context is unavailable.
* **Bug Fixes**
  * Fixed approval-link generation to retain the original run initiator context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->