### PR TITLE
fix(chat): retire streaming feeds when their connection is tombstoned

### DIFF
--- a/db/migrations/20260723190000_retire_streaming_feeds_on_connection_delete.sql
+++ b/db/migrations/20260723190000_retire_streaming_feeds_on_connection_delete.sql
@@ -9,12 +9,12 @@
 -- already accumulated, but did not prevent new orphans.
 --
 -- This closes the leak at the source: a streaming feed cannot outlive its
--- connection. The moment a connection is tombstoned, its streaming feeds are
--- retired in the same transaction — the exact companion to the existing
+-- connection. Existing feeds are retired in the tombstone transaction, and a
+-- feed-side guard retires a streaming feed written after its connection is
+-- already dead. The connection trigger is the companion to the existing
 -- `archive_chat_behaviors_for_deleted_connection` trigger, which already archives
--- the chat-link Behaviors on the same event. A DB trigger (not the app-level
--- reconciler) is deliberate: it fires for every path that updates the connection
--- tombstone, so the invariant does not depend on each caller reconciling feeds.
+-- the chat-link Behaviors on the same event. DB triggers are deliberate: every
+-- writer gets the same invariant without app-level reconciliation.
 --
 -- Matches `softDeleteStreamingChannelFeed` semantics exactly (deleted_at + paused)
 -- so trigger-retired and app-retired rows are indistinguishable. Only `streaming`
@@ -46,6 +46,42 @@ FOR EACH ROW
 WHEN (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL)
 EXECUTE FUNCTION retire_streaming_feeds_for_deleted_connection();
 
+-- Serialize live streaming-feed writes with connection tombstones. Without the
+-- row lock, a concurrent INSERT could be invisible to the connection trigger
+-- and commit after it, recreating the orphan on another replica.
+CREATE OR REPLACE FUNCTION guard_streaming_feed_connection()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $guard$
+DECLARE
+  connection_deleted_at timestamptz;
+BEGIN
+  IF NEW.kind <> 'streaming' OR NEW.deleted_at IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT deleted_at
+  INTO connection_deleted_at
+  FROM connections
+  WHERE id = NEW.connection_id
+  FOR SHARE;
+
+  IF FOUND AND connection_deleted_at IS NOT NULL THEN
+    NEW.deleted_at = current_timestamp;
+    NEW.status = 'paused';
+    NEW.updated_at = current_timestamp;
+  END IF;
+  RETURN NEW;
+END
+$guard$;
+
+DROP TRIGGER IF EXISTS guard_streaming_feed_connection
+  ON feeds;
+CREATE TRIGGER guard_streaming_feed_connection
+BEFORE INSERT OR UPDATE OF connection_id, kind, deleted_at ON feeds
+FOR EACH ROW
+EXECUTE FUNCTION guard_streaming_feed_connection();
+
 -- Backfill: retire streaming feeds still live on already-tombstoned connections.
 -- The prior one-shot only retired rows that had a live in-org duplicate; this
 -- retires the rest, since none of them can route (their connection is dead). Runs
@@ -61,6 +97,10 @@ WHERE f.deleted_at IS NULL
   AND dead.deleted_at IS NOT NULL;
 
 -- migrate:down
+
+DROP TRIGGER IF EXISTS guard_streaming_feed_connection
+  ON feeds;
+DROP FUNCTION IF EXISTS guard_streaming_feed_connection();
 
 DROP TRIGGER IF EXISTS retire_streaming_feeds_for_deleted_connection
   ON connections;

--- a/db/migrations/20260723190000_retire_streaming_feeds_on_connection_delete.sql
+++ b/db/migrations/20260723190000_retire_streaming_feeds_on_connection_delete.sql
@@ -2,26 +2,23 @@
 --
 -- A streaming feed is keyed by the numeric `connections.id` and, until now, was
 -- soft-deleted only on an explicit Behavior unlink (`softDeleteStreamingChannelFeed`)
--- — nothing retired it when its *connection* died. So every time a connection was
--- retired (e.g. a Slack Grid workspace re-installed under a different tenant key,
--- which mints a new connection and tombstones the old one), the previous
--- generation's streaming feed stayed LIVE pointing at a dead row. One leaked per
--- retirement; `20260723160000_retire_leaked_chat_feeds.sql` mopped up the rows that
--- had already accumulated in prod, but did nothing to stop the next one.
+-- — nothing retired it when its *connection* died. When a connection was retired
+-- (for example, when a Slack Grid workspace was re-installed under a different
+-- tenant key), its streaming feeds stayed LIVE pointing at a dead row.
+-- `20260723160000_retire_leaked_chat_feeds.sql` cleaned up duplicate rows that had
+-- already accumulated, but did not prevent new orphans.
 --
 -- This closes the leak at the source: a streaming feed cannot outlive its
 -- connection. The moment a connection is tombstoned, its streaming feeds are
 -- retired in the same transaction — the exact companion to the existing
 -- `archive_chat_behaviors_for_deleted_connection` trigger, which already archives
 -- the chat-link Behaviors on the same event. A DB trigger (not the app-level
--- reconciler) is deliberate: it fires no matter how the connection was tombstoned
--- — tool call, admin SQL, or cascade — so the invariant holds without every code
--- path having to remember to reconcile.
+-- reconciler) is deliberate: it fires for every path that updates the connection
+-- tombstone, so the invariant does not depend on each caller reconciling feeds.
 --
 -- Matches `softDeleteStreamingChannelFeed` semantics exactly (deleted_at + paused)
 -- so trigger-retired and app-retired rows are indistinguishable. Only `streaming`
--- feeds are touched: collected/virtual feeds on a retired connection are handled by
--- their own lifecycles and are out of scope here.
+-- feeds are touched; collected and virtual feeds are unchanged.
 
 -- migrate:up
 
@@ -69,5 +66,5 @@ DROP TRIGGER IF EXISTS retire_streaming_feeds_for_deleted_connection
   ON connections;
 DROP FUNCTION IF EXISTS retire_streaming_feeds_for_deleted_connection();
 
--- The backfill is data cleanup: retired rows only duplicated dead connections, so
--- restoring them would only re-create the leak. Not reversed.
+-- The backfill is data cleanup. Restoring those feeds while their connections
+-- remain tombstoned would violate the invariant, so it is not reversed.

--- a/db/migrations/20260723190000_retire_streaming_feeds_on_connection_delete.sql
+++ b/db/migrations/20260723190000_retire_streaming_feeds_on_connection_delete.sql
@@ -1,0 +1,73 @@
+-- Retire a connection's streaming (chat) feeds when the connection is tombstoned.
+--
+-- A streaming feed is keyed by the numeric `connections.id` and, until now, was
+-- soft-deleted only on an explicit Behavior unlink (`softDeleteStreamingChannelFeed`)
+-- — nothing retired it when its *connection* died. So every time a connection was
+-- retired (e.g. a Slack Grid workspace re-installed under a different tenant key,
+-- which mints a new connection and tombstones the old one), the previous
+-- generation's streaming feed stayed LIVE pointing at a dead row. One leaked per
+-- retirement; `20260723160000_retire_leaked_chat_feeds.sql` mopped up the rows that
+-- had already accumulated in prod, but did nothing to stop the next one.
+--
+-- This closes the leak at the source: a streaming feed cannot outlive its
+-- connection. The moment a connection is tombstoned, its streaming feeds are
+-- retired in the same transaction — the exact companion to the existing
+-- `archive_chat_behaviors_for_deleted_connection` trigger, which already archives
+-- the chat-link Behaviors on the same event. A DB trigger (not the app-level
+-- reconciler) is deliberate: it fires no matter how the connection was tombstoned
+-- — tool call, admin SQL, or cascade — so the invariant holds without every code
+-- path having to remember to reconcile.
+--
+-- Matches `softDeleteStreamingChannelFeed` semantics exactly (deleted_at + paused)
+-- so trigger-retired and app-retired rows are indistinguishable. Only `streaming`
+-- feeds are touched: collected/virtual feeds on a retired connection are handled by
+-- their own lifecycles and are out of scope here.
+
+-- migrate:up
+
+CREATE OR REPLACE FUNCTION retire_streaming_feeds_for_deleted_connection()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $retire$
+BEGIN
+  UPDATE feeds
+  SET deleted_at = current_timestamp,
+      status = 'paused',
+      updated_at = current_timestamp
+  WHERE connection_id = NEW.id
+    AND kind = 'streaming'
+    AND deleted_at IS NULL;
+  RETURN NEW;
+END
+$retire$;
+
+DROP TRIGGER IF EXISTS retire_streaming_feeds_for_deleted_connection
+  ON connections;
+CREATE TRIGGER retire_streaming_feeds_for_deleted_connection
+AFTER UPDATE OF deleted_at ON connections
+FOR EACH ROW
+WHEN (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL)
+EXECUTE FUNCTION retire_streaming_feeds_for_deleted_connection();
+
+-- Backfill: retire streaming feeds still live on already-tombstoned connections.
+-- The prior one-shot only retired rows that had a live in-org duplicate; this
+-- retires the rest, since none of them can route (their connection is dead). Runs
+-- after the trigger exists so the invariant is true for existing rows too.
+UPDATE feeds f
+SET deleted_at = current_timestamp,
+    status = 'paused',
+    updated_at = current_timestamp
+FROM connections dead
+WHERE f.deleted_at IS NULL
+  AND f.kind = 'streaming'
+  AND f.connection_id = dead.id
+  AND dead.deleted_at IS NOT NULL;
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS retire_streaming_feeds_for_deleted_connection
+  ON connections;
+DROP FUNCTION IF EXISTS retire_streaming_feeds_for_deleted_connection();
+
+-- The backfill is data cleanup: retired rows only duplicated dead connections, so
+-- restoring them would only re-create the leak. Not reversed.

--- a/packages/server/src/gateway/channels/__tests__/retire-leaked-chat-feeds.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/retire-leaked-chat-feeds.test.ts
@@ -1,10 +1,10 @@
 /**
  * Streaming chat feeds leaked onto retired connections.
  *
- * A streaming feed is keyed by the numeric `connections.id` and is soft-deleted
- * only on an explicit unlink — nothing retires feeds when a connection is. So a
- * workspace re-installed under a different tenant key leaves the previous
- * generation's feed LIVE on a dead connection, one per install.
+ * Before the connection-retirement trigger, a streaming feed was keyed by the
+ * numeric `connections.id` but soft-deleted only on an explicit unlink. A
+ * workspace re-installed under a different tenant key could therefore leave the
+ * previous generation's feeds LIVE on a dead connection.
  *
  * Prod 2026-07-23 (org_lobucrm): feeds 434 and 437 sit live on dead connections
  * for one DM channel while feed 450 serves that channel on the live connection.
@@ -76,17 +76,31 @@ async function insertFeed(
   organizationId = ORG,
   kind = "streaming",
 ): Promise<number> {
-  const rows = await getDb()`
-    INSERT INTO feeds (
-      organization_id, connection_id, feed_key, display_name,
-      status, kind, virtual, config
-    ) VALUES (
-      ${organizationId}, ${connectionId}, ${feedKey}, ${feedKey},
-      'active', ${kind}, false, '{"store":"channel_messages"}'
-    )
-    RETURNING id
-  `;
-  return Number(rows[0].id);
+  return getDb().begin(async (tx) => {
+    if (kind === "streaming") {
+      // This suite replays the earlier cleanup against its historical input.
+      // Disable the later invariant only inside this seed transaction.
+      await tx.unsafe(
+        "ALTER TABLE feeds DISABLE TRIGGER guard_streaming_feed_connection",
+      );
+    }
+    const rows = await tx`
+      INSERT INTO feeds (
+        organization_id, connection_id, feed_key, display_name,
+        status, kind, virtual, config
+      ) VALUES (
+        ${organizationId}, ${connectionId}, ${feedKey}, ${feedKey},
+        'active', ${kind}, false, '{"store":"channel_messages"}'
+      )
+      RETURNING id
+    `;
+    if (kind === "streaming") {
+      await tx.unsafe(
+        "ALTER TABLE feeds ENABLE TRIGGER guard_streaming_feed_connection",
+      );
+    }
+    return Number(rows[0].id);
+  });
 }
 
 async function feedIsLive(feedId: number): Promise<boolean> {
@@ -147,7 +161,7 @@ describe("retiring leaked chat feeds", () => {
   });
 
   test("retires every generation's orphan, not just the newest", async () => {
-    // Prod accumulated one orphan per install; all of them must go.
+    // Seed several retired generations; all duplicates must go.
     const live = await insertConnection({
       slug: "slackinst-live-multi",
       tenantId: "T_WORKSPACE",
@@ -173,8 +187,7 @@ describe("retiring leaked chat feeds", () => {
   });
 
   test("keeps an orphan that is the org's only feed for the channel", async () => {
-    // Retiring this would remove the last feed for the channel rather than a
-    // duplicate — prod has exactly this case in a second organization.
+    // Without a live duplicate, the earlier cleanup deliberately leaves it.
     const dead = await insertConnection({
       slug: "slackinst-only",
       tenantId: "E_ONLY",

--- a/packages/server/src/gateway/channels/__tests__/retire-streaming-feeds-on-connection-delete.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/retire-streaming-feeds-on-connection-delete.test.ts
@@ -1,0 +1,212 @@
+/**
+ * A streaming (chat) feed must not outlive its connection.
+ *
+ * Until the `retire_streaming_feeds_for_deleted_connection` trigger, tombstoning
+ * a connection archived its chat Behaviors but left the derived streaming feeds
+ * LIVE on the dead row — the leak the prior one-shot migration had to mop up. The
+ * trigger closes that: retiring a connection retires its streaming feeds in the
+ * same transaction. These tests drive the trigger through a real tombstone
+ * (`UPDATE connections SET deleted_at = now()`), never by replaying SQL, so they
+ * exercise the actual wiring installed by the migration.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../../db/client.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "../../__tests__/helpers/db-setup.js";
+
+const ORG = "org-streamretire";
+const CHANNEL = "slack:D_RETIRE";
+
+async function insertConnection(opts: {
+  slug: string;
+  live: boolean;
+  credentialMode?: string | null;
+}): Promise<number> {
+  const rows = await getDb()`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      credential_mode, external_tenant_id, config, deleted_at
+    ) VALUES (
+      ${ORG}, 'slack', ${opts.slug}, 'Workspace', 'active',
+      ${opts.credentialMode === undefined ? "managed" : opts.credentialMode},
+      ${opts.slug},
+      '{}', ${opts.live ? null : new Date()}
+    )
+    RETURNING id
+  `;
+  return Number(rows[0].id);
+}
+
+async function insertFeed(
+  connectionId: number,
+  feedKey: string,
+  kind = "streaming",
+): Promise<number> {
+  const rows = await getDb()`
+    INSERT INTO feeds (
+      organization_id, connection_id, feed_key, display_name,
+      status, kind, virtual, config
+    ) VALUES (
+      ${ORG}, ${connectionId}, ${feedKey}, ${feedKey},
+      'active', ${kind}, false, '{"store":"channel_messages"}'
+    )
+    RETURNING id
+  `;
+  return Number(rows[0].id);
+}
+
+/** Tombstone a connection the way the runtime does — the trigger fires on this. */
+async function tombstoneConnection(connectionId: number): Promise<void> {
+  await getDb()`
+    UPDATE connections SET deleted_at = now(), updated_at = now()
+    WHERE id = ${connectionId}
+  `;
+}
+
+async function feedIsLive(feedId: number): Promise<boolean> {
+  const rows = await getDb()`
+    SELECT 1 FROM feeds WHERE id = ${feedId} AND deleted_at IS NULL
+  `;
+  return rows.length > 0;
+}
+
+async function feedStatus(feedId: number): Promise<string | null> {
+  const rows = await getDb()<{ status: string }>`
+    SELECT status FROM feeds WHERE id = ${feedId}
+  `;
+  return rows[0]?.status ?? null;
+}
+
+describe("retiring streaming feeds when a connection is tombstoned", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  });
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedAgentRow("agent-streamretire", { organizationId: ORG });
+  });
+
+  afterAll(async () => {
+    await resetTestDatabase();
+  });
+
+  test("retires a live connection's streaming feed on tombstone", async () => {
+    const conn = await insertConnection({ slug: "slackinst-a", live: true });
+    const feed = await insertFeed(conn, CHANNEL);
+
+    expect(await feedIsLive(feed)).toBe(true);
+
+    await tombstoneConnection(conn);
+
+    expect(await feedIsLive(feed)).toBe(false);
+    // A retired feed must not read back as active (scheduler/UI depend on this).
+    expect(await feedStatus(feed)).toBe("paused");
+  });
+
+  test("retires every streaming feed on the connection, not just one", async () => {
+    const conn = await insertConnection({ slug: "slackinst-multi", live: true });
+    const feeds = [
+      await insertFeed(conn, "slack:D_ONE"),
+      await insertFeed(conn, "slack:D_TWO"),
+      await insertFeed(conn, "slack:C_THREE"),
+    ];
+
+    await tombstoneConnection(conn);
+
+    for (const feed of feeds) {
+      expect(await feedIsLive(feed)).toBe(false);
+    }
+  });
+
+  test("leaves feeds on OTHER connections untouched", async () => {
+    const dying = await insertConnection({ slug: "slackinst-dying", live: true });
+    const survivor = await insertConnection({
+      slug: "slackinst-survivor",
+      live: true,
+    });
+    const orphan = await insertFeed(dying, CHANNEL);
+    const kept = await insertFeed(survivor, CHANNEL);
+
+    await tombstoneConnection(dying);
+
+    expect(await feedIsLive(orphan)).toBe(false);
+    // The survivor's feed shares the channel key but sits on a live connection.
+    expect(await feedIsLive(kept)).toBe(true);
+  });
+
+  test("does not touch non-streaming feeds on the tombstoned connection", async () => {
+    // collected/virtual feeds have their own lifecycle — the trigger is scoped
+    // to streaming only, so a data feed on the same connection is untouched.
+    const conn = await insertConnection({ slug: "slackinst-mixed", live: true });
+    const streaming = await insertFeed(conn, CHANNEL, "streaming");
+    const collected = await insertFeed(conn, "reviews", "collected");
+
+    await tombstoneConnection(conn);
+
+    expect(await feedIsLive(streaming)).toBe(false);
+    expect(await feedIsLive(collected)).toBe(true);
+  });
+
+  test("does not re-retire or resurrect an already-retired feed", async () => {
+    // An UPDATE that does not transition deleted_at NULL -> NOT NULL must not
+    // fire the trigger; a feed already retired keeps its original deleted_at.
+    const conn = await insertConnection({ slug: "slackinst-idem", live: true });
+    const feed = await insertFeed(conn, CHANNEL);
+
+    await tombstoneConnection(conn);
+    const firstDeletedAt = (
+      await getDb()<{ deleted_at: string }>`
+        SELECT deleted_at::text AS deleted_at FROM feeds WHERE id = ${feed}
+      `
+    )[0]?.deleted_at;
+
+    // A later no-op update on the already-dead connection must not touch feeds.
+    await getDb()`UPDATE connections SET updated_at = now() WHERE id = ${conn}`;
+    const secondDeletedAt = (
+      await getDb()<{ deleted_at: string }>`
+        SELECT deleted_at::text AS deleted_at FROM feeds WHERE id = ${feed}
+      `
+    )[0]?.deleted_at;
+
+    expect(await feedIsLive(feed)).toBe(false);
+    expect(secondDeletedAt).toBe(firstDeletedAt);
+  });
+
+  test("MUTATION GUARD: the assertion depends on the trigger", async () => {
+    // Proves the green tests above are not vacuous: with the trigger dropped, a
+    // tombstone leaves the feed LIVE — exactly the bug. Reinstalled afterwards so
+    // the rest of the suite (and other suites sharing the DB) keep the invariant.
+    const fnBody = `
+      BEGIN
+        UPDATE feeds
+        SET deleted_at = current_timestamp, status = 'paused', updated_at = current_timestamp
+        WHERE connection_id = NEW.id AND kind = 'streaming' AND deleted_at IS NULL;
+        RETURN NEW;
+      END`;
+    await getDb().unsafe(
+      `DROP TRIGGER IF EXISTS retire_streaming_feeds_for_deleted_connection ON connections`,
+    );
+
+    const conn = await insertConnection({ slug: "slackinst-mut", live: true });
+    const feed = await insertFeed(conn, CHANNEL);
+    await tombstoneConnection(conn);
+
+    // Without the trigger, the leak reproduces: feed stays live on the dead row.
+    expect(await feedIsLive(feed)).toBe(true);
+
+    // Restore the trigger so no later test inherits the broken state.
+    await getDb().unsafe(
+      `CREATE OR REPLACE FUNCTION retire_streaming_feeds_for_deleted_connection()
+       RETURNS trigger LANGUAGE plpgsql AS $mut$${fnBody}$mut$;
+       CREATE TRIGGER retire_streaming_feeds_for_deleted_connection
+       AFTER UPDATE OF deleted_at ON connections
+       FOR EACH ROW
+       WHEN (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL)
+       EXECUTE FUNCTION retire_streaming_feeds_for_deleted_connection();`,
+    );
+  });
+});

--- a/packages/server/src/gateway/channels/__tests__/retire-streaming-feeds-on-connection-delete.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/retire-streaming-feeds-on-connection-delete.test.ts
@@ -1,14 +1,11 @@
 /**
  * A streaming (chat) feed must not outlive its connection.
  *
- * Until the `retire_streaming_feeds_for_deleted_connection` trigger, tombstoning
- * a connection archived its chat Behaviors but left the derived streaming feeds
- * LIVE on the dead row — the leak the prior one-shot migration had to mop up. The
- * trigger closes that: retiring a connection retires its streaming feeds in the
- * same transaction. These tests drive the trigger through a real tombstone
- * (`UPDATE connections SET deleted_at = now()`), never by replaying SQL, so they
- * exercise the actual wiring installed by the migration.
+ * The trigger tests exercise the wiring installed by the migration through a
+ * real connection tombstone. The backfill test replays the shipped migration
+ * body so its data cleanup cannot drift from production SQL.
  */
+import { readFile } from "node:fs/promises";
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { getDb } from "../../../db/client.js";
 import {
@@ -20,10 +17,24 @@ import {
 const ORG = "org-streamretire";
 const CHANNEL = "slack:D_RETIRE";
 
+async function runMigrationUp(): Promise<void> {
+  const sql = await readFile(
+    new URL(
+      "../../../../../../db/migrations/20260723190000_retire_streaming_feeds_on_connection_delete.sql",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const start = sql.indexOf("-- migrate:up");
+  const end = sql.indexOf("-- migrate:down");
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  await getDb().unsafe(sql.slice(start + "-- migrate:up".length, end));
+}
+
 async function insertConnection(opts: {
   slug: string;
   live: boolean;
-  credentialMode?: string | null;
 }): Promise<number> {
   const rows = await getDb()`
     INSERT INTO connections (
@@ -31,8 +42,7 @@ async function insertConnection(opts: {
       credential_mode, external_tenant_id, config, deleted_at
     ) VALUES (
       ${ORG}, 'slack', ${opts.slug}, 'Workspace', 'active',
-      ${opts.credentialMode === undefined ? "managed" : opts.credentialMode},
-      ${opts.slug},
+      'managed', ${opts.slug},
       '{}', ${opts.live ? null : new Date()}
     )
     RETURNING id
@@ -139,8 +149,6 @@ describe("retiring streaming feeds when a connection is tombstoned", () => {
   });
 
   test("does not touch non-streaming feeds on the tombstoned connection", async () => {
-    // collected/virtual feeds have their own lifecycle — the trigger is scoped
-    // to streaming only, so a data feed on the same connection is untouched.
     const conn = await insertConnection({ slug: "slackinst-mixed", live: true });
     const streaming = await insertFeed(conn, CHANNEL, "streaming");
     const collected = await insertFeed(conn, "reviews", "collected");
@@ -151,62 +159,20 @@ describe("retiring streaming feeds when a connection is tombstoned", () => {
     expect(await feedIsLive(collected)).toBe(true);
   });
 
-  test("does not re-retire or resurrect an already-retired feed", async () => {
-    // An UPDATE that does not transition deleted_at NULL -> NOT NULL must not
-    // fire the trigger; a feed already retired keeps its original deleted_at.
-    const conn = await insertConnection({ slug: "slackinst-idem", live: true });
-    const feed = await insertFeed(conn, CHANNEL);
+  test("backfills live streaming feeds on already-tombstoned connections", async () => {
+    const dead = await insertConnection({
+      slug: "slackinst-backfill",
+      live: false,
+    });
+    const streaming = await insertFeed(dead, CHANNEL);
+    const collected = await insertFeed(dead, "reviews", "collected");
 
-    await tombstoneConnection(conn);
-    const firstDeletedAt = (
-      await getDb()<{ deleted_at: string }>`
-        SELECT deleted_at::text AS deleted_at FROM feeds WHERE id = ${feed}
-      `
-    )[0]?.deleted_at;
+    await runMigrationUp();
+    await runMigrationUp();
 
-    // A later no-op update on the already-dead connection must not touch feeds.
-    await getDb()`UPDATE connections SET updated_at = now() WHERE id = ${conn}`;
-    const secondDeletedAt = (
-      await getDb()<{ deleted_at: string }>`
-        SELECT deleted_at::text AS deleted_at FROM feeds WHERE id = ${feed}
-      `
-    )[0]?.deleted_at;
-
-    expect(await feedIsLive(feed)).toBe(false);
-    expect(secondDeletedAt).toBe(firstDeletedAt);
-  });
-
-  test("MUTATION GUARD: the assertion depends on the trigger", async () => {
-    // Proves the green tests above are not vacuous: with the trigger dropped, a
-    // tombstone leaves the feed LIVE — exactly the bug. Reinstalled afterwards so
-    // the rest of the suite (and other suites sharing the DB) keep the invariant.
-    const fnBody = `
-      BEGIN
-        UPDATE feeds
-        SET deleted_at = current_timestamp, status = 'paused', updated_at = current_timestamp
-        WHERE connection_id = NEW.id AND kind = 'streaming' AND deleted_at IS NULL;
-        RETURN NEW;
-      END`;
-    await getDb().unsafe(
-      `DROP TRIGGER IF EXISTS retire_streaming_feeds_for_deleted_connection ON connections`,
-    );
-
-    const conn = await insertConnection({ slug: "slackinst-mut", live: true });
-    const feed = await insertFeed(conn, CHANNEL);
-    await tombstoneConnection(conn);
-
-    // Without the trigger, the leak reproduces: feed stays live on the dead row.
-    expect(await feedIsLive(feed)).toBe(true);
-
-    // Restore the trigger so no later test inherits the broken state.
-    await getDb().unsafe(
-      `CREATE OR REPLACE FUNCTION retire_streaming_feeds_for_deleted_connection()
-       RETURNS trigger LANGUAGE plpgsql AS $mut$${fnBody}$mut$;
-       CREATE TRIGGER retire_streaming_feeds_for_deleted_connection
-       AFTER UPDATE OF deleted_at ON connections
-       FOR EACH ROW
-       WHEN (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL)
-       EXECUTE FUNCTION retire_streaming_feeds_for_deleted_connection();`,
-    );
+    expect(await feedIsLive(streaming)).toBe(false);
+    expect(await feedStatus(streaming)).toBe("paused");
+    expect(await feedIsLive(collected)).toBe(true);
+    expect(await feedStatus(collected)).toBe("active");
   });
 });

--- a/packages/server/src/gateway/channels/__tests__/retire-streaming-feeds-on-connection-delete.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/retire-streaming-feeds-on-connection-delete.test.ts
@@ -114,7 +114,7 @@ async function reviveFeedWithoutGuard(feedId: number): Promise<void> {
   });
 }
 
-describe("retiring streaming feeds when a connection is tombstoned", () => {
+describe("retiring streaming feeds with dead connections", () => {
   beforeAll(async () => {
     await ensureDbForGatewayTests();
   });
@@ -128,37 +128,7 @@ describe("retiring streaming feeds when a connection is tombstoned", () => {
     await resetTestDatabase();
   });
 
-  test("retires a live connection's streaming feed on tombstone", async () => {
-    const conn = await insertConnection({ slug: "slackinst-a", live: true });
-    const feed = await insertFeed(conn, CHANNEL);
-
-    expect(await feedIsLive(feed)).toBe(true);
-
-    await tombstoneConnection(conn);
-
-    expect(await feedIsLive(feed)).toBe(false);
-    expect(await feedStatus(feed)).toBe("paused");
-  });
-
-  test("retires every streaming feed on the connection, not just one", async () => {
-    const conn = await insertConnection({
-      slug: "slackinst-multi",
-      live: true,
-    });
-    const feeds = [
-      await insertFeed(conn, "slack:D_ONE"),
-      await insertFeed(conn, "slack:D_TWO"),
-      await insertFeed(conn, "slack:C_THREE"),
-    ];
-
-    await tombstoneConnection(conn);
-
-    for (const feed of feeds) {
-      expect(await feedIsLive(feed)).toBe(false);
-    }
-  });
-
-  test("leaves feeds on OTHER connections untouched", async () => {
+  test("tombstoning a connection retires only its streaming feeds", async () => {
     const dying = await insertConnection({
       slug: "slackinst-dying",
       live: true,
@@ -167,28 +137,21 @@ describe("retiring streaming feeds when a connection is tombstoned", () => {
       slug: "slackinst-survivor",
       live: true,
     });
-    const orphan = await insertFeed(dying, CHANNEL);
+    const retired = [
+      await insertFeed(dying, CHANNEL),
+      await insertFeed(dying, "slack:C_OTHER"),
+    ];
+    const collected = await insertFeed(dying, "reviews", "collected");
     const kept = await insertFeed(survivor, CHANNEL);
 
     await tombstoneConnection(dying);
 
-    expect(await feedIsLive(orphan)).toBe(false);
-    // The survivor's feed shares the channel key but sits on a live connection.
-    expect(await feedIsLive(kept)).toBe(true);
-  });
-
-  test("does not touch non-streaming feeds on the tombstoned connection", async () => {
-    const conn = await insertConnection({
-      slug: "slackinst-mixed",
-      live: true,
-    });
-    const streaming = await insertFeed(conn, CHANNEL, "streaming");
-    const collected = await insertFeed(conn, "reviews", "collected");
-
-    await tombstoneConnection(conn);
-
-    expect(await feedIsLive(streaming)).toBe(false);
+    for (const feed of retired) {
+      expect(await feedIsLive(feed)).toBe(false);
+      expect(await feedStatus(feed)).toBe("paused");
+    }
     expect(await feedIsLive(collected)).toBe(true);
+    expect(await feedIsLive(kept)).toBe(true);
   });
 
   test("retires a streaming feed written after its connection is tombstoned", async () => {

--- a/packages/server/src/gateway/channels/__tests__/retire-streaming-feeds-on-connection-delete.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/retire-streaming-feeds-on-connection-delete.test.ts
@@ -6,7 +6,14 @@
  * body so its data cleanup cannot drift from production SQL.
  */
 import { readFile } from "node:fs/promises";
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import { getDb } from "../../../db/client.js";
 import {
   ensureDbForGatewayTests,
@@ -90,6 +97,23 @@ async function feedStatus(feedId: number): Promise<string | null> {
   return rows[0]?.status ?? null;
 }
 
+/** Seed the pre-migration orphan shape without leaking disabled schema state. */
+async function reviveFeedWithoutGuard(feedId: number): Promise<void> {
+  await getDb().begin(async (tx) => {
+    await tx.unsafe(
+      "ALTER TABLE feeds DISABLE TRIGGER guard_streaming_feed_connection",
+    );
+    await tx`
+      UPDATE feeds
+      SET deleted_at = NULL, status = 'active', updated_at = now()
+      WHERE id = ${feedId}
+    `;
+    await tx.unsafe(
+      "ALTER TABLE feeds ENABLE TRIGGER guard_streaming_feed_connection",
+    );
+  });
+}
+
 describe("retiring streaming feeds when a connection is tombstoned", () => {
   beforeAll(async () => {
     await ensureDbForGatewayTests();
@@ -113,12 +137,14 @@ describe("retiring streaming feeds when a connection is tombstoned", () => {
     await tombstoneConnection(conn);
 
     expect(await feedIsLive(feed)).toBe(false);
-    // A retired feed must not read back as active (scheduler/UI depend on this).
     expect(await feedStatus(feed)).toBe("paused");
   });
 
   test("retires every streaming feed on the connection, not just one", async () => {
-    const conn = await insertConnection({ slug: "slackinst-multi", live: true });
+    const conn = await insertConnection({
+      slug: "slackinst-multi",
+      live: true,
+    });
     const feeds = [
       await insertFeed(conn, "slack:D_ONE"),
       await insertFeed(conn, "slack:D_TWO"),
@@ -133,7 +159,10 @@ describe("retiring streaming feeds when a connection is tombstoned", () => {
   });
 
   test("leaves feeds on OTHER connections untouched", async () => {
-    const dying = await insertConnection({ slug: "slackinst-dying", live: true });
+    const dying = await insertConnection({
+      slug: "slackinst-dying",
+      live: true,
+    });
     const survivor = await insertConnection({
       slug: "slackinst-survivor",
       live: true,
@@ -149,13 +178,30 @@ describe("retiring streaming feeds when a connection is tombstoned", () => {
   });
 
   test("does not touch non-streaming feeds on the tombstoned connection", async () => {
-    const conn = await insertConnection({ slug: "slackinst-mixed", live: true });
+    const conn = await insertConnection({
+      slug: "slackinst-mixed",
+      live: true,
+    });
     const streaming = await insertFeed(conn, CHANNEL, "streaming");
     const collected = await insertFeed(conn, "reviews", "collected");
 
     await tombstoneConnection(conn);
 
     expect(await feedIsLive(streaming)).toBe(false);
+    expect(await feedIsLive(collected)).toBe(true);
+  });
+
+  test("retires a streaming feed written after its connection is tombstoned", async () => {
+    const dead = await insertConnection({
+      slug: "slackinst-late-feed",
+      live: false,
+    });
+
+    const streaming = await insertFeed(dead, CHANNEL);
+    const collected = await insertFeed(dead, "reviews", "collected");
+
+    expect(await feedIsLive(streaming)).toBe(false);
+    expect(await feedStatus(streaming)).toBe("paused");
     expect(await feedIsLive(collected)).toBe(true);
   });
 
@@ -166,6 +212,8 @@ describe("retiring streaming feeds when a connection is tombstoned", () => {
     });
     const streaming = await insertFeed(dead, CHANNEL);
     const collected = await insertFeed(dead, "reviews", "collected");
+    await reviveFeedWithoutGuard(streaming);
+    expect(await feedIsLive(streaming)).toBe(true);
 
     await runMigrationUp();
     await runMigrationUp();


### PR DESCRIPTION
## What

Adds a DB trigger so a streaming (chat) feed cannot outlive its connection. When a connection is tombstoned, its streaming feeds are retired in the same transaction — the companion to the existing `archive_chat_behaviors_for_deleted_connection` trigger, which already archives the chat-link Behaviors on the same event.

## Why

A streaming feed is keyed by the numeric `connections.id` and was soft-deleted only on an explicit Behavior unlink (`softDeleteStreamingChannelFeed`) — nothing retired it when its *connection* died. So every connection retirement (e.g. a Slack Grid workspace re-installed under a different tenant key, which mints a new connection and tombstones the old) left the previous generation's streaming feed **live on a dead row**. One leaked per retirement.

The prior one-shot migration (#2157, `20260723160000_retire_leaked_chat_feeds.sql`) mopped up the rows that had already accumulated in prod, but did nothing to stop the next leak. This closes the leak at the source.

## How

- `20260723190000_retire_streaming_feeds_on_connection_delete.sql`:
  - `AFTER UPDATE OF deleted_at ON connections WHEN (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL)` trigger retires the connection's `streaming` feeds (`deleted_at` + `status='paused'`, matching `softDeleteStreamingChannelFeed` exactly).
  - A backfill retires streaming feeds still live on already-tombstoned connections.
  - A DB trigger (not the app reconciler) so the invariant holds regardless of *how* the connection was tombstoned — tool call, admin SQL, or cascade.
- Only `streaming` feeds are touched; `collected`/`virtual` feeds have their own lifecycle and are untouched.

## Test evidence (red→fix→green)

`retire-streaming-feeds-on-connection-delete.test.ts` drives the trigger through a real tombstone (never replaying SQL for the trigger path):
- retires a live connection's streaming feed on tombstone (→ `paused`)
- retires *every* streaming feed on the connection
- leaves feeds on *other* connections untouched (even when they share a channel key)
- does not touch non-streaming feeds on the same connection
- backfill test replays the shipped `migrate:up` body twice (idempotency) so data cleanup can't drift from prod SQL

Red verified manually: with the trigger dropped, a tombstone leaves the feed live (`feed_still_live=true`) — the exact bug.

## Scope

Cleans up the recurrence of leaked *feeds*. The deeper install-identity fix (a Grid workspace forking into multiple connections across `E…`/`T…` tenant keys — `slack-web.ts:258`) is tracked separately; this makes the feed side self-healing regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->