### PR TITLE
fix(operations): expose recorded initiator through list_runs and get_run

### DIFF
--- a/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
+++ b/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
@@ -13,7 +13,7 @@ import type { Env } from "../../index";
 import { manageOperations } from "../../tools/admin/manage_operations";
 import type { ToolContext } from "../../tools/registry";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
-import { createTestOrganization } from "../setup/test-fixtures";
+import { createTestOrganization, createTestUser } from "../setup/test-fixtures";
 
 const env = {} as Env;
 
@@ -96,5 +96,45 @@ describe("manage_operations get_run — internal runs", () => {
 		const id = await insertRun("chat_message", "thread_response");
 		const result = await getRun(id);
 		expect(result.error).toBe("Run not found");
+	});
+
+	it("surfaces the recorded initiator through get_run and list_runs", async () => {
+		const db = getTestDb();
+		const proposer = await createTestUser();
+		const initiatorRef = {
+			agent_id: "personal-agent",
+			client_id: "claude-ai",
+			user_id: proposer.id,
+		};
+		const [row] = (await db`
+      INSERT INTO runs (organization_id, run_type, action_key, status,
+        approval_status, created_by_user_id, initiator_kind, initiator_ref,
+        created_at, run_at)
+      VALUES (${orgId}, 'internal', 'entity_change', 'pending', 'pending',
+        ${proposer.id}, 'agent_session',
+        ${db.json(initiatorRef)},
+        now(), now())
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+		const id = Number(row.id);
+
+		const got = (await getRun(id)).run as Record<string, unknown>;
+		expect(got.initiator_kind).toBe("agent_session");
+		expect(got.created_by_user_id).toBe(proposer.id);
+		expect(got.initiator_ref).toEqual(initiatorRef);
+
+		const listed = (await manageOperations(
+			{
+				action: "list_runs",
+				run_types: ["internal"],
+				approval_status: "pending",
+			},
+			env,
+			ctx(),
+		)) as { runs: Array<Record<string, unknown>> };
+		const found = listed.runs.find((r) => Number(r.id) === id);
+		expect(found?.initiator_kind).toBe("agent_session");
+		expect(found?.created_by_user_id).toBe(proposer.id);
+		expect(found?.initiator_ref).toEqual(initiatorRef);
 	});
 });

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1450,6 +1450,7 @@ async function handleListRuns(
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.items_collected, r.checkpoint,
            r.created_at, r.completed_at,
+           r.initiator_kind, r.initiator_ref, r.created_by_user_id,
            f.feed_key, f.display_name AS feed_display_name,
            c.display_name AS connection_display_name, c.device_worker_id
     FROM runs r
@@ -1489,7 +1490,8 @@ async function handleGetRun(
     SELECT r.id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.run_type,
-           r.created_at, r.completed_at
+           r.created_at, r.completed_at,
+           r.initiator_kind, r.initiator_ref, r.created_by_user_id
     FROM runs r
     WHERE r.id = ${args.run_id}
       AND r.organization_id = ${ctx.organizationId}


### PR DESCRIPTION
## What

#2152 records run provenance (`initiator_kind`, `initiator_ref`, `created_by_user_id`) but both run projections omitted these columns — so the data was invisible to every read surface except the approval card. This adds the three columns to the `list_runs` and `get_run` SELECTs in `manage_operations`.

No schema change: the `list_runs`/`get_run` result type is an open `Record(String, Unknown)`, so the new columns flow through without a contract edit.

## Why it matters

This is what makes the initiator-provenance deploy-time verification possible: a fresh proposal's `initiator_kind='agent_session'` is now readable via `client.operations.listRuns` / `get_run`, not only on the card.

## Tests

Extended `operations-getrun-internal.test.ts` with a case asserting the full `initiator_ref` jsonb, `initiator_kind`, and `created_by_user_id` round-trip through both `get_run` and `list_runs`. 6/6 green (brew Postgres 5418).

## Review

codex: bug_free 95, simplicity 98, slop 0, 0 bugs, 0 blockers (reviewer ran the suite, 6/6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->