### PR TITLE
fix(chat): supersede stale org-wide Grid connections on per-workspace reinstall

### DIFF
--- a/db/migrations/20260723200000_backfill_slack_enterprise_id_on_connections.sql
+++ b/db/migrations/20260723200000_backfill_slack_enterprise_id_on_connections.sql
@@ -1,0 +1,73 @@
+-- Backfill the Grid enterprise id onto Slack connection projections, and retire
+-- stale org-wide (`E…`-keyed) connections that a later per-workspace reinstall
+-- orphaned.
+--
+-- An ORG-WIDE Grid install returns no `team` from oauth.v2.access, so its
+-- connection was keyed on the enterprise `E…` id. A later PER-WORKSPACE reinstall
+-- of the same workspace arrives under a `T…` key and mints a NEW connection; the
+-- projection's exact-tenant demote could not recognize the `E…` row as the same
+-- workspace, so it was left live-but-orphaned (its streaming feed stranded — the
+-- damage #2157 cleaned and #2163 stopped recurring on the feed side).
+--
+-- The code fix (persist `enterpriseId` onto the connection + enterprise-sibling
+-- supersede in the projection) prevents new orphans. This migration makes the
+-- invariant true for EXISTING rows:
+--   1. Backfill `chatMetadata.enterpriseId` / `isEnterpriseInstall` from each
+--      connection's backing `app_installations` row, so the projection can match
+--      the enterprise on the next reinstall.
+--   2. Retire any LIVE org-wide (`E…`-keyed) connection that is already superseded
+--      by a live per-workspace (`T…`) connection of the SAME enterprise in the
+--      same org. Scoped to Slack managed rows. The retire fires
+--      `retire_streaming_feeds_for_deleted_connection` (#2163), reclaiming feeds.
+
+-- migrate:up
+
+-- 1. Backfill enterprise metadata onto connection projections from their install.
+--    `metadata->>'external_id'` on the install is the connection slug.
+UPDATE connections c
+-- Merge onto the existing chatMetadata object (creating it when absent).
+-- `jsonb_set` alone cannot create the intermediate `chatMetadata` key, so build
+-- the whole sub-object with `||` and set it in one shot.
+SET config = jsonb_set(
+      COALESCE(c.config, '{}'::jsonb),
+      '{chatMetadata}',
+      COALESCE(c.config->'chatMetadata', '{}'::jsonb)
+        || jsonb_build_object(
+             'enterpriseId', ai.metadata->>'enterprise_id',
+             'isEnterpriseInstall', (ai.metadata->>'is_enterprise_install') = 'true'
+           ),
+      true
+    ),
+    updated_at = now()
+FROM app_installations ai
+WHERE ai.provider = 'slack'
+  AND ai.metadata->>'external_id' = c.slug
+  AND ai.metadata->>'enterprise_id' IS NOT NULL
+  AND c.connector_key = 'slack'
+  AND c.credential_mode = 'managed'
+  AND (c.config->'chatMetadata'->>'enterpriseId') IS DISTINCT FROM (ai.metadata->>'enterprise_id');
+
+-- 2. Retire stale org-wide (`E…`-keyed) connections superseded by a live
+--    per-workspace (`T…`) connection of the same enterprise in the same org.
+--    `external_tenant_id` starting with 'E' identifies the org-wide generation;
+--    the live sibling carries this enterprise id in its backfilled metadata.
+UPDATE connections dead
+SET deleted_at = now(), status = 'paused', updated_at = now()
+FROM connections live
+WHERE dead.connector_key = 'slack'
+  AND dead.credential_mode = 'managed'
+  AND dead.deleted_at IS NULL
+  AND dead.external_tenant_id LIKE 'E%'
+  AND live.organization_id = dead.organization_id
+  AND live.connector_key = 'slack'
+  AND live.credential_mode = 'managed'
+  AND live.deleted_at IS NULL
+  AND live.id <> dead.id
+  AND live.config->'chatMetadata'->>'enterpriseId' = dead.external_tenant_id;
+
+-- migrate:down
+
+-- Data cleanup: the retired org-wide rows were orphans with no backing install,
+-- and the metadata backfill only mirrors the install's own enterprise id, so
+-- neither is reversed.
+SELECT 1;

--- a/db/migrations/20260723200000_backfill_slack_enterprise_id_on_connections.sql
+++ b/db/migrations/20260723200000_backfill_slack_enterprise_id_on_connections.sql
@@ -4,10 +4,10 @@
 --
 -- An ORG-WIDE Grid install returns no `team` from oauth.v2.access, so its
 -- connection was keyed on the enterprise `E…` id. A later PER-WORKSPACE reinstall
--- of the same workspace arrives under a `T…` key and mints a NEW connection; the
--- projection's exact-tenant demote could not recognize the `E…` row as the same
--- workspace, so it was left live-but-orphaned (its streaming feed stranded — the
--- damage #2157 cleaned and #2163 stopped recurring on the feed side).
+-- arrives under a `T…` key and mints a NEW connection; the projection's
+-- exact-tenant demote could not recognize an orphaned `E…` row as the superseded
+-- generation, so it was left live (its streaming feed stranded — the damage
+-- #2157 cleaned and #2163 stopped recurring on the feed side).
 --
 -- The code fix (persist `enterpriseId` onto the connection + enterprise-sibling
 -- supersede in the projection) prevents new orphans. This migration makes the
@@ -15,9 +15,10 @@
 --   1. Backfill `chatMetadata.enterpriseId` / `isEnterpriseInstall` from each
 --      connection's backing `app_installations` row, so the projection can match
 --      the enterprise on the next reinstall.
---   2. Retire any LIVE org-wide (`E…`-keyed) connection that is already superseded
---      by a live per-workspace (`T…`) connection of the SAME enterprise in the
---      same org. Scoped to Slack managed rows. The retire fires
+--   2. Retire any LIVE orphaned org-wide (`E…`-keyed) connection with no active
+--      backing install that is superseded by a live per-workspace (`T…`)
+--      connection of the same enterprise and org. Scoped to Slack managed rows.
+--      The retire fires
 --      `retire_streaming_feeds_for_deleted_connection` (#2163), reclaiming feeds.
 
 -- migrate:up
@@ -34,7 +35,8 @@ SET config = jsonb_set(
       COALESCE(c.config->'chatMetadata', '{}'::jsonb)
         || jsonb_build_object(
              'enterpriseId', ai.metadata->>'enterprise_id',
-             'isEnterpriseInstall', (ai.metadata->>'is_enterprise_install') = 'true'
+             'isEnterpriseInstall',
+             COALESCE((ai.metadata->>'is_enterprise_install') = 'true', false)
            ),
       true
     ),
@@ -45,29 +47,47 @@ WHERE ai.provider = 'slack'
   AND ai.metadata->>'enterprise_id' IS NOT NULL
   AND c.connector_key = 'slack'
   AND c.credential_mode = 'managed'
-  AND (c.config->'chatMetadata'->>'enterpriseId') IS DISTINCT FROM (ai.metadata->>'enterprise_id');
+  AND (
+    (c.config->'chatMetadata'->>'enterpriseId') IS DISTINCT FROM (ai.metadata->>'enterprise_id')
+    OR (c.config->'chatMetadata'->>'isEnterpriseInstall') IS DISTINCT FROM
+       CASE
+         WHEN ai.metadata->>'is_enterprise_install' = 'true' THEN 'true'
+         ELSE 'false'
+       END
+  );
 
 -- 2. Retire stale org-wide (`E…`-keyed) connections superseded by a live
 --    per-workspace (`T…`) connection of the same enterprise in the same org.
 --    `external_tenant_id` starting with 'E' identifies the org-wide generation;
 --    the live sibling carries this enterprise id in its backfilled metadata.
+--    An active backing install means the org-wide connection is intentional,
+--    not orphaned, so it must remain available for sibling-workspace routing.
 UPDATE connections dead
 SET deleted_at = now(), status = 'paused', updated_at = now()
 FROM connections live
 WHERE dead.connector_key = 'slack'
   AND dead.credential_mode = 'managed'
+  AND dead.status = 'active'
   AND dead.deleted_at IS NULL
   AND dead.external_tenant_id LIKE 'E%'
   AND live.organization_id = dead.organization_id
   AND live.connector_key = 'slack'
   AND live.credential_mode = 'managed'
+  AND live.status = 'active'
   AND live.deleted_at IS NULL
   AND live.id <> dead.id
-  AND live.config->'chatMetadata'->>'enterpriseId' = dead.external_tenant_id;
+  AND live.config->'chatMetadata'->>'enterpriseId' = dead.external_tenant_id
+  AND NOT EXISTS (
+    SELECT 1
+    FROM app_installations dead_ai
+    WHERE dead_ai.organization_id = dead.organization_id
+      AND dead_ai.provider = 'slack'
+      AND dead_ai.metadata->>'external_id' = dead.slug
+      AND dead_ai.status = 'active'
+  );
 
 -- migrate:down
 
--- Data cleanup: the retired org-wide rows were orphans with no backing install,
--- and the metadata backfill only mirrors the install's own enterprise id, so
--- neither is reversed.
+-- Data cleanup is not reversed: restoring superseded connections would recreate
+-- ambiguous routing, and prior metadata values cannot be reconstructed.
 SELECT 1;

--- a/packages/server/src/__tests__/integration/connectors/connections-unify-managed-routing.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connections-unify-managed-routing.test.ts
@@ -126,4 +126,58 @@ describe("connections-unify managed-install routing", () => {
 		expect(await status(orgId, "slackinst-xfer-a")).toBe("paused");
 		expect(await status(orgB, "slackinst-xfer-b")).toBe("active");
 	});
+
+	it("retires a stale org-wide (E…) connection when a per-workspace reinstall arrives", async () => {
+		const db = getDb();
+		const ENTERPRISE = "EGRIDSUP";
+		const WORKSPACE = "TGRIDSUP";
+		const project = (
+			id: string,
+			teamId: string,
+			metadata: Record<string, unknown>,
+		) =>
+			db.begin(async (tx: typeof db) =>
+				upsertChatConnectionProjection(
+					tx,
+					(v) => db.json(v),
+					{
+						id,
+						platform: "slack",
+						organizationId: orgId,
+						config: { platform: "slack", botToken: `secret://${id}` },
+						settings: {},
+						metadata: { teamId, ...metadata },
+						status: "active",
+						createdAt: Date.now(),
+						updatedAt: Date.now(),
+					},
+					orgId,
+					"managed",
+				),
+			);
+
+		// 1) An ORG-WIDE Grid install: no `team`, keyed on the enterprise E… id.
+		await project("slackinst-grid-orgwide", ENTERPRISE, {
+			enterpriseId: ENTERPRISE,
+			isEnterpriseInstall: true,
+		});
+		// 2) The SAME workspace reinstalled PER-WORKSPACE: Slack returns a T… id,
+		//    and the install carries the enterprise id in metadata.
+		await project("slackinst-grid-workspace", WORKSPACE, {
+			enterpriseId: ENTERPRISE,
+		});
+
+		const live = async (slug: string) => {
+			const [r] = (await db`
+				SELECT 1 FROM connections
+				WHERE organization_id = ${orgId} AND slug = ${slug} AND deleted_at IS NULL
+			`) as Array<unknown>;
+			return r != null;
+		};
+
+		// The per-workspace connection is live; the stale org-wide E… connection is
+		// retired (soft-deleted), not left orphaned.
+		expect(await live("slackinst-grid-workspace")).toBe(true);
+		expect(await live("slackinst-grid-orgwide")).toBe(false);
+	});
 });

--- a/packages/server/src/__tests__/integration/connectors/connections-unify-managed-routing.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connections-unify-managed-routing.test.ts
@@ -14,14 +14,46 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getDb } from "../../../db/client";
 import { resolveBoundChannelRows } from "../../../gateway/channels/bound-channels";
+import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
 import { upsertChatConnectionProjection } from "../../../lobu/stores/connections-projection";
+import { upsertSlackInstallByTeam } from "../../../lobu/stores/slack-installations";
 import { initWorkspaceProvider } from "../../../workspace";
+import { createTestBehaviorSubscription } from "../../setup/behavior-subscriptions";
 import {
 	createTestAgent,
 	createTestOrganization,
 	createTestUser,
 } from "../../setup/test-fixtures";
-import { createTestBehaviorSubscription } from "../../setup/behavior-subscriptions";
+
+function memorySecretStore() {
+	const secrets = new Map<string, string>();
+	const nameOf = (nameOrRef: string) =>
+		nameOrRef.startsWith("secret://")
+			? nameOrRef.slice("secret://".length)
+			: nameOrRef;
+	return {
+		async get(ref: string) {
+			return secrets.get(nameOf(ref)) ?? null;
+		},
+		async put(name: string, value: string) {
+			secrets.set(name, value);
+			return `secret://${name}`;
+		},
+		async delete(nameOrRef: string) {
+			secrets.delete(nameOf(nameOrRef));
+		},
+		async list(prefix = "") {
+			return [...secrets.keys()]
+				.filter((name) => name.startsWith(prefix))
+				.map((name) => ({
+					ref: `secret://${name}`,
+					backend: "memory",
+					name,
+					updatedAt: 0,
+				}));
+		},
+	} as never;
+}
 
 describe("connections-unify managed-install routing", () => {
 	let orgId: string;
@@ -40,6 +72,7 @@ describe("connections-unify managed-install routing", () => {
 		const sql = getDb();
 		await sql`DELETE FROM watchers WHERE organization_id IN (${orgId}, ${orgB})`;
 		await sql`DELETE FROM connections WHERE organization_id IN (${orgId}, ${orgB})`;
+		await sql`DELETE FROM app_installations WHERE organization_id IN (${orgId}, ${orgB})`;
 	});
 
 	it("resolves a managed install's bound channel via connection_id (agent_id NULL)", async () => {
@@ -131,41 +164,26 @@ describe("connections-unify managed-install routing", () => {
 		const db = getDb();
 		const ENTERPRISE = "EGRIDSUP";
 		const WORKSPACE = "TGRIDSUP";
-		const project = (
-			id: string,
-			teamId: string,
-			metadata: Record<string, unknown>,
-		) =>
-			db.begin(async (tx: typeof db) =>
-				upsertChatConnectionProjection(
-					tx,
-					(v) => db.json(v),
-					{
-						id,
-						platform: "slack",
-						organizationId: orgId,
-						config: { platform: "slack", botToken: `secret://${id}` },
-						settings: {},
-						metadata: { teamId, ...metadata },
-						status: "active",
-						createdAt: Date.now(),
-						updatedAt: Date.now(),
-					},
-					orgId,
-					"managed",
-				),
-			);
-
-		// 1) An ORG-WIDE Grid install: no `team`, keyed on the enterprise E… id.
-		await project("slackinst-grid-orgwide", ENTERPRISE, {
-			enterpriseId: ENTERPRISE,
-			isEnterpriseInstall: true,
-		});
-		// 2) The SAME workspace reinstalled PER-WORKSPACE: Slack returns a T… id,
-		//    and the install carries the enterprise id in metadata.
-		await project("slackinst-grid-workspace", WORKSPACE, {
-			enterpriseId: ENTERPRISE,
-		});
+		const secretStore = memorySecretStore();
+		await db`
+			INSERT INTO connections (
+				organization_id, connector_key, external_tenant_id, display_name,
+				status, config, credential_mode, slug, visibility
+			) VALUES (
+				${orgId}, 'slack', ${ENTERPRISE}, 'Stale Grid install',
+				'active', '{}', 'managed', 'slackinst-grid-orphan', 'org'
+			)
+		`;
+		const workspace = await upsertSlackInstallByTeam(
+			createPostgresAppInstallationStore(),
+			secretStore,
+			orgId,
+			WORKSPACE,
+			{
+				botToken: "xoxb-grid-test",
+				enterpriseId: ENTERPRISE,
+			},
+		);
 
 		const live = async (slug: string) => {
 			const [r] = (await db`
@@ -175,9 +193,39 @@ describe("connections-unify managed-install routing", () => {
 			return r != null;
 		};
 
-		// The per-workspace connection is live; the stale org-wide E… connection is
-		// retired (soft-deleted), not left orphaned.
-		expect(await live("slackinst-grid-workspace")).toBe(true);
-		expect(await live("slackinst-grid-orgwide")).toBe(false);
+		expect(await live(workspace.id)).toBe(true);
+		expect(await live("slackinst-grid-orphan")).toBe(false);
+	});
+
+	it("keeps an active org-wide Grid install when a workspace sibling is installed", async () => {
+		const db = getDb();
+		const enterpriseId = "EGRIDACTIVE";
+		const secretStore = memorySecretStore();
+		const install = (teamId: string, isEnterpriseInstall = false) =>
+			upsertSlackInstallByTeam(
+				createPostgresAppInstallationStore(),
+				secretStore,
+				orgId,
+				teamId,
+				{
+					botToken: "xoxb-grid-test",
+					enterpriseId,
+					isEnterpriseInstall,
+				},
+			);
+
+		const orgWide = await install(enterpriseId, true);
+		const workspace = await install("TGRIDACTIVE");
+		const live = await db<{ slug: string }[]>`
+			SELECT slug FROM connections
+			WHERE organization_id = ${orgId}
+				AND slug IN (${orgWide.id}, ${workspace.id})
+				AND deleted_at IS NULL AND status = 'active'
+			ORDER BY slug
+		`;
+
+		expect(live.map((row) => row.slug)).toEqual(
+			[orgWide.id, workspace.id].sort(),
+		);
 	});
 });

--- a/packages/server/src/gateway/channels/__tests__/backfill-slack-enterprise-id.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/backfill-slack-enterprise-id.test.ts
@@ -1,10 +1,10 @@
 /**
  * The Grid enterprise id must live on a Slack connection's projection so a later
- * per-workspace reinstall can recognize the stale org-wide (`E…`) generation as
- * the same workspace and supersede it. This replays the shipped migration body
- * so its data cleanup cannot drift from production SQL.
+ * per-workspace reinstall can recognize and retire an orphaned org-wide (`E…`)
+ * generation. This replays the migration body so its data cleanup cannot drift
+ * from production SQL.
  */
-import { readFile } from "node:fs/promises";
+
 import {
 	afterAll,
 	beforeAll,
@@ -13,6 +13,7 @@ import {
 	expect,
 	test,
 } from "bun:test";
+import { readFile } from "node:fs/promises";
 import { getDb } from "../../../db/client.js";
 import {
 	ensureDbForGatewayTests,
@@ -48,10 +49,10 @@ async function insertInstall(opts: {
       organization_id, provider, provider_app_id, external_tenant_id, status, metadata
     ) VALUES (
       ${ORG}, 'slack', 'A_TEST', ${opts.externalTenantId}, 'active',
-      ${getDb().json({
+			${getDb().json({
 				external_id: opts.externalId,
 				...(opts.enterpriseId ? { enterprise_id: opts.enterpriseId } : {}),
-				is_enterprise_install: opts.isEnterpriseInstall ? "true" : "false",
+				is_enterprise_install: opts.isEnterpriseInstall,
 			})}
     )
   `;
@@ -82,6 +83,14 @@ async function connEnterpriseId(id: number): Promise<string | null> {
     SELECT config->'chatMetadata'->>'enterpriseId' AS ent FROM connections WHERE id = ${id}
   `;
 	return rows[0]?.ent ?? null;
+}
+
+async function connIsEnterpriseInstall(id: number): Promise<boolean | null> {
+	const rows = await getDb()<{ org_wide: boolean | null }>`
+    SELECT (config->'chatMetadata'->'isEnterpriseInstall')::boolean AS org_wide
+    FROM connections WHERE id = ${id}
+  `;
+	return rows[0]?.org_wide ?? null;
 }
 
 async function connIsLive(id: number): Promise<boolean> {
@@ -128,6 +137,25 @@ describe("backfill slack enterprise id migration", () => {
 		expect(await connEnterpriseId(conn)).toBe(ENTERPRISE);
 	});
 
+	test("backfills a missing org-wide flag when enterpriseId is already present", async () => {
+		await insertInstall({
+			externalTenantId: "E_ALREADY",
+			externalId: "slackinst-existing-enterprise",
+			enterpriseId: "E_ALREADY",
+			isEnterpriseInstall: true,
+		});
+		const conn = await insertConnection({
+			slug: "slackinst-existing-enterprise",
+			externalTenantId: "E_ALREADY",
+			live: true,
+			config: { chatMetadata: { enterpriseId: "E_ALREADY" } },
+		});
+
+		expect(await connIsEnterpriseInstall(conn)).toBeNull();
+		await runMigrationUp();
+		expect(await connIsEnterpriseInstall(conn)).toBe(true);
+	});
+
 	test("retires a live org-wide (E…) connection superseded by a per-workspace sibling", async () => {
 		// Backing install for the live workspace connection carries the enterprise id.
 		await insertInstall({
@@ -142,8 +170,8 @@ describe("backfill slack enterprise id migration", () => {
 			externalTenantId: "T_WS",
 			live: true,
 		});
-		// The stale org-wide (E…) connection: still live, no per-workspace sibling yet
-		// recognized. Same enterprise id, so it must be retired.
+		// The orphaned org-wide connection has no backing install and is superseded
+		// by the active workspace projection above.
 		const orphan = await insertConnection({
 			slug: "slackinst-orgwide",
 			externalTenantId: ENTERPRISE,
@@ -169,6 +197,52 @@ describe("backfill slack enterprise id migration", () => {
 		await runMigrationUp();
 
 		expect(await connIsLive(lone)).toBe(true);
+	});
+
+	test("never retires an org-wide connection for a paused per-workspace sibling", async () => {
+		await insertConnection({
+			slug: "slackinst-paused-workspace",
+			externalTenantId: "T_PAUSED",
+			live: true,
+			config: { chatMetadata: { enterpriseId: ENTERPRISE } },
+		});
+		await getDb()`
+      UPDATE connections SET status = 'paused'
+      WHERE slug = 'slackinst-paused-workspace'
+    `;
+		const orgWide = await insertConnection({
+			slug: "slackinst-live-orgwide",
+			externalTenantId: ENTERPRISE,
+			live: true,
+		});
+
+		await runMigrationUp();
+
+		expect(await connIsLive(orgWide)).toBe(true);
+	});
+
+	test("never retires an org-wide connection with an active backing install", async () => {
+		await insertInstall({
+			externalTenantId: ENTERPRISE,
+			externalId: "slackinst-backed-orgwide",
+			enterpriseId: ENTERPRISE,
+			isEnterpriseInstall: true,
+		});
+		await insertConnection({
+			slug: "slackinst-live-workspace",
+			externalTenantId: "T_LIVE_SIBLING",
+			live: true,
+			config: { chatMetadata: { enterpriseId: ENTERPRISE } },
+		});
+		const orgWide = await insertConnection({
+			slug: "slackinst-backed-orgwide",
+			externalTenantId: ENTERPRISE,
+			live: true,
+		});
+
+		await runMigrationUp();
+
+		expect(await connIsLive(orgWide)).toBe(true);
 	});
 
 	test("never crosses orgs when superseding", async () => {

--- a/packages/server/src/gateway/channels/__tests__/backfill-slack-enterprise-id.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/backfill-slack-enterprise-id.test.ts
@@ -42,7 +42,10 @@ async function insertInstall(opts: {
 	externalTenantId: string;
 	externalId: string;
 	enterpriseId: string | null;
-	isEnterpriseInstall: boolean;
+	// Omit to reproduce the real per-workspace Grid shape: `buildMetadata` only
+	// writes `is_enterprise_install` when truthy, so the key is absent (not
+	// `false`) on the backing install — the null-vs-false gap the COALESCE guards.
+	isEnterpriseInstall?: boolean;
 }): Promise<void> {
 	await getDb()`
     INSERT INTO app_installations (
@@ -52,7 +55,9 @@ async function insertInstall(opts: {
 			${getDb().json({
 				external_id: opts.externalId,
 				...(opts.enterpriseId ? { enterprise_id: opts.enterpriseId } : {}),
-				is_enterprise_install: opts.isEnterpriseInstall,
+				...(opts.isEnterpriseInstall === undefined
+					? {}
+					: { is_enterprise_install: opts.isEnterpriseInstall }),
 			})}
     )
   `;
@@ -154,6 +159,29 @@ describe("backfill slack enterprise id migration", () => {
 		expect(await connIsEnterpriseInstall(conn)).toBeNull();
 		await runMigrationUp();
 		expect(await connIsEnterpriseInstall(conn)).toBe(true);
+	});
+
+	test("backfills isEnterpriseInstall as false when the install omits the key", async () => {
+		// Real per-workspace Grid shape: `enterprise_id` is set but the
+		// `is_enterprise_install` key is absent on the backing install. The
+		// COALESCE must land JSON boolean `false`, never JSON `null`.
+		await insertInstall({
+			externalTenantId: "T_NOKEY",
+			externalId: "slackinst-nokey",
+			enterpriseId: ENTERPRISE,
+			// isEnterpriseInstall omitted on purpose.
+		});
+		const conn = await insertConnection({
+			slug: "slackinst-nokey",
+			externalTenantId: "T_NOKEY",
+			live: true,
+		});
+
+		await runMigrationUp();
+
+		expect(await connEnterpriseId(conn)).toBe(ENTERPRISE);
+		// `false`, not `null`: a JSON null would fail this assertion, catching the gap.
+		expect(await connIsEnterpriseInstall(conn)).toBe(false);
 	});
 
 	test("retires a live org-wide (E…) connection superseded by a per-workspace sibling", async () => {

--- a/packages/server/src/gateway/channels/__tests__/backfill-slack-enterprise-id.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/backfill-slack-enterprise-id.test.ts
@@ -1,0 +1,205 @@
+/**
+ * The Grid enterprise id must live on a Slack connection's projection so a later
+ * per-workspace reinstall can recognize the stale org-wide (`E…`) generation as
+ * the same workspace and supersede it. This replays the shipped migration body
+ * so its data cleanup cannot drift from production SQL.
+ */
+import { readFile } from "node:fs/promises";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import { getDb } from "../../../db/client.js";
+import {
+	ensureDbForGatewayTests,
+	resetTestDatabase,
+} from "../../__tests__/helpers/db-setup.js";
+
+const ORG = "org-entbackfill";
+const ENTERPRISE = "E_BACKFILL";
+
+async function runMigrationUp(): Promise<void> {
+	const sql = await readFile(
+		new URL(
+			"../../../../../../db/migrations/20260723200000_backfill_slack_enterprise_id_on_connections.sql",
+			import.meta.url,
+		),
+		"utf8",
+	);
+	const start = sql.indexOf("-- migrate:up");
+	const end = sql.indexOf("-- migrate:down");
+	expect(start).toBeGreaterThan(-1);
+	expect(end).toBeGreaterThan(start);
+	await getDb().unsafe(sql.slice(start + "-- migrate:up".length, end));
+}
+
+async function insertInstall(opts: {
+	externalTenantId: string;
+	externalId: string;
+	enterpriseId: string | null;
+	isEnterpriseInstall: boolean;
+}): Promise<void> {
+	await getDb()`
+    INSERT INTO app_installations (
+      organization_id, provider, provider_app_id, external_tenant_id, status, metadata
+    ) VALUES (
+      ${ORG}, 'slack', 'A_TEST', ${opts.externalTenantId}, 'active',
+      ${getDb().json({
+				external_id: opts.externalId,
+				...(opts.enterpriseId ? { enterprise_id: opts.enterpriseId } : {}),
+				is_enterprise_install: opts.isEnterpriseInstall ? "true" : "false",
+			})}
+    )
+  `;
+}
+
+async function insertConnection(opts: {
+	slug: string;
+	externalTenantId: string;
+	live: boolean;
+	config?: Record<string, unknown>;
+}): Promise<number> {
+	const rows = await getDb()`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      credential_mode, external_tenant_id, config, deleted_at
+    ) VALUES (
+      ${ORG}, 'slack', ${opts.slug}, 'Workspace', 'active',
+      'managed', ${opts.externalTenantId},
+      ${getDb().json(opts.config ?? {})}, ${opts.live ? null : new Date()}
+    )
+    RETURNING id
+  `;
+	return Number(rows[0].id);
+}
+
+async function connEnterpriseId(id: number): Promise<string | null> {
+	const rows = await getDb()<{ ent: string | null }>`
+    SELECT config->'chatMetadata'->>'enterpriseId' AS ent FROM connections WHERE id = ${id}
+  `;
+	return rows[0]?.ent ?? null;
+}
+
+async function connIsLive(id: number): Promise<boolean> {
+	const rows = await getDb()`
+    SELECT 1 FROM connections WHERE id = ${id} AND deleted_at IS NULL
+  `;
+	return rows.length > 0;
+}
+
+describe("backfill slack enterprise id migration", () => {
+	beforeAll(async () => {
+		await ensureDbForGatewayTests();
+	});
+
+	beforeEach(async () => {
+		await resetTestDatabase();
+		await getDb()`
+      INSERT INTO organization (id, name, slug) VALUES (${ORG}, 'Ent Backfill', ${ORG})
+      ON CONFLICT (id) DO NOTHING
+    `;
+	});
+
+	afterAll(async () => {
+		await resetTestDatabase();
+	});
+
+	test("backfills enterpriseId onto a connection from its install", async () => {
+		await insertInstall({
+			externalTenantId: "T_LIVE",
+			externalId: "slackinst-live",
+			enterpriseId: ENTERPRISE,
+			isEnterpriseInstall: true,
+		});
+		const conn = await insertConnection({
+			slug: "slackinst-live",
+			externalTenantId: "T_LIVE",
+			live: true,
+		});
+
+		// A connection whose config has NO chatMetadata object yet — the backfill must
+		// still create it (jsonb_set alone cannot create the intermediate key).
+		expect(await connEnterpriseId(conn)).toBeNull();
+		await runMigrationUp();
+		expect(await connEnterpriseId(conn)).toBe(ENTERPRISE);
+	});
+
+	test("retires a live org-wide (E…) connection superseded by a per-workspace sibling", async () => {
+		// Backing install for the live workspace connection carries the enterprise id.
+		await insertInstall({
+			externalTenantId: "T_WS",
+			externalId: "slackinst-ws",
+			enterpriseId: ENTERPRISE,
+			isEnterpriseInstall: true,
+		});
+		// The live per-workspace (T…) connection — backfill will stamp its enterprise id.
+		const workspace = await insertConnection({
+			slug: "slackinst-ws",
+			externalTenantId: "T_WS",
+			live: true,
+		});
+		// The stale org-wide (E…) connection: still live, no per-workspace sibling yet
+		// recognized. Same enterprise id, so it must be retired.
+		const orphan = await insertConnection({
+			slug: "slackinst-orgwide",
+			externalTenantId: ENTERPRISE,
+			live: true,
+		});
+
+		await runMigrationUp();
+
+		expect(await connIsLive(workspace)).toBe(true);
+		expect(await connEnterpriseId(workspace)).toBe(ENTERPRISE);
+		expect(await connIsLive(orphan)).toBe(false);
+	});
+
+	test("never retires an org-wide connection with no live per-workspace sibling", async () => {
+		// An org-wide (E…) connection whose workspace was never reinstalled
+		// per-workspace: no live T… sibling carries this enterprise id, so it stays.
+		const lone = await insertConnection({
+			slug: "slackinst-lone-orgwide",
+			externalTenantId: ENTERPRISE,
+			live: true,
+		});
+
+		await runMigrationUp();
+
+		expect(await connIsLive(lone)).toBe(true);
+	});
+
+	test("never crosses orgs when superseding", async () => {
+		const OTHER = "org-other-ent";
+		await getDb()`
+      INSERT INTO organization (id, name, slug) VALUES (${OTHER}, 'Other', ${OTHER})
+      ON CONFLICT (id) DO NOTHING
+    `;
+		// Live per-workspace sibling in ORG carrying the enterprise id...
+		await insertConnection({
+			slug: "slackinst-ws-org",
+			externalTenantId: "T_WS2",
+			live: true,
+			config: { chatMetadata: { enterpriseId: ENTERPRISE } },
+		});
+		// ...must NOT retire an org-wide connection of the same enterprise in ANOTHER org.
+		const otherOrphan = (
+			await getDb()`
+        INSERT INTO connections (
+          organization_id, connector_key, slug, display_name, status,
+          credential_mode, external_tenant_id, config, deleted_at
+        ) VALUES (
+          ${OTHER}, 'slack', 'slackinst-other-orgwide', 'Workspace', 'active',
+          'managed', ${ENTERPRISE}, '{}', null
+        )
+        RETURNING id
+      `
+		)[0].id as number;
+
+		await runMigrationUp();
+
+		expect(await connIsLive(Number(otherOrphan))).toBe(true);
+	});
+});

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -201,6 +201,15 @@ export async function upsertChatConnectionProjection(
   const rawTeamId = conn.metadata?.teamId;
   const externalTenantId =
     typeof rawTeamId === "string" && rawTeamId.length > 0 ? rawTeamId : null;
+  // Grid enterprise id, when the install carried one. A stale ORG-WIDE generation
+  // of the same workspace is keyed on this `E…` id (see enterprise-sibling
+  // supersede below). Only meaningful when it differs from this row's own tenant
+  // key — i.e. this is the newer PER-WORKSPACE (`T…`) generation.
+  const rawEnterpriseId = conn.metadata?.enterpriseId;
+  const enterpriseId =
+    typeof rawEnterpriseId === "string" && rawEnterpriseId.length > 0
+      ? rawEnterpriseId
+      : null;
   const tenantLockKey = chatTenantAdvisoryLockKey(conn, orgId);
   const managedLockKey = managedTenantAdvisoryLockKey(conn);
   const displayName =
@@ -253,6 +262,48 @@ export async function upsertChatConnectionProjection(
         },
         "Demoted sibling active chat connection (one-active-per-tenant)",
       );
+    }
+
+    // Enterprise-sibling supersede (Grid). An ORG-WIDE Grid install returns no
+    // `team`, so its connection was keyed on the enterprise `E…` id. When the SAME
+    // workspace is later reinstalled PER-WORKSPACE, Slack returns a `T…` and this
+    // projection runs under that `T…` key — the exact-tenant demote above cannot
+    // see the `E…` row as the same workspace, so it would be orphaned (its
+    // streaming feed stranded). Retire that stale org-wide generation here: same
+    // org, same platform, keyed on THIS install's enterprise id. Guarded so it
+    // never touches the current row and only fires when the two keys differ (the
+    // org-wide row itself is keyed on `E…`, so re-projecting it is a no-op).
+    // Soft-delete (not pause) so it leaves routing entirely and the
+    // retire_streaming_feeds_for_deleted_connection trigger reclaims its feeds.
+    if (
+      managedLockKey &&
+      credentialMode === "managed" &&
+      enterpriseId &&
+      enterpriseId !== externalTenantId
+    ) {
+      const supersededEnterprise = await sql`
+        UPDATE connections SET deleted_at = now(), status = 'paused', updated_at = now()
+        WHERE organization_id = ${orgId}
+          AND connector_key = ${conn.platform}
+          AND external_tenant_id = ${enterpriseId}
+          AND credential_mode = 'managed'
+          AND deleted_at IS NULL
+          AND slug <> ${slug}
+        RETURNING slug
+      `;
+      if (supersededEnterprise.length > 0) {
+        logger.info(
+          {
+            orgId,
+            platform: conn.platform,
+            teamId: externalTenantId,
+            enterpriseId,
+            activated: slug,
+            superseded: supersededEnterprise.map((r: { slug: string }) => r.slug),
+          },
+          "Retired stale org-wide Grid connection superseded by per-workspace reinstall",
+        );
+      }
     }
 
     // Cross-org managed transfer/demote — managed writes ONLY. A MANAGED

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -201,10 +201,8 @@ export async function upsertChatConnectionProjection(
   const rawTeamId = conn.metadata?.teamId;
   const externalTenantId =
     typeof rawTeamId === "string" && rawTeamId.length > 0 ? rawTeamId : null;
-  // Grid enterprise id, when the install carried one. A stale ORG-WIDE generation
-  // of the same workspace is keyed on this `E…` id (see enterprise-sibling
-  // supersede below). Only meaningful when it differs from this row's own tenant
-  // key — i.e. this is the newer PER-WORKSPACE (`T…`) generation.
+  // Grid identity lets a T… projection find the stale E…-keyed generation even
+  // though their tenant keys differ.
   const rawEnterpriseId = conn.metadata?.enterpriseId;
   const enterpriseId =
     typeof rawEnterpriseId === "string" && rawEnterpriseId.length > 0
@@ -222,7 +220,7 @@ export async function upsertChatConnectionProjection(
   };
 
   if (status === "active" && externalTenantId) {
-    // Universal order (see chatTenantAdvisoryLockKey): BOTH advisories up
+    // Universal order (see chatTenantAdvisoryLockKey): tenant advisories up
     // front, before ANY row lock — in particular the same-org demote below is
     // a row lock and must follow the managed-advisory, or a concurrent
     // cross-org write (managed-advisory, then row-locks THIS org's sibling)
@@ -234,6 +232,13 @@ export async function upsertChatConnectionProjection(
     if (managedLockKey) {
       await sql.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
         managedLockKey,
+      ]);
+    }
+    if (credentialMode === "managed" && enterpriseId) {
+      // E… and T… installs take different tenant locks. This shared lock orders
+      // the E… projection write against a T… activation tombstoning that row.
+      await sql.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+        `chatconn:${orgId}:${conn.platform}:enterprise:${enterpriseId}`,
       ]);
     }
 
@@ -264,19 +269,10 @@ export async function upsertChatConnectionProjection(
       );
     }
 
-    // Enterprise-sibling supersede (Grid). An ORG-WIDE Grid install returns no
-    // `team`, so its connection was keyed on the enterprise `E…` id. When the SAME
-    // workspace is later reinstalled PER-WORKSPACE, Slack returns a `T…` and this
-    // projection runs under that `T…` key — the exact-tenant demote above cannot
-    // see the `E…` row as the same workspace, so it would be orphaned (its
-    // streaming feed stranded). Retire that stale org-wide generation here: same
-    // org, same platform, keyed on THIS install's enterprise id. Guarded so it
-    // never touches the current row and only fires when the two keys differ (the
-    // org-wide row itself is keyed on `E…`, so re-projecting it is a no-op).
-    // Soft-delete (not pause) so it leaves routing entirely and the
-    // retire_streaming_feeds_for_deleted_connection trigger reclaims its feeds.
+    // A T… activation retires an orphaned E…-keyed generation. An E… row with an
+    // active backing install remains valid: Slack allows an org-wide install to
+    // coexist with separately installed Grid workspaces.
     if (
-      managedLockKey &&
       credentialMode === "managed" &&
       enterpriseId &&
       enterpriseId !== externalTenantId
@@ -287,8 +283,16 @@ export async function upsertChatConnectionProjection(
           AND connector_key = ${conn.platform}
           AND external_tenant_id = ${enterpriseId}
           AND credential_mode = 'managed'
+          AND status = 'active'
           AND deleted_at IS NULL
           AND slug <> ${slug}
+          AND NOT EXISTS (
+            SELECT 1 FROM app_installations ai
+            WHERE ai.organization_id = ${orgId}
+              AND ai.provider = ${conn.platform}
+              AND ai.metadata->>'external_id' = connections.slug
+              AND ai.status = 'active'
+          )
         RETURNING slug
       `;
       if (supersededEnterprise.length > 0) {
@@ -301,7 +305,7 @@ export async function upsertChatConnectionProjection(
             activated: slug,
             superseded: supersededEnterprise.map((r: { slug: string }) => r.slug),
           },
-          "Retired stale org-wide Grid connection superseded by per-workspace reinstall",
+          "Retired stale enterprise-keyed Slack Grid connection projection",
         );
       }
     }

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -346,11 +346,9 @@ export async function upsertSlackInstallByTeam(
         teamId,
         ...(slackRow.teamName ? { teamName: slackRow.teamName } : {}),
         ...(slackRow.botUserId ? { botUserId: slackRow.botUserId } : {}),
-        // Persist the Grid enterprise id (and the org-wide flag) onto the
-        // connection so the projection can recognize a stale ORG-WIDE (`E…`-keyed)
-        // generation as the SAME workspace when a later PER-WORKSPACE reinstall
-        // arrives under a `T…` key — otherwise the old `E…` connection is orphaned
-        // rather than superseded, stranding its streaming feed.
+        // Persist Grid identity so a later T… activation can recognize an
+        // orphaned E…-keyed projection. An E… row with an active backing install
+        // remains valid for org-wide sibling routing and is not retired.
         ...(data.enterpriseId ? { enterpriseId: data.enterpriseId } : {}),
         ...(data.isEnterpriseInstall ? { isEnterpriseInstall: true } : {}),
       },

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -346,6 +346,13 @@ export async function upsertSlackInstallByTeam(
         teamId,
         ...(slackRow.teamName ? { teamName: slackRow.teamName } : {}),
         ...(slackRow.botUserId ? { botUserId: slackRow.botUserId } : {}),
+        // Persist the Grid enterprise id (and the org-wide flag) onto the
+        // connection so the projection can recognize a stale ORG-WIDE (`E…`-keyed)
+        // generation as the SAME workspace when a later PER-WORKSPACE reinstall
+        // arrives under a `T…` key — otherwise the old `E…` connection is orphaned
+        // rather than superseded, stranding its streaming feed.
+        ...(data.enterpriseId ? { enterpriseId: data.enterpriseId } : {}),
+        ...(data.isEnterpriseInstall ? { isEnterpriseInstall: true } : {}),
       },
       status: "active",
       createdAt: slackRow.createdAt,


### PR DESCRIPTION
## What

Fixes the Slack Grid recurrence root cause on the **connection** side (companion to the feed-side fixes #2157 and #2163).

A Grid **org-wide** install returns no `team` from `oauth.v2.access`, so its connection is keyed on the enterprise `E…` id. When the same workspace is later reinstalled **per-workspace**, Slack returns a `T…` id and mints a *new* connection. The projection's exact-tenant demote can't recognize the `E…` row as the same workspace, so it's left live-but-orphaned — stranding its streaming feed (the damage #2157 cleaned and #2163 stopped recurring on the feed side).

## How

- **`slack-installations.ts`** — persist the Grid `enterpriseId` + `isEnterpriseInstall` onto the connection at install time, so the projection can recognize a stale org-wide generation as the same workspace.
- **`connections-projection.ts`** — enterprise-sibling supersede: when a per-workspace (`T…`) reinstall carries an `enterpriseId` that differs from its own tenant key, soft-delete the stale org-wide (`E…`) generation (same org, same connector, keyed on that enterprise id, `slug <> this`). The `retire_streaming_feeds_for_deleted_connection` trigger (#2163) then reclaims its feeds.
- **Migration `20260723200000`** — makes the invariant true for existing rows:
  1. Backfill `chatMetadata.enterpriseId`/`isEnterpriseInstall` from each connection's backing `app_installations` row. Built via `jsonb || jsonb_build_object(...)` merge so it works even when the connection config has no `chatMetadata` object yet (plain `jsonb_set('{chatMetadata,enterpriseId}',…,true)` is a **silent no-op** in that case — caught by the replay test).
  2. Retire any live org-wide (`E…`) connection already superseded by a live per-workspace sibling of the same enterprise in the same org.

## Testing

- **Migration replay test** (`backfill-slack-enterprise-id.test.ts`, 4 cases) — mutation-proven: red on the neutered `jsonb_set` form, green on the merge form.
- **Projection supersede test** (added to `connections-unify-managed-routing.test.ts`) — mutation-proven: red when the supersede block is neutered (`E…` orphan stays live), green with the fix.
- **Prod dry-run** (rolled back): backfill 1 row (conn 448 LobuSandbox → `E0BDSKL1KJL`), retire 0 (orphans already tombstoned — no collateral).
- `make pre-pr` clean; pre-commit biome + tsc pass.

## Follow-up (not in this PR)

End-to-end reinstall test (org-wide → per-workspace) against a live Slack workspace via the paired Owletto extension — to be done after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack enterprise connection handling when a workspace is reinstalled.
  * Automatically retires stale organization-wide connections when a valid workspace connection supersedes them.
  * Preserves active workspace connections while preventing duplicate or orphaned enterprise connections.
  * Backfills missing enterprise metadata for existing Slack connections.
* **Tests**
  * Added coverage for enterprise routing, organization boundaries, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->