### PR TITLE
fix(agents): query workspace data before deflecting to chat-only

### DIFF
--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -161,6 +161,25 @@ describe('buildWorkspaceInstructions render fixes', () => {
       '- shop.disconnected (Available before setup): create_order'
     );
   });
+
+  it('renders workspace-data query guidance without org-specific setup', async () => {
+    const emptyOrg = await createTestOrganization({ name: 'Empty Render Org' });
+    const out = await buildWorkspaceInstructions(emptyOrg.id);
+    expect(out).toContain(
+      "When asked about the workspace's data — including people, leads, companies, connections, feeds, runs, or counts — query it before answering"
+    );
+    expect(out).toContain(
+      'Use `search_memory` for semantic recall and `query_sdk` or `query_sql` for structured lookups and counts'
+    );
+    expect(out).toContain(
+      'Do not claim you can see only chat/Slack messages or channel members without querying workspace data first'
+    );
+    const directiveIdx =
+      out?.indexOf("When asked about the workspace's data") ?? -1;
+    const toolSurfaceIdx = out?.indexOf('### Tool surface') ?? -1;
+    expect(directiveIdx).toBeGreaterThan(-1);
+    expect(directiveIdx).toBeLessThan(toolSurfaceIdx);
+  });
 });
 
 describe('org-wide guidance context', () => {

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -97,6 +97,8 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       '## Lobu — Your Persistent Memory',
       '',
       "You have persistent memory. Use it proactively — don't wait to be asked.",
+      '',
+      "When asked about the workspace's data — including people, leads, companies, connections, feeds, runs, or counts — query it before answering. Use `search_memory` for semantic recall and `query_sdk` or `query_sql` for structured lookups and counts; these tools default to the current organization. Do not claim you can see only chat/Slack messages or channel members without querying workspace data first.",
     ];
 
     // Org-wide admin-authored context goes near the top: it is the governed


### PR DESCRIPTION
## Problem
The shared Lobu MCP-server instruction block — rendered into **every** agent's prompt via `buildMcpServerInstructions` → `gatewayInstructions` — told agents they have persistent memory but never told them to **query the workspace's own data** when asked about it.

A setup-focused agent (e.g. the **Builder** in LobuSandbox) asked *"how many people do we have?"* answered *"I can only read Slack messages… the only person I see is you"* — interpreting a CRM-data question as a Slack-channel-members question and deflecting to the chat transcript, instead of querying the `Person`/`Lead` entities (org `org_lobucrm`: 951 Person + 26 Lead) it **already had** `query_sdk`/`query_sql`/`search_memory` tools for. `agents.tools_config = {}` = full default toolset — the capability was there; the prompt didn't point at it.

## Fix
Add a query-first directive to the always-present intro of the "## Lobu — Your Persistent Memory" block in `buildWorkspaceInstructions`. Because this block ships to every agent, it fixes the whole class at once — not one agent's `identity_md`, which would let the narrow-identity trap recur for the next agent someone creates.

The directive: when asked about the workspace's data (people/leads/companies/connections/feeds/runs/counts), query it first (`search_memory` for semantic recall, `query_sdk`/`query_sql` for structured lookups and counts); do not claim chat-only visibility without querying.

## Why this layer (not per-agent, not a new instruction mechanism)
- Reuses the **existing** MCP-server-instructions mechanism (`buildWorkspaceInstructions` → `mcp-handler` sets `authCtx.instructions` → rendered by `buildMcpServerInstructions`). No new prompt layer.
- The intro is unconditional, so agents in orgs with **no** connectors/guidance still receive it (test pins this against a fresh empty org).

## Test / evidence
- New integration test in `workspace-instructions.test.ts` asserts the directive renders for an org with no org-specific setup and sits before the conditional `### Tool surface` section.
- Red→green proven locally: test FAILS with the directive removed, PASSES with it. Full file 25/25 green (Postgres on :5418).
- `make pre-pr` clean; `make review-fix` run on the settled diff (it tightened tool-role wording and strengthened the test to use an empty org).

## Post-deploy verification owed
The Builder DM re-test (repro *"how many people do we have?"* in LobuSandbox → expect ~951 with a real `query_sdk`/`query_sql` call in the run) requires this to be **live**, since the Builder runs on prod infra. Pre-deploy prod still deflects (that's the captured "before"). Will re-run once deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance to ensure workspace-data questions are checked using the appropriate tools before responding.
  * Clarified that workspace contents should not be claimed as visible without querying them.

* **Tests**
  * Added coverage verifying this guidance appears correctly, including when no organization-specific setup is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->