### PR TITLE
feat: landing-page theme on public pages + owletto bump

### DIFF
--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -346,7 +346,7 @@ function renderPublicShell(
       ? `<nav class="mb-5 flex flex-wrap gap-2 text-sm text-muted-foreground" aria-label="Breadcrumb">${breadcrumbs
           .map((crumb, index) =>
             crumb.href
-              ? `<a class="text-primary no-underline hover:underline" href="${escapeAttribute(crumb.href)}">${escapeHtml(crumb.label)}</a>${
+              ? `<a class="text-foreground no-underline hover:underline" href="${escapeAttribute(crumb.href)}">${escapeHtml(crumb.label)}</a>${
                   index < breadcrumbs.length - 1
                     ? '<span class="text-muted-foreground/60">/</span>'
                     : ''
@@ -360,7 +360,7 @@ function renderPublicShell(
     <div class="mx-auto max-w-6xl px-4 pb-16 pt-8 text-foreground sm:px-5 sm:pb-20 sm:pt-12">
       ${breadcrumbHtml}
       <header class="mb-8">
-        <p class="mb-3 text-xs font-bold uppercase tracking-wider text-primary">${escapeHtml(eyebrow)}</p>
+        <p class="mb-3 text-xs font-bold uppercase tracking-wider text-foreground">${escapeHtml(eyebrow)}</p>
         <h1 class="font-display text-3xl font-semibold text-foreground">${escapeHtml(heading)}</h1>
         <p class="mt-3 max-w-2xl text-base leading-relaxed text-muted-foreground">${escapeHtml(description)}</p>
       </header>

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -297,7 +297,7 @@ function renderStatList(stats: Array<{ label: string; value: string }>): string 
       ${stats
         .map(
           (stat) => `
-            <div class="rounded-xl border border-border bg-muted/30 p-4">
+            <div class="rounded-lg bg-card p-4">
               <dt class="text-xs uppercase tracking-wide text-muted-foreground">${escapeHtml(stat.label)}</dt>
               <dd class="mt-1.5 text-lg font-bold text-foreground">${escapeHtml(stat.value)}</dd>
             </div>
@@ -321,10 +321,10 @@ function renderLinkList(
         .map(
           (item) => `
             <li class="m-0">
-              <a class="block rounded-xl border border-border bg-card p-4 text-foreground no-underline transition-colors hover:border-muted-foreground/40 hover:bg-muted/30" href="${escapeAttribute(item.href)}">
-                <strong class="block text-base font-semibold text-foreground">${escapeHtml(item.title)}</strong>
+              <a class="block rounded-lg bg-card p-4 text-muted-foreground no-underline transition-colors hover:bg-accent/50 hover:text-foreground" href="${escapeAttribute(item.href)}">
+                <strong class="block text-base font-semibold">${escapeHtml(item.title)}</strong>
                 ${item.meta ? `<span class="mt-1.5 block text-sm text-muted-foreground">${escapeHtml(item.meta)}</span>` : ''}
-                ${item.body ? `<span class="mt-2 block leading-relaxed text-foreground/80">${escapeHtml(item.body)}</span>` : ''}
+                ${item.body ? `<span class="mt-2 block leading-relaxed text-muted-foreground">${escapeHtml(item.body)}</span>` : ''}
               </a>
             </li>
           `
@@ -346,7 +346,7 @@ function renderPublicShell(
       ? `<nav class="mb-5 flex flex-wrap gap-2 text-sm text-muted-foreground" aria-label="Breadcrumb">${breadcrumbs
           .map((crumb, index) =>
             crumb.href
-              ? `<a class="text-teal-700 no-underline hover:underline dark:text-teal-400" href="${escapeAttribute(crumb.href)}">${escapeHtml(crumb.label)}</a>${
+              ? `<a class="text-primary no-underline hover:underline" href="${escapeAttribute(crumb.href)}">${escapeHtml(crumb.label)}</a>${
                   index < breadcrumbs.length - 1
                     ? '<span class="text-muted-foreground/60">/</span>'
                     : ''
@@ -360,7 +360,7 @@ function renderPublicShell(
     <div class="mx-auto max-w-6xl px-4 pb-16 pt-8 text-foreground sm:px-5 sm:pb-20 sm:pt-12">
       ${breadcrumbHtml}
       <header class="mb-8">
-        <p class="mb-3 text-xs font-bold uppercase tracking-wider text-teal-700 dark:text-teal-400">${escapeHtml(eyebrow)}</p>
+        <p class="mb-3 text-xs font-bold uppercase tracking-wider text-primary">${escapeHtml(eyebrow)}</p>
         <h1 class="text-3xl font-semibold text-foreground">${escapeHtml(heading)}</h1>
         <p class="mt-3 max-w-2xl text-base leading-relaxed text-muted-foreground">${escapeHtml(description)}</p>
       </header>
@@ -756,7 +756,7 @@ function buildEntityModel(
           ? `<dl class="grid gap-3">${metadataEntries
               .map(
                 ([key, value]) => `
-                  <div class="rounded-xl border border-border bg-card p-4">
+                  <div class="rounded-lg bg-card p-4">
                     <dt class="text-xs uppercase tracking-wide text-muted-foreground">${escapeHtml(sentenceCase(key))}</dt>
                     <dd class="mt-2 leading-relaxed text-foreground">${escapeHtml(
                       Array.isArray(value)

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -361,7 +361,7 @@ function renderPublicShell(
       ${breadcrumbHtml}
       <header class="mb-8">
         <p class="mb-3 text-xs font-bold uppercase tracking-wider text-primary">${escapeHtml(eyebrow)}</p>
-        <h1 class="text-3xl font-semibold text-foreground">${escapeHtml(heading)}</h1>
+        <h1 class="font-display text-3xl font-semibold text-foreground">${escapeHtml(heading)}</h1>
         <p class="mt-3 max-w-2xl text-base leading-relaxed text-muted-foreground">${escapeHtml(description)}</p>
       </header>
       ${sections


### PR DESCRIPTION
Server-side companion to owletto#571 (landing theme + ChatGPT sidebar).

## Changes (lobu)
- \`public-pages.ts\`: align the SSR public pages (\`app.lobu.ai/*\`) with the app/landing design tokens
  - teal accent → \`text-primary\` (teal was never in the palette)
  - banned \`rounded-xl\` → \`rounded-lg\`; drop redundant borders on filled \`bg-card\` boxes (§2/§7)
  - Geist Pixel display font on public-page headings (\`font-display\`)
- bump the owletto submodule pointer to pick up the theme + sidebar work

## Depends on
- owletto#571 — the actual app theme + sidebar changes (submodule)

Public SSR pages already share the app's Tailwind theme, so these render red/Inter/Geist Pixel once the owletto bump lands. Verified the isolated public page renders correctly in light+dark.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the appearance of public pages, including stat cards, link lists, breadcrumbs, page headers, and metadata tiles.
  - Updated typography, colors, spacing, and visual presentation for a more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->