### PR TITLE
feat(behaviors): multi-trigger editor (OR activations)

### DIFF
--- a/packages/server/src/__tests__/unit/behavior-event-trigger.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-event-trigger.test.ts
@@ -104,6 +104,47 @@ describe('behavior event trigger matching', () => {
     ).toEqual([]);
   });
 
+  test('returns every matching event trigger in array order (multi-trigger OR)', () => {
+    const broad: BehaviorEventTrigger = {
+      ...githubTrigger,
+      match: undefined,
+      execution: 'window',
+      output: 'silent',
+    };
+    const specific: BehaviorEventTrigger = {
+      ...githubTrigger,
+      execution: 'turn',
+      output: 'reply_to_source',
+    };
+    const signal: ConnectorTriggerSignal = {
+      connector_key: 'github',
+      connection_id: 42,
+      event_type: 'pull_request.created',
+      delivery_id: 'delivery-multi',
+      input_text: 'GitHub PR',
+      resource_type: 'pull_request',
+      resource_ref: 'github:pull_request:lobu-ai/lobu#208',
+      attributes: { resource_ref: 'github:pull_request:lobu-ai/lobu#208' },
+    };
+    // First match wins for activation policy; matching itself keeps full order.
+    expect(matchingBehaviorTriggers([broad, specific], signal)).toEqual([
+      broad,
+      specific,
+    ]);
+    expect(matchingBehaviorTriggers([specific, broad], signal)[0]).toBe(
+      specific,
+    );
+  });
+
+  test('rejects more than one schedule trigger on write', () => {
+    expect(() =>
+      normalizeBehaviorTriggers([
+        { kind: 'schedule', cron: '0 9 * * *' },
+        { kind: 'schedule', cron: '0 18 * * *' },
+      ]),
+    ).toThrow(/at most one schedule/i);
+  });
+
   test('fails closed across connections and normalized match fields', () => {
     const signal: ConnectorTriggerSignal = {
       connector_key: 'slack',

--- a/packages/server/src/behaviors/activation.ts
+++ b/packages/server/src/behaviors/activation.ts
@@ -116,6 +116,9 @@ export async function findMatchingBehaviorActivations(
     const triggers = Array.isArray(row.triggers)
       ? (row.triggers as BehaviorEventTrigger[])
       : [];
+    // Multi-trigger Behaviors OR activations: any matching event trigger is
+    // enough to run once. When several match the same signal, the first in
+    // array order supplies execution/output/active_run (UI documents this).
     const [trigger] = matchingBehaviorTriggers(
       triggers.filter(
         (candidate): candidate is BehaviorEventTrigger =>


### PR DESCRIPTION
## What
Submodule bump for **owletto#581** plus a small server doc/test for multi-trigger matching.

Behaviors already store `triggers[]` and the runtime ORs them. The SPA only edited the first trigger.

- **UI**: multi-trigger list on create + edit; saves full array; ≤1 schedule
- **Summaries**: `When A, or when B…`
- **Runtime**: if several triggers match one event, first in array order still supplies run options (comment + unit coverage)

## Testing
- Owletto behavior editor + model tests: 20 passing; `tsc -b` clean
- Lobu pre-commit: typecheck + biome clean

Paired with https://github.com/lobu-ai/owletto/pull/581

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->