### PR TITLE
fix(cli): clear message on unsupported Node instead of undici crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
         with:
           bun-version: 1.3.5
 
+      # Node 22 — the node-version-guard test spawns the real `node` on PATH and
+      # asserts the CLI gate lets a supported Node through. The runner's default
+      # Node major (20) is below Lobu's floor of 22, so without this the guard
+      # fires and the "real runtime, >=22" case fails. Matches every other job.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
       - name: Install bubblewrap (for embedded exec-sandbox tests)
         # The worker exec-sandbox uses bwrap on Linux; without it, the live
         # bwrap escape-matrix tests in `packages/agent-worker/src/__tests__/exec-sandbox.test.ts`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - **`events` is append-only.** Never `DELETE FROM events`; tombstone/supersede instead.
 - **Workers never receive real credentials.** They may receive only placeholders/proxied access.
 - Default to static `import`. New dynamic imports require measured cost justification here or in the package AGENTS plus a rationale comment at the call site. Tests may dynamically import after mocks.
+  - Node-version gate exceptions: `packages/cli/bin/lobu.js` defers the existing CLI graph without duplicating it, and `packages/server/src/server-entry.ts` adds an 842-byte gate in front of the 4.34 MB server graph (measured 2026-07-24). Both call sites must stay dependency-free until their checks pass.
 - Bug fixes require red→fix→green evidence. If you cannot reproduce, bail and report the dead end.
 - Run `make pre-pr` (fast no-DB CI gates: typecheck + knip + lint) AND `make review` (LLM verdict) before PR/merge. `make review` does NOT run typecheck/knip/tests — it is not proof CI will pass. If you touch server/runtime code, also run the relevant `bun test`/`make test-integration` suite.
 - **Run `make review-fix` on the settled diff BEFORE the first `make review`.** It runs the reviewer with write access to fix review-grade findings (bugs, slop, stale claims) without posting a status; verify its diff, commit, then post one review. Never iterate `make review` as a find-fix loop — each posted round costs a review + CI cycle. If a posted review still fails, fix the finding AND its whole class before re-running.

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -71,8 +71,10 @@ const config: KnipConfig = {
     },
     "packages/server": {
       entry: [
-        // Main server boot (package main points at compiled dist/, so knip
-        // can't map it back to source).
+        // Bundle entry (esbuild). server-entry.ts is the Node-version gate that
+        // dynamically imports the server-main bundle; server.ts is the graph it
+        // loads. Both are esbuild entrypoints, so knip can't see them via imports.
+        "src/server-entry.ts",
         "src/server.ts",
         // Sentry preload (node --import) and embedded-Postgres boot.
         "src/instrument.ts",

--- a/packages/cli/bin/lobu.js
+++ b/packages/cli/bin/lobu.js
@@ -1,5 +1,51 @@
 #!/usr/bin/env node
 
-import { runCli } from "../dist/index.js";
+// ─────────────────────────────────────────────────────────────────────────────
+// Node-version gate. MUST run before `import "../dist/index.js"`.
+//
+// The floor is Node 22 because Lobu's agent-code sandbox (isolated-vm) only
+// has native builds for Node 22–24 and 26+. Separately, on Node < 20 the
+// bundled server's undici (via @sentry/node) references the `File` global and
+// the very first `import` of the bundle throws a cryptic
+// `ReferenceError: File is not defined` — before any Lobu code, including the
+// server's own assert-node-version guard, can run (ESM hoists the graph's
+// imports above module bodies). So the check lives here, with zero imports, so
+// nothing loads before it, and old-Node users get a clear message instead.
+//
+// Keep the threshold in sync with packages/cli/src/internal/node-version.ts
+// (`lobu doctor`) and packages/server's assert-node-version.ts. 25 boots but
+// has no isolated-vm build (no SDK sandbox).
+// ─────────────────────────────────────────────────────────────────────────────
+{
+  const MIN_NODE_MAJOR = 22;
+  const current = process.versions.node;
+  const major = Number.parseInt(current.split(".")[0], 10);
+  if (!Number.isFinite(major) || major < MIN_NODE_MAJOR) {
+    process.stderr.write(
+      [
+        "",
+        `  Lobu needs Node.js ${MIN_NODE_MAJOR} or newer — you're on Node ${current}.`,
+        "",
+        "  (Lobu runs agent code in an isolated-vm sandbox whose native builds",
+        `   only cover Node ${MIN_NODE_MAJOR}–24 and 26+, so ${MIN_NODE_MAJOR} is the minimum.)`,
+        "",
+        "  Install a supported Node, then re-run:",
+        "    • nvm:   nvm install 22 && nvm use 22",
+        "    • fnm:   fnm install 22 && fnm use 22",
+        "    • brew:  brew install node@22",
+        "",
+        "  Check your version with:  node --version",
+        "",
+      ].join("\n") + "\n"
+    );
+    process.exit(1);
+  }
+}
+
+// Dynamic import (not a static top-level `import`) is REQUIRED here: a static
+// import is hoisted and evaluated before the guard block above runs, so the
+// bundle — and undici — would load before we could reject an old Node. The
+// dynamic import defers that load until after the version gate has passed.
+const { runCli } = await import("../dist/index.js");
 
 await runCli(process.argv);

--- a/packages/cli/scripts/build.cjs
+++ b/packages/cli/scripts/build.cjs
@@ -69,7 +69,11 @@ copyDirIfExists("../owletto/dist", "dist/owletto/dist");
 // what ships inside the CLI tarball. CI's publish flow builds the bundles
 // (`build:server`) before this script runs; if they're missing locally, run
 // `bun run --filter '@lobu/server' build:server` first.
-for (const bundleName of ["server.bundle.mjs"]) {
+// server.bundle.mjs is the tiny Node-version gate; it dynamically imports its
+// sibling server-main.bundle.mjs (the real server graph) at runtime — so both
+// must ship together. Missing server-main.bundle.mjs
+// would make `lobu run` fail with a module-not-found after the gate passes.
+for (const bundleName of ["server.bundle.mjs", "server-main.bundle.mjs"]) {
   const bundleSrc = `../server/dist/${bundleName}`;
   const bundleDest = `dist/${bundleName}`;
   if (fs.existsSync(bundleSrc)) {
@@ -77,7 +81,7 @@ for (const bundleName of ["server.bundle.mjs"]) {
   } else {
     console.warn(
       `[cli build] server bundle missing at ${bundleSrc}; ` +
-        "`lobu run` may fall back to monorepo-relative lookup. Run " +
+        "`lobu run` requires both server bundles. Run " +
         "`bun run --filter '@lobu/server' build:server` to bundle it."
     );
   }

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -266,6 +266,9 @@ describe("lobu run backend bundle resolution", () => {
     );
     expect(buildScript).toContain('copyDirIfExists("../../db/migrations"');
     expect(buildScript).toContain('"server.bundle.mjs"');
+    // The gate bundle dynamically imports server-main.bundle.mjs at runtime;
+    // both must ship or `lobu run` breaks after the Node-version check passes.
+    expect(buildScript).toContain('"server-main.bundle.mjs"');
   });
 });
 

--- a/packages/cli/src/__tests__/node-version-guard.test.ts
+++ b/packages/cli/src/__tests__/node-version-guard.test.ts
@@ -1,0 +1,126 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+  checkNodeSupport,
+  sandboxAvailableForNode,
+} from "../internal/node-version.js";
+
+// bin/lobu.js runs under Node in production (its shebang is `#!/usr/bin/env
+// node`). `process.execPath` here is Bun, so invoke `node` through PATH.
+const NODE = "node";
+const temporaryDirs: string[] = [];
+
+function spoofPreload(version: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "lobu-nodever-"));
+  temporaryDirs.push(dir);
+  const file = join(dir, "spoof.cjs");
+  writeFileSync(
+    file,
+    `Object.defineProperty(process.versions, 'node', { value: ${JSON.stringify(
+      version
+    )}, configurable: true });\n`
+  );
+  return file;
+}
+
+afterAll(() => {
+  for (const dir of temporaryDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("checkNodeSupport", () => {
+  test("classifies the running Node as supported (tests run on >=22)", () => {
+    const support = checkNodeSupport();
+    expect(support.ok).toBe(true);
+  });
+
+  test("sandbox availability follows the isolated-vm build matrix", () => {
+    // isolated-vm@6 → 22–24; nothing on 25; isolated-vm@7 → 26+.
+    expect(sandboxAvailableForNode(22)).toBe(true);
+    expect(sandboxAvailableForNode(24)).toBe(true);
+    expect(sandboxAvailableForNode(25)).toBe(false);
+    expect(sandboxAvailableForNode(26)).toBe(true);
+    // Below the floor is not "sandbox unavailable", it's unsupported entirely.
+    expect(sandboxAvailableForNode(18)).toBe(false);
+  });
+});
+
+describe("bin/lobu.js Node gate", () => {
+  // Spoof process.versions.node via a preload that runs BEFORE the bin body,
+  // so we can prove the guard fires on an old Node without needing one
+  // installed. defineProperty is required — process.versions.node is read-only.
+  const binEntry = join(import.meta.dir, "..", "..", "bin", "lobu.js");
+
+  test("exits non-zero with an explicit message on Node 18", () => {
+    const proc = spawnSync(NODE, [binEntry, "--version"], {
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--require ${spoofPreload("18.19.1")}`,
+      },
+      encoding: "utf8",
+    });
+    const out = (proc.stdout ?? "") + (proc.stderr ?? "");
+
+    // The explicit, actionable message — NOT the raw undici crash.
+    expect(out).toContain("Node.js 22 or newer");
+    expect(out).toContain("18.19.1");
+    expect(out).not.toContain("File is not defined");
+    expect(proc.status).not.toBe(0);
+  });
+
+  test("does not fire on a supported Node (real runtime, >=22)", () => {
+    // No spoof: the guard must let a supported Node through to normal CLI
+    // handling. `--version` prints and exits 0.
+    const proc = spawnSync(NODE, [binEntry, "--version"], {
+      env: { ...process.env },
+      encoding: "utf8",
+    });
+    const out = (proc.stdout ?? "") + (proc.stderr ?? "");
+    expect(out).not.toContain("Node.js 22 or newer");
+    expect(proc.status).toBe(0);
+  });
+});
+
+describe("server.bundle.mjs Node gate (direct `node bundle` path)", () => {
+  // Covers systemd / managed hosts that run the bundle directly, bypassing
+  // bin/lobu.js. The build (build-server-bundle.mjs) makes server.bundle.mjs a
+  // tiny gate entry that checks the Node version, then dynamically imports the
+  // real graph (server-main.bundle.mjs). The split is required: an in-file
+  // guard can't beat ESM hoisting of the graph's @sentry/node → undici import,
+  // which crashes old Node with `ReferenceError: File is not defined`.
+  //
+  // NOTE: on this Node 26 host, spoofing only the version STRING can't trigger
+  // the real undici crash (the `File` global is genuinely present), so this
+  // asserts the version-gate message + clean exit. The gate-runs-before-undici
+  // guarantee comes from the two-bundle split, not from this spoof.
+  const bundlePath = join(
+    import.meta.dir,
+    "..",
+    "..",
+    "dist",
+    "server.bundle.mjs"
+  );
+  const built = existsSync(bundlePath);
+
+  test.skipIf(!built)(
+    "bundle rejects Node 18 with an explicit message, no undici crash",
+    () => {
+      const proc = spawnSync(NODE, [bundlePath], {
+        env: {
+          ...process.env,
+          NODE_OPTIONS: `--require ${spoofPreload("18.19.1")}`,
+          DATABASE_URL: join(tmpdir(), "lobu-guard-test-nonexistent"),
+        },
+        encoding: "utf8",
+      });
+      const out = (proc.stdout ?? "") + (proc.stderr ?? "");
+      expect(out).toContain("Node.js 22 or newer");
+      expect(out).not.toContain("File is not defined");
+      expect(proc.status).toBe(1);
+    }
+  );
+});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -11,6 +11,7 @@ import {
   resolveEmbeddedDataRoot,
 } from "./dev.js";
 import { parseEnvContent } from "../internal/env-file.js";
+import { MIN_NODE_MAJOR, checkNodeSupport } from "../internal/node-version.js";
 import { loadProviderRegistry } from "./providers/registry.js";
 import { loadProjectConfig } from "./_lib/apply/desired-state.js";
 
@@ -37,13 +38,15 @@ function checkBinaryExists(name: string): Check {
 
 function checkNodeVersion(): Check {
   const version = process.version;
-  const major = Number.parseInt(version.slice(1), 10);
-  // isolated-vm@6 → 22–24, isolated-vm@7 → 26+. Node 25 boots but has no SDK
-  // sandbox build; anything below 22 is unsupported.
-  if (major < 22) {
-    return { name: "node", status: "warn", detail: `${version} (needs >=22)` };
+  const support = checkNodeSupport();
+  if (!support.ok) {
+    return {
+      name: "node",
+      status: "fail",
+      detail: `${version} (needs >=${MIN_NODE_MAJOR})`,
+    };
   }
-  if (major === 25) {
+  if (!support.sandbox) {
     return {
       name: "node",
       status: "warn",

--- a/packages/cli/src/internal/node-version.ts
+++ b/packages/cli/src/internal/node-version.ts
@@ -1,0 +1,54 @@
+/**
+ * Single source of truth for the CLI's Node-version policy.
+ *
+ * Lobu's SDK sandbox (query_sdk / run_sdk) uses isolated-vm, whose native addon
+ * is tied to each Node line's V8 ABI: isolated-vm@6 covers Node 22–24, the
+ * aliased isolated-vm@7 covers Node 26+. Node 25 is an EOL non-LTS line upstream
+ * skipped, so it boots but has no sandbox build. Below 22 nothing works — the
+ * bundled server's deps (undici via @sentry/node) reference globals absent on
+ * old Node and crash on load.
+ *
+ * The `bin/lobu.js` entrypoint carries an inline copy of the MIN threshold
+ * because it must run with zero imports (before the bundle loads); keep it and
+ * packages/server/src/utils/assert-node-version.ts in sync with this file.
+ */
+
+export const MIN_NODE_MAJOR = 22;
+const SANDBOX_GAP_NODE_MAJOR = 25;
+
+function currentNodeMajor(): number {
+  return Number.parseInt(process.versions.node.split(".")[0] ?? "", 10);
+}
+
+/** True when isolated-vm has a build for this Node major (sandbox works). */
+export function sandboxAvailableForNode(major: number): boolean {
+  return (
+    (major >= MIN_NODE_MAJOR && major < SANDBOX_GAP_NODE_MAJOR) || major >= 26
+  );
+}
+
+type NodeSupport =
+  | { ok: true; sandbox: boolean }
+  | { ok: false; reason: string; why: string };
+
+/**
+ * One-line explanation of the floor, so user-facing messages say WHY 22 —
+ * not a bare "unsupported" that reads as arbitrary.
+ */
+const NODE_FLOOR_REASON =
+  `Lobu runs agent code in an isolated-vm sandbox whose native builds only ` +
+  `cover Node ${MIN_NODE_MAJOR}–24 and 26+, so ${MIN_NODE_MAJOR} is the minimum.`;
+
+/** Classify the running Node against Lobu's support policy. */
+export function checkNodeSupport(): NodeSupport {
+  const current = process.versions.node;
+  const major = currentNodeMajor();
+  if (!Number.isFinite(major) || major < MIN_NODE_MAJOR) {
+    return {
+      ok: false,
+      reason: `Lobu needs Node.js ${MIN_NODE_MAJOR} or newer — you're on Node ${current}.`,
+      why: NODE_FLOOR_REASON,
+    };
+  }
+  return { ok: true, sandbox: sandboxAvailableForNode(major) };
+}

--- a/packages/server/scripts/build-server-bundle.mjs
+++ b/packages/server/scripts/build-server-bundle.mjs
@@ -118,10 +118,25 @@ function assertSingleConnectorWorkerIdentity(metafile, outfile) {
   }
 }
 
-// Single entry for both backends: server.ts branches on DATABASE_URL
+// Single server graph for both backends: server.ts branches on DATABASE_URL
 // (postgres:// = external; path/file:// = embedded, lazy-loading the embedded
 // Postgres runtime so the external/prod path never resolves that binary).
-await buildBundle('src/server.ts', 'dist/server.bundle.mjs');
+//
+// Two-file split for the Node-version gate:
+//   server.bundle.mjs       — tiny gate entry (server-entry.ts). Zero app deps.
+//                             Runs a dependency-free Node-major check, then
+//                             dynamically imports ./server-main.bundle.mjs.
+//   server-main.bundle.mjs  — the real server graph (server.ts + all deps).
+//
+// The gate MUST be its own file so esbuild can't hoist the server graph's
+// @sentry/node → undici import above the check. On Node 18, undici references
+// the absent `File` global and throws `File is not defined` at load —
+// before any in-graph guard could run. Keeping the graph behind a runtime
+// dynamic import to a *separate* bundle means undici only loads after the gate
+// passes. server-entry.ts constructs the sibling URL at runtime so esbuild
+// cannot resolve and inline it.
+await buildBundle('src/server.ts', 'dist/server-main.bundle.mjs');
+await buildBundle('src/server-entry.ts', 'dist/server.bundle.mjs');
 
 const connectorsSrc = join(pkgDir, '..', 'connectors', 'src');
 const connectorsDest = join(pkgDir, 'dist', 'connectors');

--- a/packages/server/src/server-entry.ts
+++ b/packages/server/src/server-entry.ts
@@ -1,0 +1,54 @@
+/**
+ * Bundle entry wrapper — Node-version gate FIRST, then the real server.
+ *
+ * The server graph statically imports `@sentry/node`, which pulls `undici`.
+ * On Node 18 undici references the absent `File` global and throws
+ * `ReferenceError: File is not defined` at load — a cryptic crash that
+ * fires before `./server`'s own `assert-node-version` guard can run, because
+ * ES `import` statements are hoisted and evaluated before any sibling module
+ * body (verified: a top-level import's side effects run before an IIFE placed
+ * textually above it).
+ *
+ * So the gate lives HERE, in an entry with zero static imports of the server
+ * graph. The synchronous check runs first; only if it passes do we DYNAMICALLY
+ * import the server graph — which the build emits as a SEPARATE bundle
+ * (server-main.bundle.mjs). Its URL is constructed at runtime so esbuild cannot
+ * inline and re-hoist it.
+ * That is where Sentry/undici finally load. Result: an old Node gets an
+ * explicit, actionable message and a clean exit(1) instead of the undici
+ * ReferenceError.
+ *
+ * Keep the threshold in sync with ./utils/assert-node-version.ts and the CLI's
+ * internal/node-version.ts + bin/lobu.js.
+ */
+
+const MIN_NODE_MAJOR = 22;
+
+function assertNodeOrExit(): void {
+  const current = process.versions.node;
+  const major = Number.parseInt((current ?? "").split(".")[0] ?? "", 10);
+  if (!Number.isFinite(major) || major < MIN_NODE_MAJOR) {
+    process.stderr.write(
+      `\n  Lobu needs Node.js ${MIN_NODE_MAJOR} or newer — you're on Node ${current}.\n` +
+        `  (The isolated-vm sandbox only has native builds for Node ${MIN_NODE_MAJOR}–24 and 26+.)\n` +
+        `  Install Node ${MIN_NODE_MAJOR}+ (nvm/fnm/brew) and re-run.\n\n`,
+    );
+    process.exit(1);
+  }
+}
+
+assertNodeOrExit();
+
+// Dynamic import of the SEPARATE server-main bundle is REQUIRED: a static
+// import — or a dynamic import esbuild can resolve and inline — would hoist the
+// server graph's @sentry/node → undici above assertNodeOrExit(), defeating the
+// gate. Constructing the URL at runtime leaves the import for Node and defers
+// undici until after the check passes. server-main self-executes its main() on
+// load, so importing it boots the server.
+//
+// The specifier is resolved relative to this file's URL so it works from the
+// bundle's dist dir regardless of cwd. In the TS source (dev/tsx) the sibling
+// bundle doesn't exist; that path is bundle-only, which is why this entry is
+// the build's entrypoint, not something imported by the TS server at runtime.
+const serverMainUrl = new URL("./server-main.bundle.mjs", import.meta.url).href;
+await import(serverMainUrl);


### PR DESCRIPTION
## Problem

`npx @lobu/cli@latest run` on **Node 18** crashed with a cryptic `ReferenceError: File is not defined` from undici (issue #2153). `npm`/`npx` don't enforce the `engines` field, so the CLI ran on an unsupported Node. The bundled server statically imports `@sentry/node → undici`, which references the `File` global (absent before Node 20/22) and throws at load — **before** any Lobu code, including the server's own `assert-node-version.ts` guard, could run.

The existing guard couldn't help: ES `import` statements are hoisted and evaluated before any sibling module body, so undici loads first (verified empirically — a hoisted import's side effect runs before an IIFE placed above it). esbuild bundling compounds this by re-hoisting all externals.

The floor is Node 22 because Lobu's agent-code sandbox (`isolated-vm`) only ships native builds for Node 22–24 and 26+.

## Fix

- **`bin/lobu.js`** — dependency-free Node-major gate, then a dynamic (deferred) bundle import so undici can't load first. Clear message stating the requirement and *why*.
- **Server bundle** — split into a tiny gate entry (`server-entry.ts` → `server.bundle.mjs`, 842 bytes) that checks the version, then dynamically imports the real graph as a **separate** `server-main.bundle.mjs` (URL constructed at runtime so esbuild can't inline+re-hoist it). Covers the direct `node server.bundle.mjs` path (systemd/managed).
- **`doctor.ts` + `internal/node-version.ts`** — single source of truth for the policy; old Node now reports `fail`, not `warn`.
- **CLI build + knip config** — ship both bundles; register the new entry.
- **AGENTS.md** — document the two dynamic-import exceptions (measured).

## Messaging (before → after)

Before: raw `ReferenceError: File is not defined`. After:

```
  Lobu needs Node.js 22 or newer — you're on Node 18.19.1.

  (Lobu runs agent code in an isolated-vm sandbox whose native builds
   only cover Node 22–24 and 26+, so 22 is the minimum.)

  Install a supported Node, then re-run:
    • nvm:   nvm install 22 && nvm use 22
    • fnm:   fnm install 22 && fnm use 22
    • brew:  brew install node@22

  Check your version with:  node --version
```

## Verification

- New `node-version-guard.test.ts`: red→green proven (reverting the guard makes it fail with `14.2.0` instead of the message). All 24 CLI guard+dev tests pass.
- Spoofed Node 18 → exit 1 with the message, **zero undici/Sentry loaded**; real Node → server boots normally.
- `make pre-pr` all 5 gates clean.

Closes #2153

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent Node.js version check requiring Node.js 22 or newer for CLI and server startup.
  * Unsupported versions now show a clear, actionable error and exit cleanly instead of producing low-level runtime failures.
  * CLI packages now include all required server bundles for `lobu run`.

* **Bug Fixes**
  * Prevented server and CLI startup crashes caused by loading incompatible dependencies on older Node.js versions.
  * Improved environment detection for sandbox support in diagnostic checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->