### PR TITLE
fix(agent-history): scope threads to the ambient org, not ownership-first

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-history-authorization.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-authorization.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import type { UserAgentsStore } from "../auth/user-agents-store.js";
+import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
+
+const ORG_ID = "test-org-agent-history-auth";
+
+afterEach(() => {
+	setAuthProvider(null);
+});
+
+test("keeps an agent-bound session scoped to its agent in the ambient org", async () => {
+	const userAgentsStore = {
+		findAgentOrganizations: async (
+			_platform: string,
+			_userId: string,
+			agentId: string,
+		) => (agentId === "agent-b" ? [ORG_ID] : []),
+		ownsAgent: async (
+			_platform: string,
+			_userId: string,
+			agentId: string,
+			organizationId?: string,
+		) => agentId === "agent-b" && organizationId === ORG_ID,
+	} as unknown as UserAgentsStore;
+	const app = new Hono();
+	app.route(
+		"/api/v1/agents/:agentId/history",
+		createAgentHistoryRoutes({ userAgentsStore }),
+	);
+	setAuthProvider(() => ({
+		agentId: "agent-a",
+		userId: "history-user",
+		platform: "external",
+		exp: Date.now() + 60_000,
+	}));
+
+	const response = await orgContext.run({ organizationId: ORG_ID }, () =>
+		app.request("/api/v1/agents/agent-b/history/threads/invalid%21/messages", {
+			headers: { host: "localhost" },
+		}),
+	);
+
+	expect(response.status).toBe(401);
+});

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -579,6 +579,65 @@ describe("agent history routes", () => {
 		expect(response.status).toBe(401);
 	});
 
+	test("scopes threads to the ambient org for a per-org system agent, not the ownership-first org", async () => {
+		const sql = getDb();
+		const SHARED_ORG = "test-org-shared-system-agent";
+		await orgContext.run({ organizationId: SHARED_ORG }, async () => {
+			await seedAgentRow("agent-1", {
+				organizationId: SHARED_ORG,
+				name: "Builder",
+				ownerPlatform: "external",
+				ownerUserId: USER_ID,
+			});
+		});
+		// The caller owns agent-1 only in ORG_ID; shared-org access comes from
+		// owner role plus the system-agent pointer.
+		await sql`
+			INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+			VALUES (${USER_ID}, 'History User', ${`${USER_ID}@test.example.com`}, true, now(), now())
+			ON CONFLICT (id) DO NOTHING
+		`;
+		await addUserToOrganization(USER_ID, SHARED_ORG, "owner");
+		await sql`UPDATE "organization" SET system_agent_id = 'agent-1' WHERE id = ${SHARED_ORG}`;
+
+		const sharedThreadId = "sharedthread";
+		const sharedConvId = buildApiConversationId({
+			agentId: "agent-1",
+			userId: USER_ID,
+			organizationId: SHARED_ORG,
+			threadId: sharedThreadId,
+		});
+		await sql`
+			INSERT INTO public.conversations
+				(organization_id, agent_id, platform, conversation_id, kind, user_id, title, last_activity_at)
+			VALUES
+				(${SHARED_ORG}, 'agent-1', 'web', ${sharedConvId}, 'owned', ${USER_ID}, 'Shared org thread', now())
+		`;
+
+		setAuthProvider(() => ({
+			userId: USER_ID,
+			platform: "external",
+			exp: Date.now() + 60_000,
+		}));
+
+		const response = await orgContext.run({ organizationId: SHARED_ORG }, () =>
+			createApp().request("/api/v1/agents/agent-1/history/threads", {
+				method: "GET",
+				headers: { host: "localhost" },
+			}),
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			threads: Array<{ id: string; title: string }>;
+		};
+		expect(body.threads).toEqual([
+			expect.objectContaining({
+				id: sharedThreadId,
+				title: "Shared org thread",
+			}),
+		]);
+	});
+
 	test("allows a non-owner org member to read a bound platform transcript through federated ACL", async () => {
 		const { channelMember, conversationId } =
 			await seedPlatformConversationAcl();

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -390,6 +390,24 @@ export function createAgentHistoryRoutes(deps: {
 		agentMetadataStore: deps.agentConfigStore,
 	});
 
+	async function canUseSystemAgent(
+		agentId: string,
+		organizationId: string,
+		userId: string,
+	): Promise<boolean> {
+		const rows = await getDb()`
+			SELECT 1
+			FROM "organization" o
+			JOIN "member" m ON m."organizationId" = o.id
+			WHERE o.id = ${organizationId}
+				AND o.system_agent_id = ${agentId}
+				AND m."userId" = ${userId}
+				AND m.role IN ('owner', 'admin')
+			LIMIT 1
+		`;
+		return rows.length > 0;
+	}
+
 	async function getAuthorizedAgentScope(c: Context): Promise<{
 		agentId: string;
 		organizationId: string | undefined;
@@ -399,12 +417,45 @@ export function createAgentHistoryRoutes(deps: {
 		if (!session) return null;
 		const agentId = c.req.param("agentId") || session.agentId || null;
 		if (!agentId || !isSafeAgentId(agentId)) return null;
+		const userId = resolveSettingsLookupUserId(session);
+		const ambientOrgId = resolveOrgId();
+
+		// Apply the resolver's admin bypass and agent-binding restriction before
+		// selecting a tenant from the ambient request.
+		if (session.isAdmin) {
+			return {
+				agentId,
+				organizationId: ambientOrgId ?? undefined,
+				userId,
+			};
+		}
+		if (session.agentId && session.agentId !== agentId) return null;
+
+		// The SPA sends x-lobu-org for the workspace being viewed. Its
+		// membership-verified ambient org must win over ownership-first resolution
+		// because the same system-agent id exists in every organization.
+		if (ambientOrgId) {
+			const ownsHere =
+				(await deps.userAgentsStore?.ownsAgent(
+					session.platform,
+					userId,
+					agentId,
+					ambientOrgId,
+				)) ?? false;
+			const authorized =
+				ownsHere || (await canUseSystemAgent(agentId, ambientOrgId, userId));
+			if (authorized) {
+				return { agentId, organizationId: ambientOrgId, userId };
+			}
+			return null;
+		}
+
 		const result = await resolveOwnership(session, agentId);
 		if (!result.authorized) return null;
 		return {
 			agentId,
 			organizationId: resolveOrgId(result.organizationId) ?? undefined,
-			userId: resolveSettingsLookupUserId(session),
+			userId,
 		};
 	}
 


### PR DESCRIPTION
## Problem

The agent-history `/threads` endpoint (and the 5 other routes sharing `getAuthorizedAgentScope`) resolved the org from agent **ownership** (`resolveOwnership` → first `agent_users` match), then passed it to `resolveOrgId(explicit)` — which short-circuits the ambient (`x-lobu-org`) org whenever `explicit` is set.

For a **per-org system agent** (the built-in Builder exists once per org), a user's only `agent_users` row is in their personal org. So every org's Builder history resolved to the **personal** org: **Recent listed the wrong org's threads**, and a Slack DM/platform conversation in the viewed org returned 404. This hit the Builder in **every org that isn't the caller's ownership default**.

Found by driving the paired browser: `/lobu-crm/` Recent showed buremba's `hey` web thread and never lobu-crm's Slack DM; a direct DM read 404'd — because the endpoint was reading buremba's data despite `x-lobu-org: lobu-crm`.

## Fix

Scope to the **ambient org** (the `x-lobu-org` the SPA sends, already membership-verified by the gateway middleware before it sets the ALS org). Authorize the agent in that org via per-org ownership (`ownsAgent`) **OR** system-agent-owner/admin (mirrors the write-side gate in `agent.ts`). Preserves the resolver's admin bypass and agent-bound-token semantics; falls back to the prior ownership-org only when there is no ambient org (token-only callers). `getAuthorizedPlatformConversationScope` already scoped to the ambient org — this brings the owner-history scope in line.

## Testing

Red→green: new test `scopes threads to the ambient org for a per-org system agent` fails on `origin/main` (ownership-first returns the wrong/empty org) and passes here. All existing agent-history-routes tests stay green (17/17 across both test files). `make pre-pr` clean; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent history access controls for organization-bound system agents.
  - Ensured organization owners and administrators can access history only for agents assigned to their organization.
  - Enforced organization-aware thread listing so conversations remain scoped to the active organization.
  - Denied unauthorized requests consistently, including requests with invalid message path values.

- **Tests**
  - Added coverage for authorization failures and organization-scoped agent history access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->