### PR TITLE
fix(authz): provision $member atomically — no claimless orphan, throw on mismatch

### DIFF
--- a/packages/server/src/__tests__/integration/auth/invitation-member-placeholder.test.ts
+++ b/packages/server/src/__tests__/integration/auth/invitation-member-placeholder.test.ts
@@ -71,23 +71,18 @@ describe("invitation member placeholder", () => {
 		expect(claims).toHaveLength(0);
 	});
 
-	it("refuses claims when userId does not own the member email", async () => {
+	it("creates no $member at all when userId does not own the member email", async () => {
 		const sql = getTestDb();
 		const victimEmail = "victim-invariant@test.example.com";
 
-		await ensureMemberEntity({
-			organizationId: orgId,
-			userId: inviterUserId,
-			name: victimEmail,
-			email: victimEmail,
-			role: "member",
-			status: "active",
-		});
 		await expect(
-			provisionMemberAndCoreIdentities(orgId, {
+			ensureMemberEntity({
+				organizationId: orgId,
 				userId: inviterUserId,
-				email: victimEmail,
 				name: victimEmail,
+				email: victimEmail,
+				role: "member",
+				status: "active",
 			}),
 		).rejects.toThrow("does not own");
 
@@ -100,17 +95,46 @@ describe("invitation member placeholder", () => {
         AND e.metadata->>'email' = ${victimEmail}
         AND e.deleted_at IS NULL
     `;
-		expect(victimRows).toHaveLength(1);
+		expect(victimRows).toHaveLength(0);
+	});
 
-		const leaked = await sql<{ identifier: string }>`
-      SELECT identifier
+	it("writes the auth:signup claim for a matching user", async () => {
+		const sql = getTestDb();
+		const owner = await createTestUser({
+			email: "atomic-owner@test.example.com",
+		});
+
+		await ensureMemberEntity({
+			organizationId: orgId,
+			userId: owner.id,
+			name: "Atomic Owner",
+			email: owner.email,
+			role: "member",
+			status: "active",
+		});
+
+		const rows = await sql<{ id: number }>`
+      SELECT e.id
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id AND et.organization_id = e.organization_id
+      WHERE et.slug = '$member'
+        AND e.organization_id = ${orgId}
+        AND e.metadata->>'email' = ${owner.email}
+        AND e.deleted_at IS NULL
+    `;
+		expect(rows).toHaveLength(1);
+
+		const claims = await sql<{ identifier: string; source_connector: string }>`
+      SELECT identifier, source_connector
       FROM entity_identities
       WHERE organization_id = ${orgId}
-        AND entity_id = ${Number(victimRows[0].id)}
+        AND entity_id = ${Number(rows[0].id)}
         AND namespace = 'auth_user_id'
         AND deleted_at IS NULL
     `;
-		expect(leaked).toHaveLength(0);
+		expect(claims).toHaveLength(1);
+		expect(claims[0].identifier).toBe(owner.id);
+		expect(claims[0].source_connector).toBe("auth:signup");
 	});
 
 	it("provisions a fresh $member with the caller's role, not a hardcoded owner", async () => {

--- a/packages/server/src/utils/member-entity.ts
+++ b/packages/server/src/utils/member-entity.ts
@@ -8,7 +8,6 @@
 
 import { getDb } from '../db/client';
 import { createEntity, type EntityData } from './entity-management';
-import logger from './logger';
 import { ensureMemberEntityType, resolveMemberSchemaFieldsFromSchema } from './member-entity-type';
 
 /**
@@ -68,6 +67,20 @@ export async function ensureMemberEntity(params: EnsureMemberEntityParams): Prom
   await ensureMemberEntityType(params.organizationId);
   const { emailField, imageField } = await resolveMemberSchemaFields(params.organizationId);
 
+  // Validate before creating the $member: checking after creation leaves a
+  // claimless entity when userId does not own the email used for lookup.
+  if (params.userId) {
+    const owner = await sql<{ email: string | null }>`
+      SELECT email FROM "user" WHERE id = ${params.userId} LIMIT 1
+    `;
+    const ownerEmail = owner[0]?.email?.trim().toLowerCase();
+    if (ownerEmail !== params.email.trim().toLowerCase()) {
+      throw new Error(
+        `Refusing to provision $member for user ${params.userId}: user does not own the member email`
+      );
+    }
+  }
+
   const findIdByEmail = async (): Promise<number | null> => {
     const rows = await sql.unsafe<{ id: number }>(
       `SELECT e.id
@@ -118,32 +131,7 @@ export async function ensureMemberEntity(params: EnsureMemberEntityParams): Prom
   // to existing members too so ones created before this gets backfilled. The
   // 'auth:signup' source is the gate's anti-hijack guard — only written here from
   // trusted server-side provisioning with a verified user id.
-  //
-  // RUNTIME INVARIANT: `userId` must be the id of the user who OWNS `email`. The
-  // entity is resolved by email but the claim is keyed on the user id, so a
-  // mismatched pair hands `userId` the channel visibility of whoever owns
-  // `email` — the authz gate resolves a signed-in user to their $member via
-  // exactly this claim. That is not hypothetical: it shipped once, when the
-  // invitation hook passed the INVITER's id alongside the INVITEE's email
-  // (fixed in #2126). The doc comment on `userId` said not to, which is a
-  // convention; this check is the enforcement. Fail closed — skip the claim and
-  // keep the entity rather than write a hijackable identity.
   if (params.userId && memberEntityId !== null) {
-    const owner = await sql<{ email: string | null }>`
-      SELECT email FROM "user" WHERE id = ${params.userId} LIMIT 1
-    `;
-    const ownerEmail = owner[0]?.email?.trim().toLowerCase();
-    if (ownerEmail !== params.email.trim().toLowerCase()) {
-      logger.error(
-        {
-          organizationId: params.organizationId,
-          userId: params.userId,
-          memberEntityId,
-        },
-        '[ensureMemberEntity] refusing to write auth_user_id claim: userId does not own the email this $member was resolved by'
-      );
-      return;
-    }
     await sql`
       INSERT INTO entity_identities (
         organization_id, entity_id, namespace, identifier, source_connector


### PR DESCRIPTION
## Problem

`ensureMemberEntity` created the `$member` entity first, then wrote its `auth_user_id`/`auth:signup` claim — with the email-owner guard checked **after** the entity existed. A self-provisioning caller (`userId` set) whose `userId` didn't own the resolved email left an **orphan `$member` with no resolvable claim** — the exact silent-drift shape the authz channel-visibility gate hides every enforced channel behind, and one the member-claim-drift detector could only report, never prevent.

## Fix

Move the email-owner invariant to the top, **before any entity write**, and **throw** `does not own` on mismatch (consistent with `provisionMemberAndCoreIdentities`, which already throws). Provisioning is now all-or-nothing: a `$member` **with** its claim, or an error — never a claimless orphan. Every auth-hook caller wraps the call in try/catch → structured `member_claim_drift` log; the invitee placeholder passes `createdByUserId` (never `userId`), so the throw only fires on genuine self-provisioning with a mismatched pair.

This makes new orgs/installs structurally unable to drift going forward; the historical `scripts/backfill-member-claims.ts` remains for pre-existing rows.

## Testing

Red→green: `creates no $member at all when userId does not own the member email` fails on `origin/main` (orphan `$member` present) and passes here; a positive test asserts entity + `auth:signup` claim are provisioned together. `make pre-pr` clean; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->