### PR TITLE
fix(cli): surface Node 25 sandbox-unavailable warning upfront in lobu run

### DIFF
--- a/packages/cli/src/__tests__/node-version-guard.test.ts
+++ b/packages/cli/src/__tests__/node-version-guard.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterAll, describe, expect, test } from "bun:test";
 import {
   checkNodeSupport,
@@ -82,6 +83,44 @@ describe("bin/lobu.js Node gate", () => {
     const out = (proc.stdout ?? "") + (proc.stderr ?? "");
     expect(out).not.toContain("Node.js 22 or newer");
     expect(proc.status).toBe(0);
+  });
+});
+
+describe("lobu run Node warning", () => {
+  test("warns before environment validation fails on Node 25", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "lobu-node25-run-"));
+    temporaryDirs.push(cwd);
+    const devModule = pathToFileURL(
+      join(import.meta.dir, "..", "commands", "dev.ts")
+    ).href;
+    const script = [
+      "Object.defineProperty(process.versions, 'node',",
+      "  { value: '25.1.0', configurable: true });",
+      `const { devCommand } = await import(${JSON.stringify(devModule)});`,
+      `await devCommand(${JSON.stringify(cwd)});`,
+    ].join("\n");
+
+    // A shared shell DATABASE_URL makes devCommand stop after its initial
+    // validation, without starting the embedded server.
+    const proc = spawnSync(process.execPath, ["--eval", script], {
+      env: {
+        ...process.env,
+        DATABASE_URL: "postgres://user:pass@db.example.com:5432/prod",
+        NO_COLOR: "1",
+      },
+      encoding: "utf8",
+    });
+    const out = (proc.stdout ?? "") + (proc.stderr ?? "");
+    const warning = out.indexOf(
+      "the agent-code sandbox (query_sdk / run_sdk) is unavailable"
+    );
+    const validationFailure = out.indexOf(
+      "DATABASE_URL inherited from shell points at a shared DB"
+    );
+
+    expect(proc.status).toBe(1);
+    expect(warning).toBeGreaterThanOrEqual(0);
+    expect(validationFailure).toBeGreaterThan(warning);
   });
 });
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -20,6 +20,7 @@ import {
 } from "../internal/context.js";
 import { type Credentials, saveCredentials } from "../internal/credentials.js";
 import { parseEnvContent } from "../internal/index.js";
+import { checkNodeSupport } from "../internal/node-version.js";
 import { loadProjectLink } from "../internal/project-link.js";
 import { loadProjectConfig } from "./_lib/apply/desired-state.js";
 
@@ -135,6 +136,23 @@ export async function devCommand(
   options: DevOptions = {}
 ): Promise<void> {
   const spinner = ora("Validating environment...").start();
+
+  // The server also warns on Node 25, but only after the CLI's boot output.
+  // Surface the sandbox limitation before validation so it is hard to miss.
+  const nodeSupport = checkNodeSupport();
+  if (nodeSupport.ok && !nodeSupport.sandbox) {
+    spinner.warn(
+      chalk.yellow(
+        `Node ${process.versions.node}: the agent-code sandbox (query_sdk / run_sdk) is unavailable.`
+      )
+    );
+    console.warn(
+      chalk.dim(
+        "  isolated-vm has no Node 25 build. Use Node 24 (LTS) or 26+ to enable the sandbox.\n"
+      )
+    );
+    spinner.start("Validating environment...");
+  }
 
   const envPath = join(cwd, ".env");
   let envVars: Record<string, string> = {};


### PR DESCRIPTION
## Problem

Node 25 boots but has no `isolated-vm` build (upstream skipped the odd non-LTS line), so the SDK sandbox (`query_sdk` / `run_sdk`) is unavailable. The server already logs this — but only deep in boot output, after "Environment ready", interleaved with Prometheus/DB init. A `lobu run` user on Node 25 could easily miss it and later wonder why the sandbox tools silently do nothing.

Follow-up to #2175.

## Fix

Surface the sandbox limitation **upfront** in `lobu run`, before the boot noise:

```
⚠ Node 25.1.0: the agent-code sandbox (query_sdk / run_sdk) is unavailable.
  isolated-vm has no Node 25 build. Use Node 24 (LTS) or 26+ to enable the sandbox.
✔ Environment ready
...
```

Non-blocking — the rest of Lobu runs normally. Keyed on `checkNodeSupport()`'s `{ok:true, sandbox:false}`, which is specifically the Node 25 gap (`bin/lobu.js` already hard-fails Node < 22).

## Verification

- New integration test spoofs Node 25, invokes `devCommand`, and asserts the warning appears **before** environment validation (ordering, not just presence).
- Manually verified end-to-end: Node 25 → warning upfront + boots; Node 26 → no warning, boots normally.
- `make pre-pr` all gates clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->