### PR TITLE
fix(agent-history): scope platform conversation reads to the ambient org too

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -664,6 +664,112 @@ describe("agent history routes", () => {
 		]);
 	});
 
+	test("reads a per-org system agent's platform conversation in the ambient org, not the ownership-first org", async () => {
+		// The prod bug, for the conversation-READ route. USER_ID owns `agent-1` in
+		// ORG_ID (their personal org). A DIFFERENT org (SHARED_ORG) has `agent-1` as
+		// its system agent, USER_ID is an owner there, and the bound Slack channel's
+		// conversation lives in SHARED_ORG. On origin/main
+		// getAuthorizedPlatformConversationScope took the ownership-first branch and
+		// resolved ORG_ID, so isConversationVisible checked ORG_ID's bindings and
+		// 404'd. The fix scopes to the ambient org (SHARED_ORG).
+		const sql = getDb();
+		const SHARED_ORG = "test-org-shared-system-read";
+		await orgContext.run({ organizationId: SHARED_ORG }, async () => {
+			await seedAgentRow("agent-1", {
+				organizationId: SHARED_ORG,
+				name: "Builder",
+				ownerPlatform: "external",
+				ownerUserId: USER_ID,
+			});
+		});
+		await sql`
+			INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+			VALUES (${USER_ID}, 'History User', ${`${USER_ID}@test.example.com`}, true, now(), now())
+			ON CONFLICT (id) DO NOTHING
+		`;
+		await addUserToOrganization(USER_ID, SHARED_ORG, "owner");
+		await sql`UPDATE "organization" SET system_agent_id = 'agent-1' WHERE id = ${SHARED_ORG}`;
+		// USER_ID must NOT own agent-1 via agent_users in SHARED_ORG — access is via
+		// org-owner + system_agent_id, so they take the non-owner (enforced-ACL) path.
+
+		// Bind a channel + build the enforced ACL + a $member with the member_of
+		// edge, all in SHARED_ORG. Seed a platform conversation there.
+		const CHANNEL = "C0SHARED";
+		const TEAM = "T0SHARED";
+		const SLACK_USER = "U0SHAREDU";
+		await insertChatConnectionRow({
+			id: "shared-read-conn",
+			organizationId: SHARED_ORG,
+			agentId: "agent-1",
+			platform: "slack",
+			status: "active",
+			metadata: { teamId: TEAM },
+		});
+		await createTestBehaviorSubscription({
+			organizationId: SHARED_ORG,
+			agentId: "agent-1",
+			connectionSlug: `agentconn-shared-read-conn`,
+			platform: "slack",
+			channelId: CHANNEL,
+			teamId: TEAM,
+			configuredBy: USER_ID,
+		});
+		const member = await createTestEntity({
+			name: "History User",
+			entity_type: "$member",
+			organization_id: SHARED_ORG,
+			created_by: USER_ID,
+		});
+		await sql`
+			INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+			VALUES
+				(${SHARED_ORG}, ${member.id}, 'auth_user_id', ${USER_ID}, 'auth:signup'),
+				(${SHARED_ORG}, ${member.id}, 'slack_user_id', ${normalizeSlackUserId(TEAM, SLACK_USER)}, 'auth:signup')
+		`;
+		await buildAccessGraph({
+			organizationId: SHARED_ORG,
+			connectionId: "shared-read-conn",
+			connectorKey: slackAclSource.key,
+			resourceNamespace: slackAclSource.resourceNamespace,
+			memberIdentities: slackAclSource.memberIdentities,
+			resources: slackChannelsToResources(TEAM, [
+				{ channelId: CHANNEL, name: "shared", memberSlackUserIds: [SLACK_USER] },
+			]),
+		});
+		const conversationId = `slack:${CHANNEL}:1700000000.123456`;
+		const jsonl =
+			`{"type":"session","version":3,"id":"s-shared","timestamp":"2026-07-23T10:00:00Z","cwd":"/w"}\n` +
+			`{"type":"message","id":"u-shared","parentId":null,"timestamp":"2026-07-23T10:00:01Z","message":{"role":"user","content":[{"type":"text","text":"Shared org DM"}]}}\n`;
+		const runId = await insertRun({
+			organizationId: SHARED_ORG,
+			agentId: "agent-1",
+			conversationId,
+		});
+		await sql`
+			INSERT INTO public.agent_transcript_snapshot
+				(organization_id, agent_id, conversation_id, run_id, snapshot_jsonl, byte_size, terminal_status)
+			VALUES
+				(${SHARED_ORG}, 'agent-1', ${conversationId}, ${runId}, ${jsonl}, ${Buffer.byteLength(jsonl, "utf-8")}, 'completed')
+		`;
+
+		setAuthProvider(() => ({
+			userId: USER_ID,
+			platform: "external",
+			agentId: "agent-1",
+			exp: Date.now() + 60_000,
+		}));
+		// Ambient org = SHARED_ORG (what x-lobu-org sets, membership-verified).
+		const response = await orgContext.run({ organizationId: SHARED_ORG }, () =>
+			createApp().request(
+				`/api/v1/agents/agent-1/history/conversations/${encodeURIComponent(conversationId)}/messages`,
+				{ method: "GET", headers: { host: "localhost" } },
+			),
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { messages: Array<{ id: string }> };
+		expect(body.messages.map((m) => m.id)).toEqual(["u-shared"]);
+	});
+
 	test("requires an enforced channel ACL for a non-owner org member", async () => {
 		const { channelMember, conversationId } =
 			await seedPlatformConversationAcl({ buildAcl: false });

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -784,6 +784,26 @@ describe("agent history routes", () => {
 		expect(response.status).toBe(200);
 	});
 
+	test("keeps a metadata-only owner on the bound-channel path when agent_users is unreconciled", async () => {
+		// Ownership survives only in agent metadata (`agents.owner_*`), never
+		// mirrored into `agent_users`, so `ownsAgent` is false. Under the ambient
+		// org the owner must still reach the legacy bound-channel path via the
+		// metadata fallback rather than drop to the enforced ACL and 404.
+		const { conversationId } = await seedPlatformConversationAcl({
+			buildAcl: false,
+		});
+		await getDb()`DELETE FROM agent_users WHERE agent_id = 'agent-1'`;
+		expect(
+			await orgContext.run({ organizationId: ORG_ID }, () =>
+				userAgentsStore.ownsAgent("external", USER_ID, "agent-1", ORG_ID),
+			),
+		).toBe(false);
+
+		const response = await readPlatformTranscript(USER_ID, conversationId);
+
+		expect(response.status).toBe(200);
+	});
+
 	test("a platform admin reads bound transcripts without an ownership row or ACL", async () => {
 		// Restores the admin bypass the ownership resolver granted before this
 		// route stopped calling it. The admin has no agent_users row and only a

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -224,12 +224,13 @@ describe("agent history routes", () => {
 	async function readPlatformTranscript(
 		userId: string,
 		conversationId: string,
-		opts?: { agentBound?: boolean; withOrgContext?: boolean },
+		opts?: { agentBound?: boolean; withOrgContext?: boolean; isAdmin?: boolean },
 	): Promise<Response> {
 		setAuthProvider(() => ({
 			userId,
 			platform: "external",
 			...(opts?.agentBound ? { agentId: "agent-1" } : {}),
+			...(opts?.isAdmin ? { isAdmin: true } : {}),
 			exp: Date.now() + 60_000,
 		}));
 		const request = () =>
@@ -779,6 +780,23 @@ describe("agent history routes", () => {
 			buildAcl: false,
 		});
 		const response = await readPlatformTranscript(USER_ID, conversationId);
+
+		expect(response.status).toBe(200);
+	});
+
+	test("a platform admin reads bound transcripts without an ownership row or ACL", async () => {
+		// Restores the admin bypass the ownership resolver granted before this
+		// route stopped calling it. The admin is neither an org owner nor in
+		// agent_users and no ACL is built, so every ownership/member path
+		// declines — only session.isAdmin authorizes. Without the bypass this
+		// falls to the enforced-ACL path and 404s.
+		const { conversationId } = await seedPlatformConversationAcl({
+			buildAcl: false,
+		});
+		const admin = await createTestUser({ name: "Platform Admin" });
+		const response = await readPlatformTranscript(admin.id, conversationId, {
+			isAdmin: true,
+		});
 
 		expect(response.status).toBe(200);
 	});

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -665,22 +665,13 @@ describe("agent history routes", () => {
 	});
 
 	test("reads a per-org system agent's platform conversation in the ambient org, not the ownership-first org", async () => {
-		// The prod bug, for the conversation-READ route. USER_ID owns `agent-1` in
-		// ORG_ID (their personal org). A DIFFERENT org (SHARED_ORG) has `agent-1` as
-		// its system agent, USER_ID is an owner there, and the bound Slack channel's
-		// conversation lives in SHARED_ORG. On origin/main
-		// getAuthorizedPlatformConversationScope took the ownership-first branch and
-		// resolved ORG_ID, so isConversationVisible checked ORG_ID's bindings and
-		// 404'd. The fix scopes to the ambient org (SHARED_ORG).
 		const sql = getDb();
 		const SHARED_ORG = "test-org-shared-system-read";
-		await orgContext.run({ organizationId: SHARED_ORG }, async () => {
-			await seedAgentRow("agent-1", {
-				organizationId: SHARED_ORG,
-				name: "Builder",
-				ownerPlatform: "external",
-				ownerUserId: USER_ID,
-			});
+		await seedAgentRow("agent-1", {
+			organizationId: SHARED_ORG,
+			name: "Builder",
+			ownerPlatform: "external",
+			ownerUserId: USER_ID,
 		});
 		await sql`
 			INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
@@ -692,8 +683,6 @@ describe("agent history routes", () => {
 		// USER_ID must NOT own agent-1 via agent_users in SHARED_ORG — access is via
 		// org-owner + system_agent_id, so they take the non-owner (enforced-ACL) path.
 
-		// Bind a channel + build the enforced ACL + a $member with the member_of
-		// edge, all in SHARED_ORG. Seed a platform conversation there.
 		const CHANNEL = "C0SHARED";
 		const TEAM = "T0SHARED";
 		const SLACK_USER = "U0SHAREDU";
@@ -733,7 +722,11 @@ describe("agent history routes", () => {
 			resourceNamespace: slackAclSource.resourceNamespace,
 			memberIdentities: slackAclSource.memberIdentities,
 			resources: slackChannelsToResources(TEAM, [
-				{ channelId: CHANNEL, name: "shared", memberSlackUserIds: [SLACK_USER] },
+				{
+					channelId: CHANNEL,
+					name: "shared",
+					memberSlackUserIds: [SLACK_USER],
+				},
 			]),
 		});
 		const conversationId = `slack:${CHANNEL}:1700000000.123456`;
@@ -758,7 +751,6 @@ describe("agent history routes", () => {
 			agentId: "agent-1",
 			exp: Date.now() + 60_000,
 		}));
-		// Ambient org = SHARED_ORG (what x-lobu-org sets, membership-verified).
 		const response = await orgContext.run({ organizationId: SHARED_ORG }, () =>
 			createApp().request(
 				`/api/v1/agents/agent-1/history/conversations/${encodeURIComponent(conversationId)}/messages`,

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -786,14 +786,18 @@ describe("agent history routes", () => {
 
 	test("a platform admin reads bound transcripts without an ownership row or ACL", async () => {
 		// Restores the admin bypass the ownership resolver granted before this
-		// route stopped calling it. The admin is neither an org owner nor in
-		// agent_users and no ACL is built, so every ownership/member path
-		// declines — only session.isAdmin authorizes. Without the bypass this
-		// falls to the enforced-ACL path and 404s.
+		// route stopped calling it. The admin has no agent_users row and only a
+		// plain 'member' role (which fails canUseSystemAgent's owner/admin check),
+		// and no ACL is built — so every ownership/member path declines and only
+		// session.isAdmin authorizes. Without the bypass this falls to the
+		// enforced-ACL path and 404s (proven red->green).
 		const { conversationId } = await seedPlatformConversationAcl({
 			buildAcl: false,
 		});
 		const admin = await createTestUser({ name: "Platform Admin" });
+		// Ordinary membership mirrors production: the ambient-org middleware only
+		// sets x-lobu-org to an org the caller belongs to.
+		await addUserToOrganization(admin.id, ORG_ID, "member");
 		const response = await readPlatformTranscript(admin.id, conversationId, {
 			isAdmin: true,
 		});

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -483,16 +483,8 @@ export function createAgentHistoryRoutes(deps: {
 		if (session.agentId && session.agentId !== agentId) return null;
 		const userId = resolveSettingsLookupUserId(session);
 
-		// Scope to the AMBIENT org (the membership-verified `x-lobu-org` the SPA
-		// sends for the workspace being viewed), NOT the ownership-first org — the
-		// same fix `getAuthorizedAgentScope` applies. A per-org SYSTEM agent (the
-		// Builder) exists in every org, so ownership resolution returns the user's
-		// personal org and platform transcripts (Slack DMs/channels) in the viewed
-		// org would 404 as "not in the personal org". The owner path keeps
-		// `allowNotGraphed: true` (legacy bound-channel behavior), but only when the
-		// caller owns the agent IN THE AMBIENT org; anyone else — system-agent
-		// admins and plain members — needs a fresh enforced ACL proving channel
-		// membership (`allowNotGraphed: false`).
+		// A shared system-agent id can resolve to an ownership row in another org.
+		// Keep both the transcript lookup and owner check in the ambient org.
 		const ambientOrgId = resolveOrgId();
 		if (!ambientOrgId) return null;
 
@@ -511,8 +503,6 @@ export function createAgentHistoryRoutes(deps: {
 				allowNotGraphed: true,
 			};
 		}
-		// Non-owner (system-agent admin or plain org member): scoped to the ambient
-		// org, but must prove channel membership via a fresh enforced ACL.
 		return {
 			agentId,
 			organizationId: ambientOrgId,

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -480,13 +480,26 @@ export function createAgentHistoryRoutes(deps: {
 		if (!session) return null;
 		const agentId = c.req.param("agentId") || session.agentId || null;
 		if (!agentId || !isSafeAgentId(agentId)) return null;
-		if (session.agentId && session.agentId !== agentId) return null;
 		const userId = resolveSettingsLookupUserId(session);
 
 		// A shared system-agent id can resolve to an ownership row in another org.
 		// Keep both the transcript lookup and owner check in the ambient org.
 		const ambientOrgId = resolveOrgId();
 		if (!ambientOrgId) return null;
+
+		// Admin bypass mirrors `getAuthorizedAgentScope` and the ownership
+		// resolver: admins read platform transcripts without an ownership row,
+		// scoped to the ambient org. Runs before the agent-binding check so an
+		// admin's request isn't rejected by a session bound to another agent.
+		if (session.isAdmin) {
+			return {
+				agentId,
+				organizationId: ambientOrgId,
+				userId,
+				allowNotGraphed: true,
+			};
+		}
+		if (session.agentId && session.agentId !== agentId) return null;
 
 		const ownsHere =
 			(await deps.userAgentsStore?.ownsAgent(

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -481,29 +481,42 @@ export function createAgentHistoryRoutes(deps: {
 		const agentId = c.req.param("agentId") || session.agentId || null;
 		if (!agentId || !isSafeAgentId(agentId)) return null;
 		if (session.agentId && session.agentId !== agentId) return null;
-		// A chat-issued settings claim carries agentId so it can be limited to one
-		// agent, but that binding is not ownership proof. Re-run the ownership
-		// resolver without the binding before granting the legacy owner path.
-		const ownership = await resolveOwnership(
-			{ ...session, agentId: undefined },
-			agentId,
-		);
-		if (ownership.authorized) {
-			const organizationId = resolveOrgId(ownership.organizationId);
-			if (!organizationId) return null;
+		const userId = resolveSettingsLookupUserId(session);
+
+		// Scope to the AMBIENT org (the membership-verified `x-lobu-org` the SPA
+		// sends for the workspace being viewed), NOT the ownership-first org — the
+		// same fix `getAuthorizedAgentScope` applies. A per-org SYSTEM agent (the
+		// Builder) exists in every org, so ownership resolution returns the user's
+		// personal org and platform transcripts (Slack DMs/channels) in the viewed
+		// org would 404 as "not in the personal org". The owner path keeps
+		// `allowNotGraphed: true` (legacy bound-channel behavior), but only when the
+		// caller owns the agent IN THE AMBIENT org; anyone else — system-agent
+		// admins and plain members — needs a fresh enforced ACL proving channel
+		// membership (`allowNotGraphed: false`).
+		const ambientOrgId = resolveOrgId();
+		if (!ambientOrgId) return null;
+
+		const ownsHere =
+			(await deps.userAgentsStore?.ownsAgent(
+				session.platform,
+				userId,
+				agentId,
+				ambientOrgId,
+			)) ?? false;
+		if (ownsHere) {
 			return {
 				agentId,
-				organizationId,
-				userId: resolveSettingsLookupUserId(session),
+				organizationId: ambientOrgId,
+				userId,
 				allowNotGraphed: true,
 			};
 		}
-		const organizationId = resolveOrgId();
-		if (!organizationId) return null;
+		// Non-owner (system-agent admin or plain org member): scoped to the ambient
+		// org, but must prove channel membership via a fresh enforced ACL.
 		return {
 			agentId,
-			organizationId,
-			userId: resolveSettingsLookupUserId(session),
+			organizationId: ambientOrgId,
+			userId,
 			allowNotGraphed: false,
 		};
 	}

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -487,10 +487,9 @@ export function createAgentHistoryRoutes(deps: {
 		const ambientOrgId = resolveOrgId();
 		if (!ambientOrgId) return null;
 
-		// Admin bypass mirrors `getAuthorizedAgentScope` and the ownership
-		// resolver: admins read platform transcripts without an ownership row,
-		// scoped to the ambient org. Runs before the agent-binding check so an
-		// admin's request isn't rejected by a session bound to another agent.
+		// Preserve the ownership resolver's platform-admin bypass, scoped to the
+		// ambient org. Runs before the agent-binding check so an admin's request
+		// isn't rejected by a session bound to another agent.
 		if (session.isAdmin) {
 			return {
 				agentId,

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -34,6 +34,7 @@ import { readWatcherRunThreads } from "../../services/watcher-run-thread.js";
 import {
 	createOwnershipResolver,
 	resolveSettingsLookupUserId,
+	sessionMatchesMetadataOwner,
 } from "../shared/agent-ownership.js";
 import { errorResponse } from "../shared/helpers.js";
 import { verifySettingsSession } from "./settings-auth.js";
@@ -515,6 +516,39 @@ export function createAgentHistoryRoutes(deps: {
 				allowNotGraphed: true,
 			};
 		}
+
+		// `ownsAgent` reads `agent_users`, but legacy ownership can survive only
+		// in agent metadata (`agents.owner_*`) that was never reconciled into the
+		// mapping. Mirror the ownership resolver's metadata fallback so those
+		// owners keep the legacy bound-channel path. `getMetadata` is ALS-scoped to
+		// the ambient org, so a match proves ambient-org ownership: a per-org
+		// SYSTEM agent (the Builder) has no per-user owner in a shared org (owner
+		// column is NULL), so system-agent admins still fall through to the
+		// enforced ACL below, unchanged. Reconcile into `agent_users` so the next
+		// read hits the fast path.
+		const metadata = await deps.agentConfigStore?.getMetadata(agentId);
+		if (
+			metadata?.owner &&
+			metadata.organizationId === ambientOrgId &&
+			sessionMatchesMetadataOwner(
+				session,
+				metadata.owner.platform,
+				metadata.owner.userId,
+			)
+		) {
+			deps.userAgentsStore
+				?.addAgent(session.platform, userId, agentId, ambientOrgId)
+				.catch(() => {
+					/* best-effort reconciliation */
+				});
+			return {
+				agentId,
+				organizationId: ambientOrgId,
+				userId,
+				allowNotGraphed: true,
+			};
+		}
+
 		return {
 			agentId,
 			organizationId: ambientOrgId,

--- a/packages/server/src/gateway/routes/shared/agent-ownership.ts
+++ b/packages/server/src/gateway/routes/shared/agent-ownership.ts
@@ -34,7 +34,7 @@ export function resolveSettingsLookupUserId(
     : session.userId;
 }
 
-function sessionMatchesMetadataOwner(
+export function sessionMatchesMetadataOwner(
   session: SettingsTokenPayload,
   ownerPlatform: string,
   ownerUserId: string


### PR DESCRIPTION
## Problem (sibling of #2176)

#2176 fixed `getAuthorizedAgentScope` (used by `/threads`) to scope to the membership-verified ambient org (`x-lobu-org`). But the conversation-**read** scope — `getAuthorizedPlatformConversationScope`, used by `GET /conversations/:conversationId/messages` — still resolved the org **ownership-first**.

Result: a per-org **system agent** (the Builder) had its Slack DM/channel conversation **list** correctly in Recent (via the #2176 fix) but **404 on open** — the read route built channel visibility for the caller's *personal* org, where the viewed org's conversation isn't bound.

Verified live: after #2176 deployed, the lobu-crm DM appears in Recent, but clicking it → `GET .../conversations/slack:D0BEQTB3WFN/messages` returned **404**.

## Fix

Apply the same ambient-org-first scoping to the read route: resolve to the membership-verified `x-lobu-org`; grant the owner path (`allowNotGraphed: true`, legacy bound-channel access) **only when the caller owns the agent in that org**; route system-agent admins + plain org members through the existing enforced-ACL path (`allowNotGraphed: false`), unchanged.

## Testing

Red→green: new test `reads a per-org system agent's platform conversation in the ambient org` returns **404 on origin/main** (ownership-first resolves the wrong org) and **200** here. All existing agent-history-routes + authorization tests stay green (**18/18**). `make pre-pr` clean; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization when viewing platform conversation transcripts.
  * Ambient-organization users can now access eligible conversations for system agents.
  * Platform administrators can access bound platform transcripts even when standard ownership or access records are unavailable.
  * Requests without a valid organization context are denied safely.
* **Tests**
  * Added coverage for system-agent access and administrator transcript access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->