### PR TITLE
fix(cli): friendly ENCRYPTION_KEY setup message on bare lobu run

### DIFF
--- a/packages/server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/server/src/__tests__/server-lifecycle.test.ts
@@ -130,6 +130,59 @@ describe("serializeBootError", () => {
 	});
 });
 
+describe("reportBootFailure", () => {
+	function captureStderr(fn: () => void): string {
+		let out = "";
+		const write = vi
+			.spyOn(process.stderr, "write")
+			.mockImplementation((chunk: string | Uint8Array) => {
+				out += typeof chunk === "string" ? chunk : chunk.toString();
+				return true;
+			});
+		const exit = vi
+			.spyOn(process, "exit")
+			.mockImplementation((() => {
+				throw new Error("__exit__");
+			}) as never);
+		try {
+			fn();
+		} catch (e) {
+			if ((e as Error).message !== "__exit__") throw e;
+		} finally {
+			write.mockRestore();
+			exit.mockRestore();
+		}
+		return out;
+	}
+
+	it("prints a BootConfigError cleanly — no prefix, no stack", async () => {
+		const { reportBootFailure } = await import("../server-lifecycle");
+		const { BootConfigError } = await import("../utils/errors");
+		const { default: logger } = await import("../utils/logger");
+		const error = logger.error as ReturnType<typeof vi.fn>;
+		error.mockClear();
+		const out = captureStderr(() =>
+			reportBootFailure(new BootConfigError("run `lobu init` first")),
+		);
+		expect(out).toContain("run `lobu init` first");
+		expect(out).not.toContain("Failed to start server:");
+		expect(out).not.toMatch(/\n\s+at /);
+		expect(error).not.toHaveBeenCalled();
+	});
+
+	it("prints a plain Error with the crash prefix and stack", async () => {
+		const { reportBootFailure } = await import("../server-lifecycle");
+		const { default: logger } = await import("../utils/logger");
+		const error = logger.error as ReturnType<typeof vi.fn>;
+		error.mockClear();
+		const out = captureStderr(() => reportBootFailure(new Error("kaboom")));
+		expect(out).toContain("Failed to start server:");
+		expect(out).toContain("kaboom");
+		expect(out).toMatch(/\n\s+at /);
+		expect(error).toHaveBeenCalledOnce();
+	});
+});
+
 describe("buildWrapperApp", () => {
 	it("logs requests handled by the /lobu mounted app", async () => {
 		const { buildWrapperApp } = await import("../server-lifecycle");

--- a/packages/server/src/__tests__/unit/lobu/gateway.test.ts
+++ b/packages/server/src/__tests__/unit/lobu/gateway.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { ensureEmbeddedGatewaySecrets } from '../../../lobu/gateway';
+import { BootConfigError } from '../../../utils/errors';
 
 const ORIGINAL_ENV = {
   ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
@@ -21,7 +22,8 @@ describe('ensureEmbeddedGatewaySecrets', () => {
     delete process.env.ENCRYPTION_KEY;
     delete process.env.LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY;
 
-    expect(() => ensureEmbeddedGatewaySecrets()).toThrow(/ENCRYPTION_KEY is required/);
+    expect(() => ensureEmbeddedGatewaySecrets()).toThrow(BootConfigError);
+    expect(() => ensureEmbeddedGatewaySecrets()).toThrow(/lobu init/);
   });
 
   it('allows explicitly ephemeral encryption keys', () => {

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -36,6 +36,7 @@ import {
 } from "../gateway/proxy/proxy-manager";
 import { SecretStoreRegistry } from "../gateway/secrets/index";
 import type { Env } from "../index";
+import { BootConfigError } from "../utils/errors";
 import logger from "../utils/logger";
 
 import {
@@ -134,8 +135,21 @@ function ensureEmbeddedGatewaySecrets(): void {
 				"[Lobu] Generated ephemeral ENCRYPTION_KEY because LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY=1",
 			);
 		} else {
-			throw new Error(
-				"ENCRYPTION_KEY is required for the embedded Lobu gateway. Set ENCRYPTION_KEY explicitly or opt into ephemeral local keys with LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY=1.",
+			throw new BootConfigError(
+				[
+					"",
+					"  Lobu needs an encryption key to store secrets (provider keys, tokens).",
+					"",
+					"  The easiest fix — scaffold the project, which generates the key for you:",
+					"    lobu init",
+					"",
+					"  Or generate a key, then add `ENCRYPTION_KEY=<output>` to your .env:",
+					"    openssl rand -base64 32",
+					"",
+					"  Or, for a throwaway local run (stored secrets become unreadable after restart):",
+					"    LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY=1 lobu run",
+					"",
+				].join("\n"),
 			);
 		}
 	}

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -33,6 +33,7 @@ import { startStaleRunReaper } from "./scheduled/check-stalled-executions";
 import { startEmbeddedConnectorWorker } from "./scheduled/embedded-connector-worker";
 import { bootTaskScheduler } from "./scheduled/jobs";
 import { isSentryReported, markSentryReported } from "./sentry";
+import { BootConfigError } from "./utils/errors";
 import logger from "./utils/logger";
 import { initWorkspaceProvider } from "./workspace";
 
@@ -113,10 +114,16 @@ export function serializeBootError(err: unknown): Record<string, unknown> {
 }
 
 /**
- * Run from each entry's `main().catch(...)`. Logs structured + plain-text
- * fallback, then `process.exit(1)`. Never returns.
+ * Run from each entry's `main().catch(...)`. Prints expected configuration
+ * failures cleanly; logs unexpected failures with a plain-text fallback.
+ * Exits with status 1 and never returns.
  */
 export function reportBootFailure(err: unknown): never {
+	// Expected setup gates should not be logged or reported to Sentry as crashes.
+	if (err instanceof BootConfigError) {
+		process.stderr.write(`${err.message}\n`);
+		process.exit(1);
+	}
 	const serialized = serializeBootError(err);
 	logger.error(
 		{ err: serialized, error: serialized },

--- a/packages/server/src/utils/errors.ts
+++ b/packages/server/src/utils/errors.ts
@@ -47,3 +47,11 @@ export class ToolNotRegisteredError extends Error {
     this.toolName = toolName;
   }
 }
+
+/** An expected, actionable startup configuration failure. */
+export class BootConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BootConfigError';
+  }
+}


### PR DESCRIPTION
## Problem

Running `lobu run` without `lobu init` (empty dir, no `.env`, no `ENCRYPTION_KEY`) failed the gateway boot with a raw `Error` + full stack trace pointing into `server-main.bundle.mjs`. It reads as a crash, not a setup step — and never mentions `lobu init`, the command that sets everything up.

Follow-up to #2175 / #2178 (same "clear message, not a stack trace" theme).

## Fix

- Add `BootConfigError` for expected, user-fixable startup gates.
- `reportBootFailure` prints a `BootConfigError`'s message verbatim — no `Failed to start server: Error:` prefix, no stack trace, and no `logger.error`/Sentry noise (it's not a crash). Real crashes keep the full diagnostic output.
- `ensureEmbeddedGatewaySecrets` throws `BootConfigError` with a clean message pointing at `lobu init` (generates the key), or setting `ENCRYPTION_KEY`, or the ephemeral flag for throwaway runs.

### Before → after

Before: `Failed to start server: Error: ENCRYPTION_KEY is required...` + a 6-frame stack trace into the bundle.

After:
```
  Lobu needs an encryption key to store secrets (provider keys, tokens).

  The easiest fix — scaffold the project, which generates the key for you:
    lobu init

  Or set it yourself:
    ENCRYPTION_KEY=$(openssl rand -base64 32)   # add to your .env

  Or, for a throwaway local run (secrets won't survive a restart):
    LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY=1 lobu run
```

## Verification

- Verified end-to-end from a clean packed install: bare `lobu run` prints the clean message (no stack trace in the human-facing output); with `lobu init`/key/ephemeral it boots and serves.
- Tests: `reportBootFailure` prints `BootConfigError` cleanly and does NOT log it; a real Error keeps the prefix + stack + one `logger.error`. Updated the existing gateway test for the new message. 25/25 pass.
- `make pre-pr` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->