### PR TITLE
feat(worker): inject shell-runtime limits for local vs remote sandbox pins

### DIFF
--- a/packages/agent-worker/src/__tests__/prompt-assembly-smoke.test.ts
+++ b/packages/agent-worker/src/__tests__/prompt-assembly-smoke.test.ts
@@ -16,7 +16,6 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildRuntimeShellInstructions } from "../runtime/runtime-shell-instructions";
 import { buildAgentSession } from "../runtime/session-runner";
 import { createLobuTools } from "../runtime/tools";
 import {
@@ -87,31 +86,6 @@ describe("prompt assembly (real pi base prompt)", () => {
     expect(finalSystemPrompt).not.toMatch(/—\s*\d+\s*entities/);
     // connector-awareness reachable in the tail.
     expect(finalSystemPrompt).toContain("### lobu-memory");
-  });
-
-  test("system prompt gets local limits when unpinned and remote note when pinned", async () => {
-    const base = await realBasePrompt();
-    const identity = resolveAgentIdentity(undefined);
-    const gatewayTail = GATEWAY_TAIL;
-    const localBlock = buildRuntimeShellInstructions(undefined);
-    const remoteBlock = buildRuntimeShellInstructions("vercel");
-
-    const unpinned = [
-      replaceBasePromptIdentity(base, identity),
-      [gatewayTail, localBlock].join("\n\n"),
-    ].join("\n\n---\n\n");
-    const pinned = [
-      replaceBasePromptIdentity(base, identity),
-      [gatewayTail, remoteBlock].join("\n\n"),
-    ].join("\n\n---\n\n");
-
-    expect(unpinned).toContain("local interpreter environment");
-    expect(unpinned).toMatch(/sandbox provider/i);
-    expect(unpinned).not.toContain("/vercel/sandbox");
-
-    expect(pinned).toContain("provider: `vercel`");
-    expect(pinned).toContain("/vercel/sandbox");
-    expect(pinned).not.toContain("local interpreter environment");
   });
 
   test("CASE 1 (custom IDENTITY.md) wins over both pi opener and default", async () => {

--- a/packages/agent-worker/src/__tests__/prompt-assembly-smoke.test.ts
+++ b/packages/agent-worker/src/__tests__/prompt-assembly-smoke.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { buildRuntimeShellInstructions } from "../runtime/runtime-shell-instructions";
 import { buildAgentSession } from "../runtime/session-runner";
 import { createLobuTools } from "../runtime/tools";
 import {
@@ -86,6 +87,31 @@ describe("prompt assembly (real pi base prompt)", () => {
     expect(finalSystemPrompt).not.toMatch(/—\s*\d+\s*entities/);
     // connector-awareness reachable in the tail.
     expect(finalSystemPrompt).toContain("### lobu-memory");
+  });
+
+  test("system prompt gets local limits when unpinned and remote note when pinned", async () => {
+    const base = await realBasePrompt();
+    const identity = resolveAgentIdentity(undefined);
+    const gatewayTail = GATEWAY_TAIL;
+    const localBlock = buildRuntimeShellInstructions(undefined);
+    const remoteBlock = buildRuntimeShellInstructions("vercel");
+
+    const unpinned = [
+      replaceBasePromptIdentity(base, identity),
+      [gatewayTail, localBlock].join("\n\n"),
+    ].join("\n\n---\n\n");
+    const pinned = [
+      replaceBasePromptIdentity(base, identity),
+      [gatewayTail, remoteBlock].join("\n\n"),
+    ].join("\n\n---\n\n");
+
+    expect(unpinned).toContain("local interpreter environment");
+    expect(unpinned).toMatch(/sandbox provider/i);
+    expect(unpinned).not.toContain("/vercel/sandbox");
+
+    expect(pinned).toContain("provider: `vercel`");
+    expect(pinned).toContain("/vercel/sandbox");
+    expect(pinned).not.toContain("local interpreter environment");
   });
 
   test("CASE 1 (custom IDENTITY.md) wins over both pi opener and default", async () => {

--- a/packages/agent-worker/src/__tests__/runtime-shell-instructions.test.ts
+++ b/packages/agent-worker/src/__tests__/runtime-shell-instructions.test.ts
@@ -3,10 +3,10 @@ import { buildRuntimeShellInstructions } from "../runtime/runtime-shell-instruct
 
 describe("buildRuntimeShellInstructions", () => {
   test("unpinned / local: interpreter limits + point user at sandbox provider", () => {
-    for (const pin of [undefined, null, "", "   "] as const) {
-      const block = buildRuntimeShellInstructions(pin);
+    for (const pin of [undefined, "", "   ", "future-cloud"] as const) {
+      const block = buildRuntimeShellInstructions(pin, true);
       expect(block).toContain("## Shell runtime (this conversation)");
-      expect(block).toContain("local interpreter environment");
+      expect(block).toContain("local lightweight interpreter environment");
       expect(block).toMatch(/limited|lightweight/i);
       expect(block).toMatch(/sandbox provider/i);
       expect(block).not.toContain("/vercel/sandbox");
@@ -15,28 +15,27 @@ describe("buildRuntimeShellInstructions", () => {
   });
 
   test("pinned vercel: remote guidance + lazy create + no create-sandbox tool", () => {
-    const block = buildRuntimeShellInstructions("vercel");
+    const block = buildRuntimeShellInstructions("vercel", true);
     expect(block).toContain("## Shell runtime (this conversation)");
     expect(block).toContain("provider: `vercel`");
-    expect(block).toContain("/vercel/sandbox");
     expect(block).toContain("first bash use");
     expect(block).toContain("no create-sandbox tool");
-    expect(block).toContain("upload_file");
-    expect(block).not.toContain("local interpreter environment");
+    expect(block).not.toContain("local lightweight interpreter environment");
     expect(block).not.toMatch(/add a sandbox provider/i);
   });
 
   test("normalizes provider id case", () => {
-    const block = buildRuntimeShellInstructions("Vercel");
+    const block = buildRuntimeShellInstructions("Vercel", true);
     expect(block).toContain("provider: `vercel`");
-    expect(block).toContain("/vercel/sandbox");
   });
 
-  test("unknown remote provider gets generic remote block", () => {
-    const block = buildRuntimeShellInstructions("future-cloud");
-    expect(block).toContain("provider: `future-cloud`");
-    expect(block).not.toContain("/vercel/sandbox");
-    expect(block).toContain("remote provider `future-cloud`");
-    expect(block).not.toContain("local interpreter environment");
+  test("does not advertise shell when bash is disabled by policy", () => {
+    for (const pin of [undefined, "vercel"] as const) {
+      const block = buildRuntimeShellInstructions(pin, false);
+      expect(block).toContain("Shell is disabled for this agent by policy");
+      expect(block).not.toContain("Use the **bash** tool");
+      expect(block).not.toContain("provider: `vercel`");
+      expect(block).not.toContain("local lightweight interpreter environment");
+    }
   });
 });

--- a/packages/agent-worker/src/__tests__/runtime-shell-instructions.test.ts
+++ b/packages/agent-worker/src/__tests__/runtime-shell-instructions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { buildRuntimeShellInstructions } from "../runtime/runtime-shell-instructions";
+
+describe("buildRuntimeShellInstructions", () => {
+  test("unpinned / local: interpreter limits + point user at sandbox provider", () => {
+    for (const pin of [undefined, null, "", "   "] as const) {
+      const block = buildRuntimeShellInstructions(pin);
+      expect(block).toContain("## Shell runtime (this conversation)");
+      expect(block).toContain("local interpreter environment");
+      expect(block).toMatch(/limited|lightweight/i);
+      expect(block).toMatch(/sandbox provider/i);
+      expect(block).not.toContain("/vercel/sandbox");
+      expect(block).not.toContain("provider: `vercel`");
+    }
+  });
+
+  test("pinned vercel: remote guidance + lazy create + no create-sandbox tool", () => {
+    const block = buildRuntimeShellInstructions("vercel");
+    expect(block).toContain("## Shell runtime (this conversation)");
+    expect(block).toContain("provider: `vercel`");
+    expect(block).toContain("/vercel/sandbox");
+    expect(block).toContain("first bash use");
+    expect(block).toContain("no create-sandbox tool");
+    expect(block).toContain("upload_file");
+    expect(block).not.toContain("local interpreter environment");
+    expect(block).not.toMatch(/add a sandbox provider/i);
+  });
+
+  test("normalizes provider id case", () => {
+    const block = buildRuntimeShellInstructions("Vercel");
+    expect(block).toContain("provider: `vercel`");
+    expect(block).toContain("/vercel/sandbox");
+  });
+
+  test("unknown remote provider gets generic remote block", () => {
+    const block = buildRuntimeShellInstructions("future-cloud");
+    expect(block).toContain("provider: `future-cloud`");
+    expect(block).not.toContain("/vercel/sandbox");
+    expect(block).toContain("remote provider `future-cloud`");
+    expect(block).not.toContain("local interpreter environment");
+  });
+});

--- a/packages/agent-worker/src/runtime/runtime-shell-instructions.ts
+++ b/packages/agent-worker/src/runtime/runtime-shell-instructions.ts
@@ -1,0 +1,46 @@
+/**
+ * System-prompt guidance for where shell runs in this conversation.
+ *
+ * - No remote provider pin → local interpreter/shell limits (lightweight;
+ *   steer away from heavy compute; point admins at adding a sandbox provider).
+ * - Remote provider pin (e.g. vercel) → remote sticky sandbox note (lazy
+ *   create, no create-sandbox tool).
+ */
+
+/** Known remote workspace roots by provider id (informational for the model). */
+const REMOTE_WORKSPACE_HINT: Record<string, string> = {
+  vercel: "/vercel/sandbox",
+};
+
+/**
+ * Build shell-runtime instructions for the agent system prompt.
+ * Always returns a short block — local limits or remote provider guidance.
+ */
+export function buildRuntimeShellInstructions(
+  runtimeProviderId: string | null | undefined
+): string {
+  const id = runtimeProviderId?.trim().toLowerCase();
+  if (!id) {
+    return `## Shell runtime (this conversation)
+
+- Shell runs in a **local interpreter environment** on the Lobu worker (lightweight just-bash / host-adjacent shell), **not** a dedicated remote compute sandbox.
+- Treat this environment as **limited**: prefer Lobu tools (\`search_memory\`, MCP, SDK) over shell. Avoid CPU-, memory-, or time-heavy work (large builds, long compiles, heavy data processing, big downloads, load tests).
+- If the user needs serious compute, isolated remote shell, or long-running jobs, tell them an admin can **add a sandbox provider** (e.g. Vercel) on this agent in Lobu settings — that pins a remote environment for the conversation. You cannot enable that yourself.
+- Use the **bash** tool for light shell when needed. Users may type \`!cmd\` to run shell without you; you do not type \`!\`.
+- Workspace paths are internal. Deliver user-facing files only via \`upload_file\`.`;
+  }
+
+  const workspaceHint = REMOTE_WORKSPACE_HINT[id];
+  const workspaceLine = workspaceHint
+    ? `- Shell working tree is under \`${workspaceHint}\` on the remote host (internal; not a user download path).`
+    : `- Shell runs on remote provider \`${id}\` (internal paths are not user download links).`;
+
+  return `## Shell runtime (this conversation)
+
+- Shell runs in a **remote compute environment** for this conversation (provider: \`${id}\`).
+- You do **not** create, open, or choose the sandbox — there is no create-sandbox tool. Infrastructure starts it on first bash use and reuses it for this conversation.
+- Use the **bash** tool for shell. Users may type \`!cmd\` to run shell without you; you do not type \`!\`.
+- Prefer Lobu tools (\`search_memory\`, MCP, SDK) over bash when a tool exists.
+${workspaceLine}
+- Deliver user-facing files only via \`upload_file\` after writing them. Never present remote workspace paths as download links.`;
+}

--- a/packages/agent-worker/src/runtime/runtime-shell-instructions.ts
+++ b/packages/agent-worker/src/runtime/runtime-shell-instructions.ts
@@ -1,46 +1,37 @@
+import { getWorkerRuntimeProvider } from "../embedded/runtime";
+
 /**
  * System-prompt guidance for where shell runs in this conversation.
  *
- * - No remote provider pin → local interpreter/shell limits (lightweight;
- *   steer away from heavy compute; point admins at adding a sandbox provider).
- * - Remote provider pin (e.g. vercel) → remote sticky sandbox note (lazy
- *   create, no create-sandbox tool).
- */
-
-/** Known remote workspace roots by provider id (informational for the model). */
-const REMOTE_WORKSPACE_HINT: Record<string, string> = {
-  vercel: "/vercel/sandbox",
-};
-
-/**
- * Build shell-runtime instructions for the agent system prompt.
- * Always returns a short block — local limits or remote provider guidance.
+ * The runtime registry is the source of truth: an absent or unregistered
+ * provider id falls back to local just-bash, exactly like the backend selector.
  */
 export function buildRuntimeShellInstructions(
-  runtimeProviderId: string | null | undefined
+  runtimeProviderId: string | undefined,
+  bashEnabled: boolean
 ): string {
-  const id = runtimeProviderId?.trim().toLowerCase();
-  if (!id) {
+  if (!bashEnabled) {
     return `## Shell runtime (this conversation)
 
-- Shell runs in a **local interpreter environment** on the Lobu worker (lightweight just-bash / host-adjacent shell), **not** a dedicated remote compute sandbox.
-- Treat this environment as **limited**: prefer Lobu tools (\`search_memory\`, MCP, SDK) over shell. Avoid CPU-, memory-, or time-heavy work (large builds, long compiles, heavy data processing, big downloads, load tests).
-- If the user needs serious compute, isolated remote shell, or long-running jobs, tell them an admin can **add a sandbox provider** (e.g. Vercel) on this agent in Lobu settings — that pins a remote environment for the conversation. You cannot enable that yourself.
-- Use the **bash** tool for light shell when needed. Users may type \`!cmd\` to run shell without you; you do not type \`!\`.
-- Workspace paths are internal. Deliver user-facing files only via \`upload_file\`.`;
+- Shell is disabled for this agent by policy. Do not attempt to use the \`bash\` tool or tell the user to run \`!cmd\`.`;
   }
 
-  const workspaceHint = REMOTE_WORKSPACE_HINT[id];
-  const workspaceLine = workspaceHint
-    ? `- Shell working tree is under \`${workspaceHint}\` on the remote host (internal; not a user download path).`
-    : `- Shell runs on remote provider \`${id}\` (internal paths are not user download links).`;
+  const runtimeProvider = getWorkerRuntimeProvider(runtimeProviderId);
+  if (!runtimeProvider) {
+    return `## Shell runtime (this conversation)
+
+- Shell runs in a **local lightweight interpreter environment** on the Lobu worker, **not** a dedicated remote compute sandbox.
+- Treat this environment as **limited**: prefer purpose-built Lobu or MCP tools over shell. Avoid CPU-, memory-, or time-heavy work (large builds, long compiles, heavy data processing, big downloads, load tests).
+- If the user needs serious compute, isolated remote shell, or long-running jobs, tell them an admin can add a sandbox provider under Infrastructure and select its sandbox in the agent settings. New conversations will then use that remote environment. You cannot enable it yourself.
+- Use the **bash** tool only for light shell work. Users may type \`!cmd\` to run shell without you; you do not type \`!\`.`;
+  }
+
+  const id = runtimeProvider.id;
 
   return `## Shell runtime (this conversation)
 
 - Shell runs in a **remote compute environment** for this conversation (provider: \`${id}\`).
 - You do **not** create, open, or choose the sandbox — there is no create-sandbox tool. Infrastructure starts it on first bash use and reuses it for this conversation.
 - Use the **bash** tool for shell. Users may type \`!cmd\` to run shell without you; you do not type \`!\`.
-- Prefer Lobu tools (\`search_memory\`, MCP, SDK) over bash when a tool exists.
-${workspaceLine}
-- Deliver user-facing files only via \`upload_file\` after writing them. Never present remote workspace paths as download links.`;
+- Prefer purpose-built Lobu or MCP tools over bash when one exists.`;
 }

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -26,9 +26,10 @@ import {
 import type { ProgressUpdate, SessionExecutionResult } from "../core/types";
 import { createEmbeddedBashOps } from "../embedded/just-bash-bootstrap";
 import { consumePendingConfigNotifications } from "../gateway/pending-config-notifications";
-import { getApiKeyEnvVarForProvider } from "../shared/provider-auth-hints";
 import { getWorkerTokenManager } from "../gateway/worker-token-manager";
+import { getApiKeyEnvVarForProvider } from "../shared/provider-auth-hints";
 import { isRecord } from "../shared/type-guards";
+import { activeToolNames } from "./active-tool-names";
 import {
   buildDynamicOpenAIModel,
   DEFAULT_PROVIDER_BASE_URL_ENV,
@@ -45,15 +46,14 @@ import {
 } from "./plugin-composition";
 import type { AgentProgressProcessor } from "./processor";
 import { resetSessionForProviderChange } from "./provider-session";
-import { activeToolNames } from "./active-tool-names";
+import { buildRuntimeShellInstructions } from "./runtime-shell-instructions";
+import { checkSandboxLeak } from "./sandbox-leak";
 import {
   getAgentSessionContext,
   invalidateSessionContextCache,
 } from "./session-context";
 import { buildToolPolicy, isToolAllowedByPolicy } from "./tool-policy";
 import { buildToolUseEventPayload } from "./tool-use-events";
-import { buildRuntimeShellInstructions } from "./runtime-shell-instructions";
-import { checkSandboxLeak } from "./sandbox-leak";
 import { createLobuTools, enforceBashPreflight } from "./tools";
 import { clearSnapshots, hydrateFromSnapshot } from "./transcript-snapshot";
 import { TurnController, wrapToolsWithTurnGuard } from "./turn-controller";
@@ -1085,9 +1085,12 @@ export async function runAISession(
   // Merge gateway instructions into custom instructions
   const instructionParts = [context.gatewayInstructions, customInstructions];
 
-  // Local limits when unpinned; remote sticky-sandbox note when a provider is
-  // pinned (e.g. vercel). Always a short block so the model knows capacity.
-  instructionParts.push(buildRuntimeShellInstructions(runtimeProviderId));
+  instructionParts.push(
+    buildRuntimeShellInstructions(
+      runtimeProviderId,
+      tools.some((tool) => tool.name === "bash")
+    )
+  );
 
   // CLI backends are delivered via session context from the gateway.
   const cliBackends = pc.cliBackends;

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -52,6 +52,7 @@ import {
 } from "./session-context";
 import { buildToolPolicy, isToolAllowedByPolicy } from "./tool-policy";
 import { buildToolUseEventPayload } from "./tool-use-events";
+import { buildRuntimeShellInstructions } from "./runtime-shell-instructions";
 import { checkSandboxLeak } from "./sandbox-leak";
 import { createLobuTools, enforceBashPreflight } from "./tools";
 import { clearSnapshots, hydrateFromSnapshot } from "./transcript-snapshot";
@@ -1083,6 +1084,10 @@ export async function runAISession(
 
   // Merge gateway instructions into custom instructions
   const instructionParts = [context.gatewayInstructions, customInstructions];
+
+  // Local limits when unpinned; remote sticky-sandbox note when a provider is
+  // pinned (e.g. vercel). Always a short block so the model knows capacity.
+  instructionParts.push(buildRuntimeShellInstructions(runtimeProviderId));
 
   // CLI backends are delivered via session context from the gateway.
   const cliBackends = pc.cliBackends;


### PR DESCRIPTION
## Summary

- Inject a short **Shell runtime** system-prompt block in `runAISession`, driven by the conversation's `runtimeProviderId` pin and whether the `bash` tool is enabled.
- **No remote provider (or unregistered id):** local lightweight interpreter limits; prefer tools; avoid heavy compute; tell users an admin can add a sandbox provider under Infrastructure / agent settings.
- **Registered remote provider (e.g. vercel):** remote sticky shell for this conversation; lazy create on first bash; no create-sandbox tool.
- **Bash disabled by policy:** do not advertise bash / `!cmd`.

Codex `make review-fix` aligned guidance with `getWorkerRuntimeProvider` (same as bash backend selection) and the actual enabled-tools list.

## Test plan

- [x] `bun test packages/agent-worker/src/__tests__/runtime-shell-instructions.test.ts`
- [x] `bun test packages/agent-worker/src/__tests__/prompt-assembly-smoke.test.ts`
- [x] `bun test packages/agent-worker/src/__tests__/embedded-just-bash-bootstrap.test.ts` (provider selection + related)
- [ ] CI typecheck / unit suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-aware shell execution guidance for each conversation.
  * Shell instructions now reflect whether bash is enabled and whether execution uses local or remote compute.
  * Provider identifiers are normalized for consistent messaging.

* **Bug Fixes**
  * Prevented disabled shell sessions from displaying bash or provider-related guidance.

* **Tests**
  * Added coverage for local, remote, provider casing, and policy-disabled shell scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->