### PR TITLE
fix(search): gate search_memory connections on the shared visibility predicate

### DIFF
--- a/packages/server/src/__tests__/integration/authz/search-connection-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/search-connection-visibility.test.ts
@@ -49,7 +49,7 @@ describe('search_memory connection visibility', () => {
 
     const org = await createTestOrganization({ name: 'Search Conn Visibility Org' });
     orgId = org.id;
-    await seedSystemEntityTypes(orgId);
+    await seedSystemEntityTypes();
 
     const owner = await createTestUser();
     const admin = await createTestUser();

--- a/packages/server/src/__tests__/integration/authz/search-connection-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/search-connection-visibility.test.ts
@@ -1,24 +1,3 @@
-/**
- * `search_memory` connection visibility — INTRA-ORG authz gate.
- *
- * `fetchConnectionsForEntity` (tools/search.ts) enumerates the connections
- * attached to the primary entity and returns them under `connections`. Its
- * only filter used to be `connectionLinkedToBusinessEntitySql` — a PURE
- * business-entity linkage test with no `visibility`, no `created_by`, and no
- * `deleted_at` clause. `search_memory` sits in the most permissive tool tier
- * (PUBLIC_READ_ACTIONS: null) and `include_connections` defaults to TRUE, so
- * ANY plain org member could enumerate ANOTHER member's PRIVATE connections
- * just by searching an entity those connections are linked to.
- *
- * Every sibling read seam (manage_feeds read_feed, manage_connections
- * list/get, query_sql, connector pushdown) compiles the SAME predicate from
- * `authz/connection-visibility#compileConnectionRowVisibility`; this seam had
- * diverged. These tests assert on connection IDENTITY (connection_id /
- * display_name) — deliberately NOT on any secret value inside `config`, so a
- * redaction change elsewhere can never make them pass while the authz hole
- * stays open.
- */
-
 import { beforeAll, describe, expect, it } from 'vitest';
 import type { ToolContext } from '../../../tools/registry';
 import { search } from '../../../tools/search';
@@ -47,12 +26,13 @@ function ctxFor(
     scopedToOrg: !userId,
     allowCrossOrg: !!userId,
     scopes: userId ? ['mcp:read'] : undefined,
-  } as ToolContext;
+  };
 }
 
-describe('search_memory connection visibility (intra-org)', () => {
+describe('search_memory connection visibility', () => {
   let orgId: string;
   let entityId: number;
+  let privateOnlyEntityId: number;
   let ownerUserId: string;
   let adminUserId: string;
   let memberUserId: string;
@@ -61,6 +41,7 @@ describe('search_memory connection visibility (intra-org)', () => {
   let memberPrivateConnectionId: number;
   let legacyUnownedConnectionId: number;
   let deletedOrgConnectionId: number;
+  let foreignOrgConnectionId: number;
 
   beforeAll(async () => {
     await cleanupTestDatabase();
@@ -87,26 +68,30 @@ describe('search_memory connection visibility (intra-org)', () => {
       created_by: ownerUserId,
     });
     entityId = entity.id;
+    privateOnlyEntityId = (
+      await createTestEntity({
+        name: 'Private Connection Only Co',
+        entity_type: 'company',
+        organization_id: orgId,
+        created_by: ownerUserId,
+      })
+    ).id;
 
-    // Every connection is linked to the SAME entity (via its default feed's
-    // entity_ids), so linkage is never what distinguishes them — visibility is.
     const mk = async (opts: {
       display_name: string;
-      created_by: string | undefined;
+      created_by?: string;
       visibility: 'org' | 'private';
     }) =>
-      Number(
-        (
-          await createTestConnection({
-            organization_id: orgId,
-            connector_key: 'github',
-            display_name: opts.display_name,
-            entity_ids: [entityId],
-            created_by: opts.created_by,
-            visibility: opts.visibility,
-          })
-        ).id
-      );
+      (
+        await createTestConnection({
+          organization_id: orgId,
+          connector_key: 'github',
+          display_name: opts.display_name,
+          entity_ids: [entityId],
+          created_by: opts.created_by,
+          visibility: opts.visibility,
+        })
+      ).id;
 
     orgConnectionId = await mk({
       display_name: 'Org Visible GitHub',
@@ -123,10 +108,8 @@ describe('search_memory connection visibility (intra-org)', () => {
       created_by: memberUserId,
       visibility: 'private',
     });
-    // Legacy row predating `created_by`: admins may see it, plain members not.
     legacyUnownedConnectionId = await mk({
       display_name: 'Legacy Unowned GitHub',
-      created_by: undefined,
       visibility: 'private',
     });
     deletedOrgConnectionId = await mk({
@@ -134,78 +117,93 @@ describe('search_memory connection visibility (intra-org)', () => {
       created_by: ownerUserId,
       visibility: 'org',
     });
+    await createTestConnection({
+      organization_id: orgId,
+      connector_key: 'github',
+      display_name: 'Private Only GitHub',
+      entity_ids: [privateOnlyEntityId],
+      created_by: ownerUserId,
+      visibility: 'private',
+    });
 
     await getTestDb()`
       UPDATE connections SET deleted_at = NOW() WHERE id = ${deletedOrgConnectionId}
     `;
+
+    const foreignOrg = await createTestOrganization({ name: 'Foreign Search Org' });
+    foreignOrgConnectionId = (
+      await createTestConnection({
+        organization_id: foreignOrg.id,
+        connector_key: 'github',
+        display_name: 'Foreign Org GitHub',
+        entity_ids: [entityId],
+        visibility: 'org',
+      })
+    ).id;
   });
 
-  async function connectionsFor(ctx: ToolContext): Promise<{
-    ids: Set<number>;
-    names: string[];
-  }> {
+  async function connectionIdsFor(ctx: ToolContext): Promise<number[]> {
     const result = await search(
-      { entity_id: entityId, include_connections: true, include_content: false } as never,
-      {} as never,
+      { entity_id: entityId, include_content: false },
+      {} as Parameters<typeof search>[1],
       ctx
     );
-    const rows = result.connections ?? [];
-    return {
-      ids: new Set(rows.map((c) => Number(c.connection_id))),
-      names: rows.map((c) => c.display_name ?? ''),
-    };
+    return (result.connections ?? []).map((connection) => Number(connection.connection_id));
   }
 
-  it('does NOT leak another member\'s private connection to a plain org member', async () => {
-    const { ids, names } = await connectionsFor(ctxFor(orgId, memberUserId, 'member'));
+  it('returns only org-visible and self-owned connections to a member', async () => {
+    const ids = await connectionIdsFor(ctxFor(orgId, memberUserId, 'member'));
 
-    // THE BUG: the owner's private connection is another user's private asset.
-    expect(ids.has(ownerPrivateConnectionId)).toBe(false);
-    expect(names).not.toContain('Owner Private GitHub');
-    // Legacy-unowned private rows are admin-tier only.
-    expect(ids.has(legacyUnownedConnectionId)).toBe(false);
-    expect(names).not.toContain('Legacy Unowned GitHub');
-  });
-
-  it('still returns org-visible and own-private connections to that member', async () => {
-    const { ids } = await connectionsFor(ctxFor(orgId, memberUserId, 'member'));
-
-    expect(ids.has(orgConnectionId)).toBe(true);
-    expect(ids.has(memberPrivateConnectionId)).toBe(true);
+    expect(ids).toContain(orgConnectionId);
+    expect(ids).toContain(memberPrivateConnectionId);
+    expect(ids).not.toContain(ownerPrivateConnectionId);
+    expect(ids).not.toContain(legacyUnownedConnectionId);
+    expect(ids).not.toContain(foreignOrgConnectionId);
   });
 
   it('still returns the owner their own private connection', async () => {
-    const { ids } = await connectionsFor(ctxFor(orgId, ownerUserId, 'owner'));
+    const ids = await connectionIdsFor(ctxFor(orgId, ownerUserId, 'owner'));
 
-    expect(ids.has(ownerPrivateConnectionId)).toBe(true);
-    expect(ids.has(orgConnectionId)).toBe(true);
-    // Admin tier sees legacy-unowned rows...
-    expect(ids.has(legacyUnownedConnectionId)).toBe(true);
-    // ...but admin is NOT a bypass for another member's private connection.
-    expect(ids.has(memberPrivateConnectionId)).toBe(false);
+    expect(ids).toContain(ownerPrivateConnectionId);
+    expect(ids).toContain(orgConnectionId);
+    expect(ids).toContain(legacyUnownedConnectionId);
+    expect(ids).not.toContain(memberPrivateConnectionId);
   });
 
-  it('grants an admin the same tier as the owner', async () => {
-    const { ids } = await connectionsFor(ctxFor(orgId, adminUserId, 'admin'));
+  it('returns legacy-unowned but not user-owned private connections to an admin', async () => {
+    const ids = await connectionIdsFor(ctxFor(orgId, adminUserId, 'admin'));
 
-    expect(ids.has(orgConnectionId)).toBe(true);
-    expect(ids.has(legacyUnownedConnectionId)).toBe(true);
-    expect(ids.has(ownerPrivateConnectionId)).toBe(false);
-    expect(ids.has(memberPrivateConnectionId)).toBe(false);
+    expect(ids).toContain(orgConnectionId);
+    expect(ids).toContain(legacyUnownedConnectionId);
+    expect(ids).not.toContain(ownerPrivateConnectionId);
+    expect(ids).not.toContain(memberPrivateConnectionId);
   });
 
   it('gives an anonymous caller org-visible connections only', async () => {
-    const { ids } = await connectionsFor(ctxFor(orgId, null, null));
+    const ids = await connectionIdsFor(ctxFor(orgId, null, null));
 
-    expect(ids.has(orgConnectionId)).toBe(true);
-    expect(ids.has(ownerPrivateConnectionId)).toBe(false);
-    expect(ids.has(memberPrivateConnectionId)).toBe(false);
-    expect(ids.has(legacyUnownedConnectionId)).toBe(false);
+    expect(ids).toContain(orgConnectionId);
+    expect(ids).not.toContain(ownerPrivateConnectionId);
+    expect(ids).not.toContain(memberPrivateConnectionId);
+    expect(ids).not.toContain(legacyUnownedConnectionId);
   });
 
   it('excludes soft-deleted connections', async () => {
-    const { ids } = await connectionsFor(ctxFor(orgId, ownerUserId, 'owner'));
+    const ids = await connectionIdsFor(ctxFor(orgId, ownerUserId, 'owner'));
 
-    expect(ids.has(deletedOrgConnectionId)).toBe(false);
+    expect(ids).not.toContain(deletedOrgConnectionId);
+  });
+
+  it('does not count hidden private connections in entity stats or suggestions', async () => {
+    const result = await search(
+      { entity_id: privateOnlyEntityId, include_content: false },
+      {} as Parameters<typeof search>[1],
+      ctxFor(orgId, memberUserId, 'member')
+    );
+
+    expect(result.connections).toEqual([]);
+    expect(result.entity?.stats.connection_count).toBe(0);
+    expect(result.entity?.stats.active_connection_count).toBe(0);
+    expect(result.suggestion).toContain('no connections');
   });
 });

--- a/packages/server/src/__tests__/integration/authz/search-connection-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/search-connection-visibility.test.ts
@@ -1,0 +1,211 @@
+/**
+ * `search_memory` connection visibility — INTRA-ORG authz gate.
+ *
+ * `fetchConnectionsForEntity` (tools/search.ts) enumerates the connections
+ * attached to the primary entity and returns them under `connections`. Its
+ * only filter used to be `connectionLinkedToBusinessEntitySql` — a PURE
+ * business-entity linkage test with no `visibility`, no `created_by`, and no
+ * `deleted_at` clause. `search_memory` sits in the most permissive tool tier
+ * (PUBLIC_READ_ACTIONS: null) and `include_connections` defaults to TRUE, so
+ * ANY plain org member could enumerate ANOTHER member's PRIVATE connections
+ * just by searching an entity those connections are linked to.
+ *
+ * Every sibling read seam (manage_feeds read_feed, manage_connections
+ * list/get, query_sql, connector pushdown) compiles the SAME predicate from
+ * `authz/connection-visibility#compileConnectionRowVisibility`; this seam had
+ * diverged. These tests assert on connection IDENTITY (connection_id /
+ * display_name) — deliberately NOT on any secret value inside `config`, so a
+ * redaction change elsewhere can never make them pass while the authz hole
+ * stays open.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { ToolContext } from '../../../tools/registry';
+import { search } from '../../../tools/search';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+function ctxFor(
+  orgId: string,
+  userId: string | null,
+  memberRole: 'owner' | 'admin' | 'member' | null = 'member'
+): ToolContext {
+  return {
+    organizationId: orgId,
+    userId,
+    memberRole: userId ? memberRole : null,
+    isAuthenticated: !!userId,
+    tokenType: userId ? 'oauth' : 'anonymous',
+    scopedToOrg: !userId,
+    allowCrossOrg: !!userId,
+    scopes: userId ? ['mcp:read'] : undefined,
+  } as ToolContext;
+}
+
+describe('search_memory connection visibility (intra-org)', () => {
+  let orgId: string;
+  let entityId: number;
+  let ownerUserId: string;
+  let adminUserId: string;
+  let memberUserId: string;
+  let orgConnectionId: number;
+  let ownerPrivateConnectionId: number;
+  let memberPrivateConnectionId: number;
+  let legacyUnownedConnectionId: number;
+  let deletedOrgConnectionId: number;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await initWorkspaceProvider();
+
+    const org = await createTestOrganization({ name: 'Search Conn Visibility Org' });
+    orgId = org.id;
+    await seedSystemEntityTypes(orgId);
+
+    const owner = await createTestUser();
+    const admin = await createTestUser();
+    const member = await createTestUser();
+    ownerUserId = owner.id;
+    adminUserId = admin.id;
+    memberUserId = member.id;
+    await addUserToOrganization(ownerUserId, orgId, 'owner');
+    await addUserToOrganization(adminUserId, orgId, 'admin');
+    await addUserToOrganization(memberUserId, orgId, 'member');
+
+    const entity = await createTestEntity({
+      name: 'Visibility Probe Co',
+      entity_type: 'company',
+      organization_id: orgId,
+      created_by: ownerUserId,
+    });
+    entityId = entity.id;
+
+    // Every connection is linked to the SAME entity (via its default feed's
+    // entity_ids), so linkage is never what distinguishes them — visibility is.
+    const mk = async (opts: {
+      display_name: string;
+      created_by: string | undefined;
+      visibility: 'org' | 'private';
+    }) =>
+      Number(
+        (
+          await createTestConnection({
+            organization_id: orgId,
+            connector_key: 'github',
+            display_name: opts.display_name,
+            entity_ids: [entityId],
+            created_by: opts.created_by,
+            visibility: opts.visibility,
+          })
+        ).id
+      );
+
+    orgConnectionId = await mk({
+      display_name: 'Org Visible GitHub',
+      created_by: ownerUserId,
+      visibility: 'org',
+    });
+    ownerPrivateConnectionId = await mk({
+      display_name: 'Owner Private GitHub',
+      created_by: ownerUserId,
+      visibility: 'private',
+    });
+    memberPrivateConnectionId = await mk({
+      display_name: 'Member Private GitHub',
+      created_by: memberUserId,
+      visibility: 'private',
+    });
+    // Legacy row predating `created_by`: admins may see it, plain members not.
+    legacyUnownedConnectionId = await mk({
+      display_name: 'Legacy Unowned GitHub',
+      created_by: undefined,
+      visibility: 'private',
+    });
+    deletedOrgConnectionId = await mk({
+      display_name: 'Soft Deleted GitHub',
+      created_by: ownerUserId,
+      visibility: 'org',
+    });
+
+    await getTestDb()`
+      UPDATE connections SET deleted_at = NOW() WHERE id = ${deletedOrgConnectionId}
+    `;
+  });
+
+  async function connectionsFor(ctx: ToolContext): Promise<{
+    ids: Set<number>;
+    names: string[];
+  }> {
+    const result = await search(
+      { entity_id: entityId, include_connections: true, include_content: false } as never,
+      {} as never,
+      ctx
+    );
+    const rows = result.connections ?? [];
+    return {
+      ids: new Set(rows.map((c) => Number(c.connection_id))),
+      names: rows.map((c) => c.display_name ?? ''),
+    };
+  }
+
+  it('does NOT leak another member\'s private connection to a plain org member', async () => {
+    const { ids, names } = await connectionsFor(ctxFor(orgId, memberUserId, 'member'));
+
+    // THE BUG: the owner's private connection is another user's private asset.
+    expect(ids.has(ownerPrivateConnectionId)).toBe(false);
+    expect(names).not.toContain('Owner Private GitHub');
+    // Legacy-unowned private rows are admin-tier only.
+    expect(ids.has(legacyUnownedConnectionId)).toBe(false);
+    expect(names).not.toContain('Legacy Unowned GitHub');
+  });
+
+  it('still returns org-visible and own-private connections to that member', async () => {
+    const { ids } = await connectionsFor(ctxFor(orgId, memberUserId, 'member'));
+
+    expect(ids.has(orgConnectionId)).toBe(true);
+    expect(ids.has(memberPrivateConnectionId)).toBe(true);
+  });
+
+  it('still returns the owner their own private connection', async () => {
+    const { ids } = await connectionsFor(ctxFor(orgId, ownerUserId, 'owner'));
+
+    expect(ids.has(ownerPrivateConnectionId)).toBe(true);
+    expect(ids.has(orgConnectionId)).toBe(true);
+    // Admin tier sees legacy-unowned rows...
+    expect(ids.has(legacyUnownedConnectionId)).toBe(true);
+    // ...but admin is NOT a bypass for another member's private connection.
+    expect(ids.has(memberPrivateConnectionId)).toBe(false);
+  });
+
+  it('grants an admin the same tier as the owner', async () => {
+    const { ids } = await connectionsFor(ctxFor(orgId, adminUserId, 'admin'));
+
+    expect(ids.has(orgConnectionId)).toBe(true);
+    expect(ids.has(legacyUnownedConnectionId)).toBe(true);
+    expect(ids.has(ownerPrivateConnectionId)).toBe(false);
+    expect(ids.has(memberPrivateConnectionId)).toBe(false);
+  });
+
+  it('gives an anonymous caller org-visible connections only', async () => {
+    const { ids } = await connectionsFor(ctxFor(orgId, null, null));
+
+    expect(ids.has(orgConnectionId)).toBe(true);
+    expect(ids.has(ownerPrivateConnectionId)).toBe(false);
+    expect(ids.has(memberPrivateConnectionId)).toBe(false);
+    expect(ids.has(legacyUnownedConnectionId)).toBe(false);
+  });
+
+  it('excludes soft-deleted connections', async () => {
+    const { ids } = await connectionsFor(ctxFor(orgId, ownerUserId, 'owner'));
+
+    expect(ids.has(deletedOrgConnectionId)).toBe(false);
+  });
+});

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -895,6 +895,14 @@ async function searchImpl(
           }
         )
       : Promise.resolve({});
+  const connectionScope: AuthzScope = {
+    ...authzScopeFromToolContext({
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      agentId: ctx.agentId,
+    }),
+    principalIsAdmin: await callerIsAdmin(getDb(), ctx),
+  };
 
   // ========================================
   // ID-BASED LOOKUP (highest priority)
@@ -902,7 +910,7 @@ async function searchImpl(
 
   if (args.entity_id) {
     const [entity, recall] = await Promise.all([
-      fetchEntityById(args.entity_id, env, ctx.organizationId),
+      fetchEntityById(args.entity_id, env, connectionScope),
       recallPromise,
     ]);
     if (entity) {
@@ -916,7 +924,7 @@ async function searchImpl(
           recall
         );
       }
-      return withRecall(await formatEntityResult(readable, args, ctx), recall);
+      return withRecall(await formatEntityResult(readable, args, ctx, connectionScope), recall);
     }
     return withRecall(
       emptyResult({
@@ -942,7 +950,7 @@ async function searchImpl(
   );
 
   let [results, recall] = await Promise.all([
-    queryEntities(query, args, env, ctx.organizationId),
+    queryEntities(query, args, env, connectionScope),
     recallPromise,
   ]);
 
@@ -955,7 +963,7 @@ async function searchImpl(
         fallbackQuery.slice(0, 200).trim() || null,
         args,
         env,
-        ctx.organizationId
+        connectionScope
       );
       if (results.length > 0) {
         logger.info(
@@ -969,7 +977,7 @@ async function searchImpl(
   if (results.length > 0) {
     const readable = await filterEntitiesByReadPolicy(ctx, [...results]);
     if (readable.length > 0) {
-      return withRecall(await formatEntityResult(readable, args, ctx), recall);
+      return withRecall(await formatEntityResult(readable, args, ctx, connectionScope), recall);
     }
   }
 
@@ -1051,9 +1059,10 @@ async function fetchTopEntitiesByType(
 // running them globally for a public-catalog entity would leak other
 // tenants' activity volumes through aggregate counts. Each count is
 // gated on `e.organization_id = $callerOrg` so we return zeros for
-// cross-org rows. Caller passes the parameter index for their org.
-function entitySelectColumns(callerOrgParamIdx: number): string {
+// cross-org rows. Connection counts additionally apply per-user visibility.
+function entitySelectColumns(callerOrgParamIdx: number, scope: AuthzScope): string {
   const ownOrg = `e.organization_id = $${callerOrgParamIdx}`;
+  const connectionVisibility = compileConnectionRowVisibility(scope, 'cn');
   return `
   e.id, e.organization_id, e.name, et.slug AS entity_type, e.slug, e.metadata, e.parent_id,
   pe.name as parent_name, pe.slug as parent_slug, pet.slug as parent_entity_type,
@@ -1071,8 +1080,10 @@ function entitySelectColumns(callerOrgParamIdx: number): string {
       JOIN connections cn ON cn.id = f.connection_id
       WHERE e.id = ANY(f.entity_ids)
         AND f.organization_id = e.organization_id
+        AND cn.organization_id = e.organization_id
         AND f.deleted_at IS NULL
         AND cn.deleted_at IS NULL
+        ${connectionVisibility}
     ), 0)
   ELSE 0 END as connection_count,
   CASE WHEN ${ownOrg} THEN
@@ -1082,8 +1093,10 @@ function entitySelectColumns(callerOrgParamIdx: number): string {
       JOIN connections cn ON cn.id = f.connection_id
       WHERE e.id = ANY(f.entity_ids)
         AND f.organization_id = e.organization_id
+        AND cn.organization_id = e.organization_id
         AND f.deleted_at IS NULL
         AND cn.deleted_at IS NULL
+        ${connectionVisibility}
         AND cn.status = 'active'
     ), 0)
   ELSE 0 END as active_connection_count,
@@ -1108,13 +1121,13 @@ const ENTITY_JOINS = `
  * - category, market: additional filters
  * - query_embedding: vector similarity search
  * - metadata_filter: key-value metadata conditions
- * - organizationId: organization IDs the user can read from
+ * - scope: organization and connection-visibility principal
  */
 async function queryEntities(
   query: string | null,
   args: SearchArgs,
   _env: Env,
-  organizationId: string
+  scope: AuthzScope
 ) {
   const sql = getDb();
   const fuzzyEnabled = args.fuzzy ?? true;
@@ -1156,11 +1169,11 @@ async function queryEntities(
   // flag is on (default), so an agent looking up "Apple" finds tenant-local
   // and canonical hits in one call. The result row carries the org_id so the
   // agent can tell which is which. The same param index is reused by the
-  // count subqueries in entitySelectColumns(orgParamIdx), which gate
+  // count subqueries in entitySelectColumns(orgParamIdx, scope), which gate
   // operational counts (events, connections, watchers) on caller-org rows
   // so cross-org public results don't leak other tenants' activity.
   const includePublic = args.include_public_catalogs ?? true;
-  const orgParamIdx = addParam(organizationId);
+  const orgParamIdx = addParam(scope.organizationId);
   if (includePublic) {
     conditions.push(
       `(e.organization_id = $${orgParamIdx} OR EXISTS (SELECT 1 FROM organization o WHERE o.id = e.organization_id AND o.visibility = 'public'))`
@@ -1227,7 +1240,7 @@ async function queryEntities(
   }
 
   const rows = await sql.unsafe<EntityQueryRow>(
-    `SELECT ${entitySelectColumns(orgParamIdx)},
+    `SELECT ${entitySelectColumns(orgParamIdx, scope)},
       ${scoreExpr} as match_score,
       '${matchReason}' as match_reason,
       ${vectorSimExpr} as vector_similarity
@@ -1243,21 +1256,21 @@ async function queryEntities(
   return rows;
 }
 
-async function fetchEntityById(entityId: number, _env: Env, organizationId: string) {
+async function fetchEntityById(entityId: number, _env: Env, scope: AuthzScope) {
   const sql = getDb();
 
   // Caller's org or any visibility=public catalog. Lets entity_id lookup find
   // canonical entities (HMRC, banks) the agent has discovered via search.
-  // Operational counts (events, connections, watchers) are gated on
-  // caller-org so cross-org public hits don't leak other tenants' activity.
+  // Operational counts are gated on caller org; connection counts also use
+  // the caller's row-visibility predicate.
   const result = await sql.unsafe<EntityQueryRow>(
-    `SELECT ${entitySelectColumns(2)}
+    `SELECT ${entitySelectColumns(2, scope)}
     ${ENTITY_JOINS}
     LEFT JOIN organization eo ON eo.id = e.organization_id
     WHERE e.id = $1
       AND (e.organization_id = $2 OR eo.visibility = 'public')
       AND e.deleted_at IS NULL`,
-    [entityId, organizationId]
+    [entityId, scope.organizationId]
   );
 
   if (result.length === 0) return null;
@@ -1273,7 +1286,8 @@ async function fetchEntityById(entityId: number, _env: Env, organizationId: stri
 async function formatEntityResult(
   entityRows: EntityQueryRow[],
   args: SearchArgs,
-  ctx: ToolContext
+  ctx: ToolContext,
+  connectionScope: AuthzScope
 ): Promise<UnifiedSearchResult> {
   // Map rows to unified Entity format (all fields, nulls where not applicable)
   const matches: Entity[] = entityRows.map((row) => ({
@@ -1313,14 +1327,7 @@ async function formatEntityResult(
   let connections: ConnectionInfo[] | undefined;
   const primaryIsCallerOrg = String(primaryRow.organization_id) === ctx.organizationId;
   if ((args.include_connections ?? true) && primaryIsCallerOrg) {
-    connections = await fetchConnectionsForEntity(primaryEntity.id, {
-      ...authzScopeFromToolContext({
-        organizationId: ctx.organizationId,
-        userId: ctx.userId,
-        agentId: ctx.agentId,
-      }),
-      principalIsAdmin: await callerIsAdmin(getDb(), ctx),
-    });
+    connections = await fetchConnectionsForEntity(primaryEntity.id, connectionScope);
   }
 
   // Fetch children for root entities (no parent). Children are scoped to
@@ -1409,16 +1416,6 @@ async function formatEntityResult(
   };
 }
 
-/**
- * Connections attached to the primary entity. `connectionLinkedToBusinessEntitySql`
- * is a PURE linkage test (entity tag / linked feed / `about` edge) — it carries no
- * authz. `search_memory` is a PUBLIC_READ action and `include_connections` defaults
- * to true, so without the shared gate ANY org member could enumerate another
- * member's PRIVATE connections through it. Compile the predicate from the ONE
- * place every other connection read seam uses (manage_connections list/get,
- * manage_feeds read_feed, query_sql, connector pushdown) and drop soft-deleted
- * rows, which that helper also does not filter.
- */
 async function fetchConnectionsForEntity(
   entityId: number,
   scope: AuthzScope
@@ -1443,6 +1440,7 @@ async function fetchConnectionsForEntity(
     FROM connections c
     LEFT JOIN current_event_records f ON f.connection_id = c.id
     WHERE ${sql.unsafe(connectionLinkedToBusinessEntitySql(String(entityId), 'c', 'c.organization_id'))}
+      AND c.organization_id = ${scope.organizationId}
       AND c.deleted_at IS NULL
       ${sql.unsafe(compileConnectionRowVisibility(scope, 'c'))}
     GROUP BY c.id, c.connector_key, c.display_name, c.status, c.config, c.created_at, c.updated_at

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -13,6 +13,7 @@ import { evaluateEntityMutation, resolveActingPrincipal } from '../authz/entity-
 import { type AuthzScope, authzScopeFromToolContext } from '../authz/scope';
 import { compileConnectionRowVisibility } from '../authz/connection-visibility';
 import { getDb } from '../db/client';
+import { callerIsAdmin } from './admin/helpers/db-helpers';
 import type { Env } from '../index';
 import type { FeedReader, SourceKind } from '../lib/feed-reader';
 import { readVirtualFeed } from '../lib/connector-pushdown';
@@ -1312,7 +1313,14 @@ async function formatEntityResult(
   let connections: ConnectionInfo[] | undefined;
   const primaryIsCallerOrg = String(primaryRow.organization_id) === ctx.organizationId;
   if ((args.include_connections ?? true) && primaryIsCallerOrg) {
-    connections = await fetchConnectionsForEntity(primaryEntity.id);
+    connections = await fetchConnectionsForEntity(primaryEntity.id, {
+      ...authzScopeFromToolContext({
+        organizationId: ctx.organizationId,
+        userId: ctx.userId,
+        agentId: ctx.agentId,
+      }),
+      principalIsAdmin: await callerIsAdmin(getDb(), ctx),
+    });
   }
 
   // Fetch children for root entities (no parent). Children are scoped to
@@ -1401,7 +1409,20 @@ async function formatEntityResult(
   };
 }
 
-async function fetchConnectionsForEntity(entityId: number): Promise<ConnectionInfo[]> {
+/**
+ * Connections attached to the primary entity. `connectionLinkedToBusinessEntitySql`
+ * is a PURE linkage test (entity tag / linked feed / `about` edge) — it carries no
+ * authz. `search_memory` is a PUBLIC_READ action and `include_connections` defaults
+ * to true, so without the shared gate ANY org member could enumerate another
+ * member's PRIVATE connections through it. Compile the predicate from the ONE
+ * place every other connection read seam uses (manage_connections list/get,
+ * manage_feeds read_feed, query_sql, connector pushdown) and drop soft-deleted
+ * rows, which that helper also does not filter.
+ */
+async function fetchConnectionsForEntity(
+  entityId: number,
+  scope: AuthzScope
+): Promise<ConnectionInfo[]> {
   const sql = getDb();
   const result = await sql`
     SELECT
@@ -1422,6 +1443,8 @@ async function fetchConnectionsForEntity(entityId: number): Promise<ConnectionIn
     FROM connections c
     LEFT JOIN current_event_records f ON f.connection_id = c.id
     WHERE ${sql.unsafe(connectionLinkedToBusinessEntitySql(String(entityId), 'c', 'c.organization_id'))}
+      AND c.deleted_at IS NULL
+      ${sql.unsafe(compileConnectionRowVisibility(scope, 'c'))}
     GROUP BY c.id, c.connector_key, c.display_name, c.status, c.config, c.created_at, c.updated_at
     ORDER BY
       CASE c.status


### PR DESCRIPTION
## Problem

`search_memory` returned connections filtered **only** by business-entity linkage — `connectionLinkedToBusinessEntitySql` (`authz/channel-about.ts:677-706`) has no `visibility` clause, no `created_by` clause, and no `deleted_at` filter.

Every sibling seam applies the shared `compileConnectionRowVisibility` predicate (`authz/connection-visibility.ts:67-79`); this one had diverged. Result: any plain org member could see **other users' private connections** through `search_memory` (`include_connections` defaults true), on a `PUBLIC_READ_ACTIONS: null` tool.

Org boundary was enforced, so this is intra-org, not cross-tenant.

A second, subtler leak surfaced during review: the entity stat/suggestion **count subqueries** counted connections with no visibility predicate, so a member could infer a private connection's existence from an aggregate even once the rows themselves were filtered.

## Fix

Thread the resolved `AuthzScope` through `queryEntities`/`fetchEntityById` and apply `compileConnectionRowVisibility` to both the rows **and** the counts. Adds the missing `c.deleted_at IS NULL`.

Reuses the shared predicate rather than hand-rolling a second one — the divergence from that helper *was* the bug. Mirrors the `principalIsAdmin` shape used at `manage_operations.ts:780`; note admins deliberately do **not** get a blanket bypass to other members' private connections (per the helper's own docstring).

## Testing

6 cases, all verified red against `origin/main` before the fix:

- another member's private connection is **not** returned to a plain member
- owner still sees their own private connection
- admin gets the documented tier
- anonymous gets org-visible only
- soft-deleted connections excluded
- private connections not countable via entity stats/suggestions

Assertions are on connection **identity**, not secret values — deliberately, so the parallel redaction work can't make these pass for the wrong reason.

`make pre-pr` clean. `make review`: 0 bugs, 0 blockers, bug_free 94.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->