### PR TITLE
fix(agents): make every agent-create path produce a runnable agent

### DIFF
--- a/packages/server/src/__tests__/integration/tools/agent-insert-sites-guard.test.ts
+++ b/packages/server/src/__tests__/integration/tools/agent-insert-sites-guard.test.ts
@@ -15,6 +15,7 @@
  * at and then listed here deliberately, which is the whole point.
  */
 
+import { spawnSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -48,10 +49,9 @@ const SANCTIONED_INSERT_SITES = [
 
 const PROVISIONING_HELPER = "resolveNewAgentProvisioningDefaults";
 
-async function findAgentInsertSites(): Promise<string[]> {
+function findAgentInsertSites(): string[] {
 	// `git grep` keeps this honest against the real tree (respects .gitignore,
 	// no stale build output) and is fast enough to run inline.
-	const { spawnSync } = await import("node:child_process");
 	const res = spawnSync(
 		"git",
 		["grep", "-l", "INSERT INTO agents", "--", "src/**/*.ts"],
@@ -68,8 +68,8 @@ async function findAgentInsertSites(): Promise<string[]> {
 }
 
 describe("agents insert-site guard", () => {
-	it("every INSERT INTO agents site is a known, sanctioned one", async () => {
-		const found = await findAgentInsertSites();
+	it("every INSERT INTO agents site is a known, sanctioned one", () => {
+		const found = findAgentInsertSites();
 		expect(found.length).toBeGreaterThan(0); // guard against a broken grep
 		expect(found).toEqual(SANCTIONED_INSERT_SITES);
 	});

--- a/packages/server/src/__tests__/integration/tools/agent-insert-sites-guard.test.ts
+++ b/packages/server/src/__tests__/integration/tools/agent-insert-sites-guard.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Structural guard: every `INSERT INTO agents` site must seed the shared
+ * fresh-agent provisioning defaults.
+ *
+ * This bug was six divergent create paths. Two baked a system-key `models` list,
+ * one seeded only `pre_approved_tools`, and three seeded neither — so whether a
+ * brand-new agent could run at all depended on which code path happened to
+ * create it. Convergence is not self-enforcing: the next create path added
+ * without `resolveNewAgentProvisioningDefaults()` silently reintroduces it, and
+ * the symptom surfaces far away ("Agent reply finished without calling
+ * completeWindow") with no hint at provisioning.
+ *
+ * So this test fails on an UNKNOWN insert site rather than trying to prove
+ * runtime behavior. A new site is not necessarily wrong — but it must be looked
+ * at and then listed here deliberately, which is the whole point.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// packages/server/src/__tests__/integration/tools → packages/server/src
+const SERVER_SRC = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../../..",
+);
+
+/**
+ * The sanctioned `INSERT INTO agents` sites, each of which must resolve its
+ * fresh-agent defaults from the shared helper. Paths are relative to
+ * `packages/server/src`.
+ */
+const SANCTIONED_INSERT_SITES = [
+	// The shared UPSERT — reached by AgentMetadataStore.createAgent, i.e. the
+	// POST /api/v1/agents route. Also the UPDATE path, so its DO UPDATE SET
+	// clause deliberately omits models/pre_approved_tools.
+	"lobu/stores/postgres-stores.ts",
+	// The web UI create route (POST /agents).
+	"lobu/agent-routes.ts",
+	// The manage_agents create tool (MCP + REST proxy).
+	"tools/admin/manage_agents.ts",
+	// Boot provisioning for the org's default personal agent.
+	"auth/default-provisioning.ts",
+	// Boot provisioning for the org's builder/system agent.
+	"auth/builder-provisioning.ts",
+].sort();
+
+const PROVISIONING_HELPER = "resolveNewAgentProvisioningDefaults";
+
+async function findAgentInsertSites(): Promise<string[]> {
+	// `git grep` keeps this honest against the real tree (respects .gitignore,
+	// no stale build output) and is fast enough to run inline.
+	const { spawnSync } = await import("node:child_process");
+	const res = spawnSync(
+		"git",
+		["grep", "-l", "INSERT INTO agents", "--", "src/**/*.ts"],
+		{ cwd: path.resolve(SERVER_SRC, ".."), encoding: "utf8" },
+	);
+	return res.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.map((line) => line.replace(/^src\//, ""))
+		// Tests may insert agent rows freely — they are not production paths.
+		.filter((file) => !file.includes("__tests__"))
+		.sort();
+}
+
+describe("agents insert-site guard", () => {
+	it("every INSERT INTO agents site is a known, sanctioned one", async () => {
+		const found = await findAgentInsertSites();
+		expect(found.length).toBeGreaterThan(0); // guard against a broken grep
+		expect(found).toEqual(SANCTIONED_INSERT_SITES);
+	});
+
+	it("every sanctioned site resolves the shared provisioning defaults", async () => {
+		for (const relPath of SANCTIONED_INSERT_SITES) {
+			const source = await readFile(path.join(SERVER_SRC, relPath), "utf8");
+			expect(
+				source.includes(PROVISIONING_HELPER),
+				`${relPath} inserts into agents but never calls ${PROVISIONING_HELPER}(). ` +
+					"A freshly created agent must carry a system-key models list and the " +
+					"lobu-memory pre-approval, or it silently fails to run.",
+			).toBe(true);
+		}
+	});
+});

--- a/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
@@ -30,7 +30,10 @@ import { ensureDefaultAgent } from "../../../auth/default-provisioning";
 import type { Env } from "../../../index";
 import { orgContext } from "../../../lobu/stores/org-context";
 import { createPostgresAgentConfigStore } from "../../../lobu/stores/postgres-stores";
-import { createInferenceProvider } from "../../../lobu/stores/provider-secrets";
+import {
+	createInferenceProvider,
+	setInferenceProviderDefault,
+} from "../../../lobu/stores/provider-secrets";
 import type { AuthContext } from "../../../tools/execute";
 import { executeTool } from "../../../tools/execute";
 import { initWorkspaceProvider } from "../../../workspace";
@@ -240,18 +243,20 @@ describe("manage_agents create — env-key deployment provisions a runnable agen
 	});
 
 	it("a re-save does NOT clobber a curated models list or pre-approvals", async () => {
-		// `updateMetadata` (rename, lastUsedAt touch, …) funnels back through the
-		// same UPSERT. Seeding on INSERT must not leak into the CONFLICT path —
-		// otherwise every metadata touch would reset an admin's allow-list.
+		// Seeding on INSERT must not leak into the CONFLICT path — otherwise a
+		// re-save of an existing agent would reset an admin's allow-list. Driven
+		// through `saveMetadata` itself (the UPSERT), since that is the only
+		// caller that can reach the ON CONFLICT branch.
 		const store = createPostgresAgentConfigStore();
 		const sql = getTestDb();
+		const metadata = {
+			agentId: "store-curated-bot",
+			name: "v1",
+			owner: { platform: "external", userId: "u-store" },
+			createdAt: Date.now(),
+		};
 		await orgContext.run({ organizationId: orgId }, async () => {
-			await store.saveMetadata("store-curated-bot", {
-				agentId: "store-curated-bot",
-				name: "v1",
-				owner: { platform: "external", userId: "u-store" },
-				createdAt: Date.now(),
-			});
+			await store.saveMetadata("store-curated-bot", metadata);
 		});
 		// An admin curates the allow-list and narrows the pre-approvals.
 		await sql`
@@ -261,9 +266,10 @@ describe("manage_agents create — env-key deployment provisions a runnable agen
 			WHERE organization_id = ${orgId} AND id = 'store-curated-bot'
 		`;
 
-		// A later metadata-only edit (the rename path) must leave both alone.
+		// A re-save of the SAME id takes the ON CONFLICT branch: it updates the
+		// metadata columns and must leave the curated policy columns alone.
 		await orgContext.run({ organizationId: orgId }, async () => {
-			await store.updateMetadata("store-curated-bot", { name: "v2" });
+			await store.saveMetadata("store-curated-bot", { ...metadata, name: "v2" });
 		});
 
 		const rows = await sql`
@@ -275,5 +281,178 @@ describe("manage_agents create — env-key deployment provisions a runnable agen
 		expect(rows[0]?.pre_approved_tools).toEqual([
 			"/mcp/lobu-memory/tools/query_sdk",
 		]);
+	});
+
+	it("updateMetadata renames WITHOUT touching models or pre-approvals", async () => {
+		// The direct-UPDATE path: a metadata-only edit must not run provisioning
+		// at all, and must leave the policy columns untouched.
+		const store = createPostgresAgentConfigStore();
+		const sql = getTestDb();
+		await orgContext.run({ organizationId: orgId }, async () => {
+			await store.saveMetadata("store-rename-bot", {
+				agentId: "store-rename-bot",
+				name: "before",
+				description: "keep me",
+				owner: { platform: "external", userId: "u-store" },
+				createdAt: Date.now(),
+			});
+		});
+		await sql`
+			UPDATE agents SET models = ${sql.json(["myco/myco-large"])}
+			WHERE organization_id = ${orgId} AND id = 'store-rename-bot'
+		`;
+
+		await orgContext.run({ organizationId: orgId }, async () => {
+			await store.updateMetadata("store-rename-bot", { name: "after" });
+		});
+
+		const rows = await sql`
+			SELECT name, description, models FROM agents
+			WHERE organization_id = ${orgId} AND id = 'store-rename-bot'
+		`;
+		expect(rows[0]?.name).toBe("after");
+		// COALESCE keeps an omitted field at its current value.
+		expect(rows[0]?.description).toBe("keep me");
+		expect(rows[0]?.models).toEqual(["myco/myco-large"]);
+	});
+});
+
+/**
+ * The other half of the ordering: an org that has DELIBERATELY configured a
+ * default model. Seeding a system-key ref into `models` here would be persisted
+ * at `models[0]`, which `resolveAgentModelInfo` checks FIRST — permanently
+ * shadowing the org default, so an admin's later change to it would silently
+ * never reach agents created before that change. A new agent must inherit
+ * instead: runnable, but through the org default, not around it.
+ *
+ * The env key is set here too, so the ONLY thing distinguishing this suite from
+ * the one above is the presence of the org default row.
+ */
+describe("agent create — an org default is inherited, never shadowed", () => {
+	let orgId: string;
+	let ownerCtx: AuthContext;
+	const savedAnthropicKey = process.env.ANTHROPIC_API_KEY;
+	const savedRegistryPath = process.env.LOBU_PROVIDER_REGISTRY_PATH;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		process.env.ANTHROPIC_API_KEY = "sk-ant-test-system-key";
+		process.env.LOBU_PROVIDER_REGISTRY_PATH = PROVIDERS_JSON;
+
+		const org = await createTestOrganization({ name: "org-default provisioning" });
+		orgId = org.id;
+		const owner = await createTestUser({ email: "orgdefault-owner@test.com" });
+		await addUserToOrganization(owner.id, org.id, "owner");
+		ownerCtx = {
+			organizationId: org.id,
+			tokenOrganizationId: org.id,
+			userId: owner.id,
+			memberRole: "owner",
+			agentId: null,
+			requestedAgentId: null,
+			isAuthenticated: true,
+			clientId: null,
+			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+			tokenType: "oauth",
+			requestUrl: `http://localhost/api/${org.id}`,
+			baseUrl: "",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+		};
+
+		// The deliberate org-level policy this suite protects.
+		await orgContext.run({ organizationId: org.id }, async () => {
+			await createInferenceProvider({
+				organizationId: org.id,
+				slug: "myco",
+				kind: "openai",
+				apiKey: "sk-test",
+				capabilities: { text: { model: "myco-large" } },
+			});
+			await setInferenceProviderDefault(org.id, "myco");
+		});
+	});
+
+	afterAll(() => {
+		if (savedAnthropicKey === undefined) {
+			delete process.env.ANTHROPIC_API_KEY;
+		} else {
+			process.env.ANTHROPIC_API_KEY = savedAnthropicKey;
+		}
+		if (savedRegistryPath === undefined) {
+			delete process.env.LOBU_PROVIDER_REGISTRY_PATH;
+		} else {
+			process.env.LOBU_PROVIDER_REGISTRY_PATH = savedRegistryPath;
+		}
+	});
+
+	it("manage_agents create resolves via the ORG DEFAULT, not a baked system-key model", async () => {
+		const res = (await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "inherits-bot", name: "Inherits" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { created: boolean; model: ModelInfo };
+
+		expect(res.created).toBe(true);
+		expect(res.model.not_runnable).toBe(false);
+		// THE REGRESSION: this was 'agent' / 'claude/claude-sonnet-5', because
+		// provisioning baked the system-key list in regardless of the org default.
+		expect(res.model.source).toBe("org_default");
+		expect(res.model.effective_model).toBe("myco/myco-large");
+
+		// Nothing pinned on the row — that absence IS the inheritance.
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT models FROM agents
+			WHERE organization_id = ${orgId} AND id = 'inherits-bot'
+		`;
+		const models = rows[0]?.models as string[] | null;
+		expect(models === null || models.length === 0).toBe(true);
+	});
+
+	it("the shared saveMetadata UPSERT also inherits the org default", async () => {
+		const store = createPostgresAgentConfigStore();
+		await orgContext.run({ organizationId: orgId }, async () => {
+			await store.saveMetadata("store-inherits-bot", {
+				agentId: "store-inherits-bot",
+				name: "Store Inherits",
+				owner: { platform: "external", userId: "u-store" },
+				createdAt: Date.now(),
+			});
+		});
+
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT models, pre_approved_tools FROM agents
+			WHERE organization_id = ${orgId} AND id = 'store-inherits-bot'
+		`;
+		const models = rows[0]?.models as string[] | null;
+		expect(models === null || models.length === 0).toBe(true);
+		// The pre-approval is unconditional — it is not model policy.
+		expect(rows[0]?.pre_approved_tools).toContain("/mcp/lobu-memory/tools/*");
+	});
+
+	it("an explicit default_model still outranks the org default", async () => {
+		const res = (await executeTool(
+			"manage_agents",
+			{
+				action: "create",
+				agent_id: "pinned-over-org-bot",
+				name: "Pinned Over Org",
+				default_model: "myco/myco-large",
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { model: ModelInfo };
+		expect(res.model.source).toBe("agent");
+
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT models FROM agents
+			WHERE organization_id = ${orgId} AND id = 'pinned-over-org-bot'
+		`;
+		expect(rows[0]?.models).toEqual(["myco/myco-large"]);
 	});
 });

--- a/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
@@ -1,0 +1,214 @@
+/**
+ * A freshly created agent must be RUNNABLE on a deployment configured purely by
+ * environment API keys.
+ *
+ * The bug: three paths insert an `agents` row, and only two of them baked in a
+ * `models` list resolved from the deployment's system keys:
+ *   - `ensureDefaultAgent` / `ensureBuilderAgent` call
+ *     `resolveSystemKeyProvidersAndModel()` and persist the result.
+ *   - `manage_agents` create persisted `models` ONLY when the caller passed an
+ *     explicit `default_model`.
+ *
+ * The runtime fallback is `agent.models[0] → org default row → nothing`, and the
+ * org-default tail reads `inference_providers WHERE is_default` — a DB ROW that
+ * environment API keys never create. So on an env-key-only deployment an agent
+ * made through `manage_agents create` resolved NO model, never completed a turn,
+ * and its Behavior failed with "Agent reply finished without calling
+ * completeWindow" — while the SAME Behavior succeeded on an older agent that had
+ * been provisioned through `ensureDefaultAgent`.
+ *
+ * `pre_approved_tools` had the same shape of divergence: the web create route
+ * seeds `/mcp/lobu-memory/tools/*` so the agent may call `query_sdk` / `run_sdk`
+ * (which is how a Behavior reaches `completeWindow`) without an interactive
+ * approval, and the tool path seeded nothing.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ensureDefaultAgent } from "../../../auth/default-provisioning";
+import type { Env } from "../../../index";
+import { orgContext } from "../../../lobu/stores/org-context";
+import { createInferenceProvider } from "../../../lobu/stores/provider-secrets";
+import type { AuthContext } from "../../../tools/execute";
+import { executeTool } from "../../../tools/execute";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const TEST_ENV: Env = {
+	ENVIRONMENT: "test",
+	DATABASE_URL: process.env.DATABASE_URL,
+	JWT_SECRET: "test-jwt-secret-for-testing-only",
+	BETTER_AUTH_SECRET: "test-auth-secret-for-testing-only",
+	MAX_CONSECUTIVE_FAILURES: "3",
+	RATE_LIMIT_ENABLED: "false",
+};
+
+type ModelInfo = {
+	effective_model: string | null;
+	source: "agent" | "org_default" | "none";
+	not_runnable: boolean;
+};
+
+// packages/server/src/__tests__/integration/tools → repo root.
+const PROVIDERS_JSON = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../../../../../../config/providers.json",
+);
+
+describe("manage_agents create — env-key deployment provisions a runnable agent", () => {
+	let orgId: string;
+	let ownerCtx: AuthContext;
+	const savedAnthropicKey = process.env.ANTHROPIC_API_KEY;
+	const savedRegistryPath = process.env.LOBU_PROVIDER_REGISTRY_PATH;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+
+		// The prod shape this bug reproduces: the deployment's ONLY model
+		// credential is an environment API key. There is deliberately no
+		// `inference_providers` row (and therefore no org default), because env
+		// keys never create one. The registry path is pinned so the catalog's
+		// `defaultModel` resolves to a concrete ref (as it does in prod) rather
+		// than an `__unresolved__` sentinel.
+		process.env.ANTHROPIC_API_KEY = "sk-ant-test-system-key";
+		process.env.LOBU_PROVIDER_REGISTRY_PATH = PROVIDERS_JSON;
+
+		const org = await createTestOrganization({
+			name: "env-key create provisioning",
+		});
+		orgId = org.id;
+		const owner = await createTestUser({ email: "envkey-owner@test.com" });
+		await addUserToOrganization(owner.id, org.id, "owner");
+		ownerCtx = {
+			organizationId: org.id,
+			tokenOrganizationId: org.id,
+			userId: owner.id,
+			memberRole: "owner",
+			agentId: null,
+			requestedAgentId: null,
+			isAuthenticated: true,
+			clientId: null,
+			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+			tokenType: "oauth",
+			requestUrl: `http://localhost/api/${org.id}`,
+			baseUrl: "",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+		};
+	});
+
+	afterAll(() => {
+		if (savedAnthropicKey === undefined) {
+			delete process.env.ANTHROPIC_API_KEY;
+		} else {
+			process.env.ANTHROPIC_API_KEY = savedAnthropicKey;
+		}
+		if (savedRegistryPath === undefined) {
+			delete process.env.LOBU_PROVIDER_REGISTRY_PATH;
+		} else {
+			process.env.LOBU_PROVIDER_REGISTRY_PATH = savedRegistryPath;
+		}
+	});
+
+	it("the org has NO inference_providers default row (env keys never create one)", async () => {
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT 1 FROM inference_providers
+			WHERE organization_id = ${orgId} AND is_default AND deleted_at IS NULL
+		`;
+		expect(rows.length).toBe(0);
+	});
+
+	it("create WITHOUT default_model bakes the system-key models list ⇒ runnable", async () => {
+		const res = (await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "envkey-bot", name: "Env Key Bot" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { created: boolean; model: ModelInfo };
+
+		expect(res.created).toBe(true);
+		// THE BUG: this resolved { source: 'none', not_runnable: true } because
+		// `models` was left NULL and no org-default row exists to fall back to.
+		expect(res.model.not_runnable).toBe(false);
+		expect(res.model.source).toBe("agent");
+		expect(res.model.effective_model).toBe("claude/claude-sonnet-5");
+
+		// The list is persisted on the row — the same single source of truth
+		// `ensureDefaultAgent` writes, not a read-time inference.
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT models FROM agents
+			WHERE organization_id = ${orgId} AND id = 'envkey-bot'
+		`;
+		expect(rows[0]?.models).toContain("claude/claude-sonnet-5");
+	});
+
+	it("create seeds the lobu-memory pre-approval so query_sdk / run_sdk need no interactive approval", async () => {
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT pre_approved_tools FROM agents
+			WHERE organization_id = ${orgId} AND id = 'envkey-bot'
+		`;
+		// A Behavior reaches completeWindow through run_sdk on the lobu-memory
+		// MCP. The web create route already seeds this; the tool path did not.
+		expect(rows[0]?.pre_approved_tools).toContain("/mcp/lobu-memory/tools/*");
+	});
+
+	it("an explicit default_model still wins over the system-key default", async () => {
+		// Regression guard: baking a default must not override a caller's choice.
+		// The ref is validated against the org's providers, so this uses a real
+		// `inference_providers` row rather than the env-key provider (whose slug
+		// resolves through the module registry, which is empty in-process here).
+		await orgContext.run({ organizationId: orgId }, async () => {
+			await createInferenceProvider({
+				organizationId: orgId,
+				slug: "myco",
+				kind: "openai",
+				apiKey: "sk-test",
+				capabilities: { text: { model: "myco-large" } },
+			});
+		});
+		const res = (await executeTool(
+			"manage_agents",
+			{
+				action: "create",
+				agent_id: "envkey-pinned-bot",
+				name: "Pinned",
+				default_model: "myco/myco-large",
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { created: boolean; model: ModelInfo };
+		expect(res.model.effective_model).toBe("myco/myco-large");
+		expect(res.model.source).toBe("agent");
+
+		// ONLY the caller's pin — the system-key list must not have been merged in.
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT models FROM agents
+			WHERE organization_id = ${orgId} AND id = 'envkey-pinned-bot'
+		`;
+		expect(rows[0]?.models).toEqual(["myco/myco-large"]);
+	});
+
+	it("CONTRAST: an ensureDefaultAgent-provisioned agent in the SAME env is runnable", async () => {
+		// This is the asymmetry the user hit — the older agent worked because its
+		// provisioning path baked the models list in.
+		const org = await createTestOrganization({ name: "env-key default agent" });
+		await ensureDefaultAgent(org.id);
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT models FROM agents WHERE organization_id = ${org.id}
+		`;
+		expect(rows.length).toBeGreaterThan(0);
+		expect(rows[0]?.models).toContain("claude/claude-sonnet-5");
+	});
+});

--- a/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
@@ -29,6 +29,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { ensureDefaultAgent } from "../../../auth/default-provisioning";
 import type { Env } from "../../../index";
 import { orgContext } from "../../../lobu/stores/org-context";
+import { createPostgresAgentConfigStore } from "../../../lobu/stores/postgres-stores";
 import { createInferenceProvider } from "../../../lobu/stores/provider-secrets";
 import type { AuthContext } from "../../../tools/execute";
 import { executeTool } from "../../../tools/execute";
@@ -210,5 +211,69 @@ describe("manage_agents create — env-key deployment provisions a runnable agen
 		`;
 		expect(rows.length).toBeGreaterThan(0);
 		expect(rows[0]?.models).toContain("claude/claude-sonnet-5");
+	});
+
+	// ── The shared UPSERT (`saveMetadata`) ────────────────────────────────────
+	// Reached by `AgentMetadataStore.createAgent`, i.e. the `POST /api/v1/agents`
+	// route mounted at gateway.ts. It is a genuine sixth insert site, and it is
+	// ALSO the update path (`updateMetadata` reads-then-re-saves), so the two
+	// cases below pin both halves of the contract.
+
+	it("saveMetadata seeds provisioning defaults on a FRESH insert", async () => {
+		const store = createPostgresAgentConfigStore();
+		await orgContext.run({ organizationId: orgId }, async () => {
+			await store.saveMetadata("store-fresh-bot", {
+				agentId: "store-fresh-bot",
+				name: "Store Fresh Bot",
+				owner: { platform: "external", userId: "u-store" },
+				createdAt: Date.now(),
+			});
+		});
+
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT models, pre_approved_tools FROM agents
+			WHERE organization_id = ${orgId} AND id = 'store-fresh-bot'
+		`;
+		expect(rows[0]?.models).toContain("claude/claude-sonnet-5");
+		expect(rows[0]?.pre_approved_tools).toContain("/mcp/lobu-memory/tools/*");
+	});
+
+	it("a re-save does NOT clobber a curated models list or pre-approvals", async () => {
+		// `updateMetadata` (rename, lastUsedAt touch, …) funnels back through the
+		// same UPSERT. Seeding on INSERT must not leak into the CONFLICT path —
+		// otherwise every metadata touch would reset an admin's allow-list.
+		const store = createPostgresAgentConfigStore();
+		const sql = getTestDb();
+		await orgContext.run({ organizationId: orgId }, async () => {
+			await store.saveMetadata("store-curated-bot", {
+				agentId: "store-curated-bot",
+				name: "v1",
+				owner: { platform: "external", userId: "u-store" },
+				createdAt: Date.now(),
+			});
+		});
+		// An admin curates the allow-list and narrows the pre-approvals.
+		await sql`
+			UPDATE agents
+			SET models = ${sql.json(["myco/myco-large"])},
+			    pre_approved_tools = ${sql.json(["/mcp/lobu-memory/tools/query_sdk"])}
+			WHERE organization_id = ${orgId} AND id = 'store-curated-bot'
+		`;
+
+		// A later metadata-only edit (the rename path) must leave both alone.
+		await orgContext.run({ organizationId: orgId }, async () => {
+			await store.updateMetadata("store-curated-bot", { name: "v2" });
+		});
+
+		const rows = await sql`
+			SELECT name, models, pre_approved_tools FROM agents
+			WHERE organization_id = ${orgId} AND id = 'store-curated-bot'
+		`;
+		expect(rows[0]?.name).toBe("v2");
+		expect(rows[0]?.models).toEqual(["myco/myco-large"]);
+		expect(rows[0]?.pre_approved_tools).toEqual([
+			"/mcp/lobu-memory/tools/query_sdk",
+		]);
 	});
 });

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -222,7 +222,7 @@ export async function ensureBuilderAgent(
 			return { created: false };
 		}
 
-		const resolved = await resolveNewAgentProvisioningDefaults();
+		const resolved = await resolveNewAgentProvisioningDefaults(organizationId);
 		const ownerUserId = await resolveOwnerUserId(client, organizationId);
 
 		await client`

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -35,7 +35,10 @@ import type { DbClient } from "../db/client";
 import { getDb } from "../db/client";
 import logger from "../utils/logger";
 import { hasOrgSentinel } from "./default-provisioning";
-import { resolveSystemKeyProvidersAndModel } from "./system-provider-resolution";
+import {
+	resolveNewAgentProvisioningDefaults,
+	resolveSystemKeyProvidersAndModel,
+} from "./system-provider-resolution";
 
 export const BUILDER_AGENT_ID = "lobu-builder";
 export const BUILDER_AGENT_SENTINEL = "builder_agent_provisioned";
@@ -219,19 +222,20 @@ export async function ensureBuilderAgent(
 			return { created: false };
 		}
 
-		const resolved = await resolveSystemKeyProvidersAndModel();
+		const resolved = await resolveNewAgentProvisioningDefaults();
 		const ownerUserId = await resolveOwnerUserId(client, organizationId);
 
 		await client`
       INSERT INTO agents (
         id, organization_id, name, identity_md,
         owner_platform, owner_user_id,
-        models,
+        models, pre_approved_tools,
         created_at, updated_at
       ) VALUES (
         ${BUILDER_AGENT_ID}, ${organizationId}, ${BUILDER_AGENT_NAME}, ${BUILDER_AGENT_IDENTITY},
         'external', ${ownerUserId},
         ${client.json(resolved.models)},
+        ${client.json(resolved.preApprovedTools)},
         NOW(), NOW()
       )
       ON CONFLICT (organization_id, id) DO NOTHING

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -28,7 +28,10 @@ import { getDb } from "../db/client";
 import { getNextNumericId } from "../tools/admin/helpers/db-helpers";
 import { nextRunAt } from "../utils/cron";
 import logger from "../utils/logger";
-import { resolveSystemKeyProvidersAndModel } from "./system-provider-resolution";
+import {
+	resolveNewAgentProvisioningDefaults,
+	resolveSystemKeyProvidersAndModel,
+} from "./system-provider-resolution";
 
 export const DEFAULT_AGENT_SENTINEL = "default_agent_provisioned";
 export const DEFAULT_WATCHER_SENTINEL = "default_watcher_provisioned";
@@ -271,8 +274,9 @@ export async function ensureDefaultAgent(
 		// into a concrete `models` list for the default agent up front. Without
 		// this, the row exists with no models and `lobu chat -c local` would
 		// immediately hit "No model configured" — even though the env keys are
-		// sitting right there in the same process.
-		const resolved = await resolveSystemKeyProvidersAndModel();
+		// sitting right there in the same process. Shared with the other create
+		// paths so every freshly provisioned agent starts runnable.
+		const resolved = await resolveNewAgentProvisioningDefaults();
 
 		// Resolve the owning user — the personal_org metadata is the canonical
 		// marker. The default agent is shown as user-owned (rather than the
@@ -295,12 +299,13 @@ export async function ensureDefaultAgent(
       INSERT INTO agents (
         id, organization_id, name, identity_md,
         owner_platform, owner_user_id,
-        models,
+        models, pre_approved_tools,
         created_at, updated_at
       ) VALUES (
         ${DEFAULT_AGENT_ID}, ${organizationId}, ${DEFAULT_AGENT_NAME}, ${DEFAULT_AGENT_IDENTITY},
         'external', ${ownerUserId},
         ${client.json(resolved.models)},
+        ${client.json(resolved.preApprovedTools)},
         NOW(), NOW()
       )
       ON CONFLICT (organization_id, id) DO NOTHING

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -276,7 +276,7 @@ export async function ensureDefaultAgent(
 		// immediately hit "No model configured" — even though the env keys are
 		// sitting right there in the same process. Shared with the other create
 		// paths so every freshly provisioned agent starts runnable.
-		const resolved = await resolveNewAgentProvisioningDefaults();
+		const resolved = await resolveNewAgentProvisioningDefaults(organizationId);
 
 		// Resolve the owning user — the personal_org metadata is the canonical
 		// marker. The default agent is shown as user-owned (rather than the

--- a/packages/server/src/auth/system-provider-resolution.ts
+++ b/packages/server/src/auth/system-provider-resolution.ts
@@ -13,6 +13,7 @@ import { resolveEnv } from "../gateway/auth/mcp/string-substitution";
 import { collectProviderModelOptions } from "../gateway/auth/provider-model-options";
 import { UNRESOLVED_MODEL_SUFFIX } from "../gateway/auth/model-sentinel";
 import { getModelProviderModules } from "../gateway/modules/module-system";
+import { getOrgDefaultModel } from "../lobu/stores/provider-secrets";
 import {
 	ProviderRegistryService,
 	resolveProviderRegistryPath,
@@ -208,26 +209,43 @@ export const DEFAULT_PRE_APPROVED_TOOLS = ["/mcp/lobu-memory/tools/*"];
 /**
  * The provisioning defaults a brand-new agent row must carry to be runnable on
  * THIS deployment. Every create path — `ensureDefaultAgent`,
- * `ensureBuilderAgent`, the web `POST /agents` route, and the `manage_agents`
- * create tool — resolves its fresh-agent defaults here.
+ * `ensureBuilderAgent`, the web `POST /agents` route, the `manage_agents` create
+ * tool, and the shared `saveMetadata` UPSERT — resolves its defaults here.
  *
- * Why `models` must be baked in at create rather than inferred at run time: the
- * run path's fallback is `agent.models[0] → the org's `inference_providers`
- * `is_default` ROW → nothing`. Environment API keys (ANTHROPIC_API_KEY,
- * CLAUDE_CODE_OAUTH_TOKEN, a providers.json `envVarName`, a module registry
- * `hasSystemKey()`) never create that row, so on an env-key-only deployment an
- * agent left with `models = NULL` resolves NO model at all. It then never
- * completes a turn, and its Behavior fails with "Agent reply finished without
- * calling completeWindow".
+ * The run path resolves a model as `agent.models[0] → the org's
+ * `inference_providers` is_default ROW → nothing`, so `models` is seeded
+ * ORG-AWARELY, in that same order of authority:
+ *
+ *   - The org HAS a configured default ⇒ seed an EMPTY list. The agent inherits
+ *     the org default at run time, which is the documented design. Baking a
+ *     concrete ref here would be persisted at `models[0]` and permanently SHADOW
+ *     the org default — an admin's later change to it would silently not reach
+ *     agents created before the change.
+ *   - The org has NO default ⇒ bake the system-key list. Environment API keys
+ *     (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, a providers.json
+ *     `envVarName`, a module registry `hasSystemKey()`) never create an
+ *     `inference_providers` row, so without this the agent resolves NO model at
+ *     all, never completes a turn, and its Behavior fails with "Agent reply
+ *     finished without calling completeWindow".
+ *
+ * An explicit `default_model` supplied by the caller outranks both and is
+ * applied by the caller, not here.
  *
  * Keeping this in ONE place is the point: the divergence between paths that
  * baked a models list and paths that did not WAS the bug.
  */
-export async function resolveNewAgentProvisioningDefaults(): Promise<{
+export async function resolveNewAgentProvisioningDefaults(
+	organizationId: string,
+): Promise<{
 	models: string[];
 	preApprovedTools: string[];
 }> {
-	const resolved = await resolveSystemKeyProvidersAndModel();
+	// An org-level default already makes the agent runnable through the
+	// documented fallback, so seed nothing and let it inherit.
+	const orgDefault = await getOrgDefaultModel(organizationId);
+	const resolved = orgDefault
+		? { models: [] }
+		: await resolveSystemKeyProvidersAndModel();
 	return {
 		models: resolved.models,
 		preApprovedTools: [...DEFAULT_PRE_APPROVED_TOOLS],

--- a/packages/server/src/auth/system-provider-resolution.ts
+++ b/packages/server/src/auth/system-provider-resolution.ts
@@ -192,3 +192,44 @@ export async function resolveSystemKeyProvidersAndModel(): Promise<ResolvedSyste
 	}
 	return { models };
 }
+
+/**
+ * The `pre_approved_tools` every freshly created agent starts with. A Behavior
+ * reaches `complete_window` through `run_sdk` (and reads through `query_sdk`) on
+ * the internal `lobu-memory` MCP server; without this pre-approval those calls
+ * need an interactive approval no watcher run can satisfy, so the turn ends
+ * without completing the window.
+ *
+ * The `lobu-memory` server itself is NOT stored per-agent — it is derived at
+ * worker startup by `McpConfigService`. Only the approval pattern is persisted.
+ */
+export const DEFAULT_PRE_APPROVED_TOOLS = ["/mcp/lobu-memory/tools/*"];
+
+/**
+ * The provisioning defaults a brand-new agent row must carry to be runnable on
+ * THIS deployment. Every create path — `ensureDefaultAgent`,
+ * `ensureBuilderAgent`, the web `POST /agents` route, and the `manage_agents`
+ * create tool — resolves its fresh-agent defaults here.
+ *
+ * Why `models` must be baked in at create rather than inferred at run time: the
+ * run path's fallback is `agent.models[0] → the org's `inference_providers`
+ * `is_default` ROW → nothing`. Environment API keys (ANTHROPIC_API_KEY,
+ * CLAUDE_CODE_OAUTH_TOKEN, a providers.json `envVarName`, a module registry
+ * `hasSystemKey()`) never create that row, so on an env-key-only deployment an
+ * agent left with `models = NULL` resolves NO model at all. It then never
+ * completes a turn, and its Behavior fails with "Agent reply finished without
+ * calling completeWindow".
+ *
+ * Keeping this in ONE place is the point: the divergence between paths that
+ * baked a models list and paths that did not WAS the bug.
+ */
+export async function resolveNewAgentProvisioningDefaults(): Promise<{
+	models: string[];
+	preApprovedTools: string[];
+}> {
+	const resolved = await resolveSystemKeyProvidersAndModel();
+	return {
+		models: resolved.models,
+		preApprovedTools: [...DEFAULT_PRE_APPROVED_TOOLS],
+	};
+}

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -12,6 +12,7 @@ import {
 import { Hono } from "hono";
 import { ensureBuilderAgent } from "../auth/builder-provisioning";
 import { mcpAuth } from "../auth/middleware";
+import { resolveNewAgentProvisioningDefaults } from "../auth/system-provider-resolution";
 import { resolveBehaviorTriggerWrite } from "../behaviors/triggers";
 import { getDb } from "../db/client";
 import { grantStrategyFor } from "../gateway/auth/oauth/grant-strategy";
@@ -516,16 +517,22 @@ routes.post("/", async (c) => {
 	// stored per-agent — it's derived at worker startup by McpConfigService.
 	const sql = getDb();
 	const now = new Date();
-	const ownerPreApprovedTools = ["/mcp/lobu-memory/tools/*"];
+	// Fresh-agent provisioning defaults from the shared helper — the SAME source
+	// the boot provisioning paths and the manage_agents create tool use. `models`
+	// is baked in here because the run path's org-default tail reads an
+	// `inference_providers` row that environment API keys never create; an agent
+	// left model-less on an env-key-only deployment resolves no model at all.
+	const provisioning = await resolveNewAgentProvisioningDefaults();
 	const inserted = await sql`
     INSERT INTO agents (
       id, organization_id, name, description, owner_platform, owner_user_id,
-      pre_approved_tools, created_at, updated_at
+      models, pre_approved_tools, created_at, updated_at
     )
     VALUES (
       ${agentId}, ${orgId}, ${name}, ${description ?? null},
       'lobu', ${user.id},
-      ${sql.json(ownerPreApprovedTools)}, ${now}, ${now}
+      ${sql.json(provisioning.models)},
+      ${sql.json(provisioning.preApprovedTools)}, ${now}, ${now}
     )
     ON CONFLICT (organization_id, id) DO NOTHING
     RETURNING id

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -522,7 +522,7 @@ routes.post("/", async (c) => {
 	// is baked in here because the run path's org-default tail reads an
 	// `inference_providers` row that environment API keys never create; an agent
 	// left model-less on an env-key-only deployment resolves no model at all.
-	const provisioning = await resolveNewAgentProvisioningDefaults();
+	const provisioning = await resolveNewAgentProvisioningDefaults(orgId);
 	const inserted = await sql`
     INSERT INTO agents (
       id, organization_id, name, description, owner_platform, owner_user_id,

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -5,6 +5,7 @@ import type {
 	AgentSettings,
 } from "@lobu/core";
 import { createLogger } from "@lobu/core";
+import { resolveNewAgentProvisioningDefaults } from "../../auth/system-provider-resolution";
 import { getDb, tsTime, tsTimeOrNull } from "../../db/client";
 import { recordLifecycleEvent } from "../../utils/insert-event";
 import {
@@ -234,6 +235,20 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			const sql = getDb();
 			const orgId = getOrgId();
 			const now = new Date();
+			// Fresh-agent provisioning defaults, from the SAME helper every other
+			// create path uses. This is the shared UPSERT reached by
+			// `AgentMetadataStore.createAgent` (the `/api/v1/agents` POST route), so
+			// seeding here is what keeps an agent created through that route
+			// runnable — without it the row lands with `models = NULL` and, on a
+			// deployment whose only model credential is an environment API key,
+			// resolves no model at all.
+			//
+			// These two columns are deliberately ABSENT from the DO UPDATE SET
+			// clause below: `saveMetadata` is also the UPDATE path (see
+			// `updateMetadata`, which reads-then-re-saves), and a re-save must never
+			// clobber an admin's curated `models` allow-list or an agent's
+			// pre-approvals. INSERT seeds them; CONFLICT leaves them untouched.
+			const provisioning = await resolveNewAgentProvisioningDefaults();
 			// The PK is (organization_id, id) — UPSERT on the composite key. Two
 			// orgs can independently own an agent with the same id; the conflict
 			// path here only triggers for re-saves within the *same* org.
@@ -241,10 +256,12 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			// a CONFLICT UPDATE so we can emit the right lifecycle event.
 			const rows = await sql`
         INSERT INTO agents (id, organization_id, name, description, owner_platform, owner_user_id,
-                            created_at)
+                            models, pre_approved_tools, created_at)
         VALUES (
           ${agentId}, ${orgId}, ${metadata.name}, ${metadata.description ?? null},
           ${metadata.owner.platform}, ${metadata.owner.userId},
+          ${sql.json(provisioning.models)},
+          ${sql.json(provisioning.preApprovedTools)},
           ${metadata.createdAt ? new Date(metadata.createdAt) : now}
         )
         ON CONFLICT (organization_id, id) DO UPDATE SET

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -236,19 +236,18 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			const orgId = getOrgId();
 			const now = new Date();
 			// Fresh-agent provisioning defaults, from the SAME helper every other
-			// create path uses. This is the shared UPSERT reached by
-			// `AgentMetadataStore.createAgent` (the `/api/v1/agents` POST route), so
-			// seeding here is what keeps an agent created through that route
-			// runnable — without it the row lands with `models = NULL` and, on a
-			// deployment whose only model credential is an environment API key,
-			// resolves no model at all.
+			// create path uses (see `resolveNewAgentProvisioningDefaults`). This is
+			// the shared UPSERT reached by `AgentMetadataStore.createAgent`, i.e. the
+			// `POST /api/v1/agents` route, so seeding here is what keeps an agent
+			// created through that route runnable.
 			//
 			// These two columns are deliberately ABSENT from the DO UPDATE SET
-			// clause below: `saveMetadata` is also the UPDATE path (see
-			// `updateMetadata`, which reads-then-re-saves), and a re-save must never
-			// clobber an admin's curated `models` allow-list or an agent's
-			// pre-approvals. INSERT seeds them; CONFLICT leaves them untouched.
-			const provisioning = await resolveNewAgentProvisioningDefaults();
+			// clause below. `saveMetadata` is an UPSERT, so any caller re-saving an
+			// existing agent (a re-`createAgent` on an id that already exists, a
+			// replayed apply) must never clobber an admin's curated `models`
+			// allow-list or an agent's pre-approvals. INSERT seeds them; CONFLICT
+			// leaves them untouched.
+			const provisioning = await resolveNewAgentProvisioningDefaults(orgId);
 			// The PK is (organization_id, id) — UPSERT on the composite key. Two
 			// orgs can independently own an agent with the same id; the conflict
 			// path here only triggers for re-saves within the *same* org.
@@ -285,9 +284,33 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			});
 		},
 		async updateMetadata(agentId, updates) {
-			const existing = await store.getMetadata(agentId);
-			if (!existing) return;
-			await store.saveMetadata(agentId, { ...existing, ...updates });
+			const sql = getDb();
+			const orgId = getOrgId();
+			// A DIRECT update of the three mutable metadata fields, deliberately NOT
+			// a read-then-`saveMetadata` round trip. Routing a rename through the
+			// UPSERT would run fresh-agent provisioning (provider discovery, and a
+			// possible org-default lookup) on a metadata-only edit — wasted work,
+			// and a rename that could fail on a provider-discovery error. COALESCE
+			// keeps an omitted field at its current value.
+			const rows = await sql`
+        UPDATE agents SET
+          name = COALESCE(${updates.name ?? null}, name),
+          description = COALESCE(${updates.description ?? null}, description),
+          last_used_at = COALESCE(${
+						updates.lastUsedAt ? new Date(updates.lastUsedAt) : null
+					}, last_used_at),
+          updated_at = ${new Date()}
+        WHERE id = ${agentId} AND organization_id = ${orgId}
+        RETURNING name
+      `;
+			if (rows.length === 0) return;
+			recordLifecycleEvent({
+				organizationId: orgId,
+				entityType: "agent",
+				op: "updated",
+				entityId: agentId,
+				summary: `Agent "${rows[0].name ?? agentId}" updated`,
+			});
 		},
 		async deleteMetadata(agentId) {
 			const sql = getDb();

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -342,19 +342,14 @@ export async function applyCreate(
   }
   const sql = createDbClientFromEnv(env);
   const ownerUserId = ctx.userId;
-  // Fresh-agent provisioning defaults, resolved from the SAME helper the boot
-  // provisioning paths use. `models` is baked in ONLY when the caller did not
-  // pin an explicit `default_model` — an explicit choice always wins and is
-  // persisted below by the non-column field loop.
-  //
-  // Without this the row landed with `models = NULL`, and on a deployment whose
-  // only model credential is an environment API key there is no
-  // `inference_providers` is_default row to fall back to. The agent then
-  // resolved NO model, never completed a turn, and its Behavior failed with
-  // "Agent reply finished without calling completeWindow" — while an older
-  // agent from `ensureDefaultAgent` (which bakes the list) ran the same
-  // Behavior fine. That divergence was the bug.
-  const provisioning = await resolveNewAgentProvisioningDefaults();
+  // Fresh-agent provisioning defaults, from the SAME helper every other create
+  // path uses (see `resolveNewAgentProvisioningDefaults` for the full rationale
+  // and the org-default ordering). Seeded ONLY when the caller did not pin an
+  // explicit `default_model` — that outranks both and is persisted below by the
+  // non-column field loop.
+  const provisioning = await resolveNewAgentProvisioningDefaults(
+    ctx.organizationId
+  );
   const explicitModel = argValue(args, 'default_model');
   const seedModels =
     explicitModel !== undefined && explicitModel.trim()

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -39,6 +39,7 @@ import {
   resolveWritePolicyDecision,
   type ActingPrincipal,
 } from '../../authz/entity-policy';
+import { resolveNewAgentProvisioningDefaults } from '../../auth/system-provider-resolution';
 import { createDbClientFromEnv, getDb } from '../../db/client';
 import type { Env } from '../../index';
 import {
@@ -341,6 +342,24 @@ export async function applyCreate(
   }
   const sql = createDbClientFromEnv(env);
   const ownerUserId = ctx.userId;
+  // Fresh-agent provisioning defaults, resolved from the SAME helper the boot
+  // provisioning paths use. `models` is baked in ONLY when the caller did not
+  // pin an explicit `default_model` — an explicit choice always wins and is
+  // persisted below by the non-column field loop.
+  //
+  // Without this the row landed with `models = NULL`, and on a deployment whose
+  // only model credential is an environment API key there is no
+  // `inference_providers` is_default row to fall back to. The agent then
+  // resolved NO model, never completed a turn, and its Behavior failed with
+  // "Agent reply finished without calling completeWindow" — while an older
+  // agent from `ensureDefaultAgent` (which bakes the list) ran the same
+  // Behavior fine. That divergence was the bug.
+  const provisioning = await resolveNewAgentProvisioningDefaults();
+  const explicitModel = argValue(args, 'default_model');
+  const seedModels =
+    explicitModel !== undefined && explicitModel.trim()
+      ? null
+      : provisioning.models;
   // Mirror the provisioning pattern (ensureDefaultAgent / ensureBuilderAgent):
   // owner_platform='external' on the row AND an agent_users mapping, so the
   // per-user ownership check (SPA cookie / PAT session) can reach the new agent.
@@ -350,11 +369,15 @@ export async function applyCreate(
   const rows = await sql`
     INSERT INTO agents (
       id, organization_id, name, description, identity_md,
-      owner_platform, owner_user_id, created_at, updated_at
+      owner_platform, owner_user_id, models, pre_approved_tools,
+      created_at, updated_at
     )
     VALUES (
       ${args.agent_id}, ${ctx.organizationId}, ${args.name}, ${args.description ?? null},
-      ${args.identity_md ?? ''}, 'external', ${ownerUserId}, NOW(), NOW()
+      ${args.identity_md ?? ''}, 'external', ${ownerUserId},
+      ${seedModels === null ? null : sql.json(seedModels)},
+      ${sql.json(provisioning.preApprovedTools)},
+      NOW(), NOW()
     )
     ON CONFLICT (organization_id, id) DO NOTHING
     RETURNING id


### PR DESCRIPTION
## Problem

A brand-new agent could be created successfully, have a Behavior attached, and then fail every run with:

> Agent reply finished without calling completeWindow…

The same Behavior succeeded on an older agent.

Root cause: **six agent-create paths had diverged into two classes.**

`ensureDefaultAgent` (`auth/default-provisioning.ts:268`) resolved `resolveSystemKeyProvidersAndModel()` and baked a concrete `models` list into the row. That resolver reads **environment API keys** (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, providers.json, module registry).

`manage_agents` create, the web `POST /agents` route, and the shared `saveMetadata` UPSERT (reached by the live `/api/v1/agents` route, mounted at `gateway.ts:601`) did **not**. They set `models` only when an explicit `default_model` was passed.

The runtime fallback is `agent.models[0] → org default → not_runnable`, and the org default reads an `inference_providers` **row** — which environment keys never create. So on an env-key-only deployment, agents from the first class ran and agents from the second resolved no model at all, never completed a turn, and never called `completeWindow`.

`pre_approved_tools` had the same split: without `/mcp/lobu-memory/tools/*`, `completeWindow` needs an interactive approval no watcher run can satisfy.

An existing test (`manage-agents-e2e.test.ts:744`) **codified the bug as intended** — it only passed because that suite runs with no env key set.

## Fix

One shared helper, `resolveNewAgentProvisioningDefaults(organizationId)`, called by every create path. Seeds in the run path's own order of authority:

| org state | seeded `models` | resolves via |
|---|---|---|
| has `is_default` row | `[]` | `org_default` |
| no default (env keys only) | system-key list | `agent` |
| explicit `default_model` | caller's pin | `agent` |

Baking at create rather than changing the runtime fallback is deliberate: `models` is an exact **allow-list** enforced by `enforceModelAllowList` which fails closed, and `models = []` already means "allow-all". Synthesizing models at run time would silently widen every model-less agent's allow-list — a policy change wearing a bug fix's clothes.

`models`/`pre_approved_tools` are deliberately **absent from the `DO UPDATE SET` clause** in the shared UPSERT: INSERT seeds them, CONFLICT leaves them alone, so a re-save can't clobber a curated allow-list. `updateMetadata` is now a direct UPDATE so a rename never triggers provider discovery.

## Testing

All verified red before green:

- env-key-only org → new agent is runnable (was `not_runnable: true`)
- `pre_approved_tools` seeded (was `[]`)
- **org default is inherited, never shadowed** (was `source: 'agent'`, should be `'org_default'`) — this one caught a regression the first version of the fix introduced
- re-save does not clobber curated `models`/pre-approvals
- **structural guard**: enumerates every `INSERT INTO agents` outside tests and fails on an unsanctioned site. Proven to fail against an injected rogue path — six paths diverged once and would again.

`make pre-pr` clean. `make review`: 0 bugs, 0 blockers, bug_free 92, tests_adequate true.

## Note

This fixes **newly created** agents. Agents already persisted with `models IS NULL` and no org default stay broken; repair is `manage_agents update` with a `default_model`, or a backfill — deliberately not included here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->