### PR TITLE
feat(approvals): expire undecided approvals and add scoped bulk decisions

### DIFF
--- a/db/migrations/20260726120000_runs_approval_status_expired.sql
+++ b/db/migrations/20260726120000_runs_approval_status_expired.sql
@@ -29,18 +29,15 @@
 --   3. DROP the old constraint and rename the replacement into its place — both
 --      catalog-only, so each lock is momentary.
 --
--- The earlier draft used a single transaction reasoning that the column must
--- never be momentarily unconstrained. That instinct is right but the tradeoff
--- was wrong, and the temp-name ordering satisfies it anyway: between steps 1 and
--- 3 the column is guarded by BOTH the old constraint and the new one, never by
--- neither. Two overlapping constraints for a few seconds is strictly safer than
--- a production stall. The widened predicate accepts every value the old one did,
--- so VALIDATE cannot fail on existing rows.
--- Step 1 is wrapped in a guard because `ADD CONSTRAINT` has no `IF NOT EXISTS`.
--- Under transaction:false each statement commits on its own, so a crash between
--- steps leaves the temp constraint behind; a bare ADD would then fail on every
--- retry with "already exists" and the migration could never record as applied.
--- Same hazard the companion index migration heals for its INVALID carcass.
+-- The column is never left unconstrained: between steps 1 and 3 BOTH the old
+-- constraint and the new one guard it. The widened predicate accepts every value
+-- the old one did, so VALIDATE cannot fail on existing rows.
+--
+-- RETRY SAFETY. Each step is guarded because ADD/RENAME CONSTRAINT have no
+-- `IF NOT EXISTS`, and under transaction:false every statement commits on its
+-- own. Without the guards a crash mid-sequence would leave the temp constraint
+-- behind and fail every retry with "already exists", so the migration could
+-- never record as applied. Re-running the section from any point converges.
 DO $add_new$
 BEGIN
   IF NOT EXISTS (

--- a/db/migrations/20260726120000_runs_approval_status_expired.sql
+++ b/db/migrations/20260726120000_runs_approval_status_expired.sql
@@ -1,0 +1,59 @@
+-- migrate:up
+
+-- Add 'expired' to the runs.approval_status vocabulary.
+--
+-- A run parked at approval_status='pending' is deliberately exempt from the
+-- short-horizon claim reaper (scheduled/stale-run-sweeper.ts, #2044): no worker
+-- will ever claim it, so force-timing it out before a human can decide is wrong.
+-- That exemption was never paired with a LONG-horizon expiry, so undecided
+-- approvals accumulate forever.
+--
+-- 'expired' is its own value rather than a reuse of 'rejected' because the two
+-- mean different things downstream: 'rejected' is a HUMAN decision — it is what
+-- the batch-reject path mines into a `correction` event the Behavior learns from
+-- on its next turn — while 'expired' is the system giving up on an undecided
+-- run. A reviewer who never looked at a proposal did not reject it, and an agent
+-- must not train on silence as if it were disapproval.
+--
+-- Swap the CHECK inside one transaction so there is never a window where
+-- approval_status is unconstrained. NOT VALID + VALIDATE keeps the existing-row
+-- scan off the ACCESS EXCLUSIVE lock (the widened predicate accepts every value
+-- the old one did, so validation cannot fail).
+ALTER TABLE public.runs
+  DROP CONSTRAINT IF EXISTS runs_approval_status_check;
+
+ALTER TABLE public.runs
+  ADD CONSTRAINT runs_approval_status_check
+  CHECK (approval_status = ANY (ARRAY[
+    'pending'::text,
+    'approved'::text,
+    'rejected'::text,
+    'expired'::text,
+    'auto'::text
+  ]))
+  NOT VALID;
+
+ALTER TABLE public.runs
+  VALIDATE CONSTRAINT runs_approval_status_check;
+
+-- migrate:down
+
+-- Fold any expired rows back into 'rejected' so the narrower constraint can be
+-- re-applied without failing on live data.
+UPDATE public.runs SET approval_status = 'rejected' WHERE approval_status = 'expired';
+
+ALTER TABLE public.runs
+  DROP CONSTRAINT IF EXISTS runs_approval_status_check;
+
+ALTER TABLE public.runs
+  ADD CONSTRAINT runs_approval_status_check
+  CHECK (approval_status = ANY (ARRAY[
+    'pending'::text,
+    'approved'::text,
+    'rejected'::text,
+    'auto'::text
+  ]))
+  NOT VALID;
+
+ALTER TABLE public.runs
+  VALIDATE CONSTRAINT runs_approval_status_check;

--- a/db/migrations/20260726120000_runs_approval_status_expired.sql
+++ b/db/migrations/20260726120000_runs_approval_status_expired.sql
@@ -1,4 +1,4 @@
--- migrate:up
+-- migrate:up transaction:false
 
 -- Add 'expired' to the runs.approval_status vocabulary.
 --
@@ -15,45 +15,146 @@
 -- run. A reviewer who never looked at a proposal did not reject it, and an agent
 -- must not train on silence as if it were disapproval.
 --
--- Swap the CHECK inside one transaction so there is never a window where
--- approval_status is unconstrained. NOT VALID + VALIDATE keeps the existing-row
--- scan off the ACCESS EXCLUSIVE lock (the widened predicate accepts every value
--- the old one did, so validation cannot fail).
+-- LOCK SAFETY. `runs` is one of the hottest tables in the system, so the swap is
+-- deliberately NOT one transaction. DROP CONSTRAINT and ADD CONSTRAINT both take
+-- ACCESS EXCLUSIVE, and Postgres holds that lock until COMMIT — so bundling the
+-- VALIDATE into the same transaction would run its full-table scan *under*
+-- ACCESS EXCLUSIVE and stall all `runs` traffic for the length of the scan.
+-- Instead (transaction:false runs each statement standalone; see
+-- packages/server/src/db/migration-loader.ts):
+--   1. ADD the widened CHECK under a TEMPORARY name as NOT VALID — a brief
+--      ACCESS EXCLUSIVE that takes no scan, then commits.
+--   2. VALIDATE it on its own — takes only SHARE UPDATE EXCLUSIVE, so concurrent
+--      reads and writes keep running while the scan proceeds.
+--   3. DROP the old constraint and rename the replacement into its place — both
+--      catalog-only, so each lock is momentary.
+--
+-- The earlier draft used a single transaction reasoning that the column must
+-- never be momentarily unconstrained. That instinct is right but the tradeoff
+-- was wrong, and the temp-name ordering satisfies it anyway: between steps 1 and
+-- 3 the column is guarded by BOTH the old constraint and the new one, never by
+-- neither. Two overlapping constraints for a few seconds is strictly safer than
+-- a production stall. The widened predicate accepts every value the old one did,
+-- so VALIDATE cannot fail on existing rows.
+-- Step 1 is wrapped in a guard because `ADD CONSTRAINT` has no `IF NOT EXISTS`.
+-- Under transaction:false each statement commits on its own, so a crash between
+-- steps leaves the temp constraint behind; a bare ADD would then fail on every
+-- retry with "already exists" and the migration could never record as applied.
+-- Same hazard the companion index migration heals for its INVALID carcass.
+DO $add_new$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.runs'::regclass
+      AND conname = 'runs_approval_status_check_new'
+  ) THEN
+    EXECUTE $ddl$
+      ALTER TABLE public.runs
+        ADD CONSTRAINT runs_approval_status_check_new
+        CHECK (approval_status = ANY (ARRAY[
+          'pending'::text,
+          'approved'::text,
+          'rejected'::text,
+          'expired'::text,
+          'auto'::text
+        ]))
+        NOT VALID
+    $ddl$;
+  END IF;
+END
+$add_new$;
+
+-- Step 2: validate on its own so the scan runs under SHARE UPDATE EXCLUSIVE.
+-- Guarded so the statement is a no-op once the constraint is already validated
+-- (or already renamed away by a completed earlier attempt), which keeps the
+-- whole section convergent on retry from any crash point.
+DO $validate_new$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.runs'::regclass
+      AND conname = 'runs_approval_status_check_new'
+      AND NOT convalidated
+  ) THEN
+    ALTER TABLE public.runs
+      VALIDATE CONSTRAINT runs_approval_status_check_new;
+  END IF;
+END
+$validate_new$;
+
 ALTER TABLE public.runs
   DROP CONSTRAINT IF EXISTS runs_approval_status_check;
 
-ALTER TABLE public.runs
-  ADD CONSTRAINT runs_approval_status_check
-  CHECK (approval_status = ANY (ARRAY[
-    'pending'::text,
-    'approved'::text,
-    'rejected'::text,
-    'expired'::text,
-    'auto'::text
-  ]))
-  NOT VALID;
+-- Guarded for the same retry reason: after a completed run the temp name is
+-- gone, so a bare RENAME would fail on re-execution.
+DO $rename_new$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.runs'::regclass
+      AND conname = 'runs_approval_status_check_new'
+  ) THEN
+    ALTER TABLE public.runs
+      RENAME CONSTRAINT runs_approval_status_check_new TO runs_approval_status_check;
+  END IF;
+END
+$rename_new$;
 
-ALTER TABLE public.runs
-  VALIDATE CONSTRAINT runs_approval_status_check;
+-- migrate:down transaction:false
 
--- migrate:down
-
--- Fold any expired rows back into 'rejected' so the narrower constraint can be
--- re-applied without failing on live data.
+-- Fold any expired rows back into 'rejected' FIRST: the narrower constraint
+-- cannot validate while 'expired' rows exist.
 UPDATE public.runs SET approval_status = 'rejected' WHERE approval_status = 'expired';
 
+-- Same never-unconstrained, never-stalling, retry-safe ordering as the up path.
+DO $add_old$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.runs'::regclass
+      AND conname = 'runs_approval_status_check_old'
+  ) THEN
+    EXECUTE $ddl$
+      ALTER TABLE public.runs
+        ADD CONSTRAINT runs_approval_status_check_old
+        CHECK (approval_status = ANY (ARRAY[
+          'pending'::text,
+          'approved'::text,
+          'rejected'::text,
+          'auto'::text
+        ]))
+        NOT VALID
+    $ddl$;
+  END IF;
+END
+$add_old$;
+
+DO $validate_old$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.runs'::regclass
+      AND conname = 'runs_approval_status_check_old'
+      AND NOT convalidated
+  ) THEN
+    ALTER TABLE public.runs
+      VALIDATE CONSTRAINT runs_approval_status_check_old;
+  END IF;
+END
+$validate_old$;
+
 ALTER TABLE public.runs
   DROP CONSTRAINT IF EXISTS runs_approval_status_check;
 
-ALTER TABLE public.runs
-  ADD CONSTRAINT runs_approval_status_check
-  CHECK (approval_status = ANY (ARRAY[
-    'pending'::text,
-    'approved'::text,
-    'rejected'::text,
-    'auto'::text
-  ]))
-  NOT VALID;
-
-ALTER TABLE public.runs
-  VALIDATE CONSTRAINT runs_approval_status_check;
+DO $rename_old$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.runs'::regclass
+      AND conname = 'runs_approval_status_check_old'
+  ) THEN
+    ALTER TABLE public.runs
+      RENAME CONSTRAINT runs_approval_status_check_old TO runs_approval_status_check;
+  END IF;
+END
+$rename_old$;

--- a/db/migrations/20260726120010_runs_pending_approval_age_index.sql
+++ b/db/migrations/20260726120010_runs_pending_approval_age_index.sql
@@ -1,0 +1,38 @@
+-- migrate:up transaction:false
+
+-- Age index for the pending-approval expiry sweeper + the stale-pending health
+-- metric. Both scan `runs` for approval_status='pending' ordered/filtered by
+-- created_at across every org; without this the tick is a seq-scan of the whole
+-- runs table. Partial on the pending predicate so the index stays tiny (pending
+-- approvals are a handful of rows next to the full run history).
+--
+-- The INVALID-carcass heal is inlined (not a companion migration) so it re-runs
+-- on every retry: if a CONCURRENTLY build crashes it leaves a same-named INVALID
+-- index, and `IF NOT EXISTS` would silently no-op over it and record this
+-- migration as applied with a non-enforcing carcass in place. The runners split
+-- transaction:false sections statement-at-a-time (prod: scripts/migrate-up.mjs;
+-- embedded/tests: packages/server/src/db/migration-loader.ts), so the heal DO
+-- and the CONCURRENTLY build each run unwrapped.
+DO $heal$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'idx_runs_pending_approval_created_at'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.idx_runs_pending_approval_created_at';
+  END IF;
+END
+$heal$;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runs_pending_approval_created_at
+  ON public.runs (created_at)
+  WHERE approval_status = 'pending';
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_runs_pending_approval_created_at;

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -665,7 +665,16 @@ export interface Feed {
 
 export type RunType = 'sync' | 'action' | 'code' | 'behavior' | 'auth';
 export type RunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'timeout';
-export type ApprovalStatus = 'pending' | 'approved' | 'rejected' | 'auto';
+// 'expired' is the system giving up on an undecided approval after the TTL
+// (scheduled/expire-pending-approvals.ts). It is deliberately distinct from
+// 'rejected', which is a HUMAN decision the Behavior learns from — an agent
+// must not train on silence as if it were disapproval.
+export type ApprovalStatus =
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'expired'
+  | 'auto';
 
 export interface Run {
   id: number;

--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -223,12 +223,62 @@ export const RejectAction = Type.Object({
   reason: Type.Optional(Type.String()),
 });
 
+/**
+ * Explicit scope for a batch decision over queued connector-operation approvals
+ * (`run_type='action'`), the lane that accumulates when nobody decides.
+ *
+ * At least one narrowing filter is REQUIRED — there is deliberately no
+ * "decide everything pending" shape. Batch APPROVE executes queued side effects
+ * en masse, so the caller must name what they are approving; an unscoped sweep
+ * would let one click fire every queued write in the org.
+ */
+export const ApprovalBatchScope = Type.Object(
+  {
+    connection_id: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description: "Only approvals queued against this connection.",
+      })
+    ),
+    connector_key: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Only approvals for this connector (e.g. 'github').",
+      })
+    ),
+    action_key: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Only approvals for this operation key.",
+      })
+    ),
+    behavior_id: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description: "Only approvals queued by this Behavior.",
+      })
+    ),
+    older_than_days: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description:
+          "Only approvals queued more than this many days ago. Narrows further; never widens.",
+      })
+    ),
+  },
+  {
+    description:
+      "Scope filters for a connector-approval batch. At least one of connection_id / connector_key / action_key / behavior_id is required.",
+  }
+);
+
 export const ApproveBatchAction = Type.Object({
   action: Type.Literal("approve_batch", {
     description:
-      "Approve every pending proposal a Behavior run produced, in one go. Groups by the run's window.",
+      "Approve many pending approvals at once. Either scope by window_id (a Behavior run's proposals) or by `scope` (queued connector operations). Exactly one of the two is required — there is no unscoped approve-everything.",
   }),
-  window_id: Type.Number(),
+  window_id: Type.Optional(Type.Number()),
+  scope: Type.Optional(ApprovalBatchScope),
   run_ids: Type.Optional(
     Type.Array(Type.Integer({ minimum: 1 }), {
       minItems: 1,
@@ -243,9 +293,10 @@ export const ApproveBatchAction = Type.Object({
 export const RejectBatchAction = Type.Object({
   action: Type.Literal("reject_batch", {
     description:
-      "Reject every pending proposal a Behavior run produced. The reason is fed back to the agent so it can revise its proposals (the conversational revision loop).",
+      "Reject many pending approvals at once. Either scope by window_id (a Behavior run's proposals — the reason is fed back so the agent revises) or by `scope` (queued connector operations). Exactly one of the two is required.",
   }),
-  window_id: Type.Number(),
+  window_id: Type.Optional(Type.Number()),
+  scope: Type.Optional(ApprovalBatchScope),
   run_ids: Type.Optional(
     Type.Array(Type.Integer({ minimum: 1 }), {
       minItems: 1,
@@ -358,7 +409,8 @@ export const ManageOperationsResultSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("approve_batch"),
-    window_id: Type.Integer(),
+    /** Present when the batch was scoped by window (Behavior proposals). */
+    window_id: Type.Optional(Type.Integer()),
     approved_count: Type.Integer(),
     failed_count: Type.Integer(),
     run_ids: Type.Array(Type.Integer()),
@@ -366,7 +418,8 @@ export const ManageOperationsResultSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("reject_batch"),
-    window_id: Type.Integer(),
+    /** Present when the batch was scoped by window (Behavior proposals). */
+    window_id: Type.Optional(Type.Integer()),
     rejected_count: Type.Integer(),
     run_ids: Type.Array(Type.Integer()),
     message: Type.String(),

--- a/packages/server/src/__tests__/integration/operations-approval-batch-scope.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-batch-scope.test.ts
@@ -19,11 +19,21 @@ import { manageOperations } from "../../tools/admin/manage_operations";
 import type { ToolContext } from "../../tools/registry";
 import { initWorkspaceProvider } from "../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
-import { seedOwnerContext } from "../setup/test-fixtures";
+import {
+	addUserToOrganization,
+	createTestConnection,
+	createTestConnectorDefinition,
+	createTestUser,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
+
+const APPROVAL_CONNECTOR = "demo.batch.approval";
 
 describe("manage_operations batch scope (connector-approval lane)", () => {
 	let orgId: string;
 	let ownerCtx: ToolContext;
+	let memberCtx: ToolContext;
+	let approvalConnectionId: number;
 
 	beforeAll(async () => {
 		await cleanupTestDatabase();
@@ -33,6 +43,39 @@ describe("manage_operations batch scope (connector-approval lane)", () => {
 		});
 		orgId = org.id;
 		ownerCtx = ctx;
+		const member = await createTestUser({ name: "Batch Scope Member" });
+		await addUserToOrganization(member.id, org.id);
+		memberCtx = {
+			...ctx,
+			userId: member.id,
+			memberRole: "member",
+			scopes: ["mcp:read", "mcp:write"],
+		};
+
+		await createTestConnectorDefinition({
+			key: APPROVAL_CONNECTOR,
+			name: "Batch approval connector",
+			organization_id: org.id,
+		});
+		const sql = getTestDb();
+		await sql`
+      UPDATE connector_definitions
+      SET actions_schema = ${sql.json({
+				needs_approval: {
+					name: "Needs approval",
+					kind: "write",
+					requiresApproval: true,
+				},
+			})}
+      WHERE organization_id = ${org.id}
+        AND key = ${APPROVAL_CONNECTOR}
+    `;
+		const connection = await createTestConnection({
+			organization_id: org.id,
+			connector_key: APPROVAL_CONNECTOR,
+			created_by: ctx.userId ?? undefined,
+		});
+		approvalConnectionId = connection.id;
 	});
 
 	beforeEach(async () => {
@@ -45,15 +88,21 @@ describe("manage_operations batch scope (connector-approval lane)", () => {
 		connectorKey: string;
 		actionKey: string;
 		ageDays?: number;
+		behaviorId?: number;
+		connectionId?: number;
 	}): Promise<number> {
 		const sql = getTestDb();
 		const rows = await sql`
       INSERT INTO runs (
         organization_id, run_type, status, approval_status,
-        connector_key, action_key, created_at
+        connection_id, connector_key, action_key, policy_principal_kind,
+        policy_principal_id, created_at
       ) VALUES (
         ${orgId}, 'action', 'pending', 'pending',
+        ${opts.connectionId ?? null},
         ${opts.connectorKey}, ${opts.actionKey},
+        ${opts.behaviorId === undefined ? null : "watcher"},
+        ${opts.behaviorId === undefined ? null : `watcher:${opts.behaviorId}`},
         NOW() - (${opts.ageDays ?? 0}::int * interval '1 day')
       )
       RETURNING id
@@ -118,6 +167,64 @@ describe("manage_operations batch scope (connector-approval lane)", () => {
 			{
 				action: "reject_batch",
 				scope: { connector_key: "github", action_key: "create_issue" },
+			},
+			{} as Env,
+			ownerCtx,
+		)) as { rejected_count: number };
+
+		expect(result.rejected_count).toBe(1);
+		expect(await approvalStatusOf(target)).toBe("rejected");
+		expect(await approvalStatusOf(sibling)).toBe("pending");
+	});
+
+	it("approve_batch applies only the connector operations selected by scope", async () => {
+		const target = await seedPendingAction({
+			connectionId: approvalConnectionId,
+			connectorKey: APPROVAL_CONNECTOR,
+			actionKey: "needs_approval",
+		});
+		const sibling = await seedPendingAction({
+			connectorKey: APPROVAL_CONNECTOR,
+			actionKey: "needs_approval",
+		});
+
+		const result = (await manageOperations(
+			{
+				action: "approve_batch",
+				scope: { connection_id: approvalConnectionId },
+				run_ids: [target],
+			},
+			{} as Env,
+			ownerCtx,
+		)) as {
+			approved_count: number;
+			failed_count: number;
+			run_ids: number[];
+		};
+
+		expect(result.approved_count).toBe(1);
+		expect(result.failed_count).toBe(0);
+		expect(result.run_ids).toEqual([target]);
+		expect(await approvalStatusOf(target)).toBe("approved");
+		expect(await approvalStatusOf(sibling)).toBe("pending");
+	});
+
+	it("behavior_id matches the trusted watcher principal stored on action runs", async () => {
+		const target = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+			behaviorId: 41,
+		});
+		const sibling = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+			behaviorId: 42,
+		});
+
+		const result = (await manageOperations(
+			{
+				action: "reject_batch",
+				scope: { behavior_id: 41 },
 			},
 			{} as Env,
 			ownerCtx,
@@ -274,6 +381,54 @@ describe("manage_operations batch scope (connector-approval lane)", () => {
 
 		expect(result.error).toContain("signed-in user");
 		expect(await approvalStatusOf(pending)).toBe("pending");
+	});
+
+	it("preflights every run's authority before mutating a window batch", async () => {
+		const sql = getTestDb();
+		const rows = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status,
+        action_key, action_input, window_id
+      ) VALUES
+        (
+          ${orgId}, 'internal', 'pending', 'pending',
+          'entity_field_change',
+          ${sql.json({
+						entity_id: 1,
+						fields: { priority: "high" },
+						owner_user_id: memberCtx.userId,
+					})},
+          91
+        ),
+        (
+          ${orgId}, 'internal', 'pending', 'pending',
+          'entity_field_change',
+          ${sql.json({
+						entity_id: 2,
+						fields: { priority: "high" },
+						owner_user_id: "another-user",
+					})},
+          91
+        )
+      RETURNING id
+    `;
+		const runIds = rows.map((row) => Number(row.id));
+
+		await expect(
+			manageOperations(
+				{
+					action: "reject_batch",
+					window_id: 91,
+					run_ids: runIds,
+				},
+				{} as Env,
+				memberCtx,
+			),
+		).rejects.toThrow("requires admin or owner access");
+
+		for (const runId of runIds) {
+			expect(await approvalStatusOf(runId)).toBe("pending");
+		}
 	});
 
 	it("never crosses the org boundary", async () => {

--- a/packages/server/src/__tests__/integration/operations-approval-batch-scope.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-batch-scope.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Scoped bulk approve/reject over queued connector-operation approvals.
+ *
+ * `approve_batch` / `reject_batch` already existed but were reachable ONLY via
+ * `window_id` — i.e. only for the Behavior-proposal lane (`run_type='internal'`).
+ * The lane that actually accumulates undecided rows, queued connector operations
+ * (`run_type='action'`), had no bulk action at all: an operator had to decide
+ * them one at a time or leave them pending forever.
+ *
+ * These tests pin the added `scope` target and — more importantly — the guards
+ * that keep it safe. Batch APPROVE fires real side effects en masse, so the
+ * contract is: it acts on the scoped set ONLY, it refuses to run unscoped, and
+ * it inherits the exact same authz as deciding one run.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import type { ToolContext } from "../../tools/registry";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import { seedOwnerContext } from "../setup/test-fixtures";
+
+describe("manage_operations batch scope (connector-approval lane)", () => {
+	let orgId: string;
+	let ownerCtx: ToolContext;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, ctx } = await seedOwnerContext({
+			orgName: "Batch Scope Org",
+		});
+		orgId = org.id;
+		ownerCtx = ctx;
+	});
+
+	beforeEach(async () => {
+		const sql = getTestDb();
+		await sql`DELETE FROM runs WHERE organization_id = ${orgId}`;
+	});
+
+	/** Seed a pending connector-operation approval with the given shape. */
+	async function seedPendingAction(opts: {
+		connectorKey: string;
+		actionKey: string;
+		ageDays?: number;
+	}): Promise<number> {
+		const sql = getTestDb();
+		const rows = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status,
+        connector_key, action_key, created_at
+      ) VALUES (
+        ${orgId}, 'action', 'pending', 'pending',
+        ${opts.connectorKey}, ${opts.actionKey},
+        NOW() - (${opts.ageDays ?? 0}::int * interval '1 day')
+      )
+      RETURNING id
+    `;
+		return Number(rows[0].id);
+	}
+
+	async function approvalStatusOf(runId: number): Promise<string> {
+		const sql = getTestDb();
+		const rows = await sql`
+      SELECT approval_status FROM runs WHERE id = ${runId}
+    `;
+		return String(rows[0]?.approval_status ?? "missing");
+	}
+
+	it("reject_batch acts on the scoped set ONLY and leaves out-of-scope rows pending", async () => {
+		const inScopeA = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+		});
+		const inScopeB = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "close_issue",
+		});
+		// Same org, DIFFERENT connector — must survive a github-scoped batch.
+		const otherConnector = await seedPendingAction({
+			connectorKey: "linear",
+			actionKey: "create_issue",
+		});
+
+		const result = (await manageOperations(
+			{
+				action: "reject_batch",
+				scope: { connector_key: "github" },
+				reason: "stale queue",
+			},
+			{} as Env,
+			ownerCtx,
+		)) as { action: string; rejected_count: number; run_ids: number[] };
+
+		expect(result.action).toBe("reject_batch");
+		expect(result.rejected_count).toBe(2);
+		expect(result.run_ids.sort()).toEqual([inScopeA, inScopeB].sort());
+
+		expect(await approvalStatusOf(inScopeA)).toBe("rejected");
+		expect(await approvalStatusOf(inScopeB)).toBe("rejected");
+		// The out-of-scope row is untouched — this is the whole safety property.
+		expect(await approvalStatusOf(otherConnector)).toBe("pending");
+	});
+
+	it("action_key narrows within a connector", async () => {
+		const target = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+		});
+		const sibling = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "close_issue",
+		});
+
+		const result = (await manageOperations(
+			{
+				action: "reject_batch",
+				scope: { connector_key: "github", action_key: "create_issue" },
+			},
+			{} as Env,
+			ownerCtx,
+		)) as { rejected_count: number };
+
+		expect(result.rejected_count).toBe(1);
+		expect(await approvalStatusOf(target)).toBe("rejected");
+		expect(await approvalStatusOf(sibling)).toBe("pending");
+	});
+
+	it("older_than_days narrows further and never widens", async () => {
+		const old = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+			ageDays: 30,
+		});
+		const recent = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+			ageDays: 1,
+		});
+
+		const result = (await manageOperations(
+			{
+				action: "reject_batch",
+				scope: { connector_key: "github", older_than_days: 14 },
+			},
+			{} as Env,
+			ownerCtx,
+		)) as { rejected_count: number };
+
+		expect(result.rejected_count).toBe(1);
+		expect(await approvalStatusOf(old)).toBe("rejected");
+		expect(await approvalStatusOf(recent)).toBe("pending");
+	});
+
+	it("refuses an UNSCOPED batch — there is no approve-everything", async () => {
+		const pending = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+		});
+
+		// No narrowing filter at all: an empty scope object must be rejected, not
+		// silently interpreted as "every pending approval in the organization".
+		for (const action of ["approve_batch", "reject_batch"] as const) {
+			const result = (await manageOperations(
+				{ action, scope: {} },
+				{} as Env,
+				ownerCtx,
+			)) as { error?: string };
+			expect(result.error).toContain("must be scoped");
+		}
+
+		// Omitting the target entirely is refused too.
+		for (const action of ["approve_batch", "reject_batch"] as const) {
+			const result = (await manageOperations(
+				{ action },
+				{} as Env,
+				ownerCtx,
+			)) as { error?: string };
+			expect(result.error).toContain("requires a target");
+		}
+
+		expect(await approvalStatusOf(pending)).toBe("pending");
+	});
+
+	it("refuses an ambiguous batch carrying BOTH window_id and scope", async () => {
+		const pending = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+		});
+
+		const result = (await manageOperations(
+			{
+				action: "reject_batch",
+				window_id: 1,
+				scope: { connector_key: "github" },
+			},
+			{} as Env,
+			ownerCtx,
+		)) as { error?: string };
+
+		expect(result.error).toContain("not both");
+		expect(await approvalStatusOf(pending)).toBe("pending");
+	});
+
+	it("fails closed when the pending set moved under the reviewer", async () => {
+		const shown = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+		});
+		// A second approval arrived after the reviewer loaded the page.
+		await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+		});
+
+		const result = (await manageOperations(
+			{
+				action: "reject_batch",
+				scope: { connector_key: "github" },
+				run_ids: [shown],
+			},
+			{} as Env,
+			ownerCtx,
+		)) as { error?: string };
+
+		expect(result.error).toContain("changed after this batch was loaded");
+		expect(await approvalStatusOf(shown)).toBe("pending");
+	});
+
+	it("rejects an unauthorized caller — no agent may bulk-decide", async () => {
+		const pending = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+		});
+
+		// An agent identity on the context is the exact case
+		// requireHumanApprovalContext exists to stop: an automation must never be
+		// able to approve (let alone bulk-approve) work it queued.
+		const agentCtx = {
+			...ownerCtx,
+			agentId: "agent-1",
+		} as ToolContext;
+
+		for (const action of ["approve_batch", "reject_batch"] as const) {
+			const result = (await manageOperations(
+				{ action, scope: { connector_key: "github" } },
+				{} as Env,
+				agentCtx,
+			)) as { error?: string };
+			expect(result.error).toContain("human web session");
+		}
+
+		expect(await approvalStatusOf(pending)).toBe("pending");
+	});
+
+	it("rejects a caller with no verified human identity", async () => {
+		const pending = await seedPendingAction({
+			connectorKey: "github",
+			actionKey: "create_issue",
+		});
+
+		const anonCtx = {
+			...ownerCtx,
+			userId: null,
+		} as unknown as ToolContext;
+
+		const result = (await manageOperations(
+			{ action: "reject_batch", scope: { connector_key: "github" } },
+			{} as Env,
+			anonCtx,
+		)) as { error?: string };
+
+		expect(result.error).toContain("signed-in user");
+		expect(await approvalStatusOf(pending)).toBe("pending");
+	});
+
+	it("never crosses the org boundary", async () => {
+		const { org: otherOrg } = await seedOwnerContext({
+			orgName: "Other Batch Org",
+		});
+		const sql = getTestDb();
+		const rows = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status,
+        connector_key, action_key, created_at
+      ) VALUES (
+        ${otherOrg.id}, 'action', 'pending', 'pending',
+        'github', 'create_issue', NOW()
+      )
+      RETURNING id
+    `;
+		const foreignRun = Number(rows[0].id);
+
+		const result = (await manageOperations(
+			{ action: "reject_batch", scope: { connector_key: "github" } },
+			{} as Env,
+			ownerCtx,
+		)) as { rejected_count: number };
+
+		expect(result.rejected_count).toBe(0);
+		expect(await approvalStatusOf(foreignRun)).toBe("pending");
+
+		await sql`DELETE FROM runs WHERE organization_id = ${otherOrg.id}`;
+	});
+});

--- a/packages/server/src/config/intervals.ts
+++ b/packages/server/src/config/intervals.ts
@@ -114,6 +114,19 @@ export const intervals = {
     return parseEnvInt('RUNS_POLL_INTERVAL_MS', 200);
   },
 
+  /** Long-horizon TTL (days) after which a run still sitting at
+   *  `approval_status='pending'` is expired.
+   *
+   *  Deliberately measured in DAYS, not the 120s claim horizon: the
+   *  short-horizon reaper exempts approval-pending rows on purpose (#2044,
+   *  scheduled/stale-run-sweeper.ts) because a human needs real time to decide.
+   *  7 days spans a full work week plus a weekend, so a reviewer on PTO still
+   *  gets a chance; past that the proposal's inputs are stale enough that
+   *  executing it would surprise the operator more than dropping it. */
+  get pendingApprovalTtlDays(): number {
+    return parseEnvInt('PENDING_APPROVAL_TTL_DAYS', 7);
+  },
+
   /** TTL for per-agent SSE backlog entries (pruned lazily on read/write). */
   get sseBacklogTtlMs(): number {
     return parseEnvInt('SSE_BACKLOG_TTL_MS', 2 * 60 * 1000);

--- a/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
+++ b/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
@@ -181,23 +181,12 @@ describe("expirePendingApprovals", () => {
 		expect((await runStateOf(internalId)).approval_status).toBe("expired");
 	});
 
-	test("scheduler health surfaces approvals that remain pending past the TTL", async () => {
-		await seedApproval({
-			approvalStatus: "pending",
-			ageDays: TTL_DAYS + 3,
-		});
-
+	/** Run getSchedulerHealth with the TTL pinned to this suite's value. */
+	async function healthWithPinnedTtl() {
 		const previousTtl = process.env.PENDING_APPROVAL_TTL_DAYS;
 		process.env.PENDING_APPROVAL_TTL_DAYS = String(TTL_DAYS);
 		try {
-			const health = await getSchedulerHealth({} as Env);
-			expect(health.metrics.stalePendingApprovals).toBe(1);
-			expect(health.metrics.oldestPendingApprovalDays).toBeGreaterThan(
-				TTL_DAYS,
-			);
-			expect(
-				health.issues.some((issue) => /approvals undecided past/i.test(issue)),
-			).toBe(true);
+			return await getSchedulerHealth({} as Env);
 		} finally {
 			if (previousTtl === undefined) {
 				delete process.env.PENDING_APPROVAL_TTL_DAYS;
@@ -205,6 +194,44 @@ describe("expirePendingApprovals", () => {
 				process.env.PENDING_APPROVAL_TTL_DAYS = previousTtl;
 			}
 		}
+	}
+
+	// The sweep runs DAILY, so a row that crosses the TTL right after a tick is
+	// stale for up to a day BY DESIGN. Alarming on that would leave
+	// /health/scheduler at 503 during normal operation and train operators to
+	// ignore it. The count is still reported — only the issue is withheld.
+	test("scheduler health reports, but does NOT alarm on, expected between-tick drift", async () => {
+		await seedApproval({
+			approvalStatus: "pending",
+			// Past the TTL but inside the one-day sweep grace.
+			ageDays: TTL_DAYS,
+		});
+
+		const health = await healthWithPinnedTtl();
+
+		// The operator still sees the backlog...
+		expect(health.metrics.stalePendingApprovals).toBe(1);
+		// ...but this is not a fault, so no issue is raised.
+		expect(
+			health.issues.some((issue) => /approvals undecided past/i.test(issue)),
+		).toBe(false);
+	});
+
+	test("scheduler health DOES alarm once a full sweep opportunity was missed", async () => {
+		await seedApproval({
+			approvalStatus: "pending",
+			// Past TTL + the one-day grace: a sweep should have taken this terminal.
+			ageDays: TTL_DAYS + 3,
+		});
+
+		const health = await healthWithPinnedTtl();
+
+		expect(health.metrics.stalePendingApprovals).toBe(1);
+		expect(health.metrics.oldestPendingApprovalDays).toBeGreaterThan(TTL_DAYS);
+		expect(
+			health.issues.some((issue) => /approvals undecided past/i.test(issue)),
+		).toBe(true);
+		expect(health.healthy).toBe(false);
 	});
 
 	test("is idempotent — a second pass expires nothing new", async () => {
@@ -396,24 +423,58 @@ describe("expirePendingApprovals — draining and cross-org fairness", () => {
 		// the ceiling is what stops it). Under the old global oldest-first
 		// selection the hog's older rows would fill that batch entirely and the
 		// small org would get nothing.
+		// A ceiling of 120 makes this a single bounded batch, so the assertion is
+		// about batch COMPOSITION rather than the end state after a full drain.
+		// The hog holds far more than the per-org cap (50), so an unfair selection
+		// would spend the whole batch on it.
+		const batchCeiling = 120;
 		const hogOrg = ORG_ID;
-		const hogRows = 800;
-		await seedManyStale(hogOrg, hogRows, TTL_DAYS + 60);
+		await seedManyStale(hogOrg, 200, TTL_DAYS + 60);
 		await seedOrg("fair-small");
 		await seedManyStale("fair-small", 3, TTL_DAYS + 1);
 
-		// Ceiling of one batch: only the FIRST batch runs, so this asserts on batch
-		// composition rather than on the end state after everything drains.
-		const result = await expirePendingApprovals(TTL_DAYS, 500);
+		const result = await expirePendingApprovals(TTL_DAYS, batchCeiling);
 
-		// The small org is served within that first batch despite every one of its
-		// rows being NEWER than all 800 of the hog's — proof the selection is not
-		// globally oldest-first. The old code would have spent the whole batch on
-		// the hog and left these three untouched.
+		// The small org is served despite every one of its rows being NEWER than
+		// all 200 of the hog's — proof the selection is not globally oldest-first.
 		expect(await expiredCount("fair-small")).toBe(3);
-		expect(result.expired).toBe(500);
-		// The hog is capped well below the batch, leaving room for everyone else.
-		expect(await expiredCount(hogOrg)).toBeLessThan(500);
+		expect(result.expired).toBe(batchCeiling);
+		// The hog cannot take the whole batch: the per-org cap bounds its share,
+		// leaving room for other orgs even though its rows are the oldest.
+		expect(await expiredCount(hogOrg)).toBeLessThan(batchCeiling);
+	});
+
+	test("more backlogged orgs than the batch can cover: a newer org still gets rows in the FIRST batch", async () => {
+		// The per-org cap alone does NOT give fairness. With batch=500 and
+		// per-org=50, ten backlogged orgs fill the batch exactly (10 × 50 = 500).
+		// If the batch is then ordered globally by age, the ten OLDEST orgs consume
+		// it entirely and an eleventh org never appears — and if those ten sustain
+		// their backlog, the eleventh is starved forever. That is the original
+		// starvation bug with the threshold moved from 1 org to 10.
+		//
+		// Selection must interleave by per-org rank (every org's oldest row first,
+		// then every org's second, …) so representation does not depend on how many
+		// other orgs are backlogged.
+		// 14 older orgs × the 50-row per-org cap = 700 rows ranked ahead of the
+		// newcomer under global age ordering — more than the 120-row batch below,
+		// so the newcomer is invisible unless selection interleaves by org.
+		const olderOrgs = Array.from({ length: 14 }, (_, i) => `starve-old-${i}`);
+		for (const org of olderOrgs) {
+			await seedOrg(org);
+			await seedManyStale(org, 12, TTL_DAYS + 90);
+		}
+		// One newer org, guaranteed to lose every global age comparison.
+		await seedOrg("starve-newcomer");
+		await seedManyStale("starve-newcomer", 4, TTL_DAYS + 1);
+
+		// Ceiling of exactly one batch so this asserts on batch COMPOSITION.
+		const batchCeiling = 120;
+		const result = await expirePendingApprovals(TTL_DAYS, batchCeiling);
+		expect(result.expired).toBe(batchCeiling);
+
+		// The newcomer must be represented in that first batch. Under global age
+		// ordering it gets 0: all 14 older orgs rank ahead of it.
+		expect(await expiredCount("starve-newcomer")).toBeGreaterThan(0);
 	});
 
 	test("respects the per-invocation ceiling on a pathological backlog", async () => {

--- a/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
+++ b/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
@@ -11,16 +11,30 @@
  * lane that never holds a human gate — is left completely alone.
  */
 
-import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
 import { getDb } from "../../db/client";
 import {
 	ensureDbForGatewayTests,
 	resetTestDatabase,
 } from "../../gateway/__tests__/helpers/db-setup";
+import type { Env } from "../../index";
 import { expirePendingApprovals } from "../expire-pending-approvals";
+import { getSchedulerHealth } from "../scheduler-health";
 
 const ORG_ID = "approval-expiry-org";
 const TTL_DAYS = 7;
+const DROP_FAIL_TRIGGER = `
+DROP TRIGGER IF EXISTS test_fail_expiry_supersede_trg ON events;
+DROP FUNCTION IF EXISTS test_fail_expiry_supersede();
+`;
+let failTriggerCleanupNeeded = false;
 
 beforeAll(async () => {
 	await ensureDbForGatewayTests();
@@ -33,7 +47,13 @@ beforeEach(async () => {
     INSERT INTO organization (id, name, slug)
     VALUES (${ORG_ID}, ${ORG_ID}, ${ORG_ID})
     ON CONFLICT (id) DO NOTHING
-  `;
+	`;
+});
+
+afterEach(async () => {
+	if (!failTriggerCleanupNeeded) return;
+	await getDb().unsafe(DROP_FAIL_TRIGGER);
+	failTriggerCleanupNeeded = false;
 });
 
 interface SeedApprovalOpts {
@@ -161,6 +181,32 @@ describe("expirePendingApprovals", () => {
 		expect((await runStateOf(internalId)).approval_status).toBe("expired");
 	});
 
+	test("scheduler health surfaces approvals that remain pending past the TTL", async () => {
+		await seedApproval({
+			approvalStatus: "pending",
+			ageDays: TTL_DAYS + 3,
+		});
+
+		const previousTtl = process.env.PENDING_APPROVAL_TTL_DAYS;
+		process.env.PENDING_APPROVAL_TTL_DAYS = String(TTL_DAYS);
+		try {
+			const health = await getSchedulerHealth({} as Env);
+			expect(health.metrics.stalePendingApprovals).toBe(1);
+			expect(health.metrics.oldestPendingApprovalDays).toBeGreaterThan(
+				TTL_DAYS,
+			);
+			expect(
+				health.issues.some((issue) => /approvals undecided past/i.test(issue)),
+			).toBe(true);
+		} finally {
+			if (previousTtl === undefined) {
+				delete process.env.PENDING_APPROVAL_TTL_DAYS;
+			} else {
+				process.env.PENDING_APPROVAL_TTL_DAYS = previousTtl;
+			}
+		}
+	});
+
 	test("is idempotent — a second pass expires nothing new", async () => {
 		await seedApproval({
 			approvalStatus: "pending",
@@ -172,9 +218,50 @@ describe("expirePendingApprovals", () => {
 
 		// The UPDATE re-asserts `approval_status = 'pending'`, so the row it just
 		// took terminal no longer matches. This is the same predicate that makes
-		// two overlapping replicas safe: only one UPDATE can ever match a row.
+		// two overlapping replicas safe: only one expiry can commit for a row.
 		const second = await expirePendingApprovals(TTL_DAYS);
 		expect(second.expired).toBe(0);
+	});
+
+	test("an event supersede failure rolls back that run without blocking the rest", async () => {
+		const staleId = await seedApproval({
+			approvalStatus: "pending",
+			ageDays: TTL_DAYS + 3,
+		});
+		const healthyId = await seedApproval({
+			approvalStatus: "pending",
+			ageDays: TTL_DAYS + 2,
+		});
+		const sql = getDb();
+		await sql`
+      INSERT INTO events (
+        organization_id, origin_id, title, payload_text, run_id,
+        semantic_type, interaction_type, interaction_status
+      ) VALUES (
+        ${ORG_ID}, ${`run_${staleId}_pending`}, 'Pending approval',
+        'Awaiting review', ${staleId}, 'operation', 'approval', 'pending'
+      )
+    `;
+		failTriggerCleanupNeeded = true;
+		await sql.unsafe(`
+      CREATE OR REPLACE FUNCTION test_fail_expiry_supersede()
+        RETURNS trigger AS $fn$
+      BEGIN
+        IF NEW.supersedes_event_id IS NOT NULL THEN
+          RAISE EXCEPTION 'simulated expiry supersede failure';
+        END IF;
+        RETURN NEW;
+      END;
+      $fn$ LANGUAGE plpgsql;
+      CREATE TRIGGER test_fail_expiry_supersede_trg
+        BEFORE INSERT ON events
+        FOR EACH ROW EXECUTE FUNCTION test_fail_expiry_supersede();
+    `);
+
+		const result = await expirePendingApprovals(TTL_DAYS);
+		expect(result.expired).toBe(1);
+		expect((await runStateOf(staleId)).approval_status).toBe("pending");
+		expect((await runStateOf(healthyId)).approval_status).toBe("expired");
 	});
 
 	test("a decision landing between scan and sweep wins over the expiry", async () => {

--- a/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
+++ b/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration test for the long-horizon pending-approval expiry sweep.
+ *
+ * A run parked at `approval_status='pending'` is deliberately exempt from the
+ * SHORT-horizon claim reaper (#2044) so a human gets real time to decide. That
+ * exemption was never paired with a long-horizon expiry, so undecided approvals
+ * accumulated forever. This sweep closes the other end of the timescale.
+ *
+ * The tests pin both directions: a row past the TTL goes terminal at
+ * 'expired', and everything else — inside the TTL, already decided, or in a
+ * lane that never holds a human gate — is left completely alone.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../db/client";
+import {
+	ensureDbForGatewayTests,
+	resetTestDatabase,
+} from "../../gateway/__tests__/helpers/db-setup";
+import { expirePendingApprovals } from "../expire-pending-approvals";
+
+const ORG_ID = "approval-expiry-org";
+const TTL_DAYS = 7;
+
+beforeAll(async () => {
+	await ensureDbForGatewayTests();
+});
+
+beforeEach(async () => {
+	await resetTestDatabase();
+	const sql = getDb();
+	await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG_ID}, ${ORG_ID}, ${ORG_ID})
+    ON CONFLICT (id) DO NOTHING
+  `;
+});
+
+interface SeedApprovalOpts {
+	approvalStatus: "pending" | "approved" | "rejected" | "auto";
+	ageDays: number;
+	runType?: "action" | "internal" | "sync" | "behavior";
+	status?: string;
+	organizationId?: string;
+}
+
+async function seedApproval(opts: SeedApprovalOpts): Promise<number> {
+	const sql = getDb();
+	const rows = (await sql.unsafe(
+		`INSERT INTO runs (
+       organization_id, run_type, status, approval_status, action_key, created_at
+     ) VALUES (
+       $1, $2, $3, $4, 'send_message',
+       now() - ($5::int * interval '1 day')
+     )
+     RETURNING id`,
+		[
+			opts.organizationId ?? ORG_ID,
+			opts.runType ?? "action",
+			opts.status ?? "pending",
+			opts.approvalStatus,
+			opts.ageDays,
+		],
+	)) as unknown as Array<{ id: number | string }>;
+	return Number(rows[0].id);
+}
+
+async function runStateOf(
+	runId: number,
+): Promise<{ approval_status: string; status: string }> {
+	const sql = getDb();
+	const rows = (await sql`
+    SELECT approval_status, status FROM runs WHERE id = ${runId}
+  `) as unknown as Array<{ approval_status: string; status: string }>;
+	return rows[0];
+}
+
+describe("expirePendingApprovals", () => {
+	test("a pending approval older than the TTL becomes terminal 'expired'", async () => {
+		const staleId = await seedApproval({
+			approvalStatus: "pending",
+			ageDays: TTL_DAYS + 3,
+		});
+
+		const result = await expirePendingApprovals(TTL_DAYS);
+
+		expect(result.expired).toBe(1);
+		const state = await runStateOf(staleId);
+		expect(state.approval_status).toBe("expired");
+		expect(state.status).toBe("cancelled");
+
+		// The reason is recorded on the row so an operator can tell an expiry
+		// apart from a human rejection without reading the event chain.
+		const sql = getDb();
+		const [row] = (await sql`
+      SELECT error_message, completed_at FROM runs WHERE id = ${staleId}
+    `) as unknown as Array<{
+			error_message: string | null;
+			completed_at: string | null;
+		}>;
+		expect(row.error_message).toContain("Approval expired");
+		expect(row.completed_at).not.toBeNull();
+	});
+
+	test("a pending approval INSIDE the TTL is untouched", async () => {
+		// One day short of the TTL — the human still has time to decide, and the
+		// whole point of #2044 is that we must not take that away.
+		const freshId = await seedApproval({
+			approvalStatus: "pending",
+			ageDays: TTL_DAYS - 1,
+		});
+
+		const result = await expirePendingApprovals(TTL_DAYS);
+
+		expect(result.expired).toBe(0);
+		const state = await runStateOf(freshId);
+		expect(state.approval_status).toBe("pending");
+		expect(state.status).toBe("pending");
+	});
+
+	test("already approved / rejected / auto rows are never touched, however old", async () => {
+		const approvedId = await seedApproval({
+			approvalStatus: "approved",
+			ageDays: TTL_DAYS * 10,
+			status: "running",
+		});
+		const rejectedId = await seedApproval({
+			approvalStatus: "rejected",
+			ageDays: TTL_DAYS * 10,
+			status: "cancelled",
+		});
+		const autoId = await seedApproval({
+			approvalStatus: "auto",
+			ageDays: TTL_DAYS * 10,
+		});
+
+		const result = await expirePendingApprovals(TTL_DAYS);
+
+		expect(result.expired).toBe(0);
+		expect((await runStateOf(approvedId)).approval_status).toBe("approved");
+		expect((await runStateOf(rejectedId)).approval_status).toBe("rejected");
+		expect((await runStateOf(autoId)).approval_status).toBe("auto");
+	});
+
+	test("covers both human-gated lanes: action and internal", async () => {
+		const actionId = await seedApproval({
+			approvalStatus: "pending",
+			ageDays: TTL_DAYS + 1,
+			runType: "action",
+		});
+		const internalId = await seedApproval({
+			approvalStatus: "pending",
+			ageDays: TTL_DAYS + 1,
+			runType: "internal",
+		});
+
+		const result = await expirePendingApprovals(TTL_DAYS);
+
+		expect(result.expired).toBe(2);
+		expect((await runStateOf(actionId)).approval_status).toBe("expired");
+		expect((await runStateOf(internalId)).approval_status).toBe("expired");
+	});
+
+	test("is idempotent — a second pass expires nothing new", async () => {
+		await seedApproval({
+			approvalStatus: "pending",
+			ageDays: TTL_DAYS + 5,
+		});
+
+		const first = await expirePendingApprovals(TTL_DAYS);
+		expect(first.expired).toBe(1);
+
+		// The UPDATE re-asserts `approval_status = 'pending'`, so the row it just
+		// took terminal no longer matches. This is the same predicate that makes
+		// two overlapping replicas safe: only one UPDATE can ever match a row.
+		const second = await expirePendingApprovals(TTL_DAYS);
+		expect(second.expired).toBe(0);
+	});
+
+	test("a decision landing between scan and sweep wins over the expiry", async () => {
+		// Multi-replica / human-race safety: a row approved just before the sweep
+		// must keep the human's decision, not be overwritten by the reaper.
+		const raceId = await seedApproval({
+			approvalStatus: "pending",
+			ageDays: TTL_DAYS + 30,
+		});
+		const sql = getDb();
+		await sql`
+      UPDATE runs SET approval_status = 'approved', status = 'running'
+      WHERE id = ${raceId}
+    `;
+
+		const result = await expirePendingApprovals(TTL_DAYS);
+
+		expect(result.expired).toBe(0);
+		expect((await runStateOf(raceId)).approval_status).toBe("approved");
+	});
+
+	test("the TTL is configurable — a shorter TTL expires a younger row", async () => {
+		const id = await seedApproval({
+			approvalStatus: "pending",
+			ageDays: 3,
+		});
+
+		// Untouched at the 7-day default...
+		expect((await expirePendingApprovals(7)).expired).toBe(0);
+		expect((await runStateOf(id)).approval_status).toBe("pending");
+
+		// ...and expired once the TTL is tightened below its age.
+		expect((await expirePendingApprovals(2)).expired).toBe(1);
+		expect((await runStateOf(id)).approval_status).toBe("expired");
+	});
+});

--- a/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
+++ b/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
@@ -298,3 +298,140 @@ describe("expirePendingApprovals", () => {
 		expect((await runStateOf(id)).approval_status).toBe("expired");
 	});
 });
+
+/**
+ * Batch draining + cross-org fairness.
+ *
+ * The first cut selected rows globally oldest-first with a flat 500-row cap on a
+ * DAILY job. That starved everyone: a single tenant with more than 500 stale
+ * approvals consumed the whole budget on every tick, so its own backlog never
+ * drained and no other org's approvals were ever reached.
+ */
+describe("expirePendingApprovals — draining and cross-org fairness", () => {
+	/** Seed `count` stale pending approvals for an org in one statement. */
+	async function seedManyStale(
+		organizationId: string,
+		count: number,
+		ageDays: number,
+	): Promise<void> {
+		const sql = getDb();
+		await sql.unsafe(
+			`INSERT INTO runs (
+         organization_id, run_type, status, approval_status, action_key, created_at
+       )
+       SELECT $1, 'action', 'pending', 'pending', 'send_message',
+              now() - ($3::int * interval '1 day') - (g * interval '1 second')
+       FROM generate_series(1, $2::int) AS g`,
+			[organizationId, count, ageDays],
+		);
+	}
+
+	async function pendingCount(organizationId: string): Promise<number> {
+		const sql = getDb();
+		const rows = (await sql`
+      SELECT count(*)::int AS n FROM runs
+      WHERE organization_id = ${organizationId} AND approval_status = 'pending'
+    `) as unknown as Array<{ n: number }>;
+		return Number(rows[0]?.n ?? 0);
+	}
+
+	async function expiredCount(organizationId: string): Promise<number> {
+		const sql = getDb();
+		const rows = (await sql`
+      SELECT count(*)::int AS n FROM runs
+      WHERE organization_id = ${organizationId} AND approval_status = 'expired'
+    `) as unknown as Array<{ n: number }>;
+		return Number(rows[0]?.n ?? 0);
+	}
+
+	async function seedOrg(id: string): Promise<void> {
+		const sql = getDb();
+		await sql`
+      INSERT INTO organization (id, name, slug) VALUES (${id}, ${id}, ${id})
+      ON CONFLICT (id) DO NOTHING
+    `;
+	}
+
+	test("drains a backlog LARGER than one 500-row batch in a single invocation", async () => {
+		// 620 > the 500-row batch size. With the old flat cap this returned exactly
+		// 500 and left 120 waiting a full day for the next tick.
+		await seedManyStale(ORG_ID, 620, TTL_DAYS + 2);
+
+		const result = await expirePendingApprovals(TTL_DAYS);
+
+		expect(result.expired).toBe(620);
+		expect(await pendingCount(ORG_ID)).toBe(0);
+		expect(await expiredCount(ORG_ID)).toBe(620);
+	});
+
+	test("a huge single-tenant backlog does NOT starve other orgs", async () => {
+		// The starvation reproducer. ORG_ID's rows are all OLDER than the other
+		// orgs', so a purely oldest-first global selection would fill the entire
+		// first batch with ORG_ID and never reach the small orgs.
+		const hogOrg = ORG_ID;
+		const hogRows = 700;
+		await seedManyStale(hogOrg, hogRows, TTL_DAYS + 60);
+
+		const smallOrgs = ["fair-org-a", "fair-org-b", "fair-org-c"];
+		for (const org of smallOrgs) {
+			await seedOrg(org);
+			await seedManyStale(org, 5, TTL_DAYS + 1);
+		}
+
+		const result = await expirePendingApprovals(TTL_DAYS);
+
+		// Every org drains — the small ones are not left behind the big tenant.
+		for (const org of smallOrgs) {
+			expect(await expiredCount(org)).toBe(5);
+			expect(await pendingCount(org)).toBe(0);
+		}
+		expect(await expiredCount(hogOrg)).toBe(hogRows);
+		expect(result.expired).toBe(hogRows + smallOrgs.length * 5);
+	});
+
+	test("the per-org cap bounds how much one tenant takes from a single batch", async () => {
+		// Fairness is a per-BATCH property, not only an end-state one. Seed a hog
+		// with far more than one batch of much-older rows plus one small org, then
+		// run a sweep whose ceiling admits only a single batch (ttl unchanged, but
+		// the ceiling is what stops it). Under the old global oldest-first
+		// selection the hog's older rows would fill that batch entirely and the
+		// small org would get nothing.
+		const hogOrg = ORG_ID;
+		const hogRows = 800;
+		await seedManyStale(hogOrg, hogRows, TTL_DAYS + 60);
+		await seedOrg("fair-small");
+		await seedManyStale("fair-small", 3, TTL_DAYS + 1);
+
+		// Ceiling of one batch: only the FIRST batch runs, so this asserts on batch
+		// composition rather than on the end state after everything drains.
+		const result = await expirePendingApprovals(TTL_DAYS, 500);
+
+		// The small org is served within that first batch despite every one of its
+		// rows being NEWER than all 800 of the hog's — proof the selection is not
+		// globally oldest-first. The old code would have spent the whole batch on
+		// the hog and left these three untouched.
+		expect(await expiredCount("fair-small")).toBe(3);
+		expect(result.expired).toBe(500);
+		// The hog is capped well below the batch, leaving room for everyone else.
+		expect(await expiredCount(hogOrg)).toBeLessThan(500);
+	});
+
+	test("respects the per-invocation ceiling on a pathological backlog", async () => {
+		// A backlog larger than the ceiling must stop AT the ceiling rather than
+		// running unbounded, and the remainder must drain on the next tick so no
+		// permanent backlog forms. The ceiling is injected here so this exercises
+		// the real bound without seeding the 10k production value.
+		const ceiling = 120;
+		await seedManyStale(ORG_ID, ceiling + 30, TTL_DAYS + 2);
+
+		const result = await expirePendingApprovals(TTL_DAYS, ceiling);
+
+		expect(result.expired).toBe(ceiling);
+		expect(await pendingCount(ORG_ID)).toBe(30);
+
+		// The remainder drains on the following tick — no permanent backlog.
+		const second = await expirePendingApprovals(TTL_DAYS, ceiling);
+		expect(second.expired).toBe(30);
+		expect(await pendingCount(ORG_ID)).toBe(0);
+	});
+});

--- a/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
+++ b/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
@@ -52,7 +52,8 @@ interface SeedRunOpts {
 	feedId?: number | null;
 	createdAtAgoSeconds?: number;
 	/** Defaults to 'auto' (worker-claimable). Set 'pending' for a human-approval run. */
-	approvalStatus?: "auto" | "pending" | "approved" | "rejected";
+	approvalStatus?: "auto" | "pending" | "approved" | "rejected" | "expired";
+	createdAtAgoDays?: number;
 }
 
 async function seedRun(opts: SeedRunOpts): Promise<number> {
@@ -66,7 +67,10 @@ async function seedRun(opts: SeedRunOpts): Promise<number> {
 		opts.claimedAtAgoSeconds !== null && opts.claimedAtAgoSeconds !== undefined
 			? `current_timestamp - interval '${opts.claimedAtAgoSeconds} seconds'`
 			: "NULL";
-	const createdAt = `current_timestamp - interval '${opts.createdAtAgoSeconds ?? 0} seconds'`;
+	const createdAt =
+		opts.createdAtAgoDays !== undefined
+			? `current_timestamp - interval '${opts.createdAtAgoDays} days'`
+			: `current_timestamp - interval '${opts.createdAtAgoSeconds ?? 0} seconds'`;
 	const rows = (await sql.unsafe(
 		`INSERT INTO runs (
        organization_id, run_type, feed_id, status, approval_status,
@@ -113,6 +117,14 @@ async function statusOf(runId: number): Promise<string> {
 			status: string;
 		}>;
 	return rows[0]?.status ?? "missing";
+}
+
+async function approvalStatusOf(runId: number): Promise<string> {
+	const sql = getDb();
+	const rows = (await sql`
+    SELECT approval_status FROM runs WHERE id = ${runId}
+  `) as unknown as Array<{ approval_status: string }>;
+	return rows[0]?.approval_status ?? "missing";
 }
 
 describe("reapStaleRuns — connector lanes", () => {
@@ -206,6 +218,68 @@ describe("reapStaleRuns — connector lanes", () => {
 
 		expect(result.reaped).toBe(1);
 		expect(await statusOf(autoId)).toBe("timeout");
+	});
+
+	// #2044 REGRESSION GUARD — the single most important assertion here.
+	//
+	// The long-horizon expiry sweep (scheduled/expire-pending-approvals.ts) was
+	// added to take undecided approvals terminal after DAYS. It must not have
+	// leaked into the SHORT-horizon reaper: a fresh approval-pending run, and a
+	// stale-by-CLAIM-horizon one, must both still survive this reaper untouched,
+	// however long they sit, because no worker will ever claim them and the human
+	// has not decided yet. If this fails, #2044 is re-broken and approval URLs
+	// point at dead runs again.
+	test("#2044: approval-pending runs survive the short-horizon reaper at every age", async () => {
+		const fresh = await seedRun({
+			status: "pending",
+			approvalStatus: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "action",
+			createdAtAgoSeconds: 1,
+		});
+		const pastClaimHorizon = await seedRun({
+			status: "pending",
+			approvalStatus: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "action",
+			createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 50,
+		});
+		// Older than the LONG horizon too. Even here the short reaper must not act
+		// — expiring this row is the expiry sweep's job, under its own vocabulary
+		// ('expired'), not a claim timeout.
+		const pastExpiryHorizon = await seedRun({
+			status: "pending",
+			approvalStatus: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "action",
+			createdAtAgoDays: 30,
+		});
+
+		const result = await reapStaleRuns();
+
+		expect(result.reaped).toBe(0);
+		for (const id of [fresh, pastClaimHorizon, pastExpiryHorizon]) {
+			expect(await statusOf(id)).toBe("pending");
+			expect(await approvalStatusOf(id)).toBe("pending");
+		}
+	});
+
+	// The reaper must also leave an already-EXPIRED row alone: it is terminal, and
+	// re-reaping it would overwrite 'cancelled' with 'timeout' and lose the reason.
+	test("an expired approval run is terminal and not re-reaped", async () => {
+		const expiredId = await seedRun({
+			status: "cancelled",
+			approvalStatus: "expired",
+			lastHeartbeatAgoSeconds: null,
+			runType: "action",
+			createdAtAgoDays: 30,
+		});
+
+		const result = await reapStaleRuns();
+
+		expect(result.reaped).toBe(0);
+		expect(await statusOf(expiredId)).toBe("cancelled");
+		expect(await approvalStatusOf(expiredId)).toBe("expired");
 	});
 
 	test("a worker claim holding the row lock wins over pending expiration", async () => {

--- a/packages/server/src/scheduled/expire-pending-approvals.ts
+++ b/packages/server/src/scheduled/expire-pending-approvals.ts
@@ -1,0 +1,124 @@
+/**
+ * Long-horizon expiry for undecided approvals.
+ *
+ * A run queued behind a human gate lands at `approval_status='pending'` and is
+ * DELIBERATELY exempt from the short-horizon claim reaper (#2044, see
+ * scheduled/stale-run-sweeper.ts): no worker will ever claim it, so timing it
+ * out on the 120s claim horizon would kill the run before anyone could decide.
+ * That exemption was never paired with a long-horizon expiry, so undecided
+ * approvals accumulated forever — cluttering the approvals surface and keeping
+ * side effects queued against inputs that went stale months ago.
+ *
+ * This reaper closes that hole at the OTHER end of the timescale: rows still
+ * pending after `intervals.pendingApprovalTtlDays` (default 7 DAYS) go terminal
+ * at `approval_status='expired', status='cancelled'`. It never touches anything
+ * inside the TTL, so the #2044 grace window is untouched — the two reapers do
+ * not overlap in the horizons they cover.
+ *
+ * 'expired' is a distinct value, not a reuse of 'rejected': rejection is a HUMAN
+ * decision the batch-reject path feeds back to the Behavior as a `correction` to
+ * learn from, while expiry is the system giving up on an undecided run. An agent
+ * must not train on silence as if it were disapproval.
+ *
+ * Scope is both human-gated lanes — `action` (connector operations) and
+ * `internal` (builder / entity-change / Behavior proposals). Nothing else can
+ * hold `approval_status='pending'`.
+ *
+ * Multi-pod safety: the UPDATE re-asserts `approval_status = 'pending'`, so it
+ * is the authoritative claim — a row a human approved between scan and write is
+ * excluded by the predicate, and two overlapping runners can never both expire
+ * the same row (only one UPDATE matches). Pure Postgres, correct under N>1
+ * replicas; RETURNING drives the card supersede so each expiry is announced
+ * exactly once.
+ */
+
+import { intervals } from '../config/intervals';
+import { getDb, pgTextArray } from '../db/client';
+import { supersedeActionEvent } from '../tools/admin/manage_operations';
+import logger from '../utils/logger';
+
+/** Lanes that can hold `approval_status='pending'`. */
+const APPROVAL_RUN_TYPES = ['action', 'internal'] as const;
+
+/** Cap on rows expired per tick so one sweep can't hold a long write burst. */
+const EXPIRY_BATCH_LIMIT = 500;
+
+interface ExpiredApprovalRow {
+  id: string | number;
+  organization_id: string;
+  action_key: string | null;
+}
+
+export interface ExpirePendingApprovalsResult {
+  /** Rows transitioned pending → expired this tick. */
+  expired: number;
+}
+
+/**
+ * One pass of the pending-approval expiry sweep. Idempotent: a row already
+ * expired no longer matches `approval_status = 'pending'`.
+ */
+export async function expirePendingApprovals(
+  ttlDays: number = intervals.pendingApprovalTtlDays,
+): Promise<ExpirePendingApprovalsResult> {
+  const sql = getDb();
+  const reason = `Approval expired: nobody decided within ${ttlDays} day${ttlDays === 1 ? '' : 's'}.`;
+
+  // Authoritative claim + transition in one statement. The inner SELECT bounds
+  // the batch oldest-first; the UPDATE re-asserts the full pending predicate so
+  // a row decided between scan and write is left to the human who decided it.
+  const expired = (await sql`
+    UPDATE runs
+    SET approval_status = 'expired',
+        status = 'cancelled',
+        error_message = ${reason},
+        completed_at = NOW()
+    WHERE id IN (
+      SELECT id FROM runs
+      WHERE approval_status = 'pending'
+        AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
+        AND created_at < NOW() - (${ttlDays}::int * interval '1 day')
+      ORDER BY created_at ASC
+      LIMIT ${EXPIRY_BATCH_LIMIT}
+    )
+      AND approval_status = 'pending'
+    RETURNING id, organization_id, action_key
+  `) as unknown as ExpiredApprovalRow[];
+
+  // Supersede each approval card so the UI stops offering a dead Approve button.
+  // `events` is append-only — supersedeActionEvent appends a superseding row, it
+  // never deletes. interaction_status has no 'expired' member, so the card lands
+  // as 'rejected' (it is no longer actionable, which is what the renderer keys
+  // off); the precise reason lives on runs.approval_status + the event metadata.
+  // Best-effort per row: a card that can't be superseded must not strand the
+  // remaining rows, which are already terminal in the database.
+  for (const row of expired) {
+    const runId = Number(row.id);
+    const label = row.action_key ?? 'approval';
+    try {
+      await supersedeActionEvent(
+        runId,
+        row.organization_id,
+        'rejected',
+        `${label} — expired`,
+        reason,
+        { reason, expired: true, expired_after_days: ttlDays },
+      );
+    } catch (error) {
+      logger.warn(
+        { runId, organizationId: row.organization_id, error: String(error) },
+        '[task] expire-pending-approvals: card supersede failed (row already expired)',
+      );
+    }
+  }
+
+  return { expired: expired.length };
+}
+
+/** Scheduled-task wrapper: run the sweep and log a summary. */
+export async function runExpirePendingApprovals(): Promise<void> {
+  const result = await expirePendingApprovals();
+  if (result.expired > 0) {
+    logger.info({ ...result }, '[task] expire-pending-approvals completed');
+  }
+}

--- a/packages/server/src/scheduled/expire-pending-approvals.ts
+++ b/packages/server/src/scheduled/expire-pending-approvals.ts
@@ -24,6 +24,12 @@
  * `internal` (builder / entity-change / Behavior proposals). Nothing else can
  * hold `approval_status='pending'`.
  *
+ * Fairness + throughput: candidates are selected with a per-organization cap so
+ * one tenant with a huge backlog cannot consume the batch and starve every other
+ * org, and the sweep drains successive batches within a bounded per-invocation
+ * ceiling so a backlog larger than one batch clears in a single run instead of
+ * one batch per daily tick.
+ *
  * Multi-pod safety: the UPDATE re-asserts `approval_status = 'pending'`, so it
  * is the authoritative claim — a row a human approved between scan and write is
  * excluded by the predicate, and only one overlapping runner can commit an
@@ -40,8 +46,31 @@ import logger from "../utils/logger";
 /** Lanes that can hold `approval_status='pending'`. */
 const APPROVAL_RUN_TYPES = ["action", "internal"] as const;
 
-/** Cap on rows expired per tick so one sweep can't hold a long write burst. */
-const EXPIRY_BATCH_LIMIT = 500;
+/**
+ * Rows claimed per batch. Bounds each SELECT and the write burst that follows
+ * it; a backlog larger than this is drained by successive batches within the
+ * same invocation rather than being deferred to tomorrow's tick.
+ */
+const EXPIRY_BATCH_SIZE = 500;
+
+/**
+ * Ceiling on rows expired per invocation. The sweep drains batch after batch up
+ * to this many rows, so a >500-row backlog clears in one run instead of one
+ * batch per DAY, while a pathological backlog still cannot run unbounded.
+ */
+const EXPIRY_INVOCATION_LIMIT = 10_000;
+
+/**
+ * Rows taken from any ONE organization per batch.
+ *
+ * Without this the selection is globally oldest-first, so a single tenant with
+ * more stale approvals than the batch size consumes the entire budget on every
+ * tick: its own backlog never drains AND every other org's stale approvals are
+ * starved indefinitely — which defeats the point of the sweep. Taking a bounded
+ * slice per org per batch means every org with a backlog makes progress on every
+ * batch, and the round-robin across batches drains the big tenants too.
+ */
+const EXPIRY_PER_ORG_BATCH_SIZE = 50;
 
 interface ExpiredApprovalRow {
 	id: string | number;
@@ -61,70 +90,97 @@ interface ExpirePendingApprovalsResult {
 /**
  * One pass of the pending-approval expiry sweep. Idempotent: a row already
  * expired no longer matches `approval_status = 'pending'`.
+ *
+ * `invocationLimit` is injectable purely so tests can exercise the ceiling
+ * without seeding 10k rows; production always uses the default.
  */
 export async function expirePendingApprovals(
 	ttlDays: number = intervals.pendingApprovalTtlDays,
+	invocationLimit: number = EXPIRY_INVOCATION_LIMIT,
 ): Promise<ExpirePendingApprovalsResult> {
 	const sql = getDb();
 	const reason = `Approval expired: nobody decided within ${ttlDays} day${ttlDays === 1 ? "" : "s"}.`;
 
-	const candidates = (await sql`
-    SELECT id FROM runs
-    WHERE approval_status = 'pending'
-      AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
-      AND created_at < NOW() - (${ttlDays}::int * interval '1 day')
-    ORDER BY created_at ASC
-    LIMIT ${EXPIRY_BATCH_LIMIT}
-  `) as unknown as PendingApprovalCandidate[];
-
 	let expiredCount = 0;
-	for (const candidate of candidates) {
-		try {
-			const didExpire = await sql.begin(async (tx) => {
-				// Re-assert the full candidate predicate while claiming the row. A human
-				// decision or another replica's committed expiry wins before this write.
-				const rows = (await tx`
-      UPDATE runs
-      SET approval_status = 'expired',
-          status = 'cancelled',
-          error_message = ${reason},
-          completed_at = NOW()
-      WHERE id = ${candidate.id}
-        AND approval_status = 'pending'
-        AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
-        AND created_at < NOW() - (${ttlDays}::int * interval '1 day')
-      RETURNING id, organization_id, action_key
-        `) as unknown as ExpiredApprovalRow[];
-				const row = rows[0];
-				if (!row) return false;
+	// Drain successive batches so a backlog bigger than one batch clears in this
+	// invocation. Bounded by EXPIRY_INVOCATION_LIMIT; also stops as soon as a
+	// batch comes back empty or makes no progress (see below).
+	while (expiredCount < invocationLimit) {
+		const remaining = invocationLimit - expiredCount;
+		const batchSize = Math.min(EXPIRY_BATCH_SIZE, remaining);
 
-				// `events` stays append-only. interaction_status has no 'expired'
-				// member, so the card uses 'rejected' as its non-actionable UI state
-				// while run status and metadata retain the precise expiry reason.
-				const runId = Number(row.id);
-				const label = row.action_key ?? "approval";
-				await supersedeActionEvent(
-					runId,
-					row.organization_id,
-					"rejected",
-					`${label} — expired`,
-					reason,
-					{ reason, expired: true, expired_after_days: ttlDays },
-					null,
-					tx,
+		// Fair selection: rank each org's stale approvals oldest-first and take at
+		// most EXPIRY_PER_ORG_BATCH_SIZE from any one org, so a single large tenant
+		// cannot consume the batch and starve every other org. Within that, the
+		// batch is still ordered oldest-first so the longest-waiting rows go first.
+		const candidates = (await sql`
+      SELECT id FROM (
+        SELECT id, created_at,
+               ROW_NUMBER() OVER (
+                 PARTITION BY organization_id ORDER BY created_at ASC, id ASC
+               ) AS org_rank
+        FROM runs
+        WHERE approval_status = 'pending'
+          AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
+          AND created_at < NOW() - (${ttlDays}::int * interval '1 day')
+      ) ranked
+      WHERE org_rank <= ${EXPIRY_PER_ORG_BATCH_SIZE}
+      ORDER BY created_at ASC, id ASC
+      LIMIT ${batchSize}
+    `) as unknown as PendingApprovalCandidate[];
+
+		if (candidates.length === 0) break;
+
+		const expiredBeforeBatch = expiredCount;
+		for (const candidate of candidates) {
+			try {
+				const didExpire = await sql.begin(async (tx) => {
+					// Re-assert the full candidate predicate while claiming the row. A
+					// human decision or another replica's committed expiry wins before
+					// this write.
+					const rows = (await tx`
+            UPDATE runs
+            SET approval_status = 'expired',
+                status = 'cancelled',
+                error_message = ${reason},
+                completed_at = NOW()
+            WHERE id = ${candidate.id}
+              AND approval_status = 'pending'
+              AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
+              AND created_at < NOW() - (${ttlDays}::int * interval '1 day')
+            RETURNING id, organization_id, action_key
+          `) as unknown as ExpiredApprovalRow[];
+					const row = rows[0];
+					if (!row) return false;
+
+					// `events` stays append-only. interaction_status has no 'expired'
+					// member, so the card uses 'rejected' as its non-actionable UI state
+					// while run status and metadata retain the precise expiry reason.
+					await supersedeActionEvent(
+						Number(row.id),
+						row.organization_id,
+						"rejected",
+						`${row.action_key ?? "approval"} — expired`,
+						reason,
+						{ reason, expired: true, expired_after_days: ttlDays },
+						null,
+						tx,
+					);
+					return true;
+				});
+				if (didExpire) expiredCount += 1;
+			} catch (error) {
+				logger.warn(
+					{ runId: Number(candidate.id), error: String(error) },
+					"[task] expire-pending-approvals: expiry rolled back after card supersede failure",
 				);
-				return true;
-			});
-			if (didExpire) expiredCount += 1;
-		} catch (error) {
-			logger.warn(
-				{
-					runId: Number(candidate.id),
-					error: String(error),
-				},
-				"[task] expire-pending-approvals: expiry rolled back after card supersede failure",
-			);
+			}
 		}
+
+		// No row in a non-empty batch advanced — every candidate was either decided
+		// under us or is failing its supersede. Stop rather than re-selecting the
+		// same rows forever; the next scheduled tick retries with fresh state.
+		if (expiredCount === expiredBeforeBatch) break;
 	}
 
 	return { expired: expiredCount };

--- a/packages/server/src/scheduled/expire-pending-approvals.ts
+++ b/packages/server/src/scheduled/expire-pending-approvals.ts
@@ -26,32 +26,36 @@
  *
  * Multi-pod safety: the UPDATE re-asserts `approval_status = 'pending'`, so it
  * is the authoritative claim — a row a human approved between scan and write is
- * excluded by the predicate, and two overlapping runners can never both expire
- * the same row (only one UPDATE matches). Pure Postgres, correct under N>1
- * replicas; RETURNING drives the card supersede so each expiry is announced
- * exactly once.
+ * excluded by the predicate, and only one overlapping runner can commit an
+ * expiry for a row. Pure Postgres, correct under N>1 replicas. The run
+ * transition and card supersession share a transaction: if the event write
+ * fails, the run remains pending for the next sweep.
  */
 
-import { intervals } from '../config/intervals';
-import { getDb, pgTextArray } from '../db/client';
-import { supersedeActionEvent } from '../tools/admin/manage_operations';
-import logger from '../utils/logger';
+import { intervals } from "../config/intervals";
+import { getDb, pgTextArray } from "../db/client";
+import { supersedeActionEvent } from "../tools/admin/manage_operations";
+import logger from "../utils/logger";
 
 /** Lanes that can hold `approval_status='pending'`. */
-const APPROVAL_RUN_TYPES = ['action', 'internal'] as const;
+const APPROVAL_RUN_TYPES = ["action", "internal"] as const;
 
 /** Cap on rows expired per tick so one sweep can't hold a long write burst. */
 const EXPIRY_BATCH_LIMIT = 500;
 
 interface ExpiredApprovalRow {
-  id: string | number;
-  organization_id: string;
-  action_key: string | null;
+	id: string | number;
+	organization_id: string;
+	action_key: string | null;
 }
 
-export interface ExpirePendingApprovalsResult {
-  /** Rows transitioned pending → expired this tick. */
-  expired: number;
+interface PendingApprovalCandidate {
+	id: string | number;
+}
+
+interface ExpirePendingApprovalsResult {
+	/** Rows transitioned pending → expired this tick. */
+	expired: number;
 }
 
 /**
@@ -59,66 +63,77 @@ export interface ExpirePendingApprovalsResult {
  * expired no longer matches `approval_status = 'pending'`.
  */
 export async function expirePendingApprovals(
-  ttlDays: number = intervals.pendingApprovalTtlDays,
+	ttlDays: number = intervals.pendingApprovalTtlDays,
 ): Promise<ExpirePendingApprovalsResult> {
-  const sql = getDb();
-  const reason = `Approval expired: nobody decided within ${ttlDays} day${ttlDays === 1 ? '' : 's'}.`;
+	const sql = getDb();
+	const reason = `Approval expired: nobody decided within ${ttlDays} day${ttlDays === 1 ? "" : "s"}.`;
 
-  // Authoritative claim + transition in one statement. The inner SELECT bounds
-  // the batch oldest-first; the UPDATE re-asserts the full pending predicate so
-  // a row decided between scan and write is left to the human who decided it.
-  const expired = (await sql`
-    UPDATE runs
-    SET approval_status = 'expired',
-        status = 'cancelled',
-        error_message = ${reason},
-        completed_at = NOW()
-    WHERE id IN (
-      SELECT id FROM runs
-      WHERE approval_status = 'pending'
+	const candidates = (await sql`
+    SELECT id FROM runs
+    WHERE approval_status = 'pending'
+      AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
+      AND created_at < NOW() - (${ttlDays}::int * interval '1 day')
+    ORDER BY created_at ASC
+    LIMIT ${EXPIRY_BATCH_LIMIT}
+  `) as unknown as PendingApprovalCandidate[];
+
+	let expiredCount = 0;
+	for (const candidate of candidates) {
+		try {
+			const didExpire = await sql.begin(async (tx) => {
+				// Re-assert the full candidate predicate while claiming the row. A human
+				// decision or another replica's committed expiry wins before this write.
+				const rows = (await tx`
+      UPDATE runs
+      SET approval_status = 'expired',
+          status = 'cancelled',
+          error_message = ${reason},
+          completed_at = NOW()
+      WHERE id = ${candidate.id}
+        AND approval_status = 'pending'
         AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
         AND created_at < NOW() - (${ttlDays}::int * interval '1 day')
-      ORDER BY created_at ASC
-      LIMIT ${EXPIRY_BATCH_LIMIT}
-    )
-      AND approval_status = 'pending'
-    RETURNING id, organization_id, action_key
-  `) as unknown as ExpiredApprovalRow[];
+      RETURNING id, organization_id, action_key
+        `) as unknown as ExpiredApprovalRow[];
+				const row = rows[0];
+				if (!row) return false;
 
-  // Supersede each approval card so the UI stops offering a dead Approve button.
-  // `events` is append-only — supersedeActionEvent appends a superseding row, it
-  // never deletes. interaction_status has no 'expired' member, so the card lands
-  // as 'rejected' (it is no longer actionable, which is what the renderer keys
-  // off); the precise reason lives on runs.approval_status + the event metadata.
-  // Best-effort per row: a card that can't be superseded must not strand the
-  // remaining rows, which are already terminal in the database.
-  for (const row of expired) {
-    const runId = Number(row.id);
-    const label = row.action_key ?? 'approval';
-    try {
-      await supersedeActionEvent(
-        runId,
-        row.organization_id,
-        'rejected',
-        `${label} — expired`,
-        reason,
-        { reason, expired: true, expired_after_days: ttlDays },
-      );
-    } catch (error) {
-      logger.warn(
-        { runId, organizationId: row.organization_id, error: String(error) },
-        '[task] expire-pending-approvals: card supersede failed (row already expired)',
-      );
-    }
-  }
+				// `events` stays append-only. interaction_status has no 'expired'
+				// member, so the card uses 'rejected' as its non-actionable UI state
+				// while run status and metadata retain the precise expiry reason.
+				const runId = Number(row.id);
+				const label = row.action_key ?? "approval";
+				await supersedeActionEvent(
+					runId,
+					row.organization_id,
+					"rejected",
+					`${label} — expired`,
+					reason,
+					{ reason, expired: true, expired_after_days: ttlDays },
+					null,
+					tx,
+				);
+				return true;
+			});
+			if (didExpire) expiredCount += 1;
+		} catch (error) {
+			logger.warn(
+				{
+					runId: Number(candidate.id),
+					error: String(error),
+				},
+				"[task] expire-pending-approvals: expiry rolled back after card supersede failure",
+			);
+		}
+	}
 
-  return { expired: expired.length };
+	return { expired: expiredCount };
 }
 
 /** Scheduled-task wrapper: run the sweep and log a summary. */
 export async function runExpirePendingApprovals(): Promise<void> {
-  const result = await expirePendingApprovals();
-  if (result.expired > 0) {
-    logger.info({ ...result }, '[task] expire-pending-approvals completed');
-  }
+	const result = await expirePendingApprovals();
+	if (result.expired > 0) {
+		logger.info({ ...result }, "[task] expire-pending-approvals completed");
+	}
 }

--- a/packages/server/src/scheduled/expire-pending-approvals.ts
+++ b/packages/server/src/scheduled/expire-pending-approvals.ts
@@ -24,11 +24,12 @@
  * `internal` (builder / entity-change / Behavior proposals). Nothing else can
  * hold `approval_status='pending'`.
  *
- * Fairness + throughput: candidates are selected with a per-organization cap so
- * one tenant with a huge backlog cannot consume the batch and starve every other
- * org, and the sweep drains successive batches within a bounded per-invocation
- * ceiling so a backlog larger than one batch clears in a single run instead of
- * one batch per daily tick.
+ * Fairness + throughput: candidates are selected round-robin across
+ * organizations — interleaved by per-org rank, with a per-org cap — so neither
+ * one huge tenant nor the N oldest tenants can consume a batch and starve
+ * everyone else. The sweep then drains successive batches within a bounded
+ * per-invocation ceiling, so a backlog larger than one batch clears in a single
+ * run instead of one batch per daily tick.
  *
  * Multi-pod safety: the UPDATE re-asserts `approval_status = 'pending'`, so it
  * is the authoritative claim — a row a human approved between scan and write is
@@ -109,10 +110,20 @@ export async function expirePendingApprovals(
 		const remaining = invocationLimit - expiredCount;
 		const batchSize = Math.min(EXPIRY_BATCH_SIZE, remaining);
 
-		// Fair selection: rank each org's stale approvals oldest-first and take at
-		// most EXPIRY_PER_ORG_BATCH_SIZE from any one org, so a single large tenant
-		// cannot consume the batch and starve every other org. Within that, the
-		// batch is still ordered oldest-first so the longest-waiting rows go first.
+		// Fair selection, round-robin across organizations.
+		//
+		// Ranking per org and capping at EXPIRY_PER_ORG_BATCH_SIZE is NOT enough on
+		// its own: if the capped set is then ordered globally by age, the oldest
+		// (batchSize / perOrgCap) orgs fill the batch exactly and every other org
+		// is invisible — starvation with the threshold moved from 1 org to N,
+		// rather than removed.
+		//
+		// Ordering by `org_rank` FIRST interleaves the orgs: every org's oldest row
+		// comes before any org's second row, and so on. Representation therefore
+		// never depends on how many other orgs are backlogged. `created_at` stays
+		// as the tiebreak WITHIN a rank, so the longest-waiting rows still lead at
+		// equal standing, and the per-org cap keeps one tenant from monopolising
+		// the tail of the batch.
 		const candidates = (await sql`
       SELECT id FROM (
         SELECT id, created_at,
@@ -125,7 +136,7 @@ export async function expirePendingApprovals(
           AND created_at < NOW() - (${ttlDays}::int * interval '1 day')
       ) ranked
       WHERE org_rank <= ${EXPIRY_PER_ORG_BATCH_SIZE}
-      ORDER BY created_at ASC, id ASC
+      ORDER BY org_rank ASC, created_at ASC, id ASC
       LIMIT ${batchSize}
     `) as unknown as PendingApprovalCandidate[];
 

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -28,6 +28,7 @@ import { triggerEmbedBackfill } from './trigger-embed-backfill';
 import { runMemberClaimDriftCheck } from './member-claim-drift';
 import { runReapStaleDeviceWorkers } from './reap-stale-device-workers';
 import { runReapExpiredPendingSlackInstalls } from './reap-expired-pending-installs';
+import { runExpirePendingApprovals } from './expire-pending-approvals';
 import { getDb, pgTextArray } from '../db/client';
 import { createNotificationForUsers } from '../notifications/service';
 import {
@@ -292,6 +293,23 @@ function registerMaintenanceTasks(
       await runReapExpiredPendingSlackInstalls();
     },
     { cron: '17 3 * * *' },
+  );
+
+  // Long-horizon pending-approval expiry — transitions runs still sitting at
+  // approval_status='pending' past PENDING_APPROVAL_TTL_DAYS (default 7 DAYS)
+  // to 'expired' and supersedes their approval card. This is the deliberate
+  // counterpart to the SHORT-horizon claim reaper, which exempts
+  // approval-pending rows on purpose (#2044) so a human gets real time to
+  // decide; without a long horizon those rows never resolve. Days apart from
+  // that 120s exemption, so the two never contend for the same row.
+  // Single-claimant per tick; pure Postgres (multi-replica safe). Daily,
+  // off-peak, distinct minute from the other two reapers.
+  scheduler.register(
+    'expire-pending-approvals',
+    async () => {
+      await runExpirePendingApprovals();
+    },
+    { cron: '31 3 * * *' },
   );
 
   // Watcher automation: reconcile in-flight runs, materialize newly-due runs,

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -295,15 +295,11 @@ function registerMaintenanceTasks(
     { cron: '17 3 * * *' },
   );
 
-  // Long-horizon pending-approval expiry — transitions runs still sitting at
-  // approval_status='pending' past PENDING_APPROVAL_TTL_DAYS (default 7 DAYS)
-  // to 'expired' and supersedes their approval card. This is the deliberate
-  // counterpart to the SHORT-horizon claim reaper, which exempts
-  // approval-pending rows on purpose (#2044) so a human gets real time to
-  // decide; without a long horizon those rows never resolve. Days apart from
-  // that 120s exemption, so the two never contend for the same row.
-  // Single-claimant per tick; pure Postgres (multi-replica safe). Daily,
-  // off-peak, distinct minute from the other two reapers.
+  // Long-horizon pending-approval expiry: the counterpart to the short-horizon
+  // claim reaper, which exempts approval-pending rows on purpose (#2044) and so
+  // never resolves them. Rationale + fairness/draining details live in
+  // scheduled/expire-pending-approvals.ts. Daily, off-peak, distinct minute from
+  // the other two reapers.
   scheduler.register(
     'expire-pending-approvals',
     async () => {

--- a/packages/server/src/scheduled/scheduler-health.ts
+++ b/packages/server/src/scheduled/scheduler-health.ts
@@ -46,6 +46,10 @@ const EXECUTION_GAP_THRESHOLD_HOURS = 2; // Alert if no runs are created in 2 ho
 // Alert only once it is overdue by more than an hour — matches the feed
 // threshold and avoids flapping on normal tick jitter.
 const BEHAVIOR_OVERDUE_THRESHOLD_HOURS = 1;
+// Cadence of the pending-approval expiry sweep (`expire-pending-approvals` is
+// registered on a daily cron in scheduled/jobs.ts). Used as the grace window on
+// top of the TTL before a stale approval counts as a fault rather than drift.
+const EXPIRY_SWEEP_INTERVAL_DAYS = 1;
 
 export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStatus> {
   const sql = getDb();
@@ -151,11 +155,11 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
 
     // Undecided approvals past the long-horizon TTL — the expire-pending-
     // approvals sweep (scheduled/expire-pending-approvals.ts) should have taken
-    // these terminal. A non-zero count between daily ticks is expected drift; a
-    // count that persists means the sweep is wedged, so an operator sees the
-    // backlog instead of it silently growing forever (the original gap: the
+    // these terminal. The COUNT is always reported: it is the operator's view of
+    // the backlog, which the original gap let grow forever unseen (the
     // short-horizon reaper exempts these rows on purpose, #2044, and nothing
-    // else ever resolved them).
+    // else resolved them). The health ISSUE is raised only past the sweep grace
+    // below, since a non-zero count between daily ticks is expected drift.
     const stalePendingApprovalStats = await sql`
       SELECT
         CAST(COUNT(*) AS INTEGER) AS stale_pending,
@@ -167,6 +171,11 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
         AND created_at
             < current_timestamp - (${intervals.pendingApprovalTtlDays}::int * interval '1 day')
     `;
+    // One full sweep interval of slack on top of the TTL. The expiry job is
+    // registered on a daily cron (scheduled/jobs.ts), so anything younger than
+    // this is drift the next tick will clear, not a fault.
+    const staleApprovalAlarmAfterDays =
+      intervals.pendingApprovalTtlDays + EXPIRY_SWEEP_INTERVAL_DAYS;
     const stalePendingApprovals = Number(
       stalePendingApprovalStats[0]?.stale_pending || 0
     );
@@ -209,9 +218,15 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
       );
     }
 
-    if (stalePendingApprovals > 0) {
+    // Alarm only once a full sweep opportunity has been MISSED, not merely
+    // because a row crossed the TTL. The expiry sweep runs daily, so an approval
+    // that ages past the TTL just after a tick sits stale for up to a day by
+    // design; alarming on that would put /health/scheduler in 503 during normal
+    // operation and train operators to ignore it. Past TTL + one sweep interval,
+    // a row that is still pending means the sweep did not do its job.
+    if (oldestPendingApprovalDays > staleApprovalAlarmAfterDays) {
       issues.push(
-        `${stalePendingApprovals} approvals undecided past the ${intervals.pendingApprovalTtlDays}-day TTL (oldest ${oldestPendingApprovalDays.toFixed(1)} days)`
+        `${stalePendingApprovals} approvals undecided past the ${intervals.pendingApprovalTtlDays}-day TTL with the oldest at ${oldestPendingApprovalDays.toFixed(1)} days — past the ${staleApprovalAlarmAfterDays}-day sweep grace, so the expiry sweep looks wedged`
       );
     }
 

--- a/packages/server/src/scheduled/scheduler-health.ts
+++ b/packages/server/src/scheduled/scheduler-health.ts
@@ -32,6 +32,10 @@ interface SchedulerHealthStatus {
     overdueBehaviors: number;
     behaviorsOverdueByHours: number;
     stalePendingBehaviorRuns: number;
+    /** Approvals still undecided past PENDING_APPROVAL_TTL_DAYS. */
+    stalePendingApprovals: number;
+    /** Age of the oldest undecided approval, in days. */
+    oldestPendingApprovalDays: number;
   };
 }
 
@@ -145,6 +149,31 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
         ?.stale_pending || 0
     );
 
+    // Undecided approvals past the long-horizon TTL — the expire-pending-
+    // approvals sweep (scheduled/expire-pending-approvals.ts) should have taken
+    // these terminal. A non-zero count between daily ticks is expected drift; a
+    // count that persists means the sweep is wedged, so an operator sees the
+    // backlog instead of it silently growing forever (the original gap: the
+    // short-horizon reaper exempts these rows on purpose, #2044, and nothing
+    // else ever resolved them).
+    const stalePendingApprovalStats = await sql`
+      SELECT
+        CAST(COUNT(*) AS INTEGER) AS stale_pending,
+        MAX(EXTRACT(EPOCH FROM (current_timestamp - created_at)) / 86400.0)
+          AS oldest_days
+      FROM runs
+      WHERE approval_status = 'pending'
+        AND run_type IN ('action', 'internal')
+        AND created_at
+            < current_timestamp - (${intervals.pendingApprovalTtlDays}::int * interval '1 day')
+    `;
+    const stalePendingApprovals = Number(
+      stalePendingApprovalStats[0]?.stale_pending || 0
+    );
+    const oldestPendingApprovalDays = Number(
+      stalePendingApprovalStats[0]?.oldest_days || 0
+    );
+
     // Check for issues
     if (overdueByHours > OVERDUE_THRESHOLD_HOURS) {
       issues.push(`${overdueFeeds} feeds overdue by up to ${overdueByHours.toFixed(1)} hours`);
@@ -180,6 +209,12 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
       );
     }
 
+    if (stalePendingApprovals > 0) {
+      issues.push(
+        `${stalePendingApprovals} approvals undecided past the ${intervals.pendingApprovalTtlDays}-day TTL (oldest ${oldestPendingApprovalDays.toFixed(1)} days)`
+      );
+    }
+
     const healthy = issues.length === 0;
 
     if (!healthy) {
@@ -202,6 +237,8 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
         overdueBehaviors,
         behaviorsOverdueByHours: Math.round(behaviorsOverdueByHours * 10) / 10,
         stalePendingBehaviorRuns,
+        stalePendingApprovals,
+        oldestPendingApprovalDays: Math.round(oldestPendingApprovalDays * 10) / 10,
       },
     };
   } catch (error) {
@@ -222,6 +259,8 @@ export async function getSchedulerHealth(_env: Env): Promise<SchedulerHealthStat
         overdueBehaviors: 0,
         behaviorsOverdueByHours: 0,
         stalePendingBehaviorRuns: 0,
+        stalePendingApprovals: 0,
+        oldestPendingApprovalDays: 0,
       },
     };
   }

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -119,14 +119,14 @@ type InlineExecutionResult =
 	| { status: "failed"; error_message: string };
 
 type ConnectionRow = {
-	id: number;
-	connector_key: string;
-	status: string;
-	auth_profile_id: number | null;
-	app_auth_profile_id: number | null;
-	display_name: string | null;
-	config: Record<string, unknown> | null;
-	name: string;
+  id: number;
+  connector_key: string;
+  status: string;
+  auth_profile_id: number | null;
+  app_auth_profile_id: number | null;
+  display_name: string | null;
+  config: Record<string, unknown> | null;
+  name: string;
 };
 
 type ExecutionTarget = {
@@ -172,22 +172,22 @@ type OperationTargetRow = {
  * separates because operation keys themselves contain dots (`slack.send_message`).
  */
 export function qualifiedOperationKey(
-	connectorKey: string,
-	operationKey: string,
+  connectorKey: string,
+  operationKey: string,
 ): string {
-	return `${connectorKey}::${operationKey}`;
+  return `${connectorKey}::${operationKey}`;
 }
 
 const manageOperationsTool = defineActionTool("manage_operations", {
-	list_available: action(ListAvailableAction, handleListAvailable),
-	execute: action(ExecuteAction, handleExecute),
-	list_runs: action(ListRunsAction, handleListRuns),
-	get_run: action(GetRunAction, handleGetRun),
-	list_activity: action(ListActivityAction, handleListActivity),
-	approve: action(ApproveAction, handleApprove),
-	reject: action(RejectAction, handleReject),
-	approve_batch: action(ApproveBatchAction, handleApproveBatch),
-	reject_batch: action(RejectBatchAction, handleRejectBatch),
+  list_available: action(ListAvailableAction, handleListAvailable),
+  execute: action(ExecuteAction, handleExecute),
+  list_runs: action(ListRunsAction, handleListRuns),
+  get_run: action(GetRunAction, handleGetRun),
+  list_activity: action(ListActivityAction, handleListActivity),
+  approve: action(ApproveAction, handleApprove),
+  reject: action(RejectAction, handleReject),
+  approve_batch: action(ApproveBatchAction, handleApproveBatch),
+  reject_batch: action(RejectBatchAction, handleRejectBatch),
 });
 
 export { ManageOperationsResultSchema, ManageOperationsSchema };
@@ -350,32 +350,32 @@ async function executeMcpToolInline(
 			status: "failed",
 			error_message: "Invalid MCP operation backend config",
 		};
-	}
+  }
 
 	let result: Awaited<ReturnType<typeof callProxyTool>>;
 	try {
 		result = await callProxyTool(
-			connection.connector_key,
-			{
-				upstream_url: operation.backend_config.upstreamUrl,
+    connection.connector_key,
+    {
+      upstream_url: operation.backend_config.upstreamUrl,
 				tool_prefix: "",
-			},
-			organizationId,
-			operation.backend_config.toolName,
+    },
+    organizationId,
+    operation.backend_config.toolName,
 			actionInput,
 			connection.id,
-		);
+  );
 	} catch (error) {
 		return failRunInline(runId, organizationId, getErrorMessage(error));
 	}
 
-	if (result.isError) {
-		const errorText =
-			(result.content as Array<{ type: string; text?: string }>).find(
+  if (result.isError) {
+    const errorText =
+      (result.content as Array<{ type: string; text?: string }>).find(
 				(item) => item?.type === "text",
 			)?.text ?? "Upstream MCP error";
-		return failRunInline(runId, organizationId, errorText);
-	}
+    return failRunInline(runId, organizationId, errorText);
+  }
 
 	return completeRunInline(runId, organizationId, {
 		content: result.content,
@@ -392,16 +392,16 @@ async function executeOperationInline(
 	abortSignal?: AbortSignal,
 ): Promise<InlineExecutionResult> {
 	if (operation.backend === "local_action") {
-		return executeLocalActionInline(
-			runId,
-			organizationId,
-			connection,
-			operation,
-			actionInput,
-			env,
+    return executeLocalActionInline(
+      runId,
+      organizationId,
+      connection,
+      operation,
+      actionInput,
+      env,
 			abortSignal,
-		);
-	}
+    );
+  }
 	if (operation.backend === "mcp_tool") {
 		return executeMcpToolInline(
 			runId,
@@ -410,7 +410,7 @@ async function executeOperationInline(
 			operation,
 			actionInput,
 		);
-	}
+  }
 	return executeHttpOperation(
 		runId,
 		organizationId,
@@ -864,23 +864,23 @@ async function handleListAvailable(
 
 	const targetsByConnector = groupExecutionTargets(targetRows);
 
-	// A `disabled` connector_action effect turns an operation OFF for this principal
-	// — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
-	// which surface then gate on execute). Two levels now: the BLANKET `execute` rule
-	// (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
-	// can disable a single op while the rest stay listed.
-	const actor = await resolveActingPrincipal(getDb(), {
-		organizationId: ctx.organizationId,
-		userId: ctx.userId,
-		agentId: ctx.agentId,
-		sessionWatcherId: ctx.actingWatcherId ?? null,
-	});
-	// Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
-	// ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
-	// its hidden count from the global total gives an inconsistent `total` across pages
-	// and can return a short page while visible ops remain past the offset (a client
-	// treating "short page = end" would silently truncate the catalog). Pagination must
-	// run on the post-filter list.
+  // A `disabled` connector_action effect turns an operation OFF for this principal
+  // — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
+  // which surface then gate on execute). Two levels now: the BLANKET `execute` rule
+  // (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
+  // can disable a single op while the rest stay listed.
+  const actor = await resolveActingPrincipal(getDb(), {
+    organizationId: ctx.organizationId,
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    sessionWatcherId: ctx.actingWatcherId ?? null,
+  });
+  // Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
+  // ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
+  // its hidden count from the global total gives an inconsistent `total` across pages
+  // and can return a short page while visible ops remain past the offset (a client
+  // treating "short page = end" would silently truncate the catalog). Pagination must
+  // run on the post-filter list.
 	// For an explicit connection, targetRows already performed the visibility and
 	// authorization lookup. Query the connector catalog by that row's key instead
 	// of applying listOperations' legacy per-connection action-mode filter; the
@@ -890,23 +890,23 @@ async function handleListAvailable(
 		args.connection_id !== undefined
 			? targetRows[0]?.connector_key
 			: args.connector_key;
-	const full = await listOperations({
-		organizationId: ctx.organizationId,
+  const full = await listOperations({
+    organizationId: ctx.organizationId,
 		connectorKey: catalogConnectorKey,
-		entityId: args.entity_id,
-		kind: args.kind,
-		backend: args.backend,
+    entityId: args.entity_id,
+    kind: args.kind,
+    backend: args.backend,
 		// Required-input detection still needs the schema when the caller hides the
 		// descriptor copy from the public response.
 		includeInputSchema: true,
-		includeOutputSchema: args.include_output_schema ?? false,
-		// Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
-		// would silently drop ops past index 100 and make them unreachable at any
-		// caller offset. We must filter per-op-disabled across the full set BEFORE
-		// slicing, so no internal cap here; the caller's limit/offset apply below.
-		limit: Number.MAX_SAFE_INTEGER,
-		offset: 0,
-	});
+    includeOutputSchema: args.include_output_schema ?? false,
+    // Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
+    // would silently drop ops past index 100 and make them unreachable at any
+    // caller offset. We must filter per-op-disabled across the full set BEFORE
+    // slicing, so no internal cap here; the caller's limit/offset apply below.
+    limit: Number.MAX_SAFE_INTEGER,
+    offset: 0,
+  });
 	const qualifiedWriteKeys = full.operations
 		.filter((operation) => operation.kind === "write")
 		.map((operation) =>
@@ -924,20 +924,20 @@ async function handleListAvailable(
 	});
 	const blanketDisabled = policyEffects.get(null) === "disabled";
 
-	// Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
-	// filtered by agent write-policy. Humans always resolve auto for policy.
+  // Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
+  // filtered by agent write-policy. Humans always resolve auto for policy.
 	const visibleFlags = full.operations.map((op) => {
-		if (op.kind === "read") return "auto" as const;
-		if (blanketDisabled) return "disabled" as const;
-		return (
-			policyEffects.get(
-				qualifiedOperationKey(op.connector_key, op.operation_key),
-			) ?? "auto"
-		);
-	});
+			if (op.kind === "read") return "auto" as const;
+			if (blanketDisabled) return "disabled" as const;
+			return (
+				policyEffects.get(
+					qualifiedOperationKey(op.connector_key, op.operation_key),
+				) ?? "auto"
+  );
+		});
 	const policyVisible = full.operations.filter(
 		(_op, i) => visibleFlags[i] !== "disabled",
-	);
+  );
 
 	const queryTokens = (args.query ?? "")
 		.toLocaleLowerCase()
@@ -964,15 +964,15 @@ async function handleListAvailable(
 			return operationMatchesQuery(operation, queryTokens);
 		});
 
-	const offset = args.offset ?? 0;
+  const offset = args.offset ?? 0;
 	const limit = args.limit ?? 100;
-	return {
+  return {
 		action: "list_available",
 		operations: publicOperations.slice(offset, offset + limit),
 		total: publicOperations.length,
-		limit,
-		offset,
-	};
+    limit,
+    offset,
+  };
 }
 
 // Poll `runs` until status flips to completed/failed/timeout or we hit
@@ -1162,36 +1162,36 @@ async function handleExecute(
 			});
 			const event = await insertEvent(
 				{
-					entityIds,
-					organizationId: ctx.organizationId,
-					originId: `run_${createdRunId}_pending`,
-					title: `${operation.name} — pending approval`,
-					content: `Agent requested operation: ${operation.name}`,
-					semanticType: "operation",
-					connectorKey: connection.connector_key,
-					connectionId: args.connection_id,
-					runId: createdRunId,
-					interactionType: "approval",
-					interactionStatus: "pending",
-					interactionInputSchema:
-						(operation.input_schema as Record<string, unknown> | undefined) ??
-						null,
-					interactionInput: input,
-					metadata: {
-						operation_key: operation.operation_key,
-						operation_name: operation.name,
-						action_key: operation.operation_key,
-						action_name: operation.name,
-						operation_input: input,
-						action_input: input,
-						input_schema: operation.input_schema ?? null,
-						status: "pending_approval",
+				entityIds,
+				organizationId: ctx.organizationId,
+				originId: `run_${createdRunId}_pending`,
+				title: `${operation.name} — pending approval`,
+				content: `Agent requested operation: ${operation.name}`,
+				semanticType: "operation",
+				connectorKey: connection.connector_key,
+				connectionId: args.connection_id,
+				runId: createdRunId,
+				interactionType: "approval",
+				interactionStatus: "pending",
+				interactionInputSchema:
+					(operation.input_schema as Record<string, unknown> | undefined) ??
+					null,
+				interactionInput: input,
+				metadata: {
+					operation_key: operation.operation_key,
+					operation_name: operation.name,
+					action_key: operation.operation_key,
+					action_name: operation.name,
+					operation_input: input,
+					action_input: input,
+					input_schema: operation.input_schema ?? null,
+					status: "pending_approval",
 						connection_name:
 							connection.display_name ?? connection.connector_key,
-						run_id: createdRunId,
-					},
-					authorName: ctx.clientId ?? "agent",
+					run_id: createdRunId,
 				},
+				authorName: ctx.clientId ?? "agent",
+			},
 				{ sql: tx },
 			);
 			return { runId: createdRunId, eventId: Number(event.id) };
@@ -1370,84 +1370,84 @@ async function handleListRuns(
 	args: Static<typeof ListRunsAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-	const sql = getDb();
-	const limit = args.limit ?? 20;
-	// Keyset pagination short-circuits offset whenever a cursor is supplied.
-	const hasCursor = args.before_id != null && args.before_created_at != null;
-	const offset = hasCursor ? 0 : (args.offset ?? 0);
+  const sql = getDb();
+  const limit = args.limit ?? 20;
+  // Keyset pagination short-circuits offset whenever a cursor is supplied.
+  const hasCursor = args.before_id != null && args.before_created_at != null;
+  const offset = hasCursor ? 0 : (args.offset ?? 0);
 
-	// Date-range bounds are validated up front so a bad value is a clean caller
-	// error instead of a mid-query Postgres cast failure.
-	for (const field of ["created_after", "created_before"] as const) {
-		const value = args[field];
-		if (value != null && Number.isNaN(Date.parse(value))) {
-			throw new ToolUserError(
-				`${field} must be an ISO 8601 timestamp (got '${value}')`,
-				400,
-			);
-		}
-	}
+  // Date-range bounds are validated up front so a bad value is a clean caller
+  // error instead of a mid-query Postgres cast failure.
+  for (const field of ["created_after", "created_before"] as const) {
+    const value = args[field];
+    if (value != null && Number.isNaN(Date.parse(value))) {
+      throw new ToolUserError(
+        `${field} must be an ISO 8601 timestamp (got '${value}')`,
+        400,
+      );
+    }
+  }
 
-	// Shared WHERE fragment so the count and page queries can't drift apart.
-	let where = sql`r.organization_id = ${ctx.organizationId}`;
-	if (args.run_types && args.run_types.length > 0) {
-		// fetch_types:false means JS arrays aren't auto-serialized — use the
-		// PG array-literal helpers (see db/client.ts).
-		where = sql`${where} AND r.run_type = ANY(${pgTextArray(args.run_types)}::text[])`;
-	} else {
-		// Default operational view: hide the chat-message transport lane (complete
-		// replies + per-delta streaming fragments) that otherwise buries real run
-		// history (#2051). Naming run_types explicitly opts back in.
-		where = sql`${where} AND r.run_type <> ALL(${pgTextArray([...LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES])}::text[])`;
-	}
-	// connection scope: scalar connection_id (REST/SDK), an explicit id list, or
-	// every connection pinned to a device.
-	if (args.connection_id != null) {
-		where = sql`${where} AND r.connection_id = ${args.connection_id}`;
-	}
-	if (args.connection_ids && args.connection_ids.length > 0) {
-		where = sql`${where} AND r.connection_id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
-	}
-	if (args.feed_ids && args.feed_ids.length > 0) {
-		where = sql`${where} AND r.feed_id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
-	}
-	if (args.device_worker_id) {
-		where = sql`${where} AND r.connection_id IN (
+  // Shared WHERE fragment so the count and page queries can't drift apart.
+  let where = sql`r.organization_id = ${ctx.organizationId}`;
+  if (args.run_types && args.run_types.length > 0) {
+    // fetch_types:false means JS arrays aren't auto-serialized — use the
+    // PG array-literal helpers (see db/client.ts).
+    where = sql`${where} AND r.run_type = ANY(${pgTextArray(args.run_types)}::text[])`;
+  } else {
+    // Default operational view: hide the chat-message transport lane (complete
+    // replies + per-delta streaming fragments) that otherwise buries real run
+    // history (#2051). Naming run_types explicitly opts back in.
+    where = sql`${where} AND r.run_type <> ALL(${pgTextArray([...LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES])}::text[])`;
+  }
+  // connection scope: scalar connection_id (REST/SDK), an explicit id list, or
+  // every connection pinned to a device.
+  if (args.connection_id != null) {
+    where = sql`${where} AND r.connection_id = ${args.connection_id}`;
+  }
+  if (args.connection_ids && args.connection_ids.length > 0) {
+    where = sql`${where} AND r.connection_id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
+  }
+  if (args.feed_ids && args.feed_ids.length > 0) {
+    where = sql`${where} AND r.feed_id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
+  }
+  if (args.device_worker_id) {
+    where = sql`${where} AND r.connection_id IN (
       SELECT id FROM connections
       WHERE device_worker_id = ${args.device_worker_id}
         AND organization_id = ${ctx.organizationId}
         AND deleted_at IS NULL
     )`;
-	}
-	if (args.connector_key) {
-		where = sql`${where} AND r.connector_key = ${args.connector_key}`;
-	}
-	if (args.operation_key) {
-		where = sql`${where} AND r.action_key = ${args.operation_key}`;
-	}
-	if (args.status) {
-		where = sql`${where} AND r.status = ${args.status}`;
-	}
-	if (args.created_after) {
-		where = sql`${where} AND r.created_at >= ${args.created_after}::timestamptz`;
-	}
-	if (args.created_before) {
-		where = sql`${where} AND r.created_at < ${args.created_before}::timestamptz`;
-	}
-	if (args.approval_status) {
-		where = sql`${where} AND r.approval_status = ${args.approval_status}`;
-	}
-	if (args.behavior_ids && args.behavior_ids.length > 0) {
-		where = sql`${where} AND r.watcher_id = ANY(${pgBigintArray(args.behavior_ids)}::bigint[])`;
-	}
+  }
+  if (args.connector_key) {
+    where = sql`${where} AND r.connector_key = ${args.connector_key}`;
+  }
+  if (args.operation_key) {
+    where = sql`${where} AND r.action_key = ${args.operation_key}`;
+  }
+  if (args.status) {
+    where = sql`${where} AND r.status = ${args.status}`;
+  }
+  if (args.created_after) {
+    where = sql`${where} AND r.created_at >= ${args.created_after}::timestamptz`;
+  }
+  if (args.created_before) {
+    where = sql`${where} AND r.created_at < ${args.created_before}::timestamptz`;
+  }
+  if (args.approval_status) {
+    where = sql`${where} AND r.approval_status = ${args.approval_status}`;
+  }
+  if (args.behavior_ids && args.behavior_ids.length > 0) {
+    where = sql`${where} AND r.watcher_id = ANY(${pgBigintArray(args.behavior_ids)}::bigint[])`;
+  }
 
-	const countQuery = sql`SELECT COUNT(*)::int AS total FROM runs r WHERE ${where}`;
+  const countQuery = sql`SELECT COUNT(*)::int AS total FROM runs r WHERE ${where}`;
 
-	let pageWhere = where;
-	if (hasCursor) {
-		pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
-	}
-	const query = sql`
+  let pageWhere = where;
+  if (hasCursor) {
+    pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
+  }
+  const query = sql`
     SELECT r.id, r.run_type, r.watcher_id, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.items_collected, r.checkpoint,
@@ -1463,32 +1463,32 @@ async function handleListRuns(
     LIMIT ${limit} OFFSET ${offset}
   `;
 
-	const [countResult, rows] = await Promise.all([countQuery, query]);
+  const [countResult, rows] = await Promise.all([countQuery, query]);
 
-	return {
+  return {
 		action: "list_runs",
-		runs: rows,
-		total: Number(countResult[0]?.total ?? 0),
-		limit,
-		offset,
-		has_more: rows.length === limit,
-	};
+    runs: rows,
+    total: Number(countResult[0]?.total ?? 0),
+    limit,
+    offset,
+    has_more: rows.length === limit,
+  };
 }
 
 async function handleGetRun(
 	args: Static<typeof GetRunAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-	const sql = getDb();
-	// Include 'internal' runs (builder / entity-change approvals), not just
-	// connector 'action' runs: list_runs surfaces them and approve/reject act on
-	// them, so a caller that can list and approve an internal run must be able to
-	// get_run it too. get_run must resolve ANY run_type that list_runs surfaces —
-	// action, internal, behavior, sync — not just action+internal. It uses the
-	// SAME excluded-types set as the list_runs default so the two can never drift:
-	// a run visible in the list is always fetchable here. Only the chat-message
-	// transport lane (the list's default exclusion) stays unfetchable.
-	const rows = await sql`
+  const sql = getDb();
+  // Include 'internal' runs (builder / entity-change approvals), not just
+  // connector 'action' runs: list_runs surfaces them and approve/reject act on
+  // them, so a caller that can list and approve an internal run must be able to
+  // get_run it too. get_run must resolve ANY run_type that list_runs surfaces —
+  // action, internal, behavior, sync — not just action+internal. It uses the
+  // SAME excluded-types set as the list_runs default so the two can never drift:
+  // a run visible in the list is always fetchable here. Only the chat-message
+  // transport lane (the list's default exclusion) stays unfetchable.
+  const rows = await sql`
     SELECT r.id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.run_type,
@@ -1512,9 +1512,9 @@ async function handleGetRun(
  * (e.g. a worker completing a device action it was told to run).
  */
 export interface ApprovalReviewer {
-	userId: string;
-	/** Display name resolved at decision time; falls back to userId when unknown. */
-	name: string | null;
+  userId: string;
+  /** Display name resolved at decision time; falls back to userId when unknown. */
+  name: string | null;
 }
 
 export async function supersedeActionEvent(
@@ -1527,8 +1527,8 @@ export async function supersedeActionEvent(
 	reviewer: ApprovalReviewer | null = null,
 	db: DbClient = getDb(),
 ): Promise<number | undefined> {
-	const sql = db;
-	const originalEvent = await sql`
+  const sql = db;
+  const originalEvent = await sql`
     SELECT id, entity_ids, connection_id, connector_key, metadata, author_name, interaction_input_schema, interaction_input
     FROM current_event_records
     WHERE run_id = ${runId}
@@ -1556,67 +1556,67 @@ export async function supersedeActionEvent(
 
 	const nextEvent = await insertEvent(
 		{
-			entityIds: Array.isArray(orig.entity_ids)
-				? orig.entity_ids.map(Number)
-				: [],
-			organizationId,
-			originId: `run_${runId}_${status}_${Date.now()}`,
-			title,
-			content,
-			semanticType: "operation",
-			connectorKey: orig.connector_key,
-			connectionId: orig.connection_id,
-			runId,
-			interactionType: "approval",
-			interactionStatus:
-				status === "confirmed"
-					? "approved"
-					: status === "rejected"
-						? "rejected"
-						: status === "completed"
-							? "completed"
-							: status === "failed"
-								? "failed"
-								: "pending",
-			interactionInputSchema:
+		entityIds: Array.isArray(orig.entity_ids)
+			? orig.entity_ids.map(Number)
+			: [],
+		organizationId,
+		originId: `run_${runId}_${status}_${Date.now()}`,
+		title,
+		content,
+		semanticType: "operation",
+		connectorKey: orig.connector_key,
+		connectionId: orig.connection_id,
+		runId,
+		interactionType: "approval",
+		interactionStatus:
+			status === "confirmed"
+				? "approved"
+				: status === "rejected"
+					? "rejected"
+					: status === "completed"
+						? "completed"
+						: status === "failed"
+							? "failed"
+							: "pending",
+		interactionInputSchema:
 				(orig.interaction_input_schema as Record<string, unknown> | null) ??
 				null,
-			interactionInput:
-				(orig.interaction_input as Record<string, unknown> | null) ?? null,
-			interactionOutput:
-				((extraMetadata.output ?? extraMetadata.action_output) as
-					| Record<string, unknown>
-					| undefined) ?? null,
-			interactionError:
-				(extraMetadata.error_message as string | undefined) ?? null,
-			supersedesEventId: Number(orig.id),
-			// The durable identity (FK → user); set on the first decision event and
-			// preserved down the chain.
-			createdBy: reviewedById,
-			metadata: {
-				...priorMetadata,
-				status,
-				...(reviewedById ? { reviewed_by_id: reviewedById } : {}),
-				...(reviewedByName ? { reviewed_by_name: reviewedByName } : {}),
+		interactionInput:
+			(orig.interaction_input as Record<string, unknown> | null) ?? null,
+		interactionOutput:
+			((extraMetadata.output ?? extraMetadata.action_output) as
+				| Record<string, unknown>
+				| undefined) ?? null,
+		interactionError:
+			(extraMetadata.error_message as string | undefined) ?? null,
+		supersedesEventId: Number(orig.id),
+		// The durable identity (FK → user); set on the first decision event and
+		// preserved down the chain.
+		createdBy: reviewedById,
+		metadata: {
+			...priorMetadata,
+			status,
+			...(reviewedById ? { reviewed_by_id: reviewedById } : {}),
+			...(reviewedByName ? { reviewed_by_name: reviewedByName } : {}),
 				...(extraMetadata.output
 					? { action_output: extraMetadata.output }
 					: {}),
-				...(extraMetadata.error_message
-					? { error_message: extraMetadata.error_message }
-					: {}),
-				...extraMetadata,
-				// Superseding copies the prior metadata forward, so a durable approval
-				// written before the Behaviors rename (#2034) would keep minting NEW
-				// rows carrying `resourceKind: "watcher"` every time it is resolved.
-				// Canonicalize on write: history keeps whatever it recorded, but nothing
-				// emitted from here reintroduces the pre-rename value. Must stay below
-				// both spreads so neither the prior row nor a caller can restore it.
-				...(priorMetadata.resourceKind === "watcher" ||
-				extraMetadata.resourceKind === "watcher"
-					? { resourceKind: "behavior" }
-					: {}),
-			},
-			authorName: orig.author_name ?? null,
+			...(extraMetadata.error_message
+				? { error_message: extraMetadata.error_message }
+				: {}),
+			...extraMetadata,
+			// Superseding copies the prior metadata forward, so a durable approval
+			// written before the Behaviors rename (#2034) would keep minting NEW
+			// rows carrying `resourceKind: "watcher"` every time it is resolved.
+			// Canonicalize on write: history keeps whatever it recorded, but nothing
+			// emitted from here reintroduces the pre-rename value. Must stay below
+			// both spreads so neither the prior row nor a caller can restore it.
+			...(priorMetadata.resourceKind === "watcher" ||
+			extraMetadata.resourceKind === "watcher"
+				? { resourceKind: "behavior" }
+				: {}),
+		},
+		authorName: orig.author_name ?? null,
 		},
 		{ sql },
 	);
@@ -1632,11 +1632,11 @@ export async function supersedeActionEvent(
 async function resolveReviewer(
 	ctx: ToolContext,
 ): Promise<ApprovalReviewer | null> {
-	if (!ctx.userId) return null;
-	const rows = await getDb()<{ name: string | null }>`
+  if (!ctx.userId) return null;
+  const rows = await getDb()<{ name: string | null }>`
     SELECT name FROM "user" WHERE id = ${ctx.userId} LIMIT 1
   `;
-	return { userId: ctx.userId, name: rows[0]?.name ?? null };
+  return { userId: ctx.userId, name: rows[0]?.name ?? null };
 }
 
 /**
@@ -1978,7 +1978,7 @@ async function claimEntityChangeRun(
             AND action_key = ANY(${actionKeys}::text[])
           RETURNING action_input
         `
-			: await sql`
+      : await sql`
           UPDATE runs
           SET approval_status = 'rejected', status = 'cancelled',
               error_message = ${rejectReason ?? "Rejected by user"}, completed_at = NOW()
@@ -3019,7 +3019,7 @@ async function handleRejectBatch(
 					? "No pending proposals for this run."
 					: "No pending approvals matched this scope."
 				: args.window_id !== undefined
-					? `Rejected ${rejected} proposals. The Behavior's next run will see this feedback and revise.`
+				? `Rejected ${rejected} proposals. The Behavior's next run will see this feedback and revise.`
 					: `Rejected ${rejected} queued operations.`,
 	};
 }

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -119,14 +119,14 @@ type InlineExecutionResult =
 	| { status: "failed"; error_message: string };
 
 type ConnectionRow = {
-  id: number;
-  connector_key: string;
-  status: string;
-  auth_profile_id: number | null;
-  app_auth_profile_id: number | null;
-  display_name: string | null;
-  config: Record<string, unknown> | null;
-  name: string;
+	id: number;
+	connector_key: string;
+	status: string;
+	auth_profile_id: number | null;
+	app_auth_profile_id: number | null;
+	display_name: string | null;
+	config: Record<string, unknown> | null;
+	name: string;
 };
 
 type ExecutionTarget = {
@@ -172,22 +172,22 @@ type OperationTargetRow = {
  * separates because operation keys themselves contain dots (`slack.send_message`).
  */
 export function qualifiedOperationKey(
-  connectorKey: string,
-  operationKey: string,
+	connectorKey: string,
+	operationKey: string,
 ): string {
-  return `${connectorKey}::${operationKey}`;
+	return `${connectorKey}::${operationKey}`;
 }
 
 const manageOperationsTool = defineActionTool("manage_operations", {
-  list_available: action(ListAvailableAction, handleListAvailable),
-  execute: action(ExecuteAction, handleExecute),
-  list_runs: action(ListRunsAction, handleListRuns),
-  get_run: action(GetRunAction, handleGetRun),
-  list_activity: action(ListActivityAction, handleListActivity),
-  approve: action(ApproveAction, handleApprove),
-  reject: action(RejectAction, handleReject),
-  approve_batch: action(ApproveBatchAction, handleApproveBatch),
-  reject_batch: action(RejectBatchAction, handleRejectBatch),
+	list_available: action(ListAvailableAction, handleListAvailable),
+	execute: action(ExecuteAction, handleExecute),
+	list_runs: action(ListRunsAction, handleListRuns),
+	get_run: action(GetRunAction, handleGetRun),
+	list_activity: action(ListActivityAction, handleListActivity),
+	approve: action(ApproveAction, handleApprove),
+	reject: action(RejectAction, handleReject),
+	approve_batch: action(ApproveBatchAction, handleApproveBatch),
+	reject_batch: action(RejectBatchAction, handleRejectBatch),
 });
 
 export { ManageOperationsResultSchema, ManageOperationsSchema };
@@ -350,32 +350,32 @@ async function executeMcpToolInline(
 			status: "failed",
 			error_message: "Invalid MCP operation backend config",
 		};
-  }
+	}
 
 	let result: Awaited<ReturnType<typeof callProxyTool>>;
 	try {
 		result = await callProxyTool(
-    connection.connector_key,
-    {
-      upstream_url: operation.backend_config.upstreamUrl,
+			connection.connector_key,
+			{
+				upstream_url: operation.backend_config.upstreamUrl,
 				tool_prefix: "",
-    },
-    organizationId,
-    operation.backend_config.toolName,
+			},
+			organizationId,
+			operation.backend_config.toolName,
 			actionInput,
 			connection.id,
-  );
+		);
 	} catch (error) {
 		return failRunInline(runId, organizationId, getErrorMessage(error));
 	}
 
-  if (result.isError) {
-    const errorText =
-      (result.content as Array<{ type: string; text?: string }>).find(
+	if (result.isError) {
+		const errorText =
+			(result.content as Array<{ type: string; text?: string }>).find(
 				(item) => item?.type === "text",
 			)?.text ?? "Upstream MCP error";
-    return failRunInline(runId, organizationId, errorText);
-  }
+		return failRunInline(runId, organizationId, errorText);
+	}
 
 	return completeRunInline(runId, organizationId, {
 		content: result.content,
@@ -392,16 +392,16 @@ async function executeOperationInline(
 	abortSignal?: AbortSignal,
 ): Promise<InlineExecutionResult> {
 	if (operation.backend === "local_action") {
-    return executeLocalActionInline(
-      runId,
-      organizationId,
-      connection,
-      operation,
-      actionInput,
-      env,
+		return executeLocalActionInline(
+			runId,
+			organizationId,
+			connection,
+			operation,
+			actionInput,
+			env,
 			abortSignal,
-    );
-  }
+		);
+	}
 	if (operation.backend === "mcp_tool") {
 		return executeMcpToolInline(
 			runId,
@@ -410,7 +410,7 @@ async function executeOperationInline(
 			operation,
 			actionInput,
 		);
-  }
+	}
 	return executeHttpOperation(
 		runId,
 		organizationId,
@@ -761,8 +761,7 @@ function buildAvailableOperation(args: {
 			remediationTarget,
 			remediationConfig: remediationInternalTarget?.config,
 			remediationAuthKind: remediationInternalTarget?.auth_profile_kind,
-			remediationAuthProfileSlug:
-				remediationInternalTarget?.auth_profile_slug,
+			remediationAuthProfileSlug: remediationInternalTarget?.auth_profile_slug,
 			missingScopes,
 			requestedScopes: remediationInternalTarget?.requested_scopes ?? [],
 			viewUrl,
@@ -865,23 +864,23 @@ async function handleListAvailable(
 
 	const targetsByConnector = groupExecutionTargets(targetRows);
 
-  // A `disabled` connector_action effect turns an operation OFF for this principal
-  // — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
-  // which surface then gate on execute). Two levels now: the BLANKET `execute` rule
-  // (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
-  // can disable a single op while the rest stay listed.
-  const actor = await resolveActingPrincipal(getDb(), {
-    organizationId: ctx.organizationId,
-    userId: ctx.userId,
-    agentId: ctx.agentId,
-    sessionWatcherId: ctx.actingWatcherId ?? null,
-  });
-  // Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
-  // ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
-  // its hidden count from the global total gives an inconsistent `total` across pages
-  // and can return a short page while visible ops remain past the offset (a client
-  // treating "short page = end" would silently truncate the catalog). Pagination must
-  // run on the post-filter list.
+	// A `disabled` connector_action effect turns an operation OFF for this principal
+	// — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
+	// which surface then gate on execute). Two levels now: the BLANKET `execute` rule
+	// (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
+	// can disable a single op while the rest stay listed.
+	const actor = await resolveActingPrincipal(getDb(), {
+		organizationId: ctx.organizationId,
+		userId: ctx.userId,
+		agentId: ctx.agentId,
+		sessionWatcherId: ctx.actingWatcherId ?? null,
+	});
+	// Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
+	// ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
+	// its hidden count from the global total gives an inconsistent `total` across pages
+	// and can return a short page while visible ops remain past the offset (a client
+	// treating "short page = end" would silently truncate the catalog). Pagination must
+	// run on the post-filter list.
 	// For an explicit connection, targetRows already performed the visibility and
 	// authorization lookup. Query the connector catalog by that row's key instead
 	// of applying listOperations' legacy per-connection action-mode filter; the
@@ -891,23 +890,23 @@ async function handleListAvailable(
 		args.connection_id !== undefined
 			? targetRows[0]?.connector_key
 			: args.connector_key;
-  const full = await listOperations({
-    organizationId: ctx.organizationId,
+	const full = await listOperations({
+		organizationId: ctx.organizationId,
 		connectorKey: catalogConnectorKey,
-    entityId: args.entity_id,
-    kind: args.kind,
-    backend: args.backend,
+		entityId: args.entity_id,
+		kind: args.kind,
+		backend: args.backend,
 		// Required-input detection still needs the schema when the caller hides the
 		// descriptor copy from the public response.
 		includeInputSchema: true,
-    includeOutputSchema: args.include_output_schema ?? false,
-    // Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
-    // would silently drop ops past index 100 and make them unreachable at any
-    // caller offset. We must filter per-op-disabled across the full set BEFORE
-    // slicing, so no internal cap here; the caller's limit/offset apply below.
-    limit: Number.MAX_SAFE_INTEGER,
-    offset: 0,
-  });
+		includeOutputSchema: args.include_output_schema ?? false,
+		// Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
+		// would silently drop ops past index 100 and make them unreachable at any
+		// caller offset. We must filter per-op-disabled across the full set BEFORE
+		// slicing, so no internal cap here; the caller's limit/offset apply below.
+		limit: Number.MAX_SAFE_INTEGER,
+		offset: 0,
+	});
 	const qualifiedWriteKeys = full.operations
 		.filter((operation) => operation.kind === "write")
 		.map((operation) =>
@@ -925,20 +924,20 @@ async function handleListAvailable(
 	});
 	const blanketDisabled = policyEffects.get(null) === "disabled";
 
-  // Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
-  // filtered by agent write-policy. Humans always resolve auto for policy.
+	// Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
+	// filtered by agent write-policy. Humans always resolve auto for policy.
 	const visibleFlags = full.operations.map((op) => {
-			if (op.kind === "read") return "auto" as const;
-			if (blanketDisabled) return "disabled" as const;
-			return (
-				policyEffects.get(
-					qualifiedOperationKey(op.connector_key, op.operation_key),
-				) ?? "auto"
-  );
-		});
+		if (op.kind === "read") return "auto" as const;
+		if (blanketDisabled) return "disabled" as const;
+		return (
+			policyEffects.get(
+				qualifiedOperationKey(op.connector_key, op.operation_key),
+			) ?? "auto"
+		);
+	});
 	const policyVisible = full.operations.filter(
 		(_op, i) => visibleFlags[i] !== "disabled",
-  );
+	);
 
 	const queryTokens = (args.query ?? "")
 		.toLocaleLowerCase()
@@ -965,15 +964,15 @@ async function handleListAvailable(
 			return operationMatchesQuery(operation, queryTokens);
 		});
 
-  const offset = args.offset ?? 0;
+	const offset = args.offset ?? 0;
 	const limit = args.limit ?? 100;
-  return {
+	return {
 		action: "list_available",
 		operations: publicOperations.slice(offset, offset + limit),
 		total: publicOperations.length,
-    limit,
-    offset,
-  };
+		limit,
+		offset,
+	};
 }
 
 // Poll `runs` until status flips to completed/failed/timeout or we hit
@@ -1161,37 +1160,40 @@ async function handleExecute(
 				policyPrincipalId: actor.id,
 				db: tx,
 			});
-			const event = await insertEvent({
-				entityIds,
-				organizationId: ctx.organizationId,
-				originId: `run_${createdRunId}_pending`,
-				title: `${operation.name} — pending approval`,
-				content: `Agent requested operation: ${operation.name}`,
-				semanticType: "operation",
-				connectorKey: connection.connector_key,
-				connectionId: args.connection_id,
-				runId: createdRunId,
-				interactionType: "approval",
-				interactionStatus: "pending",
-				interactionInputSchema:
-					(operation.input_schema as Record<string, unknown> | undefined) ??
-					null,
-				interactionInput: input,
-				metadata: {
-					operation_key: operation.operation_key,
-					operation_name: operation.name,
-					action_key: operation.operation_key,
-					action_name: operation.name,
-					operation_input: input,
-					action_input: input,
-					input_schema: operation.input_schema ?? null,
-					status: "pending_approval",
-					connection_name: connection.display_name ?? connection.connector_key,
-					run_id: createdRunId,
+			const event = await insertEvent(
+				{
+					entityIds,
+					organizationId: ctx.organizationId,
+					originId: `run_${createdRunId}_pending`,
+					title: `${operation.name} — pending approval`,
+					content: `Agent requested operation: ${operation.name}`,
+					semanticType: "operation",
+					connectorKey: connection.connector_key,
+					connectionId: args.connection_id,
+					runId: createdRunId,
+					interactionType: "approval",
+					interactionStatus: "pending",
+					interactionInputSchema:
+						(operation.input_schema as Record<string, unknown> | undefined) ??
+						null,
+					interactionInput: input,
+					metadata: {
+						operation_key: operation.operation_key,
+						operation_name: operation.name,
+						action_key: operation.operation_key,
+						action_name: operation.name,
+						operation_input: input,
+						action_input: input,
+						input_schema: operation.input_schema ?? null,
+						status: "pending_approval",
+						connection_name:
+							connection.display_name ?? connection.connector_key,
+						run_id: createdRunId,
+					},
+					authorName: ctx.clientId ?? "agent",
 				},
-				authorName: ctx.clientId ?? "agent",
-			},
-			{ sql: tx });
+				{ sql: tx },
+			);
 			return { runId: createdRunId, eventId: Number(event.id) };
 		});
 
@@ -1368,84 +1370,84 @@ async function handleListRuns(
 	args: Static<typeof ListRunsAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-  const sql = getDb();
-  const limit = args.limit ?? 20;
-  // Keyset pagination short-circuits offset whenever a cursor is supplied.
-  const hasCursor = args.before_id != null && args.before_created_at != null;
-  const offset = hasCursor ? 0 : (args.offset ?? 0);
+	const sql = getDb();
+	const limit = args.limit ?? 20;
+	// Keyset pagination short-circuits offset whenever a cursor is supplied.
+	const hasCursor = args.before_id != null && args.before_created_at != null;
+	const offset = hasCursor ? 0 : (args.offset ?? 0);
 
-  // Date-range bounds are validated up front so a bad value is a clean caller
-  // error instead of a mid-query Postgres cast failure.
-  for (const field of ["created_after", "created_before"] as const) {
-    const value = args[field];
-    if (value != null && Number.isNaN(Date.parse(value))) {
-      throw new ToolUserError(
-        `${field} must be an ISO 8601 timestamp (got '${value}')`,
-        400,
-      );
-    }
-  }
+	// Date-range bounds are validated up front so a bad value is a clean caller
+	// error instead of a mid-query Postgres cast failure.
+	for (const field of ["created_after", "created_before"] as const) {
+		const value = args[field];
+		if (value != null && Number.isNaN(Date.parse(value))) {
+			throw new ToolUserError(
+				`${field} must be an ISO 8601 timestamp (got '${value}')`,
+				400,
+			);
+		}
+	}
 
-  // Shared WHERE fragment so the count and page queries can't drift apart.
-  let where = sql`r.organization_id = ${ctx.organizationId}`;
-  if (args.run_types && args.run_types.length > 0) {
-    // fetch_types:false means JS arrays aren't auto-serialized — use the
-    // PG array-literal helpers (see db/client.ts).
-    where = sql`${where} AND r.run_type = ANY(${pgTextArray(args.run_types)}::text[])`;
-  } else {
-    // Default operational view: hide the chat-message transport lane (complete
-    // replies + per-delta streaming fragments) that otherwise buries real run
-    // history (#2051). Naming run_types explicitly opts back in.
-    where = sql`${where} AND r.run_type <> ALL(${pgTextArray([...LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES])}::text[])`;
-  }
-  // connection scope: scalar connection_id (REST/SDK), an explicit id list, or
-  // every connection pinned to a device.
-  if (args.connection_id != null) {
-    where = sql`${where} AND r.connection_id = ${args.connection_id}`;
-  }
-  if (args.connection_ids && args.connection_ids.length > 0) {
-    where = sql`${where} AND r.connection_id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
-  }
-  if (args.feed_ids && args.feed_ids.length > 0) {
-    where = sql`${where} AND r.feed_id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
-  }
-  if (args.device_worker_id) {
-    where = sql`${where} AND r.connection_id IN (
+	// Shared WHERE fragment so the count and page queries can't drift apart.
+	let where = sql`r.organization_id = ${ctx.organizationId}`;
+	if (args.run_types && args.run_types.length > 0) {
+		// fetch_types:false means JS arrays aren't auto-serialized — use the
+		// PG array-literal helpers (see db/client.ts).
+		where = sql`${where} AND r.run_type = ANY(${pgTextArray(args.run_types)}::text[])`;
+	} else {
+		// Default operational view: hide the chat-message transport lane (complete
+		// replies + per-delta streaming fragments) that otherwise buries real run
+		// history (#2051). Naming run_types explicitly opts back in.
+		where = sql`${where} AND r.run_type <> ALL(${pgTextArray([...LIST_RUNS_DEFAULT_EXCLUDED_RUN_TYPES])}::text[])`;
+	}
+	// connection scope: scalar connection_id (REST/SDK), an explicit id list, or
+	// every connection pinned to a device.
+	if (args.connection_id != null) {
+		where = sql`${where} AND r.connection_id = ${args.connection_id}`;
+	}
+	if (args.connection_ids && args.connection_ids.length > 0) {
+		where = sql`${where} AND r.connection_id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
+	}
+	if (args.feed_ids && args.feed_ids.length > 0) {
+		where = sql`${where} AND r.feed_id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
+	}
+	if (args.device_worker_id) {
+		where = sql`${where} AND r.connection_id IN (
       SELECT id FROM connections
       WHERE device_worker_id = ${args.device_worker_id}
         AND organization_id = ${ctx.organizationId}
         AND deleted_at IS NULL
     )`;
-  }
-  if (args.connector_key) {
-    where = sql`${where} AND r.connector_key = ${args.connector_key}`;
-  }
-  if (args.operation_key) {
-    where = sql`${where} AND r.action_key = ${args.operation_key}`;
-  }
-  if (args.status) {
-    where = sql`${where} AND r.status = ${args.status}`;
-  }
-  if (args.created_after) {
-    where = sql`${where} AND r.created_at >= ${args.created_after}::timestamptz`;
-  }
-  if (args.created_before) {
-    where = sql`${where} AND r.created_at < ${args.created_before}::timestamptz`;
-  }
-  if (args.approval_status) {
-    where = sql`${where} AND r.approval_status = ${args.approval_status}`;
-  }
-  if (args.behavior_ids && args.behavior_ids.length > 0) {
-    where = sql`${where} AND r.watcher_id = ANY(${pgBigintArray(args.behavior_ids)}::bigint[])`;
-  }
+	}
+	if (args.connector_key) {
+		where = sql`${where} AND r.connector_key = ${args.connector_key}`;
+	}
+	if (args.operation_key) {
+		where = sql`${where} AND r.action_key = ${args.operation_key}`;
+	}
+	if (args.status) {
+		where = sql`${where} AND r.status = ${args.status}`;
+	}
+	if (args.created_after) {
+		where = sql`${where} AND r.created_at >= ${args.created_after}::timestamptz`;
+	}
+	if (args.created_before) {
+		where = sql`${where} AND r.created_at < ${args.created_before}::timestamptz`;
+	}
+	if (args.approval_status) {
+		where = sql`${where} AND r.approval_status = ${args.approval_status}`;
+	}
+	if (args.behavior_ids && args.behavior_ids.length > 0) {
+		where = sql`${where} AND r.watcher_id = ANY(${pgBigintArray(args.behavior_ids)}::bigint[])`;
+	}
 
-  const countQuery = sql`SELECT COUNT(*)::int AS total FROM runs r WHERE ${where}`;
+	const countQuery = sql`SELECT COUNT(*)::int AS total FROM runs r WHERE ${where}`;
 
-  let pageWhere = where;
-  if (hasCursor) {
-    pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
-  }
-  const query = sql`
+	let pageWhere = where;
+	if (hasCursor) {
+		pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
+	}
+	const query = sql`
     SELECT r.id, r.run_type, r.watcher_id, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.items_collected, r.checkpoint,
@@ -1461,32 +1463,32 @@ async function handleListRuns(
     LIMIT ${limit} OFFSET ${offset}
   `;
 
-  const [countResult, rows] = await Promise.all([countQuery, query]);
+	const [countResult, rows] = await Promise.all([countQuery, query]);
 
-  return {
+	return {
 		action: "list_runs",
-    runs: rows,
-    total: Number(countResult[0]?.total ?? 0),
-    limit,
-    offset,
-    has_more: rows.length === limit,
-  };
+		runs: rows,
+		total: Number(countResult[0]?.total ?? 0),
+		limit,
+		offset,
+		has_more: rows.length === limit,
+	};
 }
 
 async function handleGetRun(
 	args: Static<typeof GetRunAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-  const sql = getDb();
-  // Include 'internal' runs (builder / entity-change approvals), not just
-  // connector 'action' runs: list_runs surfaces them and approve/reject act on
-  // them, so a caller that can list and approve an internal run must be able to
-  // get_run it too. get_run must resolve ANY run_type that list_runs surfaces —
-  // action, internal, behavior, sync — not just action+internal. It uses the
-  // SAME excluded-types set as the list_runs default so the two can never drift:
-  // a run visible in the list is always fetchable here. Only the chat-message
-  // transport lane (the list's default exclusion) stays unfetchable.
-  const rows = await sql`
+	const sql = getDb();
+	// Include 'internal' runs (builder / entity-change approvals), not just
+	// connector 'action' runs: list_runs surfaces them and approve/reject act on
+	// them, so a caller that can list and approve an internal run must be able to
+	// get_run it too. get_run must resolve ANY run_type that list_runs surfaces —
+	// action, internal, behavior, sync — not just action+internal. It uses the
+	// SAME excluded-types set as the list_runs default so the two can never drift:
+	// a run visible in the list is always fetchable here. Only the chat-message
+	// transport lane (the list's default exclusion) stays unfetchable.
+	const rows = await sql`
     SELECT r.id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.run_type,
@@ -1510,9 +1512,9 @@ async function handleGetRun(
  * (e.g. a worker completing a device action it was told to run).
  */
 export interface ApprovalReviewer {
-  userId: string;
-  /** Display name resolved at decision time; falls back to userId when unknown. */
-  name: string | null;
+	userId: string;
+	/** Display name resolved at decision time; falls back to userId when unknown. */
+	name: string | null;
 }
 
 export async function supersedeActionEvent(
@@ -1525,8 +1527,8 @@ export async function supersedeActionEvent(
 	reviewer: ApprovalReviewer | null = null,
 	db: DbClient = getDb(),
 ): Promise<number | undefined> {
-  const sql = db;
-  const originalEvent = await sql`
+	const sql = db;
+	const originalEvent = await sql`
     SELECT id, entity_ids, connection_id, connector_key, metadata, author_name, interaction_input_schema, interaction_input
     FROM current_event_records
     WHERE run_id = ${runId}
@@ -1552,66 +1554,72 @@ export async function supersedeActionEvent(
 		(priorMetadata.reviewed_by_name as string | undefined) ??
 		null;
 
-	const nextEvent = await insertEvent({
-		entityIds: Array.isArray(orig.entity_ids)
-			? orig.entity_ids.map(Number)
-			: [],
-		organizationId,
-		originId: `run_${runId}_${status}_${Date.now()}`,
-		title,
-		content,
-		semanticType: "operation",
-		connectorKey: orig.connector_key,
-		connectionId: orig.connection_id,
-		runId,
-		interactionType: "approval",
-		interactionStatus:
-			status === "confirmed"
-				? "approved"
-				: status === "rejected"
-					? "rejected"
-					: status === "completed"
-						? "completed"
-						: status === "failed"
-							? "failed"
-							: "pending",
-		interactionInputSchema:
-			(orig.interaction_input_schema as Record<string, unknown> | null) ?? null,
-		interactionInput:
-			(orig.interaction_input as Record<string, unknown> | null) ?? null,
-		interactionOutput:
-			((extraMetadata.output ?? extraMetadata.action_output) as
-				| Record<string, unknown>
-				| undefined) ?? null,
-		interactionError:
-			(extraMetadata.error_message as string | undefined) ?? null,
-		supersedesEventId: Number(orig.id),
-		// The durable identity (FK → user); set on the first decision event and
-		// preserved down the chain.
-		createdBy: reviewedById,
-		metadata: {
-			...priorMetadata,
-			status,
-			...(reviewedById ? { reviewed_by_id: reviewedById } : {}),
-			...(reviewedByName ? { reviewed_by_name: reviewedByName } : {}),
-			...(extraMetadata.output ? { action_output: extraMetadata.output } : {}),
-			...(extraMetadata.error_message
-				? { error_message: extraMetadata.error_message }
-				: {}),
-			...extraMetadata,
-			// Superseding copies the prior metadata forward, so a durable approval
-			// written before the Behaviors rename (#2034) would keep minting NEW
-			// rows carrying `resourceKind: "watcher"` every time it is resolved.
-			// Canonicalize on write: history keeps whatever it recorded, but nothing
-			// emitted from here reintroduces the pre-rename value. Must stay below
-			// both spreads so neither the prior row nor a caller can restore it.
-			...(priorMetadata.resourceKind === "watcher" ||
-			extraMetadata.resourceKind === "watcher"
-				? { resourceKind: "behavior" }
-				: {}),
+	const nextEvent = await insertEvent(
+		{
+			entityIds: Array.isArray(orig.entity_ids)
+				? orig.entity_ids.map(Number)
+				: [],
+			organizationId,
+			originId: `run_${runId}_${status}_${Date.now()}`,
+			title,
+			content,
+			semanticType: "operation",
+			connectorKey: orig.connector_key,
+			connectionId: orig.connection_id,
+			runId,
+			interactionType: "approval",
+			interactionStatus:
+				status === "confirmed"
+					? "approved"
+					: status === "rejected"
+						? "rejected"
+						: status === "completed"
+							? "completed"
+							: status === "failed"
+								? "failed"
+								: "pending",
+			interactionInputSchema:
+				(orig.interaction_input_schema as Record<string, unknown> | null) ??
+				null,
+			interactionInput:
+				(orig.interaction_input as Record<string, unknown> | null) ?? null,
+			interactionOutput:
+				((extraMetadata.output ?? extraMetadata.action_output) as
+					| Record<string, unknown>
+					| undefined) ?? null,
+			interactionError:
+				(extraMetadata.error_message as string | undefined) ?? null,
+			supersedesEventId: Number(orig.id),
+			// The durable identity (FK → user); set on the first decision event and
+			// preserved down the chain.
+			createdBy: reviewedById,
+			metadata: {
+				...priorMetadata,
+				status,
+				...(reviewedById ? { reviewed_by_id: reviewedById } : {}),
+				...(reviewedByName ? { reviewed_by_name: reviewedByName } : {}),
+				...(extraMetadata.output
+					? { action_output: extraMetadata.output }
+					: {}),
+				...(extraMetadata.error_message
+					? { error_message: extraMetadata.error_message }
+					: {}),
+				...extraMetadata,
+				// Superseding copies the prior metadata forward, so a durable approval
+				// written before the Behaviors rename (#2034) would keep minting NEW
+				// rows carrying `resourceKind: "watcher"` every time it is resolved.
+				// Canonicalize on write: history keeps whatever it recorded, but nothing
+				// emitted from here reintroduces the pre-rename value. Must stay below
+				// both spreads so neither the prior row nor a caller can restore it.
+				...(priorMetadata.resourceKind === "watcher" ||
+				extraMetadata.resourceKind === "watcher"
+					? { resourceKind: "behavior" }
+					: {}),
+			},
+			authorName: orig.author_name ?? null,
 		},
-		authorName: orig.author_name ?? null,
-	}, { sql });
+		{ sql },
+	);
 
 	return Number(nextEvent.id);
 }
@@ -1624,11 +1632,11 @@ export async function supersedeActionEvent(
 async function resolveReviewer(
 	ctx: ToolContext,
 ): Promise<ApprovalReviewer | null> {
-  if (!ctx.userId) return null;
-  const rows = await getDb()<{ name: string | null }>`
+	if (!ctx.userId) return null;
+	const rows = await getDb()<{ name: string | null }>`
     SELECT name FROM "user" WHERE id = ${ctx.userId} LIMIT 1
   `;
-  return { userId: ctx.userId, name: rows[0]?.name ?? null };
+	return { userId: ctx.userId, name: rows[0]?.name ?? null };
 }
 
 /**
@@ -1970,7 +1978,7 @@ async function claimEntityChangeRun(
             AND action_key = ANY(${actionKeys}::text[])
           RETURNING action_input
         `
-      : await sql`
+			: await sql`
           UPDATE runs
           SET approval_status = 'rejected', status = 'cancelled',
               error_message = ${rejectReason ?? "Rejected by user"}, completed_at = NOW()
@@ -2347,7 +2355,9 @@ async function tryRejectEntityChangeRun(
 	if (!pending?.action_input) return null;
 	const reason = args.reason ?? "Rejected by user";
 	const reviewer = await resolveReviewer(ctx);
-	const reject = async (db: DbClient): Promise<ManageOperationsResult | null> => {
+	const reject = async (
+		db: DbClient,
+	): Promise<ManageOperationsResult | null> => {
 		const claimed = await claimEntityChangeRun(
 			args.run_id,
 			ctx.organizationId,
@@ -2756,7 +2766,9 @@ async function pendingActionRunIdsForScope(
 		where = sql`${where} AND r.action_key = ${scope.action_key}`;
 	}
 	if (scope.behavior_id !== undefined) {
-		where = sql`${where} AND r.watcher_id = ${scope.behavior_id}`;
+		where = sql`${where}
+      AND r.policy_principal_kind = 'watcher'
+      AND r.policy_principal_id = ${`watcher:${scope.behavior_id}`}`;
 	}
 	if (scope.older_than_days !== undefined) {
 		where = sql`${where} AND r.created_at < NOW() - (${scope.older_than_days}::int * interval '1 day')`;
@@ -2775,7 +2787,10 @@ async function pendingActionRunIdsForScope(
  * ambiguous which one bounded the blast radius.
  */
 async function resolveBatchRunIds(
-	args: { window_id?: number; scope?: Static<typeof ApproveBatchAction>["scope"] },
+	args: {
+		window_id?: number;
+		scope?: Static<typeof ApproveBatchAction>["scope"];
+	},
 	organizationId: string,
 ): Promise<number[] | { error: string }> {
 	if (args.window_id !== undefined && args.scope !== undefined) {
@@ -2817,12 +2832,27 @@ function batchRunSetChanged(
 }
 
 /**
+ * Check the entire batch before deciding its first row. A member may own one
+ * entity-change proposal in a window but not its siblings; checking only inside
+ * each single-run handler would mutate the owned prefix before a later authority
+ * failure aborted the request.
+ */
+async function requireBatchApprovalAuthority(
+	action: "approve" | "reject",
+	runIds: number[],
+	ctx: ToolContext,
+): Promise<void> {
+	for (const runId of runIds) {
+		await requireApprovalAuthority(action, runId, ctx);
+	}
+}
+
+/**
  * Approve every pending approval in one bounded target, in one action. Reuses
  * the single-run approve path per row so each still applies through its own
- * gate/apply handler — including {@link requireApprovalAuthority}, which THROWS
- * on an unauthorized caller and so aborts the whole batch rather than letting a
- * partial sweep through. The batch is purely the grouping, not a second code
- * path, so whoever may approve one is exactly who may bulk-approve.
+ * gate/apply handler. Authority is preflighted across the full set before the
+ * first mutation, then enforced again by each single-run path, so whoever may
+ * approve every row individually is exactly who may bulk-approve them.
  *
  * The target is either a window (a Behavior run's proposals) or an explicit
  * scope over queued connector operations. There is no unscoped variant: batch
@@ -2844,6 +2874,7 @@ async function handleApproveBatch(
 			error: batchSetChangedError(args.window_id !== undefined, "approving"),
 		};
 	}
+	await requireBatchApprovalAuthority("approve", runIds, ctx);
 	if (runIds.length === 0) {
 		return {
 			action: "approve_batch",
@@ -2874,7 +2905,7 @@ async function handleApproveBatch(
 		approved_count: approved,
 		failed_count: failed,
 		run_ids: runIds,
-		message: `Approved ${approved} of ${runIds.length} approvals${failed > 0 ? ` (${failed} failed)` : ""}.`,
+		message: `Approved ${approved} of ${runIds.length} ${args.window_id !== undefined ? "proposals" : "approvals"}${failed > 0 ? ` (${failed} failed)` : ""}.`,
 	};
 }
 
@@ -2931,6 +2962,7 @@ async function handleRejectBatch(
 			error: batchSetChangedError(args.window_id !== undefined, "rejecting"),
 		};
 	}
+	await requireBatchApprovalAuthority("reject", runIds, ctx);
 	const reason = args.reason ?? "Rejected by user";
 	let rejected = 0;
 	for (const runId of runIds) {

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -2715,6 +2715,95 @@ async function pendingRunIdsForWindow(
 	return rows.map((r) => Number(r.id));
 }
 
+/**
+ * Pending connector-operation approvals (`run_type='action'`) matching an
+ * explicit scope. This is the lane that accumulates — a queued operation nobody
+ * decided sits pending until the long-horizon expiry sweep takes it terminal
+ * (scheduled/expire-pending-approvals.ts).
+ *
+ * At least one narrowing filter is REQUIRED. Batch approve fires queued side
+ * effects en masse, so there is deliberately no "everything pending in the org"
+ * shape: the caller must name the connection, connector, operation, or Behavior
+ * they are deciding for. `older_than_days` only narrows further.
+ */
+async function pendingActionRunIdsForScope(
+	scope: NonNullable<Static<typeof ApproveBatchAction>["scope"]>,
+	organizationId: string,
+): Promise<number[] | { error: string }> {
+	const hasNarrowingFilter =
+		scope.connection_id !== undefined ||
+		scope.connector_key !== undefined ||
+		scope.action_key !== undefined ||
+		scope.behavior_id !== undefined;
+	if (!hasNarrowingFilter) {
+		return {
+			error:
+				"A batch decision must be scoped: provide at least one of connection_id, connector_key, action_key, or behavior_id. Approving every pending operation in the organization is not supported.",
+		};
+	}
+
+	const sql = getDb();
+	let where = sql`r.organization_id = ${organizationId}
+    AND r.approval_status = 'pending'
+    AND r.run_type = 'action'`;
+	if (scope.connection_id !== undefined) {
+		where = sql`${where} AND r.connection_id = ${scope.connection_id}`;
+	}
+	if (scope.connector_key !== undefined) {
+		where = sql`${where} AND r.connector_key = ${scope.connector_key}`;
+	}
+	if (scope.action_key !== undefined) {
+		where = sql`${where} AND r.action_key = ${scope.action_key}`;
+	}
+	if (scope.behavior_id !== undefined) {
+		where = sql`${where} AND r.watcher_id = ${scope.behavior_id}`;
+	}
+	if (scope.older_than_days !== undefined) {
+		where = sql`${where} AND r.created_at < NOW() - (${scope.older_than_days}::int * interval '1 day')`;
+	}
+
+	const rows = await sql<{ id: number }>`
+    SELECT r.id FROM runs r WHERE ${where} ORDER BY r.id ASC
+  `;
+	return rows.map((r) => Number(r.id));
+}
+
+/**
+ * Resolve the pending set a batch action targets, from whichever scope the
+ * caller supplied. Exactly one of `window_id` / `scope` is required — accepting
+ * neither would mean an unscoped sweep, and accepting both would leave it
+ * ambiguous which one bounded the blast radius.
+ */
+async function resolveBatchRunIds(
+	args: { window_id?: number; scope?: Static<typeof ApproveBatchAction>["scope"] },
+	organizationId: string,
+): Promise<number[] | { error: string }> {
+	if (args.window_id !== undefined && args.scope !== undefined) {
+		return {
+			error:
+				"Provide either window_id or scope, not both — the batch must have exactly one bounded target.",
+		};
+	}
+	if (args.window_id !== undefined) {
+		return pendingRunIdsForWindow(args.window_id, organizationId);
+	}
+	if (args.scope !== undefined) {
+		return pendingActionRunIdsForScope(args.scope, organizationId);
+	}
+	return {
+		error:
+			"A batch decision requires a target: pass window_id (a Behavior run's proposals) or scope (queued connector operations).",
+	};
+}
+
+/** Fail-closed message when the pending set moved under the reviewer. Named per
+ *  scope so a window batch still says "proposals" (what the reviewer saw) while
+ *  a scoped connector batch says "approvals". */
+function batchSetChangedError(isWindowScope: boolean, verb: string): string {
+	const noun = isWindowScope ? "Pending proposals" : "Pending approvals";
+	return `${noun} changed after this batch was loaded. Refresh before ${verb} the batch.`;
+}
+
 function batchRunSetChanged(
 	pendingRunIds: number[],
 	reviewedRunIds: number[] | undefined,
@@ -2728,9 +2817,17 @@ function batchRunSetChanged(
 }
 
 /**
- * Approve every pending proposal a watcher run produced, in one action. Reuses
- * the single-run approve path per proposal so each still applies through its own
- * gate/apply handler — the batch is purely the grouping, not a second code path.
+ * Approve every pending approval in one bounded target, in one action. Reuses
+ * the single-run approve path per row so each still applies through its own
+ * gate/apply handler — including {@link requireApprovalAuthority}, which THROWS
+ * on an unauthorized caller and so aborts the whole batch rather than letting a
+ * partial sweep through. The batch is purely the grouping, not a second code
+ * path, so whoever may approve one is exactly who may bulk-approve.
+ *
+ * The target is either a window (a Behavior run's proposals) or an explicit
+ * scope over queued connector operations. There is no unscoped variant: batch
+ * approve fires real side effects en masse, so the blast radius must always be
+ * named by the caller.
  */
 async function handleApproveBatch(
 	args: Static<typeof ApproveBatchAction>,
@@ -2739,24 +2836,25 @@ async function handleApproveBatch(
 ): Promise<ManageOperationsResult> {
 	const humanGate = requireHumanApprovalContext(ctx, "approve");
 	if (humanGate) return humanGate;
-	const runIds = await pendingRunIdsForWindow(
-		args.window_id,
-		ctx.organizationId,
-	);
+	const resolved = await resolveBatchRunIds(args, ctx.organizationId);
+	if (!Array.isArray(resolved)) return resolved;
+	const runIds = resolved;
 	if (batchRunSetChanged(runIds, args.run_ids)) {
 		return {
-			error:
-				"Pending proposals changed after this run was loaded. Refresh before approving the batch.",
+			error: batchSetChangedError(args.window_id !== undefined, "approving"),
 		};
 	}
 	if (runIds.length === 0) {
 		return {
 			action: "approve_batch",
-			window_id: args.window_id,
+			...(args.window_id !== undefined ? { window_id: args.window_id } : {}),
 			approved_count: 0,
 			failed_count: 0,
 			run_ids: [],
-			message: "No pending proposals for this run.",
+			message:
+				args.window_id !== undefined
+					? "No pending proposals for this run."
+					: "No pending approvals matched this scope.",
 		};
 	}
 	let approved = 0;
@@ -2772,11 +2870,11 @@ async function handleApproveBatch(
 	}
 	return {
 		action: "approve_batch",
-		window_id: args.window_id,
+		...(args.window_id !== undefined ? { window_id: args.window_id } : {}),
 		approved_count: approved,
 		failed_count: failed,
 		run_ids: runIds,
-		message: `Approved ${approved} of ${runIds.length} proposals${failed > 0 ? ` (${failed} failed)` : ""}.`,
+		message: `Approved ${approved} of ${runIds.length} approvals${failed > 0 ? ` (${failed} failed)` : ""}.`,
 	};
 }
 
@@ -2825,14 +2923,12 @@ async function handleRejectBatch(
 ): Promise<ManageOperationsResult> {
 	const humanGate = requireHumanApprovalContext(ctx, "reject");
 	if (humanGate) return humanGate;
-	const runIds = await pendingRunIdsForWindow(
-		args.window_id,
-		ctx.organizationId,
-	);
+	const resolved = await resolveBatchRunIds(args, ctx.organizationId);
+	if (!Array.isArray(resolved)) return resolved;
+	const runIds = resolved;
 	if (batchRunSetChanged(runIds, args.run_ids)) {
 		return {
-			error:
-				"Pending proposals changed after this run was loaded. Refresh before rejecting the batch.",
+			error: batchSetChangedError(args.window_id !== undefined, "rejecting"),
 		};
 	}
 	const reason = args.reason ?? "Rejected by user";
@@ -2844,7 +2940,12 @@ async function handleRejectBatch(
 		);
 		if (!("error" in result)) rejected += 1;
 	}
-	if (rejected > 0) {
+	// The `correction` feedback event is a WINDOW concept — it is keyed to the
+	// watcher that produced the proposals so its next turn reads the rejection
+	// and revises. A scope-targeted batch over queued connector operations has no
+	// such producing run, so it records no correction; each rejected row still
+	// supersedes its own card through the single-run reject path.
+	if (rejected > 0 && args.window_id !== undefined) {
 		const { watcherId, entityIds } = await resolveWindowRevisionContext(
 			args.window_id,
 			ctx.organizationId,
@@ -2877,12 +2978,16 @@ async function handleRejectBatch(
 	}
 	return {
 		action: "reject_batch",
-		window_id: args.window_id,
+		...(args.window_id !== undefined ? { window_id: args.window_id } : {}),
 		rejected_count: rejected,
 		run_ids: runIds,
 		message:
-			rejected > 0
-				? `Rejected ${rejected} proposals. The Behavior's next run will see this feedback and revise.`
-				: "No pending proposals for this run.",
+			rejected === 0
+				? args.window_id !== undefined
+					? "No pending proposals for this run."
+					: "No pending approvals matched this scope."
+				: args.window_id !== undefined
+					? `Rejected ${rejected} proposals. The Behavior's next run will see this feedback and revise.`
+					: `Rejected ${rejected} queued operations.`,
 	};
 }


### PR DESCRIPTION
## Problem

Pending approvals accumulate **forever**. There was no expiry, no cleanup, and no `approval_status = 'expired'` transition anywhere in the codebase.

The cause is a correct decision that was never completed. Runs parked at `approval_status = 'pending'` are deliberately exempt from every reaper (`stale-run-sweeper.ts:137`, `AND approval_status <> 'pending'`) because #2044 established that force-timing-out a queued approval before a human can decide is wrong. That exclusion is right — but it was never paired with a **long-horizon** expiry, so approvals became permanently exempt from cleanup.

`approve_batch`/`reject_batch` already existed but were scoped only to `window_id` + `run_type='internal'` (Behavior proposals). The connector-operation lane (`run_type='action'`) — the one that actually accumulates — had no bulk path at all.

## Fix

**Expiry.** A daily sweep transitions approvals past a configurable TTL (default 7d, env-tunable) to a new terminal `expired` state. `expired` is deliberately **not** a reuse of `rejected`: rejection is a human decision that `reject_batch` mines into a `correction` event the Behavior learns from on its next turn. An agent must not train on silence as if it were disapproval.

Selection is **fair across organizations** — `ORDER BY org_rank, created_at` with a per-org cap, so every org's oldest row precedes any org's second row. Representation never depends on how many other orgs are backlogged. The sweep drains successive batches under a per-invocation ceiling. Run transition and card supersede share a transaction, so a failed event write leaves the run pending for the next sweep.

**Bulk decisions.** Extended the *existing* batch actions to the action lane rather than adding a parallel API. Bulk-approve requires explicit scoping (at least one of `connection_id`/`connector_key`/`action_key`/`behavior_id`); `scope: {}` is refused, and `window_id` + `scope` together is refused as ambiguous. The batch loops the single-run `handleApprove`, so `requireApprovalAuthority` runs per row and throws on an unauthorized caller rather than half-applying.

**Health.** `stalePendingApprovals` is surfaced, but only alarms past `TTL + one sweep interval` — a strict threshold would return 503 for up to 24h during expected daily-cron drift.

## Migration

Constraint swap runs `transaction:false` with a temp-named `NOT VALID` constraint validated in its own statement. In a single transaction the `ACCESS EXCLUSIVE` lock is held through the `VALIDATE` scan — measured on PG18 — which would stall a hot `runs` table. Each step is guarded for re-runnability, since `transaction:false` means a crash between steps must not wedge every retry. Squawk clean, no ignore directives.

## Testing

77 scheduled tests. Every guard verified **red** before green:

- **#2044 regression guard** (most important): replacing the exclusion with `AND TRUE` turns the approval-pending tests red at 1s, 50× the claim horizon, and 30 days. Independently re-verified.
- fairness: 14 older backlogged orgs + 1 newcomer — the newcomer got **0 rows** under the old global-age ordering
- drain past one batch; per-org cap; per-invocation ceiling
- health: just-past-TTL stays healthy, past-grace fails
- batch scope, authorization, org isolation

`make pre-pr` clean. `make review`: 0 bugs, 0 blockers, tests_adequate true.

## Note

No UI calls the new `scope` target yet — bulk-decide is agent/API-only until the approvals page wires it up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->