### PR TITLE
fix(security): stop leaking connection/feed config secrets on every read path

### DIFF
--- a/packages/core/src/utils/secret-redaction.ts
+++ b/packages/core/src/utils/secret-redaction.ts
@@ -1,15 +1,17 @@
 /**
- * Shared secret redaction for config audit surfaces.
+ * Shared secret redaction for config audit + serialization surfaces.
  *
- * One denylist, two consumers with one secret model between them:
+ * One denylist, three consumers with one secret model between them:
  *  - the server redacts config-change audit snapshots before persisting them
- *    (`packages/server/src/utils/config-redaction.ts`), and
+ *    (`packages/server/src/utils/config-redaction.ts`),
+ *  - the server redacts `connections.config` before it is serialized to any
+ *    caller (`packages/server/src/utils/connection-config-redaction.ts`), and
  *  - the CLI strips secret values out of the desired state before hashing it
  *    into a deployment's `manifest_hash` (`_lib/apply/deployment.ts`).
  *
- * Keeping both on this module means a key classified as secret is redacted
- * from stored snapshots AND excluded from the manifest hash in the same
- * release — they can't drift apart.
+ * Keeping all three on this module means a key classified as secret is
+ * redacted from stored snapshots, withheld from API responses, AND excluded
+ * from the manifest hash in the same release — they can't drift apart.
  */
 
 /**
@@ -23,19 +25,77 @@ export const REDACTED_SENTINEL = "__LOBU_REDACTED__";
  * Key-name denylist. Matches the whole key or a `_`-separated suffix,
  * singular or plural, any case: `token`, `apiKey`, `api_key`,
  * `refresh_tokens`, `clientSecret`, ...
+ *
+ * Anchoring on a `_`-separated SUFFIX (not a substring) is deliberate: it is
+ * what keeps `tokenizer`, `keyboard`, and `secretsPolicy` out of the denylist.
+ * Add a term here only if its suffix form is unambiguously a credential.
+ *
+ * `authorization` / `cookie` / `session_id` / `*_url`-style connection strings
+ * are NOT key-suffix matches on their own — they are covered below by
+ * {@link isSecretKey}'s exact-name set and by {@link redactUriCredentials}.
  */
 const SECRET_KEY_RE =
-  /(^|_)(token|secret|password|api_?key|credential|private_?key|refresh_?token|access_?token)s?$/i;
+  /(^|_)(token|secret|password|passwd|api_?key|credential|private_?key|refresh_?token|access_?token|client_?secret|session_?id|auth_?header)s?$/i;
+
+/**
+ * Exact key names (case-insensitive, after camel→snake normalization) that are
+ * credentials but do not end in a denylisted suffix. Kept separate from the
+ * suffix regex so a future `cookie_policy` or `authorization_mode` key isn't
+ * swept up by accident.
+ */
+const SECRET_EXACT_KEYS = new Set([
+  "authorization",
+  "auth",
+  "bearer",
+  "cookie",
+  "cookies",
+  "set_cookie",
+  "proxy_authorization",
+  "database_url",
+  "db_url",
+  "connection_string",
+  "dsn",
+]);
 
 /** camelCase → snake_case so `apiKey`/`privateKey` hit the `_`-anchored regex. */
+function normalizeKey(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
 export function isSecretKey(key: string): boolean {
-  return SECRET_KEY_RE.test(key.replace(/([a-z0-9])([A-Z])/g, "$1_$2"));
+  const normalized = normalizeKey(key);
+  return SECRET_EXACT_KEYS.has(normalized) || SECRET_KEY_RE.test(normalized);
+}
+
+/**
+ * `scheme://user:password@host/...` — the credential lives in the userinfo
+ * component, so the value is secret even when the KEY name is innocuous
+ * (`host`, `endpoint`, `primary`). Only the userinfo is replaced: the scheme
+ * and host stay readable so a UI can still show which database is wired up.
+ */
+const URI_CREDENTIAL_RE = /([a-z][a-z0-9+.-]*:\/\/)([^/\s@]+)@/gi;
+
+/**
+ * Replace the `user:password@` userinfo of any URI inside a string with the
+ * sentinel. Non-string input and strings with no credential-bearing URI pass
+ * through unchanged (identity), so this is safe to apply to every string.
+ */
+export function redactUriCredentials(value: string): string {
+  return value.replace(
+    URI_CREDENTIAL_RE,
+    (match, scheme: string, userinfo: string) =>
+      // A bare `host@` with no `:password` is not a credential (e.g. an email-ish
+      // path segment); only redact when a password component is present.
+      userinfo.includes(":") ? `${scheme}${REDACTED_SENTINEL}@` : match
+  );
 }
 
 /**
  * Deep-walk a JSON-ish value, replacing every non-null value under a
  * denylisted key with REDACTED_SENTINEL. Arrays and nested objects are
- * walked; primitives pass through untouched.
+ * walked; string primitives additionally have any embedded URI credential
+ * stripped, so a `postgres://u:pw@host/db` never survives under a
+ * non-denylisted key.
  */
 export function deepRedactSecrets(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(deepRedactSecrets);
@@ -49,5 +109,6 @@ export function deepRedactSecrets(value: unknown): unknown {
     }
     return out;
   }
+  if (typeof value === "string") return redactUriCredentials(value);
   return value;
 }

--- a/packages/core/src/utils/secret-redaction.ts
+++ b/packages/core/src/utils/secret-redaction.ts
@@ -77,7 +77,12 @@ export function isSecretKey(key: string): boolean {
  * (`host`, `endpoint`, `primary`). Only the userinfo is replaced: the scheme
  * and host stay readable so a UI can still show which database is wired up.
  */
-const URI_CREDENTIAL_RE = /([a-z][a-z0-9+.-]*:\/\/)([^/\s@]+)@/gi;
+// The scheme repetition is bounded ({0,63}, i.e. schemes up to 64 chars — far
+// longer than any real URI scheme) rather than `*`: an unbounded quantifier
+// re-scans at every start offset on adversarial input (e.g. a long run of 'a's
+// with no `://`), which is a polynomial-ReDoS shape. A constant bound keeps the
+// per-offset work constant, so matching stays linear on untrusted config values.
+const URI_CREDENTIAL_RE = /([a-z][a-z0-9+.-]{0,63}:\/\/)([^/\s@]+)@/gi;
 
 /**
  * Replace the `user:password@` userinfo of any URI inside a string with the

--- a/packages/core/src/utils/secret-redaction.ts
+++ b/packages/core/src/utils/secret-redaction.ts
@@ -1,17 +1,17 @@
 /**
  * Shared secret redaction for config audit + serialization surfaces.
  *
- * One denylist, three consumers with one secret model between them:
+ * One denylist shared across TypeScript config exposures:
  *  - the server redacts config-change audit snapshots before persisting them
  *    (`packages/server/src/utils/config-redaction.ts`),
  *  - the server redacts `connections.config` before it is serialized to any
  *    caller (`packages/server/src/utils/connection-config-redaction.ts`), and
  *  - the CLI strips secret values out of the desired state before hashing it
- *    into a deployment's `manifest_hash` (`_lib/apply/deployment.ts`).
+ *    into a deployment's `manifest_hash` (`_lib/apply/deployment.ts`), while
+ *    setup continuations use the same classification when omitting credentials.
  *
- * Keeping all three on this module means a key classified as secret is
- * redacted from stored snapshots, withheld from API responses, AND excluded
- * from the manifest hash in the same release — they can't drift apart.
+ * A key classified here is therefore omitted or redacted consistently across
+ * persistence, API responses, setup continuations, and deployment hashes.
  */
 
 /**
@@ -22,9 +22,9 @@
 export const REDACTED_SENTINEL = "__LOBU_REDACTED__";
 
 /**
- * Key-name denylist. Matches the whole key or a `_`-separated suffix,
- * singular or plural, any case: `token`, `apiKey`, `api_key`,
- * `refresh_tokens`, `clientSecret`, ...
+ * Key-name denylist. After camel-case and separator normalization, matches the
+ * whole key or an `_`-separated suffix, singular or plural, any case: `token`,
+ * `apiKey`, `X-Api-Key`, `refresh_tokens`, `clientSecret`, ...
  *
  * Anchoring on a `_`-separated SUFFIX (not a substring) is deliberate: it is
  * what keeps `tokenizer`, `keyboard`, and `secretsPolicy` out of the denylist.
@@ -38,7 +38,7 @@ const SECRET_KEY_RE =
   /(^|_)(token|secret|password|passwd|api_?key|credential|private_?key|refresh_?token|access_?token|client_?secret|session_?id|auth_?header)s?$/i;
 
 /**
- * Exact key names (case-insensitive, after camel→snake normalization) that are
+ * Exact key names (case-insensitive, after key normalization) that are
  * credentials but do not end in a denylisted suffix. Kept separate from the
  * suffix regex so a future `cookie_policy` or `authorization_mode` key isn't
  * swept up by accident.
@@ -57,9 +57,13 @@ const SECRET_EXACT_KEYS = new Set([
   "dsn",
 ]);
 
-/** camelCase → snake_case so `apiKey`/`privateKey` hit the `_`-anchored regex. */
+/** Normalize camelCase and separators so config keys and HTTP headers agree. */
 function normalizeKey(key: string): string {
-  return key.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
 }
 
 export function isSecretKey(key: string): boolean {

--- a/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
+++ b/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
@@ -1,3 +1,4 @@
+import { REDACTED_SENTINEL } from "@lobu/core";
 import { beforeAll, describe, expect, it } from "vitest";
 import { querySql } from "../../tools/admin/query_sql";
 import type { ToolContext } from "../../tools/registry";
@@ -244,5 +245,223 @@ describe("connection config redaction", () => {
 			memberCtx,
 		);
 		assertNoSecrets(result, "query_sql SELECT config FROM feeds");
+	});
+});
+
+/**
+ * `manage_feeds` serializes `f.*`, which carries two columns that must not
+ * reach a caller:
+ *
+ *  - `checkpoint` — the connector's opaque sync cursor. `table-schema.ts`
+ *    already names it as a column query_sql must never emit; these tools should
+ *    not be a way around that, and cursors have historically carried tokens and
+ *    whole result payloads.
+ *  - `config` — free-form jsonb. No SHIPPED connector routes a credential into
+ *    feed-scoped config today, so this arm is hardening rather than a live
+ *    leak — pinned so it stays that way.
+ *
+ * All three read actions are in the same exposure tier as the connection
+ * list/get paths, so all three are asserted.
+ */
+describe("feed config redaction", () => {
+	let workspace: TestWorkspace;
+	let feedId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		workspace = await TestWorkspace.create({
+			name: "Feed Redaction Org",
+			visibility: "public",
+		});
+
+		const connection = await createTestConnection({
+			organization_id: workspace.org.id,
+			connector_key: "postgres",
+			display_name: "Feedful Postgres",
+			created_by: workspace.users.owner.id,
+			visibility: "org",
+		});
+
+		// createTestConnection makes a 'default' feed; plant the probes plus a
+		// checkpoint into it.
+		const rows = await getTestDb()`
+      UPDATE feeds
+      SET config = ${getTestDb().json({ ...SECRET_PROBES, host: "db.internal" })}::jsonb,
+          checkpoint = ${getTestDb().json({ cursor: "pw-LEAK-checkpoint" })}::jsonb
+      WHERE connection_id = ${Number(connection.id)}
+      RETURNING id
+    `;
+		feedId = Number((rows[0] as { id: number }).id);
+	});
+
+	it("does not leak feed secrets or checkpoint through feeds.list()", async () => {
+		const result = await workspace.owner.feeds.list({});
+		assertNoSecrets(result, "feeds.list()");
+		expect(JSON.stringify(result)).not.toContain("pw-LEAK-checkpoint");
+		expect(JSON.stringify(result)).not.toContain("checkpoint");
+	});
+
+	it("does not leak feed secrets or checkpoint through feeds.get()", async () => {
+		const result = await workspace.owner.feeds.get({ feed_id: feedId });
+		assertNoSecrets(result, "feeds.get()");
+		expect(JSON.stringify(result)).not.toContain("pw-LEAK-checkpoint");
+
+		// Redaction, not suppression — non-secret config survives.
+		const feed = (result as { feed?: { config?: Record<string, unknown> } })
+			.feed;
+		expect(feed?.config?.host).toBe("db.internal");
+	});
+
+	it("does not leak feed secrets or checkpoint through feeds.readMany()", async () => {
+		const result = await workspace.owner.feeds.readMany({ feed_ids: [feedId] });
+		assertNoSecrets(result, "feeds.readMany()");
+		expect(JSON.stringify(result)).not.toContain("pw-LEAK-checkpoint");
+	});
+
+	it("preserves the stored feed secret when a redacted config is PATCHed back", async () => {
+		const read = (await workspace.owner.feeds.get({ feed_id: feedId })) as {
+			feed?: { config?: Record<string, unknown> };
+		};
+		const fetched = read.feed?.config ?? {};
+		expect(JSON.stringify(fetched)).toContain(REDACTED_SENTINEL);
+
+		await workspace.owner.feeds.update({
+			feed_id: feedId,
+			config: { ...fetched, host: "db.updated" },
+		});
+
+		const rows = await getTestDb()`
+      SELECT config FROM feeds WHERE id = ${feedId}
+    `;
+		const stored = (rows[0] as { config: Record<string, unknown> }).config;
+		expect(stored.host).toBe("db.updated");
+		expect(stored.password).toBe(SECRET_PROBES.password);
+		expect(stored.DATABASE_URL).toBe(SECRET_PROBES.DATABASE_URL);
+	});
+});
+
+/**
+ * Redaction must not DESTROY the value it hides.
+ *
+ * Every real client round-trips config: the Owletto action-modes editor
+ * (connection-settings-tab.tsx) spreads the FETCHED connection.config and
+ * PATCHes it straight back with one field changed, and an agent calling
+ * `connections.update` via run_sdk does the same. Once the read path returns
+ * `__LOBU_REDACTED__` in place of a secret, that write path would persist the
+ * SENTINEL over the real credential — the connection breaks at next use, with
+ * no error at save time and no way to recover the plaintext.
+ *
+ * That failure mode is strictly worse than the leak it came from, so the write
+ * path treats the sentinel as "unchanged" and restores the stored value.
+ *
+ * These assertions read the RAW `connections.config` jsonb straight from
+ * Postgres on purpose. Asserting on the API response would be worthless here —
+ * the response is redacted either way, so a corrupted row and a healthy row are
+ * indistinguishable through it, and the test would pass while the credential
+ * was already destroyed.
+ */
+describe("connection config redaction > sentinel round-trip", () => {
+	let workspace: TestWorkspace;
+	let connectionId: number;
+
+	/** The stored plaintext, straight from the row. */
+	async function storedConfig(): Promise<Record<string, unknown>> {
+		const rows = await getTestDb()`
+      SELECT config FROM connections WHERE id = ${connectionId}
+    `;
+		return (rows[0] as { config: Record<string, unknown> }).config;
+	}
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		workspace = await TestWorkspace.create({
+			name: "Round Trip Org",
+			visibility: "public",
+		});
+
+		connectionId = Number(
+			(
+				await createTestConnection({
+					organization_id: workspace.org.id,
+					connector_key: "postgres",
+					display_name: "Round Trip Postgres",
+					created_by: workspace.users.owner.id,
+					visibility: "org",
+					config: { ...SECRET_PROBES, host: "db.internal" },
+				})
+			).id,
+		);
+	});
+
+	it("preserves the stored secret when a redacted config is PATCHed back", async () => {
+		// Exactly what the UI does: read, spread, change one unrelated field.
+		const read = (await workspace.owner.connections.get(connectionId)) as {
+			connection?: { config?: Record<string, unknown> };
+		};
+		const fetched = read.connection?.config ?? {};
+		// Precondition: the read really is redacted, otherwise this test would
+		// pass for the wrong reason (nothing to round-trip).
+		expect(JSON.stringify(fetched)).toContain(REDACTED_SENTINEL);
+
+		await workspace.owner.connections.update({
+			connection_id: connectionId,
+			config: { ...fetched, action_modes: { some_op: "auto" } },
+		});
+
+		const stored = await storedConfig();
+		// The unrelated edit landed...
+		expect(stored.action_modes).toEqual({ some_op: "auto" });
+		// ...and every secret survived, at every depth and shape.
+		expect(stored.password).toBe(SECRET_PROBES.password);
+		expect(stored.api_key).toBe(SECRET_PROBES.api_key);
+		expect(stored.refresh_token).toBe(SECRET_PROBES.refresh_token);
+		expect(stored.cookie).toBe(SECRET_PROBES.cookie);
+		// The URI form: redactUriCredentials emits
+		// `postgres://__LOBU_REDACTED__@host/db`, which is NOT equal to the bare
+		// sentinel — a naive equality check would miss it and clobber the DSN.
+		expect(stored.DATABASE_URL).toBe(SECRET_PROBES.DATABASE_URL);
+		// Nested, including below the SQL redaction depth bound.
+		const nested = stored.nested as Record<string, Record<string, unknown>>;
+		expect(nested.database.password).toBe("pw-LEAK-nested-password");
+		expect((nested.headers as Record<string, unknown>).Authorization).toBe(
+			"Bearer pw-LEAK-bearer",
+		);
+		expect((nested.credentials as Record<string, unknown>).client_secret).toBe(
+			"pw-LEAK-client-secret",
+		);
+		// Non-secret values still update normally.
+		expect(stored.host).toBe("db.internal");
+	});
+
+	it("still lets a caller set a genuinely new secret", async () => {
+		// Preserve-on-sentinel must not become "secrets are immutable": a real
+		// rotation has to go through.
+		await workspace.owner.connections.update({
+			connection_id: connectionId,
+			config: { password: "rotated-plaintext" },
+		});
+		expect((await storedConfig()).password).toBe("rotated-plaintext");
+	});
+
+	it("preserves secrets under replace_config (declarative apply)", async () => {
+		// `lobu apply` sends replace_config: true so a REMOVED manifest key really
+		// disappears. A sentinel there still means "unchanged", not "set the
+		// literal sentinel" — otherwise re-applying a manifest built from a
+		// redacted read would wipe every credential in the org at once.
+		const read = (await workspace.owner.connections.get(connectionId)) as {
+			connection?: { config?: Record<string, unknown> };
+		};
+		const fetched = read.connection?.config ?? {};
+
+		await workspace.owner.connections.update({
+			connection_id: connectionId,
+			config: { ...fetched, host: "db.replaced" },
+			replace_config: true,
+		});
+
+		const stored = await storedConfig();
+		expect(stored.host).toBe("db.replaced");
+		expect(stored.password).toBe("rotated-plaintext");
+		expect(stored.DATABASE_URL).toBe(SECRET_PROBES.DATABASE_URL);
 	});
 });

--- a/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
+++ b/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
@@ -15,11 +15,11 @@ import { TestWorkspace } from "../setup/test-mcp-client";
  * Secrets must never leave the server through a Connection serializer.
  *
  * `connections.config` is written verbatim on the create/update path (it is
- * split by FEED SCOPE, never by secrecy), so any connector option declared
- * `format: "password"` — Slack/Discord bot tokens, webhook bearer tokens,
- * a Postgres DATABASE_URL — lands in the row as plaintext. Both read paths
- * (`handleList`, `handleGet`) select `c.*`, so without redaction the secret is
- * echoed straight back to any caller who can see the connection.
+ * split by FEED SCOPE, never by secrecy), so secret options such as
+ * Slack/Discord bot tokens and webhook bearer tokens land in the row as
+ * plaintext. Free-form and legacy rows can carry other credentials, including
+ * connection strings. Both read paths (`handleList`, `handleGet`) select `c.*`,
+ * so without redaction the secret is echoed to any caller who can see the row.
  *
  * These probes are the canaries: each value is a distinctive sentinel, and the
  * assertion is on the SERIALIZED response text, so a leak through any nested
@@ -33,10 +33,14 @@ const SECRET_PROBES = {
 	refresh_token: "pw-LEAK-refresh-token",
 	nested: {
 		database: { password: "pw-LEAK-nested-password" },
-		headers: { Authorization: "Bearer pw-LEAK-bearer" },
+		headers: {
+			Authorization: "Bearer pw-LEAK-bearer",
+			"X-Api-Key": "pw-LEAK-hyphenated-header",
+		},
 		credentials: { client_secret: "pw-LEAK-client-secret" },
 		deep: { a: { b: { c: { session_id: "pw-LEAK-deep-session" } } } },
 	},
+	primary: "postgres://user:pw-LEAK-innocent-uri@db.internal:5432/app",
 	cookie: "session=pw-LEAK-cookie",
 } as const;
 
@@ -48,8 +52,10 @@ const LEAK_SENTINELS = [
 	"pw-LEAK-refresh-token",
 	"pw-LEAK-nested-password",
 	"pw-LEAK-bearer",
+	"pw-LEAK-hyphenated-header",
 	"pw-LEAK-client-secret",
 	"pw-LEAK-deep-session",
+	"pw-LEAK-innocent-uri",
 	"pw-LEAK-cookie",
 ];
 
@@ -183,8 +189,8 @@ describe("connection config redaction", () => {
 	});
 
 	/**
-	 * The widest surface of all: `query_sql` is a top-level, member-safe MCP tool
-	 * in every agent's tool set, and `connections` is NOT in
+	 * The widest surface of all: `query_sql` is a top-level, member-safe MCP tool,
+	 * and `connections` is NOT in
 	 * ADMIN_ONLY_QUERYABLE_TABLES — so a plain member (or any agent) could
 	 * `SELECT config FROM connections` and read the raw jsonb.
 	 *
@@ -256,9 +262,9 @@ describe("connection config redaction", () => {
  *    already names it as a column query_sql must never emit; these tools should
  *    not be a way around that, and cursors have historically carried tokens and
  *    whole result payloads.
- *  - `config` — free-form jsonb. No SHIPPED connector routes a credential into
- *    feed-scoped config today, so this arm is hardening rather than a live
- *    leak — pinned so it stays that way.
+ *  - `config` — free-form jsonb. Built-in feed schemas currently declare no
+ *    password/secret fields, but URL and other free-form values can still carry
+ *    credentials.
  *
  * All three read actions are in the same exposure tier as the connection
  * list/get paths, so all three are asserted.
@@ -325,10 +331,13 @@ describe("feed config redaction", () => {
 		const fetched = read.feed?.config ?? {};
 		expect(JSON.stringify(fetched)).toContain(REDACTED_SENTINEL);
 
-		await workspace.owner.feeds.update({
+		const update = await workspace.owner.feeds.update({
 			feed_id: feedId,
 			config: { ...fetched, host: "db.updated" },
 		});
+		assertNoSecrets(update, "feeds.update()");
+		expect(JSON.stringify(update)).not.toContain("pw-LEAK-checkpoint");
+		expect(JSON.stringify(update)).not.toContain("checkpoint");
 
 		const rows = await getTestDb()`
       SELECT config FROM feeds WHERE id = ${feedId}

--- a/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
+++ b/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
@@ -80,7 +80,7 @@ describe("connection config redaction", () => {
 			name: "Redaction Org",
 			visibility: "public",
 		});
-		await seedSystemEntityTypes(workspace.org.id);
+		await seedSystemEntityTypes();
 
 		entityId = Number(
 			(

--- a/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
+++ b/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
@@ -1,0 +1,248 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { querySql } from "../../tools/admin/query_sql";
+import type { ToolContext } from "../../tools/registry";
+import { search } from "../../tools/search";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestConnection,
+	createTestEntity,
+	seedSystemEntityTypes,
+} from "../setup/test-fixtures";
+import { TestWorkspace } from "../setup/test-mcp-client";
+
+/**
+ * Secrets must never leave the server through a Connection serializer.
+ *
+ * `connections.config` is written verbatim on the create/update path (it is
+ * split by FEED SCOPE, never by secrecy), so any connector option declared
+ * `format: "password"` — Slack/Discord bot tokens, webhook bearer tokens,
+ * a Postgres DATABASE_URL — lands in the row as plaintext. Both read paths
+ * (`handleList`, `handleGet`) select `c.*`, so without redaction the secret is
+ * echoed straight back to any caller who can see the connection.
+ *
+ * These probes are the canaries: each value is a distinctive sentinel, and the
+ * assertion is on the SERIALIZED response text, so a leak through any nested
+ * shape (config.database.password, config.headers.Authorization, …) trips it
+ * regardless of depth.
+ */
+const SECRET_PROBES = {
+	DATABASE_URL: "postgres://u:pw-LEAK-database-url@db.internal:5432/app",
+	password: "pw-LEAK-flat-password",
+	api_key: "pw-LEAK-api-key",
+	refresh_token: "pw-LEAK-refresh-token",
+	nested: {
+		database: { password: "pw-LEAK-nested-password" },
+		headers: { Authorization: "Bearer pw-LEAK-bearer" },
+		credentials: { client_secret: "pw-LEAK-client-secret" },
+		deep: { a: { b: { c: { session_id: "pw-LEAK-deep-session" } } } },
+	},
+	cookie: "session=pw-LEAK-cookie",
+} as const;
+
+/** Every sentinel value planted above, flattened. */
+const LEAK_SENTINELS = [
+	"pw-LEAK-database-url",
+	"pw-LEAK-flat-password",
+	"pw-LEAK-api-key",
+	"pw-LEAK-refresh-token",
+	"pw-LEAK-nested-password",
+	"pw-LEAK-bearer",
+	"pw-LEAK-client-secret",
+	"pw-LEAK-deep-session",
+	"pw-LEAK-cookie",
+];
+
+function assertNoSecrets(payload: unknown, label: string): void {
+	const serialized = JSON.stringify(payload ?? null);
+	for (const sentinel of LEAK_SENTINELS) {
+		expect(
+			serialized.includes(sentinel),
+			`${label} leaked secret sentinel ${sentinel}`,
+		).toBe(false);
+	}
+}
+
+describe("connection config redaction", () => {
+	let workspace: TestWorkspace;
+	let connectionId: number;
+	let entityId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		workspace = await TestWorkspace.create({
+			name: "Redaction Org",
+			visibility: "public",
+		});
+		await seedSystemEntityTypes(workspace.org.id);
+
+		entityId = Number(
+			(
+				await createTestEntity({
+					name: "Redaction Probe Co",
+					organization_id: workspace.org.id,
+					created_by: workspace.users.owner.id,
+				})
+			).id,
+		);
+
+		connectionId = Number(
+			(
+				await createTestConnection({
+					organization_id: workspace.org.id,
+					connector_key: "postgres",
+					display_name: "Secretful Postgres",
+					created_by: workspace.users.owner.id,
+					visibility: "org",
+					// Tags the connection onto the entity so search_memory's
+					// `fetchConnectionsForEntity` picks it up.
+					entity_ids: [entityId],
+					config: {
+						...SECRET_PROBES,
+						// A non-secret key must survive redaction untouched —
+						// redaction that nukes the whole config is not a fix.
+						host: "db.internal",
+					},
+				})
+			).id,
+		);
+
+		// `createTestConnection` also creates a 'default' feed. Plant the same
+		// probes into ITS config so the feeds arm of the query_sql chokepoint is
+		// exercised by a real row rather than an empty result set.
+		await getTestDb()`
+      UPDATE feeds
+      SET config = ${getTestDb().json({ ...SECRET_PROBES, host: "db.internal" })}::jsonb
+      WHERE connection_id = ${connectionId}
+    `;
+	});
+
+	it("does not leak secrets through connections.list()", async () => {
+		const result = await workspace.owner.connections.list({});
+		assertNoSecrets(result, "connections.list()");
+	});
+
+	it("does not leak secrets through connections.get()", async () => {
+		const result = await workspace.owner.connections.get(connectionId);
+		assertNoSecrets(result, "connections.get()");
+	});
+
+	it("preserves non-secret config values", async () => {
+		const result = (await workspace.owner.connections.get(connectionId)) as {
+			connection?: { config?: Record<string, unknown> };
+		};
+		expect(result.connection?.config?.host).toBe("db.internal");
+	});
+
+	/**
+	 * Second leak found in the same audit: `search_memory` embeds the entity's
+	 * connections via `fetchConnectionsForEntity`, which selected `c.config`
+	 * raw and typed it straight into the tool's output schema — the same
+	 * plaintext secrets, on a tool that is publicly readable.
+	 */
+	it("does not leak secrets through search_memory's entity connections", async () => {
+		const ctx = {
+			organizationId: workspace.org.id,
+			userId: workspace.users.owner.id,
+			memberRole: "owner",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopedToOrg: false,
+			allowCrossOrg: true,
+			scopes: ["mcp:read"],
+		} as ToolContext;
+
+		const result = await search(
+			{ entity_id: entityId, include_connections: true } as never,
+			{} as never,
+			ctx,
+		);
+		assertNoSecrets(result, "search_memory(include_connections)");
+
+		// The connection must still be reported — redaction, not suppression.
+		const connections = (
+			result as { connections?: Array<{ config?: unknown }> }
+		).connections;
+		expect(connections?.length).toBeGreaterThan(0);
+		expect((connections?.[0]?.config as Record<string, unknown>)?.host).toBe(
+			"db.internal",
+		);
+	});
+
+	/**
+	 * `create` and `update` echo the row back via `RETURNING *`, so a caller
+	 * who POSTs a secret gets it mirrored into the response (and from there
+	 * into any log/transcript that captures tool output).
+	 */
+	it("does not echo secrets back from connections.update()", async () => {
+		const result = await workspace.owner.connections.update({
+			connection_id: connectionId,
+			config: { password: "pw-LEAK-flat-password" },
+		});
+		assertNoSecrets(result, "connections.update()");
+	});
+
+	/**
+	 * The widest surface of all: `query_sql` is a top-level, member-safe MCP tool
+	 * in every agent's tool set, and `connections` is NOT in
+	 * ADMIN_ONLY_QUERYABLE_TABLES — so a plain member (or any agent) could
+	 * `SELECT config FROM connections` and read the raw jsonb.
+	 *
+	 * table-schema.ts is the DESIGNATED chokepoint for this tool and its header
+	 * asserted secret columns were "already excluded", but `config` sat in the
+	 * connections AND feeds allowlists. Fixed there, so the redaction is applied
+	 * in the generated CTE and cannot be bypassed by query shape.
+	 */
+	it("does not leak secrets to a member through query_sql on connections", async () => {
+		const memberCtx = {
+			organizationId: workspace.org.id,
+			userId: workspace.users.member.id,
+			memberRole: "member",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+			scopes: ["mcp:read"],
+		} as ToolContext;
+
+		const result = await querySql(
+			{ sql: "SELECT id, config FROM connections" } as never,
+			{} as never,
+			memberCtx,
+		);
+		assertNoSecrets(result, "query_sql SELECT config FROM connections");
+
+		// The column must still resolve — dropping it would break every legitimate
+		// operational query. Non-secret keys survive.
+		const rows = (result as { rows?: Array<{ config?: unknown }> }).rows ?? [];
+		expect(rows.length).toBeGreaterThan(0);
+		expect((rows[0]?.config as Record<string, unknown>)?.host).toBe(
+			"db.internal",
+		);
+	});
+
+	/**
+	 * Same chokepoint, the other table: `feeds.config` was allowlisted verbatim
+	 * too. No shipped connector is known to place a secret in FEED-scoped config
+	 * today (connection-scoped is where credentials land), so this is a latent
+	 * hole rather than an active exploit — pinned so it stays closed.
+	 */
+	it("does not leak secrets to a member through query_sql on feeds", async () => {
+		const memberCtx = {
+			organizationId: workspace.org.id,
+			userId: workspace.users.member.id,
+			memberRole: "member",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+			scopes: ["mcp:read"],
+		} as ToolContext;
+
+		const result = await querySql(
+			{ sql: "SELECT id, config FROM feeds" } as never,
+			{} as never,
+			memberCtx,
+		);
+		assertNoSecrets(result, "query_sql SELECT config FROM feeds");
+	});
+});

--- a/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
+++ b/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
@@ -255,6 +255,126 @@ describe("connection config redaction", () => {
 });
 
 /**
+ * The keyname heuristic is a BACKSTOP, not the contract. The contract is what
+ * the connector DECLARES secret:
+ *   - `options_schema.properties.<k>.format === "password"`
+ *   - `auth_schema.methods[].fields[].secret === true`
+ *
+ * A connector is free to name such a field anything. `signingMaterial` and
+ * `OPAQUE_HANDLE` are declared secrets whose names match NEITHER the suffix
+ * regex nor the exact-name set, so the heuristic alone cannot see them.
+ *
+ * The TypeScript serializers apply both layers, so list()/get() redact these
+ * correctly. query_sql redacted in SQL with the heuristic only — meaning a
+ * declared secret with an off-denylist name stayed PLAINTEXT on a member-safe
+ * tool in every agent's tool set. Same class as the original P0, same surface.
+ *
+ * `table-schema-redaction.test.ts` pins the SQL and TS denylists against each
+ * other, but only via `isSecretKey` — so by construction it could never catch
+ * a schema-declared name. That is what this test is for.
+ */
+describe("query_sql honors schema-declared secrets", () => {
+	let workspace: TestWorkspace;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		workspace = await TestWorkspace.create({
+			name: "Declared Secret Org",
+			visibility: "public",
+		});
+
+		const sql = getTestDb();
+		// A connector whose secret fields are declared, not guessable by name.
+		await sql`
+      INSERT INTO connector_definitions (
+        key, name, version, options_schema, auth_schema, feeds_schema,
+        organization_id, status, created_at, updated_at
+      ) VALUES (
+        'declaredsecret', 'Declared Secret Connector', '1.0.0',
+        ${sql.json({
+					type: "object",
+					properties: {
+						signingMaterial: { type: "string", format: "password" },
+						host: { type: "string" },
+					},
+				})},
+        ${sql.json({
+					methods: [
+						{
+							type: "env_keys",
+							fields: [
+								{ key: "OPAQUE_HANDLE", secret: true },
+								{ key: "region" },
+							],
+						},
+					],
+				})},
+        ${sql.json({ default: {} })},
+        ${workspace.org.id}, 'active', NOW(), NOW()
+      )
+    `;
+
+		await createTestConnection({
+			organization_id: workspace.org.id,
+			connector_key: "declaredsecret",
+			display_name: "Declared Secret Connection",
+			created_by: workspace.users.owner.id,
+			visibility: "org",
+			config: {
+				// Declared secret, name defeats the heuristic entirely.
+				signingMaterial: "pw-LEAK-declared-signing",
+				OPAQUE_HANDLE: "pw-LEAK-declared-handle",
+				host: "declared.internal",
+			},
+		});
+	});
+
+	it("redacts a schema-declared secret through connections.get()", async () => {
+		// The TS serializer already handled this — asserted so the two layers are
+		// pinned to the SAME expectation.
+		const result = await workspace.owner.connections.list({});
+		const serialized = JSON.stringify(result);
+		expect(serialized).not.toContain("pw-LEAK-declared-signing");
+		expect(serialized).not.toContain("pw-LEAK-declared-handle");
+	});
+
+	it("redacts a schema-declared secret through query_sql", async () => {
+		const memberCtx = {
+			organizationId: workspace.org.id,
+			userId: workspace.users.member.id,
+			memberRole: "member",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+			scopes: ["mcp:read"],
+		} as ToolContext;
+
+		const result = await querySql(
+			{ sql: "SELECT id, config FROM connections" } as never,
+			{} as never,
+			memberCtx,
+		);
+		const serialized = JSON.stringify(result);
+		expect(
+			serialized.includes("pw-LEAK-declared-signing"),
+			"query_sql leaked options_schema format:password field",
+		).toBe(false);
+		expect(
+			serialized.includes("pw-LEAK-declared-handle"),
+			"query_sql leaked auth_schema secret:true field",
+		).toBe(false);
+
+		// Redaction, not suppression — the non-secret declared field survives.
+		const rows = (result as { rows?: Array<{ config?: unknown }> }).rows ?? [];
+		expect(rows.length).toBeGreaterThan(0);
+		expect((rows[0]?.config as Record<string, unknown>)?.host).toBe(
+			"declared.internal",
+		);
+	});
+});
+
+/**
  * `manage_feeds` serializes `f.*`, which carries two columns that must not
  * reach a caller:
  *
@@ -452,6 +572,73 @@ describe("connection config redaction > sentinel round-trip", () => {
 		expect((await storedConfig()).password).toBe("rotated-plaintext");
 	});
 
+	/**
+	 * Preserve-from-a-stale-snapshot is a credential ROLLBACK.
+	 *
+	 * `handleUpdate` reads the row without a lock, then does a long stretch of
+	 * awaits (auth-profile lookups, device binding, feed checks) before writing.
+	 * If the restore sourced its values from that stale snapshot, this sequence
+	 * would silently undo a rotation:
+	 *
+	 *   A: read (redacted)            — sees sentinel, snapshot has OLD secret
+	 *   B: rotate secret              — commits NEW secret
+	 *   A: write, restoring from A's snapshot → OLD secret overwrites NEW
+	 *
+	 * Multi-replica correctness is a hard invariant here (AGENTS.md), so this is
+	 * a real interleaving, not a theoretical one. The fix re-reads the config
+	 * FOR UPDATE inside the write transaction, so the restore source is the row
+	 * the write is actually based on.
+	 *
+	 * Asserted against the raw row: the API response is redacted either way, so
+	 * a rolled-back credential is invisible through it.
+	 */
+	it("does not roll back a concurrent rotation via a stale restore", async () => {
+		// A: read the redacted config (the snapshot a round-tripping client holds).
+		const read = (await workspace.owner.connections.get(connectionId)) as {
+			connection?: { config?: Record<string, unknown> };
+		};
+		const staleFetched = read.connection?.config ?? {};
+		expect(JSON.stringify(staleFetched)).toContain(REDACTED_SENTINEL);
+
+		// Force the interleaving deterministically rather than racing the
+		// scheduler: hold a row lock on the connection, kick off A's redacted
+		// round-trip (which blocks at its own `FOR UPDATE`), rotate the secret
+		// under the held lock, then release. A therefore resumes with a snapshot
+		// that predates the rotation — precisely the A-reads / B-rotates /
+		// A-writes ordering. Without the locked re-read, A's restore would source
+		// the pre-rotation plaintext and overwrite B's new value.
+		const sql = getTestDb();
+		let updatePromise!: Promise<unknown>;
+		await sql.begin(async (tx) => {
+			await tx`
+        SELECT config FROM connections WHERE id = ${connectionId} FOR UPDATE
+      `;
+
+			updatePromise = workspace.owner.connections.update({
+				connection_id: connectionId,
+				config: { ...staleFetched, action_modes: { later_op: "manual" } },
+			});
+
+			// Let A run until it blocks on the row lock this transaction holds.
+			await new Promise((resolve) => setTimeout(resolve, 300));
+
+			// B rotates while A is parked mid-update.
+			await tx`
+        UPDATE connections
+        SET config = jsonb_set(config, '{password}', ${tx.json("rotated-by-replica-b")}::jsonb)
+        WHERE id = ${connectionId}
+      `;
+		});
+
+		await updatePromise;
+
+		const stored = await storedConfig();
+		// A's unrelated edit landed...
+		expect(stored.action_modes).toEqual({ later_op: "manual" });
+		// ...without clobbering B's rotation with A's stale plaintext.
+		expect(stored.password).toBe("rotated-by-replica-b");
+	});
+
 	it("preserves secrets under replace_config (declarative apply)", async () => {
 		// `lobu apply` sends replace_config: true so a REMOVED manifest key really
 		// disappears. A sentinel there still means "unchanged", not "set the
@@ -461,6 +648,9 @@ describe("connection config redaction > sentinel round-trip", () => {
 			connection?: { config?: Record<string, unknown> };
 		};
 		const fetched = read.connection?.config ?? {};
+		// Whatever the earlier cases left stored — asserted against the row rather
+		// than a hardcoded value so this stays independent of test ordering.
+		const before = await storedConfig();
 
 		await workspace.owner.connections.update({
 			connection_id: connectionId,
@@ -470,7 +660,7 @@ describe("connection config redaction > sentinel round-trip", () => {
 
 		const stored = await storedConfig();
 		expect(stored.host).toBe("db.replaced");
-		expect(stored.password).toBe("rotated-plaintext");
+		expect(stored.password).toBe(before.password);
 		expect(stored.DATABASE_URL).toBe(SECRET_PROBES.DATABASE_URL);
 	});
 });

--- a/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
+++ b/packages/server/src/__tests__/integration/connections-config-redaction.test.ts
@@ -273,6 +273,131 @@ describe("connection config redaction", () => {
  * other, but only via `isSecretKey` — so by construction it could never catch
  * a schema-declared name. That is what this test is for.
  */
+/**
+ * Feed-scoped declared secrets.
+ *
+ * `FeedDefinition.configSchema` is `Record<string, unknown>` — completely
+ * unconstrained — so a CUSTOM connector may declare `format: "password"` on a
+ * feed's own config just as it can on the connection's. No shipped connector
+ * does today (all 27 audited, zero hits), so this is a latent hole rather than
+ * a live leak — but custom connector definitions are a supported product
+ * feature, and a redactor documented as total must not silently exempt one
+ * declaration site.
+ *
+ * Both feed surfaces are covered: the manage_feeds serializers and the
+ * `SELECT config FROM feeds` arm of query_sql.
+ */
+describe("feed tools honor schema-declared secrets", () => {
+	let workspace: TestWorkspace;
+	let feedId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		workspace = await TestWorkspace.create({
+			name: "Feed Declared Secret Org",
+			visibility: "public",
+		});
+
+		const sql = getTestDb();
+		// A connector whose FEED declares a secret field the keyname heuristic
+		// cannot see — `signingMaterial` matches neither the suffix regex nor the
+		// exact-name set.
+		await sql`
+      INSERT INTO connector_definitions (
+        key, name, version, options_schema, auth_schema, feeds_schema,
+        organization_id, status, created_at, updated_at
+      ) VALUES (
+        'feeddeclared', 'Feed Declared Secret Connector', '1.0.0',
+        ${sql.json({ type: "object", properties: {} })},
+        ${sql.json({ methods: [{ type: "none" }] })},
+        ${sql.json({
+					default: {
+						key: "default",
+						name: "Default",
+						configSchema: {
+							type: "object",
+							properties: {
+								signingMaterial: { type: "string", format: "password" },
+								host: { type: "string" },
+							},
+						},
+					},
+				})},
+        ${workspace.org.id}, 'active', NOW(), NOW()
+      )
+    `;
+
+		const connection = await createTestConnection({
+			organization_id: workspace.org.id,
+			connector_key: "feeddeclared",
+			display_name: "Feed Declared Connection",
+			created_by: workspace.users.owner.id,
+			visibility: "org",
+		});
+
+		const rows = await sql`
+      UPDATE feeds
+      SET config = ${sql.json({
+				signingMaterial: "pw-LEAK-feed-declared",
+				host: "feed.internal",
+			})}::jsonb
+      WHERE connection_id = ${Number(connection.id)}
+      RETURNING id
+    `;
+		feedId = Number((rows[0] as { id: number }).id);
+	});
+
+	it("redacts a feed's declared secret through feeds.get()", async () => {
+		const result = await workspace.owner.feeds.get({ feed_id: feedId });
+		expect(
+			JSON.stringify(result).includes("pw-LEAK-feed-declared"),
+			"feeds.get() leaked a configSchema format:password field",
+		).toBe(false);
+
+		// Redaction, not suppression — the non-secret declared field survives.
+		const feed = (result as { feed?: { config?: Record<string, unknown> } })
+			.feed;
+		expect(feed?.config?.host).toBe("feed.internal");
+	});
+
+	it("redacts a feed's declared secret through feeds.list()", async () => {
+		const result = await workspace.owner.feeds.list({});
+		expect(
+			JSON.stringify(result).includes("pw-LEAK-feed-declared"),
+			"feeds.list() leaked a configSchema format:password field",
+		).toBe(false);
+	});
+
+	it("redacts a feed's declared secret through query_sql", async () => {
+		const memberCtx = {
+			organizationId: workspace.org.id,
+			userId: workspace.users.member.id,
+			memberRole: "member",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+			scopes: ["mcp:read"],
+		} as ToolContext;
+
+		const result = await querySql(
+			{ sql: "SELECT id, config FROM feeds" } as never,
+			{} as never,
+			memberCtx,
+		);
+		expect(
+			JSON.stringify(result).includes("pw-LEAK-feed-declared"),
+			"query_sql leaked a feed configSchema format:password field",
+		).toBe(false);
+
+		const rows = (result as { rows?: Array<{ config?: unknown }> }).rows ?? [];
+		expect(rows.length).toBeGreaterThan(0);
+		expect((rows[0]?.config as Record<string, unknown>)?.host).toBe(
+			"feed.internal",
+		);
+	});
+});
+
 describe("query_sql honors schema-declared secrets", () => {
 	let workspace: TestWorkspace;
 

--- a/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
@@ -6,6 +6,7 @@
  *     pattern), not a generic "(root) Expected union value".
  */
 import { describe, expect, test } from "bun:test";
+import { restoreRedactedConfig } from "../../../utils/connection-config-redaction.js";
 import {
 	parseConfig,
 	unwrapIncomingChatConfig,
@@ -148,5 +149,83 @@ describe("unwrapIncomingChatConfig", () => {
 				},
 			}),
 		).rejects.toThrow(/secret store unavailable/);
+	});
+});
+
+/**
+ * The chat twin of the non-chat locked-restore race.
+ *
+ * `connections.update` on a chat connection routes into `updateChatConnection`.
+ * A redacted round-trip sends `__LOBU_REDACTED__` back for any
+ * `format: "password"` field, and the sentinel is restored from the stored row.
+ * If that restore sources a snapshot taken BEFORE the write is serialized, this
+ * interleaving silently rolls back a rotation:
+ *
+ *   A: read (redacted)       — snapshot holds the OLD token
+ *   B: rotate the bot token  — commits the NEW token
+ *   A: write, restoring from A's snapshot → OLD token overwrites NEW
+ *
+ * It matters more here than on the non-chat path: the chat connectors
+ * (slack/discord/telegram/teams/whatsapp/gchat/webhook) are exactly the ones
+ * declaring `format: "password"`, so this is where live bot tokens sit.
+ *
+ * The fix has two halves: `crud.ts` passes the RAW incoming config (it must NOT
+ * restore against the handler's unlocked snapshot), and `updateChatConnection`
+ * takes `withStableChatLock`, re-reads the row inside it, and restores from
+ * THAT. These cases pin the property that makes the second half correct —
+ * restoring against the fresh row yields the ROTATED value, restoring against
+ * the stale snapshot yields the old one.
+ *
+ * This is a seam test, not end-to-end. An integration attempt could park
+ * `handleUpdate` mid-flight and prove the stale token reaches the manager, but
+ * the row it finally persists is written by `ChatInstanceManager` against a
+ * warm in-memory instance the test harness has no way to create — so the
+ * end-to-end assertion passed whether or not the fix was present. A test that
+ * cannot fail is worse than no test, so it was dropped in favour of this.
+ */
+describe("chat config restore sources the fresh row", () => {
+	const REDACTED = "__LOBU_REDACTED__";
+	const OLD_TOKEN = "webhook-token-original";
+	const ROTATED_TOKEN = "webhook-token-rotated-by-replica-b";
+
+	// What a client sends back after reading the redacted connection.
+	const incoming = { token: REDACTED, semanticType: "probe" };
+
+	test("restoring against the freshly-read row keeps the rotation", () => {
+		// The row as re-read INSIDE the lock, after B's rotation committed.
+		const freshRow = { token: ROTATED_TOKEN, platform: "webhook" };
+		const restored = restoreRedactedConfig(incoming, freshRow) as Record<
+			string,
+			unknown
+		>;
+		expect(restored.token).toBe(ROTATED_TOKEN);
+		expect(restored.semanticType).toBe("probe");
+	});
+
+	test("restoring against a stale snapshot resurrects the old token", () => {
+		// The snapshot `crud.ts` used to restore from — read before the rotation.
+		// This is the bug, pinned so the failure mode stays visible: the sentinel
+		// resolves to a credential that is no longer current.
+		const staleSnapshot = { token: OLD_TOKEN, platform: "webhook" };
+		const restored = restoreRedactedConfig(incoming, staleSnapshot) as Record<
+			string,
+			unknown
+		>;
+		expect(restored.token).toBe(OLD_TOKEN);
+		expect(restored.token).not.toBe(ROTATED_TOKEN);
+	});
+
+	test("the merge cannot reintroduce a stale value the restore dropped", () => {
+		// `updateChatConnection` merges `{...currentConfig, ...restored}` where
+		// BOTH sides come from the locked row, so no pre-lock value can leak in.
+		const freshRow = { token: ROTATED_TOKEN, platform: "webhook" };
+		const restored = restoreRedactedConfig(incoming, freshRow) as Record<
+			string,
+			unknown
+		>;
+		const merged = { ...freshRow, ...restored };
+		expect(merged.token).toBe(ROTATED_TOKEN);
+		expect(JSON.stringify(merged)).not.toContain(OLD_TOKEN);
+		expect(JSON.stringify(merged)).not.toContain(REDACTED);
 	});
 });

--- a/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
@@ -6,7 +6,10 @@
  *     pattern), not a generic "(root) Expected union value".
  */
 import { describe, expect, test } from "bun:test";
-import { parseConfig } from "../chat-connection-service.js";
+import {
+	parseConfig,
+	unwrapIncomingChatConfig,
+} from "../chat-connection-service.js";
 
 describe("parseConfig", () => {
 	test("webhook string booleans are accepted and unknown keys stripped", () => {
@@ -58,5 +61,92 @@ describe("parseConfig", () => {
 				mentionRoleIds: "role-1",
 			}),
 		).toThrow(/mentionRoleIds/);
+	});
+});
+
+
+/**
+ * A redacted re-apply of an UNCHANGED BYO chat connection must end up holding
+ * the REAL credential, not a placeholder.
+ *
+ * `unwrapIncomingChatConfig` is the production seam every BYO apply goes
+ * through. It unwinds two placeholder layers in order: `__LOBU_REDACTED__` →
+ * stored value (restore), then `secret://…` → plaintext (resolve). Skipping
+ * the second meant an unresolved ref reached `parseConfig`,
+ * `connectionMatches` and `validateProviderIdentity` — so an unchanged
+ * re-apply reported `changed`, and Slack's `authTest` was handed the literal
+ * `secret://…` URI and failed the apply.
+ *
+ * `resolveRefs` is injected here because the real implementation is the chat
+ * manager's secret-store lookup; everything else is the shipped code path.
+ */
+describe("unwrapIncomingChatConfig", () => {
+	const REDACTED = "__LOBU_REDACTED__";
+	const REF = "secret://org-1/webhook-token";
+	const PLAINTEXT = "real-webhook-bearer-token";
+
+	/** Stands in for the manager's secret-store resolution. */
+	const resolveRefs = async (_id: string, config: Record<string, unknown>) =>
+		Object.fromEntries(
+			Object.entries(config).map(([k, v]) => [k, v === REF ? PLAINTEXT : v]),
+		) as never;
+
+	const incoming = { token: REDACTED, semanticType: "probe" };
+	const stored = { token: REF, semanticType: "probe" };
+
+	function unwrap(
+		over: Partial<Parameters<typeof unwrapIncomingChatConfig>[0]> = {},
+	) {
+		return unwrapIncomingChatConfig({
+			organizationId: "org-1",
+			stableId: "byo-webhook-1",
+			incoming,
+			stored,
+			resolveRefs,
+			...over,
+		});
+	}
+
+	test("a redacted re-apply yields the real credential, never a placeholder", async () => {
+		const out = await unwrap();
+		expect(out.token).toBe(PLAINTEXT);
+		// Neither placeholder may survive to a consumer.
+		expect(JSON.stringify(out)).not.toContain(REDACTED);
+		expect(JSON.stringify(out)).not.toContain("secret://");
+		// Non-secret fields round-trip untouched.
+		expect(out.semanticType).toBe("probe");
+	});
+
+	test("an unchanged re-apply matches the resolved stored config", async () => {
+		// This equality is what the `changed: false` determination rests on.
+		const applySide = await unwrap();
+		const storedSide = await resolveRefs("byo-webhook-1", stored);
+		expect(applySide).toEqual(storedSide as unknown as Record<string, unknown>);
+	});
+
+	test("a genuine rotation still passes through", async () => {
+		// Preserve-on-sentinel must not make credentials immutable.
+		const out = await unwrap({ incoming: { token: "rotated-plaintext" } });
+		expect(out.token).toBe("rotated-plaintext");
+	});
+
+	test("a create (no stored row) passes the caller's config through", async () => {
+		const out = await unwrap({
+			incoming: { token: "brand-new" },
+			stored: undefined,
+		});
+		expect(out.token).toBe("brand-new");
+	});
+
+	test("resolution failure surfaces rather than persisting a reference", async () => {
+		// Failing loudly beats silently storing an unresolvable ref as if it were
+		// a credential.
+		await expect(
+			unwrap({
+				resolveRefs: async () => {
+					throw new Error("secret store unavailable");
+				},
+			}),
+		).rejects.toThrow(/secret store unavailable/);
 	});
 });

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -385,60 +385,85 @@ export async function updateChatConnection(input: {
 	config?: Record<string, unknown>;
 	status?: string;
 }): Promise<void> {
-	const row = await getChatConnectionRow(
+	// Identity-only pre-read: resolves which connection this is (and therefore
+	// the lock key). Every value this function ACTS on is re-read under the lock
+	// below — nothing from this snapshot is trusted for the write.
+	const identity = await getChatConnectionRow(
 		input.organizationId,
 		input.connectionId,
 	);
-	if (!row) throw new Error("Chat connection not found");
-	// Managed installs own their credentials, but credential-free updates —
-	// pause/resume, rename — still apply to them.
-	if (row.credential_mode !== "byo" && input.config) {
-		throw new Error("Managed app credentials cannot be edited directly");
-	}
-	const runtimeId = slugToRuntimeConnectionId(row.slug);
-	const manager = requireManager();
-	if (input.config) {
-		const currentConfig = { ...(row.config ?? {}) };
-		delete currentConfig.settings;
-		delete currentConfig.chatMetadata;
-		const merged = {
-			...currentConfig,
-			...input.config,
-		} as PlatformAdapterConfig;
-		const resolved = await manager.resolveConnectionConfig(runtimeId, merged);
-		const config = parseConfig(row.connector_key, resolved);
-		const providerMetadata = await validateProviderIdentity(config);
-		await orgContext.run({ organizationId: input.organizationId }, () =>
-			manager.updateConnection(runtimeId, {
-				...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
-				config,
-				metadata: {
-					...providerMetadata,
-					...(input.displayName ? { teamName: input.displayName } : {}),
-				},
-			}),
+	if (!identity) throw new Error("Chat connection not found");
+	const runtimeId = slugToRuntimeConnectionId(identity.slug);
+
+	// Serialize on the same stable-chat lock `upsertByoChatConnection` uses, so
+	// a config edit and a concurrent apply/rotation of the SAME connection
+	// cannot interleave. Without it there is no serialization on this path at
+	// all, and the restore below would source a stale row.
+	return withStableChatLock(input.organizationId, runtimeId, async () => {
+		// Re-read INSIDE the lock: this is the row the write is actually based on.
+		const row = await getChatConnectionRow(
+			input.organizationId,
+			input.connectionId,
 		);
-	} else if (input.agentId !== undefined) {
-		// agentId-only update: no config change, so no restart is needed — the
-		// manager persists the new fallback agent and refreshes any warm
-		// in-memory instance in place.
-		await orgContext.run({ organizationId: input.organizationId }, () =>
-			manager.updateConnection(runtimeId, { agentId: input.agentId }),
-		);
-	}
-	if (input.status === "active") {
-		await manager.restartConnection(runtimeId);
-	} else if (input.status === "paused") {
-		await manager.stopConnection(runtimeId);
-	}
-	if (input.displayName !== undefined) {
-		const sql = getDb();
-		await sql`
-      UPDATE connections
-      SET display_name = ${input.displayName || row.connector_key}, updated_at = now()
-      WHERE id = ${row.id} AND organization_id = ${input.organizationId}
-    `;
-	}
+		if (!row) throw new Error("Chat connection not found");
+		// Managed installs own their credentials, but credential-free updates —
+		// pause/resume, rename — still apply to them.
+		if (row.credential_mode !== "byo" && input.config) {
+			throw new Error("Managed app credentials cannot be edited directly");
+		}
+		const manager = requireManager();
+		if (input.config) {
+			const currentConfig = { ...(row.config ?? {}) };
+			delete currentConfig.settings;
+			delete currentConfig.chatMetadata;
+			// Un-redact against the LOCKED row, not the caller's snapshot. A
+			// `__LOBU_REDACTED__` means "unchanged", so it must resolve to what is
+			// stored NOW — restoring from a stale read would write a pre-rotation
+			// token back over a newer one, silently rolling the rotation back.
+			// (This is why crud.ts hands us the RAW incoming config.)
+			const restored = restoreRedactedConfig(
+				input.config,
+				currentConfig,
+			) as Record<string, unknown>;
+			const merged = {
+				...currentConfig,
+				...restored,
+			} as PlatformAdapterConfig;
+			const resolved = await manager.resolveConnectionConfig(runtimeId, merged);
+			const config = parseConfig(row.connector_key, resolved);
+			const providerMetadata = await validateProviderIdentity(config);
+			await orgContext.run({ organizationId: input.organizationId }, () =>
+				manager.updateConnection(runtimeId, {
+					...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
+					config,
+					metadata: {
+						...providerMetadata,
+						...(input.displayName ? { teamName: input.displayName } : {}),
+					},
+				}),
+			);
+		} else if (input.agentId !== undefined) {
+			// agentId-only update: no config change, so no restart is needed — the
+			// manager persists the new fallback agent and refreshes any warm
+			// in-memory instance in place.
+			await orgContext.run({ organizationId: input.organizationId }, () =>
+				manager.updateConnection(runtimeId, { agentId: input.agentId }),
+			);
+		}
+		if (input.status === "active") {
+			await manager.restartConnection(runtimeId);
+		} else if (input.status === "paused") {
+			await manager.stopConnection(runtimeId);
+		}
+		if (input.displayName !== undefined) {
+			const sql = getDb();
+			await sql`
+        UPDATE connections
+        SET display_name = ${input.displayName || row.connector_key}, updated_at = now()
+        WHERE id = ${row.id} AND organization_id = ${input.organizationId}
+      `;
+		}
+	});
 }
 
 export async function deleteChatConnection(

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -175,6 +175,63 @@ export async function getChatConnectionRow(
 	return rows[0] ?? null;
 }
 
+/**
+ * Unwind the two placeholder layers on an incoming BYO chat config, in order,
+ * before anything treats it as credentials.
+ *
+ * 1. RESTORE. Callers round-trip config read back from the (redacted)
+ *    connection read paths, so a `__LOBU_REDACTED__` here means "unchanged" —
+ *    take the stored value rather than persisting the placeholder. Chat
+ *    connectors are the ones declaring `format: "password"` (Slack/Discord bot
+ *    tokens), so without this an apply built from a redacted read would both
+ *    fail `validateProviderIdentity` and overwrite a live bot token.
+ *
+ * 2. RESOLVE. What the restore hands back is whatever is STORED — and for a BYO
+ *    chat connection that is a `secret://` REFERENCE, not plaintext. None of
+ *    the downstream consumers (`parseConfig`, `connectionMatches`,
+ *    `validateProviderIdentity`) resolve references, so an unresolved ref makes
+ *    an UNCHANGED re-apply look changed and makes `validateProviderIdentity`
+ *    authenticate with the literal `secret://…` URI.
+ *
+ * This is the sentinel bug one indirection out: that fix stopped a PLACEHOLDER
+ * being treated as a live credential, and a stored `secret://` ref is the same
+ * kind of placeholder. Order matters — resolving before restoring does nothing
+ * for a sentinel, so the placeholder would reach the consumers.
+ *
+ * `stableId` IS the runtime id resolution needs (the slug is derived from it),
+ * so this needs nothing that isn't already in hand at the call site: no
+ * validation is reordered to make it possible.
+ *
+ * Exported as the testable seam for that ordering — `upsertByoChatConnection`
+ * itself takes a `pg_advisory_lock` through `sql.reserve()`, which the test
+ * harness's pooled client does not service.
+ */
+export async function unwrapIncomingChatConfig(params: {
+	organizationId: string;
+	stableId: string;
+	incoming: Record<string, unknown>;
+	/** The stored row's config, or undefined when creating. */
+	stored: Record<string, unknown> | undefined;
+	resolveRefs: (
+		runtimeId: string,
+		config: PlatformAdapterConfig,
+	) => Promise<PlatformAdapterConfig>;
+}): Promise<Record<string, unknown>> {
+	// Nothing stored yet: the caller supplied real values, and there is no row
+	// to restore from or reference to resolve.
+	if (!params.stored) return params.incoming;
+
+	const restored = restoreRedactedConfig(
+		params.incoming,
+		params.stored,
+	) as PlatformAdapterConfig;
+
+	return (await orgContext.run(
+		{ organizationId: params.organizationId },
+		() => params.resolveRefs(params.stableId, restored),
+	)) as unknown as Record<string, unknown>;
+}
+
 export async function upsertByoChatConnection(
 	input: UpsertChatConnectionInput,
 ): Promise<{
@@ -212,21 +269,15 @@ export async function upsertByoChatConnection(
 		const manager = requireManager();
 		const settings = { allowGroups: true, ...(input.settings ?? {}) };
 		const existing = existingRows[0];
-		// Callers round-trip config read back from the (redacted) connection read
-		// paths, so a `__LOBU_REDACTED__` here means "unchanged" — restore the
-		// stored value rather than persisting the placeholder. Chat connectors are
-		// the ones declaring `format: "password"` (Slack/Discord bot tokens), so
-		// without this an apply built from a redacted read would both fail
-		// validateProviderIdentity (authenticating with the literal sentinel) and
-		// overwrite a live bot token.
 		const config = parseConfig(
 			input.platform,
-			existing
-				? (restoreRedactedConfig(input.config, existing.config) as Record<
-						string,
-						unknown
-					>)
-				: input.config,
+			await unwrapIncomingChatConfig({
+				organizationId: input.organizationId,
+				stableId: input.stableId,
+				incoming: input.config,
+				stored: existing?.config,
+				resolveRefs: (id, cfg) => manager.resolveConnectionConfig(id, cfg),
+			}),
 		);
 		if (!existing) {
 			const providerMetadata = await validateProviderIdentity(config);

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -6,6 +6,7 @@ import {
 	slugToRuntimeConnectionId,
 } from "../../lobu/stores/connections-projection.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
+import { restoreRedactedConfig } from "../../utils/connection-config-redaction.js";
 import { SLACK_INSTALLATION_ID_PREFIX } from "../../lobu/stores/slack-installations.js";
 import { PlatformAdapterConfigSchema } from "../routes/schemas/platform-config.js";
 import { isAdapterlessPlatform } from "./chat-instance-manager.js";
@@ -208,10 +209,25 @@ export async function upsertByoChatConnection(
 			agent_id: string | null;
 		}>;
 
-		const config = parseConfig(input.platform, input.config);
 		const manager = requireManager();
 		const settings = { allowGroups: true, ...(input.settings ?? {}) };
 		const existing = existingRows[0];
+		// Callers round-trip config read back from the (redacted) connection read
+		// paths, so a `__LOBU_REDACTED__` here means "unchanged" — restore the
+		// stored value rather than persisting the placeholder. Chat connectors are
+		// the ones declaring `format: "password"` (Slack/Discord bot tokens), so
+		// without this an apply built from a redacted read would both fail
+		// validateProviderIdentity (authenticating with the literal sentinel) and
+		// overwrite a live bot token.
+		const config = parseConfig(
+			input.platform,
+			existing
+				? (restoreRedactedConfig(input.config, existing.config) as Record<
+						string,
+						unknown
+					>)
+				: input.config,
+		);
 		if (!existing) {
 			const providerMetadata = await validateProviderIdentity(config);
 			await orgContext.run({ organizationId: input.organizationId }, () =>

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -16,6 +16,12 @@ import {
 } from "../../../../db/client";
 import { recordToolConfigChange } from "../../helpers/config-audit";
 import {
+	connectorSecretKeysFromSchemas,
+	loadConnectorSecretKeys,
+	redactConnectionConfig,
+	redactConnectionRow,
+} from "../../../../utils/connection-config-redaction";
+import {
 	deleteChatConnection,
 	updateChatConnection,
 	upsertByoChatConnection,
@@ -372,6 +378,13 @@ export async function handleList(
 		organizationId,
 		connectorKeys,
 	);
+	// `SELECT c.*` carries the raw `config` jsonb, which is written verbatim
+	// (split by feed scope, never by secrecy). Resolve each connector's
+	// schema-declared secret keys ONCE for the page, then redact per row below.
+	const secretKeysByConnector = await loadConnectorSecretKeys(
+		organizationId,
+		connectorKeys,
+	);
 
   const connections = resolved.map((row) => {
 		const operationsSummary = summaries.get(String(row.connector_key)) ?? {
@@ -380,6 +393,11 @@ export async function handleList(
     const hasOperations = operationsSummary.total > 0;
     return {
       ...row,
+      // Secrets never leave the server through a connection serializer.
+      config: redactConnectionConfig(
+        row.config,
+        secretKeysByConnector.get(String(row.connector_key)),
+      ),
       // Postgres returns bigint[] as a literal string ('{2}'); parse to number[]
       // so the API contract matches the typed entity_ids the UI picker expects.
       entity_ids: parsePgNumberArray(row.entity_ids),
@@ -436,6 +454,10 @@ export async function handleGet(
            cd.name AS connector_name,
            cd.feeds_schema,
            cd.auth_schema,
+           -- options_schema drives schema-declared config redaction below
+           -- (format:"password" properties); auth_schema covers the
+           -- env_keys secret:true fields.
+           cd.options_schema,
            cd.declares_chat,
            ap.slug AS auth_profile_slug,
            ap.display_name AS auth_profile_name,
@@ -540,6 +562,16 @@ export async function handleGet(
 				device_label: getRow.device_label as string | null,
 			}),
       ...(connectToken ? { connect_token: connectToken } : {}),
+      // Secrets never leave the server through a connection serializer. The
+      // connector's own schemas are already joined in above (cd.auth_schema /
+      // cd.options_schema), so this needs no extra query.
+      config: redactConnectionConfig(
+        getRow.config,
+        connectorSecretKeysFromSchemas({
+          optionsSchema: getRow.options_schema,
+          authSchema: getRow.auth_schema,
+        }),
+      ),
       operations_summary: operationsSummary,
       has_operations: hasOperations,
       facets: deriveConnectionFacets({
@@ -639,6 +671,13 @@ export async function handleCreate(
 			error: `Connector '${args.connector_key}' not found or not active`,
 		};
 	}
+
+	// Schema-declared secret config keys for this connector — used to redact the
+	// `RETURNING *` row before it is serialized back to the caller.
+	const createSecretKeys = connectorSecretKeysFromSchemas({
+		optionsSchema: connector.options_schema,
+		authSchema: connector.auth_schema,
+	});
 
 	const chatPlatform =
 		connector.options_schema &&
@@ -1227,7 +1266,10 @@ export async function handleCreate(
   return {
 		action: "create",
     connection: enrichWithAuthProfiles(
-      inserted[0] as Record<string, unknown>,
+      // `RETURNING *` echoes back the config we just inserted — including any
+      // secret the caller supplied. Redact before serializing; `connector` is
+      // already loaded here, so the schema pass is free.
+      redactConnectionRow(inserted[0] as Record<string, unknown>, createSecretKeys),
       authSelection?.authProfile ?? null,
 			authSelection?.appAuthProfile ?? null,
     ),
@@ -1299,10 +1341,10 @@ export async function handleUpdate(
   // Verify ownership
   const existingRows = await sql`
     SELECT c.id, c.connector_key, c.auth_profile_id, c.app_auth_profile_id, c.created_by,
-           c.config, c.credential_mode, cd.auth_schema, cd.feeds_schema
+           c.config, c.credential_mode, cd.auth_schema, cd.options_schema, cd.feeds_schema
     FROM connections c
     LEFT JOIN LATERAL (
-      SELECT auth_schema, feeds_schema
+      SELECT auth_schema, options_schema, feeds_schema
       FROM connector_definitions
       WHERE key = c.connector_key
         AND status = 'active'
@@ -1322,6 +1364,7 @@ export async function handleUpdate(
     id: number;
     connector_key: string;
     auth_schema: { methods?: Array<Record<string, unknown>> } | null;
+    options_schema: Record<string, unknown> | null;
     feeds_schema: Record<string, unknown> | null;
     auth_profile_id: number | null;
     app_auth_profile_id: number | null;
@@ -1833,7 +1876,15 @@ export async function handleUpdate(
   return {
 		action: "update",
     connection: enrichWithAuthProfiles(
-      updated[0] as Record<string, unknown>,
+      // `RETURNING *` echoes the merged config back — redact before it is
+      // serialized. Schemas came from the `existing` lookup at the top.
+      redactConnectionRow(
+        updated[0] as Record<string, unknown>,
+        connectorSecretKeysFromSchemas({
+          optionsSchema: existing.options_schema,
+          authSchema: existing.auth_schema,
+        }),
+      ),
       effectiveAuth ?? null,
 			effectiveAppAuth ?? null,
     ),

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1777,24 +1777,69 @@ export async function handleUpdate(
   // biome-ignore lint/suspicious/noExplicitAny: postgres.js row shape
   let updated: any[];
   try {
-    updated = await sql`
-      UPDATE connections
-      SET display_name = COALESCE(${args.display_name ?? null}, display_name),
-          slug = COALESCE(${nextSlug}, slug),
-          status = COALESCE(${effectiveStatus}, status),
-          auth_profile_id = ${nextAuthProfileId},
-          app_auth_profile_id = ${nextAppAuthProfileId},
-          visibility = CASE WHEN ${rebindToPersonalCred} THEN 'private' ELSE visibility END,
-          entity_ids = COALESCE(${entityIdsValue}::bigint[], entity_ids),
-          config = ${
-            replaceConfig
-              ? sql`${sql.json(connectionConfigForReplace)}::jsonb`
-              : sql`CASE WHEN ${splitConfig.connectionConfig ? sql.json(splitConfig.connectionConfig) : null}::jsonb IS NOT NULL THEN COALESCE(config, '{}'::jsonb) || ${splitConfig.connectionConfig ? sql.json(splitConfig.connectionConfig) : null}::jsonb ELSE config END`
-          },
-          updated_at = NOW()
-      WHERE id = ${args.connection_id} AND organization_id = ${organizationId} AND deleted_at IS NULL
-      RETURNING *
-    `;
+    // Row-locked restore→write. The `existing` snapshot at the top of this
+    // handler is read WITHOUT a lock, and many awaits (auth-profile lookups,
+    // device binding, feed checks) happen between it and this write — so
+    // restoring sentinels from that snapshot could roll back a rotation another
+    // replica committed in the meantime: A reads, B rotates the secret, A's
+    // restore fills the sentinel from its STALE copy and writes the OLD
+    // plaintext back over B's new value. Silent credential rollback, invisible
+    // through the API because the response is redacted either way.
+    //
+    // Re-reading the config FOR UPDATE inside the same transaction as the
+    // UPDATE makes the restore source the row the write is actually based on.
+    // Mirrors the shape manage_feeds already uses for handleUpdateFeed.
+    updated = await sql.begin(async (tx) => {
+      const lockedRows = await tx`
+        SELECT config
+        FROM connections
+        WHERE id = ${args.connection_id}
+          AND organization_id = ${organizationId}
+          AND deleted_at IS NULL
+        FOR UPDATE
+      `;
+      if (lockedRows.length === 0) return [];
+      const lockedConfig = parseJsonObject(
+        (lockedRows[0] as { config: unknown }).config,
+      );
+
+      // Recompute the incoming config against the LOCKED row. Only the restore
+      // depends on stored values, so this is the sole recomputation needed —
+      // the merge itself is already atomic (`config || <incoming>` below reads
+      // the live row).
+      const lockedSplit =
+        args.config === undefined
+          ? null
+          : splitConfigByFeedScope(
+              restoreRedactedConfig(args.config, lockedConfig) as Record<
+                string,
+                unknown
+              >,
+              (existing.feeds_schema as Record<string, FeedDefinition>) ?? null,
+            );
+      const lockedConnectionConfig = lockedSplit?.connectionConfig ?? null;
+      const lockedReplaceConfig = lockedConnectionConfig ?? {};
+
+      return tx`
+        UPDATE connections
+        SET display_name = COALESCE(${args.display_name ?? null}, display_name),
+            slug = COALESCE(${nextSlug}, slug),
+            status = COALESCE(${effectiveStatus}, status),
+            auth_profile_id = ${nextAuthProfileId},
+            app_auth_profile_id = ${nextAppAuthProfileId},
+            visibility = CASE WHEN ${rebindToPersonalCred} THEN 'private' ELSE visibility END,
+            entity_ids = COALESCE(${entityIdsValue}::bigint[], entity_ids),
+            config = ${
+              replaceConfig
+                ? tx`${tx.json(lockedReplaceConfig)}::jsonb`
+                : tx`CASE WHEN ${lockedConnectionConfig ? tx.json(lockedConnectionConfig) : null}::jsonb IS NOT NULL THEN COALESCE(config, '{}'::jsonb) || ${lockedConnectionConfig ? tx.json(lockedConnectionConfig) : null}::jsonb ELSE config END`
+            },
+            updated_at = NOW()
+        WHERE id = ${args.connection_id} AND organization_id = ${organizationId} AND deleted_at IS NULL
+        RETURNING *
+      `;
+    });
+    if (updated.length === 0) return { error: "Connection not found" };
   } catch (err) {
     if (isConnectionSlugUniqueViolation(err) && updateExplicitSlug) {
 			return {

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1433,11 +1433,9 @@ export async function handleUpdate(
 				organizationId,
 				connectionId: args.connection_id,
 				displayName: args.display_name,
-				// Same un-redaction as the non-chat path below, and this branch needs
-				// it most: chat connectors are precisely the ones declaring
-				// `format: "password"` (Slack/Discord bot tokens), so a UI round-trip
-				// here would clobber the bot token and take the whole chat
-				// integration down.
+				// Same un-redaction as the non-chat path below. Several chat
+				// connectors declare `format: "password"` bot tokens, so a UI
+				// round-trip here would otherwise clobber the live token.
 				config:
 					args.config === undefined
 						? undefined

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1433,16 +1433,15 @@ export async function handleUpdate(
 				organizationId,
 				connectionId: args.connection_id,
 				displayName: args.display_name,
-				// Same un-redaction as the non-chat path below. Several chat
-				// connectors declare `format: "password"` bot tokens, so a UI
-				// round-trip here would otherwise clobber the live token.
-				config:
-					args.config === undefined
-						? undefined
-						: (restoreRedactedConfig(
-								args.config,
-								parseJsonObject(existing.config),
-							) as Record<string, unknown>),
+				// Pass the RAW incoming config. Un-redaction deliberately does NOT
+				// happen here: `existing` is the UNLOCKED snapshot read at the top
+				// of this handler, and restoring from it would roll back a
+				// rotation another replica committed in between — the same stale
+				// -restore race fixed for the non-chat path below, and it matters
+				// more here because the chat connectors are the ones declaring
+				// `format: "password"` bot tokens. `updateChatConnection` re-reads
+				// the row under the stable-chat lock and restores from THAT.
+				config: args.config,
 				status: args.status,
 				...(hasAgentIdArg ? { agentId: args.agent_id ?? null } : {}),
 			});

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -20,6 +20,7 @@ import {
 	loadConnectorSecretKeys,
 	redactConnectionConfig,
 	redactConnectionRow,
+	restoreRedactedConfig,
 } from "../../../../utils/connection-config-redaction";
 import {
 	deleteChatConnection,
@@ -1432,7 +1433,18 @@ export async function handleUpdate(
 				organizationId,
 				connectionId: args.connection_id,
 				displayName: args.display_name,
-				config: args.config,
+				// Same un-redaction as the non-chat path below, and this branch needs
+				// it most: chat connectors are precisely the ones declaring
+				// `format: "password"` (Slack/Discord bot tokens), so a UI round-trip
+				// here would clobber the bot token and take the whole chat
+				// integration down.
+				config:
+					args.config === undefined
+						? undefined
+						: (restoreRedactedConfig(
+								args.config,
+								parseJsonObject(existing.config),
+							) as Record<string, unknown>),
 				status: args.status,
 				...(hasAgentIdArg ? { agentId: args.agent_id ?? null } : {}),
 			});
@@ -1648,8 +1660,25 @@ export async function handleUpdate(
 					? "active"
 					: "pending_auth"
       : null);
+  // Un-redact BEFORE anything reads the incoming config. Clients round-trip
+  // what the (now redacted) read path gave them — the Owletto action-modes
+  // editor spreads `connection.config` and PATCHes it straight back — so a
+  // `__LOBU_REDACTED__` here means "unchanged", not "set the literal
+  // placeholder". Without this the update would overwrite the live credential
+  // with the sentinel: silent data loss, worse than the leak it came from.
+  //
+  // Placed ahead of splitConfigByFeedScope so the feed-scope split, the
+  // consent_only computation, the merge and the replace all see real values.
+  const incomingConfigForWrite =
+    args.config === undefined
+      ? undefined
+      : (restoreRedactedConfig(
+          args.config,
+          parseJsonObject(existing.config),
+        ) as Record<string, unknown>);
+
   const splitConfig = splitConfigByFeedScope(
-    args.config ?? null,
+    incomingConfigForWrite ?? null,
 		(existing.feeds_schema as Record<string, FeedDefinition>) ?? null,
   );
 

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -58,7 +58,10 @@ import {
   validateFeedConfig,
   type FeedDefinition,
 } from './helpers/feed-helpers';
-import { redactConnectionConfig } from '../../utils/connection-config-redaction';
+import {
+  redactConnectionConfig,
+  restoreRedactedConfig,
+} from '../../utils/connection-config-redaction';
 
 /**
  * Sanitize a raw `feeds` row before it is serialized to a caller.
@@ -701,10 +704,20 @@ async function handleUpdateFeed(
     }
     const feedRow = existing[0] as Record<string, unknown>;
 
+    // `read_feed`/`list_feeds` redact feeds.config, so a client that reads and
+    // PATCHes back would otherwise persist `__LOBU_REDACTED__` over the stored
+    // value. Restore from the row (read under the same FOR UPDATE lock, so the
+    // restore sees exactly what the write is based on) before merge/replace.
+    const restoredConfig = hasConfigArg
+      ? (restoreRedactedConfig(args.config, parseJsonObject(feedRow.config)) as Record<
+          string,
+          unknown
+        >)
+      : undefined;
     const effectiveConfig = hasConfigArg
       ? replaceFeedConfig
-        ? (args.config as Record<string, unknown>)
-        : { ...parseJsonObject(feedRow.config), ...args.config }
+        ? (restoredConfig as Record<string, unknown>)
+        : { ...parseJsonObject(feedRow.config), ...restoredConfig }
       : null;
     // Only collected feeds sync — virtual/streaming configs are not the
     // sync-config contract.

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -58,7 +58,37 @@ import {
   validateFeedConfig,
   type FeedDefinition,
 } from './helpers/feed-helpers';
+import { redactConnectionConfig } from '../../utils/connection-config-redaction';
 
+/**
+ * Sanitize a raw `feeds` row before it is serialized to a caller.
+ *
+ * `list_feeds` / `read_feed` / `read_feeds` select `f.*` and spread the row, so
+ * two columns need handling:
+ *
+ *  - `checkpoint` — the connector's opaque sync cursor. `table-schema.ts` names
+ *    it as a column query_sql must never emit; there is no reason these tools
+ *    should be a way around that, and cursors have historically carried tokens
+ *    and full result payloads. Dropped.
+ *  - `config` — free-form jsonb, written verbatim. No SHIPPED connector can
+ *    currently place a credential here (every `secret: true` / `format:
+ *    "password"` declaration sits in an auth/options schema, and
+ *    `splitConfigByFeedScope` only routes a key to feeds.config when a feed's
+ *    own configSchema declares it), so this is HARDENING against a future
+ *    connector rather than a live leak — but the redaction is free and the
+ *    invariant should not depend on a connector author's care. Redacted with
+ *    the same shared walk the connection serializers use.
+ *
+ * All three actions are in PUBLIC_READ_ACTIONS, i.e. the same exposure tier as
+ * the connections list/get paths this branch fixes.
+ */
+function toPublicFeed<T extends Record<string, unknown>>(
+  row: T
+): Omit<T, 'checkpoint'> {
+  const { checkpoint: _checkpoint, ...feed } = row;
+  if (!('config' in feed)) return feed;
+  return { ...feed, config: redactConnectionConfig(feed.config) };
+}
 
 // ============================================
 // Main Function (Action Router)
@@ -229,8 +259,11 @@ async function handleListFeeds(
     total = Number(countRow?.total ?? 0);
   }
   // Strip the window-count helper column from each feed row — it is metadata
-  // about the result set, not a feed field.
-  const feeds = rows.map(({ filtered_total: _filtered_total, ...feed }) => feed);
+  // about the result set, not a feed field — then sanitize the row itself
+  // (checkpoint out, config redacted).
+  const feeds = rows.map(({ filtered_total: _filtered_total, ...feed }) =>
+    toPublicFeed(feed)
+  );
   return {
     action: 'list_feeds',
     feeds,
@@ -288,7 +321,7 @@ async function handleReadFeed(
       ${visibilityFilter}
   `) as Array<Record<string, any>>;
   if (rows.length === 0) return { error: 'Feed not found' };
-  const feed = rows[0];
+  const feed = toPublicFeed(rows[0]);
 
   // A streaming (chat-channel) feed has no sync runs — its content is the live
   // transcript in `channel_messages`. Map the connection slug + feed_key to the

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -59,8 +59,12 @@ import {
   type FeedDefinition,
 } from './helpers/feed-helpers';
 import {
+  feedSecretKeyLookup,
+  feedSecretKeysFromSchema,
+  loadFeedSecretKeys,
   redactConnectionConfig,
   restoreRedactedConfig,
+  type ConnectorSecretKeys,
 } from '../../utils/connection-config-redaction';
 
 /**
@@ -73,20 +77,44 @@ import {
  *    it as a column query_sql must never emit; there is no reason these tools
  *    should be a way around that, and cursors have historically carried tokens
  *    and full result payloads. Dropped.
- *  - `config` — free-form jsonb, written verbatim. Built-in feed schemas
- *    currently declare no password/secret fields, but URL and other free-form
- *    values can still contain credentials. Redacted with the same shared walk
- *    the connection serializers use.
+ *  - `config` — free-form jsonb, written verbatim. Redacted on two layers, the
+ *    same as connection config: the connector's own
+ *    `feeds_schema[feed_key].configSchema` `format: "password"` declarations
+ *    (exact), then the shared keyname/URI walk (backstop). `configSchema` is
+ *    an unconstrained `Record<string, unknown>`, so a CUSTOM connector may
+ *    declare a feed-scoped credential under any name — no shipped connector
+ *    does today (all 27 audited, zero hits), which makes the declared layer
+ *    latent rather than live, but custom definitions are a supported feature
+ *    and the contract must not exempt a declaration site.
  *
  * All three actions are in PUBLIC_READ_ACTIONS, i.e. the same exposure tier as
  * the connections list/get paths this branch fixes.
  */
 function toPublicFeed<T extends Record<string, unknown>>(
-  row: T
+  row: T,
+  declaredSecretKeys?: ConnectorSecretKeys
 ): Omit<T, 'checkpoint'> {
   const { checkpoint: _checkpoint, ...feed } = row;
   if (!('config' in feed)) return feed;
-  return { ...feed, config: redactConnectionConfig(feed.config) };
+  return {
+    ...feed,
+    config: redactConnectionConfig(feed.config, declaredSecretKeys),
+  };
+}
+
+/**
+ * Batch form: sanitize a page of feed rows, resolving each one's
+ * connector-declared secret keys from its own `connector_key` + `feed_key`.
+ * One definition query for the whole page — a per-row lookup would reintroduce
+ * an N+1 on the list path.
+ */
+async function toPublicFeeds<T extends Record<string, unknown>>(
+  organizationId: string,
+  rows: T[]
+): Promise<Array<Omit<T, 'checkpoint'>>> {
+  if (rows.length === 0) return [];
+  const secretKeys = await loadFeedSecretKeys(organizationId, rows);
+  return rows.map((row) => toPublicFeed(row, secretKeys.get(feedSecretKeyLookup(row))));
 }
 
 // ============================================
@@ -163,7 +191,7 @@ async function handleListFeeds(
   // page (offset past the last row); the overshoot fallback below recovers the
   // true count there.
   const pageQuery = sql`
-    SELECT f.*, COUNT(*) OVER()::int AS filtered_total
+    SELECT f.*, c.connector_key, COUNT(*) OVER()::int AS filtered_total
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
     WHERE ${where}
@@ -260,8 +288,9 @@ async function handleListFeeds(
   // Strip the window-count helper column from each feed row — it is metadata
   // about the result set, not a feed field — then sanitize the row itself
   // (checkpoint out, config redacted).
-  const feeds = rows.map(({ filtered_total: _filtered_total, ...feed }) =>
-    toPublicFeed(feed)
+  const feeds = await toPublicFeeds(
+    organizationId,
+    rows.map(({ filtered_total: _filtered_total, ...feed }) => feed)
   );
   return {
     action: 'list_feeds',
@@ -320,7 +349,7 @@ async function handleReadFeed(
       ${visibilityFilter}
   `) as Array<Record<string, any>>;
   if (rows.length === 0) return { error: 'Feed not found' };
-  const feed = toPublicFeed(rows[0]);
+  const [feed] = await toPublicFeeds(organizationId, [rows[0]]);
 
   // A streaming (chat-channel) feed has no sync runs — its content is the live
   // transcript in `channel_messages`. Map the connection slug + feed_key to the
@@ -614,7 +643,12 @@ async function handleCreateFeed(
 
   return {
     action: 'create_feed',
-    feed: toPublicFeed(inserted[0] as Record<string, unknown>),
+    feed: toPublicFeed(
+      inserted[0] as Record<string, unknown>,
+      // `feedsSchema` is the connector definition already loaded above for
+      // config validation — no extra lookup needed.
+      feedSecretKeysFromSchema(feedsSchema, args.feed_key)
+    ),
   };
 }
 
@@ -761,12 +795,19 @@ async function handleUpdateFeed(
     return {
       updated,
       authProfileId: Number(feedRow.auth_profile_id) || null,
+      // Resolved here because the connector's feeds_schema is already joined
+      // into this query — the response serializer below needs it to redact
+      // feed-scoped `format: "password"` fields without a second lookup.
+      declaredSecretKeys: feedSecretKeysFromSchema(
+        feedRow.feeds_schema,
+        String(feedRow.feed_key)
+      ),
     };
   });
   if ('error' in txResult && txResult.error !== undefined) {
     return { error: txResult.error };
   }
-  const { updated, authProfileId } = txResult;
+  const { updated, authProfileId, declaredSecretKeys } = txResult;
   if (authProfileId) {
     const authProfile = await getAuthProfileById(organizationId, authProfileId);
     if (authProfile?.profile_kind === 'oauth_account') {
@@ -793,7 +834,10 @@ async function handleUpdateFeed(
     ...(changedFields.length > 0 ? { changedFields } : {}),
   });
 
-  return { action: 'update_feed', feed: toPublicFeed(updatedFeed) };
+  return {
+    action: 'update_feed',
+    feed: toPublicFeed(updatedFeed, declaredSecretKeys),
+  };
 }
 
 async function handleDeleteFeed(

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -73,14 +73,10 @@ import {
  *    it as a column query_sql must never emit; there is no reason these tools
  *    should be a way around that, and cursors have historically carried tokens
  *    and full result payloads. Dropped.
- *  - `config` — free-form jsonb, written verbatim. No SHIPPED connector can
- *    currently place a credential here (every `secret: true` / `format:
- *    "password"` declaration sits in an auth/options schema, and
- *    `splitConfigByFeedScope` only routes a key to feeds.config when a feed's
- *    own configSchema declares it), so this is HARDENING against a future
- *    connector rather than a live leak — but the redaction is free and the
- *    invariant should not depend on a connector author's care. Redacted with
- *    the same shared walk the connection serializers use.
+ *  - `config` — free-form jsonb, written verbatim. Built-in feed schemas
+ *    currently declare no password/secret fields, but URL and other free-form
+ *    values can still contain credentials. Redacted with the same shared walk
+ *    the connection serializers use.
  *
  * All three actions are in PUBLIC_READ_ACTIONS, i.e. the same exposure tier as
  * the connections list/get paths this branch fixes.
@@ -616,7 +612,10 @@ async function handleCreateFeed(
     state: inserted[0] as Record<string, unknown>,
   });
 
-  return { action: 'create_feed', feed: inserted[0] };
+  return {
+    action: 'create_feed',
+    feed: toPublicFeed(inserted[0] as Record<string, unknown>),
+  };
 }
 
 async function handleUpdateFeed(
@@ -794,7 +793,7 @@ async function handleUpdateFeed(
     ...(changedFields.length > 0 ? { changedFields } : {}),
   });
 
-  return { action: 'update_feed', feed: updated[0] };
+  return { action: 'update_feed', feed: toPublicFeed(updatedFeed) };
 }
 
 async function handleDeleteFeed(

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -1419,9 +1419,9 @@ async function formatEntityResult(
 
 /**
  * `c.config` here is the same verbatim jsonb the manage_connections read paths
- * serve, so it carries connector secrets (bot tokens, DATABASE_URLs). Redacted
- * on the way out — the field stays present (sentinel, not deleted) so a caller
- * can still see WHICH options are configured.
+ * serve, so it can carry connector secrets such as bot tokens and connection
+ * strings. Redacted on the way out; the field stays present so callers can
+ * still see which options are configured.
  */
 async function fetchConnectionsForEntity(
   entityId: number,

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -24,6 +24,7 @@ import {
 import { entityLinkMatchSql, searchContentByText } from '../utils/content-search';
 import { resolveBoundChannelRows, stripPlatformPrefix } from '../gateway/channels/bound-channels';
 import { filterChannelsForRequester } from '../authz/channel-visibility';
+import { redactConnectionRows } from '../utils/connection-config-redaction';
 import { toVectorLiteral } from '../utils/entity-management';
 import { ToolUserError } from '../utils/errors';
 import logger from '../utils/logger';
@@ -1416,6 +1417,12 @@ async function formatEntityResult(
   };
 }
 
+/**
+ * `c.config` here is the same verbatim jsonb the manage_connections read paths
+ * serve, so it carries connector secrets (bot tokens, DATABASE_URLs). Redacted
+ * on the way out — the field stays present (sentinel, not deleted) so a caller
+ * can still see WHICH options are configured.
+ */
 async function fetchConnectionsForEntity(
   entityId: number,
   scope: AuthzScope
@@ -1454,7 +1461,10 @@ async function fetchConnectionsForEntity(
     LIMIT 20
   `;
 
-  return result as ConnectionInfo[];
+  return (await redactConnectionRows(
+    scope.organizationId,
+    result as unknown as Array<Record<string, unknown>>
+  )) as unknown as ConnectionInfo[];
 }
 
 async function attachOrganizationSlugs(rows: EntityQueryRow[]): Promise<void> {

--- a/packages/server/src/utils/__tests__/config-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/config-redaction.test.ts
@@ -4,6 +4,7 @@ import {
   REDACTED_SENTINEL,
   redactConfigState,
 } from '../config-redaction';
+import { restoreRedactedConfig } from '../connection-config-redaction';
 
 describe('redactConfigState', () => {
   it('redacts denylisted keys at any depth, any case style', () => {
@@ -102,6 +103,74 @@ describe('isSecretKey > URL/DSN-shaped credential keys', () => {
       expect(isSecretKey(key)).toBe(false);
     }
   );
+});
+
+/**
+ * The write-side inverse. A client that reads a redacted config and PATCHes it
+ * back must not persist the placeholder over the live credential — the sentinel
+ * means "unchanged".
+ */
+describe('restoreRedactedConfig', () => {
+  it('restores a bare sentinel from the stored value', () => {
+    const out = restoreRedactedConfig(
+      { password: REDACTED_SENTINEL, host: 'db.internal' },
+      { password: 'real-secret', host: 'old.host' }
+    ) as Record<string, unknown>;
+    expect(out.password).toBe('real-secret');
+    // A non-secret edit still lands.
+    expect(out.host).toBe('db.internal');
+  });
+
+  it('restores the URI form, which is not equal to the bare sentinel', () => {
+    // redactUriCredentials emits `postgres://__LOBU_REDACTED__@host/db`; a
+    // naive `=== REDACTED_SENTINEL` check misses this and clobbers the DSN.
+    const stored = 'postgres://u:pw@db.internal:5432/app';
+    const out = restoreRedactedConfig(
+      { DATABASE_URL: `postgres://${REDACTED_SENTINEL}@db.internal:5432/app` },
+      { DATABASE_URL: stored }
+    ) as Record<string, unknown>;
+    expect(out.DATABASE_URL).toBe(stored);
+  });
+
+  it('restores at any nesting depth and through arrays', () => {
+    const out = restoreRedactedConfig(
+      {
+        nested: { database: { password: REDACTED_SENTINEL } },
+        headers: [{ Authorization: REDACTED_SENTINEL }, { 'X-Trace': 'keep' }],
+      },
+      {
+        nested: { database: { password: 'deep-secret' } },
+        headers: [{ Authorization: 'Bearer real' }, { 'X-Trace': 'old' }],
+      }
+    ) as Record<string, any>;
+    expect(out.nested.database.password).toBe('deep-secret');
+    expect(out.headers[0].Authorization).toBe('Bearer real');
+    expect(out.headers[1]['X-Trace']).toBe('keep');
+  });
+
+  it('lets a genuinely new secret through (rotation still works)', () => {
+    const out = restoreRedactedConfig(
+      { password: 'rotated' },
+      { password: 'old-secret' }
+    ) as Record<string, unknown>;
+    expect(out.password).toBe('rotated');
+  });
+
+  it('drops a sentinel that has nothing to restore from', () => {
+    // Writing the literal placeholder is never the caller's intent, so a
+    // sentinel on a key with no stored counterpart is omitted, not persisted.
+    const out = restoreRedactedConfig(
+      { brand_new: REDACTED_SENTINEL, kept: 'value' },
+      {}
+    ) as Record<string, unknown>;
+    expect('brand_new' in out).toBe(false);
+    expect(out.kept).toBe('value');
+  });
+
+  it('is a no-op when nothing is redacted', () => {
+    const incoming = { host: 'db.internal', port: 5432, tags: ['a', 'b'] };
+    expect(restoreRedactedConfig(incoming, { host: 'old' })).toEqual(incoming);
+  });
 });
 
 /**

--- a/packages/server/src/utils/__tests__/config-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/config-redaction.test.ts
@@ -1,3 +1,4 @@
+import { isSecretKey } from '@lobu/core';
 import { describe, expect, it } from 'vitest';
 import {
   REDACTED_SENTINEL,
@@ -68,5 +69,58 @@ describe('redactConfigState', () => {
     });
     expect(out?.apiKey).toBe(REDACTED_SENTINEL);
     expect(out?.baseUrl).toBe('https://api.z.ai');
+  });
+});
+
+/**
+ * The denylist is SUFFIX-anchored (`(^|_)(token|secret|…)s?$`), which by
+ * construction misses URL/DSN-shaped credential keys — `DATABASE_URL` ends in
+ * `_url`, not in any denylisted term. That gap is exactly the bug this branch
+ * started from: a `postgres://user:pass@host/db` sitting in
+ * `connections.config.DATABASE_URL` and served straight back by
+ * `connections.list()`. These cases pin the fix so it cannot silently regress.
+ */
+describe('isSecretKey > URL/DSN-shaped credential keys', () => {
+  it.each(['DATABASE_URL', 'database_url', 'databaseUrl', 'dsn', 'connection_string', 'connectionString', 'db_url'])(
+    'classifies %s as secret',
+    (key) => {
+      expect(isSecretKey(key)).toBe(true);
+    }
+  );
+
+  it.each(['authorization', 'Authorization', 'cookie', 'session_id', 'sessionId', 'bearer'])(
+    'classifies %s as secret',
+    (key) => {
+      expect(isSecretKey(key)).toBe(true);
+    }
+  );
+
+  // The suffix anchoring is load-bearing — these must stay readable.
+  it.each(['tokenizer', 'keyboard', 'secretsPolicy', 'url', 'base_url', 'webhook_url', 'authorization_mode'])(
+    'does NOT classify %s as secret',
+    (key) => {
+      expect(isSecretKey(key)).toBe(false);
+    }
+  );
+});
+
+/**
+ * Key names are not sufficient on their own: a connection string can sit under
+ * a perfectly innocuous key (`primary`, `endpoint`). The value-shaped pass
+ * strips the `user:password@` userinfo while leaving scheme + host readable.
+ */
+describe('redactConfigState > URI credential values', () => {
+  it('redacts credentials embedded in a connection string under a non-secret key', () => {
+    const out = redactConfigState('connection', {
+      config: {
+        primary: 'postgres://admin:hunter2@db.internal:5432/app',
+        endpoint: 'https://api.example.com/v1',
+      },
+    });
+    const config = out?.config as Record<string, unknown>;
+    expect(config.primary).toBe(`postgres://${REDACTED_SENTINEL}@db.internal:5432/app`);
+    expect(config.primary).not.toContain('hunter2');
+    // A URL with no userinfo is untouched.
+    expect(config.endpoint).toBe('https://api.example.com/v1');
   });
 });

--- a/packages/server/src/utils/__tests__/config-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/config-redaction.test.ts
@@ -4,7 +4,11 @@ import {
   REDACTED_SENTINEL,
   redactConfigState,
 } from '../config-redaction';
-import { restoreRedactedConfig } from '../connection-config-redaction';
+import {
+  connectorSecretKeysFromSchemas,
+  redactConnectionConfig,
+  restoreRedactedConfig,
+} from '../connection-config-redaction';
 
 describe('redactConfigState', () => {
   it('redacts denylisted keys at any depth, any case style', () => {
@@ -89,7 +93,19 @@ describe('isSecretKey > URL/DSN-shaped credential keys', () => {
     }
   );
 
-  it.each(['authorization', 'Authorization', 'cookie', 'session_id', 'sessionId', 'bearer'])(
+  it.each([
+    'authorization',
+    'Authorization',
+    'cookie',
+    'session_id',
+    'sessionId',
+    'bearer',
+    'X-Api-Key',
+    'Proxy-Authorization',
+    'Set-Cookie',
+    'client-secret',
+    ' password ',
+  ])(
     'classifies %s as secret',
     (key) => {
       expect(isSecretKey(key)).toBe(true);
@@ -170,6 +186,58 @@ describe('restoreRedactedConfig', () => {
   it('is a no-op when nothing is redacted', () => {
     const incoming = { host: 'db.internal', port: 5432, tags: ['a', 'b'] };
     expect(restoreRedactedConfig(incoming, { host: 'old' })).toEqual(incoming);
+  });
+});
+
+describe('redactConnectionConfig', () => {
+  it('redacts array-valued config recursively', () => {
+    expect(
+      redactConnectionConfig([
+        { password: 'array-secret' },
+        { nested: { apiKey: 'nested-array-secret' }, visible: 'value' },
+      ])
+    ).toEqual([
+      { password: REDACTED_SENTINEL },
+      { nested: { apiKey: REDACTED_SENTINEL }, visible: 'value' },
+    ]);
+  });
+
+  it('redacts schema-declared secrets whose names do not match the denylist', () => {
+    const declaredKeys = connectorSecretKeysFromSchemas({
+      optionsSchema: {
+        properties: {
+          opaqueOption: { type: 'string', format: 'password' },
+          visibleOption: { type: 'string' },
+        },
+      },
+      authSchema: {
+        methods: [
+          {
+            fields: [
+              { key: 'authMaterial', secret: true },
+              { key: 'visibleValue', secret: false },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(
+      redactConnectionConfig(
+        {
+          opaqueOption: 'option-secret',
+          authMaterial: 'auth-secret',
+          visibleOption: 'visible',
+          visibleValue: 'also-visible',
+        },
+        declaredKeys
+      )
+    ).toEqual({
+      opaqueOption: REDACTED_SENTINEL,
+      authMaterial: REDACTED_SENTINEL,
+      visibleOption: 'visible',
+      visibleValue: 'also-visible',
+    });
   });
 });
 

--- a/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
@@ -14,7 +14,11 @@
 import { isSecretKey } from '@lobu/core';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { getTestDb } from '../../__tests__/setup/test-db';
-import { SAFE_COLUMN_DEFS, buildColumnList } from '../table-schema';
+import {
+  DECLARED_SECRETS_REF,
+  SAFE_COLUMN_DEFS,
+  buildColumnList,
+} from '../table-schema';
 
 /** Key names probed against both implementations. */
 const SECRET_KEYS = [
@@ -64,6 +68,34 @@ const NON_SECRET_KEYS = [
 ];
 
 describe('table-schema config redaction', () => {
+  /**
+   * The heuristic denylist is only ONE of the two layers the TypeScript
+   * serializers apply; the other is what the connector DECLARES secret. The SQL
+   * path must carry both, or a declared secret with an off-denylist name
+   * (`signingMaterial`) is redacted by list()/get() and plaintext via query_sql.
+   *
+   * The parity cases below compare SQL to `isSecretKey` and by construction can
+   * never catch that, so the declared layer is pinned structurally here.
+   */
+  it('incorporates connector-declared secrets for connections, not just the denylist', () => {
+    const connectionsConfig = SAFE_COLUMN_DEFS.get('connections')?.find(
+      (c) => c.name === 'config'
+    );
+    expect(connectionsConfig?.expr).toContain(DECLARED_SECRETS_REF);
+
+    // Bound to an alias, the marker must resolve to a real correlated lookup
+    // over connector_definitions — not silently vanish.
+    const bound = buildColumnList(SAFE_COLUMN_DEFS.get('connections') ?? [], 'cn');
+    expect(bound).not.toContain(DECLARED_SECRETS_REF);
+    expect(bound).toContain('connector_definitions');
+    expect(bound).toContain("'password'");
+    expect(bound).toContain("af->>'secret'");
+    // Correlation must be org-scoped: another tenant's connector definition
+    // must not decide what this row redacts.
+    expect(bound).toContain('cn.organization_id');
+    expect(bound).toContain('cn.connector_key');
+  });
+
   it('emits a redacting expression for connections.config and feeds.config', () => {
     for (const table of ['connections', 'feeds']) {
       const defs = SAFE_COLUMN_DEFS.get(table);
@@ -89,6 +121,24 @@ describe('table-schema config redaction', () => {
     });
 
     /**
+     * Bind the generated expression's markers for a synthetic probe row.
+     *
+     * `$COL$` becomes the probe's jsonb literal. `$DECLARED$` becomes the empty
+     * array: these cases probe the HEURISTIC layer against a row with no
+     * connector to correlate to, and an unbound `$DECLARED$` would additionally
+     * be parsed by Postgres as a dollar-quote and blow up the statement. The
+     * declared-secret layer is covered separately, structurally above and
+     * end-to-end in connections-config-redaction.test.ts.
+     */
+    function bindExpr(expr: string): string {
+      return expr
+        .split('$COL$')
+        .join('probe.config')
+        .split('$DECLARED$')
+        .join('ARRAY[]::text[]');
+    }
+
+    /**
      * Run the real generated expression over a one-row jsonb literal and report
      * whether the value under `key` came back redacted.
      */
@@ -96,9 +146,7 @@ describe('table-schema config redaction', () => {
       const defs = SAFE_COLUMN_DEFS.get('connections') ?? [];
       const expr = defs.find((c) => c.name === 'config')?.expr;
       if (!expr) throw new Error('connections.config has no redaction expr');
-      // The expr references the source column via the $COL$ marker, which
-      // buildColumnList substitutes; here we bind it to the probe literal.
-      const bound = expr.split('$COL$').join('probe.config');
+      const bound = bindExpr(expr);
       // The key is inlined as a quoted literal rather than bound: postgres.js
       // cannot infer a type for the right-hand side of `->>`, so a $N parameter
       // there comes back NULL and every probe would read as "redacted". Keys
@@ -125,7 +173,7 @@ describe('table-schema config redaction', () => {
     it('redacts a nested secret, not just the top level', async () => {
       const defs = SAFE_COLUMN_DEFS.get('connections') ?? [];
       const expr = defs.find((c) => c.name === 'config')?.expr;
-      const bound = (expr ?? '').split('$COL$').join('probe.config');
+      const bound = bindExpr(expr ?? '');
       const rows = await sql.unsafe(
         `SELECT (${bound}) #>> '{nested,database,password}' AS value
          FROM (SELECT $1::jsonb AS config) probe`,
@@ -137,7 +185,7 @@ describe('table-schema config redaction', () => {
     it('preserves a nested non-secret value', async () => {
       const defs = SAFE_COLUMN_DEFS.get('connections') ?? [];
       const expr = defs.find((c) => c.name === 'config')?.expr;
-      const bound = (expr ?? '').split('$COL$').join('probe.config');
+      const bound = bindExpr(expr ?? '');
       const rows = await sql.unsafe(
         `SELECT (${bound}) #>> '{nested,database,host}' AS value
          FROM (SELECT $1::jsonb AS config) probe`,
@@ -149,7 +197,7 @@ describe('table-schema config redaction', () => {
     it('redacts URI credentials under a non-secret key', async () => {
       const defs = SAFE_COLUMN_DEFS.get('connections') ?? [];
       const expr = defs.find((c) => c.name === 'config')?.expr;
-      const bound = (expr ?? '').split('$COL$').join('probe.config');
+      const bound = bindExpr(expr ?? '');
       const rows = await sql.unsafe(
         `SELECT (${bound}) ->> 'primary' AS value
          FROM (SELECT $1::jsonb AS config) probe`,

--- a/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
@@ -85,7 +85,11 @@ describe('table-schema config redaction', () => {
 
     // Bound to an alias, the marker must resolve to a real correlated lookup
     // over connector_definitions — not silently vanish.
-    const bound = buildColumnList(SAFE_COLUMN_DEFS.get('connections') ?? [], 'cn');
+    const bound = buildColumnList(
+      SAFE_COLUMN_DEFS.get('connections') ?? [],
+      'cn',
+      'connections'
+    );
     expect(bound).not.toContain(DECLARED_SECRETS_REF);
     expect(bound).toContain('connector_definitions');
     expect(bound).toContain("'password'");
@@ -94,6 +98,29 @@ describe('table-schema config redaction', () => {
     // must not decide what this row redacts.
     expect(bound).toContain('cn.organization_id');
     expect(bound).toContain('cn.connector_key');
+  });
+
+  it('incorporates connector-declared secrets for feeds, correlated via connection_id', () => {
+    // `feeds` carries no `connector_key`, so the definition is reached through
+    // `connection_id` -> `connections` -> `connector_definitions`. An earlier
+    // pass claimed this was not correlatable and left the feeds arm
+    // heuristic-only; it IS correlatable, and this pins it.
+    const bound = buildColumnList(SAFE_COLUMN_DEFS.get('feeds') ?? [], 'fd', 'feeds');
+    expect(bound).not.toContain(DECLARED_SECRETS_REF);
+    expect(bound).toContain('connector_definitions');
+    expect(bound).toContain("'configSchema'");
+    expect(bound).toContain('fd.connection_id');
+    expect(bound).toContain('fd.feed_key');
+    // Org-scoped on BOTH hops.
+    expect(bound).toContain('fd.organization_id');
+    expect(bound).toContain('cdfeed.organization_id = cfeed.organization_id');
+  });
+
+  it('falls back to the empty set for an unrecognized table', () => {
+    // No correlation available -> heuristic-only, never MORE exposed.
+    const bound = buildColumnList(SAFE_COLUMN_DEFS.get('feeds') ?? [], 'z', 'not_a_table');
+    expect(bound).not.toContain(DECLARED_SECRETS_REF);
+    expect(bound).toContain('ARRAY[]::text[]');
   });
 
   it('emits a redacting expression for connections.config and feeds.config', () => {
@@ -107,7 +134,7 @@ describe('table-schema config redaction', () => {
         `${table}.config must carry a redacting expr, not be selected raw`
       ).toBeTruthy();
       // The generated list must never contain a bare reference to the column.
-      const list = buildColumnList(defs ?? [], 'x');
+      const list = buildColumnList(defs ?? [], 'x', table);
       expect(list).toContain('as "config"');
       expect(list).not.toMatch(/x\."config" as "config"/);
     }

--- a/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
@@ -1,0 +1,144 @@
+/**
+ * `query_sql` redacts `connections.config` / `feeds.config` in SQL, at the
+ * table-schema chokepoint, because the tool is member-safe and neither table is
+ * in ADMIN_ONLY_QUERYABLE_TABLES. That means the denylist exists twice: once in
+ * TypeScript (`isSecretKey` in @lobu/core, used by every serializer) and once
+ * as a SQL regex + IN-list inside the generated CTE expression.
+ *
+ * Two implementations of one security rule drift. These tests pin them
+ * together: every key name the TS side calls secret must also be matched by the
+ * SQL expression, and vice versa. If you add a term to one, this fails until
+ * you add it to the other.
+ */
+
+import { isSecretKey } from '@lobu/core';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getTestDb } from '../../__tests__/setup/test-db';
+import { SAFE_COLUMN_DEFS, buildColumnList } from '../table-schema';
+
+/** Key names probed against both implementations. */
+const SECRET_KEYS = [
+  'password',
+  'passwd',
+  'token',
+  'access_token',
+  'refresh_token',
+  'accessToken',
+  'api_key',
+  'apiKey',
+  'secret',
+  'client_secret',
+  'clientSecret',
+  'private_key',
+  'credential',
+  'credentials',
+  'session_id',
+  'sessionId',
+  'authorization',
+  'cookie',
+  'bearer',
+  'DATABASE_URL',
+  'database_url',
+  'databaseUrl',
+  'db_url',
+  'connection_string',
+  'dsn',
+];
+
+const NON_SECRET_KEYS = [
+  'host',
+  'port',
+  'channel',
+  'base_url',
+  'webhook_url',
+  'tokenizer',
+  'keyboard',
+  'secretsPolicy',
+  'display_name',
+  'feed_key',
+];
+
+describe('table-schema config redaction', () => {
+  it('emits a redacting expression for connections.config and feeds.config', () => {
+    for (const table of ['connections', 'feeds']) {
+      const defs = SAFE_COLUMN_DEFS.get(table);
+      expect(defs, `${table} must be queryable`).toBeDefined();
+      const config = defs?.find((c) => c.name === 'config');
+      expect(config, `${table}.config must stay queryable`).toBeDefined();
+      expect(
+        config?.expr,
+        `${table}.config must carry a redacting expr, not be selected raw`
+      ).toBeTruthy();
+      // The generated list must never contain a bare reference to the column.
+      const list = buildColumnList(defs ?? [], 'x');
+      expect(list).toContain('as "config"');
+      expect(list).not.toMatch(/x\."config" as "config"/);
+    }
+  });
+
+  describe('SQL denylist matches the TypeScript denylist', () => {
+    let sql: ReturnType<typeof getTestDb>;
+
+    beforeAll(() => {
+      sql = getTestDb();
+    });
+
+    /**
+     * Run the real generated expression over a one-row jsonb literal and report
+     * whether the value under `key` came back redacted.
+     */
+    async function sqlRedacts(key: string): Promise<boolean> {
+      const defs = SAFE_COLUMN_DEFS.get('connections') ?? [];
+      const expr = defs.find((c) => c.name === 'config')?.expr;
+      if (!expr) throw new Error('connections.config has no redaction expr');
+      // The expr references the source column via the $COL$ marker, which
+      // buildColumnList substitutes; here we bind it to the probe literal.
+      const bound = expr.split('$COL$').join('probe.config');
+      // The key is inlined as a quoted literal rather than bound: postgres.js
+      // cannot infer a type for the right-hand side of `->>`, so a $N parameter
+      // there comes back NULL and every probe would read as "redacted". Keys
+      // come from the fixed arrays above, and quotes are escaped.
+      const keyLiteral = `'${key.replace(/'/g, "''")}'`;
+      const rows = await sql.unsafe(
+        `SELECT (${bound}) ->> ${keyLiteral} AS value
+         FROM (SELECT $1::jsonb AS config) probe`,
+        [sql.json({ [key]: 'probe-value' }) as unknown as string]
+      );
+      return (rows[0] as { value: string | null }).value !== 'probe-value';
+    }
+
+    it.each(SECRET_KEYS)('SQL redacts %s (TS agrees)', async (key) => {
+      expect(isSecretKey(key), `TS denylist must classify ${key} as secret`).toBe(true);
+      expect(await sqlRedacts(key), `SQL denylist must redact ${key}`).toBe(true);
+    });
+
+    it.each(NON_SECRET_KEYS)('SQL preserves %s (TS agrees)', async (key) => {
+      expect(isSecretKey(key), `TS denylist must NOT classify ${key} as secret`).toBe(false);
+      expect(await sqlRedacts(key), `SQL denylist must preserve ${key}`).toBe(false);
+    });
+
+    it('redacts a nested secret, not just the top level', async () => {
+      const defs = SAFE_COLUMN_DEFS.get('connections') ?? [];
+      const expr = defs.find((c) => c.name === 'config')?.expr;
+      const bound = (expr ?? '').split('$COL$').join('probe.config');
+      const rows = await sql.unsafe(
+        `SELECT (${bound}) #>> '{nested,database,password}' AS value
+         FROM (SELECT $1::jsonb AS config) probe`,
+        [sql.json({ nested: { database: { password: 'probe-value' } } }) as unknown as string]
+      );
+      expect((rows[0] as { value: string | null }).value).not.toBe('probe-value');
+    });
+
+    it('preserves a nested non-secret value', async () => {
+      const defs = SAFE_COLUMN_DEFS.get('connections') ?? [];
+      const expr = defs.find((c) => c.name === 'config')?.expr;
+      const bound = (expr ?? '').split('$COL$').join('probe.config');
+      const rows = await sql.unsafe(
+        `SELECT (${bound}) #>> '{nested,database,host}' AS value
+         FROM (SELECT $1::jsonb AS config) probe`,
+        [sql.json({ nested: { database: { host: 'db.internal' } } }) as unknown as string]
+      );
+      expect((rows[0] as { value: string | null }).value).toBe('db.internal');
+    });
+  });
+});

--- a/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
@@ -2,13 +2,13 @@
  * `query_sql` redacts `connections.config` / `feeds.config` in SQL, at the
  * table-schema chokepoint, because the tool is member-safe and neither table is
  * in ADMIN_ONLY_QUERYABLE_TABLES. That means the denylist exists twice: once in
- * TypeScript (`isSecretKey` in @lobu/core, used by every serializer) and once
- * as a SQL regex + IN-list inside the generated CTE expression.
+ * TypeScript (`isSecretKey` in @lobu/core, used by the config serializers) and
+ * once as a SQL regex + IN-list inside the generated CTE expression.
  *
  * Two implementations of one security rule drift. These tests pin them
  * together: every key name the TS side calls secret must also be matched by the
- * SQL expression, and vice versa. If you add a term to one, this fails until
- * you add it to the other.
+ * SQL expression, and vice versa. The value-shaped URI credential backstop is
+ * also exercised against the generated expression.
  */
 
 import { isSecretKey } from '@lobu/core';
@@ -43,6 +43,11 @@ const SECRET_KEYS = [
   'db_url',
   'connection_string',
   'dsn',
+  'X-Api-Key',
+  'Proxy-Authorization',
+  'Set-Cookie',
+  'client-secret',
+  ' password ',
 ];
 
 const NON_SECRET_KEYS = [
@@ -139,6 +144,22 @@ describe('table-schema config redaction', () => {
         [sql.json({ nested: { database: { host: 'db.internal' } } }) as unknown as string]
       );
       expect((rows[0] as { value: string | null }).value).toBe('db.internal');
+    });
+
+    it('redacts URI credentials under a non-secret key', async () => {
+      const defs = SAFE_COLUMN_DEFS.get('connections') ?? [];
+      const expr = defs.find((c) => c.name === 'config')?.expr;
+      const bound = (expr ?? '').split('$COL$').join('probe.config');
+      const rows = await sql.unsafe(
+        `SELECT (${bound}) ->> 'primary' AS value
+         FROM (SELECT $1::jsonb AS config) probe`,
+        [
+          sql.json({
+            primary: 'postgres://user:pw-LEAK-uri@db.internal:5432/app',
+          }) as unknown as string,
+        ]
+      );
+      expect((rows[0] as { value: string | null }).value).not.toContain('pw-LEAK-uri');
     });
   });
 });

--- a/packages/server/src/utils/connection-config-redaction.ts
+++ b/packages/server/src/utils/connection-config-redaction.ts
@@ -45,7 +45,7 @@ export { REDACTED_SENTINEL };
  * conventions. Top-level `config` keys only — nesting under them is handled by
  * the recursive keyname backstop.
  */
-type ConnectorSecretKeys = ReadonlySet<string>;
+export type ConnectorSecretKeys = ReadonlySet<string>;
 
 /** Collect `options_schema.properties.<key>.format === 'password'` keys. */
 function optionPasswordKeys(optionsSchema: unknown): string[] {
@@ -101,6 +101,81 @@ export function connectorSecretKeysFromSchemas(params: {
 		...optionPasswordKeys(params.optionsSchema),
 		...authSecretFieldKeys(params.authSchema),
 	]);
+}
+
+/**
+ * Declared secret keys for ONE feed, from its connector's
+ * `feeds_schema[feed_key].configSchema.properties.<k>.format === "password"`.
+ *
+ * `FeedDefinition.configSchema` is `Record<string, unknown>` — unconstrained —
+ * so a custom connector may declare a feed-scoped credential under any name.
+ * No shipped connector does today, but the redaction contract must not exempt
+ * a declaration site just because nothing currently uses it.
+ */
+export function feedSecretKeysFromSchema(
+	feedsSchema: unknown,
+	feedKey: string,
+): ConnectorSecretKeys {
+	if (!feedsSchema || typeof feedsSchema !== "object") return new Set();
+	const definition = (feedsSchema as Record<string, unknown>)[feedKey];
+	if (!definition || typeof definition !== "object") return new Set();
+	return new Set(
+		optionPasswordKeys((definition as Record<string, unknown>).configSchema),
+	);
+}
+
+/**
+ * Batch form: resolve each row's feed-declared secret keys from its own
+ * `connector_key` + `feed_key`, in ONE query for the whole page.
+ *
+ * Rows must carry `feed_key` and `connector_key` (the manage_feeds queries
+ * already join the connection for `connector_key`).
+ */
+export async function loadFeedSecretKeys(
+	organizationId: string,
+	rows: ReadonlyArray<{ connector_key?: unknown; feed_key?: unknown }>,
+): Promise<Map<string, ConnectorSecretKeys>> {
+	const byConnectorFeed = new Map<string, ConnectorSecretKeys>();
+	const connectorKeys = [
+		...new Set(rows.map((r) => String(r.connector_key ?? "")).filter(Boolean)),
+	];
+	if (connectorKeys.length === 0) return byConnectorFeed;
+
+	const sql = getDb();
+	const definitions = await sql`
+    SELECT DISTINCT ON (key) key, feeds_schema
+    FROM connector_definitions
+    WHERE organization_id = ${organizationId}
+      AND status = 'active'
+      AND key = ANY(${pgTextArray(connectorKeys)}::text[])
+    ORDER BY key, updated_at DESC
+  `;
+	const schemaByConnector = new Map<string, unknown>(
+		(
+			definitions as unknown as Array<{ key: string; feeds_schema: unknown }>
+		).map((row) => [row.key, row.feeds_schema]),
+	);
+
+	for (const row of rows) {
+		const connectorKey = String(row.connector_key ?? "");
+		const feedKey = String(row.feed_key ?? "");
+		if (!connectorKey || !feedKey) continue;
+		const cacheKey = `${connectorKey}\u0000${feedKey}`;
+		if (byConnectorFeed.has(cacheKey)) continue;
+		byConnectorFeed.set(
+			cacheKey,
+			feedSecretKeysFromSchema(schemaByConnector.get(connectorKey), feedKey),
+		);
+	}
+	return byConnectorFeed;
+}
+
+/** Key into the {@link loadFeedSecretKeys} map for a row. */
+export function feedSecretKeyLookup(row: {
+	connector_key?: unknown;
+	feed_key?: unknown;
+}): string {
+	return `${String(row.connector_key ?? "")}\u0000${String(row.feed_key ?? "")}`;
 }
 
 /**
@@ -244,31 +319,24 @@ function isRedactedValue(value: unknown): boolean {
 /**
  * Restore redacted values in an INCOMING config from what is already stored.
  *
- * Clients may round-trip config: the Owletto action-modes editor spreads the
- * fetched `connection.config` and PATCHes it back with one field changed, and
- * agents can use the same read-modify-write pattern through run_sdk.
- * Because the read path now returns `__LOBU_REDACTED__` where a secret used to
- * be, that write would persist the SENTINEL over the live credential: the
- * connection breaks at next use, with no error at save time and no way to
- * recover the plaintext. That is data loss caused by the redaction, which is
- * strictly worse than the leak it prevents.
+ * INVARIANT: on the write side a sentinel means "unchanged", never a literal
+ * value. Clients round-trip config (the Owletto editor spreads
+ * `connection.config` and PATCHes it back; agents do the same via run_sdk), so
+ * without this the sentinel would overwrite the live credential — silent data
+ * loss, worse than the leak the redaction prevents. Rotation still works: new
+ * plaintext carries no sentinel.
  *
- * So a sentinel on the WRITE side means "unchanged": it is replaced with the
- * value currently stored at the same path. Well-behaved clients see a no-op;
- * a client that genuinely wants to rotate a secret sends the new plaintext,
- * which contains no sentinel and is written normally.
+ * Preserve was chosen over rejecting the write because the API is public and
+ * already in use; a 400 would break shipped clients for doing the obvious
+ * read-modify-write.
  *
- * Walks objects and arrays so it matches the read path's depth, and handles
- * the URI form by restoring the stored value whenever the incoming string
- * merely CONTAINS a sentinel. A sentinel with no stored counterpart (a key that
- * did not previously exist) is dropped rather than persisted — writing the
- * literal placeholder is never the caller's intent.
+ * Walks objects and arrays to match the read path's depth, and treats a string
+ * that CONTAINS a sentinel as redacted so the URI form is covered too. A
+ * sentinel with no stored counterpart is dropped rather than persisted.
  *
- * REJECTING the write instead was the alternative. Preserve wins because the
- * API is public and already in use: an agent that reads-modifies-writes is
- * doing the obvious thing, and a 400 would break the shipped action-modes
- * toggle until every client is patched. Preserve is invisible to correct
- * clients and lossless for careless ones.
+ * Callers must pass the value they are actually writing against — restoring
+ * from a stale snapshot rolls back a concurrent rotation, so read the row under
+ * the same lock/transaction as the write.
  */
 export function restoreRedactedConfig(
 	incoming: unknown,

--- a/packages/server/src/utils/connection-config-redaction.ts
+++ b/packages/server/src/utils/connection-config-redaction.ts
@@ -1,0 +1,213 @@
+/**
+ * Redaction for `connections.config` on every serialization boundary.
+ *
+ * `connections.config` is written VERBATIM — the create/update path splits it
+ * by FEED SCOPE (`splitConfigByFeedScope`), never by secrecy — so a Slack bot
+ * token, a webhook bearer token, or a Postgres `DATABASE_URL` lands in the row
+ * as plaintext. Every read path that serializes a connection to a caller must
+ * therefore pass its `config` through {@link redactConnectionConfig} first.
+ *
+ * Two layers, in this order:
+ *
+ *  1. SCHEMA-DRIVEN (primary, precise). Connectors already declare which of
+ *     their option/auth fields are secret, in two existing conventions:
+ *       - `options_schema.properties.<key>.format === "password"`
+ *         (discord `botToken`, webhook `token`, slack, telegram, …)
+ *       - `auth_schema.methods[].fields[].secret === true` on an `env_keys`
+ *         method (postgres `DATABASE_URL`, github, producthunt)
+ *     Those declarations are the source of truth: a correctly annotated
+ *     connector gets exact redaction with no name guessing.
+ *
+ *  2. KEYNAME HEURISTIC (backstop, recursive). `config` is free-form JSONB and
+ *     most connectors are NOT fully annotated — a user can put anything under
+ *     any key at any depth, and legacy rows predate the schemas entirely. So
+ *     the schema pass is followed by `deepRedactSecrets` from @lobu/core: the
+ *     SAME denylist the config-audit snapshots and the CLI manifest hash use.
+ *     There is exactly one denylist in the repo; extend it there, never here.
+ *
+ * Values are REPLACED with {@link REDACTED_SENTINEL}, not deleted, so the UI
+ * can still render "this field is SET" and a form can show a filled input.
+ * (The `connect-setup-continuation` resume-call builder deliberately OMITS
+ * instead — a sentinel inside an EXECUTABLE sdk call could be replayed as if
+ * it were a real credential. That reasoning does not apply to a read-only
+ * serializer, which is why this module uses the sentinel.)
+ */
+
+import { deepRedactSecrets, REDACTED_SENTINEL } from "@lobu/core";
+import { getDb, pgTextArray } from "../db/client";
+
+export { REDACTED_SENTINEL };
+
+/**
+ * Secret field keys declared by a connector definition, in the two existing
+ * conventions. Top-level `config` keys only — nesting under them is handled by
+ * the recursive keyname backstop.
+ */
+export type ConnectorSecretKeys = ReadonlySet<string>;
+
+/** Collect `options_schema.properties.<key>.format === 'password'` keys. */
+function optionPasswordKeys(optionsSchema: unknown): string[] {
+	if (!optionsSchema || typeof optionsSchema !== "object") return [];
+	const properties = (optionsSchema as Record<string, unknown>).properties;
+	if (!properties || typeof properties !== "object") return [];
+	const keys: string[] = [];
+	for (const [key, spec] of Object.entries(
+		properties as Record<string, unknown>,
+	)) {
+		if (
+			spec &&
+			typeof spec === "object" &&
+			(spec as Record<string, unknown>).format === "password"
+		) {
+			keys.push(key);
+		}
+	}
+	return keys;
+}
+
+/** Collect `auth_schema.methods[].fields[].secret === true` keys. */
+function authSecretFieldKeys(authSchema: unknown): string[] {
+	if (!authSchema || typeof authSchema !== "object") return [];
+	const methods = (authSchema as Record<string, unknown>).methods;
+	if (!Array.isArray(methods)) return [];
+	const keys: string[] = [];
+	for (const method of methods) {
+		if (!method || typeof method !== "object") continue;
+		const fields = (method as Record<string, unknown>).fields;
+		if (!Array.isArray(fields)) continue;
+		for (const field of fields) {
+			if (!field || typeof field !== "object") continue;
+			const record = field as Record<string, unknown>;
+			if (record.secret === true && typeof record.key === "string") {
+				keys.push(record.key);
+			}
+		}
+	}
+	return keys;
+}
+
+/**
+ * Declared secret keys for one connector's schemas. Pure — pass the schemas
+ * you already have on hand (handleGet selects `cd.auth_schema`) instead of
+ * re-querying.
+ */
+export function connectorSecretKeysFromSchemas(params: {
+	optionsSchema?: unknown;
+	authSchema?: unknown;
+}): ConnectorSecretKeys {
+	return new Set([
+		...optionPasswordKeys(params.optionsSchema),
+		...authSecretFieldKeys(params.authSchema),
+	]);
+}
+
+/**
+ * Load declared secret keys for a set of connector keys in ONE query.
+ *
+ * List endpoints serialize many connections across a handful of connectors, so
+ * this is batched by design — a per-row `getScopedConnectorDefinition` would
+ * reintroduce the N+1 the list query was explicitly tuned to avoid.
+ *
+ * A connector with no active definition in this org yields an empty set; the
+ * keyname backstop still applies, so an unknown connector is never LESS
+ * redacted than an annotated one, only less precise.
+ */
+export async function loadConnectorSecretKeys(
+	organizationId: string,
+	connectorKeys: readonly string[],
+): Promise<Map<string, ConnectorSecretKeys>> {
+	const byConnector = new Map<string, ConnectorSecretKeys>();
+	const unique = [...new Set(connectorKeys.filter(Boolean))];
+	if (unique.length === 0) return byConnector;
+
+	const sql = getDb();
+	const rows = await sql`
+    SELECT DISTINCT ON (key) key, options_schema, auth_schema
+    FROM connector_definitions
+    WHERE organization_id = ${organizationId}
+      AND status = 'active'
+      AND key = ANY(${pgTextArray(unique)}::text[])
+    ORDER BY key, updated_at DESC
+  `;
+
+	for (const row of rows as unknown as Array<{
+		key: string;
+		options_schema: unknown;
+		auth_schema: unknown;
+	}>) {
+		byConnector.set(
+			row.key,
+			connectorSecretKeysFromSchemas({
+				optionsSchema: row.options_schema,
+				authSchema: row.auth_schema,
+			}),
+		);
+	}
+	return byConnector;
+}
+
+/**
+ * Redact a single `connections.config` value.
+ *
+ * Schema-declared keys first (exact), then the shared recursive keyname walk
+ * (backstop, any depth, plus embedded `scheme://user:pass@host` credentials).
+ * Non-secret values pass through byte-identical.
+ *
+ * Returns the input unchanged when it is not an object (null config stays
+ * null) so callers can pipe a raw row value straight through.
+ */
+export function redactConnectionConfig(
+	config: unknown,
+	declaredSecretKeys?: ConnectorSecretKeys,
+): unknown {
+	if (!config || typeof config !== "object" || Array.isArray(config)) {
+		return config;
+	}
+
+	const walked = deepRedactSecrets(config) as Record<string, unknown>;
+	if (!declaredSecretKeys || declaredSecretKeys.size === 0) return walked;
+
+	for (const key of declaredSecretKeys) {
+		if (walked[key] != null) walked[key] = REDACTED_SENTINEL;
+	}
+	return walked;
+}
+
+/**
+ * Redact `row.config` in place-free fashion, returning a NEW row object.
+ *
+ * The house serializer shape is `{ ...row }`, so this is the one-liner every
+ * connection read path applies before spreading. Rows without a `config` key
+ * are returned untouched.
+ */
+export function redactConnectionRow<T extends Record<string, unknown>>(
+	row: T,
+	declaredSecretKeys?: ConnectorSecretKeys,
+): T {
+	if (!("config" in row)) return row;
+	return {
+		...row,
+		config: redactConnectionConfig(row.config, declaredSecretKeys),
+	};
+}
+
+/**
+ * Batch form: redact `config` on every row, resolving each row's declared
+ * secret keys from its own `connector_key`. One query for the whole page.
+ */
+export async function redactConnectionRows<T extends Record<string, unknown>>(
+	organizationId: string,
+	rows: T[],
+): Promise<T[]> {
+	if (rows.length === 0) return rows;
+	const secretKeysByConnector = await loadConnectorSecretKeys(
+		organizationId,
+		rows.map((row) => String(row.connector_key ?? "")),
+	);
+	return rows.map((row) =>
+		redactConnectionRow(
+			row,
+			secretKeysByConnector.get(String(row.connector_key ?? "")),
+		),
+	);
+}

--- a/packages/server/src/utils/connection-config-redaction.ts
+++ b/packages/server/src/utils/connection-config-redaction.ts
@@ -211,3 +211,88 @@ export async function redactConnectionRows<T extends Record<string, unknown>>(
 		),
 	);
 }
+
+// ============================================
+// Write side — undoing the redaction
+// ============================================
+
+/**
+ * Does this value carry a redaction sentinel this module could have produced?
+ *
+ * Two shapes, because the read path emits two:
+ *  - the whole value replaced (`"__LOBU_REDACTED__"`), and
+ *  - a URI whose userinfo was replaced
+ *    (`"postgres://__LOBU_REDACTED__@db.internal:5432/app"`), which
+ *    {@link redactUriCredentials} produces for connection strings under
+ *    non-secret keys.
+ *
+ * A bare equality check catches only the first, which is exactly how a naive
+ * guard silently corrupts every DATABASE_URL in the org.
+ */
+function isRedactedValue(value: unknown): boolean {
+	return typeof value === "string" && value.includes(REDACTED_SENTINEL);
+}
+
+/**
+ * Restore redacted values in an INCOMING config from what is already stored.
+ *
+ * Every real client round-trips config — the Owletto action-modes editor
+ * spreads the fetched `connection.config` and PATCHes it back with one field
+ * changed, and an agent doing `connections.update` via run_sdk does the same.
+ * Because the read path now returns `__LOBU_REDACTED__` where a secret used to
+ * be, that write would persist the SENTINEL over the live credential: the
+ * connection breaks at next use, with no error at save time and no way to
+ * recover the plaintext. That is data loss caused by the redaction, which is
+ * strictly worse than the leak it prevents.
+ *
+ * So a sentinel on the WRITE side means "unchanged": it is replaced with the
+ * value currently stored at the same path. Well-behaved clients see a no-op;
+ * a client that genuinely wants to rotate a secret sends the new plaintext,
+ * which contains no sentinel and is written normally.
+ *
+ * Walks objects and arrays so it matches the read path's depth, and handles
+ * the URI form by restoring the stored value whenever the incoming string
+ * merely CONTAINS a sentinel. A sentinel with no stored counterpart (a key that
+ * did not previously exist) is dropped rather than persisted — writing the
+ * literal placeholder is never the caller's intent.
+ *
+ * REJECTING the write instead was the alternative. Preserve wins because the
+ * API is public and already in use: an agent that reads-modifies-writes is
+ * doing the obvious thing, and a 400 would break the shipped action-modes
+ * toggle until every client is patched. Preserve is invisible to correct
+ * clients and lossless for careless ones.
+ */
+export function restoreRedactedConfig(
+	incoming: unknown,
+	stored: unknown,
+): unknown {
+	if (Array.isArray(incoming)) {
+		const storedArray = Array.isArray(stored) ? stored : [];
+		return incoming.map((item, index) =>
+			restoreRedactedConfig(item, storedArray[index]),
+		);
+	}
+
+	if (incoming && typeof incoming === "object") {
+		const storedObject =
+			stored && typeof stored === "object" && !Array.isArray(stored)
+				? (stored as Record<string, unknown>)
+				: {};
+		const out: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(
+			incoming as Record<string, unknown>,
+		)) {
+			const restored = restoreRedactedConfig(value, storedObject[key]);
+			// Drop a sentinel that has nothing to restore from, rather than
+			// persisting the placeholder text as if it were a real value.
+			if (restored === undefined) continue;
+			out[key] = restored;
+		}
+		return out;
+	}
+
+	if (isRedactedValue(incoming)) {
+		return stored === undefined ? undefined : stored;
+	}
+	return incoming;
+}

--- a/packages/server/src/utils/connection-config-redaction.ts
+++ b/packages/server/src/utils/connection-config-redaction.ts
@@ -2,10 +2,11 @@
  * Redaction for `connections.config` on every serialization boundary.
  *
  * `connections.config` is written VERBATIM — the create/update path splits it
- * by FEED SCOPE (`splitConfigByFeedScope`), never by secrecy — so a Slack bot
- * token, a webhook bearer token, or a Postgres `DATABASE_URL` lands in the row
- * as plaintext. Every read path that serializes a connection to a caller must
- * therefore pass its `config` through {@link redactConnectionConfig} first.
+ * by FEED SCOPE (`splitConfigByFeedScope`), never by secrecy — so connector
+ * options such as Slack bot tokens and webhook bearer tokens land in the row
+ * as plaintext. Free-form and legacy rows may carry other credentials too.
+ * Every read path that serializes a connection to a caller must therefore pass
+ * its `config` through {@link redactConnectionConfig} first.
  *
  * Two layers, in this order:
  *
@@ -23,7 +24,8 @@
  *     any key at any depth, and legacy rows predate the schemas entirely. So
  *     the schema pass is followed by `deepRedactSecrets` from @lobu/core: the
  *     SAME denylist the config-audit snapshots and the CLI manifest hash use.
- *     There is exactly one denylist in the repo; extend it there, never here.
+ *     TypeScript serializers share this one denylist. The SQL-side mirror for
+ *     query_sql is pinned against it by `table-schema-redaction.test.ts`.
  *
  * Values are REPLACED with {@link REDACTED_SENTINEL}, not deleted, so the UI
  * can still render "this field is SET" and a form can show a filled input.
@@ -43,7 +45,7 @@ export { REDACTED_SENTINEL };
  * conventions. Top-level `config` keys only — nesting under them is handled by
  * the recursive keyname backstop.
  */
-export type ConnectorSecretKeys = ReadonlySet<string>;
+type ConnectorSecretKeys = ReadonlySet<string>;
 
 /** Collect `options_schema.properties.<key>.format === 'password'` keys. */
 function optionPasswordKeys(optionsSchema: unknown): string[] {
@@ -109,8 +111,8 @@ export function connectorSecretKeysFromSchemas(params: {
  * reintroduce the N+1 the list query was explicitly tuned to avoid.
  *
  * A connector with no active definition in this org yields an empty set; the
- * keyname backstop still applies, so an unknown connector is never LESS
- * redacted than an annotated one, only less precise.
+ * keyname and URI backstops still apply, but schema-only secret names cannot be
+ * recognized without the definition.
  */
 export async function loadConnectorSecretKeys(
 	organizationId: string,
@@ -153,24 +155,30 @@ export async function loadConnectorSecretKeys(
  * (backstop, any depth, plus embedded `scheme://user:pass@host` credentials).
  * Non-secret values pass through byte-identical.
  *
- * Returns the input unchanged when it is not an object (null config stays
- * null) so callers can pipe a raw row value straight through.
+ * Arrays use the heuristic walk (schema declarations describe top-level object
+ * fields). Other non-object values pass through unchanged.
  */
 export function redactConnectionConfig(
 	config: unknown,
 	declaredSecretKeys?: ConnectorSecretKeys,
 ): unknown {
-	if (!config || typeof config !== "object" || Array.isArray(config)) {
+	if (!config || typeof config !== "object") {
 		return config;
 	}
+	if (Array.isArray(config)) return deepRedactSecrets(config);
 
-	const walked = deepRedactSecrets(config) as Record<string, unknown>;
-	if (!declaredSecretKeys || declaredSecretKeys.size === 0) return walked;
-
-	for (const key of declaredSecretKeys) {
-		if (walked[key] != null) walked[key] = REDACTED_SENTINEL;
+	if (!declaredSecretKeys || declaredSecretKeys.size === 0) {
+		return deepRedactSecrets(config);
 	}
-	return walked;
+
+	const withDeclaredRedaction = { ...(config as Record<string, unknown>) };
+	for (const key of declaredSecretKeys) {
+		if (withDeclaredRedaction[key] != null) {
+			withDeclaredRedaction[key] = REDACTED_SENTINEL;
+		}
+	}
+
+	return deepRedactSecrets(withDeclaredRedaction);
 }
 
 /**
@@ -226,8 +234,8 @@ export async function redactConnectionRows<T extends Record<string, unknown>>(
  *    {@link redactUriCredentials} produces for connection strings under
  *    non-secret keys.
  *
- * A bare equality check catches only the first, which is exactly how a naive
- * guard silently corrupts every DATABASE_URL in the org.
+ * A bare equality check catches only the first, so it can silently overwrite a
+ * redacted connection string with the placeholder form.
  */
 function isRedactedValue(value: unknown): boolean {
 	return typeof value === "string" && value.includes(REDACTED_SENTINEL);
@@ -236,9 +244,9 @@ function isRedactedValue(value: unknown): boolean {
 /**
  * Restore redacted values in an INCOMING config from what is already stored.
  *
- * Every real client round-trips config — the Owletto action-modes editor
- * spreads the fetched `connection.config` and PATCHes it back with one field
- * changed, and an agent doing `connections.update` via run_sdk does the same.
+ * Clients may round-trip config: the Owletto action-modes editor spreads the
+ * fetched `connection.config` and PATCHes it back with one field changed, and
+ * agents can use the same read-modify-write pattern through run_sdk.
  * Because the read path now returns `__LOBU_REDACTED__` where a secret used to
  * be, that write would persist the SENTINEL over the live credential: the
  * connection breaks at next use, with no error at save time and no way to

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -494,7 +494,10 @@ export function buildScopedQuery(
   const sel = (table: string, alias?: string) => {
     const defs = sc?.get(table);
     if (!defs) return alias ? `${alias}.*` : '*';
-    return buildColumnList(defs, alias);
+    // `table` drives how a redaction expression resolves the row's
+    // connector-DECLARED secret fields: a connection carries `connector_key`,
+    // a feed reaches it through `connection_id`.
+    return buildColumnList(defs, alias, table);
   };
 
   // Build the SELECT list for the entities CTE, where entity_type is now a

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -141,9 +141,47 @@ const DECLARED_SECRET_KEYS_SUBQUERY =
   `AND af->>'key' IS NOT NULL` +
   `) dk)`;
 
+/**
+ * The declared-secret key set for one `feeds` row.
+ *
+ * A feed's own credentials are declared in
+ * `feeds_schema[feed_key].configSchema.properties.<k>.format === "password"`.
+ * `FeedDefinition.configSchema` is an unconstrained `Record<string, unknown>`,
+ * so a CUSTOM connector may name such a field anything; no shipped connector
+ * declares one today (all 27 audited, zero hits), which makes this latent
+ * rather than live — but custom connector definitions are a supported feature,
+ * and a redactor documented as total must not exempt a declaration site.
+ *
+ * `feeds` carries no `connector_key` of its own, so the definition is reached
+ * through `connection_id` → `connections` → `connector_definitions`. Both hops
+ * are org-scoped, so another tenant's definition can never decide what this row
+ * redacts.
+ */
+const FEED_DECLARED_SECRET_KEYS_SUBQUERY =
+  `(SELECT COALESCE(array_agg(fp.key), ARRAY[]::text[]) ` +
+  `FROM public.connections cfeed ` +
+  `JOIN LATERAL (` +
+  `SELECT cdfeed.feeds_schema ` +
+  `FROM public.connector_definitions cdfeed ` +
+  `WHERE cdfeed.key = cfeed.connector_key ` +
+  `AND cdfeed.organization_id = cfeed.organization_id ` +
+  `AND cdfeed.status = 'active' ` +
+  `ORDER BY cdfeed.updated_at DESC LIMIT 1` +
+  `) cdf ON TRUE, ` +
+  `jsonb_each(cdf.feeds_schema -> %ALIAS%.feed_key -> 'configSchema' -> 'properties') fp ` +
+  `WHERE cfeed.id = %ALIAS%.connection_id ` +
+  `AND cfeed.organization_id = %ALIAS%.organization_id ` +
+  `AND jsonb_typeof(cdf.feeds_schema -> %ALIAS%.feed_key -> 'configSchema' -> 'properties') = 'object' ` +
+  `AND fp.value->>'format' = 'password')`;
+
 /** Bind {@link DECLARED_SECRET_KEYS_SUBQUERY} to a concrete table alias. */
 export function declaredSecretKeysExpr(alias: string): string {
   return DECLARED_SECRET_KEYS_SUBQUERY.split('%ALIAS%').join(alias);
+}
+
+/** Bind {@link FEED_DECLARED_SECRET_KEYS_SUBQUERY} to a concrete table alias. */
+export function feedDeclaredSecretKeysExpr(alias: string): string {
+  return FEED_DECLARED_SECRET_KEYS_SUBQUERY.split('%ALIAS%').join(alias);
 }
 
 /**
@@ -237,17 +275,19 @@ function buildRedactionExpr(
 /**
  * The `config` column, redacted at the chokepoint.
  *
- * `withDeclaredSecrets` is set for `connections`, whose rows carry the
- * `connector_key` + `organization_id` needed to resolve the connector's
- * declared secret fields. `feeds.config` has no such association, so it stays
- * on heuristic + URI redaction — feed-scoped config is not where connectors
- * declare credentials.
+ * Both `connections` and `feeds` resolve their connector's DECLARED secret
+ * fields on top of the keyname/URI heuristic — a declared secret with an
+ * off-denylist name would otherwise be redacted by the TypeScript serializers
+ * and served plaintext here. The two differ only in how the definition is
+ * reached: a connection carries `connector_key` directly, a feed reaches it
+ * through `connection_id` (see {@link feedDeclaredSecretKeysExpr}), which is
+ * why `buildColumnList` binds the marker per table.
  */
-function redactedConfigColumn(withDeclaredSecrets = false): ColumnDef {
+function redactedConfigColumn(): ColumnDef {
   return {
     name: 'config',
     type: 'jsonb',
-    expr: buildRedactionExpr(COLUMN_REF, REDACTION_DEPTH, withDeclaredSecrets),
+    expr: buildRedactionExpr(COLUMN_REF, REDACTION_DEPTH, true),
   };
 }
 
@@ -333,7 +373,7 @@ export const QUERYABLE_SCHEMA = {
           'account_id',
           'entity_ids'
         ),
-        redactedConfigColumn(true),
+        redactedConfigColumn(),
         ...cols(
           'error_message',
           'created_by',
@@ -678,7 +718,11 @@ export const SAFE_COLUMN_DEFS = new Map<string, ColumnDef[]>(
 );
 
 /** Build a SELECT column list from column defs, optionally prefixed with a table alias. */
-export function buildColumnList(defs: ColumnDef[], alias?: string): string {
+export function buildColumnList(
+  defs: ColumnDef[],
+  alias?: string,
+  table?: string
+): string {
   return defs
     .map((c) => {
       if (c.expr) {
@@ -693,16 +737,20 @@ export function buildColumnList(defs: ColumnDef[], alias?: string): string {
             ? c.expr.replace(/^(\w+)/, `${alias}.$1`)
             : c.expr;
         // `$DECLARED$` resolves to the connector's declared secret key set for
-        // the row. It needs a table alias to correlate on (connector_key +
-        // organization_id); with no alias there is nothing to correlate to, so
-        // it degrades to the empty set — heuristic-only, never MORE exposed
-        // than before, just less precise.
+        // the row. It needs a table alias to correlate on, and the correlation
+        // differs per table: `connections` carries `connector_key` directly,
+        // `feeds` reaches the definition through `connection_id`. With no alias
+        // — or an unrecognized table — there is nothing to correlate to, so it
+        // degrades to the empty set: heuristic-only, never MORE exposed than
+        // before, just less precise.
         if (prefixed.includes(DECLARED_SECRETS_REF)) {
-          prefixed = prefixed
-            .split(DECLARED_SECRETS_REF)
-            .join(
-              alias ? declaredSecretKeysExpr(alias) : `ARRAY[]::text[]`
-            );
+          const declared =
+            alias && table === 'connections'
+              ? declaredSecretKeysExpr(alias)
+              : alias && table === 'feeds'
+                ? feedDeclaredSecretKeysExpr(alias)
+                : `ARRAY[]::text[]`;
+          prefixed = prefixed.split(DECLARED_SECRETS_REF).join(declared);
         }
         return `${prefixed} as "${c.name}"`;
       }

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -92,6 +92,61 @@ const SQL_KEY_IS_SECRET = (keyExpr: string) => {
 };
 
 /**
+ * Marker for the expression that yields the set of key names the CONNECTOR
+ * declares secret for the row being redacted. {@link buildColumnList}
+ * substitutes it the same way it substitutes {@link COLUMN_REF}; a table with
+ * no connector association (or a caller with no substitution) gets an empty
+ * array, which degrades cleanly to heuristic-only redaction.
+ */
+export const DECLARED_SECRETS_REF = '$DECLARED$';
+
+/**
+ * The declared-secret key set for one `connections` row, as a correlated
+ * subquery over that row's active `connector_definitions` entry.
+ *
+ * Connectors declare secrecy in two conventions, and the TypeScript
+ * serializers honor BOTH on top of the keyname heuristic:
+ *   - `options_schema.properties.<key>.format === "password"`
+ *   - `auth_schema.methods[].fields[].secret === true`
+ *
+ * The SQL path previously had the heuristic ONLY, so a declared secret whose
+ * name does not match the denylist (`signingMaterial`, `OPAQUE_HANDLE`, or
+ * anything a custom connector chooses) was redacted by list()/get() but served
+ * PLAINTEXT by query_sql — the same class of leak as the original P0, on a
+ * member-reachable tool. This closes that gap by resolving the declarations in
+ * SQL, so the two redactors cannot disagree about what a connector declared.
+ *
+ * `%ALIAS%` is replaced with the connections alias in scope.
+ */
+const DECLARED_SECRET_KEYS_SUBQUERY =
+  `(SELECT COALESCE(array_agg(dk.k), ARRAY[]::text[]) FROM (` +
+  `SELECT p.key AS k ` +
+  `FROM public.connector_definitions cdsec, jsonb_each(cdsec.options_schema->'properties') p ` +
+  `WHERE cdsec.key = %ALIAS%.connector_key ` +
+  `AND cdsec.organization_id = %ALIAS%.organization_id ` +
+  `AND cdsec.status = 'active' ` +
+  `AND jsonb_typeof(cdsec.options_schema->'properties') = 'object' ` +
+  `AND p.value->>'format' = 'password' ` +
+  `UNION ` +
+  `SELECT af->>'key' ` +
+  `FROM public.connector_definitions cdsec, ` +
+  `jsonb_array_elements(cdsec.auth_schema->'methods') am, ` +
+  `jsonb_array_elements(am->'fields') af ` +
+  `WHERE cdsec.key = %ALIAS%.connector_key ` +
+  `AND cdsec.organization_id = %ALIAS%.organization_id ` +
+  `AND cdsec.status = 'active' ` +
+  `AND jsonb_typeof(cdsec.auth_schema->'methods') = 'array' ` +
+  `AND jsonb_typeof(am->'fields') = 'array' ` +
+  `AND af->>'secret' = 'true' ` +
+  `AND af->>'key' IS NOT NULL` +
+  `) dk)`;
+
+/** Bind {@link DECLARED_SECRET_KEYS_SUBQUERY} to a concrete table alias. */
+export function declaredSecretKeysExpr(alias: string): string {
+  return DECLARED_SECRET_KEYS_SUBQUERY.split('%ALIAS%').join(alias);
+}
+
+/**
  * How many levels of nesting the generated expression walks.
  *
  * Config nesting in practice is shallow — the deepest real shapes are
@@ -120,7 +175,18 @@ const REDACTION_DEPTH = 3;
  * re-test the OUTERMOST key and nested secrets would survive — that bug was
  * caught by the nested-probe case in table-schema-redaction.test.ts.
  */
-function buildRedactionExpr(valueExpr: string, depth: number): string {
+function buildRedactionExpr(
+  valueExpr: string,
+  depth: number,
+  /**
+   * Whether keys at THIS level are also tested against the connector's
+   * declared secret set. True only at the root: `options_schema.properties`
+   * and `auth_schema…fields[].key` name TOP-LEVEL config keys, so applying the
+   * set deeper would redact an unrelated nested key that merely shares a name.
+   * Nested levels remain covered by the heuristic + URI shape.
+   */
+  applyDeclared = false
+): string {
   // Bottom of the walk: anything still an object/array here is replaced
   // wholesale — fail-closed rather than emitting unredacted nested content.
   if (depth === 0) {
@@ -143,8 +209,16 @@ function buildRedactionExpr(valueExpr: string, depth: number): string {
     // objects: rebuild, redacting denylisted keys and recursing into the rest
     `WHEN jsonb_typeof(${valueExpr}) = 'object' THEN (` +
     `SELECT COALESCE(jsonb_object_agg(${kv}.key, ` +
-    `CASE WHEN ${SQL_KEY_IS_SECRET(`${kv}.key`)} ` +
-    `THEN to_jsonb('${REDACTED_SENTINEL}'::text) ELSE ${child} END), '{}'::jsonb) ` +
+    `CASE WHEN ${SQL_KEY_IS_SECRET(`${kv}.key`)}` +
+    // Schema-declared secrets: the connector said this key is secret, whatever
+    // it is named. Only applied at the root (see `applyDeclared`).
+    // `= ANY(<subquery>)` would treat the subquery as a set of rows; the
+    // subquery yields ONE text[] row, so the array is compared with `@>`
+    // (contains) instead.
+    (applyDeclared
+      ? ` OR (${DECLARED_SECRETS_REF}) @> ARRAY[${kv}.key]::text[]`
+      : '') +
+    ` THEN to_jsonb('${REDACTED_SENTINEL}'::text) ELSE ${child} END), '{}'::jsonb) ` +
     `FROM jsonb_each(${valueExpr}) ${kv}) ` +
     // arrays: recurse elementwise (a list of header objects is a real shape)
     `WHEN jsonb_typeof(${valueExpr}) = 'array' THEN (` +
@@ -160,12 +234,20 @@ function buildRedactionExpr(valueExpr: string, depth: number): string {
   );
 }
 
-/** The `config` column, redacted at the chokepoint. */
-function redactedConfigColumn(): ColumnDef {
+/**
+ * The `config` column, redacted at the chokepoint.
+ *
+ * `withDeclaredSecrets` is set for `connections`, whose rows carry the
+ * `connector_key` + `organization_id` needed to resolve the connector's
+ * declared secret fields. `feeds.config` has no such association, so it stays
+ * on heuristic + URI redaction — feed-scoped config is not where connectors
+ * declare credentials.
+ */
+function redactedConfigColumn(withDeclaredSecrets = false): ColumnDef {
   return {
     name: 'config',
     type: 'jsonb',
-    expr: buildRedactionExpr(COLUMN_REF, REDACTION_DEPTH),
+    expr: buildRedactionExpr(COLUMN_REF, REDACTION_DEPTH, withDeclaredSecrets),
   };
 }
 
@@ -251,7 +333,7 @@ export const QUERYABLE_SCHEMA = {
           'account_id',
           'entity_ids'
         ),
-        redactedConfigColumn(),
+        redactedConfigColumn(true),
         ...cols(
           'error_message',
           'created_by',
@@ -605,11 +687,23 @@ export function buildColumnList(defs: ColumnDef[], alias?: string): string {
         // times). Legacy expressions with no marker keep the old behavior:
         // alias-prefix the leading identifier.
         const ref = alias ? `${alias}."${c.name}"` : `"${c.name}"`;
-        const prefixed = c.expr.includes(COLUMN_REF)
+        let prefixed = c.expr.includes(COLUMN_REF)
           ? c.expr.split(COLUMN_REF).join(ref)
           : alias
             ? c.expr.replace(/^(\w+)/, `${alias}.$1`)
             : c.expr;
+        // `$DECLARED$` resolves to the connector's declared secret key set for
+        // the row. It needs a table alias to correlate on (connector_key +
+        // organization_id); with no alias there is nothing to correlate to, so
+        // it degrades to the empty set — heuristic-only, never MORE exposed
+        // than before, just less precise.
+        if (prefixed.includes(DECLARED_SECRETS_REF)) {
+          prefixed = prefixed
+            .split(DECLARED_SECRETS_REF)
+            .join(
+              alias ? declaredSecretKeysExpr(alias) : `ARRAY[]::text[]`
+            );
+        }
         return `${prefixed} as "${c.name}"`;
       }
       return alias ? `${alias}."${c.name}"` : `"${c.name}"`;

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -119,6 +119,7 @@ export const DECLARED_SECRETS_REF = '$DECLARED$';
  * `%ALIAS%` is replaced with the connections alias in scope.
  */
 const DECLARED_SECRET_KEYS_SUBQUERY =
+  // security-allowed: static SQL fragment built from string literals; %ALIAS% is replaced with a fixed table alias, never user input.
   `(SELECT COALESCE(array_agg(dk.k), ARRAY[]::text[]) FROM (` +
   `SELECT p.key AS k ` +
   `FROM public.connector_definitions cdsec, jsonb_each(cdsec.options_schema->'properties') p ` +
@@ -128,6 +129,7 @@ const DECLARED_SECRET_KEYS_SUBQUERY =
   `AND jsonb_typeof(cdsec.options_schema->'properties') = 'object' ` +
   `AND p.value->>'format' = 'password' ` +
   `UNION ` +
+  // security-allowed: static SQL fragment (auth_schema UNION branch); no user input.
   `SELECT af->>'key' ` +
   `FROM public.connector_definitions cdsec, ` +
   `jsonb_array_elements(cdsec.auth_schema->'methods') am, ` +
@@ -158,9 +160,11 @@ const DECLARED_SECRET_KEYS_SUBQUERY =
  * redacts.
  */
 const FEED_DECLARED_SECRET_KEYS_SUBQUERY =
+  // security-allowed: static SQL fragment; %ALIAS% is replaced with a fixed table alias, never user input.
   `(SELECT COALESCE(array_agg(fp.key), ARRAY[]::text[]) ` +
   `FROM public.connections cfeed ` +
   `JOIN LATERAL (` +
+  // security-allowed: static SQL fragment (feed definition lookup); no user input.
   `SELECT cdfeed.feeds_schema ` +
   `FROM public.connector_definitions cdfeed ` +
   `WHERE cdfeed.key = cfeed.connector_key ` +
@@ -246,6 +250,7 @@ function buildRedactionExpr(
     `CASE ` +
     // objects: rebuild, redacting denylisted keys and recursing into the rest
     `WHEN jsonb_typeof(${valueExpr}) = 'object' THEN (` +
+    // security-allowed: static redaction SQL; ${kv}/${el} are code-generated aliases, not user input.
     `SELECT COALESCE(jsonb_object_agg(${kv}.key, ` +
     `CASE WHEN ${SQL_KEY_IS_SECRET(`${kv}.key`)}` +
     // Schema-declared secrets: the connector said this key is secret, whatever
@@ -260,6 +265,7 @@ function buildRedactionExpr(
     `FROM jsonb_each(${valueExpr}) ${kv}) ` +
     // arrays: recurse elementwise (a list of header objects is a real shape)
     `WHEN jsonb_typeof(${valueExpr}) = 'array' THEN (` +
+    // security-allowed: static redaction SQL; ${element}/${el} are code-generated aliases, not user input.
     `SELECT COALESCE(jsonb_agg(${element} ORDER BY ${el}.ordinality), '[]'::jsonb) ` +
     `FROM jsonb_array_elements(${valueExpr}) WITH ORDINALITY ${el}(value, ordinality)) ` +
     // credential-bearing URI scalars fail closed; unlike the TypeScript

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -39,26 +39,26 @@ function cols(...names: string[]): ColumnDef[] {
  * `config` cannot simply be dropped from the allowlist — it carries the
  * operational settings every legitimate query reads (host, channel, feed_key
  * options). But it is written VERBATIM by the connection/feed write paths
- * (split by feed SCOPE, never by secrecy), so a connector option declared
- * `format: "password"` — a Slack/Discord bot token, a webhook bearer token —
- * and a `secret: true` env field like postgres' DATABASE_URL land in it as
- * plaintext. `query_sql` is a member-safe tool in every agent's tool set and
- * `connections` is deliberately NOT in {@link ADMIN_ONLY_QUERYABLE_TABLES}, so
- * without this a plain member could `SELECT config FROM connections` and read
- * them.
+ * (split by feed SCOPE, never by secrecy), so connector options such as bot and
+ * webhook tokens land in it as plaintext; free-form and legacy rows can carry
+ * other credentials. `query_sql` is member-safe, and `connections` is
+ * deliberately NOT in
+ * {@link ADMIN_ONLY_QUERYABLE_TABLES}, so without this a plain member could
+ * `SELECT config FROM connections` and read them.
  *
  * This is the CHOKEPOINT: `buildColumnList` emits this expression in the
  * generated CTE, so the redaction applies no matter how the caller shapes the
  * query (aliases, subselects, `->>` extraction — all read the redacted CTE).
  *
  * The denylist mirrors `isSecretKey` in @lobu/core (`secret-redaction`), which
- * is the single source of truth for the TypeScript serializers. Keep the two in
- * sync: a key added there must be added here, and
- * `table-schema-redaction.test.ts` pins that they agree.
+ * is the single source of truth for the TypeScript serializers. String values
+ * also fail closed when they contain URI userinfo (`scheme://user:password@`),
+ * matching the value-shaped backstop in `deepRedactSecrets`. Keep both rules in
+ * sync; `table-schema-redaction.test.ts` pins the key-name rule and URI case.
  *
- * Matching is RECURSIVE (a `jsonb_object_agg` over `jsonb_each`, applied by a
- * SQL function so nested objects and arrays are walked). A top-level-only pass
- * is not sufficient: a proven repro planted the secret at
+ * Matching is RECURSIVE (the generated expression rebuilds `jsonb_each` /
+ * `jsonb_array_elements` results so nested objects and arrays are walked). A
+ * top-level-only pass is not sufficient: a proven repro planted the secret at
  * `config.nested.database.password`.
  *
  * Values are replaced with the sentinel, not deleted, so a query can still see
@@ -68,6 +68,8 @@ const SQL_SECRET_KEY_PATTERN =
   '(^|_)(token|secret|password|passwd|api_?key|credential|private_?key|refresh_?token|access_?token|client_?secret|session_?id|auth_?header)s?$';
 const SQL_SECRET_EXACT_KEYS =
   "('authorization','auth','bearer','cookie','cookies','set_cookie','proxy_authorization','database_url','db_url','connection_string','dsn')";
+const SQL_URI_CREDENTIAL_PATTERN =
+  '[a-z][a-z0-9+.-]*://[^/@[:space:]]*:[^/@[:space:]]*@';
 
 /**
  * Placeholder for the source column inside an {@link ColumnDef.expr}.
@@ -75,12 +77,19 @@ const SQL_SECRET_EXACT_KEYS =
  * quoted column when there is no alias), so an expression may reference the
  * column any number of times.
  */
-export const COLUMN_REF = '$COL$';
+const COLUMN_REF = '$COL$';
 
 /** SQL test for "this jsonb key is a denylisted secret name". */
-const SQL_KEY_IS_SECRET = (keyExpr: string) =>
-  `lower(regexp_replace(${keyExpr}, '([a-z0-9])([A-Z])', '\\1_\\2', 'g')) IN ${SQL_SECRET_EXACT_KEYS} ` +
-  `OR lower(regexp_replace(${keyExpr}, '([a-z0-9])([A-Z])', '\\1_\\2', 'g')) ~ '${SQL_SECRET_KEY_PATTERN}'`;
+const SQL_KEY_IS_SECRET = (keyExpr: string) => {
+  const normalized =
+    `lower(regexp_replace(regexp_replace(` +
+    `regexp_replace(${keyExpr}, '([a-z0-9])([A-Z])', '\\1_\\2', 'g'), ` +
+    `'[^a-zA-Z0-9]+', '_', 'g'), '^_+|_+$', '', 'g'))`;
+  return (
+    `${normalized} IN ${SQL_SECRET_EXACT_KEYS} ` +
+    `OR ${normalized} ~ '${SQL_SECRET_KEY_PATTERN}'`
+  );
+};
 
 /**
  * How many levels of nesting the generated expression walks.
@@ -116,8 +125,13 @@ function buildRedactionExpr(valueExpr: string, depth: number): string {
   // wholesale — fail-closed rather than emitting unredacted nested content.
   if (depth === 0) {
     return (
-      `CASE WHEN jsonb_typeof(${valueExpr}) IN ('object','array') ` +
-      `THEN to_jsonb('${REDACTED_SENTINEL}'::text) ELSE ${valueExpr} END`
+      `CASE ` +
+      `WHEN jsonb_typeof(${valueExpr}) IN ('object','array') ` +
+      `THEN to_jsonb('${REDACTED_SENTINEL}'::text) ` +
+      `WHEN jsonb_typeof(${valueExpr}) = 'string' ` +
+      `AND (${valueExpr} #>> '{}') ~* '${SQL_URI_CREDENTIAL_PATTERN}' ` +
+      `THEN to_jsonb('${REDACTED_SENTINEL}'::text) ` +
+      `ELSE ${valueExpr} END`
     );
   }
   const kv = `kv${depth}`;
@@ -136,7 +150,12 @@ function buildRedactionExpr(valueExpr: string, depth: number): string {
     `WHEN jsonb_typeof(${valueExpr}) = 'array' THEN (` +
     `SELECT COALESCE(jsonb_agg(${element} ORDER BY ${el}.ordinality), '[]'::jsonb) ` +
     `FROM jsonb_array_elements(${valueExpr}) WITH ORDINALITY ${el}(value, ordinality)) ` +
-    // scalars pass through untouched
+    // credential-bearing URI scalars fail closed; unlike the TypeScript
+    // serializer, SQL replaces the whole string rather than rebuilding userinfo
+    `WHEN jsonb_typeof(${valueExpr}) = 'string' ` +
+    `AND (${valueExpr} #>> '{}') ~* '${SQL_URI_CREDENTIAL_PATTERN}' ` +
+    `THEN to_jsonb('${REDACTED_SENTINEL}'::text) ` +
+    // remaining scalars pass through untouched
     `ELSE ${valueExpr} END`
   );
 }

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -2,13 +2,22 @@
  * Allowlist schema for query_sql validation.
  *
  * Sensitive columns (credentials, secrets, tokens, embeddings, PII) are
- * excluded. Two layers of enforcement:
+ * excluded. Three layers of enforcement:
  *   1. validateWithSchema() rejects SQL referencing unlisted tables/columns
  *   2. SAFE_COLUMN_DEFS is used by buildScopedQuery to emit explicit column lists
  *      in CTEs, so excluded columns are never reachable even if validation
  *      is bypassed
+ *   3. columns that must stay QUERYABLE but carry secret values — the free-form
+ *      `config` jsonb on `connections` / `feeds` — carry a redacting `expr`
+ *      (see redactedConfigColumn) that the CTE emits in their place. Exclusion
+ *      is not an option for those: legitimate operational queries read them.
+ *
+ * A column is only safe here if it is EXCLUDED or REDACTED. "It's only reachable
+ * by admins" is not sufficient — `connections` and `feeds` are deliberately NOT
+ * in ADMIN_ONLY_QUERYABLE_TABLES, and query_sql is member-safe.
  */
 
+import { REDACTED_SENTINEL } from '@lobu/core';
 import { Dialect, ast, parse, validateWithSchema } from '@polyglot-sql/sdk';
 
 export interface ColumnDef {
@@ -21,6 +30,124 @@ export interface ColumnDef {
 
 function cols(...names: string[]): ColumnDef[] {
   return names.map((name) => ({ name, type: 'text' }));
+}
+
+/**
+ * SQL-side redaction for the free-form `config` jsonb on `connections` /
+ * `feeds`.
+ *
+ * `config` cannot simply be dropped from the allowlist — it carries the
+ * operational settings every legitimate query reads (host, channel, feed_key
+ * options). But it is written VERBATIM by the connection/feed write paths
+ * (split by feed SCOPE, never by secrecy), so a connector option declared
+ * `format: "password"` — a Slack/Discord bot token, a webhook bearer token —
+ * and a `secret: true` env field like postgres' DATABASE_URL land in it as
+ * plaintext. `query_sql` is a member-safe tool in every agent's tool set and
+ * `connections` is deliberately NOT in {@link ADMIN_ONLY_QUERYABLE_TABLES}, so
+ * without this a plain member could `SELECT config FROM connections` and read
+ * them.
+ *
+ * This is the CHOKEPOINT: `buildColumnList` emits this expression in the
+ * generated CTE, so the redaction applies no matter how the caller shapes the
+ * query (aliases, subselects, `->>` extraction — all read the redacted CTE).
+ *
+ * The denylist mirrors `isSecretKey` in @lobu/core (`secret-redaction`), which
+ * is the single source of truth for the TypeScript serializers. Keep the two in
+ * sync: a key added there must be added here, and
+ * `table-schema-redaction.test.ts` pins that they agree.
+ *
+ * Matching is RECURSIVE (a `jsonb_object_agg` over `jsonb_each`, applied by a
+ * SQL function so nested objects and arrays are walked). A top-level-only pass
+ * is not sufficient: a proven repro planted the secret at
+ * `config.nested.database.password`.
+ *
+ * Values are replaced with the sentinel, not deleted, so a query can still see
+ * WHICH options are set.
+ */
+const SQL_SECRET_KEY_PATTERN =
+  '(^|_)(token|secret|password|passwd|api_?key|credential|private_?key|refresh_?token|access_?token|client_?secret|session_?id|auth_?header)s?$';
+const SQL_SECRET_EXACT_KEYS =
+  "('authorization','auth','bearer','cookie','cookies','set_cookie','proxy_authorization','database_url','db_url','connection_string','dsn')";
+
+/**
+ * Placeholder for the source column inside an {@link ColumnDef.expr}.
+ * {@link buildColumnList} substitutes it with `alias.<column>` (or the bare
+ * quoted column when there is no alias), so an expression may reference the
+ * column any number of times.
+ */
+export const COLUMN_REF = '$COL$';
+
+/** SQL test for "this jsonb key is a denylisted secret name". */
+const SQL_KEY_IS_SECRET = (keyExpr: string) =>
+  `lower(regexp_replace(${keyExpr}, '([a-z0-9])([A-Z])', '\\1_\\2', 'g')) IN ${SQL_SECRET_EXACT_KEYS} ` +
+  `OR lower(regexp_replace(${keyExpr}, '([a-z0-9])([A-Z])', '\\1_\\2', 'g')) ~ '${SQL_SECRET_KEY_PATTERN}'`;
+
+/**
+ * How many levels of nesting the generated expression walks.
+ *
+ * Config nesting in practice is shallow — the deepest real shapes are
+ * `config.headers.Authorization` and `config.database.password` (2 levels
+ * under the root). 3 covers those with a level of headroom. The expression is
+ * unrolled, so each extra level multiplies its size; this is the knob that
+ * keeps the generated CTE reasonable.
+ *
+ * BELOW this depth a still-nested object/array is emitted WHOLLY REDACTED
+ * rather than passed through. That is deliberate fail-closed behavior: an
+ * unexpectedly deep blob is rendered useless rather than leaked. It is also
+ * why raising this number is safe but lowering it is not.
+ */
+const REDACTION_DEPTH = 3;
+
+/**
+ * Build a recursive jsonb-redaction expression, unrolled to a fixed depth.
+ *
+ * Unrolled rather than a `CREATE FUNCTION` so the guarantee lives entirely in
+ * the generated CTE: no migration ordering to get wrong, and no deployment
+ * window where the schema claims "redacted" while the database has no function
+ * yet.
+ *
+ * Each level uses a DEPTH-SUFFIXED alias (`kv3`, `kv2`, …). Reusing one alias
+ * lets the inner `jsonb_each` shadow the outer one, so every level would
+ * re-test the OUTERMOST key and nested secrets would survive — that bug was
+ * caught by the nested-probe case in table-schema-redaction.test.ts.
+ */
+function buildRedactionExpr(valueExpr: string, depth: number): string {
+  // Bottom of the walk: anything still an object/array here is replaced
+  // wholesale — fail-closed rather than emitting unredacted nested content.
+  if (depth === 0) {
+    return (
+      `CASE WHEN jsonb_typeof(${valueExpr}) IN ('object','array') ` +
+      `THEN to_jsonb('${REDACTED_SENTINEL}'::text) ELSE ${valueExpr} END`
+    );
+  }
+  const kv = `kv${depth}`;
+  const el = `el${depth}`;
+  const child = buildRedactionExpr(`${kv}.value`, depth - 1);
+  const element = buildRedactionExpr(`${el}.value`, depth - 1);
+  return (
+    `CASE ` +
+    // objects: rebuild, redacting denylisted keys and recursing into the rest
+    `WHEN jsonb_typeof(${valueExpr}) = 'object' THEN (` +
+    `SELECT COALESCE(jsonb_object_agg(${kv}.key, ` +
+    `CASE WHEN ${SQL_KEY_IS_SECRET(`${kv}.key`)} ` +
+    `THEN to_jsonb('${REDACTED_SENTINEL}'::text) ELSE ${child} END), '{}'::jsonb) ` +
+    `FROM jsonb_each(${valueExpr}) ${kv}) ` +
+    // arrays: recurse elementwise (a list of header objects is a real shape)
+    `WHEN jsonb_typeof(${valueExpr}) = 'array' THEN (` +
+    `SELECT COALESCE(jsonb_agg(${element} ORDER BY ${el}.ordinality), '[]'::jsonb) ` +
+    `FROM jsonb_array_elements(${valueExpr}) WITH ORDINALITY ${el}(value, ordinality)) ` +
+    // scalars pass through untouched
+    `ELSE ${valueExpr} END`
+  );
+}
+
+/** The `config` column, redacted at the chokepoint. */
+function redactedConfigColumn(): ColumnDef {
+  return {
+    name: 'config',
+    type: 'jsonb',
+    expr: buildRedactionExpr(COLUMN_REF, REDACTION_DEPTH),
+  };
 }
 
 export const QUERYABLE_SCHEMA = {
@@ -90,32 +217,37 @@ export const QUERYABLE_SCHEMA = {
         'supersedes_event_id'
       ),
     },
-    // connections (excludes: credentials)
+    // connections (excludes: credentials; `config` is REDACTED, not excluded —
+    // see redactedConfigColumn)
     {
       name: 'connections',
-      columns: cols(
-        'id',
-        'organization_id',
-        'connector_key',
-        'slug',
-        'display_name',
-        'status',
-        'account_id',
-        'entity_ids',
-        'config',
-        'error_message',
-        'created_by',
-        'created_at',
-        'updated_at',
-        'auth_profile_id',
-        'app_auth_profile_id',
-        'visibility',
-        'deleted_at',
-        'agent_id',
-        'device_worker_id',
-        'external_tenant_id',
-        'credential_mode'
-      ),
+      columns: [
+        ...cols(
+          'id',
+          'organization_id',
+          'connector_key',
+          'slug',
+          'display_name',
+          'status',
+          'account_id',
+          'entity_ids'
+        ),
+        redactedConfigColumn(),
+        ...cols(
+          'error_message',
+          'created_by',
+          'created_at',
+          'updated_at',
+          'auth_profile_id',
+          'app_auth_profile_id',
+          'visibility',
+          'deleted_at',
+          'agent_id',
+          'device_worker_id',
+          'external_tenant_id',
+          'credential_mode'
+        ),
+      ],
     },
     // watchers
     {
@@ -284,39 +416,44 @@ export const QUERYABLE_SCHEMA = {
         'principal_kind'
       ),
     },
-    // feeds (excludes: checkpoint)
+    // feeds (excludes: checkpoint; `config` is REDACTED, not excluded — see
+    // redactedConfigColumn)
     {
       name: 'feeds',
-      columns: cols(
-        'id',
-        'organization_id',
-        'connection_id',
-        'feed_key',
-        'status',
-        'entity_ids',
-        'config',
-        'schedule',
-        'timezone',
-        'next_run_at',
-        'last_sync_at',
-        'last_sync_status',
-        'last_error',
-        'consecutive_failures',
-        'items_collected',
-        'created_at',
-        'updated_at',
-        'pinned_version',
-        'display_name',
-        'deleted_at',
-        'repair_agent_id',
-        'repair_thread_id',
-        'repair_attempt_count',
-        'last_repair_at',
-        'first_failure_at',
-        'last_repair_post_hash',
-        'virtual',
-        'kind'
-      ),
+      columns: [
+        ...cols(
+          'id',
+          'organization_id',
+          'connection_id',
+          'feed_key',
+          'status',
+          'entity_ids'
+        ),
+        redactedConfigColumn(),
+        ...cols(
+          'schedule',
+          'timezone',
+          'next_run_at',
+          'last_sync_at',
+          'last_sync_status',
+          'last_error',
+          'consecutive_failures',
+          'items_collected',
+          'created_at',
+          'updated_at',
+          'pinned_version',
+          'display_name',
+          'deleted_at',
+          'repair_agent_id',
+          'repair_thread_id',
+          'repair_attempt_count',
+          'last_repair_at',
+          'first_failure_at',
+          'last_repair_post_hash',
+          'virtual',
+          'kind'
+        ),
+      ],
     },
     // channel_messages — chat-channel transcripts (streaming feeds). Content is
     // membership-gated per row by the channel_messages CTE in execute-data-sources
@@ -419,8 +556,13 @@ export const QUERYABLE_TABLE_NAMES = new Set(QUERYABLE_SCHEMA.tables.map((t) => 
  * are member-accessible: the auth + identity tables. Members can read the
  * org's operational data (entities, events, connections, feeds, watchers, …) but
  * not enumerate every OAuth token/app or the full user roster. Secret columns
- * (credentials, client_secret, token_hash, email, phone) are already excluded
- * from the schema above; this is the table-level guard on top of that.
+ * (credentials, client_secret, token_hash, email, phone) are excluded from the
+ * schema above, and the secret-carrying `config` jsonb is redacted in-place;
+ * this is the table-level guard on top of that.
+ *
+ * Do NOT rely on this set to protect a column: `connections` and `feeds` are
+ * intentionally member-readable, so a secret in one of their columns must be
+ * excluded or redacted at the schema, not gated here.
  */
 export const ADMIN_ONLY_QUERYABLE_TABLES: ReadonlySet<string> = new Set([
   'oauth_tokens',
@@ -439,7 +581,16 @@ export function buildColumnList(defs: ColumnDef[], alias?: string): string {
   return defs
     .map((c) => {
       if (c.expr) {
-        const prefixed = alias ? c.expr.replace(/^(\w+)/, `${alias}.$1`) : c.expr;
+        // `$COL$` marks every reference to the source column, so an expression
+        // may use it more than once (the redaction CASE reads `config` three
+        // times). Legacy expressions with no marker keep the old behavior:
+        // alias-prefix the leading identifier.
+        const ref = alias ? `${alias}."${c.name}"` : `"${c.name}"`;
+        const prefixed = c.expr.includes(COLUMN_REF)
+          ? c.expr.split(COLUMN_REF).join(ref)
+          : alias
+            ? c.expr.replace(/^(\w+)/, `${alias}.$1`)
+            : c.expr;
         return `${prefixed} as "${c.name}"`;
       }
       return alias ? `${alias}."${c.name}"` : `"${c.name}"`;


### PR DESCRIPTION
## Problem

`connections.config` (JSONB) stored connector option values **verbatim** — the write path splits config by *feed scope* only (`splitConfigByFeedScope`), never by secrecy. Every read path then echoed it back.

Reproduced end-to-end: a planted `config.DATABASE_URL` came back in plaintext through `connections.list()` and `.get()`.

The leak was **wider than the reported endpoint**:

| surface | who could see it |
|---|---|
| `connections.list()` / `.get()` | any caller who can see the connection |
| **`query_sql`** | **any org member, and every agent** — `table-schema.ts` is the designated chokepoint, and its own comment said `// connections (excludes: credentials)` while `config` sat in the allowlist |
| `search_memory` | `PUBLIC_READ_ACTIONS` tier |
| `manage_feeds` list/read | also returned `checkpoint`, which `table-schema.ts:906` names as never-emit |
| feed `configSchema` secrets | latent — reachable by any custom connector |

`query_sql` was the worst of these and is verified at runtime: a plain non-admin member got `{"config":{"DATABASE_URL":"postgres://u:pw-QSQL-LEAK@..."}}`.

## Fix

Two layers, both routed through the single existing `@lobu/core/secret-redaction`:

1. **Schema-driven (primary)** — honors the declarations already in the codebase: `options_schema.format === "password"` and `auth_schema…fields[].secret === true`. Batched, no N+1. Applied at the config root only (those schemas name top-level keys) and org-scoped on both hops.
2. **Heuristic backstop** — recursive key-name pass plus a URI-credential matcher, for un-annotated/legacy/user-supplied config.

The suffix-anchored `isSecretKey` regex would **not** have matched `DATABASE_URL`, `dsn`, or `connection_string` — the very bug we started from. Those are now an exact-name set (kept separate so `authorization_mode` isn't swept up), plus `redactUriCredentials` for `scheme://user:pass@host` under innocuous keys. All three names have explicit tests.

Values are replaced with a sentinel, not deleted, so the UI can still show *which* options are set.

## Three bugs found while fixing this

- **Sentinel round-trip destroyed credentials.** The settings UI spreads the fetched config and PATCHes it back (`connection-settings-tab.tsx:854`), so toggling an action mode would write `__LOBU_REDACTED__` over a live bot token. The sentinel now means "unchanged" on write, across four write paths including `replace_config` (where the naive behavior would have wiped every credential in the org on a manifest re-apply).
- **Concurrent rotation rollback.** The restore read an unlocked snapshot, so a redacted round-trip racing a rotation silently reverted it. Now `SELECT … FOR UPDATE` in the same transaction as the write.
- **`secret://` refs treated as plaintext** on the chat re-apply path — the same placeholder bug one indirection out.

## Testing

Every guard verified by **neutering the fix and confirming the test goes red** — not merely by passing. Round-trip and rotation tests assert against the **raw DB row**, since the API response is redacted either way and would mask corruption.

3 tests on this branch initially passed with their fix fully removed and were rewritten or deleted; that check earned its keep.

`make pre-pr` clean. `make review`: 0 bugs, 0 blockers, bug_free 88, tests_adequate true.

## Known bound

SQL redaction is unrolled to depth 3 and **fails closed** below it (deeper objects are wholly redacted). Deliberate: a `CREATE FUNCTION` would open a deploy window where the schema claims redaction the DB can't yet perform.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->