### PR TITLE
fix(security): encrypt env auth-profile credentials at rest

### DIFF
--- a/packages/core/src/utils/secret-redaction.ts
+++ b/packages/core/src/utils/secret-redaction.ts
@@ -89,7 +89,12 @@ export function isSecretKey(key: string): boolean {
  * (`host`, `endpoint`, `primary`). Only the userinfo is replaced: the scheme
  * and host stay readable so a UI can still show which database is wired up.
  */
-const URI_CREDENTIAL_RE = /([a-z][a-z0-9+.-]*:\/\/)([^/\s@]+)@/gi;
+// The scheme repetition is bounded ({0,63}, i.e. schemes up to 64 chars — far
+// longer than any real URI scheme) rather than `*`: an unbounded quantifier
+// re-scans at every start offset on adversarial input (e.g. a long run of 'a's
+// with no `://`), which is a polynomial-ReDoS shape. A constant bound keeps the
+// per-offset work constant, so matching stays linear on untrusted config values.
+const URI_CREDENTIAL_RE = /([a-z][a-z0-9+.-]{0,63}:\/\/)([^/\s@]+)@/gi;
 
 /**
  * Replace the `user:password@` userinfo of any URI inside a string with the

--- a/packages/core/src/utils/secret-redaction.ts
+++ b/packages/core/src/utils/secret-redaction.ts
@@ -35,7 +35,7 @@ export const REDACTED_SENTINEL = "__LOBU_REDACTED__";
  * {@link isSecretKey}'s exact-name set and by {@link redactUriCredentials}.
  */
 const SECRET_KEY_RE =
-  /(^|_)(token|secret|password|passwd|api_?key|credential|private_?key|refresh_?token|access_?token|client_?secret|session_?id|auth_?header)s?$/i;
+  /(^|_)(token|secret|password|passwd|api_?key|secret_?(?:access_?)?key|credential|private_?key|refresh_?token|access_?token|client_?secret|session_?id|auth_?header)s?$/i;
 
 /**
  * Exact key names (case-insensitive, after key normalization) that are
@@ -55,11 +55,17 @@ const SECRET_EXACT_KEYS = new Set([
   "db_url",
   "connection_string",
   "dsn",
+  // Fully capitalized acronym runs have no case boundary for `normalizeKey`
+  // to split, so they need explicit entries.
+  "dburl",
+  "databaseurl",
+  "connectionstring",
 ]);
 
 /** Normalize camelCase and separators so config keys and HTTP headers agree. */
 function normalizeKey(key: string): string {
   return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
     .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
     .replace(/[^a-zA-Z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "")
@@ -77,12 +83,7 @@ export function isSecretKey(key: string): boolean {
  * (`host`, `endpoint`, `primary`). Only the userinfo is replaced: the scheme
  * and host stay readable so a UI can still show which database is wired up.
  */
-// The scheme repetition is bounded ({0,63}, i.e. schemes up to 64 chars — far
-// longer than any real URI scheme) rather than `*`: an unbounded quantifier
-// re-scans at every start offset on adversarial input (e.g. a long run of 'a's
-// with no `://`), which is a polynomial-ReDoS shape. A constant bound keeps the
-// per-offset work constant, so matching stays linear on untrusted config values.
-const URI_CREDENTIAL_RE = /([a-z][a-z0-9+.-]{0,63}:\/\/)([^/\s@]+)@/gi;
+const URI_CREDENTIAL_RE = /([a-z][a-z0-9+.-]*:\/\/)([^/\s@]+)@/gi;
 
 /**
  * Replace the `user:password@` userinfo of any URI inside a string with the

--- a/packages/core/src/utils/secret-redaction.ts
+++ b/packages/core/src/utils/secret-redaction.ts
@@ -64,16 +64,18 @@ const SECRET_EXACT_KEYS = new Set([
 
 /** Normalize camelCase and separators so config keys and HTTP headers agree. */
 function normalizeKey(key: string): string {
-  return key
-    // Split an acronym run from a following word ("APIKey" -> "API_Key").
-    // A fixed-width lookahead (never a greedy `[A-Z]+` that overlaps the next
-    // `[A-Z]`) keeps this linear: a long uppercase run like "AAAA..." can't
-    // trigger quadratic backtracking (CodeQL polynomial-ReDoS).
-    .replace(/([A-Z])(?=[A-Z][a-z])/g, "$1_")
-    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
-    .replace(/[^a-zA-Z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .toLowerCase();
+  return (
+    key
+      // Split an acronym run from a following word ("APIKey" -> "API_Key").
+      // A fixed-width lookahead (never a greedy `[A-Z]+` that overlaps the next
+      // `[A-Z]`) keeps this linear: a long uppercase run like "AAAA..." can't
+      // trigger quadratic backtracking (CodeQL polynomial-ReDoS).
+      .replace(/([A-Z])(?=[A-Z][a-z])/g, "$1_")
+      .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+      .replace(/[^a-zA-Z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .toLowerCase()
+  );
 }
 
 export function isSecretKey(key: string): boolean {

--- a/packages/core/src/utils/secret-redaction.ts
+++ b/packages/core/src/utils/secret-redaction.ts
@@ -65,7 +65,11 @@ const SECRET_EXACT_KEYS = new Set([
 /** Normalize camelCase and separators so config keys and HTTP headers agree. */
 function normalizeKey(key: string): string {
   return key
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    // Split an acronym run from a following word ("APIKey" -> "API_Key").
+    // A fixed-width lookahead (never a greedy `[A-Z]+` that overlaps the next
+    // `[A-Z]`) keeps this linear: a long uppercase run like "AAAA..." can't
+    // trigger quadratic backtracking (CodeQL polynomial-ReDoS).
+    .replace(/([A-Z])(?=[A-Z][a-z])/g, "$1_")
     .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
     .replace(/[^a-zA-Z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "")

--- a/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
+++ b/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
@@ -6,8 +6,12 @@ import {
 	migrateLegacyPlaintextAuthData,
 	persistAuthCredentials,
 	resolveAuthCredentials,
+	toSecretRefAuthData,
 } from "../../utils/auth-credential-secrets";
-import { createAuthProfile } from "../../utils/auth-profiles";
+import {
+	createAuthProfile,
+	deleteAuthProfile,
+} from "../../utils/auth-profiles";
 import { resolveExecutionAuth } from "../../utils/execution-context";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import { createTestConnection } from "../setup/test-fixtures";
@@ -502,5 +506,127 @@ describe("auth_profiles credential storage", () => {
 			DSN_PASSWORD,
 		);
 		expect(JSON.stringify(row.config)).not.toContain(DSN_PASSWORD);
+	});
+
+	/**
+	 * Public create/validate paths must never treat a caller-supplied
+	 * `secret://…` string as an already-stored ref. Without ownership checks a
+	 * crafted credential would bind the profile to a predictable org/global
+	 * secret without ever writing the submitted value.
+	 */
+	it("does not bind a caller-supplied foreign secret:// ref", async () => {
+		const orgId = workspace.org.id;
+		const victimId = await seedEnvProfile(orgId, "pg-ref-victim", {});
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: victimId,
+				credentials: { DATABASE_URL: DSN },
+			}),
+		);
+		const victimRef = String((await rawAuthData(victimId)).DATABASE_URL);
+		expect(parseSecretRef(victimRef)?.scheme).toBe("secret");
+
+		const attackerId = await seedEnvProfile(orgId, "pg-ref-attacker", {});
+		const putCalls: string[] = [];
+		const store = new PostgresSecretStore();
+		const originalPut = store.put.bind(store);
+		store.put = async (name, value, options) => {
+			putCalls.push(value);
+			return originalPut(name, value, options);
+		};
+
+		const out = await orgContext.run({ organizationId: orgId }, () =>
+			toSecretRefAuthData({
+				organizationId: orgId,
+				authProfileId: attackerId,
+				credentials: { DATABASE_URL: victimRef },
+				secretStore: store,
+			}),
+		);
+
+		// Must have written (not short-circuited) and must not keep the victim ref.
+		expect(putCalls).toHaveLength(1);
+		expect(putCalls[0]).toBe(victimRef);
+		expect(out.DATABASE_URL).not.toBe(victimRef);
+		expect(parseSecretRef(out.DATABASE_URL)?.scheme).toBe("secret");
+
+		// Resolving the attacker's profile must NOT yield the victim DSN.
+		const resolved = await resolveAuthCredentials({
+			organizationId: orgId,
+			authData: out,
+		});
+		expect(resolved.DATABASE_URL).toBe(victimRef);
+		expect(resolved.DATABASE_URL).not.toBe(DSN);
+	});
+
+	it("preserves a rename-only re-submit of the profile's own refs", async () => {
+		const orgId = workspace.org.id;
+		const profileId = await seedEnvProfile(orgId, "pg-ref-owned", {});
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: DSN },
+			}),
+		);
+		const ownedRef = String((await rawAuthData(profileId)).DATABASE_URL);
+		const putCalls: string[] = [];
+		const store = new PostgresSecretStore();
+		const originalPut = store.put.bind(store);
+		store.put = async (name, value, options) => {
+			putCalls.push(value);
+			return originalPut(name, value, options);
+		};
+
+		const out = await orgContext.run({ organizationId: orgId }, () =>
+			toSecretRefAuthData({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: ownedRef },
+				secretStore: store,
+			}),
+		);
+
+		expect(putCalls).toHaveLength(0);
+		expect(out.DATABASE_URL).toBe(ownedRef);
+	});
+
+	/**
+	 * Deleting a profile must drop its encrypted credential rows. Leaving
+	 * `agent_secrets` behind keeps decryptable bearer credentials forever.
+	 */
+	it("deletes agent_secrets when the auth profile is deleted", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const profile = await createAuthProfile({
+			organizationId: orgId,
+			connectorKey: "postgres",
+			displayName: "Delete cleanup",
+			slug: "pg-delete-cleanup",
+			profileKind: "env",
+			authData: { DATABASE_URL: DSN },
+		});
+		const secretRowsBefore = await sql`
+      SELECT name FROM agent_secrets
+      WHERE organization_id = ${orgId}
+        AND name LIKE ${`auth-profile/${profile.id}/%`}
+    `;
+		expect(secretRowsBefore.length).toBeGreaterThan(0);
+
+		const deleted = await deleteAuthProfile(orgId, profile.slug);
+		expect(deleted?.id).toBe(profile.id);
+
+		const profileGone = await sql`
+      SELECT 1 FROM auth_profiles WHERE id = ${profile.id}
+    `;
+		expect(profileGone).toHaveLength(0);
+
+		const secretRowsAfter = await sql`
+      SELECT name FROM agent_secrets
+      WHERE organization_id = ${orgId}
+        AND name LIKE ${`auth-profile/${profile.id}/%`}
+    `;
+		expect(secretRowsAfter).toHaveLength(0);
 	});
 });

--- a/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
+++ b/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
@@ -1,0 +1,506 @@
+import { parseSecretRef } from "@lobu/core";
+import { beforeAll, describe, expect, it } from "vitest";
+import { PostgresSecretStore } from "../../lobu/stores/postgres-secret-store";
+import { orgContext } from "../../lobu/stores/org-context";
+import {
+	migrateLegacyPlaintextAuthData,
+	persistAuthCredentials,
+	resolveAuthCredentials,
+} from "../../utils/auth-credential-secrets";
+import { createAuthProfile } from "../../utils/auth-profiles";
+import { resolveExecutionAuth } from "../../utils/execution-context";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import { createTestConnection } from "../setup/test-fixtures";
+import { TestWorkspace } from "../setup/test-mcp-client";
+
+/**
+ * A postgres connection string is a bearer credential: whoever reads it owns
+ * the database. Before this suite, the DSN sat as PLAINTEXT in
+ * `auth_profiles.auth_data` — the row BOTH execution paths read through
+ * `resolveExecutionAuth` — and (for at least one live connection) a second
+ * plaintext copy in `connections.config`.
+ *
+ * Every assertion below reads the RAW DB ROW rather than an API response.
+ * The list/get/query_sql surfaces are redacted, so asserting on the API would
+ * pass even if the column underneath were still plaintext — that exact trap
+ * produced a false-negative test earlier in this sprint.
+ */
+const DSN_PASSWORD = "pw-LEAK-dsn-secret-storage";
+const DSN = `postgres://app_ro:${DSN_PASSWORD}@db.internal:5432/app`;
+const ROTATED_PASSWORD = "pw-LEAK-dsn-rotated";
+const ROTATED_DSN = `postgres://app_ro:${ROTATED_PASSWORD}@db.internal:5432/app`;
+
+let workspace: TestWorkspace;
+
+async function seedEnvProfile(
+	organizationId: string,
+	slug: string,
+	authData: Record<string, unknown>,
+): Promise<number> {
+	const sql = getTestDb();
+	const [row] = await sql`
+    INSERT INTO auth_profiles (
+      organization_id, connector_key, slug, display_name,
+      profile_kind, status, auth_data, created_at, updated_at
+    ) VALUES (
+      ${organizationId}, 'postgres', ${slug}, ${slug},
+      'env', 'active', ${sql.json(authData)}, NOW(), NOW()
+    )
+    RETURNING id
+  `;
+	return Number((row as { id: number }).id);
+}
+
+async function rawAuthData(profileId: number): Promise<Record<string, unknown>> {
+	const sql = getTestDb();
+	const rows = await sql`
+    SELECT auth_data FROM auth_profiles WHERE id = ${profileId}
+  `;
+	return (rows[0] as { auth_data: Record<string, unknown> }).auth_data ?? {};
+}
+
+async function waitForBlockedSecretWrite(): Promise<void> {
+	const sql = getTestDb();
+	for (let attempt = 0; attempt < 40; attempt++) {
+		const rows = await sql`
+      SELECT 1
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND wait_event_type = 'Lock'
+        AND query ILIKE '%INSERT INTO agent_secrets%'
+      LIMIT 1
+    `;
+		if (rows.length > 0) return;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	throw new Error("Legacy convergence did not reach the blocked secret write");
+}
+
+/** Resolve credentials the way BOTH execution paths do. */
+async function resolveCredentials(
+	organizationId: string,
+	connectionId: number,
+	authProfileId: number,
+): Promise<Record<string, string>> {
+	const { connectionCredentials } = await resolveExecutionAuth({
+		organizationId,
+		connectionId,
+		authProfileId,
+		appAuthProfileId: null,
+		credentialDb: getTestDb(),
+		logContext: {},
+	});
+	return connectionCredentials as Record<string, string>;
+}
+
+describe("auth_profiles credential storage", () => {
+	beforeAll(async () => {
+		workspace = await TestWorkspace.create();
+		return async () => {
+			await cleanupTestDatabase();
+		};
+	});
+
+	/**
+	 * ITEM 1 — WRITE. The persisted row must not contain the password in any
+	 * form. Asserted on the serialized raw row so a nested/re-encoded copy
+	 * still trips it.
+	 */
+	it("stores no plaintext credential in the auth_profiles row", async () => {
+		const orgId = workspace.org.id;
+		const profileId = await seedEnvProfile(orgId, "pg-write", {});
+
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: DSN },
+			}),
+		);
+
+		const stored = await rawAuthData(profileId);
+		expect(JSON.stringify(stored)).not.toContain(DSN_PASSWORD);
+		// Stored as a secret:// ref, not a bare value.
+		// Must be a ref into the BUILTIN store. `isSecretRef` would also accept
+		// the raw `postgres://` DSN, so the scheme is asserted explicitly.
+		expect(parseSecretRef(String(stored.DATABASE_URL))?.scheme).toBe("secret");
+	});
+
+	it("creates an env profile with credentials inside a caller transaction", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const profile = await sql.begin((tx) =>
+			createAuthProfile(
+				{
+					organizationId: orgId,
+					connectorKey: "postgres",
+					displayName: "Transactional env profile",
+					slug: "pg-transactional-create",
+					profileKind: "env",
+					authData: { DATABASE_URL: DSN },
+				},
+				tx,
+			),
+		);
+
+		const stored = await rawAuthData(profile.id);
+		expect(JSON.stringify(stored)).not.toContain(DSN_PASSWORD);
+		expect(parseSecretRef(String(stored.DATABASE_URL))?.scheme).toBe("secret");
+	});
+
+	/**
+	 * ITEM 4/5 — BOTH EXECUTION PATHS. `resolveExecutionAuth` is the single
+	 * seam the worker-sync path (poll.ts) and the virtual-feed pushdown path
+	 * (connector-pushdown.ts) both funnel through, so proving it here proves
+	 * the credential materializes for both. The dedicated per-path tests below
+	 * assert each caller actually reaches this seam.
+	 */
+	it("resolves the real credential back through resolveExecutionAuth", async () => {
+		const orgId = workspace.org.id;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "postgres",
+		});
+		const profileId = await seedEnvProfile(orgId, "pg-resolve", {});
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: DSN },
+			}),
+		);
+
+		const creds = await resolveCredentials(orgId, conn.id, profileId);
+		expect(JSON.stringify(await rawAuthData(profileId))).not.toContain(
+			DSN_PASSWORD,
+		);
+		expect(creds.DATABASE_URL).toBe(DSN);
+	});
+
+	/**
+	 * ITEM 6 — ROTATION. Writing a new password must supersede the old one on
+	 * the resolve path (a stale cached ref would keep the old DSN alive).
+	 */
+	it("resolves the new value after the credential is rotated", async () => {
+		const orgId = workspace.org.id;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "postgres",
+		});
+		const profileId = await seedEnvProfile(orgId, "pg-rotate", {});
+
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: DSN },
+			}),
+		);
+		expect(await resolveCredentials(orgId, conn.id, profileId)).toEqual({
+			DATABASE_URL: DSN,
+		});
+
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: ROTATED_DSN },
+			}),
+		);
+
+		const rotated = await resolveCredentials(orgId, conn.id, profileId);
+		expect(rotated.DATABASE_URL).toBe(ROTATED_DSN);
+		expect(rotated.DATABASE_URL).not.toContain(DSN_PASSWORD);
+
+		const stored = await rawAuthData(profileId);
+		expect(JSON.stringify(stored)).not.toContain(ROTATED_PASSWORD);
+	});
+
+	/**
+	 * Cross-tenant guard. `PostgresSecretStore.put` falls back to a GLOBAL
+	 * bucket when no org context is ambient; a secret written there shadows
+	 * every org's read of the same name. The credential must be scoped to the
+	 * writing org explicitly, so another org resolving the same ref gets
+	 * nothing.
+	 */
+	it("scopes the stored credential to the owning organization", async () => {
+		const orgId = workspace.org.id;
+		const profileId = await seedEnvProfile(orgId, "pg-scope", {});
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: DSN },
+			}),
+		);
+		const ref = String((await rawAuthData(profileId)).DATABASE_URL);
+		// Precondition: a real ref was stored. Without this the org-scoping
+		// assertion below is vacuous — a plaintext column trivially "isn't
+		// readable by another org through the store".
+		expect(parseSecretRef(ref)?.scheme).toBe("secret");
+
+		const store = new PostgresSecretStore();
+		// The owning org resolves it...
+		const ownerRead = await orgContext.run({ organizationId: orgId }, () =>
+			store.get(ref as never),
+		);
+		expect(ownerRead).toBe(DSN);
+		// ...and another org does not.
+		const otherOrgRead = await orgContext.run(
+			{ organizationId: "org-someone-else" },
+			() => store.get(ref as never),
+		);
+		expect(otherOrgRead).not.toBe(DSN);
+	});
+
+	/**
+	 * ITEM 7 — MIGRATION. A row seeded in the OLD plaintext shape must be
+	 * converted by the migration and still resolve afterwards.
+	 */
+	it("converts a legacy plaintext row and keeps it resolvable", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "postgres",
+		});
+		const profileId = await seedEnvProfile(orgId, "pg-legacy", {
+			DATABASE_URL: DSN,
+		});
+		await sql`
+      UPDATE connections SET auth_profile_id = ${profileId} WHERE id = ${conn.id}
+    `;
+
+		// Precondition: the legacy row really is plaintext.
+		expect(JSON.stringify(await rawAuthData(profileId))).toContain(
+			DSN_PASSWORD,
+		);
+
+		await orgContext.run({ organizationId: orgId }, () =>
+			migrateLegacyPlaintextAuthData(),
+		);
+
+		const stored = await rawAuthData(profileId);
+		expect(JSON.stringify(stored)).not.toContain(DSN_PASSWORD);
+		const creds = await resolveCredentials(orgId, conn.id, profileId);
+		expect(creds.DATABASE_URL).toBe(DSN);
+	});
+
+	it("does not overwrite a credential rotated during legacy convergence", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const blockerId = await seedEnvProfile(orgId, "pg-migration-blocker", {});
+		await persistAuthCredentials({
+			organizationId: orgId,
+			authProfileId: blockerId,
+			credentials: { DATABASE_URL: DSN },
+		});
+		await orgContext.run({ organizationId: orgId }, () =>
+			new PostgresSecretStore().put(
+				`auth-profile/${blockerId}/legacy-convergence/DATABASE_URL`,
+				DSN,
+			),
+		);
+		await sql`
+      UPDATE auth_profiles
+      SET auth_data = ${sql.json({ DATABASE_URL: DSN })}
+      WHERE id = ${blockerId}
+    `;
+
+		const targetId = await seedEnvProfile(orgId, "pg-migration-race", {
+			DATABASE_URL: DSN,
+		});
+		let migration: Promise<number> | undefined;
+		await sql.begin(async (tx) => {
+			await tx`
+        SELECT name
+        FROM agent_secrets
+        WHERE organization_id = ${orgId}
+          AND name IN (
+            ${`auth-profile/${blockerId}/DATABASE_URL`},
+            ${`auth-profile/${blockerId}/legacy-convergence/DATABASE_URL`}
+          )
+        FOR UPDATE
+      `;
+
+			migration = migrateLegacyPlaintextAuthData();
+			await waitForBlockedSecretWrite();
+			await persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: targetId,
+				credentials: { DATABASE_URL: ROTATED_DSN },
+			});
+		});
+		await migration;
+
+		const resolved = await resolveAuthCredentials({
+			organizationId: orgId,
+			authData: await rawAuthData(targetId),
+		});
+		expect(resolved.DATABASE_URL).toBe(ROTATED_DSN);
+		const staleStagingRows = await sql`
+      SELECT 1
+      FROM agent_secrets
+      WHERE organization_id = ${orgId}
+        AND name LIKE ${`auth-profile/${targetId}/legacy-convergence/%`}
+    `;
+		expect(staleStagingRows).toHaveLength(0);
+	});
+
+	/**
+	 * ITEM 4 — EXECUTION PATH A (worker sync).
+	 *
+	 * `poll.ts` hands the connector its DSN through the `connection_credentials`
+	 * field, which the worker merges into `ctx.config` (executor.ts `mergeEnv`).
+	 * Asserted against the poll SELECT's own shape: the path reads
+	 * `conn.auth_profile_id` and resolves through `resolveExecutionAuth`, so a
+	 * regression that dropped ref-resolution would surface the literal
+	 * `secret://…` string here instead of a usable DSN.
+	 */
+	it("path A (worker sync) receives a usable DSN, not a ref", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "postgres",
+		});
+		const profileId = await seedEnvProfile(orgId, "pg-path-a", {});
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: DSN },
+			}),
+		);
+		await sql`
+      UPDATE connections SET auth_profile_id = ${profileId} WHERE id = ${conn.id}
+    `;
+
+		// The columns poll.ts selects for credential resolution.
+		const [row] = (await sql`
+      SELECT auth_profile_id, app_auth_profile_id
+      FROM connections WHERE id = ${conn.id}
+    `) as unknown as Array<{
+			auth_profile_id: number | null;
+			app_auth_profile_id: number | null;
+		}>;
+
+		const { connectionCredentials } = await resolveExecutionAuth({
+			organizationId: orgId,
+			connectionId: conn.id,
+			authProfileId: row.auth_profile_id,
+			appAuthProfileId: row.app_auth_profile_id,
+			credentialDb: getTestDb(),
+			logContext: {},
+		});
+
+		// Two-sided: the credential must ARRIVE usable *and* have been stored as
+		// a ref. Asserting only that it resolves passes trivially when the DSN
+		// is sitting in the column as plaintext — verified by neutering.
+		expect(JSON.stringify(await rawAuthData(profileId))).not.toContain(
+			DSN_PASSWORD,
+		);
+		expect(connectionCredentials.DATABASE_URL).toBe(DSN);
+		expect(String(connectionCredentials.DATABASE_URL)).not.toContain(
+			"secret://",
+		);
+	});
+
+	/**
+	 * ITEM 5 — EXECUTION PATH B (virtual feed pushdown).
+	 *
+	 * This is the path the live churn feed uses, and the one that would break
+	 * silently: `connector-pushdown.ts` never selects `connections.config`, so
+	 * its ONLY credential source is the auth profile. It builds ctx.config as
+	 * `{...connectionCredentials, ...feedConfig, ...dbEgressConfig()}`, which is
+	 * reproduced here — a regression that left the DSN out of
+	 * `connectionCredentials` would leave `ctx.config.DATABASE_URL` undefined
+	 * and the connector would throw "DATABASE_URL is required".
+	 */
+	it("path B (virtual feed pushdown) receives a usable DSN, not a ref", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "postgres",
+		});
+		const profileId = await seedEnvProfile(orgId, "pg-path-b", {});
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: DSN },
+			}),
+		);
+		await sql`
+      UPDATE connections SET auth_profile_id = ${profileId} WHERE id = ${conn.id}
+    `;
+
+		// Exactly the columns readVirtualFeed selects — note it does NOT read
+		// c.config, so nothing but the auth profile can supply the DSN.
+		const [feedRow] = (await sql`
+      SELECT c.id AS connection_id, c.auth_profile_id, c.app_auth_profile_id
+      FROM connections c WHERE c.id = ${conn.id}
+    `) as unknown as Array<{
+			connection_id: number;
+			auth_profile_id: number | null;
+			app_auth_profile_id: number | null;
+		}>;
+
+		const { connectionCredentials } = await resolveExecutionAuth({
+			organizationId: orgId,
+			connectionId: Number(feedRow.connection_id),
+			authProfileId: Number(feedRow.auth_profile_id) || null,
+			appAuthProfileId: Number(feedRow.app_auth_profile_id) || null,
+			credentialDb: getTestDb(),
+			logContext: {},
+		});
+
+		// The config object the pushdown actually hands the connector.
+		const config = { ...connectionCredentials, ...{ query: "SELECT 1" } };
+		expect(JSON.stringify(await rawAuthData(profileId))).not.toContain(
+			DSN_PASSWORD,
+		);
+		expect(config.DATABASE_URL).toBe(DSN);
+		expect(String(config.DATABASE_URL)).not.toContain("secret://");
+	});
+
+	/**
+	 * ITEM 2 — the second copy. `connections.config` is exposed by design
+	 * through `query_sql`, so a DSN must never be duplicated into it. Path A
+	 * gets its credential from `connection_credentials` (the auth profile),
+	 * never from `config`, so there is nothing to keep here.
+	 */
+	it("keeps no plaintext DSN in connections.config", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "postgres",
+		});
+		const profileId = await seedEnvProfile(orgId, "pg-config", {});
+		await orgContext.run({ organizationId: orgId }, () =>
+			persistAuthCredentials({
+				organizationId: orgId,
+				authProfileId: profileId,
+				credentials: { DATABASE_URL: DSN },
+			}),
+		);
+		await sql`
+      UPDATE connections SET auth_profile_id = ${profileId} WHERE id = ${conn.id}
+    `;
+
+		const [row] = (await sql`
+      SELECT COALESCE(config, '{}'::jsonb) AS config
+      FROM connections WHERE id = ${conn.id}
+    `) as unknown as Array<{ config: Record<string, unknown> }>;
+
+		// `config` never held the DSN for a fixture-created connection, so assert
+		// the auth profile as well — otherwise this test is vacuous and would
+		// pass with the fix removed.
+		expect(JSON.stringify(await rawAuthData(profileId))).not.toContain(
+			DSN_PASSWORD,
+		);
+		expect(JSON.stringify(row.config)).not.toContain(DSN_PASSWORD);
+	});
+});

--- a/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
+++ b/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
@@ -11,6 +11,7 @@ import {
 import {
 	createAuthProfile,
 	deleteAuthProfile,
+	updateAuthProfile,
 } from "../../utils/auth-profiles";
 import { resolveExecutionAuth } from "../../utils/execution-context";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
@@ -658,7 +659,6 @@ describe("auth_profiles credential storage", () => {
 	});
 
 	it("rename-only update keeps existing refs without re-storing", async () => {
-		const { updateAuthProfile } = await import("../../utils/auth-profiles");
 		const orgId = workspace.org.id;
 		const profile = await createAuthProfile({
 			organizationId: orgId,
@@ -722,6 +722,38 @@ describe("auth_profiles credential storage", () => {
         AND name LIKE ${`auth-profile/${profile.id}/%`}
     `;
 		expect(secretRowsAfter).toHaveLength(0);
+	});
+
+	it("refuses credential writes when the profile was deleted concurrently", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const profile = await createAuthProfile({
+			organizationId: orgId,
+			connectorKey: "postgres",
+			displayName: "Race delete",
+			slug: "pg-race-delete",
+			profileKind: "env",
+			authData: { DATABASE_URL: DSN },
+		});
+		await deleteAuthProfile(orgId, profile.slug);
+
+		await expect(
+			sql.begin(async (tx) =>
+				toSecretRefAuthData({
+					organizationId: orgId,
+					authProfileId: profile.id,
+					credentials: { DATABASE_URL: ROTATED_DSN },
+					db: tx,
+				}),
+			),
+		).rejects.toThrow(/not found for credential write/);
+
+		const secrets = await sql`
+      SELECT name FROM agent_secrets
+      WHERE organization_id = ${orgId}
+        AND name LIKE ${`auth-profile/${profile.id}/%`}
+    `;
+		expect(secrets).toHaveLength(0);
 	});
 
 	it("rolls back agent_secrets when the caller transaction aborts", async () => {

--- a/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
+++ b/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
@@ -591,7 +591,6 @@ describe("auth_profiles credential storage", () => {
 	});
 
 	it("does not resolve a legacy unowned secret:// planted in auth_data", async () => {
-		const sql = getTestDb();
 		const orgId = workspace.org.id;
 		const store = new PostgresSecretStore();
 		const foreignRef = await orgContext.run({ organizationId: orgId }, () =>

--- a/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
+++ b/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
@@ -510,20 +510,17 @@ describe("auth_profiles credential storage", () => {
 
 	/**
 	 * Public create/validate paths must never treat a caller-supplied
-	 * `secret://…` string as an already-stored ref. Without ownership checks a
-	 * crafted credential would bind the profile to a predictable org/global
-	 * secret without ever writing the submitted value.
+	 * `secret://…` string as an already-stored ref — not even one under this
+	 * profile's own name (cross-key binding) or another profile's.
 	 */
 	it("does not bind a caller-supplied foreign secret:// ref", async () => {
 		const orgId = workspace.org.id;
 		const victimId = await seedEnvProfile(orgId, "pg-ref-victim", {});
-		await orgContext.run({ organizationId: orgId }, () =>
-			persistAuthCredentials({
-				organizationId: orgId,
-				authProfileId: victimId,
-				credentials: { DATABASE_URL: DSN },
-			}),
-		);
+		await persistAuthCredentials({
+			organizationId: orgId,
+			authProfileId: victimId,
+			credentials: { DATABASE_URL: DSN },
+		});
 		const victimRef = String((await rawAuthData(victimId)).DATABASE_URL);
 		expect(parseSecretRef(victimRef)?.scheme).toBe("secret");
 
@@ -536,14 +533,12 @@ describe("auth_profiles credential storage", () => {
 			return originalPut(name, value, options);
 		};
 
-		const out = await orgContext.run({ organizationId: orgId }, () =>
-			toSecretRefAuthData({
-				organizationId: orgId,
-				authProfileId: attackerId,
-				credentials: { DATABASE_URL: victimRef },
-				secretStore: store,
-			}),
-		);
+		const out = await toSecretRefAuthData({
+			organizationId: orgId,
+			authProfileId: attackerId,
+			credentials: { DATABASE_URL: victimRef },
+			secretStore: store,
+		});
 
 		// Must have written (not short-circuited) and must not keep the victim ref.
 		expect(putCalls).toHaveLength(1);
@@ -560,36 +555,63 @@ describe("auth_profiles credential storage", () => {
 		expect(resolved.DATABASE_URL).not.toBe(DSN);
 	});
 
-	it("preserves a rename-only re-submit of the profile's own refs", async () => {
+	it("does not bind one field to another via same-profile secret:// ref", async () => {
 		const orgId = workspace.org.id;
-		const profileId = await seedEnvProfile(orgId, "pg-ref-owned", {});
-		await orgContext.run({ organizationId: orgId }, () =>
-			persistAuthCredentials({
-				organizationId: orgId,
-				authProfileId: profileId,
-				credentials: { DATABASE_URL: DSN },
-			}),
-		);
-		const ownedRef = String((await rawAuthData(profileId)).DATABASE_URL);
-		const putCalls: string[] = [];
-		const store = new PostgresSecretStore();
-		const originalPut = store.put.bind(store);
-		store.put = async (name, value, options) => {
-			putCalls.push(value);
-			return originalPut(name, value, options);
-		};
+		const profileId = await seedEnvProfile(orgId, "pg-ref-cross-key", {});
+		await persistAuthCredentials({
+			organizationId: orgId,
+			authProfileId: profileId,
+			credentials: { API_KEY: "real-api-key", DATABASE_URL: DSN },
+		});
+		const stored = await rawAuthData(profileId);
+		const apiKeyRef = String(stored.API_KEY);
+		expect(parseSecretRef(apiKeyRef)?.scheme).toBe("secret");
 
-		const out = await orgContext.run({ organizationId: orgId }, () =>
-			toSecretRefAuthData({
-				organizationId: orgId,
-				authProfileId: profileId,
-				credentials: { DATABASE_URL: ownedRef },
-				secretStore: store,
-			}),
-		);
+		// Attacker re-submits the API_KEY ref as DATABASE_URL.
+		await persistAuthCredentials({
+			organizationId: orgId,
+			authProfileId: profileId,
+			credentials: { DATABASE_URL: apiKeyRef },
+		});
+		const after = await rawAuthData(profileId);
+		// DATABASE_URL must be a NEW ref for that field — not the API_KEY ref.
+		expect(String(after.DATABASE_URL)).not.toBe(apiKeyRef);
+		const resolved = await resolveAuthCredentials({
+			organizationId: orgId,
+			authData: after,
+		});
+		// Opaque store of the ref string — must not resolve to the API key value.
+		expect(resolved.DATABASE_URL).toBe(apiKeyRef);
+		expect(resolved.DATABASE_URL).not.toBe("real-api-key");
+		expect(resolved.DATABASE_URL).not.toBe(DSN);
+	});
 
-		expect(putCalls).toHaveLength(0);
-		expect(out.DATABASE_URL).toBe(ownedRef);
+	it("rename-only update keeps existing refs without re-storing", async () => {
+		const { updateAuthProfile } = await import("../../utils/auth-profiles");
+		const orgId = workspace.org.id;
+		const profile = await createAuthProfile({
+			organizationId: orgId,
+			connectorKey: "postgres",
+			displayName: "Rename me",
+			slug: "pg-ref-rename",
+			profileKind: "env",
+			authData: { DATABASE_URL: DSN },
+		});
+		const before = String((await rawAuthData(profile.id)).DATABASE_URL);
+		expect(parseSecretRef(before)?.scheme).toBe("secret");
+
+		const updated = await updateAuthProfile({
+			organizationId: orgId,
+			slug: profile.slug,
+			displayName: "Renamed",
+		});
+		expect(updated?.display_name).toBe("Renamed");
+		expect(String((await rawAuthData(profile.id)).DATABASE_URL)).toBe(before);
+		const resolved = await resolveAuthCredentials({
+			organizationId: orgId,
+			authData: await rawAuthData(profile.id),
+		});
+		expect(resolved.DATABASE_URL).toBe(DSN);
 	});
 
 	/**
@@ -628,5 +650,47 @@ describe("auth_profiles credential storage", () => {
         AND name LIKE ${`auth-profile/${profile.id}/%`}
     `;
 		expect(secretRowsAfter).toHaveLength(0);
+	});
+
+	it("rolls back agent_secrets when the caller transaction aborts", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		let profileId: number | undefined;
+		try {
+			await sql.begin(async (tx) => {
+				const profile = await createAuthProfile(
+					{
+						organizationId: orgId,
+						connectorKey: "postgres",
+						displayName: "Rollback secrets",
+						slug: "pg-rollback-secrets",
+						profileKind: "env",
+						authData: { DATABASE_URL: DSN },
+					},
+					tx,
+				);
+				profileId = profile.id;
+				const secretsInTx = await tx`
+          SELECT name FROM agent_secrets
+          WHERE organization_id = ${orgId}
+            AND name LIKE ${`auth-profile/${profile.id}/%`}
+        `;
+				expect(secretsInTx.length).toBeGreaterThan(0);
+				throw new Error("force-rollback");
+			});
+		} catch (err) {
+			expect((err as Error).message).toBe("force-rollback");
+		}
+		expect(profileId).toBeDefined();
+		const profileGone = await sql`
+      SELECT 1 FROM auth_profiles WHERE id = ${profileId!}
+    `;
+		expect(profileGone).toHaveLength(0);
+		const secretsGone = await sql`
+      SELECT name FROM agent_secrets
+      WHERE organization_id = ${orgId}
+        AND name LIKE ${`auth-profile/${profileId!}/%`}
+    `;
+		expect(secretsGone).toHaveLength(0);
 	});
 });

--- a/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
+++ b/packages/server/src/__tests__/integration/auth-profile-secret-storage.test.ts
@@ -339,6 +339,7 @@ describe("auth_profiles credential storage", () => {
 
 		const resolved = await resolveAuthCredentials({
 			organizationId: orgId,
+			authProfileId: targetId,
 			authData: await rawAuthData(targetId),
 		});
 		expect(resolved.DATABASE_URL).toBe(ROTATED_DSN);
@@ -549,6 +550,7 @@ describe("auth_profiles credential storage", () => {
 		// Resolving the attacker's profile must NOT yield the victim DSN.
 		const resolved = await resolveAuthCredentials({
 			organizationId: orgId,
+			authProfileId: attackerId,
 			authData: out,
 		});
 		expect(resolved.DATABASE_URL).toBe(victimRef);
@@ -578,12 +580,81 @@ describe("auth_profiles credential storage", () => {
 		expect(String(after.DATABASE_URL)).not.toBe(apiKeyRef);
 		const resolved = await resolveAuthCredentials({
 			organizationId: orgId,
+			authProfileId: profileId,
 			authData: after,
 		});
 		// Opaque store of the ref string — must not resolve to the API key value.
 		expect(resolved.DATABASE_URL).toBe(apiKeyRef);
 		expect(resolved.DATABASE_URL).not.toBe("real-api-key");
 		expect(resolved.DATABASE_URL).not.toBe(DSN);
+	});
+
+	it("does not resolve a legacy unowned secret:// planted in auth_data", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const store = new PostgresSecretStore();
+		const foreignRef = await orgContext.run({ organizationId: orgId }, () =>
+			store.put("predictable-global-name", "should-not-leak"),
+		);
+		const profileId = await seedEnvProfile(orgId, "pg-legacy-inject", {
+			DATABASE_URL: foreignRef,
+		});
+		const resolved = await resolveAuthCredentials({
+			organizationId: orgId,
+			authProfileId: profileId,
+			authData: await rawAuthData(profileId),
+		});
+		expect(resolved.DATABASE_URL).toBeUndefined();
+		// Convergence must encrypt the foreign ref as opaque input, not keep it.
+		await migrateLegacyPlaintextAuthData();
+		const after = await rawAuthData(profileId);
+		expect(String(after.DATABASE_URL)).not.toBe(foreignRef);
+		expect(parseSecretRef(String(after.DATABASE_URL))?.scheme).toBe("secret");
+		const afterResolve = await resolveAuthCredentials({
+			organizationId: orgId,
+			authProfileId: profileId,
+			authData: after,
+		});
+		expect(afterResolve.DATABASE_URL).toBe(foreignRef);
+		expect(afterResolve.DATABASE_URL).not.toBe("should-not-leak");
+	});
+
+	it("deletes agent_secrets for credential keys removed from auth_data", async () => {
+		const sql = getTestDb();
+		const orgId = workspace.org.id;
+		const profileId = await seedEnvProfile(orgId, "pg-key-prune", {});
+		await persistAuthCredentials({
+			organizationId: orgId,
+			authProfileId: profileId,
+			credentials: { DATABASE_URL: DSN, API_KEY: "extra-key" },
+		});
+		const before = await sql`
+      SELECT name FROM agent_secrets
+      WHERE organization_id = ${orgId}
+        AND name LIKE ${`auth-profile/${profileId}/%`}
+      ORDER BY name
+    `;
+		expect(before.map((r) => (r as { name: string }).name)).toEqual(
+			expect.arrayContaining([
+				`auth-profile/${profileId}/API_KEY`,
+				`auth-profile/${profileId}/DATABASE_URL`,
+			]),
+		);
+
+		await persistAuthCredentials({
+			organizationId: orgId,
+			authProfileId: profileId,
+			credentials: { DATABASE_URL: DSN },
+		});
+		const after = await sql`
+      SELECT name FROM agent_secrets
+      WHERE organization_id = ${orgId}
+        AND name LIKE ${`auth-profile/${profileId}/%`}
+      ORDER BY name
+    `;
+		expect(after.map((r) => (r as { name: string }).name)).toEqual([
+			`auth-profile/${profileId}/DATABASE_URL`,
+		]);
 	});
 
 	it("rename-only update keeps existing refs without re-storing", async () => {
@@ -609,6 +680,7 @@ describe("auth_profiles credential storage", () => {
 		expect(String((await rawAuthData(profile.id)).DATABASE_URL)).toBe(before);
 		const resolved = await resolveAuthCredentials({
 			organizationId: orgId,
+			authProfileId: profile.id,
 			authData: await rawAuthData(profile.id),
 		});
 		expect(resolved.DATABASE_URL).toBe(DSN);

--- a/packages/server/src/__tests__/integration/complete-auth-embeddings-status-guard.test.ts
+++ b/packages/server/src/__tests__/integration/complete-auth-embeddings-status-guard.test.ts
@@ -236,6 +236,7 @@ describe('completeAuthRun status guard (late-completion-after-timeout)', () => {
     ).toBe('secret');
     const resolved = await resolveAuthCredentials({
       organizationId: org.id,
+      authProfileId: profileId,
       authData: profileAfter[0].auth_data,
     });
     expect(resolved).toEqual({ access_token: 'fresh' });

--- a/packages/server/src/__tests__/integration/complete-auth-embeddings-status-guard.test.ts
+++ b/packages/server/src/__tests__/integration/complete-auth-embeddings-status-guard.test.ts
@@ -29,9 +29,11 @@
  * authorizeRunForWorker's read, in the TOCTOU window before the UPDATE).
  */
 
+import { parseSecretRef } from '@lobu/core';
 import type { Context } from 'hono';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../../index';
+import { resolveAuthCredentials } from '../../utils/auth-credential-secrets';
 import { completeAuthRun, completeEmbeddings } from '../../worker-api';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { createTestOrganization } from '../setup/test-fixtures';
@@ -226,7 +228,17 @@ describe('completeAuthRun status guard (late-completion-after-timeout)', () => {
       SELECT status, auth_data FROM auth_profiles WHERE id = ${profileId}
     `) as Array<{ status: string; auth_data: Record<string, unknown> }>;
     expect(profileAfter[0].status).toBe('active');
-    expect(profileAfter[0].auth_data).toEqual({ access_token: 'fresh' });
+    // Credentials persist as encrypted secret:// refs, never plaintext, and
+    // resolve back to the real value at connect time.
+    expect(JSON.stringify(profileAfter[0].auth_data)).not.toContain('fresh');
+    expect(
+      parseSecretRef(String(profileAfter[0].auth_data.access_token))?.scheme
+    ).toBe('secret');
+    const resolved = await resolveAuthCredentials({
+      organizationId: org.id,
+      authData: profileAfter[0].auth_data,
+    });
+    expect(resolved).toEqual({ access_token: 'fresh' });
   });
 });
 

--- a/packages/server/src/__tests__/integration/complete-auth-run-claimant-guard.test.ts
+++ b/packages/server/src/__tests__/integration/complete-auth-run-claimant-guard.test.ts
@@ -147,6 +147,7 @@ describe('completeAuthRun claimant guard', () => {
     );
     const resolved = await resolveAuthCredentials({
       organizationId: org.id,
+      authProfileId: profileId,
       authData: profile[0].auth_data,
     });
     expect(resolved).toEqual({ api_key: 'real-token' });

--- a/packages/server/src/__tests__/integration/complete-auth-run-claimant-guard.test.ts
+++ b/packages/server/src/__tests__/integration/complete-auth-run-claimant-guard.test.ts
@@ -25,9 +25,11 @@
  * (non-'user') cloud worker would hit it in production.
  */
 
+import { parseSecretRef } from '@lobu/core';
 import type { Context } from 'hono';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../../index';
+import { resolveAuthCredentials } from '../../utils/auth-credential-secrets';
 import { completeAuthRun } from '../../worker-api';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { createTestOrganization } from '../setup/test-fixtures';
@@ -137,7 +139,17 @@ describe('completeAuthRun claimant guard', () => {
       SELECT status, auth_data FROM auth_profiles WHERE id = ${profileId}
     `) as Array<{ status: string; auth_data: Record<string, unknown> }>;
     expect(profile[0].status).toBe('active');
-    expect(profile[0].auth_data).toEqual({ api_key: 'real-token' });
+    // Credentials persist as encrypted secret:// refs, never plaintext, and
+    // resolve back to the real value at connect time.
+    expect(JSON.stringify(profile[0].auth_data)).not.toContain('real-token');
+    expect(parseSecretRef(String(profile[0].auth_data.api_key))?.scheme).toBe(
+      'secret'
+    );
+    const resolved = await resolveAuthCredentials({
+      organizationId: org.id,
+      authData: profile[0].auth_data,
+    });
+    expect(resolved).toEqual({ api_key: 'real-token' });
 
     const run = (await sql`
       SELECT status FROM runs WHERE id = ${runId}

--- a/packages/server/src/__tests__/integration/complete-auth-run-session-state-passthrough.test.ts
+++ b/packages/server/src/__tests__/integration/complete-auth-run-session-state-passthrough.test.ts
@@ -1,0 +1,117 @@
+/**
+ * completeAuthRun session-state passthrough.
+ *
+ * Regression: an auth run can be linked to an `interactive` profile (the
+ * reauthenticate / interactive-connection-setup pairing flow). Its returned
+ * credentials are structured SESSION STATE (e.g. Baileys creds — nested
+ * objects), which execution reads back verbatim as `sessionState` and never
+ * resolves as `secret://` refs.
+ *
+ * The credential-at-rest change wraps ONLY flat bearer credentials (env,
+ * oauth_account) in secret refs. Session-state kinds must pass through
+ * unchanged: secret-ref'ing them would both strip their non-string values
+ * (normalizeAuthValues keeps only strings) and leave unresolvable refs on the
+ * worker.
+ *
+ * Green: an `interactive` profile completing an auth run keeps its nested
+ * session state verbatim — no `secret://` refs, nothing dropped.
+ */
+
+import { parseSecretRef } from '@lobu/core';
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { completeAuthRun } from '../../worker-api';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization } from '../setup/test-fixtures';
+
+const CLAIMANT = 'worker-legit';
+
+function mockWorkerCtx(body: unknown): {
+  ctx: Context<{ Bindings: Env }>;
+  result: () => { body: unknown; status: number };
+} {
+  let captured: { body: unknown; status: number } = { body: undefined, status: 200 };
+  const ctx = {
+    req: { json: async () => body },
+    var: {},
+    json: (b: unknown, status?: number) => {
+      captured = { body: b, status: status ?? 200 };
+      return captured as unknown as Response;
+    },
+  } as unknown as Context<{ Bindings: Env }>;
+  return { ctx, result: () => captured };
+}
+
+async function insertInteractiveProfile(organizationId: string): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO auth_profiles
+      (organization_id, slug, display_name, connector_key, profile_kind,
+       status, auth_data, metadata, created_at, updated_at)
+    VALUES
+      (${organizationId}, 'wa-pairing', 'WhatsApp', 'whatsapp', 'interactive',
+       'pending_auth', '{}'::jsonb, '{}'::jsonb, NOW(), NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows[0].id;
+}
+
+async function insertRunningAuthRun(
+  organizationId: string,
+  authProfileId: number
+): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO runs
+      (organization_id, run_type, status, claimed_by, claimed_at,
+       auth_profile_id, created_at)
+    VALUES
+      (${organizationId}, 'auth', 'running', ${CLAIMANT}, NOW(),
+       ${authProfileId}, NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows[0].id;
+}
+
+describe('completeAuthRun session-state passthrough', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('stores interactive session state verbatim — no secret refs, nothing dropped', async () => {
+    const org = await createTestOrganization();
+    const profileId = await insertInteractiveProfile(org.id);
+    const runId = await insertRunningAuthRun(org.id, profileId);
+    const sql = getTestDb();
+
+    // Baileys-style session state: nested objects + a flat string field. None
+    // of this is a bearer credential the execution path resolves as a ref.
+    const sessionState = {
+      creds: { noiseKey: { private: 'abc', public: 'def' }, registered: true },
+      account_id: '15551234567',
+    };
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: CLAIMANT,
+      status: 'success',
+      credentials: sessionState,
+      metadata: { paired: true },
+    });
+    await completeAuthRun(ctx);
+
+    expect(result().body).toEqual({ success: true });
+
+    const profile = (await sql`
+      SELECT status, auth_data FROM auth_profiles WHERE id = ${profileId}
+    `) as Array<{ status: string; auth_data: Record<string, unknown> }>;
+
+    // Passthrough: the whole session state survives intact (nested objects
+    // preserved), and no value was converted into a secret:// ref.
+    expect(profile[0].status).toBe('active');
+    expect(profile[0].auth_data).toEqual(sessionState);
+    expect(JSON.stringify(profile[0].auth_data)).not.toContain('secret://');
+    expect(parseSecretRef(String(profile[0].auth_data.account_id))).toBeNull();
+  });
+});

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -29,7 +29,10 @@ import {
   normalizeAuthProfileSlug,
   normalizeAuthValues,
 } from '../utils/auth-profiles';
-import { toSecretRefAuthData } from '../utils/auth-credential-secrets';
+import {
+  persistAuthCredentials,
+  toSecretRefAuthData,
+} from '../utils/auth-credential-secrets';
 import { type ConnectTokenRow, resolveConnectToken } from '../utils/connect-tokens';
 import logger from '../utils/logger';
 import { syncOAuthConnectionsForAuthProfile } from '../utils/oauth-connection-state';
@@ -494,10 +497,17 @@ connectRoutes.post('/:token/cancel', requireConnectToken, async (c) => {
 
   await sql.begin(async (tx) => {
     if (tokenRow.auth_profile_id) {
+      // Clear auth_data AND drop the encrypted credential rows. Setting
+      // auth_data to {} alone would leave decryptable agent_secrets behind.
+      await persistAuthCredentials({
+        organizationId: tokenRow.organization_id,
+        authProfileId: Number(tokenRow.auth_profile_id),
+        credentials: {},
+        db: tx,
+      });
       await tx`
         UPDATE auth_profiles
-        SET auth_data = '{}'::jsonb,
-            status = 'pending_auth',
+        SET status = 'pending_auth',
             updated_at = NOW()
         WHERE id = ${tokenRow.auth_profile_id}
           AND organization_id = ${tokenRow.organization_id}

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -214,6 +214,8 @@ connectRoutes.post('/:token/validate', requireConnectToken, async (c) => {
   if (!tokenRow.auth_profile_id || !tokenRow.connection_id) {
     return c.json({ error: 'This env auth flow is not attached to a pending connection.' }, 400);
   }
+  const authProfileId = Number(tokenRow.auth_profile_id);
+  const connectionId = Number(tokenRow.connection_id);
 
   const sql = getDb();
 
@@ -224,7 +226,7 @@ connectRoutes.post('/:token/validate', requireConnectToken, async (c) => {
       f.feed_key,
       f.config
     FROM feeds f
-    WHERE connection_id = ${tokenRow.connection_id} AND f.deleted_at IS NULL
+    WHERE connection_id = ${connectionId} AND f.deleted_at IS NULL
     ORDER BY id ASC
     LIMIT 1
   `;
@@ -283,37 +285,42 @@ connectRoutes.post('/:token/validate', requireConnectToken, async (c) => {
   // Store credentials on the pending auth profile but keep connection in
   // pending_auth. The submitted values are bearer credentials (a postgres DSN
   // embeds its own password), so they go to the encrypted secret store and
-  // only `secret://` refs land in `auth_data`.
-  const credentialRefs = await toSecretRefAuthData({
-    organizationId: tokenRow.organization_id,
-    authProfileId: tokenRow.auth_profile_id,
-    credentials: normalizeAuthValues(body.credentials),
+  // only `secret://` refs land in `auth_data`. Secret write + profile/connection
+  // updates share one transaction so a partial failure cannot leave a
+  // decryptable secret without the matching auth_data ref.
+  await sql.begin(async (tx) => {
+    const credentialRefs = await toSecretRefAuthData({
+      organizationId: tokenRow.organization_id,
+      authProfileId,
+      credentials: normalizeAuthValues(body.credentials),
+      db: tx,
+    });
+    await tx`
+      UPDATE auth_profiles
+      SET auth_data = ${tx.json(credentialRefs)},
+          status = 'pending_auth',
+          updated_at = NOW()
+      WHERE id = ${authProfileId}
+        AND organization_id = ${tokenRow.organization_id}
+    `;
+
+    await tx`
+      UPDATE connections
+      SET status = 'pending_auth',
+          updated_at = NOW()
+      WHERE id = ${connectionId}
+        AND organization_id = ${tokenRow.organization_id}
+    `;
+
+    // Activate feeds so the worker can pick them up for validation
+    await tx`
+      UPDATE feeds
+      SET status = 'active',
+          next_run_at = NOW(),
+          updated_at = NOW()
+      WHERE connection_id = ${connectionId}
+    `;
   });
-  await sql`
-    UPDATE auth_profiles
-    SET auth_data = ${sql.json(credentialRefs)},
-        status = 'pending_auth',
-        updated_at = NOW()
-    WHERE id = ${tokenRow.auth_profile_id}
-      AND organization_id = ${tokenRow.organization_id}
-  `;
-
-  await sql`
-    UPDATE connections
-    SET status = 'pending_auth',
-        updated_at = NOW()
-    WHERE id = ${tokenRow.connection_id}
-      AND organization_id = ${tokenRow.organization_id}
-  `;
-
-  // Activate feeds so the worker can pick them up for validation
-  await sql`
-    UPDATE feeds
-    SET status = 'active',
-        next_run_at = NOW(),
-        updated_at = NOW()
-    WHERE connection_id = ${tokenRow.connection_id}
-  `;
 
   const feedId = Number(feed.id);
   const runId = await createSyncRun(feedId, c.env as unknown as Env);

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -29,6 +29,7 @@ import {
   normalizeAuthProfileSlug,
   normalizeAuthValues,
 } from '../utils/auth-profiles';
+import { toSecretRefAuthData } from '../utils/auth-credential-secrets';
 import { type ConnectTokenRow, resolveConnectToken } from '../utils/connect-tokens';
 import logger from '../utils/logger';
 import { syncOAuthConnectionsForAuthProfile } from '../utils/oauth-connection-state';
@@ -279,10 +280,18 @@ connectRoutes.post('/:token/validate', requireConnectToken, async (c) => {
     );
   }
 
-  // Store credentials on the pending auth profile but keep connection in pending_auth
+  // Store credentials on the pending auth profile but keep connection in
+  // pending_auth. The submitted values are bearer credentials (a postgres DSN
+  // embeds its own password), so they go to the encrypted secret store and
+  // only `secret://` refs land in `auth_data`.
+  const credentialRefs = await toSecretRefAuthData({
+    organizationId: tokenRow.organization_id,
+    authProfileId: tokenRow.auth_profile_id,
+    credentials: normalizeAuthValues(body.credentials),
+  });
   await sql`
     UPDATE auth_profiles
-    SET auth_data = ${sql.json(normalizeAuthValues(body.credentials))},
+    SET auth_data = ${sql.json(credentialRefs)},
         status = 'pending_auth',
         updated_at = NOW()
     WHERE id = ${tokenRow.auth_profile_id}

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -36,6 +36,7 @@ import {
   enqueueAgentMessage,
 } from '../gateway/services/agent-threads';
 import { buildMessagePayload } from '../gateway/services/platform-helpers';
+import { migrateLegacyPlaintextAuthData } from '../utils/auth-credential-secrets';
 
 function asDeliveryContext(value: unknown): ScheduledDeliveryContext | null {
   if (!value || typeof value !== 'object') return null;
@@ -263,6 +264,23 @@ function registerMaintenanceTasks(
       }
     },
     { cron: '0 * * * *' },
+  );
+
+  // Credential-at-rest convergence — rewrites any `env` auth profile still
+  // holding a PLAINTEXT credential (e.g. a postgres DSN, which embeds its own
+  // password) into an encrypted `secret://` ref. Encryption cannot happen in a
+  // SQL migration, so the conversion runs here instead. Idempotent: a profile
+  // already holding refs is skipped, so this is a no-op after the first pass.
+  // Single-claimant per tick; pure Postgres, so multi-replica safe.
+  scheduler.register(
+    'converge-auth-credential-secrets',
+    async () => {
+      const converted = await migrateLegacyPlaintextAuthData();
+      if (converted > 0) {
+        logger.info({ converted }, '[task] converge-auth-credential-secrets converted profiles');
+      }
+    },
+    { cron: '*/10 * * * *' },
   );
 
   // Stale device-worker reaper — deletes device_workers rows that are unseen

--- a/packages/server/src/utils/__tests__/config-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/config-redaction.test.ts
@@ -1,4 +1,4 @@
-import { isSecretKey } from '@lobu/core';
+import { isSecretKey, redactUriCredentials } from '@lobu/core';
 import { describe, expect, it } from 'vitest';
 import {
   REDACTED_SENTINEL,
@@ -119,6 +119,36 @@ describe('isSecretKey > URL/DSN-shaped credential keys', () => {
       expect(isSecretKey(key)).toBe(false);
     }
   );
+});
+
+/**
+ * URI redaction runs on every string in untrusted config. An unbounded scheme
+ * quantifier (`[a-z0-9+.-]*`) is a polynomial-ReDoS on long non-matching
+ * input (e.g. runs of 'a' with no `://`). The scheme quantifier is bounded
+ * `{0,63}` so work stays linear — this pins that against regression.
+ */
+describe('redactUriCredentials > ReDoS-safe on adversarial non-matching input', () => {
+  it('stays near-linear as non-matching input doubles', () => {
+    const sizes = [10_000, 20_000, 40_000] as const;
+    const times: number[] = [];
+    for (const n of sizes) {
+      const input = 'a'.repeat(n);
+      const start = performance.now();
+      expect(redactUriCredentials(input)).toBe(input);
+      times.push(performance.now() - start);
+    }
+    // Quadratic growth would put 40k ~4× the 20k cost (or worse). Allow up to
+    // 8× headroom for timer noise / GC, which still fails a true quadratic.
+    expect(times[2]).toBeLessThan(Math.max(times[1] * 8, 50));
+    // Absolute ceiling: even the largest sample should finish quickly.
+    expect(times[2]).toBeLessThan(200);
+  });
+
+  it('still redacts a real credential-bearing URI', () => {
+    expect(redactUriCredentials('postgres://u:pw@host/db')).toBe(
+      `postgres://${REDACTED_SENTINEL}@host/db`,
+    );
+  });
 });
 
 /**

--- a/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema-redaction.test.ts
@@ -52,6 +52,17 @@ const SECRET_KEYS = [
   'Set-Cookie',
   'client-secret',
   ' password ',
+  // Unseparated acronym runs: `normalizeKey` only splits on a
+  // lowercase-to-uppercase boundary, so these collapse to one unspaced token
+  // the suffix pattern cannot reach. Covered by explicit exact-key entries on
+  // both sides; removing those entries makes exactly these three go plaintext.
+  'DBUrl',
+  'DBURL',
+  'DATABASEURL',
+  'AWSSecretKey',
+  'AWS_SECRET_KEY',
+  'AWSSecretAccessKey',
+  'AWS_SECRET_ACCESS_KEY',
 ];
 
 const NON_SECRET_KEYS = [
@@ -65,6 +76,11 @@ const NON_SECRET_KEYS = [
   'secretsPolicy',
   'display_name',
   'feed_key',
+  // A bare `key` is not a credential suffix: `feed_key`, `sort_key`, and
+  // `idempotency_key` are ordinary identifiers. Explicit credential compounds
+  // such as `secret_key`, `api_key`, and `private_key` are covered above.
+  'sort_key',
+  'idempotency_key',
 ];
 
 describe('table-schema config redaction', () => {

--- a/packages/server/src/utils/auth-credential-secrets.ts
+++ b/packages/server/src/utils/auth-credential-secrets.ts
@@ -154,6 +154,24 @@ async function storeAuthCredentialRefs(
 	const out: Record<string, string> = {};
 	const sql = params.db ?? getDb();
 
+	// When writing on a caller transaction, lock the profile first. Concurrent
+	// deleteAuthProfile takes the same row lock; if the profile is gone we must
+	// not insert decryptable agent_secrets that would survive as orphans.
+	if (params.db && !params.secretStore) {
+		const locked = await sql`
+      SELECT id
+      FROM auth_profiles
+      WHERE id = ${params.authProfileId}
+        AND organization_id = ${params.organizationId}
+      FOR UPDATE
+    `;
+		if (locked.length === 0) {
+			throw new Error(
+				`auth profile ${params.authProfileId} not found for credential write`,
+			);
+		}
+	}
+
 	for (const [key, value] of Object.entries(values)) {
 		// Migration of partially-converted rows may still hold some refs.
 		// Public paths never set preserveStoredRefs — every caller-supplied

--- a/packages/server/src/utils/auth-credential-secrets.ts
+++ b/packages/server/src/utils/auth-credential-secrets.ts
@@ -1,0 +1,249 @@
+/**
+ * Credential-at-rest handling for `auth_profiles.auth_data`.
+ *
+ * `auth_data` on an `env` profile holds bearer credentials — a postgres DSN
+ * carries its own password, so whoever reads the column owns the database.
+ * Historically the column stored those values verbatim, which put a live
+ * credential in plaintext in a row that several read paths select wholesale.
+ *
+ * Values are now stored as `secret://` refs. The ref points at
+ * `agent_secrets`, whose store already encrypts with AES-256-GCM and scopes
+ * rows per organization — the same mechanism Slack bot tokens and webhook
+ * secrets use. Reusing it (rather than encrypting the JSONB value inline)
+ * means one key-management story, one rotation story, and it composes with
+ * the redaction layer, which already treats a `secret://` ref as non-secret
+ * to echo.
+ *
+ * Only `env`-kind profiles are converted. `browser_session` / `interactive`
+ * profiles hold structured session state (cookie jars, Baileys creds), not
+ * flat credential strings; they are out of scope here and untouched.
+ */
+
+import { parseSecretRef } from "@lobu/core";
+import { type DbClient, getDb } from "../db/client";
+import { PostgresSecretStore } from "../lobu/stores/postgres-secret-store";
+import { orgContext } from "../lobu/stores/org-context";
+import {
+	resolveSecretValue,
+	type SecretStore,
+	type WritableSecretStore,
+} from "../gateway/secrets/index.js";
+import { createLogger } from "@lobu/core";
+import { normalizeAuthValues } from "./auth-profiles";
+
+const logger = createLogger("auth-credential-secrets");
+
+/** Scheme of the builtin (`agent_secrets`-backed) store. */
+const BUILTIN_SECRET_SCHEME = "secret";
+
+/**
+ * True only for a ref into the builtin secret store.
+ *
+ * Deliberately NOT `isSecretRef` from @lobu/core: that matches ANY
+ * `scheme://…` URI, so a `postgres://user:pass@host/db` DSN — exactly the
+ * credential this module exists to protect — parses as an "already stored
+ * ref" and would be passed through verbatim, leaving the password in
+ * plaintext. The scheme must be checked explicitly.
+ */
+function isStoredSecretRef(value: string): boolean {
+	return parseSecretRef(value)?.scheme === BUILTIN_SECRET_SCHEME;
+}
+
+/**
+ * Secret name for one credential field. Namespaced per auth profile so two
+ * profiles holding a `DATABASE_URL` never collide.
+ */
+function authCredentialSecretName(
+	authProfileId: number,
+	key: string,
+	namespace?: "legacy-convergence",
+): string {
+	return namespace
+		? `auth-profile/${authProfileId}/${namespace}/${key}`
+		: `auth-profile/${authProfileId}/${key}`;
+}
+
+type SecretRefAuthDataParams = {
+	organizationId: string;
+	authProfileId: number;
+	credentials: Record<string, unknown>;
+	secretStore?: WritableSecretStore;
+};
+
+async function storeAuthCredentialRefs(
+	params: SecretRefAuthDataParams,
+	namespace?: "legacy-convergence",
+): Promise<Record<string, string>> {
+	const store = params.secretStore ?? new PostgresSecretStore();
+	const values = normalizeAuthValues(params.credentials);
+	const out: Record<string, string> = {};
+
+	await orgContext.run({ organizationId: params.organizationId }, async () => {
+		for (const [key, value] of Object.entries(values)) {
+			// Already a builtin ref (e.g. a rename-only profile update): keep it
+			// rather than re-storing the ref string as if it were a credential.
+			if (isStoredSecretRef(value)) {
+				out[key] = value;
+				continue;
+			}
+			// `store.put` directly, NOT `persistSecretValue` — the latter skips
+			// any value matching `isSecretRef`, which a `postgres://` DSN does.
+			out[key] = await store.put(
+				authCredentialSecretName(params.authProfileId, key, namespace),
+				value,
+			);
+		}
+	});
+
+	return out;
+}
+
+/**
+ * Convert a credential map into one safe to store in `auth_data`: every
+ * value is written to the secret store and replaced by its `secret://` ref.
+ *
+ * The org is threaded EXPLICITLY rather than relying on the ambient
+ * AsyncLocalStorage context. `PostgresSecretStore.put` silently falls back to
+ * a deployment-wide GLOBAL bucket when no context is set, and a tenant
+ * credential landing there would shadow every other org's read of the same
+ * name. Worker-token paths (run completion) have no ambient org, so the
+ * fallback would otherwise be reachable in production.
+ */
+export async function toSecretRefAuthData(
+	params: SecretRefAuthDataParams,
+): Promise<Record<string, string>> {
+	return storeAuthCredentialRefs(params);
+}
+
+/**
+ * Write a credential map onto an auth profile, storing only `secret://` refs.
+ */
+export async function persistAuthCredentials(params: {
+	organizationId: string;
+	authProfileId: number;
+	credentials: Record<string, unknown>;
+	secretStore?: WritableSecretStore;
+	db?: DbClient;
+}): Promise<Record<string, string>> {
+	const refs = await toSecretRefAuthData(params);
+	const sql = params.db ?? getDb();
+	await sql`
+    UPDATE auth_profiles
+    SET auth_data = ${sql.json(refs)},
+        updated_at = NOW()
+    WHERE id = ${params.authProfileId}
+      AND organization_id = ${params.organizationId}
+  `;
+	return refs;
+}
+
+/**
+ * Resolve any `secret://` refs in an `env` profile's `auth_data` back to real
+ * values, for handing to connector execution.
+ *
+ * A value that is not a ref is passed through: `auth_data` also carries
+ * non-secret bookkeeping (`requested_scopes`, `granted_scopes`) that was never
+ * secret-stored.
+ */
+export async function resolveAuthCredentials(params: {
+	organizationId: string;
+	authData: Record<string, unknown> | null | undefined;
+	secretStore?: SecretStore;
+}): Promise<Record<string, string>> {
+	const values = normalizeAuthValues(params.authData ?? {});
+	if (Object.keys(values).length === 0) return {};
+
+	const store = params.secretStore ?? new PostgresSecretStore();
+	const out: Record<string, string> = {};
+
+	await orgContext.run({ organizationId: params.organizationId }, async () => {
+		for (const [key, value] of Object.entries(values)) {
+			if (!isStoredSecretRef(value)) {
+				out[key] = value;
+				continue;
+			}
+			const resolved = await resolveSecretValue(store, value);
+			if (resolved === undefined) {
+				// A dangling ref means the credential is gone. Drop the key rather
+				// than passing the literal `secret://…` string to a connector,
+				// which would surface as a confusing connect failure.
+				logger.warn(
+					{ key, auth_profile_ref: value },
+					"Auth credential ref did not resolve",
+				);
+				continue;
+			}
+			out[key] = resolved;
+		}
+	});
+
+	return out;
+}
+
+/**
+ * One pass converting legacy plaintext `env` credentials into secret refs.
+ *
+ * Called by the scheduled convergence job. Kept in TS because the values must
+ * pass through the encrypting secret store.
+ */
+export async function migrateLegacyPlaintextAuthData(): Promise<number> {
+	const sql = getDb();
+	const rows = (await sql`
+    SELECT id, organization_id, auth_data
+    FROM auth_profiles
+    WHERE profile_kind = 'env'
+      AND auth_data IS NOT NULL
+      AND auth_data <> '{}'::jsonb
+  `) as unknown as Array<{
+		id: number;
+		organization_id: string;
+		auth_data: Record<string, unknown> | null;
+	}>;
+
+	let converted = 0;
+	for (const row of rows) {
+		const values = normalizeAuthValues(row.auth_data ?? {});
+		if (!Object.values(values).some((value) => !isStoredSecretRef(value))) {
+			continue;
+		}
+
+		// Use a staging namespace rather than the live rotation names. If a user
+		// rotates this profile after the scan but before the UPDATE below, a
+		// losing convergence attempt must not overwrite the live secret value.
+		const refs = await storeAuthCredentialRefs(
+			{
+				organizationId: row.organization_id,
+				authProfileId: Number(row.id),
+				credentials: values,
+			},
+			"legacy-convergence",
+		);
+		const updated = await sql`
+      UPDATE auth_profiles
+      SET auth_data = ${sql.json(refs)},
+          updated_at = NOW()
+      WHERE id = ${row.id}
+        AND organization_id = ${row.organization_id}
+        AND auth_data = ${sql.json(row.auth_data)}::jsonb
+      RETURNING id
+		`;
+		if (updated.length > 0) converted += 1;
+	}
+
+	// Staging rows remain referenced after a successful conversion. Remove them
+	// only after the profile has rotated to a live ref (or been deleted); this
+	// also cleans up a staging write whose compare-and-swap lost a race.
+	await sql`
+    DELETE FROM agent_secrets staged
+    WHERE staged.name LIKE 'auth-profile/%/legacy-convergence/%'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM auth_profiles profile
+        WHERE profile.organization_id = staged.organization_id
+          AND profile.id::text = split_part(staged.name, '/', 2)
+          AND profile.auth_data::text LIKE '%legacy-convergence%'
+      )
+  `;
+
+	return converted;
+}

--- a/packages/server/src/utils/auth-credential-secrets.ts
+++ b/packages/server/src/utils/auth-credential-secrets.ts
@@ -17,9 +17,20 @@
  * Only `env`-kind profiles are converted. `browser_session` / `interactive`
  * profiles hold structured session state (cookie jars, Baileys creds), not
  * flat credential strings; they are out of scope here and untouched.
+ *
+ * Caller-supplied credential values are NEVER treated as already-stored
+ * refs: a crafted `secret://…` string is encrypted as opaque input under
+ * this profile's name. Already-stored refs are preserved only on internal
+ * paths (no-authData profile updates, legacy migration of partially
+ * converted rows).
  */
 
-import { parseSecretRef } from "@lobu/core";
+import {
+	createBuiltinSecretRef,
+	createLogger,
+	encrypt,
+	parseSecretRef,
+} from "@lobu/core";
 import { type DbClient, getDb } from "../db/client";
 import { PostgresSecretStore } from "../lobu/stores/postgres-secret-store";
 import { orgContext } from "../lobu/stores/org-context";
@@ -28,7 +39,6 @@ import {
 	type SecretStore,
 	type WritableSecretStore,
 } from "../gateway/secrets/index.js";
-import { createLogger } from "@lobu/core";
 import { normalizeAuthValues } from "./auth-profiles";
 
 const logger = createLogger("auth-credential-secrets");
@@ -67,66 +77,81 @@ type SecretRefAuthDataParams = {
 	organizationId: string;
 	authProfileId: number;
 	credentials: Record<string, unknown>;
+	/** Injected store for tests; production writes use `db` directly. */
 	secretStore?: WritableSecretStore;
+	/**
+	 * Connection that also owns the profile UPDATE. Secret rows are written
+	 * on this handle so they share the caller's transaction (rollback +
+	 * concurrent delete cannot leave decryptable orphans).
+	 */
+	db?: DbClient;
+	/**
+	 * Internal only (legacy migration). When set, already-stored
+	 * `secret://` values are kept rather than re-encrypted as opaque strings.
+	 * Public create/validate/completion paths must leave this false.
+	 */
+	preserveStoredRefs?: boolean;
 };
 
 /**
- * True when `value` is a builtin `secret://` ref that already belongs to
- * THIS auth profile (live name or legacy-convergence staging name).
- *
- * Public create / validate / completion paths must NEVER treat a
- * caller-supplied `secret://…` string as already-stored: an attacker who
- * can guess an org-scoped name would otherwise bind the profile to that
- * secret without ever knowing its plaintext. Only refs under
- * `auth-profile/<this-id>/…` are trusted, and only for no-op updates that
- * re-submit the profile's own stored refs.
+ * Encrypt one credential into `agent_secrets` on the caller's DbClient so the
+ * write participates in the same transaction as the profile row update.
  */
-function isOwnedAuthCredentialRef(
-	value: string,
-	authProfileId: number,
-): boolean {
-	const parsed = parseSecretRef(value);
-	if (parsed?.scheme !== BUILTIN_SECRET_SCHEME) return false;
-	let name: string;
-	try {
-		name = decodeURIComponent(parsed.path);
-	} catch {
-		return false;
-	}
-	const livePrefix = `auth-profile/${authProfileId}/`;
-	if (!name.startsWith(livePrefix)) return false;
-	// Reject path-traversal-ish names (`auth-profile/1/../2/key`).
-	const rest = name.slice(livePrefix.length);
-	return rest.length > 0 && !rest.includes("..") && !rest.includes("//");
+async function putAuthCredentialOnDb(params: {
+	db: DbClient;
+	organizationId: string;
+	name: string;
+	value: string;
+}): Promise<string> {
+	const ciphertext = encrypt(params.value);
+	await params.db`
+    INSERT INTO agent_secrets (organization_id, name, ciphertext, expires_at, created_at, updated_at)
+    VALUES (${params.organizationId}, ${params.name}, ${ciphertext}, NULL, now(), now())
+    ON CONFLICT (organization_id, name) DO UPDATE SET
+      ciphertext = EXCLUDED.ciphertext,
+      expires_at = EXCLUDED.expires_at,
+      updated_at = now()
+  `;
+	return createBuiltinSecretRef(encodeURIComponent(params.name));
 }
 
 async function storeAuthCredentialRefs(
 	params: SecretRefAuthDataParams,
 	namespace?: "legacy-convergence",
 ): Promise<Record<string, string>> {
-	const store = params.secretStore ?? new PostgresSecretStore();
 	const values = normalizeAuthValues(params.credentials);
 	const out: Record<string, string> = {};
+	const sql = params.db ?? getDb();
 
-	await orgContext.run({ organizationId: params.organizationId }, async () => {
-		for (const [key, value] of Object.entries(values)) {
-			// Owned refs (rename-only profile update re-submitting stored
-			// auth_data): keep them rather than re-storing the ref string as
-			// if it were a credential. Foreign or crafted `secret://` values
-			// fall through to `store.put` and are encrypted as opaque strings
-			// under THIS profile's name — they do not bind another secret.
-			if (isOwnedAuthCredentialRef(value, params.authProfileId)) {
-				out[key] = value;
-				continue;
-			}
-			// `store.put` directly, NOT `persistSecretValue` — the latter skips
-			// any value matching `isSecretRef`, which a `postgres://` DSN does.
-			out[key] = await store.put(
-				authCredentialSecretName(params.authProfileId, key, namespace),
-				value,
-			);
+	for (const [key, value] of Object.entries(values)) {
+		// Migration of partially-converted rows may still hold some refs.
+		// Public paths never set preserveStoredRefs — every caller-supplied
+		// value is encrypted under THIS profile's field name.
+		if (params.preserveStoredRefs && isStoredSecretRef(value)) {
+			out[key] = value;
+			continue;
 		}
-	});
+		const name = authCredentialSecretName(
+			params.authProfileId,
+			key,
+			namespace,
+		);
+		if (params.secretStore) {
+			// Test injection path — still force the org context so a bare
+			// store cannot land tenant secrets in the GLOBAL bucket.
+			out[key] = await orgContext.run(
+				{ organizationId: params.organizationId },
+				() => params.secretStore!.put(name, value),
+			);
+		} else {
+			out[key] = await putAuthCredentialOnDb({
+				db: sql,
+				organizationId: params.organizationId,
+				name,
+				value,
+			});
+		}
+	}
 
 	return out;
 }
@@ -135,12 +160,16 @@ async function storeAuthCredentialRefs(
  * Convert a credential map into one safe to store in `auth_data`: every
  * value is written to the secret store and replaced by its `secret://` ref.
  *
- * The org is threaded EXPLICITLY rather than relying on the ambient
- * AsyncLocalStorage context. `PostgresSecretStore.put` silently falls back to
- * a deployment-wide GLOBAL bucket when no context is set, and a tenant
- * credential landing there would shadow every other org's read of the same
- * name. Worker-token paths (run completion) have no ambient org, so the
- * fallback would otherwise be reachable in production.
+ * Caller-supplied strings are always stored, including strings that look
+ * like `secret://…`. That closes the connect-route ref-injection attack:
+ * an attacker cannot bind a profile field to another secret by submitting
+ * its ref. Rename-only updates that must keep existing refs go through
+ * `updateAuthProfile` without `authData`, which never calls this function.
+ *
+ * The org is threaded EXPLICITLY on every write. `PostgresSecretStore.put`
+ * silently falls back to a deployment-wide GLOBAL bucket when no ambient
+ * context is set; worker-token paths have none, so the fallback would
+ * otherwise be reachable in production for the test-store path.
  */
 export async function toSecretRefAuthData(
 	params: SecretRefAuthDataParams,
@@ -150,6 +179,11 @@ export async function toSecretRefAuthData(
 
 /**
  * Write a credential map onto an auth profile, storing only `secret://` refs.
+ *
+ * Secret upserts and the `auth_data` UPDATE run on the same DbClient. When
+ * the caller does not pass one, they share a fresh transaction so a failed
+ * update cannot leave a rotated secret behind, and a rolled-back create
+ * cannot leave decryptable orphans.
  */
 export async function persistAuthCredentials(params: {
 	organizationId: string;
@@ -158,16 +192,42 @@ export async function persistAuthCredentials(params: {
 	secretStore?: WritableSecretStore;
 	db?: DbClient;
 }): Promise<Record<string, string>> {
-	const refs = await toSecretRefAuthData(params);
-	const sql = params.db ?? getDb();
-	await sql`
-    UPDATE auth_profiles
-    SET auth_data = ${sql.json(refs)},
-        updated_at = NOW()
-    WHERE id = ${params.authProfileId}
-      AND organization_id = ${params.organizationId}
-  `;
-	return refs;
+	const write = async (sql: DbClient): Promise<Record<string, string>> => {
+		// Lock the profile row so a concurrent delete cannot race a secret
+		// write and leave credentials without a profile.
+		const locked = await sql`
+      SELECT id
+      FROM auth_profiles
+      WHERE id = ${params.authProfileId}
+        AND organization_id = ${params.organizationId}
+      FOR UPDATE
+    `;
+		if (locked.length === 0) {
+			throw new Error(
+				`auth profile ${params.authProfileId} not found for credential write`,
+			);
+		}
+		const refs = await storeAuthCredentialRefs({
+			organizationId: params.organizationId,
+			authProfileId: params.authProfileId,
+			credentials: params.credentials,
+			secretStore: params.secretStore,
+			db: sql,
+		});
+		await sql`
+      UPDATE auth_profiles
+      SET auth_data = ${sql.json(refs)},
+          updated_at = NOW()
+      WHERE id = ${params.authProfileId}
+        AND organization_id = ${params.organizationId}
+    `;
+		return refs;
+	};
+
+	if (params.db) {
+		return write(params.db);
+	}
+	return getDb().begin((tx) => write(tx));
 }
 
 /**
@@ -240,27 +300,43 @@ export async function migrateLegacyPlaintextAuthData(): Promise<number> {
 			continue;
 		}
 
-		// Use a staging namespace rather than the live rotation names. If a user
-		// rotates this profile after the scan but before the UPDATE below, a
-		// losing convergence attempt must not overwrite the live secret value.
-		const refs = await storeAuthCredentialRefs(
-			{
-				organizationId: row.organization_id,
-				authProfileId: Number(row.id),
-				credentials: values,
-			},
-			"legacy-convergence",
-		);
-		const updated = await sql`
-      UPDATE auth_profiles
-      SET auth_data = ${sql.json(refs)},
-          updated_at = NOW()
-      WHERE id = ${row.id}
-        AND organization_id = ${row.organization_id}
-        AND auth_data = ${sql.json(row.auth_data)}::jsonb
-      RETURNING id
-		`;
-		if (updated.length > 0) converted += 1;
+		// Staging namespace + compare-and-swap on auth_data: a rotation that
+		// lands between scan and write wins, and the losing staging rows are
+		// cleaned up below.
+		const refs = await sql.begin(async (tx) => {
+			const locked = await tx`
+        SELECT id, auth_data
+        FROM auth_profiles
+        WHERE id = ${row.id}
+          AND organization_id = ${row.organization_id}
+          AND auth_data = ${tx.json(row.auth_data)}::jsonb
+        FOR UPDATE
+      `;
+			if (locked.length === 0) return null;
+
+			const nextRefs = await storeAuthCredentialRefs(
+				{
+					organizationId: row.organization_id,
+					authProfileId: Number(row.id),
+					credentials: values,
+					db: tx,
+					// Partially-converted rows may already hold some refs.
+					preserveStoredRefs: true,
+				},
+				"legacy-convergence",
+			);
+			const updated = await tx`
+        UPDATE auth_profiles
+        SET auth_data = ${tx.json(nextRefs)},
+            updated_at = NOW()
+        WHERE id = ${row.id}
+          AND organization_id = ${row.organization_id}
+          AND auth_data = ${tx.json(row.auth_data)}::jsonb
+        RETURNING id
+      `;
+			return updated.length > 0 ? nextRefs : null;
+		});
+		if (refs) converted += 1;
 	}
 
 	// Staging rows remain referenced after a successful conversion. Remove them

--- a/packages/server/src/utils/auth-credential-secrets.ts
+++ b/packages/server/src/utils/auth-credential-secrets.ts
@@ -70,6 +70,36 @@ type SecretRefAuthDataParams = {
 	secretStore?: WritableSecretStore;
 };
 
+/**
+ * True when `value` is a builtin `secret://` ref that already belongs to
+ * THIS auth profile (live name or legacy-convergence staging name).
+ *
+ * Public create / validate / completion paths must NEVER treat a
+ * caller-supplied `secret://…` string as already-stored: an attacker who
+ * can guess an org-scoped name would otherwise bind the profile to that
+ * secret without ever knowing its plaintext. Only refs under
+ * `auth-profile/<this-id>/…` are trusted, and only for no-op updates that
+ * re-submit the profile's own stored refs.
+ */
+function isOwnedAuthCredentialRef(
+	value: string,
+	authProfileId: number,
+): boolean {
+	const parsed = parseSecretRef(value);
+	if (parsed?.scheme !== BUILTIN_SECRET_SCHEME) return false;
+	let name: string;
+	try {
+		name = decodeURIComponent(parsed.path);
+	} catch {
+		return false;
+	}
+	const livePrefix = `auth-profile/${authProfileId}/`;
+	if (!name.startsWith(livePrefix)) return false;
+	// Reject path-traversal-ish names (`auth-profile/1/../2/key`).
+	const rest = name.slice(livePrefix.length);
+	return rest.length > 0 && !rest.includes("..") && !rest.includes("//");
+}
+
 async function storeAuthCredentialRefs(
 	params: SecretRefAuthDataParams,
 	namespace?: "legacy-convergence",
@@ -80,9 +110,12 @@ async function storeAuthCredentialRefs(
 
 	await orgContext.run({ organizationId: params.organizationId }, async () => {
 		for (const [key, value] of Object.entries(values)) {
-			// Already a builtin ref (e.g. a rename-only profile update): keep it
-			// rather than re-storing the ref string as if it were a credential.
-			if (isStoredSecretRef(value)) {
+			// Owned refs (rename-only profile update re-submitting stored
+			// auth_data): keep them rather than re-storing the ref string as
+			// if it were a credential. Foreign or crafted `secret://` values
+			// fall through to `store.put` and are encrypted as opaque strings
+			// under THIS profile's name — they do not bind another secret.
+			if (isOwnedAuthCredentialRef(value, params.authProfileId)) {
 				out[key] = value;
 				continue;
 			}

--- a/packages/server/src/utils/auth-credential-secrets.ts
+++ b/packages/server/src/utils/auth-credential-secrets.ts
@@ -31,7 +31,7 @@ import {
 	encrypt,
 	parseSecretRef,
 } from "@lobu/core";
-import { type DbClient, getDb } from "../db/client";
+import { type DbClient, getDb, pgTextArray } from "../db/client";
 import { PostgresSecretStore } from "../lobu/stores/postgres-secret-store";
 import { orgContext } from "../lobu/stores/org-context";
 import {
@@ -243,12 +243,14 @@ async function storeAuthCredentialRefs(
           AND name LIKE ${`auth-profile/${params.authProfileId}/%`}
       `;
 		} else {
-			// `sql(array)` expands to a parenthesized list for IN/NOT IN.
+			// fetch_types:false can't auto-serialize a JS array, so pass a
+			// `text[]` literal and use `<> ALL(...)` — equivalent to `NOT IN`
+			// for the non-null secret names collected above.
 			await sql`
         DELETE FROM agent_secrets
         WHERE organization_id = ${params.organizationId}
           AND name LIKE ${`auth-profile/${params.authProfileId}/%`}
-          AND name NOT IN ${sql(keepNames)}
+          AND name <> ALL(${pgTextArray(keepNames)}::text[])
       `;
 		}
 	}

--- a/packages/server/src/utils/auth-credential-secrets.ts
+++ b/packages/server/src/utils/auth-credential-secrets.ts
@@ -60,6 +60,37 @@ function isStoredSecretRef(value: string): boolean {
 }
 
 /**
+ * Decode a builtin secret ref to its logical name, or null if not a builtin ref.
+ */
+function secretRefName(value: string): string | null {
+	const parsed = parseSecretRef(value);
+	if (parsed?.scheme !== BUILTIN_SECRET_SCHEME) return null;
+	try {
+		return decodeURIComponent(parsed.path);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * True when `value` is exactly the live or legacy-convergence secret for
+ * `auth-profile/<id>/<key>`. Resolution and migration must not honor any
+ * other `secret://` string — including same-org secrets or GLOBAL names.
+ */
+function isOwnedFieldRef(
+	value: string,
+	authProfileId: number,
+	key: string,
+): boolean {
+	const name = secretRefName(value);
+	if (name === null) return false;
+	return (
+		name === authCredentialSecretName(authProfileId, key) ||
+		name === authCredentialSecretName(authProfileId, key, "legacy-convergence")
+	);
+}
+
+/**
  * Secret name for one credential field. Namespaced per auth profile so two
  * profiles holding a `DATABASE_URL` never collide.
  */
@@ -127,7 +158,10 @@ async function storeAuthCredentialRefs(
 		// Migration of partially-converted rows may still hold some refs.
 		// Public paths never set preserveStoredRefs — every caller-supplied
 		// value is encrypted under THIS profile's field name.
-		if (params.preserveStoredRefs && isStoredSecretRef(value)) {
+		if (
+			params.preserveStoredRefs &&
+			isOwnedFieldRef(value, params.authProfileId, key)
+		) {
 			out[key] = value;
 			continue;
 		}
@@ -150,6 +184,54 @@ async function storeAuthCredentialRefs(
 				name,
 				value,
 			});
+		}
+	}
+
+	// Drop prior credential rows whose fields are no longer present. Replacing
+	// or shrinking auth_data must not leave decryptable bearer secrets behind.
+	// (Namespace staging rows for keys still referenced above are kept.)
+	const keepNames = Object.keys(out).flatMap((key) => {
+		const live = authCredentialSecretName(params.authProfileId, key);
+		const staged = authCredentialSecretName(
+			params.authProfileId,
+			key,
+			"legacy-convergence",
+		);
+		const kept: string[] = [live];
+		const current = out[key];
+		if (current && secretRefName(current) === staged) kept.push(staged);
+		return kept;
+	});
+	if (params.secretStore) {
+		await orgContext.run({ organizationId: params.organizationId }, async () => {
+			const listed = await params.secretStore!.list(
+				`auth-profile/${params.authProfileId}/`,
+			);
+			const keep = new Set(keepNames);
+			await Promise.all(
+				listed
+					.filter((entry) => !keep.has(entry.name))
+					.map((entry) => params.secretStore!.delete(entry.ref)),
+			);
+		});
+	} else {
+		// postgres.js: empty array for NOT IN is awkward — only run when we
+		// have keep names (always at least one when out is non-empty). When
+		// out is empty, delete the entire profile prefix.
+		if (keepNames.length === 0) {
+			await sql`
+        DELETE FROM agent_secrets
+        WHERE organization_id = ${params.organizationId}
+          AND name LIKE ${`auth-profile/${params.authProfileId}/%`}
+      `;
+		} else {
+			// `sql(array)` expands to a parenthesized list for IN/NOT IN.
+			await sql`
+        DELETE FROM agent_secrets
+        WHERE organization_id = ${params.organizationId}
+          AND name LIKE ${`auth-profile/${params.authProfileId}/%`}
+          AND name NOT IN ${sql(keepNames)}
+      `;
 		}
 	}
 
@@ -240,6 +322,8 @@ export async function persistAuthCredentials(params: {
  */
 export async function resolveAuthCredentials(params: {
 	organizationId: string;
+	/** Required so resolution can refuse foreign/predictable secret:// names. */
+	authProfileId: number;
 	authData: Record<string, unknown> | null | undefined;
 	secretStore?: SecretStore;
 }): Promise<Record<string, string>> {
@@ -252,7 +336,18 @@ export async function resolveAuthCredentials(params: {
 	await orgContext.run({ organizationId: params.organizationId }, async () => {
 		for (const [key, value] of Object.entries(values)) {
 			if (!isStoredSecretRef(value)) {
+				// Non-ref bookkeeping or still-plaintext legacy values.
 				out[key] = value;
+				continue;
+			}
+			// Only resolve refs that name THIS profile's field. A crafted
+			// secret://other-name in auth_data must not materialize another
+			// org/GLOBAL secret at execution time.
+			if (!isOwnedFieldRef(value, params.authProfileId, key)) {
+				logger.warn(
+					{ key, auth_profile_id: params.authProfileId, auth_profile_ref: value },
+					"Ignoring unowned auth credential ref",
+				);
 				continue;
 			}
 			const resolved = await resolveSecretValue(store, value);
@@ -296,7 +391,13 @@ export async function migrateLegacyPlaintextAuthData(): Promise<number> {
 	let converted = 0;
 	for (const row of rows) {
 		const values = normalizeAuthValues(row.auth_data ?? {});
-		if (!Object.values(values).some((value) => !isStoredSecretRef(value))) {
+		const profileId = Number(row.id);
+		// Convert plaintext AND unowned secret:// strings. Fully owned rows
+		// (every value is already this profile's field ref) are no-ops.
+		const needsConversion = Object.entries(values).some(
+			([key, value]) => !isOwnedFieldRef(value, profileId, key),
+		);
+		if (!needsConversion) {
 			continue;
 		}
 
@@ -317,10 +418,10 @@ export async function migrateLegacyPlaintextAuthData(): Promise<number> {
 			const nextRefs = await storeAuthCredentialRefs(
 				{
 					organizationId: row.organization_id,
-					authProfileId: Number(row.id),
+					authProfileId: profileId,
 					credentials: values,
 					db: tx,
-					// Partially-converted rows may already hold some refs.
+					// Keep only refs that already name this profile's field.
 					preserveStoredRefs: true,
 				},
 				"legacy-convergence",

--- a/packages/server/src/utils/auth-profiles.ts
+++ b/packages/server/src/utils/auth-profiles.ts
@@ -558,14 +558,28 @@ export async function deleteAuthProfile(
   slug: string
 ): Promise<AuthProfileRow | null> {
   const sql = getDb();
-  const rows = await sql`
-    DELETE FROM auth_profiles
-    WHERE organization_id = ${organizationId}
-      AND slug = ${slug}
-    RETURNING ${sql.unsafe(AUTH_PROFILE_COLUMNS)}
-  `;
-
-  return rows.length > 0 ? (rows[0] as AuthProfileRow) : null;
+  // Profile row + its encrypted credential rows must leave together. Env
+  // profiles write `agent_secrets` under `auth-profile/<id>/…`; leaving those
+  // behind after a delete keeps decryptable bearer credentials (DSNs, API
+  // keys) until manual GC. Both deletes run in one transaction so a partial
+  // failure cannot orphan secrets or leave a profile without credentials.
+  return await sql.begin(async (tx) => {
+    const rows = await tx`
+      DELETE FROM auth_profiles
+      WHERE organization_id = ${organizationId}
+        AND slug = ${slug}
+      RETURNING ${tx.unsafe(AUTH_PROFILE_COLUMNS)}
+    `;
+    if (rows.length === 0) return null;
+    const deleted = rows[0] as AuthProfileRow;
+    // Numeric id → safe as a LIKE prefix; no caller-controlled wildcards.
+    await tx`
+      DELETE FROM agent_secrets
+      WHERE organization_id = ${organizationId}
+        AND name LIKE ${`auth-profile/${deleted.id}/%`}
+    `;
+    return deleted;
+  });
 }
 
 export async function getPrimaryAuthProfileForKind(params: {

--- a/packages/server/src/utils/auth-profiles.ts
+++ b/packages/server/src/utils/auth-profiles.ts
@@ -1,6 +1,6 @@
 import { slugify } from '@lobu/core';
 import { getDb, type DbClient } from '../db/client';
-import { persistAuthCredentials, toSecretRefAuthData } from './auth-credential-secrets';
+import { persistAuthCredentials } from './auth-credential-secrets';
 import { ToolUserError } from './errors';
 import { isUniqueViolation } from './pg-errors';
 
@@ -450,6 +450,10 @@ export async function createAuthProfile(params: {
     // `env` credentials are inserted empty above (the secret name is namespaced
     // by profile id, which only exists after the INSERT), then written as
     // `secret://` refs here — so a raw credential never touches the column.
+    // When the caller passed a transaction (`db !== getDb()`), secrets must
+    // use that same handle so a rollback discards both. Otherwise omit `db`
+    // and let persistAuthCredentials open its own transaction for the
+    // put+update pair (a bare pool connection cannot hold FOR UPDATE).
     if (params.profileKind === 'env') {
       const values = normalizeAuthValues(params.authData ?? {});
       if (Object.keys(values).length > 0) {
@@ -457,7 +461,7 @@ export async function createAuthProfile(params: {
           organizationId: params.organizationId,
           authProfileId: created.id,
           credentials: values,
-          db,
+          ...(db !== getDb() ? { db } : {}),
         });
       }
     }
@@ -517,30 +521,36 @@ export async function updateAuthProfile(params: {
         })
       : existing.slug;
 
-  const normalizedAuthData =
-    params.authData === undefined
-      ? normalizeAuthData(existing.profile_kind, existing.auth_data)
-      : normalizeAuthData(existing.profile_kind, params.authData);
+  // `env` profiles: a no-credential update (rename, status) leaves authData
+  // undefined and keeps existing refs as-is. An explicit authData rewrite
+  // always encrypts caller-supplied values (never trusts secret:// strings).
+  if (
+    existing.profile_kind === 'env' &&
+    params.authData !== undefined
+  ) {
+    await persistAuthCredentials({
+      organizationId: params.organizationId,
+      authProfileId: existing.id,
+      credentials: normalizeAuthData(existing.profile_kind, params.authData),
+    });
+  }
 
-  // `env` profiles hold flat bearer credentials (e.g. a postgres DSN, which
-  // embeds its own password). Those never persist verbatim — swap each value
-  // for a `secret://` ref backed by the encrypted secret store. Values already
-  // in ref form are passed through unchanged, so a no-credential update
-  // (rename, status change) does not re-write the secret.
   const nextAuthData =
     existing.profile_kind === 'env'
-      ? await toSecretRefAuthData({
-          organizationId: params.organizationId,
-          authProfileId: existing.id,
-          credentials: normalizedAuthData,
-        })
-      : normalizedAuthData;
+      ? undefined // already written above (or left unchanged)
+      : params.authData === undefined
+        ? normalizeAuthData(existing.profile_kind, existing.auth_data)
+        : normalizeAuthData(existing.profile_kind, params.authData);
 
   const rows = await sql`
     UPDATE auth_profiles
     SET slug = ${nextSlug},
         display_name = COALESCE(${params.displayName ?? null}, display_name),
-        auth_data = ${sql.json(nextAuthData)},
+        ${
+          nextAuthData !== undefined
+            ? sql`auth_data = ${sql.json(nextAuthData)},`
+            : sql``
+        }
         status = COALESCE(${params.status ?? null}, status),
         account_id = COALESCE(${params.accountId ?? null}, account_id),
         provider = COALESCE(${params.provider ?? null}, provider),

--- a/packages/server/src/utils/auth-profiles.ts
+++ b/packages/server/src/utils/auth-profiles.ts
@@ -457,12 +457,29 @@ export async function createAuthProfile(params: {
     if (params.profileKind === 'env') {
       const values = normalizeAuthValues(params.authData ?? {});
       if (Object.keys(values).length > 0) {
-        created.auth_data = await persistAuthCredentials({
-          organizationId: params.organizationId,
-          authProfileId: created.id,
-          credentials: values,
-          ...(db !== getDb() ? { db } : {}),
-        });
+        try {
+          created.auth_data = await persistAuthCredentials({
+            organizationId: params.organizationId,
+            authProfileId: created.id,
+            credentials: values,
+            ...(db !== getDb() ? { db } : {}),
+          });
+        } catch (err) {
+          // Default (non-transactional) path: the INSERT above already
+          // committed, so a persist failure would strand an `env` profile with
+          // empty auth_data (no compensating rollback). Delete the orphan row
+          // before rethrowing. Transactional callers pass their own `db`; their
+          // tx rolls back the INSERT (and is already aborted), so skip the
+          // compensating delete for them.
+          if (db === getDb()) {
+            await sql`
+              DELETE FROM auth_profiles
+              WHERE id = ${created.id}
+                AND organization_id = ${params.organizationId}
+            `;
+          }
+          throw err;
+        }
       }
     }
 

--- a/packages/server/src/utils/auth-profiles.ts
+++ b/packages/server/src/utils/auth-profiles.ts
@@ -1,5 +1,6 @@
 import { slugify } from '@lobu/core';
 import { getDb, type DbClient } from '../db/client';
+import { persistAuthCredentials, toSecretRefAuthData } from './auth-credential-secrets';
 import { ToolUserError } from './errors';
 import { isUniqueViolation } from './pg-errors';
 
@@ -69,6 +70,10 @@ interface BrowserSessionReadiness extends BrowserSessionSummary {
   resolved_cdp_url: string | null;
 }
 
+// `auth-credential-secrets` imports `normalizeAuthValues` from this module and
+// this module imports the persist helpers back. The cycle is safe (both sides
+// only call across at runtime, never during module init) and keeps the
+// credential-at-rest policy in one file instead of splitting it.
 export function normalizeAuthValues(raw: unknown): Record<string, string> {
   if (typeof raw === 'string') {
     try {
@@ -388,7 +393,11 @@ export async function createAuthProfile(params: {
           ${params.connectorKey ?? null},
           ${params.profileKind},
           ${params.status ?? 'active'},
-          ${sql.json(normalizeAuthData(params.profileKind, params.authData ?? {}))},
+          ${sql.json(
+            params.profileKind === 'env'
+              ? {}
+              : normalizeAuthData(params.profileKind, params.authData ?? {})
+          )},
           ${params.accountId ?? null},
           ${normalizedProvider},
           ${params.createdBy ?? null},
@@ -436,7 +445,24 @@ export async function createAuthProfile(params: {
       );
     }
 
-    return rows[0] as AuthProfileRow;
+    const created = rows[0] as AuthProfileRow;
+
+    // `env` credentials are inserted empty above (the secret name is namespaced
+    // by profile id, which only exists after the INSERT), then written as
+    // `secret://` refs here — so a raw credential never touches the column.
+    if (params.profileKind === 'env') {
+      const values = normalizeAuthValues(params.authData ?? {});
+      if (Object.keys(values).length > 0) {
+        created.auth_data = await persistAuthCredentials({
+          organizationId: params.organizationId,
+          authProfileId: created.id,
+          credentials: values,
+          db,
+        });
+      }
+    }
+
+    return created;
   }
 }
 
@@ -491,10 +517,24 @@ export async function updateAuthProfile(params: {
         })
       : existing.slug;
 
-  const nextAuthData =
+  const normalizedAuthData =
     params.authData === undefined
       ? normalizeAuthData(existing.profile_kind, existing.auth_data)
       : normalizeAuthData(existing.profile_kind, params.authData);
+
+  // `env` profiles hold flat bearer credentials (e.g. a postgres DSN, which
+  // embeds its own password). Those never persist verbatim — swap each value
+  // for a `secret://` ref backed by the encrypted secret store. Values already
+  // in ref form are passed through unchanged, so a no-credential update
+  // (rename, status change) does not re-write the secret.
+  const nextAuthData =
+    existing.profile_kind === 'env'
+      ? await toSecretRefAuthData({
+          organizationId: params.organizationId,
+          authProfileId: existing.id,
+          credentials: normalizedAuthData,
+        })
+      : normalizedAuthData;
 
   const rows = await sql`
     UPDATE auth_profiles

--- a/packages/server/src/utils/execution-context.ts
+++ b/packages/server/src/utils/execution-context.ts
@@ -152,14 +152,20 @@ export async function resolveExecutionAuth(
   // pushdown (lib/connector-pushdown.ts). Non-ref entries (scope bookkeeping)
   // pass through untouched.
   const connectionCredentials = {
-    ...(await resolveAuthCredentials({
-      organizationId: params.organizationId,
-      authData: appAuthProfile?.auth_data ?? {},
-    })),
-    ...(await resolveAuthCredentials({
-      organizationId: params.organizationId,
-      authData: authProfile?.profile_kind === 'env' ? (authProfile.auth_data ?? {}) : {},
-    })),
+    ...(appAuthProfile
+      ? await resolveAuthCredentials({
+          organizationId: params.organizationId,
+          authProfileId: appAuthProfile.id,
+          authData: appAuthProfile.auth_data ?? {},
+        })
+      : {}),
+    ...(authProfile?.profile_kind === 'env'
+      ? await resolveAuthCredentials({
+          organizationId: params.organizationId,
+          authProfileId: authProfile.id,
+          authData: authProfile.auth_data ?? {},
+        })
+      : {}),
   };
   let sessionState =
     authProfile?.profile_kind === 'browser_session' || authProfile?.profile_kind === 'interactive'

--- a/packages/server/src/utils/execution-context.ts
+++ b/packages/server/src/utils/execution-context.ts
@@ -3,6 +3,7 @@ import { resolveCloudCredential } from '../connect/cloud-credential';
 import { getBuiltinProviderConfig } from '../connect/oauth-providers';
 import { type DbClient, getDb } from '../db/client';
 import { getAuthProfileById, normalizeAuthValues } from './auth-profiles';
+import { resolveAuthCredentials } from './auth-credential-secrets';
 import {
   getAppInstallationAuthMethods,
   getOAuthAuthMethods,
@@ -145,11 +146,20 @@ export async function resolveExecutionAuth(
     }
   }
 
+  // `env` credentials live in `auth_data` as `secret://` refs, never as raw
+  // values — resolve them here so this single seam serves BOTH execution
+  // paths: the worker sync poll (worker-api/poll.ts) and the virtual-feed
+  // pushdown (lib/connector-pushdown.ts). Non-ref entries (scope bookkeeping)
+  // pass through untouched.
   const connectionCredentials = {
-    ...normalizeAuthValues(appAuthProfile?.auth_data ?? {}),
-    ...normalizeAuthValues(
-      authProfile?.profile_kind === 'env' ? (authProfile.auth_data ?? {}) : {}
-    ),
+    ...(await resolveAuthCredentials({
+      organizationId: params.organizationId,
+      authData: appAuthProfile?.auth_data ?? {},
+    })),
+    ...(await resolveAuthCredentials({
+      organizationId: params.organizationId,
+      authData: authProfile?.profile_kind === 'env' ? (authProfile.auth_data ?? {}) : {},
+    })),
   };
   let sessionState =
     authProfile?.profile_kind === 'browser_session' || authProfile?.profile_kind === 'interactive'

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -65,9 +65,9 @@ function cols(...names: string[]): ColumnDef[] {
  * WHICH options are set.
  */
 const SQL_SECRET_KEY_PATTERN =
-  '(^|_)(token|secret|password|passwd|api_?key|credential|private_?key|refresh_?token|access_?token|client_?secret|session_?id|auth_?header)s?$';
+  '(^|_)(token|secret|password|passwd|api_?key|secret_?(access_?)?key|credential|private_?key|refresh_?token|access_?token|client_?secret|session_?id|auth_?header)s?$';
 const SQL_SECRET_EXACT_KEYS =
-  "('authorization','auth','bearer','cookie','cookies','set_cookie','proxy_authorization','database_url','db_url','connection_string','dsn')";
+  "('authorization','auth','bearer','cookie','cookies','set_cookie','proxy_authorization','database_url','db_url','connection_string','dsn','dburl','databaseurl','connectionstring')";
 const SQL_URI_CREDENTIAL_PATTERN =
   '[a-z][a-z0-9+.-]*://[^/@[:space:]]*:[^/@[:space:]]*@';
 
@@ -81,9 +81,13 @@ const COLUMN_REF = '$COL$';
 
 /** SQL test for "this jsonb key is a denylisted secret name". */
 const SQL_KEY_IS_SECRET = (keyExpr: string) => {
+  // Mirrors `normalizeKey` in `@lobu/core/utils/secret-redaction`: splits
+  // acronym-to-word boundaries (`AWSSecretKey` -> `AWS_Secret_Key`) and
+  // lower-to-uppercase boundaries (`apiKey` -> `api_Key`).
   const normalized =
-    `lower(regexp_replace(regexp_replace(` +
-    `regexp_replace(${keyExpr}, '([a-z0-9])([A-Z])', '\\1_\\2', 'g'), ` +
+    `lower(regexp_replace(regexp_replace(regexp_replace(` +
+    `regexp_replace(${keyExpr}, '([A-Z]+)([A-Z][a-z])', '\\1_\\2', 'g'), ` +
+    `'([a-z0-9])([A-Z])', '\\1_\\2', 'g'), ` +
     `'[^a-zA-Z0-9]+', '_', 'g'), '^_+|_+$', '', 'g'))`;
   return (
     `${normalized} IN ${SQL_SECRET_EXACT_KEYS} ` +

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -68,8 +68,10 @@ const SQL_SECRET_KEY_PATTERN =
   '(^|_)(token|secret|password|passwd|api_?key|secret_?(access_?)?key|credential|private_?key|refresh_?token|access_?token|client_?secret|session_?id|auth_?header)s?$';
 const SQL_SECRET_EXACT_KEYS =
   "('authorization','auth','bearer','cookie','cookies','set_cookie','proxy_authorization','database_url','db_url','connection_string','dsn','dburl','databaseurl','connectionstring')";
+// Bound the scheme quantifier to match `URI_CREDENTIAL_RE` in
+// `@lobu/core/utils/secret-redaction` — see that file for the ReDoS rationale.
 const SQL_URI_CREDENTIAL_PATTERN =
-  '[a-z][a-z0-9+.-]*://[^/@[:space:]]*:[^/@[:space:]]*@';
+  '[a-z][a-z0-9+.-]{0,63}://[^/@[:space:]]*:[^/@[:space:]]*@';
 
 /**
  * Placeholder for the source column inside an {@link ColumnDef.expr}.
@@ -83,10 +85,11 @@ const COLUMN_REF = '$COL$';
 const SQL_KEY_IS_SECRET = (keyExpr: string) => {
   // Mirrors `normalizeKey` in `@lobu/core/utils/secret-redaction`: splits
   // acronym-to-word boundaries (`AWSSecretKey` -> `AWS_Secret_Key`) and
-  // lower-to-uppercase boundaries (`apiKey` -> `api_Key`).
+  // lower-to-uppercase boundaries (`apiKey` -> `api_Key`). Bound acronym
+  // runs to match TS ReDoS-safe quantifiers.
   const normalized =
     `lower(regexp_replace(regexp_replace(regexp_replace(` +
-    `regexp_replace(${keyExpr}, '([A-Z]+)([A-Z][a-z])', '\\1_\\2', 'g'), ` +
+    `regexp_replace(${keyExpr}, '([A-Z]{1,32})([A-Z][a-z])', '\\1_\\2', 'g'), ` +
     `'([a-z0-9])([A-Z])', '\\1_\\2', 'g'), ` +
     `'[^a-zA-Z0-9]+', '_', 'g'), '^_+|_+$', '', 'g'))`;
   return (

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -30,6 +30,7 @@ import {
 import { resolveConnectorCode } from '../utils/ensure-connector-installed';
 import { resolveDeviceClaimableOrgs } from '../utils/device-claimable-orgs';
 import { errorMessage } from '../utils/errors';
+import { resolveAuthCredentials } from '../utils/auth-credential-secrets';
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';
 import { stripServerOnlyExecutionConfig } from '../tools/admin/behavior-execution-config';
 import logger from '../utils/logger';
@@ -899,6 +900,16 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         sessionState: null,
       };
 
+  // `auth_data` holds `secret://` refs, not values. An `authenticate` run
+  // consumes these as REAL credentials (e.g. to refresh an expiring token),
+  // so resolve them rather than shipping the refs verbatim.
+  const previousCredentials = deliverConnectionAuth
+    ? await resolveAuthCredentials({
+        organizationId: row.organization_id,
+        authData: row.auth_profile_auth_data,
+      })
+    : undefined;
+
   // Native (nixpkgs) packages the connector declared in `runtime.nix.packages`.
   // The worker provisions these on PATH via nix-shell before executing.
   const nixPackages = (row.connector_runtime?.nix?.packages ?? []).filter(
@@ -939,8 +950,6 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     operation_key: row.action_key ?? undefined,
     action_input: (row as any).approved_input ?? row.action_input ?? undefined,
     auth_profile_id: deliverConnectionAuth ? (row.run_auth_profile_id ?? undefined) : undefined,
-    previous_credentials: deliverConnectionAuth
-      ? (row.auth_profile_auth_data ?? undefined)
-      : undefined,
+    previous_credentials: previousCredentials,
   });
 }

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -903,13 +903,23 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // `auth_data` holds `secret://` refs, not values. An `authenticate` run
   // consumes these as REAL credentials (e.g. to refresh an expiring token),
   // so resolve them rather than shipping the refs verbatim.
-  const previousCredentials =
+  // resolveAuthCredentials returns `{}` (not undefined) when there are no
+  // refs to resolve, e.g. a null auth_profile_auth_data. Collapse the empty
+  // object to undefined so `previous_credentials` is omitted rather than
+  // serialized as `{}` — matching the connection_credentials idiom below and
+  // keeping the payload contract unchanged for workers that test presence.
+  const resolvedPreviousCredentials =
     deliverConnectionAuth && row.run_auth_profile_id != null
       ? await resolveAuthCredentials({
           organizationId: row.organization_id,
           authProfileId: Number(row.run_auth_profile_id),
           authData: row.auth_profile_auth_data,
         })
+      : undefined;
+  const previousCredentials =
+    resolvedPreviousCredentials &&
+    Object.keys(resolvedPreviousCredentials).length > 0
+      ? resolvedPreviousCredentials
       : undefined;
 
   // Native (nixpkgs) packages the connector declared in `runtime.nix.packages`.

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -903,12 +903,14 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // `auth_data` holds `secret://` refs, not values. An `authenticate` run
   // consumes these as REAL credentials (e.g. to refresh an expiring token),
   // so resolve them rather than shipping the refs verbatim.
-  const previousCredentials = deliverConnectionAuth
-    ? await resolveAuthCredentials({
-        organizationId: row.organization_id,
-        authData: row.auth_profile_auth_data,
-      })
-    : undefined;
+  const previousCredentials =
+    deliverConnectionAuth && row.run_auth_profile_id != null
+      ? await resolveAuthCredentials({
+          organizationId: row.organization_id,
+          authProfileId: Number(row.run_auth_profile_id),
+          authData: row.auth_profile_auth_data,
+        })
+      : undefined;
 
   // Native (nixpkgs) packages the connector declared in `runtime.nix.packages`.
   // The worker provisions these on PATH via nix-shell before executing.

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -110,36 +110,41 @@ async function reactivateProfileCascade(
 	}
 ): Promise<void> {
 	// Credentials returned by an auth run are bearer values; store refs, not
-	// the values themselves.
-	const credentialRefs = await toSecretRefAuthData({
-		organizationId,
-		authProfileId,
-		credentials: authData.credentials,
+	// the values themselves. Secret upsert + profile activation share one
+	// transaction so a partial failure cannot leave a rotated secret without
+	// the matching auth_data row (or vice versa).
+	await sql.begin(async (tx) => {
+		const credentialRefs = await toSecretRefAuthData({
+			organizationId,
+			authProfileId,
+			credentials: authData.credentials,
+			db: tx,
+		});
+		await tx`
+      UPDATE auth_profiles
+      SET auth_data = ${tx.json(credentialRefs)},
+          metadata = ${tx.json(authData.metadata)},
+          status = 'active',
+          updated_at = current_timestamp
+      WHERE id = ${authProfileId}
+    `;
+		await tx`
+      UPDATE connections
+      SET status = 'active', updated_at = current_timestamp
+      WHERE auth_profile_id = ${authProfileId}
+        AND status = 'pending_auth'
+    `;
+		await tx`
+      UPDATE feeds f
+      SET status = 'active',
+          next_run_at = COALESCE(f.next_run_at, NOW()),
+          updated_at = current_timestamp
+      FROM connections c
+      WHERE f.connection_id = c.id
+        AND c.auth_profile_id = ${authProfileId}
+        AND f.status = 'paused'
+    `;
 	});
-	await sql`
-    UPDATE auth_profiles
-    SET auth_data = ${sql.json(credentialRefs)},
-        metadata = ${sql.json(authData.metadata)},
-        status = 'active',
-        updated_at = current_timestamp
-    WHERE id = ${authProfileId}
-  `;
-	await sql`
-    UPDATE connections
-    SET status = 'active', updated_at = current_timestamp
-    WHERE auth_profile_id = ${authProfileId}
-      AND status = 'pending_auth'
-  `;
-	await sql`
-    UPDATE feeds f
-    SET status = 'active',
-        next_run_at = COALESCE(f.next_run_at, NOW()),
-        updated_at = current_timestamp
-    FROM connections c
-    WHERE f.connection_id = c.id
-      AND c.auth_profile_id = ${authProfileId}
-      AND f.status = 'paused'
-  `;
 }
 
 /**

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -39,6 +39,7 @@ import {
 	getAuthProfileById,
 	getBrowserSessionReadiness,
 } from "../utils/auth-profiles";
+import { toSecretRefAuthData } from "../utils/auth-credential-secrets";
 import { autoLinkEvent } from "../utils/auto-linker";
 import { nextRunAt as nextRunAtFromCron } from "../utils/cron";
 import { needsEmbeddingSql } from "../utils/embeddings";
@@ -102,14 +103,22 @@ async function finalizeRun(
 async function reactivateProfileCascade(
 	sql: DbClient,
 	authProfileId: number,
+	organizationId: string,
 	authData: {
 		credentials: Record<string, unknown>;
 		metadata: Record<string, unknown>;
 	}
 ): Promise<void> {
+	// Credentials returned by an auth run are bearer values; store refs, not
+	// the values themselves.
+	const credentialRefs = await toSecretRefAuthData({
+		organizationId,
+		authProfileId,
+		credentials: authData.credentials,
+	});
 	await sql`
     UPDATE auth_profiles
-    SET auth_data = ${sql.json(authData.credentials)},
+    SET auth_data = ${sql.json(credentialRefs)},
         metadata = ${sql.json(authData.metadata)},
         status = 'active',
         updated_at = current_timestamp
@@ -1332,8 +1341,13 @@ export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
 		const authProfileId = runRows[0]?.auth_profile_id ?? null;
 		const organizationId = runRows[0]?.organization_id;
 
-		if (req.status === "success" && authProfileId && req.credentials) {
-			await reactivateProfileCascade(sql, authProfileId, {
+		if (
+			req.status === "success" &&
+			authProfileId &&
+			req.credentials &&
+			organizationId
+		) {
+			await reactivateProfileCascade(sql, authProfileId, organizationId, {
 				credentials: req.credentials,
 				metadata: req.metadata ?? {},
 			});

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -36,6 +36,7 @@ import type { Env } from "../index";
 import { notifyBrowserAuthExpired } from "../notifications/triggers";
 import { supersedeActionEvent } from "../tools/admin/manage_operations";
 import {
+	type AuthProfileKind,
 	getAuthProfileById,
 	getBrowserSessionReadiness,
 } from "../utils/auth-profiles";
@@ -104,25 +105,37 @@ async function reactivateProfileCascade(
 	sql: DbClient,
 	authProfileId: number,
 	organizationId: string,
+	profileKind: AuthProfileKind | null,
 	authData: {
 		credentials: Record<string, unknown>;
 		metadata: Record<string, unknown>;
 	}
 ): Promise<void> {
-	// Credentials returned by an auth run are bearer values; store refs, not
-	// the values themselves. Secret upsert + profile activation share one
-	// transaction so a partial failure cannot leave a rotated secret without
-	// the matching auth_data row (or vice versa).
+	// Only flat bearer-credential kinds (env, oauth_account, …) get their
+	// auth_data stored as `secret://` refs. `browser_session` / `interactive`
+	// profiles hold structured session state (cookie jars, Baileys creds) that
+	// execution passes through verbatim as `sessionState` and never resolves as
+	// refs — secret-ref'ing them would both strip their non-string values
+	// (normalizeAuthValues keeps only strings) and leave unresolvable refs on
+	// the worker. So those kinds pass their session state through unchanged.
+	//
+	// Secret upsert + profile activation still share one transaction so a
+	// partial failure cannot leave a rotated secret without the matching
+	// auth_data row (or vice versa).
+	const isSessionStateProfile =
+		profileKind === "browser_session" || profileKind === "interactive";
 	await sql.begin(async (tx) => {
-		const credentialRefs = await toSecretRefAuthData({
-			organizationId,
-			authProfileId,
-			credentials: authData.credentials,
-			db: tx,
-		});
+		const nextAuthData = isSessionStateProfile
+			? authData.credentials
+			: await toSecretRefAuthData({
+					organizationId,
+					authProfileId,
+					credentials: authData.credentials,
+					db: tx,
+				});
 		await tx`
       UPDATE auth_profiles
-      SET auth_data = ${tx.json(credentialRefs)},
+      SET auth_data = ${tx.json(nextAuthData)},
           metadata = ${tx.json(authData.metadata)},
           status = 'active',
           updated_at = current_timestamp
@@ -1352,10 +1365,23 @@ export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
 			req.credentials &&
 			organizationId
 		) {
-			await reactivateProfileCascade(sql, authProfileId, organizationId, {
-				credentials: req.credentials,
-				metadata: req.metadata ?? {},
-			});
+			// The profile kind decides whether the returned credentials are
+			// secret-ref'd (bearer kinds) or written through as session state
+			// (browser_session / interactive) — see reactivateProfileCascade.
+			const authProfile = await getAuthProfileById(
+				organizationId,
+				authProfileId
+			);
+			await reactivateProfileCascade(
+				sql,
+				authProfileId,
+				organizationId,
+				authProfile?.profile_kind ?? null,
+				{
+					credentials: req.credentials,
+					metadata: req.metadata ?? {},
+				}
+			);
 
 			if (organizationId) {
 				emit(organizationId, { keys: ["connections", "auth-profiles"] });


### PR DESCRIPTION
## What

A postgres DSN embeds its own password, so `auth_profiles.auth_data` held a **plaintext bearer credential** in the row that BOTH execution paths read. Credentials now persist as encrypted `secret://` refs and resolve at connect time.

This is the write-side companion to #2195 (which fixed the read side). #2195 stopped config secrets leaking out of read paths; this stops the credential being stored in plaintext in the first place.

## Changes

- **`auth-credential-secrets.ts`** (new) — store/resolve helpers. Uses a scheme-accurate `isStoredSecretRef` rather than the shared `isSecretRef`, which matches ANY `scheme://` and would treat a `postgres://` DSN as an already-stored ref, **silently skipping encryption**.
- **Org threaded explicitly** — `PostgresSecretStore.put` falls back to a deployment-wide GLOBAL bucket when no ambient org context is set, and worker-token paths have none. A tenant credential landing there would shadow every other org's read of the same name.
- **Both execution paths** (worker sync, virtual-feed pushdown) resolve through the same `resolveExecutionAuth` seam, each with its own test — the path most likely to be missed.
- **Transaction correctness** — `createAuthProfile` accepts a caller transaction, but credential persistence resolved its own pool handle, so credentials survived a rollback that discarded the profile.
- **Legacy convergence race** — the scheduled job scanned rows then wrote refs under the LIVE secret names; a rotation landing between scan and write was silently overwritten with the stale value. Conversion now stages under a separate namespace and lands via compare-and-swap on the scanned `auth_data`, so a losing attempt is a no-op. Orphaned staging rows are collected afterwards.
- **`secret_?(access_?)?key`** closes `AWSSecretKey` / `AWS_SECRET_ACCESS_KEY` without loosening the bare-`key` exclusion that keeps `feed_key` / `sort_key` / `idempotency_key` out. This makes the acronym-boundary split load-bearing, so it is applied on both the TS and SQL sides (a parity test pins them together).

## Testing

**127 tests green**; server + core typecheck clean; `make pre-pr` clean.

Every guard verified by **neutering the fix** and confirming the specific test goes red — not just that it passes:

| Neutered | Result |
|---|---|
| `toSecretRefAuthData` | all 8 storage tests red |
| compare-and-swap in convergence | exactly the rotation-race test red |
| acronym split (with new pattern) | `AWSSecretKey`, `AWSSecretAccessKey` leak |
| the 3 exact-key entries | `DBUrl`, `DBURL`, `DATABASEURL` leak |

Assertions read the **raw DB row**, not the API response — the API is redacted either way and would mask a plaintext column underneath. That exact trap produced a false-negative test earlier in this work.

## Blast radius

Measured, not assumed: exactly **1** plaintext credential org-wide (connection 451 / auth profile 96). The convergence job is idempotent and a no-op after the first pass.

## Follow-up

Rotating connection 451 is sequenced **after** this lands, so the new password stores as an encrypted ref rather than plaintext through the same path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Environment-based auth credentials are now stored as encrypted `secret://` references (no plaintext at rest) and resolved only for the owning scope.
  * Added secret-ref persistence to auth profile activation/reactivation and connect token validation, all within transactions.
  * Expanded secret-key and URI redaction coverage for more key/URI variants and hardened matching.

* **New Features**
  * Added scheduled job to periodically migrate legacy plaintext credentials into encrypted secret references.

* **Bug Fixes**
  * Credential resolution is now consistently used across execution and worker flows.

* **Tests**
  * Expanded integration coverage to verify secret-at-rest behavior, rotation, concurrency/migration edge cases, and redaction robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->