### PR TITLE
docs(client): surface the data layer as a first-class composability path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ Under the hood, workers run Lobu's Pi-based agent loop (bash, files, MCP tools, 
 
 https://github.com/user-attachments/assets/d72a9286-0325-4b8b-afc0-c1efe9c96f4e
 
-## Two ways in
+## Three ways in
+
+Lobu is not a harness you have to build on. It is the data layer your agents
+work against — a durable event log and a typed ontology over your org's tools.
+Bring your own agent and reach it over MCP, the CLI, or the TypeScript SDK; or
+run Lobu's own agents on top. The same org-scoped graph backs all of them.
 
 ### 1. Full agent — Slack, Telegram, behaviors, connectors
 
@@ -23,17 +28,57 @@ npx @lobu/cli@latest chat -c local "hello"    # talk to it
 
 Next steps: [Getting started](https://lobu.ai/getting-started/) (project layout, develop with your coding agent, evals) · [Memory](https://lobu.ai/getting-started/memory/) · [Skills](https://lobu.ai/getting-started/skills/) · [Channels](#channels)
 
-### 2. Memory for Claude Code (and Claude Desktop)
+### 2. Bring your own agent — memory over MCP
 
-Give Claude durable, structured memory via MCP — the same graph your Lobu agents use. Full setup: [Connect from Claude](https://lobu.ai/connect-from/claude/).
+Point any MCP client at Lobu and it gets durable, structured memory — the same
+graph your Lobu agents read. No `lobu.config.ts` or local Lobu agent runtime is
+required.
 
 ```bash
 claude mcp add --transport http lobu https://lobu.ai/mcp   # or http://localhost:8787/mcp locally
 ```
 
-Complete the OAuth flow when prompted, then enable the connector. Pair it with a project instruction or skill that tells Claude when to search memory and when to save what it learned.
+Complete the OAuth flow when prompted, then enable the connector. Pair it with a project instruction or skill that tells the agent when to search memory and when to save what it learned.
 
-Works the same for [ChatGPT](https://lobu.ai/connect-from/chatgpt/) and other MCP clients — one memory backend across clients.
+`lobu memory init` can detect and configure **Claude Code**, **Codex**,
+**Gemini CLI**, and **Cursor**, and provides manual setup instructions for
+**Claude Desktop** and **ChatGPT**. It accepts a Lobu Cloud, local, or custom
+MCP endpoint. Setup guides:
+[Claude](https://lobu.ai/connect-from/claude/) ·
+[ChatGPT](https://lobu.ai/connect-from/chatgpt/).
+
+### 3. Your own code — CLI and TypeScript SDK
+
+The data layer is reachable without an agent at all. From the terminal:
+
+```bash
+npx @lobu/cli@latest memory run                     # list the memory tools
+npx @lobu/cli@latest memory run search_memory '{"query":"onboarding"}'
+npx @lobu/cli@latest memory exec \
+  'export default async (_ctx, client) => client.entities.list({ limit: 5 })'
+```
+
+Or from any Node/TypeScript program, with no sandbox in the loop:
+
+```ts
+import { client, searchMemory } from "@lobu/client";
+
+// Defaults to http://localhost:8787 — point it at your instance and add a token.
+client.setConfig({
+  baseUrl: "https://lobu.ai",
+  headers: { Authorization: `Bearer ${process.env.LOBU_TOKEN}` },
+});
+
+const hits = await searchMemory({
+  path: { orgSlug: "my-org" },
+  body: { query: "onboarding" },
+});
+```
+
+Mint a token with `lobu token create`.
+
+The MCP and typed SDK operations share the server-side tool registry, while the
+CLI dispatches those same MCP operations by name.
 
 ## Architecture
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,35 @@
 export * as generated from "./generated/index.js";
+
+/**
+ * Shared fetch client backing the operations below. Defaults to
+ * `http://localhost:8787` — call `client.setConfig({ baseUrl, headers })` once
+ * at startup to point at your instance and attach a token.
+ */
+export { client } from "./generated/client.gen.js";
+
+/**
+ * Curated data-layer operations at the package root. Their implementations and
+ * types are generated from the server tool registry; camelCase names correspond
+ * to MCP names such as `search_memory` and `save_memory`.
+ *
+ * The full generated surface (agents, auth, webhooks, …) stays under
+ * `generated.*`.
+ */
+export {
+  getBehavior,
+  manageBehaviors,
+  manageConversations,
+  manageEntity,
+  manageEntitySchema,
+  manageFeeds,
+  querySdk,
+  querySql,
+  readKnowledge,
+  runSdk,
+  saveMemory,
+  searchMemory,
+  searchSdk,
+} from "./generated/index.js";
 export { Lobu } from "./client.js";
 export { LobuAgentError, LobuApiError } from "./errors.js";
 export { AgentSession } from "./session.js";


### PR DESCRIPTION
## What

Lobu already works without building an agent on it — any MCP client, the CLI, and the typed SDK all reach the same org-scoped graph. Neither the README nor the `@lobu/client` package root said so, which made the product read as harness-first.

**`packages/client/src/index.ts`** — re-export the 13 data-layer operations (`searchMemory`, `saveMemory`, `readKnowledge`, `manageEntity`, `manageEntitySchema`, `manageConversations`, `manageFeeds`, `manageBehaviors`, `getBehavior`, `querySdk`, `querySql`, `runSdk`, `searchSdk`) plus the shared fetch `client` at the package root. Reading your org's memory from a plain Node program is now one import instead of reaching into `generated.*`. Purely additive — the full generated surface stays under `generated.*`, and `Lobu`/`AgentSession` are untouched.

**`README.md`** — "Two ways in" → three. Section 2 reframed from Claude-specific to bring-your-own-agent (naming the clients `lobu memory init` handles). New section 3 documents the CLI memory commands and SDK usage as a first-class path.

## Why

Positioning gap, not a bug. The composability was real but undiscoverable: the data operations were buried under `generated.*`, and the README framed both entry points as "run Lobu."

## Verification

No API changes — the tool registry is untouched, so the OpenAPI spec and MCP tool list are byte-identical.

Runtime-verified against the built `dist` (not just a typecheck):

```
ops: all 13 ok
client exported: true | setConfig: function
setConfig applied: https://example.invalid
generated ns: object | Lobu: function
```

Every documented command form checked against source before writing:
- `memory run` bare / with tool + JSON args → `packages/cli/src/commands/memory/run.ts`
- `memory exec '<script>'` → executed against prod, returns entities
- The `searchMemory({ path, body })` shape → `SearchMemoryData` in `types.gen.ts`

`make pre-pr` clean (all 5 gates). `make review-fix` applied and its changes verified — it corrected three real inaccuracies in the first draft (an overstated `memory init` capability claim, a placeholder script path, and an overclaim about surface drift).

## Notes

Two errors caught during verification and fixed before commit: `import { client }` initially resolved from the wrong module (`client` is in `client.gen.ts`, not the generated index), and the first SDK snippet would have silently pointed at `localhost:8787` with no auth.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->