### PR TITLE
fix(server): escape notification bodies per surface, not with Slack entities

### DIFF
--- a/packages/server/src/__tests__/unit/approval-notification-render.test.ts
+++ b/packages/server/src/__tests__/unit/approval-notification-render.test.ts
@@ -238,6 +238,25 @@ describe("approval notification rendering", () => {
 		expect(body).toContain(String.raw`- Entity ids: \[ 886 \]`);
 	});
 
+	test("setext underlines of any length are escaped", () => {
+		// A single "=" under a line turns it into an <h1>; the escape must not be
+		// limited to the 3+ runs that form a `---` thematic break.
+		for (const underline of ["=", "==", "--", "---"]) {
+			const body = formatActionApprovalBody({
+				details: {
+					kind: "entity_change",
+					operation: "delete",
+					actorLabel: "A watcher",
+					entityId: 1,
+					entityType: "topic",
+					entityName: "X",
+					reason: underline,
+				},
+			});
+			expect(body.split("\n").pop()).toBe(`\\${underline}`);
+		}
+	});
+
 	test("renderer-owned diff delimiters are not escaped away", () => {
 		// `~old~` is OUR strikethrough, not user text. Escaping the assembled
 		// diff line turned it into a literal `\~old\~`.

--- a/packages/server/src/__tests__/unit/approval-notification-render.test.ts
+++ b/packages/server/src/__tests__/unit/approval-notification-render.test.ts
@@ -7,10 +7,10 @@ import {
 } from "../../notifications/triggers";
 
 /**
- * Golden-pins the approval card/body rendering for all four shapes
- * (field change, entity create, entity delete, entity merge) plus the generic fallback —
- * captured from the pre-unification renderer, so the shared model+emitters
- * must stay byte-identical to the three historical blocks.
+ * Golden-pins approval card/body rendering for all four structured shapes
+ * (field change, entity create, entity delete, entity merge) plus the generic
+ * fallback. The in-app and Slack expectations differ where their markup
+ * syntaxes require different escaping.
  */
 
 function cardText(card: ReturnType<typeof buildActionApprovalCard>): string {
@@ -37,9 +37,9 @@ describe("approval notification rendering", () => {
 			"Review topic fields: Severity, Name",
 		);
 		expect(formatActionApprovalBody({ approvalUrl, details })).toBe(
-			"**Watcher &lt;One&gt;** wants to update [App &amp; Crashes](https://app.lobu.ai/acme/topic/app-crashes):\n" +
+			"**Watcher <One>** wants to update [App & Crashes](https://app.lobu.ai/acme/topic/app-crashes):\n" +
 				"- Severity: ~high~\n→ critical\n" +
-				"- Name: ~Old Name~\n→ New &lt;Name&gt;\n" +
+				"- Name: ~Old Name~\n→ New <Name>\n" +
 				"\nField is protected: severity (currently set by you).\n" +
 				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/42)",
 		);
@@ -86,9 +86,9 @@ describe("approval notification rendering", () => {
 			"Review creating topic",
 		);
 		expect(formatActionApprovalBody({ approvalUrl, details })).toBe(
-			"**A watcher** wants to create Slow &amp; Loading.\n" +
-				"- Entity type: topic\n- Name: Slow &amp; Loading\n- Parent id: 3\n" +
-				'\nA watcher proposes creating topic "Slow &amp; Loading".\n' +
+			"**A watcher** wants to create Slow & Loading.\n" +
+				"- Entity type: topic\n- Name: Slow & Loading\n- Parent id: 3\n" +
+				'\nA watcher proposes creating topic "Slow & Loading".\n' +
 				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/44)",
 		);
 		expect(cardText(buildActionApprovalCard({ runId: 44, approvalUrl, details }))).toBe(
@@ -127,8 +127,8 @@ describe("approval notification rendering", () => {
 				details,
 			}),
 		).toBe(
-			"**An agent** wants to delete [Old &lt;Topic&gt;](https://app.lobu.ai/acme/topic/old-topic).\n" +
-				"- Entity id: 11\n- Entity type: topic\n- Name: Old &lt;Topic&gt;\n- Force delete tree: false\n" +
+			"**An agent** wants to delete [Old <Topic>](https://app.lobu.ai/acme/topic/old-topic).\n" +
+				"- Entity id: 11\n- Entity type: topic\n- Name: Old <Topic>\n- Force delete tree: false\n" +
 				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/45)",
 		);
 		expect(cardText(buildActionApprovalCard({ runId: 45, details }))).toBe(
@@ -165,6 +165,68 @@ describe("approval notification rendering", () => {
 		expect(cardText(buildActionApprovalCard({ details }))).toContain(
 			"*Proposed action:* Merge these entities",
 		);
+	});
+
+	test("escaping is per-surface: Markdown neutralises link/emphasis, Slack neutralises mrkdwn", () => {
+		// One hostile name, two surfaces. The Markdown body must not let it forge a
+		// link or bold run; the Slack card must not let it ping the channel or
+		// spoof `<url|label>`. Neither surface may leak the OTHER's escaping.
+		const details: ActionApprovalDetails = {
+			kind: "entity_change",
+			operation: "delete",
+			actorLabel: "[Review [nested]](https://evil)",
+			entityId: 5,
+			entityType: "topic",
+			entityName: "*Urgent* <!channel> & [click](https://evil)",
+			proposal: { name: "*Urgent* <!channel> & [click](https://evil)" },
+			reason: "# [Review [nested]](https://evil)",
+		};
+
+		const body = formatActionApprovalBody({ details });
+		// Markdown: brackets/emphasis defanged, ampersand left as a literal `&`.
+		expect(body).toContain(
+			"**[Review [nested]\\](https://evil)** wants to delete " +
+				"\\*Urgent\\* <!channel> & [click\\](https://evil) (#5).",
+		);
+		expect(body).not.toContain("&amp;");
+		expect(body).toContain(
+			"\n\n\\# [Review [nested]\\](https://evil)",
+		);
+
+		const card = cardText(buildActionApprovalCard({ details }));
+		// Slack: angle brackets/ampersand entity-escaped so `<!channel>` is inert.
+		expect(card).toContain(
+			"*Requested by:* [Review [nested]](https://evil)",
+		);
+		expect(card).toContain(
+			"*Entity:* *Urgent* &lt;!channel&gt; &amp; [click](https://evil)",
+		);
+		// The Markdown backslashes must not bleed into the Slack surface.
+		expect(card).not.toContain("\\*");
+		expect(card).not.toContain("\\[");
+	});
+
+	test("bracketed values stay literal; only link-forming brackets are escaped", () => {
+		// A JSON array value ("[ 886 ]") is inert Markdown and must render as
+		// typed — escaping every bracket leaked visible backslashes into the card.
+		const details: ActionApprovalDetails = {
+			kind: "entity_change",
+			operation: "merge",
+			actorLabel: "An agent",
+			entityId: 886,
+			entityType: "person",
+			entityName: "905319918039@s.whatsapp.net",
+			entityUrl: "https://app.lobu.ai/buremba/person/member-0faa51dac0",
+			proposal: {
+				entity_ids: [886],
+				// Only this one forms a link and must be defanged.
+				note: "see [Review in Lobu](https://evil)",
+			},
+			reason: null,
+		};
+		const body = formatActionApprovalBody({ details });
+		expect(body).toContain("- Entity ids: [ 886 ]");
+		expect(body).toContain("- Note: see [Review in Lobu\\](https://evil)");
 	});
 
 	test("generic action: no card, connection fallback body", () => {

--- a/packages/server/src/__tests__/unit/approval-notification-render.test.ts
+++ b/packages/server/src/__tests__/unit/approval-notification-render.test.ts
@@ -238,6 +238,31 @@ describe("approval notification rendering", () => {
 		expect(body).toContain(String.raw`- Entity ids: \[ 886 \]`);
 	});
 
+	test("multiline names collapse so the summary stays one sentence", () => {
+		// A blank line inside a name would split the summary across Markdown
+		// paragraphs, and the card preview (first block only) would then show a
+		// misleading half-sentence: "wants to delete Bad".
+		const body = formatActionApprovalBody({
+			details: {
+				kind: "entity_change",
+				operation: "delete",
+				actorLabel: "An\nagent",
+				entityId: 5,
+				entityType: "topic",
+				entityName: "Bad\n\nName",
+				reason: null,
+			},
+		});
+		expect(body).toBe("**An agent** wants to delete Bad Name (#5).");
+
+		expect(
+			formatActionApprovalBody({
+				connectionName: "Git\nHub",
+				approvalUrl: "/acme/runs/1",
+			}),
+		).toContain("A queued action on Git Hub is waiting");
+	});
+
 	test("generic approval escapes the connection name", () => {
 		// The non-structured branch interpolates connectionName straight into the
 		// Markdown body; unescaped it could forge an external "Review" anchor.

--- a/packages/server/src/__tests__/unit/approval-notification-render.test.ts
+++ b/packages/server/src/__tests__/unit/approval-notification-render.test.ts
@@ -37,9 +37,10 @@ describe("approval notification rendering", () => {
 			"Review topic fields: Severity, Name",
 		);
 		expect(formatActionApprovalBody({ approvalUrl, details })).toBe(
-			"**Watcher <One>** wants to update [App & Crashes](https://app.lobu.ai/acme/topic/app-crashes):\n" +
+			String.raw`**Watcher \<One\>** wants to update [App & Crashes](https://app.lobu.ai/acme/topic/app-crashes):` +
+				"\n" +
 				"- Severity: ~high~\n→ critical\n" +
-				"- Name: ~Old Name~\n→ New <Name>\n" +
+				"- Name: ~Old Name~\n\u2192 New " + String.raw`\<Name\>` + "\n" +
 				"\nField is protected: severity (currently set by you).\n" +
 				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/42)",
 		);
@@ -127,8 +128,8 @@ describe("approval notification rendering", () => {
 				details,
 			}),
 		).toBe(
-			"**An agent** wants to delete [Old <Topic>](https://app.lobu.ai/acme/topic/old-topic).\n" +
-				"- Entity id: 11\n- Entity type: topic\n- Name: Old <Topic>\n- Force delete tree: false\n" +
+			String.raw`**An agent** wants to delete [Old \<Topic\>](https://app.lobu.ai/acme/topic/old-topic).` + "\n" +
+				"- Entity id: 11\n- Entity type: topic\n" + String.raw`- Name: Old \<Topic\>` + "\n- Force delete tree: false\n" +
 				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/45)",
 		);
 		expect(cardText(buildActionApprovalCard({ runId: 45, details }))).toBe(
@@ -183,14 +184,16 @@ describe("approval notification rendering", () => {
 		};
 
 		const body = formatActionApprovalBody({ details });
-		// Markdown: brackets/emphasis defanged, ampersand left as a literal `&`.
+		// Markdown: every link/emphasis delimiter defanged; `&` stays a literal
+		// `&` (Slack's entity escaping must not leak into Markdown).
 		expect(body).toContain(
-			"**[Review [nested]\\](https://evil)** wants to delete " +
-				"\\*Urgent\\* <!channel> & [click\\](https://evil) (#5).",
+			String.raw`**\[Review \[nested\]\](https://evil)** wants to delete ` +
+				String.raw`\*Urgent\* \<!channel\> & \[click\](https://evil) (#5).`,
 		);
 		expect(body).not.toContain("&amp;");
+		// Leading `#` must not become a heading in the reason paragraph.
 		expect(body).toContain(
-			"\n\n\\# [Review [nested]\\](https://evil)",
+			"\n\n" + String.raw`\# \[Review \[nested\]\](https://evil)`,
 		);
 
 		const card = cardText(buildActionApprovalCard({ details }));
@@ -206,27 +209,49 @@ describe("approval notification rendering", () => {
 		expect(card).not.toContain("\\[");
 	});
 
-	test("bracketed values stay literal; only link-forming brackets are escaped", () => {
-		// A JSON array value ("[ 886 ]") is inert Markdown and must render as
-		// typed — escaping every bracket leaked visible backslashes into the card.
+	test("markdown escaping covers strikethrough, autolinks, and unmatched brackets", () => {
+		// The three vectors that survived a narrower escape set: `~~x~~` rendered
+		// as <del>, `<https://evil>` became a real anchor, and a stray `]` closed
+		// our link label early so the rest of the name escaped the anchor.
 		const details: ActionApprovalDetails = {
 			kind: "entity_change",
-			operation: "merge",
-			actorLabel: "An agent",
-			entityId: 886,
-			entityType: "person",
-			entityName: "905319918039@s.whatsapp.net",
-			entityUrl: "https://app.lobu.ai/buremba/person/member-0faa51dac0",
-			proposal: {
-				entity_ids: [886],
-				// Only this one forms a link and must be defanged.
-				note: "see [Review in Lobu](https://evil)",
-			},
+			operation: "delete",
+			actorLabel: "~~trusted agent~~",
+			entityId: 7,
+			entityType: "topic",
+			entityName: "Budget] <https://evil.example>",
+			entityUrl: "https://app.lobu.ai/acme/topic/budget",
+			proposal: { entity_ids: [886] },
 			reason: null,
 		};
 		const body = formatActionApprovalBody({ details });
-		expect(body).toContain("- Entity ids: [ 886 ]");
-		expect(body).toContain("- Note: see [Review in Lobu\\](https://evil)");
+
+		expect(body).toContain(
+			String.raw`**\~\~trusted agent\~\~** wants to delete ` +
+				String.raw`[Budget\] \<https://evil.example\>](https://app.lobu.ai/acme/topic/budget).`,
+		);
+		// Our own diff/link chrome must survive — only the values are escaped.
+		expect(body).toContain("](https://app.lobu.ai/acme/topic/budget)");
+		// Brackets in JSON values are escaped too; the renderer strips the
+		// backslashes, so the user still reads "[ 886 ]" (asserted in
+		// owletto's markdown-text.inline.test.tsx).
+		expect(body).toContain(String.raw`- Entity ids: \[ 886 \]`);
+	});
+
+	test("renderer-owned diff delimiters are not escaped away", () => {
+		// `~old~` is OUR strikethrough, not user text. Escaping the assembled
+		// diff line turned it into a literal `\~old\~`.
+		const body = formatActionApprovalBody({
+			details: {
+				kind: "entity_field_change",
+				entityId: 9,
+				entityType: "topic",
+				fields: { severity: "critical" },
+				current: { severity: "high" },
+				reason: null,
+			},
+		});
+		expect(body).toContain("- Severity: ~high~\n→ critical");
 	});
 
 	test("generic action: no card, connection fallback body", () => {

--- a/packages/server/src/__tests__/unit/approval-notification-render.test.ts
+++ b/packages/server/src/__tests__/unit/approval-notification-render.test.ts
@@ -238,6 +238,20 @@ describe("approval notification rendering", () => {
 		expect(body).toContain(String.raw`- Entity ids: \[ 886 \]`);
 	});
 
+	test("generic approval escapes the connection name", () => {
+		// The non-structured branch interpolates connectionName straight into the
+		// Markdown body; unescaped it could forge an external "Review" anchor.
+		expect(
+			formatActionApprovalBody({
+				connectionName: "GitHub](https://evil.example) [x",
+				approvalUrl: "/acme/runs/46",
+			}),
+		).toBe(
+			String.raw`A queued action on GitHub\](https://evil.example) \[x is waiting for your review.` +
+				"\n\nReview: [Review in Lobu](/acme/runs/46)",
+		);
+	});
+
 	test("setext underlines of any length are escaped", () => {
 		// A single "=" under a line turns it into an <h1>; the escape must not be
 		// limited to the 3+ runs that form a `---` thematic break.

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -99,6 +99,7 @@ function truncateNotificationLine(value: string): string {
 		: normalized;
 }
 
+
 /** "$parent_id" → "Parent id", "entity_type" → "Entity type". */
 export function formatLabel(value: string): string {
 	return value
@@ -207,8 +208,16 @@ function buildApprovalRenderModel(
 	details: ActionApprovalDetails,
 ): ApprovalRenderModel {
 	const base = {
-		requestedBy: details.actorLabel ?? null,
-		entityName: details.entityName ?? null,
+		// Collapsed to one line: these are interpolated into a single summary
+		// sentence, and an embedded newline would split it across Markdown
+		// paragraphs — leaving the card preview (first block only) showing a
+		// truncated half-sentence.
+		requestedBy: details.actorLabel
+			? truncateNotificationLine(details.actorLabel)
+			: null,
+		entityName: details.entityName
+			? truncateNotificationLine(details.entityName)
+			: null,
 		entityUrl: details.entityUrl ?? null,
 		entityId: details.entityId ?? null,
 		entityTypeLabel: details.entityType ? formatLabel(details.entityType) : null,
@@ -343,7 +352,7 @@ export function formatActionApprovalBody(params: {
 	// Escaped like every other interpolation into this Markdown body — a
 	// connection named "X](https://evil) [y" would otherwise forge an anchor.
 	const connLabel = params.connectionName
-		? ` on ${escapeMarkdownText(params.connectionName)}`
+		? ` on ${escapeMarkdownText(truncateNotificationLine(params.connectionName))}`
 		: "";
 	const urlLine = params.approvalUrl
 		? `\n\nReview: ${formatReviewLink(params.approvalUrl)}`

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -40,22 +40,50 @@ export type ActionApprovalDetails =
 	| EntityChangeApprovalDetails;
 
 /**
- * Escape user/agent-controlled text before it lands in Slack mrkdwn (and the
- * in-app Markdown body — both render HTML entities). Without this, a proposed
- * field value containing `<!channel>` pings the room from inside a trusted
- * approval card, and `<https://evil|Review in Lobu>` spoofs the review link.
+ * Escape user/agent-controlled text before it lands in Slack mrkdwn. Without
+ * this, a proposed field value containing `<!channel>` pings the room from
+ * inside a trusted approval card, and `<https://evil|Review in Lobu>` spoofs
+ * the review link.
+ *
+ * Slack-only: the persisted in-app body is Markdown source, not Slack mrkdwn.
+ * Storing Slack's HTML entities there couples plain-text consumers to Slack
+ * escaping. The Markdown emitter neutralises its own injection vectors via
+ * `escapeMarkdownText`.
  */
-function escapeNotificationText(value: string): string {
+function escapeSlackText(value: string): string {
 	return value
 		.replace(/&/g, "&amp;")
 		.replace(/</g, "&lt;")
 		.replace(/>/g, "&gt;");
 }
 
+/**
+ * Escape user/agent-controlled text for the in-app Markdown body. Narrow by
+ * design — it must neutralise forged chrome without littering ordinary prose,
+ * because these strings are entity names and JSON values full of brackets,
+ * braces and hyphens:
+ *  - `*`/`_`/`` ` `` — emphasis marks that would let injected text impersonate
+ *    the card's own bolding.
+ *  - A closing `]` before `(` or `[` — enough to break inline/reference links,
+ *    including labels with nested or escaped brackets. A bare `[ 886 ]` is
+ *    inert in Markdown and stays untouched.
+ *  - Leading Markdown block marks — reasons render as their own paragraph, so
+ *    headings, quotes, and lists must remain literal text there.
+ */
+function escapeMarkdownText(value: string): string {
+	return value
+		.replace(/([\\`*_])/g, "\\$1")
+		.replace(/\](?=[([])/g, "\\]")
+		.replace(/^([ \t]{0,3})(-{3,}|={3,})(?=\s*$)/gm, "$1\\$2")
+		.replace(/^([ \t]{0,3})(?=[#>+-](?:\s|$))/gm, "$1\\")
+		.replace(/^([ \t]{0,3}\d{1,9})([.)])(?=\s|$)/gm, "$1\\$2");
+}
+
+/** Raw display text; each emitter applies its own escaping. */
 function displayNotificationValue(value: unknown): string {
 	if (value === undefined || value === null || value === "") return "Not set";
-	if (typeof value === "string") return escapeNotificationText(value);
-	return escapeNotificationText(JSON.stringify(value, null, 2));
+	if (typeof value === "string") return value;
+	return JSON.stringify(value, null, 2);
 }
 
 function truncateNotificationLine(value: string): string {
@@ -93,7 +121,7 @@ function formatReviewLink(url: string): string {
 }
 
 function formatCardLink(label: string, url: string): string {
-	return `<${url}|${escapeNotificationText(label.replace(/[<>|]/g, ""))}>`;
+	return `<${url}|${escapeSlackText(label.replace(/[<>|]/g, ""))}>`;
 }
 
 function compactDiffLine(
@@ -115,9 +143,7 @@ function formatWhyApprovalNeeded(reason: string | null | undefined): string {
 	const fallback =
 		"This change needs a human approval before it is applied.";
 	if (!reason) return fallback;
-	return escapeNotificationText(
-		reason.replace(/^Watcher proposes updating /i, "Field is protected: "),
-	);
+	return reason.replace(/^Watcher proposes updating /i, "Field is protected: ");
 }
 
 export function formatActionApprovalTitle(
@@ -145,9 +171,9 @@ export function formatActionApprovalTitle(
 
 /**
  * Format-neutral content of an approval card, computed ONCE for both surfaces
- * (in-app Markdown body and Slack mrkdwn card): escaping, truncation, labels,
- * diff lines, and the "why" sentence live here; the two emitters below only
- * decide bolding, link syntax, and blank-line placement.
+ * (in-app Markdown body and Slack mrkdwn card): truncation, labels, diff lines,
+ * and the "why" sentence live here. Each emitter applies the escaping required
+ * by its own markup syntax.
  */
 interface ApprovalRenderModel {
 	requestedBy: string | null;
@@ -169,9 +195,7 @@ function buildApprovalRenderModel(
 	details: ActionApprovalDetails,
 ): ApprovalRenderModel {
 	const base = {
-		requestedBy: details.actorLabel
-			? escapeNotificationText(details.actorLabel)
-			: null,
+		requestedBy: details.actorLabel ?? null,
 		entityName: details.entityName ?? null,
 		entityUrl: details.entityUrl ?? null,
 		entityId: details.entityId ?? null,
@@ -203,7 +227,7 @@ function buildApprovalRenderModel(
 			label: formatLabel(field),
 			value: truncateNotificationLine(displayNotificationValue(value)),
 		})),
-		why: details.reason ? escapeNotificationText(details.reason) : null,
+		why: details.reason ?? null,
 	};
 }
 
@@ -219,20 +243,23 @@ function renderApprovalBody(
 	approvalUrl?: string,
 ): string {
 	const lines: string[] = [];
-	const label = escapeNotificationText(
+	const label = escapeMarkdownText(
 		model.entityName ?? model.entityTypeLabel ?? "this entity",
 	);
+	// Only the label is escaped — the URL is ours (buildResourcePermalink), and
+	// escaping it would break the link target.
 	const entityLink = model.entityUrl
 		? `[${label}](${model.entityUrl})`
 		: model.entityId
 			? `${label} (#${model.entityId})`
 			: label;
-	const who = model.requestedBy ?? "A watcher";
+	const who = escapeMarkdownText(model.requestedBy ?? "A watcher");
 
 	// One summary line: "<Watcher> wants to <verb> <entity>."
 	if (model.diffs) {
 		lines.push(`**${who}** wants to update ${entityLink}:`);
-		for (const d of model.diffs) lines.push(`- ${d.label}: ${d.diff}`);
+		for (const d of model.diffs)
+			lines.push(`- ${d.label}: ${escapeMarkdownText(d.diff)}`);
 	} else {
 		const verb =
 			model.action === "Delete this entity"
@@ -242,11 +269,12 @@ function renderApprovalBody(
 					: "create";
 		lines.push(`**${who}** wants to ${verb} ${entityLink}.`);
 		if (model.proposal.length > 0) {
-			for (const p of model.proposal) lines.push(`- ${p.label}: ${p.value}`);
+			for (const p of model.proposal)
+				lines.push(`- ${p.label}: ${escapeMarkdownText(p.value)}`);
 		}
 	}
 	// The proposer's own reason, inline and unlabeled (it reads as a sentence).
-	if (model.why) lines.push("", model.why);
+	if (model.why) lines.push("", escapeMarkdownText(model.why));
 	if (approvalUrl) lines.push("", formatReviewLink(approvalUrl));
 	return lines.join("\n");
 }
@@ -254,24 +282,28 @@ function renderApprovalBody(
 /** Slack mrkdwn card text (bold labels, `<url|label>` links). */
 function renderApprovalCardText(model: ApprovalRenderModel): string {
 	const lines: string[] = [];
-	if (model.requestedBy) lines.push(`*Requested by:* ${model.requestedBy}`);
+	if (model.requestedBy)
+		lines.push(`*Requested by:* ${escapeSlackText(model.requestedBy)}`);
 	if (model.entityName) {
 		lines.push(
 			`*Entity:* ${
 				model.entityUrl
 					? formatCardLink(model.entityName, model.entityUrl)
-					: escapeNotificationText(model.entityName)
+					: escapeSlackText(model.entityName)
 			}`,
 		);
 	}
 	if (model.diffs) {
-		for (const d of model.diffs) lines.push("", `*${d.label}*`, d.diff);
+		for (const d of model.diffs)
+			lines.push("", `*${d.label}*`, escapeSlackText(d.diff));
 	}
 	if (model.action) {
 		lines.push("", `*Proposed action:* ${model.action}`);
-		for (const p of model.proposal) lines.push(`*${p.label}:* ${p.value}`);
+		for (const p of model.proposal)
+			lines.push(`*${p.label}:* ${escapeSlackText(p.value)}`);
 	}
-	if (model.why) lines.push("", `*Why approval is needed:* ${model.why}`);
+	if (model.why)
+		lines.push("", `*Why approval is needed:* ${escapeSlackText(model.why)}`);
 	return lines.join("\n");
 }
 

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -340,7 +340,11 @@ export function formatActionApprovalBody(params: {
 		);
 	}
 
-	const connLabel = params.connectionName ? ` on ${params.connectionName}` : "";
+	// Escaped like every other interpolation into this Markdown body — a
+	// connection named "X](https://evil) [y" would otherwise forge an anchor.
+	const connLabel = params.connectionName
+		? ` on ${escapeMarkdownText(params.connectionName)}`
+		: "";
 	const urlLine = params.approvalUrl
 		? `\n\nReview: ${formatReviewLink(params.approvalUrl)}`
 		: "";

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -77,7 +77,10 @@ function escapeSlackText(value: string): string {
 function escapeMarkdownText(value: string): string {
 	return value
 		.replace(/([\\`*_~[\]<>])/g, "\\$1")
-		.replace(/^([ \t]{0,3})(-{3,}|={3,})(?=\s*$)/gm, "$1\\$2")
+		// Setext underlines and thematic breaks: ANY run length turns the line
+		// above into a heading ("Trusted line\n=" renders as <h1>), so this is not
+		// limited to the 3+ runs that form a `---` rule.
+		.replace(/^([ \t]{0,3})([-=]+)(?=[ \t]*$)/gm, "$1\\$2")
 		.replace(/^([ \t]{0,3})(?=[#>+-](?:\s|$))/gm, "$1\\")
 		.replace(/^([ \t]{0,3}\d{1,9})([.)])(?=\s|$)/gm, "$1\\$2");
 }

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -58,22 +58,25 @@ function escapeSlackText(value: string): string {
 }
 
 /**
- * Escape user/agent-controlled text for the in-app Markdown body. Narrow by
- * design — it must neutralise forged chrome without littering ordinary prose,
- * because these strings are entity names and JSON values full of brackets,
- * braces and hyphens:
- *  - `*`/`_`/`` ` `` — emphasis marks that would let injected text impersonate
- *    the card's own bolding.
- *  - A closing `]` before `(` or `[` — enough to break inline/reference links,
- *    including labels with nested or escaped brackets. A bare `[ 886 ]` is
- *    inert in Markdown and stays untouched.
- *  - Leading Markdown block marks — reasons render as their own paragraph, so
- *    headings, quotes, and lists must remain literal text there.
+ * Escape user/agent-controlled text for the in-app Markdown body (GFM, so
+ * strikethrough and autolinks are live too). These strings are entity names,
+ * actor labels, and JSON values, and they get interpolated INTO our own
+ * `**bold**` and `[label](url)` chrome — so anything that could terminate that
+ * chrome early, or start markup of its own, has to be neutralised:
+ *  - `` \ ` * _ ~ `` — emphasis/strikethrough/code delimiters. Missing `~` let
+ *    an actor named `~~trusted agent~~` render struck-through.
+ *  - `[` and `]` — a stray `]` closes our link label early, letting the rest of
+ *    the name escape the anchor. Escaping is unconditional: a lookahead rule
+ *    (only before `(`) missed unmatched brackets. The renderer strips the
+ *    backslashes, so `[ 886 ]` still displays literally.
+ *  - `<` and `>` — GFM autolinks. `<https://evil.example>` became a real
+ *    attacker-controlled anchor inside a trusted-looking card.
+ *  - Leading block marks — reasons render as their own paragraph, so headings,
+ *    quotes, lists, and setext underlines must stay literal text there.
  */
 function escapeMarkdownText(value: string): string {
 	return value
-		.replace(/([\\`*_])/g, "\\$1")
-		.replace(/\](?=[([])/g, "\\]")
+		.replace(/([\\`*_~[\]<>])/g, "\\$1")
 		.replace(/^([ \t]{0,3})(-{3,}|={3,})(?=\s*$)/gm, "$1\\$2")
 		.replace(/^([ \t]{0,3})(?=[#>+-](?:\s|$))/gm, "$1\\")
 		.replace(/^([ \t]{0,3}\d{1,9})([.)])(?=\s|$)/gm, "$1\\$2");
@@ -124,17 +127,19 @@ function formatCardLink(label: string, url: string): string {
 	return `<${url}|${escapeSlackText(label.replace(/[<>|]/g, ""))}>`;
 }
 
-function compactDiffLine(
+/**
+ * Raw before/after pair. Kept UNASSEMBLED so each emitter can escape the two
+ * values without touching the `~old~` strikethrough delimiters it adds itself —
+ * escaping a pre-assembled string turned our own markup into literal `\~`.
+ */
+function compactDiffValues(
 	currentValue: unknown,
 	proposedValue: unknown,
-): string {
-	const current = truncateNotificationLine(
-		displayNotificationValue(currentValue),
-	);
-	const proposed = truncateNotificationLine(
-		displayNotificationValue(proposedValue),
-	);
-	return `~${current}~\n→ ${proposed}`;
+): { current: string; proposed: string } {
+	return {
+		current: truncateNotificationLine(displayNotificationValue(currentValue)),
+		proposed: truncateNotificationLine(displayNotificationValue(proposedValue)),
+	};
 }
 
 function formatWhyApprovalNeeded(reason: string | null | undefined): string {
@@ -182,8 +187,12 @@ interface ApprovalRenderModel {
 	entityId: number | null;
 	/** formatLabel(entityType), for the body's entity-link fallback. */
 	entityTypeLabel: string | null;
-	/** Field-change diffs (null for entity_change — kinds render differently). */
-	diffs: Array<{ label: string; diff: string }> | null;
+	/**
+	 * Field-change diffs (null for entity_change — kinds render differently).
+	 * Values stay unassembled so emitters escape them without mangling the
+	 * strikethrough delimiters they wrap around `current`.
+	 */
+	diffs: Array<{ label: string; current: string; proposed: string }> | null;
 	/** entity_change action sentence ("Create/Delete this entity"). */
 	action: string | null;
 	proposal: Array<{ label: string; value: string }>;
@@ -207,7 +216,7 @@ function buildApprovalRenderModel(
 			...base,
 			diffs: Object.entries(details.fields).map(([field, proposed]) => ({
 				label: formatLabel(field),
-				diff: compactDiffLine(current[field], proposed),
+				...compactDiffValues(current[field], proposed),
 			})),
 			action: null,
 			proposal: [],
@@ -259,7 +268,9 @@ function renderApprovalBody(
 	if (model.diffs) {
 		lines.push(`**${who}** wants to update ${entityLink}:`);
 		for (const d of model.diffs)
-			lines.push(`- ${d.label}: ${escapeMarkdownText(d.diff)}`);
+			lines.push(
+				`- ${d.label}: ~${escapeMarkdownText(d.current)}~\n→ ${escapeMarkdownText(d.proposed)}`,
+			);
 	} else {
 		const verb =
 			model.action === "Delete this entity"
@@ -295,7 +306,11 @@ function renderApprovalCardText(model: ApprovalRenderModel): string {
 	}
 	if (model.diffs) {
 		for (const d of model.diffs)
-			lines.push("", `*${d.label}*`, escapeSlackText(d.diff));
+			lines.push(
+				"",
+				`*${d.label}*`,
+				`~${escapeSlackText(d.current)}~\n→ ${escapeSlackText(d.proposed)}`,
+			);
 	}
 	if (model.action) {
 		lines.push("", `*Proposed action:* ${model.action}`);


### PR DESCRIPTION
## Summary
- The approval render model pre-escaped text as **HTML entities** for the Slack mrkdwn card, and the in-app Markdown body reused the same pre-escaped strings. Markdown does not decode entities, so an entity named `App & Crashes` reached the web UI as `App &amp; Crashes`.
- Keep the shared model **raw** and let each emitter escape for its own syntax:
  - Slack keeps entity escaping, so `<!channel>` stays inert and `<url|label>` can't be spoofed.
  - Markdown neutralises **its** vectors instead — emphasis marks and link-forming brackets — so a name can't forge a `[Review in Lobu](evil)` link or fake bolding.
- Escaping is deliberately narrow: a bare `[ 886 ]` (a JSON array value) is inert Markdown and renders literally. Escaping every bracket leaked visible backslashes into the card.
- Bumps the owletto pointer to lobu-ai/owletto#599, which renders these bodies as inline summaries.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test packages/server/src/__tests__/unit/` — 665 pass / 0 fail
- [x] Bug fix: red→fix→green outputs pasted below

### red (golden pins on `origin/main`'s renderer, showing the entity leak)
```
- "**Watcher &lt;One&gt;** wants to update [App &amp; Crashes](...)
+ "**Watcher <One>** wants to update [App & Crashes](...)
- - Name: Slow &amp; Loading
+ - Name: Slow & Loading
```

### green (this branch)
```
packages/server/src/__tests__/unit/approval-notification-render.test.ts
 8 pass / 0 fail / 26 expect() calls
```

## Notes
Golden pins re-captured for the Markdown body only — every Slack card assertion is unchanged and still passes byte-identical, which is the evidence the split didn't regress Slack.

Adds two tests beyond the re-pin:
- a per-surface injection case (one hostile name → Markdown defangs brackets/emphasis, Slack defangs `<!channel>`/`&`, and neither surface leaks the other's escaping);
- a regression pin that `[ 886 ]` stays literal while `[Review in Lobu](https://evil)` is escaped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved approval notification rendering with correct, format-specific escaping for in-app Markdown vs Slack.
  - Prevented user/agent content from creating unintended formatting, links, or Slack mentions.
  - Preserved literal brackets, angle brackets, and ampersands where appropriate, including renderer-owned diff delimiters.
- **Tests**
  - Updated golden “pin” expectations and expanded coverage for escaping isolation and tricky Markdown cases.
- **Chores**
  - Updated the recorded embedded submodule revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->