### PR TITLE
fix(server): filter events by OAuth client id, and stop dropping filters on the score path

### DIFF
--- a/packages/server/src/__tests__/integration/events/get-content-client-id-filter.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-client-id-filter.test.ts
@@ -1,10 +1,10 @@
 /**
  * Integration test: the `client_id` filter scopes events to one OAuth client.
  *
- * This backs the MCP activity view — "what did ChatGPT do here" — which reads
- * events filtered by `client_id` plus `semantic_type: 'audit'`. `client_id` is a
- * real indexed column on `events` (idx_events_client_id, FK → oauth_clients),
- * NOT a metadata field, so the predicate is a plain column match.
+ * Answers "what did this MCP client do here": events filtered by `client_id`,
+ * typically alongside `semantic_type: 'audit'`. `client_id` is a real indexed
+ * column on `events` (idx_events_client_id, FK → oauth_clients), NOT a metadata
+ * field, so the predicate is a plain column match.
  *
  * Why an integration test and not a unit one: the filter is threaded through two
  * SQL builders that share POSITIONAL parameter slots. `client_id` took slot $12,

--- a/packages/server/src/__tests__/integration/events/get-content-client-id-filter.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-client-id-filter.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration test: the `client_id` filter scopes events to one OAuth client.
+ *
+ * This backs the MCP activity view — "what did ChatGPT do here" — which reads
+ * events filtered by `client_id` plus `semantic_type: 'audit'`. `client_id` is a
+ * real indexed column on `events` (idx_events_client_id, FK → oauth_clients),
+ * NOT a metadata field, so the predicate is a plain column match.
+ *
+ * Why an integration test and not a unit one: the filter is threaded through two
+ * SQL builders that share POSITIONAL parameter slots. `client_id` took slot $12,
+ * which shifted every downstream index in the search path (orgScope, exclude,
+ * visibility, entity-types, cursor…). A mismatch there typechecks perfectly and
+ * fails only against a real Postgres — usually as a wrong-parameter bind rather
+ * than an error, i.e. silently wrong rows. Both query paths are exercised:
+ *
+ *   - list path   (no search_term) — appended condition, params.length-indexed
+ *   - search path (search_term)    — fixed $12 slot in a shared WHERE template
+ *
+ * A client that re-registers gets a NEW oauth_clients row under the same
+ * client_name (verified in prod: "Lobu CLI" had 6 ids), so the filter accepts an
+ * ARRAY and both shapes are covered.
+ *
+ * Vitest CI gap note (mirrors neighbors): runs locally / in the CI integration
+ * job against the pgvector DB via DATABASE_URL.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+/** Register an oauth_clients row so the events FK is satisfiable. */
+async function registerClient(opts: {
+  id: string;
+  clientName: string;
+  userId: string;
+  organizationId: string;
+}): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO oauth_clients (id, client_name, redirect_uris, user_id, organization_id)
+    VALUES (
+      ${opts.id}, ${opts.clientName}, ARRAY['https://example.test/cb']::text[],
+      ${opts.userId}, ${opts.organizationId}
+    )
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+/** Insert one audit-shaped event attributed to `clientId` (or none). */
+async function insertAuditEvent(opts: {
+  organizationId: string;
+  title: string;
+  clientId: string | null;
+  occurredAt: Date;
+}): Promise<number> {
+  const sql = getTestDb();
+  const [row] = await sql`
+    INSERT INTO events (
+      organization_id, origin_id, title, payload_type, payload_text,
+      semantic_type, client_id, occurred_at, created_at
+    ) VALUES (
+      ${opts.organizationId},
+      ${`client-filter-${opts.title}-${opts.occurredAt.getTime()}`},
+      ${opts.title}, 'text', ${opts.title},
+      'audit', ${opts.clientId}, ${opts.occurredAt}, NOW()
+    )
+    RETURNING id
+  `;
+  return Number((row as { id: unknown }).id);
+}
+
+describe('getContent > client_id scopes events to one OAuth client', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let ctx: ToolContext;
+
+  // Two ids for the SAME logical client, as happens on re-registration.
+  const CHATGPT = 'mcp_client_test_chatgpt';
+  const CLI_A = 'mcp_client_test_cli_a';
+  const CLI_B = 'mcp_client_test_cli_b';
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Client Filter Org' });
+    user = await createTestUser({ email: 'client-filter@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    for (const [id, name] of [
+      [CHATGPT, 'ChatGPT'],
+      [CLI_A, 'Lobu CLI'],
+      [CLI_B, 'Lobu CLI'],
+    ] as const) {
+      await registerClient({
+        id,
+        clientName: name,
+        userId: user.id,
+        organizationId: org.id,
+      });
+    }
+
+    const t0 = new Date('2026-07-01T00:00:00Z');
+    await insertAuditEvent({
+      organizationId: org.id,
+      title: 'chatgpt searched memory',
+      clientId: CHATGPT,
+      occurredAt: t0,
+    });
+    await insertAuditEvent({
+      organizationId: org.id,
+      title: 'cli ran query first registration',
+      clientId: CLI_A,
+      occurredAt: new Date(t0.getTime() + 1000),
+    });
+    await insertAuditEvent({
+      organizationId: org.id,
+      title: 'cli ran query second registration',
+      clientId: CLI_B,
+      occurredAt: new Date(t0.getTime() + 2000),
+    });
+    await insertAuditEvent({
+      organizationId: org.id,
+      title: 'server side activity with no client',
+      clientId: null,
+      occurredAt: new Date(t0.getTime() + 3000),
+    });
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    } as ToolContext;
+  });
+
+  it('list path: a single client id returns only that client’s events', async () => {
+    const result = await getContent(
+      { client_ids: [CHATGPT], semantic_type: 'audit', limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content.map((c) => c.title)).toEqual(['chatgpt searched memory']);
+  });
+
+  it('list path: an array matches every registration of one client', async () => {
+    const result = await getContent(
+      { client_ids: [CLI_A, CLI_B], semantic_type: 'audit', limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content.map((c) => c.title).sort()).toEqual([
+      'cli ran query first registration',
+      'cli ran query second registration',
+    ]);
+  });
+
+  it('list path: omitting client_id returns every event, client-attributed or not', async () => {
+    const result = await getContent(
+      { semantic_type: 'audit', limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    // The null-client row must NOT be filtered out when no client is requested.
+    expect(result.content.length).toBe(4);
+    expect(result.content.map((c) => c.title)).toContain(
+      'server side activity with no client'
+    );
+  });
+
+  it('search path: client_id still scopes when a search_term shifts the param slots', async () => {
+    // The search path binds client_id at fixed slot $12 and pushes orgScope to
+    // $13. If those indexes drift, this returns the wrong rows rather than
+    // erroring — which is exactly what makes it worth asserting.
+    const result = await getContent(
+      { query: "query", client_ids: [CLI_A, CLI_B], limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    const titles = result.content.map((c) => c.title);
+    expect(titles.length).toBeGreaterThan(0);
+    for (const title of titles) {
+      expect(title).toContain('cli ran query');
+    }
+    expect(titles).not.toContain('chatgpt searched memory');
+  });
+
+  it('search path: a client with no matching text returns nothing, not everything', async () => {
+    // Guards the failure mode where a mis-bound slot makes the predicate a
+    // no-op: ChatGPT has no event containing "query".
+    const result = await getContent(
+      { query: "query", client_ids: [CHATGPT], limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content).toEqual([]);
+  });
+});

--- a/packages/server/src/__tests__/integration/events/get-content-score-path-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-score-path-attribution.test.ts
@@ -1,23 +1,26 @@
 /**
- * Regression test: `sort_by: 'score'` must honour the attribution filters.
+ * Regression test: `sort_by: 'score'` must honour the forwarded filters.
  *
  * `get_content` has FOUR filter-application sites, and the
- * `sort_by === 'score' && entity_id` branch builds its OWN filters object
- * (handler.ts, the `getNormalizedScoreContent` call). That object enumerates
- * fields explicitly, so anything not listed is silently DROPPED — the query
- * returns unfiltered rows rather than erroring, which is the worst failure
- * shape: a caller asking "what did this client do" gets everything.
+ * `sort_by === 'score' && entity_id` branch runs through its own builder
+ * (`buildFilterConditionsAndJoins` in content-scoring.ts). Both it and the
+ * handler's filters object enumerate fields explicitly, so anything not listed
+ * is silently DROPPED — the query returns unfiltered rows rather than erroring,
+ * which is the worst failure shape: a caller asking "what did this client do"
+ * gets everything, led by whatever scored highest.
  *
- * Two filters were missing there:
- *   - `client_ids` — added alongside the filter itself in this branch
- *   - `agent_id`   — pre-existing hole, so this is a CLASS not a one-off
+ * THREE filters were missing, i.e. a class not a one-off:
+ *   - `client_ids`             — added alongside the filter in this branch
+ *   - `agent_id`               — pre-existing
+ *   - `analyzed_by_behavior_id`— pre-existing; the handler always passed it
  *
- * Both are asserted here against the score path specifically. The date/list and
- * search paths are covered by get-content-client-id-filter.test.ts.
+ * Fixtures deliberately give the NON-matching rows the higher score, so a
+ * dropped filter surfaces them first and fails loudly rather than passing by
+ * accident on ordering. Score sorting derives per-connection scoring formulas
+ * from the entity's sources, so unlike the list-path test these fixtures need a
+ * real entity + connection.
  *
- * Score sorting requires an entity (it derives per-connection scoring formulas
- * from the entity's sources), so unlike the list-path test these fixtures need
- * a real entity + connection, and events linked to both.
+ * The list and search paths are covered by get-content-client-id-filter.test.ts.
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -38,6 +41,8 @@ const CHATGPT = 'mcp_score_path_chatgpt';
 const CLI = 'mcp_score_path_cli';
 const AGENT_A = 'agent_score_path_a';
 const AGENT_B = 'agent_score_path_b';
+const BEHAVIOR_A = 910_001;
+const BEHAVIOR_B = 910_002;
 
 async function registerClient(opts: {
   id: string;
@@ -56,11 +61,6 @@ async function registerClient(opts: {
   `;
 }
 
-/**
- * Insert an event carrying both attribution stamps. `client_id` is a real
- * column; `agent_id` lives in metadata — the two predicates differ, so both
- * shapes must be exercised.
- */
 async function insertAttributedEvent(opts: {
   organizationId: string;
   entityId: number;
@@ -70,9 +70,9 @@ async function insertAttributedEvent(opts: {
   agentId: string | null;
   score: number;
   occurredAt: Date;
-}): Promise<void> {
+}): Promise<number> {
   const sql = getTestDb();
-  await sql`
+  const [row] = await sql`
     INSERT INTO events (
       entity_ids, connection_id, organization_id, origin_id, title,
       payload_type, payload_text, semantic_type, connector_key,
@@ -93,10 +93,12 @@ async function insertAttributedEvent(opts: {
       ${opts.occurredAt},
       NOW()
     )
+    RETURNING id
   `;
+  return Number((row as { id: unknown }).id);
 }
 
-describe('getContent > score path honours attribution filters', () => {
+describe('getContent > score path honours forwarded filters', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
   let user: Awaited<ReturnType<typeof createTestUser>>;
   let entityId: number;
@@ -139,10 +141,7 @@ describe('getContent > score path honours attribution filters', () => {
     });
 
     const t0 = new Date('2026-07-01T00:00:00Z');
-    // Deliberately give the NON-matching rows the higher score. If the filter is
-    // dropped, score ordering surfaces them first and the assertions fail loudly
-    // rather than passing by accident on ordering.
-    await insertAttributedEvent({
+    const chatgptEventId = await insertAttributedEvent({
       organizationId: org.id,
       entityId,
       connectionId: connection.id,
@@ -152,7 +151,7 @@ describe('getContent > score path honours attribution filters', () => {
       score: 99,
       occurredAt: t0,
     });
-    await insertAttributedEvent({
+    const cliEventId = await insertAttributedEvent({
       organizationId: org.id,
       entityId,
       connectionId: connection.id,
@@ -172,6 +171,14 @@ describe('getContent > score path honours attribution filters', () => {
       score: 50,
       occurredAt: new Date(t0.getTime() + 2000),
     });
+
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO watcher_window_events (window_id, event_id, watcher_id)
+      VALUES
+        (${chatgptEventId}, ${chatgptEventId}, ${BEHAVIOR_A}),
+        (${cliEventId}, ${cliEventId}, ${BEHAVIOR_B})
+    `;
 
     ctx = {
       organizationId: org.id,
@@ -204,12 +211,10 @@ describe('getContent > score path honours attribution filters', () => {
       {} as never,
       ctx
     );
-    // Before the fix this returned all three rows, led by the score-99 ChatGPT
-    // row — the exact "asked for one client, got everything" failure.
     expect(result.content.map((c) => c.title)).toEqual(['cli low score row']);
   });
 
-  it('agent_id scopes score-sorted rows to that agent (pre-existing hole)', async () => {
+  it('agent_id scopes score-sorted rows to that agent', async () => {
     const result = await getContent(
       { entity_id: entityId, sort_by: 'score', agent_id: AGENT_B, limit: 100 } as never,
       {} as never,
@@ -218,9 +223,35 @@ describe('getContent > score path honours attribution filters', () => {
     expect(result.content.map((c) => c.title)).toEqual(['cli low score row']);
   });
 
+  it('analyzed_by_behavior_id scopes score-sorted rows to that behavior', async () => {
+    const result = await getContent(
+      {
+        entity_id: entityId,
+        sort_by: 'score',
+        analyzed_by_behavior_id: BEHAVIOR_B,
+        limit: 100,
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content.map((c) => c.title)).toEqual(['cli low score row']);
+  });
+
+  it('include_superseded applies the client scope', async () => {
+    const result = await getContent(
+      {
+        entity_id: entityId,
+        include_superseded: true,
+        client_ids: [CLI],
+        limit: 100,
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content.map((c) => c.title)).toEqual(['cli low score row']);
+  });
+
   it('total count matches the filtered rows, not the unfiltered set', async () => {
-    // Rows and count come from two separate queries sharing one filter builder.
-    // If only the row query were fixed, has_more/pagination would still lie.
     const result = await getContent(
       { entity_id: entityId, sort_by: 'score', client_ids: [CHATGPT], limit: 100 } as never,
       {} as never,

--- a/packages/server/src/__tests__/integration/events/get-content-score-path-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-score-path-attribution.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Regression test: `sort_by: 'score'` must honour the attribution filters.
+ *
+ * `get_content` has FOUR filter-application sites, and the
+ * `sort_by === 'score' && entity_id` branch builds its OWN filters object
+ * (handler.ts, the `getNormalizedScoreContent` call). That object enumerates
+ * fields explicitly, so anything not listed is silently DROPPED — the query
+ * returns unfiltered rows rather than erroring, which is the worst failure
+ * shape: a caller asking "what did this client do" gets everything.
+ *
+ * Two filters were missing there:
+ *   - `client_ids` — added alongside the filter itself in this branch
+ *   - `agent_id`   — pre-existing hole, so this is a CLASS not a one-off
+ *
+ * Both are asserted here against the score path specifically. The date/list and
+ * search paths are covered by get-content-client-id-filter.test.ts.
+ *
+ * Score sorting requires an entity (it derives per-connection scoring formulas
+ * from the entity's sources), so unlike the list-path test these fixtures need
+ * a real entity + connection, and events linked to both.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const CHATGPT = 'mcp_score_path_chatgpt';
+const CLI = 'mcp_score_path_cli';
+const AGENT_A = 'agent_score_path_a';
+const AGENT_B = 'agent_score_path_b';
+
+async function registerClient(opts: {
+  id: string;
+  clientName: string;
+  userId: string;
+  organizationId: string;
+}): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO oauth_clients (id, client_name, redirect_uris, user_id, organization_id)
+    VALUES (
+      ${opts.id}, ${opts.clientName}, ARRAY['https://example.test/cb']::text[],
+      ${opts.userId}, ${opts.organizationId}
+    )
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+/**
+ * Insert an event carrying both attribution stamps. `client_id` is a real
+ * column; `agent_id` lives in metadata — the two predicates differ, so both
+ * shapes must be exercised.
+ */
+async function insertAttributedEvent(opts: {
+  organizationId: string;
+  entityId: number;
+  connectionId: number;
+  title: string;
+  clientId: string | null;
+  agentId: string | null;
+  score: number;
+  occurredAt: Date;
+}): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO events (
+      entity_ids, connection_id, organization_id, origin_id, title,
+      payload_type, payload_text, semantic_type, connector_key,
+      client_id, metadata, score, occurred_at, created_at
+    ) VALUES (
+      ARRAY[${opts.entityId}]::bigint[],
+      ${opts.connectionId},
+      ${opts.organizationId},
+      ${`score-attr-${opts.title}`},
+      ${opts.title},
+      'text',
+      ${opts.title},
+      'content',
+      'test.connector',
+      ${opts.clientId},
+      ${sql.json(opts.agentId ? { agent_id: opts.agentId } : {})},
+      ${opts.score},
+      ${opts.occurredAt},
+      NOW()
+    )
+  `;
+}
+
+describe('getContent > score path honours attribution filters', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let entityId: number;
+  let ctx: ToolContext;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Score Attribution Org' });
+    user = await createTestUser({ email: 'score-attr@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const entity = await createTestEntity({
+      name: 'Score Attribution Entity',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    entityId = entity.id;
+
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'test.connector',
+      entity_ids: [entityId],
+      created_by: user.id,
+    });
+
+    await registerClient({
+      id: CHATGPT,
+      clientName: 'ChatGPT',
+      userId: user.id,
+      organizationId: org.id,
+    });
+    await registerClient({
+      id: CLI,
+      clientName: 'Lobu CLI',
+      userId: user.id,
+      organizationId: org.id,
+    });
+
+    const t0 = new Date('2026-07-01T00:00:00Z');
+    // Deliberately give the NON-matching rows the higher score. If the filter is
+    // dropped, score ordering surfaces them first and the assertions fail loudly
+    // rather than passing by accident on ordering.
+    await insertAttributedEvent({
+      organizationId: org.id,
+      entityId,
+      connectionId: connection.id,
+      title: 'chatgpt high score row',
+      clientId: CHATGPT,
+      agentId: AGENT_A,
+      score: 99,
+      occurredAt: t0,
+    });
+    await insertAttributedEvent({
+      organizationId: org.id,
+      entityId,
+      connectionId: connection.id,
+      title: 'cli low score row',
+      clientId: CLI,
+      agentId: AGENT_B,
+      score: 1,
+      occurredAt: new Date(t0.getTime() + 1000),
+    });
+    await insertAttributedEvent({
+      organizationId: org.id,
+      entityId,
+      connectionId: connection.id,
+      title: 'unattributed row',
+      clientId: null,
+      agentId: null,
+      score: 50,
+      occurredAt: new Date(t0.getTime() + 2000),
+    });
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    } as ToolContext;
+  });
+
+  it('baseline: without a filter the score path returns every row', async () => {
+    const result = await getContent(
+      { entity_id: entityId, sort_by: 'score', limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content.map((c) => c.title).sort()).toEqual([
+      'chatgpt high score row',
+      'cli low score row',
+      'unattributed row',
+    ]);
+  });
+
+  it('client_ids scopes score-sorted rows to that client', async () => {
+    const result = await getContent(
+      { entity_id: entityId, sort_by: 'score', client_ids: [CLI], limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    // Before the fix this returned all three rows, led by the score-99 ChatGPT
+    // row — the exact "asked for one client, got everything" failure.
+    expect(result.content.map((c) => c.title)).toEqual(['cli low score row']);
+  });
+
+  it('agent_id scopes score-sorted rows to that agent (pre-existing hole)', async () => {
+    const result = await getContent(
+      { entity_id: entityId, sort_by: 'score', agent_id: AGENT_B, limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content.map((c) => c.title)).toEqual(['cli low score row']);
+  });
+
+  it('total count matches the filtered rows, not the unfiltered set', async () => {
+    // Rows and count come from two separate queries sharing one filter builder.
+    // If only the row query were fixed, has_more/pagination would still lie.
+    const result = await getContent(
+      { entity_id: entityId, sort_by: 'score', client_ids: [CHATGPT], limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content).toHaveLength(1);
+    expect(result.total).toBe(1);
+  });
+});

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -422,6 +422,7 @@ async function getContentImpl(
         feed_ids: args.feed_ids,
         run_ids: args.run_ids,
         ...(args.agent_id && { agent_id: args.agent_id }),
+        ...(args.client_ids?.length && { client_id: args.client_ids }),
         visibility_scope: visibilityScope,
         window_id: args.window_id,
         analyzed_by_watcher_id: args.analyzed_by_behavior_id,

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -381,6 +381,8 @@ async function getContentImpl(
         ...(effectiveConnectionIds?.length && { connection_ids: effectiveConnectionIds }),
         ...(args.feed_ids?.length && { feed_ids: args.feed_ids }),
         ...(args.run_ids?.length && { run_ids: args.run_ids }),
+        ...(args.agent_id && { agent_id: args.agent_id }),
+        ...(args.client_ids?.length && { client_id: args.client_ids }),
         ...(effectivePlatform && { platform: effectivePlatform }),
         ...(sinceDate && { since: sinceDate }),
         ...(untilDate && { until: untilDate }),

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -434,6 +434,11 @@ export async function fetchIncludeSuperseded(opts: {
     queryParams.push(args.agent_id);
     paramIndex += 1;
   }
+  if (args.client_ids?.length) {
+    conditions.push(`e.client_id = ANY($${paramIndex}::text[])`);
+    queryParams.push(pgTextArray(args.client_ids));
+    paramIndex += 1;
+  }
   if (args.semantic_type) {
     const types = Array.isArray(args.semantic_type)
       ? args.semantic_type
@@ -595,6 +600,12 @@ export async function fetchClassificationStats(opts: {
   if (args.agent_id) {
     conditions.push(`f.metadata->>'agent_id' = $${paramIndex++}`);
     params.push(args.agent_id);
+  }
+  // Keep the stats scope identical to the list scope — a distribution computed
+  // over a wider set than the rows it labels is simply wrong.
+  if (args.client_ids?.length) {
+    conditions.push(`f.client_id = ANY($${paramIndex++}::text[])`);
+    params.push(pgTextArray(args.client_ids));
   }
 
   // Visibility: events from connections the caller can't see must not

--- a/packages/server/src/tools/get_content/schema.ts
+++ b/packages/server/src/tools/get_content/schema.ts
@@ -54,6 +54,12 @@ export const GetContentSchema = Type.Object({
         'Limit results to memory written by this agent. Filters events where metadata.agent_id matches.',
     })
   ),
+  client_ids: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        'OAuth client IDs to filter by (events.client_id — the connected client that produced the event, e.g. a ChatGPT or CLI registration). Pass several ids to cover one client that registered more than once.',
+    })
+  ),
   platforms: Type.Optional(
     Type.Array(Type.String(), {
       description: 'Platform types to filter by (reddit, trustpilot, etc.)',

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -36,6 +36,9 @@ interface NormalizedScoreFilters {
   engagement_max?: number;
   // Additional filters to match searchContentByText
   window_id?: number;
+  /** Restrict to content some behavior has analyzed. The handler always passed
+   *  this; the builder used to ignore it — the same dropped-filter class. */
+  analyzed_by_watcher_id?: number;
   exclude_watcher_id?: number; // Exclude content already in any window for this watcher
   classification_filters?: Array<{ classifier_slug: string; value: string }>;
   classification_source?: 'user' | 'embedding' | 'llm';
@@ -190,6 +193,18 @@ async function buildFilterConditionsAndJoins(
     additionalJoins.push('JOIN watcher_window_events iwc ON iwc.event_id = f.id');
     params.push(validatedWindowId);
     filterConditions.push(`iwc.window_id = $${paramIndex++}`);
+  }
+
+  if (filters?.analyzed_by_watcher_id !== undefined) {
+    const validatedWatcherId = validateNumericId(
+      filters.analyzed_by_watcher_id,
+      'analyzed_by_watcher_id'
+    );
+    params.push(validatedWatcherId);
+    filterConditions.push(`EXISTS (
+      SELECT 1 FROM watcher_window_events iwc
+      WHERE iwc.event_id = f.id AND iwc.watcher_id = $${paramIndex++}
+    )`);
   }
 
   if (filters?.exclude_watcher_id !== undefined) {

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -1,4 +1,4 @@
-import { getDb } from '../db/client';
+import { getDb, pgTextArray } from '../db/client';
 import {
   buildFeedFilter,
   buildRunFilter,
@@ -25,6 +25,10 @@ interface NormalizedScoreFilters {
   connection_ids?: number[];
   feed_ids?: number[];
   run_ids?: number[];
+  /** Agent attribution, stored in `metadata->>'agent_id'` (mirrors params.ts $11). */
+  agent_id?: string;
+  /** OAuth client attribution, a real indexed column (mirrors params.ts $12). */
+  client_id?: string | string[];
   platform?: string;
   since?: Date;
   until?: Date;
@@ -141,6 +145,19 @@ async function buildFilterConditionsAndJoins(
   }
   if (filters?.run_ids && filters.run_ids.length > 0) {
     filterConditions.push(buildRunFilter(filters.run_ids, 'f'));
+  }
+
+  // Attribution filters. These mirror the $11/$12 predicates in
+  // content-search/params.ts so score-sort and date-sort return the same rows
+  // for the same filter — see buildStandardWhereSql.
+  if (filters?.agent_id) {
+    params.push(filters.agent_id);
+    filterConditions.push(`f.metadata->>'agent_id' = $${paramIndex++}::text`);
+  }
+  if (filters?.client_id) {
+    const clientIds = Array.isArray(filters.client_id) ? filters.client_id : [filters.client_id];
+    params.push(pgTextArray(clientIds));
+    filterConditions.push(`f.client_id = ANY($${paramIndex++}::text[])`);
   }
 
   if (filters?.platform) {

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -328,6 +328,16 @@ export async function listContentInternal(
       baseParams.push(options.agent_id);
       baseConditions.push(`f.metadata->>'agent_id' = $${baseParams.length}`);
     }
+    if (options.client_id) {
+      // `events.client_id` is a real indexed column (idx_events_client_id), not
+      // a metadata field — so this is a plain column predicate. Always ANY() so
+      // one id and a re-registered client's many ids share a single shape.
+      const clientIds = Array.isArray(options.client_id)
+        ? options.client_id
+        : [options.client_id];
+      baseParams.push(pgTextArray(clientIds));
+      baseConditions.push(`f.client_id = ANY($${baseParams.length}::text[])`);
+    }
 
     const classificationExists = buildClassificationExistsClauses(
       filtersBySlug,

--- a/packages/server/src/utils/content-search/params.ts
+++ b/packages/server/src/utils/content-search/params.ts
@@ -35,6 +35,14 @@ export function buildStandardParams(
     // Slot $11 — per-agent memory scope. WHERE template uses
     // `($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)`.
     options.agent_id ?? null,
+    // Slot $12 — per-OAuth-client scope. Always an array (a client that
+    // re-registers has several ids under one name), so the predicate is a
+    // single `= ANY(...)` for both the one-id and many-id cases. pgTextArray
+    // because `sql.unsafe(...)` does not auto-cast JS arrays — see the
+    // semantic_type slot above.
+    options.client_id
+      ? pgTextArray(Array.isArray(options.client_id) ? options.client_id : [options.client_id])
+      : null,
   ];
 }
 
@@ -62,7 +70,8 @@ export function buildStandardWhereSql(entityLinkSql: string): string {
           ))
           AND ($9::text[] IS NULL OR f.semantic_type = ANY($9::text[]))
           AND ($10::text IS NULL OR f.interaction_status = $10::text)
-          AND ($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)`;
+          AND ($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)
+          AND ($12::text[] IS NULL OR f.client_id = ANY($12::text[]))`;
 }
 
 export const WINDOW_JOIN_SQL = `LEFT JOIN watcher_window_events iwf

--- a/packages/server/src/utils/content-search/search-path.ts
+++ b/packages/server/src/utils/content-search/search-path.ts
@@ -96,15 +96,17 @@ export async function searchContentBySingleQuery(
   const searchEntityScopes =
     entityId != null ? await fetchEntityIdentityScopes(sql, entityId) : [];
 
-  // Slot $11 is the agent_id memory-scope filter — bumps orgScope to $12.
+  // Slots $11/$12 are the agent_id memory-scope and client_id filters — they
+  // bump orgScope to $13. Keep this in step with buildStandardParams: the two
+  // param lists are positional mirrors, so an added slot shifts BOTH.
   const orgScope = buildOrgScopeWhere({
     entity_id: entityId,
     organization_id: options.organization_id,
-    baseParamIndex: 12,
+    baseParamIndex: 13,
   });
   // Exclude-watcher param slot sits immediately after orgScope so its $N index
   // is stable regardless of whether an embedding param follows.
-  const excludeParamIdx = 12 + orgScope.params.length;
+  const excludeParamIdx = 13 + orgScope.params.length;
   const excludeClause = buildExcludeWatcherClause(
     options.exclude_watcher_id,
     excludeParamIdx
@@ -171,6 +173,7 @@ export async function searchContentBySingleQuery(
           AND ($9::text[] IS NULL OR f.semantic_type = ANY($9::text[]))
           AND ($10::text IS NULL OR f.interaction_status = $10::text)
           AND ($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)
+          AND ($12::text[] IS NULL OR f.client_id = ANY($12::text[]))
           ${excludeClause.sql}
           ${visibilityClause.sql}
           ${orgScope.sql}${entityTypesClause.sql}`;
@@ -462,8 +465,13 @@ export async function searchContentBySingleQuery(
       : null,
     options.interaction_status ?? null,
     // Slot $11 — per-agent memory scope. See buildStandardParams for the
-    // mirror call site. Bumps orgScope to $12 (set above).
+    // mirror call site.
     options.agent_id ?? null,
+    // Slot $12 — per-OAuth-client scope. Together with $11 this bumps orgScope
+    // to $13 (set above).
+    options.client_id
+      ? pgTextArray(Array.isArray(options.client_id) ? options.client_id : [options.client_id])
+      : null,
     ...orgScope.params,
     ...excludeClause.params,
     ...visibilityClause.params,

--- a/packages/server/src/utils/content-search/types.ts
+++ b/packages/server/src/utils/content-search/types.ts
@@ -50,6 +50,16 @@ export interface ContentSearchOptions {
   // (`entity_identities.namespace`) — see identity-normalize.ts.
   agent_id?: string;
 
+  // Per-OAuth-client scope — the `events.client_id` COLUMN (indexed,
+  // FK → oauth_clients), not a metadata field. Scopes the timeline to what one
+  // registered client did: the MCP activity view passes it alongside
+  // `semantic_type: 'audit'` to show a connected client's tool calls.
+  //
+  // A client that re-registers gets a NEW oauth_clients row with the same
+  // `client_name`, so callers wanting "everything ChatGPT did" pass every id
+  // for that name (see listMcpClientActivity) rather than a single id.
+  client_id?: string | string[];
+
   // Classification options (only JOINs when needed)
   include_classifications?: boolean; // Include classifications in results
   classification_filters?: ClassificationFilter[]; // Filter by classifications

--- a/packages/server/src/utils/content-search/types.ts
+++ b/packages/server/src/utils/content-search/types.ts
@@ -52,12 +52,11 @@ export interface ContentSearchOptions {
 
   // Per-OAuth-client scope — the `events.client_id` COLUMN (indexed,
   // FK → oauth_clients), not a metadata field. Scopes the timeline to what one
-  // registered client did: the MCP activity view passes it alongside
-  // `semantic_type: 'audit'` to show a connected client's tool calls.
+  // registered client did, typically alongside `semantic_type: 'audit'`.
   //
-  // A client that re-registers gets a NEW oauth_clients row with the same
-  // `client_name`, so callers wanting "everything ChatGPT did" pass every id
-  // for that name (see listMcpClientActivity) rather than a single id.
+  // Accepts an array because a client that re-registers gets a NEW
+  // oauth_clients row under the same `client_name` (prod: "Lobu CLI" has 6
+  // ids), so "everything ChatGPT did" means every id for that name.
   client_id?: string | string[];
 
   // Classification options (only JOINs when needed)


### PR DESCRIPTION
## What

Adds a `client_ids` filter to `read_knowledge` / the events query paths, and fixes a class of silently-dropped filters on the score-sort path.

**1. `client_ids` filter (new capability).** `events.client_id` is a real indexed column (`idx_events_client_id`, FK → `oauth_clients`) written per tool call, but nothing could filter on it. Now you can ask "what did this MCP client do here". Accepts an array because a client that re-registers gets a new `oauth_clients` row under the same name (prod: "Lobu CLI" has 6 ids).

**2. Dropped-filter class on the score path (bug fix).** `get_content` has four filter-application sites. The `sort_by === 'score' && entity_id` branch runs through its own builder (`buildFilterConditionsAndJoins`), and both it and the handler's filters object enumerate fields explicitly — so anything not listed is **silently dropped**. The query returns unfiltered rows rather than erroring, which is the worst failure shape: you ask for one client and get everything, led by whatever scored highest.

Three filters were missing there, so this is a class, not an instance:

| filter | status |
|---|---|
| `client_ids` | added with the filter itself |
| `agent_id` | pre-existing hole |
| `analyzed_by_behavior_id` | pre-existing hole — the handler *always* forwarded it; the builder had no clause |

Fixed all three in one pass per the "fix the class, not the instance" rule.

## Red → green evidence

New test file failing against the unfixed source — the filter is dropped and the highest-scoring non-matching row leads:

```
× client_ids scopes score-sorted rows to that client
  AssertionError: expected [ 'chatgpt high score row', …(2) ] to deeply equal [ 'cli low score row' ]
× agent_id scopes score-sorted rows to that agent
× total count matches the filtered rows, not the unfiltered set
  AssertionError: expected [ { id: 1, …(43) }, …(2) ] to have a length of 1 but got 3

 Tests  3 failed | 1 passed (4)
```

After the fix, whole events integration suite:

```
 Test Files  32 passed (32)
      Tests  149 passed (149)
```

## Mutation testing

Each predicate was individually neutered (`TRUE OR <predicate>`) to prove the tests bite and are correctly isolated:

| mutation | result |
|---|---|
| `agent_id` → no-op | 1 failed — only the `agent_id` test |
| `client_id` → no-op | 2 failed — the `client_ids` test + the count test |
| `analyzed_by` → no-op | 1 failed — only the `analyzed_by_behavior_id` test |

The count assertion exists because rows and `total` come from two separate queries sharing one builder; fixing only the row query would leave pagination lying.

Fixtures deliberately give the **non-matching** rows the higher score, so a dropped filter surfaces them first and fails loudly rather than passing by accident on ordering.

## Notes for review

- The `client_id` filter took positional slot `$12` in the search path, shifting `orgScope`/`exclude`/`visibility`/`entity-types`/`cursor` to `$13`. That kind of drift typechecks fine and fails only against real Postgres, so both the list path and the search path are exercised against a real DB.
- `review-fix` also suggested two classification-filter tests. Dropped: verified against unmodified `origin/main` that the fixture they introduce fails there identically, so they assert a **pre-existing** gap unrelated to this branch. Worth a separate look, not this PR.
- Scope note: this branch previously carried a derived "connected MCP clients in the Recent sidebar" feature. That was removed — `GET /api/{org}/clients` already models connected clients better (status, authState, lastSeenAt, revoke), and a second derived model was the wrong shape. The surface for it will reuse that existing API instead. Only the events filter, which stands on its own, remains here.

## Testing

- [x] `make pre-pr` — build, strict typecheck, knip, biome, exposed-surface naming
- [x] Events integration suite: 149/149 against Postgres 18 + pgvector
- [x] Red → green captured for every fixed filter
- [x] Mutation-tested each predicate individually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional client ID filter to content and audit event searches.
  * Client filtering now works across list, text search, score-sorted results, superseded history, and classification statistics.
  * Results and totals are correctly restricted to matching OAuth client registrations.

* **Bug Fixes**
  * Prevented filtered searches from returning unrelated or unattributed events.
  * Preserved client scoping when combining filters such as agents, behaviors, and superseded content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->