### PR TITLE
fix(server): archive device connector definitions the fleet no longer serves

### DIFF
--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -264,6 +264,122 @@ describe('device connector manifests', () => {
     expect(await readUpdatedAt()).toEqual(afterResync);
   });
 
+  it('archives a definition whose key the fleet no longer advertises', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    // Register the connector, then poll again WITHOUT it — the shape left
+    // behind when a per-capability connector is folded into a broader one
+    // (prod `chrome.tabs` / `browser.*` after the `chrome` v0.2 consolidation).
+    // Reconcile used to only pause feeds, so the definition stayed `active`
+    // forever and kept rendering on the connectors list as "Needs setup".
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    expect(await readDefinition(orgId)).not.toBeNull();
+
+    expect((await poll(workerId, [])).status).toBe(200);
+
+    const rows = (await sql`
+      SELECT status FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+    `) as unknown as Array<{ status: string }>;
+    expect(rows.map((r) => r.status)).toEqual(['archived']);
+
+    // Idempotent: this pass runs on EVERY poll, so a re-archive that kept
+    // stamping updated_at would churn the row forever.
+    const stamp = async () => {
+      const r = (await sql`
+        SELECT updated_at FROM connector_definitions
+        WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY} LIMIT 1
+      `) as unknown as Array<{ updated_at: string }>;
+      return r[0]?.updated_at;
+    };
+    const afterFirst = await stamp();
+    expect((await poll(workerId, [])).status).toBe(200);
+    expect(await stamp()).toEqual(afterFirst);
+  });
+
+  it('leaves a second device’s connectors alone when one device drops its manifests', async () => {
+    const { userId, orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    // A second device on the SAME user, serving a different connector. Manifests
+    // are stored per device and read back across the whole fleet, so a poll from
+    // device A must never archive what device B still serves — the failure mode
+    // that would quietly wipe a user's Mac connectors every time Chrome polled.
+    const otherWorkerId = `wk-${generateSecureToken(6)}`;
+    const otherKey = 'apple.test_other_device';
+    await sql`
+      INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
+      VALUES (${userId}, ${otherWorkerId}, 'macos', '0.1.0', ${sql.json([])}, 'Other Device', ${orgId})
+    `;
+    expect((await poll(otherWorkerId, [manifest({ key: otherKey })])).status).toBe(200);
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+
+    // Device A drops its manifests; device B has not polled again.
+    expect((await poll(workerId, [])).status).toBe(200);
+
+    const statusOf = async (key: string) => {
+      const rows = (await sql`
+        SELECT status FROM connector_definitions
+        WHERE organization_id = ${orgId} AND key = ${key}
+      `) as unknown as Array<{ status: string }>;
+      return rows.map((r) => r.status);
+    };
+    expect(await statusOf(CONNECTOR_KEY)).toEqual(['archived']);
+    expect(await statusOf(otherKey)).toEqual(['active']);
+  });
+
+  it('keeps a definition active when a connection has unknown provenance', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    // `connections.created_by` is nullable. A bare `NOT (created_by = $1 AND …)`
+    // is NULL for a NULL creator, which SQL reads as "no blocking row" — so the
+    // archive would fire on a connection we cannot attribute to ourselves.
+    // Unknown provenance must protect the definition, not permit its removal.
+    await sql`
+      UPDATE connections SET created_by = NULL
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+    `;
+
+    expect((await poll(workerId, [])).status).toBe(200);
+
+    const rows = (await sql`
+      SELECT status FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+    `) as unknown as Array<{ status: string }>;
+    expect(rows.map((r) => r.status)).toEqual(['active']);
+  });
+
+  it('keeps a definition active when a user-configured connection references it', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    // Someone OTHER than the polling device owner configured this connector, so
+    // it is not reconcile's own auto-wired row. A poll that no longer sees the
+    // manifest must leave it — retiring machinery we created is fine, deleting
+    // a connector another human set up is not.
+    const otherUserId = `user_${generateSecureToken(4)}`;
+    await sql`
+      INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+      VALUES (${otherUserId}, 'Other Owner', ${`${otherUserId}@test.local`}, true, NOW(), NOW())
+    `;
+    await sql`
+      UPDATE connections SET created_by = ${otherUserId}
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+    `;
+
+    expect((await poll(workerId, [])).status).toBe(200);
+
+    const rows = (await sql`
+      SELECT status FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+    `) as unknown as Array<{ status: string }>;
+    expect(rows.map((r) => r.status)).toEqual(['active']);
+  });
+
   it('drops a manifest whose key does not belong to the polling platform', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
 

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -268,11 +268,8 @@ describe('device connector manifests', () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const sql = getTestDb();
 
-    // Register the connector, then poll again WITHOUT it — the shape left
-    // behind when a per-capability connector is folded into a broader one
-    // (prod `chrome.tabs` / `browser.*` after the `chrome` v0.2 consolidation).
-    // Reconcile used to only pause feeds, so the definition stayed `active`
-    // forever and kept rendering on the connectors list as "Needs setup".
+    // Reconcile used to skip keys that vanished from the source inventory, so
+    // their definitions stayed active and rendered as "Needs setup" forever.
     expect((await poll(workerId, [manifest()])).status).toBe(200);
     expect(await readDefinition(orgId)).not.toBeNull();
 
@@ -283,8 +280,15 @@ describe('device connector manifests', () => {
       WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
     `) as unknown as Array<{ status: string }>;
     expect(rows.map((r) => r.status)).toEqual(['archived']);
+    const liveConnections = await sql`
+      SELECT id FROM connections
+      WHERE organization_id = ${orgId}
+        AND connector_key = ${CONNECTOR_KEY}
+        AND deleted_at IS NULL
+    `;
+    expect(liveConnections).toHaveLength(0);
 
-    // Idempotent: this pass runs on EVERY poll, so a re-archive that kept
+    // Idempotent: this pass runs on every poll, so a re-archive that kept
     // stamping updated_at would churn the row forever.
     const stamp = async () => {
       const r = (await sql`
@@ -296,6 +300,23 @@ describe('device connector manifests', () => {
     const afterFirst = await stamp();
     expect((await poll(workerId, [])).status).toBe(200);
     expect(await stamp()).toEqual(afterFirst);
+
+    // Advertising the key again creates one new active definition and live
+    // connection while retaining the archived rows for historical events.
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    const restoredDefinitions = (await sql`
+      SELECT status FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+      ORDER BY id
+    `) as unknown as Array<{ status: string }>;
+    expect(restoredDefinitions.map((r) => r.status)).toEqual(['archived', 'active']);
+    const restoredConnections = await sql`
+      SELECT id FROM connections
+      WHERE organization_id = ${orgId}
+        AND connector_key = ${CONNECTOR_KEY}
+        AND deleted_at IS NULL
+    `;
+    expect(restoredConnections).toHaveLength(1);
   });
 
   it('leaves a second device’s connectors alone when one device drops its manifests', async () => {
@@ -380,6 +401,32 @@ describe('device connector manifests', () => {
     expect(rows.map((r) => r.status)).toEqual(['active']);
   });
 
+  it('keeps a definition active when the owner has customized its connection', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    await sql`
+      UPDATE connections SET config = ${sql.json({ user_configured: true })}
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+    `;
+
+    expect((await poll(workerId, [])).status).toBe(200);
+
+    const definitions = (await sql`
+      SELECT status FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+    `) as unknown as Array<{ status: string }>;
+    expect(definitions.map((r) => r.status)).toEqual(['active']);
+    const liveConnections = await sql`
+      SELECT id FROM connections
+      WHERE organization_id = ${orgId}
+        AND connector_key = ${CONNECTOR_KEY}
+        AND deleted_at IS NULL
+    `;
+    expect(liveConnections).toHaveLength(1);
+  });
+
   it('drops a manifest whose key does not belong to the polling platform', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
 
@@ -423,6 +470,38 @@ describe('device connector manifests', () => {
       LIMIT 1
     `) as unknown as Array<{ connector_manifests: Record<string, unknown> }>;
     expect(rows[0]?.connector_manifests).toEqual({});
+  });
+
+  it('preserves the last valid inventory when a later manifest payload is rejected', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    const invalidManifest = manifest({
+      feeds_schema: {
+        snapshots: {
+          eventKinds: {
+            snapshot: {
+              entityLinks: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect((await poll(workerId, [invalidManifest])).status).toBe(200);
+
+    const definitions = (await sql`
+      SELECT status FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+    `) as unknown as Array<{ status: string }>;
+    expect(definitions.map((r) => r.status)).toEqual(['active']);
+    const devices = (await sql`
+      SELECT connector_manifests
+      FROM device_workers
+      WHERE worker_id = ${workerId}
+    `) as unknown as Array<{ connector_manifests: Record<string, unknown> }>;
+    expect(Object.keys(devices[0]?.connector_manifests ?? {})).toEqual([CONNECTOR_KEY]);
   });
 
   it('keeps manifest inventory separate from live permission state so revoked capabilities pause feeds', async () => {

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -264,14 +264,18 @@ describe('device connector manifests', () => {
     expect(await readUpdatedAt()).toEqual(afterResync);
   });
 
-  it('archives a definition whose key the fleet no longer advertises', async () => {
+  it('archives an unreferenced manifest definition the fleet no longer advertises', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const sql = getTestDb();
 
     // Reconcile used to skip keys that vanished from the source inventory, so
-    // their definitions stayed active and rendered as "Needs setup" forever.
+    // their definitions stayed active indefinitely.
     expect((await poll(workerId, [manifest()])).status).toBe(200);
     expect(await readDefinition(orgId)).not.toBeNull();
+    await sql`
+      UPDATE connections SET deleted_at = NOW()
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+    `;
 
     expect((await poll(workerId, [])).status).toBe(200);
 
@@ -302,7 +306,7 @@ describe('device connector manifests', () => {
     expect(await stamp()).toEqual(afterFirst);
 
     // Advertising the key again creates one new active definition and live
-    // connection while retaining the archived rows for historical events.
+    // connection while retaining the archived rows.
     expect((await poll(workerId, [manifest()])).status).toBe(200);
     const restoredDefinitions = (await sql`
       SELECT status FROM connector_definitions
@@ -323,10 +327,8 @@ describe('device connector manifests', () => {
     const { userId, orgId, workerId } = await seedDeviceOwner();
     const sql = getTestDb();
 
-    // A second device on the SAME user, serving a different connector. Manifests
-    // are stored per device and read back across the whole fleet, so a poll from
-    // device A must never archive what device B still serves — the failure mode
-    // that would quietly wipe a user's Mac connectors every time Chrome polled.
+    // Manifests are stored per device and read across the whole fleet, so a poll
+    // from device A must not archive what device B still serves.
     const otherWorkerId = `wk-${generateSecureToken(6)}`;
     const otherKey = 'apple.test_other_device';
     await sql`
@@ -335,6 +337,11 @@ describe('device connector manifests', () => {
     `;
     expect((await poll(otherWorkerId, [manifest({ key: otherKey })])).status).toBe(200);
     expect((await poll(workerId, [manifest()])).status).toBe(200);
+    await sql`
+      UPDATE connections SET deleted_at = NOW()
+      WHERE organization_id = ${orgId}
+        AND connector_key IN (${CONNECTOR_KEY}, ${otherKey})
+    `;
 
     // Device A drops its manifests; device B has not polled again.
     expect((await poll(workerId, [])).status).toBe(200);
@@ -350,67 +357,11 @@ describe('device connector manifests', () => {
     expect(await statusOf(otherKey)).toEqual(['active']);
   });
 
-  it('keeps a definition active when a connection has unknown provenance', async () => {
+  it('keeps a definition active while the owner has a default-shaped connection', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const sql = getTestDb();
 
     expect((await poll(workerId, [manifest()])).status).toBe(200);
-    // `connections.created_by` is nullable. A bare `NOT (created_by = $1 AND …)`
-    // is NULL for a NULL creator, which SQL reads as "no blocking row" — so the
-    // archive would fire on a connection we cannot attribute to ourselves.
-    // Unknown provenance must protect the definition, not permit its removal.
-    await sql`
-      UPDATE connections SET created_by = NULL
-      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
-    `;
-
-    expect((await poll(workerId, [])).status).toBe(200);
-
-    const rows = (await sql`
-      SELECT status FROM connector_definitions
-      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
-    `) as unknown as Array<{ status: string }>;
-    expect(rows.map((r) => r.status)).toEqual(['active']);
-  });
-
-  it('keeps a definition active when a user-configured connection references it', async () => {
-    const { orgId, workerId } = await seedDeviceOwner();
-    const sql = getTestDb();
-
-    expect((await poll(workerId, [manifest()])).status).toBe(200);
-    // Someone OTHER than the polling device owner configured this connector, so
-    // it is not reconcile's own auto-wired row. A poll that no longer sees the
-    // manifest must leave it — retiring machinery we created is fine, deleting
-    // a connector another human set up is not.
-    const otherUserId = `user_${generateSecureToken(4)}`;
-    await sql`
-      INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
-      VALUES (${otherUserId}, 'Other Owner', ${`${otherUserId}@test.local`}, true, NOW(), NOW())
-    `;
-    await sql`
-      UPDATE connections SET created_by = ${otherUserId}
-      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
-    `;
-
-    expect((await poll(workerId, [])).status).toBe(200);
-
-    const rows = (await sql`
-      SELECT status FROM connector_definitions
-      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
-    `) as unknown as Array<{ status: string }>;
-    expect(rows.map((r) => r.status)).toEqual(['active']);
-  });
-
-  it('keeps a definition active when the owner has customized its connection', async () => {
-    const { orgId, workerId } = await seedDeviceOwner();
-    const sql = getTestDb();
-
-    expect((await poll(workerId, [manifest()])).status).toBe(200);
-    await sql`
-      UPDATE connections SET config = ${sql.json({ user_configured: true })}
-      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
-    `;
-
     expect((await poll(workerId, [])).status).toBe(200);
 
     const definitions = (await sql`
@@ -425,6 +376,57 @@ describe('device connector manifests', () => {
         AND deleted_at IS NULL
     `;
     expect(liveConnections).toHaveLength(1);
+  });
+
+  it('does not archive a device-gated definition installed from a non-manifest source', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    await sql`
+      UPDATE connector_versions
+      SET source_path = 'custom/device-connector.ts'
+      WHERE connector_key = ${CONNECTOR_KEY}
+        AND (organization_id = ${orgId} OR organization_id IS NULL)
+    `;
+    await sql`
+      UPDATE connections SET deleted_at = NOW()
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+    `;
+
+    expect((await poll(workerId, [])).status).toBe(200);
+
+    const definitions = (await sql`
+      SELECT status FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+    `) as unknown as Array<{ status: string }>;
+    expect(definitions.map((r) => r.status)).toEqual(['active']);
+  });
+
+  it('archives an unreferenced definition left by a formerly bundled device connector', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    expect((await poll(workerId, [manifest()])).status).toBe(200);
+    await sql`
+      UPDATE connector_versions
+      SET organization_id = NULL,
+          source_path = 'browser/evaluate.ts'
+      WHERE organization_id = ${orgId}
+        AND connector_key = ${CONNECTOR_KEY}
+    `;
+    await sql`
+      UPDATE connections SET deleted_at = NOW()
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+    `;
+
+    expect((await poll(workerId, [])).status).toBe(200);
+
+    const definitions = (await sql`
+      SELECT status FROM connector_definitions
+      WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+    `) as unknown as Array<{ status: string }>;
+    expect(definitions.map((r) => r.status)).toEqual(['archived']);
   });
 
   it('drops a manifest whose key does not belong to the polling platform', async () => {

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -37,6 +37,11 @@ export interface DeviceConnectorSource {
   manifestHash: string;
 }
 
+interface DeviceManifestValidationResult {
+  manifests: StoredDeviceManifest[];
+  accepted: boolean;
+}
+
 export function deviceManifestHash(manifest: DeviceConnectorManifest): string {
   const { manifest_hash: _ignored, ...payload } = manifest;
   for (const key of [
@@ -88,22 +93,23 @@ export function validateDeviceConnectorManifests(params: {
   platform: string | null;
   capabilities: readonly string[];
   manifests: unknown;
-}): StoredDeviceManifest[] {
+}): DeviceManifestValidationResult {
   const { platform, manifests } = params;
-  if (!Array.isArray(manifests)) return [];
-  if (!platform || !isKnownPlatform(platform)) return [];
+  if (!Array.isArray(manifests)) return { manifests: [], accepted: false };
+  if (!platform || !isKnownPlatform(platform)) return { manifests: [], accepted: false };
   if (manifests.length > MAX_MANIFESTS_PER_POLL) {
     logger.warn({ platform, count: manifests.length }, '[device-manifests] too many manifests; dropping payload');
-    return [];
+    return { manifests: [], accepted: false };
   }
   const encodedBytes = Buffer.byteLength(JSON.stringify(manifests), 'utf8');
   if (encodedBytes > MAX_MANIFEST_BYTES) {
     logger.warn({ platform, encodedBytes }, '[device-manifests] manifest payload too large; dropping payload');
-    return [];
+    return { manifests: [], accepted: false };
   }
 
   const seen = new Set<string>();
   const valid: StoredDeviceManifest[] = [];
+  let accepted = true;
   for (const raw of manifests) {
     try {
       const manifest = normalizeManifest(raw);
@@ -134,13 +140,14 @@ export function validateDeviceConnectorManifests(params: {
         manifest,
       });
     } catch (err) {
+      accepted = false;
       logger.warn(
         { platform, err: err instanceof Error ? err.message : String(err) },
         '[device-manifests] dropped invalid manifest'
       );
     }
   }
-  return valid;
+  return { manifests: valid, accepted };
 }
 
 export async function getDeviceManifestSourcesForUser(params: {

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -389,6 +389,106 @@ async function pauseStaleDeviceFeeds(userId: string, organizationId: string, con
 }
 
 /**
+ * Archive device-connector definitions in the user's personal org whose key no
+ * longer appears in ANY source the fleet can serve — the catalog or a device
+ * manifest. {@link pauseStaleDeviceFeeds} only handles keys we still know about
+ * (capability temporarily absent); a key that vanished entirely is never
+ * visited by the reconcile loop at all, so its definition stayed `active`
+ * forever and kept rendering on the connectors list as a permanently
+ * "Needs setup" connector. That is exactly what the `chrome` v0.2 consolidation
+ * left behind in prod: `browser.evaluate` / `browser.fill_form` /
+ * `browser.page_text` / `chrome.tabs` became actions + feeds on `chrome`, and
+ * their standalone definitions outlived the manifests that created them.
+ *
+ * Scoped deliberately narrowly:
+ * - `required_capability IS NOT NULL` — only device connectors. An org-installed
+ *   API connector (github, slack) has no capability and must never be touched.
+ * - every surviving connection must be one WE auto-wired — the same signature
+ *   {@link pauseStaleDeviceFeeds} uses to recognise its own rows (`created_by`
+ *   = the polling user, `auth_profile_id IS NULL`, personal org). Those carry no
+ *   credentials and no user intent; reconcile created them and reconcile
+ *   retires them. A connection the user built by hand, or one bound to an auth
+ *   profile, makes the whole definition off-limits — deleting a connector
+ *   someone deliberately configured is not ours to do from a poll handler.
+ * - `status = 'active'` — archiving is idempotent across polls.
+ *
+ * The auto-wired connections are soft-deleted in the same statement, since a
+ * live connection pointing at an archived definition is the orphaned-connector
+ * state that `queue-service` has to defend against (a run nothing can claim).
+ * `events` those connections already produced are untouched — that table is
+ * append-only, and the rows stay reachable through the soft-deleted connection.
+ *
+ * Reversible by construction: the unique index on (organization_id, key) is
+ * partial on `status = 'active'`, so if a device advertises the key again
+ * `upsertConnectorDefinitionRecords` inserts a fresh active row and
+ * `ensureDeviceConnectorWired` re-wires a connection. Best-effort.
+ */
+async function archiveVanishedDeviceConnectors(
+  userId: string,
+  organizationId: string,
+  liveKeys: string[]
+): Promise<void> {
+  const sql = getDb();
+  try {
+    const archived = await sql.begin(async (tx) => {
+      const rows = (await tx`
+        UPDATE connector_definitions cd
+        SET status = 'archived', updated_at = NOW()
+        WHERE cd.organization_id = ${organizationId}
+          AND cd.status = 'active'
+          AND cd.required_capability IS NOT NULL
+          AND NOT (cd.key = ANY(${pgTextArray(liveKeys)}::text[]))
+          AND NOT EXISTS (
+            SELECT 1 FROM connections c
+            WHERE c.organization_id = cd.organization_id
+              AND c.connector_key = cd.key
+              AND c.deleted_at IS NULL
+              -- Fails CLOSED on unknown provenance: created_by is nullable, so a
+              -- bare NOT (c.created_by = $1 AND ...) evaluates to NULL for a
+              -- NULL creator, which the subquery reads as "no blocking row" --
+              -- i.e. an orphaned connection would silently permit the archive.
+              -- COALESCE to '' makes it a definite TRUE so anything we cannot
+              -- positively identify as our own auto-wired row protects the
+              -- definition instead.
+              AND NOT (COALESCE(c.created_by, '') = ${userId} AND c.auth_profile_id IS NULL)
+          )
+        RETURNING cd.key
+      `) as unknown as Array<{ key: string }>;
+
+      if (rows.length > 0) {
+        const keys = rows.map((r) => r.key);
+        // Deliberately NOT the COALESCE form used in the guard above: there we
+        // needed unknown provenance to COUNT (protect the definition), here we
+        // need it to be EXCLUDED (never delete a row we can't attribute to
+        // ourselves). Both directions are "fail closed" — do not unify them.
+        await tx`
+          UPDATE connections
+          SET deleted_at = NOW(), updated_at = NOW()
+          WHERE organization_id = ${organizationId}
+            AND connector_key = ANY(${pgTextArray(keys)}::text[])
+            AND created_by = ${userId}
+            AND auth_profile_id IS NULL
+            AND deleted_at IS NULL
+        `;
+      }
+      return rows;
+    });
+
+    if (archived.length > 0) {
+      logger.info(
+        { userId, organizationId, keys: archived.map((r) => r.key) },
+        '[device-connectors] Archived definitions no longer served by any device manifest'
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      { userId, organizationId, err: errorMessage(err) },
+      '[device-connectors] Failed to archive vanished device connector definitions'
+    );
+  }
+}
+
+/**
  * Reconcile a user's device connectors against what their device fleet can
  * actually serve. The set of device connectors comes from the catalog (any
  * bundled connector with a `runtime` block + a `requiredCapability`); the set of
@@ -404,6 +504,13 @@ export async function reconcileDeviceCapabilities(userId: string): Promise<void>
   const sql = getDb();
 
   let bundledDeviceConnectors: BundledDeviceConnector[];
+  // Both connector sources are fail-soft (empty on error), which makes "no
+  // sources" ambiguous: nothing is served, or we failed to look. Only the
+  // latter must suppress the archive pass below — an empty-but-successful read
+  // is a legitimate "this fleet serves nothing", and is in fact the normal
+  // state for a Chrome-only user (no bundled device connectors exist server
+  // side; every one of them arrives as a device manifest).
+  let sourcesReadable = true;
   try {
     bundledDeviceConnectors = await getBundledDeviceConnectors();
   } catch (err) {
@@ -412,6 +519,7 @@ export async function reconcileDeviceCapabilities(userId: string): Promise<void>
       '[device-connectors] Failed to read device connector catalog'
     );
     bundledDeviceConnectors = [];
+    sourcesReadable = false;
   }
 
   // Device data ALWAYS lands in the user's personal org — device tokens are
@@ -471,6 +579,7 @@ export async function reconcileDeviceCapabilities(userId: string): Promise<void>
       { userId, err: errorMessage(err) },
       '[device-connectors] Failed to read device connector manifests'
     );
+    sourcesReadable = false;
   }
 
   const byKey = new Map<
@@ -480,6 +589,16 @@ export async function reconcileDeviceCapabilities(userId: string): Promise<void>
   >();
   for (const dc of bundledDeviceConnectors) byKey.set(dc.key, dc);
   for (const src of manifestSources) byKey.set(src.key, { ...src, source: 'device-manifest' });
+
+  // Runs BEFORE the early return: a fleet that advertises nothing is precisely
+  // the case where every device definition in the org has gone stale, so
+  // bailing on an empty `byKey` would skip the one pass that can clean it up.
+  // Gated on `sourcesReadable` rather than on `byKey.size` — a transient read
+  // failure must never be read as "the fleet serves nothing" and archive a
+  // user's whole working set.
+  if (sourcesReadable) {
+    await archiveVanishedDeviceConnectors(userId, personalOrgId, [...byKey.keys()]);
+  }
   if (byKey.size === 0) return;
 
   await Promise.allSettled(

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -55,7 +55,7 @@ async function ensureDeviceConnectorWired(
   connectorKey: string,
   declaredFeedKeys: string[],
   matchingDeviceIds: string[],
-  source?: { metadata: ConnectorMetadata; sourcePath: string }
+  source?: { metadata: ConnectorMetadata; sourcePath: string; manifestHash: string }
 ): Promise<void> {
   const sql = getDb();
 
@@ -233,6 +233,20 @@ async function ensureDeviceConnectorWired(
       // both reach here, but only one holds the lock at a time, so the
       // existence-check-then-insert below is atomic.
       await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
+      if (source) {
+        // A newer poll may have removed this manifest while this reconcile was
+        // waiting for the lock. Re-check the stored fleet inventory so an older
+        // poll cannot resurrect a connector the newer poll just retired.
+        const stillAdvertised = await tx`
+          SELECT 1
+          FROM device_workers
+          WHERE user_id = ${userId}
+            AND last_seen_at > now() - ${DEVICE_WORKER_FRESH_INTERVAL}::interval
+            AND (connector_manifests -> ${connectorKey}) ->> 'manifest_hash' = ${source.manifestHash}
+          LIMIT 1
+        `;
+        if (stillAdvertised.length === 0) return;
+      }
 
       // 2. Ensure the connector definition + version are installed (idempotent).
       await upsertConnectorDefinitionRecords({
@@ -389,39 +403,12 @@ async function pauseStaleDeviceFeeds(userId: string, organizationId: string, con
 }
 
 /**
- * Archive device-connector definitions in the user's personal org whose key no
- * longer appears in ANY source the fleet can serve — the catalog or a device
- * manifest. {@link pauseStaleDeviceFeeds} only handles keys we still know about
- * (capability temporarily absent); a key that vanished entirely is never
- * visited by the reconcile loop at all, so its definition stayed `active`
- * forever and kept rendering on the connectors list as a permanently
- * "Needs setup" connector. That is exactly what the `chrome` v0.2 consolidation
- * left behind in prod: `browser.evaluate` / `browser.fill_form` /
- * `browser.page_text` / `chrome.tabs` became actions + feeds on `chrome`, and
- * their standalone definitions outlived the manifests that created them.
- *
- * Scoped deliberately narrowly:
- * - `required_capability IS NOT NULL` — only device connectors. An org-installed
- *   API connector (github, slack) has no capability and must never be touched.
- * - every surviving connection must be one WE auto-wired — the same signature
- *   {@link pauseStaleDeviceFeeds} uses to recognise its own rows (`created_by`
- *   = the polling user, `auth_profile_id IS NULL`, personal org). Those carry no
- *   credentials and no user intent; reconcile created them and reconcile
- *   retires them. A connection the user built by hand, or one bound to an auth
- *   profile, makes the whole definition off-limits — deleting a connector
- *   someone deliberately configured is not ours to do from a poll handler.
- * - `status = 'active'` — archiving is idempotent across polls.
- *
- * The auto-wired connections are soft-deleted in the same statement, since a
- * live connection pointing at an archived definition is the orphaned-connector
- * state that `queue-service` has to defend against (a run nothing can claim).
- * `events` those connections already produced are untouched — that table is
- * append-only, and the rows stay reachable through the soft-deleted connection.
- *
- * Reversible by construction: the unique index on (organization_id, key) is
- * partial on `status = 'active'`, so if a device advertises the key again
- * `upsertConnectorDefinitionRecords` inserts a fresh active row and
- * `ensureDeviceConnectorWired` re-wires a connection. Best-effort.
+ * Archive org-scoped device definitions absent from both the bundled catalog
+ * and every fresh device manifest. Only the exact auto-wire connection shape
+ * may be retired; user-modified or unknown-provenance rows protect the
+ * definition. The wire and archive paths share a per-key lock and re-check the
+ * stored manifest inventory so concurrent polls cannot leave contradictory
+ * definition and connection state. Best-effort.
  */
 async function archiveVanishedDeviceConnectors(
   userId: string,
@@ -431,6 +418,19 @@ async function archiveVanishedDeviceConnectors(
   const sql = getDb();
   try {
     const archived = await sql.begin(async (tx) => {
+      const candidates = (await tx`
+        SELECT key
+        FROM connector_definitions
+        WHERE organization_id = ${organizationId}
+          AND status = 'active'
+          AND required_capability IS NOT NULL
+          AND NOT (key = ANY(${pgTextArray(liveKeys)}::text[]))
+        ORDER BY key
+      `) as unknown as Array<{ key: string }>;
+      for (const { key } of candidates) {
+        await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${key}`}))`;
+      }
+
       const rows = (await tx`
         UPDATE connector_definitions cd
         SET status = 'archived', updated_at = NOW()
@@ -439,28 +439,35 @@ async function archiveVanishedDeviceConnectors(
           AND cd.required_capability IS NOT NULL
           AND NOT (cd.key = ANY(${pgTextArray(liveKeys)}::text[]))
           AND NOT EXISTS (
+            SELECT 1
+            FROM device_workers dw
+            WHERE dw.user_id = ${userId}
+              AND dw.last_seen_at > now() - ${DEVICE_WORKER_FRESH_INTERVAL}::interval
+              AND dw.connector_manifests -> cd.key IS NOT NULL
+          )
+          AND NOT EXISTS (
             SELECT 1 FROM connections c
             WHERE c.organization_id = cd.organization_id
               AND c.connector_key = cd.key
               AND c.deleted_at IS NULL
-              -- Fails CLOSED on unknown provenance: created_by is nullable, so a
-              -- bare NOT (c.created_by = $1 AND ...) evaluates to NULL for a
-              -- NULL creator, which the subquery reads as "no blocking row" --
-              -- i.e. an orphaned connection would silently permit the archive.
-              -- COALESCE to '' makes it a definite TRUE so anything we cannot
-              -- positively identify as our own auto-wired row protects the
-              -- definition instead.
-              AND NOT (COALESCE(c.created_by, '') = ${userId} AND c.auth_profile_id IS NULL)
+              -- Keep unknown provenance as a blocking row: created_by is nullable.
+              AND NOT (
+                COALESCE(c.created_by, '') = ${userId}
+                AND c.auth_profile_id IS NULL
+                AND c.app_auth_profile_id IS NULL
+                AND c.account_id IS NULL
+                AND c.credentials IS NULL
+                AND c.config IS NULL
+                AND c.agent_id IS NULL
+                AND COALESCE(cardinality(c.entity_ids), 0) = 0
+                AND c.visibility = 'private'
+              )
           )
         RETURNING cd.key
       `) as unknown as Array<{ key: string }>;
 
       if (rows.length > 0) {
         const keys = rows.map((r) => r.key);
-        // Deliberately NOT the COALESCE form used in the guard above: there we
-        // needed unknown provenance to COUNT (protect the definition), here we
-        // need it to be EXCLUDED (never delete a row we can't attribute to
-        // ourselves). Both directions are "fail closed" — do not unify them.
         await tx`
           UPDATE connections
           SET deleted_at = NOW(), updated_at = NOW()
@@ -468,6 +475,13 @@ async function archiveVanishedDeviceConnectors(
             AND connector_key = ANY(${pgTextArray(keys)}::text[])
             AND created_by = ${userId}
             AND auth_profile_id IS NULL
+            AND app_auth_profile_id IS NULL
+            AND account_id IS NULL
+            AND credentials IS NULL
+            AND config IS NULL
+            AND agent_id IS NULL
+            AND COALESCE(cardinality(entity_ids), 0) = 0
+            AND visibility = 'private'
             AND deleted_at IS NULL
         `;
       }
@@ -612,7 +626,7 @@ export async function reconcileDeviceCapabilities(userId: string): Promise<void>
             dc.feedKeys,
             matchingDeviceIds,
             'source' in dc && dc.source === 'device-manifest'
-              ? { metadata: dc.metadata, sourcePath: dc.sourcePath }
+              ? { metadata: dc.metadata, sourcePath: dc.sourcePath, manifestHash: dc.manifestHash }
               : undefined
           )
         : pauseStaleDeviceFeeds(userId, personalOrgId, dc.key);

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -85,6 +85,18 @@ async function ensureDeviceConnectorWired(
       matchingDeviceIds,
     });
   };
+  const manifestStillAdvertised = async (db: typeof sql): Promise<boolean> => {
+    if (!source) return true;
+    const rows = await db`
+      SELECT 1
+      FROM device_workers
+      WHERE user_id = ${userId}
+        AND last_seen_at > now() - ${DEVICE_WORKER_FRESH_INTERVAL}::interval
+        AND (connector_manifests -> ${connectorKey}) ->> 'manifest_hash' = ${source.manifestHash}
+      LIMIT 1
+    `;
+    return rows.length > 0;
+  };
 
   try {
     // Fast path: definition + version + connection + EVERY declared feed active
@@ -151,9 +163,6 @@ async function ensureDeviceConnectorWired(
       def_runtime: unknown;
       active_feed_keys: string[] | null;
     }>;
-    if (existingReady[0]?.connection_id) {
-      await reconcilePin(sql, existingReady[0].connection_id);
-    }
     // Device-manifest connectors carry their full metadata in-hand (`source`),
     // so a changed manifest MUST break the fast path or the org catalog is
     // stranded on the old definition forever: the extension re-sends its
@@ -182,9 +191,10 @@ async function ensureDeviceConnectorWired(
       );
     };
     const activeFeedKeys = new Set(existingReady[0]?.active_feed_keys ?? []);
-    if (
-      existingReady[0]?.connection_id &&
-      existingReady[0]?.version_key &&
+    const readyConnectionId = existingReady[0]?.connection_id;
+    const ready =
+      readyConnectionId != null &&
+      existingReady[0]?.version_key != null &&
       definitionMatchesSource(existingReady[0]) &&
       // userManaged-only connectors (e.g. local.directory, browser/*) report
       // declaredFeedKeys=[]. Once the connection + definition are installed,
@@ -192,8 +202,18 @@ async function ensureDeviceConnectorWired(
       // Composing primitives still hit /api/workers/me/feeds to mint
       // explicit per-instance rows; that path is unchanged.
       (declaredFeedKeys.length === 0 ||
-        declaredFeedKeys.every((feedKey) => activeFeedKeys.has(feedKey)))
-    ) {
+        declaredFeedKeys.every((feedKey) => activeFeedKeys.has(feedKey)));
+    if (ready) {
+      if (source) {
+        await sql.begin(async (tx) => {
+          await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
+          if (await manifestStillAdvertised(tx)) {
+            await reconcilePin(tx, readyConnectionId);
+          }
+        });
+      } else {
+        await reconcilePin(sql, readyConnectionId);
+      }
       return;
     }
 
@@ -233,20 +253,10 @@ async function ensureDeviceConnectorWired(
       // both reach here, but only one holds the lock at a time, so the
       // existence-check-then-insert below is atomic.
       await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
-      if (source) {
-        // A newer poll may have removed this manifest while this reconcile was
-        // waiting for the lock. Re-check the stored fleet inventory so an older
-        // poll cannot resurrect a connector the newer poll just retired.
-        const stillAdvertised = await tx`
-          SELECT 1
-          FROM device_workers
-          WHERE user_id = ${userId}
-            AND last_seen_at > now() - ${DEVICE_WORKER_FRESH_INTERVAL}::interval
-            AND (connector_manifests -> ${connectorKey}) ->> 'manifest_hash' = ${source.manifestHash}
-          LIMIT 1
-        `;
-        if (stillAdvertised.length === 0) return;
-      }
+      // A newer poll may have removed this manifest while this reconcile was
+      // waiting for the lock. Re-check the stored fleet inventory so an older
+      // poll cannot resurrect a connector the newer poll just retired.
+      if (source && !(await manifestStillAdvertised(tx))) return;
 
       // 2. Ensure the connector definition + version are installed (idempotent).
       await upsertConnectorDefinitionRecords({
@@ -403,14 +413,16 @@ async function pauseStaleDeviceFeeds(userId: string, organizationId: string, con
 }
 
 /**
- * Archive org-scoped device definitions absent from both the bundled catalog
- * and every fresh device manifest. Only the exact auto-wire connection shape
- * may be retired; user-modified or unknown-provenance rows protect the
- * definition. The wire and archive paths share a per-key lock and re-check the
- * stored manifest inventory so concurrent polls cannot leave contradictory
- * definition and connection state. Best-effort.
+ * Archive unreferenced org-scoped definitions created by device reconciliation
+ * that no current connector source still advertises. This includes manifest
+ * versions and metadata-only shared pointers left by a formerly bundled device
+ * connector, but excludes org-custom sources. A live connection always protects
+ * its definition: connection fields do not record whether reconcile or a user
+ * created the row, so deleting based on a guessed "auto-wire shape" would risk
+ * deleting user configuration. The wire and archive paths share a per-key lock
+ * and re-check stored manifests so concurrent polls converge. Best-effort.
  */
-async function archiveVanishedDeviceConnectors(
+async function archiveVanishedDeviceConnectorDefinitions(
   userId: string,
   organizationId: string,
   liveKeys: string[]
@@ -419,17 +431,40 @@ async function archiveVanishedDeviceConnectors(
   try {
     const archived = await sql.begin(async (tx) => {
       const candidates = (await tx`
-        SELECT key
-        FROM connector_definitions
-        WHERE organization_id = ${organizationId}
-          AND status = 'active'
-          AND required_capability IS NOT NULL
-          AND NOT (key = ANY(${pgTextArray(liveKeys)}::text[]))
-        ORDER BY key
+        SELECT cd.key
+        FROM connector_definitions cd
+        WHERE cd.organization_id = ${organizationId}
+          AND cd.status = 'active'
+          AND cd.required_capability IS NOT NULL
+          AND NOT (cd.key = ANY(${pgTextArray(liveKeys)}::text[]))
+          AND COALESCE((
+            SELECT CASE
+              WHEN cv.organization_id IS NOT NULL
+                THEN cv.source_path LIKE 'device-manifest://%'
+              ELSE cv.source_path IS NOT NULL
+                AND cv.compiled_code IS NULL
+                AND cv.source_code IS NULL
+            END
+            FROM connector_versions cv
+            WHERE cv.connector_key = cd.key
+              AND cv.version = cd.version
+              AND (cv.organization_id = cd.organization_id OR cv.organization_id IS NULL)
+            ORDER BY cv.organization_id NULLS LAST
+            LIMIT 1
+          ), false)
+          AND NOT EXISTS (
+            SELECT 1 FROM connections c
+            WHERE c.organization_id = cd.organization_id
+              AND c.connector_key = cd.key
+              AND c.deleted_at IS NULL
+          )
+        ORDER BY cd.key
       `) as unknown as Array<{ key: string }>;
       for (const { key } of candidates) {
         await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${key}`}))`;
       }
+      if (candidates.length === 0) return [];
+      const candidateKeys = candidates.map(({ key }) => key);
 
       const rows = (await tx`
         UPDATE connector_definitions cd
@@ -437,7 +472,22 @@ async function archiveVanishedDeviceConnectors(
         WHERE cd.organization_id = ${organizationId}
           AND cd.status = 'active'
           AND cd.required_capability IS NOT NULL
-          AND NOT (cd.key = ANY(${pgTextArray(liveKeys)}::text[]))
+          AND cd.key = ANY(${pgTextArray(candidateKeys)}::text[])
+          AND COALESCE((
+            SELECT CASE
+              WHEN cv.organization_id IS NOT NULL
+                THEN cv.source_path LIKE 'device-manifest://%'
+              ELSE cv.source_path IS NOT NULL
+                AND cv.compiled_code IS NULL
+                AND cv.source_code IS NULL
+            END
+            FROM connector_versions cv
+            WHERE cv.connector_key = cd.key
+              AND cv.version = cd.version
+              AND (cv.organization_id = cd.organization_id OR cv.organization_id IS NULL)
+            ORDER BY cv.organization_id NULLS LAST
+            LIMIT 1
+          ), false)
           AND NOT EXISTS (
             SELECT 1
             FROM device_workers dw
@@ -450,48 +500,16 @@ async function archiveVanishedDeviceConnectors(
             WHERE c.organization_id = cd.organization_id
               AND c.connector_key = cd.key
               AND c.deleted_at IS NULL
-              -- Keep unknown provenance as a blocking row: created_by is nullable.
-              AND NOT (
-                COALESCE(c.created_by, '') = ${userId}
-                AND c.auth_profile_id IS NULL
-                AND c.app_auth_profile_id IS NULL
-                AND c.account_id IS NULL
-                AND c.credentials IS NULL
-                AND c.config IS NULL
-                AND c.agent_id IS NULL
-                AND COALESCE(cardinality(c.entity_ids), 0) = 0
-                AND c.visibility = 'private'
-              )
           )
         RETURNING cd.key
       `) as unknown as Array<{ key: string }>;
-
-      if (rows.length > 0) {
-        const keys = rows.map((r) => r.key);
-        await tx`
-          UPDATE connections
-          SET deleted_at = NOW(), updated_at = NOW()
-          WHERE organization_id = ${organizationId}
-            AND connector_key = ANY(${pgTextArray(keys)}::text[])
-            AND created_by = ${userId}
-            AND auth_profile_id IS NULL
-            AND app_auth_profile_id IS NULL
-            AND account_id IS NULL
-            AND credentials IS NULL
-            AND config IS NULL
-            AND agent_id IS NULL
-            AND COALESCE(cardinality(entity_ids), 0) = 0
-            AND visibility = 'private'
-            AND deleted_at IS NULL
-        `;
-      }
       return rows;
     });
 
     if (archived.length > 0) {
       logger.info(
         { userId, organizationId, keys: archived.map((r) => r.key) },
-        '[device-connectors] Archived definitions no longer served by any device manifest'
+        '[device-connectors] Archived definitions no longer served by any connector source'
       );
     }
   } catch (err) {
@@ -611,7 +629,7 @@ export async function reconcileDeviceCapabilities(userId: string): Promise<void>
   // failure must never be read as "the fleet serves nothing" and archive a
   // user's whole working set.
   if (sourcesReadable) {
-    await archiveVanishedDeviceConnectors(userId, personalOrgId, [...byKey.keys()]);
+    await archiveVanishedDeviceConnectorDefinitions(userId, personalOrgId, [...byKey.keys()]);
   }
   if (byKey.size === 0) return;
 

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -233,15 +233,20 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   if (registrationUserId) {
     try {
       const incomingCaps = authorizedCapabilities;
-      const validConnectorManifests = connectorManifestsProvided
+      const manifestValidation = connectorManifestsProvided
         ? validateDeviceConnectorManifests({
             platform: effectivePlatform,
             capabilities: incomingCaps,
             manifests: connectorManifestsRaw,
           })
         : null;
-      const connectorManifestMap = validConnectorManifests
-        ? storedManifestMap(validConnectorManifests)
+      // An explicitly empty array is an authoritative "this device serves no
+      // connectors". A payload the validator rejected is not: replacing the
+      // last good inventory with {} would make reconcile archive working
+      // definitions because a malformed poll looked like removal.
+      const connectorManifestsAccepted = manifestValidation?.accepted === true;
+      const connectorManifestMap = connectorManifestsAccepted
+        ? storedManifestMap(manifestValidation.manifests)
         : null;
 
       // `xmax = 0` on the RETURNING row distinguishes a brand-new device
@@ -270,7 +275,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           label = COALESCE(EXCLUDED.label, device_workers.label),
           organization_id = COALESCE(device_workers.organization_id, EXCLUDED.organization_id),
           connector_manifests = CASE
-            WHEN ${connectorManifestsProvided} THEN EXCLUDED.connector_manifests
+            WHEN ${connectorManifestsAccepted} THEN EXCLUDED.connector_manifests
             ELSE device_workers.connector_manifests
           END,
           last_seen_at = now()


### PR DESCRIPTION
## Summary
- `reconcileDeviceCapabilities` only iterates connector keys the fleet **currently** advertises, so a key that disappears entirely is never visited. `pauseStaleDeviceFeeds` pauses feeds for keys we still know about, but a vanished key's `connector_definitions` row stayed `status='active'` **forever** and kept rendering on the connectors list as a permanently "Needs setup" connector with 0 connections.
- Prod symptom: `Browser Evaluate` / `Browser Fill Form` / `Browser Page Text` / `Chrome Tabs` showing as separate peers of `Chrome`. They are pre-consolidation per-capability connectors folded into `chrome` v0.2.x — their capabilities are now `chrome`'s `actions_schema` entries (`evaluate`, `click_ref`/`type_ref`) and the `open_tabs` feed. No manifest for them exists on disk anymore.
- Adds `archiveVanishedDeviceConnectors`, scoped to definitions this reconciler actually owns (manifest / former-bundled provenance). Any definition with a live connection, a custom source, or unknown provenance is protected.
- **Fixes a pre-existing data-loss path this work exposed** (see below).

### The data-loss bug CI caught
`validateDeviceConnectorManifests` returned a bare array, so a **malformed** payload and an **authoritative empty** inventory were indistinguishable — both came back `[]`. Poll keyed the overwrite off `Object.hasOwn`, so a device that sent one bad manifest had its stored inventory replaced with `{}`; the new archive pass then retired the user's *working* connector. One malformed poll could destroy a live device connector.

Validation now returns `{ manifests, accepted }`, and poll only overwrites `connector_manifests` when the payload was **accepted**. An explicit `[]` stays authoritative ("this device serves nothing"); a rejected payload preserves the last good inventory. This is the missing capability, not a guard bolted onto the archive pass.

### Safety properties
- Archiving is reversible: `idx_connector_defs_org_key` is UNIQUE **partial on `status='active'`**, so a re-advertised key just inserts a fresh active row (covered by a round-trip test).
- `events` untouched — append-only; `chrome.tabs` alone has 357 events in prod.
- Takes the same per-key advisory lock as the wire path, so a concurrent poll cannot re-wire a connection onto a definition being archived.
- Re-checks the **stored** fleet inventory, not just the caller's in-memory key list.
- `COALESCE` on the nullable `created_by` so unknown provenance fails **closed** (a bare comparison yields NULL, which SQL reads as "no blocking row").

Complements the `runs/queue-service.ts` orphan-feed defense (which soft-deletes the feed *reactively* after a failed run); this prevents the run being created at all.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `device-connector-manifests.test.ts` → **13/13**; device/poll/connector suites → **49 files / 331 tests** green
- [x] Bug fix: red→fix→green outputs pasted below

### red — the original bug (before the archive pass)
```
× device connector manifests > archives a definition whose key the fleet no longer advertises
  → expected [ 'active' ] to deeply equal [ 'archived' ]
 Tests  1 failed | 8 passed (9)
```

### red — the data-loss bug (CI, commit 881159d8f)
```
FAIL src/__tests__/integration/device-connector-manifests.test.ts > device connector manifests
     > preserves the last valid inventory when a later manifest payload is rejected
AssertionError: expected [ 'archived' ] to deeply equal [ 'active' ]
```

### green (HEAD)
```
 Tests  13 passed (13)

 Test Files  49 passed (49)
      Tests  331 passed (331)
```

### mutation tests (proving the new tests bite)
Each guard was reverted individually and the suite re-run:
- stub the archive call to `if (false)` → fails **only** the reproducer (`1 failed | 8 passed`)
- drop the `COALESCE` fail-closed guard → fails **only** the unknown-provenance test (`1 failed | 10 passed`)
- restore the `connectorManifestsProvided` overwrite → fails **only** the rejected-payload test, with the data-loss signature `expected [] to deeply equal [ 'apple.test_device_manifest' ]`

All restored afterwards.

## Notes
Multi-device isolation is covered by an explicit test: `getDeviceManifestSourcesForUser` reads `connector_manifests` from **all** of a user's devices seen in 7 days, so a Chrome poll cannot archive the Mac's connectors. Idempotency is asserted via `updated_at` stability across repeated polls, since this pass runs on every poll.

Prod cleanup already applied separately: the 4 stale rows in the affected org were archived by hand (their connections had already been soft-deleted on 2026-05-28). Only 1 org was affected — the debris never spread.

`check-drift` is red on this branch and on `main`: owletto/main has merged past the pinned SHA (#598/#599/#600). It is not a required check, this diff touches zero owletto files, and PR #2208 already covers the bump.
