### PR TITLE
fix(server): stop classification_filters dropping entity-less events

### DIFF
--- a/packages/server/src/__tests__/integration/events/classification-filter-repro.test.ts
+++ b/packages/server/src/__tests__/integration/events/classification-filter-repro.test.ts
@@ -27,8 +27,6 @@ describe('#2214 classification_filters', () => {
     const otherOrg = await createTestOrganization({ name: 'Classification Filter Other Org' });
     const user = await createTestUser({ email: 'cls-repro@example.com' });
     await addUserToOrganization(user.id, org.id, 'owner');
-    const otherUser = await createTestUser({ email: 'cls-repro-other@example.com' });
-    await addUserToOrganization(otherUser.id, otherOrg.id, 'owner');
 
     const sql = getTestDb();
     const entity = await createTestEntity({

--- a/packages/server/src/__tests__/integration/events/classification-filter-repro.test.ts
+++ b/packages/server/src/__tests__/integration/events/classification-filter-repro.test.ts
@@ -1,0 +1,145 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('#2214 classification_filters', () => {
+  let ctx: ToolContext;
+  let expectedEventIds: number[];
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    const org = await createTestOrganization({ name: 'Classification Filter Org' });
+    const otherOrg = await createTestOrganization({ name: 'Classification Filter Other Org' });
+    const user = await createTestUser({ email: 'cls-repro@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const otherUser = await createTestUser({ email: 'cls-repro-other@example.com' });
+    await addUserToOrganization(otherUser.id, otherOrg.id, 'owner');
+
+    const sql = getTestDb();
+    const entity = await createTestEntity({
+      name: 'Classification Filter Entity',
+      organization_id: org.id,
+    });
+    const otherEntity = await createTestEntity({
+      name: 'Classification Filter Other Entity',
+      organization_id: otherOrg.id,
+    });
+    await createTestConnectorDefinition({
+      key: 'classification-filter-test',
+      name: 'Classification Filter Test',
+      organization_id: org.id,
+    });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'classification-filter-test',
+      entity_ids: [entity.id],
+    });
+
+    const [directOrgEvent] = await sql<{ id: number }[]>`
+      INSERT INTO events (organization_id, origin_id, title, payload_type, payload_text,
+                          semantic_type, occurred_at, created_at)
+      VALUES (${org.id}, 'cls-repro-direct', 'direct org row', 'text', 'direct org row',
+              'audit', NOW(), NOW())
+      RETURNING id
+    `;
+    const entityBridgeEvent = await createTestEvent({
+      organization_id: otherOrg.id,
+      entity_id: entity.id,
+      origin_id: 'cls-repro-entity',
+      title: 'entity bridge row',
+      content: 'entity bridge row',
+    });
+    const connectionBridgeEvent = await createTestEvent({
+      organization_id: otherOrg.id,
+      connection_id: connection.id,
+      entity_ids: [],
+      origin_id: 'cls-repro-connection',
+      title: 'connection bridge row',
+      content: 'connection bridge row',
+    });
+    const foreignEvent = await createTestEvent({
+      organization_id: otherOrg.id,
+      entity_id: otherEntity.id,
+      origin_id: 'cls-repro-foreign',
+      title: 'foreign row',
+      content: 'foreign row',
+    });
+    await createTestEvent({
+      organization_id: org.id,
+      entity_ids: [],
+      origin_id: 'cls-repro-unclassified',
+      title: 'unclassified row',
+      content: 'unclassified row',
+    });
+
+    const [facet] = await sql<{ id: number }[]>`
+      INSERT INTO classify_facet (organization_id, slug, name, attribute_key, status,
+                                  created_by, entity_ids, attribute_values, min_similarity)
+      VALUES (${org.id}, 'repro-kind', 'Repro kind', 'repro_kind', 'active', ${user.id},
+              ARRAY[]::bigint[], ${sql.json({ alpha: { description: 'A', examples: [] } })}, 0.7)
+      RETURNING id
+    `;
+    const facetId = facet.id;
+
+    expectedEventIds = [
+      directOrgEvent.id,
+      entityBridgeEvent.id,
+      connectionBridgeEvent.id,
+    ];
+    for (const eventId of [...expectedEventIds, foreignEvent.id]) {
+      await sql`
+        INSERT INTO event_classifications (event_id, classifier_id, watcher_id, window_id,
+                                           "values", confidences, source, is_manual)
+        VALUES (${eventId}, ${facetId}, NULL, NULL, ${'{alpha}'}::text[],
+                ${sql.json({ alpha: 1 })}, 'user', true)
+      `;
+    }
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    } as ToolContext;
+  });
+
+  it('applies classification filters across every organization-scope path', async () => {
+    const result = await getContent(
+      { classification_filters: { 'repro-kind': ['alpha'] }, limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    const ids = result.content.map((item) => Number(item.id)).sort((a, b) => a - b);
+    expect(ids).toEqual([...expectedEventIds].sort((a, b) => a - b));
+    expect(result.total).toBe(expectedEventIds.length);
+  });
+
+  it('a value with no matching classification returns nothing', async () => {
+    const result = await getContent(
+      { classification_filters: { 'repro-kind': ['beta'] }, limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -269,10 +269,17 @@ export async function listContentInternal(
         baseParamIndex: baseParams.length - link.params.length + 1,
       }).sql;
     } else if (organizationId) {
-      baseParams.push(organizationId);
-      baseConditions.push(
-        `f.entity_ids && ARRAY(SELECT id FROM entities WHERE organization_id = $${baseParams.length})::bigint[]`
-      );
+      // Keep classification-filtered listings on the same direct/entity/
+      // connection org scope as the standard listing path.
+      const orgScope = buildOrgScopeWhere({
+        organization_id: organizationId,
+        baseParamIndex: baseParams.length + 1,
+      });
+      baseConditions.push(orgScope.sql.replace(/^AND\s+/, ''));
+      baseParams.push(...orgScope.params);
+      // Avoid treating the organization id in $1 as a bigint entity id while
+      // walking parent threads.
+      threadEntityLinkSql = 'TRUE';
     }
 
     baseConditions.push(connectionFilterClause);


### PR DESCRIPTION
## What

Closes #2214.

The classification branch of `listContentInternal` scoped org-wide listings with its own predicate:

```sql
f.entity_ids && ARRAY(SELECT id FROM entities WHERE organization_id = $N)::bigint[]
```

Every other listing path — including the non-classification branch of the *same file* (`list-path.ts:447`) — uses `buildOrgScopeWhere`, a three-way OR:

```sql
f.organization_id = $N  OR  EXISTS(entity in org)  OR  c.organization_id = $N
```

The narrow version dropped two whole classes of row:

- **Events with NULL/empty `entity_ids`** (audit rows, system events). Because `&&` against NULL yields **NULL, not false**, these were dropped without ever being evaluated.
- **Events reachable only through their connection's organization.**

Net effect: an org-scoped event with no entity link was invisible to `classification_filters` while remaining visible to every other filter.

## Red → green

Before — asking for a classification returns only the entity-linked row, silently missing the direct-org and connection-bridge rows:

```
× applies classification filters across every organization-scope path
  → expected [ 2 ] to deeply equal [ 1, 2, 3 ]
```

After:

```
 Test Files  33 passed (33)
      Tests  151 passed (151)   # events integration dir
```

The mutation above *is* the regression test: reverting just the org-scope predicate reproduces the original bug exactly, and the assertion names which rows go missing.

## Test coverage

The new integration test pins all three org-scope paths plus the negative cases:

| row | reaches the org via | expected |
|---|---|---|
| direct org row | `f.organization_id` | included (was **dropped**) |
| entity bridge row | entity in org | included |
| connection bridge row | connection's org | included (was **dropped**) |
| foreign row | another org entirely | excluded |
| unclassified row | direct org, no classification | excluded |

There was previously **no end-to-end integration coverage of `classification_filters` at all** — the only references were unit tests asserting it is *rejected* in the `include_superseded` path. That gap is why this survived.

## Second-order find

Switching to the shared builder surfaced a latent coupling. With no entity, `buildThreadMetaCteSql` falls back to binding `$1::bigint`; in this branch `$1` is now the org id (text), so the query failed with `22P02 invalid input syntax for type bigint`. The org branch now passes an explicit always-true entity-link fragment — which is what the existing comment above it already said the org path wanted ("org-wide listings already constrain candidates upstream").

## Testing

- [x] Red → green captured, and the red is reproducible by reverting one predicate
- [x] Events integration: **151/151**
- [x] Full server vitest suite: **2877 passed, 0 failed**
- [x] `make pre-pr` — build, strict typecheck, knip, biome, exposed-surface naming
- [x] `make review-fix` applied; it strengthened the test to cover all three scope paths + foreign-org exclusion

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->