### PR TITLE
fix(server): union nix packages at resolve time so skill/request deps reach the worker

### DIFF
--- a/packages/server/src/gateway/__tests__/enqueue-nix-config.test.ts
+++ b/packages/server/src/gateway/__tests__/enqueue-nix-config.test.ts
@@ -3,20 +3,26 @@
  * only place the spawn path reads it from (`deployment-manager` wraps the
  * worker in `nix-shell -p <packages>` off `messageData.nixConfig`).
  *
- * `buildMessagePayload` does that lift for callers that use it, but these two
- * paths hand-roll their `enqueueMessage` argument, so a resolved `nixConfig`
+ * `buildMessagePayload` does that lift for callers that use it, but two paths
+ * hand-roll their `enqueueMessage` argument, so a resolved `nixConfig`
  * previously stayed nested inside `agentOptions` and was silently dropped.
- * These tests drive both paths with a capturing queue and assert the union
- * (per-request ∪ agent settings ∪ enabled skills) lands on `payload.nixConfig`
- * and NOT in `payload.agentOptions`.
+ * These tests drive both of them — `ChatInstanceManager.routePlatformMessage`
+ * and the direct-API `POST /api/v1/agents/{agentId}/messages` — with a
+ * capturing queue, asserting the union (per-request ∪ agent settings ∪ enabled
+ * skills) lands on `payload.nixConfig` and NOT in `payload.agentOptions`.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import type { MessagePayload } from "@lobu/core";
+import { generateWorkerToken, type MessagePayload } from "@lobu/core";
 import { ChatInstanceManager } from "../connections/chat-instance-manager.js";
+import { createAgentApi } from "../routes/public/agent.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
 
 process.env.ENCRYPTION_KEY ||=
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const AGENT_ID = "agent-1";
+const ORG_ID = "org-1";
 
 const AGENT_SETTINGS = {
   models: ["openai/gpt-5"],
@@ -89,35 +95,68 @@ describe("enqueued payload carries the resolved nixConfig", () => {
     ).toBeUndefined();
   });
 
-  test("a disabled skill's packages never reach the payload", async () => {
-    const manager = Object.create(
-      ChatInstanceManager.prototype,
-    ) as ChatInstanceManager;
-
-    Object.assign(manager, {
-      services: {
-        getSessionManager: () => ({ setSession: mock(async () => {}) }),
-        getQueueProducer: () => ({
-          enqueueMessage: mock(async (payload: MessagePayload) => {
-            enqueued.push(payload);
-          }),
+  test("the direct API path unions request, agent and skill packages", async () => {
+    // `POST /agents` persists its `nix` on the session; before the fix that
+    // value was replayed into resolveAgentOptions and then dropped, so a
+    // caller-supplied package never reached the worker.
+    setAuthProvider(null);
+    const app = createAgentApi({
+      queueProducer: {
+        enqueueMessage: mock(async (payload: MessagePayload) => {
+          enqueued.push(payload);
+          return "job-1";
         }),
-        getAgentSettingsStore: makeAgentSettingsStore,
+      } as never,
+      sessionManager: {
+        getSession: async () => ({
+          agentId: AGENT_ID,
+          conversationId: "conv-1",
+          channelId: "api_user-1",
+          userId: "user-1",
+          organizationId: ORG_ID,
+          nixConfig: { packages: ["request-pkg"] },
+        }),
+        touchSession: async () => {},
+        setSession: async () => {},
+      } as never,
+      sseManager: { hasClients: () => false } as never,
+      publicGatewayUrl: "http://localhost:8787",
+      artifactStore: {} as never,
+      agentSettingsStore: makeAgentSettingsStore() as never,
+      agentMetadataStore: {
+        async getMetadata() {
+          return { owner: { platform: "api", userId: "user-1" } };
+        },
+      } as never,
+    });
+
+    const token = generateWorkerToken(AGENT_ID, "conv-1", "deploy-1", {
+      channelId: "api_user-1",
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+    });
+    const res = await app.request(
+      `/api/v1/agents/${AGENT_ID}/messages`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ message: "hi" }),
       },
-      selectConnectionForPlatform: async () => ({
-        id: "conn-1",
-        organizationId: "org-1",
-      }),
-    });
+    );
 
-    await manager.routePlatformMessage("telegram", "token-abcdefgh", "hi", {
-      agentId: "agent-1",
-      channelId: "chan-1",
-      teamId: "team-1",
-    });
-
-    const packages = enqueued[0]?.nixConfig?.packages;
-    expect(packages).toBeDefined();
-    expect(packages).not.toContain("must-not-appear");
+    expect(res.status).toBe(200);
+    expect(enqueued).toHaveLength(1);
+    const payload = enqueued[0]!;
+    expect(payload.nixConfig?.packages).toEqual([
+      "request-pkg",
+      "agent-pkg",
+      "skill-pkg",
+    ]);
+    expect(
+      (payload.agentOptions as Record<string, unknown> | undefined)?.nixConfig,
+    ).toBeUndefined();
   });
 });

--- a/packages/server/src/gateway/__tests__/enqueue-nix-config.test.ts
+++ b/packages/server/src/gateway/__tests__/enqueue-nix-config.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `nixConfig` must reach the ENQUEUED payload's top-level field — that is the
+ * only place the spawn path reads it from (`deployment-manager` wraps the
+ * worker in `nix-shell -p <packages>` off `messageData.nixConfig`).
+ *
+ * `buildMessagePayload` does that lift for callers that use it, but these two
+ * paths hand-roll their `enqueueMessage` argument, so a resolved `nixConfig`
+ * previously stayed nested inside `agentOptions` and was silently dropped.
+ * These tests drive both paths with a capturing queue and assert the union
+ * (per-request ∪ agent settings ∪ enabled skills) lands on `payload.nixConfig`
+ * and NOT in `payload.agentOptions`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { MessagePayload } from "@lobu/core";
+import { ChatInstanceManager } from "../connections/chat-instance-manager.js";
+
+process.env.ENCRYPTION_KEY ||=
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const AGENT_SETTINGS = {
+  models: ["openai/gpt-5"],
+  nixConfig: { packages: ["agent-pkg"] },
+  skillsConfig: {
+    skills: [
+      {
+        repo: "lobu/skills",
+        name: "video",
+        enabled: true,
+        nixPackages: ["skill-pkg"],
+      },
+      {
+        repo: "lobu/skills",
+        name: "disabled-one",
+        enabled: false,
+        nixPackages: ["must-not-appear"],
+      },
+    ],
+  },
+};
+
+function makeAgentSettingsStore() {
+  return { getSettings: async () => AGENT_SETTINGS };
+}
+
+describe("enqueued payload carries the resolved nixConfig", () => {
+  let enqueued: MessagePayload[];
+
+  beforeEach(() => {
+    enqueued = [];
+  });
+
+  test("routePlatformMessage lifts nixConfig out of agentOptions", async () => {
+    const manager = Object.create(
+      ChatInstanceManager.prototype,
+    ) as ChatInstanceManager;
+
+    // Only the seams routePlatformMessage touches — this asserts payload shape,
+    // not connection selection or session persistence.
+    Object.assign(manager, {
+      services: {
+        getSessionManager: () => ({ setSession: mock(async () => {}) }),
+        getQueueProducer: () => ({
+          enqueueMessage: mock(async (payload: MessagePayload) => {
+            enqueued.push(payload);
+          }),
+        }),
+        getAgentSettingsStore: makeAgentSettingsStore,
+      },
+      selectConnectionForPlatform: async () => ({
+        id: "conn-1",
+        organizationId: "org-1",
+      }),
+    });
+
+    await manager.routePlatformMessage("telegram", "token-abcdefgh", "hi", {
+      agentId: "agent-1",
+      channelId: "chan-1",
+      teamId: "team-1",
+    });
+
+    expect(enqueued).toHaveLength(1);
+    const payload = enqueued[0]!;
+    expect(payload.nixConfig?.packages).toEqual(["agent-pkg", "skill-pkg"]);
+    // The worker reads the top-level field; a copy left in agentOptions would
+    // mean the lift never happened.
+    expect(
+      (payload.agentOptions as Record<string, unknown> | undefined)?.nixConfig,
+    ).toBeUndefined();
+  });
+
+  test("a disabled skill's packages never reach the payload", async () => {
+    const manager = Object.create(
+      ChatInstanceManager.prototype,
+    ) as ChatInstanceManager;
+
+    Object.assign(manager, {
+      services: {
+        getSessionManager: () => ({ setSession: mock(async () => {}) }),
+        getQueueProducer: () => ({
+          enqueueMessage: mock(async (payload: MessagePayload) => {
+            enqueued.push(payload);
+          }),
+        }),
+        getAgentSettingsStore: makeAgentSettingsStore,
+      },
+      selectConnectionForPlatform: async () => ({
+        id: "conn-1",
+        organizationId: "org-1",
+      }),
+    });
+
+    await manager.routePlatformMessage("telegram", "token-abcdefgh", "hi", {
+      agentId: "agent-1",
+      channelId: "chan-1",
+      teamId: "team-1",
+    });
+
+    const packages = enqueued[0]?.nixConfig?.packages;
+    expect(packages).toBeDefined();
+    expect(packages).not.toContain("must-not-appear");
+  });
+});

--- a/packages/server/src/gateway/__tests__/platform-helpers-nix-union.test.ts
+++ b/packages/server/src/gateway/__tests__/platform-helpers-nix-union.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSettings, NixConfig } from "@lobu/core";
+import { resolveAgentOptions } from "../services/platform-helpers.js";
+
+type NixSettings = Partial<
+  Pick<AgentSettings, "nixConfig" | "skillsConfig">
+>;
+
+async function resolveNixConfig(
+  settings: NixSettings,
+  baseNixConfig?: NixConfig,
+): Promise<NixConfig | undefined> {
+  const settingsStore = {
+    getSettings: async () => ({
+      models: ["openai/gpt-5"],
+      ...settings,
+    }),
+  };
+  const resolved = await resolveAgentOptions(
+    "agent-1",
+    { nixConfig: baseNixConfig },
+    settingsStore as any,
+    "org-1",
+  );
+  return resolved.nixConfig;
+}
+
+describe("resolveAgentOptions nix union", () => {
+  test("an enabled skill's nixPackages reach nixConfig even when the agent has none", async () => {
+    const resolved = await resolveNixConfig({
+      skillsConfig: {
+        skills: [
+          {
+            repo: "lobu/skills",
+            name: "video",
+            enabled: true,
+            nixPackages: ["ffmpeg"],
+          },
+        ],
+      },
+    });
+
+    expect(resolved?.packages).toEqual(["ffmpeg"]);
+  });
+
+  test("agent packages come first and the union is deduped", async () => {
+    const resolved = await resolveNixConfig({
+      nixConfig: { packages: ["ripgrep", "ffmpeg"] },
+      skillsConfig: {
+        skills: [
+          {
+            repo: "lobu/skills",
+            name: "video",
+            enabled: true,
+            nixPackages: ["ffmpeg", "yt-dlp"],
+          },
+        ],
+      },
+    });
+
+    expect(resolved?.packages).toEqual(["ripgrep", "ffmpeg", "yt-dlp"]);
+  });
+
+  test("base packages survive when settings only add skill packages", async () => {
+    const resolved = await resolveNixConfig(
+      {
+        skillsConfig: {
+          skills: [
+            {
+              repo: "lobu/skills",
+              name: "video",
+              enabled: true,
+              nixPackages: ["ffmpeg"],
+            },
+          ],
+        },
+      },
+      { packages: ["ripgrep"] },
+    );
+
+    expect(resolved?.packages).toEqual(["ripgrep", "ffmpeg"]);
+  });
+
+  test("per-request, agent and skill packages are all unioned", async () => {
+    // `POST /agents` persists its `nix` on the session and replays it as a base
+    // option, so agent settings must not clobber the caller's packages.
+    const resolved = await resolveNixConfig(
+      {
+        nixConfig: { packages: ["agent-pkg"] },
+        skillsConfig: {
+          skills: [
+            {
+              repo: "lobu/skills",
+              name: "video",
+              enabled: true,
+              nixPackages: ["skill-pkg"],
+            },
+          ],
+        },
+      },
+      { packages: ["request-pkg"] },
+    );
+
+    expect(resolved?.packages).toEqual([
+      "request-pkg",
+      "agent-pkg",
+      "skill-pkg",
+    ]);
+  });
+
+  test("a per-request nixConfig survives when the agent declares none", async () => {
+    const resolved = await resolveNixConfig({}, { packages: ["request-pkg"] });
+
+    expect(resolved?.packages).toEqual(["request-pkg"]);
+  });
+
+  test("disabled skills contribute nothing", async () => {
+    const resolved = await resolveNixConfig({
+      nixConfig: { packages: ["ripgrep"] },
+      skillsConfig: {
+        skills: [
+          {
+            repo: "lobu/skills",
+            name: "video",
+            enabled: false,
+            nixPackages: ["ffmpeg"],
+          },
+        ],
+      },
+    });
+
+    expect(resolved?.packages).toEqual(["ripgrep"]);
+  });
+
+  test("flakeUrl is preserved when skill packages are unioned in", async () => {
+    const resolved = await resolveNixConfig({
+      nixConfig: { flakeUrl: "github:org/flake" },
+      skillsConfig: {
+        skills: [
+          {
+            repo: "lobu/skills",
+            name: "video",
+            enabled: true,
+            nixPackages: ["ffmpeg"],
+          },
+        ],
+      },
+    });
+
+    expect(resolved?.flakeUrl).toBe("github:org/flake");
+    expect(resolved?.packages).toEqual(["ffmpeg"]);
+  });
+
+  test("no nix anywhere leaves nixConfig unset (absent stays absent)", async () => {
+    const resolved = await resolveNixConfig({
+      skillsConfig: {
+        skills: [
+          {
+            repo: "lobu/skills",
+            name: "prose-only",
+            enabled: true,
+          },
+        ],
+      },
+    });
+
+    expect(resolved).toBeUndefined();
+  });
+});

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -2477,6 +2477,7 @@ export class ChatInstanceManager {
       agentSettingsStore,
       organizationId,
     );
+    const { nixConfig, ...remainingAgentOptions } = agentOptions;
 
     await sessionManager.setSession({
       conversationId: sessionId,
@@ -2516,7 +2517,8 @@ export class ChatInstanceManager {
         sessionId,
         source: "platform-cli",
       },
-      agentOptions,
+      agentOptions: remainingAgentOptions,
+      nixConfig,
     });
 
     logger.info(

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1498,6 +1498,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       const baseOptions: Record<string, any> = {
         provider: session.provider || "claude",
         model: behaviorModel ?? session.model,
+        nixConfig: session.nixConfig,
         ...(behaviorModel ? { behaviorModelOverride: true } : {}),
       };
       const agentOptions = await resolveAgentOptions(
@@ -1510,6 +1511,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       const {
         networkConfig: settingsNetwork,
         guardrailsInline: settingsGuardrailsInline,
+        nixConfig: resolvedNixConfig,
         ...remainingOptions
       } = agentOptions;
 
@@ -1623,6 +1625,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         agentOptions: remainingOptions,
         networkConfig: session.networkConfig || settingsNetwork,
         guardrailsInline: settingsGuardrailsInline,
+        nixConfig: resolvedNixConfig,
       });
 
       rootSpan?.end();

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -6,6 +6,7 @@
 import {
   createLogger,
   type MessagePayload,
+  type NixConfig,
 } from "@lobu/core";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import { composeEffectiveModelRef } from "../auth/settings/model-selection.js";
@@ -92,8 +93,35 @@ export async function resolveAgentOptions(
   if (settings.guardrailsInline?.length) {
     mergedOptions.guardrailsInline = settings.guardrailsInline;
   }
-  if (settings.nixConfig) {
-    mergedOptions.nixConfig = settings.nixConfig;
+  // Nix packages come from three places and every one of them is a hard
+  // requirement of some code that will run in the spawned worker, so union
+  // them rather than letting the last writer win:
+  //   1. baseOptions.nixConfig  — per-request `nix` (POST /agents supplies it),
+  //   2. settings.nixConfig     — the agent's own packages (CLI apply bakes the
+  //                               skill union of the time into this too),
+  //   3. enabled skills' nixPackages — skills enabled via the UI/catalog write
+  //                               only `skills_config`, so nothing recomputes
+  //                               `nixConfig` and their packages never reached
+  //                               provisioning before this.
+  // Absent stays absent: with no nix anywhere, `nixConfig` is left unset so the
+  // worker spawns without a nix-shell wrap.
+  const skillNixPackages = (settings.skillsConfig?.skills ?? [])
+    .filter((skill) => skill.enabled)
+    .flatMap((skill) => skill.nixPackages ?? []);
+  const baseNixConfig = mergedOptions.nixConfig as NixConfig | undefined;
+  if (baseNixConfig || settings.nixConfig || skillNixPackages.length > 0) {
+    const packages = [
+      ...new Set([
+        ...(baseNixConfig?.packages ?? []),
+        ...(settings.nixConfig?.packages ?? []),
+        ...skillNixPackages,
+      ]),
+    ];
+    mergedOptions.nixConfig = {
+      ...baseNixConfig,
+      ...settings.nixConfig,
+      ...(packages.length > 0 ? { packages } : {}),
+    };
   }
   if (settings.toolsConfig) {
     mergedOptions.toolsConfig = settings.toolsConfig;

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -98,7 +98,7 @@ export async function resolveAgentOptions(
   // them rather than letting the last writer win:
   //   1. baseOptions.nixConfig  — per-request `nix` (POST /agents supplies it),
   //   2. settings.nixConfig     — the agent's own packages (CLI apply bakes the
-  //                               skill union of the time into this too),
+  //                               skill union at apply time into this too),
   //   3. enabled skills' nixPackages — skills enabled via the UI/catalog write
   //                               only `skills_config`, so nothing recomputes
   //                               `nixConfig` and their packages never reached


### PR DESCRIPTION
## Summary
- Nix packages that a spawned worker needs were being dropped on three paths. Skills enabled via the UI/catalog write only `skills_config`; the skill→agent `nixConfig` union was an **apply-time snapshot** baked by `lobu apply` (`packages/cli/src/commands/_lib/apply/map-config.ts:296-305`), so UI-installed skills' `nixPackages` never reached provisioning.
- `chat-instance-manager.ts` and `routes/public/agent.ts` hand-roll their enqueue payload instead of calling `buildMessagePayload`, so `nixConfig` stayed nested inside `agentOptions` where the spawn path never reads it. The `nix` accepted by `POST /agents` was persisted on the session and then dropped entirely.
- Agent settings overwrote a per-request `nixConfig` wholesale instead of unioning with it.

`resolveAgentOptions` now unions all three sources (per-request → agent settings → enabled skills' `nixPackages`), deduped and request-first. Absent stays absent, so agents with no nix anywhere still spawn without a `nix-shell` wrap.

Class check: the other two `resolveAgentOptions` callers (`manage_conversations.ts:242`, `message-handler-bridge.ts:1301`) already route through `buildMessagePayload`, which lifts `nixConfig` to the top-level payload field correctly. No further instances.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test src/gateway/__tests__/platform-helpers-nix-union.test.ts src/gateway/__tests__/platform-helpers-model-resolution.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Red (helper reverted to the original `if (settings.nixConfig)`)
```
error: expect(received).toEqual(expected)
- [ "ffmpeg" ]
+ undefined
(fail) resolveAgentOptions nix union > an enabled skill's nixPackages reach nixConfig even when the agent has none
(fail) resolveAgentOptions nix union > agent packages come first and the union is deduped
(fail) resolveAgentOptions nix union > per-request, agent and skill packages are all unioned
(fail) resolveAgentOptions nix union > flakeUrl is preserved when skill packages are unioned in

 3 pass
 5 fail
Ran 8 tests across 1 file.
```

### Green
```
 22 pass
 0 fail
 28 expect() calls
Ran 22 tests across 2 files.
```

### Mutation check (proving the new assertions bite)
Dropping `...(baseNixConfig?.packages ?? [])` from the union → 2 fail. Dropping `.filter((skill) => skill.enabled)` → 1 fail (`disabled skills contribute nothing`). Both reverted.

## Notes
**Rollout / behavior change:** UI-installed skills **start** provisioning after this. Skills disabled *after* an apply keep contributing via the baked snapshot until the next `lobu apply` — once baked into `settings.nixConfig` they are indistinguishable from agent-declared packages, so they cannot be subtracted safely.

Not verified: no live worker spawn under `nix-shell` was exercised — this is unit-level at the `resolveAgentOptions` seam plus `make pre-pr`.

Follow-up: stop the CLI baking the union once servers carrying this runtime union are the norm (skew risk today: new CLI + old self-hosted server would lose skill packages).

Context: this is Stage 1 of the Behavior×Skill study — the merge into "live skills" was rejected; nix stays declared on the skill and the fix is resolve-time union, not an entity merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->