### PR TITLE
chore(behaviors): prune dead watcher hooks; retire the recap framing (owletto#610)

### DIFF
--- a/packages/server/src/tools/admin/manage_behaviors/feedback.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/feedback.ts
@@ -431,12 +431,13 @@ export async function handleGetFeedback(
 // ============================================
 
 /**
- * List the entities a watcher promoted (its keyed children). These are the
- * durable, per-item correctable units of the recap: each row carries the
- * entity's metadata (the extracted field values) plus `field_controls` (which
- * fields a human already owns), so the recap can render approve/correct
- * affordances keyed on (entity_id, field). Promoted children stamp
- * `metadata.watcher_id` / `source='watcher_promotion'` at promotion time.
+ * List the entities a watcher promoted (its keyed children) — the behavior's
+ * durable product. Each row carries the entity's metadata (the extracted
+ * field values) plus `field_controls` (which fields a human already owns).
+ * The web activity view uses only the count + entity_type for its outputs
+ * strip; field ownership/corrections live on the entity page. Promoted
+ * children stamp `metadata.watcher_id` / `source='watcher_promotion'` at
+ * promotion time.
  *
  * Org-scoped so a member of org A can't enumerate org B's promoted entities by
  * passing a watcher_id (auth also gates on requireWatcherAccess 'read').


### PR DESCRIPTION
Cleanup pass after the behavior-activity work (#2217):

- **Pointer bump to post-owletto#610 main**: `use-watchers.ts` loses every hook with no importer — the no-auth public behavior surface (`usePublicWatchersList`/`usePublicWatcherDetail`), `useTriggerWatcher`, and the recap-era window-correction loop (`useSubmitFeedback`/`useGetFeedback` + types); internal-only types lose `export`. −184 lines. Each deletion verified by word-boundary grep; server APIs untouched. The bump also absorbs owletto#607 (suggestion cards), already on owletto main.
- **Server comment fix**: `handleListPromoted`'s doc described the deleted recap approve/correct UI; it now describes the actual consumer (the activity outputs strip) and points corrections at the entity page. No behavior change.

Gates: owletto tsc/biome/vitest 950/950; parent `make pre-pr` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the description of promoted entities in recap and web activity views.
  * Explained that detailed field ownership and corrections are available on the entity page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->