### PR TITLE
docs(behaviors): align handleListPromoted comment with activity strip

### DIFF
--- a/packages/server/src/tools/admin/manage_behaviors/feedback.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/feedback.ts
@@ -431,12 +431,13 @@ export async function handleGetFeedback(
 // ============================================
 
 /**
- * List the entities a watcher promoted (its keyed children). These are the
- * durable, per-item correctable units of the recap: each row carries the
- * entity's metadata (the extracted field values) plus `field_controls` (which
- * fields a human already owns), so the recap can render approve/correct
- * affordances keyed on (entity_id, field). Promoted children stamp
- * `metadata.watcher_id` / `source='watcher_promotion'` at promotion time.
+ * List the entities a watcher promoted (its keyed children) — the behavior's
+ * durable product. Each row carries the entity's metadata (the extracted
+ * field values) plus `field_controls` (which fields a human already owns).
+ * The web activity view uses only the count + entity_type for its outputs
+ * strip; field ownership/corrections live on the entity page. Promoted
+ * children stamp `metadata.watcher_id` / `source='watcher_promotion'` at
+ * promotion time.
  *
  * Org-scoped so a member of org A can't enumerate org B's promoted entities by
  * passing a watcher_id (auth also gates on requireWatcherAccess 'read').


### PR DESCRIPTION
## Summary
- Update `handleListPromoted` docs: the recap approve/correct UI is gone; the web consumer is the activity outputs strip. Field ownership stays on the entity page.

This is the only parent-repo change still outstanding from #2221 after #2224 already landed the owletto pin (owletto#610 dead-hook prune).

## Test plan
- [x] Comment-only change; pre-commit typecheck clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how promoted-entity information is used in the web activity view.
  * Documented where field ownership and corrections are managed.
  * Added context on metadata associated with promoted child entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->