### PR TITLE
fix(api): expose behavior IDs in operation responses

### DIFF
--- a/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
@@ -177,6 +177,11 @@ describe("behavior health surfacing (#2033)", () => {
 
   it("3.3: list emits behavior_* lineage keys, never the internal watcher_* names", async () => {
     const { behaviorId, ctx } = await createScheduledBehavior();
+    await getTestDb()`
+      UPDATE watchers
+      SET source_watcher_id = id
+      WHERE id = ${behaviorId}
+    `;
     const result = await manageBehaviors({ action: "list" }, {} as Env, ctx);
     if (result.action !== "list") throw new Error("expected list result");
     const row = result.behaviors.find(
@@ -184,7 +189,7 @@ describe("behavior health surfacing (#2033)", () => {
     ) as Record<string, unknown> | undefined;
     expect(row).toBeDefined();
     expect(row?.behavior_group_id).toBe(String(behaviorId));
-    expect(row?.source_behavior_id).toBeNull();
+    expect(row?.source_behavior_id).toBe(String(behaviorId));
     expect(row).not.toHaveProperty("watcher_group_id");
     expect(row).not.toHaveProperty("source_watcher_id");
   });

--- a/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
+++ b/packages/server/src/__tests__/integration/operations-getrun-internal.test.ts
@@ -17,6 +17,17 @@ import { createTestOrganization, createTestUser } from "../setup/test-fixtures";
 
 const env = {} as Env;
 
+function watcherKeys(value: unknown, path = "$"): string[] {
+	if (Array.isArray(value)) {
+		return value.flatMap((item, index) => watcherKeys(item, `${path}[${index}]`));
+	}
+	if (value === null || typeof value !== "object") return [];
+	return Object.entries(value).flatMap(([key, child]) => [
+		...(key.toLowerCase().includes("watcher") ? [`${path}.${key}`] : []),
+		...watcherKeys(child, `${path}.${key}`),
+	]);
+}
+
 describe("manage_operations get_run — internal runs", () => {
 	let orgId: string;
 
@@ -136,5 +147,89 @@ describe("manage_operations get_run — internal runs", () => {
 		expect(found?.initiator_kind).toBe("agent_session");
 		expect(found?.created_by_user_id).toBe(proposer.id);
 		expect(found?.initiator_ref).toEqual(initiatorRef);
+	});
+
+	it("uses Behavior vocabulary for every platform-owned public run field", async () => {
+		const db = getTestDb();
+		const creator = await createTestUser();
+		const [behavior] = (await db`
+			WITH next_id AS (
+				SELECT nextval('watchers_id_seq')::integer AS id
+			)
+			INSERT INTO watchers (
+				id, watcher_group_id, organization_id, agent_id, created_by, name, slug
+			)
+			SELECT id, id, ${orgId}, 'personal-agent', ${creator.id}, 'Public vocabulary', 'public-vocabulary'
+			FROM next_id
+			RETURNING id
+		`) as unknown as Array<{ id: number }>;
+		const behaviorId = Number(behavior.id);
+		const [row] = (await db`
+			INSERT INTO runs (
+				organization_id, run_type, action_key, action_input, watcher_id,
+				status, approval_status,
+				initiator_kind, initiator_ref, created_at, run_at
+			)
+			VALUES (
+				${orgId}, 'internal', 'entity_field_change',
+				${db.json({
+					watcher_id: behaviorId,
+					entity_id: 42,
+					fields: { status: "reviewed" },
+				})},
+				${behaviorId}, 'completed', 'auto',
+				'behavior',
+				${db.json({ watcher_id: behaviorId, window_id: 17, run_id: 18 })},
+				now(), now()
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: number }>;
+		const runId = Number(row.id);
+
+		const listed = (await manageOperations(
+			{ action: "list_runs", run_types: ["internal"] },
+			env,
+			ctx(),
+		)) as { runs: Array<Record<string, unknown>> };
+		const listedRun = listed.runs.find((run) => Number(run.id) === runId);
+		expect(listedRun?.behavior_id).toBe(behaviorId);
+		expect(listedRun?.initiator_ref).toEqual({
+			behavior_id: behaviorId,
+			window_id: 17,
+			run_id: 18,
+		});
+		expect(listedRun?.input).toEqual({
+			behavior_id: behaviorId,
+			entity_id: 42,
+			fields: { status: "reviewed" },
+		});
+		expect(watcherKeys(listedRun)).toEqual([]);
+
+		const got = (await getRun(runId)).run as Record<string, unknown>;
+		expect(got.behavior_id).toBe(behaviorId);
+		expect(got.initiator_ref).toEqual({
+			behavior_id: behaviorId,
+			window_id: 17,
+			run_id: 18,
+		});
+		expect(got.input).toEqual({
+			behavior_id: behaviorId,
+			entity_id: 42,
+			fields: { status: "reviewed" },
+		});
+		expect(watcherKeys(got)).toEqual([]);
+
+		const activity = (await manageOperations(
+			{
+				action: "list_activity",
+				include_notifications: false,
+				aggregate: false,
+			},
+			env,
+			ctx(),
+		)) as { items: Array<Record<string, unknown>> };
+		const card = activity.items.find((item) => Number(item.run_id) === runId);
+		expect(card?.behavior_id).toBe(behaviorId);
+		expect(watcherKeys(card)).toEqual([]);
 	});
 });

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1366,6 +1366,42 @@ async function handleListActivity(
 	};
 }
 
+function publicBehaviorFields(value: unknown): unknown {
+	if (
+		value === null ||
+		typeof value !== "object" ||
+		Array.isArray(value)
+	) {
+		return value;
+	}
+	const {
+		watcher_id: behaviorId,
+		...publicRef
+	} = value as Record<string, unknown>;
+	return behaviorId == null
+		? publicRef
+		: { ...publicRef, behavior_id: behaviorId };
+}
+
+function publicRunRecord(
+	row: Record<string, unknown>,
+): Record<string, unknown> {
+	return {
+		...row,
+		input:
+			row.run_type === "internal" &&
+			ENTITY_CHANGE_ACTION_KEYS.some(
+				(actionKey) => actionKey === row.operation_key,
+			)
+				? publicBehaviorFields(row.input)
+				: row.input,
+		initiator_ref:
+			row.initiator_kind === "behavior"
+				? publicBehaviorFields(row.initiator_ref)
+				: row.initiator_ref,
+	};
+}
+
 async function handleListRuns(
 	args: Static<typeof ListRunsAction>,
 	ctx: ToolContext,
@@ -1448,7 +1484,7 @@ async function handleListRuns(
     pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
   }
   const query = sql`
-    SELECT r.id, r.run_type, r.watcher_id, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
+    SELECT r.id, r.run_type, r.watcher_id AS behavior_id, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.items_collected, r.checkpoint,
            r.created_at, r.completed_at,
@@ -1467,7 +1503,7 @@ async function handleListRuns(
 
   return {
 		action: "list_runs",
-    runs: rows,
+    runs: rows.map((row) => publicRunRecord(row)),
     total: Number(countResult[0]?.total ?? 0),
     limit,
     offset,
@@ -1489,7 +1525,7 @@ async function handleGetRun(
   // a run visible in the list is always fetchable here. Only the chat-message
   // transport lane (the list's default exclusion) stays unfetchable.
   const rows = await sql`
-    SELECT r.id, r.connection_id, r.connector_key,
+    SELECT r.id, r.watcher_id AS behavior_id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.run_type,
            r.created_at, r.completed_at,
@@ -1501,7 +1537,10 @@ async function handleGetRun(
     LIMIT 1
   `;
 	if (rows.length === 0) return { error: "Run not found" };
-	return { action: "get_run", run: rows[0] };
+	return {
+		action: "get_run",
+		run: publicRunRecord(rows[0] as Record<string, unknown>),
+	};
 }
 
 /**

--- a/packages/server/src/tools/admin/manage_operations/activity-feed.ts
+++ b/packages/server/src/tools/admin/manage_operations/activity-feed.ts
@@ -48,7 +48,7 @@ export type ActivityCard = {
 	interaction_inline?: boolean;
 	member_run_ids?: number[];
 	connection_id?: number;
-	watcher_id?: number;
+	behavior_id?: number;
 };
 
 type RawCard = ActivityCard & {
@@ -444,7 +444,7 @@ export async function listOrgActivity(opts: {
 					href: runHref(opts.ownerSlug, r),
 					run_id: r.id,
 					connection_id: r.connection_id ?? undefined,
-					watcher_id: r.watcher_id ?? undefined,
+					behavior_id: r.watcher_id ?? undefined,
 					collapseKey: collapseKeyForRun(r),
 					itemsCollected: r.items_collected,
 				});

--- a/scripts/__tests__/check-exposed-surface-naming.test.ts
+++ b/scripts/__tests__/check-exposed-surface-naming.test.ts
@@ -24,6 +24,10 @@ const CONTRACT_FILE = join(
   REPO_ROOT,
   "packages/core/src/contracts/tools/manage-entity.ts"
 );
+const PUBLIC_ACTIVITY_FILE = join(
+  REPO_ROOT,
+  "packages/server/src/tools/admin/manage_operations/activity-feed.ts"
+);
 /** Defines `AuthProfileKind`, which the auth-profiles namespace imports aliased. */
 const IMPORTED_TYPE_FILE = join(
   REPO_ROOT,
@@ -94,6 +98,15 @@ describe("check-exposed-surface-naming", () => {
       CONTRACT_FILE,
       "  behavior_source: Type.Optional(",
       "  watcherId: Type.Optional(Type.String()),\n"
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("fails on a banned key in a plain public response type", () => {
+    mutate(
+      PUBLIC_ACTIVITY_FILE,
+      "\tbehavior_id?: number;",
+      "\twatcher_id?: number;"
     );
     expect(runGuard()).toBe(1);
   });

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -7,6 +7,7 @@
  *   - MCP tool schemas, names, descriptions, or titles
  *   - ClientSDK discovery metadata, aliases, or namespace method names
  *   - the connector-sdk public reaction contract
+ *   - server and web-client response types for shared public tool payloads
  *
  * TypeBox schema initializers are scanned under the core tool contracts and the
  * server's tool/type sources. Other source scans are deliberately limited to
@@ -445,6 +446,23 @@ for (const file of collectTsFiles(namespacesDir)) {
   scanNamespaceSurface(file, violations);
 }
 
+// Plain TypeScript response types are not TypeBox initializers, but they still
+// describe public tool payloads. Keep the server projection and the trusted web
+// client's wire models under the same vocabulary gate so a generic
+// Type.Record result cannot hide a stale key from the schema scan.
+for (const file of [
+  join(
+    REPO_ROOT,
+    "packages/server/src/tools/admin/manage_operations/activity-feed.ts"
+  ),
+  join(REPO_ROOT, "packages/owletto/src/lib/api/activity.ts"),
+  join(REPO_ROOT, "packages/owletto/src/lib/api/behaviors.ts"),
+  join(REPO_ROOT, "packages/owletto/src/lib/api/content.ts"),
+  join(REPO_ROOT, "packages/owletto/src/lib/api/runs.ts"),
+]) {
+  scanNamespaceSurface(file, violations);
+}
+
 const seen = new Set<string>();
 const unique = violations.filter((violation) => {
   const key = `${violation.file}:${violation.line}:${violation.excerpt}`;
@@ -466,7 +484,7 @@ if (unique.length > 0) {
   }
   console.error(
     `\nScope: MCP tool schemas/descriptions, ClientSDK discovery and callable ` +
-      `method names, and the public reaction client types. Internal engine ` +
+      `method names, public response types, and the reaction client types. Internal engine ` +
       `names outside exposed schema constructs remain allowed.`
   );
   process.exit(1);


### PR DESCRIPTION
## Summary
- expose `behavior_id` instead of `watcher_id` in public operation and activity responses
- project nested Behavior initiator and platform-owned entity-change inputs to public behavior terminology
- add a public-surface naming guard and integration coverage for list/get/activity response shapes
- pin Owletto to merged PR lobu-ai/owletto#611, which updates public response models and removes dead watcher-era activity helpers

Internal database/runtime watcher identifiers remain unchanged; this PR only cleans the public API surface.

## Validation
- `make pre-pr`
- `REVIEWER_CLI=codex make review` — 0 bugs, 0 blockers, tests adequate
- focused server operation/behavior integration tests
- focused Owletto tests and typecheck
- red→green coverage for missing `behavior_id` and leaked entity-change `input.watcher_id`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Public run and activity responses now use behavior-focused fields instead of internal watcher terminology.
  * Run listings and details provide consistent behavior identifiers, initiator information, and inputs.
  * Internal watcher-specific fields are no longer exposed in public run, activity, or behavior responses.
* **Quality**
  * Added safeguards to prevent internal watcher naming from appearing in public response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->