### PR TITLE
fix(server): surface pending approvals hidden by the ACL resource gate + stop persisting NULL occurred_at

### DIFF
--- a/db/migrations/20260728100000_events_occurred_at_backfill.sql
+++ b/db/migrations/20260728100000_events_occurred_at_backfill.sql
@@ -1,0 +1,23 @@
+-- Backfill occurred_at on agent/system-emitted events that were inserted NULL.
+--
+-- insertEvent had no occurred_at default, so callers that supplied no source
+-- timestamp (operation approval cards, tool-invocation audit rows, and
+-- change/lifecycle/config audit trails) persisted NULL. NULL occurred_at is
+-- excluded by the memory feed's since/until filters, sorts ahead of dated rows
+-- under `ORDER BY occurred_at DESC`, and can prevent construction of a
+-- before_occurred_at keyset cursor. The code fix stamps insert time for new
+-- insertEvent rows; created_at is the best available approximation for existing
+-- rows because these events had no separate source timestamp.
+--
+-- Metadata-only repair of rows that were never orderable; payloads untouched
+-- (append-only invariant applies to content).
+
+-- migrate:up
+UPDATE public.events
+   SET occurred_at = created_at
+ WHERE occurred_at IS NULL;
+
+-- migrate:down
+-- Intentionally empty: the pre-backfill NULLs carried no information, and new
+-- inserts default occurred_at anyway — there is no meaningful prior state to
+-- restore.

--- a/db/migrations/20260728100010_behavior_default_source_excludes_bookkeeping.sql
+++ b/db/migrations/20260728100010_behavior_default_source_excludes_bookkeeping.sql
@@ -1,0 +1,75 @@
+-- Rewrite the persisted Behavior default source to exclude bookkeeping rows.
+--
+-- Behaviors authored with no sources persist a default all-events source
+-- (`SELECT * FROM events ORDER BY occurred_at DESC`). Server bookkeeping rows
+-- (`semantic_type` 'change' — config/lifecycle/entity audit trails — and
+-- 'audit' — the tool-invocation log) were historically invisible to Behavior
+-- windows only because they were inserted with occurred_at NULL; now that
+-- insertEvent stamps occurred_at, an unchanged default source would let a
+-- Behavior's own creation bookkeeping defeat skip_if_unchanged and would turn
+-- every config edit into "new workspace content". New Behaviors persist the
+-- excluding query (DEFAULT_BEHAVIOR_SOURCE_QUERY); this rewrites EXISTING
+-- rows, matched by the exact legacy literal so explicitly authored sources are
+-- never touched.
+
+-- migrate:up
+UPDATE public.watchers
+   SET sources = (
+     SELECT jsonb_agg(
+       CASE
+         WHEN elem->>'query' = 'SELECT * FROM events ORDER BY occurred_at DESC'
+         THEN jsonb_set(
+           elem,
+           '{query}',
+           to_jsonb('SELECT * FROM events WHERE semantic_type NOT IN (''change'', ''audit'') ORDER BY occurred_at DESC'::text)
+         )
+         ELSE elem
+       END
+     )
+     FROM jsonb_array_elements(sources) AS elem
+   )
+ WHERE sources @> '[{"query": "SELECT * FROM events ORDER BY occurred_at DESC"}]'::jsonb;
+
+UPDATE public.watcher_versions
+   SET version_sources = (
+     SELECT jsonb_agg(
+       CASE
+         WHEN elem->>'query' = 'SELECT * FROM events ORDER BY occurred_at DESC'
+         THEN jsonb_set(
+           elem,
+           '{query}',
+           to_jsonb('SELECT * FROM events WHERE semantic_type NOT IN (''change'', ''audit'') ORDER BY occurred_at DESC'::text)
+         )
+         ELSE elem
+       END
+     )
+     FROM jsonb_array_elements(version_sources) AS elem
+   )
+ WHERE version_sources @> '[{"query": "SELECT * FROM events ORDER BY occurred_at DESC"}]'::jsonb;
+
+-- migrate:down
+UPDATE public.watchers
+   SET sources = (
+     SELECT jsonb_agg(
+       CASE
+         WHEN elem->>'query' = 'SELECT * FROM events WHERE semantic_type NOT IN (''change'', ''audit'') ORDER BY occurred_at DESC'
+         THEN jsonb_set(elem, '{query}', to_jsonb('SELECT * FROM events ORDER BY occurred_at DESC'::text))
+         ELSE elem
+       END
+     )
+     FROM jsonb_array_elements(sources) AS elem
+   )
+ WHERE sources @> '[{"query": "SELECT * FROM events WHERE semantic_type NOT IN (''change'', ''audit'') ORDER BY occurred_at DESC"}]'::jsonb;
+
+UPDATE public.watcher_versions
+   SET version_sources = (
+     SELECT jsonb_agg(
+       CASE
+         WHEN elem->>'query' = 'SELECT * FROM events WHERE semantic_type NOT IN (''change'', ''audit'') ORDER BY occurred_at DESC'
+         THEN jsonb_set(elem, '{query}', to_jsonb('SELECT * FROM events ORDER BY occurred_at DESC'::text))
+         ELSE elem
+       END
+     )
+     FROM jsonb_array_elements(version_sources) AS elem
+   )
+ WHERE version_sources @> '[{"query": "SELECT * FROM events WHERE semantic_type NOT IN (''change'', ''audit'') ORDER BY occurred_at DESC"}]'::jsonb;

--- a/packages/server/src/__tests__/integration/events/approval-event-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/approval-event-visibility.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Interaction events (approvals, suggestions) must stay visible to organization
+ * members while a connection's ACL graph is fresh.
+ *
+ * The generic resource gate (`authz/resource-visibility`) hides an enforced
+ * connection's events unless the requester is `member_of` a resource entity in
+ * `events.entity_ids`. Agent-emitted interaction events (an operation's
+ * "pending approval" card) are stamped with the connection they act THROUGH but
+ * carry no resource entity link — so the gate hid them from org admins too, and
+ * the approval permalink (`/{org}/memory?run_ids=…`)
+ * rendered "No results found" with no way to approve. Interaction rows are
+ * workflow state addressed to the org's authenticated humans, not
+ * connector-synced resource content, so the fresh-ACL gate passes them through
+ * without weakening its headless or stale-ACL boundaries.
+ *
+ * Also pins the second defect on the same rows: `insertEvent` persisted
+ * `occurred_at` NULL when the caller supplied no timestamp, which breaks
+ * date-feed ordering and terminates keyset pagination.
+ */
+
+import {
+  type GithubRepoInput,
+  githubAclSource,
+  githubReposToResources,
+} from '@lobu/connectors/github-identity';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildAccessGraph } from '../../../authz/access-graph';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { insertEvent } from '../../../utils/insert-event';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+function ctxFor(
+  orgId: string,
+  userId: string | null,
+  memberRole: string | null = userId ? 'owner' : null
+): ToolContext {
+  return {
+    organizationId: orgId,
+    userId,
+    memberRole,
+    isAuthenticated: !!userId,
+    tokenType: userId ? 'oauth' : 'anonymous',
+    scopedToOrg: !userId,
+    allowCrossOrg: !!userId,
+    scopes: userId ? ['mcp:read'] : undefined,
+  } as ToolContext;
+}
+
+async function listEventIdsForRun(
+  ctx: ToolContext,
+  runId: number
+): Promise<Set<number>> {
+  const result = (await getContent(
+    { run_ids: [runId], limit: 50 } as never,
+    {} as never,
+    ctx
+  )) as { content?: Array<{ id: number }> };
+  return new Set((result.content ?? []).map((c) => c.id));
+}
+
+describe('interaction events on ACL-enforced connections (approval permalink path)', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    clearEntityLinkRulesCache();
+  });
+
+  async function createPendingRun(orgId: string, connectionId: number): Promise<number> {
+    const sql = getTestDb();
+    const rows = await sql`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status, connection_id, connector_key, action_key
+      ) VALUES (
+        ${orgId}, 'action', 'pending', 'pending', ${connectionId}, 'github', 'create_issue'
+      )
+      RETURNING id
+    `;
+    return Number(rows[0].id);
+  }
+
+  function insertApprovalEvent(orgId: string, connectionId: number, runId: number, origin: string) {
+    return insertEvent({
+      entityIds: [],
+      organizationId: orgId,
+      originId: origin,
+      title: 'Create Issue — pending approval',
+      semanticType: 'operation',
+      connectorKey: 'github',
+      connectionId,
+      runId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+    });
+  }
+
+  async function setupEnforcedWorkspace() {
+    const org = await createTestOrganization({ name: 'Acme Approvals' });
+    const alice = await createTestUser({
+      name: 'Alice',
+      email: 'alice-approvals@example.com',
+    });
+    await addUserToOrganization(alice.id, org.id, 'owner');
+
+    const conn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      visibility: 'org',
+      createDefaultFeed: false,
+    });
+
+    const repos: GithubRepoInput[] = [
+      { fullName: 'acme/repo-a', collaborators: [{ login: 'bob', id: 102 }] },
+    ];
+    await buildAccessGraph({
+      organizationId: org.id,
+      connectionId: String(conn.id),
+      connectorKey: githubAclSource.key,
+      resourceNamespace: githubAclSource.resourceNamespace,
+      memberIdentities: githubAclSource.memberIdentities,
+      resources: githubReposToResources(repos),
+    });
+
+    return { org, alice, conn };
+  }
+
+  it('an org member sees the pending-approval event via run_ids even though it has no resource link', async () => {
+    const { org, alice, conn } = await setupEnforcedWorkspace();
+    const runId = await createPendingRun(org.id, conn.id);
+    const event = await insertApprovalEvent(org.id, conn.id, runId, `run_${runId}_pending`);
+
+    // The approval permalink reads exactly this: run_ids-scoped list as the
+    // signed-in member. Pre-fix the resource gate dropped the row (0 results).
+    const visible = await listEventIdsForRun(ctxFor(org.id, alice.id), runId);
+    expect(visible.has(event.id)).toBe(true);
+  });
+
+  it('the approval stays visible to a member when the ACL graph goes STALE (a stalled sync must not wedge approvals)', async () => {
+    const { org, alice, conn } = await setupEnforcedWorkspace();
+    const runId = await createPendingRun(org.id, conn.id);
+
+    const event = await insertApprovalEvent(org.id, conn.id, runId, `run_${runId}_pending`);
+
+    const sql = getTestDb();
+    await sql`
+      UPDATE authz_source_acl_state
+      SET last_synced_at = current_timestamp - interval '90 minutes'
+      WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+    `;
+
+    const visible = await listEventIdsForRun(ctxFor(org.id, alice.id), runId);
+    expect(visible.has(event.id)).toBe(true);
+  });
+
+  it('a plain non-interaction event with no resource link stays gated (exemption is interaction-only)', async () => {
+    const { org, alice, conn } = await setupEnforcedWorkspace();
+    const runId = await createPendingRun(org.id, conn.id);
+
+    const event = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `synced_${runId}`,
+      title: 'repo A issue: quarterly metrics',
+      content: 'synced connector content without a resource link',
+      semanticType: 'message',
+      connectorKey: 'github',
+      connectionId: conn.id,
+      runId,
+    });
+
+    // interaction_type='none' rows keep the enforced-connection membership
+    // requirement — the exemption must not become a general bypass.
+    const visible = await listEventIdsForRun(ctxFor(org.id, alice.id), runId);
+    expect(visible.has(event.id)).toBe(false);
+  });
+
+  it('a headless caller cannot read the interaction event on an enforced connection', async () => {
+    const { org, conn } = await setupEnforcedWorkspace();
+    const runId = await createPendingRun(org.id, conn.id);
+    const event = await insertApprovalEvent(org.id, conn.id, runId, `headless_${runId}`);
+
+    const visible = await listEventIdsForRun(ctxFor(org.id, null), runId);
+    expect(visible.has(event.id)).toBe(false);
+  });
+
+  it('an authenticated non-member cannot read the interaction event', async () => {
+    const { org, conn } = await setupEnforcedWorkspace();
+    const outsider = await createTestUser({
+      name: 'Outsider',
+      email: 'outsider-approvals@example.com',
+    });
+    const runId = await createPendingRun(org.id, conn.id);
+    const event = await insertApprovalEvent(org.id, conn.id, runId, `outsider_${runId}`);
+
+    const visible = await listEventIdsForRun(ctxFor(org.id, outsider.id, null), runId);
+    expect(visible.has(event.id)).toBe(false);
+  });
+
+  it('insertEvent stamps occurred_at when the caller supplies none', async () => {
+    const { org, conn } = await setupEnforcedWorkspace();
+
+    const event = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'occurred-at-default-probe',
+      title: 'no timestamp supplied',
+      semanticType: 'operation',
+      connectionId: conn.id,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+    });
+
+    const sql = getTestDb();
+    const rows = await sql`SELECT occurred_at FROM events WHERE id = ${event.id}`;
+    expect(rows[0]?.occurred_at).not.toBeNull();
+  });
+
+  it('an occurredAt-less upsert of identical state stays "unchanged" despite the stamped default', async () => {
+    const { org, conn } = await setupEnforcedWorkspace();
+
+    const params = {
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'occurred-at-dedup-probe',
+      title: 'idempotent upsert',
+      semanticType: 'operation' as const,
+      connectionId: conn.id,
+    };
+    const first = await insertEvent(params, { onConflictUpdate: true });
+    expect(first.change).toBe('inserted');
+
+    // The auto-stamped occurred_at of the first insert must not read as a
+    // semantic change on the identical re-upsert — that would supersede the
+    // row on every re-sync.
+    const second = await insertEvent(params, { onConflictUpdate: true });
+    expect(second.change).toBe('unchanged');
+    expect(second.id).toBe(first.id);
+  });
+});

--- a/packages/server/src/__tests__/integration/migrations/behavior-default-source-migration.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/behavior-default-source-migration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Migration 20260728100010 rewrites the persisted Behavior DEFAULT source
+ * (the legacy `SELECT * FROM events ORDER BY occurred_at DESC` literal) to the
+ * bookkeeping-excluding DEFAULT_BEHAVIOR_SOURCE_QUERY. It matches by exact
+ * query text — the schema stores no generated-vs-authored provenance — so this
+ * replay proves both directions of the contract:
+ *   - a source carrying the exact legacy literal IS rewritten (and any source
+ *   with that text had identical pre-change window behavior, since
+ *   bookkeeping rows were invisible via occurred_at NULL);
+ *   - any other authored source, however similar, is left byte-identical.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { getDb } from '../../../db/client';
+import { loadMigrationUpSection } from '../../../db/migration-loader';
+import { manageBehaviors } from '../../../tools/admin/manage_behaviors';
+import { DEFAULT_BEHAVIOR_SOURCE_QUERY } from '../../../watchers/source-refs';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, seedOwnerContext } from '../../setup/test-fixtures';
+
+const MIGRATION = '20260728100010_behavior_default_source_excludes_bookkeeping.sql';
+const LEGACY_DEFAULT = 'SELECT * FROM events ORDER BY occurred_at DESC';
+const AUTHORED_CUSTOM =
+  "SELECT id, payload_text FROM events WHERE connector_key = 'github' ORDER BY occurred_at DESC";
+
+function resolveMigrationsDir(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'db/migrations');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate db/migrations from the test directory');
+}
+
+async function executeSection(section: string): Promise<void> {
+  const sql = getDb();
+  for (const statement of section.split(/;\s*(?:\n|$)/).map((part) => part.trim())) {
+    if (statement) await sql.unsafe(statement);
+  }
+}
+
+describe('behavior default-source migration replay', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+  });
+
+  it('rewrites only the exact legacy default literal, leaving authored sources byte-identical', async () => {
+    const { org, user, ctx } = await seedOwnerContext();
+    const agent = await createTestAgent({
+      organizationId: org.id,
+      ownerUserId: user.id,
+    });
+    const created = await manageBehaviors(
+      {
+        action: 'create',
+        slug: 'default-source-migration-probe',
+        name: 'Default source migration probe',
+        prompt: 'Summarize new workspace content.',
+        agent_id: agent.agentId,
+        triggers: [{ kind: 'schedule', cron: '* * * * *' }],
+      },
+      {} as Env,
+      ctx
+    );
+    if (created.action !== 'create' || !('behavior_id' in created)) {
+      throw new Error('Behavior creation did not complete');
+    }
+    const behaviorId = Number(created.behavior_id);
+    const sql = getTestDb();
+
+    // Recreate the pre-deploy state: one legacy default source and one
+    // authored custom source, on both the watcher row and its version row.
+    // sql.json, not a ::jsonb-cast string — the prod value options serialize a
+    // plain string param into a double-encoded JSON string.
+    const preDeploySources = [
+      { name: 'content', query: LEGACY_DEFAULT },
+      { name: 'github', query: AUTHORED_CUSTOM },
+    ];
+    await sql`
+      UPDATE watchers SET sources = ${sql.json(preDeploySources)} WHERE id = ${behaviorId}
+    `;
+    await sql`
+      UPDATE watcher_versions SET version_sources = ${sql.json(preDeploySources)}
+      WHERE id = (SELECT current_version_id FROM watchers WHERE id = ${behaviorId})
+    `;
+
+    await executeSection(loadMigrationUpSection(resolveMigrationsDir(), MIGRATION));
+
+    const [watcher] = await sql`SELECT sources FROM watchers WHERE id = ${behaviorId}`;
+    const [version] = await sql`
+      SELECT version_sources FROM watcher_versions
+      WHERE id = (SELECT current_version_id FROM watchers WHERE id = ${behaviorId})
+    `;
+    for (const sources of [watcher.sources, version.version_sources]) {
+      const byName = Object.fromEntries(
+        (sources as Array<{ name: string; query: string }>).map((s) => [s.name, s.query])
+      );
+      expect(byName.content).toBe(DEFAULT_BEHAVIOR_SOURCE_QUERY);
+      expect(byName.github).toBe(AUTHORED_CUSTOM);
+    }
+  });
+});

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -27,6 +27,7 @@ import type { DbClient } from "../db/client";
 import { getDb } from "../db/client";
 import { getNextNumericId } from "../tools/admin/helpers/db-helpers";
 import { nextRunAt } from "../utils/cron";
+import { DEFAULT_BEHAVIOR_SOURCE_QUERY } from "../watchers/source-refs";
 import logger from "../utils/logger";
 import {
 	resolveNewAgentProvisioningDefaults,
@@ -458,7 +459,7 @@ export async function ensureDefaultWatcher(params: {
 		}
 
 		const sources = [
-			{ name: "content", query: "SELECT * FROM events ORDER BY occurred_at DESC" },
+			{ name: "content", query: DEFAULT_BEHAVIOR_SOURCE_QUERY },
 		];
 
 		// triggers is the canonical activation contract; schedule/timezone/

--- a/packages/server/src/authz/resource-visibility.ts
+++ b/packages/server/src/authz/resource-visibility.ts
@@ -24,12 +24,26 @@
  *     stale membership. Once a connection is graphed, it never falls back to the
  *     legacy per-connection fence — a stalled sync hides data, it does not leak it.
  *
- * Fail-closed: a headless/null principal, an enforced-connection event linked to
- * no resource the requester belongs to, or any event on a stale connection is
- * dropped. Generic across sources — GitHub repos and Linear teams gate
- * identically; a new source needs only a registry entry (`./sources`) plus its
- * connector stamping the resource identity on its events so they link to the
- * resource entity.
+ * Fail-closed: a headless/null principal on an enforced connection, a
+ * non-interaction event linked to no resource the requester belongs to, or any
+ * event on a stale connection is dropped.
+ *
+ * Interaction events (`interaction_type <> 'none'`: approvals, suggestions)
+ * are instead readable by any ORGANIZATION member, in every graph state.
+ * They are server-authored workflow state, not synced resource content: an
+ * operation's approval card is stamped with the connection it acts THROUGH but
+ * may have no resource entity link, so the membership branch could never match
+ * and the gate hid pending approvals from everyone, org admins included (prod
+ * run 757649). The arm is deliberately freshness-independent — hiding an
+ * approval because the ACL sync stalled would silently wedge the operation it
+ * gates, and the `member`-row check it relies on is live data, not the synced
+ * graph. It still requires an organization membership row, so headless and
+ * public non-member reads gain nothing, and connector sync never writes
+ * `interaction_type`, so no synced resource content can ride the exemption.
+ * The per-connection visibility gate always still applies in front. Generic
+ * across sources — GitHub repos and Linear teams gate identically; a new
+ * source needs only a registry entry (`./sources`) plus its connector stamping
+ * the resource identity on its events so they link to the resource entity.
  */
 
 import { ACL_RESOURCE_TYPE_SLUG } from '@lobu/connector-sdk';
@@ -62,14 +76,23 @@ export function compileResourceVisibility(
   // Three-state split (mirrors `getConnectionEnforcement`), NOT a bare
   // `NOT IN (enforced)`:
   //   1. no ACL row for the connection → passthrough (never graphed → legacy fence);
-  //   2. row is enforced (in the fresh-enforced set) → require the member_of EXISTS;
+  //   2. row is enforced (in the fresh-enforced set) → require resource membership;
   //   3. row exists but is NOT enforced (stale/partial/failed/aged-out) → neither
   //      branch matches → FAIL CLOSED. A bare `NOT IN (enforced)` would make (3)
   //      true and leak stale-connection events to non-members — the hole this fix
   //      closes, matching the channel gate.
+  // Server-authored interaction events sit OUTSIDE the split: any organization
+  // member may read them in every graph state (see module doc).
   const sql = `AND (
       ${tableAlias}.connection_id IS NULL
       OR ${tableAlias}.connection_id::text NOT IN (${aclStateExistsSelectSql(orgParam)})
+      OR (${tableAlias}.interaction_type <> 'none'
+      AND EXISTS (
+        SELECT 1
+        FROM public."member" om
+        WHERE om."organizationId" = ${orgParam}
+          AND om."userId" = ${userParam}
+      ))
       OR (${tableAlias}.connection_id::text IN (${enforcedConnectionsSelectSql(orgParam)})
       AND EXISTS (
         SELECT 1

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -36,7 +36,7 @@ import {
   type WatcherOperationResult,
 } from './shared';
 import { getErrorMessage } from '@lobu/core';
-import { extractSourcesFromPromptTokens, mergePromptSources } from '../../../watchers/source-refs';
+import { DEFAULT_BEHAVIOR_SOURCE_QUERY, extractSourcesFromPromptTokens, mergePromptSources } from '../../../watchers/source-refs';
 import {
   compileReactionScript,
   extractReactionInputSchema,
@@ -128,7 +128,7 @@ export async function handleCreate(
       : [
           {
             name: 'content',
-            query: 'SELECT * FROM events ORDER BY occurred_at DESC',
+            query: DEFAULT_BEHAVIOR_SOURCE_QUERY,
           },
         ];
 

--- a/packages/server/src/tools/get_content/behavior-mode.ts
+++ b/packages/server/src/tools/get_content/behavior-mode.ts
@@ -21,6 +21,7 @@ import { getAvailableOperations, getPastReactionsSummary } from '../../utils/wat
 import { deriveWatcherExtractionSchema } from '../../utils/watcher-extraction-schema';
 import { computePendingWindow, foldUnprocessedRanges } from '../../utils/window-utils';
 import {
+  DEFAULT_BEHAVIOR_SOURCE_QUERY,
   type NormalizedWatcherSource,
   normalizeWatcherSources,
 } from '../../watchers/source-refs';
@@ -377,7 +378,7 @@ export async function handleBehaviorMode(
   if (watcherSources.length > 0) {
     sources = watcherSources;
   } else {
-    sources = [{ name: 'content', query: 'SELECT * FROM events ORDER BY occurred_at DESC' }];
+    sources = [{ name: 'content', query: DEFAULT_BEHAVIOR_SOURCE_QUERY }];
   }
 
   // Fetch classifiers attached to this watcher

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -63,6 +63,9 @@ interface InsertEventParams {
   attachments?: unknown[];
   authorName?: string | null;
   sourceUrl?: string | null;
+  /** Source-side timestamp. Defaults to insert time when omitted — a NULL
+   *  occurred_at is excluded by date windows and can prevent cursor pagination,
+   *  so "recorded now" is the better approximation. */
   occurredAt?: Date | string | null;
   semanticType: string;
   originType?: string | null;
@@ -192,8 +195,12 @@ function isSemanticallyEqual(
     stableJson(existing.attachments ?? []) === stableJson(params.attachments ?? []) &&
     (existing.author_name ?? null) === (params.authorName ?? null) &&
     (existing.source_url ?? null) === (params.sourceUrl ?? null) &&
-    normalizedTimestamp(existing.occurred_at ?? null) ===
-      normalizedTimestamp(params.occurredAt ?? null) &&
+    // Only compare occurred_at when the caller supplied one. Insert defaults a
+    // missing occurred_at to now(), so an occurredAt-less re-upsert comparing
+    // null against the stamped default would supersede on every re-sync.
+    (params.occurredAt == null ||
+      normalizedTimestamp(existing.occurred_at ?? null) ===
+        normalizedTimestamp(params.occurredAt)) &&
     existing.semantic_type === params.semanticType &&
     (existing.origin_type ?? null) === (params.originType ?? null) &&
     stableJson(existing.metadata ?? {}) === stableJson(params.metadata ?? {}) &&
@@ -362,7 +369,7 @@ export async function insertEvent(
       ${params.score ?? null},
       ${params.authorName ?? null},
       ${params.sourceUrl ?? null},
-      ${params.occurredAt ?? null},
+      ${params.occurredAt ?? new Date()},
       ${params.parentOriginId ?? null},
       ${params.originType ?? null},
       ${params.connectorKey ?? null},

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -88,6 +88,21 @@ function sqlString(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
+/**
+ * Default all-events source for a Behavior authored with no sources.
+ *
+ * Excludes the server's bookkeeping rows — `change` (config/lifecycle/entity
+ * audit trails) and `audit` (tool-invocation log). Historically these were
+ * invisible to Behavior windows by accident (they were inserted with
+ * occurred_at NULL, which no window matched); once insertEvent started
+ * stamping occurred_at, a Behavior's own creation bookkeeping would land in
+ * its first window and defeat `skip_if_unchanged`, and every config edit
+ * would read as new workspace content. Explicitly authored sources are
+ * untouched — a source that wants the audit trail can still select it.
+ */
+export const DEFAULT_BEHAVIOR_SOURCE_QUERY =
+  "SELECT * FROM events WHERE semantic_type NOT IN ('change', 'audit') ORDER BY occurred_at DESC";
+
 function eventSelect(where: string): string {
   return (
     'SELECT id, organization_id, entity_ids, origin_id, title, payload_type, payload_text, ' +


### PR DESCRIPTION
## Summary
- Prod run 757649's approval permalink (`/lobu-team/memory?run_ids=757649`) rendered "No results found": the resource-visibility gate hid the pending-approval event from **everyone** (org admins included) because agent-emitted interaction events carry the connection they act through but no resource entity link, so the enforced-connection membership branch could never match. Interaction events (`interaction_type <> 'none'`) are now readable by any organization member, in every ACL graph state — the member-row check is live data, so a stalled hourly sync can no longer wedge approvals. Headless and non-member principals still see nothing; connector sync never writes `interaction_type`, so no synced resource content rides the exemption.
- `insertEvent` persisted `occurred_at` NULL whenever the caller supplied no timestamp (approval cards, tool-invocation audit rows, change/lifecycle/config trails — ~30k prod rows), which breaks date-window filters and terminates keyset pagination. It now defaults to insert time; the upsert dedup skips the `occurred_at` comparison when the caller supplied none so occurredAt-less re-syncs stay `unchanged`; migration `20260728100000` backfills existing NULLs from `created_at`.
- Follow-on the stamping exposed: `change`/`audit` bookkeeping rows were only invisible to Behavior windows via the NULL `occurred_at` accident. Once stamped, a Behavior's own creation bookkeeping defeated `skip_if_unchanged` (caught red by `schedule-skip-unchanged.test.ts`). The Behavior **default** source now excludes them explicitly (`DEFAULT_BEHAVIOR_SOURCE_QUERY`, used by create/read/provisioning); migration `20260728100010` rewrites the exact legacy literal on stored `watchers.sources` / `watcher_versions.version_sources` — authored sources untouched.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: full `make test-integration` — 339 files, 2901 passed / 2 skipped
- [x] Bug fix: red→fix→green outputs pasted below

### Red (before fix)
```
FAIL  … approval-event-visibility.test.ts > an org member sees the pending-approval event via run_ids …
AssertionError: expected false to be true    // gate dropped the approval event

FAIL  … approval-event-visibility.test.ts > insertEvent stamps occurred_at when the caller supplies none
AssertionError: expected null not to be null

Tests  2 failed | 2 passed (4)
```
Also red mid-branch (caused by the occurred_at stamping, fixed by the default-source exclusion):
```
FAIL  … schedule-skip-unchanged.test.ts > does not treat its own empty-window cursor as default-source content
AssertionError: expected { runsCreated: 1, … } to match object { runsCreated: 0, skipped: 1 }
```

### Green (after fix)
```
✓ … approval-event-visibility.test.ts (7 tests)
✓ … schedule-skip-unchanged.test.ts (2 tests)
Test Files  339 passed (339)
Tests  2901 passed | 2 skipped (2903)
```
Mutation check: removing the dedup guard (keeping the default) flips the upsert test to `expected 'superseded' to be 'unchanged'` — the test bites.

## Notes
- Verified against prod: event 4669138 (run 757649) fails all three gate branches today — `connection_id` set, connection 385 ACL-graphed fresh, `entity_ids` empty.
- Deliberate design point: the interaction-event arm is freshness-independent (an approval must stay actionable while the ACL sync is stale); a `make review-fix` pass had proposed fresh-only and a test pinning it — replaced with a stale-graph visibility test pinning the opposite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->