### PR TITLE
feat(server): audit every external tool invocation with its MCP session id

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -227,6 +227,42 @@ describe('tool invocation audit coverage', () => {
     }
   );
 
+  it('fully redacts secrets embedded in NON-secret string fields (quoted values, Basic auth, comma-delimited)', async () => {
+    // deepRedactSecrets only covers denylisted KEYS; secrets pasted into free
+    // text (a note, a script arg) rely on the text patterns, which must consume
+    // the complete credential — not stop at the first space, comma, or scheme
+    // word and leak the remainder into the preview.
+    await recordToolInvocationAudit({
+      toolName: 'probe_freetext_redaction',
+      args: {
+        note: [
+          'password="my secret value"',
+          'authorization: Basic dXNlcjpwYXNz',
+          'token=part1,part2',
+        ].join(' | '),
+      },
+      result: { ok: true },
+      durationMs: 3,
+      ctx: {
+        organizationId: orgId,
+        userId: ownerId,
+        memberRole: 'owner',
+        isAuthenticated: true,
+        tokenType: 'pat',
+        scopedToOrg: false,
+        allowCrossOrg: false,
+      } as never,
+    });
+
+    const row = await latestAuditRow(orgId, 'probe_freetext_redaction');
+    expect(row).not.toBeNull();
+    const preview = String(row!.payload_data.args_preview_redacted);
+    expect(preview).not.toContain('my secret value');
+    expect(preview).not.toContain('secret value');
+    expect(preview).not.toContain('dXNlcjpwYXNz');
+    expect(preview).not.toContain('part2');
+  });
+
   it('audits org-agnostic list_organizations under the bound org (early-return path)', async () => {
     await executeTool('list_organizations', {}, {} as Env, authCtxFor('oauth'));
 

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -99,7 +99,11 @@ describe('tool invocation audit coverage', () => {
     expect(row).not.toBeNull();
     expect(row!.payload_data.success).toBe(true);
     expect(row!.payload_data.args_sha256).toEqual(expect.any(String));
-    expect(row!.payload_data.args_preview_redacted).toContain('audit coverage probe');
+    // The preview keeps the call SHAPE (keys), never free-text values — a
+    // search query is user content and could carry a pasted secret.
+    expect(row!.payload_data.args_preview_redacted).toContain('"query"');
+    expect(row!.payload_data.args_preview_redacted).not.toContain('audit coverage probe');
+    expect(row!.payload_data.args_preview_redacted).toContain(REDACTED_SENTINEL);
     expect(row!.payload_data).not.toHaveProperty('content');
     expect(row!.metadata.mcp_session_id).toBe(sessionId);
   });
@@ -221,9 +225,8 @@ describe('tool invocation audit coverage', () => {
       const row = await latestAuditRow(orgId, toolName);
       expect(row).not.toBeNull();
       expect(row!.payload_data.success).toBe(false);
-      expect(row!.payload_data.error).toMatchObject({
-        message: `soft ${status} outcome`,
-      });
+      // Name only — handler-supplied error text never reaches the ledger.
+      expect(row!.payload_data.error).toEqual({ name: 'ToolError' });
     }
   );
 
@@ -242,6 +245,8 @@ describe('tool invocation audit coverage', () => {
           'token=part1,part2',
           'password="my secret value"',
           'authorization: Basic dXNlcjpwYXNz',
+          'curl --token sk-live-1234567890',
+          'the token is sk-live-abcdef',
         ].join(' | '),
         digest_header:
           'authorization: Digest username="mufasa", realm="testrealm", nonce="dcd98b7102dd", response="6629fae49393"',
@@ -276,6 +281,8 @@ describe('tool invocation audit coverage', () => {
       '6629fae49393',
       'scar',
       'abc9f8de77',
+      'sk-live-1234567890',
+      'sk-live-abcdef',
     ]) {
       expect(preview).not.toContain(fragment);
     }
@@ -301,8 +308,7 @@ describe('tool invocation audit coverage', () => {
     const row = await latestAuditRow(orgId, 'manage_classifiers');
     expect(row).not.toBeNull();
     expect(row!.payload_data.success).toBe(false);
-    expect(row!.payload_data.error).toMatchObject({
-      message: 'Missing required field: classifier_id',
-    });
+    expect(row!.payload_data.error).toMatchObject({ name: expect.any(String) });
+    expect(row!.payload_data.error).not.toHaveProperty('message');
   });
 });

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -235,11 +235,17 @@ describe('tool invocation audit coverage', () => {
     await recordToolInvocationAudit({
       toolName: 'probe_freetext_redaction',
       args: {
+        // token= sits BEFORE authorization: the header pattern consumes the
+        // rest of the value, so a later position would not prove the
+        // comma-delimited assignment branch on its own.
         note: [
+          'token=part1,part2',
           'password="my secret value"',
           'authorization: Basic dXNlcjpwYXNz',
-          'token=part1,part2',
         ].join(' | '),
+        digest_header:
+          'authorization: Digest username="mufasa", realm="testrealm", nonce="dcd98b7102dd", response="6629fae49393"',
+        bare_digest: 'Digest username="scar", uri="/dir/index.html", response="abc9f8de77"',
       },
       result: { ok: true },
       durationMs: 3,
@@ -261,6 +267,18 @@ describe('tool invocation audit coverage', () => {
     expect(preview).not.toContain('secret value');
     expect(preview).not.toContain('dXNlcjpwYXNz');
     expect(preview).not.toContain('part2');
+    // Digest parameters are credential material end to end — none of the
+    // quoted values may survive, with or without the authorization: prefix.
+    for (const fragment of [
+      'mufasa',
+      'testrealm',
+      'dcd98b7102dd',
+      '6629fae49393',
+      'scar',
+      'abc9f8de77',
+    ]) {
+      expect(preview).not.toContain(fragment);
+    }
   });
 
   it('audits org-agnostic list_organizations under the bound org (early-return path)', async () => {

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -204,12 +204,13 @@ describe('tool invocation audit coverage', () => {
     expect(rows[0].payload_data.args_sha256).not.toBe(rawHashA);
   });
 
-  it('sentinels every string and number leaf — numeric PINs and identifier-shaped values do not survive', async () => {
+  it('sentinels every caller-controlled leaf AND key — PINs, identifier-shaped values, credential-shaped keys', async () => {
     await recordToolInvocationAudit({
       toolName: 'probe_leaf_sanitization',
       args: {
         input: { pin: 123456 },
         kind: 'sk-live-credential-value',
+        'sk-live-secret-as-a-key': 1,
         dry_run: true,
       },
       result: { ok: true },
@@ -230,9 +231,11 @@ describe('tool invocation audit coverage', () => {
     const preview = String(row!.payload_data.args_preview_redacted);
     expect(preview).not.toContain('123456');
     expect(preview).not.toContain('sk-live-credential-value');
-    // Structure and booleans survive: keys are visible, one-bit values kept.
-    expect(preview).toContain('"pin"');
-    expect(preview).toContain('"dry_run":true');
+    expect(preview).not.toContain('sk-live-secret-as-a-key');
+    // This probe tool has no registered schema, so NO key is trusted: the
+    // whole preview collapses to sentinel structure with the boolean kept
+    // (repeated sentinel keys merge; first key position, last value wins).
+    expect(preview).toBe(`{"${REDACTED_SENTINEL}":true}`);
   });
 
   it.each(['error', 'timeout'] as const)(

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -1,6 +1,8 @@
+import { createHash } from 'node:crypto';
 import { REDACTED_SENTINEL } from '@lobu/core';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { SCOPE_CHECK_NOT_APPLICABLE } from '../../../auth/tool-access';
+import { recordToolInvocationAudit } from '../../../tools/audit';
 import { getDb } from '../../../db/client';
 import type { Env } from '../../../index';
 import { type AuthContext, executeTool } from '../../../tools/execute';
@@ -164,6 +166,66 @@ describe('tool invocation audit coverage', () => {
     );
     expect(row!.payload_data.args_preview_redacted).toContain(REDACTED_SENTINEL);
   });
+
+  it('args_sha256 is computed over REDACTED args — a secret value cannot be verified against the hash', async () => {
+    const argsWithSecretA = { action: 'nope', token: 'candidate-secret-A' };
+    const argsWithSecretB = { action: 'nope', token: 'candidate-secret-B' };
+    await expect(
+      executeTool('manage_connections', argsWithSecretA, {} as Env, authCtxFor('pat'))
+    ).rejects.toThrow();
+    await expect(
+      executeTool('manage_connections', argsWithSecretB, {} as Env, authCtxFor('pat'))
+    ).rejects.toThrow();
+
+    const sql = getDb();
+    const rows = await sql<Array<{ payload_data: Record<string, unknown> }>>`
+      SELECT payload_data FROM events
+      WHERE organization_id = ${orgId}
+        AND semantic_type = 'audit'
+        AND payload_data->>'tool_name' = 'manage_connections'
+        AND payload_data->>'args_preview_redacted' LIKE '%"action":"nope"%'
+      ORDER BY id DESC
+      LIMIT 2
+    `;
+    expect(rows).toHaveLength(2);
+    // Same call shape, different secret value → identical hash. If the raw
+    // args fed the hash, the two digests would differ and either could be
+    // used as an offline verifier for candidate secrets.
+    expect(rows[0].payload_data.args_sha256).toBe(rows[1].payload_data.args_sha256);
+    const rawHashA = createHash('sha256')
+      .update(JSON.stringify(argsWithSecretA))
+      .digest('hex');
+    expect(rows[0].payload_data.args_sha256).not.toBe(rawHashA);
+  });
+
+  it.each(['error', 'timeout'] as const)(
+    'records a result with status=%s as a failed invocation',
+    async (status) => {
+      const toolName = `probe_status_${status}`;
+      await recordToolInvocationAudit({
+        toolName,
+        args: { probe: true },
+        result: { status, message: `soft ${status} outcome` },
+        durationMs: 5,
+        ctx: {
+          organizationId: orgId,
+          userId: ownerId,
+          memberRole: 'owner',
+          isAuthenticated: true,
+          tokenType: 'pat',
+          scopedToOrg: false,
+          allowCrossOrg: false,
+        } as never,
+      });
+
+      const row = await latestAuditRow(orgId, toolName);
+      expect(row).not.toBeNull();
+      expect(row!.payload_data.success).toBe(false);
+      expect(row!.payload_data.error).toMatchObject({
+        message: `soft ${status} outcome`,
+      });
+    }
+  );
 
   it('audits org-agnostic list_organizations under the bound org (early-return path)', async () => {
     await executeTool('list_organizations', {}, {} as Env, authCtxFor('oauth'));

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -165,6 +165,14 @@ describe('tool invocation audit coverage', () => {
     expect(row!.payload_data.args_preview_redacted).toContain(REDACTED_SENTINEL);
   });
 
+  it('audits org-agnostic list_organizations under the bound org (early-return path)', async () => {
+    await executeTool('list_organizations', {}, {} as Env, authCtxFor('oauth'));
+
+    const row = await latestAuditRow(orgId, 'list_organizations');
+    expect(row).not.toBeNull();
+    expect(row!.payload_data.success).toBe(true);
+  });
+
   it('records resolved tool failures as failed', async () => {
     const result = (await executeTool(
       'manage_classifiers',

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -1,0 +1,184 @@
+import { REDACTED_SENTINEL } from '@lobu/core';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { SCOPE_CHECK_NOT_APPLICABLE } from '../../../auth/tool-access';
+import { getDb } from '../../../db/client';
+import type { Env } from '../../../index';
+import { type AuthContext, executeTool } from '../../../tools/execute';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+import { ensureMcpSession, mcpToolsCall } from '../../setup/test-helpers';
+
+interface AuditRow {
+  payload_data: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+}
+
+async function latestAuditRow(orgId: string, toolName: string): Promise<AuditRow | null> {
+  const sql = getDb();
+  const rows = await sql<AuditRow[]>`
+    SELECT payload_data, metadata
+    FROM events
+    WHERE organization_id = ${orgId}
+      AND semantic_type = 'audit'
+      AND origin_type = 'tool_invocation'
+      AND payload_data->>'tool_name' = ${toolName}
+    ORDER BY id DESC
+    LIMIT 1
+  `;
+  return rows[0] ?? null;
+}
+
+describe('tool invocation audit coverage', () => {
+  let token: string;
+  let orgId: string;
+  let orgSlug: string;
+  let ownerId: string;
+  let clientId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const org = await createTestOrganization({
+      name: 'Audit Coverage Org',
+      slug: 'audit-coverage-org',
+    });
+    orgId = org.id;
+    orgSlug = org.slug;
+    const owner = await createTestUser({ email: 'audit-coverage@test.example.com' });
+    ownerId = owner.id;
+    await addUserToOrganization(owner.id, org.id, 'owner');
+    const oauthClient = await createTestOAuthClient();
+    clientId = oauthClient.client_id;
+    token = (
+      await createTestAccessToken(owner.id, org.id, oauthClient.client_id, {
+        scope: 'mcp:read mcp:write mcp:admin',
+      })
+    ).token;
+  });
+
+  function authCtxFor(tokenType: 'oauth' | 'pat' | 'session'): AuthContext {
+    return {
+      organizationId: orgId,
+      tokenOrganizationId: tokenType === 'session' ? null : orgId,
+      userId: ownerId,
+      memberRole: 'owner',
+      agentId: null,
+      requestedAgentId: null,
+      isAuthenticated: true,
+      clientId: tokenType === 'oauth' ? clientId : null,
+      scopes:
+        tokenType === 'session'
+          ? [...SCOPE_CHECK_NOT_APPLICABLE]
+          : ['mcp:read', 'mcp:write', 'mcp:admin'],
+      tokenType,
+      requestUrl: 'http://localhost/lobu/tools/test',
+      baseUrl: 'http://localhost',
+      scopedToOrg: false,
+      allowCrossOrg: tokenType === 'oauth',
+    };
+  }
+
+  it('audits a generic OAuth MCP call with its session id', async () => {
+    await mcpToolsCall(
+      'search_memory',
+      { query: 'audit coverage probe', limit: 1 },
+      { token, orgSlug }
+    );
+    const sessionId = await ensureMcpSession({ token, orgSlug });
+
+    const row = await latestAuditRow(orgId, 'search_memory');
+    expect(row).not.toBeNull();
+    expect(row!.payload_data.success).toBe(true);
+    expect(row!.payload_data.args_sha256).toEqual(expect.any(String));
+    expect(row!.payload_data.args_preview_redacted).toContain('audit coverage probe');
+    expect(row!.payload_data).not.toHaveProperty('content');
+    expect(row!.metadata.mcp_session_id).toBe(sessionId);
+  });
+
+  it('records the requested org_slug on query_sql audit rows', async () => {
+    const result = (await executeTool(
+      'query_sql',
+      { sql: 'SELECT id FROM events', sort_by: 'id', limit: 1, org_slug: orgSlug },
+      {} as Env,
+      authCtxFor('oauth')
+    )) as { error?: string };
+    expect(result.error).toBeUndefined();
+
+    const row = await latestAuditRow(orgId, 'query_sql');
+    expect(row).not.toBeNull();
+    expect(row!.payload_data.org_slug).toBe(orgSlug);
+    expect(row!.metadata).toHaveProperty('mcp_session_id', null);
+  });
+
+  it('does NOT write generic audit rows for browser-session tool calls', async () => {
+    const before = await latestAuditRow(orgId, 'list_metrics');
+    expect(before).toBeNull();
+
+    await executeTool('list_metrics', {}, {} as Env, authCtxFor('session'));
+
+    expect(await latestAuditRow(orgId, 'list_metrics')).toBeNull();
+  });
+
+  it('still audits query_sql for browser-session callers (detailed audit is token-type independent)', async () => {
+    await executeTool(
+      'query_sql',
+      { sql: 'SELECT id FROM entities', sort_by: 'id', limit: 1 },
+      {} as Env,
+      authCtxFor('session')
+    );
+
+    const sql = getDb();
+    const rows = await sql`
+      SELECT id FROM events
+      WHERE organization_id = ${orgId}
+        AND semantic_type = 'audit'
+        AND payload_data->>'tool_name' = 'query_sql'
+        AND payload_data->>'sql_preview_redacted' LIKE '%FROM entities%'
+    `;
+    expect(rows).toHaveLength(1);
+  });
+
+  it('audits a failed generic call with the error captured', async () => {
+    await expect(
+      executeTool(
+        'manage_connections',
+        { action: 'nope', token: 'must-not-reach-the-audit-log' },
+        {} as Env,
+        authCtxFor('pat')
+      )
+    ).rejects.toThrow();
+
+    const row = await latestAuditRow(orgId, 'manage_connections');
+    expect(row).not.toBeNull();
+    expect(row!.payload_data.success).toBe(false);
+    expect(row!.payload_data.error).toBeTruthy();
+    expect(row!.payload_data.args_preview_redacted).not.toContain(
+      'must-not-reach-the-audit-log'
+    );
+    expect(row!.payload_data.args_preview_redacted).toContain(REDACTED_SENTINEL);
+  });
+
+  it('records resolved tool failures as failed', async () => {
+    const result = (await executeTool(
+      'manage_classifiers',
+      { action: 'delete' },
+      {} as Env,
+      authCtxFor('pat')
+    )) as { success: boolean };
+    expect(result.success).toBe(false);
+
+    const row = await latestAuditRow(orgId, 'manage_classifiers');
+    expect(row).not.toBeNull();
+    expect(row!.payload_data.success).toBe(false);
+    expect(row!.payload_data.error).toMatchObject({
+      message: 'Missing required field: classifier_id',
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -324,6 +324,41 @@ describe('tool invocation audit coverage', () => {
     }
   });
 
+  it('query_sql preview redaction consumes complete credentials (the pattern path the generic sentinel does not cover)', async () => {
+    // The generic path sentinels everything before the regexes run; query_sql
+    // and run_sdk previews are where pattern redaction still carries the load.
+    const sql = [
+      "SELECT /* redaction-probe */ 'password=\"my secret value\"',",
+      "'authorization: Basic dXNlcjpwYXNz',",
+      '\'Digest username="mufasa", realm="testrealm", response="6629fae49393"\',',
+      "'token=part1,part2' FROM events",
+    ].join(' ');
+    await executeTool('query_sql', { sql, limit: 1 }, {} as Env, authCtxFor('oauth'));
+
+    const db = getDb();
+    const rows = await db<Array<{ payload_data: Record<string, unknown> }>>`
+      SELECT payload_data FROM events
+      WHERE organization_id = ${orgId}
+        AND semantic_type = 'audit'
+        AND payload_data->>'tool_name' = 'query_sql'
+        AND payload_data->>'sql_preview_redacted' LIKE '%redaction-probe%'
+      ORDER BY id DESC
+      LIMIT 1
+    `;
+    expect(rows).toHaveLength(1);
+    const preview = String(rows[0].payload_data.sql_preview_redacted);
+    for (const fragment of [
+      'my secret value',
+      'dXNlcjpwYXNz',
+      'mufasa',
+      'testrealm',
+      '6629fae49393',
+      'part2',
+    ]) {
+      expect(preview).not.toContain(fragment);
+    }
+  });
+
   it('audits org-agnostic list_organizations under the bound org (early-return path)', async () => {
     await executeTool('list_organizations', {}, {} as Env, authCtxFor('oauth'));
 

--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -171,14 +171,17 @@ describe('tool invocation audit coverage', () => {
     expect(row!.payload_data.args_preview_redacted).toContain(REDACTED_SENTINEL);
   });
 
-  it('args_sha256 is computed over REDACTED args — a secret value cannot be verified against the hash', async () => {
-    const argsWithSecretA = { action: 'nope', token: 'candidate-secret-A' };
-    const argsWithSecretB = { action: 'nope', token: 'candidate-secret-B' };
+  it('args_sha256 is computed over SANITIZED args — a secret value cannot be verified against the hash', async () => {
+    const argsWithSecretA = { query: 'probe', token: 'candidate-secret-A' };
+    const argsWithSecretB = { query: 'probe', token: 'candidate-secret-B' };
+    // `token` is not a search_sdk argument: validation rejects both calls, and
+    // the audit fires on the catch path with the raw args — the exact moment a
+    // raw-args hash would persist a credential-derived verifier.
     await expect(
-      executeTool('manage_connections', argsWithSecretA, {} as Env, authCtxFor('pat'))
+      executeTool('search_sdk', argsWithSecretA, {} as Env, authCtxFor('pat'))
     ).rejects.toThrow();
     await expect(
-      executeTool('manage_connections', argsWithSecretB, {} as Env, authCtxFor('pat'))
+      executeTool('search_sdk', argsWithSecretB, {} as Env, authCtxFor('pat'))
     ).rejects.toThrow();
 
     const sql = getDb();
@@ -186,8 +189,7 @@ describe('tool invocation audit coverage', () => {
       SELECT payload_data FROM events
       WHERE organization_id = ${orgId}
         AND semantic_type = 'audit'
-        AND payload_data->>'tool_name' = 'manage_connections'
-        AND payload_data->>'args_preview_redacted' LIKE '%"action":"nope"%'
+        AND payload_data->>'tool_name' = 'search_sdk'
       ORDER BY id DESC
       LIMIT 2
     `;
@@ -200,6 +202,37 @@ describe('tool invocation audit coverage', () => {
       .update(JSON.stringify(argsWithSecretA))
       .digest('hex');
     expect(rows[0].payload_data.args_sha256).not.toBe(rawHashA);
+  });
+
+  it('sentinels every string and number leaf — numeric PINs and identifier-shaped values do not survive', async () => {
+    await recordToolInvocationAudit({
+      toolName: 'probe_leaf_sanitization',
+      args: {
+        input: { pin: 123456 },
+        kind: 'sk-live-credential-value',
+        dry_run: true,
+      },
+      result: { ok: true },
+      durationMs: 2,
+      ctx: {
+        organizationId: orgId,
+        userId: ownerId,
+        memberRole: 'owner',
+        isAuthenticated: true,
+        tokenType: 'pat',
+        scopedToOrg: false,
+        allowCrossOrg: false,
+      } as never,
+    });
+
+    const row = await latestAuditRow(orgId, 'probe_leaf_sanitization');
+    expect(row).not.toBeNull();
+    const preview = String(row!.payload_data.args_preview_redacted);
+    expect(preview).not.toContain('123456');
+    expect(preview).not.toContain('sk-live-credential-value');
+    // Structure and booleans survive: keys are visible, one-bit values kept.
+    expect(preview).toContain('"pin"');
+    expect(preview).toContain('"dry_run":true');
   });
 
   it.each(['error', 'timeout'] as const)(

--- a/packages/server/src/__tests__/setup/test-helpers.ts
+++ b/packages/server/src/__tests__/setup/test-helpers.ts
@@ -152,7 +152,7 @@ import { mcpSessions } from './mcp-session-cache';
  * Sends the proper initialize + notifications/initialized handshake
  * and caches the resulting session ID for subsequent requests.
  */
-async function ensureMcpSession(options?: {
+export async function ensureMcpSession(options?: {
   token?: string;
   env?: Partial<Env>;
   agentId?: string;

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -846,6 +846,10 @@ function createSessionTransport(
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator,
     onsessioninitialized: (id) => {
+      // The per-session authCtx object is shared by every request on this
+      // session, so stamping once here threads the session id into each
+      // tool call's ToolContext (audit rows group client activity by it).
+      authCtx.mcpSessionId = id;
       sessions.set(id, {
         transport,
         server,

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { deepRedactSecrets } from '@lobu/core';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
 import { AUDIT_SEMANTIC_TYPE } from './constants';
@@ -6,7 +7,7 @@ import type { ToolContext } from './registry';
 
 const MAX_PREVIEW_CHARS = 500;
 const SENSITIVE_ASSIGNMENT_RE =
-  /(api[_-]?key|apikey|authorization|cookie|credential|password|private[_-]?key|secret|token)\s*[:=]\s*[^\s,'"}]+/gi;
+  /(api[_-]?key|authorization|cookie|credential|password|private[_-]?key|secret|token)\s*["']?\s*[:=]\s*["']?[^\s,'"}]+/gi;
 const BEARER_TOKEN_RE = /bearer\s+[a-z0-9._~+\/-]+/gi;
 
 interface ToolInvocationAuditParams {
@@ -22,14 +23,20 @@ function sha256(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
-function redactPreview(value: string): string {
+function redactSensitiveText(value: string): string {
   return value
-    .slice(0, MAX_PREVIEW_CHARS)
     .replace(BEARER_TOKEN_RE, 'Bearer [redacted]')
-    .replace(SENSITIVE_ASSIGNMENT_RE, (match) => {
-      const prefix = match.match(/^[^:=]+/)?.[0]?.trim() ?? 'secret';
-      return `${prefix}=[redacted]`;
-    });
+    .replace(SENSITIVE_ASSIGNMENT_RE, (_match, key: string) => `${key}=[redacted]`);
+}
+
+function redactPreview(value: string): string {
+  return redactSensitiveText(value.slice(0, MAX_PREVIEW_CHARS));
+}
+
+function stringifyRedacted(value: unknown): string {
+  return JSON.stringify(deepRedactSecrets(value), (_key, nestedValue) =>
+    typeof nestedValue === 'string' ? redactSensitiveText(nestedValue) : nestedValue
+  );
 }
 
 function asObject(value: unknown): Record<string, unknown> {
@@ -38,19 +45,25 @@ function asObject(value: unknown): Record<string, unknown> {
     : {};
 }
 
-function errorPayload(error: unknown): Record<string, unknown> | null {
+function errorPayload(
+  error: unknown,
+  fallbackName: string = 'Error'
+): Record<string, unknown> | null {
   if (!error) return null;
   if (error instanceof Error) {
-    return { name: error.name, message: error.message };
+    return { name: error.name, message: redactPreview(error.message) };
   }
   if (typeof error === 'object') {
     const record = error as Record<string, unknown>;
     return {
-      name: typeof record.name === 'string' ? record.name : 'Error',
-      message: typeof record.message === 'string' ? record.message : JSON.stringify(record),
+      name: typeof record.name === 'string' ? record.name : fallbackName,
+      message:
+        typeof record.message === 'string'
+          ? redactPreview(record.message)
+          : stringifyRedacted(record).slice(0, MAX_PREVIEW_CHARS),
     };
   }
-  return { name: 'Error', message: String(error) };
+  return { name: fallbackName, message: redactPreview(String(error)) };
 }
 
 function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown> | null {
@@ -81,11 +94,16 @@ function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown
 
   if (params.toolName === 'query_sql') {
     const sql = typeof params.args.sql === 'string' ? params.args.sql : '';
-    const resultError = typeof result.error === 'string' ? { name: 'QuerySqlError', message: result.error } : null;
+    const resultError =
+      typeof result.error === 'string'
+        ? { name: 'QuerySqlError', message: redactPreview(result.error) }
+        : null;
     return {
       tool_name: params.toolName,
       sql_sha256: sql ? sha256(sql) : null,
       sql_preview_redacted: sql ? redactPreview(sql) : null,
+      // The event stays in the bound org, so retain the requested target.
+      org_slug: typeof params.args.org_slug === 'string' ? params.args.org_slug : null,
       sort_by: typeof params.args.sort_by === 'string' ? params.args.sort_by : null,
       sort_order: params.args.sort_order === 'desc' ? 'desc' : 'asc',
       limit: typeof params.args.limit === 'number' ? params.args.limit : null,
@@ -98,16 +116,39 @@ function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown
     };
   }
 
-  return null;
+  // Browser-session and anonymous reads would generate an event per page view;
+  // only externally authenticated calls belong in the client activity ledger.
+  if (params.ctx.tokenType !== 'oauth' && params.ctx.tokenType !== 'pat') {
+    return null;
+  }
+  const argsJson = JSON.stringify(params.args ?? {});
+  const redactedArgsJson = stringifyRedacted(params.args ?? {});
+  const resultError = errorPayload(result.error, 'ToolError');
+  const reportedFailure = result.success === false || result.status === 'failed';
+  const softError =
+    resultError ??
+    (reportedFailure
+      ? errorPayload(
+          result.error_message ?? result.message ?? 'Tool reported failure',
+          'ToolError'
+        )
+      : null);
+  return {
+    tool_name: params.toolName,
+    args_sha256: sha256(argsJson),
+    args_preview_redacted: redactedArgsJson.slice(0, MAX_PREVIEW_CHARS),
+    success: !(toolError || softError),
+    error: toolError ?? softError,
+    duration_ms: params.durationMs,
+  };
 }
 
 export async function recordToolInvocationAudit(
   params: ToolInvocationAuditParams
 ): Promise<void> {
-  const payload = buildPayload(params);
-  if (!payload) return;
-
   try {
+    const payload = buildPayload(params);
+    if (!payload) return;
     const success = payload.success === true;
     await insertEvent({
       entityIds: [],
@@ -124,6 +165,7 @@ export async function recordToolInvocationAudit(
         tool_name: params.toolName,
         token_type: params.ctx.tokenType,
         agent_id: params.ctx.agentId ?? null,
+        mcp_session_id: params.ctx.mcpSessionId ?? null,
       },
       createdBy: params.ctx.userId ?? null,
       clientId: params.ctx.clientId ?? null,

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -121,10 +121,17 @@ function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown
   if (params.ctx.tokenType !== 'oauth' && params.ctx.tokenType !== 'pat') {
     return null;
   }
-  const argsJson = JSON.stringify(params.args ?? {});
+  // Hash the REDACTED serialization: the raw one would persist an unsalted
+  // credential-derived digest whenever args carry a secret (manage_connections
+  // tokens etc.), letting a candidate secret be verified against the ledger.
+  // The hash identifies the call shape, so redacted input serves it fully.
   const redactedArgsJson = stringifyRedacted(params.args ?? {});
   const resultError = errorPayload(result.error, 'ToolError');
-  const reportedFailure = result.success === false || result.status === 'failed';
+  const reportedFailure =
+    result.success === false ||
+    result.status === 'failed' ||
+    result.status === 'error' ||
+    result.status === 'timeout';
   const softError =
     resultError ??
     (reportedFailure
@@ -135,7 +142,7 @@ function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown
       : null);
   return {
     tool_name: params.toolName,
-    args_sha256: sha256(argsJson),
+    args_sha256: sha256(redactedArgsJson),
     args_preview_redacted: redactedArgsJson.slice(0, MAX_PREVIEW_CHARS),
     success: !(toolError || softError),
     error: toolError ?? softError,

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -6,14 +6,24 @@ import { AUDIT_SEMANTIC_TYPE } from './constants';
 import type { ToolContext } from './registry';
 
 const MAX_PREVIEW_CHARS = 500;
-// The value alternatives must consume the COMPLETE credential: a quoted string
-// up to its closing quote (spaces included), otherwise an unquoted run that
-// does not stop at commas — stopping early leaks the remainder into the
-// preview. Over-consumption is fine here (previews are display-only; identity
-// comes from the hash), partial redaction is not.
+// Redaction principle: consume the COMPLETE credential. Over-consumption is
+// fine (previews are display-only; identity comes from the hash of the
+// redacted form), partial redaction is not — a stop at the first space,
+// comma, or scheme word leaks the remainder.
+//
+// Header-named credentials carry STRUCTURED values (scheme + params, cookie
+// lists), so everything after the separator is credential material — consume
+// to the end of the string/line.
+const HEADER_CREDENTIAL_RE =
+  /\b(authorization|proxy-authorization|www-authenticate|set-cookie|cookie)\s*["']?\s*[:=]\s*[^\n]+/gi;
+// Bare scheme credentials: Digest takes a comma-delimited key=value list
+// (quoted values included); token schemes take a single blob.
+const AUTH_SCHEME_RE =
+  /\b(bearer|basic|digest)\s+(?:[a-z0-9_-]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s,]+)(?:\s*,\s*[a-z0-9_-]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s,]+))*|[a-z0-9._~+/=:-]+)/gi;
+// Denylisted key assignments: a quoted string up to its closing quote (spaces
+// included), otherwise an unquoted run that does not stop at commas.
 const SENSITIVE_ASSIGNMENT_RE =
-  /(api[_-]?key|authorization|cookie|credential|password|private[_-]?key|secret|token)\s*["']?\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s'"}]+)/gi;
-const AUTH_SCHEME_RE = /\b(bearer|basic|digest)\s+[a-z0-9._~+/=:-]+/gi;
+  /(api[_-]?key|credential|password|private[_-]?key|secret|token)\s*["']?\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s'"}]+)/gi;
 
 interface ToolInvocationAuditParams {
   toolName: string;
@@ -30,12 +40,15 @@ function sha256(value: string): string {
 
 function redactSensitiveText(value: string): string {
   return value
+    .replace(HEADER_CREDENTIAL_RE, (_match, key: string) => `${key}=[redacted]`)
     .replace(AUTH_SCHEME_RE, (_match, scheme: string) => `${scheme} [redacted]`)
     .replace(SENSITIVE_ASSIGNMENT_RE, (_match, key: string) => `${key}=[redacted]`);
 }
 
 function redactPreview(value: string): string {
-  return redactSensitiveText(value.slice(0, MAX_PREVIEW_CHARS));
+  // Redact BEFORE truncating: slicing first can split a quoted credential and
+  // the unbalanced quote defeats the pattern, leaking the visible fragment.
+  return redactSensitiveText(value).slice(0, MAX_PREVIEW_CHARS);
 }
 
 function stringifyRedacted(value: unknown): string {

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -52,46 +52,23 @@ function redactPreview(value: string): string {
 }
 
 /**
- * Structural keys whose string values are safe to persist in the generic audit
- * preview: enum-ish discriminators and resource references, never user
- * content. Everything else defaults to the sentinel — free text can carry a
- * secret in shapes no pattern enumerates (`curl --token sk-live-…`), so the
- * ledger keeps the SHAPE of a call, not its content.
+ * Generic audit entries persist the SHAPE of a call, never its content: keys,
+ * structure, and booleans/nulls (provably structural — one bit) survive; every
+ * string and number leaf becomes the sentinel. No key allowlist and no value
+ * pattern can be trusted here — audit also fires on FAILED validation, so even
+ * an enum-typed key like `action` can arrive carrying arbitrary pasted text,
+ * and identifier-shaped secrets (`sk-live-…`) are indistinguishable from
+ * slugs. Free text can hide a secret in shapes no pattern enumerates.
  */
-const SAFE_ARG_KEYS = new Set([
-  'action',
-  'agent_id',
-  'connection',
-  'dry_run',
-  'entity_type',
-  'feed',
-  'key',
-  'kind',
-  'org_slug',
-  'semantic_type',
-  'slug',
-  'sort_by',
-  'sort_order',
-  'status',
-  'type',
-]);
-const MAX_SAFE_VALUE_CHARS = 120;
-
-function sanitizeArgLeaves(value: unknown, parentKey?: string): unknown {
-  if (Array.isArray(value)) return value.map((item) => sanitizeArgLeaves(item, parentKey));
+function sanitizeArgLeaves(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => sanitizeArgLeaves(item));
   if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value).map(([key, nested]) => [key, sanitizeArgLeaves(nested, key)])
+      Object.entries(value).map(([key, nested]) => [key, sanitizeArgLeaves(nested)])
     );
   }
-  if (typeof value === 'string') {
-    return parentKey !== undefined &&
-      SAFE_ARG_KEYS.has(parentKey) &&
-      value.length <= MAX_SAFE_VALUE_CHARS
-      ? redactSensitiveText(value)
-      : REDACTED_SENTINEL;
-  }
-  return value;
+  if (typeof value === 'boolean' || value === null || value === undefined) return value;
+  return REDACTED_SENTINEL;
 }
 
 function asObject(value: unknown): Record<string, unknown> {

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { deepRedactSecrets } from '@lobu/core';
+import { REDACTED_SENTINEL } from '@lobu/core';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
 import { AUDIT_SEMANTIC_TYPE } from './constants';
@@ -51,10 +51,47 @@ function redactPreview(value: string): string {
   return redactSensitiveText(value).slice(0, MAX_PREVIEW_CHARS);
 }
 
-function stringifyRedacted(value: unknown): string {
-  return JSON.stringify(deepRedactSecrets(value), (_key, nestedValue) =>
-    typeof nestedValue === 'string' ? redactSensitiveText(nestedValue) : nestedValue
-  );
+/**
+ * Structural keys whose string values are safe to persist in the generic audit
+ * preview: enum-ish discriminators and resource references, never user
+ * content. Everything else defaults to the sentinel — free text can carry a
+ * secret in shapes no pattern enumerates (`curl --token sk-live-…`), so the
+ * ledger keeps the SHAPE of a call, not its content.
+ */
+const SAFE_ARG_KEYS = new Set([
+  'action',
+  'agent_id',
+  'connection',
+  'dry_run',
+  'entity_type',
+  'feed',
+  'key',
+  'kind',
+  'org_slug',
+  'semantic_type',
+  'slug',
+  'sort_by',
+  'sort_order',
+  'status',
+  'type',
+]);
+const MAX_SAFE_VALUE_CHARS = 120;
+
+function sanitizeArgLeaves(value: unknown, parentKey?: string): unknown {
+  if (Array.isArray(value)) return value.map((item) => sanitizeArgLeaves(item, parentKey));
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, sanitizeArgLeaves(nested, key)])
+    );
+  }
+  if (typeof value === 'string') {
+    return parentKey !== undefined &&
+      SAFE_ARG_KEYS.has(parentKey) &&
+      value.length <= MAX_SAFE_VALUE_CHARS
+      ? redactSensitiveText(value)
+      : REDACTED_SENTINEL;
+  }
+  return value;
 }
 
 function asObject(value: unknown): Record<string, unknown> {
@@ -78,10 +115,27 @@ function errorPayload(
       message:
         typeof record.message === 'string'
           ? redactPreview(record.message)
-          : stringifyRedacted(record).slice(0, MAX_PREVIEW_CHARS),
+          : fallbackName,
     };
   }
   return { name: fallbackName, message: redactPreview(String(error)) };
+}
+
+/**
+ * Error shape for GENERIC audit entries: the class name (and `code` when the
+ * error carries one) only. Handler-supplied message text can echo user values
+ * in shapes no pattern enumerates, so it never reaches the append-only ledger
+ * — the caller already received the full error on the live response.
+ */
+function errorNameOnly(error: unknown, fallbackName: string): Record<string, unknown> | null {
+  if (!error) return null;
+  const record =
+    typeof error === 'object' ? (error as Record<string, unknown>) : ({} as Record<string, unknown>);
+  const name =
+    error instanceof Error ? error.name
+    : typeof record.name === 'string' ? record.name
+    : fallbackName;
+  return typeof record.code === 'string' ? { name, code: record.code } : { name };
 }
 
 function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown> | null {
@@ -139,31 +193,27 @@ function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown
   if (params.ctx.tokenType !== 'oauth' && params.ctx.tokenType !== 'pat') {
     return null;
   }
-  // Hash the REDACTED serialization: the raw one would persist an unsalted
-  // credential-derived digest whenever args carry a secret (manage_connections
-  // tokens etc.), letting a candidate secret be verified against the ledger.
-  // The hash identifies the call shape, so redacted input serves it fully.
-  const redactedArgsJson = stringifyRedacted(params.args ?? {});
-  const resultError = errorPayload(result.error, 'ToolError');
+  // The preview and hash are built from the SANITIZED args: every string leaf
+  // becomes the sentinel unless its key is a known structural discriminator.
+  // A raw or pattern-redacted serialization would persist free-text values
+  // (and an unsalted credential-derived digest) whenever a secret hides in a
+  // shape no pattern enumerates — the ledger records the call's shape, never
+  // its content.
+  const sanitizedArgsJson = JSON.stringify(sanitizeArgLeaves(params.args ?? {}));
   const reportedFailure =
+    result.error != null ||
     result.success === false ||
     result.status === 'failed' ||
     result.status === 'error' ||
     result.status === 'timeout';
-  const softError =
-    resultError ??
-    (reportedFailure
-      ? errorPayload(
-          result.error_message ?? result.message ?? 'Tool reported failure',
-          'ToolError'
-        )
-      : null);
+  const softError = reportedFailure ? errorNameOnly(result.error, 'ToolError') ?? { name: 'ToolError' } : null;
+  const thrownError = errorNameOnly(params.error, 'Error');
   return {
     tool_name: params.toolName,
-    args_sha256: sha256(redactedArgsJson),
-    args_preview_redacted: redactedArgsJson.slice(0, MAX_PREVIEW_CHARS),
-    success: !(toolError || softError),
-    error: toolError ?? softError,
+    args_sha256: sha256(sanitizedArgsJson),
+    args_preview_redacted: sanitizedArgsJson.slice(0, MAX_PREVIEW_CHARS),
+    success: !(thrownError || softError),
+    error: thrownError ?? softError,
     duration_ms: params.durationMs,
   };
 }

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -6,9 +6,14 @@ import { AUDIT_SEMANTIC_TYPE } from './constants';
 import type { ToolContext } from './registry';
 
 const MAX_PREVIEW_CHARS = 500;
+// The value alternatives must consume the COMPLETE credential: a quoted string
+// up to its closing quote (spaces included), otherwise an unquoted run that
+// does not stop at commas — stopping early leaks the remainder into the
+// preview. Over-consumption is fine here (previews are display-only; identity
+// comes from the hash), partial redaction is not.
 const SENSITIVE_ASSIGNMENT_RE =
-  /(api[_-]?key|authorization|cookie|credential|password|private[_-]?key|secret|token)\s*["']?\s*[:=]\s*["']?[^\s,'"}]+/gi;
-const BEARER_TOKEN_RE = /bearer\s+[a-z0-9._~+\/-]+/gi;
+  /(api[_-]?key|authorization|cookie|credential|password|private[_-]?key|secret|token)\s*["']?\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s'"}]+)/gi;
+const AUTH_SCHEME_RE = /\b(bearer|basic|digest)\s+[a-z0-9._~+/=:-]+/gi;
 
 interface ToolInvocationAuditParams {
   toolName: string;
@@ -25,7 +30,7 @@ function sha256(value: string): string {
 
 function redactSensitiveText(value: string): string {
   return value
-    .replace(BEARER_TOKEN_RE, 'Bearer [redacted]')
+    .replace(AUTH_SCHEME_RE, (_match, scheme: string) => `${scheme} [redacted]`)
     .replace(SENSITIVE_ASSIGNMENT_RE, (_match, key: string) => `${key}=[redacted]`);
 }
 

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -3,7 +3,7 @@ import { REDACTED_SENTINEL } from '@lobu/core';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
 import { AUDIT_SEMANTIC_TYPE } from './constants';
-import type { ToolContext } from './registry';
+import { getTool, type ToolContext } from './registry';
 
 const MAX_PREVIEW_CHARS = 500;
 // Redaction principle: consume the COMPLETE credential. Over-consumption is
@@ -52,19 +52,43 @@ function redactPreview(value: string): string {
 }
 
 /**
- * Generic audit entries persist the SHAPE of a call, never its content: keys,
- * structure, and booleans/nulls (provably structural — one bit) survive; every
- * string and number leaf becomes the sentinel. No key allowlist and no value
- * pattern can be trusted here — audit also fires on FAILED validation, so even
- * an enum-typed key like `action` can arrive carrying arbitrary pasted text,
- * and identifier-shaped secrets (`sk-live-…`) are indistinguishable from
- * slugs. Free text can hide a secret in shapes no pattern enumerates.
+ * Generic audit entries persist the SHAPE of a call, never its content.
+ * Nothing caller-controlled survives: values are sentineled except
+ * booleans/nulls (provably structural — one bit), and property NAMES are kept
+ * only when the tool's own input schema declares them at the top level —
+ * audit also fires on FAILED validation, so arbitrary pasted text can arrive
+ * as a value of an enum-typed key or even AS a key, and identifier-shaped
+ * secrets (`sk-live-…`) are indistinguishable from slugs. Repeated sentinel
+ * keys merge; that collapse is part of recording shape, not content.
  */
-function sanitizeArgLeaves(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map((item) => sanitizeArgLeaves(item));
+function schemaPropertyNames(toolName: string): Set<string> {
+  const schema = getTool(toolName)?.inputSchema as
+    | {
+        properties?: Record<string, unknown>;
+        anyOf?: Array<{ properties?: Record<string, unknown> } | undefined>;
+      }
+    | undefined;
+  const names = new Set<string>();
+  for (const props of [schema?.properties, ...(schema?.anyOf ?? []).map((v) => v?.properties)]) {
+    if (props) for (const key of Object.keys(props)) names.add(key);
+  }
+  return names;
+}
+
+function sanitizeArgLeaves(
+  value: unknown,
+  trustedKeys: ReadonlySet<string>,
+  topLevel: boolean
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeArgLeaves(item, trustedKeys, false));
+  }
   if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value).map(([key, nested]) => [key, sanitizeArgLeaves(nested)])
+      Object.entries(value).map(([key, nested]) => [
+        topLevel && trustedKeys.has(key) ? key : REDACTED_SENTINEL,
+        sanitizeArgLeaves(nested, trustedKeys, false),
+      ])
     );
   }
   if (typeof value === 'boolean' || value === null || value === undefined) return value;
@@ -176,7 +200,9 @@ function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown
   // (and an unsalted credential-derived digest) whenever a secret hides in a
   // shape no pattern enumerates — the ledger records the call's shape, never
   // its content.
-  const sanitizedArgsJson = JSON.stringify(sanitizeArgLeaves(params.args ?? {}));
+  const sanitizedArgsJson = JSON.stringify(
+    sanitizeArgLeaves(params.args ?? {}, schemaPropertyNames(params.toolName), true)
+  );
   const reportedFailure =
     result.error != null ||
     result.success === false ||

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -229,12 +229,34 @@ export async function executeTool(
       throw new Error('User context required.');
     }
     if (toolName === 'list_organizations') {
-      return trackMCPToolCall(toolName, args, () =>
-        listOrganizations(args as any, env, {
-          userId: authCtx.userId!,
-          currentOrganizationId: authCtx.organizationId,
-        })
-      );
+      // This early return sits BEFORE the shared audit seam below, so it must
+      // audit its own invocation. The event needs an owning org: use the bound
+      // org when there is one; a session with no bound org has no ledger to
+      // write into, and toToolContext would throw on it anyway.
+      const startTime = Date.now();
+      const auditIfOrgBound = (outcome: { result?: unknown; error?: unknown }) =>
+        authCtx.organizationId
+          ? recordToolInvocationAudit({
+              toolName,
+              args,
+              ...outcome,
+              durationMs: Date.now() - startTime,
+              ctx: toToolContext(authCtx),
+            })
+          : Promise.resolve();
+      try {
+        const result = await trackMCPToolCall(toolName, args, () =>
+          listOrganizations(args as any, env, {
+            userId: authCtx.userId!,
+            currentOrganizationId: authCtx.organizationId,
+          })
+        );
+        await auditIfOrgBound({ result });
+        return result;
+      } catch (error) {
+        await auditIfOrgBound({ error });
+        throw error;
+      }
     }
   }
 

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -46,6 +46,12 @@ export interface AuthContext {
   baseUrl: string;
   scopedToOrg: boolean;
   allowCrossOrg: boolean;
+  /**
+   * Persistent MCP session id (`mcp-session-id` header) when the call arrived
+   * through an MCP transport session; null for REST-proxy and internal calls.
+   * Audit rows carry it so a client's activity can be grouped per session.
+   */
+  mcpSessionId?: string | null;
   instructions?: string;
   /** `x-lobu-apply-id` when the call belongs to a `lobu apply` run. */
   applyId?: string | null;
@@ -326,5 +332,6 @@ export function toToolContext(authCtx: AuthContext): ToolContext {
     requestUrl: authCtx.requestUrl,
     baseUrl: authCtx.baseUrl,
     applyId: authCtx.applyId ?? null,
+    mcpSessionId: authCtx.mcpSessionId ?? null,
   };
 }

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -106,6 +106,8 @@ export interface ToolContext {
   sourceContext?: ToolSourceContext | null;
   /** `x-lobu-apply-id` when this call belongs to a `lobu apply` run (REST proxy only). */
   applyId?: string | null;
+  /** Persistent MCP session id driving this call; null off the MCP transport. */
+  mcpSessionId?: string | null;
   /** Whether request was authenticated */
   isAuthenticated: boolean;
   /** OAuth client ID that created this request (null for session/anonymous) */


### PR DESCRIPTION
## Summary

Completes the tool-invocation audit so an external MCP/API client's full activity is recorded, not just `run_sdk`/`query_sql` — the prerequisite for surfacing MCP-client sessions in Recent.

- **Generic audit fallback** (`tools/audit.ts`): every tool dispatched through `executeTool` with an **external token** (`oauth`/`pat`) now writes a `semantic_type='audit'` event: `args_sha256`, redacted args preview, success/error, duration. Results are never copied — the ledger records who did what, not the data read. Browser-`session` and `anonymous` calls do NOT get the fallback (the web app's own reads would write an event per page view); `run_sdk`/`query_sql` keep their detailed audit for every token type as before.
- **`mcp_session_id` in audit metadata**: plumbed `AuthContext.mcpSessionId → ToolContext`, stamped once per MCP session at `onsessioninitialized` (the recovery path reuses the original id via its `sessionIdGenerator`, so recovered sessions are stamped by the same hook). REST-proxy calls carry `null`. This is the grouping key for the upcoming Recent arm.
- **`org_slug` recorded on `query_sql` audit rows**: during the run-757649 incident a correctly-redirected cross-org query was misread as "org_slug silently ignored" because the audit row only showed the bound org. The redirect target is now part of the payload.
- Redaction hardened (via review-fix pass): JSON-quoted secrets (`"token":"secret"`) escaped the assignment regex; args now go through `deepRedactSecrets` (key-based) plus quote-tolerant patterns, and error messages are redacted too.

## Red → Green

Red (before implementation, new suite):

```
 Test Files  1 failed (1)
      Tests  5 failed (5)
   FAIL  … > audits a generic (non run_sdk/query_sql) tool call from an MCP oauth session …
AssertionError: expected null not to be null   (no audit row was written)
```

Green (after):

```
 ✓ src/__tests__/integration/mcp/tool-invocation-audit.test.ts (6 tests)
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Mutation check: disabling the token-type guard (`if (false)`) makes the negative test fail (`does NOT write generic audit rows for browser-session tool calls ×`), proving it bites.

## Testing

- New: `src/__tests__/integration/mcp/tool-invocation-audit.test.ts` (6 tests: oauth MCP call audited + session id stamped; `org_slug` recorded; session calls not generically audited; `query_sql` still audited for session callers; thrown failure audited with redacted args; resolved `success:false` failure audited as failed).
- Full MCP integration dir: 87 passed / 2 skipped (serial).
- Full server integration suite: 341/341 files, 2908 passed / 2 skipped (serial, local pgvector DB).
- `make pre-pr` clean; `make review-fix` applied and its diff verified (it also removed my redundant recovery-path stamp — correct, see above).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added audit tracking for MCP tool invocations, including success and failure outcomes.
  - Audit records now include session correlation details and tool-specific context.
  - Added redaction for sensitive arguments, error messages, SQL previews, and other secret values.

- **Bug Fixes**
  - Prevented sensitive tokens and credentials from appearing in audit previews.
  - Improved handling of failed and resolved tool errors in audit records.
  - Browser-session tool calls are excluded from generic audit records while retaining SQL query coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->