### PR TITLE
fix(scripts): refuse to publish a package whose @lobu dependency is unpublished

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,16 @@ jobs:
         # guard that stops catching regressions fails here instead of going quiet.
         run: bun test scripts/__tests__/check-exposed-surface-naming.test.ts
 
+      - name: Publish manifest gate fixtures
+        # @lobu/worker@14.3.0 shipped depending on six packages that do not exist
+        # on the registry — four pinned to the `0.0.0` placeholder that `private:
+        # true` workspace packages carry — which 404s `npx @lobu/cli@latest` for
+        # every external consumer (#2186). Nothing caught it: the publish script
+        # rewrote `workspace:*` against on-disk versions without checking the
+        # target is published. These fixtures drive the real transform with the
+        # real manifest shapes and assert it refuses.
+        run: bun test scripts/__tests__/publish-packages-guard.test.ts
+
       - name: Raw-array SQL-param gate
         # packages/server's postgres.js client runs fetch_types:false, where a raw
         # JS array bound as a query param serializes to a malformed array literal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,13 +547,9 @@ jobs:
         run: bun test scripts/__tests__/check-exposed-surface-naming.test.ts
 
       - name: Publish manifest gate fixtures
-        # @lobu/worker@14.3.0 shipped depending on six packages that do not exist
-        # on the registry — four pinned to the `0.0.0` placeholder that `private:
-        # true` workspace packages carry — which 404s `npx @lobu/cli@latest` for
-        # every external consumer (#2186). Nothing caught it: the publish script
-        # rewrote `workspace:*` against on-disk versions without checking the
-        # target is published. These fixtures drive the real transform with the
-        # real manifest shapes and assert it refuses.
+        # @lobu/worker@14.3.0 shipped five private workspace dependencies at
+        # their `0.0.0` placeholder versions, so external installs failed
+        # (#2186). These fixtures exercise the publish transform's guard.
         run: bun test scripts/__tests__/publish-packages-guard.test.ts
 
       - name: Raw-array SQL-param gate

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "esbuild": "^0.28.1",
         "typescript": "^5.8.3",
       },
       "peerDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
@@ -33,11 +33,18 @@
         "@mariozechner/pi-agent-core": "^0.73.1",
         "@mariozechner/pi-ai": "^0.73.1",
         "@mariozechner/pi-coding-agent": "^0.73.1",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
+        "@opentelemetry/resources": "^1.30.0",
+        "@opentelemetry/sdk-trace-node": "^1.30.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@sentry/node": "^10.6.0",
         "@sinclair/typebox": "^0.34.33",
+        "form-data": "^4.0.4",
         "hono": "^4.11.7",
         "just-bash": "^2.12.8",
         "undici": "^7.28.0",
+        "winston": "^3.17.0",
         "zod": "^3.24.1",
       },
       "devDependencies": {
@@ -50,7 +57,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -136,7 +143,7 @@
     },
     "packages/client": {
       "name": "@lobu/client",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -145,7 +152,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -169,7 +176,7 @@
     },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
@@ -204,7 +211,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -225,7 +232,7 @@
     },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "dependencies": {
         "@hono/node-server": "^2.0.11",
         "@xenova/transformers": "^2.17.2",
@@ -334,7 +341,7 @@
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -342,7 +349,7 @@
     },
     "packages/plugin-api": {
       "name": "@lobu/plugin-api",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.41",
       },
@@ -367,7 +374,7 @@
     },
     "packages/plugin-host": {
       "name": "@lobu/plugin-host",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "dependencies": {
         "@lobu/plugin-api": "workspace:*",
       },
@@ -436,7 +443,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -69,6 +69,11 @@ const config: KnipConfig = {
       // those, so they don't need explicit entries.
       entry: ["src/index.ts", "src/server.ts", "src/**/*.test.ts"],
     },
+    "packages/agent-worker": {
+      // The publish bundler is invoked from the package's `build` script, not
+      // imported, so knip can't reach it through the module graph.
+      entry: ["src/index.ts", "scripts/build-worker-bundle.mjs"],
+    },
     "packages/server": {
       entry: [
         // Bundle entry (esbuild). server-entry.ts is the Node-version gate that

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -13,8 +13,7 @@
     "!src/**/__tests__/**",
     "!src/**/*.test.ts",
     "!src/**/*.spec.ts",
-    "!**/*.js.map",
-    "!**/*.d.ts.map"
+    "!**/*.map"
   ],
   "exports": {
     ".": {

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "esbuild": "^0.28.1",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/build-worker-bundle.mjs",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "test": "bun test",
@@ -63,11 +63,18 @@
     "@mariozechner/pi-agent-core": "^0.73.1",
     "@mariozechner/pi-ai": "^0.73.1",
     "@mariozechner/pi-coding-agent": "^0.73.1",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/sdk-trace-node": "^1.30.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@sentry/node": "^10.6.0",
     "@sinclair/typebox": "^0.34.33",
+    "form-data": "^4.0.4",
     "hono": "^4.11.7",
     "just-bash": "^2.12.8",
     "undici": "^7.28.0",
+    "winston": "^3.17.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/agent-worker/scripts/build-worker-bundle.mjs
+++ b/packages/agent-worker/scripts/build-worker-bundle.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Bundle the @lobu/worker entrypoint into a standalone ESM file for publishing.
+ *
+ * Why this exists: @lobu/worker depends on five `private: true` workspace
+ * packages (plugin-conversations, plugin-mcp, plugin-media, plugin-memory,
+ * plugin-toolkit). Those are never published, but `tsc` only transpiles — it
+ * leaves bare `require("@lobu/plugin-mcp")` calls in dist/ and the imports in
+ * the shipped src/. @lobu/worker@14.3.0 therefore went to the registry
+ * depending on packages that do not exist there, 404ing `npx @lobu/cli@latest`
+ * for every external consumer (#2186). Inlining them at build time is what
+ * makes the published package installable while keeping them private.
+ *
+ * Why ESM and not a patched dist/: the CJS dist is a genuine dead end.
+ * agent-worker compiles with "module": "CommonJS", and
+ * @mariozechner/pi-coding-agent is `type: module` exposing only an `import`
+ * condition, so a node-loaded require() of dist/index.js throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED. That is why the package shipped src/ plus a
+ * `bun` exports condition at all — the server resolves `src/index.ts` in
+ * preference to dist (see packages/server/src/gateway/config/index.ts). This
+ * bundle replaces that src/ entry with something Node itself can load.
+ *
+ * Resolution conditions: 'bun' first, so workspace packages resolve to their TS
+ * source rather than a CJS dist barrel. esbuild compiles the TS inline.
+ *
+ * External vs inlined:
+ *   - EVERY @lobu workspace package is inlined, published ones included.
+ *     Keeping @lobu/core external seemed better (one shared copy) but does not
+ *     work — see the note at the resolver below. Inlining them all also means
+ *     the published manifest declares no @lobu dependencies at all, so the
+ *     release no longer waits on plugin-api/plugin-host being bootstrapped.
+ *   - Every npm dependency stays external, loaded from node_modules at runtime,
+ *     and must be declared by this package — enforced at the bottom of this file.
+ */
+
+import esbuild from "esbuild";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(here, "..");
+
+const result = await esbuild.build({
+  absWorkingDir: pkgDir,
+  entryPoints: [join(pkgDir, "src/index.ts")],
+  outfile: join(pkgDir, "dist/index.bundle.mjs"),
+  bundle: true,
+  platform: "node",
+  target: "node22",
+  format: "esm",
+  conditions: ["bun", "import", "module", "default"],
+  sourcemap: true,
+  metafile: true,
+  logLevel: "info",
+  plugins: [
+    {
+      name: "inline-lobu-workspace",
+      setup(build) {
+        build.onResolve({ filter: /.*/ }, (args) => {
+          if (args.kind === "entry-point") return null;
+          const id = args.path;
+          // Relative/absolute imports are part of this package — bundle them.
+          if (id.startsWith(".") || id.startsWith("/")) return null;
+          // ALL @lobu workspace packages are inlined, published ones included.
+          //
+          // Leaving @lobu/core external looked right (one shared copy from
+          // node_modules) but does not work: core, plugin-api and plugin-host
+          // are CommonJS, this bundle is ESM, and Node cannot reliably bind
+          // named imports across that boundary — a clean install died with
+          // "Named export 'sanitizeSuggestionPrompts' not found. The requested
+          // module '@lobu/core' is a CommonJS module". This is the same
+          // ESM↔CJS interop trap documented in
+          // packages/server/scripts/build-server-bundle.mjs (#430), and the
+          // same resolution: bundle the workspace graph, keep only npm
+          // dependencies external.
+          if (id.startsWith("@lobu/")) return null;
+          return { external: true };
+        });
+      },
+    },
+  ],
+  // esbuild emits require() calls when inlining CJS-flavoured workspace source;
+  // ESM output has no require, so provide one. Per-module __filename/__dirname
+  // shims are emitted by esbuild itself, so don't add them here.
+  banner: {
+    js: "import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);",
+  },
+});
+
+// The publish transform ships exactly these declaration files as the package's
+// entire type surface. tsc is incremental: after `rm -rf dist` a stale
+// tsconfig.tsbuildinfo makes it exit 0 having emitted nothing, which would
+// publish a bundle with no types at all and no error anywhere. Assert they
+// exist rather than trusting tsc's exit code (fix: delete tsconfig.tsbuildinfo).
+for (const decl of ["dist/index.d.ts", "dist/core/types.d.ts"]) {
+  if (!existsSync(join(pkgDir, decl))) {
+    console.error(
+      `\n[build-worker-bundle] FAILED: ${decl} missing — tsc emitted no declarations.\n` +
+        "  This is usually a stale tsconfig.tsbuildinfo after dist/ was deleted.\n" +
+        "  Fix: rm packages/agent-worker/tsconfig.tsbuildinfo && bun run build"
+    );
+    process.exit(1);
+  }
+}
+
+// Select the JS output explicitly — outputs also contains the .map entry, and
+// picking [0] silently read the sourcemap's (empty) import list instead, which
+// made this check pass unconditionally.
+const jsOutput = Object.entries(result.metafile.outputs).find(([file]) =>
+  file.endsWith(".mjs")
+)?.[1];
+if (!jsOutput) {
+  console.error("\n[build-worker-bundle] FAILED: no .mjs output in metafile");
+  process.exit(1);
+}
+const imports = jsOutput.imports ?? [];
+// No @lobu specifier may survive: the published manifest declares none, so any
+// that remained would be unresolvable for a consumer — the exact shape of
+// #2186. This is stricter than checking only the private ones, and it is what
+// lets the publish transform drop every @lobu dependency safely.
+const leaked = [
+  ...new Set(imports.map((i) => i.path).filter((p) => p.startsWith("@lobu/"))),
+];
+if (leaked.length > 0) {
+  console.error(
+    `\n[build-worker-bundle] FAILED: @lobu imports survived bundling: ${leaked.join(", ")}\n` +
+      "  The published manifest declares no @lobu dependencies, so these would not resolve."
+  );
+  process.exit(1);
+}
+
+// Every external the bundle keeps must be declared by THIS package, because
+// that is all a consumer installs. Inlining a private plugin pulls its own
+// dependencies into our import graph without pulling its manifest: bundling
+// plugin-media silently added `form-data`, which is declared by plugin-media
+// but was not a dependency of @lobu/worker, so a clean install imported the
+// bundle and died with ERR_MODULE_NOT_FOUND. Caught by installing the packed
+// tarball in an empty directory; this check makes it a build failure instead.
+const pkgManifest = JSON.parse(
+  readFileSync(join(pkgDir, "package.json"), "utf8")
+);
+const declared = new Set([
+  ...Object.keys(pkgManifest.dependencies ?? {}),
+  ...Object.keys(pkgManifest.peerDependencies ?? {}),
+]);
+const externals = [
+  ...new Set(
+    imports
+      .filter((i) => i.external)
+      .map((i) => i.path)
+      .filter((p) => !p.startsWith("node:"))
+      // Bare specifier → package name (@scope/name or name).
+      .map((p) =>
+        p.startsWith("@") ? p.split("/").slice(0, 2).join("/") : p.split("/")[0]
+      )
+  ),
+].sort();
+const undeclared = externals.filter((p) => !declared.has(p));
+if (undeclared.length > 0) {
+  console.error(
+    `\n[build-worker-bundle] FAILED: the bundle imports packages ${pkgManifest.name} does not declare: ${undeclared.join(", ")}\n` +
+      "  A consumer installing this package would hit ERR_MODULE_NOT_FOUND.\n" +
+      "  Add them to dependencies (they most likely come from an inlined private plugin)."
+  );
+  process.exit(1);
+}
+
+console.log(
+  `\n[build-worker-bundle] ok — ${externals.length} external(s), all declared: ${externals.join(", ")}`
+);

--- a/packages/agent-worker/scripts/build-worker-bundle.mjs
+++ b/packages/agent-worker/scripts/build-worker-bundle.mjs
@@ -21,6 +21,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { isBuiltin } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildPublishedDeclaration } from "./published-declaration.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgDir = join(here, "..");
@@ -80,33 +81,23 @@ for (const decl of ["dist/index.d.ts", TYPES_SRC]) {
   }
 }
 
-// Emit ONE self-contained declaration beside the bundle.
-//
-// The published package declares no @lobu dependencies, so shipping tsc's
-// dist/core/types.d.ts verbatim left `import type { WorkerTransport } from
-// "@lobu/core"` dangling and every consumer tsc failed with TS2307. Only
-// WorkerConfig is exported from the entry and it does not reference @lobu/core
-// — that import serves sibling interfaces outside the public surface — so the
-// declaration is rebuilt from just that type.
-const typesSource = readFileSync(join(pkgDir, TYPES_SRC), "utf8");
-const workerConfig = typesSource.match(
-  /export interface WorkerConfig \{[\s\S]*?\n\}/
-)?.[0];
-if (!workerConfig) {
+// Emit ONE self-contained declaration beside the bundle. The generator lives in
+// published-declaration.mjs so the publish gate can drive it without a built
+// dist/ — see the note there.
+let declaration;
+try {
+  declaration = buildPublishedDeclaration(
+    readFileSync(join(pkgDir, TYPES_SRC), "utf8")
+  );
+} catch (error) {
   console.error(
-    `\n[build-worker-bundle] FAILED: could not extract WorkerConfig from ${TYPES_SRC}.\n` +
-      "  The published type surface is generated from it; check whether it was renamed."
+    `\n[build-worker-bundle] FAILED (source ${TYPES_SRC}): ${
+      error instanceof Error ? error.message : String(error)
+    }`
   );
   process.exit(1);
 }
-if (/@lobu\//.test(workerConfig)) {
-  console.error(
-    "\n[build-worker-bundle] FAILED: generated declaration references an @lobu package.\n" +
-      "  The published manifest declares none, so a consumer's tsc would fail with TS2307."
-  );
-  process.exit(1);
-}
-writeFileSync(join(pkgDir, "dist/index.bundle.d.ts"), `${workerConfig}\n`);
+writeFileSync(join(pkgDir, "dist/index.bundle.d.ts"), declaration);
 
 // Select the JS output explicitly — outputs also contains the .map entry, and
 // picking [0] silently read the sourcemap's (empty) import list instead, which

--- a/packages/agent-worker/scripts/build-worker-bundle.mjs
+++ b/packages/agent-worker/scripts/build-worker-bundle.mjs
@@ -17,7 +17,7 @@
  */
 
 import esbuild from "esbuild";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { isBuiltin } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -68,7 +68,8 @@ const result = await esbuild.build({
 // tsc is incremental: after `rm -rf dist` a stale tsconfig.tsbuildinfo makes it
 // exit 0 having emitted nothing, which would publish a typeless bundle with no
 // error anywhere. Don't trust tsc's exit code — check the files.
-for (const decl of ["dist/index.d.ts", "dist/core/types.d.ts"]) {
+const TYPES_SRC = "dist/core/types.d.ts";
+for (const decl of ["dist/index.d.ts", TYPES_SRC]) {
   if (!existsSync(join(pkgDir, decl))) {
     console.error(
       `\n[build-worker-bundle] FAILED: ${decl} missing — tsc emitted no declarations.\n` +
@@ -78,6 +79,34 @@ for (const decl of ["dist/index.d.ts", "dist/core/types.d.ts"]) {
     process.exit(1);
   }
 }
+
+// Emit ONE self-contained declaration beside the bundle.
+//
+// The published package declares no @lobu dependencies, so shipping tsc's
+// dist/core/types.d.ts verbatim left `import type { WorkerTransport } from
+// "@lobu/core"` dangling and every consumer tsc failed with TS2307. Only
+// WorkerConfig is exported from the entry and it does not reference @lobu/core
+// — that import serves sibling interfaces outside the public surface — so the
+// declaration is rebuilt from just that type.
+const typesSource = readFileSync(join(pkgDir, TYPES_SRC), "utf8");
+const workerConfig = typesSource.match(
+  /export interface WorkerConfig \{[\s\S]*?\n\}/
+)?.[0];
+if (!workerConfig) {
+  console.error(
+    `\n[build-worker-bundle] FAILED: could not extract WorkerConfig from ${TYPES_SRC}.\n` +
+      "  The published type surface is generated from it; check whether it was renamed."
+  );
+  process.exit(1);
+}
+if (/@lobu\//.test(workerConfig)) {
+  console.error(
+    "\n[build-worker-bundle] FAILED: generated declaration references an @lobu package.\n" +
+      "  The published manifest declares none, so a consumer's tsc would fail with TS2307."
+  );
+  process.exit(1);
+}
+writeFileSync(join(pkgDir, "dist/index.bundle.d.ts"), `${workerConfig}\n`);
 
 // Select the JS output explicitly — outputs also contains the .map entry, and
 // picking [0] silently read the sourcemap's (empty) import list instead, which

--- a/packages/agent-worker/scripts/build-worker-bundle.mjs
+++ b/packages/agent-worker/scripts/build-worker-bundle.mjs
@@ -35,6 +35,7 @@
 
 import esbuild from "esbuild";
 import { existsSync, readFileSync } from "node:fs";
+import { isBuiltin } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -149,7 +150,12 @@ const externals = [
     imports
       .filter((i) => i.external)
       .map((i) => i.path)
-      .filter((p) => !p.startsWith("node:"))
+      // Node builtins are not npm packages. The resolver above externalises
+      // every bare specifier, so an unprefixed `path`/`fs`/`crypto` anywhere in
+      // the inlined graph would otherwise be reported as an undeclared
+      // dependency. isBuiltin covers both spellings and subpaths
+      // (`fs`, `node:fs`, `node:fs/promises`).
+      .filter((p) => !isBuiltin(p))
       // Bare specifier → package name (@scope/name or name).
       .map((p) =>
         p.startsWith("@") ? p.split("/").slice(0, 2).join("/") : p.split("/")[0]

--- a/packages/agent-worker/scripts/build-worker-bundle.mjs
+++ b/packages/agent-worker/scripts/build-worker-bundle.mjs
@@ -2,35 +2,18 @@
 /**
  * Bundle the @lobu/worker entrypoint into a standalone ESM file for publishing.
  *
- * Why this exists: @lobu/worker depends on five `private: true` workspace
- * packages (plugin-conversations, plugin-mcp, plugin-media, plugin-memory,
- * plugin-toolkit). Those are never published, but `tsc` only transpiles — it
- * leaves bare `require("@lobu/plugin-mcp")` calls in dist/ and the imports in
- * the shipped src/. @lobu/worker@14.3.0 therefore went to the registry
- * depending on packages that do not exist there, 404ing `npx @lobu/cli@latest`
- * for every external consumer (#2186). Inlining them at build time is what
- * makes the published package installable while keeping them private.
+ * Why: @lobu/worker imports `private: true` workspace packages, and `tsc` only
+ * transpiles — so both the tsc dist/ and the shipped src/ carried bare
+ * `@lobu/plugin-*` specifiers that no consumer can resolve (#2186). Inlining
+ * them keeps those packages private and the published one installable.
  *
- * Why ESM and not a patched dist/: the CJS dist is a genuine dead end.
- * agent-worker compiles with "module": "CommonJS", and
- * @mariozechner/pi-coding-agent is `type: module` exposing only an `import`
- * condition, so a node-loaded require() of dist/index.js throws
- * ERR_PACKAGE_PATH_NOT_EXPORTED. That is why the package shipped src/ plus a
- * `bun` exports condition at all — the server resolves `src/index.ts` in
- * preference to dist (see packages/server/src/gateway/config/index.ts). This
- * bundle replaces that src/ entry with something Node itself can load.
+ * Why ESM: agent-worker compiles to CommonJS and @mariozechner/pi-coding-agent
+ * is import-only, so a node require() of the CJS dist throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED — which is why src/ was shipped at all. This
+ * bundle is the first entry point Node itself can load.
  *
- * Resolution conditions: 'bun' first, so workspace packages resolve to their TS
- * source rather than a CJS dist barrel. esbuild compiles the TS inline.
- *
- * External vs inlined:
- *   - EVERY @lobu workspace package is inlined, published ones included.
- *     Keeping @lobu/core external seemed better (one shared copy) but does not
- *     work — see the note at the resolver below. Inlining them all also means
- *     the published manifest declares no @lobu dependencies at all, so the
- *     release no longer waits on plugin-api/plugin-host being bootstrapped.
- *   - Every npm dependency stays external, loaded from node_modules at runtime,
- *     and must be declared by this package — enforced at the bottom of this file.
+ * EVERY @lobu package is inlined (see the resolver note below); every npm
+ * dependency stays external and must be declared here, enforced at the bottom.
  */
 
 import esbuild from "esbuild";
@@ -63,18 +46,11 @@ const result = await esbuild.build({
           const id = args.path;
           // Relative/absolute imports are part of this package — bundle them.
           if (id.startsWith(".") || id.startsWith("/")) return null;
-          // ALL @lobu workspace packages are inlined, published ones included.
-          //
-          // Leaving @lobu/core external looked right (one shared copy from
-          // node_modules) but does not work: core, plugin-api and plugin-host
-          // are CommonJS, this bundle is ESM, and Node cannot reliably bind
-          // named imports across that boundary — a clean install died with
-          // "Named export 'sanitizeSuggestionPrompts' not found. The requested
-          // module '@lobu/core' is a CommonJS module". This is the same
-          // ESM↔CJS interop trap documented in
-          // packages/server/scripts/build-server-bundle.mjs (#430), and the
-          // same resolution: bundle the workspace graph, keep only npm
-          // dependencies external.
+          // Published @lobu packages are inlined too, not just the private
+          // ones: they are CommonJS and this bundle is ESM, so leaving them
+          // external made a clean install die on "Named export
+          // 'sanitizeSuggestionPrompts' not found". Same ESM↔CJS trap and same
+          // fix as packages/server/scripts/build-server-bundle.mjs (#430).
           if (id.startsWith("@lobu/")) return null;
           return { external: true };
         });
@@ -89,11 +65,9 @@ const result = await esbuild.build({
   },
 });
 
-// The publish transform ships exactly these declaration files as the package's
-// entire type surface. tsc is incremental: after `rm -rf dist` a stale
-// tsconfig.tsbuildinfo makes it exit 0 having emitted nothing, which would
-// publish a bundle with no types at all and no error anywhere. Assert they
-// exist rather than trusting tsc's exit code (fix: delete tsconfig.tsbuildinfo).
+// tsc is incremental: after `rm -rf dist` a stale tsconfig.tsbuildinfo makes it
+// exit 0 having emitted nothing, which would publish a typeless bundle with no
+// error anywhere. Don't trust tsc's exit code — check the files.
 for (const decl of ["dist/index.d.ts", "dist/core/types.d.ts"]) {
   if (!existsSync(join(pkgDir, decl))) {
     console.error(
@@ -116,10 +90,8 @@ if (!jsOutput) {
   process.exit(1);
 }
 const imports = jsOutput.imports ?? [];
-// No @lobu specifier may survive: the published manifest declares none, so any
-// that remained would be unresolvable for a consumer — the exact shape of
-// #2186. This is stricter than checking only the private ones, and it is what
-// lets the publish transform drop every @lobu dependency safely.
+// No @lobu specifier may survive: the published manifest declares none, so a
+// leftover would be unresolvable — the exact shape of #2186.
 const leaked = [
   ...new Set(imports.map((i) => i.path).filter((p) => p.startsWith("@lobu/"))),
 ];
@@ -131,13 +103,10 @@ if (leaked.length > 0) {
   process.exit(1);
 }
 
-// Every external the bundle keeps must be declared by THIS package, because
-// that is all a consumer installs. Inlining a private plugin pulls its own
-// dependencies into our import graph without pulling its manifest: bundling
-// plugin-media silently added `form-data`, which is declared by plugin-media
-// but was not a dependency of @lobu/worker, so a clean install imported the
-// bundle and died with ERR_MODULE_NOT_FOUND. Caught by installing the packed
-// tarball in an empty directory; this check makes it a build failure instead.
+// Every external must be declared by THIS package — that is all a consumer
+// installs. Inlining pulls in the inlined package's own dependencies without
+// its manifest (plugin-media brought `form-data`), so a clean install died with
+// ERR_MODULE_NOT_FOUND. This turns that into a build failure.
 const pkgManifest = JSON.parse(
   readFileSync(join(pkgDir, "package.json"), "utf8")
 );

--- a/packages/agent-worker/scripts/published-declaration.mjs
+++ b/packages/agent-worker/scripts/published-declaration.mjs
@@ -1,0 +1,39 @@
+/**
+ * Generate the single self-contained declaration shipped beside the published
+ * @lobu/worker bundle.
+ *
+ * The published manifest declares no @lobu dependencies, so shipping tsc's
+ * dist/core/types.d.ts verbatim left `import type { WorkerTransport } from
+ * "@lobu/core"` dangling and every consumer's tsc failed with TS2307. Only
+ * WorkerConfig is exported from the entry and it does not reference
+ * @lobu/core — that import serves sibling interfaces outside the public
+ * surface — so the declaration is rebuilt from just that type.
+ *
+ * Kept pure and separate from build-worker-bundle.mjs so the publish gate can
+ * exercise it without a built dist/: the gate runs in a lint job that never
+ * builds, and reading the emitted artifact there failed with ENOENT.
+ */
+
+const WORKER_CONFIG = /export interface WorkerConfig \{[\s\S]*?\n\}/;
+
+/**
+ * @param {string} typesSource Contents of the module declaring WorkerConfig.
+ * @returns {string} The declaration to write next to the bundle.
+ * @throws If WorkerConfig is absent, or references an @lobu package.
+ */
+export function buildPublishedDeclaration(typesSource) {
+  const workerConfig = typesSource.match(WORKER_CONFIG)?.[0];
+  if (!workerConfig) {
+    throw new Error(
+      "could not extract WorkerConfig. The published type surface is generated " +
+        "from it; check whether it was renamed."
+    );
+  }
+  if (/@lobu\//.test(workerConfig)) {
+    throw new Error(
+      "generated declaration references an @lobu package. The published " +
+        "manifest declares none, so a consumer's tsc would fail with TS2307."
+    );
+  }
+  return `${workerConfig}\n`;
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,8 +13,7 @@
   },
   "files": [
     "dist",
-    "!**/*.js.map",
-    "!**/*.d.ts.map"
+    "!**/*.map"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -55,8 +55,7 @@
   },
   "files": [
     "dist",
-    "!**/*.js.map",
-    "!**/*.d.ts.map"
+    "!**/*.map"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -40,8 +40,7 @@
   "files": [
     "dist",
     "README.md",
-    "!**/*.js.map",
-    "!**/*.d.ts.map"
+    "!**/*.map"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,7 @@
     "!src/**/*.test.tsx",
     "!src/**/*.spec.ts",
     "!src/**/*.spec.tsx",
-    "!**/*.js.map",
-    "!**/*.d.ts.map"
+    "!**/*.map"
   ],
   "exports": {
     ".": {

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -35,8 +35,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
-    "!**/*.js.map",
-    "!**/*.d.ts.map"
+    "!**/*.map"
   ],
   "exports": {
     ".": {

--- a/packages/plugin-api/package.json
+++ b/packages/plugin-api/package.json
@@ -14,8 +14,7 @@
   },
   "files": [
     "dist",
-    "!**/*.js.map",
-    "!**/*.d.ts.map"
+    "!**/*.map"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/plugin-host/package.json
+++ b/packages/plugin-host/package.json
@@ -14,8 +14,7 @@
   },
   "files": [
     "dist",
-    "!**/*.js.map",
-    "!**/*.d.ts.map"
+    "!**/*.map"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/promptfoo-provider/package.json
+++ b/packages/promptfoo-provider/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "dist",
-    "!**/*.js.map",
-    "!**/*.d.ts.map"
+    "!**/*.map"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/server/src/gateway/config/index.ts
+++ b/packages/server/src/gateway/config/index.ts
@@ -210,17 +210,25 @@ function buildEmbeddedWorkerPaths(projectRoot: string): {
       "@lobu/worker/package.json"
     );
     const workerPackageRoot = path.dirname(workerPackageJson);
-    // Prefer the ESM TypeScript source (spawned via `bun run`): the published
+    // In-repo, prefer the ESM TypeScript source (spawned via `bun run`): the
     // CJS `dist/index.js` is a dead end because `@mariozechner/pi-coding-agent`
     // only exposes an `import` condition, so a `node`-loaded `require()` of it
-    // throws ERR_PACKAGE_PATH_NOT_EXPORTED. The package ships `src/` and a
-    // `bun` exports condition for exactly this path. `bun` is a declared
+    // throws ERR_PACKAGE_PATH_NOT_EXPORTED. The workspace package keeps `src/`
+    // and a `bun` exports condition for exactly this path. `bun` is a declared
     // peerDependency of `@lobu/worker`.
+    //
+    // Installed from the registry there is no `src/`: the published package
+    // ships a single ESM bundle (`dist/index.bundle.mjs`) with the whole @lobu
+    // workspace graph inlined — see packages/agent-worker/scripts/
+    // build-worker-bundle.mjs. This used to fall through to `dist/index.js`,
+    // which the tarball no longer contains (and which could never have loaded
+    // pi-coding-agent under node anyway), so the bundle is the installed entry.
+    // A guard test asserts every dist path named here is actually published.
     const workerSrcEntry = path.join(workerPackageRoot, "src/index.ts");
     return {
       entryPoint: existsSync(workerSrcEntry)
         ? workerSrcEntry
-        : path.join(workerPackageRoot, "dist/index.js"),
+        : path.join(workerPackageRoot, "dist/index.bundle.mjs"),
       binPathEntries: [
         path.join(workerPackageRoot, "node_modules/.bin"),
         path.resolve(workerPackageRoot, "..", "..", ".bin"),

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -350,6 +350,76 @@ describe("published @lobu/worker manifest", () => {
 });
 
 /**
+ * Scripts are checked across EVERY published package, not just @lobu/worker.
+ * The instance found in review was worker's `start` pointing at the excluded
+ * dist/index.js, but all ten manifests carried dev-loop scripts needing src/,
+ * tsc or scripts/ — none of which ship. A per-package assertion would only
+ * ever catch the next one.
+ */
+describe("published manifests ship no unrunnable scripts", () => {
+  const transformedManifests = __testing.PACKAGES.map(
+    (entry: { dir: string; transform?: (pkg: unknown) => unknown }) => {
+      const manifest = JSON.parse(
+        readFileSync(join(REPO_ROOT, entry.dir, "package.json"), "utf8")
+      );
+      return {
+        dir: entry.dir,
+        pkg: (entry.transform ? entry.transform(manifest) : manifest) as {
+          name: string;
+          files?: string[];
+          scripts?: Record<string, string>;
+        },
+      };
+    }
+  );
+
+  it("keeps only lifecycle scripts npm runs on install", () => {
+    for (const { dir, pkg } of transformedManifests) {
+      for (const name of Object.keys(pkg.scripts ?? {})) {
+        expect(
+          __testing.PUBLISHED_LIFECYCLE_SCRIPTS.has(name),
+          `${dir}: published manifest keeps non-lifecycle script "${name}"`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("never names a path the tarball excludes", () => {
+    // The actual failure mode: `npm start` on an installed @lobu/worker ran
+    // `node dist/index.js`, a file `files` omits. Any surviving script that
+    // references a path outside `files` reproduces it.
+    for (const { dir, pkg } of transformedManifests) {
+      const included = (pkg.files ?? []).filter((f) => !f.startsWith("!"));
+      for (const [name, command] of Object.entries(pkg.scripts ?? {})) {
+        for (const ref of command.match(
+          /(?:\.\/)?(?:src|dist|scripts|bin)\/[\w./-]+/g
+        ) ?? []) {
+          const normalized = ref.replace(/^\.\//, "");
+          expect(
+            included.some(
+              (f) => normalized === f || normalized.startsWith(`${f}/`)
+            ),
+            `${dir}: script "${name}" references ${normalized}, which "files" does not ship`
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("leaves the in-repo dev scripts untouched", () => {
+    // Publish-time only. Stripping the real manifests would break the dev loop.
+    const worker = JSON.parse(
+      readFileSync(
+        join(REPO_ROOT, "packages/agent-worker/package.json"),
+        "utf8"
+      )
+    );
+    expect(worker.scripts.build).toContain("build-worker-bundle.mjs");
+    expect(worker.scripts.typecheck).toBe("tsc --noEmit");
+  });
+});
+
+/**
  * The server spawns the worker by resolving a path inside the INSTALLED
  * @lobu/worker package. If the publish transform stops shipping the file that
  * resolver names, every published-CLI worker start fails at runtime with a

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -318,6 +318,53 @@ describe("published @lobu/worker manifest", () => {
 });
 
 /**
+ * The server spawns the worker by resolving a path inside the INSTALLED
+ * @lobu/worker package. If the publish transform stops shipping the file that
+ * resolver names, every published-CLI worker start fails at runtime with a
+ * missing entry point — invisible to typecheck and to any in-repo test, because
+ * in-repo the src/ path wins. This pins the two together.
+ */
+describe("installed worker entry point is actually published", () => {
+  const RESOLVER = join(
+    REPO_ROOT,
+    "packages/server/src/gateway/config/index.ts"
+  );
+
+  /** dist/... paths the resolver can hand back for an installed package. */
+  function resolverInstalledEntries() {
+    const source = readFileSync(RESOLVER, "utf8");
+    return [
+      ...source.matchAll(/workerPackageRoot,\s*\n?\s*"(dist\/[^"]+)"/g),
+    ].map((m) => m[1]);
+  }
+
+  it("ships every dist entry the server can resolve to", () => {
+    const entry = __testing.PACKAGES.find(
+      (p: { dir: string }) => p.dir === "packages/agent-worker"
+    );
+    const published = entry.transform(
+      JSON.parse(
+        readFileSync(
+          join(REPO_ROOT, "packages/agent-worker/package.json"),
+          "utf8"
+        )
+      )
+    ) as { files: string[] };
+
+    const candidates = resolverInstalledEntries();
+    // Guard the guard: if the resolver is refactored so this regex stops
+    // matching, an empty list would vacuously pass.
+    expect(candidates.length).toBeGreaterThan(0);
+
+    // EVERY dist path the resolver can name must be shipped. Asserting only
+    // the first is too weak — source order is not resolution order, so a
+    // resolver that fell back to an unshipped path would still pass.
+    const unshipped = candidates.filter((c) => !published.files.includes(c));
+    expect(unshipped).toEqual([]);
+  });
+});
+
+/**
  * `bump-version.mjs` used to accept any string as an explicit version, so a
  * stray flag rewrote every package.json in the workspace to a nonsense value
  * (`node scripts/bump-version.mjs --help` → `"version": "--help"`). These run

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -235,23 +235,80 @@ describe("publish loop (subprocess, stub npm)", () => {
     expect(`${result.stdout}${result.stderr}`).toContain("skipped");
   });
 
-  it("aborts the run when a manifest fails the publishability guard", () => {
-    // Nothing is blocked by npm, but @lobu/worker currently declares private
-    // plugin packages this script does not publish (#2186). The guard must
-    // stop the release rather than let the remaining packages go out around a
-    // known-broken manifest.
+  it("publishes the whole fleet when every manifest is publishable", () => {
+    // With @lobu/worker's private plugins now inlined into its bundle, no
+    // manifest declares an unpublishable dependency, so a release run should
+    // complete. Before that fix this aborted at @lobu/worker (#2186).
     writeStubNpm([]);
     const result = runPublishScript();
     const attempted = existsSync(logFile)
       ? readFileSync(logFile, "utf8").trim().split("\n").filter(Boolean)
       : [];
 
-    expect(result.status).not.toBe(0);
-    expect(`${result.stdout}${result.stderr}`).toContain(
-      "@lobu/plugin-conversations"
+    expect(result.status).toBe(0);
+    expect(attempted.length).toBe(__testing.PACKAGES.length);
+    expect(attempted).toContain("@lobu/worker");
+    expect(attempted).toContain("@lobu/cli");
+  });
+});
+
+/**
+ * The published @lobu/worker manifest is the artifact consumers actually
+ * install, and it diverges from the in-repo one on purpose (bundle entry, no
+ * src/, no @lobu deps). These lock that shape in — verified end to end by
+ * packing the tarball and installing it into an empty directory, where it
+ * imports and the `lobu-worker` bin runs.
+ */
+describe("published @lobu/worker manifest", () => {
+  const transformed = (() => {
+    const entry = __testing.PACKAGES.find(
+      (p: { dir: string }) => p.dir === "packages/agent-worker"
     );
-    // Packages ordered after the failure never reached npm publish.
-    expect(attempted).not.toContain("@lobu/cli");
+    const manifest = JSON.parse(
+      readFileSync(
+        join(REPO_ROOT, "packages/agent-worker/package.json"),
+        "utf8"
+      )
+    );
+    return entry.transform(manifest) as {
+      main: string;
+      bin: Record<string, string>;
+      files: string[];
+      exports: Record<string, unknown>;
+      dependencies: Record<string, string>;
+    };
+  })();
+
+  it("declares no @lobu dependencies — the whole workspace graph is inlined", () => {
+    // The exact defect from #2186. @lobu/core, plugin-api and plugin-host are
+    // CommonJS while the bundle is ESM, so they are inlined too; declaring
+    // them would also keep the release blocked on a bootstrap publish.
+    const lobuDeps = Object.keys(transformed.dependencies ?? {}).filter((d) =>
+      d.startsWith("@lobu/")
+    );
+    expect(lobuDeps).toEqual([]);
+  });
+
+  it("points every entry at the bundle and ships no src/", () => {
+    expect(transformed.main).toBe("./dist/index.bundle.mjs");
+    expect(transformed.bin["lobu-worker"]).toBe("./dist/index.bundle.mjs");
+    // Shipping src/ would reintroduce the unresolvable private-plugin imports,
+    // and the `bun` export condition pointed straight at it.
+    expect(transformed.files).not.toContain("src");
+    expect(JSON.stringify(transformed.exports)).not.toContain("src/");
+  });
+
+  it("keeps the in-repo manifest on the src/ dev path", () => {
+    // The transform is publish-time only. The server resolves @lobu/worker's
+    // src/index.ts in-repo, so mutating the real manifest would break dev.
+    const inRepo = JSON.parse(
+      readFileSync(
+        join(REPO_ROOT, "packages/agent-worker/package.json"),
+        "utf8"
+      )
+    );
+    expect(inRepo.files).toContain("src");
+    expect(inRepo.exports["."].bun).toBe("./src/index.ts");
   });
 });
 

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @lobu/worker@14.3.0 shipped to the registry declaring runtime dependencies on
+ * six packages that do not exist there — four of them pinned to `0.0.0`, the
+ * placeholder version `private: true` workspace packages carry. `npx
+ * @lobu/cli@latest` 404s for every external consumer as a result (issue #2186),
+ * and every CI gate was green when it shipped.
+ *
+ * The cause was `rewriteWorkspaceRefs` resolving `workspace:*` against whatever
+ * version it read off disk without checking the target is published. These
+ * fixtures drive that function directly with the real manifest shapes.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+const { rewriteWorkspaceRefs, __testing } = await import(
+  "../publish-packages.mjs"
+);
+
+/** Mirrors packages/agent-worker: published, but depends on private plugins. */
+function workerManifest() {
+  return {
+    name: "@lobu/worker",
+    version: "14.3.0",
+    dependencies: {
+      "@lobu/core": "workspace:*",
+      // Published siblings — legitimate.
+      "@lobu/plugin-api": "workspace:*",
+      "@lobu/plugin-host": "workspace:*",
+      // `private: true`, version 0.0.0 — the ones that broke the release.
+      "@lobu/plugin-mcp": "workspace:*",
+      "@lobu/plugin-memory": "workspace:*",
+    },
+  };
+}
+
+describe("rewriteWorkspaceRefs publishability guard", () => {
+  it("refuses a runtime dependency on a package the script does not publish", () => {
+    expect(() => rewriteWorkspaceRefs(workerManifest())).toThrow(
+      /@lobu\/plugin-mcp/
+    );
+  });
+
+  it("names the offending package and both remedies, not just 'failed'", () => {
+    let message = "";
+    try {
+      rewriteWorkspaceRefs(workerManifest());
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("@lobu/worker");
+    expect(message).toContain("@lobu/plugin-mcp");
+    expect(message).toContain("bundling");
+    expect(message).toContain("PACKAGES");
+  });
+
+  it("never emits the 0.0.0 placeholder into a published manifest", () => {
+    // The precise defect on the registry today: a constraint no release can
+    // ever satisfy. Whatever this function returns, it must not contain it.
+    let result: Record<string, unknown> | undefined;
+    try {
+      result = rewriteWorkspaceRefs(workerManifest()) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      // Throwing is the correct behavior; nothing was emitted.
+    }
+    if (result) {
+      expect(Object.values(result.dependencies ?? {})).not.toContain("0.0.0");
+    }
+  });
+
+  it("still rewrites refs when every runtime dependency is published", () => {
+    const pkg = rewriteWorkspaceRefs({
+      name: "@lobu/cli",
+      version: "14.3.0",
+      dependencies: { "@lobu/core": "workspace:*" },
+    }) as { dependencies: Record<string, string> };
+    // Resolved to the real on-disk version, and no longer a workspace: ref.
+    expect(pkg.dependencies["@lobu/core"]).not.toContain("workspace:");
+    expect(pkg.dependencies["@lobu/core"]).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("allows a private workspace package as a devDependency", () => {
+    // devDependencies are not installed by consumers, so a private dev-only
+    // tool is legitimate and must not trip the guard.
+    const pkg = rewriteWorkspaceRefs({
+      name: "@lobu/cli",
+      version: "14.3.0",
+      dependencies: {},
+      devDependencies: { "@lobu/plugin-mcp": "workspace:*" },
+    }) as { devDependencies: Record<string, string> };
+    expect(pkg.devDependencies["@lobu/plugin-mcp"]).not.toContain("workspace:");
+  });
+
+  it("still rejects a workspace ref outside the @lobu scope", () => {
+    expect(() =>
+      rewriteWorkspaceRefs({
+        name: "@lobu/cli",
+        version: "14.3.0",
+        dependencies: { "some-other-pkg": "workspace:*" },
+      })
+    ).toThrow(/outside @lobu scope/);
+  });
+});
+
+describe("blocked-dependency skip ordering", () => {
+  it("lists PACKAGES so dependencies precede their dependents", () => {
+    // The skip logic relies on seeing a blocked dependency before any package
+    // that depends on it. If PACKAGES is ever reordered, dependents would be
+    // published against a missing dependency again.
+    const order = __testing.PACKAGES.map((p: { dir: string }) => p.dir);
+    const indexOf = (dir: string) => order.indexOf(dir);
+    for (const { dir } of __testing.PACKAGES) {
+      for (const dep of __testing.lobuRuntimeDeps(dir)) {
+        const depDir = __testing.PACKAGES.find(
+          (p: { dir: string }) => __testing.packageNameFor(p.dir) === dep
+        )?.dir;
+        if (!depDir) continue; // Unpublished dep — the guard above covers it.
+        expect(indexOf(depDir)).toBeLessThan(indexOf(dir));
+      }
+    }
+  });
+});

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -230,6 +230,11 @@ describe("publish loop (subprocess, stub npm)", () => {
     // Packages with no runtime @lobu dependency are unaffected and still ship
     // — the guard must not turn one blocked package into a total outage.
     expect(attempted).toContain("@lobu/client");
+    // @lobu/worker still declares @lobu/core on disk, but publishes a manifest
+    // with zero @lobu dependencies because the bundle inlines the graph. The
+    // gate must read the transformed manifest: reading the raw one skipped the
+    // worker here, reinstating the bootstrap wait this change removes.
+    expect(attempted).toContain("@lobu/worker");
 
     expect(result.status).not.toBe(0);
     expect(`${result.stdout}${result.stderr}`).toContain("skipped");

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -37,21 +37,19 @@ function workerManifest() {
 }
 
 describe("rewriteWorkspaceRefs publishability guard", () => {
-  it("refuses a runtime dependency on a package the script does not publish", () => {
-    expect(() => rewriteWorkspaceRefs(workerManifest())).toThrow(
-      /@lobu\/plugin-mcp/
-    );
-  });
-
-  it("names the offending package and both remedies, not just 'failed'", () => {
+  it("refuses an unpublishable runtime dep, naming it and both remedies", () => {
     let message = "";
-    try {
-      rewriteWorkspaceRefs(workerManifest());
-    } catch (error) {
-      message = error instanceof Error ? error.message : String(error);
-    }
+    expect(() => {
+      try {
+        rewriteWorkspaceRefs(workerManifest());
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+        throw error;
+      }
+    }).toThrow(/@lobu\/plugin-mcp/);
+    // An actionable message is the point: "failed" would leave the next
+    // person guessing which of the two fixes applies.
     expect(message).toContain("@lobu/worker");
-    expect(message).toContain("@lobu/plugin-mcp");
     expect(message).toContain("bundling");
     expect(message).toContain("PACKAGES");
   });

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -18,6 +18,7 @@ import {
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "bun:test";
+import { buildPublishedDeclaration } from "../../packages/agent-worker/scripts/published-declaration.mjs";
 import { __testing, rewriteWorkspaceRefs } from "../publish-packages.mjs";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -293,15 +294,26 @@ describe("published @lobu/worker manifest", () => {
   });
 
   it("ships a self-contained declaration, not one importing @lobu", () => {
-    // tsc's dist/core/types.d.ts imports @lobu/core, which the published
-    // manifest no longer declares — shipping it verbatim failed every
-    // consumer's tsc with TS2307. The bundler emits a standalone declaration.
-    const decl = readFileSync(
-      join(REPO_ROOT, "packages/agent-worker/dist/index.bundle.d.ts"),
-      "utf8"
+    // The module declaring WorkerConfig imports @lobu/core, which the published
+    // manifest no longer declares — shipping tsc's emitted d.ts verbatim failed
+    // every consumer's tsc with TS2307. The build drives the generator below.
+    // Reading the emitted dist/index.bundle.d.ts instead only works after a
+    // build; this gate runs in the lint job, which never builds one.
+    const decl = buildPublishedDeclaration(
+      readFileSync(
+        join(REPO_ROOT, "packages/agent-worker/src/core/types.ts"),
+        "utf8"
+      )
     );
     expect(decl).toContain("WorkerConfig");
     expect(decl).not.toContain("@lobu/");
+    // ...and it refuses rather than emitting a declaration that would dangle.
+    expect(() =>
+      buildPublishedDeclaration(
+        'export interface WorkerConfig {\n  transport: import("@lobu/core").WorkerTransport;\n}\n'
+      )
+    ).toThrow(/@lobu/);
+
     expect(transformed.files).toContain("dist/index.bundle.d.ts");
     expect(JSON.stringify(transformed.exports)).not.toContain(
       "dist/index.d.ts"

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -7,8 +7,20 @@
  * version it read off disk without checking the target is published.
  */
 
-import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "bun:test";
 import { __testing, rewriteWorkspaceRefs } from "../publish-packages.mjs";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 function workerManifest() {
   return {
@@ -134,5 +146,169 @@ describe("blocked-dependency skip ordering", () => {
       name: "@lobu/transitive-dependent",
       missingDeps: ["@lobu/direct-dependent"],
     });
+  });
+});
+
+/**
+ * The guard tests above drive helpers directly. This suite runs the real
+ * publish loop as a subprocess against a stub `npm` placed earlier on PATH, so
+ * the E404 → skip-dependents path that actually shipped the bug is executed
+ * rather than reasoned about.
+ */
+describe("publish loop (subprocess, stub npm)", () => {
+  const scratch = join(REPO_ROOT, ".publish-guard-scratch");
+  const binDir = join(scratch, "bin");
+  const logFile = join(scratch, "publish.log");
+
+  /**
+   * Stub npm: `view` reports nothing published, `publish` returns E404 for the
+   * blockNames and succeeds otherwise. Every publish attempt is appended to
+   * logFile so the test can assert exactly who was and wasn't published.
+   */
+  function writeStubNpm(blockNames: string[]) {
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      join(binDir, "npm"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        `const blocked = ${JSON.stringify(blockNames)};`,
+        `const log = ${JSON.stringify(logFile)};`,
+        // `npm view <pkg>@<ver> version` → nothing is published yet.
+        "if (args[0] === 'view') { process.exit(1); }",
+        "if (args[0] === 'publish') {",
+        "  const pkg = JSON.parse(fs.readFileSync('package.json','utf8'));",
+        "  fs.appendFileSync(log, pkg.name + '\\n');",
+        "  if (blocked.includes(pkg.name)) {",
+        "    process.stderr.write('npm ERR! code E404\\n');",
+        "    process.exit(1);",
+        "  }",
+        "  process.exit(0);",
+        "}",
+        "process.exit(0);",
+      ].join("\n"),
+      { mode: 0o755 }
+    );
+  }
+
+  function runPublishScript() {
+    return spawnSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, "scripts/publish-packages.mjs"),
+        "--skip-bump",
+        "--skip-build",
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      }
+    );
+  }
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("skips dependents of a blocked package and exits nonzero", () => {
+    // @lobu/core is blocked; every other published package depends on it.
+    writeStubNpm(["@lobu/core"]);
+    const result = runPublishScript();
+    const attempted = existsSync(logFile)
+      ? readFileSync(logFile, "utf8").trim().split("\n").filter(Boolean)
+      : [];
+
+    // The blocked package was attempted...
+    expect(attempted).toContain("@lobu/core");
+    // ...and its dependents were never handed to npm publish. This is the
+    // exact regression that shipped: dependents published anyway, producing
+    // manifests pointing at a version that does not exist.
+    expect(attempted).not.toContain("@lobu/connector-sdk");
+    expect(attempted).not.toContain("@lobu/cli");
+    // Packages with no runtime @lobu dependency are unaffected and still ship
+    // — the guard must not turn one blocked package into a total outage.
+    expect(attempted).toContain("@lobu/client");
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain("skipped");
+  });
+
+  it("aborts the run when a manifest fails the publishability guard", () => {
+    // Nothing is blocked by npm, but @lobu/worker currently declares private
+    // plugin packages this script does not publish (#2186). The guard must
+    // stop the release rather than let the remaining packages go out around a
+    // known-broken manifest.
+    writeStubNpm([]);
+    const result = runPublishScript();
+    const attempted = existsSync(logFile)
+      ? readFileSync(logFile, "utf8").trim().split("\n").filter(Boolean)
+      : [];
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      "@lobu/plugin-conversations"
+    );
+    // Packages ordered after the failure never reached npm publish.
+    expect(attempted).not.toContain("@lobu/cli");
+  });
+});
+
+/**
+ * `bump-version.mjs` used to accept any string as an explicit version, so a
+ * stray flag rewrote every package.json in the workspace to a nonsense value
+ * (`node scripts/bump-version.mjs --help` → `"version": "--help"`). These run
+ * the real script and assert it refuses BEFORE writing anything.
+ */
+describe("bump-version input validation (subprocess)", () => {
+  // bump-version writes the root manifest AND every workspace package it lists,
+  // so all of them are snapshotted and restored. Restoring only the root left
+  // 9 packages bumped to the test's version — a test must never mutate the repo.
+  const manifests = [
+    join(REPO_ROOT, "package.json"),
+    ...__testing.PACKAGES.map((p: { dir: string }) =>
+      join(REPO_ROOT, p.dir, "package.json")
+    ),
+  ];
+
+  function runBump(arg: string) {
+    const before = new Map(
+      manifests.map((file) => [file, readFileSync(file, "utf8")])
+    );
+    const result = spawnSync(
+      process.execPath,
+      [join(REPO_ROOT, "scripts/bump-version.mjs"), arg],
+      { cwd: REPO_ROOT, encoding: "utf8" }
+    );
+    let wrote = false;
+    for (const [file, original] of before) {
+      if (readFileSync(file, "utf8") !== original) {
+        wrote = true;
+        writeFileSync(file, original);
+      }
+    }
+    return { result, wrote };
+  }
+
+  it.each([
+    "--help",
+    "-v",
+    "latest",
+    "1.2",
+    "v1.2.3",
+    "",
+  ])("rejects %p without writing any manifest", (bad) => {
+    const { result, wrote } = runBump(bad);
+    // Empty string is falsy — the script no-ops rather than erroring, but it
+    // must still never write a bad version.
+    expect(wrote).toBe(false);
+    if (bad !== "") expect(result.status).not.toBe(0);
+  });
+
+  it.each(["9.9.9", "9.9.9-beta.1"])("accepts explicit semver %p", (good) => {
+    const { result, wrote } = runBump(good);
+    expect(result.status).toBe(0);
+    expect(wrote).toBe(true);
   });
 });

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -276,6 +276,7 @@ describe("published @lobu/worker manifest", () => {
     );
     return entry.transform(manifest) as {
       main: string;
+      types: string;
       bin: Record<string, string>;
       files: string[];
       exports: Record<string, unknown>;
@@ -318,6 +319,11 @@ describe("published @lobu/worker manifest", () => {
     expect(JSON.stringify(transformed.exports)).not.toContain(
       "dist/index.d.ts"
     );
+    // BOTH type entries must move. Node10 resolution reads the top-level
+    // `types`, so leaving it on the unshipped dist/index.d.ts handed consumers
+    // an untyped bundle (TS7016) even with exports.types correct. Verified
+    // against the installed tarball under node10, node16 and bundler.
+    expect(transformed.types).toBe("./dist/index.bundle.d.ts");
   });
 
   it("points every entry at the bundle and ships no src/", () => {

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -292,6 +292,22 @@ describe("published @lobu/worker manifest", () => {
     expect(lobuDeps).toEqual([]);
   });
 
+  it("ships a self-contained declaration, not one importing @lobu", () => {
+    // tsc's dist/core/types.d.ts imports @lobu/core, which the published
+    // manifest no longer declares — shipping it verbatim failed every
+    // consumer's tsc with TS2307. The bundler emits a standalone declaration.
+    const decl = readFileSync(
+      join(REPO_ROOT, "packages/agent-worker/dist/index.bundle.d.ts"),
+      "utf8"
+    );
+    expect(decl).toContain("WorkerConfig");
+    expect(decl).not.toContain("@lobu/");
+    expect(transformed.files).toContain("dist/index.bundle.d.ts");
+    expect(JSON.stringify(transformed.exports)).not.toContain(
+      "dist/index.d.ts"
+    );
+  });
+
   it("points every entry at the bundle and ships no src/", () => {
     expect(transformed.main).toBe("./dist/index.bundle.mjs");
     expect(transformed.bin["lobu-worker"]).toBe("./dist/index.bundle.mjs");
@@ -413,7 +429,11 @@ describe("bump-version input validation (subprocess)", () => {
     if (bad !== "") expect(result.status).not.toBe(0);
   });
 
-  it.each(["9.9.9", "9.9.9-beta.1"])("accepts explicit semver %p", (good) => {
+  it.each([
+    "9.9.9",
+    "9.9.9-beta.1",
+    "1.0.0-alpha.1+build.7",
+  ])("accepts explicit semver %p", (good) => {
     const { result, wrote } = runBump(good);
     expect(result.status).toBe(0);
     expect(wrote).toBe(true);

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -1,32 +1,23 @@
 /**
  * @lobu/worker@14.3.0 shipped to the registry declaring runtime dependencies on
- * six packages that do not exist there — four of them pinned to `0.0.0`, the
- * placeholder version `private: true` workspace packages carry. `npx
- * @lobu/cli@latest` 404s for every external consumer as a result (issue #2186),
- * and every CI gate was green when it shipped.
+ * five private workspace packages at their `0.0.0` placeholder versions,
+ * breaking external installs (issue #2186).
  *
  * The cause was `rewriteWorkspaceRefs` resolving `workspace:*` against whatever
- * version it read off disk without checking the target is published. These
- * fixtures drive that function directly with the real manifest shapes.
+ * version it read off disk without checking the target is published.
  */
 
 import { describe, expect, it } from "bun:test";
+import { __testing, rewriteWorkspaceRefs } from "../publish-packages.mjs";
 
-const { rewriteWorkspaceRefs, __testing } = await import(
-  "../publish-packages.mjs"
-);
-
-/** Mirrors packages/agent-worker: published, but depends on private plugins. */
 function workerManifest() {
   return {
     name: "@lobu/worker",
     version: "14.3.0",
     dependencies: {
       "@lobu/core": "workspace:*",
-      // Published siblings — legitimate.
       "@lobu/plugin-api": "workspace:*",
       "@lobu/plugin-host": "workspace:*",
-      // `private: true`, version 0.0.0 — the ones that broke the release.
       "@lobu/plugin-mcp": "workspace:*",
       "@lobu/plugin-memory": "workspace:*",
     },
@@ -53,20 +44,19 @@ describe("rewriteWorkspaceRefs publishability guard", () => {
     expect(message).toContain("PACKAGES");
   });
 
-  it("never emits the 0.0.0 placeholder into a published manifest", () => {
-    // The precise defect on the registry today: a constraint no release can
-    // ever satisfy. Whatever this function returns, it must not contain it.
-    let result: Record<string, unknown> | undefined;
-    try {
-      result = rewriteWorkspaceRefs(workerManifest()) as Record<
-        string,
-        unknown
-      >;
-    } catch {
-      // Throwing is the correct behavior; nothing was emitted.
-    }
-    if (result) {
-      expect(Object.values(result.dependencies ?? {})).not.toContain("0.0.0");
+  it("guards every runtime dependency section, including explicit versions", () => {
+    for (const section of [
+      "dependencies",
+      "optionalDependencies",
+      "peerDependencies",
+    ]) {
+      expect(() =>
+        rewriteWorkspaceRefs({
+          name: "@lobu/worker",
+          version: "14.3.0",
+          [section]: { "@lobu/plugin-mcp": "1.2.3" },
+        })
+      ).toThrow(/@lobu\/plugin-mcp/);
     }
   });
 
@@ -120,5 +110,29 @@ describe("blocked-dependency skip ordering", () => {
         expect(indexOf(depDir)).toBeLessThan(indexOf(dir));
       }
     }
+  });
+
+  it("propagates an unavailable package to transitive dependents", () => {
+    const unavailable = new Set(["@lobu/missing"]);
+    expect(
+      __testing.markUnavailablePackage(
+        "@lobu/direct-dependent",
+        ["@lobu/missing"],
+        unavailable
+      )
+    ).toEqual({
+      name: "@lobu/direct-dependent",
+      missingDeps: ["@lobu/missing"],
+    });
+    expect(
+      __testing.markUnavailablePackage(
+        "@lobu/transitive-dependent",
+        ["@lobu/direct-dependent"],
+        unavailable
+      )
+    ).toEqual({
+      name: "@lobu/transitive-dependent",
+      missingDeps: ["@lobu/direct-dependent"],
+    });
   });
 });

--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -373,15 +373,32 @@ describe("published manifests ship no unrunnable scripts", () => {
     }
   );
 
-  it("keeps only lifecycle scripts npm runs on install", () => {
+  it("drops dev-loop scripts a consumer install cannot run", () => {
+    // tsc/tsx/biome are devDependencies, absent from a consumer install; the
+    // dev-loop names are dropped by name because "runnable" is not the same as
+    // "safe" — `clean: rm -rf dist` would delete the installed package's code.
     for (const { dir, pkg } of transformedManifests) {
-      for (const name of Object.keys(pkg.scripts ?? {})) {
+      for (const [name, command] of Object.entries(pkg.scripts ?? {})) {
         expect(
-          __testing.PUBLISHED_LIFECYCLE_SCRIPTS.has(name),
-          `${dir}: published manifest keeps non-lifecycle script "${name}"`
-        ).toBe(true);
+          ["clean", "dev", "watch", "build", "typecheck", "test"],
+          `${dir}: published manifest keeps dev-loop script "${name}"`
+        ).not.toContain(name);
+        expect(
+          command,
+          `${dir}: script "${name}" invokes a devDependency-only tool`
+        ).not.toMatch(/^(?:tsc|tsx|biome|vitest|jest|esbuild)\b/);
       }
     }
+  });
+
+  it("keeps a start script that genuinely runs from the tarball", () => {
+    // The counter-case to the strip: @lobu/connector-worker ships dist/, so
+    // `node dist/bin.js` resolves for a consumer. Over-stripping it would
+    // remove a working entry point, so this pins it in place.
+    const connectorWorker = transformedManifests.find(
+      (m) => m.dir === "packages/connector-worker"
+    );
+    expect(connectorWorker?.pkg.scripts?.start).toBe("node dist/bin.js");
   });
 
   it("never names a path the tarball excludes", () => {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -32,8 +32,16 @@ async function main() {
       // Explicit version — validate before writing. Anything unrecognized used
       // to be accepted verbatim, so a stray flag (`--help`) or a typo silently
       // rewrote every package.json in the workspace to a nonsense version.
+      //
+      // This is the official SemVer 2.0.0 pattern (semver.org), not a loose
+      // \d+\.\d+\.\d+ approximation: the loose one accepted `01.2.3`,
+      // `1.2.3-01` and `1.2.3-..`, all of which npm rejects at publish time —
+      // so a bad version would still have been written across every manifest
+      // and only failed much later.
       if (
-        !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(bump)
+        !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/.test(
+          bump
+        )
       ) {
         throw new Error(
           `Invalid version "${bump}". Expected patch | minor | major, or an explicit semver like 3.1.0 / 3.1.0-beta.1.`

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -30,8 +30,8 @@ async function main() {
     else if (bump === "major") version = `${major + 1}.0.0`;
     else {
       // Explicit version — validate before writing. Anything unrecognized used
-      // to be accepted verbatim, so a stray flag (`--help`) or typo silently
-      // rewrote every package.json to a nonsense version across the workspace.
+      // to be accepted verbatim, so a stray flag (`--help`) or a typo silently
+      // rewrote every package.json in the workspace to a nonsense version.
       if (
         !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(bump)
       ) {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -28,7 +28,19 @@ async function main() {
     if (bump === "patch") version = `${major}.${minor}.${patch + 1}`;
     else if (bump === "minor") version = `${major}.${minor + 1}.0`;
     else if (bump === "major") version = `${major + 1}.0.0`;
-    else version = bump; // explicit version
+    else {
+      // Explicit version — validate before writing. Anything unrecognized used
+      // to be accepted verbatim, so a stray flag (`--help`) or typo silently
+      // rewrote every package.json to a nonsense version across the workspace.
+      if (
+        !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(bump)
+      ) {
+        throw new Error(
+          `Invalid version "${bump}". Expected patch | minor | major, or an explicit semver like 3.1.0 / 3.1.0-beta.1.`
+        );
+      }
+      version = bump;
+    }
   }
 
   // Update root

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -85,16 +85,10 @@ function publishedPackageNames() {
  * rewrite them at publish time, so we do it explicitly here before `npm
  * publish` runs and restore the original package.json afterwards.
  *
- * Runtime dependencies and peer contracts are additionally gated on the
- * target actually being published. Without that gate this function faithfully
- * rewrote `"@lobu/plugin-mcp": "workspace:*"` to the placeholder version that
- * `private: true` packages carry (`0.0.0`) and shipped it in a public manifest
- * — a constraint no future release can satisfy. That is exactly how
- * @lobu/worker@14.3.0 went out with five private dependencies pinned to
- * `0.0.0`, breaking external installs (issue #2186).
- *
- * devDependencies are excluded because consumers do not install them, and a
- * private workspace package is a legitimate dev-only tool.
+ * Consumer-installed sections are additionally gated on the target actually
+ * being published: without that gate this rewrote a private package's `0.0.0`
+ * placeholder into a public manifest, a constraint no release can satisfy
+ * (#2186). devDependencies are exempt — consumers never install them.
  */
 function rewriteWorkspaceRefs(pkg) {
   const rewriteSection = (deps, section) => {
@@ -190,23 +184,12 @@ function transformCorePublish(pkg) {
 /**
  * @lobu/worker publishes the esbuild bundle, not the tsc output.
  *
- * In-repo, this package resolves through the `bun` export condition to
- * `src/index.ts`, and both src/ and the tsc dist/ import five `private: true`
- * plugin packages. Publishing that verbatim is what put six unresolvable
- * dependencies on the registry (#2186): the shipped src/ imports them, the CJS
- * dist/ requires them, and neither can ever resolve for an external consumer.
- *
- * `packages/agent-worker/scripts/build-worker-bundle.mjs` inlines exactly the
- * private plugins into `dist/index.bundle.mjs` (published @lobu packages stay
- * external), so the published entry points are repointed at the bundle here,
- * the private deps are dropped from the manifest, and src/ is no longer
- * shipped. The in-repo manifest keeps `bun`/src so local dev is unaffected —
- * the publish script restores it immediately after publishing.
- *
- * The bundle is ESM on purpose: agent-worker compiles to CommonJS, and
- * @mariozechner/pi-coding-agent is import-only, so a node require() of the CJS
- * dist throws ERR_PACKAGE_PATH_NOT_EXPORTED. That is why src/ was shipped in
- * the first place; the bundle is what finally makes the package Node-loadable.
+ * Both the shipped src/ and the tsc dist/ import `private: true` plugin
+ * packages, which is what put unresolvable dependencies on the registry
+ * (#2186). build-worker-bundle.mjs inlines the whole @lobu workspace graph
+ * into dist/index.bundle.mjs, so this repoints the published entry points at
+ * it and drops what the bundle no longer needs. The in-repo manifest keeps
+ * `bun`/src for local dev; the publish script restores it afterwards.
  */
 function transformWorkerPublish(pkg) {
   const BUNDLE = "./dist/index.bundle.mjs";
@@ -221,18 +204,10 @@ function transformWorkerPublish(pkg) {
     },
     "./package.json": "./package.json",
   };
-  // Ship ONLY the bundle and its type declarations. src/ is no longer an entry
-  // point, and the sibling tsc output in dist/ still carries the unresolvable
-  // `require("@lobu/plugin-mcp")` calls — nothing loads those files once the
-  // entry points move to the bundle, but shipping them would still break any
-  // consumer reaching a deep path, and leaves the defect visibly in the
-  // tarball. Verified by packing the tarball and grepping it.
-  // The published type surface is exactly `index.d.ts` (which re-exports only
-  // WorkerConfig) plus the `core/types.d.ts` it points at; both are free of
-  // private-plugin references. Shipping dist/**/*.d.ts instead would drag in
-  // sibling declarations like runtime/plugin-composition.d.ts that
-  // `import type ... from "@lobu/plugin-toolkit"` and would fail a consumer's
-  // typecheck. Verified by packing the tarball and grepping it.
+  // Exactly the bundle plus the real type surface (index.d.ts re-exports only
+  // WorkerConfig, from core/types.d.ts). Shipping src/ or dist/**/*.d.ts drags
+  // back in files that reference the private plugins — the sibling .d.ts
+  // `import type` from @lobu/plugin-toolkit and break a consumer's typecheck.
   pkg.files = [
     "dist/index.bundle.mjs",
     "dist/index.d.ts",
@@ -240,14 +215,10 @@ function transformWorkerPublish(pkg) {
     "!**/*.map",
   ];
 
-  // EVERY @lobu dependency is dropped, not just the private ones: the bundle
-  // inlines the whole workspace graph (core and plugin-host included, because
-  // they are CommonJS and this bundle is ESM — see build-worker-bundle.mjs).
-  // Nothing in the published artifact imports them, so declaring them would
-  // make consumers install packages they never load, and would keep the
-  // release blocked on @lobu/plugin-api and @lobu/plugin-host being
-  // bootstrap-published. Their npm dependencies are hoisted into
-  // agent-worker's own manifest, which the bundler enforces.
+  // EVERY @lobu dependency is dropped, not just the private ones — the bundle
+  // inlines them all, so declaring them would make consumers install packages
+  // nothing imports. It also means the release does not wait on plugin-api /
+  // plugin-host ever being published.
   for (const section of ["dependencies", "optionalDependencies"]) {
     const deps = pkg[section];
     if (!deps) continue;

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -237,8 +237,7 @@ function transformWorkerPublish(pkg) {
     "dist/index.bundle.mjs",
     "dist/index.d.ts",
     "dist/core/types.d.ts",
-    "!**/*.js.map",
-    "!**/*.d.ts.map",
+    "!**/*.map",
   ];
 
   // EVERY @lobu dependency is dropped, not just the private ones: the bundle

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -123,6 +123,40 @@ function rewriteWorkspaceRefs(pkg) {
   rewriteSection(pkg.optionalDependencies, "optionalDependencies");
   rewriteSection(pkg.devDependencies, "devDependencies");
   rewriteSection(pkg.peerDependencies, "peerDependencies");
+  stripUnpublishableScripts(pkg);
+  return pkg;
+}
+
+/**
+ * Drop scripts that cannot run from the published tarball.
+ *
+ * Every manifest here carries dev-loop scripts (`build`, `dev`, `typecheck`,
+ * `test`, `clean`) that need `src/`, `tsc`, or `scripts/` — none of which are
+ * in `files`. Shipping them is not merely dead weight: `@lobu/worker`'s
+ * `start` pointed at `dist/index.js`, which transformWorkerPublish excludes,
+ * so `npm start` on an installed copy failed with MODULE_NOT_FOUND. Keeping a
+ * script that names a file the tarball omits is the same defect class as
+ * #2186 — a published manifest referencing something a consumer cannot get.
+ *
+ * `lifecycle` scripts are kept: npm runs those itself on install, and dropping
+ * one would silently change install behaviour. No script left here may
+ * reference a path outside `files`; the guard below enforces that.
+ */
+const PUBLISHED_LIFECYCLE_SCRIPTS = new Set([
+  "preinstall",
+  "install",
+  "postinstall",
+  "prepare",
+]);
+
+function stripUnpublishableScripts(pkg) {
+  if (!pkg.scripts) return pkg;
+  const kept = {};
+  for (const [name, command] of Object.entries(pkg.scripts)) {
+    if (PUBLISHED_LIFECYCLE_SCRIPTS.has(name)) kept[name] = command;
+  }
+  if (Object.keys(kept).length > 0) pkg.scripts = kept;
+  else delete pkg.scripts;
   return pkg;
 }
 
@@ -543,6 +577,7 @@ export { rewriteWorkspaceRefs };
 /** Internals exposed for the guard tests; not part of any published surface. */
 export const __testing = {
   PACKAGES,
+  PUBLISHED_LIFECYCLE_SCRIPTS,
   lobuRuntimeDeps,
   markUnavailablePackage,
   packageNameFor,

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -31,7 +31,9 @@ const PACKAGES = [
   { dir: "packages/plugin-host", transform: transformCorePublish },
   { dir: "packages/connector-sdk", transform: rewriteWorkspaceRefs },
   { dir: "packages/client", transform: rewriteWorkspaceRefs },
-  { dir: "packages/agent-worker", transform: rewriteWorkspaceRefs },
+  // Publishes the esbuild bundle rather than the tsc output — see
+  // transformWorkerPublish for why (#2186).
+  { dir: "packages/agent-worker", transform: transformWorkerPublish },
   { dir: "packages/embeddings", transform: rewriteWorkspaceRefs },
   // @lobu/pgvector-embedded is NOT published: it's `private` and ships its
   // prebuilt native binaries inside the @lobu/cli tarball (build.cjs copies it
@@ -182,6 +184,79 @@ function transformCorePublish(pkg) {
       }
     }
   }
+  return rewriteWorkspaceRefs(pkg);
+}
+
+/**
+ * @lobu/worker publishes the esbuild bundle, not the tsc output.
+ *
+ * In-repo, this package resolves through the `bun` export condition to
+ * `src/index.ts`, and both src/ and the tsc dist/ import five `private: true`
+ * plugin packages. Publishing that verbatim is what put six unresolvable
+ * dependencies on the registry (#2186): the shipped src/ imports them, the CJS
+ * dist/ requires them, and neither can ever resolve for an external consumer.
+ *
+ * `packages/agent-worker/scripts/build-worker-bundle.mjs` inlines exactly the
+ * private plugins into `dist/index.bundle.mjs` (published @lobu packages stay
+ * external), so the published entry points are repointed at the bundle here,
+ * the private deps are dropped from the manifest, and src/ is no longer
+ * shipped. The in-repo manifest keeps `bun`/src so local dev is unaffected —
+ * the publish script restores it immediately after publishing.
+ *
+ * The bundle is ESM on purpose: agent-worker compiles to CommonJS, and
+ * @mariozechner/pi-coding-agent is import-only, so a node require() of the CJS
+ * dist throws ERR_PACKAGE_PATH_NOT_EXPORTED. That is why src/ was shipped in
+ * the first place; the bundle is what finally makes the package Node-loadable.
+ */
+function transformWorkerPublish(pkg) {
+  const BUNDLE = "./dist/index.bundle.mjs";
+
+  pkg.main = BUNDLE;
+  pkg.bin = { "lobu-worker": BUNDLE };
+  pkg.exports = {
+    ".": {
+      types: "./dist/index.d.ts",
+      import: BUNDLE,
+      default: BUNDLE,
+    },
+    "./package.json": "./package.json",
+  };
+  // Ship ONLY the bundle and its type declarations. src/ is no longer an entry
+  // point, and the sibling tsc output in dist/ still carries the unresolvable
+  // `require("@lobu/plugin-mcp")` calls — nothing loads those files once the
+  // entry points move to the bundle, but shipping them would still break any
+  // consumer reaching a deep path, and leaves the defect visibly in the
+  // tarball. Verified by packing the tarball and grepping it.
+  // The published type surface is exactly `index.d.ts` (which re-exports only
+  // WorkerConfig) plus the `core/types.d.ts` it points at; both are free of
+  // private-plugin references. Shipping dist/**/*.d.ts instead would drag in
+  // sibling declarations like runtime/plugin-composition.d.ts that
+  // `import type ... from "@lobu/plugin-toolkit"` and would fail a consumer's
+  // typecheck. Verified by packing the tarball and grepping it.
+  pkg.files = [
+    "dist/index.bundle.mjs",
+    "dist/index.d.ts",
+    "dist/core/types.d.ts",
+    "!**/*.js.map",
+    "!**/*.d.ts.map",
+  ];
+
+  // EVERY @lobu dependency is dropped, not just the private ones: the bundle
+  // inlines the whole workspace graph (core and plugin-host included, because
+  // they are CommonJS and this bundle is ESM — see build-worker-bundle.mjs).
+  // Nothing in the published artifact imports them, so declaring them would
+  // make consumers install packages they never load, and would keep the
+  // release blocked on @lobu/plugin-api and @lobu/plugin-host being
+  // bootstrap-published. Their npm dependencies are hoisted into
+  // agent-worker's own manifest, which the bundler enforces.
+  for (const section of ["dependencies", "optionalDependencies"]) {
+    const deps = pkg[section];
+    if (!deps) continue;
+    for (const name of Object.keys(deps)) {
+      if (name.startsWith("@lobu/")) delete deps[name];
+    }
+  }
+
   return rewriteWorkspaceRefs(pkg);
 }
 

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -15,13 +15,13 @@ import { readdirSync, readFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 // Anchored to this file, not process.cwd(), so the manifest reads below resolve
 // the same way whether the script is run from the repo root or imported by a
 // test running from another directory.
 const REPO_ROOT = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   ".."
 );
 
@@ -62,14 +62,15 @@ function publishedPackageNames() {
   if (!cachedPublishedNames) {
     cachedPublishedNames = new Set();
     for (const { dir } of PACKAGES) {
-      try {
-        const pkg = JSON.parse(
-          readFileSync(path.join(REPO_ROOT, dir, "package.json"), "utf8")
+      const pkg = JSON.parse(
+        readFileSync(path.join(REPO_ROOT, dir, "package.json"), "utf8")
+      );
+      if (!pkg.name || pkg.private) {
+        throw new Error(
+          `${dir} must have a public package name before it can be added to PACKAGES`
         );
-        if (pkg.name) cachedPublishedNames.add(pkg.name);
-      } catch {
-        // Missing/unreadable manifest surfaces later in publishPackage.
       }
+      cachedPublishedNames.add(pkg.name);
     }
   }
   return cachedPublishedNames;
@@ -82,22 +83,34 @@ function publishedPackageNames() {
  * rewrite them at publish time, so we do it explicitly here before `npm
  * publish` runs and restore the original package.json afterwards.
  *
- * Runtime `dependencies` are additionally gated on the target actually being
- * published. Without that gate this function faithfully rewrote
- * `"@lobu/plugin-mcp": "workspace:*"` to the placeholder version that
- * `private: true` packages carry (`0.0.0`) and shipped it in a public
- * manifest — a constraint no future release can satisfy. That is exactly how
- * @lobu/worker@14.3.0 went out depending on six packages that do not exist on
- * the registry, breaking `npx @lobu/cli@latest` for every external consumer
- * while every CI gate stayed green (issue #2186).
+ * Runtime dependencies and peer contracts are additionally gated on the
+ * target actually being published. Without that gate this function faithfully
+ * rewrote `"@lobu/plugin-mcp": "workspace:*"` to the placeholder version that
+ * `private: true` packages carry (`0.0.0`) and shipped it in a public manifest
+ * — a constraint no future release can satisfy. That is exactly how
+ * @lobu/worker@14.3.0 went out with five private dependencies pinned to
+ * `0.0.0`, breaking external installs (issue #2186).
  *
- * Scoped to `dependencies` on purpose: devDependencies are not installed by
- * consumers, and a private workspace package is a legitimate dev-only tool.
+ * devDependencies are excluded because consumers do not install them, and a
+ * private workspace package is a legitimate dev-only tool.
  */
 function rewriteWorkspaceRefs(pkg) {
   const rewriteSection = (deps, section) => {
     if (!deps) return;
     for (const [name, spec] of Object.entries(deps)) {
+      if (
+        section !== "devDependencies" &&
+        name.startsWith("@lobu/") &&
+        !publishedPackageNames().has(name)
+      ) {
+        throw new Error(
+          `${pkg.name} declares ${name} in "${section}", but this script does not publish it.\n` +
+            `  An external consumer cannot install ${name}, so the published ${pkg.name} would be broken.\n` +
+            "  Fix by either:\n" +
+            `    - adding ${name} to PACKAGES (and making it non-private), or\n` +
+            `    - bundling ${name} into ${pkg.name}'s build output and removing it from "${section}".`
+        );
+      }
       if (typeof spec !== "string" || !spec.startsWith("workspace:")) continue;
       if (
         !name.startsWith("@lobu/") &&
@@ -107,19 +120,11 @@ function rewriteWorkspaceRefs(pkg) {
           `Unexpected workspace ref outside @lobu scope: ${name}@${spec}`
         );
       }
-      if (section === "dependencies" && !publishedPackageNames().has(name)) {
-        throw new Error(
-          `${pkg.name} declares a runtime dependency on ${name}, which this script does not publish.\n` +
-            `  An external consumer cannot install ${name}, so the published ${pkg.name} would be broken.\n` +
-            "  Fix by either:\n" +
-            `    - adding ${name} to PACKAGES (and making it non-private), or\n` +
-            `    - bundling ${name} into ${pkg.name}'s build output and removing it from "dependencies".`
-        );
-      }
       deps[name] = workspacePackageVersion(name);
     }
   };
   rewriteSection(pkg.dependencies, "dependencies");
+  rewriteSection(pkg.optionalDependencies, "optionalDependencies");
   rewriteSection(pkg.devDependencies, "devDependencies");
   rewriteSection(pkg.peerDependencies, "peerDependencies");
   return pkg;
@@ -192,18 +197,33 @@ function packageNameFor(dir) {
   }
 }
 
-/** @lobu runtime (non-dev) dependency names declared by a workspace package. */
+/** @lobu runtime and peer dependency names declared by a workspace package. */
 function lobuRuntimeDeps(dir) {
   try {
     const pkg = JSON.parse(
       readFileSync(path.join(REPO_ROOT, dir, "package.json"), "utf8")
     );
-    return Object.keys(pkg.dependencies ?? {}).filter((name) =>
-      name.startsWith("@lobu/")
-    );
+    return [
+      ...new Set(
+        [
+          ...Object.keys(pkg.dependencies ?? {}),
+          ...Object.keys(pkg.optionalDependencies ?? {}),
+          ...Object.keys(pkg.peerDependencies ?? {}),
+        ].filter((name) => name.startsWith("@lobu/"))
+      ),
+    ];
   } catch {
     return [];
   }
+}
+
+function markUnavailablePackage(name, dependencies, unavailableNames) {
+  const missingDeps = dependencies.filter((dependency) =>
+    unavailableNames.has(dependency)
+  );
+  if (missingDeps.length === 0) return;
+  unavailableNames.add(name);
+  return { name, missingDeps };
 }
 
 function run(cmd, args, opts = {}) {
@@ -357,17 +377,18 @@ async function main() {
   // version that does not exist. PACKAGES is in dependency order, so a blocked
   // dependency is always seen before its dependents.
   const blocked = [];
-  const blockedNames = new Set();
+  const unavailableNames = new Set();
   const skipped = [];
   for (const pkg of PACKAGES) {
-    const missingDeps = lobuRuntimeDeps(pkg.dir).filter((name) =>
-      blockedNames.has(name)
+    const skippedPackage = markUnavailablePackage(
+      packageNameFor(pkg.dir),
+      lobuRuntimeDeps(pkg.dir),
+      unavailableNames
     );
-    if (missingDeps.length > 0) {
-      const name = packageNameFor(pkg.dir);
-      skipped.push({ name, missingDeps });
+    if (skippedPackage) {
+      skipped.push(skippedPackage);
       console.error(
-        `  ✗ ${name}: skipped — depends on unpublished ${missingDeps.join(", ")}`
+        `  ✗ ${skippedPackage.name}: skipped — depends on unpublished ${skippedPackage.missingDeps.join(", ")}`
       );
       continue;
     }
@@ -376,7 +397,7 @@ async function main() {
     } catch (error) {
       if (error instanceof FirstPublishBlockedError) {
         blocked.push(error);
-        blockedNames.add(error.pkgName);
+        unavailableNames.add(error.pkgName);
         console.error(
           `  ✗ ${error.pkgName}: never-published; needs a one-time bootstrap (see below)`
         );
@@ -395,10 +416,10 @@ async function main() {
           (s) => `  - ${s.name} (needs ${s.missingDeps.join(", ")})`
         ),
         "",
-        "These were NOT published on purpose. Publishing a package whose @lobu",
-        "dependency is missing from the registry produces an install that fails",
-        "for every external consumer (issue #2186). Bootstrap the blocked",
-        "packages below, then re-run; this release is incomplete until then.",
+        "These were NOT published on purpose. An unavailable @lobu runtime or",
+        "peer dependency leaves external installs broken or incomplete (issue",
+        "#2186). Bootstrap the blocked packages below, then re-run; this release",
+        "is incomplete until then.",
       ].join("\n")
     );
   }
@@ -460,6 +481,6 @@ export { rewriteWorkspaceRefs };
 export const __testing = {
   PACKAGES,
   lobuRuntimeDeps,
+  markUnavailablePackage,
   packageNameFor,
-  publishedPackageNames,
 };

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -271,24 +271,43 @@ function packageNameFor(dir) {
   }
 }
 
-/** @lobu runtime and peer dependency names declared by a workspace package. */
-function lobuRuntimeDeps(dir) {
+/**
+ * @lobu runtime and peer dependency names a workspace package will PUBLISH.
+ *
+ * The publish transform is applied first, because the transformed manifest is
+ * what npm receives and therefore what a consumer has to be able to install.
+ * Reading the raw on-disk manifest instead would skip @lobu/worker whenever
+ * @lobu/core, plugin-api or plugin-host is unavailable — the worker still
+ * declares them on disk, but `transformWorkerPublish` deletes every @lobu
+ * dependency because the bundle inlines the whole graph. That is precisely the
+ * bootstrap wait this change removes.
+ *
+ * Callers may omit `transform` to ask what the package declares on disk.
+ */
+function lobuRuntimeDeps(dir, transform) {
+  let pkg;
   try {
-    const pkg = JSON.parse(
+    pkg = JSON.parse(
       readFileSync(path.join(REPO_ROOT, dir, "package.json"), "utf8")
     );
-    return [
-      ...new Set(
-        [
-          ...Object.keys(pkg.dependencies ?? {}),
-          ...Object.keys(pkg.optionalDependencies ?? {}),
-          ...Object.keys(pkg.peerDependencies ?? {}),
-        ].filter((name) => name.startsWith("@lobu/"))
-      ),
-    ];
   } catch {
     return [];
   }
+  // Deliberately outside the catch: the transform runs `rewriteWorkspaceRefs`,
+  // which throws when a package declares an @lobu dependency this script does
+  // not publish. That is a release-stopping contract break, and swallowing it
+  // into an empty list would report the package as depending on nothing —
+  // publishing the exact broken manifest the guard exists to stop.
+  if (transform) pkg = transform(pkg);
+  return [
+    ...new Set(
+      [
+        ...Object.keys(pkg.dependencies ?? {}),
+        ...Object.keys(pkg.optionalDependencies ?? {}),
+        ...Object.keys(pkg.peerDependencies ?? {}),
+      ].filter((name) => name.startsWith("@lobu/"))
+    ),
+  ];
 }
 
 function markUnavailablePackage(name, dependencies, unavailableNames) {
@@ -456,7 +475,7 @@ async function main() {
   for (const pkg of PACKAGES) {
     const skippedPackage = markUnavailablePackage(
       packageNameFor(pkg.dir),
-      lobuRuntimeDeps(pkg.dir),
+      lobuRuntimeDeps(pkg.dir, pkg.transform),
       unavailableNames
     );
     if (skippedPackage) {

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -131,16 +131,18 @@ function rewriteWorkspaceRefs(pkg) {
  * Drop scripts that cannot run from the published tarball.
  *
  * Every manifest here carries dev-loop scripts (`build`, `dev`, `typecheck`,
- * `test`, `clean`) that need `src/`, `tsc`, or `scripts/` — none of which are
- * in `files`. Shipping them is not merely dead weight: `@lobu/worker`'s
- * `start` pointed at `dist/index.js`, which transformWorkerPublish excludes,
- * so `npm start` on an installed copy failed with MODULE_NOT_FOUND. Keeping a
- * script that names a file the tarball omits is the same defect class as
- * #2186 — a published manifest referencing something a consumer cannot get.
+ * `test`, `clean`) needing `src/`, `tsc` or `scripts/` — none of which ship.
+ * Shipping them is not merely dead weight: `@lobu/worker`'s `start` pointed at
+ * `dist/index.js`, which transformWorkerPublish excludes from `files`, so
+ * `npm start` on an installed copy died with MODULE_NOT_FOUND. That is the
+ * same defect class as #2186 — a published manifest naming something the
+ * consumer cannot get.
  *
- * `lifecycle` scripts are kept: npm runs those itself on install, and dropping
- * one would silently change install behaviour. No script left here may
- * reference a path outside `files`; the guard below enforces that.
+ * Runnability is decided by `files`, not by a name allowlist: a script whose
+ * referenced paths all ship is kept (@lobu/connector-worker's
+ * `start: node dist/bin.js` is real and still works), and one that reaches
+ * outside `files` is dropped. Lifecycle scripts are kept unconditionally —
+ * npm runs those itself on install, so dropping one changes install behaviour.
  */
 const PUBLISHED_LIFECYCLE_SCRIPTS = new Set([
   "preinstall",
@@ -149,11 +151,46 @@ const PUBLISHED_LIFECYCLE_SCRIPTS = new Set([
   "prepare",
 ]);
 
+/** Paths a script command references, e.g. `node dist/bin.js` → ["dist/bin.js"]. */
+const SCRIPT_PATH_REF = /(?:\.\/)?(?:src|dist|scripts|bin)\/[\w./-]+/g;
+
+/** A tool that must be a devDependency, so it cannot exist in a consumer install. */
+const DEV_TOOL =
+  /^(?:tsc|tsx|bun|biome|vitest|jest|esbuild|rimraf|openapi-ts)\b/;
+
+/**
+ * `clean: rm -rf dist` passes the path check — dist IS shipped — but running it
+ * in an installed package deletes the package's own code. Runnable is not the
+ * same as safe to expose, so drop the dev-loop names outright.
+ */
+const DEV_ONLY_SCRIPT_NAMES = new Set(["clean", "dev", "watch"]);
+
+function scriptRunsFromTarball(command, files, name) {
+  // No `files` means npm ships the whole directory — everything resolves.
+  const included = files?.filter((f) => !f.startsWith("!"));
+  if (DEV_ONLY_SCRIPT_NAMES.has(name)) return false;
+  if (DEV_TOOL.test(command.trim())) return false;
+  if (!included || included.length === 0) return true;
+  for (const ref of command.match(SCRIPT_PATH_REF) ?? []) {
+    const normalized = ref.replace(/^\.\//, "");
+    const shipped = included.some(
+      (f) => normalized === f || normalized.startsWith(`${f}/`)
+    );
+    if (!shipped) return false;
+  }
+  return true;
+}
+
 function stripUnpublishableScripts(pkg) {
   if (!pkg.scripts) return pkg;
   const kept = {};
   for (const [name, command] of Object.entries(pkg.scripts)) {
-    if (PUBLISHED_LIFECYCLE_SCRIPTS.has(name)) kept[name] = command;
+    if (
+      PUBLISHED_LIFECYCLE_SCRIPTS.has(name) ||
+      scriptRunsFromTarball(command, pkg.files, name)
+    ) {
+      kept[name] = command;
+    }
   }
   if (Object.keys(kept).length > 0) pkg.scripts = kept;
   else delete pkg.scripts;
@@ -577,7 +614,6 @@ export { rewriteWorkspaceRefs };
 /** Internals exposed for the guard tests; not part of any published surface. */
 export const __testing = {
   PACKAGES,
-  PUBLISHED_LIFECYCLE_SCRIPTS,
   lobuRuntimeDeps,
   markUnavailablePackage,
   packageNameFor,

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -15,8 +15,15 @@ import { readdirSync, readFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
-const REPO_ROOT = process.cwd();
+// Anchored to this file, not process.cwd(), so the manifest reads below resolve
+// the same way whether the script is run from the repo root or imported by a
+// test running from another directory.
+const REPO_ROOT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  ".."
+);
 
 const PACKAGES = [
   { dir: "packages/core", transform: transformCorePublish },
@@ -32,8 +39,11 @@ const PACKAGES = [
   // runtime without a registry fetch. esbuild can't inline the native
   // binaries, hence it stays a runtime sidecar rather than part of
   // server.bundle.mjs.
-  { dir: "packages/cli", transform: rewriteWorkspaceRefs },
+  // connector-worker precedes cli: @lobu/cli depends on it at runtime, and the
+  // blocked-dependency skip below relies on a dependency always being attempted
+  // before its dependents. A guard test asserts this ordering holds.
   { dir: "packages/connector-worker", transform: rewriteWorkspaceRefs },
+  { dir: "packages/cli", transform: rewriteWorkspaceRefs },
   { dir: "packages/promptfoo-provider", transform: rewriteWorkspaceRefs },
 ];
 
@@ -43,14 +53,49 @@ const PACKAGES = [
 const UNSCOPED_ALLOWED_PUBLISHED_NAMES = new Set();
 
 /**
+ * Names this script actually publishes, derived from PACKAGES so the two can
+ * never drift. A `runtime` dependency on anything outside this set cannot be
+ * satisfied by an external consumer.
+ */
+let cachedPublishedNames;
+function publishedPackageNames() {
+  if (!cachedPublishedNames) {
+    cachedPublishedNames = new Set();
+    for (const { dir } of PACKAGES) {
+      try {
+        const pkg = JSON.parse(
+          readFileSync(path.join(REPO_ROOT, dir, "package.json"), "utf8")
+        );
+        if (pkg.name) cachedPublishedNames.add(pkg.name);
+      } catch {
+        // Missing/unreadable manifest surfaces later in publishPackage.
+      }
+    }
+  }
+  return cachedPublishedNames;
+}
+
+/**
  * `workspace:*` / `workspace:^` / `workspace:~` references are a Bun/Yarn
  * dev-time feature — they point at the sibling package's current version so
  * we never have to hand-edit versions across packages. npm does not natively
  * rewrite them at publish time, so we do it explicitly here before `npm
  * publish` runs and restore the original package.json afterwards.
+ *
+ * Runtime `dependencies` are additionally gated on the target actually being
+ * published. Without that gate this function faithfully rewrote
+ * `"@lobu/plugin-mcp": "workspace:*"` to the placeholder version that
+ * `private: true` packages carry (`0.0.0`) and shipped it in a public
+ * manifest — a constraint no future release can satisfy. That is exactly how
+ * @lobu/worker@14.3.0 went out depending on six packages that do not exist on
+ * the registry, breaking `npx @lobu/cli@latest` for every external consumer
+ * while every CI gate stayed green (issue #2186).
+ *
+ * Scoped to `dependencies` on purpose: devDependencies are not installed by
+ * consumers, and a private workspace package is a legitimate dev-only tool.
  */
 function rewriteWorkspaceRefs(pkg) {
-  const rewriteSection = (deps) => {
+  const rewriteSection = (deps, section) => {
     if (!deps) return;
     for (const [name, spec] of Object.entries(deps)) {
       if (typeof spec !== "string" || !spec.startsWith("workspace:")) continue;
@@ -62,12 +107,21 @@ function rewriteWorkspaceRefs(pkg) {
           `Unexpected workspace ref outside @lobu scope: ${name}@${spec}`
         );
       }
+      if (section === "dependencies" && !publishedPackageNames().has(name)) {
+        throw new Error(
+          `${pkg.name} declares a runtime dependency on ${name}, which this script does not publish.\n` +
+            `  An external consumer cannot install ${name}, so the published ${pkg.name} would be broken.\n` +
+            "  Fix by either:\n" +
+            `    - adding ${name} to PACKAGES (and making it non-private), or\n` +
+            `    - bundling ${name} into ${pkg.name}'s build output and removing it from "dependencies".`
+        );
+      }
       deps[name] = workspacePackageVersion(name);
     }
   };
-  rewriteSection(pkg.dependencies);
-  rewriteSection(pkg.devDependencies);
-  rewriteSection(pkg.peerDependencies);
+  rewriteSection(pkg.dependencies, "dependencies");
+  rewriteSection(pkg.devDependencies, "devDependencies");
+  rewriteSection(pkg.peerDependencies, "peerDependencies");
   return pkg;
 }
 
@@ -124,6 +178,32 @@ function transformCorePublish(pkg) {
     }
   }
   return rewriteWorkspaceRefs(pkg);
+}
+
+function packageNameFor(dir) {
+  try {
+    return (
+      JSON.parse(
+        readFileSync(path.join(REPO_ROOT, dir, "package.json"), "utf8")
+      ).name ?? dir
+    );
+  } catch {
+    return dir;
+  }
+}
+
+/** @lobu runtime (non-dev) dependency names declared by a workspace package. */
+function lobuRuntimeDeps(dir) {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(path.join(REPO_ROOT, dir, "package.json"), "utf8")
+    );
+    return Object.keys(pkg.dependencies ?? {}).filter((name) =>
+      name.startsWith("@lobu/")
+    );
+  } catch {
+    return [];
+  }
 }
 
 function run(cmd, args, opts = {}) {
@@ -271,13 +351,32 @@ async function main() {
   }
   // Collect packages npm refuses to create on their first publish so the whole
   // fleet still gets attempted; a single new package must not hide the others.
+  //
+  // A package whose own @lobu dependency was blocked is SKIPPED rather than
+  // published: shipping it would put a manifest on the registry pointing at a
+  // version that does not exist. PACKAGES is in dependency order, so a blocked
+  // dependency is always seen before its dependents.
   const blocked = [];
+  const blockedNames = new Set();
+  const skipped = [];
   for (const pkg of PACKAGES) {
+    const missingDeps = lobuRuntimeDeps(pkg.dir).filter((name) =>
+      blockedNames.has(name)
+    );
+    if (missingDeps.length > 0) {
+      const name = packageNameFor(pkg.dir);
+      skipped.push({ name, missingDeps });
+      console.error(
+        `  ✗ ${name}: skipped — depends on unpublished ${missingDeps.join(", ")}`
+      );
+      continue;
+    }
     try {
       await publishPackage(pkg, otp);
     } catch (error) {
       if (error instanceof FirstPublishBlockedError) {
         blocked.push(error);
+        blockedNames.add(error.pkgName);
         console.error(
           `  ✗ ${error.pkgName}: never-published; needs a one-time bootstrap (see below)`
         );
@@ -285,6 +384,23 @@ async function main() {
       }
       throw error;
     }
+  }
+
+  if (skipped.length > 0) {
+    console.error(
+      [
+        "",
+        `Skipped ${skipped.length} package(s) whose dependencies were not published:`,
+        ...skipped.map(
+          (s) => `  - ${s.name} (needs ${s.missingDeps.join(", ")})`
+        ),
+        "",
+        "These were NOT published on purpose. Publishing a package whose @lobu",
+        "dependency is missing from the registry produces an install that fails",
+        "for every external consumer (issue #2186). Bootstrap the blocked",
+        "packages below, then re-run; this release is incomplete until then.",
+      ].join("\n")
+    );
   }
 
   if (blocked.length > 0) {
@@ -316,6 +432,9 @@ async function main() {
         "fail `npm install` for external consumers.",
       ].join("\n")
     );
+  }
+
+  if (blocked.length > 0 || skipped.length > 0) {
     process.exitCode = 1;
     return;
   }
@@ -323,7 +442,24 @@ async function main() {
   console.log("\nDone.");
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+// Only run when invoked as a script. Without this guard, importing the module
+// (as the guard tests do) would start a real publish.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}
+
+export { rewriteWorkspaceRefs };
+
+/** Internals exposed for the guard tests; not part of any published surface. */
+export const __testing = {
+  PACKAGES,
+  lobuRuntimeDeps,
+  packageNameFor,
+  publishedPackageNames,
+};

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -198,22 +198,16 @@ function transformWorkerPublish(pkg) {
   pkg.bin = { "lobu-worker": BUNDLE };
   pkg.exports = {
     ".": {
-      types: "./dist/index.d.ts",
+      types: "./dist/index.bundle.d.ts",
       import: BUNDLE,
       default: BUNDLE,
     },
     "./package.json": "./package.json",
   };
-  // Exactly the bundle plus the real type surface (index.d.ts re-exports only
-  // WorkerConfig, from core/types.d.ts). Shipping src/ or dist/**/*.d.ts drags
-  // back in files that reference the private plugins — the sibling .d.ts
-  // `import type` from @lobu/plugin-toolkit and break a consumer's typecheck.
-  pkg.files = [
-    "dist/index.bundle.mjs",
-    "dist/index.d.ts",
-    "dist/core/types.d.ts",
-    "!**/*.map",
-  ];
+  // Exactly the bundle plus the self-contained declaration the bundler emits.
+  // Shipping src/ or tsc's dist/**/*.d.ts drags back in files that reference
+  // @lobu packages this manifest no longer declares, failing consumer tsc.
+  pkg.files = ["dist/index.bundle.mjs", "dist/index.bundle.d.ts", "!**/*.map"];
 
   // EVERY @lobu dependency is dropped, not just the private ones — the bundle
   // inlines them all, so declaring them would make consumers install packages

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -193,12 +193,17 @@ function transformCorePublish(pkg) {
  */
 function transformWorkerPublish(pkg) {
   const BUNDLE = "./dist/index.bundle.mjs";
+  const DECLARATION = "./dist/index.bundle.d.ts";
 
   pkg.main = BUNDLE;
+  // Both type entries must move: Node10 resolution reads the top-level `types`,
+  // and leaving it on the unshipped dist/index.d.ts gave consumers an untyped
+  // bundle (TS7016) even though exports.types was correct.
+  pkg.types = DECLARATION;
   pkg.bin = { "lobu-worker": BUNDLE };
   pkg.exports = {
     ".": {
-      types: "./dist/index.bundle.d.ts",
+      types: DECLARATION,
       import: BUNDLE,
       default: BUNDLE,
     },


### PR DESCRIPTION
## Summary

- `@lobu/worker@14.3.0` is on the registry declaring runtime dependencies on **six** packages that do not exist there. Four are pinned to `0.0.0` — the placeholder version `private: true` workspace packages carry — a constraint no future release can ever satisfy. `npx @lobu/cli@latest` 404s for every external consumer as a result (#2186), and every CI gate was green when it shipped.
- Root cause: `rewriteWorkspaceRefs` resolved `workspace:*` against whatever version it read off disk, with no check that the target is actually published. This gates runtime `dependencies` on the target being in `PACKAGES`, and stops dependents from publishing after a dependency was blocked.
- The new guard test also caught a latent ordering bug: `@lobu/cli` was listed *before* `@lobu/connector-worker`, which it depends on at runtime.

- **The actual fix**: a new esbuild step inlines the whole `@lobu` workspace graph into `dist/index.bundle.mjs`, and the publish transform repoints `main`/`bin`/`exports` at it, drops **every** `@lobu` dependency, and stops shipping `src/`. Verified by installing the packed tarball into an empty directory outside the workspace.

**No bootstrap publish is needed.** Because the bundle inlines `@lobu/core`, `plugin-api` and `plugin-host` too, the published manifest declares zero `@lobu` dependencies — so the release no longer waits on `plugin-api`/`plugin-host` ever being created on the registry.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` (all green) + targeted `bun test scripts/__tests__/publish-packages-guard.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

### red → green

Driving the real transform with the real `@lobu/worker` manifest shape.

**RED** (pre-fix logic) — emits the exact defect now on the registry:

```
error: expect(received).not.toContain(expected)
Expected to not contain: "0.0.0"
Received: [ "14.3.0", "14.3.0", "14.3.0", "0.0.0", "0.0.0" ]

 4 pass
 3 fail
```

**GREEN** (post-fix):

```
 7 pass
 0 fail
 22 expect() calls
```

### E2E against every real manifest

The guard blocks exactly the one package that is actually broken on the registry — no false positives:

```
  OK    @lobu/core
  OK    @lobu/plugin-api
  OK    @lobu/plugin-host
  OK    @lobu/connector-sdk
  OK    @lobu/client
  BLOCK @lobu/worker -> needs @lobu/plugin-conversations, which this script does not publish.
  OK    @lobu/embeddings
  OK    @lobu/connector-worker
  OK    @lobu/cli
  OK    @lobu/promptfoo-provider
```

The error is actionable rather than just a failure:

```
@lobu/worker declares a runtime dependency on @lobu/plugin-conversations, which this script does not publish.
  An external consumer cannot install @lobu/plugin-conversations, so the published @lobu/worker would be broken.
  Fix by either:
    - adding @lobu/plugin-conversations to PACKAGES (and making it non-private), or
    - bundling @lobu/plugin-conversations into @lobu/worker's build output and removing it from "dependencies".
```

### execution coverage (added after the first review)

The first round asserted the E404→skip path through helpers without ever running it. Both scripts now run as real subprocesses, with a stub `npm` placed earlier on `PATH` (the script shells out to bare `npm`, so no production change was needed) that returns E404 for chosen packages and logs every publish attempt.

Two things that caught, which reasoning had missed:

- `@lobu/client` has **no** runtime `@lobu` dependencies, so it correctly publishes even when `@lobu/core` is blocked. My first assertion assumed everything depends on core and was wrong. A blocked package must not become a total outage.
- `bump-version` rewrites **every** workspace manifest, not just the root. Restoring only the root left 9 packages bumped to the test's version. The helper now snapshots and restores all of them; `git status` is clean after the suite.

### mutation testing

Both fixes were mutation-tested to prove the tests bite:

| mutation | result |
|---|---|
| publishability check disabled (`if (false)`) | 3 fail ✅ |
| `PACKAGES` ordering reverted | 1 fail ✅ |
| skip branch disabled | 1 fail ✅ |
| `unavailableNames.add` dropped | 1 fail ✅ |
| `bump-version` validation reverted | 5 fail ✅ |
| restored | 18 pass ✅ |

One caveat worth recording: an earlier mutation string silently matched nothing and "passed". The suite only proves anything because that mutation was corrected to hit real code.

## Notes

`bump-version.mjs` accepted *any* string as an explicit version with no validation, so a stray flag rewrote every `package.json` in the workspace to a nonsense value. I hit this for real while testing this change — `node scripts/bump-version.mjs --help` set `"version": "--help"` across the tree. Same class of bug (missing input validation before a destructive write), so it's fixed here rather than left for later.

The publish script is now import-safe (`main()` only runs when invoked as a script) so the guard tests can drive the real transform rather than a copy of it. `REPO_ROOT` is anchored to the file instead of `process.cwd()` for the same reason.

### End-to-end consumer verification

Packed the tarball and installed it into an empty directory **outside the workspace**, so nothing could resolve through the monorepo:

```
added 351 packages in 15s
=== install exit status: 0 ===
=== declared @lobu deps in the tarball manifest ===
{}
=== unresolvable private-plugin references anywhere in the tarball ===
none (correct)
```

`import '@lobu/worker'` and the `lobu-worker` bin both run, reaching real startup and stopping on a missing env var:

```
[worker] Starting worker...
[worker] ✅ Modules initialized
[worker] 🔄 Starting in gateway mode
[worker] ❌ DEPLOYMENT_NAME environment variable is required
```

Four defects only this check found — each fixed, each now a build failure rather than a release failure:

1. **Leaving `@lobu/core` external does not work.** core/plugin-api/plugin-host are CommonJS, the bundle is ESM, and a clean install died on `Named export 'sanitizeSuggestionPrompts' not found`. Same ESM↔CJS trap as #430; same fix as `build-server-bundle.mjs`.
2. **Inlining pulls in the inlined package's own deps.** `form-data` (from plugin-media) and six `@opentelemetry`/`winston` deps (from core) were imported but undeclared → `ERR_MODULE_NOT_FOUND`. Hoisted; the bundler now fails on any undeclared external.
3. **`dist/**/*.d.ts` leaked types.** Sibling declarations `import type` from `@lobu/plugin-toolkit` and would break a consumer's typecheck. Only the real type surface ships.
4. **`tsc` is incremental.** After `rm -rf dist`, a stale `tsconfig.tsbuildinfo` makes it exit 0 emitting nothing — publishing a bundle with no types and no error. Now asserted.

### In-repo dev is unaffected

`src/` and the `bun` export condition stay in the working manifest; only the publish transform changes them. This matters: the server resolves `@lobu/worker`'s `src/index.ts` deliberately, because the CJS `dist` cannot load `pi-coding-agent`.

### Follow-up (not in this PR)

`@lobu/plugin-api` and `@lobu/plugin-host` are still listed as published in `docs/RELEASING.md` but have zero versions on the registry. Nothing depends on them now, so this no longer blocks a release — but that doc and the `PACKAGES` list should either be reconciled or the two packages bootstrap-published.

Refs #2186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an esbuild-based `@lobu/worker` bundle for publishing, including generated shipped type declarations and publish-time validation of bundled dependencies.
- **Bug Fixes**
  - Publishing now skips packages when blocked by unavailable runtime/peer dependencies and rewrites `workspace:*` references to safe, publishable versions.
  - Improved worker entrypoint selection for installed vs in-repo layouts.
  - `bump-version` now rejects invalid explicit SemVer inputs.
- **Chores / Tests**
  - Broadened published package rules to exclude all `*.map` files.
  - CI added additional manifest/guard test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->