### PR TITLE
chore(submodule): bump owletto to current main

### DIFF
--- a/packages/core/src/__tests__/reserved.test.ts
+++ b/packages/core/src/__tests__/reserved.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
+  INFERENCE_ROW_KEY_PREFIX,
   isReservedEntityTypeSlug,
   isSystemEntityType,
   RESERVED_ENTITY_TYPE_SLUGS,
   RESERVED_PATHS,
+  SANDBOX_PROVIDER_KEY_PREFIX,
+  SANDBOX_ROW_KEY_PREFIX,
 } from "../reserved";
 
 describe("isSystemEntityType", () => {
@@ -31,5 +34,15 @@ describe("lists", () => {
     expect(RESERVED_PATHS).toContain("memory");
     expect(RESERVED_PATHS).toContain("www");
     expect(RESERVED_ENTITY_TYPE_SLUGS).toContain("organization");
+  });
+});
+
+describe("connector-key namespace prefixes", () => {
+  it("pins the shared prefixes the SPA and URL builders depend on", () => {
+    // These are a cross-repo contract: owletto re-exports them and its
+    // detail-route parsers slice on them, so the values must not drift.
+    expect(INFERENCE_ROW_KEY_PREFIX).toBe("inference-provider:");
+    expect(SANDBOX_ROW_KEY_PREFIX).toBe("sandbox:");
+    expect(SANDBOX_PROVIDER_KEY_PREFIX).toBe("sandbox-provider:");
   });
 });

--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -77,6 +77,32 @@ export const RESERVED_PATHS = [
 
 export const RESERVED_PATHS_SET: ReadonlySet<string> = new Set(RESERVED_PATHS);
 
+// ── Connector-key namespace prefixes ────────────────────────────────────────
+
+/**
+ * Namespace prefixes for synthesized connectors-list rows whose underlying data
+ * lives outside the `connections` table. Model providers and remote sandboxes
+ * share the connectors list/map with real connectors, so each gets a reserved
+ * key prefix that keeps e.g. a provider named `slack` from colliding with the
+ * real Slack connector. The prefixed key IS the routable connector key: rows
+ * link to `/connectors/$connectorKey`, and the detail route strips the prefix to
+ * resolve the remainder as a provider / sandbox instead of a connector def.
+ *
+ * These live in core (not the SPA) because the server's chat-message URL
+ * builders emit the same prefixed keys into agent-error CTA links, and the SPA
+ * re-exports them so browser code keeps one import site. Keep these values in
+ * sync with the detail-route parsers (`inference-rows.ts`, `sandbox-rows.ts`).
+ */
+
+/** Model-provider row / CTA target: `inference-provider:<slug>`. */
+export const INFERENCE_ROW_KEY_PREFIX = "inference-provider:";
+
+/** Org sandbox-instance row: `sandbox:<id>`. */
+export const SANDBOX_ROW_KEY_PREFIX = "sandbox:";
+
+/** Sandbox provider-kind (catalog) row: `sandbox-provider:<kind>`. */
+export const SANDBOX_PROVIDER_KEY_PREFIX = "sandbox-provider:";
+
 // ── Entity type create denylist ─────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
Advances the `packages/owletto` submodule pointer from `073cbe5` to `owletto/main` HEAD `93a493ae`, clearing the repo-wide `Submodule Drift` (`check-drift`) failure, plus the parent-side core change that owletto's new HEAD needs to build.

`owletto/main` moved one non-bot commit past the pinned SHA:

```
93a493ae feat(web): make the sidebar the site map and fold providers/sandboxes into connectors (#614)
```

(plus two FluxCD `chore: update images` bot commits, which the drift check ignores). The pinned SHA is a clean ancestor of `owletto/main`, so this is a straight fast-forward pointer bump and the target SHA is already pushed to owletto's remote.

```
diff --git a/packages/owletto b/packages/owletto
-Subproject commit 073cbe514ef4a5955ab8cf8d8990e767408e57e6
+Subproject commit 93a493ae168fe57df716cfb7d4ad547ca8e79c31
```

## Core companion change (fixes the `frontend` CI job)

owletto's #614 folded model providers and sandboxes into the connectors list and, per its own design comment, moved the connector-key namespace prefixes into `@lobu/core/reserved` (the single source of truth the server's chat-message URL builders and the SPA both read). The bumped HEAD now imports `INFERENCE_ROW_KEY_PREFIX`, `SANDBOX_ROW_KEY_PREFIX`, and `SANDBOX_PROVIDER_KEY_PREFIX` from there, but the parent repo's `packages/core/src/reserved.ts` never defined them, so they resolved to `undefined`. That broke the `frontend` job's owletto vitest run, e.g. an agent-error CTA built `.../connectors/undefinedz-ai` instead of `.../connectors/inference-provider%3Az-ai`.

This adds the three prefixes to core as a purely additive export (no existing parent code imported them, so server/worker behavior is unchanged), matching the string contract owletto's parsers slice on:

```ts
export const INFERENCE_ROW_KEY_PREFIX = "inference-provider:";
export const SANDBOX_ROW_KEY_PREFIX = "sandbox:";
export const SANDBOX_PROVIDER_KEY_PREFIX = "sandbox-provider:";
```

Verified locally: `packages/core` builds and the previously failing owletto suites (`lobu-chat-store`, `agent-error-cta`, `inference-rows`, `sandbox-rows`) now pass (55/55), plus a core `reserved.test.ts` case pins the three values so they can't silently drift.

The drift failure also shows up on the release PR #2187, whose branch does not touch the submodule; once this merges to `main`, `check-drift` goes green there automatically.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
