### PR TITLE
feat(server): org-level MCP session activity endpoint + session-stamped approvals

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -190,6 +190,7 @@ describe("manage_entity merge action", () => {
 			userId: null,
 			agentId: "personal-agent",
 			actingWatcherId: 6001,
+			mcpSessionId: "session-entity-merge",
 		} as ToolContext;
 		const queued = (await manageEntity(
 			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
@@ -211,12 +212,15 @@ describe("manage_entity merge action", () => {
 			"merge",
 		);
 		const [approvalEvent] = await sql`
-			SELECT title FROM current_event_records
+			SELECT title, metadata FROM current_event_records
 			WHERE run_id = ${queued.approval_run_id} AND interaction_status = 'pending'
 		`;
 		expect(approvalEvent.title).toBe(
 			"Merge Loser into Winner — pending approval",
 		);
+		expect(approvalEvent.metadata).toMatchObject({
+			mcp_session_id: "session-entity-merge",
+		});
 
 		const approved = await manageOperations(
 			{ action: "approve", run_id: queued.approval_run_id },

--- a/packages/server/src/__tests__/integration/mcp/client-sessions-route.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/client-sessions-route.test.ts
@@ -1,0 +1,176 @@
+/** Integration coverage for org-scoped MCP session activity. */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { recordToolInvocationAudit } from '../../../tools/audit';
+import type { ToolContext } from '../../../tools/registry';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+import { get } from '../../setup/test-helpers';
+
+describe('client sessions activity route', () => {
+  let token: string;
+  let orgId: string;
+  let orgSlug: string;
+  let ownerId: string;
+  let clientId: string;
+  let clientName: string;
+  let otherOrgId: string;
+
+  function auditCtx(overrides: Partial<ToolContext> = {}): ToolContext {
+    return {
+      organizationId: orgId,
+      userId: ownerId,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      clientId,
+      agentId: 'session-agent',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      ...overrides,
+    } as ToolContext;
+  }
+
+  async function recordCall(
+    sessionId: string,
+    toolName: string,
+    overrides: Partial<ToolContext> = {},
+    result: Record<string, unknown> = { ok: true }
+  ): Promise<void> {
+    await recordToolInvocationAudit({
+      toolName,
+      args: { query: 'probe' },
+      result,
+      durationMs: 3,
+      ctx: auditCtx({ mcpSessionId: sessionId, ...overrides }),
+    });
+  }
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const org = await createTestOrganization({
+      name: 'Sessions Route Org',
+      slug: 'sessions-route-org',
+    });
+    orgId = org.id;
+    orgSlug = org.slug;
+    const owner = await createTestUser({ email: 'sessions-route@test.example.com' });
+    ownerId = owner.id;
+    await addUserToOrganization(owner.id, org.id, 'owner');
+    clientName = 'Sessions Probe App';
+    const oauthClient = await createTestOAuthClient({ client_name: clientName });
+    clientId = oauthClient.client_id;
+    token = (
+      await createTestAccessToken(owner.id, org.id, oauthClient.client_id, {
+        scope: 'mcp:read mcp:write mcp:admin',
+      })
+    ).token;
+    const otherOrg = await createTestOrganization({
+      name: 'Sessions Route Other',
+      slug: 'sessions-route-other',
+    });
+    otherOrgId = otherOrg.id;
+
+    // Session A: two calls, one pending approval linked by the session stamp.
+    await recordCall('sess-alpha', 'search_memory');
+    await recordCall('sess-alpha', 'query_sql', {}, { error: 'probe failure' });
+    await insertEvent({
+      entityIds: [],
+      organizationId: orgId,
+      originId: 'sess-alpha-approval',
+      title: 'Create Issue — pending approval',
+      semanticType: 'operation',
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+      clientId,
+      metadata: { mcp_session_id: 'sess-alpha' },
+    });
+
+    // Session B sorts first: pin session A an hour back so ordering does not
+    // depend on sub-millisecond insertion timing.
+    const db = getDb();
+    await db`
+      UPDATE events SET occurred_at = now() - interval '1 hour'
+      WHERE organization_id = ${orgId}
+        AND semantic_type = 'audit'
+        AND metadata->>'mcp_session_id' = 'sess-alpha'
+    `;
+    await recordCall('sess-beta', 'search_sdk');
+
+    // Cross-org session: must never appear for orgSlug.
+    await recordCall('sess-foreign', 'search_memory', {
+      organizationId: otherOrgId,
+    } as Partial<ToolContext>);
+
+    // Stale session: outside the activity window.
+    await recordCall('sess-stale', 'search_memory');
+    const sql = getDb();
+    await sql`
+      UPDATE events SET occurred_at = now() - interval '30 days'
+      WHERE organization_id = ${orgId}
+        AND metadata->>'mcp_session_id' = 'sess-stale'
+    `;
+  });
+
+  it('lists recent sessions newest-first with counts, tools, client identity, and pending interactions', async () => {
+    const res = await get(`/api/${orgSlug}/clients/sessions`, { token });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      sessions: Array<{
+        sessionId: string;
+        clientId: string | null;
+        clientName: string | null;
+        userId: string | null;
+        agentId: string | null;
+        firstCallAt: number;
+        failedCount: number;
+        callCount: number;
+        tools: string[];
+        pendingInteractionCount: number;
+        lastCallAt: number;
+      }>;
+    };
+
+    const ids = body.sessions.map((s) => s.sessionId);
+    expect(ids).toEqual(['sess-beta', 'sess-alpha']);
+    expect(ids).not.toContain('sess-foreign');
+    expect(ids).not.toContain('sess-stale');
+
+    const alpha = body.sessions.find((s) => s.sessionId === 'sess-alpha')!;
+    expect(alpha.callCount).toBe(2);
+    expect(alpha.failedCount).toBe(1);
+    expect(alpha.tools).toEqual(['query_sql', 'search_memory']);
+    expect(alpha.clientId).toBe(clientId);
+    expect(alpha.clientName).toBe(clientName);
+    expect(alpha.userId).toBe(ownerId);
+    expect(alpha.agentId).toBe('session-agent');
+    expect(alpha.firstCallAt).toBeLessThanOrEqual(alpha.lastCallAt);
+    expect(alpha.pendingInteractionCount).toBe(1);
+
+    const beta = body.sessions.find((s) => s.sessionId === 'sess-beta')!;
+    expect(beta.callCount).toBe(1);
+    expect(beta.pendingInteractionCount).toBe(0);
+  });
+
+  it('honors the bounded result limit', async () => {
+    const res = await get(`/api/${orgSlug}/clients/sessions?limit=1`, { token });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sessions: Array<{ sessionId: string }> };
+    expect(body.sessions.map((session) => session.sessionId)).toEqual(['sess-beta']);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const res = await get(`/api/${orgSlug}/clients/sessions`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/server/src/__tests__/integration/operations-approval-event-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-event-atomicity.test.ts
@@ -57,6 +57,7 @@ describe("approval-event atomicity (item 16)", () => {
 			orgName: "Approval Atomicity Org",
 		});
 		ownerCtx.baseUrl = "https://gateway.test/lobu";
+		ownerCtx.mcpSessionId = "session-approval-atomicity";
 		orgId = org.id;
 		userId = user.id;
 		ctx = ownerCtx;
@@ -160,7 +161,7 @@ describe("approval-event atomicity (item 16)", () => {
 		// The approval event exists, is org-scoped, and joins to the run — this is
 		// what the /memory?run_ids= page reads. A stranded run would have none.
 		const eventRows = await sql`
-			SELECT id, interaction_type, interaction_status, organization_id
+			SELECT id, interaction_type, interaction_status, organization_id, metadata
 			FROM events
 			WHERE run_id = ${result.run_id} AND organization_id = ${orgId}
 		`;
@@ -169,6 +170,9 @@ describe("approval-event atomicity (item 16)", () => {
 		expect(eventRows[0].interaction_type).toBe("approval");
 		expect(eventRows[0].interaction_status).toBe("pending");
 		expect(eventRows[0].organization_id).toBe(orgId);
+		expect(eventRows[0].metadata).toMatchObject({
+			mcp_session_id: "session-approval-atomicity",
+		});
 
 		const after = await sql`SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}`;
 		expect(after[0].n).toBe(before[0].n + 1);

--- a/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
@@ -134,6 +134,7 @@ describe("manage_agents — builder gate e2e", () => {
 			["mcp:read", "mcp:write", "mcp:admin"],
 			"builder-agent",
 		);
+		agentCtx.mcpSessionId = "session-manage-agents";
 		memberCtx = baseCtx(org.id, member.id, "member", ["mcp:read", "mcp:write"]);
 	});
 
@@ -340,6 +341,9 @@ describe("manage_agents — builder gate e2e", () => {
 		`;
 		expect(eventRows.length).toBe(1);
 		expect(eventRows[0]?.interaction_status).toBe("pending");
+		expect(eventRows[0]?.metadata).toMatchObject({
+			mcp_session_id: "session-manage-agents",
+		});
 
 		// No agent created yet — the gate is the whole point.
 		expect(await agentExists(orgId, "support-bot")).toBe(false);

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
@@ -124,6 +124,7 @@ describe("manage_behaviors — builder gate e2e", () => {
 			["mcp:read", "mcp:write", "mcp:admin"],
 			agentId
 		);
+		agentCtx.mcpSessionId = "session-manage-behaviors";
 	});
 
 	it("human owner: create applies immediately with no approval run", async () => {
@@ -198,6 +199,9 @@ describe("manage_behaviors — builder gate e2e", () => {
 		`;
 		expect(eventRows.length).toBe(1);
 		expect(eventRows[0]?.interaction_status).toBe("pending");
+		expect(eventRows[0]?.metadata).toMatchObject({
+			mcp_session_id: "session-manage-behaviors",
+		});
 		expect(
 			(eventRows[0]?.metadata as { initiator?: Record<string, unknown> })
 				?.initiator

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -67,6 +67,7 @@ import { isExcludedSpaPath } from "./http/spa-route-filter";
 import { isShuttingDown } from "./lifecycle-state";
 import { agentRoutes } from "./lobu/agent-routes";
 import { clientRoutes } from "./lobu/client-routes";
+import { clientSessionRoutes } from "./lobu/client-session-routes";
 import { deploymentRoutes } from "./lobu/deployment-routes";
 import { sandboxRoutes } from "./lobu/sandbox-routes";
 import {
@@ -2345,6 +2346,7 @@ app.route("/api/:orgSlug/installed", orgInstalledRoutes);
 app.route("/api/:orgSlug/agents", agentRoutes);
 app.route("/api/:orgSlug/deployments", deploymentRoutes);
 app.route("/api/:orgSlug/sandboxes", sandboxRoutes);
+app.route("/api/:orgSlug/clients/sessions", clientSessionRoutes);
 app.route("/api/:orgSlug/clients", clientRoutes);
 
 // ============================================

--- a/packages/server/src/lobu/client-session-routes.ts
+++ b/packages/server/src/lobu/client-session-routes.ts
@@ -1,0 +1,106 @@
+import { Hono } from "hono";
+import { mcpAuth } from "../auth/middleware";
+import { getDb } from "../db/client";
+import type { Env } from "../index";
+
+/** Recent org-wide MCP session activity derived from tool-invocation audits. */
+const routes = new Hono<{ Bindings: Env }>();
+
+const ACTIVITY_WINDOW_DAYS = 14;
+
+interface SessionRow {
+	session_id: string;
+	client_id: string | null;
+	client_name: string | null;
+	user_id: string | null;
+	agent_id: string | null;
+	first_call_at: Date;
+	last_call_at: Date;
+	call_count: string;
+	failed_count: string;
+	tools: string[] | null;
+	pending_interaction_count: string;
+}
+
+routes.get("/", mcpAuth, async (c) => {
+	const organizationId = c.get("organizationId") as string | undefined;
+	if (!organizationId) {
+		return c.json({ error: "Organization required" }, 401);
+	}
+	const rawLimit = Number.parseInt(c.req.query("limit") ?? "20", 10);
+	const limit = Math.min(Math.max(Number.isNaN(rawLimit) ? 20 : rawLimit, 1), 100);
+
+	const sql = getDb();
+	const rows = (await sql`
+		WITH session_calls AS (
+			SELECT
+				e.metadata->>'mcp_session_id' AS session_id,
+				e.client_id,
+				e.created_by,
+				e.metadata->>'agent_id' AS agent_id,
+				e.payload_data->>'tool_name' AS tool_name,
+				(e.payload_data->>'success')::boolean AS success,
+				e.occurred_at
+			FROM events e
+			WHERE e.organization_id = ${organizationId}
+				AND e.semantic_type = 'audit'
+				AND e.origin_type = 'tool_invocation'
+				AND e.metadata->>'mcp_session_id' IS NOT NULL
+				AND e.occurred_at > now() - make_interval(days => ${ACTIVITY_WINDOW_DAYS})
+		),
+		sessions AS (
+			SELECT
+				session_id,
+				max(client_id) AS client_id,
+				max(created_by) AS user_id,
+				max(agent_id) AS agent_id,
+				min(occurred_at) AS first_call_at,
+				max(occurred_at) AS last_call_at,
+				count(*) AS call_count,
+				count(*) FILTER (WHERE success IS NOT TRUE) AS failed_count,
+				-- to_jsonb: raw text[] arrives as an unparsed "{a,b}" string under
+				-- the prod fetch_types:false client options; jsonb parses cleanly.
+				to_jsonb((array_agg(DISTINCT tool_name ORDER BY tool_name))[1:8]) AS tools
+			FROM session_calls
+			GROUP BY session_id
+		),
+		pending_interactions AS (
+			SELECT
+				a.metadata->>'mcp_session_id' AS session_id,
+				count(*) AS pending_interaction_count
+			FROM current_event_records a
+			WHERE a.organization_id = ${organizationId}
+				AND a.interaction_type <> 'none'
+				AND a.interaction_status = 'pending'
+				AND a.metadata->>'mcp_session_id' IS NOT NULL
+			GROUP BY a.metadata->>'mcp_session_id'
+		)
+		SELECT
+			s.*,
+			oc.client_name,
+			coalesce(pi.pending_interaction_count, 0) AS pending_interaction_count
+		FROM sessions s
+		LEFT JOIN oauth_clients oc ON oc.id = s.client_id
+		LEFT JOIN pending_interactions pi ON pi.session_id = s.session_id
+		ORDER BY last_call_at DESC
+		LIMIT ${limit}
+	`) as unknown as SessionRow[];
+
+	return c.json({
+		sessions: rows.map((row) => ({
+			sessionId: row.session_id,
+			clientId: row.client_id,
+			clientName: row.client_name,
+			userId: row.user_id,
+			agentId: row.agent_id,
+			firstCallAt: new Date(row.first_call_at).getTime(),
+			lastCallAt: new Date(row.last_call_at).getTime(),
+			callCount: Number(row.call_count),
+			failedCount: Number(row.failed_count),
+			tools: row.tools ?? [],
+			pendingInteractionCount: Number(row.pending_interaction_count),
+		})),
+	});
+});
+
+export const clientSessionRoutes = routes;

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -713,6 +713,7 @@ export async function proposeEntityChange(
 					proposer_rationale: mergeProposal?.proposer_rationale ?? null,
 					status: "pending_approval",
 					run_id: runId,
+					mcp_session_id: ctx.mcpSessionId ?? null,
 				},
 				authorName: attribution,
 			},

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -771,6 +771,7 @@ async function queueWriteForApproval(
       },
       status: 'pending_approval',
       run_id: runId,
+      mcp_session_id: ctx.mcpSessionId ?? null,
     },
     authorName: ctx.clientId ?? 'agent',
   });

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -747,6 +747,7 @@ async function queueWatcherWriteForApproval(
       run_id: runId,
       input_schema: inputSchema,
       action_input: displayInput,
+      mcp_session_id: ctx.mcpSessionId ?? null,
     },
     authorName: ctx.clientId ?? 'agent',
   });

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1186,9 +1186,10 @@ async function handleExecute(
 					action_input: input,
 					input_schema: operation.input_schema ?? null,
 					status: "pending_approval",
-						connection_name:
-							connection.display_name ?? connection.connector_key,
+					connection_name:
+						connection.display_name ?? connection.connector_key,
 					run_id: createdRunId,
+					mcp_session_id: ctx.mcpSessionId ?? null,
 				},
 				authorName: ctx.clientId ?? "agent",
 			},


### PR DESCRIPTION
## Summary

Step 3 (server half) of the MCP-activity-in-Recent plan (follows #2229, #2233).

- **`GET /api/{org}/clients/sessions`** (new router `client-session-routes.ts`, mounted before the clients inventory router): one entry per persistent MCP session over a 14-day window, derived from the tool-invocation audit ledger — client id/name (oauth_clients join), user, agent, first/last call, call + failure counts, distinct tools (jsonb — raw `text[]` is an unparsed string under `fetch_types:false`), and an exact `pendingInteractionCount`.
- **Session-stamped approvals:** every approval-emitting site (`manage_operations`, `manage_agents`, `manage_behaviors`, `entity-field-approval`) now writes `metadata.mcp_session_id` on the pending interaction event, so an approval links back to the client session that requested it. Class-fixed in one pass across all four sites.
- Deliberately an org-level endpoint, NOT the per-agent `listAgentThreads` fanout (that topology duplicates org-global rows once per agent — reproduced 2026-07-27).

## Red → Green
Route tests fail on main by construction (404 — endpoint does not exist); 3 route tests green after. Stamp coverage added inside four EXISTING approval e2e suites (each now asserts `metadata.mcp_session_id` on the pending event), red without the stamp lines.

## Testing
- New: `integration/mcp/client-sessions-route.test.ts` (ordering, counts, tools, client identity, pending-interaction count, cross-org isolation, activity window, limit bound, 401).
- Modified: 4 approval e2e suites assert the session stamp. All affected suites: 5 files / 57 tests green.
- `make pre-pr` clean; `make review-fix` applied (it generalized my single-site stamp to all four approval sites and added the e2e stamp assertions) and its diff verified hunk-by-hunk.

Frontend (Recent arm + clients-under-connectors section) follows in an owletto-side PR now that the pointer situation is resolved (#2236).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint for viewing recent MCP client session activity.
  * Session activity includes call counts, failures, tools used, client and agent details, timestamps, and pending approvals.
  * Results can be limited to the most recent sessions and are restricted to the authenticated organization.
* **Improvements**
  * Approval events now retain the associated MCP session identifier, improving traceability across entity, agent, behavior, and operation workflows.
* **Bug Fixes**
  * Unauthenticated access to session activity is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->