### PR TITLE
fix(server): keep an org's default inference provider populated

### DIFF
--- a/packages/cli/src/commands/__tests__/infra-commands.test.ts
+++ b/packages/cli/src/commands/__tests__/infra-commands.test.ts
@@ -188,6 +188,17 @@ describe("providers", () => {
     });
   });
 
+  test("create reports an automatic default returned by the server", async () => {
+    responses = [{ provider: { slug: "z-ai", isDefault: true } }];
+
+    await providersCreateCommand("z-ai", {
+      kind: "z-ai",
+      key: "sk-literal",
+    });
+
+    expect(logLines.join("\n")).toContain("and set as org default");
+  });
+
   test("create --default reports partial success when the default PUT fails", async () => {
     responses = [{ provider: { slug: "p1" } }];
     failPathSuffix = "/p1/default";

--- a/packages/cli/src/commands/providers/manage.ts
+++ b/packages/cli/src/commands/providers/manage.ts
@@ -192,11 +192,17 @@ export async function providersCreateCommand(
     }
   }
 
+  // The server auto-promotes an org's first runnable provider, so "is it the
+  // default" is NOT knowable from the flags alone — trust what it returned.
+  // `--default` above issues an explicit PUT that throws on failure, so
+  // reaching here with the flag set means that call succeeded.
+  const isDefault = options.default || (provider.isDefault ?? false);
+
   if (options.json) {
-    printJson({ ...provider, isDefault: options.default ?? false });
+    printJson({ ...provider, isDefault });
     return;
   }
-  const defaultNote = options.default ? " and set as org default" : "";
+  const defaultNote = isDefault ? " and set as org default" : "";
   console.log(
     chalk.green(`\n  Created provider ${slug} in ${orgSlug}${defaultNote}.\n`)
   );

--- a/packages/cli/src/commands/providers/manage.ts
+++ b/packages/cli/src/commands/providers/manage.ts
@@ -37,7 +37,7 @@ interface OrgProviderRow {
   hasCustomUpstream: boolean;
   status: string;
   createdAt: string;
-  isDefault?: boolean;
+  isDefault: boolean;
 }
 
 interface CatalogEntry {
@@ -196,7 +196,7 @@ export async function providersCreateCommand(
   // default" is NOT knowable from the flags alone — trust what it returned.
   // `--default` above issues an explicit PUT that throws on failure, so
   // reaching here with the flag set means that call succeeded.
-  const isDefault = options.default || (provider.isDefault ?? false);
+  const isDefault = options.default || provider.isDefault;
 
   if (options.json) {
     printJson({ ...provider, isDefault });

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -352,6 +352,50 @@ describe('inference provider org default', () => {
     expect(await getOrgDefaultModel(org.id)).toBeNull();
   });
 
+  it('(j7) a row ALREADY oauth and still flagged default is repaired, not skipped', async () => {
+    const org = await newOrg();
+    await create(org.id, 'zed', 'zed-model');
+    await create(org.id, 'openai', 'gpt-4o-mini');
+
+    // First sign-in converts and demotes correctly (covered by j5).
+    await ensureOAuthInferenceProvider({
+      organizationId: org.id,
+      slug: 'zed',
+      kind: 'zed',
+      defaultModel: 'zed-model',
+    });
+    expect(await defaultSlug(org.id)).toBe('openai');
+
+    // Now recreate the legacy state this branch has to survive: an `oauth://`
+    // row that is STILL flagged default. Rows predating the demote landed this
+    // way, and a second ensureOAuthInferenceProvider call takes the
+    // already-oauth path — which returns early. If that path does not clear the
+    // flag, promotion cannot repair it either: the NOT EXISTS guard sees a
+    // default present and no-ops, stranding the org on a credential only one
+    // member can read.
+    // Two statements: `inference_providers_org_default_live` is a partial
+    // unique index, so a single UPDATE flipping both rows trips it mid-write.
+    await getDb()`
+      UPDATE inference_providers SET is_default = false
+      WHERE organization_id = ${org.id} AND deleted_at IS NULL
+    `;
+    await getDb()`
+      UPDATE inference_providers SET is_default = true
+      WHERE organization_id = ${org.id} AND slug = 'zed' AND deleted_at IS NULL
+    `;
+    expect(await defaultSlug(org.id)).toBe('zed');
+
+    await ensureOAuthInferenceProvider({
+      organizationId: org.id,
+      slug: 'zed',
+      kind: 'zed',
+      defaultModel: 'zed-model',
+    });
+
+    expect(await defaultSlug(org.id)).toBe('openai');
+    expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
+  });
+
   it('(k) an explicit model resolves with a row key and static OpenAI URL', async () => {
     const org = await newOrg();
     await create(org.id, 'openai');

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Integration test: an org always has a resolvable default inference provider.
+ *
+ * The org default is the tail of the layered model fallback
+ * (behavior → agent → org default). When it is missing, `getOrgDefaultModel`
+ * returns null and EVERY org-scoped model consumer silently no-ops — no error,
+ * no UI signal, just nothing happening.
+ *
+ * Prod showed both halves of that failure on 2026-07-28: no live row anywhere
+ * carried `is_default`, and the only row that did was soft-deleted. The two
+ * causes this file pins down:
+ *   (a) creating a provider never marked it default — that was a SEPARATE
+ *       explicit call nothing chained to creation, so a one-provider org had
+ *       no default despite there being only one sensible answer;
+ *   (b) deleting the default left the org with none.
+ *
+ * Harness: vitest + real Postgres, matching the other store-level suites.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { __resetEncryptionKeyCacheForTests } from '@lobu/core';
+import {
+  createInferenceProvider,
+  getOrgDefaultModel,
+  listInferenceProviders,
+  setInferenceProviderDefault,
+  softDeleteInferenceProvider,
+} from '../../lobu/stores/provider-secrets';
+import { getDb } from '../../db/client';
+import { initWorkspaceProvider } from '../../workspace';
+import { cleanupTestDatabase } from '../setup/test-db';
+import { createTestOrganization } from '../setup/test-fixtures';
+
+let originalEncryptionKey: string | undefined;
+
+async function newOrg() {
+  return await createTestOrganization({ name: 'Provider Default Org' });
+}
+
+/** Create a provider, failing loudly on a slug conflict. */
+async function create(
+  organizationId: string,
+  slug: string,
+  model?: string,
+) {
+  const result = await createInferenceProvider({
+    organizationId,
+    slug,
+    kind: slug,
+    apiKey: `sk-${slug}`,
+    capabilities: model ? { text: { model } } : {},
+  });
+  if ('error' in result) throw new Error(`unexpected conflict for ${slug}`);
+  return result;
+}
+
+async function defaultSlug(organizationId: string): Promise<string | null> {
+  const rows = (await getDb()`
+    SELECT slug FROM inference_providers
+    WHERE organization_id = ${organizationId} AND is_default AND deleted_at IS NULL
+  `) as Array<{ slug: string }>;
+  return rows[0]?.slug ?? null;
+}
+
+describe('inference provider org default', () => {
+  beforeAll(async () => {
+    originalEncryptionKey = process.env.ENCRYPTION_KEY;
+    process.env.ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    __resetEncryptionKeyCacheForTests();
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+  });
+
+  afterAll(() => {
+    if (originalEncryptionKey !== undefined) {
+      process.env.ENCRYPTION_KEY = originalEncryptionKey;
+    } else {
+      delete process.env.ENCRYPTION_KEY;
+    }
+    __resetEncryptionKeyCacheForTests();
+  });
+
+  it('(a) the first provider an org creates becomes its default', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+
+    expect(await defaultSlug(org.id)).toBe('openai');
+    // The whole point: a model now resolves org-wide.
+    expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
+  });
+
+  it('(b) later providers do NOT steal the default', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await create(org.id, 'z-ai', 'glm-4.6');
+    await create(org.id, 'xai', 'grok-4');
+
+    expect(await defaultSlug(org.id)).toBe('openai');
+    expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
+  });
+
+  it('(c) deleting the default promotes the oldest survivor', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await create(org.id, 'z-ai', 'glm-4.6');
+    await create(org.id, 'xai', 'grok-4');
+    expect(await defaultSlug(org.id)).toBe('openai');
+
+    expect(await softDeleteInferenceProvider(org.id, 'openai')).toBe(true);
+
+    // z-ai was created before xai, so it inherits.
+    expect(await defaultSlug(org.id)).toBe('z-ai');
+    expect(await getOrgDefaultModel(org.id)).toBe('z-ai/glm-4.6');
+  });
+
+  it('(d) deleting a NON-default provider leaves the default alone', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await create(org.id, 'z-ai', 'glm-4.6');
+
+    expect(await softDeleteInferenceProvider(org.id, 'z-ai')).toBe(true);
+    expect(await defaultSlug(org.id)).toBe('openai');
+  });
+
+  it('(e) deleting the last provider is a no-op, not a crash', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+
+    expect(await softDeleteInferenceProvider(org.id, 'openai')).toBe(true);
+    expect(await defaultSlug(org.id)).toBeNull();
+    expect(await getOrgDefaultModel(org.id)).toBeNull();
+  });
+
+  it('(f) re-creating after deleting everything defaults again', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await softDeleteInferenceProvider(org.id, 'openai');
+
+    // A soft-deleted row must not count as "already has a provider", or the
+    // org could never recover a default.
+    await create(org.id, 'z-ai', 'glm-4.6');
+    expect(await defaultSlug(org.id)).toBe('z-ai');
+  });
+
+  it('(g) an explicit set-default still wins over the auto-assignment', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await create(org.id, 'z-ai', 'glm-4.6');
+
+    expect(await setInferenceProviderDefault(org.id, 'z-ai')).toBe(true);
+    expect(await defaultSlug(org.id)).toBe('z-ai');
+    // Exactly one default survives the switch (partial unique index).
+    const providers = await listInferenceProviders(org.id);
+    expect(providers.filter((p) => p.isDefault)).toHaveLength(1);
+  });
+
+  it('(h) two orgs each keep their own default', async () => {
+    const orgA = await newOrg();
+    const orgB = await newOrg();
+    await create(orgA.id, 'openai', 'gpt-4o-mini');
+    await create(orgB.id, 'z-ai', 'glm-4.6');
+
+    expect(await getOrgDefaultModel(orgA.id)).toBe('openai/gpt-4o-mini');
+    expect(await getOrgDefaultModel(orgB.id)).toBe('z-ai/glm-4.6');
+  });
+});

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -318,11 +318,8 @@ describe('inference provider org default', () => {
     expect(await defaultSlug(org.id)).toBe('zed');
 
     // Signing in with OAuth converts the EXISTING api-key row in place. The
-    // row keeps its id and its is_default flag, but its credential becomes
-    // per-user — so it is no longer eligible to be the ORG default. Leaving
-    // the flag set would strand the org on a credential only one member can
-    // read, and promotion cannot fix it: the NOT EXISTS guard sees a default
-    // already present and no-ops.
+    // row keeps its id, but its credential becomes per-user — so the conversion
+    // must clear its default flag before promotion can choose a successor.
     await ensureOAuthInferenceProvider({
       organizationId: org.id,
       slug: 'zed',
@@ -488,10 +485,8 @@ describe('inference provider org default', () => {
     /**
      * The POSITIVE half of the invariant. (m)/(n) prove an unregistered
      * provider resolves nothing; without this, a resolver that returned null
-     * for EVERYTHING would still pass them. Prod is the reason this matters:
-     * every live `inference_providers` row carries `capabilities = {}` (an API
-     * key and nothing else), so the registry upstream — not the row — is what
-     * actually routes a gateway completion for a non-OpenAI provider.
+     * for EVERYTHING would still pass them. Provider rows need not define a
+     * `base_url`, so registered providers must inherit their catalog upstream.
      */
     /**
      * A guardrail's `model` was historically a RAW model id posted to one
@@ -635,7 +630,7 @@ describe('inference provider org default', () => {
       const org = await newOrg();
       await create(org.id, 'openai', 'gpt-4o-mini');
       await create(org.id, 'z-ai', 'glm-4.6');
-      // Force the legacy state every pre-fix org is in.
+      // Force the legacy state where an org has providers but no default.
       await getDb()`
         UPDATE inference_providers
         SET is_default = false

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -3,7 +3,7 @@
  * OAuth defaults, and promotion after deletion.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { __resetEncryptionKeyCacheForTests } from '@lobu/core';
 import {
   createInferenceProvider,

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -83,6 +83,25 @@ describe('inference provider org default', () => {
     expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
   });
 
+  it('(a2) create REPORTS the auto-promotion in its return value', async () => {
+    const org = await newOrg();
+
+    // The contract, not just the DB state: the caller cannot infer this from
+    // its own request, and both the REST response and `lobu providers create
+    // --json` publish it. The INSERT's RETURNING captures is_default BEFORE
+    // promotion, so a naive implementation reports a stale `false` here.
+    const first = await create(org.id, 'openai', 'gpt-4o-mini');
+    expect(first.isDefault).toBe(true);
+
+    // A later provider is NOT the default, and must say so.
+    const second = await create(org.id, 'z-ai', 'glm-4.6');
+    expect(second.isDefault).toBe(false);
+
+    // A model-less row is never promoted, so it is never reported as default.
+    const third = await create(org.id, 'groq');
+    expect(third.isDefault).toBe(false);
+  });
+
   it('(b) later providers do NOT steal the default', async () => {
     const org = await newOrg();
     await create(org.id, 'openai', 'gpt-4o-mini');

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -476,7 +476,7 @@ describe('inference provider org default', () => {
 
       // Even asked for BY NAME, an oauth:// ref joins to no vault secret, so the
       // gateway transport declines rather than sending a keyless request.
-      // Claude is also sdkCompat:"anthropic", the one non-OpenAI protocol.
+      // Claude also uses the non-OpenAI `anthropic` protocol.
       expect(
         await resolveCompletionTarget(org.id, 'claude/claude-sonnet-5'),
       ).toBeNull();

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -1,31 +1,20 @@
 /**
- * Integration test: an org always has a resolvable default inference provider.
- *
- * The org default is the tail of the layered model fallback
- * (behavior → agent → org default). When it is missing, `getOrgDefaultModel`
- * returns null and EVERY org-scoped model consumer silently no-ops — no error,
- * no UI signal, just nothing happening.
- *
- * Prod showed both halves of that failure on 2026-07-28: no live row anywhere
- * carried `is_default`, and the only row that did was soft-deleted. The two
- * causes this file pins down:
- *   (a) creating a provider never marked it default — that was a SEPARATE
- *       explicit call nothing chained to creation, so a one-provider org had
- *       no default despite there being only one sensible answer;
- *   (b) deleting the default left the org with none.
- *
- * Harness: vitest + real Postgres, matching the other store-level suites.
+ * Integration coverage for automatic org-default assignment, legacy repair,
+ * OAuth defaults, and promotion after deletion.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { __resetEncryptionKeyCacheForTests } from '@lobu/core';
 import {
   createInferenceProvider,
+  ensureOAuthInferenceProvider,
   getOrgDefaultModel,
   listInferenceProviders,
   setInferenceProviderDefault,
   softDeleteInferenceProvider,
+  updateInferenceProviderCapabilities,
 } from '../../lobu/stores/provider-secrets';
+import { resolveCompletionTarget } from '../../gateway/inference/gateway-completion';
 import { getDb } from '../../db/client';
 import { initWorkspaceProvider } from '../../workspace';
 import { cleanupTestDatabase } from '../setup/test-db';
@@ -81,7 +70,7 @@ describe('inference provider org default', () => {
     __resetEncryptionKeyCacheForTests();
   });
 
-  it('(a) the first provider an org creates becomes its default', async () => {
+  it('(a) the first runnable provider an org creates becomes its default', async () => {
     const org = await newOrg();
     await create(org.id, 'openai', 'gpt-4o-mini');
 
@@ -123,7 +112,7 @@ describe('inference provider org default', () => {
     expect(await defaultSlug(org.id)).toBe('openai');
   });
 
-  it('(e) deleting the last provider is a no-op, not a crash', async () => {
+  it('(e) deleting the last provider leaves the org without a default', async () => {
     const org = await newOrg();
     await create(org.id, 'openai', 'gpt-4o-mini');
 
@@ -163,5 +152,121 @@ describe('inference provider org default', () => {
 
     expect(await getOrgDefaultModel(orgA.id)).toBe('openai/gpt-4o-mini');
     expect(await getOrgDefaultModel(orgB.id)).toBe('z-ai/glm-4.6');
+  });
+
+  it('(i) repairs a legacy org whose live providers have no default', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await getDb()`
+      UPDATE inference_providers
+      SET is_default = false
+      WHERE organization_id = ${org.id}
+    `;
+
+    expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
+    expect(await defaultSlug(org.id)).toBe('openai');
+  });
+
+  it('(j) an OAuth provider can become the runnable org default', async () => {
+    const org = await newOrg();
+    await ensureOAuthInferenceProvider({
+      organizationId: org.id,
+      slug: 'claude',
+      kind: 'claude',
+      defaultModel: 'claude-sonnet-5',
+    });
+
+    expect(await getOrgDefaultModel(org.id)).toBe('claude/claude-sonnet-5');
+    expect(await defaultSlug(org.id)).toBe('claude');
+  });
+
+  it('(k) an explicit model resolves with a row key and static OpenAI URL', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai');
+
+    const target = await resolveCompletionTarget(org.id, 'openai/gpt-4o-mini');
+    expect(target?.baseUrl).toBeTruthy();
+    expect(target?.apiKey).toBe('sk-openai');
+    expect(target?.model).toBe('gpt-4o-mini');
+  });
+
+  it('(l) an unrunnable default is replaced by the oldest runnable provider', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await create(org.id, 'z-ai', 'glm-4.6');
+    await updateInferenceProviderCapabilities(org.id, 'openai', 'text', {});
+
+    expect(await getOrgDefaultModel(org.id)).toBe('z-ai/glm-4.6');
+    expect(await defaultSlug(org.id)).toBe('z-ai');
+  });
+
+  /**
+   * The misrouting invariant, pinned to the resolver that now owns it.
+   *
+   * Sending a request to a guessed endpoint would mis-deliver it to the wrong
+   * vendor with a model ID that vendor does not know — surfacing as a baffling
+   * "400 <model> is not a valid model ID" rather than "this provider isn't
+   * wired up". Returning null (feature skipped) is the correct failure: a
+   * missing chip beats a wrong-vendor call. Mirrors `buildDynamicOpenAIModel`
+   * in agent-worker/src/runtime/model-resolver.ts.
+   */
+  describe('misrouting invariant', () => {
+    it('(m) an unregistered provider with no row base_url does NOT resolve', async () => {
+      const org = await newOrg();
+      // `kind` matches no registered module, so there is no upstream to
+      // inherit — and it is not OpenAI, so it gets no public-endpoint default.
+      await create(org.id, 'totally-unknown-vendor', 'some-model');
+
+      expect(
+        await resolveCompletionTarget(
+          org.id,
+          'totally-unknown-vendor/some-model'
+        )
+      ).toBeNull();
+    });
+
+    it('(n) a lookalike slug does not inherit the OpenAI public endpoint', async () => {
+      const org = await newOrg();
+      await create(org.id, 'openai-lookalike', 'gpt-4o-mini');
+
+      expect(
+        await resolveCompletionTarget(org.id, 'openai-lookalike/gpt-4o-mini')
+      ).toBeNull();
+    });
+
+    it('(o) the org row base_url wins over any registered upstream', async () => {
+      const org = await newOrg();
+      const result = await createInferenceProvider({
+        organizationId: org.id,
+        slug: 'openai',
+        kind: 'openai',
+        apiKey: 'sk-tenant',
+        capabilities: {
+          text: { base_url: 'https://tenant.example/v1', model: 'gpt-4o-mini' },
+        },
+      });
+      if ('error' in result) throw new Error('unexpected conflict');
+
+      expect((await resolveCompletionTarget(org.id))?.baseUrl).toBe(
+        'https://tenant.example/v1'
+      );
+    });
+
+    it('(p) an OAuth-backed row has no API key, so it never resolves a target', async () => {
+      const org = await newOrg();
+      await ensureOAuthInferenceProvider({
+        organizationId: org.id,
+        slug: 'claude',
+        kind: 'claude',
+        defaultModel: 'claude-sonnet-5',
+      });
+
+      // It IS the org default (see (j)) — but an oauth:// ref joins to no vault
+      // secret, so the transport declines rather than sending a keyless
+      // request. Claude is also sdkCompat:"anthropic", the one non-OpenAI
+      // protocol in the registry.
+      expect(await getOrgDefaultModel(org.id)).toBe('claude/claude-sonnet-5');
+      expect(await resolveCompletionTarget(org.id)).toBeNull();
+    });
   });
 });

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -310,6 +310,48 @@ describe('inference provider org default', () => {
     expect(await defaultSlug(org.id)).toBe('openai');
   });
 
+  it('(j5) converting the DEFAULT api-key row to oauth hands off the default', async () => {
+    const org = await newOrg();
+    // `zed` is the default (created first); `openai` is an eligible successor.
+    await create(org.id, 'zed', 'zed-model');
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    expect(await defaultSlug(org.id)).toBe('zed');
+
+    // Signing in with OAuth converts the EXISTING api-key row in place. The
+    // row keeps its id and its is_default flag, but its credential becomes
+    // per-user — so it is no longer eligible to be the ORG default. Leaving
+    // the flag set would strand the org on a credential only one member can
+    // read, and promotion cannot fix it: the NOT EXISTS guard sees a default
+    // already present and no-ops.
+    await ensureOAuthInferenceProvider({
+      organizationId: org.id,
+      slug: 'zed',
+      kind: 'zed',
+      defaultModel: 'zed-model',
+    });
+
+    expect(await defaultSlug(org.id)).toBe('openai');
+    expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
+  });
+
+  it('(j6) converting the ONLY provider to oauth leaves no default at all', async () => {
+    const org = await newOrg();
+    await create(org.id, 'zed', 'zed-model');
+    expect(await defaultSlug(org.id)).toBe('zed');
+
+    // No eligible successor exists. Default-less is CORRECT here — better than
+    // a default every headless run would fail to authenticate.
+    await ensureOAuthInferenceProvider({
+      organizationId: org.id,
+      slug: 'zed',
+      kind: 'zed',
+      defaultModel: 'zed-model',
+    });
+
+    expect(await defaultSlug(org.id)).toBeNull();
+    expect(await getOrgDefaultModel(org.id)).toBeNull();
+  });
+
   it('(k) an explicit model resolves with a row key and static OpenAI URL', async () => {
     const org = await newOrg();
     await create(org.id, 'openai');

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -4,7 +4,11 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { __resetEncryptionKeyCacheForTests } from '@lobu/core';
+import {
+  __resetEncryptionKeyCacheForTests,
+  moduleRegistry,
+  type ModuleInterface,
+} from '@lobu/core';
 import {
   createInferenceProvider,
   ensureOAuthInferenceProvider,
@@ -267,6 +271,130 @@ describe('inference provider org default', () => {
       // protocol in the registry.
       expect(await getOrgDefaultModel(org.id)).toBe('claude/claude-sonnet-5');
       expect(await resolveCompletionTarget(org.id)).toBeNull();
+    });
+
+    /**
+     * The POSITIVE half of the invariant. (m)/(n) prove an unregistered
+     * provider resolves nothing; without this, a resolver that returned null
+     * for EVERYTHING would still pass them. Prod is the reason this matters:
+     * every live `inference_providers` row carries `capabilities = {}` (an API
+     * key and nothing else), so the registry upstream — not the row — is what
+     * actually routes a gateway completion for a non-OpenAI provider.
+     */
+    it('(q) a REGISTERED provider with no row base_url inherits its registry upstream', async () => {
+      const org = await newOrg();
+      await create(org.id, 'groq', 'llama-3.3-70b-versatile');
+
+      // The gateway registers config-driven provider modules at boot
+      // (core-services `initializeClaudeServices`); a bare vitest process has
+      // an empty registry, so stand one up the way that path does. Restored
+      // afterwards — the registry is process-global.
+      const registry = moduleRegistry as unknown as {
+        modules: Map<string, ModuleInterface>;
+      };
+      const saved = new Map(registry.modules);
+      try {
+        moduleRegistry.register({
+          name: 'groq-api-key',
+          isEnabled: () => true,
+          providerId: 'groq',
+          providerDisplayName: 'Groq',
+          sdkCompat: 'openai',
+          // `providerId` + `getSecretEnvVarNames` are what mark this a
+          // ModelProviderModule for getModelProviderModules()'s filter.
+          getSecretEnvVarNames: () => [],
+          getUpstreamConfig: () => ({
+            slug: 'groq',
+            upstreamBaseUrl: 'https://api.groq.com/openai/v1',
+          }),
+        } as unknown as ModuleInterface);
+
+        const target = await resolveCompletionTarget(org.id);
+        expect(target).not.toBeNull();
+        // Not a guess and not OpenAI's endpoint — groq's declared upstream.
+        expect(target?.baseUrl).toBe('https://api.groq.com/openai/v1');
+        expect(target?.model).toBe('llama-3.3-70b-versatile');
+        expect(target?.apiKey).toBe('sk-groq');
+      } finally {
+        registry.modules = saved;
+      }
+    });
+  });
+
+  /**
+   * Multi-replica correctness (AGENTS.md hard invariant). Every
+   * default-mutating path takes the same per-org `organization` row lock as its
+   * FIRST statement, so concurrent writers serialize instead of racing.
+   *
+   * What the lock actually buys, precisely: the partial unique index
+   * `inference_providers_org_default_live` already makes two live defaults
+   * IMPOSSIBLE — it would abort the second write. So the lock is not what keeps
+   * the count at one; it is what stops that abort from surfacing to a user as a
+   * failed, unrelated "add provider" call. These tests therefore assert on
+   * OUTCOMES (every concurrent call succeeds, exactly one default, org stays
+   * resolvable) rather than on the lock's existence.
+   */
+  describe('concurrency', () => {
+    it('(r) concurrent creates all succeed and yield exactly one default', async () => {
+      const org = await newOrg();
+
+      // Each of these promotes if the org has no default yet. Without
+      // serialization several can pass that check together and collide on the
+      // unique index — `create()` throws on any non-row result, so a lost race
+      // fails this test rather than silently degrading.
+      const results = await Promise.all([
+        create(org.id, 'openai', 'gpt-4o-mini'),
+        create(org.id, 'z-ai', 'glm-4.6'),
+        create(org.id, 'groq', 'llama-3.3-70b-versatile'),
+        create(org.id, 'xai', 'grok-4'),
+      ]);
+      expect(results).toHaveLength(4);
+
+      const live = await listInferenceProviders(org.id);
+      expect(live).toHaveLength(4);
+      expect(live.filter((p) => p.isDefault)).toHaveLength(1);
+      // Whichever won, the org resolves a runnable model — never null.
+      expect(await getOrgDefaultModel(org.id)).not.toBeNull();
+    });
+
+    it('(s) concurrent delete + create keeps exactly one default', async () => {
+      const org = await newOrg();
+      await create(org.id, 'openai', 'gpt-4o-mini');
+      await create(org.id, 'z-ai', 'glm-4.6');
+      expect(await defaultSlug(org.id)).toBe('openai');
+
+      // Racing the removal of THE default against a new arrival is the window
+      // where a lost update would leave the org with zero (or two) defaults.
+      await Promise.all([
+        softDeleteInferenceProvider(org.id, 'openai'),
+        create(org.id, 'groq', 'llama-3.3-70b-versatile'),
+      ]);
+
+      const live = await listInferenceProviders(org.id);
+      expect(live.filter((p) => p.isDefault)).toHaveLength(1);
+      expect(await getOrgDefaultModel(org.id)).not.toBeNull();
+    });
+
+    it('(t) concurrent lazy repairs promote once, not once per caller', async () => {
+      const org = await newOrg();
+      await create(org.id, 'openai', 'gpt-4o-mini');
+      await create(org.id, 'z-ai', 'glm-4.6');
+      // Force the legacy state every pre-fix org is in.
+      await getDb()`
+        UPDATE inference_providers
+        SET is_default = false
+        WHERE organization_id = ${org.id}
+      `;
+
+      const reads = await Promise.all(
+        Array.from({ length: 5 }, () => getOrgDefaultModel(org.id)),
+      );
+
+      // Every concurrent reader agrees, and the repair happened once.
+      expect(new Set(reads).size).toBe(1);
+      expect(reads[0]).toBe('openai/gpt-4o-mini');
+      const live = await listInferenceProviders(org.id);
+      expect(live.filter((p) => p.isDefault)).toHaveLength(1);
     });
   });
 });

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -260,7 +260,15 @@ describe('inference provider org default', () => {
     expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
   });
 
-  it('(j3) a user may still choose an OAuth provider explicitly', async () => {
+  /**
+   * An OAuth row is rejected as an EXPLICIT default too, not just an automatic
+   * one. Its credential lives in one user's `auth_profiles`
+   * (`getProviderProfiles(agentId, provider, context.userId)`), so no other
+   * member — and no headless Behavior run, which carries a synthetic user id —
+   * can read it. "The chooser holds the profile" is not enough: an org-wide
+   * default is inherited by everyone else too.
+   */
+  it('(j3) an OAuth provider is rejected as an EXPLICIT org default', async () => {
     const org = await newOrg();
     await create(org.id, 'openai', 'gpt-4o-mini');
     await ensureOAuthInferenceProvider({
@@ -270,11 +278,33 @@ describe('inference provider org default', () => {
       defaultModel: 'claude-sonnet-5',
     });
 
-    // Deliberate act by someone who holds the profile — allowed, and it must
-    // SURVIVE a subsequent resolution rather than being silently repaired away.
-    expect(await setInferenceProviderDefault(org.id, 'claude')).toBe('ok');
-    expect(await getOrgDefaultModel(org.id)).toBe('claude/claude-sonnet-5');
+    expect(await setInferenceProviderDefault(org.id, 'claude')).toBe(
+      'not_runnable',
+    );
+    // The prior, org-readable default is untouched.
+    expect(await defaultSlug(org.id)).toBe('openai');
+    expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
+  });
+
+  it('(j4) a LEGACY oauth default is demoted and replaced on read', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await ensureOAuthInferenceProvider({
+      organizationId: org.id,
+      slug: 'claude',
+      kind: 'claude',
+      defaultModel: 'claude-sonnet-5',
+    });
+    // Simulate a row written before the oauth rule existed.
+    await getDb()`
+      UPDATE inference_providers SET is_default = (slug = 'claude')
+      WHERE organization_id = ${org.id}
+    `;
     expect(await defaultSlug(org.id)).toBe('claude');
+
+    // Reading repairs it rather than handing out an unauthenticatable model.
+    expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
+    expect(await defaultSlug(org.id)).toBe('openai');
   });
 
   it('(k) an explicit model resolves with a row key and static OpenAI URL', async () => {
@@ -358,15 +388,12 @@ describe('inference provider org default', () => {
         defaultModel: 'claude-sonnet-5',
       });
 
-      // Reached the default the only legitimate way for an OAuth row: an
-      // explicit user choice (auto-promotion declines these — see (j)).
-      expect(await setInferenceProviderDefault(org.id, 'claude')).toBe('ok');
-      expect(await getOrgDefaultModel(org.id)).toBe('claude/claude-sonnet-5');
-
-      // An oauth:// ref joins to no vault secret, so the gateway transport
-      // declines rather than sending a keyless request. Claude is also
-      // sdkCompat:"anthropic", the one non-OpenAI protocol in the registry.
-      expect(await resolveCompletionTarget(org.id)).toBeNull();
+      // Even asked for BY NAME, an oauth:// ref joins to no vault secret, so the
+      // gateway transport declines rather than sending a keyless request.
+      // Claude is also sdkCompat:"anthropic", the one non-OpenAI protocol.
+      expect(
+        await resolveCompletionTarget(org.id, 'claude/claude-sonnet-5'),
+      ).toBeNull();
     });
 
     /**
@@ -377,6 +404,50 @@ describe('inference provider org default', () => {
      * key and nothing else), so the registry upstream — not the row — is what
      * actually routes a gateway completion for a non-OpenAI provider.
      */
+    /**
+     * A guardrail's `model` was historically a RAW model id posted to one
+     * operator-configured base URL. Reinterpreting every override as
+     * `<slug>/<model>` silently disabled chips for every existing value, so
+     * both forms must resolve. The distinction cannot be "does it contain a
+     * slash" — provider-native ids do (`anthropic/claude-sonnet-5`).
+     */
+    it('(q1) a BARE model override runs on the org default provider', async () => {
+      const org = await newOrg();
+      await create(org.id, 'openai', 'gpt-4o-mini');
+
+      const target = await resolveCompletionTarget(org.id, 'gpt-4.1-mini');
+      expect(target).not.toBeNull();
+      expect(target?.model).toBe('gpt-4.1-mini');
+      expect(target?.apiKey).toBe('sk-openai');
+    });
+
+    it('(q2) a provider-native override containing "/" is kept whole', async () => {
+      const org = await newOrg();
+      await create(org.id, 'openai', 'gpt-4o-mini');
+
+      // `anthropic` is not a provider row in this org, so the whole string is
+      // the model — NOT slug=anthropic. Splitting it would resolve nothing.
+      const target = await resolveCompletionTarget(
+        org.id,
+        'anthropic/claude-sonnet-5',
+      );
+      expect(target?.model).toBe('anthropic/claude-sonnet-5');
+      expect(target?.apiKey).toBe('sk-openai');
+    });
+
+    it('(q3) a qualified override still routes to THAT provider', async () => {
+      const org = await newOrg();
+      // z-ai is created FIRST, so it holds the org default; the override must
+      // move both the model and the credentials to openai.
+      await create(org.id, 'z-ai', 'glm-4.6');
+      await create(org.id, 'openai', 'gpt-4o-mini');
+      expect(await defaultSlug(org.id)).toBe('z-ai');
+
+      const target = await resolveCompletionTarget(org.id, 'openai/gpt-4.1');
+      expect(target?.model).toBe('gpt-4.1');
+      expect(target?.apiKey).toBe('sk-openai');
+    });
+
     it('(q) a REGISTERED provider with no row base_url inherits its registry upstream', async () => {
       const org = await newOrg();
       await create(org.id, 'groq', 'llama-3.3-70b-versatile');

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -160,11 +160,44 @@ describe('inference provider org default', () => {
     await create(org.id, 'openai', 'gpt-4o-mini');
     await create(org.id, 'z-ai', 'glm-4.6');
 
-    expect(await setInferenceProviderDefault(org.id, 'z-ai')).toBe(true);
+    expect(await setInferenceProviderDefault(org.id, 'z-ai')).toBe('ok');
     expect(await defaultSlug(org.id)).toBe('z-ai');
     // Exactly one default survives the switch (partial unique index).
     const providers = await listInferenceProviders(org.id);
     expect(providers.filter((p) => p.isDefault)).toHaveLength(1);
+  });
+
+  /**
+   * set-default must not report success for a choice the next read undoes.
+   *
+   * A model-less row resolves to null in `getOrgDefaultModel`, which then
+   * REPAIRS the org by demoting it and promoting a runnable row. Accepting the
+   * write would make the API claim to have stored something it immediately
+   * reverts — the CLI printed "set as org default" for a selection that was
+   * gone one request later.
+   */
+  it('(g2) set-default REJECTS a provider with no text model', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await create(org.id, 'groq'); // no text model
+
+    expect(await setInferenceProviderDefault(org.id, 'groq')).toBe(
+      'not_runnable',
+    );
+    // The prior default is untouched — a rejected write changes nothing.
+    expect(await defaultSlug(org.id)).toBe('openai');
+    expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
+  });
+
+  it('(g3) an accepted set-default survives the next resolution', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await create(org.id, 'z-ai', 'glm-4.6');
+
+    expect(await setInferenceProviderDefault(org.id, 'z-ai')).toBe('ok');
+    // The round trip is the point: resolution must NOT repair this away.
+    expect(await getOrgDefaultModel(org.id)).toBe('z-ai/glm-4.6');
+    expect(await defaultSlug(org.id)).toBe('z-ai');
   });
 
   it('(h) two orgs each keep their own default', async () => {
@@ -190,7 +223,16 @@ describe('inference provider org default', () => {
     expect(await defaultSlug(org.id)).toBe('openai');
   });
 
-  it('(j) an OAuth provider can become the runnable org default', async () => {
+  /**
+   * An OAuth row is NOT auto-promoted, even though it has a text model.
+   *
+   * OAuth credentials live in per-user `auth_profiles`; `oauth://` joins to no
+   * `agent_secrets` row, so the org-shared key reader returns null for it. A
+   * headless Behavior run carries a synthetic user id with no profile, so an
+   * OAuth org default hands every agent a model it cannot authenticate — it
+   * fails at egress instead of falling back, which is worse than no default.
+   */
+  it('(j) an OAuth provider is NOT auto-promoted to org default', async () => {
     const org = await newOrg();
     await ensureOAuthInferenceProvider({
       organizationId: org.id,
@@ -199,6 +241,38 @@ describe('inference provider org default', () => {
       defaultModel: 'claude-sonnet-5',
     });
 
+    expect(await defaultSlug(org.id)).toBeNull();
+    expect(await getOrgDefaultModel(org.id)).toBeNull();
+  });
+
+  it('(j2) an API-key provider is promoted over an older OAuth row', async () => {
+    const org = await newOrg();
+    // OAuth first, so "oldest wins" alone would pick it.
+    await ensureOAuthInferenceProvider({
+      organizationId: org.id,
+      slug: 'claude',
+      kind: 'claude',
+      defaultModel: 'claude-sonnet-5',
+    });
+    await create(org.id, 'openai', 'gpt-4o-mini');
+
+    expect(await defaultSlug(org.id)).toBe('openai');
+    expect(await getOrgDefaultModel(org.id)).toBe('openai/gpt-4o-mini');
+  });
+
+  it('(j3) a user may still choose an OAuth provider explicitly', async () => {
+    const org = await newOrg();
+    await create(org.id, 'openai', 'gpt-4o-mini');
+    await ensureOAuthInferenceProvider({
+      organizationId: org.id,
+      slug: 'claude',
+      kind: 'claude',
+      defaultModel: 'claude-sonnet-5',
+    });
+
+    // Deliberate act by someone who holds the profile — allowed, and it must
+    // SURVIVE a subsequent resolution rather than being silently repaired away.
+    expect(await setInferenceProviderDefault(org.id, 'claude')).toBe('ok');
     expect(await getOrgDefaultModel(org.id)).toBe('claude/claude-sonnet-5');
     expect(await defaultSlug(org.id)).toBe('claude');
   });
@@ -284,11 +358,14 @@ describe('inference provider org default', () => {
         defaultModel: 'claude-sonnet-5',
       });
 
-      // It IS the org default (see (j)) — but an oauth:// ref joins to no vault
-      // secret, so the transport declines rather than sending a keyless
-      // request. Claude is also sdkCompat:"anthropic", the one non-OpenAI
-      // protocol in the registry.
+      // Reached the default the only legitimate way for an OAuth row: an
+      // explicit user choice (auto-promotion declines these — see (j)).
+      expect(await setInferenceProviderDefault(org.id, 'claude')).toBe('ok');
       expect(await getOrgDefaultModel(org.id)).toBe('claude/claude-sonnet-5');
+
+      // An oauth:// ref joins to no vault secret, so the gateway transport
+      // declines rather than sending a keyless request. Claude is also
+      // sdkCompat:"anthropic", the one non-OpenAI protocol in the registry.
       expect(await resolveCompletionTarget(org.id)).toBeNull();
     });
 

--- a/packages/server/src/__tests__/integration/inference-provider-default.test.ts
+++ b/packages/server/src/__tests__/integration/inference-provider-default.test.ts
@@ -182,7 +182,7 @@ describe('inference provider org default', () => {
     await create(org.id, 'groq'); // no text model
 
     expect(await setInferenceProviderDefault(org.id, 'groq')).toBe(
-      'not_runnable',
+      'no_text_model',
     );
     // The prior default is untouched — a rejected write changes nothing.
     expect(await defaultSlug(org.id)).toBe('openai');
@@ -278,8 +278,11 @@ describe('inference provider org default', () => {
       defaultModel: 'claude-sonnet-5',
     });
 
+    // A DISTINCT reason from "no text model" — claude HAS one; the problem is
+    // that its credential belongs to a single user. The route turns each into
+    // its own message, because the fix differs.
     expect(await setInferenceProviderDefault(org.id, 'claude')).toBe(
-      'not_runnable',
+      'oauth_provider',
     );
     // The prior, org-readable default is untouched.
     expect(await defaultSlug(org.id)).toBe('openai');

--- a/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
@@ -223,8 +223,17 @@ describe("manage_agents create — env-key deployment provisions a runnable agen
 	// cases below pin both halves of the contract.
 
 	it("saveMetadata seeds provisioning defaults on a FRESH insert", async () => {
+		// Own org: this pins the NO-org-default branch of
+		// resolveNewAgentProvisioningDefaults (seed the system-key models list).
+		// The shared `orgId` can't be used — an earlier test in this file creates
+		// an `inference_providers` row there, and an org's first provider becomes
+		// its default, which correctly switches provisioning to the seed-nothing
+		// branch ("already runnable via the documented fallback").
+		const freshOrg = await createTestOrganization({
+			name: "store fresh insert",
+		});
 		const store = createPostgresAgentConfigStore();
-		await orgContext.run({ organizationId: orgId }, async () => {
+		await orgContext.run({ organizationId: freshOrg.id }, async () => {
 			await store.saveMetadata("store-fresh-bot", {
 				agentId: "store-fresh-bot",
 				name: "Store Fresh Bot",
@@ -236,10 +245,42 @@ describe("manage_agents create — env-key deployment provisions a runnable agen
 		const sql = getTestDb();
 		const rows = await sql`
 			SELECT models, pre_approved_tools FROM agents
-			WHERE organization_id = ${orgId} AND id = 'store-fresh-bot'
+			WHERE organization_id = ${freshOrg.id} AND id = 'store-fresh-bot'
 		`;
 		expect(rows[0]?.models).toContain("claude/claude-sonnet-5");
 		expect(rows[0]?.pre_approved_tools).toContain("/mcp/lobu-memory/tools/*");
+	});
+
+	it("an org WITH a default seeds no models list (inherits the fallback)", async () => {
+		// The other branch, made explicit rather than left to test ordering:
+		// once an org has a default provider the agent is already runnable, so
+		// baking a redundant models list would just pin a stale snapshot.
+		const orgWithDefault = await createTestOrganization({
+			name: "store org default",
+		});
+		await createInferenceProvider({
+			organizationId: orgWithDefault.id,
+			slug: "myco",
+			kind: "openai",
+			apiKey: "sk-test",
+			capabilities: { text: { model: "myco-large" } },
+		});
+		const store = createPostgresAgentConfigStore();
+		await orgContext.run({ organizationId: orgWithDefault.id }, async () => {
+			await store.saveMetadata("store-inherit-bot", {
+				agentId: "store-inherit-bot",
+				name: "Store Inherit Bot",
+				owner: { platform: "external", userId: "u-store" },
+				createdAt: Date.now(),
+			});
+		});
+
+		const sql = getTestDb();
+		const rows = await sql`
+			SELECT models FROM agents
+			WHERE organization_id = ${orgWithDefault.id} AND id = 'store-inherit-bot'
+		`;
+		expect(rows[0]?.models).toEqual([]);
 	});
 
 	it("a re-save does NOT clobber a curated models list or pre-approvals", async () => {

--- a/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-create-provisioning.test.ts
@@ -226,9 +226,8 @@ describe("manage_agents create — env-key deployment provisions a runnable agen
 		// Own org: this pins the NO-org-default branch of
 		// resolveNewAgentProvisioningDefaults (seed the system-key models list).
 		// The shared `orgId` can't be used — an earlier test in this file creates
-		// an `inference_providers` row there, and an org's first provider becomes
-		// its default, which correctly switches provisioning to the seed-nothing
-		// branch ("already runnable via the documented fallback").
+		// a runnable `inference_providers` row there, which becomes the org
+		// default and switches provisioning to the seed-nothing branch.
 		const freshOrg = await createTestOrganization({
 			name: "store fresh insert",
 		});

--- a/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
@@ -746,16 +746,39 @@ describe("manage_agents — model config (#2047)", () => {
 	});
 
 	it("create WITHOUT default_model and no org default ⇒ not_runnable", async () => {
+		// Needs an org with NO provider at all: the shared `orgId` has a `myco`
+		// row from beforeAll, and an org's first provider becomes its default, so
+		// that org resolves `org_default` rather than `none`.
+		const bareOrg = await createTestOrganization({ name: "no provider org" });
+		const bareOwner = await createTestUser({ email: "ma-bare-owner@test.com" });
+		await addUserToOrganization(bareOwner.id, bareOrg.id, "owner");
+
 		const res = (await executeTool(
 			"manage_agents",
 			{ action: "create", agent_id: "no-model-bot", name: "No Model" },
 			TEST_ENV,
-			ownerCtx,
+			baseCtx(bareOrg.id, bareOwner.id),
 		)) as { created: boolean; model: ModelInfo };
 		expect(res.created).toBe(true);
 		expect(res.model.source).toBe("none");
 		expect(res.model.not_runnable).toBe(true);
 		expect(res.model.effective_model).toBeNull();
+	});
+
+	it("create WITHOUT default_model but WITH an org default ⇒ runnable via org_default", async () => {
+		// The complement: the shared org has a provider (hence a default), so a
+		// model-less agent is still runnable by inheriting it. This is the branch
+		// that makes "an org's first provider is its default" worth having.
+		const res = (await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "inherit-model-bot", name: "Inherit" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { created: boolean; model: ModelInfo };
+		expect(res.created).toBe(true);
+		expect(res.model.source).toBe("org_default");
+		expect(res.model.not_runnable).toBe(false);
+		expect(res.model.effective_model).toBe("myco/myco-large");
 	});
 
 	it("create WITH a valid default_model ⇒ pinned, runnable, source 'agent'", async () => {

--- a/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
@@ -746,9 +746,9 @@ describe("manage_agents — model config (#2047)", () => {
 	});
 
 	it("create WITHOUT default_model and no org default ⇒ not_runnable", async () => {
-		// Needs an org with NO provider at all: the shared `orgId` has a `myco`
-		// row from beforeAll, and an org's first provider becomes its default, so
-		// that org resolves `org_default` rather than `none`.
+		// Needs an org with NO provider at all: the shared `orgId` has a runnable
+		// `myco` row from beforeAll, so it resolves `org_default` rather than
+		// `none`.
 		const bareOrg = await createTestOrganization({ name: "no provider org" });
 		const bareOwner = await createTestUser({ email: "ma-bare-owner@test.com" });
 		await addUserToOrganization(bareOwner.id, bareOrg.id, "owner");
@@ -766,9 +766,8 @@ describe("manage_agents — model config (#2047)", () => {
 	});
 
 	it("create WITHOUT default_model but WITH an org default ⇒ runnable via org_default", async () => {
-		// The complement: the shared org has a provider (hence a default), so a
-		// model-less agent is still runnable by inheriting it. This is the branch
-		// that makes "an org's first provider is its default" worth having.
+		// The complement: the shared org has a runnable default provider, so a
+		// model-less agent inherits it.
 		const res = (await executeTool(
 			"manage_agents",
 			{ action: "create", agent_id: "inherit-model-bot", name: "Inherit" },

--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -340,7 +340,7 @@ describe("worker model fallback (real DB, both channels)", () => {
       base_url: "https://api.byo.example.com",
       model: "byo-model",
     });
-    expect(await setInferenceProviderDefault(ORG, "byo-default")).toBe(true);
+    expect(await setInferenceProviderDefault(ORG, "byo-default")).toBe('ok');
 
     const catalog = new ProviderCatalogService(
       // Agent settings with an EMPTY models list — the exact gap.

--- a/packages/server/src/gateway/auth/oauth/__tests__/oauth-registry.test.ts
+++ b/packages/server/src/gateway/auth/oauth/__tests__/oauth-registry.test.ts
@@ -50,6 +50,9 @@ describe("OAuth registry from providers.json", () => {
     expect(ids).toContain("xai");
 
     expect(getOAuthProviderConfig("claude")?.grant).toBe("authorization-code");
+    expect(getOAuthProviderConfig("claude")?.defaultModel).toBe(
+      configs.claude?.defaultModel
+    );
     expect(getOAuthProviderConfig("chatgpt")?.grant).toBe("openai-device-auth");
     expect(getOAuthProviderConfig("xai")?.grant).toBe("device-code");
     expect(getOAuthProviderConfig("xai")?.deviceCodeUrl).toContain("auth.x.ai");

--- a/packages/server/src/gateway/auth/oauth/providers.ts
+++ b/packages/server/src/gateway/auth/oauth/providers.ts
@@ -19,6 +19,7 @@ export type OAuthGrantKind = ProviderOAuthGrantKind;
 export type OAuthProviderConfig = ProviderOAuthConfig & {
   id: string;
   name: string;
+  defaultModel?: string;
 };
 
 const logger = createLogger("oauth-provider-registry");
@@ -57,6 +58,7 @@ export function loadOAuthProvidersFromConfigs(
       ...oauth,
       id,
       name: entry.displayName || id,
+      defaultModel: entry.defaultModel,
     });
   }
   registry = next;

--- a/packages/server/src/lobu/__tests__/inference-provider-set-default-route.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-provider-set-default-route.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Route coverage for `PUT /inference-providers/:slug/default`.
+ *
+ * The store returns THREE distinct rejections and the route must turn each
+ * into an accurate, actionable message. Collapsing them was a real defect: an
+ * OAuth provider was told "no text model is configured", which is both false
+ * (it has one) and unactionable (setting a model changes nothing).
+ *
+ * Covers all three branches end-to-end through Hono, not just the store:
+ *   - missing slug            → 404
+ *   - live row, no text model → 400 "has no text model configured"
+ *   - live row, oauth:// ref  → 400 "signed in with OAuth"
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+	ensureDbForGatewayTests,
+	resetTestDatabase,
+} from "../../gateway/__tests__/helpers/db-setup.js";
+import { orgContext } from "../stores/org-context";
+import { authStash, installRouteTestMocks } from "./helpers/route-test-mocks";
+
+installRouteTestMocks();
+
+const TEST_ENCRYPTION_KEY =
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const ORG = "org-set-default";
+const USER = "u-set-default";
+
+beforeAll(async () => {
+	await ensureDbForGatewayTests();
+	process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+}, 60_000);
+
+async function importAgentRoutes() {
+	const mod = await import("../agent-routes.js");
+	return mod.agentRoutes;
+}
+
+async function seedOrg(): Promise<void> {
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${USER}, 'Test', 'sd@test', true, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+	await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG}, ${ORG}, ${ORG})
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+async function setDefault(slug: string): Promise<Response> {
+	const app = await importAgentRoutes();
+	return await app.request(
+		`/inference-providers/${encodeURIComponent(slug)}/default`,
+		{ method: "PUT" },
+	);
+}
+
+describe("PUT /inference-providers/:slug/default", () => {
+	beforeEach(async () => {
+		await resetTestDatabase();
+		await seedOrg();
+		authStash.user = {
+			id: USER,
+			name: "Test",
+			email: "sd@test",
+			emailVerified: true,
+		};
+		authStash.organizationId = ORG;
+		authStash.authSource = "session";
+		authStash.mcpAuthInfo = null;
+	});
+
+	test("a runnable API-key provider is accepted", async () => {
+		const { createInferenceProvider } = await import(
+			"../stores/provider-secrets.js"
+		);
+		await orgContext.run({ organizationId: ORG }, () =>
+			createInferenceProvider({
+				organizationId: ORG,
+				slug: "openai",
+				kind: "openai",
+				apiKey: "sk-openai",
+				capabilities: { text: { model: "gpt-4o-mini" } },
+			}),
+		);
+
+		const res = await setDefault("openai");
+		expect(res.status).toBe(200);
+		expect((await res.json()) as { isDefault: boolean }).toMatchObject({
+			isDefault: true,
+		});
+	});
+
+	test("a missing slug is 404, not a 400", async () => {
+		const res = await setDefault("does-not-exist");
+		expect(res.status).toBe(404);
+	});
+
+	test("no text model → 400 telling the caller to set one", async () => {
+		const { createInferenceProvider } = await import(
+			"../stores/provider-secrets.js"
+		);
+		await orgContext.run({ organizationId: ORG }, () =>
+			createInferenceProvider({
+				organizationId: ORG,
+				slug: "groq",
+				kind: "groq",
+				apiKey: "sk-groq",
+				capabilities: {},
+			}),
+		);
+
+		const res = await setDefault("groq");
+		expect(res.status).toBe(400);
+		const { error } = (await res.json()) as { error: string };
+		expect(error).toContain("no text model configured");
+		expect(error).toContain("set-capabilities");
+	});
+
+	test("an oauth provider → 400 explaining the credential is per-user", async () => {
+		const { ensureOAuthInferenceProvider } = await import(
+			"../stores/provider-secrets.js"
+		);
+		await orgContext.run({ organizationId: ORG }, () =>
+			ensureOAuthInferenceProvider({
+				organizationId: ORG,
+				slug: "claude",
+				kind: "claude",
+				defaultModel: "claude-sonnet-5",
+			}),
+		);
+
+		const res = await setDefault("claude");
+		expect(res.status).toBe(400);
+		const { error } = (await res.json()) as { error: string };
+		// The DISTINCT message: claude HAS a text model, so telling the caller to
+		// set one would be false and would not help.
+		expect(error).toContain("OAuth");
+		expect(error).not.toContain("no text model configured");
+	});
+});

--- a/packages/server/src/lobu/__tests__/inference-provider-set-default-route.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-provider-set-default-route.test.ts
@@ -119,10 +119,9 @@ describe("PUT /inference-providers/:slug/default", () => {
 		expect(res.status).toBe(400);
 		const { error } = (await res.json()) as { error: string };
 		expect(error).toContain("no text model configured");
-		// The remedy must name a real surface. An earlier revision pointed at
-		// `lobu providers set-capabilities`, which does not exist in the CLI —
-		// the capabilities writer is this route.
-		expect(error).toContain("/capabilities/text");
+		expect(error).toContain(
+			"lobu providers set-capability groq text --model <model>"
+		);
 	});
 
 	test("an oauth provider → 400 explaining the credential is per-user", async () => {

--- a/packages/server/src/lobu/__tests__/inference-provider-set-default-route.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-provider-set-default-route.test.ts
@@ -119,7 +119,10 @@ describe("PUT /inference-providers/:slug/default", () => {
 		expect(res.status).toBe(400);
 		const { error } = (await res.json()) as { error: string };
 		expect(error).toContain("no text model configured");
-		expect(error).toContain("set-capabilities");
+		// The remedy must name a real surface. An earlier revision pointed at
+		// `lobu providers set-capabilities`, which does not exist in the CLI —
+		// the capabilities writer is this route.
+		expect(error).toContain("/capabilities/text");
 	});
 
 	test("an oauth provider → 400 explaining the credential is per-user", async () => {

--- a/packages/server/src/lobu/__tests__/inference-provider-set-default-route.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-provider-set-default-route.test.ts
@@ -120,7 +120,7 @@ describe("PUT /inference-providers/:slug/default", () => {
 		const { error } = (await res.json()) as { error: string };
 		expect(error).toContain("no text model configured");
 		expect(error).toContain(
-			"lobu providers set-capability groq text --model <model>"
+			"lobu providers set-capability groq text --model <model>",
 		);
 	});
 

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1056,8 +1056,24 @@ routes.put("/inference-providers/:slug/default", async (c) => {
 	if (typeof orgId !== "string") return orgId;
 	const { slug } = c.req.param();
 
-	const ok = await setInferenceProviderDefault(orgId, slug);
-	if (!ok) return c.json({ error: "Provider not found" }, 404);
+	const result = await setInferenceProviderDefault(orgId, slug);
+	if (result === "not_found") {
+		return c.json({ error: "Provider not found" }, 404);
+	}
+	// A provider with no text model cannot hold the default: the next
+	// getOrgDefaultModel read would demote it and promote another row, so
+	// reporting success here would be a lie.
+	if (result === "not_runnable") {
+		return c.json(
+			{
+				error:
+					`Provider '${slug}' has no text model configured, so it cannot be ` +
+					`the org default. Set one with: lobu providers set-capabilities ` +
+					`${slug} text --model <model>`,
+			},
+			400
+		);
+	}
 	emitConfigChange(c, {
 		resourceKind: "inference-provider",
 		resourceId: slug,

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1064,14 +1064,14 @@ routes.put("/inference-providers/:slug/default", async (c) => {
 	// different reasons — and the fix differs, so the message must too.
 	if (result === "no_text_model") {
 		return c.json(
-				{
-					error:
-						`Provider '${slug}' has no text model configured, so it cannot be ` +
-						`the org default. Set one with: lobu providers set-capability ` +
-						`${slug} text --model <model>`,
-				},
-				400
-			);
+			{
+				error:
+					`Provider '${slug}' has no text model configured, so it cannot be ` +
+					`the org default. Set one with: lobu providers set-capability ` +
+					`${slug} text --model <model>`,
+			},
+			400
+		);
 	}
 	if (result === "oauth_provider") {
 		return c.json(

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1060,16 +1060,27 @@ routes.put("/inference-providers/:slug/default", async (c) => {
 	if (result === "not_found") {
 		return c.json({ error: "Provider not found" }, 404);
 	}
-	// A provider with no text model cannot hold the default: the next
-	// getOrgDefaultModel read would demote it and promote another row, so
-	// reporting success here would be a lie.
-	if (result === "not_runnable") {
+	// Both rejections mean "this row cannot hold the org default", but for
+	// different reasons — and the fix differs, so the message must too.
+	if (result === "no_text_model") {
 		return c.json(
 			{
 				error:
 					`Provider '${slug}' has no text model configured, so it cannot be ` +
 					`the org default. Set one with: lobu providers set-capabilities ` +
 					`${slug} text --model <model>`,
+			},
+			400
+		);
+	}
+	if (result === "oauth_provider") {
+		return c.json(
+			{
+				error:
+					`Provider '${slug}' is signed in with OAuth, so its credential ` +
+					`belongs to one user. An org default is inherited by every member ` +
+					`and by headless Behavior runs, which cannot read that token. Use ` +
+					`a provider added with an API key instead.`,
 			},
 			400
 		);

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1067,8 +1067,8 @@ routes.put("/inference-providers/:slug/default", async (c) => {
 			{
 				error:
 					`Provider '${slug}' has no text model configured, so it cannot be ` +
-					`the org default. Set one with: lobu providers set-capabilities ` +
-					`${slug} text --model <model>`,
+					`the org default. Set one with: PUT /inference-providers/${slug}` +
+					`/capabilities/text {"block":{"model":"<model>"}}`,
 			},
 			400
 		);

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -843,6 +843,7 @@ routes.post("/inference-providers/oauth/complete", async (c) => {
 				capabilities: provider.capabilities,
 				hasCustomUpstream: provider.hasCustomUpstream,
 				status: provider.status,
+				isDefault: provider.isDefault,
 			},
 		});
 
@@ -964,10 +965,13 @@ routes.post("/inference-providers", async (c) => {
 			capabilities: result.capabilities,
 			hasCustomUpstream: result.hasCustomUpstream,
 			status: result.status,
+			isDefault: result.isDefault,
 		},
 	});
 
 	// Never echo the key or the api_key_ref back to the caller.
+	// `isDefault` is load-bearing: the first runnable provider is auto-promoted,
+	// so a caller cannot infer it from its own request.
 	return c.json(
 		{
 			provider: {
@@ -979,6 +983,7 @@ routes.post("/inference-providers", async (c) => {
 				hasCustomUpstream: result.hasCustomUpstream,
 				status: result.status,
 				createdAt: result.createdAt,
+				isDefault: result.isDefault,
 			},
 		},
 		201

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1064,14 +1064,14 @@ routes.put("/inference-providers/:slug/default", async (c) => {
 	// different reasons — and the fix differs, so the message must too.
 	if (result === "no_text_model") {
 		return c.json(
-			{
-				error:
-					`Provider '${slug}' has no text model configured, so it cannot be ` +
-					`the org default. Set one with: PUT /inference-providers/${slug}` +
-					`/capabilities/text {"block":{"model":"<model>"}}`,
-			},
-			400
-		);
+				{
+					error:
+						`Provider '${slug}' has no text model configured, so it cannot be ` +
+						`the org default. Set one with: lobu providers set-capability ` +
+						`${slug} text --model <model>`,
+				},
+				400
+			);
 	}
 	if (result === "oauth_provider") {
 		return c.json(

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -634,6 +634,7 @@ async function ensureVisibleOAuthProvidersForUser(
 			slug: config.id,
 			kind: config.id,
 			displayName: config.name,
+			defaultModel: config.defaultModel,
 			createdBy: user.id,
 		});
 	}
@@ -827,6 +828,7 @@ routes.post("/inference-providers/oauth/complete", async (c) => {
 			slug: config.id,
 			kind: config.id,
 			displayName: config.name,
+			defaultModel: config.defaultModel,
 			createdBy: user.id,
 		});
 		emitConfigChange(c, {

--- a/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
@@ -222,7 +222,7 @@ describe('inference-provider store', () => {
     // Mark openai the default → its text model is the org default, returned as
     // a routable `slug/model` ref (the worker derives the provider from the
     // prefix; a bare model would throw "No provider specified" there).
-    expect(await setInferenceProviderDefault(ORG, 'openai')).toBe(true);
+    expect(await setInferenceProviderDefault(ORG, 'openai')).toBe('ok');
     expect(await getOrgDefaultModel(ORG)).toBe('openai/gpt-x');
     expect(
       (await listInferenceProviders(ORG)).find((p) => p.slug === 'openai')
@@ -230,7 +230,7 @@ describe('inference-provider store', () => {
     ).toBe(true);
 
     // Switching the default clears the prior one (one live default per org).
-    expect(await setInferenceProviderDefault(ORG, 'groq')).toBe(true);
+    expect(await setInferenceProviderDefault(ORG, 'groq')).toBe('ok');
     expect(await getOrgDefaultModel(ORG)).toBe('groq/llama-y');
     const after = await listInferenceProviders(ORG);
     expect(after.find((p) => p.slug === 'openai')?.isDefault).toBe(false);
@@ -249,7 +249,7 @@ describe('inference-provider store', () => {
       apiKey: 'k1',
       capabilities: { text: { model: 'anthropic/claude-sonnet-5' } },
     });
-    expect(await setInferenceProviderDefault(ORG, 'openrouter')).toBe(true);
+    expect(await setInferenceProviderDefault(ORG, 'openrouter')).toBe('ok');
     expect(await getOrgDefaultModel(ORG)).toBe(
       'openrouter/anthropic/claude-sonnet-5'
     );
@@ -263,12 +263,12 @@ describe('inference-provider store', () => {
       apiKey: 'k1',
       capabilities: { text: { model: 'openai/gpt-x' } },
     });
-    expect(await setInferenceProviderDefault(ORG, 'openai')).toBe(true);
+    expect(await setInferenceProviderDefault(ORG, 'openai')).toBe('ok');
     expect(await getOrgDefaultModel(ORG)).toBe('openai/gpt-x');
   });
 
-  it('setInferenceProviderDefault returns false for a missing slug', async () => {
-    expect(await setInferenceProviderDefault(ORG, 'does-not-exist')).toBe(false);
+  it('setInferenceProviderDefault returns not_found for a missing slug', async () => {
+    expect(await setInferenceProviderDefault(ORG, 'does-not-exist')).toBe('not_found');
   });
 
   it('setting a missing slug default does NOT clear the existing default', async () => {
@@ -279,11 +279,11 @@ describe('inference-provider store', () => {
       apiKey: 'k1',
       capabilities: { text: { model: 'gpt-x' } },
     });
-    expect(await setInferenceProviderDefault(ORG, 'openai')).toBe(true);
+    expect(await setInferenceProviderDefault(ORG, 'openai')).toBe('ok');
     expect(await getOrgDefaultModel(ORG)).toBe('openai/gpt-x');
 
     // A no-op on a missing slug must leave the current default intact.
-    expect(await setInferenceProviderDefault(ORG, 'ghost')).toBe(false);
+    expect(await setInferenceProviderDefault(ORG, 'ghost')).toBe('not_found');
     expect(await getOrgDefaultModel(ORG)).toBe('openai/gpt-x');
   });
 });

--- a/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
@@ -215,8 +215,11 @@ describe('inference-provider store', () => {
       capabilities: { text: { model: 'llama-y' } },
     });
 
-    // No default yet → no org default model.
-    expect(await getOrgDefaultModel(ORG)).toBeNull();
+    // The FIRST provider an org creates becomes its default automatically, so
+    // the org is already resolvable here — `groq`, created second, did not
+    // steal it. (Before that behaviour existed, an org could sit with zero
+    // defaults forever and every org-scoped model consumer silently no-opped.)
+    expect(await getOrgDefaultModel(ORG)).toBe('openai/gpt-x');
 
     // Mark openai the default → its text model is the org default, returned as
     // a routable `slug/model` ref (the worker derives the provider from the

--- a/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
@@ -215,10 +215,8 @@ describe('inference-provider store', () => {
       capabilities: { text: { model: 'llama-y' } },
     });
 
-    // The FIRST provider an org creates becomes its default automatically, so
-    // the org is already resolvable here — `groq`, created second, did not
-    // steal it. (Before that behaviour existed, an org could sit with zero
-    // defaults forever and every org-scoped model consumer silently no-opped.)
+    // The first runnable provider becomes the default; `groq`, created second,
+    // does not steal it.
     expect(await getOrgDefaultModel(ORG)).toBe('openai/gpt-x');
 
     // Mark openai the default → its text model is the org default, returned as

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -297,11 +297,28 @@ async function lockInferenceProviderDefaults(
  * org currently has none (the `NOT EXISTS` guard makes this idempotent, so
  * every mutating path can call it unconditionally).
  *
- * "Runnable" = carries a non-blank `capabilities.text.model`. A row without one
- * would resolve to null in `getOrgDefaultModel`, leaving the org just as
- * default-less as before while *looking* fixed. Oldest-first (`created_at`,
- * ties broken by the monotonic identity id) keeps the choice deterministic and
- * identical across replicas.
+ * "Runnable" has TWO halves, and both are load-bearing:
+ *
+ *  1. A non-blank `capabilities.text.model`. Without one the row resolves to
+ *     null in `getOrgDefaultModel`, leaving the org just as default-less as
+ *     before while *looking* fixed.
+ *
+ *  2. An org-readable credential — i.e. NOT an `oauth://` ref. OAuth
+ *     credentials live in per-user `auth_profiles` and are fetched by
+ *     `getBestProfile(agentId, providerId, …, context)`; `oauth://` joins to no
+ *     `agent_secrets` row, so `readOrgSharedProviderApiKey` returns null for
+ *     them. A headless Behavior run carries a synthetic user id with no
+ *     profile, so inheriting an OAuth row as the ORG default hands every agent
+ *     in the org a model it cannot authenticate — worse than having no default,
+ *     because it fails at egress instead of falling back. (The gateway
+ *     transport already refuses these; this keeps the run path honest too.)
+ *
+ * A user can still choose an OAuth provider explicitly via
+ * {@link setInferenceProviderDefault} — that is a deliberate act by someone who
+ * holds the profile. This guard only governs AUTOMATIC promotion.
+ *
+ * Oldest-first (`created_at`, ties broken by the monotonic identity id) keeps
+ * the choice deterministic and identical across replicas.
  */
 async function promoteOldestRunnableProvider(
 	sql: DbClient,
@@ -316,6 +333,7 @@ async function promoteOldestRunnableProvider(
 			WHERE candidate.organization_id = ${organizationId}
 			  AND candidate.deleted_at IS NULL
 			  AND NULLIF(BTRIM(candidate.capabilities #>> '{text,model}'), '') IS NOT NULL
+			  AND candidate.api_key_ref NOT LIKE 'oauth://%'
 			  AND NOT EXISTS (
 				  SELECT 1 FROM inference_providers current_default
 				  WHERE current_default.organization_id = ${organizationId}
@@ -613,6 +631,17 @@ interface OrgDefaultModelRow {
 	is_default: boolean;
 }
 
+/**
+ * The row that currently is — or should become — the org default.
+ *
+ * The flagged default always wins (`is_default DESC`), whatever its ref: an
+ * explicit `setInferenceProviderDefault` choice is a user decision this read
+ * must never second-guess. The `OR` branch exists ONLY to find a promotion
+ * candidate for an org that has no flag yet, so it applies exactly the filter
+ * {@link promoteOldestRunnableProvider} does — including the `oauth://`
+ * exclusion. Without that, a read would report an OAuth model as the org
+ * default that promotion had deliberately declined to set.
+ */
 async function readOrgDefaultCandidate(
 	sql: DbClient,
 	organizationId: string,
@@ -624,7 +653,10 @@ async function readOrgDefaultCandidate(
 		  AND deleted_at IS NULL
 		  AND (
 			  is_default
-			  OR NULLIF(BTRIM(capabilities #>> '{text,model}'), '') IS NOT NULL
+			  OR (
+				  NULLIF(BTRIM(capabilities #>> '{text,model}'), '') IS NOT NULL
+				  AND api_key_ref NOT LIKE 'oauth://%'
+			  )
 		  )
 		ORDER BY is_default DESC, created_at, id
 		LIMIT 1
@@ -693,13 +725,26 @@ export async function getOrgDefaultModel(
 /**
  * Mark one live provider as the org default (clearing any prior default in the
  * same transaction). The partial unique index guarantees at most one live
- * default per org; clearing first keeps the switch atomic. Returns false when
- * the slug has no live row.
+ * default per org; clearing first keeps the switch atomic.
+ *
+ * Rejects a target with no `capabilities.text.model` as `not_runnable` rather
+ * than committing it. Such a row cannot serve as a default: `getOrgDefaultModel`
+ * resolves it to null and then REPAIRS the org by demoting it and promoting a
+ * runnable row. Accepting the write would report success for a selection that
+ * silently reverts on the very next read — the API must not claim to have
+ * stored something it will immediately undo. An OAuth row IS accepted here:
+ * unlike automatic promotion, this is a deliberate act by a user who holds the
+ * profile (see {@link promoteOldestRunnableProvider}).
  */
+export type SetInferenceProviderDefaultResult =
+	| "ok"
+	| "not_found"
+	| "not_runnable";
+
 export async function setInferenceProviderDefault(
 	organizationId: string,
 	slug: string,
-): Promise<boolean> {
+): Promise<SetInferenceProviderDefaultResult> {
 	const sql = getDb();
 	return await sql.begin(async (tx) => {
 		await lockInferenceProviderDefaults(tx, organizationId);
@@ -708,12 +753,14 @@ export async function setInferenceProviderDefault(
 		// otherwise a missing slug would commit the clear and leave the org with
 		// no default at all.
 		const target = (await tx`
-			SELECT id FROM inference_providers
+			SELECT id, NULLIF(BTRIM(capabilities #>> '{text,model}'), '') AS text_model
+			FROM inference_providers
 			WHERE organization_id = ${organizationId}
 			  AND slug = ${slug} AND deleted_at IS NULL
 			LIMIT 1
-		`) as Array<{ id: string | number }>;
-		if (target.length === 0) return false;
+		`) as Array<{ id: string | number; text_model: string | null }>;
+		if (target.length === 0) return "not_found";
+		if (!target[0]?.text_model) return "not_runnable";
 
 		await tx`
 			UPDATE inference_providers
@@ -727,7 +774,7 @@ export async function setInferenceProviderDefault(
 			WHERE organization_id = ${organizationId}
 			  AND slug = ${slug} AND deleted_at IS NULL
 		`;
-		return true;
+		return "ok";
 	});
 }
 

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -266,7 +266,7 @@ function mapRow(r: RawInferenceProviderRow): InferenceProviderRow {
 			r.created_at instanceof Date
 				? r.created_at.toISOString()
 				: String(r.created_at),
-		isDefault: r.is_default ?? false,
+		isDefault: r.is_default,
 	};
 }
 
@@ -651,7 +651,7 @@ export async function listInferenceProviders(
 			r.created_at instanceof Date
 				? r.created_at.toISOString()
 				: String(r.created_at),
-		isDefault: r.is_default ?? false,
+		isDefault: r.is_default,
 	}));
 }
 
@@ -666,13 +666,10 @@ interface OrgDefaultModelRow {
 /**
  * The row that currently is — or should become — the org default.
  *
- * The flagged default always wins (`is_default DESC`), whatever its ref: an
- * explicit `setInferenceProviderDefault` choice is a user decision this read
- * must never second-guess. The `OR` branch exists ONLY to find a promotion
- * candidate for an org that has no flag yet, so it applies exactly the filter
- * {@link promoteOldestRunnableProvider} does — including the `oauth://`
- * exclusion. Without that, a read would report an OAuth model as the org
- * default that promotion had deliberately declined to set.
+ * A flagged row sorts first so the caller can either return it or repair it
+ * when it is no longer eligible. The `OR` branch finds a promotion candidate
+ * for an org with no usable flag, using the same model and `oauth://` filters
+ * as {@link promoteOldestRunnableProvider}.
  */
 async function readOrgDefaultCandidate(
 	sql: DbClient,

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -313,9 +313,10 @@ async function lockInferenceProviderDefaults(
  *     because it fails at egress instead of falling back. (The gateway
  *     transport already refuses these; this keeps the run path honest too.)
  *
- * A user can still choose an OAuth provider explicitly via
- * {@link setInferenceProviderDefault} — that is a deliberate act by someone who
- * holds the profile. This guard only governs AUTOMATIC promotion.
+ * {@link setInferenceProviderDefault} rejects these for the SAME reason, so an
+ * explicit choice cannot reach a state automatic promotion refuses to create.
+ * (An earlier revision allowed the explicit path, reasoning the chooser holds
+ * the profile — but an ORG-WIDE default is inherited by everyone else too.)
  *
  * Oldest-first (`created_at`, ties broken by the monotonic identity id) keeps
  * the choice deterministic and identical across replicas.
@@ -742,7 +743,8 @@ export async function getOrgDefaultModel(
  * same transaction). The partial unique index guarantees at most one live
  * default per org; clearing first keeps the switch atomic.
  *
- * Rejects two kinds of target as `not_runnable` rather than committing them:
+ * Rejects two kinds of target rather than committing them, each with its own
+ * result so the caller can explain WHY:
  *
  *  - no `capabilities.text.model`. Such a row cannot serve as a default:
  *    `getOrgDefaultModel` resolves it to null and then REPAIRS the org by
@@ -763,7 +765,10 @@ export async function getOrgDefaultModel(
 export type SetInferenceProviderDefaultResult =
 	| "ok"
 	| "not_found"
-	| "not_runnable";
+	/** Live row, but no `capabilities.text.model` to resolve. */
+	| "no_text_model"
+	/** Live row with a model, but an `oauth://` ref only one user can read. */
+	| "oauth_provider";
 
 export async function setInferenceProviderDefault(
 	organizationId: string,
@@ -790,8 +795,8 @@ export async function setInferenceProviderDefault(
 		}>;
 		const row = target[0];
 		if (!row) return "not_found";
-		if (!row.text_model) return "not_runnable";
-		if (isOAuthInferenceProviderRef(row.api_key_ref)) return "not_runnable";
+		if (!row.text_model) return "no_text_model";
+		if (isOAuthInferenceProviderRef(row.api_key_ref)) return "oauth_provider";
 
 		await tx`
 			UPDATE inference_providers

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -115,6 +115,13 @@ export interface InferenceProviderRow {
 	hasCustomUpstream: boolean;
 	status: string;
 	createdAt: string;
+	/**
+	 * Whether THIS row is the org default. Load-bearing on create: the first
+	 * runnable provider is auto-promoted, so a caller that assumed "not default
+	 * unless I asked" would report the wrong state (the CLI's `--json` output
+	 * did exactly that). Resolved inside the same transaction as the promotion.
+	 */
+	isDefault: boolean;
 }
 
 /** Typed error returned (not thrown) when a live slug already exists for the org. */
@@ -259,6 +266,7 @@ function mapRow(r: RawInferenceProviderRow): InferenceProviderRow {
 			r.created_at instanceof Date
 				? r.created_at.toISOString()
 				: String(r.created_at),
+		isDefault: r.is_default ?? false,
 	};
 }
 
@@ -298,8 +306,8 @@ async function lockInferenceProviderDefaults(
 async function promoteOldestRunnableProvider(
 	sql: DbClient,
 	organizationId: string,
-): Promise<void> {
-	await sql`
+): Promise<number | null> {
+	const promoted = (await sql`
 		UPDATE inference_providers
 		SET is_default = true, updated_at = now()
 		WHERE id = (
@@ -317,7 +325,26 @@ async function promoteOldestRunnableProvider(
 			ORDER BY candidate.created_at, candidate.id
 			LIMIT 1
 		)
-	`;
+		RETURNING id
+	`) as Array<{ id: string | number }>;
+	return promoted[0] ? Number(promoted[0].id) : null;
+}
+
+/**
+ * Stamp `isDefault` onto a row that may have just been auto-promoted.
+ *
+ * Every writer reads its row with `RETURNING` BEFORE calling
+ * {@link promoteOldestRunnableProvider}, so the returned `is_default` is stale
+ * `false` for the very row the promotion then picks. Callers publish this over
+ * the REST API and the CLI prints it, so a stale value is a lie about state the
+ * server owns — `lobu providers create --json` reported `isDefault: false` for
+ * a provider that WAS the org default.
+ */
+function withPromotion(
+	row: InferenceProviderRow,
+	promotedId: number | null,
+): InferenceProviderRow {
+	return promotedId === row.id ? { ...row, isDefault: true } : row;
 }
 
 /**
@@ -385,10 +412,13 @@ export async function createInferenceProvider(args: {
 					${apiKeyRef}, ${sql.json(capabilities)}, ${createdBy}
 				)
 				RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
-				          capabilities, has_custom_upstream, status, created_at
+				          capabilities, has_custom_upstream, status, created_at, is_default
 			`) as RawInferenceProviderRow[];
 
-			await promoteOldestRunnableProvider(tx, organizationId);
+			const promotedId = await promoteOldestRunnableProvider(
+				tx,
+				organizationId,
+			);
 
 			// Encrypt the key into the org vault under the row-unique name.
 			await tx`
@@ -398,7 +428,7 @@ export async function createInferenceProvider(args: {
 				DO UPDATE SET ciphertext = EXCLUDED.ciphertext, updated_at = now()
 			`;
 
-			return mapRow(rows[0]);
+			return withPromotion(mapRow(rows[0]), promotedId);
 		});
 	} catch (error) {
 		const msg = getErrorMessage(error);
@@ -450,7 +480,7 @@ export async function ensureOAuthInferenceProvider(args: {
 
 			const existing = (await tx`
 					SELECT id, organization_id, slug, kind, display_name, api_key_ref,
-					       capabilities, has_custom_upstream, status, created_at
+					       capabilities, has_custom_upstream, status, created_at, is_default
 					FROM inference_providers
 					WHERE organization_id = ${organizationId}
 					  AND slug = ${slug}
@@ -475,12 +505,15 @@ export async function ensureOAuthInferenceProvider(args: {
 							    updated_at = now()
 							WHERE id = ${existingRow.id}
 							RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
-							          capabilities, has_custom_upstream, status, created_at
+							          capabilities, has_custom_upstream, status, created_at, is_default
 						`) as RawInferenceProviderRow[];
 						row = updated[0] ?? existingRow;
 					}
-					await promoteOldestRunnableProvider(tx, organizationId);
-					return mapRow(row);
+					const promotedId = await promoteOldestRunnableProvider(
+						tx,
+						organizationId,
+					);
+					return withPromotion(mapRow(row), promotedId);
 				}
 
 				const apiKeyRef = oauthInferenceProviderRef(
@@ -498,10 +531,13 @@ export async function ensureOAuthInferenceProvider(args: {
 						    updated_at = now()
 						WHERE id = ${existingRow.id}
 						RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
-						          capabilities, has_custom_upstream, status, created_at
+						          capabilities, has_custom_upstream, status, created_at, is_default
 					`) as RawInferenceProviderRow[];
-				await promoteOldestRunnableProvider(tx, organizationId);
-				return mapRow(repaired[0]);
+				const promotedId = await promoteOldestRunnableProvider(
+					tx,
+					organizationId,
+				);
+				return withPromotion(mapRow(repaired[0]), promotedId);
 			}
 
 			const idRows = (await tx`
@@ -518,11 +554,14 @@ export async function ensureOAuthInferenceProvider(args: {
 					${apiKeyRef}, ${sql.json(oauthCapabilities)}::jsonb, ${createdBy}
 				)
 				RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
-				          capabilities, has_custom_upstream, status, created_at
+				          capabilities, has_custom_upstream, status, created_at, is_default
 			`) as RawInferenceProviderRow[];
 
-			await promoteOldestRunnableProvider(tx, organizationId);
-			return mapRow(rows[0]);
+			const promotedId = await promoteOldestRunnableProvider(
+				tx,
+				organizationId,
+			);
+			return withPromotion(mapRow(rows[0]), promotedId);
 		});
 	} catch (error) {
 		const msg = getErrorMessage(error);
@@ -703,7 +742,7 @@ export async function getInferenceProviderBySlug(
 	const sql = getDb();
 	const rows = (await sql`
 		SELECT id, organization_id, slug, kind, display_name, api_key_ref,
-		       capabilities, has_custom_upstream, status, created_at
+		       capabilities, has_custom_upstream, status, created_at, is_default
 		FROM inference_providers
 		WHERE organization_id = ${organizationId} AND slug = ${slug}
 		  AND deleted_at IS NULL
@@ -865,7 +904,7 @@ export async function updateInferenceProviderCapabilities(
 		WHERE organization_id = ${organizationId} AND slug = ${slug}
 		  AND deleted_at IS NULL
 		RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
-		          capabilities, has_custom_upstream, status, created_at
+		          capabilities, has_custom_upstream, status, created_at, is_default
 	`) as RawInferenceProviderRow[];
 
 	return rows[0] ? mapRow(rows[0]) : null;
@@ -891,7 +930,7 @@ export async function updateInferenceProviderCoreFields(
 		WHERE organization_id = ${organizationId} AND slug = ${slug}
 		  AND deleted_at IS NULL
 		RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
-		          capabilities, has_custom_upstream, status, created_at
+		          capabilities, has_custom_upstream, status, created_at, is_default
 	`) as RawInferenceProviderRow[];
 	return rows[0] ? mapRow(rows[0]) : null;
 }

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -528,6 +528,24 @@ export async function ensureOAuthInferenceProvider(args: {
 						`) as RawInferenceProviderRow[];
 						row = updated[0] ?? existingRow;
 					}
+					// A row that is ALREADY `oauth://` can still carry `is_default`:
+					// rows predating the demote below landed that way, and this
+					// branch returns before reaching it. Clearing here is the same
+					// load-bearing repair for the same reason — an `oauth://`
+					// credential belongs to ONE user, and promotion cannot fix the
+					// flag on its own because the NOT EXISTS guard sees a default
+					// already present and no-ops, stranding the org on a model no
+					// other member and no headless run can authenticate.
+					if (row.is_default) {
+						const demoted = (await tx`
+							UPDATE inference_providers
+							SET is_default = false, updated_at = now()
+							WHERE id = ${row.id}
+							RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
+							          capabilities, has_custom_upstream, status, created_at, is_default
+						`) as RawInferenceProviderRow[];
+						row = demoted[0] ?? row;
+					}
 					const promotedId = await promoteOldestRunnableProvider(
 						tx,
 						organizationId,

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -376,12 +376,10 @@ function withPromotion(
  * `{ error: 'slug_conflict' }` rather than throwing.
  *
  * Why (d): the org default is the tail of the layered model fallback
- * (behavior → agent → org default), so an org with no default has no
- * resolvable model at all — `getOrgDefaultModel` returns null and every
- * org-scoped model consumer silently no-ops. Marking a provider default was a
- * SEPARATE explicit call (`PUT /inference-providers/:slug/default`) that
- * nothing chained to creation, so creating a provider could leave the org
- * without a model fallback.
+ * (behavior → agent → org default), so `getOrgDefaultModel` returns null when
+ * neither a behavior nor an agent supplies a model. Marking a provider default
+ * was a SEPARATE explicit call (`PUT /inference-providers/:slug/default`) that
+ * nothing chained to creation.
  *
  * "Runnable" is load-bearing — promotion only ever considers rows that carry a
  * `capabilities.text.model`. Promoting a model-less row would hand the org a
@@ -1100,11 +1098,10 @@ export async function rotateInferenceProviderKey(
  * Returns false when no live row exists for the slug.
  *
  * Deleting THE default promotes the oldest surviving runnable provider in the
- * same transaction. Without this, removing the default silently leaves the org
- * with none — `getOrgDefaultModel` starts returning null and every org-scoped
- * model consumer no-ops, with nothing in the UI to indicate why. Promotion is
- * skipped when the deleted row was not the default, and is a no-op when it was
- * the org's last runnable provider.
+ * same transaction. Without this, removing the default makes
+ * `getOrgDefaultModel` return null until another default is chosen. Promotion
+ * is skipped when the deleted row was not the default, and is a no-op when it
+ * was the org's last runnable provider.
  */
 export async function softDeleteInferenceProvider(
 	organizationId: string,

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -15,7 +15,7 @@
  */
 
 import { createLogger, decrypt, encrypt, getErrorMessage } from "@lobu/core";
-import { getDb } from "../../db/client.js";
+import { getDb, type DbClient } from "../../db/client.js";
 
 const logger = createLogger("provider-secrets");
 
@@ -263,29 +263,84 @@ function mapRow(r: RawInferenceProviderRow): InferenceProviderRow {
 }
 
 /**
+ * Serialize every default-mutating path for ONE org by taking a row lock on
+ * its `organization` row. Multi-replica correctness: two pods creating or
+ * deleting providers concurrently would otherwise interleave the
+ * "is there a default?" read with the other's write, and both could conclude
+ * "no default exists" and promote — which the partial unique index
+ * `inference_providers_org_default_live` then surfaces to a user as a spurious
+ * conflict error on an unrelated create. Locking the parent row (never the
+ * provider rows, which the racing txn may be inserting) makes promotion
+ * read-modify-write safe. Scoped per-org, so unrelated tenants never contend.
+ */
+async function lockInferenceProviderDefaults(
+	sql: DbClient,
+	organizationId: string,
+): Promise<void> {
+	await sql`
+		SELECT id FROM organization
+		WHERE id = ${organizationId}
+		FOR UPDATE
+	`;
+}
+
+/**
+ * Promote the oldest RUNNABLE live provider to org default, but only when the
+ * org currently has none (the `NOT EXISTS` guard makes this idempotent, so
+ * every mutating path can call it unconditionally).
+ *
+ * "Runnable" = carries a non-blank `capabilities.text.model`. A row without one
+ * would resolve to null in `getOrgDefaultModel`, leaving the org just as
+ * default-less as before while *looking* fixed. Oldest-first (`created_at`,
+ * ties broken by the monotonic identity id) keeps the choice deterministic and
+ * identical across replicas.
+ */
+async function promoteOldestRunnableProvider(
+	sql: DbClient,
+	organizationId: string,
+): Promise<void> {
+	await sql`
+		UPDATE inference_providers
+		SET is_default = true, updated_at = now()
+		WHERE id = (
+			SELECT candidate.id
+			FROM inference_providers candidate
+			WHERE candidate.organization_id = ${organizationId}
+			  AND candidate.deleted_at IS NULL
+			  AND NULLIF(BTRIM(candidate.capabilities #>> '{text,model}'), '') IS NOT NULL
+			  AND NOT EXISTS (
+				  SELECT 1 FROM inference_providers current_default
+				  WHERE current_default.organization_id = ${organizationId}
+				    AND current_default.is_default
+				    AND current_default.deleted_at IS NULL
+			  )
+			ORDER BY candidate.created_at, candidate.id
+			LIMIT 1
+		)
+	`;
+}
+
+/**
  * Create one inference-provider credential for an org. Atomic: a single
  * transaction (a) mints the row id via the identity sequence, (b) derives the
  * row-unique `api_key_ref = secret://<org>/<slug>-<id>`, (c) INSERTs the row
- * with the explicit id — as the org default when it is the org's FIRST live
- * provider — and (d) encrypts the api key into `agent_secrets` under
- * `<slug>-<id>`. On a live slug collision returns a typed
+ * with the explicit id, (d) ensures the org has a runnable default, and (e)
+ * encrypts the api key into `agent_secrets` under `<slug>-<id>`. On a live slug
+ * collision returns a typed
  * `{ error: 'slug_conflict' }` rather than throwing.
  *
- * First-provider-is-default: the org default is the tail of the layered model
- * fallback (behavior → agent → org default), so an org with no default has no
+ * Why (d): the org default is the tail of the layered model fallback
+ * (behavior → agent → org default), so an org with no default has no
  * resolvable model at all — `getOrgDefaultModel` returns null and every
  * org-scoped model consumer silently no-ops. Marking a provider default was a
  * SEPARATE explicit call (`PUT /inference-providers/:slug/default`) that
- * nothing chains to creation, so in practice orgs connected a provider and
- * never got a default: as of 2026-07-28 no live prod row had `is_default`.
- * Defaulting the first one removes a required manual step that had no sensible
- * alternative answer — with one provider, it IS the default.
+ * nothing chained to creation, so creating a provider could leave the org
+ * without a model fallback.
  *
- * Safe under concurrency: the partial unique index
- * `inference_providers_org_default_live (organization_id) WHERE is_default AND
- * deleted_at IS NULL` lets Postgres, not this read, be the arbiter. Two
- * simultaneous first-creates make one commit and the other fail the index,
- * which the caller already surfaces as a conflict — never two defaults.
+ * "Runnable" is load-bearing — promotion only ever considers rows that carry a
+ * `capabilities.text.model`. Promoting a model-less row would hand the org a
+ * default that still resolves to null, which is the same silent no-op wearing
+ * a different hat.
  */
 export async function createInferenceProvider(args: {
 	organizationId: string;
@@ -311,6 +366,8 @@ export async function createInferenceProvider(args: {
 
 	try {
 		return await sql.begin(async (tx) => {
+			await lockInferenceProviderDefaults(tx, organizationId);
+
 			// Mint the id up front so it can be embedded in api_key_ref BEFORE the
 			// INSERT (BY DEFAULT identity allows the explicit id; see migration).
 			const idRows = (await tx`
@@ -320,25 +377,18 @@ export async function createInferenceProvider(args: {
 			const secretName = inferenceProviderSecretName(slug, id);
 			const apiKeyRef = `secret://${organizationId}/${secretName}`;
 
-			// Is this the org's first live provider? Read inside the txn; the
-			// partial unique index is the real arbiter under a concurrent race.
-			const existing = (await tx`
-				SELECT 1 FROM inference_providers
-				WHERE organization_id = ${organizationId} AND deleted_at IS NULL
-				LIMIT 1
-			`) as Array<{ "?column?": number }>;
-			const isFirstProvider = existing.length === 0;
-
 			const rows = (await tx`
 				INSERT INTO inference_providers
-					(id, organization_id, slug, kind, display_name, api_key_ref, capabilities, created_by, is_default)
+					(id, organization_id, slug, kind, display_name, api_key_ref, capabilities, created_by)
 				VALUES (
 					${id}, ${organizationId}, ${slug}, ${kind}, ${displayName},
-					${apiKeyRef}, ${sql.json(capabilities)}, ${createdBy}, ${isFirstProvider}
+					${apiKeyRef}, ${sql.json(capabilities)}, ${createdBy}
 				)
 				RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
 				          capabilities, has_custom_upstream, status, created_at
 			`) as RawInferenceProviderRow[];
+
+			await promoteOldestRunnableProvider(tx, organizationId);
 
 			// Encrypt the key into the org vault under the row-unique name.
 			await tx`
@@ -378,6 +428,7 @@ export async function ensureOAuthInferenceProvider(args: {
 	slug: string;
 	kind: string;
 	displayName?: string | null;
+	defaultModel?: string | null;
 	createdBy?: string | null;
 }): Promise<InferenceProviderRow> {
 	const {
@@ -385,12 +436,18 @@ export async function ensureOAuthInferenceProvider(args: {
 		slug,
 		kind,
 		displayName = null,
+		defaultModel = null,
 		createdBy = null,
 	} = args;
 	const sql = getDb();
+	const oauthCapabilities: InferenceCapabilities = defaultModel
+		? { text: { model: defaultModel } }
+		: {};
 
 	try {
 		return await sql.begin(async (tx) => {
+			await lockInferenceProviderDefaults(tx, organizationId);
+
 			const existing = (await tx`
 					SELECT id, organization_id, slug, kind, display_name, api_key_ref,
 					       capabilities, has_custom_upstream, status, created_at
@@ -403,7 +460,27 @@ export async function ensureOAuthInferenceProvider(args: {
 			const existingRow = existing[0];
 			if (existingRow) {
 				if (isOAuthInferenceProviderRef(existingRow.api_key_ref)) {
-					return mapRow(existingRow);
+					let row = existingRow;
+					if (
+						defaultModel &&
+						!existingRow.capabilities?.text?.model?.trim()
+					) {
+						const updated = (await tx`
+							UPDATE inference_providers
+							SET capabilities = capabilities || jsonb_build_object(
+								'text',
+								COALESCE(capabilities -> 'text', '{}'::jsonb) ||
+									jsonb_build_object('model', ${defaultModel}::text)
+							),
+							    updated_at = now()
+							WHERE id = ${existingRow.id}
+							RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
+							          capabilities, has_custom_upstream, status, created_at
+						`) as RawInferenceProviderRow[];
+						row = updated[0] ?? existingRow;
+					}
+					await promoteOldestRunnableProvider(tx, organizationId);
+					return mapRow(row);
 				}
 
 				const apiKeyRef = oauthInferenceProviderRef(
@@ -416,13 +493,14 @@ export async function ensureOAuthInferenceProvider(args: {
 						SET kind = ${kind},
 						    display_name = COALESCE(${displayName}, display_name),
 						    api_key_ref = ${apiKeyRef},
-						    capabilities = '{}'::jsonb,
+						    capabilities = ${sql.json(oauthCapabilities)}::jsonb,
 						    created_by = COALESCE(created_by, ${createdBy}),
 						    updated_at = now()
 						WHERE id = ${existingRow.id}
 						RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
 						          capabilities, has_custom_upstream, status, created_at
 					`) as RawInferenceProviderRow[];
+				await promoteOldestRunnableProvider(tx, organizationId);
 				return mapRow(repaired[0]);
 			}
 
@@ -437,12 +515,13 @@ export async function ensureOAuthInferenceProvider(args: {
 					(id, organization_id, slug, kind, display_name, api_key_ref, capabilities, created_by)
 				VALUES (
 					${id}, ${organizationId}, ${slug}, ${kind}, ${displayName},
-					${apiKeyRef}, '{}'::jsonb, ${createdBy}
+					${apiKeyRef}, ${sql.json(oauthCapabilities)}::jsonb, ${createdBy}
 				)
 				RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
 				          capabilities, has_custom_upstream, status, created_at
 			`) as RawInferenceProviderRow[];
 
+			await promoteOldestRunnableProvider(tx, organizationId);
 			return mapRow(rows[0]);
 		});
 	} catch (error) {
@@ -488,40 +567,88 @@ export async function listInferenceProviders(
 	}));
 }
 
+interface OrgDefaultModelRow {
+	id: string | number;
+	slug: string;
+	capabilities: InferenceCapabilities;
+	is_default: boolean;
+}
+
+async function readOrgDefaultCandidate(
+	sql: DbClient,
+	organizationId: string,
+): Promise<OrgDefaultModelRow | null> {
+	const rows = (await sql`
+		SELECT id, slug, capabilities, is_default
+		FROM inference_providers
+		WHERE organization_id = ${organizationId}
+		  AND deleted_at IS NULL
+		  AND (
+			  is_default
+			  OR NULLIF(BTRIM(capabilities #>> '{text,model}'), '') IS NOT NULL
+		  )
+		ORDER BY is_default DESC, created_at, id
+		LIMIT 1
+	`) as OrgDefaultModelRow[];
+	return rows[0] ?? null;
+}
+
+function modelRefFromDefaultRow(row: OrgDefaultModelRow | null): string | null {
+	const model = row?.capabilities?.text?.model?.trim();
+	if (!model || !row?.slug) return null;
+	return model.startsWith(`${row.slug}/`) ? model : `${row.slug}/${model}`;
+}
+
 /**
- * The org's default model — the fallback tail of `behavior → agent → org`. Reads
- * the `is_default` inference-provider row and returns a ROUTABLE `slug/model`
- * ref built from the row's slug + text-modality model (`capabilities.text.model`),
- * or null when the org has no default (or the default row carries no text model).
+ * The org's default model — the fallback tail of `behavior → agent → org` —
+ * as a ROUTABLE `slug/model` ref, or null when the org has nothing runnable.
  *
  * The `slug/` prefix is load-bearing: the worker derives the provider from a
- * model ref's first segment (`model-resolver.ts` auto path). A bare model like
- * `gpt-4o` throws "No provider specified" there, so an agent with no installed
- * providers (the exact case the org default exists to serve) could never route
- * a bare org default. Returning `openai/gpt-4o` lets the worker route it with no
- * installed-provider module. Callers fall through to the worker's hard "no model
- * resolved" error only when this is null.
+ * model ref's first segment (`model-resolver.ts` auto path), so a bare `gpt-4o`
+ * throws "No provider specified" there. Checking for a bare `/` would be wrong
+ * — provider-native ids often contain slashes (openrouter
+ * `anthropic/claude-sonnet-5`) — so only an existing `${slug}/…` is left alone.
+ *
+ * SELF-HEALING, because the writers alone cannot fix history. Orgs that
+ * predate first-provider-is-default (and orgs whose only flagged default was
+ * later soft-deleted) would otherwise stay default-less forever. Two repairs
+ * happen under the org lock:
+ *   - no flagged default at all ⇒ promote the oldest runnable provider;
+ *   - a flagged default that is NOT runnable (no `capabilities.text.model`)
+ *     ⇒ demote it, then promote a runnable one. Leaving it would keep
+ *     returning null while the UI showed a default, which is the confusing
+ *     half of the bug.
+ * The fast path (a runnable flagged default) never opens a transaction.
  */
 export async function getOrgDefaultModel(
 	organizationId: string,
 ): Promise<string | null> {
 	const sql = getDb();
-	const rows = (await sql`
-		SELECT slug, capabilities
-		FROM inference_providers
-		WHERE organization_id = ${organizationId}
-		  AND is_default AND deleted_at IS NULL
-		LIMIT 1
-	`) as Array<{ slug: string; capabilities: InferenceCapabilities }>;
-	const row = rows[0];
-	const model = row?.capabilities?.text?.model?.trim();
-	if (!model || !row?.slug) return null;
-	// Prefix with the provider slug unless it's ALREADY prefixed with THIS
-	// slug. Checking for a bare `/` is wrong: provider-native model ids often
-	// contain slashes (openrouter `anthropic/claude-sonnet-5`, nvidia
-	// `nvidia/moonshotai/kimi-k2.6`), and returning those bare would misroute
-	// them to the wrong provider. Only `${slug}/…` is already routable.
-	return model.startsWith(`${row.slug}/`) ? model : `${row.slug}/${model}`;
+	const current = await readOrgDefaultCandidate(sql, organizationId);
+	if (!current) return null;
+	const currentModel = modelRefFromDefaultRow(current);
+	if (current.is_default && currentModel) return currentModel;
+
+	return await sql.begin(async (tx) => {
+		await lockInferenceProviderDefaults(tx, organizationId);
+		const afterLock = await readOrgDefaultCandidate(tx, organizationId);
+		if (!afterLock) return null;
+		const afterLockModel = modelRefFromDefaultRow(afterLock);
+		if (afterLock.is_default && afterLockModel) return afterLockModel;
+
+		if (afterLock.is_default) {
+			await tx`
+				UPDATE inference_providers
+				SET is_default = false, updated_at = now()
+				WHERE id = ${afterLock.id}
+			`;
+		}
+
+		await promoteOldestRunnableProvider(tx, organizationId);
+		return modelRefFromDefaultRow(
+			await readOrgDefaultCandidate(tx, organizationId),
+		);
+	});
 }
 
 /**
@@ -536,6 +663,8 @@ export async function setInferenceProviderDefault(
 ): Promise<boolean> {
 	const sql = getDb();
 	return await sql.begin(async (tx) => {
+		await lockInferenceProviderDefaults(tx, organizationId);
+
 		// Confirm the target exists BEFORE clearing the current default —
 		// otherwise a missing slug would commit the clear and leave the org with
 		// no default at all.
@@ -656,6 +785,59 @@ export async function resolveInferenceProviderConfig(
 	};
 }
 
+interface ResolvedInferenceProviderCredential {
+	kind: string;
+	baseUrl?: string;
+	apiKey?: string;
+}
+
+/**
+ * Resolve a provider row's credential even when it has no modality override.
+ * The base URL and ciphertext come from one read so a concurrent capability
+ * edit cannot pair a tenant URL with a key read from a different row state.
+ */
+export async function resolveInferenceProviderCredential(
+	organizationId: string,
+	slug: string,
+	modality: InferenceModality,
+): Promise<ResolvedInferenceProviderCredential | null> {
+	const sql = getDb();
+	const rows = (await sql`
+		SELECT p.kind, p.capabilities -> ${modality} AS block, s.ciphertext
+		FROM inference_providers p
+		LEFT JOIN agent_secrets s
+		  ON s.organization_id = p.organization_id
+		 AND ('secret://' || p.organization_id || '/' || s.name) = p.api_key_ref
+		 AND (s.expires_at IS NULL OR s.expires_at > now())
+		WHERE p.organization_id = ${organizationId} AND p.slug = ${slug}
+		  AND p.deleted_at IS NULL
+		LIMIT 1
+	`) as Array<{
+		kind: string;
+		block: InferenceCapabilityBlock | null;
+		ciphertext: string | null;
+	}>;
+	const row = rows[0];
+	if (!row) return null;
+
+	let apiKey: string | undefined;
+	if (row.ciphertext) {
+		try {
+			apiKey = decrypt(row.ciphertext);
+		} catch (error) {
+			logger.warn(
+				`Failed to decrypt inference-provider key for ${organizationId}/${slug}: ${getErrorMessage(error)}`,
+			);
+		}
+	}
+
+	return {
+		kind: row.kind,
+		baseUrl: row.block?.base_url,
+		apiKey,
+	};
+}
+
 /**
  * Merge (never clobber) one modality's block into `capabilities`:
  * `capabilities || jsonb_build_object(<modality>, <block>)`, so a concurrent
@@ -768,14 +950,12 @@ export async function rotateInferenceProviderKey(
  * recreate mints a fresh id so it never inherits this row's ciphertext.
  * Returns false when no live row exists for the slug.
  *
- * Deleting THE default promotes the oldest surviving live provider in the same
- * transaction. Without this, removing the default silently leaves the org with
- * none — `getOrgDefaultModel` starts returning null and every org-scoped model
- * consumer no-ops, with nothing in the UI to indicate why. Prod shows this is
- * the real failure mode, not a hypothetical: the only `is_default` row found
- * there (2026-07-28) was soft-deleted, leaving every org default-less.
- * Promotion is skipped when the deleted row was not the default, and is a no-op
- * when it was the org's last provider.
+ * Deleting THE default promotes the oldest surviving runnable provider in the
+ * same transaction. Without this, removing the default silently leaves the org
+ * with none — `getOrgDefaultModel` starts returning null and every org-scoped
+ * model consumer no-ops, with nothing in the UI to indicate why. Promotion is
+ * skipped when the deleted row was not the default, and is a no-op when it was
+ * the org's last runnable provider.
  */
 export async function softDeleteInferenceProvider(
 	organizationId: string,
@@ -783,6 +963,8 @@ export async function softDeleteInferenceProvider(
 ): Promise<boolean> {
 	const sql = getDb();
 	return await sql.begin(async (tx) => {
+		await lockInferenceProviderDefaults(tx, organizationId);
+
 		const rows = (await tx`
 			UPDATE inference_providers
 			SET deleted_at = now(), updated_at = now()
@@ -793,18 +975,7 @@ export async function softDeleteInferenceProvider(
 		if (rows.length === 0) return false;
 		if (!rows[0]?.is_default) return true;
 
-		// Oldest-first so promotion is deterministic and stable across replicas
-		// (`created_at` ties broken by the monotonic identity id).
-		await tx`
-			UPDATE inference_providers
-			SET is_default = true, updated_at = now()
-			WHERE id = (
-				SELECT id FROM inference_providers
-				WHERE organization_id = ${organizationId} AND deleted_at IS NULL
-				ORDER BY created_at, id
-				LIMIT 1
-			)
-		`;
+		await promoteOldestRunnableProvider(tx, organizationId);
 		return true;
 	});
 }
@@ -919,57 +1090,4 @@ export async function readOrgSharedProviderApiKey(
 		);
 		return null;
 	}
-}
-
-interface ResolvedInferenceProviderCredential {
-	kind: string;
-	baseUrl?: string;
-	apiKey?: string;
-}
-
-/**
- * Resolve a provider row's credential even when it has no modality override.
- * The base URL and ciphertext come from one read so a concurrent capability
- * edit cannot pair a tenant URL with a key read from a different row state.
- */
-export async function resolveInferenceProviderCredential(
-	organizationId: string,
-	slug: string,
-	modality: InferenceModality,
-): Promise<ResolvedInferenceProviderCredential | null> {
-	const sql = getDb();
-	const rows = (await sql`
-		SELECT p.kind, p.capabilities -> ${modality} AS block, s.ciphertext
-		FROM inference_providers p
-		LEFT JOIN agent_secrets s
-		  ON s.organization_id = p.organization_id
-		 AND ('secret://' || p.organization_id || '/' || s.name) = p.api_key_ref
-		 AND (s.expires_at IS NULL OR s.expires_at > now())
-		WHERE p.organization_id = ${organizationId} AND p.slug = ${slug}
-		  AND p.deleted_at IS NULL
-		LIMIT 1
-	`) as Array<{
-		kind: string;
-		block: InferenceCapabilityBlock | null;
-		ciphertext: string | null;
-	}>;
-	const row = rows[0];
-	if (!row) return null;
-
-	let apiKey: string | undefined;
-	if (row.ciphertext) {
-		try {
-			apiKey = decrypt(row.ciphertext);
-		} catch (error) {
-			logger.warn(
-				`Failed to decrypt inference-provider key for ${organizationId}/${slug}: ${getErrorMessage(error)}`,
-			);
-		}
-	}
-
-	return {
-		kind: row.kind,
-		baseUrl: row.block?.base_url,
-		apiKey,
-	};
 }

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -540,6 +540,17 @@ export async function ensureOAuthInferenceProvider(args: {
 					slug,
 					existingRow.id,
 				);
+				// Clearing `is_default` is load-bearing, not tidiness. This row is
+				// becoming `oauth://`, which {@link promoteOldestRunnableProvider}
+				// and {@link setInferenceProviderDefault} both refuse as an org
+				// default — its credential belongs to ONE user. Keeping the flag
+				// would strand the org on a model no other member and no headless
+				// Behavior run can authenticate, and promotion could not repair it:
+				// the NOT EXISTS guard sees a default already present and no-ops.
+				// Clearing first lets the promotion below hand off to an eligible
+				// row, or leave the org default-less when none exists — which is
+				// the correct outcome, since a default that always fails at egress
+				// is worse than none.
 				const repaired = (await tx`
 						UPDATE inference_providers
 						SET kind = ${kind},
@@ -547,6 +558,7 @@ export async function ensureOAuthInferenceProvider(args: {
 						    api_key_ref = ${apiKeyRef},
 						    capabilities = ${sql.json(oauthCapabilities)}::jsonb,
 						    created_by = COALESCE(created_by, ${createdBy}),
+						    is_default = false,
 						    updated_at = now()
 						WHERE id = ${existingRow.id}
 						RETURNING id, organization_id, slug, kind, display_name, api_key_ref,

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -629,6 +629,7 @@ interface OrgDefaultModelRow {
 	slug: string;
 	capabilities: InferenceCapabilities;
 	is_default: boolean;
+	api_key_ref: string;
 }
 
 /**
@@ -647,7 +648,7 @@ async function readOrgDefaultCandidate(
 	organizationId: string,
 ): Promise<OrgDefaultModelRow | null> {
 	const rows = (await sql`
-		SELECT id, slug, capabilities, is_default
+		SELECT id, slug, capabilities, is_default, api_key_ref
 		FROM inference_providers
 		WHERE organization_id = ${organizationId}
 		  AND deleted_at IS NULL
@@ -664,9 +665,22 @@ async function readOrgDefaultCandidate(
 	return rows[0] ?? null;
 }
 
+/**
+ * Can this row serve as the ORG-wide default? One predicate, used by the read
+ * path and mirrored by the promotion SQL, so a read can never repair away what
+ * a write just accepted. Both halves are required: a model to resolve, and a
+ * credential every member (and every headless run) can actually read.
+ */
+function isOrgDefaultEligible(row: OrgDefaultModelRow | null): boolean {
+	if (!row?.slug) return false;
+	if (!row.capabilities?.text?.model?.trim()) return false;
+	return !isOAuthInferenceProviderRef(row.api_key_ref);
+}
+
 function modelRefFromDefaultRow(row: OrgDefaultModelRow | null): string | null {
-	const model = row?.capabilities?.text?.model?.trim();
-	if (!model || !row?.slug) return null;
+	if (!isOrgDefaultEligible(row) || !row) return null;
+	const model = row.capabilities?.text?.model?.trim();
+	if (!model) return null;
 	return model.startsWith(`${row.slug}/`) ? model : `${row.slug}/${model}`;
 }
 
@@ -685,10 +699,11 @@ function modelRefFromDefaultRow(row: OrgDefaultModelRow | null): string | null {
  * later soft-deleted) would otherwise stay default-less forever. Two repairs
  * happen under the org lock:
  *   - no flagged default at all ⇒ promote the oldest runnable provider;
- *   - a flagged default that is NOT runnable (no `capabilities.text.model`)
- *     ⇒ demote it, then promote a runnable one. Leaving it would keep
- *     returning null while the UI showed a default, which is the confusing
- *     half of the bug.
+ *   - a flagged default that is NOT eligible — no `capabilities.text.model`,
+ *     or an `oauth://` ref whose credential only one user can read ⇒ demote it,
+ *     then promote an eligible one. Leaving it would keep returning null while
+ *     the UI showed a default, which is the confusing half of the bug. The
+ *     OAuth case also repairs rows written before that rule existed.
  * The fast path (a runnable flagged default) never opens a transaction.
  */
 export async function getOrgDefaultModel(
@@ -727,14 +742,23 @@ export async function getOrgDefaultModel(
  * same transaction). The partial unique index guarantees at most one live
  * default per org; clearing first keeps the switch atomic.
  *
- * Rejects a target with no `capabilities.text.model` as `not_runnable` rather
- * than committing it. Such a row cannot serve as a default: `getOrgDefaultModel`
- * resolves it to null and then REPAIRS the org by demoting it and promoting a
- * runnable row. Accepting the write would report success for a selection that
- * silently reverts on the very next read — the API must not claim to have
- * stored something it will immediately undo. An OAuth row IS accepted here:
- * unlike automatic promotion, this is a deliberate act by a user who holds the
- * profile (see {@link promoteOldestRunnableProvider}).
+ * Rejects two kinds of target as `not_runnable` rather than committing them:
+ *
+ *  - no `capabilities.text.model`. Such a row cannot serve as a default:
+ *    `getOrgDefaultModel` resolves it to null and then REPAIRS the org by
+ *    demoting it and promoting a runnable row. Accepting the write would
+ *    report success for a selection that silently reverts on the very next
+ *    read — the API must not claim to have stored something it will undo.
+ *
+ *  - an `oauth://` row. Its credential lives in ONE user's `auth_profiles` and
+ *    is fetched with `getProviderProfiles(agentId, provider, context.userId)`,
+ *    so no other member of the org — and no headless Behavior run, which
+ *    carries a synthetic user id — can read it. An ORG-WIDE default backed by
+ *    one person's token hands everyone else a model they cannot authenticate.
+ *    Being a deliberate choice does not help: the chooser is not the only one
+ *    who has to run on it. Same reason automatic promotion skips these (see
+ *    {@link promoteOldestRunnableProvider}); the two paths must agree, or a
+ *    read repairs away what a write just accepted.
  */
 export type SetInferenceProviderDefaultResult =
 	| "ok"
@@ -753,14 +777,21 @@ export async function setInferenceProviderDefault(
 		// otherwise a missing slug would commit the clear and leave the org with
 		// no default at all.
 		const target = (await tx`
-			SELECT id, NULLIF(BTRIM(capabilities #>> '{text,model}'), '') AS text_model
+			SELECT id, api_key_ref,
+			       NULLIF(BTRIM(capabilities #>> '{text,model}'), '') AS text_model
 			FROM inference_providers
 			WHERE organization_id = ${organizationId}
 			  AND slug = ${slug} AND deleted_at IS NULL
 			LIMIT 1
-		`) as Array<{ id: string | number; text_model: string | null }>;
-		if (target.length === 0) return "not_found";
-		if (!target[0]?.text_model) return "not_runnable";
+		`) as Array<{
+			id: string | number;
+			api_key_ref: string;
+			text_model: string | null;
+		}>;
+		const row = target[0];
+		if (!row) return "not_found";
+		if (!row.text_model) return "not_runnable";
+		if (isOAuthInferenceProviderRef(row.api_key_ref)) return "not_runnable";
 
 		await tx`
 			UPDATE inference_providers

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -266,9 +266,26 @@ function mapRow(r: RawInferenceProviderRow): InferenceProviderRow {
  * Create one inference-provider credential for an org. Atomic: a single
  * transaction (a) mints the row id via the identity sequence, (b) derives the
  * row-unique `api_key_ref = secret://<org>/<slug>-<id>`, (c) INSERTs the row
- * with the explicit id, and (d) encrypts the api key into `agent_secrets` under
+ * with the explicit id — as the org default when it is the org's FIRST live
+ * provider — and (d) encrypts the api key into `agent_secrets` under
  * `<slug>-<id>`. On a live slug collision returns a typed
  * `{ error: 'slug_conflict' }` rather than throwing.
+ *
+ * First-provider-is-default: the org default is the tail of the layered model
+ * fallback (behavior → agent → org default), so an org with no default has no
+ * resolvable model at all — `getOrgDefaultModel` returns null and every
+ * org-scoped model consumer silently no-ops. Marking a provider default was a
+ * SEPARATE explicit call (`PUT /inference-providers/:slug/default`) that
+ * nothing chains to creation, so in practice orgs connected a provider and
+ * never got a default: as of 2026-07-28 no live prod row had `is_default`.
+ * Defaulting the first one removes a required manual step that had no sensible
+ * alternative answer — with one provider, it IS the default.
+ *
+ * Safe under concurrency: the partial unique index
+ * `inference_providers_org_default_live (organization_id) WHERE is_default AND
+ * deleted_at IS NULL` lets Postgres, not this read, be the arbiter. Two
+ * simultaneous first-creates make one commit and the other fail the index,
+ * which the caller already surfaces as a conflict — never two defaults.
  */
 export async function createInferenceProvider(args: {
 	organizationId: string;
@@ -303,12 +320,21 @@ export async function createInferenceProvider(args: {
 			const secretName = inferenceProviderSecretName(slug, id);
 			const apiKeyRef = `secret://${organizationId}/${secretName}`;
 
+			// Is this the org's first live provider? Read inside the txn; the
+			// partial unique index is the real arbiter under a concurrent race.
+			const existing = (await tx`
+				SELECT 1 FROM inference_providers
+				WHERE organization_id = ${organizationId} AND deleted_at IS NULL
+				LIMIT 1
+			`) as Array<{ "?column?": number }>;
+			const isFirstProvider = existing.length === 0;
+
 			const rows = (await tx`
 				INSERT INTO inference_providers
-					(id, organization_id, slug, kind, display_name, api_key_ref, capabilities, created_by)
+					(id, organization_id, slug, kind, display_name, api_key_ref, capabilities, created_by, is_default)
 				VALUES (
 					${id}, ${organizationId}, ${slug}, ${kind}, ${displayName},
-					${apiKeyRef}, ${sql.json(capabilities)}, ${createdBy}
+					${apiKeyRef}, ${sql.json(capabilities)}, ${createdBy}, ${isFirstProvider}
 				)
 				RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
 				          capabilities, has_custom_upstream, status, created_at
@@ -741,20 +767,46 @@ export async function rotateInferenceProviderKey(
  * api_key_ref unique index keeps the `<slug>-<id>` name reserved, and a
  * recreate mints a fresh id so it never inherits this row's ciphertext.
  * Returns false when no live row exists for the slug.
+ *
+ * Deleting THE default promotes the oldest surviving live provider in the same
+ * transaction. Without this, removing the default silently leaves the org with
+ * none — `getOrgDefaultModel` starts returning null and every org-scoped model
+ * consumer no-ops, with nothing in the UI to indicate why. Prod shows this is
+ * the real failure mode, not a hypothetical: the only `is_default` row found
+ * there (2026-07-28) was soft-deleted, leaving every org default-less.
+ * Promotion is skipped when the deleted row was not the default, and is a no-op
+ * when it was the org's last provider.
  */
 export async function softDeleteInferenceProvider(
 	organizationId: string,
 	slug: string,
 ): Promise<boolean> {
 	const sql = getDb();
-	const rows = (await sql`
-		UPDATE inference_providers
-		SET deleted_at = now(), updated_at = now()
-		WHERE organization_id = ${organizationId} AND slug = ${slug}
-		  AND deleted_at IS NULL
-		RETURNING id
-	`) as Array<{ id: string | number }>;
-	return rows.length > 0;
+	return await sql.begin(async (tx) => {
+		const rows = (await tx`
+			UPDATE inference_providers
+			SET deleted_at = now(), updated_at = now()
+			WHERE organization_id = ${organizationId} AND slug = ${slug}
+			  AND deleted_at IS NULL
+			RETURNING id, is_default
+		`) as Array<{ id: string | number; is_default: boolean }>;
+		if (rows.length === 0) return false;
+		if (!rows[0]?.is_default) return true;
+
+		// Oldest-first so promotion is deterministic and stable across replicas
+		// (`created_at` ties broken by the monotonic identity id).
+		await tx`
+			UPDATE inference_providers
+			SET is_default = true, updated_at = now()
+			WHERE id = (
+				SELECT id FROM inference_providers
+				WHERE organization_id = ${organizationId} AND deleted_at IS NULL
+				ORDER BY created_at, id
+				LIMIT 1
+			)
+		`;
+		return true;
+	});
 }
 
 /**

--- a/scripts/__tests__/check-gateway-llm-calls.test.ts
+++ b/scripts/__tests__/check-gateway-llm-calls.test.ts
@@ -119,6 +119,22 @@ describe("check-gateway-llm-calls", () => {
     expect(runGuard()).toBe(1);
   });
 
+  it("ignores comments inside formatter-split statements", () => {
+    create(
+      `import {\n` +
+        `  // This local adapter is intentionally not "openai".\n` +
+        `  request,\n` +
+        `} from "./request";\n` +
+        `export async function probe(url: string) {\n` +
+        `  return fetch(\n` +
+        `    url, // This does not call /chat/completions.\n` +
+        `    { method: "GET" },\n` +
+        `  );\n` +
+        `}\n`
+    );
+    expect(runGuard()).toBe(0);
+  });
+
   it("still ignores prose that merely mentions a completions path", () => {
     create(
       `// Historical note: this used to POST to /chat/completions directly.\n` +

--- a/scripts/__tests__/check-gateway-llm-calls.test.ts
+++ b/scripts/__tests__/check-gateway-llm-calls.test.ts
@@ -90,6 +90,35 @@ describe("check-gateway-llm-calls", () => {
     expect(runGuard()).toBe(1);
   });
 
+  /**
+   * Regression: the guard used to inspect single physical lines, but
+   * prettier/biome split any call over the print width — so the most likely
+   * real-world shape put `fetch(` and the URL on different lines, and no line
+   * held both. The merged gate returned exit 0 on exactly these two fixtures
+   * (verified against origin/main before `statementText()` landed).
+   */
+  it("fails on a formatter-split completions fetch", () => {
+    create(
+      `export async function probe(u: string) {\n` +
+        `  return fetch(\n` +
+        `    \`\${u}/chat/completions\`,\n` +
+        `    { method: "POST" },\n` +
+        `  );\n` +
+        `}\n`
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("fails on a formatter-split vendor SDK import", () => {
+    create(
+      `import {\n` +
+        `  Anthropic,\n` +
+        `} from "@anthropic-ai/sdk";\n` +
+        `export default Anthropic;\n`
+    );
+    expect(runGuard()).toBe(1);
+  });
+
   it("still ignores prose that merely mentions a completions path", () => {
     create(
       `// Historical note: this used to POST to /chat/completions directly.\n` +

--- a/scripts/__tests__/check-gateway-llm-calls.test.ts
+++ b/scripts/__tests__/check-gateway-llm-calls.test.ts
@@ -143,6 +143,18 @@ describe("check-gateway-llm-calls", () => {
     expect(runGuard()).toBe(0);
   });
 
+  it("ignores inline and multiline block comments inside statements", () => {
+    create(
+      `export async function probe(url: string) {\n` +
+        `  return fetch(\n` +
+        `    url, /* historical note: POST /chat/completions */\n` +
+        `    { method: "GET" },\n` +
+        `  );\n` +
+        `}\n`
+    );
+    expect(runGuard()).toBe(0);
+  });
+
   it("honours a gateway-llm-ok suppression on the flagged line", () => {
     create(
       `export async function probe(u: string) {\n` +

--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -93,6 +93,48 @@ function isSuppressed(lines, idx) {
   return false;
 }
 
+/**
+ * Text of the statement that STARTS at `idx`, spanning however many physical
+ * lines it takes to close — balanced `(`/`{` for a call or import clause, or a
+ * terminating `;`.
+ *
+ * Why not just the one line: prettier/biome split any construct that exceeds
+ * the print width, so the real-world violations are
+ *
+ *   return fetch(                  import {
+ *     "https://host/v1/chat/completions",   OpenAI,
+ *   );                             } from "openai";
+ *
+ * where no single line holds both the keyword and the literal the rule looks
+ * for. A line-local check was therefore weakest at exactly the shape a
+ * formatter produces. Depth counting stops at the matching close so an
+ * unrelated later statement cannot be dragged in, and a bounded lookahead
+ * keeps a malformed file from scanning to EOF.
+ */
+function statementText(lines, idx) {
+  const MAX_STATEMENT_LINES = 40;
+  let depth = 0;
+  let opened = false;
+  const parts = [];
+  for (let i = idx; i < lines.length && i < idx + MAX_STATEMENT_LINES; i++) {
+    const raw = lines[i];
+    parts.push(raw);
+    for (const ch of raw) {
+      if (ch === "(" || ch === "{") {
+        depth++;
+        opened = true;
+      } else if (ch === ")" || ch === "}") {
+        depth--;
+      }
+    }
+    // A statement with no bracket at all (`import "openai";`) ends at its
+    // semicolon; one that opened brackets ends when they balance.
+    if (opened && depth <= 0) break;
+    if (!opened && raw.includes(";")) break;
+  }
+  return parts.join("\n");
+}
+
 function flag(file, lineNo, kind, snippet) {
   violations.push({
     file: relative(REPO_ROOT, file),
@@ -186,9 +228,15 @@ for (const file of files) {
     if (isSuppressed(lines, i)) continue;
 
     // 1. fetch() to a completions-style path.
+    //
+    // Match against the whole call expression, not the single physical line:
+    // a formatter routinely splits `fetch(` from its URL argument, and a
+    // line-local check silently exempted that — the most likely shape the
+    // violation actually gets written in.
     if (/\bfetch\s*\(/.test(code)) {
+      const callText = statementText(lines, i);
       for (const p of COMPLETION_PATHS) {
-        if (code.includes(p)) {
+        if (callText.includes(p)) {
           flag(file, i + 1, "hand-rolled completion fetch", line);
           break;
         }
@@ -197,12 +245,16 @@ for (const file of files) {
 
     // 2. Vendor SDK import.
     if (/\b(?:import|require)\b/.test(code)) {
+      // Whole statement, not the line: `import {\n ... \n} from "openai"` is
+      // the shape a formatter produces, and it carried the module literal on a
+      // line with no `import` keyword on it.
+      const importText = statementText(lines, i);
       for (const sdk of VENDOR_SDKS) {
         if (
-          code.includes(`"${sdk}"`) ||
-          code.includes(`'${sdk}'`) ||
-          code.includes(`"${sdk}/`) ||
-          code.includes(`'${sdk}/`)
+          importText.includes(`"${sdk}"`) ||
+          importText.includes(`'${sdk}'`) ||
+          importText.includes(`"${sdk}/`) ||
+          importText.includes(`'${sdk}/`)
         ) {
           flag(file, i + 1, `vendor SDK import (${sdk})`, line);
           break;

--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -124,9 +124,33 @@ function statementText(lines, idx) {
   const MAX_STATEMENT_LINES = 40;
   let depth = 0;
   let opened = false;
+  let inBlockComment = false;
   const parts = [];
   for (let i = idx; i < lines.length && i < idx + MAX_STATEMENT_LINES; i++) {
-    const code = stripComments(lines[i]);
+    const line = lines[i];
+    let code = "";
+    let j = 0;
+    while (j < line.length) {
+      if (inBlockComment) {
+        const closeIdx = line.indexOf("*/", j);
+        if (closeIdx !== -1) {
+          inBlockComment = false;
+          j = closeIdx + 2;
+        } else {
+          break;
+        }
+      } else {
+        if (line.startsWith("/*", j)) {
+          inBlockComment = true;
+          j += 2;
+        } else if (line.startsWith("//", j) && (j === 0 || line[j - 1] !== ":")) {
+          break;
+        } else {
+          code += line[j];
+          j++;
+        }
+      }
+    }
     parts.push(code);
     for (const ch of code) {
       if (ch === "(" || ch === "{") {

--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -93,10 +93,19 @@ function isSuppressed(lines, idx) {
   return false;
 }
 
+function stripComments(line) {
+  return line
+    .replace(/\/\*\*?.*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/, "$1")
+    .replace(/^\s*\*.*$/, "")
+    .replace(/^\s*\/\*.*$/, "");
+}
+
 /**
- * Text of the statement that STARTS at `idx`, spanning however many physical
+ * Code in the statement that STARTS at `idx`, spanning however many physical
  * lines it takes to close — balanced `(`/`{` for a call or import clause, or a
- * terminating `;`.
+ * terminating `;`. Comments are removed so prose inside a multiline statement
+ * cannot become a violation.
  *
  * Why not just the one line: prettier/biome split any construct that exceeds
  * the print width, so the real-world violations are
@@ -117,9 +126,9 @@ function statementText(lines, idx) {
   let opened = false;
   const parts = [];
   for (let i = idx; i < lines.length && i < idx + MAX_STATEMENT_LINES; i++) {
-    const raw = lines[i];
-    parts.push(raw);
-    for (const ch of raw) {
+    const code = stripComments(lines[i]);
+    parts.push(code);
+    for (const ch of code) {
       if (ch === "(" || ch === "{") {
         depth++;
         opened = true;
@@ -130,7 +139,7 @@ function statementText(lines, idx) {
     // A statement with no bracket at all (`import "openai";`) ends at its
     // semicolon; one that opened brackets ends when they balance.
     if (opened && depth <= 0) break;
-    if (!opened && raw.includes(";")) break;
+    if (!opened && code.includes(";")) break;
   }
   return parts.join("\n");
 }
@@ -219,11 +228,7 @@ for (const file of files) {
     // `const u = "https:` and the literal URL — the most obvious way to
     // hand-roll a call — sails straight through. Require the `//` to be at
     // line start or preceded by something other than `:`.
-    const code = line
-      .replace(/\/\*\*?.*?\*\//g, "")
-      .replace(/(^|[^:])\/\/.*$/, "$1")
-      .replace(/^\s*\*.*$/, "")
-      .replace(/^\s*\/\*.*$/, "");
+    const code = stripComments(line);
     if (!code.trim()) continue;
     if (isSuppressed(lines, i)) continue;
 


### PR DESCRIPTION
## Summary

> **Rebased 2026-07-28.** The shared-gateway-LLM-client half of this PR landed on `main` independently as #2246 (same title, from the sibling branch `feat/gateway-llm-client`). Rebasing dropped 7 commits that were already upstream verbatim, including the single-client refactor, the non-OpenAI endpoint fix, and the CI wiring for the gate. This PR is now the remainder: **19 commits to 12, 25 files to 12.** The evidence sections below are unchanged and still describe work in this diff, with one caveat noted under red->green.

- Pointing the gateway features at `inference_providers` wasn't enough: **no live prod row had `is_default`**. Creating a provider never marked one and deleting the default never reassigned it, so every org resolved to `null`. Both writers are fixed, and `getOrgDefaultModel` self-heals legacy orgs on read.
- Promotion is restricted to rows an org can actually run: non-blank `capabilities.text.model`, readable credentials, and no OAuth rows (which carry no org-usable secret). A provider converting to OAuth hands the default off, and a legacy OAuth row still flagged default is demoted.
- The auto-promoted `isDefault` is reported back through the HTTP API and the CLI, and the set-default rejection is split into its two real reasons instead of one ambiguous error.
- `scripts/check-gateway-llm-calls.mjs` (the gate that shipped in #2246) now inspects whole statements rather than single lines, so a multi-line one-off LLM client can no longer slip past it.

## Test plan

- [x] `make pre-pr` clean — all 6 gates
- [x] Tests run: 16/16 provider-default, 49/49 across affected integration suites, 47 unit tests
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### red→green — the misrouting invariant

Injected the naive implementation (guess OpenAI's public endpoint for any unresolved provider):

```
× (m) an unregistered provider with no row base_url does NOT resolve
    → expected { …(3) } to be null
× (n) a lookalike slug does not inherit the OpenAI public endpoint
    → expected { …(3) } to be null

  Tests  2 failed | 14 passed (16)      ← against the injected bug
  Tests  16 passed (16)                 ← against the real code
```

Sending a request to a guessed endpoint delivers it to the wrong vendor with a model ID it doesn't know, surfacing as `400 <model> is not a valid model ID` rather than "this provider isn't configured". Skipping the feature is the correct failure. Mirrors `buildDynamicOpenAIModel` in `agent-worker/src/runtime/model-resolver.ts`.

> **Post-rebase caveat.** The fix this evidence was produced against (`fix(server): don't guess a public endpoint for a non-OpenAI provider`) is one of the commits that landed on `main` via #2246, so the implementation is no longer part of this diff. The two regression tests that pin the invariant, `(m)` and `(n)` in `inference-provider-default.test.ts`, **are** still in this PR and continue to guard it.

### Live end-to-end

Booted server on :8895, provider created over the authenticated HTTP API:

```
[E2E-PROBE] resolveCompletionTarget
  resolved: true
  baseUrl:  https://api.z.ai/api/coding/paas/v4   ← from the module registry
  model:    glm-4.6

[E2E-PROBE] rewrite variants        (live OpenAI call, ~1s)
  ["quarterly revenue projections",
   "northwest territory revenue",
   "financial forecasts northwest region"]
```

The chips guardrail, which returned nothing for its entire life, now produces real output from a live model call in 1.3s.

## Notes

Endpoint resolution reads the provider module registry (`getUpstreamConfig()`) rather than deriving `<PROVIDER>_BASE_URL` from env — the registry already knows each provider's upstream **and** folds in the deployment's `baseUrlEnvVarName` override, so z-ai/xai/openrouter resolve where an env-derived version returned `undefined`. `sdkCompat !== "openai"` rejects Anthropic-protocol rows rather than sending them an OpenAI-shaped request.

Default promotion only considers **runnable** rows (non-blank `capabilities.text.model`) — promoting a model-less row hands the org a default that still resolves to `null`. Every default-mutating path takes a per-org row lock so concurrent creates cannot both promote.

**Full E2E evidence with UI screenshots:** https://claude.ai/code/artifact/d1b7f813-cfab-4d5b-a311-3c27b085b74e

### Known limits

- **Egress judge not migrated.** Still on the Anthropic SDK, explicitly suppressed in the gate. It fails *closed*, and `organizationId` doesn't reach the input/output/pre-tool guardrail contexts yet — its own PR, owing red→green.
- **Existing prod orgs aren't backfilled.** The fix repairs lazily on read and on any create/delete; orgs with zero live providers stay default-less until they add one.
- **Slow models still time out on the rewriter.** glm-4.6 exceeded the 30s search-path budget and failed open to the raw query — correct behavior, pre-existing tuning, not a regression.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Follow-up suggestions and query-rewrite recovery now use org-scoped, OpenAI-compatible gateway completion routing.
  * Inference-provider organization defaults are supported with richer default-model handling (including OAuth).
* **Bug Fixes**
  * Provider default setting/reporting is more explicit (clearer outcomes and error messages, including missing-text-model and OAuth cases).
  * Improved “fail open” behavior so enrichment returns no results when upstream resolution or completion fails.
* **Chores**
  * Added/expanded CI and pre-PR guardrails to validate that server-side LLM calls go through the single approved gateway path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
