### PR TITLE
fix(ci): tag docker images to releases instead of every main push

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -24,8 +24,7 @@ on:
       - main
   # release-please publishes `lobu-vX.Y.Z`. Building on that too is what gives
   # the images a semver tag and repoints `latest` at a release instead of an
-  # arbitrary commit (#2184). The timestamp tag is still produced on every run
-  # so Flux's ImagePolicy keeps matching.
+  # arbitrary commit (#2184). Unrelated releases are ignored.
   release:
     types: [published]
   workflow_dispatch:
@@ -64,39 +63,53 @@ jobs:
       tag: ${{ steps.timestamp.outputs.tag }}
       semver: ${{ steps.semver.outputs.semver }}
       is_stable: ${{ steps.semver.outputs.is_stable }}
+      should_publish: ${{ steps.semver.outputs.should_publish }}
     steps:
       - name: Generate shared timestamp tag
         id: timestamp
         run: echo "tag=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
 
-      # Both outputs are empty on non-release runs, so a plain main push
-      # publishes only the timestamp tag — that is the #2184 fix. Computed once
-      # here so app/worker/embeddings can never disagree about the version.
+      # Computed once here so app/worker/embeddings can never disagree about
+      # release eligibility or version.
       - name: Derive semver tag from the release
         id: semver
         env:
+          EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
           PRERELEASE: ${{ github.event_name == 'release' && github.event.release.prerelease || false }}
         run: |
           set -euo pipefail
-          semver="${RELEASE_TAG#lobu-v}"
-          if [ "$semver" = "$RELEASE_TAG" ]; then
-            # Not a lobu-v* release (e.g. the Mac app). Publish no version tag
-            # rather than guessing, so `latest` never moves to an unrelated one.
-            semver=""
+          semver=""
+          is_stable=false
+          should_publish=true
+
+          if [ "$EVENT_NAME" = "release" ]; then
+            case "$RELEASE_TAG" in
+              lobu-v*) semver="${RELEASE_TAG#lobu-v}" ;;
+              *) should_publish=false ;;
+            esac
+
+            if [ "$should_publish" = "true" ] \
+              && ! printf '%s' "$semver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+              echo "::error::Refusing to use release tag '$RELEASE_TAG' — not a valid Lobu semver tag."
+              exit 1
+            fi
           fi
+
           # `latest` must track STABLE releases only. A prerelease still gets its
           # own version tag (so it is installable) but must not become what a
           # plain `docker pull ghcr.io/lobu-ai/lobu-app` resolves to. Checked
           # against the semver string too, not just GitHub's prerelease flag,
           # since release-please marks that flag only when it is told to.
-          is_stable=true
-          case "$semver" in
-            ""|*-*) is_stable=false ;;
-          esac
-          if [ "$PRERELEASE" = "true" ]; then is_stable=false; fi
-          echo "semver=$semver" >> "$GITHUB_OUTPUT"
-          echo "is_stable=$is_stable" >> "$GITHUB_OUTPUT"
+          if [ -n "$semver" ] && [[ "$semver" != *-* ]] && [ "$PRERELEASE" != "true" ]; then
+            is_stable=true
+          fi
+
+          {
+            echo "semver=$semver"
+            echo "is_stable=$is_stable"
+            echo "should_publish=$should_publish"
+          } >> "$GITHUB_OUTPUT"
 
   # Connector-runtime parity smoke gate (main/deploy side). RUNS the built worker
   # artifact's self-check before any image is pushed, so the packaging/parity
@@ -111,6 +124,8 @@ jobs:
   # buildx cache scope as `build-worker` so this doesn't double the build cost.
   connector-parity-smoke:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [generate-tag]
+    if: needs.generate-tag.outputs.should_publish == 'true'
     timeout-minutes: 25
     # Builds + runs the image locally (push: false), so it never needs the
     # top-level `packages: write`. Drop to read-only for least privilege.
@@ -140,6 +155,7 @@ jobs:
 
   build-app:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: needs.generate-tag.outputs.should_publish == 'true'
     # Push the app image LAST. Flux's ImageUpdateAutomation only watches
     # the app image policy, but the chart applies one shared tag to app,
     # worker, AND embeddings. If app pushed before worker or embeddings,
@@ -220,6 +236,7 @@ jobs:
     # Gate the worker push (and transitively the app push, which `needs:
     # build-worker`) on the parity smoke passing.
     needs: [generate-tag, connector-parity-smoke]
+    if: needs.generate-tag.outputs.should_publish == 'true'
     permissions:
       contents: read
       packages: write
@@ -275,6 +292,7 @@ jobs:
   build-embeddings-service:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [generate-tag]
+    if: needs.generate-tag.outputs.should_publish == 'true'
     permissions:
       contents: read
       packages: write
@@ -326,10 +344,11 @@ jobs:
             -d '{"visibility":"public"}' || true
 
   # Failure notification. The chart applies one shared tag to app + worker +
-  # embeddings, so if any of the three build/push jobs fails on main, the next
-  # ImageUpdateAutomation cycle either rolls a tag that does not exist for one
-  # service (half-rolled prod) or — when app fails after worker/embeddings
-  # already pushed — silently leaves prod on the previous app tag while the
+  # embeddings, so if any of the three build/push jobs fails on main or a Lobu
+  # release, sibling tags may be incomplete. On timestamped runs the next
+  # ImageUpdateAutomation cycle can either roll a tag that does not exist for
+  # one service (half-rolled prod) or — when app fails after worker/embeddings
+  # already pushed — silently leave prod on the previous app tag while the
   # other two move forward. Both modes were caught only by manual inspection
   # before this notifier existed (PR #1116 build-app disk-full incident).
   #
@@ -340,7 +359,10 @@ jobs:
   notify-failure:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [generate-tag, connector-parity-smoke, build-worker, build-embeddings-service, build-app]
-    if: failure() && github.ref == 'refs/heads/main'
+    if: >-
+      failure()
+      && needs.generate-tag.outputs.should_publish == 'true'
+      && (github.ref == 'refs/heads/main' || github.event_name == 'release')
     permissions:
       contents: read
     steps:
@@ -349,7 +371,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          RUN_SUMMARY: ${{ github.event.head_commit.message || github.event.release.name || github.ref_name }}
+          REF_NAME: ${{ github.ref_name }}
           ACTOR: ${{ github.actor }}
           SHA_SHORT: ${{ github.sha }}
         run: |
@@ -357,9 +380,9 @@ jobs:
             echo "SLACK_DEPLOY_WEBHOOK_URL not set; skipping notification."
             exit 0
           fi
-          # First line of commit message only, JSON-escaped via jq.
-          first_line=$(printf '%s' "$COMMIT_MSG" | head -n1)
+          # First line of commit/release summary only, JSON-escaped via jq.
+          first_line=$(printf '%s' "$RUN_SUMMARY" | head -n1)
           payload=$(jq -nc \
-            --arg text "<@U09513HH1N1> :rotating_light: build-images failed on \`main\` — prod will roll half (or not at all). <${RUN_URL}|run> · <${COMMIT_URL}|${SHA_SHORT:0:7}> by ${ACTOR}\n> ${first_line}" \
+            --arg text "<@U09513HH1N1> :rotating_light: build-images failed on \`${REF_NAME}\` — sibling image tags may be incomplete. <${RUN_URL}|run> · <${COMMIT_URL}|${SHA_SHORT:0:7}> by ${ACTOR}\n> ${first_line}" \
             '{text: $text}')
           curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -69,47 +69,21 @@ jobs:
         id: timestamp
         run: echo "tag=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
 
-      # Computed once here so app/worker/embeddings can never disagree about
-      # release eligibility or version.
+      # Only this job needs the repo; the build jobs check out separately.
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # Derivation lives in scripts/derive-image-tags.mjs so it is unit-tested
+      # (scripts/__tests__/derive-image-tags.test.ts) — inline YAML shell can
+      # only be exercised by cutting a real release. Computed once here so
+      # app/worker/embeddings can never disagree about eligibility or version.
       - name: Derive semver tag from the release
         id: semver
         env:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
           PRERELEASE: ${{ github.event_name == 'release' && github.event.release.prerelease || false }}
-        run: |
-          set -euo pipefail
-          semver=""
-          is_stable=false
-          should_publish=true
-
-          if [ "$EVENT_NAME" = "release" ]; then
-            case "$RELEASE_TAG" in
-              lobu-v*) semver="${RELEASE_TAG#lobu-v}" ;;
-              *) should_publish=false ;;
-            esac
-
-            if [ "$should_publish" = "true" ] \
-              && ! printf '%s' "$semver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
-              echo "::error::Refusing to use release tag '$RELEASE_TAG' — not a valid Lobu semver tag."
-              exit 1
-            fi
-          fi
-
-          # `latest` must track STABLE releases only. A prerelease still gets its
-          # own version tag (so it is installable) but must not become what a
-          # plain `docker pull ghcr.io/lobu-ai/lobu-app` resolves to. Checked
-          # against the semver string too, not just GitHub's prerelease flag,
-          # since release-please marks that flag only when it is told to.
-          if [ -n "$semver" ] && [[ "$semver" != *-* ]] && [ "$PRERELEASE" != "true" ]; then
-            is_stable=true
-          fi
-
-          {
-            echo "semver=$semver"
-            echo "is_stable=$is_stable"
-            echo "should_publish=$should_publish"
-          } >> "$GITHUB_OUTPUT"
+        run: node scripts/derive-image-tags.mjs
 
   # Connector-runtime parity smoke gate (main/deploy side). RUNS the built worker
   # artifact's self-check before any image is pushed, so the packaging/parity

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,6 +22,12 @@ on:
   push:
     branches:
       - main
+  # release-please publishes `lobu-vX.Y.Z`. Building on that too is what gives
+  # the images a semver tag and repoints `latest` at a release instead of an
+  # arbitrary commit (#2184). The timestamp tag is still produced on every run
+  # so Flux's ImagePolicy keeps matching.
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       platforms:
@@ -56,10 +62,41 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       tag: ${{ steps.timestamp.outputs.tag }}
+      semver: ${{ steps.semver.outputs.semver }}
+      is_stable: ${{ steps.semver.outputs.is_stable }}
     steps:
       - name: Generate shared timestamp tag
         id: timestamp
         run: echo "tag=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      # Both outputs are empty on non-release runs, so a plain main push
+      # publishes only the timestamp tag — that is the #2184 fix. Computed once
+      # here so app/worker/embeddings can never disagree about the version.
+      - name: Derive semver tag from the release
+        id: semver
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+          PRERELEASE: ${{ github.event_name == 'release' && github.event.release.prerelease || false }}
+        run: |
+          set -euo pipefail
+          semver="${RELEASE_TAG#lobu-v}"
+          if [ "$semver" = "$RELEASE_TAG" ]; then
+            # Not a lobu-v* release (e.g. the Mac app). Publish no version tag
+            # rather than guessing, so `latest` never moves to an unrelated one.
+            semver=""
+          fi
+          # `latest` must track STABLE releases only. A prerelease still gets its
+          # own version tag (so it is installable) but must not become what a
+          # plain `docker pull ghcr.io/lobu-ai/lobu-app` resolves to. Checked
+          # against the semver string too, not just GitHub's prerelease flag,
+          # since release-please marks that flag only when it is told to.
+          is_stable=true
+          case "$semver" in
+            ""|*-*) is_stable=false ;;
+          esac
+          if [ "$PRERELEASE" = "true" ]; then is_stable=false; fi
+          echo "semver=$semver" >> "$GITHUB_OUTPUT"
+          echo "is_stable=$is_stable" >> "$GITHUB_OUTPUT"
 
   # Connector-runtime parity smoke gate (main/deploy side). RUNS the built worker
   # artifact's self-check before any image is pushed, so the packaging/parity
@@ -149,7 +186,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_APP }}
           tags: |
             type=raw,value=${{ needs.generate-tag.outputs.tag }}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.generate-tag.outputs.semver }},enable=${{ needs.generate-tag.outputs.semver != '' }}
+            type=raw,value=latest,enable=${{ needs.generate-tag.outputs.is_stable == 'true' }}
 
       - name: Build and push App image
         uses: useblacksmith/build-push-action@v2
@@ -210,7 +248,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_WORKER }}
           tags: |
             type=raw,value=${{ needs.generate-tag.outputs.tag }}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.generate-tag.outputs.semver }},enable=${{ needs.generate-tag.outputs.semver != '' }}
+            type=raw,value=latest,enable=${{ needs.generate-tag.outputs.is_stable == 'true' }}
 
       - name: Build and push Worker image
         uses: useblacksmith/build-push-action@v2
@@ -264,7 +303,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_EMBEDDINGS }}
           tags: |
             type=raw,value=${{ needs.generate-tag.outputs.tag }}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.generate-tag.outputs.semver }},enable=${{ needs.generate-tag.outputs.semver != '' }}
+            type=raw,value=latest,enable=${{ needs.generate-tag.outputs.is_stable == 'true' }}
 
       - name: Build and push Embeddings Service image
         uses: useblacksmith/build-push-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,6 +552,13 @@ jobs:
         # (#2186). These fixtures exercise the publish transform's guard.
         run: bun test scripts/__tests__/publish-packages-guard.test.ts
 
+      - name: Image tag derivation
+        # Decides which docker tags a build publishes. `latest` used to follow
+        # every main commit (#2184); the logic that stopped that lives in a
+        # script precisely so it is testable — as embedded workflow shell it
+        # could only be exercised by cutting a real release.
+        run: bun test scripts/__tests__/derive-image-tags.test.ts
+
       - name: Raw-array SQL-param gate
         # packages/server's postgres.js client runs fetch_types:false, where a raw
         # JS array bound as a query param serializes to a malformed array literal

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,10 +20,21 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
+      # Releases created with GITHUB_TOKEN do not trigger release-event
+      # workflows, including build-images and mac-release.
+      - name: Require release automation token
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PLEASE_TOKEN" ]; then
+            echo "::error::RELEASE_PLEASE_TOKEN is required so release-event workflows can run."
+            exit 1
+          fi
+
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           include-component-in-tag: true
@@ -41,6 +52,8 @@ jobs:
     steps:
       - name: Trigger publish-packages workflow
         env:
+          # workflow_dispatch is allowed to create a run with GITHUB_TOKEN;
+          # only release-event consumers require the automation token above.
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run publish-packages.yml \

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -34,9 +34,9 @@ services:
       retries: 20
 
   lobu:
-    # `latest` tracks the newest STABLE release (e.g. 14.3.0), not every commit
-    # on main. Pin the version for reproducible deploys:
-    #   image: ghcr.io/lobu-ai/lobu-app:14.3.0
+    # Main-branch builds no longer move `latest`; stable releases do.
+    # Pin a published version for reproducible deploys:
+    #   image: ghcr.io/lobu-ai/lobu-app:X.Y.Z
     image: ghcr.io/lobu-ai/lobu-app:latest
     # platform: linux/amd64  # required on Apple Silicon until multi-arch image lands (see GitHub Issues)
     container_name: lobu-app

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -34,6 +34,9 @@ services:
       retries: 20
 
   lobu:
+    # `latest` tracks the newest STABLE release (e.g. 14.3.0), not every commit
+    # on main. Pin the version for reproducible deploys:
+    #   image: ghcr.io/lobu-ai/lobu-app:14.3.0
     image: ghcr.io/lobu-ai/lobu-app:latest
     # platform: linux/amd64  # required on Apple Silicon until multi-arch image lands (see GitHub Issues)
     container_name: lobu-app

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -74,7 +74,7 @@ The Dockerfile lives at `docker/app/Dockerfile`. Three notable details:
 
 ## Bumping versions
 
-The `:latest` tag tracks the most recent merged `main` build. For pinned deploys, use a version tag from the [GitHub Releases page](https://github.com/lobu-ai/lobu/releases) — they follow `lobu-vX.Y.Z` and match release-please commits on `main`.
+Main-branch builds publish timestamp tags but no longer move `:latest`. Publishing a stable [GitHub Release](https://github.com/lobu-ai/lobu/releases) named `lobu-vX.Y.Z` publishes image tag `:X.Y.Z` and moves `:latest`; prereleases publish only their version tag. For reproducible deploys, pin a published version. Releases from before versioned image publishing was enabled are not backfilled automatically.
 
 Migrations are applied at boot. If you roll back to an older image whose migrations dir is a strict prefix of what's already applied, set `SKIP_SCHEMA_VERSION_CHECK=1` once to get past the version assertion.
 

--- a/scripts/__tests__/derive-image-tags.test.ts
+++ b/scripts/__tests__/derive-image-tags.test.ts
@@ -1,6 +1,21 @@
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "bun:test";
 // @ts-expect-error — plain .mjs script, no type declarations by design.
 import { deriveImageTags } from "../derive-image-tags.mjs";
+
+const SCRIPT = fileURLToPath(
+  new URL("../derive-image-tags.mjs", import.meta.url)
+);
 
 /**
  * `latest` used to move on every main push, so self-hosters pulling it got an
@@ -81,5 +96,82 @@ describe("deriveImageTags", () => {
     });
     expect(result.semver).toBe("1.0.0-alpha.1+build.7");
     expect(result.is_stable).toBe(false);
+  });
+});
+
+/**
+ * The workflow consumes this script as a subprocess, so the CLI half needs its
+ * own coverage: the exported function can be perfect while the main block never
+ * runs. That is not hypothetical — a `process.argv[1].endsWith(name)` guard, and
+ * later a raw `import.meta.url === pathToFileURL(argv[1]).href` compare, both
+ * silently produced NO output when the path contained a symlink (macOS
+ * /tmp -> /private/tmp). The job still exits 0, so the workflow just reads empty
+ * tags and publishes nothing.
+ */
+describe("derive-image-tags CLI", () => {
+  // Must be literal "node", NOT process.execPath: under `bun test` execPath is
+  // bun, which both runs a different runtime than CI's `node scripts/...` and
+  // resolves a symlinked argv[0] before exec — silently defeating the symlink
+  // case below. The workflow invokes node, so the test must too.
+  const run = (env: Record<string, string>, scriptPath = SCRIPT) => {
+    const dir = mkdtempSync(join(tmpdir(), "derive-tags-"));
+    const outFile = join(dir, "gh-output");
+    writeFileSync(outFile, "");
+    try {
+      const proc = spawnSync("node", [scriptPath], {
+        env: { ...process.env, ...env, GITHUB_OUTPUT: outFile },
+        encoding: "utf8",
+      });
+      return { status: proc.status, output: readFileSync(outFile, "utf8") };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  it("writes every output GITHUB_OUTPUT consumer reads", () => {
+    const { status, output } = run({
+      EVENT_NAME: "release",
+      RELEASE_TAG: "lobu-v14.4.0",
+      PRERELEASE: "false",
+    });
+    expect(status).toBe(0);
+    // The workflow keys `latest` and the version tag off these exact names;
+    // a missing line reads as "no release" rather than as a failure.
+    expect(output).toContain("semver=14.4.0");
+    expect(output).toContain("is_stable=true");
+    expect(output).toContain("should_publish=true");
+  });
+
+  it("still runs when invoked through a symlink with a different name", () => {
+    // The symlink must point at a DIFFERENTLY-NAMED file for this to bite.
+    // A same-name copy passes under every broken guard tried here: Node
+    // derives import.meta.url from the argv[1] string it was handed, so both
+    // sides agree until the link name and the real name diverge.
+    const dir = mkdtempSync(join(tmpdir(), "derive-tags-link-"));
+    const real = join(dir, "derive-image-tags.mjs");
+    const link = join(dir, "run-tags.mjs");
+    try {
+      writeFileSync(real, readFileSync(SCRIPT, "utf8"));
+      symlinkSync(real, link);
+      const { status, output } = run(
+        { EVENT_NAME: "release", RELEASE_TAG: "lobu-v14.4.0" },
+        link
+      );
+      expect(status).toBe(0);
+      expect(output).toContain("semver=14.4.0");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails the job on an unparseable release tag", () => {
+    // Must be non-zero: exiting 0 with empty outputs would let the build
+    // proceed and quietly publish no version tag.
+    const { status, output } = run({
+      EVENT_NAME: "release",
+      RELEASE_TAG: "lobu-vnext",
+    });
+    expect(status).toBe(1);
+    expect(output).toBe("");
   });
 });

--- a/scripts/__tests__/derive-image-tags.test.ts
+++ b/scripts/__tests__/derive-image-tags.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+// @ts-expect-error — plain .mjs script, no type declarations by design.
+import { deriveImageTags } from "../derive-image-tags.mjs";
+
+/**
+ * `latest` used to move on every main push, so self-hosters pulling it got an
+ * arbitrary commit and no tag identified a release (#2184). These pin the
+ * decision table down; before this the logic was shell inside YAML, only
+ * exercisable by cutting a real release.
+ */
+describe("deriveImageTags", () => {
+  it("publishes no version tag and never moves latest on a main push", () => {
+    // The #2184 regression itself: a plain push must publish the timestamp
+    // tag only. should_publish stays true — main builds still deploy.
+    expect(deriveImageTags({ eventName: "push" })).toEqual({
+      semver: "",
+      is_stable: false,
+      should_publish: true,
+    });
+  });
+
+  it("publishes the version tag and moves latest for a stable release", () => {
+    expect(
+      deriveImageTags({ eventName: "release", releaseTag: "lobu-v14.3.0" })
+    ).toEqual({ semver: "14.3.0", is_stable: true, should_publish: true });
+  });
+
+  it("keeps latest off a prerelease flagged only by its semver suffix", () => {
+    // release-please sets GitHub's prerelease flag only when told to, so the
+    // string must be checked too or `latest` silently follows a beta.
+    expect(
+      deriveImageTags({
+        eventName: "release",
+        releaseTag: "lobu-v15.0.0-beta.1",
+      })
+    ).toEqual({
+      semver: "15.0.0-beta.1",
+      is_stable: false,
+      should_publish: true,
+    });
+  });
+
+  it("keeps latest off a prerelease flagged only by GitHub", () => {
+    for (const prerelease of [true, "true"]) {
+      expect(
+        deriveImageTags({
+          eventName: "release",
+          releaseTag: "lobu-v15.0.0",
+          prerelease,
+        }).is_stable,
+        `prerelease=${JSON.stringify(prerelease)} must not move latest`
+      ).toBe(false);
+    }
+  });
+
+  it("skips the build entirely for another component's release", () => {
+    // owletto-mac-v* shares this event feed. Building would burn a full run to
+    // produce no new tag, and must never move Lobu's `latest`.
+    expect(
+      deriveImageTags({
+        eventName: "release",
+        releaseTag: "owletto-mac-v2.1.0",
+      })
+    ).toEqual({ semver: "", is_stable: false, should_publish: false });
+  });
+
+  it("refuses a lobu release whose tag is not valid semver", () => {
+    // Prefix-stripping alone would hand `01.2.3` or `next` to docker as a tag.
+    for (const tag of ["lobu-v01.2.3", "lobu-vnext", "lobu-v1.2", "lobu-v"]) {
+      expect(
+        () => deriveImageTags({ eventName: "release", releaseTag: tag }),
+        `${tag} must be rejected`
+      ).toThrow(/not valid semver/);
+    }
+  });
+
+  it("accepts a build-metadata release without moving latest off it", () => {
+    const result = deriveImageTags({
+      eventName: "release",
+      releaseTag: "lobu-v1.0.0-alpha.1+build.7",
+    });
+    expect(result.semver).toBe("1.0.0-alpha.1+build.7");
+    expect(result.is_stable).toBe(false);
+  });
+});

--- a/scripts/derive-image-tags.mjs
+++ b/scripts/derive-image-tags.mjs
@@ -14,6 +14,8 @@
  * embedded YAML shell is only exercisable by cutting a real release.
  */
 
+import { appendFileSync } from "node:fs";
+
 /** release-please publishes lobu-vX.Y.Z; other repos' releases share this feed. */
 const LOBU_TAG_PREFIX = "lobu-v";
 
@@ -63,7 +65,6 @@ export function deriveImageTags({
 
 // Invoked from the workflow: writes GitHub Actions outputs.
 if (process.argv[1]?.endsWith("derive-image-tags.mjs")) {
-  const { appendFileSync } = await import("node:fs");
   let result;
   try {
     result = deriveImageTags({

--- a/scripts/derive-image-tags.mjs
+++ b/scripts/derive-image-tags.mjs
@@ -14,7 +14,8 @@
  * embedded YAML shell is only exercisable by cutting a real release.
  */
 
-import { appendFileSync } from "node:fs";
+import { appendFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 /** release-please publishes lobu-vX.Y.Z; other repos' releases share this feed. */
 const LOBU_TAG_PREFIX = "lobu-v";
@@ -63,8 +64,27 @@ export function deriveImageTags({
   return { semver, is_stable, should_publish: true };
 }
 
+/** True when this file was run directly rather than imported. */
+function isMainModule() {
+  try {
+    return (
+      realpathSync(fileURLToPath(import.meta.url)) ===
+      realpathSync(process.argv[1])
+    );
+  } catch {
+    return false;
+  }
+}
+
 // Invoked from the workflow: writes GitHub Actions outputs.
-if (process.argv[1]?.endsWith("derive-image-tags.mjs")) {
+//
+// Compares real paths, not filenames and not raw URLs. A filename check
+// no-ops if the file is renamed or copied; a raw URL compare no-ops when the
+// path contains a symlink, because import.meta.url is already resolved while
+// argv[1] is not (macOS /tmp -> /private/tmp is the everyday case). Either
+// way the failure is silent — the workflow reads empty tag outputs rather
+// than seeing an error — so resolve both sides.
+if (process.argv[1] && isMainModule()) {
   let result;
   try {
     result = deriveImageTags({

--- a/scripts/derive-image-tags.mjs
+++ b/scripts/derive-image-tags.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Decide which docker tags a build-images run publishes.
+ *
+ * `latest` used to be pushed on every main commit, so a self-hoster pulling
+ * ghcr.io/lobu-ai/lobu-app:latest got an arbitrary build and no tag identified
+ * a release at all (#2184). This derives, for one workflow run:
+ *
+ *   semver         version tag to publish ("" = none)
+ *   is_stable      whether `latest` moves to this build
+ *   should_publish whether the build jobs run at all
+ *
+ * Lives here rather than inline in the workflow so it can be unit-tested —
+ * embedded YAML shell is only exercisable by cutting a real release.
+ */
+
+/** release-please publishes lobu-vX.Y.Z; other repos' releases share this feed. */
+const LOBU_TAG_PREFIX = "lobu-v";
+
+/** Full SemVer 2.0.0 (semver.org). A loose \d+\.\d+\.\d+ accepts `01.2.3`. */
+const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+/**
+ * @param {{eventName?: string, releaseTag?: string, prerelease?: boolean|string}} input
+ * @returns {{semver: string, is_stable: boolean, should_publish: boolean}}
+ * @throws when a lobu-v* release carries a tag that is not valid semver.
+ */
+export function deriveImageTags({
+  eventName = "",
+  releaseTag = "",
+  prerelease = false,
+} = {}) {
+  // Not a release: main pushes and workflow_dispatch publish the timestamp tag
+  // only. That is the #2184 fix — `latest` no longer follows every commit.
+  if (eventName !== "release") {
+    return { semver: "", is_stable: false, should_publish: true };
+  }
+
+  // A release from another component (owletto-mac-v*) shares this event feed.
+  // Skip the whole build rather than publishing an unrelated `latest`.
+  if (!releaseTag.startsWith(LOBU_TAG_PREFIX)) {
+    return { semver: "", is_stable: false, should_publish: false };
+  }
+
+  const semver = releaseTag.slice(LOBU_TAG_PREFIX.length);
+  if (!SEMVER.test(semver)) {
+    throw new Error(
+      `Refusing to use release tag '${releaseTag}' — '${semver}' is not valid semver.`
+    );
+  }
+
+  // `latest` tracks STABLE releases only. A prerelease keeps its own version
+  // tag so it stays installable, but must not become what a bare
+  // `docker pull ghcr.io/lobu-ai/lobu-app` resolves to. Checked against the
+  // semver string as well as GitHub's flag, which release-please sets only
+  // when explicitly told to.
+  const flagged = prerelease === true || prerelease === "true";
+  const is_stable = !flagged && !semver.includes("-");
+
+  return { semver, is_stable, should_publish: true };
+}
+
+// Invoked from the workflow: writes GitHub Actions outputs.
+if (process.argv[1]?.endsWith("derive-image-tags.mjs")) {
+  const { appendFileSync } = await import("node:fs");
+  let result;
+  try {
+    result = deriveImageTags({
+      eventName: process.env.EVENT_NAME,
+      releaseTag: process.env.RELEASE_TAG,
+      prerelease: process.env.PRERELEASE,
+    });
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  }
+  const lines = [
+    `semver=${result.semver}`,
+    `is_stable=${result.is_stable}`,
+    `should_publish=${result.should_publish}`,
+  ];
+  console.log(lines.join("\n"));
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join("\n")}\n`);
+  }
+}


### PR DESCRIPTION
Fixes #2184.

## Problem

`latest` was published on **every** default-branch push, so a self-hoster pulling `ghcr.io/lobu-ai/lobu-app:latest` got whatever commit landed last. And no tag identified a release at all — as the issue puts it, "it's quite impossible to figure out which is 14.2.0", because you could not pull `14.2.0`.

## Fix

Images are also built on release publication, where they get a semver tag derived from release-please's `lobu-vX.Y.Z`, and `latest` moves only then. Main pushes keep publishing the timestamp tag unchanged.

`latest` tracks **stable** releases only. A prerelease still gets its version tag so it stays installable, but must not become what a bare `docker pull` resolves to — detected from both the semver string and GitHub's `prerelease` flag, since release-please only sets the flag when told to.

## End-to-end verification

Driving the committed script through the committed workflow's own tag templates:

| scenario | published tags |
|---|---|
| stable release `lobu-v14.4.0` | `<timestamp>`, `14.4.0`, `latest` |
| prerelease `lobu-v15.0.0-beta.1` | `<timestamp>`, `15.0.0-beta.1` |
| main push | `<timestamp>` |
| `owletto-mac-v2.1.0` | build skipped entirely |

## Deploys are unaffected

Checked rather than assumed:

- Flux's `ImagePolicy` pattern is anchored `^(\d{8})-(\d{6})$`. Verified it selects the timestamp tag and rejects `14.4.0`, `latest` and `15.0.0-beta.1`.
- The prod HelmRelease pins an explicit timestamp carrying the `{"$imagepolicy": ...}` marker that ImageUpdateAutomation rewrites, so nothing in the deploy path ever resolves `latest`.

## Three things review caught that I had wrong

**`GITHUB_TOKEN` releases do not fire `release:` triggers.** `release-please.yml` had a `secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN` fallback, so under the fallback this entire fix would have been a silent no-op. The fallback is gone and the workflow now fails loudly if the token is missing (it is configured). `helm-chart` and `mac-release` consume release events too and get the same protection.

**A dynamic `await import("node:fs")`** violated the repo's static-import invariant. Fixed, and grepped the branch — no others.

**The main-module guard was `argv[1].endsWith(...)`**, which silently no-ops if the file is renamed or reached via a symlink; the script then exits 0 having written nothing, so the workflow reads empty tag outputs and publishes nothing. Now compares realpaths on both sides — a raw URL compare is not enough, because `import.meta.url` is pre-resolved while `argv[1]` is not.

## Tests

`scripts/derive-image-tags.mjs` exists as a script (rather than inline YAML shell) specifically so it can be tested; the suite is wired into `ci.yml`, which names `scripts/__tests__` files explicitly rather than globbing.

Mutation-tested — every rule fails the suite when broken: latest-follows-every-push, ignore-the-prerelease-flag, build-on-unrelated-releases, loose-semver, filename guard, raw-URL guard, exit-0-on-bad-tag.

Two harness bugs were found this way, both of which had made new tests pass against broken code: `spawnSync(process.execPath)` runs **bun**, not node, under `bun test` (and bun resolves a symlinked argv[0] before exec, defeating the case under test), and a same-name copy never reproduces a symlink bug because Node derives `import.meta.url` from the argv[1] string it is handed.

## Not verified

The `release:` trigger only fires on a real published release, so the first stable release after merge is the live check: `latest` and the semver tag should both appear, and Flux should still roll on the timestamp tag.
