### PR TITLE
docs(chart): correct the bwrap guidance with measured prod results

### DIFF
--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -106,8 +106,11 @@ app:
   #
   # Consequence: connector-contributed CLIs (`gh`) exit 127 on this cluster, by
   # design, and that is the SAFE outcome — see the isolation note above.
-  # Enabling them needs a runtime-level change (a userns-remap / RuntimeClass
-  # that permits uid_map writes), not a values.yaml edit.
+  # Enabling them needs a runtime-level change, not a values.yaml edit. Also
+  # measured: this cluster declares `crun` and `gvisor` RuntimeClasses, but
+  # neither handler is installed on the nodes ("no runtime for \"crun\" is
+  # configured" / "...\"runsc\"..."), so switching runtimeClassName is not an
+  # available workaround here either.
   #
   # Verify on any cluster before assuming otherwise:
   #   kubectl exec <app-pod> -- bwrap --unshare-user --unshare-pid --ro-bind \

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -93,32 +93,28 @@ app:
   # the gateway's environment — verified, not theoretical. The pod boundary is
   # per-POD, and the tenants are inside it.
   #
-  # To enable contributed CLIs, bubblewrap needs `unshare(CLONE_NEWUSER)`. Two
-  # supported ways, both of which keep a REAL per-exec sandbox (never disable it
-  # — see the isolation note above):
+  # MEASURED on this cluster (k3s v1.32.8, containerd 2.0.5, Ubuntu 24.04 /
+  # kernel 6.8): bubblewrap CANNOT be enabled by any securityContext change.
+  # `unshare --user` succeeds once SYS_ADMIN is added, but bwrap then fails at
   #
-  #  a) Preferred, no node changes: add SYS_ADMIN back so bwrap can create the
-  #     namespaces, keeping RuntimeDefault seccomp otherwise intact.
+  #     bwrap: setting up uid map: Operation not permitted
   #
-  #       containerSecurityContext:
-  #         allowPrivilegeEscalation: false
-  #         capabilities:
-  #           drop: [ALL]
-  #           add: [SYS_ADMIN]
-  #         seccompProfile:
-  #           type: RuntimeDefault
+  # which still failed with SETUID+SETGID+SYS_CHROOT+MKNOD+DAC_OVERRIDE added,
+  # allowPrivilegeEscalation: true, AND seccomp removed entirely. Writing
+  # /proc/self/uid_map is restricted by the container runtime, not by seccomp or
+  # capabilities, so no chart-level knob reaches it.
   #
-  #  b) Tighter, needs the file staged on every node: a Localhost profile
-  #     derived from RuntimeDefault that allows `unshare` and `clone` with
-  #     namespace flags.
+  # Consequence: connector-contributed CLIs (`gh`) exit 127 on this cluster, by
+  # design, and that is the SAFE outcome — see the isolation note above.
+  # Enabling them needs a runtime-level change (a userns-remap / RuntimeClass
+  # that permits uid_map writes), not a values.yaml edit.
   #
-  #       seccompProfile:
-  #         type: Localhost
-  #         localhostProfile: profiles/bwrap-unshare.json
-  #
-  # Verify either with: `kubectl exec <app-pod> -- bwrap --unshare-user --ro-bind
-  # /usr /usr -- /usr/bin/true` — it must exit 0. If it does not, contributed
-  # CLIs will (correctly) keep exiting 127 rather than running unsandboxed.
+  # Verify on any cluster before assuming otherwise:
+  #   kubectl exec <app-pod> -- bwrap --unshare-user --unshare-pid --ro-bind \
+  #     /usr /usr --proc /proc --dev /dev -- /usr/bin/true
+  # Exit 0 means contributed CLIs will register; anything else means 127.
+  # Do NOT "fix" a non-zero result with LOBU_ALLOW_UNSANDBOXED_EXEC: workers and
+  # the gateway share this container, and /proc/1/environ is readable from it.
   #
   # Do NOT reach for `type: Unconfined` (drops the whole filter) or for
   # LOBU_ALLOW_UNSANDBOXED_EXEC (skips the sandbox AND unlocks full


### PR DESCRIPTION
Follow-up to #2243. My chart note there gave two ways to enable connector-contributed CLIs and claimed either would work. I tested both on the actual cluster and **neither does**.

## What I measured

New image `20260728-105827` (built from the #2243 merge) has everything it should: `gh 2.23.0`, `git`, `bubblewrap 0.8.0` all at `/usr/bin`.

But the probe `probeSandboxStrategy` actually runs fails:

```
bwrap: setting up uid map: Operation not permitted
BWRAP_ISOLATION_FAILED
```

Persisting through every escalation I could try:

| Config | `unshare --user` | bwrap isolation probe |
|---|---|---|
| shipped default | BLOCKED | — |
| `+SYS_ADMIN` | **OK** | FAILED |
| `+SETUID +SETGID` | OK | FAILED |
| `allowPrivilegeEscalation: true` | OK | FAILED |
| seccomp removed, 6 caps added | OK | FAILED |

## Where my earlier claim went wrong

I probed with bare `unshare --user -- /bin/true`, which **does** start succeeding under SYS_ADMIN — so I reported the guidance as verified. But bwrap goes further and writes `/proc/self/uid_map`, which this container runtime restricts regardless of capabilities or seccomp. I verified the easy half and generalized from it.

## Consequence

Contributed CLIs exit 127 on this cluster and cannot be enabled from values.yaml. That is the safe outcome, not a regression — `/proc/1/environ` is readable from the app container and worker workspaces are siblings under `/app/workspaces/`, both verified in prod, so running them unsandboxed would be a real cross-tenant exposure.

Enabling them needs a runtime-level change (userns-remap or a RuntimeClass permitting uid_map writes), which is a cluster decision rather than a chart edit.

This PR replaces the two false recipes with the measurement, the correct full probe command, and an explicit warning not to work around a failure with `LOBU_ALLOW_UNSANDBOXED_EXEC`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for enabling connector-contributed command-line tools.
  * Documented the observed sandboxing limitation and expected exit behavior when sandboxing is unavailable.
  * Added a verification command and clarified that disabling sandbox protections is not recommended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->