### PR TITLE
fix(server): one gateway LLM client, org-resolved credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,20 @@ jobs:
         # guard that stops catching regressions fails here instead of going quiet.
         run: bun test scripts/__tests__/check-exposed-surface-naming.test.ts
 
+      - name: Gateway LLM client gate
+        # packages/server speaks to model providers through ONE client
+        # (gateway/inference/gateway-completion.ts). A new per-feature
+        # <PREFIX>_API_KEY/_BASE_URL/_MODEL triple or a second vendor SDK is how
+        # suggest-followups and the query rewriter ended up reading env vars no
+        # environment set — dead on every request since launch.
+        run: node scripts/check-gateway-llm-calls.mjs
+
+      - name: Gateway LLM client gate fixtures
+        # Same reasoning as the naming-gate fixtures above: a guard that stops
+        # catching its violations is worse than no guard, because it reads as
+        # proof. These seed real violations and assert the exit code.
+        run: bun test scripts/__tests__/check-gateway-llm-calls.test.ts
+
       - name: Publish manifest gate fixtures
         # @lobu/worker@14.3.0 shipped five private workspace dependencies at
         # their `0.0.0` placeholder versions, so external installs failed

--- a/Makefile
+++ b/Makefile
@@ -293,22 +293,24 @@ review-fix:
 # NOT a substitute for the DB-backed suites (make test-integration) when you
 # touch server/runtime code — but it catches the cheap, common misses.
 pre-pr:
-	@echo "🔎 [1/5] Build workspace packages (fresh dist)..."
+	@echo "🔎 [1/6] Build workspace packages (fresh dist)..."
 	@# Typecheck resolves @lobu/* against built dist, not src. Without this a
 	@# stale core dist yields PHANTOM errors on any contract change (e.g. a new
 	@# field the dist predates) — the exact trap CI avoids by building first.
 	@make build-packages
-	@echo "🔎 [2/5] Strict typecheck (root + excluded packages)..."
+	@echo "🔎 [2/6] Strict typecheck (root + excluded packages)..."
 	@bun run typecheck
 	@for pkg in server connector-worker connector-sdk plugin-api plugin-host plugin-toolkit plugin-memory plugin-conversations plugin-media plugin-mcp embeddings cli; do \
 		echo "   typecheck packages/$$pkg..."; \
 		( cd "packages/$$pkg" && bunx tsc --noEmit ) || exit $$?; \
 	done
-	@echo "🔎 [3/5] Dead-code gate (knip --include files)..."
+	@echo "🔎 [3/6] Dead-code gate (knip --include files)..."
 	@bun run knip --include files
-	@echo "🔎 [4/5] Lint/format (biome)..."
+	@echo "🔎 [4/6] Lint/format (biome)..."
 	@bun run check
-	@echo "🔎 [5/5] Exposed surface naming (no agent-facing 'watcher')..."
+	@echo "🔎 [5/6] Exposed surface naming (no agent-facing 'watcher')..."
 	@bun scripts/check-exposed-surface-naming.ts
+	@echo "🔎 [6/6] Gateway LLM calls (no unapproved one-off clients)..."
+	@node scripts/check-gateway-llm-calls.mjs
 	@echo "✅ pre-pr gates clean. NOTE: confirm your fix is in 'git show HEAD:<file>',"
 	@echo "   not just the working tree — a fix that isn't committed won't reach CI."

--- a/config/providers.json
+++ b/config/providers.json
@@ -52,7 +52,6 @@
           "upstreamBaseUrl": "https://chatgpt.com/backend-api",
           "apiKeyInstructions": "Sign in with ChatGPT Plus/Pro, or paste an OpenAI API key",
           "apiKeyPlaceholder": "sk-...",
-          "sdkCompat": "openai",
           "modalities": ["text"],
           "oauth": {
             "clientId": "app_EMoamEEZ73f0CkXaXp7hrann",

--- a/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
@@ -10,7 +10,10 @@
  * is the behaviour this file pins down:
  *   - miss  → rewriter consulted, variant hits recovered
  *   - hit   → rewriter NEVER consulted (no fetch), result unchanged
- *   - no key / date sort / offset>0 → rescue skipped, graceful
+ *   - no provider row / date sort / offset>0 → rescue skipped, graceful
+ *
+ * Credentials come from an org-owned OpenAI-compatible provider row, so the
+ * configured case exercises row-key resolution rather than an env flag.
  *
  * Harness: vitest + embedded Postgres (real PG18 + pgvector), mirroring
  * get-content-visibility.test.ts. The LLM is stubbed at the FETCH boundary: we
@@ -35,16 +38,13 @@ import {
   createTestUser,
   seedSystemEntityTypes,
 } from '../../setup/test-fixtures';
+import {
+  createInferenceProvider,
+  setInferenceProviderDefault,
+} from '../../../lobu/stores/provider-secrets';
+import { __resetEncryptionKeyCacheForTests } from '@lobu/core';
 
-const REWRITER_ENV: Env = {
-  ENVIRONMENT: 'test',
-  QUERY_REWRITER_API_KEY: 'test-key',
-  QUERY_REWRITER_MODEL: 'gpt-4o-mini',
-} as Env;
-
-const NO_KEY_ENV: Env = {
-  ENVIRONMENT: 'test',
-} as Env;
+const ENV: Env = { ENVIRONMENT: 'test' } as Env;
 
 // The variants the stubbed LLM "rewrites" the raw query into.
 let cannedVariants: string[] = [];
@@ -83,10 +83,16 @@ describe('getContent > auto on-miss recall rescue', () => {
   let dermatologistEventId: number;
   let entEventId: number;
   let specialistEventId: number;
+  // A second org holding the SAME fixtures but no provider row — the
+  // unconfigured case. Splitting orgs (rather than toggling an env) is what the
+  // org-scoped credential model requires.
+  let bareOrg: Awaited<ReturnType<typeof createTestOrganization>>;
+  let bareEntity: Awaited<ReturnType<typeof createTestEntity>>;
+  let originalEncryptionKey: string | undefined;
 
-  function ctx(): ToolContext {
+  function ctx(organizationId: string = org.id): ToolContext {
     return {
-      organizationId: org.id,
+      organizationId,
       userId: user.id,
       memberRole: 'owner',
       isAuthenticated: true,
@@ -98,6 +104,14 @@ describe('getContent > auto on-miss recall rescue', () => {
   }
 
   beforeAll(async () => {
+    // The provider row stores its key encrypted at rest, so this suite needs a
+    // key like any credential-touching path. Set (and restore) it locally
+    // rather than depending on ambient env, so the file runs standalone.
+    originalEncryptionKey = process.env.ENCRYPTION_KEY;
+    process.env.ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    __resetEncryptionKeyCacheForTests();
+
     await initWorkspaceProvider();
     await cleanupTestDatabase();
     await seedSystemEntityTypes();
@@ -106,6 +120,32 @@ describe('getContent > auto on-miss recall rescue', () => {
     user = await createTestUser({ email: 'rescue@example.com' });
     await addUserToOrganization(user.id, org.id, 'owner');
     entity = await createTestEntity({ name: 'Rescue Entity', organization_id: org.id });
+
+    // The org's provider row IS the rewriter's configuration now.
+    const provider = await createInferenceProvider({
+      organizationId: org.id,
+      slug: 'openai',
+      kind: 'openai',
+      apiKey: 'test-key',
+      capabilities: {
+        text: { model: 'gpt-4o-mini', base_url: 'https://api.example.test/v1' },
+      },
+    });
+    if ('conflict' in provider) throw new Error('provider fixture conflicted');
+    await setInferenceProviderDefault(org.id, 'openai');
+
+    // Unconfigured org: same content, no provider row.
+    bareOrg = await createTestOrganization({ name: 'No Provider Org' });
+    await addUserToOrganization(user.id, bareOrg.id, 'owner');
+    bareEntity = await createTestEntity({
+      name: 'Bare Entity',
+      organization_id: bareOrg.id,
+    });
+    await createTestEvent({
+      organization_id: bareOrg.id,
+      entity_id: bareEntity.id,
+      content: 'The dermatologist recommended a new prescription for my skin condition.',
+    });
 
     dermatologistEventId = (
       await createTestEvent({
@@ -134,6 +174,12 @@ describe('getContent > auto on-miss recall rescue', () => {
 
   afterAll(() => {
     global.fetch = realFetch;
+    if (originalEncryptionKey !== undefined) {
+      process.env.ENCRYPTION_KEY = originalEncryptionKey;
+    } else {
+      delete process.env.ENCRYPTION_KEY;
+    }
+    __resetEncryptionKeyCacheForTests();
   });
 
   beforeEach(() => {
@@ -144,19 +190,19 @@ describe('getContent > auto on-miss recall rescue', () => {
   it('(a) a total miss triggers the rescue and recovers a variant-only session', async () => {
     // Confirm the trigger: the raw query "physician" matches nothing.
     const miss = await getContent(
-      { entity_id: entity.id, query: 'physician', limit: 50 } as never,
-      NO_KEY_ENV as never,
-      ctx()
+      { entity_id: bareEntity.id, query: 'physician', limit: 50 } as never,
+      ENV as never,
+      ctx(bareOrg.id)
     );
     expect(miss.content.length).toBe(0);
     expect(fetchCalls.length).toBe(0); // text-only path, no fetch at all
 
-    // With a rewriter key present, the same raw miss expands "physician" →
+    // With a provider row present, the same raw miss expands "physician" →
     // ["dermatologist"] and the previously-unreachable session is recovered.
     cannedVariants = ['dermatologist'];
     const rescued = await getContent(
       { entity_id: entity.id, query: 'physician', limit: 50 } as never,
-      REWRITER_ENV as never,
+      ENV as never,
       ctx()
     );
     const ids = new Set(rescued.content.map((c) => c.id));
@@ -172,7 +218,7 @@ describe('getContent > auto on-miss recall rescue', () => {
     cannedVariants = ['specialist', 'ENT'];
     const result = await getContent(
       { entity_id: entity.id, query: 'dermatologist', limit: 50 } as never,
-      REWRITER_ENV as never,
+      ENV as never,
       ctx()
     );
     const ids = new Set(result.content.map((c) => c.id));
@@ -181,15 +227,15 @@ describe('getContent > auto on-miss recall rescue', () => {
     expect(rewriteCalls().length).toBe(0);
   });
 
-  it('(c) miss with no API key is graceful: empty result, no crash, no fetch', async () => {
+  it('(c) miss in an org with no provider row is graceful: empty, no crash, no fetch', async () => {
     cannedVariants = ['dermatologist']; // would recover IF the rewriter ran
     const result = await getContent(
-      { entity_id: entity.id, query: 'physician', limit: 50 } as never,
-      NO_KEY_ENV as never,
-      ctx()
+      { entity_id: bareEntity.id, query: 'physician', limit: 50 } as never,
+      ENV as never,
+      ctx(bareOrg.id)
     );
     expect(result.content.length).toBe(0);
-    // rewriteQueries() short-circuits on the missing key before any fetch.
+    // resolveCompletionTarget() returns null before any fetch is attempted.
     expect(fetchCalls.length).toBe(0);
   });
 
@@ -197,7 +243,7 @@ describe('getContent > auto on-miss recall rescue', () => {
     cannedVariants = ['dermatologist', 'ENT', 'specialist'];
     const result = await getContent(
       { entity_id: entity.id, query: 'physician', limit: 2 } as never,
-      REWRITER_ENV as never,
+      ENV as never,
       ctx()
     );
     expect(result.content.length).toBe(2);
@@ -209,7 +255,7 @@ describe('getContent > auto on-miss recall rescue', () => {
     cannedVariants = ['dermatologist', 'ENT', 'specialist'];
     const wide = await getContent(
       { entity_id: entity.id, query: 'physician', limit: 50 } as never,
-      REWRITER_ENV as never,
+      ENV as never,
       ctx()
     );
     const wideIds = new Set(wide.content.map((c) => c.id));
@@ -224,7 +270,7 @@ describe('getContent > auto on-miss recall rescue', () => {
     cannedVariants = ['dermatologist'];
     const result = await getContent(
       { entity_id: entity.id, query: 'physician', limit: 50, sort_by: 'date' } as never,
-      REWRITER_ENV as never,
+      ENV as never,
       ctx()
     );
     expect(rewriteCalls().length).toBe(0);
@@ -237,7 +283,7 @@ describe('getContent > auto on-miss recall rescue', () => {
     cannedVariants = ['dermatologist'];
     const result = await getContent(
       { entity_id: entity.id, query: 'physician', limit: 2, offset: 2 } as never,
-      REWRITER_ENV as never,
+      ENV as never,
       ctx()
     );
     expect(result.content.length).toBe(0);

--- a/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
+++ b/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
@@ -66,12 +66,34 @@ async function newOrgWithProvider(slug: string, model: string) {
   return orgId;
 }
 
+/** A second, NON-default provider in an existing org. */
+async function addProvider(orgId: string, slug: string, model: string) {
+  const created = await createInferenceProvider({
+    organizationId: orgId,
+    slug,
+    kind: slug,
+    apiKey: `sk-${slug}-test`,
+    capabilities: { text: { model } },
+  });
+  if ('error' in created) throw new Error(`create failed: ${created.error}`);
+}
+
 function register(module: Record<string, unknown>) {
   moduleRegistry.register({
     isEnabled: () => true,
     getSecretEnvVarNames: () => [],
     ...module,
   } as unknown as ModuleInterface);
+}
+
+function registerOpenAiCompatible(providerId: string, upstreamBaseUrl: string) {
+  register({
+    name: `${providerId}-api-key`,
+    providerId,
+    providerDisplayName: providerId,
+    sdkCompat: 'openai',
+    getUpstreamConfig: () => ({ slug: providerId, upstreamBaseUrl }),
+  });
 }
 
 describe('resolveCompletionTarget protocol gating', () => {
@@ -122,9 +144,13 @@ describe('resolveCompletionTarget protocol gating', () => {
    *
    * Registering config-first inverts the outcome and the provider resolves.
    * A live e2e that got this order wrong reported a false failure, which is
-   * exactly why this is pinned: if someone moves the config loop above the
-   * specialized registrations, chat completions would start egressing to
-   * chatgpt.com/backend-api.
+   * what prompted pinning it.
+   *
+   * SCOPE: this simulates the two registry states directly; it does not import
+   * core-services, so reordering the real registrations there would NOT fail
+   * here. What it pins is the consequence — that whichever module wins the
+   * providerId lookup decides the protocol — so the resolver's behaviour under
+   * each state is locked even though the wiring that produces them is not.
    */
   it('the specialized module wins over the config entry, and only because it registers first', async () => {
     const orgId = await newOrgWithProvider('chatgpt', 'gpt-5');
@@ -172,6 +198,60 @@ describe('resolveCompletionTarget protocol gating', () => {
     const chatgpt = cfg.providers.find((g) => g.id === 'chatgpt');
     expect(chatgpt).toBeDefined();
     expect(chatgpt?.providers[0]?.sdkCompat).toBeUndefined();
+  });
+
+  /**
+   * `modelRef` overrides — the branch a guardrail's `model` field drives.
+   *
+   * Historically that field held a RAW model id (`gpt-4o-mini`) posted to one
+   * operator-configured base URL. Now that credentials come from provider rows
+   * a ref may ALSO be `<slug>/<model>`, and the two cannot be told apart by
+   * looking for a "/": provider-native ids contain them (`anthropic/claude-…`,
+   * `nvidia/moonshotai/kimi-k2.6`). So the resolver tries the prefix as a slug
+   * and only accepts that reading if the org has such a row.
+   *
+   * All of this was previously untested — every other case here resolves the
+   * org default with no ref at all.
+   */
+  describe('modelRef override', () => {
+    it('a qualified <slug>/<model> ref routes to THAT provider, not the default', async () => {
+      const orgId = await newOrgWithProvider('groq', 'llama-3.3-70b-versatile');
+      await addProvider(orgId, 'together-ai', 'Qwen/Qwen2.5-72B-Instruct-Turbo');
+      registerOpenAiCompatible('groq', 'https://api.groq.com/openai/v1');
+      registerOpenAiCompatible('together-ai', 'https://api.together.xyz/v1');
+
+      const target = await resolveCompletionTarget(orgId, 'together-ai/deepseek-ai/DeepSeek-V3');
+      // The ref names a real row, so the prefix IS the slug — and the rest of
+      // the string stays whole, slashes included.
+      expect(target?.baseUrl).toBe('https://api.together.xyz/v1');
+      expect(target?.model).toBe('deepseek-ai/DeepSeek-V3');
+    });
+
+    it('a BARE model ref borrows the default provider credentials', async () => {
+      const orgId = await newOrgWithProvider('groq', 'llama-3.3-70b-versatile');
+      registerOpenAiCompatible('groq', 'https://api.groq.com/openai/v1');
+
+      const target = await resolveCompletionTarget(orgId, 'llama-3.1-8b-instant');
+      // No "/" at all: the operator's raw model id runs on the org default.
+      expect(target?.baseUrl).toBe('https://api.groq.com/openai/v1');
+      expect(target?.model).toBe('llama-3.1-8b-instant');
+    });
+
+    it('a provider-native ref whose prefix is NOT a row is kept whole', async () => {
+      const orgId = await newOrgWithProvider('openrouter', 'auto');
+      registerOpenAiCompatible('openrouter', 'https://openrouter.ai/api/v1');
+
+      // `anthropic/` is openrouter's MODEL namespace here, not a provider row.
+      // Splitting on it would misroute to a provider the org does not have.
+      const target = await resolveCompletionTarget(orgId, 'anthropic/claude-sonnet-5');
+      expect(target?.baseUrl).toBe('https://openrouter.ai/api/v1');
+      expect(target?.model).toBe('anthropic/claude-sonnet-5');
+    });
+
+    it('an override is skipped when the org has no default to borrow from', async () => {
+      const org = await createTestOrganization();
+      expect(await resolveCompletionTarget(org.id, 'some-model')).toBeNull();
+    });
   });
 
   it('does NOT resolve an explicitly non-OpenAI protocol', async () => {

--- a/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
+++ b/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
@@ -10,7 +10,7 @@
  * LONG before it reaches the protocol check, so a registry-only test would
  * pass even with the check deleted.
  */
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import {
   __resetEncryptionKeyCacheForTests,
   moduleRegistry,
@@ -32,6 +32,12 @@ beforeAll(() => {
   process.env.LOBU_ENCRYPTION_KEY ||= 'a'.repeat(64);
   __resetEncryptionKeyCacheForTests();
   savedModules = new Map(registry.modules);
+});
+
+// The registry is process-global; a module leaking into the next test would
+// silently change which one wins the providerId lookup.
+afterEach(() => {
+  registry.modules = new Map(savedModules);
 });
 
 afterAll(async () => {
@@ -97,6 +103,52 @@ describe('resolveCompletionTarget protocol gating', () => {
       }),
     });
 
+    expect(await resolveCompletionTarget(orgId)).toBeNull();
+  });
+
+  /**
+   * The ordering is what makes the case above real, so assert it directly.
+   *
+   * providers.json DOES declare `sdkCompat: "openai"` for id `chatgpt`. It
+   * never takes effect because core-services registers the specialized module
+   * FIRST and the config loop then skips ids already claimed
+   * (`registeredIds.has(id)`). `getModelProviderModules().find()` returns the
+   * first match by providerId, so the OAuth module — sdkCompat undefined —
+   * wins.
+   *
+   * Registering config-first inverts the outcome and the provider resolves.
+   * A live e2e that got this order wrong reported a false failure, which is
+   * exactly why this is pinned: if someone moves the config loop above the
+   * specialized registrations, chat completions would start egressing to
+   * chatgpt.com/backend-api.
+   */
+  it('the specialized module wins over the config entry, and only because it registers first', async () => {
+    const orgId = await newOrgWithProvider('chatgpt', 'gpt-5');
+
+    // Config-first: providers.json's sdkCompat "openai" wins and it resolves.
+    register({
+      name: 'chatgpt-config-driven',
+      providerId: 'chatgpt',
+      providerDisplayName: 'ChatGPT',
+      sdkCompat: 'openai',
+      getUpstreamConfig: () => ({
+        slug: 'chatgpt',
+        upstreamBaseUrl: 'https://chatgpt.com/backend-api',
+      }),
+    });
+    expect(await resolveCompletionTarget(orgId)).not.toBeNull();
+
+    // Production order: specialized first, config skipped. Now it does not.
+    registry.modules = new Map(savedModules);
+    register({
+      name: 'chatgpt-oauth',
+      providerId: 'chatgpt',
+      providerDisplayName: 'ChatGPT (subscription login)',
+      getUpstreamConfig: () => ({
+        slug: 'openai-codex',
+        upstreamBaseUrl: 'https://chatgpt.com/backend-api',
+      }),
+    });
     expect(await resolveCompletionTarget(orgId)).toBeNull();
   });
 

--- a/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
+++ b/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
@@ -10,6 +10,8 @@
  * LONG before it reaches the protocol check, so a registry-only test would
  * pass even with the check deleted.
  */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import {
   __resetEncryptionKeyCacheForTests,
@@ -74,18 +76,20 @@ function register(module: Record<string, unknown>) {
 
 describe('resolveCompletionTarget protocol gating', () => {
   /**
-   * The ChatGPT subscription provider. It is registered by a SPECIALIZED module
-   * (`ChatGPTOAuthModule`, core-services.ts) which claims `providerId:
-   * "chatgpt"` BEFORE the config-driven loop runs — so providers.json's
-   * `sdkCompat: "openai"` for that id is never applied and the winning module
-   * leaves it undefined.
+   * The ChatGPT subscription provider resolves to null, and that is CORRECT.
    *
-   * Resolving to null is CORRECT here, not an oversight. Its upstream is
-   * `chatgpt.com/backend-api` — Codex's subscription backend, not an
-   * OpenAI-compatible `/chat/completions` API. The module's own comment records
-   * the incident: an `openai/<model>` request that leaked to that host returned
+   * Its upstream is `chatgpt.com/backend-api` — Codex's subscription backend,
+   * not an OpenAI-compatible `/chat/completions` API. Its models endpoint
+   * returns `{models:[{slug,title}]}` rather than OpenAI's `{data:[{id}]}`
+   * (chatgpt-oauth-module.ts:94), and that module's comment records the
+   * incident where an `openai/<model>` request leaking to this host returned
    * `403` without a ChatGPT session. Treating "undefined sdkCompat" as
    * "probably OpenAI" would re-create exactly that misroute.
+   *
+   * providers.json used to declare `sdkCompat: "openai"` for this id. It was
+   * inert — the specialized module claims the id first and the config loop
+   * skips it — but it was still a false claim about the wire protocol, so it
+   * has been removed. `sdkCompatIsNotDeclaredForChatgpt` below pins that.
    *
    * If ChatGPT should ever back these features, the fix is to give it a real
    * OpenAI-compatible upstream — not to loosen this check.
@@ -150,6 +154,24 @@ describe('resolveCompletionTarget protocol gating', () => {
       }),
     });
     expect(await resolveCompletionTarget(orgId)).toBeNull();
+  });
+
+  /**
+   * The config must not claim a protocol the upstream does not speak.
+   *
+   * This was inert (the specialized module wins the id), but a false entry is
+   * a trap: `buildProviderCatalog` resolves `config?.sdkCompat ?? module…`, so
+   * config wins wherever it IS consulted. With it removed, the catalog, the
+   * API-key creation gate in agent-routes.ts, and this resolver all agree that
+   * chatgpt is not routable as OpenAI.
+   */
+  it('providers.json does not declare an OpenAI protocol for chatgpt', async () => {
+    const cfg = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, '../../../../../config/providers.json'), 'utf8'),
+    ) as { providers: Array<{ id: string; providers: Array<{ sdkCompat?: string }> }> };
+    const chatgpt = cfg.providers.find((g) => g.id === 'chatgpt');
+    expect(chatgpt).toBeDefined();
+    expect(chatgpt?.providers[0]?.sdkCompat).toBeUndefined();
   });
 
   it('does NOT resolve an explicitly non-OpenAI protocol', async () => {

--- a/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
+++ b/packages/server/src/__tests__/integration/gateway-completion-resolve.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `resolveCompletionTarget` protocol gating, against REAL provider rows.
+ *
+ * These features speak ONE wire protocol: OpenAI-compatible
+ * `POST {baseUrl}/chat/completions`. A provider whose upstream speaks anything
+ * else must resolve to null so the caller fails open, rather than posting a
+ * chat/completions body somewhere that cannot parse it.
+ *
+ * A real row is required: the resolver returns null on a missing credential
+ * LONG before it reaches the protocol check, so a registry-only test would
+ * pass even with the check deleted.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  __resetEncryptionKeyCacheForTests,
+  moduleRegistry,
+  type ModuleInterface,
+} from '@lobu/core';
+import { createInferenceProvider } from '../../lobu/stores/provider-secrets';
+import { resolveCompletionTarget } from '../../gateway/inference/gateway-completion';
+import { getDb } from '../../db/client';
+import { cleanupTestDatabase } from '../setup/test-db';
+import { createTestOrganization } from '../setup/test-fixtures';
+
+const registry = moduleRegistry as unknown as {
+  modules: Map<string, ModuleInterface>;
+};
+
+let savedModules: Map<string, ModuleInterface>;
+
+beforeAll(() => {
+  process.env.LOBU_ENCRYPTION_KEY ||= 'a'.repeat(64);
+  __resetEncryptionKeyCacheForTests();
+  savedModules = new Map(registry.modules);
+});
+
+afterAll(async () => {
+  registry.modules = savedModules;
+  await cleanupTestDatabase();
+});
+
+async function newOrgWithProvider(slug: string, model: string) {
+  const org = await createTestOrganization();
+  const orgId = org.id;
+  const created = await createInferenceProvider({
+    organizationId: orgId,
+    slug,
+    kind: slug,
+    apiKey: 'sk-resolver-test',
+    capabilities: { text: { model } },
+  });
+  if ('error' in created) throw new Error(`create failed: ${created.error}`);
+  // main does not auto-promote; flag it so the resolver has a default to read.
+  await getDb()`
+    UPDATE inference_providers SET is_default = true
+    WHERE organization_id = ${orgId} AND slug = ${slug}
+  `;
+  return orgId;
+}
+
+function register(module: Record<string, unknown>) {
+  moduleRegistry.register({
+    isEnabled: () => true,
+    getSecretEnvVarNames: () => [],
+    ...module,
+  } as unknown as ModuleInterface);
+}
+
+describe('resolveCompletionTarget protocol gating', () => {
+  /**
+   * The ChatGPT subscription provider. It is registered by a SPECIALIZED module
+   * (`ChatGPTOAuthModule`, core-services.ts) which claims `providerId:
+   * "chatgpt"` BEFORE the config-driven loop runs — so providers.json's
+   * `sdkCompat: "openai"` for that id is never applied and the winning module
+   * leaves it undefined.
+   *
+   * Resolving to null is CORRECT here, not an oversight. Its upstream is
+   * `chatgpt.com/backend-api` — Codex's subscription backend, not an
+   * OpenAI-compatible `/chat/completions` API. The module's own comment records
+   * the incident: an `openai/<model>` request that leaked to that host returned
+   * `403` without a ChatGPT session. Treating "undefined sdkCompat" as
+   * "probably OpenAI" would re-create exactly that misroute.
+   *
+   * If ChatGPT should ever back these features, the fix is to give it a real
+   * OpenAI-compatible upstream — not to loosen this check.
+   */
+  it('does NOT resolve a provider whose module leaves sdkCompat undefined', async () => {
+    const orgId = await newOrgWithProvider('chatgpt', 'gpt-5');
+    register({
+      name: 'chatgpt-oauth',
+      providerId: 'chatgpt',
+      providerDisplayName: 'ChatGPT (subscription login)',
+      // Deliberately absent — mirrors ChatGPTOAuthModule.
+      getUpstreamConfig: () => ({
+        slug: 'openai-codex',
+        upstreamBaseUrl: 'https://chatgpt.com/backend-api',
+      }),
+    });
+
+    expect(await resolveCompletionTarget(orgId)).toBeNull();
+  });
+
+  it('does NOT resolve an explicitly non-OpenAI protocol', async () => {
+    const orgId = await newOrgWithProvider('anthropic', 'claude-sonnet-5');
+    register({
+      name: 'anthropic-api-key',
+      providerId: 'anthropic',
+      providerDisplayName: 'Anthropic',
+      sdkCompat: 'anthropic',
+      getUpstreamConfig: () => ({
+        slug: 'anthropic',
+        upstreamBaseUrl: 'https://api.anthropic.com',
+      }),
+    });
+
+    expect(await resolveCompletionTarget(orgId)).toBeNull();
+  });
+
+  /** The positive control: same shape, only sdkCompat differs. */
+  it('DOES resolve an OpenAI-compatible module', async () => {
+    const orgId = await newOrgWithProvider('groq', 'llama-3.3-70b-versatile');
+    register({
+      name: 'groq-api-key',
+      providerId: 'groq',
+      providerDisplayName: 'Groq',
+      sdkCompat: 'openai',
+      getUpstreamConfig: () => ({
+        slug: 'groq',
+        upstreamBaseUrl: 'https://api.groq.com/openai/v1',
+      }),
+    });
+
+    const target = await resolveCompletionTarget(orgId);
+    expect(target).not.toBeNull();
+    expect(target?.baseUrl).toBe('https://api.groq.com/openai/v1');
+    expect(target?.model).toBe('llama-3.3-70b-versatile');
+  });
+});

--- a/packages/server/src/__tests__/unit/gateway-completion.test.ts
+++ b/packages/server/src/__tests__/unit/gateway-completion.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { gatewayCompletion } from "../../gateway/inference/gateway-completion";
+
+const TARGET = {
+  baseUrl: "https://api.example.test/v1",
+  apiKey: "sk-test",
+  model: "test-model",
+};
+
+let restore: (() => void) | null = null;
+afterEach(() => {
+  restore?.();
+  restore = null;
+});
+
+/** Stub `fetch`, capturing the request for assertions. */
+function stubFetch(
+  body: unknown,
+  init: { ok?: boolean } = {}
+): { calls: Array<{ url: string; init: RequestInit }> } {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string, requestInit: RequestInit) => {
+    calls.push({ url: String(url), init: requestInit });
+    return new Response(JSON.stringify(body), {
+      status: init.ok === false ? 500 : 200,
+    });
+  }) as unknown as typeof fetch;
+  restore = () => {
+    globalThis.fetch = original;
+  };
+  return { calls };
+}
+
+function completionBody(content: string) {
+  return { choices: [{ message: { content } }] };
+}
+
+describe("gatewayCompletion", () => {
+  test("posts an OpenAI-compatible chat/completions request", async () => {
+    const { calls } = stubFetch(completionBody("hello"));
+
+    const out = await gatewayCompletion({
+      target: TARGET,
+      systemPrompt: "SYS",
+      userPrompt: "USER",
+      timeoutMs: 5_000,
+    });
+
+    expect(out).toBe("hello");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://api.example.test/v1/chat/completions");
+
+    const sent = JSON.parse(String(calls[0]?.init.body));
+    expect(sent.model).toBe("test-model");
+    expect(sent.messages).toEqual([
+      { role: "system", content: "SYS" },
+      { role: "user", content: "USER" },
+    ]);
+    // These callers all parse strict JSON, so determinism is the default.
+    expect(sent.temperature).toBe(0);
+  });
+
+  test("sends the key as a bearer token", async () => {
+    const { calls } = stubFetch(completionBody("ok"));
+    await gatewayCompletion({
+      target: TARGET,
+      systemPrompt: "s",
+      userPrompt: "u",
+      timeoutMs: 5_000,
+    });
+    const headers = calls[0]?.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer sk-test");
+  });
+
+  test("an explicit temperature overrides the deterministic default", async () => {
+    const { calls } = stubFetch(completionBody("ok"));
+    await gatewayCompletion({
+      target: TARGET,
+      systemPrompt: "s",
+      userPrompt: "u",
+      temperature: 0.3,
+      timeoutMs: 5_000,
+    });
+    expect(JSON.parse(String(calls[0]?.init.body)).temperature).toBe(0.3);
+  });
+
+  test("throws on a non-ok response", async () => {
+    stubFetch({}, { ok: false });
+    await expect(
+      gatewayCompletion({
+        target: TARGET,
+        systemPrompt: "s",
+        userPrompt: "u",
+        timeoutMs: 5_000,
+      })
+    ).rejects.toThrow(/500/);
+  });
+
+  test("throws when the response carries no text", async () => {
+    stubFetch({ choices: [{ message: { content: null } }] });
+    await expect(
+      gatewayCompletion({
+        target: TARGET,
+        systemPrompt: "s",
+        userPrompt: "u",
+        timeoutMs: 5_000,
+      })
+    ).rejects.toThrow(/no text/);
+  });
+
+  test("an elapsed timeout aborts the request", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = ((_url: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () =>
+          reject(new Error("aborted"))
+        );
+      })) as unknown as typeof fetch;
+    restore = () => {
+      globalThis.fetch = original;
+    };
+
+    await expect(
+      gatewayCompletion({
+        target: TARGET,
+        systemPrompt: "s",
+        userPrompt: "u",
+        timeoutMs: 10,
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/server/src/__tests__/unit/suggest-followups.test.ts
+++ b/packages/server/src/__tests__/unit/suggest-followups.test.ts
@@ -10,14 +10,27 @@ import type { Guardrail } from "@lobu/core";
 const REPLY =
   "I looked at the connector and it polls every 15 minutes. The rate limit is 100 requests per hour, so the current schedule leaves plenty of headroom.";
 
-function env(over: Record<string, string | undefined> = {}) {
-  return {
-    SUGGESTION_GENERATOR_API_KEY: "sk-test",
-    SUGGESTION_GENERATOR_BASE_URL: "https://api.example.com/v1",
-    SUGGESTION_GENERATOR_MODEL: "gpt-test",
+const ORG = "org-test";
+const ORG_DEFAULT_MODEL = "gpt-test";
+
+/**
+ * Stub target resolution so unit tests stay DB-free. Injected via
+ * `options.resolveTarget` rather than `mock.module`, which is process-global in
+ * Bun and corrupts sibling suites.
+ */
+function target(
+  over: Partial<{ baseUrl: string; apiKey: string; model: string }> = {}
+) {
+  return async () => ({
+    baseUrl: "https://api.example.com/v1",
+    apiKey: "sk-test",
+    model: ORG_DEFAULT_MODEL,
     ...over,
-  };
+  });
 }
+
+/** Resolution that finds nothing — the org has no provider row. */
+const noTarget = async () => null;
 
 /** Stub `fetch` with a canned chat-completion body. */
 function stubFetch(content: string | null, ok = true): () => void {
@@ -87,7 +100,7 @@ describe("generateSuggestFollowups", () => {
         ],
       })
     );
-    const out = await generateSuggestFollowups(REPLY, env());
+    const out = await generateSuggestFollowups(REPLY, ORG, { resolveTarget: target() });
     expect(out).toHaveLength(2);
     expect(out[0]).toEqual({
       title: "Raise the interval",
@@ -99,11 +112,11 @@ describe("generateSuggestFollowups", () => {
     restore = stubFetch(
       '```json\n{"prompts":[{"title":"T","message":"M"}]}\n```'
     );
-    const out = await generateSuggestFollowups(REPLY, env());
+    const out = await generateSuggestFollowups(REPLY, ORG, { resolveTarget: target() });
     expect(out).toEqual([{ title: "T", message: "M" }]);
   });
 
-  test("returns [] when unconfigured rather than calling out", async () => {
+  test("returns [] when the org resolves no model, without calling out", async () => {
     let called = false;
     const original = globalThis.fetch;
     globalThis.fetch = (async () => {
@@ -114,10 +127,9 @@ describe("generateSuggestFollowups", () => {
       globalThis.fetch = original;
     };
 
-    const out = await generateSuggestFollowups(
-      REPLY,
-      env({ SUGGESTION_GENERATOR_API_KEY: undefined })
-    );
+    const out = await generateSuggestFollowups(REPLY, ORG, {
+      resolveTarget: noTarget,
+    });
     expect(out).toEqual([]);
     expect(called).toBe(false);
   });
@@ -133,21 +145,21 @@ describe("generateSuggestFollowups", () => {
       globalThis.fetch = original;
     };
 
-    const out = await generateSuggestFollowups("ok", env());
+    const out = await generateSuggestFollowups("ok", ORG, { resolveTarget: target() });
     expect(out).toEqual([]);
     expect(called).toBe(false);
   });
 
   test("returns [] when the model HTTP-errors", async () => {
     restore = stubFetch("{}", false);
-    const out = await generateSuggestFollowups(REPLY, env());
+    const out = await generateSuggestFollowups(REPLY, ORG, { resolveTarget: target() });
     expect(out).toEqual([]);
   });
 
-  // A per-agent `model` is the one override worth having: the credentials are
-  // an operator secret, but model choice decides whether chips arrive at all
-  // (a slow reasoning model times out and silently yields none).
-  test("a per-guardrail model overrides the env model", async () => {
+  // A per-agent `model` is the one override worth having: credentials come from
+  // the org's provider row either way, but model choice decides whether chips
+  // arrive at all (a slow reasoning model times out and silently yields none).
+  test("a per-guardrail model ref overrides the org default", async () => {
     let sentModel: string | undefined;
     const original = globalThis.fetch;
     globalThis.fetch = (async (_url: string, init: RequestInit) => {
@@ -168,14 +180,15 @@ describe("generateSuggestFollowups", () => {
       globalThis.fetch = original;
     };
 
-    const out = await generateSuggestFollowups(REPLY, env(), {
-      model: "per-agent-model",
+    const out = await generateSuggestFollowups(REPLY, ORG, {
+      model: "prov/per-agent-model",
+      resolveTarget: target({ model: "per-agent-model" }),
     });
     expect(sentModel).toBe("per-agent-model");
     expect(out).toEqual([{ title: "T", message: "M" }]);
   });
 
-  test("falls back to the env model when the guardrail sets none", async () => {
+  test("falls back to the org default model when the guardrail sets none", async () => {
     let sentModel: string | undefined;
     const original = globalThis.fetch;
     globalThis.fetch = (async (_url: string, init: RequestInit) => {
@@ -190,8 +203,8 @@ describe("generateSuggestFollowups", () => {
       globalThis.fetch = original;
     };
 
-    await generateSuggestFollowups(REPLY, env(), {});
-    expect(sentModel).toBe(env().SUGGESTION_GENERATOR_MODEL);
+    await generateSuggestFollowups(REPLY, ORG, { resolveTarget: target() });
+    expect(sentModel).toBe(ORG_DEFAULT_MODEL);
   });
 
   test("an elapsed timeout yields [] rather than throwing", async () => {
@@ -206,7 +219,10 @@ describe("generateSuggestFollowups", () => {
       globalThis.fetch = original;
     };
 
-    const out = await generateSuggestFollowups(REPLY, env(), { timeoutMs: 10 });
+    const out = await generateSuggestFollowups(REPLY, ORG, {
+      timeoutMs: 10,
+      resolveTarget: target(),
+    });
     expect(out).toEqual([]);
   });
 });

--- a/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
@@ -521,7 +521,11 @@ describe("ChatResponseBridge.handleCompletion — multi-replica finalText", () =
       organizationId: "org-1",
       publicGatewayUrl: "",
     });
-    const bridge = new ChatResponseBridge(manager as any);
+    const bridge = new ChatResponseBridge(manager as any, async () => ({
+      baseUrl: "https://example.test/v1",
+      apiKey: "test-key",
+      model: "test-model",
+    }));
     const registry = new GuardrailRegistry();
     registerBuiltinGuardrails(registry);
     bridge.setGuardrails(
@@ -536,14 +540,6 @@ describe("ChatResponseBridge.handleCompletion — multi-replica finalText", () =
     bridge.setInteractionService({ postSuggestion } as any);
 
     const originalFetch = globalThis.fetch;
-    const previousEnv = {
-      key: process.env.SUGGESTION_GENERATOR_API_KEY,
-      baseUrl: process.env.SUGGESTION_GENERATOR_BASE_URL,
-      model: process.env.SUGGESTION_GENERATOR_MODEL,
-    };
-    process.env.SUGGESTION_GENERATOR_API_KEY = "test-key";
-    process.env.SUGGESTION_GENERATOR_BASE_URL = "https://example.test/v1";
-    process.env.SUGGESTION_GENERATOR_MODEL = "test-model";
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
@@ -581,15 +577,6 @@ describe("ChatResponseBridge.handleCompletion — multi-replica finalText", () =
       await waitFor(() => postSuggestion.mock.calls.length > 0);
     } finally {
       globalThis.fetch = originalFetch;
-      if (previousEnv.key === undefined)
-        delete process.env.SUGGESTION_GENERATOR_API_KEY;
-      else process.env.SUGGESTION_GENERATOR_API_KEY = previousEnv.key;
-      if (previousEnv.baseUrl === undefined)
-        delete process.env.SUGGESTION_GENERATOR_BASE_URL;
-      else process.env.SUGGESTION_GENERATOR_BASE_URL = previousEnv.baseUrl;
-      if (previousEnv.model === undefined)
-        delete process.env.SUGGESTION_GENERATOR_MODEL;
-      else process.env.SUGGESTION_GENERATOR_MODEL = previousEnv.model;
     }
 
     expect(postSuggestion).toHaveBeenCalledTimes(1);

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -30,6 +30,7 @@ import {
   type OutputGuardrailTrip,
 } from "../guardrails/output-scan.js";
 import { generateSuggestFollowups } from "../guardrails/suggest-followups.js";
+import { resolveCompletionTarget } from "../inference/gateway-completion.js";
 import type { ThreadResponsePayload } from "../infrastructure/queue/index.js";
 import type { InteractionService } from "../interactions.js";
 import {
@@ -113,7 +114,10 @@ export class ChatResponseBridge implements ResponseRenderer {
    */
   private readonly outputGuardrail = new OutputGuardrailScanner();
 
-  constructor(private manager: ChatInstanceManager) {}
+  constructor(
+    private manager: ChatInstanceManager,
+    private readonly resolveCompletionTargetFn = resolveCompletionTarget
+  ) {}
 
   /**
    * Wire output-stage guardrails. Both must be set for guardrails to run;
@@ -236,8 +240,9 @@ export class ChatResponseBridge implements ResponseRenderer {
         organizationId
       );
       if (!config) return;
-      const prompts = await generateSuggestFollowups(replyText, undefined, {
+      const prompts = await generateSuggestFollowups(replyText, organizationId, {
         model: config.model,
+        resolveTarget: this.resolveCompletionTargetFn,
       });
       if (prompts.length === 0) return;
       await this.interactionService.postSuggestion(

--- a/packages/server/src/gateway/guardrails/suggest-followups.ts
+++ b/packages/server/src/gateway/guardrails/suggest-followups.ts
@@ -12,12 +12,10 @@
  * secret-bearing reply never reaches this LLM call. See
  * {@link isEnrichmentGuardrail}.
  *
- * Opt-in transport: process env `SUGGESTION_GENERATOR_API_KEY` +
- * `SUGGESTION_GENERATOR_BASE_URL` + `SUGGESTION_GENERATOR_MODEL` (OpenAI-
- * compatible chat/completions). Incomplete config or any failure fails open
- * (no chips) — same state as before this guardrail existed. Lives in the
- * gateway (not `@lobu/core`) so the generation pipeline stays a server
- * concern next to the other built-ins.
+ * Transport: the shared {@link gatewayCompletion} client, resolving an
+ * org-owned OpenAI-compatible provider key. OAuth-only and non-OpenAI
+ * providers are not callable through this transport. An unsupported provider,
+ * unresolvable model, or any failure fails open (no chips).
  */
 
 import {
@@ -27,6 +25,10 @@ import {
   type Guardrail,
   type SuggestedPrompt,
 } from "@lobu/core";
+import {
+  gatewayCompletion,
+  resolveCompletionTarget,
+} from "../inference/gateway-completion.js";
 
 const logger = createLogger("suggest-followups");
 
@@ -55,10 +57,12 @@ const MAX_INPUT_CHARS = 6_000;
  * (MCP_PROXY_FETCH_TIMEOUT_MS, TRANSCRIPTION_FETCH_TIMEOUT_MS) rather than like
  * the blocking judges, which fail fast because a turn is stalled behind them.
  *
- * Do not trim this without measuring the configured model: reasoning-tier
- * models are slow here (glm-4.7 measured 19-26s, glm-4.6 16.7s, glm-4.5-air
- * 21.9s on 2026-07-28), and a timeout below the model's real latency yields
- * zero chips on every turn while still paying for the call.
+ * Do not trim this without measuring the org's model: reasoning-tier models are
+ * slow here (glm-4.7 measured 19-26s, glm-4.6 16.7s, glm-4.5-air 21.9s on
+ * 2026-07-28), and a timeout below the model's real latency yields zero chips
+ * on every turn while still paying for the call. Since the model comes from the
+ * org's provider row it can be ANY tier, so sizing for the slow end is the safe
+ * default.
  */
 const DEFAULT_TIMEOUT_MS = 60_000;
 const MIN_REPLY_CHARS = 40;
@@ -77,18 +81,6 @@ const SYSTEM_PROMPT = [
   "Do not offer an action the assistant already completed in the reply.",
   'Return STRICT JSON {"prompts":[{"title":"...","message":"..."}]} only.',
 ].join("\n");
-
-interface ChatCompletionResponse {
-  choices?: Array<{
-    message?: { content?: string | null } | null;
-  } | null> | null;
-}
-
-export interface SuggestFollowupsEnv {
-  SUGGESTION_GENERATOR_API_KEY?: string;
-  SUGGESTION_GENERATOR_BASE_URL?: string;
-  SUGGESTION_GENERATOR_MODEL?: string;
-}
 
 /**
  * Built-in registration stub. The actual generation runs out-of-band after
@@ -110,79 +102,60 @@ export function createSuggestFollowupsGuardrail(): Guardrail<"output"> {
 }
 
 /** Per-guardrail overrides, from the agent's `suggest-followups` entry. */
-export interface SuggestFollowupsOptions {
-  /** `model` on the guardrail entry — wins over SUGGESTION_GENERATOR_MODEL. */
+interface SuggestFollowupsOptions {
+  /**
+   * `model` on the guardrail entry. Wins over the org default — the one knob
+   * worth varying, since a slow reasoning model yields nothing under any sane
+   * timeout and chip quality differs sharply by tier. Mirrors how a judge
+   * guardrail's `model` field already works.
+   *
+   * Accepts EITHER form. `<slug>/<model>` routes to that provider row;
+   * anything else is treated as a bare model id and runs on the org's default
+   * provider — which is what this field always meant before credentials moved
+   * to `inference_providers`, so existing values keep working. See
+   * {@link resolveCompletionTarget}.
+   */
   model?: string;
   /** Abort budget; defaults to {@link DEFAULT_TIMEOUT_MS}. */
   timeoutMs?: number;
+  /**
+   * Test seam for target resolution, which otherwise reads Postgres. Injected
+   * rather than mocked because Bun's `mock.module` is process-global and
+   * corrupts sibling suites (see connector-discovery.test.ts).
+   */
+  resolveTarget?: typeof resolveCompletionTarget;
 }
 
 /**
  * Derive follow-up chips from the (already scanned) agent reply. Returns []
- * when unconfigured, on short replies, or on any failure.
- *
- * The credentials stay env-scoped (an operator secret, not agent-editable), but
- * `model` is per-agent: it is the one knob worth varying — a slow reasoning
- * model yields nothing under any sane timeout, and chip quality differs sharply
- * by tier. It mirrors how a judge guardrail's `model` field already works.
+ * when no model resolves for the org, on short replies, or on any failure —
+ * this guardrail never blocks a turn, so every path fails open.
  */
 export async function generateSuggestFollowups(
   replyText: string,
-  env: SuggestFollowupsEnv = process.env as SuggestFollowupsEnv,
+  organizationId: string,
   options: SuggestFollowupsOptions = {}
 ): Promise<SuggestedPrompt[]> {
-  const apiKey = env.SUGGESTION_GENERATOR_API_KEY?.trim();
-  const configuredBaseUrl = env.SUGGESTION_GENERATOR_BASE_URL?.trim();
-  const model =
-    options.model?.trim() || env.SUGGESTION_GENERATOR_MODEL?.trim();
-  // Keep provider selection explicit — no silent hardcoding of a base URL or
-  // model outside the operator-configured env.
-  if (!apiKey || !configuredBaseUrl || !model) return [];
-
   const trimmed = replyText.trim();
   // A one-word reply ("Done.") gives the model no material and yields filler.
   if (trimmed.length < MIN_REPLY_CHARS) return [];
 
-  const baseUrl = configuredBaseUrl.replace(/\/+$/, "");
   const input =
     trimmed.length > MAX_INPUT_CHARS ? trimmed.slice(-MAX_INPUT_CHARS) : trimmed;
 
-  const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    options.timeoutMs ?? DEFAULT_TIMEOUT_MS
-  );
-
   try {
-    const response = await fetch(`${baseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        temperature: 0.3,
-        messages: [
-          { role: "system", content: SYSTEM_PROMPT },
-          { role: "user", content: input },
-        ],
-      }),
-      signal: controller.signal,
+    const resolve = options.resolveTarget ?? resolveCompletionTarget;
+    const target = await resolve(organizationId, options.model);
+    // No supported target means enrichment stays off for this turn.
+    if (!target) return [];
+
+    const content = await gatewayCompletion({
+      target,
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt: input,
+      temperature: 0.3,
+      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     });
-
-    if (!response.ok) {
-      logger.warn(
-        { status: response.status },
-        "suggest-followups completion failed; turn ends without chips"
-      );
-      return [];
-    }
-
-    const data = (await response.json()) as ChatCompletionResponse;
-    const content = data.choices?.[0]?.message?.content;
-    if (!content) return [];
-
     return parsePrompts(content);
   } catch (error) {
     logger.warn(
@@ -190,8 +163,6 @@ export async function generateSuggestFollowups(
       "suggest-followups generation failed; turn ends without chips"
     );
     return [];
-  } finally {
-    clearTimeout(timeout);
   }
 }
 

--- a/packages/server/src/gateway/inference/gateway-completion.ts
+++ b/packages/server/src/gateway/inference/gateway-completion.ts
@@ -1,0 +1,213 @@
+/**
+ * Shared gateway-side LLM transport for fail-open enrichment and retrieval
+ * features.
+ *
+ * `suggest-followups` chips and the memory query rewriter are both "prompt in,
+ * strict JSON out" features. Routing them through one client avoids separate
+ * per-feature credential triples.
+ *
+ * Credentials resolve through the org's `inference_providers` — the SAME
+ * machinery the agent run path uses — so a model an agent can run is a model
+ * these features can use. Gateway features resolve the org-owned provider row
+ * independently of worker execution.
+ *
+ * OAuth-backed rows (no API key) and non-OpenAI wire protocols are
+ * deliberately unsupported here; the calling feature fails open.
+ */
+
+import { createLogger, getErrorMessage } from "@lobu/core";
+import {
+  getOrgDefaultModel,
+  resolveInferenceProviderCredential,
+} from "../../lobu/stores/provider-secrets.js";
+import { getModelProviderModules } from "../modules/module-system.js";
+
+const logger = createLogger("gateway-completion");
+
+/** A resolved, callable upstream. */
+interface GatewayCompletionTarget {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+interface GatewayCompletionRequest {
+  target: GatewayCompletionTarget;
+  systemPrompt: string;
+  userPrompt: string;
+  /** Defaults to 0 — these callers all want deterministic, parseable output. */
+  temperature?: number;
+  timeoutMs: number;
+}
+
+interface ChatCompletionResponse {
+  choices?: Array<{
+    message?: { content?: string | null } | null;
+  } | null> | null;
+}
+
+/**
+ * Split a ref on its FIRST `/` into a candidate `{slug, model}`. Returns null
+ * only when there is no interior separator at all.
+ *
+ * This is a syntactic split, not a validation: the caller must confirm the
+ * slug names a real provider row before trusting it. Assuming otherwise is a
+ * live bug — `anthropic/claude-sonnet-5` is a single provider-NATIVE model id
+ * on openrouter, not provider `anthropic`, and a bare `gpt-4o-mini` is a
+ * perfectly valid guardrail override rather than a caller error.
+ */
+function splitModelRef(
+  ref: string
+): { slug: string; model: string } | null {
+  const i = ref.indexOf("/");
+  if (i <= 0 || i === ref.length - 1) return null;
+  return { slug: ref.slice(0, i), model: ref.slice(i + 1) };
+}
+
+/**
+ * Resolve a callable target from an org + optional model ref.
+ *
+ * `modelRef` wins when given; otherwise the org's default provider is used.
+ * Returns null when the row has no usable API key, upstream, or supported wire
+ * protocol.
+ */
+export async function resolveCompletionTarget(
+  organizationId: string,
+  modelRef?: string
+): Promise<GatewayCompletionTarget | null> {
+  const override = modelRef?.trim();
+  const orgDefault = override ? null : await getOrgDefaultModel(organizationId);
+  const ref = override || orgDefault;
+  if (!ref) return null;
+
+  // A guardrail's `model` was historically a RAW model id (`gpt-4o-mini`),
+  // posted to one operator-configured base URL. Now that credentials come from
+  // the org's provider rows, a ref may also be `<slug>/<model>`. Both must
+  // work, and the distinction cannot be made by looking for a "/": provider-
+  // native ids contain them (`anthropic/claude-sonnet-5`,
+  // `nvidia/moonshotai/kimi-k2.6`).
+  //
+  // So: try the prefix as a provider slug, and only accept that reading if the
+  // org actually HAS such a row. Otherwise treat the whole string as a model
+  // name on the org's default provider. Guessing wrong in the old direction
+  // silently disabled the feature; this way an operator's existing value keeps
+  // working and a qualified ref still routes explicitly.
+  const parts = splitModelRef(ref);
+  let config = parts
+    ? await resolveInferenceProviderCredential(organizationId, parts.slug, "text")
+    : null;
+  let model = parts?.model;
+  let slug = parts?.slug;
+
+  if (!config) {
+    const fallbackRef = override
+      ? await getOrgDefaultModel(organizationId)
+      : null;
+    const fallbackParts = fallbackRef ? splitModelRef(fallbackRef) : null;
+    if (!fallbackParts) {
+      logger.warn(
+        { ref },
+        "model ref names no provider row and the org has no default; gateway completion skipped"
+      );
+      return null;
+    }
+    // Keep the operator's model, borrow the default provider's credentials.
+    config = await resolveInferenceProviderCredential(
+      organizationId,
+      fallbackParts.slug,
+      "text"
+    );
+    model = ref;
+    slug = fallbackParts.slug;
+  }
+
+  if (!config?.apiKey || !model) return null;
+
+  const providerModule = getModelProviderModules().find(
+    (module) => module.providerId === config.kind
+  );
+  if (providerModule && providerModule.sdkCompat !== "openai") {
+    logger.warn(
+      { slug, kind: config.kind, sdkCompat: providerModule.sdkCompat },
+      "provider does not use the OpenAI-compatible protocol; gateway completion skipped"
+    );
+    return null;
+  }
+
+  // Endpoint precedence: the org row's tenant URL, then the provider module's
+  // REGISTERED upstream (which already folds in this deployment's
+  // `baseUrlEnvVarName` override), then — only for real OpenAI — the public
+  // endpoint.
+  //
+  // The tail matters: guessing a public endpoint for an unregistered provider
+  // would mis-deliver the request to the wrong vendor with a model ID it does
+  // not know, surfacing as a baffling "400 <model> is not a valid model ID"
+  // rather than "this provider isn't wired up". Mirrors the run path's
+  // reliability invariant (`buildDynamicOpenAIModel` in
+  // agent-worker/src/runtime/model-resolver.ts). Returning undefined makes the
+  // caller skip the feature — a missing chip beats a wrong-vendor call.
+  const baseUrl =
+    config.baseUrl ??
+    providerModule?.getUpstreamConfig?.()?.upstreamBaseUrl ??
+    (config.kind === "openai" ? "https://api.openai.com/v1" : undefined);
+  if (!baseUrl) {
+    logger.warn(
+      { slug, kind: config.kind },
+      "provider has no text base_url or registered upstream; gateway completion skipped"
+    );
+    return null;
+  }
+
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    apiKey: config.apiKey,
+    model,
+  };
+}
+
+/**
+ * Call the resolved target and return raw assistant text. Throws on transport
+ * or API failure; fail-open callers catch and return their empty value.
+ */
+export async function gatewayCompletion(
+  request: GatewayCompletionRequest
+): Promise<string> {
+  const { target, timeoutMs } = request;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(`${target.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${target.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: target.model,
+        temperature: request.temperature ?? 0,
+        messages: [
+          { role: "system", content: request.systemPrompt },
+          { role: "user", content: request.userPrompt },
+        ],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Gateway completion failed: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const data = (await response.json()) as ChatCompletionResponse;
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) throw new Error("Gateway completion returned no text");
+    return content;
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    throw new Error(getErrorMessage(error));
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/packages/server/src/gateway/proxy/egress-judge/anthropic-client.ts
+++ b/packages/server/src/gateway/proxy/egress-judge/anthropic-client.ts
@@ -1,3 +1,6 @@
+// gateway-llm-ok: pending migration to gateway-completion.ts. This judge fails
+// closed, so changing its credential and transport path needs separate
+// red→green coverage. See scripts/check-gateway-llm-calls.mjs.
 import Anthropic from "@anthropic-ai/sdk";
 import type { JudgeClient, JudgeVerdict } from "./types.js";
 import { getErrorMessage } from "@lobu/core";

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -868,3 +868,56 @@ export async function readOrgSharedProviderApiKey(
 		return null;
 	}
 }
+
+interface ResolvedInferenceProviderCredential {
+	kind: string;
+	baseUrl?: string;
+	apiKey?: string;
+}
+
+/**
+ * Resolve a provider row's credential even when it has no modality override.
+ * The base URL and ciphertext come from one read so a concurrent capability
+ * edit cannot pair a tenant URL with a key read from a different row state.
+ */
+export async function resolveInferenceProviderCredential(
+	organizationId: string,
+	slug: string,
+	modality: InferenceModality,
+): Promise<ResolvedInferenceProviderCredential | null> {
+	const sql = getDb();
+	const rows = (await sql`
+		SELECT p.kind, p.capabilities -> ${modality} AS block, s.ciphertext
+		FROM inference_providers p
+		LEFT JOIN agent_secrets s
+		  ON s.organization_id = p.organization_id
+		 AND ('secret://' || p.organization_id || '/' || s.name) = p.api_key_ref
+		 AND (s.expires_at IS NULL OR s.expires_at > now())
+		WHERE p.organization_id = ${organizationId} AND p.slug = ${slug}
+		  AND p.deleted_at IS NULL
+		LIMIT 1
+	`) as Array<{
+		kind: string;
+		block: InferenceCapabilityBlock | null;
+		ciphertext: string | null;
+	}>;
+	const row = rows[0];
+	if (!row) return null;
+
+	let apiKey: string | undefined;
+	if (row.ciphertext) {
+		try {
+			apiKey = decrypt(row.ciphertext);
+		} catch (error) {
+			logger.warn(
+				`Failed to decrypt inference-provider key for ${organizationId}/${slug}: ${getErrorMessage(error)}`,
+			);
+		}
+	}
+
+	return {
+		kind: row.kind,
+		baseUrl: row.block?.base_url,
+		apiKey,
+	};
+}

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -480,7 +480,9 @@ async function getContentImpl(
         !args.after_occurred_at &&
         offset === 0 &&
         limit <= FALLBACK_FETCH_CAP;
-      const variants = fallbackEligible ? await rewriteQueries(args.query as string, env) : [];
+      const variants = fallbackEligible
+        ? await rewriteQueries(args.query as string, ctx.organizationId)
+        : [];
 
       if (variants.length > 0 && args.query) {
         // Over-fetch per variant so fusion has a real candidate pool to re-rank

--- a/packages/server/src/utils/query-rewriter.ts
+++ b/packages/server/src/utils/query-rewriter.ts
@@ -20,17 +20,18 @@
  * shared/in-memory state, so it is trivially correct under N>1 app replicas —
  * each request rewrites independently, nothing to fan out across pods.
  *
- * Opt-in: rewriting only runs when QUERY_REWRITER_API_KEY is configured. With
- * no key (or on any failure) it returns [] and the caller falls back to the raw
- * query alone — so default behavior is byte-for-byte unchanged.
+ * Credentials come from an org-owned OpenAI-compatible provider row via the
+ * shared gateway completion client. An unsupported or missing provider (or any
+ * failure) yields [] and the caller falls back to the raw query alone.
  */
 
-import type { Env } from '../index';
 import logger from './logger';
 import { getErrorMessage } from "@lobu/core";
+import {
+  gatewayCompletion,
+  resolveCompletionTarget,
+} from '../gateway/inference/gateway-completion.js';
 
-const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
-const DEFAULT_MODEL = 'gpt-4o-mini';
 const MAX_INPUT_CHARS = 12_000;
 const TIMEOUT_MS = 30_000;
 const MAX_VARIANTS = 4;
@@ -38,60 +39,33 @@ const MAX_VARIANTS = 4;
 const SYSTEM_PROMPT =
   'Rewrite the user\'s question into 3 short keyword search queries that retrieve the relevant past conversation sessions from a memory store. Strip conversational filler. Include synonym variants (doctor/physician/specialist; job/role/position). Return STRICT JSON {"queries":["...","...","..."]} only.';
 
-interface ChatCompletionResponse {
-  choices?: Array<{ message?: { content?: string | null } | null } | null> | null;
-}
-
 /**
  * Rewrite a conversational/underspecified query into up to 4 focused keyword
  * search-query variants (NOT including the original). Returns [] on any failure
- * or when unconfigured — the caller falls back to the raw query only.
+ * or when the org has no resolvable model — the caller falls back to the raw
+ * query only.
  */
-export async function rewriteQueries(query: string, env: Env): Promise<string[]> {
-  const apiKey = env.QUERY_REWRITER_API_KEY;
-  // Opt-in via the API key. No key → no rewrite (graceful, default-off).
-  if (!apiKey) return [];
-
+export async function rewriteQueries(
+  query: string,
+  organizationId: string
+): Promise<string[]> {
   const trimmed = query.trim();
   if (trimmed.length === 0) return [];
 
-  const baseUrl = (env.QUERY_REWRITER_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
-  const model = env.QUERY_REWRITER_MODEL || DEFAULT_MODEL;
   const input = trimmed.slice(0, MAX_INPUT_CHARS);
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
   try {
-    const response = await fetch(`${baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        temperature: 0,
-        messages: [
-          { role: 'system', content: SYSTEM_PROMPT },
-          { role: 'user', content: input },
-        ],
-      }),
-      signal: controller.signal,
+    const target = await resolveCompletionTarget(organizationId);
+    // No supported target means the raw query remains the only variant.
+    if (!target) return [];
+
+    const content = await gatewayCompletion({
+      target,
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt: input,
+      temperature: 0,
+      timeoutMs: TIMEOUT_MS,
     });
-
-    if (!response.ok) {
-      logger.warn(
-        { status: response.status },
-        '[query-rewriter] chat completion request failed; falling back to raw query'
-      );
-      return [];
-    }
-
-    const data = (await response.json()) as ChatCompletionResponse;
-    const content = data.choices?.[0]?.message?.content;
-    if (!content) return [];
-
     return parseQueries(content);
   } catch (error) {
     // Fail open: any error (timeout/abort, network, parse) means the caller
@@ -101,8 +75,6 @@ export async function rewriteQueries(query: string, env: Env): Promise<string[]>
       '[query-rewriter] rewrite failed; falling back to raw query'
     );
     return [];
-  } finally {
-    clearTimeout(timeout);
   }
 }
 

--- a/scripts/__tests__/check-gateway-llm-calls.test.ts
+++ b/scripts/__tests__/check-gateway-llm-calls.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The gateway-LLM guard is only worth having if it actually fails on the
+ * violations it was written to catch. A guard that has quietly stopped
+ * catching them is worse than no guard, because a green run reads as proof.
+ *
+ * (The sibling naming guard needed four revisions before it caught its own
+ * fixtures — see check-exposed-surface-naming.test.ts.)
+ *
+ * These write a scratch file into the real scanned tree, run the guard as a
+ * subprocess, and assert the exit code — the same signal `make pre-pr` and CI
+ * act on. Every fixture file is removed in afterEach.
+ */
+
+import { rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const GUARD = join(REPO_ROOT, "scripts/check-gateway-llm-calls.mjs");
+/** Inside packages/server/src, which is the tree the guard scans. */
+const PROBE = join(REPO_ROOT, "packages/server/src/gateway/guard-probe.ts");
+
+const created: string[] = [];
+
+function create(contents: string): void {
+  created.push(PROBE);
+  writeFileSync(PROBE, contents);
+}
+
+function runGuard(): number {
+  return Bun.spawnSync(["node", GUARD], { cwd: REPO_ROOT }).exitCode;
+}
+
+afterEach(() => {
+  for (const file of created.splice(0)) rmSync(file, { force: true });
+});
+
+describe("check-gateway-llm-calls", () => {
+  it("passes on the clean tree", () => {
+    expect(runGuard()).toBe(0);
+  });
+
+  it("fails on a hand-rolled chat/completions fetch", () => {
+    create(
+      `export async function probe(baseUrl: string) {\n` +
+        `  return fetch(\`\${baseUrl}/chat/completions\`, { method: "POST" });\n` +
+        `}\n`
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("fails on a per-feature credential triple", () => {
+    create(
+      `const PROBE_API_KEY = process.env.PROBE_API_KEY;\n` +
+        `const PROBE_BASE_URL = process.env.PROBE_BASE_URL;\n` +
+        `const PROBE_MODEL = process.env.PROBE_MODEL;\n` +
+        `export const probe = { PROBE_API_KEY, PROBE_BASE_URL, PROBE_MODEL };\n`
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("fails on a vendor SDK import outside the allowlisted client", () => {
+    create(`import Anthropic from "@anthropic-ai/sdk";\nexport default Anthropic;\n`);
+    expect(runGuard()).toBe(1);
+  });
+
+  it("fails on the /v1/messages and /responses paths too", () => {
+    create(
+      `export async function probe(u: string) {\n` +
+        `  await fetch(\`\${u}/v1/messages\`, { method: "POST" });\n` +
+        `  return fetch(\`\${u}/responses\`, { method: "POST" });\n` +
+        `}\n`
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("honours a gateway-llm-ok suppression on the flagged line", () => {
+    create(
+      `export async function probe(u: string) {\n` +
+        `  // gateway-llm-ok: fixture — asserts the escape hatch still works.\n` +
+        `  return fetch(\`\${u}/chat/completions\`, { method: "POST" });\n` +
+        `}\n`
+    );
+    expect(runGuard()).toBe(0);
+  });
+});

--- a/scripts/__tests__/check-gateway-llm-calls.test.ts
+++ b/scripts/__tests__/check-gateway-llm-calls.test.ts
@@ -60,7 +60,9 @@ describe("check-gateway-llm-calls", () => {
   });
 
   it("fails on a vendor SDK import outside the allowlisted client", () => {
-    create(`import Anthropic from "@anthropic-ai/sdk";\nexport default Anthropic;\n`);
+    create(
+      `import Anthropic from "@anthropic-ai/sdk";\nexport default Anthropic;\n`
+    );
     expect(runGuard()).toBe(1);
   });
 

--- a/scripts/__tests__/check-gateway-llm-calls.test.ts
+++ b/scripts/__tests__/check-gateway-llm-calls.test.ts
@@ -76,6 +76,28 @@ describe("check-gateway-llm-calls", () => {
     expect(runGuard()).toBe(1);
   });
 
+  /**
+   * Regression: the comment stripper used to run `/\/\/.*$/`, which matches the
+   * `//` in `https://`. That truncated the line to `fetch("https:` and let the
+   * most obvious hand-rolled call — a hardcoded vendor URL — through untouched.
+   */
+  it("fails on a literal https:// completions URL", () => {
+    create(
+      `export async function probe() {\n` +
+        `  return fetch("https://api.example.test/chat/completions", { method: "POST" });\n` +
+        `}\n`
+    );
+    expect(runGuard()).toBe(1);
+  });
+
+  it("still ignores prose that merely mentions a completions path", () => {
+    create(
+      `// Historical note: this used to POST to /chat/completions directly.\n` +
+        `export const probe = 1;\n`
+    );
+    expect(runGuard()).toBe(0);
+  });
+
   it("honours a gateway-llm-ok suppression on the flagged line", () => {
     create(
       `export async function probe(u: string) {\n` +

--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// Prevent new, unsuppressed per-feature LLM transports in packages/server.
+// Suggestion chips and query rewriting share gateway-completion.ts. The
+// existing fail-closed egress judge remains explicitly suppressed pending its
+// own migration and red→green coverage.
+//
+// COVERAGE (textual, deliberately — see HONEST GAP):
+//   1. `fetch(...)` whose URL expression mentions a completions-style path
+//      (/chat/completions, /v1/messages, /completions, /responses).
+//   2. Importing a vendor SDK (@anthropic-ai/sdk, openai, @google/generative-ai,
+//      @mistralai/*, cohere-ai, groq-sdk, replicate) anywhere outside the
+//      allowlisted module.
+//   3. Declaring a new per-feature credential triple: an identifier or string
+//      matching <PREFIX>_API_KEY where a sibling <PREFIX>_BASE_URL or
+//      <PREFIX>_MODEL also appears in the same file.
+//
+// HONEST GAP: this is textual, not type-aware — a call assembled through enough
+// indirection (a URL built far from the fetch, an SDK re-exported by a local
+// module) will not be caught. The durable backstop for those is review plus the
+// fact that a NEW credential triple is itself flagged, and a hand-rolled client
+// needs credentials from somewhere. It also does not scan packages outside
+// packages/server; agent-worker legitimately owns model routing (pi-ai).
+//
+// Escape hatch: put `gateway-llm-ok` in a comment on the flagged line (or the
+// line above) with a reason.
+//
+// No DB, no build — pure static text analysis.
+// Run: `node scripts/check-gateway-llm-calls.mjs`.
+
+import { existsSync, globSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SERVER_SRC = join(REPO_ROOT, "packages/server/src");
+
+// The ONE module allowed to speak HTTP to a model provider. Its whole job is
+// being that seam, so it necessarily contains the patterns this gate forbids.
+const ALLOWED_CLIENT =
+  "packages/server/src/gateway/inference/gateway-completion.ts";
+
+// `gateway/auth/**` is a DIFFERENT concern and is exempt from the credential-
+// triple rule (it is still subject to the fetch + SDK rules). Those modules
+// hand a credential to the agent's own CLI subprocess — they build the env a
+// spawned `claude`/`codex` process reads, so naming ANTHROPIC_API_KEY /
+// OPENAI_API_KEY is their whole job, not a hand-rolled transport. The gate is
+// about the SERVER calling a model itself; forwarding a credential to the run
+// path is exactly what it should keep doing.
+const CREDENTIAL_RULE_EXEMPT_DIRS = ["packages/server/src/gateway/auth/"];
+
+// Vendor SDKs that imply a hand-rolled, provider-pinned transport.
+const VENDOR_SDKS = [
+  "@anthropic-ai/sdk",
+  "openai",
+  "@google/generative-ai",
+  "@google/genai",
+  "cohere-ai",
+  "groq-sdk",
+  "replicate",
+  "@mistralai/mistralai",
+];
+
+// Completion-ish endpoint paths. `/embeddings` is deliberately ABSENT: the
+// embeddings package owns that path and it is not a chat completion.
+const COMPLETION_PATHS = [
+  "/chat/completions",
+  "/v1/messages",
+  "/responses",
+  "/completions",
+];
+
+const violations = [];
+
+/**
+ * Suppressed if the flagged line carries `gateway-llm-ok`, or if the comment
+ * block immediately above it does. Scanning the WHOLE contiguous comment block
+ * (rather than just the previous line) is deliberate: a suppression is required
+ * to state its reason, and a real reason rarely fits on one line — a
+ * single-line window would push authors toward terse, uninformative excuses.
+ * The scan stops at the first non-comment line, so it cannot reach across an
+ * unrelated statement into some earlier block's marker.
+ */
+function isSuppressed(lines, idx) {
+  if (/gateway-llm-ok/.test(lines[idx] ?? "")) return true;
+  for (let i = idx - 1; i >= 0; i--) {
+    const line = (lines[i] ?? "").trim();
+    if (line === "") continue;
+    const isComment =
+      line.startsWith("//") || line.startsWith("*") || line.startsWith("/*");
+    if (!isComment) return false;
+    if (/gateway-llm-ok/.test(line)) return true;
+  }
+  return false;
+}
+
+function flag(file, lineNo, kind, snippet) {
+  violations.push({
+    file: relative(REPO_ROOT, file),
+    line: lineNo,
+    kind,
+    snippet: snippet.trim().replace(/\s+/g, " ").slice(0, 100),
+  });
+}
+
+/**
+ * Find `<PREFIX>_API_KEY` occurrences that have a sibling `<PREFIX>_BASE_URL`
+ * or `<PREFIX>_MODEL` in the same file — the signature of a new per-feature
+ * credential triple. A lone `*_API_KEY` is NOT flagged: plenty of legitimate
+ * non-LLM integrations carry one.
+ */
+function findCredentialTriples(text) {
+  const keys = new Set();
+  const siblings = new Set();
+  for (const m of text.matchAll(
+    /\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*)_API_KEY\b/g
+  )) {
+    keys.add(m[1]);
+  }
+  for (const m of text.matchAll(
+    /\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*)_(?:BASE_URL|MODEL)\b/g
+  )) {
+    siblings.add(m[1]);
+  }
+  return [...keys].filter((k) => siblings.has(k));
+}
+
+let scannedCount = 0;
+const files = globSync("**/*.{ts,tsx}", { cwd: SERVER_SRC }).map((f) =>
+  resolve(SERVER_SRC, f)
+);
+
+for (const file of files) {
+  const rel = relative(REPO_ROOT, file);
+  if (rel === ALLOWED_CLIENT) continue;
+  // Tests legitimately construct fake upstreams and stub vendor clients.
+  if (rel.includes("/__tests__/")) continue;
+  if (file.endsWith(".d.ts")) continue;
+  scannedCount++;
+
+  const text = readFileSync(file, "utf8");
+  const lines = text.split("\n");
+
+  const credentialRuleApplies = !CREDENTIAL_RULE_EXEMPT_DIRS.some((d) =>
+    rel.startsWith(d)
+  );
+  const triples = credentialRuleApplies ? findCredentialTriples(text) : [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Strip comments so prose ABOUT the old design (a historical note, a
+    // migration comment, a doc block naming the env var a module forwards)
+    // does not trip the gate. Covers `// …`, a jsdoc continuation line `* …`,
+    // and a single-line `/** … */`.
+    const code = line
+      .replace(/\/\*\*?.*?\*\//g, "")
+      .replace(/\/\/.*$/, "")
+      .replace(/^\s*\*.*$/, "")
+      .replace(/^\s*\/\*.*$/, "");
+    if (!code.trim()) continue;
+    if (isSuppressed(lines, i)) continue;
+
+    // 1. fetch() to a completions-style path.
+    if (/\bfetch\s*\(/.test(code)) {
+      for (const p of COMPLETION_PATHS) {
+        if (code.includes(p)) {
+          flag(file, i + 1, "hand-rolled completion fetch", line);
+          break;
+        }
+      }
+    }
+
+    // 2. Vendor SDK import.
+    if (/\b(?:import|require)\b/.test(code)) {
+      for (const sdk of VENDOR_SDKS) {
+        if (
+          code.includes(`"${sdk}"`) ||
+          code.includes(`'${sdk}'`) ||
+          code.includes(`"${sdk}/`) ||
+          code.includes(`'${sdk}/`)
+        ) {
+          flag(file, i + 1, `vendor SDK import (${sdk})`, line);
+          break;
+        }
+      }
+    }
+
+    // 3. New per-feature credential triple.
+    for (const prefix of triples) {
+      if (code.includes(`${prefix}_API_KEY`)) {
+        flag(file, i + 1, `per-feature credential triple (${prefix}_*)`, line);
+        break;
+      }
+    }
+  }
+}
+
+// Guard against a vacuous green: if the glob ever stops matching, the loop
+// scans nothing and would report "clean" — silently disabling the gate.
+if (!existsSync(SERVER_SRC)) {
+  console.error(`✗ expected ${SERVER_SRC} to exist`);
+  process.exit(1);
+}
+if (scannedCount === 0) {
+  console.error(
+    "✗ gateway-llm gate scanned ZERO packages/server/src files — the glob likely\n" +
+      "  regressed. A clean result here would be vacuous; failing instead."
+  );
+  process.exit(1);
+}
+if (!existsSync(join(REPO_ROOT, ALLOWED_CLIENT))) {
+  console.error(
+    `✗ gateway-llm gate: the shared client ${ALLOWED_CLIENT} is missing.\n` +
+      "  Unsuppressed gateway LLM calls are supposed to route through it; if it moved,\n" +
+      "  update ALLOWED_CLIENT in scripts/check-gateway-llm-calls.mjs."
+  );
+  process.exit(1);
+}
+
+if (violations.length) {
+  violations.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+  console.error(`\n✗ gateway-llm gate failed (${violations.length}):\n`);
+  for (const v of violations) {
+    console.error(`  - ${v.file}:${v.line}  [${v.kind}]`);
+    console.error(`      ${v.snippet}`);
+  }
+  console.error(
+    "\nNew packages/server LLM calls go through\n" +
+      "  gateway/inference/gateway-completion.ts\n" +
+      "Do not add a per-feature *_API_KEY / *_BASE_URL / *_MODEL triple or a\n" +
+      "second vendor client.\n\n" +
+      "If a case is genuinely safe, add a `gateway-llm-ok` comment WITH A REASON\n" +
+      "on the flagged line. See scripts/check-gateway-llm-calls.mjs.\n"
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✓ gateway-llm gate: ${scannedCount} packages/server/src files contain no unsuppressed one-off LLM client`
+);

--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -171,9 +171,15 @@ for (const file of files) {
     // migration comment, a doc block naming the env var a module forwards)
     // does not trip the gate. Covers `// …`, a jsdoc continuation line `* …`,
     // and a single-line `/** … */`.
+    //
+    // The `//` rule must NOT fire on a scheme separator: stripping from the
+    // `//` in `https://api.example/chat/completions` truncates the line to
+    // `const u = "https:` and the literal URL — the most obvious way to
+    // hand-roll a call — sails straight through. Require the `//` to be at
+    // line start or preceded by something other than `:`.
     const code = line
       .replace(/\/\*\*?.*?\*\//g, "")
-      .replace(/\/\/.*$/, "")
+      .replace(/(^|[^:])\/\/.*$/, "$1")
       .replace(/^\s*\*.*$/, "")
       .replace(/^\s*\/\*.*$/, "");
     if (!code.trim()) continue;

--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -27,7 +27,7 @@
 // No DB, no build — pure static text analysis.
 // Run: `node scripts/check-gateway-llm-calls.mjs`.
 
-import { existsSync, globSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -124,10 +124,30 @@ function findCredentialTriples(text) {
   return [...keys].filter((k) => siblings.has(k));
 }
 
+/**
+ * Walk for `.ts`/`.tsx` under `dir`.
+ *
+ * Hand-rolled rather than `fs.globSync`: that landed in Node 22.0 as
+ * experimental and this repo's CI pins Node 22, where importing it throws
+ * `does not provide an export named 'globSync'` — the gate then fails every
+ * run for a reason that has nothing to do with the code it guards. `readdirSync`
+ * with `withFileTypes` is stable across every version we support.
+ */
+function collectSourceFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectSourceFiles(full));
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
 let scannedCount = 0;
-const files = globSync("**/*.{ts,tsx}", { cwd: SERVER_SRC }).map((f) =>
-  resolve(SERVER_SRC, f)
-);
+const files = collectSourceFiles(SERVER_SRC);
 
 for (const file of files) {
   const rel = relative(REPO_ROOT, file);


### PR DESCRIPTION
## Summary

- Two gateway features — `suggest-followups` chips and the memory query rewriter — read env vars (`SUGGESTION_GENERATOR_*`, `QUERY_REWRITER_*`) that are set in **no environment**: not in any deploy manifest, env file, or Makefile. Both have silently returned nothing on every request since launch.
- They now resolve credentials from the org's `inference_providers`, the same table the agent run path uses, through **one shared client** (`gateway/inference/gateway-completion.ts`). A per-feature credential triple is no longer how you add an LLM call here.
- `scripts/check-gateway-llm-calls.mjs` makes a new one-off client a build failure. It runs in **both** `make pre-pr` (gate 6/6) and `ci.yml`, with fixture tests asserting it still bites — verified to fail on planted violations, not merely to pass on clean code.

> Corrected after review: the gate was originally wired into `make pre-pr` only, so this bullet's "CI failure" claim was false — a contributor who skipped pre-pr passed every required check. Fixed in `8ed3bcb7`.

**Split from #2240.** That PR carried two concerns; this is the client half only. It deliberately does **not** change org-default assignment — it consumes `getOrgDefaultModel` exactly as `main` defines it. The default-lifecycle rewrite (auto-promotion, self-heal on read, org-row locking, OAuth eligibility) stays on #2240, where its `behavior_change_risk: high` is proportionate. Every review finding on #2240 to date has landed in that half; none in this one.

### Activation prerequisite (deliberate, not an oversight)

`main` does not auto-promote a provider to org default, and prod currently has **0 live defaults across 5 orgs**. So these features stay dead until a default row exists. Making one appear is a one-row `UPDATE` on the single eligible prod row (`8dc12bdd…` / `z-ai` / `glm-5.2`) — n=1 blast radius, reversible. Until then, both features fail open exactly as they do today.

## Test plan

- [x] `make pre-pr` clean — all 6 gates
- [x] Tests: 18 unit (gateway-completion + suggest-followups), 6 query-rewrite integration, 29 chat-response-bridge = **53 passing**
- [x] Live e2e against a real vendor — see below
- [x] Bug fix: red→green evidence below

### The CI gate, proven red

A green gate proves nothing on its own, so I planted a violation — a `BOGUS_*` credential triple plus a hand-rolled `fetch` to `/chat/completions`:

```
✗ gateway-llm gate failed (2):
  - packages/server/src/gateway/probe-violation.ts:1  [per-feature credential triple (BOGUS_*)]
  - packages/server/src/gateway/probe-violation.ts:4  [hand-rolled completion fetch]
EXIT=1
```

Both violation classes caught, exit 1, remedy named. Restored:

```
✓ gateway-llm gate: 621 packages/server/src files contain no unsuppressed one-off LLM client
```

### Live end-to-end — real Postgres, real encrypted credentials, real vendor HTTP

Proves both halves of the prerequisite: dead without a default (prod's state today), alive with one `UPDATE`.

```
PASS  1. main does NOT auto-promote — org still has no default   {"orgDefault":null}
PASS  2. with no default the feature resolves nothing (dead, as in prod today)
PASS  3. suggest-followups fails OPEN with no default — empty, not an error   {"chips":0}
PASS  4. one UPDATE is enough — org default resolves   {"orgDefault":"openai/gpt-4o-mini"}
PASS  5. credentials resolve (decrypted key + registry upstream)
        {"baseUrl":"https://api.openai.com/v1","model":"gpt-4o-mini","apiKeyMatchesStored":true}
PASS  6. LIVE completion through the real vendor   {"latencyMs":1531,"preview":"{\"ok\":true}"}
PASS  7. suggest-followups returns REAL chips — the dead feature is alive
        {"count":3,"chips":[{"title":"Adjust polling rate",…},{"title":"Check rate limit",…},…]}

ALL PASSED
```

### The misrouting invariant, red→green

`resolveCompletionTarget` refuses to guess an endpoint for an unregistered provider. Injecting the naive implementation (guess OpenAI's public endpoint for anything unresolved):

```
× (m) an unregistered provider with no row base_url does NOT resolve
× (n) a lookalike slug does not inherit the OpenAI public endpoint
  Tests  2 failed | 14 passed (16)   ← against the injected bug
  Tests  16 passed (16)              ← against the real code
```

Guessing mis-delivers the request to the wrong vendor with a model ID it does not know, surfacing as `400 <model> is not a valid model ID` rather than "this provider isn't configured". Skipping the feature is the correct failure. Mirrors `buildDynamicOpenAIModel` in `agent-worker/src/runtime/model-resolver.ts`.

## Notes

- The egress judge keeps its Anthropic SDK under an explicit `gateway-llm-ok` suppression **with a stated reason**: it fails *closed*, so moving its transport needs its own red→green coverage rather than riding along here.
- `resolveInferenceProviderCredential` is the only addition to `provider-secrets.ts` (+53 lines): one SELECT joining `inference_providers` to `agent_secrets`, decrypt, return. It touches no promotion, locking, or `is_default` logic.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->


## Scope of activation

`main` sets `is_default` only via the explicit `PUT /inference-providers/:slug/default` route — there is no auto-promotion (that is #2240). So "both features now work" precisely means **works for orgs that have explicitly set a default provider**. Orgs without one continue to get nothing, failing open exactly as today.

Two further cases stay off by design:
- **Anthropic/Claude-defaulted orgs** — `sdkCompat: "anthropic"` is not the OpenAI wire protocol, so the resolver skips them rather than posting a chat/completions body to `api.anthropic.com`.
- **ChatGPT subscription rows** — see the protocol-gating tests; `chatgpt.com/backend-api` is Codex's backend, not an OpenAI-compatible API.

Prod today has **0 live defaults across 5 orgs**, so on merge nothing changes behaviourally until a default is set. The single eligible row is `8dc12bdd…` / `z-ai` / `glm-5.2`.
