### PR TITLE
fix(server): declare the subdomain zone to the SPA at runtime

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -50,7 +50,20 @@ services:
       ENCRYPTION_KEY: REPLACE_ME_openssl_rand_base64_32
       # 32-byte base64 — generate with: openssl rand -base64 32
       BETTER_AUTH_SECRET: REPLACE_ME_openssl_rand_base64_32
+      # Your EXTERNAL url, as the browser sees it. Behind a reverse proxy this
+      # must be the public address (https://lobu.example.com/lobu), not
+      # localhost — links and redirects are built from it.
       PUBLIC_GATEWAY_URL: http://localhost:8787/lobu
+
+      # ---- Per-org subdomains (optional) -----------------------------------
+      # Leave AUTH_COOKIE_DOMAIN unset for path-based routing
+      # (lobu.example.com/your-org) — the right default behind a single
+      # reverse proxy, and no wildcard DNS required.
+      #
+      # Set it only if you want each org on its own host
+      # (your-org.lobu.example.com); that needs wildcard DNS plus a matching
+      # proxy/cert. The value is the shared parent zone:
+      #   AUTH_COOKIE_DOMAIN: .lobu.example.com
 
       # ---- Recommended -----------------------------------------------------
       NODE_ENV: production

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -84,6 +84,20 @@ Migrations are applied at boot. If you roll back to an older image whose migrati
 
 `FRAME_ANCESTORS` lets you embed the admin UI inside another origin if needed (Content-Security-Policy frame-ancestors directive). Set as a comma-separated list of allowed origins; leave unset to deny all framing.
 
+### Path-based orgs (default) vs per-org subdomains
+
+By default each organization lives on a path — `https://lobu.example.com/your-org`. This needs nothing beyond `PUBLIC_GATEWAY_URL` and works behind a single reverse proxy with one hostname and one certificate.
+
+Set `AUTH_COOKIE_DOMAIN` only if you want each org on its own hostname (`your-org.lobu.example.com`). The value is the shared parent zone, with or without the leading dot:
+
+```yaml
+AUTH_COOKIE_DOMAIN: .lobu.example.com
+```
+
+That mode additionally requires wildcard DNS (`*.lobu.example.com`), a wildcard-capable certificate, and a proxy that forwards those hosts to the container. If any of the three is missing, leave `AUTH_COOKIE_DOMAIN` unset — the app stays on path-based URLs.
+
+The server tells the frontend which mode is active at runtime, so this is a plain env change: no image rebuild, and nothing is inferred from the hostname you happen to serve on.
+
 ## Production checklist
 
 - [ ] Real `ENCRYPTION_KEY` and `BETTER_AUTH_SECRET` (NOT the example placeholders).

--- a/packages/server/src/__tests__/unit/runtime-config-injection.test.ts
+++ b/packages/server/src/__tests__/unit/runtime-config-injection.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { injectRuntimeConfig } from '../../public-pages';
+import { __resetPublicOriginCachesForTests } from '../../utils/public-origin';
+
+const TEMPLATE = '<html><head><title>Lobu</title></head><body><div id="root"></div></body></html>';
+
+function readInjectedZone(html: string): string | null {
+  const match = html.match(/window\.__LOBU_RUNTIME_CONFIG__=(\{.*?\});/);
+  if (!match?.[1]) throw new Error(`no runtime config injected into: ${html}`);
+  // Undo the script-context escaping applied by serializeForScript.
+  const decoded = match[1]
+    .replace(/\\u003c/g, '<')
+    .replace(/\\u003e/g, '>')
+    .replace(/\\u0026/g, '&');
+  return (JSON.parse(decoded) as { subdomainZone: string | null }).subdomainZone;
+}
+
+describe('injectRuntimeConfig', () => {
+  const originalCookieDomain = process.env.AUTH_COOKIE_DOMAIN;
+  const originalGatewayUrl = process.env.PUBLIC_GATEWAY_URL;
+
+  beforeEach(() => {
+    delete process.env.AUTH_COOKIE_DOMAIN;
+    delete process.env.PUBLIC_GATEWAY_URL;
+    // PUBLIC_GATEWAY_URL is memoized on first read. Without this reset the
+    // env assignments below are silently ignored once an earlier test has
+    // populated the cache, and the assertions pass for the wrong reason.
+    __resetPublicOriginCachesForTests();
+  });
+
+  afterEach(() => {
+    if (originalCookieDomain === undefined) delete process.env.AUTH_COOKIE_DOMAIN;
+    else process.env.AUTH_COOKIE_DOMAIN = originalCookieDomain;
+    if (originalGatewayUrl === undefined) delete process.env.PUBLIC_GATEWAY_URL;
+    else process.env.PUBLIC_GATEWAY_URL = originalGatewayUrl;
+  });
+
+  // lobu#2183: an unconfigured self-host must declare NO zone, so the SPA stays
+  // on path-based /{org} routing instead of guessing one from the hostname.
+  it('declares a null zone when nothing is configured', () => {
+    expect(readInjectedZone(injectRuntimeConfig(TEMPLATE))).toBeNull();
+  });
+
+  it('declares the AUTH_COOKIE_DOMAIN zone when set', () => {
+    process.env.AUTH_COOKIE_DOMAIN = '.lobu.ai';
+    __resetPublicOriginCachesForTests();
+    expect(readInjectedZone(injectRuntimeConfig(TEMPLATE))).toBe('lobu.ai');
+  });
+
+  // A path-based self-host still sets PUBLIC_GATEWAY_URL. Deriving the zone
+  // from it would re-enable per-org subdomains nobody asked for — the same
+  // class of bug as the old hostname heuristic (lobu#2183).
+  it('does not enable subdomains from PUBLIC_GATEWAY_URL alone', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    __resetPublicOriginCachesForTests();
+    expect(readInjectedZone(injectRuntimeConfig(TEMPLATE))).toBeNull();
+  });
+
+  // Vite emits the app bundle INSIDE <head>, so injecting at `</head>` lands
+  // after it. Assert against a head-script shell — the toy body-only template
+  // passed while the real dist/index.html did not.
+  it('injects before an app bundle that lives in the head', () => {
+    const viteShell =
+      '<html><head><meta charset="utf-8" />' +
+      '<script type="module" crossorigin src="/assets/index-abc.js"></script>' +
+      '</head><body><div id="root"></div></body></html>';
+    const html = injectRuntimeConfig(viteShell);
+    expect(html.indexOf('__LOBU_RUNTIME_CONFIG__')).toBeLessThan(
+      html.indexOf('type="module"')
+    );
+  });
+
+  it('still injects into a template with no head', () => {
+    expect(readInjectedZone(injectRuntimeConfig('<div id="root"></div>'))).toBeNull();
+  });
+
+  it('never emits a zone that breaks out of the script tag', () => {
+    process.env.AUTH_COOKIE_DOMAIN = '</script><script>alert(1)//';
+    const html = injectRuntimeConfig(TEMPLATE);
+    expect(html).not.toContain('<script>alert(1)');
+    expect(readInjectedZone(html)).toBeNull();
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -94,6 +94,7 @@ import {
 	buildSitemapEntries,
 	buildSitemapXml,
 	PUBLIC_XML_CACHE,
+	injectRuntimeConfig,
 	renderPublicPageTemplate,
 } from "./public-pages";
 import {
@@ -384,6 +385,9 @@ async function serveStaticFile(
 			? "public, max-age=0, s-maxage=60, stale-while-revalidate=300"
 			: "public, max-age=31536000, immutable",
 	);
+	if (isHtml) {
+		return c.html(injectRuntimeConfig(body.toString("utf-8")));
+	}
 	// Hono's Data type expects Uint8Array<ArrayBuffer>; copy into a fresh
 	// ArrayBuffer since fs.readFile returns Buffer<ArrayBufferLike>.
 	const ab = new ArrayBuffer(body.byteLength);
@@ -2824,9 +2828,11 @@ app.get("*", async (c) => {
 			const template = await loadAnySpaHtmlTemplate();
 			if (template) {
 				const rendered = renderPublicPageTemplate(template, publicPageModel);
-				const html = viteDev
-					? await viteDev.transformIndexHtml(c.req.path, rendered)
-					: rendered;
+				const html = injectRuntimeConfig(
+					viteDev
+						? await viteDev.transformIndexHtml(c.req.path, rendered)
+						: rendered,
+				);
 				c.header("Cache-Control", publicPageModel.cacheControl);
 				c.header("Vary", "Accept, Cookie");
 				return c.html(html, publicPageModel.status as 200 | 404);
@@ -2841,7 +2847,9 @@ app.get("*", async (c) => {
 				path.resolve(viteDev.config.root, "index.html"),
 				"utf-8",
 			);
-			const html = await viteDev.transformIndexHtml(c.req.path, raw);
+			const html = injectRuntimeConfig(
+				await viteDev.transformIndexHtml(c.req.path, raw),
+			);
 			return c.html(html);
 		}
 		return c.notFound();

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -10,7 +10,10 @@ import {
 } from './utils/entity-management';
 import { entityLinkMatchSql } from './utils/content-search';
 import { escapeHtml } from './utils/html';
-import { getConfiguredPublicOrigin } from './utils/public-origin';
+import {
+  getConfiguredPublicOrigin,
+  getConfiguredSubdomainZone,
+} from './utils/public-origin';
 import { RESERVED_PATHS_SET } from './utils/reserved';
 
 interface PublicOrganization {
@@ -1094,6 +1097,26 @@ export async function buildPublicPageModel(
 
 export function renderPublicPageTemplate(templateHtml: string, model: PublicPageModel): string {
   return injectIntoTemplate(templateHtml, model);
+}
+
+/**
+ * Injects deployment config before the first script so it is available when
+ * the SPA bundle starts. This is runtime data because Docker serves a prebuilt
+ * frontend, and it is separate from the public-page-only bootstrap payload.
+ */
+export function injectRuntimeConfig(templateHtml: string): string {
+  const zone = getConfiguredSubdomainZone();
+  const script = `<script>window.__LOBU_RUNTIME_CONFIG__=${serializeForScript({
+    subdomainZone: zone,
+  })};</script>`;
+
+  const firstScript = templateHtml.search(/<script\b/i);
+  if (firstScript !== -1) {
+    return `${templateHtml.slice(0, firstScript)}${script}\n${templateHtml.slice(firstScript)}`;
+  }
+  return /<\/head>/i.test(templateHtml)
+    ? templateHtml.replace(/<\/head>/i, `${script}\n</head>`)
+    : `${script}${templateHtml}`;
 }
 
 export async function buildSitemapEntries(origin: string): Promise<SitemapEntry[]> {

--- a/packages/server/src/utils/__tests__/public-origin.test.ts
+++ b/packages/server/src/utils/__tests__/public-origin.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractSubdomainOrg,
   getCanonicalRedirectUrl,
+  getConfiguredSubdomainZone,
   getSubdomainZone,
   normalizeHost,
 } from '../public-origin';
@@ -83,11 +84,22 @@ describe('getSubdomainZone', () => {
   });
 
   it('falls back to the configured origin host when no cookie domain is set', () => {
-    expect(getSubdomainZone('https://app.example.com', undefined)).toBe('app.example.com');
+    expect(getSubdomainZone('https://app.example.com', '')).toBe('app.example.com');
   });
 
   it('returns null when nothing is configured', () => {
-    expect(getSubdomainZone(undefined, undefined)).toBeNull();
+    expect(getSubdomainZone('', '')).toBeNull();
+  });
+});
+
+describe('getConfiguredSubdomainZone', () => {
+  it('returns only an explicit, subdomain-capable cookie zone', () => {
+    expect(getConfiguredSubdomainZone('.lobu.ai')).toBe('lobu.ai');
+    expect(getConfiguredSubdomainZone('')).toBeNull();
+    expect(getConfiguredSubdomainZone('localhost')).toBeNull();
+    expect(getConfiguredSubdomainZone('127.0.0.1')).toBeNull();
+    expect(getConfiguredSubdomainZone('192.168.1.50')).toBeNull();
+    expect(getConfiguredSubdomainZone('[::1]')).toBeNull();
   });
 });
 

--- a/packages/server/src/utils/public-origin.ts
+++ b/packages/server/src/utils/public-origin.ts
@@ -239,6 +239,27 @@ export function getSubdomainZone(
 }
 
 /**
+ * Returns the zone explicitly configured for cross-host organization routing.
+ * Unlike getSubdomainZone(), this never falls back to PUBLIC_GATEWAY_URL:
+ * path-based deployments also configure a public origin.
+ */
+export function getConfiguredSubdomainZone(
+  cookieDomain = process.env.AUTH_COOKIE_DOMAIN
+): string | null {
+  const zone = normalizeHost(cookieDomain);
+  return zone && isSubdomainCapableHost(zone) ? zone : null;
+}
+
+/** False for loopback names and IP literals, which cannot carry subdomains. */
+function isSubdomainCapableHost(host: string): boolean {
+  if (LOCALHOST_HOSTNAMES.has(host)) return false;
+  // IPv4 dotted-quad, or the bracketed/colon forms of IPv6.
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) return false;
+  if (host.includes(':') || host.startsWith('[')) return false;
+  return true;
+}
+
+/**
  * Extracts the org slug from a Host header for `{org}.{zone}` requests.
  * Reserved subdomains (www, api, app, etc.) are skipped so infra hostnames are
  * not mistaken for org slugs. Returns null when the host does not belong to the


### PR DESCRIPTION
## Summary
- Self-hosters behind a reverse proxy could register but then hit 404s on models, chats and everything else (#2183). The SPA inferred its subdomain zone from `window.location.hostname`, so `service.my-domain.com` had `service` read as an org slug and redirected to `{org}.my-domain.com` — a host the proxy did not serve. Wildcard DNS "fixed" it only by making reality match the guess.
- The server now declares the zone in every SPA shell via `window.__LOBU_RUNTIME_CONFIG__`, injected ahead of the first script tag. Runtime rather than build-time, because Docker self-hosters run a prebuilt frontend. No zone → path-based `/{org}` routing.
- Docs + compose example now cover the reverse-proxy case: path-based is the default, `AUTH_COOKIE_DOMAIN` is the opt-in and needs wildcard DNS.

Requires lobu-ai/owletto#615 (submodule pointer included).

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test src/__tests__/unit/runtime-config-injection.test.ts` (6), `bunx vitest run src/utils/__tests__/public-origin.test.ts` (26), owletto `src/lib/` (364)
- [x] Bug fix: red→fix→green outputs pasted below

**Red** (client-side reproduction of the reported behavior):
```
AssertionError: expected 'service' to be null
  - Expected: null
  + Received: "service"
Tests  2 failed | 14 passed (16)
```

**Green**:
```
6 pass 0 fail   (runtime-config-injection)
Tests  26 passed (26)   (public-origin)
Tests  364 passed (364) (owletto src/lib)
```

**Booted and exercised both branches** (clean boots, zero `EADDRINUSE`/start failures):
```
# path-based: PUBLIC_GATEWAY_URL=https://lobu.example.com/lobu, no cookie domain
__LOBU_RUNTIME_CONFIG__={"subdomainZone":null};

# opt-in: AUTH_COOKIE_DOMAIN=.lobu.example.com
__LOBU_RUNTIME_CONFIG__={"subdomainZone":"lobu.example.com"};
```

Mutation-tested: pointing the injector at the broad `getSubdomainZone` fails
`does not enable subdomains from PUBLIC_GATEWAY_URL alone`; forcing the zone
null fails the two zone-declaration tests.

## Notes
`getConfiguredSubdomainZone` is deliberately narrower than `getSubdomainZone`. The latter falls back to the `PUBLIC_GATEWAY_URL` host, which every path-based deployment also sets — using it for the SPA would re-enable per-org subdomains nobody asked for. `getSubdomainZone` keeps that fallback for CORS/host parsing and now also refuses loopback and IP-literal hosts, since `{org}.127.0.0.1` is not a resolvable name.

Injection ordering matters: Vite emits the app bundle inside `<head>`, so appending at `</head>` would land after it. It is injected before the first `<script>` instead.

**Not covered here:** making per-org subdomains work behind a single reverse proxy without wildcard DNS — the reporter's follow-up ask. That needs host-based scope extraction, the post-org-creation redirect, and cookie scoping to agree, and belongs in its own change. #2183 stays the tracking issue for it if you'd rather not close on this.

Closes #2183

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->