### PR TITLE
fix(ci): stop main pushes from evicting a queued release build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -26,6 +26,13 @@ name: Build and Push Images
 # other (the timestamp-collision incident above), while a release — which is
 # rare, and never concurrent with another release — can never be evicted by
 # routine merges.
+#
+# The release group deliberately keeps GitHub's default `queue: single`.
+# `queue: max` (100 pending runs, no eviction) takes no expression, so it would
+# apply to the push group too and build every intermediate commit instead of
+# coalescing to the newest. Eviction here would need three `release: published`
+# events inside one build: release-please publishes exactly one `lobu-v*`
+# release per release PR, and mac-release/helm-chart only consume that event.
 concurrency:
   group: build-images${{ github.event_name == 'release' && '-release' || '' }}
   cancel-in-progress: false

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -91,34 +91,30 @@ jobs:
       is_stable: ${{ steps.semver.outputs.is_stable }}
       should_publish: ${{ steps.semver.outputs.should_publish }}
     steps:
-      # Claim a timestamp tag no image already carries. Serialization alone no
+      # `{date}-{run_number}`, not a wall-clock time. Serialization alone no
       # longer guarantees uniqueness now that a release can run beside a push,
-      # and the tag is second-resolution. Format stays `^(\d{8})-(\d{6})$`
-      # because that is what Flux's ImagePolicy matches — semver/latest are
-      # invisible to it, so the timestamp is what actually deploys.
+      # and a clock is the wrong tool: two runs starting in the same second
+      # produce the same value. Asking the registry first does not fix it
+      # either — that is check-then-act, and concurrent runs both observe the
+      # tag free before either has pushed.
       #
-      # Probes the app repo only: all three images share one tag, so if app is
-      # free the others are too. Failing open on an unreachable registry keeps
-      # a GHCR blip from blocking every build; the tag is then merely as unique
-      # as it was before this loop.
-      - name: Generate shared timestamp tag
+      # run_number is unique and monotonic per workflow, so equal tags are
+      # impossible by construction rather than unlikely. Zero-padded to six
+      # digits to satisfy Flux's ImagePolicy `^(\d{8})-(\d{6})$` — semver and
+      # latest are invisible to it, so this tag is what actually deploys — and
+      # its numerical `${date}${time}` extract still orders ascending, so the
+      # newest build still wins. Hard-fails past 999999 rather than silently
+      # emitting an unmatched tag that would freeze deploys.
+      - name: Generate shared image tag
         id: timestamp
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          for _ in $(seq 1 10); do
-            tag="$(date -u +'%Y%m%d-%H%M%S')"
-            if ! taken="$(gh api "/orgs/${{ github.repository_owner }}/packages/container/lobu-app/versions" \
-                  --paginate --jq '[.[].metadata.container.tags[]] | @tsv' 2>/dev/null)"; then
-              echo "::warning::registry unreachable; using $tag unverified"
-              break
-            fi
-            case "	$taken	" in
-              *"	$tag	"*) echo "tag $tag already published, retrying"; sleep 1; continue;;
-            esac
-            break
-          done
+          run_number="${{ github.run_number }}"
+          if [ "$run_number" -gt 999999 ]; then
+            echo "::error::run_number $run_number exceeds the 6 digits the tag format allows."
+            exit 1
+          fi
+          tag="$(date -u +'%Y%m%d')-$(printf '%06d' "$run_number")"
           echo "Using image tag: $tag"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,16 +1,19 @@
 name: Build and Push Images
 
-# Every run publishes images tagged `date -u +%Y%m%d-%H%M%S` (generate-tag
-# below), so concurrent runs — including manual dispatches from other refs —
-# can compute the SAME tag and overwrite each other. On 2026-07-22 five PRs
-# merged within 14s, all five runs stamped `20260722-121441`, and prod ended up
-# on whichever pushed last: two merged PRs never deployed, every workflow green.
+# Every run publishes images tagged `<date>-<time>-<run_number>` (generate-tag
+# below). The timestamp was the whole tag until this change, so concurrent runs
+# — including manual dispatches from other refs — could compute the SAME tag
+# and overwrite each other. On 2026-07-22 five PRs merged within 14s, all five
+# runs stamped `20260722-121441`, and prod ended up on whichever pushed last:
+# two merged PRs never deployed, every workflow green.
 #
-# Serializing makes the tag unique in practice (runs are minutes apart, not
-# milliseconds). The tag cannot simply carry the commit SHA instead: Flux's
-# ImagePolicy matches '^(\d{8})-(\d{6})$' and lives in the owletto submodule, so
-# changing the format needs a coordinated two-repo change and a mismatch stops
-# every deploy.
+# Serializing made the tag unique only in practice (runs are minutes apart, not
+# milliseconds); the run-number suffix makes it unique by construction. The tag
+# still cannot simply carry the commit SHA instead: Flux deploys the
+# highest-sorting tag, and a SHA carries no ordering. The matching ImagePolicy
+# lives in the owletto submodule (it accepts the old two-segment tags as well as
+# the new three-segment form), so any further format change needs the same
+# coordinated two-repo change, and a mismatch stops every deploy.
 #
 # cancel-in-progress stays false: a cancelled run can leave the chart pointing
 # at a tag whose sibling images were never pushed.

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -35,11 +35,8 @@ name: Build and Push Images
 #
 # That does mean a release and a push can now run at the same time, so
 # serialization no longer guarantees a unique timestamp tag on its own.
-# `generate-tag` therefore claims a tag the registry does not already carry
-# rather than trusting runs to be seconds apart. Dropping the timestamp from
-# release runs would have been simpler but breaks deploys outright: Flux's
-# ImagePolicy matches ONLY '^(\d{8})-(\d{6})$', so semver/latest never roll
-# prod.
+# `generate-tag` therefore appends a run-number suffix — see the note there
+# for why the clock alone, a registry probe, and run_number alone all fail.
 concurrency:
   group: build-images${{ github.event_name == 'release' && '-release' || '' }}
   cancel-in-progress: false
@@ -91,30 +88,43 @@ jobs:
       is_stable: ${{ steps.semver.outputs.is_stable }}
       should_publish: ${{ steps.semver.outputs.should_publish }}
     steps:
-      # `{date}-{run_number}`, not a wall-clock time. Serialization alone no
-      # longer guarantees uniqueness now that a release can run beside a push,
-      # and a clock is the wrong tool: two runs starting in the same second
-      # produce the same value. Asking the registry first does not fix it
-      # either — that is check-then-act, and concurrent runs both observe the
-      # tag free before either has pushed.
+      # `{date}-{time}-{run_number}`. Both halves are load-bearing, and each
+      # replaces something that failed:
       #
-      # run_number is unique and monotonic per workflow, so equal tags are
-      # impossible by construction rather than unlikely. Zero-padded to six
-      # digits to satisfy Flux's ImagePolicy `^(\d{8})-(\d{6})$` — semver and
-      # latest are invisible to it, so this tag is what actually deploys — and
-      # its numerical `${date}${time}` extract still orders ascending, so the
-      # newest build still wins. Hard-fails past 999999 rather than silently
-      # emitting an unmatched tag that would freeze deploys.
+      # The timestamp ORDERS. Flux picks the numerically highest tag, so the
+      # key has to track when a build actually ran. Ordering by run_number
+      # alone breaks recovery: re-running an earlier failed release after a
+      # later push republishes a LOWER number, and the recovered release never
+      # deploys — which is exactly the rerun that unstuck `lobu-v14.4.0`.
+      #
+      # run_number BREAKS TIES. A release can now run beside a push (see the
+      # concurrency note above), so two builds can reach this step in the same
+      # second and stamp the same time. Probing the registry first does not
+      # help — that is check-then-act, and concurrent runs both see the tag
+      # free before either has pushed. run_number is unique and monotonic per
+      # workflow, so equal tags are impossible by construction.
+      #
+      # Zero-padded to a fixed width: the numerical extract concatenates the
+      # groups, so a variable-width component would misorder.
+      #
+      # The matching pattern lives in the owletto submodule
+      # (deploy/k8s/infrastructure/image-automation/image-policies.yaml) and
+      # accepts the old two-segment tags too, so the two repos can land in
+      # either order without a gap where nothing matches.
       - name: Generate shared image tag
         id: timestamp
         run: |
           set -euo pipefail
+          # The WHOLE run number, never truncated. Taking it modulo anything
+          # reintroduces collisions: a rerun reuses an OLD run_number, so
+          # re-running 1562 beside a fresh 1662 yields the same suffix in the
+          # same second. Reruns are not hypothetical — one published v14.4.0.
           run_number="${{ github.run_number }}"
           if [ "$run_number" -gt 999999 ]; then
             echo "::error::run_number $run_number exceeds the 6 digits the tag format allows."
             exit 1
           fi
-          tag="$(date -u +'%Y%m%d')-$(printf '%06d' "$run_number")"
+          tag="$(date -u +'%Y%m%d-%H%M%S')-$(printf '%06d' "$run_number")"
           echo "Using image tag: $tag"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -94,7 +94,8 @@ jobs:
       # `{date}-{time}-{run_number}`. Both halves are load-bearing, and each
       # replaces something that failed:
       #
-      # The timestamp ORDERS. Flux picks the numerically highest tag, so the
+      # The timestamp ORDERS. Flux picks the lexicographically highest
+      # extracted value (every component fixed-width, zero-padded), so the
       # key has to track when a build actually ran. Ordering by run_number
       # alone breaks recovery: re-running an earlier failed release after a
       # later push republishes a LOWER number, and the recovered release never
@@ -107,13 +108,15 @@ jobs:
       # free before either has pushed. run_number is unique and monotonic per
       # workflow, so equal tags are impossible by construction.
       #
-      # Zero-padded to a fixed width: the numerical extract concatenates the
-      # groups, so a variable-width component would misorder.
+      # Zero-padded to a fixed width: the extract concatenates the groups for
+      # lexicographic comparison, so a variable-width component would misorder.
       #
       # The matching pattern lives in the owletto submodule
-      # (deploy/k8s/infrastructure/image-automation/image-policies.yaml) and
-      # accepts the old two-segment tags too, so the two repos can land in
-      # either order without a gap where nothing matches.
+      # (deploy/k8s/infrastructure/image-automation/image-policies.yaml). It
+      # landed FIRST (owletto #616) and still accepts the old two-segment
+      # tags, so there was no window where published tags matched nothing.
+      # The reverse order would have frozen deploys: the old pattern anchors
+      # on two segments and ignores three-segment tags.
       - name: Generate shared image tag
         id: timestamp
         run: |

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -14,8 +14,20 @@ name: Build and Push Images
 #
 # cancel-in-progress stays false: a cancelled run can leave the chart pointing
 # at a tag whose sibling images were never pushed.
+#
+# Release runs get their OWN group. GitHub keeps only one *pending* run per
+# group, so a third arrival evicts the queued second — on 2026-07-28 the
+# `lobu-v14.4.0` release run was cancelled while queued behind two main pushes
+# that landed within the same two minutes, and `14.4.0` was never published
+# while `latest` stayed on a pre-release build. A cancelled queued run reports
+# no failure, so the release silently did not happen.
+#
+# Splitting only the release event keeps push runs serialized against each
+# other (the timestamp-collision incident above), while a release — which is
+# rare, and never concurrent with another release — can never be evicted by
+# routine merges.
 concurrency:
-  group: build-images
+  group: build-images${{ github.event_name == 'release' && '-release' || '' }}
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -23,9 +23,8 @@ name: Build and Push Images
 # no failure, so the release silently did not happen.
 #
 # Splitting only the release event keeps push runs serialized against each
-# other (the timestamp-collision incident above), while a release — which is
-# rare, and never concurrent with another release — can never be evicted by
-# routine merges.
+# other, while a release — which is rare, and never concurrent with another
+# release — can never be evicted by routine merges.
 #
 # The release group deliberately keeps GitHub's default `queue: single`.
 # `queue: max` (100 pending runs, no eviction) takes no expression, so it would
@@ -33,6 +32,14 @@ name: Build and Push Images
 # coalescing to the newest. Eviction here would need three `release: published`
 # events inside one build: release-please publishes exactly one `lobu-v*`
 # release per release PR, and mac-release/helm-chart only consume that event.
+#
+# That does mean a release and a push can now run at the same time, so
+# serialization no longer guarantees a unique timestamp tag on its own.
+# `generate-tag` therefore claims a tag the registry does not already carry
+# rather than trusting runs to be seconds apart. Dropping the timestamp from
+# release runs would have been simpler but breaks deploys outright: Flux's
+# ImagePolicy matches ONLY '^(\d{8})-(\d{6})$', so semver/latest never roll
+# prod.
 concurrency:
   group: build-images${{ github.event_name == 'release' && '-release' || '' }}
   cancel-in-progress: false
@@ -84,9 +91,36 @@ jobs:
       is_stable: ${{ steps.semver.outputs.is_stable }}
       should_publish: ${{ steps.semver.outputs.should_publish }}
     steps:
+      # Claim a timestamp tag no image already carries. Serialization alone no
+      # longer guarantees uniqueness now that a release can run beside a push,
+      # and the tag is second-resolution. Format stays `^(\d{8})-(\d{6})$`
+      # because that is what Flux's ImagePolicy matches — semver/latest are
+      # invisible to it, so the timestamp is what actually deploys.
+      #
+      # Probes the app repo only: all three images share one tag, so if app is
+      # free the others are too. Failing open on an unreachable registry keeps
+      # a GHCR blip from blocking every build; the tag is then merely as unique
+      # as it was before this loop.
       - name: Generate shared timestamp tag
         id: timestamp
-        run: echo "tag=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 10); do
+            tag="$(date -u +'%Y%m%d-%H%M%S')"
+            if ! taken="$(gh api "/orgs/${{ github.repository_owner }}/packages/container/lobu-app/versions" \
+                  --paginate --jq '[.[].metadata.container.tags[]] | @tsv' 2>/dev/null)"; then
+              echo "::warning::registry unreachable; using $tag unverified"
+              break
+            fi
+            case "	$taken	" in
+              *"	$tag	"*) echo "tag $tag already published, retrying"; sleep 1; continue;;
+            esac
+            break
+          done
+          echo "Using image tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       # Only this job needs the repo; the build jobs check out separately.
       - name: Checkout repository

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,45 +1,21 @@
 name: Build and Push Images
 
-# Every run publishes images tagged `<date>-<time>-<run_number>` (generate-tag
-# below). The timestamp was the whole tag until this change, so concurrent runs
-# — including manual dispatches from other refs — could compute the SAME tag
-# and overwrite each other. On 2026-07-22 five PRs merged within 14s, all five
-# runs stamped `20260722-121441`, and prod ended up on whichever pushed last:
-# two merged PRs never deployed, every workflow green.
+# GitHub keeps only one pending run per concurrency group. On 2026-07-28 the
+# `lobu-v14.4.0` release queued behind a main build, then a later main push
+# evicted it. The version images were not published until a manual rerun. Give
+# releases their own group so routine merges cannot evict them.
 #
-# Serializing made the tag unique only in practice (runs are minutes apart, not
-# milliseconds); the run-number suffix makes it unique by construction. The tag
-# still cannot simply carry the commit SHA instead: Flux deploys the
-# highest-sorting tag, and a SHA carries no ordering. The matching ImagePolicy
-# lives in the owletto submodule (it accepts the old two-segment tags as well as
-# the new three-segment form), so any further format change needs the same
-# coordinated two-repo change, and a mismatch stops every deploy.
+# Pushes deliberately keep the default single-item queue so bursts coalesce to
+# the newest commit. `queue: max` is not conditional, so setting it here would
+# queue intermediate pushes instead. cancel-in-progress stays false because
+# cancelling a running build can leave only some of the shared image tags
+# published.
 #
-# cancel-in-progress stays false: a cancelled run can leave the chart pointing
-# at a tag whose sibling images were never pushed.
-#
-# Release runs get their OWN group. GitHub keeps only one *pending* run per
-# group, so a third arrival evicts the queued second — on 2026-07-28 the
-# `lobu-v14.4.0` release run was cancelled while queued behind two main pushes
-# that landed within the same two minutes, and `14.4.0` was never published
-# while `latest` stayed on a pre-release build. A cancelled queued run reports
-# no failure, so the release silently did not happen.
-#
-# Splitting only the release event keeps push runs serialized against each
-# other, while a release — which is rare, and never concurrent with another
-# release — can never be evicted by routine merges.
-#
-# The release group deliberately keeps GitHub's default `queue: single`.
-# `queue: max` (100 pending runs, no eviction) takes no expression, so it would
-# apply to the push group too and build every intermediate commit instead of
-# coalescing to the newest. Eviction here would need three `release: published`
-# events inside one build: release-please publishes exactly one `lobu-v*`
-# release per release PR, and mac-release/helm-chart only consume that event.
-#
-# That does mean a release and a push can now run at the same time, so
-# serialization no longer guarantees a unique timestamp tag on its own.
-# `generate-tag` therefore appends a run-number suffix — see the note there
-# for why the clock alone, a registry probe, and run_number alone all fail.
+# Separate groups let a release and push run in the same second. generate-tag
+# therefore appends a zero-padded run number to the timestamp; the timestamp
+# preserves Flux ordering across reruns and the run number breaks ties. The
+# matching ImagePolicy lives in the owletto submodule and accepts both the old
+# two-segment tags and the new three-segment form.
 concurrency:
   group: build-images${{ github.event_name == 'release' && '-release' || '' }}
   cancel-in-progress: false
@@ -86,65 +62,23 @@ jobs:
   generate-tag:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
-      tag: ${{ steps.timestamp.outputs.tag }}
-      semver: ${{ steps.semver.outputs.semver }}
-      is_stable: ${{ steps.semver.outputs.is_stable }}
-      should_publish: ${{ steps.semver.outputs.should_publish }}
+      tag: ${{ steps.tags.outputs.tag }}
+      semver: ${{ steps.tags.outputs.semver }}
+      is_stable: ${{ steps.tags.outputs.is_stable }}
+      should_publish: ${{ steps.tags.outputs.should_publish }}
     steps:
-      # `{date}-{time}-{run_number}`. Both halves are load-bearing, and each
-      # replaces something that failed:
-      #
-      # The timestamp ORDERS. Flux picks the lexicographically highest
-      # extracted value (every component fixed-width, zero-padded), so the
-      # key has to track when a build actually ran. Ordering by run_number
-      # alone breaks recovery: re-running an earlier failed release after a
-      # later push republishes a LOWER number, and the recovered release never
-      # deploys — which is exactly the rerun that unstuck `lobu-v14.4.0`.
-      #
-      # run_number BREAKS TIES. A release can now run beside a push (see the
-      # concurrency note above), so two builds can reach this step in the same
-      # second and stamp the same time. Probing the registry first does not
-      # help — that is check-then-act, and concurrent runs both see the tag
-      # free before either has pushed. run_number is unique and monotonic per
-      # workflow, so equal tags are impossible by construction.
-      #
-      # Zero-padded to a fixed width: the extract concatenates the groups for
-      # lexicographic comparison, so a variable-width component would misorder.
-      #
-      # The matching pattern lives in the owletto submodule
-      # (deploy/k8s/infrastructure/image-automation/image-policies.yaml). It
-      # landed FIRST (owletto #616) and still accepts the old two-segment
-      # tags, so there was no window where published tags matched nothing.
-      # The reverse order would have frozen deploys: the old pattern anchors
-      # on two segments and ignores three-segment tags.
-      - name: Generate shared image tag
-        id: timestamp
-        run: |
-          set -euo pipefail
-          # The WHOLE run number, never truncated. Taking it modulo anything
-          # reintroduces collisions: a rerun reuses an OLD run_number, so
-          # re-running 1562 beside a fresh 1662 yields the same suffix in the
-          # same second. Reruns are not hypothetical — one published v14.4.0.
-          run_number="${{ github.run_number }}"
-          if [ "$run_number" -gt 999999 ]; then
-            echo "::error::run_number $run_number exceeds the 6 digits the tag format allows."
-            exit 1
-          fi
-          tag="$(date -u +'%Y%m%d-%H%M%S')-$(printf '%06d' "$run_number")"
-          echo "Using image tag: $tag"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
       # Only this job needs the repo; the build jobs check out separately.
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      # Derivation lives in scripts/derive-image-tags.mjs so it is unit-tested
-      # (scripts/__tests__/derive-image-tags.test.ts) — inline YAML shell can
-      # only be exercised by cutting a real release. Computed once here so
-      # app/worker/embeddings can never disagree about eligibility or version.
-      - name: Derive semver tag from the release
-        id: semver
+      # Every tag decision lives in scripts/derive-image-tags.mjs so it is
+      # covered by scripts/__tests__/derive-image-tags.test.ts. Computed once
+      # here so app/worker/embeddings cannot disagree about the tag,
+      # eligibility, or version.
+      - name: Derive image tags
+        id: tags
         env:
+          RUN_NUMBER: ${{ github.run_number }}
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
           PRERELEASE: ${{ github.event_name == 'release' && github.event.release.prerelease || false }}

--- a/scripts/__tests__/derive-image-tags.test.ts
+++ b/scripts/__tests__/derive-image-tags.test.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "bun:test";
 // @ts-expect-error — plain .mjs script, no type declarations by design.
-import { deriveImageTags } from "../derive-image-tags.mjs";
+import { buildImageTag, deriveImageTags } from "../derive-image-tags.mjs";
 
 const SCRIPT = fileURLToPath(
   new URL("../derive-image-tags.mjs", import.meta.url)
@@ -100,6 +100,68 @@ describe("deriveImageTags", () => {
 });
 
 /**
+ * Flux's ImagePolicy (owletto: deploy/k8s/infrastructure/image-automation/
+ * image-policies.yaml) filters on this pattern and orders tags by the
+ * concatenated groups, compared as strings (`alphabetical` policy). Mirror that
+ * contract here to prove generated tags are accepted and ordered as intended.
+ */
+const FLUX_PATTERN = /^(\d{8})-(\d{6})(?:-(\d{6}))?$/;
+const fluxExtract = (tag: string) => {
+  const match = FLUX_PATTERN.exec(tag);
+  if (!match) throw new Error(`tag '${tag}' does not match the Flux pattern`);
+  return `${match[1]}${match[2]}${match[3] ?? ""}`;
+};
+
+describe("buildImageTag", () => {
+  const at = (iso: string, runNumber: number | string) =>
+    buildImageTag({ now: new Date(iso), runNumber });
+
+  it("formats UTC fixed-width and zero-pads the run number", () => {
+    expect(at("2026-07-28T13:51:24Z", 1662)).toBe("20260728-135124-001662");
+    expect(at("2026-01-02T03:04:05Z", 7)).toBe("20260102-030405-000007");
+  });
+
+  it("keeps two same-second builds distinct — including a lower-numbered rerun", () => {
+    // The race the split concurrency groups create: a release beside a push.
+    const now = "2026-07-28T13:51:24Z";
+    const fresh = at(now, 1662);
+    for (const other of [1663, 1562]) {
+      expect(at(now, other)).not.toBe(fresh);
+      expect(fluxExtract(at(now, other))).not.toBe(fluxExtract(fresh));
+    }
+  });
+
+  it("lets a later rerun of a lower run number win Flux's ordering", () => {
+    // Re-running an earlier failed release AFTER a later push must still
+    // deploy — the recovery that unstuck lobu-v14.4.0. Timestamp orders;
+    // run number only breaks ties.
+    const pushAt1359 = at("2026-07-28T13:59:59Z", 1662);
+    const rerunAt1400 = at("2026-07-28T14:00:00Z", 1562);
+    expect(fluxExtract(rerunAt1400) > fluxExtract(pushAt1359)).toBe(true);
+  });
+
+  it("sorts above the retired two-segment format at the same second", () => {
+    // The policy accepts both formats. The old extract is a strict prefix of a
+    // same-second new tag, while its timestamp still wins in the next second.
+    const oldFormat = fluxExtract("20260728-135124");
+    const newFormat = fluxExtract(at("2026-07-28T13:51:24Z", 1));
+    expect(newFormat > oldFormat).toBe(true);
+    expect(fluxExtract("20260728-135125") > newFormat).toBe(true);
+  });
+
+  it("rejects run numbers the fixed-width format cannot carry", () => {
+    const now = "2026-07-28T13:51:24Z";
+    expect(at(now, 999999)).toBe("20260728-135124-999999");
+    for (const bad of [1000000, 0, -1, 1.5, "", "abc", undefined]) {
+      expect(
+        () => buildImageTag({ now: new Date(now), runNumber: bad }),
+        `run number ${JSON.stringify(bad)} must be rejected`
+      ).toThrow();
+    }
+  });
+});
+
+/**
  * The workflow consumes this script as a subprocess, so the CLI half needs its
  * own coverage: the exported function can be perfect while the main block never
  * runs. That is not hypothetical — a `process.argv[1].endsWith(name)` guard, and
@@ -133,13 +195,26 @@ describe("derive-image-tags CLI", () => {
       EVENT_NAME: "release",
       RELEASE_TAG: "lobu-v14.4.0",
       PRERELEASE: "false",
+      RUN_NUMBER: "1662",
     });
     expect(status).toBe(0);
     // The workflow keys `latest` and the version tag off these exact names;
     // a missing line reads as "no release" rather than as a failure.
+    expect(output).toMatch(/tag=\d{8}-\d{6}-001662\n/);
     expect(output).toContain("semver=14.4.0");
     expect(output).toContain("is_stable=true");
     expect(output).toContain("should_publish=true");
+  });
+
+  it("fails the job when RUN_NUMBER is missing", () => {
+    const { status, output } = run({
+      EVENT_NAME: "push",
+      RELEASE_TAG: "",
+      PRERELEASE: "false",
+      RUN_NUMBER: "",
+    });
+    expect(status).toBe(1);
+    expect(output).toBe("");
   });
 
   it("still runs when invoked through a symlink with a different name", () => {
@@ -154,7 +229,7 @@ describe("derive-image-tags CLI", () => {
       writeFileSync(real, readFileSync(SCRIPT, "utf8"));
       symlinkSync(real, link);
       const { status, output } = run(
-        { EVENT_NAME: "release", RELEASE_TAG: "lobu-v14.4.0" },
+        { EVENT_NAME: "release", RELEASE_TAG: "lobu-v14.4.0", RUN_NUMBER: "7" },
         link
       );
       expect(status).toBe(0);

--- a/scripts/derive-image-tags.mjs
+++ b/scripts/derive-image-tags.mjs
@@ -6,12 +6,13 @@
  * ghcr.io/lobu-ai/lobu-app:latest got an arbitrary build and no tag identified
  * a release at all (#2184). This derives, for one workflow run:
  *
+ *   tag            shared deployment tag when this run publishes images
  *   semver         version tag to publish ("" = none)
  *   is_stable      whether `latest` moves to this build
  *   should_publish whether the build jobs run at all
  *
- * Lives here rather than inline in the workflow so it can be unit-tested —
- * embedded YAML shell is only exercisable by cutting a real release.
+ * Lives here rather than inline in the workflow so the decision table has a
+ * narrow unit-test path.
  */
 
 import { appendFileSync, realpathSync } from "node:fs";
@@ -19,6 +20,36 @@ import { fileURLToPath } from "node:url";
 
 /** release-please publishes lobu-vX.Y.Z; other repos' releases share this feed. */
 const LOBU_TAG_PREFIX = "lobu-v";
+
+const MAX_RUN_NUMBER = 999999;
+
+/**
+ * Build `<UTC date>-<UTC time>-<run number>`. Flux orders by the timestamp so
+ * rerunning an older workflow after a newer run still deploys the rerun. The
+ * run number distinguishes separate runs created in the same second.
+ *
+ * All components are fixed-width because the matching ImagePolicy concatenates
+ * them and compares the result lexicographically.
+ *
+ * @param {{now: Date, runNumber: number|string}} input
+ * @returns {string}
+ * @throws when runNumber is not a positive integer or exceeds six digits.
+ */
+export function buildImageTag({ now, runNumber }) {
+  const n = Number(runNumber);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`run number '${runNumber}' is not a positive integer.`);
+  }
+  if (n > MAX_RUN_NUMBER) {
+    throw new Error(
+      `run number ${n} exceeds the 6 digits the tag format allows.`
+    );
+  }
+  const pad = (value, width) => String(value).padStart(width, "0");
+  const date = `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1, 2)}${pad(now.getUTCDate(), 2)}`;
+  const time = `${pad(now.getUTCHours(), 2)}${pad(now.getUTCMinutes(), 2)}${pad(now.getUTCSeconds(), 2)}`;
+  return `${date}-${time}-${pad(n, 6)}`;
+}
 
 /** Full SemVer 2.0.0 (semver.org). A loose \d+\.\d+\.\d+ accepts `01.2.3`. */
 const SEMVER =
@@ -34,7 +65,7 @@ export function deriveImageTags({
   releaseTag = "",
   prerelease = false,
 } = {}) {
-  // Not a release: main pushes and workflow_dispatch publish the timestamp tag
+  // Not a release: main pushes and workflow_dispatch publish the deployment tag
   // only. That is the #2184 fix — `latest` no longer follows every commit.
   if (eventName !== "release") {
     return { semver: "", is_stable: false, should_publish: true };
@@ -86,17 +117,25 @@ function isMainModule() {
 // than seeing an error — so resolve both sides.
 if (process.argv[1] && isMainModule()) {
   let result;
+  let tag;
   try {
     result = deriveImageTags({
       eventName: process.env.EVENT_NAME,
       releaseTag: process.env.RELEASE_TAG,
       prerelease: process.env.PRERELEASE,
     });
+    // RUN_NUMBER is required so a missing workflow input fails at its source
+    // instead of surfacing an empty tag to the build jobs.
+    tag = buildImageTag({
+      now: new Date(),
+      runNumber: process.env.RUN_NUMBER,
+    });
   } catch (error) {
     console.error(`::error::${error.message}`);
     process.exit(1);
   }
   const lines = [
+    `tag=${tag}`,
     `semver=${result.semver}`,
     `is_stable=${result.is_stable}`,
     `should_publish=${result.should_publish}`,


### PR DESCRIPTION
## Summary
- GitHub keeps only one *pending* run per concurrency group, so a third arrival evicts the queued second. `build-images.yml` put every trigger in one group.
- On 2026-07-28 the `lobu-v14.4.0` release run was cancelled while queued between two main pushes that landed within the same two minutes. `14.4.0` was never published and `latest` stayed on a pre-release build — with every workflow green, because a cancelled queued run surfaces no failure.
- Only the release event moves to its own group. Push and `workflow_dispatch` stay serialized against each other, preserving the timestamp-collision protection documented in the file header.
- Because a release and a push can now run at the same time, the tag itself became the weak link: `generate-tag` now stamps `<date>-<time>-<run_number>` instead of the bare timestamp. The matching Flux `ImagePolicy` change is paired in lobu-ai/owletto#616 and pinned via `packages/owletto`.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [ ] Tests run — n/a, workflow-config only
- [x] Bug fix: evidence below

**The incident** (`gh run list --workflow=build-images.yml`):
```
30364268031 13:36 push    completed  (ran)
30364235587 13:35 release completed  cancelled   <- evicted
30364197440 13:35 push    completed  cancelled
30364086204 13:34 push    completed  success
```

**Consequence** (ghcr, both images, all versions):
```
lobu-app    semver tags: NONE — 14.4.0 never published
lobu-worker semver tags: NONE — 14.4.0 never published
latest -> 20260728-071749   (pre-release build)
```

**The publish logic itself was never broken** — only the run that would have reached it:
```
$ EVENT_NAME=release RELEASE_TAG=lobu-v14.4.0 PRERELEASE=false node scripts/derive-image-tags.mjs
semver=14.4.0
is_stable=true
should_publish=true
```

**Group resolution after the change:**
```
push               -> "build-images"
release            -> "build-images-release"
workflow_dispatch  -> "build-images"
```

## Notes
A release and a push can now run concurrently, so the timestamp alone no longer guarantees a unique tag. `generate-tag` therefore appends the run number, zero-padded to six digits and never truncated: a rerun reuses an *old* run number, so any modulo reintroduces the collision it was meant to remove. The timestamp keeps doing the ordering, so re-running an earlier failed build after a later push still wins, which is exactly the rerun that finally published `lobu-v14.4.0`.

**Merge order: lobu-ai/owletto#616 first.** The matching `ImagePolicy` lives in the owletto submodule, so this is a paired landing. That PR widens the pattern to `^(?P<date>\d{8})-(?P<time>\d{6})(?:-(?P<run>\d{6}))?## Summary
- GitHub keeps only one *pending* run per concurrency group, so a third arrival evicts the queued second. `build-images.yml` put every trigger in one group.
- On 2026-07-28 the `lobu-v14.4.0` release run was cancelled while queued between two main pushes that landed within the same two minutes. `14.4.0` was never published and `latest` stayed on a pre-release build — with every workflow green, because a cancelled queued run surfaces no failure.
- Only the release event moves to its own group. Push and `workflow_dispatch` stay serialized against each other, preserving the timestamp-collision protection documented in the file header.
- Because a release and a push can now run at the same time, the tag itself became the weak link: `generate-tag` now stamps `<date>-<time>-<run_number>` instead of the bare timestamp. The matching Flux `ImagePolicy` change is paired in lobu-ai/owletto#616 and pinned via `packages/owletto`.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [ ] Tests run — n/a, workflow-config only
- [x] Bug fix: evidence below

**The incident** (`gh run list --workflow=build-images.yml`):
```
30364268031 13:36 push    completed  (ran)
30364235587 13:35 release completed  cancelled   <- evicted
30364197440 13:35 push    completed  cancelled
30364086204 13:34 push    completed  success
```

**Consequence** (ghcr, both images, all versions):
```
lobu-app    semver tags: NONE — 14.4.0 never published
lobu-worker semver tags: NONE — 14.4.0 never published
latest -> 20260728-071749   (pre-release build)
```

**The publish logic itself was never broken** — only the run that would have reached it:
```
$ EVENT_NAME=release RELEASE_TAG=lobu-v14.4.0 PRERELEASE=false node scripts/derive-image-tags.mjs
semver=14.4.0
is_stable=true
should_publish=true
```

**Group resolution after the change:**
```
push               -> "build-images"
release            -> "build-images-release"
workflow_dispatch  -> "build-images"
```

## Notes
 and moves the policy from `numerical` to `alphabetical` (the numerical policy parses the extract with `strconv.ParseFloat(.., 64)`, which rounds the low-order digits off a 20-digit value and makes two same-second tags compare equal, silently undoing the tie-break). The suffix group is optional, so merging owletto first is a no-op against every already-published tag; merging this PR first would publish three-segment tags the live pattern rejects and freeze all deploys. `check-drift` stays red here until owletto#616 squash-merges and `packages/owletto` is re-pointed at that squash SHA.

Follow-up worth considering: nothing alerts when a release publishes no image. The failure mode this fixes was invisible for hours precisely because cancelled runs look like successes.

Related: #2184 (which introduced the release-triggered tagging), #2241.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release build reliability by preventing release runs from being cancelled by concurrent builds triggered through other events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
