### PR TITLE
fix(scripts): stop attempting to publish the two inline-only plugin packages

### DIFF
--- a/scripts/__tests__/publish-packages-guard.test.ts
+++ b/scripts/__tests__/publish-packages-guard.test.ts
@@ -47,7 +47,10 @@ describe("rewriteWorkspaceRefs publishability guard", () => {
         message = error instanceof Error ? error.message : String(error);
         throw error;
       }
-    }).toThrow(/@lobu\/plugin-mcp/);
+      // plugin-api is the first unpublishable dep in this manifest. It is not
+      // in PACKAGES (nothing on npm can resolve it, and @lobu/worker inlines
+      // it), so the guard must name it exactly as it names a private plugin.
+    }).toThrow(/@lobu\/plugin-api/);
     // An actionable message is the point: "failed" would leave the next
     // person guessing which of the two fixes applies.
     expect(message).toContain("@lobu/worker");

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -27,8 +27,14 @@ const REPO_ROOT = path.resolve(
 
 const PACKAGES = [
   { dir: "packages/core", transform: transformCorePublish },
-  { dir: "packages/plugin-api", transform: transformCorePublish },
-  { dir: "packages/plugin-host", transform: transformCorePublish },
+  // @lobu/plugin-api and @lobu/plugin-host are NOT published. Their only
+  // consumer is @lobu/worker, whose publish transform inlines the entire
+  // @lobu graph into dist/index.bundle.mjs and declares no @lobu dependency
+  // at all — so nothing on npm can resolve them, and nothing needs to. They
+  // sat in this list without ever existing on the registry, which made every
+  // release report a first-publish failure (npm returns E404 when the CI
+  // granular token cannot name a package that does not exist yet) even though
+  // every package a consumer actually installs published fine.
   { dir: "packages/connector-sdk", transform: rewriteWorkspaceRefs },
   { dir: "packages/client", transform: rewriteWorkspaceRefs },
   // Publishes the esbuild bundle rather than the tsc output — see


### PR DESCRIPTION
## What

Removes `@lobu/plugin-api` and `@lobu/plugin-host` from the `PACKAGES` publish set in `scripts/publish-packages.mjs`.

## Why

They have never existed on the registry:

```
curl https://registry.npmjs.org/@lobu/plugin-api   → {"error":"Not found"}
curl https://registry.npmjs.org/@lobu/plugin-host  → {"error":"Not found"}
```

Their only consumer is `@lobu/worker`, whose `transformWorkerPublish` inlines the entire `@lobu` graph into `dist/index.bundle.mjs` and declares **no** `@lobu` dependency. So nothing published can resolve them, and nothing needs to. The existing guard test already states this intent: *"declaring them would also keep the release blocked on a bootstrap publish."*

The cost was a permanently red release. The registry returns E404 on the first publish of a scoped package the CI granular token cannot name, so every run ended in `FirstPublishBlockedError` for these two:

```
refused the first publish of 2 new package(s):
  - @lobu/plugin-api
  - @lobu/plugin-host
```

14.4.0 published correctly and still reported failure. Three prior releases (07-16, 07-21, 07-24) failed the same way.

## Verification

The publish transform is unaffected — packed `agent-worker` with the real publish manifest:

```
tarball: package/package.json
         package/dist/index.bundle.d.ts
         package/dist/index.bundle.mjs      3 files, 83.74KB

bun add ./lobu-worker.tgz  →  341 packages installed, exit 0
node -e 'import "@lobu/worker"'  →  boots, exits on missing USER_ID
[build-worker-bundle] ok — 15 external(s), zero @lobu
```

Identical to the published 14.4.0 artifact.

```
bun test scripts/__tests__/publish-packages-guard.test.ts   27 pass, 0 fail
make pre-pr                                                  ✅ clean
```

One guard fixture asserted on `@lobu/plugin-mcp` as the first unpublishable dep; with `plugin-api` no longer in `PACKAGES` it trips first, so the assertion now names it. The test's intent (the guard names an unpublishable dep and both remedies) is unchanged.

## Not verified

I could not run a real publish — registry auth returns 401 locally. The next release is what proves the workflow goes green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->