### PR TITLE
refactor: delete all legacy owner routes; reserve their segments

### DIFF
--- a/docs/plans/final-architecture-annotated.md
+++ b/docs/plans/final-architecture-annotated.md
@@ -84,10 +84,10 @@
 > provider in the web UI first — the exact step the demo is meant to eliminate.
 > Files: `packages/server/src/auth/builder-provisioning.ts:175-189` +
 > `packages/server/src/auth/system-provider-resolution.ts:55-105` (repair no-op);
-> existing link+form path to reuse: `packages/server/src/utils/url-builder.ts:84-107` +
-> `packages/owletto/src/app/$owner/inference-providers/new.tsx:8-16` *(route deleted 2026-07-28 —
-> the form now lives at `/$owner/connectors/inference-provider:<slug>`, emitted by
-> `buildProviderConnectUrl` in `url-builder.ts`)*. Fix: when the builder has no
+> current link+form path to reuse: `buildProviderConnectUrl` in
+> `packages/server/src/utils/url-builder.ts` +
+> `ProviderConnectorBody` in
+> `packages/owletto/src/app/$owner/connectors/$connectorKey.index.tsx`. Fix: when the builder has no
 > usable model, have the bot post the run-backed configure link (§16.2) instead of erroring; deliver
 > the §16.2/§21 flow in Phase 0.
 >
@@ -554,11 +554,10 @@ Every public action has one `ActionDefinition` (input/output schemas, access tie
 
 ## 16.1 Stateless prefill link
 > **CUT (low).** Query-param prefill without a run. Run-backed links (§16.2) cover the demo; this is a
-> nice-to-have. Note: no owletto route reads these params for runtime connections today, and the
-> environments form hardcodes Vercel's three fields client-side
-> (`packages/owletto/src/app/$owner/inference-providers/new.tsx:8-13`;
-> `.../environments/index.tsx:24-43` — *both routes deleted 2026-07-28; the connect form now lives
-> at `/$owner/connectors/inference-provider:<slug>`*). Defer.
+> nice-to-have. Inference-provider CTAs already use stateless `model`/`reason`/`agentId` prefill on
+> `/$owner/connectors/inference-provider:<slug>`. The former `/$owner/environments` route was only a
+> redirect by the time this branch started and is now deleted; any remaining runtime prefill work must
+> target the current sandbox-provider connector flow. Defer the remaining runtime prefill.
 
 ## 16.2 Run-backed configuration link
 > **KEEP + GAP (high) — this is the demo's config mechanism; build it in Phase 0/1.** Correct design,

--- a/docs/plans/final-architecture-annotated.md
+++ b/docs/plans/final-architecture-annotated.md
@@ -85,7 +85,9 @@
 > Files: `packages/server/src/auth/builder-provisioning.ts:175-189` +
 > `packages/server/src/auth/system-provider-resolution.ts:55-105` (repair no-op);
 > existing link+form path to reuse: `packages/server/src/utils/url-builder.ts:84-107` +
-> `packages/owletto/src/app/$owner/inference-providers/new.tsx:8-16`. Fix: when the builder has no
+> `packages/owletto/src/app/$owner/inference-providers/new.tsx:8-16` *(route deleted 2026-07-28 —
+> the form now lives at `/$owner/connectors/inference-provider:<slug>`, emitted by
+> `buildProviderConnectUrl` in `url-builder.ts`)*. Fix: when the builder has no
 > usable model, have the bot post the run-backed configure link (§16.2) instead of erroring; deliver
 > the §16.2/§21 flow in Phase 0.
 >
@@ -555,7 +557,8 @@ Every public action has one `ActionDefinition` (input/output schemas, access tie
 > nice-to-have. Note: no owletto route reads these params for runtime connections today, and the
 > environments form hardcodes Vercel's three fields client-side
 > (`packages/owletto/src/app/$owner/inference-providers/new.tsx:8-13`;
-> `.../environments/index.tsx:24-43`). Defer.
+> `.../environments/index.tsx:24-43` — *both routes deleted 2026-07-28; the connect form now lives
+> at `/$owner/connectors/inference-provider:<slug>`*). Defer.
 
 ## 16.2 Run-backed configuration link
 > **KEEP + GAP (high) — this is the demo's config mechanism; build it in Phase 0/1.** Correct design,

--- a/packages/core/src/__tests__/reserved.test.ts
+++ b/packages/core/src/__tests__/reserved.test.ts
@@ -24,6 +24,19 @@ describe("isReservedEntityTypeSlug", () => {
     expect(isReservedEntityTypeSlug("person")).toBe(false);
     expect(isReservedEntityTypeSlug("channel")).toBe(false);
   });
+
+  it("blocks live routes missing from OWNER_ROUTE_SEGMENTS and deleted legacy segments", () => {
+    // /$owner/entity-types is a live route absent from OWNER_ROUTE_SEGMENTS —
+    // an entity type with that slug would get its list page permanently
+    // shadowed by the static route.
+    expect(isReservedEntityTypeSlug("entity-types")).toBe(true);
+    // Deleted legacy routes stay reserved via REMOVED_OWNER_SEGMENTS: chat
+    // history still contains their URLs (`events` is append-only), so no
+    // entity type may ever claim a dead URL.
+    expect(isReservedEntityTypeSlug("inference-providers")).toBe(true);
+    expect(isReservedEntityTypeSlug("environments")).toBe(true);
+    expect(isReservedEntityTypeSlug("infrastructure")).toBe(true);
+  });
 });
 
 describe("lists", () => {

--- a/packages/core/src/__tests__/reserved.test.ts
+++ b/packages/core/src/__tests__/reserved.test.ts
@@ -30,9 +30,8 @@ describe("isReservedEntityTypeSlug", () => {
     // an entity type with that slug would get its list page permanently
     // shadowed by the static route.
     expect(isReservedEntityTypeSlug("entity-types")).toBe(true);
-    // Deleted legacy routes stay reserved via REMOVED_OWNER_SEGMENTS: chat
-    // history still contains their URLs (`events` is append-only), so no
-    // entity type may ever claim a dead URL.
+    // Deleted legacy routes stay reserved via REMOVED_OWNER_SEGMENTS so old
+    // bookmarks and chat links can never resolve as an unrelated entity type.
     expect(isReservedEntityTypeSlug("inference-providers")).toBe(true);
     expect(isReservedEntityTypeSlug("environments")).toBe(true);
     expect(isReservedEntityTypeSlug("infrastructure")).toBe(true);

--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -36,7 +36,7 @@ export const OWNER_ROUTE_SEGMENTS = [
 /**
  * Legacy page slugs removed from the UI router. Bookmarks and previously sent
  * chat messages can still contain URLs under these segments, so the segments
- * stay reserved: no entity type or org slug may ever claim a dead URL, and the
+ * stay reserved: new entity types and orgs cannot claim their names, and the
  * SPA's entity-type/splat guards notFound() them instead of resolving them as
  * entities.
  */
@@ -47,8 +47,9 @@ export const REMOVED_OWNER_SEGMENTS = [
   "sources",
   // Redirect-only shims deleted 2026-07-28: environments → connectors,
   // infrastructure/models + inference-providers(/new) → provider connector
-  // detail. Their URLs were emitted into Slack/Telegram messages (PRs #1766,
-  // #1847); old links now land on the router's global not-found page.
+  // detail. The provider URLs were emitted into chat messages (PRs #1766,
+  // #1847), while environments may remain in bookmarks; these old links now
+  // land on the router's global not-found page.
   "environments",
   "infrastructure",
   "inference-providers",

--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -28,24 +28,30 @@ export const OWNER_ROUTE_SEGMENTS = [
   "agents",
   "connectors",
   "devices",
-  // Legacy redirect path /$owner/environments → connectors.
-  // Keep reserved so an org/entity slug never collides with the redirect.
-  "environments",
-  // Redirect-only segment for immutable chat-message links: /$owner/
-  // infrastructure/models URLs were emitted into Slack/Telegram messages
-  // (PR #1847) and cannot be rewritten, so the segment must keep routing.
-  "infrastructure",
   "memory",
   "members",
   "settings",
 ] as const;
 
-/** Legacy page slugs removed from the UI router. */
+/**
+ * Legacy page slugs removed from the UI router. Chat history still contains
+ * URLs under some of these segments (`events` is append-only — the links can
+ * never be rewritten), so the segments stay reserved: no entity type or org
+ * slug may ever claim a dead URL, and the SPA's entity-type/splat guards
+ * notFound() them instead of resolving them as entities.
+ */
 export const REMOVED_OWNER_SEGMENTS = [
   "events",
   "watchers",
   "connections",
   "sources",
+  // Redirect-only shims deleted 2026-07-28: environments → connectors,
+  // infrastructure/models + inference-providers(/new) → provider connector
+  // detail. Their URLs were emitted into Slack/Telegram messages (PRs #1766,
+  // #1847); old links now land on the router's global not-found page.
+  "environments",
+  "infrastructure",
+  "inference-providers",
 ] as const;
 
 /**
@@ -91,6 +97,13 @@ export const RESERVED_PATHS_SET: ReadonlySet<string> = new Set(RESERVED_PATHS);
 export const RESERVED_ENTITY_TYPE_SLUGS = [
   ...OWNER_ROUTE_SEGMENTS,
   ...REMOVED_OWNER_SEGMENTS,
+  // Live /$owner/<segment> route that is NOT an owner-nav segment (so it is
+  // absent from OWNER_ROUTE_SEGMENTS): an entity type with this slug would get
+  // its list page permanently shadowed by the static route. Create-time
+  // hygiene only — deliberately not added to OWNER_ROUTE_SEGMENTS, which also
+  // feeds the SPA's entity-splat routing guard and would break any existing
+  // entity type already using the slug.
+  "entity-types",
   "organization",
   "user",
   "watcher",

--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -34,11 +34,11 @@ export const OWNER_ROUTE_SEGMENTS = [
 ] as const;
 
 /**
- * Legacy page slugs removed from the UI router. Chat history still contains
- * URLs under some of these segments (`events` is append-only — the links can
- * never be rewritten), so the segments stay reserved: no entity type or org
- * slug may ever claim a dead URL, and the SPA's entity-type/splat guards
- * notFound() them instead of resolving them as entities.
+ * Legacy page slugs removed from the UI router. Bookmarks and previously sent
+ * chat messages can still contain URLs under these segments, so the segments
+ * stay reserved: no entity type or org slug may ever claim a dead URL, and the
+ * SPA's entity-type/splat guards notFound() them instead of resolving them as
+ * entities.
  */
 export const REMOVED_OWNER_SEGMENTS = [
   "events",


### PR DESCRIPTION
## Summary
- Deletes **all four** legacy owner routes: `/$owner/inference-providers/new`, `/$owner/environments`, `/$owner/inference-providers`, and `/$owner/infrastructure/models`. All were redirect-only shims kept for URLs already emitted into chat history; deleting them is a deliberate call (user decision, made knowing ~372 delivered prod messages link to them — `events` is append-only, so those links can never be rewritten).
- Old links now land on a **real page**: the router gains a styled `defaultNotFoundComponent` — previously an unhandled `notFound()` rendered TanStack's bare unstyled `<p>Not Found</p>` outside the app shell.
- The segments move to `REMOVED_OWNER_SEGMENTS` (the existing pattern for router-removed slugs — `events`, `watchers`, `connections`, `sources`), so the SPA's entity-type/splat guards `notFound()` the dead URLs and no entity type or org slug can ever claim them.
- Closes a latent gap found while auditing the reserved lists: `/$owner/entity-types` is a live route absent from **every** reserved list, so an entity type with that slug would get its list page permanently shadowed by the static route. Now in the create denylist (create-time only — deliberately NOT in `OWNER_ROUTE_SEGMENTS`, which also feeds splat routing and would break any existing entity type using the slug).
- The add-a-provider form lives at `/$owner/connectors/inference-provider:<slug>`, emitted by `buildProviderConnectUrl` (verified: `origin/main` has zero emitters of any deleted route).

## Test plan
- [x] `make pre-pr` clean — all 6 gates
- [x] Full owletto suite **995/995** (117 files); repo `make test-unit` green; core reserved tests 4/4
- [x] Bug fix red→green (reservation gap):
```
# before the fix
(fail) isReservedEntityTypeSlug > blocks ... [expect true, received false]  ← "inference-providers"
 3 pass / 1 fail
# after
 4 pass / 0 fail
```
- [x] Route smoke now asserts behavior, not just mounting: new opt-in `expectText` on `RouteCase`; all four dead paths assert the global not-found page **actually renders** (`getByText("Page not found")`), and the test-harness router mirrors the prod router's `defaultNotFoundComponent` so smokes exercise the same surface production serves. The route-file↔smoke-entry sync test turns any resurrection of the deleted files into a failure.
- [ ] Bot behavior: n/a

## Notes
- Route tree regenerated: **0 references** to any deleted route.
- Sweep for emitters/references (backend + owletto, excluding generated): clean. Only residue was two point-in-time citations in `docs/plans/final-architecture-annotated.md`, now annotated with where the form lives.
- Owletto submodule `d66c295f`; branch carries codesmith/user main-merges on both repos (FluxCD image commits + #2250) — no source overlap, `git diff --name-only origin/main...HEAD` is exactly the intended file list.