### PR TITLE
feat(ci): audit that the newest stable release is actually served by ghcr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,6 +573,13 @@ jobs:
         # could only be exercised by cutting a real release.
         run: bun test scripts/__tests__/derive-image-tags.test.ts
 
+      - name: Release image audit decision table
+        # The scheduled audit (release-image-audit.yml) is the only thing that
+        # notices a release which published no image — a run evicted from its
+        # concurrency queue fails nothing. A wrong decision table here silently
+        # disables that alarm, so it is pinned by tests like the tag logic above.
+        run: bun test scripts/__tests__/audit-release-images.test.ts
+
       - name: Raw-array SQL-param gate
         # packages/server's postgres.js client runs fetch_types:false, where a raw
         # JS array bound as a query param serializes to a malformed array literal

--- a/.github/workflows/release-image-audit.yml
+++ b/.github/workflows/release-image-audit.yml
@@ -1,0 +1,38 @@
+name: Release Image Audit
+
+# A release that publishes no image is invisible from inside the pipeline: a
+# build-images run evicted from its concurrency queue (lobu-v14.4.0,
+# 2026-07-28) fails nothing — the version tag just never appears in ghcr and
+# `latest` stays on an older build. No job inside build-images can catch a run
+# that never executes, so this audits from OUTSIDE on a schedule: the newest
+# stable GitHub release must be anonymously pullable from ghcr and `latest`
+# must be that same build. A red run here IS the alert — the same idiom as
+# supply-chain.yml and providers-live.yml. Logic lives in
+# scripts/audit-release-images.mjs so the decision table is unit-tested.
+on:
+  schedule:
+    - cron: "43 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A newer scheduled audit supersedes a stuck older one.
+concurrency:
+  group: release-image-audit
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Compare the newest stable release against ghcr
+        env:
+          # Only for listing releases without rate-limit flakes; the ghcr
+          # probes are deliberately anonymous — the self-hoster pull path.
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/audit-release-images.mjs

--- a/scripts/__tests__/audit-release-images.test.ts
+++ b/scripts/__tests__/audit-release-images.test.ts
@@ -4,6 +4,7 @@ import {
   IMAGES,
   auditRelease,
   fetchAuditedRelease,
+  fetchDigest,
   pickAuditedRelease,
   // @ts-expect-error — plain .mjs script, no type declarations by design.
 } from "../audit-release-images.mjs";
@@ -194,5 +195,76 @@ describe("auditRelease", () => {
       digests: {},
     });
     expect(verdict.status).toBe("skip");
+  });
+});
+
+describe("fetchDigest", () => {
+  // The probe is deliberately anonymous — the self-hoster pull path — so the
+  // token exchange carries no credentials and a private package reads as
+  // "not pullable", not as an auth problem to work around.
+  const ghcr = (handlers: {
+    token?: () => Response;
+    manifest?: (init?: RequestInit) => Response;
+  }) => {
+    const requests: string[] = [];
+    const fetchImpl = async (url: string, init?: RequestInit) => {
+      requests.push(url);
+      if (url.startsWith("https://ghcr.io/token")) {
+        return handlers.token?.() ?? Response.json({ token: "anon-token" });
+      }
+      return handlers.manifest?.(init) ?? new Response(null, { status: 404 });
+    };
+    return { requests, fetchImpl };
+  };
+
+  it("requests a pull token and HEADs the manifest with it", async () => {
+    let manifestInit: RequestInit | undefined;
+    const { requests, fetchImpl } = ghcr({
+      manifest: (init) => {
+        manifestInit = init;
+        return new Response(null, {
+          status: 200,
+          headers: { "docker-content-digest": "sha256:abc" },
+        });
+      },
+    });
+
+    const result = await fetchDigest({
+      image: "lobu-app",
+      tag: "14.4.1",
+      fetchImpl,
+    });
+
+    expect(result).toBe("sha256:abc");
+    expect(requests).toEqual([
+      "https://ghcr.io/token?scope=repository:lobu-ai/lobu-app:pull",
+      "https://ghcr.io/v2/lobu-ai/lobu-app/manifests/14.4.1",
+    ]);
+    expect(manifestInit?.method).toBe("HEAD");
+    const headers = new Headers(manifestInit?.headers);
+    expect(headers.get("authorization")).toBe("Bearer anon-token");
+    // Without the index/list Accept types the registry answers 404 for
+    // multi-arch images even though the tag exists.
+    expect(headers.get("accept")).toContain(
+      "application/vnd.oci.image.index.v1+json"
+    );
+  });
+
+  it("returns null for a missing manifest — the audit's failure signal", async () => {
+    const { fetchImpl } = ghcr({});
+    expect(
+      await fetchDigest({ image: "lobu-app", tag: "99.99.99", fetchImpl })
+    ).toBeNull();
+  });
+
+  it("returns null when the token exchange itself fails", async () => {
+    // A private package rejects the anonymous token exchange; that must read
+    // as "not pullable", not crash the audit before it can report.
+    const { fetchImpl } = ghcr({
+      token: () => new Response(null, { status: 403 }),
+    });
+    expect(
+      await fetchDigest({ image: "lobu-app", tag: "14.4.1", fetchImpl })
+    ).toBeNull();
   });
 });

--- a/scripts/__tests__/audit-release-images.test.ts
+++ b/scripts/__tests__/audit-release-images.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "bun:test";
+import {
+  GRACE_MINUTES,
+  IMAGES,
+  auditRelease,
+  fetchAuditedRelease,
+  pickAuditedRelease,
+  // @ts-expect-error — plain .mjs script, no type declarations by design.
+} from "../audit-release-images.mjs";
+
+/**
+ * The audit exists because a release build evicted from its concurrency queue
+ * fails NOTHING — lobu-v14.4.0 published no image for hours with every
+ * workflow green. These pin the decision table: what counts as the audited
+ * release, when to hold off, and which registry states are the incident.
+ */
+
+const digest = (n: number) => `sha256:${String(n).repeat(8)}`;
+const allImages = (semver: string | null, latest: string | null) =>
+  Object.fromEntries(IMAGES.map((image) => [image, { semver, latest }]));
+
+describe("pickAuditedRelease", () => {
+  it("picks the newest stable lobu release, skipping the shared feed's noise", () => {
+    // The release feed interleaves mac releases and prereleases; none of
+    // those move `latest`, so none of them is what ghcr must serve.
+    expect(
+      pickAuditedRelease([
+        {
+          tag_name: "owletto-mac-v2.1.0",
+          published_at: "2026-07-28T15:00:00Z",
+        },
+        {
+          tag_name: "lobu-v15.0.0-beta.1",
+          published_at: "2026-07-28T14:00:00Z",
+        },
+        {
+          tag_name: "lobu-v14.5.0",
+          prerelease: true,
+          published_at: "2026-07-28T13:00:00Z",
+        },
+        {
+          tag_name: "lobu-v14.4.1",
+          draft: true,
+          published_at: "2026-07-28T12:00:00Z",
+        },
+        { tag_name: "lobu-v14.4.0", published_at: "2026-07-28T11:00:00Z" },
+      ]),
+    ).toEqual({ version: "14.4.0", publishedAt: "2026-07-28T11:00:00Z" });
+  });
+
+  it("returns null when no stable lobu release exists", () => {
+    expect(pickAuditedRelease([])).toBeNull();
+    expect(
+      pickAuditedRelease([
+        {
+          tag_name: "owletto-mac-v2.1.0",
+          published_at: "2026-07-28T15:00:00Z",
+        },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("fetchAuditedRelease", () => {
+  it("continues past a full page of unrelated releases", async () => {
+    const pages = [
+      Array.from({ length: 100 }, (_, index) => ({
+        tag_name: `owletto-mac-v2.${index}.0`,
+        published_at: "2026-07-28T15:00:00Z",
+      })),
+      [
+        {
+          tag_name: "lobu-v14.4.0",
+          published_at: "2026-07-28T11:00:00Z",
+        },
+      ],
+    ];
+    const requests: string[] = [];
+
+    const release = await fetchAuditedRelease({
+      repo: "lobu-ai/lobu",
+      token: "test-token",
+      fetchImpl: async (url: string | URL | Request, init?: RequestInit) => {
+        requests.push(String(url));
+        expect(new Headers(init?.headers).get("authorization")).toBe(
+          "Bearer test-token",
+        );
+        return Response.json(pages[requests.length - 1]);
+      },
+    });
+
+    expect(release).toEqual({
+      version: "14.4.0",
+      publishedAt: "2026-07-28T11:00:00Z",
+    });
+    expect(requests).toEqual([
+      "https://api.github.com/repos/lobu-ai/lobu/releases?per_page=100&page=1",
+      "https://api.github.com/repos/lobu-ai/lobu/releases?per_page=100&page=2",
+    ]);
+  });
+
+  it("returns null after exhausting the release feed", async () => {
+    const release = await fetchAuditedRelease({
+      repo: "lobu-ai/lobu",
+      fetchImpl: async () => Response.json([]),
+    });
+
+    expect(release).toBeNull();
+  });
+
+  it("fails closed when GitHub cannot list releases", async () => {
+    expect(
+      fetchAuditedRelease({
+        repo: "lobu-ai/lobu",
+        fetchImpl: async () => new Response(null, { status: 503 }),
+      }),
+    ).rejects.toThrow("listing releases failed: HTTP 503");
+  });
+});
+
+describe("auditRelease", () => {
+  const release = { version: "14.4.0", publishedAt: "2026-07-28T12:00:00Z" };
+  const wellAfter = new Date("2026-07-28T14:00:00Z");
+
+  it("skips while the release build may legitimately still be running", () => {
+    // One minute inside the grace period: flagging here would page on every
+    // normal release, which is how alerts get muted and then missed.
+    const justUnder = new Date(
+      new Date(release.publishedAt).getTime() + (GRACE_MINUTES - 1) * 60000,
+    );
+    const verdict = auditRelease({
+      release,
+      now: justUnder,
+      digests: allImages(null, null),
+    });
+    expect(verdict.status).toBe("skip");
+  });
+
+  it("passes when every image serves the version and latest matches it", () => {
+    const verdict = auditRelease({
+      release,
+      now: wellAfter,
+      digests: allImages(digest(1), digest(1)),
+    });
+    expect(verdict).toEqual({ status: "ok", problems: [] });
+  });
+
+  it("fails when the version tag never appeared — the 14.4.0 eviction", () => {
+    const verdict = auditRelease({
+      release,
+      now: wellAfter,
+      digests: allImages(null, digest(1)),
+    });
+    expect(verdict.status).toBe("fail");
+    expect(verdict.problems).toHaveLength(IMAGES.length);
+    expect(verdict.problems[0]).toContain("14.4.0");
+  });
+
+  it("fails when latest was left behind on an older build", () => {
+    // The user-facing half of the incident: `docker pull …:latest` kept
+    // resolving to a pre-release image even after the release existed.
+    const verdict = auditRelease({
+      release,
+      now: wellAfter,
+      digests: allImages(digest(1), digest(2)),
+    });
+    expect(verdict.status).toBe("fail");
+    expect(verdict.problems[0]).toContain("left on an older image");
+  });
+
+  it("fails when a single sibling image is missing", () => {
+    // The chart applies ONE tag to app, worker, and embeddings; a partial
+    // publish rolls prod onto a tag whose sibling does not exist.
+    const digests = allImages(digest(1), digest(1));
+    digests["lobu-worker"] = { semver: null, latest: digest(1) };
+    const verdict = auditRelease({ release, now: wellAfter, digests });
+    expect(verdict.status).toBe("fail");
+    expect(verdict.problems).toHaveLength(1);
+    expect(verdict.problems[0]).toContain("lobu-worker");
+  });
+
+  it("treats missing digest data as a failure, not a pass", () => {
+    // An empty digests map must read as "nothing pullable", never as "ok" —
+    // otherwise a broken probe silently disables the audit.
+    const verdict = auditRelease({ release, now: wellAfter, digests: {} });
+    expect(verdict.status).toBe("fail");
+    expect(verdict.problems).toHaveLength(IMAGES.length);
+  });
+
+  it("skips when there is no stable release to audit", () => {
+    const verdict = auditRelease({
+      release: null,
+      now: wellAfter,
+      digests: {},
+    });
+    expect(verdict.status).toBe("skip");
+  });
+});

--- a/scripts/__tests__/audit-release-images.test.ts
+++ b/scripts/__tests__/audit-release-images.test.ts
@@ -44,7 +44,7 @@ describe("pickAuditedRelease", () => {
           published_at: "2026-07-28T12:00:00Z",
         },
         { tag_name: "lobu-v14.4.0", published_at: "2026-07-28T11:00:00Z" },
-      ]),
+      ])
     ).toEqual({ version: "14.4.0", publishedAt: "2026-07-28T11:00:00Z" });
   });
 
@@ -56,7 +56,7 @@ describe("pickAuditedRelease", () => {
           tag_name: "owletto-mac-v2.1.0",
           published_at: "2026-07-28T15:00:00Z",
         },
-      ]),
+      ])
     ).toBeNull();
   });
 });
@@ -83,7 +83,7 @@ describe("fetchAuditedRelease", () => {
       fetchImpl: async (url: string | URL | Request, init?: RequestInit) => {
         requests.push(String(url));
         expect(new Headers(init?.headers).get("authorization")).toBe(
-          "Bearer test-token",
+          "Bearer test-token"
         );
         return Response.json(pages[requests.length - 1]);
       },
@@ -113,7 +113,7 @@ describe("fetchAuditedRelease", () => {
       fetchAuditedRelease({
         repo: "lobu-ai/lobu",
         fetchImpl: async () => new Response(null, { status: 503 }),
-      }),
+      })
     ).rejects.toThrow("listing releases failed: HTTP 503");
   });
 });
@@ -126,7 +126,7 @@ describe("auditRelease", () => {
     // One minute inside the grace period: flagging here would page on every
     // normal release, which is how alerts get muted and then missed.
     const justUnder = new Date(
-      new Date(release.publishedAt).getTime() + (GRACE_MINUTES - 1) * 60000,
+      new Date(release.publishedAt).getTime() + (GRACE_MINUTES - 1) * 60000
     );
     const verdict = auditRelease({
       release,

--- a/scripts/audit-release-images.mjs
+++ b/scripts/audit-release-images.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * Audit that the newest stable lobu release actually exists in ghcr.
+ *
+ * A release that publishes no image is invisible from inside the pipeline: on
+ * 2026-07-28 the lobu-v14.4.0 build-images run was evicted from its
+ * concurrency queue before it started, so no job anywhere failed — `14.4.0`
+ * simply never appeared in ghcr and `latest` stayed on a pre-release build
+ * for hours. No step inside build-images can catch a run that never executes,
+ * so this compares intent (the newest stable GitHub release) against reality
+ * (what ghcr serves) from the outside, on a schedule.
+ *
+ * Probes ghcr ANONYMOUSLY on purpose: that is the exact path a self-hoster's
+ * `docker pull` takes, so the audit also fails if a package is accidentally
+ * flipped private — a breakage no authenticated check would see.
+ *
+ * Lives here rather than inline in the workflow so the decision table is
+ * unit-tested (scripts/__tests__/audit-release-images.test.ts); the network
+ * fetches stay in the thin CLI below.
+ */
+
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const LOBU_TAG_PREFIX = "lobu-v";
+const RELEASES_PER_PAGE = 100;
+export const IMAGES = ["lobu-app", "lobu-worker", "lobu-embeddings"];
+
+/**
+ * Builds finish in ~10-25 minutes; the grace period only delays detection, so
+ * it errs long to never flag a release whose build is legitimately still
+ * running or queued.
+ */
+export const GRACE_MINUTES = 45;
+
+/**
+ * Pick the release whose images ghcr must serve: the newest non-draft,
+ * non-prerelease lobu-v* release. Mirrors derive-image-tags.mjs: `latest`
+ * moves only for releases that are stable by BOTH GitHub's flag and the
+ * version string, so anything else is not audited against `latest`.
+ *
+ * @param {Array<{tag_name?: string, draft?: boolean, prerelease?: boolean, published_at?: string}>} releases
+ *   newest-first, as the GitHub API returns them.
+ * @returns {{version: string, publishedAt: string} | null}
+ */
+export function pickAuditedRelease(releases) {
+  for (const release of releases ?? []) {
+    const tag = release.tag_name ?? "";
+    if (!tag.startsWith(LOBU_TAG_PREFIX)) continue;
+    if (release.draft || release.prerelease) continue;
+    const version = tag.slice(LOBU_TAG_PREFIX.length);
+    if (version.includes("-")) continue;
+    if (!release.published_at) continue;
+    return { version, publishedAt: release.published_at };
+  }
+  return null;
+}
+
+/**
+ * Fetch release pages until the newest stable Lobu release is found.
+ *
+ * This repository also publishes Owletto releases, so the first API page is
+ * not guaranteed to contain a Lobu release.
+ */
+export async function fetchAuditedRelease({ repo, token, fetchImpl = fetch }) {
+  for (let page = 1; ; page += 1) {
+    const response = await fetchImpl(
+      `https://api.github.com/repos/${repo}/releases?per_page=${RELEASES_PER_PAGE}&page=${page}`,
+      {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`listing releases failed: HTTP ${response.status}`);
+    }
+
+    const releases = await response.json();
+    const release = pickAuditedRelease(releases);
+    if (release) return release;
+    if (releases.length < RELEASES_PER_PAGE) return null;
+  }
+}
+
+/**
+ * The decision table, pure so it is testable: given the audited release and
+ * the digests ghcr returned (null = manifest missing/unreadable), decide
+ * skip/ok/fail.
+ *
+ * `latest` must carry the SAME digest as the version tag: both are pushed by
+ * one build, so a mismatch means `latest` was left behind on an older build —
+ * the exact symptom the 14.4.0 eviction produced.
+ *
+ * @param {{
+ *   release: {version: string, publishedAt: string} | null,
+ *   now: Date,
+ *   digests: Record<string, {semver: string|null, latest: string|null}>,
+ * }} input
+ * @returns {{status: "skip"|"ok"|"fail", problems: string[], reason?: string}}
+ */
+export function auditRelease({ release, now, digests }) {
+  if (!release) {
+    return { status: "skip", problems: [], reason: "no stable lobu release" };
+  }
+  const ageMinutes =
+    (now.getTime() - new Date(release.publishedAt).getTime()) / 60000;
+  if (ageMinutes < GRACE_MINUTES) {
+    return {
+      status: "skip",
+      problems: [],
+      reason: `release is ${Math.round(ageMinutes)}min old; its build may still be running (grace ${GRACE_MINUTES}min)`,
+    };
+  }
+
+  const problems = [];
+  for (const image of IMAGES) {
+    const { semver = null, latest = null } = digests[image] ?? {};
+    if (!semver) {
+      problems.push(
+        `${image}: tag ${release.version} is not anonymously pullable from ghcr — the release build never published it, or the package went private`,
+      );
+      continue;
+    }
+    if (!latest) {
+      problems.push(
+        `${image}: tag latest is not anonymously pullable from ghcr`,
+      );
+    } else if (latest !== semver) {
+      problems.push(
+        `${image}: latest (${latest}) is not the ${release.version} build (${semver}) — latest was left on an older image`,
+      );
+    }
+  }
+  return { status: problems.length ? "fail" : "ok", problems };
+}
+
+/** True when this file was run directly rather than imported. */
+function isMainModule() {
+  try {
+    return (
+      realpathSync(fileURLToPath(import.meta.url)) ===
+      realpathSync(process.argv[1])
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Anonymous manifest digest for one tag, or null when it is not pullable. */
+async function fetchDigest(image, tag) {
+  const scope = `repository:lobu-ai/${image}:pull`;
+  const tokenRes = await fetch(`https://ghcr.io/token?scope=${scope}`);
+  if (!tokenRes.ok) return null;
+  const { token } = await tokenRes.json();
+  const res = await fetch(
+    `https://ghcr.io/v2/lobu-ai/${image}/manifests/${tag}`,
+    {
+      method: "HEAD",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: [
+          "application/vnd.oci.image.index.v1+json",
+          "application/vnd.docker.distribution.manifest.list.v2+json",
+          "application/vnd.docker.distribution.manifest.v2+json",
+        ].join(","),
+      },
+    },
+  );
+  if (!res.ok) return null;
+  return res.headers.get("docker-content-digest");
+}
+
+if (process.argv[1] && isMainModule()) {
+  const repo = process.env.GITHUB_REPOSITORY ?? "lobu-ai/lobu";
+  let release;
+  try {
+    release = await fetchAuditedRelease({
+      repo,
+      token: process.env.GH_TOKEN,
+    });
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  }
+
+  const digests = {};
+  if (release) {
+    for (const image of IMAGES) {
+      digests[image] = {
+        semver: await fetchDigest(image, release.version),
+        latest: await fetchDigest(image, "latest"),
+      };
+    }
+  }
+
+  const verdict = auditRelease({ release, now: new Date(), digests });
+  if (verdict.status === "skip") {
+    console.log(`Skipping: ${verdict.reason}`);
+    process.exit(0);
+  }
+  if (verdict.status === "ok") {
+    console.log(
+      `ghcr serves ${release.version} (and latest matches) for: ${IMAGES.join(", ")}`,
+    );
+    process.exit(0);
+  }
+  for (const problem of verdict.problems) {
+    console.error(`::error::${problem}`);
+  }
+  process.exit(1);
+}

--- a/scripts/audit-release-images.mjs
+++ b/scripts/audit-release-images.mjs
@@ -146,12 +146,12 @@ function isMainModule() {
 }
 
 /** Anonymous manifest digest for one tag, or null when it is not pullable. */
-async function fetchDigest(image, tag) {
+export async function fetchDigest({ image, tag, fetchImpl = fetch }) {
   const scope = `repository:lobu-ai/${image}:pull`;
-  const tokenRes = await fetch(`https://ghcr.io/token?scope=${scope}`);
+  const tokenRes = await fetchImpl(`https://ghcr.io/token?scope=${scope}`);
   if (!tokenRes.ok) return null;
   const { token } = await tokenRes.json();
-  const res = await fetch(
+  const res = await fetchImpl(
     `https://ghcr.io/v2/lobu-ai/${image}/manifests/${tag}`,
     {
       method: "HEAD",
@@ -186,8 +186,8 @@ if (process.argv[1] && isMainModule()) {
   if (release) {
     for (const image of IMAGES) {
       digests[image] = {
-        semver: await fetchDigest(image, release.version),
-        latest: await fetchDigest(image, "latest"),
+        semver: await fetchDigest({ image, tag: release.version }),
+        latest: await fetchDigest({ image, tag: "latest" }),
       };
     }
   }

--- a/scripts/audit-release-images.mjs
+++ b/scripts/audit-release-images.mjs
@@ -68,7 +68,7 @@ export async function fetchAuditedRelease({ repo, token, fetchImpl = fetch }) {
       `https://api.github.com/repos/${repo}/releases?per_page=${RELEASES_PER_PAGE}&page=${page}`,
       {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
-      },
+      }
     );
     if (!response.ok) {
       throw new Error(`listing releases failed: HTTP ${response.status}`);
@@ -116,17 +116,17 @@ export function auditRelease({ release, now, digests }) {
     const { semver = null, latest = null } = digests[image] ?? {};
     if (!semver) {
       problems.push(
-        `${image}: tag ${release.version} is not anonymously pullable from ghcr — the release build never published it, or the package went private`,
+        `${image}: tag ${release.version} is not anonymously pullable from ghcr — the release build never published it, or the package went private`
       );
       continue;
     }
     if (!latest) {
       problems.push(
-        `${image}: tag latest is not anonymously pullable from ghcr`,
+        `${image}: tag latest is not anonymously pullable from ghcr`
       );
     } else if (latest !== semver) {
       problems.push(
-        `${image}: latest (${latest}) is not the ${release.version} build (${semver}) — latest was left on an older image`,
+        `${image}: latest (${latest}) is not the ${release.version} build (${semver}) — latest was left on an older image`
       );
     }
   }
@@ -163,7 +163,7 @@ async function fetchDigest(image, tag) {
           "application/vnd.docker.distribution.manifest.v2+json",
         ].join(","),
       },
-    },
+    }
   );
   if (!res.ok) return null;
   return res.headers.get("docker-content-digest");
@@ -199,7 +199,7 @@ if (process.argv[1] && isMainModule()) {
   }
   if (verdict.status === "ok") {
     console.log(
-      `ghcr serves ${release.version} (and latest matches) for: ${IMAGES.join(", ")}`,
+      `ghcr serves ${release.version} (and latest matches) for: ${IMAGES.join(", ")}`
     );
     process.exit(0);
   }


### PR DESCRIPTION
## What

A scheduled (hourly + `workflow_dispatch`) audit that the newest **stable** GitHub release is actually served by ghcr: the version tag must be anonymously pullable for all three images (`lobu-app`, `lobu-worker`, `lobu-embeddings`) and `latest` must carry the same digest as that version.

## Why

A release that publishes no image is invisible from inside the pipeline. On 2026-07-28 the `lobu-v14.4.0` build-images run was evicted from its concurrency queue before it started — no job failed anywhere, `14.4.0` never appeared in ghcr, and `latest` stayed on a pre-release build for hours (#2183 reporter pulled it). #2250 prevents that specific eviction, but nothing *detects* the class (build failure on the tag ref, registry push failure, another eviction variant). No step inside `build-images` can catch a run that never executes, so this audits from outside: intent (GitHub releases) vs reality (ghcr). A red run is the alert — the same idiom as `supply-chain.yml` / `providers-live.yml`.

Probes ghcr **anonymously** on purpose: that is the self-hoster `docker pull` path, so an accidental flip of a package to private also fails the audit.

## Evidence (red → green)

Decision table unit-tested (12 cases) and mutation-tested — each mutant fails the suite:

```
MUTANT-1 (ignore latest mismatch): 8 pass 1 fail
MUTANT-2 (no grace period):        8 pass 1 fail
MUTANT-3 (audit prereleases):      8 pass 1 fail
MUTANT   (no pagination):         11 pass 1 fail
RESTORED:                         12 pass 0 fail
```

Live against the real registry, all three CLI paths:

```
# grace path (release 41min old):
Skipping: release is 41min old; its build may still be running (grace 45min)  EXIT=0
# ok path (after grace):
ghcr serves 14.4.1 (and latest matches) for: lobu-app, lobu-worker, lobu-embeddings  EXIT=0
# fail path (nonexistent image name):
::error::…: tag 14.4.1 is not anonymously pullable from ghcr — the release build never published it, or the package went private  EXIT=1
```

## Notes

- Decision logic lives in `scripts/audit-release-images.mjs` (pure functions), wired into CI next to the derive-image-tags tests; the workflow is a thin caller.
- 45-minute grace period so a release whose build is legitimately still running never pages.
- Release listing paginates past feed noise (mac releases, prereleases) and fails closed on API errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->