### PR TITLE
fix(server): reply with an unlinked notice on non-Slack platforms instead of dropping

### DIFF
--- a/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
+++ b/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
@@ -1,10 +1,8 @@
 /**
- * `workspaceUnlinkedNotice` — the reply a tenant's own OAuth-installed Slack bot
- * sends in a channel that isn't bound to an agent yet. It must be actionable:
- * list the org's agents, deep-link each to a prefilled Behavior event trigger,
- * and give the CLI `/lobu link` compatibility path. It must
- * degrade gracefully when the public origin isn't configured or the org has no
- * agents, and never turn into a dead drop.
+ * `workspaceUnlinkedNotice` — the reply from a tenant connection with no owning
+ * agent when a chat is not bound to a Behavior. Slack gets agent deep links and
+ * `/lobu link`; other platforms get generic dashboard and `/link` instructions.
+ * The notice must remain available when the Slack agent lookup fails.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -38,9 +36,15 @@ describe("workspaceUnlinkedNotice", () => {
 		setOrigin(savedOrigin);
 	});
 
-	it("returns null for non-slack platforms", async () => {
+	it("returns a generic dashboard+CLI notice for Telegram (#2230)", async () => {
 		const org = await createTestOrganization();
-		expect(await workspaceUnlinkedNotice("telegram", org.id)).toBeNull();
+		const text = await workspaceUnlinkedNotice("telegram", org.id);
+		expect(text).toContain("isn't linked");
+		// The platform's own command spelling, not Slack's `/lobu link` wrapper…
+		expect(text).toContain("/link <code>");
+		expect(text).not.toContain("/lobu link");
+		// …and no Slack workspace/team deep links or mrkdwn inline links.
+		expect(text).not.toContain("<http");
 	});
 
 	it('deep-links each agent to the Behaviors "new" step with the channel prefilled', async () => {
@@ -57,14 +61,12 @@ describe("workspaceUnlinkedNotice", () => {
 			name: "Builder",
 		});
 
-		const notice = await workspaceUnlinkedNotice("slack", org.id, {
+		const text = await workspaceUnlinkedNotice("slack", org.id, {
 			channelId: "slack:C0ABC123",
 			teamId: "T0TEAM",
 			channelName: "general",
 			connectionId: "42",
 		});
-		expect(notice).not.toBeNull();
-		const text = notice as string;
 
 		// getConfiguredPublicOrigin() returns the URL *origin* (scheme+host), so the
 		// /lobu gateway mount is dropped — the SPA lives at the bare origin. The link
@@ -95,11 +97,11 @@ describe("workspaceUnlinkedNotice", () => {
 			name: "A&B <Co>",
 		});
 
-		const text = (await workspaceUnlinkedNotice("slack", org.id, {
+		const text = await workspaceUnlinkedNotice("slack", org.id, {
 			channelId: "slack:C0ABC123",
 			teamId: "T0TEAM",
 			channelName: "general",
-		})) as string;
+		});
 
 		// The label inside `<url|label>` is entity-escaped; the raw name never
 		// reaches Slack, so a `>` can't prematurely close the inline link.
@@ -116,7 +118,7 @@ describe("workspaceUnlinkedNotice", () => {
 			name: "Planner",
 		});
 
-		const text = (await workspaceUnlinkedNotice("slack", org.id)) as string;
+		const text = await workspaceUnlinkedNotice("slack", org.id);
 		expect(text).toContain("https://app.lobu.ai/acme/agents/planner/behaviors");
 		expect(text).not.toContain("/behaviors/new?");
 	});
@@ -130,7 +132,7 @@ describe("workspaceUnlinkedNotice", () => {
 			name: "Planner",
 		});
 
-		const text = (await workspaceUnlinkedNotice("slack", org.id)) as string;
+		const text = await workspaceUnlinkedNotice("slack", org.id);
 		expect(text).toContain("Planner");
 		expect(text).not.toContain("/agents/planner/behaviors");
 		expect(text).toContain("lobu run"); // CLI path still present
@@ -140,7 +142,7 @@ describe("workspaceUnlinkedNotice", () => {
 		setOrigin("https://app.lobu.ai");
 		const org = await createTestOrganization();
 
-		const text = (await workspaceUnlinkedNotice("slack", org.id)) as string;
+		const text = await workspaceUnlinkedNotice("slack", org.id);
 		expect(text).toContain("lobu run");
 		expect(text).toContain("/lobu link");
 		// No agent-list section.
@@ -149,11 +151,10 @@ describe("workspaceUnlinkedNotice", () => {
 
 	it("never throws / dead-drops for an unknown org (returns the CLI-only notice)", async () => {
 		setOrigin("https://app.lobu.ai");
-		const text = (await workspaceUnlinkedNotice(
+		const text = await workspaceUnlinkedNotice(
 			"slack",
 			"org_does_not_exist",
-		)) as string;
-		expect(text).not.toBeNull();
+		);
 		expect(text).toContain("/lobu link");
 	});
 });

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -564,8 +564,10 @@ describe("MessageHandlerBridge.handleMessage — thread backfill", () => {
   });
 });
 
-describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", () => {
+describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", () => {
   function makePreviewHarness(opts: {
+    /** Chat platform for the connection (default "slack"). */
+    platform?: string;
     linkedBehavior?: {
       agentId: string;
       organizationId?: string;
@@ -590,16 +592,17 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
   }) {
     const state = new InMemoryStateAdapter();
     const conversationState = new ConversationStateStore(state);
+    const platform = opts.platform ?? "slack";
     const connection: PlatformConnection = {
       id: CONN_ID,
-      platform: "slack",
+      platform,
       // Default to the template agent; tests for an OAuth-installed workspace
       // connection (no owning agent) pass `agentId: undefined` explicitly.
       agentId: "agentId" in opts ? opts.agentId : TEMPLATE_AGENT_ID,
       // The hosted preview connection lives in its OWN org; linked Behaviors may
       // live in OTHER orgs (see the cross-org test below).
       organizationId: "org-connection",
-      config: { platform: "slack" } as any,
+      config: { platform } as any,
       settings: {
         allowGroups: true,
         previewMode: opts.previewMode ?? true,
@@ -941,9 +944,9 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
 
   test("OAuth workspace connection (no agent, not preview): unlinked → link notice, no agent run", async () => {
     // A tenant's OAuth-installed bot has no owning agent and metadata.teamId.
-    // An unlinked non-command message must get a one-line "link your agent"
-    // notice instead of being silently dropped (the install dead-end we reverted
-    // for), and must NOT enqueue a worker turn against a non-existent agent.
+    // An unlinked non-command message must get a "link your agent" notice instead
+    // of being silently dropped, and must NOT enqueue a worker turn against a
+    // non-existent agent.
     const { bridge, enqueueMessage } = makePreviewHarness({
       linkedBehavior: null,
       previewMode: false,
@@ -956,6 +959,157 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
 
     expect(thread.post).toHaveBeenCalledTimes(1);
     expect(String(thread.post.mock.calls[0]?.[0])).toContain("/lobu link");
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("telegram unrouted message → generic link notice, no agent run (#2230)", async () => {
+    // Same dead end as the Slack OAuth test above, but on a non-Slack platform:
+    // no owning agent, no channel Behavior. Slack replies with a link notice;
+    // every other platform used to log a warn and drop the message silently.
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      platform: "telegram",
+      linkedBehavior: null,
+      previewMode: false,
+      agentId: undefined,
+      metadata: { botUsername: "testbot" },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ text: "hello, anyone there?" }),
+      "dm"
+    );
+
+    expect(enqueueMessage).not.toHaveBeenCalled();
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    const posted = String(thread.post.mock.calls[0]?.[0]);
+    expect(posted).toContain("isn't linked");
+    // Platform-native command spelling — not Slack's `/lobu link` wrapper.
+    expect(posted).toContain("/link <code>");
+    expect(posted).not.toContain("/lobu link");
+  });
+
+  test("telegram unrouted button click → generic link notice, no turn (#2230)", async () => {
+    // The interaction drop site has the same shape as the message one.
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      platform: "telegram",
+      linkedBehavior: null,
+      previewMode: false,
+      agentId: undefined,
+      metadata: { botUsername: "testbot" },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.ingestClick({
+      userId: "U_USER",
+      channelId: CHANNEL_ID,
+      conversationId: THREAD_ID,
+      value: "Approve",
+      thread,
+    });
+
+    expect(enqueueMessage).not.toHaveBeenCalled();
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    expect(String(thread.post.mock.calls[0]?.[0])).toContain("/link <code>");
+  });
+
+  test("slack OAuth workspace unrouted click → link notice (interaction parity)", async () => {
+    // Slack itself also used to drop unrouted interactions silently — only the
+    // message path had the notice. Both sites now share one helper.
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      linkedBehavior: null,
+      previewMode: false,
+      agentId: undefined,
+      metadata: { teamId: "T_WS", botUserId: "U_BOT" },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.ingestClick({
+      userId: "U_USER",
+      channelId: CHANNEL_ID,
+      conversationId: THREAD_ID,
+      value: "Approve",
+      thread,
+    });
+
+    expect(enqueueMessage).not.toHaveBeenCalled();
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    expect(String(thread.post.mock.calls[0]?.[0])).toContain("/lobu link");
+  });
+
+  test("`/link <code>` in an unrouted telegram chat reaches the dispatcher, not the notice (#2230)", async () => {
+    // The notice tells the user to paste `/link <code>` into this same chat.
+    // On Slack that arrives as a native slash command (its own ingress path);
+    // on every other platform it arrives as plain message text — so it must
+    // dispatch from the unrouted dead end instead of being dropped with it.
+    const tryHandleSlashText = mock(async () => true);
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      platform: "telegram",
+      linkedBehavior: null,
+      previewMode: false,
+      agentId: undefined,
+      metadata: { botUsername: "testbot" },
+      commandDispatcher: {
+        tryHandleSlashText,
+        tryHandle: mock(async () => false),
+      },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ text: "/link crm-ABC123" }),
+      "dm"
+    );
+
+    expect(tryHandleSlashText).toHaveBeenCalledTimes(1);
+    expect(tryHandleSlashText.mock.calls[0]?.[0]).toBe("/link crm-ABC123");
+    expect(thread.post).not.toHaveBeenCalled();
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("telegram linked mention-only channel: ordinary chatter gets no notice spam", async () => {
+    // Mirror of the Slack loop-prevention semantics: a channel that HAS a
+    // Behavior subscription but whose trigger filters rejected this message
+    // must stay silent — the notice is only for genuinely unlinked chats.
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      platform: "telegram",
+      previewMode: false,
+      agentId: undefined,
+      metadata: { botUsername: "testbot" },
+      behaviors: [
+        {
+          behaviorId: 74,
+          organizationId: "org-connection",
+          agentId: "tg-agent",
+          deviceWorkerId: null,
+          agentKind: null,
+          model: null,
+          instructions: "Only respond to mentions.",
+          trigger: {
+            kind: "event",
+            connector_key: "telegram",
+            connection_id: 42,
+            event_types: ["message.created"],
+            match: { channel_id: CHANNEL_ID, mention_only: true },
+            execution: "turn",
+            active_run: "queue",
+            output: "reply_to_source",
+            skip_if_unchanged: false,
+          },
+        },
+      ],
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ text: "ordinary chatter", isMention: false }),
+      "subscribed"
+    );
+
+    expect(thread.post).not.toHaveBeenCalled();
     expect(enqueueMessage).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -1069,6 +1069,37 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
     expect(enqueueMessage).not.toHaveBeenCalled();
   });
 
+  test("`@bot /link <code>` in an unrouted chat dispatches on mention-stripped text", async () => {
+    // Addressing the bot by mention is the normal way to reach it in a
+    // mention-gated group chat, and the slash regex requires a leading `/` — so
+    // the dead-end dispatch must run on the same mention-stripped text every
+    // other command call site uses, not the raw message.
+    const tryHandleSlashText = mock(async () => true);
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      platform: "telegram",
+      linkedBehavior: null,
+      previewMode: false,
+      agentId: undefined,
+      metadata: { botUsername: "testbot", botUserId: "U_BOT" },
+      commandDispatcher: {
+        tryHandleSlashText,
+        tryHandle: mock(async () => false),
+      },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ text: "@testbot <@U_BOT> /link crm-ABC123" }),
+      "mention"
+    );
+
+    expect(tryHandleSlashText).toHaveBeenCalledTimes(1);
+    expect(tryHandleSlashText.mock.calls[0]?.[0]).toBe("/link crm-ABC123");
+    expect(thread.post).not.toHaveBeenCalled();
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
   test("telegram linked mention-only channel: ordinary chatter gets no notice spam", async () => {
     // Mirror of the Slack loop-prevention semantics: a channel that HAS a
     // Behavior subscription but whose trigger filters rejected this message

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -485,9 +485,13 @@ export class MessageHandlerBridge {
       stripped = stripped.replace(`@${botUsername}`, "").trim();
     }
     if (botUserId) {
+      // Provider-sourced metadata, so escape it before it reaches `RegExp`: a
+      // stray metacharacter would otherwise throw mid-message or over-strip.
+      // Real Slack ids (`U…`) carry none, so their stripping is unchanged.
+      const idPattern = botUserId.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
       stripped = stripped
-        .replace(new RegExp(`<@${botUserId}>`, "g"), "")
-        .replace(new RegExp(`@${botUserId}\\b`, "g"), "")
+        .replace(new RegExp(`<@${idPattern}>`, "g"), "")
+        .replace(new RegExp(`@${idPattern}\\b`, "g"), "")
         .replace(/\s+/g, " ")
         .trim();
     }

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -469,6 +469,32 @@ export class MessageHandlerBridge {
   }
 
   /**
+   * Strip the bot's own mention out of inbound text. Slack delivers raw
+   * `<@Uxxx>` tokens; the Chat SDK may strip the brackets, so we also catch the
+   * bare `@Uxxx` form. Every command-matching call site must run on the
+   * stripped text — `@mybot /link ABC123` is the normal way to address a bot in
+   * a mention-gated group chat, and the slash regex requires a leading `/`.
+   */
+  private stripBotMention(text: string): string {
+    const botMetadata = this.manager.getInstance(this.connection.id)?.connection
+      .metadata;
+    const botUsername = botMetadata?.botUsername as string | undefined;
+    const botUserId = botMetadata?.botUserId as string | undefined;
+    let stripped = text;
+    if (botUsername) {
+      stripped = stripped.replace(`@${botUsername}`, "").trim();
+    }
+    if (botUserId) {
+      stripped = stripped
+        .replace(new RegExp(`<@${botUserId}>`, "g"), "")
+        .replace(new RegExp(`@${botUserId}\\b`, "g"), "")
+        .replace(/\s+/g, " ")
+        .trim();
+    }
+    return stripped;
+  }
+
+  /**
    * Reply at a routing dead end — an inbound message/interaction resolved to
    * no channel Behavior and the connection has no owning agent — with a
    * "link this chat" notice instead of dropping silently.
@@ -738,7 +764,9 @@ export class MessageHandlerBridge {
       // dispatcher ever saw it (#2230).
       if (this.commandDispatcher) {
         const handled = await this.commandDispatcher.tryHandleSlashText(
-          typeof message.text === "string" ? message.text : "",
+          this.stripBotMention(
+            typeof message.text === "string" ? message.text : ""
+          ),
           {
             platform,
             userId,
@@ -932,22 +960,9 @@ export class MessageHandlerBridge {
       }
     }
 
-    // Remove bot mention from text. Slack delivers raw `<@Uxxx>` tokens; the
-    // Chat SDK may strip the brackets, so we also catch the bare `@Uxxx` form.
-    const botMetadata = this.manager.getInstance(this.connection.id)?.connection
-      .metadata;
-    const botUsername = botMetadata?.botUsername as string | undefined;
-    const botUserId = botMetadata?.botUserId as string | undefined;
-    if (botUsername) {
-      messageText = messageText.replace(`@${botUsername}`, "").trim();
-    }
-    if (botUserId) {
-      messageText = messageText
-        .replace(new RegExp(`<@${botUserId}>`, "g"), "")
-        .replace(new RegExp(`@${botUserId}\\b`, "g"), "")
-        .replace(/\s+/g, " ")
-        .trim();
-    }
+    // Remove bot mention from text — shared with the unrouted dead-end slash
+    // dispatch so both match commands addressed via an @-mention.
+    messageText = this.stripBotMention(messageText);
 
     // Intercept a `!`-bash message before slash dispatch. `!cmd` runs `cmd` as
     // shell in the conversation's pinned sandbox (LLM skipped); `!!cmd` runs it

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -468,6 +468,101 @@ export class MessageHandlerBridge {
     );
   }
 
+  /**
+   * Reply at a routing dead end — an inbound message/interaction resolved to
+   * no channel Behavior and the connection has no owning agent — with a
+   * "link this chat" notice instead of dropping silently.
+   *
+   * Slack keeps its original gate: only a tenant's OAuth-installed workspace
+   * bot (`metadata.teamId`) gets the deep-linked notice. Every other platform
+   * gets the generic dashboard+CLI notice (#2230). Loop safety needs no extra
+   * state: the Chat SDK never re-delivers the bot's own posts (`isMe`), and a
+   * channel with a Behavior subscription never reaches this dead end (the
+   * planner-rejection guard in `handleMessage` drops it silently first).
+   *
+   * Returns true when a notice was posted (the caller should stop).
+   */
+  private async postUnlinkedChatNotice(
+    thread: { post: (content: unknown) => Promise<unknown> },
+    channelId: string,
+    teamId: string | undefined
+  ): Promise<boolean> {
+    const platform = this.connection.platform;
+    if (!this.connection.organizationId) return false;
+
+    let noticeChannel: {
+      channelId: string;
+      teamId?: string;
+      channelName?: string;
+      connectionId?: string;
+    } = { channelId, connectionId: this.connection.id };
+
+    if (platform === "slack") {
+      // A tenant's OAuth-installed Slack workspace bot has no owning agent —
+      // routing is via tagged Behaviors created by `/lobu link`. Before the
+      // tenant links a channel, a non-command message resolves to nothing.
+      // (Slash commands like `/lobu link` take the `onSlashCommand` path and
+      // never reach here.)
+      if (!this.connection.metadata?.teamId) return false;
+      // Fall back to the connection's stored team when the raw event omits
+      // team_id, so the deep-link stays team-scoped. The connection always
+      // carries it — it's the gate above.
+      const linkTeamId = teamId ?? this.connection.metadata?.teamId;
+      // Best-effort: resolve the channel's friendly name (#general) for the
+      // notice's deep-link label. Uses this connection's own bot token via
+      // conversations.info; any failure (no token, not-in-channel, rate limit)
+      // just drops to the channel id in the UI — never blocks the notice.
+      let channelName: string | undefined;
+      if (linkTeamId) {
+        try {
+          const slackWeb = createSlackWebApi();
+          const identity = await resolveSlackBotIdentity(
+            {
+              installStore: this.services.getAppInstallationStore(),
+              secretStore: this.services.getSecretStore(),
+              slackWeb,
+            },
+            {
+              organizationId: this.connection.organizationId,
+              teamId: linkTeamId,
+              connectionId: this.connection.id,
+            }
+          );
+          if (identity?.token) {
+            const info = await slackWeb.conversationInfo(
+              identity.token,
+              stripPlatformPrefix(platform, channelId)
+            );
+            channelName = info.name ?? undefined;
+          }
+        } catch (err) {
+          logger.debug(
+            { channelId, error: String(err) },
+            "unlinked-notice: channel name lookup failed (using id)"
+          );
+        }
+      }
+      noticeChannel = {
+        channelId,
+        teamId: linkTeamId,
+        channelName,
+        connectionId: this.connection.id,
+      };
+    }
+
+    const notice = await workspaceUnlinkedNotice(
+      platform,
+      this.connection.organizationId,
+      noticeChannel
+    );
+    logger.info(
+      { platform, channelId, teamId, connectionId: this.connection.id },
+      "Unlinked chat and connection has no owning agent — replying with link notice"
+    );
+    await thread.post(notice);
+    return true;
+  }
+
   async handleMessage(
     thread: any,
     message: any,
@@ -635,74 +730,34 @@ export class MessageHandlerBridge {
         return;
       }
 
-      // A tenant's OAuth-installed Slack workspace bot has no owning agent —
-      // routing is via tagged Behaviors created by `/lobu link`. Before the
-      // tenant links a channel, a non-command message resolves to nothing. Reply with a
-      // one-line "link your agent" notice instead of silently dropping so the
-      // install never dead-ends. (Slash commands like `/lobu link` take the
-      // `onSlashCommand` path and never reach here.)
-      if (
-        !isPreview &&
-        platform === "slack" &&
-        this.connection.metadata?.teamId &&
-        this.connection.organizationId
-      ) {
-        const linkTeamId = teamId ?? this.connection.metadata?.teamId;
-        // Best-effort: resolve the channel's friendly name (#general) for the
-        // notice's deep-link label. Uses this connection's own bot token via
-        // conversations.info; any failure (no token, not-in-channel, rate limit)
-        // just drops to the channel id in the UI — never blocks the notice.
-        let channelName: string | undefined;
-        if (linkTeamId) {
-          try {
-            const slackWeb = createSlackWebApi();
-            const identity = await resolveSlackBotIdentity(
-              {
-                installStore: this.services.getAppInstallationStore(),
-                secretStore: this.services.getSecretStore(),
-                slackWeb,
-              },
-              {
-                organizationId: this.connection.organizationId,
-                teamId: linkTeamId,
-                connectionId: this.connection.id,
-              }
-            );
-            if (identity?.token) {
-              const info = await slackWeb.conversationInfo(
-                identity.token,
-                stripPlatformPrefix(platform, channelId)
-              );
-              channelName = info.name ?? undefined;
-            }
-          } catch (err) {
-            logger.debug(
-              { channelId, error: String(err) },
-              "unlinked-notice: channel name lookup failed (using id)"
-            );
-          }
-        }
-        const notice = await workspaceUnlinkedNotice(
-          platform,
-          this.connection.organizationId,
-          // Fall back to the connection's stored team when the raw message omits
-          // team_id, so the deep-link stays team-scoped. The connection always
-          // carries it — it's the gate above.
+      // An unrouted chat still has to honor commands: the unlinked notice
+      // below tells the user to paste `/link <code>` (or `/lobu link <code>`)
+      // into this same chat. Slack delivers those natively via the
+      // `onSlashCommand` ingress, but every other platform delivers them as
+      // plain message text — which used to die in this dead end before the
+      // dispatcher ever saw it (#2230).
+      if (this.commandDispatcher) {
+        const handled = await this.commandDispatcher.tryHandleSlashText(
+          typeof message.text === "string" ? message.text : "",
           {
+            platform,
+            userId,
             channelId,
-            teamId: linkTeamId,
-            channelName,
+            teamId,
+            isGroup,
+            conversationId,
             connectionId: this.connection.id,
+            organizationId: this.connection.organizationId,
+            reply: createChatReply((content) => thread.post(content)),
           }
         );
-        if (notice) {
-          logger.info(
-            { platform, channelId, teamId, connectionId: this.connection.id },
-            "Slack workspace connection: unlinked channel — replying with link notice"
-          );
-          await thread.post(notice);
-          return;
-        }
+        if (handled) return;
+      }
+      if (
+        !isPreview &&
+        (await this.postUnlinkedChatNotice(thread, channelId, teamId))
+      ) {
+        return;
       }
       logger.warn(
         { platform, channelId, teamId, connectionId: this.connection.id },
@@ -1497,6 +1552,14 @@ export class MessageHandlerBridge {
       crossOrg: isPreview,
     });
     if (!resolved) {
+      // Same dead end as the message path: reply with the unlinked notice
+      // (Slack and non-Slack alike) instead of eating the click silently.
+      if (
+        !isPreview &&
+        (await this.postUnlinkedChatNotice(thread, channelId, teamId))
+      ) {
+        return;
+      }
       logger.warn(
         { platform, channelId, teamId, connectionId: this.connection.id },
         "No channel Behavior and connection has no owning agent — dropping interaction"

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -629,16 +629,6 @@ async function listOrgAgentsForNotice(organizationId: string): Promise<{
 }
 
 /**
- * Reply for a tenant's own OAuth-installed workspace bot (a connection with a
- * `metadata.teamId` but no owning agent) when a non-command message arrives in
- * a channel that isn't bound to one of the tenant's agents yet. Unlike a
- * preview connection there are no demo agents to offer — the tenant links their
- * own agents. Lists the org's agents and, when the public origin is configured,
- * deep-links each to its Behaviors page (where a channel is added as a Listen
- * source); also gives the CLI `lobu run` / `/lobu link <code>` path. Returns
- * null for non-Slack platforms (OAuth install is Slack-only today).
- */
-/**
  * Escape the Slack mrkdwn chars that break an inline `<url|label>` link label.
  * Agent names are user-controlled; a `>`, `<`, or `&` in a name would otherwise
  * terminate/mangle the link (Slack reads `text` as mrkdwn, and `&` is the entity
@@ -652,6 +642,20 @@ function escapeMrkdwnLabel(text: string): string {
 		.replace(/>/g, "&gt;");
 }
 
+/**
+ * Reply for a tenant's own workspace bot (a connection with no owning agent)
+ * when a non-command message arrives in a chat that isn't bound to one of the
+ * tenant's agents yet. Unlike a preview connection there are no demo agents to
+ * offer — the tenant links their own agents.
+ *
+ * Slack: lists the org's agents and, when the public origin is configured,
+ * deep-links each to its Behaviors page (where a channel is added as a Listen
+ * source); also gives the CLI `lobu run` / `/lobu link <code>` path.
+ *
+ * Every other platform (Telegram, …) gets a generic dashboard+CLI notice —
+ * there is no workspace/team concept to deep-link, and dropping silently left
+ * the user with no signal at all (#2230).
+ */
 export async function workspaceUnlinkedNotice(
 	platform: string,
 	organizationId: string,
@@ -661,8 +665,20 @@ export async function workspaceUnlinkedNotice(
 		channelName?: string;
 		connectionId?: string;
 	},
-): Promise<string | null> {
-	if (platform !== "slack") return null;
+): Promise<string> {
+	// Non-Slack platforms have no workspace/team deep links, so the notice is
+	// generic: the dashboard path plus the platform's own link command.
+	// Deliberately static — no DB/origin lookups whose failure could turn the
+	// reply back into a dead drop.
+	if (platform !== "slack") {
+		return [
+			"👋 This chat isn't linked to a Lobu agent yet.",
+			"",
+			"Link it two ways:",
+			"• In the dashboard — open an agent's Behaviors page and add this chat as a Listen source.",
+			`• From the CLI — run \`lobu run\`, then paste the \`${linkCommand(platform)} <code>\` it prints here.`,
+		].join("\n");
+	}
 
 	const header =
 		"👋 Thanks for adding Lobu! This channel isn't linked to one of your agents yet.";


### PR DESCRIPTION
## Summary
- Fixes #2230 — on Telegram (and every non-Slack platform), an inbound chat message or button click that resolves to no agent (no owning agent on the connection, no channel Behavior) was logged server-side and dropped with zero reply; Slack alone got the `workspaceUnlinkedNotice()` "channel not linked" reply.
- `workspaceUnlinkedNotice()` now returns a generic dashboard+CLI notice for non-Slack platforms (no Slack workspace/team deep links, no mrkdwn; deliberately static so no lookup failure can turn the reply back into a dead drop). Slack output is unchanged.
- Both drop sites — the message path and the interaction (`ingestClick`) path — now share one `postUnlinkedChatNotice()` helper, so Slack interactions get the notice too (they previously dropped silently even on Slack).
- Same-class fix found while there: the notice tells the user to paste `/link <code>` into the chat, but on non-Slack platforms that command arrives as plain message text and used to die in the same dead end before the dispatcher ever saw it (Slack's `/lobu link` rides the native `onSlashCommand` ingress and was immune). The unrouted path now tries `tryHandleSlashText` before posting the notice.

Loop-prevention mirrors the existing Slack semantics exactly — no new state: the Chat SDK never re-delivers the bot's own posts (`isMe`), and a channel that has a Behavior subscription whose filters rejected the message never reaches the dead end (the planner-rejection guard drops it silently first; covered by a new telegram spam-guard test).

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` + `bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts` + `bun test packages/server/src/gateway/__tests__/dm-link-message-e2e.test.ts` + `cd packages/server && bunx vitest run src/__tests__/integration/preview/workspace-unlinked-notice.test.ts` (7/7, embedded PG)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval — not run; covered by the bridge unit tests above, no live Telegram bot in this environment

### Red (tests written first, on the unfixed tree)

```
$ bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
error: expect(received).toHaveBeenCalledTimes(expected)   # thread.post never called — silent drop
(fail) MessageHandlerBridge.handleMessage — Slack Preview unlinked chat > telegram unrouted message → generic link notice, no agent run (#2230) [0.36ms]
error: expect(received).toHaveBeenCalledTimes(expected)
(fail) MessageHandlerBridge.handleMessage — Slack Preview unlinked chat > telegram unrouted button click → generic link notice, no turn (#2230) [0.65ms]
error: expect(received).toHaveBeenCalledTimes(expected)
(fail) MessageHandlerBridge.handleMessage — Slack Preview unlinked chat > slack OAuth workspace unrouted click → link notice (interaction parity) [0.14ms]
error: expect(received).toHaveBeenCalledTimes(expected)   # dispatcher never reached
(fail) MessageHandlerBridge.handleMessage — Slack Preview unlinked chat > `/link <code>` in an unrouted telegram chat reaches the dispatcher, not the notice (#2230) [0.22ms]

 56 pass
 4 fail
Ran 60 tests across 1 file.
```

### Green (same tests after the fix)

```
$ bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
 60 pass
 0 fail
Ran 60 tests across 1 file.

$ cd packages/server && bunx vitest run src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
 ✓ src/__tests__/integration/preview/workspace-unlinked-notice.test.ts (7 tests) 900ms
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Notes
- The integration case `returns null for non-slack platforms` asserted the buggy behavior; it now asserts the generic notice content (platform-native `/link` spelling, no `/lobu link`, no deep links).
- `workspaceUnlinkedNotice()` no longer has a null return path, so its signature tightened from `Promise<string | null>` to `Promise<string>` and the callers' null-guards / `as string` casts are gone (`make review-fix` caught this; typecheck clean after).
- Not in scope: `resolveSlackActionReviewer` in interaction-bridge.ts also gates on `platform === "slack"`, but that is reviewer authz mapping, not a user-facing silent drop — widening it is an authz change, not this bug's class.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-appropriate unlinked-chat guidance (Slack agent links; Telegram generic “/link \<code>” via dashboard + CLI).
  * Handle `/link <code>` arriving as plain message text and route it to the proper command flow.
  * Show linking notices for unrouted interactions/buttons while keeping mention-only Telegram channels silent.
* **Bug Fixes**
  * Ensure notices still appear even when Slack details can’t be resolved, with safer Slack link label escaping.
* **Tests**
  * Expanded coverage for Slack and Telegram unlinked/routed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->