### PR TITLE
fix(docker): ship the lobu CLI in the app image

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -95,7 +95,7 @@ COPY packages/server/ packages/server/
 COPY packages/cli/ packages/cli/
 # Bundled into the CLI dist by packages/cli/scripts/build.cjs: the starter
 # skill and the embedded-DB migrations.
-COPY skills/ skills/
+COPY skills/lobu/ skills/lobu/
 COPY db/migrations db/migrations
 # Copy the private frontend submodule when present.
 COPY packages/owletto packages/owletto
@@ -125,21 +125,19 @@ RUN cd packages/server && bun run build:server
 
 # Build the CLI (#2231). It must build after build:server because
 # packages/cli/scripts/build.cjs copies the server bundles + catalog manifests
-# into the CLI dist, and @lobu/worker dist must exist for the CLI's tsc. It
-# runs *before* the owletto web build, so the CLI dist intentionally carries
-# no second copy of the SPA — the container already serves the web UI from
-# packages/owletto/dist, and `lobu run` inside the container stays headless.
-RUN cd packages/agent-worker && bunx tsc \
-    && cd ../cli && bun run build
+# into the CLI dist. It runs *before* the owletto web build, so the CLI dist
+# intentionally carries no second copy of the SPA — the container already
+# serves the web UI from packages/owletto/dist, which the bundled server finds
+# through its monorepo-relative fallback.
+RUN cd packages/cli && bun run build
 
 # Prune the embedded-Postgres runtime (~145MB platform binary) before it reaches
 # the runtime image. Prod always uses an external DATABASE_URL (postgres://), so
 # server.ts never loads embedded-postgres or the pgvector injector — both are
 # reached only via await import() on the file:// path. The builder needs them
 # for the type-check + bundle above, so we drop them only afterward. This also
-# means the in-image `lobu` CLI cannot boot an embedded database — in the
-# container every CLI workflow talks to the external DATABASE_URL, which is
-# the only supported mode here.
+# means the in-image `lobu run` cannot boot an embedded database; it must use
+# the container's external DATABASE_URL.
 RUN rm -rf node_modules/embedded-postgres node_modules/@embedded-postgres
 
 # Build frontend static assets (production only)

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -37,6 +37,10 @@ COPY packages/connector-sdk/package.json packages/connector-sdk/
 COPY packages/connectors/package.json packages/connectors/
 COPY packages/embeddings/package.json packages/embeddings/
 COPY packages/connector-worker/package.json packages/connector-worker/
+# The CLI ships in this image so self-hosters can run
+# `docker exec <container> lobu ...` (#2231). Real manifest, not a stub, so
+# bun install resolves its dependencies below.
+COPY packages/cli/package.json packages/cli/
 # server depends on @lobu/pgvector-embedded (workspace:*); its manifest must be
 # present for bun install to resolve the workspace member and for tsc to find
 # its types. Prod never loads it at runtime (external Postgres) — it's pruned
@@ -48,11 +52,16 @@ COPY packages/owletto/package.jso[n] packages/owletto/
 
 # Stub out workspace packages we don't build in this image so bun install doesn't
 # error on missing manifests.
-RUN mkdir -p packages/cli packages/lobu-cli packages/browser-extension packages/mcpsandbox \
-    && for p in cli browser-extension mcpsandbox; do \
+RUN mkdir -p packages/lobu-cli packages/browser-extension packages/mcpsandbox \
+    && for p in browser-extension mcpsandbox; do \
         echo "{\"name\":\"@lobu/$p\",\"version\":\"0.0.0\",\"private\":true}" > "packages/$p/package.json"; \
       done \
     && echo '{"name":"lobu","version":"0.0.0","private":true}' > packages/lobu-cli/package.json
+
+# The CLI depends on playwright (npm:patchright) and playwright-vanilla
+# (npm:playwright). Neither may download browser binaries during install — the
+# runtime stage installs the single patchright Chromium this image uses.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 # Hoisted layout (npm-style flat node_modules) is required so the bundled
 # server.bundle.mjs (built below) can resolve transitive npm deps via Node's
@@ -83,6 +92,11 @@ COPY packages/embeddings/ packages/embeddings/
 COPY packages/connector-worker/ packages/connector-worker/
 COPY packages/pgvector-embedded/ packages/pgvector-embedded/
 COPY packages/server/ packages/server/
+COPY packages/cli/ packages/cli/
+# Bundled into the CLI dist by packages/cli/scripts/build.cjs: the starter
+# skill and the embedded-DB migrations.
+COPY skills/ skills/
+COPY db/migrations db/migrations
 # Copy the private frontend submodule when present.
 COPY packages/owletto packages/owletto
 
@@ -109,11 +123,23 @@ RUN cd packages/server && bunx tsc --noEmit
 # for the full rationale.
 RUN cd packages/server && bun run build:server
 
+# Build the CLI (#2231). It must build after build:server because
+# packages/cli/scripts/build.cjs copies the server bundles + catalog manifests
+# into the CLI dist, and @lobu/worker dist must exist for the CLI's tsc. It
+# runs *before* the owletto web build, so the CLI dist intentionally carries
+# no second copy of the SPA — the container already serves the web UI from
+# packages/owletto/dist, and `lobu run` inside the container stays headless.
+RUN cd packages/agent-worker && bunx tsc \
+    && cd ../cli && bun run build
+
 # Prune the embedded-Postgres runtime (~145MB platform binary) before it reaches
 # the runtime image. Prod always uses an external DATABASE_URL (postgres://), so
 # server.ts never loads embedded-postgres or the pgvector injector — both are
 # reached only via await import() on the file:// path. The builder needs them
-# for the type-check + bundle above, so we drop them only afterward.
+# for the type-check + bundle above, so we drop them only afterward. This also
+# means the in-image `lobu` CLI cannot boot an embedded database — in the
+# container every CLI workflow talks to the external DATABASE_URL, which is
+# the only supported mode here.
 RUN rm -rf node_modules/embedded-postgres node_modules/@embedded-postgres
 
 # Build frontend static assets (production only)
@@ -178,6 +204,11 @@ COPY --from=builder /app/packages/connectors ./packages/connectors
 COPY --from=builder /app/packages/embeddings ./packages/embeddings
 COPY --from=builder /app/packages/connector-worker ./packages/connector-worker
 COPY --from=builder /app/packages/server ./packages/server
+# The lobu CLI (#2231): self-hosters run `docker exec <container> lobu ...`.
+# bin/lobu.js resolves ../dist relative to its realpath and walks up to the
+# hoisted /app/node_modules, so a symlink onto PATH is all it needs.
+COPY --from=builder /app/packages/cli ./packages/cli
+RUN ln -s /app/packages/cli/bin/lobu.js /usr/local/bin/lobu
 COPY --from=builder /app/packages/owletto ./packages/owletto
 
 # Database migrations (+ statement-at-a-time runner for transaction:false)


### PR DESCRIPTION
## Summary
- The app image never shipped a `lobu` binary: the builder stubbed `packages/cli` purely so `bun install` would resolve, never built it, and the runtime stage never copied it. Docker self-hosters had **no CLI configuration path at all** — the exact dead end hit in #2151, where a user was told to run `lobu providers create` to point at a local ollama and could not.
- Builds the real CLI in the builder stage and symlinks `bin/lobu.js` onto PATH in the runtime stage, so `docker exec <container> lobu ...` works.
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` keeps the CLI's `playwright` / `playwright-vanilla` deps from pulling browser binaries — the runtime stage's single patchright Chromium stays the only browser in the image.

Implements **option 1** from the issue discussion (ship the whole CLI), chosen so `lobu` inside the container is never a confusing subset of the real CLI.

## Image size cost
Measured by building both Dockerfiles from the same tree (`SKIP_WEB_BUILD=true`, linux/arm64, podman):

| image | size |
| --- | --- |
| baseline (`origin/main` Dockerfile) | 3.41 GB (3,412,793,915 B) |
| with the CLI | 3.46 GB (3,459,342,951 B) |
| **delta** | **+46.5 MB (+1.4%)** |

Much cheaper than the 27-CLI-only-dependency list suggested: most of those packages were already in the image transitively, and skipping the browser download avoids a second Chromium.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] Tests run — no unit/integration suite covers the Dockerfile; verified by building and running the image instead.

### Red (baseline image, `origin/main` Dockerfile)
```
$ podman run --rm lobu-app:cli-before lobu --version
Error: Cannot find module '/app/lobu'
    at Function._resolveFilename (node:internal/modules/cjs/loader:1430:15)

$ podman run --rm lobu-app:cli-before sh -c 'command -v lobu || echo "NO lobu ON PATH"; ls /app/packages/cli'
NO lobu ON PATH
ls: cannot access '/app/packages/cli': No such file or directory
```

### Green (this branch)
```
$ podman run --rm lobu-app:cli-after sh -c 'command -v lobu; lobu --version'
/usr/local/bin/lobu
14.4.1
```

`docker exec`-style invocation, which is the workflow the issue is about:
```
$ podman exec <container> lobu --version
14.4.1

$ podman exec <container> lobu providers --help
Commands:
  list [options]                              List the org's model providers
  catalog [options]                           List provider kinds available to add
  create [options] <slug>                     Add a model provider with an API key
  ...

$ podman exec <container> lobu providers catalog
  Error: Not logged in to context "lobu". Run `lobu login` first.
```
`providers catalog` reaching Lobu's own auth check (rather than crashing) is the correct result for a container with no credentials — the binary boots, parses, and reports sensibly.

## Notes
Fixes #2231.

- The CLI builds *after* `build:server`, because `packages/cli/scripts/build.cjs` copies the server bundles + catalog manifests into the CLI dist.
- It builds *before* the owletto web build, so the CLI dist deliberately carries no second copy of the SPA — the container already serves the web UI from `packages/owletto/dist`.
- `embedded-postgres` is still pruned from the runtime image, so the in-container `lobu run` cannot boot an embedded database; CLI workflows in the container use the external `DATABASE_URL`. Unchanged from before this PR.
- Verified on linux/arm64 locally. CI builds linux/amd64; the change is arch-independent (no prebuilt binaries added), but the amd64 image build in `build-images.yml` is the confirming run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->