### PR TITLE
fix(docker): ship the lobu CLI in the app image

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -95,7 +95,7 @@ COPY packages/server/ packages/server/
 COPY packages/cli/ packages/cli/
 # Bundled into the CLI dist by packages/cli/scripts/build.cjs: the starter
 # skill and the embedded-DB migrations.
-COPY skills/ skills/
+COPY skills/lobu/ skills/lobu/
 COPY db/migrations db/migrations
 # Copy the private frontend submodule when present.
 COPY packages/owletto packages/owletto
@@ -125,21 +125,19 @@ RUN cd packages/server && bun run build:server
 
 # Build the CLI (#2231). It must build after build:server because
 # packages/cli/scripts/build.cjs copies the server bundles + catalog manifests
-# into the CLI dist, and @lobu/worker dist must exist for the CLI's tsc. It
-# runs *before* the owletto web build, so the CLI dist intentionally carries
-# no second copy of the SPA — the container already serves the web UI from
-# packages/owletto/dist, and `lobu run` inside the container stays headless.
-RUN cd packages/agent-worker && bunx tsc \
-    && cd ../cli && bun run build
+# into the CLI dist. It runs *before* the owletto web build, so the CLI dist
+# intentionally carries no second copy of the SPA — the container already
+# serves the web UI from packages/owletto/dist, which the bundled server finds
+# through its monorepo-relative fallback.
+RUN cd packages/cli && bun run build
 
 # Prune the embedded-Postgres runtime (~145MB platform binary) before it reaches
 # the runtime image. Prod always uses an external DATABASE_URL (postgres://), so
 # server.ts never loads embedded-postgres or the pgvector injector — both are
 # reached only via await import() on the file:// path. The builder needs them
 # for the type-check + bundle above, so we drop them only afterward. This also
-# means the in-image `lobu` CLI cannot boot an embedded database — in the
-# container every CLI workflow talks to the external DATABASE_URL, which is
-# the only supported mode here.
+# means the in-image `lobu run` cannot boot an embedded database; it must use
+# the container's external DATABASE_URL.
 RUN rm -rf node_modules/embedded-postgres node_modules/@embedded-postgres
 
 # Build frontend static assets (production only)

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -37,6 +37,10 @@ COPY packages/connector-sdk/package.json packages/connector-sdk/
 COPY packages/connectors/package.json packages/connectors/
 COPY packages/embeddings/package.json packages/embeddings/
 COPY packages/connector-worker/package.json packages/connector-worker/
+# The CLI ships in this image so self-hosters can run
+# `docker exec <container> lobu ...` (#2231). Real manifest, not a stub, so
+# bun install resolves its dependencies below.
+COPY packages/cli/package.json packages/cli/
 # server depends on @lobu/pgvector-embedded (workspace:*); its manifest must be
 # present for bun install to resolve the workspace member and for tsc to find
 # its types. Prod never loads it at runtime (external Postgres) — it's pruned
@@ -48,11 +52,16 @@ COPY packages/owletto/package.jso[n] packages/owletto/
 
 # Stub out workspace packages we don't build in this image so bun install doesn't
 # error on missing manifests.
-RUN mkdir -p packages/cli packages/lobu-cli packages/browser-extension packages/mcpsandbox \
-    && for p in cli browser-extension mcpsandbox; do \
+RUN mkdir -p packages/lobu-cli packages/browser-extension packages/mcpsandbox \
+    && for p in browser-extension mcpsandbox; do \
         echo "{\"name\":\"@lobu/$p\",\"version\":\"0.0.0\",\"private\":true}" > "packages/$p/package.json"; \
       done \
     && echo '{"name":"lobu","version":"0.0.0","private":true}' > packages/lobu-cli/package.json
+
+# The CLI depends on playwright (npm:patchright) and playwright-vanilla
+# (npm:playwright). Neither may download browser binaries during install — the
+# runtime stage installs the single patchright Chromium this image uses.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 # Hoisted layout (npm-style flat node_modules) is required so the bundled
 # server.bundle.mjs (built below) can resolve transitive npm deps via Node's
@@ -83,6 +92,11 @@ COPY packages/embeddings/ packages/embeddings/
 COPY packages/connector-worker/ packages/connector-worker/
 COPY packages/pgvector-embedded/ packages/pgvector-embedded/
 COPY packages/server/ packages/server/
+COPY packages/cli/ packages/cli/
+# Bundled into the CLI dist by packages/cli/scripts/build.cjs: the starter
+# skill and the embedded-DB migrations.
+COPY skills/ skills/
+COPY db/migrations db/migrations
 # Copy the private frontend submodule when present.
 COPY packages/owletto packages/owletto
 
@@ -109,11 +123,23 @@ RUN cd packages/server && bunx tsc --noEmit
 # for the full rationale.
 RUN cd packages/server && bun run build:server
 
+# Build the CLI (#2231). It must build after build:server because
+# packages/cli/scripts/build.cjs copies the server bundles + catalog manifests
+# into the CLI dist, and @lobu/worker dist must exist for the CLI's tsc. It
+# runs *before* the owletto web build, so the CLI dist intentionally carries
+# no second copy of the SPA — the container already serves the web UI from
+# packages/owletto/dist, and `lobu run` inside the container stays headless.
+RUN cd packages/agent-worker && bunx tsc \
+    && cd ../cli && bun run build
+
 # Prune the embedded-Postgres runtime (~145MB platform binary) before it reaches
 # the runtime image. Prod always uses an external DATABASE_URL (postgres://), so
 # server.ts never loads embedded-postgres or the pgvector injector — both are
 # reached only via await import() on the file:// path. The builder needs them
-# for the type-check + bundle above, so we drop them only afterward.
+# for the type-check + bundle above, so we drop them only afterward. This also
+# means the in-image `lobu` CLI cannot boot an embedded database — in the
+# container every CLI workflow talks to the external DATABASE_URL, which is
+# the only supported mode here.
 RUN rm -rf node_modules/embedded-postgres node_modules/@embedded-postgres
 
 # Build frontend static assets (production only)
@@ -178,6 +204,11 @@ COPY --from=builder /app/packages/connectors ./packages/connectors
 COPY --from=builder /app/packages/embeddings ./packages/embeddings
 COPY --from=builder /app/packages/connector-worker ./packages/connector-worker
 COPY --from=builder /app/packages/server ./packages/server
+# The lobu CLI (#2231): self-hosters run `docker exec <container> lobu ...`.
+# bin/lobu.js resolves ../dist relative to its realpath and walks up to the
+# hoisted /app/node_modules, so a symlink onto PATH is all it needs.
+COPY --from=builder /app/packages/cli ./packages/cli
+RUN ln -s /app/packages/cli/bin/lobu.js /usr/local/bin/lobu
 COPY --from=builder /app/packages/owletto ./packages/owletto
 
 # Database migrations (+ statement-at-a-time runner for transaction:false)


### PR DESCRIPTION
## Summary
- Docker self-hosters had **no CLI path at all**: the runtime stage never copied `packages/cli` (it was stubbed at build time purely so `bun install` resolved), so `docker exec <container> lobu ...` was impossible. Reported downstream in #2151, where a user was told to run `lobu providers create` to point at a local ollama and had no way to do it.
- Ships the CLI in the app image and symlinks it onto `PATH`. Option 1 from the issue discussion — the whole CLI, so `lobu` in the container is not a silently-partial subset of the documented CLI.
- Image cost: **3.41 GB → 3.46 GB (+50 MB, +1.5%)**. Browser downloads are suppressed (`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`); the image keeps using its single patchright Chromium.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: no unit tests cover the Dockerfile; verification is the real-image evidence below
- [x] Bug fix: red→fix→green outputs pasted below

**Red** — baseline image built from `origin/main`:
```
$ podman run --rm --entrypoint sh localhost/lobu-app:cli-before -c 'lobu --version'
sh: 1: lobu: not found
EXIT=127
```

**Green** — image built from this branch:
```
$ podman run --rm --entrypoint sh localhost/lobu-app:cli-after -c 'lobu --version'
14.4.1
```

The actual #2151 use case now works in-image:
```
$ podman run --rm --entrypoint sh localhost/lobu-app:cli-after -c 'lobu providers --help'
Usage: lobu providers [options] [command]
Manage org model providers (inference providers)
Commands:
  list / catalog / create / update / set-key / set-capability / set-default / delete
```

## Notes
Fixes #2231. Unblocks the configuration path #2151 asked for.

Three constraints are recorded as comments at their call sites, since none are obvious from the surrounding lines:
- The CLI build must run **after** `build:server` (its build script copies the server bundles + catalog manifests into the CLI dist) and **before** the owletto web build (so the CLI dist carries no second copy of the SPA — the container already serves the web UI from `packages/owletto/dist`).
- `bin/lobu.js` resolves `../dist` from its realpath and walks up to the hoisted `/app/node_modules`, so a symlink onto `PATH` is sufficient.
- Embedded Postgres is still pruned from the runtime image, so in-image `lobu run` cannot boot an embedded database — it must use the container's external `DATABASE_URL`. Called out in the comment so the next reader doesn't file it as a bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->