### PR TITLE
test(server): make webhook-ingest rate-limit tests clock-deterministic

### DIFF
--- a/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
+++ b/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
@@ -17,7 +17,15 @@
  */
 
 import { createHmac } from "node:crypto";
-import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	setSystemTime,
+	test,
+} from "bun:test";
 import {
 	ensureDbForGatewayTests,
 	ensureEncryptionKey,
@@ -614,6 +622,20 @@ describe("handleWebhookIngest idempotency", () => {
 });
 
 describe("handleWebhookIngest rate limiting", () => {
+	// The limiter derives its fixed window from Date.now(), so on a slow runner
+	// the 60s window can roll over mid-loop, refill the budget, and no request
+	// ever 429s (#2073). Freeze the clock at a window start so every request in
+	// a limit+1 loop deterministically lands in one window, regardless of how
+	// long the loop takes in real time.
+	beforeEach(() => {
+		const nowSec = Math.floor(Date.now() / 1000);
+		setSystemTime(new Date((nowSec - (nowSec % 60)) * 1000));
+	});
+
+	afterEach(() => {
+		setSystemTime(); // restore real time for the rest of the process
+	});
+
 	test("429 once the authenticated per-connection budget is exhausted", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		const { WEBHOOK_INGEST_RATE_LIMIT } = await import(

--- a/packages/server/src/utils/__tests__/rate-limiter.test.ts
+++ b/packages/server/src/utils/__tests__/rate-limiter.test.ts
@@ -10,7 +10,7 @@
  * which is exactly the production topology.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanupTestDatabase, getTestDb } from '../../__tests__/setup/test-db';
 import { getClientIP, getRateLimiter, RateLimiter, resetRateLimiterForTests } from '../rate-limiter';
 
@@ -20,7 +20,7 @@ function uniqueKey(label: string): string {
   return `test:${label}:${Date.now()}:${keySeq++}`;
 }
 
-/** Big window so a test can never straddle an epoch-aligned boundary. */
+/** Wide window; with the frozen clock below, a window can never roll mid-test. */
 const WIDE = { limit: 3, windowSeconds: 3600 };
 
 describe('RateLimiter (Postgres-backed fixed window)', () => {
@@ -30,9 +30,15 @@ describe('RateLimiter (Postgres-backed fixed window)', () => {
     await cleanupTestDatabase();
     resetRateLimiterForTests();
     limiter = getRateLimiter();
+    // The limiter derives its fixed window from Date.now(); on a slow runner a
+    // real-time test can straddle an epoch-aligned window boundary and the
+    // budget silently refills mid-test (#2073). Fake Date only (timers and DB
+    // I/O stay real) and drive window rollover explicitly via setSystemTime.
+    vi.useFakeTimers({ toFake: ['Date'], now: Date.now() });
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     resetRateLimiterForTests();
   });
 
@@ -104,15 +110,15 @@ describe('RateLimiter (Postgres-backed fixed window)', () => {
     const key = uniqueKey('window-roll');
     const config = { limit: 1, windowSeconds: 1 };
 
-    // Wait for the start of a fresh 1s window so both calls land inside it.
-    const msIntoWindow = Date.now() % 1000;
-    await new Promise((r) => setTimeout(r, 1000 - msIntoWindow + 10));
+    // Pin the clock to the start of a 1s window so both calls land inside it.
+    const windowStartMs = Math.ceil(Date.now() / 1000) * 1000;
+    vi.setSystemTime(windowStartMs);
 
     expect(limiter.checkLimit(key, config).allowed).toBe(true);
     expect(limiter.checkLimit(key, config).allowed).toBe(false);
 
     // Next fixed window → fresh budget.
-    await new Promise((r) => setTimeout(r, 1010));
+    vi.setSystemTime(windowStartMs + 1000);
     expect(limiter.checkLimit(key, config).allowed).toBe(true);
     await limiter.flushPendingWrites();
   });


### PR DESCRIPTION
## Summary
- `handleWebhookIngest rate limiting > 429 once the authenticated per-connection budget is exhausted` was flaky in the `integration` CI job (#2073). The limiter derives its fixed window from `Date.now()`, so on a slow runner the 60s window could roll over mid-loop, refill the per-connection budget, and no request in the `limit + 1` loop would ever 429 — the assertion then failed against a perfectly correct limiter.
- Freezes the clock at a window start so every request in the loop lands in one window regardless of how long the loop takes in real time. **Test-only — no production code changed.**
- Fixes the same class in the vitest limiter suite, which faked window rollover with real `setTimeout(1010)` sleeps: same straddle risk, plus ~2s of wall clock per test.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test packages/server/src/gateway/__tests__/webhook-ingest.test.ts` → **45 pass / 0 fail**; `bunx vitest run src/utils/__tests__/rate-limiter.test.ts` → **11 pass**
- [x] Bug fix: red→fix→green outputs pasted below

**The flake mechanism, reproduced deterministically.** Freezing the clock late in a window (rather than at its start) reproduces the original failure — the window rolls mid-loop, the budget refills, and nothing 429s:
```
error: expect(received).toBeDefined()
(fail) handleWebhookIngest rate limiting > 429 once the authenticated per-connection budget is exhausted
```

**Green, and stable across repeated runs** (5 consecutive runs of the rate-limiting describe block):
```
run 1:  3 pass  0 fail
run 2:  3 pass  0 fail
run 3:  3 pass  0 fail
run 4:  3 pass  0 fail
run 5:  3 pass  0 fail
```

**Mutation-tested** — the point of a rate-limit test is that it detects a broken limiter, and freezing a clock is exactly the kind of change that can quietly defang one. Disabling enforcement in `rate-limiter.ts` (`const allowed = true`) makes the test fail as it should:
```
(fail) handleWebhookIngest rate limiting > 429 once the authenticated per-connection budget is exhausted [3171.59ms]
 0 pass
 1 fail
```
The mutation was reverted; `rate-limiter.ts` is unchanged on this branch.

## Notes
Fixes #2073.

`make review-fix` reported the diff review-clean and made no edits. It could not start the two DB-backed suites inside its sandbox (`EPERM` on port binding); both were run outside it, with the results above.

Vitest fakes `Date` only — timers and DB I/O stay real, so the Postgres-backed limiter is still exercised for real rather than mocked out.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->