### PR TITLE
style(scripts): format the gateway-llm gate to biome's line width

### DIFF
--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -143,7 +143,10 @@ function statementText(lines, idx) {
         if (line.startsWith("/*", j)) {
           inBlockComment = true;
           j += 2;
-        } else if (line.startsWith("//", j) && (j === 0 || line[j - 1] !== ":")) {
+        } else if (
+          line.startsWith("//", j) &&
+          (j === 0 || line[j - 1] !== ":")
+        ) {
           break;
         } else {
           code += line[j];


### PR DESCRIPTION
`main` is currently red on `format-lint`: #2240 left line 146 of `scripts/check-gateway-llm-calls.mjs` at 82 columns, over the 80-column `lineWidth` in `config/biome.config.json`, so `bun run format:check` fails on `main` and on every branch cut from it.

Reproduced on `origin/main` at 94d9cb0 (`bunx @biomejs/biome@2.4.13 format --config-path config/biome.config.json .` → `Found 1 error`), and green after this change (`Checked 510 files ... No fixes applied`). Biome pinned to the lockfile's 2.4.13; earlier versions format several other files differently, so version drift here produces false positives.

The change is purely biome's own output for the condition, applied with `--write`:

```js
} else if (
  line.startsWith("//", j) &&
  (j === 0 || line[j - 1] !== ":")
) {
```

Because the gate parses source line-by-line and strips comments, splitting a condition across lines is exactly the shape it has to keep handling, so I re-ran both of its CI steps: `node scripts/check-gateway-llm-calls.mjs` passes over 624 files, and `bun test scripts/__tests__/check-gateway-llm-calls.test.ts` is 12/12, including the `formatter-split` and `ignores comments inside formatter-split statements` fixtures.

Fixing this on `main` rather than only on the release branch: the same one-line fix was pushed to #2254 earlier today and release-please dropped it when it regenerated that branch, which is why `format-lint` came back. Landing it here fixes it for `main` and for the next release-please regeneration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->