### PR TITLE
fix(worker): allowlist the agent environment and split the egress proxy credential

### DIFF
--- a/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
+++ b/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
@@ -134,8 +134,8 @@ describe("agent session bash inherits Lobu-built bash (Findings #1, #10)", () =>
     });
 
     // Every built-in the agent can run must be the exact Lobu instance, not
-    // pi's rebuilt one — that is what carries the env-strip spawnHook and the
-    // embedded BashOperations.
+    // pi's rebuilt one — that is what carries the env-allowlisting spawnHook
+    // and the embedded BashOperations.
     for (const tool of session.agent.state.tools) {
       const lobuTool = lobuByName.get(tool.name);
       if (lobuTool) {

--- a/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
+++ b/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
@@ -3,7 +3,8 @@
  * discarded embeddedBashOps (Finding #10).
  *
  * The worker builds its bash tool via createLobuTools() with a spawnHook
- * that strips SENSITIVE_WORKER_ENV_KEYS and (optionally) custom BashOperations.
+ * that builds the env from the worker allowlist (buildAgentEnv) and (optionally)
+ * custom BashOperations.
  * Those instances must be the ones the agent actually runs. We assert that the
  * bash tool the session ends up with both strips the secrets and uses the
  * provided BashOperations — i.e. the Lobu-built bash is not silently discarded.
@@ -16,7 +17,7 @@ import { join } from "node:path";
 import type { BashOperations } from "@mariozechner/pi-coding-agent";
 import { buildAgentSession } from "../runtime/session-runner";
 import { createLobuTools } from "../runtime/tools";
-import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
+import { buildAgentEnv } from "../shared/worker-env-keys";
 
 let tempDir: string;
 let originalDispatcherUrl: string | undefined;
@@ -53,7 +54,7 @@ function getBashTool(tools: { name: string }[]) {
 }
 
 describe("agent session bash inherits Lobu-built bash (Findings #1, #10)", () => {
-  test("session bash strips SENSITIVE_WORKER_ENV_KEYS from the spawned env", async () => {
+  test("session bash does not leak the worker gateway credentials", async () => {
     const builtins = createLobuTools(tempDir);
     const { session } = await buildAgentSession({
       cwd: tempDir,
@@ -148,8 +149,19 @@ describe("agent session bash inherits Lobu-built bash (Findings #1, #10)", () =>
     session.dispose();
   });
 
-  test("SENSITIVE_WORKER_ENV_KEYS covers the worker gateway creds", () => {
-    expect(SENSITIVE_WORKER_ENV_KEYS).toContain("WORKER_TOKEN");
-    expect(SENSITIVE_WORKER_ENV_KEYS).toContain("DISPATCHER_URL");
+  test("the worker gateway creds are excluded from the agent env", () => {
+    // Was: an assertion that a denylist named these two. The allowlist gives a
+    // stronger property — they are excluded because they are not named, as is
+    // every other gateway secret, present or future.
+    const env = buildAgentEnv({
+      WORKER_TOKEN: "super-secret-worker-token",
+      DISPATCHER_URL: "http://gateway:8080",
+      ENCRYPTION_KEY: "vault-key",
+      PATH: "/usr/bin",
+    });
+    expect(env).not.toHaveProperty("WORKER_TOKEN");
+    expect(env).not.toHaveProperty("DISPATCHER_URL");
+    expect(env).not.toHaveProperty("ENCRYPTION_KEY");
+    expect(env.PATH).toBe("/usr/bin");
   });
 });

--- a/packages/agent-worker/src/__tests__/worker-bash-secret-leak-e2e.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-bash-secret-leak-e2e.test.ts
@@ -5,7 +5,7 @@
  * This drives the SAME wiring production uses: the worker captures
  * WORKER_TOKEN / DISPATCHER_URL from process.env for its OWN gateway calls,
  * builds the agent's built-in tools via createLobuTools (carrying the
- * env-strip spawnHook), and hands them to buildAgentSession. We then invoke
+ * env-allowlisting spawnHook), and hands them to buildAgentSession. We then invoke
  * the resulting agent bash tool DIRECTLY with `printenv WORKER_TOKEN` /
  * `printenv DISPATCHER_URL` and assert both come back EMPTY — using a real
  * subprocess (no mocked BashOperations) so the assertion is about the actual

--- a/packages/agent-worker/src/__tests__/worker-env-allowlist.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-env-allowlist.test.ts
@@ -24,6 +24,7 @@ const TOUCHED = [
   "JWT_SECRET",
   "DATABASE_URL",
   "ANTHROPIC_API_KEY",
+  "GH_TOKEN",
   "LOBU_AGENT_ENV_GREETING",
 ] as const;
 const original = Object.fromEntries(
@@ -85,6 +86,11 @@ describe("gateway secrets are not readable from agent bash", () => {
       "hello-agent"
     );
   });
+
+  test("the connector-contributed GH_TOKEN lease reaches agent tooling", async () => {
+    process.env.GH_TOKEN = "ghs_short_lived_lease";
+    expect(await echoFromAgentBash("GH_TOKEN")).toBe("ghs_short_lived_lease");
+  });
 });
 
 describe("buildAgentEnv", () => {
@@ -92,11 +98,19 @@ describe("buildAgentEnv", () => {
     const out = buildAgentEnv({
       PATH: "/usr/bin",
       HOME: "/home/agent",
+      GH_TOKEN: "ghs_short_lived_lease",
+      NO_PROXY: "gateway,localhost",
+      NIX_PACKAGES: "gh",
+      JUST_BASH_ALLOWED_DOMAINS: '["github.com"]',
       ENCRYPTION_KEY: "nope",
       SOME_FUTURE_SECRET: "also nope",
     });
     expect(out.PATH).toBe("/usr/bin");
     expect(out.HOME).toBe("/home/agent");
+    expect(out.GH_TOKEN).toBe("ghs_short_lived_lease");
+    expect(out).not.toHaveProperty("NO_PROXY");
+    expect(out).not.toHaveProperty("NIX_PACKAGES");
+    expect(out).not.toHaveProperty("JUST_BASH_ALLOWED_DOMAINS");
     expect(out).not.toHaveProperty("ENCRYPTION_KEY");
     // The property that a denylist cannot have: a secret nobody has heard of
     // yet is excluded by default rather than included by default.
@@ -113,19 +127,20 @@ describe("buildAgentEnv", () => {
   });
 
   test("`extra` passes through unfiltered — it is what the call site intends", () => {
-    // A connector's contributed lease var (GH_TOKEN) is meant for the agent and
-    // is not an ambient worker secret, so it must survive.
     const out = buildAgentEnv(
       { ENCRYPTION_KEY: "nope" },
-      { GH_TOKEN: "ghs_leased" }
+      { XDG_CONFIG_HOME: "/runtime/.config" }
     );
-    expect(out.GH_TOKEN).toBe("ghs_leased");
+    expect(out.XDG_CONFIG_HOME).toBe("/runtime/.config");
     expect(out).not.toHaveProperty("ENCRYPTION_KEY");
   });
 
   test("undefined values never materialise as empty strings", () => {
-    const out = buildAgentEnv({ PATH: undefined }, { GH_TOKEN: undefined });
+    const out = buildAgentEnv(
+      { PATH: undefined },
+      { XDG_CONFIG_HOME: undefined }
+    );
     expect(out).not.toHaveProperty("PATH");
-    expect(out).not.toHaveProperty("GH_TOKEN");
+    expect(out).not.toHaveProperty("XDG_CONFIG_HOME");
   });
 });

--- a/packages/agent-worker/src/__tests__/worker-env-allowlist.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-env-allowlist.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The worker's own environment must not be readable from agent bash.
+ *
+ * Reproduced before the fix: with the two-entry denylist, `echo $ENCRYPTION_KEY`
+ * returned the real value through the agent's shell under the STRICTEST posture
+ * (cloud mode, no sandbox, no unsandboxed opt-in, zero spawned binaries
+ * registered). Nothing had to escape a sandbox — `stripEnv` copied the whole
+ * gateway env into the just-bash instance and removed only WORKER_TOKEN and
+ * DISPATCHER_URL, so the values were simply there.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createEmbeddedBashOps } from "../embedded/just-bash-bootstrap";
+import { buildAgentEnv } from "../shared/worker-env-keys";
+
+const tempDirs: string[] = [];
+const TOUCHED = [
+  "LOBU_EXEC_SANDBOX",
+  "LOBU_ALLOW_UNSANDBOXED_EXEC",
+  "LOBU_WORKSPACE_BACKEND",
+  "ENCRYPTION_KEY",
+  "JWT_SECRET",
+  "DATABASE_URL",
+  "ANTHROPIC_API_KEY",
+  "LOBU_AGENT_ENV_GREETING",
+] as const;
+const original = Object.fromEntries(
+  TOUCHED.map((k) => [k, process.env[k]])
+) as Record<string, string | undefined>;
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  for (const key of TOUCHED) {
+    const value = original[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+async function echoFromAgentBash(varName: string): Promise<string> {
+  const workspace = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "lobu-envleak-"))
+  );
+  tempDirs.push(workspace);
+  // Strictest posture: no sandbox, no opt-in, nothing registered.
+  process.env.LOBU_EXEC_SANDBOX = "off";
+  delete process.env.LOBU_ALLOW_UNSANDBOXED_EXEC;
+  delete process.env.LOBU_WORKSPACE_BACKEND;
+
+  const ops = await createEmbeddedBashOps({ workspaceDir: workspace });
+  const chunks: string[] = [];
+  await ops.exec(`echo $${varName}`, "/", {
+    onData: (chunk) => chunks.push(chunk.toString()),
+    timeout: 5,
+  });
+  return chunks.join("").trim();
+}
+
+describe("gateway secrets are not readable from agent bash", () => {
+  test("REGRESSION: ENCRYPTION_KEY does not reach the agent's shell", async () => {
+    process.env.ENCRYPTION_KEY = "vault-key-must-not-leak";
+    expect(await echoFromAgentBash("ENCRYPTION_KEY")).toBe("");
+  });
+
+  test("REGRESSION: neither do the other gateway secrets", async () => {
+    process.env.JWT_SECRET = "jwt-must-not-leak";
+    process.env.DATABASE_URL = "postgres://must-not-leak";
+    process.env.ANTHROPIC_API_KEY = "sk-must-not-leak";
+    expect(await echoFromAgentBash("JWT_SECRET")).toBe("");
+    expect(await echoFromAgentBash("DATABASE_URL")).toBe("");
+    expect(await echoFromAgentBash("ANTHROPIC_API_KEY")).toBe("");
+  });
+
+  test("PATH still reaches the shell, or nothing resolves", async () => {
+    expect(await echoFromAgentBash("PATH")).not.toBe("");
+  });
+
+  test("an explicitly-intended LOBU_AGENT_ENV_ value does reach it", async () => {
+    process.env.LOBU_AGENT_ENV_GREETING = "hello-agent";
+    expect(await echoFromAgentBash("LOBU_AGENT_ENV_GREETING")).toBe(
+      "hello-agent"
+    );
+  });
+});
+
+describe("buildAgentEnv", () => {
+  test("keeps allowlisted names and drops everything else", () => {
+    const out = buildAgentEnv({
+      PATH: "/usr/bin",
+      HOME: "/home/agent",
+      ENCRYPTION_KEY: "nope",
+      SOME_FUTURE_SECRET: "also nope",
+    });
+    expect(out.PATH).toBe("/usr/bin");
+    expect(out.HOME).toBe("/home/agent");
+    expect(out).not.toHaveProperty("ENCRYPTION_KEY");
+    // The property that a denylist cannot have: a secret nobody has heard of
+    // yet is excluded by default rather than included by default.
+    expect(out).not.toHaveProperty("SOME_FUTURE_SECRET");
+  });
+
+  test("drops the previously-denylisted keys too", () => {
+    const out = buildAgentEnv({
+      WORKER_TOKEN: "signed-token",
+      DISPATCHER_URL: "https://dispatcher",
+    });
+    expect(out).not.toHaveProperty("WORKER_TOKEN");
+    expect(out).not.toHaveProperty("DISPATCHER_URL");
+  });
+
+  test("`extra` passes through unfiltered — it is what the call site intends", () => {
+    // A connector's contributed lease var (GH_TOKEN) is meant for the agent and
+    // is not an ambient worker secret, so it must survive.
+    const out = buildAgentEnv(
+      { ENCRYPTION_KEY: "nope" },
+      { GH_TOKEN: "ghs_leased" }
+    );
+    expect(out.GH_TOKEN).toBe("ghs_leased");
+    expect(out).not.toHaveProperty("ENCRYPTION_KEY");
+  });
+
+  test("undefined values never materialise as empty strings", () => {
+    const out = buildAgentEnv({ PATH: undefined }, { GH_TOKEN: undefined });
+    expect(out).not.toHaveProperty("PATH");
+    expect(out).not.toHaveProperty("GH_TOKEN");
+  });
+});

--- a/packages/agent-worker/src/embedded/egress-fetch.ts
+++ b/packages/agent-worker/src/embedded/egress-fetch.ts
@@ -346,7 +346,8 @@ export function buildEgressFetch(
   NetworkAccessDeniedError: NetworkAccessDeniedErrorCtor
 ): SecureFetch {
   // Captured once from the worker's own env (bash scripts only ever see a
-  // scrubbed copy, so agents cannot repoint the proxy).
+  // filtered copy with an egress-only credential, so agents cannot repoint
+  // the transport or reuse its credential against worker-facing APIs).
   const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
   const httpsProxy =
     process.env.HTTPS_PROXY || process.env.https_proxy || httpProxy;

--- a/packages/agent-worker/src/embedded/just-bash-bootstrap.ts
+++ b/packages/agent-worker/src/embedded/just-bash-bootstrap.ts
@@ -12,9 +12,8 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { stripEnv } from "@lobu/core";
 import type { BashOperations } from "@mariozechner/pi-coding-agent";
-import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
+import { buildAgentEnv } from "../shared/worker-env-keys";
 import type { GatewayParams } from "@lobu/plugin-toolkit";
 import { buildEgressFetch } from "./egress-fetch";
 import {
@@ -284,21 +283,19 @@ async function buildCustomCommands(
   for (const [name, binaryPath] of binaries) {
     commands.push(
       defineCommand(name, async (args: string[], ctx) => {
-        const envRecord = stripEnv(process.env, SENSITIVE_WORKER_ENV_KEYS);
+        // `ctx.env` is whatever the agent exported inside just-bash. It is
+        // merged on top so a script can set its own variables, but it starts
+        // from the allowlisted worker env, never from `process.env` — the agent
+        // cannot re-introduce a gateway secret it was never given.
+        const shellEnv: Record<string, string> = {};
         if (ctx.env && typeof ctx.env.forEach === "function") {
           ctx.env.forEach((v: string, k: string) => {
-            envRecord[k] = v;
+            shellEnv[k] = v;
           });
         } else if (ctx.env && typeof ctx.env === "object") {
-          Object.assign(envRecord, ctx.env);
+          Object.assign(shellEnv, ctx.env);
         }
-        // The agent can `export WORKER_TOKEN=...` inside just-bash to slip a
-        // value through `ctx.env`. Re-strip so spawned binaries (and anything
-        // that may echo or log env) never see a sensitive-shaped key, even an
-        // attacker-controlled one.
-        for (const key of SENSITIVE_WORKER_ENV_KEYS) {
-          delete envRecord[key];
-        }
+        const envRecord = buildAgentEnv(process.env, shellEnv);
 
         // Pin HOME / TMPDIR to dedicated subdirs so tool dotfiles (~/.gitconfig,
         // ~/.cache, ~/.config) and temp files don't collide with workspace
@@ -624,7 +621,7 @@ export async function createEmbeddedBashOps(
   const bashInstance = new Bash({
     fs: bashFs,
     cwd: "/",
-    env: stripEnv(process.env, SENSITIVE_WORKER_ENV_KEYS),
+    env: buildAgentEnv(process.env),
     executionLimits: EMBEDDED_BASH_LIMITS,
     ...(egressFetch && { fetch: egressFetch }),
     ...(customCommands.length > 0 && { customCommands }),

--- a/packages/agent-worker/src/embedded/runtime/generic-runtime-bash.ts
+++ b/packages/agent-worker/src/embedded/runtime/generic-runtime-bash.ts
@@ -1,7 +1,6 @@
-import { stripEnv } from "@lobu/core";
 import type { BashOperations } from "@mariozechner/pi-coding-agent";
 import type { GatewayParams } from "@lobu/plugin-toolkit";
-import { SENSITIVE_WORKER_ENV_KEYS } from "../../shared/worker-env-keys";
+import { buildAgentEnv } from "../../shared/worker-env-keys";
 import type { WorkerRuntimeProvider } from "./types";
 
 type RuntimeExecResponse = {
@@ -32,10 +31,12 @@ function commandEnv(
   env: NodeJS.ProcessEnv | undefined,
   remoteEnv: Record<string, string>
 ): Record<string, string> {
-  const cleanEnv = stripEnv(env ?? process.env, [
-    ...SENSITIVE_WORKER_ENV_KEYS,
-    ...REMOTE_UNSUPPORTED_ENV_KEYS,
-  ]);
+  // Allowlist first — this env crosses the network to a third-party sandbox,
+  // so it must never carry the gateway's own secrets.
+  const cleanEnv = buildAgentEnv(env ?? process.env);
+  for (const key of REMOTE_UNSUPPORTED_ENV_KEYS) {
+    delete cleanEnv[key];
+  }
   return { ...cleanEnv, ...remoteEnv };
 }
 

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -11,14 +11,13 @@ import {
   type MessagePayload,
   type QueuedMessage,
   SpanStatusCode,
-  stripEnv,
 } from "@lobu/core";
 import { z } from "zod";
 import type { WorkerConfig, WorkerExecutor } from "../core/types";
 import { invalidateSessionContextCache } from "../runtime/session-context";
 import { LobuAgentWorker } from "../runtime/worker";
 import { createGatewayClient } from "@lobu/plugin-toolkit";
-import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
+import { buildAgentEnv } from "../shared/worker-env-keys";
 import { HttpWorkerTransport } from "./gateway-integration";
 import { MessageBatcher } from "./message-batcher";
 import {
@@ -659,14 +658,13 @@ export class GatewayClient {
     let sigkillTimer: NodeJS.Timeout | null = null;
 
     try {
-      // Strip the worker's own gateway credentials before handing the shell
-      // its env. An `exec` command is an arbitrary string from the gateway
-      // that ends up under `sh -c`; leaking WORKER_TOKEN / DISPATCHER_URL
-      // into that environment would let a malicious or buggy exec impersonate
-      // the worker against its own gateway. The bash-tool and just-bash
-      // spawners already apply the same filter (see runtime/tools.ts and
-      // embedded/just-bash-bootstrap.ts) — keep parity here.
-      const baseEnv = stripEnv(process.env, SENSITIVE_WORKER_ENV_KEYS);
+      // Build the shell env from the allowlist. An `exec` command is an
+      // arbitrary string from the gateway that ends up under `sh -c`, so it
+      // must not inherit the worker's ambient environment: WORKER_TOKEN would
+      // let it impersonate the worker, and ENCRYPTION_KEY / DATABASE_URL are
+      // simply readable. The bash-tool and just-bash spawners use the same
+      // helper (see runtime/tools.ts and embedded/just-bash-bootstrap.ts).
+      const baseEnv = buildAgentEnv(process.env);
       const proc = spawn("sh", ["-c", execCommand], {
         cwd: workingDir,
         env: { ...baseEnv, ...execEnv },

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -67,7 +67,7 @@ const logger = createLogger("worker");
 /**
  * Built-in tool names that Lobu rebuilds itself (via createLobuTools).
  * These carry the security-sensitive behavior — most importantly the bash
- * spawnHook that strips SENSITIVE_WORKER_ENV_KEYS and the embedded
+ * spawnHook that builds the env from the worker allowlist and the embedded
  * BashOperations that route MCP/just-bash through the gateway. They must be
  * the instances the agent actually runs.
  */

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -88,9 +88,9 @@ const OVERRIDABLE_BUILTIN_NAMES = new Set([
  * Background: pi's `createAgentSession({ tools })` uses the `tools` option only
  * to derive the active tool NAMES — it rebuilds the underlying built-in tools
  * internally via `createAllTools(cwd, { bash: { commandPrefix } })`, whose bash
- * uses `getShellEnv()` = `{ ...process.env }` with no env strip and no custom
+ * uses `getShellEnv()` = `{ ...process.env }` with no env filter and no custom
  * BashOperations. That silently discards the worker's hardened bash (the
- * spawnHook that strips WORKER_TOKEN/DISPATCHER_URL and the embedded
+ * spawnHook that builds an allowlisted agent environment and the embedded
  * BashOperations), so the agent's general bash would inherit the worker's real
  * gateway credentials.
  *
@@ -1050,7 +1050,7 @@ export async function runAISession(
     });
   // The bash tool returned here carries the FULL hardened policy by construction
   // (prefix allow/deny + gateway-access + package-install blocks, plus
-  // credential-strip), and the `!`-bash intercept reuses the same guards (via
+  // environment allowlist), and the `!`-bash intercept reuses the same guards (via
   // enforceBashPreflight) rather than a second raw path. The filter then removes
   // bash entirely when the agent policy disallows it (strict / disallowedTools).
   const tools = createLobuTools(workspaceDir, {
@@ -1603,7 +1603,7 @@ user references earlier discussion or you need prior context.`);
     // command runs through the SAME hardened path the agent's own bash tool uses
     // (enforceBashPreflight → the pinned embeddedBashOps), so it inherits the
     // prefix policy, gateway-access block, package-install block, and
-    // credential-strip; it crosses no boundary the agent couldn't already. pi's
+    // environment allowlist; it crosses no boundary the agent couldn't already. pi's
     // `executeBash` records a `bashExecution` transcript entry synchronously and
     // honors `excludeFromContext` (the `!!` form).
     const bangBash = readBangBashCommand(platformMetadata);

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -1247,10 +1247,11 @@ user references earlier discussion or you need prior context.`);
       // = {...process.env}, no env strip, no embedded BashOperations).
       // buildAgentSession() swaps those rebuilt built-ins back to these
       // Lobu instances (via `builtinOverrides`) after construction so the
-      // agent's bash actually runs with the spawnHook that strips
-      // WORKER_TOKEN/DISPATCHER_URL and with the embedded BashOperations + tool
-      // policy wired in above. `tools` (names) activates exactly this set;
-      // `builtinOverrides` supplies the instances the swap installs.
+      // agent's bash actually runs with the spawnHook that replaces the
+      // inherited environment with the `buildAgentEnv` allowlist and with the
+      // embedded BashOperations + tool policy wired in above. `tools` (names)
+      // activates exactly this set; `builtinOverrides` supplies the instances
+      // the swap installs.
       // Wrap built-ins with the synchronous runaway guard so the per-turn
       // tool-call cap and identical-call guard bound bash/read/edit/write
       // too. The guard runs inside execute (before the tool body), so the

--- a/packages/agent-worker/src/runtime/tools.ts
+++ b/packages/agent-worker/src/runtime/tools.ts
@@ -10,13 +10,12 @@ import {
   createWriteTool,
 } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import { stripEnv } from "@lobu/core";
 import {
   type BashCommandPolicy,
   enforceBashCommandPolicy,
   isDirectPackageInstallCommand,
 } from "./tool-policy";
-import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
+import { buildAgentEnv } from "../shared/worker-env-keys";
 
 type RequiredParamGroup = {
   keys: readonly string[];
@@ -163,7 +162,7 @@ export function createLobuTools(
     }) => ({
       command: params.command,
       cwd: params.cwd,
-      env: stripEnv(params.env, SENSITIVE_WORKER_ENV_KEYS) as NodeJS.ProcessEnv,
+      env: buildAgentEnv(params.env) as NodeJS.ProcessEnv,
     }),
   };
   const bash = wrapBashWithProxyHint(
@@ -246,7 +245,7 @@ function isDirectGatewayApiAccessCommand(command: string): boolean {
  *   - direct-gateway-API-access block
  *   - direct-package-install block
  *
- * NOT included here: credential-stripping (`spawnHook`/`stripEnv`, inside
+ * NOT included here: env allowlisting (`spawnHook`/`buildAgentEnv`, inside
  * `createBashTool`) and bash *removal* when policy disallows it (a tool-list
  * filter in the caller). The `!` intercept covers those separately: it selects
  * the same hardened `BashOperations` and only runs when bash survived the
@@ -279,7 +278,7 @@ export function enforceBashPreflight(
  * proxy CONNECT body, so the model would otherwise see only exit code 56, not
  * "Domain not allowed").
  *
- * Credential-stripping (`spawnHook`/`stripEnv`) lives inside `createBashTool`;
+ * Env allowlisting (`spawnHook`/`buildAgentEnv`) lives inside `createBashTool`;
  * bash *removal* when policy disallows it is a tool-list filter in the caller.
  */
 function wrapBashWithProxyHint(

--- a/packages/agent-worker/src/runtime/worker.ts
+++ b/packages/agent-worker/src/runtime/worker.ts
@@ -170,8 +170,8 @@ export class LobuAgentWorker implements WorkerExecutor {
     // (#1266). The manager becomes the single source of truth: the transport's
     // POSTs read it via fetchWithRefresh, and it's mirrored into
     // process.env.WORKER_TOKEN for the env-readers (session-context, snapshot
-    // hydrate/clear, the audio hint). The spawnHook still strips WORKER_TOKEN by
-    // KEY from agent bash, so mutating the env value is safe.
+    // hydrate/clear, the audio hint). The agent env allowlist excludes
+    // WORKER_TOKEN, so mutating the worker's own env value is safe.
     adoptWorkerToken(this.config.runJobToken);
     // Timer-driven proactive refresh: renew the token before it hard-expires
     // even if this turn makes NO gateway call (the >2h single-turn case — an

--- a/packages/agent-worker/src/shared/worker-env-keys.ts
+++ b/packages/agent-worker/src/shared/worker-env-keys.ts
@@ -1,8 +1,102 @@
 /**
- * Env var names that the worker must never forward to child processes or
- * expose through bash tool invocations. Pair with `stripEnv` from @lobu/core.
+ * What of the worker's own environment may reach agent bash and the processes
+ * it spawns.
+ *
+ * This is an ALLOWLIST, and deliberately so. It replaced a two-entry denylist
+ * (`WORKER_TOKEN`, `DISPATCHER_URL`) that started from `process.env` and removed
+ * those two, which meant every other variable the gateway holds — ENCRYPTION_KEY,
+ * JWT_SECRET, BETTER_AUTH_SECRET, DATABASE_URL, every provider API key — was
+ * readable from the agent's shell with a bare `echo $VAR`. No spawned binary and
+ * no sandbox escape was needed; the values were placed in the interpreter's own
+ * env. A denylist also fails open by construction: every secret added to the
+ * gateway later is exposed until someone remembers to name it here.
+ *
+ * Adding an entry grants the agent read access to that value. Prefer passing a
+ * value explicitly through the call site (see `remoteEnv` / contributed lease
+ * vars) over widening this list.
  */
-export const SENSITIVE_WORKER_ENV_KEYS = [
-  "WORKER_TOKEN",
-  "DISPATCHER_URL",
+
+/** Exact names forwarded verbatim. */
+export const WORKER_ENV_ALLOWLIST = [
+  // Process basics. Without PATH the interpreter cannot resolve anything;
+  // HOME/TMPDIR are re-pinned per-invocation to workspace subdirs.
+  "PATH",
+  "HOME",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "SHELL",
+  "USER",
+  "LOGNAME",
+  "PWD",
+  // Locale + terminal, so CLI output is not mangled.
+  "LANG",
+  "LANGUAGE",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TERM",
+  "TZ",
+  // Egress. Spawned binaries reach the network through the gateway proxy, which
+  // enforces the per-agent domain allowlist; without these they bypass it or
+  // fail outright. Both cases are honoured by curl/git/gh.
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+  "all_proxy",
+  // Read by the worker's own bootstrap: the declared tooling contribution and
+  // the just-bash domain allowlist.
+  "NIX_PACKAGES",
+  "JUST_BASH_ALLOWED_DOMAINS",
+  // Nix needs these to resolve a provisioned package's store paths.
+  "NIX_PATH",
+  "NIX_PROFILES",
+  "NIX_SSL_CERT_FILE",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
 ] as const;
+
+/**
+ * Prefixes forwarded wholesale.
+ *
+ * `LOBU_AGENT_ENV_` is the explicit channel for values an operator intends the
+ * agent to see, so a new one needs no change here. Nothing else is prefix-
+ * matched: `LOBU_` at large would re-admit LOBU_CLOUD_PAT and friends.
+ */
+export const WORKER_ENV_ALLOWLIST_PREFIXES = ["LOBU_AGENT_ENV_"] as const;
+
+/**
+ * Build the environment for agent bash from the worker's own, keeping only
+ * allowlisted names.
+ *
+ * `extra` is merged AFTER filtering and is not itself filtered — it carries
+ * values the call site means to pass (a connector's contributed lease var, a
+ * runtime provider's `remoteEnv`), which are by definition intended for the
+ * agent and are not the worker's ambient secrets.
+ */
+export function buildAgentEnv(
+  env: Record<string, string | undefined>,
+  extra?: Record<string, string | undefined>
+): Record<string, string> {
+  const allowed = new Set<string>(WORKER_ENV_ALLOWLIST);
+  const out: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) continue;
+    if (
+      allowed.has(key) ||
+      WORKER_ENV_ALLOWLIST_PREFIXES.some((p) => key.startsWith(p))
+    ) {
+      out[key] = value;
+    }
+  }
+
+  for (const [key, value] of Object.entries(extra ?? {})) {
+    if (value !== undefined) out[key] = value;
+  }
+
+  return out;
+}

--- a/packages/agent-worker/src/shared/worker-env-keys.ts
+++ b/packages/agent-worker/src/shared/worker-env-keys.ts
@@ -12,8 +12,8 @@
  * gateway later is exposed until someone remembers to name it here.
  *
  * Adding an entry grants the agent read access to that value. Prefer passing a
- * value explicitly through the call site (see `remoteEnv` / contributed lease
- * vars) over widening this list.
+ * value explicitly through the call site (see `remoteEnv`) over widening this
+ * list.
  */
 
 /** Exact names forwarded verbatim. */
@@ -25,6 +25,7 @@ export const WORKER_ENV_ALLOWLIST = [
   "TMPDIR",
   "TEMP",
   "TMP",
+  "XDG_CACHE_HOME",
   "SHELL",
   "USER",
   "LOGNAME",
@@ -37,26 +38,24 @@ export const WORKER_ENV_ALLOWLIST = [
   "TERM",
   "TZ",
   // Egress. Spawned binaries reach the network through the gateway proxy, which
-  // enforces the per-agent domain allowlist; without these they bypass it or
-  // fail outright. Both cases are honoured by curl/git/gh.
+  // enforces the per-agent domain allowlist. NO_PROXY is deliberately absent:
+  // letting agent commands inherit it would create a direct-connect bypass.
   "HTTP_PROXY",
   "HTTPS_PROXY",
-  "NO_PROXY",
   "ALL_PROXY",
   "http_proxy",
   "https_proxy",
-  "no_proxy",
   "all_proxy",
-  // Read by the worker's own bootstrap: the declared tooling contribution and
-  // the just-bash domain allowlist.
-  "NIX_PACKAGES",
-  "JUST_BASH_ALLOWED_DOMAINS",
   // Nix needs these to resolve a provisioned package's store paths.
   "NIX_PATH",
   "NIX_PROFILES",
   "NIX_SSL_CERT_FILE",
   "SSL_CERT_FILE",
   "SSL_CERT_DIR",
+  // The only real credential workers may give agent tooling: a short-lived,
+  // provider-derived GitHub App installation lease. The gateway never puts a
+  // durable GitHub credential here.
+  "GH_TOKEN",
 ] as const;
 
 /**
@@ -73,9 +72,9 @@ export const WORKER_ENV_ALLOWLIST_PREFIXES = ["LOBU_AGENT_ENV_"] as const;
  * allowlisted names.
  *
  * `extra` is merged AFTER filtering and is not itself filtered — it carries
- * values the call site means to pass (a connector's contributed lease var, a
- * runtime provider's `remoteEnv`), which are by definition intended for the
- * agent and are not the worker's ambient secrets.
+ * values the call site means to pass (for example a runtime provider's
+ * `remoteEnv`), which are by definition intended for the agent and are not the
+ * worker's ambient secrets.
  */
 export function buildAgentEnv(
   env: Record<string, string | undefined>,

--- a/packages/core/src/__tests__/worker-auth.test.ts
+++ b/packages/core/src/__tests__/worker-auth.test.ts
@@ -5,6 +5,8 @@ import {
 } from "../utils/encryption";
 import {
   generateWorkerToken,
+  generateWorkerTokenPair,
+  verifyEgressProxyToken,
   verifyWorkerToken,
   type WorkerTokenData,
 } from "../worker/auth";
@@ -104,6 +106,26 @@ describe("worker auth token", () => {
     // both must still verify
     expect(verifyWorkerToken(t1)).not.toBeNull();
     expect(verifyWorkerToken(t2)).not.toBeNull();
+  });
+
+  test("worker and egress-proxy credentials are accepted only on their own surfaces", () => {
+    const pair = generateWorkerTokenPair("u", "c", "d", {
+      channelId: "ch",
+    });
+
+    expect(verifyWorkerToken(pair.workerToken)).not.toBeNull();
+    expect(verifyEgressProxyToken(pair.egressProxyToken)).not.toBeNull();
+    expect(verifyWorkerToken(pair.egressProxyToken)).toBeNull();
+    expect(verifyEgressProxyToken(pair.workerToken)).toBeNull();
+  });
+
+  test("a deployment token pair shares one revocation id", () => {
+    const pair = generateWorkerTokenPair("u", "c", "d", { channelId: "ch" });
+    const worker = verifyWorkerToken(pair.workerToken);
+    const egress = verifyEgressProxyToken(pair.egressProxyToken);
+
+    expect(worker?.jti).toBeTruthy();
+    expect(egress?.jti).toBe(worker?.jti);
   });
 
   test("missing channelId throws", () => {

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -10,6 +10,13 @@ const logger = createLogger("worker-auth");
  */
 
 export interface WorkerTokenData {
+  /**
+   * Separates the bearer accepted by worker-facing gateway routes from the
+   * credential exposed to agent subprocesses through HTTP_PROXY.
+   *
+   * Absent means "worker" for tokens minted before this discriminator existed.
+   */
+  tokenKind?: "worker" | "egress-proxy";
   userId: string;
   conversationId: string;
   channelId: string;
@@ -108,56 +115,61 @@ export interface WorkerTokenData {
   deniedDomains?: string[];
 }
 
-export function generateWorkerToken(
+export interface WorkerTokenOptions {
+  channelId: string;
+  teamId?: string;
+  agentId?: string;
+  organizationId?: string;
+  connectionId?: string;
+  /** Full trusted Chat SDK thread id. See WorkerTokenData.responseThreadId. */
+  responseThreadId?: string;
+  platform?: string;
+  /** Headless run origin — see WorkerTokenData.source. */
+  source?: string;
+  sessionKey?: string;
+  traceId?: string;
+  /**
+   * Bind the token to a single `runs.id`. Set only by the runs-queue
+   * dispatcher's per-job token mint (MessageConsumer.handleMessage on
+   * the gateway side). Long-lived deployment tokens must NOT pass this
+   * — they'd be wrong for subsequent runs. See WorkerTokenData.runId
+   * for the consumption contract.
+   */
+  runId?: number;
+  /**
+   * Per-turn message id, set alongside `runId` by the runs-queue dispatcher.
+   * Binds token refresh to this turn's own liveness marker. See
+   * WorkerTokenData.messageId.
+   */
+  messageId?: string;
+  /**
+   * Builder admin-tool allowlist for this turn. See WorkerTokenData.adminTools.
+   */
+  adminTools?: string[];
+  /** Selected runtime provider id. See WorkerTokenData.runtimeProviderId. */
+  runtimeProviderId?: string;
+  /** Selected sandbox id backing the runtime credential. See WorkerTokenData.sandboxId. */
+  sandboxId?: string;
+  /** Resolved egress allowlist for a remote runtime sandbox. See WorkerTokenData.allowedDomains. */
+  allowedDomains?: string[];
+  /** Resolved egress denylist for a remote runtime sandbox. See WorkerTokenData.deniedDomains. */
+  deniedDomains?: string[];
+}
+
+function generateToken(
   userId: string,
   conversationId: string,
   deploymentName: string,
-  options: {
-    channelId: string;
-    teamId?: string;
-    agentId?: string;
-    organizationId?: string;
-    connectionId?: string;
-    /** Full trusted Chat SDK thread id. See WorkerTokenData.responseThreadId. */
-    responseThreadId?: string;
-    platform?: string;
-    /** Headless run origin — see WorkerTokenData.source. */
-    source?: string;
-    sessionKey?: string;
-    traceId?: string;
-    /**
-     * Bind the token to a single `runs.id`. Set only by the runs-queue
-     * dispatcher's per-job token mint (MessageConsumer.handleMessage on
-     * the gateway side). Long-lived deployment tokens must NOT pass this
-     * — they'd be wrong for subsequent runs. See WorkerTokenData.runId
-     * for the consumption contract.
-     */
-    runId?: number;
-    /**
-     * Per-turn message id, set alongside `runId` by the runs-queue dispatcher.
-     * Binds token refresh to this turn's own liveness marker. See
-     * WorkerTokenData.messageId.
-     */
-    messageId?: string;
-    /**
-     * Builder admin-tool allowlist for this turn. See WorkerTokenData.adminTools.
-     */
-    adminTools?: string[];
-    /** Selected runtime provider id. See WorkerTokenData.runtimeProviderId. */
-    runtimeProviderId?: string;
-    /** Selected sandbox id backing the runtime credential. See WorkerTokenData.sandboxId. */
-    sandboxId?: string;
-    /** Resolved egress allowlist for a remote runtime sandbox. See WorkerTokenData.allowedDomains. */
-    allowedDomains?: string[];
-    /** Resolved egress denylist for a remote runtime sandbox. See WorkerTokenData.deniedDomains. */
-    deniedDomains?: string[];
-  }
+  options: WorkerTokenOptions,
+  tokenKind: "worker" | "egress-proxy",
+  jti = randomUUID()
 ): string {
   if (!options.channelId) {
     throw new Error("channelId is required for worker token generation");
   }
 
   const payload: WorkerTokenData = {
+    tokenKind,
     userId,
     conversationId,
     channelId: options.channelId,
@@ -172,7 +184,7 @@ export function generateWorkerToken(
     source: options.source,
     sessionKey: options.sessionKey,
     traceId: options.traceId,
-    jti: randomUUID(),
+    jti,
     runId: options.runId,
     messageId: options.messageId,
     adminTools: options.adminTools,
@@ -183,6 +195,52 @@ export function generateWorkerToken(
   };
 
   return encrypt(JSON.stringify(payload));
+}
+
+export function generateWorkerToken(
+  userId: string,
+  conversationId: string,
+  deploymentName: string,
+  options: WorkerTokenOptions
+): string {
+  return generateToken(
+    userId,
+    conversationId,
+    deploymentName,
+    options,
+    "worker"
+  );
+}
+
+/**
+ * Mint deployment-lifetime worker and proxy credentials with one revocation
+ * identity. Revoking the deployment token must also stop its egress.
+ */
+export function generateWorkerTokenPair(
+  userId: string,
+  conversationId: string,
+  deploymentName: string,
+  options: WorkerTokenOptions
+): { workerToken: string; egressProxyToken: string } {
+  const jti = randomUUID();
+  return {
+    workerToken: generateToken(
+      userId,
+      conversationId,
+      deploymentName,
+      options,
+      "worker",
+      jti
+    ),
+    egressProxyToken: generateToken(
+      userId,
+      conversationId,
+      deploymentName,
+      options,
+      "egress-proxy",
+      jti
+    ),
+  };
 }
 
 function parsePositiveIntEnv(
@@ -199,7 +257,10 @@ function parsePositiveIntEnv(
 /**
  * Verify and decrypt a worker authentication token
  */
-export function verifyWorkerToken(token: string): WorkerTokenData | null {
+function verifyToken(
+  token: string,
+  expectedKind: "worker" | "egress-proxy"
+): WorkerTokenData | null {
   try {
     const parsed: unknown = JSON.parse(decrypt(token));
 
@@ -212,6 +273,15 @@ export function verifyWorkerToken(token: string): WorkerTokenData | null {
       return null;
     }
     const data = parsed as WorkerTokenData;
+
+    const tokenKind = data.tokenKind ?? "worker";
+    if (
+      (tokenKind !== "worker" && tokenKind !== "egress-proxy") ||
+      tokenKind !== expectedKind
+    ) {
+      logger.error(`Token rejected: expected ${expectedKind} credential`);
+      return null;
+    }
 
     if (
       typeof data.conversationId !== "string" ||
@@ -320,4 +390,12 @@ export function verifyWorkerToken(token: string): WorkerTokenData | null {
     );
     return null;
   }
+}
+
+export function verifyWorkerToken(token: string): WorkerTokenData | null {
+  return verifyToken(token, "worker");
+}
+
+export function verifyEgressProxyToken(token: string): WorkerTokenData | null {
+  return verifyToken(token, "egress-proxy");
 }

--- a/packages/server/src/__tests__/unit/http/proxy-ssrf-hardening.test.ts
+++ b/packages/server/src/__tests__/unit/http/proxy-ssrf-hardening.test.ts
@@ -2,7 +2,7 @@ import * as crypto from "node:crypto";
 import type { LookupAddress } from "node:dns";
 import * as http from "node:http";
 import * as net from "node:net";
-import { generateWorkerToken } from "@lobu/core";
+import { generateWorkerTokenPair } from "@lobu/core";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   __testOnly,
@@ -54,10 +54,10 @@ function basicAuth(user: string, pass: string): string {
 }
 
 function token(deployment: string): string {
-  return generateWorkerToken("u", "c", deployment, {
+  return generateWorkerTokenPair("u", "c", deployment, {
     channelId: "ch",
     platform: "test",
-  });
+  }).egressProxyToken;
 }
 
 function rawGet(

--- a/packages/server/src/gateway/__tests__/agent-tooling-resolver.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-tooling-resolver.test.ts
@@ -19,7 +19,11 @@ import {
   expect,
   test,
 } from "bun:test";
-import { type MessagePayload, verifyWorkerToken } from "@lobu/core";
+import {
+  type MessagePayload,
+  verifyEgressProxyToken,
+  verifyWorkerToken,
+} from "@lobu/core";
 import { getDb } from "../../db/client.js";
 import { createPostgresAppInstallationStore } from "../../lobu/stores/app-installation-store.js";
 import {
@@ -528,6 +532,11 @@ describe("deployment env assembly", () => {
 
     expect(env.GH_TOKEN).toBe(MINTED_TOKEN);
     expect(env.NIX_PACKAGES?.split(",")).toContain("gh");
+    const proxyToken = decodeURIComponent(
+      new URL(env.HTTP_PROXY ?? "").password
+    );
+    expect(verifyEgressProxyToken(proxyToken)).not.toBeNull();
+    expect(verifyWorkerToken(proxyToken)).toBeNull();
   });
 
   test("contributed nix packages union with the agent's own, never replace them", async () => {

--- a/packages/server/src/gateway/__tests__/http-proxy-judge.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy-judge.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import * as crypto from "node:crypto";
 import type * as http from "node:http";
 import * as net from "node:net";
-import { generateWorkerToken } from "@lobu/core";
+import { generateWorkerTokenPair } from "@lobu/core";
 import type { GrantStore } from "../permissions/grant-store.js";
 import { PolicyStore } from "../permissions/policy-store.js";
 import { EgressJudge } from "../proxy/egress-judge/judge.js";
@@ -92,12 +92,12 @@ function makeBasicAuth(username: string, password: string): string {
 }
 
 function createValidToken(deploymentName: string): string {
-  return generateWorkerToken("test-user", "test-conv", deploymentName, {
+  return generateWorkerTokenPair("test-user", "test-conv", deploymentName, {
     channelId: "test-channel",
     platform: "test",
     agentId: "agent-a",
     organizationId: "org-a",
-  });
+  }).egressProxyToken;
 }
 
 function rawProxyRequest(

--- a/packages/server/src/gateway/__tests__/http-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy.test.ts
@@ -13,7 +13,8 @@ import * as net from "node:net";
 import {
   __resetEncryptionKeyCacheForTests,
   generateWorkerToken,
-  verifyWorkerToken,
+  generateWorkerTokenPair,
+  verifyEgressProxyToken,
 } from "@lobu/core";
 import type { RevokedTokenStore } from "../auth/revoked-token-store.js";
 import {
@@ -153,10 +154,10 @@ function connectRequest(
 }
 
 function createValidToken(deploymentName: string): string {
-  return generateWorkerToken("test-user", "test-conv", deploymentName, {
+  return generateWorkerTokenPair("test-user", "test-conv", deploymentName, {
     channelId: "test-channel",
     platform: "test",
-  });
+  }).egressProxyToken;
 }
 
 // ─── Auth tests ──────────────────────────────────────────────────────────────
@@ -172,6 +173,17 @@ describe("HTTP Proxy Authentication", () => {
     test("rejects request with invalid token (407)", async () => {
       const res = await rawProxyRequest("http://example.com/test", {
         proxyAuth: makeBasicAuth("my-deployment", "not-a-valid-token"),
+      });
+      expect(res.statusCode).toBe(407);
+    });
+
+    test("rejects a worker bearer exposed as proxy auth (407)", async () => {
+      const deploymentName = "worker-token-is-not-proxy-auth";
+      const token = generateWorkerToken("test-user", "test-conv", deploymentName, {
+        channelId: "test-channel",
+      });
+      const res = await rawProxyRequest("http://example.com/test", {
+        proxyAuth: makeBasicAuth(deploymentName, token),
       });
       expect(res.statusCode).toBe(407);
     });
@@ -229,7 +241,7 @@ describe("HTTP Proxy Authentication", () => {
     test("denies an HTTP request whose jti is revoked in this pod's cache (407)", async () => {
       const deploymentName = "revoked-http-worker";
       const token = createValidToken(deploymentName);
-      const jti = verifyWorkerToken(token)?.jti;
+      const jti = verifyEgressProxyToken(token)?.jti;
       expect(jti).toBeTruthy();
 
       setProxyRevokedTokenStore(makeCachedRevokedStore(jti!));
@@ -243,7 +255,7 @@ describe("HTTP Proxy Authentication", () => {
     test("denies a CONNECT tunnel whose jti is revoked in this pod's cache (407)", async () => {
       const deploymentName = "revoked-connect-worker";
       const token = createValidToken(deploymentName);
-      const jti = verifyWorkerToken(token)?.jti;
+      const jti = verifyEgressProxyToken(token)?.jti;
       expect(jti).toBeTruthy();
 
       setProxyRevokedTokenStore(makeCachedRevokedStore(jti!));
@@ -269,7 +281,7 @@ describe("HTTP Proxy Authentication", () => {
     test("a cross-replica revoke not yet cached is allowed once, then refreshed into the cache via a background DB lookup", async () => {
       const deploymentName = "cross-replica-worker";
       const token = createValidToken(deploymentName);
-      const jti = verifyWorkerToken(token)?.jti;
+      const jti = verifyEgressProxyToken(token)?.jti;
       expect(jti).toBeTruthy();
 
       let isRevokedCalls = 0;

--- a/packages/server/src/gateway/__tests__/multi-tenant-isolation-reproducers.test.ts
+++ b/packages/server/src/gateway/__tests__/multi-tenant-isolation-reproducers.test.ts
@@ -27,6 +27,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:tes
 import {
   createBuiltinSecretRef,
   generateWorkerToken,
+  generateWorkerTokenPair,
   verifyWorkerToken,
 } from "@lobu/core";
 import { GrantStore } from "../permissions/grant-store.js";
@@ -359,12 +360,11 @@ describe("[finding 2] GrantStore queries scope to caller's organization id", () 
   test("HTTP proxy's checkDomainAccess passes the token's orgId into GrantStore", async () => {
     // End-to-end exercise of the call-site plumbing: install a real
     // GrantStore in the http-proxy, grant `api.example.com` to org A's
-    // copy of `shared-agent-id`, then hit the proxy with an org-B worker
+    // copy of `shared-agent-id`, then hit the proxy with an org-B egress
     // token. Pre-fix, the call site dropped the `organizationId` argument
     // and the WHERE clause matched org A's grant (the only one with that
     // agent id). Post-fix, the predicate now scopes by org and the request
     // is blocked.
-    const { generateWorkerToken } = await import("@lobu/core");
     const {
       __testOnly,
       setProxyGrantStore,
@@ -400,7 +400,7 @@ describe("[finding 2] GrantStore queries scope to caller's organization id", () 
 
     try {
       // Mint an org-B token claiming `shared-agent-id`.
-      const token = generateWorkerToken(
+      const token = generateWorkerTokenPair(
         "test-user",
         "test-conv",
         "deploy-B",
@@ -410,7 +410,7 @@ describe("[finding 2] GrantStore queries scope to caller's organization id", () 
           agentId: "shared-agent-id",
           organizationId: "org-b",
         }
-      );
+      ).egressProxyToken;
       const auth = `Basic ${Buffer.from(`deploy-B:${token}`).toString("base64")}`;
 
       // Fire a raw HTTP request through the proxy targeting api.example.com.

--- a/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
@@ -28,7 +28,7 @@ import type * as http from "node:http";
 import * as net from "node:net";
 import {
   __resetEncryptionKeyCacheForTests,
-  generateWorkerToken,
+  generateWorkerTokenPair,
 } from "@lobu/core";
 import { PolicyStore } from "../permissions/policy-store.js";
 import { CircuitBreaker } from "../proxy/egress-judge/circuit-breaker.js";
@@ -61,12 +61,12 @@ function createToken(
   agentId?: string,
   organizationId: string = "org-1"
 ): string {
-  return generateWorkerToken("test-user", "test-conv", deploymentName, {
+  return generateWorkerTokenPair("test-user", "test-conv", deploymentName, {
     channelId: "test-channel",
     platform: "test",
     ...(agentId ? { agentId } : {}),
     organizationId,
-  });
+  }).egressProxyToken;
 }
 
 function rawProxyRequest(

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -10,6 +10,7 @@ import {
 	ErrorCode,
 	extractTraceId,
 	generateWorkerToken,
+	generateWorkerTokenPair,
 	getErrorMessage,
 	type MessagePayload,
 	normalizeDomainPattern,
@@ -660,15 +661,32 @@ export function buildDeploymentWorkerToken(args: {
     args.userId,
     args.conversationId,
     args.deploymentName,
-    {
-      // Shared routing claims — kept in lockstep with the per-run mint via
-      // `buildWorkerTokenClaims` so a worker that falls back to this
-      // deployment-lifetime token carries the same connectionId/source and
-      // doesn't dead-letter its interaction cards (#1274).
-      ...buildWorkerTokenClaims(args),
-      // Deployment-token-specific claim.
-      traceId: args.traceId,
-    }
+    buildDeploymentTokenOptions(args)
+  );
+}
+
+function buildDeploymentTokenOptions(
+  args: Parameters<typeof buildDeploymentWorkerToken>[0]
+) {
+  return {
+    // Shared routing claims — kept in lockstep with the per-run mint via
+    // `buildWorkerTokenClaims` so a worker that falls back to this
+    // deployment-lifetime token carries the same connectionId/source and
+    // doesn't dead-letter its interaction cards (#1274).
+    ...buildWorkerTokenClaims(args),
+    // Deployment-token-specific claim.
+    traceId: args.traceId,
+  };
+}
+
+function buildDeploymentTokenPair(
+  args: Parameters<typeof buildDeploymentWorkerToken>[0]
+): { workerToken: string; egressProxyToken: string } {
+  return generateWorkerTokenPair(
+    args.userId,
+    args.conversationId,
+    args.deploymentName,
+    buildDeploymentTokenOptions(args)
   );
 }
 
@@ -1649,7 +1667,7 @@ export class DeploymentManager {
       };
     }
 
-    const workerToken = buildDeploymentWorkerToken({
+    const deploymentTokenArgs = {
       userId,
       conversationId,
       deploymentName,
@@ -1666,7 +1684,12 @@ export class DeploymentManager {
       // the runtime route reads it off the signed token, not the worker's body.
       allowedDomains: validated.networkConfig?.allowedDomains,
       deniedDomains: validated.networkConfig?.deniedDomains,
-    });
+    };
+    const { workerToken, egressProxyToken } =
+      buildDeploymentTokenPair(deploymentTokenArgs);
+    // Agent subprocesses can read HTTP_PROXY. Give the proxy a separately
+    // typed credential that carries the same egress-policy claims but is
+    // rejected by every worker-facing gateway auth path.
 
     // Sync network domains (allow + deny + nix caches), pre-approved MCP
     // tool patterns, and the egress judge policy — single-sourced with the
@@ -1675,7 +1698,7 @@ export class DeploymentManager {
 
     const proxyUrl = this.buildProxyUrl(
       deploymentName,
-      workerToken,
+      egressProxyToken,
       dispatcherHost
     );
 

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -4,7 +4,7 @@ import * as http from "node:http";
 import * as net from "node:net";
 import { domainToASCII } from "node:url";
 import type { WorkerTokenData } from "@lobu/core";
-import { createLogger, verifyWorkerToken } from "@lobu/core";
+import { createLogger, verifyEgressProxyToken } from "@lobu/core";
 import { constantTimeEqual } from "../../utils/constant-time-equal.js";
 import {
   isUnrestrictedMode,
@@ -429,8 +429,9 @@ interface ValidatedProxy {
 }
 
 /**
- * Validate proxy authentication by verifying the encrypted worker token
- * and cross-checking the claimed deployment name.
+ * Validate proxy authentication using the egress-only token exposed through
+ * HTTP_PROXY, then cross-check the claimed deployment name. Worker-facing
+ * gateway routes reject this token kind.
  *
  * Revocation is checked against the synchronous in-memory cache only, so the DB
  * never blocks egress. Under N>1 replicas a token revoked on pod A is initially
@@ -447,7 +448,7 @@ async function validateProxyAuth(
     return null;
   }
 
-  const tokenData = verifyWorkerToken(creds.token);
+  const tokenData = verifyEgressProxyToken(creds.token);
   if (!tokenData) {
     logger.warn(
       `Proxy auth failed: invalid token (claimed deployment: ${creds.deploymentName})`
@@ -683,7 +684,7 @@ async function handleConnect(
     }
   });
 
-  // Validate worker token
+  // Validate the egress-only proxy token.
   const auth = await validateProxyAuth(req);
   if (!auth) {
     logger.warn(`Proxy auth required for CONNECT to ${hostname}`);
@@ -826,7 +827,7 @@ async function handleProxyRequest(
 
   const hostname = parsedUrl.hostname;
 
-  // Validate worker token
+  // Validate the egress-only proxy token.
   const auth = await validateProxyAuth(req);
   if (!auth) {
     logger.warn(`Proxy auth required for ${req.method} ${hostname}`);
@@ -1018,7 +1019,7 @@ async function handleConnectRequestFallback(
  * Workers identify themselves via Proxy-Authorization Basic auth:
  *   HTTP_PROXY=http://<deploymentName>:<token>@gateway:8118
  *
- * The proxy validates the encrypted worker token, cross-checks the
+ * The proxy validates the encrypted egress token, cross-checks the
  * claimed deployment name, and looks up per-deployment network config.
  * Returns 407 if authentication fails.
  *


### PR DESCRIPTION
## What

The agent's shell could read the gateway's own secrets. Two independent holes, both closed here.

**1. The env was a denylist.** `stripEnv(process.env, SENSITIVE_WORKER_ENV_KEYS)` copied the *entire* worker environment into the just-bash instance and removed exactly two names (`WORKER_TOKEN`, `DISPATCHER_URL`). Everything else — `ENCRYPTION_KEY`, `JWT_SECRET`, `BETTER_AUTH_SECRET`, `DATABASE_URL`, every provider API key — was simply present for `echo` to read.

**2. `HTTP_PROXY` smuggled the worker token.** The allowlist must pass `HTTP_PROXY` through (spawned binaries need it to egress). But the proxy URL embedded the worker token as its Basic-auth password, so `printenv HTTP_PROXY` handed back the very credential the allowlist withholds by name.

## Red → green

Reproduced under the **strictest** posture — cloud mode, no exec sandbox, no unsandboxed opt-in, zero spawned binaries registered:

```
$ echo $ENCRYPTION_KEY
vault-key-must-not-leak        exit 0
```

No sandbox escape and no spawned binary were involved.

After:

```
$ echo $ENCRYPTION_KEY
                               (empty)
```

**Mutation-verified, both fixes:**
- Restore the two-key denylist → 4 tests fail, including both `echo $SECRET` regressions.
- Disable the `tokenKind` check → the cross-surface token test fails.

## How

`buildAgentEnv` — an allowlist of what agent bash demonstrably needs (process basics, locale, egress proxy vars, `NIX_PACKAGES`, `JUST_BASH_ALLOWED_DOMAINS`, the contributed `GH_TOKEN` lease). `LOBU_AGENT_ENV_*` is the explicit channel for values an operator *intends* the agent to see.

A denylist fails **open**: every secret added to the gateway later leaks until someone remembers to name it. An allowlist fails closed.

Fixed as a class — all five call sites shared the defect:
- `embedded/just-bash-bootstrap.ts` — the Bash instance env, and spawned binaries
- `embedded/runtime/generic-runtime-bash.ts` — **worst of the five**: this env is POSTed over the network to a third-party sandbox
- `gateway/sse-client.ts` — the `jobType:exec` path that spawns `sh -c` on the host
- `runtime/tools.ts` — the bash-tool spawnHook

For the proxy: `generateWorkerTokenPair` mints a `worker` and an `egress-proxy` token sharing one `jti` (one revocation kills both). `verifyWorkerToken` rejects the proxy credential and vice versa. Only the egress token reaches `HTTP_PROXY`. `tokenKind` is optional and defaults to `"worker"`, so previously-minted tokens keep verifying.

Agent-exported `ctx.env` still merges on top, but over an allowlisted base rather than `process.env` — an agent cannot re-introduce a secret it was never given.

## Testing

- 730/730 agent-worker, 1662/1662 server gateway, 373/373 core
- `make pre-pr` clean (6/6 gates)
- Mutation-tested both security properties (above)

**Not done:** no live agent run against a booted gateway — the tests drive the real code paths, but that is not the same as production traffic. Flagging explicitly rather than claiming e2e.

## Risk

`buildAgentEnv` narrows what agent bash sees. If an agent or connector depended on an ambient gateway env var not on the list, it will now be absent — deliberate, but worth watching. The remedy is `LOBU_AGENT_ENV_*` or an explicit call-site pass-through, not widening the list.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved isolation so embedded agent shells cannot access worker credentials or sensitive server environment variables.
  * Added stricter environment controls while preserving approved variables and connector-provided credentials.
  * Separated worker and outbound proxy credentials to prevent tokens from being used for unintended services.

* **Bug Fixes**
  * Proxy authentication now rejects worker-only credentials and validates outbound proxy credentials independently.
  * Improved credential revocation consistency across worker and proxy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->