### PR TITLE
feat(web): fold agent config behind Configure tabs and preview an empty Activity feed

### DIFF
--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -143,7 +143,10 @@ function statementText(lines, idx) {
         if (line.startsWith("/*", j)) {
           inBlockComment = true;
           j += 2;
-        } else if (line.startsWith("//", j) && (j === 0 || line[j - 1] !== ":")) {
+        } else if (
+          line.startsWith("//", j) &&
+          (j === 0 || line[j - 1] !== ":")
+        ) {
           break;
         } else {
           code += line[j];


### PR DESCRIPTION
Submodule bump for owletto **#618** — see that PR for the full front-end diff. This branch carries only the `packages/owletto` pointer.

## What

**1. Agent config folds behind one Configure row.** The per-agent sidebar rows (Skills / Guardrails / Settings) collapse into a single **Configure** row opening a tab strip: Skills · Guardrails · Permissions · Models · Settings. Permissions is un-folded out of Guardrails into its own admin-only tab; Models moves out of Settings, carrying the model allow-list and sandbox picker. Tabs replace sidebar rows rather than duplicating them.

**2. Connect surfaces left-aligned, duplicate CTA removed.** `/connectors` with nothing added redirects to `/connectors/create` (the empty list showed a second Add button beside the empty state's own). `/create` gains a back arrow when there's something to go back to. Catalog rows drop Install/Available badges; installed connectors get a green **Installed** badge with a checkbox to filter to them.

**3. Activity's empty state previews a real feed.** Placeholder bars said nothing about what Activity is for. It now renders sample events through the **actual** `TimelineRow` + `EventCard` — a pending approval with its field diff, a completed action, messages, an email, a file — under an overlay with a **Connect your data** CTA. The page chrome (filter bar, search, count row) stays mounted behind it: only the list region is substituted. The preview is `aria-hidden` + `inert`.

## Bug found in review

The `/create` back arrow originally counted only connectors. The connectors list is built as `[...connectorItems, ...providerItems, ...sandboxItems]`, so an org with only an inference provider or sandbox has a non-empty list, never hits the empty redirect, and would have been **stranded on `/create` with no way back**. Now counts all three.

## Merge safety

`origin/main` had advanced owletto to `67bdd935` after this branch started. Bumping the pointer as-is would have reverted #617, #616 and several image updates. Verified via `merge-base --is-ancestor` (NO), then resolved with `git merge` per the submodule rule — the merged pointer contains both sides.

That merge then exposed a stale `packages/core/dist`: owletto's main expects `inference-providers` to be a reserved 404 segment, a constant living in `@lobu/core`. Source had it; the built output did not, and `tsc` passed regardless. `make build-packages` fixed the 3 resulting failures.

## Testing

- `make pre-pr` — all 6 gates clean (twice: before and after the main merge), including exposed-surface naming.
- `tsc -b` clean; **1001/1001 vitest green**.
- New tests pin the empty-state preview: renders through the real card (including the approval's `Growth` → `Enterprise` diff), interaction cards lead the feed, real search/filter chrome stays mounted, preview hidden from assistive tech and keyboard focus. Each mutation-tested — removing the preview or reverting to an early-return empty state fails them.

## Screenshots

⚠️ **Owed.** The browser tooling in my environment cannot reach the dev server (`curl` returns 200 from the same URL, so it is an extension-side reachability problem). This is a UI change that has not been visually verified by anyone — flagging explicitly rather than implying it was checked.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->