### PR TITLE
fix(ci): apply biome formatting to the gateway LLM gate script

### DIFF
--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -143,7 +143,10 @@ function statementText(lines, idx) {
         if (line.startsWith("/*", j)) {
           inBlockComment = true;
           j += 2;
-        } else if (line.startsWith("//", j) && (j === 0 || line[j - 1] !== ":")) {
+        } else if (
+          line.startsWith("//", j) &&
+          (j === 0 || line[j - 1] !== ":")
+        ) {
           break;
         } else {
           code += line[j];


### PR DESCRIPTION
## Summary
- `format-lint` is red on `main` itself, not just on one PR: the `else if` chain that #2240 added to `scripts/check-gateway-llm-calls.mjs` exceeds biome's print width, so `bun run format:check` fails and every downstream gate in that job (lint, jscpd, the naming/gateway/publish gates, the review-tooling shell tests) never runs.
- Every open PR inherits the failure, including submodule-pointer PRs like #2264 whose diff is a single `packages/owletto` line.
- This is the formatter's own output, applied to that one statement. No behavior change.

```js
        } else if (
          line.startsWith("//", j) &&
          (j === 0 || line[j - 1] !== ":")
        ) {
```

## Test plan
- [x] Bug fix: red→fix→green outputs pasted below
- [x] Tests run: targeted `bun test scripts/__tests__/check-gateway-llm-calls.test.ts` (12 pass), plus the gate itself

Red, before (biome 2.4.13, the version the lockfile resolves):

```
$ biome format --config-path config/biome.config.json .
scripts/check-gateway-llm-calls.mjs format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  × Formatter would have printed the following content:
    146 │ - ········}·else·if·(line.startsWith("//",·j)·&&·(j·===·0·||·line[j·-·1]·!==·":"))·{
Checked 510 files in 247ms. No fixes applied.
Found 1 error.
```

Green, after:

```
$ biome format --config-path config/biome.config.json .
Checked 510 files in 219ms. No fixes applied.

$ biome lint --config-path config/biome.config.json .
Checked 510 files in 395ms. No fixes applied.
Found 2 infos.

$ node scripts/check-gateway-llm-calls.mjs
✓ gateway-llm gate: 624 packages/server/src files contain no unsuppressed one-off LLM client

$ bun test scripts/__tests__/check-gateway-llm-calls.test.ts
 12 pass
 0 fail
```

## Notes
The formatter-split shape this reflows is exactly what the gate's own `statementText` walker is written to handle, and the "fails on a formatter-split completions fetch" / "ignores comments inside formatter-split statements" fixtures still pass, so the guard keeps catching what it was added for.

Downstream steps in `format-lint` were unreachable while `format:check` aborted the job, so CI on this PR is the first run that exercises them since #2240; anything they surface is pre-existing and separate from this reflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->