### PR TITLE
style(scripts): reformat the gateway LLM gate to satisfy biome

### DIFF
--- a/scripts/check-gateway-llm-calls.mjs
+++ b/scripts/check-gateway-llm-calls.mjs
@@ -143,7 +143,10 @@ function statementText(lines, idx) {
         if (line.startsWith("/*", j)) {
           inBlockComment = true;
           j += 2;
-        } else if (line.startsWith("//", j) && (j === 0 || line[j - 1] !== ":")) {
+        } else if (
+          line.startsWith("//", j) &&
+          (j === 0 || line[j - 1] !== ":")
+        ) {
           break;
         } else {
           code += line[j];


### PR DESCRIPTION
`bun run format:check` is red on `main` (94d9cb0), so the `format-lint` job fails on every open PR regardless of its diff. Biome wants the comment-scanner's `else if` condition in `scripts/check-gateway-llm-calls.mjs` wrapped, and the file landed unformatted in #2240/#2246.

This applies the formatter's own output, nothing else:

```js
} else if (
  line.startsWith("//", j) &&
  (j === 0 || line[j - 1] !== ":")
) {
  break;
```

Verified with the same command and config CI runs (`biome format --config-path config/biome.config.json .`, biome 2.4.13): red before, `Checked 510 files ... No fixes applied.` after, and `biome lint` exits 0. `git diff --name-only origin/main...HEAD` is exactly `scripts/check-gateway-llm-calls.mjs`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->