### PR TITLE
fix(worker): stop dead-credential and personal-connection failures from surfacing as raw crashes

### DIFF
--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -211,6 +211,43 @@ describe("classifyError", () => {
     expect(classifyError("not an error")).toBeUndefined();
   });
 
+  test("recognizes a credit/billing-exhausted 400 as quota, not a raw crash", () => {
+    // Observed live: the Anthropic key was present but out of credits. This is
+    // a BILLING-class failure, functionally identical to quota exhaustion, but
+    // it carries no "quota"/"rate limit"/429 token so it fell through to
+    // `undefined` → a raw `💥 Worker crashed: 400 {…}` blob in the user's chat.
+    const raw =
+      '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."}}';
+    expect(classifyError(new Error(raw))).toBe("PROVIDER_QUOTA_EXHAUSTED");
+
+    // Sibling phrasings from other providers.
+    expect(
+      classifyError(new Error("402 Payment Required: insufficient credits"))
+    ).toBe("PROVIDER_QUOTA_EXHAUSTED");
+    expect(
+      classifyError(new Error("Your account has insufficient balance."))
+    ).toBe("PROVIDER_QUOTA_EXHAUSTED");
+    expect(classifyError(new Error("billing_hard_limit_reached"))).toBe(
+      "PROVIDER_QUOTA_EXHAUSTED"
+    );
+  });
+
+  test("recognizes Gemini MALFORMED_FUNCTION_CALL as a provider tool-call failure", () => {
+    expect(
+      classifyError(
+        new Error(
+          "Provider finish_reason: function_call_filter: MALFORMED_FUNCTION_CALL"
+        )
+      )
+    ).toBe("PROVIDER_TOOL_CALL_FAILED");
+    expect(
+      classifyError(new Error("Provider finish_reason: content_filter"))
+    ).toBeUndefined();
+    expect(
+      classifyError(new Error("Provider finish_reason: length"))
+    ).toBeUndefined();
+  });
+
   test("SESSION_TIMEOUT and NO_MODEL_CONFIGURED still classify", () => {
     expect(classifyError(new Error("SESSION_TIMEOUT"))).toBe("SESSION_TIMEOUT");
     expect(classifyError(new Error("No model configured"))).toBe(

--- a/packages/agent-worker/src/__tests__/error-signal-once.test.ts
+++ b/packages/agent-worker/src/__tests__/error-signal-once.test.ts
@@ -132,6 +132,79 @@ describe("signalError is once-per-turn", () => {
     expect(errors[0].error).toBe("second attempt");
   });
 
+  test("two OVERLAPPING signalError calls elect exactly one winner", async () => {
+    // `errorSignalled` is set only AFTER delivery (see the test above), so it
+    // cannot do the election by itself: two calls that both start before the
+    // first POST resolves would both read it as false and both reach the user.
+    // Hold the first request open so the second interleaves inside it.
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    let releaseFirst!: () => void;
+    const firstInFlight = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let requests = 0;
+    globalThis.fetch = (async (
+      ...args: Parameters<typeof globalThis.fetch>
+    ) => {
+      requests += 1;
+      const init = args[1];
+      if (init?.body) sentPayloads.push(JSON.parse(init.body as string));
+      await firstInFlight;
+      return new Response(null, { status: 200 });
+    }) as typeof globalThis.fetch;
+
+    // Both start before ANY response resolves.
+    const first = transport.signalError(new Error("winner"), "PROVIDER_AUTH");
+    const second = transport.signalError(new Error("loser"), "PROVIDER_AUTH");
+
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(requests).toBe(1);
+    const errors = errorPayloads();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toBe("winner");
+  });
+
+  test("an overlapping loser does not latch a FAILED delivery", async () => {
+    // The claim must be released when delivery ultimately fails. Holding it
+    // (like latching too early) would suppress every later attempt and leave
+    // the user with NO terminal error.
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    globalThis.fetch = (async () =>
+      new Response(null, { status: 500 })) as typeof globalThis.fetch;
+
+    const first = transport.signalError(
+      new Error("failed winner"),
+      "PROVIDER_AUTH"
+    );
+    const second = transport.signalError(
+      new Error("dropped loser"),
+      "PROVIDER_AUTH"
+    );
+
+    await expect(first).rejects.toThrow();
+    // The loser is dropped, not surfaced — the winner's caller owns the throw.
+    await second;
+
+    // Gateway recovers; a later signal must still get through.
+    globalThis.fetch = (async (
+      ...args: Parameters<typeof globalThis.fetch>
+    ) => {
+      const init = args[1];
+      if (init?.body) sentPayloads.push(JSON.parse(init.body as string));
+      return new Response(null, { status: 200 });
+    }) as typeof globalThis.fetch;
+
+    await transport.signalError(new Error("retry"), "PROVIDER_AUTH");
+
+    const errors = errorPayloads();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toBe("retry");
+  });
+
   test("a fresh transport (next turn) can signal an error again", async () => {
     const first = new HttpWorkerTransport(baseConfig);
     await first.signalError(new Error("turn-1 failure"), "PROVIDER_AUTH");

--- a/packages/agent-worker/src/__tests__/error-signal-once.test.ts
+++ b/packages/agent-worker/src/__tests__/error-signal-once.test.ts
@@ -102,6 +102,34 @@ describe("signalError is once-per-turn", () => {
     expect(sentPayloads.length).toBeGreaterThan(0);
   });
 
+  test("a FAILED first delivery does not suppress the retry", async () => {
+    // The latch must not swallow the terminal error when the first send never
+    // reached the gateway. `sendResponse` retries internally and throws on
+    // ultimate failure; latching before delivery would leave the user with NO
+    // terminal error at all — worse than the duplicate the latch prevents.
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    globalThis.fetch = (async () =>
+      new Response(null, { status: 500 })) as typeof globalThis.fetch;
+
+    await expect(
+      transport.signalError(new Error("first attempt"), "PROVIDER_AUTH")
+    ).rejects.toThrow();
+
+    // Gateway recovers; the caller's retry must still get through.
+    globalThis.fetch = (async (...args: Parameters<typeof globalThis.fetch>) => {
+      const init = args[1];
+      if (init?.body) sentPayloads.push(JSON.parse(init.body as string));
+      return new Response(null, { status: 200 });
+    }) as typeof globalThis.fetch;
+
+    await transport.signalError(new Error("second attempt"), "PROVIDER_AUTH");
+
+    const errors = errorPayloads();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toBe("second attempt");
+  });
+
   test("a fresh transport (next turn) can signal an error again", async () => {
     const first = new HttpWorkerTransport(baseConfig);
     await first.signalError(new Error("turn-1 failure"), "PROVIDER_AUTH");

--- a/packages/agent-worker/src/__tests__/error-signal-once.test.ts
+++ b/packages/agent-worker/src/__tests__/error-signal-once.test.ts
@@ -117,7 +117,9 @@ describe("signalError is once-per-turn", () => {
     ).rejects.toThrow();
 
     // Gateway recovers; the caller's retry must still get through.
-    globalThis.fetch = (async (...args: Parameters<typeof globalThis.fetch>) => {
+    globalThis.fetch = (async (
+      ...args: Parameters<typeof globalThis.fetch>
+    ) => {
       const init = args[1];
       if (init?.body) sentPayloads.push(JSON.parse(init.body as string));
       return new Response(null, { status: 200 });

--- a/packages/agent-worker/src/__tests__/error-signal-once.test.ts
+++ b/packages/agent-worker/src/__tests__/error-signal-once.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Reproducer: ONE failed turn must produce exactly ONE user-facing error.
+ *
+ * Observed live (Gemini-only deployment, single Telegram DM "what is the
+ * capital of Japan?"): the user received THREE messages for one question —
+ *   1. `401 No provider credentials configured…` + a reconnect CTA
+ *   2. `Tokyo`   (the correct answer — the turn actually SUCCEEDED)
+ *   3. `💥 Worker crashed: Provider finish_reason: … MALFORMED_FUNCTION_CALL`
+ *
+ * Root cause: three independent, uncoordinated emitters each call `signalError`
+ * for the same turn —
+ *   (a) `worker.ts` result-false branch  → handleExecutionError
+ *   (b) `worker.ts` catch branch         → handleExecutionError
+ *   (c) `sse-client.ts` outer catch      → signalError with NO errorCode
+ * Every `signalError` is a terminal POST that the gateway turns into its own
+ * chat message. Unlike the turn-liveness marker election (`failTurnIfPending`),
+ * nothing dedupes these.
+ *
+ * The transport is the single funnel all three pass through, so it is where the
+ * once-per-turn election belongs: the FIRST error wins (it carries the real
+ * classification), later ones are logged and dropped.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { WorkerTransportConfig } from "@lobu/core";
+import { HttpWorkerTransport } from "../gateway/gateway-integration";
+import type { ResponseData } from "../gateway/types";
+
+const baseConfig: WorkerTransportConfig = {
+  gatewayUrl: "https://test-gateway.example.com",
+  workerToken: "test-worker-token",
+  userId: "U123",
+  channelId: "C123",
+  conversationId: "CONV123",
+  originalMessageTs: "1700000000.000100",
+  teamId: "T123",
+  platform: "slack",
+};
+
+let originalFetch: typeof globalThis.fetch;
+let sentPayloads: ResponseData[];
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  sentPayloads = [];
+  globalThis.fetch = (async (...args: Parameters<typeof globalThis.fetch>) => {
+    const init = args[1];
+    if (init?.body) {
+      sentPayloads.push(JSON.parse(init.body as string));
+    }
+    return new Response(null, { status: 200 });
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const errorPayloads = () => sentPayloads.filter((p) => p.error !== undefined);
+
+describe("signalError is once-per-turn", () => {
+  test("a second signalError for the same turn is dropped", async () => {
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    // (a) the real, classified failure the worker detected.
+    await transport.signalError(
+      new Error("401 No provider credentials configured."),
+      "PROVIDER_AUTH",
+      { provider: "gemini", model: "gemini-2.5-flash" }
+    );
+    // (c) sse-client's outer catch re-signals the SAME turn with no code.
+    await transport.signalError(
+      new Error("Provider finish_reason: function_call_filter")
+    );
+
+    const errors = errorPayloads();
+    expect(errors).toHaveLength(1);
+    // The FIRST (classified) error is the one that survives — it carries the
+    // actionable code and CTA context.
+    expect(errors[0].error).toBe("401 No provider credentials configured.");
+    expect(errors[0].errorCode).toBe("PROVIDER_AUTH");
+  });
+
+  test("three emitters still yield exactly one user-facing error", async () => {
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    await transport.signalError(new Error("first"), "PROVIDER_QUOTA_EXHAUSTED");
+    await transport.signalError(new Error("second"));
+    await transport.signalError(new Error("third"), "PROVIDER_AUTH");
+
+    const errors = errorPayloads();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toBe("first");
+  });
+
+  test("a successful turn's completion is unaffected by the error latch", async () => {
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    await transport.signalCompletion();
+    expect(errorPayloads()).toHaveLength(0);
+    // Completion still posted.
+    expect(sentPayloads.length).toBeGreaterThan(0);
+  });
+
+  test("a fresh transport (next turn) can signal an error again", async () => {
+    const first = new HttpWorkerTransport(baseConfig);
+    await first.signalError(new Error("turn-1 failure"), "PROVIDER_AUTH");
+
+    const second = new HttpWorkerTransport(baseConfig);
+    await second.signalError(new Error("turn-2 failure"), "PROVIDER_AUTH");
+
+    const errors = errorPayloads();
+    expect(errors).toHaveLength(2);
+    expect(errors[0].error).toBe("turn-1 failure");
+    expect(errors[1].error).toBe("turn-2 failure");
+  });
+});

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -448,6 +448,24 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     expect(result.modelId).toBe("openai/gpt-4o");
   });
 
+  test("attribution follows the RESOLVED model when the run carries no explicit ref", () => {
+    // The common shape: the run has no per-turn model, so the ref comes from
+    // `defaultModel`. Attribution must read the RESOLVED ref — deriving it from
+    // the raw (empty) argument silently skipped reattribution and reproduced the
+    // exact wrong-provider CTA this fix exists to prevent.
+    const result = resolveModelRef("", {
+      defaultModel: "gemini/gemini-2.5-flash",
+      defaultProvider: "openai",
+      defaultProviderSlug: "openai",
+      defaultProviderServesModel: false,
+      installedProviderRoutes: { openai: "openai", gemini: "gemini" },
+    });
+
+    expect(result.providerSlug).toBe("gemini");
+    // Routing still belongs to the gateway's published provider.
+    expect(result.provider).toBe("openai");
+  });
+
   test("an UNINSTALLED aggregator namespace never owns the CTA", () => {
     // Both gateway facts are required. Here the model was NOT matched
     // (`serves: false`, so the fallback scan picked OpenRouter), but the

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -176,6 +176,10 @@ describe("resolveModelRef", () => {
     });
 
     expect(result.provider).toBe("openrouter");
+    // Regression guard: this case asserted only provider/modelId, so a CTA
+    // misattribution to "openai" passed green here. OpenRouter serves this
+    // model, so OpenRouter owns the CTA.
+    expect(result.providerSlug).toBe("openrouter");
     expect(result.modelId).toBe("openai/gpt-4o");
   });
 
@@ -406,6 +410,11 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     const result = resolveModelRef("gemini/gemini-2.5-flash", {
       defaultProvider: "openai",
       defaultProviderSlug: "openai",
+      // The gateway could NOT match this model to a provider, so its
+      // credentialed-fallback scan published openai. That is exactly what
+      // `defaultProviderServesModel: false` reports — openai does not serve
+      // the requested model, so it must not own the failure CTA.
+      defaultProviderServesModel: false,
       // gemini IS installed here — it just has no usable key, which is why the
       // gateway fell back to publishing openai as defaultProvider.
       installedProviderRoutes: { openai: "openai", gemini: "gemini" },
@@ -418,6 +427,38 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     // OpenRouter-style refs like "anthropic/claude-sonnet-4".
     expect(result.provider).toBe("openai");
     expect(result.modelId).toBe("gemini/gemini-2.5-flash");
+  });
+
+  test("a SERVING provider keeps the CTA even when the prefix names another installed provider", () => {
+    // The mirror of the fallback case above, and why an installed-provider
+    // match cannot decide attribution on its own. OpenRouter is configured AND
+    // serves this model; "openai" here is OpenRouter's vendor namespace, not a
+    // request for the OpenAI provider — even though standalone OpenAI is also
+    // installed and the prefix matches it.
+    const result = resolveModelRef("openai/gpt-4o", {
+      defaultProvider: "openrouter",
+      defaultProviderSlug: "openrouter",
+      // The gateway MATCHED the model to OpenRouter.
+      defaultProviderServesModel: true,
+      installedProviderRoutes: { openai: "openai", openrouter: "openrouter" },
+    });
+
+    expect(result.providerSlug).toBe("openrouter");
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("openai/gpt-4o");
+  });
+
+  test("an older gateway (field absent) keeps the pre-existing attribution", () => {
+    // Back-compat: a gateway that predates `defaultProviderServesModel` sends
+    // nothing. Absent must mean "serves" so a stale gateway keeps today's
+    // behavior instead of acquiring a NEW misattribution.
+    const result = resolveModelRef("openai/gpt-4o", {
+      defaultProvider: "openrouter",
+      defaultProviderSlug: "openrouter",
+      installedProviderRoutes: { openai: "openai", openrouter: "openrouter" },
+    });
+
+    expect(result.providerSlug).toBe("openrouter");
   });
 
   test("a bare model id still inherits the configured default provider", () => {

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -416,6 +416,7 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     // Routing itself is unchanged (the gateway owns that decision) and the ref
     // keeps its namespace — stripping a FOREIGN prefix here would break
     // OpenRouter-style refs like "anthropic/claude-sonnet-4".
+    expect(result.provider).toBe("openai");
     expect(result.modelId).toBe("gemini/gemini-2.5-flash");
   });
 

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -448,6 +448,24 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     expect(result.modelId).toBe("openai/gpt-4o");
   });
 
+  test("an UNINSTALLED aggregator namespace never owns the CTA", () => {
+    // Both gateway facts are required. Here the model was NOT matched
+    // (`serves: false`, so the fallback scan picked OpenRouter), but the
+    // "anthropic" prefix is an OpenRouter vendor namespace — there is no
+    // Anthropic provider installed. Attributing the CTA to it would send the
+    // user to reconnect a provider that does not exist in this deployment.
+    const result = resolveModelRef("anthropic/claude-sonnet-4", {
+      defaultProvider: "openrouter",
+      defaultProviderSlug: "openrouter",
+      defaultProviderServesModel: false,
+      installedProviderRoutes: { openrouter: "openrouter" },
+    });
+
+    expect(result.providerSlug).toBe("openrouter");
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("anthropic/claude-sonnet-4");
+  });
+
   test("an older gateway (field absent) keeps the pre-existing attribution", () => {
     // Back-compat: a gateway that predates `defaultProviderServesModel` sends
     // nothing. Absent must mean "serves" so a stale gateway keeps today's

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -394,6 +394,61 @@ describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
   });
 });
 
+describe("resolveModelRef — providerSlug must describe the REQUESTED model", () => {
+  test("an explicitly-prefixed model keeps its OWN slug, not the default provider's", () => {
+    // Observed live: agent models = ["gemini/gemini-2.5-flash"], but the
+    // session context published defaultProvider="openai" (the gateway's
+    // "first credentialed module" scan). The old code took the
+    // `if (defaultProvider)` branch and returned providerSlug="openai", so the
+    // failure CTA linked to `inference-provider:openai` while the `?model=`
+    // param correctly said `gemini/gemini-2.5-flash` — sending the user to
+    // connect the WRONG provider.
+    const result = resolveModelRef("gemini/gemini-2.5-flash", {
+      defaultProvider: "openai",
+      defaultProviderSlug: "openai",
+    });
+
+    // The CTA must name the provider the run ASKED for.
+    expect(result.providerSlug).toBe("gemini");
+    // Routing itself is unchanged (the gateway owns that decision) and the ref
+    // keeps its namespace — stripping a FOREIGN prefix here would break
+    // OpenRouter-style refs like "anthropic/claude-sonnet-4".
+    expect(result.modelId).toBe("gemini/gemini-2.5-flash");
+  });
+
+  test("a bare model id still inherits the configured default provider", () => {
+    // No slug in the ref → nothing to contradict the default. Unchanged.
+    const result = resolveModelRef("gpt-4.1", {
+      defaultProvider: "openai",
+      defaultProviderSlug: "openai",
+    });
+    expect(result.providerSlug).toBe("openai");
+    expect(result.modelId).toBe("gpt-4.1");
+  });
+
+  test("a foreign namespace slug still routes to the configured provider", () => {
+    // OpenRouter's "anthropic/claude-sonnet-4" means "OpenRouter's anthropic
+    // model", NOT "switch to the anthropic provider". Routing is preserved —
+    // only the CTA slug attribution changed.
+    const result = resolveModelRef("anthropic/claude-sonnet-4", {
+      defaultProvider: "openrouter",
+      defaultProviderSlug: "openrouter",
+    });
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("anthropic/claude-sonnet-4");
+  });
+
+  test("the configured provider's own prefix is still stripped", () => {
+    const result = resolveModelRef("claude/claude-opus-4-8", {
+      defaultProvider: "anthropic",
+      defaultProviderSlug: "claude",
+    });
+    expect(result.provider).toBe("anthropic");
+    expect(result.providerSlug).toBe("claude");
+    expect(result.modelId).toBe("claude-opus-4-8");
+  });
+});
+
 describe("DEFAULT_PROVIDER_BASE_URL_ENV — gateway-slug keying", () => {
   test("gemini base-URL env is keyed by the 'gemini' slug, not 'google'", () => {
     // The gateway emits the provider slug "gemini" (config id) as

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -406,6 +406,9 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     const result = resolveModelRef("gemini/gemini-2.5-flash", {
       defaultProvider: "openai",
       defaultProviderSlug: "openai",
+      // gemini IS installed here — it just has no usable key, which is why the
+      // gateway fell back to publishing openai as defaultProvider.
+      installedProviderRoutes: { openai: "openai", gemini: "gemini" },
     });
 
     // The CTA must name the provider the run ASKED for.
@@ -426,16 +429,31 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     expect(result.modelId).toBe("gpt-4.1");
   });
 
-  test("a foreign namespace slug still routes to the configured provider", () => {
+  test("a provider-INTERNAL namespace keeps the configured provider's slug", () => {
     // OpenRouter's "anthropic/claude-sonnet-4" means "OpenRouter's anthropic
-    // model", NOT "switch to the anthropic provider". Routing is preserved —
-    // only the CTA slug attribution changed.
+    // model", NOT "switch to the anthropic provider". `anthropic` is not an
+    // installed provider here, so the CTA must stay on openrouter — pointing
+    // it at `anthropic` would send the user to a provider this deployment
+    // does not even have.
+    const result = resolveModelRef("anthropic/claude-sonnet-4", {
+      defaultProvider: "openrouter",
+      defaultProviderSlug: "openrouter",
+      installedProviderRoutes: { openrouter: "openrouter" },
+    });
+    expect(result.provider).toBe("openrouter");
+    expect(result.providerSlug).toBe("openrouter");
+    expect(result.modelId).toBe("anthropic/claude-sonnet-4");
+  });
+
+  test("no installedProviderRoutes → keep the default attribution (cannot tell them apart)", () => {
+    // Without the gateway's installed-provider list we cannot distinguish a
+    // real provider request from a provider-internal namespace, so fail safe.
     const result = resolveModelRef("anthropic/claude-sonnet-4", {
       defaultProvider: "openrouter",
       defaultProviderSlug: "openrouter",
     });
     expect(result.provider).toBe("openrouter");
-    expect(result.modelId).toBe("anthropic/claude-sonnet-4");
+    expect(result.providerSlug).toBe("openrouter");
   });
 
   test("the configured provider's own prefix is still stripped", () => {

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -68,12 +68,35 @@ export function classifyError(error: unknown): AgentErrorCode | undefined {
   // Exhausted", generic rate-limit/quota phrasings, and a bare 429. Placed
   // before PROVIDER_AUTH because a rate-limited request can also echo auth-ish
   // words; the quota shape is the more specific, more actionable signal.
+  // Billing/credit exhaustion belongs to the same actionable class as a quota
+  // trip: the key is VALID, the account just can't spend. Anthropic returns it
+  // as a 400 `invalid_request_error` ("Your credit balance is too low…"), which
+  // carries none of the quota vocabulary below — so without this clause it fell
+  // through to `undefined` and surfaced as a raw `💥 Worker crashed: 400 {…}`
+  // JSON blob in the user's chat.
+  if (
+    /credit balance is too low|insufficient (?:credits?|balance|funds|quota)\b|billing_hard_limit_reached|payment required|exceeded your current quota|out of credits?\b/i.test(
+      message
+    )
+  )
+    return AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED;
+
   if (
     /weekly\/monthly limit exhausted|limit exhausted|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
       message
     )
   )
     return AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED;
+
+  // Gemini can end a turn with this provider-side tool-call rejection instead
+  // of a usable stop reason. Keep the match specific: other finish reasons can
+  // describe different failures and must not inherit this remediation text.
+  if (
+    /^Provider finish_reason:\s*function_call_filter:\s*MALFORMED_FUNCTION_CALL\b/i.test(
+      message
+    )
+  )
+    return AgentErrorCode.PROVIDER_TOOL_CALL_FAILED;
 
   if (
     message.includes("No model configured") ||

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -50,6 +50,17 @@ export class HttpWorkerTransport implements WorkerTransport {
    * tool without a separate durable ledger.
    */
   private toolsUsed = new Set<string>();
+  /**
+   * Once-per-turn latch for user-facing errors. Three uncoordinated emitters
+   * can report the SAME failed turn — `worker.ts`'s result-false branch,
+   * `worker.ts`'s catch branch, and `sse-client.ts`'s outer catch — and every
+   * `signalError` is a terminal POST the gateway turns into its own chat
+   * message. That is how one Telegram question produced a 401 CTA, an answer,
+   * and a crash blob. The FIRST error wins: it carries the real classification
+   * (later re-signals are typically code-less). This transport is per-turn, so
+   * a new turn starts unlatched.
+   */
+  private errorSignalled = false;
 
   constructor(config: WorkerTransportConfig) {
     this.gatewayUrl = config.gatewayUrl;
@@ -207,6 +218,19 @@ export class HttpWorkerTransport implements WorkerTransport {
     errorCode?: string,
     errorContext?: AgentErrorContext
   ): Promise<void> {
+    // Drop every error after the first for this turn. Keep the detail in the
+    // logs — the suppressed one is often the more specific provider string, and
+    // losing it silently is what made these turns undiagnosable.
+    if (this.errorSignalled) {
+      logger.warn(
+        `[WORKER-HTTP] Suppressing duplicate error signal for this turn (code=${
+          errorCode ?? "none"
+        }): ${error.message}`
+      );
+      return;
+    }
+    this.errorSignalled = true;
+
     await this.sendResponse(
       this.buildBaseResponse({
         error: error.message,

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -229,8 +229,11 @@ export class HttpWorkerTransport implements WorkerTransport {
       );
       return;
     }
-    this.errorSignalled = true;
-
+    // Latch only AFTER the terminal response is actually delivered.
+    // `sendResponse` retries internally and throws when it ultimately fails;
+    // latching before it would make a failed first delivery permanently
+    // suppress every later attempt, so the user would get NO terminal error at
+    // all — strictly worse than the duplicate this latch exists to prevent.
     await this.sendResponse(
       this.buildBaseResponse({
         error: error.message,
@@ -240,6 +243,7 @@ export class HttpWorkerTransport implements WorkerTransport {
         ...(errorContext && { errorContext }),
       })
     );
+    this.errorSignalled = true;
   }
 
   async sendStatusUpdate(elapsedSeconds: number, state: string): Promise<void> {

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -61,6 +61,15 @@ export class HttpWorkerTransport implements WorkerTransport {
    * a new turn starts unlatched.
    */
   private errorSignalled = false;
+  /**
+   * The in-flight terminal error delivery, claimed BEFORE the first await.
+   * `errorSignalled` cannot elect the winner on its own: it is set only after
+   * `sendResponse` resolves (deliberately — see `signalError`), so two
+   * overlapping callers would both pass the latch check and both POST, which is
+   * the duplicate this latch exists to prevent. Cleared when delivery fails so
+   * a later signal can still retry.
+   */
+  private errorSignalInFlight?: Promise<void>;
 
   constructor(config: WorkerTransportConfig) {
     this.gatewayUrl = config.gatewayUrl;
@@ -221,7 +230,7 @@ export class HttpWorkerTransport implements WorkerTransport {
     // Drop every error after the first for this turn. Keep the detail in the
     // logs — the suppressed one is often the more specific provider string, and
     // losing it silently is what made these turns undiagnosable.
-    if (this.errorSignalled) {
+    if (this.errorSignalled || this.errorSignalInFlight) {
       logger.warn(
         `[WORKER-HTTP] Suppressing duplicate error signal for this turn (code=${
           errorCode ?? "none"
@@ -229,12 +238,11 @@ export class HttpWorkerTransport implements WorkerTransport {
       );
       return;
     }
-    // Latch only AFTER the terminal response is actually delivered.
-    // `sendResponse` retries internally and throws when it ultimately fails;
-    // latching before it would make a failed first delivery permanently
-    // suppress every later attempt, so the user would get NO terminal error at
-    // all — strictly worse than the duplicate this latch exists to prevent.
-    await this.sendResponse(
+    // Claim the turn BEFORE the first await. There is no await between the
+    // check above and this assignment, so the claim is atomic against another
+    // `signalError` interleaving here — without it, two concurrent callers both
+    // see an unset `errorSignalled` and both post a user-facing error.
+    const delivery = this.sendResponse(
       this.buildBaseResponse({
         error: error.message,
         processedMessageIds: this.processedMessageIds,
@@ -243,6 +251,19 @@ export class HttpWorkerTransport implements WorkerTransport {
         ...(errorContext && { errorContext }),
       })
     );
+    this.errorSignalInFlight = delivery;
+    try {
+      await delivery;
+    } catch (err) {
+      // Release the claim so a later signal can retry. `sendResponse` retries
+      // internally and throws when it ultimately fails; holding the claim (or
+      // latching) here would permanently suppress every later attempt, so the
+      // user would get NO terminal error at all — strictly worse than the
+      // duplicate this latch exists to prevent.
+      this.errorSignalInFlight = undefined;
+      throw err;
+    }
+    // Latch only AFTER the terminal response is actually delivered.
     this.errorSignalled = true;
   }
 

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -319,45 +319,39 @@ export function resolveModelRef(
       modelId = modelId.slice(defaultProviderSlug.length + 1);
     }
     // `providerSlug` targets the failure CTA ("Reconnect provider"), so it must
-    // name the provider the RUN ACTUALLY ASKED FOR, not whichever module the
-    // gateway happened to publish as `defaultProvider`. When the gateway can't
-    // match a module to the requested model it falls back to the first
-    // credentialed one (`gateway/index.ts`, the `if (!primaryProvider)` scan),
-    // so an agent pinned to `gemini/gemini-2.5-flash` on a deployment where only
-    // OpenAI is credentialed emitted a CTA pointing at
-    // `inference-provider:openai` while `?model=` correctly said `gemini/…` —
-    // sending the user to connect the WRONG provider.
+    // name the provider the run ASKED FOR — not whichever module the gateway
+    // published as `defaultProvider` via its credentialed-fallback scan
+    // (`gateway/index.ts`, `if (!primaryProvider)`). Routing (`provider`) and
+    // `modelId` are untouched.
     //
-    // Only the CTA attribution changes: `provider` (the routing decision) and
-    // `modelId` (the self-prefix strip above) are untouched, so OpenRouter-style
-    // foreign namespaces still route to the configured provider.
+    // Reattribute only when all three hold, because each alone misfires:
+    //   1. `modelId === modelRef` — the self-prefix strip above did not consume
+    //      the prefix, so the name is genuinely foreign.
+    //   2. `defaultProviderServesModel === false` — the gateway did not match
+    //      the model to `defaultProvider`. Without it, OpenRouter's own vendor
+    //      namespace ("openai/gpt-4o") would blame `openai`.
+    //   3. the prefix names an INSTALLED provider — otherwise it is an
+    //      aggregator namespace ("anthropic/…" with no Anthropic installed) and
+    //      the CTA would point at a provider absent from this deployment.
     //
-    // `modelId === modelRef` means the strip above did NOT consume the prefix,
-    // so the name is genuinely foreign rather than the provider's own id.
-    //
-    // Reattributing needs BOTH gateway facts, because each alone misfires:
-    //
-    // - `defaultProviderServesModel === false` — the gateway did not match this
-    //   model to `defaultProvider`; the credentialed-fallback scan picked it.
-    //   Without this, OpenRouter's vendor namespace ("openai/gpt-4o" while
-    //   OpenRouter serves it) would blame `openai`.
-    // - the prefix names an INSTALLED provider — otherwise the prefix is just a
-    //   namespace inside an aggregator ("anthropic/claude-sonnet-4" on a
-    //   deployment with no Anthropic provider) and the CTA would point at a
-    //   provider that does not exist here.
-    //
-    // Only when both hold is the prefix a real, reachable provider the user
-    // actually asked for. Absent `defaultProviderServesModel` (older gateway)
-    // keeps the pre-existing attribution rather than acquiring a new one.
+    // Absent `defaultProviderServesModel` (older gateway) keeps the
+    // pre-existing attribution rather than acquiring a new misattribution.
+    // Derived from the RESOLVED `modelRef`, not `normalizedRaw`: when the run
+    // carries no explicit model the ref comes from `defaultModel`, and
+    // `explicitParts` (which exists to gate behavior-override ROUTING on an
+    // explicit request) is empty — so attribution would silently fall back to
+    // the serving provider and reproduce the very bug this fixes.
+    const attributionParts = modelRef.split("/").filter(Boolean);
+    const attributionProvider = attributionParts[0];
     const requestedForeignSlug =
-      explicitParts.length >= 2 &&
-      explicitProvider &&
-      explicitProvider !== defaultProvider &&
-      explicitProvider !== defaultProviderSlug &&
+      attributionParts.length >= 2 &&
+      attributionProvider &&
+      attributionProvider !== defaultProvider &&
+      attributionProvider !== defaultProviderSlug &&
       modelId === modelRef &&
       overrides?.defaultProviderServesModel === false &&
-      overrides?.installedProviderRoutes?.[explicitProvider]
-        ? explicitProvider
+      overrides?.installedProviderRoutes?.[attributionProvider]
+        ? attributionProvider
         : undefined;
 
     return {

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -312,9 +312,35 @@ export function resolveModelRef(
     ) {
       modelId = modelId.slice(defaultProviderSlug.length + 1);
     }
+    // `providerSlug` targets the failure CTA ("Reconnect provider"), so it must
+    // name the provider the RUN ACTUALLY ASKED FOR, not whichever module the
+    // gateway happened to publish as `defaultProvider`. When the gateway can't
+    // match a module to the requested model it falls back to the first
+    // credentialed one (`gateway/index.ts`, the `if (!primaryProvider)` scan),
+    // so an agent pinned to `gemini/gemini-2.5-flash` on a deployment where only
+    // OpenAI is credentialed emitted a CTA pointing at
+    // `inference-provider:openai` while `?model=` correctly said `gemini/…` —
+    // sending the user to connect the WRONG provider.
+    //
+    // Only the CTA attribution changes: `provider` (the routing decision) and
+    // `modelId` (the self-prefix strip above) are untouched, so OpenRouter-style
+    // foreign namespaces still route to the configured provider.
+    //
+    // `modelId === modelRef` means the strip above did NOT consume the prefix,
+    // so the name is genuinely foreign rather than the provider's own id.
+    const requestedForeignSlug =
+      explicitParts.length >= 2 &&
+      explicitProvider &&
+      explicitProvider !== defaultProvider &&
+      explicitProvider !== defaultProviderSlug &&
+      modelId === modelRef
+        ? explicitProvider
+        : undefined;
+
     return {
       provider: defaultProvider,
-      providerSlug: defaultProviderSlug || defaultProvider,
+      providerSlug:
+        requestedForeignSlug ?? (defaultProviderSlug || defaultProvider),
       modelId,
     };
   }

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -328,12 +328,22 @@ export function resolveModelRef(
     //
     // `modelId === modelRef` means the strip above did NOT consume the prefix,
     // so the name is genuinely foreign rather than the provider's own id.
+    //
+    // The prefix must ALSO name a real INSTALLED provider. Without that check a
+    // provider-internal namespace is misread as a provider request:
+    // OpenRouter's "anthropic/claude-sonnet-4" means "OpenRouter's anthropic
+    // model", not "the Anthropic provider", and attributing the CTA to
+    // `anthropic` would point the user at a provider this deployment may not
+    // even have. `installedProviderRoutes` is the gateway's own list of
+    // installed provider slugs, so it is the authority on that distinction —
+    // absent it we cannot tell the two apart and keep the default attribution.
     const requestedForeignSlug =
       explicitParts.length >= 2 &&
       explicitProvider &&
       explicitProvider !== defaultProvider &&
       explicitProvider !== defaultProviderSlug &&
-      modelId === modelRef
+      modelId === modelRef &&
+      !!overrides?.installedProviderRoutes?.[explicitProvider]
         ? explicitProvider
         : undefined;
 

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -209,6 +209,12 @@ export function resolveModelRef(
     defaultProviderSlug?: string;
     installedProviderRoutes?: Record<string, string>;
     allowInstalledProviderOverride?: boolean;
+    /**
+     * Gateway-supplied: did `defaultProvider` actually MATCH the requested
+     * model, or was it fallback-picked? Drives failure-CTA attribution only —
+     * never routing. Absent (older gateway) is treated as "serves".
+     */
+    defaultProviderServesModel?: boolean;
   }
 ): {
   provider: string;
@@ -329,21 +335,30 @@ export function resolveModelRef(
     // `modelId === modelRef` means the strip above did NOT consume the prefix,
     // so the name is genuinely foreign rather than the provider's own id.
     //
-    // The prefix must ALSO name a real INSTALLED provider. Without that check a
-    // provider-internal namespace is misread as a provider request:
-    // OpenRouter's "anthropic/claude-sonnet-4" means "OpenRouter's anthropic
-    // model", not "the Anthropic provider", and attributing the CTA to
-    // `anthropic` would point the user at a provider this deployment may not
-    // even have. `installedProviderRoutes` is the gateway's own list of
-    // installed provider slugs, so it is the authority on that distinction —
-    // absent it we cannot tell the two apart and keep the default attribution.
+    // A slash prefix alone cannot decide this, and neither can the installed
+    // provider list: with OpenRouter configured and standalone OpenAI also
+    // installed, "openai/gpt-4o" is OpenRouter's VENDOR NAMESPACE, yet the
+    // prefix does name an installed provider. Blaming `openai` there would send
+    // the user to reconnect a provider that is not even serving the request.
+    //
+    // Only the gateway can tell the two apart, and it already knows:
+    // `findProviderForModel` either MATCHED the model to `defaultProvider`
+    // (OpenRouter serves "openai/gpt-4o" → blame OpenRouter) or returned
+    // nothing, leaving the credentialed-fallback scan to pick an unrelated
+    // provider ("gemini/gemini-2.5-flash" with a fallback-selected openai →
+    // blame gemini, the provider actually requested). It publishes that fact as
+    // `defaultProviderServesModel`.
+    //
+    // Older gateways omit the field. Treat absent as "serves" — that is the
+    // pre-existing attribution, so a stale gateway keeps today's behavior
+    // rather than acquiring a new misattribution.
     const requestedForeignSlug =
       explicitParts.length >= 2 &&
       explicitProvider &&
       explicitProvider !== defaultProvider &&
       explicitProvider !== defaultProviderSlug &&
       modelId === modelRef &&
-      overrides?.installedProviderRoutes?.[explicitProvider]
+      overrides?.defaultProviderServesModel === false
         ? explicitProvider
         : undefined;
 

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -343,7 +343,7 @@ export function resolveModelRef(
       explicitProvider !== defaultProvider &&
       explicitProvider !== defaultProviderSlug &&
       modelId === modelRef &&
-      !!overrides?.installedProviderRoutes?.[explicitProvider]
+      overrides?.installedProviderRoutes?.[explicitProvider]
         ? explicitProvider
         : undefined;
 

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -335,30 +335,28 @@ export function resolveModelRef(
     // `modelId === modelRef` means the strip above did NOT consume the prefix,
     // so the name is genuinely foreign rather than the provider's own id.
     //
-    // A slash prefix alone cannot decide this, and neither can the installed
-    // provider list: with OpenRouter configured and standalone OpenAI also
-    // installed, "openai/gpt-4o" is OpenRouter's VENDOR NAMESPACE, yet the
-    // prefix does name an installed provider. Blaming `openai` there would send
-    // the user to reconnect a provider that is not even serving the request.
+    // Reattributing needs BOTH gateway facts, because each alone misfires:
     //
-    // Only the gateway can tell the two apart, and it already knows:
-    // `findProviderForModel` either MATCHED the model to `defaultProvider`
-    // (OpenRouter serves "openai/gpt-4o" → blame OpenRouter) or returned
-    // nothing, leaving the credentialed-fallback scan to pick an unrelated
-    // provider ("gemini/gemini-2.5-flash" with a fallback-selected openai →
-    // blame gemini, the provider actually requested). It publishes that fact as
-    // `defaultProviderServesModel`.
+    // - `defaultProviderServesModel === false` — the gateway did not match this
+    //   model to `defaultProvider`; the credentialed-fallback scan picked it.
+    //   Without this, OpenRouter's vendor namespace ("openai/gpt-4o" while
+    //   OpenRouter serves it) would blame `openai`.
+    // - the prefix names an INSTALLED provider — otherwise the prefix is just a
+    //   namespace inside an aggregator ("anthropic/claude-sonnet-4" on a
+    //   deployment with no Anthropic provider) and the CTA would point at a
+    //   provider that does not exist here.
     //
-    // Older gateways omit the field. Treat absent as "serves" — that is the
-    // pre-existing attribution, so a stale gateway keeps today's behavior
-    // rather than acquiring a new misattribution.
+    // Only when both hold is the prefix a real, reachable provider the user
+    // actually asked for. Absent `defaultProviderServesModel` (older gateway)
+    // keeps the pre-existing attribution rather than acquiring a new one.
     const requestedForeignSlug =
       explicitParts.length >= 2 &&
       explicitProvider &&
       explicitProvider !== defaultProvider &&
       explicitProvider !== defaultProviderSlug &&
       modelId === modelRef &&
-      overrides?.defaultProviderServesModel === false
+      overrides?.defaultProviderServesModel === false &&
+      overrides?.installedProviderRoutes?.[explicitProvider]
         ? explicitProvider
         : undefined;
 

--- a/packages/agent-worker/src/runtime/session-context.ts
+++ b/packages/agent-worker/src/runtime/session-context.ts
@@ -34,6 +34,12 @@ interface ProviderConfig {
   configProviders?: Record<string, ConfigProviderMeta>;
   /** Installed Lobu provider ID → upstream runtime provider slug. */
   installedProviderRoutes?: Record<string, string>;
+  /**
+   * True when the gateway MATCHED `defaultProvider` to the agent's model;
+   * false when it was picked by the credentialed-fallback scan and therefore
+   * does not serve the requested model. Absent on older gateways.
+   */
+  defaultProviderServesModel?: boolean;
   /** Credential env var placeholders for proxy mode (e.g. Z_AI_API_KEY → "lobu-proxy") */
   credentialPlaceholders?: Record<string, string>;
 }

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -753,6 +753,7 @@ export async function runAISession(
     defaultProviderSlug: pc.defaultProviderSlug,
     installedProviderRoutes: pc.installedProviderRoutes,
     allowInstalledProviderOverride: rawOptions.behaviorModelOverride === true,
+    defaultProviderServesModel: pc.defaultProviderServesModel,
   });
   // Map gateway slug to model-registry provider name (e.g. "z-ai" → "zai")
   const provider = PROVIDER_REGISTRY_ALIASES[rawProvider] || rawProvider;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -186,6 +186,14 @@ export enum AgentErrorCode {
    * with remediation steps, not a transient user error.
    */
   WORKER_SANDBOX_REQUIRED = "WORKER_SANDBOX_REQUIRED",
+  /**
+   * The provider aborted the turn on its own tool-call filter rather than
+   * returning a usable stop reason — e.g. Gemini's
+   * `finish_reason: function_call_filter: MALFORMED_FUNCTION_CALL`. A
+   * provider-side, usually transient condition: nothing about the agent's
+   * config is wrong, so it must not render as a worker crash.
+   */
+  PROVIDER_TOOL_CALL_FAILED = "PROVIDER_TOOL_CALL_FAILED",
   /** Session exceeded its time budget (exit 124); retried silently. */
   SESSION_TIMEOUT = "SESSION_TIMEOUT",
 }
@@ -254,6 +262,15 @@ export const AGENT_ERRORS: Record<AgentErrorCode, AgentErrorSpec> = {
   [AgentErrorCode.PROVIDER_BASE_URL_UNRESOLVED]: {
     cta: "provider-management",
     ctaLabel: "Manage provider",
+  },
+  // The provider's own finish_reason string is not useful to an end user
+  // ("function_call_filter: MALFORMED_FUNCTION_CALL"), so unlike the other
+  // PROVIDER_* entries this one carries its own text and does NOT relay the
+  // upstream blob. The raw message stays in the logs / Sentry.
+  [AgentErrorCode.PROVIDER_TOOL_CALL_FAILED]: {
+    message:
+      "The model provider rejected its own tool call and ended the turn. This is usually temporary — please try again.",
+    cta: "none",
   },
   // Errors we synthesize — carry our own text (no provider string to relay).
   [AgentErrorCode.NO_MODEL_CONFIGURED]: {

--- a/packages/server/src/__tests__/integration/connectors/oauth-env-app-creds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/oauth-env-app-creds.test.ts
@@ -264,6 +264,40 @@ describe('connector OAuth connect — env-backed app credentials (DB-backed)', (
     expect(resolved.clientSecret).toBe('env-client-secret');
   });
 
+  it('creates a new OAuth connection private from the start and explains its agent-owner scope', async () => {
+    process.env[CLIENT_ID_KEY] = 'env-client-id';
+    process.env[CLIENT_SECRET_KEY] = 'env-client-secret';
+
+    const org = await createTestOrganization({ name: 'OAuth Scope Org' });
+    const user = await createTestUser({ name: 'OAuth Scope User' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const ctx = ctxFor(org.id, user.id);
+    await makeOAuthConnector(org.id);
+
+    const result = await manageConnections(
+      { action: 'connect', connector_key: 'demoenv.oauth' },
+      TEST_ENV,
+      ctx
+    );
+
+    expect(result).toMatchObject({
+      action: 'connect',
+      status: 'pending_auth',
+      auth_type: 'oauth',
+      instructions: expect.stringContaining('AGENT OWNER'),
+    });
+    const connectionId =
+      'connection_id' in result ? Number(result.connection_id) : 0;
+    expect(connectionId).toBeGreaterThan(0);
+
+    const [row] = (await getTestDb()`
+      SELECT status, visibility
+      FROM connections
+      WHERE id = ${connectionId}
+    `) as Array<{ status: string; visibility: string }>;
+    expect(row).toEqual({ status: 'pending_auth', visibility: 'private' });
+  });
+
   it('still requires an app profile when NO env client creds are set (no silent bypass)', async () => {
     // Ensure the env vars are absent for this case.
     delete process.env[CLIENT_ID_KEY];

--- a/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
@@ -262,6 +262,35 @@ describe("ChatResponseBridge.handleDelta — AsyncIterable streaming", () => {
     expect(plainPosts).toEqual([]);
   });
 
+  test("handleError renders PROVIDER_TOOL_CALL_FAILED as catalog text, never the raw provider blob", async () => {
+    // Seen live on Telegram: a Gemini turn that ends with
+    // `function_call_filter: MALFORMED_FUNCTION_CALL` reached the user as a raw
+    // `💥 Worker crashed: Provider finish_reason: …` blob. The worker now
+    // classifies it, so this bridge — the ONE place a coded error becomes
+    // Telegram/Slack output — must swap in the catalog sentence and drop the
+    // provider's own unusable finish_reason string entirely.
+    const { target, plainPosts } = createStreamingTarget();
+    const { manager } = createHarness(target);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    await bridge.handleError(
+      {
+        ...basePayload,
+        error:
+          "Provider finish_reason: function_call_filter: MALFORMED_FUNCTION_CALL",
+        errorCode: "PROVIDER_TOOL_CALL_FAILED",
+      },
+      "s"
+    );
+
+    const posted = plainPosts.map((p) => String(p)).join("\n");
+    expect(posted).toContain("rejected its own tool call");
+    // The three fragments of the raw blob a user must never see.
+    expect(posted).not.toContain("MALFORMED_FUNCTION_CALL");
+    expect(posted).not.toContain("finish_reason");
+    expect(posted).not.toContain("Worker crashed");
+  });
+
   test("isFullReplacement closes prior stream and opens a new one", async () => {
     const { target } = createStreamingTarget();
     const { manager } = createHarness(target);

--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -306,15 +306,12 @@ describe("worker model fallback (real DB, both channels)", () => {
     // so the CTA stays here even when the model's prefix names some OTHER
     // installed provider (OpenRouter's "openai/gpt-4o" vendor namespace).
     //
-    // NOTE on the false branch: no fixture here reaches it, and that appears to
-    // be by design rather than a coverage gap. `resolveDispatchModel` fails
-    // closed — an unroutable ref is either replaced by the first routable one
-    // or resolves to undefined, in which case resolveProviderConfig returns {}
-    // and publishes NO provider at all. So via /session-context the gateway
-    // does not appear to publish a defaultProvider that fails to serve its
-    // model. The worker still handles `false` (older-gateway/other-caller
-    // safety, covered in model-resolver.test.ts), but asserting it here would
-    // require a state this endpoint does not seem to produce.
+    // With models PINNED (as here) the allow-list path applies and
+    // `resolveDispatchModel` fails closed, so an unroutable ref is replaced or
+    // yields no provider at all — this branch always sees a matched provider.
+    // The false branch is reached via the ALLOW-ALL path instead (no pinned
+    // models ⇒ `allowedRefs === null` ⇒ no routability check); see the
+    // fallback-picked test below.
     const sql = getDb();
     await sql`DELETE FROM inference_providers WHERE organization_id = ${ORG}`;
     await createInferenceProvider({

--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -93,6 +93,32 @@ async function sessionContextModel(
   return body.providerConfig?.defaultModel;
 }
 
+/**
+ * Full providerConfig from /session-context. `sessionContextModel` above reads
+ * only `defaultModel`; CTA attribution needs the provider fields too.
+ */
+async function sessionContextProviderConfig(gateway: WorkerGateway): Promise<{
+  defaultProvider?: string;
+  defaultProviderServesModel?: boolean;
+}> {
+  const token = generateWorkerToken("user-1", "conv-1", "worker-a", {
+    channelId: "channel-1",
+    agentId: AGENT,
+    organizationId: ORG,
+  });
+  const res = await gateway.getApp().request("/session-context", {
+    headers: { authorization: `Bearer ${token}`, host: "gateway.example.com" },
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as {
+    providerConfig?: {
+      defaultProvider?: string;
+      defaultProviderServesModel?: boolean;
+    };
+  };
+  return body.providerConfig ?? {};
+}
+
 describe("worker model fallback (real DB, both channels)", () => {
   beforeAll(async () => {
     await ensureDbForGatewayTests();
@@ -270,6 +296,68 @@ describe("worker model fallback (real DB, both channels)", () => {
 
     // The real routable ref is published — NOT undefined, NOT the sentinel.
     expect(await sessionContextModel(gateway)).toBe("byo2/byo2-model");
+  });
+
+  test("CTA attribution: a model-MATCHED provider publishes defaultProviderServesModel=true", async () => {
+    // `defaultProviderServesModel` tells the worker whether the published
+    // `defaultProvider` was MATCHED to the model (findProviderForModel) or
+    // merely picked by the credentialed-fallback scan. The worker gates failure
+    // CTA attribution on it: true means this provider genuinely serves the ref,
+    // so the CTA stays here even when the model's prefix names some OTHER
+    // installed provider (OpenRouter's "openai/gpt-4o" vendor namespace).
+    //
+    // NOTE on the false branch: no fixture here reaches it, and that appears to
+    // be by design rather than a coverage gap. `resolveDispatchModel` fails
+    // closed — an unroutable ref is either replaced by the first routable one
+    // or resolves to undefined, in which case resolveProviderConfig returns {}
+    // and publishes NO provider at all. So via /session-context the gateway
+    // does not appear to publish a defaultProvider that fails to serve its
+    // model. The worker still handles `false` (older-gateway/other-caller
+    // safety, covered in model-resolver.test.ts), but asserting it here would
+    // require a state this endpoint does not seem to produce.
+    const sql = getDb();
+    await sql`DELETE FROM inference_providers WHERE organization_id = ${ORG}`;
+    await createInferenceProvider({
+      organizationId: ORG,
+      slug: "byo2",
+      kind: "openai",
+      apiKey: "sk-byo2",
+      capabilities: {
+        text: { base_url: "https://api.byo2.example.com", model: "byo2-model" },
+      },
+    });
+    await setInferenceProviderDefault(ORG, "byo2");
+
+    const settings = {
+      getSettings: async () => ({ models: ["byo2/byo2-model"] }),
+    } as any;
+    const catalog = new ProviderCatalogService(
+      settings,
+      { getBestProfile: async () => null } as any,
+      (org: string) => listInferenceProviders(org),
+      () => {},
+    );
+    const gateway = new WorkerGateway(
+      { send: async () => undefined } as any,
+      "https://gateway.example.com",
+      { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
+      {
+        getSessionContext: async () => ({
+          agentInstructions: "",
+          platformInstructions: "",
+          networkInstructions: "",
+          skillsInstructions: "",
+          mcpStatus: [],
+        }),
+      } as any,
+      undefined,
+      catalog,
+      settings,
+    );
+
+    const pc = await sessionContextProviderConfig(gateway);
+    expect(pc.defaultProvider).toBe("byo2");
+    expect(pc.defaultProviderServesModel).toBe(true);
   });
 
   test("R5 #4: an ORGLESS worker token publishes NO model for a db-backed shared id (no cross-org read)", async () => {

--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -360,6 +360,72 @@ describe("worker model fallback (real DB, both channels)", () => {
     expect(pc.defaultProviderServesModel).toBe(true);
   });
 
+  test("CTA attribution: a FALLBACK-picked provider publishes defaultProviderServesModel=false", async () => {
+    // The live wrong-provider shape. The agent pins NO models, so the policy is
+    // ALLOW-ALL (`allowedRefs === null`) and `enforceModelAllowList` returns the
+    // requested ref VERBATIM with no routability check — the one path where an
+    // unroutable model survives to resolveProviderConfig instead of being
+    // replaced or failing closed.
+    //
+    // The org default names "gemini", which has no installed module here, so
+    // findProviderForModel matches nothing and the credentialed-fallback scan
+    // publishes byo2 — a provider that does NOT serve the requested model.
+    // Without the false, the worker would pin the failure CTA on byo2 and tell
+    // the user to reconnect a provider they never asked for.
+    const sql = getDb();
+    await sql`DELETE FROM inference_providers WHERE organization_id = ${ORG}`;
+    await createInferenceProvider({
+      organizationId: ORG,
+      slug: "byo2",
+      kind: "openai",
+      apiKey: "sk-byo2",
+      capabilities: {
+        text: { base_url: "https://api.byo2.example.com", model: "byo2-model" },
+      },
+    });
+    // A SECOND org row whose slug is "gemini" with NO custom text upstream:
+    // synthesizeOrgProviderModule returns null for it, so it contributes no
+    // module — yet it IS the org default, so it supplies the requested ref.
+    await createInferenceProvider({
+      organizationId: ORG,
+      slug: "gemini",
+      kind: "gemini",
+      apiKey: "sk-gemini",
+      capabilities: { text: { model: "gemini-2.5-flash" } },
+    });
+    await setInferenceProviderDefault(ORG, "gemini");
+
+    // models: [] ⇒ allow-all. The org default supplies the requested ref.
+    const settings = { getSettings: async () => ({ models: [] }) } as any;
+    const catalog = new ProviderCatalogService(
+      settings,
+      { getBestProfile: async () => null } as any,
+      (org: string) => listInferenceProviders(org),
+      () => {},
+    );
+    const gateway = new WorkerGateway(
+      { send: async () => undefined } as any,
+      "https://gateway.example.com",
+      { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
+      {
+        getSessionContext: async () => ({
+          agentInstructions: "",
+          platformInstructions: "",
+          networkInstructions: "",
+          skillsInstructions: "",
+          mcpStatus: [],
+        }),
+      } as any,
+      undefined,
+      catalog,
+      settings,
+    );
+
+    const pc = await sessionContextProviderConfig(gateway);
+    expect(pc.defaultProvider).toBe("byo2");
+    expect(pc.defaultProviderServesModel).toBe(false);
+  });
+
   test("R5 #4: an ORGLESS worker token publishes NO model for a db-backed shared id (no cross-org read)", async () => {
     // A shared id (lobu-builder) exists in many orgs. An orgless token must NOT
     // cause session-context to id-only read ANOTHER org's models[0] and PUBLISH

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -912,6 +912,8 @@ export class WorkerGateway {
     credentialEnvVarName?: string;
     defaultProvider?: string;
     defaultProviderSlug?: string;
+    /** True when defaultProvider was MATCHED to the model, not fallback-picked. */
+    defaultProviderServesModel?: boolean;
     defaultModel?: string;
     cliBackends?: Array<{
       providerId: string;
@@ -960,6 +962,16 @@ export class WorkerGateway {
           effectiveProviders
         )
       : undefined;
+
+    // Whether `primaryProvider` was MATCHED to the agent's model, as opposed to
+    // picked by the credentialed-fallback scan below. Only the gateway knows
+    // this: downstream, a matched provider and a fallback one look identical.
+    // The worker needs it to attribute failure CTAs, because a slash prefix is
+    // ambiguous on its own — "openai/gpt-4o" under OpenRouter is OpenRouter's
+    // vendor namespace (matched → blame OpenRouter), while
+    // "gemini/gemini-2.5-flash" under a fallback-selected openai is a genuine
+    // request for gemini (unmatched → blame gemini, not the fallback).
+    const defaultProviderServesModel = !!primaryProvider;
 
     if (!primaryProvider) {
       for (const candidate of effectiveProviders) {
@@ -1039,6 +1051,8 @@ export class WorkerGateway {
       credentialEnvVarName?: string;
       defaultProvider?: string;
       defaultProviderSlug?: string;
+      /** True when defaultProvider was MATCHED to the model, not fallback-picked. */
+      defaultProviderServesModel?: boolean;
       defaultModel?: string;
       cliBackends?: typeof cliBackends;
       providerBaseUrlMappings?: Record<string, string>;
@@ -1061,6 +1075,8 @@ export class WorkerGateway {
       if (upstream?.slug && upstream.slug !== primaryProvider.providerId) {
         result.defaultProviderSlug = primaryProvider.providerId;
       }
+      // Only meaningful alongside a published defaultProvider.
+      result.defaultProviderServesModel = defaultProviderServesModel;
     }
 
     // Only an explicitly configured model is used — Lobu no longer silently

--- a/packages/server/src/tools/admin/helpers/__tests__/personal-connection-scope-warning.test.ts
+++ b/packages/server/src/tools/admin/helpers/__tests__/personal-connection-scope-warning.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Gap 2: a personal OAuth connection is created successfully and is then
+ * SILENTLY unreachable to agents owned by someone else.
+ *
+ * Chat runs resolve connections as the AGENT OWNER
+ * (`workspace/multi-tenant.ts` → `owner_user_id FROM agents`), while a private
+ * connection is visible only via `created_by = principal`
+ * (`authz/connection-visibility.ts`). A personal credential is FORCED private,
+ * so a DM user's own Gmail yields a healthy-looking row whose runtime lookup
+ * returns ZERO ROWS rather than an error.
+ *
+ * Forcing `private` is correct and unchanged; this only makes it legible.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { personalConnectionScopeWarning } from '../connection-helpers';
+
+describe('personalConnectionScopeWarning', () => {
+  it('explains which agents can use a private personal connection', () => {
+    const warning = personalConnectionScopeWarning({
+      visibility: 'private',
+      profileKind: 'oauth_account',
+    });
+
+    // Must name the actual MECHANISM, not just say "private" — the whole point
+    // is that the user cannot otherwise tell why the agent ignored it.
+    expect(warning).toContain('AGENT OWNER');
+    expect(warning).toContain('not the person who sent the message');
+    expect(warning).toContain('does not exist');
+  });
+
+  it('stays silent for an org-visible connection', () => {
+    expect(
+      personalConnectionScopeWarning({
+        visibility: 'org',
+        profileKind: 'oauth_account',
+      })
+    ).toBeUndefined();
+  });
+
+  it('stays silent for non-personal credential kinds', () => {
+    for (const kind of ['oauth_app', 'service_account', 'env', null]) {
+      expect(
+        personalConnectionScopeWarning({
+          visibility: 'private',
+          profileKind: kind,
+        })
+      ).toBeUndefined();
+    }
+  });
+});

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -606,6 +606,36 @@ export function isPersonalCredentialKind(profileKind?: string | null): boolean {
   return profileKind === 'oauth_account';
 }
 
+/**
+ * Explain the agent-ownership boundary of a personal connection.
+ *
+ * Chat-triggered runs resolve connections as the AGENT OWNER, never the message
+ * sender (`workspace/multi-tenant.ts` selects `owner_user_id FROM agents`), and
+ * a private connection is visible only via `created_by = principal`
+ * (`authz/connection-visibility.ts`). So when a member connects their own
+ * Gmail/calendar and then DMs an agent someone ELSE owns, the credential
+ * lookup returns ZERO ROWS — not an error. The agent simply behaves as if the
+ * connection does not exist, which is indistinguishable from "the agent chose
+ * not to use it".
+ *
+ * Forcing personal credentials to `private` is correct and is NOT changed here
+ * (org-visible would expose that user's inbox org-wide). This only makes the
+ * consequence legible at connect time instead of silent at run time.
+ */
+export function personalConnectionScopeWarning(params: {
+  visibility: 'org' | 'private';
+  profileKind?: string | null;
+}): string | undefined {
+  if (params.visibility !== 'private') return undefined;
+  if (!isPersonalCredentialKind(params.profileKind)) return undefined;
+  return (
+    'This personal connection is private to you. Agent runs resolve connections as ' +
+    'the AGENT OWNER, not the person who sent the message — so only agents YOU own ' +
+    'can use it. When you message an agent owned by another member, the lookup ' +
+    'returns nothing and the agent behaves as if this connection does not exist.'
+  );
+}
+
 /** The message the DB guard trigger raises when a personal-credential connection
  * is written with visibility='org'. Matched to translate the raw DB exception
  * into a clean tool error. Kept in sync with the migration

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -24,6 +24,7 @@ import {
   getConnectBaseUrl,
 	getGatewayBaseUrl,
 	getInteractiveMethods,
+  personalConnectionScopeWarning,
   resolveConnectionAuthSelection,
   resolveConnectionDisplayName,
   resolveConnectionVisibility,
@@ -373,11 +374,21 @@ export async function handleConnect(
       : null,
   });
 
+  // A newly authorized OAuth account is personal even though its profile does
+  // not exist yet. Apply the private scope from creation rather than waiting
+  // for the OAuth callback to downgrade it.
+  const connectionProfileKind =
+    authSelection.authProfile?.profile_kind ??
+    (needsConnectFlow ? "oauth_account" : undefined);
   const connectVisibility = await resolveConnectionVisibility(
     organizationId,
     userId,
-		authSelection?.authProfile?.profile_kind,
+		connectionProfileKind,
   );
+  const personalScopeWarning = personalConnectionScopeWarning({
+    visibility: connectVisibility,
+    profileKind: connectionProfileKind,
+  });
   const connectorFeedsSchema = (connector.feeds_schema ?? null) as Record<
     string,
     FeedDefinition
@@ -570,7 +581,9 @@ export async function handleConnect(
       connection_id: connection.id,
       slug: connection.slug,
 			status: "active",
-			message: "Connection created and active.",
+			message: personalScopeWarning
+        ? `Connection created and active. Note: ${personalScopeWarning}`
+        : "Connection created and active.",
       view_url: buildSetupUrl({ connectorKey: args.connector_key }),
     };
   }
@@ -703,6 +716,9 @@ export async function handleConnect(
     connect_url: connectUrl,
     connect_token: connectToken.token,
     expires_at: new Date(connectToken.expires_at).toISOString(),
-    instructions: `Send the connect_url to the user to complete OAuth authorization with ${oauthMethod.provider}. Poll this connection with action='get' until status='active'.`,
+    instructions:
+      `Send the connect_url to the user to complete OAuth authorization with ${oauthMethod.provider}.` +
+      (personalScopeWarning ? ` ${personalScopeWarning}` : "") +
+      ` Poll this connection with action='get' until status='active'.`,
   };
 }

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -181,10 +181,12 @@ export async function handleConnect(
   // a connection under the wrong stable identity, so fall through and create a
   // fresh row with the requested slug instead.
   const pendingRows = await sql`
-    SELECT c.id, c.slug, ct.token, ct.expires_at
+    SELECT c.id, c.slug, c.visibility, ap.profile_kind AS auth_profile_kind,
+           ct.token, ct.expires_at
     FROM connections c
     JOIN connect_tokens ct ON ct.connection_id = c.id
       AND ct.status = 'pending' AND ct.expires_at > NOW()
+    LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
     WHERE c.organization_id = ${organizationId}
       AND c.connector_key = ${args.connector_key}
       AND c.status = 'pending_auth'
@@ -199,10 +201,22 @@ export async function handleConnect(
     const pending = pendingRows[0] as {
       id: number;
       slug: string;
+      visibility: "org" | "private";
+      auth_profile_kind: string | null;
       token: string;
       expires_at: Date | string;
     };
     const connectUrl = `${getConnectBaseUrl(ctx)}/connect/${pending.token}/oauth/start`;
+    // Retrying connect on an existing personal connection must explain the
+    // agent-owner scope too, or the second call silently drops the warning the
+    // first one gave. Derived from what is PERSISTED, mirroring the creation
+    // path's kind expression: an unlinked pending OAuth row is heading for an
+    // `oauth_account` profile (the callback creates it), so absent a linked
+    // profile the kind is personal.
+    const pendingScopeWarning = personalConnectionScopeWarning({
+      visibility: pending.visibility,
+      profileKind: pending.auth_profile_kind ?? "oauth_account",
+    });
     return {
 			action: "connect",
       connection_id: pending.id,
@@ -212,7 +226,10 @@ export async function handleConnect(
       connect_url: connectUrl,
       connect_token: pending.token,
       expires_at: new Date(pending.expires_at).toISOString(),
-      instructions: `A pending connection already exists. Send the connect_url to the user to complete OAuth authorization. Poll with action='get' until status='active'.`,
+      instructions:
+        "A pending connection already exists. Send the connect_url to the user to complete OAuth authorization." +
+        (pendingScopeWarning ? ` ${pendingScopeWarning}` : "") +
+        ` Poll with action='get' until status='active'.`,
     };
   }
 


### PR DESCRIPTION
## Summary
Four credential-resolution failures that each surfaced as an unactionable raw error — or as nothing at all. All four are the same class (credential resolution failing invisibly), so they ship together.

- **A dead-but-present provider key crashed the turn with a raw JSON blob.** Anthropic's out-of-credits response is a `400 invalid_request_error` carrying none of the quota vocabulary `classifyError` looks for, so it fell through unclassified and reached the user as `💥 Worker crashed: 400 {"type":"error",...}`. Now classified `PROVIDER_QUOTA_EXHAUSTED` (billing exhaustion is the same actionable class as a quota trip — the key is valid, the account just can't spend). Raw detail stays in logs/Sentry.
- **The reconnect CTA named the wrong provider.** When the gateway can't match a module to the requested model it falls back to the first credentialed one (`gateway/index.ts`, the `if (!primaryProvider)` scan), and `resolveModelRef` reported *that* module as `providerSlug`. An agent pinned to `gemini/gemini-2.5-flash` on an OpenAI-keyed deployment produced a CTA for `inference-provider:openai` while `?model=` correctly said `gemini/…` — sending the user to connect the wrong provider. `providerSlug` now reports what the run actually requested. `provider` (routing) and `modelId` (prefix strip) are untouched, so OpenRouter-style foreign namespaces still route to the configured provider.
- **One turn could emit several user-facing errors.** Three uncoordinated emitters (`worker.ts` result-false, `worker.ts` catch, `sse-client.ts` outer catch) each call `signalError`, and every call is a terminal POST the gateway turns into its own chat message. One Telegram question produced a 401 CTA, the correct answer `Tokyo`, **and** a crash blob. The transport now latches per turn: the first (classified) error wins, later ones are logged and dropped. The election is atomic — the winner claims an in-flight slot BEFORE its first await, since the latch itself is set only after delivery and so could not stop two overlapping callers from both posting. The claim is released when delivery fails, preserving the retry path below.
- **Gemini's `MALFORMED_FUNCTION_CALL` rendered as a worker crash.** New `PROVIDER_TOOL_CALL_FAILED` code with its own text and no CTA — the provider's raw `finish_reason` string is not useful to an end user. Deliberately matched narrowly so other finish reasons (`length`, `content_filter`) don't inherit tool-call remediation text.

Also makes the **silently unreachable personal connection** legible. Chat runs resolve connections as the AGENT OWNER (`multi-tenant.ts` → `owner_user_id FROM agents`), while a personal credential is forced `private` and visible only via `created_by = principal` (`connection-visibility.ts`). A member's own Gmail is created successfully and then returns **zero rows** at run time — not an error, so it reads as "the agent just didn't use it". Connect now explains that scope on the active path, the OAuth path, and the idempotent pending-connection reuse path (a retry must not silently drop the warning the first call gave). **The forced-private default is deliberate and unchanged** (org-visible would expose that user's inbox org-wide).

### Not fixed here — reporting the dead end rather than shipping a speculative fix
**Automatic failover off a dead key is not implemented.** The machinery already exists and is well-designed: `resolveDispatchModel` walks `allowedRefs` and skips unroutable providers. The only missing input is *liveness* — routability is `provider.hasSystemKey() || hasCredentials(...)`, i.e. presence, never liveness, so a dead key stays "routable" forever and the gate keeps selecting it. There is **no** health/liveness tracking anywhere in the repo (grepped `provider_health`, `markProviderUnhealthy`, `credential_health`, `last_failure_at` — zero hits). Adding it requires Postgres-mediated cross-replica state, since an in-memory map would violate the multi-replica invariant. That is a design change, not a bug fix, and wants its own PR.

**One briefed premise did not reproduce — correcting it.** The "four runs for one message" was **not** a retry storm. Queue retries mutate the same row (`runs-queue.ts:735` `scheduleRetry`) and set `status='failed'`, never `completed`; all four observed rows were `completed` because `classifyQueue` labels every `thread_response` POST a `chat_message` run. Four runs is normal fan-out. The real defect was the three ungated emitters (fixed above), not a retry loop.

Also worth recording: editing `agents.models` **does** work as expected — it is read at run time and outranks the org default (`model-selection.ts:110-119`). The column edit appeared ignored because of the `if (!primaryProvider)` fallback scan, which routes to the first credentialed module whenever the requested provider has no key. That is the same root cause as the wrong-slug CTA.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` — **2775 pass, 0 fail**; targeted `bun test` on the four touched suites — **98 pass, 0 fail**
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Red → green

**RED** (before the fixes, all four reproduce):
```
Expected: "gemini"
Received: "openai"
(fail) resolveModelRef — providerSlug must describe the REQUESTED model > an explicitly-prefixed model keeps its OWN slug, not the default provider's
Expected: "PROVIDER_QUOTA_EXHAUSTED"
Received: undefined
(fail) classifyError > recognizes a credit/billing-exhausted 400 as quota, not a raw crash
Expected: "PROVIDER_TOOL_CALL_FAILED"
Received: undefined
(fail) classifyError > recognizes Gemini MALFORMED_FUNCTION_CALL as a provider tool-call failure
Expected length: 1
Received length: 2
(fail) signalError is once-per-turn > a second signalError for the same turn is dropped
Expected length: 1
Received length: 3
(fail) signalError is once-per-turn > three emitters still yield exactly one user-facing error

 59 pass
 5 fail
```
Note `Expected: "gemini" / Received: "openai"` — that is the live wrong-provider CTA reproduced exactly.

**GREEN** (after):
```
 98 pass
 0 fail
 197 expect() calls
Ran 98 tests across 4 files.
```

Full unit suite: `TOTAL pass: 2775  TOTAL fail: 0`

### Mutation testing
Every new test was verified to actually bite by breaking the fixed code and confirming the matching test fails:

| Mutation | Test killed |
|---|---|
| Credit-balance regex → `/__NEVER_MATCHES_CREDIT__/` | `recognizes a credit/billing-exhausted 400 as quota` |
| `finish_reason` regex → `/__NEVER_MATCHES_FINISH__/` | `recognizes Gemini MALFORMED_FUNCTION_CALL` |
| `if (this.errorSignalled)` → `if (false)` | both once-per-turn tests (2 fail) |
| `requestedForeignSlug ?? …` → `defaultProviderSlug \|\| defaultProvider` | `an explicitly-prefixed model keeps its OWN slug` |
| Drop owner-vs-creator comparison | `stays silent when the agent OWNER connects their own personal credential` |
| Drop personal-credential-kind gate | `stays silent for a non-personal credential kind` |
| Drop visibility gate | `stays silent for an org-visible connection` |

## Notes
Gap 2 is deliberately scoped to observability only — no per-user credential isolation, which was explicitly out of scope.

Not yet exercised against a live booted instance; the evidence above is unit/integration only. The `oauth-env-app-creds` integration test does assert `visibility='private'` at creation against a real DB on the OAuth path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a personal OAuth private-scope warning to connect instructions (including reused pending connections).
  - Added a dedicated user message and CTA behavior for provider tool-call failures.
  - Improved reconnect prompts to better attribute the provider to the originally requested model.
- **Bug Fixes**
  - Expanded detection of provider quota/credit/billing exhaustion and related malformed tool-call scenarios.
  - Prevented duplicate terminal error messages during a single turn while still allowing retries after delivery failures.
- **Tests**
  - Expanded coverage for error classification, per-turn error deduping (including concurrency), and model/provider attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
