### PR TITLE
feat(owletto): make the workspace schema map readable

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -300,9 +300,9 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "cronstrue": "^3.24.0",
-        "dagre": "^0.8.5",
         "date-fns": "^4.1.0",
         "echarts": "^5.5.0",
+        "elkjs": "^0.12.0",
         "lucide-react": "^0.469.0",
         "qrcode.react": "^4.2.0",
         "radix-ui": "^1.6.0",
@@ -321,7 +321,6 @@
         "@tanstack/router-plugin": "^1.95.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/dagre": "^0.7.54",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1937,8 +1936,6 @@
 
     "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
 
-    "@types/dagre": ["@types/dagre@0.7.54", "", {}, "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ=="],
-
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -2313,8 +2310,6 @@
 
     "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
-    "dagre": ["dagre@0.8.5", "", { "dependencies": { "graphlib": "^2.1.8", "lodash": "^4.17.15" } }, "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw=="],
-
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
@@ -2402,6 +2397,8 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
     "elen": ["elen@1.0.10", "", {}, "sha512-ZL799/V/kzxYJ6Wlfktreq6qQWfGc3VkGUQJW5lZQ8/MhsQiKTAwERPfhEwIsV2movRGe2DfV7H2MjRw76Z7Wg=="],
+
+    "elkjs": ["elkjs@0.12.0", "", {}, "sha512-YZcKynxVxYoKIOEpywEPwCFdg+BTbxQRNf3pbwdDCvc8O3kQD8bmIwSxKU1eOTVc4Xo+VG9Te+575mlfvOrhEQ=="],
 
     "embedded-postgres": ["embedded-postgres@18.3.0-beta.17", "", { "dependencies": { "async-exit-hook": "^2.0.1", "pg": "^8.7.3" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "^18.3.0-beta.17", "@embedded-postgres/darwin-x64": "^18.3.0-beta.17", "@embedded-postgres/linux-arm": "^18.3.0-beta.17", "@embedded-postgres/linux-arm64": "^18.3.0-beta.17", "@embedded-postgres/linux-ia32": "^18.3.0-beta.17", "@embedded-postgres/linux-ppc64": "^18.3.0-beta.17", "@embedded-postgres/linux-x64": "^18.3.0-beta.17", "@embedded-postgres/windows-x64": "^18.3.0-beta.17" } }, "sha512-1biFWyuPVtAV5S9RBgcr4PGuAdNL9WhnNZVQ5Arp3gsB24Ci9X9s/8Z7RFYFSc6tJWcj9kzF55YcDAcr3jLUbQ=="],
 
@@ -2600,8 +2597,6 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
-
-    "graphlib": ["graphlib@2.1.8", "", { "dependencies": { "lodash": "^4.17.15" } }, "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A=="],
 
     "graphql": ["graphql@16.13.2", "", {}, "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig=="],
 


### PR DESCRIPTION
## What

Makes the workspace schema map (`/<org>/memory?view=entities`) readable when a workspace has more types than relationships.

Three things changed on the canvas, plus a layout-engine swap:

- **Parallel rules collapse.** Sibling rules of one relationship type on the same ordered pair drew as N overlapping paths carrying identical text. They now fold into one edge labelled with a count (`Works At ×3`). Folding is keyed on `slug|source|target`, so `contains` joining order→product and invoice→payment stays two distinct edges.
- **Islands move to the top left.** Types no rule touches used to trail below the connected flow, off the bottom of the viewport on arrival. They now take a column beside it and read as a legend of "types with no relationships yet".
- **A cluster panel indexes the map.** One row per connected component, plus the unconnected types. Selecting a cluster dims everything else rather than hiding it, so the surrounding schema stays as context.
- **dagre → ELK.** dagre minimizes crossings between adjacent ranks but does not account for edge lanes when positioning nodes. ELK does, so its coordinates leave room for the smooth-step paths React Flow draws between ordered handles. dagre was also last released in 2018.

Box counts now say `18 fields` and a separate record count, instead of a bare `18f 2035` where the two numbers were indistinguishable.

## Screenshots

Before/after against the same workspace and seed data:
https://claude.ai/code/artifact/1adaa057-6cbf-4855-9588-6c69bcaabb60

Same 12 types and 10 rules in both. Before: 10 edges, three of them parallel `works_at` all captioned "Works At", no cluster index. After: 8 edges with `Works At ×3`, islands in a left column, cluster panel present.

## Testing

`bunx vitest run src/components/entities/` — 86 pass, including new suites for edge collapsing (4) and `schemaClusters` (6).

Verified in a real browser against the branch database, driven headed via Playwright:

```
{ "nodes": 12, "edges": 8,
  "labels": ["Assigned To","Claims Identity","Has Authority",
             "Proposes Merge With","Proposes Merge With","Proposes Merge With",
             "Reports To","Works At ×3"],
  "clusters": true }
```

The self-loop (`Reports To`, person→person) renders, and all 8 paths are orthogonal.

**Note for reviewers verifying this by hand:** React Flow measures nodes with a `ResizeObserver` and gates *all* edge rendering on `nodesInitialized`. A backgrounded or headless tab has its rendering pipeline suspended, so the observer never fires and the map renders boxes with **zero edges** — on this branch and on `main` alike. Check it in a focused window.

## Notes

`make pre-pr` clean. A workspace-error change that had been sharing this branch was dropped: `apiCall` throws for any non-OK response and a missing org returns 404, so keying the outage message on `isError` reported a genuinely missing organization as a server failure. Telling them apart needs the status preserved on the thrown error in `lib/api/core`, which is wider than this branch should carry. Kept on `wip/workspace-error-distinction`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Owletto component to the latest version.
  * No user-facing feature or API changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->