### PR TITLE
fix(agent-worker): match package installs only at a command position

### DIFF
--- a/packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts
@@ -70,7 +70,8 @@ describe("isDirectPackageInstallCommand", () => {
   // Should NOT detect (false positive guard).
   // Note: "brew list" IS detected (brew prefix matches) — intentionally conservative.
   // Note: "apt-get update" IS detected (apt-get prefix matches) — intentionally conservative.
-  // Note: "echo npm install" IS detected via regex (embedded npm install) — intentionally conservative.
+  // A manager named as an ARGUMENT ("echo npm install") is NOT detected: the
+  // patterns match only at a command position.
   const allowed = [
     "",
     "   ",
@@ -106,9 +107,33 @@ describe("isDirectPackageInstallCommand", () => {
     expect(isDirectPackageInstallCommand("apt-get update")).toBe(true);
   });
 
-  test("echo npm install IS detected (regex matches embedded npm install)", () => {
-    // The DIRECT_PACKAGE_INSTALL_PATTERNS match npm install anywhere in the command
-    expect(isDirectPackageInstallCommand("echo npm install")).toBe(true);
+  test("a manager named as an argument is NOT detected", () => {
+    // The patterns match only at a command position — start of input, a
+    // newline, or just after a shell operator. `echo npm install` prints a
+    // string; it installs nothing, so blocking it only broke honest commands.
+    for (const cmd of [
+      "echo npm install",
+      "echo uvx cowsay",
+      "git log --grep nix run",
+      "man nix run",
+      "git commit -m fix-apt-install-docs",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(false);
+    }
+  });
+
+  test("a real install at a command position is still detected", () => {
+    for (const cmd of [
+      "npm install lodash",
+      "  npm install lodash",
+      "true; npm install lodash",
+      "true && uvx cowsay",
+      "echo hi | uvx cowsay",
+      "(nix shell nixpkgs#hello)",
+      "true\nnix run x",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(true);
+    }
   });
 });
 

--- a/packages/agent-worker/src/runtime/tool-policy.ts
+++ b/packages/agent-worker/src/runtime/tool-policy.ts
@@ -95,26 +95,26 @@ const DEFAULT_PACKAGE_MANAGER_DENY_PREFIXES = [
 ];
 
 const DIRECT_PACKAGE_INSTALL_PATTERNS = [
-  /(^|[\s;|&()])(?:sudo\s+)?(?:apt|apt-get|yum|dnf|apk|pacman|zypper|brew)\s+(?:install|upgrade|add)\b/i,
-  /(^|[\s;|&()])(?:sudo\s+)?(?:nix-shell|nix-env)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?(?:apt|apt-get|yum|dnf|apk|pacman|zypper|brew)\s+(?:install|upgrade|add)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?(?:nix-shell|nix-env)\b/i,
   // New-style nix subcommands and the nix-* helpers, recognized after a shell
   // operator or `sudo` (leading forms are already covered by the prefix list).
-  /(^|[\s;|&()])(?:sudo\s+)?nix\s+(?:profile|shell|run|develop|build|eval|flake|store|copy|bundle|repl|search|edit|print-dev-env|why-depends|derivation|realisation|registry|upgrade-nix)\b/i,
-  /(^|[\s;|&()])(?:sudo\s+)?nix-(?:build|store|channel|instantiate|prefetch-url|collect-garbage|copy-closure)\b/i,
-  /(^|[\s;|&()])(?:pip|pip3)\s+install\b/i,
-  /(^|[\s;|&()])uv\s+pip\s+install\b/i,
-  /(^|[\s;|&()])uv\s+(?:tool\s+(?:install|run|upgrade)|add)\b/i,
-  /(^|[\s;|&()])uvx\b/i,
-  /(^|[\s;|&()])pipx\s+(?:install|run|upgrade|upgrade-all|inject|reinstall|reinstall-all|runpip)\b/i,
-  /(^|[\s;|&()])npm\s+(?:install|i)\b/i,
-  /(^|[\s;|&()])pnpm\s+(?:install|add|dlx)\b/i,
-  /(^|[\s;|&()])yarn\s+(?:install|add|global\s+add|dlx)\b/i,
-  /(^|[\s;|&()])bun\s+(?:install|add)\b/i,
-  /(^|[\s;|&()])cargo\s+install\b/i,
-  /(^|[\s;|&()])go\s+install\b/i,
-  /(^|[\s;|&()])gem\s+install\b/i,
-  /(^|[\s;|&()])poetry\s+add\b/i,
-  /(^|[\s;|&()])composer\s+require\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?nix\s+(?:profile|shell|run|develop|build|eval|flake|store|copy|bundle|repl|search|edit|print-dev-env|why-depends|derivation|realisation|registry|upgrade-nix)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?nix-(?:build|store|channel|instantiate|prefetch-url|collect-garbage|copy-closure)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:pip|pip3)\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*uv\s+pip\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*uv\s+(?:tool\s+(?:install|run|upgrade)|add)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*uvx\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*pipx\s+(?:install|run|upgrade|upgrade-all|inject|reinstall|reinstall-all|runpip)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*npm\s+(?:install|i)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*pnpm\s+(?:install|add|dlx)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*yarn\s+(?:install|add|global\s+add|dlx)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*bun\s+(?:install|add)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*cargo\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*go\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*gem\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*poetry\s+add\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*composer\s+require\b/i,
 ];
 
 /**
@@ -205,14 +205,11 @@ function blankQuotedSpans(text: string): string {
  * reimplementing bash's lexer and only produces false positives on honest
  * commands.
  *
- * KNOWN OVER-DENIAL: the patterns treat any whitespace as a command boundary,
- * so a manager named as a plain ARGUMENT is flagged too — `echo uvx cowsay`,
- * `git log --grep nix run`, `man nix run`. That is deliberate on main (see the
- * "intentionally conservative" cases in tool-policy-edge-cases.test.ts, which
- * pin `echo npm install` as detected) and predates the nix entries here.
- * Anchoring the patterns to real command positions fixes it for every manager,
- * but flips that documented contract, so it belongs in its own change rather
- * than riding along with this one.
+ * The patterns match only at a COMMAND POSITION — start of input, a newline, or
+ * just after a shell operator (`;`, `|`, `&`, parens) — so a manager named as a
+ * plain ARGUMENT is not flagged: `echo uvx cowsay`, `git log --grep nix run`
+ * and `man nix run` all run untouched. Earlier the boundary was any whitespace,
+ * which read every argument as a command.
  *
  * It is advisory on BOTH bash backends, for different reasons:
  *


### PR DESCRIPTION
## What

The install-detection patterns used *any whitespace* as a word boundary, so a package manager named as a plain **argument** was treated as an install and blocked.

Match only at a real command position — start of input, a newline, or just after a shell operator (`;`, `|`, `&`, parens).

## Why

`echo npm install` prints a string. It installs nothing. Blocking it bought no safety and only broke honest commands that happen to mention a manager — which is common in this repo, where "nix shell" turns up in commit messages, grep patterns, and docs.

## Red → green

Before:

```
DENIED  "echo uvx cowsay"
DENIED  "git log --grep nix run"
DENIED  "man nix run"
DENIED  "echo apt install is bad"
```

After:

```
allow   "echo uvx cowsay"
allow   "git log --grep nix run"
allow   "man nix run"
allow   "echo apt install is bad"
```

Every true positive still fires — after operators, inside subshells, on a later line, and in an `sh -c` body:

```
npm install lodash
  npm install lodash          (leading whitespace)
true; npm install lodash
true && uvx cowsay
echo hi | uvx cowsay
(nix shell nixpkgs#hello)
true<newline>nix run x
bash -c 'nix run x'
```

Full agent-worker suite: **743 pass / 0 fail**. Mutation-tested — restoring the whitespace boundary fails the new test.

## Contract change (please review this specifically)

This flips a documented behaviour. `tool-policy-edge-cases.test.ts` pinned `echo npm install` as **detected**, with "intentionally conservative" written next to it. That test is updated rather than preserved.

The argument for changing it: the old behaviour never prevented an install, so the conservatism protected nothing while producing false positives across `apt` / `npm` / `pip` / `nix` alike. If you disagree, this is the commit to push back on.

## Base

Stacked on `feat/nix-deny-list-gap` (#2259) — the defect only fully reproduces with that branch's nix patterns present; branching from `main` yields a misleading reproducer where only `apt install` fires. Retarget to `main` once #2259 merges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->