### PR TITLE
fix(agent-worker): forward NIX_PACKAGES so declared tooling resolves in agent bash

### DIFF
--- a/packages/agent-worker/src/__tests__/worker-env-allowlist.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-env-allowlist.test.ts
@@ -108,13 +108,28 @@ describe("buildAgentEnv", () => {
     expect(out.PATH).toBe("/usr/bin");
     expect(out.HOME).toBe("/home/agent");
     expect(out.GH_TOKEN).toBe("ghs_short_lived_lease");
+    expect(out.NIX_PACKAGES).toBe("gh");
     expect(out).not.toHaveProperty("NO_PROXY");
-    expect(out).not.toHaveProperty("NIX_PACKAGES");
     expect(out).not.toHaveProperty("JUST_BASH_ALLOWED_DOMAINS");
     expect(out).not.toHaveProperty("ENCRYPTION_KEY");
     // The property that a denylist cannot have: a secret nobody has heard of
     // yet is excluded by default rather than included by default.
     expect(out).not.toHaveProperty("SOME_FUTURE_SECRET");
+  });
+
+  test("forwards NIX_PACKAGES so declared tooling is discoverable", () => {
+    // Regression: the allowlist originally omitted NIX_PACKAGES. The gateway
+    // set it correctly from the connector's declared packages, but the filter
+    // dropped it before `discoverBinaries()` could read it — so a connector's
+    // CLI was never registered and agent bash answered "gh: command not found"
+    // while holding a perfectly good GH_TOKEN lease. Verified in production:
+    // the credential arrived, the tool to spend it did not.
+    const out = buildAgentEnv({
+      NIX_PACKAGES: "gh,ripgrep",
+      GH_TOKEN: "ghs_short_lived_lease",
+    });
+    expect(out.NIX_PACKAGES).toBe("gh,ripgrep");
+    expect(out.GH_TOKEN).toBe("ghs_short_lived_lease");
   });
 
   test("drops the previously-denylisted keys too", () => {

--- a/packages/agent-worker/src/shared/worker-env-keys.ts
+++ b/packages/agent-worker/src/shared/worker-env-keys.ts
@@ -47,6 +47,11 @@ export const WORKER_ENV_ALLOWLIST = [
   "https_proxy",
   "all_proxy",
   // Nix needs these to resolve a provisioned package's store paths.
+  // `NIX_PACKAGES` is the deployment's declared tooling (a comma-separated list
+  // of package names, never a secret). `discoverBinaries()` reads it to decide
+  // which contributed CLIs to register; without it a connector's declared `gh`
+  // is provisioned into the sandbox but never resolvable from agent bash.
+  "NIX_PACKAGES",
   "NIX_PATH",
   "NIX_PROFILES",
   "NIX_SSL_CERT_FILE",


### PR DESCRIPTION
## What

Adds `NIX_PACKAGES` to `WORKER_ENV_ALLOWLIST`.

## Why

The worker env allowlist (added in #2263) omitted `NIX_PACKAGES`. The gateway sets it correctly from the connector's declared `agentTooling.nix.packages`, but `buildAgentEnv` dropped it before `discoverBinaries()` could read it — so a connector's CLI was provisioned into the sandbox and never registered as a command.

The result: an agent holding a valid `GH_TOKEN` installation lease that cannot use it.

```
gateway   assembleBaseEnv → NIX_PACKAGES="gh"     ✓
worker    buildAgentEnv   → not in allowlist      ✗ dropped
bash      discoverBinaries reads ""               → gh never registered
```

`GH_TOKEN` is allowlisted, so the credential arrives. `NIX_PACKAGES` was not, so the tool to spend it does not.

## Production evidence

Verified against the `lobu-team` org on prod (`app.lobu.ai`), agent `lobu-builder`:

```
tool_use: bash → echo "gh=${GH_TOKEN:+present}${GH_TOKEN:-absent}"
output:   gh=present ghs_…            ← lease works

tool_use: bash → gh --version
output:   not found                    ← tooling does not
```

Asked to open a PR, the agent then reported it had created a *"simulated pull request"* — it wrote a local `README.md` and uploaded it as an artifact. No PR existed. A silent degrade that reads as success.

A separate check confirmed `NIX_PACKAGES` is empty inside the worker:

```
NIX=[] PATHHEAD=/app/node_modules/.bin:/usr/local/bin:…
```

## Red → green

Before (the existing test asserted the broken behaviour, which is why the suite stayed green while the feature was broken):

```
expect(out.NIX_PACKAGES).toBe("gh,ripgrep")
Expected: "gh,ripgrep"
Received: undefined
 8 pass, 2 fail
```

After:

```
34 pass, 1 skip, 0 fail   (worker-env-allowlist + agent-session-bash-env + embedded-just-bash-bootstrap)
```

## Class check

Every var `just-bash-bootstrap.ts` reads from `process.env` was audited. `JUST_BASH_ALLOWED_DOMAINS`, `LOBU_ALLOW_UNSANDBOXED_EXEC` and `WORKSPACE_DIR` are consumed in the worker process *before* filtering — they configure the sandbox and correctly do not reach agent bash. `NIX_PACKAGES` is the only var that must survive into the child env. The class is exactly one.

## Note on the test change

`worker-env-allowlist.test.ts` previously asserted `expect(out).not.toHaveProperty("NIX_PACKAGES")`. That assertion encoded the bug — a green test locking in a wrong belief. It is now inverted, plus a dedicated regression test explaining the failure mode.

`NIX_PACKAGES` is a comma-separated list of package names, never a secret.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent environments now forward the `NIX_PACKAGES` setting, enabling configured Nix packages to be used in agent bash sessions.

* **Bug Fixes**
  * Corrected environment handling so the approved `NIX_PACKAGES` setting is preserved while sensitive or unrelated variables remain excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->