### PR TITLE
fix(agent-worker): match package installs only at a command position

### DIFF
--- a/packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts
@@ -131,8 +131,23 @@ describe("isDirectPackageInstallCommand", () => {
       "echo hi | uvx cowsay",
       "(nix shell nixpkgs#hello)",
       "true\nnix run x",
+      // A reserved word opens a command position too. Anchoring only on
+      // operators missed every one of these.
+      "if nix run x; then :; fi",
+      "{ nix run x; }",
+      "! nix run x",
+      "for i in 1; do nix run x; done",
+      "while :; do uvx x; done",
     ]) {
       expect(isDirectPackageInstallCommand(cmd)).toBe(true);
+    }
+  });
+
+  test("a keyword lookalike does not open a command position", () => {
+    // `if`/`do` only count as reserved words on their own, so a longer word
+    // starting with those letters stays ordinary argument text.
+    for (const cmd of ["echo iffy nix run", "echo dofile nix run"]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(false);
     }
   });
 });

--- a/packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts
@@ -70,7 +70,8 @@ describe("isDirectPackageInstallCommand", () => {
   // Should NOT detect (false positive guard).
   // Note: "brew list" IS detected (brew prefix matches) — intentionally conservative.
   // Note: "apt-get update" IS detected (apt-get prefix matches) — intentionally conservative.
-  // Note: "echo npm install" IS detected via regex (embedded npm install) — intentionally conservative.
+  // A manager named as an ARGUMENT ("echo npm install") is NOT detected: the
+  // patterns match only at a command position.
   const allowed = [
     "",
     "   ",
@@ -106,9 +107,33 @@ describe("isDirectPackageInstallCommand", () => {
     expect(isDirectPackageInstallCommand("apt-get update")).toBe(true);
   });
 
-  test("echo npm install IS detected (regex matches embedded npm install)", () => {
-    // The DIRECT_PACKAGE_INSTALL_PATTERNS match npm install anywhere in the command
-    expect(isDirectPackageInstallCommand("echo npm install")).toBe(true);
+  test("a manager named as an argument is NOT detected", () => {
+    // The patterns match only at a command position — start of input, a
+    // newline, or just after a shell operator. `echo npm install` prints a
+    // string; it installs nothing, so blocking it only broke honest commands.
+    for (const cmd of [
+      "echo npm install",
+      "echo uvx cowsay",
+      "git log --grep nix run",
+      "man nix run",
+      "git commit -m fix-apt-install-docs",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(false);
+    }
+  });
+
+  test("a real install at a command position is still detected", () => {
+    for (const cmd of [
+      "npm install lodash",
+      "  npm install lodash",
+      "true; npm install lodash",
+      "true && uvx cowsay",
+      "echo hi | uvx cowsay",
+      "(nix shell nixpkgs#hello)",
+      "true\nnix run x",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(true);
+    }
   });
 });
 

--- a/packages/agent-worker/src/runtime/tool-policy.ts
+++ b/packages/agent-worker/src/runtime/tool-policy.ts
@@ -95,26 +95,26 @@ const DEFAULT_PACKAGE_MANAGER_DENY_PREFIXES = [
 ];
 
 const DIRECT_PACKAGE_INSTALL_PATTERNS = [
-  /(^|[\s;|&()])(?:sudo\s+)?(?:apt|apt-get|yum|dnf|apk|pacman|zypper|brew)\s+(?:install|upgrade|add)\b/i,
-  /(^|[\s;|&()])(?:sudo\s+)?(?:nix-shell|nix-env)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?(?:apt|apt-get|yum|dnf|apk|pacman|zypper|brew)\s+(?:install|upgrade|add)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?(?:nix-shell|nix-env)\b/i,
   // New-style nix subcommands and the nix-* helpers, recognized after a shell
   // operator or `sudo` (leading forms are already covered by the prefix list).
-  /(^|[\s;|&()])(?:sudo\s+)?nix\s+(?:profile|shell|run|develop|build|eval|flake|store|copy|bundle|repl|search|edit|print-dev-env|why-depends|derivation|realisation|registry|upgrade-nix)\b/i,
-  /(^|[\s;|&()])(?:sudo\s+)?nix-(?:build|store|channel|instantiate|prefetch-url|collect-garbage|copy-closure)\b/i,
-  /(^|[\s;|&()])(?:pip|pip3)\s+install\b/i,
-  /(^|[\s;|&()])uv\s+pip\s+install\b/i,
-  /(^|[\s;|&()])uv\s+(?:tool\s+(?:install|run|upgrade)|add)\b/i,
-  /(^|[\s;|&()])uvx\b/i,
-  /(^|[\s;|&()])pipx\s+(?:install|run|upgrade|upgrade-all|inject|reinstall|reinstall-all|runpip)\b/i,
-  /(^|[\s;|&()])npm\s+(?:install|i)\b/i,
-  /(^|[\s;|&()])pnpm\s+(?:install|add|dlx)\b/i,
-  /(^|[\s;|&()])yarn\s+(?:install|add|global\s+add|dlx)\b/i,
-  /(^|[\s;|&()])bun\s+(?:install|add)\b/i,
-  /(^|[\s;|&()])cargo\s+install\b/i,
-  /(^|[\s;|&()])go\s+install\b/i,
-  /(^|[\s;|&()])gem\s+install\b/i,
-  /(^|[\s;|&()])poetry\s+add\b/i,
-  /(^|[\s;|&()])composer\s+require\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?nix\s+(?:profile|shell|run|develop|build|eval|flake|store|copy|bundle|repl|search|edit|print-dev-env|why-depends|derivation|realisation|registry|upgrade-nix)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?nix-(?:build|store|channel|instantiate|prefetch-url|collect-garbage|copy-closure)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*(?:pip|pip3)\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*uv\s+pip\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*uv\s+(?:tool\s+(?:install|run|upgrade)|add)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*uvx\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*pipx\s+(?:install|run|upgrade|upgrade-all|inject|reinstall|reinstall-all|runpip)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*npm\s+(?:install|i)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*pnpm\s+(?:install|add|dlx)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*yarn\s+(?:install|add|global\s+add|dlx)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*bun\s+(?:install|add)\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*cargo\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*go\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*gem\s+install\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*poetry\s+add\b/i,
+  /(?:^|[;|&()\n])[^\S\n]*composer\s+require\b/i,
 ];
 
 /**
@@ -212,8 +212,12 @@ function blankQuotedSpans(text: string): string {
  * name (`"nix" run`, `n\ix run`, `/usr/bin/nix run`), a manager behind an exec
  * wrapper (`env nix run`, `xargs npm install`), a name built at runtime, and
  * the body of an interpreter reached by path or long option (`/bin/bash -c`,
- * `bash --login -c`). It also over-denies a manager named as a plain argument
- * (`echo uvx cowsay`).
+ * `bash --login -c`).
+ *
+ * It matches only at a COMMAND POSITION — start of input, a newline, or just
+ * after a shell operator (`;`, `|`, `&`, parens) — so a manager named as a
+ * plain argument is left alone: `echo uvx cowsay`, `git log --grep nix run`
+ * and `man nix run` all run untouched.
  *
  * Those misses are not holes on the local backend: the manager is never a
  * runnable command there. `UNSANDBOXED_INTERPRETERS` in

--- a/packages/agent-worker/src/runtime/tool-policy.ts
+++ b/packages/agent-worker/src/runtime/tool-policy.ts
@@ -94,27 +94,47 @@ const DEFAULT_PACKAGE_MANAGER_DENY_PREFIXES = [
   "composer require ",
 ];
 
+/**
+ * A command position: the start of input, a shell operator or newline, a brace,
+ * or a reserved word that introduces a command (`if npm install`, `do uvx x`,
+ * `! nix run x`). Anchoring here is what keeps a manager named as a plain
+ * ARGUMENT — `echo uvx cowsay`, `git log --grep nix run` — from matching, while
+ * still catching an install wherever the shell would actually run one.
+ */
+const CMD_POS = String.raw`(?:^|[;|&(){}\n]|(?<![^\s;|&(){}])(?:if|then|else|elif|do|while|until|!)\s)[^\S\n]*`;
+
+/** Build an install pattern anchored at a command position. */
+const atCmd = (body: string): RegExp => new RegExp(CMD_POS + body, "i");
+
 const DIRECT_PACKAGE_INSTALL_PATTERNS = [
-  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?(?:apt|apt-get|yum|dnf|apk|pacman|zypper|brew)\s+(?:install|upgrade|add)\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?(?:nix-shell|nix-env)\b/i,
+  atCmd(
+    String.raw`(?:sudo\s+)?(?:apt|apt-get|yum|dnf|apk|pacman|zypper|brew)\s+(?:install|upgrade|add)\b`
+  ),
+  atCmd(String.raw`(?:sudo\s+)?(?:nix-shell|nix-env)\b`),
   // New-style nix subcommands and the nix-* helpers, recognized after a shell
   // operator or `sudo` (leading forms are already covered by the prefix list).
-  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?nix\s+(?:profile|shell|run|develop|build|eval|flake|store|copy|bundle|repl|search|edit|print-dev-env|why-depends|derivation|realisation|registry|upgrade-nix)\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*(?:sudo\s+)?nix-(?:build|store|channel|instantiate|prefetch-url|collect-garbage|copy-closure)\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*(?:pip|pip3)\s+install\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*uv\s+pip\s+install\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*uv\s+(?:tool\s+(?:install|run|upgrade)|add)\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*uvx\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*pipx\s+(?:install|run|upgrade|upgrade-all|inject|reinstall|reinstall-all|runpip)\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*npm\s+(?:install|i)\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*pnpm\s+(?:install|add|dlx)\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*yarn\s+(?:install|add|global\s+add|dlx)\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*bun\s+(?:install|add)\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*cargo\s+install\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*go\s+install\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*gem\s+install\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*poetry\s+add\b/i,
-  /(?:^|[;|&()\n])[^\S\n]*composer\s+require\b/i,
+  atCmd(
+    String.raw`(?:sudo\s+)?nix\s+(?:profile|shell|run|develop|build|eval|flake|store|copy|bundle|repl|search|edit|print-dev-env|why-depends|derivation|realisation|registry|upgrade-nix)\b`
+  ),
+  atCmd(
+    String.raw`(?:sudo\s+)?nix-(?:build|store|channel|instantiate|prefetch-url|collect-garbage|copy-closure)\b`
+  ),
+  atCmd(String.raw`(?:pip|pip3)\s+install\b`),
+  atCmd(String.raw`uv\s+pip\s+install\b`),
+  atCmd(String.raw`uv\s+(?:tool\s+(?:install|run|upgrade)|add)\b`),
+  atCmd(String.raw`uvx\b`),
+  atCmd(
+    String.raw`pipx\s+(?:install|run|upgrade|upgrade-all|inject|reinstall|reinstall-all|runpip)\b`
+  ),
+  atCmd(String.raw`npm\s+(?:install|i)\b`),
+  atCmd(String.raw`pnpm\s+(?:install|add|dlx)\b`),
+  atCmd(String.raw`yarn\s+(?:install|add|global\s+add|dlx)\b`),
+  atCmd(String.raw`bun\s+(?:install|add)\b`),
+  atCmd(String.raw`cargo\s+install\b`),
+  atCmd(String.raw`go\s+install\b`),
+  atCmd(String.raw`gem\s+install\b`),
+  atCmd(String.raw`poetry\s+add\b`),
+  atCmd(String.raw`composer\s+require\b`),
 ];
 
 /**


### PR DESCRIPTION
Replaces #2273. That one got auto-closed as "merged" when the #2259 squash deleted its base branch, but the commit never actually landed on main, so this re-opens it against main.

The install-detection patterns treated any whitespace as a word boundary, so a package manager named as a plain argument counted as an install and got blocked. Now they only match at a real command position: start of input, a newline, or right after a shell operator (`;`, `|`, `&`, parens).

`echo npm install` prints a string, it doesn't install anything. Blocking it never bought us safety, it just broke honest commands that happen to mention a manager, which comes up a lot here since "nix shell" shows up in commit messages and grep patterns.

Before, on main:

```
DENIED  "echo uvx cowsay"
DENIED  "git log --grep nix run"
DENIED  "man nix run"
```

After:

```
allow   "echo uvx cowsay"
allow   "git log --grep nix run"
allow   "man nix run"
```

Real installs still get caught, including the `-c` handling from #2259:

```
nix run x / uvx cowsay / apt install curl / sudo nix run x
true; nix run x / true && uvx x / (nix shell nixpkgs#hello) / true<newline>nix run x
bash -c 'nix run x' / bash -euo pipefail -c 'uvx x'
```

The ReDoS fix from #2259 survives the rebase too: 2000 bare dashes and 2000 repeated options both finish under 1ms. Full agent-worker suite is 778 pass / 0 fail.

One thing worth a look: this flips a documented behaviour. `tool-policy-edge-cases.test.ts` pinned `echo npm install` as detected, with "intentionally conservative" next to it, and I updated that test rather than keeping it. My reasoning is the old behaviour never prevented an install so the conservatism protected nothing, but if you disagree that's the commit to push back on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of direct package installation commands by recognizing package managers only when they appear in valid shell command positions.
  * Prevented false positives when package-manager names are used as ordinary command arguments.
  * Preserved detection after shell operators and reserved-word constructs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->