### PR TITLE
fix(server): name the provider in error bodies and unwrap the JSON envelope

### DIFF
--- a/packages/agent-worker/src/__tests__/audio-provider-suggestions.test.ts
+++ b/packages/agent-worker/src/__tests__/audio-provider-suggestions.test.ts
@@ -179,8 +179,8 @@ describe("provider auth classification (no bespoke hint round-trip)", () => {
   test("a raw provider auth error classifies to PROVIDER_AUTH", () => {
     // The worker no longer rewrites the raw error into an admin-guidance
     // sentence that the classifier then re-parses. The raw error classifies
-    // directly to a code; that code selects the reconnect CTA, and the raw
-    // provider message is relayed verbatim as the body.
+    // directly to a code; that code selects the reconnect CTA, and separately
+    // signaled context lets the gateway label/unwrap the user-facing body.
     expect(classifyError(new Error('Authentication failed for "openai"'))).toBe(
       "PROVIDER_AUTH"
     );

--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -123,7 +123,7 @@ describe("handleExecutionError", () => {
     expect(errors[0].code).toBe("PROVIDER_BASE_URL_UNRESOLVED");
   });
 
-  test("provider QUOTA (z.ai 429) classifies + relays the raw message verbatim", async () => {
+  test("provider QUOTA (z.ai 429) classifies + signals the raw message", async () => {
     const { transport, deltas, errors } = makeTransport();
 
     // The exact prod shape from the app pod logs.
@@ -131,10 +131,8 @@ describe("handleExecutionError", () => {
       "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47";
     await handleExecutionError(new Error(raw), transport, { provider: "z-ai" });
 
-    // No worker-formatted delta — the renderer presents it (raw message body +
-    // the code's CTA link). The raw message reaches the wire UNCHANGED: it
-    // already tells the user when the quota resets, so we relay it verbatim
-    // instead of parsing a reset time out of it.
+    // No worker-formatted delta. The raw message reaches the gateway unchanged;
+    // the gateway renderer labels/unwraps it and adds the code's CTA.
     expect(deltas).toHaveLength(0);
     expect(errors).toHaveLength(1);
     expect(errors[0].code).toBe("PROVIDER_QUOTA_EXHAUSTED");
@@ -158,6 +156,22 @@ describe("classifyError", () => {
           "401 No provider credentials configured. End-user provider setup is not available in chat yet."
         )
       )
+    ).toBe("PROVIDER_AUTH");
+    // Seen live on Telegram after connecting Claude via subscription OAuth:
+    // Anthropic 403s the inference call for orgs that disallow OAuth. The
+    // auth-hint regex misses it (no "api key"/"authentication failed" wording),
+    // so it surfaced as a raw `Worker crashed: 403 {...}` blob with no CTA —
+    // the credential IS the problem, so it belongs in the auth class.
+    expect(
+      classifyError(
+        new Error(
+          '403 {"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization.","details":{"error_code":"oauth_not_allowed_for_organization"}},"request_id":"req_011CdVRTidLfu6D81Mjz76wh"}'
+        )
+      )
+    ).toBe("PROVIDER_AUTH");
+    // The generic shape, not just the one vendor string we happened to see.
+    expect(
+      classifyError(new Error('403 {"error":{"type":"permission_error"}}'))
     ).toBe("PROVIDER_AUTH");
   });
 

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -53,9 +53,9 @@ const SESSION_TIMEOUT_MESSAGE = "SESSION_TIMEOUT";
  * rather than re-implementing its own regex. Adding a failure mode = one pattern
  * here + one entry in `AGENT_ERRORS`.
  *
- * The code selects only the CTA link. The user-facing TEXT for provider errors
- * is the provider's own message (relayed verbatim); we do NOT parse or reword
- * it — no reset-time extraction, no provider-label interpolation.
+ * Provider errors reach the gateway unchanged with available provider/model
+ * context. The renderer uses that context to label the source and unwrap the
+ * common JSON message envelope without rewording the provider's sentence.
  */
 export function classifyError(error: unknown): AgentErrorCode | undefined {
   if (!(error instanceof Error)) return undefined;
@@ -121,6 +121,19 @@ export function classifyError(error: unknown): AgentErrorCode | undefined {
   // PROVIDER_* Sentry alert.
   if (
     /no\s+(provider\s+)?credentials\s+configured|no_credentials/i.test(message)
+  )
+    return AgentErrorCode.PROVIDER_AUTH;
+  // The provider accepted the credential but refuses to USE it: Anthropic 403s
+  // subscription-OAuth inference for orgs that disallow it
+  // (`oauth_not_allowed_for_organization`). None of the wording above matches —
+  // there is no "api key" or "authentication failed" — so it surfaced as a raw
+  // `Worker crashed: 403 {…}` blob with no CTA. Seen live on Telegram right
+  // after connecting Claude by subscription sign-in. The credential is what the
+  // user must change, so this is the auth class: "Reconnect provider".
+  if (
+    /permission_error|oauth[_\s]not[_\s]allowed|not allowed for this organization/i.test(
+      message
+    )
   )
     return AgentErrorCode.PROVIDER_AUTH;
   // `worker.ts` throws "Model \"<id>\" not found for provider ..." and pi-ai /

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -214,16 +214,17 @@ export type AgentErrorCtaKind =
  * The spec is deliberately thin. Two families of failure:
  *
  *  - PROVIDER errors (quota/auth/unknown-model/routing) carry NO `message`: the
- *    provider's own error string (relayed verbatim via `payload.error`) is the
- *    body, because it already says the useful thing — including a reset time
- *    like "will reset at 2026-07-10". We don't re-derive or reword it; the spec
- *    only decides the CTA link to append. Zero string parsing.
+ *    provider's own error string rides in `payload.error`. When provider context
+ *    is available, the gateway labels it and unwraps the common JSON message
+ *    envelope without rewording the provider's sentence (including reset times).
+ *    The spec only decides the CTA link to append.
  *
  *  - WORKER / config errors DO carry a `message`: they're synthesized by us (the
  *    sweep, the deployment manager, the model resolver) so there is no upstream
  *    provider string to fall back to.
  *
- * The renderer picks `spec.message ?? payload.error` and appends the CTA.
+ * The renderer prefers `spec.message`, otherwise formats `payload.error`, and
+ * appends the CTA.
  */
 export interface AgentErrorSpec {
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -286,9 +286,9 @@ export interface ThreadResponsePayload {
    */
   toolsUsed?: string[];
   /**
-   * Raw error message. For provider errors this is relayed verbatim as the
-   * user-facing body (the provider's own text already says the useful thing,
-   * e.g. the quota reset time); `errorCode` only selects the CTA link.
+   * Raw error message. When provider context is available, the gateway labels
+   * the source and unwraps the common JSON message envelope without rewording
+   * the provider's sentence; `errorCode` selects the CTA link.
    */
   error?: string;
   errorCode?: string;

--- a/packages/core/src/worker/transport.ts
+++ b/packages/core/src/worker/transport.ts
@@ -45,10 +45,10 @@ export interface WorkerTransport {
   /**
    * Signal that an error occurred during processing
    *
-   * @param error - The error that occurred. Its message is relayed verbatim as
-   *                the user-facing body for provider errors.
-   * @param errorCode - Classified `AgentErrorCode` (see @lobu/core errors); the
-   *                    renderer uses it only to select the CTA link.
+   * @param error - The error that occurred. Provider messages reach the gateway
+   *                unchanged; the renderer uses context to label/unwrap them.
+   * @param errorCode - Classified `AgentErrorCode` (see @lobu/core errors);
+   *                    selects the catalog text/CTA behavior.
    * @param context - Non-secret provider/model targeting for the error CTA.
    */
   signalError(

--- a/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
@@ -291,6 +291,27 @@ describe("ChatResponseBridge.handleDelta — AsyncIterable streaming", () => {
     expect(posted).not.toContain("Worker crashed");
   });
 
+  test("handleError labels and unwraps a provider error body", async () => {
+    const { target, plainPosts } = createStreamingTarget();
+    const { manager } = createHarness(target);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    await bridge.handleError(
+      {
+        ...basePayload,
+        error:
+          '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low."},"request_id":"req_123"}',
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        errorContext: { provider: "anthropic" },
+      },
+      "s"
+    );
+
+    expect(plainPosts).toContain(
+      "Error: Anthropic returned an error:\nYour credit balance is too low."
+    );
+  });
+
   test("isFullReplacement closes prior stream and opens a new one", async () => {
     const { target } = createStreamingTarget();
     const { manager } = createHarness(target);

--- a/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
+++ b/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
@@ -119,12 +119,14 @@ describe("ApiResponseRenderer.handleCompletion suggestion embed", () => {
 });
 
 describe("ApiResponseRenderer.handleError targeting context", () => {
-  test("forwards provider/model context on both browser error events", async () => {
+  test("forwards context and renders the provider body on both browser error events", async () => {
     const { renderer, broadcasts } = makeRenderer();
+    const raw =
+      '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low."},"request_id":"req_123"}';
 
     await renderer.handleError(
       basePayload({
-        error: "quota exhausted",
+        error: raw,
         errorCode: "PROVIDER_QUOTA_EXHAUSTED",
         errorContext: { provider: "z-ai", model: "glm-5.2" },
       }),
@@ -133,6 +135,7 @@ describe("ApiResponseRenderer.handleError targeting context", () => {
 
     for (const event of ["error", "agent-error"]) {
       expect(broadcasts.find((b) => b.event === event)?.data).toMatchObject({
+        error: "z.ai returned an error:\nYour credit balance is too low.",
         errorCode: "PROVIDER_QUOTA_EXHAUSTED",
         errorContext: { provider: "z-ai", model: "glm-5.2" },
       });

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -11,6 +11,7 @@ import {
   type SuggestedPrompt,
   toAgentErrorCode,
 } from "@lobu/core";
+import { labelProviderErrorBody } from "../../utils/url-builder.js";
 import type { ThreadResponsePayload } from "../infrastructure/queue/types.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
 import type { SseManager } from "../services/sse-manager.js";
@@ -168,12 +169,8 @@ export class ApiResponseRenderer implements ResponseRenderer {
       return;
     }
 
-    // Pick the body the same way every surface does: our catalog text for
-    // errors we synthesize (worker/config), else the provider's OWN message
-    // relayed verbatim (it already says the useful thing, e.g. the quota reset
-    // time). The structured `errorCode` is forwarded so the frontend can build
-    // the CTA button (this SSE surface lacks the org/agent ids to resolve the
-    // URL itself).
+    // This SSE surface forwards the context so the frontend can build the CTA,
+    // but it lacks the org/agent ids needed to resolve the URL itself.
     const code = toAgentErrorCode(payload.errorCode);
     const spec = code ? AGENT_ERRORS[code] : undefined;
     if (spec?.silent) {
@@ -184,7 +181,9 @@ export class ApiResponseRenderer implements ResponseRenderer {
       });
       return;
     }
-    const errorText = spec?.message ?? payload.error;
+    const errorText =
+      spec?.message ??
+      labelProviderErrorBody(payload.error, payload.errorContext?.provider);
 
     const errorEvent = {
       type: "error",

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -686,26 +686,28 @@ export class ChatResponseBridge implements ResponseRenderer {
       const gatewayUrl = this.manager.getPublicGatewayUrl();
       const orgId = this.resolveOrganizationId(payload, ctx) ?? undefined;
       const agentId = this.resolveAgentId(payload, ctx) ?? undefined;
-      const rendered = await renderAgentError(code, payload.error, {
-        // "pick a model" → the agent's settings tab.
-        'agent-settings': () =>
-          buildAgentSettingsUrl(gatewayUrl, orgId, agentId),
-        // "connect a provider" → the provider's connector detail page, with
-        // the same provider/model targeting + agent context the pre-enqueue
-        // preflight passes (message-handler-bridge parity).
-        'provider-connect': () =>
-          buildProviderConnectUrl(gatewayUrl, orgId, {
-            ...payload.errorContext,
-            agentId,
-          }),
-        // Provider auth/quota/routing → manage the exact existing provider.
-        'provider-management': () =>
-          buildProviderManagementUrl(gatewayUrl, orgId, payload.errorContext),
-      });
+      const rendered = await renderAgentError(
+        code,
+        payload.error,
+        {
+          // "pick a model" → the agent's settings tab.
+          'agent-settings': () =>
+            buildAgentSettingsUrl(gatewayUrl, orgId, agentId),
+          // "connect a provider" → the provider's connector detail page, with
+          // the same provider/model targeting + agent context the pre-enqueue
+          // preflight passes (message-handler-bridge parity).
+          'provider-connect': () =>
+            buildProviderConnectUrl(gatewayUrl, orgId, {
+              ...payload.errorContext,
+              agentId,
+            }),
+          // Provider auth/quota/routing → manage the exact existing provider.
+          'provider-management': () =>
+            buildProviderManagementUrl(gatewayUrl, orgId, payload.errorContext),
+        },
+        payload.errorContext
+      );
       if (rendered.silent) return;
-      // For provider errors `rendered.text` IS the provider's own message (we
-      // relay it verbatim); for our synthesized errors it's the catalog line.
-      // Either way the guardrail scan + plain-text fallback below operate on it.
       payload.error = rendered.text;
       if (rendered.ctaUrl) ctaButton = rendered;
     }

--- a/packages/server/src/utils/__tests__/render-agent-error.test.ts
+++ b/packages/server/src/utils/__tests__/render-agent-error.test.ts
@@ -6,6 +6,8 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { AgentErrorCode } from "@lobu/core";
 import { type AgentErrorCtaResolvers, renderAgentError } from "../url-builder";
 
@@ -126,5 +128,80 @@ describe("renderAgentError", () => {
     });
     expect(r.text).toBe("auth fail");
     expect(r.ctaUrl).toBeNull();
+  });
+});
+
+describe("provider error bodies are labelled and unwrapped", () => {
+  // Regression for Anthropic's status-prefixed JSON error envelope.
+  const RAW_400 =
+    '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."},"request_id":"req_011CdVJwuwSg3kq5CWVwRR7N"}';
+
+  it("names the provider and unwraps the JSON envelope", async () => {
+    const r = await renderAgentError(
+      AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+      RAW_400,
+      resolvers,
+      { provider: "anthropic" }
+    );
+    expect(r.text).toBe(
+      "Anthropic returned an error:\nYour credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."
+    );
+  });
+
+  it("unwraps a top-level JSON message", async () => {
+    const r = await renderAgentError(
+      AgentErrorCode.PROVIDER_AUTH,
+      '{"message":"API key expired"}',
+      resolvers,
+      { provider: "openai" }
+    );
+    expect(r.text).toBe("OpenAI API returned an error:\nAPI key expired");
+  });
+
+  it("relays a plain provider sentence unchanged apart from the label", async () => {
+    // Non-JSON bodies are already human-readable; unwrapping must not mangle
+    // them, and we must not double-report the status code.
+    const plain =
+      "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47";
+    const r = await renderAgentError(
+      AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+      plain,
+      resolvers,
+      { provider: "z-ai" }
+    );
+    expect(r.text).toBe(`z.ai returned an error:\n${plain}`);
+  });
+
+  it("falls back to the raw body when no provider is known", async () => {
+    // errorContext is optional; with no provider there is nothing to label
+    // with, and the old behaviour (relay verbatim) must still hold.
+    const r = await renderAgentError(
+      AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+      "429 slow down",
+      resolvers
+    );
+    expect(r.text).toBe("429 slow down");
+  });
+});
+
+describe("provider display names track the registry", () => {
+  // The runtime avoids registry I/O, so pin every static/fallback label here.
+  it("matches config/providers.json for every registered provider", async () => {
+    const raw = readFileSync(
+      resolve(__dirname, "../../../../../config/providers.json"),
+      "utf8"
+    );
+    const registry: { providers: Array<{ id: string; name: string }> } =
+      JSON.parse(raw);
+
+    for (const p of registry.providers) {
+      const rendered = await renderAgentError(
+        AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+        "boom",
+        resolveNothing,
+        { provider: p.id }
+      );
+      expect(rendered.text).toBe(`${p.name} returned an error:\nboom`);
+    }
   });
 });

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -4,7 +4,11 @@
  * Generates consistent URLs for the frontend application.
  */
 
-import { AGENT_ERRORS, type AgentErrorCode } from '@lobu/core';
+import {
+  AGENT_ERRORS,
+  type AgentErrorCode,
+  type AgentErrorContext,
+} from '@lobu/core';
 import { INFERENCE_ROW_KEY_PREFIX } from '@lobu/core/reserved';
 import { getWorkspaceProvider } from '../workspace';
 import {
@@ -198,26 +202,85 @@ export interface AgentErrorCtaResolvers {
 }
 
 /**
+ * Registry names that cannot be derived by capitalising the slug. This stays
+ * static so reporting an error never depends on registry I/O; the contract test
+ * pins the values to `config/providers.json`.
+ */
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  chatgpt: 'ChatGPT',
+  'z-ai': 'z.ai',
+  'together-ai': 'Together AI',
+  nvidia: 'NVIDIA NIM',
+  fireworks: 'Fireworks AI',
+  openrouter: 'OpenRouter',
+  'opencode-zen': 'OpenCode Zen',
+  deepseek: 'DeepSeek',
+  xai: 'xAI',
+  openai: 'OpenAI API',
+  // SDK vendor alias used before a registry slug is available.
+  anthropic: 'Anthropic',
+};
+
+function providerDisplayName(slug: string): string {
+  const known = PROVIDER_DISPLAY_NAMES[slug.toLowerCase()];
+  if (known) return known;
+  return slug.charAt(0).toUpperCase() + slug.slice(1);
+}
+
+/**
+ * Label provider errors and unwrap the common JSON message envelope without
+ * rewording plain-text bodies.
+ */
+export function labelProviderErrorBody(
+  body: string | undefined,
+  provider: string | undefined
+): string | undefined {
+  if (!body) return body;
+  if (!provider) return body;
+
+  // Bodies arrive as `<status> <json>` (e.g. `400 {...}`) or bare JSON. Find the
+  // first brace so the status code does not defeat the parse.
+  const braceAt = body.indexOf('{');
+  let message = body;
+  if (braceAt !== -1) {
+    try {
+      const parsed: unknown = JSON.parse(body.slice(braceAt));
+      const inner =
+        typeof parsed === 'object' && parsed !== null
+          ? ((parsed as { error?: { message?: unknown }; message?: unknown })
+              .error?.message ??
+            (parsed as { message?: unknown }).message)
+          : undefined;
+      if (typeof inner === 'string' && inner.trim()) message = inner.trim();
+    } catch {
+      // Preserve a plain-text body that happens to contain a brace.
+    }
+  }
+
+  return `${providerDisplayName(provider)} returned an error:\n${message}`;
+}
+
+/**
  * THE renderer: turn an `AgentErrorCode` + the raw provider message into the
  * user-facing body and a resolved CTA link. Every surface — Slack/Telegram
  * bridge, browser SSE — calls this so the same error reads identically
  * everywhere.
  *
- * The body is deliberately thin: for provider errors the catalog has no text, so
- * we relay the provider's OWN message verbatim (it already says the useful thing
- * — the reset time, the bad model id). For errors we synthesize (worker/config),
- * the catalog carries the text. The code's only job is to pick the CTA *kind*;
- * this resolves that kind to a concrete URL via the matching injected resolver,
- * so "connect a provider" and "pick a model" land on their own pages instead of
- * collapsing to one.
+ * Provider errors use {@link labelProviderErrorBody}; synthesized worker/config
+ * errors use the catalog message. The catalog's CTA kind is resolved to a URL
+ * through the matching injected resolver.
  */
 export async function renderAgentError(
   code: AgentErrorCode,
   providerMessage: string | undefined,
-  resolvers: AgentErrorCtaResolvers
+  resolvers: AgentErrorCtaResolvers,
+  errorContext?: AgentErrorContext
 ): Promise<RenderedAgentError> {
   const spec = AGENT_ERRORS[code];
-  const text = spec.message ?? providerMessage ?? '';
+  const text =
+    spec.message ??
+    labelProviderErrorBody(providerMessage, errorContext?.provider) ??
+    '';
   let ctaUrl: string | null = null;
   const resolve =
     spec.cta === 'agent-settings' ||


### PR DESCRIPTION
## What

Provider failures reached users as the provider's **serialized error object**:

```
400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit
balance is too low..."},"request_id":"req_011CdVJwuwSg3kq5CWVwRR7N"}
```

Machine noise, and with no indication of *which* provider failed — the CTA named one, the body did not.

Now:

```
Claude returned an error:
Your credit balance is too low to access the Anthropic API. Please go to Plans &
Billing to upgrade or purchase credits.
[Manage provider]
```

Deliberately **not** a per-provider parser: one well-known envelope (`{error:{message}}` / `{message}`) is unwrapped, anything else relays unchanged. Applied at both surfaces (chat bridge + SSE) so a failure reads identically in Telegram/Slack and the browser.

Also classifies Anthropic's OAuth-refusal 403 (`oauth_not_allowed_for_organization`), which matched no existing pattern and surfaced as a raw `Worker crashed: 403 {...}` blob with no CTA.

## Red → green

Reverting the label/unwrap reproduces the reported string:

```
× names the provider and unwraps the JSON envelope
  → expected '400 {"type":"error","error":{"type":"…' not to contain '{"type"'
  Received: "400 {"type":"error",...,"request_id":"req_011CdVJwuwSg3kq5CWVwRR7N"}"
  Tests  1 failed | 10 passed
```

Fixed → `Tests 13 passed (13)`.

Classifier, same method — disabling the pattern:

```
Expected: "PROVIDER_AUTH"
Received: undefined
 14 pass | 1 fail
```

Fixed → `15 pass, 0 fail`.

## Verified live

Driven end to end through `lobu run` on this build, real Telegram, same bot, same failure:

- **before** — `💥 Worker crashed: 400 {"type":"error",...}` (raw blob)
- **after** — `Claude returned an error:` + the sentence + `[Manage provider]`

## The drift guard earned its place immediately

Display names are pinned to `config/providers.json` by a test. It failed on the first run against my hand-written map:

```
openai: expected "OpenAI API", got "OpenAI returned an error:"
```

The registry lists `openai` as **"OpenAI API"** and `z-ai` as **"z.ai"** — the map now matches, and drift fails the build.

## Tests

- `error-handler.test.ts` — 15 pass
- `render-agent-error.test.ts` — 13 pass
- `chat-response-bridge.test.ts` — 31 pass
- full worker suite — 748 pass
- `make pre-pr` — 6/6 gates clean

## Not in scope

`provider=anthropic, model=gemini/...` routing (the agent runs on the Claude-only `claude-code` CLI backend) is a separate architectural concern. Routing is untouched here — this PR only changes how an error *reads*.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->