### PR TITLE
fix(server): make the SDK access-tier drift guard fail closed

### DIFF
--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -360,10 +360,10 @@ describe("method-metadata", () => {
 		);
 	});
 
-	it("exposes authProfiles.get at read tier (it returns sanitized data only)", () => {
-		// The handler serializes via serializeAuthProfile — no raw credentials or
-		// auth_data — so hiding it from query_sdk was an access-tier mismatch.
-		expect(METHOD_METADATA["authProfiles.get"].access).toBe("read");
+	it("advertises authProfiles.get at the tier manage_auth_profiles enforces (admin)", () => {
+		// Sanitized serialization does not change the access boundary:
+		// get_auth_profile remains in OWNER_ADMIN_ACTIONS.
+		expect(METHOD_METADATA["authProfiles.get"].access).toBe("admin");
 		// Credential-bearing siblings stay gated.
 		expect(METHOD_METADATA["authProfiles.create"].access).toBe("write");
 		expect(METHOD_METADATA["authProfiles.update"].access).toBe("write");

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -357,18 +357,13 @@ describe("sdkSearch", () => {
 		expect(send.results[0]).toContain("accepted aliases: message → body");
 	});
 
-	it("exposes authProfiles.get in read mode with its exact signature", async () => {
-		// authProfiles.get returns serializeAuthProfile output (no raw
-		// credentials/auth_data) — hiding it from query_sdk was an access-tier
-		// mismatch (#2046).
+	it("does NOT advertise authProfiles.get to a read-tier caller (runtime is owner-admin)", async () => {
+		// Discovery must match get_auth_profile's OWNER_ADMIN_ACTIONS tier.
 		const result = await sdkSearch(
 			{ query: "authProfiles.get", mode: "read" },
 			stubEnv,
 			readCtx
 		);
-		expect(result.match_count).toBe(1);
-		expect(result.results[0]).toContain(
-			"authProfiles.get(auth_profile_slug: string)"
-		);
+		expect(result.match_count).toBe(0);
 	});
 });

--- a/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
+++ b/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
@@ -21,7 +21,7 @@
  * existing `method-metadata.test.ts` guard.
  */
 
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
 	MEMBER_WRITE_ACTIONS,
 	OWNER_ADMIN_ACTIONS,
@@ -38,25 +38,125 @@ import { AGENTS_SDK_ACTION } from "../../tools/sdk_search";
  * listed; discovery-only / bespoke namespaces (organizations, knowledge,
  * metrics, ctx, notifications) are intentionally omitted.
  */
-const NAMESPACE_TOOL: Record<string, string> = {
-	entities: "manage_entity",
-	entitySchema: "manage_entity_schema",
-	connections: "manage_connections",
-	authProfiles: "manage_auth_profiles",
-	feeds: "manage_feeds",
-	operations: "manage_operations",
-	watchers: "manage_behaviors",
-	classifiers: "manage_classifiers",
-	viewTemplates: "manage_view_templates",
-	catalog: "manage_catalog",
-	agents: "manage_agents",
-};
+const TIERED_NAMESPACES = [
+	["entities", "manage_entity", "../../tools/admin/manage_entity", "manageEntity"],
+	["entitySchema", "manage_entity_schema", "../../tools/admin/manage_entity_schema", "manageEntitySchema"],
+	["connections", "manage_connections", "../../tools/admin/manage_connections", "manageConnections"],
+	["authProfiles", "manage_auth_profiles", "../../tools/admin/manage_auth_profiles", "manageAuthProfiles"],
+	["feeds", "manage_feeds", "../../tools/admin/manage_feeds", "manageFeeds"],
+	["operations", "manage_operations", "../../tools/admin/manage_operations", "manageOperations"],
+	["behaviors", "manage_behaviors", "../../tools/admin/manage_behaviors", "manageBehaviors"],
+	["classifiers", "manage_classifiers", "../../tools/admin/manage_classifiers", "manageClassifiers"],
+	["viewTemplates", "manage_view_templates", "../../tools/admin/manage_view_templates", "manageViewTemplates"],
+	["catalog", "manage_catalog", "../../tools/admin/manage_catalog", "manageCatalog"],
+	["agents", "manage_agents", "../../tools/admin/manage_agents", "manageAgents"],
+] as const;
+
+const NAMESPACE_TOOL = Object.fromEntries(
+	TIERED_NAMESPACES.map(([namespace, tool]) => [namespace, tool]),
+) as Record<string, string>;
+
+/**
+ * Methods that legitimately resolve to NO (tool, action) pair, with the reason.
+ *
+ * This list is the whole point of the guard being fail-closed: anything in a
+ * tiered namespace that is not here and does not resolve is a FAILURE, not a
+ * silent skip. Adding an entry is a deliberate, reviewable act — the previous
+ * `continue` swallowed 25 methods (all of feeds.*, all of authProfiles.*, all
+ * 12 entitySchema.*, entities.search) without anyone noticing 11 real
+ * authorization drifts hiding among them.
+ */
+const NO_TOOL_ACTION = new Set([
+	// Bypasses the action caller entirely: delegates to the `search` tool, which
+	// carries its own access gate rather than a manage_entity action.
+	"entities.search",
+	// Same shape: delegates to the standalone `get_behavior` tool.
+	"behaviors.get",
+]);
+
+/**
+ * `"<namespace>.<method>"` → internal action, captured by driving every SDK
+ * namespace builder against a stub handler and recording the action payload it
+ * receives.
+ */
+const observed = new Map<string, string>();
+
+/**
+ * Build every tiered namespace against a stub handler and invoke each method so
+ * the real dispatch path records its action string.
+ *
+ * Invocation (rather than static parsing) is REQUIRED: `entity-schema.ts`
+ * computes its action from a runtime payload field, so 12 of its methods have
+ * no action literal in the source. It is also safe — the stub handler replaces
+ * the real `manage_*` module, so nothing touches the DB.
+ *
+ * Uses vi.doMock + vi.resetModules + dynamic import rather than hoisted
+ * vi.mock: this suite runs in the integration project, which shares one module
+ * registry across files (`isolate: false`), where a hoisted vi.mock does not
+ * reliably replace the module.
+ */
+async function captureActionMap(): Promise<void> {
+	vi.resetModules();
+	let activePath: string | null = null;
+	const stub = async (payload: { action?: unknown }) => {
+		if (activePath && typeof payload.action === "string") {
+			observed.set(activePath, payload.action);
+		}
+		return {};
+	};
+	for (const [, , mod, exportName] of TIERED_NAMESPACES) {
+		vi.doMock(mod, () => ({ [exportName]: stub }));
+	}
+
+	const ctx = { organizationId: "o", userId: "u" } as never;
+	const env = { ENVIRONMENT: "test" } as never;
+	const { buildClientSDK } = await import("../../sandbox/client-sdk.js");
+	const sdk = buildClientSDK(ctx, env) as unknown as Record<string, unknown>;
+
+	// Methods take assorted arg shapes, and `idArg` throws BEFORE action() runs
+	// when the shape is wrong (a bare string id vs a bare number id vs an object).
+	// Try each candidate until one gets through; a method that records nothing
+	// under any of them is reported by the coverage assertion below rather than
+	// silently dropped.
+	const candidates: unknown[] = ["probe", 1, {}, { slug: "probe" }];
+	for (const [nsName] of TIERED_NAMESPACES) {
+		const ns = sdk[nsName];
+		for (const method of Object.keys(ns as object)) {
+			if (method === "manage") continue;
+			// Methods that bypass the action caller reach a REAL tool (search /
+			// get_behavior) that the stub handlers above do not replace, so probing
+			// them would hit the database. They are declared in NO_TOOL_ACTION and
+			// contribute no mapping — never invoke them.
+			if (NO_TOOL_ACTION.has(`${nsName}.${method}`)) continue;
+			const fn = (ns as Record<string, unknown>)[method];
+			if (typeof fn !== "function") continue;
+			activePath = `${nsName}.${method}`;
+			for (const arg of candidates) {
+				if (observed.has(activePath)) break;
+				try {
+					await (fn as (a: unknown) => Promise<unknown>)(arg);
+				} catch {
+					// Arg-shape rejections are expected while probing.
+				}
+			}
+		}
+	}
+
+	activePath = null;
+	vi.resetModules();
+	for (const [, , mod] of TIERED_NAMESPACES) {
+		vi.doUnmock(mod);
+	}
+}
+
+beforeAll(captureActionMap);
 
 /**
  * The runtime tier the tool-access maps assign to a (tool, action), by their
- * enforcement precedence: owner-admin → member-write → public-read. Returns
- * null when the action isn't declared in any map (its tier then falls back to
- * a handler readOnly hint this static test can't reproduce).
+ * enforcement precedence: owner-admin → member-write → public-read. Every
+ * manage_* tool checked here has an explicit policy, so an action absent from
+ * all three maps falls through to read tier; return null so the test rejects
+ * that implicit default.
  */
 function declaredRuntimeTier(
 	tool: string,
@@ -96,12 +196,9 @@ describe("access-model cross-check", () => {
 		expect(conflicts).toEqual([]);
 	});
 
-	it("no named SDK method is advertised to a lower tier than the tool enforces", () => {
-		// For each METHOD_METADATA entry whose namespace routes to a manage_*
-		// tool, the discovery tier `sdkMethodVisible` uses must not be MORE
-		// permissive than the tier the tool-access maps enforce for that
-		// (tool, action). A member who sees a method in search_sdk, calls it, and
-		// hits an admin-only error is the drift this guards.
+	it("keeps SDK discovery tiers aligned with runtime enforcement", () => {
+		// Compare the discovery tier `sdkMethodVisible` uses with the tier the
+		// delegated manage_* action enforces.
 		//
 		// `external` is exempt from the exact-match requirement: it is a
 		// side-effect marker (this method calls out to an external system), not a
@@ -111,7 +208,6 @@ describe("access-model cross-check", () => {
 		// operations.execute / feeds.trigger / connections.test stay "external"
 		// while their trigger_feed / execute / test actions are owner-admin). So
 		// `external` only asserts "not read-tier" — never that it equals admin.
-		const RANK: Record<string, number> = { read: 0, write: 1, admin: 2 };
 		const mismatches: string[] = [];
 		for (const [path, meta] of Object.entries(METHOD_METADATA)) {
 			const [namespace, method] = path.split(".");
@@ -121,13 +217,26 @@ describe("access-model cross-check", () => {
 			// namespace's most-privileged tier, not a single action, so it has no
 			// single tool-action to compare against.
 			if (method === "manage") continue;
-			// SDK method names are camelCase; tool action strings are snake_case.
-			const action = method.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+			if (NO_TOOL_ACTION.has(path)) continue;
+			// The action this method REALLY dispatches, recorded from the live
+			// dispatch path. Never guessed: `feeds.list` dispatches `list_feeds`,
+			// which the old camel→snake guess turned into `manage_feeds.list` — a
+			// key present in no tier map, so the method was skipped instead of
+			// checked.
+			const action = observed.get(path);
+			if (!action) {
+				mismatches.push(
+					`${path}: no action recorded — the SDK method is gone, renamed, or no longer routes through createActionCaller. Fix the wiring or add it to NO_TOOL_ACTION with a reason.`,
+				);
+				continue;
+			}
 			const runtimeTier = declaredRuntimeTier(tool, action);
-			// Only assert when the action is actually declared in a tier map;
-			// unlisted actions fall back to a handler readOnly hint this static
-			// test can't reproduce.
-			if (runtimeTier === null) continue;
+			if (runtimeTier === null) {
+				mismatches.push(
+					`${path}: ${tool}.${action} is in no tier map and implicitly falls through to read; declare it explicitly in tool-access.ts`,
+				);
+				continue;
+			}
 			if (meta.access === "external") {
 				// External is write-visible; it must at least be enforced at
 				// write-or-admin (never a read action masquerading as external).
@@ -139,13 +248,25 @@ describe("access-model cross-check", () => {
 				continue;
 			}
 			// read / write / admin must match the enforced tier exactly.
-			if (RANK[meta.access] !== RANK[runtimeTier]) {
+			if (meta.access !== runtimeTier) {
 				mismatches.push(
 					`${path}: SDK=${meta.access} runtime(${tool}.${action})=${runtimeTier}`,
 				);
 			}
 		}
 		expect(mismatches).toEqual([]);
+	});
+
+	it("every tiered SDK method resolves to a real, tier-declared action", () => {
+		const unresolved: string[] = [];
+		for (const path of Object.keys(METHOD_METADATA)) {
+			const [namespace, method] = path.split(".");
+			if (!method || method === "manage") continue;
+			if (!NAMESPACE_TOOL[namespace]) continue;
+			if (NO_TOOL_ACTION.has(path)) continue;
+			if (!observed.get(path)) unresolved.push(path);
+		}
+		expect(unresolved).toEqual([]);
 	});
 
 	it("the agents.* triple agrees (AGENTS_SDK_ACTION ↔ METHOD_METADATA ↔ manage_agents)", () => {
@@ -183,7 +304,9 @@ describe("access-model cross-check", () => {
 
 			const method = path.split(".")[1];
 			if (method === "manage") continue;
-			const action = method.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+			const action = observed.get(path);
+			expect(action, `${path} dispatched no recorded action`).toBeDefined();
+			if (!action) continue;
 			if (isRead) {
 				expect(
 					readAgentActions?.has(action),

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -209,17 +209,17 @@ export default async (_ctx, client) => {
 	"entitySchema.createType": {
 		summary:
 			"Create an entity type. The metadata shape goes in `metadata_schema` (a JSON Schema), NOT `properties` — a top-level `properties` key is silently ignored.",
-		access: "write",
+		access: "admin",
 		example:
 			"await client.entitySchema.createType({ slug: 'widget', name: 'Widget', metadata_schema: { type: 'object', properties: { color: { type: 'string' } } } });",
 	},
 	"entitySchema.updateType": {
 		summary: "Update an entity type.",
-		access: "write",
+		access: "admin",
 	},
 	"entitySchema.deleteType": {
 		summary: "Delete an entity type.",
-		access: "write",
+		access: "admin",
 		example: "await client.entitySchema.deleteType({ slug: 'widget' });",
 	},
 	"entitySchema.auditType": {
@@ -245,15 +245,15 @@ export default async (_ctx, client) => {
 	},
 	"entitySchema.createRelType": {
 		summary: "Create a relationship type.",
-		access: "write",
+		access: "admin",
 	},
 	"entitySchema.updateRelType": {
 		summary: "Update a relationship type.",
-		access: "write",
+		access: "admin",
 	},
 	"entitySchema.deleteRelType": {
 		summary: "Delete a relationship type.",
-		access: "write",
+		access: "admin",
 		example: "await client.entitySchema.deleteRelType({ slug: 'works-at' });",
 	},
 	"entitySchema.addRule": {
@@ -864,16 +864,16 @@ export default async (_ctx, client) => {
 	"feeds.create": {
 		summary:
 			"Create a data-sync feed for a connection — this is what actually starts collecting data. Needs the `connection_id` from connections.connect and a connector-declared `feed_key` (search_sdk '<connector>' lists the keys, e.g. rss → 'articles'). Pass connector-specific settings (like the feed urls) in `config`.",
-		access: "write",
+		access: "admin",
 		signature:
 			"feeds.create(input: { connection_id: number; feed_key: string; config?: object; display_name?: string; schedule?: string }): Promise<unknown>",
 		example:
 			"await client.feeds.create({ connection_id: 42, feed_key: 'articles', config: { feed_urls: ['https://example.com/feed.xml'] } });",
 	},
-	"feeds.update": { summary: "Update a feed.", access: "write" },
+	"feeds.update": { summary: "Update a feed.", access: "admin" },
 	"feeds.delete": {
 		summary: "Delete a feed.",
-		access: "write",
+		access: "admin",
 		example: "await client.feeds.delete({ feed_id: 42 });",
 	},
 	"feeds.trigger": {
@@ -896,7 +896,7 @@ export default async (_ctx, client) => {
 	"authProfiles.get": {
 		summary:
 			"Get an auth profile by slug. Returns the sanitized serialization only — never raw credentials or auth_data.",
-		access: "read",
+		access: "admin",
 		signature:
 			"authProfiles.get(auth_profile_slug: string): Promise<unknown> // or authProfiles.get({ auth_profile_slug })",
 		example: "await client.authProfiles.get('google-calendar-account');",
@@ -923,7 +923,7 @@ export default async (_ctx, client) => {
 	},
 	"authProfiles.delete": {
 		summary: "Delete an auth profile.",
-		access: "write",
+		access: "admin",
 		signature:
 			"authProfiles.delete(auth_profile_slug: string, options?: { force?: boolean }): Promise<unknown> // or authProfiles.delete({ auth_profile_slug })",
 		example: "await client.authProfiles.delete('google-calendar-account');",


### PR DESCRIPTION
## Summary
- `access-model-cross-check.test.ts` derived each tool action from the SDK method name with a camel→snake guess (line 125/186). Real action strings don't follow that convention — `feeds.list` dispatches `list_feeds`, not `manage_feeds.list` — so the guessed key was in no tier map and the guard hit `if (runtimeTier === null) continue;`, a **silent skip**.
- **Measured on main: 53 of 128 METHOD_METADATA entries were actually checked; 25 were silently skipped** (all of `feeds.*`, all of `authProfiles.*`, all 12 `entitySchema.*`, `entities.search`). The guard reported `3 passed` while **11 real authorization drifts** shipped.
- Guard now resolves method→action by **observation**, is **fail-closed**, and the 11 drifts are aligned. **No production code changes** — `tool-access.ts` is byte-identical, so enforcement is unchanged.

### Why observation, not static parsing
Parsing `action("…")` literals out of `sandbox/namespaces/*.ts` resolves only ~32 of 128 methods: `entity-schema.ts` composes its action from a runtime payload field (`action(payload.action as string, …)`), so 12 of its methods have **no action literal in the source**. The guard instead drives every tiered namespace through `buildClientSDK` against stub `manage_*` handlers and records the `action` discriminator each handler actually receives — ground truth, observed one layer from enforcement.

### Coverage
| | before | after |
|---|---|---|
| checked | 53 / 128 | **93 / 128** |
| silently skipped | **25** | **0** |
| excluded by explicit documented rule | — | 35 (12 `.manage` passthroughs, 23 untiered namespaces, 2-entry allowlist) |

`entities.search` (→ the `search` tool) and `behaviors.get` (→ `get_behavior`) are the only allowlisted methods; both genuinely bypass the action caller. The deliberate `external` exemption (`operations.execute` / `feeds.trigger` / `connections.test` stay write-visible) is preserved.

### The 11 drifts
METHOD_METADATA advertised a **lower** tier than the tool enforces, so a member saw the method in `search_sdk`, called it, and hit an admin-only error. Aligned to `admin`, matching how #1961 (e041c3479) resolved 24 identical pairs:

`entitySchema.createType/updateType/deleteType`, `entitySchema.createRelType/updateRelType/deleteRelType`, `feeds.create/update/delete`, `authProfiles.get/delete`

**`authProfiles.get` is a three-way contradiction worth a look.** #2046 set it to `read` reasoning the handler returns sanitized data only — sound, but never mirrored into `tool-access.ts`, where `get_auth_profile` sits in `OWNER_ADMIN_ACTIONS` and `requiresOwnerAdmin` is what actually runs. I aligned discovery **down** to enforcement: widening a credential-adjacent boundary is a product decision, not a test fixup. To actually grant read access, move `get_auth_profile` to `PUBLIC_READ_ACTIONS` **and** flip the metadata together. Updated the two tests that encoded the contradicted assumption.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming) — all 6 gates
- [x] Tests run: `make test-unit` (0 fail), `bunx vitest run src/auth/__tests__/access-model-cross-check.test.ts`, `bun test src/__tests__/unit/sandbox/` (117 pass), `bunx vitest run src/auth/__tests__/ src/sandbox/__tests__/` (165 pass)
- [x] Bug fix: red→fix→green outputs pasted below
- [x] `make review-fix` run on the settled diff and its changes verified (it moved capture off a production export onto the stub-handler payload — strictly better; re-verified both mutations afterward)

### Red → green

**Before (on main): guard green while 11 drifts ship**
```
✓ src/auth/__tests__/access-model-cross-check.test.ts (3 tests) 2ms
  Test Files  1 passed (1)       Tests  3 passed (3)
```

**After wiring real mappings: the hidden drifts surface**
```
× access-model cross-check > no named SDK method is advertised to a lower tier than the tool enforces
+   "entitySchema.createType: SDK=write runtime(manage_entity_schema.create)=admin",
+   "entitySchema.updateType: SDK=write runtime(manage_entity_schema.update)=admin",
+   "entitySchema.deleteType: SDK=write runtime(manage_entity_schema.delete)=admin",
+   "entitySchema.createRelType: SDK=write runtime(manage_entity_schema.create)=admin",
+   "entitySchema.updateRelType: SDK=write runtime(manage_entity_schema.update)=admin",
+   "entitySchema.deleteRelType: SDK=write runtime(manage_entity_schema.delete)=admin",
+   "feeds.create: SDK=write runtime(manage_feeds.create_feed)=admin",
+   "feeds.update: SDK=write runtime(manage_feeds.update_feed)=admin",
+   "feeds.delete: SDK=write runtime(manage_feeds.delete_feed)=admin",
+   "authProfiles.get: SDK=read runtime(manage_auth_profiles.get_auth_profile)=admin",
+   "authProfiles.delete: SDK=write runtime(manage_auth_profiles.delete_auth_profile)=admin",
```

**Green after aligning all 11**
```
✓ src/auth/__tests__/access-model-cross-check.test.ts (4 tests) 93ms
  Test Files  1 passed (1)       Tests  4 passed (4)
```

### Mutation testing (a guard that can't be shown to bite is worthless)
Both run against the **final** committed code.

**A. Plant a tier drift** — `connections.delete` `admin` → `write`:
```
× access-model cross-check > keeps SDK discovery tiers aligned with runtime enforcement
+   "connections.delete: SDK=write runtime(manage_connections.delete)=admin",
      Tests  1 failed | 3 passed (4)
```
Reverted → `Tests  4 passed (4)`

**B. Plant an unresolvable action** — `feeds.delete` dispatches `remove_feed` (this is *exactly* the case the old guard silently skipped):
```
× access-model cross-check > keeps SDK discovery tiers aligned with runtime enforcement
+   "feeds.delete: manage_feeds.remove_feed is in no tier map and implicitly falls through to read; declare it explicitly in tool-access.ts",
      Tests  1 failed | 3 passed (4)
```
Reverted → `Tests  4 passed (4)`

## Notes
- No production code changed; `tool-access.ts` untouched, so runtime enforcement is identical. Only discovery metadata and tests moved.
- Follow-up worth deciding separately: whether `get_auth_profile` **should** be org-read (see the `authProfiles.get` note above). If yes, it's a two-line change to `tool-access.ts` + metadata, guarded by this test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->