### PR TITLE
fix(server): prove the tenant before scoping org-less agent history

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-history-authorization.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-authorization.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
+import type { AgentConfigStore } from "@lobu/core";
 import { Hono } from "hono";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import type { UserAgentsStore } from "../auth/user-agents-store.js";
@@ -44,4 +45,93 @@ test("keeps an agent-bound session scoped to its agent in the ambient org", asyn
 	);
 
 	expect(response.status).toBe(401);
+});
+
+const FOREIGN_ORG_ID = "test-org-agent-history-foreign";
+const SHARED_AGENT_ID = "lobu-builder";
+
+test("rejects no-ambient history when only unscoped metadata names an org", async () => {
+	const userAgentsStore = {
+		findAgentOrganizations: async () => [],
+		ownsAgent: async () => false,
+		addAgent: async () => {},
+	} as unknown as UserAgentsStore;
+	const agentConfigStore = {
+		getMetadata: async (agentId: string) =>
+			agentId === SHARED_AGENT_ID
+				? {
+						agentId: SHARED_AGENT_ID,
+						name: "Builder",
+						owner: { platform: "external", userId: "history-user" },
+						organizationId: FOREIGN_ORG_ID,
+						createdAt: 0,
+						lastUsedAt: null,
+					}
+				: null,
+	} as unknown as Pick<AgentConfigStore, "getMetadata">;
+	const app = new Hono();
+	app.route(
+		"/api/v1/agents/:agentId/history",
+		createAgentHistoryRoutes({ userAgentsStore, agentConfigStore }),
+	);
+	setAuthProvider(() => ({
+		userId: "history-user",
+		platform: "external",
+		exp: Date.now() + 60_000,
+	}));
+
+	const response = await app.request(
+		`/api/v1/agents/${SHARED_AGENT_ID}/history/threads`,
+	);
+
+	expect(response.status).toBe(401);
+});
+
+test("rejects no-ambient admin history without a tenant scope", async () => {
+	const app = new Hono();
+	app.route(
+		"/api/v1/agents/:agentId/history",
+		createAgentHistoryRoutes({}),
+	);
+	setAuthProvider(() => ({
+		userId: "history-admin",
+		platform: "external",
+		isAdmin: true,
+		exp: Date.now() + 60_000,
+	}));
+
+	const response = await app.request(
+		`/api/v1/agents/${SHARED_AGENT_ID}/history/session/messages`,
+	);
+
+	expect(response.status).toBe(401);
+});
+
+test("uses the single agent_users org without consulting metadata", async () => {
+	const userAgentsStore = {
+		findAgentOrganizations: async () => [FOREIGN_ORG_ID],
+		ownsAgent: async () => false,
+		addAgent: async () => {},
+	} as unknown as UserAgentsStore;
+	const agentConfigStore = {
+		getMetadata: async () => {
+			throw new Error("metadata fallback should not run");
+		},
+	} as unknown as Pick<AgentConfigStore, "getMetadata">;
+	const app = new Hono();
+	app.route(
+		"/api/v1/agents/:agentId/history",
+		createAgentHistoryRoutes({ userAgentsStore, agentConfigStore }),
+	);
+	setAuthProvider(() => ({
+		userId: "history-user",
+		platform: "external",
+		exp: Date.now() + 60_000,
+	}));
+
+	const response = await app.request(
+		`/api/v1/agents/${SHARED_AGENT_ID}/history/threads/invalid%21/messages`,
+	);
+
+	expect(response.status).toBe(400);
 });

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -431,9 +431,10 @@ export function createAgentHistoryRoutes(deps: {
 		// Apply the resolver's admin bypass and agent-binding restriction before
 		// selecting a tenant from the ambient request.
 		if (session.isAdmin) {
+			if (!ambientOrgId) return null;
 			return {
 				agentId,
-				organizationId: ambientOrgId ?? undefined,
+				organizationId: ambientOrgId,
 				userId,
 			};
 		}
@@ -458,11 +459,21 @@ export function createAgentHistoryRoutes(deps: {
 			return null;
 		}
 
+		// History DB reads and worker/file fallbacks all require a proven tenant.
+		// Metadata can be org-less here, so resolve the tenant independently from
+		// the authoritative per-org owner mapping.
 		const result = await resolveOwnership(session, agentId);
 		if (!result.authorized) return null;
+		const ownerOrganizations =
+			await deps.userAgentsStore?.findAgentOrganizations(
+				result.ownerPlatform ?? session.platform,
+				result.ownerUserId ?? userId,
+				agentId,
+			);
+		if (ownerOrganizations?.length !== 1) return null;
 		return {
 			agentId,
-			organizationId: resolveOrgId(result.organizationId) ?? undefined,
+			organizationId: ownerOrganizations[0],
 			userId,
 		};
 	}


### PR DESCRIPTION
## Summary
- `getAuthorizedAgentScope`'s ownership fallback could scope an agent-history read to an **arbitrary tenant**. It is reached only when the request carries **no ambient org** — a bot-issued `/connect/claim` settings cookie has no Better Auth user, so `createLobuOrgContextMiddleware` calls `next()` without opening an `orgContext`.
- On that path `resolveOrgId(result.organizationId)` was a **no-op** (the `if (ambientOrgId)` branch above returns in every case, so its ambient fallback is provably null). The org therefore came straight from `verifyOwnedAgentAccess`'s metadata branch, which reads `AgentConfigStore.getMetadata` — and that only filters by org when an ambient org exists. With none it runs `WHERE id = $agentId`, **no org predicate and no ORDER BY**. `agents` is keyed `(organization_id, id)`, so a shared system-agent id (`lobu-builder` exists in ~20 orgs) matches one row per tenant and `rows[0]` is arbitrary. The `owner_*` columns it vouches against are legacy and unique only by convention, so that arbitrary row can still name the caller. The result was passed to `listAgentThreads` as the transcript read scope.
- Fix: resolve the tenant independently from `agent_users` (the authoritative per-org owner mapping) and decline unless it names exactly one org. Same reasoning applied to the admin bypass, which previously returned an undefined org.

Scope note: `resolveOrgId` itself is **unchanged**. Making an explicit/ambient disagreement throw was considered and rejected — its call sites include worker/token paths where the explicit org legitimately wins (classification below).

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming) — exit 0
- [x] Tests run: `make test-unit` (exit 0, `0 fail` across all 9 suites); targeted DB-backed run with `DATABASE_URL` — 47/47
- [x] Bug fix: red→fix→green outputs pasted below

### RED (source at `origin/main`, new tests present)
```
$ git checkout origin/main -- packages/server/src/gateway/routes/public/agent-history.ts
$ bun test packages/server/src/gateway/__tests__/agent-history-authorization.test.ts

(fail) rejects no-ambient history when only unscoped metadata names an org [1.36ms]
(fail) rejects no-ambient admin history without a tenant scope [1.46ms]
 2 pass
 2 fail
```

Before the fix the first case resolved the tenant to `test-org-agent-history-foreign` — an org the caller proved no membership in — and passed it to `listAgentThreads` as the read scope.

### GREEN (with fix)
```
$ bun test packages/server/src/gateway/__tests__/agent-history-authorization.test.ts \
    packages/server/src/gateway/__tests__/agent-history-routes.test.ts \
    packages/server/src/gateway/__tests__/agent-ownership.test.ts \
    packages/server/src/gateway/__tests__/agent-session-create-cross-org-owner.test.ts \
    packages/server/src/gateway/__tests__/agent-transcript-snapshot.test.ts

 60 pass
 0 fail
Ran 60 tests across 5 files.
```

DB-backed (`DATABASE_URL` from `.env`):
```
 47 pass
 0 fail
Ran 47 tests across 3 files.
```

`make test-unit`: exit 0, `0 fail` across all 9 suites.

### Non-regression guard
`uses the single agent_users org without consulting metadata` stubs `getMetadata` to **throw**, proving a legitimate single-org owner resolves via `agent_users` and never reaches the metadata fallback. This is what keeps real `/connect/claim` users working rather than 401-ing.

## Notes
Reconnaissance for a follow-up, no code changed here — the shared `resolveOrgId`/`requireOrgId` helper has **18** non-test call sites (an earlier count of ~49 conflated tests plus a same-named **local** `requireOrgId(c: any)` in `lobu/agent-routes.ts:1876` that reads the Hono context and is unrelated):

| Class | Count | Sites | Explicit org wins correctly? |
|---|---|---|---|
| Ambient-request (store methods under `orgContext`) | 12 | `grant-store.ts` (5), `user-agents-store.ts` (3), `behavior-subscription-service.ts` (4) | Explicit arg is normally absent; ambient supplies the tenant |
| Worker/token & provider-context | 3 | `base-provider-module.ts` (3, all `context?.organizationId`) | **Yes** — credential resolution runs outside a request; no ambient context exists |
| Ambient-read only (no explicit arg) | 2 | `agent-history.ts:429`, `:506` — both `resolveOrgId()` | N/A |
| Fixed here | 1 | `agent-history.ts:465` | Was the only site feeding an **ownership-derived** org in as the explicit arg |

The `base-provider-module.ts` group is the concrete reason a throw-on-disagreement change to `resolveOrgId` would be wrong.

Remaining latent issue, deliberately **not** fixed here to keep this diff scoped to the tenant-isolation bug: `AgentConfigStore.getMetadata`'s org-less branch (`packages/server/src/lobu/stores/postgres-stores.ts:215`) still returns an arbitrary row for a shared agent id when no ambient org is set. This PR removes the one path that turned that into a cross-tenant read; other `getMetadata` consumers should be audited separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->