### PR TITLE
fix(server): validate guardrails carried on skills at the write boundary

### DIFF
--- a/packages/server/src/lobu/__tests__/agent-routes-guardrail-trips.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-guardrail-trips.test.ts
@@ -362,4 +362,103 @@ describe('GET /agents/:agentId/guardrail-trips', () => {
     expect(garbage.status).toBe(200);
     expect(((await garbage.json()) as { trips: unknown[] }).trips).toHaveLength(3);
   });
+
+  // These drive the real PATCH route, not the exported validator: the plausible
+  // way this ships broken is the helper existing but never being called.
+  test('rejects a malformed skill pre-tool guardrail through the route', async () => {
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        skillsConfig: {
+          skills: [
+            {
+              repo: 'file/x',
+              name: 'x',
+              enabled: true,
+              // No `kind` — the core union requires it on both arms.
+              guardrails: { 'pre-tool': [{ policy: 'deny everything' }] },
+            },
+          ],
+        },
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string; error_description?: string };
+    expect(body.error).toBe('invalid_guardrail');
+    expect(body.error_description).toContain('pre-tool');
+  });
+
+  test('rejects a skill judge guardrail with no model when no gateway default is set', async () => {
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        skillsConfig: {
+          skills: [
+            {
+              repo: 'file/x',
+              name: 'needs-model',
+              enabled: true,
+              guardrails: { 'pre-tool': [{ kind: 'judge', policy: 'deny' }] },
+            },
+          ],
+        },
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe('guardrail_model_required');
+  });
+
+  test('accepts a well-formed skill guardrail payload', async () => {
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        skillsConfig: {
+          skills: [
+            {
+              repo: 'file/x',
+              name: 'x',
+              enabled: true,
+              guardrails: {
+                'pre-tool': [
+                  { kind: 'builtin', name: 'secret-scan' },
+                  { kind: 'judge', policy: 'no rm -rf', model: 'anthropic/claude-haiku-4-5' },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('a disabled skill is not subject to the judge-model requirement', async () => {
+    // Matches the aggregator: a disabled skill never materializes, so rejecting
+    // it would fail a payload that cannot run.
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        skillsConfig: {
+          skills: [
+            {
+              repo: 'file/x',
+              name: 'off',
+              enabled: false,
+              guardrails: { 'pre-tool': [{ kind: 'judge', policy: 'deny' }] },
+            },
+          ],
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
 });

--- a/packages/server/src/lobu/__tests__/agent-routes-guardrail-trips.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-guardrail-trips.test.ts
@@ -439,6 +439,32 @@ describe('GET /agents/:agentId/guardrail-trips', () => {
     expect(res.status).toBe(200);
   });
 
+  test('a truthy non-boolean enabled cannot bypass the model requirement', async () => {
+    // The runtime enables on truthiness, so `enabled: "yes"` would run while
+    // skipping a `enabled === true` model check. Rejected at the boundary.
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        skillsConfig: {
+          skills: [
+            {
+              repo: 'file/x',
+              name: 'sneaky',
+              enabled: 'yes',
+              guardrails: { 'pre-tool': [{ kind: 'judge', policy: 'deny' }] },
+            },
+          ],
+        },
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string; error_description?: string };
+    expect(body.error).toBe('invalid_guardrail');
+    expect(body.error_description).toMatch(/enabled must be a boolean/);
+  });
+
   test('a disabled skill is not subject to the judge-model requirement', async () => {
     // Matches the aggregator: a disabled skill never materializes, so rejecting
     // it would fail a payload that cannot run.

--- a/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
@@ -284,6 +284,43 @@ describe("validateSkillsConfigGuardrails", () => {
     ).toMatch(/tools must be an array of strings/);
   });
 
+  test("rejects a present-but-empty judge model", () => {
+    // judge-runner resolves `input.model ?? defaultModel`, so "" is passed
+    // through rather than falling back to EGRESS_JUDGE_MODEL. Omitting the key
+    // is the way to inherit the default.
+    for (const model of ["", "   "]) {
+      expect(
+        validateSkillsConfigGuardrails(
+          wrap({ "pre-tool": [{ kind: "judge", policy: "p", model }] })
+        )
+      ).toMatch(/model must be a non-empty string when present/);
+    }
+    // Absent is fine — that is the inherit-the-default path.
+    expect(
+      validateSkillsConfigGuardrails(
+        wrap({ "pre-tool": [{ kind: "judge", policy: "p" }] })
+      )
+    ).toBeNull();
+  });
+
+  test("rejects a non-boolean enabled", () => {
+    // The runtime tests `s.enabled &&` (truthiness), so a truthy non-boolean
+    // would materialize while skipping the route's judge-model check, which
+    // compares against `true`. Pinning the type keeps the two in agreement.
+    for (const enabled of ["yes", 1, {}]) {
+      expect(
+        validateSkillsConfigGuardrails({
+          skills: [{ repo: "f/x", name: "x", enabled }],
+        })
+      ).toMatch(/enabled must be a boolean/);
+    }
+    expect(
+      validateSkillsConfigGuardrails({
+        skills: [{ repo: "f/x", name: "x", enabled: false }],
+      })
+    ).toBeNull();
+  });
+
   test("rejects malformed containers", () => {
     expect(validateSkillsConfigGuardrails({ skills: "nope" })).toMatch(
       /skills must be an array/

--- a/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
@@ -16,7 +16,8 @@ import { describe, expect, test } from "bun:test";
 import { installRouteTestMocks } from "./helpers/route-test-mocks";
 
 installRouteTestMocks();
-const { validateGuardrailsInline } = await import("../agent-routes.js");
+const { validateGuardrailsInline, validateSkillsConfigGuardrails } =
+  await import("../agent-routes.js");
 
 describe("validateGuardrailsInline", () => {
   test("returns null for an absent payload", () => {
@@ -185,5 +186,128 @@ describe("validateGuardrailsInline", () => {
         },
       ])
     ).toMatch(/model must be a string/);
+  });
+});
+
+/**
+ * `skillsConfig[].guardrails["pre-tool"]` had no write-boundary validation: the
+ * PATCH route spreads `skillsConfig` through untouched, so a malformed entry was
+ * persisted verbatim and then ran on every `tools/call`. These pin the sibling
+ * validator against `SkillPreToolGuardrailSchema`.
+ */
+describe("validateSkillsConfigGuardrails", () => {
+  const wrap = (guardrails: unknown) => ({
+    skills: [{ repo: "file/x", name: "x", enabled: true, guardrails }],
+  });
+
+  test("returns null for payloads with nothing to check", () => {
+    expect(validateSkillsConfigGuardrails(undefined)).toBeNull();
+    expect(validateSkillsConfigGuardrails({})).toBeNull();
+    expect(validateSkillsConfigGuardrails({ skills: [] })).toBeNull();
+    // A skill with no guardrails is the overwhelmingly common shape.
+    expect(
+      validateSkillsConfigGuardrails({
+        skills: [{ repo: "file/x", name: "x", enabled: true }],
+      })
+    ).toBeNull();
+  });
+
+  test("accepts the two valid arms", () => {
+    expect(
+      validateSkillsConfigGuardrails(
+        wrap({ "pre-tool": [{ kind: "builtin", name: "secret-scan" }] })
+      )
+    ).toBeNull();
+    expect(
+      validateSkillsConfigGuardrails(
+        wrap({
+          "pre-tool": [
+            {
+              kind: "judge",
+              policy: "no destructive commands",
+              tools: ["Bash"],
+              model: "anthropic/claude-haiku-4-5",
+            },
+          ],
+        })
+      )
+    ).toBeNull();
+  });
+
+  test("rejects a missing or unknown kind", () => {
+    // Unlike guardrailsInline, an omitted `kind` is NOT defaulted here: the core
+    // union makes it a required literal on both arms.
+    expect(
+      validateSkillsConfigGuardrails(wrap({ "pre-tool": [{ policy: "x" }] }))
+    ).toMatch(/kind must be "builtin" or "judge"/);
+    expect(
+      validateSkillsConfigGuardrails(
+        wrap({ "pre-tool": [{ kind: "require-tool", policy: "x" }] })
+      )
+    ).toMatch(/kind must be "builtin" or "judge"/);
+  });
+
+  test("rejects a judge with an empty policy", () => {
+    // createJudgeGuardrail hashes the policy; an empty one judges nothing.
+    expect(
+      validateSkillsConfigGuardrails(
+        wrap({ "pre-tool": [{ kind: "judge", policy: "   " }] })
+      )
+    ).toMatch(/policy must be a non-empty string/);
+  });
+
+  test("rejects fields the builtin arm silently ignores", () => {
+    // The aggregator drops these for built-ins by design, so persisting them
+    // would misrepresent what actually runs.
+    expect(
+      validateSkillsConfigGuardrails(
+        wrap({ "pre-tool": [{ kind: "builtin", name: "s", model: "x" }] })
+      )
+    ).toMatch(/model is not supported for kind "builtin"/);
+    expect(
+      validateSkillsConfigGuardrails(
+        wrap({ "pre-tool": [{ kind: "builtin", name: "s", tools: ["Bash"] }] })
+      )
+    ).toMatch(/tools is not supported for kind "builtin"/);
+  });
+
+  test("rejects malformed optional fields on a judge", () => {
+    expect(
+      validateSkillsConfigGuardrails(
+        wrap({ "pre-tool": [{ kind: "judge", policy: "p", model: 42 }] })
+      )
+    ).toMatch(/model must be a string/);
+    expect(
+      validateSkillsConfigGuardrails(
+        wrap({ "pre-tool": [{ kind: "judge", policy: "p", tools: [1] }] })
+      )
+    ).toMatch(/tools must be an array of strings/);
+  });
+
+  test("rejects malformed containers", () => {
+    expect(validateSkillsConfigGuardrails({ skills: "nope" })).toMatch(
+      /skills must be an array/
+    );
+    expect(validateSkillsConfigGuardrails(wrap("nope"))).toMatch(
+      /guardrails must be an object/
+    );
+    expect(validateSkillsConfigGuardrails(wrap({ "pre-tool": {} }))).toMatch(
+      /must be an array/
+    );
+  });
+
+  test("error paths name the offending entry", () => {
+    const err = validateSkillsConfigGuardrails({
+      skills: [
+        { repo: "a", name: "a", enabled: true },
+        {
+          repo: "b",
+          name: "b",
+          enabled: true,
+          guardrails: { "pre-tool": [{ kind: "builtin", name: "ok" }, {}] },
+        },
+      ],
+    });
+    expect(err).toContain('skills[1].guardrails["pre-tool"][1]');
   });
 });

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1735,6 +1735,16 @@ export function validateSkillsConfigGuardrails(value: unknown): string | null {
 		if (typeof skill !== "object" || skill === null) {
 			return `skillsConfig.skills[${i}] must be an object`;
 		}
+		// `enabled` gates whether a skill's guardrails materialize at runtime, and
+		// the runtime tests it for TRUTHINESS (`s.enabled && …`). A non-boolean
+		// truthy value (`"yes"`, `1`) would therefore run while skipping the
+		// judge-model check below, which compares against `true`. Pin the type
+		// here so the write boundary and the runtime cannot disagree.
+		const enabled = (skill as { enabled?: unknown }).enabled;
+		if (enabled !== undefined && typeof enabled !== "boolean") {
+			return `skillsConfig.skills[${i}].enabled must be a boolean`;
+		}
+
 		const guardrails = (skill as { guardrails?: unknown }).guardrails;
 		if (guardrails === undefined) continue;
 		if (typeof guardrails !== "object" || guardrails === null) {
@@ -1771,8 +1781,17 @@ export function validateSkillsConfigGuardrails(value: unknown): string | null {
 			if (typeof g.policy !== "string" || g.policy.trim() === "") {
 				return `${path}.policy must be a non-empty string`;
 			}
-			if (g.model !== undefined && typeof g.model !== "string") {
-				return `${path}.model must be a string`;
+			// A present-but-empty model is worse than an absent one: the runner
+			// resolves `input.model ?? defaultModel`, so `""` is NOT replaced by
+			// the gateway default — it is passed through as the model. Omit the
+			// key to inherit the default.
+			if (g.model !== undefined) {
+				if (typeof g.model !== "string") {
+					return `${path}.model must be a string`;
+				}
+				if (g.model.trim() === "") {
+					return `${path}.model must be a non-empty string when present (omit it to use the gateway default)`;
+				}
 			}
 			if (
 				g.tools !== undefined &&

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1699,6 +1699,92 @@ export function validateGuardrailsInline(value: unknown): string | null {
 	return null;
 }
 
+/**
+ * Write-boundary validation for `skillsConfig[].guardrails["pre-tool"]`, the
+ * sibling of {@link validateGuardrailsInline}.
+ *
+ * A skill's pre-tool guardrails run on EVERY `tools/call` (see the MCP proxy's
+ * pre-tool gate) and a tripped one blocks the call, so a malformed entry is not
+ * inert: an unknown `kind` reaches the aggregator's exhaustiveness guard, and a
+ * judge with an empty `policy` yields a guardrail that judges nothing. Both are
+ * persisted verbatim today because the PATCH route spreads `skillsConfig`
+ * through without checking it.
+ *
+ * Validated against `SkillPreToolGuardrailSchema` in core. Two deliberate
+ * differences from the `guardrailsInline` rules:
+ *  - `kind` is REQUIRED on both arms here. The core schema makes it a literal
+ *    on each union member, so an omitted `kind` would persist a value the
+ *    schema rejects (`AgentInlineGuardrailSchema` defaults it to "judge" for
+ *    backward compatibility with rows written before `kind` existed; the skill
+ *    union has no such legacy).
+ *  - The `builtin` arm rejects `policy`/`model`/`tools`. The aggregator ignores
+ *    them for built-ins by design, so accepting them persists a lie about what
+ *    will actually run.
+ */
+export function validateSkillsConfigGuardrails(value: unknown): string | null {
+	if (value === undefined) return null;
+	if (typeof value !== "object" || value === null) {
+		return "skillsConfig must be an object";
+	}
+	const skills = (value as { skills?: unknown }).skills;
+	if (skills === undefined) return null;
+	if (!Array.isArray(skills)) return "skillsConfig.skills must be an array";
+
+	for (let i = 0; i < skills.length; i++) {
+		const skill = skills[i];
+		if (typeof skill !== "object" || skill === null) {
+			return `skillsConfig.skills[${i}] must be an object`;
+		}
+		const guardrails = (skill as { guardrails?: unknown }).guardrails;
+		if (guardrails === undefined) continue;
+		if (typeof guardrails !== "object" || guardrails === null) {
+			return `skillsConfig.skills[${i}].guardrails must be an object`;
+		}
+		const preTool = (guardrails as Record<string, unknown>)["pre-tool"];
+		if (preTool === undefined) continue;
+		if (!Array.isArray(preTool)) {
+			return `skillsConfig.skills[${i}].guardrails["pre-tool"] must be an array`;
+		}
+
+		for (let j = 0; j < preTool.length; j++) {
+			const path = `skillsConfig.skills[${i}].guardrails["pre-tool"][${j}]`;
+			const entry = preTool[j];
+			if (typeof entry !== "object" || entry === null) {
+				return `${path} must be an object`;
+			}
+			const g = entry as Record<string, unknown>;
+			if (g.kind !== "builtin" && g.kind !== "judge") {
+				return `${path}.kind must be "builtin" or "judge"`;
+			}
+			if (g.kind === "builtin") {
+				if (typeof g.name !== "string" || g.name.trim() === "") {
+					return `${path}.name must be a non-empty string`;
+				}
+				for (const unsupported of ["policy", "model", "tools"]) {
+					if (g[unsupported] !== undefined) {
+						return `${path}.${unsupported} is not supported for kind "builtin"`;
+					}
+				}
+				continue;
+			}
+			// judge
+			if (typeof g.policy !== "string" || g.policy.trim() === "") {
+				return `${path}.policy must be a non-empty string`;
+			}
+			if (g.model !== undefined && typeof g.model !== "string") {
+				return `${path}.model must be a string`;
+			}
+			if (
+				g.tools !== undefined &&
+				(!Array.isArray(g.tools) || g.tools.some((t) => typeof t !== "string"))
+			) {
+				return `${path}.tools must be an array of strings`;
+			}
+		}
+	}
+	return null;
+}
+
 routes.patch("/:agentId/config", async (c) => {
 	const denied = requireSessionOrAdminPat(c);
 	if (denied) return denied;
@@ -1718,6 +1804,19 @@ routes.patch("/:agentId/config", async (c) => {
 	if (guardrailError) {
 		return c.json(
 			{ error: "invalid_guardrail", error_description: guardrailError },
+			400
+		);
+	}
+
+	// Same gate for guardrails carried on skills. Without this a payload the
+	// `guardrailsInline` path would reject lands verbatim via the
+	// `...settingsUpdates` spread below, and then runs on every tools/call.
+	const skillGuardrailError = validateSkillsConfigGuardrails(
+		(updates as { skillsConfig?: unknown }).skillsConfig
+	);
+	if (skillGuardrailError) {
+		return c.json(
+			{ error: "invalid_guardrail", error_description: skillGuardrailError },
 			400
 		);
 	}
@@ -1752,6 +1851,47 @@ routes.patch("/:agentId/config", async (c) => {
 				},
 				400
 			);
+		}
+	}
+
+	// Same requirement for judge guardrails declared on a skill: with no gateway
+	// default they fail closed at runtime and block every tools/call. Scoped to
+	// ENABLED skills, matching the aggregator — a disabled skill never
+	// materializes, so rejecting it would fail a harmless payload.
+	if (!judgeDefault) {
+		const skillList = (
+			updates as {
+				skillsConfig?: {
+					skills?: Array<{
+						name?: string;
+						enabled?: boolean;
+						guardrails?: {
+							"pre-tool"?: Array<{ kind?: string; model?: string }>;
+						};
+					}>;
+				};
+			}
+		).skillsConfig?.skills;
+		if (Array.isArray(skillList)) {
+			for (const skill of skillList) {
+				if (skill?.enabled !== true) continue;
+				const entries = skill.guardrails?.["pre-tool"];
+				if (!Array.isArray(entries)) continue;
+				const needsModel = entries.find(
+					(e) =>
+						e?.kind === "judge" &&
+						(typeof e.model !== "string" || e.model.trim() === "")
+				);
+				if (needsModel) {
+					return c.json(
+						{
+							error: "guardrail_model_required",
+							error_description: `Skill "${skill.name ?? "(unnamed)"}" declares a judge guardrail that needs a model: the gateway has no default judge model (EGRESS_JUDGE_MODEL is unset).`,
+						},
+						400
+					);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
`PATCH /:agentId/config` validates `guardrailsInline` and rejects malformed entries, but `skillsConfig` goes straight through the `...settingsUpdates` spread and gets written verbatim. So a guardrail payload that the documented field would reject is accepted when you attach it to a skill instead.

That matters because a skill's `guardrails['pre-tool']` entries run on every `tools/call` and a tripped one blocks the call. A malformed entry isn't inert: an unknown `kind` reaches the aggregator's exhaustiveness guard mid-message, and a judge with an empty policy produces a guardrail that judges nothing.

Adds a sibling `validateSkillsConfigGuardrails` matching `SkillPreToolGuardrailSchema`, wired in next to the existing check, and extends the judge-model requirement to enabled skills.

Two deliberate differences from the inline rules, both straight from the core schema:

- `kind` is required on both arms here. `AgentInlineGuardrailSchema` defaults it to "judge" for rows written before `kind` existed; the skill union has no such legacy, so accepting an omitted `kind` would persist something the schema rejects.
- The builtin arm rejects `policy`/`model`/`tools`. The aggregator ignores them for built-ins by design, so accepting them would persist a lie about what actually runs.

Scoped to enabled skills, matching the aggregator — a disabled skill never materializes, so rejecting one would fail a payload that can't run.

## On the justification

An earlier framing of this called it a privilege escalation, on the theory that a skill judge could name a model outside the agent's `models` allow-list. That's wrong and I want it on the record rather than buried:

- `anthropic-client.ts:11-14` — the judge is a gateway-level dependency using `ANTHROPIC_API_KEY`. It explicitly does not use any agent's key, to keep agent context out of audit logs and bills.
- `validateModelRefsAgainstOrg` (`model-config.ts:57-107`) gates `<provider>/<model>` refs against the org's providers. A judge model is a bare model id that wouldn't parse as such a ref.

Disjoint planes, no bypass. The asymmetry also runs the other way from what I first claimed: `validateGuardrailsInline` (agent-routes.ts:1660) checks only `typeof model === "string"`, no allow-list either. Gating skill judge models against `models` would make the skills path *stricter* than the inline one and reject legitimate values — `guardrails.test.ts` pins `model: "anthropic/claude-haiku-4-5"` on a skill judge, which needn't name an org-installed provider. So this PR deliberately does not do that. If judge models should be constrained, that's a separate operator-level decision covering both paths.

This is a robustness fix, not a security fix.

## Checked prod before enabling a 400

`skill-editor.tsx:46` spreads `...row._original`, so the web editor re-submits guardrails it never renders. If a stored row were already malformed, someone toggling an unrelated checkbox would get an opaque 400 about a field with no UI.

Queried the prod primary (`pg_is_in_recovery() = f`), read-only:

```
54 agents total, 2 with any skills
both skill rows: guardrails = NULL, no modelPreference/thinkingLevel/providers/contentFetchedAt
```

No stored row can be rejected by this, and no backfill is needed. The judge-model rule is safe for the same reason — there are no judge entries in prod at all.

## Red → green

Tested through the route, not just the exported helper. Removing the call site while leaving the helper intact:

```
route tests:  14 pass, 1 fail
unit tests:   25 pass, 0 fail
```

The unit tests alone would have shipped this inert — "helper exists but is never called" was the plausible failure here, so the route coverage is the part that matters. Restored:

```
40 pass, 0 fail  (25 validator unit + 15 route)
```

`make pre-pr`: all 6 gates clean.

## Not in this PR

- `providers` and `contentFetchedAt` on `SkillConfig` have zero readers and zero writers — `contentFetchedAt` is a fossil of a removed ClawHub fetch. Worth deleting, but that's its own change.
- `modelPreference` and `thinkingLevel` are *not* dead — `instruction-service.ts:93-97` interpolates both into agent prompt text. Deleting them would silently change prompt behaviour, so they stay.
- `aggregator.ts:80-81` claims operator guardrails dominate skill ones, but that rests on loop order with nothing asserting it. Worth a test; separate concern.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->