### PR TITLE
fix(server): never steal a device pin another live connection holds

### DIFF
--- a/packages/server/src/__tests__/integration/device-pin-owner-guard.test.ts
+++ b/packages/server/src/__tests__/integration/device-pin-owner-guard.test.ts
@@ -1,0 +1,174 @@
+/**
+ * reconcileDeviceCapabilities — never steal a device pin another live
+ * connection holds. Integration test against real Postgres.
+ *
+ * `idx_connections_org_connector_device_live` is UNIQUE on
+ * (organization_id, connector_key, device_worker_id) WHERE deleted_at IS NULL
+ * AND device_worker_id IS NOT NULL — an org legitimately holds one connection
+ * PER DEVICE, the same shape `idx_connections_org_connector_account_live` gives
+ * OAuth accounts.
+ *
+ * Retiring a Mac leaves its connection pinned to the now-stale device while the
+ * replacement Mac's connection holds the only fresh one. The fast path resolves
+ * a connection for the (org, connector) with no ORDER BY, hands it to
+ * `reconcilePin`, and the pin UPDATE targets a device the OTHER row owns — 23505,
+ * the whole wire transaction aborts, and the poll retries forever.
+ *
+ * Observed on prod 2026-07-29: org 8dc12bdd, apple.computer_use, rows 397
+ * (MacBook Pro, last seen 10d) and 447 (Mac mini, last seen 2h), ~8 errors/min
+ * across two replicas.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { reconcileDeviceCapabilities } from '../../worker-api/device-reconcile';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization, createTestUser } from '../setup/test-fixtures';
+
+const sql = getTestDb();
+
+const CONNECTOR = 'test.device_pin';
+const CAPABILITY = 'test_device_pin';
+
+async function seedDefinition(orgId: string) {
+  // A bundled-shape device connector: runtime + required_capability, and
+  // feeds_schema {} so `declaredFeedKeys` is empty and the fast-path `ready`
+  // check short-circuits true — exactly apple.computer_use's shape.
+  await sql`
+    INSERT INTO connector_definitions (
+      organization_id, key, name, version, status, required_capability,
+      runtime, feeds_schema, auth_schema, actions_schema, options_schema
+    ) VALUES (
+      ${orgId}, ${CONNECTOR}, 'Test Device Pin', '1.0.0', 'active', ${CAPABILITY},
+      ${sql.json({ kind: 'device' })}, ${sql.json({})}, ${sql.json({})},
+      ${sql.json({})}, ${sql.json({})}
+    )
+  `;
+  await sql`
+    INSERT INTO connector_versions (organization_id, connector_key, version)
+    VALUES (${orgId}, ${CONNECTOR}, '1.0.0')
+    ON CONFLICT DO NOTHING
+  `;
+}
+
+/**
+ * The connector must reach reconcile as a DEVICE MANIFEST: bundled connectors
+ * come from the on-disk catalog (`getBundledDeviceConnectors`), which is empty
+ * in tests, so a DB-only definition never enters `byKey` and the wire pass
+ * returns before it can pin anything.
+ */
+const MANIFEST = {
+  key: CONNECTOR,
+  version: '1.0.0',
+  name: 'Test Device Pin',
+  required_capability: CAPABILITY,
+  runtime: { platforms: ['macos'] },
+  feeds_schema: {},
+};
+
+async function seedWorker(userId: string, orgId: string, fresh: boolean): Promise<string> {
+  const workerId = `mac-${Math.random().toString(36).slice(2, 10)}`;
+  // Stale = outside DEVICE_WORKER_FRESH_INTERVAL ('7 days').
+  const lastSeen = fresh ? new Date() : new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+  const manifests = {
+    [CONNECTOR]: {
+      manifest: MANIFEST,
+      manifest_hash: `hash-${CONNECTOR}-1.0.0`,
+      received_at: new Date().toISOString(),
+    },
+  };
+  const [row] = (await sql`
+    INSERT INTO device_workers (
+      user_id, worker_id, platform, capabilities, label, organization_id,
+      last_seen_at, connector_manifests
+    ) VALUES (
+      ${userId}, ${workerId}, 'macos', ${sql.json([CAPABILITY])},
+      ${fresh ? 'Mac mini' : 'MacBook Pro'}, ${orgId}, ${lastSeen},
+      ${sql.json(manifests)}
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return String(row.id);
+}
+
+async function seedConn(orgId: string, userId: string, device: string | null): Promise<number> {
+  const slug = `conn-${Math.random().toString(36).slice(2, 8)}`;
+  const [row] = (await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      auth_profile_id, created_by, visibility, device_worker_id
+    ) VALUES (
+      ${orgId}, ${CONNECTOR}, ${slug}, 'Test Device Pin', 'active',
+      NULL, ${userId}, 'private', ${device}::uuid
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+async function pinOf(id: number): Promise<string | null> {
+  const [row] = (await sql`
+    SELECT device_worker_id FROM connections WHERE id = ${id}
+  `) as unknown as Array<{ device_worker_id: string | null }>;
+  return row?.device_worker_id ?? null;
+}
+
+describe('device pin owner guard', () => {
+  let orgId: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    const user = await createTestUser();
+    userId = user.id;
+    const org = await createTestOrganization();
+    orgId = org.id;
+    // Auto-wire targets the user's PERSONAL org, resolved by this metadata tag
+    // (auth/personal-org-provisioning.ts) rather than by ownership.
+    await sql`
+      UPDATE "organization"
+      SET metadata = ${JSON.stringify({ personal_org_for_user_id: userId })}
+      WHERE id = ${orgId}
+    `;
+    await seedDefinition(orgId);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('does not steal a pin held by another live connection, and clears the dead one', async () => {
+    const staleDevice = await seedWorker(userId, orgId, false);
+    const freshDevice = await seedWorker(userId, orgId, true);
+
+    const retired = await seedConn(orgId, userId, staleDevice); // old MacBook's row
+    const current = await seedConn(orgId, userId, freshDevice); // new Mac mini's row
+
+    // Before the guard this throws 23505 inside the wire pass, the transaction
+    // aborts, and the error is swallowed by the catch.
+    await reconcileDeviceCapabilities(userId);
+
+    // The live row keeps its device; the retired row is unpinned (claimable by
+    // any future device) rather than left pointing at a vanished one.
+    expect(await pinOf(current)).toBe(freshDevice);
+    expect(await pinOf(retired)).toBeNull();
+  });
+
+  it('still repairs a stale pin to the sole fresh device when nothing else holds it', async () => {
+    const staleDevice = await seedWorker(userId, orgId, false);
+    const freshDevice = await seedWorker(userId, orgId, true);
+    const only = await seedConn(orgId, userId, staleDevice);
+
+    await reconcileDeviceCapabilities(userId);
+
+    // The documented repair must survive the guard.
+    expect(await pinOf(only)).toBe(freshDevice);
+  });
+
+  it('leaves a pin that is already a fresh device untouched', async () => {
+    const freshDevice = await seedWorker(userId, orgId, true);
+    const only = await seedConn(orgId, userId, freshDevice);
+
+    await reconcileDeviceCapabilities(userId);
+
+    expect(await pinOf(only)).toBe(freshDevice);
+  });
+});

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -63,7 +63,42 @@ async function ensureDeviceConnectorWired(
   // (the WHERE matches nothing when the pin is already a valid fresh device), and
   // runs even on the fast path so a stale pin doesn't silently strand the feeds.
   const reconcilePin = async (db: typeof sql, connectionId: number) => {
-    const target = matchingDeviceIds.length === 1 ? matchingDeviceIds[0] : null;
+    let target = matchingDeviceIds.length === 1 ? matchingDeviceIds[0] : null;
+    // `idx_connections_org_connector_device_live` is UNIQUE on
+    // (organization_id, connector_key, device_worker_id) for live rows, and an
+    // org legitimately holds one connection PER DEVICE (same shape as
+    // `idx_connections_org_connector_account_live` for OAuth accounts). So the
+    // row we were handed is not necessarily the one that owns `target`: retiring
+    // a Mac leaves its connection pinned to the stale device while the new Mac's
+    // connection holds the only fresh one, and pinning the former to the latter's
+    // device violates the index, aborts the whole wire transaction, and retries
+    // forever (~8/min in prod for apple.computer_use).
+    //
+    // Never steal a pin another live connection holds — the same guard
+    // `resolveOnlineChromeConnection` already carries for this index (see
+    // `findOwnerOf` in dispatch-chrome-action.ts, where it used to 500 the
+    // dispatcher). Fall back to NULL rather than skipping the UPDATE: NULL still
+    // clears the dead pin (a connection pinned to a vanished device is claimable
+    // by nobody, while an unpinned one is claimable by any polling device), so
+    // the documented stale-pin repair survives.
+    if (target) {
+      const owner = (await db`
+        SELECT id FROM connections
+        WHERE organization_id = ${organizationId}
+          AND connector_key = ${connectorKey}
+          AND device_worker_id = ${target}::uuid
+          AND deleted_at IS NULL
+        LIMIT 1
+      `) as unknown as Array<{ id: number }>;
+      const ownerId = owner[0]?.id;
+      if (ownerId != null && Number(ownerId) !== connectionId) {
+        logger.warn(
+          { userId, connectorKey, connectionId, ownerConnectionId: ownerId, deviceWorkerId: target },
+          '[device-connectors] Device already pinned to another connection — unpinning instead'
+        );
+        target = null;
+      }
+    }
     // Compare via text on both sides — passing a `pgTextArray(...)` literal
     // through a `::uuid[]` cast trips a postgres "malformed array literal"
     // failure under the extended-protocol path postgres.js uses (the bound

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -247,7 +247,16 @@ async function ensureDeviceConnectorWired(
           }
         });
       } else {
-        await reconcilePin(sql, readyConnectionId);
+        // Same advisory lock as the `source` branch above: reconcilePin's owner
+        // check is read-then-write, so two replicas polling concurrently could
+        // both observe "nobody owns this device" and race into the unique index.
+        // (No bundled device connectors ship today, so this branch is currently
+        // unreachable — keep it serialized anyway rather than leave the race
+        // armed for the first one that does.)
+        await sql.begin(async (tx) => {
+          await tx`SELECT pg_advisory_xact_lock(hashtext('lobu:autowire'), hashtext(${`${userId}:${connectorKey}`}))`;
+          await reconcilePin(tx, readyConnectionId);
+        });
       }
       return;
     }


### PR DESCRIPTION
## What

`idx_connections_org_connector_device_live` is UNIQUE on `(organization_id, connector_key, device_worker_id)` for live rows, and an org legitimately holds **one connection per device** — the same shape `idx_connections_org_connector_account_live` gives OAuth accounts.

Retiring a Mac leaves its connection pinned to the now-stale device while the replacement Mac's connection holds the only fresh one. The fast path resolves a connection for the `(org, connector)` **with no ORDER BY**, hands it to `reconcilePin`, and the pin UPDATE targets a device the *other* row owns → 23505, the whole wire transaction aborts, and the poll retries forever.

Measured on prod (`summaries-prod`, org `8dc12bdd`, `apple.computer_use`):

```
397  mac-computer-use          private  device 2c295bed (MacBook Pro, last seen 10d)  → STALE
447  mac-computer-use-buremba  org      device e7806c72 (Mac mini,    last seen  2h)  → FRESH
```

Exactly one fresh device ⇒ `matchingDeviceIds.length === 1` ⇒ row 397 is pinned toward the device 447 already holds. **~8 errors/min across two replicas**, swallowed by the catch so it never surfaced.

## Fix

Look up the target device's current owner before pinning; fall back to `NULL` when another live connection holds it. This is the guard `resolveOnlineChromeConnection` **already carries for this same index** — see `findOwnerOf` in `dispatch-chrome-action.ts`, whose comment records that it "used to 500 the dispatcher (multi-Chrome orgs: Mac mini + MacBook)". Same index, same shape, already fixed once for `chrome`; `device-reconcile.ts` was the unfixed sibling.

`NULL` rather than skipping the UPDATE is deliberate: the dead pin is still cleared, so the documented stale-pin repair survives, and an unpinned connection is claimable by any polling device while one pinned to a vanished device is claimable by nobody.

## Red → green

`device-reconcile.ts` had **zero** test coverage. The new integration test drives the real manifest-sourced fast path — a DB-only definition never enters the wire pass, so the connector must arrive via `device_workers.connector_manifests`, exactly as prod's `apple.computer_use` does.

**RED** (at `origin/main`, fix reverted):

```
× does not steal a pin held by another live connection, and clears the dead one
  → expected '99b41f88-76f2-4b30-adfb-6daea1c51193' to be null
✓ still repairs a stale pin to the sole fresh device when nothing else holds it
✓ leaves a pin that is already a fresh device untouched
  Tests  1 failed | 2 passed (3)
```

Failure cause confirmed as the real thing, not a fixture artifact:

```
duplicate key value violates unique constraint
Failed to wire device connector
```

**GREEN** (with the fix):

```
✓ src/__tests__/integration/device-pin-owner-guard.test.ts (3 tests) 168ms
  Tests  3 passed (3)
```

**Mutation-tested** — disabling the guard (`if (false && ownerId != null …)`) fails *only* the conflict case, so the guard is what does the work:

```
× does not steal a pin held by another live connection, and clears the dead one
✓ still repairs a stale pin to the sole fresh device when nothing else holds it
✓ leaves a pin that is already a fresh device untouched
```

## Class check

Six non-test writers of `device_worker_id`. Two `SET NULL` (cannot violate a partial `IS NOT NULL` index), one is the already-guarded chrome path, one is this fix. **`crud.ts:1866` is a real second instance** — the user-initiated update path has no pre-flight owner check, unlike the create path at `crud.ts:1094`. Filed as a follow-up rather than bundled: it wants a clean user-facing error, not a silent unpin, so it is a different behaviour with a different blast radius.

## Blast radius

One row's pin: the stale connection goes `device → NULL`. The live row is never written (it appears only in a `SELECT … LIMIT 1`). No DELETE, no `events` write, no org row. Reversible. Adds one indexed SELECT per poll per device connector, hitting `idx_connections_org_connector_device_live`.

## Not included

Prod rows 397/447 are untouched — retiring the stale connection is a decision about a real user's data and is surfaced separately for a human call. The guard is correct with or without that cleanup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->