### PR TITLE
fix(server): scope org-less agent config reads to a proven tenant

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-config-org-scope.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-config-org-scope.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AgentConfigStore, AgentSettings } from "@lobu/core";
+import { Hono } from "hono";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
+import type { UserAgentsStore } from "../auth/user-agents-store.js";
+import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
+
+const AGENT_ID = "lobu-builder";
+const ORGANIZATION_ID = "org-b";
+
+function createApp(
+  settingsReads: Array<string | undefined>,
+  organizations = [ORGANIZATION_ID],
+): Hono {
+  const configStore = {
+    async getSettings(): Promise<AgentSettings> {
+      settingsReads.push(orgContext.getStore()?.organizationId);
+      return {
+        models: ["gemini/gemini-2.5-flash"],
+        updatedAt: Date.now(),
+      };
+    },
+    async getMetadata() {
+      return null;
+    },
+  } as AgentConfigStore;
+  const userAgentsStore = {
+    async findAgentOrganizations() {
+      return organizations;
+    },
+  } as UserAgentsStore;
+  const router = createAgentConfigRoutes({
+    agentSettingsStore: new AgentSettingsStore(configStore),
+    agentConfigStore: configStore,
+    userAgentsStore,
+  });
+  const app = new Hono();
+  app.route("/api/v1/agents/:agentId/config", router);
+  return app;
+}
+
+describe("agent config tenant scope", () => {
+  afterEach(() => {
+    setAuthProvider(null);
+  });
+
+  test("uses the tenant proven by the settings-cookie owner mapping", async () => {
+    const settingsReads: Array<string | undefined> = [];
+    setAuthProvider(() => ({
+      userId: "owner-b",
+      platform: "slack",
+      agentId: AGENT_ID,
+      exp: Date.now() + 60_000,
+    }));
+
+    const response = await createApp(settingsReads).request(
+      `/api/v1/agents/${AGENT_ID}/config`,
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).models).toEqual([
+      "gemini/gemini-2.5-flash",
+    ]);
+    expect(settingsReads).toEqual([ORGANIZATION_ID]);
+  });
+
+  test("rejects an ambiguous owner mapping without reading settings", async () => {
+    const settingsReads: Array<string | undefined> = [];
+    setAuthProvider(() => ({
+      userId: "owner-b",
+      platform: "slack",
+      agentId: AGENT_ID,
+      exp: Date.now() + 60_000,
+    }));
+
+    const response = await createApp(settingsReads, [
+      "org-a",
+      ORGANIZATION_ID,
+    ]).request(`/api/v1/agents/${AGENT_ID}/config`);
+
+    expect(response.status).toBe(401);
+    expect(settingsReads).toEqual([]);
+  });
+});

--- a/packages/server/src/gateway/__tests__/worker-path-org-scope-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-path-org-scope-e2e.test.ts
@@ -8,8 +8,7 @@
  * path runs with NO ambient orgContext. Before the #1779 fix, `resolveAgentOptions`
  * fell to an id-only read and returned an arbitrary org's model (the Gemini/Claude
  * 404). This drives the real resolver against the real store and asserts the
- * right model comes back — and that a deliberately unscoped read returns the wrong
- * one (the bug it fixes).
+ * right model comes back — and that a deliberately unscoped read fails closed.
  */
 
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
@@ -24,8 +23,8 @@ import {
 } from "./helpers/db-setup.js";
 
 const AGENT = "lobu-builder";
-const ORG_CLAUDE = "org-claude"; // the org an unscoped read returns first
-const ORG_GEMINI = "org-gemini"; // install 10's org in the real incident
+const ORG_CLAUDE = "org-claude";
+const ORG_GEMINI = "org-gemini";
 
 describe("worker-path org scope (real store, shared agent id)", () => {
   let store: AgentSettingsStore;
@@ -38,9 +37,7 @@ describe("worker-path org scope (real store, shared agent id)", () => {
     await resetTestDatabase();
     store = new AgentSettingsStore(createPostgresAgentConfigStore());
 
-    // Seed the SAME agent id in two orgs with different models lists. Order
-    // matters: org-claude is created first so an unscoped `WHERE id = $agentId`
-    // (no ORDER BY) tends to return it — the wrong row for a gemini install.
+    // Seed the same agent id in two orgs with different model lists.
     await seedAgentRow(AGENT, { organizationId: ORG_CLAUDE });
     await seedAgentRow(AGENT, { organizationId: ORG_GEMINI });
     await orgContext.run({ organizationId: ORG_CLAUDE }, () =>
@@ -65,14 +62,10 @@ describe("worker-path org scope (real store, shared agent id)", () => {
     expect(resolved.model).not.toBe("claude/claude-sonnet-4-6");
   });
 
-  test("the OLD unscoped read returns the WRONG org's model (the bug this fixes)", async () => {
-    // Simulate the pre-fix behavior: read with no org and no ambient context.
-    // The store falls to the id-only query and returns an arbitrary org's row.
+  test("an unscoped read cannot return either org's model", async () => {
     const unscoped = await store.getSettings(AGENT);
 
-    // Whatever it returns, it is NOT reliably the gemini org — demonstrating why
-    // the explicit org scope is required. In this seeding it returns claude's.
-    expect(unscoped?.models?.[0]).toBe("claude/claude-sonnet-4-6");
+    expect(unscoped).toBeNull();
   });
 
   test("each org resolves its own model independently", async () => {

--- a/packages/server/src/gateway/routes/public/agent-config.ts
+++ b/packages/server/src/gateway/routes/public/agent-config.ts
@@ -7,6 +7,7 @@
 import { Type } from "@sinclair/typebox";
 import type { AgentConfigStore, ModelOption, SkillConfig } from "@lobu/core";
 import { type Context, Hono } from "hono";
+import { orgContext, tryGetOrgId } from "../../../lobu/stores/org-context.js";
 import { defineRoute, type RouteSpec } from "../shared/define-route.js";
 import {
 	buildProviderCatalog,
@@ -31,7 +32,7 @@ import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { WorkerConnectionManager } from "../../gateway/connection-manager.js";
 import type { IMessageQueue } from "../../infrastructure/queue/index.js";
 import type { GrantStore } from "../../permissions/grant-store.js";
-import { createTokenVerifier } from "../shared/agent-ownership.js";
+import { createOwnershipResolver } from "../shared/agent-ownership.js";
 import { errorResponse } from "../shared/helpers.js";
 import {
 	ErrorResponseSchema,
@@ -298,7 +299,7 @@ async function buildResolvedConfigResponse(
 export function createAgentConfigRoutes(config: AgentConfigRoutesConfig): Hono {
 	const app = new Hono();
 
-	const baseVerifyToken = createTokenVerifier({
+	const resolveOwnership = createOwnershipResolver({
 		userAgentsStore: config.userAgentsStore,
 		agentMetadataStore: config.agentConfigStore,
 	});
@@ -313,63 +314,93 @@ export function createAgentConfigRoutes(config: AgentConfigRoutesConfig): Hono {
 	const verifyToken = async (
 		payload: SettingsTokenPayload | null,
 		agentId: string,
-	): Promise<SettingsTokenPayload | null> => {
+	): Promise<{
+		payload: SettingsTokenPayload;
+		organizationId?: string;
+	} | null> => {
 		if (!payload) return null;
 		if (payload.isAdmin || payload.settingsMode === "admin") {
+			const organizationId = tryGetOrgId() ?? undefined;
+			if (
+				!organizationId &&
+				!config.agentSettingsStore.isDeclaredAgent(agentId)
+			) {
+				return null;
+			}
 			return {
-				...payload,
-				isAdmin: true,
-				settingsMode: "admin",
+				payload: {
+					...payload,
+					isAdmin: true,
+					settingsMode: "admin",
+				},
+				organizationId,
 			};
 		}
 
-		const verified = await baseVerifyToken(payload, agentId);
-		if (!verified) return null;
+		const ownership = await resolveOwnership(payload, agentId);
+		if (!ownership.authorized) return null;
+		if (
+			!ownership.organizationId &&
+			!config.agentSettingsStore.isDeclaredAgent(agentId)
+		) {
+			return null;
+		}
 
-		if (verified.agentId || verified.settingsMode === "user") {
-			return verified;
+		if (payload.agentId || payload.settingsMode === "user") {
+			return { payload, organizationId: ownership.organizationId };
 		}
 
 		return {
-			...verified,
-			isAdmin: true,
-			settingsMode: "admin",
+			payload: {
+				...payload,
+				isAdmin: true,
+				settingsMode: "admin",
+			},
+			organizationId: ownership.organizationId,
 		};
 	};
 
 	/**
 	 * Resolve the `agentId` path param and verify the settings session/token for
-	 * it. Returns the verified payload plus agentId, or a 401 Response to
-	 * early-return. Collapses the identical preamble every config handler ran.
+	 * it. Returns the verified payload and tenant scope, or a 401 Response.
 	 */
 	const requireConfigAuth = async (
 		c: Context,
-	): Promise<{ agentId: string; payload: SettingsTokenPayload } | Response> => {
+	): Promise<{
+		agentId: string;
+		payload: SettingsTokenPayload;
+		organizationId?: string;
+	} | Response> => {
 		const agentId = c.req.param("agentId") || "";
-		const payload = await verifyToken(
+		const auth = await verifyToken(
 			await verifySettingsSessionOrToken(c),
 			agentId,
 		);
-		if (!payload) return errorResponse(c, "Unauthorized", 401);
-		return { agentId, payload };
+		if (!auth) return errorResponse(c, "Unauthorized", 401);
+		return { agentId, ...auth };
 	};
 
 	defineRoute(app, getConfigRoute, async (c): Promise<Response> => {
 		const auth = await requireConfigAuth(c);
 		if (auth instanceof Response) return auth;
-		const { agentId, payload } = auth;
-		const providerModels = await collectProviderModelOptions(
-			agentId,
-			payload.userId,
-		);
-		return c.json(
-			await buildResolvedConfigResponse(
-				config,
+		const { agentId, payload, organizationId } = auth;
+		const loadConfig = async () => {
+			const providerModels = await collectProviderModelOptions(
 				agentId,
-				payload,
-				providerModels,
-			),
-		);
+				payload.userId,
+			);
+			return c.json(
+				await buildResolvedConfigResponse(
+					config,
+					agentId,
+					payload,
+					providerModels,
+				),
+			);
+		};
+		return organizationId
+			? orgContext.run({ organizationId }, loadConfig)
+			: loadConfig();
 	});
 
 	// ===== Grant Endpoints (read-only) =====
@@ -382,7 +413,10 @@ export function createAgentConfigRoutes(config: AgentConfigRoutesConfig): Hono {
 			const auth = await requireConfigAuth(c);
 			if (auth instanceof Response) return auth;
 
-			const grants = await grantStore.listGrants(auth.agentId);
+			const grants = await grantStore.listGrants(
+				auth.agentId,
+				auth.organizationId,
+			);
 			return c.json(grants);
 		});
 	}

--- a/packages/server/src/lobu/stores/__tests__/agents-orgless-cross-tenant.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/agents-orgless-cross-tenant.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Cross-tenant regression test for the org-less `AgentConfigStore` read path.
+ *
+ * `agents` is keyed `(organization_id, id)` and has exactly two indexes —
+ * `agents_pkey UNIQUE (organization_id, id)` and the non-unique
+ * `agents_organization_id_idx`. There is NO global unique index on `agents.id`,
+ * so a system agent id provisioned per-org (`lobu-builder`, `owletto-default`)
+ * exists once per tenant.
+ *
+ * `getSettings`/`getMetadata` used to fall back to a bare `WHERE id = $agentId`
+ * with no `LIMIT` and no `ORDER BY` when no ambient `orgContext` was set,
+ * returning `rows[0]` — an arbitrary tenant's row. That leaked `models`,
+ * `guardrails`, `pre_approved_tools`, `tools_config`, `nix_config` and
+ * `sandbox_id` across tenants, and (via `verifyOwnedAgentAccess`) let an
+ * unscoped metadata row decide authorization.
+ *
+ * The org-less HTTP path is real: `createLobuOrgContextMiddleware` early-returns
+ * without opening an `orgContext` when there is no Better Auth user, while
+ * `GET /api/v1/agents/:agentId/config` authenticates purely with the
+ * `lobu_settings_session` cookie minted by `/connect/claim`. See PR #2284, which
+ * fixed the same class in `agent-history.ts`.
+ *
+ * These reads now fail closed: with no ambient org they resolve nothing rather
+ * than guessing a tenant.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	cleanupTestDatabase,
+	getTestDb,
+} from "../../../__tests__/setup/test-db";
+import { createTestOrganization } from "../../../__tests__/setup/test-fixtures";
+import { orgContext } from "../org-context";
+import { createPostgresAgentConfigStore } from "../postgres-stores";
+
+const SHARED_AGENT_ID = "lobu-builder";
+
+describe("org-less agent config reads must not cross tenants", () => {
+	let orgA: string;
+	let orgB: string;
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		const a = await createTestOrganization({ name: "Tenant A" });
+		const b = await createTestOrganization({ name: "Tenant B" });
+		orgA = a.id;
+		orgB = b.id;
+
+		const config = createPostgresAgentConfigStore();
+		// Both tenants provision the SAME system agent id with DIVERGENT config.
+		for (const [orgId, label] of [
+			[orgA, "A"],
+			[orgB, "B"],
+		] as const) {
+			await orgContext.run({ organizationId: orgId }, async () => {
+				await config.saveMetadata(SHARED_AGENT_ID, {
+					agentId: SHARED_AGENT_ID,
+					name: `Builder ${label}`,
+					owner: { platform: "lobu", userId: `owner-${label}` },
+					createdAt: Date.now(),
+				});
+				await config.saveSettings(SHARED_AGENT_ID, {
+					models: [`provider-${label}/model-${label}`],
+					soulMd: `secret soul for ${label}`,
+					preApprovedTools: [`tool_${label}`],
+				});
+			});
+		}
+	});
+
+	afterEach(async () => {
+		const db = getTestDb();
+		await db`TRUNCATE agents CASCADE`;
+	});
+
+	it("proves the shared id really has one row per tenant (no global unique on agents.id)", async () => {
+		const db = getTestDb();
+		const rows = await db`
+			SELECT organization_id FROM agents WHERE id = ${SHARED_AGENT_ID}
+		`;
+		expect(rows.length).toBe(2);
+		expect(new Set(rows.map((r: { organization_id: string }) => r.organization_id))).toEqual(
+			new Set([orgA, orgB]),
+		);
+	});
+
+	it("getSettings with no ambient org returns null instead of an arbitrary tenant's config", async () => {
+		const config = createPostgresAgentConfigStore();
+
+		// No `orgContext.run` wrapper — exactly the settings-cookie HTTP path.
+		const leaked = await config.getSettings(SHARED_AGENT_ID);
+
+		expect(leaked).toBeNull();
+	});
+
+	it("getMetadata with no ambient org returns null instead of an arbitrary tenant's row", async () => {
+		const config = createPostgresAgentConfigStore();
+
+		const leaked = await config.getMetadata(SHARED_AGENT_ID);
+
+		expect(leaked).toBeNull();
+	});
+
+	it("still resolves each tenant's own row when the org context is set", async () => {
+		const config = createPostgresAgentConfigStore();
+
+		const settingsA = await orgContext.run({ organizationId: orgA }, () =>
+			config.getSettings(SHARED_AGENT_ID),
+		);
+		const settingsB = await orgContext.run({ organizationId: orgB }, () =>
+			config.getSettings(SHARED_AGENT_ID),
+		);
+		const metaA = await orgContext.run({ organizationId: orgA }, () =>
+			config.getMetadata(SHARED_AGENT_ID),
+		);
+		const metaB = await orgContext.run({ organizationId: orgB }, () =>
+			config.getMetadata(SHARED_AGENT_ID),
+		);
+
+		expect(settingsA?.soulMd).toBe("secret soul for A");
+		expect(settingsB?.soulMd).toBe("secret soul for B");
+		expect(settingsA?.models).toEqual(["provider-A/model-A"]);
+		expect(settingsB?.models).toEqual(["provider-B/model-B"]);
+		expect(metaA?.name).toBe("Builder A");
+		expect(metaB?.name).toBe("Builder B");
+		expect(metaA?.organizationId).toBe(orgA);
+		expect(metaB?.organizationId).toBe(orgB);
+	});
+});

--- a/packages/server/src/lobu/stores/__tests__/agents-orgless-cross-tenant.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/agents-orgless-cross-tenant.test.ts
@@ -1,34 +1,17 @@
 /**
  * Cross-tenant regression test for the org-less `AgentConfigStore` read path.
  *
- * `agents` is keyed `(organization_id, id)` and has exactly two indexes —
- * `agents_pkey UNIQUE (organization_id, id)` and the non-unique
- * `agents_organization_id_idx`. There is NO global unique index on `agents.id`,
- * so a system agent id provisioned per-org (`lobu-builder`, `owletto-default`)
- * exists once per tenant.
- *
- * `getSettings`/`getMetadata` used to fall back to a bare `WHERE id = $agentId`
- * with no `LIMIT` and no `ORDER BY` when no ambient `orgContext` was set,
- * returning `rows[0]` — an arbitrary tenant's row. That leaked `models`,
- * `guardrails`, `pre_approved_tools`, `tools_config`, `nix_config` and
- * `sandbox_id` across tenants, and (via `verifyOwnedAgentAccess`) let an
- * unscoped metadata row decide authorization.
- *
- * The org-less HTTP path is real: `createLobuOrgContextMiddleware` early-returns
- * without opening an `orgContext` when there is no Better Auth user, while
- * `GET /api/v1/agents/:agentId/config` authenticates purely with the
- * `lobu_settings_session` cookie minted by `/connect/claim`. See PR #2284, which
- * fixed the same class in `agent-history.ts`.
- *
- * These reads now fail closed: with no ambient org they resolve nothing rather
- * than guessing a tenant.
+ * `agents` is keyed `(organization_id, id)` with no global unique index on
+ * `id`, so a per-org system agent (`lobu-builder`, `owletto-default`) has one
+ * row per tenant. `getSettings`/`getMetadata` used to fall back to a bare
+ * `WHERE id = $agentId` — no `LIMIT`, no `ORDER BY` — and return `rows[0]`,
+ * leaking an arbitrary tenant's config and letting its `owner_*` columns decide
+ * authorization. The org-less HTTP path is real: the settings-cookie routes
+ * authenticate without a Better Auth user, so no `orgContext` is opened.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-	cleanupTestDatabase,
-	getTestDb,
-} from "../../../__tests__/setup/test-db";
+import { cleanupTestDatabase, getTestDb } from "../../../__tests__/setup/test-db";
 import { createTestOrganization } from "../../../__tests__/setup/test-fixtures";
 import { orgContext } from "../org-context";
 import { createPostgresAgentConfigStore } from "../postgres-stores";
@@ -47,7 +30,6 @@ describe("org-less agent config reads must not cross tenants", () => {
 		orgB = b.id;
 
 		const config = createPostgresAgentConfigStore();
-		// Both tenants provision the SAME system agent id with DIVERGENT config.
 		for (const [orgId, label] of [
 			[orgA, "A"],
 			[orgB, "B"],
@@ -68,10 +50,7 @@ describe("org-less agent config reads must not cross tenants", () => {
 		}
 	});
 
-	afterEach(async () => {
-		const db = getTestDb();
-		await db`TRUNCATE agents CASCADE`;
-	});
+	afterEach(cleanupTestDatabase);
 
 	it("proves the shared id really has one row per tenant (no global unique on agents.id)", async () => {
 		const db = getTestDb();
@@ -79,26 +58,25 @@ describe("org-less agent config reads must not cross tenants", () => {
 			SELECT organization_id FROM agents WHERE id = ${SHARED_AGENT_ID}
 		`;
 		expect(rows.length).toBe(2);
-		expect(new Set(rows.map((r: { organization_id: string }) => r.organization_id))).toEqual(
-			new Set([orgA, orgB]),
-		);
+		expect(
+			new Set(rows.map((r: { organization_id: string }) => r.organization_id)),
+		).toEqual(new Set([orgA, orgB]));
 	});
 
 	it("getSettings with no ambient org returns null instead of an arbitrary tenant's config", async () => {
 		const config = createPostgresAgentConfigStore();
 
-		// No `orgContext.run` wrapper — exactly the settings-cookie HTTP path.
-		const leaked = await config.getSettings(SHARED_AGENT_ID);
+		const settings = await config.getSettings(SHARED_AGENT_ID);
 
-		expect(leaked).toBeNull();
+		expect(settings).toBeNull();
 	});
 
 	it("getMetadata with no ambient org returns null instead of an arbitrary tenant's row", async () => {
 		const config = createPostgresAgentConfigStore();
 
-		const leaked = await config.getMetadata(SHARED_AGENT_ID);
+		const metadata = await config.getMetadata(SHARED_AGENT_ID);
 
-		expect(leaked).toBeNull();
+		expect(metadata).toBeNull();
 	});
 
 	it("still resolves each tenant's own row when the org context is set", async () => {

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -128,34 +128,34 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 	const store: AgentConfigStore = {
 		async getSettings(agentId) {
 			const sql = getDb();
-			// Workers/gateway-internal callers run without org context — agent IDs
-			// are globally unique and the worker token already proves authenticity,
-			// so falling back to id-only lookup is safe. HTTP request paths always
-			// have an org context (set by middleware) and get the row scoped to it.
+			// CROSS-TENANT GUARD: `agents` is keyed (organization_id, id) and has no
+			// global unique index on `id`, so a per-org system agent (`lobu-builder`,
+			// `owletto-default`) has one row per tenant. An unscoped `WHERE id = …`
+			// would return an arbitrary tenant's `models`, `guardrails`,
+			// `pre_approved_tools`, `tools_config`, `nix_config` and `sandbox_id`.
+			// Not hypothetical: `createLobuOrgContextMiddleware` opens no context
+			// when there is no Better Auth user, and the settings-cookie routes
+			// (`/connect/claim` → `GET /api/v1/agents/:agentId/config`) authenticate
+			// without one. Fail closed, as PR #2284 did for agent history.
 			const orgId = tryGetOrgId();
-			const rows = orgId
-				? await sql`
-            SELECT models,
-                   network_config, nix_config,
-                   soul_md, user_md, identity_md,
-                   skills_config, tools_config,
-                   verbose_logging, show_tool_calls,
-                   pre_approved_tools, guardrails, guardrails_inline,
-                   sandbox_id, updated_at
-            FROM agents
-            WHERE id = ${agentId} AND organization_id = ${orgId}
-          `
-				: await sql`
-            SELECT models,
-                   network_config, nix_config,
-                   soul_md, user_md, identity_md,
-                   skills_config, tools_config,
-                   verbose_logging, show_tool_calls,
-                   pre_approved_tools, guardrails, guardrails_inline,
-                   sandbox_id, updated_at
-            FROM agents
-            WHERE id = ${agentId}
-          `;
+			if (!orgId) {
+				logger.warn(
+					{ agentId },
+					"[getSettings] no org context — returning null (cross-tenant guard)",
+				);
+				return null;
+			}
+			const rows = await sql`
+          SELECT models,
+                 network_config, nix_config,
+                 soul_md, user_md, identity_md,
+                 skills_config, tools_config,
+                 verbose_logging, show_tool_calls,
+                 pre_approved_tools, guardrails, guardrails_inline,
+                 sandbox_id, updated_at
+          FROM agents
+          WHERE id = ${agentId} AND organization_id = ${orgId}
+        `;
 			if (rows.length === 0) return null;
 			return rowToSettings(rows[0]);
 		},
@@ -214,20 +214,25 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 		},
 		async getMetadata(agentId) {
 			const sql = getDb();
+			// CROSS-TENANT GUARD: same composite-key reasoning as `getSettings`, and
+			// higher stakes — `verifyOwnedAgentAccess` vouches the caller against the
+			// `owner_*` columns of whatever row this returns, so an unscoped read
+			// lets an arbitrary tenant's row decide authorization. PR #2284 fixed the
+			// one caller that had already been traced; this closes the query itself.
 			const orgId = tryGetOrgId();
-			const rows = orgId
-				? await sql`
-            SELECT id, organization_id, name, description, owner_platform, owner_user_id,
-                   created_at, last_used_at
-            FROM agents
-            WHERE id = ${agentId} AND organization_id = ${orgId}
-          `
-				: await sql`
-            SELECT id, organization_id, name, description, owner_platform, owner_user_id,
-                   created_at, last_used_at
-            FROM agents
-            WHERE id = ${agentId}
-          `;
+			if (!orgId) {
+				logger.warn(
+					{ agentId },
+					"[getMetadata] no org context — returning null (cross-tenant guard)",
+				);
+				return null;
+			}
+			const rows = await sql`
+          SELECT id, organization_id, name, description, owner_platform, owner_user_id,
+                 created_at, last_used_at
+          FROM agents
+          WHERE id = ${agentId} AND organization_id = ${orgId}
+        `;
 			if (rows.length === 0) return null;
 			return rowToMetadata(rows[0]);
 		},

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -128,15 +128,13 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 	const store: AgentConfigStore = {
 		async getSettings(agentId) {
 			const sql = getDb();
-			// CROSS-TENANT GUARD: `agents` is keyed (organization_id, id) and has no
-			// global unique index on `id`, so a per-org system agent (`lobu-builder`,
-			// `owletto-default`) has one row per tenant. An unscoped `WHERE id = …`
-			// would return an arbitrary tenant's `models`, `guardrails`,
-			// `pre_approved_tools`, `tools_config`, `nix_config` and `sandbox_id`.
-			// Not hypothetical: `createLobuOrgContextMiddleware` opens no context
-			// when there is no Better Auth user, and the settings-cookie routes
-			// (`/connect/claim` → `GET /api/v1/agents/:agentId/config`) authenticate
-			// without one. Fail closed, as PR #2284 did for agent history.
+			// CROSS-TENANT GUARD: `agents` is keyed (organization_id, id) with no
+			// global unique index on `id`, so a per-org system agent (`lobu-builder`)
+			// has one row per tenant and an id-only read returns an arbitrary one.
+			// The settings-cookie routes authenticate without a Better Auth user, so
+			// `createLobuOrgContextMiddleware` opens no context on a real, externally
+			// reachable path. Callers must prove the tenant and open their own
+			// orgContext; fail closed here, as PR #2284 did for agent history.
 			const orgId = tryGetOrgId();
 			if (!orgId) {
 				logger.warn(
@@ -216,9 +214,8 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			const sql = getDb();
 			// CROSS-TENANT GUARD: same composite-key reasoning as `getSettings`, and
 			// higher stakes — `verifyOwnedAgentAccess` vouches the caller against the
-			// `owner_*` columns of whatever row this returns, so an unscoped read
-			// lets an arbitrary tenant's row decide authorization. PR #2284 fixed the
-			// one caller that had already been traced; this closes the query itself.
+			// `owner_*` columns of whatever row this returns, so an id-only read lets
+			// an arbitrary tenant's row decide authorization.
 			const orgId = tryGetOrgId();
 			if (!orgId) {
 				logger.warn(


### PR DESCRIPTION
## Summary
- `agents` is keyed `(organization_id, id)` and has **exactly two** indexes — `agents_pkey UNIQUE (organization_id, id)` and the non-unique `agents_organization_id_idx`. There is **no** global unique index on `agents.id`, so a per-org system agent (`lobu-builder`, `owletto-default`) has one row per tenant.
- `AgentConfigStore.getSettings`/`getMetadata` fell back to a bare `WHERE id = $agentId` — no `LIMIT`, no `ORDER BY` — when no ambient `orgContext` was set, then returned `rows[0]`, i.e. an **arbitrary tenant's row**. That leaked `models`, `guardrails`, `guardrails_inline`, `pre_approved_tools`, `tools_config`, `nix_config`, `sandbox_id`, and via `verifyOwnedAgentAccess` let an unscoped row's `owner_*` columns decide authorization.
- The comment justifying it was false on both counts. "Agent IDs are globally unique" — they are not. "HTTP request paths always have an org context (set by middleware)" — `createLobuOrgContextMiddleware` early-returns without opening a context when there is no Better Auth user, and `GET /api/v1/agents/:agentId/config` authenticates purely with the `lobu_settings_session` cookie minted by `/connect/claim`. Comment deleted, not annotated.
- Fails closed, matching the `listConnections` CROSS-TENANT GUARD and #2284, which fixed this same class in `agent-history.ts` without touching this query.

### Why fail-closed rather than "throw when `rows.length > 1`"
A single-tenant deployment passes a `rows.length > 1` check silently and only starts throwing the day a second org provisions the same system agent — that ships a latent time-bomb instead of a guard. Refusing an unproven tenant is deterministic. No legitimate caller regresses: every gateway caller already passes `{ organizationId }` (`output-scan`, `provider-catalog`, `mcp/proxy:452`, `message-consumer`, `built-in-commands`, `platform-helpers`, `instruction-service`, `gateway/index`), and `catalog/installed.ts` is wrapped by router middleware that 401s on a missing org. The one route that genuinely had no org — the settings-cookie config page — now resolves its tenant explicitly (commit 2).

### Verification of the premise (run, not assumed)
```
=== FULL pg_indexes dump for agents (no truncation) ===
indexname  | agents_pkey
indexdef   | CREATE UNIQUE INDEX agents_pkey ON public.agents USING btree (organization_id, id)
indexname  | agents_organization_id_idx
indexdef   | CREATE INDEX agents_organization_id_idx ON public.agents USING btree (organization_id)
=== index COUNT ===  2

=== EMPIRICAL COLLISION TEST: same id, two orgs ===
INSERT 0 2
=== unscoped SELECT (exactly the getSettings org-less branch) ===
      id      | organization_id | name |   models
--------------+-----------------+------+-------------
 lobu-builder | org-a           | A    | ["model-a"]
 lobu-builder | org-b           | B    | ["model-b"]
(2 rows)
```

### Reachability (traced, not latent-only)
Concrete external chain, all on the same Hono app:
1. Bot posts a settings link (`gateway/index.ts:611`) → `/connect/claim?claim=…` carrying a **platform** user id, no Better Auth account.
2. `GET /connect/claim` (`connect-auth.ts:229-255`) sets the `lobu_settings_session` cookie and 302s to `/api/v1/agents/{agentId}/config`.
3. `createLobuAuthBridge` reads only PAT bearers and Better Auth sessions — the cookie is invisible to it, so `c.get("user")` is null → `createLobuOrgContextMiddleware` hits `if (!user?.id) { await next(); return; }` and **opens no orgContext**.
4. `requireConfigAuth` → `verifySettingsSessionOrToken` succeeds on the cookie → `resolveSettingsView` → `getSettings(agentId)` with no context → `tryGetOrgId()` null → unscoped `WHERE id = …`.

Independent corroboration: `worker-path-org-scope-e2e.test.ts` (from incident #1779) already asserted the leak directly, pinning `unscoped?.models?.[0]` to the *wrong* org's model. That stale expectation is updated here.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` (all green, 0 fail), targeted `bunx vitest run` + `bun test`
- [x] Bug fix: red→fix→green outputs pasted below

### RED (before fix)
```
FAIL src/lobu/stores/__tests__/agents-orgless-cross-tenant.test.ts > getSettings with no ambient org …
AssertionError: expected { …(15) } to be null
+ Received:
{ "models": ["provider-A/model-A"],
  "preApprovedTools": ["tool_A"],
  "soulMd": "secret soul for A", … }

FAIL … > getMetadata with no ambient org …
AssertionError: expected { agentId: 'lobu-builder', …(6) } to be null
+ Received:
{ "agentId": "lobu-builder", "name": "Builder A",
  "organizationId": "org_X7ifuBbrbIQ",
  "owner": { "platform": "lobu", "userId": "owner-A" } }

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```
A caller with **no tenant identity** received Tenant A's `soulMd`, `models` and `preApprovedTools`.

### GREEN (after fix)
```
✓ src/lobu/stores/__tests__/agents-orgless-cross-tenant.test.ts (4 tests)
 Test Files  1 passed (1)
      Tests  4 passed (4)

18 pass / 0 fail  (bun test: agent-config-org-scope, worker-path-org-scope-e2e,
                   agent-history-authorization, agent-settings-store)
```

### MUTATION TEST (fix reverted to `origin/main`, then restored)
Reverted:
```
   ✓ proves the shared id really has one row per tenant (no global unique on agents.id)
   × getSettings with no ambient org …  → expected { …(15) } to be null
   × getMetadata with no ambient org …  → expected { agentId: 'lobu-builder', …(6) } to be null
   ✓ still resolves each tenant's own row when the org context is set
 Test Files  1 failed (1) | Tests 2 failed | 2 passed (4)

(fail) worker-path org scope > an unscoped read cannot return either org's model
 4 pass / 1 fail
```
Restored:
```
 Test Files  1 passed (1) | Tests 4 passed (4)
 18 pass / 0 fail
```
The tests bite on both runners.

### Which runner / CI path
`agents-orgless-cross-tenant.test.ts` lives in `src/lobu/stores/__tests__/`, which **vitest includes** (the config explicitly notes nested dirs under `src/lobu/**` other than `src/lobu/__tests__/` must stay visible to vitest) — so it runs under `make test-integration`. `agent-config-org-scope.test.ts` and `worker-path-org-scope-e2e.test.ts` are under `src/gateway/**/__tests__/**`, which vitest **excludes**; they run under the server `bun test` job. Both paths are CI-gated.

## Notes
- The store guard alone would have made the settings-cookie config page return an empty config. Commit 2 (from `make review-fix`, reviewed and adjusted by hand) resolves the tenant from the ownership mapping and runs the read inside `orgContext.run`, declining on an ambiguous or absent mapping — the same shape as #2284.
- Class swept per AGENTS.md: the other `tryGetOrgId()` sites in `postgres-stores.ts` are on `connections`, which is keyed by a globally-unique slug (`connections_chat_slug_unique`), and `listConnections` already carries its own guard. The two `agents` reads were the whole class in this file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->