### PR TITLE
chore(hooks): refuse to prove a schema negative from truncated output

### DIFF
--- a/.claude/hooks/no-truncated-schema-proof.sh
+++ b/.claude/hooks/no-truncated-schema-proof.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# PreToolUse hook: refuse to prove a schema NEGATIVE from truncated output.
+#
+# Why this exists: a session queried `pg_indexes` for the unique indexes on
+# `connections`, piped it through `head -6`, and the 7th row — the partial
+# unique index that made the whole finding a false positive — was amputated.
+# That single dropped row cost an 85-confidence wrong claim, a dispatched
+# agent, and a near-miss brief authorising deletion of a load-bearing branch.
+#
+# The rule: truncation is fine when you are confirming something EXISTS (the
+# first match proves it). It is never fine when the conclusion is "there is no
+# other index/constraint/policy", because the row that refutes you is exactly
+# the one that scrolls off.
+#
+# Scope is deliberately narrow — only the catalogs that describe CONSTRAINTS
+# (pg_indexes / pg_constraint / pg_policies). information_schema is excluded:
+# it is dominated by "does this column exist" checks, where `| head -1` is a
+# legitimate positive test. Measured over 156,887 historical Bash calls in
+# this project, this matcher fires 2 times, and both are the dangerous shape.
+#
+# Escape hatch (matches the repo's existing `raw-array-ok` / `squawk-ignore`
+# convention): add `# TRUNCATION-OK: <reason>` to the command.
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+[ -z "$command" ] && exit 0
+
+# Explicit opt-out, with a stated reason.
+echo "$command" | grep -qE '#[[:space:]]*TRUNCATION-OK:' && exit 0
+
+# (a) Does it read a constraint-shaped catalog?
+echo "$command" | grep -qE 'pg_indexes|pg_constraint|pg_policies' || exit 0
+
+# (b) Is the result truncated? `head`/`tail` through a pipe, or a SQL LIMIT.
+echo "$command" | grep -qE '\|[[:space:]]*(head|tail)([[:space:]]|$)|[Ll][Ii][Mm][Ii][Tt][[:space:]]+[0-9]' || exit 0
+
+cat >&2 <<'MSG'
+BLOCKED: truncated schema-catalog query.
+
+You are reading pg_indexes/pg_constraint/pg_policies through `head`/`tail`/`LIMIT`.
+If you are about to conclude "there is no other constraint" — the row that would
+refute you is the one being cut off. This exact pattern produced a false-positive
+cross-tenant bug report in this repo.
+
+Do instead:
+  - Drop the truncation and read every row.
+  - Add `SELECT count(*)` alongside it so a missing row is visibly impossible.
+
+If the truncation is genuinely safe (you are confirming something EXISTS, and the
+first match settles it), say so explicitly:
+  # TRUNCATION-OK: confirming the index exists, not proving absence
+MSG
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,10 @@
           {
             "type": "command",
             "command": "bash -c 's=\"${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-bun.sh}\"; [ -n \"$s\" ] && [ -f \"$s\" ] || s=\"$(git rev-parse --show-toplevel)/.claude/hooks/enforce-bun.sh\"; exec bash \"$s\"'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 's=\"${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.claude/hooks/no-truncated-schema-proof.sh}\"; [ -n \"$s\" ] && [ -f \"$s\" ] || s=\"$(git rev-parse --show-toplevel)/.claude/hooks/no-truncated-schema-proof.sh\"; exec bash \"$s\"'"
           }
         ]
       }


### PR DESCRIPTION
## What

Adds a `PreToolUse` Bash hook that blocks reading a constraint-shaped catalog (`pg_indexes` / `pg_constraint` / `pg_policies`) through `head`/`tail`/`LIMIT`.

## Why

This session produced a false-positive cross-tenant bug report. The cause was one command:

```
psql "$D" -tAc "SELECT indexname, indexdef FROM pg_indexes WHERE tablename='connections' AND indexdef ILIKE '%unique%'" 2>&1 | head -6
```

It returned exactly 6 rows. The 7th — `connections_chat_slug_unique`, the partial unique index that makes the org-less lookup in `postgres-stores.ts` correct — was cut off. Cost: a wrong high-confidence claim, a dispatched agent that ended in `duplicate key value violates unique constraint`, and a brief that authorised deleting a branch the public webhook URL, exclusive-transport restart, and claims lease all depend on.

The rule: truncation is fine when confirming something **exists** (the first match proves it). It is never fine when the conclusion is "there is no other constraint" — the refuting row is exactly the one that scrolls off.

## Scope

Deliberately narrow. `information_schema` is **excluded**: it is dominated by column-existence checks where `| head -1` is a legitimate positive test.

Measured over **156,887 historical Bash calls** in this project:

| matcher | fires | false positives |
|---|---|---|
| incl. `information_schema` | 30 | several (legit existence checks) |
| **constraint catalogs only (shipped)** | **2** | **0** |

Both hits are the dangerous shape — querying unique indexes with truncation. ~1 in 78,000 calls.

## Escape hatch

Follows the repo's existing `raw-array-ok` / `squawk-ignore` convention:

```bash
# TRUNCATION-OK: confirming the index exists, not proving absence
```

## Verification

All 7 cases pass:

| case | expected | got |
|---|---|---|
| the actual false-positive command | BLOCK | exit 2 |
| historical near-miss (`entity_identities ... LIMIT 5`) | BLOCK | exit 2 |
| untruncated catalog read | pass | exit 0 |
| `git log \| head -5` | pass | exit 0 |
| `bun test \| tail -20` | pass | exit 0 |
| `information_schema ... \| head -1` | pass | exit 0 |
| escape hatch | pass | exit 0 |

Existing `enforce-bun.sh` re-verified still firing (exit 2 on `npm install`) after the settings edit.

## Risk

Tooling-only. No product code. Worst case is a spurious block, resolvable with the documented escape hatch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->