### PR TITLE
fix(server): make org scoping fail closed instead of dropping the filter

### DIFF
--- a/packages/server/src/__tests__/integration/grant-store-org-scope.test.ts
+++ b/packages/server/src/__tests__/integration/grant-store-org-scope.test.ts
@@ -1,0 +1,112 @@
+/**
+ * GrantStore org scoping — fail closed, never answer for every tenant.
+ *
+ * `orgScope(sql, orgId)` used to accept null/undefined and return an EMPTY SQL
+ * fragment, so a caller with no organization silently dropped the tenant
+ * predicate: every read answered across all orgs, and `revoke`'s DELETE removed
+ * matching grants in every org at once. Nothing signalled it — no error, no log.
+ *
+ * `agents_pkey` is `PRIMARY KEY (organization_id, id)`, so an agent id is unique
+ * only WITHIN an org — a shared slug like `lobu-builder` exists in many orgs at
+ * once, which is exactly what made the unscoped query dangerous rather than
+ * merely wrong.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { GrantStore } from '../../gateway/permissions/grant-store';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization } from '../setup/test-fixtures';
+
+const sql = getTestDb();
+
+// The same agent id in two orgs — legal, because the PK is composite.
+const AGENT_ID = 'lobu-builder';
+
+/**
+ * `grants` is FK'd to `agents(organization_id, id)`, so the agent must exist in
+ * each org — which is the whole point: the SAME id legitimately exists in both,
+ * because `agents_pkey` is `(organization_id, id)`.
+ */
+async function seedAgent(orgId: string) {
+  await sql`
+    INSERT INTO agents (organization_id, id, name)
+    VALUES (${orgId}, ${AGENT_ID}, 'Builder')
+    ON CONFLICT DO NOTHING
+  `;
+}
+
+async function seedGrant(orgId: string, pattern: string, denied = false) {
+  await sql`
+    INSERT INTO grants (organization_id, agent_id, kind, pattern, granted_at, denied)
+    VALUES (${orgId}, ${AGENT_ID}, 'domain', ${pattern}, NOW(), ${denied})
+  `;
+}
+
+describe('GrantStore org scoping', () => {
+  let orgA: string;
+  let orgB: string;
+  let store: GrantStore;
+
+  beforeEach(async () => {
+    orgA = (await createTestOrganization()).id;
+    orgB = (await createTestOrganization()).id;
+    await seedAgent(orgA);
+    await seedAgent(orgB);
+    store = new GrantStore();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('does not see another org grant for the same agent id', async () => {
+    await seedGrant(orgB, 'evil.example.com');
+
+    // Org A never granted this domain. Unscoped, org B's grant would satisfy it.
+    expect(await store.hasGrant(AGENT_ID, 'evil.example.com', orgA)).toBe(false);
+    expect(await store.hasGrant(AGENT_ID, 'evil.example.com', orgB)).toBe(true);
+  });
+
+  it('lists only the calling org grants', async () => {
+    await seedGrant(orgA, 'a.example.com');
+    await seedGrant(orgB, 'b.example.com');
+
+    const a = await store.listGrants(AGENT_ID, orgA);
+    expect(a.map((g) => g.pattern)).toEqual(['a.example.com']);
+  });
+
+  it('revoke never deletes another org grant', async () => {
+    await seedGrant(orgA, 'shared.example.com');
+    await seedGrant(orgB, 'shared.example.com');
+
+    await store.revoke(AGENT_ID, 'shared.example.com', orgA);
+
+    // Org B's grant must survive — an unscoped DELETE would take both.
+    expect(await store.listGrants(AGENT_ID, orgA)).toHaveLength(0);
+    expect(await store.listGrants(AGENT_ID, orgB)).toHaveLength(1);
+  });
+
+  it('isDenied does not inherit another org deny', async () => {
+    await seedGrant(orgB, 'blocked.example.com', true);
+    expect(await store.isDenied(AGENT_ID, 'blocked.example.com', orgA)).toBe(false);
+  });
+
+  /**
+   * The behavioural core of the change: with no org, these throw instead of
+   * running unscoped. Previously each returned an all-tenant answer.
+   */
+  it('throws rather than running unscoped when no org can be resolved', async () => {
+    await expect(store.hasGrant(AGENT_ID, 'x.example.com')).rejects.toThrow(
+      /GrantStore\.hasGrant requires organizationId/
+    );
+    await expect(store.listGrants(AGENT_ID)).rejects.toThrow(
+      /GrantStore\.listGrants requires organizationId/
+    );
+    await expect(store.isDenied(AGENT_ID, 'x.example.com')).rejects.toThrow(
+      /GrantStore\.isDenied requires organizationId/
+    );
+    await expect(store.revoke(AGENT_ID, 'x.example.com')).rejects.toThrow(
+      /GrantStore\.revoke requires organizationId/
+    );
+  });
+});

--- a/packages/server/src/gateway/__tests__/agent-config-org-scope.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-config-org-scope.test.ts
@@ -4,8 +4,10 @@ import { Hono } from "hono";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import type { UserAgentsStore } from "../auth/user-agents-store.js";
+import type { GrantStore } from "../permissions/grant-store.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
 import { setAuthProvider } from "../routes/public/settings-auth.js";
+import { DeclaredAgentRegistry } from "../services/declared-agent-registry.js";
 
 const AGENT_ID = "lobu-builder";
 const ORGANIZATION_ID = "org-b";
@@ -13,6 +15,7 @@ const ORGANIZATION_ID = "org-b";
 function createApp(
   settingsReads: Array<string | undefined>,
   organizations = [ORGANIZATION_ID],
+  options: { declaredSettings?: AgentSettings; grantStore?: GrantStore } = {},
 ): Hono {
   const configStore = {
     async getSettings(): Promise<AgentSettings> {
@@ -31,10 +34,21 @@ function createApp(
       return organizations;
     },
   } as UserAgentsStore;
+  const agentSettingsStore = new AgentSettingsStore(configStore);
+  if (options.declaredSettings) {
+    const registry = new DeclaredAgentRegistry();
+    registry.replaceAll(
+      new Map([
+        [AGENT_ID, { settings: options.declaredSettings, credentials: [] }],
+      ]),
+    );
+    agentSettingsStore.setDeclaredAgents(registry);
+  }
   const router = createAgentConfigRoutes({
-    agentSettingsStore: new AgentSettingsStore(configStore),
+    agentSettingsStore,
     agentConfigStore: configStore,
     userAgentsStore,
+    grantStore: options.grantStore,
   });
   const app = new Hono();
   app.route("/api/v1/agents/:agentId/config", router);
@@ -82,5 +96,75 @@ describe("agent config tenant scope", () => {
 
     expect(response.status).toBe(401);
     expect(settingsReads).toEqual([]);
+  });
+
+  test("serves an orgless declared agent with no grants instead of failing", async () => {
+    // `verifyToken` authorizes a declared (SDK-embedded) agent without a
+    // tenant on purpose — its settings are org-agnostic. Grants are not:
+    // there is no org to scope them to, so the response reports none rather
+    // than reading `grants` across every tenant.
+    const settingsReads: Array<string | undefined> = [];
+    const grantReads: Array<string | undefined> = [];
+    setAuthProvider(() => ({
+      userId: "owner-b",
+      platform: "slack",
+      agentId: AGENT_ID,
+      exp: Date.now() + 60_000,
+    }));
+
+    const grantStore = {
+      async listGrants(_agentId: string, organizationId?: string) {
+        grantReads.push(organizationId);
+        return [];
+      },
+    } as unknown as GrantStore;
+
+    const app = createApp(settingsReads, [], {
+      declaredSettings: {
+        models: ["anthropic/claude-sonnet-4"],
+        updatedAt: Date.now(),
+      },
+      grantStore,
+    });
+
+    const response = await app.request(`/api/v1/agents/${AGENT_ID}/config`);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.models).toEqual(["anthropic/claude-sonnet-4"]);
+    expect(body.tools.permissions).toEqual([]);
+    // Neither the DB settings row nor the grants table is read unscoped.
+    expect(settingsReads).toEqual([]);
+    expect(grantReads).toEqual([]);
+  });
+
+  test("orgless declared agent lists no grants instead of reading unscoped", async () => {
+    const settingsReads: Array<string | undefined> = [];
+    const grantReads: Array<string | undefined> = [];
+    setAuthProvider(() => ({
+      userId: "owner-b",
+      platform: "slack",
+      agentId: AGENT_ID,
+      exp: Date.now() + 60_000,
+    }));
+
+    const grantStore = {
+      async listGrants(_agentId: string, organizationId?: string) {
+        grantReads.push(organizationId);
+        return [];
+      },
+    } as unknown as GrantStore;
+
+    const response = await createApp(settingsReads, [], {
+      declaredSettings: {
+        models: ["anthropic/claude-sonnet-4"],
+        updatedAt: Date.now(),
+      },
+      grantStore,
+    }).request(`/api/v1/agents/${AGENT_ID}/config/grants`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([]);
+    expect(grantReads).toEqual([]);
   });
 });

--- a/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
+++ b/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
@@ -75,6 +75,12 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
   let policyStore: PolicyStore;
   let manager: TestDeploymentManager;
 
+  // Grant reads are org-scoped, so every lookup needs the payload org.
+  const hasGrant = (pattern: string, organizationId = "test-org") =>
+    grantStore.hasGrant("agent-1", pattern, organizationId);
+  const isDenied = (pattern: string, organizationId = "test-org") =>
+    grantStore.isDenied("agent-1", pattern, organizationId);
+
   beforeAll(async () => {
     await ensureDbForGatewayTests();
   });
@@ -99,8 +105,8 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       })
     );
 
-    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
-    expect(await grantStore.hasGrant("agent-1", ".github.com")).toBe(true);
+    expect(await hasGrant("api.example.com")).toBe(true);
+    expect(await hasGrant(".github.com")).toBe(true);
   });
 
   test("syncs preApprovedTools as MCP tool grants", async () => {
@@ -113,13 +119,9 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       })
     );
 
-    expect(
-      await grantStore.hasGrant("agent-1", "/mcp/gmail/tools/list_messages")
-    ).toBe(true);
+    expect(await hasGrant("/mcp/gmail/tools/list_messages")).toBe(true);
     // Wildcard pattern should match a specific tool under it.
-    expect(
-      await grantStore.hasGrant("agent-1", "/mcp/linear/tools/create_issue")
-    ).toBe(true);
+    expect(await hasGrant("/mcp/linear/tools/create_issue")).toBe(true);
   });
 
   test("syncs networkConfig.deniedDomains as deny grants", async () => {
@@ -132,10 +134,10 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       })
     );
 
-    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
-    expect(await grantStore.isDenied("agent-1", "evil.com")).toBe(true);
-    expect(await grantStore.isDenied("agent-1", "sub.bad.com")).toBe(true);
-    expect(await grantStore.hasGrant("agent-1", "evil.com")).toBe(false);
+    expect(await hasGrant("api.example.com")).toBe(true);
+    expect(await isDenied("evil.com")).toBe(true);
+    expect(await isDenied("sub.bad.com")).toBe(true);
+    expect(await hasGrant("evil.com")).toBe(false);
   });
 
   test("removing a denied domain from config revokes the deny grant", async () => {
@@ -144,12 +146,12 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
         networkConfig: { deniedDomains: ["evil.com"] },
       })
     );
-    expect(await grantStore.isDenied("agent-1", "evil.com")).toBe(true);
+    expect(await isDenied("evil.com")).toBe(true);
 
     await manager.syncNetworkConfigGrants(
       buildPayload({ networkConfig: { deniedDomains: [] } })
     );
-    expect(await grantStore.isDenied("agent-1", "evil.com")).toBe(false);
+    expect(await isDenied("evil.com")).toBe(false);
   });
 
   test("flipping a domain from denied to allowed updates the grant", async () => {
@@ -158,17 +160,15 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
         networkConfig: { deniedDomains: ["flip.example.com"] },
       })
     );
-    expect(await grantStore.isDenied("agent-1", "flip.example.com")).toBe(true);
+    expect(await isDenied("flip.example.com")).toBe(true);
 
     await manager.syncNetworkConfigGrants(
       buildPayload({
         networkConfig: { allowedDomains: ["flip.example.com"] },
       })
     );
-    expect(await grantStore.isDenied("agent-1", "flip.example.com")).toBe(
-      false
-    );
-    expect(await grantStore.hasGrant("agent-1", "flip.example.com")).toBe(true);
+    expect(await isDenied("flip.example.com")).toBe(false);
+    expect(await hasGrant("flip.example.com")).toBe(true);
   });
 
   test("same agent id in two orgs syncs independently (org-scoped cache)", async () => {
@@ -188,12 +188,8 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       })
     );
 
-    expect(await grantStore.isDenied("agent-1", "evil.com", "test-org")).toBe(
-      true
-    );
-    expect(await grantStore.isDenied("agent-1", "evil.com", "org-b")).toBe(
-      true
-    );
+    expect(await isDenied("evil.com")).toBe(true);
+    expect(await isDenied("evil.com", "org-b")).toBe(true);
   });
 
   test("revokes a config-removed domain even when the sync cache is cold", async () => {
@@ -202,7 +198,7 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
         networkConfig: { allowedDomains: ["a.example.com"] },
       })
     );
-    expect(await grantStore.hasGrant("agent-1", "a.example.com")).toBe(true);
+    expect(await hasGrant("a.example.com")).toBe(true);
 
     // Fresh manager = cold cache (pod restart / other replica). The domain
     // was removed from config; revocation must not depend on pod-local state.
@@ -213,7 +209,7 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       buildPayload({ networkConfig: { allowedDomains: [] } })
     );
 
-    expect(await grantStore.hasGrant("agent-1", "a.example.com")).toBe(false);
+    expect(await hasGrant("a.example.com")).toBe(false);
   });
 
   test("cold-cache sync does not revoke user-approved MCP tool grants", async () => {
@@ -234,23 +230,21 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       buildPayload({ networkConfig: { allowedDomains: ["x.example.com"] } })
     );
 
-    expect(
-      await grantStore.hasGrant("agent-1", "/mcp/gmail/tools/send_email")
-    ).toBe(true);
+    expect(await hasGrant("/mcp/gmail/tools/send_email")).toBe(true);
   });
 
   test("grants nix cache domains while nix is configured, revokes on removal", async () => {
     await manager.syncNetworkConfigGrants(
       buildPayload({ nixConfig: { packages: ["python311"] } })
     );
-    expect(await grantStore.hasGrant("agent-1", "cache.nixos.org")).toBe(true);
+    expect(await hasGrant("cache.nixos.org")).toBe(true);
 
     const freshManager = new TestDeploymentManager(TEST_CONFIG);
     freshManager.setGrantStore(grantStore);
     freshManager.setPolicyStore(policyStore);
     await freshManager.syncNetworkConfigGrants(buildPayload({}));
 
-    expect(await grantStore.hasGrant("agent-1", "cache.nixos.org")).toBe(false);
+    expect(await hasGrant("cache.nixos.org")).toBe(false);
   });
 
   test("removing a deny listed under an alias spelling re-allows the domain", async () => {
@@ -263,15 +257,15 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
         },
       })
     );
-    expect(await grantStore.isDenied("agent-1", "api.example.com")).toBe(true);
+    expect(await isDenied("api.example.com")).toBe(true);
 
     await manager.syncNetworkConfigGrants(
       buildPayload({
         networkConfig: { allowedDomains: ["*.example.com"] },
       })
     );
-    expect(await grantStore.isDenied("agent-1", "api.example.com")).toBe(false);
-    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
+    expect(await isDenied("api.example.com")).toBe(false);
+    expect(await hasGrant("api.example.com")).toBe(true);
   });
 
   test("reconcile preserves infra-granted npm registry domains", async () => {
@@ -292,9 +286,7 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       buildPayload({ networkConfig: { allowedDomains: ["x.example.com"] } })
     );
 
-    expect(await grantStore.hasGrant("agent-1", "registry.npmjs.org")).toBe(
-      true
-    );
+    expect(await hasGrant("registry.npmjs.org")).toBe(true);
   });
 
   test("a config-denied npm registry row survives reconcile as a deny", async () => {
@@ -305,9 +297,7 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
         networkConfig: { deniedDomains: ["registry.npmjs.org"] },
       })
     );
-    expect(
-      await grantStore.isDenied("agent-1", "registry.npmjs.org", "test-org")
-    ).toBe(true);
+    expect(await isDenied("registry.npmjs.org")).toBe(true);
 
     // Removing the deny from config drops the row even though the domain is
     // in the infra exempt set — a denied row is never exempt.
@@ -315,9 +305,7 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     freshManager.setGrantStore(grantStore);
     freshManager.setPolicyStore(policyStore);
     await freshManager.syncNetworkConfigGrants(buildPayload({}));
-    expect(
-      await grantStore.isDenied("agent-1", "registry.npmjs.org", "test-org")
-    ).toBe(false);
+    expect(await isDenied("registry.npmjs.org")).toBe(false);
   });
 
   test("two-replica X→Y→X: a warm stale cache must not skip reconciliation", async () => {
@@ -332,15 +320,15 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     // Replica A syncs X (warm cache = X), replica B syncs Y (DB = Y).
     await replicaA.syncNetworkConfigGrants(buildPayload(configX));
     await replicaB.syncNetworkConfigGrants(buildPayload(configY));
-    expect(await grantStore.hasGrant("agent-1", "y.example.com")).toBe(true);
-    expect(await grantStore.hasGrant("agent-1", "x.example.com")).toBe(false);
+    expect(await hasGrant("y.example.com")).toBe(true);
+    expect(await hasGrant("x.example.com")).toBe(false);
 
     // Config reverts to X and the message lands on replica A, whose cache
     // already says X. Skipping on the pod-local cache would leave Y's rows
     // active and X's rows missing.
     await replicaA.syncNetworkConfigGrants(buildPayload(configX));
-    expect(await grantStore.hasGrant("agent-1", "y.example.com")).toBe(false);
-    expect(await grantStore.hasGrant("agent-1", "x.example.com")).toBe(true);
+    expect(await hasGrant("y.example.com")).toBe(false);
+    expect(await hasGrant("x.example.com")).toBe(true);
   });
 
   test("syncs both network and pre-approved tools in one call", async () => {
@@ -351,10 +339,8 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       })
     );
 
-    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
-    expect(
-      await grantStore.hasGrant("agent-1", "/mcp/gmail/tools/send_email")
-    ).toBe(true);
+    expect(await hasGrant("api.example.com")).toBe(true);
+    expect(await hasGrant("/mcp/gmail/tools/send_email")).toBe(true);
   });
 
   test("no-op when grantStore is not set", async () => {
@@ -463,11 +449,9 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       })
     );
 
-    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
-    expect(await grantStore.hasGrant("agent-1", ".github.com")).toBe(true);
-    expect(
-      await grantStore.hasGrant("agent-1", "/mcp/gmail/tools/send_email")
-    ).toBe(true);
+    expect(await hasGrant("api.example.com")).toBe(true);
+    expect(await hasGrant(".github.com")).toBe(true);
+    expect(await hasGrant("/mcp/gmail/tools/send_email")).toBe(true);
 
     // Shrink the set: drop the second domain and the MCP tool grant.
     await manager.syncNetworkConfigGrants(
@@ -477,11 +461,9 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     );
 
     expect(revokeSpy).toHaveBeenCalledTimes(2);
-    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
-    expect(await grantStore.hasGrant("agent-1", ".github.com")).toBe(false);
-    expect(
-      await grantStore.hasGrant("agent-1", "/mcp/gmail/tools/send_email")
-    ).toBe(false);
+    expect(await hasGrant("api.example.com")).toBe(true);
+    expect(await hasGrant(".github.com")).toBe(false);
+    expect(await hasGrant("/mcp/gmail/tools/send_email")).toBe(false);
   });
 
   test("domain sync writes only on drift, and repairs drift without invalidation", async () => {
@@ -506,7 +488,7 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     await grantStore.revoke("agent-1", "api.example.com", "test-org");
     await manager.syncNetworkConfigGrants(payload);
     expect(grantSpy.mock.calls.length).toBe(firstCallCount + 1);
-    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
+    expect(await hasGrant("api.example.com")).toBe(true);
   });
 
   test("revokes all grants when the config is cleared entirely", async () => {
@@ -517,18 +499,14 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
       })
     );
 
-    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
-    expect(
-      await grantStore.hasGrant("agent-1", "/mcp/gmail/tools/send_email")
-    ).toBe(true);
+    expect(await hasGrant("api.example.com")).toBe(true);
+    expect(await hasGrant("/mcp/gmail/tools/send_email")).toBe(true);
 
     // Operator clears both lists.
     await manager.syncNetworkConfigGrants(buildPayload({}));
 
-    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(false);
-    expect(
-      await grantStore.hasGrant("agent-1", "/mcp/gmail/tools/send_email")
-    ).toBe(false);
+    expect(await hasGrant("api.example.com")).toBe(false);
+    expect(await hasGrant("/mcp/gmail/tools/send_email")).toBe(false);
   });
 });
 

--- a/packages/server/src/gateway/permissions/grant-store.ts
+++ b/packages/server/src/gateway/permissions/grant-store.ts
@@ -6,11 +6,7 @@ import {
   type GrantKind,
 } from "@lobu/core";
 import { getDb, pgTextArray } from "../../db/client.js";
-import {
-  orgScope,
-  requireOrgId,
-  resolveOrgId,
-} from "../../lobu/stores/org-context.js";
+import { orgScope, requireOrgId } from "../../lobu/stores/org-context.js";
 
 const logger = createLogger("grant-store");
 
@@ -126,7 +122,7 @@ export class GrantStore {
   ): Promise<boolean> {
     pattern = normalizeDomainPattern(pattern);
     const kind = inferGrantKind(pattern);
-    const orgId = resolveOrgId(organizationId);
+    const orgId = requireOrgId(organizationId, "GrantStore.hasGrant");
 
     // Build the candidate pattern set (exact + wildcards) and look them
     // up in a single query.
@@ -174,7 +170,7 @@ export class GrantStore {
     pattern = normalizeDomainPattern(pattern);
     const kind = inferGrantKind(pattern);
     const candidates = buildGrantCandidates(pattern, kind);
-    const orgId = resolveOrgId(organizationId);
+    const orgId = requireOrgId(organizationId, "GrantStore.isDenied");
 
     const sql = getDb();
     try {
@@ -205,7 +201,7 @@ export class GrantStore {
    */
   async listGrants(agentId: string, organizationId?: string): Promise<Grant[]> {
     const sql = getDb();
-    const orgId = resolveOrgId(organizationId);
+    const orgId = requireOrgId(organizationId, "GrantStore.listGrants");
     try {
       const rows = await sql<GrantRow>`
         SELECT pattern, kind, granted_at, expires_at, denied
@@ -239,7 +235,7 @@ export class GrantStore {
   ): Promise<void> {
     const candidates = getDomainGrantCandidates(pattern);
     const kind = inferGrantKind(pattern);
-    const orgId = resolveOrgId(organizationId);
+    const orgId = requireOrgId(organizationId, "GrantStore.revoke");
     const sql = getDb();
     await sql`
       DELETE FROM grants

--- a/packages/server/src/gateway/routes/public/agent-config.ts
+++ b/packages/server/src/gateway/routes/public/agent-config.ts
@@ -64,7 +64,6 @@ const getConfigRoute: RouteSpec = {
 	responses: {
 		200: { description: "Configuration", schema: Type.Any() },
 		...errorResponses(ErrorResponseSchema, {
-			400: "Organization context required",
 			401: "Unauthorized",
 		}),
 	},
@@ -163,10 +162,17 @@ async function buildResolvedConfigResponse(
 	agentId: string,
 	payload: SettingsTokenPayload | null,
 	providerModels: Record<string, ModelOption[]>,
+	organizationId?: string,
 ): Promise<any> {
 	const [settingsView, grants] = await Promise.all([
 		resolveSettingsView(config, agentId, payload),
-		config.grantStore?.listGrants(agentId) ?? Promise.resolve([]),
+		// `grants` rows are keyed by organization, so there is nothing to read
+		// for a declared agent authorized without a tenant. Asking anyway used
+		// to answer across every organization at once.
+		organizationId
+			? (config.grantStore?.listGrants(agentId, organizationId) ??
+				Promise.resolve([]))
+			: Promise.resolve([]),
 	]);
 	const settings = settingsView.settings;
 
@@ -396,14 +402,18 @@ export function createAgentConfigRoutes(config: AgentConfigRoutesConfig): Hono {
 					agentId,
 					payload,
 					providerModels,
+					organizationId,
 				),
 			);
 		};
-		// No org means no tenant to scope to. Running unscoped used to read
-		// grants across every organization, silently — `orgScope` emitted an
-		// empty fragment and the query answered for all tenants at once.
+		// No org here means `verifyToken` authorized a DECLARED agent, whose
+		// settings are org-agnostic — a DB-backed agent without a tenant is
+		// already rejected there with 401. So the config still loads; the org
+		// only decides whether there are grants to read, and
+		// `buildResolvedConfigResponse` skips them rather than querying
+		// unscoped (which used to answer for every tenant at once).
 		if (!organizationId) {
-			return c.json({ error: "Organization context required" }, 400);
+			return loadConfig();
 		}
 		return orgContext.run({ organizationId }, loadConfig);
 	});
@@ -417,6 +427,11 @@ export function createAgentConfigRoutes(config: AgentConfigRoutesConfig): Hono {
 		app.get("/grants", async (c) => {
 			const auth = await requireConfigAuth(c);
 			if (auth instanceof Response) return auth;
+
+			// Same tenant rule as the config route: a declared agent authorized
+			// without an org has no org-scoped rows to list, and `listGrants`
+			// now refuses to run unscoped rather than answering for everyone.
+			if (!auth.organizationId) return c.json([]);
 
 			const grants = await grantStore.listGrants(
 				auth.agentId,

--- a/packages/server/src/gateway/routes/public/agent-config.ts
+++ b/packages/server/src/gateway/routes/public/agent-config.ts
@@ -64,6 +64,7 @@ const getConfigRoute: RouteSpec = {
 	responses: {
 		200: { description: "Configuration", schema: Type.Any() },
 		...errorResponses(ErrorResponseSchema, {
+			400: "Organization context required",
 			401: "Unauthorized",
 		}),
 	},

--- a/packages/server/src/gateway/routes/public/agent-config.ts
+++ b/packages/server/src/gateway/routes/public/agent-config.ts
@@ -398,9 +398,13 @@ export function createAgentConfigRoutes(config: AgentConfigRoutesConfig): Hono {
 				),
 			);
 		};
-		return organizationId
-			? orgContext.run({ organizationId }, loadConfig)
-			: loadConfig();
+		// No org means no tenant to scope to. Running unscoped used to read
+		// grants across every organization, silently — `orgScope` emitted an
+		// empty fragment and the query answered for all tenants at once.
+		if (!organizationId) {
+			return c.json({ error: "Organization context required" }, 400);
+		}
+		return orgContext.run({ organizationId }, loadConfig);
 	});
 
 	// ===== Grant Endpoints (read-only) =====

--- a/packages/server/src/lobu/stores/org-context.ts
+++ b/packages/server/src/lobu/stores/org-context.ts
@@ -45,10 +45,18 @@ export function requireOrgId(explicit: string | null | undefined, caller: string
 }
 
 /**
- * Optional `organization_id` filter as a composable SQL fragment, so the
- * org-scoped and legacy (org-less) query variants share a single statement.
- * Returns an empty fragment when `orgId` is null/undefined.
+ * `organization_id` filter as a composable SQL fragment.
+ *
+ * Fail-closed by construction: `orgId` is required. This used to accept
+ * null/undefined and return an EMPTY fragment, which silently dropped the
+ * tenant predicate — a cross-tenant read on every SELECT that used it, and a
+ * cross-tenant wipe on `GrantStore.revoke`'s DELETE. Nothing signalled it: no
+ * error, no log, just a query answering for every org at once.
+ *
+ * A caller that cannot produce an org must say so explicitly by resolving it
+ * with {@link requireOrgId} (which throws and names the caller) rather than
+ * passing a nullable through and inheriting an unscoped query.
  */
-export function orgScope(sql: ReturnType<typeof getDb>, orgId: string | null | undefined) {
-  return orgId ? sql`AND organization_id = ${orgId}` : sql``;
+export function orgScope(sql: ReturnType<typeof getDb>, orgId: string) {
+  return sql`AND organization_id = ${orgId}`;
 }


### PR DESCRIPTION
## What

`orgScope(sql, orgId)` accepted `null | undefined` and returned an **empty SQL fragment**:

```ts
export function orgScope(sql, orgId: string | null | undefined) {
  return orgId ? sql`AND organization_id = ${orgId}` : sql``;   // ← silent
}
```

So any caller without an organization silently lost the tenant predicate. Every `GrantStore` read answered across **all** orgs at once, and `revoke`'s `DELETE FROM grants` removed matching rows in every org. No error, no log — the query just answered for the wrong tenants.

That matters because `agents_pkey` is `PRIMARY KEY (organization_id, id)`: an agent id is unique only *within* an org, so a shared slug like `lobu-builder` exists in ~20 orgs and an unscoped `WHERE agent_id = $1` matches all of them.

## Fix

Require the org **in the type**. `orgScope` now takes `orgId: string`, which makes an unscoped query unrepresentable rather than merely discouraged. The four remaining `GrantStore` methods (`hasGrant`, `isDenied`, `listGrants`, `revoke`) now use the `requireOrgId` helper that `grant()` already used — it throws and names the caller, e.g. `GrantStore.revoke requires organizationId (explicit or via orgContext)`.

**Typecheck found no other call site to migrate.** Every remaining caller already supplied an org: `http-proxy` passes it explicitly, `mcp/proxy` wraps in `runWithOrganizationContext`, `deployment-manager` passes `orgId`.

### One reachable leak fixed with it

`agent-config.ts` ran the resolved-config handler **outside** the org context when the request had no `organizationId`:

```ts
return organizationId
  ? orgContext.run({ organizationId }, loadConfig)
  : loadConfig();          // ← listGrants(agentId) reads every tenant
```

`organizationId?: string` is optional throughout that path, so this was reachable by type.

That orgless path is legitimate for exactly one caller: `verifyToken` authorizes DECLARED (SDK-embedded) agents without a tenant, because their settings are org-agnostic; a DB-backed agent with no org is already rejected there with 401. So the handler no longer runs the unscoped read, and it does not reject the request either. It passes the resolved org into `buildResolvedConfigResponse`, which skips grants entirely when there is none, so a declared agent gets `tools.permissions: []`. The adjacent `/grants` endpoint returns `[]` on the same condition rather than calling the now-strict `listGrants` unscoped.

## Red → green

```
RED (at origin/main)
  ✓ does not see another org grant for the same agent id
  ✓ lists only the calling org grants
  ✓ revoke never deletes another org grant
  ✓ isDenied does not inherit another org deny
  × throws rather than running unscoped when no org can be resolved
    → promise resolved "false" instead of rejecting
  Tests  1 failed | 4 passed (5)

GREEN
  Tests  5 passed (5)
```

The red shape is the useful part: **the four org-scoped controls pass on `origin/main`**, so callers that supply an org were always scoped correctly. Only the null path leaked — which is exactly what the type change removes, and it means no behaviour changes for existing correct callers.

Test note: `grants` is FK'd to `agents(organization_id, id)`, so the fixture seeds the *same* agent id in both orgs — the composite-PK situation this PR is about.

## Scope

This is the smallest safe first step. Deliberately **not** included:

- `postgres-stores.ts` `getSettings`/`getMetadata` still have org-less branches guarded by a comment claiming "agent IDs are globally unique", which is false given the composite PK. Different mechanism (`tryGetOrgId` + branching, not `orgScope`), so it is its own PR.
- The `AgentConfigStore` interface still takes only `agentId`; putting org in that signature is a larger migration best done *after* this lands, so a mis-migrated call site fails loudly instead of silently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Bug Fixes**
  * Enforced organization scoping for grant checks, listings, denials, and revocations.
  * Prevented cross-organization grant access or deletion.
  * Unscoped requests now fail safely instead of running without tenant restrictions.
  * Agent configuration requests without organization context now return a clear 400 error.
* **Tests**
  * Added coverage for organization isolation and fail-closed behavior across grant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
