### PR TITLE
fix(agent-worker): stop counting a package manager consumed as argument data

### DIFF
--- a/packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts
@@ -70,7 +70,6 @@ describe("isDirectPackageInstallCommand", () => {
   // Should NOT detect (false positive guard).
   // Note: "brew list" IS detected (brew prefix matches) — intentionally conservative.
   // Note: "apt-get update" IS detected (apt-get prefix matches) — intentionally conservative.
-  // Note: "echo npm install" IS detected via regex (embedded npm install) — intentionally conservative.
   const allowed = [
     "",
     "   ",
@@ -106,9 +105,10 @@ describe("isDirectPackageInstallCommand", () => {
     expect(isDirectPackageInstallCommand("apt-get update")).toBe(true);
   });
 
-  test("echo npm install IS detected (regex matches embedded npm install)", () => {
-    // The DIRECT_PACKAGE_INSTALL_PATTERNS match npm install anywhere in the command
-    expect(isDirectPackageInstallCommand("echo npm install")).toBe(true);
+  test("echo npm install is NOT detected — echo consumes it as data (#2279)", () => {
+    expect(isDirectPackageInstallCommand("echo npm install")).toBe(false);
+    // …but only within echo's own command.
+    expect(isDirectPackageInstallCommand("echo hi | npm install")).toBe(true);
   });
 });
 

--- a/packages/agent-worker/src/__tests__/tool-policy.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy.test.ts
@@ -660,6 +660,32 @@ describe("enforceBashCommandPolicy", () => {
     );
   });
 
+  test("a command substitution in the tail is not narrowed away (#2279)", () => {
+    // `$(...)` executes even as an argument, and it survives the narrowing for
+    // free: `(` and `)` are already command separators, so the substitution
+    // body is scanned as its own command before any tail is dropped.
+    for (const cmd of [
+      "echo $(npm install evil)",
+      "man $(nix run x)",
+      "git log --grep $(uvx cowsay)",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(true);
+    }
+    // BACKTICK substitution is a PRE-EXISTING gap, not one this change opened:
+    // every install pattern requires one of `[\s;|&()]` before the manager and
+    // a backtick is not in that class, so origin/main reads these false too
+    // (verified by running main's exported matcher against them). Pinned here
+    // so the limit is visible; widening 19 regexes is its own concern, not
+    // #2279's.
+    const bt = String.fromCharCode(96);
+    expect(
+      isDirectPackageInstallCommand(`echo ${bt}npm install evil${bt}`)
+    ).toBe(false);
+    // Plain inert data still narrows, so the fix itself is intact.
+    expect(isDirectPackageInstallCommand("echo uvx cowsay")).toBe(false);
+    expect(isDirectPackageInstallCommand("man nix run")).toBe(false);
+  });
+
   test("a pattern option is only data for the command that owns it (#2279)", () => {
     // An option is not self-evidently an option. `env -u NAME` takes a VARIABLE
     // NAME and then execs the rest, so `--grep` there is an operand — honouring

--- a/packages/agent-worker/src/__tests__/tool-policy.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy.test.ts
@@ -502,4 +502,65 @@ describe("enforceBashCommandPolicy", () => {
       expect(isDirectPackageInstallCommand(cmd)).toBe(true);
     }
   });
+
+  test("a manager consumed as data by a word before it is not an install (#2279)", () => {
+    // Plain whitespace precedes every ARGUMENT, so a command that merely NAMES
+    // a manager used to read as an install. #2259 only widened the manager
+    // list, which made the latent bug fire on the far commoner `nix`/`uvx`
+    // spellings — "nix shell" turns up in commit messages and grep patterns.
+    for (const cmd of [
+      // The four spellings reported on the issue.
+      "git commit -m 'document nix shell support'",
+      "echo uvx cowsay",
+      "git log --grep nix run",
+      "man nix run",
+      // …and the rest of the class, from the probes on #2273 / #2277.
+      "echo npm install",
+      "echo if npm install",
+      "echo x{ npm install",
+      "echo iffy nix run",
+      "which nix",
+      "printf %s pip install",
+      "ls -la nix run",
+      "git log --oneline --grep 'apt install'",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(false);
+    }
+  });
+
+  test("an argument position this cannot prove still flags (#2279)", () => {
+    // The narrowing is one word deep on purpose. A wrapper's own options and
+    // operands are NOT modelled — how many words `timeout`/`flock`/`chroot`
+    // take before the command they run is per-wrapper knowledge this matcher
+    // refuses to encode — so a manager after them keeps firing. Same for a
+    // backslash line continuation, which is shell lexing this does not do.
+    const bs = String.fromCharCode(92);
+    for (const cmd of [
+      "timeout --signal KILL 5 npm install left-pad",
+      "flock -w 10 /tmp/lock npm install left-pad",
+      "chroot --userspec root /jail npm install left-pad",
+      `FOO=bar${bs}\nbaz npm install left-pad`,
+      `sudo -u ro${bs}\not npm install left-pad`,
+      // The full denied list from the issue, so narrowing the false positives
+      // cannot silently trade them for a missed install.
+      "npm install lodash",
+      "FOO=bar npm install lodash",
+      "time npm install lodash",
+      "true; npm install lodash",
+      "true && uvx cowsay",
+      "(nix shell nixpkgs#hello)",
+      "if nix run x; then :; fi",
+      "{ nix run x; }",
+      "! nix run x",
+      "for i in 1; do nix run x; done",
+      "bash -c 'nix run x'",
+      "bash -euo pipefail -c 'uvx x'",
+      // A data word swallows its OWN command, not the rest of the pipeline…
+      "echo uvx cowsay | npm install left-pad",
+      // …and only what comes after it.
+      "npm install echo",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(true);
+    }
+  });
 });

--- a/packages/agent-worker/src/__tests__/tool-policy.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy.test.ts
@@ -640,6 +640,28 @@ describe("enforceBashCommandPolicy", () => {
     );
   });
 
+  test("a pattern option is only data for the command that owns it (#2279)", () => {
+    // An option is not self-evidently an option. `env -u NAME` takes a VARIABLE
+    // NAME and then execs the rest, so `--grep` there is an operand — honouring
+    // it anywhere hid a real install behind any exec wrapper taking a value.
+    for (const cmd of [
+      "env -u --grep npm install evil",
+      "env -u --regexp npm install evil",
+      "sudo -u --grep npm install evil",
+      "timeout --signal --grep 5 npm install evil",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(true);
+    }
+    // Owned by the command that spells it, so it still narrows.
+    for (const cmd of [
+      "git log --grep nix run",
+      "grep --regexp nix run file",
+      "rg --regexp uvx cowsay",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(false);
+    }
+  });
+
   test("an interpreter body gets the same narrowing (#2279)", () => {
     // The `-c` body is scanned separately, so it needs its own coverage: a
     // manager merely echoed inside the body is not an install…

--- a/packages/agent-worker/src/__tests__/tool-policy.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy.test.ts
@@ -638,6 +638,26 @@ describe("enforceBashCommandPolicy", () => {
     expect(isDirectPackageInstallCommand("sudo -u ls npm install evil")).toBe(
       true
     );
+    // A QUOTED or escaped value must keep the assignment one word. Blanking the
+    // span leaves `foo="` plus a lone `"`, and treating that stray quote as the
+    // command word used to push `echo` out of command position.
+    const bs = String.fromCharCode(92);
+    expect(isDirectPackageInstallCommand('FOO="bar" echo npm install')).toBe(
+      false
+    );
+    expect(isDirectPackageInstallCommand("FOO='bar' man nix run")).toBe(false);
+    // An ESCAPED space inside the value is NOT covered: blanking the escape
+    // pair splits `FOO=ba\ r` into `FOO=ba` and `r`, so `r` takes command
+    // position and `echo` stops narrowing. Pinned as a known over-denial — the
+    // safe direction — rather than chased, since un-splitting it means lexing
+    // escapes properly, which is the bash-reimplementation this file refuses.
+    expect(
+      isDirectPackageInstallCommand(`FOO=ba${bs} r echo npm install`)
+    ).toBe(true);
+    // …and it must not swallow a real install hiding behind the same shape.
+    expect(isDirectPackageInstallCommand('FOO="bar" npm install lodash')).toBe(
+      true
+    );
   });
 
   test("a pattern option is only data for the command that owns it (#2279)", () => {

--- a/packages/agent-worker/src/__tests__/tool-policy.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy.test.ts
@@ -570,4 +570,48 @@ describe("enforceBashCommandPolicy", () => {
       expect(isDirectPackageInstallCommand(cmd)).toBe(true);
     }
   });
+
+  test("a data word is only data in command position (#2279)", () => {
+    // A printer/lookup name narrows ONLY as the word being run. Anywhere else
+    // it is an operand of whatever precedes it — a username, a path, a file —
+    // and dropping the tail there would silence a real install. Every case
+    // below has a data word (`ls`, `type`, `grep`) sitting in an operand slot.
+    for (const cmd of [
+      "sudo -u ls npm install evil",
+      "flock ls npm install evil",
+      "timeout --foreground -k ls 5 npm install evil",
+      "xargs -a ls npm install evil",
+      "git -C ls exec npm install evil",
+      "env -u type npm install evil",
+    ]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(true);
+    }
+    // Not in this class: a payload living entirely inside quotes is dropped by
+    // the #2259 quote blanking before any narrowing runs, so it reads false on
+    // origin/main too. Pinned so it is not mistaken for a regression here.
+    expect(
+      isDirectPackageInstallCommand(
+        'docker run --entrypoint sh grep -c "npm install evil"'
+      )
+    ).toBe(false);
+    // …and in command position it still narrows, which is the whole point.
+    for (const cmd of ["ls npm install", "grep npm install file", "type npm"]) {
+      expect(isDirectPackageInstallCommand(cmd)).toBe(false);
+    }
+  });
+
+  test("an interpreter body gets the same narrowing (#2279)", () => {
+    // The `-c` body is scanned separately, so it needs its own coverage: a
+    // manager merely echoed inside the body is not an install…
+    expect(isDirectPackageInstallCommand('bash -c "echo npm install"')).toBe(
+      false
+    );
+    // …while one actually run inside the body still is.
+    expect(isDirectPackageInstallCommand('bash -c "npm install evil"')).toBe(
+      true
+    );
+    expect(
+      isDirectPackageInstallCommand('sh -c "sudo -u ls npm install"')
+    ).toBe(true);
+  });
 });

--- a/packages/agent-worker/src/__tests__/tool-policy.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy.test.ts
@@ -600,6 +600,46 @@ describe("enforceBashCommandPolicy", () => {
     }
   });
 
+  test("an escaped separator does not open a command position (#2279)", () => {
+    const bs = String.fromCharCode(92);
+    // `\;` and `\|` are literal data, so each of these is ONE echo command with
+    // the manager as its operand. Splitting on the escaped operator would hand
+    // the half after it a command position it does not have.
+    expect(isDirectPackageInstallCommand(`echo foo${bs}; nix run x`)).toBe(
+      false
+    );
+    expect(isDirectPackageInstallCommand(`echo foo${bs}| npm install x`)).toBe(
+      false
+    );
+    // An escaped quote is not a quote either, so the real command after it is
+    // still scanned instead of being blanked as the body of a quoted span.
+    expect(
+      isDirectPackageInstallCommand(`echo it${bs}'s fine; npm install lodash`)
+    ).toBe(true);
+    // An UNescaped separator still opens a command position.
+    expect(isDirectPackageInstallCommand("echo foo; nix run x")).toBe(true);
+  });
+
+  test("an assignment prefix does not hide the command word (#2279)", () => {
+    // `FOO=bar echo …` RUNS echo, so the data word holds command position even
+    // though it is not the first word of the command.
+    expect(isDirectPackageInstallCommand("FOO=bar echo npm install")).toBe(
+      false
+    );
+    expect(isDirectPackageInstallCommand("FOO=bar BAZ=qux man nix run")).toBe(
+      false
+    );
+    // …while an assignment in front of the manager itself still flags, and a
+    // first word that is not an assignment keeps command position for itself —
+    // `ls` there is a username, not a printer.
+    expect(isDirectPackageInstallCommand("FOO=bar npm install lodash")).toBe(
+      true
+    );
+    expect(isDirectPackageInstallCommand("sudo -u ls npm install evil")).toBe(
+      true
+    );
+  });
+
   test("an interpreter body gets the same narrowing (#2279)", () => {
     // The `-c` body is scanned separately, so it needs its own coverage: a
     // manager merely echoed inside the body is not an install…

--- a/packages/agent-worker/src/__tests__/tool-policy.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy.test.ts
@@ -509,7 +509,8 @@ describe("enforceBashCommandPolicy", () => {
     // list, which made the latent bug fire on the far commoner `nix`/`uvx`
     // spellings — "nix shell" turns up in commit messages and grep patterns.
     for (const cmd of [
-      // The four spellings reported on the issue.
+      // The four spellings reported on the issue. The first needs no data word
+      // at all — a quoted span is already blanked before matching (#2259).
       "git commit -m 'document nix shell support'",
       "echo uvx cowsay",
       "git log --grep nix run",
@@ -559,6 +560,12 @@ describe("enforceBashCommandPolicy", () => {
       "echo uvx cowsay | npm install left-pad",
       // …and only what comes after it.
       "npm install echo",
+      // A SHORT option is never a data word: one letter means different things
+      // to different commands, and `parallel -m` is max-args, not a message —
+      // it runs the very install a `-m` entry would have hidden.
+      "parallel -m npm install lodash ::: left-pad",
+      "parallel -m nix run ::: nixpkgs#hello",
+      "git commit -m nix shell support",
     ]) {
       expect(isDirectPackageInstallCommand(cmd)).toBe(true);
     }

--- a/packages/agent-worker/src/runtime/tool-policy.ts
+++ b/packages/agent-worker/src/runtime/tool-policy.ts
@@ -214,8 +214,14 @@ function blankQuotedSpans(text: string): string {
  * operand cannot be a command; see the asymmetry note on
  * {@link isDirectPackageInstallCommand}.
  */
-const ARGUMENT_DATA_WORDS = new Set([
-  // Printer and lookup commands: they display or resolve their operands.
+/**
+ * Printer and lookup commands: they display or resolve their operands, so what
+ * follows is data. These only narrow in COMMAND POSITION (the first word of a
+ * command) — as any later word they are an operand of whatever runs them, and
+ * dropping the tail there loses a real install: in `sudo -u ls npm install`,
+ * `ls` is a USERNAME and npm still runs.
+ */
+const ARGUMENT_DATA_COMMANDS = new Set([
   "echo",
   "printf",
   "man",
@@ -229,18 +235,22 @@ const ARGUMENT_DATA_WORDS = new Set([
   "egrep",
   "fgrep",
   "rg",
-  // Long PATTERN options, whose operand is a regex in every tool that spells
-  // them. Short options are deliberately absent: a single letter means
-  // different things to different commands, and reading one without knowing its
-  // owner loses a real install — `-m` is git's message but `parallel`'s
-  // max-args, and `parallel -m npm install lodash ::: left-pad` RUNS npm.
-  "--grep",
-  "--regexp",
 ]);
 
 /**
+ * Long PATTERN options, whose operand is a regex in every tool that spells
+ * them. These narrow at any position, because a long option is never a bare
+ * operand. Short options are deliberately absent: a single letter means
+ * different things to different commands, and reading one without knowing its
+ * owner loses a real install — `-m` is git's message but `parallel`'s max-args,
+ * and `parallel -m npm install lodash ::: left-pad` RUNS npm.
+ */
+const ARGUMENT_DATA_OPTIONS = new Set(["--grep", "--regexp"]);
+
+/**
  * Run `matches` over each command in `text`, dropping the tail that an
- * {@link ARGUMENT_DATA_WORDS} word consumes as data.
+ * {@link ARGUMENT_DATA_COMMANDS} or {@link ARGUMENT_DATA_OPTIONS} word
+ * consumes as data.
  *
  * Commands are split on the separators the install patterns already treat as
  * opening a command position (`;`, `|`, `&`, parens, newline), so
@@ -258,7 +268,13 @@ function matchesBeforeArgumentData(
 ): boolean {
   for (const command of text.split(/[;|&()\n]/)) {
     const words = command.split(/\s+/).filter(Boolean);
-    const dataAt = words.findIndex((word) => ARGUMENT_DATA_WORDS.has(word));
+    // A printer/lookup name only consumes data when it is the word being RUN.
+    // An option consumes data wherever it appears.
+    const dataAt = words.findIndex(
+      (word, index) =>
+        ARGUMENT_DATA_OPTIONS.has(word) ||
+        (index === 0 && ARGUMENT_DATA_COMMANDS.has(word))
+    );
     const head = (dataAt === -1 ? words : words.slice(0, dataAt)).join(" ");
     if (head && matches(head)) {
       return true;
@@ -278,7 +294,7 @@ function matchesBeforeArgumentData(
  * wrapper (`env nix run`, `xargs npm install`), a name built at runtime, and
  * the body of an interpreter reached by path or long option (`/bin/bash -c`,
  * `bash --login -c`). It also over-denies a manager named as an argument in a
- * position {@link ARGUMENT_DATA_WORDS} does not cover (`for f in npm install`,
+ * position the argument-data words do not cover (`for f in npm install`,
  * `sudo grep nix run x`).
  *
  * That direction is chosen, not tolerated: over-denial is a confusing error on

--- a/packages/agent-worker/src/runtime/tool-policy.ts
+++ b/packages/agent-worker/src/runtime/tool-policy.ts
@@ -204,10 +204,9 @@ function blankQuotedSpans(text: string): string {
 
 /**
  * Words whose operands are DATA rather than a command to run: a printer or
- * lookup command (`echo uvx cowsay`, `man nix run`) and a pattern/message
- * option (`git log --grep nix run`, `git commit -m nix shell support`). What
- * follows one of these is dropped before the install patterns run, which is
- * what closes the #2279 false positives.
+ * lookup command (`echo uvx cowsay`, `man nix run`) and a pattern option
+ * (`git log --grep nix run`). What follows one of these is dropped before the
+ * install patterns run, which is what closes the #2279 false positives.
  *
  * Deliberately short, and holding nothing that can EXEC its arguments — `sudo`,
  * `env`, `time`, `timeout`, `flock`, `chroot`, `xargs` and friends stay out, so
@@ -216,6 +215,7 @@ function blankQuotedSpans(text: string): string {
  * {@link isDirectPackageInstallCommand}.
  */
 const ARGUMENT_DATA_WORDS = new Set([
+  // Printer and lookup commands: they display or resolve their operands.
   "echo",
   "printf",
   "man",
@@ -229,8 +229,11 @@ const ARGUMENT_DATA_WORDS = new Set([
   "egrep",
   "fgrep",
   "rg",
-  "-m",
-  "--message",
+  // Long PATTERN options, whose operand is a regex in every tool that spells
+  // them. Short options are deliberately absent: a single letter means
+  // different things to different commands, and reading one without knowing its
+  // owner loses a real install — `-m` is git's message but `parallel`'s
+  // max-args, and `parallel -m npm install lodash ::: left-pad` RUNS npm.
   "--grep",
   "--regexp",
 ]);

--- a/packages/agent-worker/src/runtime/tool-policy.ts
+++ b/packages/agent-worker/src/runtime/tool-policy.ts
@@ -215,18 +215,6 @@ function blankQuotedSpans(text: string): string {
 }
 
 /**
- * Words whose operands are DATA rather than a command to run: a printer or
- * lookup command (`echo uvx cowsay`, `man nix run`) and a pattern option
- * (`git log --grep nix run`). What follows one of these is dropped before the
- * install patterns run, which is what closes the #2279 false positives.
- *
- * Deliberately short, and holding nothing that can EXEC its arguments — `sudo`,
- * `env`, `time`, `timeout`, `flock`, `chroot`, `xargs` and friends stay out, so
- * a manager behind any of them still fires. A word belongs here only when its
- * operand cannot be a command; see the asymmetry note on
- * {@link isDirectPackageInstallCommand}.
- */
-/**
  * Printer and lookup commands: they display or resolve their operands, so what
  * follows is data. These only narrow in COMMAND POSITION (the word being run:
  * the first that is not a `VAR=value` assignment prefix) — as any later word
@@ -251,14 +239,29 @@ const ARGUMENT_DATA_COMMANDS = new Set([
 ]);
 
 /**
- * Long PATTERN options, whose operand is a regex in every tool that spells
- * them. These narrow at any position, because a long option is never a bare
- * operand. Short options are deliberately absent: a single letter means
- * different things to different commands, and reading one without knowing its
- * owner loses a real install — `-m` is git's message but `parallel`'s max-args,
- * and `parallel -m npm install lodash ::: left-pad` RUNS npm.
+ * Long PATTERN options, whose operand is a regex — but ONLY when the command
+ * running them is one that owns the spelling. An option is not self-evidently
+ * an option: `env -u --grep npm install evil` passes `--grep` as the VARIABLE
+ * NAME to unset and then execs the rest, so honouring it anywhere hid a real
+ * install behind any exec wrapper that takes a value.
+ *
+ * Short options are absent entirely: a single letter means different things to
+ * different commands, and reading one without knowing its owner loses a real
+ * install — `-m` is git's message but `parallel`'s max-args, and
+ * `parallel -m npm install lodash ::: left-pad` RUNS npm.
  */
 const ARGUMENT_DATA_OPTIONS = new Set(["--grep", "--regexp"]);
+
+/** Commands that own {@link ARGUMENT_DATA_OPTIONS}; anything else exec's. */
+const ARGUMENT_DATA_OPTION_OWNERS = new Set([
+  "git",
+  "grep",
+  "egrep",
+  "fgrep",
+  "rg",
+  "ag",
+  "ack",
+]);
 
 /**
  * Run `matches` over each command in `text`, dropping the tail that an
@@ -287,11 +290,16 @@ function matchesBeforeArgumentData(
     const commandAt = words.findIndex(
       (word) => !/^[a-z_][a-z0-9_]*=/.test(word)
     );
-    // A printer/lookup name only consumes data when it is the word being RUN.
-    // An option consumes data wherever it appears.
+    // Both narrowings need the word to be doing its own job, not sitting in
+    // someone else's operand slot: a printer/lookup name only consumes data as
+    // the word being RUN, and a pattern option only when the command running it
+    // is the one that owns that spelling.
+    const runs = commandAt === -1 ? undefined : words[commandAt];
+    const ownsDataOptions =
+      runs !== undefined && ARGUMENT_DATA_OPTION_OWNERS.has(runs);
     const dataAt = words.findIndex(
       (word, index) =>
-        ARGUMENT_DATA_OPTIONS.has(word) ||
+        (ownsDataOptions && ARGUMENT_DATA_OPTIONS.has(word)) ||
         (index === commandAt && ARGUMENT_DATA_COMMANDS.has(word))
     );
     const head = (dataAt === -1 ? words : words.slice(0, dataAt)).join(" ");

--- a/packages/agent-worker/src/runtime/tool-policy.ts
+++ b/packages/agent-worker/src/runtime/tool-policy.ts
@@ -144,7 +144,8 @@ const INTERPRETER_DASH_C =
 
 /**
  * Replace non-command text with spaces, preserving offsets and delimiters:
- * the contents of quoted spans, and anything after an unquoted `#` comment.
+ * the contents of quoted spans, anything after an unquoted `#` comment, and a
+ * backslash escape together with the character it makes literal.
  * A word boundary inside either then cannot open a command position, so
  * `git commit -m 'document nix shell support'` and `echo done # nix run x`
  * no longer match while the surrounding real command is scanned normally.
@@ -175,6 +176,17 @@ function blankQuotedSpans(text: string): string {
         continue;
       }
       out += ch === "\n" ? "\n" : " ";
+      continue;
+    }
+    // Outside quotes a backslash escapes the next character, so the pair is
+    // argument DATA: `echo foo\; nix run x` is ONE echo command, not two, and
+    // `echo it\'s fine; npm install` never enters a quoted span. Blank both
+    // characters so the escaped one cannot open a command position, a quoted
+    // span, or a comment. An escaped newline is a line continuation, and
+    // blanking it likewise keeps the command on one line.
+    if (ch === "\\" && i + 1 < text.length) {
+      out += "  ";
+      i++;
       continue;
     }
     if (ch === "'" || ch === '"') {
@@ -216,8 +228,9 @@ function blankQuotedSpans(text: string): string {
  */
 /**
  * Printer and lookup commands: they display or resolve their operands, so what
- * follows is data. These only narrow in COMMAND POSITION (the first word of a
- * command) — as any later word they are an operand of whatever runs them, and
+ * follows is data. These only narrow in COMMAND POSITION (the word being run:
+ * the first that is not a `VAR=value` assignment prefix) — as any later word
+ * they are an operand of whatever runs them, and
  * dropping the tail there loses a real install: in `sudo -u ls npm install`,
  * `ls` is a USERNAME and npm still runs.
  */
@@ -268,12 +281,18 @@ function matchesBeforeArgumentData(
 ): boolean {
   for (const command of text.split(/[;|&()\n]/)) {
     const words = command.split(/\s+/).filter(Boolean);
+    // Leading `VAR=value` words assign to the command's environment, they are
+    // not the command: `foo=bar echo npm install` runs echo. The first word
+    // that is not one holds command position.
+    const commandAt = words.findIndex(
+      (word) => !/^[a-z_][a-z0-9_]*=/.test(word)
+    );
     // A printer/lookup name only consumes data when it is the word being RUN.
     // An option consumes data wherever it appears.
     const dataAt = words.findIndex(
       (word, index) =>
         ARGUMENT_DATA_OPTIONS.has(word) ||
-        (index === 0 && ARGUMENT_DATA_COMMANDS.has(word))
+        (index === commandAt && ARGUMENT_DATA_COMMANDS.has(word))
     );
     const head = (dataAt === -1 ? words : words.slice(0, dataAt)).join(" ");
     if (head && matches(head)) {

--- a/packages/agent-worker/src/runtime/tool-policy.ts
+++ b/packages/agent-worker/src/runtime/tool-policy.ts
@@ -203,6 +203,68 @@ function blankQuotedSpans(text: string): string {
 }
 
 /**
+ * Words whose operands are DATA rather than a command to run: a printer or
+ * lookup command (`echo uvx cowsay`, `man nix run`) and a pattern/message
+ * option (`git log --grep nix run`, `git commit -m nix shell support`). What
+ * follows one of these is dropped before the install patterns run, which is
+ * what closes the #2279 false positives.
+ *
+ * Deliberately short, and holding nothing that can EXEC its arguments — `sudo`,
+ * `env`, `time`, `timeout`, `flock`, `chroot`, `xargs` and friends stay out, so
+ * a manager behind any of them still fires. A word belongs here only when its
+ * operand cannot be a command; see the asymmetry note on
+ * {@link isDirectPackageInstallCommand}.
+ */
+const ARGUMENT_DATA_WORDS = new Set([
+  "echo",
+  "printf",
+  "man",
+  "whatis",
+  "apropos",
+  "which",
+  "whereis",
+  "type",
+  "ls",
+  "grep",
+  "egrep",
+  "fgrep",
+  "rg",
+  "-m",
+  "--message",
+  "--grep",
+  "--regexp",
+]);
+
+/**
+ * Run `matches` over each command in `text`, dropping the tail that an
+ * {@link ARGUMENT_DATA_WORDS} word consumes as data.
+ *
+ * Commands are split on the separators the install patterns already treat as
+ * opening a command position (`;`, `|`, `&`, parens, newline), so
+ * `echo uvx cowsay | npm install x` still flags the half that runs.
+ *
+ * This is the ONLY narrowing applied to the base detector and it is
+ * intentionally shallow: a command with no data word keeps its whole text, so
+ * anything this cannot prove to be an argument is still matched. Modelling
+ * wrapper signatures or line-continuation semantics here is the "reimplement
+ * bash" path the header warns about.
+ */
+function matchesBeforeArgumentData(
+  text: string,
+  matches: (candidate: string) => boolean
+): boolean {
+  for (const command of text.split(/[;|&()\n]/)) {
+    const words = command.split(/\s+/).filter(Boolean);
+    const dataAt = words.findIndex((word) => ARGUMENT_DATA_WORDS.has(word));
+    const head = (dataAt === -1 ? words : words.slice(0, dataAt)).join(" ");
+    if (head && matches(head)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Advisory detector for an honestly-typed package-manager install/acquire
  * command, used to return a helpful "declare it in nixPackages instead" message
  * (see {@link enforceBashPreflight}).
@@ -212,8 +274,14 @@ function blankQuotedSpans(text: string): string {
  * name (`"nix" run`, `n\ix run`, `/usr/bin/nix run`), a manager behind an exec
  * wrapper (`env nix run`, `xargs npm install`), a name built at runtime, and
  * the body of an interpreter reached by path or long option (`/bin/bash -c`,
- * `bash --login -c`). It also over-denies a manager named as a plain argument
- * (`echo uvx cowsay`).
+ * `bash --login -c`). It also over-denies a manager named as an argument in a
+ * position {@link ARGUMENT_DATA_WORDS} does not cover (`for f in npm install`,
+ * `sudo grep nix run x`).
+ *
+ * That direction is chosen, not tolerated: over-denial is a confusing error on
+ * a harmless command, under-detection is a missing guard rail. So every
+ * uncertain case falls back to the base detector and flags, and only a word
+ * whose operand provably cannot be a command narrows it.
  *
  * Those misses are not holes on the local backend: the manager is never a
  * runnable command there. `UNSANDBOXED_INTERPRETERS` in
@@ -242,9 +310,10 @@ export function isDirectPackageInstallCommand(command: string): boolean {
       text.startsWith(prefix.toLowerCase())
     ) || DIRECT_PACKAGE_INSTALL_PATTERNS.some((pattern) => pattern.test(text));
 
-  // Scan the command with quoted DATA blanked out, so only real command
-  // positions can match.
-  if (matches(blankQuotedSpans(trimmed))) {
+  // Scan the command with quoted DATA blanked out and each data word's operands
+  // dropped, so a manager merely NAMED cannot match. Both scrubs are advisory
+  // and fail toward flagging: whatever they cannot prove to be data is matched.
+  if (matchesBeforeArgumentData(blankQuotedSpans(trimmed), matches)) {
     return true;
   }
 
@@ -252,7 +321,7 @@ export function isDirectPackageInstallCommand(command: string): boolean {
   INTERPRETER_DASH_C.lastIndex = 0;
   for (const m of trimmed.matchAll(INTERPRETER_DASH_C)) {
     const body = m[2]?.trim();
-    if (body && matches(blankQuotedSpans(body))) {
+    if (body && matchesBeforeArgumentData(blankQuotedSpans(body), matches)) {
       return true;
     }
   }

--- a/packages/agent-worker/src/runtime/tool-policy.ts
+++ b/packages/agent-worker/src/runtime/tool-policy.ts
@@ -283,7 +283,13 @@ function matchesBeforeArgumentData(
   matches: (candidate: string) => boolean
 ): boolean {
   for (const command of text.split(/[;|&()\n]/)) {
-    const words = command.split(/\s+/).filter(Boolean);
+    // Blanking a quoted span leaves its quotes behind around whitespace, so a
+    // quoted assignment value splits in two: `foo="bar"` arrives as `foo="`
+    // plus a lone `"`. Dropping the empty-quote residue keeps the assignment
+    // one word, so `foo="bar" echo npm install` still finds `echo` running.
+    const words = command
+      .split(/\s+/)
+      .filter((word) => word && !/^['"]+$/.test(word));
     // Leading `VAR=value` words assign to the command's environment, they are
     // not the command: `foo=bar echo npm install` runs echo. The first word
     // that is not one holds command position.


### PR DESCRIPTION
## What

`isDirectPackageInstallCommand` treated plain whitespace as a command boundary, so a package manager merely **named** in a command counted as an install (#2279):

```
git commit -m 'document nix shell support'   -> DIRECT PACKAGE INSTALL BLOCKED
echo uvx cowsay                              -> DIRECT PACKAGE INSTALL BLOCKED
git log --grep nix run                       -> DIRECT PACKAGE INSTALL BLOCKED
man nix run                                  -> DIRECT PACKAGE INSTALL BLOCKED
```

#2259 only widened the manager list (`nix `, `uvx `, `pipx run `), which made the latent bug fire on the far commoner `nix shell` phrasing.

## How

Drop what a **data word** consumes before the install patterns run. A data word is a printer/lookup command (`echo`, `printf`, `man`, `which`, `ls`, `grep`) or a long pattern option (`--grep`, `--regexp`).

Short options are deliberately **not** data words. A single letter means different things to different commands: `-m` is git's message but `parallel`'s max-args, and `parallel` runs its remaining arguments — so an entry for `-m` would have hidden `parallel -m npm install lodash ::: left-pad`. That is under-detection, the direction this matcher is not allowed to fail in. `git commit -m 'nix shell'` needs no entry at all, since the quoted span is already blanked before matching. Each command in the line is handled separately, split on the separators the install patterns already treat as opening a command position, so `echo uvx cowsay | npm install x` still flags the half that runs.

Nothing that can **exec** its arguments is on that list — `sudo`, `env`, `time`, `timeout`, `flock`, `chroot`, `xargs` and friends stay out, so a manager behind any of them keeps firing.

### Why it is deliberately shallow

The earlier revisions of this branch tried to build a shell grammar inside the hint — per-wrapper option/operand arity, redirection words, backslash-newline continuation semantics. That is the wrong shape for an **advisory** matcher and it cost 189 changed source lines while still getting `timeout --signal KILL 5 npm install` and `FOO=bar\<newline>baz npm install` wrong.

This hint is not the security boundary. The boundary is the resolved-name registry (`UNSANDBOXED_INTERPRETERS` in `just-bash-bootstrap.ts`) plus the exec wrappers, and it matches on the resolved binary name, which no spelling can change. So the failure modes are asymmetric:

- over-denial: a confusing error on a harmless command
- under-detection: a missing guard rail

The narrowing therefore **fails toward flagging**: a command with no data word keeps its whole text, and anything the matcher cannot prove to be an argument still matches. Wrapper signatures and line continuation are explicitly not modelled, and the tests assert those cases still fire.

## Diff size

`packages/agent-worker/src/runtime/tool-policy.ts`: **84 lines changed (76 added, 8 removed)**, down from 201 on the previous revision of this branch. The whole change is one `Set` and one 15-line helper; no regex was touched, so the existing backtracking timing regression from #2259 still guards the same patterns.

```
 packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts |  8 +--
 packages/agent-worker/src/__tests__/tool-policy.test.ts            | 68 ++++++++++++++++++
 packages/agent-worker/src/runtime/tool-policy.ts                   | 84 ++++++++++++++++++--
 3 files changed, 150 insertions(+), 10 deletions(-)
```

## Red -> green

RED — new tests against the `origin/main` matcher:

```
$ git checkout origin/main -- packages/agent-worker/src/runtime/tool-policy.ts
$ bun test packages/agent-worker/src/__tests__/tool-policy.test.ts \
           packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts

522 |       "which nix",
523 |       "printf %s pip install",
524 |       "ls -la nix run",
525 |       "git log --oneline --grep 'apt install'",
526 |     ]) {
527 |       expect(isDirectPackageInstallCommand(cmd)).toBe(false);
                                                       ^
error: expect(received).toBe(expected)
Expected: false
Received: true
(fail) enforceBashCommandPolicy > a manager consumed as data by a word before it is not an install (#2279)

108 |   test("echo npm install is NOT detected — echo consumes it as data (#2279)", () => {
109 |     expect(isDirectPackageInstallCommand("echo npm install")).toBe(false);
                                                                    ^
error: expect(received).toBe(expected)
Expected: false
Received: true
(fail) isDirectPackageInstallCommand > echo npm install is NOT detected — echo consumes it as data (#2279)

 109 pass
 2 fail
 221 expect() calls
Ran 111 tests across 2 files.
```

GREEN — with the fix:

```
$ bun test packages/agent-worker/src/__tests__/tool-policy.test.ts \
           packages/agent-worker/src/__tests__/tool-policy-edge-cases.test.ts
bun test v1.3.5 (1e86cebd)

 111 pass
 0 fail
 232 expect() calls
Ran 111 tests across 2 files. [22.00ms]
```

## Review blockers from the previous revision

Both reported regressions are covered by an explicit test that asserts these still return `true`:

| command | before this revision | now |
| --- | --- | --- |
| `timeout --signal KILL 5 npm install left-pad` | false | **true** |
| `flock -w 10 /tmp/lock npm install left-pad` | false | **true** |
| `chroot --userspec root /jail npm install left-pad` | false | **true** |
| `FOO=bar\`<newline>`baz npm install left-pad` | false | **true** |
| `sudo -u ro\`<newline>`ot npm install left-pad` | false | **true** |

The reviewer's suggested fix was per-wrapper signatures. That is not what this does — it removes the wrapper grammar entirely and leans on the over-denial direction instead, which is what an advisory hint should do.

The full denied list from the issue is asserted alongside them (`time npm install`, `FOO=bar npm install`, `{ nix run x; }`, `! nix run x`, `for i in 1; do nix run x; done`, `bash -euo pipefail -c 'uvx x'`, …) so the narrowing cannot silently trade a false positive for a missed install.

## Mutation tests

Every new assertion was proven to bite by breaking the fix:

| mutation | result |
| --- | --- |
| `dataAt` forced to `-1` (narrowing disabled) | 2 fail — both #2279 allow-tests |
| `"timeout"` added to `ARGUMENT_DATA_WORDS` | 1 fail — "an argument position this cannot prove still flags" |
| per-command split removed (whole line as one command) | 4 fail |
| `sh -c` body scan broken | 4 fail |
| `"-m"` re-added to `ARGUMENT_DATA_WORDS` | 1 fail — the `parallel -m` regression |

Restored exactly after each: 111 pass, 0 fail.

## Review round

`make review` on `de83b163` raised one blocker: bare short options were read independently of the command that owns them, so `parallel -m npm install lodash ::: left-pad` returned false. Fixed in `5a2db9e3` by dropping short options entirely rather than by making option handling command-aware — the smaller change, and it removes the collision class instead of enumerating it. `parallel -m npm install lodash ::: left-pad`, `parallel -m nix run ::: nixpkgs#hello` and `git commit -m nix shell support` are asserted as denied.

Closes #2279


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command detection to avoid flagging package-install text when it is used only as data or an argument.
  * Preserved detection for genuine install commands in pipelines and interpreter command bodies.
  * Improved handling of quoted commands and container entrypoint scenarios.

* **Tests**
  * Added coverage for command, argument, pipeline, quoting, and interpreter edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->