### PR TITLE
ci: assert a merged PR actually reached main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,6 +580,14 @@ jobs:
         # disables that alarm, so it is pinned by tests like the tag logic above.
         run: bun test scripts/__tests__/audit-release-images.test.ts
 
+      - name: Merge integrity decision table
+        # #2273 was based on another feature branch; squashing that base away
+        # left GitHub reporting it MERGED with its fix absent from main, while
+        # #2279 stayed open describing that exact bug. Every required check was
+        # green. Same reasoning as the gates above — the guard is pinned here so
+        # it cannot quietly stop catching the thing it exists for.
+        run: bun test scripts/__tests__/check-merge-integrity.test.ts
+
       - name: Raw-array SQL-param gate
         # packages/server's postgres.js client runs fetch_types:false, where a raw
         # JS array bound as a query param serializes to a malformed array literal

--- a/.github/workflows/merge-integrity.yml
+++ b/.github/workflows/merge-integrity.yml
@@ -1,0 +1,67 @@
+name: Merge Integrity
+
+# Proves that a PR GitHub reports as "merged" actually reached main.
+#
+# PR #2273 was opened against `feat/nix-deny-list-gap`. Squashing that base away
+# left GitHub reporting #2273 as MERGED, its branch deleted, and its fix absent
+# from main — while issue #2279 stayed open describing the very bug it claimed
+# to fix. Every required check was green; none of them asked whether the
+# commits landed.
+#
+# NOTE: there is deliberately no `branches:` filter below. That filter matches
+# the BASE branch, so it would skip exactly the mis-based PRs this catches.
+
+on:
+  pull_request:
+    types:
+      [opened, synchronize, reopened, edited, labeled, unlabeled, closed]
+  schedule:
+    - cron: "0 13 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # Prevention. Configure this job as a required check so it blocks the merge
+  # button before the damage.
+  base-branch-guard:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Base must be main (or carry an explicit stacked-pr label)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          node scripts/check-merge-integrity.mjs base \
+            --base "$BASE_REF" --labels-json "$PR_LABELS_JSON"
+
+  # Detection. Catches whatever the base gate did not — the per-PR run fires at
+  # merge; the daily sweep is the durable alarm if that run is ever missed.
+  merged-reachability:
+    if: |
+      github.event_name != 'pull_request'
+      || (github.event.action == 'closed' && github.event.pull_request.merged == true)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Ancestry needs real history on both sides; a shallow clone reports
+          # every merge commit as unreachable and the gate becomes noise.
+          fetch-depth: 0
+
+      - name: Assert the merge commit is on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PR_NUMBER:-}" ]; then
+            node scripts/check-merge-integrity.mjs reach --pr "$PR_NUMBER"
+          else
+            node scripts/check-merge-integrity.mjs reach --sweep --limit 100
+          fi

--- a/scripts/__tests__/check-merge-integrity.test.ts
+++ b/scripts/__tests__/check-merge-integrity.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { fileURLToPath } from "node:url";
+// @ts-expect-error — plain .mjs script, no type declarations by design.
+import {
+  CANONICAL_BASE,
+  checkBaseBranch,
+  classifyMergedPrs,
+  STACKED_PR_LABEL,
+} from "../check-merge-integrity.mjs";
+
+const SCRIPT = fileURLToPath(
+  new URL("../check-merge-integrity.mjs", import.meta.url)
+);
+
+function runReach(pr: {
+  number: number;
+  title: string;
+  baseRefName: string;
+  mergeCommit: { oid: string } | null;
+  state: string;
+}) {
+  const root = mkdtempSync(join(tmpdir(), "merge-integrity-test-"));
+  const bin = join(root, "bin");
+  mkdirSync(bin);
+
+  const git = join(bin, "git");
+  writeFileSync(
+    git,
+    `#!/usr/bin/env node
+const [command, flag, sha] = process.argv.slice(2);
+if (command === "fetch") process.exit(0);
+if (command === "merge-base" && flag === "--is-ancestor") {
+  process.exit(sha === "on-main" ? 0 : 1);
+}
+process.exit(2);
+`
+  );
+  chmodSync(git, 0o755);
+
+  const gh = join(bin, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env node
+process.stdout.write(process.env.FAKE_PR_JSON ?? "");
+`
+  );
+  chmodSync(gh, 0o755);
+
+  try {
+    return spawnSync(
+      process.execPath,
+      [SCRIPT, "reach", "--pr", `${pr.number}`],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_PR_JSON: JSON.stringify(pr),
+          PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+        },
+      }
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/**
+ * PR #2273 was opened against `feat/nix-deny-list-gap`. Squashing that base
+ * away left GitHub reporting #2273 as MERGED while its commits never reached
+ * `main` — issue #2279 stayed open describing the bug the PR claimed to fix,
+ * and every required check had been green. These pin both halves of the gate:
+ * refuse the non-main base up front, and catch an unreachable merge commit
+ * after the fact.
+ */
+describe("checkBaseBranch", () => {
+  it("accepts main", () => {
+    expect(checkBaseBranch(CANONICAL_BASE, [])).toMatchObject({ ok: true });
+  });
+
+  it("rejects a non-main base — the #2273 shape", () => {
+    const result = checkBaseBranch("feat/nix-deny-list-gap", []);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("feat/nix-deny-list-gap");
+    expect(result.reason).toContain("#2273");
+  });
+
+  it("lets an explicit stacked-pr label through", () => {
+    expect(checkBaseBranch("feat/parent", [STACKED_PR_LABEL])).toMatchObject({
+      ok: true,
+    });
+  });
+
+  it("ignores unrelated labels", () => {
+    expect(checkBaseBranch("feat/parent", ["bug", "security"]).ok).toBe(false);
+  });
+});
+
+describe("classifyMergedPrs", () => {
+  const onMain = {
+    number: 2285,
+    title: "on main",
+    baseRefName: "main",
+    mergeCommit: { oid: "aaa" },
+  };
+  const lost = {
+    number: 2273,
+    title: "merged but absent",
+    baseRefName: "feat/nix-deny-list-gap",
+    mergeCommit: { oid: "cb85c1ef" },
+  };
+
+  it("separates reachable from unreachable merge commits", () => {
+    const result = classifyMergedPrs(
+      [onMain, lost],
+      (sha: string) => sha === "aaa"
+    );
+    expect(result.ok.map((p: { number: number }) => p.number)).toEqual([2285]);
+    expect(result.lost.map((p: { number: number }) => p.number)).toEqual([
+      2273,
+    ]);
+    expect(result.unknown).toEqual([]);
+  });
+
+  it("passes nothing when every merge commit is reachable", () => {
+    const result = classifyMergedPrs([onMain], () => true);
+    expect(result.lost).toEqual([]);
+    expect(result.passed).toBe(true);
+  });
+
+  it("surfaces a merged PR with no merge commit rather than passing it", () => {
+    // Silence here is what let #2273 read as shipped; an absent SHA must not
+    // be treated as "nothing to check".
+    const result = classifyMergedPrs(
+      [{ number: 1, title: "no sha", baseRefName: "main", mergeCommit: null }],
+      () => true
+    );
+    expect(result.unknown).toHaveLength(1);
+    expect(result.ok).toEqual([]);
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe("CLI", () => {
+  it("exits 1 and annotates when the base is not main", () => {
+    const run = spawnSync(
+      process.execPath,
+      [SCRIPT, "base", "--base", "feat/nix-deny-list-gap"],
+      { encoding: "utf8" }
+    );
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("::error::");
+    expect(run.stderr).toContain(STACKED_PR_LABEL);
+  });
+
+  it("exits 0 for a main-based PR", () => {
+    const run = spawnSync(
+      process.execPath,
+      [SCRIPT, "base", "--base", "main"],
+      {
+        encoding: "utf8",
+      }
+    );
+    expect(run.status).toBe(0);
+  });
+
+  it("accepts the exact stacked-pr label from workflow JSON", () => {
+    const run = spawnSync(
+      process.execPath,
+      [
+        SCRIPT,
+        "base",
+        "--base",
+        "feat/parent",
+        "--labels-json",
+        '["stacked-pr"]',
+      ],
+      { encoding: "utf8" }
+    );
+    expect(run.status).toBe(0);
+  });
+
+  it("does not split a comma inside a label name", () => {
+    const run = spawnSync(
+      process.execPath,
+      [
+        SCRIPT,
+        "base",
+        "--base",
+        "feat/parent",
+        "--labels-json",
+        '["triage,stacked-pr"]',
+      ],
+      { encoding: "utf8" }
+    );
+    expect(run.status).toBe(1);
+  });
+
+  it("exits 2 on an unknown mode rather than passing silently", () => {
+    const run = spawnSync(process.execPath, [SCRIPT, "nonsense"], {
+      encoding: "utf8",
+    });
+    expect(run.status).toBe(2);
+  });
+
+  it("requires reach to name a PR or an explicit sweep", () => {
+    const run = spawnSync(process.execPath, [SCRIPT, "reach"], {
+      encoding: "utf8",
+    });
+    expect(run.status).toBe(2);
+    expect(run.stderr).toContain("exactly one of --pr or --sweep");
+  });
+});
+
+describe("reach CLI", () => {
+  const pr = {
+    number: 1,
+    title: "merged change",
+    baseRefName: "main",
+    mergeCommit: { oid: "on-main" },
+    state: "MERGED",
+  };
+
+  it("passes when the recorded merge commit is on main", () => {
+    const run = runReach(pr);
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("1 on main, 0 missing");
+  });
+
+  it("fails when the recorded merge commit is absent from main", () => {
+    const run = runReach({
+      ...pr,
+      baseRefName: "feat/parent",
+      mergeCommit: { oid: "missing" },
+    });
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("is not reachable from origin/main");
+  });
+
+  it("fails closed when GitHub records no merge commit", () => {
+    const run = runReach({ ...pr, mergeCommit: null });
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("cannot be verified");
+  });
+
+  it("rejects a PR that GitHub does not report as merged", () => {
+    const run = runReach({ ...pr, state: "OPEN" });
+    expect(run.status).toBe(2);
+    expect(run.stderr).toContain("is OPEN, not MERGED");
+  });
+});

--- a/scripts/check-merge-integrity.mjs
+++ b/scripts/check-merge-integrity.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Prove that a PR GitHub calls "merged" actually reached `main`.
+ *
+ * PR #2273 ("fix(agent-worker): match package installs only at a command
+ * position") was opened against `feat/nix-deny-list-gap` rather than `main`.
+ * When that base branch was squashed away, GitHub marked #2273 MERGED and
+ * deleted the branch — so the PR reads as shipped, the fix is absent from
+ * `main`, and issue #2279 stayed open describing the exact bug the PR claimed
+ * to fix. Every required check was green; none of them ask the one question
+ * that mattered.
+ *
+ * Two complementary gates, because prevention and detection fail differently:
+ *
+ *   base    a PR whose base is not `main` cannot be trusted to land on `main`.
+ *           Blocks pre-merge. Escape hatch: the `stacked-pr` label, which
+ *           forces a human to say "yes, I know this stacks".
+ *   reach   after a merge, assert the merge commit is an ancestor of
+ *           origin/main. Catches whatever the base gate did not.
+ *
+ * The classification is pure and takes an `isAncestor` predicate so the
+ * decision table is unit-testable without git or network.
+ *
+ * Usage:
+ *   check-merge-integrity.mjs base   --base <ref> [--labels-json '["name"]']
+ *   check-merge-integrity.mjs reach  --pr <number>
+ *   check-merge-integrity.mjs reach  --sweep [--limit 100]
+ */
+
+import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export const STACKED_PR_LABEL = "stacked-pr";
+
+export const CANONICAL_BASE = "main";
+
+/**
+ * Decide whether a PR's base branch is acceptable.
+ *
+ * @param {string} baseRef branch the PR merges INTO
+ * @param {string[]} labels labels currently on the PR
+ * @returns {{ok: boolean, reason: string}}
+ */
+export function checkBaseBranch(baseRef, labels = []) {
+  if (baseRef === CANONICAL_BASE) {
+    return { ok: true, reason: `base is ${CANONICAL_BASE}` };
+  }
+  if (labels.includes(STACKED_PR_LABEL)) {
+    return {
+      ok: true,
+      reason: `base is '${baseRef}' but '${STACKED_PR_LABEL}' label acknowledges the stack`,
+    };
+  }
+  return {
+    ok: false,
+    reason:
+      `base is '${baseRef}', not '${CANONICAL_BASE}'. When the base branch is ` +
+      `squashed away, GitHub marks this PR MERGED while its commits never ` +
+      `reach ${CANONICAL_BASE} (see #2273).`,
+  };
+}
+
+/**
+ * Classify merged PRs and decide whether every merge commit is provably
+ * reachable from main.
+ *
+ * @param {Array<{number:number,title:string,baseRefName:string,mergeCommit:{oid:string}|null}>} prs
+ * @param {(sha: string) => boolean} isAncestor
+ */
+export function classifyMergedPrs(prs, isAncestor) {
+  const lost = [];
+  const ok = [];
+  const unknown = [];
+  for (const pr of prs) {
+    const sha = pr.mergeCommit?.oid;
+    if (!sha) {
+      // A merged PR with no merge commit predates the data or was merged by
+      // a path the API does not record. Surface it rather than pass it.
+      unknown.push(pr);
+      continue;
+    }
+    (isAncestor(sha) ? ok : lost).push({ ...pr, sha });
+  }
+  return {
+    lost,
+    ok,
+    unknown,
+    passed: lost.length === 0 && unknown.length === 0,
+  };
+}
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function gh(args) {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+}
+
+/** git merge-base --is-ancestor exits 1 for "not an ancestor" — not an error. */
+function makeIsAncestor(ref) {
+  return (sha) => {
+    try {
+      execFileSync("git", ["merge-base", "--is-ancestor", sha, ref], {
+        stdio: "ignore",
+      });
+      return true;
+    } catch (error) {
+      if (
+        error &&
+        typeof error === "object" &&
+        "status" in error &&
+        error.status === 1
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  };
+}
+
+function arg(argv, name) {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : argv[i + 1];
+}
+
+function runBase(argv) {
+  const baseRef = arg(argv, "base");
+  if (!baseRef) {
+    console.error("::error::--base <ref> is required");
+    process.exit(2);
+  }
+  let labels;
+  try {
+    labels = JSON.parse(arg(argv, "labels-json") ?? "[]");
+  } catch {
+    console.error("::error::--labels-json must be a JSON array of strings");
+    process.exit(2);
+  }
+  if (
+    !Array.isArray(labels) ||
+    labels.some((label) => typeof label !== "string")
+  ) {
+    console.error("::error::--labels-json must be a JSON array of strings");
+    process.exit(2);
+  }
+
+  const { ok, reason } = checkBaseBranch(baseRef, labels);
+  if (ok) {
+    console.log(`Base branch OK — ${reason}`);
+    return;
+  }
+  console.error(`::error::PR ${reason}`);
+  console.error("");
+  console.error("Fix: retarget this PR at main.");
+  console.error("  git rebase --onto origin/main <old-base> <this-branch>");
+  console.error(`  gh pr edit <n> --base ${CANONICAL_BASE}`);
+  console.error("");
+  console.error(
+    `If the stack is deliberate, add the '${STACKED_PR_LABEL}' label and ` +
+      "confirm the parent lands first."
+  );
+  process.exit(1);
+}
+
+function runReach(argv) {
+  const single = arg(argv, "pr");
+  const sweep = argv.includes("--sweep");
+  if (Boolean(single) === sweep) {
+    console.error("::error::reach requires exactly one of --pr or --sweep");
+    process.exit(2);
+  }
+
+  // origin/main goes stale in a shallow CI checkout; the fetch is load-bearing.
+  git(["fetch", "--quiet", "origin", CANONICAL_BASE]);
+  const isAncestor = makeIsAncestor(`origin/${CANONICAL_BASE}`);
+
+  const limit = arg(argv, "limit") ?? "100";
+  let prs;
+  if (single) {
+    const pr = JSON.parse(
+      gh([
+        "pr",
+        "view",
+        single,
+        "--json",
+        "number,title,baseRefName,mergeCommit,state",
+      ])
+    );
+    if (pr.state !== "MERGED") {
+      console.error(`::error::#${single} is ${pr.state}, not MERGED`);
+      process.exit(2);
+    }
+    prs = [pr];
+  } else {
+    prs = JSON.parse(
+      gh([
+        "pr",
+        "list",
+        "--state",
+        "merged",
+        "--limit",
+        limit,
+        "--json",
+        "number,title,baseRefName,mergeCommit",
+      ])
+    );
+  }
+
+  const { lost, ok, unknown, passed } = classifyMergedPrs(prs, isAncestor);
+  console.log(
+    `Checked ${prs.length} merged PR(s): ${ok.length} on ${CANONICAL_BASE}, ` +
+      `${lost.length} missing, ${unknown.length} without a merge commit.`
+  );
+
+  for (const pr of unknown) {
+    console.error(
+      `::error::#${pr.number} is merged but records no merge commit, so its ` +
+        `presence on ${CANONICAL_BASE} cannot be verified.`
+    );
+  }
+  if (passed) {
+    return;
+  }
+  for (const pr of lost) {
+    console.error(
+      `::error::#${pr.number} reads MERGED but ${pr.sha} is not reachable from ` +
+        `origin/${CANONICAL_BASE} (base was '${pr.baseRefName}') — ${pr.title}`
+    );
+  }
+  console.error("");
+  console.error(
+    "These PRs are not proven present on main. Investigate missing merge " +
+      "commits and re-open absent changes against main."
+  );
+  process.exit(1);
+}
+
+function main() {
+  const [mode, ...argv] = process.argv.slice(2);
+  if (mode === "base") return runBase(argv);
+  if (mode === "reach") return runReach(argv);
+  console.error("Usage: check-merge-integrity.mjs <base|reach> [options]");
+  process.exit(2);
+}
+
+if (
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}


### PR DESCRIPTION
## Summary

- PR #2273 was opened against `feat/nix-deny-list-gap`, not `main`. Squashing that base away left GitHub reporting it **MERGED** with its branch deleted, while its fix never reached `main` — and issue #2279 is still open describing the exact bug it claimed to fix. All seven required checks were green; none asked whether the commits landed.
- Adds two gates: `base-branch-guard` (prevention, pre-merge) and `merged-reachability` (detection, at merge + a daily sweep).
- Decision table lives in a script rather than workflow YAML so it is testable without cutting a real merge — same reasoning as `derive-image-tags.mjs` and `audit-release-images.mjs`.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test scripts/__tests__/check-merge-integrity.test.ts` — 17 pass, 0 fail
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval — n/a

### red → green against the real historical failure

The gate is pointed at the actual PR that produced this bug class, and at a control that merged normally.

```
$ node scripts/check-merge-integrity.mjs reach --pr 2273
Checked 1 merged PR(s): 0 on main, 1 missing, 0 without a merge commit.
::error::#2273 reads MERGED but cb85c1efebb6433848517bb29eeb1f444ff31f0a is not
reachable from origin/main (base was 'feat/nix-deny-list-gap') —
fix(agent-worker): match package installs only at a command position
exit=1
```

```
$ node scripts/check-merge-integrity.mjs reach --pr 2285
Checked 1 merged PR(s): 1 on main, 0 missing, 0 without a merge commit.
exit=0
```

Base gate, invoked exactly as the workflow does:

```
$ node check-merge-integrity.mjs base --base main            --labels-json '[]'
Base branch OK — base is main                                            exit=0

$ node check-merge-integrity.mjs base --base feat/x --labels-json '["bug","stacked-pr"]'
Base branch OK — 'stacked-pr' label acknowledges the stack                exit=0

$ node check-merge-integrity.mjs base --base feat/x --labels-json '["triage,stacked-pr"]'
::error::PR base is 'feat/x', not 'main'...                              exit=1
```

That last case is a bug the `make review-fix` pass caught in the first revision: labels were split on `,`, so a label whose *name* contains a comma would have satisfied `includes("stacked-pr")` and bypassed the gate. Now parsed as JSON via `toJSON(...)`.

### mutation testing

A guard that stops catching its own violation is worse than no guard, because it reads as proof. Each mutation was applied to the final code and reverted:

| mutation | result |
|---|---|
| base gate always passes (`if (true)`) | **4 fail** |
| `unknown` no longer fails closed | **2 fail** |
| label check ignores the label list (`if (false)`) | **2 fail** |
| *(restored)* | 17 pass, 0 fail |

## Notes

Fails closed throughout: a merged PR with no recorded merge commit is an error rather than a warning, and a non-1 exit from `git merge-base` re-throws instead of being read as "not reachable".

There is deliberately **no `branches:` filter** on the workflow — that filter matches the *base* branch, so it would skip exactly the mis-based PRs this exists to catch.

Requires the `stacked-pr` label (created) for the escape hatch. To make the prevention half binding, `base-branch-guard` needs adding to the required status checks — configuration, not code, so it is not in this diff.

Follow-up worth a separate issue: `make build-packages` rewrites `packages/plugin-api/package.json` and `packages/plugin-host/package.json` from `14.6.0` to `1.0.0-alpha.1+build.7`. Any `git add -A` after a build commits a version downgrade of two published packages.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->