### PR TITLE
fix(ci): publish arm64 alongside amd64 on releases

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -53,10 +53,19 @@ env:
   # memory), so main-branch pushes build amd64 only. This dropped the
   # build-app step from ~25min to ~8min AND fixed the disk-full failure
   # mode (~14GB GHA runner couldn't hold both arch Playwright/Chrome
-  # downloads + image layers + buildx cache). The workflow_dispatch
-  # `platforms` input lets you rebuild multi-arch on demand if a dev
-  # machine needs the arm64 image, without slowing every prod deploy.
-  BUILD_PLATFORMS: ${{ inputs.platforms || 'linux/amd64' }}
+  # downloads + image layers + buildx cache).
+  #
+  # Releases are the exception: the tagged images are what self-hosters
+  # pull, and a chunk of them are on arm64 (Apple Silicon, Ampere, Graviton).
+  # Until this, `inputs.platforms` was only populated on workflow_dispatch,
+  # so every published release fell through to amd64-only and ARM operators
+  # silently ran the whole stack — Chromium included — under emulation.
+  # Releases are rare and not latency-sensitive, so they absorb the longer
+  # multi-arch build; main pushes stay fast.
+  BUILD_PLATFORMS: >-
+    ${{ inputs.platforms
+        || (github.event_name == 'release' && 'linux/amd64,linux/arm64')
+        || 'linux/amd64' }}
 
 jobs:
   generate-tag:


### PR DESCRIPTION
## The gap

`inputs.platforms` is only populated on `workflow_dispatch`, so the `release` trigger always fell through to the `linux/amd64` default. Confirmed against the registry with `crane`:

```
latest     ['linux/amd64']
14.6.0     ['linux/amd64']
14.5.0     ['linux/amd64']
```

Tagged images are exactly what self-hosters pull, and a meaningful share of them are on arm64 (Apple Silicon, Ampere, Graviton). Those operators have been running the entire stack under emulation, Chromium and Playwright included, with nothing telling them why it's slow.

Surfaced by a self-hoster in #2151 while debugging an unrelated Docker issue.

## The change

`BUILD_PLATFORMS` now resolves per trigger:

| Trigger | Platforms |
|---|---|
| push to main | `linux/amd64` |
| release published | `linux/amd64,linux/arm64` |
| dispatch (default) | `linux/amd64` |
| dispatch (override) | whatever is passed |

Main-branch pushes are unchanged, deliberately. The existing amd64-only default is there for good reasons documented in the env block: prod is x86-only Hetzner, dual-arch took the app build from ~8min back to ~25min, and it filled the runner disk. Releases are rare and not latency-sensitive, so they can absorb it.

Affects the app, worker and embeddings images. The local test build at line 118 stays pinned to `linux/amd64` since it never pushes.

## Verification

- YAML parses; `BUILD_PLATFORMS` resolves to a single expression string
- All four trigger permutations simulated against GitHub's `&&`/`||` semantics (falsy-left returns, empty string falsy) and produce the table above
- `tsc --noEmit` and Biome clean via pre-commit

Not verified: an actual multi-arch release build. The first published release after this merges is the real test, and the ghcr audit from #2256 should confirm the manifest. Worth watching that run for the disk-full mode the original comment describes, since it's now on the release path rather than never.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->