### PR TITLE
fix(server): close MCP recall, Behavior exposure, and connector-health gaps

### DIFF
--- a/packages/connectors/src/__tests__/google_calendar.test.ts
+++ b/packages/connectors/src/__tests__/google_calendar.test.ts
@@ -104,6 +104,129 @@ describe('GoogleCalendarConnector full sync', () => {
   });
 });
 
+/**
+ * Drives an incremental-then-full sync where the first (incremental) request
+ * fails with `status`/`body`, and every later request is a healthy full-sync
+ * page. Returns the recorded query params so the test can assert the poisoned
+ * token was dropped rather than replayed.
+ */
+function rejectingTokenHttp(status: number, body: string) {
+  const calls: Array<Record<string, string | null>> = [];
+  let call = 0;
+  return {
+    calls,
+    client: {
+      raw: async (url: string) => {
+        const u = new URL(url);
+        calls.push({
+          syncToken: u.searchParams.get('syncToken'),
+          pageToken: u.searchParams.get('pageToken'),
+          timeMin: u.searchParams.get('timeMin'),
+        });
+        call++;
+        if (call === 1) {
+          return {
+            ok: false,
+            status,
+            json: async () => JSON.parse(body),
+            text: async () => body,
+          } as unknown as Response;
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            kind: 'calendar#events',
+            items: [calEvent('full-1', '2026-02-01T10:00:00Z')],
+            nextSyncToken: 'FRESH',
+          }),
+          text: async () => '',
+        } as unknown as Response;
+      },
+    },
+  };
+}
+
+/** The exact body prod returns for a syncToken minted under a stale grant. */
+const SCOPE_REJECTION_BODY = JSON.stringify({
+  error: {
+    code: 403,
+    message: 'Request had insufficient authentication scopes.',
+    status: 'PERMISSION_DENIED',
+    errors: [{ reason: 'insufficientPermissions' }],
+    details: [{ reason: 'ACCESS_TOKEN_SCOPE_INSUFFICIENT' }],
+  },
+});
+
+describe('GoogleCalendarConnector poisoned sync token recovery', () => {
+  test('a 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT on the incremental request drops the token and full-syncs', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client, calls } = rejectingTokenHttp(403, SCOPE_REJECTION_BODY);
+    connector.client = () => client;
+
+    const result = await connector.sync({
+      config: { calendar_id: 'primary', max_results: 100 },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { sync_token: 'POISONED' },
+    });
+
+    // The poisoned token was tried once...
+    expect(calls[0]?.syncToken).toBe('POISONED');
+    // ...then abandoned: the next request is a full sync (windowed by timeMin,
+    // carrying no syncToken at all).
+    expect(calls[1]?.syncToken).toBeNull();
+    expect(calls[1]?.timeMin).toBeTruthy();
+
+    // Recovery produced real events and a fresh checkpoint that no longer
+    // carries the poisoned token.
+    expect(result.events).toHaveLength(1);
+    expect(result.checkpoint.sync_token).toBe('FRESH');
+  });
+
+  test('a genuinely missing scope still fails loudly instead of looping full syncs', async () => {
+    const connector = new GoogleCalendarConnector();
+    // Both the incremental AND the full-sync retry are rejected — the signature
+    // of a scope the user never granted. Recovery must not mask this.
+    connector.client = () => ({
+      raw: async () =>
+        ({
+          ok: false,
+          status: 403,
+          json: async () => JSON.parse(SCOPE_REJECTION_BODY),
+          text: async () => SCOPE_REJECTION_BODY,
+        }) as unknown as Response,
+    });
+
+    await expect(
+      connector.sync({
+        config: { calendar_id: 'primary', max_results: 100 },
+        credentials: { accessToken: 'tok' },
+        checkpoint: { sync_token: 'POISONED' },
+      })
+    ).rejects.toThrow(/insufficient authentication scopes/);
+  });
+
+  test('an unrelated 403 is not treated as a poisoned token', async () => {
+    const connector = new GoogleCalendarConnector();
+    const forbidden = JSON.stringify({
+      error: { code: 403, message: 'Daily Limit Exceeded', status: 'PERMISSION_DENIED' },
+    });
+    const { client, calls } = rejectingTokenHttp(403, forbidden);
+    connector.client = () => client;
+
+    await expect(
+      connector.sync({
+        config: { calendar_id: 'primary', max_results: 100 },
+        credentials: { accessToken: 'tok' },
+        checkpoint: { sync_token: 'GOOD' },
+      })
+    ).rejects.toThrow(/Daily Limit Exceeded/);
+
+    // Only the incremental attempt ran — no full-sync fallback was triggered.
+    expect(calls).toHaveLength(1);
+  });
+});
+
 describe('GoogleCalendarConnector incremental sync', () => {
   test('an expired syncToken (410) falls through to a full sync', async () => {
     const connector = new GoogleCalendarConnector();

--- a/packages/connectors/src/__tests__/youtube.test.ts
+++ b/packages/connectors/src/__tests__/youtube.test.ts
@@ -364,3 +364,292 @@ describe('YouTubeConnector actions', () => {
     expect(result.error).toMatch(/requires OAuth/i);
   });
 });
+
+describe('YouTubeConnector stale page-token recovery', () => {
+  /**
+   * Serves search.list. The first request is rejected with `rejection`; every
+   * later request succeeds. Records each request's pageToken so the test can
+   * assert the dead cursor was dropped rather than replayed forever.
+   */
+  function searchHttp(rejection: { status: number; body: string }) {
+    const pageTokens: Array<string | null> = [];
+    let call = 0;
+    return {
+      pageTokens,
+      http: {
+        raw: async (url: string) => {
+          const u = new URL(url);
+          if (u.pathname.endsWith('/search')) {
+            pageTokens.push(u.searchParams.get('pageToken'));
+            call++;
+            if (call === 1) {
+              return {
+                ok: false,
+                status: rejection.status,
+                text: async () => rejection.body,
+                json: async () => JSON.parse(rejection.body),
+              } as unknown as Response;
+            }
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                items: [
+                  {
+                    id: { videoId: 'vid1' },
+                    snippet: { publishedAt: '2026-07-01T10:00:00Z', title: 'Recovered' },
+                  },
+                ],
+              }),
+              text: async () => '',
+            } as unknown as Response;
+          }
+          // videos.list — details for the recovered video.
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              items: [
+                {
+                  id: 'vid1',
+                  snippet: {
+                    publishedAt: '2026-07-01T10:00:00Z',
+                    title: 'Recovered',
+                    channelTitle: 'Chan',
+                    description: '',
+                  },
+                  statistics: { viewCount: '1', likeCount: '0', commentCount: '0' },
+                  contentDetails: { duration: 'PT1M' },
+                },
+              ],
+            }),
+            text: async () => '',
+          } as unknown as Response;
+        },
+      },
+    };
+  }
+
+  const INVALID_PAGE_TOKEN = JSON.stringify({
+    error: {
+      code: 400,
+      message: "Request contains an invalid argument.",
+      errors: [{ reason: 'invalidPageToken' }],
+    },
+  });
+
+  test('a rejected persisted pageToken is dropped and the search restarts from page one', async () => {
+    const connector = new YouTubeConnector();
+    const { http, pageTokens } = searchHttp({ status: 400, body: INVALID_PAGE_TOKEN });
+    connector.http = http;
+
+    const result = await connector.syncSearchVideos(
+      {
+        config: {
+          search_query: 'lobu',
+          max_results: 5,
+          include_transcripts: false,
+          include_comments: false,
+        },
+        credentials: { accessToken: 'tok' },
+        checkpoint: { next_page_token: 'DEAD_TOKEN' },
+      },
+      { accessToken: 'tok' }
+    );
+
+    // Dead cursor tried once, then abandoned for a first-page request.
+    expect(pageTokens[0]).toBe('DEAD_TOKEN');
+    expect(pageTokens[1]).toBeNull();
+    // Recovery actually produced events instead of throwing.
+    expect(result.events.length).toBeGreaterThan(0);
+  });
+
+  test('a quota 403 is not treated as a stale cursor and still throws', async () => {
+    const connector = new YouTubeConnector();
+    const quota = JSON.stringify({
+      error: { code: 403, errors: [{ reason: 'quotaExceeded' }] },
+    });
+    const { http, pageTokens } = searchHttp({ status: 403, body: quota });
+    connector.http = http;
+
+    await expect(
+      connector.syncSearchVideos(
+        {
+          config: { search_query: 'lobu', max_results: 5 },
+          credentials: { accessToken: 'tok' },
+          checkpoint: { next_page_token: 'GOOD' },
+        },
+        { accessToken: 'tok' }
+      )
+    ).rejects.toThrow(/quotaExceeded/);
+
+    // No blind restart was attempted.
+    expect(pageTokens).toHaveLength(1);
+  });
+
+  /**
+   * Serves search.list for a feed whose cursor dies *mid*-pagination: page one
+   * always succeeds and always advertises `DEAD` as its next page, but `DEAD`
+   * is always rejected. This is the shape that turns a naive "restart from page
+   * one" recovery into an infinite loop — the restart re-fetches page one,
+   * which hands the dead cursor straight back to the paginator.
+   */
+  function midPaginationHttp(rejection: { status: number; body: string }) {
+    const pageTokens: Array<string | null> = [];
+    return {
+      pageTokens,
+      http: {
+        raw: async (url: string) => {
+          const u = new URL(url);
+          if (u.pathname.endsWith('/search')) {
+            const token = u.searchParams.get('pageToken');
+            pageTokens.push(token);
+            // Runaway guard: fail loudly instead of hanging until the timeout.
+            if (pageTokens.length > 20) {
+              throw new Error(`runaway pagination: ${JSON.stringify(pageTokens)}`);
+            }
+            if (token === 'DEAD') {
+              return {
+                ok: false,
+                status: rejection.status,
+                text: async () => rejection.body,
+                json: async () => JSON.parse(rejection.body),
+              } as unknown as Response;
+            }
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                nextPageToken: 'DEAD',
+                items: [
+                  {
+                    id: { videoId: 'vid1' },
+                    snippet: { publishedAt: '2026-07-01T10:00:00Z', title: 'Page one' },
+                  },
+                ],
+              }),
+              text: async () => '',
+            } as unknown as Response;
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              items: [
+                {
+                  id: 'vid1',
+                  snippet: {
+                    publishedAt: '2026-07-01T10:00:00Z',
+                    title: 'Page one',
+                    channelTitle: 'Chan',
+                    description: '',
+                  },
+                  statistics: { viewCount: '1', likeCount: '0', commentCount: '0' },
+                  contentDetails: { duration: 'PT1M' },
+                },
+              ],
+            }),
+            text: async () => '',
+          } as unknown as Response;
+        },
+      },
+    };
+  }
+
+  test('a cursor rejected mid-pagination terminates instead of looping back into it', async () => {
+    const connector = new YouTubeConnector();
+    const { http, pageTokens } = midPaginationHttp({ status: 400, body: INVALID_PAGE_TOKEN });
+    connector.http = http;
+
+    const result = await connector.syncSearchVideos(
+      {
+        config: {
+          search_query: 'lobu',
+          max_results: 50,
+          include_transcripts: false,
+          include_comments: false,
+        },
+        credentials: { accessToken: 'tok' },
+        checkpoint: {},
+      },
+      { accessToken: 'tok' }
+    );
+
+    // page one (null) -> DEAD rejected -> restart at page one -> page one hands
+    // back DEAD again, which is already known-dead, so the sync stops.
+    expect(pageTokens).toEqual([null, 'DEAD', null]);
+    expect(result.events.length).toBeGreaterThan(0);
+    // The dead cursor must NOT be persisted, or the next run starts wedged.
+    expect(result.checkpoint.next_page_token).toBeUndefined();
+  });
+
+  test('subscriptions pagination is bounded even when the API never stops paging', async () => {
+    const connector = new YouTubeConnector();
+    // Drop the politeness delay: 200 pages x 200ms would blow the test timeout.
+    connector.RATE_LIMIT_MS = 0;
+    let calls = 0;
+    connector.http = {
+      raw: async (url: string) => {
+        const u = new URL(url);
+        calls++;
+        // Runaway guard well above the 200-page ceiling: without maxPages this
+        // endpoint would page forever, since it always advertises a new cursor
+        // and the caller's item budget (5000) is never reached.
+        if (calls > 400) throw new Error(`runaway pagination: ${calls} requests`);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            nextPageToken: `page${calls}`,
+            items: [
+              {
+                id: `sub${calls}`,
+                snippet: {
+                  publishedAt: '2026-01-02T00:00:00Z',
+                  title: `Channel ${calls}`,
+                  resourceId: { kind: 'youtube#channel', channelId: `UC${calls}` },
+                },
+              },
+            ],
+          }),
+          text: async () => '',
+        } as unknown as Response;
+      },
+    };
+
+    const result = await connector.sync({
+      feedKey: 'subscriptions',
+      credentials: { accessToken: 'tok' },
+      config: { max_results: 5000 },
+      checkpoint: {},
+    });
+
+    // Stopped by the page ceiling, not by the item budget.
+    expect(calls).toBe(200);
+    expect(result.events).toHaveLength(200);
+  });
+
+  test('the recovered run persists a checkpoint free of the rejected cursor', async () => {
+    const connector = new YouTubeConnector();
+    const { http } = searchHttp({ status: 400, body: INVALID_PAGE_TOKEN });
+    connector.http = http;
+
+    const result = await connector.syncSearchVideos(
+      {
+        config: {
+          search_query: 'lobu',
+          max_results: 5,
+          include_transcripts: false,
+          include_comments: false,
+        },
+        credentials: { accessToken: 'tok' },
+        checkpoint: { next_page_token: 'DEAD_TOKEN' },
+      },
+      { accessToken: 'tok' }
+    );
+
+    // The restart page carried no nextPageToken, so the stored cursor clears
+    // rather than persisting the rejected one for the next run to choke on.
+    expect(result.checkpoint.next_page_token).toBeUndefined();
+  });
+});

--- a/packages/connectors/src/__tests__/youtube.test.ts
+++ b/packages/connectors/src/__tests__/youtube.test.ts
@@ -589,8 +589,7 @@ describe('YouTubeConnector stale page-token recovery', () => {
     connector.RATE_LIMIT_MS = 0;
     let calls = 0;
     connector.http = {
-      raw: async (url: string) => {
-        const u = new URL(url);
+      raw: async () => {
         calls++;
         // Runaway guard well above the 200-page ceiling: without maxPages this
         // endpoint would page forever, since it always advertises a new cursor

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -59,6 +59,36 @@ interface CalendarCheckpoint {
   last_sync_at?: string;
 }
 
+/**
+ * Does this events.list failure mean "the syncToken itself is no longer
+ * usable" (as opposed to "your credentials are wrong")?
+ *
+ * Two shapes qualify:
+ *  - 410 GONE — Google's documented signal that an incremental sync token has
+ *    expired or been invalidated.
+ *  - 403 with `insufficientPermissions` / `ACCESS_TOKEN_SCOPE_INSUFFICIENT` —
+ *    a token minted under a *previous* grant. Google validates the syncToken
+ *    against the grant that produced it, so re-authorizing the connection with
+ *    the same scopes leaves the old token permanently rejected even though the
+ *    live credentials are fine.
+ *
+ * In both cases the recovery is identical and is what Google documents: drop
+ * the token and perform a full resync.
+ *
+ * A genuinely-missing scope produces the *same* 403 body, so this predicate
+ * cannot distinguish them on its own — the caller resolves the ambiguity by
+ * retrying exactly once without the token. If the scope really is missing the
+ * full sync fails the same way and that error propagates, which is why the
+ * retry is bounded to a single attempt and never becomes a resync loop.
+ */
+function isSyncTokenRejection(status: number, body: string): boolean {
+  if (status === 410) return true;
+  if (status !== 403) return false;
+  return (
+    body.includes('ACCESS_TOKEN_SCOPE_INSUFFICIENT') || body.includes('insufficientPermissions')
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Connector
 // ---------------------------------------------------------------------------
@@ -251,7 +281,11 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       if (result) {
         return this.buildResult(result.events, result.nextSyncToken, result.events.length);
       }
-      // syncToken invalid (410) -- fall through to full sync
+      // The stored token was rejected (see isSyncTokenRejection). Fall through
+      // to a full sync exactly once — no retry loop. The full sync below either
+      // succeeds and overwrites the checkpoint with a token minted under the
+      // current grant, or throws (the scope is genuinely missing) and the error
+      // reaches the run record instead of being swallowed.
     }
 
     // Full sync
@@ -365,9 +399,10 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
   ): Promise<{ events: EventEnvelope[]; nextSyncToken?: string } | null> {
     const events: EventEnvelope[] = [];
     let nextSyncToken: string | undefined;
-    // 410 Gone means the syncToken is expired — abort and let the caller fall
-    // through to a full sync. Signalled out of the generator via this flag.
-    let syncTokenExpired = false;
+    // The stored syncToken was rejected (410 expired, or 403 because it was
+    // minted under a superseded grant) — abort and let the caller drop it and
+    // fall through to a full sync. Signalled out of the generator via this flag.
+    let syncTokenRejected = false;
 
     // Same hard ceiling as the full-sync path — defensive only.
     const MAX_PAGES = 200;
@@ -387,15 +422,13 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
         const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
         const response = await http.raw(url);
 
-        if (response.status === 410) {
-          syncTokenExpired = true;
-          return { items: [], nextCursor: undefined };
-        }
-
         if (!response.ok) {
-          throw new Error(
-            `Calendar events.list error (${response.status}): ${await response.text()}`
-          );
+          const body = await response.text();
+          if (isSyncTokenRejection(response.status, body)) {
+            syncTokenRejected = true;
+            return { items: [], nextCursor: undefined };
+          }
+          throw new Error(`Calendar events.list error (${response.status}): ${body}`);
         }
 
         const data = (await response.json()) as CalendarEventListResponse;
@@ -413,7 +446,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       }
     }
 
-    if (syncTokenExpired) return null;
+    if (syncTokenRejected) return null;
 
     return { events, nextSyncToken };
   }
@@ -637,6 +670,10 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     // Sort events by occurred_at descending
     events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
 
+    // Built fresh rather than spread over the previous checkpoint: the whole
+    // object replaces the stored one, so a run that recovered from a rejected
+    // token cannot leave that token behind. When the sync produced no new token
+    // the key is absent, and the next run correctly starts from a full sync.
     const newCheckpoint: CalendarCheckpoint = {
       ...(syncToken ? { sync_token: syncToken } : {}),
       last_sync_at: new Date().toISOString(),
@@ -653,7 +690,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
   // Auth-aware client (Bearer + retry/backoff on transient 429/5xx). Built per
   // token so each sync/action uses its own credentials. `.raw()` preserves the
-  // existing `response.ok`/status-code branching (e.g. 410 sync-token expiry).
+  // existing `response.ok`/status-code branching (e.g. sync-token rejection).
   private client(token: string): HttpClient {
     return createHttpClient({ token, errorPrefix: 'Calendar API' });
   }

--- a/packages/connectors/src/youtube.ts
+++ b/packages/connectors/src/youtube.ts
@@ -229,6 +229,26 @@ interface YouTubeCheckpoint {
   next_page_token?: string;
 }
 
+/**
+ * Does this search.list failure mean the persisted `pageToken` is no longer
+ * usable? YouTube rejects a stale/foreign page token with 400
+ * `invalidPageToken`; 410 GONE is the generic Google "this cursor is dead"
+ * signal. Either way the token must be dropped and the sync restarted from the
+ * first page, because the run-lifecycle preserves the checkpoint on failure —
+ * so a rejected token that keeps throwing wedges the feed permanently.
+ *
+ * Deliberately narrow: a quota/auth 403 is NOT a token rejection and must keep
+ * throwing so the real problem surfaces.
+ *
+ * Termination is guaranteed by the caller, not by this predicate: every token
+ * it rejects is recorded and never requested again, so each distinct cursor can
+ * trigger at most one restart and pagination cannot re-enter a dead one.
+ */
+function isPageTokenRejection(status: number, body: string): boolean {
+  if (status === 410) return true;
+  return status === 400 && body.includes('invalidPageToken');
+}
+
 // ---------------------------------------------------------------------------
 // Connector
 // ---------------------------------------------------------------------------
@@ -573,6 +593,10 @@ export default class YouTubeConnector extends ConnectorRuntime {
   private readonly BASE_URL = 'https://www.googleapis.com/youtube/v3';
   private readonly RATE_LIMIT_MS = 200;
   private readonly COMMENT_PAGE_LIMIT = 3;
+  // Hard ceiling on cursor pagination, matching the Calendar connector's
+  // MAX_PAGES. Defensive only: every loop below also stops on its own item
+  // budget. This is the backstop for an API that keeps handing back a cursor.
+  private readonly MAX_PAGES = 200;
   private readonly http = createHttpClient({ errorPrefix: 'YouTube API' });
 
   // -------------------------------------------------------------------------
@@ -731,7 +755,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
         const data = (await response.json()) as YouTubePlaylistResponse;
         return { items: data.items ?? [], nextCursor: data.nextPageToken };
       },
-      { delayMs: this.RATE_LIMIT_MS }
+      { maxPages: this.MAX_PAGES, delayMs: this.RATE_LIMIT_MS }
     );
     for await (const batch of pages) {
       for (const playlist of batch) {
@@ -816,7 +840,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
         const data = (await response.json()) as YouTubePlaylistResponse;
         return { items: data.items ?? [], nextCursor: data.nextPageToken };
       },
-      { delayMs: this.RATE_LIMIT_MS }
+      { maxPages: this.MAX_PAGES, delayMs: this.RATE_LIMIT_MS }
     );
 
     for await (const playlists of playlistPages) {
@@ -887,7 +911,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
         const data = (await response.json()) as YouTubeSubscriptionResponse;
         return { items: data.items ?? [], nextCursor: data.nextPageToken };
       },
-      { delayMs: this.RATE_LIMIT_MS }
+      { maxPages: this.MAX_PAGES, delayMs: this.RATE_LIMIT_MS }
     );
 
     for await (const subscriptions of pages) {
@@ -947,24 +971,57 @@ export default class YouTubeConnector extends ConnectorRuntime {
 
     let pageToken: string | undefined = checkpoint.next_page_token;
     let totalCollected = 0;
+    // Cursors YouTube rejected during this run. Remembering the token itself —
+    // not merely "a recovery happened" — is what makes the restart safe: page
+    // one legitimately re-advertises the same nextPageToken that just died, so
+    // a bare flag would let the paginator walk right back into the dead cursor.
+    const rejectedPageTokens = new Set<string>();
+
+    // One page fetch, including the single restart-from-page-one recovery.
+    const fetchSearchPage = async (cursor: string | null): Promise<YouTubeSearchResponse> => {
+      const pageSize = Math.min(50, maxResults - totalCollected);
+      const response = await this.apiGet(
+        this.buildSearchUrl(searchQuery, pageSize, cursor ?? undefined),
+        auth
+      );
+      if (response.ok) return (await response.json()) as YouTubeSearchResponse;
+
+      // Read the body exactly once — it drives both the rejection test and the
+      // error message, and a Response body cannot be consumed twice.
+      const body = await response.text();
+      if (!cursor || !isPageTokenRejection(response.status, body)) {
+        throw new Error(`YouTube Search API error (${response.status}): ${body}`);
+      }
+
+      // Stale cursor: remember it so pagination can never follow it again, then
+      // restart from page one so the feed recovers instead of failing forever.
+      rejectedPageTokens.add(cursor);
+      const restart = await this.apiGet(this.buildSearchUrl(searchQuery, pageSize), auth);
+      if (!restart.ok) {
+        throw new Error(`YouTube Search API error (${restart.status}): ${await restart.text()}`);
+      }
+      return (await restart.json()) as YouTubeSearchResponse;
+    };
 
     const searchPages = paginateByCursor<YouTubeSearchItem, string>(
       async (cursor) => {
-        const pageSize = Math.min(50, maxResults - totalCollected);
-        const searchUrl = this.buildSearchUrl(searchQuery, pageSize, cursor ?? undefined);
-
-        const searchResponse = await this.apiGet(searchUrl, auth);
-        if (!searchResponse.ok) {
-          throw new Error(
-            `YouTube Search API error (${searchResponse.status}): ${await searchResponse.text()}`
-          );
-        }
-
-        const searchData = (await searchResponse.json()) as YouTubeSearchResponse;
-        pageToken = searchData.nextPageToken;
-        return { items: searchData.items, nextCursor: searchData.nextPageToken };
+        const searchData = await fetchSearchPage(cursor);
+        // Stop rather than follow a cursor this run has already seen rejected.
+        // Page one legitimately re-advertises the token that just died, so
+        // without this the restart would walk straight back into it. Dropping
+        // it here also keeps it out of the persisted checkpoint below.
+        const next =
+          searchData.nextPageToken && rejectedPageTokens.has(searchData.nextPageToken)
+            ? undefined
+            : searchData.nextPageToken;
+        pageToken = next;
+        return { items: searchData.items, nextCursor: next };
       },
-      { initialCursor: checkpoint.next_page_token ?? null, delayMs: this.RATE_LIMIT_MS }
+      {
+        initialCursor: checkpoint.next_page_token ?? null,
+        maxPages: this.MAX_PAGES,
+        delayMs: this.RATE_LIMIT_MS,
+      }
     );
 
     for await (const searchItems of searchPages) {
@@ -1143,7 +1200,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
         const data = (await response.json()) as YouTubePlaylistItemResponse;
         return { items: data.items ?? [], nextCursor: data.nextPageToken };
       },
-      { delayMs: this.RATE_LIMIT_MS }
+      { maxPages: this.MAX_PAGES, delayMs: this.RATE_LIMIT_MS }
     );
 
     for await (const items of itemPages) {
@@ -1323,7 +1380,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
         const data = (await response.json()) as YouTubePlaylistItemResponse;
         return { items: data.items ?? [], nextCursor: data.nextPageToken };
       },
-      { delayMs: this.RATE_LIMIT_MS }
+      { maxPages: this.MAX_PAGES, delayMs: this.RATE_LIMIT_MS }
     );
     for await (const items of pages) {
       for (const item of items) {

--- a/packages/server/src/__tests__/integration/connector-health-alert.test.ts
+++ b/packages/server/src/__tests__/integration/connector-health-alert.test.ts
@@ -558,6 +558,39 @@ describe('connector-health alerter', () => {
     expect(row.unhealthy_alerted_at).not.toBeNull();
   });
 
+  // Rule A must stay sensitive to a SINGLE bad run. Narrowing its numerator to
+  // persistent failures (the degraded rule's stricter count) would let a
+  // connection whose every expected feed just failed report healthy until the
+  // consecutive counters climbed to the threshold — silence during exactly the
+  // window where the failure is newest.
+  it('flags a connection whose expected feeds all failed once, below the failure threshold', async () => {
+    const freshlyBroken = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'notion',
+      slug: 'fresh-total-failure',
+      createdAt: OLD,
+    });
+    for (const key of ['a', 'b']) {
+      await seedFeed({
+        orgId,
+        connectionId: freshlyBroken.id,
+        feedKey: key,
+        status: 'active',
+        lastSyncStatus: 'failed',
+        lastSyncAt: new Date(),
+        // One failed run: BELOW failureThreshold, so the persistent-failure
+        // count is 0 and only the latest-run half of the predicate catches it.
+        consecutiveFailures: 1,
+        lastError: 'worker_claim_timeout',
+      });
+    }
+
+    const res = await runConnectorHealthCheck();
+    expect(1).toBeLessThan(cfg.failureThreshold);
+    expect(reasonFor(res.details, freshlyBroken.id)).toBe('all_feeds_failing');
+  });
+
   it('flags a 3-feed connection at the degraded ratio', async () => {
     const threeFeed = await seedConnection({
       orgId,

--- a/packages/server/src/__tests__/integration/connector-health-alert.test.ts
+++ b/packages/server/src/__tests__/integration/connector-health-alert.test.ts
@@ -443,7 +443,13 @@ describe('connector-health alerter', () => {
     });
 
     const res = await runConnectorHealthCheck();
-    expect(reasonFor(res.details, mostlyOff.id)).toBe('feeds_degraded');
+    // What this pins is that the 8 operator-paused-clean feeds are excluded
+    // from the denominator: with them counted, 3 failing of 11 is neither
+    // "all feeds" nor past degradedFailingRatio, and the connection would be
+    // silently healthy. Excluded, all 3 EXPECTED feeds are failing, so Rule A
+    // claims it before the degraded rule is reached — the stronger and more
+    // accurate reason, and the one an operator can act on directly.
+    expect(reasonFor(res.details, mostlyOff.id)).toBe('all_feeds_failing');
   });
 
   // Guards the degraded threshold against noise: connection 3 ("healthy") has
@@ -499,6 +505,57 @@ describe('connector-health alerter', () => {
       SELECT unhealthy_alerted_at FROM connections WHERE id = ${twoFeed.id}
     `) as unknown as Array<{ unhealthy_alerted_at: Date | null }>;
     expect(row.unhealthy_alerted_at).toBeNull();
+  });
+
+  // The seam between Rule A and Rule D. Rule A used to compare failures against
+  // ALL feeds while Rule D's floor counts only EXPECTED ones, so a connection
+  // could satisfy neither: 2 of 10 failing is not "all feeds", and 2 expected
+  // feeds is below the three-feed floor. Every feed the operator still expects
+  // is dead and it reported healthy. Both rules now share the same denominator.
+  it('flags a connection whose only expected feeds all fail, below the degraded floor', async () => {
+    const sql = getTestDb();
+    const mostlyPaused = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'notion',
+      slug: 'paused-plus-all-expected-failing',
+      createdAt: OLD,
+    });
+    // Deliberately switched off by an operator (cf=0) — never a health signal.
+    for (let i = 0; i < 8; i++) {
+      await seedFeed({
+        orgId,
+        connectionId: mostlyPaused.id,
+        feedKey: `off-${i}`,
+        status: 'paused',
+        lastSyncStatus: 'success',
+        lastSyncAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+        consecutiveFailures: 0,
+      });
+    }
+    // The only two feeds still expected to run, both persistently failing.
+    for (const key of ['bad-a', 'bad-b']) {
+      await seedFeed({
+        orgId,
+        connectionId: mostlyPaused.id,
+        feedKey: key,
+        status: 'active',
+        lastSyncStatus: 'failed',
+        lastSyncAt: new Date(),
+        consecutiveFailures: cfg.failureThreshold,
+        lastError: 'worker_claim_timeout',
+      });
+    }
+
+    const res = await runConnectorHealthCheck();
+    // Below the degraded floor, so Rule D cannot be what catches it.
+    expect(2).toBeLessThan(cfg.degradedMinExpectedFeeds);
+    expect(reasonFor(res.details, mostlyPaused.id)).toBe('all_feeds_failing');
+
+    const [row] = (await sql`
+      SELECT unhealthy_alerted_at FROM connections WHERE id = ${mostlyPaused.id}
+    `) as unknown as Array<{ unhealthy_alerted_at: Date | null }>;
+    expect(row.unhealthy_alerted_at).not.toBeNull();
   });
 
   it('flags a 3-feed connection at the degraded ratio', async () => {

--- a/packages/server/src/__tests__/integration/connector-health-alert.test.ts
+++ b/packages/server/src/__tests__/integration/connector-health-alert.test.ts
@@ -1,14 +1,21 @@
 /**
  * connector-health alerter — integration test against real Postgres.
  *
- * Seeds four active connections in one org:
+ * Seeds five active connections in one org:
  *   1. all-feeds-failing (every non-deleted feed last_sync_status='failed')
  *   2. zero-feeds (active connection, no non-deleted feeds, past grace age)
- *   3. healthy (a feed that synced successfully recently)
+ *   3. healthy (one feed syncing, one PERSISTENTLY failing — 1 of 2 expected
+ *      feeds, i.e. exactly degradedFailingRatio; stays healthy only because of
+ *      the min-expected-feeds floor)
  *   4. deliberately-paused (paused feed, consecutive_failures=0, past success)
+ *   5. degraded (majority of feeds auto-paused BECAUSE they failed, one
+ *      survivor still syncing — the prod LinkedIn shape)
  *
- * Asserts the check flags ONLY (1) and (2), leaves (3) and (4) alone, and
- * alerts on the transition into unhealthy — not on every run.
+ * Asserts the check flags (1), (2) and (5), leaves (3) and (4) alone, and
+ * alerts on the transition into unhealthy — not on every run. Later tests pin
+ * the degraded rule's two independent guards: the operator-paused DENOMINATOR,
+ * and the min-expected-feeds FLOOR (2-feed quiet vs 3-feed alerting at the
+ * same ratio).
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -84,6 +91,7 @@ describe('connector-health alerter', () => {
   let zeroFeedsId: number;
   let healthyId: number;
   let pausedId: number;
+  let degradedId: number;
 
   beforeAll(async () => {
     await cleanupTestDatabase();
@@ -164,13 +172,17 @@ describe('connector-health alerter', () => {
       lastSyncAt: new Date(),
       consecutiveFailures: 0,
     });
-    // A second feed currently failing but the connection is NOT all-failing.
+    // A second feed that is PERSISTENTLY failing (consecutive_failures at the
+    // failure threshold, not a single blip). This is 1 of 2 expected feeds =
+    // exactly degradedFailingRatio, so only the min-expected-feeds floor keeps
+    // this connection healthy. Seeding it below the threshold (the original
+    // cf=1) would never exercise that boundary at all.
     await seedFeed({
       orgId,
       connectionId: healthyId,
       feedKey: 'b',
       lastSyncStatus: 'failed',
-      consecutiveFailures: 1,
+      consecutiveFailures: cfg.failureThreshold,
     });
 
     // 4. deliberately-paused: only a paused, never-failing feed with a past
@@ -190,6 +202,43 @@ describe('connector-health alerter', () => {
       status: 'paused',
       lastSyncStatus: 'success',
       lastSyncAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      consecutiveFailures: 0,
+    });
+
+    // 5. degraded: the prod LinkedIn (connection 412) shape. 11 feeds, 10 of
+    //    which are AUTO-paused because they kept failing (status='paused' with
+    //    consecutive_failures 9-10, last_error='worker_claim_timeout', dark for
+    //    11 days). One surviving feed still syncs, so the connection is neither
+    //    all-feeds-failing nor stale-by-newest-sync — yet it is plainly sick.
+    const degraded = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'linkedin',
+      slug: 'degraded',
+      createdAt: OLD,
+    });
+    degradedId = degraded.id;
+    const elevenDaysAgo = new Date(Date.now() - 11 * 24 * 60 * 60 * 1000);
+    for (let i = 0; i < 10; i++) {
+      await seedFeed({
+        orgId,
+        connectionId: degradedId,
+        feedKey: `dead-${i}`,
+        status: 'paused',
+        lastSyncStatus: 'failed',
+        lastSyncAt: elevenDaysAgo,
+        consecutiveFailures: i < 2 ? 10 : 9,
+        lastError: 'worker_claim_timeout',
+      });
+    }
+    // The single survivor that masks the other ten.
+    await seedFeed({
+      orgId,
+      connectionId: degradedId,
+      feedKey: 'home_feed',
+      status: 'active',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(),
       consecutiveFailures: 0,
     });
   });
@@ -217,9 +266,9 @@ describe('connector-health alerter', () => {
     expect(reasonFor(first.details, allFailingId)).toBe('all_feeds_failing');
     expect(reasonFor(first.details, zeroFeedsId)).toBe('zero_feeds');
 
-    // First run is the transition → both alerts fire.
-    expect(first.unhealthy).toBe(2);
-    expect(first.newlyAlerted).toBe(2);
+    // First run is the transition → all three alerts fire.
+    expect(first.unhealthy).toBe(3);
+    expect(first.newlyAlerted).toBe(3);
 
     // The marker was persisted for the flagged connections only.
     const sql = getTestDb();
@@ -229,14 +278,26 @@ describe('connector-health alerter', () => {
       ORDER BY id
     `) as unknown as Array<{ id: string }>;
     expect(marked.map((r) => Number(r.id)).sort((a, b) => a - b)).toEqual(
-      [allFailingId, zeroFeedsId].sort((a, b) => a - b)
+      [allFailingId, zeroFeedsId, degradedId].sort((a, b) => a - b)
     );
+  });
+
+  // DEFECT A: a single surviving feed used to mask ten dead ones. Prod
+  // LinkedIn connection 412 reported fully healthy while 10 of its 11 feeds
+  // had been auto-paused at consecutive_failures 9-10 for 11 days.
+  it('flags a connection whose feeds are mostly auto-paused failures', async () => {
+    const first = await runConnectorHealthCheck();
+    expect(reasonFor(first.details, degradedId)).toBe('feeds_degraded');
+
+    const detail = first.details.find((d) => d.connectionId === degradedId);
+    expect(detail?.feedCount).toBe(11);
+    expect(detail?.failingFeedCount).toBe(10);
   });
 
   it('does not re-alert on the next run while still unhealthy', async () => {
     const second = await runConnectorHealthCheck();
     // Still detected as unhealthy...
-    expect(second.unhealthy).toBe(2);
+    expect(second.unhealthy).toBe(3);
     // ...but no new alert fires (transition already claimed).
     expect(second.newlyAlerted).toBe(0);
     expect(second.recovered).toBe(0);
@@ -270,5 +331,269 @@ describe('connector-health alerter', () => {
     const broken = await runConnectorHealthCheck();
     expect(broken.newlyAlerted).toBe(1);
     expect(reasonFor(broken.details, allFailingId)).toBe('all_feeds_failing');
+  });
+
+  // The crux of the degraded rule: an operator pausing most of a connection's
+  // feeds is intent, NOT a failure. Only feeds paused *because they failed*
+  // (consecutive_failures > 0) count toward degradation.
+  it('does not flag a connection whose feeds an operator paused cleanly', async () => {
+    const sql = getTestDb();
+    const operatorPaused = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'notion',
+      slug: 'operator-paused',
+      createdAt: OLD,
+    });
+    // Eight cleanly-paused feeds (cf=0, no error) — operator intent.
+    for (let i = 0; i < 8; i++) {
+      await seedFeed({
+        orgId,
+        connectionId: operatorPaused.id,
+        feedKey: `off-${i}`,
+        status: 'paused',
+        lastSyncStatus: 'success',
+        lastSyncAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+        consecutiveFailures: 0,
+      });
+    }
+    // Two feeds are still EXPECTED to run, and both are healthy. The
+    // connection is fine, so it must not be flagged.
+    for (const key of ['on-a', 'on-b']) {
+      await seedFeed({
+        orgId,
+        connectionId: operatorPaused.id,
+        feedKey: key,
+        status: 'active',
+        lastSyncStatus: 'success',
+        lastSyncAt: new Date(),
+        consecutiveFailures: 0,
+      });
+    }
+
+    const res = await runConnectorHealthCheck();
+    expect(res.details.some((d) => d.connectionId === operatorPaused.id)).toBe(false);
+
+    const [row] = (await sql`
+      SELECT unhealthy_alerted_at FROM connections WHERE id = ${operatorPaused.id}
+    `) as unknown as Array<{ unhealthy_alerted_at: Date | null }>;
+    expect(row.unhealthy_alerted_at).toBeNull();
+  });
+
+  // The mirror of the above, and what actually pins the ratio DENOMINATOR:
+  // operator-paused feeds must not dilute a real degradation. Here all three
+  // feeds the operator still expects to run are persistently failing (3/3 =
+  // 1.0), so the connection is degraded. If the 8 deliberately-paused feeds
+  // were counted in the denominator the ratio would be 3/11 = 0.27 and the
+  // outage would be missed. Rule A cannot cover this either, since 3 failing
+  // !== 11 feeds.
+  //
+  // The expected set is deliberately 3, not 2: the min-expected-feeds floor
+  // applies to this rule too, and a 2-feed expected set would be suppressed by
+  // the floor rather than by the denominator logic this test exists to pin.
+  it('counts only expected feeds in the degraded ratio, not operator-paused ones', async () => {
+    const mostlyOff = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'notion',
+      slug: 'mostly-off',
+      createdAt: OLD,
+    });
+    for (let i = 0; i < 8; i++) {
+      await seedFeed({
+        orgId,
+        connectionId: mostlyOff.id,
+        feedKey: `off-${i}`,
+        status: 'paused',
+        lastSyncStatus: 'success',
+        lastSyncAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+        consecutiveFailures: 0,
+      });
+    }
+    // Keep a recent success on the connection so Rule C cannot be what fires.
+    await seedFeed({
+      orgId,
+      connectionId: mostlyOff.id,
+      feedKey: 'broken-a',
+      status: 'active',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(),
+      consecutiveFailures: 6,
+      lastError: 'worker_claim_timeout',
+    });
+    await seedFeed({
+      orgId,
+      connectionId: mostlyOff.id,
+      feedKey: 'broken-b',
+      status: 'paused',
+      lastSyncStatus: 'failed',
+      lastSyncAt: new Date(),
+      consecutiveFailures: 7,
+      lastError: 'worker_claim_timeout',
+    });
+    await seedFeed({
+      orgId,
+      connectionId: mostlyOff.id,
+      feedKey: 'broken-c',
+      status: 'paused',
+      lastSyncStatus: 'failed',
+      lastSyncAt: new Date(),
+      consecutiveFailures: 8,
+      lastError: 'worker_claim_timeout',
+    });
+
+    const res = await runConnectorHealthCheck();
+    expect(reasonFor(res.details, mostlyOff.id)).toBe('feeds_degraded');
+  });
+
+  // Guards the degraded threshold against noise: connection 3 ("healthy") has
+  // 2 expected feeds, one of them persistently failing AT the failure
+  // threshold. That is 1/2 = exactly degradedFailingRatio, so the ratio alone
+  // would fire — only the min-expected-feeds floor keeps it quiet.
+  it('does not flag a persistently failing feed on a 2-feed connection', async () => {
+    const res = await runConnectorHealthCheck();
+    expect(res.details.some((d) => d.connectionId === healthyId)).toBe(false);
+  });
+
+  // The boundary, pinned explicitly and symmetrically. Same ratio (exactly
+  // degradedFailingRatio, same persistent failure depth), differing ONLY in the
+  // number of expected feeds — 2 stays quiet, 3 alerts. This is the shape a
+  // bare `expectedCount > 0` guard gets wrong: it pages an operator for every
+  // 2-feed connection with a single bad feed.
+  it('does not flag a 2-feed connection with one persistently failing feed', async () => {
+    const sql = getTestDb();
+    const twoFeed = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'notion',
+      slug: 'two-feed-boundary',
+      createdAt: OLD,
+    });
+    await seedFeed({
+      orgId,
+      connectionId: twoFeed.id,
+      feedKey: 'bad',
+      status: 'active',
+      lastSyncStatus: 'failed',
+      lastSyncAt: new Date(),
+      consecutiveFailures: cfg.failureThreshold,
+      lastError: 'worker_claim_timeout',
+    });
+    await seedFeed({
+      orgId,
+      connectionId: twoFeed.id,
+      feedKey: 'good',
+      status: 'active',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(),
+      consecutiveFailures: 0,
+    });
+
+    const res = await runConnectorHealthCheck();
+    // 1 of 2 expected feeds failing IS >= degradedFailingRatio — the floor is
+    // the only thing keeping this connection off the alert path.
+    expect(1 / 2).toBeGreaterThanOrEqual(cfg.degradedFailingRatio);
+    expect(res.details.some((d) => d.connectionId === twoFeed.id)).toBe(false);
+
+    const [row] = (await sql`
+      SELECT unhealthy_alerted_at FROM connections WHERE id = ${twoFeed.id}
+    `) as unknown as Array<{ unhealthy_alerted_at: Date | null }>;
+    expect(row.unhealthy_alerted_at).toBeNull();
+  });
+
+  it('flags a 3-feed connection at the degraded ratio', async () => {
+    const threeFeed = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'notion',
+      slug: 'three-feed-boundary',
+      createdAt: OLD,
+    });
+    // 2 of 3 expected feeds persistently failing: the cheapest way to reach
+    // degradedFailingRatio once the floor applies, and a real outage.
+    for (const key of ['bad-a', 'bad-b']) {
+      await seedFeed({
+        orgId,
+        connectionId: threeFeed.id,
+        feedKey: key,
+        status: 'active',
+        lastSyncStatus: 'failed',
+        lastSyncAt: new Date(),
+        consecutiveFailures: cfg.failureThreshold,
+        lastError: 'worker_claim_timeout',
+      });
+    }
+    // A survivor with a fresh success, so neither Rule A nor Rule C can be
+    // what fires — this must be the degraded rule or nothing.
+    await seedFeed({
+      orgId,
+      connectionId: threeFeed.id,
+      feedKey: 'good',
+      status: 'active',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(),
+      consecutiveFailures: 0,
+    });
+
+    const res = await runConnectorHealthCheck();
+    expect(reasonFor(res.details, threeFeed.id)).toBe('feeds_degraded');
+  });
+
+  // DEFECT B control: a connection that is genuinely stale (Rule C) must KEEP
+  // its alert, while a healthy connection carrying a leftover marker gets it
+  // cleared. Mirrors prod 387 (true positive) vs 342/347 (stale markers).
+  it('clears a stale marker on a healthy connection but keeps a true positive', async () => {
+    const sql = getTestDb();
+    const day = 24 * 60 * 60 * 1000;
+
+    // Healthy but carrying a leftover alert (prod 347 / 342 shape).
+    const staleMarker = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'spotify',
+      slug: 'stale-marker',
+      createdAt: OLD,
+    });
+    await seedFeed({
+      orgId,
+      connectionId: staleMarker.id,
+      feedKey: 'a',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(),
+      consecutiveFailures: 0,
+    });
+
+    // Genuinely stale — newest success older than NO_SYNC_DAYS (prod 387).
+    const trueStale = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'apple.reminders',
+      slug: 'true-stale',
+      createdAt: OLD,
+    });
+    await seedFeed({
+      orgId,
+      connectionId: trueStale.id,
+      feedKey: 'a',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(Date.now() - 10 * day),
+      consecutiveFailures: 0,
+    });
+
+    await sql`
+      UPDATE connections SET unhealthy_alerted_at = now() - interval '3 days'
+      WHERE id IN (${staleMarker.id}, ${trueStale.id})
+    `;
+
+    await runConnectorHealthCheck();
+
+    const rows = (await sql`
+      SELECT id, unhealthy_alerted_at FROM connections
+      WHERE id IN (${staleMarker.id}, ${trueStale.id})
+    `) as unknown as Array<{ id: string; unhealthy_alerted_at: Date | null }>;
+    const byId = new Map(rows.map((r) => [Number(r.id), r.unhealthy_alerted_at]));
+
+    expect(byId.get(staleMarker.id)).toBeNull();
+    expect(byId.get(trueStale.id)).not.toBeNull();
   });
 });

--- a/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
+++ b/packages/server/src/__tests__/integration/tools/search-memory-recall-contract.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Regression: `search_memory` must not silently lie about what it recalled.
+ *
+ * THREE defects were reproduced and fixed on this branch, all in the
+ * agent-facing memory READ hot path (`tools/search.ts`):
+ *
+ *  A. The `content` facet vanished entirely (key absent) whenever the recall
+ *     produced zero rows, so an agent could not distinguish "nothing matched"
+ *     from "content search never ran".
+ *  B. `min_similarity` was INERT. `fetchContentSnippets` hardcoded 0.4 and
+ *     discarded the caller's value, and the entity fuzzy-name predicate
+ *     hardcoded `similarity(...) > 0.3` and never read `args.min_similarity`
+ *     at all — so the documented 0.0-1.0 knob changed nothing on EITHER path
+ *     it claims to govern. Both now read the caller's value.
+ *  C. A valid `agent_id` was applied as an ENTITY metadata filter, so an
+ *     exact-name lookup for an entity that DOES exist returned `not_found`
+ *     plus coaching to call `client.entities.create()` — turning a read-filter
+ *     into duplicate writes.
+ *
+ * NOT a defect, but pinned here anyway: content-snippet ORDERING. An earlier
+ * pass on this branch claimed `content_limit` truncated an unsorted set. That
+ * was WRONG — `fetchContentSnippets` already passes `sort_by: 'score'` on
+ * `origin/main`, and the "red" run that appeared to prove it actually failed on
+ * an uninitialized WorkspaceProvider in the harness, not on the ordering. The
+ * ordering test below is retained as a genuine regression guard (nothing else
+ * pins that `sort_by`), but it guards behaviour that was never broken and must
+ * not be described as a fix.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { search } from '../../../tools/search';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const EMBEDDING_DIM = 768;
+
+/**
+ * A unit vector in the 0/1 plane at `angle` radians from axis 0. The query is
+ * angle 0, so cosine similarity against the query is exactly cos(angle) —
+ * letting each fixture event be given an EXACT, known similarity score.
+ */
+function planeVec(angle: number): number[] {
+  const v = new Array(EMBEDDING_DIM).fill(0);
+  v[0] = Math.cos(angle);
+  v[1] = Math.sin(angle);
+  return v;
+}
+
+/** Similarity → the angle that produces it. */
+const atSimilarity = (sim: number) => planeVec(Math.acos(sim));
+
+describe('search_memory > recall contract', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let ctx: ToolContext;
+  const env = {} as Env;
+  const queryEmbedding = planeVec(0);
+
+  // Six low-scoring decoys (~0.54) and two strong hits (~0.80) — the exact
+  // shape of the prod "Cognitive Links" reproduction, where content_limit:6
+  // returned only the six 0.54 rows and the two 0.80 rows appeared at ranks
+  // 7-8 only once content_limit was raised to 12.
+  const STRONG_SIM = 0.8;
+  const WEAK_SIM = 0.54;
+  const strongIds: number[] = [];
+
+  // Fuzzy-name fixture for the ENTITY-side min_similarity floor. Nonsense words
+  // so nothing else in the org can match them. Trigram similarities against
+  // FUZZY_QUERY were MEASURED against this schema's pg_trgm, not guessed:
+  //   NEAR_NAME 0.75, MID_NAME 0.56.
+  // Both are invisible to the other three arms of the fuzzy OR (LIKE-substring,
+  // exact equality, websearch_to_tsquery), so only similarity() can admit them.
+  const FUZZY_QUERY = 'Zarquon Bittersweet';
+  const NEAR_NAME = 'Zarquonn Bittersweett';
+  const MID_NAME = 'Zarqu0n Bttersweet';
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    await initWorkspaceProvider();
+
+    org = await createTestOrganization({ name: 'Recall Contract Org' });
+    user = await createTestUser({ email: 'recall-contract@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const entity = await createTestEntity({
+      name: 'Cognitive Links',
+      organization_id: org.id,
+    });
+
+    for (const name of [NEAR_NAME, MID_NAME]) {
+      await createTestEntity({ name, organization_id: org.id });
+    }
+
+    await createTestConnectorDefinition({
+      key: 'recall-test-connector',
+      name: 'Recall Test',
+      organization_id: org.id,
+    });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'recall-test-connector',
+      entity_ids: [entity.id],
+    });
+
+    // Six weak decoys first (older), then the two strong hits.
+    for (let i = 0; i < 6; i++) {
+      await createTestEvent({
+        entity_id: entity.id,
+        connection_id: connection.id,
+        content: `Weak decoy note number ${i}`,
+        occurred_at: new Date(`2025-04-0${i + 1}T10:00:00Z`),
+        organization_id: org.id,
+        embedding: atSimilarity(WEAK_SIM),
+      });
+    }
+    for (let i = 0; i < 2; i++) {
+      const ev = await createTestEvent({
+        entity_id: entity.id,
+        connection_id: connection.id,
+        content: `Strong match about cognitive links ${i}`,
+        occurred_at: new Date(`2025-04-1${i}T10:00:00Z`),
+        organization_id: org.id,
+        embedding: atSimilarity(STRONG_SIM),
+      });
+      strongIds.push(ev.id);
+    }
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      tokenType: 'session',
+    } as ToolContext;
+  });
+
+  // ── ORDERING GUARD (never-broken behaviour, pinned) ──────────────────────
+  it('sorts content by similarity DESC so content_limit truncates the WORST, not the best', async () => {
+    const result = await search(
+      {
+        query: 'cognitive links',
+        query_embedding: queryEmbedding,
+        include_content: true,
+        content_limit: 2,
+        min_similarity: 0.3,
+      },
+      env,
+      ctx
+    );
+
+    const sims = (result.content ?? []).map((c) => Number(c.similarity));
+    // Monotonically non-increasing — the ordering contract itself.
+    for (let i = 1; i < sims.length; i++) {
+      expect(sims[i - 1]).toBeGreaterThanOrEqual(sims[i]);
+    }
+    // A limit of 2 against 8 candidates must return the two BEST, never two
+    // of the six 0.54 decoys.
+    const ids = (result.content ?? []).map((c) => c.id);
+    expect(ids.sort()).toEqual([...strongIds].sort());
+  });
+
+  // ── DEFECT A ────────────────────────────────────────────────────────────
+  it('always emits the content facet when include_content is true, even with zero hits', async () => {
+    // A query that matches NOTHING — neither lexically nor by vector. This is
+    // the shape that produced the prod symptom: the response carried no
+    // `content` key at all, so the agent could not tell recall had run.
+    const result = await search(
+      {
+        query: 'zzzz-nonexistent-topic-qqqq',
+        include_content: true,
+        content_limit: 5,
+        min_similarity: 0.3,
+      },
+      env,
+      ctx
+    );
+
+    // The KEY must be present. Absent-vs-empty is the whole defect: an agent
+    // on the JSON path reads a missing key as "recall never ran" and answers
+    // from nothing.
+    expect(result).toHaveProperty('content');
+    expect(Array.isArray(result.content)).toBe(true);
+  });
+
+  // ── DEFECT B (content path) ─────────────────────────────────────────────
+  it('honors min_similarity as a real floor on recalled content', async () => {
+    const common = {
+      query: 'cognitive links',
+      query_embedding: queryEmbedding,
+      include_content: true,
+      content_limit: 50,
+    } as const;
+
+    const permissive = await search({ ...common, min_similarity: 0.3 }, env, ctx);
+    const strict = await search({ ...common, min_similarity: 0.7 }, env, ctx);
+
+    // 0.3 admits the 0.54 decoys AND the 0.80 hits; 0.7 excludes the decoys.
+    // Before the fix both calls returned the identical 8 rows, because the
+    // floor was hardcoded to 0.4 and the caller's value was discarded.
+    expect((permissive.content ?? []).length).toBeGreaterThan(
+      (strict.content ?? []).length
+    );
+    // Every row the strict call kept clears the requested vector floor. (A
+    // lexical hit can still enter on the text branch of the hybrid match — the
+    // floor governs the VECTOR branch — so assert on the vector-matched set.)
+    expect((strict.content ?? []).map((c) => c.id).sort()).toEqual(
+      [...strongIds].sort()
+    );
+    for (const c of strict.content ?? []) {
+      expect(Number(c.similarity)).toBeGreaterThanOrEqual(0.7);
+    }
+
+    // Omitting the arg must equal an explicit 0.3. `fetchContentSnippets`
+    // forwards `undefined` rather than re-defaulting, so this pins that the
+    // ONE surviving copy of the constant (search-path.ts) is the documented
+    // one. Note 0.3 vs the old hardcoded 0.4 is itself observable here: the
+    // 0.54 decoys clear 0.3 and 0.4 alike, but the constant is now single-
+    // sourced instead of duplicated.
+    const defaulted = await search({ ...common }, env, ctx);
+    expect((defaulted.content ?? []).map((c) => c.id).sort()).toEqual(
+      (permissive.content ?? []).map((c) => c.id).sort()
+    );
+  });
+
+  // ── DEFECT B (entity fuzzy-name path) ───────────────────────────────────
+  it('honors min_similarity as a real floor on fuzzy ENTITY name matching', async () => {
+    const common = {
+      query: FUZZY_QUERY,
+      fuzzy: true,
+      include_content: false,
+      limit: 50,
+    } as const;
+
+    const permissive = await search({ ...common, min_similarity: 0.3 }, env, ctx);
+    const strict = await search({ ...common, min_similarity: 0.7 }, env, ctx);
+
+    const namesOf = (r: Awaited<ReturnType<typeof search>>) =>
+      (r.matches ?? []).map((m) => m.name).sort();
+
+    // Measured trigram similarities against FUZZY_QUERY (pg_trgm, this schema):
+    //   NEAR_NAME  0.75  — clears BOTH floors
+    //   MID_NAME   0.56  — clears 0.3, must be CUT by 0.7
+    // Both names are built so the trigram arm is the ONLY arm that can admit
+    // them: neither is a substring of the query nor the query a substring of
+    // them (LIKE '%…%' false), neither equals it, and neither shares an English
+    // lexeme with it (websearch_to_tsquery false). So a change in the result set
+    // is attributable to the similarity() threshold and nothing else.
+    expect(namesOf(permissive)).toEqual([MID_NAME, NEAR_NAME].sort());
+
+    // THE BITE: before the fix this predicate was hardcoded `similarity(...) >
+    // 0.3` and never read args.min_similarity, so raising the floor to 0.7
+    // returned the identical two rows.
+    expect(namesOf(strict)).toEqual([NEAR_NAME]);
+    expect(namesOf(strict).length).toBeLessThan(namesOf(permissive).length);
+
+    // OMITTING min_similarity must behave as the schema's documented 0.3 —
+    // this is what lets `fetchContentSnippets` forward `undefined` instead of
+    // keeping its own copy of the constant. If either path ever stops applying
+    // 0.3 on the omitted-value branch, this diverges from `permissive`.
+    const defaulted = await search({ ...common }, env, ctx);
+    expect(namesOf(defaulted)).toEqual(namesOf(permissive));
+
+    // A non-empty strict result also proves the query itself still works —
+    // the row count did not collapse to zero for some unrelated reason, and
+    // the zero-result fallback expansion (searchImpl) never had to fire.
+    expect(strict.matches?.length).toBe(1);
+  });
+
+  // ── DEFECT C ────────────────────────────────────────────────────────────
+  it('does not let agent_id filter ENTITY resolution into a false not_found', async () => {
+    const result = await search(
+      {
+        query: 'Cognitive Links',
+        fuzzy: false,
+        include_content: false,
+        agent_id: 'some-agent-id',
+      },
+      env,
+      ctx
+    );
+
+    // The entity exists. Returning not_found here is what drove agents to
+    // call client.entities.create() and write a duplicate.
+    expect(result.discovery_status).toBe('complete');
+    expect(result.entity?.name).toBe('Cognitive Links');
+    expect(result.suggestion ?? '').not.toContain('entities.create');
+  });
+
+  // ── Accepted-vs-advertised coherence ────────────────────────────────────
+  it('does not advertise server-internal args in its unknown-argument error', async () => {
+    const err = await search(
+      { query: 'Cognitive Links', not_a_real_arg: 1 } as never,
+      env,
+      ctx
+    ).catch((e: Error) => e.message);
+
+    // The error must enumerate the PUBLIC surface only. Naming these here is
+    // how an agent discovered args that `tools/list` deliberately hides.
+    expect(err).toContain('unknown argument(s): not_a_real_arg');
+    expect(err).not.toContain('query_embedding');
+    expect(err).not.toContain('agent_id');
+    // …while still listing the genuinely public ones.
+    expect(err).toContain('min_similarity');
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/behavior-reference-validation.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/behavior-reference-validation.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Foreign-key-shaped reference validation on manage_behaviors.
+ *
+ * `agent_id` and `keying_config.entity_type` are both free-text columns with NO
+ * database foreign key, so a typo is accepted and only fails much later — or
+ * never fails at all, silently:
+ *
+ *  - `agent_id`: the scheduler joins watchers to agents on `agent_id`, so a
+ *    nonexistent agent yields a Behavior that reports status 'active' /
+ *    health 'healthy' and never runs. `behaviors.create` documents
+ *    `throws: ["EntityNotFound"]` for exactly this case (see
+ *    src/sandbox/method-metadata.ts) but never resolved the id.
+ *  - `keying_config.entity_type`: deriveWatcherExtractionSchema() returns null
+ *    for an unknown type, and complete_window SKIPS extraction validation when
+ *    the derived schema is null — so an unknown type silently VOIDS the output
+ *    contract instead of enforcing it. Its sibling `entity_id` is validated
+ *    and throws, so the pair was inconsistent.
+ *
+ * Both are validated on create, update, and create_version.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import type { AuthContext } from "../../../tools/execute";
+import { executeTool } from "../../../tools/execute";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { createTestAgent } from "../../setup/test-fixtures";
+import { TestWorkspace } from "../../setup/test-mcp-client";
+
+const TEST_ENV: Env = {
+	ENVIRONMENT: "test",
+	DATABASE_URL: process.env.DATABASE_URL,
+	JWT_SECRET: "test-jwt-secret-for-testing-only",
+	BETTER_AUTH_SECRET: "test-auth-secret-for-testing-only",
+};
+
+function ownerCtx(orgId: string, userId: string): AuthContext {
+	return {
+		organizationId: orgId,
+		tokenOrganizationId: orgId,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		requestedAgentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		requestUrl: `http://localhost/api/${orgId}`,
+		baseUrl: "",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	};
+}
+
+describe("manage_behaviors reference validation", () => {
+	let workspace: TestWorkspace;
+	let ctx: AuthContext;
+	let agentId: string;
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		workspace = await TestWorkspace.create();
+		ctx = ownerCtx(workspace.org.id, workspace.users.owner.id);
+		const agent = await createTestAgent({
+			organizationId: workspace.org.id,
+			ownerUserId: workspace.users.owner.id,
+		});
+		agentId = agent.agentId;
+	});
+
+	// ============================================
+	// agent_id
+	// ============================================
+
+	it("create rejects a nonexistent agent_id (documented EntityNotFound)", async () => {
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "create",
+					slug: "ghost-agent",
+					name: "ghost-agent",
+					prompt: "Track things.",
+					agent_id: "agent-does-not-exist",
+				},
+				TEST_ENV,
+				ctx
+			)
+		).rejects.toThrow(/Agent "agent-does-not-exist" not found/i);
+	});
+
+	it("create does NOT persist a Behavior when agent_id is nonexistent", async () => {
+		await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ghost-agent-norow",
+				name: "ghost-agent-norow",
+				prompt: "Track things.",
+				agent_id: "agent-does-not-exist",
+			},
+			TEST_ENV,
+			ctx
+		).catch(() => undefined);
+
+		const rows = await getTestDb()<{ id: number }>`
+      SELECT id FROM watchers WHERE slug = ${"ghost-agent-norow"}
+    `;
+		expect(rows).toHaveLength(0);
+	});
+
+	it("create rejects an agent_id belonging to ANOTHER organization", async () => {
+		const other = await TestWorkspace.create({ name: "Other Org" });
+		const foreign = await createTestAgent({
+			organizationId: other.org.id,
+			ownerUserId: other.users.owner.id,
+		});
+
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "create",
+					slug: "cross-org-agent",
+					name: "cross-org-agent",
+					prompt: "Track things.",
+					agent_id: foreign.agentId,
+				},
+				TEST_ENV,
+				ctx
+			)
+		).rejects.toThrow(/not found/i);
+	});
+
+	it("update rejects a nonexistent agent_id", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "update-agent-target",
+				name: "update-agent-target",
+				prompt: "Track things.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ctx
+		)) as { behavior_id: string };
+
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "update",
+					behavior_id: created.behavior_id,
+					agent_id: "agent-does-not-exist",
+				},
+				TEST_ENV,
+				ctx
+			)
+		).rejects.toThrow(/Agent "agent-does-not-exist" not found/i);
+
+		// The stored owner must be untouched by the rejected update.
+		const [row] = await getTestDb()<{ agent_id: string }>`
+      SELECT agent_id FROM watchers WHERE id = ${Number(created.behavior_id)}
+    `;
+		expect(row.agent_id).toBe(agentId);
+	});
+
+	it("create/update accept a real agent_id", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "happy-agent",
+				name: "happy-agent",
+				prompt: "Track things.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ctx
+		)) as { behavior_id: string };
+		expect(created.behavior_id).toBeDefined();
+
+		const second = await createTestAgent({
+			organizationId: workspace.org.id,
+			ownerUserId: workspace.users.owner.id,
+		});
+		const updated = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "update",
+				behavior_id: created.behavior_id,
+				agent_id: second.agentId,
+			},
+			TEST_ENV,
+			ctx
+		)) as { updated_fields: string[] };
+		expect(updated.updated_fields).toContain("agent_id");
+	});
+
+	// ============================================
+	// keying_config.entity_type
+	// ============================================
+
+	it("create rejects a nonexistent keying_config.entity_type", async () => {
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "create",
+					slug: "ghost-entity-type",
+					name: "ghost-entity-type",
+					prompt: "Track things.",
+					agent_id: agentId,
+					keying_config: {
+						entity_type: "not-a-real-type",
+						entity_path: "rows",
+						key_fields: ["sku"],
+						key_output_field: "row_key",
+					},
+				},
+				TEST_ENV,
+				ctx
+			)
+		).rejects.toThrow(/Unknown entity type 'not-a-real-type'/i);
+	});
+
+	it("create accepts a keying_config.entity_type that exists", async () => {
+		await workspace.owner.entity_schema.createType({
+			slug: "price",
+			name: "Price",
+		});
+
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "real-entity-type",
+				name: "real-entity-type",
+				prompt: "Track things.",
+				agent_id: agentId,
+				keying_config: {
+					entity_type: "price",
+					entity_path: "prices",
+					key_fields: ["sku"],
+					key_output_field: "price_key",
+				},
+			},
+			TEST_ENV,
+			ctx
+		)) as { behavior_id: string };
+		expect(created.behavior_id).toBeDefined();
+	});
+
+	it("create_version rejects a nonexistent keying_config.entity_type", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "version-entity-type",
+				name: "version-entity-type",
+				prompt: "Track things.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ctx
+		)) as { behavior_id: string };
+
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "create_version",
+					behavior_id: created.behavior_id,
+					prompt: "Track things differently.",
+					keying_config: {
+						entity_type: "not-a-real-type",
+						entity_path: "rows",
+						key_fields: ["sku"],
+						key_output_field: "row_key",
+					},
+				},
+				TEST_ENV,
+				ctx
+			)
+		).rejects.toThrow(/Unknown entity type 'not-a-real-type'/i);
+	});
+});

--- a/packages/server/src/__tests__/unit/query-sql-behavior-exposure.test.ts
+++ b/packages/server/src/__tests__/unit/query-sql-behavior-exposure.test.ts
@@ -1,0 +1,182 @@
+/**
+ * query_sql's Behavior surface: the exposed relation must be NAMED for agents,
+ * COMPLETE for its own org, and CLOSED across orgs.
+ *
+ * Three defects reproduced live against prod, all rooted in
+ * `QUERYABLE_SCHEMA` / the CTE builder:
+ *
+ *   1. `behavior_versions` (formerly exposed as `watcher_versions`) listed a
+ *      `sources` column the table has never had. The CTE emits an explicit
+ *      column list, so `wv."sources"` was injected into EVERY query — even
+ *      `SELECT 1 AS one FROM …`, which references no column at all. The whole
+ *      relation was 100% unqueryable with an error naming a column the caller
+ *      never wrote.
+ *   2. The `watchers` CTE scoped through `EXISTS (SELECT 1 FROM entities WHERE
+ *      ent.id = ANY(i.entity_ids) …)`. `entity_ids` is nullable and org-scoped
+ *      Behaviors carry NULL, so they were structurally invisible — a confident
+ *      wrong count with no coverage hint. `watchers.organization_id` is NOT
+ *      NULL, so direct org scoping is both complete and strictly fail-closed.
+ *   3. `watcher` is internal engine/DB vocabulary; the agent-facing product
+ *      name is Behavior. The allowlist error enumerated `watchers` /
+ *      `watcher_versions` to the agent and asserted `behaviors` did not exist,
+ *      routing it to the wrong (and broken) table.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  buildScopedQuery,
+  executeDataSources,
+  validateAndScopeQuery,
+} from '../../utils/execute-data-sources';
+import {
+  QUERYABLE_TABLE_NAMES,
+  SAFE_COLUMN_DEFS,
+  formatUnknownTablesError,
+  validateTableQuery,
+} from '../../utils/table-schema';
+
+const scope = (sql: string, orgId = 'org_1') =>
+  validateAndScopeQuery(sql, orgId, { safeColumns: SAFE_COLUMN_DEFS });
+
+describe('Defect 1 — behavior_versions is queryable at all', () => {
+  it('does not project a column the physical table has never had', () => {
+    // `sources` exists on `watchers`, never on `watcher_versions` (the version
+    // row carries `version_sources`). Projecting it poisons every query.
+    const defs = SAFE_COLUMN_DEFS.get('behavior_versions');
+    expect(defs).toBeDefined();
+    expect(defs?.map((c) => c.name)).not.toContain('sources');
+  });
+
+  it('emits no reference to a dropped column for a query that names no column', () => {
+    // The caller references NOTHING. Any column name in the generated SQL is
+    // server-injected — this is the exact prod repro.
+    const { sql } = scope('SELECT 1 AS one FROM behavior_versions');
+    expect(sql).not.toMatch(/\bwv\."sources"/);
+    expect(sql).toContain('version_sources');
+  });
+});
+
+describe('Defect 2 — org-scoped Behaviors are visible to their own org', () => {
+  it('scopes behaviors by organization_id, not by an entity join', () => {
+    const { sql, params } = scope('SELECT count(*) AS n FROM behaviors');
+    // The entity-existence join is what hid entity-less Behaviors.
+    expect(sql).not.toMatch(/ent\.id = ANY\(\w+\.entity_ids\)/);
+    expect(sql).toMatch(/public\.watchers \w+ WHERE \w+\.organization_id = \$1/);
+    expect(params[0]).toBe('org_1');
+  });
+
+  it('scopes behavior_versions through the parent behavior organization_id', () => {
+    const { sql } = scope('SELECT id FROM behavior_versions');
+    expect(sql).not.toMatch(/ent\.id = ANY\(w\.entity_ids\)/);
+    expect(sql).toMatch(/public\.watchers w ON w\.id = wv\.watcher_id/);
+    expect(sql).toMatch(/w\.organization_id = \$1/);
+  });
+
+  it('stays fail-closed across orgs — the org predicate is never dropped', () => {
+    // Widening visibility must not become a tenancy leak: every Behavior CTE
+    // must still carry the bound org param, and nothing else.
+    for (const q of ['SELECT id FROM behaviors', 'SELECT id FROM behavior_versions']) {
+      const { sql, params } = scope(q, 'org_tenant_a');
+      expect(params).toEqual(['org_tenant_a']);
+      expect(sql).toMatch(/organization_id = \$1/);
+    }
+  });
+
+  it('does not widen the behaviors CTE to an unfiltered table scan', () => {
+    const { sql } = buildScopedQuery('SELECT id FROM behaviors', ['behaviors'], {
+      organizationId: 'org_1',
+    });
+    // A `WHERE TRUE` / missing predicate would read every tenant's rows.
+    expect(sql).toMatch(/FROM public\.watchers \w+ WHERE/);
+  });
+});
+
+describe('Defect 3 — the agent-facing surface speaks Behavior', () => {
+  it('exposes behaviors / behavior_versions, not the internal watcher names', () => {
+    expect(QUERYABLE_TABLE_NAMES.has('behaviors')).toBe(true);
+    expect(QUERYABLE_TABLE_NAMES.has('behavior_versions')).toBe(true);
+    expect(QUERYABLE_TABLE_NAMES.has('watchers')).toBe(false);
+    expect(QUERYABLE_TABLE_NAMES.has('watcher_versions')).toBe(false);
+  });
+
+  it('never leaks internal watcher vocabulary in the allowlist error', () => {
+    const message = formatUnknownTablesError(['conversations']);
+    expect(message).not.toMatch(/watcher/i);
+    expect(message).toContain('behaviors');
+  });
+
+  it('rejects the internal table name and points the agent at behaviors', () => {
+    const result = validateTableQuery('SELECT id FROM watchers');
+    expect(result.valid).toBe(false);
+    expect(result.errors.join('; ')).toContain('behaviors');
+  });
+
+  it('keeps internal watcher_id FK columns on joinable tables', () => {
+    // Column identifiers are internal vocabulary and stay as-is — only the
+    // exposed RELATION name is renamed. event_classifications.watcher_id is
+    // the join key to behaviors.id and must keep working.
+    const { sql } = scope(
+      'SELECT ec.id FROM event_classifications ec JOIN behaviors b ON b.id = ec.watcher_id'
+    );
+    expect(sql).toContain('watcher_id');
+  });
+});
+
+describe('Defect 4 — a source saved before the rename fails loudly, not silently', () => {
+  // The rename retires `watchers` as an exposed relation. `executeDataSources`
+  // compiles an UNKNOWN table ref as an entity-type CTE instead of erroring, and
+  // its slug validation only runs at SAVE time (`validateEntitySlugs`), which is
+  // exactly when these rows did NOT go through it — they were saved before the
+  // rename existed. Without an explicit retired-name check a stored
+  // `FROM watchers` resolves to a nonexistent entity type and returns ZERO ROWS:
+  // a view template that silently empties instead of failing.
+  const ctx = { organizationId: 'org_1' };
+  // The rejection happens before any SQL is issued, so the client is never used.
+  const unusedDb = (() => {
+    throw new Error('database must not be reached — the retired name must be rejected first');
+  }) as unknown as Parameters<typeof executeDataSources>[2];
+
+  it('rejects a retired relation name and names its replacement', async () => {
+    await expect(
+      executeDataSources({ dead: { query: 'SELECT id FROM watchers' } }, ctx, unusedDb, {
+        throwOnError: true,
+      })
+    ).rejects.toThrow(/watchers → behaviors/);
+  });
+
+  it('rejects the retired version relation too', async () => {
+    await expect(
+      executeDataSources({ dead: { query: 'SELECT id FROM watcher_versions' } }, ctx, unusedDb, {
+        throwOnError: true,
+      })
+    ).rejects.toThrow(/watcher_versions → behavior_versions/);
+  });
+
+  it('still accepts the current name', () => {
+    // Control: the replacement resolves through the normal allowlist path.
+    expect(QUERYABLE_TABLE_NAMES.has('behaviors')).toBe(true);
+    expect(() => scope('SELECT id FROM behaviors')).not.toThrow();
+  });
+});
+
+describe('smaller fixes in the same class', () => {
+  it('projects connections.unhealthy_alerted_at so org health is auditable', () => {
+    const names = SAFE_COLUMN_DEFS.get('connections')?.map((c) => c.name) ?? [];
+    expect(names).toContain('unhealthy_alerted_at');
+    const { sql } = scope('SELECT unhealthy_alerted_at FROM connections');
+    expect(sql).toContain('unhealthy_alerted_at');
+  });
+
+  it('shows feeds the SDK shows — gate on the feed row org + connection row visibility', () => {
+    // The feeds CTE used the FK (events) form, which drops soft-deleted and
+    // legacy-unowned connections. manage_feeds gates on the ROW form, so the
+    // SDK returned feeds SQL could not see. Same structural class as Defect 2.
+    const { sql } = scope('SELECT id FROM feeds');
+    expect(sql).toMatch(/public\.feeds fd WHERE fd\.organization_id = \$1/);
+    // FK form's tell: an IN-subquery over connections keyed on connection_id.
+    expect(sql).not.toMatch(/fd\.connection_id IS NULL OR fd\.connection_id IN/);
+    // Row form's tell: correlated EXISTS on the owning connection.
+    expect(sql).toMatch(/EXISTS \(SELECT 1 FROM public\.connections/);
+    expect(sql).toMatch(/visibility = 'org'/);
+  });
+});

--- a/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
+++ b/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
@@ -60,12 +60,29 @@ describe('buildScopedQuery events CTE — per-user connection visibility (S0)', 
   });
 
   it('gates feeds via their owning connection (connection_id NOT NULL)', () => {
-    const { sql, params } = buildScopedQuery('SELECT config FROM feeds', ['feeds'], {
+    // The gate is the connection ROW predicate (same one manage_feeds applies),
+    // not the FK/events form. The FK form additionally required the connection
+    // to be non-soft-deleted, which hid live feeds that `client.feeds.get`
+    // still returned — the SDK and the SQL view disagreed about what exists.
+    const { sql } = buildScopedQuery('SELECT config FROM feeds', ['feeds'], {
       organizationId: 'org_test',
       userId: 'user_a',
     });
-    expect(sql).toContain('fd.connection_id');
-    expect(sql).toContain("vc.visibility = 'org'");
-    expect(params).toContain('user_a');
+    expect(sql).toContain('fc.id = fd.connection_id');
+    expect(sql).toContain("fc.visibility = 'org'");
+    // Private connections created by OTHER users are still excluded.
+    expect(sql).toContain("fc.created_by = 'user_a'");
+  });
+
+  it('does not leak another org’s feeds when widening connection visibility', () => {
+    // Both the feed row and its owning connection stay bound to the org param —
+    // widening must never trade a visibility bug for a tenancy leak.
+    const { sql, params } = buildScopedQuery('SELECT id FROM feeds', ['feeds'], {
+      organizationId: 'org_test',
+      userId: 'user_a',
+    });
+    expect(sql).toContain('fd.organization_id = $1');
+    expect(sql).toContain('fc.organization_id = $1');
+    expect(params[0]).toBe('org_test');
   });
 });

--- a/packages/server/src/__tests__/unit/validate-args.test.ts
+++ b/packages/server/src/__tests__/unit/validate-args.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { Type } from "@sinclair/typebox";
 import { getAllTools, getTool } from "../../tools/registry";
-import { validateToolArgs, validateToolResult, withValidatedArgs } from "../../tools/validate-args";
+import {
+  markAcceptedInternalFields,
+  validateToolArgs,
+  validateToolResult,
+  withValidatedArgs,
+} from "../../tools/validate-args";
 import { ToolUserError } from "../../utils/errors";
 
 describe("validateToolArgs coercion", () => {
@@ -404,5 +409,69 @@ describe("registry outputSchema normalization (MCP spec: must be an object schem
     const byName = new Map(getAllTools().map((t) => [t.name, t]));
     const search = byName.get("search_memory") as { outputSchema?: any } | undefined;
     expect(search?.outputSchema?.type).toBe("object");
+  });
+});
+
+describe("accepted-but-unadvertised arg annotation", () => {
+  const schema = Type.Object({
+    query: Type.String(),
+    limit: Type.Optional(Type.Number()),
+    agent_id: Type.Optional(Type.String()),
+  });
+  markAcceptedInternalFields(schema, ["agent_id"]);
+
+  it("omits annotated fields from the unknown-argument error's valid-args list", () => {
+    let msg = "";
+    try {
+      validateToolArgs("t", schema, { query: "q", nope: 1 });
+    } catch (err) {
+      msg = (err as ToolUserError).message;
+    }
+    expect(msg).toContain("unknown argument(s): nope");
+    // The whole point: an error message must not publish an arg the tool's
+    // advertised schema deliberately hides.
+    expect(msg).not.toContain("agent_id");
+    // …while still naming the genuinely public ones.
+    expect(msg).toContain("query");
+    expect(msg).toContain("limit");
+  });
+
+  it("still ACCEPTS the annotated field — it is hidden, not rejected", () => {
+    const out = validateToolArgs("t", schema, { query: "q", agent_id: "a1" }) as Record<
+      string,
+      unknown
+    >;
+    expect(out.agent_id).toBe("a1");
+  });
+
+  it("keeps search_memory's server-internal args out of the ADVERTISED inputSchema", () => {
+    // The published schema is what an agent reads to learn the tool's surface.
+    // `agent_id` and `query_embedding` stay accepted by the handler but must
+    // not be advertised — and the marker that hides them from error text must
+    // not sneak into the advertised payload either.
+    const byName = new Map(getAllTools().map((t) => [t.name, t]));
+    const search = byName.get("search_memory") as { inputSchema?: any } | undefined;
+    const props = Object.keys(search?.inputSchema?.properties ?? {});
+    expect(props).not.toContain("agent_id");
+    expect(props).not.toContain("query_embedding");
+    // The public knobs are still there.
+    expect(props).toContain("query");
+    expect(props).toContain("min_similarity");
+    expect(JSON.stringify(search?.inputSchema)).not.toContain(
+      "x-lobu-accepted-internal-fields"
+    );
+  });
+
+  it("does not serialize the marker into JSON.stringify(schema)", () => {
+    // A TypeBox schema is routinely stringified into tools/list payloads and
+    // discovery metadata. An ENUMERABLE marker would ship the hidden field
+    // names straight to clients — publishing exactly what the annotation
+    // exists to suppress. Non-enumerable is what makes the marker inert for a
+    // future tool that opts in WITHOUT declaring a separate publicInputSchema.
+    const serialized = JSON.stringify(schema);
+    expect(serialized).not.toContain("x-lobu-accepted-internal-fields");
+    expect(Object.keys(schema)).not.toContain("x-lobu-accepted-internal-fields");
+    // Spread/clone paths must drop it too, for the same reason.
+    expect(JSON.stringify({ ...schema })).not.toContain("x-lobu-accepted-internal-fields");
   });
 });

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -179,6 +179,7 @@ interface UnhealthyRow {
   active_feed_count: string;
   operator_paused_feed_count: string;
   persistently_failing_feed_count: string;
+  failing_expected_feed_count: string;
   newest_sync_at: Date | null;
   last_error: string | null;
 }
@@ -232,6 +233,18 @@ async function loadConnectionHealthRows(
       COUNT(f.id) FILTER (
         WHERE f.consecutive_failures >= ${cfg.failureThreshold}
       ) AS persistently_failing_feed_count,
+      -- Rule A's numerator: the SAME "failing" predicate as
+      -- failing_feed_count (a single most-recent-run failure counts), but over
+      -- expected feeds only. Rule A must stay sensitive to one bad run —
+      -- narrowing it to persistent failures would let a connection whose every
+      -- expected feed just failed report healthy until the counters climb.
+      COUNT(f.id) FILTER (
+        WHERE NOT (f.status = 'paused' AND f.consecutive_failures = 0)
+          AND (
+            f.last_sync_status = 'failed'
+            OR f.consecutive_failures >= ${cfg.failureThreshold}
+          )
+      ) AS failing_expected_feed_count,
       MAX(f.last_sync_at) FILTER (WHERE f.last_sync_status = 'success') AS newest_sync_at,
       (ARRAY_AGG(f.last_error) FILTER (WHERE f.last_error IS NOT NULL))[1] AS last_error
     FROM connections c
@@ -259,6 +272,7 @@ function classify(
   const activeCount = Number(row.active_feed_count);
   const operatorPausedCount = Number(row.operator_paused_feed_count);
   const persistentlyFailingCount = Number(row.persistently_failing_feed_count);
+  const failingExpectedCount = Number(row.failing_expected_feed_count);
 
   // Rule B: active connection, zero non-deleted feeds. (Grace handled by the
   // query's min-age window — a connection that has existed > min age and still
@@ -279,8 +293,15 @@ function classify(
   // three-expected-feed floor, so it reported healthy while 100% of what it was
   // still expected to collect was dead. Deliberately switching feeds off must
   // never make the remaining failures harder to see.
+  //
+  // The PREDICATE is unchanged from the original rule — a feed counts as
+  // failing if its latest sync failed OR it is past the failure threshold.
+  // Only the denominator narrowed. Reusing the degraded rule's stricter
+  // persistent-failure count here would have been a second regression: a
+  // connection whose every expected feed just failed once would report healthy
+  // until the counters climbed to the threshold.
   const expectedCount = feedCount - operatorPausedCount;
-  if (expectedCount > 0 && persistentlyFailingCount === expectedCount) {
+  if (expectedCount > 0 && failingExpectedCount === expectedCount) {
     return 'all_feeds_failing';
   }
 

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -3,10 +3,12 @@
  *
  * The per-feed repair-agent (`repair-agent.ts`) only fires when a worker
  * actually RUNS and fails — it cannot catch a connector that has silently
- * stopped scheduling runs, an active connection that collects nothing, or a
- * whole connection whose every feed is dead. Those failure modes currently
- * surface to nobody and have gone unnoticed for weeks in prod (expired Revolut
- * sessions, "Authentication failed — cookies may be expired", etc.).
+ * stopped scheduling runs, an active connection that collects nothing, a whole
+ * connection whose every feed is dead, or a connection where most feeds have
+ * been auto-paused by repeated failure while one survivor masks them. Those
+ * failure modes currently surface to nobody and have gone unnoticed for weeks
+ * in prod (expired Revolut sessions, "Authentication failed — cookies may be
+ * expired", LinkedIn connection 412 dark for 11 days, etc.).
  *
  * This module is a periodic, read-only scan over `connections` + `feeds` that
  * classifies each active connection as healthy or unhealthy by clear rules and
@@ -67,11 +69,56 @@ const ZERO_FEEDS_GRACE_HOURS = 48;
  */
 const NO_SYNC_DAYS = 7;
 
+/**
+ * Fraction of the feeds a connection is still expected to run that must be
+ * PERSISTENTLY failing before the connection is "degraded" — sick even though
+ * at least one feed still works.
+ *
+ * Why a proportion and not "any failing feed": a single transiently-failing
+ * feed alongside nine healthy ones is normal operational noise, and alerting on
+ * it would make the signal useless. Why 0.5: a connection collecting less than
+ * half of what it is configured to collect is materially broken. Prod LinkedIn
+ * connection 412 sat at 10/11 = 0.91 for eleven days while reporting fully
+ * healthy.
+ *
+ * This ratio ALONE is not enough: it is trivially reachable on a tiny
+ * connection (1 of 2 expected feeds failing is exactly 0.5 and fires), which
+ * would page an operator for a single bad feed. `DEGRADED_MIN_EXPECTED_FEEDS`
+ * below is what keeps that quiet — see its docstring.
+ */
+const DEGRADED_FAILING_RATIO = 0.5;
+
+/**
+ * Minimum number of expected feeds (feeds the operator has NOT deliberately
+ * paused) a connection must have before the degraded rule may fire at all.
+ *
+ * A ratio is meaningless at small denominators. With 2 expected feeds, one
+ * persistently-failing feed is 1/2 = 0.5 and clears `DEGRADED_FAILING_RATIO`
+ * — so without this floor every 2-feed connection with one bad feed pages an
+ * operator, which is exactly the alert fatigue the degraded rule exists to
+ * avoid. At 3 expected feeds the cheapest way to reach the ratio is 2 of 3
+ * feeds persistently failing, which is a real outage rather than one flaky
+ * feed.
+ *
+ * The floor does NOT weaken coverage of the case this rule was built for: prod
+ * LinkedIn 412 has 11 expected feeds with 10 failing. And a small connection
+ * whose feeds ALL fail is still caught — by Rule A (`all_feeds_failing`), which
+ * has no floor. What the floor gives up is exactly one shape: a 1-or-2-feed
+ * connection that is partly (not wholly) failing. That is deliberate.
+ *
+ * Pinned by 'does not flag a 2-feed connection with one persistently failing
+ * feed' and 'flags a 3-feed connection at the degraded ratio' in
+ * `__tests__/integration/connector-health-alert.test.ts`.
+ */
+const DEGRADED_MIN_EXPECTED_FEEDS = 3;
+
 export interface ConnectorHealthConfig {
   failureThreshold: number;
   minConnectionAgeHours: number;
   zeroFeedsGraceHours: number;
   noSyncDays: number;
+  degradedFailingRatio: number;
+  degradedMinExpectedFeeds: number;
 }
 
 export const DEFAULT_CONNECTOR_HEALTH_CONFIG: ConnectorHealthConfig = {
@@ -79,9 +126,15 @@ export const DEFAULT_CONNECTOR_HEALTH_CONFIG: ConnectorHealthConfig = {
   minConnectionAgeHours: MIN_CONNECTION_AGE_HOURS,
   zeroFeedsGraceHours: ZERO_FEEDS_GRACE_HOURS,
   noSyncDays: NO_SYNC_DAYS,
+  degradedFailingRatio: DEGRADED_FAILING_RATIO,
+  degradedMinExpectedFeeds: DEGRADED_MIN_EXPECTED_FEEDS,
 };
 
-export type UnhealthyReason = 'all_feeds_failing' | 'zero_feeds' | 'no_recent_sync';
+export type UnhealthyReason =
+  | 'all_feeds_failing'
+  | 'feeds_degraded'
+  | 'zero_feeds'
+  | 'no_recent_sync';
 
 export interface UnhealthyConnection {
   connectionId: number;
@@ -124,6 +177,8 @@ interface UnhealthyRow {
   feed_count: string;
   failing_feed_count: string;
   active_feed_count: string;
+  operator_paused_feed_count: string;
+  persistently_failing_feed_count: string;
   newest_sync_at: Date | null;
   last_error: string | null;
 }
@@ -161,6 +216,22 @@ async function loadConnectionHealthRows(
       COUNT(f.id) FILTER (
         WHERE NOT (f.status = 'paused' AND f.consecutive_failures = 0)
       ) AS active_feed_count,
+      -- Feeds an OPERATOR deliberately switched off: paused with a clean
+      -- failure counter. These are intent, so they are excluded from the
+      -- degraded-ratio denominator entirely — pausing 9 of 10 feeds on purpose
+      -- must never read as a dying connection. Distinct from a feed the system
+      -- AUTO-paused after repeated failures (paused with consecutive_failures
+      -- > 0), which is a symptom and stays in the denominator.
+      COUNT(f.id) FILTER (
+        WHERE f.status = 'paused' AND f.consecutive_failures = 0
+      ) AS operator_paused_feed_count,
+      -- Feeds failing PERSISTENTLY (past the failure threshold), as opposed to
+      -- failing_feed_count which also counts a single most-recent-run blip.
+      -- Only persistent failures feed the degraded ratio, so one transiently
+      -- failing feed on a small connection is not an alert.
+      COUNT(f.id) FILTER (
+        WHERE f.consecutive_failures >= ${cfg.failureThreshold}
+      ) AS persistently_failing_feed_count,
       MAX(f.last_sync_at) FILTER (WHERE f.last_sync_status = 'success') AS newest_sync_at,
       (ARRAY_AGG(f.last_error) FILTER (WHERE f.last_error IS NOT NULL))[1] AS last_error
     FROM connections c
@@ -187,6 +258,8 @@ function classify(
   const feedCount = Number(row.feed_count);
   const failingCount = Number(row.failing_feed_count);
   const activeCount = Number(row.active_feed_count);
+  const operatorPausedCount = Number(row.operator_paused_feed_count);
+  const persistentlyFailingCount = Number(row.persistently_failing_feed_count);
 
   // Rule B: active connection, zero non-deleted feeds. (Grace handled by the
   // query's min-age window — a connection that has existed > min age and still
@@ -200,6 +273,28 @@ function classify(
 
   // Rule A: every non-deleted feed is failing.
   if (failingCount === feedCount) return 'all_feeds_failing';
+
+  // Rule D: a substantial proportion of the feeds the operator still expects to
+  // run are failing, but at least one survivor keeps Rule A from firing. That
+  // survivor also refreshes newest_sync_at, so Rule C cannot catch this either
+  // — without this rule the connection reports fully healthy while most of it
+  // is dark (prod LinkedIn 412: 10 of 11 feeds auto-paused for eleven days).
+  //
+  // The denominator excludes operator-paused-clean feeds so that deliberately
+  // switching feeds off never trips the rule; only feeds that are running or
+  // were auto-paused BY failure are counted. The numerator counts only
+  // PERSISTENT failures, so a single bad run on a small connection stays quiet.
+  //
+  // The min-expected-feeds floor is load-bearing, not belt-and-braces: at 2
+  // expected feeds one persistent failure is exactly the ratio and would fire.
+  // Small connections that are WHOLLY failing are still caught by Rule A above.
+  const expectedCount = feedCount - operatorPausedCount;
+  if (
+    expectedCount >= cfg.degradedMinExpectedFeeds &&
+    persistentlyFailingCount / expectedCount >= cfg.degradedFailingRatio
+  ) {
+    return 'feeds_degraded';
+  }
 
   // Rule C: was collecting but stopped. Only applies when at least one feed
   // once succeeded (newest_sync_at not null) — a connection that never synced

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -256,7 +256,6 @@ function classify(
   nowMs: number
 ): UnhealthyReason | null {
   const feedCount = Number(row.feed_count);
-  const failingCount = Number(row.failing_feed_count);
   const activeCount = Number(row.active_feed_count);
   const operatorPausedCount = Number(row.operator_paused_feed_count);
   const persistentlyFailingCount = Number(row.persistently_failing_feed_count);
@@ -271,8 +270,19 @@ function classify(
   // paused-clean feed.
   if (activeCount === 0) return null;
 
-  // Rule A: every non-deleted feed is failing.
-  if (failingCount === feedCount) return 'all_feeds_failing';
+  // Rule A: every feed the operator still EXPECTS to run is failing.
+  //
+  // The denominator is expected feeds, not all feeds — the same one Rule D
+  // uses. Comparing against `feedCount` instead left a hole exactly where the
+  // two rules meet: a connection with 8 deliberately-paused-clean feeds and 2
+  // persistently failing ones satisfies neither `2 === 10` nor Rule D's
+  // three-expected-feed floor, so it reported healthy while 100% of what it was
+  // still expected to collect was dead. Deliberately switching feeds off must
+  // never make the remaining failures harder to see.
+  const expectedCount = feedCount - operatorPausedCount;
+  if (expectedCount > 0 && persistentlyFailingCount === expectedCount) {
+    return 'all_feeds_failing';
+  }
 
   // Rule D: a substantial proportion of the feeds the operator still expects to
   // run are failing, but at least one survivor keeps Rule A from firing. That
@@ -288,7 +298,6 @@ function classify(
   // The min-expected-feeds floor is load-bearing, not belt-and-braces: at 2
   // expected feeds one persistent failure is exactly the ratio and would fire.
   // Small connections that are WHOLLY failing are still caught by Rule A above.
-  const expectedCount = feedCount - operatorPausedCount;
   if (
     expectedCount >= cfg.degradedMinExpectedFeeds &&
     persistentlyFailingCount / expectedCount >= cfg.degradedFailingRatio

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -27,6 +27,8 @@ import {
   type BehaviorUpdatePatch,
 } from '@lobu/core/contracts/tools/manage-behaviors';
 import {
+  assertAgentExists,
+  assertKeyingConfigEntityTypeExists,
   assertWatcherVersionConfigValid,
   assertWatcherSourcesResolve,
   parseJsonInput,
@@ -196,6 +198,12 @@ export async function handleCreate(
   if (!organizationId) {
     throw new ToolUserError('Cannot resolve Behavior sources without an organization');
   }
+  // Both of these are free-text columns with NO database foreign key, so an
+  // unresolvable id is accepted by the INSERT and only shows up as a Behavior
+  // that never runs (agent_id) or one whose output contract is silently voided
+  // (keying_config.entity_type). Resolve them BEFORE the row is written.
+  await assertAgentExists(sql, organizationId, args.agent_id);
+  await assertKeyingConfigEntityTypeExists(sql, organizationId, keyingConfig);
   await assertWatcherSourcesResolve(
     sql,
     organizationId,
@@ -472,6 +480,11 @@ export async function handleUpdate(
       );
     }
   }
+  // Same unresolvable-reference hole as create: `agent_id` has no FK, so
+  // re-pointing a Behavior at a nonexistent/cross-org agent would silently
+  // strand it (the scheduler joins on agents). Fence on ctx.organizationId —
+  // the same org the UPDATE below scopes to.
+  await assertAgentExists(sql, ctx.organizationId, args.agent_id);
 
   const updatedFields: string[] = [];
   if (args.model_config !== undefined) updatedFields.push('model_config');
@@ -719,6 +732,12 @@ export async function handleCreateFromVersion(
       `Source Behavior version ${args.version_id} has no agent_id; assign an agent on the source before cloning.`
     );
   }
+
+  // The source's agent_id is copied verbatim onto every clone, and a version can
+  // outlive the agent it named (agent_id has no FK, so a deleted agent leaves the
+  // reference dangling). Resolve it once here so the fan-out cannot mint a whole
+  // batch of Behaviors the scheduler will never run.
+  await assertAgentExists(sql, organizationId, version.agent_id as string);
 
   // Reject cross-org entity_ids before cloning: a watcher attached to another
   // org's entity links its synced/extracted content to a non-existent in-org

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -271,6 +271,84 @@ export async function assertWatcherSourcesResolve(
 }
 
 // ============================================
+// Foreign-key-shaped reference validation
+// ============================================
+
+/**
+ * Resolve `agent_id` against the caller's org before it is persisted.
+ *
+ * `watchers.agent_id` is NOT NULL but carries NO foreign key to `agents`, so a
+ * typo'd or cross-org id is accepted by the database and only surfaces as a
+ * Behavior that reports status 'active' / health 'healthy' and never runs — the
+ * scheduler joins watchers to agents on `agent_id` (see watchers/automation.ts),
+ * so an unresolvable owner silently drops the row out of every scheduling pass.
+ * `behaviors.create` already documents `throws: ["EntityNotFound"]` for this
+ * case in src/sandbox/method-metadata.ts; this honours that contract.
+ *
+ * Org-scoped by design: `agents` ids are unique only WITHIN an org, so resolving
+ * without the org fence would let one tenant name another tenant's agent.
+ * Matches the 404 shape manage_agents' own get/update handlers emit.
+ */
+export async function assertAgentExists(
+  sql: DbClient,
+  organizationId: string,
+  agentId: string | null | undefined
+): Promise<void> {
+  if (agentId == null) return;
+  const rows = await sql<{ id: string }>`
+    SELECT id FROM agents
+    WHERE organization_id = ${organizationId} AND id = ${agentId}
+    LIMIT 1
+  `;
+  if (rows.length === 0) {
+    throw new ToolUserError(`Agent "${agentId}" not found`, 404);
+  }
+}
+
+/**
+ * Resolve `keying_config.entity_type` against the org before it is persisted.
+ *
+ * An entity-typed Behavior derives its whole output contract from the named
+ * type's `metadata_schema`. When the type does not exist,
+ * `deriveWatcherExtractionSchema()` returns null and complete_window SKIPS
+ * extraction validation entirely — so a typo does not fail loudly, it silently
+ * VOIDS the contract the Behavior was created to enforce. Its sibling
+ * `entity_id` is already existence-checked at create, so validating here makes
+ * the pair consistent.
+ *
+ * Uses the same tenant-first-then-public-catalog visibility rule as
+ * `resolveEntityTypeMetadataSchema()` (watcher-extraction-schema.ts) so a type
+ * that derivation CAN see is never rejected here — checking existence only, as
+ * a type legitimately may carry no metadata_schema yet.
+ */
+export async function assertKeyingConfigEntityTypeExists(
+  sql: DbClient,
+  organizationId: string,
+  keyingConfig: Record<string, unknown> | null | undefined
+): Promise<void> {
+  const rawType = keyingConfig?.entity_type;
+  if (typeof rawType !== 'string') return;
+  const entityType = rawType.trim();
+  if (!entityType) return;
+
+  const rows = await sql<{ id: number }>`
+    SELECT et.id
+    FROM entity_types et
+    LEFT JOIN organization o ON o.id = et.organization_id
+    WHERE et.slug = ${entityType}
+      AND et.deleted_at IS NULL
+      AND (et.organization_id = ${organizationId} OR o.visibility = 'public')
+    LIMIT 1
+  `;
+  if (rows.length === 0) {
+    throw new ToolUserError(
+      `Unknown entity type '${entityType}' in keying_config. Use manage_entity_schema(schema_type="entity_type", action="list") to list available types or create a custom type first.`,
+      422
+    );
+  }
+}
+
+// ============================================
 // Watcher access control
 // ============================================
 

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -12,6 +12,7 @@ import { extractSourcesFromPromptTokens, mergePromptSources } from '../../../wat
 import type { ToolContext } from '../../registry';
 import type { ManageBehaviorsArgs, ManageBehaviorsResult } from '../manage_behaviors';
 import {
+  assertKeyingConfigEntityTypeExists,
   assertWatcherVersionConfigValid,
   assertWatcherSourcesResolve,
   parseJsonInput,
@@ -140,6 +141,12 @@ export async function handleCreateVersion(
   // entity_ids so {{entityId}} validates as it runs.
   const versionOrganizationId = watcherRows[0].organization_id as string | null;
   if (versionOrganizationId) {
+    // Only validate a CALLER-SUPPLIED keying_config. An inherited value comes
+    // from the stored previous version, and a metadata-only bump (name/schedule)
+    // must not start failing because of a type that was already persisted.
+    if (args.keying_config !== undefined) {
+      await assertKeyingConfigEntityTypeExists(sql, versionOrganizationId, keyingConfig);
+    }
     await assertWatcherSourcesResolve(
       sql,
       versionOrganizationId,

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -32,7 +32,7 @@ import { expandSearchQueries } from '../utils/query-expansion';
 import { buildEntityUrl, getPublicWebUrl } from '../utils/url-builder';
 import { getWorkspaceProvider } from '../workspace';
 import type { ToolContext } from './registry';
-import { withValidatedArgs } from './validate-args';
+import { markAcceptedInternalFields, withValidatedArgs } from './validate-args';
 import { getErrorMessage } from '@lobu/core';
 
 // ============================================
@@ -79,7 +79,8 @@ export const SearchSchema = Type.Object({
   ),
   min_similarity: Type.Optional(
     Type.Number({
-      description: 'Minimum similarity threshold for fuzzy matching (0.0-1.0)',
+      description:
+        'Minimum similarity threshold (0.0-1.0) applied to BOTH fuzzy entity-name matching and recalled content. Raise it to cut weak matches, lower it to widen recall.',
       default: 0.3,
       minimum: 0,
       maximum: 1,
@@ -120,7 +121,7 @@ export const SearchSchema = Type.Object({
   agent_id: Type.Optional(
     Type.String({
       description:
-        "Limit results to memory written by this agent. Filters events where `metadata.agent_id` matches the given id; pass the same id here to scope recall to that agent's own writes.",
+        "Scope recalled CONTENT to memory written by this agent — filters events where `metadata.agent_id` matches the given id. Entity resolution is NOT filtered by it: entities are workspace nouns with no writing agent, so scoping them here would report an existing entity as not-found.",
     })
   ),
   limit: Type.Optional(
@@ -140,6 +141,17 @@ export const SearchSchema = Type.Object({
 });
 
 /**
+ * Accepted by the handler, but NOT advertised on `tools/list` (see
+ * {@link PublicSearchSchema}). Listed here so the arg validator keeps them
+ * VALID while omitting them from the "valid arguments are: …" text of an
+ * unknown-argument error — otherwise a mistyped arg teaches an agent that
+ * `agent_id` / `query_embedding` exist, which is exactly the accepted-but-
+ * unadvertised trap this split is meant to close.
+ */
+const PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS = ['query_embedding', 'agent_id'];
+markAcceptedInternalFields(SearchSchema, PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS);
+
+/**
  * Schema advertised on `tools/list`. Drops the server-internal fields that
  * `SearchSchema` still accepts (so validation passes for internal callers and
  * tests): `query_embedding` (a pre-computed vector the content-search layer
@@ -147,7 +159,6 @@ export const SearchSchema = Type.Object({
  * resolved from auth context — clients asserting it cross-agent within an org
  * is a footgun, not an affordance). See `ToolDefinition.publicInputSchema`.
  */
-const PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS = ['query_embedding', 'agent_id'];
 export const PublicSearchSchema = Type.Object(
   Object.fromEntries(
     Object.entries(SearchSchema.properties).filter(
@@ -360,7 +371,8 @@ async function fetchContentSnippets(
   contentLimit: number,
   env: Env,
   queryEmbedding?: number[],
-  agentId?: string
+  agentId?: string,
+  minSimilarity?: number
 ): Promise<ContentSnippet[]> {
   const result = await searchContentByText(
     query,
@@ -376,7 +388,14 @@ async function fetchContentSnippets(
         userId: gate.principal,
       },
       limit: contentLimit,
-      min_similarity: 0.4,
+      // The caller's `min_similarity` is the advertised recall floor (schema:
+      // 0.0-1.0, default 0.3). It used to be hardcoded to 0.4 here, so the knob
+      // was completely inert: sweeping 0 → 1.0 never changed the result set, and
+      // the documented default was silently overridden. Pass `undefined` through
+      // rather than defaulting here — `search-path.ts` already applies the SAME
+      // documented 0.3 (and clamps it to [0,1]); a second copy of the constant
+      // could silently drift from the one that actually reaches the SQL.
+      min_similarity: minSimilarity,
       query_embedding: queryEmbedding,
       agent_id: agentId,
       // Recall wants the most *relevant* matching content, not the most recent.
@@ -572,6 +591,9 @@ export interface RecallContext {
   contentLimit: number;
   env: Env;
   queryEmbedding?: number[];
+  /** Caller-supplied similarity floor for recalled content (schema 0.0-1.0,
+   * default 0.3). Undefined means "use the documented default". */
+  minSimilarity?: number;
 }
 
 /**
@@ -637,9 +659,15 @@ const knowledgeSource: RecallSource = {
       ctx.contentLimit,
       ctx.env,
       ctx.queryEmbedding,
-      ctx.contentAgentId
+      ctx.contentAgentId,
+      ctx.minSimilarity
     );
-    return content.length > 0 ? { content } : {};
+    // ALWAYS emit the facet, even empty. An ABSENT `content` key and an empty
+    // one are indistinguishable to an agent reading raw JSON, so omitting it on
+    // zero hits reads as "content search never ran" — the agent then concludes
+    // the workspace knows nothing and answers from nothing. `[]` says "we
+    // looked and found nothing", which is the honest answer.
+    return { content };
   },
 };
 
@@ -893,6 +921,7 @@ async function searchImpl(
             contentLimit,
             env,
             queryEmbedding: args.query_embedding,
+            minSimilarity: args.min_similarity,
           }
         )
       : Promise.resolve({});
@@ -1155,7 +1184,30 @@ async function queryEntities(
   // Query match condition: text match OR vector match
   if (query) {
     if (fuzzyEnabled) {
-      const textCondition = `(LOWER(e.name) LIKE '%' || LOWER($${queryParamIdx}) || '%' OR LOWER(e.name) = LOWER($${queryParamIdx}) OR similarity(LOWER(e.name), LOWER($${queryParamIdx})) > 0.3 OR e.content_tsv @@ websearch_to_tsquery('english', $${queryParamIdx}))`;
+      // `min_similarity` is the caller-facing knob whose schema declares it
+      // applies to BOTH fuzzy entity-name matching and recalled content. This
+      // predicate is the entity-name half, so it must read the caller's value
+      // rather than a hardcoded constant. Clamped to [0,1] (an out-of-range
+      // value would make the arm always-true / always-false) and defaulted to
+      // the SAME 0.3 the schema advertises, so an omitted value keeps today's
+      // behaviour exactly.
+      //
+      // Bound as a param with an explicit `::numeric` cast, mirroring
+      // content-search/search-path.ts: `packages/server` runs `fetch_types:
+      // false`, so an uncast placeholder leaves postgres.js without a type to
+      // infer. `similarity()` returns `real`; `real > numeric` resolves fine.
+      // No index is lost by parameterizing: the only trigram index in the
+      // schema is `idx_events_raw_content_trgm` on `events.payload_text`, and
+      // the sole index on this column, `idx_entities_name`, is a BTREE over
+      // `lower(name)` — a btree can never serve `similarity()` at any
+      // threshold, literal or bound. It still serves the `LOWER(e.name) =
+      // LOWER($n)` arm of this same OR, which is untouched.
+      const rawMinSimilarity = Number(args.min_similarity ?? 0.3);
+      const nameSimFloor = Number.isFinite(rawMinSimilarity)
+        ? Math.max(0, Math.min(1, rawMinSimilarity))
+        : 0.3;
+      const minSimParamIdx = addParam(nameSimFloor);
+      const textCondition = `(LOWER(e.name) LIKE '%' || LOWER($${queryParamIdx}) || '%' OR LOWER(e.name) = LOWER($${queryParamIdx}) OR similarity(LOWER(e.name), LOWER($${queryParamIdx})) > $${minSimParamIdx}::numeric OR e.content_tsv @@ websearch_to_tsquery('english', $${queryParamIdx}))`;
       conditions.push(
         hasEmbedding ? `(${textCondition} OR e.embedding IS NOT NULL)` : textCondition
       );
@@ -1201,16 +1253,15 @@ async function queryEntities(
     }
   }
 
-  // Structured agent_id filter. The top-level `agent_id` arg is the only
-  // accepted form — it's server-internal (resolved from auth context in
-  // searchImpl, or passed by server-internal callers); it is NOT advertised
-  // on the public schema (see PublicSearchSchema). Do NOT honor
-  // `metadata_filter.agent_id` — `metadata_filter` is public, so honoring it
-  // would re-expose the cross-agent footgun the field split hides.
-  const agentIdFilter = args.agent_id;
-  if (agentIdFilter) {
-    conditions.push(`e.metadata->>'agent_id' = $${addParam(agentIdFilter)}`);
-  }
+  // NOTE: `agent_id` is deliberately NOT an entity filter. It is a MEMORY-SCOPE
+  // axis over `events.metadata->>'agent_id'` (which agent WROTE a memory) — see
+  // RecallContext.contentAgentId, where it is applied. Entities are workspace
+  // nouns with no writing agent, so almost none carry `metadata.agent_id`;
+  // applying it here matched ~nothing and made an exact-name lookup for an
+  // entity that DOES exist return `not_found` plus "call client.entities.create()"
+  // coaching — turning a read-scope filter into DUPLICATE WRITES.
+  // Do NOT honor `metadata_filter.agent_id` here either: `metadata_filter` is on
+  // the public schema, so honoring it would re-expose the cross-agent footgun.
 
   const whereClause = conditions.join(' AND ');
 

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -39,6 +39,46 @@ interface SchemaWithVariants {
 }
 
 /**
+ * Schema-level annotation listing fields a tool ACCEPTS but does not ADVERTISE
+ * (server-internal args populated from auth context or a server pre-compute).
+ * Such fields stay valid input, but must not appear in the "valid arguments
+ * are: …" list of an unknown-argument error — an error message is not a place
+ * to publish an affordance the tool's advertised schema deliberately hides.
+ */
+const ACCEPTED_INTERNAL_FIELDS = 'x-lobu-accepted-internal-fields';
+
+/**
+ * Annotate `schema` with the args it accepts but does not advertise.
+ *
+ * The annotation is defined NON-ENUMERABLE on purpose. A TypeBox schema object
+ * is routinely handed to `JSON.stringify` (tools/list payloads, ClientSDK
+ * discovery metadata, snapshot fixtures), and an enumerable own property would
+ * serialize straight into that JSON — publishing the very field names the
+ * annotation exists to keep unpublished. `search_memory` happens to be safe
+ * today because it declares a marker-free `publicInputSchema`, but the marker
+ * must be inert-by-construction for the next tool that opts in without one.
+ * `Object.keys` / spread / `{...schema}` skip it for the same reason; readers
+ * go through `advertisedArgNames`, which reads the key directly.
+ */
+export function markAcceptedInternalFields(schema: TSchema, fields: readonly string[]): void {
+  Object.defineProperty(schema, ACCEPTED_INTERNAL_FIELDS, {
+    value: [...fields],
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  });
+}
+
+/** Public argument names to name in error text: declared properties minus the
+ * accepted-but-unadvertised ones. */
+function advertisedArgNames(schema: TSchema): string[] {
+  const { properties } = schema as { properties?: Record<string, unknown> };
+  const internal = (schema as Record<string, unknown>)[ACCEPTED_INTERNAL_FIELDS];
+  const hidden = new Set(Array.isArray(internal) ? internal.map(String) : []);
+  return Object.keys(properties ?? {}).filter((key) => !hidden.has(key));
+}
+
+/**
  * For a `Type.Union` of per-action variants, validation must dispatch on the
  * `action` literal and check ONLY the matched variant: the schema advertised
  * to MCP clients is the FLATTENED union (registry `flattenUnionSchema`), so a
@@ -212,9 +252,7 @@ function checkAgainst(toolName: string, schema: TSchema, args: unknown): unknown
 
   if (checkPassed) {
     if (unknown && unknown.length > 0) {
-      const valid = Object.keys(
-        (schema as { properties?: Record<string, unknown> }).properties ?? {}
-      );
+      const valid = advertisedArgNames(schema);
       throw new ToolUserError(
         `Invalid arguments for ${toolName}: unknown argument(s): ${unknown.join(', ')} — valid arguments${scope} are: ${valid.join(', ')}`
       );
@@ -250,9 +288,7 @@ function checkAgainst(toolName: string, schema: TSchema, args: unknown): unknown
   // caller who supplied the wrong field name (dropping the required one) sees
   // both problems at once instead of fixing them serially.
   if (unknown && unknown.length > 0) {
-    const valid = Object.keys(
-      (schema as { properties?: Record<string, unknown> }).properties ?? {}
-    );
+    const valid = advertisedArgNames(schema);
     errs.push(
       `unknown argument(s): ${unknown.join(', ')} — valid arguments${scope} are: ${valid.join(', ')}`
     );

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, inject, it } from 'vitest';
 import { validateAndScopeQuery } from '../execute-data-sources';
 import {
   buildColumnList,
+  physicalTableFor,
   QUERYABLE_SCHEMA,
   QUERYABLE_TABLE_NAMES,
   SAFE_COLUMN_DEFS,
@@ -14,9 +15,11 @@ describe('QUERYABLE_TABLE_NAMES', () => {
       'entities',
       'events',
       'connections',
-      'watchers',
+      // Agent-facing relation names: the engine's `watchers` /
+      // `watcher_versions` are exposed as Behavior vocabulary.
+      'behaviors',
       'event_classifications',
-      'watcher_versions',
+      'behavior_versions',
       'oauth_clients',
       'oauth_tokens',
       'user',
@@ -71,14 +74,14 @@ describe('SAFE_COLUMN_DEFS', () => {
     expect(cols).not.toContain('"content_tsv"');
   });
 
-  it('should emit direct columns for watcher_versions', () => {
-    const cols = colList('watcher_versions');
+  it('should emit direct columns for behavior_versions', () => {
+    const cols = colList('behavior_versions');
     expect(cols).toContain('"prompt"');
     expect(cols).toContain('"classifiers"');
   });
 
   it('should prefix columns with alias', () => {
-    const defs = SAFE_COLUMN_DEFS.get('watcher_versions')!;
+    const defs = SAFE_COLUMN_DEFS.get('behavior_versions')!;
     const cols = buildColumnList(defs, 'wv');
     expect(cols).toContain('wv."prompt"');
     expect(cols).toContain('wv."id"');
@@ -134,8 +137,17 @@ describe('validateAndScopeQuery', () => {
 
 /**
  * Schema drift detection — runs whenever the suite has a Postgres backend.
- * Ensures every real column in queryable tables is listed in QUERYABLE_SCHEMA
- * so the polyglot-sql validator doesn't reject valid JOINs.
+ *
+ * BIDIRECTIONAL, and it has to be. The original block only checked DB → schema
+ * ("is every real column listed?"). The opposite direction is the one that
+ * takes a relation down entirely: `buildColumnList` emits an EXPLICIT
+ * projection into the generated CTE, so a schema column that does not exist in
+ * the database is injected into every query against that relation — including
+ * `SELECT 1 AS one FROM behavior_versions`, which references no column at all.
+ * `behavior_versions` listed `sources` (a `watchers` column that has never
+ * existed on `watcher_versions`) and was therefore 100% unqueryable in prod,
+ * with an error naming a column no caller ever wrote, while this gate stayed
+ * green. A one-directional drift check is a half gate.
  *
  * Gating note: the previous `describe.skipIf(!process.env.DATABASE_URL)` was
  * evaluated at module load. In the embedded-PG path the URL is set by
@@ -154,7 +166,7 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     // flip makes the view `WHERE superseded_by IS NULL`, so through the view
     // the column is always NULL. Lineage queries belong on the raw table.
     events: new Set(['superseded_by']),
-    connections: new Set(['credentials', 'unhealthy_alerted_at']),
+    connections: new Set(['credentials']),
     // Large per-connector JSONB blobs — too big and structure-dependent to expose
     // via raw SQL. Callers should hit the typed connector handler instead.
     connector_definitions: new Set([
@@ -169,6 +181,72 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     user: new Set(['email', 'phoneNumber', 'phoneNumberVerified']),
   };
 
+  /**
+   * Schema columns that legitimately have no physical column of that name on
+   * the backing table, because the CTE DERIVES them. Keep this list tiny: every
+   * entry is a column the reverse check can no longer protect.
+   */
+  const DERIVED_COLUMNS: Record<string, Set<string>> = {
+    // entities CTE JOINs entity_types and aliases et.slug AS entity_type.
+    entities: new Set(['entity_type']),
+  };
+
+  /** relation name → physical column set, read once per drift test. */
+  async function loadDbColumns(): Promise<Map<string, Set<string>>> {
+    const { getDb, pgTextArray } = await import('../../db/client');
+    const sql = getDb();
+
+    // Query by PHYSICAL table: an exposed relation may be renamed for the
+    // agent-facing surface (behaviors → watchers). Looking up the relation name
+    // in information_schema would find nothing and silently skip the table —
+    // exactly the "guard skips its own surface" failure mode.
+    const physicalNames = QUERYABLE_SCHEMA.tables.map((t) => physicalTableFor(t.name));
+
+    const rows = await sql`
+      SELECT table_name, column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = ANY(${pgTextArray(physicalNames)}::text[])
+      ORDER BY table_name, ordinal_position
+    `;
+
+    const byPhysical = new Map<string, Set<string>>();
+    for (const row of rows) {
+      const table = row.table_name as string;
+      if (!byPhysical.has(table)) byPhysical.set(table, new Set());
+      byPhysical.get(table)!.add(row.column_name as string);
+    }
+
+    const byRelation = new Map<string, Set<string>>();
+    for (const t of QUERYABLE_SCHEMA.tables) {
+      const physical = byPhysical.get(physicalTableFor(t.name));
+      if (physical) byRelation.set(t.name, physical);
+    }
+    return byRelation;
+  }
+
+  it('resolves every exposed relation to a real physical table', async (ctx) => {
+    const databaseUrl = inject('databaseUrl');
+    if (!databaseUrl) {
+      ctx.skip();
+      return;
+    }
+    process.env.DATABASE_URL = databaseUrl;
+
+    // A relation that resolves to nothing means both drift directions silently
+    // pass for it. Assert coverage explicitly rather than letting a `continue`
+    // skip it.
+    const byRelation = await loadDbColumns();
+    const unresolved = QUERYABLE_SCHEMA.tables
+      .map((t) => t.name)
+      .filter((name) => !byRelation.has(name));
+
+    expect(
+      unresolved,
+      `Exposed relations with no backing table/view:\n  ${unresolved.join('\n  ')}`
+    ).toEqual([]);
+  });
+
   it('should have every DB column listed in the schema (or intentionally omitted)', async (ctx) => {
     const databaseUrl = inject('databaseUrl');
     if (!databaseUrl) {
@@ -180,42 +258,55 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     // global-setup, independent of env-propagation timing into this fork.
     process.env.DATABASE_URL = databaseUrl;
 
-    const { getDb, pgTextArray } = await import('../../db/client');
-    const sql = getDb();
-
-    const tableNames = QUERYABLE_SCHEMA.tables.map((t) => t.name);
-
-    const dbColumns = await sql`
-      SELECT table_name, column_name
-      FROM information_schema.columns
-      WHERE table_schema = 'public'
-        AND table_name = ANY(${pgTextArray(tableNames)}::text[])
-      ORDER BY table_name, ordinal_position
-    `;
-
-    const schemaColumnsByTable = new Map<string, Set<string>>();
-    for (const t of QUERYABLE_SCHEMA.tables) {
-      schemaColumnsByTable.set(t.name, new Set(t.columns.map((c) => c.name)));
-    }
+    const byRelation = await loadDbColumns();
 
     const missing: string[] = [];
-    for (const row of dbColumns) {
-      const table = row.table_name as string;
-      const column = row.column_name as string;
-      const schemaCols = schemaColumnsByTable.get(table);
-      if (!schemaCols) continue;
-
-      const omitted = INTENTIONALLY_OMITTED[table];
-      if (omitted?.has(column)) continue;
-
-      if (!schemaCols.has(column)) {
-        missing.push(`${table}.${column}`);
+    for (const t of QUERYABLE_SCHEMA.tables) {
+      const dbCols = byRelation.get(t.name);
+      if (!dbCols) continue; // asserted non-empty by the coverage test above
+      const schemaCols = new Set(t.columns.map((c) => c.name));
+      const omitted = INTENTIONALLY_OMITTED[t.name];
+      for (const column of dbCols) {
+        if (omitted?.has(column)) continue;
+        if (!schemaCols.has(column)) missing.push(`${t.name}.${column}`);
       }
     }
 
     expect(missing, `DB columns missing from QUERYABLE_SCHEMA:\n  ${missing.join('\n  ')}`).toEqual(
       []
     );
+  });
+
+  it('should not list a schema column the physical table does not have', async (ctx) => {
+    const databaseUrl = inject('databaseUrl');
+    if (!databaseUrl) {
+      ctx.skip();
+      return;
+    }
+    process.env.DATABASE_URL = databaseUrl;
+
+    // The direction that was missing. A phantom column is injected into the
+    // generated CTE's explicit projection, so it does not degrade one query —
+    // it breaks EVERY query against the relation. This is what let
+    // `behavior_versions.sources` reach prod.
+    const byRelation = await loadDbColumns();
+
+    const phantom: string[] = [];
+    for (const t of QUERYABLE_SCHEMA.tables) {
+      const dbCols = byRelation.get(t.name);
+      if (!dbCols) continue; // asserted non-empty by the coverage test above
+      const derived = DERIVED_COLUMNS[t.name];
+      for (const c of t.columns) {
+        if (derived?.has(c.name)) continue;
+        if (!dbCols.has(c.name)) phantom.push(`${t.name}.${c.name}`);
+      }
+    }
+
+    expect(
+      phantom,
+      `QUERYABLE_SCHEMA columns with no physical column (every query against ` +
+        `these relations fails):\n  ${phantom.join('\n  ')}`
+    ).toEqual([]);
   });
 
   it('should execute graph CTEs with local and public relationship types only', async (ctx) => {

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -31,6 +31,7 @@ import {
   type ColumnDef,
   formatUnknownTablesError,
   QUERYABLE_TABLE_NAMES,
+  RETIRED_RELATION_NAMES,
   SAFE_COLUMN_DEFS,
   validateTableQuery,
 } from './table-schema';
@@ -592,12 +593,22 @@ export function buildScopedQuery(
           connectionRowVisibility('cn') +
           ')'
       );
-    } else if (table === 'watchers') {
+    } else if (table === 'behaviors') {
+      // Scoped on `watchers.organization_id` (NOT NULL), NOT through an
+      // entity-existence join.
+      //
+      // The old predicate was `EXISTS (SELECT 1 FROM entities ent WHERE ent.id =
+      // ANY(i.entity_ids) AND ent.organization_id = $org)`. `entity_ids` is
+      // NULLABLE and org-scoped Behaviors carry NULL, so every entity-less
+      // Behavior was structurally invisible — `SELECT count(*) FROM behaviors`
+      // returned a confident wrong number while `behaviors.list` showed them.
+      // The direct column is both COMPLETE (no row can lack it) and strictly
+      // fail-closed (it is the tenancy key itself, so this cannot widen
+      // cross-org visibility the way an EXISTS over a joined table could).
       // security-allowed: see block comment above the for-loop
       ctes.push(
-        `"${safeName}" AS (SELECT ${sel(table, 'i')} FROM public.watchers i WHERE EXISTS (` +
-          'SELECT 1 FROM public.entities ent WHERE ent.id = ANY(i.entity_ids) ' +
-          `AND ent.organization_id = ${orgP}))`
+        `"${safeName}" AS (SELECT ${sel(table, 'i')} FROM public.watchers i ` +
+          `WHERE i.organization_id = ${orgP})`
       );
     } else if (table === 'canvas_windows') {
       // Watcher windows as canvas chains (view over events; migration
@@ -623,13 +634,17 @@ export function buildScopedQuery(
           eventResourceVisibility('ev') +
           '))'
       );
-    } else if (table === 'watcher_versions') {
+    } else if (table === 'behavior_versions') {
+      // `watcher_versions` carries no organization_id of its own, so it inherits
+      // the parent Behavior's. Same fix as the `behaviors` CTE: the previous
+      // entity-existence join hid every version of an entity-less Behavior. The
+      // INNER JOIN is the tenancy boundary — a version whose parent is missing
+      // or in another org yields no row, so this stays fail-closed.
       // security-allowed: see block comment above the for-loop
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table, 'wv')} FROM public.watcher_versions wv ` +
-          'JOIN public.watchers w ON w.id = wv.watcher_id WHERE EXISTS (' +
-          'SELECT 1 FROM public.entities ent WHERE ent.id = ANY(w.entity_ids) ' +
-          `AND ent.organization_id = ${orgP}))`
+          'JOIN public.watchers w ON w.id = wv.watcher_id ' +
+          `WHERE w.organization_id = ${orgP})`
       );
     } else if (table === 'oauth_clients') {
       ctes.push(
@@ -649,11 +664,25 @@ export function buildScopedQuery(
       // Every feed derives from a connection (`connection_id` NOT NULL), so a
       // private connection's feeds (display_name, config, last_error) are
       // per-user too — gate via the owning connection's visibility.
+      //
+      // This uses the ROW form (`compileConnectionRowVisibility`), matching
+      // `manage_feeds`. It previously used the FK form, which is built for
+      // EVENT tables and additionally requires `vc.deleted_at IS NULL` — so a
+      // live feed on a soft-deleted connection vanished from SQL while
+      // `client.feeds.get` still returned it. Feeds carry their own
+      // `deleted_at`; the CONNECTION's soft-delete is not the feed's, and
+      // query_sql is an audit surface. Same structural-visibility class as the
+      // Behaviors defect: the SDK and the SQL view must agree on what exists.
+      // The row form also honors the legacy-unowned (`created_by IS NULL`)
+      // admin arm, which is the other half of the SDK/SQL disagreement.
       // security-allowed: see block comment above the for-loop
       ctes.push(
-        `"${safeName}" AS (SELECT ${sel(table, 'fd')} FROM public.feeds fd WHERE fd.organization_id = ${orgP}` +
-          eventConnVisibility('fd') +
-          ')'
+        `"${safeName}" AS (SELECT ${sel(table, 'fd')} FROM public.feeds fd ` +
+          `WHERE fd.organization_id = ${orgP} ` +
+          `AND EXISTS (SELECT 1 FROM public.connections fc ` +
+          `WHERE fc.id = fd.connection_id AND fc.organization_id = ${orgP}` +
+          connectionRowVisibility('fc') +
+          '))'
       );
     } else if (table === 'channel_messages') {
       // Chat transcript rows. `text` is verbatim channel content, so the CTE
@@ -878,6 +907,23 @@ export async function executeDataSources(
         if (restricted.length > 0) {
           throw new Error(
             `Source '${name}': table(s) require admin access: ${[...new Set(restricted)].join(', ')}`
+          );
+        }
+
+        // A source saved against a RETIRED relation name must fail loudly. The
+        // agent-facing relations were renamed (`watchers` → `behaviors`), and
+        // unknown refs compile as entity-type CTEs rather than erroring — so a
+        // previously-saved `FROM watchers` would silently resolve to a
+        // nonexistent entity type and return ZERO ROWS instead of the Behaviors
+        // it used to. This check runs on every execution (not just save, where
+        // `validateEntitySlugs` applies) precisely because the rows it protects
+        // were saved BEFORE the rename.
+        const retired = tableRefs.filter((t) => RETIRED_RELATION_NAMES.has(t));
+        if (retired.length > 0) {
+          throw new Error(
+            `Source '${name}': table(s) renamed: ${[...new Set(retired)]
+              .map((t) => `${t} → ${RETIRED_RELATION_NAMES.get(t)}`)
+              .join(', ')}. Update the query to use the current name.`
           );
         }
 

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -679,6 +679,7 @@ export function buildScopedQuery(
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table, 'fd')} FROM public.feeds fd ` +
           `WHERE fd.organization_id = ${orgP} ` +
+          // security-allowed: see block comment above the for-loop
           `AND EXISTS (SELECT 1 FROM public.connections fc ` +
           `WHERE fc.id = fd.connection_id AND fc.organization_id = ${orgP}` +
           connectionRowVisibility('fc') +

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -15,6 +15,16 @@
  * A column is only safe here if it is EXCLUDED or REDACTED. "It's only reachable
  * by admins" is not sufficient — `connections` and `feeds` are deliberately NOT
  * in ADMIN_ONLY_QUERYABLE_TABLES, and query_sql is member-safe.
+ *
+ * NAMING: `name` here is the AGENT-FACING relation name, which is not always the
+ * physical table. The agent-facing product name is Behavior, so the engine's
+ * `watchers` / `watcher_versions` tables are exposed as `behaviors` /
+ * `behavior_versions` (see {@link PHYSICAL_TABLE_BY_RELATION}); column
+ * identifiers stay internal vocabulary (`watcher_id` remains the join key).
+ * A column listed here MUST exist on the physical table: `buildColumnList`
+ * emits an explicit projection into the generated CTE, so a stale name breaks
+ * EVERY query against the relation — including ones that reference no column at
+ * all. The drift test pins both directions.
  */
 
 import { REDACTED_SENTINEL } from '@lobu/core';
@@ -399,13 +409,17 @@ export const QUERYABLE_SCHEMA = {
           'agent_id',
           'device_worker_id',
           'external_tenant_id',
-          'credential_mode'
+          'credential_mode',
+          // Connector-health alert claim (NULL → healthy). A plain timestamptz,
+          // no secret: the SDK returns it, so SQL must too or org health can't
+          // be audited from query_sql.
+          'unhealthy_alerted_at'
         ),
       ],
     },
-    // watchers
+    // behaviors — physical table `watchers` (internal engine vocabulary).
     {
-      name: 'watchers',
+      name: 'behaviors',
       columns: cols(
         'id',
         'name',
@@ -468,9 +482,14 @@ export const QUERYABLE_SCHEMA = {
         'excerpts'
       ),
     },
-    // watcher_versions
+    // behavior_versions — physical table `watcher_versions`.
+    // NO `sources` column: that lives on `watchers`; a version row carries
+    // `version_sources`. It was listed here and, because the CTE emits an
+    // explicit projection, `wv."sources"` was injected into every query — the
+    // relation was 100% unqueryable with an error naming a column no caller
+    // wrote.
     {
-      name: 'watcher_versions',
+      name: 'behavior_versions',
       columns: cols(
         'id',
         'watcher_id',
@@ -478,7 +497,6 @@ export const QUERYABLE_SCHEMA = {
         'name',
         'description',
         'prompt',
-        'sources',
         'keying_config',
         'classifiers',
         'reactions_guidance',
@@ -707,6 +725,35 @@ export const QUERYABLE_SCHEMA = {
 export const QUERYABLE_TABLE_NAMES = new Set(QUERYABLE_SCHEMA.tables.map((t) => t.name));
 
 /**
+ * Exposed relation name → physical table, for the relations whose agent-facing
+ * name differs from the engine's.
+ *
+ * The agent-facing product name is Behavior; `watcher` is internal engine/DB
+ * vocabulary that must not reach an agent (AGENTS.md hard invariant). The
+ * allowlist error enumerates {@link QUERYABLE_TABLE_NAMES} verbatim to the
+ * caller, so exposing the physical names both leaked the vocabulary and told the
+ * agent that `behaviors` — the name every other tool uses — does not exist.
+ *
+ * Only the RELATION is renamed. Column identifiers stay internal
+ * (`behavior_versions.watcher_id`, `event_classifications.watcher_id`) because
+ * they are the real join keys and renaming them would desync the projection
+ * from the physical row.
+ *
+ * Every entry must be consumed by the CTE builder in `execute-data-sources`;
+ * a relation with no physical mapping falls through to the entity-type-slug
+ * branch and silently returns entities instead of erroring.
+ */
+const PHYSICAL_TABLE_BY_RELATION: ReadonlyMap<string, string> = new Map([
+  ['behaviors', 'watchers'],
+  ['behavior_versions', 'watcher_versions'],
+]);
+
+/** Physical table backing an exposed relation (identity when not renamed). */
+export function physicalTableFor(relation: string): string {
+  return PHYSICAL_TABLE_BY_RELATION.get(relation) ?? relation;
+}
+
+/**
  * Queryable tables that stay OWNER/ADMIN-only even when query_sql / metric_series
  * are member-accessible: the auth + identity tables. Members can read the
  * org's operational data (entities, events, connections, feeds, watchers, …) but
@@ -812,6 +859,27 @@ function outputAliases(sql: string): Set<string> {
   return out;
 }
 
+/**
+ * Physical table → exposed relation, so a caller who reached for the internal
+ * engine name is redirected instead of being told the table simply does not
+ * exist. Derived from {@link PHYSICAL_TABLE_BY_RELATION} so the two cannot drift.
+ */
+const RELATION_BY_PHYSICAL_TABLE: ReadonlyMap<string, string> = new Map(
+  [...PHYSICAL_TABLE_BY_RELATION].map(([relation, physical]) => [physical, relation])
+);
+
+/**
+ * Retired relation name → the name that replaced it, for callers that persisted
+ * a query BEFORE the rename. Same map as {@link RELATION_BY_PHYSICAL_TABLE}: a
+ * physical name that is no longer an exposed relation is exactly a retired one.
+ *
+ * `execute-data-sources` compiles an unknown table ref as an entity-type CTE
+ * rather than erroring, so without this a saved `FROM watchers` silently returns
+ * ZERO ROWS instead of failing. Stored queries are not rewritten by the rename,
+ * so the retired name must stay recognizable — as an ERROR, never as an alias.
+ */
+export const RETIRED_RELATION_NAMES: ReadonlyMap<string, string> = RELATION_BY_PHYSICAL_TABLE;
+
 /** Build one actionable error covering all unknown tables in a query. */
 export function formatUnknownTablesError(tableNames: Iterable<string>): string {
   const names = [...new Set(tableNames)].sort();
@@ -820,9 +888,20 @@ export function formatUnknownTablesError(tableNames: Iterable<string>): string {
       ? `Unknown table '${names[0]}'`
       : `Unknown tables ${names.map((name) => `'${name}'`).join(', ')}`;
   const queryableTables = [...QUERYABLE_TABLE_NAMES].sort().join(', ');
+  // A caller who wrote the internal engine name gets the exposed relation, not
+  // a dead end. Built from the reverse map so it can never name a relation that
+  // is not actually queryable.
+  const redirects = names
+    .map((name) => {
+      const relation = RELATION_BY_PHYSICAL_TABLE.get(name);
+      return relation ? `'${name}' is internal — query '${relation}' instead.` : null;
+    })
+    .filter((hint): hint is string => hint !== null);
   return (
     `${subject} — not in the queryable allowlist, so the query did not run. ` +
-    `This is an error, not an empty result. Queryable tables are: ${queryableTables}.`
+    `This is an error, not an empty result. ` +
+    (redirects.length > 0 ? `${redirects.join(' ')} ` : '') +
+    `Queryable tables are: ${queryableTables}.`
   );
 }
 

--- a/scripts/check-exposed-surface-naming.ts
+++ b/scripts/check-exposed-surface-naming.ts
@@ -8,6 +8,8 @@
  *   - ClientSDK discovery metadata, aliases, or namespace method names
  *   - the connector-sdk public reaction contract
  *   - server and web-client response types for shared public tool payloads
+ *   - query_sql's queryable-relation allowlist (QUERYABLE_SCHEMA table names),
+ *     which the unknown-table error enumerates verbatim to the caller
  *
  * TypeBox schema initializers are scanned under the core tool contracts and the
  * server's tool/type sources. Other source scans are deliberately limited to
@@ -392,6 +394,67 @@ function scanNamespaceSurface(file: string, violations: Violation[]): void {
   scanFile(file, null);
 }
 
+/**
+ * query_sql's queryable-relation allowlist.
+ *
+ * BLIND SPOT THIS CLOSES: `QUERYABLE_SCHEMA` in
+ * `packages/server/src/utils/table-schema.ts` is agent-facing vocabulary — the
+ * allowlist error enumerates every relation name verbatim to the caller — but
+ * `utils/` was in NO scanned directory, and the name reaches the agent through
+ * a runtime `[...QUERYABLE_TABLE_NAMES].join(', ')` rather than a static
+ * literal, so neither the directory scans nor the literal scans could have
+ * seen it. `watchers` / `watcher_versions` were exposed to agents for the
+ * entire life of this guard while it reported clean.
+ *
+ * Scanning the whole file would fire on every legitimate internal use (physical
+ * table names in the CTE builder, `watcher_id` columns, comments). What is
+ * agent-facing is precisely the `name:` of each entry in the
+ * `QUERYABLE_SCHEMA.tables` array, so that is what is checked — the exposed
+ * relation names only, not the physical mapping beside them.
+ */
+function scanQueryableRelationNames(
+  file: string,
+  violations: Violation[]
+): void {
+  const source = parse(file);
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === "QUERYABLE_SCHEMA" &&
+      node.initializer &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      for (const property of node.initializer.properties) {
+        if (
+          !ts.isPropertyAssignment(property) ||
+          propertyNameText(property.name) !== "tables" ||
+          !ts.isArrayLiteralExpression(property.initializer)
+        ) {
+          continue;
+        }
+        for (const entry of property.initializer.elements) {
+          if (!ts.isObjectLiteralExpression(entry)) continue;
+          for (const field of entry.properties) {
+            if (
+              ts.isPropertyAssignment(field) &&
+              propertyNameText(field.name) === "name" &&
+              ts.isStringLiteral(field.initializer) &&
+              BANNED.test(field.initializer.text)
+            ) {
+              addViolation(violations, file, source, field.initializer);
+            }
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+}
+
 /** Published declaration text, including JSDoc. */
 function scanFullText(file: string, violations: Violation[]): void {
   const lines = readFileSync(file, "utf8").split("\n");
@@ -425,6 +488,13 @@ for (const dir of [
     scanTypeBoxSchemas(file, violations);
   }
 }
+
+// query_sql's queryable-relation allowlist: enumerated verbatim to agents in
+// the unknown-table error, so the relation names are agent-facing vocabulary.
+scanQueryableRelationNames(
+  join(REPO_ROOT, "packages/server/src/utils/table-schema.ts"),
+  violations
+);
 
 // Tool names/descriptions/titles and SDK discovery text/names/aliases.
 for (const file of [


### PR DESCRIPTION
## What

A live audit of the MCP tool surface (271 calls against prod) plus the connector
health path surfaced defects that share one shape: **the system reported success
while returning wrong or incomplete data**. This closes the blockers and majors.

Five concerns, one branch, no file overlap between them.

### 1. Connector health was wrong in both directions
`classify()` had no rule between "every feed failing" (Rule A) and "newest
success is stale" (Rule C). A connection whose feeds were auto-paused *because*
they failed reported **fully healthy** as long as one feed survived.

Prod evidence: LinkedIn connection 412 — feeds 419-428 at `consecutive_failures`
9-10, all `paused`, `last_error='worker_claim_timeout'`, nothing synced since
2026-07-18. Feed 429 alone still worked, so `10 !== 11` and the connection showed
`unhealthy_alerted_at: null`.

Adds Rule D (`feeds_degraded`) at a >=50% failing ratio **and** a
minimum-expected-feeds floor of 3, so a 2-feed connection with one bad feed does
not page an operator.

### 2. Incremental sync cursors could never recover
Only HTTP 410 counted as "cursor dead"; every other status threw. Since
`run-lifecycle` preserves the checkpoint on a failed run, a token rejected any
other way could **never** be cleared.

Prod evidence: Calendar feed 442 403-ing on every run with
`ACCESS_TOKEN_SCOPE_INSUFFICIENT` against a `syncToken` minted under a superseded
grant — while the scope *is* granted and `connections.test` returns "Credentials
valid". Dark since 2026-07-18.

A rejected token is now dropped and the sync falls back to a full resync exactly
once — bounded, so a genuinely-missing scope surfaces instead of looping.
YouTube had the same class: its guard tracked *that a restart happened* rather
than *which token was dead*, letting pagination re-enter the dead cursor. It now
tracks the rejected tokens, and previously-unbounded `paginateByCursor` call
sites in that file take an explicit page ceiling.

### 3. `search_memory` recall lied about what it found
- `min_similarity` was **hardcoded to 0.4** at the call site, so the documented
  0.0-1.0 knob was inert (sweeping 0 -> 1.0 never changed the result set;
  `min_similarity: 1` returned rows scoring 0.46) and its 0.3 default was
  silently overridden. It now governs both entity fuzzy matching and content
  recall.
- The `content` facet was omitted entirely on zero hits — indistinguishable from
  "content search never ran", so an agent concludes the workspace knows nothing.
  It now always emits.

### 4. Behavior references were never resolved
`agent_id` and `keying_config.entity_type` are free-text columns with no FK. A
bad `agent_id` yielded a Behavior the scheduler silently skips (it joins
`watchers` -> `agents`); a bad `entity_type` made
`deriveWatcherExtractionSchema()` return null, which makes `complete_window`
**skip extraction validation entirely** and void the output contract. Its sibling
`entity_id` was already validated, so the pair was inconsistent. Both are now
validated on create, update, and create_version.

### 5. `query_sql`'s Behavior surface
- `behavior_versions` listed a `sources` column that **has never existed** on
  that table (it lives on `watchers`; versions carry `version_sources`). The CTE
  emits an explicit column list, so `wv."sources"` was injected into every query
  — even `SELECT 1 AS one FROM ...`. The relation was 100% unqueryable with an
  error naming a column the caller never wrote.
- The `watchers` CTE scoped through `entity_ids`, which is nullable, so
  org-scoped Behaviors were structurally invisible — a confident wrong count.
- Relations are now named for agents (`behaviors` / `behavior_versions`);
  internal column identifiers stay engine vocabulary. **Because an unknown table
  ref compiles as an entity-type CTE rather than erroring**, a query saved before
  the rename would have silently returned zero rows — retired names are now
  rejected with the replacement named.
- Also projects `connections.unhealthy_alerted_at` so org health is auditable in
  SQL, and gates `feeds` on the row form so SQL shows what the SDK shows.

## Testing

Every fix has a test that was **verified to fail against the unfixed code**.

Sample mutation check — removing the retired-name guard:

```
 13 pass
  2 fail
error: expect(received).toThrow(expected)
Expected pattern: /watcher_versions → behavior_versions/
Received message: "Data source 'dead' failed: sql.begin is not a function..."
```

The error text is itself the proof: without the guard, execution reaches
`sql.begin`, i.e. the retired name was accepted and compiled as an entity CTE —
exactly the silent-zero-rows path. Restored:

```
 15 pass
  0 fail
```

Suites run (all green):
- `query-sql-behavior-exposure.test.ts` — 15 pass
- `table-schema.test.ts` (vitest) — 19 pass
- `connector-health-alert.test.ts` + `connector-health-reauth-notify.test.ts` — 12 pass
- `behavior-reference-validation.test.ts` + `search-memory-recall-contract.test.ts` — 14 pass
- `google_calendar.test.ts` + `youtube.test.ts` — 21 pass

The connector-health run logs confirm the boundary: the LinkedIn shape
(11 feeds / 10 failing) trips `feeds_degraded`, the 3-feed boundary case fires,
and the 2-feed case stays quiet.

`make pre-pr` — all 6 gates clean, including exposed-surface naming.
`make typecheck` — clean.

## Not covered

- No live third-party sync was re-run after these changes; the Calendar fix is
  proven against mocked 410/403 responses, not a real Google call. The poisoned
  checkpoint on the prod connection is not retroactively cleared by this PR —
  the next run clears it.
- Private-org cross-tenant read isolation remains untested (every non-member org
  reachable from the audit account is public).
- Zero-feed `apple.computer_use` connections tripping `zero_feeds` is a separate
  triage, deliberately not folded in here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->