### PR TITLE
fix(server): pre-flight the device pin on connection update

### DIFF
--- a/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
+++ b/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
@@ -163,6 +163,38 @@ describe("connections.update device pin pre-flight", () => {
 		expect(await pinOf(loser)).toBeNull();
 	});
 
+	it("rejects a combined update atomically, persisting nothing", async () => {
+		// The guard must run BEFORE the general update commits. Rejecting after it
+		// would return an error while silently keeping the display_name change —
+		// a partial write the caller has no reason to expect, and no way to see.
+		const taken = await seedDevice("Taken");
+		await seedConnectionOnDevice(taken);
+		const mover = await seedConnectionOnDevice(null);
+
+		const [before] = (await sql`
+      SELECT display_name FROM connections WHERE id = ${mover}
+    `) as unknown as Array<{ display_name: string }>;
+
+		const result = (await manageConnections(
+			{
+				action: "update",
+				connection_id: mover,
+				display_name: "Renamed By A Rejected Update",
+				device_worker_id: taken,
+			},
+			{} as Env,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(String(result.error)).toMatch(/already assigned to that device/i);
+
+		const [after] = (await sql`
+      SELECT display_name FROM connections WHERE id = ${mover}
+    `) as unknown as Array<{ display_name: string }>;
+		expect(after.display_name).toBe(before.display_name);
+		expect(await pinOf(mover)).toBeNull();
+	});
+
 	it("still allows re-pinning to a free device", async () => {
 		const inUse = await seedDevice("In Use");
 		const free = await seedDevice("Free");

--- a/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
+++ b/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
@@ -19,6 +19,7 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import type { Env } from "../../index";
 import { manageConnections } from "../../tools/admin/manage_connections";
+import { isConnectionDevicePinUniqueViolation } from "../../utils/connections";
 import type { ToolContext } from "../../tools/registry";
 import { initWorkspaceProvider } from "../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
@@ -120,6 +121,36 @@ describe("connections.update device pin pre-flight", () => {
 		// Neither row is mutated by a rejected update.
 		expect(await pinOf(occupant)).toBe(macMini);
 		expect(await pinOf(mover)).toBe(macBook);
+	});
+
+	it("translates a lost race (raw 23505) into the same readable error", async () => {
+		// The pre-flight is an unlocked SELECT, so two replicas can both observe
+		// the device as free and race into the index; the loser must not surface
+		// the driver's constraint text. A true cross-replica interleaving is not
+		// reachable from a single-process test — the pre-flight always sees the
+		// committed winner — so this drives the recovery path directly: perform
+		// the write the loser would perform, and assert the violation is
+		// recognised as this index's rather than propagating raw.
+		const contested = await seedDevice("Contested");
+		const holder = await seedConnectionOnDevice(contested);
+		const loser = await seedConnectionOnDevice(null);
+
+		let caught: unknown;
+		try {
+			await sql`
+        UPDATE connections SET device_worker_id = ${contested}::uuid
+        WHERE id = ${loser}
+      `;
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(caught).toBeDefined();
+		expect(isConnectionDevicePinUniqueViolation(caught)).toBe(true);
+
+		// The winner keeps the device; the loser is untouched by the failed write.
+		expect(await pinOf(holder)).toBe(contested);
+		expect(await pinOf(loser)).toBeNull();
 	});
 
 	it("still allows re-pinning to a free device", async () => {

--- a/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
+++ b/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
@@ -123,14 +123,24 @@ describe("connections.update device pin pre-flight", () => {
 		expect(await pinOf(mover)).toBe(macBook);
 	});
 
-	it("translates a lost race (raw 23505) into the same readable error", async () => {
+	it("recognises the index violation a lost race would raise", async () => {
 		// The pre-flight is an unlocked SELECT, so two replicas can both observe
-		// the device as free and race into the index; the loser must not surface
-		// the driver's constraint text. A true cross-replica interleaving is not
-		// reachable from a single-process test — the pre-flight always sees the
-		// committed winner — so this drives the recovery path directly: perform
-		// the write the loser would perform, and assert the violation is
-		// recognised as this index's rather than propagating raw.
+		// the device as free and race into the index; `handleUpdate` catches that
+		// violation and returns the same readable error.
+		//
+		// The catch branch is NOT reachable in-process, and deliberately so: the
+		// pre-flight predicate mirrors the index predicate exactly — same
+		// (organization_id, connector_key, device_worker_id), same
+		// `deleted_at IS NULL` — so every row the index would reject, the
+		// pre-flight already caught. Only a genuine cross-process interleaving
+		// gets past it, which a single-process test cannot construct without
+		// stubbing the driver.
+		//
+		// So this asserts the part that IS testable and that the branch depends
+		// on: that a real violation raised by the live index is recognised by
+		// `isConnectionDevicePinUniqueViolation`. If the constraint were renamed
+		// or the driver stopped surfacing `constraint_name`, this fails here
+		// rather than silently leaking raw 23505 text to a user in prod.
 		const contested = await seedDevice("Contested");
 		const holder = await seedConnectionOnDevice(contested);
 		const loser = await seedConnectionOnDevice(null);

--- a/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
+++ b/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
@@ -1,0 +1,158 @@
+/**
+ * connections.update must refuse to re-pin onto a device another live
+ * connection already holds — with a readable error, not a raw 23505.
+ *
+ * `idx_connections_org_connector_device_live` is UNIQUE on
+ * (organization_id, connector_key, device_worker_id) for live rows. The CREATE
+ * path already pre-flights this (see the duplicate check in crud.ts, whose
+ * comment says it exists so callers get a clean error "instead of hitting the
+ * partial unique index as a primary exception"). The UPDATE path did not, so
+ * re-assigning a connection to an occupied device surfaced the driver's
+ * constraint violation to the caller.
+ *
+ * Sibling of the background-poll instance fixed in #2286; that one degrades to
+ * NULL because a poll has no user to talk to. This is user-initiated, so the
+ * correct behaviour is a clean error — silently unpinning someone else's
+ * connection would be wrong here.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageConnections } from "../../tools/admin/manage_connections";
+import type { ToolContext } from "../../tools/registry";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestConnection,
+	createTestConnectorDefinition,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
+
+const CONNECTOR_KEY = "apple.computer_use";
+const sql = getTestDb();
+
+describe("connections.update device pin pre-flight", () => {
+	let orgId: string;
+	let userId: string;
+	let ctx: ToolContext;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, user, ctx: ownerCtx } = await seedOwnerContext({
+			orgName: "Pin Preflight Org",
+		});
+		orgId = org.id;
+		userId = user.id;
+		ctx = ownerCtx;
+		await createTestConnectorDefinition({
+			organization_id: orgId,
+			key: CONNECTOR_KEY,
+			name: "Computer Use",
+		});
+	});
+
+	async function seedDevice(label: string): Promise<string> {
+		const workerId = `mac-${Math.random().toString(36).slice(2, 10)}`;
+		const [row] = (await sql`
+      INSERT INTO device_workers (
+        user_id, worker_id, platform, capabilities, label,
+        organization_id, last_seen_at
+      ) VALUES (
+        ${userId}, ${workerId}, 'macos', ${sql.json(["computer_use"])},
+        ${label}, ${orgId}, NOW()
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: string }>;
+		return String(row.id);
+	}
+
+	async function seedConnectionOnDevice(deviceId: string | null): Promise<number> {
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: CONNECTOR_KEY,
+			created_by: userId,
+		});
+		if (deviceId) {
+			await sql`
+        UPDATE connections SET device_worker_id = ${deviceId}::uuid WHERE id = ${conn.id}
+      `;
+		}
+		return conn.id;
+	}
+
+	async function update(
+		connectionId: number,
+		deviceWorkerId: string | null,
+	): Promise<Record<string, unknown>> {
+		return (await manageConnections(
+			{
+				action: "update",
+				connection_id: connectionId,
+				device_worker_id: deviceWorkerId,
+			},
+			{} as Env,
+			ctx,
+		)) as Record<string, unknown>;
+	}
+
+	async function pinOf(id: number): Promise<string | null> {
+		const [row] = (await sql`
+      SELECT device_worker_id FROM connections WHERE id = ${id}
+    `) as unknown as Array<{ device_worker_id: string | null }>;
+		return row?.device_worker_id ?? null;
+	}
+
+	it("returns a readable error instead of a raw constraint violation", async () => {
+		const macMini = await seedDevice("Mac mini");
+		const macBook = await seedDevice("MacBook Pro");
+		const occupant = await seedConnectionOnDevice(macMini);
+		const mover = await seedConnectionOnDevice(macBook);
+
+		const result = await update(mover, macMini);
+
+		// The message must name the occupying connection, and must NOT be the
+		// driver's constraint text leaking through.
+		expect(String(result.error)).toContain(String(occupant));
+		expect(String(result.error)).toMatch(/already assigned to that device/i);
+		expect(String(result.error)).not.toMatch(/duplicate key|violates unique/i);
+
+		// Neither row is mutated by a rejected update.
+		expect(await pinOf(occupant)).toBe(macMini);
+		expect(await pinOf(mover)).toBe(macBook);
+	});
+
+	it("still allows re-pinning to a free device", async () => {
+		const inUse = await seedDevice("In Use");
+		const free = await seedDevice("Free");
+		await seedConnectionOnDevice(inUse);
+		const mover = await seedConnectionOnDevice(null);
+
+		const result = await update(mover, free);
+
+		expect(result.error).toBeUndefined();
+		expect(await pinOf(mover)).toBe(free);
+	});
+
+	it("still allows clearing a pin", async () => {
+		const device = await seedDevice("Clearable");
+		const conn = await seedConnectionOnDevice(device);
+
+		const result = await update(conn, null);
+
+		expect(result.error).toBeUndefined();
+		expect(await pinOf(conn)).toBeNull();
+	});
+
+	it("allows re-pinning a connection to the device it already holds", async () => {
+		// The guard excludes the row being updated, so a no-op re-pin must not
+		// report the connection as colliding with itself.
+		const device = await seedDevice("Self");
+		const conn = await seedConnectionOnDevice(device);
+
+		const result = await update(conn, device);
+
+		expect(result.error).toBeUndefined();
+		expect(await pinOf(conn)).toBe(device);
+	});
+});

--- a/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
+++ b/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
@@ -123,76 +123,44 @@ describe("connections.update device pin pre-flight", () => {
 		expect(await pinOf(mover)).toBe(macBook);
 	});
 
-	it("recognises the index violation a lost race would raise", async () => {
-		// The pre-flight is an unlocked SELECT, so two replicas can both observe
-		// the device as free and race into the index; `handleUpdate` catches that
-		// violation and returns the same readable error.
-		//
-		// The catch branch is NOT reachable in-process, and deliberately so: the
-		// pre-flight predicate mirrors the index predicate exactly — same
-		// (organization_id, connector_key, device_worker_id), same
-		// `deleted_at IS NULL` — so every row the index would reject, the
-		// pre-flight already caught. Only a genuine cross-process interleaving
-		// gets past it, which a single-process test cannot construct without
-		// stubbing the driver.
-		//
-		// So this asserts the part that IS testable and that the branch depends
-		// on: that a real violation raised by the live index is recognised by
-		// `isConnectionDevicePinUniqueViolation`. If the constraint were renamed
-		// or the driver stopped surfacing `constraint_name`, this fails here
-		// rather than silently leaking raw 23505 text to a user in prod.
+	it("rolls a lost race back entirely, error only, nothing persisted", async () => {
+		// Both updates pass the pre-flight (the device is free when each reads),
+		// then collide in the index. Deterministic because the winner's
+		// transaction is held open until the loser has already passed its
+		// pre-flight — no scan-order or timing luck involved.
 		const contested = await seedDevice("Contested");
-		const holder = await seedConnectionOnDevice(contested);
 		const loser = await seedConnectionOnDevice(null);
-
-		let caught: unknown;
-		try {
-			await sql`
-        UPDATE connections SET device_worker_id = ${contested}::uuid
-        WHERE id = ${loser}
-      `;
-		} catch (err) {
-			caught = err;
-		}
-
-		expect(caught).toBeDefined();
-		expect(isConnectionDevicePinUniqueViolation(caught)).toBe(true);
-
-		// The winner keeps the device; the loser is untouched by the failed write.
-		expect(await pinOf(holder)).toBe(contested);
-		expect(await pinOf(loser)).toBeNull();
-	});
-
-	it("rejects a combined update atomically, persisting nothing", async () => {
-		// The guard must run BEFORE the general update commits. Rejecting after it
-		// would return an error while silently keeping the display_name change —
-		// a partial write the caller has no reason to expect, and no way to see.
-		const taken = await seedDevice("Taken");
-		await seedConnectionOnDevice(taken);
-		const mover = await seedConnectionOnDevice(null);
-
 		const [before] = (await sql`
-      SELECT display_name FROM connections WHERE id = ${mover}
+      SELECT display_name FROM connections WHERE id = ${loser}
     `) as unknown as Array<{ display_name: string }>;
 
-		const result = (await manageConnections(
-			{
-				action: "update",
-				connection_id: mover,
-				display_name: "Renamed By A Rejected Update",
-				device_worker_id: taken,
-			},
-			{} as Env,
-			ctx,
-		)) as Record<string, unknown>;
+		// Winner: claims the device inside a transaction and holds it briefly, so
+		// the loser's pre-flight reads BEFORE the claim is visible. The hold is a
+		// fixed delay rather than a handshake — the loser must not gate the
+		// winner's commit, or the two deadlock on the index.
+		const winnerConn = await seedConnectionOnDevice(null);
+		const winner = sql.begin(async (tx) => {
+			await tx`
+        UPDATE connections SET device_worker_id = ${contested}::uuid
+        WHERE id = ${winnerConn}
+      `;
+			await new Promise((r) => setTimeout(r, 250));
+		});
+
+		// Loser: pre-flight sees the device free (winner uncommitted), proceeds to
+		// the write, blocks on the index until the winner commits, then loses.
+		await new Promise((r) => setTimeout(r, 50));
+		const [result] = await Promise.all([update(loser, contested), winner]);
 
 		expect(String(result.error)).toMatch(/already assigned to that device/i);
+		expect(String(result.error)).not.toMatch(/duplicate key|violates unique/i);
 
+		// Nothing of the loser's update survives.
 		const [after] = (await sql`
-      SELECT display_name FROM connections WHERE id = ${mover}
-    `) as unknown as Array<{ display_name: string }>;
+      SELECT display_name, device_worker_id FROM connections WHERE id = ${loser}
+    `) as unknown as Array<{ display_name: string; device_worker_id: string | null }>;
 		expect(after.display_name).toBe(before.display_name);
-		expect(await pinOf(mover)).toBeNull();
+		expect(after.device_worker_id).toBeNull();
 	});
 
 	it("still allows re-pinning to a free device", async () => {

--- a/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
+++ b/packages/server/src/__tests__/integration/connection-update-device-pin-preflight.test.ts
@@ -19,7 +19,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import type { Env } from "../../index";
 import { manageConnections } from "../../tools/admin/manage_connections";
-import { isConnectionDevicePinUniqueViolation } from "../../utils/connections";
 import type { ToolContext } from "../../tools/registry";
 import { initWorkspaceProvider } from "../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
@@ -150,7 +149,21 @@ describe("connections.update device pin pre-flight", () => {
 		// Loser: pre-flight sees the device free (winner uncommitted), proceeds to
 		// the write, blocks on the index until the winner commits, then loses.
 		await new Promise((r) => setTimeout(r, 50));
-		const [result] = await Promise.all([update(loser, contested), winner]);
+		const [result] = await Promise.all([
+			// A COMBINED update: the rename must roll back with the failed pin, or
+			// the caller sees an error while the database kept half the change.
+			manageConnections(
+				{
+					action: "update",
+					connection_id: loser,
+					display_name: "Renamed By A Lost Race",
+					device_worker_id: contested,
+				},
+				{} as Env,
+				ctx,
+			) as Promise<Record<string, unknown>>,
+			winner,
+		]);
 
 		expect(String(result.error)).toMatch(/already assigned to that device/i);
 		expect(String(result.error)).not.toMatch(/duplicate key|violates unique/i);

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1774,6 +1774,29 @@ export async function handleUpdate(
     nextSlug = updateExplicitSlug;
   }
 
+	// Same pre-flight the create path runs (see the duplicate check above):
+	// `idx_connections_org_connector_device_live` is UNIQUE on
+	// (organization_id, connector_key, device_worker_id) for live rows, so
+	// re-pointing this connection at a device another live connection already
+	// holds hits the index as a raw 23505 instead of a readable error. Only
+	// the create path was guarded; the update path was not.
+	if (nextDeviceWorkerId) {
+		const pinDup = (await sql`
+        SELECT id FROM connections
+        WHERE organization_id = ${organizationId}
+          AND connector_key = ${existing.connector_key}
+          AND device_worker_id = ${nextDeviceWorkerId}
+          AND deleted_at IS NULL
+          AND id <> ${args.connection_id}
+        LIMIT 1
+      `) as unknown as Array<{ id: number }>;
+		if (pinDup.length > 0) {
+			return {
+				error: `A ${existing.connector_key} connection (id: ${pinDup[0].id}) is already assigned to that device in this org.`,
+			};
+		}
+	}
+
   // biome-ignore lint/suspicious/noExplicitAny: postgres.js row shape
   let updated: any[];
   try {
@@ -1856,28 +1879,6 @@ export async function handleUpdate(
 		hasDeviceWorkerArg ||
 		(updateProfileDeviceWorkerId && !hasDeviceWorkerArg)
 	) {
-		// Same pre-flight the create path runs (see the duplicate check above):
-		// `idx_connections_org_connector_device_live` is UNIQUE on
-		// (organization_id, connector_key, device_worker_id) for live rows, so
-		// re-pointing this connection at a device another live connection already
-		// holds hits the index as a raw 23505 instead of a readable error. Only
-		// the create path was guarded; the update path was not.
-		if (nextDeviceWorkerId) {
-			const pinDup = (await sql`
-        SELECT id FROM connections
-        WHERE organization_id = ${organizationId}
-          AND connector_key = ${existing.connector_key}
-          AND device_worker_id = ${nextDeviceWorkerId}
-          AND deleted_at IS NULL
-          AND id <> ${args.connection_id}
-        LIMIT 1
-      `) as unknown as Array<{ id: number }>;
-			if (pinDup.length > 0) {
-				return {
-					error: `A ${existing.connector_key} connection (id: ${pinDup[0].id}) is already assigned to that device in this org.`,
-				};
-			}
-		}
 		// Any change to the pin (set or clear) drops DELETE/move tombstones.
 		// Re-pinning a live device also un-pauses so the connection can run again.
 		const previousError = (updated[0] as Record<string, unknown>)

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -47,6 +47,7 @@ import {
   connectionSlugFormatError,
   connectionSlugTaken,
   insertConnectionWithSlug,
+  isConnectionDevicePinUniqueViolation,
   isConnectionSlugUniqueViolation,
   resolveNewConnectionSlug,
 } from "../../../../utils/connections";
@@ -1883,7 +1884,12 @@ export async function handleUpdate(
 			.error_message as string | null;
 		const pinningDevice = nextDeviceWorkerId != null;
 		clearedDeviceTombstone = isDevicePinTombstone(previousError);
-		await sql`
+		// The pre-flight above is an unlocked SELECT, so two replicas can both
+		// observe the device as free and race into the index — the loser would
+		// otherwise surface the raw 23505 this fix exists to prevent. The index is
+		// the real arbiter; translate its violation into the same readable error.
+		try {
+			await sql`
       UPDATE connections
       SET device_worker_id = ${nextDeviceWorkerId},
           error_message = CASE
@@ -1903,6 +1909,24 @@ export async function handleUpdate(
         AND organization_id = ${organizationId}
         AND deleted_at IS NULL
     `;
+		} catch (err) {
+			if (isConnectionDevicePinUniqueViolation(err)) {
+				const winner = (await sql`
+          SELECT id FROM connections
+          WHERE organization_id = ${organizationId}
+            AND connector_key = ${existing.connector_key}
+            AND device_worker_id = ${nextDeviceWorkerId}
+            AND deleted_at IS NULL
+          LIMIT 1
+        `) as unknown as Array<{ id: number }>;
+				return {
+					error: winner[0]
+						? `A ${existing.connector_key} connection (id: ${winner[0].id}) is already assigned to that device in this org.`
+						: `That device is already assigned to another ${existing.connector_key} connection in this org.`,
+				};
+			}
+			throw err;
+		}
 		(updated[0] as Record<string, unknown>).device_worker_id =
 			nextDeviceWorkerId;
 		if (clearedDeviceTombstone) {

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1855,6 +1855,28 @@ export async function handleUpdate(
 		hasDeviceWorkerArg ||
 		(updateProfileDeviceWorkerId && !hasDeviceWorkerArg)
 	) {
+		// Same pre-flight the create path runs (see the duplicate check above):
+		// `idx_connections_org_connector_device_live` is UNIQUE on
+		// (organization_id, connector_key, device_worker_id) for live rows, so
+		// re-pointing this connection at a device another live connection already
+		// holds hits the index as a raw 23505 instead of a readable error. Only
+		// the create path was guarded; the update path was not.
+		if (nextDeviceWorkerId) {
+			const pinDup = (await sql`
+        SELECT id FROM connections
+        WHERE organization_id = ${organizationId}
+          AND connector_key = ${existing.connector_key}
+          AND device_worker_id = ${nextDeviceWorkerId}
+          AND deleted_at IS NULL
+          AND id <> ${args.connection_id}
+        LIMIT 1
+      `) as unknown as Array<{ id: number }>;
+			if (pinDup.length > 0) {
+				return {
+					error: `A ${existing.connector_key} connection (id: ${pinDup[0].id}) is already assigned to that device in this org.`,
+				};
+			}
+		}
 		// Any change to the pin (set or clear) drops DELETE/move tombstones.
 		// Re-pinning a live device also un-pauses so the connection can run again.
 		const previousError = (updated[0] as Record<string, unknown>)

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1843,7 +1843,7 @@ export async function handleUpdate(
       const lockedConnectionConfig = lockedSplit?.connectionConfig ?? null;
       const lockedReplaceConfig = lockedConnectionConfig ?? {};
 
-      return tx`
+      const rows = await tx`
         UPDATE connections
         SET display_name = COALESCE(${args.display_name ?? null}, display_name),
             slug = COALESCE(${nextSlug}, slug),
@@ -1861,6 +1861,38 @@ export async function handleUpdate(
         WHERE id = ${args.connection_id} AND organization_id = ${organizationId} AND deleted_at IS NULL
         RETURNING *
       `;
+      // The device pin writes in THIS transaction, not after it. The pre-flight
+      // above is an unlocked SELECT, so two replicas can both see the device as
+      // free and race into `idx_connections_org_connector_device_live`; the
+      // loser's violation must abort the general update too, or a combined
+      // request reports failure while persisting the display_name/config/auth
+      // changes it claims to have rejected.
+      if (
+        hasDeviceWorkerArg ||
+        (updateProfileDeviceWorkerId && !hasDeviceWorkerArg)
+      ) {
+        await tx`
+          UPDATE connections
+          SET device_worker_id = ${nextDeviceWorkerId},
+              error_message = CASE
+                WHEN error_message = ANY(${pgTextArray([...DEVICE_PIN_TOMBSTONE_MESSAGES])}::text[])
+                THEN NULL
+                ELSE error_message
+              END,
+              status = CASE
+                WHEN ${nextDeviceWorkerId != null}
+                 AND status = 'paused'
+                 AND error_message = ANY(${pgTextArray([...DEVICE_PIN_TOMBSTONE_MESSAGES])}::text[])
+                THEN 'active'
+                ELSE status
+              END,
+              updated_at = NOW()
+          WHERE id = ${args.connection_id}
+            AND organization_id = ${organizationId}
+            AND deleted_at IS NULL
+        `;
+      }
+      return rows;
     });
     if (updated.length === 0) return { error: "Connection not found" };
   } catch (err) {
@@ -1871,6 +1903,24 @@ export async function handleUpdate(
     }
 		if (isPersonalCredVisibilityViolation(err))
 			return { error: PERSONAL_CRED_ORG_VISIBILITY_ERROR };
+		// A replica won the device between our pre-flight and this write. The
+		// transaction aborted, so nothing was persisted — report the same readable
+		// collision the pre-flight would have.
+		if (isConnectionDevicePinUniqueViolation(err)) {
+			const winner = (await sql`
+        SELECT id FROM connections
+        WHERE organization_id = ${organizationId}
+          AND connector_key = ${existing.connector_key}
+          AND device_worker_id = ${nextDeviceWorkerId}
+          AND deleted_at IS NULL
+        LIMIT 1
+      `) as unknown as Array<{ id: number }>;
+			return {
+				error: winner[0]
+					? `A ${existing.connector_key} connection (id: ${winner[0].id}) is already assigned to that device in this org.`
+					: `That device is already assigned to another ${existing.connector_key} connection in this org.`,
+			};
+		}
     throw err;
   }
 
@@ -1885,49 +1935,6 @@ export async function handleUpdate(
 			.error_message as string | null;
 		const pinningDevice = nextDeviceWorkerId != null;
 		clearedDeviceTombstone = isDevicePinTombstone(previousError);
-		// The pre-flight above is an unlocked SELECT, so two replicas can both
-		// observe the device as free and race into the index — the loser would
-		// otherwise surface the raw 23505 this fix exists to prevent. The index is
-		// the real arbiter; translate its violation into the same readable error.
-		try {
-			await sql`
-      UPDATE connections
-      SET device_worker_id = ${nextDeviceWorkerId},
-          error_message = CASE
-            WHEN error_message = ANY(${pgTextArray([...DEVICE_PIN_TOMBSTONE_MESSAGES])}::text[])
-            THEN NULL
-            ELSE error_message
-          END,
-          status = CASE
-            WHEN ${pinningDevice}
-             AND status = 'paused'
-             AND error_message = ANY(${pgTextArray([...DEVICE_PIN_TOMBSTONE_MESSAGES])}::text[])
-            THEN 'active'
-            ELSE status
-          END,
-          updated_at = NOW()
-      WHERE id = ${args.connection_id}
-        AND organization_id = ${organizationId}
-        AND deleted_at IS NULL
-    `;
-		} catch (err) {
-			if (isConnectionDevicePinUniqueViolation(err)) {
-				const winner = (await sql`
-          SELECT id FROM connections
-          WHERE organization_id = ${organizationId}
-            AND connector_key = ${existing.connector_key}
-            AND device_worker_id = ${nextDeviceWorkerId}
-            AND deleted_at IS NULL
-          LIMIT 1
-        `) as unknown as Array<{ id: number }>;
-				return {
-					error: winner[0]
-						? `A ${existing.connector_key} connection (id: ${winner[0].id}) is already assigned to that device in this org.`
-						: `That device is already assigned to another ${existing.connector_key} connection in this org.`,
-				};
-			}
-			throw err;
-		}
 		(updated[0] as Record<string, unknown>).device_worker_id =
 			nextDeviceWorkerId;
 		if (clearedDeviceTombstone) {

--- a/packages/server/src/utils/connections.ts
+++ b/packages/server/src/utils/connections.ts
@@ -32,6 +32,7 @@ export class ConnectionSlugConflictError extends Error {
 
 const PG_UNIQUE_VIOLATION = '23505';
 const CONNECTION_SLUG_CONSTRAINT = 'connections_org_slug_unique';
+const CONNECTION_DEVICE_PIN_CONSTRAINT = 'idx_connections_org_connector_device_live';
 
 /** True when a thrown DB error is the per-org connection-slug unique violation. */
 export function isConnectionSlugUniqueViolation(err: unknown): boolean {
@@ -41,6 +42,24 @@ export function isConnectionSlugUniqueViolation(err: unknown): boolean {
   if (typeof e.constraint_name === 'string') return e.constraint_name === CONNECTION_SLUG_CONSTRAINT;
   // Fallback when the driver doesn't surface the constraint name.
   return typeof e.message === 'string' && e.message.includes(CONNECTION_SLUG_CONSTRAINT);
+}
+
+/**
+ * True when a thrown DB error is the per-(org, connector, device) live-pin
+ * unique violation. A pre-flight SELECT cannot prevent this on its own: two
+ * replicas can both observe a free device and race into the index, so the
+ * loser must still be translated into the same readable error rather than
+ * leaking the driver's constraint text.
+ */
+export function isConnectionDevicePinUniqueViolation(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { code?: unknown; constraint_name?: unknown; message?: unknown };
+  if (e.code !== PG_UNIQUE_VIOLATION) return false;
+  if (typeof e.constraint_name === 'string')
+    return e.constraint_name === CONNECTION_DEVICE_PIN_CONSTRAINT;
+  return (
+    typeof e.message === 'string' && e.message.includes(CONNECTION_DEVICE_PIN_CONSTRAINT)
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #2289.

## What

`idx_connections_org_connector_device_live` is UNIQUE on `(organization_id, connector_key, device_worker_id)` for live rows.

The **create** path already pre-flights this — its comment states the check exists so callers get a clean error *"instead of hitting the partial unique index as a primary exception"*. The **update** path never got the same treatment, so re-pointing a connection at a device another live connection holds surfaced the driver's raw `23505` straight to the caller.

## Fix

Port the same check to the update path, excluding the row being updated so a no-op re-pin (to the device a connection already holds) is not reported as colliding with itself.

Sibling of the background-poll instance fixed in #2286. That one degrades to `NULL` because a poll has no user to talk to; this one is **user-initiated**, so a clean error is the correct behaviour — silently unpinning someone else's connection would be wrong here. That difference is why it was split rather than bundled.

## Red → green

**RED** (at `origin/main`) — the failure is the bug verbatim:

```
× returns a readable error instead of a raw constraint violation
  → duplicate key value violates unique constraint "idx_connections_org_connector_device_live"
✓ still allows re-pinning to a free device
✓ still allows clearing a pin
✓ allows re-pinning a connection to the device it already holds
  Tests  1 failed | 3 passed (4)
```

**GREEN**: `4 passed (4)`.

The three controls guard the ways this fix could over-reach: it must not block re-pinning to a free device, must not block clearing a pin, and must not treat a connection's own device as a conflict.

## Class check

Six non-test writers of `device_worker_id`, all now accounted for:

| site | state |
|---|---|
| `device-reconcile.ts` pin | fixed in #2286 |
| `device-reconcile.ts` sweep | #2299 |
| `dispatch-chrome-action.ts:300` | already guarded (`findOwnerOf`) |
| `device-management.ts:459,530` | `SET NULL` — cannot violate a partial `IS NOT NULL` index |
| `crud.ts:1094` create | already guarded |
| `crud.ts:1866` update | **this PR** |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection device pinning to provide clear errors when a device is already assigned.
  * Prevented failed or conflicting updates from partially changing connection details.
  * Added reliable handling for concurrent attempts to claim the same device.
  * Confirmed that clearing pins, re-pinning to available devices, and no-op updates continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->