### PR TITLE
fix(server): read a conversation by its stored id, fenced on its row

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -765,6 +765,60 @@ describe("agent history routes", () => {
 		expect(body.messages.map((m) => m.id)).toEqual(["u-shared"]);
 	});
 
+	test("reads an OWNED conversation by its stored id, and denies a non-owner", async () => {
+		// The gap this closes: an owned conversation was listed under its stored id
+		// but no handler accepted that id — the read path re-derived one from the
+		// caller's own userId, so the id the listing returned resolved to nothing.
+		const sql = getDb();
+		const conversationId = `agent-1_${USER_ID}_${ORG_ID}_thread-owned-1`;
+		const jsonl =
+			`{"type":"session","version":3,"id":"s-owned","timestamp":"2026-07-23T10:00:00Z","cwd":"/w"}\n` +
+			`{"type":"message","id":"u-owned","parentId":null,"timestamp":"2026-07-23T10:00:01Z","message":{"role":"user","content":[{"type":"text","text":"Private note"}]}}\n`;
+		const runId = await insertRun({
+			organizationId: ORG_ID,
+			agentId: "agent-1",
+			conversationId,
+		});
+		await sql`
+			INSERT INTO public.agent_transcript_snapshot
+				(organization_id, agent_id, conversation_id, run_id, snapshot_jsonl, byte_size, terminal_status)
+			VALUES
+				(${ORG_ID}, 'agent-1', ${conversationId}, ${runId}, ${jsonl}, ${Buffer.byteLength(jsonl, "utf-8")}, 'completed')
+		`;
+		await sql`
+			INSERT INTO public.conversations
+				(organization_id, agent_id, platform, conversation_id, thread_id, kind, user_id, title)
+			VALUES
+				(${ORG_ID}, 'agent-1', 'web', ${conversationId}, 'thread-owned-1', 'owned', ${USER_ID}, 'Private note')
+			ON CONFLICT DO NOTHING
+		`;
+
+		const read = (userId: string) => {
+			setAuthProvider(() => ({
+				userId,
+				platform: "external",
+				agentId: "agent-1",
+				exp: Date.now() + 60_000,
+			}));
+			return orgContext.run({ organizationId: ORG_ID }, () =>
+				createApp().request(
+					`/api/v1/agents/agent-1/history/conversations/${encodeURIComponent(conversationId)}/messages`,
+					{ method: "GET", headers: { host: "localhost" } },
+				),
+			);
+		};
+
+		const owner = await read(USER_ID);
+		expect(owner.status).toBe(200);
+		const body = (await owner.json()) as { messages: Array<{ id: string }> };
+		expect(body.messages.map((m) => m.id)).toEqual(["u-owned"]);
+
+		// Another member of the SAME org must not read it. 404, not 403, so an
+		// unauthorized id is indistinguishable from one that does not exist.
+		const stranger = await read("user-history-stranger");
+		expect(stranger.status).toBe(404);
+	});
+
 	test("requires an enforced channel ACL for a non-owner org member", async () => {
 		const { channelMember, conversationId } =
 			await seedPlatformConversationAcl({ buildAcl: false });

--- a/packages/server/src/gateway/__tests__/conversations-list-scope.test.ts
+++ b/packages/server/src/gateway/__tests__/conversations-list-scope.test.ts
@@ -8,16 +8,21 @@ import {
 } from "./helpers/db-setup.js";
 
 /**
- * `scope: "all"` widens a listing to PLATFORM conversations. It must never
- * widen it to another user's private ones.
+ * The three listing scopes, and specifically the line between `shared` and
+ * `admin` — they return identical platform rows and differ ONLY on other
+ * users' owned rows, which is exactly why they must be separate names.
  *
- * Before this fix the scope predicate applied `kind='owned' AND user_id = …`
- * only when `scope === "user"`, so `scope: "all"` returned every user's owned
- * rows — and a conversation title is message text. That was inert only because
- * the read path re-derived its id from the caller's own userId, so the ids
- * handed out were not readable. Now that a conversation is addressable by its
- * stored id, listing someone else's would hand out a readable id, turning a
- * title disclosure into a full transcript disclosure.
+ * Before this fix there were two scopes, and the predicate applied
+ * `kind='owned' AND user_id = …` only when `scope === "user"`. So the
+ * end-user feed's `all` returned every user's owned rows — and a conversation
+ * title is message text. That was inert only because the read path re-derived
+ * a conversation's id from the caller's own userId, so the ids handed out were
+ * not readable. Making conversations addressable by their stored id would have
+ * turned that title disclosure into a full transcript disclosure.
+ *
+ * Narrowing it is not enough on its own: `manage_conversations` derives its
+ * scope from an already-checked admin/owner role and MUST still see every row,
+ * so the fix is a third scope rather than a blanket narrowing.
  */
 
 const ORG = "test-org-scope-all-owned";
@@ -49,11 +54,11 @@ afterAll(async () => {
 });
 
 describe("listConversations scope", () => {
-	test("scope=all excludes another user's owned conversations", async () => {
+	test("scope=shared excludes another user's owned conversations", async () => {
 		const rows = await listConversations({
 			organizationId: ORG,
 			agentId: AGENT,
-			scope: "all",
+			scope: "shared",
 			userId: OWNER,
 		});
 
@@ -63,17 +68,36 @@ describe("listConversations scope", () => {
 		expect(rows.map((r) => r.title)).not.toContain("Stranger private note");
 	});
 
-	test("scope=all still widens to platform conversations", async () => {
-		// The whole point of `all`: platform rows the user does not own are the
+	test("scope=shared still widens to platform conversations", async () => {
+		// The whole point of `shared`: platform rows the user does not own are the
 		// reason the scope exists. Narrowing owned rows must not narrow these.
 		const rows = await listConversations({
 			organizationId: ORG,
 			agentId: AGENT,
-			scope: "all",
+			scope: "shared",
 			userId: OWNER,
 		});
 
 		expect(rows.some((r) => r.kind === "platform")).toBe(true);
+		expect(rows.map((r) => r.title)).toContain("Team channel");
+	});
+
+	test("scope=admin lists every user's owned conversations", async () => {
+		// `manage_conversations` reaches this only after checking an admin/owner
+		// role, and its `get` action likewise lets an admin read any row. If a
+		// narrowing meant to protect the end-user feed also applied here, the
+		// admin listing would silently lose rows while `get` still served them.
+		const rows = await listConversations({
+			organizationId: ORG,
+			agentId: AGENT,
+			scope: "admin",
+			userId: OWNER,
+		});
+
+		const owned = rows.filter((r) => r.kind === "owned");
+		expect(owned.map((r) => r.userId).sort()).toEqual([OWNER, STRANGER].sort());
+		expect(rows.map((r) => r.title)).toContain("Stranger private note");
+		// Platform rows are unaffected by the owner predicate.
 		expect(rows.map((r) => r.title)).toContain("Team channel");
 	});
 

--- a/packages/server/src/gateway/__tests__/conversations-scope-all-owned.test.ts
+++ b/packages/server/src/gateway/__tests__/conversations-scope-all-owned.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../db/client.js";
+import { listConversations } from "../services/conversations-store.js";
+import {
+	ensureDbForGatewayTests,
+	resetTestDatabase,
+	seedAgentRow,
+} from "./helpers/db-setup.js";
+
+/**
+ * `scope: "all"` widens a listing to PLATFORM conversations. It must never
+ * widen it to another user's private ones.
+ *
+ * Before this fix the scope predicate applied `kind='owned' AND user_id = …`
+ * only when `scope === "user"`, so `scope: "all"` returned every user's owned
+ * rows — and a conversation title is message text. That was inert only because
+ * the read path re-derived its id from the caller's own userId, so the ids
+ * handed out were not readable. Now that a conversation is addressable by its
+ * stored id, listing someone else's would hand out a readable id, turning a
+ * title disclosure into a full transcript disclosure.
+ */
+
+const ORG = "test-org-scope-all-owned";
+const OWNER = "user-scope-owner";
+const STRANGER = "user-scope-stranger";
+const AGENT = "agent-scope-all";
+
+await ensureDbForGatewayTests();
+
+beforeEach(async () => {
+	await resetTestDatabase();
+	// Creates the organization row the conversations FK requires.
+	await seedAgentRow(AGENT, { organizationId: ORG, name: "Scope Agent" });
+	const sql = getDb();
+	// Two owned conversations by different users, plus a platform one.
+	await sql`
+		INSERT INTO public.conversations
+			(organization_id, agent_id, platform, conversation_id, thread_id, kind, user_id, title)
+		VALUES
+			(${ORG}, ${AGENT}, 'web', ${`${AGENT}_${OWNER}_${ORG}_t-owner`}, 't-owner', 'owned', ${OWNER}, 'Owner private note'),
+			(${ORG}, ${AGENT}, 'web', ${`${AGENT}_${STRANGER}_${ORG}_t-stranger`}, 't-stranger', 'owned', ${STRANGER}, 'Stranger private note'),
+			(${ORG}, ${AGENT}, 'slack', 'slack:C0SCOPE:1700000000.1', NULL, 'platform', NULL, 'Team channel')
+		ON CONFLICT DO NOTHING
+	`;
+});
+
+afterAll(async () => {
+	await resetTestDatabase();
+});
+
+describe("listConversations scope", () => {
+	test("scope=all excludes another user's owned conversations", async () => {
+		const rows = await listConversations({
+			organizationId: ORG,
+			agentId: AGENT,
+			scope: "all",
+			userId: OWNER,
+		});
+
+		const owned = rows.filter((r) => r.kind === "owned");
+		expect(owned.map((r) => r.userId)).toEqual([OWNER]);
+		// Titles are message text — the stranger's must not appear at all.
+		expect(rows.map((r) => r.title)).not.toContain("Stranger private note");
+	});
+
+	test("scope=all still widens to platform conversations", async () => {
+		// The whole point of `all`: platform rows the user does not own are the
+		// reason the scope exists. Narrowing owned rows must not narrow these.
+		const rows = await listConversations({
+			organizationId: ORG,
+			agentId: AGENT,
+			scope: "all",
+			userId: OWNER,
+		});
+
+		expect(rows.some((r) => r.kind === "platform")).toBe(true);
+		expect(rows.map((r) => r.title)).toContain("Team channel");
+	});
+
+	test("scope=user returns only the caller's owned conversations", async () => {
+		const rows = await listConversations({
+			organizationId: ORG,
+			agentId: AGENT,
+			scope: "user",
+			userId: OWNER,
+		});
+
+		expect(rows.every((r) => r.kind === "owned")).toBe(true);
+		expect(rows.map((r) => r.userId)).toEqual([OWNER]);
+	});
+});

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -31,6 +31,7 @@ import {
 	resolveChannelVisibility,
 } from "../../services/agent-thread-list.js";
 import { buildApiConversationId } from "../../services/api-conversation-id.js";
+import { findConversationById } from "../../services/conversations-store.js";
 import { readWatcherRunThreads } from "../../services/watcher-run-thread.js";
 import {
 	createOwnershipResolver,
@@ -494,6 +495,12 @@ export function createAgentHistoryRoutes(deps: {
 		organizationId: string;
 		userId: string;
 		allowNotGraphed: boolean;
+		/**
+		 * Platform admin. Distinct from `allowNotGraphed`, which an agent OWNER
+		 * also gets: owning an agent must not confer read access to every user's
+		 * private conversation with it.
+		 */
+		isAdmin: boolean;
 	} | null> {
 		const session = await verifySettingsSession(c);
 		if (!session) return null;
@@ -515,6 +522,7 @@ export function createAgentHistoryRoutes(deps: {
 				organizationId: ambientOrgId,
 				userId,
 				allowNotGraphed: true,
+				isAdmin: true,
 			};
 		}
 		if (session.agentId && session.agentId !== agentId) return null;
@@ -532,6 +540,7 @@ export function createAgentHistoryRoutes(deps: {
 				organizationId: ambientOrgId,
 				userId,
 				allowNotGraphed: true,
+				isAdmin: false,
 			};
 		}
 
@@ -564,6 +573,7 @@ export function createAgentHistoryRoutes(deps: {
 				organizationId: ambientOrgId,
 				userId,
 				allowNotGraphed: true,
+				isAdmin: false,
 			};
 		}
 
@@ -572,6 +582,7 @@ export function createAgentHistoryRoutes(deps: {
 			organizationId: ambientOrgId,
 			userId,
 			allowNotGraphed: false,
+			isAdmin: false,
 		};
 	}
 
@@ -781,8 +792,13 @@ export function createAgentHistoryRoutes(deps: {
 		return c.json({ ...data, interactions });
 	});
 
-	// Read a PLATFORM conversation (e.g. `slack:{channel}:{ts}`) read-only by its
-	// raw conversation id. The id carries colons, so it's URL-encoded in the path.
+	// Read ANY conversation the listing handed out, by its STORED id.
+	//
+	// The fence comes from the `conversations` row, not from the shape of the id.
+	// Previously this route accepted only `{platform}:{...}` ids and the owned
+	// read path re-derived its id from the caller's own userId — which meant an
+	// owned conversation could be listed and then never opened, because no
+	// handler accepted the id the listing returned.
 	app.get("/conversations/:conversationId/messages", async (c) => {
 		const scope = await getAuthorizedPlatformConversationScope(c);
 		if (!scope) return errorResponse(c, "Unauthorized", 401);
@@ -790,23 +806,45 @@ export function createAgentHistoryRoutes(deps: {
 		const conversationId = decodeURIComponent(
 			c.req.param("conversationId") || ""
 		);
-		// Platform conversation ids are `{platform}:{...}` — alnum/._:- only.
+		// Platform ids carry colons; owned ids are underscore-delimited. Both are
+		// alnum plus `._:-`, so one charset covers them without implying a shape.
 		if (!conversationId || !/^[a-zA-Z0-9._:-]+$/.test(conversationId)) {
 			return errorResponse(c, "Invalid conversation id", 400);
 		}
 
-		// ACL: the requester must be able to read this conversation's channel —
-		// the same per-agent fence ∩ per-user channel gate the listing applies.
-		// Fail closed (404, not 403) so an unauthorized id is indistinguishable
-		// from a non-existent one.
-		const channelVis = await resolveChannelVisibility(getDb(), {
+		// Fail closed (404, not 403) throughout, so an unauthorized id is
+		// indistinguishable from a non-existent one.
+		// A row is the only thing that can prove a conversation is OWNED. Platform
+		// transcripts are readable without one — federated channel ACL admits a
+		// non-owner org member whose access comes from the channel, not from a
+		// conversations row — so a miss falls through to the channel gate rather
+		// than 404ing, which is what the row-mandatory version got wrong.
+		const row = await findConversationById({
 			organizationId: scope.organizationId,
 			agentId: scope.agentId,
-			userId: scope.userId,
-			allowNotGraphed: scope.allowNotGraphed,
+			conversationId,
 		});
-		if (!isConversationVisible(conversationId, channelVis)) {
-			return errorResponse(c, "Conversation not found", 404);
+
+		if (row?.kind === "owned") {
+			// An owned conversation belongs to the user who started it. Admins keep
+			// the bypass the scope resolver already granted them.
+			if (!scope.isAdmin && row.userId !== scope.userId) {
+				return errorResponse(c, "Conversation not found", 404);
+			}
+		} else {
+			// Platform conversations stay behind the per-agent fence ∩ per-user
+			// channel gate. The channel segment is still parsed out of the id: the
+			// `conversations` row carries no channel column, so there is nothing
+			// else to read it from.
+			const channelVis = await resolveChannelVisibility(getDb(), {
+				organizationId: scope.organizationId,
+				agentId: scope.agentId,
+				userId: scope.userId,
+				allowNotGraphed: scope.allowNotGraphed,
+			});
+			if (!isConversationVisible(conversationId, channelVis)) {
+				return errorResponse(c, "Conversation not found", 404);
+			}
 		}
 
 		const cursor = c.req.query("cursor") || "";

--- a/packages/server/src/gateway/services/agent-thread-list.ts
+++ b/packages/server/src/gateway/services/agent-thread-list.ts
@@ -174,10 +174,14 @@ export async function listAgentThreads(args: {
 	// single listing source. This replaces the old
 	// `DISTINCT ON (conversation_id) FROM agent_transcript_snapshot` derive path
 	// AND the workspace-directory scan.
+	//
+	// This is an end-user feed, so "all" means "mine plus the channels I may
+	// read" — `shared`, never the store's `admin`. Admin listing is
+	// `manage_conversations`, which checks a role first.
 	const rows = await listConversations({
 		organizationId,
 		agentId,
-		scope,
+		scope: scope === "all" ? "shared" : "user",
 		userId,
 	});
 

--- a/packages/server/src/gateway/services/conversations-store.ts
+++ b/packages/server/src/gateway/services/conversations-store.ts
@@ -125,6 +125,56 @@ export interface ConversationListRow {
  * exist (or is soft-deleted). The single get source, mirroring
  * {@link listConversations}'s read of the materialized entity.
  */
+/**
+ * Look up a conversation by its STORED id, without knowing its platform.
+ *
+ * The read path addresses a conversation by the id the listing handed out, and
+ * that id alone does not say which platform it belongs to — only the row does.
+ * Callers use the returned `kind`/`userId` to apply the right fence: an owned
+ * conversation is its owner's, a platform one is gated on channel visibility.
+ * Deriving those facts by parsing the id string is what made owned
+ * conversations unreadable in the first place.
+ */
+export async function findConversationById(args: {
+	organizationId: string;
+	agentId: string;
+	conversationId: string;
+}): Promise<ConversationListRow | null> {
+	const { organizationId, agentId, conversationId } = args;
+	const sql = getDb();
+	const rows = await sql<{
+		platform: string;
+		conversation_id: string;
+		thread_id: string | null;
+		kind: ConversationKind;
+		user_id: string | null;
+		title: string | null;
+		last_activity_at: Date | null;
+		created_at: Date;
+	}>`
+    SELECT platform, conversation_id, thread_id, kind, user_id, title,
+           last_activity_at, created_at
+    FROM public.conversations
+    WHERE organization_id = ${organizationId}
+      AND agent_id = ${agentId}
+      AND conversation_id = ${conversationId}
+      AND archived_at IS NULL
+    LIMIT 1
+  `;
+	const r = rows[0];
+	if (!r) return null;
+	return {
+		platform: r.platform,
+		conversationId: r.conversation_id,
+		threadId: r.thread_id,
+		kind: r.kind,
+		userId: r.user_id,
+		title: r.title,
+		lastActivityAt: r.last_activity_at ?? r.created_at,
+		createdAt: r.created_at,
+	};
+}
+
 export async function getConversation(args: {
 	organizationId: string;
 	agentId: string;
@@ -263,7 +313,12 @@ export async function listConversations(args: {
       ${
 				scope === "user"
 					? sql`AND kind = 'owned' AND user_id = ${userId}`
-					: sql``
+					: // `all` widens to platform conversations, NOT to other users'
+						// private ones. An owned conversation belongs to whoever started
+						// it in every scope; its title is message text, and the read path
+						// now addresses a conversation by its stored id, so listing
+						// someone else's here would hand out a readable id.
+						sql`AND (kind <> 'owned' OR user_id = ${userId})`
 			}
     ORDER BY last_activity_at DESC NULLS LAST, created_at DESC
   `;

--- a/packages/server/src/gateway/services/conversations-store.ts
+++ b/packages/server/src/gateway/services/conversations-store.ts
@@ -120,11 +120,9 @@ export interface ConversationListRow {
 	createdAt: Date;
 }
 
-/**
- * Read one conversation row by its full PK. Returns null when the row does not
- * exist (or is soft-deleted). The single get source, mirroring
- * {@link listConversations}'s read of the materialized entity.
- */
+/** Audience a conversation listing is built for. See {@link listConversations}. */
+export type ConversationListScope = "user" | "shared" | "admin";
+
 /**
  * Look up a conversation by its STORED id, without knowing its platform.
  *
@@ -288,8 +286,19 @@ export async function readConversationReply(args: {
 export async function listConversations(args: {
 	organizationId: string;
 	agentId: string;
-	/** "user": only this user's owned conversations. "all": every conversation. */
-	scope: "user" | "all";
+	/**
+	 * Who the listing is for — NOT merely which kinds to include:
+	 * - `"user"`: only this user's owned conversations.
+	 * - `"shared"`: this user's owned conversations plus platform ones. Widening
+	 *   to a channel is not widening to another person's private thread.
+	 * - `"admin"`: every conversation in the org, including other users' owned
+	 *   ones. Only for a caller whose admin/owner role has ALREADY been checked.
+	 *
+	 * `"shared"` and `"admin"` return the same platform rows and differ only on
+	 * other users' owned rows, so the two must stay separate names: one label
+	 * covering both is what let an authorization decision be made by a default.
+	 */
+	scope: ConversationListScope;
 	userId: string;
 }): Promise<ConversationListRow[]> {
 	const { organizationId, agentId, scope, userId } = args;
@@ -313,12 +322,16 @@ export async function listConversations(args: {
       ${
 				scope === "user"
 					? sql`AND kind = 'owned' AND user_id = ${userId}`
-					: // `all` widens to platform conversations, NOT to other users'
-						// private ones. An owned conversation belongs to whoever started
-						// it in every scope; its title is message text, and the read path
-						// now addresses a conversation by its stored id, so listing
-						// someone else's here would hand out a readable id.
-						sql`AND (kind <> 'owned' OR user_id = ${userId})`
+					: scope === "shared"
+						? // `shared` widens to platform conversations, NOT to other users'
+							// private ones. An owned conversation belongs to whoever started
+							// it; its title is message text, and the read path now addresses
+							// a conversation by its stored id, so listing someone else's here
+							// would hand out an id that is readable.
+							sql`AND (kind <> 'owned' OR user_id = ${userId})`
+						: // `admin`: no owner predicate at all. Reaching here means the
+							// caller's admin/owner role was checked upstream.
+							sql``
 			}
     ORDER BY last_activity_at DESC NULLS LAST, created_at DESC
   `;

--- a/packages/server/src/gateway/services/conversations-store.ts
+++ b/packages/server/src/gateway/services/conversations-store.ts
@@ -121,7 +121,7 @@ export interface ConversationListRow {
 }
 
 /** Audience a conversation listing is built for. See {@link listConversations}. */
-export type ConversationListScope = "user" | "shared" | "admin";
+type ConversationListScope = "user" | "shared" | "admin";
 
 /**
  * Look up a conversation by its STORED id, without knowing its platform.

--- a/packages/server/src/tools/admin/manage_conversations.ts
+++ b/packages/server/src/tools/admin/manage_conversations.ts
@@ -106,7 +106,7 @@ async function handleList(
   // conversation; a plain member sees only their own owned threads. (Deriving
   // scope from `ctx.userId` alone inverted this — an admin was limited to their
   // own rows while a null-userId caller saw all.)
-  const scope = isAdminOrOwnerRole(ctx.memberRole) ? "all" : "user";
+  const scope = isAdminOrOwnerRole(ctx.memberRole) ? "admin" : "user";
   const conversations = await listConversations({
     organizationId: ctx.organizationId,
     agentId: args.agent_id,


### PR DESCRIPTION
## What

Makes a conversation readable by the id the listing hands out, and fences it on its `conversations` row instead of on the shape of its id.

## Why

`GET /conversations/:conversationId/messages` was platform-only: it required a `{platform}:{...}` id, and `isConversationVisible` derives the channel via `conversationId.split(":")`. An owned id is `{agentId}_{userId}_{orgId}_{threadId}` — underscore-delimited — so it fails that gate before anything else runs.

Meanwhile the owned read path (`readThreadMessages`) re-derived its id from the **caller's own userId**. That re-derivation *was* the access control, and it meant a conversation could only ever be opened by an id the server had just built — never by the id the listing returned.

Measured in production: **60 owned conversations** (`kind=owned, platform=web`) listed and unopenable. `agent_transcript_snapshot` had every transcript; 42/42 snapshots joined to a `conversations` row. Nothing was missing — nothing could be addressed.

`api-conversation-id.ts` already documented the required fix: *"Making those origins listable means teaching the read path to address a conversation by its stored id."*

## The fence now comes from the row

```
row.kind === 'owned'   → owner only (scope.isAdmin keeps the admin bypass)
otherwise              → per-agent fence ∩ per-user channel gate (unchanged)
```

Two things that are deliberate rather than incidental:

**A missing row is not a 404.** Platform transcripts are readable without a `conversations` row — federated channel ACL admits a non-owner org member whose access comes from the channel. A row-mandatory lookup broke `allows a non-owner org member to read a bound platform transcript through federated ACL`; caught by that test, fixed by making the lookup advisory. A row can prove *owned*; its absence proves nothing.

**The owner check gates on `isAdmin`, not `allowNotGraphed`.** An agent **owner** also receives `allowNotGraphed: true` (`agent-history.ts:534`). Using it here would let anyone who owns an agent read every user's private conversations with it. `isAdmin` is added to the scope result specifically to keep those distinct.

The channel gate still parses the id — `conversations` carries no channel column, so there is nothing else to read it from. That parse is now scoped to platform conversations, where it is correct.

## Second fix, required in the same commit

`listConversations` applied `AND kind='owned' AND user_id = ${userId}` **only** when `scope === 'user'`. Under `scope='all'` the predicate was empty, so every user's owned rows were listed — and a title is message text.

That was inert only because the returned ids were not readable. Making a stored id readable would have converted a title disclosure into a full transcript disclosure, so the filter lands here, not in a follow-up.

## Tests

```
agent-history-routes.test.ts              23 pass   (+1 new)
conversations-scope-all-owned.test.ts      3 pass   (new file)
agent-history-authorization + owned-elsewhere + related   7 pass
make pre-pr                                clean
```

New coverage: an owned conversation is readable by its owner via its stored id, and **404s for another member of the same org** (404 not 403, so an unauthorized id is indistinguishable from a nonexistent one). Plus `scope=all` excludes other users' owned rows while still widening to platform ones.

**Mutation-tested.** Disabling `!scope.isAdmin && row.userId !== scope.userId` fails the ACL test; reverting the scope predicate to `sql\`\`` fails the disclosure test.

## Not in this PR

`isConversationVisible` still parses the id — unavoidable without a channel column. The orphaned frontend hooks were removed separately in owletto #628.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation history can now be opened reliably from listed conversations.
  * Conversation listings now support distinct personal, shared, and administrative views.
  * Administrators can view all eligible conversations, while shared views show platform conversations and the requester’s own conversations.

* **Bug Fixes**
  * Improved access controls prevent users from opening or discovering conversations they do not own or cannot access.
  * Archived conversations are excluded from conversation lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->