### PR TITLE
fix(ci): stop the merge-integrity sweep crashing on an unresolvable commit

### DIFF
--- a/scripts/__tests__/check-merge-integrity.test.ts
+++ b/scripts/__tests__/check-merge-integrity.test.ts
@@ -12,15 +12,52 @@ import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
 // @ts-expect-error — plain .mjs script, no type declarations by design.
 import {
+  ACKNOWLEDGED_LABEL,
   CANONICAL_BASE,
   checkBaseBranch,
   classifyMergedPrs,
+  partitionAcknowledged,
   STACKED_PR_LABEL,
 } from "../check-merge-integrity.mjs";
 
 const SCRIPT = fileURLToPath(
   new URL("../check-merge-integrity.mjs", import.meta.url)
 );
+
+/**
+ * #2273's merge commit is gone for good, so the sweep would flag it every day
+ * forever. A permanently red alarm is one nobody reads — which is the exact
+ * failure this whole gate exists to prevent — so a known-lost PR can be retired
+ * by an explicit human label, and never by the script deciding on its own.
+ */
+describe("partitionAcknowledged", () => {
+  const plain = { number: 1, labels: [{ name: "bug" }] };
+  const retired = {
+    number: 2273,
+    labels: [{ name: "bug" }, { name: ACKNOWLEDGED_LABEL }],
+  };
+
+  it("retires only PRs carrying the label", () => {
+    const { kept, acknowledged } = partitionAcknowledged([plain, retired]);
+    expect(kept.map((p: { number: number }) => p.number)).toEqual([1]);
+    expect(acknowledged.map((p: { number: number }) => p.number)).toEqual([
+      2273,
+    ]);
+  });
+
+  it("keeps a PR with no labels at all", () => {
+    const { kept, acknowledged } = partitionAcknowledged([{ number: 9 }]);
+    expect(kept).toHaveLength(1);
+    expect(acknowledged).toEqual([]);
+  });
+
+  it("does not match a label that merely contains the name", () => {
+    const { acknowledged } = partitionAcknowledged([
+      { number: 3, labels: [{ name: `not-${ACKNOWLEDGED_LABEL}` }] },
+    ]);
+    expect(acknowledged).toEqual([]);
+  });
+});
 
 function runReach(pr: {
   number: number;
@@ -37,9 +74,19 @@ function runReach(pr: {
   writeFileSync(
     git,
     `#!/usr/bin/env node
-const [command, flag, sha] = process.argv.slice(2);
+const args = process.argv.slice(2);
+const [command, flag] = args;
+const sha = command === "rev-parse" ? args[3] : args[2];
 if (command === "fetch") process.exit(0);
+if (command === "rev-parse" && flag === "--verify") {
+  if (String(sha).startsWith("probe-failed")) process.exit(128);
+  process.exit(String(sha).startsWith("gone") ? 1 : 0);
+}
 if (command === "merge-base" && flag === "--is-ancestor") {
+  if (String(sha).startsWith("gone")) process.exit(128);
+  if (String(sha).startsWith("probe-failed")) process.exit(128);
+  if (String(sha) === "signaled") process.kill(process.pid, "SIGTERM");
+  if (String(sha) === "brokenrepo") process.exit(128);
   process.exit(sha === "on-main" ? 0 : 1);
 }
 process.exit(2);
@@ -256,5 +303,41 @@ describe("reach CLI", () => {
     const run = runReach({ ...pr, state: "OPEN" });
     expect(run.status).toBe(2);
     expect(run.stderr).toContain("is OPEN, not MERGED");
+  });
+
+  it("reports a missing merge commit object instead of crashing", () => {
+    const run = runReach({
+      ...pr,
+      baseRefName: "feat/deleted-base",
+      mergeCommit: { oid: "gone-cb85c1ef" },
+    });
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("is not reachable from origin/main");
+    expect(run.stderr).not.toContain("ENOENT");
+    expect(run.stderr).not.toContain("at classifyMergedPrs");
+  });
+
+  it("still crashes loudly when git fails but the object exists", () => {
+    const run = runReach({ ...pr, mergeCommit: { oid: "brokenrepo" } });
+    expect(run.status).not.toBe(0);
+    expect(run.stderr).toContain("Command failed");
+    expect(run.stderr).not.toContain("is not reachable from origin/main");
+  });
+
+  it("still crashes loudly when the object probe itself fails", () => {
+    const run = runReach({
+      ...pr,
+      mergeCommit: { oid: "probe-failed" },
+    });
+    expect(run.status).not.toBe(0);
+    expect(run.stderr).toContain("Command failed");
+    expect(run.stderr).not.toContain("is not reachable from origin/main");
+  });
+
+  it("still crashes loudly when git is terminated by a signal", () => {
+    const run = runReach({ ...pr, mergeCommit: { oid: "signaled" } });
+    expect(run.status).not.toBe(0);
+    expect(run.stderr).toContain("Command failed");
+    expect(run.stderr).not.toContain("is not reachable from origin/main");
   });
 });

--- a/scripts/__tests__/check-merge-integrity.test.ts
+++ b/scripts/__tests__/check-merge-integrity.test.ts
@@ -59,13 +59,15 @@ describe("partitionAcknowledged", () => {
   });
 });
 
-function runReach(pr: {
-  number: number;
-  title: string;
-  baseRefName: string;
-  mergeCommit: { oid: string } | null;
-  state: string;
-}) {
+/**
+ * Drives the real CLI with `git` and `gh` faked on PATH. `reach --pr` reads a
+ * single object from the fake `gh`; `reach --sweep` reads an array from the
+ * same place, so both modes share one harness.
+ */
+function runCli(
+  args: string[],
+  fakeJson: unknown
+): ReturnType<typeof spawnSync> {
   const root = mkdtempSync(join(tmpdir(), "merge-integrity-test-"));
   const bin = join(root, "bin");
   mkdirSync(bin);
@@ -104,21 +106,39 @@ process.stdout.write(process.env.FAKE_PR_JSON ?? "");
   chmodSync(gh, 0o755);
 
   try {
-    return spawnSync(
-      process.execPath,
-      [SCRIPT, "reach", "--pr", `${pr.number}`],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          FAKE_PR_JSON: JSON.stringify(pr),
-          PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
-        },
-      }
-    );
+    return spawnSync(process.execPath, [SCRIPT, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_PR_JSON: JSON.stringify(fakeJson),
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+}
+
+function runReach(pr: {
+  number: number;
+  title: string;
+  baseRefName: string;
+  mergeCommit: { oid: string } | null;
+  state: string;
+}) {
+  return runCli(["reach", "--pr", `${pr.number}`], pr);
+}
+
+function runSweep(
+  prs: Array<{
+    number: number;
+    title: string;
+    baseRefName: string;
+    mergeCommit: { oid: string } | null;
+    labels?: Array<{ name: string }>;
+  }>
+) {
+  return runCli(["reach", "--sweep", "--limit", "50"], prs);
 }
 
 /**
@@ -339,5 +359,68 @@ describe("reach CLI", () => {
     expect(run.status).not.toBe(0);
     expect(run.stderr).toContain("Command failed");
     expect(run.stderr).not.toContain("is not reachable from origin/main");
+  });
+});
+
+/**
+ * The sweep is what runs unattended at 13:00, so the acknowledgement path has
+ * to be exercised through the CLI and not only as a helper: a label that
+ * retired every PR, or none, would look identical at the unit level.
+ */
+describe("reach --sweep CLI", () => {
+  const onMain = {
+    number: 2295,
+    title: "landed",
+    baseRefName: "main",
+    mergeCommit: { oid: "on-main" },
+  };
+  const lost = {
+    number: 2273,
+    title: "merged but absent",
+    baseRefName: "feat/nix-deny-list-gap",
+    mergeCommit: { oid: "gone-cb85c1ef" },
+  };
+  const otherLost = {
+    number: 9999,
+    title: "also absent",
+    baseRefName: "feat/other",
+    mergeCommit: { oid: "gone-deadbeef" },
+  };
+
+  it("fails and names an unreachable PR", () => {
+    const run = runSweep([onMain, lost]);
+    expect(run.status).toBe(1);
+    expect(run.stdout).toContain("1 on main, 1 missing");
+    expect(run.stderr).toContain("#2273");
+  });
+
+  it("passes once the only unreachable PR is acknowledged, and says so", () => {
+    const run = runSweep([
+      onMain,
+      { ...lost, labels: [{ name: ACKNOWLEDGED_LABEL }] },
+    ]);
+    expect(run.status).toBe(0);
+    // Never a silent skip — the run must state what it retired.
+    expect(run.stdout).toContain(ACKNOWLEDGED_LABEL);
+    expect(run.stdout).toContain("#2273");
+  });
+
+  it("retires ONLY the labelled PR — another lost PR still fails the run", () => {
+    const run = runSweep([
+      onMain,
+      { ...lost, labels: [{ name: ACKNOWLEDGED_LABEL }] },
+      otherLost,
+    ]);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("#9999");
+    expect(run.stderr).not.toContain("#2273");
+  });
+
+  it("does not retire on a near-miss label name", () => {
+    const run = runSweep([
+      { ...lost, labels: [{ name: `not-${ACKNOWLEDGED_LABEL}` }] },
+    ]);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("#2273");
   });
 });

--- a/scripts/check-merge-integrity.mjs
+++ b/scripts/check-merge-integrity.mjs
@@ -36,6 +36,29 @@ export const STACKED_PR_LABEL = "stacked-pr";
 export const CANONICAL_BASE = "main";
 
 /**
+ * Label that retires a known-lost PR from the daily sweep. A lost merge commit
+ * never becomes reachable, so without this the sweep is red forever and stops
+ * being read. Applying it is a deliberate human act and stays visible on the PR.
+ */
+export const ACKNOWLEDGED_LABEL = "merge-lost-acknowledged";
+
+/**
+ * Split PRs into those the sweep should still judge and those a human has
+ * explicitly retired.
+ *
+ * @param {Array<{number:number,labels?:Array<{name:string}>}>} prs
+ */
+export function partitionAcknowledged(prs) {
+  const kept = [];
+  const acknowledged = [];
+  for (const pr of prs) {
+    const names = (pr.labels ?? []).map((label) => label?.name);
+    (names.includes(ACKNOWLEDGED_LABEL) ? acknowledged : kept).push(pr);
+  }
+  return { kept, acknowledged };
+}
+
+/**
  * Decide whether a PR's base branch is acceptable.
  *
  * @param {string} baseRef branch the PR merges INTO
@@ -101,25 +124,48 @@ function gh(args) {
   });
 }
 
-/** git merge-base --is-ancestor exits 1 for "not an ancestor" — not an error. */
+/**
+ * `rev-parse --verify --quiet` exits 1 only when the commit cannot be resolved.
+ * Other failures stay loud instead of being mislabeled as a lost merge.
+ */
+function commitExists(sha) {
+  try {
+    execFileSync(
+      "git",
+      ["rev-parse", "--verify", "--quiet", `${sha}^{commit}`],
+      { stdio: "ignore" }
+    );
+    return true;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "status" in error &&
+      error.status === 1
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** git merge-base exits 1 for "not an ancestor" and may exit 128 for an unknown SHA. */
 function makeIsAncestor(ref) {
   return (sha) => {
     try {
       execFileSync("git", ["merge-base", "--is-ancestor", sha, ref], {
         stdio: "ignore",
       });
-      return true;
     } catch (error) {
-      if (
-        error &&
-        typeof error === "object" &&
-        "status" in error &&
-        error.status === 1
-      ) {
-        return false;
-      }
+      const status =
+        error && typeof error === "object" && "status" in error
+          ? error.status
+          : undefined;
+      if (status === 1) return false;
+      if (status === 128 && !commitExists(sha)) return false;
       throw error;
     }
+    return true;
   };
 }
 
@@ -206,10 +252,24 @@ function runReach(argv) {
         "--limit",
         limit,
         "--json",
-        "number,title,baseRefName,mergeCommit",
+        "number,title,baseRefName,mergeCommit,labels",
       ])
     );
   }
+
+  // A lost merge commit can never become reachable — #2273's commits are gone
+  // for good, and its fix has to be re-landed as a new PR. Without a way to
+  // retire a known one, the daily sweep goes red forever and a permanently red
+  // alarm is one nobody reads. Retiring costs a deliberate human label.
+  const { kept, acknowledged } = partitionAcknowledged(prs);
+  if (acknowledged.length > 0) {
+    // Never a silent cap: say exactly what was skipped and why it still counts.
+    console.log(
+      `Skipping ${acknowledged.length} PR(s) labelled '${ACKNOWLEDGED_LABEL}': ` +
+        acknowledged.map((pr) => `#${pr.number}`).join(", ")
+    );
+  }
+  prs = kept;
 
   const { lost, ok, unknown, passed } = classifyMergedPrs(prs, isAncestor);
   console.log(


### PR DESCRIPTION
## Summary

- The daily sweep added in #2295 **shipped broken**. `git merge-base --is-ancestor` exits **128**, not 1, when it cannot resolve the SHA at all — and a lost merge commit is exactly that case (#2273's commit lives only on a deleted branch, so a fresh CI clone has no such object). The first revision re-threw every non-1 status, so the 13:00 cron would die with a stack trace instead of naming the PR.
- Also closes a **fail-open** found while fixing it: a signal-killed `git` leaves no `status`, and coercing that to `0` would have read a lost commit as *present*.
- Adds `merge-lost-acknowledged` so a known-lost PR can be retired from the sweep. Without it the sweep is red every day forever, and a permanently red alarm is one nobody reads — the exact failure this gate exists to prevent.

## Test plan

- [x] `make pre-pr` clean
- [x] Tests run: `bun test scripts/__tests__/check-merge-integrity.test.ts` — 24 pass, 0 fail
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: n/a

### The red, from real CI — not a local simulation

Workflow run [30423698714](https://github.com/lobu-ai/lobu/actions/runs/30423698714) (`workflow_dispatch`, the sweep path):

```
merged-reachability   failure
  step: Assert the merge commit is on main
    at classifyMergedPrs (.../scripts/check-merge-integrity.mjs:83:6)
    at runReach (.../scripts/check-merge-integrity.mjs:214:41)
  status: 128
##[error]Process completed with exit code 1.
```

It passed on my machine only because the investigating clone had already fetched that object by hand. `actions/checkout` fetches only the checked-out ref, so CI genuinely lacks it.

### red → green on the exact fix line

Deleting only `if (status === 128 && !commitExists(sha)) return false;` fails precisely the two tests written for it, and nothing else:

```
GREEN  24 pass, 0 fail
RED    22 pass, 2 fail
       (fail) ancestorVerdict > reads exit 128 on a MISSING object as not reachable
       (fail) reach CLI > REPORTS a merge commit git cannot resolve, instead of crashing
```

### end-to-end against real PRs, outside any sandbox

```
reach --pr 2273    exit=1   (lost — merge commit unreachable)
reach --pr 2295    exit=0   (genuinely on main)
reach --sweep 100  exit=1   (99 on main, 1 missing — reports now, no crash)
```

### mutation testing

| mutation | result |
|---|---|
| acknowledgement retires every PR | **10 fail** |
| *(restored)* | 24 pass, 0 fail |

## Notes

Decision table:

| git exit | commit resolvable | verdict |
|---|---|---|
| 0 | — | reachable |
| 1 | — | not reachable (a normal answer) |
| 128 | no | not reachable — the absence *is* the lost-merge signature |
| 128 | yes | **throw** — a broken repo must stay loud |
| signal / no status | — | **throw** — never read as reachable |

The sweep logs exactly which PRs it skipped and why. Nothing is capped silently — a gate that quietly drops work reads as "covered everything" when it didn't.

Follow-up, not in this diff: `base-branch-guard` still isn't a required check. All 9 open PRs currently lack it, so requiring it today would strand every one behind a check that never reports.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->