### PR TITLE
fix(server): let members read a single auth profile, matching list

### DIFF
--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -360,10 +360,8 @@ describe("method-metadata", () => {
 		);
 	});
 
-	it("advertises authProfiles.get at the tier manage_auth_profiles enforces (admin)", () => {
-		// Sanitized serialization does not change the access boundary:
-		// get_auth_profile remains in OWNER_ADMIN_ACTIONS.
-		expect(METHOD_METADATA["authProfiles.get"].access).toBe("admin");
+	it("advertises authProfiles.get at the tier manage_auth_profiles enforces (read)", () => {
+		expect(METHOD_METADATA["authProfiles.get"].access).toBe("read");
 		// Credential-bearing siblings stay gated.
 		expect(METHOD_METADATA["authProfiles.create"].access).toBe("write");
 		expect(METHOD_METADATA["authProfiles.update"].access).toBe("write");

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -357,13 +357,13 @@ describe("sdkSearch", () => {
 		expect(send.results[0]).toContain("accepted aliases: message → body");
 	});
 
-	it("does NOT advertise authProfiles.get to a read-tier caller (runtime is owner-admin)", async () => {
-		// Discovery must match get_auth_profile's OWNER_ADMIN_ACTIONS tier.
+	it("advertises authProfiles.get to a read-tier caller", async () => {
 		const result = await sdkSearch(
 			{ query: "authProfiles.get", mode: "read" },
 			stubEnv,
 			readCtx
 		);
-		expect(result.match_count).toBe(0);
+		expect(result.match_count).toBe(1);
+		expect(result.results[0]).toContain("authProfiles.get");
 	});
 });

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -82,10 +82,14 @@ describe('requiresOwnerAdmin', () => {
     );
   });
 
-  it('should require admin for manage_auth_profiles sensitive actions', () => {
+  it('should allow public auth profile metadata reads and require admin for sensitive actions', () => {
     expect(requiresOwnerAdmin('manage_auth_profiles', { action: 'get_auth_profile' }, false)).toBe(
-      true
+      false
     );
+    expect(
+      getRequiredAccessLevel('manage_auth_profiles', { action: 'get_auth_profile' }, false)
+    ).toBe('read');
+    expect(isPublicReadable('manage_auth_profiles', { action: 'get_auth_profile' })).toBe(true);
     expect(requiresOwnerAdmin('manage_auth_profiles', { action: 'test_auth_profile' }, false)).toBe(
       true
     );
@@ -712,7 +716,7 @@ manage_catalog: list_catalog=read+public list_installed=read+public ?=read
 manage_agents: list=read+public get=read+public create=admin update=admin delete=admin set_system_agent=admin ?=read
 manage_conversations: list=read get=read send=write ?=read
 manage_feeds: list_feeds=read+public read_feed=read+public read_feeds=read+public create_feed=admin update_feed=admin delete_feed=admin trigger_feed=admin ?=read
-manage_auth_profiles: list_auth_profiles=read+public get_auth_profile=admin test_auth_profile=admin create_auth_profile=write update_auth_profile=write delete_auth_profile=admin set_default_auth_profile=admin ?=read
+manage_auth_profiles: list_auth_profiles=read+public get_auth_profile=read+public test_auth_profile=admin create_auth_profile=write update_auth_profile=write delete_auth_profile=admin set_default_auth_profile=admin ?=read
 manage_operations: list_available=read+public execute=admin list_runs=read+public get_run=read+public list_activity=read+public approve=write reject=write approve_batch=write reject_batch=write ?=read
 notify: send=admin ?=admin
 manage_schedules: create=admin list=admin update=admin pause=admin cancel=admin ?=admin

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -29,11 +29,8 @@ export const MEMBER_WRITE_ACTIONS: Record<string, Set<string> | null> = {
 	manage_connections: new Set(["create", "update", "reauthenticate"]),
 	// Members create / reconnect their own oauth_account profile. The handler
 	// gates `profile_kind` against role so env / oauth_app / browser_session
-	// stay admin-only. `get_auth_profile` / `test_auth_profile` are NOT here —
-	// they are owner-admin (see OWNER_ADMIN_ACTIONS). `requiresOwnerAdmin` runs
-	// first so listing them here too was dead (admin still won), but the
-	// duplicate falsely read as "member-write" to any surface that inspects
-	// this map directly.
+	// stay admin-only. `get_auth_profile` is public-read because it returns the
+	// same sanitized metadata as list; `test_auth_profile` stays owner-admin.
 	manage_auth_profiles: new Set(["create_auth_profile", "update_auth_profile"]),
 	// `complete_window` is how watcher AGENTS report results — server-side
 	// agent workers and device CLI runs (the Owletto Mac dispatcher wires the
@@ -109,7 +106,8 @@ export const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
 		// `create_auth_profile` and `update_auth_profile` are in
 		// MEMBER_WRITE_ACTIONS — the handler enforces oauth_account-only access
 		// for non-admins so members can't create org-shared credentials.
-		"get_auth_profile",
+		// `get_auth_profile` is in PUBLIC_READ_ACTIONS because it uses the same
+		// credential-free `serializeAuthProfile` payload as `list_auth_profiles`.
 		"test_auth_profile",
 		"delete_auth_profile",
 		"set_default_auth_profile",
@@ -161,7 +159,7 @@ export const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {
 	manage_connections: new Set(["list", "list_connector_groups", "get"]),
 	manage_catalog: new Set(["list_catalog", "list_installed"]),
 	manage_feeds: new Set(["list_feeds", "read_feed", "read_feeds"]),
-	manage_auth_profiles: new Set(["list_auth_profiles"]),
+	manage_auth_profiles: new Set(["list_auth_profiles", "get_auth_profile"]),
 	manage_operations: new Set([
 		"list_available",
 		"list_runs",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -896,7 +896,7 @@ export default async (_ctx, client) => {
 	"authProfiles.get": {
 		summary:
 			"Get an auth profile by slug. Returns the sanitized serialization only — never raw credentials or auth_data.",
-		access: "admin",
+		access: "read",
 		signature:
 			"authProfiles.get(auth_profile_slug: string): Promise<unknown> // or authProfiles.get({ auth_profile_slug })",
 		example: "await client.authProfiles.get('google-calendar-account');",


### PR DESCRIPTION
## What

Moves `get_auth_profile` from `OWNER_ADMIN_ACTIONS` to `PUBLIC_READ_ACTIONS`, and restores `METHOD_METADATA["authProfiles.get"].access` to `read` so discovery matches enforcement.

## Why

`get_auth_profile` was owner-admin while `list_auth_profiles` was public-read — but **both map through the same `serializeAuthProfile`**, which emits metadata only and never credentials or `auth_data`:

- `handleListAuthProfiles` returns `authProfiles.map(serializeAuthProfile)` for **every** profile in the org, with no `profile_kind` filtering.
- `handleGetAuthProfile` returns `serializeAuthProfile(authProfile)` for **one** profile.

So a member could already read every org-shared profile's metadata via `list`. Gating the single-profile read on admin protected nothing — it only made `get` inconsistent with `list`, and meant a member who could see a profile in `list` hit an admin error fetching it by slug.

This is a consistency fix, not a privilege widening: no data becomes reachable that `list` did not already expose.

## Scope

`test_auth_profile`, `delete_auth_profile`, and `set_default_auth_profile` stay owner-admin. `create`/`update` stay member-write with the handler's existing `oauth_account`-only gate for non-admins.

## Verification

`access-model-cross-check` (the drift guard from #2283) passes — both sides agree `authProfiles.get` is `read`:
```
Tests  4 passed (4)
```

**Mutation test** — planted the old `admin` tier back in `METHOD_METADATA` while enforcement says read:
```
× keeps SDK discovery tiers aligned with runtime enforcement
+ "authProfiles.get: SDK=admin runtime(manage_auth_profiles.get_auth_profile)=read"
      Tests  1 failed | 3 passed (4)
```
Restored → `4 passed`. The guard bites in both directions.

`make test-unit`: 0 failures. `make pre-pr`: all 6 gates clean.

Three test files updated by `make review-fix` to assert the new tier — verified each change reads `read+public` for `get_auth_profile` only, with `test`/`delete`/`set_default` still admin.

## Risk

Low. Metadata-only surface already reachable via `list`; no credential path touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->