### PR TITLE
fix(server): stop the Chat SDK history cache from dropping inbound messages

### DIFF
--- a/packages/server/src/gateway/connections/__tests__/inbound-dispatch-parity.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/inbound-dispatch-parity.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Inbound dispatch must behave identically for every chat adapter.
+ *
+ * Chat SDK runs `messageHistory.append()` inside `handleIncomingMessage`
+ * BEFORE `dispatchToHandlers`, guarded only by the adapter's
+ * `persistMessageHistory` flag. Telegram and WhatsApp set that flag; Slack,
+ * Discord, Teams and GChat do not. The append is unguarded, so any throw
+ * inside it is caught by `processMessage` and the inbound message is discarded
+ * even though the webhook still returns 200.
+ *
+ * That made a durable-history *cache* write able to drop a user's message, and
+ * only on the two platforms that set the flag (prod: a Telegram DM returned 200
+ * with no reply, while Slack on the same build was unaffected).
+ *
+ * Lobu already persists transcripts itself via `captureChannelMessage` →
+ * `channel_messages`, which is platform-agnostic, idempotent and explicitly
+ * fire-and-forget. Its live-history path also falls back to
+ * `ConversationStateStore` for platforms without a history API, so the SDK
+ * cache must never be able to block dispatch.
+ *
+ * These tests pin the regression and the production seam: an adapter that
+ * would persist SDK history still dispatches when that store fails.
+ */
+import { describe, expect, test } from "bun:test";
+import { Chat } from "chat";
+import { disableSdkMessageHistory } from "../platforms/shared.js";
+
+/** In-memory StateAdapter whose list ops fail, standing in for any store fault. */
+function createStateAdapter(options: { failListAppend: boolean }) {
+	return {
+		async connect() {},
+		async disconnect() {},
+		async setIfNotExists() {
+			return true;
+		},
+		async acquireLock(threadId: string) {
+			return { threadId, token: "t", expiresAt: Date.now() + 60_000 };
+		},
+		async releaseLock() {},
+		async isSubscribed() {
+			return false;
+		},
+		async appendToList() {
+			if (options.failListAppend) {
+				throw new Error("history store unavailable");
+			}
+		},
+	};
+}
+
+/** Minimal persisting adapter implementing the inbound surface under test. */
+function createAdapter() {
+	return {
+		name: "test",
+		userName: "lobubot",
+		botUserId: "999",
+		persistMessageHistory: true,
+		async initialize() {},
+		async shutdown() {},
+		isDM: (threadId: string) => !threadId.includes(":group"),
+		channelIdFromThreadId: (threadId: string) => threadId,
+		getChannelVisibility: () => "private" as const,
+		async postMessage() {
+			return {} as Record<string, unknown>;
+		},
+		parseMessage: (raw: unknown) => raw,
+	};
+}
+
+function createMessage(text: string) {
+	return {
+		id: "m1",
+		text,
+		author: {
+			userId: "42",
+			userName: "human",
+			fullName: "Human",
+			isBot: false,
+			isMe: false,
+		},
+		isMention: false,
+		metadata: {},
+		toJSON: () => ({ id: "m1", text, raw: null }),
+	};
+}
+
+/**
+ * Drive one inbound DM through the real Chat SDK and report whether the
+ * registered handler ran.
+ */
+async function dispatchOnce(params: {
+	failListAppend: boolean;
+	/** Skip the production seam, to show the raw SDK behaviour it guards against. */
+	rawSdk?: boolean;
+}): Promise<string[]> {
+	const delivered: string[] = [];
+	const built = createAdapter();
+	// Production wraps every adapter through this seam in createAdapter().
+	const adapter = params.rawSdk ? built : disableSdkMessageHistory(built);
+	const chat = new Chat({
+		userName: "lobubot",
+		adapters: { test: adapter as never },
+		state: createStateAdapter({
+			failListAppend: params.failListAppend,
+		}) as never,
+		logger: "silent",
+	});
+	chat.onDirectMessage(async (_thread: unknown, message: { text: string }) => {
+		delivered.push(message.text);
+	});
+	await chat.initialize();
+	let processing: Promise<void> | undefined;
+	// Go through processMessage, exactly as an adapter's webhook handler does,
+	// and capture its background task through the SDK's webhook completion hook.
+	(
+		chat as unknown as {
+			processMessage: (
+				a: unknown,
+				t: string,
+				m: unknown,
+				options: { waitUntil(task: Promise<void>): void },
+			) => void;
+		}
+	).processMessage(adapter, "test:dm-1", createMessage("hello"), {
+		waitUntil(task) {
+			processing = task;
+		},
+	});
+	if (!processing) {
+		throw new Error("Chat SDK did not register its background message task");
+	}
+	await processing;
+	return delivered;
+}
+
+describe("Chat SDK message-history dispatch", () => {
+	test("raw SDK dispatches when its history store is healthy", async () => {
+		expect(
+			await dispatchOnce({
+				failListAppend: false,
+				rawSdk: true,
+			}),
+		).toEqual(["hello"]);
+	});
+
+	test("a failing history store does not drop the message after normalization", async () => {
+		expect(
+			await dispatchOnce({
+				failListAppend: true,
+			}),
+		).toEqual(["hello"]);
+	});
+
+	/**
+	 * Pins WHY the seam exists. Without `disableSdkMessageHistory`, the SDK
+	 * appends history before dispatching and a failing store swallows the
+	 * message — the exact production symptom (webhook 200, no reply).
+	 * If this ever starts delivering, the SDK fixed it upstream and the seam
+	 * can go.
+	 */
+	test("raw SDK drops the message when history persistence fails", async () => {
+		expect(
+			await dispatchOnce({
+				failListAppend: true,
+				rawSdk: true,
+			}),
+		).toEqual([]);
+	});
+});

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1553,11 +1553,10 @@ export class ChatInstanceManager {
         userName: connection.metadata.botUsername || `bot-${connection.id}`,
         adapters: { [adapterKey]: adapter },
         state: stateAdapter,
-        // Not hardcoded: every SDK-internal inbound drop (duplicate, lock
-        // conflict, and the catch-all in `processMessage`) logs at `debug`, so
-        // pinning this to "warn" made those drops invisible at any LOG_LEVEL —
-        // which is why the history-cache drop above took a production
-        // investigation to find. Default stays "warn"; the SDK is loud at info.
+        // Not hardcoded: the SDK's silent-drop paths (self-authored, duplicate,
+        // lock conflict) log at `debug`, so pinning this to "warn" made a
+        // dropped inbound message leave no trace at any LOG_LEVEL. Default
+        // stays "warn"; the SDK is loud at info.
         logger: process.env.LOG_LEVEL?.toLowerCase() === "debug"
           ? "debug"
           : "warn",

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -37,7 +37,10 @@ import {
   registerMessageHandlers,
 } from "./message-handler-bridge.js";
 import { getPlatformDescriptor, PLATFORM_REGISTRY } from "./platforms/index.js";
-import { resolveChatTarget } from "./platforms/shared.js";
+import {
+  disableSdkMessageHistory,
+  resolveChatTarget,
+} from "./platforms/shared.js";
 import { SlackConnectionCoordinator } from "./slack-connection-coordinator.js";
 import {
   registerSlackAppHome,
@@ -1550,7 +1553,14 @@ export class ChatInstanceManager {
         userName: connection.metadata.botUsername || `bot-${connection.id}`,
         adapters: { [adapterKey]: adapter },
         state: stateAdapter,
-        logger: "warn",
+        // Not hardcoded: every SDK-internal inbound drop (duplicate, lock
+        // conflict, and the catch-all in `processMessage`) logs at `debug`, so
+        // pinning this to "warn" made those drops invisible at any LOG_LEVEL —
+        // which is why the history-cache drop above took a production
+        // investigation to find. Default stays "warn"; the SDK is loud at info.
+        logger: process.env.LOG_LEVEL?.toLowerCase() === "debug"
+          ? "debug"
+          : "warn",
       });
 
       const commandDispatcher = new CommandDispatcher({
@@ -1689,7 +1699,8 @@ export class ChatInstanceManager {
     if (!descriptor) {
       throw new Error(`No adapter factory for: ${connection.platform}`);
     }
-    return descriptor.createAdapter(connection.config);
+    const adapter = await descriptor.createAdapter(connection.config);
+    return disableSdkMessageHistory(adapter);
   }
 
   /**

--- a/packages/server/src/gateway/connections/platforms/shared.ts
+++ b/packages/server/src/gateway/connections/platforms/shared.ts
@@ -11,6 +11,28 @@ import type { ChatPlatformInstance, PlatformRoutingInfo } from "./types.js";
 
 const logger = createLogger("chat-target-resolver");
 
+/**
+ * Turn off the Chat SDK's message-history cache so every adapter shares one
+ * inbound path.
+ *
+ * The SDK writes that cache in `handleIncomingMessage` BEFORE dispatch, gated
+ * on the adapter's `persistMessageHistory` flag and unguarded; `processMessage`
+ * catches the throw and the webhook still answers 200, so a failing cache write
+ * drops the message before Lobu sees it. Only Telegram and WhatsApp set the
+ * flag. Lobu's durable transcripts use `channel_messages`, and its live-history
+ * path already falls back to `ConversationStateStore` when a platform has no
+ * history API, so delivery must not depend on this secondary cache.
+ */
+export function disableSdkMessageHistory<T extends object>(adapter: T): T {
+  // Declared readonly on the SDK interface, so redefine rather than assign.
+  Object.defineProperty(adapter, "persistMessageHistory", {
+    value: false,
+    configurable: true,
+    writable: true,
+  });
+  return adapter;
+}
+
 /** Drain a Readable into a single Buffer. */
 export async function streamToBuffer(readable: Readable): Promise<Buffer> {
   const chunks: Buffer[] = [];


### PR DESCRIPTION
## What

The Chat SDK writes its message-history cache inside `handleIncomingMessage`
**before** dispatching to handlers, gated only on the adapter's
`persistMessageHistory` flag and with no `try/catch`. `processMessage` swallows
whatever it throws and the webhook still answers `200`, so a failing *cache*
write silently discards the user's message.

Only Telegram and WhatsApp set that flag; Slack, Discord, Teams and GChat do
not — so the same build dropped Telegram DMs while Slack was fine. That is a
per-platform divergence in the one path that must be identical everywhere.

Nothing reads that cache. Lobu's durable transcripts go to `channel_messages`
via `captureChannelMessage` (platform-agnostic, idempotent, fire-and-forget),
which is what `read_conversation` and the conversations route actually query.
`grep` for `getMessages`/`msg-history` across `packages/server/src` returns zero
consumers.

Fix: normalize the flag off in `createAdapter` — the single chokepoint every
platform's adapter passes through — so inbound dispatch is identical for all six
adapters. This removes a write path; it does not add one.

Also stops hardcoding the SDK logger to `"warn"`. Every SDK-internal inbound
drop (duplicate, lock conflict, and the `processMessage` catch-all) logs at
`debug`, so the pin made these failures invisible at any `LOG_LEVEL` — which is
why this took a production investigation to find.

## Production evidence

A real Telegram DM to `@burembalobubot` (connection 459):

```
POST /lobu/api/v1/webhooks/85045b7a87884eea
cf-connecting-ip: 91.108.5.129        (Telegram)
x-telegram-bot-api-secret-token: ...  (valid)
content-length: 279  ->  res.status: 200, responseTime: 1079ms
```

`200` returned, no `"Processing inbound message"`, no `platform=telegram`
anywhere after it — the bridge was never reached. `getWebhookInfo` reported no
delivery error, so Telegram considered it delivered. Slack on the same build
was unaffected.

## Red -> green

Red (before the fix), both failures at `chat/dist/index.js:2966` inside
`handleIncomingMessage`, before dispatch:

```
(fail) inbound dispatch parity across chat adapters > a failing history store must NOT drop the message
(fail) inbound dispatch parity across chat adapters > delivery is identical whether or not the adapter persists history
 2 pass
 2 fail
```

Green (after):

```
 3 pass
 0 fail
Ran 3 tests across 1 file.
```

Mutation-tested: flipping `value: false` -> `true` in `disableSdkMessageHistory`
re-breaks the drop test, so the test bites.

`raw SDK drops the message when history persistence fails` pins *why* the seam
exists — if it ever starts delivering, the SDK fixed it upstream and the seam
can go.

## Test plan

- [x] `make pre-pr` clean
- [x] `make test-unit` — 156 + 163 + 4 pass, 0 fail
- [x] `make review-fix` applied and diff verified
- [ ] Prod: Telegram DM gets a reply; Slack still replies; pages render

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->