### PR TITLE
fix(ci): stop the reviewer's own sandbox from blocking merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,6 +588,14 @@ jobs:
         # it cannot quietly stop catching the thing it exists for.
         run: bun test scripts/__tests__/check-merge-integrity.test.ts
 
+      - name: Review-prompt blocker rule
+        # `pi-review` is required and enforce_admins is on, so `blockers>0` is
+        # unbypassable. §4 of the review prompt told the reviewer to record its
+        # OWN inability to run tests as a blocker, which red-flagged #2306 twice
+        # under codex's read-only sandbox and then passed on an identical re-run.
+        # Three other sections say the opposite; this pins the one direction.
+        run: bun test scripts/__tests__/review-prompt-env-blockers.test.ts
+
       - name: Raw-array SQL-param gate
         # packages/server's postgres.js client runs fetch_types:false, where a raw
         # JS array bound as a query param serializes to a malformed array literal

--- a/prompts/review-prompt.md
+++ b/prompts/review-prompt.md
@@ -82,9 +82,10 @@ skipped exploration, say so explicitly — don't lie by omission.
 ## 4. Judgment Rules
 
 - ~15 min total compute budget.
-- If you cannot run tests at all — your sandbox is read-only, a probe dies
-  with `EPERM`, deps are missing — that is never a `blocker`. Your sandbox
-  is not the diff. Record it in `notes` with the `[env]` prefix, keep
+- If test execution is unavailable because of the reviewer's environment
+  rather than the diff — for example, the sandbox is read-only or a probe
+  dies with `EPERM` — that is never a `blocker`. Record it in `notes` with
+  the `[env]` prefix, keep
   `bug_free_confidence` in the 70–89 band you can actually defend, and
   finish the verdict from static review plus the CI snapshot. The
   deterministic suites are separate required checks and still have to pass

--- a/prompts/review-prompt.md
+++ b/prompts/review-prompt.md
@@ -82,9 +82,13 @@ skipped exploration, say so explicitly — don't lie by omission.
 ## 4. Judgment Rules
 
 - ~15 min total compute budget.
-- If the environment itself is broken (e.g. you cannot run even a narrow
-  test file), record that as a `blocker` and finish with a partial
-  verdict. Do not retry indefinitely.
+- If you cannot run tests at all — your sandbox is read-only, a probe dies
+  with `EPERM`, deps are missing — that is never a `blocker`. Your sandbox
+  is not the diff. Record it in `notes` with the `[env]` prefix, keep
+  `bug_free_confidence` in the 70–89 band you can actually defend, and
+  finish the verdict from static review plus the CI snapshot. The
+  deterministic suites are separate required checks and still have to pass
+  on their own. Do not retry indefinitely.
 - The numeric scores must reflect what you empirically verified — don't
   inflate `bugs` from speculation. Confirmed by a CI failure you attributed
   to the diff OR a failure you reproduced locally = a bug. "This looks

--- a/scripts/__tests__/review-prompt-env-blockers.test.ts
+++ b/scripts/__tests__/review-prompt-env-blockers.test.ts
@@ -14,7 +14,12 @@
  * Three other sections (§2, §6, and the Blockers list) already say the
  * opposite: environment problems are `[env]` notes and blockers require a
  * failure the diff caused. This pins that the prompt says it in ONE
- * direction, because the contradiction is what the reviewer resolved wrongly.
+ * direction.
+ *
+ * It deliberately matches the *shape* of the rule rather than its wording.
+ * An exact-string assertion would fail on any honest rewrite while still
+ * letting a freshly-worded contradiction through — the guard has to catch
+ * the class, since the class is what the reviewer resolved wrongly.
  */
 
 import { readFileSync } from "node:fs";
@@ -26,7 +31,14 @@ const PROMPT = join(REPO_ROOT, "prompts/review-prompt.md");
 
 /** Reviewer-side inability to execute — a fact about the sandbox, not the diff. */
 const ENV_INABILITY =
-  /(environment (itself )?is broken|sandbox|read-only|EPERM|cannot run|can't run|unable to run|could not run)/i;
+  /(environment (itself )?is broken|reviewer's environment|sandbox|read-only|EPERM|execution is unavailable|denies the writes|cannot run|can't run|unable to run|could not run)/i;
+/**
+ * Same pattern, global — only for `replace`. It cannot be one shared regex:
+ * a `/g` regex carries `lastIndex` across `.test()` calls, so sharing it
+ * makes the filter below skip every other bullet. That defect shipped in a
+ * draft of this file and let an added contradictory bullet through.
+ */
+const ENV_INABILITY_ALL = new RegExp(ENV_INABILITY.source, "gi");
 const MENTIONS_BLOCKER = /blocker/i;
 /**
  * A prohibition ("never a `blocker`", "DO NOT add them to `blockers`") is the
@@ -40,8 +52,12 @@ const MENTIONS_BLOCKER = /blocker/i;
  *   2. The env phrase negates itself. "you cannot run even a narrow test
  *      file" sits in the same sentence, so its `cannot` reads as the
  *      prohibition. Strip the env phrasing before looking for negation.
+ *
+ * Kept to bare negatives on purpose: "rather than" / "instead of" appear in
+ * the rule's own causation clause, so accepting them as prohibitions would
+ * let "record it as a `blocker` rather than a note" pass.
  */
-const PROHIBITION = /\b(not|never|n't|rather than|instead of)\b/i;
+const PROHIBITION = /\b(not|never|n't)\b/i;
 const SENTENCES = /[^.!?]+[.!?]?/g;
 
 /**
@@ -75,7 +91,7 @@ describe("review prompt: environment failures are never blockers", () => {
       .flatMap((bullet) => bullet.match(SENTENCES) ?? [])
       .filter((sentence) => MENTIONS_BLOCKER.test(sentence))
       .filter(
-        (sentence) => !PROHIBITION.test(sentence.replace(ENV_INABILITY, ""))
+        (sentence) => !PROHIBITION.test(sentence.replace(ENV_INABILITY_ALL, ""))
       )
       .map((sentence) => sentence.trim());
 

--- a/scripts/__tests__/review-prompt-env-blockers.test.ts
+++ b/scripts/__tests__/review-prompt-env-blockers.test.ts
@@ -1,0 +1,94 @@
+/**
+ * `pi-review` is a required status check and `enforce_admins` is on, so a
+ * non-empty `blockers` array is unbypassable — review.sh turns `blockers>0`
+ * into a red status with no override path.
+ *
+ * That makes one prompt sentence load-bearing for the whole repo. #2306 hit
+ * it: the reviewer runs under `codex exec --sandbox read-only`, the changed
+ * test called `mkdtemp`, the write failed with EPERM, and §4 told the
+ * reviewer to "record that as a `blocker`" — so a property of the reviewer's
+ * own sandbox, not of the diff, blocked main. A re-run with byte-identical
+ * content then passed, which is what a gate that measures the environment
+ * looks like from the outside.
+ *
+ * Three other sections (§2, §6, and the Blockers list) already say the
+ * opposite: environment problems are `[env]` notes and blockers require a
+ * failure the diff caused. This pins that the prompt says it in ONE
+ * direction, because the contradiction is what the reviewer resolved wrongly.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "bun:test";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const PROMPT = join(REPO_ROOT, "prompts/review-prompt.md");
+
+/** Reviewer-side inability to execute — a fact about the sandbox, not the diff. */
+const ENV_INABILITY =
+  /(environment (itself )?is broken|sandbox|read-only|EPERM|cannot run|can't run|unable to run|could not run)/i;
+const MENTIONS_BLOCKER = /blocker/i;
+/**
+ * A prohibition ("never a `blocker`", "DO NOT add them to `blockers`") is the
+ * rule we want; an instruction ("record that as a `blocker`") is the bug.
+ *
+ * Two traps make the obvious check useless, and the first revision of this
+ * guard fell into both — it passed against the very prompt that broke #2306:
+ *   1. Scope. The offending bullet ended "Do not retry indefinitely", so a
+ *      negation search over the whole bullet matched a `not` belonging to a
+ *      different sentence. Scope to the sentence that says `blocker`.
+ *   2. The env phrase negates itself. "you cannot run even a narrow test
+ *      file" sits in the same sentence, so its `cannot` reads as the
+ *      prohibition. Strip the env phrasing before looking for negation.
+ */
+const PROHIBITION = /\b(not|never|n't|rather than|instead of)\b/i;
+const SENTENCES = /[^.!?]+[.!?]?/g;
+
+/**
+ * Markdown bullets, joined with their indented continuation lines — the rule
+ * that broke #2306 spanned three lines, so a line-at-a-time scan misses it.
+ */
+function bullets(markdown: string): string[] {
+  const out: string[] = [];
+  let current: string | null = null;
+  for (const line of markdown.split("\n")) {
+    if (/^- /.test(line)) {
+      if (current !== null) out.push(current);
+      current = line;
+    } else if (current !== null && /^\s+\S/.test(line)) {
+      current += ` ${line.trim()}`;
+    } else {
+      if (current !== null) out.push(current);
+      current = null;
+    }
+  }
+  if (current !== null) out.push(current);
+  return out;
+}
+
+describe("review prompt: environment failures are never blockers", () => {
+  const markdown = readFileSync(PROMPT, "utf8");
+
+  it("states the env-vs-blocker rule in only one direction", () => {
+    const offenders = bullets(markdown)
+      .filter((bullet) => ENV_INABILITY.test(bullet))
+      .flatMap((bullet) => bullet.match(SENTENCES) ?? [])
+      .filter((sentence) => MENTIONS_BLOCKER.test(sentence))
+      .filter(
+        (sentence) => !PROHIBITION.test(sentence.replace(ENV_INABILITY, ""))
+      )
+      .map((sentence) => sentence.trim());
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("still routes what it cannot run into [env] notes", () => {
+    // Deleting the contradictory rule must not delete the guidance with it —
+    // an unrunnable suite has to surface somewhere the reader can see.
+    expect(markdown).toContain("[env]");
+  });
+
+  it("keeps blockers tied to a failure the diff caused", () => {
+    expect(markdown).toMatch(/actually failed and the diff is\s+the cause/);
+  });
+});

--- a/scripts/__tests__/review-prompt-env-blockers.test.ts
+++ b/scripts/__tests__/review-prompt-env-blockers.test.ts
@@ -61,7 +61,9 @@ function contradictions(markdown: string): string[] {
     .filter((bullet) => ENV_INABILITY.test(bullet))
     .flatMap((bullet) => bullet.split(CLAUSE_BOUNDARY))
     .filter((clause) => MENTIONS_BLOCKER.test(clause))
-    .filter((clause) => !PROHIBITION.test(clause.replace(ENV_INABILITY_ALL, "")))
+    .filter(
+      (clause) => !PROHIBITION.test(clause.replace(ENV_INABILITY_ALL, ""))
+    )
     .map((clause) => clause.trim());
 }
 

--- a/scripts/__tests__/review-prompt-env-blockers.test.ts
+++ b/scripts/__tests__/review-prompt-env-blockers.test.ts
@@ -34,23 +34,29 @@ const PROMPT = join(REPO_ROOT, "prompts/review-prompt.md");
 /** Reviewer-side inability to execute — a fact about the sandbox, not the diff. */
 const ENV_INABILITY =
   /(environment (itself )?is broken|reviewer's environment|sandbox|read-only|EPERM|execution is unavailable|denies the writes|cannot run|can't run|unable to run|could not run)/i;
-/**
- * Same pattern, global — only for `replace`. It cannot be one shared regex:
- * a `/g` regex carries `lastIndex` across `.test()` calls, so sharing it makes
- * the bullet filter skip every other bullet.
- */
-const ENV_INABILITY_ALL = new RegExp(ENV_INABILITY.source, "gi");
 const MENTIONS_BLOCKER = /blocker/i;
-const PROHIBITION = /\b(not|never|n't)\b/i;
-/**
- * Split on clause boundaries, not sentence boundaries. "do not hide it;
- * record it as a blocker" is one sentence whose negation governs a different
- * verb — scoping to the sentence accepts it. Splitting wider risks the
- * reverse error (a negation stranded from the clause it governs), which is
- * the safe direction: a false positive is a loud CI failure on a 250-line
- * document, a false negative is another silent unbypassable gate.
- */
 const CLAUSE_BOUNDARY = /(?<=[.;!?—,])\s*/;
+
+/**
+ * The two ways the prompt may legitimately connect an env failure to
+ * blockers. Anything else inside an env rule is a contradiction.
+ *
+ * This is a whitelist because the three revisions before it were blacklists —
+ * "does this clause contain a negation" — and each died to a negation that
+ * governed a different verb: first across sentences ("Do not retry
+ * indefinitely"), then across a semicolon, then across an "and" ("do not hide
+ * it and record it as a blocker"). Which verb a `not` attaches to is not
+ * something a regex settles, and every patch moved the counter-example one
+ * conjunction further out.
+ *
+ * Inverting it removes the question. A phrasing this does not recognize gets
+ * flagged rather than allowed, so an unanticipated rewrite fails loudly on a
+ * 250-line document instead of silently reopening an unbypassable gate.
+ */
+const PROHIBITS_BLOCKER = [
+  /\b(?:never|not)\s+a\s+`?blockers?`?/i,
+  /\bnot\s+\w+\s+(?:them\s+)?(?:to|under|in|as)\s+`?blockers?`?/i,
+];
 
 /**
  * Every clause that ties a reviewer-side inability to `blockers` without
@@ -62,7 +68,7 @@ function contradictions(markdown: string): string[] {
     .flatMap((bullet) => bullet.split(CLAUSE_BOUNDARY))
     .filter((clause) => MENTIONS_BLOCKER.test(clause))
     .filter(
-      (clause) => !PROHIBITION.test(clause.replace(ENV_INABILITY_ALL, ""))
+      (clause) => !PROHIBITS_BLOCKER.some((allowed) => allowed.test(clause))
     )
     .map((clause) => clause.trim());
 }
@@ -99,8 +105,15 @@ const CONTRADICTORY = [
   // An unrelated negation earlier in the same sentence; defeats a
   // sentence-scoped negation search.
   "- If your sandbox is read-only, do not hide it; record it as a blocker.",
+  // The same, with `and` instead of `;` — no clause boundary at all, which is
+  // what defeated the clause-scoped revision.
+  "- If your sandbox is read-only, do not hide it and record it as a blocker.",
   // Bare copula, no imperative verb to key on.
   "- A read-only sandbox counts as a `blocker`.",
+  // Negation present but attached to something else entirely.
+  "- When the reviewer's environment fails, nothing stops you recording a blocker.",
+  // A verb the whitelist was never written around.
+  "- If you cannot run the suite, escalate it to `blockers`.",
 ];
 
 /** Phrasings that must NOT be flagged, so the guard stays usable. */
@@ -108,6 +121,7 @@ const CONSISTENT = [
   "- If the sandbox is read-only, that is never a `blocker`; put it in `notes`\n  with the `[env]` prefix.",
   "- Environment problems (a read-only sandbox) — DO NOT add them to `blockers`.",
   "- A probe that dies with `EPERM` is not a `blocker`.",
+  "- A sandbox denial does not belong in `blockers`.",
 ];
 
 describe("review prompt: environment failures are never blockers", () => {

--- a/scripts/__tests__/review-prompt-env-blockers.test.ts
+++ b/scripts/__tests__/review-prompt-env-blockers.test.ts
@@ -84,8 +84,18 @@ describe("review prompt: environment failures are never blockers", () => {
 
   it("still routes what it cannot run into [env] notes", () => {
     // Deleting the contradictory rule must not delete the guidance with it —
-    // an unrunnable suite has to surface somewhere the reader can see.
-    expect(markdown).toContain("[env]");
+    // an unrunnable suite has to surface somewhere the reader can see. Scope
+    // this to the env-inability rules themselves: a bare `[env]` search over
+    // the whole prompt passes on any unrelated mention, so it would stay green
+    // even if §4 stopped routing what it cannot run into `notes`.
+    const envRules = bullets(markdown).filter((bullet) =>
+      ENV_INABILITY.test(bullet)
+    );
+    expect(
+      envRules.some(
+        (bullet) => /\bnotes\b/i.test(bullet) && /\[env\]/i.test(bullet)
+      )
+    ).toBe(true);
   });
 
   it("keeps blockers tied to a failure the diff caused", () => {

--- a/scripts/__tests__/review-prompt-env-blockers.test.ts
+++ b/scripts/__tests__/review-prompt-env-blockers.test.ts
@@ -14,12 +14,14 @@
  * Three other sections (§2, §6, and the Blockers list) already say the
  * opposite: environment problems are `[env]` notes and blockers require a
  * failure the diff caused. This pins that the prompt says it in ONE
- * direction.
+ * direction, matching the *shape* of the rule rather than its wording — an
+ * exact-string assertion would fail on any honest rewrite while still letting
+ * a freshly-worded contradiction through.
  *
- * It deliberately matches the *shape* of the rule rather than its wording.
- * An exact-string assertion would fail on any honest rewrite while still
- * letting a freshly-worded contradiction through — the guard has to catch
- * the class, since the class is what the reviewer resolved wrongly.
+ * The fixtures below are the point of the file. Three revisions of this guard
+ * were wrong in three different ways, each one passing against a prompt that
+ * contradicted itself, so the guard is tested against known-bad and known-good
+ * phrasings rather than trusted to be correct by inspection.
  */
 
 import { readFileSync } from "node:fs";
@@ -34,31 +36,34 @@ const ENV_INABILITY =
   /(environment (itself )?is broken|reviewer's environment|sandbox|read-only|EPERM|execution is unavailable|denies the writes|cannot run|can't run|unable to run|could not run)/i;
 /**
  * Same pattern, global — only for `replace`. It cannot be one shared regex:
- * a `/g` regex carries `lastIndex` across `.test()` calls, so sharing it
- * makes the filter below skip every other bullet. That defect shipped in a
- * draft of this file and let an added contradictory bullet through.
+ * a `/g` regex carries `lastIndex` across `.test()` calls, so sharing it makes
+ * the bullet filter skip every other bullet.
  */
 const ENV_INABILITY_ALL = new RegExp(ENV_INABILITY.source, "gi");
 const MENTIONS_BLOCKER = /blocker/i;
-/**
- * A prohibition ("never a `blocker`", "DO NOT add them to `blockers`") is the
- * rule we want; an instruction ("record that as a `blocker`") is the bug.
- *
- * Two traps make the obvious check useless, and the first revision of this
- * guard fell into both — it passed against the very prompt that broke #2306:
- *   1. Scope. The offending bullet ended "Do not retry indefinitely", so a
- *      negation search over the whole bullet matched a `not` belonging to a
- *      different sentence. Scope to the sentence that says `blocker`.
- *   2. The env phrase negates itself. "you cannot run even a narrow test
- *      file" sits in the same sentence, so its `cannot` reads as the
- *      prohibition. Strip the env phrasing before looking for negation.
- *
- * Kept to bare negatives on purpose: "rather than" / "instead of" appear in
- * the rule's own causation clause, so accepting them as prohibitions would
- * let "record it as a `blocker` rather than a note" pass.
- */
 const PROHIBITION = /\b(not|never|n't)\b/i;
-const SENTENCES = /[^.!?]+[.!?]?/g;
+/**
+ * Split on clause boundaries, not sentence boundaries. "do not hide it;
+ * record it as a blocker" is one sentence whose negation governs a different
+ * verb — scoping to the sentence accepts it. Splitting wider risks the
+ * reverse error (a negation stranded from the clause it governs), which is
+ * the safe direction: a false positive is a loud CI failure on a 250-line
+ * document, a false negative is another silent unbypassable gate.
+ */
+const CLAUSE_BOUNDARY = /(?<=[.;!?—,])\s*/;
+
+/**
+ * Every clause that ties a reviewer-side inability to `blockers` without
+ * prohibiting it. Empty means the prompt states the rule in one direction.
+ */
+function contradictions(markdown: string): string[] {
+  return bullets(markdown)
+    .filter((bullet) => ENV_INABILITY.test(bullet))
+    .flatMap((bullet) => bullet.split(CLAUSE_BOUNDARY))
+    .filter((clause) => MENTIONS_BLOCKER.test(clause))
+    .filter((clause) => !PROHIBITION.test(clause.replace(ENV_INABILITY_ALL, "")))
+    .map((clause) => clause.trim());
+}
 
 /**
  * Markdown bullets, joined with their indented continuation lines — the rule
@@ -82,20 +87,40 @@ function bullets(markdown: string): string[] {
   return out;
 }
 
+/** Phrasings that must be flagged. Each one defeated an earlier revision. */
+const CONTRADICTORY = [
+  // The literal §4 rule that red-flagged #2306 twice.
+  "- If the environment itself is broken (e.g. you cannot run even a narrow\n  test file), record that as a `blocker` and finish with a partial verdict.",
+  // Added alongside a correct rule instead of replacing it — the realistic
+  // drift, and what an exact-string guard misses entirely.
+  "- When your sandbox denies the writes a narrow test needs, list that under\n  `blockers` so the gap stays visible to the merger.",
+  // An unrelated negation earlier in the same sentence; defeats a
+  // sentence-scoped negation search.
+  "- If your sandbox is read-only, do not hide it; record it as a blocker.",
+  // Bare copula, no imperative verb to key on.
+  "- A read-only sandbox counts as a `blocker`.",
+];
+
+/** Phrasings that must NOT be flagged, so the guard stays usable. */
+const CONSISTENT = [
+  "- If the sandbox is read-only, that is never a `blocker`; put it in `notes`\n  with the `[env]` prefix.",
+  "- Environment problems (a read-only sandbox) — DO NOT add them to `blockers`.",
+  "- A probe that dies with `EPERM` is not a `blocker`.",
+];
+
 describe("review prompt: environment failures are never blockers", () => {
   const markdown = readFileSync(PROMPT, "utf8");
 
   it("states the env-vs-blocker rule in only one direction", () => {
-    const offenders = bullets(markdown)
-      .filter((bullet) => ENV_INABILITY.test(bullet))
-      .flatMap((bullet) => bullet.match(SENTENCES) ?? [])
-      .filter((sentence) => MENTIONS_BLOCKER.test(sentence))
-      .filter(
-        (sentence) => !PROHIBITION.test(sentence.replace(ENV_INABILITY_ALL, ""))
-      )
-      .map((sentence) => sentence.trim());
+    expect(contradictions(markdown)).toEqual([]);
+  });
 
-    expect(offenders).toEqual([]);
+  it.each(CONTRADICTORY)("flags: %s", (fixture) => {
+    expect(contradictions(fixture)).not.toEqual([]);
+  });
+
+  it.each(CONSISTENT)("allows: %s", (fixture) => {
+    expect(contradictions(fixture)).toEqual([]);
   });
 
   it("still routes what it cannot run into [env] notes", () => {


### PR DESCRIPTION
## Summary

- `pi-review` is a required status check and `enforce_admins` is on, so `blockers.length > 0` is unbypassable by anyone, including admins. §4 of the review prompt told the reviewer to record **its own inability to run a test** as a `blocker`. The reviewer runs under `codex exec --sandbox read-only`, so any PR whose changed tests write files (`mkdtemp` → `EPERM`) could red the gate on a property of the reviewer's environment rather than of the diff.
- That is what happened to #2306: two `failure` verdicts citing "Read-only review environment prevents executing the changed narrow test", then a `success` on a re-run with byte-identical content. A gate that measures the sandbox is a coin flip with no override path.
- §2, §6, the Blockers list, and `docs/REVIEW_SCHEMA.md:176` **already** state the opposite rule — environment problems are `[env]` notes, and a blocker needs a failure the diff caused. §4 was the lone outlier across all four documents, so this deletes a contradiction rather than adding a rule.

The rule is now written around causation ("unavailable because of the reviewer's environment rather than the diff") instead of a list of symptoms, so it covers env failures nobody enumerated.

No branch-protection change is needed for this: with the prompt self-consistent, `pi-review` stays required and `enforce_admins` stays on.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted `bun test scripts/__tests__/review-prompt-env-blockers.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval — n/a

### red (guard against the unfixed prompt)

```
$ bun test scripts/__tests__/review-prompt-env-blockers.test.ts
- []
+ [
+   "you cannot run even a narrow test file), record that as a `blocker` and finish with a partial verdict.",
+ ]
(fail) states the env-vs-blocker rule in only one direction
 2 pass / 1 fail
```

### green

```
$ bun test scripts/__tests__/review-prompt-env-blockers.test.ts
 3 pass / 0 fail
```

### mutation — the guard has to bite in both directions

`A` restores the exact historical sentence. `C` keeps the correct rule and **adds** a differently-worded contradiction (`"When your sandbox denies the writes a narrow test needs, list that under blockers…"`) — the realistic drift, since guidance usually gets added rather than reverted.

```
GREEN (unmutated)   3 pass / 0 fail
MUTATION A          1 fail  <- "…record that as a `blocker` and finish with a partial verdict."
MUTATION C          1 fail  <- "- When your sandbox denies the writes a narrow test needs, list that under `blockers`…"
restored            3 pass / 0 fail
```

## Notes

**Two guard defects were found by testing the guard, not the code.**

1. The first revision **passed against the broken prompt**. It searched the whole bullet for a negation, and the offending bullet ended `Do not retry indefinitely` — a `not` from a different sentence. It also has to strip the env phrasing first, because `you cannot run even a narrow test file` sits in the same sentence and reads as its own prohibition. The committed guard scopes to the sentence naming the blocker, then strips.
2. A later revision shared one `/g` regex between `.test()` and `.replace()`. A global regex carries `lastIndex` across `.test()` calls, so the filter silently skipped every other bullet and mutation `C` passed. Split into a non-global for matching and a global for stripping.

**On `make review-fix`:** it improved the prompt wording (kept — see Summary) and rewrote the guard as an exact match on the expected sentence plus a literal check for the historical one. That version is not kept. It fails on any honest rewording, and run head-to-head against mutation `C` it reports `2 pass / 0 fail` while the parser reports `1 fail` — it pins two instances where the risk is the class.

Class check: `grep`ed all of `prompts/` and `docs/REVIEW_SCHEMA.md` for other blocker instructions — §4 was the only one pointing the wrong way.
