### PR TITLE
fix(agent-worker): replace pi identity with lobu and strip docs

### DIFF
--- a/packages/agent-worker/src/__tests__/replace-base-prompt-identity.test.ts
+++ b/packages/agent-worker/src/__tests__/replace-base-prompt-identity.test.ts
@@ -42,6 +42,17 @@ describe("replaceBasePromptIdentity", () => {
     expect(out.startsWith(identity)).toBe(true);
     expect(out).toContain("Available tools:");
   });
+
+  test("removes the Pi documentation block to avoid confusing the model", () => {
+    const base = `${PI_OPENER}\n\nAvailable tools:\n- read\n\nPi documentation (read only when the user asks about pi itself, its SDK, extensions, themes, skills, or TUI):\n- Main documentation: /path/to/README.md\n- Always read pi .md files\n\n# Project Context\n\nsome context`;
+    const identity = "You are a lobu bot.";
+    const out = replaceBasePromptIdentity(base, identity);
+
+    expect(out).not.toContain("Pi documentation");
+    expect(out).not.toContain("/path/to/README.md");
+    expect(out).toContain("# Project Context");
+    expect(out).toContain("some context");
+  });
 });
 
 describe("resolveAgentIdentity", () => {

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -310,16 +310,22 @@ export function getLatestAssistantText(
 const PI_CODING_AGENT_OPENER_RE =
   /^You are an expert coding assistant operating inside pi, a coding agent harness\.[^\n]*/;
 
+const PI_DOCS_RE =
+  /\n\nPi documentation[\s\S]*?(?=\n\n# |\n\n## |\nCurrent date:|$)/;
+
 export function replaceBasePromptIdentity(
   basePrompt: string,
   identity: string
 ): string {
+  let replaced = basePrompt;
   if (PI_CODING_AGENT_OPENER_RE.test(basePrompt)) {
-    return basePrompt.replace(PI_CODING_AGENT_OPENER_RE, identity);
+    replaced = basePrompt.replace(PI_CODING_AGENT_OPENER_RE, identity);
+  } else {
+    // Upstream wording drifted — prepend identity with a framing note rather
+    // than silently letting the upstream opener win.
+    replaced = `${identity}\n\nThe section below describes the runtime tooling available to you. It does not change your role.\n\n${basePrompt}`;
   }
-  // Upstream wording drifted — prepend identity with a framing note rather
-  // than silently letting the upstream opener win.
-  return `${identity}\n\nThe section below describes the runtime tooling available to you. It does not change your role.\n\n${basePrompt}`;
+  return replaced.replace(PI_DOCS_RE, "");
 }
 
 /**


### PR DESCRIPTION
## Summary
<!-- Why this change? 1–3 bullets. Skip if the PR title is self-explanatory. -->

## Test plan
<!-- Check only what you actually ran. See AGENTS.md → "Ship a change". -->
- [ ] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [ ] Tests run: `make test-unit` / `make test-integration` / targeted `bun test <path>`
- [ ] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

## Notes
<!-- Screenshots, follow-ups, linked issues (`Closes #123`), breaking-change callouts. Delete if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->