### PR TITLE
fix(ci): refuse to post a review verdict onto a superseded commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,6 +619,7 @@ jobs:
           bash scripts/lib/__tests__/review-commit-lock.test.sh
           bash scripts/lib/__tests__/review-process.test.sh
           bash scripts/lib/__tests__/review-reviewer.test.sh
+          bash scripts/lib/__tests__/review-upstream-guard.test.sh
 
   typecheck:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/scripts/lib/__tests__/review-upstream-guard.test.sh
+++ b/scripts/lib/__tests__/review-upstream-guard.test.sh
@@ -23,8 +23,12 @@ fail() {
 # failure this guard exists to catch.
 new_clone() {
   local name="$1" origin="$tmp/$1-origin.git" work="$tmp/$1"
-  git init -q --bare "$origin"
-  git init -q "$work"
+  # Pin the branch name: with init.defaultBranch=master (git's default when the
+  # environment leaves it unset, as CI does) the bare HEAD would point at a ref
+  # that never gets created, and the later clone would start an unrelated root
+  # commit on master instead of building on main.
+  git init -q --bare -b main "$origin"
+  git init -q -b main "$work"
   git -C "$work" config user.email t@t.t
   git -C "$work" config user.name t
   git -C "$work" commit -q --allow-empty -m base

--- a/scripts/lib/__tests__/review-upstream-guard.test.sh
+++ b/scripts/lib/__tests__/review-upstream-guard.test.sh
@@ -29,9 +29,9 @@ guard_call_count="$(
 [ "$guard_call_count" -eq 3 ] ||
   fail "review.sh must re-check the upstream at all three publication boundaries"
 
-# A clone whose upstream is a real remote, so the guard's `git fetch` is
-# exercised rather than stubbed — a stale remote-tracking ref is precisely the
-# failure this guard exists to catch.
+# A real remote, so the guard's `git ls-remote` talks to one rather than being
+# stubbed — comparing against the local remote-tracking ref is precisely the
+# mistake this guard must not make, since that ref goes stale on its own.
 # Pin the branch because Git's default differs across developer and CI hosts.
 new_clone() {
   local name="$1"

--- a/scripts/lib/__tests__/review-upstream-guard.test.sh
+++ b/scripts/lib/__tests__/review-upstream-guard.test.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+review_script="$repo_root/scripts/review.sh"
 # shellcheck source=scripts/lib/review-upstream-guard.sh
 . "$repo_root/scripts/lib/review-upstream-guard.sh"
 
@@ -18,33 +19,44 @@ fail() {
   exit 1
 }
 
+# The remote can move while the reviewer is running. Guard the cheap
+# preflight, the final commit status, and the PR comment independently.
+# shellcheck disable=SC2016
+guard_call_count="$(
+  grep -Fc 'review_assert_head_is_current "$HEAD_SHA" "$PI_REVIEW_STATUS_CONTEXT"' \
+    "$review_script" || true
+)"
+[ "$guard_call_count" -eq 3 ] ||
+  fail "review.sh must re-check the upstream at all three publication boundaries"
+
 # A clone whose upstream is a real remote, so the guard's `git fetch` is
 # exercised rather than stubbed — a stale remote-tracking ref is precisely the
 # failure this guard exists to catch.
+# Pin the branch because Git's default differs across developer and CI hosts.
 new_clone() {
-  local name="$1" origin="$tmp/$1-origin.git" work="$tmp/$1"
-  # Pin the branch name: with init.defaultBranch=master (git's default when the
-  # environment leaves it unset, as CI does) the bare HEAD would point at a ref
-  # that never gets created, and the later clone would start an unrelated root
-  # commit on master instead of building on main.
-  git init -q --bare -b main "$origin"
-  git init -q -b main "$work"
+  local name="$1"
+  local origin="$tmp/$name-origin.git"
+  local work="$tmp/$name"
+  git init -q --bare "$origin"
+  git -C "$origin" symbolic-ref HEAD refs/heads/main
+  git init -q "$work"
+  git -C "$work" symbolic-ref HEAD refs/heads/main
   git -C "$work" config user.email t@t.t
   git -C "$work" config user.name t
   git -C "$work" commit -q --allow-empty -m base
   git -C "$work" remote add origin "$origin"
-  git -C "$work" push -q -u origin HEAD:refs/heads/main 2>/dev/null
+  git -C "$work" push -q -u origin main
   printf '%s\n' "$work"
 }
 
 # Simulates Codex pushing to the branch from elsewhere.
 push_from_elsewhere() {
   local work="$1" other="$tmp/other-$RANDOM"
-  git clone -q "$(git -C "$work" remote get-url origin)" "$other"
+  git clone -q -b main "$(git -C "$work" remote get-url origin)" "$other"
   git -C "$other" config user.email c@c.c
   git -C "$other" config user.name Codesmith
   git -C "$other" commit -q --allow-empty -m "style: apply biome formatting"
-  git -C "$other" push -q origin HEAD:main
+  git -C "$other" push -q origin main
 }
 
 run_guard() {

--- a/scripts/lib/__tests__/review-upstream-guard.test.sh
+++ b/scripts/lib/__tests__/review-upstream-guard.test.sh
@@ -68,6 +68,18 @@ run_guard() {
 work="$(new_clone insync)"
 run_guard "$work" || fail "rejected a HEAD that matches its upstream"
 
+# 1b. Reading the remote must write nothing locally. `git fetch` would answer
+#     the same question but clobbers FETCH_HEAD — per-worktree scratch state
+#     shared with every other git command running there — and downloads
+#     objects this check never needs. `ls-remote` asks the remote directly.
+#     This is the assertion that separates the two: under fetch the sentinel
+#     below is destroyed.
+fetch_head="$(cd "$work" && git rev-parse --git-path FETCH_HEAD)"
+printf 'sentinel\n' >"$work/$fetch_head"
+run_guard "$work" || fail "rejected a HEAD that matches its upstream"
+[ "$(cat "$work/$fetch_head")" = "sentinel" ] \
+  || fail "guard wrote FETCH_HEAD — it must not touch shared worktree state"
+
 # 2. Local commits not yet pushed. review.sh reviews unpushed commits by
 #    design (the CI snapshot is just empty), so being AHEAD must stay allowed.
 work="$(new_clone ahead)"

--- a/scripts/lib/__tests__/review-upstream-guard.test.sh
+++ b/scripts/lib/__tests__/review-upstream-guard.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+# shellcheck source=scripts/lib/review-upstream-guard.sh
+. "$repo_root/scripts/lib/review-upstream-guard.sh"
+
+tmp="$(mktemp -d /tmp/lobu-review-upstream-guard-test.XXXXXX)"
+cleanup() {
+  trap - EXIT INT TERM HUP
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# A clone whose upstream is a real remote, so the guard's `git fetch` is
+# exercised rather than stubbed — a stale remote-tracking ref is precisely the
+# failure this guard exists to catch.
+new_clone() {
+  local name="$1" origin="$tmp/$1-origin.git" work="$tmp/$1"
+  git init -q --bare "$origin"
+  git init -q "$work"
+  git -C "$work" config user.email t@t.t
+  git -C "$work" config user.name t
+  git -C "$work" commit -q --allow-empty -m base
+  git -C "$work" remote add origin "$origin"
+  git -C "$work" push -q -u origin HEAD:refs/heads/main 2>/dev/null
+  printf '%s\n' "$work"
+}
+
+# Simulates Codex pushing to the branch from elsewhere.
+push_from_elsewhere() {
+  local work="$1" other="$tmp/other-$RANDOM"
+  git clone -q "$(git -C "$work" remote get-url origin)" "$other"
+  git -C "$other" config user.email c@c.c
+  git -C "$other" config user.name Codesmith
+  git -C "$other" commit -q --allow-empty -m "style: apply biome formatting"
+  git -C "$other" push -q origin HEAD:main
+}
+
+run_guard() {
+  local work="$1"
+  ( cd "$work" && review_assert_head_is_current "$(git rev-parse HEAD)" pi-review ) 2>"$tmp/err"
+}
+
+# 1. Up to date with the remote — the ordinary case, must pass.
+work="$(new_clone insync)"
+run_guard "$work" || fail "rejected a HEAD that matches its upstream"
+
+# 2. Local commits not yet pushed. review.sh reviews unpushed commits by
+#    design (the CI snapshot is just empty), so being AHEAD must stay allowed.
+work="$(new_clone ahead)"
+git -C "$work" commit -q --allow-empty -m "local work"
+run_guard "$work" || fail "rejected a HEAD that is merely ahead of its upstream"
+
+# 3. The remote moved and HEAD does not contain it — a verdict posted here
+#    lands on a commit that is not the PR head. This is the bug.
+work="$(new_clone behind)"
+push_from_elsewhere "$work"
+if run_guard "$work"; then
+  fail "accepted a HEAD superseded on the remote — the verdict would be orphaned"
+fi
+grep -q "does not contain" "$tmp/err" \
+  || fail "stale-head error did not explain the problem: $(cat "$tmp/err")"
+
+# 4. Diverged: both sides moved. Still unsafe, for the same reason.
+work="$(new_clone diverged)"
+git -C "$work" commit -q --allow-empty -m "local work"
+push_from_elsewhere "$work"
+if run_guard "$work"; then
+  fail "accepted a diverged HEAD"
+fi
+
+# 5. No upstream at all — nothing to strand, so the review proceeds.
+git init -q "$tmp/noupstream"
+git -C "$tmp/noupstream" config user.email t@t.t
+git -C "$tmp/noupstream" config user.name t
+git -C "$tmp/noupstream" commit -q --allow-empty -m base
+run_guard "$tmp/noupstream" || fail "rejected a branch that was never pushed"
+
+# 6. Unreachable remote must fail OPEN: this guard prevents a wasted verdict,
+#    it is not a correctness gate, and blocking offline review would be worse.
+work="$(new_clone offline)"
+git -C "$work" remote set-url origin "$tmp/does-not-exist.git"
+run_guard "$work" || fail "blocked the review when the remote was unreachable"
+grep -q "skipping stale-head check" "$tmp/err" \
+  || fail "fail-open path did not warn: $(cat "$tmp/err")"
+
+echo "review-upstream-guard.test.sh: all cases pass"

--- a/scripts/lib/review-upstream-guard.sh
+++ b/scripts/lib/review-upstream-guard.sh
@@ -1,0 +1,59 @@
+# review-upstream-guard.sh — refuse to post a verdict onto a superseded commit.
+# shellcheck shell=bash
+#
+# review.sh posts the pi-review status to `repos/$repo/statuses/$HEAD_SHA` —
+# the LOCAL head. Codex (committer `Codesmith`) pushes commits to open PR
+# branches asynchronously; it has done so on 15+ branches in the last 30 days.
+# When it lands one while a review is in flight, the verdict attaches to a
+# commit that is no longer the PR head, the real head carries no `pi-review`
+# status at all, and because that context is required with enforce_admins the
+# PR sits blocked forever. Nothing reports the problem: the reviewer exits 0,
+# the status posts successfully, and the PR just never becomes mergeable.
+#
+# Being AHEAD of the remote is fine and stays allowed — review.sh already
+# supports reviewing unpushed commits (the CI snapshot is simply empty). The
+# only unsafe case is the remote holding commits this HEAD does not contain,
+# which is exactly `! git merge-base --is-ancestor <upstream> HEAD`.
+
+# Exits non-zero when the upstream branch has moved past HEAD.
+#   $1 — HEAD sha the verdict would be posted to
+#   $2 — status context name, for the message only (default: pi-review)
+review_assert_head_is_current() {
+  local head_sha="$1"
+  local status_context="${2:-pi-review}"
+  local upstream remote branch upstream_sha
+
+  upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+  # No upstream: the branch was never pushed, so there is no PR head to
+  # strand. review.sh reviews it diff-only by design.
+  [ -n "$upstream" ] || return 0
+
+  remote="${upstream%%/*}"
+  branch="${upstream#*/}"
+
+  # The remote-tracking ref goes stale on its own, so the fetch is
+  # load-bearing — without it this compares against whatever was last seen
+  # locally and passes exactly when it matters most.
+  if ! git fetch -q "$remote" "$branch" 2>/dev/null; then
+    # Offline or the branch is gone from the remote. Fail open: this guard
+    # exists to stop a wasted verdict, not to gate correctness, and a review
+    # that cannot run at all is worse than one posted from stale information.
+    printf '>> warning: could not fetch %s — skipping stale-head check\n' "$upstream" >&2
+    return 0
+  fi
+
+  upstream_sha="$(git rev-parse FETCH_HEAD 2>/dev/null || true)"
+  [ -n "$upstream_sha" ] || return 0
+
+  git merge-base --is-ancestor "$upstream_sha" "$head_sha" 2>/dev/null && return 0
+
+  printf '!! %s is at %s, which HEAD (%s) does not contain.\n' \
+    "$upstream" "${upstream_sha:0:9}" "${head_sha:0:9}" >&2
+  printf '   Someone pushed while you were working — Codex pushes to open PR\n' >&2
+  printf '   branches, so check `git log --format=%%cn` before assuming an agent.\n' >&2
+  printf '   A verdict posted now would attach to a commit that is not the PR\n' >&2
+  printf "   head, leaving the real head with no '%s' status and the PR\n" "$status_context" >&2
+  printf '   blocked with nothing reporting why.\n' >&2
+  printf '   Integrate first:  git pull --rebase   (then re-run the tests)\n' >&2
+  return 1
+}

--- a/scripts/lib/review-upstream-guard.sh
+++ b/scripts/lib/review-upstream-guard.sh
@@ -33,12 +33,15 @@ review_assert_head_is_current() {
 
   # Ask the remote directly. The remote-tracking ref goes stale on its own, so
   # comparing against it would pass exactly when it matters most — but a
-  # `git fetch` is the wrong way to refresh it here: fetch writes FETCH_HEAD,
-  # which is per-worktree shared scratch, and review.sh runs reviews of
-  # different commits concurrently. Reading a FETCH_HEAD another command had
-  # already overwritten produced an unparseable sha and a silent fail-OPEN —
-  # the guard would allow precisely the case it exists to catch.
-  # `ls-remote` writes nothing and needs no object download.
+  # `git fetch` is the wrong way to refresh it here: it writes FETCH_HEAD,
+  # per-worktree scratch shared with every other git command in the worktree,
+  # and downloads objects this check never needs. `ls-remote` writes nothing.
+  #
+  # No concurrent-corruption bug was ever demonstrated — fetch rewrites
+  # FETCH_HEAD immediately before the read, so a seeded value never survived
+  # to be misread. The reason to prefer `ls-remote` is simply that a read-only
+  # check should not mutate shared state, which is also the one property the
+  # test can actually assert.
   upstream_sha="$(git ls-remote "$remote" "refs/heads/$branch" 2>/dev/null | awk 'NR==1{print $1}')"
   if [ -z "$upstream_sha" ]; then
     # Offline, or the branch is gone from the remote. Fail open: this guard

--- a/scripts/lib/review-upstream-guard.sh
+++ b/scripts/lib/review-upstream-guard.sh
@@ -31,20 +31,26 @@ review_assert_head_is_current() {
   remote="${upstream%%/*}"
   branch="${upstream#*/}"
 
-  # The remote-tracking ref goes stale on its own, so the fetch is
-  # load-bearing — without it this compares against whatever was last seen
-  # locally and passes exactly when it matters most.
-  if ! git fetch -q "$remote" "$branch" 2>/dev/null; then
-    # Offline or the branch is gone from the remote. Fail open: this guard
+  # Ask the remote directly. The remote-tracking ref goes stale on its own, so
+  # comparing against it would pass exactly when it matters most — but a
+  # `git fetch` is the wrong way to refresh it here: fetch writes FETCH_HEAD,
+  # which is per-worktree shared scratch, and review.sh runs reviews of
+  # different commits concurrently. Reading a FETCH_HEAD another command had
+  # already overwritten produced an unparseable sha and a silent fail-OPEN —
+  # the guard would allow precisely the case it exists to catch.
+  # `ls-remote` writes nothing and needs no object download.
+  upstream_sha="$(git ls-remote "$remote" "refs/heads/$branch" 2>/dev/null | awk 'NR==1{print $1}')"
+  if [ -z "$upstream_sha" ]; then
+    # Offline, or the branch is gone from the remote. Fail open: this guard
     # exists to stop a wasted verdict, not to gate correctness, and a review
     # that cannot run at all is worse than one posted from stale information.
-    printf '>> warning: could not fetch %s — skipping stale-head check\n' "$upstream" >&2
+    printf '>> warning: could not read %s from %s — skipping stale-head check\n' \
+      "$branch" "$remote" >&2
     return 0
   fi
 
-  upstream_sha="$(git rev-parse FETCH_HEAD 2>/dev/null || true)"
-  [ -n "$upstream_sha" ] || return 0
-
+  # An unknown object means the remote holds a commit this checkout has never
+  # seen, so `--is-ancestor` errors and the guard refuses — which is right.
   git merge-base --is-ancestor "$upstream_sha" "$head_sha" 2>/dev/null && return 0
 
   printf '!! %s is at %s, which HEAD (%s) does not contain.\n' \

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -43,6 +43,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/lib/review-process.sh"
 # shellcheck source=scripts/lib/review-reviewer.sh
 . "$SCRIPT_DIR/lib/review-reviewer.sh"
+# shellcheck source=scripts/lib/review-upstream-guard.sh
+. "$SCRIPT_DIR/lib/review-upstream-guard.sh"
 
 # --- preflight --------------------------------------------------------------
 
@@ -104,6 +106,11 @@ echo ">> cwd:  $(pwd)"
 echo ">> base: $BASE_BRANCH (merge-base $MERGE_BASE)"
 echo ">> head: $HEAD_SHA"
 echo ">> reviewer: $REVIEWER_CLI_SELECTED"
+
+# Before spending a reviewer run, make sure the verdict can actually land on
+# the PR head. Runs ahead of the build and the commit lock so a superseded
+# HEAD costs nothing.
+review_assert_head_is_current "$HEAD_SHA" "$PI_REVIEW_STATUS_CONTEXT" || exit 2
 
 post_review_status() {
   [ "$GH_AVAILABLE" = "1" ] || return 0

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -134,6 +134,14 @@ post_review_status() {
 REVIEW_STATUS_STARTED=0
 REVIEW_STATUS_FINALIZED=0
 finalize_review_status() {
+  # The upstream can move during the reviewer run. Do not finalize a verdict
+  # on a commit that is no longer the PR head.
+  if [ "$GH_AVAILABLE" = "1" ] &&
+     ! review_assert_head_is_current "$HEAD_SHA" "$PI_REVIEW_STATUS_CONTEXT"; then
+    # Suppress the EXIT trap's fallback error status on the same stale commit.
+    REVIEW_STATUS_FINALIZED=1
+    return 2
+  fi
   post_review_status "$1" "$2" "${3:-}"
   REVIEW_STATUS_FINALIZED=1
 }
@@ -428,6 +436,9 @@ finalize_review_status "$STATUS_STATE" "$STATUS_DESCRIPTION" "$PR_URL"
 if [ -z "$PR_NUMBER" ]; then
   echo ">> no PR for current branch; skipping GitHub comment"
 else
+  # A push between the final status and this comment would make the displayed
+  # verdict stale even though branch protection correctly blocks the new head.
+  review_assert_head_is_current "$HEAD_SHA" "$PI_REVIEW_STATUS_CONTEXT" || exit 2
   NOTES="$(echo "$VERDICT" | jq -r '.notes // ""')"
   PRETTY="$(echo "$VERDICT" | jq .)"
   SUGGESTIONS_TABLE="$(echo "$VERDICT" | jq -r '


### PR DESCRIPTION
## Summary

- `scripts/review.sh:96` takes `HEAD_SHA` from the **local** head and never compares it to the remote, then posts the verdict to `repos/$repo/statuses/$HEAD_SHA` (`:123`). Codex — committer `Codesmith` — pushes commits to open PR branches asynchronously: measured today, 15+ branches in the last 30 days, up to 8 commits on one, and twice onto #2308 while its review was running.
- When one lands mid-review the verdict attaches to a commit that is no longer the PR head. The real head then carries **no `pi-review` status at all**, and since that context is required with `enforce_admins: true`, the PR is blocked with nothing reporting why — the reviewer exits 0, the status posts successfully, and the PR simply never becomes mergeable.
- The guard runs before the build and before the commit lock, so a superseded HEAD costs nothing instead of a full reviewer run.

Scope decisions:

- **Being ahead of the remote stays allowed.** `review.sh` supports reviewing unpushed commits by design (the CI snapshot is just empty). The unsafe case is only the remote holding commits HEAD lacks — exactly `! git merge-base --is-ancestor <upstream> HEAD`.
- **Unreachable remote fails open** with a warning. This guards against a wasted verdict, not correctness; blocking offline review would be the worse failure.
- **The remote is read with `git ls-remote`, not `git fetch`.** The remote-tracking ref goes stale on its own so it cannot be trusted, but `fetch` writes `FETCH_HEAD` — per-worktree scratch shared with every other git command there — and downloads objects this check never needs. `ls-remote` writes nothing.
- **Guarded at all three publication boundaries**, not just the preflight: the reviewer run takes minutes, and that is the window Codesmith actually pushed into on #2308. The upstream is re-checked before the final commit status and before the PR comment.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bash scripts/lib/__tests__/review-upstream-guard.test.sh` (6 cases), wired into CI's "Review tooling shell tests"
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval — n/a

### e2e — the real `./scripts/review.sh`, remote ahead by one Codesmith commit

```
local: a93c3dc4f   upstream stale/probe: b510ee6ba
>> head: a93c3dc4f418b64856e18321bcfb76c3c99b1250
>> reviewer: codex
!! stale/probe is at b510ee6ba, which HEAD (a93c3dc4f) does not contain.
   Someone pushed while you were working — Codex pushes to open PR
   branches, so check `git log --format=%cn` before assuming an agent.
   A verdict posted now would attach to a commit that is not the PR
   head, leaving the real head with no 'pi-review' status and the PR
   blocked with nothing reporting why.
   Integrate first:  git pull --rebase   (then re-run the tests)
exit=2
```

Refused before `make build-packages` and before `invoking codex review` — both of which the same command reached on the unguarded run. On a correctly-synced branch the guard returns `ALLOWED`.

### unit — 6 cases

```
$ bash scripts/lib/__tests__/review-upstream-guard.test.sh
review-upstream-guard.test.sh: all cases pass
```

in sync → pass · ahead (unpushed) → pass · remote ahead → refuse · diverged → refuse · no upstream → pass · unreachable remote → fail open with warning

### mutation — the guard has to bite

```
MUTATION reversed is-ancestor args:   caught -> FAIL: rejected a HEAD that is merely ahead of its upstream
MUTATION always allow:                caught -> FAIL: accepted a HEAD superseded on the remote
MUTATION back to fetch/FETCH_HEAD:    caught -> FAIL: guard wrote FETCH_HEAD — it must not touch shared worktree state
restored:                             all cases pass
```

Also green under both `init.defaultBranch=main` and `=master` — CI's differs from this host's, which is what failed `format-lint` on the first push.

### corrections made during review

Two claims I made and then disproved, recorded because the PR body asserted them at one point:

1. I wrote a FETCH_HEAD test case that **passed against both implementations** — `fetch` rewrites `FETCH_HEAD` before the read, so a seeded sentinel never mattered. The claim of a "silent fail-open" that I derived from it was wrong. The committed case asserts the one property that actually separates them: whether the check writes locally at all.
2. The first `format-lint` failure looked like a guard failure but was a fixture bug (`init.defaultBranch`). Reproduced locally with `GIT_CONFIG_KEY_0=init.defaultBranch=master` before fixing.

## Notes

Reversed `--is-ancestor` arguments are a repeat offender in this repo (the rollout gate in AGENTS.md step 10 documents the same trap), which is why it is an explicit mutation case rather than a code comment.

This does not stop Codex from pushing — feature branches have no protection at all (all three rulesets target `~DEFAULT_BRANCH`; `gh api .../branches --jq 'select(.protected)'` is empty). It only makes the collision loud instead of silent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guard to prevent review statuses and verdicts from being posted for outdated pull request commits.
  * Reviews re-check commit currency before reviewing, publishing statuses, and updating the review marker/comment.
  * Clear warnings are shown when newer or stale commits are detected.

* **Bug Fixes**
  * Avoids stale verdict publication and suppresses fallback error-status behavior when the head moves.

* **Tests**
  * Added scenarios covering updated head, divergent histories, missing upstream, and unreachable remotes (including no workspace state mutation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->