### PR TITLE
fix(server): reclaim expired chat-state claims instead of blocking forever

### DIFF
--- a/packages/server/src/gateway/connections/__tests__/state-adapter-expiry-reclaim.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/state-adapter-expiry-reclaim.test.ts
@@ -1,0 +1,181 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { Chat } from "chat";
+import { getDb } from "../../../db/client.js";
+import { createConnectedGatewayStateAdapter } from "../state-adapter.js";
+
+const hasDb = Boolean(process.env.DATABASE_URL);
+const suffix = `${process.pid}-${Date.now()}`;
+const cacheKeys = new Set<string>();
+
+function key(name: string): string {
+  const cacheKey = `test:expiry-reclaim:${name}:${suffix}`;
+  cacheKeys.add(cacheKey);
+  return cacheKey;
+}
+
+const adapters: Array<{ disconnect(): Promise<void> }> = [];
+
+async function connect() {
+  const adapter = await createConnectedGatewayStateAdapter();
+  adapters.push(adapter);
+  return adapter;
+}
+
+afterEach(async () => {
+  if (!hasDb) return;
+  const sql = getDb();
+  for (const cacheKey of cacheKeys) {
+    await sql`
+      DELETE FROM chat_state_cache
+      WHERE key_prefix = 'chat-conn' AND cache_key = ${cacheKey}
+    `;
+  }
+  cacheKeys.clear();
+});
+
+afterAll(async () => {
+  for (const adapter of adapters) await adapter.disconnect();
+});
+
+describe("LobuStateAdapter.setIfNotExists expiry semantics", () => {
+  test.skipIf(!hasDb)("reclaims an expired key", async () => {
+    const adapter = await connect();
+    const k = key("expired");
+
+    // 🚨 Do NOT assert `get()` before the claim. `get` opportunistically DELETES
+    // an expired row on miss, which removes the condition under test and makes
+    // this pass against the unfixed code. The bug only surfaces on a claim path
+    // that never reads first — exactly what the SDK's dedupe does.
+    await adapter.set(k, "stale", -1000);
+    expect(await adapter.setIfNotExists(k, "fresh", 60_000)).toBe(true);
+    expect(await adapter.get(k)).toBe("fresh");
+  });
+
+  test.skipIf(!hasDb)("preserves a live key", async () => {
+    const adapter = await connect();
+    const k = key("live");
+
+    expect(await adapter.setIfNotExists(k, "first", 60_000)).toBe(true);
+    expect(await adapter.setIfNotExists(k, "second", 60_000)).toBe(false);
+    expect(await adapter.get(k)).toBe("first");
+  });
+
+  test.skipIf(!hasDb)("preserves a non-expiring key", async () => {
+    const adapter = await connect();
+    const k = key("no-ttl");
+
+    await adapter.set(k, "permanent");
+    expect(await adapter.setIfNotExists(k, "usurper", 60_000)).toBe(false);
+    expect(await adapter.get(k)).toBe("permanent");
+  });
+
+  test.skipIf(!hasDb)(
+    "an expired claim is reclaimable repeatedly, not just once",
+    async () => {
+      const adapter = await connect();
+      const k = key("repeat");
+
+      await adapter.set(k, "gen1", -1000);
+      expect(await adapter.setIfNotExists(k, "gen2", -1000)).toBe(true);
+      expect(await adapter.setIfNotExists(k, "gen3", 60_000)).toBe(true);
+      expect(await adapter.get(k)).toBe("gen3");
+    },
+  );
+
+  test.skipIf(!hasDb)("only one concurrent caller reclaims an expired key", async () => {
+    const adapter = await connect();
+    const k = key("concurrent");
+    await adapter.set(k, "stale", -1000);
+
+    const claims = await Promise.all(
+      ["first", "second"].map(async (value) => ({
+        value,
+        claimed: await adapter.setIfNotExists(k, value, 60_000),
+      })),
+    );
+    const winner = claims.filter(({ claimed }) => claimed);
+
+    expect(winner).toHaveLength(1);
+    expect(await adapter.get(k)).toBe(winner[0]!.value);
+  });
+});
+
+describe("Chat SDK inbound dedupe over the Postgres adapter", () => {
+  function createAdapter() {
+    return {
+      name: "test",
+      userName: "lobubot",
+      async initialize() {},
+      isDM: () => true,
+      channelIdFromThreadId: (threadId: string) => threadId,
+      getChannelVisibility: () => "private" as const,
+    };
+  }
+
+  function createMessage(id: string, text: string) {
+    return {
+      id,
+      text,
+      author: {
+        userId: "42",
+        userName: "human",
+        fullName: "Human",
+        isBot: false,
+        isMe: false,
+      },
+      isMention: false,
+    };
+  }
+
+  test.skipIf(!hasDb)(
+    "a stale dedupe row no longer swallows a replayed message id",
+    async () => {
+      const state = await connect();
+      const messageId = `mid-${suffix}`;
+      const dedupeKey = `dedupe:test:${messageId}`;
+      const threadId = `test:dm-${suffix}`;
+      const delivered: string[] = [];
+      cacheKeys.add(dedupeKey);
+
+      const adapter = createAdapter();
+      const chat = new Chat({
+        userName: "lobubot",
+        adapters: { test: adapter as never },
+        state: state as never,
+        logger: "silent",
+      });
+      chat.onDirectMessage(async (_t: unknown, m: { text: string }) => {
+        delivered.push(m.text);
+      });
+      await chat.initialize();
+
+      const dispatch = async (text: string) => {
+        let processing: Promise<void> | undefined;
+        chat.processMessage(adapter as never, threadId, createMessage(messageId, text) as never, {
+          waitUntil(task) {
+            processing = task;
+          },
+        });
+        if (!processing) throw new Error("SDK registered no background task");
+        await processing;
+      };
+
+      await dispatch("first");
+      expect(delivered).toEqual(["first"]);
+
+      await dispatch("redelivery");
+      expect(delivered).toEqual(["first"]);
+
+      const sql = getDb();
+      await sql`
+        UPDATE chat_state_cache
+        SET expires_at = now() - interval '1 hour'
+        WHERE key_prefix = 'chat-conn' AND cache_key = ${dedupeKey}
+      `;
+
+      await dispatch("after expiry");
+      expect(delivered).toEqual(["first", "after expiry"]);
+      await chat.shutdown();
+    },
+  );
+});

--- a/packages/server/src/gateway/connections/state-adapter.ts
+++ b/packages/server/src/gateway/connections/state-adapter.ts
@@ -212,6 +212,22 @@ class LobuStateAdapter implements StateAdapter {
     `;
   }
 
+  /**
+   * Claim `key` iff it is not currently held — where "held" means present AND
+   * unexpired. Both callers are TTL-bounded claims: the Chat SDK's inbound
+   * dedupe (5-minute window) and `claimThreadBackfill` (24-hour window, whose
+   * own docstring promises "at most once per thread per TTL window"). A lapsed
+   * claim must therefore be re-acquirable.
+   *
+   * A bare `ON CONFLICT DO NOTHING` blocks on the row's EXISTENCE, not its
+   * validity, and expired rows are only swept opportunistically inside `get()`
+   * — which this path never calls. That turned every TTL here into "once,
+   * permanently": a Telegram message id claimed by one bot silently discarded a
+   * different bot's message months later, since ids restart at 1 per bot chat.
+   *
+   * Mirrors `acquireLock` above; this was the one TTL-bounded claim in the file
+   * not already written that way.
+   */
   async setIfNotExists(
     key: string,
     value: unknown,
@@ -223,7 +239,15 @@ class LobuStateAdapter implements StateAdapter {
     const rows = await this.sql<{ cache_key: string }>`
       INSERT INTO chat_state_cache (key_prefix, cache_key, value, expires_at)
       VALUES (${this.keyPrefix}, ${key}, ${serialized}, ${expiresAt})
-      ON CONFLICT (key_prefix, cache_key) DO NOTHING
+      ON CONFLICT (key_prefix, cache_key) DO UPDATE
+        SET value = EXCLUDED.value,
+            expires_at = EXCLUDED.expires_at,
+            updated_at = now()
+        -- Expired rows are logically absent. A live row fails this guard, so
+        -- nothing is updated and RETURNING is empty: the caller sees false and
+        -- the stored value is untouched. A NULL expires_at (never expires) also
+        -- fails it, since NULL compared to now() is NULL rather than TRUE.
+        WHERE chat_state_cache.expires_at <= now()
       RETURNING cache_key
     `;
     return rows.length > 0;


### PR DESCRIPTION
## Summary
- `setIfNotExists` used a bare `ON CONFLICT DO NOTHING`, which blocks on a row's **existence** rather than its **validity**. Expired rows are only swept opportunistically inside `get()` — a path this primitive never takes — so every TTL it backs silently meant "once, permanently" instead of "once per window".
- Both callers are TTL-bounded claims: the Chat SDK's inbound dedupe (5-minute window) and `claimThreadBackfill` (24-hour window, whose own docstring promises "at most once per thread per TTL window"). Neither could ever re-acquire a lapsed key.
- **Prod impact:** Telegram message ids restart at 1 for each new bot's private chat, so a new bot replayed ids a previous bot had already burned. Every replayed id read as a duplicate and the user's message was discarded with an HTTP 200 and no log line. In org `buremba`, dedupe rows written in May (ids 1–6) were still blocking messages in July; messages landing on unused ids (8, 10, 12) worked, which is exactly the observed pattern.
- Fix mirrors `acquireLock` ~100 lines above, which already used `DO UPDATE … WHERE expires_at <= now()`. This was the only TTL-bounded claim in the file not written that way.

This is a **separate defect from #2305**. #2305 fixed an unguarded history-cache write that dropped messages *after* the dedupe claim; this one drops them *at* the claim. #2305's "confirmed reproducer" (`KK4477 ping`, a low message id) was in fact killed by this bug — its post-fix verification used a fresh chat id whose id space could not collide, which is why it passed.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted `bun test packages/server/src/gateway/connections/__tests__/state-adapter-expiry-reclaim.test.ts` + regression on `inbound-dispatch-parity`, `state-adapter-connect`, `session-manager`, `chat-history-store` (26 tests, all green)
- [x] Bug fix: red→fix→green outputs pasted below

### RED (fix reverted to `ON CONFLICT DO NOTHING`)
```
(fail) LobuStateAdapter.setIfNotExists expiry semantics > reclaims an expired key
(fail) LobuStateAdapter.setIfNotExists expiry semantics > an expired claim is reclaimable repeatedly, not just once
(fail) LobuStateAdapter.setIfNotExists expiry semantics > only one concurrent caller reclaims an expired key
(fail) Chat SDK inbound dedupe over the Postgres adapter > a stale dedupe row no longer swallows a replayed message id
 2 pass
 4 fail
```

### GREEN (fix applied)
```
 6 pass
 0 fail
 15 expect() calls
Ran 6 tests across 1 file. [185.00ms]
```

## Notes
**Tests run against real Postgres deliberately** — the defect lives in the conflict clause's SQL semantics, so an in-memory fake cannot reproduce it. The suite includes an end-to-end case that drives the **real Chat SDK** (`processMessage`) over the **real Postgres adapter**: deliver → redelivery suppressed (proving dedupe is not weakened) → age the row past its TTL → replayed id delivered.

**Trap worth knowing (comment in the test):** an assertion of `get()` *before* the claim makes the test pass against the unfixed code, because `get` opportunistically deletes an expired row on miss and removes the condition under test. The first draft of this test did exactly that and passed for the wrong reason.

**Mutation-tested.** Reverting to `DO NOTHING` fails 4 tests including the SDK-level one. Separately, an `expires_at IS NOT NULL` clause was tried and then removed after mutation testing showed it never bites — Postgres three-valued logic already excludes NULL (`NULL <= now()` is NULL, not TRUE). The behaviour stays pinned by the "preserves a non-expiring key" test rather than by redundant SQL.

**Class check:** every other `INSERT … ON CONFLICT DO NOTHING` in `packages/server/src` was checked against whether its table has an `expires_at` column. None do. Single instance; class closed.

### Follow-up (not in this PR)
The dedupe key is `dedupe:<platform>:<chatId>:<messageId>` under a single global `keyPrefix` (`chat-conn`), so the key space is shared across every connection **and every org**. This fix removes the permanent-poisoning failure; a same-window collision between two bots messaging the same user remains theoretically possible. Scoping the prefix per connection is the correct fix but orphans existing rows (sessions included), so it needs its own change with a TTL-window plan.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->