### PR TITLE
fix(server): stop provider rows being created unroutable, and log the fallback

### DIFF
--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -986,6 +986,29 @@ export class WorkerGateway {
           break;
         }
       }
+      // The fallback silently re-points the turn at a provider the model does
+      // not belong to, so "<slug>/<model>" goes upstream verbatim and returns an
+      // opaque "400 invalid model ID" naming neither the requested provider nor
+      // the reason it was skipped. The provider is usually INSTALLED but not
+      // routable — commonly an `inference_providers` row with no
+      // `capabilities.<modality>` block, whose org key therefore never resolves.
+      // Without this line the only evidence is a slash surviving in the model id.
+      const requestedSlug = agentModel?.includes("/")
+        ? agentModel.slice(0, agentModel.indexOf("/"))
+        : undefined;
+      if (requestedSlug && requestedSlug !== primaryProvider?.providerId) {
+        logger.warn(
+          {
+            agentId,
+            organizationId,
+            agentModel,
+            requestedProvider: requestedSlug,
+            fallbackProvider: primaryProvider?.providerId ?? null,
+            installedProviders: effectiveProviders.map((p) => p.providerId),
+          },
+          "Requested model's provider is not routable (not installed, or no resolvable credential) — falling back to a credentialed provider; the model keeps its prefix"
+        );
+      }
     }
 
     // Build proxy base URL mappings for all installed providers

--- a/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
@@ -1,0 +1,163 @@
+/** Route coverage for seeding a catalog default text model at provider create. */
+
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import { __resetEncryptionKeyCacheForTests } from "@lobu/core";
+import {
+	ensureDbForGatewayTests,
+	resetTestDatabase,
+} from "../../gateway/__tests__/helpers/db-setup.js";
+import { authStash, installRouteTestMocks } from "./helpers/route-test-mocks";
+
+installRouteTestMocks();
+
+const TEST_ENCRYPTION_KEY =
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const ORG = "org-create-seed";
+const USER = "u-create-seed";
+let savedEncryptionKey: string | undefined;
+let savedRegistryPath: string | undefined;
+
+beforeAll(async () => {
+	savedEncryptionKey = process.env.ENCRYPTION_KEY;
+	savedRegistryPath = process.env.LOBU_PROVIDER_REGISTRY_PATH;
+	await ensureDbForGatewayTests();
+	process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+	__resetEncryptionKeyCacheForTests();
+	// The route resolves the registry via cwd/config/providers.json, which is the
+	// REPO root — not packages/server, where the test runs. Point at the real
+	// file so the seed reads the same catalog defaults production does.
+	process.env.LOBU_PROVIDER_REGISTRY_PATH = new URL(
+		"../../../../../config/providers.json",
+		import.meta.url,
+	).pathname;
+}, 60_000);
+
+afterAll(() => {
+	if (savedEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+	else process.env.ENCRYPTION_KEY = savedEncryptionKey;
+	if (savedRegistryPath === undefined)
+		delete process.env.LOBU_PROVIDER_REGISTRY_PATH;
+	else process.env.LOBU_PROVIDER_REGISTRY_PATH = savedRegistryPath;
+	__resetEncryptionKeyCacheForTests();
+});
+
+async function seedOrg(): Promise<void> {
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${USER}, 'Test', 'cs@test', true, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+	await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG}, ${ORG}, ${ORG})
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+async function createProvider(body: Record<string, unknown>): Promise<Response> {
+	const mod = await import("../agent-routes.js");
+	return await mod.agentRoutes.request("/inference-providers", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+async function readCapabilities(slug: string): Promise<unknown> {
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	const rows = (await sql`
+    SELECT capabilities FROM inference_providers
+    WHERE organization_id = ${ORG} AND slug = ${slug} AND deleted_at IS NULL
+    LIMIT 1
+  `) as Array<{ capabilities: unknown }>;
+	return rows[0]?.capabilities;
+}
+
+describe("POST /inference-providers seeds a routable text model", () => {
+	beforeEach(async () => {
+		await resetTestDatabase();
+		await seedOrg();
+		authStash.user = {
+			id: USER,
+			name: "Test",
+			email: "cs@test",
+			emailVerified: true,
+		};
+		authStash.organizationId = ORG;
+		authStash.authSource = "session";
+		authStash.mcpAuthInfo = null;
+	});
+
+	test("a catalog provider created with NO capabilities gets the catalog default model", async () => {
+		const res = await createProvider({
+			slug: "gemini",
+			kind: "gemini",
+			apiKey: "AIza-test",
+		});
+		expect(res.status).toBe(201);
+
+		// Without the seed this remains `{}` and cannot become the org default.
+		const capabilities = (await readCapabilities("gemini")) as {
+			text?: { model?: string };
+		};
+		expect(capabilities?.text?.model).toBe("gemini-2.5-pro");
+	});
+
+	test("an explicitly requested model is NOT overwritten by the catalog default", async () => {
+		const res = await createProvider({
+			slug: "gemini",
+			kind: "gemini",
+			apiKey: "AIza-test",
+			capabilities: { text: { model: "gemini-2.5-flash" } },
+		});
+		expect(res.status).toBe(201);
+
+		const capabilities = (await readCapabilities("gemini")) as {
+			text?: { model?: string };
+		};
+		expect(capabilities?.text?.model).toBe("gemini-2.5-flash");
+	});
+
+	test("a caller-supplied base_url survives seeding", async () => {
+		// Seeding must MERGE into the caller's text block, never replace it —
+		// dropping a tenant upstream would silently re-point the org at the
+		// catalog URL.
+		const res = await createProvider({
+			slug: "my-upstream",
+			kind: "gemini",
+			apiKey: "AIza-test",
+			capabilities: { text: { base_url: "https://tenant.example.com/v1" } },
+		});
+		expect(res.status).toBe(201);
+
+		const capabilities = (await readCapabilities("my-upstream")) as {
+			text?: { model?: string; base_url?: string };
+		};
+		expect(capabilities?.text?.base_url).toBe("https://tenant.example.com/v1");
+		expect(capabilities?.text?.model).toBe("gemini-2.5-pro");
+	});
+
+	test("an unknown kind with no model is still created (no catalog default to seed)", async () => {
+		const res = await createProvider({
+			slug: "custom-thing",
+			kind: "some-unlisted-endpoint",
+			apiKey: "sk-custom",
+		});
+		expect(res.status).toBe(201);
+
+		const capabilities = (await readCapabilities("custom-thing")) as {
+			text?: { model?: string };
+		};
+		expect(capabilities?.text?.model).toBeUndefined();
+	});
+});

--- a/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
@@ -147,6 +147,49 @@ describe("POST /inference-providers seeds a routable text model", () => {
 		expect(capabilities?.text?.model).toBe("gemini-2.5-pro");
 	});
 
+	test("an ALIAS slug with no base_url is NOT seeded and does NOT become the org default", async () => {
+		// `getModelPolicy` keys its module map by SLUG: "my-gemini" matches no
+		// static module, and with no `text.base_url` there is nothing to
+		// synthesize either — so the row cannot route. Seeding it would be worse
+		// than useless: a text model is the predicate the org-default promotion
+		// uses, so an unroutable row would become the default for every
+		// allow-all agent in the org.
+		const res = await createProvider({
+			slug: "my-gemini",
+			kind: "gemini",
+			apiKey: "AIza-test",
+		});
+		expect(res.status).toBe(201);
+
+		const capabilities = (await readCapabilities("my-gemini")) as {
+			text?: { model?: string };
+		};
+		expect(capabilities?.text?.model).toBeUndefined();
+
+		const { getDb } = await import("../../db/client.js");
+		const sql = getDb();
+		const rows = (await sql`
+      SELECT is_default FROM inference_providers
+      WHERE organization_id = ${ORG} AND slug = 'my-gemini' AND deleted_at IS NULL
+    `) as Array<{ is_default: boolean }>;
+		expect(rows[0]?.is_default).toBe(false);
+	});
+
+	test("an alias slug WITH a base_url is seeded — synthesis can route it", async () => {
+		const res = await createProvider({
+			slug: "my-gemini-2",
+			kind: "gemini",
+			apiKey: "AIza-test",
+			capabilities: { text: { base_url: "https://tenant.example.com/v1" } },
+		});
+		expect(res.status).toBe(201);
+
+		const capabilities = (await readCapabilities("my-gemini-2")) as {
+			text?: { model?: string };
+		};
+		expect(capabilities?.text?.model).toBe("gemini-2.5-pro");
+	});
+
 	test("an unknown kind with no model is still created (no catalog default to seed)", async () => {
 		const res = await createProvider({
 			slug: "custom-thing",

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -911,15 +911,15 @@ routes.post("/inference-providers", async (c) => {
 	const capErr = validateCapabilitiesMap(body.capabilities);
 	if (capErr) return c.json({ error: capErr }, 400);
 
-	// Gate: a provider is addable via a pasted API key only if its wire protocol
-	// is one we can route (present in SDK_COMPAT_PROTOCOLS). `kind` is the catalog
-	// slug the user picked; a known catalog entry whose sdkCompat isn't routable
-	// (e.g. a subscription-only OAuth provider) is rejected so an unroutable row
-	// can't be created. Unknown kinds (custom endpoints) pass — they're treated as
-	// OpenAI-compatible by the synthesize path.
+	// Known catalog kinds must use a routable wire protocol. Unknown kinds pass
+	// because custom endpoints are synthesized as OpenAI-compatible providers.
+	// Read the default from configs because the catalog contains only provider
+	// modules registered in this process.
+	let catalogDefaultModel: string | undefined;
 	try {
 		const registry = new ProviderRegistryService(resolveProviderRegistryPath());
-		const catalog = buildProviderCatalog(await registry.getProviderConfigs());
+		const configs = await registry.getProviderConfigs();
+		const catalog = buildProviderCatalog(configs);
 		const entry = catalog.find((e) => e.slug === kind);
 		if (entry && !isSdkCompat(entry.sdkCompat)) {
 			return c.json(
@@ -929,6 +929,7 @@ routes.post("/inference-providers", async (c) => {
 				400
 			);
 		}
+		catalogDefaultModel = configs[kind]?.defaultModel ?? undefined;
 	} catch (err) {
 		// Fail open on catalog-load errors: don't block creation on a metadata
 		// read. The synthesize path still gates routing downstream.
@@ -940,13 +941,38 @@ routes.post("/inference-providers", async (c) => {
 
 	const createdBy = c.get("user")?.id ?? null;
 
+	// Seed the curated model so each API caller need not duplicate catalog
+	// defaults — and so a row cannot be born unroutable.
+	//
+	// `resolveInferenceProviderConfig` selects `capabilities -> <modality>` and
+	// returns null when the block is absent, so `resolveUrlInvariant` answers
+	// `no-custom-upstream` and the row's own org key is NEVER read. With no
+	// deployment env key that resolves to no credential at all: the provider is
+	// dropped from routing and the model goes upstream with its slug prefix
+	// intact, surfacing as an opaque "400 invalid model ID".
+	//
+	// Merge into the caller's text block rather than replacing it — dropping a
+	// tenant `base_url` would silently re-point the org at the catalog URL.
+	const requestedCapabilities =
+		(body.capabilities as InferenceCapabilities) ?? {};
+	const hasTextModel = !!requestedCapabilities.text?.model?.trim();
+	const capabilities =
+		hasTextModel || !catalogDefaultModel
+			? requestedCapabilities
+			: {
+					...requestedCapabilities,
+					text: {
+						...requestedCapabilities.text,
+						model: catalogDefaultModel,
+					},
+				};
 	const result = await createInferenceProvider({
 		organizationId: orgId,
 		slug,
 		kind,
 		displayName: typeof body.displayName === "string" ? body.displayName : null,
 		apiKey,
-		capabilities: (body.capabilities as InferenceCapabilities) ?? {},
+		capabilities,
 		createdBy,
 	});
 	if ("error" in result) {

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -953,11 +953,23 @@ routes.post("/inference-providers", async (c) => {
 	//
 	// Merge into the caller's text block rather than replacing it — dropping a
 	// tenant `base_url` would silently re-point the org at the catalog URL.
+	//
+	// Seed ONLY a row that will actually route. A text model is also the
+	// predicate `promoteOldestRunnableProvider` uses to choose the org default,
+	// so seeding an unroutable row would promote it to default and break every
+	// allow-all agent in the org. `getModelPolicy` keys its module map by the
+	// row's SLUG, so the row resolves to a module only when either:
+	//   - slug === kind   → the catalog's own static module answers to it, or
+	//   - a text base_url → `synthesizeOrgProviderModule` can build one.
+	// An alias slug with no base_url (slug=my-gemini, kind=gemini) matches
+	// neither and is dropped by the policy — it must not look configured.
 	const requestedCapabilities =
 		(body.capabilities as InferenceCapabilities) ?? {};
 	const hasTextModel = !!requestedCapabilities.text?.model?.trim();
+	const wouldRoute =
+		slug === kind || !!requestedCapabilities.text?.base_url?.trim();
 	const capabilities =
-		hasTextModel || !catalogDefaultModel
+		hasTextModel || !catalogDefaultModel || !wouldRoute
 			? requestedCapabilities
 			: {
 					...requestedCapabilities,
@@ -966,6 +978,16 @@ routes.post("/inference-providers", async (c) => {
 						model: catalogDefaultModel,
 					},
 				};
+	if (!capabilities.text?.model) {
+		// Nothing seeded: unknown kind, no catalog default, or an alias slug with
+		// no upstream to route to. Say so at creation — otherwise the row's only
+		// symptom is a far-away 400 naming a different provider.
+		logger.warn(
+			{ slug, kind, wouldRoute },
+			"[inference-providers POST] created with no text model — this provider will not route until `capabilities.text.model` is set (an alias slug, where slug !== kind, also needs `capabilities.text.base_url`)"
+		);
+	}
+
 	const result = await createInferenceProvider({
 		organizationId: orgId,
 		slug,


### PR DESCRIPTION
## Summary
An `inference_providers` row created with no `capabilities.<modality>` block is born **permanently unroutable**, and fails with an error that names neither the provider nor the cause.

The chain: `resolveInferenceProviderConfig` selects `capabilities -> <modality>` and returns `null` when the block is absent (`provider-secrets.ts:913`) → `resolveUrlInvariant` answers `no-custom-upstream` → the row's own org key is **never read**. For a catalog provider with no deployment env key that resolves to *no credential at all*, so the module is dropped from routing, `resolveProviderConfig`'s credentialed-fallback scan picks some other provider, and the worker sends the model upstream **with its slug prefix intact** — surfacing as an opaque `400 invalid model ID`.

Two changes:
1. **`POST /inference-providers` seeds the catalog's default text model** when the caller names none, so a row cannot be created in the unroutable state. Seeding **merges** into the caller's text block, so a tenant `base_url` is preserved. When there is no catalog default to seed (unknown/custom kind) it logs instead of silently creating a dead row.
2. **The fallback logs.** When the requested model's provider is not routable, the gateway now warns naming the requested provider, the fallback actually chosen, and the installed set. Previously the only evidence was a slash surviving in the model id.

The seed reads the registry **configs** rather than `buildProviderCatalog`: the catalog is built by iterating *registered modules*, so it is empty in any process that has not booted them (the first version of this fix silently no-op'd for exactly that reason — caught by the tests below).

### Prod evidence (org `buremba`)
A `gemini` row created without a model 400'd every turn, while `z-ai` — same shape but *with* a text block — routed fine. The deployment has **no** `OPENAI/ANTHROPIC/GEMINI/Z_AI/OPENROUTER_API_KEY`, so every provider must resolve through its org row; that is what makes a missing block fatal rather than cosmetic.

Confirmed live after repairing the rows by hand:
- `gemini/gemini-2.5-pro` → reply OK, `POST /lobu/api/proxy/gemini/…` → 200
- `openai/gpt-4o-mini` → reply OK (it was a **dead entry** in the agent's allow-list: its row had `capabilities = {}`)
- `z-ai/glm-5.2` → routes correctly to `api.z.ai`, genuine upstream `429 Weekly/Monthly Limit Exhausted` (unrelated quota)

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] New: `packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts` (4 tests, real Postgres)
- [x] Regression: `inference-provider-set-default-route`, `inference-providers-oauth`, `sandbox-routes-provider-catalog`, `provider-catalog-org-inference` — 29 pass
- [x] Bug fix: red→green below

### RED (seeding disabled)
```
(fail) a catalog provider created with NO capabilities gets the catalog default model
(fail) a caller-supplied base_url survives seeding
 2 pass
 2 fail
```

### GREEN (fix applied)
```
 4 pass
 0 fail
```

## Notes
**Mutation-tested.** Disabling the seed fails exactly the two tests that assert it; the "explicit model is not overwritten" and "unknown kind" cases stay green in both states, so they pin behaviour rather than the fix.

**The `base_url` test is the important one.** Seeding must merge, not replace — replacing the caller's text block would silently re-point an org from its tenant upstream to the catalog URL.

### Follow-up (not in this PR)
Existing rows created before this fix stay unroutable — the seed only covers creation. Prod org `buremba` was repaired by hand (rows 9 and 13). A one-off repair for rows with a missing text block, or surfacing them in the UI as "needs a model", is worth doing separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->