### PR TITLE
refactor(server): send the agent's instruction layers apart, not welded

### DIFF
--- a/packages/agent-worker/src/__tests__/embedded-tools.test.ts
+++ b/packages/agent-worker/src/__tests__/embedded-tools.test.ts
@@ -758,7 +758,12 @@ describe("session context cache TTL", () => {
 
   function makeSessionResponse() {
     return {
-      agentInstructions: "test agent",
+      agentLayers: {
+        identityMd: "test agent",
+        soulMd: "",
+        userMd: "",
+        unconfiguredNotice: "",
+      },
       platformInstructions: "test platform",
       networkInstructions: "test network",
       skillsInstructions: "test skills",
@@ -799,6 +804,7 @@ describe("session context cache TTL", () => {
     const second = await getAgentSessionContext();
 
     expect(fetchCount).toBe(1);
+    expect(first.agentLayers).toEqual(makeSessionResponse().agentLayers);
     expect(first.mcpContext).toEqual({ lobu: "Check memory" });
     expect(second.mcpContext).toEqual({ lobu: "Check memory" });
   });

--- a/packages/agent-worker/src/__tests__/prompt-assembly-smoke.test.ts
+++ b/packages/agent-worker/src/__tests__/prompt-assembly-smoke.test.ts
@@ -93,9 +93,16 @@ describe("prompt assembly (real pi base prompt)", () => {
     const custom = "You are Aria, Acme's support agent.";
     const finalSystemPrompt = replaceBasePromptIdentity(
       base,
-      resolveAgentIdentity(custom)
+      resolveAgentIdentity({
+        identityMd: custom,
+        soulMd: "",
+        userMd: "",
+        unconfiguredNotice: "",
+      })
     );
-    expect(finalSystemPrompt.startsWith(custom)).toBe(true);
+    expect(finalSystemPrompt.startsWith(`## Agent Identity\n\n${custom}`)).toBe(
+      true
+    );
     expect(finalSystemPrompt).not.toContain("You are a Lobu agent");
     expect(finalSystemPrompt).not.toContain(
       "expert coding assistant operating inside pi"

--- a/packages/agent-worker/src/__tests__/replace-base-prompt-identity.test.ts
+++ b/packages/agent-worker/src/__tests__/replace-base-prompt-identity.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  type AgentInstructionLayers,
+  EMPTY_AGENT_LAYERS,
+} from "../runtime/session-context";
+import {
   LOBU_DEFAULT_IDENTITY,
   replaceBasePromptIdentity,
   resolveAgentIdentity,
@@ -44,20 +48,67 @@ describe("replaceBasePromptIdentity", () => {
   });
 });
 
+function layers(
+  partial: Partial<AgentInstructionLayers> = {}
+): AgentInstructionLayers {
+  return { ...EMPTY_AGENT_LAYERS, ...partial };
+}
+
 describe("resolveAgentIdentity", () => {
-  test("uses the agent's own IDENTITY.md when present", () => {
+  test("uses the agent's own identity when it is the only layer set", () => {
     const identity = "You are Aria, Acme's support agent.";
-    expect(resolveAgentIdentity(identity)).toBe(identity);
+    expect(resolveAgentIdentity(layers({ identityMd: identity }))).toBe(
+      `## Agent Identity\n\n${identity}`
+    );
   });
 
-  test("trims surrounding whitespace from a present identity", () => {
-    expect(resolveAgentIdentity("  You are Aria.  \n")).toBe("You are Aria.");
+  test("trims surrounding whitespace from each layer", () => {
+    expect(
+      resolveAgentIdentity(layers({ identityMd: "  You are Aria.  \n" }))
+    ).toBe("## Agent Identity\n\nYou are Aria.");
   });
 
-  test("falls back to the Lobu default when identity is empty", () => {
-    expect(resolveAgentIdentity("")).toBe(LOBU_DEFAULT_IDENTITY);
-    expect(resolveAgentIdentity("   \n  ")).toBe(LOBU_DEFAULT_IDENTITY);
+  test("falls back to the Lobu default when every layer is empty", () => {
+    expect(resolveAgentIdentity(layers())).toBe(LOBU_DEFAULT_IDENTITY);
+    expect(
+      resolveAgentIdentity(
+        layers({ identityMd: "   \n  ", soulMd: " ", userMd: "\t" })
+      )
+    ).toBe(LOBU_DEFAULT_IDENTITY);
     expect(resolveAgentIdentity(undefined)).toBe(LOBU_DEFAULT_IDENTITY);
+  });
+
+  test("composes identity, soul and user in that order with their headings", () => {
+    expect(
+      resolveAgentIdentity(
+        layers({
+          identityMd: "I am Aria.",
+          soulMd: "Be terse.",
+          userMd: "Acme staff.",
+        })
+      )
+    ).toBe(
+      "## Agent Identity\n\nI am Aria.\n\n" +
+        "## Agent Instructions\n\nBe terse.\n\n" +
+        "## User Context\n\nAcme staff."
+    );
+  });
+
+  test("omits the heading of every layer that is blank", () => {
+    expect(resolveAgentIdentity(layers({ soulMd: "Be terse." }))).toBe(
+      "## Agent Instructions\n\nBe terse."
+    );
+    expect(resolveAgentIdentity(layers({ userMd: "Acme staff." }))).toBe(
+      "## User Context\n\nAcme staff."
+    );
+  });
+
+  test("the unconfigured notice stands in for the whole block, not the default", () => {
+    // The gateway supplies this only when every configured layer is blank.
+    const notice = "## Agent Configuration Notice\n\nAsk an admin.";
+    expect(resolveAgentIdentity(layers({ unconfiguredNotice: notice }))).toBe(
+      notice
+    );
   });
 
   test("the Lobu default never leaks the pi harness framing", () => {
@@ -77,7 +128,10 @@ describe("resolveAgentIdentity", () => {
 
   test("default identity replaces the pi opener end-to-end", () => {
     const base = `${PI_OPENER}\n\nAvailable tools:\n- read`;
-    const out = replaceBasePromptIdentity(base, resolveAgentIdentity(""));
+    const out = replaceBasePromptIdentity(
+      base,
+      resolveAgentIdentity(EMPTY_AGENT_LAYERS)
+    );
     expect(out).not.toContain("expert coding assistant");
     expect(out).toContain("Lobu agent");
     expect(out).toContain("Available tools:");

--- a/packages/agent-worker/src/runtime/session-context.ts
+++ b/packages/agent-worker/src/runtime/session-context.ts
@@ -49,8 +49,28 @@ interface SkillContent {
   content: string;
 }
 
+/**
+ * The agent's configured instruction sources, kept apart on the wire so prompt
+ * assembly does not have to recover their boundaries from operator-authored
+ * headings.
+ */
+export interface AgentInstructionLayers {
+  identityMd: string;
+  soulMd: string;
+  userMd: string;
+  /** Non-empty only when identity, soul and user are all blank. */
+  unconfiguredNotice: string;
+}
+
+export const EMPTY_AGENT_LAYERS: AgentInstructionLayers = {
+  identityMd: "",
+  soulMd: "",
+  userMd: "",
+  unconfiguredNotice: "",
+};
+
 interface SessionContextResponse {
-  agentInstructions: string;
+  agentLayers: AgentInstructionLayers;
   platformInstructions: string;
   networkInstructions: string;
   skillsInstructions: string;
@@ -65,7 +85,7 @@ interface SessionContextResponse {
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 const DEFAULT_SESSION_CONTEXT = {
-  agentInstructions: "",
+  agentLayers: EMPTY_AGENT_LAYERS,
   gatewayInstructions: "",
   providerConfig: {} as ProviderConfig,
   skillsConfig: [] as SkillContent[],
@@ -76,7 +96,7 @@ const DEFAULT_SESSION_CONTEXT = {
 
 // Module-level cache for session context
 let cachedResult: {
-  agentInstructions: string;
+  agentLayers: AgentInstructionLayers;
   gatewayInstructions: string;
   providerConfig: ProviderConfig;
   skillsConfig: SkillContent[];
@@ -270,13 +290,12 @@ export async function getAgentSessionContext(
   opts: { mcpExposure?: "tools" | "cli" } = {}
 ): Promise<{
   /**
-   * Identity/soul/user instructions for this agent. Returned separately from
-   * `gatewayInstructions` so the worker can prepend identity BEFORE the
+   * The agent's identity/soul/user sources, still separate. Returned apart
+   * from `gatewayInstructions` because their composed block belongs BEFORE the
    * pi-coding-agent base prompt (which would otherwise anchor the model with
-   * "You are an expert coding assistant" before the agent's real persona is
-   * declared).
+   * "You are an expert coding assistant" before the agent's real persona).
    */
-  agentInstructions: string;
+  agentLayers: AgentInstructionLayers;
   /** Platform / network / skills / MCP setup instructions (no identity). */
   gatewayInstructions: string;
   providerConfig: ProviderConfig;
@@ -358,9 +377,8 @@ export async function getAgentSessionContext(
     const mcpCliInstructions =
       mcpExposure === "cli" ? buildMcpCliInstructions(data.mcpStatus) : "";
 
-    // Identity/soul/user instructions are returned separately so the worker
-    // can prepend them BEFORE the pi-coding-agent base prompt.
-    const agentInstructions = data.agentInstructions || "";
+    // Keep the wire-level boundaries intact until prompt assembly.
+    const agentLayers = data.agentLayers;
 
     const gatewayInstructions = [
       data.platformInstructions,
@@ -376,13 +394,13 @@ export async function getAgentSessionContext(
     const mcpTools = data.mcpTools || {};
 
     logger.info(
-      `Built gateway instructions: agent (${agentInstructions.length} chars, prepended) + platform (${data.platformInstructions.length} chars) + network (${data.networkInstructions.length} chars) + skills (${(data.skillsInstructions || "").length} chars) + MCP setup (${mcpSetupInstructions.length} chars) + MCP server instructions (${mcpServerInstructions.length} chars), mcpTools: ${Object.keys(mcpTools).length} servers`
+      `Built gateway instructions: agent (identity ${agentLayers.identityMd.length} / soul ${agentLayers.soulMd.length} / user ${agentLayers.userMd.length} chars, prepended) + platform (${data.platformInstructions.length} chars) + network (${data.networkInstructions.length} chars) + skills (${(data.skillsInstructions || "").length} chars) + MCP setup (${mcpSetupInstructions.length} chars) + MCP server instructions (${mcpServerInstructions.length} chars), mcpTools: ${Object.keys(mcpTools).length} servers`
     );
 
     const mcpContext = data.mcpContext || {};
 
     const result = {
-      agentInstructions,
+      agentLayers,
       gatewayInstructions,
       providerConfig: data.providerConfig || {},
       skillsConfig: data.skillsConfig || [],

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -50,6 +50,7 @@ import { resetSessionForProviderChange } from "./provider-session";
 import { buildRuntimeShellInstructions } from "./runtime-shell-instructions";
 import { checkSandboxLeak } from "./sandbox-leak";
 import {
+  type AgentInstructionLayers,
   getAgentSessionContext,
   invalidateSessionContextCache,
 } from "./session-context";
@@ -351,14 +352,13 @@ export function replaceBasePromptIdentity(
 }
 
 /**
- * Fallback identity used when an agent ships no IDENTITY.md (i.e.
- * `context.agentInstructions` is empty). Without this, the pi-coding-agent
- * opener wins and the agent introduces itself as "an expert coding assistant
- * operating inside pi, a coding agent harness" — leaking harness internals and
- * mis-describing what a Lobu agent actually is.
+ * Fallback identity used when every configured instruction layer is empty.
+ * Without this, the pi-coding-agent opener wins and the agent introduces
+ * itself as "an expert coding assistant operating inside pi, a coding agent
+ * harness" — leaking harness internals and mis-describing what a Lobu agent
+ * actually is.
  *
- * A custom IDENTITY.md still fully overrides this; it only applies when the
- * agent has declared no identity of its own.
+ * Any configured identity, soul, or user layer overrides this fallback.
  *
  * The capabilities section is grounded in what every Lobu agent has by
  * construction (shared memory, connectors, actions, channel presence) rather
@@ -384,15 +384,37 @@ export const LOBU_DEFAULT_IDENTITY = `You are a Lobu agent — a persistent, mem
 Introduce yourself in terms of who you help and what you can do for them — concretely and specifically to this organization — not in terms of the software you are running on.`;
 
 /**
- * Resolve the identity to inject: the agent's own IDENTITY.md when present,
- * otherwise the Lobu default persona. Returns a non-empty string, so the pi
- * opener is always replaced and never reaches the model verbatim.
+ * Compose configured layers in their existing prompt order. The worker owns
+ * this step because prompt placement is a worker concern.
+ *
+ * `unconfiguredNotice` replaces the whole block rather than appending to it:
+ * the gateway only sets it when all three sources are blank.
+ */
+function composeAgentInstructions(layers: AgentInstructionLayers): string {
+  const sections: string[] = [];
+  if (layers.identityMd.trim()) {
+    sections.push(`## Agent Identity\n\n${layers.identityMd.trim()}`);
+  }
+  if (layers.soulMd.trim()) {
+    sections.push(`## Agent Instructions\n\n${layers.soulMd.trim()}`);
+  }
+  if (layers.userMd.trim()) {
+    sections.push(`## User Context\n\n${layers.userMd.trim()}`);
+  }
+  const composed = sections.join("\n\n");
+  return composed || layers.unconfiguredNotice;
+}
+
+/**
+ * Resolve the identity to inject: the agent's own configured instructions when
+ * present, otherwise the Lobu default persona. Returns a non-empty string, so
+ * the pi opener is always replaced and never reaches the model verbatim.
  */
 export function resolveAgentIdentity(
-  agentInstructions: string | undefined
+  layers: AgentInstructionLayers | undefined
 ): string {
-  const trimmed = agentInstructions?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : LOBU_DEFAULT_IDENTITY;
+  const composed = layers ? composeAgentInstructions(layers).trim() : "";
+  return composed.length > 0 ? composed : LOBU_DEFAULT_IDENTITY;
 }
 
 /**
@@ -1317,17 +1339,12 @@ user references earlier discussion or you need prior context.`);
       createdSession.session.agent.abort();
     });
 
-    // Pi-coding-agent's base prompt opens with "You are an expert coding
-    // assistant operating inside pi, a coding agent harness…" — that anchor
-    // overrides any IDENTITY.md the agent ships with. Replace just that
-    // opener with the agent's real identity (or the lobu default) so the
-    // tools/guidelines/cwd footer below it still applies, but the role on
-    // top is the one we actually want.
+    // Pi-coding-agent's base prompt opens with its own role declaration.
+    // Replace just that opener with the configured instruction block (or Lobu
+    // default) so its tools/guidelines/cwd footer still applies without
+    // anchoring the model to the harness identity.
     const basePrompt = session.systemPrompt;
-    // Resolve the identity from the agent's IDENTITY.md, falling back to the
-    // Lobu default persona when the agent declares none. Either way we replace
-    // the pi opener so it never reaches the model verbatim.
-    const identity = resolveAgentIdentity(context.agentInstructions);
+    const identity = resolveAgentIdentity(context.agentLayers);
     const finalSystemPrompt = [
       replaceBasePromptIdentity(basePrompt, identity),
       finalInstructionsUpdated,

--- a/packages/server/src/gateway/__tests__/instruction-service.test.ts
+++ b/packages/server/src/gateway/__tests__/instruction-service.test.ts
@@ -55,15 +55,45 @@ describe("InstructionService", () => {
       { settingsUrl: "http://localhost:8080/api/v1/agents/agent-1/config" }
     );
 
-    expect(sessionContext.agentInstructions).toContain(
+    expect(sessionContext.agentLayers.unconfiguredNotice).toContain(
       "## Agent Configuration Notice"
     );
-    expect(sessionContext.agentInstructions).toContain(
+    expect(sessionContext.agentLayers.unconfiguredNotice).toContain(
       "IDENTITY.md, SOUL.md, USER.md"
     );
-    expect(sessionContext.agentInstructions).not.toContain(
+    expect(sessionContext.agentLayers.unconfiguredNotice).not.toContain(
       "Do not invent product capabilities"
     );
+  });
+
+  test("keeps identity, soul and user in their own fields (no welded blob)", async () => {
+    // Joining here would force prompt assembly to recover boundaries from
+    // headings that operators can also use in their own content.
+    await seedAgentRow("layered", { organizationId: "org-a" });
+    await orgContext.run({ organizationId: "org-a" }, () =>
+      store.saveSettings("layered", {
+        identityMd: "I am Aria.",
+        soulMd: "Always answer in British English.",
+        userMd: "Your audience is Acme's support team.",
+      } as any)
+    );
+
+    const ctx = await service.getSessionContext("telegram", {
+      agentId: "layered",
+      organizationId: "org-a",
+      userId: "user-1",
+      workingDirectory: "/workspace/thread-1",
+    } as any);
+
+    expect(ctx.agentLayers.identityMd).toBe("I am Aria.");
+    expect(ctx.agentLayers.soulMd).toBe("Always answer in British English.");
+    expect(ctx.agentLayers.userMd).toBe(
+      "Your audience is Acme's support team."
+    );
+    // Configured agents get no notice, and no layer absorbs another.
+    expect(ctx.agentLayers.unconfiguredNotice).toBe("");
+    expect(ctx.agentLayers.identityMd).not.toContain("British English");
+    expect(ctx.agentLayers.soulMd).not.toContain("Aria");
   });
 
   test("resolves agent identity scoped to the caller's org (shared agent id across orgs)", async () => {
@@ -94,14 +124,14 @@ describe("InstructionService", () => {
     } as any);
 
     // org-b's identity resolved — not org-a's (the unscoped-read bug).
-    expect(ctxB.agentInstructions).toContain("I am the ORG-B builder.");
-    expect(ctxB.agentInstructions).not.toContain("I am the ORG-A builder.");
+    expect(ctxB.agentLayers.identityMd).toContain("I am the ORG-B builder.");
+    expect(ctxB.agentLayers.identityMd).not.toContain("I am the ORG-A builder.");
   });
 
-  test("does NOT inject org guidance into agentInstructions (delivered via lobu-memory MCP, not duplicated)", async () => {
+  test("does NOT inject org guidance into the agent layers (delivered via lobu-memory MCP, not duplicated)", async () => {
     // Single source of truth: guidance reaches the worker prompt through the
     // lobu-memory MCP server's instructions (buildWorkspaceInstructions renders
-    // the "Organization Context" section). Injecting it into agentInstructions
+    // the "Organization Context" section). Injecting it into the agent layers
     // here too — under the same org-scope gate — would duplicate it in the
     // prompt. This test pins that the session-context path stays out of it.
     await seedAgentRow("agent-guided", { organizationId: "org-a" });
@@ -114,8 +144,10 @@ describe("InstructionService", () => {
       workingDirectory: "/workspace/thread-1",
     } as any);
 
-    expect(ctxA.agentInstructions).not.toContain("## Organization Context");
-    expect(ctxA.agentInstructions).not.toContain(
+    expect(JSON.stringify(ctxA.agentLayers)).not.toContain(
+      "## Organization Context"
+    );
+    expect(JSON.stringify(ctxA.agentLayers)).not.toContain(
       "Fiscal year starts in February."
     );
   });

--- a/packages/server/src/gateway/__tests__/session-context-cross-tenant.test.ts
+++ b/packages/server/src/gateway/__tests__/session-context-cross-tenant.test.ts
@@ -93,7 +93,7 @@ describe("session-context cross-tenant guard (R6) — all agent-scoped reads", (
     );
 
     // Identity/soul/user: NOT the foreign tenant's.
-    expect(result.agentInstructions).not.toContain("FOREIGN");
+    expect(JSON.stringify(result.agentLayers)).not.toContain("FOREIGN");
     // Skills: generic discovery blurb, NOT the foreign skill content.
     expect(result.skillsInstructions).not.toContain("FOREIGN SKILL");
     // No by-id settings read happened at all.
@@ -116,7 +116,7 @@ describe("session-context cross-tenant guard (R6) — all agent-scoped reads", (
     );
 
     // The declared agent's own identity/soul resolve.
-    expect(result.agentInstructions).toContain("FOREIGN IDENTITY");
+    expect(result.agentLayers.identityMd).toContain("FOREIGN IDENTITY");
   });
 
   test("normal org-scoped agent: identity + skills + MCP all intact (regression)", async () => {
@@ -133,7 +133,7 @@ describe("session-context cross-tenant guard (R6) — all agent-scoped reads", (
     expect(reads.length).toBeGreaterThan(0);
     expect(reads.every((r) => r.organizationId === "acme-org")).toBe(true);
     // Identity + skills resolve.
-    expect(result.agentInstructions).toContain("FOREIGN IDENTITY");
+    expect(result.agentLayers.identityMd).toContain("FOREIGN IDENTITY");
     expect(result.skillsInstructions).toContain("foreign-skill");
     // MCP resolved with the org → a lobu-memory status entry exists.
     expect(result.mcpStatus.length).toBeGreaterThan(0);

--- a/packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts
@@ -33,7 +33,12 @@ describe("WorkerGateway session context", () => {
       } as any,
       {
         getSessionContext: async () => ({
-          agentInstructions: "",
+          agentLayers: {
+            identityMd: "I am Aria.",
+            soulMd: "Be concise.",
+            userMd: "Acme support.",
+            unconfiguredNotice: "",
+          },
           platformInstructions: "",
           networkInstructions: "",
           skillsInstructions:
@@ -74,10 +79,22 @@ describe("WorkerGateway session context", () => {
     expect(response.status).toBe(200);
 
     const body = (await response.json()) as {
+      agentLayers: {
+        identityMd: string;
+        soulMd: string;
+        userMd: string;
+        unconfiguredNotice: string;
+      };
       skillsConfig: Array<{ name: string; content: string }>;
       skillsInstructions: string;
     };
 
+    expect(body.agentLayers).toEqual({
+      identityMd: "I am Aria.",
+      soulMd: "Be concise.",
+      userMd: "Acme support.",
+      unconfiguredNotice: "",
+    });
     expect(body.skillsConfig).toEqual([
       { name: "custom-skill", content: "# Custom Skill\n" },
     ]);

--- a/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
@@ -71,7 +71,12 @@ function makeGateway(): WorkerGateway {
     { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
     {
       getSessionContext: async () => ({
-        agentInstructions: "",
+        agentLayers: {
+          identityMd: "",
+          soulMd: "",
+          userMd: "",
+          unconfiguredNotice: "",
+        },
         platformInstructions: "",
         networkInstructions: "",
         skillsInstructions: "",

--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -48,6 +48,12 @@ let savedEncryptionKey: string | undefined;
  */
 const ORG = "org-worker-ctx-fallback";
 const AGENT = "agent-worker-ctx";
+const EMPTY_AGENT_LAYERS = {
+  identityMd: "",
+  soulMd: "",
+  userMd: "",
+  unconfiguredNotice: "",
+};
 
 function buildGatewayNoCatalog(getSettings: () => Promise<any>): WorkerGateway {
   return new WorkerGateway(
@@ -56,7 +62,7 @@ function buildGatewayNoCatalog(getSettings: () => Promise<any>): WorkerGateway {
     { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
     {
       getSessionContext: async () => ({
-        agentInstructions: "",
+        agentLayers: EMPTY_AGENT_LAYERS,
         platformInstructions: "",
         networkInstructions: "",
         skillsInstructions: "",
@@ -229,7 +235,7 @@ describe("worker model fallback (real DB, both channels)", () => {
       { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
       {
         getSessionContext: async () => ({
-          agentInstructions: "",
+          agentLayers: EMPTY_AGENT_LAYERS,
           platformInstructions: "",
           networkInstructions: "",
           skillsInstructions: "",
@@ -282,7 +288,7 @@ describe("worker model fallback (real DB, both channels)", () => {
       { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
       {
         getSessionContext: async () => ({
-          agentInstructions: "",
+          agentLayers: EMPTY_AGENT_LAYERS,
           platformInstructions: "",
           networkInstructions: "",
           skillsInstructions: "",
@@ -340,7 +346,7 @@ describe("worker model fallback (real DB, both channels)", () => {
       { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
       {
         getSessionContext: async () => ({
-          agentInstructions: "",
+          agentLayers: EMPTY_AGENT_LAYERS,
           platformInstructions: "",
           networkInstructions: "",
           skillsInstructions: "",
@@ -406,7 +412,7 @@ describe("worker model fallback (real DB, both channels)", () => {
       { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
       {
         getSessionContext: async () => ({
-          agentInstructions: "",
+          agentLayers: EMPTY_AGENT_LAYERS,
           platformInstructions: "",
           networkInstructions: "",
           skillsInstructions: "",
@@ -448,7 +454,7 @@ describe("worker model fallback (real DB, both channels)", () => {
       { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
       {
         getSessionContext: async () => ({
-          agentInstructions: "",
+          agentLayers: EMPTY_AGENT_LAYERS,
           platformInstructions: "",
           networkInstructions: "",
           skillsInstructions: "",

--- a/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
@@ -78,7 +78,12 @@ function makeGateway(): WorkerGateway {
     { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
     {
       getSessionContext: async () => ({
-        agentInstructions: "",
+        agentLayers: {
+          identityMd: "",
+          soulMd: "",
+          userMd: "",
+          unconfiguredNotice: "",
+        },
         platformInstructions: "",
         networkInstructions: "",
         skillsInstructions: "",

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -725,12 +725,12 @@ export class WorkerGateway {
       const mergedSkillsInstructions = contextData.skillsInstructions || "";
 
       logger.info(
-        `Session context for ${userId}: ${Object.keys(mcpConfig.mcpServers || {}).length} MCPs, ${contextData.agentInstructions.length} chars agent instructions, ${contextData.platformInstructions.length} chars platform instructions, ${contextData.networkInstructions.length} chars network instructions, ${mergedSkillsInstructions.length} chars skills instructions, ${enrichedMcpStatus.length} MCP status entries, ${Object.keys(mcpTools).length} MCP tool lists, ${Object.keys(mcpInstructions).length} MCP instructions, ${skillsConfig.length} skills, provider: ${providerConfig.defaultProvider || "none"}`
+        `Session context for ${userId}: ${Object.keys(mcpConfig.mcpServers || {}).length} MCPs, ${contextData.agentLayers.identityMd.length}/${contextData.agentLayers.soulMd.length}/${contextData.agentLayers.userMd.length} chars identity/soul/user, ${contextData.platformInstructions.length} chars platform instructions, ${contextData.networkInstructions.length} chars network instructions, ${mergedSkillsInstructions.length} chars skills instructions, ${enrichedMcpStatus.length} MCP status entries, ${Object.keys(mcpTools).length} MCP tool lists, ${Object.keys(mcpInstructions).length} MCP instructions, ${skillsConfig.length} skills, provider: ${providerConfig.defaultProvider || "none"}`
       );
 
       return c.json({
         mcpConfig,
-        agentInstructions: contextData.agentInstructions,
+        agentLayers: contextData.agentLayers,
         platformInstructions: contextData.platformInstructions,
         networkInstructions: contextData.networkInstructions,
         skillsInstructions: mergedSkillsInstructions,

--- a/packages/server/src/gateway/services/instruction-service.ts
+++ b/packages/server/src/gateway/services/instruction-service.ts
@@ -19,8 +19,31 @@ interface McpStatus {
   requiresInput: boolean;
 }
 
+/**
+ * The agent's configured instruction sources, kept apart rather than welded
+ * into one blob. Keeping the wire-level boundaries lets the worker own prompt
+ * assembly without parsing headings that may also appear in operator content.
+ *
+ * `unconfiguredNotice` is rendered here rather than in the worker because it
+ * embeds the settings URL, which only the gateway knows. It is non-empty only
+ * when all three sources are blank.
+ */
+interface AgentInstructionLayers {
+  identityMd: string;
+  soulMd: string;
+  userMd: string;
+  unconfiguredNotice: string;
+}
+
+const EMPTY_AGENT_LAYERS: AgentInstructionLayers = {
+  identityMd: "",
+  soulMd: "",
+  userMd: "",
+  unconfiguredNotice: "",
+};
+
 interface SessionContextData {
-  agentInstructions: string;
+  agentLayers: AgentInstructionLayers;
   platformInstructions: string;
   networkInstructions: string;
   skillsInstructions: string;
@@ -278,10 +301,10 @@ export class InstructionService {
       logger.error("Failed to get network instructions:", error);
     }
 
-    // Build agent instructions from identity/soul/user settings. Skip the by-id
-    // read for an orgless DB-backed agent (`orgScoped === false`) — it would
-    // id-only read another org's identity/soul/user for a shared id.
-    let agentInstructions = "";
+    // Read the agent's identity/soul/user settings. Skip the by-id read for an
+    // orgless DB-backed agent (`orgScoped === false`) — it would id-only read
+    // another org's identity/soul/user for a shared id.
+    let agentLayers: AgentInstructionLayers = EMPTY_AGENT_LAYERS;
     if (
       this.agentSettingsStore &&
       context.agentId &&
@@ -292,32 +315,25 @@ export class InstructionService {
           context.agentId,
           { organizationId: context.organizationId }
         );
-        if (settings) {
-          const sections: string[] = [];
-          if (settings.identityMd?.trim()) {
-            sections.push(`## Agent Identity\n\n${settings.identityMd.trim()}`);
-          }
-          if (settings.soulMd?.trim()) {
-            sections.push(`## Agent Instructions\n\n${settings.soulMd.trim()}`);
-          }
-          if (settings.userMd?.trim()) {
-            sections.push(`## User Context\n\n${settings.userMd.trim()}`);
-          }
-          agentInstructions = sections.join("\n\n");
-        }
-
-        // When soul is unconfigured, tell the agent to defer to admin config.
-        if (!agentInstructions.trim()) {
-          agentInstructions = buildUnconfiguredAgentNotice(
-            options?.settingsUrl
-          );
-        }
+        const identityMd = settings?.identityMd?.trim() ?? "";
+        const soulMd = settings?.soulMd?.trim() ?? "";
+        const userMd = settings?.userMd?.trim() ?? "";
+        // When nothing is configured, tell the agent to defer to admin config.
+        const unconfigured = !identityMd && !soulMd && !userMd;
+        agentLayers = {
+          identityMd,
+          soulMd,
+          userMd,
+          unconfiguredNotice: unconfigured
+            ? buildUnconfiguredAgentNotice(options?.settingsUrl)
+            : "",
+        };
 
         logger.info(
-          `Built agent instructions (${agentInstructions.length} chars)`
+          `Read agent layers (identity ${identityMd.length} chars, soul ${soulMd.length} chars, user ${userMd.length} chars${unconfigured ? ", unconfigured" : ""})`
         );
       } catch (error) {
-        logger.error("Failed to build agent instructions:", error);
+        logger.error("Failed to read agent instruction layers:", error);
       }
     }
 
@@ -357,7 +373,7 @@ export class InstructionService {
     }
 
     return {
-      agentInstructions,
+      agentLayers,
       platformInstructions,
       networkInstructions,
       skillsInstructions,


### PR DESCRIPTION
## Summary
- The gateway joined `identityMd`, `soulMd` and `userMd` into one `agentInstructions` string, and the worker handed that whole blob to `resolveAgentIdentity` as the agent's identity.
- The join is lossy in a way the worker cannot undo: `## Agent Identity` is a heading an operator could equally have typed inside their own `soulMd`, so nothing downstream can tell persona from operator configuration from audience context. Any text matcher that tried would be guessing.
- The gateway now sends `agentLayers: { identityMd, soulMd, userMd, unconfiguredNotice }` and the worker composes them. Composition belongs in the worker because *where each layer goes in the prompt* is a prompt-assembly decision.
- `unconfiguredNotice` is still rendered gateway-side — it embeds the settings URL, which only the gateway knows — and is non-empty only when all three sources are blank.

**This PR moves the seam, not the bytes.** The composed block is byte-for-byte what the gateway used to produce, including the quirk that the unconfigured notice *replaces* the whole block rather than appending to it (so an unconfigured agent still never sees `LOBU_DEFAULT_IDENTITY`). Splitting the layers across the prompt — persona up top, operator config in its own layer, audience context in another — is the follow-up PR.

## Why not keep welding in the gateway
The three sources are different kinds of text with different authors and different correct placements. Welding them at the producer forces every consumer to treat operator configuration as persona. Follow-up work needs to place `soulMd` after the Lobu contract and `userMd` in an audience layer; that is impossible to do correctly against a pre-joined string.

The wire type is declared on both sides rather than shared, matching the existing convention for this boundary — `McpStatus` is already declared separately in `instruction-service.ts` and `session-context.ts`.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming + gateway-llm)
- [x] Tests run — agent-worker: **797 pass, 12 skip, 0 fail**
- [x] Gateway suites, each run clean:
      `instruction-service` 4 pass · `session-context-cross-tenant` 5 pass ·
      `worker-gateway-session-context` 1 pass · `worker-response-liveness` 8 pass ·
      `worker-token-refresh-route` 8 pass · `worker-session-context-model-fallback` 12 pass
- [x] New tests mutation-tested
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### byte-equivalence is pinned by test, not by claim
`resolveAgentIdentity` gained cases asserting the exact composed output:

```ts
resolveAgentIdentity({ identityMd: "I am Aria.", soulMd: "Be terse.", userMd: "Acme staff." })
// === "## Agent Identity\n\nI am Aria.\n\n"
//   + "## Agent Instructions\n\nBe terse.\n\n"
//   + "## User Context\n\nAcme staff."
```

plus: blank layers omit their heading, every-layer-blank falls back to `LOBU_DEFAULT_IDENTITY`,
the unconfigured notice stands in for the whole block, and a configured layer wins over a
stale notice. 12 pass in that file.

### mutation evidence
The new gateway test `"keeps identity, soul and user in their own fields (no welded blob)"`
was run against a mutant that re-welds the layers into `identityMd`:

```
(fail) InstructionService > keeps identity, soul and user in their own fields (no welded blob) [152.40ms]
 3 pass  1 fail
```

Reverted after measuring.

## Notes
- Two gateway test files (`instruction-service`, `session-context-cross-tenant`) time out at 5000ms when run **together in one process**. I reproduced that identically on a worktree without this change, so it is pre-existing cross-file interference, not something introduced here. Each file passes on its own.
- No compatibility shim: `agentInstructions` is gone from the wire, the gateway response, the worker cache and every fixture. Gateway and worker ship in the same image, so there is no mixed-version window.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->