### PR TITLE
fix(server): tell every chat agent it is a participant, not an observer

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -201,6 +201,8 @@ export type LogLevel = "debug" | "info" | "warn" | "error";
 export interface InstructionContext {
   userId: string;
   agentId: string;
+  /** Signed chat connection id for connection-scoped instruction lookups. */
+  connectionId?: string;
   /**
    * Owning org of the agent. An agent id can exist in multiple orgs (PK is
    * `(organization_id, id)`), so instruction providers must scope their

--- a/packages/server/src/gateway/connections/__tests__/chat-identity-instruction-provider.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/chat-identity-instruction-provider.test.ts
@@ -76,6 +76,33 @@ describe("ChatIdentityInstructionProvider", () => {
     expect(result).toContain("@current-bot");
   });
 
+  test("no connectionId on the turn: framing WITHOUT identity, by design", async () => {
+    // Identity resolution deliberately has no agent+platform fallback: there is
+    // exactly one InstructionContext construction site (`gateway/index.ts`) and
+    // it always carries the signed `connectionId`, which `enqueueUserTurn` sets
+    // on every inbound chat turn. Guessing a connection when the field is
+    // missing would pick an arbitrary one for an agent with several.
+    //
+    // Pinning the DEGRADATION so it stays intentional: the handle drops, the
+    // framing does not. If a future caller builds a context without the field,
+    // the agent still knows it is a participant.
+    const provider = new ChatIdentityInstructionProvider(
+      {
+        getConnection: async () => {
+          throw new Error("must not be called without a connection id");
+        },
+      } as never,
+      "slack"
+    );
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: "acme", connectionId: undefined })
+    );
+
+    expect(result).toContain("participant in this conversation");
+    expect(result).not.toContain("@");
+  });
+
   test("orgless declared context emits generic framing without reading connections", async () => {
     let getCalled = false;
     const provider = new ChatIdentityInstructionProvider(
@@ -129,6 +156,23 @@ describe("ChatIdentityInstructionProvider", () => {
     const provider = new ChatIdentityInstructionProvider(
       managerReturning(null),
       "gchat"
+    );
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: "acme" })
+    );
+
+    expect(result).toContain("participant in this conversation");
+  });
+
+  test("connection lookup failure still emits participant framing", async () => {
+    const provider = new ChatIdentityInstructionProvider(
+      {
+        getConnection: async () => {
+          throw new Error("store unavailable");
+        },
+      } as never,
+      "telegram"
     );
 
     const result = await provider.getInstructions(

--- a/packages/server/src/gateway/connections/__tests__/chat-identity-instruction-provider.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/chat-identity-instruction-provider.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import type { InstructionContext } from "@lobu/core";
+import { orgContext } from "../../../lobu/stores/org-context.js";
+import { ChatIdentityInstructionProvider } from "../chat-identity-instruction-provider.js";
+import { ChatInstanceManager } from "../chat-instance-manager.js";
+import { PLATFORM_REGISTRY } from "../platforms/index.js";
+import { SlackInstructionProvider } from "../slack-instruction-provider.js";
+
+function ctx(overrides: Partial<InstructionContext>): InstructionContext {
+  return {
+    userId: "u1",
+    agentId: "personal-agent",
+    connectionId: "conn-1",
+    sessionKey: "u1",
+    workingDirectory: "/workspace",
+    availableProjects: [],
+    ...overrides,
+  };
+}
+
+function managerReturning(
+  connection: { metadata: Record<string, string> } | null,
+  onGet?: (connectionId: string) => void
+) {
+  return {
+    getConnection: async (connectionId: string) => {
+      onGet?.(connectionId);
+      return connection;
+    },
+  } as never;
+}
+
+describe("ChatIdentityInstructionProvider", () => {
+  test("telegram gets identity and participant framing", async () => {
+    const provider = new ChatIdentityInstructionProvider(
+      managerReturning({
+        metadata: {
+          botUsername: "burembalobubot",
+          botUserId: "8834276769",
+        },
+      }),
+      "telegram"
+    );
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: "buremba" })
+    );
+
+    expect(result).toContain("@burembalobubot");
+    expect(result).toContain("8834276769");
+    expect(result).toContain("Telegram");
+    expect(result).toContain("participant in this conversation");
+    expect(result).toContain('Address them as "you"');
+  });
+
+  test("uses the signed connection id without listing other connections", async () => {
+    let requestedId: string | undefined;
+    const manager = {
+      getConnection: async (connectionId: string) => {
+        requestedId = connectionId;
+        return {
+          metadata: { botUsername: "current-bot", botUserId: "CURRENT" },
+        };
+      },
+      listConnections: async () => {
+        throw new Error("must not guess from another connection");
+      },
+    } as never;
+    const provider = new ChatIdentityInstructionProvider(manager, "telegram");
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: "acme", connectionId: "current-connection" })
+    );
+
+    expect(requestedId).toBe("current-connection");
+    expect(result).toContain("@current-bot");
+  });
+
+  test("orgless declared context emits generic framing without reading connections", async () => {
+    let getCalled = false;
+    const provider = new ChatIdentityInstructionProvider(
+      managerReturning(
+        { metadata: { botUsername: "foreign-bot", botUserId: "UFOREIGN" } },
+        () => {
+          getCalled = true;
+        }
+      ),
+      "telegram"
+    );
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: undefined, connectionId: undefined })
+    );
+
+    expect(result).toContain("participant in this conversation");
+    expect(result).not.toContain("foreign-bot");
+    expect(getCalled).toBe(false);
+  });
+
+  test("reads the connection inside the token org", async () => {
+    let seenOrg: string | undefined;
+    const provider = new ChatIdentityInstructionProvider(
+      managerReturning({ metadata: { botUsername: "acme-bot" } }, () => {
+        seenOrg = orgContext.getStore()?.organizationId;
+      }),
+      "telegram"
+    );
+
+    await provider.getInstructions(ctx({ organizationId: "acme-org" }));
+
+    expect(seenOrg).toBe("acme-org");
+  });
+
+  test("no bot handle configured: still emits participant framing", async () => {
+    const provider = new ChatIdentityInstructionProvider(
+      managerReturning({ metadata: {} }),
+      "whatsapp"
+    );
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: "acme" })
+    );
+
+    expect(result).toContain("participant in this conversation");
+    expect(result).toContain("WhatsApp");
+  });
+
+  test("no connection resolved at all: still emits participant framing", async () => {
+    const provider = new ChatIdentityInstructionProvider(
+      managerReturning(null),
+      "gchat"
+    );
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: "acme" })
+    );
+
+    expect(result).toContain("participant in this conversation");
+  });
+
+  test.each([
+    ["telegram", "Telegram"],
+    ["slack", "Slack"],
+    ["discord", "Discord"],
+    ["whatsapp", "WhatsApp"],
+    ["teams", "Microsoft Teams"],
+    ["gchat", "Google Chat"],
+  ])(
+    "%s renders a human platform label, never the raw key",
+    async (platform, label) => {
+      const provider = new ChatIdentityInstructionProvider(
+        managerReturning({ metadata: { botUsername: "bot" } }),
+        platform
+      );
+
+      const result = await provider.getInstructions(
+        ctx({ organizationId: "acme" })
+      );
+
+      expect(result).toContain(label);
+      expect(result).toContain("participant in this conversation");
+    }
+  );
+
+  test("output stays identical across conversations on one connection", async () => {
+    const provider = new ChatIdentityInstructionProvider(
+      managerReturning({
+        metadata: {
+          botUsername: "burembalobubot",
+          botUserId: "8834276769",
+        },
+      }),
+      "telegram"
+    );
+
+    const first = await provider.getInstructions(
+      ctx({ organizationId: "buremba", userId: "user-a", sessionKey: "chat-1" })
+    );
+    const second = await provider.getInstructions(
+      ctx({ organizationId: "buremba", userId: "user-b", sessionKey: "chat-2" })
+    );
+
+    expect(first).toBe(second);
+    expect(first).not.toContain("user-a");
+    expect(first).not.toContain("chat-1");
+  });
+});
+
+describe("every chat platform is wired to an instruction provider", () => {
+  function adapterFor(platform: string) {
+    const manager = Object.create(
+      ChatInstanceManager.prototype
+    ) as ChatInstanceManager;
+    return (
+      manager as unknown as {
+        createPlatformAdapter: (name: string) => {
+          getInstructionProvider?: () => unknown;
+        };
+      }
+    ).createPlatformAdapter(platform);
+  }
+
+  test("telegram gets the generic provider", () => {
+    const provider = adapterFor("telegram").getInstructionProvider?.();
+
+    expect(provider).toBeInstanceOf(ChatIdentityInstructionProvider);
+    expect(provider).not.toBeInstanceOf(SlackInstructionProvider);
+  });
+
+  test("slack — a platform declaring its own provider keeps it", () => {
+    const provider = adapterFor("slack").getInstructionProvider?.();
+
+    expect(provider).toBeInstanceOf(SlackInstructionProvider);
+  });
+
+  test("every registered platform resolves a provider", () => {
+    const platforms = Object.keys(PLATFORM_REGISTRY);
+    expect(platforms.length).toBeGreaterThan(0);
+
+    const missing = platforms.filter(
+      (p) =>
+        !(
+          adapterFor(p).getInstructionProvider?.() instanceof
+          ChatIdentityInstructionProvider
+        )
+    );
+
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("SlackInstructionProvider still adds its own quirks", () => {
+  test("keeps mention guidance on top of the shared framing", async () => {
+    const provider = new SlackInstructionProvider(
+      managerReturning({
+        metadata: { botUsername: "acme-bot", botUserId: "UACME" },
+      })
+    );
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: "acme-org" })
+    );
+
+    expect(result).toContain("<@UACME>");
+    expect(result).toContain("participant in this conversation");
+    expect(result).toContain("@acme-bot");
+  });
+});

--- a/packages/server/src/gateway/connections/__tests__/slack-instruction-provider.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-instruction-provider.test.ts
@@ -1,9 +1,9 @@
 /**
  * R7 BLOCK #1 layer (b): SlackInstructionProvider must NOT leak another tenant's
- * Slack identity. Its `listConnections` read is agent-scoped and — without an
- * ambient org — would return ANOTHER org's newest Slack connection for a shared
- * agent id (foreign botUsername/botUserId). So:
- *   - orgless context ⇒ "" (no identity without an org);
+ * Slack identity. Identity now resolves from the signed `connectionId` rather
+ * than an agent-scoped connection listing, so:
+ *   - orgless/connection-less context ⇒ participation framing only, and no
+ *     connection read at all (nothing to leak);
  *   - org-present ⇒ the read runs INSIDE the token org (orgContext.run).
  */
 
@@ -16,6 +16,7 @@ function ctx(overrides: Partial<InstructionContext>): InstructionContext {
   return {
     userId: "u1",
     agentId: "lobu-builder",
+    connectionId: "conn-1",
     sessionKey: "u1",
     workingDirectory: "/workspace",
     availableProjects: [],
@@ -24,36 +25,36 @@ function ctx(overrides: Partial<InstructionContext>): InstructionContext {
 }
 
 describe("SlackInstructionProvider — cross-tenant guard", () => {
-  test("orgless context: returns '' (no Slack identity leaked) and does NOT read connections", async () => {
-    let listCalled = false;
+  test("orgless context: leaks no Slack identity and does NOT read connections", async () => {
+    let getCalled = false;
     const manager = {
-      listConnections: async () => {
-        listCalled = true;
-        return [
-          { metadata: { botUsername: "foreign-bot", botUserId: "UFOREIGN" } },
-        ];
+      getConnection: async () => {
+        getCalled = true;
+        return {
+          metadata: { botUsername: "foreign-bot", botUserId: "UFOREIGN" },
+        };
       },
     } as never;
     const provider = new SlackInstructionProvider(manager);
 
     const result = await provider.getInstructions(
-      ctx({ organizationId: undefined })
+      ctx({ organizationId: undefined, connectionId: undefined })
     );
 
-    expect(result).toBe("");
     // No connection read happened at all — nothing to leak.
-    expect(listCalled).toBe(false);
+    expect(getCalled).toBe(false);
+    expect(result).not.toContain("foreign");
+    // The participation framing is unconditional; only the handle is gated.
+    expect(result).toContain("participant in this conversation");
   });
 
   test("org-present: reads connections INSIDE the token org and returns the identity", async () => {
     let seenOrg: string | undefined;
     const manager = {
-      listConnections: async (_filter: unknown) => {
+      getConnection: async (_connectionId: string) => {
         // Capture the AMBIENT org the read runs under (must be the token org).
         seenOrg = orgContext.getStore()?.organizationId;
-        return [
-          { metadata: { botUsername: "acme-bot", botUserId: "UACME" } },
-        ];
+        return { metadata: { botUsername: "acme-bot", botUserId: "UACME" } };
       },
     } as never;
     const provider = new SlackInstructionProvider(manager);

--- a/packages/server/src/gateway/connections/chat-identity-instruction-provider.ts
+++ b/packages/server/src/gateway/connections/chat-identity-instruction-provider.ts
@@ -1,12 +1,44 @@
 /**
  * Shared identity and participant framing for chat platforms.
  *
- * This is part of the cached gateway prefix. Keep it connection-scoped; sender,
- * channel, message, and session details belong in the per-turn run context.
+ * An agent reached over chat needs two facts nothing else in the prompt
+ * supplies: WHO it is in the conversation, and that the messages it receives
+ * are addressed TO it. Without them it has only its identity/soul markdown,
+ * which describes the principal in the third person ("you work on the user's
+ * data on their behalf") and never says the person currently typing IS that
+ * principal. The model resolves that ambiguity per turn, often the wrong way:
+ * it treats the message as observed conversation about a third party and
+ * narrates it back — "Burak is asking … how would you like to respond?" — to an
+ * operator who does not exist. Slack never showed this only because its
+ * provider happened to say "You are reachable in Slack as `@x`", which implies
+ * participation; every platform declaring no provider got nothing.
+ *
+ * Identity is best-effort, the framing is not. `Adapter.botUserId` is optional
+ * in the Chat SDK, a turn may carry no `connectionId`, and the store can fail —
+ * in all three cases the handle is omitted but the framing still renders, since
+ * the framing is the half that resolves the ambiguity.
+ *
+ * PROMPT-CACHE CONTRACT — read before adding a line here.
+ * This block sits at the FRONT of `gatewayInstructions` (`session-context.ts`),
+ * and the openai-completions path has no explicit cache breakpoints: reuse is
+ * longest-common-prefix only. Everything emitted here must be CONNECTION-scoped
+ * (platform, bot handle, bot id) — constant for the life of the connection, so
+ * every conversation on it shares one prefix. Never interpolate anything
+ * CONVERSATION-scoped (sender name, channel/chat id, message text, timestamps):
+ * that hands every new conversation a unique prefix and forfeits the cache for
+ * all of them. Those belong in the per-turn run context, which is not cached.
+ * A test pins this by rendering two users/sessions on one connection and
+ * asserting byte equality.
  */
-import { BaseInstructionProvider, type InstructionContext } from "@lobu/core";
+import {
+  BaseInstructionProvider,
+  createLogger,
+  type InstructionContext,
+} from "@lobu/core";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
+
+const logger = createLogger("chat-identity-instructions");
 
 const PLATFORM_LABELS: Record<string, string> = {
   slack: "Slack",
@@ -63,7 +95,15 @@ export class ChatIdentityInstructionProvider extends BaseInstructionProvider {
   protected async buildInstructions(
     context: InstructionContext
   ): Promise<string> {
-    const identity = await this.resolveIdentity(context);
+    let identity: ChatBotIdentity | null = null;
+    try {
+      identity = await this.resolveIdentity(context);
+    } catch (error) {
+      logger.warn(
+        { error, connectionId: context.connectionId },
+        "Failed to resolve chat identity; using generic framing"
+      );
+    }
     return this.renderIdentity(identity ?? {});
   }
 

--- a/packages/server/src/gateway/connections/chat-identity-instruction-provider.ts
+++ b/packages/server/src/gateway/connections/chat-identity-instruction-provider.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared identity and participant framing for chat platforms.
+ *
+ * This is part of the cached gateway prefix. Keep it connection-scoped; sender,
+ * channel, message, and session details belong in the per-turn run context.
+ */
+import { BaseInstructionProvider, type InstructionContext } from "@lobu/core";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import type { ChatInstanceManager } from "./chat-instance-manager.js";
+
+const PLATFORM_LABELS: Record<string, string> = {
+  slack: "Slack",
+  telegram: "Telegram",
+  whatsapp: "WhatsApp",
+  discord: "Discord",
+  teams: "Microsoft Teams",
+  gchat: "Google Chat",
+};
+
+function platformLabel(platform: string): string {
+  return PLATFORM_LABELS[platform] ?? platform;
+}
+
+export interface ChatBotIdentity {
+  botUsername?: string;
+  botUserId?: string;
+}
+
+export class ChatIdentityInstructionProvider extends BaseInstructionProvider {
+  // Widened to `string` deliberately: an inferred literal type would make the
+  // property invariant and block a subclass from naming itself.
+  readonly name: string = "chat-identity";
+  readonly priority = 20;
+
+  constructor(
+    protected readonly manager: ChatInstanceManager,
+    protected readonly platform: string
+  ) {
+    super();
+  }
+
+  protected async resolveIdentity(
+    context: InstructionContext
+  ): Promise<ChatBotIdentity | null> {
+    const { organizationId, connectionId } = context;
+    if (!organizationId || !connectionId) return null;
+    const connection = await orgContext.run(
+      { organizationId },
+      () => this.manager.getConnection(connectionId)
+    );
+    if (!connection) return null;
+
+    const botUsername = connection.metadata?.botUsername;
+    const botUserId = connection.metadata?.botUserId;
+    return {
+      ...(typeof botUsername === "string" && botUsername
+        ? { botUsername }
+        : {}),
+      ...(typeof botUserId === "string" && botUserId ? { botUserId } : {}),
+    };
+  }
+
+  protected async buildInstructions(
+    context: InstructionContext
+  ): Promise<string> {
+    const identity = await this.resolveIdentity(context);
+    return this.renderIdentity(identity ?? {});
+  }
+
+  protected renderIdentity(identity: ChatBotIdentity): string {
+    const label = platformLabel(this.platform);
+    const lines: string[] = [`**${label} identity:**`];
+
+    if (identity.botUsername && identity.botUserId) {
+      lines.push(
+        `- You are reachable in ${label} as \`@${identity.botUsername}\` (user ID \`${identity.botUserId}\`).`
+      );
+    } else if (identity.botUsername) {
+      lines.push(
+        `- You are reachable in ${label} as \`@${identity.botUsername}\`.`
+      );
+    } else if (identity.botUserId) {
+      lines.push(`- Your ${label} user ID is \`${identity.botUserId}\`.`);
+    } else {
+      lines.push(`- You are reachable in this ${label} conversation.`);
+    }
+
+    lines.push(
+      "- You are a participant in this conversation, not an outside observer.",
+      '- Reply directly to the people in this conversation. Address them as "you" rather than describing them in the third person, and do not ask an unseen operator how to respond.'
+    );
+
+    return lines.join("\n");
+  }
+}

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -29,6 +29,7 @@ import {
   resolveSecretValue,
 } from "../secrets/index.js";
 import { resolveAgentOptions } from "../services/platform-helpers.js";
+import { ChatIdentityInstructionProvider } from "./chat-identity-instruction-provider.js";
 import { configsEqual } from "./config-equal.js";
 import { ConversationStateStore } from "./conversation-state-store.js";
 import { registerInteractionBridge } from "./interaction-bridge.js";
@@ -2376,12 +2377,10 @@ export class ChatInstanceManager {
 				},
       ) => this.routePlatformMessage(name, token, message, options),
       getFileHandler: (options) => this.getPlatformFileHandler(name, options),
-      ...(descriptor?.getInstructionProvider
-        ? {
-            getInstructionProvider: () =>
-              descriptor.getInstructionProvider!(this),
-          }
-        : {}),
+      // Platform-specific providers extend or replace the shared chat framing.
+      getInstructionProvider: () =>
+        descriptor?.getInstructionProvider?.(this) ??
+        new ChatIdentityInstructionProvider(this, name),
     };
   }
 

--- a/packages/server/src/gateway/connections/slack-instruction-provider.ts
+++ b/packages/server/src/gateway/connections/slack-instruction-provider.ts
@@ -1,55 +1,20 @@
-import { BaseInstructionProvider, type InstructionContext } from "@lobu/core";
-import { orgContext } from "../../lobu/stores/org-context.js";
+import {
+  type ChatBotIdentity,
+  ChatIdentityInstructionProvider,
+} from "./chat-identity-instruction-provider.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
 
-export class SlackInstructionProvider extends BaseInstructionProvider {
-  readonly name = "slack-identity";
-  readonly priority = 20;
+/** Adds Slack's mention encoding to the shared chat identity block. */
+export class SlackInstructionProvider extends ChatIdentityInstructionProvider {
+  override readonly name = "slack-identity";
 
-  constructor(private readonly manager: ChatInstanceManager) {
-    super();
+  constructor(manager: ChatInstanceManager) {
+    super(manager, "slack");
   }
 
-  protected async buildInstructions(
-    context: InstructionContext
-  ): Promise<string> {
-    // Defense in depth: no Slack identity without an org. `listConnections` is
-    // agent-scoped and — without an ambient org — would return ANOTHER tenant's
-    // newest Slack connection for a shared agent id (leaking foreign
-    // botUsername/botUserId). Require the org and run the read INSIDE it so it's
-    // actually tenant-scoped. (The InstructionService also gates this provider
-    // out when `orgScoped === false`; this is the belt to that suspenders.)
-    if (!context.organizationId) return "";
-    const connections = await orgContext.run(
-      { organizationId: context.organizationId },
-      () =>
-        this.manager.listConnections({
-          platform: "slack",
-          agentId: context.agentId,
-        })
-    );
-    const connection = connections[0];
-    if (!connection) return "";
-
-    const botUsername = connection.metadata?.botUsername as string | undefined;
-    const botUserId = connection.metadata?.botUserId as string | undefined;
-    if (!botUsername && !botUserId) return "";
-
-    const lines: string[] = ["**Slack identity:**"];
-    if (botUsername && botUserId) {
-      lines.push(
-        `- You are reachable in Slack as \`@${botUsername}\` (user ID \`${botUserId}\`).`
-      );
-    } else if (botUsername) {
-      lines.push(`- You are reachable in Slack as \`@${botUsername}\`.`);
-    } else if (botUserId) {
-      lines.push(`- Your Slack user ID is \`${botUserId}\`.`);
-    }
-    if (botUserId) {
-      lines.push(
-        `- Mentions of \`<@${botUserId}>\` (or the bare \`@${botUserId}\`) refer to *you*; the gateway strips them before delivery, so anything you still see is incidental — do not treat your own ID as a stranger.`
-      );
-    }
-    return lines.join("\n");
+  protected override renderIdentity(identity: ChatBotIdentity): string {
+    const base = super.renderIdentity(identity);
+    if (!identity.botUserId) return base;
+    return `${base}\n- Mentions of \`<@${identity.botUserId}>\` (or the bare \`@${identity.botUserId}\`) refer to *you*; the gateway strips them before delivery, so anything you still see is incidental — do not treat your own ID as a stranger.`;
   }
 }

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -588,6 +588,7 @@ export class WorkerGateway {
       const instructionContext: InstructionContext = {
         userId,
         agentId: agentId || "",
+        connectionId: auth.tokenData.connectionId,
         organizationId: tokenOrgId,
         // Instruction providers skip their by-id settings read when this is
         // false (orgless DB-backed agent) and use the generic branch.


### PR DESCRIPTION
## What

Only Slack supplied chat identity instructions. `createPlatformAdapter` attached an instruction provider **solely when the platform descriptor declared one**, and Slack is the only descriptor that does — so Telegram, Discord, WhatsApp, Teams and Google Chat received an empty `platformInstructions`.

Without them the agent has only its identity markdown, which describes the principal in the third person ("you work on the user's data on their behalf") and never says the person currently typing *is* that principal. The model resolves that ambiguity per turn, often the wrong way — narrating the conversation back to an operator who does not exist.

Real prod replies from `@burembalobubot` (Telegram, org `buremba`):

> "It looks like Burak Kabakci sent a message with "hey2" in the Telegram chat. **Would you like to respond to this message**…"
> "Burak is asking if "REVERTCHECK" is working. **How would you like to respond?**"

## Approach

Identity becomes the **default for every chat platform** rather than a per-platform opt-in, so a platform added later inherits it instead of re-deriving it. Slack keeps only its genuine delta (`<@U…>` mention encoding) and inherits the rest — net −54 lines there.

Two properties worth calling out:

**Identity is best-effort; framing is not.** `Adapter.botUserId` is optional in the Chat SDK and some platforms carry no handle. The participation framing is emitted even when no handle resolves — that is the half that actually fixes the voice. The only case emitting nothing is a missing org, which is the cross-tenant guard.

**Prompt-cache safe.** The block is connection-scoped (platform, handle, bot id) and sits at the front of `gatewayInstructions`, where the openai-completions path caches by longest-common-prefix with no explicit breakpoints. A test renders it for two users/sessions on one connection and asserts byte equality, so a later conversation-scoped interpolation (sender name, chat id) fails the build rather than silently costing the cache on every new conversation.

## Red → green

Asserted at the **seam**, not on the new class — a test of a class that did not exist cannot prove a regression. Reverting only the conditional in `createPlatformAdapter`:

```
(fail) telegram — a platform declaring NO provider still gets the generic one
Expected constructor: ChatIdentityInstructionProvider
Received value: undefined
```

`undefined` — Telegram had no instruction provider at all. Slack's tests passed throughout, which is exactly why only Telegram showed the symptom.

Restored: **18 pass** in the new file, **152 pass / 0 fail** across `connections/__tests__`, `pre-pr` clean on all 6 gates.

The seam test enumerates `PLATFORM_REGISTRY` rather than sampling, so it fails if a future platform is added without the framing or if an opt-in conditional is reintroduced.

## Honest limits

- The observer voice is **not deterministic** — recent prod turns on undeployed code came out correctly in the second person. This is a consistency fix, so a single post-deploy message cannot confirm it; it needs several turns compared against the third-person samples above.
- `review-fix` replaced an arbitrary `connections[0]` lookup with a `connectionId`-targeted one plumbed from the signed token. Verified tenant-safe: `getConnection` reads `tryGetOrgId()` and queries `WHERE organization_id = $orgId AND slug = $slug`, inside `orgContext.run`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->