### PR TITLE
fix(server): record why a merge was proposed, not just who

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -285,6 +285,52 @@ describe("manage_entity merge action", () => {
 		});
 	});
 
+	it("records the matching values that justify the merge on both sides of the snapshot", async () => {
+		const org = await createTestOrganization({ name: "Snapshot Evidence Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+      UPDATE entities SET metadata = jsonb_build_object('phone', '+90 539 510 22 40')
+      WHERE id = ${winner.id} AND organization_id = ${org.id}
+    `;
+		await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+      VALUES
+        (${org.id}, ${loser.id}, 'phone', '905395102240'),
+        (${org.id}, ${loser.id}, 'wa_jid', '905395102240@s.whatsapp.net')
+    `;
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+			} as ToolContext,
+		)) as unknown as { approval_queued: boolean; approval_run_id: number };
+
+		expect(queued.approval_queued).toBe(true);
+		const [run] = await sql<{ action_input: Record<string, unknown> }[]>`
+			SELECT action_input FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		const current = (run.action_input as { current: Record<string, unknown> })
+			.current as {
+			winner: { resolution_keys?: Record<string, string[]> };
+			duplicates: Array<{ resolution_keys?: Record<string, string[]> }>;
+		};
+		expect(current.winner.resolution_keys).toEqual({
+			phone: ["905395102240"],
+		});
+		expect(current.duplicates[0]?.resolution_keys).toEqual({
+			phone: ["905395102240"],
+		});
+		// Persist normalized policy values without copying arbitrary entity metadata.
+		expect(current.winner).not.toHaveProperty("metadata");
+	});
+
 	it("records the agent session that proposed the merge, not an orphan run", async () => {
 		const org = await createTestOrganization({ name: "Initiator Agent Org" });
 		const user = await createTestUser();

--- a/packages/server/src/entity-resolution/discovery.test.ts
+++ b/packages/server/src/entity-resolution/discovery.test.ts
@@ -326,6 +326,10 @@ describe("entity resolution module", () => {
 			kind: "phone",
 			identifier: "447700900123",
 		});
+		expect(assessment.resolutionKeys).toEqual([
+			{ id: 1, keys: { phone: ["447700900123"] } },
+			{ id: 2, keys: { phone: ["447700900123"] } },
+		]);
 	});
 
 	it("reads a JID-shell's phone identity but does not match a corrupted metadata phone", () => {
@@ -474,6 +478,29 @@ describe("entity resolution module", () => {
 			kind: "email + phone",
 			identifier: "same@example.com · 447700900123",
 		});
+	});
+
+	it("records custom rule labels without colliding with object prototype keys", () => {
+		const assessment = assessEntityResolution({
+			metadataSchema: {
+				"x-lobu-resolution": {
+					rules: [
+						{
+							fields: ["constructor"],
+							normalizer: "exact",
+							onMatch: "review",
+						},
+					],
+				},
+			},
+			winner: { id: 1, metadata: { constructor: "shared" } },
+			losers: [{ id: 2, metadata: { constructor: "shared" } }],
+		});
+
+		expect(assessment.resolutionKeys).toEqual([
+			{ id: 1, keys: { constructor: ["shared"] } },
+			{ id: 2, keys: { constructor: ["shared"] } },
+		]);
 	});
 
 	it("rejects oversized decision batches before returning partial work", () => {

--- a/packages/server/src/entity-resolution/policy.ts
+++ b/packages/server/src/entity-resolution/policy.ts
@@ -19,12 +19,23 @@ interface ResolutionEntity {
 	identities?: ResolutionIdentity[];
 }
 
+/**
+ * One entity's normalized rule keys, grouped under the same labels used by
+ * `evidence.kind`. This is a readable view of the rule evaluation included in
+ * the resolution fingerprint. Rules that normalize no values are omitted.
+ */
+export interface ResolutionKeySet {
+	id: number;
+	keys: Record<string, string[]>;
+}
+
 interface EntityResolutionAssessment {
 	decision: ResolutionDecision;
 	evidence: ResolutionEvidence[];
 	policyHash: string;
 	fingerprint: string;
 	reason: string;
+	resolutionKeys: ResolutionKeySet[];
 }
 
 interface ResolutionRule {
@@ -275,12 +286,31 @@ export function assessEntityResolution(input: {
 		loserIds: input.losers.map((entity) => entity.id).sort((a, b) => a - b),
 		normalizedIdentities,
 	});
+	// Derive the snapshot view from the same normalized values used above without
+	// changing the fingerprint input.
+	const resolutionKeys: ResolutionKeySet[] = normalizedIdentities.map(
+		({ id, values }) => {
+			const keysByLabel = new Map<string, string[]>();
+			values.forEach((ruleKeys, index) => {
+				if (ruleKeys.length === 0) return;
+				const rule = rules[index]!;
+				const label = rule.fields.join(" + ");
+				const existingKeys = keysByLabel.get(label) ?? [];
+				keysByLabel.set(
+					label,
+					[...new Set([...existingKeys, ...ruleKeys])].sort(),
+				);
+			});
+			return { id, keys: Object.fromEntries(keysByLabel) };
+		},
+	);
 
 	return {
 		decision,
 		evidence: deduplicatedEvidence,
 		policyHash,
 		fingerprint,
+		resolutionKeys,
 		// Addressed to the human deciding the approval, so each branch says what
 		// the workspace could verify and what it now needs from them — not what
 		// the rules engine did internally.

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -14,6 +14,7 @@ import {
 } from "@lobu/core/contracts/interaction-envelope";
 import { resolveEntityApprovalPolicy } from "../../authz/entity-policy";
 import { type DbClient, getDb, pgBigintArray } from "../../db/client";
+import type { ResolutionKeySet } from "../../entity-resolution/policy";
 import { assertResolutionFingerprintCurrent } from "../../entity-resolution/staleness";
 import type { Env } from "../../index";
 import {
@@ -328,6 +329,7 @@ async function loadEntitySnapshot(
 function toEntityReviewSnapshot(
 	urlContext: Awaited<ReturnType<typeof getOrgUrlContext>>,
 	entity: EntitySnapshot,
+	resolutionKeys: Record<string, string[]>,
 ) {
 	const { ownerSlug, baseUrl } = urlContext;
 	const href =
@@ -352,6 +354,11 @@ function toEntityReviewSnapshot(
 		parent_slug: entity.parent_slug,
 		parent_entity_type: entity.parent_entity_type,
 		...(href ? { href } : {}),
+		// Preserve the policy's normalized view even when a value came from entity
+		// metadata and therefore is absent from the identity rows below.
+		...(Object.keys(resolutionKeys).length > 0
+			? { resolution_keys: resolutionKeys }
+			: {}),
 		identities: entity.identities.map((identity) => ({
 			...identity,
 			...(ownerSlug && identity.connection_id && identity.connector_key
@@ -440,22 +447,38 @@ export async function proposeEntityMerge(
 	proposal: Omit<EntityMergeProposal, "operation" | "current" | "entity_id"> & {
 		entity_ids: number[];
 	},
+	resolutionKeys: readonly ResolutionKeySet[],
 ): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
 	const ids = [...new Set([...proposal.entity_ids, proposal.winner_entity_id])];
 	const snapshots = await loadEntitySnapshots(ctx, ids);
 	const byId = new Map(snapshots.map((entity) => [Number(entity.id), entity]));
+	const keysById = new Map(
+		resolutionKeys.map((entry) => [Number(entry.id), entry.keys]),
+	);
 	const requireSnapshot = (entityId: number) => {
 		const snapshot = byId.get(entityId);
 		if (!snapshot) throw new Error(`Entity ${entityId} not found`);
 		return snapshot;
 	};
+	const requireResolutionKeys = (entityId: number) => {
+		const keys = keysById.get(entityId);
+		if (!keys) {
+			throw new Error(`Resolution keys for entity ${entityId} not found`);
+		}
+		return keys;
+	};
 	const urlContext = await getOrgUrlContext(ctx);
 	const linkedDuplicates = proposal.entity_ids.map((entityId) =>
-		toEntityReviewSnapshot(urlContext, requireSnapshot(entityId)),
+		toEntityReviewSnapshot(
+			urlContext,
+			requireSnapshot(entityId),
+			requireResolutionKeys(entityId),
+		),
 	);
 	const linkedWinner = toEntityReviewSnapshot(
 		urlContext,
 		requireSnapshot(proposal.winner_entity_id),
+		requireResolutionKeys(proposal.winner_entity_id),
 	);
 	const [loser, ...rest] = linkedDuplicates;
 	if (!loser) throw new Error("At least one duplicate entity is required");

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -749,24 +749,29 @@ async function handleMerge(
 				},
 			};
 		}
-		const queued = await proposeEntityMerge(ctx, {
-			entity_ids: loserIds,
-			winner_entity_id: winnerId,
-			evidence: resolution.evidence,
-			watcher_id:
-				ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null,
-			window_id: ctx.actingWindowId ?? args.behavior_source?.window_id ?? null,
-			source_run_id: ctx.actingRunId ?? null,
-			policy_hash: resolution.policyHash,
-			resolution_fingerprint: resolution.fingerprint,
-			attribution,
-			reason: resolution.reason,
-			// The proposer's own words, kept strictly separate from `reason` (the
-			// machine-computed policy verdict). Displayed as a claim attributed to
-			// whoever proposed the merge — it is never evidence and never affects
-			// the auto-merge decision, which is recomputed server-side above.
-			proposer_rationale: args.merge_rationale?.trim() || null,
-		});
+		const queued = await proposeEntityMerge(
+			ctx,
+			{
+				entity_ids: loserIds,
+				winner_entity_id: winnerId,
+				evidence: resolution.evidence,
+				watcher_id:
+					ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null,
+				window_id:
+					ctx.actingWindowId ?? args.behavior_source?.window_id ?? null,
+				source_run_id: ctx.actingRunId ?? null,
+				policy_hash: resolution.policyHash,
+				resolution_fingerprint: resolution.fingerprint,
+				attribution,
+				reason: resolution.reason,
+				// The proposer's own words, kept strictly separate from `reason` (the
+				// machine-computed policy verdict). Displayed as a claim attributed to
+				// whoever proposed the merge — it is never evidence and never affects
+				// the auto-merge decision, which is recomputed server-side above.
+				proposer_rationale: args.merge_rationale?.trim() || null,
+			},
+			resolution.resolutionKeys,
+		);
 		return {
 			action: "merge",
 			approval_queued: true,


### PR DESCRIPTION
## Summary
- A queued merge approval stored **who** was involved but never **why**. `action_input.current` carried id/name/slug/href plus the `entity_identities` rows — so when the matching value lived in `entities.metadata` instead, the snapshot recorded no reason at all. Prod run `702099` is exactly that shape: the reviewer sees two names and `evidence: []`.
- `assessEntityResolution` now returns the normalized per-entity rule keys it already computed, and `proposeEntityMerge` writes them onto each side of the snapshot as `resolution_keys`.
- Derived from `normalizedIdentities` **after** the fingerprint digest is taken, so no fingerprint value changes and no pending proposal is stranded.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted vitest, unit + integration (56 total)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval — n/a

### Red (production code reverted, new tests kept)

```
× entity resolution module > reads rule-field values from entity_identities rows, not just metadata
  → expected undefined to deeply equal [ { id: 1, …(1) }, { id: 2, …(1) } ]
× entity resolution module > records custom rule labels without colliding with object prototype keys
  → expected undefined to deeply equal [ { id: 1, keys: { …(1) } }, …(1) ]
  Tests  2 failed | 18 passed (20)

× manage_entity merge action > records the matching values that justify the merge on both sides of the snapshot
  → expected undefined to deeply equal { phone: [ '905395102240' ] }
  Tests  1 failed | 22 passed (23)
```

### Green

```
discovery.test.ts                              20 passed (20)
entity-merge-tool.test.ts + events/entity-merge.test.ts
                                               36 passed (36)
```

## Notes

**Prototype collision.** The key map is a `Map` + `Object.fromEntries`, not an object literal. A rule field named `constructor` or `__proto__` would otherwise read off `Object.prototype` and throw on spread. Mutation-verified — reverting to the object literal fails the new test with `TypeError: (keys[label] ?? []) is not iterable`.

**Fingerprint stability.** The `digest()` input is untouched and sits above the new code. Recomputing all 18 currently-pending prod proposals under this policy produced byte-identical hashes (`cfb69107`, `6ca24e37`, `16f817dd`, `dd2f8f17`, `c3c8838b`, `0141173a`).

**Live e2e.** Exercised over real MCP streamable HTTP with an agent-attributed `manage_entity` merge, then approved through the UI: the snapshot carried `resolution_keys: {"phone":["905395102240"]}` on the winner (whose `identities` was `[]` — the metadata-only case this fixes) and on the duplicate; approval applied cleanly with tombstone, forward pointer, and identity fold.

**Follow-up, not in this PR.** This makes an existing proposal legible; it does not fix the reason the 18 prod proposals are unapprovable. Those were minted before #2152 added `entity_identities` as a fingerprint input, so their stored hashes are metadata-only and can never revalidate. That needs a version stamp plus a refresh path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->