### PR TITLE
fix(server): re-present a merge whose fingerprint format changed, not dead-end it

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -8,7 +8,10 @@
 import postgres from "postgres";
 import { beforeEach, describe, expect, it } from "vitest";
 import { PROD_PG_VALUE_OPTIONS } from "../../../db/client";
-import { assessEntityResolution } from "../../../entity-resolution/policy";
+import {
+	assessEntityResolution,
+	RESOLUTION_FINGERPRINT_VERSION,
+} from "../../../entity-resolution/policy";
 import { assertResolutionFingerprintCurrent } from "../../../entity-resolution/staleness";
 import type { Env } from "../../../index";
 import { manageEntity } from "../../../tools/admin/manage_entity";
@@ -245,6 +248,157 @@ describe("manage_entity merge action", () => {
 			WHERE run_id = ${queued.approval_run_id}
 		`;
 		expect(completedEvent.interaction_status).toBe("completed");
+	});
+
+	it("re-presents a merge whose fingerprint predates the current format instead of dead-ending it", async () => {
+		// Replicates an unversioned proposal minted before #2152 added
+		// entity_identities to the hashed inputs. Before this fix every approval
+		// bounced the run back to pending with a mismatch the reviewer could not
+		// clear.
+		const org = await createTestOrganization({ name: "Stranded Merge Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+
+		const watcherCtx = {
+			...ctx(org.id, user.id, "owner"),
+			userId: null,
+			agentId: "personal-agent",
+		} as ToolContext;
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			watcherCtx,
+		)) as unknown as { approval_queued: boolean; approval_run_id: number };
+		expect(queued.approval_queued).toBe(true);
+
+		// Rewrite the stored proposal into the pre-#2152 shape: a digest from the
+		// old input set and no version stamp at all.
+		const [minted] = await sql`
+			SELECT action_input FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		const stale = {
+			...(minted.action_input as Record<string, unknown>),
+			resolution_fingerprint: "0".repeat(64),
+		};
+		delete stale.resolution_fingerprint_version;
+		await sql`
+			UPDATE runs SET action_input = ${sql.json(stale)}
+			WHERE id = ${queued.approval_run_id}
+		`;
+
+		const refreshed = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("error" in refreshed && refreshed.error).toMatch(
+			/without a known current matching format/i,
+		);
+
+		// The merge must NOT have applied — the reviewer approved evidence the
+		// server could not verify, so their click does not carry over.
+		const [untouched] =
+			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
+		expect(untouched.merged_into).toBeNull();
+		expect(untouched.deleted_at).toBeNull();
+
+		// ...but the proposal is now approvable: pending, restamped, and carrying
+		// a fingerprint the server can actually check.
+		const [reset] = await sql`
+			SELECT approval_status, status, action_input FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		expect(reset).toMatchObject({
+			approval_status: "pending",
+			status: "pending",
+		});
+		const resetInput = reset.action_input as Record<string, unknown>;
+		expect(resetInput.resolution_fingerprint_version).toBe(
+			RESOLUTION_FINGERPRINT_VERSION,
+		);
+		expect(resetInput.resolution_fingerprint).not.toBe("0".repeat(64));
+
+		const [recheckedEvent] = await sql`
+			SELECT title, interaction_status, interaction_input, metadata
+			FROM current_event_records
+			WHERE run_id = ${queued.approval_run_id}
+		`;
+		expect(recheckedEvent.title).toBe(
+			"entity_merge — evidence re-checked, still pending",
+		);
+		expect(recheckedEvent.interaction_input).toEqual(resetInput);
+		expect(recheckedEvent.metadata).toMatchObject({
+			current: resetInput.current,
+			proposal: {
+				evidence: resetInput.evidence,
+			},
+			reason: resetInput.reason,
+		});
+
+		// Approving the re-presented card applies, ending the dead end.
+		const applied = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("approved" in applied && applied.approved).toBe(true);
+		const [merged] =
+			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
+		expect(Number(merged.merged_into)).toBe(winner.id);
+		expect(merged.deleted_at).not.toBeNull();
+	});
+
+	it("does not downgrade a merge fingerprint from a newer format", async () => {
+		const org = await createTestOrganization({ name: "Future Merge Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+			} as ToolContext,
+		)) as unknown as { approval_queued: boolean; approval_run_id: number };
+		expect(queued.approval_queued).toBe(true);
+
+		const [minted] = await sql`
+			SELECT action_input FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		const future = {
+			...(minted.action_input as Record<string, unknown>),
+			resolution_fingerprint_version: RESOLUTION_FINGERPRINT_VERSION + 1,
+		};
+		await sql`
+			UPDATE runs SET action_input = ${sql.json(future)}
+			WHERE id = ${queued.approval_run_id}
+		`;
+
+		const result = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("error" in result && result.error).toMatch(
+			/newer resolution format/i,
+		);
+		const [reset] = await sql`
+			SELECT approval_status, status, action_input
+			FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		expect(reset).toMatchObject({
+			approval_status: "pending",
+			status: "pending",
+		});
+		expect(reset.action_input).toEqual(future);
+		const [untouched] =
+			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
+		expect(untouched.merged_into).toBeNull();
+		expect(untouched.deleted_at).toBeNull();
 	});
 
 	it("queues review evidence for a phone shared only through entity_identities", async () => {
@@ -1279,6 +1433,7 @@ describe("manage_entity merge action", () => {
 					winnerId: winner.id,
 					loserIds: [loser.id],
 					expectedFingerprint: assessment.fingerprint,
+					expectedVersion: RESOLUTION_FINGERPRINT_VERSION,
 				});
 				await expect(
 					writer.begin(async (writerTx) => {

--- a/packages/server/src/entity-resolution/policy.ts
+++ b/packages/server/src/entity-resolution/policy.ts
@@ -1,5 +1,21 @@
 import { createHash } from "node:crypto";
 
+/**
+ * Version of the inputs `assessEntityResolution` hashes into `fingerprint`.
+ *
+ * Bump this whenever the hashed input set changes shape — adding a field,
+ * changing normalization, reading a new source. A fingerprint mismatch only
+ * proves drift within the same version: across versions the digests can differ
+ * even when nothing about the entities changed.
+ *
+ * v1 → v2: #2152 added `entity_identities` rows alongside `entities.metadata`
+ * as rule-field inputs. Proposals minted before it stored metadata-only
+ * digests, which current recomputation cannot compare. Because the version
+ * stamp was added later, unstamped mismatches are conservatively refreshed:
+ * their exact historical format cannot be inferred from the digest alone.
+ */
+export const RESOLUTION_FINGERPRINT_VERSION = 2;
+
 type ResolutionDecision = "auto_merge" | "review";
 
 export interface ResolutionEvidence {
@@ -29,7 +45,7 @@ export interface ResolutionKeySet {
 	keys: Record<string, string[]>;
 }
 
-interface EntityResolutionAssessment {
+export interface EntityResolutionAssessment {
 	decision: ResolutionDecision;
 	evidence: ResolutionEvidence[];
 	policyHash: string;

--- a/packages/server/src/entity-resolution/staleness.ts
+++ b/packages/server/src/entity-resolution/staleness.ts
@@ -1,6 +1,43 @@
 import { type DbClient, pgBigintArray } from "../db/client";
 import { loadLiveEntityIdentities } from "./identities";
-import { assessEntityResolution } from "./policy";
+import {
+	assessEntityResolution,
+	type EntityResolutionAssessment,
+	RESOLUTION_FINGERPRINT_VERSION,
+} from "./policy";
+
+/**
+ * Why a reviewed merge could not be applied against its stored fingerprint.
+ *
+ * `changed` means the workspace moved under the reviewer: same hash inputs,
+ * different values. The proposal is genuinely stale.
+ *
+ * `incomparable` means the stored digest has no known current version, so it
+ * cannot be compared at all. Nothing about the entities necessarily changed —
+ * treating this as staleness makes the proposal permanently unapprovable,
+ * because every retry recomputes the same mismatch.
+ */
+type ResolutionFingerprintFailure = "changed" | "incomparable";
+
+export class ResolutionFingerprintError extends Error {
+	readonly failure: ResolutionFingerprintFailure;
+	/** The freshly computed assessment, so a caller can refresh without redoing the work. */
+	readonly assessment: EntityResolutionAssessment;
+
+	constructor(
+		failure: ResolutionFingerprintFailure,
+		assessment: EntityResolutionAssessment,
+	) {
+		super(
+			failure === "incomparable"
+				? "Merge evidence was recorded without a known current resolution format"
+				: "Merge evidence or resolution policy changed after review was requested",
+		);
+		this.name = "ResolutionFingerprintError";
+		this.failure = failure;
+		this.assessment = assessment;
+	}
+}
 
 /** Lock and re-evaluate a reviewed merge immediately before applying it. */
 export async function assertResolutionFingerprintCurrent(
@@ -10,6 +47,13 @@ export async function assertResolutionFingerprintCurrent(
 		winnerId: number;
 		loserIds: number[];
 		expectedFingerprint: string;
+		/**
+		 * Which format produced `expectedFingerprint`. Required, and deliberately
+		 * without a default: a live fingerprint computed in this process is current
+		 * by construction, while an unstamped stored proposal has unknown provenance.
+		 * Guessing a version could silently accept incomparable evidence.
+		 */
+		expectedVersion: number | null;
 	},
 ): Promise<void> {
 	const ids = [...input.loserIds, input.winnerId].sort((a, b) => a - b);
@@ -62,9 +106,25 @@ export async function assertResolutionFingerprintCurrent(
 			identities: identities.get(loserId) ?? [],
 		})),
 	});
-	if (assessment.fingerprint !== input.expectedFingerprint) {
+	// A newer stamp must fail closed during a rolling deploy rather than being
+	// downgraded by an older replica.
+	if (
+		input.expectedVersion !== null &&
+		input.expectedVersion > RESOLUTION_FINGERPRINT_VERSION
+	) {
 		throw new Error(
-			"Merge evidence or resolution policy changed after review was requested",
+			"Merge evidence was recorded under a newer resolution format and cannot be verified by this server",
 		);
 	}
+	// Exact equality is safe even for an unstamped or older proposal. The version
+	// is needed only to interpret a mismatch: missing/older inputs are
+	// incomparable, while a current-version mismatch proves drift.
+	if (assessment.fingerprint === input.expectedFingerprint) return;
+	if (
+		input.expectedVersion === null ||
+		input.expectedVersion < RESOLUTION_FINGERPRINT_VERSION
+	) {
+		throw new ResolutionFingerprintError("incomparable", assessment);
+	}
+	throw new ResolutionFingerprintError("changed", assessment);
 }

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -14,7 +14,11 @@ import {
 } from "@lobu/core/contracts/interaction-envelope";
 import { resolveEntityApprovalPolicy } from "../../authz/entity-policy";
 import { type DbClient, getDb, pgBigintArray } from "../../db/client";
-import type { ResolutionKeySet } from "../../entity-resolution/policy";
+import {
+	type EntityResolutionAssessment,
+	RESOLUTION_FINGERPRINT_VERSION,
+	type ResolutionKeySet,
+} from "../../entity-resolution/policy";
 import { assertResolutionFingerprintCurrent } from "../../entity-resolution/staleness";
 import type { Env } from "../../index";
 import {
@@ -134,6 +138,12 @@ export interface EntityMergeProposal {
 	source_run_id?: number | null;
 	policy_hash?: string | null;
 	resolution_fingerprint?: string | null;
+	/**
+	 * Which version of the hashed input set produced `resolution_fingerprint`.
+	 * An absent stamp cannot distinguish proposals minted before and after the
+	 * last input-format change, so a mismatch is refreshed rather than guessed.
+	 */
+	resolution_fingerprint_version?: number | null;
 	attribution?: ApprovalAttributionType;
 	reason?: string | null;
 	/**
@@ -184,7 +194,9 @@ function asCreateProposal(
 	);
 }
 
-function asMergeProposal(proposal: EntityChangeProposal): EntityMergeProposal {
+export function asMergeProposal(
+	proposal: EntityChangeProposal,
+): EntityMergeProposal {
 	if (proposal.operation === "merge") return proposal;
 	throw new Error(
 		`Expected merge proposal, got ${proposal.operation ?? "update"}`,
@@ -200,6 +212,23 @@ function changedEntityId(proposal: EntityChangeProposal): number {
 
 function mergeEntityIds(proposal: EntityMergeProposal): number[] {
 	return proposal.entity_ids ?? [proposal.entity_id];
+}
+
+export function mergeReviewEventMetadata(proposal: EntityMergeProposal) {
+	const duplicates = proposal.current.duplicates ?? [proposal.current.loser];
+	return {
+		current: proposal.current,
+		proposal: {
+			entity_id: proposal.entity_id,
+			entity_ids: mergeEntityIds(proposal),
+			winner_entity_id: proposal.winner_entity_id,
+			evidence: proposal.evidence ?? [],
+			names: duplicates.map((entity) => entity.name),
+			name: proposal.current.loser.name,
+			winner_name: proposal.current.winner.name,
+		},
+		reason: proposal.reason ?? null,
+	};
 }
 
 function entityChangeIdempotencyKey(
@@ -442,18 +471,25 @@ export async function proposeEntityCreate(
 	return proposeEntityChange(ctx, { ...proposal, operation: "create" });
 }
 
-export async function proposeEntityMerge(
+/**
+ * Build the `current` snapshot a reviewer reads for a merge. Shared by the
+ * propose path and the refresh path so a refreshed card is built exactly the
+ * same way as a freshly proposed one — a refresh that produced a differently
+ * shaped snapshot would be indistinguishable from a bug to whoever reads it.
+ */
+async function buildMergeReviewSnapshot(
 	ctx: ToolContext,
-	proposal: Omit<EntityMergeProposal, "operation" | "current" | "entity_id"> & {
-		entity_ids: number[];
+	input: {
+		entityIds: number[];
+		winnerEntityId: number;
+		resolutionKeys: readonly ResolutionKeySet[];
 	},
-	resolutionKeys: readonly ResolutionKeySet[],
-): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
-	const ids = [...new Set([...proposal.entity_ids, proposal.winner_entity_id])];
+): Promise<EntityMergeProposal["current"]> {
+	const ids = [...new Set([...input.entityIds, input.winnerEntityId])];
 	const snapshots = await loadEntitySnapshots(ctx, ids);
 	const byId = new Map(snapshots.map((entity) => [Number(entity.id), entity]));
 	const keysById = new Map(
-		resolutionKeys.map((entry) => [Number(entry.id), entry.keys]),
+		input.resolutionKeys.map((entry) => [Number(entry.id), entry.keys]),
 	);
 	const requireSnapshot = (entityId: number) => {
 		const snapshot = byId.get(entityId);
@@ -468,7 +504,7 @@ export async function proposeEntityMerge(
 		return keys;
 	};
 	const urlContext = await getOrgUrlContext(ctx);
-	const linkedDuplicates = proposal.entity_ids.map((entityId) =>
+	const linkedDuplicates = input.entityIds.map((entityId) =>
 		toEntityReviewSnapshot(
 			urlContext,
 			requireSnapshot(entityId),
@@ -477,17 +513,77 @@ export async function proposeEntityMerge(
 	);
 	const linkedWinner = toEntityReviewSnapshot(
 		urlContext,
-		requireSnapshot(proposal.winner_entity_id),
-		requireResolutionKeys(proposal.winner_entity_id),
+		requireSnapshot(input.winnerEntityId),
+		requireResolutionKeys(input.winnerEntityId),
 	);
 	const [loser, ...rest] = linkedDuplicates;
 	if (!loser) throw new Error("At least one duplicate entity is required");
+	return { loser, duplicates: [loser, ...rest], winner: linkedWinner };
+}
+
+export async function proposeEntityMerge(
+	ctx: ToolContext,
+	proposal: Omit<EntityMergeProposal, "operation" | "current" | "entity_id"> & {
+		entity_ids: number[];
+	},
+	resolutionKeys: readonly ResolutionKeySet[],
+): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
+	const current = await buildMergeReviewSnapshot(ctx, {
+		entityIds: proposal.entity_ids,
+		winnerEntityId: proposal.winner_entity_id,
+		resolutionKeys,
+	});
 	return proposeEntityChange(ctx, {
 		...proposal,
-		entity_id: loser.id,
+		entity_id: current.loser.id as number,
 		operation: "merge",
-		current: { loser, duplicates: [loser, ...rest], winner: linkedWinner },
+		current,
 	});
+}
+
+/**
+ * Re-derive a pending merge proposal against the current resolution format and
+ * write the result back to its run, leaving it pending.
+ *
+ * Used when the stored fingerprint is *incomparable* rather than stale — its
+ * format stamp is absent or older, so this server cannot safely interpret a
+ * digest mismatch. Refreshing re-presents the proposal with evidence recomputed
+ * under the current format; the reviewer confirms once more against something
+ * the server can actually verify.
+ *
+ * Deliberately does NOT apply the merge. The reviewer approved a card built
+ * from evidence the server can no longer reproduce, so their click does not
+ * carry over — silently applying would treat an unverifiable approval as a
+ * verified one.
+ */
+export async function refreshMergeProposalFingerprint(
+	runId: number,
+	ctx: ToolContext,
+	proposal: EntityMergeProposal,
+	assessment: EntityResolutionAssessment,
+	db: DbClient = getDb(),
+): Promise<EntityMergeProposal> {
+	const current = await buildMergeReviewSnapshot(ctx, {
+		entityIds: mergeEntityIds(proposal),
+		winnerEntityId: proposal.winner_entity_id,
+		resolutionKeys: assessment.resolutionKeys,
+	});
+	const refreshed: EntityMergeProposal = {
+		...proposal,
+		current,
+		evidence: assessment.evidence,
+		reason: assessment.reason,
+		policy_hash: assessment.policyHash,
+		resolution_fingerprint: assessment.fingerprint,
+		resolution_fingerprint_version: RESOLUTION_FINGERPRINT_VERSION,
+	};
+	await db`
+		UPDATE runs
+		SET action_input = ${db.json(refreshed as unknown as Record<string, unknown>)}
+		WHERE id = ${runId}
+		  AND organization_id = ${ctx.organizationId}
+	`;
+	return refreshed;
 }
 
 export async function proposeEntityChange(
@@ -511,6 +607,9 @@ export async function proposeEntityChange(
 		operation === "create" ? asCreateProposal(proposal) : null;
 	const mergeProposal =
 		operation === "merge" ? asMergeProposal(proposal) : null;
+	const mergeEventMetadata = mergeProposal
+		? mergeReviewEventMetadata(mergeProposal)
+		: null;
 	const actionKey =
 		operation === "update"
 			? ENTITY_FIELD_CHANGE_ACTION_KEY
@@ -680,29 +779,17 @@ export async function proposeEntityChange(
 					action: operation === "update" ? "change" : operation,
 					entity_id: "entity_id" in proposal ? proposal.entity_id : null,
 					fields: updateProposal ? updateProposal.fields : null,
-					current: updateProposal
-						? (updateProposal.current ?? null)
-						: deleteProposal
-							? deleteProposal.current
-							: mergeProposal
-								? mergeProposal.current
+					current: mergeEventMetadata
+						? mergeEventMetadata.current
+						: updateProposal
+							? (updateProposal.current ?? null)
+							: deleteProposal
+								? deleteProposal.current
 								: null,
 					proposal: createProposal
 						? createProposal.proposal
-						: mergeProposal
-							? {
-									entity_id: mergeProposal.entity_id,
-									entity_ids: mergeEntityIds(mergeProposal),
-									winner_entity_id: mergeProposal.winner_entity_id,
-									evidence: mergeProposal.evidence ?? [],
-									names: (
-										mergeProposal.current.duplicates ?? [
-											mergeProposal.current.loser,
-										]
-									).map((entity) => entity.name),
-									name: mergeProposal.current.loser.name,
-									winner_name: mergeProposal.current.winner.name,
-								}
+						: mergeEventMetadata
+							? mergeEventMetadata.proposal
 							: deleteProposal
 								? {
 										entity_id: deleteProposal.entity_id,
@@ -732,7 +819,9 @@ export async function proposeEntityChange(
 						kind: initiatorColumns.initiatorKind,
 						...initiatorColumns.initiatorRef,
 					},
-					reason: proposal.reason ?? null,
+					reason: mergeEventMetadata
+						? mergeEventMetadata.reason
+						: (proposal.reason ?? null),
 					proposer_rationale: mergeProposal?.proposer_rationale ?? null,
 					status: "pending_approval",
 					run_id: runId,
@@ -1082,6 +1171,8 @@ export async function applyEntityChangeProposal(
 				winnerId: mergeProposal.winner_entity_id,
 				loserIds: mergeEntityIds(mergeProposal),
 				expectedFingerprint: mergeProposal.resolution_fingerprint,
+				// An unstamped mismatch has unknown provenance and must be refreshed.
+				expectedVersion: mergeProposal.resolution_fingerprint_version ?? null,
 			});
 		}
 		const params = {

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -39,7 +39,10 @@ import {
 } from "../../authz/entity-policy";
 import { discoverWorkspaceResolutionGroups } from "../../entity-resolution/discovery";
 import { loadLiveEntityIdentities } from "../../entity-resolution/identities";
-import { assessEntityResolution } from "../../entity-resolution/policy";
+import {
+	assessEntityResolution,
+	RESOLUTION_FINGERPRINT_VERSION,
+} from "../../entity-resolution/policy";
 import { wasResolutionRejected } from "../../entity-resolution/rejection";
 import { getDb, pgBigintArray, pgTextArray } from "../../db/client";
 import type { Env } from "../../index";
@@ -762,6 +765,7 @@ async function handleMerge(
 				source_run_id: ctx.actingRunId ?? null,
 				policy_hash: resolution.policyHash,
 				resolution_fingerprint: resolution.fingerprint,
+				resolution_fingerprint_version: RESOLUTION_FINGERPRINT_VERSION,
 				attribution,
 				reason: resolution.reason,
 				// The proposer's own words, kept strictly separate from `reason` (the

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -93,10 +93,14 @@ export {
 	formatActivityAttentionBlock,
 	listOrgActivity,
 } from "./manage_operations/activity-feed";
+import { ResolutionFingerprintError } from "../../entity-resolution/staleness";
 import {
 	applyEntityChangeProposal,
+	asMergeProposal,
 	ENTITY_CHANGE_ACTION_KEYS,
 	type EntityChangeProposal,
+	mergeReviewEventMetadata,
+	refreshMergeProposalFingerprint,
 } from "./entity-field-approval";
 import { callerIsAdmin } from "./helpers/db-helpers";
 import {
@@ -1566,6 +1570,7 @@ export async function supersedeActionEvent(
 	extraMetadata: Record<string, unknown> = {},
 	reviewer: ApprovalReviewer | null = null,
 	db: DbClient = getDb(),
+	interactionInput?: Record<string, unknown> | null,
 ): Promise<number | undefined> {
   const sql = db;
   const originalEvent = await sql`
@@ -1622,7 +1627,9 @@ export async function supersedeActionEvent(
 				(orig.interaction_input_schema as Record<string, unknown> | null) ??
 				null,
 		interactionInput:
-			(orig.interaction_input as Record<string, unknown> | null) ?? null,
+			interactionInput === undefined
+				? ((orig.interaction_input as Record<string, unknown> | null) ?? null)
+				: interactionInput,
 		interactionOutput:
 			((extraMetadata.output ?? extraMetadata.action_output) as
 				| Record<string, unknown>
@@ -2259,6 +2266,59 @@ async function tryApproveEntityChangeRun(
 		};
 	};
 
+	// A fingerprint without a known current input-format stamp cannot be compared
+	// safely, only recomputed. Failing it like drift makes a genuinely old
+	// proposal permanently unapprovable: every retry recomputes the same mismatch
+	// and there is no blocker the reviewer can clear. Re-present it instead — the
+	// run stays pending with evidence rebuilt under the current format.
+	const refreshIncomparableFingerprint = async (
+		error: unknown,
+		proposal: EntityChangeProposal,
+		db: DbClient,
+	): Promise<ManageOperationsResult | null> => {
+		if (
+			!(error instanceof ResolutionFingerprintError) ||
+			error.failure !== "incomparable" ||
+			entityChangeOperation(proposal) !== "merge"
+		) {
+			return null;
+		}
+		const reset = await db`
+      UPDATE runs SET approval_status = 'pending', status = 'pending', error_message = ${error.message}
+      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+		AND approval_status = 'approved' AND status = 'running'
+		RETURNING id
+    `;
+		if (reset.length === 0) return null;
+		const refreshedProposal = await refreshMergeProposalFingerprint(
+			args.run_id,
+			ctx,
+			asMergeProposal(proposal),
+			error.assessment,
+			db,
+		);
+		const eventId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"pending",
+			"entity_merge — evidence re-checked, still pending",
+			`This merge was proposed without a known current matching format, so its recorded evidence could not be verified. It has been re-checked against the workspace as it stands now: ${error.assessment.reason} Review the updated evidence and approve again, or reject it.`,
+			mergeReviewEventMetadata(refreshedProposal),
+			reviewer,
+			db,
+			refreshedProposal as unknown as Record<string, unknown>,
+		);
+		if (eventId === undefined) {
+			throw new Error(
+				"Cannot refresh merge approval because its approval event is missing",
+			);
+		}
+		return {
+			error:
+				"This merge was recorded without a known current matching format. Its evidence has been re-checked and the approval is pending again — review the updated evidence and approve once more, or reject it.",
+		};
+	};
+
 	const applyFailure = async (
 		error: unknown,
 	): Promise<ManageOperationsResult> => {
@@ -2351,7 +2411,17 @@ async function tryApproveEntityChangeRun(
 					tx,
 				);
 				if (!claimed) return null;
-				return completeApproval(tx, claimed.proposal);
+				try {
+					return await completeApproval(tx, claimed.proposal);
+				} catch (error) {
+					const refreshed = await refreshIncomparableFingerprint(
+						error,
+						claimed.proposal,
+						tx,
+					);
+					if (refreshed) return refreshed;
+					throw error;
+				}
 			});
 		} catch (error) {
 			return applyFailure(error);

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -27,7 +27,10 @@
 import { isDeepStrictEqual } from "node:util";
 import { type DbClient, getDb, pgBigintArray } from "../db/client";
 import { mergeEntityState } from "../entity-resolution/merge-state";
-import type { ResolutionEvidence } from "../entity-resolution/policy";
+import {
+	RESOLUTION_FINGERPRINT_VERSION,
+	type ResolutionEvidence,
+} from "../entity-resolution/policy";
 import { assertResolutionFingerprintCurrent } from "../entity-resolution/staleness";
 import logger from "./logger";
 
@@ -112,6 +115,9 @@ export async function applyMergeGroupInTransaction(
 			winnerId: params.winnerId,
 			loserIds,
 			expectedFingerprint: params.expectedResolutionFingerprint,
+			// Computed by this process moments ago, so it is current by
+			// construction — never a stored digest from an older format.
+			expectedVersion: RESOLUTION_FINGERPRINT_VERSION,
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Approving certain merges failed **forever**. `assertResolutionFingerprintCurrent` treated any digest mismatch as staleness, but one comparison was hiding two conditions:
  - **`changed`** — same hashed inputs, different values. The workspace moved under the reviewer; refusing is correct.
  - **`incomparable`** — the digest came from an older input set, so it says nothing about drift. Refusing is *permanent*: every retry recomputes the same mismatch and there is no blocker the reviewer can clear.
- #2152 added `entity_identities` to the hashed inputs, so every proposal minted before it is the second kind treated as the first. **18 are stranded in one prod workspace**, all with `has_version = 0`.
- The fingerprint now carries a version. An exact digest match still applies regardless of stamp; only a mismatch consults the version. Absent/older → re-present. **Newer → fail closed**, so an older replica mid-rolling-deploy cannot downgrade a proposal.
- Refresh deliberately does **not** apply the merge — the reviewer confirmed a card built from evidence this server cannot reproduce, so the click does not carry over. Reset, refresh, and card replacement share one transaction.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` (872 + 826 pass, 0 fail) + targeted integration
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval — n/a

### Red (production code reverted, reproducer kept)

The reproducer replicates the stranded prod shape — a metadata-era digest with no version stamp — and gets the exact error users hit:

```
× re-presents a merge whose fingerprint predates the current format instead of dead-ending it
  → expected 'Failed to apply entity merge: Merge e…' to match /older matching format/i
```

### Green

```
entity-merge-tool.test.ts        25 passed
events/entity-merge.test.ts      13 passed
discovery.test.ts                20 passed
                                 58 passed (58)
```

## Notes

**Mutation-verified.** Deleting the future-version guard fails `does not downgrade a merge fingerprint from a newer format`. The test bites.

**Prod pre-flight.** All 18 stranded runs carry the fields the refresh needs and none has a version stamp, so every one takes the new path:

```
stranded  has_fingerprint  has_version  has_winner  has_losers
      18               18            0          18          18
```

**Card correctness.** `supersedeActionEvent` gained an `interactionInput` parameter so the re-presented card renders the *refreshed* proposal. Without it the run would hold new evidence while the card still showed the old — the approval card reads `interaction_input`, not `metadata`.

**Shared builders.** `buildMergeReviewSnapshot` and `mergeReviewEventMetadata` are used by both the propose and refresh paths, so a refreshed card cannot drift in shape from a freshly proposed one.

**Follow-up, not in this PR.** This unblocks the stranded proposals; it does not address why they existed. Those 18 are named-contact ↔ WhatsApp-JID pairs that only needed a phone number matched — the write path that created them (`run_sdk`) has no identity contract, so the values landed in `entities.metadata` as raw strings instead of normalized identity claims.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->