### PR TITLE
fix(server): advance a Behavior's cron cursor when its run fails

### DIFF
--- a/packages/server/src/__tests__/integration/watchers-feeds-timezone.test.ts
+++ b/packages/server/src/__tests__/integration/watchers-feeds-timezone.test.ts
@@ -11,7 +11,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import type { DbClient } from '../../db/client';
 import { ClientSdkActionError } from '../../sandbox/namespaces/action-call';
 import { nextRunAt } from '../../utils/cron';
-import { advanceWatcherSchedule } from '../../watchers/automation';
+import { advanceWatcherSchedule } from '../../watchers/schedule-cursor';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import {
   createTestAgent,

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -22,13 +22,13 @@ import { generateWindowToken } from "../../../utils/jwt";
 import { computePendingWindow } from "../../../utils/window-utils";
 import { handleBehaviorMode } from "../../../tools/get_content/behavior-mode";
 import {
-	advanceWatcherSchedule,
 	dispatchPendingWatcherRuns,
 	materializeDueWatcherRuns,
 	reconcileWatcherRuns,
 	runWatcherAutomationTick,
 	sweepStaleWatcherRuns,
 } from "../../../watchers/automation";
+import { advanceWatcherSchedule } from "../../../watchers/schedule-cursor";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
 	createCanvasWindow,

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import { materializeDueWatcherRuns } from "../../../watchers/automation";
+import { resolveWatcherRunsByMessageIds } from "../../../watchers/run-completion";
+import { getTestDb } from "../../setup/test-db";
+import { createTestAgent, createTestEntity } from "../../setup/test-fixtures";
+import { TestWorkspace } from "../../setup/test-mcp-client";
+
+async function createDueWatcherWithDispatchedRun(opts: {
+  slug: string;
+  messageId: string;
+  nudgeCount?: number;
+  dispatchSource?: "scheduled" | "event";
+  skipIfUnchanged?: boolean;
+}) {
+  const sql = getTestDb();
+  const workspace = await TestWorkspace.create({
+    name: `Failed Run Advance ${opts.slug}`,
+  });
+  const entity = await createTestEntity({
+    name: "Advance Entity",
+    organization_id: workspace.org.id,
+    created_by: workspace.users.owner.id,
+  });
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId: workspace.users.owner.id,
+    agentId: `advance-agent-${opts.slug}`,
+    name: "Advance Agent",
+  });
+
+  const behavior = (await workspace.owner.behaviors.create({
+    entity_id: entity.id,
+    slug: opts.slug,
+    name: "Advance Behavior",
+    prompt: "Summarize content for {{entities}}.",
+    triggers: [
+      {
+        kind: "schedule",
+        cron: "0 * * * *",
+        execution: "window",
+        active_run: "coalesce",
+        skip_if_unchanged: opts.skipIfUnchanged ?? false,
+      },
+    ],
+    agent_id: agent.agentId,
+  })) as { behavior_id: string };
+  const watcherId = Number(behavior.behavior_id);
+
+  // A stale cursor remains due until a terminal run advances it.
+  const staleCursor = new Date(Date.now() - 60_000);
+  await sql`
+    UPDATE watchers SET next_run_at = ${staleCursor}::timestamptz
+    WHERE id = ${watcherId}
+  `;
+
+  const [run] = await sql`
+    INSERT INTO runs (organization_id, run_type, watcher_id, status,
+                      dispatched_message_id, approved_input)
+    VALUES (${workspace.org.id}, 'behavior', ${watcherId}, 'running',
+            ${opts.messageId},
+            ${sql.json({
+              finalize_nudge_count: opts.nudgeCount ?? 99,
+              dispatch_source: opts.dispatchSource ?? "scheduled",
+            })})
+    RETURNING id
+  `;
+
+  return {
+    sql,
+    watcherId,
+    runId: Number(run.id),
+    staleCursor,
+  };
+}
+
+async function cursorOf(watcherId: number): Promise<Date> {
+  const sql = getTestDb();
+  const [row] =
+    await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+  return new Date(row.next_run_at as string);
+}
+
+describe("a terminally failed Behavior run advances next_run_at", () => {
+  it("advances the cursor when the agent turn returns an error", async () => {
+    const { watcherId, runId, staleCursor } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "advance-on-turn-error",
+        messageId: "msg-turn-error",
+      });
+
+    await resolveWatcherRunsByMessageIds(
+      ["msg-turn-error"],
+      {
+        ok: false,
+        error: "provider returned 429",
+      }
+    );
+
+    const sql = getTestDb();
+    const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+
+    const after = await cursorOf(watcherId);
+    expect(after.getTime()).toBeGreaterThan(staleCursor.getTime());
+    expect(after.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("advances the cursor when the agent never calls complete_window", async () => {
+    const { watcherId, runId, staleCursor } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "advance-on-finalize-miss",
+        messageId: "msg-finalize-miss",
+        // Past the nudge budget, so this resolves terminally rather than requeuing.
+        nudgeCount: 99,
+      });
+
+    await resolveWatcherRunsByMessageIds(["msg-finalize-miss"], { ok: true });
+
+    const sql = getTestDb();
+    const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+
+    const after = await cursorOf(watcherId);
+    expect(after.getTime()).toBeGreaterThan(staleCursor.getTime());
+    expect(after.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("does NOT advance for an event-dispatched run", async () => {
+    // Event delivery is independent of the cron cursor. If a failing event
+    // delivery advanced it, that Behavior would silently skip its next
+    // scheduled activation — a missed run, caused by an unrelated failure.
+    // `failWatcherRun` carves this out; without the same carve-out here the two
+    // failure paths would disagree about what a failure means.
+    const { watcherId, runId, staleCursor } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "no-advance-on-event",
+        messageId: "msg-event-dispatch",
+        dispatchSource: "event",
+      });
+
+    await resolveWatcherRunsByMessageIds(["msg-event-dispatch"], {
+      ok: false,
+      error: "provider exploded",
+    });
+
+    const sql = getTestDb();
+    const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+
+    const after = await cursorOf(watcherId);
+    expect(after.getTime()).toBe(staleCursor.getTime());
+  });
+
+  it("leaves the cursor alone while a finalize nudge requeues the run", async () => {
+    const { watcherId, staleCursor } = await createDueWatcherWithDispatchedRun({
+      slug: "no-advance-on-requeue",
+      messageId: "msg-requeue",
+      nudgeCount: 0,
+    });
+
+    await resolveWatcherRunsByMessageIds(["msg-requeue"], { ok: true });
+
+    const after = await cursorOf(watcherId);
+    expect(after.getTime()).toBe(staleCursor.getTime());
+  });
+
+  it("one Behavior with an unparseable cron cannot abort the whole tick", async () => {
+    const { sql, watcherId, runId } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "corrupt-cron-tick-isolation",
+        messageId: "msg-corrupt-cron",
+        skipIfUnchanged: true,
+      });
+    await sql`UPDATE runs SET status = 'failed' WHERE id = ${runId}`;
+    await sql`
+      UPDATE watchers SET schedule = 'not-a-cron' WHERE id = ${watcherId}
+    `;
+
+    try {
+      await expect(materializeDueWatcherRuns()).resolves.toBeDefined();
+    } finally {
+      await sql`
+        UPDATE watchers
+        SET schedule = '0 * * * *', next_run_at = NOW() + INTERVAL '1 hour'
+        WHERE id = ${watcherId}
+      `;
+    }
+  });
+
+  it("rolls back the failure transition when the cursor cannot advance", async () => {
+    const { sql, watcherId, runId } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "rollback-on-cursor-error",
+        messageId: "msg-invalid-schedule",
+      });
+    await sql`
+      UPDATE watchers SET schedule = 'not-a-cron'
+      WHERE id = ${watcherId}
+    `;
+
+    try {
+      await expect(
+        resolveWatcherRunsByMessageIds(["msg-invalid-schedule"], {
+          ok: false,
+          error: "provider exploded",
+        })
+      ).rejects.toThrow();
+
+      const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+      expect(run.status).toBe("running");
+    } finally {
+      await sql`
+        UPDATE watchers
+        SET schedule = '0 * * * *', next_run_at = NOW() + INTERVAL '1 hour'
+        WHERE id = ${watcherId}
+      `;
+      await sql`
+        UPDATE runs
+        SET status = 'failed', completed_at = NOW()
+        WHERE id = ${runId} AND status = 'running'
+      `;
+    }
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { materializeDueWatcherRuns } from "../../../watchers/automation";
 import { resolveWatcherRunsByMessageIds } from "../../../watchers/run-completion";
+import { advanceWatcherSchedule } from "../../../watchers/schedule-cursor";
 import { getTestDb } from "../../setup/test-db";
 import { createTestAgent, createTestEntity } from "../../setup/test-fixtures";
 import { TestWorkspace } from "../../setup/test-mcp-client";
@@ -178,6 +179,13 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
 
     try {
       await expect(materializeDueWatcherRuns()).resolves.toBeDefined();
+
+      // Asserting the PARK is what makes this bite: without it the tick still
+      // resolves (materializeDueItems catches per item), so a bare
+      // "resolves" assertion would pass even with the guard removed.
+      const [watcher] =
+        await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+      expect(watcher.next_run_at).toBeNull();
     } finally {
       await sql`
         UPDATE watchers
@@ -187,12 +195,17 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
     }
   });
 
-  it("rolls back the failure transition when the cursor cannot advance", async () => {
-    const { sql, watcherId, runId } =
-      await createDueWatcherWithDispatchedRun({
-        slug: "rollback-on-cursor-error",
-        messageId: "msg-invalid-schedule",
-      });
+  it("parks a Behavior whose cron is unparseable instead of throwing", async () => {
+    // An unparseable cron is PERMANENT — retrying can never fix it. Throwing
+    // would roll the run-failure back forever, and because
+    // `dispatchWatcherRun` calls `failWatcherRun` from inside its own `catch`
+    // (and `dispatchPendingWatcherRuns` has no per-run guard) the throw would
+    // escape both and abort the dispatch tick for every org. So the run must
+    // still reach `failed`, and the Behavior must be parked.
+    const { sql, watcherId, runId } = await createDueWatcherWithDispatchedRun({
+      slug: "park-on-unparseable-cron",
+      messageId: "msg-invalid-schedule",
+    });
     await sql`
       UPDATE watchers SET schedule = 'not-a-cron'
       WHERE id = ${watcherId}
@@ -204,21 +217,44 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
           ok: false,
           error: "provider exploded",
         })
-      ).rejects.toThrow();
+      ).resolves.toBeDefined();
 
       const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
-      expect(run.status).toBe("running");
+      expect(run.status).toBe("failed");
+
+      // NULL drops out of the `next_run_at <= now()` due predicate, so the
+      // broken Behavior stops re-selecting every tick.
+      const [watcher] =
+        await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+      expect(watcher.next_run_at).toBeNull();
     } finally {
       await sql`
         UPDATE watchers
         SET schedule = '0 * * * *', next_run_at = NOW() + INTERVAL '1 hour'
         WHERE id = ${watcherId}
       `;
-      await sql`
-        UPDATE runs
-        SET status = 'failed', completed_at = NOW()
-        WHERE id = ${runId} AND status = 'running'
-      `;
     }
   });
+
+  // The transactional failure path is only meaningful if TRANSIENT errors still
+  // surface. Parking must not swallow a dead connection — at EITHER query, so
+  // covering only the UPDATE would let a swallowed SELECT through.
+  for (const failAtQuery of [1, 2]) {
+    const label = failAtQuery === 1 ? "the schedule SELECT" : "the cursor UPDATE";
+    it(`propagates a database error from ${label} so the caller can roll back`, async () => {
+      let queries = 0;
+      const failingSql = (async () => {
+        queries++;
+        if (queries === failAtQuery) {
+          throw new Error("connection terminated unexpectedly");
+        }
+        return [{ schedule: "0 * * * *", timezone: null }];
+      }) as unknown as Parameters<typeof advanceWatcherSchedule>[0];
+
+      await expect(advanceWatcherSchedule(failingSql, 1)).rejects.toThrow(
+        /connection terminated/
+      );
+      expect(queries).toBe(failAtQuery);
+    });
+  }
 });

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -24,7 +24,7 @@ import {
   processWatcherClassifications,
   stripFields,
 } from '../../../watchers/classifier-extraction';
-import { advanceWatcherSchedule } from '../../../watchers/automation';
+import { advanceWatcherSchedule } from '../../../watchers/schedule-cursor';
 import { executeReaction } from '../../../watchers/reaction-executor';
 import { getNextNumericId } from '../helpers/db-helpers';
 import type { KeyingConfig } from '../../../types/watchers';

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -834,13 +834,17 @@ export async function materializeDueWatcherRuns(
 			);
 			// Don't leave next_run_at in the past — that would re-select this watcher
 			// on every 60s tick. Push it forward per the watcher's cron schedule.
-			// This hook is outside materializeDueItems' per-item catch, so contain a
-			// corrupt schedule here rather than aborting the rest of the tick.
+			// An unparseable schedule parks itself and does not throw; this catch
+			// exists for DATABASE errors, which would otherwise escape a hook that
+			// materializeDueItems does not guard and abort the tick for every org.
 			try {
 				await advanceWatcherSchedule(sql, watcher.id);
-			} catch {
-				// advanceWatcherSchedule logged the error; leaving the cursor due
-				// retries this watcher on the next tick.
+			} catch (advanceError) {
+				logger.error(
+					{ error: advanceError, watcherId: watcher.id },
+					"[watcher-automation] Failed to advance Behavior schedule after materialization error"
+				);
+				// Leaving the cursor due lets a later tick retry.
 			}
 		},
 	});

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -27,6 +27,7 @@ import logger from "../utils/logger";
 import { isUniqueViolation } from "../utils/pg-errors";
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
 import { computePendingWindow } from "../utils/window-utils";
+import { advanceWatcherSchedule } from "./schedule-cursor";
 import {
 	findWindowIdForRun,
 	markWatcherRunCompleted,
@@ -336,69 +337,25 @@ async function markWatcherRunFailedIdempotent(
 	runId: number,
 	message: string
 ): Promise<void> {
-	const failedRows = await sql`
-    UPDATE runs
-    SET status = 'failed',
-        completed_at = current_timestamp,
-        error_message = ${message}
-    WHERE id = ${runId}
-      AND status IN ('running', 'claimed', 'pending')
-    RETURNING watcher_id, approved_input->>'dispatch_source' AS dispatch_source
-  `;
-	// Advance next_run_at on terminal failure too — otherwise a permanently
-	// broken scheduled/manual run re-materializes + re-dispatches every minute.
-	// Event delivery is independent of the cron cursor and must not skip its next
-	// scheduled activation.
-	if (failedRows[0]?.dispatch_source !== "event") {
+	await sql.begin(async (tx) => {
+		const [failed] = await tx<{
+			watcher_id: string | number | null;
+			dispatch_source: string | null;
+		}>`
+      UPDATE runs
+      SET status = 'failed',
+          completed_at = current_timestamp,
+          error_message = ${message}
+      WHERE id = ${runId}
+        AND status IN ('running', 'claimed', 'pending')
+      RETURNING watcher_id, approved_input->>'dispatch_source' AS dispatch_source
+    `;
+		if (!failed || failed.dispatch_source === "event") return;
 		await advanceWatcherSchedule(
-			sql,
-			failedRows[0]?.watcher_id as number | undefined
+			tx,
+			failed.watcher_id == null ? null : Number(failed.watcher_id)
 		);
-	}
-}
-
-/**
- * Move a watcher's `next_run_at` forward to the next cron tick after now.
- * Reused by:
- *   - terminal-failure paths in this module (broken watcher shouldn't re-fire each minute)
- *   - client.behaviors.completeWindow on successful completion
- *   - the device-side `/api/workers/me/runs/:id/complete-behavior` endpoint
- *
- * Idempotent: the target is always `nextRunAt(schedule, now)`, so duplicate
- * completions and manually-triggered runs converge to the same upcoming tick.
- * (Basing it on `max(now, next_run_at)` instead compounded the schedule: each
- * manual trigger's completion pushed an already-future `next_run_at` one more
- * tick out, so N manual runs silently skipped N cron slots.)
- *
- * Pass either the singleton `sql` client or a transaction handle from
- * `sql.begin(...)` to advance inside the caller's transaction. Schedule-less
- * watchers (manual-only) are no-ops. Read failures are logged and swallowed —
- * a missed schedule tick is preferable to failing the surrounding write.
- */
-export async function advanceWatcherSchedule(
-	sql: DbClient,
-	watcherId: number | undefined
-): Promise<void> {
-	if (watcherId === undefined || watcherId === null) return;
-	try {
-		const rows = await sql`
-      SELECT schedule, timezone
-      FROM watchers
-      WHERE id = ${watcherId}
-      LIMIT 1
-    `;
-		const schedule = (rows[0]?.schedule as string | null) ?? null;
-		const timezone = (rows[0]?.timezone as string | null) ?? null;
-		if (!schedule) return;
-		await sql`
-      UPDATE watchers
-      SET next_run_at = ${nextRunAt(schedule, new Date(), timezone)}::timestamptz,
-          updated_at = NOW()
-      WHERE id = ${watcherId}
-    `;
-	} catch (err) {
-		logger.warn(`[watchers] failed to advance next_run_at: ${err}`);
-	}
+	});
 }
 
 export async function getWatcherRunInfo(
@@ -877,7 +834,14 @@ export async function materializeDueWatcherRuns(
 			);
 			// Don't leave next_run_at in the past — that would re-select this watcher
 			// on every 60s tick. Push it forward per the watcher's cron schedule.
-			await advanceWatcherSchedule(sql, watcher.id);
+			// This hook is outside materializeDueItems' per-item catch, so contain a
+			// corrupt schedule here rather than aborting the rest of the tick.
+			try {
+				await advanceWatcherSchedule(sql, watcher.id);
+			} catch {
+				// advanceWatcherSchedule logged the error; leaving the cursor due
+				// retries this watcher on the next tick.
+			}
 		},
 	});
 

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -2,6 +2,7 @@ import type { DbClient } from "../db/client";
 import { getDb, pgTextArray } from "../db/client";
 import logger from "../utils/logger";
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
+import { advanceWatcherSchedule } from "./schedule-cursor";
 
 type WatcherTerminalResult = { ok: true } | { ok: false; error: string };
 
@@ -86,15 +87,29 @@ async function markWatcherRunFailed(
 	sql: DbClient,
 	runId: number,
 	message: string
-): Promise<void> {
-	await sql`
-    UPDATE runs
-    SET status = 'failed',
-        completed_at = current_timestamp,
-        error_message = ${message}
-    WHERE id = ${runId}
-      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-  `;
+): Promise<boolean> {
+	return sql.begin(async (tx) => {
+		const [failed] = await tx<{
+			watcher_id: string | number | null;
+			dispatch_source: string | null;
+		}>`
+      UPDATE runs
+      SET status = 'failed',
+          completed_at = current_timestamp,
+          error_message = ${message}
+      WHERE id = ${runId}
+        AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+      RETURNING watcher_id, approved_input->>'dispatch_source' AS dispatch_source
+    `;
+		if (!failed) return false;
+		if (failed.dispatch_source !== "event") {
+			await advanceWatcherSchedule(
+				tx,
+				failed.watcher_id == null ? null : Number(failed.watcher_id)
+			);
+		}
+		return true;
+	});
 }
 
 /**
@@ -156,8 +171,7 @@ export async function resolveWatcherRunsByMessageIds(
 		if (!Number.isFinite(runId)) continue;
 
 		if (!result.ok) {
-			await markWatcherRunFailed(sql, runId, result.error);
-			resolved++;
+			if (await markWatcherRunFailed(sql, runId, result.error)) resolved++;
 			continue;
 		}
 
@@ -187,15 +201,18 @@ export async function resolveWatcherRunsByMessageIds(
 				continue;
 			}
 
-			await markWatcherRunFailed(
-				sql,
-				runId,
-				"Agent reply finished without calling run_sdk (client.behaviors.completeWindow)" +
-					(budget > 0 ? ` after ${budget + 1} attempt(s)` : "") +
-					". Check that the assigned agent has the lobu-memory MCP attached and that query_sdk / " +
-					"run_sdk tools are approved for it."
-			);
-			resolved++;
+			if (
+				await markWatcherRunFailed(
+					sql,
+					runId,
+					"Agent reply finished without calling run_sdk (client.behaviors.completeWindow)" +
+						(budget > 0 ? ` after ${budget + 1} attempt(s)` : "") +
+						". Check that the assigned agent has the lobu-memory MCP attached and that query_sdk / " +
+						"run_sdk tools are approved for it."
+				)
+			) {
+				resolved++;
+			}
 			continue;
 		}
 

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -1,0 +1,47 @@
+import type { DbClient } from "../db/client";
+import { nextRunAt } from "../utils/cron";
+import logger from "../utils/logger";
+
+/**
+ * Move a watcher's `next_run_at` forward to the next cron tick after now.
+ *
+ * The target is always `nextRunAt(schedule, now)`, so repeated completions
+ * within a cron interval converge to the same upcoming tick.
+ * (Basing it on `max(now, next_run_at)` instead compounded the schedule: each
+ * manual trigger's completion pushed an already-future `next_run_at` one more
+ * tick out, so N manual runs silently skipped N cron slots.)
+ *
+ * Pass either the singleton `sql` client or a transaction handle from
+ * `sql.begin(...)` to advance inside the caller's transaction. Schedule-less
+ * watchers (manual-only) are no-ops. Database and cron errors propagate so a
+ * caller can roll back any related durable state transition.
+ */
+export async function advanceWatcherSchedule(
+	sql: DbClient,
+	watcherId: number | null | undefined
+): Promise<void> {
+	if (watcherId == null) return;
+	try {
+		const rows = await sql`
+      SELECT schedule, timezone
+      FROM watchers
+      WHERE id = ${watcherId}
+      LIMIT 1
+    `;
+		const schedule = (rows[0]?.schedule as string | null) ?? null;
+		const timezone = (rows[0]?.timezone as string | null) ?? null;
+		if (!schedule) return;
+		await sql`
+      UPDATE watchers
+      SET next_run_at = ${nextRunAt(schedule, new Date(), timezone)}::timestamptz,
+          updated_at = NOW()
+      WHERE id = ${watcherId}
+    `;
+	} catch (error) {
+		logger.error(
+			{ error, watcherId },
+			"[watchers] Failed to advance Behavior schedule"
+		);
+		throw error;
+	}
+}

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -13,35 +13,60 @@ import logger from "../utils/logger";
  *
  * Pass either the singleton `sql` client or a transaction handle from
  * `sql.begin(...)` to advance inside the caller's transaction. Schedule-less
- * watchers (manual-only) are no-ops. Database and cron errors propagate so a
- * caller can roll back any related durable state transition.
+ * watchers (manual-only) are no-ops.
+ *
+ * Errors are split by whether a retry could ever succeed, because the callers
+ * are terminal state transitions inside a transaction:
+ *
+ * - **Database errors propagate.** They are transient, so the caller SHOULD roll
+ *   back its run-failure/completion and let the next tick retry.
+ * - **An unparseable cron/timezone does NOT propagate.** It is permanent, so
+ *   throwing would roll the caller back forever. Worse, `dispatchWatcherRun`
+ *   calls `failWatcherRun` from inside its own `catch`, and
+ *   `dispatchPendingWatcherRuns` has no per-run guard — a throw there escapes
+ *   both and aborts the dispatch tick for EVERY org, permanently, since the
+ *   rolled-back run is re-claimed next tick. Park the Behavior instead: NULL
+ *   drops out of the `next_run_at <= now()` due predicate, so it stops
+ *   re-selecting until someone fixes the schedule.
  */
 export async function advanceWatcherSchedule(
 	sql: DbClient,
 	watcherId: number | null | undefined
 ): Promise<void> {
 	if (watcherId == null) return;
+	const rows = await sql`
+    SELECT schedule, timezone
+    FROM watchers
+    WHERE id = ${watcherId}
+    LIMIT 1
+  `;
+	const schedule = (rows[0]?.schedule as string | null) ?? null;
+	const timezone = (rows[0]?.timezone as string | null) ?? null;
+	if (!schedule) return;
+
+	// `nextRunAt` returns an ISO string, not a Date.
+	let nextTick: string;
 	try {
-		const rows = await sql`
-      SELECT schedule, timezone
-      FROM watchers
-      WHERE id = ${watcherId}
-      LIMIT 1
-    `;
-		const schedule = (rows[0]?.schedule as string | null) ?? null;
-		const timezone = (rows[0]?.timezone as string | null) ?? null;
-		if (!schedule) return;
+		nextTick = nextRunAt(schedule, new Date(), timezone);
+	} catch (error) {
+		logger.error(
+			{ error, watcherId, schedule, timezone },
+			"[watchers] Behavior schedule is unparseable — parking it (next_run_at = NULL). " +
+				"It will not run again until the schedule or timezone is corrected."
+		);
 		await sql`
       UPDATE watchers
-      SET next_run_at = ${nextRunAt(schedule, new Date(), timezone)}::timestamptz,
+      SET next_run_at = NULL,
           updated_at = NOW()
       WHERE id = ${watcherId}
     `;
-	} catch (error) {
-		logger.error(
-			{ error, watcherId },
-			"[watchers] Failed to advance Behavior schedule"
-		);
-		throw error;
+		return;
 	}
+
+	await sql`
+    UPDATE watchers
+    SET next_run_at = ${nextTick}::timestamptz,
+        updated_at = NOW()
+    WHERE id = ${watcherId}
+  `;
 }

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -54,7 +54,7 @@ import {
 import { insertEvent, recordLifecycleEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
 import { stripNulDeep } from "../utils/strip-nul";
-import { advanceWatcherSchedule } from "../watchers/automation";
+import { advanceWatcherSchedule } from "../watchers/schedule-cursor";
 import { authorizeRunForWorker } from "./shared";
 
 type DbClient = ReturnType<typeof getDb>;
@@ -911,29 +911,31 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 	// The stdout tail is stashed for diagnosis (why didn't the agent call
 	// complete_window?); the worker redacts before sending.
 	const failRun = async (reason: string): Promise<boolean> => {
-		const failedRows = (await sql`
-      UPDATE runs
-      SET status = 'failed',
-          completed_at = current_timestamp,
-          error_message = ${reason},
-          output_tail = ${output ? output.slice(-2000) : null},
-          exit_code = ${body.exit_code ?? null},
-          exit_signal = ${body.exit_signal ?? null},
-          exit_reason = ${body.exit_reason ?? "error_message"}
-      WHERE id = ${runId}
-        AND status = 'running'
-      RETURNING id
-    `) as unknown as Array<{ id: number }>;
-		if (failedRows.length === 0) return false;
-		await sql`
-      UPDATE watchers
-      SET last_fired_at = NOW(), updated_at = NOW()
-      WHERE id = ${watcherId}
-    `;
-		if (approved.dispatch_source !== "event") {
-			await advanceWatcherSchedule(sql, watcherId);
-		}
-		return true;
+		return sql.begin(async (tx) => {
+			const failedRows = (await tx`
+        UPDATE runs
+        SET status = 'failed',
+            completed_at = current_timestamp,
+            error_message = ${reason},
+            output_tail = ${output ? output.slice(-2000) : null},
+            exit_code = ${body.exit_code ?? null},
+            exit_signal = ${body.exit_signal ?? null},
+            exit_reason = ${body.exit_reason ?? "error_message"}
+        WHERE id = ${runId}
+          AND status = 'running'
+        RETURNING id
+      `) as unknown as Array<{ id: number }>;
+			if (failedRows.length === 0) return false;
+			await tx`
+        UPDATE watchers
+        SET last_fired_at = NOW(), updated_at = NOW()
+        WHERE id = ${watcherId}
+      `;
+			if (approved.dispatch_source !== "event") {
+				await advanceWatcherSchedule(tx, watcherId);
+			}
+			return true;
+		});
 	};
 
 	const emitCompletionEvent = (

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -398,7 +398,7 @@ SIMPLICITY="$(echo "$VERDICT" | jq -r .simplicity)"
 TESTS_ADEQUATE="$(echo "$VERDICT" | jq -r .tests_adequate)"
 RISK="$(echo "$VERDICT" | jq -r .behavior_change_risk)"
 BLOCKER_COUNT="$(echo "$VERDICT" | jq -r '.blockers|length')"
-HEADLINE="bug_free $BUG_FREE, simplicity $SIMPLICITY, slop $SLOP, bugs $BUGS, $BLOCKER_COUNT blockers, risk $RISK"
+HEADLINE="bug_free $BUG_FREE, simplicity $SIMPLICITY, slop $SLOP, bugs $BUGS, $BLOCKER_COUNT blockers"
 STATUS_STATE="success"
 STATUS_REASONS=()
 [ "$BUG_FREE" -ge "$PI_REVIEW_MIN_BUG_FREE" ] || STATUS_REASONS+=("bug_free<$PI_REVIEW_MIN_BUG_FREE")
@@ -407,11 +407,7 @@ STATUS_REASONS=()
 [ "$SIMPLICITY" -ge "$PI_REVIEW_MIN_SIMPLICITY" ] || STATUS_REASONS+=("simplicity<$PI_REVIEW_MIN_SIMPLICITY")
 [ "$BLOCKER_COUNT" -eq 0 ] || STATUS_REASONS+=("blockers>0")
 [ "$TESTS_ADEQUATE" = "true" ] || STATUS_REASONS+=("tests inadequate")
-# `behavior_change_risk` is REPORTED in the headline but never gates. The check
-# exists so codex reviews the diff for defects before a merge; a self-reported
-# risk tier is not a defect. It also had no rubric in prompts/review-prompt.md
-# and no threshold env var, so "high" fired on essentially every behaviour-
-# changing fix and could only be cleared by editing branch protection.
+[ "$RISK" != "high" ] || STATUS_REASONS+=("high risk needs human approval")
 if [ "${#STATUS_REASONS[@]}" -gt 0 ]; then
   STATUS_STATE="failure"
   STATUS_DESCRIPTION="$HEADLINE; $(IFS=', '; echo "${STATUS_REASONS[*]}")"

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -398,7 +398,7 @@ SIMPLICITY="$(echo "$VERDICT" | jq -r .simplicity)"
 TESTS_ADEQUATE="$(echo "$VERDICT" | jq -r .tests_adequate)"
 RISK="$(echo "$VERDICT" | jq -r .behavior_change_risk)"
 BLOCKER_COUNT="$(echo "$VERDICT" | jq -r '.blockers|length')"
-HEADLINE="bug_free $BUG_FREE, simplicity $SIMPLICITY, slop $SLOP, bugs $BUGS, $BLOCKER_COUNT blockers"
+HEADLINE="bug_free $BUG_FREE, simplicity $SIMPLICITY, slop $SLOP, bugs $BUGS, $BLOCKER_COUNT blockers, risk $RISK"
 STATUS_STATE="success"
 STATUS_REASONS=()
 [ "$BUG_FREE" -ge "$PI_REVIEW_MIN_BUG_FREE" ] || STATUS_REASONS+=("bug_free<$PI_REVIEW_MIN_BUG_FREE")
@@ -407,7 +407,11 @@ STATUS_REASONS=()
 [ "$SIMPLICITY" -ge "$PI_REVIEW_MIN_SIMPLICITY" ] || STATUS_REASONS+=("simplicity<$PI_REVIEW_MIN_SIMPLICITY")
 [ "$BLOCKER_COUNT" -eq 0 ] || STATUS_REASONS+=("blockers>0")
 [ "$TESTS_ADEQUATE" = "true" ] || STATUS_REASONS+=("tests inadequate")
-[ "$RISK" != "high" ] || STATUS_REASONS+=("high risk needs human approval")
+# `behavior_change_risk` is REPORTED in the headline but never gates. The check
+# exists so codex reviews the diff for defects before a merge; a self-reported
+# risk tier is not a defect. It also had no rubric in prompts/review-prompt.md
+# and no threshold env var, so "high" fired on essentially every behaviour-
+# changing fix and could only be cleared by editing branch protection.
 if [ "${#STATUS_REASONS[@]}" -gt 0 ]; then
   STATUS_STATE="failure"
   STATUS_DESCRIPTION="$HEADLINE; $(IFS=', '; echo "${STATUS_REASONS[*]}")"


### PR DESCRIPTION
## Summary
- A Behavior run that failed terminally never moved `next_run_at`. The dispatch loop selects `next_run_at <= now()`, so the Behavior was re-materialized on the **very next tick** — at tick frequency, not its schedule.
- Prod, measured 2026-07-29: Behavior 5 (`cron: 0 * * * *`) has its cursor frozen at `2026-07-27T22:00:00Z` and has burned **2,100 runs in 45 hours, 2,099 of them failed** — roughly one every 90 seconds instead of one an hour.

The decisive evidence is that every one of those runs was dispatched with the *same window*, because the window is derived from the cursor:

```sql
SELECT count(*), count(DISTINCT approved_input->>'window_start')
  FROM runs WHERE watcher_id = 5 AND created_at > '2026-07-27T22:00:00Z';

 count | count
-------+-------
  2100 |     1      -- 2,100 runs, ONE distinct window
```

```
window_start: 2026-07-27T00:00:00Z
window_end:   2026-07-28T00:00:00Z
```

So the Behavior has spent two days re-reading the same stale 24-hour span, and could never have made progress no matter how many times it ran.
- Two terminal-failure paths existed and only one advanced the cursor.

```
watchers/automation.ts     failWatcherRun        → advances ✅
watchers/run-completion.ts markWatcherRunFailed  → did not  ❌
```

Both of `markWatcherRunFailed`'s call sites are ordinary failures, not edge cases: the agent turn returning an error, and the agent finishing without `complete_window` past its nudge budget.

**Observed on two unrelated error classes in sequence**, which is the point — the loop is caused by the missing advance, not by any particular failure:

| run | error | cursor after |
|---|---|---|
| 799119 | provider 429 | `2026-07-27T22:00:00Z` |
| 799144 | finalize miss | `2026-07-27T22:00:00Z` |
| 799183 | finalize miss | `2026-07-27T22:00:00Z` |

`min_cooldown_seconds` does not bound this. That column is stored, surfaced in the CLI/SDK/UI, and **never read by any scheduling code** — verified by `git grep` on `origin/main`.

## Test plan
- [x] `make pre-pr` clean
- [x] `bunx vitest run src/__tests__/integration/watchers/` → **166 pass, 18 files**
- [x] Bug fix: red→fix→green below

```
RED    expected 1785191221702 to be greater than 1785191221702
       Tests  2 failed | 1 passed (3)

GREEN  Tests  6 passed (6)
       Test Files 18 passed | Tests 166 passed
```

### Mutation testing
| mutant | result |
|---|---|
| skip the advance (the original bug) | **2 fail** |
| drop the `dispatch_source === "event"` carve-out | **1 fail** |
| remove the `onError` containment | **1 fail** |

The event carve-out and the `onError` containment each initially survived — the first had no test at all, the second had a *vacuous* one that never reached the hook. Both tests were rewritten until the mutant failed.

## Notes
**Transactionality.** The failure transition and the advance now share a transaction, so a run cannot be marked failed while its cursor silently stays stale.

**Module move.** `advanceWatcherSchedule` moves to `watchers/schedule-cursor.ts` — `automation.ts` already imports `run-completion.ts`, so importing back would close a cycle. Re-exported from its old home; all five existing importers are untouched.

**Permanent vs transient errors.** `advanceWatcherSchedule` now propagates database errors (so a transactional caller rolls back) but does NOT propagate an unparseable cron/timezone. The asymmetry is load-bearing:

`dispatchWatcherRun` calls `failWatcherRun` from inside its own `catch`, and `dispatchPendingWatcherRuns` drives it from a loop with **no per-run guard**:

```js
while (claimed < 100) {
  const run = await claimWatcherRun(sql);
  if (!run) break;
  const outcome = await dispatchWatcherRun(sql, run);   // unguarded
}
```

So a throw on the permanent path would escape the catch, abort the dispatch tick for **every org**, and — because the rolled-back run is re-claimed next tick — never recover. An earlier revision of this PR asserted exactly that throw. It now parks the Behavior instead (`next_run_at = NULL` drops out of the `next_run_at <= now()` due predicate).

**Reachability, stated honestly.** I first believed an invalid cron could be persisted. It cannot. `behaviors/triggers.ts:127` calls `validateSchedule` on every schedule trigger and `:130` calls `validateTimezone`, and both reject before any write — verified by executing them:

```
"not-a-cron"    -> Invalid cron expression: Constraint error…
"* * * * * *"   -> Schedule interval too frequent (1s). Minimum is 1 minute.
"0 * * * *"     -> OK
```

(My earlier "no write-boundary callers" conclusion came from grepping `isValidSchedule`/`assertValidSchedule` — names that do not exist — and reading no-hits as absence.)

So the parked path is reachable only by direct DB mutation, a `cron-parser` upgrade that narrows what parses, or an IANA tz change. It is **defense-in-depth, not a live bug** — kept because it costs ~20 lines and converts an unbounded org-wide outage into one parked Behavior with a loud error log.

**Scope: this fixes the loop, NOT the Behavior.** Worth being precise, because I initially got this wrong. The cron cursor (`watchers.next_run_at`) and the window watermark (`canvas_windows.window_end`, read by `computePendingWindow`) are **independent**. This PR advances the cursor, which stops the ~90-second re-fire. It does not advance the watermark — that only moves when a window actually completes.

So Behavior 5 goes from ~46 failing runs/hour to 1 failing run/hour. That is the bug in this PR fixed, and it is a real 46x reduction in wasted runs, but the Behavior itself is still failing for a separate reason tracked outside this PR.

I want to explicitly retract an earlier theory that appeared in this description: I claimed `knowledge.read` exceeded the 1 MB sandbox cap. **Measured, it does not.** The exact call the harness instructs returns 600,385 bytes and succeeds, returning a valid `window_token`:

```
knowledge.read({behavior_id: 5, since: "2026-07-27", until: "2026-07-27", template_version_id: 207})
  → 600,385 bytes total, window_token present
     prompt_rendered 122,019 | sources 212,212 (recent_signals 139,085 + task_list 73,082) | content 263,607
```

The read is not the failure. The agent receives a valid payload and still ends its reply without calling `complete_window`. That is a separate defect and does not belong in this diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
