### PR TITLE
fix(server): apply a re-checked merge on one approval when evidence strengthened

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -12,6 +12,7 @@ import {
 	assessEntityResolution,
 	RESOLUTION_FINGERPRINT_VERSION,
 } from "../../../entity-resolution/policy";
+import { lockResolutionCandidate } from "../../../entity-resolution/rejection";
 import { assertResolutionFingerprintCurrent } from "../../../entity-resolution/staleness";
 import type { Env } from "../../../index";
 import { manageEntity } from "../../../tools/admin/manage_entity";
@@ -1639,6 +1640,80 @@ describe("manage_entity merge action", () => {
 			});
 		} finally {
 			await writer.end();
+		}
+	});
+
+	it("serializes decisions for one entity group across differing fingerprints", async () => {
+		// The lock used to be keyed on the resolution fingerprint. Refresh rotates
+		// that fingerprint, so two reviewers holding different reviewed digests for
+		// the SAME pair took two different locks and could race past each other's
+		// rejection memory. Keying on the entity group is what makes them contend.
+		const org = await createTestOrganization({ name: "Candidate Lock Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const other = await createTestEntity({
+			name: "Unrelated",
+			entity_type: "person",
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const sql = getTestDb();
+		const contender = postgres(process.env.DATABASE_URL as string, {
+			max: 1,
+			onnotice: () => {},
+			...PROD_PG_VALUE_OPTIONS,
+		});
+		try {
+			await sql.begin(async (tx) => {
+				await lockResolutionCandidate(tx, {
+					organizationId: org.id,
+					winnerId: winner.id,
+					loserIds: [loser.id],
+				});
+
+				// Same pair, and the caller need not even know the fingerprint: it is
+				// no longer part of the key, so this must block.
+				await expect(
+					contender.begin(async (contenderTx) => {
+						await contenderTx`SET LOCAL lock_timeout = '150ms'`;
+						await lockResolutionCandidate(contenderTx, {
+							organizationId: org.id,
+							winnerId: winner.id,
+							loserIds: [loser.id],
+						});
+					}),
+				).rejects.toMatchObject({ code: "55P03" });
+
+				// Order must not matter either — the key is the sorted group, so the
+				// same pair with winner and loser swapped is the same candidate.
+				await expect(
+					contender.begin(async (contenderTx) => {
+						await contenderTx`SET LOCAL lock_timeout = '150ms'`;
+						await lockResolutionCandidate(contenderTx, {
+							organizationId: org.id,
+							winnerId: loser.id,
+							loserIds: [winner.id],
+						});
+					}),
+				).rejects.toMatchObject({ code: "55P03" });
+
+				// ...but an unrelated candidate must NOT be serialized, or every merge
+				// in the workspace would queue behind one review.
+				await expect(
+					contender.begin(async (contenderTx) => {
+						await contenderTx`SET LOCAL lock_timeout = '150ms'`;
+						await lockResolutionCandidate(contenderTx, {
+							organizationId: org.id,
+							winnerId: winner.id,
+							loserIds: [other.id],
+						});
+						return "acquired";
+					}),
+				).resolves.toBe("acquired");
+			});
+		} finally {
+			await contender.end();
 		}
 	});
 

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -288,17 +288,23 @@ describe("manage_entity merge action", () => {
 			WHERE id = ${queued.approval_run_id}
 		`;
 
+		// These two entities share nothing, so re-assessment proves no more than
+		// the reviewer saw. An unverifiable fingerprint with no gain in evidence is
+		// re-presented, not applied.
 		const refreshed = await manageOperations(
 			{ action: "approve", run_id: queued.approval_run_id },
 			env,
 			ctx(org.id, user.id, "owner"),
 		);
 		expect("error" in refreshed && refreshed.error).toMatch(
-			/without a known current matching format/i,
+			/re-checked.*approve again to apply/i,
+		);
+		// The reviewer-facing text must not leak fingerprint-format vocabulary:
+		// this string is what the approval card renders.
+		expect("error" in refreshed && refreshed.error).not.toMatch(
+			/fingerprint|resolution format|matching format/i,
 		);
 
-		// The merge must NOT have applied — the reviewer approved evidence the
-		// server could not verify, so their click does not carry over.
 		const [untouched] =
 			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
 		expect(untouched.merged_into).toBeNull();
@@ -307,12 +313,16 @@ describe("manage_entity merge action", () => {
 		// ...but the proposal is now approvable: pending, restamped, and carrying
 		// a fingerprint the server can actually check.
 		const [reset] = await sql`
-			SELECT approval_status, status, action_input FROM runs WHERE id = ${queued.approval_run_id}
+			SELECT approval_status, status, action_input, error_message FROM runs WHERE id = ${queued.approval_run_id}
 		`;
 		expect(reset).toMatchObject({
 			approval_status: "pending",
 			status: "pending",
 		});
+		// error_message is the column the card reads, so it carries the reviewer
+		// message rather than the internal exception text.
+		expect(reset.error_message).toMatch(/approve again to apply/i);
+		expect(reset.error_message).not.toMatch(/resolution format/i);
 		const resetInput = reset.action_input as Record<string, unknown>;
 		expect(resetInput.resolution_fingerprint_version).toBe(
 			RESOLUTION_FINGERPRINT_VERSION,
@@ -347,6 +357,168 @@ describe("manage_entity merge action", () => {
 			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
 		expect(Number(merged.merged_into)).toBe(winner.id);
 		expect(merged.deleted_at).not.toBeNull();
+	});
+
+	it("applies a legacy merge in one approval when re-assessment proves more", async () => {
+		// A legacy proposal can have an unstamped fingerprint, evidence [] at
+		// review time, and a phone both sides actually share.
+		// Re-assessment gains that phone and drops nothing, so the reviewer's
+		// approval already covers this merge and must not be asked for twice.
+		const org = await createTestOrganization({ name: "Strengthened Merge Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+			INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+			VALUES
+				(${org.id}, ${winner.id}, 'phone', '+44 7700 900 123'),
+				(${org.id}, ${loser.id}, 'phone', '447700900123')
+		`;
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+			} as ToolContext,
+		)) as unknown as { approval_queued: boolean; approval_run_id: number };
+		expect(queued.approval_queued).toBe(true);
+
+		// Strip the evidence and version stamp to reproduce the legacy shape: the
+		// reviewer saw no recorded proof and the digest cannot be compared.
+		const [minted] = await sql`
+			SELECT action_input FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		const stale = {
+			...(minted.action_input as Record<string, unknown>),
+			resolution_fingerprint: "0".repeat(64),
+			evidence: [],
+		};
+		delete stale.resolution_fingerprint_version;
+		await sql`
+			UPDATE runs SET action_input = ${sql.json(stale)}
+			WHERE id = ${queued.approval_run_id}
+		`;
+
+		const applied = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("approved" in applied && applied.approved).toBe(true);
+
+		const [merged] =
+			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
+		expect(Number(merged.merged_into)).toBe(winner.id);
+		expect(merged.deleted_at).not.toBeNull();
+	});
+
+	it("re-presents when new matching proof arrives with unmatched identity changes", async () => {
+		const org = await createTestOrganization({ name: "Mixed Merge Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+			} as ToolContext,
+		)) as unknown as { approval_run_id: number };
+
+		// The shared phone strengthens the proof, but the two different emails are
+		// also new. Evidence lists matches only, so an evidence-only comparison
+		// would hide the unmatched changes and apply a materially different merge.
+		await sql`
+			INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+			VALUES
+				(${org.id}, ${winner.id}, 'phone', '+44 7700 900 123'),
+				(${org.id}, ${loser.id}, 'phone', '447700900123'),
+				(${org.id}, ${winner.id}, 'email', 'winner@example.com'),
+				(${org.id}, ${loser.id}, 'email', 'loser@example.com')
+		`;
+
+		const refused = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("error" in refused && refused.error).toMatch(
+			/re-checked.*approve again to apply/i,
+		);
+
+		const [untouched] =
+			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
+		expect(untouched.merged_into).toBeNull();
+		expect(untouched.deleted_at).toBeNull();
+	});
+
+	it("re-presents a merge whose reviewed evidence no longer holds", async () => {
+		// The case a second look can actually catch: the reviewer approved on a
+		// shared phone, and that phone is gone by the time they clicked.
+		const org = await createTestOrganization({ name: "Weakened Merge Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+			INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier)
+			VALUES
+				(${org.id}, ${winner.id}, 'phone', '+44 7700 900 123'),
+				(${org.id}, ${loser.id}, 'phone', '447700900123')
+		`;
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+			} as ToolContext,
+		)) as unknown as { approval_run_id: number };
+		const [minted] = await sql`
+			SELECT action_input FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		expect(
+			(minted.action_input as { evidence: unknown[] }).evidence.length,
+		).toBeGreaterThan(0);
+
+		// The phone that justified the merge is corrected away after review.
+		await sql`
+			UPDATE entity_identities SET deleted_at = now()
+			WHERE organization_id = ${org.id} AND entity_id = ${loser.id}
+		`;
+
+		const refused = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("error" in refused && refused.error).toMatch(
+			/no longer supports what you reviewed/i,
+		);
+		// The message must name the specific proof that stopped holding.
+		expect("error" in refused && refused.error).toMatch(/447700900123/);
+
+		const [untouched] =
+			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
+		expect(untouched.merged_into).toBeNull();
+		expect(untouched.deleted_at).toBeNull();
+
+		const [card] = await sql`
+			SELECT title FROM current_event_records WHERE run_id = ${queued.approval_run_id}
+		`;
+		expect(card.title).toBe(
+			"entity_merge — evidence no longer supports the merge",
+		);
 	});
 
 	it("does not downgrade a merge fingerprint from a newer format", async () => {
@@ -1103,6 +1275,23 @@ describe("manage_entity merge action", () => {
 			watcherCtx(7102),
 		)) as unknown as { approval_run_id: number };
 		expect(second.approval_run_id).not.toBe(first.approval_run_id);
+
+		// Make the second run look legacy. Its stored fingerprint differs from the
+		// current candidate, so approval must check rejection memory against both
+		// the reviewed and re-assessed fingerprints.
+		const [secondRun] = await sql`
+			SELECT action_input FROM runs WHERE id = ${second.approval_run_id}
+		`;
+		const legacySecond = {
+			...(secondRun.action_input as Record<string, unknown>),
+			resolution_fingerprint: "0".repeat(64),
+			evidence: [],
+		};
+		delete legacySecond.resolution_fingerprint_version;
+		await sql`
+			UPDATE runs SET action_input = ${sql.json(legacySecond)}
+			WHERE id = ${second.approval_run_id}
+		`;
 
 		await manageOperations(
 			{ action: "reject", run_id: first.approval_run_id },

--- a/packages/server/src/entity-resolution/evidence-strength.test.ts
+++ b/packages/server/src/entity-resolution/evidence-strength.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+	droppedEvidence,
+	gainedEvidence,
+	hasEvidenceStrengthened,
+	hasMergeEvidenceStrengthened,
+} from "./evidence-strength";
+
+const phone = { kind: "phone", identifier: "905395102240" };
+const email = { kind: "email", identifier: "a@example.com" };
+
+describe("hasEvidenceStrengthened", () => {
+	it("strengthens when a merge reviewed with no evidence gains proof", () => {
+		// Legacy proposals can have no recorded evidence even though the current
+		// matcher proves a shared identity.
+		expect(hasEvidenceStrengthened([], [phone])).toBe(true);
+	});
+
+	it("strengthens when the re-check proves strictly more", () => {
+		expect(hasEvidenceStrengthened([phone], [phone, email])).toBe(true);
+	});
+
+	it("does not strengthen when the evidence set is unchanged", () => {
+		// A fingerprint can differ while evidence stands still — an identity row
+		// added to one side only produces no match. The merge now carries a claim
+		// nobody reviewed, so it must be re-presented, not applied.
+		expect(hasEvidenceStrengthened([], [])).toBe(false);
+		expect(hasEvidenceStrengthened([phone], [phone])).toBe(false);
+	});
+
+	it("does not strengthen when an item the reviewer relied on is gone", () => {
+		expect(hasEvidenceStrengthened([phone], [])).toBe(false);
+		expect(hasEvidenceStrengthened([phone, email], [email])).toBe(false);
+	});
+
+	it("does not strengthen on a swap that both gains and drops", () => {
+		// Trading one proof for another is not a strengthening: what the reviewer
+		// relied on stopped holding, whatever replaced it.
+		expect(hasEvidenceStrengthened([phone], [email])).toBe(false);
+	});
+
+	it("treats a changed identifier under the same kind as a swap", () => {
+		expect(
+			hasEvidenceStrengthened([phone], [{ kind: "phone", identifier: "1" }]),
+		).toBe(false);
+	});
+
+	it("does not let kind and identifier bleed across the key boundary", () => {
+		// A delimiter-joined key would make these equal, reporting "unchanged" for
+		// evidence that was never proven.
+		expect(
+			hasEvidenceStrengthened(
+				[{ kind: "a b", identifier: "c" }],
+				[{ kind: "a", identifier: "b c" }],
+			),
+		).toBe(false);
+		expect(
+			droppedEvidence(
+				[{ kind: "a b", identifier: "c" }],
+				[{ kind: "a", identifier: "b c" }],
+			),
+		).toEqual([{ kind: "a b", identifier: "c" }]);
+	});
+
+	it("ignores ordering and duplication", () => {
+		expect(hasEvidenceStrengthened([phone], [email, phone, phone])).toBe(true);
+	});
+});
+
+describe("droppedEvidence / gainedEvidence", () => {
+	it("names what stopped holding, for the reviewer-facing message", () => {
+		expect(droppedEvidence([phone, email], [email])).toEqual([phone]);
+		expect(droppedEvidence([phone], [phone])).toEqual([]);
+	});
+
+	it("names what the re-check newly proved", () => {
+		expect(gainedEvidence([], [phone])).toEqual([phone]);
+		expect(gainedEvidence([phone], [phone])).toEqual([]);
+	});
+});
+
+describe("hasMergeEvidenceStrengthened", () => {
+	it("accepts a newly shared key on both merge sides", () => {
+		expect(
+			hasMergeEvidenceStrengthened({
+				reviewedEvidence: [],
+				currentEvidence: [phone],
+				winnerId: 1,
+				loserIds: [2],
+				reviewedResolutionKeys: [
+					{ id: 1, keys: {} },
+					{ id: 2, keys: {} },
+				],
+				currentResolutionKeys: [
+					{ id: 1, keys: { phone: [phone.identifier] } },
+					{ id: 2, keys: { phone: [phone.identifier] } },
+				],
+			}),
+		).toBe(true);
+	});
+
+	it("survives a rule field named like an Object prototype member", () => {
+		// Rule fields are user-defined metadata field names, and these keys arrive
+		// as JSON from runs.action_input. Indexing an object literal would read
+		// Object.prototype.constructor and throw inside new Set(...).
+		const run = () =>
+			hasMergeEvidenceStrengthened({
+				reviewedEvidence: [],
+				currentEvidence: [phone],
+				winnerId: 1,
+				loserIds: [2],
+				reviewedResolutionKeys: [
+					{ id: 1, keys: {} },
+					{ id: 2, keys: {} },
+				],
+				currentResolutionKeys: [
+					{ id: 1, keys: { constructor: [phone.identifier] } },
+					{ id: 2, keys: { constructor: [phone.identifier] } },
+				],
+			});
+		expect(run).not.toThrow();
+		expect(run()).toBe(true);
+	});
+
+	it("rejects a matching gain that hides a new one-sided identity", () => {
+		expect(
+			hasMergeEvidenceStrengthened({
+				reviewedEvidence: [],
+				currentEvidence: [phone],
+				winnerId: 1,
+				loserIds: [2],
+				reviewedResolutionKeys: [
+					{ id: 1, keys: {} },
+					{ id: 2, keys: {} },
+				],
+				currentResolutionKeys: [
+					{
+						id: 1,
+						keys: {
+							phone: [phone.identifier],
+							email: ["winner@example.com"],
+						},
+					},
+					{
+						id: 2,
+						keys: {
+							phone: [phone.identifier],
+							email: ["loser@example.com"],
+						},
+					},
+				],
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/server/src/entity-resolution/evidence-strength.ts
+++ b/packages/server/src/entity-resolution/evidence-strength.ts
@@ -1,0 +1,105 @@
+import type { ResolutionEvidence, ResolutionKeySet } from "./policy";
+
+/** Preserve the boundary between two free-form values without a delimiter. */
+const evidenceKey = (item: ResolutionEvidence): string =>
+	JSON.stringify([item.kind, item.identifier]);
+
+/**
+ * A strict evidence gain preserves everything reviewed and adds at least one
+ * new proof. Unchanged evidence is not enough because the fingerprint may have
+ * moved on an unmatched identity that evidence does not expose.
+ */
+export function hasEvidenceStrengthened(
+	reviewed: ResolutionEvidence[],
+	current: ResolutionEvidence[],
+): boolean {
+	return (
+		droppedEvidence(reviewed, current).length === 0 &&
+		gainedEvidence(reviewed, current).length > 0
+	);
+}
+
+/** Evidence present at review time that the current assessment no longer proves. */
+export function droppedEvidence(
+	reviewed: ResolutionEvidence[],
+	current: ResolutionEvidence[],
+): ResolutionEvidence[] {
+	const currentKeys = new Set(current.map(evidenceKey));
+	return reviewed.filter((item) => !currentKeys.has(evidenceKey(item)));
+}
+
+/** Evidence the current assessment proves that was not recorded at review time. */
+export function gainedEvidence(
+	reviewed: ResolutionEvidence[],
+	current: ResolutionEvidence[],
+): ResolutionEvidence[] {
+	const reviewedKeys = new Set(reviewed.map(evidenceKey));
+	return current.filter((item) => !reviewedKeys.has(evidenceKey(item)));
+}
+
+/**
+ * Whether a merge re-check added proof without changing any unmatched
+ * resolution key. Evidence alone cannot establish that: a new shared phone can
+ * hide a different new email on each side because only matches become evidence.
+ */
+export function hasMergeEvidenceStrengthened(input: {
+	reviewedEvidence: ResolutionEvidence[];
+	currentEvidence: ResolutionEvidence[];
+	winnerId: number;
+	loserIds: number[];
+	reviewedResolutionKeys: readonly ResolutionKeySet[];
+	currentResolutionKeys: readonly ResolutionKeySet[];
+}): boolean {
+	if (
+		!hasEvidenceStrengthened(input.reviewedEvidence, input.currentEvidence)
+	) {
+		return false;
+	}
+
+	// Keys arrive as JSON objects from runs.action_input, and a rule field is a
+	// user-defined metadata field name — so `keys["constructor"]` would read off
+	// Object.prototype and blow up on `new Set(...)`. Index through Maps, never
+	// object literals. (Same class of bug as the object-literal key map that
+	// review-fix caught in assessEntityResolution.)
+	const keysById = (sets: readonly ResolutionKeySet[]) =>
+		new Map(
+			sets.map(({ id, keys }) => [
+				id,
+				new Map(Object.entries(keys).map(([kind, values]) => [kind, values])),
+			]),
+		);
+	const reviewedById = keysById(input.reviewedResolutionKeys);
+	const currentById = keysById(input.currentResolutionKeys);
+	const entityIds = [input.winnerId, ...input.loserIds];
+
+	for (const entityId of entityIds) {
+		const current = currentById.get(entityId);
+		if (!current) return false;
+		const reviewed = reviewedById.get(entityId) ?? new Map<string, string[]>();
+
+		// Nothing the reviewer was shown may have disappeared.
+		for (const [kind, reviewedValues] of reviewed) {
+			const currentValues = new Set(current.get(kind) ?? []);
+			if (reviewedValues.some((value) => !currentValues.has(value))) {
+				return false;
+			}
+		}
+
+		// Any newly appeared key must be matched by a counterpart. An unmatched
+		// one produces no evidence, so it would otherwise widen the merge with a
+		// claim nobody reviewed.
+		const counterpartIds =
+			entityId === input.winnerId ? input.loserIds : [input.winnerId];
+		for (const [kind, currentValues] of current) {
+			const reviewedValues = new Set(reviewed.get(kind) ?? []);
+			for (const value of currentValues) {
+				if (reviewedValues.has(value)) continue;
+				const gainedMatch = counterpartIds.some((counterpartId) =>
+					(currentById.get(counterpartId)?.get(kind) ?? []).includes(value),
+				);
+				if (!gainedMatch) return false;
+			}
+		}
+	}
+	return true;
+}

--- a/packages/server/src/entity-resolution/rejection.ts
+++ b/packages/server/src/entity-resolution/rejection.ts
@@ -1,13 +1,16 @@
 import type { DbClient } from "../db/client";
 
-/** Serialize decisions for one candidate across pods and watcher windows. */
-export async function lockResolutionFingerprint(
+/** Serialize decisions for one entity group across pods and evidence versions. */
+export async function lockResolutionCandidate(
 	db: DbClient,
-	input: { organizationId: string; fingerprint: string },
+	input: { organizationId: string; winnerId: number; loserIds: number[] },
 ): Promise<void> {
+	const entityIds = [...new Set([input.winnerId, ...input.loserIds])].sort(
+		(left, right) => left - right,
+	);
 	await db`
 		SELECT pg_advisory_xact_lock(
-			hashtextextended(${`${input.organizationId}:${input.fingerprint}`}, 0)
+			hashtextextended(${`${input.organizationId}:${entityIds.join(",")}`}, 0)
 		)
 	`;
 }

--- a/packages/server/src/entity-resolution/staleness.ts
+++ b/packages/server/src/entity-resolution/staleness.ts
@@ -55,7 +55,7 @@ export async function assertResolutionFingerprintCurrent(
 		 */
 		expectedVersion: number | null;
 	},
-): Promise<void> {
+): Promise<EntityResolutionAssessment> {
 	const ids = [...input.loserIds, input.winnerId].sort((a, b) => a - b);
 	const rows = await db<{
 		id: number;
@@ -119,7 +119,7 @@ export async function assertResolutionFingerprintCurrent(
 	// Exact equality is safe even for an unstamped or older proposal. The version
 	// is needed only to interpret a mismatch: missing/older inputs are
 	// incomparable, while a current-version mismatch proves drift.
-	if (assessment.fingerprint === input.expectedFingerprint) return;
+	if (assessment.fingerprint === input.expectedFingerprint) return assessment;
 	if (
 		input.expectedVersion === null ||
 		input.expectedVersion < RESOLUTION_FINGERPRINT_VERSION

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -17,9 +17,14 @@ import { type DbClient, getDb, pgBigintArray } from "../../db/client";
 import {
 	type EntityResolutionAssessment,
 	RESOLUTION_FINGERPRINT_VERSION,
+	type ResolutionEvidence,
 	type ResolutionKeySet,
 } from "../../entity-resolution/policy";
-import { assertResolutionFingerprintCurrent } from "../../entity-resolution/staleness";
+import { hasMergeEvidenceStrengthened } from "../../entity-resolution/evidence-strength";
+import {
+	assertResolutionFingerprintCurrent,
+	ResolutionFingerprintError,
+} from "../../entity-resolution/staleness";
 import type { Env } from "../../index";
 import {
 	formatFieldChangeAction,
@@ -212,6 +217,17 @@ function changedEntityId(proposal: EntityChangeProposal): number {
 
 function mergeEntityIds(proposal: EntityMergeProposal): number[] {
 	return proposal.entity_ids ?? [proposal.entity_id];
+}
+
+function mergeReviewResolutionKeys(
+	proposal: EntityMergeProposal,
+): ResolutionKeySet[] {
+	const duplicates = proposal.current.duplicates ?? [proposal.current.loser];
+	return [proposal.current.winner, ...duplicates].map((entity) => ({
+		id: Number(entity.id),
+		keys:
+			(entity.resolution_keys as Record<string, string[]> | undefined) ?? {},
+	}));
 }
 
 export function mergeReviewEventMetadata(proposal: EntityMergeProposal) {
@@ -545,16 +561,9 @@ export async function proposeEntityMerge(
  * Re-derive a pending merge proposal against the current resolution format and
  * write the result back to its run, leaving it pending.
  *
- * Used when the stored fingerprint is *incomparable* rather than stale — its
- * format stamp is absent or older, so this server cannot safely interpret a
- * digest mismatch. Refreshing re-presents the proposal with evidence recomputed
- * under the current format; the reviewer confirms once more against something
- * the server can actually verify.
- *
- * Deliberately does NOT apply the merge. The reviewer approved a card built
- * from evidence the server can no longer reproduce, so their click does not
- * carry over — silently applying would treat an unverifiable approval as a
- * verified one.
+ * Used when a fingerprint mismatch cannot safely carry the existing approval
+ * forward. The refreshed card contains current evidence and a current-format
+ * fingerprint for the reviewer to approve again.
  */
 export async function refreshMergeProposalFingerprint(
 	runId: number,
@@ -1128,11 +1137,65 @@ export async function applyEntityFieldChangeProposal(
 	});
 }
 
+export interface MergeApprovalResolution {
+	fingerprint: string | null;
+	evidence: ResolutionEvidence[];
+	policyHash: string | null;
+}
+
+export async function resolveMergeApproval(
+	proposal: EntityMergeProposal,
+	organizationId: string,
+	db: DbClient,
+): Promise<MergeApprovalResolution> {
+	const fingerprint = proposal.resolution_fingerprint ?? null;
+	if (!fingerprint) {
+		return {
+			fingerprint: null,
+			evidence: proposal.evidence ?? [],
+			policyHash: proposal.policy_hash ?? null,
+		};
+	}
+
+	let assessment: EntityResolutionAssessment;
+	try {
+		assessment = await assertResolutionFingerprintCurrent(db, {
+			organizationId,
+			winnerId: proposal.winner_entity_id,
+			loserIds: mergeEntityIds(proposal),
+			expectedFingerprint: fingerprint,
+			expectedVersion: proposal.resolution_fingerprint_version ?? null,
+		});
+	} catch (error) {
+		if (
+			!(error instanceof ResolutionFingerprintError) ||
+			!hasMergeEvidenceStrengthened({
+				reviewedEvidence: proposal.evidence ?? [],
+				currentEvidence: error.assessment.evidence,
+				winnerId: proposal.winner_entity_id,
+				loserIds: mergeEntityIds(proposal),
+				reviewedResolutionKeys: mergeReviewResolutionKeys(proposal),
+				currentResolutionKeys: error.assessment.resolutionKeys,
+			})
+		) {
+			throw error;
+		}
+		assessment = error.assessment;
+	}
+
+	return {
+		fingerprint: assessment.fingerprint,
+		evidence: assessment.evidence,
+		policyHash: assessment.policyHash,
+	};
+}
+
 export async function applyEntityChangeProposal(
 	proposal: EntityChangeProposal,
 	ctx: ToolContext,
 	env: Env,
 	db: DbClient,
+	mergeResolution?: MergeApprovalResolution,
 ): Promise<unknown> {
 	const operation = operationOf(proposal);
 	if (operation === "update") {
@@ -1165,16 +1228,9 @@ export async function applyEntityChangeProposal(
 	}
 	if (operation === "merge") {
 		const mergeProposal = asMergeProposal(proposal);
-		if (mergeProposal.resolution_fingerprint) {
-			await assertResolutionFingerprintCurrent(db, {
-				organizationId: ctx.organizationId,
-				winnerId: mergeProposal.winner_entity_id,
-				loserIds: mergeEntityIds(mergeProposal),
-				expectedFingerprint: mergeProposal.resolution_fingerprint,
-				// An unstamped mismatch has unknown provenance and must be refreshed.
-				expectedVersion: mergeProposal.resolution_fingerprint_version ?? null,
-			});
-		}
+		const resolved =
+			mergeResolution ??
+			(await resolveMergeApproval(mergeProposal, ctx.organizationId, db));
 		const params = {
 			orgId: ctx.organizationId,
 			loserIds: mergeEntityIds(mergeProposal),
@@ -1186,8 +1242,8 @@ export async function applyEntityChangeProposal(
 				watcherId: mergeProposal.watcher_id ?? null,
 				windowId:
 					mergeProposal.source_window_id ?? mergeProposal.window_id ?? null,
-				policyHash: mergeProposal.policy_hash ?? null,
-				evidence: mergeProposal.evidence ?? [],
+				policyHash: resolved.policyHash,
+				evidence: resolved.evidence,
 			},
 		};
 		return applyMergeGroupInTransaction(params, db);

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -47,9 +47,11 @@ import {
 	pgTextArray,
 } from "../../db/client";
 import {
-	lockResolutionFingerprint,
+	lockResolutionCandidate,
 	wasResolutionRejected,
 } from "../../entity-resolution/rejection";
+import { droppedEvidence } from "../../entity-resolution/evidence-strength";
+import { ResolutionFingerprintError } from "../../entity-resolution/staleness";
 import type { Env } from "../../index";
 import { callTool as callProxyTool } from "../../mcp-proxy/client";
 import { notifyActionApprovalNeeded } from "../../notifications/triggers";
@@ -93,14 +95,15 @@ export {
 	formatActivityAttentionBlock,
 	listOrgActivity,
 } from "./manage_operations/activity-feed";
-import { ResolutionFingerprintError } from "../../entity-resolution/staleness";
 import {
 	applyEntityChangeProposal,
 	asMergeProposal,
 	ENTITY_CHANGE_ACTION_KEYS,
 	type EntityChangeProposal,
+	type MergeApprovalResolution,
 	mergeReviewEventMetadata,
 	refreshMergeProposalFingerprint,
+	resolveMergeApproval,
 } from "./entity-field-approval";
 import { callerIsAdmin } from "./helpers/db-helpers";
 import {
@@ -2193,6 +2196,7 @@ async function tryApproveEntityChangeRun(
 	const completeApproval = async (
 		db: DbClient,
 		proposal: EntityChangeProposal,
+		mergeResolution?: MergeApprovalResolution,
 	): Promise<ManageOperationsResult> => {
 		const operation = entityChangeOperation(proposal);
 		const description = describeEntityChange(proposal);
@@ -2211,7 +2215,13 @@ async function tryApproveEntityChangeRun(
 			db,
 		);
 
-		const result = await applyEntityChangeProposal(proposal, ctx, env, db);
+		const result = await applyEntityChangeProposal(
+			proposal,
+			ctx,
+			env,
+			db,
+			mergeResolution,
+		);
 		const staleFields =
 			operation === "update" &&
 			result &&
@@ -2266,25 +2276,36 @@ async function tryApproveEntityChangeRun(
 		};
 	};
 
-	// A fingerprint without a known current input-format stamp cannot be compared
-	// safely, only recomputed. Failing it like drift makes a genuinely old
-	// proposal permanently unapprovable: every retry recomputes the same mismatch
-	// and there is no blocker the reviewer can clear. Re-present it instead — the
-	// run stays pending with evidence rebuilt under the current format.
-	const refreshIncomparableFingerprint = async (
+	// Re-present a proposal when the current resolution keys are not a strict,
+	// matching-only extension of what the reviewer saw. This also gives an
+	// unstamped proposal a current fingerprint, so a later approval can succeed.
+	const refreshStaleFingerprint = async (
 		error: unknown,
 		proposal: EntityChangeProposal,
 		db: DbClient,
 	): Promise<ManageOperationsResult | null> => {
 		if (
 			!(error instanceof ResolutionFingerprintError) ||
-			error.failure !== "incomparable" ||
 			entityChangeOperation(proposal) !== "merge"
 		) {
 			return null;
 		}
+		const dropped = droppedEvidence(
+			asMergeProposal(proposal).evidence ?? [],
+			error.assessment.evidence,
+		);
+		// Name what stopped holding in the reviewer's terms; the internal
+		// fingerprint failure does not describe their contact evidence.
+		const lostSummary =
+			dropped.length > 0
+				? ` No longer proven: ${dropped.map((item) => `${item.kind} ${item.identifier}`).join(", ")}.`
+				: "";
+		const reviewerMessage =
+			dropped.length > 0
+				? `Evidence has been re-checked and no longer supports what you reviewed.${lostSummary} Current finding: ${error.assessment.reason} Review it and approve again to apply, or reject it.`
+				: `Evidence has been re-checked against the workspace as it stands now. Current finding: ${error.assessment.reason} Review it and approve again to apply, or reject it.`;
 		const reset = await db`
-      UPDATE runs SET approval_status = 'pending', status = 'pending', error_message = ${error.message}
+      UPDATE runs SET approval_status = 'pending', status = 'pending', error_message = ${reviewerMessage}
       WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
 		AND approval_status = 'approved' AND status = 'running'
 		RETURNING id
@@ -2301,8 +2322,10 @@ async function tryApproveEntityChangeRun(
 			args.run_id,
 			ctx.organizationId,
 			"pending",
-			"entity_merge — evidence re-checked, still pending",
-			`This merge was proposed without a known current matching format, so its recorded evidence could not be verified. It has been re-checked against the workspace as it stands now: ${error.assessment.reason} Review the updated evidence and approve again, or reject it.`,
+			dropped.length > 0
+				? "entity_merge — evidence no longer supports the merge"
+				: "entity_merge — evidence re-checked, still pending",
+			reviewerMessage,
 			mergeReviewEventMetadata(refreshedProposal),
 			reviewer,
 			db,
@@ -2313,10 +2336,7 @@ async function tryApproveEntityChangeRun(
 				"Cannot refresh merge approval because its approval event is missing",
 			);
 		}
-		return {
-			error:
-				"This merge was recorded without a known current matching format. Its evidence has been re-checked and the approval is pending again — review the updated evidence and approve once more, or reject it.",
-		};
+		return { error: reviewerMessage };
 	};
 
 	const applyFailure = async (
@@ -2357,52 +2377,42 @@ async function tryApproveEntityChangeRun(
 		};
 	};
 
+	const cancelPreviouslyRejectedMerge = async (
+		db: DbClient,
+	): Promise<ManageOperationsResult | null> => {
+		const cancelled = await db`
+			UPDATE runs
+			SET approval_status = 'rejected', status = 'cancelled',
+			    error_message = 'The same resolution candidate was already rejected',
+			    completed_at = NOW()
+			WHERE id = ${args.run_id}
+			  AND organization_id = ${ctx.organizationId}
+			  AND approval_status = 'approved'
+			  AND status = 'running'
+			RETURNING id
+		`;
+		if (cancelled.length === 0) return null;
+		await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"rejected",
+			"entity_merge — rejected",
+			"This unchanged duplicate candidate was already rejected in another Behavior run.",
+			{
+				reject_reason: "The same resolution candidate was already rejected",
+			},
+			null,
+			db,
+		);
+		return {
+			error:
+				"This duplicate candidate was already rejected. Refresh the Behavior run.",
+		};
+	};
+
 	if (pendingOperation === "merge") {
 		try {
 			return await sql.begin(async (tx) => {
-				const fingerprint = resolutionFingerprintOf(pendingProposal);
-				if (fingerprint) {
-					await lockResolutionFingerprint(tx, {
-						organizationId: ctx.organizationId,
-						fingerprint,
-					});
-					if (
-						await wasResolutionRejected(tx, {
-							organizationId: ctx.organizationId,
-							fingerprint,
-						})
-					) {
-						const cancelled = await tx`
-							UPDATE runs
-							SET approval_status = 'rejected', status = 'cancelled',
-							    error_message = 'The same resolution candidate was already rejected',
-							    completed_at = NOW()
-							WHERE id = ${args.run_id}
-							  AND organization_id = ${ctx.organizationId}
-							  AND approval_status = 'pending'
-							  AND status = 'pending'
-							RETURNING id
-						`;
-						if (cancelled.length === 0) return null;
-						await supersedeActionEvent(
-							args.run_id,
-							ctx.organizationId,
-							"rejected",
-							"entity_merge — rejected",
-							"This unchanged duplicate candidate was already rejected in another Behavior run.",
-							{
-								reject_reason:
-									"The same resolution candidate was already rejected",
-							},
-							null,
-							tx,
-						);
-						return {
-							error:
-								"This duplicate candidate was already rejected. Refresh the Behavior run.",
-						};
-					}
-				}
 				const claimed = await claimEntityChangeRun(
 					args.run_id,
 					ctx.organizationId,
@@ -2412,9 +2422,43 @@ async function tryApproveEntityChangeRun(
 				);
 				if (!claimed) return null;
 				try {
-					return await completeApproval(tx, claimed.proposal);
+					const mergeProposal = asMergeProposal(claimed.proposal);
+					await lockResolutionCandidate(tx, {
+						organizationId: ctx.organizationId,
+						winnerId: mergeProposal.winner_entity_id,
+						loserIds:
+							mergeProposal.entity_ids ?? [mergeProposal.entity_id],
+					});
+					const reviewedFingerprint = resolutionFingerprintOf(
+						claimed.proposal,
+					);
+					if (
+						reviewedFingerprint &&
+						(await wasResolutionRejected(tx, {
+							organizationId: ctx.organizationId,
+							fingerprint: reviewedFingerprint,
+						}))
+					) {
+						return cancelPreviouslyRejectedMerge(tx);
+					}
+					const resolution = await resolveMergeApproval(
+						mergeProposal,
+						ctx.organizationId,
+						tx,
+					);
+					if (
+						resolution.fingerprint &&
+						resolution.fingerprint !== reviewedFingerprint &&
+						(await wasResolutionRejected(tx, {
+							organizationId: ctx.organizationId,
+							fingerprint: resolution.fingerprint,
+						}))
+					) {
+						return cancelPreviouslyRejectedMerge(tx);
+					}
+					return await completeApproval(tx, claimed.proposal, resolution);
 				} catch (error) {
-					const refreshed = await refreshIncomparableFingerprint(
+					const refreshed = await refreshStaleFingerprint(
 						error,
 						claimed.proposal,
 						tx,
@@ -2465,6 +2509,7 @@ async function tryRejectEntityChangeRun(
 	if (!pending?.action_input) return null;
 	const reason = args.reason ?? "Rejected by user";
 	const reviewer = await resolveReviewer(ctx);
+	const pendingIsMerge = entityChangeOperation(pending.action_input) === "merge";
 	const reject = async (
 		db: DbClient,
 	): Promise<ManageOperationsResult | null> => {
@@ -2476,6 +2521,14 @@ async function tryRejectEntityChangeRun(
 			db,
 		);
 		if (!claimed) return null;
+		if (pendingIsMerge) {
+			const mergeProposal = asMergeProposal(claimed.proposal);
+			await lockResolutionCandidate(db, {
+				organizationId: ctx.organizationId,
+				winnerId: mergeProposal.winner_entity_id,
+				loserIds: mergeProposal.entity_ids ?? [mergeProposal.entity_id],
+			});
+		}
 		const operation = entityChangeOperation(claimed.proposal);
 		const description = describeEntityChange(claimed.proposal);
 		const eventId = await supersedeActionEvent(
@@ -2502,15 +2555,8 @@ async function tryRejectEntityChangeRun(
 		};
 	};
 
-	const fingerprint = resolutionFingerprintOf(pending.action_input);
-	if (!fingerprint) return reject(sql);
-	return sql.begin(async (tx) => {
-		await lockResolutionFingerprint(tx, {
-			organizationId: ctx.organizationId,
-			fingerprint,
-		});
-		return reject(tx);
-	});
+	if (!pendingIsMerge) return reject(sql);
+	return sql.begin(reject);
 }
 
 async function handleApprove(


### PR DESCRIPTION
## Summary

- Approving a stranded merge in prod showed the reviewer `Merge evidence was recorded without a known current resolution format` — a sentence about hash versioning, rendered as a failure — and then silently required a **second** click. Both are fixed.
- A fingerprint difference is not by itself grounds to ask again. When re-assessment proves strictly **more** than the reviewer was shown and contradicts none of it, their approval already covers the merge: it applies on the first click, and the merge ledger cites the recomputed evidence and policy hash rather than the stale snapshot.
- Re-consent is still owed when something they relied on stopped holding — and that test is over **resolution keys**, not evidence alone.

## Why resolution keys and not just evidence

Only *matches* become evidence, so an evidence-set comparison is blind in two directions:

- an identity added to **one side** produces no match, so evidence is unchanged while the merge now carries a claim nobody reviewed;
- a newly shared phone can **mask** a different new email on each side, so evidence looks strictly gained while two unreviewed one-sided claims ride along.

`hasMergeEvidenceStrengthened` therefore requires: nothing the reviewer saw disappeared, at least one new proof, and every newly appeared key matched by a counterpart. This comparison is only possible because #2321 recorded `resolution_keys` in the snapshot.

The first case is guarded by a pre-existing test (`does not apply an approved merge when an identity row appeared after proposal`) that my initial evidence-only rule broke — it caught a real hole, and the fix generalizes to the class rather than the instance.

## Reviewer-facing text

`runs.error_message` is the column the approval card renders, so it now carries reviewer prose instead of the exception message, and **names the proof that stopped holding**:

> Evidence has been re-checked and no longer supports what you reviewed. No longer proven: phone 905395102240. Current finding: … Review it and approve again to apply, or reject it.

Asserted by tests that fail if `fingerprint` / `resolution format` leak into it.

## Also

Re-keys the **existing** advisory lock from the fingerprint to the entity group. Refresh rotates the fingerprint, so a lock keyed on it had stopped serializing decisions for the same candidate. No new lock is introduced.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` (167 pass / 0 fail), targeted integration + resolution suites (61 pass / 0 fail)
- [x] Bug fix: red→fix→green below

### Red (before)

The pre-existing guard, against my first evidence-only rule:

```
× does not apply an approved merge when an identity row appeared after proposal
  → expected true to be false
```

Prod symptom, run 702099 before the fix — internal text in the column the card reads:

```
error_message | Merge evidence was recorded without a known current resolution format
```

### Green (after)

```
Test Files  3 passed (3)
     Tests  61 passed (61)      # merge integration + entity-resolution
     Tests  167 pass / 0 fail   # make test-unit
```

### Mutation-verified

Each planted mutant is caught, so the tests bite rather than merely pass:

| mutation | caught by |
|---|---|
| `gained > 0` → `gained >= 0` | 3 tests, incl. the pre-existing identity-row guard |
| drop the "nothing lost" half | 3 unit tests (swap cases) |
| Map indexing → object-literal indexing | prototype-key test: `TypeError: function is not iterable` |

## Notes

Rule fields are user-defined metadata field names arriving as JSON from `runs.action_input`, so the key comparison indexes through `Map`s — an object literal would read `Object.prototype.constructor` for a field named `constructor` and throw inside `new Set(...)`. Same class of bug `review-fix` caught in `assessEntityResolution` on #2321; this is the third instance, hardened with a test.

**Not in this PR:** rendering an old-vs-new evidence diff in the approval card. The data is fully reconstructible today (`supersedes_event_id` links both snapshots in the append-only log) and nothing reads it — that is an owletto change, tracked separately.

**Prod impact:** the 18 stranded proposals in `buremba` become **one** click each instead of two, and re-assessment gains the matching phone that #2152 taught the matcher to read, so they apply with real evidence rather than none.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->