### PR TITLE
feat(cli,server): compile Behavior skills[] into frozen prompt at apply

### DIFF
--- a/examples/agent-community/lobu.config.ts
+++ b/examples/agent-community/lobu.config.ts
@@ -2,6 +2,7 @@ import {
   connectorFromFile,
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineRelationshipType,
   defineBehavior,
@@ -11,8 +12,15 @@ import {
 import type DiscoursePostsConnector from "./discourse-posts.connector.ts";
 import type opportunityMatcherReaction from "./opportunity-matcher.reaction.ts";
 
+const opportunityMatcherSkill = defineSkill({
+  name: "opportunity-matcher",
+  content:
+    "Monitor connected profiles, newsletters, websites, and member updates for new launches, posts, hiring signals, funding news, and project changes. Identify which members are likely to care, explain why, and queue approved intro or outreach drafts.\n",
+});
+
 const agentCommunity = defineAgent({
   id: "agent-community",
+  skills: [opportunityMatcherSkill],
   name: "agent-community",
   description:
     "Discover aligned members, explain why they should meet, and draft warm introductions",
@@ -153,8 +161,7 @@ const opportunityMatcher = defineBehavior({
   reaction: reactionFromFile<typeof opportunityMatcherReaction>(
     "./opportunity-matcher.reaction.ts"
   ),
-  prompt:
-    "Monitor connected profiles, newsletters, websites, and member updates for new launches, posts, hiring signals, funding news, and project changes. Identify which members are likely to care, explain why, and queue approved intro or outreach drafts.\n",
+  skills: ["opportunity-matcher"],
 });
 
 export default defineConfig({

--- a/examples/atlas/lobu.config.ts
+++ b/examples/atlas/lobu.config.ts
@@ -1,6 +1,7 @@
 import {
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineBehavior,
   reactionFromFile,
@@ -8,8 +9,15 @@ import {
 } from "@lobu/cli/config";
 import type catalogStalenessCheckerReaction from "./catalog-staleness-checker.reaction.ts";
 
+const catalogStalenessCheckerSkill = defineSkill({
+  name: "catalog-staleness-checker",
+  content:
+    'Sweep the atlas reference catalog for entries that haven\'t been\nupdated in 90+ days. List the stalest 10 across cities, countries,\nindustries, technologies, and universities. Suggest a re-verification\naction for each (e.g. "country/PL: confirm population from latest census").\n',
+});
+
 const atlasCurator = defineAgent({
   id: "atlas-curator",
+  skills: [catalogStalenessCheckerSkill],
   name: "atlas-curator",
   description:
     "Curate Atlas reference data — countries, cities, regions, industries, technologies, universities",
@@ -209,8 +217,7 @@ const catalogStalenessChecker = defineBehavior({
   reaction: reactionFromFile<typeof catalogStalenessCheckerReaction>(
     "./catalog-staleness-checker.reaction.ts"
   ),
-  prompt:
-    'Sweep the atlas reference catalog for entries that haven\'t been\nupdated in 90+ days. List the stalest 10 across cities, countries,\nindustries, technologies, and universities. Suggest a re-verification\naction for each (e.g. "country/PL: confirm population from latest census").\n',
+  skills: ["catalog-staleness-checker"],
 });
 
 export default defineConfig({

--- a/examples/delivery/lobu.config.ts
+++ b/examples/delivery/lobu.config.ts
@@ -2,6 +2,7 @@ import {
   connectorFromFile,
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineRelationshipType,
   defineBehavior,
@@ -9,8 +10,15 @@ import {
 } from "@lobu/cli/config";
 import type ShopifyOrdersConnector from "./shopify-orders.connector.ts";
 
+const phoenixRolloutTrackerSkill = defineSkill({
+  name: "phoenix-rollout-tracker",
+  content:
+    "Check project blockers, milestone progress, and generate the weekly risk summary for leadership.\n",
+});
+
 const delivery = defineAgent({
   id: "delivery",
+  skills: [phoenixRolloutTrackerSkill],
   name: "delivery",
   description:
     "Help delivery teams keep milestones, blockers, owners, and artifacts aligned",
@@ -157,8 +165,7 @@ const phoenixRolloutTracker = defineBehavior({
   notification: { priority: "high", channel: "both" },
   tags: ["delivery", "weekly", "rollout"],
   minCooldownSeconds: 3600,
-  prompt:
-    "Check project blockers, milestone progress, and generate the weekly risk summary for leadership.\n",
+  skills: ["phoenix-rollout-tracker"],
 });
 
 export default defineConfig({

--- a/examples/ecommerce/lobu.config.ts
+++ b/examples/ecommerce/lobu.config.ts
@@ -2,6 +2,7 @@ import {
   connectorFromFile,
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineRelationshipType,
   defineBehavior,
@@ -9,8 +10,15 @@ import {
 } from "@lobu/cli/config";
 import type StripeChargesConnector from "./stripe-charges.connector.ts";
 
+const customerActivityTrackerSkill = defineSkill({
+  name: "customer-activity-tracker",
+  content:
+    "Monitor customers for new orders, subscription changes, delivery requests, and support interactions.\n",
+});
+
 const ecommerceOps = defineAgent({
   id: "ecommerce-ops",
+  skills: [customerActivityTrackerSkill],
   name: "ecommerce-ops",
   description:
     "Manage subscriptions, process order changes, and resolve customer requests",
@@ -166,8 +174,7 @@ const customerActivityTracker = defineBehavior({
   notification: { priority: "normal" },
   tags: ["ecommerce", "customer-ops"],
   minCooldownSeconds: 300,
-  prompt:
-    "Monitor customers for new orders, subscription changes, delivery requests, and support interactions.\n",
+  skills: ["customer-activity-tracker"],
 });
 
 export default defineConfig({

--- a/examples/finance/lobu.config.ts
+++ b/examples/finance/lobu.config.ts
@@ -2,6 +2,7 @@ import {
   connectorFromFile,
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineRelationshipType,
   defineBehavior,
@@ -11,8 +12,15 @@ import {
 import type QuickBooksTransactionsConnector from "./quickbooks-transactions.connector.ts";
 import type reconciliationMonitorReaction from "./reconciliation-monitor.reaction.ts";
 
+const reconciliationMonitorSkill = defineSkill({
+  name: "reconciliation-monitor",
+  content:
+    "Check accounts for unreconciled transactions, new variances, and approaching reporting deadlines. Lead with exceptions that need review.\n",
+});
+
 const finance = defineAgent({
   id: "finance",
+  skills: [reconciliationMonitorSkill],
   name: "finance",
   description:
     "Help finance teams reconcile data, explain variance, and prepare reporting runs",
@@ -178,8 +186,7 @@ const reconciliationMonitor = defineBehavior({
   reaction: reactionFromFile<typeof reconciliationMonitorReaction>(
     "./reconciliation-monitor.reaction.ts"
   ),
-  prompt:
-    "Check accounts for unreconciled transactions, new variances, and approaching reporting deadlines. Lead with exceptions that need review.\n",
+  skills: ["reconciliation-monitor"],
 });
 
 export default defineConfig({

--- a/examples/leadership/lobu.config.ts
+++ b/examples/leadership/lobu.config.ts
@@ -2,6 +2,7 @@ import {
   connectorFromFile,
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineRelationshipType,
   defineBehavior,
@@ -9,8 +10,15 @@ import {
 } from "@lobu/cli/config";
 import type LinearCyclesConnector from "./linear-cycles.connector.ts";
 
+const boardActionTrackerSkill = defineSkill({
+  name: "board-action-tracker",
+  content:
+    "Track board action items: check task delivery status, blocker resolution progress, and approaching deadlines for the next board packet.\n",
+});
+
 const leadership = defineAgent({
   id: "leadership",
+  skills: [boardActionTrackerSkill],
   name: "leadership",
   description:
     "Help leadership teams turn memos, decisions, and board materials into reusable operating context",
@@ -187,8 +195,7 @@ const boardActionTracker = defineBehavior({
   notification: { priority: "high", channel: "both" },
   tags: ["leadership", "daily", "board"],
   agentKind: "notifier",
-  prompt:
-    "Track board action items: check task delivery status, blocker resolution progress, and approaching deadlines for the next board packet.\n",
+  skills: ["board-action-tracker"],
 });
 
 export default defineConfig({

--- a/examples/legal/lobu.config.ts
+++ b/examples/legal/lobu.config.ts
@@ -2,6 +2,7 @@ import {
   connectorFromFile,
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineRelationshipType,
   defineBehavior,
@@ -9,8 +10,15 @@ import {
 } from "@lobu/cli/config";
 import type DocuSignEnvelopesConnector from "./docusign-envelopes.connector.ts";
 
+const contractReviewTrackerSkill = defineSkill({
+  name: "contract-review-tracker",
+  content:
+    "Review active contracts for approaching deadlines, unsigned agreements, and unresolved risk items. Flag any clauses that still need counsel approval.\n",
+});
+
 const legalReview = defineAgent({
   id: "legal-review",
+  skills: [contractReviewTrackerSkill],
   name: "legal-review",
   description:
     "Review contracts, summarize risk, and surface missing protections",
@@ -179,8 +187,7 @@ const contractReviewTracker = defineBehavior({
   minCooldownSeconds: 1800,
   reactionsGuidance:
     "For any contract with `status: needs_counsel`, route an entity-scoped event\nto the assigned reviewer. For contracts >90 days unsigned, escalate to the\ncounterparty owner; never auto-resolve risk items.\n",
-  prompt:
-    "Review active contracts for approaching deadlines, unsigned agreements, and unresolved risk items. Flag any clauses that still need counsel approval.\n",
+  skills: ["contract-review-tracker"],
 });
 
 export default defineConfig({

--- a/examples/lobu-crm/lobu.config.ts
+++ b/examples/lobu-crm/lobu.config.ts
@@ -3,6 +3,7 @@ import {
   defineAgent,
   defineAuthProfile,
   defineConfig,
+  defineSkill,
   defineConnection,
   defineEntityType,
   defineRelationshipType,
@@ -16,13 +17,29 @@ import type WebsiteConnector from "../brand-intelligence/website.connector.ts";
 import type funnelDigestReaction from "./funnel-digest.reaction.ts";
 import type inboundTriageReaction from "./inbound-triage.reaction.ts";
 
+const funnelDigestSkill = defineSkill({
+  name: "funnel-digest",
+  content:
+    'Produce the weekly funnel digest and post it to Slack. Keep it short.\n\n1. The single recommended action for the week, on the first line. Pick the\n   move that does the most to get pilot #1 closer (almost always: follow up\n   with the warmest lead in "conversation", or progress whichever pilot\n   conversation is furthest along).\n2. Funnel snapshot: count of `lead` entities per stage; what moved since the\n   last digest (new leads, stage changes, new/updated `pilot` entities).\n3. Top-of-funnel since last digest: new GitHub stars, X mentions/replies,\n   HN/PH activity.\n4. Stale: any lead in `conversation` with no `lead:interaction` in 7+ days —\n   list them for follow-up.\n5. One gap callout if there is one (e.g. "18 new stars, 0 became leads —\n   is inbound-triage catching the right signal?").\n\nTone: a checklist a busy founder reads in 30 seconds. End on the next action,\nnot the status. Remember: the metric that matters is customer conversations\nthis week — if that number is below 3, say so plainly.\n',
+});
+
+const inboundTriageSkill = defineSkill({
+  name: "inbound-triage",
+  content:
+    'Look for new top-of-funnel signals since the last run, across the connectors\nin this org:\n  - GitHub: new stargazers on lobu-ai/lobu; new issues / issue comments /\n    PR comments — especially anything with deployment, self-host, multi-tenant,\n    "how do I", or evaluation language.\n  - X: new @-mentions of Lobu, replies to Burak\'s Lobu threads, quote-tweets.\n  - Hacker News / Product Hunt: new comments or posts mentioning Lobu or OpenClaw.\n\nFor each signal that looks like a real person (not a bot, not a casual star):\n  1. search_memory for an existing `lead` (match github handle / x handle / email).\n  2. If none, create a `lead` entity at the lowest stage the evidence supports\n     (a bare star → "signal"; a deployment-flavored issue comment or a\n     "how do I deploy this for my team" mention → "trial" or "conversation"),\n     with source set to where it came from, and entity_ids linking to the\n     source event. Then save a `lead:created` event.\n  3. If a lead exists, enrich it (add the handle, bump the stage if the new\n     signal warrants it, update last_touch) and save a `lead:interaction` or\n     `lead:stage_changed` event as appropriate.\n\nThen post to Slack: the new/updated leads, ranked by closeness-to-a-paying-pilot,\neach with a one-line recommended next action (e.g. "reply on the issue and offer\na 20-min call"). If nothing notable, post nothing — don\'t manufacture noise.\n',
+});
+
 const crm = defineAgent({
   id: "crm",
   dir: ".",
   name: "crm",
   description:
     "Maintains Lobu's funnel CRM — leads, pilots, inbound triage, weekly digest",
-  skills: [skillFromFile("./skills/crm-ops")],
+  skills: [
+    skillFromFile("./skills/crm-ops"),
+    funnelDigestSkill,
+    inboundTriageSkill,
+  ],
   providers: [
     {
       id: "z-ai",
@@ -164,8 +181,7 @@ const funnelDigestBehavior = defineBehavior({
   reaction: reactionFromFile<typeof funnelDigestReaction>(
     "./funnel-digest.reaction.ts"
   ),
-  prompt:
-    'Produce the weekly funnel digest and post it to Slack. Keep it short.\n\n1. The single recommended action for the week, on the first line. Pick the\n   move that does the most to get pilot #1 closer (almost always: follow up\n   with the warmest lead in "conversation", or progress whichever pilot\n   conversation is furthest along).\n2. Funnel snapshot: count of `lead` entities per stage; what moved since the\n   last digest (new leads, stage changes, new/updated `pilot` entities).\n3. Top-of-funnel since last digest: new GitHub stars, X mentions/replies,\n   HN/PH activity.\n4. Stale: any lead in `conversation` with no `lead:interaction` in 7+ days —\n   list them for follow-up.\n5. One gap callout if there is one (e.g. "18 new stars, 0 became leads —\n   is inbound-triage catching the right signal?").\n\nTone: a checklist a busy founder reads in 30 seconds. End on the next action,\nnot the status. Remember: the metric that matters is customer conversations\nthis week — if that number is below 3, say so plainly.\n',
+  skills: ["funnel-digest"],
 });
 
 const inboundTriageBehavior = defineBehavior({
@@ -179,8 +195,7 @@ const inboundTriageBehavior = defineBehavior({
   reaction: reactionFromFile<typeof inboundTriageReaction>(
     "./inbound-triage.reaction.ts"
   ),
-  prompt:
-    'Look for new top-of-funnel signals since the last run, across the connectors\nin this org:\n  - GitHub: new stargazers on lobu-ai/lobu; new issues / issue comments /\n    PR comments — especially anything with deployment, self-host, multi-tenant,\n    "how do I", or evaluation language.\n  - X: new @-mentions of Lobu, replies to Burak\'s Lobu threads, quote-tweets.\n  - Hacker News / Product Hunt: new comments or posts mentioning Lobu or OpenClaw.\n\nFor each signal that looks like a real person (not a bot, not a casual star):\n  1. search_memory for an existing `lead` (match github handle / x handle / email).\n  2. If none, create a `lead` entity at the lowest stage the evidence supports\n     (a bare star → "signal"; a deployment-flavored issue comment or a\n     "how do I deploy this for my team" mention → "trial" or "conversation"),\n     with source set to where it came from, and entity_ids linking to the\n     source event. Then save a `lead:created` event.\n  3. If a lead exists, enrich it (add the handle, bump the stage if the new\n     signal warrants it, update last_touch) and save a `lead:interaction` or\n     `lead:stage_changed` event as appropriate.\n\nThen post to Slack: the new/updated leads, ranked by closeness-to-a-paying-pilot,\neach with a one-line recommended next action (e.g. "reply on the issue and offer\na 20-min call"). If nothing notable, post nothing — don\'t manufacture noise.\n',
+  skills: ["inbound-triage"],
 });
 
 const github_accountAuth = defineAuthProfile({

--- a/examples/market/lobu.config.ts
+++ b/examples/market/lobu.config.ts
@@ -2,6 +2,7 @@ import {
   connectorFromFile,
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineRelationshipType,
   defineBehavior,
@@ -13,8 +14,21 @@ import type founderActivityTrackerReaction from "./founder-activity-tracker.reac
 
 const SECTOR_ENUM = ["bio-health", "ai", "fintech", "crypto", "consumer"];
 
+const founderActivityTrackerSkill = defineSkill({
+  name: "founder-activity-tracker",
+  content:
+    "You are a venture capital analyst tracking the public activity of startup founders in your portfolio.\n\nThe founders are the entities bound to this Behavior — the payload's `entities` array lists each founder's name, type, and ID. Their recent public activity arrives in the payload's `founder_posts` source.\n\nProduce a structured founder activity report:\n1. **Executive Summary**: 2-3 sentence overview of founder activity and signals.\n2. **Per-Founder Analysis**: For each active founder, summarize their messaging themes, engagement level, and signals about company direction.\n3. **Cross-Portfolio Patterns**: Themes multiple founders discuss.\n4. **Notable Signals**: Flag potential announcements, strategic shifts, or concerns.\n\nBe specific and cite actual tweets/posts as evidence.\n",
+});
+
+const opportunityMatcherSkill = defineSkill({
+  name: "opportunity-matcher",
+  content:
+    "You are a community intelligence agent for a private founder community managed by a venture capital fund.\nYour job is to monitor founder activity and identify high-quality introduction opportunities between portfolio founders.\n\nThe community members are the entities bound to this Behavior — the payload's `entities` array carries each member's name, type, and metadata (title, role). Their recent activity arrives in the payload's `content` source.\n\n## Instructions\n1. Scan all new content for signals: launches, posts, hiring announcements, funding news, project updates, and collaboration signals.\n2. For each signal, identify which other community founders are likely to care and explain why.\n3. Suggest a concrete action: warm intro draft, shared-interest notification, or flagging for community ops review.\n4. Only suggest introductions where there is a clear, specific overlap — not generic \"both work in tech\" matches.\n5. Rate each signal's strength (high/medium/low) based on timeliness and relevance.\n",
+});
+
 const vcTracking = defineAgent({
   id: "vc-tracking",
+  skills: [founderActivityTrackerSkill, opportunityMatcherSkill],
   name: "vc-tracking",
   description:
     "Track companies, founders, and investment opportunities for venture firms",
@@ -463,8 +477,7 @@ const founderActivityTracker = defineBehavior({
   reaction: reactionFromFile<typeof founderActivityTrackerReaction>(
     "./founder-activity-tracker.reaction.ts"
   ),
-  prompt:
-    "You are a venture capital analyst tracking the public activity of startup founders in your portfolio.\n\nThe founders are the entities bound to this Behavior — the payload's `entities` array lists each founder's name, type, and ID. Their recent public activity arrives in the payload's `founder_posts` source.\n\nProduce a structured founder activity report:\n1. **Executive Summary**: 2-3 sentence overview of founder activity and signals.\n2. **Per-Founder Analysis**: For each active founder, summarize their messaging themes, engagement level, and signals about company direction.\n3. **Cross-Portfolio Patterns**: Themes multiple founders discuss.\n4. **Notable Signals**: Flag potential announcements, strategic shifts, or concerns.\n\nBe specific and cite actual tweets/posts as evidence.\n",
+  skills: ["founder-activity-tracker"],
   sources: {
     founder_posts:
       "SELECT id, title, payload_text, author_name, source_url, occurred_at, score, origin_type, connector_key FROM events WHERE connector_key IN ('x') AND origin_type IN ('tweet', 'reply') ORDER BY occurred_at DESC LIMIT 300\n",
@@ -481,8 +494,7 @@ const opportunityMatcher = defineBehavior({
   notification: { priority: "normal" },
   tags: ["vc", "matching"],
   minCooldownSeconds: 600,
-  prompt:
-    "You are a community intelligence agent for a private founder community managed by a venture capital fund.\nYour job is to monitor founder activity and identify high-quality introduction opportunities between portfolio founders.\n\nThe community members are the entities bound to this Behavior — the payload's `entities` array carries each member's name, type, and metadata (title, role). Their recent activity arrives in the payload's `content` source.\n\n## Instructions\n1. Scan all new content for signals: launches, posts, hiring announcements, funding news, project updates, and collaboration signals.\n2. For each signal, identify which other community founders are likely to care and explain why.\n3. Suggest a concrete action: warm intro draft, shared-interest notification, or flagging for community ops review.\n4. Only suggest introductions where there is a clear, specific overlap — not generic \"both work in tech\" matches.\n5. Rate each signal's strength (high/medium/low) based on timeliness and relevance.\n",
+  skills: ["opportunity-matcher"],
   sources: {
     content:
       "SELECT id, title, payload_text, author_name, source_url, occurred_at, score, origin_type, connector_key FROM events WHERE entity_id IN (SELECT id FROM entities WHERE entity_type = 'founder') ORDER BY occurred_at DESC LIMIT 300\n",

--- a/examples/office-bot/lobu.config.ts
+++ b/examples/office-bot/lobu.config.ts
@@ -2,6 +2,7 @@ import {
   connectorFromFile,
   defineAgent,
   defineConfig,
+  defineSkill,
   defineConnection,
   defineEntityType,
   defineBehavior,
@@ -12,13 +13,29 @@ import {
 import type DeliverooConnector from "./deliveroo.connector.ts";
 import type lunchDeliverooReaction from "./lunch-deliveroo.reaction.ts";
 
+const lunchOpenSkill = defineSkill({
+  name: "lunch-open",
+  content:
+    "Open today's office lunch run (step 1 in your instructions):\n\n1. Check memory for a `lunch-run` entity dated today — if one exists and isn't\n   cancelled, stop (don't open a second one).\n2. Guess who's in from recent chat activity and past `lunch-run` entities.\n3. Post the lunch call in the channel: react 🍕 / \"+1\" to join, drop restaurant\n   recommendations, options coming ~11:35, targeting ~12:30 delivery. @-mention\n   the people you think are in, but make clear anyone can join or skip.\n4. Open a thread off that message.\n5. Save a `lunch-run` entity {date, channel, status: \"collecting\", thread_ref,\n   restaurant: null, items: []} and a `lunch:opened` event linked to it.\n\nThen end — the lunch-finalize Behavior takes it from here. Keep it to one short\nmessage in the channel.\n",
+});
+
+const lunchFinalizeSkill = defineSkill({
+  name: "lunch-finalize",
+  content:
+    'Finalize today\'s office lunch run (step 2 in your instructions):\n\n1. Find today\'s `lunch-run` entity (status "collecting"). If there isn\'t one,\n   open one (step 1) and stop. If it\'s already "done"/"cancelled", do nothing.\n2. Read the run\'s thread — work out who\'s in (🍕 / "+1" / put in an order) and\n   any restaurant recommendations. If nobody\'s in: post a "skipping today 👋"\n   note, set the run to "cancelled", save a `lunch:cancelled` event, stop.\n3. Pick the restaurant (a clear thread recommendation, else a usual spot from\n   USER.md, biased away from the last couple of runs).\n4. Post the call for orders: name the restaurant and its Deliveroo page. You do\n   NOT scrape the menu yourself — a live menu shortlist with real prices is\n   fetched and posted automatically right after this turn (the deliveroo\n   connector reads it via the office\'s Owletto extension). Just set `restaurant`\n   so that reaction knows which one. Always accept free-text orders.\n5. Collect orders from replies + number reactions into items: [{person, item,\n   price?, notes}]. Ask directly about anything ambiguous — don\'t guess silently.\n6. Post the summary in the thread: restaurant; per-person list (@person — item\n   (notes)); subtotal + per-head (flag if well over budget); and the next action\n   — "@here someone place + pay on Deliveroo: <link>". The live menu + order link\n   arrive from the reaction; you never build a basket, log in, or touch payment.\n7. Update the `lunch-run` entity (status "done", restaurant, items, subtotal)\n   and save a `lunch:placed` event linked to it. Outcome is "manual" — a human\n   places + pays on Deliveroo.\n\nNever complete checkout or pay. A run is a success once the order list is\ncollected and handed off cleanly.\n',
+});
+
 const foodOrdering = defineAgent({
   id: "food-ordering",
   name: "food-ordering",
   description:
     "Runs the office lunch order — presence check, recommendations, options poll, order collection, Deliveroo basket handoff",
   dir: ".",
-  skills: [skillFromFile("./skills/deliveroo-order")],
+  skills: [
+    skillFromFile("./skills/deliveroo-order"),
+    lunchOpenSkill,
+    lunchFinalizeSkill,
+  ],
   providers: [
     {
       id: "z-ai",
@@ -130,8 +147,7 @@ const lunchOpen = defineBehavior({
   notification: { priority: "high", channel: "both" },
   tags: ["lunch", "daily"],
   minCooldownSeconds: 600,
-  prompt:
-    "Open today's office lunch run (step 1 in your instructions):\n\n1. Check memory for a `lunch-run` entity dated today — if one exists and isn't\n   cancelled, stop (don't open a second one).\n2. Guess who's in from recent chat activity and past `lunch-run` entities.\n3. Post the lunch call in the channel: react 🍕 / \"+1\" to join, drop restaurant\n   recommendations, options coming ~11:35, targeting ~12:30 delivery. @-mention\n   the people you think are in, but make clear anyone can join or skip.\n4. Open a thread off that message.\n5. Save a `lunch-run` entity {date, channel, status: \"collecting\", thread_ref,\n   restaurant: null, items: []} and a `lunch:opened` event linked to it.\n\nThen end — the lunch-finalize Behavior takes it from here. Keep it to one short\nmessage in the channel.\n",
+  skills: ["lunch-open"],
   // No inline schema: the run's state lives on the `lunch-run` entity (created
   // above) — the one source of truth, editable + correctable like any entity.
 });
@@ -149,8 +165,7 @@ const lunchFinalize = defineBehavior({
   ),
   reactionsGuidance:
     "When the run ends in `placed` or `manual`, store the per-head cost back into a\n`lunch:placed` event on the lunch-run entity so the next day's lunch-open can\nread the most-recent restaurant.\n",
-  prompt:
-    'Finalize today\'s office lunch run (step 2 in your instructions):\n\n1. Find today\'s `lunch-run` entity (status "collecting"). If there isn\'t one,\n   open one (step 1) and stop. If it\'s already "done"/"cancelled", do nothing.\n2. Read the run\'s thread — work out who\'s in (🍕 / "+1" / put in an order) and\n   any restaurant recommendations. If nobody\'s in: post a "skipping today 👋"\n   note, set the run to "cancelled", save a `lunch:cancelled` event, stop.\n3. Pick the restaurant (a clear thread recommendation, else a usual spot from\n   USER.md, biased away from the last couple of runs).\n4. Post the call for orders: name the restaurant and its Deliveroo page. You do\n   NOT scrape the menu yourself — a live menu shortlist with real prices is\n   fetched and posted automatically right after this turn (the deliveroo\n   connector reads it via the office\'s Owletto extension). Just set `restaurant`\n   so that reaction knows which one. Always accept free-text orders.\n5. Collect orders from replies + number reactions into items: [{person, item,\n   price?, notes}]. Ask directly about anything ambiguous — don\'t guess silently.\n6. Post the summary in the thread: restaurant; per-person list (@person — item\n   (notes)); subtotal + per-head (flag if well over budget); and the next action\n   — "@here someone place + pay on Deliveroo: <link>". The live menu + order link\n   arrive from the reaction; you never build a basket, log in, or touch payment.\n7. Update the `lunch-run` entity (status "done", restaurant, items, subtotal)\n   and save a `lunch:placed` event linked to it. Outcome is "manual" — a human\n   places + pays on Deliveroo.\n\nNever complete checkout or pay. A run is a success once the order list is\ncollected and handed off cleanly.\n',
+  skills: ["lunch-finalize"],
   // No inline schema: the reaction reads the run's outcome straight off the
   // `lunch-run` entity this prompt updates (status "done" + restaurant), so the
   // handoff contract is the entity, not a Behavior-authored payload.

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -3,6 +3,7 @@ import {
   defineAgent,
   defineBehavior,
   defineConfig,
+  defineSkill,
   defineConnection,
   defineEntityType,
   defineRelationshipType,
@@ -16,8 +17,24 @@ import type TwitterTakeoutConnector from "./twitter-takeout.connector.ts";
 import type WhatsAppCloudConnector from "./whatsapp.cloud.connector.ts";
 import type MidasConnector from "./midas.connector.ts";
 
+const hourlyTaskCollaboratorSkill = defineSkill({
+  name: "hourly-task-collaborator",
+  content:
+    "Review the current hourly window's content and the collaborative task list in the payload's task_list source. The task_list source includes recently closed tasks (metadata status done or dismissed) for reference so you know what is already finished. Return a JSON object with a tasks array matching the provided task schema. Extract only concrete actions Burak or his personal agent should take; ignore advertisements, newsletters, automated notices, passive information, and vague ideas. Use concise imperative wording in action so equivalent requests deduplicate across runs. Preserve existing tasks instead of restating them. Never re-emit, reopen, or recreate any task whose status is done or dismissed in the task list, even if the originating message still appears in recent signals. Set status to backlog unless there is clear evidence work has started. Assign owner \"Burak\" unless the action can be safely completed by the personal agent. Use ISO-8601 due_date only when a real deadline is present. Include source_event_id and source when available, and a short rationale. Produce at most 12 tasks, ordered by priority.",
+});
+
+const duplicateEntityResolutionRealV3FinalSkill = defineSkill({
+  name: "duplicate-entity-resolution-real-v3-final",
+  content:
+    "Review every row in sources.people. Explain likely duplicate groups in analysis_summary and put name-only, alias-only, handle-only, oversized, or otherwise uncertain groups in uncertain_groups with why. Do not call entity tools or emit backlog tasks. After analysis, the deterministic reaction submits only candidate IDs to the server. The person entity type's x-lobu-resolution policy decides which normalized identities auto-merge and which require human review. Without that extension, normalized email and phone matches remain review-only and never auto-merge.\n",
+});
+
 const personalAgent = defineAgent({
   id: "personal-agent",
+  skills: [
+    hourlyTaskCollaboratorSkill,
+    duplicateEntityResolutionRealV3FinalSkill,
+  ],
   dir: ".",
   name: "personal-agent",
   description:
@@ -933,8 +950,7 @@ const hourlyTaskCollaborator = defineBehavior({
         "SELECT NULL::bigint AS id, t.name, t.metadata, t.updated_at FROM entities t WHERE t.entity_type = 'task' AND t.deleted_at IS NULL AND (COALESCE(t.metadata->>'status', 'backlog') NOT IN ('done', 'dismissed') OR t.updated_at > now() - interval '14 days') ORDER BY t.updated_at DESC LIMIT 100",
     },
   },
-  prompt:
-    "Review the current hourly window's content and the collaborative task list in the payload's task_list source. The task_list source includes recently closed tasks (metadata status done or dismissed) for reference so you know what is already finished. Return a JSON object with a tasks array matching the provided task schema. Extract only concrete actions Burak or his personal agent should take; ignore advertisements, newsletters, automated notices, passive information, and vague ideas. Use concise imperative wording in action so equivalent requests deduplicate across runs. Preserve existing tasks instead of restating them. Never re-emit, reopen, or recreate any task whose status is done or dismissed in the task list, even if the originating message still appears in recent signals. Set status to backlog unless there is clear evidence work has started. Assign owner \"Burak\" unless the action can be safely completed by the personal agent. Use ISO-8601 due_date only when a real deadline is present. Include source_event_id and source when available, and a short rationale. Produce at most 12 tasks, ordered by priority.",
+  skills: ["hourly-task-collaborator"],
 });
 
 const duplicateEntityResolution = defineBehavior({
@@ -953,8 +969,7 @@ const duplicateEntityResolution = defineBehavior({
   },
   reactionsGuidance:
     "Explain uncertainty; never decide identity from names, aliases, or handles. The server-side entity type policy is the only merge authority.",
-  prompt:
-    "Review every row in sources.people. Explain likely duplicate groups in analysis_summary and put name-only, alias-only, handle-only, oversized, or otherwise uncertain groups in uncertain_groups with why. Do not call entity tools or emit backlog tasks. After analysis, the deterministic reaction submits only candidate IDs to the server. The person entity type's x-lobu-resolution policy decides which normalized identities auto-merge and which require human review. Without that extension, normalized email and phone matches remain review-only and never auto-merge.\n",
+  skills: ["duplicate-entity-resolution-real-v3-final"],
 });
 
 export default defineConfig({

--- a/examples/personal-finance/lobu.config.ts
+++ b/examples/personal-finance/lobu.config.ts
@@ -1,14 +1,28 @@
 import {
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineRelationshipType,
   defineBehavior,
   secret,
 } from "@lobu/cli/config";
 
+const gmailTxSkill = defineSkill({
+  name: "gmail-tx",
+  content:
+    'You are a private financial accountant scanning the user\'s forwarded Gmail messages for events that matter to a UK Self Assessment return.\n\nThe emails to scan arrive in the payload\'s `gmail_messages` source (an empty source means no new messages this window). The active tax year, when one is bound, appears in the payload\'s `entities` array.\n\nIdentify and extract financial events. Each email may yield zero, one, or many events. Be conservative: skip noise (marketing, password resets, etc.).\n\nCategories to extract:\n- **transactions** — deposits, debits, transfers, salary credits, dividend payments hitting an account\n- **cgt_events** — broker contract notes for sells/disposals, gifts, transfers out of a GIA\n- **dividends** — UK or foreign dividend notifications (gross + currency)\n- **documents** — P60/P45/P11D/SA302/contract notes/mortgage statements arriving as attachments or linked PDFs\n\nFor each item, set `gmail_message_id` to the `id` value of the `gmail_messages` row it came from — that column is the provider message ID. Never invent or omit it; if you cannot attribute an item to a specific row, drop the item. Prefer GBP unless the message clearly states a different currency.\n\nSkip transactions inside ISAs and SIPPs unless they are dividends or contributions (which are still reportable). Mark `tax_relevance="none"` for ISA-internal transactions; mark `tax_relevance="cgt"` for non-wrapper disposals.\n',
+});
+
+const netWorthSkill = defineSkill({
+  name: "net-worth",
+  content:
+    "You are a wealth manager tracking the user's global net worth.\n\nAccount activity arrives in the payload's `revolut_events` and `midas_events` sources; either may be empty when a provider has no new data.\n\nExtract the latest known balance for each unique account or asset. For Revolut, create/update `account` entities (setting `provider` to \"Revolut\" and updating `current_amount`). For Midas, create/update `holding` entities (setting `ticker`, `quantity`, and `avg_cost` based on the price).",
+});
+
 const personal_finance = defineAgent({
   id: "personal-finance",
+  skills: [gmailTxSkill, netWorthSkill],
   dir: ".",
   name: "personal-finance",
   description:
@@ -1127,8 +1141,7 @@ const gmailTxBehavior = defineBehavior({
     gmail_messages:
       "SELECT id, title, payload_text, payload_html, occurred_at FROM events WHERE connector_key = 'google.gmail' ORDER BY occurred_at DESC LIMIT 200\n",
   },
-  prompt:
-    'You are a private financial accountant scanning the user\'s forwarded Gmail messages for events that matter to a UK Self Assessment return.\n\nThe emails to scan arrive in the payload\'s `gmail_messages` source (an empty source means no new messages this window). The active tax year, when one is bound, appears in the payload\'s `entities` array.\n\nIdentify and extract financial events. Each email may yield zero, one, or many events. Be conservative: skip noise (marketing, password resets, etc.).\n\nCategories to extract:\n- **transactions** — deposits, debits, transfers, salary credits, dividend payments hitting an account\n- **cgt_events** — broker contract notes for sells/disposals, gifts, transfers out of a GIA\n- **dividends** — UK or foreign dividend notifications (gross + currency)\n- **documents** — P60/P45/P11D/SA302/contract notes/mortgage statements arriving as attachments or linked PDFs\n\nFor each item, set `gmail_message_id` to the `id` value of the `gmail_messages` row it came from — that column is the provider message ID. Never invent or omit it; if you cannot attribute an item to a specific row, drop the item. Prefer GBP unless the message clearly states a different currency.\n\nSkip transactions inside ISAs and SIPPs unless they are dividends or contributions (which are still reportable). Mark `tax_relevance="none"` for ISA-internal transactions; mark `tax_relevance="cgt"` for non-wrapper disposals.\n',
+  skills: ["gmail-tx"],
 });
 
 const netWorthBehavior = defineBehavior({
@@ -1147,8 +1160,7 @@ const netWorthBehavior = defineBehavior({
     midas_events:
       "SELECT metadata, occurred_at FROM events WHERE connector_key = 'midas' ORDER BY occurred_at DESC LIMIT 50\n",
   },
-  prompt:
-    "You are a wealth manager tracking the user's global net worth.\n\nAccount activity arrives in the payload's `revolut_events` and `midas_events` sources; either may be empty when a provider has no new data.\n\nExtract the latest known balance for each unique account or asset. For Revolut, create/update `account` entities (setting `provider` to \"Revolut\" and updating `current_amount`). For Midas, create/update `holding` entities (setting `ticker`, `quantity`, and `avg_cost` based on the price).",
+  skills: ["net-worth"],
 });
 
 export default defineConfig({

--- a/examples/sales/lobu.config.ts
+++ b/examples/sales/lobu.config.ts
@@ -2,6 +2,7 @@ import {
   connectorFromFile,
   defineAgent,
   defineConfig,
+  defineSkill,
   defineEntityType,
   defineRelationshipType,
   defineBehavior,
@@ -11,8 +12,15 @@ import {
 import type SalesforcePipelineConnector from "./salesforce-pipeline.connector.ts";
 import type accountHealthMonitorReaction from "./account-health-monitor.reaction.ts";
 
+const accountHealthMonitorSkill = defineSkill({
+  name: "account-health-monitor",
+  content:
+    "Poll CRM data for tracked accounts. Track expansion progress, risk level changes, and renewal timeline.\n",
+});
+
 const sales = defineAgent({
   id: "sales",
+  skills: [accountHealthMonitorSkill],
   name: "sales",
   description:
     "Help revenue teams track account health, rollout progress, and renewal signals",
@@ -193,8 +201,7 @@ const accountHealthMonitor = defineBehavior({
   reaction: reactionFromFile<typeof accountHealthMonitorReaction>(
     "./account-health-monitor.reaction.ts"
   ),
-  prompt:
-    "Poll CRM data for tracked accounts. Track expansion progress, risk level changes, and renewal timeline.\n",
+  skills: ["account-health-monitor"],
 });
 
 export default defineConfig({

--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd-dryrun.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd-dryrun.test.ts
@@ -209,7 +209,6 @@ export default defineConfig({
   behaviors: [defineBehavior({
     agent,
     slug: "review-pr",
-    prompt: "Review it",
     triggers: [{
       kind: "event",
       connector_key: "github",

--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -262,6 +262,82 @@ describe("executePlan — BYO chat connection dependencies", () => {
   });
 });
 
+describe("executePlan — atomic Behavior triggers+prompt update", () => {
+  test("sends simultaneous prompt+trigger drift through createBehaviorVersion only", async () => {
+    const desired = {
+      slug: "digest",
+      agent: "triage",
+      prompt: "Now scheduled digest instructions.",
+      triggers: [{ kind: "schedule" as const, cron: "0 9 * * *" }],
+    };
+    const state = stateWith({
+      definitions: [],
+      authProfiles: [],
+      connections: [],
+    });
+    state.watchers = [desired];
+    const plan: DiffPlan = {
+      rows: [
+        {
+          kind: "watcher",
+          verb: "update",
+          id: desired.slug,
+          desired,
+          changedFields: ["triggers", "prompt"],
+          versionBoundFields: ["prompt"],
+        },
+      ],
+      counts: { create: 0, update: 1, noop: 0, drift: 0, delete: 0 },
+      notes: [],
+    };
+    const remote: RemoteSnapshot = {
+      agents: [],
+      agentSettings: new Map(),
+      entityTypes: [],
+      relationshipTypes: [],
+      watchers: [
+        {
+          slug: "digest",
+          behavior_id: "42",
+          agent_id: "triage",
+          prompt: "",
+          triggers: [
+            {
+              kind: "event",
+              connector_key: "slack",
+              event_types: ["message.created"],
+              execution: "turn",
+            },
+          ],
+        },
+      ],
+      connectorDefinitions: [],
+      authProfiles: [],
+      connections: [],
+      feedsByConnectionId: new Map(),
+      inferenceProviders: [],
+    };
+    const updateBehavior = mock(async () => ({}));
+    const createBehaviorVersion = mock(async () => ({ version: 2 }));
+    const client = {
+      updateBehavior,
+      createBehaviorVersion,
+    } as unknown as ApplyClient;
+
+    await executePlan({ client, state, plan, remote }, []);
+
+    // Must not split triggers onto update (would fail the instruction rule
+    // against the empty current prompt before create_version lands).
+    expect(updateBehavior).not.toHaveBeenCalled();
+    expect(createBehaviorVersion).toHaveBeenCalledTimes(1);
+    expect(createBehaviorVersion.mock.calls[0]?.[0]).toMatchObject({
+      behavior_id: "42",
+      prompt: "Now scheduled digest instructions.",
+      triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+    });
+  });
+});
+
 describe("normalizeConnectionConfigScope — feed-scoped keys demote to feeds", () => {
   // A connector whose `search_query`/`lookback_days` are feed-scoped (declared
   // on the `stories` feed), with one genuinely connection-scoped key (`region`).

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -438,12 +438,15 @@ describe("apply diff — watchers", () => {
           defineBehavior({
             agent,
             slug: "minimal-schedule",
-            prompt: "Produce a digest.",
+            skills: ["digest"],
             triggers: [{ kind: "schedule", cron: "0 9 * * 1" }],
           }),
         ],
       })
     );
+    // The loader compiles skills[] into prompt before diffing; this test maps
+    // directly, so stand in for the compile step.
+    if (desired.watchers[0]) desired.watchers[0].prompt = "Produce a digest.";
     const remote: RemoteSnapshot = {
       ...emptyRemote(),
       agents: [{ agentId: "triage", name: "triage" }],

--- a/packages/cli/src/commands/_lib/apply/__tests__/load-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/load-config.test.ts
@@ -369,12 +369,12 @@ describe("loadDesiredStateFromConfig", () => {
     writeFileSync(
       join(dir, "lobu.config.ts"),
       [
-        `import { defineAgent, defineConfig, defineBehavior, reactionFromFile } from "@lobu/cli/config";`,
-        `const crm = defineAgent({ id: "crm" });`,
+        `import { defineAgent, defineConfig, defineBehavior, defineSkill, reactionFromFile } from "@lobu/cli/config";`,
+        `const crm = defineAgent({ id: "crm", skills: [defineSkill({ name: "s", content: "p" })] });`,
         `export default defineConfig({`,
         `  agents: [crm],`,
         `  behaviors: [defineBehavior({`,
-        `    agent: crm, slug: "health", prompt: "p",`,
+        `    agent: crm, slug: "health", skills: ["s"],`,
         `    reaction: reactionFromFile("./reactions/health.reaction.ts"),`,
         `  })],`,
         `});`,
@@ -394,10 +394,10 @@ describe("loadDesiredStateFromConfig", () => {
       writeFileSync(
         join(dir, "lobu.config.ts"),
         [
-          `import { defineAgent, defineConfig, defineBehavior, reactionFromFile } from "@lobu/cli/config";`,
-          `const crm = defineAgent({ id: "crm" });`,
+          `import { defineAgent, defineConfig, defineBehavior, defineSkill, reactionFromFile } from "@lobu/cli/config";`,
+          `const crm = defineAgent({ id: "crm", skills: [defineSkill({ name: "s", content: "p" })] });`,
           `export default defineConfig({ agents: [crm], behaviors: [defineBehavior({`,
-          `  agent: crm, slug: "w", prompt: "p", reaction: reactionFromFile(${JSON.stringify(reaction)}),`,
+          `  agent: crm, slug: "w", skills: ["s"], reaction: reactionFromFile(${JSON.stringify(reaction)}),`,
           `})] });`,
           ``,
         ].join("\n")
@@ -429,10 +429,10 @@ describe("loadDesiredStateFromConfig", () => {
     writeFileSync(
       join(dir, "lobu.config.ts"),
       [
-        `import { defineAgent, defineConfig, defineBehavior } from "@lobu/cli/config";`,
-        `const crm = defineAgent({ id: "crm" });`,
+        `import { defineAgent, defineConfig, defineBehavior, defineSkill } from "@lobu/cli/config";`,
+        `const crm = defineAgent({ id: "crm", skills: [defineSkill({ name: "s", content: "p" })] });`,
         `export default defineConfig({ agents: [crm], behaviors: [defineBehavior({`,
-        `  agent: crm, slug: "w", prompt: "p", reaction: "./reactions/x.reaction.ts",`,
+        `  agent: crm, slug: "w", skills: ["s"], reaction: "./reactions/x.reaction.ts",`,
         `})] });`,
         ``,
       ].join("\n")
@@ -452,11 +452,11 @@ describe("loadDesiredStateFromConfig", () => {
     writeFileSync(
       join(dir, "lobu.config.ts"),
       [
-        `import { defineAgent, defineConfig, defineBehavior, reactionFromFile } from "@lobu/cli/config";`,
-        `const a = defineAgent({ id: "a" });`,
+        `import { defineAgent, defineConfig, defineBehavior, defineSkill, reactionFromFile } from "@lobu/cli/config";`,
+        `const a = defineAgent({ id: "a", skills: [defineSkill({ name: "s", content: "p" })] });`,
         `export default defineConfig({ agents: [a], behaviors: [`,
-        `  defineBehavior({ agent: a, slug: "first", prompt: "p" }),`,
-        `  defineBehavior({ agent: a, slug: "second", prompt: "p", reaction: reactionFromFile("./reactions/second.reaction.ts") }),`,
+        `  defineBehavior({ agent: a, slug: "first", skills: ["s"] }),`,
+        `  defineBehavior({ agent: a, slug: "second", skills: ["s"], reaction: reactionFromFile("./reactions/second.reaction.ts") }),`,
         `] });`,
         ``,
       ].join("\n")
@@ -468,6 +468,72 @@ describe("loadDesiredStateFromConfig", () => {
     expect(state.watchers[1]?.slug).toBe("second");
     expect(state.watchers[1]?.reactionScript?.sourcePath).toContain(
       "second.reaction.ts"
+    );
+  });
+
+  test("compiles Behavior skills[] into prompt: ordered join, content-only", async () => {
+    dir = mkdtempSync(join(import.meta.dir, "compile-"));
+    writeFileSync(
+      join(dir, "lobu.config.ts"),
+      [
+        `import { defineAgent, defineConfig, defineBehavior, defineSkill } from "@lobu/cli/config";`,
+        `const a = defineAgent({ id: "a", skills: [`,
+        `  defineSkill({ name: "triage", description: "d1", content: "Triage rules." }),`,
+        `  defineSkill({ name: "style", description: "d2", content: "Style rules." }),`,
+        `] });`,
+        `export default defineConfig({ agents: [a], behaviors: [`,
+        `  defineBehavior({ agent: a, slug: "w", skills: ["style", "triage"] }),`,
+        `] });`,
+        ``,
+      ].join("\n")
+    );
+    const { state } = await loadDesiredStateFromConfig({ cwd: dir });
+    // Join follows the Behavior's order, not the library's; descriptions do
+    // not compile (a description-only skill edit must not churn versions).
+    expect(state.watchers[0]?.prompt).toBe("Style rules.\n\nTriage rules.");
+  });
+
+  test("rejects a Behavior skill that is missing or has an empty body", async () => {
+    const write = (skills: string, behaviorSkills: string) => {
+      dir = mkdtempSync(join(import.meta.dir, "badskill-"));
+      writeFileSync(
+        join(dir, "lobu.config.ts"),
+        [
+          `import { defineAgent, defineConfig, defineBehavior, defineSkill } from "@lobu/cli/config";`,
+          `const a = defineAgent({ id: "a", skills: [${skills}] });`,
+          `export default defineConfig({ agents: [a], behaviors: [`,
+          `  defineBehavior({ agent: a, slug: "w", skills: [${behaviorSkills}] }),`,
+          `] });`,
+          ``,
+        ].join("\n")
+      );
+      return loadDesiredStateFromConfig({ cwd: dir });
+    };
+    await expect(
+      write(`defineSkill({ name: "real", content: "x" })`, `"ghost"`)
+    ).rejects.toThrow(/no skill with that name/);
+    rmSync(dir, { recursive: true, force: true });
+    await expect(
+      write(`defineSkill({ name: "empty", content: "  " })`, `"empty"`)
+    ).rejects.toThrow(/body is empty/);
+  });
+
+  test("rejects compiled instructions over the 32KB cap", async () => {
+    dir = mkdtempSync(join(import.meta.dir, "cap-"));
+    writeFileSync(
+      join(dir, "lobu.config.ts"),
+      [
+        `import { defineAgent, defineConfig, defineBehavior, defineSkill } from "@lobu/cli/config";`,
+        `const big = "x".repeat(33 * 1024);`,
+        `const a = defineAgent({ id: "a", skills: [defineSkill({ name: "big", content: big })] });`,
+        `export default defineConfig({ agents: [a], behaviors: [`,
+        `  defineBehavior({ agent: a, slug: "w", skills: ["big"] }),`,
+        `] });`,
+        ``,
+      ].join("\n")
+    );
+    await expect(loadDesiredStateFromConfig({ cwd: dir })).rejects.toThrow(
+      /maximum is 32768/
     );
   });
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -152,12 +152,12 @@ describe("mapProjectToDesiredState", () => {
     const w1 = defineBehavior({
       slug: "w",
       agent: a,
-      prompt: "p",
+      skills: ["s"],
     });
     const w2 = defineBehavior({
       slug: "w",
       agent: a,
-      prompt: "p",
+      skills: ["s"],
     });
     expect(() =>
       mapProjectToDesiredState(
@@ -466,7 +466,7 @@ describe("mapProjectToDesiredState", () => {
     const watcher = defineBehavior({
       agent: crm,
       slug: "health",
-      prompt: "assess",
+      skills: ["s"],
       sources: {
         accounts: "SELECT 1",
         ctx: { query: "SELECT 2", context: true },
@@ -537,7 +537,6 @@ describe("mapProjectToDesiredState", () => {
       defineBehavior({
         agent: crm,
         slug: "review-pr",
-        prompt: "Review it",
         triggers: [
           {
             kind: "event",
@@ -582,7 +581,6 @@ describe("mapProjectToDesiredState", () => {
             defineBehavior({
               agent: crm,
               slug: "review-pr",
-              prompt: "Review it",
               triggers: [
                 {
                   kind: "event",
@@ -607,7 +605,7 @@ describe("mapProjectToDesiredState", () => {
     const watcher = defineBehavior({
       agent: crm,
       slug: "w",
-      prompt: "p",
+      skills: ["s"],
       reactionsGuidance: "Notify the account owner.",
       agentKind: "notifier",
     });
@@ -623,7 +621,7 @@ describe("mapProjectToDesiredState", () => {
     const watcher = defineBehavior({
       agent: crm,
       slug: "pricing",
-      prompt: "extract",
+      skills: ["s"],
       keyingConfig: {
         entityType: "price",
         entityPath: "prices",
@@ -648,7 +646,7 @@ describe("mapProjectToDesiredState", () => {
     const watcher = defineBehavior({
       agent: "ghost",
       slug: "x",
-      prompt: "p",
+      skills: ["s"],
     });
     expect(() =>
       mapProjectToDesiredState(
@@ -778,7 +776,7 @@ describe("mapProjectToDesiredState", () => {
     const watcher = defineBehavior({
       agent: crm,
       slug: "w",
-      prompt: "p",
+      skills: ["s"],
       triggers: [{ kind: "schedule", cron: "not-a-cron" }],
     });
     expect(() =>
@@ -793,7 +791,7 @@ describe("mapProjectToDesiredState", () => {
     const watcher = defineBehavior({
       agent: crm,
       slug: "w",
-      prompt: "p",
+      skills: ["s"],
       triggers: [{ kind: "schedule", cron: "*/30 * * * * *" }],
     });
     expect(() =>
@@ -808,7 +806,7 @@ describe("mapProjectToDesiredState", () => {
     const behavior = defineBehavior({
       agent: crm,
       slug: "w",
-      prompt: "p",
+      skills: ["s"],
       triggers: [
         { kind: "schedule", cron: "0 8 * * *" },
         { kind: "schedule", cron: "0 9 * * *" },
@@ -819,6 +817,94 @@ describe("mapProjectToDesiredState", () => {
         defineConfig({ agents: [crm], behaviors: [behavior] })
       )
     ).toThrow(/more than one schedule trigger/i);
+  });
+
+  test("requires >=1 skill for schedule, window-event, and manual Behaviors", () => {
+    const crm = defineAgent({ id: "crm" });
+    const map = (behavior: ReturnType<typeof defineBehavior>) => () =>
+      mapProjectToDesiredState(
+        defineConfig({ agents: [crm], behaviors: [behavior] })
+      );
+    // Schedule trigger, no skills → rejected.
+    expect(
+      map(
+        defineBehavior({
+          agent: crm,
+          slug: "sched",
+          triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+        })
+      )
+    ).toThrow(/needs at least one skill/i);
+    // Event trigger with execution "window", no skills → rejected.
+    expect(
+      map(
+        defineBehavior({
+          agent: crm,
+          slug: "win",
+          triggers: [
+            {
+              kind: "event",
+              connector_key: "github",
+              event_types: ["pull_request.created"],
+              execution: "window",
+            },
+          ],
+        })
+      )
+    ).toThrow(/needs at least one skill/i);
+    // No triggers (manual-only), no skills → rejected.
+    expect(map(defineBehavior({ agent: crm, slug: "manual" }))).toThrow(
+      /needs at least one skill/i
+    );
+  });
+
+  test("event-turn Behaviors may omit skills; mapper carries skills + empty prompt", () => {
+    const crm = defineAgent({ id: "crm" });
+    const listen = defineBehavior({
+      agent: crm,
+      slug: "listen",
+      triggers: [
+        {
+          kind: "event",
+          connector_key: "slack",
+          event_types: ["message.created"],
+          // execution omitted → defaults to "turn"
+        },
+      ],
+    });
+    const packs = defineBehavior({
+      agent: crm,
+      slug: "packs",
+      skills: ["triage", "sql-style"],
+      triggers: [
+        {
+          kind: "event",
+          connector_key: "slack",
+          event_types: ["message.created"],
+          execution: "turn",
+        },
+      ],
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ agents: [crm], behaviors: [listen, packs] })
+    );
+    // The mapper cannot read skill files — prompt is compiled by the loader.
+    expect(state.watchers[0]?.prompt).toBe("");
+    expect(state.watchers[0]?.skills).toBeUndefined();
+    expect(state.watchers[1]?.skills).toEqual(["triage", "sql-style"]);
+  });
+
+  test("rejects duplicate and over-cap Behavior skills", () => {
+    const crm = defineAgent({ id: "crm" });
+    const map = (skills: string[]) => () =>
+      mapProjectToDesiredState(
+        defineConfig({
+          agents: [crm],
+          behaviors: [defineBehavior({ agent: crm, slug: "w", skills })],
+        })
+      );
+    expect(map(["a", "b", "a"])).toThrow(/duplicate skill/i);
+    expect(map(["a", "b", "c", "d", "e", "f"])).toThrow(/maximum is 5/i);
   });
 
   test("rejects credentials on an interactive auth profile", () => {
@@ -920,7 +1006,6 @@ describe("mapProjectToDesiredState", () => {
     const behavior = defineBehavior({
       agent: crm,
       slug: "review-pr",
-      prompt: "Review it",
       triggers: [
         {
           kind: "event",
@@ -950,7 +1035,6 @@ describe("mapProjectToDesiredState", () => {
     const behavior = defineBehavior({
       agent: crm,
       slug: "review-pr",
-      prompt: "Review it",
       triggers: [
         {
           kind: "event",

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -881,38 +881,47 @@ export async function executePlan(
         const scalarChanges = [...changed].filter(
           (f) => !versionBound.has(f) && f !== "reaction_script"
         );
+        // When triggers and compiled instructions both change, send them
+        // together through create_version so the server validates the final
+        // pair atomically. A separate update(triggers) would reject
+        // event-turn → schedule mid-apply (empty current prompt + new shape).
+        const triggersWithPrompt =
+          scalarChanges.includes("triggers") && versionBound.has("prompt");
+        const scalarForUpdate = triggersWithPrompt
+          ? scalarChanges.filter((f) => f !== "triggers")
+          : scalarChanges;
         // a) Scalar fields → manage_behaviors update
-        if (scalarChanges.length > 0) {
+        if (scalarForUpdate.length > 0) {
           await ctx.client.updateBehavior({
             behavior_id: watcherId,
-            ...(scalarChanges.includes("triggers")
+            ...(scalarForUpdate.includes("triggers")
               ? { triggers: w.triggers ?? [] }
               : {}),
-            ...(scalarChanges.includes("agent_id")
+            ...(scalarForUpdate.includes("agent_id")
               ? { agent_id: w.agent }
               : {}),
-            ...(scalarChanges.includes("device_worker_id")
+            ...(scalarForUpdate.includes("device_worker_id")
               ? { device_worker_id: w.deviceWorkerId ?? null }
               : {}),
-            ...(scalarChanges.includes("scheduler_client_id")
+            ...(scalarForUpdate.includes("scheduler_client_id")
               ? { scheduler_client_id: w.schedulerClientId ?? null }
               : {}),
-            ...(scalarChanges.includes("notification_channel") &&
+            ...(scalarForUpdate.includes("notification_channel") &&
             w.notificationChannel
               ? { notification_channel: w.notificationChannel }
               : {}),
-            ...(scalarChanges.includes("notification_priority") &&
+            ...(scalarForUpdate.includes("notification_priority") &&
             w.notificationPriority
               ? { notification_priority: w.notificationPriority }
               : {}),
-            ...(scalarChanges.includes("min_cooldown_seconds") &&
+            ...(scalarForUpdate.includes("min_cooldown_seconds") &&
             w.minCooldownSeconds !== undefined
               ? { min_cooldown_seconds: w.minCooldownSeconds }
               : {}),
-            ...(scalarChanges.includes("tags") && w.tags
+            ...(scalarForUpdate.includes("tags") && w.tags
               ? { tags: w.tags }
               : {}),
-            ...(scalarChanges.includes("agent_kind")
+            ...(scalarForUpdate.includes("agent_kind")
               ? { agent_kind: w.agentKind ?? null }
               : {}),
           });
@@ -920,7 +929,10 @@ export async function executePlan(
         // b) Version-bound fields → manage_behaviors create_version (server
         //    inherits unset fields from the previous version row, but we always
         //    send the desired-side values for the changed keys).
-        if (row.versionBoundFields && row.versionBoundFields.length > 0) {
+        if (
+          (row.versionBoundFields && row.versionBoundFields.length > 0) ||
+          triggersWithPrompt
+        ) {
           await ctx.client.createBehaviorVersion({
             behavior_id: watcherId,
             ...(versionBound.has("prompt") ? { prompt: w.prompt } : {}),
@@ -938,6 +950,7 @@ export async function executePlan(
             ...(versionBound.has("classifiers") && w.classifiers !== undefined
               ? { classifiers: w.classifiers }
               : {}),
+            ...(triggersWithPrompt ? { triggers: w.triggers ?? [] } : {}),
           });
         }
       }

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -1015,6 +1015,8 @@ export class ApplyClient {
     classifiers?: unknown[];
     reactions_guidance?: string;
     change_notes?: string;
+    /** When set, written atomically with the new version (set_as_current). */
+    triggers?: import("@lobu/core/contracts/tools/manage-behaviors").BehaviorTrigger[];
   }): Promise<{ version?: number }> {
     const { body } = await this.request<{ version?: number }>(
       "POST",
@@ -1033,6 +1035,9 @@ export class ApplyClient {
           : {}),
         ...(payload.reactions_guidance !== undefined
           ? { reactions_guidance: payload.reactions_guidance }
+          : {}),
+        ...(payload.triggers !== undefined
+          ? { triggers: payload.triggers }
           : {}),
         ...(payload.change_notes
           ? { change_notes: payload.change_notes }

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -428,7 +428,7 @@ async function resolveSkill(
 }
 
 /** Byte cap on a Behavior's compiled instruction text (issue #2320). */
-export const MAX_COMPILED_INSTRUCTIONS_BYTES = 32 * 1024;
+const MAX_COMPILED_INSTRUCTIONS_BYTES = 32 * 1024;
 
 /**
  * Compile a Behavior's ordered `skills[]` into its frozen instruction text:

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -96,7 +96,19 @@ export interface DesiredWatcher {
   name?: string;
   description?: string;
   triggers?: DesiredBehaviorTrigger[];
+  /**
+   * Compiled instructions — the join of the referenced skill bodies in order,
+   * produced by `compileBehaviorInstructions` at load time. This is what the
+   * server stores as the version's frozen instruction text (the internal
+   * `prompt` column); it is not author-facing. Empty only for event-turn
+   * Behaviors with no skills (the server-side default applies at run time).
+   */
   prompt: string;
+  /**
+   * Ordered skill names (declarative apply input only — resolved against the
+   * owning agent's skill library at load time, never sent to the server).
+   */
+  skills?: string[];
   /** Optional SQL data sources; server applies a default when omitted. */
   sources?: BehaviorSource[];
   /**
@@ -413,6 +425,49 @@ async function resolveSkill(
     source: "inline",
     description: skill.description,
   });
+}
+
+/** Byte cap on a Behavior's compiled instruction text (issue #2320). */
+export const MAX_COMPILED_INSTRUCTIONS_BYTES = 32 * 1024;
+
+/**
+ * Compile a Behavior's ordered `skills[]` into its frozen instruction text:
+ * the referenced skill bodies joined in order with a blank line. Fails loud on
+ * a name the owning agent's skill library doesn't declare, an empty body, or
+ * a compiled text over {@link MAX_COMPILED_INSTRUCTIONS_BYTES}. Returns "" for
+ * a Behavior with no skills (event-turn only — the mapper already rejected
+ * every other trigger shape without skills).
+ */
+function compileBehaviorInstructions(
+  watcher: DesiredWatcher,
+  agentSkills: SkillConfigEntry[]
+): string {
+  const names = watcher.skills ?? [];
+  if (names.length === 0) return "";
+  const byName = new Map(agentSkills.map((skill) => [skill.name, skill]));
+  const bodies = names.map((name) => {
+    const skill = byName.get(name);
+    if (!skill) {
+      throw new ValidationError(
+        `Behavior "${watcher.slug}" references skill "${name}", but agent "${watcher.agent}" declares no skill with that name in its skills library`
+      );
+    }
+    const body = skill.content?.trim();
+    if (!body) {
+      throw new ValidationError(
+        `Behavior "${watcher.slug}" references skill "${name}", but its body is empty — compiled Behavior instructions need text`
+      );
+    }
+    return body;
+  });
+  const compiled = bodies.join("\n\n");
+  const bytes = Buffer.byteLength(compiled, "utf8");
+  if (bytes > MAX_COMPILED_INSTRUCTIONS_BYTES) {
+    throw new ValidationError(
+      `Behavior "${watcher.slug}" compiles to ${bytes} bytes of instructions — the maximum is ${MAX_COMPILED_INSTRUCTIONS_BYTES} (${MAX_COMPILED_INSTRUCTIONS_BYTES / 1024}KB)`
+    );
+  }
+  return compiled;
 }
 
 /**
@@ -1005,6 +1060,7 @@ export async function loadDesiredStateFromConfig(
   // Agent artifacts: SOUL/IDENTITY/USER.md (convention, from the agent dir) +
   // skills (explicit `defineAgent({ skills })`, inline or `skillFromFile`). The
   // mapper stays pure (no file IO); we read the files here and merge them in.
+  const skillsByAgentId = new Map<string, SkillConfigEntry[]>();
   await Promise.all(
     typedProject.agents.map(async (agent, i) => {
       const settings = state.agents[i]?.settings;
@@ -1016,8 +1072,20 @@ export async function loadDesiredStateFromConfig(
         opts.cwd
       );
       mergeAgentDirArtifacts(settings, markdown, localSkills);
+      skillsByAgentId.set(agent.id, localSkills);
     })
   );
+
+  // Compile each Behavior's `skills[]` into its frozen instruction text — the
+  // join of the referenced skill bodies in order. This happens BEFORE the diff
+  // reads `prompt`, so compiled-text equality (content only — descriptions
+  // don't compile) is what drives version churn.
+  for (const watcher of state.watchers) {
+    watcher.prompt = compileBehaviorInstructions(
+      watcher,
+      skillsByAgentId.get(watcher.agent) ?? []
+    );
+  }
 
   // Behavior reaction scripts: a sibling `.ts` file referenced by path. The
   // mapper stays pure; resolve + read the source here (raw, server compiles

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -522,7 +522,7 @@ function normalizeKeyingConfig(
 }
 
 /** Max skills a Behavior may reference (ordered compile; issue #2320 cap). */
-export const MAX_BEHAVIOR_SKILLS = 5;
+const MAX_BEHAVIOR_SKILLS = 5;
 
 /**
  * Skills-presence rule. An event trigger executing as "turn" carries its own

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -521,6 +521,48 @@ function normalizeKeyingConfig(
   return out;
 }
 
+/** Max skills a Behavior may reference (ordered compile; issue #2320 cap). */
+export const MAX_BEHAVIOR_SKILLS = 5;
+
+/**
+ * Skills-presence rule. An event trigger executing as "turn" carries its own
+ * content (the incoming message/event), so it may run with zero skills on the
+ * built-in default instruction. Everything else — schedule triggers, event
+ * triggers with execution "window", and Behaviors with no triggers at all
+ * (manual runs) — runs on its compiled instructions alone and must reference
+ * at least one skill.
+ *
+ * This CLI preflight exists because apply pushes triggers (`update`) and
+ * compiled instructions (`create_version`) as two non-atomic calls; the server
+ * enforces the same rule on the stored instruction text (it cannot see
+ * `skills[]`, a declarative-only concept).
+ */
+function assertBehaviorSkills(watcher: DesiredWatcher): void {
+  const skills = watcher.skills ?? [];
+  const duplicates = skills.filter((name, i) => skills.indexOf(name) !== i);
+  if (duplicates.length > 0) {
+    throw new ValidationError(
+      `Behavior "${watcher.slug}" lists duplicate skill(s): ${[...new Set(duplicates)].join(", ")} — each skill may appear once (the compile is ordered, not repeated)`
+    );
+  }
+  if (skills.length > MAX_BEHAVIOR_SKILLS) {
+    throw new ValidationError(
+      `Behavior "${watcher.slug}" references ${skills.length} skills — the maximum is ${MAX_BEHAVIOR_SKILLS}`
+    );
+  }
+  const triggers = watcher.triggers ?? [];
+  const requiresSkills =
+    triggers.length === 0 ||
+    triggers.some(
+      (trigger) => trigger.kind === "schedule" || trigger.execution === "window"
+    );
+  if (requiresSkills && skills.length === 0) {
+    throw new ValidationError(
+      `Behavior "${watcher.slug}" needs at least one skill: schedule triggers, event triggers with execution "window", and Behaviors with no triggers run on their compiled skill instructions alone. Only event triggers with execution "turn" may omit skills.`
+    );
+  }
+}
+
 function mapBehavior(behavior: Behavior): DesiredWatcher {
   const watcher = behavior;
   const sources = watcher.sources
@@ -591,7 +633,12 @@ function mapBehavior(behavior: Behavior): DesiredWatcher {
   return {
     slug: watcher.slug,
     agent: agentId(watcher.agent),
-    prompt: watcher.prompt,
+    // Compiled at load time from the referenced skill bodies (see
+    // `compileBehaviorInstructions` in desired-state.ts). The mapper stays pure
+    // — it cannot read skill files — so the placeholder holds until the loader
+    // overwrites it. Event-turn Behaviors with no skills legitimately keep "".
+    prompt: "",
+    ...(watcher.skills?.length ? { skills: watcher.skills } : {}),
     ...(watcher.keyingConfig
       ? { keyingConfig: normalizeKeyingConfig(watcher.keyingConfig) }
       : {}),
@@ -868,6 +915,7 @@ export function mapProjectToDesiredState(
         `Behavior "${watcher.slug}" names agent "${watcher.agent}", but no agent with that id is declared in lobu.config.ts`
       );
     }
+    assertBehaviorSkills(watcher);
     for (const trigger of watcher.triggers ?? []) {
       if (trigger.kind !== "event" || !trigger.connectionSlug) continue;
       const connection = (project.connections ?? []).find(

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -532,10 +532,10 @@ export const MAX_BEHAVIOR_SKILLS = 5;
  * (manual runs) — runs on its compiled instructions alone and must reference
  * at least one skill.
  *
- * This CLI preflight exists because apply pushes triggers (`update`) and
- * compiled instructions (`create_version`) as two non-atomic calls; the server
- * enforces the same rule on the stored instruction text (it cannot see
- * `skills[]`, a declarative-only concept).
+ * This CLI preflight mirrors the server rule on the stored instruction text
+ * (the server cannot see `skills[]`, a declarative-only concept). When both
+ * triggers and compiled instructions change, apply sends them together through
+ * create_version so the final pair is validated atomically.
  */
 function assertBehaviorSkills(watcher: DesiredWatcher): void {
   const skills = watcher.skills ?? [];

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -383,6 +383,10 @@ describe("lobu init --from-org", () => {
     expect(w?.slug).toBe("account-health");
     expect(w?.agent).toBe("sales");
     expect(w?.name).toBe("Account health");
+    // Skills-first round trip: the stored instruction text was emitted as a
+    // generated skill named after the Behavior slug, and compiling it back
+    // reproduces the exact frozen text (no version churn on re-apply).
+    expect(w?.skills).toEqual(["account-health"]);
     expect(w?.prompt).toBe("Poll CRM data.");
     expect(w?.triggers?.[0]).toMatchObject({
       kind: "event",

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -283,7 +283,8 @@ function emitAgent(
   settings: AgentSettings | null,
   imports: ImportTracker,
   secrets: SecretCollector,
-  minter: IdentMinter
+  minter: IdentMinter,
+  behaviorSkills: Array<{ name: string; content: string }> = []
 ): EmittedAgent {
   imports.use("defineAgent");
   const fields: string[] = [`id: ${str(agent.agentId)}`];
@@ -406,6 +407,21 @@ function emitAgent(
     });
     skillRefs.push(`skillFromFile(${str(`./${dir}/skills/${skill.name}`)})`);
   }
+  // Behavior-derived skills: each stored Behavior's frozen instruction text
+  // round-trips as a skill on its owning agent (skills-first authoring — the
+  // Behavior references it by name; there is no author-facing prompt).
+  for (const skill of behaviorSkills) {
+    files.push({
+      relPath: `${dir}/skills/${skill.name}/SKILL.md`,
+      body: emitSkillFile({
+        repo: `file/${skill.name}`,
+        name: skill.name,
+        content: skill.content,
+        enabled: true,
+      }),
+    });
+    skillRefs.push(`skillFromFile(${str(`./${dir}/skills/${skill.name}`)})`);
+  }
   if (skillRefs.length > 0) {
     imports.use("skillFromFile");
     fields.push(`skills: [\n    ${skillRefs.join(",\n    ")},\n  ]`);
@@ -492,13 +508,30 @@ function emitRelationshipType(
   };
 }
 
+/**
+ * Skills-presence rule, mirrored from `lobu apply` validation: only an
+ * event-turn-only Behavior may run without skills (the built-in default
+ * applies); schedule triggers, window execution, and no triggers (manual)
+ * need compiled instructions.
+ */
+function behaviorRequiresSkills(triggers: RemoteBehavior["triggers"]): boolean {
+  const list = triggers ?? [];
+  if (list.length === 0) return true;
+  return list.some(
+    (trigger) =>
+      trigger.kind === "schedule" ||
+      (trigger.kind === "event" && trigger.execution === "window")
+  );
+}
+
 function emitBehavior(
   w: RemoteBehavior,
   reactionScript: string | null,
   agentHandles: Map<string, string>,
   connectionHandlesById: ReadonlyMap<number, string>,
   imports: ImportTracker,
-  minter: IdentMinter
+  minter: IdentMinter,
+  skillName: string | undefined
 ): { handle: Handle; reactionFile?: { relPath: string; body: string } } {
   imports.use("defineBehavior");
   const agentRef = w.agent_id ? agentHandles.get(w.agent_id) : undefined;
@@ -521,7 +554,11 @@ function emitBehavior(
     });
     fields.push(`triggers: ${emitValue(triggers, 1)}`);
   }
-  fields.push(`prompt: ${str(w.prompt ?? "")}`);
+  // Skills-first: the stored instruction text was emitted as a skill on the
+  // owning agent (see generateProject); the Behavior references it by name.
+  // An event-turn Behavior with no stored instructions emits no skills — the
+  // built-in default applies.
+  if (skillName) fields.push(`skills: [${str(skillName)}]`);
   // A watcher's output schema is owned by its entity type (keying_config.entityType)
   // or falls back to the worker's free-form `{ summary }` — never inline. Emit
   // `keyingConfig` (the entity connection) only.
@@ -923,11 +960,63 @@ function generateProject(
   const files: Array<{ relPath: string; body: string }> = [];
   const warnings: string[] = [];
 
+  // Skills-first Behaviors: each stored Behavior's frozen instruction text
+  // round-trips as a generated skill on its owning agent, referenced by name
+  // from the Behavior's `skills` list (there is no author-facing prompt).
+  // Names default to the Behavior slug, suffixed on collision with an
+  // existing agent skill.
+  const behaviorSkillsByAgent = new Map<
+    string,
+    Array<{ name: string; content: string }>
+  >();
+  const behaviorSkillNames = new Map<string, string>();
+  {
+    const usedNamesByAgent = new Map<string, Set<string>>();
+    for (const { agent, settings } of state.agents) {
+      usedNamesByAgent.set(
+        agent.agentId,
+        new Set(
+          (settings?.skillsConfig?.skills ?? [])
+            .filter((s) => !s.system)
+            .map((s) => s.name)
+        )
+      );
+    }
+    for (const { watcher } of state.watchers) {
+      const instructions = watcher.prompt?.trim();
+      const agentId = watcher.agent_id ?? "";
+      if (!instructions) {
+        if (behaviorRequiresSkills(watcher.triggers)) {
+          warnings.push(
+            `Behavior "${watcher.slug}" has no stored instructions but is not event-turn-only — attach at least one skill before the next \`lobu apply\`.`
+          );
+        }
+        continue;
+      }
+      const used = usedNamesByAgent.get(agentId) ?? new Set<string>();
+      usedNamesByAgent.set(agentId, used);
+      let name = watcher.slug;
+      for (let n = 2; used.has(name); n++) name = `${watcher.slug}-${n}`;
+      used.add(name);
+      behaviorSkillNames.set(watcher.slug, name);
+      const list = behaviorSkillsByAgent.get(agentId) ?? [];
+      list.push({ name, content: instructions });
+      behaviorSkillsByAgent.set(agentId, list);
+    }
+  }
+
   // Agents first (watchers reference their handles).
   const agentHandles = new Map<string, string>();
   const agentDecls: string[] = [];
   for (const { agent, settings } of state.agents) {
-    const emitted = emitAgent(agent, settings, imports, secrets, minter);
+    const emitted = emitAgent(
+      agent,
+      settings,
+      imports,
+      secrets,
+      minter,
+      behaviorSkillsByAgent.get(agent.agentId) ?? []
+    );
     agentHandles.set(agent.agentId, emitted.handle.name);
     agentDecls.push(emitted.handle.decl);
     files.push(...emitted.files);
@@ -1022,7 +1111,8 @@ function generateProject(
       agentHandles,
       connectionHandlesById,
       imports,
-      minter
+      minter,
+      behaviorSkillNames.get(watcher.slug)
     );
     watcherDecls.push(handle.decl);
     watcherHandles.push(handle.name);

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -405,7 +405,18 @@ export interface Behavior {
   description?: string;
   /** Connector events and/or cadence that activate this Behavior. */
   triggers?: BehaviorTriggerConfig[];
-  prompt: string;
+  /**
+   * Ordered skill names from the owning agent's skill library
+   * ({@link Agent.skills}). `lobu apply` compiles the referenced skill bodies —
+   * joined in this order — into the Behavior's frozen instructions; editing the
+   * library later does not change existing Behaviors until re-apply.
+   *
+   * Optional for event triggers with execution `"turn"` (chat/webhook listen —
+   * the incoming event is the content and a built-in default applies).
+   * Required (≥1) for schedule triggers, event triggers with execution
+   * `"window"`, and Behaviors with no triggers (manual runs).
+   */
+  skills?: string[];
   /**
    * Stable key generation for promoted entities. When `entityType` is set, the
    * Behavior is entity-typed: its output schema derives from that entity type's

--- a/packages/cli/src/templates/AGENTS.md.tmpl
+++ b/packages/cli/src/templates/AGENTS.md.tmpl
@@ -17,8 +17,9 @@ An open-source, event-sourced backend for AI agents:
   **entities** and **relationships**.
 - **Agents** react to messages in real time and answer over chat platforms, HTTP,
   and MCP.
-- **Behaviors** are reusable prompts activated by connector events, schedules,
-  or an explicit call (a PR review, Slack reply, daily digest, etc.).
+- **Behaviors** subscribe an agent to connector events, schedules, or an
+  explicit call (a PR review, Slack reply, daily digest, etc.). Their
+  instructions come from the agent's skills, referenced by name.
 
 `lobu run` boots the whole thing (gateway + worker + memory) as one Node process
 on http://localhost:{{GATEWAY_PORT}}.
@@ -50,8 +51,8 @@ install it — don't work around it.
 
 Author everything in `lobu.config.ts` with helpers from `@lobu/cli/config`:
 `defineConfig`, `defineAgent`, `defineEntityType`, `defineRelationshipType`,
-`defineBehavior`, `defineConnection`, `defineAuthProfile`, `secret`, plus
-`connectorFromFile`, `reactionFromFile`, `skillFromFile`.
+`defineBehavior`, `defineSkill`, `defineConnection`, `defineAuthProfile`,
+`secret`, plus `connectorFromFile`, `reactionFromFile`, `skillFromFile`.
 
 Read the complete, working reference before editing:
 https://github.com/lobu-ai/lobu/blob/main/examples/lobu-crm/lobu.config.ts
@@ -187,7 +188,21 @@ ask the user to add it to `.env`.
 
 ### Behavior (event, schedule, or manual) + reaction
 
+A Behavior's instructions come from the agent's skill library: list skill names
+in `skills` and `lobu apply` compiles their bodies (in order) into the frozen
+instructions for that Behavior version. Schedule triggers, event triggers with
+`execution: "window"`, and Behaviors with no triggers (manual) require at least
+one skill; an event trigger with `execution: "turn"` (chat/webhook listen) may
+omit `skills` — the incoming message is the content and a built-in default
+applies.
+
 ```ts
+const digestSkill = defineSkill({
+  name: "daily-digest",
+  content: "Summarize yesterday's tickets by root cause and post to Slack.",
+});
+// … add it to the agent: defineAgent({ …, skills: [digestSkill] })
+
 const digest = defineBehavior({
   agent,
   slug: "daily-digest",
@@ -197,7 +212,7 @@ const digest = defineBehavior({
     // Or react to a connector event:
     // { kind: "event", connector_key: "github", connection: gh, event_types: ["pull_request.created"] },
   ],
-  prompt: "Summarize yesterday's tickets by root cause and post to Slack.",
+  skills: ["daily-digest"],
   // Entity-typed: the output schema comes from the `ticket` entity type's
   // properties (schema lives on the type, not the Behavior), and extracted rows
   // are keyed + merged into ticket entities across windows.

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -230,7 +230,8 @@ export const ManageBehaviorsSchema = Type.Object(
     action: Type.Union(
       [
         Type.Literal("create", {
-          description: "Create a Behavior with prompt + sources.",
+          description:
+            "Create a Behavior. Author instructions as agent skills where possible; prompt is the compiled instruction text and may be omitted for event triggers with execution 'turn'.",
         }),
         Type.Literal("list", { description: "List Behaviors." }),
         Type.Literal("update", { description: "Patch Behavior config." }),
@@ -329,7 +330,7 @@ export const ManageBehaviorsSchema = Type.Object(
     prompt: Type.Optional(
       Type.String({
         description:
-          "[create/create_version] Literal LLM instruction text for the Behavior. No template expansion happens — the text is delivered to the agent verbatim, and the window's data (content, sources, entities, extraction_schema) arrives alongside it in the knowledge-read payload.",
+          "[create/create_version] Literal LLM instruction text for the Behavior, frozen into the version. No template expansion happens — the text is delivered to the agent verbatim, and the window's data (content, sources, entities, extraction_schema) arrives alongside it in the knowledge-read payload. Prefer authoring instructions as skills on the owning agent and compiling them here (declarative configs join the referenced skill bodies in order). Required for schedule triggers, event triggers with execution 'window', and Behaviors with no triggers; omit it for event triggers with execution 'turn' to use the built-in default.",
       })
     ),
     sources: Type.Optional(

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
@@ -1,0 +1,191 @@
+/**
+ * manage_behaviors — instruction-presence rule (issue #2320, thin Behaviors).
+ *
+ * A Behavior's instruction text (`prompt`, internally the compiled skill
+ * bodies) is required only for trigger shapes that run on it alone: schedule
+ * triggers, event triggers with execution "window", and no triggers (manual).
+ * An event trigger with execution "turn" carries its own content (the incoming
+ * message) and may be created with NO prompt — previously `create` hard-failed
+ * with "prompt is required for create action".
+ *
+ * create_version enforces the same rule when it writes instruction text.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import type { AuthContext } from "../../../tools/execute";
+import { executeTool } from "../../../tools/execute";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const TEST_ENV: Env = {
+	ENVIRONMENT: "test",
+	DATABASE_URL: process.env.DATABASE_URL,
+	JWT_SECRET: "test-jwt-secret-for-testing-only",
+	BETTER_AUTH_SECRET: "test-auth-secret-for-testing-only",
+	MAX_CONSECUTIVE_FAILURES: "3",
+	RATE_LIMIT_ENABLED: "false",
+};
+
+const TURN_TRIGGER = {
+	kind: "event",
+	connector_key: "slack",
+	event_types: ["message.created"],
+	execution: "turn",
+	output: "reply_to_source",
+};
+
+describe("manage_behaviors — instruction-presence rule", () => {
+	let orgId: string;
+	let ownerCtx: AuthContext;
+	let agentId: string;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const org = await createTestOrganization({ name: "instruction rule" });
+		orgId = org.id;
+		const owner = await createTestUser({ email: "ir-owner@test.com" });
+		await addUserToOrganization(owner.id, org.id, "owner");
+		ownerCtx = {
+			organizationId: orgId,
+			tokenOrganizationId: orgId,
+			userId: owner.id,
+			memberRole: "owner",
+			agentId: null,
+			requestedAgentId: null,
+			isAuthenticated: true,
+			clientId: null,
+			scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+			tokenType: "oauth",
+			requestUrl: `http://localhost/api/${orgId}`,
+			baseUrl: "",
+			scopedToOrg: true,
+			allowCrossOrg: false,
+		};
+		const agent = await createTestAgent({
+			organizationId: orgId,
+			agentId: "ir-agent",
+			ownerUserId: owner.id,
+		});
+		agentId = agent.agentId;
+	});
+
+	it("creates an event-turn Behavior with NO prompt (built-in default applies)", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ir-listen",
+				agent_id: agentId,
+				triggers: [TURN_TRIGGER],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+		expect(created.behavior_id).toBeTruthy();
+	});
+
+	it("rejects a schedule Behavior with no prompt", async () => {
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "create",
+					slug: "ir-sched",
+					agent_id: agentId,
+					triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+				},
+				TEST_ENV,
+				ownerCtx
+			)
+		).rejects.toThrow(/needs instructions/i);
+	});
+
+	it("rejects a manual (no-trigger) Behavior with no prompt", async () => {
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{ action: "create", slug: "ir-manual", agent_id: agentId },
+				TEST_ENV,
+				ownerCtx
+			)
+		).rejects.toThrow(/needs instructions/i);
+	});
+
+	it("create_version rejects blanking instructions on a schedule Behavior, accepts real text", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ir-sched-ok",
+				agent_id: agentId,
+				prompt: "Daily digest instructions.",
+				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+		const behaviorId = created.behavior_id!;
+
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "create_version",
+					behavior_id: behaviorId,
+					prompt: "   ",
+					set_as_current: true,
+				},
+				TEST_ENV,
+				ownerCtx
+			)
+		).rejects.toThrow(/needs instructions/i);
+
+		const versioned = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				prompt: "Updated digest instructions.",
+				set_as_current: true,
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { version?: number };
+		expect(versioned.version).toBeGreaterThan(1);
+	});
+
+	it("create_version allows writing empty instructions on an event-turn Behavior", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ir-listen-v",
+				agent_id: agentId,
+				prompt: "Initial listen guidance.",
+				triggers: [TURN_TRIGGER],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+
+		const versioned = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: created.behavior_id!,
+				prompt: "",
+				set_as_current: true,
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { version?: number };
+		expect(versioned.version).toBeGreaterThan(1);
+	});
+});

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
@@ -188,4 +188,116 @@ describe("manage_behaviors — instruction-presence rule", () => {
 		)) as { version?: number };
 		expect(versioned.version).toBeGreaterThan(1);
 	});
+
+	it("rejects event-turn → schedule via update when the current prompt is empty", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ir-turn-to-sched-update",
+				agent_id: agentId,
+				triggers: [TURN_TRIGGER],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "update",
+					behavior_id: created.behavior_id!,
+					triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+				},
+				TEST_ENV,
+				ownerCtx
+			)
+		).rejects.toThrow(/needs instructions/i);
+	});
+
+	it("rejects event-turn → schedule via create_version when prompt stays empty", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ir-turn-to-sched-cv",
+				agent_id: agentId,
+				triggers: [TURN_TRIGGER],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "create_version",
+					behavior_id: created.behavior_id!,
+					triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+					set_as_current: true,
+				},
+				TEST_ENV,
+				ownerCtx
+			)
+		).rejects.toThrow(/needs instructions/i);
+	});
+
+	it("create_version accepts event-turn → schedule with instructions in one call", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ir-turn-to-sched-ok",
+				agent_id: agentId,
+				triggers: [TURN_TRIGGER],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+
+		const versioned = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: created.behavior_id!,
+				prompt: "Now scheduled digest instructions.",
+				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+				set_as_current: true,
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { version?: number };
+		expect(versioned.version).toBeGreaterThan(1);
+	});
+
+	it("create_version accepts schedule → event-turn with an explicit empty prompt", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ir-sched-to-turn",
+				agent_id: agentId,
+				prompt: "Scheduled instructions.",
+				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+
+		const versioned = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: created.behavior_id!,
+				prompt: "",
+				triggers: [TURN_TRIGGER],
+				set_as_current: true,
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { version?: number };
+		expect(versioned.version).toBeGreaterThan(1);
+	});
 });

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
@@ -300,4 +300,71 @@ describe("manage_behaviors — instruction-presence rule", () => {
 		)) as { version?: number };
 		expect(versioned.version).toBeGreaterThan(1);
 	});
+
+	it("rejects blanking a group-shared prompt while a schedule sibling still needs it", async () => {
+		// Root: event-turn with empty prompt (ok for turn).
+		const root = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ir-group-root",
+				agent_id: agentId,
+				triggers: [TURN_TRIGGER],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+		const rootId = root.behavior_id!;
+
+		// Promote root to a schedule with instructions so clones share that version.
+		await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: rootId,
+				prompt: "Shared scheduled instructions.",
+				triggers: [{ kind: "schedule", cron: "0 10 * * *" }],
+				set_as_current: true,
+			},
+			TEST_ENV,
+			ownerCtx
+		);
+
+		// Second assignment in the same group: keep schedule triggers (needs prompt).
+		// create_from_version shares the group + version; we approximate by creating
+		// a second Behavior then re-pointing is hard in tests — instead create another
+		// schedule Behavior and assert blanking via create_version on a single
+		// schedule assignment (already covered). For true group coverage: blanking
+		// the root prompt while it is still schedule-shaped must fail.
+		await expect(
+			executeTool(
+				"manage_behaviors",
+				{
+					action: "create_version",
+					behavior_id: rootId,
+					prompt: "",
+					// Keep schedule triggers (incoming) — must not clear instructions.
+					triggers: [{ kind: "schedule", cron: "0 10 * * *" }],
+					set_as_current: true,
+				},
+				TEST_ENV,
+				ownerCtx
+			)
+		).rejects.toThrow(/needs instructions/i);
+
+		// Targeted assignment can switch to turn AND blank prompt in one call.
+		const ok = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: rootId,
+				prompt: "",
+				triggers: [TURN_TRIGGER],
+				set_as_current: true,
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { version?: number };
+		expect(ok.version).toBeGreaterThan(1);
+	});
 });

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
@@ -19,9 +19,11 @@ import { cleanupTestDatabase } from "../../setup/test-db";
 import {
 	addUserToOrganization,
 	createTestAgent,
+	createTestEntity,
 	createTestOrganization,
 	createTestUser,
 } from "../../setup/test-fixtures";
+import { getTestDb } from "../../setup/test-db";
 
 const TEST_ENV: Env = {
 	ENVIRONMENT: "test",
@@ -302,40 +304,65 @@ describe("manage_behaviors — instruction-presence rule", () => {
 	});
 
 	it("rejects blanking a group-shared prompt while a schedule sibling still needs it", async () => {
-		// Root: event-turn with empty prompt (ok for turn).
+		const sql = getTestDb();
+		const rootEntity = await createTestEntity({
+			name: "IR Group Root Entity",
+			organization_id: orgId,
+			created_by: ownerCtx.userId!,
+		});
+		const siblingEntity = await createTestEntity({
+			name: "IR Group Sibling Entity",
+			organization_id: orgId,
+			created_by: ownerCtx.userId!,
+		});
+
+		// Root assignment: schedule + shared instructions (entity-bound so
+		// create_from_version can fan out another assignment in the group).
 		const root = (await executeTool(
 			"manage_behaviors",
 			{
 				action: "create",
 				slug: "ir-group-root",
 				agent_id: agentId,
-				triggers: [TURN_TRIGGER],
+				entity_id: rootEntity.id,
+				prompt: "Shared scheduled instructions.",
+				triggers: [{ kind: "schedule", cron: "0 10 * * *" }],
 			},
 			TEST_ENV,
 			ownerCtx
 		)) as { behavior_id?: string };
 		const rootId = root.behavior_id!;
 
-		// Promote root to a schedule with instructions so clones share that version.
-		await executeTool(
+		const [rootRow] = await sql`
+			SELECT current_version_id, watcher_group_id FROM watchers WHERE id = ${Number(rootId)}
+		`;
+		const versionId = Number(rootRow.current_version_id);
+
+		// Real second assignment in the same group — keeps schedule triggers
+		// and shares the version/prompt with the root.
+		const cloned = (await executeTool(
 			"manage_behaviors",
 			{
-				action: "create_version",
-				behavior_id: rootId,
-				prompt: "Shared scheduled instructions.",
-				triggers: [{ kind: "schedule", cron: "0 10 * * *" }],
-				set_as_current: true,
+				action: "create_from_version",
+				version_id: String(versionId),
+				entity_ids: [siblingEntity.id],
 			},
 			TEST_ENV,
 			ownerCtx
-		);
+		)) as { created?: Array<{ behavior_id: string }> };
+		expect(cloned.created?.[0]?.behavior_id).toBeTruthy();
+		const siblingId = Number(cloned.created![0].behavior_id);
 
-		// Second assignment in the same group: keep schedule triggers (needs prompt).
-		// create_from_version shares the group + version; we approximate by creating
-		// a second Behavior then re-pointing is hard in tests — instead create another
-		// schedule Behavior and assert blanking via create_version on a single
-		// schedule assignment (already covered). For true group coverage: blanking
-		// the root prompt while it is still schedule-shaped must fail.
+		const siblings = await sql`
+			SELECT id, triggers FROM watchers
+			WHERE watcher_group_id = ${Number(rootRow.watcher_group_id)}
+			ORDER BY id
+		`;
+		expect(siblings).toHaveLength(2);
+
+		// Switch ONLY the targeted root to event-turn with a blank prompt.
+		// The sibling still has schedule triggers → group-shared blank prompt
+		// must be rejected (incoming triggers on the target do not exempt siblings).
 		await expect(
 			executeTool(
 				"manage_behaviors",
@@ -343,8 +370,7 @@ describe("manage_behaviors — instruction-presence rule", () => {
 					action: "create_version",
 					behavior_id: rootId,
 					prompt: "",
-					// Keep schedule triggers (incoming) — must not clear instructions.
-					triggers: [{ kind: "schedule", cron: "0 10 * * *" }],
+					triggers: [TURN_TRIGGER],
 					set_as_current: true,
 				},
 				TEST_ENV,
@@ -352,19 +378,11 @@ describe("manage_behaviors — instruction-presence rule", () => {
 			)
 		).rejects.toThrow(/needs instructions/i);
 
-		// Targeted assignment can switch to turn AND blank prompt in one call.
-		const ok = (await executeTool(
-			"manage_behaviors",
-			{
-				action: "create_version",
-				behavior_id: rootId,
-				prompt: "",
-				triggers: [TURN_TRIGGER],
-				set_as_current: true,
-			},
-			TEST_ENV,
-			ownerCtx
-		)) as { version?: number };
-		expect(ok.version).toBeGreaterThan(1);
+		// Sibling still scheduled after the rejected write.
+		const [siblingAfter] = await sql`
+			SELECT triggers FROM watchers WHERE id = ${siblingId}
+		`;
+		const siblingTriggers = siblingAfter.triggers as Array<{ kind: string }>;
+		expect(siblingTriggers.some((t) => t.kind === "schedule")).toBe(true);
 	});
 });

--- a/packages/server/src/__tests__/unit/behavior-instructions-rule.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-instructions-rule.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import type { BehaviorTrigger } from "@lobu/core/contracts/tools/manage-behaviors";
+import {
+	assertBehaviorInstructions,
+	behaviorRequiresInstructions,
+} from "../../behaviors/triggers";
+
+const eventTurn: BehaviorTrigger = {
+	kind: "event",
+	connector_key: "slack",
+	event_types: ["message.created"],
+	execution: "turn",
+};
+
+// An omitted execution defaults to "turn" per the contract schema.
+const eventDefault = {
+	kind: "event",
+	connector_key: "slack",
+	event_types: ["message.created"],
+} as BehaviorTrigger;
+
+const eventWindow: BehaviorTrigger = {
+	kind: "event",
+	connector_key: "github",
+	event_types: ["pull_request.created"],
+	execution: "window",
+};
+
+const schedule: BehaviorTrigger = {
+	kind: "schedule",
+	cron: "0 9 * * *",
+};
+
+describe("behaviorRequiresInstructions", () => {
+	test("event-turn triggers (explicit or defaulted) do not require instructions", () => {
+		expect(behaviorRequiresInstructions([eventTurn])).toBe(false);
+		expect(behaviorRequiresInstructions([eventDefault])).toBe(false);
+		expect(behaviorRequiresInstructions([eventTurn, eventDefault])).toBe(false);
+	});
+
+	test("schedule, window-event, and empty (manual) trigger sets require instructions", () => {
+		expect(behaviorRequiresInstructions([schedule])).toBe(true);
+		expect(behaviorRequiresInstructions([eventWindow])).toBe(true);
+		expect(behaviorRequiresInstructions([])).toBe(true);
+		// Mixed: one non-turn trigger is enough.
+		expect(behaviorRequiresInstructions([eventTurn, schedule])).toBe(true);
+	});
+});
+
+describe("assertBehaviorInstructions", () => {
+	test("allows an event-turn Behavior with no instruction text", () => {
+		expect(() => assertBehaviorInstructions([eventTurn], undefined)).not.toThrow();
+		expect(() => assertBehaviorInstructions([eventTurn], "")).not.toThrow();
+	});
+
+	test("rejects empty instructions for schedule/window/manual shapes", () => {
+		for (const triggers of [[schedule], [eventWindow], [] as BehaviorTrigger[]]) {
+			expect(() => assertBehaviorInstructions(triggers, undefined)).toThrow(
+				/needs instructions/
+			);
+			expect(() => assertBehaviorInstructions(triggers, "   ")).toThrow(
+				/needs instructions/
+			);
+		}
+	});
+
+	test("accepts any trigger shape once instruction text is present", () => {
+		expect(() =>
+			assertBehaviorInstructions([schedule], "Do the digest.")
+		).not.toThrow();
+		expect(() => assertBehaviorInstructions([], "Manual runbook.")).not.toThrow();
+	});
+});

--- a/packages/server/src/behaviors/triggers.ts
+++ b/packages/server/src/behaviors/triggers.ts
@@ -195,6 +195,47 @@ export function resolveBehaviorTriggerWrite(args: {
 	};
 }
 
+/**
+ * Whether this trigger set runs on stored instructions alone. An event trigger
+ * executing as "turn" carries its own content — the incoming message/event is
+ * the input, and the built-in default instruction applies when the Behavior
+ * has none. Schedule triggers, event triggers with execution "window", and an
+ * empty trigger set (manual runs) have no such content, so they need
+ * instruction text. An omitted event execution defaults to "turn"
+ * (the contract's default).
+ */
+export function behaviorRequiresInstructions(
+	triggers: BehaviorTrigger[]
+): boolean {
+	if (triggers.length === 0) return true;
+	return triggers.some(
+		(trigger) =>
+			trigger.kind === "schedule" ||
+			(trigger.kind === "event" && trigger.execution === "window")
+	);
+}
+
+/**
+ * Enforce the instruction-presence rule on a Behavior write. UNGATED — unlike
+ * `assertBehaviorTriggerConnections` (which create_version runs only when
+ * triggers changed), this runs on every create and on every instruction write
+ * (create_version with a prompt). Deliberately NOT on trigger updates:
+ * `lobu apply` pushes triggers (`update`) then compiled instructions
+ * (`create_version`) as two non-atomic calls, so a trigger-write assert would
+ * reject the legitimate event-turn → schedule transition mid-apply; the CLI
+ * preflights the full skills[] rule instead.
+ */
+export function assertBehaviorInstructions(
+	triggers: BehaviorTrigger[],
+	instructions: string | null | undefined
+): void {
+	if (!behaviorRequiresInstructions(triggers)) return;
+	if (instructions?.trim()) return;
+	throw new ToolUserError(
+		"This Behavior runs from a schedule, an analysis window, or manual runs, so it needs instructions: attach at least one skill (their bodies compile into the stored instructions) or provide instruction text. Only event triggers with execution 'turn' may omit instructions."
+	);
+}
+
 /** Validate connection-scoped triggers against the owning organization. */
 export async function assertBehaviorTriggerConnections(
 	sql: DbClient,

--- a/packages/server/src/behaviors/triggers.ts
+++ b/packages/server/src/behaviors/triggers.ts
@@ -216,14 +216,9 @@ export function behaviorRequiresInstructions(
 }
 
 /**
- * Enforce the instruction-presence rule on a Behavior write. UNGATED — unlike
- * `assertBehaviorTriggerConnections` (which create_version runs only when
- * triggers changed), this runs on every create and on every instruction write
- * (create_version with a prompt). Deliberately NOT on trigger updates:
- * `lobu apply` pushes triggers (`update`) then compiled instructions
- * (`create_version`) as two non-atomic calls, so a trigger-write assert would
- * reject the legitimate event-turn → schedule transition mid-apply; the CLI
- * preflights the full skills[] rule instead.
+ * Enforce the instruction-presence rule on a complete trigger + instruction
+ * pair before either side is stored. Callers must pass the *final* resolved
+ * pair (inherited prompt when omitted, resolved triggers after write-merge).
  */
 export function assertBehaviorInstructions(
 	triggers: BehaviorTrigger[],

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -23,7 +23,6 @@
 
 import { InteractionResourceKind } from '@lobu/core/contracts/interaction-envelope';
 import {
-  type BehaviorTrigger,
   ListBehaviorsResultSchema,
   ListBehaviorsSchema,
   ManageBehaviorsResultSchema,
@@ -163,26 +162,10 @@ async function manageBehaviorsImpl(
     }
   }
 
-  // Instruction-presence rule for create_version, checked UNGATED (the
-  // handler's connection assert runs only when triggers changed): when the
-  // caller writes instruction text, validate it against the Behavior's CURRENT
-  // trigger shape — a schedule/window/manual Behavior cannot publish an empty
-  // instruction version. An omitted prompt inherits the previous version's
-  // text and needs no re-check. Runs after requireWatcherAccess fenced the id
-  // to the caller's organization.
-  if (
-    args.action === 'create_version' &&
-    args.behavior_id &&
-    args.prompt !== undefined
-  ) {
-    const triggerRows = await pgSql`
-      SELECT triggers FROM watchers WHERE id = ${args.behavior_id} LIMIT 1
-    `;
-    assertBehaviorInstructions(
-      (triggerRows[0]?.triggers ?? []) as BehaviorTrigger[],
-      args.prompt
-    );
-  }
+  // Instruction-presence for create_version is enforced in handleCreateVersion
+  // against the *final* resolved (triggers, prompt) pair — not here against
+  // stored triggers + only an explicit prompt write. That incomplete pre-check
+  // let event-turn → schedule transitions keep an empty prompt.
 
   // A watcher IS agent config — it's an autonomous-execution definition (prompt,
   // SQL source, reaction). Gate its create/update/delete under the `agent_config`

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -23,6 +23,7 @@
 
 import { InteractionResourceKind } from '@lobu/core/contracts/interaction-envelope';
 import {
+  type BehaviorTrigger,
   ListBehaviorsResultSchema,
   ListBehaviorsSchema,
   ManageBehaviorsResultSchema,
@@ -45,6 +46,7 @@ import {
   requireReadAccess,
   requireWriteAccess,
 } from '../../utils/organization-access';
+import { assertBehaviorInstructions } from '../../behaviors/triggers';
 import { resolveRunInitiator } from '../initiator';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
@@ -159,6 +161,27 @@ async function manageBehaviorsImpl(
     for (const eid of args.entity_ids) {
       await requireWriteAccess(pgSql, eid, ctx);
     }
+  }
+
+  // Instruction-presence rule for create_version, checked UNGATED (the
+  // handler's connection assert runs only when triggers changed): when the
+  // caller writes instruction text, validate it against the Behavior's CURRENT
+  // trigger shape — a schedule/window/manual Behavior cannot publish an empty
+  // instruction version. An omitted prompt inherits the previous version's
+  // text and needs no re-check. Runs after requireWatcherAccess fenced the id
+  // to the caller's organization.
+  if (
+    args.action === 'create_version' &&
+    args.behavior_id &&
+    args.prompt !== undefined
+  ) {
+    const triggerRows = await pgSql`
+      SELECT triggers FROM watchers WHERE id = ${args.behavior_id} LIMIT 1
+    `;
+    assertBehaviorInstructions(
+      (triggerRows[0]?.triggers ?? []) as BehaviorTrigger[],
+      args.prompt
+    );
   }
 
   // A watcher IS agent config — it's an autonomous-execution definition (prompt,
@@ -451,7 +474,9 @@ function buildWatcherProposal(
   }
   if (args.action === 'create') {
     if (!args.slug) throw new ToolUserError('slug is required for create action');
-    if (!args.prompt) throw new ToolUserError('prompt is required for create action');
+    // Instruction text is required only for trigger shapes that run on it
+    // alone — event-turn Behaviors may omit prompt (built-in default).
+    assertBehaviorInstructions(args.triggers ?? [], args.prompt);
     if (!args.agent_id) {
       throw new ToolUserError(
         'agent_id is required to create a Behavior (the agent that executes it).'

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -442,9 +442,11 @@ export async function handleUpdate(
 
   await requireExists(sql, 'watchers', args.behavior_id, 'Behavior');
   const currentRows = await sql`
-    SELECT organization_id, agent_id, schedule, timezone, triggers
-    FROM watchers
-    WHERE id = ${args.behavior_id}
+    SELECT w.organization_id, w.agent_id, w.schedule, w.timezone, w.triggers,
+           cv.prompt AS current_prompt
+    FROM watchers w
+    LEFT JOIN watcher_versions cv ON cv.id = w.current_version_id
+    WHERE w.id = ${args.behavior_id}
     LIMIT 1
   `;
   const currentRow = currentRows[0] as {
@@ -453,6 +455,7 @@ export async function handleUpdate(
     schedule: string | null;
     timezone: string | null;
     triggers: ManageBehaviorsArgs['triggers'];
+    current_prompt: string | null;
   };
   const triggerWrite = resolveBehaviorTriggerWrite({
     triggers: args.triggers,
@@ -463,13 +466,12 @@ export async function handleUpdate(
     !behaviorTriggersEqual(currentRow.triggers ?? [], triggerWrite.triggers)
   ) {
     await assertBehaviorTriggerConnections(sql, currentRow.organization_id, triggerWrite.triggers);
+    // Trigger shape alone can force the instruction rule (event-turn → schedule
+    // with an empty current prompt must fail). Callers that need to change both
+    // triggers and instructions atomically must use create_version with both
+    // fields — lobu apply does that path.
+    assertBehaviorInstructions(triggerWrite.triggers, currentRow.current_prompt);
   }
-  // NOTE: no instruction-presence assert here. `lobu apply` pushes triggers
-  // (`update`) and compiled instructions (`create_version`) as two non-atomic
-  // calls in that order, so asserting on a trigger write would reject the
-  // legitimate event-turn → schedule transition mid-apply. Creates and
-  // instruction writes are the enforced seams (see assertBehaviorInstructions
-  // in behaviors/triggers.ts).
 
   // Match the invariant from handleCreate: a watcher with no agent_id is
   // a zombie the scheduler will never run (automation joins on

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -44,6 +44,7 @@ import {
   extractReactionInputSchema,
 } from '../../../watchers/reaction-executor';
 import {
+  assertBehaviorInstructions,
   assertBehaviorTriggerConnections,
   behaviorTriggersEqual,
   resolveBehaviorTriggerWrite,
@@ -93,15 +94,15 @@ export async function handleCreate(
 }> {
   const sql = getDb();
 
-  // Require slug + prompt for create. The output contract is not authored
+  // Require slug for create. Instruction text (prompt) is required only when
+  // the trigger shape runs on instructions alone — event-turn Behaviors may
+  // omit it and run on the built-in default (see assertBehaviorInstructions,
+  // called after triggers resolve below). The output contract is not authored
   // here: an entity-typed watcher (keying_config.entity_type) derives it from
   // entity_types.metadata_schema at runtime, and an untyped watcher uses the
   // worker's free-form summary fallback.
   if (!args.slug) {
     throw new ToolUserError('slug is required for create action');
-  }
-  if (!args.prompt) {
-    throw new ToolUserError('prompt is required for create action');
   }
   assertValidExecutionConfig(args.execution_config, ctx);
   // A device pin runs the watcher's agent CLI on the device owner's machine —
@@ -121,7 +122,7 @@ export async function handleCreate(
   //      — the backend derives them so the UI sends only the raw prompt.
   //   2. explicit `args.sources` (API callers / legacy).
   // If neither yields anything, fall back to a default all-events source.
-  const promptSources = extractSourcesFromPromptTokens(args.prompt);
+  const promptSources = extractSourcesFromPromptTokens(args.prompt ?? '');
   const explicitSources = args.sources ?? [];
   const merged = mergePromptSources(explicitSources, promptSources);
   const sources: Array<{ name: string; query: string }> =
@@ -214,6 +215,7 @@ export async function handleCreate(
     triggers: args.triggers,
   });
   await assertBehaviorTriggerConnections(sql, organizationId, triggerWrite.triggers);
+  assertBehaviorInstructions(triggerWrite.triggers, args.prompt);
 
   // Check slug uniqueness within org
   const existingSlug = await sql`
@@ -300,7 +302,7 @@ export async function handleCreate(
         reactions_guidance, change_notes, created_by, created_at
       ) VALUES (
         ${versionId}, ${watcherId}, 1, ${args.name ?? args.slug}, ${args.description ?? null},
-        ${args.prompt}, ${toJsonParam(tx, sources)},
+        ${args.prompt ?? ''}, ${toJsonParam(tx, sources)},
         ${toJsonParam(tx, keyingConfig)}, ${toJsonParam(tx, classifiers)},
         ${args.reactions_guidance ?? null}, ${'Initial version'}, ${createdBy}, NOW()
       )
@@ -397,7 +399,7 @@ export async function handleCreate(
         notification_channel: args.notification_channel ?? 'canvas',
         notification_priority: args.notification_priority ?? 'normal',
         min_cooldown_seconds: args.min_cooldown_seconds ?? 0,
-        prompt: args.prompt,
+        prompt: args.prompt ?? '',
         description: args.description ?? null,
         keying_config: keyingConfig ?? null,
         classifiers: classifiers ?? null,
@@ -462,6 +464,12 @@ export async function handleUpdate(
   ) {
     await assertBehaviorTriggerConnections(sql, currentRow.organization_id, triggerWrite.triggers);
   }
+  // NOTE: no instruction-presence assert here. `lobu apply` pushes triggers
+  // (`update`) and compiled instructions (`create_version`) as two non-atomic
+  // calls in that order, so asserting on a trigger write would reject the
+  // legitimate event-turn → schedule transition mid-apply. Creates and
+  // instruction writes are the enforced seams (see assertBehaviorInstructions
+  // in behaviors/triggers.ts).
 
   // Match the invariant from handleCreate: a watcher with no agent_id is
   // a zombie the scheduler will never run (automation joins on

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -829,6 +829,13 @@ export async function handleCreateFromVersion(
         // system:chat-link tag): those bind a live channel responder, and
         // cloning them would create a second agent turn for the same message.
         const cloneTriggers = stripChatLinkTriggers(version.triggers);
+        // After stripping, the residual trigger shape must still satisfy the
+        // instruction rule (chat-link-only sources become manual/empty triggers
+        // and require a non-empty prompt).
+        assertBehaviorInstructions(
+          (Array.isArray(cloneTriggers) ? cloneTriggers : []) as BehaviorTrigger[],
+          version.prompt as string | null | undefined
+        );
         // `tags` is a text[] column read under fetch_types:false, so postgres.js
         // hands back a raw array literal string (e.g. "{}" or "{system:chat-link}"),
         // not a JS array. Parse it before filtering.

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -155,14 +155,15 @@ function validateWatcherConfig(input: {
   classifiers?: unknown[];
   sources?: Array<{ name: string; query: string }>;
 }): string | null {
-  if (!input.prompt || typeof input.prompt !== 'string') {
-    return 'prompt is required and must be a string';
-  }
-
-  // Prompts are literal instruction text — no templating layer. Any `{{` is
-  // legal prose. Only reject an effectively empty prompt.
-  if (input.prompt.trim().length === 0) {
-    return 'prompt cannot be empty';
+  // Instruction PRESENCE is trigger-shape-dependent (event-turn Behaviors may
+  // run with no instruction text) and is enforced by assertBehaviorInstructions
+  // (behaviors/triggers.ts) at the create / create_version seams — here an
+  // absent or empty prompt is structurally valid.
+  //
+  // Prompts are literal instruction text — no templating layer — so `{{` is
+  // legal prose and there is nothing else to validate about the shape.
+  if (input.prompt !== undefined && typeof input.prompt !== 'string') {
+    return 'prompt must be a string';
   }
 
   // The output contract is no longer authored on the watcher. An entity-typed

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -157,8 +157,8 @@ function validateWatcherConfig(input: {
 }): string | null {
   // Instruction PRESENCE is trigger-shape-dependent (event-turn Behaviors may
   // run with no instruction text) and is enforced by assertBehaviorInstructions
-  // (behaviors/triggers.ts) at the create / create_version seams — here an
-  // absent or empty prompt is structurally valid.
+  // when either instructions or triggers change — here an absent or empty
+  // prompt is structurally valid.
   //
   // Prompts are literal instruction text — no templating layer — so `{{` is
   // legal prose and there is nothing else to validate about the shape.

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -172,15 +172,26 @@ export async function handleCreateVersion(
     );
   }
 
-  // Final-state instruction rule: inherited prompt + requested/current
-  // triggers. When set_as_current, the new pair becomes live; when not, only
-  // the version row is written and triggers stay on previousTriggers, so
-  // validate the draft prompt against the live trigger shape.
+  // Final-state instruction rule. The prompt version is group-shared
+  // (cascades to every assignment), while triggers are per-assignment — so
+  // when set_as_current, validate the new prompt against every sibling's
+  // final trigger set (the targeted row uses triggerWrite.triggers).
   const setAsCurrent = args.set_as_current !== false;
-  assertBehaviorInstructions(
-    setAsCurrent ? triggerWrite.triggers : previousTriggers,
-    prompt
-  );
+  if (setAsCurrent) {
+    const siblingRows = await sql`
+      SELECT id, triggers FROM watchers WHERE watcher_group_id = ${groupId}
+    `;
+    for (const sibling of siblingRows) {
+      const siblingTriggers =
+        Number(sibling.id) === Number(args.behavior_id)
+          ? triggerWrite.triggers
+          : ((sibling.triggers ?? []) as typeof triggerWrite.triggers);
+      assertBehaviorInstructions(siblingTriggers, prompt);
+    }
+  } else {
+    // Draft version only — triggers on the live row do not change.
+    assertBehaviorInstructions(previousTriggers, prompt);
+  }
 
   const createdBy = ctx.userId ?? 'system';
   let versionId = 0;

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -20,6 +20,7 @@ import {
   toJsonParam,
 } from './shared';
 import {
+  assertBehaviorInstructions,
   assertBehaviorTriggerConnections,
   behaviorTriggersEqual,
   resolveBehaviorTriggerWrite,
@@ -171,8 +172,17 @@ export async function handleCreateVersion(
     );
   }
 
-  const createdBy = ctx.userId ?? 'system';
+  // Final-state instruction rule: inherited prompt + requested/current
+  // triggers. When set_as_current, the new pair becomes live; when not, only
+  // the version row is written and triggers stay on previousTriggers, so
+  // validate the draft prompt against the live trigger shape.
   const setAsCurrent = args.set_as_current !== false;
+  assertBehaviorInstructions(
+    setAsCurrent ? triggerWrite.triggers : previousTriggers,
+    prompt
+  );
+
+  const createdBy = ctx.userId ?? 'system';
   let versionId = 0;
   let lockedNextVersion = nextVersion;
   await sql.begin(async (tx) => {

--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -94,12 +94,17 @@ PROJ="$RUN_DIR/proj"; mkdir -p "$PROJ"
 ( cd "$PROJ" && $LOBU init . -y --here --provider gemini >/dev/null 2>&1 )
 rm -rf "$PROJ/package.json" "$PROJ/node_modules" "$PROJ/bun.lock"
 cat > "$PROJ/lobu.config.ts" <<'TS'
-import { connectorFromFile, defineAgent, defineBehavior, defineConfig, defineConnection, defineEntityType, defineRelationshipType, reactionFromFile, secret } from "@lobu/cli/config";
+import { connectorFromFile, defineAgent, defineBehavior, defineConfig, defineConnection, defineEntityType, defineRelationshipType, defineSkill, reactionFromFile, secret } from "@lobu/cli/config";
 import type PulseConnector from "./connectors/pulse.connector.ts";
 import type digestReaction from "./reactions/digest.reaction.ts";
 
+// The Behavior's instructions live in the agent's skill library; `lobu apply`
+// compiles the referenced bodies into the Behavior version's frozen prompt.
+const digestSkill = defineSkill({ name: "digest", content: "summarize" });
+
 const agent = defineAgent({
   id: "echo", name: "Echo", dir: "./agents/echo",
+  skills: [digestSkill],
   providers: [{ id: "mock", model: "mock-model", key: secret("MOCK_API_KEY") }],
 });
 // `company` exercises the declarative rendering config: event_kinds (with a
@@ -139,7 +144,7 @@ const pulseConn = defineConnection({
 // (the agentic LLM turn never produces the complete_window tool-call against a
 // fixed-reply mock) and asserts the reaction's side effect.
 const digest = defineBehavior({
-  slug: "digest", agent, name: "Digest", prompt: "summarize",
+  slug: "digest", agent, name: "Digest", skills: ["digest"],
   // No inline extraction schema — the reaction OWNS the contract via its exported
   // `input`, which set_reaction_script extracts and surfaces to the worker.
   reaction: reactionFromFile<typeof digestReaction>("./reactions/digest.reaction.ts"),


### PR DESCRIPTION
## Summary
- Add optional `skills?: string[]` on `defineBehavior`.
- At `lobu apply`, expand ordered skill bodies into the Behavior version prompt so scheduled/window/manual runs freeze instruction text (no live skill-library override for automations).
- Server create/update validates: schedule, window-execution, or empty triggers require non-empty instructions; event-turn listen behaviors may omit them.
- CLI expands skills before diff so plan matches apply. Examples migrated to `skills: [...]`.

Part of issue #2320 (thin Skills track PR 2, after #2324).

## Test plan
- [x] `make pre-pr` clean
- [x] CLI unit: map-config + load-config skill compile paths (86 tests)
- [x] Unit: `behavior-instructions-rule.test.ts`
- [x] Integration: `manage-behaviors-instruction-rule.test.ts` (5/5)
- [ ] Full unit/integration in CI

## Notes
- Isolation of live skill library on Behavior runs (PR 3) is a follow-up.
- Follows #2324 skill nix strip on main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->