### PR TITLE
fix(server): name the approval gate in a Behavior finalize failure

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -68,6 +68,7 @@ async function createDueWatcherWithDispatchedRun(opts: {
 
   return {
     sql,
+    organizationId: workspace.org.id,
     watcherId,
     runId: Number(run.id),
     staleCursor,
@@ -257,4 +258,104 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
       expect(queries).toBe(failAtQuery);
     });
   }
+});
+
+describe("finalize-miss diagnostics", () => {
+  it("names the pending tool approval instead of blaming the agent", async () => {
+    const { sql, organizationId, watcherId, runId } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "finalize-miss-names-approval",
+        messageId: "msg-gated-approval",
+        nudgeCount: 99,
+      });
+    await sql`
+      INSERT INTO oauth_states (id, scope, payload, expires_at)
+      VALUES (
+        ${`ta_test_${runId}`},
+        'pending-tool',
+        ${sql.json({
+          mcpId: "lobu-memory",
+          toolName: "run_sdk",
+          agentId: "advance-agent-finalize-miss-names-approval",
+          userId: "u1",
+          organizationId,
+          args: {},
+          conversationId: `personal-agent_watcher_${watcherId}_run_${runId}`,
+        })},
+        NOW() + INTERVAL '1 hour'
+      )
+    `;
+
+    await resolveWatcherRunsByMessageIds(["msg-gated-approval"], { ok: true });
+
+    const [run] =
+      await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+    expect(run.error_message).toMatch(/blocked on tool approval/);
+    expect(run.error_message).toMatch(/lobu-memory\/run_sdk/);
+    expect(run.error_message).not.toMatch(/finished without calling/);
+  });
+
+  it("ignores approvals outside the run's tenant and conversation", async () => {
+    const { sql, organizationId, watcherId, runId } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "finalize-miss-scopes-approval",
+        messageId: "msg-scoped-approval",
+        nudgeCount: 99,
+      });
+    const pending = (
+      id: string,
+      toolName: string,
+      org: string,
+      behaviorId: number
+    ) => sql`
+        INSERT INTO oauth_states (id, scope, payload, expires_at)
+        VALUES (
+          ${id},
+          'pending-tool',
+          ${sql.json({
+            mcpId: "lobu-memory",
+            toolName,
+            agentId: "advance-agent-finalize-miss-scopes-approval",
+            userId: "u1",
+            organizationId: org,
+            args: {},
+            conversationId:
+              `personal-agent_watcher_${behaviorId}_run_${runId}`,
+          })},
+          NOW() + INTERVAL '1 hour'
+        )
+      `;
+    await pending(`ta_wrong_org_${runId}`, "wrong_org", "other-org", watcherId);
+    await pending(
+      `ta_wrong_behavior_${runId}`,
+      "wrong_behavior",
+      organizationId,
+      watcherId + 1
+    );
+
+    await resolveWatcherRunsByMessageIds(["msg-scoped-approval"], { ok: true });
+
+    const [run] =
+      await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+    expect(run.error_message).toMatch(/No active tool approval was found/);
+    expect(run.error_message).not.toMatch(/wrong_org|wrong_behavior/);
+  });
+
+  it("falls back to the agent-miss message when nothing is pending", async () => {
+    const { sql, runId } = await createDueWatcherWithDispatchedRun({
+      slug: "finalize-miss-no-approval",
+      messageId: "msg-no-approval",
+      nudgeCount: 99,
+    });
+
+    await resolveWatcherRunsByMessageIds(["msg-no-approval"], { ok: true });
+
+    const [run] =
+      await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+    expect(run.error_message).toMatch(/finished without calling/);
+    expect(run.error_message).toMatch(/No active tool approval was found/);
+  });
 });

--- a/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
+++ b/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
@@ -93,3 +93,35 @@ export async function takePendingTool(
   if (rows.length === 0) return null;
 	return (rows[0] as { payload: PendingToolInvocation }).payload ?? null;
 }
+
+/** Active tool approvals belonging to this Behavior run's agent session. */
+export async function listPendingToolsForRun(
+	runId: number,
+	sql: ReturnType<typeof getDb>
+): Promise<Array<{ mcpId: string; toolName: string }>> {
+	const rows = await sql`
+    SELECT DISTINCT
+      pending.payload->>'mcpId' AS mcp_id,
+      pending.payload->>'toolName' AS tool_name
+    FROM oauth_states pending
+    JOIN runs behavior_run
+      ON behavior_run.id = ${runId}
+     AND behavior_run.run_type = 'behavior'
+    WHERE pending.scope = ${SCOPE}
+      AND pending.expires_at > now()
+      AND pending.payload->>'organizationId' = behavior_run.organization_id
+      AND right(
+        pending.payload->>'conversationId',
+        length(
+          '_watcher_' || behavior_run.watcher_id::text ||
+          '_run_' || behavior_run.id::text
+        )
+      ) = '_watcher_' || behavior_run.watcher_id::text ||
+          '_run_' || behavior_run.id::text
+    ORDER BY mcp_id, tool_name
+  `;
+	return rows
+		.map((r) => r as { mcp_id: string | null; tool_name: string | null })
+		.filter((r) => r.mcp_id && r.tool_name)
+		.map((r) => ({ mcpId: r.mcp_id as string, toolName: r.tool_name as string }));
+}

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -27,7 +27,10 @@ import logger from "../utils/logger";
 import { isUniqueViolation } from "../utils/pg-errors";
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
 import { computePendingWindow } from "../utils/window-utils";
-import { advanceWatcherSchedule } from "./schedule-cursor";
+import {
+	advanceScheduleAfterTerminalFailure,
+	advanceWatcherSchedule,
+} from "./schedule-cursor";
 import {
 	findWindowIdForRun,
 	markWatcherRunCompleted,
@@ -347,13 +350,14 @@ async function markWatcherRunFailedIdempotent(
           completed_at = current_timestamp,
           error_message = ${message}
       WHERE id = ${runId}
-        AND status IN ('running', 'claimed', 'pending')
+        AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
       RETURNING watcher_id, approved_input->>'dispatch_source' AS dispatch_source
     `;
-		if (!failed || failed.dispatch_source === "event") return;
-		await advanceWatcherSchedule(
+		if (!failed) return;
+		await advanceScheduleAfterTerminalFailure(
 			tx,
-			failed.watcher_id == null ? null : Number(failed.watcher_id)
+			failed.watcher_id == null ? null : Number(failed.watcher_id),
+			failed.dispatch_source
 		);
 	});
 }

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -1,8 +1,9 @@
 import type { DbClient } from "../db/client";
 import { getDb, pgTextArray } from "../db/client";
+import { listPendingToolsForRun } from "../gateway/auth/mcp/pending-tool-store";
 import logger from "../utils/logger";
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
-import { advanceWatcherSchedule } from "./schedule-cursor";
+import { advanceScheduleAfterTerminalFailure } from "./schedule-cursor";
 
 type WatcherTerminalResult = { ok: true } | { ok: false; error: string };
 
@@ -102,12 +103,11 @@ async function markWatcherRunFailed(
       RETURNING watcher_id, approved_input->>'dispatch_source' AS dispatch_source
     `;
 		if (!failed) return false;
-		if (failed.dispatch_source !== "event") {
-			await advanceWatcherSchedule(
-				tx,
-				failed.watcher_id == null ? null : Number(failed.watcher_id)
-			);
-		}
+		await advanceScheduleAfterTerminalFailure(
+			tx,
+			failed.watcher_id == null ? null : Number(failed.watcher_id),
+			failed.dispatch_source
+		);
 		return true;
 	});
 }
@@ -205,10 +205,7 @@ export async function resolveWatcherRunsByMessageIds(
 				await markWatcherRunFailed(
 					sql,
 					runId,
-					"Agent reply finished without calling run_sdk (client.behaviors.completeWindow)" +
-						(budget > 0 ? ` after ${budget + 1} attempt(s)` : "") +
-						". Check that the assigned agent has the lobu-memory MCP attached and that query_sdk / " +
-						"run_sdk tools are approved for it."
+					await describeFinalizeMiss(sql, runId, budget)
 				)
 			) {
 				resolved++;
@@ -221,4 +218,48 @@ export async function resolveWatcherRunsByMessageIds(
 	}
 
 	return { resolved };
+}
+
+async function describeFinalizeMiss(
+	sql: DbClient,
+	runId: number,
+	budget: number
+): Promise<string> {
+	const attempts = budget > 0 ? ` after ${budget + 1} attempt(s)` : "";
+	const agentMiss =
+		"Agent reply finished without calling run_sdk (client.behaviors.completeWindow)" +
+		attempts;
+	let pending: Array<{ mcpId: string; toolName: string }>;
+	try {
+		pending = await listPendingToolsForRun(runId, sql);
+	} catch (error) {
+		logger.warn(
+			{ error, run_id: runId },
+			"[watchers] Could not check pending tool approvals for a finalize miss"
+		);
+		return (
+			agentMiss +
+			". Tool approval status could not be checked; inspect the warning log " +
+			"before attributing the miss to the agent."
+		);
+	}
+
+	if (pending.length > 0) {
+		const tools = pending.map((p) => `${p.mcpId}/${p.toolName}`).join(", ");
+		const grants = pending
+			.map((p) => `/mcp/${p.mcpId}/tools/${p.toolName}`)
+			.join(", ");
+		return (
+			`Behavior run blocked on tool approval${attempts}: ${tools} queued for ` +
+			"human approval, so complete_window never ran. Headless Behavior runs " +
+			`cannot answer approval cards; grant standing access (${grants}) and ` +
+			"retry the Behavior."
+		);
+	}
+
+	return (
+		agentMiss +
+		". No active tool approval was found, so check that the assigned agent has the " +
+		"lobu-memory MCP attached and that query_sdk / run_sdk are available to it."
+	);
 }

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -70,3 +70,23 @@ export async function advanceWatcherSchedule(
     WHERE id = ${watcherId}
   `;
 }
+
+/**
+ * Advance after terminal failure unless the run came from an event. Event
+ * delivery is independent of the cron cursor, so advancing it would skip the
+ * next scheduled activation. Call inside the failure transaction.
+ *
+ * Shared deliberately: three paths mark a Behavior run failed — agent dispatch
+ * (`failWatcherRun`), turn resolution (`resolveWatcherRunsByMessageIds`), and
+ * the device-CLI `/complete-behavior` endpoint. Written out three times the
+ * carve-out drifts, and a diff-scoped reviewer only ever sees one copy. Keep it
+ * here rather than re-inlining.
+ */
+export async function advanceScheduleAfterTerminalFailure(
+	sql: DbClient,
+	watcherId: number | null | undefined,
+	dispatchSource: string | null | undefined
+): Promise<void> {
+	if (dispatchSource === "event") return;
+	await advanceWatcherSchedule(sql, watcherId);
+}

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -54,7 +54,7 @@ import {
 import { insertEvent, recordLifecycleEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
 import { stripNulDeep } from "../utils/strip-nul";
-import { advanceWatcherSchedule } from "../watchers/schedule-cursor";
+import { advanceScheduleAfterTerminalFailure } from "../watchers/schedule-cursor";
 import { authorizeRunForWorker } from "./shared";
 
 type DbClient = ReturnType<typeof getDb>;
@@ -905,9 +905,9 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 			? Math.max(0, Math.floor(body.duration_ms))
 			: null;
 
-	// Mark the run failed and tick the schedule forward — but only when the
-	// UPDATE actually transitioned the row (RETURNING guard), so a concurrent
-	// duplicate POST can't double-advance `next_run_at` and skip a window.
+	// Mark the run failed and, for non-event dispatches, tick the schedule
+	// forward. The RETURNING guard keeps a concurrent duplicate POST from
+	// advancing `next_run_at` twice and skipping a window.
 	// The stdout tail is stashed for diagnosis (why didn't the agent call
 	// complete_window?); the worker redacts before sending.
 	const failRun = async (reason: string): Promise<boolean> => {
@@ -931,9 +931,13 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
         SET last_fired_at = NOW(), updated_at = NOW()
         WHERE id = ${watcherId}
       `;
-			if (approved.dispatch_source !== "event") {
-				await advanceWatcherSchedule(tx, watcherId);
-			}
+			await advanceScheduleAfterTerminalFailure(
+				tx,
+				watcherId,
+				typeof approved.dispatch_source === "string"
+					? approved.dispatch_source
+					: null
+			);
 			return true;
 		});
 	};


### PR DESCRIPTION
## Summary
Two fixes to the Behavior terminal-failure path, both surfaced by a multi-day prod investigation into Behavior 5 — **2,100 failed runs in 45 hours**, every one dispatching the identical stale window.

### 1. The terminal message named the wrong cause

It read:

> Agent reply finished without calling run_sdk (client.behaviors.completeWindow)

**The agent had called it.** The MCP proxy blocked the call pending human approval and the session ended before it executed:

> `Tool call requires approval. The user has been asked to approve. Your session will end.`

A scheduled dispatch has no human in the loop, so those cards never resolve. Prod had **26 live `pending-tool` rows**, all `personal-agent → lobu-memory → run_sdk`, while the runs were being recorded as "the agent never called it".

That message points every investigation at the prompt or the model instead of the missing grant. It cost days here, and the fix was a single grant row.

`describeFinalizeMiss` now checks `oauth_states` for approvals queued by that run and names the real cause and remedy:

```
Behavior run blocked on tool approval after 2 attempt(s): lobu-memory/run_sdk
queued for human approval and was never granted, so complete_window never ran.
A scheduled run has no human in the loop — grant the agent standing access to
/mcp/lobu-memory/tools/run_sdk, or approve the pending request.
```

With nothing pending it falls back to the agent-miss message, now explicitly saying no approval was pending so the two cases are distinguishable.

The lookup is wrapped in try/catch — a diagnostic must never change the terminal outcome.

### 2. The event carve-out lived in three places

"A failed **event** dispatch must not advance the cron cursor" (advancing would silently skip that Behavior's next scheduled activation) was written out at all three failure paths:

```
automation.ts      markWatcherRunFailedIdempotent   (agent dispatch)
run-completion.ts  markWatcherRunFailed             (turn resolution)
run-lifecycle.ts   failRun                          (device-CLI complete-behavior)
```

Extracted to `advanceScheduleAfterTerminalFailure`. Three copies drift, and a diff-scoped reviewer only ever sees the one in front of it.

Also unifies `automation.ts`'s hardcoded `IN ('running','claimed','pending')` to the existing `ACTIVE_RUN_STATUSES` constant — identical set, two spellings.

## Test plan
- [x] `make pre-pr` clean (caught a real `unknown` → `string` type error the tests could not: `approved.dispatch_source`)
- [x] `bunx vitest run src/__tests__/integration/watchers/ src/__tests__/integration/watchers-feeds-timezone.test.ts` → **176 pass, 19 files**
- [x] `make review-fix` applied and reviewed

### Mutation testing
| mutant | result |
|---|---|
| ignore pending approvals (restore the misleading message) | **1 fail** |
| drop the `dispatch_source === "event"` carve-out from the shared helper | **1 fail** |

The second is the payoff from consolidating: the carve-out now has exactly one place to break, and a test watching it.

## Notes
**Not in scope: `execution_config.permission_mode` is inert.** `git grep permission_mode origin/main` finds only the TypeBox contract and a role-validation check; `permissionMode` has zero hits. Nothing reads it, so `"dontAsk"` does nothing and every agent still needs a manually added `mcp_tool` grant. Making it real means shipping a config switch that disables human approval for write tools — a security-design decision that deserves its own PR, not a rider on this one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->