### PR TITLE
feat(server): record and show what a merge re-check changed

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -329,6 +329,10 @@ describe("manage_entity merge action", () => {
 			RESOLUTION_FINGERPRINT_VERSION,
 		);
 		expect(resetInput.resolution_fingerprint).not.toBe("0".repeat(64));
+		expect(resetInput.evidence_change).toEqual({
+			dropped: [],
+			gained: [],
+		});
 
 		const [recheckedEvent] = await sql`
 			SELECT title, interaction_status, interaction_input, metadata
@@ -343,6 +347,7 @@ describe("manage_entity merge action", () => {
 			current: resetInput.current,
 			proposal: {
 				evidence: resetInput.evidence,
+				evidence_change: resetInput.evidence_change,
 			},
 			reason: resetInput.reason,
 		});
@@ -454,6 +459,15 @@ describe("manage_entity merge action", () => {
 		expect("error" in refused && refused.error).toMatch(
 			/re-checked.*approve again to apply/i,
 		);
+		const [refreshedRun] = await sql`
+			SELECT action_input FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		expect(
+			(refreshedRun.action_input as Record<string, unknown>).evidence_change,
+		).toEqual({
+			dropped: [],
+			gained: [{ kind: "phone", identifier: "447700900123" }],
+		});
 
 		const [untouched] =
 			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
@@ -527,11 +541,21 @@ describe("manage_entity merge action", () => {
 		expect(untouched.deleted_at).toBeNull();
 
 		const [card] = await sql`
-			SELECT title FROM current_event_records WHERE run_id = ${queued.approval_run_id}
+			SELECT title, metadata
+			FROM current_event_records
+			WHERE run_id = ${queued.approval_run_id}
 		`;
 		expect(card.title).toBe(
 			"entity_merge — evidence no longer supports the merge",
 		);
+		expect(card.metadata).toMatchObject({
+			proposal: {
+				evidence_change: {
+					dropped: [{ kind: "phone", identifier: "447700900123" }],
+					gained: [],
+				},
+			},
+		});
 	});
 
 	it("does not downgrade a merge fingerprint from a newer format", async () => {

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -509,6 +509,18 @@ describe("manage_entity merge action", () => {
 		// The message must name the specific proof that stopped holding.
 		expect("error" in refused && refused.error).toMatch(/447700900123/);
 
+		// The card renders the delta from evidence_change, so the refreshed proposal
+		// must carry it — naming the proof that was lost, and gaining nothing.
+		const [refreshedRun] = await sql`
+			SELECT action_input FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		expect(
+			(refreshedRun.action_input as Record<string, unknown>).evidence_change,
+		).toEqual({
+			dropped: [{ kind: "phone", identifier: "447700900123" }],
+			gained: [],
+		});
+
 		const [untouched] =
 			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
 		expect(untouched.merged_into).toBeNull();

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -20,7 +20,11 @@ import {
 	type ResolutionEvidence,
 	type ResolutionKeySet,
 } from "../../entity-resolution/policy";
-import { hasMergeEvidenceStrengthened } from "../../entity-resolution/evidence-strength";
+import {
+	droppedEvidence,
+	gainedEvidence,
+	hasMergeEvidenceStrengthened,
+} from "../../entity-resolution/evidence-strength";
 import {
 	assertResolutionFingerprintCurrent,
 	ResolutionFingerprintError,
@@ -149,6 +153,15 @@ export interface EntityMergeProposal {
 	 * last input-format change, so a mismatch is refreshed rather than guessed.
 	 */
 	resolution_fingerprint_version?: number | null;
+	/**
+	 * How the last re-check changed the evidence, against what the reviewer was
+	 * previously shown. Written only by `refreshMergeProposalFingerprint`; absent
+	 * on a first-time proposal, where there is nothing to compare against.
+	 */
+	evidence_change?: {
+		dropped: ResolutionEvidence[];
+		gained: ResolutionEvidence[];
+	} | null;
 	attribution?: ApprovalAttributionType;
 	reason?: string | null;
 	/**
@@ -577,6 +590,7 @@ export async function refreshMergeProposalFingerprint(
 		winnerEntityId: proposal.winner_entity_id,
 		resolutionKeys: assessment.resolutionKeys,
 	});
+	const reviewedEvidence = proposal.evidence ?? [];
 	const refreshed: EntityMergeProposal = {
 		...proposal,
 		current,
@@ -585,6 +599,14 @@ export async function refreshMergeProposalFingerprint(
 		policy_hash: assessment.policyHash,
 		resolution_fingerprint: assessment.fingerprint,
 		resolution_fingerprint_version: RESOLUTION_FINGERPRINT_VERSION,
+		// Record the delta against what the reviewer was last shown. Only this
+		// side sees both snapshots — the card receives the refreshed proposal
+		// alone — so computing it here is what lets the card say what moved
+		// instead of re-presenting an identical-looking card.
+		evidence_change: {
+			dropped: droppedEvidence(reviewedEvidence, assessment.evidence),
+			gained: gainedEvidence(reviewedEvidence, assessment.evidence),
+		},
 	};
 	await db`
 		UPDATE runs

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -252,6 +252,9 @@ export function mergeReviewEventMetadata(proposal: EntityMergeProposal) {
 			entity_ids: mergeEntityIds(proposal),
 			winner_entity_id: proposal.winner_entity_id,
 			evidence: proposal.evidence ?? [],
+			...(proposal.evidence_change
+				? { evidence_change: proposal.evidence_change }
+				: {}),
 			names: duplicates.map((entity) => entity.name),
 			name: proposal.current.loser.name,
 			winner_name: proposal.current.winner.name,


### PR DESCRIPTION
## Summary

Follow-up to #2330, which made a re-checked merge apply on one approval but left the reviewer unable to see *what* the re-check changed.

- The refresh path now records `evidence_change: {dropped, gained}` on the proposal, measured against what the reviewer was previously shown. Only the server sees both snapshots — the card receives the refreshed proposal alone — so computing it here is what makes the delta renderable at all.
- `mergeReviewEventMetadata` carries it onto the approval card metadata. Without that the delta sat in `action_input` and the card's metadata path saw nothing.
- Repoints owletto to `05636095`, which renders it.

## The UI half took three attempts, and the first two were on the wrong component

owletto #629 and #630 added the block to `buildEntityMergeInteraction` — the **agent-chat** card. The Memory page, where merges are actually reviewed, renders `MergeApprovalPanel` inside `event-card.tsx`. Both PRs were green, mutation-verified, and invisible on the surface that matters; tests on a builder prove the builder works, not that anything renders it. #631 fixes the real card.

## Test plan
- [x] `make pre-pr` clean
- [x] `make test-unit` — 167 pass / 0 fail
- [x] Integration + resolution suites — 62 pass / 0 fail
- [x] owletto — 23 pass on the card, 11 on the builder
- [x] **Driven in a booted app across all four states** (dev server + vite with `LOBU_API_PROXY`), DOM read plus screenshot, and confirmed by the reporter clicking it:

| seeded run | state | rendered |
|---|---|---|
| 95 | evidence weakened | `WHAT CHANGED SINCE YOU REVIEWED THIS / No longer proven Phone: 905355951101` |
| 96 | re-checked, unchanged | `EVIDENCE RE-CHECKED / The recorded match evidence did not change.` |
| 97 | strengthened (shape of the 18 stranded prod proposals) | no block; one Confirm applies |
| 98 | ordinary first-time proposal | no block |

### Mutation-verified

| mutation | result |
|---|---|
| emit an empty delta from the server | integration test fails |
| suppress the unchanged case in the card | `says so when a re-check changed nothing` fails |
| accept malformed payloads | `ignores a malformed evidence_change` fails |

## Notes

An `evidence_change` of `{dropped: [], gained: []}` must still render — it is the most common re-presented card (the fingerprint moved because an identity appeared on one side only, which produces no match and so changes no evidence), and it was the state that still looked identical to the card the reviewer had already clicked. Malformed payloads stay silent, so the two cases are separated explicitly rather than both collapsing to "empty".

Once this rolls out, the 18 stranded proposals in `buremba` are one click each **and** show why.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->