### PR TITLE
fix(server): honour min_cooldown_seconds on event-triggered Behaviors

### DIFF
--- a/db/migrations/20260730120000_watchers_last_event_activation_at.sql
+++ b/db/migrations/20260730120000_watchers_last_event_activation_at.sql
@@ -11,14 +11,15 @@
 --     finish.
 --   * `runs.created_at` covers background Behaviors but not `reply_to_source`
 --     ones — reply targets are routed through the chat transport and never
---     write a `behavior` run row, so the cooldown would be a silent no-op on
---     exactly the Behaviors an operator is most likely to want debounced.
+--     write a `behavior` run row, so the cooldown would be a silent no-op for
+--     reply Behaviors.
 --
 -- One cursor, written by both activation paths under the existing
 -- per-Behavior advisory lock, keeps a single predicate for a single feature.
 -- Deliberately scoped to event activations: a schedule already spaces its own
--- firings (cron IS the operator's cadence control), and suppressing a
--- scheduled firing would strand `next_run_at` in the past and hot-loop.
+-- firings (cron IS the operator's cadence control). Applying this debounce in
+-- the event activation path to a scheduled firing would also bypass the
+-- scheduler's `next_run_at` advancement and leave the cursor due.
 --
 -- Nullable with no backfill: an existing Behavior has no recorded event
 -- activation, so its first activation after this deploy is allowed. That is

--- a/db/migrations/20260730120000_watchers_last_event_activation_at.sql
+++ b/db/migrations/20260730120000_watchers_last_event_activation_at.sql
@@ -1,0 +1,32 @@
+-- migrate:up
+
+-- `min_cooldown_seconds` is the operator's debounce for event-triggered
+-- Behaviors. It needs a cursor recording when a Behavior last *activated on an
+-- event*, and none of the existing columns mean that:
+--
+--   * `last_fired_at` is stamped when a run reaches a TERMINAL state
+--     (run-lifecycle completion/failure). A burst that starts a run and
+--     immediately re-fires would not be debounced by the run it just started,
+--     so the cooldown would only take effect after the first run happened to
+--     finish.
+--   * `runs.created_at` covers background Behaviors but not `reply_to_source`
+--     ones — reply targets are routed through the chat transport and never
+--     write a `behavior` run row, so the cooldown would be a silent no-op on
+--     exactly the Behaviors an operator is most likely to want debounced.
+--
+-- One cursor, written by both activation paths under the existing
+-- per-Behavior advisory lock, keeps a single predicate for a single feature.
+-- Deliberately scoped to event activations: a schedule already spaces its own
+-- firings (cron IS the operator's cadence control), and suppressing a
+-- scheduled firing would strand `next_run_at` in the past and hot-loop.
+--
+-- Nullable with no backfill: an existing Behavior has no recorded event
+-- activation, so its first activation after this deploy is allowed. That is
+-- the correct reading of "has not fired within the cooldown window".
+ALTER TABLE public.watchers
+  ADD COLUMN IF NOT EXISTS last_event_activation_at timestamp with time zone;
+
+-- migrate:down
+
+ALTER TABLE public.watchers
+  DROP COLUMN IF EXISTS last_event_activation_at;

--- a/packages/server/src/__tests__/integration/behaviors/event-trigger-cooldown.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/event-trigger-cooldown.test.ts
@@ -5,6 +5,13 @@
  * MCP contract, `defineBehavior`, and `lobu apply` since it was added, and no
  * dispatch path ever read it. An operator who set it got no debounce at all.
  *
+ * WHERE THE CHECK LIVES: at the chokepoint that already serializes a Behavior
+ * activation — the `pg_advisory_xact_lock` inside `createBehaviorEventRun` —
+ * NOT in `findMatchingBehaviorActivations`. The lookup is an unlocked SELECT,
+ * so two concurrent deliveries would both read "no recent activation" and both
+ * fire. `debounces two concurrent deliveries` below is the regression test for
+ * that; it fails against a cooldown evaluated during the match.
+ *
  * WHY ONLY THE EVENT PATH: a schedule already spaces its own firings — cron IS
  * the operator's cadence control — so a cooldown there is redundant. Worse, the
  * scheduled path would have to skip materializing a run, and `next_run_at` only
@@ -12,13 +19,17 @@
  * A suppressed scheduled firing would leave the cursor in the past and the
  * Behavior would re-select on every tick forever — exactly the hot loop #2326
  * fixed. Event activations have no cursor to strand: suppressing one simply
- * means that event does not fire this Behavior. So the cooldown belongs here
- * and only here.
+ * means that event does not fire this Behavior.
  */
 
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { findMatchingBehaviorActivations } from "../../../behaviors/activation";
+import {
+	findMatchingBehaviorActivations,
+	queueBehaviorActivations,
+} from "../../../behaviors/activation";
+import { claimBehaviorCooldownStandalone } from "../../../behaviors/cooldown";
 import type { Env } from "../../../index";
+import { createBehaviorEventRun } from "../../../runs/queue-service";
 import { manageBehaviors } from "../../../tools/admin/manage_behaviors";
 import { initWorkspaceProvider } from "../../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
@@ -53,14 +64,14 @@ interface Workspace {
 
 async function behaviorWithCooldown(
 	cooldownSeconds: number,
-	reuse?: Workspace,
+	options?: { reuse?: Workspace; activeRun?: "queue" | "coalesce" },
 ): Promise<Fixture & { workspace: Workspace }> {
 	const sql = getTestDb();
 	const slug = `cooldown-${++counter}`;
 
 	let workspace: Workspace;
-	if (reuse) {
-		workspace = reuse;
+	if (options?.reuse) {
+		workspace = options.reuse;
 	} else {
 		const seeded = await seedOwnerContext();
 		workspace = {
@@ -98,7 +109,7 @@ async function behaviorWithCooldown(
 					connection_id: connectionId,
 					event_types: ["pull_request.updated"],
 					execution: "window",
-					active_run: "coalesce",
+					active_run: options?.activeRun ?? "coalesce",
 					output: "silent",
 				},
 			],
@@ -132,26 +143,52 @@ async function behaviorWithCooldown(
 	};
 }
 
-/** A prior firing of this Behavior, `secondsAgo` in the past. */
-async function priorRun(
+/** A prior event activation of this Behavior, `secondsAgo` in the past. */
+async function priorActivation(
 	fixture: Fixture,
 	secondsAgo: number,
-	status = "completed",
 ): Promise<void> {
 	const sql = getTestDb();
 	await sql`
-    INSERT INTO runs (organization_id, run_type, watcher_id, status, created_at)
-    VALUES (${fixture.organizationId}, 'behavior', ${fixture.behaviorId},
-            ${status}, now() - make_interval(secs => ${secondsAgo}))
+    UPDATE watchers
+    SET last_event_activation_at = now() - make_interval(secs => ${secondsAgo})
+    WHERE id = ${fixture.behaviorId}
   `;
 }
 
-async function matches(fixture: Fixture): Promise<number> {
-	const found = await findMatchingBehaviorActivations(
-		fixture.organizationId,
-		{ ...fixture.signal, delivery_id: `event:cooldown:${++counter}` },
+async function match(fixture: Fixture) {
+	const found = await findMatchingBehaviorActivations(fixture.organizationId, {
+		...fixture.signal,
+		delivery_id: `event:cooldown:${++counter}`,
+	});
+	const activation = found.find(
+		(candidate) => candidate.behaviorId === fixture.behaviorId,
 	);
-	return found.length;
+	if (!activation) throw new Error("Behavior did not match its own signal");
+	return activation;
+}
+
+/** Drive one delivery all the way through the durable activation path. */
+async function activate(fixture: Fixture): Promise<"queued" | "suppressed"> {
+	const activation = await match(fixture);
+	const results = await queueBehaviorActivations({
+		matches: [activation],
+		signal: {
+			...fixture.signal,
+			delivery_id: `event:cooldown:${++counter}`,
+		},
+	});
+	return results.length > 0 ? "queued" : "suppressed";
+}
+
+async function behaviorRunCount(fixture: Fixture): Promise<number> {
+	const sql = getTestDb();
+	const [row] = await sql`
+    SELECT count(*)::int AS n
+    FROM runs
+    WHERE watcher_id = ${fixture.behaviorId} AND run_type = 'behavior'
+  `;
+	return Number(row.n);
 }
 
 describe("min_cooldown_seconds debounces event-triggered Behaviors", () => {
@@ -165,53 +202,167 @@ describe("min_cooldown_seconds debounces event-triggered Behaviors", () => {
 
 	it("suppresses an activation inside the cooldown window", async () => {
 		const fixture = await behaviorWithCooldown(1800);
-		await priorRun(fixture, 60);
+		await priorActivation(fixture, 60);
 
-		expect(await matches(fixture)).toBe(0);
+		expect(await activate(fixture)).toBe("suppressed");
+		expect(await behaviorRunCount(fixture)).toBe(0);
 	});
 
 	it("allows an activation once the cooldown has elapsed", async () => {
 		const fixture = await behaviorWithCooldown(1800);
-		await priorRun(fixture, 7200);
+		await priorActivation(fixture, 7200);
 
-		expect(await matches(fixture)).toBe(1);
+		expect(await activate(fixture)).toBe("queued");
+		expect(await behaviorRunCount(fixture)).toBe(1);
 	});
 
 	it("allows the first activation when the Behavior has never run", async () => {
 		const fixture = await behaviorWithCooldown(1800);
 
-		expect(await matches(fixture)).toBe(1);
+		expect(await activate(fixture)).toBe("queued");
 	});
 
 	it("does not debounce at all when the cooldown is 0 (the default)", async () => {
 		const fixture = await behaviorWithCooldown(0);
-		await priorRun(fixture, 1);
+		await priorActivation(fixture, 1);
 
-		expect(await matches(fixture)).toBe(1);
+		expect(await activate(fixture)).toBe("queued");
 	});
 
-	it("counts a still-running firing, not just a finished one", async () => {
+	it("consumes the window on the activation itself, not on run completion", async () => {
 		// A burst that starts a run and immediately re-fires must be debounced by
-		// the run it just started, otherwise the cooldown only works after the
-		// first run happens to finish.
-		const fixture = await behaviorWithCooldown(1800);
-		await priorRun(fixture, 5, "running");
+		// the run it just started. `watchers.last_fired_at` is stamped when a run
+		// reaches a TERMINAL state, so a cooldown built on it would only take
+		// effect after the first run happened to finish — hence the dedicated
+		// dispatch-time cursor. `active_run: "queue"` so the second signal is
+		// judged by the cooldown rather than folded into the pending run.
+		const fixture = await behaviorWithCooldown(1800, { activeRun: "queue" });
 
-		expect(await matches(fixture)).toBe(0);
+		expect(await activate(fixture)).toBe("queued");
+		expect(await activate(fixture)).toBe("suppressed");
+		expect(await behaviorRunCount(fixture)).toBe(1);
+	});
+
+	it("debounces two concurrent deliveries, not just sequential ones", async () => {
+		// THE regression test for the blocker that drafted #2341: with the check
+		// in `findMatchingBehaviorActivations` both deliveries pass the unlocked
+		// SELECT before either run exists, and two runs are created. The claim
+		// only holds when it happens under the advisory lock that already
+		// serializes `createBehaviorEventRun`.
+		// `active_run: "queue"`, not the fixture default: a coalescing trigger
+		// folds the second signal into the pending run and correctly never
+		// reaches the cooldown, which would mask the race this test exists for.
+		const fixture = await behaviorWithCooldown(1800, { activeRun: "queue" });
+		const activation = await match(fixture);
+
+		const settled = await Promise.all(
+			[1, 2].map((n) =>
+				createBehaviorEventRun({
+					organizationId: fixture.organizationId,
+					watcherId: fixture.behaviorId,
+					agentId: fixture.workspace.agentId,
+					trigger: activation.trigger,
+					signal: {
+						...fixture.signal,
+						// Distinct delivery ids: this must be debounced by the cooldown,
+						// not incidentally by the delivery-id dedupe.
+						delivery_id: `event:concurrent:${fixture.behaviorId}:${n}`,
+					},
+				}),
+			),
+		);
+
+		const dispositions = settled.map((result) => result.disposition).sort();
+		expect(dispositions).toEqual(["cooldown", "queued"]);
+		expect(await behaviorRunCount(fixture)).toBe(1);
 	});
 
 	it("scopes the cooldown to one Behavior, not the whole connection", async () => {
 		const cooling = await behaviorWithCooldown(1800);
 		// The sibling must ALSO have a non-zero cooldown, or it short-circuits on
 		// `min_cooldown_seconds = 0` and never reaches the scoping predicate —
-		// which would let a cooldown that ignores `watcher_id` pass unnoticed
+		// which would let a cooldown that ignores the Behavior id pass unnoticed
 		// (caught by mutation testing: a zero-cooldown sibling misses it).
-		const sibling = await behaviorWithCooldown(1800, cooling.workspace);
-		await priorRun(cooling, 60);
+		const sibling = await behaviorWithCooldown(1800, {
+			reuse: cooling.workspace,
+		});
+		await priorActivation(cooling, 60);
 
-		// One signal reaches both Behaviors. Only `cooling` has fired recently, so
-		// exactly one match proves both halves: the sibling is not suppressed by
-		// another Behavior's run, and `cooling` genuinely is suppressed by its own.
-		expect(await matches(sibling)).toBe(1);
+		expect(await activate(cooling)).toBe("suppressed");
+		expect(await activate(sibling)).toBe("queued");
+	});
+
+	it("does not consume the window when a signal coalesces into a pending run", async () => {
+		// Coalescing folds a signal into a run that is already pending — the
+		// Behavior does not start again, so it must not count against the
+		// operator's cooldown or a busy trigger would starve itself.
+		const fixture = await behaviorWithCooldown(1800);
+		const activation = await match(fixture);
+		const queue = (deliveryId: string) =>
+			createBehaviorEventRun({
+				organizationId: fixture.organizationId,
+				watcherId: fixture.behaviorId,
+				agentId: fixture.workspace.agentId,
+				trigger: activation.trigger,
+				signal: { ...fixture.signal, delivery_id: deliveryId },
+			});
+
+		expect((await queue("event:coalesce:1")).disposition).toBe("queued");
+		expect((await queue("event:coalesce:2")).disposition).toBe("coalesced");
+		expect(await behaviorRunCount(fixture)).toBe(1);
+	});
+
+	describe("the cursor the reply_to_source path shares", () => {
+		it("is consumed by a standalone claim, as the chat bridge makes it", async () => {
+			// Reply targets are handed to the chat transport and never write a
+			// `behavior` run row, so a cooldown expressed over `runs` is a silent
+			// no-op for them. Both paths claim `last_event_activation_at`, so the
+			// operator gets one predicate regardless of a Behavior's output mode.
+			const fixture = await behaviorWithCooldown(1800);
+
+			expect(await claimBehaviorCooldownStandalone(fixture.behaviorId)).toBe(
+				true,
+			);
+			expect(await claimBehaviorCooldownStandalone(fixture.behaviorId)).toBe(
+				false,
+			);
+		});
+
+		it("is never claimed at the 0 default, so ordinary chat is untouched", async () => {
+			const fixture = await behaviorWithCooldown(0);
+			const activation = await match(fixture);
+
+			// The bridge skips the claim entirely on this hint; assert it is the
+			// value the bridge branches on, so the two cannot drift apart.
+			expect(activation.minCooldownSeconds).toBe(0);
+			expect(await claimBehaviorCooldownStandalone(fixture.behaviorId)).toBe(
+				true,
+			);
+			expect(await claimBehaviorCooldownStandalone(fixture.behaviorId)).toBe(
+				true,
+			);
+		});
+
+		it("suppresses a reply when a background activation just consumed the window", async () => {
+			// One Behavior, one window: a background firing must debounce a reply
+			// firing and vice versa, or a mixed-trigger Behavior would get two
+			// independent budgets.
+			const fixture = await behaviorWithCooldown(1800);
+
+			expect(await activate(fixture)).toBe("queued");
+			expect(await claimBehaviorCooldownStandalone(fixture.behaviorId)).toBe(
+				false,
+			);
+		});
+	});
+
+	it("suppresses an activation for a Behavior that no longer exists", async () => {
+		const fixture = await behaviorWithCooldown(1800);
+		const sql = getTestDb();
+		await sql`DELETE FROM watchers WHERE id = ${fixture.behaviorId}`;
+
+		expect(await claimBehaviorCooldownStandalone(fixture.behaviorId)).toBe(
+			false,
+		);
 	});
 });

--- a/packages/server/src/__tests__/integration/behaviors/event-trigger-cooldown.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/event-trigger-cooldown.test.ts
@@ -202,10 +202,16 @@ describe("min_cooldown_seconds debounces event-triggered Behaviors", () => {
 
 	it("scopes the cooldown to one Behavior, not the whole connection", async () => {
 		const cooling = await behaviorWithCooldown(1800);
-		const sibling = await behaviorWithCooldown(0, cooling.workspace);
+		// The sibling must ALSO have a non-zero cooldown, or it short-circuits on
+		// `min_cooldown_seconds = 0` and never reaches the scoping predicate —
+		// which would let a cooldown that ignores `watcher_id` pass unnoticed
+		// (caught by mutation testing: a zero-cooldown sibling misses it).
+		const sibling = await behaviorWithCooldown(1800, cooling.workspace);
 		await priorRun(cooling, 60);
 
-		// Same signal reaches both Behaviors; only the cooling one is suppressed.
+		// One signal reaches both Behaviors. Only `cooling` has fired recently, so
+		// exactly one match proves both halves: the sibling is not suppressed by
+		// another Behavior's run, and `cooling` genuinely is suppressed by its own.
 		expect(await matches(sibling)).toBe(1);
 	});
 });

--- a/packages/server/src/__tests__/integration/behaviors/event-trigger-cooldown.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/event-trigger-cooldown.test.ts
@@ -1,0 +1,211 @@
+/**
+ * `min_cooldown_seconds` must actually debounce event-triggered Behaviors.
+ *
+ * The column has existed (NOT NULL DEFAULT 0) and been writable through the
+ * MCP contract, `defineBehavior`, and `lobu apply` since it was added, and no
+ * dispatch path ever read it. An operator who set it got no debounce at all.
+ *
+ * WHY ONLY THE EVENT PATH: a schedule already spaces its own firings — cron IS
+ * the operator's cadence control — so a cooldown there is redundant. Worse, the
+ * scheduled path would have to skip materializing a run, and `next_run_at` only
+ * advances when a run reaches a terminal state (see `advanceWatcherSchedule`).
+ * A suppressed scheduled firing would leave the cursor in the past and the
+ * Behavior would re-select on every tick forever — exactly the hot loop #2326
+ * fixed. Event activations have no cursor to strand: suppressing one simply
+ * means that event does not fire this Behavior. So the cooldown belongs here
+ * and only here.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { findMatchingBehaviorActivations } from "../../../behaviors/activation";
+import type { Env } from "../../../index";
+import { manageBehaviors } from "../../../tools/admin/manage_behaviors";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestAgent,
+	createTestConnection,
+	seedOwnerContext,
+} from "../../setup/test-fixtures";
+
+interface Fixture {
+	organizationId: string;
+	behaviorId: number;
+	signal: {
+		connector_key: string;
+		connection_id: string;
+		event_type: string;
+		label: string;
+		input_text: string;
+	};
+}
+
+let counter = 0;
+
+type OwnerContext = Awaited<ReturnType<typeof seedOwnerContext>>["ctx"];
+
+interface Workspace {
+	organizationId: string;
+	agentId: string;
+	connectionId: string;
+	ctx: OwnerContext;
+}
+
+async function behaviorWithCooldown(
+	cooldownSeconds: number,
+	reuse?: Workspace,
+): Promise<Fixture & { workspace: Workspace }> {
+	const sql = getTestDb();
+	const slug = `cooldown-${++counter}`;
+
+	let workspace: Workspace;
+	if (reuse) {
+		workspace = reuse;
+	} else {
+		const seeded = await seedOwnerContext();
+		workspace = {
+			organizationId: seeded.org.id,
+			ctx: seeded.ctx,
+			agentId: (
+				await createTestAgent({
+					organizationId: seeded.org.id,
+					ownerUserId: seeded.user.id,
+				})
+			).agentId,
+			connectionId: (
+				await createTestConnection({
+					organization_id: seeded.org.id,
+					connector_key: "github",
+					created_by: seeded.user.id,
+				})
+			).id,
+		};
+	}
+	const { organizationId, agentId, connectionId, ctx } = workspace;
+
+	const created = await manageBehaviors(
+		{
+			action: "create",
+			slug,
+			name: `Cooldown ${slug}`,
+			prompt: "Summarize changed pull requests.",
+			agent_id: agentId,
+			min_cooldown_seconds: cooldownSeconds,
+			triggers: [
+				{
+					kind: "event",
+					connector_key: "github",
+					connection_id: connectionId,
+					event_types: ["pull_request.updated"],
+					execution: "window",
+					active_run: "coalesce",
+					output: "silent",
+				},
+			],
+		},
+		{} as Env,
+		ctx,
+	);
+	if (created.action !== "create" || !("behavior_id" in created)) {
+		throw new Error("Behavior creation did not complete");
+	}
+	const behaviorId = Number(created.behavior_id);
+
+	// Guard the fixture itself: if the contract ever stops persisting the field,
+	// every assertion below would pass vacuously against cooldown 0.
+	const [row] = await sql`
+    SELECT min_cooldown_seconds FROM watchers WHERE id = ${behaviorId}
+  `;
+	expect(Number(row.min_cooldown_seconds)).toBe(cooldownSeconds);
+
+	return {
+		organizationId,
+		behaviorId,
+		workspace,
+		signal: {
+			connector_key: "github",
+			connection_id: connectionId,
+			event_type: "pull_request.updated",
+			label: "PR changed",
+			input_text: "A pull request changed.",
+		},
+	};
+}
+
+/** A prior firing of this Behavior, `secondsAgo` in the past. */
+async function priorRun(
+	fixture: Fixture,
+	secondsAgo: number,
+	status = "completed",
+): Promise<void> {
+	const sql = getTestDb();
+	await sql`
+    INSERT INTO runs (organization_id, run_type, watcher_id, status, created_at)
+    VALUES (${fixture.organizationId}, 'behavior', ${fixture.behaviorId},
+            ${status}, now() - make_interval(secs => ${secondsAgo}))
+  `;
+}
+
+async function matches(fixture: Fixture): Promise<number> {
+	const found = await findMatchingBehaviorActivations(
+		fixture.organizationId,
+		{ ...fixture.signal, delivery_id: `event:cooldown:${++counter}` },
+	);
+	return found.length;
+}
+
+describe("min_cooldown_seconds debounces event-triggered Behaviors", () => {
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+	});
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("suppresses an activation inside the cooldown window", async () => {
+		const fixture = await behaviorWithCooldown(1800);
+		await priorRun(fixture, 60);
+
+		expect(await matches(fixture)).toBe(0);
+	});
+
+	it("allows an activation once the cooldown has elapsed", async () => {
+		const fixture = await behaviorWithCooldown(1800);
+		await priorRun(fixture, 7200);
+
+		expect(await matches(fixture)).toBe(1);
+	});
+
+	it("allows the first activation when the Behavior has never run", async () => {
+		const fixture = await behaviorWithCooldown(1800);
+
+		expect(await matches(fixture)).toBe(1);
+	});
+
+	it("does not debounce at all when the cooldown is 0 (the default)", async () => {
+		const fixture = await behaviorWithCooldown(0);
+		await priorRun(fixture, 1);
+
+		expect(await matches(fixture)).toBe(1);
+	});
+
+	it("counts a still-running firing, not just a finished one", async () => {
+		// A burst that starts a run and immediately re-fires must be debounced by
+		// the run it just started, otherwise the cooldown only works after the
+		// first run happens to finish.
+		const fixture = await behaviorWithCooldown(1800);
+		await priorRun(fixture, 5, "running");
+
+		expect(await matches(fixture)).toBe(0);
+	});
+
+	it("scopes the cooldown to one Behavior, not the whole connection", async () => {
+		const cooling = await behaviorWithCooldown(1800);
+		const sibling = await behaviorWithCooldown(0, cooling.workspace);
+		await priorRun(cooling, 60);
+
+		// Same signal reaches both Behaviors; only the cooling one is suppressed.
+		expect(await matches(sibling)).toBe(1);
+	});
+});

--- a/packages/server/src/__tests__/integration/behaviors/event-trigger-cooldown.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/event-trigger-cooldown.test.ts
@@ -13,13 +13,11 @@
  * that; it fails against a cooldown evaluated during the match.
  *
  * WHY ONLY THE EVENT PATH: a schedule already spaces its own firings — cron IS
- * the operator's cadence control — so a cooldown there is redundant. Worse, the
- * scheduled path would have to skip materializing a run, and `next_run_at` only
- * advances when a run reaches a terminal state (see `advanceWatcherSchedule`).
- * A suppressed scheduled firing would leave the cursor in the past and the
- * Behavior would re-select on every tick forever — exactly the hot loop #2326
- * fixed. Event activations have no cursor to strand: suppressing one simply
- * means that event does not fire this Behavior.
+ * the operator's cadence control — so a cooldown there is redundant. Applying
+ * this debounce in the event activation path to a scheduled firing would also
+ * bypass the scheduler's `next_run_at` advancement and leave the cursor due.
+ * Event activations have no cursor to strand: suppressing one simply means that
+ * event does not fire this Behavior.
  */
 
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -27,7 +25,12 @@ import {
 	findMatchingBehaviorActivations,
 	queueBehaviorActivations,
 } from "../../../behaviors/activation";
-import { claimBehaviorCooldownStandalone } from "../../../behaviors/cooldown";
+import {
+	claimBehaviorCooldown,
+	claimBehaviorCooldownStandalone,
+	lockBehaviorForActivation,
+} from "../../../behaviors/cooldown";
+import type { DbClient } from "../../../db/client";
 import type { Env } from "../../../index";
 import { createBehaviorEventRun } from "../../../runs/queue-service";
 import { manageBehaviors } from "../../../tools/admin/manage_behaviors";
@@ -143,7 +146,6 @@ async function behaviorWithCooldown(
 	};
 }
 
-/** A prior event activation of this Behavior, `secondsAgo` in the past. */
 async function priorActivation(
 	fixture: Fixture,
 	secondsAgo: number,
@@ -168,7 +170,6 @@ async function match(fixture: Fixture) {
 	return activation;
 }
 
-/** Drive one delivery all the way through the durable activation path. */
 async function activate(fixture: Fixture): Promise<"queued" | "suppressed"> {
 	const activation = await match(fixture);
 	const results = await queueBehaviorActivations({
@@ -244,11 +245,10 @@ describe("min_cooldown_seconds debounces event-triggered Behaviors", () => {
 	});
 
 	it("debounces two concurrent deliveries, not just sequential ones", async () => {
-		// THE regression test for the blocker that drafted #2341: with the check
-		// in `findMatchingBehaviorActivations` both deliveries pass the unlocked
-		// SELECT before either run exists, and two runs are created. The claim
-		// only holds when it happens under the advisory lock that already
-		// serializes `createBehaviorEventRun`.
+		// With the check in `findMatchingBehaviorActivations` both deliveries pass
+		// the unlocked SELECT before either run exists, and two runs are created.
+		// The claim only holds when it happens under the advisory lock that
+		// already serializes `createBehaviorEventRun`.
 		// `active_run: "queue"`, not the fixture default: a coalescing trigger
 		// folds the second signal into the pending run and correctly never
 		// reaches the cooldown, which would mask the race this test exists for.
@@ -308,8 +308,37 @@ describe("min_cooldown_seconds debounces event-triggered Behaviors", () => {
 			});
 
 		expect((await queue("event:coalesce:1")).disposition).toBe("queued");
+		const [claimed] = await getTestDb()`
+			SELECT last_event_activation_at
+			FROM watchers
+			WHERE id = ${fixture.behaviorId}
+		`;
 		expect((await queue("event:coalesce:2")).disposition).toBe("coalesced");
 		expect(await behaviorRunCount(fixture)).toBe(1);
+		const [afterCoalesce] = await getTestDb()`
+			SELECT last_event_activation_at
+			FROM watchers
+			WHERE id = ${fixture.behaviorId}
+		`;
+		expect(afterCoalesce.last_event_activation_at).toEqual(
+			claimed.last_event_activation_at,
+		);
+	});
+
+	it("measures the cooldown at claim time, not transaction start", async () => {
+		const fixture = await behaviorWithCooldown(1);
+		const sql = getTestDb();
+
+		await sql.begin(async (tx) => {
+			await lockBehaviorForActivation(tx, fixture.behaviorId);
+			await tx`
+				UPDATE watchers
+				SET last_event_activation_at = now()
+				WHERE id = ${fixture.behaviorId}
+			`;
+			await tx`SELECT pg_sleep(1.1)`;
+			expect(await claimBehaviorCooldown(tx, fixture.behaviorId)).toBe(true);
+		});
 	});
 
 	describe("the cursor the reply_to_source path shares", () => {
@@ -328,12 +357,10 @@ describe("min_cooldown_seconds debounces event-triggered Behaviors", () => {
 			);
 		});
 
-		it("is never claimed at the 0 default, so ordinary chat is untouched", async () => {
+		it("does not consume the cursor at the 0 default", async () => {
 			const fixture = await behaviorWithCooldown(0);
 			const activation = await match(fixture);
 
-			// The bridge skips the claim entirely on this hint; assert it is the
-			// value the bridge branches on, so the two cannot drift apart.
 			expect(activation.minCooldownSeconds).toBe(0);
 			expect(await claimBehaviorCooldownStandalone(fixture.behaviorId)).toBe(
 				true,
@@ -341,6 +368,12 @@ describe("min_cooldown_seconds debounces event-triggered Behaviors", () => {
 			expect(await claimBehaviorCooldownStandalone(fixture.behaviorId)).toBe(
 				true,
 			);
+			const [row] = await getTestDb()`
+				SELECT last_event_activation_at
+				FROM watchers
+				WHERE id = ${fixture.behaviorId}
+			`;
+			expect(row.last_event_activation_at).toBeNull();
 		});
 
 		it("suppresses a reply when a background activation just consumed the window", async () => {
@@ -364,5 +397,18 @@ describe("min_cooldown_seconds debounces event-triggered Behaviors", () => {
 		expect(await claimBehaviorCooldownStandalone(fixture.behaviorId)).toBe(
 			false,
 		);
+	});
+
+	it("propagates a cooldown claim failure instead of reporting suppression", async () => {
+		const error = new Error("cooldown database unavailable");
+		const unavailableDb = {
+			begin: async () => {
+				throw error;
+			},
+		} as unknown as DbClient;
+
+		await expect(
+			claimBehaviorCooldownStandalone(123, unavailableDb),
+		).rejects.toBe(error);
 	});
 });

--- a/packages/server/src/behaviors/activation.ts
+++ b/packages/server/src/behaviors/activation.ts
@@ -108,6 +108,24 @@ export async function findMatchingBehaviorActivations(
 		  AND w.agent_id IS NOT NULL
 		  AND ${triggerFilter}
 		  ${organizationFilter}
+		  -- min_cooldown_seconds debounce. The column is NOT NULL DEFAULT 0, so
+		  -- the guard costs nothing for the overwhelming majority of Behaviors:
+		  -- at 0 the outer test short-circuits and the subquery never runs.
+		  -- Counts ANY firing, not just finished ones — a burst that starts a run
+		  -- and immediately re-fires must be debounced by the run it just
+		  -- started, or the cooldown would only take effect after the first run
+		  -- happens to complete.
+		  AND (
+		    w.min_cooldown_seconds = 0
+		    OR NOT EXISTS (
+		      SELECT 1
+		      FROM runs recent
+		      WHERE recent.watcher_id = w.id
+		        AND recent.run_type = 'behavior'
+		        AND recent.created_at >
+		            now() - make_interval(secs => w.min_cooldown_seconds)
+		    )
+		  )
 		ORDER BY w.id ASC
 	`;
 

--- a/packages/server/src/behaviors/activation.ts
+++ b/packages/server/src/behaviors/activation.ts
@@ -4,7 +4,7 @@ import type { DbClient } from "../db/client";
 import { getDb } from "../db/client";
 import { runtimeConnectionIdToSlug } from "../lobu/stores/connections-projection";
 import {
-  type BehaviorEventRunResult,
+  type BehaviorEventRunQueued,
   createBehaviorEventRun,
 } from "../runs/queue-service";
 import logger from "../utils/logger";
@@ -19,10 +19,18 @@ export interface MatchingBehaviorActivation {
   agentKind: string | null;
   model: string | null;
   instructions: string;
+  /**
+   * The Behavior's `min_cooldown_seconds`. Carried on the match so a caller can
+   * skip the cooldown claim entirely for the overwhelming majority of
+   * Behaviors, which leave it at the 0 default. This is a feature-enabled hint,
+   * NOT the decision: the window is re-read and consumed authoritatively under
+   * the per-Behavior lock in `claimBehaviorCooldown`.
+   */
+  minCooldownSeconds: number;
   trigger: BehaviorEventTrigger;
 }
 
-export interface BehaviorActivationResult extends BehaviorEventRunResult {
+export interface BehaviorActivationResult extends BehaviorEventRunQueued {
   behaviorId: number;
   trigger: BehaviorEventTrigger;
 }
@@ -101,35 +109,13 @@ export async function findMatchingBehaviorActivations(
   const rows = await db`
 		SELECT w.id, w.organization_id, w.agent_id, w.device_worker_id::text AS device_worker_id,
 		       w.agent_kind, w.triggers, w.execution_config->>'model' AS model,
-		       v.prompt
+		       w.min_cooldown_seconds, v.prompt
 		FROM watchers w
 		JOIN watcher_versions v ON v.id = w.current_version_id
 		WHERE w.status = 'active'
 		  AND w.agent_id IS NOT NULL
 		  AND ${triggerFilter}
 		  ${organizationFilter}
-		  -- min_cooldown_seconds debounce. The column is NOT NULL DEFAULT 0, so
-		  -- the guard costs nothing for the overwhelming majority of Behaviors:
-		  -- at 0 the outer test short-circuits and the subquery never runs.
-		  -- That short-circuit is an optimisation, NOT a correctness guard, and
-		  -- mutation testing says so: removing it keeps the suite green, because
-		  -- a zero-second window can never match a row created in the past.
-		  -- Keep it for the query plan.
-		  -- Counts ANY firing, not just finished ones — a burst that starts a run
-		  -- and immediately re-fires must be debounced by the run it just
-		  -- started, or the cooldown would only take effect after the first run
-		  -- happens to complete.
-		  AND (
-		    w.min_cooldown_seconds = 0
-		    OR NOT EXISTS (
-		      SELECT 1
-		      FROM runs recent
-		      WHERE recent.watcher_id = w.id
-		        AND recent.run_type = 'behavior'
-		        AND recent.created_at >
-		            now() - make_interval(secs => w.min_cooldown_seconds)
-		    )
-		  )
 		ORDER BY w.id ASC
 	`;
 
@@ -158,6 +144,7 @@ export async function findMatchingBehaviorActivations(
       agentKind: typeof row.agent_kind === "string" ? row.agent_kind : null,
       model: typeof row.model === "string" ? row.model : null,
       instructions: typeof row.prompt === "string" ? row.prompt : "",
+      minCooldownSeconds: Number(row.min_cooldown_seconds ?? 0),
       trigger,
     });
   }
@@ -219,6 +206,10 @@ export async function queueBehaviorActivations(args: {
       },
       args.db,
     );
+    // A cooldown-suppressed activation produced no run, so it has nothing to
+    // dispatch and must not reach `dispatchBehaviorRunsBestEffort`. The
+    // decision itself is logged inside the claim.
+    if (queued.disposition === "cooldown") continue;
     results.push({
       ...queued,
       behaviorId: match.behaviorId,

--- a/packages/server/src/behaviors/activation.ts
+++ b/packages/server/src/behaviors/activation.ts
@@ -21,10 +21,9 @@ export interface MatchingBehaviorActivation {
   instructions: string;
   /**
    * The Behavior's `min_cooldown_seconds`. Carried on the match so a caller can
-   * skip the cooldown claim entirely for the overwhelming majority of
-   * Behaviors, which leave it at the 0 default. This is a feature-enabled hint,
-   * NOT the decision: the window is re-read and consumed authoritatively under
-   * the per-Behavior lock in `claimBehaviorCooldown`.
+   * skip the cooldown claim for Behaviors observed at the 0 default. Positive
+   * values are re-read and consumed authoritatively under the per-Behavior lock
+   * in `claimBehaviorCooldown`.
    */
   minCooldownSeconds: number;
   trigger: BehaviorEventTrigger;

--- a/packages/server/src/behaviors/activation.ts
+++ b/packages/server/src/behaviors/activation.ts
@@ -111,6 +111,10 @@ export async function findMatchingBehaviorActivations(
 		  -- min_cooldown_seconds debounce. The column is NOT NULL DEFAULT 0, so
 		  -- the guard costs nothing for the overwhelming majority of Behaviors:
 		  -- at 0 the outer test short-circuits and the subquery never runs.
+		  -- That short-circuit is an optimisation, NOT a correctness guard, and
+		  -- mutation testing says so: removing it keeps the suite green, because
+		  -- a zero-second window can never match a row created in the past.
+		  -- Keep it for the query plan.
 		  -- Counts ANY firing, not just finished ones — a burst that starts a run
 		  -- and immediately re-fires must be debounced by the run it just
 		  -- started, or the cooldown would only take effect after the first run

--- a/packages/server/src/behaviors/cooldown.ts
+++ b/packages/server/src/behaviors/cooldown.ts
@@ -1,0 +1,119 @@
+import type { DbClient } from "../db/client";
+import { getDb } from "../db/client";
+import logger from "../utils/logger";
+
+/**
+ * `watchers.min_cooldown_seconds` debounce for event-triggered Behaviors.
+ *
+ * A Behavior activates on an event through two substrates: background targets
+ * become durable `behavior` runs via `createBehaviorEventRun`, and
+ * `reply_to_source` targets are handed to the chat transport and never write a
+ * run row at all. A predicate over `runs` would therefore be a silent no-op on
+ * exactly one half of the feature, so both paths claim the same cursor
+ * (`watchers.last_event_activation_at`) through this module.
+ *
+ * The claim must be serialized, or two concurrent deliveries both read "no
+ * recent activation" and both fire. It reuses the advisory lock
+ * `createBehaviorEventRun` already takes per Behavior rather than introducing
+ * a second one: the lock is transaction-scoped, so the read and the cursor
+ * write cannot interleave with another replica's.
+ */
+const BEHAVIOR_ACTIVATION_LOCK_NAMESPACE = "behavior_event_run";
+
+/**
+ * Serialize activation decisions for one Behavior. Transaction-scoped: the
+ * lock is released when `tx` commits or rolls back.
+ */
+export async function lockBehaviorForActivation(
+  tx: DbClient,
+  watcherId: number,
+): Promise<void> {
+  await tx`
+    SELECT pg_advisory_xact_lock(
+      hashtext(${BEHAVIOR_ACTIVATION_LOCK_NAMESPACE}),
+      ${watcherId}
+    )
+  `;
+}
+
+/**
+ * Consume this Behavior's cooldown window, returning whether the activation
+ * may proceed. Callers MUST already hold `lockBehaviorForActivation` on the
+ * same transaction — the read and the write below are only atomic together.
+ *
+ * A Behavior with `min_cooldown_seconds = 0` (the NOT NULL default, and the
+ * overwhelming majority) is always allowed and never writes the cursor, so the
+ * common path costs one indexed read and no row contention.
+ *
+ * Returns false for a Behavior that no longer exists: a deleted Behavior has
+ * nothing to activate.
+ */
+export async function claimBehaviorCooldown(
+  tx: DbClient,
+  watcherId: number,
+): Promise<boolean> {
+  const rows = await tx`
+    SELECT
+      min_cooldown_seconds,
+      last_event_activation_at IS NOT NULL
+        AND last_event_activation_at >
+            now() - make_interval(secs => min_cooldown_seconds)
+        AS within_cooldown
+    FROM watchers
+    WHERE id = ${watcherId}
+    LIMIT 1
+  `;
+  const row = rows[0];
+  if (!row) {
+    logger.warn(
+      { watcherId },
+      "[cooldown] Behavior row missing while claiming an activation — suppressing",
+    );
+    return false;
+  }
+  const cooldownSeconds = Number(row.min_cooldown_seconds ?? 0);
+  if (!(cooldownSeconds > 0)) return true;
+  if (row.within_cooldown === true) {
+    logger.info(
+      { watcherId, cooldownSeconds },
+      "[cooldown] Suppressing Behavior activation inside its min_cooldown_seconds window",
+    );
+    return false;
+  }
+  await tx`
+    UPDATE watchers
+    SET last_event_activation_at = now()
+    WHERE id = ${watcherId}
+  `;
+  return true;
+}
+
+/**
+ * Claim the cooldown for a caller that has no ambient transaction — the chat
+ * reply path, which does not create a run row. Opens its own short transaction
+ * so the lock scope stays tight.
+ *
+ * The window is consumed at the moment of the claim, not when the turn is
+ * delivered: a caller that throws after claiming burns one window. That is the
+ * right trade for a debounce (at worst one event is dropped) and the opposite
+ * choice — claiming after delivery — would let a concurrent burst through.
+ */
+export async function claimBehaviorCooldownStandalone(
+  watcherId: number,
+  db?: DbClient,
+): Promise<boolean> {
+  const sql = db ?? getDb();
+  try {
+    return await sql.begin(async (tx: DbClient) => {
+      await lockBehaviorForActivation(tx, watcherId);
+      return await claimBehaviorCooldown(tx, watcherId);
+    });
+  } catch (error) {
+    // Fail closed: an unreadable cooldown must not silently become "fire".
+    logger.error(
+      { error, watcherId },
+      "[cooldown] Could not claim a Behavior cooldown window — suppressing this activation",
+    );
+    return false;
+  }
+}

--- a/packages/server/src/behaviors/cooldown.ts
+++ b/packages/server/src/behaviors/cooldown.ts
@@ -41,9 +41,9 @@ export async function lockBehaviorForActivation(
  * may proceed. Callers MUST already hold `lockBehaviorForActivation` on the
  * same transaction — the read and the write below are only atomic together.
  *
- * A Behavior with `min_cooldown_seconds = 0` (the NOT NULL default, and the
- * overwhelming majority) is always allowed and never writes the cursor, so the
- * common path costs one indexed read and no row contention.
+ * A Behavior with `min_cooldown_seconds = 0` (the NOT NULL default) is always
+ * allowed and never writes the cursor, so the common path costs one indexed
+ * read and no row contention.
  *
  * Returns false for a Behavior that no longer exists: a deleted Behavior has
  * nothing to activate.
@@ -57,7 +57,7 @@ export async function claimBehaviorCooldown(
       min_cooldown_seconds,
       last_event_activation_at IS NOT NULL
         AND last_event_activation_at >
-            now() - make_interval(secs => min_cooldown_seconds)
+            clock_timestamp() - make_interval(secs => min_cooldown_seconds)
         AS within_cooldown
     FROM watchers
     WHERE id = ${watcherId}
@@ -82,7 +82,7 @@ export async function claimBehaviorCooldown(
   }
   await tx`
     UPDATE watchers
-    SET last_event_activation_at = now()
+    SET last_event_activation_at = clock_timestamp()
     WHERE id = ${watcherId}
   `;
   return true;
@@ -97,6 +97,8 @@ export async function claimBehaviorCooldown(
  * delivered: a caller that throws after claiming burns one window. That is the
  * right trade for a debounce (at worst one event is dropped) and the opposite
  * choice — claiming after delivery — would let a concurrent burst through.
+ * Database failures propagate to the caller; they must never be reported as an
+ * ordinary cooldown suppression.
  */
 export async function claimBehaviorCooldownStandalone(
   watcherId: number,
@@ -109,11 +111,10 @@ export async function claimBehaviorCooldownStandalone(
       return await claimBehaviorCooldown(tx, watcherId);
     });
   } catch (error) {
-    // Fail closed: an unreadable cooldown must not silently become "fire".
     logger.error(
       { error, watcherId },
-      "[cooldown] Could not claim a Behavior cooldown window — suppressing this activation",
+      "[cooldown] Could not claim a Behavior cooldown window — activation failed",
     );
-    return false;
+    throw error;
   }
 }

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -14,12 +14,30 @@ import {
   parsePreviewLinkCode,
 } from "../connections/message-handler-bridge.js";
 import type { PlatformConnection } from "../connections/types.js";
+
 import { InMemoryStateAdapter } from "./fixtures/in-memory-state-adapter.js";
 import {
   type ArtifactTestEnv,
   createArtifactTestEnv,
   TEST_GATEWAY_URL,
 } from "./setup.js";
+
+/**
+ * The reply path consults the cooldown claim, which is Postgres-backed. Stub
+ * the module so this suite stays DB-free; `cooldownAllows` defaults to true so
+ * every other test behaves exactly as before (they all use the 0 default, which
+ * the bridge never claims for anyway).
+ */
+const cooldownClaims: number[] = [];
+let cooldownAllows = true;
+mock.module("../../behaviors/cooldown.js", () => ({
+  claimBehaviorCooldownStandalone: async (behaviorId: number) => {
+    cooldownClaims.push(behaviorId);
+    return cooldownAllows;
+  },
+  claimBehaviorCooldown: async () => true,
+  lockBehaviorForActivation: async () => undefined,
+}));
 
 describe("buildAttachmentTranscriptText", () => {
   const file = (id: string, name: string, mimetype: string) => ({
@@ -628,6 +646,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
               agentKind: null,
               model: opts.linkedBehavior.model ?? null,
               instructions: "Respond helpfully to the incoming message.",
+              minCooldownSeconds: 0,
               trigger: {
                 kind: "event",
                 connector_key: "slack",
@@ -764,6 +783,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
         agentKind: null,
         model: null,
         instructions: "Handle support messages.",
+        minCooldownSeconds: 0,
         trigger,
       },
       {
@@ -774,6 +794,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
         agentKind: null,
         model: null,
         instructions: "Audit support messages.",
+        minCooldownSeconds: 0,
         trigger,
       },
     ];
@@ -814,6 +835,102 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
       THREAD_ID,
     );
     expect(entries).toHaveLength(1);
+  });
+
+  test("a reply Behavior inside its cooldown window is suppressed", async () => {
+    // The blocker that drafted #2341: `reply_to_source` targets are handed to
+    // the chat transport and never write a `behavior` run row, so a cooldown
+    // expressed over `runs` was a silent no-op for exactly these Behaviors.
+    const trigger = {
+      kind: "event" as const,
+      connector_key: "slack",
+      connection_id: 42,
+      event_types: ["message.created"],
+      match: { channel_id: CHANNEL_ID },
+      execution: "turn" as const,
+      active_run: "queue" as const,
+      output: "reply_to_source" as const,
+      skip_if_unchanged: false,
+    };
+    const behaviors: MatchingBehaviorActivation[] = [
+      {
+        behaviorId: 81,
+        organizationId: "org-a",
+        agentId: "agent-a",
+        deviceWorkerId: null,
+        agentKind: null,
+        model: null,
+        instructions: "Handle support messages.",
+        minCooldownSeconds: 1800,
+        trigger,
+      },
+    ];
+    cooldownClaims.length = 0;
+    cooldownAllows = false;
+    try {
+      const { bridge, enqueueMessage } = makePreviewHarness({ behaviors });
+      const thread = makeThread(undefined);
+
+      await bridge.handleMessage(
+        thread,
+        makeMessage({ raw: { team_id: "TREAL" } }),
+        "mention",
+      );
+
+      expect(cooldownClaims).toEqual([81]);
+      expect(enqueueMessage).not.toHaveBeenCalled();
+      // A suppressed Behavior must not fall through to the connection owner —
+      // that would answer the message with a plain chat turn and defeat the
+      // debounce entirely.
+      expect(
+        thread.post.mock.calls.every(
+          (c: unknown[]) => !String(c[0]).includes("/lobu link"),
+        ),
+      ).toBe(true);
+    } finally {
+      cooldownAllows = true;
+    }
+  });
+
+  test("a reply Behavior at the 0 default never reaches the cooldown claim", async () => {
+    const trigger = {
+      kind: "event" as const,
+      connector_key: "slack",
+      connection_id: 42,
+      event_types: ["message.created"],
+      match: { channel_id: CHANNEL_ID },
+      execution: "turn" as const,
+      active_run: "queue" as const,
+      output: "reply_to_source" as const,
+      skip_if_unchanged: false,
+    };
+    const behaviors: MatchingBehaviorActivation[] = [
+      {
+        behaviorId: 82,
+        organizationId: "org-a",
+        agentId: "agent-a",
+        deviceWorkerId: null,
+        agentKind: null,
+        model: null,
+        instructions: "Handle support messages.",
+        minCooldownSeconds: 0,
+        trigger,
+      },
+    ];
+    cooldownClaims.length = 0;
+    const { bridge, enqueueMessage } = makePreviewHarness({ behaviors });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ raw: { team_id: "TREAL" } }),
+      "mention",
+    );
+
+    // Ordinary chat must not pay a round-trip per message, and must not be
+    // droppable by a claim that fails closed on a database blip.
+    expect(cooldownClaims).toEqual([]);
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
   });
 
   test("a rejected Behavior filter cannot be bypassed by channel fallback", async () => {
@@ -923,6 +1040,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
           agentKind: null,
           model: null,
           instructions: "Handle support messages.",
+        minCooldownSeconds: 0,
           trigger,
         },
       ],
@@ -1518,6 +1636,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
       agentKind: null,
       model: null,
       instructions: "Respond helpfully to the incoming message.",
+      minCooldownSeconds: 0,
       trigger: {
         kind: "event",
         connector_key: "slack",

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -14,7 +14,6 @@ import {
   parsePreviewLinkCode,
 } from "../connections/message-handler-bridge.js";
 import type { PlatformConnection } from "../connections/types.js";
-
 import { InMemoryStateAdapter } from "./fixtures/in-memory-state-adapter.js";
 import {
   type ArtifactTestEnv,
@@ -838,9 +837,9 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
   });
 
   test("a reply Behavior inside its cooldown window is suppressed", async () => {
-    // The blocker that drafted #2341: `reply_to_source` targets are handed to
-    // the chat transport and never write a `behavior` run row, so a cooldown
-    // expressed over `runs` was a silent no-op for exactly these Behaviors.
+    // `reply_to_source` targets are handed to the chat transport and never
+    // write a `behavior` run row, so a cooldown expressed over `runs` was a
+    // silent no-op for these Behaviors.
     const trigger = {
       kind: "event" as const,
       connector_key: "slack",
@@ -927,8 +926,8 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
       "mention",
     );
 
-    // Ordinary chat must not pay a round-trip per message, and must not be
-    // droppable by a claim that fails closed on a database blip.
+    // Ordinary chat must not pay a round-trip per message or encounter a
+    // cooldown-claim failure.
     expect(cooldownClaims).toEqual([]);
     expect(enqueueMessage).toHaveBeenCalledTimes(1);
   });
@@ -1040,7 +1039,7 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
           agentKind: null,
           model: null,
           instructions: "Handle support messages.",
-        minCooldownSeconds: 0,
+          minCooldownSeconds: 0,
           trigger,
         },
       ],

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -1177,8 +1177,9 @@ export class MessageHandlerBridge {
     for (const candidate of replyBehaviors) {
       // `minCooldownSeconds` is a feature-enabled hint carried on the match, so
       // an ordinary chat Behavior (the 0 default) costs no extra round-trip and
-      // cannot be dropped by a cooldown claim that fails closed. Behaviors that
-      // opted in re-read and consume the window under the per-Behavior lock.
+      // cannot be dropped by a cooldown claim. Behaviors that opted in re-read
+      // and consume the window under the per-Behavior lock; claim failures
+      // propagate out of this handler.
       if (
         candidate.minCooldownSeconds > 0 &&
         !(await claimBehaviorCooldownStandalone(candidate.behaviorId))

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -30,10 +30,12 @@ import { resolveSlackBotIdentity } from "../../authz/slack-acl-sync.js";
 import {
   type BehaviorActivationPlan,
   dispatchBehaviorRunsBestEffort,
+  type MatchingBehaviorActivation,
   planBehaviorActivationsForRuntimeConnection,
   queueBehaviorActivations,
   type RuntimeConnectionBehaviorLookup,
 } from "../../behaviors/activation.js";
+import { claimBehaviorCooldownStandalone } from "../../behaviors/cooldown.js";
 import {
   buildAgentSettingsUrl,
   buildProviderConnectUrl,
@@ -1166,9 +1168,35 @@ export class MessageHandlerBridge {
     });
     await dispatchBehaviorRunsBestEffort(backgroundRuns);
 
+    // `reply_to_source` Behaviors answer through the chat transport and never
+    // write a `behavior` run row, so they are invisible to the cooldown claim
+    // `createBehaviorEventRun` makes for background targets above. Claiming the
+    // same cursor here is what stops `min_cooldown_seconds` being a debounce on
+    // one half of the feature and a silent no-op on the other.
+    const replyTargetsOffCooldown: MatchingBehaviorActivation[] = [];
+    for (const candidate of replyBehaviors) {
+      // `minCooldownSeconds` is a feature-enabled hint carried on the match, so
+      // an ordinary chat Behavior (the 0 default) costs no extra round-trip and
+      // cannot be dropped by a cooldown claim that fails closed. Behaviors that
+      // opted in re-read and consume the window under the per-Behavior lock.
+      if (
+        candidate.minCooldownSeconds > 0 &&
+        !(await claimBehaviorCooldownStandalone(candidate.behaviorId))
+      ) {
+        continue;
+      }
+      replyTargetsOffCooldown.push(candidate);
+    }
+    // Every reply Behavior being suppressed is not the same as none matching:
+    // fall through to the empty-targets return rather than the owner-agent
+    // fallback, or a debounced Behavior would be answered by a plain chat turn.
+    if (replyBehaviors.length > 0 && replyTargetsOffCooldown.length === 0) {
+      return;
+    }
+
     const directTargets =
-      replyBehaviors.length > 0
-        ? replyBehaviors.map((candidate) => ({
+      replyTargetsOffCooldown.length > 0
+        ? replyTargetsOffCooldown.map((candidate) => ({
             agentId: candidate.agentId,
             organizationId: candidate.organizationId,
             model: candidate.model ?? undefined,

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -10,6 +10,10 @@
 import type { DbClient } from '../db/client';
 import type { BehaviorEventTrigger } from '@lobu/core/contracts/tools/manage-behaviors';
 import type { ConnectorTriggerSignal } from '@lobu/connector-sdk';
+import {
+  claimBehaviorCooldown,
+  lockBehaviorForActivation,
+} from '../behaviors/cooldown';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { isCloudMode } from '../utils/cloud-mode';
@@ -593,12 +597,29 @@ export async function createWatcherRun(
   }
 }
 
-export interface BehaviorEventRunResult {
+/** An activation that produced (or joined) a durable run. */
+export interface BehaviorEventRunQueued {
   runId: number;
   status: string;
   created: boolean;
   disposition: 'queued' | 'coalesced' | 'duplicate';
 }
+
+/**
+ * An activation refused by the Behavior's `min_cooldown_seconds` window. No
+ * run exists, so there is no id to dispatch — the distinct shape stops callers
+ * treating a suppressed activation as a queued one.
+ */
+export interface BehaviorEventRunSuppressed {
+  runId: null;
+  status: 'suppressed';
+  created: false;
+  disposition: 'cooldown';
+}
+
+export type BehaviorEventRunResult =
+  | BehaviorEventRunQueued
+  | BehaviorEventRunSuppressed;
 
 /**
  * Durably materialize a normalized connector signal as a Behavior run. A
@@ -619,12 +640,7 @@ export async function createBehaviorEventRun(
 ): Promise<BehaviorEventRunResult> {
   const sql = db ?? getDb();
   const execute = async (tx: DbClient): Promise<BehaviorEventRunResult> => {
-    await tx`
-      SELECT pg_advisory_xact_lock(
-        hashtext('behavior_event_run'),
-        ${params.watcherId}
-      )
-    `;
+    await lockBehaviorForActivation(tx, params.watcherId);
 
     const duplicate = await tx`
       SELECT id, status
@@ -708,6 +724,22 @@ export async function createBehaviorEventRun(
           };
         }
       }
+    }
+
+    // Only a genuinely NEW firing consumes the operator's cooldown window.
+    // Everything above this line either returned an existing run (a duplicate
+    // delivery) or folded the signal into one already pending (coalesce) —
+    // neither starts the Behavior again, so neither should count against
+    // `min_cooldown_seconds`. We hold the per-Behavior advisory lock, so the
+    // read-and-consume inside this claim cannot interleave with another
+    // replica handling a concurrent delivery.
+    if (!(await claimBehaviorCooldown(tx, params.watcherId))) {
+      return {
+        runId: null,
+        status: 'suppressed',
+        created: false,
+        disposition: 'cooldown',
+      };
     }
 
     const versionRows = await tx`

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -457,7 +457,11 @@ export const QUERYABLE_SCHEMA = {
         'notification_channel',
         'notification_priority',
         'min_cooldown_seconds',
-        'last_fired_at'
+        'last_fired_at',
+        // Dispatch-time cursor for the min_cooldown_seconds debounce. Distinct
+        // from last_fired_at, which is stamped when a run reaches a terminal
+        // state.
+        'last_event_activation_at'
       ),
     },
     // event_classifications


### PR DESCRIPTION
## What

`watchers.min_cooldown_seconds` was stored, validated, surfaced in the MCP contract, `defineBehavior`, `lobu apply` and the table schema — and read by **no dispatch predicate**. An operator who set it got no debounce at all.

This wires it at the chokepoint that already serializes a Behavior activation, and makes it work on **both** firing substrates.

## Why the previous revision was drafted

Two blockers, one root cause: the check sat at a read seam instead of the chokepoint.

1. **Lookup/create race.** The cooldown was evaluated in `findMatchingBehaviorActivations`, an unlocked `SELECT`. The actual serializer is `pg_advisory_xact_lock(hashtext('behavior_event_run'), watcherId)` inside `createBehaviorEventRun`, which runs later — so two concurrent deliveries both passed before either run existed.
2. **`reply_to_source` Behaviors accumulated no history.** `planBehaviorActivations` splits reply targets off and the chat bridge routes them through the chat transport, never `createBehaviorEventRun`. No `behavior` run row is written, so a predicate over `runs` was a silent no-op on exactly those Behaviors — a cooldown that works on some Behaviors and silently does nothing on others.

## How

- **New cursor `watchers.last_event_activation_at`** (nullable, no backfill). Neither existing column works: `last_fired_at` is stamped when a run reaches a **terminal** state, so a burst that starts a run and immediately re-fires would not be debounced by the run it just started; `runs.created_at` cannot see reply Behaviors at all.
- **`behaviors/cooldown.ts`** owns the lock and the claim. `createBehaviorEventRun` claims under the lock it already holds; the chat bridge claims through `claimBehaviorCooldownStandalone` for reply targets. One predicate, one cursor, both paths.
- The claim runs **after** dedupe and coalesce: a duplicate delivery and a coalesced signal do not start the Behavior again, so neither consumes the operator's window.
- `MatchingBehaviorActivation.minCooldownSeconds` is carried on the match as a **feature-enabled hint** so a Behavior at the 0 default (the overwhelming majority) costs no extra round-trip and cannot be dropped by a claim that fails closed. The window is still re-read and consumed authoritatively under the lock.
- Event path only, deliberately: cron already spaces scheduled firings, and suppressing one would strand `next_run_at` in the past and hot-loop — exactly what #2326 fixed. Event activations have no cursor to strand.

## Red → green

Both blockers have a killing test. Mutations applied to the committed fix:

**Mutation A — move the claim back outside the advisory lock** (the exact pre-draft placement):

```
FAIL > debounces two concurrent deliveries, not just sequential ones
AssertionError: expected [ 'queued', 'queued' ] to deeply equal [ 'cooldown', 'queued' ]
FAIL > does not consume the window when a signal coalesces into a pending run
AssertionError: expected 'cooldown' to be 'coalesced'
Tests  2 failed | 10 passed (12)
```

**Mutation B — reply path ignores the cooldown** (blocker 2):

```
(fail) MessageHandlerBridge.handleMessage > a reply Behavior inside its cooldown window is suppressed
expect(cooldownClaims).toEqual([81])
62 pass, 1 fail
```

**Green, both reverted:**

```
✓ src/__tests__/integration/behaviors/event-trigger-cooldown.test.ts (12 tests)
Test Files  1 passed (1)      Tests  12 passed (12)

bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
63 pass, 0 fail

vitest run src/__tests__/integration/behaviors src/__tests__/integration/watchers
Test Files  27 passed (27)    Tests  206 passed (206)
```

## Notes for review

- A suppressed reply Behavior returns before the history append, matching the existing "trigger filters rejected this message" path rather than answering with a plain chat turn.
- The window is consumed at claim time, not delivery time: a caller that throws after claiming burns one window. That is the right trade for a debounce; claiming after delivery would let a concurrent burst through.

## E2E on a booted gateway

`make dev` on this branch created its own branch database and applied the new migration:

```
[migrations] applying migrations to external DATABASE_URL … Migrations complete

SELECT column_name FROM information_schema.columns
 WHERE table_name='watchers' AND column_name IN ('last_event_activation_at','min_cooldown_seconds');
 last_event_activation_at
 min_cooldown_seconds
```

Two Behaviors created over the real MCP surface with a PAT (cooldown 1800 and the 0 default), sharing one GitHub connection and one trigger, then two distinct deliveries pushed through `activateBehaviorSignal`:

```
[cooldown] Suppressing Behavior activation inside its min_cooldown_seconds window
          {"watcherId":1,"cooldownSeconds":1800}

PASS  cooldown Behavior fired ONCE across two deliveries — runs=1
PASS  cooldown=0 Behavior fired for BOTH deliveries — runs=2
PASS  cursor stamped for the cooldown Behavior
PASS  cursor untouched at the 0 default
```

The `cooldown=0` assertion is the regression guard that matters most: the overwhelming majority of Behaviors leave the field at its default and must be completely unaffected, including never touching the cursor.

**Not covered live:** the `reply_to_source` half was exercised through the bridge unit test (with the claim stubbed) and a DB-level claim test, not through a real chat connection — that needs a live Slack/Telegram workspace. The claim itself is the same function on both paths.
