### PR TITLE
fix(server): keep the live skill library out of Behavior runs

### DIFF
--- a/packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts
@@ -21,7 +21,7 @@ describe("WorkerGateway session context", () => {
     }
   });
 
-  test("syncs only agent-configured skills into skillsConfig (declared agent, orgless)", async () => {
+  test("syncs configured skills for chat but suppresses them for Behavior runs", async () => {
     // A DECLARED (SDK-embedded) agent has org-agnostic settings, so an orgless
     // token legitimately syncs its skills. (A DB-backed agent with an orgless
     // token would fail closed — covered by the cross-tenant test below.)
@@ -64,21 +64,7 @@ describe("WorkerGateway session context", () => {
       } as any
     );
 
-    const token = generateWorkerToken("user-1", "conv-1", "worker-a", {
-      channelId: "channel-1",
-      agentId: "agent-1",
-    });
-
-    const response = await gateway.getApp().request("/session-context", {
-      headers: {
-        authorization: `Bearer ${token}`,
-        host: "gateway.example.com",
-      },
-    });
-
-    expect(response.status).toBe(200);
-
-    const body = (await response.json()) as {
+    type SessionContextBody = {
       agentLayers: {
         identityMd: string;
         soulMd: string;
@@ -89,18 +75,44 @@ describe("WorkerGateway session context", () => {
       skillsInstructions: string;
     };
 
-    expect(body.agentLayers).toEqual({
+    const fetchContext = async (source?: string): Promise<SessionContextBody> => {
+      const token = generateWorkerToken("user-1", "conv-1", "worker-a", {
+        channelId: "channel-1",
+        agentId: "agent-1",
+        source,
+      });
+      const response = await gateway.getApp().request("/session-context", {
+        headers: {
+          authorization: `Bearer ${token}`,
+          host: "gateway.example.com",
+        },
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()) as SessionContextBody;
+    };
+
+    const chat = await fetchContext();
+    expect(chat.agentLayers).toEqual({
       identityMd: "I am Aria.",
       soulMd: "Be concise.",
       userMd: "Acme support.",
       unconfiguredNotice: "",
     });
-    expect(body.skillsConfig).toEqual([
+    expect(chat.skillsConfig).toEqual([
       { name: "custom-skill", content: "# Custom Skill\n" },
     ]);
-    expect(body.skillsInstructions).toContain("## Skills");
-    expect(body.skillsInstructions).toContain("owner/custom-skill");
-    expect(body.skillsInstructions).not.toContain("Built-in System Skills");
+    expect(chat.skillsInstructions).toContain("## Skills");
+    expect(chat.skillsInstructions).toContain("owner/custom-skill");
+    expect(chat.skillsInstructions).not.toContain("Built-in System Skills");
+
+    const behaviorRun = await fetchContext("watcher-run");
+    expect(behaviorRun.skillsConfig).toEqual([]);
+    expect(behaviorRun.skillsInstructions).toBe("");
+
+    // Other headless sources do not execute frozen Behavior instructions.
+    const connectorRepair = await fetchContext("connector-repair");
+    expect(connectorRepair.skillsConfig).toHaveLength(1);
+    expect(connectorRepair.skillsInstructions).toContain("## Skills");
   });
 
   test("ships the PUBLIC web origin, with the embedded /lobu mount stripped", async () => {

--- a/packages/server/src/gateway/behavior-run-session.ts
+++ b/packages/server/src/gateway/behavior-run-session.ts
@@ -1,0 +1,34 @@
+/**
+ * The one name for "this turn is executing a Behavior", shared by the site
+ * that stamps it and the sites that read it back off the signed worker token.
+ *
+ * A Behavior run is dispatched with `intent.kind === "behavior_run"`; the
+ * enqueue path (routes/public/agent.ts) turns that into
+ * `platformMetadata.source = "watcher-run"`, which `buildWorkerTokenClaims`
+ * lifts into the token as `WorkerTokenData.source`. `watcher` is the internal
+ * engine vocabulary for a Behavior, so the wire value keeps its historical
+ * spelling — nothing agent-facing reads it.
+ *
+ * What reading it back means: the turn's job text is the FROZEN instruction
+ * body the Behavior version compiled at apply/save time, not a human's
+ * message. That freeze is only honest if the agent's live skill *library*
+ * stays out of the turn — the progressive catalog advertises skills the freeze
+ * never picked, and both the catalog and its generic fallback tell the model
+ * to `cat .skills/…`, which serves whatever the library holds today (issue
+ * #2320 must-fix 1). Persona, tools, MCP and network stay live; they are the
+ * agent, not the job.
+ *
+ * Narrower than the SSE-routing notion of "headless": connector-repair,
+ * scheduled-job and internal turns have no frozen Behavior text behind them,
+ * so suppressing their skills would only make them dumber. Ordinary chat is
+ * excluded for the same reason even when a Behavior is listening on the
+ * conversation — a human is in that thread and the library is theirs.
+ *
+ * Why the worker's 5-minute session-context cache needs no isolation key: a
+ * Behavior run opens its own session (`thread: watcher-<runId>`, `forceNew`,
+ * see `watchers/automation.ts`), and the deployment name hashes the
+ * conversation id — so a run's worker process is never the process that also
+ * serves that agent's chat. If a future dispatch path ever runs a Behavior on
+ * a shared conversation, that cache becomes the place this decision leaks.
+ */
+export const BEHAVIOR_RUN_SOURCE = "watcher-run";

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -15,6 +15,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
 import { bindRequestAbortToStream } from "../../events/sse-abort-bridge.js";
+import { BEHAVIOR_RUN_SOURCE } from "../behavior-run-session.js";
 import { toPublicWebOrigin } from "../../utils/url-builder.js";
 import type { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
 import { getRevokedTokenStore } from "../auth/revoked-token-store.js";
@@ -726,19 +727,26 @@ export class WorkerGateway {
       // `agentSettings` fetched above — it is null for an orgless DB-backed agent
       // (the correct fail-closed value: NO skill content leaks cross-tenant), and
       // this removes the duplicate id-only read that ignored the org guard.
+      //
+      // A Behavior run uses version-pinned instructions, so the live library
+      // must not re-enter the turn. Drop both surfaces: the catalog points the
+      // model at `.skills/`, and `skillsConfig` is what the worker syncs there.
+      const behaviorRun = auth.tokenData.source === BEHAVIOR_RUN_SOURCE;
       let skillsConfig: Array<{ name: string; content: string }> = [];
       const mcpContext: Record<string, string> = {};
-      if (agentSettings) {
+      if (agentSettings && !behaviorRun) {
         const skills = agentSettings.skillsConfig?.skills || [];
         skillsConfig = skills
           .filter((s) => s.enabled && s.content)
           .map((s) => ({ name: s.name, content: s.content! }));
       }
 
-      const mergedSkillsInstructions = contextData.skillsInstructions || "";
+      const mergedSkillsInstructions = behaviorRun
+        ? ""
+        : contextData.skillsInstructions || "";
 
       logger.info(
-        `Session context for ${userId}: ${Object.keys(mcpConfig.mcpServers || {}).length} MCPs, ${contextData.agentLayers.identityMd.length}/${contextData.agentLayers.soulMd.length}/${contextData.agentLayers.userMd.length} chars identity/soul/user, ${contextData.platformInstructions.length} chars platform instructions, ${contextData.networkInstructions.length} chars network instructions, ${mergedSkillsInstructions.length} chars skills instructions, ${enrichedMcpStatus.length} MCP status entries, ${Object.keys(mcpTools).length} MCP tool lists, ${Object.keys(mcpInstructions).length} MCP instructions, ${skillsConfig.length} skills, provider: ${providerConfig.defaultProvider || "none"}`
+        `Session context for ${userId}: ${Object.keys(mcpConfig.mcpServers || {}).length} MCPs, ${contextData.agentLayers.identityMd.length}/${contextData.agentLayers.soulMd.length}/${contextData.agentLayers.userMd.length} chars identity/soul/user, ${contextData.platformInstructions.length} chars platform instructions, ${contextData.networkInstructions.length} chars network instructions, ${mergedSkillsInstructions.length} chars skills instructions, ${enrichedMcpStatus.length} MCP status entries, ${Object.keys(mcpTools).length} MCP tool lists, ${Object.keys(mcpInstructions).length} MCP instructions, ${skillsConfig.length} skills${behaviorRun ? " (Behavior run — live skill library suppressed)" : ""}, provider: ${providerConfig.defaultProvider || "none"}`
       );
 
       return c.json({

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -18,6 +18,7 @@ import { TERMINAL_DELIVERY_SEND_OPTS } from "../infrastructure/queue/index.js";
 import type { InteractionService } from "../interactions.js";
 import type { PlatformRegistry } from "../platform.js";
 import type { SseManager } from "../services/sse-manager.js";
+import { BEHAVIOR_RUN_SOURCE } from "../behavior-run-session.js";
 import {
   finalizeTurnSuggestions,
   readCurrentSuggestion,
@@ -74,7 +75,7 @@ interface ChatInteractionEnvelope {
  * autonomous-only restrictions.
  */
 const HEADLESS_SOURCES = new Set([
-  "watcher-run",
+  BEHAVIOR_RUN_SOURCE,
   "connector-repair",
   "scheduled-job",
   "internal",

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -25,6 +25,7 @@ import { getCachedOrgBySlug } from "../../../workspace/multi-tenant.js";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store.js";
 import { listPendingToolsForConversation } from "../../auth/mcp/pending-tool-store.js";
 import { getRevokedTokenStore } from "../../auth/revoked-token-store.js";
+import { BEHAVIOR_RUN_SOURCE } from "../../behavior-run-session.js";
 import {
   createApiAuthMiddleware,
   TOKEN_EXPIRATION_MS,
@@ -1615,7 +1616,10 @@ export function createAgentApi(config: AgentApiConfig): Hono {
           // Echoed back on every response row so output-guardrail audit events
           // remain scoped to the authoritative organization.
           organizationId: messageOrganizationId,
-          source: session.intent?.kind === "behavior_run" ? "watcher-run" : "direct-api",
+          source:
+            session.intent?.kind === "behavior_run"
+              ? BEHAVIOR_RUN_SOURCE
+              : "direct-api",
           traceparent: traceparent || undefined,
           dryRun: session.dryRun || false,
           intent: session.intent,


### PR DESCRIPTION
## Summary

- A Behavior run executes the instruction text its version froze at apply/save time. The gateway was still shipping the agent's **live** skill library with that turn — `skillsConfig` (which the worker writes into `.skills/`) plus the progressive catalog, whose closing line and generic fallback both tell the model to `cat .skills/*/SKILL.md`. Either one serves whatever the library holds *today*, so a skill edited after the Behavior was saved could dilute or override the frozen job. Issue #2320 must-fix 1.
- Both surfaces are now suppressed on turns whose signed worker token carries `source: "watcher-run"` — stamped exactly when the dispatching session declared `intent.kind === "behavior_run"`. Persona, tools, MCP and network stay live; they are the agent, not the job.
- Scoped narrower than the SSE-routing sense of "headless": `connector-repair` / `scheduled-job` / `internal` turns have no frozen text behind them, and ordinary chat keeps its library even when a Behavior is listening on the conversation (a human is in that thread).

### Why the gateway, and why no worker cache key

The plan flagged the worker's 5-minute `session-context` cache (keyed only on `mcpExposure`) as a place this decision could leak. It can't, because the decision is made gateway-side and a Behavior run gets its own worker process: `watchers/automation.ts` opens the run's session with `thread: watcher-<runId>` + `forceNew`, and `generateDeploymentName` hashes the conversation id — so a run's worker is never the process that also serves that agent's chat. That reasoning is written down at the decision site so a future dispatch path that shares a conversation knows where to look.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts`, `bun test packages/server/src/__tests__/unit`
- [x] Bug fix: red→fix→green outputs pasted below

### Red (before the fix)

```
$ bun test packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts
   (isolation gate reverted: `const behaviorRun = false`)

error: expect(received).toEqual(expected)
- []
+ [
+   {
+     "content": "# Custom Skill\n",
+     "name": "custom-skill",
+   },
+ ]
(fail) WorkerGateway session context > syncs configured skills for chat but suppresses them for Behavior runs

 1 pass
 1 fail
```

### Green (after)

```
$ bun test packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts

 2 pass
 0 fail

$ bun test packages/server/src/__tests__/unit

 739 pass
 16 skip
 0 fail
Ran 755 tests across 81 files.
```

### Mutation check

Both directions of the gate are pinned, not just the happy path:

| Mutation | Result |
|---|---|
| `isBehaviorRun` → always true | chat + connector-repair assertions fail |
| gate widened to every non-empty `source` | connector-repair assertion fails |

## Notes

Part of #2320 (thin Skills + Behaviors). Follows #2324 / #2327 / #2331.

Residual, called out rather than silently assumed:
- The device-worker poll path (`worker-api/poll.ts`) embeds frozen instructions already, but its `.skills` materialisation lives in the Mac Bridge, outside this repo — unchanged here.
- A chat turn that a Behavior is *listening* on keeps the live library by design. Its instructions ride `ephemeralContext` into a live human conversation; stripping skills there would strip the human's chat skills too, and would poison the shared conversation's cached context for their next message.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Behavior runs now use a dedicated execution mode for session handling.
  * Live skills are suppressed during Behavior runs to ensure consistent execution context.
  * Behavior-run sessions retain their predefined instructions while regular sessions continue using current skills and instructions.

* **Bug Fixes**
  * Improved routing for Behavior-run activity, preventing unnecessary ownership checks during delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->