### PR TITLE
feat(server): resolve identity claims before creating an entity

### DIFF
--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -82,6 +82,29 @@ export const ManageEntitySchema = Type.Object({
     })
   ),
 
+  identities: Type.Optional(
+    Type.Array(
+      Type.Object({
+        namespace: Type.String({
+          minLength: 1,
+          maxLength: 64,
+          description:
+            "Identifier kind. Only 'phone' and 'email' may be supplied here; every other namespace is server-owned (sign-in and connector identities) and is ignored.",
+        }),
+        identifier: Type.String({
+          minLength: 1,
+          maxLength: 512,
+          description: "The value, e.g. '+90 532 235 65 86'.",
+        }),
+      }),
+      {
+        maxItems: 25,
+        description:
+          "[create] Identifiers that uniquely IDENTIFY this thing, as opposed to metadata describing it. Supplying them makes create resolve first: if a live entity already claims one, that entity is used and `attached_to_existing` comes back true instead of a duplicate being made. Values that do not parse are ignored rather than stored as claims, as are namespaces other than phone and email. Two different existing entities claiming different identifiers in one call is refused — merge them first.",
+      }
+    )
+  ),
+
   merge_evidence: Type.Optional(
     Type.Array(
       Type.Object({
@@ -395,6 +418,11 @@ export const ManageEntityResultSchema = Type.Union([
   Type.Object({
     action: Type.Literal("create"),
     entity: Type.Optional(ManageEntityItemSchema),
+    /**
+     * True when a supplied identifier already belonged to a live entity, so
+     * `entity` is that pre-existing one rather than something newly made.
+     */
+    attached_to_existing: Type.Optional(Type.Boolean()),
     warnings: Type.Optional(Type.Array(Type.String())),
     next_steps: Type.Optional(Type.Array(Type.String())),
     approval_queued: Type.Optional(Type.Boolean()),

--- a/packages/server/src/__tests__/integration/entities/manage-entity-identities.test.ts
+++ b/packages/server/src/__tests__/integration/entities/manage-entity-identities.test.ts
@@ -1,0 +1,299 @@
+/**
+ * `manage_entity` create with identity claims. The prior tool path created an
+ * entity without first consulting claims already written by connector ingest.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import { manageEntity } from "../../../tools/admin/manage_entity";
+import type { ToolContext } from "../../../tools/registry";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const env = {} as Env;
+
+function ctx(orgId: string, userId: string): ToolContext {
+	return {
+		organizationId: orgId,
+		userId,
+		memberRole: "owner",
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+	} as ToolContext;
+}
+
+type CreateResult = {
+	entity?: { id: number };
+	attached_to_existing?: boolean;
+	warnings?: string[];
+};
+
+describe("manage_entity create with identities", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+	});
+
+	async function org() {
+		const organization = await createTestOrganization({ name: "Identity Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, organization.id, "owner");
+		const sql = getTestDb();
+		// manage_entity resolves entity_type against a real row (unlike
+		// createTestEntity, which auto-ensures one).
+		await sql`
+			INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+			VALUES (${organization.id}, 'person', 'Person', current_timestamp, current_timestamp)
+			ON CONFLICT DO NOTHING
+		`;
+		return { organization, user, sql };
+	}
+
+	async function create(
+		orgId: string,
+		userId: string,
+		name: string,
+		identities?: Array<{ namespace: string; identifier: string }>,
+	) {
+		return (await manageEntity(
+			{ action: "create", entity_type: "person", name, identities },
+			env,
+			ctx(orgId, userId),
+		)) as unknown as CreateResult;
+	}
+
+	it("records the claims it was given, normalized", async () => {
+		const { organization, user, sql } = await org();
+		const created = await create(organization.id, user.id, "Esref", [
+			{ namespace: " Phone ", identifier: "+90 532 235 65 86" },
+		]);
+
+		const rows = await sql`
+			SELECT namespace, identifier, source_connector
+			FROM entity_identities
+			WHERE entity_id = ${created.entity?.id ?? 0} AND deleted_at IS NULL
+		`;
+		expect(rows).toHaveLength(1);
+		// Punctuation stripped by the phone normalizer — stored canonically so the
+		// next writer's lookup can actually find it.
+		expect(rows[0].identifier).toBe("905322356586");
+		expect(rows[0].namespace).toBe("phone");
+		expect(rows[0].source_connector).toBe("tool:manage_entity");
+	});
+
+	it("attaches to the existing person instead of creating a duplicate", async () => {
+		const { organization, user, sql } = await org();
+		const first = await create(organization.id, user.id, "Esref", [
+			{ namespace: "phone", identifier: "905322356586" },
+		]);
+
+		// Same human, a spelling the importer happened to use. This is the exact
+		// call that used to mint the duplicate.
+		const second = await create(organization.id, user.id, "Esref Kaya", [
+			{ namespace: "phone", identifier: "+90 (532) 235 65 86" },
+		]);
+
+		expect(second.attached_to_existing).toBe(true);
+		expect(second.entity?.id).toBe(first.entity?.id);
+
+		const people = await sql`
+			SELECT e.id FROM entities e
+			JOIN entity_types t ON t.id = e.entity_type_id
+			WHERE e.organization_id = ${organization.id}
+			  AND t.slug = 'person' AND e.deleted_at IS NULL
+		`;
+		expect(people).toHaveLength(1);
+	});
+
+	it("serializes concurrent creates for the same new identity", async () => {
+		const { organization, user, sql } = await org();
+		const [first, second] = await Promise.all([
+			create(organization.id, user.id, "Concurrent A", [
+				{ namespace: "email", identifier: "race@example.com" },
+			]),
+			create(organization.id, user.id, "Concurrent B", [
+				{ namespace: "email", identifier: "race@example.com" },
+			]),
+		]);
+
+		expect(first.entity?.id).toBe(second.entity?.id);
+		expect(
+			[first.attached_to_existing, second.attached_to_existing].filter(Boolean),
+		).toHaveLength(1);
+		const people = await sql`
+			SELECT e.id
+			FROM entities e
+			JOIN entity_types t ON t.id = e.entity_type_id
+			WHERE e.organization_id = ${organization.id}
+			  AND t.slug = 'person'
+			  AND e.deleted_at IS NULL
+		`;
+		expect(people).toHaveLength(1);
+	});
+
+	it("preserves normalized claims when an agent create is deferred", async () => {
+		const { organization, user, sql } = await org();
+		const agent = await createTestAgent({
+			organizationId: organization.id,
+			ownerUserId: user.id,
+		});
+		// Deferral only happens when policy holds the create for approval.
+		// Without this the tool creates immediately and the claims are attached
+		// inline, which would leave the deferred payload untested.
+		const policy = await sql<{ id: number }>`
+			INSERT INTO write_approval_policies
+				(organization_id, resource_class, principal_kind, entity_type_slug)
+			VALUES (${organization.id}, 'entity', 'agent', 'person')
+			RETURNING id
+		`;
+		await sql`
+			INSERT INTO write_policy_action_effects (policy_id, action, effect)
+			VALUES (${Number(policy[0].id)}, 'create', 'approval')
+		`;
+		const result = (await manageEntity(
+			{
+				action: "create",
+				entity_type: "person",
+				name: "Deferred Person",
+				identities: [
+					{ namespace: " Email ", identifier: " Deferred@Example.COM " },
+				],
+			},
+			env,
+			{
+				...ctx(organization.id, user.id),
+				agentId: agent.agentId,
+			} as ToolContext,
+		)) as unknown as { approval_queued?: boolean; approval_run_id?: number };
+
+		expect(result.approval_queued).toBe(true);
+		const rows = await sql`
+			SELECT action_input
+			FROM runs
+			WHERE id = ${result.approval_run_id ?? 0}
+		`;
+		expect(rows[0].action_input.identity_claims).toEqual([
+			{ namespace: "email", identifier: "deferred@example.com" },
+		]);
+		expect(rows[0].action_input.identity_source_connector).toBe(
+			`agent:${agent.agentId}`,
+		);
+	});
+
+	it("creates normally when nothing claims the identifier", async () => {
+		const { organization, user } = await org();
+		await create(organization.id, user.id, "Esref", [
+			{ namespace: "phone", identifier: "905322356586" },
+		]);
+		const other = await create(organization.id, user.id, "Dedem", [
+			{ namespace: "phone", identifier: "905067888845" },
+		]);
+		expect(other.attached_to_existing).toBeFalsy();
+	});
+
+	it("does NOT match a national-format number to a country-coded one", async () => {
+		// The phone normalizer strips punctuation but never guesses a country
+		// code, so these stay separate people.
+		const { organization, user } = await org();
+		const first = await create(organization.id, user.id, "Contact", [
+			{ namespace: "phone", identifier: "905324764881" },
+		]);
+		const second = await create(organization.id, user.id, "Contact 2", [
+			{ namespace: "phone", identifier: "05324764881" },
+		]);
+		expect(second.attached_to_existing).toBeFalsy();
+		expect(second.entity?.id).not.toBe(first.entity?.id);
+	});
+
+	it("refuses to fuse two existing people in one call", async () => {
+		const { organization, user } = await org();
+		const a = await create(organization.id, user.id, "Person A", [
+			{ namespace: "phone", identifier: "905322356586" },
+		]);
+		const b = await create(organization.id, user.id, "Person B", [
+			{ namespace: "email", identifier: "b@example.com" },
+		]);
+		expect(a.entity?.id).not.toBe(b.entity?.id);
+
+		// Both identifiers in one create would silently merge two real records.
+		await expect(
+			create(organization.id, user.id, "Person A or B", [
+				{ namespace: "phone", identifier: "905322356586" },
+				{ namespace: "email", identifier: "b@example.com" },
+			]),
+		).rejects.toThrow(/already belong to different entities/i);
+	});
+
+	it("ignores a value its namespace cannot parse rather than storing a fake claim", async () => {
+		const { organization, user, sql } = await org();
+		const created = await create(organization.id, user.id, "Nobody", [
+			{ namespace: "phone", identifier: "not a phone number at all" },
+			{ namespace: "email", identifier: "also-not-an-email" },
+		]);
+		const rows = await sql`
+			SELECT 1 FROM entity_identities
+			WHERE entity_id = ${created.entity?.id ?? 0} AND deleted_at IS NULL
+		`;
+		expect(rows).toHaveLength(0);
+		// The entity is still created — an unparseable value is a display string,
+		// not a reason to refuse the write.
+		expect(created.entity?.id).toBeGreaterThan(0);
+	});
+
+
+	it("does not let a create-only agent probe for an existing person", async () => {
+		// The oracle this guards: an agent denied READ on the type submits a phone
+		// it suspects exists. If create resolved, the response would hand back that
+		// person's record — turning create into a lookup for data it cannot read.
+		const { organization, user, sql } = await org();
+		const owner = await create(organization.id, user.id, "Private Person", [
+			{ namespace: "phone", identifier: "905551234567" },
+		]);
+		const agent = await createTestAgent({
+			organizationId: organization.id,
+			ownerUserId: user.id,
+		});
+		const policy = await sql<{ id: number }>`
+			INSERT INTO write_approval_policies
+				(organization_id, resource_class, principal_kind, entity_type_slug)
+			VALUES (${organization.id}, 'entity', 'agent', 'person')
+			RETURNING id
+		`;
+		await sql`
+			INSERT INTO write_policy_action_effects (policy_id, action, effect)
+			VALUES (${Number(policy[0].id)}, 'read', 'deny')
+		`;
+
+		const probed = (await manageEntity(
+			{
+				action: "create",
+				entity_type: "person",
+				name: "Probe",
+				identities: [{ namespace: "phone", identifier: "905551234567" }],
+			},
+			env,
+			{
+				...ctx(organization.id, user.id),
+				agentId: agent.agentId,
+			} as ToolContext,
+		)) as unknown as CreateResult;
+
+		// A fresh entity, never the existing one, and no attach signal.
+		expect(probed.entity?.id).not.toBe(owner.entity?.id);
+		expect(probed.attached_to_existing).toBeFalsy();
+		// The contested claim stays with its owner rather than moving.
+		const rows = await sql`
+			SELECT entity_id FROM entity_identities
+			WHERE organization_id = ${organization.id}
+			  AND namespace = 'phone' AND identifier = '905551234567'
+			  AND deleted_at IS NULL
+		`;
+		expect(rows).toHaveLength(1);
+		expect(Number(rows[0].entity_id)).toBe(owner.entity?.id);
+	});
+});

--- a/packages/server/src/authz/approval-interceptor.ts
+++ b/packages/server/src/authz/approval-interceptor.ts
@@ -23,6 +23,7 @@ import {
 	proposeEntityDelete,
 	proposeEntityFieldChange,
 } from "../tools/admin/entity-field-approval";
+import type { ResolutionIdentity } from "../entity-resolution/policy";
 import type { EntityData } from "../utils/entity-management";
 import type {
 	DeferredMutation,
@@ -57,6 +58,8 @@ function fieldChangeReason(
 
 export function buildCreateDeferral(args: {
 	entityData: EntityData;
+	identityClaims?: ResolutionIdentity[];
+	identitySourceConnector?: string;
 	proposal: Record<string, unknown>;
 	attribution: MutationAttribution;
 	watcherId?: number | null;
@@ -73,6 +76,8 @@ export function buildCreateDeferral(args: {
 		queue: (ctx) =>
 			proposeEntityCreate(ctx, {
 				entity_data: args.entityData,
+				identity_claims: args.identityClaims,
+				identity_source_connector: args.identitySourceConnector,
 				proposal: args.proposal,
 				watcher_id: args.watcherId ?? null,
 				window_id: args.windowId ?? null,
@@ -187,6 +192,8 @@ async function evaluate(
 			outcome: "defer",
 			deferred: buildCreateDeferral({
 				entityData: req.entityData,
+				identityClaims: req.identityClaims,
+				identitySourceConnector: req.identitySourceConnector,
 				proposal: req.proposal,
 				attribution: req.attribution,
 				watcherId: req.watcherId,

--- a/packages/server/src/authz/entity-mutation-gate.ts
+++ b/packages/server/src/authz/entity-mutation-gate.ts
@@ -39,6 +39,7 @@
 
 import type { ApprovalAttribution } from "@lobu/core/contracts/interaction-envelope";
 import type { DbClient } from "../db/client";
+import type { ResolutionIdentity } from "../entity-resolution/policy";
 import type { Env } from "../index";
 import type { ToolContext } from "../tools/registry";
 import type { EntityData } from "../utils/entity-management";
@@ -102,6 +103,8 @@ export interface CreateMutationRequest extends EntityMutationBase {
 	action: "create";
 	entityTypeSlug: string;
 	entityData: EntityData;
+	identityClaims?: ResolutionIdentity[];
+	identitySourceConnector?: string;
 	/** Snapshot payload shown on the approval card. */
 	proposal: Record<string, unknown>;
 }
@@ -210,6 +213,8 @@ export function deferEntityFieldChange(args: {
 /** Package a policy-held create as a POST-COMMIT deferred mutation. */
 export function deferEntityCreate(args: {
 	entityData: EntityData;
+	identityClaims?: ResolutionIdentity[];
+	identitySourceConnector?: string;
 	proposal: Record<string, unknown>;
 	attribution: MutationAttribution;
 	watcherId?: number | null;

--- a/packages/server/src/entity-resolution/identity-create.ts
+++ b/packages/server/src/entity-resolution/identity-create.ts
@@ -1,0 +1,211 @@
+import { getDb } from "../db/client";
+import type { Env } from "../index";
+import type { ToolContext } from "../tools/registry";
+import {
+	createEntity,
+	type CreatedEntity,
+	type EntityData,
+	getEntity,
+} from "../utils/entity-management";
+import { ToolUserError } from "../utils/errors";
+import logger from "../utils/logger";
+import {
+	attachEntityIdentities,
+	findEntitiesByIdentity,
+	resolveIdentityOwner,
+} from "./identity-lookup";
+import type { ResolutionIdentity } from "./policy";
+
+async function removeFreshEntity(
+	entityId: number,
+	organizationId: string,
+): Promise<void> {
+	const sql = getDb();
+	await sql`
+		DELETE FROM entities
+		WHERE id = ${entityId}
+		  AND organization_id = ${organizationId}
+	`;
+}
+
+export async function createEntityWithIdentityClaims(input: {
+	data: EntityData;
+	identities: ResolutionIdentity[];
+	env: Env;
+	ctx: ToolContext;
+	sourceConnector: string;
+	/**
+	 * Whether this caller may have a claim resolve to an EXISTING entity.
+	 * Supplied by the tool layer (which owns the read-policy helpers) and must
+	 * be type-level and data-independent: deciding per-resolved-entity would
+	 * make create an oracle, since "denied" vs "created" would itself reveal
+	 * that someone already claims this identifier.
+	 */
+	canResolveExisting: (entityTypeSlug: string) => Promise<boolean>;
+}): Promise<{ entity: CreatedEntity; attachedToExisting: boolean }> {
+	if (input.identities.length === 0) {
+		return {
+			entity: await createEntity(input.data, {
+				hookContext: {
+					organizationId: input.ctx.organizationId,
+					userId: input.ctx.userId,
+					env: input.env,
+				},
+			}),
+			attachedToExisting: false,
+		};
+	}
+
+	// Resolution hands back a PRE-EXISTING record, so it is only safe for a
+	// caller allowed to read this type. The check is on the TYPE and runs BEFORE
+	// any lookup on purpose: gating on the resolved entity instead would make
+	// create an oracle, because "denied" vs "created" would itself reveal that
+	// someone already claims this identifier. Denied callers fall through to a
+	// plain create — exactly what this call did before this path existed.
+	if (!(await input.canResolveExisting(input.data.entity_type))) {
+		return {
+			entity: await createUnresolvedEntity(input),
+			attachedToExisting: false,
+		};
+	}
+
+	const sql = getDb();
+	const owners = await findEntitiesByIdentity(sql, {
+		organizationId: input.ctx.organizationId,
+		identities: input.identities,
+	});
+	const resolved = resolveIdentityOwner(owners, input.identities);
+	if (resolved.decision === "ambiguous") {
+		throw new ToolUserError(
+			`These identifiers already belong to different entities (${resolved.candidateEntityIds.join(", ")}), so creating one entity for them would silently fuse separate records. Merge those entities first with manage_entity(action='merge'), or create with only the identifiers of one of them.`,
+			409,
+		);
+	}
+	if (resolved.decision === "attach" && resolved.entityId !== undefined) {
+		const existing = await getEntity(resolved.entityId, input.env, input.ctx);
+		if (!existing) {
+			throw new ToolUserError(
+				"Identity ownership changed while creating the entity; retry.",
+				409,
+			);
+		}
+		// The owner can be a DIFFERENT type than the one being created — a phone
+		// claimed by a $member, say. Authorizing only the requested type would
+		// hand back a record the caller may not read, so re-check against the
+		// owner's ACTUAL type and fall through to the indistinguishable
+		// unresolved-create path when denied.
+		if (!(await input.canResolveExisting(existing.entity_type))) {
+			return {
+				entity: await createUnresolvedEntity(input),
+				attachedToExisting: false,
+			};
+		}
+		// This is still a create operation, not an update to the resolved record.
+		// Its existing claims choose the entity; unclaimed inputs remain unchanged.
+		return { entity: existing, attachedToExisting: true };
+	}
+
+	const entity = await createEntity(input.data, {
+		hookContext: {
+			organizationId: input.ctx.organizationId,
+			userId: input.ctx.userId,
+			env: input.env,
+		},
+	});
+	try {
+		const attached = await attachEntityIdentities(sql, {
+			organizationId: input.ctx.organizationId,
+			entityId: entity.id,
+			identities: input.identities,
+			sourceConnector: input.sourceConnector,
+		});
+		if (attached.length === input.identities.length) {
+			return { entity, attachedToExisting: false };
+		}
+	} catch (error) {
+		try {
+			await removeFreshEntity(entity.id, input.ctx.organizationId);
+		} catch (cleanupError) {
+			logger.error(
+				{ cleanupError, entityId: entity.id },
+				"Failed to remove an entity after its identity claims failed",
+			);
+		}
+		throw error;
+	}
+
+	// Another writer won at least one unique claim after our lookup. The fresh
+	// row cannot survive without the full identity set; remove it and reconcile
+	// to the owner selected by the unique index.
+	await removeFreshEntity(entity.id, input.ctx.organizationId);
+	const winnerOwners = await findEntitiesByIdentity(sql, {
+		organizationId: input.ctx.organizationId,
+		identities: input.identities,
+	});
+	const winner = resolveIdentityOwner(winnerOwners, input.identities);
+	if (winner.decision === "attach" && winner.entityId !== undefined) {
+		const existing = await getEntity(winner.entityId, input.env, input.ctx);
+		if (existing) {
+			if (!(await input.canResolveExisting(existing.entity_type))) {
+				throw new ToolUserError(
+					"Identity ownership changed while creating the entity; retry.",
+					409,
+				);
+			}
+			return { entity: existing, attachedToExisting: true };
+		}
+	}
+	if (winner.decision === "ambiguous") {
+		throw new ToolUserError(
+			`These identifiers now belong to different entities (${winner.candidateEntityIds.join(", ")}); merge them before retrying.`,
+			409,
+		);
+	}
+	throw new ToolUserError(
+		"Identity ownership changed while creating the entity; retry.",
+		409,
+	);
+}
+
+/**
+ * Plain create for a caller who may not resolve against existing entities.
+ * Claims attach best-effort: one already held by another entity stays with its
+ * owner and simply does not attach here. Partial attachment is NOT treated as a
+ * lost race, because reconciling would hand back the very entity this caller is
+ * not allowed to see.
+ */
+async function createUnresolvedEntity(input: {
+	data: EntityData;
+	identities: ResolutionIdentity[];
+	env: Env;
+	ctx: ToolContext;
+	sourceConnector: string;
+}): Promise<CreatedEntity> {
+	const entity = await createEntity(input.data, {
+		hookContext: {
+			organizationId: input.ctx.organizationId,
+			userId: input.ctx.userId,
+			env: input.env,
+		},
+	});
+	if (input.identities.length === 0) return entity;
+	try {
+		await attachEntityIdentities(getDb(), {
+			organizationId: input.ctx.organizationId,
+			entityId: entity.id,
+			identities: input.identities,
+			sourceConnector: input.sourceConnector,
+		});
+	} catch (error) {
+		try {
+			await removeFreshEntity(entity.id, input.ctx.organizationId);
+		} catch (cleanupError) {
+			logger.error(
+				{ cleanupError, entityId: entity.id },
+				"Failed to remove an entity after its identity claims failed",
+			);
+		}
+		throw error;
+	}
+	return entity;
+}

--- a/packages/server/src/entity-resolution/identity-lookup.test.ts
+++ b/packages/server/src/entity-resolution/identity-lookup.test.ts
@@ -46,7 +46,6 @@ describe("normalizeRequestedIdentities", () => {
 			]),
 		).toEqual([]);
 	});
-});
 
 	it("refuses server-owned namespaces so a caller cannot squat them", () => {
 		// auth_user_id is how authz/member-claim-predicate resolves a signed-in
@@ -75,6 +74,7 @@ describe("normalizeRequestedIdentities", () => {
 			{ namespace: "email", identifier: "a@b.com" },
 		]);
 	});
+});
 
 describe("identityKey", () => {
 	it("does not let a separator in one part impersonate another claim", () => {

--- a/packages/server/src/entity-resolution/identity-lookup.test.ts
+++ b/packages/server/src/entity-resolution/identity-lookup.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The pure half of identity-lookup: how a create path decides between
+ * attaching to what exists, minting a new entity, and refusing to guess.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	contestedAgainst,
+	identityKey,
+	normalizeRequestedIdentities,
+	resolveIdentityOwner,
+} from "./identity-lookup";
+
+const phone = (identifier: string) => ({ namespace: "phone", identifier });
+
+describe("normalizeRequestedIdentities", () => {
+	it("canonicalizes generic namespace spelling and value", () => {
+		expect(
+			normalizeRequestedIdentities([
+				{ namespace: " Email ", identifier: " Alice@Example.COM " },
+			]),
+		).toEqual([{ namespace: "email", identifier: "alice@example.com" }]);
+	});
+
+	it("de-duplicates repeated claims", () => {
+		expect(
+			normalizeRequestedIdentities([
+				{ namespace: "phone", identifier: "+90 532 235 65 86" },
+				{ namespace: "phone", identifier: "905322356586" },
+			]),
+		).toEqual([{ namespace: "phone", identifier: "905322356586" }]);
+	});
+
+	it("refuses a custom namespace — the server may own it", () => {
+		expect(
+			normalizeRequestedIdentities([
+				{ namespace: "crm_contact_id", identifier: "42" },
+			]),
+		).toEqual([]);
+	});
+
+	it("drops generic namespaces that are not unique per organization", () => {
+		expect(
+			normalizeRequestedIdentities([
+				{ namespace: "email_domain", identifier: "example.com" },
+			]),
+		).toEqual([]);
+	});
+});
+
+	it("refuses server-owned namespaces so a caller cannot squat them", () => {
+		// auth_user_id is how authz/member-claim-predicate resolves a signed-in
+		// user to their $member, and it is unique per org — reserving one would
+		// make the real provisioning write lose and break member/ACL resolution.
+		expect(
+			normalizeRequestedIdentities([
+				{ namespace: "auth_user_id", identifier: "user_abc" },
+				{ namespace: "AUTH_USER_ID", identifier: "user_abc" },
+				{ namespace: "slack_user_id", identifier: "U123" },
+				{ namespace: "github_login", identifier: "octocat" },
+				{ namespace: "wa_jid", identifier: "905322356586@s.whatsapp.net" },
+				{ namespace: "watcher_key", identifier: "k1" },
+			]),
+		).toEqual([]);
+	});
+
+	it("still accepts the user-authored namespaces", () => {
+		expect(
+			normalizeRequestedIdentities([
+				{ namespace: "phone", identifier: "+90 532 235 65 86" },
+				{ namespace: "email", identifier: "A@B.com" },
+			]),
+		).toEqual([
+			{ namespace: "phone", identifier: "905322356586" },
+			{ namespace: "email", identifier: "a@b.com" },
+		]);
+	});
+
+describe("identityKey", () => {
+	it("does not let a separator in one part impersonate another claim", () => {
+		// A delimiter-joined key would make these two collide, and one entity's
+		// claim would be read as another's.
+		expect(identityKey({ namespace: "a:b", identifier: "c" })).not.toBe(
+			identityKey({ namespace: "a", identifier: "b:c" }),
+		);
+		expect(identityKey({ namespace: "a b", identifier: "c" })).not.toBe(
+			identityKey({ namespace: "a", identifier: "b c" }),
+		);
+	});
+
+	it("is stable for the same claim", () => {
+		expect(identityKey(phone("905322356586"))).toBe(
+			identityKey(phone("905322356586")),
+		);
+	});
+});
+
+describe("resolveIdentityOwner", () => {
+	it("creates when nothing claims the identifiers", () => {
+		expect(resolveIdentityOwner(new Map(), [phone("905322356586")])).toEqual({
+			decision: "create",
+			candidateEntityIds: [],
+		});
+	});
+
+	it("attaches to the single existing owner", () => {
+		const owners = new Map([[identityKey(phone("905322356586")), 42]]);
+		expect(resolveIdentityOwner(owners, [phone("905322356586")])).toEqual({
+			decision: "attach",
+			entityId: 42,
+			candidateEntityIds: [42],
+		});
+	});
+
+	it("attaches when several identifiers all point at the same entity", () => {
+		const owners = new Map([
+			[identityKey(phone("905322356586")), 42],
+			[identityKey({ namespace: "email", identifier: "a@b.com" }), 42],
+		]);
+		const resolved = resolveIdentityOwner(owners, [
+			phone("905322356586"),
+			{ namespace: "email", identifier: "a@b.com" },
+		]);
+		expect(resolved.decision).toBe("attach");
+		expect(resolved.entityId).toBe(42);
+	});
+
+	it("refuses to guess when identifiers point at DIFFERENT entities", () => {
+		// Picking either one would silently fuse two real people; picking neither
+		// and creating a third would be worse. The caller has to decide.
+		const owners = new Map([
+			[identityKey(phone("905322356586")), 42],
+			[identityKey({ namespace: "email", identifier: "a@b.com" }), 7],
+		]);
+		expect(
+			resolveIdentityOwner(owners, [
+				phone("905322356586"),
+				{ namespace: "email", identifier: "a@b.com" },
+			]),
+		).toEqual({ decision: "ambiguous", candidateEntityIds: [7, 42] });
+	});
+
+	it("ignores owners for identifiers that were not requested", () => {
+		const owners = new Map([[identityKey(phone("999")), 42]]);
+		expect(resolveIdentityOwner(owners, [phone("905322356586")]).decision).toBe(
+			"create",
+		);
+	});
+});
+
+describe("contestedAgainst", () => {
+	it("reports a claim held by a different entity", () => {
+		const owners = new Map([[identityKey(phone("905322356586")), 7]]);
+		expect(contestedAgainst(owners, 42, [phone("905322356586")])).toEqual([
+			phone("905322356586"),
+		]);
+	});
+
+	it("does not report a claim this entity already holds", () => {
+		const owners = new Map([[identityKey(phone("905322356586")), 42]]);
+		expect(contestedAgainst(owners, 42, [phone("905322356586")])).toEqual([]);
+	});
+
+	it("does not report an unclaimed identifier", () => {
+		expect(contestedAgainst(new Map(), 42, [phone("905322356586")])).toEqual([]);
+	});
+});

--- a/packages/server/src/entity-resolution/identity-lookup.ts
+++ b/packages/server/src/entity-resolution/identity-lookup.ts
@@ -1,0 +1,241 @@
+/**
+ * The identifier→owner direction of `entity_identities`, plus the writer that
+ * attaches claims without stealing or silently dropping them.
+ *
+ * `identities.ts` next door loads entity→claims, which is what the resolution
+ * policy needs once it already has candidate entities. This module answers the
+ * question a *writer* has to ask first: "does anything already claim this
+ * phone?" Without it a create path inserts blindly and mints the duplicate that
+ * a human then has to review away.
+ */
+
+import { normalizeIdentifier } from "@lobu/connector-sdk/identity-normalize";
+import {
+	getIdentityNamespaceDefinition,
+	IDENTITY,
+} from "@lobu/connector-sdk/identity-namespaces";
+import { type DbClient, pgTextArray } from "../db/client";
+import type { ResolutionIdentity } from "./policy";
+
+/**
+ * Map key for one claim. Structural rather than delimiter-joined: `namespace`
+ * and `identifier` are both free-form, so any single separator lets
+ * `{ns:"a:b", id:"c"}` collide with `{ns:"a", id:"b:c"}` and one entity's claim
+ * be read as another's.
+ */
+export function identityKey(identity: ResolutionIdentity): string {
+	return JSON.stringify([identity.namespace, identity.identifier]);
+}
+
+/**
+ * Canonicalize generic namespaces and their values. Connector-owned/custom
+ * namespaces keep their spelling and use the SDK's trim-only fallback.
+ */
+/**
+ * The only namespaces a caller may author through the tool surface.
+ *
+ * An ALLOW-list, deliberately. A deny-list cannot be made complete: there is no
+ * single enumeration of server-written namespaces — `CONNECTOR_IDENTITY_MODULES`
+ * registers only github/slack/x, while WhatsApp, Instagram and LinkedIn write
+ * `wa_jid`, `ig_username` and `linkedin_slug` without appearing there. Anything
+ * missed becomes squattable.
+ *
+ * Squatting matters because these claims are unique per org. `auth_user_id` is
+ * the sharpest case: `authz/member-claim-predicate` resolves a signed-in user to
+ * their `$member` through exactly that claim, so a claim reserved first would
+ * make the real provisioning write lose its ON CONFLICT and silently break
+ * member and ACL resolution.
+ *
+ * Widen only deliberately, and only to namespaces the server never writes.
+ */
+const CALLER_AUTHORED_NAMESPACES: ReadonlySet<string> = new Set<string>([
+	IDENTITY.EMAIL,
+	IDENTITY.PHONE,
+]);
+
+export function normalizeRequestedIdentities(
+	requested: Array<{ namespace: string; identifier: string }> | undefined,
+): ResolutionIdentity[] {
+	if (!requested || requested.length === 0) return [];
+	const out = new Map<string, ResolutionIdentity>();
+	for (const item of requested) {
+		const suppliedNamespace = item.namespace.trim();
+		if (!suppliedNamespace) continue;
+		const genericNamespace = suppliedNamespace.toLowerCase();
+		if (!CALLER_AUTHORED_NAMESPACES.has(genericNamespace)) continue;
+		const genericDefinition =
+			getIdentityNamespaceDefinition(genericNamespace);
+		if (genericDefinition && !genericDefinition.uniquePerOrg) continue;
+		const namespace = genericDefinition ? genericNamespace : suppliedNamespace;
+		const identifier = normalizeIdentifier(namespace, item.identifier);
+		if (!identifier) continue;
+		const identity = { namespace, identifier };
+		out.set(identityKey(identity), identity);
+	}
+	return [...out.values()];
+}
+
+/**
+ * The live entity owning each claim, keyed by {@link identityKey}. A missing
+ * key means nothing claims it yet.
+ */
+export async function findEntitiesByIdentity(
+	db: DbClient,
+	input: { organizationId: string; identities: ResolutionIdentity[] },
+): Promise<Map<string, number>> {
+	const owners = new Map<string, number>();
+	if (input.identities.length === 0) return owners;
+
+	// De-dupe before querying: a batch routinely repeats the same identifier.
+	const wanted = new Map<string, ResolutionIdentity>();
+	for (const identity of input.identities) {
+		wanted.set(identityKey(identity), identity);
+	}
+	const namespaces = [...wanted.values()].map((i) => i.namespace);
+	const identifiers = [...wanted.values()].map((i) => i.identifier);
+
+	const rows = await db<{
+		entity_id: number;
+		namespace: string;
+		identifier: string;
+	}>`
+		SELECT ei.entity_id, ei.namespace, ei.identifier
+		FROM entity_identities ei
+		JOIN entities e ON e.id = ei.entity_id
+		WHERE ei.organization_id = ${input.organizationId}
+		  AND ei.deleted_at IS NULL
+		  AND e.deleted_at IS NULL
+		  AND (ei.namespace, ei.identifier) IN (
+		    SELECT ns, ident
+		    FROM unnest(
+		      ${pgTextArray(namespaces)}::text[],
+		      ${pgTextArray(identifiers)}::text[]
+		    ) AS u(ns, ident)
+		  )
+	`;
+	for (const row of rows) {
+		owners.set(
+			identityKey({ namespace: row.namespace, identifier: row.identifier }),
+			Number(row.entity_id),
+		);
+	}
+	return owners;
+}
+
+/**
+ * Attach claims to `entityId`, returning the pairs this INSERT made (or
+ * completed) for it.
+ *
+ * Deliberately one statement and no follow-up read. A claim already held by
+ * this same entity with its provenance already filled does not match the
+ * DO UPDATE predicate and so does not come back — that is the steady state for
+ * a repeat message from a known sender, and it must not cost a second query.
+ * Widening the predicate to force those rows to return would write a new row
+ * version per message, adding WAL and bloat to the hottest ingestion path.
+ *
+ * Callers that need to know about CONTESTED claims (held by a different entity)
+ * derive that from the ownership map they already fetched to resolve the entity
+ * in the first place — see `contestedAgainst`. Nothing here needs to re-read it.
+ *
+ * Errors propagate: a failed identity write must not read as "this entity has
+ * no identities", which is what lets the next writer mint a duplicate.
+ */
+export async function attachEntityIdentities(
+	db: DbClient,
+	input: {
+		organizationId: string;
+		entityId: number;
+		identities: ResolutionIdentity[];
+		sourceConnector: string;
+		connectionId?: number | null;
+	},
+): Promise<ResolutionIdentity[]> {
+	if (input.identities.length === 0) return [];
+	const identities = [
+		...new Map(
+			input.identities.map((identity) => [identityKey(identity), identity]),
+		).values(),
+	].sort((left, right) => identityKey(left).localeCompare(identityKey(right)));
+	const namespaces = identities.map((i) => i.namespace);
+	const identifiers = identities.map((i) => i.identifier);
+
+	const rows = await db<{ namespace: string; identifier: string }>`
+		INSERT INTO entity_identities (
+			organization_id, entity_id, namespace, identifier,
+			source_connector, connection_id
+		)
+		SELECT ${input.organizationId}, ${input.entityId}, v.ns, v.ident,
+		       ${input.sourceConnector}, ${input.connectionId ?? null}
+		FROM unnest(
+			${pgTextArray(namespaces)}::text[],
+			${pgTextArray(identifiers)}::text[]
+		) AS v(ns, ident)
+		ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+		DO UPDATE SET connection_id = EXCLUDED.connection_id
+		WHERE entity_identities.entity_id = EXCLUDED.entity_id
+		  AND entity_identities.connection_id IS NULL
+		  AND EXCLUDED.connection_id IS NOT NULL
+		RETURNING namespace, identifier
+	`;
+	return rows.map((r) => ({
+		namespace: r.namespace,
+		identifier: r.identifier,
+	}));
+}
+
+/**
+ * The requested claims that a DIFFERENT live entity already owns, according to
+ * an ownership map the caller already has. Pure — no query.
+ *
+ * These are left with their owner rather than stolen, but they are a real
+ * "these two may be the same thing" signal, so callers surface them instead of
+ * dropping them.
+ */
+export function contestedAgainst(
+	owners: Map<string, number>,
+	entityId: number,
+	identities: ResolutionIdentity[],
+): ResolutionIdentity[] {
+	return identities.filter((identity) => {
+		const owner = owners.get(identityKey(identity));
+		return owner !== undefined && owner !== entityId;
+	});
+}
+
+/**
+ * Normalize requested claims and resolve them to a single existing owner.
+ *
+ * `decision` is what a create path should do:
+ *  - `create` — nothing claims these; insert a new entity and attach them.
+ *  - `attach` — exactly one live entity owns one or more; use it instead of
+ *    minting a duplicate.
+ *  - `ambiguous` — two or more different entities own different claims in the
+ *    same request. Fusing them is a merge decision with real people on both
+ *    sides, so this path must not guess: surface the candidates instead.
+ */
+export function resolveIdentityOwner(
+	owners: Map<string, number>,
+	identities: ResolutionIdentity[],
+): {
+	decision: "create" | "attach" | "ambiguous";
+	entityId?: number;
+	candidateEntityIds: number[];
+} {
+	const found = new Set<number>();
+	for (const identity of identities) {
+		const owner = owners.get(identityKey(identity));
+		if (owner !== undefined) found.add(owner);
+	}
+	const candidateEntityIds = [...found].sort((l, r) => l - r);
+	if (candidateEntityIds.length === 0) {
+		return { decision: "create", candidateEntityIds };
+	}
+	if (candidateEntityIds.length === 1) {
+		return {
+			decision: "attach",
+			entityId: candidateEntityIds[0],
+			candidateEntityIds,
+		};
+	}
+	return { decision: "ambiguous", candidateEntityIds };
+}

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -22,6 +22,7 @@ import {
 	type ResolutionKeySet,
 } from "../../entity-resolution/policy";
 import { createEntityWithIdentityClaims } from "../../entity-resolution/identity-create";
+import { identityKey } from "../../entity-resolution/identity-lookup";
 import {
 	droppedEvidence,
 	gainedEvidence,
@@ -267,6 +268,22 @@ export function mergeReviewEventMetadata(proposal: EntityMergeProposal) {
 	};
 }
 
+/**
+ * Claim order is the caller's, not part of the ask: `[phone, email]` and
+ * `[email, phone]` are the same proposal. Both the sha256 idempotency digest
+ * and the JSONB `=` reuse predicate compare arrays positionally, so the claims
+ * are sorted once (before the digest, the predicate, and the persisted
+ * `action_input` are derived) instead of stacking a second approval card for an
+ * identical ask.
+ */
+function canonicalIdentityClaims(
+	claims: ResolutionIdentity[],
+): ResolutionIdentity[] {
+	return [...claims].sort((left, right) =>
+		identityKey(left).localeCompare(identityKey(right)),
+	);
+}
+
 function entityChangeIdempotencyKey(
 	organizationId: string,
 	windowId: number | null,
@@ -288,6 +305,8 @@ function entityChangeIdempotencyKey(
 			};
 			break;
 		case "create":
+			// Claims arrive canonically ordered (see canonicalIdentityClaims at the
+			// proposeEntityChange entry), so this positional hash is order-stable.
 			change = {
 				entityData: asCreateProposal(proposal).entity_data,
 				identityClaims: asCreateProposal(proposal).identity_claims ?? [],
@@ -629,10 +648,22 @@ export async function refreshMergeProposalFingerprint(
 
 export async function proposeEntityChange(
 	ctx: ToolContext,
-	proposal: EntityChangeProposal,
+	requested: EntityChangeProposal,
 ): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
 	const sql = getDb();
-	const operation = operationOf(proposal);
+	const operation = operationOf(requested);
+	// The digest, the reuse predicate, and action_input all derive from
+	// `proposal`, so canonicalizing the claim order once here keeps all three
+	// order-independent and in agreement with what is stored.
+	const proposal: EntityChangeProposal =
+		operation === "create" && asCreateProposal(requested).identity_claims
+			? {
+					...asCreateProposal(requested),
+					identity_claims: canonicalIdentityClaims(
+						asCreateProposal(requested).identity_claims ?? [],
+					),
+				}
+			: requested;
 	// window_id groups a run's proposals into one batch card. It rides the column,
 	// not action_input, and is part of the canonical idempotency key below.
 	const { window_id: windowId, ...proposalWithoutWindow } = proposal;

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -18,8 +18,10 @@ import {
 	type EntityResolutionAssessment,
 	RESOLUTION_FINGERPRINT_VERSION,
 	type ResolutionEvidence,
+	type ResolutionIdentity,
 	type ResolutionKeySet,
 } from "../../entity-resolution/policy";
+import { createEntityWithIdentityClaims } from "../../entity-resolution/identity-create";
 import {
 	droppedEvidence,
 	gainedEvidence,
@@ -116,6 +118,8 @@ export interface EntityDeleteProposal {
 export interface EntityCreateProposal {
 	operation: "create";
 	entity_data: EntityData;
+	identity_claims?: ResolutionIdentity[];
+	identity_source_connector?: string;
 	proposal: Record<string, unknown>;
 	watcher_id?: number | null;
 	/** See EntityFieldChangeProposal.window_id — batches proposals by run window. */
@@ -284,7 +288,10 @@ function entityChangeIdempotencyKey(
 			};
 			break;
 		case "create":
-			change = { entityData: asCreateProposal(proposal).entity_data };
+			change = {
+				entityData: asCreateProposal(proposal).entity_data,
+				identityClaims: asCreateProposal(proposal).identity_claims ?? [],
+			};
 			break;
 		case "merge": {
 			const merge = asMergeProposal(proposal);
@@ -706,7 +713,10 @@ export async function proposeEntityChange(
           )
           AND (
             ${operation !== "create"}
-            OR r.action_input->'entity_data' = ${sql.json(createProposal?.entity_data ?? {})}::jsonb
+            OR (
+              r.action_input->'entity_data' = ${sql.json(createProposal?.entity_data ?? {})}::jsonb
+              AND COALESCE(r.action_input->'identity_claims', '[]'::jsonb) = ${sql.json(createProposal?.identity_claims ?? [])}::jsonb
+            )
           )
           AND (
             ${operation !== "merge"}
@@ -1231,25 +1241,40 @@ export async function applyEntityChangeProposal(
 	}
 	if (operation === "create") {
 		const createProposal = asCreateProposal(proposal);
-		return createEntity(
-			{
-				...createProposal.entity_data,
-				organization_id: ctx.organizationId,
-				// The watcher that PROPOSED the create is not a real user row, so
-				// entities.created_by (NOT NULL, FK → user) must attribute the create to
-				// the human who APPROVED it. Approval is human-gated (requireHuman-
-				// ApprovalContext), so ctx.userId is a verified user here — using it
-				// avoids the "system" fallback that fails the FK.
-				created_by: ctx.userId ?? createProposal.entity_data.created_by,
-			},
-			{
+		const data = {
+			...createProposal.entity_data,
+			organization_id: ctx.organizationId,
+			// The watcher that PROPOSED the create is not a real user row, so
+			// entities.created_by (NOT NULL, FK → user) must attribute the create to
+			// the human who APPROVED it. Approval is human-gated (requireHuman-
+			// ApprovalContext), so ctx.userId is a verified user here — using it
+			// avoids the "system" fallback that fails the FK.
+			created_by: ctx.userId ?? createProposal.entity_data.created_by,
+		};
+		if (!createProposal.identity_claims?.length) {
+			return createEntity(data, {
 				hookContext: {
 					organizationId: ctx.organizationId,
 					userId: ctx.userId,
 					env,
 				},
-			},
-		);
+			});
+		}
+		const result = await createEntityWithIdentityClaims({
+			data,
+			identities: createProposal.identity_claims,
+			env,
+			ctx,
+			sourceConnector:
+				createProposal.identity_source_connector ?? "tool:manage_entity",
+			// Unlike the agent-facing tool path, this runs only under
+			// requireHumanApprovalContext — a verified human who reviewed the
+			// proposal card. manage_operations refuses agents outright, so the
+			// create-but-cannot-read oracle that gate exists to close cannot
+			// arise here.
+			canResolveExisting: async () => true,
+		});
+		return result.entity;
 	}
 	if (operation === "merge") {
 		const mergeProposal = asMergeProposal(proposal);

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -38,7 +38,9 @@ import {
 	resolveActingPrincipal,
 } from "../../authz/entity-policy";
 import { discoverWorkspaceResolutionGroups } from "../../entity-resolution/discovery";
+import { createEntityWithIdentityClaims } from "../../entity-resolution/identity-create";
 import { loadLiveEntityIdentities } from "../../entity-resolution/identities";
+import { normalizeRequestedIdentities } from "../../entity-resolution/identity-lookup";
 import {
 	assessEntityResolution,
 	RESOLUTION_FINGERPRINT_VERSION,
@@ -48,7 +50,7 @@ import { getDb, pgBigintArray, pgTextArray } from "../../db/client";
 import type { Env } from "../../index";
 import {
 	batchLoadRelationships,
-	createEntity,
+	type CreatedEntity,
 	deleteEntity,
 	type EntityData,
 	getEntity,
@@ -309,11 +311,15 @@ async function handleCreate(
 		entityData.content = args.content;
 	}
 
+	const requestedIdentities = normalizeRequestedIdentities(args.identities);
 	const proposal = {
 		entity_type: entityData.entity_type,
 		name: entityData.name,
 		parent_id: entityData.parent_id ?? null,
 		metadata: entityData.metadata ?? {},
+		...(requestedIdentities.length > 0
+			? { identities: requestedIdentities }
+			: {}),
 	};
 	const actor = await actingPrincipalFor(args, ctx);
 	const attribution = attributionFor(actor);
@@ -334,6 +340,8 @@ async function handleCreate(
 		ownerResolved: actor.ownerResolved,
 		entityTypeSlug: args.entity_type,
 		entityData,
+		identityClaims: requestedIdentities,
+		identitySourceConnector: identityWriterTag(ctx),
 		proposal,
 	});
 	if (createDecision.outcome === "deny") {
@@ -356,19 +364,61 @@ async function handleCreate(
 		} as unknown as ManageEntityResult;
 	}
 
-	const entity = await createEntity(entityData, {
-		hookContext: {
-			organizationId: ctx.organizationId,
-			userId: ctx.userId,
-			env,
-		},
+	const created = await createEntityWithIdentityClaims({
+		data: entityData,
+		identities: requestedIdentities,
+		env,
+		ctx,
+		sourceConnector: identityWriterTag(ctx),
+		canResolveExisting: (entityTypeSlug) =>
+			callerMayReadEntityType(entityTypeSlug, ctx),
 	});
+	return buildCreateResult(
+		created.entity,
+		env,
+		ctx,
+		created.attachedToExisting,
+	);
+}
 
+/**
+ * Whether `ctx` may read entities of this type — the type-level half of the
+ * gates `handleGet` applies. Used to decide whether an identity claim may
+ * resolve to an existing entity. A policy denial returns false; anything else
+ * (a DB or pool error) propagates, because treating an infrastructure failure
+ * as "denied" would silently downgrade to creating duplicates.
+ */
+async function callerMayReadEntityType(
+	entityTypeSlug: string,
+	ctx: ToolContext,
+): Promise<boolean> {
+	try {
+		await assertEntityReadAllowed(undefined, ctx, entityTypeSlug);
+	} catch (error) {
+		if (error instanceof ToolUserError) return false;
+		throw error;
+	}
+	return entityTypeSlug !== MEMBER_ENTITY_TYPE_SLUG || canSeeMemberList(ctx);
+}
+
+/** Provenance for a claim written through the tool rather than a connector. */
+function identityWriterTag(ctx: ToolContext): string {
+	return ctx.agentId ? `agent:${ctx.agentId}` : "tool:manage_entity";
+}
+
+async function buildCreateResult(
+	entity: CreatedEntity,
+	env: Env,
+	ctx: ToolContext,
+	attachedToExisting: boolean,
+): Promise<ManageEntityResult> {
 	const entityTypeLabel = capitalize(entity.entity_type);
 
 	// Build next steps
 	const nextSteps: string[] = [
-		`${entityTypeLabel} "${entity.name}" created successfully with ID ${entity.id}.`,
+		attachedToExisting
+			? `${entityTypeLabel} "${entity.name}" (ID ${entity.id}) already existed under one of these identifiers, so it was used instead of creating a second one.`
+			: `${entityTypeLabel} "${entity.name}" created successfully with ID ${entity.id}.`,
 	];
 
 	if (!entity.parent_id) {
@@ -391,6 +441,7 @@ async function handleCreate(
 
 	return {
 		action: "create",
+		attached_to_existing: attachedToExisting,
 		entity: {
 			id: entityDetails.id,
 			entity_type: entityDetails.entity_type,

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -27,6 +27,12 @@ import {
 import { normalizeIdentifier } from '@lobu/connector-sdk/identity-normalize';
 import { ensureResourceEntityType } from '../authz/acl-resource-type';
 import { type DbClient, getDb, pgTextArray } from '../db/client';
+import {
+  attachEntityIdentities,
+  contestedAgainst,
+  findEntitiesByIdentity,
+  identityKey,
+} from '../entity-resolution/identity-lookup';
 import { normalizeConnectorIdentityValue } from '../identity/connector-identity-modules';
 import logger from './logger';
 import { getValueAtPath } from './object-path';
@@ -336,35 +342,29 @@ async function lookupMatches(
     identities: ExtractedLink['identities'][];
   }
 ): Promise<Map<string, number>> {
-  const keys = new Set<string>();
+  const wanted = new Map<string, { namespace: string; identifier: string }>();
   for (const arr of params.identities) {
-    for (const id of arr) keys.add(`${id.namespace}\u0000${id.identifier}`);
+    for (const id of arr) {
+      wanted.set(`${id.namespace}\u0000${id.identifier}`, {
+        namespace: id.namespace,
+        identifier: id.identifier,
+      });
+    }
   }
-  if (keys.size === 0) return new Map();
+  if (wanted.size === 0) return new Map();
 
-  const namespaces: string[] = [];
-  const identifiers: string[] = [];
-  for (const key of keys) {
-    const [ns, ident] = key.split('\u0000');
-    namespaces.push(ns);
-    identifiers.push(ident);
-  }
+  // One lookup shared with the tool create path, so the two cannot drift on
+  // which claims count as owned (see entity-resolution/identity-lookup).
+  const owners = await findEntitiesByIdentity(sql, {
+    organizationId: params.orgId,
+    identities: [...wanted.values()],
+  });
 
-  const rows = await sql<{ entity_id: number | string; namespace: string; identifier: string }>`
-    SELECT ei.entity_id, ei.namespace, ei.identifier
-    FROM entity_identities ei
-    JOIN entities e ON e.id = ei.entity_id
-    WHERE ei.organization_id = ${params.orgId}
-      AND ei.deleted_at IS NULL
-      AND e.deleted_at IS NULL
-      AND (ei.namespace, ei.identifier) IN (
-        SELECT ns, ident FROM unnest(${pgTextArray(namespaces)}::text[], ${pgTextArray(identifiers)}::text[]) AS u(ns, ident)
-      )
-  `;
-
+  // Re-key to this module's own convention, which its callers index by.
   const out = new Map<string, number>();
-  for (const row of rows) {
-    out.set(`${row.namespace}\u0000${row.identifier}`, Number(row.entity_id));
+  for (const [key, identity] of wanted) {
+    const owner = owners.get(identityKey(identity));
+    if (owner !== undefined) out.set(key, owner);
   }
   return out;
 }
@@ -470,13 +470,38 @@ async function createEntityWithIdentities(
   }
   if (entityId === null) return null;
 
-  const attached = await insertIdentities(sql, {
-    orgId: params.orgId,
-    entityId,
-    connectorKey: params.connectorKey,
-    connectionId: params.connectionId,
-    identities: persisted,
-  });
+  let attached: Array<{ namespace: string; identifier: string }>;
+  try {
+    attached = await insertIdentities(sql, {
+      orgId: params.orgId,
+      entityId,
+      connectorKey: params.connectorKey,
+      connectionId: params.connectionId,
+      identities: persisted,
+    });
+  } catch (err) {
+    // The entity was created only to own these claims and nothing references it
+    // yet, so a hard delete is right: leaving it would strand a person with no
+    // identities, and the next message would create another. A transaction is
+    // not an option here — the slug-retry loop above depends on surviving a
+    // failed INSERT, which an aborted transaction would not allow.
+    //
+    // Best-effort: if the identity write failed AFTER writing some rows, the FK
+    // holds this delete back. The original error still propagates, so ingestion
+    // fails closed either way.
+    try {
+      await sql`
+        DELETE FROM entities
+        WHERE id = ${entityId} AND organization_id = ${params.orgId}
+      `;
+    } catch (cleanupErr) {
+      logger.error(
+        { cleanupErr, entityId, orgId: params.orgId },
+        'entity cleanup failed after identity write error'
+      );
+    }
+    throw err;
+  }
   // Seed metadata.aliases from the identifiers that actually attached, so the
   // metric compiler (which resolves event fields against metadata->'aliases')
   // can attribute this contact's events from the moment it's created.
@@ -505,28 +530,18 @@ async function insertIdentities(
   }
 ): Promise<Array<{ namespace: string; identifier: string }>> {
   if (params.identities.length === 0) return [];
-  const namespaces = params.identities.map((i) => i.namespace);
-  const identifiers = params.identities.map((i) => i.identifier);
-  try {
-    const attached = await sql<{ namespace: string; identifier: string }>`
-      INSERT INTO entity_identities (
-        organization_id, entity_id, namespace, identifier, source_connector, connection_id
-      )
-      SELECT ${params.orgId}, ${params.entityId}, v.ns, v.ident,
-             ${`connector:${params.connectorKey}`}, ${params.connectionId ?? null}
-      FROM unnest(${pgTextArray(namespaces)}::text[], ${pgTextArray(identifiers)}::text[]) AS v(ns, ident)
-      ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
-      DO UPDATE SET connection_id = EXCLUDED.connection_id
-      WHERE entity_identities.entity_id = EXCLUDED.entity_id
-        AND entity_identities.connection_id IS NULL
-        AND EXCLUDED.connection_id IS NOT NULL
-      RETURNING namespace, identifier
-    `;
-    return attached.map((r) => ({ namespace: r.namespace, identifier: r.identifier }));
-  } catch (err) {
-    logger.warn({ err, entityId: params.entityId }, 'entity_identities insert failed');
-    return [];
-  }
+  // Errors propagate: a failed identity write must not read as "no identities",
+  // which is what lets the next writer mint a duplicate.
+  return attachEntityIdentities(sql, {
+    organizationId: params.orgId,
+    entityId: params.entityId,
+    identities: params.identities.map((i) => ({
+      namespace: i.namespace,
+      identifier: i.identifier,
+    })),
+    sourceConnector: `connector:${params.connectorKey}`,
+    connectionId: params.connectionId,
+  });
 }
 
 async function applyTraits(
@@ -798,6 +813,30 @@ async function resolveLinksByKind(
           identities: link.identities.filter((i) => !i.matchOnly),
         });
         attached = [...fresh];
+        // A claim held by a DIFFERENT entity stays with its owner — but it is a
+        // real "these two may be the same" signal, and it used to vanish
+        // silently. Derived from `matches`, already fetched above: no query.
+        // Namespaces only; an identifier here is someone's phone or email.
+        const contested = contestedAgainst(
+          matches,
+          entityId,
+          link.identities.map((i) => ({
+            namespace: i.namespace,
+            identifier: i.identifier,
+          }))
+        );
+        if (contested.length > 0) {
+          logger.warn(
+            {
+              orgId: params.orgId,
+              entityId,
+              connectorKey: params.connectorKey,
+              namespaces: [...new Set(contested.map((i) => i.namespace))],
+              contestedCount: contested.length,
+            },
+            'entityLink: identifier already claimed by another entity — left with its owner'
+          );
+        }
         // Mirror this link's non-matchOnly identifiers into metadata.aliases for
         // metric resolution. Passing the full set (not just `fresh`) repairs a
         // legacy entity whose identities predate aliases-on-create; ensureAliases'

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -29,7 +29,6 @@ import { ensureResourceEntityType } from '../authz/acl-resource-type';
 import { type DbClient, getDb, pgTextArray } from '../db/client';
 import {
   attachEntityIdentities,
-  contestedAgainst,
   findEntitiesByIdentity,
   identityKey,
 } from '../entity-resolution/identity-lookup';
@@ -817,14 +816,13 @@ async function resolveLinksByKind(
         // real "these two may be the same" signal, and it used to vanish
         // silently. Derived from `matches`, already fetched above: no query.
         // Namespaces only; an identifier here is someone's phone or email.
-        const contested = contestedAgainst(
-          matches,
-          entityId,
-          link.identities.map((i) => ({
-            namespace: i.namespace,
-            identifier: i.identifier,
-          }))
-        );
+        // `matches` is keyed by this module's `namespace\u0000identifier`
+        // convention, not `identityKey`, so this reuses `hitFor` rather than the
+        // shared `contestedAgainst` helper, whose lookups would never hit.
+        const contested = link.identities.filter((id) => {
+          const owner = hitFor(id);
+          return owner !== undefined && owner !== entityId;
+        });
         if (contested.length > 0) {
           logger.warn(
             {


### PR DESCRIPTION
## What

`manage_entity(action='create')` now accepts identity claims and resolves them **before** inserting, so it attaches to an entity that already claims the identifier instead of minting a duplicate.

The connector path (`entity-link-upsert`) has always looked up owners first — that is what "upsert" means there. The tool path, used by `run_sdk` and agents, did `INSERT INTO entities` unconditionally with a slug derived from the name. That asymmetry is how an address-book import created a second person for contacts a connector already knew, producing merge approvals a human then had to clear.

## Why not a schema change

Considered and rejected: adding a canonical-value column, an `assurance` column, or moving the uniqueness index. None would have prevented those duplicates — `DEFAULT_PERSON_RESOLUTION_RULES` sets `onMatch: "review"` for both email and phone, so the policy deliberately declines to auto-merge on contact identifiers. The gap was never uniqueness enforcement; it was that one write path never looked. `onMatch` in `x-lobu-resolution` remains the knob if auto-merge is ever wanted — configuration, not a migration.

## Behaviour

- One existing owner → that entity is used, `attached_to_existing: true`.
- No owner → normal create, then claims attached.
- Two *different* existing entities claiming different identifiers in one call → refused with 409 naming the candidates. Picking either would silently fuse two real records.
- A value its namespace cannot normalize is ignored rather than stored as a claim.
- Generic namespaces that are not unique per org (`email_domain`) are rejected as claims. This makes the previously **declared-but-inert** `uniquePerOrg` field load-bearing for the first time.

## Hot path

`attachEntityIdentities` is deliberately one statement with no follow-up read. A first draft classified each claim as mine-vs-contested with a second `SELECT`, which would have fired on the most common ingestion case (repeat message from a known sender, where the row exists with provenance filled and so does not match the `DO UPDATE` predicate). Widening that predicate to force rows to return was also rejected — it writes a new row version per message. Contested claims are instead derived from the ownership map `lookupMatches` already fetched, via a pure function. **Query count on ingestion is unchanged.**

## Fail-closed

`insertIdentities` previously swallowed every error into `return []`, so a DB failure read as "this entity has no identities" — the exact state that lets the next writer mint a duplicate. Errors now propagate. `createEntityWithIdentities` compensates by deleting the entity it had just created for those claims; a transaction is not available there because the slug-retry loop depends on surviving a failed INSERT.

A contested claim is now logged (namespaces only — an identifier here is someone's phone or email) instead of vanishing.

## Red → green

Mutation-verified, four planted defects each caught:

```
disable the attach branch          → 1 failed  "expected false to be true"
bypass normalization               → 3 failed  incl. unparseable-value test
drop identity_claims from deferral → 1 failed  "expected undefined to deeply equal [ { namespace: 'email', … } ]"
```

Full affected-suite run, sequential:

```
✓ entity-merge-tool.test.ts            (29 tests)
✓ entity-link-upsert.test.ts           (16 tests)
✓ discovery.test.ts                    (20 tests)
✓ manage-entity-identities.test.ts      (8 tests)
✓ entity-history-contract.test.ts       (4 tests)
✓ entity-crud.test.ts                   (8 tests)
✓ evidence-strength.test.ts            (13 tests)
✓ identity-lookup.test.ts              (13 tests)
✓ member-privacy-contract.test.ts       (2 tests)
Test Files  9 passed (9)
     Tests  113 passed (113)
```

The integration suite reproduces the production shape directly: create with `905322356586`, then create with `+90 (532) 235 65 86`, assert one person and `attached_to_existing: true`. A companion test pins that `05324764881` does **not** match `905324764881`, so the no-country-code-guessing rule cannot be quietly regressed.

## Notes for review

- `make review-fix` caught a real gap I missed: a deferred agent create dropped the claims entirely, so an approved create would have minted the duplicate this PR exists to prevent. Claims now survive in `runs.action_input` as `identity_claims` / `identity_source_connector`.
- Its own new deferral test was asserting against a path it never exercised (`approval_queued` undefined — nothing seeded a policy holding creates). Fixed by seeding `write_approval_policies` with `create → approval`.
- No migration, no index change, no backfill.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity creation now accepts identity claims such as normalized phone numbers and other supported identifiers.
  * Matching identities can attach a request to an existing entity instead of creating a duplicate.
  * Create results indicate when an existing entity was reused.
  * Identity claims are preserved when creation requires approval.
* **Bug Fixes**
  * Improved handling of concurrent creations and conflicting identities.
  * Prevented unauthorized identity lookups and duplicate entity creation.
  * Improved normalization and validation of identity values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->