### PR TITLE
fix(server): stop a Behavior's instruction text from authoring its sources

### DIFF
--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -336,7 +336,7 @@ export const ManageBehaviorsSchema = Type.Object(
     sources: Type.Optional(
       Type.Array(SourceSchema, {
         description:
-          "[create/create_version] Array of SQL data sources. Each source is { name, query }. Sources are version-owned — to change them on an existing Behavior, publish a new version with action: 'create_version'. On create_version this is a FULL REPLACEMENT: the array you pass (even []) becomes the version's complete source set. Passing [] clears all sources; OMITTING sources inherits the prior version's — including when you edit the prompt as plain text, so rewording a prompt never drops its sources. Sources derive from the prompt's @-mention chips only when the new prompt contains such chips (or the previous prompt did, so removing the last chip clears its derived source). The response returns source_count and removed_sources so you can see what a replacement dropped.",
+          "[create/create_version] Array of SQL data sources. Each source is { name, query }. To change them on an existing Behavior, publish a new version with action: 'create_version'. On create_version this array is the ONLY way to change them and is a FULL REPLACEMENT: passing it (even []) makes it the complete source set, [] clears everything, and OMITTING it keeps the stored sources unchanged. Instruction text is never an input — a Behavior's prompt is usually compiled skill bodies, so @-mention chips inside it neither add nor remove sources. (On create only, chips in the prompt still seed the initial list, which is how the web composer authors them.) The response returns source_count and removed_sources so you can see what a replacement dropped.",
       })
     ),
     keying_config: Type.Optional(

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-source-honesty.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-source-honesty.test.ts
@@ -1,0 +1,234 @@
+/**
+ * A Behavior's sources are Behavior-authored; its instruction text is not an
+ * input to them. Issue #2320 must-fix 2.
+ *
+ * Since #2331 the `prompt` column holds the compiled join of the skill bodies
+ * a Behavior named, so re-deriving `sources[]` from its `@`-chips let a
+ * skill's prose author the list — and because derivation REPLACED, a compiled
+ * prompt with no chips erased every stored source, the default `content` one
+ * included. `lobu apply` resends `prompt` on every bump, so that needed no
+ * user intent at all.
+ *
+ * `get_version_details` told the mirror-image lie: `version_sources` is NULL
+ * on every row `create_version` writes (sources are per-assignment), so it
+ * reported `sources: []` for a Behavior that plainly had them — and it looked
+ * versions up on the passed id while `get_versions` resolves the group root,
+ * so an assignment could list a version it then could not fetch.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import type { AuthContext } from "../../../tools/execute";
+import { executeTool } from "../../../tools/execute";
+import { DEFAULT_BEHAVIOR_SOURCE_QUERY } from "../../../watchers/source-refs";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestEntity,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const TEST_ENV: Env = {
+	ENVIRONMENT: "test",
+	DATABASE_URL: process.env.DATABASE_URL,
+	JWT_SECRET: "test-jwt-secret-for-testing-only",
+	BETTER_AUTH_SECRET: "test-auth-secret-for-testing-only",
+	MAX_CONSECUTIVE_FAILURES: "3",
+	RATE_LIMIT_ENABLED: "false",
+};
+
+/** Compiled skill prose that happens to match the composer's chip codec. */
+const SKILL_BODY_WITH_CHIP = [
+	"# Daily digest",
+	"",
+	"Summarise overnight activity. Pull the numbers from",
+	"@[sql:skill_pull:Skill Pull](#sql=SELECT%20id%20FROM%20events) before writing.",
+].join("\n");
+
+const RECENT_QUERY = "SELECT id FROM events ORDER BY occurred_at DESC";
+
+type Sources = Array<{ name: string; query: string }>;
+
+describe("manage_behaviors — create_version source ownership", () => {
+	let orgId: string;
+	let ownerCtx: AuthContext;
+	let agentId: string;
+
+	const baseCtx = (orgIdValue: string, userId: string): AuthContext => ({
+		organizationId: orgIdValue,
+		tokenOrganizationId: orgIdValue,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		requestedAgentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		requestUrl: `http://localhost/api/${orgIdValue}`,
+		baseUrl: "",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	});
+
+	async function createBehavior(slug: string): Promise<string> {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug,
+				name: "Digest",
+				prompt: "Write the digest.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+		return created.behavior_id!;
+	}
+
+	async function storedSources(behaviorId: string): Promise<Sources> {
+		const sql = getTestDb();
+		const rows = await sql`SELECT sources FROM watchers WHERE id = ${behaviorId}`;
+		return (rows[0] as { sources: Sources | null }).sources ?? [];
+	}
+
+	async function createVersion(
+		behaviorId: string,
+		args: Record<string, unknown>
+	): Promise<void> {
+		await executeTool(
+			"manage_behaviors",
+			{ action: "create_version", behavior_id: behaviorId, ...args },
+			TEST_ENV,
+			ownerCtx
+		);
+	}
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+
+		const org = await createTestOrganization({ name: "behavior source honesty" });
+		orgId = org.id;
+		const owner = await createTestUser({ email: "bsh-owner@test.com" });
+		await addUserToOrganization(owner.id, org.id, "owner");
+		ownerCtx = baseCtx(org.id, owner.id);
+
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "bsh-agent",
+			ownerUserId: owner.id,
+		});
+		agentId = agent.agentId;
+	});
+
+	it("keeps sources independent from instruction text", async () => {
+		const behaviorId = await createBehavior("bsh-digest");
+		expect(await storedSources(behaviorId)).toEqual([
+			{ name: "content", query: DEFAULT_BEHAVIOR_SOURCE_QUERY },
+		]);
+
+		await createVersion(behaviorId, { prompt: SKILL_BODY_WITH_CHIP });
+		expect(await storedSources(behaviorId)).toEqual([
+			{ name: "content", query: DEFAULT_BEHAVIOR_SOURCE_QUERY },
+		]);
+
+		await createVersion(behaviorId, { prompt: "Write the digest, briefly." });
+		expect(await storedSources(behaviorId)).toEqual([
+			{ name: "content", query: DEFAULT_BEHAVIOR_SOURCE_QUERY },
+		]);
+
+		await createVersion(behaviorId, {
+			prompt: SKILL_BODY_WITH_CHIP,
+			sources: [{ name: "recent", query: RECENT_QUERY }],
+		});
+		expect(await storedSources(behaviorId)).toEqual([
+			{ name: "recent", query: RECENT_QUERY },
+		]);
+
+		await createVersion(behaviorId, { sources: [] });
+		expect(await storedSources(behaviorId)).toEqual([]);
+
+		await createVersion(behaviorId, {
+			sources: [{ name: "recent", query: RECENT_QUERY }],
+		});
+		expect(await storedSources(behaviorId)).toEqual([
+			{ name: "recent", query: RECENT_QUERY },
+		]);
+
+		const details = (await executeTool(
+			"manage_behaviors",
+			{ action: "get_version_details", behavior_id: behaviorId },
+			TEST_ENV,
+			ownerCtx
+		)) as { version: number; sources: Sources };
+
+		expect(details.version).toBeGreaterThan(1);
+		expect(details.sources).toEqual([
+			{ name: "recent", query: RECENT_QUERY },
+		]);
+
+		const listed = (await executeTool(
+			"manage_behaviors",
+			{ action: "get_versions", behavior_id: behaviorId },
+			TEST_ENV,
+			ownerCtx
+		)) as { versions: Array<{ version: number }> };
+
+		for (const { version } of listed.versions) {
+			const details = (await executeTool(
+				"manage_behaviors",
+				{ action: "get_version_details", behavior_id: behaviorId, version },
+				TEST_ENV,
+				ownerCtx
+			)) as { version: number };
+			expect(details.version).toBe(version);
+		}
+	});
+
+	it("gets group-root versions through an assignment id", async () => {
+		const behaviorId = await createBehavior("bsh-assignment");
+		await createVersion(behaviorId, { prompt: "Write the digest, briefly." });
+		const sql = getTestDb();
+		const entity = await createTestEntity({
+			name: "Source Honesty Co",
+			organization_id: orgId,
+		});
+		const [root] = await sql<{ current_version_id: number }>`
+			SELECT current_version_id FROM watchers WHERE id = ${behaviorId}
+		`;
+		const assigned = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_from_version",
+				version_id: String(root.current_version_id),
+				entity_ids: [entity.id],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { created: Array<{ behavior_id: string }> };
+		const assignmentId = assigned.created[0].behavior_id;
+		expect(assignmentId).not.toBe(behaviorId);
+
+		const listed = (await executeTool(
+			"manage_behaviors",
+			{ action: "get_versions", behavior_id: assignmentId },
+			TEST_ENV,
+			ownerCtx
+		)) as { versions: Array<{ version: number }> };
+		expect(listed.versions.length).toBeGreaterThan(0);
+
+		for (const { version } of listed.versions) {
+			const details = (await executeTool(
+				"manage_behaviors",
+				{ action: "get_version_details", behavior_id: assignmentId, version },
+				TEST_ENV,
+				ownerCtx
+			)) as { version: number };
+			expect(details.version).toBe(version);
+		}
+	});
+});

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-update-version-fields.test.ts
@@ -463,7 +463,20 @@ describe("manage_behaviors create_version — source replacement semantics (#204
 		expect(await fetchSources()).toEqual([]);
 	});
 
-	it("removes the derived source when the last source token is removed", async () => {
+	it("a chip in the prompt does not author sources — only `sources` does", async () => {
+		// `prompt` is compiled skill text since #2331 (issue #2320 must-fix 2).
+		// The block above left this Behavior sourceless; give it one back.
+		await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: behaviorId,
+				sources: [{ name: "alpha", query: "SELECT id FROM events" }],
+			},
+			TEST_ENV,
+			ownerCtx,
+		);
+
 		const chip = `@[sql:s1:Recent](#sql=${encodeURIComponent("SELECT id FROM events WHERE 1=0")})`;
 		await executeTool(
 			"manage_behaviors",
@@ -475,20 +488,22 @@ describe("manage_behaviors create_version — source replacement semantics (#204
 			TEST_ENV,
 			ownerCtx,
 		);
-		expect((await fetchSources()).map((s) => s.name)).toEqual(["recent"]);
+		expect((await fetchSources()).map((s) => s.name)).toEqual(["alpha"]);
 
-		const chipRemoved = (await executeTool(
+		// Clearing is an explicit act, not a side effect of editing text.
+		const cleared = (await executeTool(
 			"manage_behaviors",
 			{
 				action: "create_version",
 				behavior_id: behaviorId,
 				prompt: "Look at nothing in particular.",
+				sources: [],
 			},
 			TEST_ENV,
 			ownerCtx,
 		)) as { source_count?: number; removed_sources?: string[] };
-		expect(chipRemoved.source_count).toBe(0);
-		expect(chipRemoved.removed_sources).toEqual(["recent"]);
+		expect(cleared.source_count).toBe(0);
+		expect(cleared.removed_sources).toEqual(["alpha"]);
 		expect(await fetchSources()).toEqual([]);
 	});
 });

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -618,11 +618,9 @@ describe('watcher CRUD', () => {
     await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
-  it('re-derives sources on a version bump — an edited SQL chip replaces (not strands) the old query', async () => {
-    // Regression: create_version used to UNION prompt-derived sources with the
-    // stored ones, so editing a SQL chip left the OLD query running under the
-    // original name and added the new one under a suffixed name. The prompt must
-    // be the single source of truth: the new prompt's tokens are authoritative.
+  it('a version bump does not re-derive sources from the prompt — the caller sends them', async () => {
+    // The prompt is compiled skill text since #2331, so its `@`-tokens are the
+    // skill's prose, not an authoring surface. Changing a source is explicit.
     const enc = (q: string) =>
       `#sql=${encodeURIComponent(q).replace(
         /[()'!*~]/g,
@@ -639,56 +637,72 @@ describe('watcher CRUD', () => {
       agent_id: agentId,
     })) as { behavior_id: string };
 
-    // Edit the SQL chip: same label/name, new query — a new prompt version.
+    const readSources = async () => {
+      const got = (await owner.behaviors.get({
+        behavior_id: created.behavior_id,
+      })) as {
+        behavior?: { sources?: Array<{ name: string; query: string }> | null };
+      };
+      return got.behavior?.sources ?? [];
+    };
+
+    // A new prompt naming a different query leaves the stored source alone.
     await owner.behaviors.createVersion({
       behavior_id: created.behavior_id,
       prompt: `Watch @[sql:recent:Recent](${enc(newQuery)}).`,
       change_notes: 'edit sql',
     });
+    expect(await readSources()).toEqual([{ name: 'recent', query: oldQuery }]);
 
-    const got = (await owner.behaviors.get({
+    // Sending `sources` replaces wholesale — no stranded old query, no
+    // suffixed `recent_2`.
+    await owner.behaviors.createVersion({
       behavior_id: created.behavior_id,
-    })) as {
-      behavior?: { sources?: Array<{ name: string; query: string }> | null };
-    };
-    // Exactly one source, carrying the NEW query — the old one is gone, not
-    // stranded under `recent`, and there is no `recent_2`.
-    expect(got.behavior?.sources).toEqual([{ name: 'recent', query: newQuery }]);
+      sources: [{ name: 'recent', query: newQuery }],
+      change_notes: 'repoint source',
+    });
+    expect(await readSources()).toEqual([{ name: 'recent', query: newQuery }]);
 
     await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
-  it('clears sources when an edited prompt removes every @-mention chip', async () => {
-    // Regression: an edited prompt (args.prompt provided) with NO source tokens
-    // must yield an empty sources[] — removing all chips clears sources. It must
-    // NOT fall back to the stored sources (that fallback is only for a bump that
-    // did not touch the prompt, e.g. a schedule-only change).
+  it('removing every @-mention chip does not clear sources — `sources: []` does', async () => {
     const enc = (q: string) =>
       `#sql=${encodeURIComponent(q).replace(
         /[()'!*~]/g,
         (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
       )}`;
+    const query = 'SELECT id FROM events';
     const created = (await owner.behaviors.create({
       entity_id: entityId,
       slug: 'clear-sources-on-edit-watcher',
       name: 'Clear Sources On Edit Watcher',
-      prompt: `Watch @[sql:recent:Recent](${enc('SELECT id FROM events')}).`,
+      prompt: `Watch @[sql:recent:Recent](${enc(query)}).`,
       agent_id: agentId,
     })) as { behavior_id: string };
 
-    // New prompt with the chip removed → sources must become empty.
+    const readSources = async () => {
+      const got = (await owner.behaviors.get({
+        behavior_id: created.behavior_id,
+      })) as {
+        behavior?: { sources?: Array<{ name: string; query: string }> | null };
+      };
+      return got.behavior?.sources ?? [];
+    };
+
     await owner.behaviors.createVersion({
       behavior_id: created.behavior_id,
       prompt: 'Just watch everything, no specific source.',
       change_notes: 'remove chip',
     });
+    expect(await readSources()).toEqual([{ name: 'recent', query }]);
 
-    const got = (await owner.behaviors.get({
+    await owner.behaviors.createVersion({
       behavior_id: created.behavior_id,
-    })) as {
-      behavior?: { sources?: Array<{ name: string; query: string }> | null };
-    };
-    expect(got.behavior?.sources ?? []).toEqual([]);
+      sources: [],
+      change_notes: 'clear sources',
+    });
+    expect(await readSources()).toEqual([]);
 
     await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -122,6 +122,9 @@ export async function handleCreate(
   //      — the backend derives them so the UI sends only the raw prompt.
   //   2. explicit `args.sources` (API callers / legacy).
   // If neither yields anything, fall back to a default all-events source.
+  // `create_version` deliberately does NOT derive (see version-actions.ts):
+  // on a bump the prompt is compiled skill text, and a skill's prose must not
+  // author the Behavior's sources.
   const promptSources = extractSourcesFromPromptTokens(args.prompt ?? '');
   const explicitSources = args.sources ?? [];
   const merged = mergePromptSources(explicitSources, promptSources);

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -8,7 +8,6 @@ import { recordToolConfigChange } from '../helpers/config-audit';
 import { nextRunAt } from '../../../utils/cron';
 import { resolveUsernames } from '../../../utils/resolve-usernames';
 import { getNextNumericId } from '../helpers/db-helpers';
-import { extractSourcesFromPromptTokens, mergePromptSources } from '../../../watchers/source-refs';
 import type { ToolContext } from '../../registry';
 import type { ManageBehaviorsArgs, ManageBehaviorsResult } from '../manage_behaviors';
 import {
@@ -94,35 +93,22 @@ export async function handleCreateVersion(
   // distinguishing "the caller omitted sources" (inherit) from "the caller
   // explicitly set them" (replace, even to empty). This closes #2048: passing
   // `sources: []` used to be conflated with "omitted" and silently re-inherited
-  // the stored sources. The three authoring intents, in precedence order:
+  // the stored sources.
   //
-  //   1. Source-token prompt edited → derive fresh from the new prompt's
-  //      `@`-chips (unioned with any explicit sources). The prompt is
-  //      authoritative: a deleted chip's source must NOT linger, an edited SQL
-  //      chip must not keep its OLD query under the same name (union-merge is
-  //      monotonic, add-only), so we derive fresh rather than union with stored.
-  //   2. `sources` passed without a source-token edit → EXPLICIT replacement.
-  //      The given list is authoritative even when empty (`[]` clears).
-  //   3. Neither a source-token edit nor sources supplied → INHERIT the stored
-  //      sources, so a metadata-only bump (schedule/name) preserves them.
-  const promptSources = extractSourcesFromPromptTokens(prompt);
-  const sourcesProvided = args.sources !== undefined;
-  const explicitSources = args.sources ?? [];
+  //   1. `sources` passed → EXPLICIT replacement. The given list is
+  //      authoritative even when empty (`[]` clears).
+  //   2. `sources` omitted → INHERIT the assignment's stored sources, so a
+  //      prompt- or metadata-only bump preserves them.
+  //
+  // The instruction text is not a third input. In particular, `lobu apply`
+  // supplies compiled skill bodies as the prompt; chip-shaped prose there must
+  // not add or remove the assignment's sources. Interactive authoring clients
+  // send an explicit replacement when their source-chip set changes.
   const storedSources = normalizeStoredJsonField(
     watcherRows[0].sources,
     [] as Array<{ name: string; query: string }>
   );
-  // Include the previous prompt so removing its last token clears its source.
-  const previousPromptHadSourceTokens =
-    promptEdited && extractSourcesFromPromptTokens((prev.prompt as string) ?? '').length > 0;
-  const shouldDerivePromptSources =
-    promptEdited && (promptSources.length > 0 || previousPromptHadSourceTokens);
-  const sources =
-    shouldDerivePromptSources
-      ? mergePromptSources(explicitSources, promptSources)
-      : sourcesProvided
-        ? explicitSources
-        : storedSources;
+  const sources = args.sources !== undefined ? args.sources : storedSources;
   const keyingConfig =
     parseJsonInput<Record<string, unknown>>(args.keying_config, 'keying_config') ??
     normalizeStoredJsonField(prev.keying_config, undefined as Record<string, unknown> | undefined);
@@ -432,6 +418,17 @@ export async function handleGetVersionDetails(
     throw new Error('behavior_id is required for get_version_details action');
   }
 
+  // Version rows live on the group root while sources live on the assignment.
+  // Resolve both so assignment ids behave consistently with get_versions.
+  const watcherRows = await sql`
+    SELECT id, watcher_group_id, sources
+    FROM watchers WHERE id = ${args.behavior_id}
+  `;
+  if (watcherRows.length === 0) {
+    throw new Error(`Behavior ${args.behavior_id} not found`);
+  }
+  const groupId = Number(watcherRows[0].watcher_group_id ?? watcherRows[0].id);
+
   let rows;
   if (args.version !== undefined) {
     rows = await sql`
@@ -441,7 +438,7 @@ export async function handleGetVersionDetails(
         keying_config, classifiers,
         reactions_guidance
       FROM watcher_versions
-      WHERE watcher_id = ${args.behavior_id} AND version = ${args.version}
+      WHERE watcher_id = ${groupId} AND version = ${args.version}
       LIMIT 1
     `;
   } else {
@@ -466,6 +463,14 @@ export async function handleGetVersionDetails(
 
   const v = rows[0] as Record<string, unknown>;
 
+  // create_version leaves version_sources NULL because sources are
+  // per-assignment. Fall through to the assignment's live list, matching
+  // get_content while retaining sources stored on older version rows.
+  const versionSources = normalizeStoredJsonField(
+    v.version_sources,
+    [] as Array<{ name: string; query: string }>
+  );
+
   return {
     action: 'get_version_details',
     behavior_id: args.behavior_id,
@@ -474,10 +479,13 @@ export async function handleGetVersionDetails(
     name: v.name as string | undefined,
     description: v.description as string | undefined,
     prompt: v.prompt as string,
-    sources: normalizeStoredJsonField(
-      v.version_sources,
-      [] as Array<{ name: string; query: string }>
-    ),
+    sources:
+      versionSources.length > 0
+        ? versionSources
+        : normalizeStoredJsonField(
+            watcherRows[0].sources,
+            [] as Array<{ name: string; query: string }>
+          ),
     keying_config: normalizeStoredJsonField(v.keying_config, undefined as unknown),
     classifiers: normalizeStoredJsonField(v.classifiers, undefined as unknown[] | undefined),
     reactions_guidance: v.reactions_guidance as string | undefined,


### PR DESCRIPTION
## Summary

- `create_version` derived a Behavior's `sources[]` from the `@`-mention chips in the prompt it was handed. That made sense when a human typed that prompt in the composer. Since #2331 the prompt is the **compiled join of the Behavior's skill bodies**, so the rule let a skill's prose author the Behavior's source list — and because derivation *replaces* rather than merges, a compiled prompt with no chips silently erased every stored source, the default `content` one included. `lobu apply` resends `prompt` on every bump, so that erasure needed no user intent at all. Issue #2320 must-fix 2.
- Sources on a bump now have exactly two inputs: an explicit `sources` argument (authoritative, `[]` still clears — #2048), or the assignment's stored list. Chip derivation stays on `create`, whose only caller sending human-written prompt text is the composer.
- `get_version_details` told the matching lie in reverse. `create_version` writes `version_sources` NULL on purpose — sources are per-assignment, so freezing one assignment's list on the shared version row would override its siblings — but the handler reported that column alone, so every v≥2 read back `sources: []` for a Behavior that plainly had sources. It now falls through to the assignment's live list, the same preference order `get_content` uses.
- Same handler, same root cause: it looked versions up on the passed behavior id while `get_versions` resolves the group **root**, so an assignment created by `create_from_version` could list a version it then could not fetch. Both now resolve the root.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `vitest run src/__tests__/integration/tools src/__tests__/integration/watchers src/__tests__/integration/behavior-source-validation.test.ts` → 342 passed
- [x] Bug fix: red→fix→green outputs pasted below

### Red (before the fix)

```
$ vitest run src/__tests__/integration/tools/manage-behaviors-source-honesty.test.ts

× a compiled skill body's chip does not rewrite the Behavior's sources
  → expected [ { name: 'skill_pull', … } ] to deeply equal [ { name: 'content', … } ]
× a prompt-only bump keeps the stored sources
  → expected [] to deeply equal [ { name: 'content', … } ]          ← every source erased
× explicit sources replace, and an explicit empty list clears (#2048)
  → expected [ { name: 'recent', … }, { name: 'skill_pull', … } ] to deeply equal [ { name: 'recent', … } ]
× get_version_details reports the sources the Behavior actually runs with
  → expected [] to deeply equal [ { name: 'recent', … } ]

 Tests  4 failed | 2 passed (6)
```

### Green (after)

```
$ vitest run src/__tests__/integration/tools/manage-behaviors-source-honesty.test.ts
 Tests  2 passed (2)

$ vitest run src/__tests__/integration/tools src/__tests__/integration/watchers
 Test Files  35 passed (35)
      Tests  328 passed (328)
```

### Mutation check

| Mutation | Result |
|---|---|
| restore the old prompt-token derivation on `create_version` | fails |
| omitted `sources` → `[]` instead of inheriting | fails |
| `get_version_details` reports `version_sources` only | fails |
| version lookup keyed on `behavior_id` instead of the group root | fails |

### Contract tests updated, not deleted

Three existing tests pinned the *old* rule (prompt chips re-derive on bump). They now pin the new one — chips in a bump's prompt leave sources alone; `sources: []` is what clears:

- `watchers-crud.test.ts` — "a version bump does not re-derive sources from the prompt", "removing every @-mention chip does not clear sources"
- `manage-behaviors-update-version-fields.test.ts` — "a chip in the prompt does not author sources"

## Notes

Part of #2320 (thin Skills + Behaviors). Follows #2324 / #2327 / #2331; pairs with the Behavior-run skill isolation PR.

**Web composer:** it used to rely on the server re-deriving sources from an edited prompt's chips. owletto#633 (merged) moves that derivation to the composer, which now sends an explicit `sources` replacement when — and only when — the chip set changed. The submodule pointer bump rides with the schema-cleanup PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->