### PR TITLE
chore(core): drop skill nixPackages and pin the Skills UI that wrote it

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -84,7 +84,7 @@ Implications, by design:
 Skills are executable, security-sensitive input:
 
 - Use curated skill lists by default.
-- Skill-level `nixPackages` are ignored. Review the agent's `nixPackages`: each binary on the allowlist is a capability, treat them as such.
+- Packages come from the agent's `nixPackages` (a skill cannot declare any). Review that list: each binary on the allowlist is a capability, treat them as such.
 - Network policy is declared on the agent (`network.allowed` / `network.denied` → `settings.networkConfig`), not on skills; gateway egress controls apply on top.
 - Destructive MCP tool calls require in-thread approval unless pre-approved via `defineAgent({ tools: { preApproved } })` in `lobu.config.ts`.
 

--- a/packages/core/src/contracts/agent-settings.ts
+++ b/packages/core/src/contracts/agent-settings.ts
@@ -124,11 +124,11 @@ export const SkillConfigSchema = Type.Object({
   enabled: Type.Boolean(),
   system: Type.Optional(Type.Boolean()),
   content: Type.Optional(Type.String()),
-  // Legacy compatibility only: runtime package resolution and the CLI ignore
-  // this field. Keep accepting it so existing `skills_config` rows validate
-  // and round-trip through the pinned Owletto editor. Remove it with the
-  // submodule change that deletes the editor field.
-  nixPackages: Type.Optional(Type.Array(Type.String())),
+  // No `nixPackages`: a skill is instruction text, and generic tooling lives on
+  // the agent's `nixConfig` (issue #2320). Stored rows written before the field
+  // was dropped still validate — `Type.Object` admits unknown keys — and every
+  // reader has ignored the value since #2324, so a legacy entry simply stops
+  // round-tripping through the editor the first time an agent's skills are saved.
   modelPreference: Type.Optional(Type.String()),
   thinkingLevel: Type.Optional(ThinkingLevelSchema),
 });

--- a/packages/server/src/gateway/__tests__/platform-helpers-nix-union.test.ts
+++ b/packages/server/src/gateway/__tests__/platform-helpers-nix-union.test.ts
@@ -45,8 +45,9 @@ describe("resolveAgentOptions nix union", () => {
     expect(resolved?.packages).toEqual(["request-pkg"]);
   });
 
-  // Stored legacy rows can still carry `nixPackages`; they must validate but
-  // contribute nothing to provisioning.
+  // `SkillConfigSchema` no longer declares `nixPackages`, but rows written
+  // before it was dropped still carry one. They must keep loading, and keep
+  // contributing nothing to provisioning.
   test("a legacy enabled skill's nixPackages entry is ignored", async () => {
     const resolved = await resolveNixConfig({
       nixConfig: { packages: ["ripgrep"] },

--- a/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
@@ -220,6 +220,8 @@ describe("validateSkillsConfig", () => {
             instructions: "i",
             content: "c",
             system: true,
+            // Dropped from the schema with the Skills UI (#2320) — a stored
+            // row that still carries it must not fail the write boundary.
             nixPackages: ["ripgrep"],
             modelPreference: "anthropic/claude-haiku-4-5",
             thinkingLevel: "low",


### PR DESCRIPTION
## Summary

- `SkillConfigSchema.nixPackages` was kept as accept-and-ignore for exactly one reason, stated in its own comment: the pinned Owletto editor still round-tripped it. owletto#632 removed that editor, so the last writer is gone and the schema can now say what has been true since #2324 — a skill is instruction text, and generic tooling lives on the agent's `nixConfig`. Issue #2320 must-fix 3.
- Bumps `packages/owletto` to `005a13f`, which carries both merged UI PRs:
  - **owletto#632** — drops the skill Packages field and badge (the change that unblocks this schema removal).
  - **owletto#633** — resolves Behavior source chips in the composer, the client half of #2345 (which stopped `create_version` deriving sources from instruction text).
- `docs/SECURITY.md` audit item now reads as a statement of the model rather than a carve-out: packages come from the agent's `nixPackages`, a skill cannot declare any.

## Legacy rows keep loading

Prod `skills_config` rows written before the drop still carry `nixPackages`. Nothing breaks:

- `Type.Object` admits unknown keys, so `validateSkillsConfig` — the PATCH write boundary, which checks against this very schema — still accepts them. Pinned by an existing test, now with a comment saying why the field is there.
- Every reader has ignored the value since #2324 (both union points). Pinned by `platform-helpers-nix-union.test.ts`, which asserts a legacy entry contributes nothing to provisioning.
- A legacy entry simply stops round-tripping the first time an agent's skills are saved. No migration or backfill needed.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] `make typecheck` (strict, server + owletto) clean
- [x] `bun test packages/server/src/gateway/__tests__/platform-helpers-nix-union.test.ts packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts` → 31 passed — the two suites that pin legacy-row tolerance
- [x] owletto at the pinned SHA: 122 files, 1045 tests passed

## Notes

Closes the schema half of #2320's "strip skill nix class-wide". Submodule-pointer PR — `check-drift` fails on every other open PR until this lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->