### PR TITLE
feat(connectors): min_scrolls jitter for X/LinkedIn home feeds

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1276,6 +1276,38 @@ describe("LinkedInConnector home_feed", () => {
     expect(res.metadata.object_all_supported).toBe(true);
   });
 
+  test("min_scrolls/max_scrolls pick a scroll budget in range each run", async () => {
+    const scrollMaxes: number[] = [];
+    const dispatcher = {
+      dispatch: async (_action: string, input: Record<string, unknown>) => {
+        scrollMaxes.push(
+          (input.scrape_config as { scroll: { max: number } }).scroll.max
+        );
+        return {
+          tab_id: 1,
+          cs_scrape: true,
+          result: { loggedIn: true, rows: [] },
+        };
+      },
+    };
+    const connector = new LinkedInConnector();
+    const realRandom = Math.random;
+    // Force mid-range pick: min + floor(0.5 * (max-min+1)) = 6 + floor(2.5) = 8
+    Math.random = () => 0.5;
+    try {
+      const res = await connector.sync({
+        feedKey: "home_feed",
+        config: { min_scrolls: 6, max_scrolls: 10 },
+        checkpoint: {},
+        sessionState: { chrome_dispatcher: dispatcher },
+      });
+      expect(scrollMaxes).toEqual([8]);
+      expect(res.metadata.scrolls_this_run).toBe(8);
+    } finally {
+      Math.random = realRandom;
+    }
+  });
+
   test("throws a clear error when not logged into LinkedIn", async () => {
     const dispatcher = {
       dispatch: async () => ({ result: { loggedIn: false, rows: [] } }),
@@ -1741,7 +1773,7 @@ describe("prepare_comment helpers", () => {
       { required: ["post_url"] },
       { required: ["activity_id"] },
     ]);
-    expect(c.definition.version).toBe("3.3.0");
+    expect(c.definition.version).toBe("3.4.0");
     expect(String(action?.description ?? "")).toMatch(/NEVER submits/i);
   });
 

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -99,6 +99,7 @@ interface LinkedInCheckpoint {
 interface LinkedInConfig extends LocalTakeoutConfig {
   company_url?: string;
   max_scrolls?: number;
+  min_scrolls?: number;
 }
 
 interface LinkedInPost {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -2038,10 +2038,7 @@ function readHomeScrollBudget(config: {
   max_scrolls?: number;
   min_scrolls?: number;
 }): number {
-  const max = Math.max(
-    1,
-    Math.min(30, Number(config.max_scrolls ?? 8) || 8),
-  );
+  const max = Math.max(1, Math.min(30, Number(config.max_scrolls ?? 8) || 8));
   if (config.min_scrolls === undefined || config.min_scrolls === null) {
     return max;
   }

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -2020,10 +2020,35 @@ const homeFeedConfigSchema = {
       minimum: 1,
       maximum: 30,
       default: 8,
-      description: "Maximum scroll iterations for the home feed (default: 8)",
+      description:
+        "Maximum scroll iterations for the home feed (default: 8). Upper end of the range when min_scrolls is set.",
+    },
+    min_scrolls: {
+      type: "integer",
+      minimum: 1,
+      maximum: 30,
+      description:
+        "Optional lower bound. When set below max_scrolls, each sync picks a uniform random scroll count in [min_scrolls, max_scrolls].",
     },
   },
 };
+
+/** Per-run scroll budget: fixed max_scrolls, or uniform [min_scrolls, max_scrolls]. */
+function readHomeScrollBudget(config: {
+  max_scrolls?: number;
+  min_scrolls?: number;
+}): number {
+  const max = Math.max(
+    1,
+    Math.min(30, Number(config.max_scrolls ?? 8) || 8),
+  );
+  if (config.min_scrolls === undefined || config.min_scrolls === null) {
+    return max;
+  }
+  const min = Math.max(1, Math.min(max, Number(config.min_scrolls) || 1));
+  if (min >= max) return max;
+  return min + Math.floor(Math.random() * (max - min + 1));
+}
 
 const jobsConfigSchema = {
   type: "object",
@@ -2071,7 +2096,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.3.0",
+    version: "3.4.0",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com
@@ -2600,7 +2625,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     // debugger stops the personalized feed from rendering) and takes no
     // company_url — it always reads linkedin.com/feed/.
     if (feedKey === "home_feed") {
-      const homeScrolls = config.max_scrolls ?? 8;
+      const homeScrolls = readHomeScrollBudget(config);
       return this.syncHomeFeed(
         homeScrolls,
         checkpoint,
@@ -2669,6 +2694,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
       metadata: {
         items_found: events.length,
         items_scraped: rows.length,
+        scrolls_this_run: maxScrolls,
         backend: "extension-cs-scrape",
         object_all_supported: objectAllSupported,
       },

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -890,7 +890,7 @@ const linkedinConnection = defineConnection({
         ].map((feed) => ({ feed, config: { takeout_dir: linkedinTakeoutDir } }))
       : []),
     // Live Chrome-extension feed (no company_url needed).
-    { feed: "home_feed", config: { max_scrolls: 8 } },
+    { feed: "home_feed", config: { min_scrolls: 6, max_scrolls: 10 } },
   ],
 });
 

--- a/packages/connectors/src/__tests__/x.test.ts
+++ b/packages/connectors/src/__tests__/x.test.ts
@@ -710,4 +710,66 @@ describe("XConnector home_feed", () => {
 		};
 		await expect(connector.sync(ctx)).rejects.toThrow(/Not logged into X/);
 	});
+
+	test("home_feed configSchema accepts min_scrolls + max_scrolls", () => {
+		const props = new XConnector().definition.feeds.home_feed.configSchema
+			.properties as Record<string, { type?: string }>;
+		expect(props.max_scrolls?.type).toBe("integer");
+		expect(props.min_scrolls?.type).toBe("integer");
+	});
+
+	test("min_scrolls/max_scrolls pick a scroll budget in range each run", async () => {
+		const scrollMaxes: number[] = [];
+		const dispatcher = {
+			dispatch: async (_action: string, input: Record<string, unknown>) => {
+				scrollMaxes.push(
+					(input.scrape_config as { scroll: { max: number } }).scroll.max,
+				);
+				return {
+					tab_id: 1,
+					cs_scrape: true,
+					result: { loggedIn: true, rows: [] },
+				};
+			},
+		};
+		const connector = new XConnector();
+		const realRandom = Math.random;
+		// Force mid-range pick: min + floor(0.5 * (max-min+1)) = 8 + floor(2.5) = 10
+		Math.random = () => 0.5;
+		try {
+			await connector.sync({
+				feedKey: "home_feed",
+				config: { min_scrolls: 8, max_scrolls: 12 },
+				checkpoint: {},
+				sessionState: { chrome_dispatcher: dispatcher },
+			});
+		} finally {
+			Math.random = realRandom;
+		}
+		expect(scrollMaxes).toEqual([10]);
+	});
+
+	test("omitting min_scrolls keeps a fixed max_scrolls budget", async () => {
+		const scrollMaxes: number[] = [];
+		const dispatcher = {
+			dispatch: async (_action: string, input: Record<string, unknown>) => {
+				scrollMaxes.push(
+					(input.scrape_config as { scroll: { max: number } }).scroll.max,
+				);
+				return {
+					tab_id: 1,
+					cs_scrape: true,
+					result: { loggedIn: true, rows: [] },
+				};
+			},
+		};
+		const connector = new XConnector();
+		await connector.sync({
+			feedKey: "home_feed",
+			config: { max_scrolls: 7 },
+			checkpoint: {},
+			sessionState: { chrome_dispatcher: dispatcher },
+		});
+		expect(scrollMaxes).toEqual([7]);
+	});
 });

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -827,8 +827,34 @@ function createOAuthHttpClient(accessToken: string): HttpClient {
 	});
 }
 
+/**
+ * Resolve how many scroll/page iterations this run should perform.
+ *
+ * - `max_scrolls` (default 10): upper bound (also the fixed value when min is omitted).
+ * - `min_scrolls` (optional): when set and &lt; max, pick uniformly in [min, max]
+ *   each run so depth varies (e.g. min 8 / max 12 ≈ ~80–120 home tweets).
+ */
+function readScrollBudget(
+	config: Record<string, unknown>,
+	opts: { defaultMax?: number; cap?: number } = {},
+): number {
+	const defaultMax = opts.defaultMax ?? 10;
+	const cap = opts.cap ?? 50;
+	const max = Math.max(
+		1,
+		Math.min(cap, Number(config.max_scrolls ?? defaultMax) || defaultMax),
+	);
+	const minRaw = config.min_scrolls;
+	if (minRaw === undefined || minRaw === null || minRaw === "") {
+		return max;
+	}
+	const min = Math.max(1, Math.min(max, Number(minRaw) || 1));
+	if (min >= max) return max;
+	return min + Math.floor(Math.random() * (max - min + 1));
+}
+
 function readMaxPages(config: Record<string, unknown>, cap = 50): number {
-	return Math.max(1, Math.min(cap, Number(config.max_scrolls ?? 10) || 10));
+	return readScrollBudget(config, { defaultMax: 10, cap });
 }
 
 type XSyncBackend = "oauth_api" | "extension";
@@ -1653,10 +1679,7 @@ async function syncHomeFeedViaDomScrape(
 	config: Record<string, unknown>,
 	checkpoint: XCheckpoint,
 ): Promise<SyncResult> {
-	const maxScrolls = Math.max(
-		1,
-		Math.min(30, Number(config.max_scrolls ?? 10) || 10),
-	);
+	const maxScrolls = readScrollBudget(config, { defaultMax: 10, cap: 30 });
 	const { items: rows, loggedIn } = await extensionDomScrape<HomeFeedRow>({
 		dispatcher: requireExtensionDispatcher(ctx),
 		url: "https://x.com/home",
@@ -1678,6 +1701,7 @@ async function syncHomeFeedViaDomScrape(
 	return finalizeSyncResult(tweets, checkpoint, {
 		backend: "extension-cs-scrape",
 		items_scraped: rows.length,
+		scrolls_this_run: maxScrolls,
 		timeline: "home",
 	});
 }
@@ -1696,6 +1720,24 @@ const backendPreferenceProperties = {
 		default: false,
 		description:
 			"Force the X API even when scopes are missing (will fail unless re-authorized).",
+	},
+} as const;
+
+const scrollBudgetProperties = {
+	max_scrolls: {
+		type: "integer",
+		minimum: 1,
+		maximum: 50,
+		default: 10,
+		description:
+			"Maximum scroll/page iterations this feed may perform (default: 10). With min_scrolls, this is the upper end of a per-run random range.",
+	},
+	min_scrolls: {
+		type: "integer",
+		minimum: 1,
+		maximum: 50,
+		description:
+			"Optional lower bound. When set below max_scrolls, each sync picks a uniform random scroll count in [min_scrolls, max_scrolls] (e.g. 8–12 ≈ ~80–120 home tweets).",
 	},
 } as const;
 
@@ -1722,14 +1764,7 @@ const searchConfigSchema = {
 			description:
 				'Search tab: "live" for Latest (chronological), "top" for Top (popular/algorithmic)',
 		},
-		max_scrolls: {
-			type: "integer",
-			minimum: 1,
-			maximum: 50,
-			default: 10,
-			description:
-				"Maximum pagination iterations (default: 10, API pages or browser scrolls)",
-		},
+		...scrollBudgetProperties,
 		...backendPreferenceProperties,
 	},
 };
@@ -1743,7 +1778,14 @@ const homeFeedConfigSchema = {
 			maximum: 30,
 			default: 10,
 			description:
-				"Maximum scroll iterations for the home timeline (default: 10)",
+				"Maximum scroll iterations for the home timeline (default: 10). Upper end of the range when min_scrolls is set.",
+		},
+		min_scrolls: {
+			type: "integer",
+			minimum: 1,
+			maximum: 30,
+			description:
+				"Optional lower bound. When set below max_scrolls, each sync picks a uniform random scroll count in [min_scrolls, max_scrolls].",
 		},
 	},
 };
@@ -1757,14 +1799,7 @@ const accountTimelineConfigSchema = {
 			description:
 				'Optional X handle (e.g. "buremba"). Defaults to the authenticated account when OAuth is available.',
 		},
-		max_scrolls: {
-			type: "integer",
-			minimum: 1,
-			maximum: 50,
-			default: 10,
-			description:
-				"Maximum pagination iterations (default: 10, API pages or browser scrolls)",
-		},
+		...scrollBudgetProperties,
 		...backendPreferenceProperties,
 	},
 };
@@ -1784,14 +1819,7 @@ const bookmarksConfigSchema = {
 			description:
 				"Optional numeric X user id for DM from_me / counterparty resolution on the extension path.",
 		},
-		max_scrolls: {
-			type: "integer",
-			minimum: 1,
-			maximum: 50,
-			default: 10,
-			description:
-				"Maximum pagination iterations (default: 10, API pages or browser scrolls)",
-		},
+		...scrollBudgetProperties,
 		...backendPreferenceProperties,
 	},
 };
@@ -1836,7 +1864,7 @@ export default class XConnector extends ConnectorRuntime {
 		name: "X (Twitter)",
 		description:
 			"Fetches tweets, likes, bookmarks, and DMs via the X API v2 or the paired Owletto Chrome extension. Links authors and DM counterparts into the person identity graph.",
-		version: "3.3.2",
+		version: "3.4.0",
 		faviconDomain: "x.com",
 		authSchema: {
 			methods: [

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -831,8 +831,8 @@ function createOAuthHttpClient(accessToken: string): HttpClient {
  * Resolve how many scroll/page iterations this run should perform.
  *
  * - `max_scrolls` (default 10): upper bound (also the fixed value when min is omitted).
- * - `min_scrolls` (optional): when set and &lt; max, pick uniformly in [min, max]
- *   each run so depth varies (e.g. min 8 / max 12 ≈ ~80–120 home tweets).
+ * - `min_scrolls` (optional): when set below max, pick uniformly in [min, max]
+ *   each run so depth varies.
  */
 function readScrollBudget(
 	config: Record<string, unknown>,
@@ -1737,7 +1737,7 @@ const scrollBudgetProperties = {
 		minimum: 1,
 		maximum: 50,
 		description:
-			"Optional lower bound. When set below max_scrolls, each sync picks a uniform random scroll count in [min_scrolls, max_scrolls] (e.g. 8–12 ≈ ~80–120 home tweets).",
+			"Optional lower bound. When set below max_scrolls, each sync picks a uniform random scroll count in [min_scrolls, max_scrolls].",
 	},
 } as const;
 


### PR DESCRIPTION
## Summary
- Adds optional `min_scrolls` alongside `max_scrolls` on X (and LinkedIn example) home feeds.
- When set, each sync picks a uniform random scroll budget in `[min, max]` for ~80–120 tweet depth without fixed paging every hour.
- Personal-agent LinkedIn `home_feed` config uses `min_scrolls: 6, max_scrolls: 10`.

## Test plan
- [x] `bun test packages/connectors/src/__tests__/x.test.ts` (25 pass, includes min/max scroll budget tests)
- [ ] `make pre-pr` (optional for connectors package)
- [ ] Prod already runs org-local 3.4.0 with this behavior; PR codifies it for catalog/main

## Notes
Org-local X/LinkedIn 3.4.0 was already deployed to buremba for validation; this lands the same source in-repo.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

## Review validation (2026-08-01)

```
bun test packages/connectors/src/__tests__/x.test.ts: 25 pass, 0 fail
bun test examples/personal-agent/__tests__/linkedin.connector.test.ts: 98 pass, 0 fail
lobu validate: valid
make pre-pr: clean after make review-fix
```

`make review-fix` added the missing LinkedIn `min_scrolls` config type and mirrored coverage for the randomized dispatched scroll budget plus `scrolls_this_run` metadata; it also corrected shared X schema wording. The targeted suites and full gate were rerun on the settled five-file diff.