### PR TITLE
feat(server): device Behavior complete-behavior resume + Mac CLI path

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -1014,6 +1014,196 @@ describe("watcher automation contract", () => {
 			expect(afterMs).toBeGreaterThan(beforeMs);
 		});
 
+		// Ambiguous delivery: the resume commits server-side but the device never
+		// sees the response, so it retries the SAME exit report. Replaying it must
+		// re-serve the grant it already earned — inferring a fresh attempt from the
+		// stored count instead would burn the budget and fail the run one spawn
+		// early, which is the delivery error being reinterpreted as work.
+		it("replays the granted resume instead of consuming a second finalize attempt", async () => {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferBehaviorGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity
+			);
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "66666666-6666-6666-6666-666666666666",
+				agentKind: "claude-code",
+			});
+			const workerId = "mac-device-replay-test";
+			await sql`
+        UPDATE runs
+        SET status = 'running', claimed_at = NOW(), claimed_by = ${workerId}
+        WHERE id = ${queued.runId}
+      `;
+
+			const report = {
+				worker_id: workerId,
+				output: "exited without finalizing",
+				duration_ms: 25,
+				exit_code: 0,
+				exit_reason: "ok",
+				// First spawn runs under finalize_nudge_count = 0.
+				finalize_attempt: 0,
+			};
+
+			const granted = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
+				{ body: report }
+			);
+			expect(granted.status).toBe(200);
+			const grantedJson = (await granted.json()) as {
+				status: string;
+				attempt?: number;
+				nudge?: string;
+			};
+			expect(grantedJson.status).toBe("resume");
+			expect(grantedJson.attempt).toBe(1);
+
+			// Byte-identical replay of the same report — the device's retry after a
+			// lost response.
+			const replay = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
+				{ body: report }
+			);
+			expect(replay.status).toBe(200);
+			const replayJson = (await replay.json()) as {
+				status: string;
+				attempt?: number;
+				reason_code?: string;
+				idempotent?: boolean;
+				nudge?: string;
+			};
+			expect(replayJson.status).toBe("resume");
+			expect(replayJson.reason_code).toBe("missing_complete_window");
+			expect(replayJson.attempt).toBe(1);
+			expect(replayJson.idempotent).toBe(true);
+			// The re-served nudge has to be usable, not just a status echo — the
+			// device feeds it straight into the re-spawned prompt.
+			expect(replayJson.nudge).toBe(grantedJson.nudge);
+
+			const [afterReplay] = await sql`
+        SELECT status,
+               approved_input->>'finalize_nudge_count' AS finalize_nudge_count
+        FROM runs WHERE id = ${queued.runId}
+      `;
+			expect(String(afterReplay.status)).toBe("running");
+			// The replay consumed nothing: still exactly one granted resume.
+			expect(Number(afterReplay.finalize_nudge_count)).toBe(1);
+
+			// The genuinely-new spawn reports attempt 1 and exhausts the budget.
+			const terminal = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
+				{ body: { ...report, finalize_attempt: 1 } }
+			);
+			expect(terminal.status).toBe(200);
+			expect(((await terminal.json()) as { status: string }).status).toBe(
+				"failed"
+			);
+		});
+
+		// Event turns have no completeWindow step — the agent's reply IS the work.
+		// A clean device exit therefore completes the run rather than failing it,
+		// and must not mint a window.
+		it("completes an event-turn Behavior on a clean device exit", async () => {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferBehaviorGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity
+			);
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "77777777-7777-7777-7777-777777777777",
+				agentKind: "claude-code",
+			});
+			const workerId = "mac-device-turn-test";
+			await sql`
+        UPDATE runs
+        SET status = 'running', claimed_at = NOW(), claimed_by = ${workerId},
+            approved_input = jsonb_set(
+              COALESCE(approved_input, '{}'::jsonb),
+              '{trigger_execution}', '"turn"'::jsonb
+            )
+        WHERE id = ${queued.runId}
+      `;
+
+			const response = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
+				{
+					body: {
+						worker_id: workerId,
+						output: "replied in the thread",
+						duration_ms: 40,
+						exit_code: 0,
+						exit_reason: "ok",
+					},
+				}
+			);
+			expect(response.status).toBe(200);
+			const json = (await response.json()) as {
+				status: string;
+				reason_code?: string;
+				window_id?: number | null;
+			};
+			expect(json.status).toBe("completed");
+			expect(json.reason_code).toBe("event_turn");
+			expect(json.window_id).toBeNull();
+
+			const [run] = await sql`
+        SELECT status, window_id, exit_reason, model_used,
+               run_metadata->>'execution_time_ms' AS execution_time_ms
+        FROM runs WHERE id = ${queued.runId}
+      `;
+			expect(String(run.status)).toBe("completed");
+			expect(run.window_id).toBeNull();
+			expect(String(run.exit_reason)).toBe("ok");
+			expect(String(run.model_used)).toBe("device-cli:claude-code");
+			expect(Number(run.execution_time_ms)).toBe(40);
+
+			// No completeWindow happened, so no canvas may be minted.
+			const windows = await sql`
+        SELECT id FROM events WHERE run_id = ${queued.runId} AND semantic_type = 'canvas_state'
+      `;
+			expect(windows).toHaveLength(0);
+
+			// A duplicate report is a no-op ack, not a second completion.
+			const dupe = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
+				{
+					body: {
+						worker_id: workerId,
+						output: "replied in the thread",
+						duration_ms: 40,
+						exit_code: 0,
+						exit_reason: "ok",
+					},
+				}
+			);
+			expect(dupe.status).toBe(200);
+			const dupeJson = (await dupe.json()) as {
+				status: string;
+				idempotent?: boolean;
+			};
+			expect(dupeJson.status).toBe("completed");
+			expect(dupeJson.idempotent).toBe(true);
+		});
+
 		it("complete-behavior endpoint marks the run failed when error is supplied", async () => {
 			const { sql, dbClient, workspace, watcherId, agent } =
 				await createAutomatedWatcher();

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -957,6 +957,8 @@ describe("watcher automation contract", () => {
 			expect(json.reason_code).toBe("missing_complete_window");
 			expect(json.attempt).toBe(1);
 			expect(String(json.nudge ?? json.error ?? "")).toMatch(/completeWindow/i);
+			expect(String(json.nudge ?? json.error ?? "")).toContain("behavior_id");
+			expect(String(json.nudge ?? json.error ?? "")).not.toContain("watcher_id");
 
 			const [runAfterResume] = await sql`
         SELECT status, error_message, window_id, output_tail,
@@ -1142,6 +1144,33 @@ describe("watcher automation contract", () => {
             )
         WHERE id = ${queued.runId}
       `;
+
+			// Token-auth workers are trusted at the HTTP authorization layer, so the
+			// terminal SQL transition itself must still enforce the run claim.
+			const wrongWorker = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
+				{
+					body: {
+						worker_id: "different-device",
+						output: "late reply from a worker that lost the claim",
+						duration_ms: 30,
+						exit_code: 0,
+						exit_reason: "ok",
+					},
+				}
+			);
+			expect(wrongWorker.status).toBe(200);
+			expect(
+				(await wrongWorker.json()) as {
+					status: string;
+					idempotent?: boolean;
+				}
+			).toMatchObject({ status: "running", idempotent: true });
+			const [afterWrongWorker] = await sql`
+        SELECT status, claimed_by FROM runs WHERE id = ${queued.runId}
+      `;
+			expect(String(afterWrongWorker.status)).toBe("running");
+			expect(String(afterWrongWorker.claimed_by)).toBe(workerId);
 
 			const response = await post(
 				`/api/workers/me/runs/${queued.runId}/complete-behavior`,

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -946,9 +946,51 @@ describe("watcher automation contract", () => {
 				ok: boolean;
 				status: string;
 				error?: string;
+				nudge?: string;
+				reason_code?: string;
+				attempt?: number;
+				max_attempts?: number;
 			};
-			expect(json.status).toBe("failed");
-			expect(String(json.error)).toMatch(/completeWindow/);
+			// Default finalize_nudges budget is 1 → first miss is a device-held resume
+			// (run stays running/claimed so the Mac can re-spawn).
+			expect(json.status).toBe("resume");
+			expect(json.reason_code).toBe("missing_complete_window");
+			expect(json.attempt).toBe(1);
+			expect(String(json.nudge ?? json.error ?? "")).toMatch(/completeWindow/i);
+
+			const [runAfterResume] = await sql`
+        SELECT status, error_message, window_id, output_tail,
+               approved_input->>'finalize_nudge_count' AS finalize_nudge_count
+        FROM runs WHERE id = ${queued.runId}
+      `;
+			expect(String(runAfterResume.status)).toBe("running");
+			expect(Number(runAfterResume.finalize_nudge_count)).toBe(1);
+			expect(runAfterResume.window_id).toBeNull();
+			expect(String(runAfterResume.output_tail)).toContain("nothing to report");
+
+			// Second clean exit with no window exhausts the budget → terminal fail.
+			const response2 = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
+				{
+					body: {
+						worker_id: workerId,
+						output: "still nothing",
+						duration_ms: 10,
+						exit_code: 0,
+						exit_reason: "ok",
+					},
+				}
+			);
+			expect(response2.status).toBe(200);
+			const json2 = (await response2.json()) as {
+				ok: boolean;
+				status: string;
+				error?: string;
+				reason_code?: string;
+			};
+			expect(json2.status).toBe("failed");
+			expect(json2.reason_code).toBe("missing_complete_window");
+			expect(String(json2.error)).toMatch(/completeWindow/);
 
 			const [run] = await sql`
         SELECT status, error_message, window_id, output_tail FROM runs WHERE id = ${queued.runId}
@@ -956,8 +998,6 @@ describe("watcher automation contract", () => {
 			expect(String(run.status)).toBe("failed");
 			expect(String(run.error_message)).toMatch(/completeWindow/);
 			expect(run.window_id).toBeNull();
-			// The stdout tail is stashed for diagnosis.
-			expect(String(run.output_tail)).toContain("nothing to report");
 
 			const windows = await sql`
         SELECT id FROM events WHERE run_id = ${queued.runId} AND semantic_type = 'canvas_state'

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -1112,8 +1112,8 @@ describe("watcher automation contract", () => {
 
 		// Pi review #1: schedule must advance on every terminal exit report or
 		// the scheduler re-fires the watcher every tick forever. This run never
-		// calls complete_window, so the report fails it — next_run_at must
-		// still move.
+		// calls complete_window, so once the finalize_nudges budget is spent the
+		// report fails it — next_run_at must still move.
 		it("advances watchers.next_run_at on a terminal exit report", async () => {
 			const { sql, dbClient, workspace, watcherId, agent } =
 				await createAutomatedWatcher();
@@ -1146,6 +1146,28 @@ describe("watcher automation contract", () => {
         SET status = 'running', claimed_at = NOW(), claimed_by = ${workerId}
         WHERE id = ${queued.runId}
       `;
+
+			// Default finalize_nudges budget is 1, so the first missing-window report
+			// is a device-held resume — non-terminal, and it must NOT advance the
+			// cursor. Only the budget-exhausted report below is terminal.
+			const resume = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
+				{
+					body: {
+						worker_id: workerId,
+						output: "agent exited without completing",
+						duration_ms: 5,
+					},
+				}
+			);
+			expect(resume.status).toBe(200);
+			expect(((await resume.json()) as { status: string }).status).toBe("resume");
+			const [afterResume] = await sql`
+        SELECT next_run_at FROM watchers WHERE id = ${watcherId}
+      `;
+			expect(new Date(afterResume.next_run_at as string).getTime()).toBe(
+				beforeNextRun ? new Date(beforeNextRun).getTime() : 0
+			);
 
 			const response = await post(
 				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
@@ -1207,7 +1229,18 @@ describe("watcher automation contract", () => {
         WHERE id = ${queued.runId}
       `;
 
-			// First report fails the run (no complete_window happened).
+			// Drain the finalize_nudges budget (default 1) so the next report is
+			// terminal: the first missing-window exit is a device-held resume.
+			const resume = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
+				{
+					body: { worker_id: workerId, output: "resume exit", duration_ms: 10 },
+				}
+			);
+			expect(resume.status).toBe(200);
+			expect(((await resume.json()) as { status: string }).status).toBe("resume");
+
+			// First report past the budget fails the run (no complete_window happened).
 			const first = await post(
 				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
 				{

--- a/packages/server/src/__tests__/unit/watchers/device-finalize-nudge.test.ts
+++ b/packages/server/src/__tests__/unit/watchers/device-finalize-nudge.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { resolveFinalizeNudgeBudget } from "../../../watchers/run-completion";
+
+describe("resolveFinalizeNudgeBudget", () => {
+	it("uses global default when execution_config omits finalize_nudges", () => {
+		// Default LOBU_WATCHER_FINALIZE_NUDGES is 1 unless env overrides.
+		const n = resolveFinalizeNudgeBudget(null);
+		expect(n).toBeGreaterThanOrEqual(0);
+		expect(n).toBeLessThanOrEqual(5);
+	});
+
+	it("honors per-watcher override clamped to 0–5", () => {
+		expect(resolveFinalizeNudgeBudget({ finalize_nudges: 0 })).toBe(0);
+		expect(resolveFinalizeNudgeBudget({ finalize_nudges: 3 })).toBe(3);
+		expect(resolveFinalizeNudgeBudget({ finalize_nudges: 99 })).toBe(5);
+		expect(resolveFinalizeNudgeBudget({ finalize_nudges: -2 })).toBe(0);
+	});
+
+	it("ignores non-numeric overrides", () => {
+		const fallback = resolveFinalizeNudgeBudget(null);
+		expect(
+			resolveFinalizeNudgeBudget({ finalize_nudges: "2" as unknown as number })
+		).toBe(fallback);
+	});
+});

--- a/packages/server/src/__tests__/unit/watchers/device-finalize-nudge.test.ts
+++ b/packages/server/src/__tests__/unit/watchers/device-finalize-nudge.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "bun:test";
 import { resolveFinalizeNudgeBudget } from "../../../watchers/run-completion";
 
 describe("resolveFinalizeNudgeBudget", () => {
-	it("uses global default when execution_config omits finalize_nudges", () => {
-		// Default LOBU_WATCHER_FINALIZE_NUDGES is 1 unless env overrides.
+	it("keeps the global budget within the device safety range", () => {
 		const n = resolveFinalizeNudgeBudget(null);
+		expect(Number.isInteger(n)).toBe(true);
 		expect(n).toBeGreaterThanOrEqual(0);
 		expect(n).toBeLessThanOrEqual(5);
 	});

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -54,7 +54,15 @@ export function resolveFinalizeNudgeBudget(
  * local CLI with a nudge. Unlike {@link requeueWatcherRunForFinalizeNudge}
  * (cloud: release claim → pending), this does not clear `claimed_by`.
  *
- * Returns false when the row is no longer `running` (another path won).
+ * Returns false when the row is no longer `running` (another path won) or when
+ * the stored count already moved past the caller's read. The count predicate is
+ * a compare-and-swap: two duplicate exit reports (a Mac retry after a timed-out
+ * response) both read the same `finalize_nudge_count` and both pass the caller's
+ * `attemptsSoFar < budget` check, so without it both would be granted a resume
+ * and the run would get one more spawn than the budget allows. Callers derive
+ * `nextNudgeCount` as read + 1, so `nextNudgeCount - 1` is the expected prior
+ * value. The count is only ever written with `to_jsonb(int)`, so the cast is
+ * safe.
  */
 export async function bumpDeviceFinalizeNudge(
 	sql: DbClient,
@@ -73,6 +81,8 @@ export async function bumpDeviceFinalizeNudge(
         error_message = ${`Device CLI attempt ${nextNudgeCount}: completeWindow not called — resume allowed`}
     WHERE id = ${runId}
       AND status = 'running'
+      AND COALESCE((approved_input->>'finalize_nudge_count')::int, 0)
+          = ${nextNudgeCount - 1}
     RETURNING id
   `) as unknown as Array<{ id: number }>;
 	return rows.length > 0;
@@ -127,8 +137,8 @@ export async function markWatcherRunCompleted(
 	runId: number,
 	windowId: number | null,
 	fallbackModel?: string
-): Promise<void> {
-	await sql`
+): Promise<boolean> {
+	const rows = (await sql`
     UPDATE runs
     SET status = 'completed',
         window_id = ${windowId},
@@ -141,7 +151,12 @@ export async function markWatcherRunCompleted(
         )
     WHERE id = ${runId}
       AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-  `;
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	// False means the row was no longer active — a concurrent path won the
+	// transition. Callers that fire side effects off this completion must check
+	// it before doing so; the ones that only need the write may ignore it.
+	return rows.length > 0;
 }
 
 async function markWatcherRunFailed(

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -27,7 +27,7 @@ const MAX_FINALIZE_NUDGES: number = (() => {
 	const raw = process.env.LOBU_WATCHER_FINALIZE_NUDGES;
 	if (raw === undefined) return 1;
 	const n = Number(raw);
-	return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 1;
+	return Number.isFinite(n) && n >= 0 ? Math.min(5, Math.floor(n)) : 1;
 })();
 
 /**
@@ -54,19 +54,20 @@ export function resolveFinalizeNudgeBudget(
  * local CLI with a nudge. Unlike {@link requeueWatcherRunForFinalizeNudge}
  * (cloud: release claim → pending), this does not clear `claimed_by`.
  *
- * Returns false when the row is no longer `running` (another path won) or when
- * the stored count already moved past the caller's read. The count predicate is
- * a compare-and-swap: two duplicate exit reports (a Mac retry after a timed-out
- * response) both read the same `finalize_nudge_count` and both pass the caller's
- * `attemptsSoFar < budget` check, so without it both would be granted a resume
- * and the run would get one more spawn than the budget allows. Callers derive
- * `nextNudgeCount` as read + 1, so `nextNudgeCount - 1` is the expected prior
- * value. The count is only ever written with `to_jsonb(int)`, so the cast is
- * safe.
+ * Returns false when the row is no longer `running` under this worker's claim,
+ * or when the stored count already moved past the caller's read. The count
+ * predicate is a compare-and-swap: two duplicate exit reports (a Mac retry
+ * after a timed-out response) both read the same `finalize_nudge_count` and
+ * both pass the caller's `attemptsSoFar < budget` check, so without it both
+ * would be granted a resume and the run would get one more spawn than the
+ * budget allows. Callers derive `nextNudgeCount` as read + 1, so
+ * `nextNudgeCount - 1` is the expected prior value. The count is only ever
+ * written with `to_jsonb(int)`, so the cast is safe.
  */
 export async function bumpDeviceFinalizeNudge(
 	sql: DbClient,
 	runId: number,
+	workerId: string,
 	nextNudgeCount: number,
 	outputTail: string | null
 ): Promise<boolean> {
@@ -81,6 +82,7 @@ export async function bumpDeviceFinalizeNudge(
         error_message = ${`Device CLI attempt ${nextNudgeCount}: completeWindow not called — resume allowed`}
     WHERE id = ${runId}
       AND status = 'running'
+      AND claimed_by = ${workerId}
       AND COALESCE((approved_input->>'finalize_nudge_count')::int, 0)
           = ${nextNudgeCount - 1}
     RETURNING id
@@ -137,8 +139,8 @@ export async function markWatcherRunCompleted(
 	runId: number,
 	windowId: number | null,
 	fallbackModel?: string
-): Promise<boolean> {
-	const rows = (await sql`
+): Promise<void> {
+	await sql`
     UPDATE runs
     SET status = 'completed',
         window_id = ${windowId},
@@ -151,12 +153,7 @@ export async function markWatcherRunCompleted(
         )
     WHERE id = ${runId}
       AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-    RETURNING id
-  `) as unknown as Array<{ id: number }>;
-	// False means the row was no longer active — a concurrent path won the
-	// transition. Callers that fire side effects off this completion must check
-	// it before doing so; the ones that only need the write may ignore it.
-	return rows.length > 0;
+  `;
 }
 
 async function markWatcherRunFailed(

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -34,8 +34,11 @@ const MAX_FINALIZE_NUDGES: number = (() => {
  * Finalize-nudge budget for a run: the watcher's per-watcher override
  * (execution_config.finalize_nudges, 0-5) when set, else the global default.
  * Clamped defensively in case a raw DB value sits outside the schema's range.
+ *
+ * Shared by the cloud dispatch path and the device `complete-behavior` exit
+ * report so both honor the same per-Behavior / global budget.
  */
-function resolveFinalizeNudgeBudget(
+export function resolveFinalizeNudgeBudget(
 	executionConfig: Record<string, unknown> | null | undefined
 ): number {
 	const override = executionConfig?.finalize_nudges;
@@ -43,6 +46,36 @@ function resolveFinalizeNudgeBudget(
 		return Math.min(5, Math.max(0, Math.floor(override)));
 	}
 	return MAX_FINALIZE_NUDGES;
+}
+
+/**
+ * Device-held finalize retry: keep the run `running` under the same claim and
+ * bump `approved_input.finalize_nudge_count` so the Mac app can re-spawn the
+ * local CLI with a nudge. Unlike {@link requeueWatcherRunForFinalizeNudge}
+ * (cloud: release claim → pending), this does not clear `claimed_by`.
+ *
+ * Returns false when the row is no longer `running` (another path won).
+ */
+export async function bumpDeviceFinalizeNudge(
+	sql: DbClient,
+	runId: number,
+	nextNudgeCount: number,
+	outputTail: string | null
+): Promise<boolean> {
+	const rows = (await sql`
+    UPDATE runs
+    SET approved_input = jsonb_set(
+          COALESCE(approved_input, '{}'::jsonb),
+          '{finalize_nudge_count}',
+          to_jsonb(${nextNudgeCount}::int)
+        ),
+        output_tail = ${outputTail},
+        error_message = ${`Device CLI attempt ${nextNudgeCount}: completeWindow not called — resume allowed`}
+    WHERE id = ${runId}
+      AND status = 'running'
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	return rows.length > 0;
 }
 
 export async function findWindowIdForRun(

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -712,6 +712,18 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 }
 
 /**
+ * Prompt appended to the re-spawned CLI when a device Behavior exited without
+ * calling completeWindow. Module-level so a granted resume and its idempotent
+ * replay hand the device byte-identical instructions.
+ */
+const MISSING_COMPLETE_WINDOW_NUDGE =
+	"Device CLI exited without calling completeWindow. Re-run the Behavior task and " +
+	"finalize via the lobu skill + CLI (preferred): " +
+	"`lobu memory exec` with client.knowledge.read({ watcher_id }) then " +
+	"client.behaviors.completeWindow({ window_token, extracted_data, behavior_run_id }). " +
+	"MCP query_sdk/run_sdk is also fine if wired. Do not only print a summary.";
+
+/**
  * POST /api/workers/me/runs/:runId/complete-behavior
  *
  * Device-side EXIT REPORT for a watcher run executed by a local CLI agent
@@ -732,6 +744,9 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
  *   status `resume` (run stays claimed/running; Mac re-spawns with nudge).
  * - clean exit + window Behavior still running + budget exhausted →
  *   failed with reason_code `missing_complete_window`.
+ * - a replay of a report already answered with a resume (body
+ *   `finalize_attempt` behind the stored count, i.e. the device never saw the
+ *   response) → the same `resume` again, consuming no further attempt.
  *
  * Authorization: the caller must own the claim — same gate as
  * /api/workers/complete (status='running' AND claimed_by === worker_id).
@@ -754,6 +769,13 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 		exit_code?: number | null;
 		exit_signal?: string | null;
 		exit_reason?: "ok" | "error_message" | "timeout" | "oom" | "crash";
+		/**
+		 * Which finalize attempt this report covers: the run's
+		 * `finalize_nudge_count` at the time the reporting spawn started. 0 for
+		 * the first spawn. Makes the report replayable — see the replay guard
+		 * below.
+		 */
+		finalize_attempt?: number;
 	}>(c, "Invalid or missing JSON body");
 	if (body instanceof Response) return body;
 
@@ -1140,6 +1162,41 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 	);
 	const nudgeCount = Number(approved.finalize_nudge_count ?? 0);
 	const attemptsSoFar = Number.isFinite(nudgeCount) ? nudgeCount : 0;
+
+	// Replay guard. `finalize_attempt` is the finalize_nudge_count the reporting
+	// spawn ran under (0 = first spawn, N = the spawn a resume #N granted). When
+	// the stored count is already past it, this exact exit report was answered
+	// with a resume the device never saw — its POST committed and the response
+	// was lost. That is an ambiguous delivery outcome, not a fresh attempt, so
+	// re-serve the same grant. Consuming another attempt here would fail the run
+	// one spawn early, reinterpreting a lost response as work that happened.
+	//
+	// A device that omits the field (a build older than this endpoint's resume
+	// contract) reads as "reporting the attempt the server has", i.e. the
+	// pre-existing behavior — the field is what makes a retry safe, so the Mac
+	// retry loop and this guard ship together.
+	const reportedAttempt =
+		typeof body.finalize_attempt === "number" &&
+		Number.isFinite(body.finalize_attempt)
+			? Math.max(0, Math.trunc(body.finalize_attempt))
+			: attemptsSoFar;
+	if (reportedAttempt < attemptsSoFar) {
+		logger.info(
+			{ run_id: runId, reported: reportedAttempt, granted: attemptsSoFar },
+			"[completeBehaviorRun] replayed exit report — re-serving the granted resume"
+		);
+		return c.json({
+			ok: true,
+			status: "resume",
+			reason_code: "missing_complete_window",
+			attempt: attemptsSoFar,
+			max_attempts: budget,
+			nudge: MISSING_COMPLETE_WINDOW_NUDGE,
+			error: MISSING_COMPLETE_WINDOW_NUDGE,
+			idempotent: true,
+		});
+	}
+
 	// attemptsSoFar is how many resumes already granted; next spawn is attempt+1.
 	// Budget N means N extra spawns after the first (same as cloud).
 	if (attemptsSoFar < budget) {
@@ -1160,12 +1217,6 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 				idempotent: true,
 			});
 		}
-		const nudge =
-			"Device CLI exited without calling completeWindow. Re-run the Behavior task and " +
-			"finalize via the lobu skill + CLI (preferred): " +
-			"`lobu memory exec` with client.knowledge.read({ watcher_id }) then " +
-			"client.behaviors.completeWindow({ window_token, extracted_data, behavior_run_id }). " +
-			"MCP query_sdk/run_sdk is also fine if wired. Do not only print a summary.";
 		logger.info(
 			{ run_id: runId, attempt: nextAttempt, max: budget },
 			"[completeBehaviorRun] missing completeWindow — device resume"
@@ -1177,9 +1228,10 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 			attempt: nextAttempt,
 			max_attempts: budget,
 			// Total spawns allowed = first + budget resumes.
-			// attempt is the resume index (1..budget); Mac should re-spawn now.
-			nudge,
-			error: nudge,
+			// attempt is the resume index (1..budget); Mac should re-spawn now
+			// and report back with finalize_attempt = attempt.
+			nudge: MISSING_COMPLETE_WINDOW_NUDGE,
+			error: MISSING_COMPLETE_WINDOW_NUDGE,
 		});
 	}
 

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -51,6 +51,11 @@ import {
 import { insertEvent, recordLifecycleEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
 import { stripNulDeep } from "../utils/strip-nul";
+import {
+	bumpDeviceFinalizeNudge,
+	markWatcherRunCompleted,
+	resolveFinalizeNudgeBudget,
+} from "../watchers/run-completion";
 import { advanceScheduleAfterTerminalFailure } from "../watchers/schedule-cursor";
 import { authorizeRunForWorker } from "./shared";
 
@@ -710,23 +715,23 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
  * POST /api/workers/me/runs/:runId/complete-behavior
  *
  * Device-side EXIT REPORT for a watcher run executed by a local CLI agent
- * (Claude Code, etc.) on the user's machine. The Owletto Mac app's
+ * (Claude Code, agy, etc.) on the user's machine. The Owletto Mac app's
  * `WatcherDispatcher` posts here once the subprocess exits.
  *
- * The CLI agent completes the run itself, over MCP, exactly like a
- * server-side watcher agent: `query_sdk` (`client.knowledge.read`) →
- * window_token → `run_sdk` (`client.behaviors.completeWindow`). The
- * dispatcher wires the gateway MCP server into the spawned CLI
- * (--mcp-config) and the prompt carries the completion instructions. This
- * endpoint therefore only records process exit metadata:
+ * The agent is expected to complete window Behaviors itself — via Lobu MCP
+ * tools (`query_sdk` / `run_sdk` → `completeWindow`) and/or the local
+ * `lobu` CLI (`lobu memory exec` with the same ClientSDK calls). This
+ * endpoint records process exit metadata and enforces the finalize contract:
  *
  * - body.error set → the subprocess crashed/timed out → run failed.
  * - clean exit + run already completed (by complete_window) → ack; stamp
  *   exit metadata and the window's wall-clock.
- * - clean exit + run still running → the agent never called
- *   complete_window → run FAILED. Same rule as the server-side dispatch
- *   guard (automation.ts): complete_window is the only signal that real
- *   work happened; absence of it is a failure, not a pass.
+ * - clean exit + event-turn Behavior still running → complete without a
+ *   window (turn path has no completeWindow step).
+ * - clean exit + window Behavior still running + finalize budget left →
+ *   status `resume` (run stays claimed/running; Mac re-spawns with nudge).
+ * - clean exit + window Behavior still running + budget exhausted →
+ *   failed with reason_code `missing_complete_window`.
  *
  * Authorization: the caller must own the claim — same gate as
  * /api/workers/complete (status='running' AND claimed_by === worker_id).
@@ -1063,19 +1068,124 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 		return c.json({ ok: true, status: run.status, idempotent: true });
 	}
 
-	// Clean exit but the run is still `running`: the agent never called
-	// run_sdk (client.behaviors.completeWindow). Fail closed — completeWindow is
-	// the only signal that real work happened (the same rule the server-side
-	// dispatch guard enforces in automation.ts). The stdout tail lands in
-	// runs.output_tail for diagnosis.
+	// Clean exit but the run is still `running`.
+	// Event turns complete on agent reply — no completeWindow.
+	if (approved.trigger_execution === "turn") {
+		const agentKind =
+			typeof approved.agent_kind === "string" &&
+			(approved.agent_kind as string).trim()
+				? (approved.agent_kind as string).trim()
+				: null;
+		await markWatcherRunCompleted(
+			sql,
+			runId,
+			null,
+			agentKind ? `device-cli:${agentKind}` : "device-cli"
+		);
+		await sql`
+      UPDATE runs
+      SET exit_code = ${body.exit_code ?? null},
+          exit_signal = ${body.exit_signal ?? null},
+          exit_reason = ${body.exit_reason ?? "ok"},
+          output_tail = ${output ? output.slice(-2000) : null},
+          run_metadata = CASE
+            WHEN ${durationMs}::bigint IS NULL THEN COALESCE(run_metadata, '{}'::jsonb)
+            ELSE jsonb_set(
+              COALESCE(run_metadata, '{}'::jsonb),
+              '{execution_time_ms}',
+              to_jsonb(${durationMs}::bigint)
+            )
+          END
+      WHERE id = ${runId}
+    `;
+		await sql`
+      UPDATE watchers
+      SET last_fired_at = NOW(), updated_at = NOW()
+      WHERE id = ${watcherId}
+    `;
+		emitCompletionEvent("completed");
+		return c.json({
+			ok: true,
+			status: "completed",
+			reason_code: "event_turn",
+			window_id: null,
+		});
+	}
+
+	// Window Behavior: agent never called completeWindow. Bounded device-held
+	// resume (same finalize_nudges budget as cloud) so the Mac can re-spawn.
+	const watcherRows = (await sql`
+    SELECT execution_config
+    FROM watchers
+    WHERE id = ${watcherId}
+    LIMIT 1
+  `) as unknown as Array<{
+		execution_config: Record<string, unknown> | null;
+	}>;
+	const budget = resolveFinalizeNudgeBudget(
+		watcherRows[0]?.execution_config ?? null
+	);
+	const nudgeCount = Number(approved.finalize_nudge_count ?? 0);
+	const attemptsSoFar = Number.isFinite(nudgeCount) ? nudgeCount : 0;
+	// attemptsSoFar is how many resumes already granted; next spawn is attempt+1.
+	// Budget N means N extra spawns after the first (same as cloud).
+	if (attemptsSoFar < budget) {
+		const nextAttempt = attemptsSoFar + 1;
+		const bumped = await bumpDeviceFinalizeNudge(
+			sql,
+			runId,
+			nextAttempt,
+			output ? output.slice(-2000) : null
+		);
+		if (!bumped) {
+			const finalRows = (await sql`
+        SELECT status FROM runs WHERE id = ${runId} LIMIT 1
+      `) as unknown as Array<{ status: string }>;
+			return c.json({
+				ok: true,
+				status: finalRows[0]?.status ?? "failed",
+				idempotent: true,
+			});
+		}
+		const nudge =
+			"Device CLI exited without calling completeWindow. Re-run the Behavior task and " +
+			"finalize via the lobu skill + CLI (preferred): " +
+			"`lobu memory exec` with client.knowledge.read({ watcher_id }) then " +
+			"client.behaviors.completeWindow({ window_token, extracted_data, behavior_run_id }). " +
+			"MCP query_sdk/run_sdk is also fine if wired. Do not only print a summary.";
+		logger.info(
+			{ run_id: runId, attempt: nextAttempt, max: budget },
+			"[completeBehaviorRun] missing completeWindow — device resume"
+		);
+		return c.json({
+			ok: true,
+			status: "resume",
+			reason_code: "missing_complete_window",
+			attempt: nextAttempt,
+			max_attempts: budget,
+			// Total spawns allowed = first + budget resumes.
+			// attempt is the resume index (1..budget); Mac should re-spawn now.
+			nudge,
+			error: nudge,
+		});
+	}
+
 	const reason =
-		"Device CLI exited without calling run_sdk (client.behaviors.completeWindow). " +
-		"The Behavior prompt instructs the agent to complete via the lobu MCP server — check that " +
-		"the dispatcher passed --mcp-config with query_sdk/run_sdk allowed, the gateway is reachable " +
-		"from the device, and the device token has mcp:write scope.";
+		"Device CLI exited without calling completeWindow " +
+		(budget > 0 ? `after ${budget + 1} attempt(s)` : "(finalize nudges disabled)") +
+		". Use the lobu skill + `lobu memory exec` (knowledge.read → completeWindow) " +
+		"or MCP query_sdk/run_sdk. Check lobu CLI login/org, gateway reachability, " +
+		"and that the device token has mcp:write if using MCP.";
 	await failRun(reason);
 	emitCompletionEvent("failed", reason);
-	return c.json({ ok: true, status: "failed", error: reason });
+	return c.json({
+		ok: true,
+		status: "failed",
+		reason_code: "missing_complete_window",
+		attempt: attemptsSoFar,
+		max_attempts: budget,
+		error: reason,
+	});
 }
 
 /**

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -53,7 +53,6 @@ import logger from "../utils/logger";
 import { stripNulDeep } from "../utils/strip-nul";
 import {
 	bumpDeviceFinalizeNudge,
-	markWatcherRunCompleted,
 	resolveFinalizeNudgeBudget,
 } from "../watchers/run-completion";
 import { advanceScheduleAfterTerminalFailure } from "../watchers/schedule-cursor";
@@ -719,7 +718,7 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 const MISSING_COMPLETE_WINDOW_NUDGE =
 	"Device CLI exited without calling completeWindow. Re-run the Behavior task and " +
 	"finalize via the lobu skill + CLI (preferred): " +
-	"`lobu memory exec` with client.knowledge.read({ watcher_id }) then " +
+	"`lobu memory exec` with client.knowledge.read({ behavior_id }) then " +
 	"client.behaviors.completeWindow({ window_token, extracted_data, behavior_run_id }). " +
 	"MCP query_sdk/run_sdk is also fine if wired. Do not only print a summary.";
 
@@ -789,11 +788,11 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 
 	const sql = getDb();
 	// Reload the row now that authorization has cleared. Status drives the
-	// exit-report decision; the authoritative guard against double-writes is
-	// failRun's status-filtered UPDATE, so a stale read can't double-fail —
-	// at worst it reports `idempotent: true` with the loser's view.
+	// exit-report decision; the status-and-claim predicates on the writes below
+	// remain authoritative if this read races another terminal path.
 	const runRows = (await sql`
-    SELECT id, organization_id, watcher_id, approved_input, run_type, claimed_at, status, window_id
+    SELECT id, organization_id, watcher_id, approved_input, run_type,
+           claimed_at, claimed_by, status, window_id
     FROM runs
     WHERE id = ${runId}
     LIMIT 1
@@ -804,6 +803,7 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 		approved_input: Record<string, unknown> | null;
 		run_type: string;
 		claimed_at: string | Date | null;
+		claimed_by: string | null;
 		status: string;
 		window_id: number | null;
 	}>;
@@ -814,6 +814,9 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 	}
 	if (run.watcher_id == null) {
 		return c.json({ error: "Behavior run missing watcher_id" }, 500);
+	}
+	if (run.claimed_by !== body.worker_id) {
+		return c.json({ ok: true, status: run.status, idempotent: true });
 	}
 
 	const watcherId = Number(run.watcher_id);
@@ -950,6 +953,7 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
             exit_reason = ${body.exit_reason ?? "error_message"}
         WHERE id = ${runId}
           AND status = 'running'
+          AND claimed_by = ${body.worker_id}
         RETURNING id
       `) as unknown as Array<{ id: number }>;
 			if (failedRows.length === 0) return false;
@@ -1098,16 +1102,32 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 			(approved.agent_kind as string).trim()
 				? (approved.agent_kind as string).trim()
 				: null;
-		// First-report-only: a duplicate/concurrent report finds the row already
-		// out of an active status, so it acks instead of re-stamping exit metadata
-		// and re-emitting the completion event.
-		const marked = await markWatcherRunCompleted(
-			sql,
+		const completedRows = await finalizeRun(sql, {
 			runId,
-			null,
-			agentKind ? `device-cli:${agentKind}` : "device-cli"
-		);
-		if (!marked) {
+			workerId: body.worker_id,
+			status: "completed",
+			extraSet: sql`,
+        window_id = NULL,
+        error_message = NULL,
+        model_used = COALESCE(
+          NULLIF(model_used, 'external-client'),
+          ${agentKind ? `device-cli:${agentKind}` : "device-cli"},
+          model_used
+        ),
+        exit_code = ${body.exit_code ?? null},
+        exit_signal = ${body.exit_signal ?? null},
+        exit_reason = ${body.exit_reason ?? "ok"},
+        output_tail = ${output ? output.slice(-2000) : null},
+        run_metadata = CASE
+          WHEN ${durationMs}::bigint IS NULL THEN COALESCE(run_metadata, '{}'::jsonb)
+          ELSE jsonb_set(
+            COALESCE(run_metadata, '{}'::jsonb),
+            '{execution_time_ms}',
+            to_jsonb(${durationMs}::bigint)
+          )
+        END`,
+		});
+		if (completedRows.length === 0) {
 			const finalRows = (await sql`
         SELECT status FROM runs WHERE id = ${runId} LIMIT 1
       `) as unknown as Array<{ status: string }>;
@@ -1117,22 +1137,6 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 				idempotent: true,
 			});
 		}
-		await sql`
-      UPDATE runs
-      SET exit_code = ${body.exit_code ?? null},
-          exit_signal = ${body.exit_signal ?? null},
-          exit_reason = ${body.exit_reason ?? "ok"},
-          output_tail = ${output ? output.slice(-2000) : null},
-          run_metadata = CASE
-            WHEN ${durationMs}::bigint IS NULL THEN COALESCE(run_metadata, '{}'::jsonb)
-            ELSE jsonb_set(
-              COALESCE(run_metadata, '{}'::jsonb),
-              '{execution_time_ms}',
-              to_jsonb(${durationMs}::bigint)
-            )
-          END
-      WHERE id = ${runId}
-    `;
 		await sql`
       UPDATE watchers
       SET last_fired_at = NOW(), updated_at = NOW()
@@ -1204,16 +1208,49 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 		const bumped = await bumpDeviceFinalizeNudge(
 			sql,
 			runId,
+			body.worker_id,
 			nextAttempt,
 			output ? output.slice(-2000) : null
 		);
 		if (!bumped) {
 			const finalRows = (await sql`
-        SELECT status FROM runs WHERE id = ${runId} LIMIT 1
-      `) as unknown as Array<{ status: string }>;
+        SELECT status,
+               claimed_by,
+               approved_input->>'finalize_nudge_count' AS finalize_nudge_count
+        FROM runs
+        WHERE id = ${runId}
+        LIMIT 1
+      `) as unknown as Array<{
+				status: string;
+				claimed_by: string | null;
+				finalize_nudge_count: string | null;
+			}>;
+			const final = finalRows[0];
+			const grantedAttempt = Number(final?.finalize_nudge_count);
+			// The CAS can lose to an identical concurrent report after both
+			// requests read the same count. Reconcile that committed grant into
+			// the same replayable response; returning plain `running` would make
+			// the device stop without ever receiving its nudge.
+			if (
+				final?.status === "running" &&
+				final.claimed_by === body.worker_id &&
+				Number.isFinite(grantedAttempt) &&
+				grantedAttempt > attemptsSoFar
+			) {
+				return c.json({
+					ok: true,
+					status: "resume",
+					reason_code: "missing_complete_window",
+					attempt: grantedAttempt,
+					max_attempts: budget,
+					nudge: MISSING_COMPLETE_WINDOW_NUDGE,
+					error: MISSING_COMPLETE_WINDOW_NUDGE,
+					idempotent: true,
+				});
+			}
 			return c.json({
 				ok: true,
-				status: finalRows[0]?.status ?? "failed",
+				status: final?.status ?? "failed",
 				idempotent: true,
 			});
 		}

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -1076,12 +1076,25 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 			(approved.agent_kind as string).trim()
 				? (approved.agent_kind as string).trim()
 				: null;
-		await markWatcherRunCompleted(
+		// First-report-only: a duplicate/concurrent report finds the row already
+		// out of an active status, so it acks instead of re-stamping exit metadata
+		// and re-emitting the completion event.
+		const marked = await markWatcherRunCompleted(
 			sql,
 			runId,
 			null,
 			agentKind ? `device-cli:${agentKind}` : "device-cli"
 		);
+		if (!marked) {
+			const finalRows = (await sql`
+        SELECT status FROM runs WHERE id = ${runId} LIMIT 1
+      `) as unknown as Array<{ status: string }>;
+			return c.json({
+				ok: true,
+				status: finalRows[0]?.status ?? "failed",
+				idempotent: true,
+			});
+		}
 		await sql`
       UPDATE runs
       SET exit_code = ${body.exit_code ?? null},
@@ -1176,7 +1189,17 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 		". Use the lobu skill + `lobu memory exec` (knowledge.read → completeWindow) " +
 		"or MCP query_sdk/run_sdk. Check lobu CLI login/org, gateway reachability, " +
 		"and that the device token has mcp:write if using MCP.";
-	await failRun(reason);
+	const transitioned = await failRun(reason);
+	if (!transitioned) {
+		const finalRows = (await sql`
+      SELECT status FROM runs WHERE id = ${runId} LIMIT 1
+    `) as unknown as Array<{ status: string }>;
+		return c.json({
+			ok: true,
+			status: finalRows[0]?.status ?? "failed",
+			idempotent: true,
+		});
+	}
 	emitCompletionEvent("failed", reason);
 	return c.json({
 		ok: true,


### PR DESCRIPTION
## Summary

Device `complete-behavior` exit reports for Behaviors run by a local CLI on the user's Mac.

- Window Behaviors: a clean exit without `completeWindow` grants a bounded device-held `resume` (run stays claimed/running so the Mac re-spawns) while the `finalize_nudges` budget lasts; exhausted budget → terminal fail with `reason_code: missing_complete_window`.
- Event turns complete on the agent's reply — no `completeWindow` step, so a clean exit completes the run without minting a window.
- Reports carry `finalize_attempt`, the finalize round the reporting spawn ran under. A report whose response the device never saw can be re-sent and re-serves the same grant instead of consuming the next attempt.
- Every exit-report transition is predicated on `claimed_by = worker_id`, so a report from a worker whose claim was reclaimed acks instead of mutating the run.

Ships with the Mac half via the owletto pointer bump (lobu-ai/owletto#647 resume loop + agy executor, lobu-ai/owletto#654 delivery split).

## The pi-review blocker, and the fix

The first review round blocked on exit-report delivery being non-idempotent. `WatcherDispatcher` wrapped `executor.run` and `completeBehaviorRun` in one `do`, so a POST that timed out **after** the server committed a resume landed in the executor `catch` and posted `completeWithError` — a delivery failure overwriting a decision the server had already made. Re-sending was no better: the server inferred the attempt from the stored `finalize_nudge_count`, so a replay found the budget spent and failed the run one spawn early.

Both halves changed:

- **Server**: reports carry `finalize_attempt`. When the stored count is already past it, the report was answered with a resume the device never received → re-serve that grant, consume nothing. A CAS loser (two identical reports racing past the same count read) reconciles into the grant that did commit rather than answering `running`.
- **Mac** (owletto#654): execution and delivery are separate failure domains. Executor failures stay terminal. Delivery goes through `deliverExitReport`, which re-sends the identical report and, when the outcome stays unknown, returns nil so the caller leaves the run claimed for the server's heartbeat-stale reaper instead of reporting a failure it cannot substantiate.

## Red → green

Red, before the fix — the replayed report consumed the second attempt and failed the run:

```
FAIL src/__tests__/integration/watchers/automation-contract.test.ts > replays the granted resume instead of consuming a second finalize attempt
AssertionError: expected 'failed' to be 'resume' // Object.is equality
 ❯ src/__tests__/integration/watchers/automation-contract.test.ts:1085:30
 Test Files  1 failed (1)
      Tests  1 failed | 44 skipped (45)
```

Green, after:

```
 ✓ src/__tests__/integration/watchers/automation-contract.test.ts (45 tests) 6070ms
 Test Files  1 passed (1)
      Tests  45 passed (45)
```

## Test plan

- [x] Integration: `bunx vitest run src/__tests__/integration/watchers/automation-contract.test.ts` → 45/45, including new coverage for replay idempotency, event-turn completion, and a wrong-worker report
- [x] Unit: `bun test packages/server/src/__tests__/unit/watchers/device-finalize-nudge.test.ts` → 3/3
- [x] `make pre-pr` → all 6 gates clean
- [x] Mac: `xcodebuild -scheme Owletto -configuration Debug build` → BUILD SUCCEEDED; `ExitReportDeliveryTests.swift` passes and fails under mutation (forcing the retry classifier to always-retry breaks the 403/409 cases)
- [ ] Live device: pin a Behavior, force a missing `completeWindow`, and drop the exit-report response to watch the re-send land

Note: neither `xcodebuild` nor the standalone `apps/mac/Tests/*.swift` run in PR CI — the Mac evidence above is local only.

## Also fixed while here

The nudge handed to a resumed CLI told it to call `client.knowledge.read({ watcher_id })`. The SDK takes `behavior_id` (`sandbox/namespaces/knowledge.ts:43`), so a resumed run was being given instructions that could not work.