### PR TITLE
fix(server): make DM conversations visible to the workspace owner

### DIFF
--- a/db/migrations/20260730190000_conversations_is_direct.sql
+++ b/db/migrations/20260730190000_conversations_is_direct.sql
@@ -1,0 +1,27 @@
+-- `conversations.is_direct` — is this platform conversation a 1:1 DM with the
+-- bot, rather than a group channel?
+--
+-- Why it must be stored rather than derived: platform conversation ids carry no
+-- portable DM marker. Telegram and Slack use different native id conventions,
+-- and future platforms need not encode the distinction in the id at all. The
+-- inbound delivery is the common authoritative source, so the message bridge
+-- records its surface classification on `platformMetadata`.
+--
+-- Why the read path needs it: `listAgentThreads(scope:"all")` gates platform
+-- rows on the agent's BOUND channels. Explicitly linked DMs can use that path,
+-- but an ordinary inbound DM has no binding and was therefore invisible to
+-- every requester. Group channels and bound DMs keep the membership fence;
+-- owner/admin access may bypass it only for a known DM (matching
+-- `manage_conversations.get`).
+--
+-- NULL = unknown (rows written before this column existed, and any platform
+-- that omits the hint). Unknown keeps today's fail-closed behaviour; the value
+-- fills in on the conversation's next inbound message via the upsert's COALESCE.
+
+-- migrate:up
+ALTER TABLE public.conversations
+  ADD COLUMN IF NOT EXISTS is_direct boolean;
+
+-- migrate:down
+ALTER TABLE public.conversations
+  DROP COLUMN IF EXISTS is_direct;

--- a/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
+++ b/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
@@ -33,6 +33,8 @@ const AGENT = "thread-list-scope-all-agent";
 const SLACK_CONV = "slack:C123:1781641725.28"; // channel C123 — agent is bound to it
 const SLACK_UNBOUND_CONV = "slack:CSECRET:1781641725.99"; // channel the agent is NOT bound to
 const CSECRET_CONN_RUNTIME_ID = "slackinst-csecret"; // managed connection owning CSECRET, initially no chat-link
+const TELEGRAM_DM_CONV = "telegram:6570514069"; // an unbound DM, gated on org role
+const TELEGRAM_LEGACY_CONV = "telegram:111222333"; // platform row with is_direct NULL (unknown)
 const WATCHER_ID = 990001;
 const OTHER_AGENT = "thread-list-other-agent";
 const OTHER_WATCHER_ID = 990002;
@@ -92,6 +94,7 @@ describe("listAgentThreads scope=all", () => {
 				platform: string;
 				kind: "owned" | "platform";
 				userId: string | null;
+				isDirect?: boolean | null;
 			},
 		) => {
 			const [run] = await sql<{ id: number }[]>`
@@ -107,10 +110,10 @@ describe("listAgentThreads scope=all", () => {
 				await sql`
           INSERT INTO conversations
             (organization_id, agent_id, platform, conversation_id,
-             kind, user_id, title, last_activity_at, created_at)
+             kind, user_id, title, is_direct, last_activity_at, created_at)
           VALUES (${org}, ${AGENT}, ${entity.platform},
                   ${conversationId}, ${entity.kind}, ${entity.userId}, ${text},
-                  ${at}, ${at})`;
+                  ${entity.isDirect ?? null}, ${at}, ${at})`;
 			}
 		};
 
@@ -182,6 +185,34 @@ describe("listAgentThreads scope=all", () => {
 				userId: null,
 			},
 		);
+		// A Telegram DM with no chat-link Behavior. The channel fence can only fail
+		// closed on it, so it is listable on the DM rule (owner/admin) or not at
+		// all.
+		await insertSnapshot(
+			TELEGRAM_DM_CONV,
+			"hello from telegram dm",
+			"2026-06-28T04:00:00Z",
+			{
+				platform: "telegram",
+				kind: "platform",
+				userId: "6570514069",
+				isDirect: true,
+			},
+		);
+		// A platform row predating the column: is_direct unknown. Must keep the
+		// old fail-closed behaviour rather than riding in on the DM rule.
+		await insertSnapshot(
+			TELEGRAM_LEGACY_CONV,
+			"legacy row with unknown surface",
+			"2026-06-28T04:30:00Z",
+			{
+				platform: "telegram",
+				kind: "platform",
+				userId: "999",
+				isDirect: null,
+			},
+		);
+
 		// A watcher + one of its run snapshots.
 		await sql`
       INSERT INTO watchers
@@ -250,6 +281,56 @@ describe("listAgentThreads scope=all", () => {
 
 	afterAll(async () => {
 		await cleanupTestDatabase();
+	});
+
+	it("lists an unbound DM for an owner/admin", async () => {
+		const threads = await listAgentThreads({
+			agentId: AGENT,
+			organizationId: org,
+			userId,
+			scope: "all",
+			isAdmin: true,
+		});
+		const dm = threads.find((t) => t.id === TELEGRAM_DM_CONV);
+		expect(dm).toBeDefined();
+		expect(dm?.platform).toBe("telegram");
+	});
+
+	it("hides a DM from a plain member, and hides unknown-surface rows from everyone", async () => {
+		const asMember = await listAgentThreads({
+			agentId: AGENT,
+			organizationId: org,
+			userId,
+			scope: "all",
+			isAdmin: false,
+		});
+		expect(asMember.map((t) => t.id)).not.toContain(TELEGRAM_DM_CONV);
+
+		// is_direct NULL must not ride in on the DM rule — it keeps the channel
+		// fence, which fails closed for an unbound channel.
+		const asAdmin = await listAgentThreads({
+			agentId: AGENT,
+			organizationId: org,
+			userId,
+			scope: "all",
+			isAdmin: true,
+		});
+		expect(asAdmin.map((t) => t.id)).not.toContain(TELEGRAM_LEGACY_CONV);
+		expect(asMember.map((t) => t.id)).not.toContain(TELEGRAM_LEGACY_CONV);
+	});
+
+	it("keeps the group-channel fence unchanged for an admin", async () => {
+		// Admin is the DM rule only — it must not become a blanket bypass of the
+		// channel-membership fence for group channels.
+		const threads = await listAgentThreads({
+			agentId: AGENT,
+			organizationId: org,
+			userId,
+			scope: "all",
+			isAdmin: true,
+		});
+		expect(threads.map((t) => t.id)).not.toContain(SLACK_UNBOUND_CONV);
+		expect(threads.map((t) => t.id)).toContain(SLACK_CONV);
 	});
 
 	it("returns web + platform + watcher entries with correct platforms, newest-first", async () => {
@@ -608,5 +689,71 @@ describe("listAgentThreads scope=all", () => {
 				status: "pending",
 			}),
 		]);
+	});
+});
+
+/**
+ * An EXPLICITLY bound DM (Slack Preview `/link`, claim onboarding) is the case
+ * that makes the owner/admin rule a BYPASS rather than a replacement: it is a DM
+ * (`is_direct = true`) but it does have a chat-link Behavior, so the ordinary
+ * channel fence already admits it and a plain member must keep that access.
+ *
+ * It gets its own org/agent because the shared fixture above asserts a single
+ * slack conversation and newest-first ordering; a second visible slack row there
+ * would decide those assertions instead of testing this one.
+ */
+describe("listAgentThreads scope=all — an explicitly bound DM", () => {
+	const BOUND_DM_AGENT = "thread-list-bound-dm-agent";
+	const BOUND_DM_CONV = "slack:D123:";
+	let org: string;
+	let userId: string;
+
+	beforeAll(async () => {
+		org = (await createTestOrganization()).id;
+		userId = (await createTestUser()).id;
+		await createTestAgent({
+			organizationId: org,
+			agentId: BOUND_DM_AGENT,
+			ownerUserId: userId,
+		});
+		const sql = getTestDb();
+		const connId = "conn_bound_dm";
+		await insertChatConnectionRow({
+			id: connId,
+			organizationId: org,
+			agentId: BOUND_DM_AGENT,
+			platform: "slack",
+			status: "active",
+		});
+		await createTestBehaviorSubscription({
+			organizationId: org,
+			agentId: BOUND_DM_AGENT,
+			connectionSlug: `agentconn-${connId}`,
+			platform: "slack",
+			channelId: "slack:D123",
+			teamId: "T1",
+		});
+		await sql`
+      INSERT INTO conversations
+        (organization_id, agent_id, platform, conversation_id,
+         kind, user_id, title, is_direct, last_activity_at, created_at)
+      VALUES (${org}, ${BOUND_DM_AGENT}, 'slack', ${BOUND_DM_CONV},
+              'platform', 'U123', 'hello from a bound slack dm',
+              true, '2026-06-28T02:00:00Z', '2026-06-28T02:00:00Z')`;
+	});
+
+	afterAll(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("stays visible to a plain member via the channel fence, without admin", async () => {
+		const threads = await listAgentThreads({
+			agentId: BOUND_DM_AGENT,
+			organizationId: org,
+			userId,
+			scope: "all",
+			isAdmin: false,
+		});
+		expect(threads.map((t) => t.id)).toContain(BOUND_DM_CONV);
 	});
 });

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -24,6 +24,7 @@ import { getDb } from "../../db/client.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
 import { insertEvent } from "../../utils/insert-event.js";
+import { invalidateMembershipRoleCache } from "../../workspace/multi-tenant.js";
 import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { UserAgentsStore } from "../auth/user-agents-store.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
@@ -107,6 +108,7 @@ describe("agent history routes", () => {
 
 	afterEach(() => {
 		setAuthProvider(null);
+		invalidateMembershipRoleCache(ORG_ID, USER_ID);
 	});
 
 	function createApp() {
@@ -665,6 +667,104 @@ describe("agent history routes", () => {
 				],
 			}),
 		]);
+	});
+
+	test("lists and reads an unbound DM for an org owner but not a member", async () => {
+		const sql = getDb();
+		await sql`
+			INSERT INTO "user" (
+				id, email, name, username, "emailVerified", "createdAt", "updatedAt"
+			) VALUES (
+				${USER_ID}, 'history-owner@test.example.com', 'History Owner',
+				'history-owner', true, NOW(), NOW()
+			)
+			ON CONFLICT (id) DO NOTHING
+		`;
+		await addUserToOrganization(USER_ID, ORG_ID, "owner");
+		invalidateMembershipRoleCache(ORG_ID, USER_ID);
+
+		const member = await createTestUser({ name: "DM-hidden member" });
+		await addUserToOrganization(member.id, ORG_ID, "member");
+		invalidateMembershipRoleCache(ORG_ID, member.id);
+
+		const conversationId = "telegram:6570514069";
+		const jsonl =
+			`{"type":"session","version":3,"id":"s-dm","timestamp":"2026-07-30T10:00:00Z","cwd":"/w"}\n` +
+			`{"type":"message","id":"u-dm","parentId":null,"timestamp":"2026-07-30T10:00:01Z","message":{"role":"user","content":[{"type":"text","text":"Private DM"}]}}\n`;
+		const runId = await insertRun({
+			organizationId: ORG_ID,
+			agentId: "agent-1",
+			conversationId,
+		});
+		await sql`
+			INSERT INTO public.agent_transcript_snapshot
+				(organization_id, agent_id, conversation_id, run_id, snapshot_jsonl, byte_size, terminal_status)
+			VALUES
+				(${ORG_ID}, 'agent-1', ${conversationId}, ${runId}, ${jsonl}, ${Buffer.byteLength(jsonl, "utf-8")}, 'completed')
+		`;
+		await sql`
+			INSERT INTO public.conversations
+				(organization_id, agent_id, platform, conversation_id, kind, user_id, title, is_direct, last_activity_at)
+			VALUES
+				(${ORG_ID}, 'agent-1', 'telegram', ${conversationId}, 'platform', '6570514069', 'Private DM', true, now())
+		`;
+
+		const requestAs = (
+			userId: string,
+			path: string,
+			opts?: { isAdmin?: boolean },
+		) => {
+			setAuthProvider(() => ({
+				userId,
+				platform: "external",
+				agentId: "agent-1",
+				...(opts?.isAdmin ? { isAdmin: true } : {}),
+				exp: Date.now() + 60_000,
+			}));
+			return orgContext.run({ organizationId: ORG_ID }, () =>
+				createApp().request(path, {
+					method: "GET",
+					headers: { host: "localhost" },
+				}),
+			);
+		};
+
+		const list = await requestAs(
+			USER_ID,
+			"/api/v1/agents/agent-1/history/threads?scope=all",
+		);
+		expect(list.status).toBe(200);
+		const listBody = (await list.json()) as {
+			threads: Array<{ conversationId: string }>;
+		};
+		expect(listBody.threads.map((thread) => thread.conversationId)).toContain(
+			conversationId,
+		);
+
+		const ownerRead = await requestAs(
+			USER_ID,
+			`/api/v1/agents/agent-1/history/conversations/${encodeURIComponent(conversationId)}/messages`,
+		);
+		expect(ownerRead.status).toBe(200);
+
+		const memberRead = await requestAs(
+			member.id,
+			`/api/v1/agents/agent-1/history/conversations/${encodeURIComponent(conversationId)}/messages`,
+		);
+		expect(memberRead.status).toBe(404);
+
+		const platformAdminList = await requestAs(
+			member.id,
+			"/api/v1/agents/agent-1/history/threads?scope=all",
+			{ isAdmin: true },
+		);
+		expect(platformAdminList.status).toBe(200);
+		const platformAdminBody = (await platformAdminList.json()) as {
+			threads: Array<{ conversationId: string }>;
+		};
+		expect(
+			platformAdminBody.threads.map((thread) => thread.conversationId),
+		).toContain(conversationId);
 	});
 
 	test("reads a per-org system agent's platform conversation in the ambient org, not the ownership-first org", async () => {

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -761,6 +761,29 @@ describe("MessageHandlerBridge.handleMessage — routing and unlinked chats", ()
     ).toBe(true);
   });
 
+  test("stamps authoritative directness on messages but not interaction clicks", async () => {
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      linkedBehavior: { agentId: "linked-agent" },
+    });
+    const thread = makeThread(undefined);
+
+    // A reply inside a DM thread has conversationId !== channelId. Directness
+    // comes from the inbound event type, not that threading relationship.
+    await bridge.handleMessage(thread, makeMessage(), "dm");
+    const dmPayload = enqueueMessage.mock.calls[0]?.[0] as any;
+    expect(dmPayload.platformMetadata.isDirect).toBe(true);
+
+    await bridge.ingestClick({
+      userId: "U_USER",
+      channelId: CHANNEL_ID,
+      conversationId: THREAD_ID,
+      value: "Continue",
+      thread,
+    });
+    const clickPayload = enqueueMessage.mock.calls[1]?.[0] as any;
+    expect(clickPayload.platformMetadata.isDirect).toBeUndefined();
+  });
+
   test("matching reply Behaviors fan out as independent turns with one history entry", async () => {
     const trigger = {
       kind: "event" as const,

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -1247,6 +1247,7 @@ export class MessageHandlerBridge {
             : messageId,
         messageText,
         isGroup,
+        isDirect: !isGroup,
         thread,
         teamId,
         payloadTeamId: isGroup ? channelId : platform,
@@ -1303,6 +1304,12 @@ export class MessageHandlerBridge {
     messageId: string;
     messageText: string;
     isGroup: boolean;
+    /**
+     * Authoritative inbound surface classification. Interaction clicks omit
+     * this: their conversationId/channelId relationship identifies threading,
+     * not whether the original surface was a DM or group channel.
+     */
+    isDirect?: boolean;
     thread: any;
     /**
      * Platform-native team/workspace id (Slack: team_id) carried on
@@ -1340,6 +1347,7 @@ export class MessageHandlerBridge {
       messageId,
       messageText,
       isGroup,
+      isDirect,
       thread,
       teamId,
       payloadTeamId,
@@ -1502,6 +1510,7 @@ export class MessageHandlerBridge {
           conversationHistory:
             conversationHistory.length > 0 ? conversationHistory : undefined,
           ...extraMetadata,
+          ...(typeof isDirect === "boolean" ? { isDirect } : {}),
         },
         agentOptions,
       });

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -477,6 +477,19 @@ export class MessageConsumer {
                 organizationId: data.organizationId,
               })
             : null;
+        // The inbound delivery is the common authoritative source for DM-ness:
+        // the message bridge derives `isDirect` from its delivery source and
+        // carries it on platformMetadata. Interaction clicks omit the hint
+        // because their conversationId/channelId relationship describes
+        // threading, not the original surface. Anything absent or non-boolean
+        // stores null, which the read gate treats as unknown and keeps
+        // fail-closed. Owned (web) rows are not channels at all, so they stay
+        // null.
+        const isDirectHint = data.platformMetadata?.isDirect;
+        const isDirect =
+          kind === "platform" && typeof isDirectHint === "boolean"
+            ? isDirectHint
+            : null;
         await upsertConversation({
           organizationId: data.organizationId,
           agentId: data.agentId,
@@ -486,6 +499,7 @@ export class MessageConsumer {
           kind,
           userId: data.userId,
           title: data.messageText?.slice(0, 200) || null,
+          isDirect,
           lastActivityAt: new Date(),
         });
       }

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -30,6 +30,8 @@ import {
 	readThreadMessages,
 	resolveChannelVisibility,
 } from "../../services/agent-thread-list.js";
+import { isAdminOrOwnerRole } from "../../../tools/access-control.js";
+import { getCachedMembershipRole } from "../../../workspace/multi-tenant.js";
 import { buildApiConversationId } from "../../services/api-conversation-id.js";
 import { findConversationById } from "../../services/conversations-store.js";
 import { readWatcherRunThreads } from "../../services/watcher-run-thread.js";
@@ -421,6 +423,7 @@ export function createAgentHistoryRoutes(deps: {
 		agentId: string;
 		organizationId: string | undefined;
 		userId: string;
+		isAdmin: boolean;
 	} | null> {
 		const session = await verifySettingsSession(c);
 		if (!session) return null;
@@ -437,6 +440,7 @@ export function createAgentHistoryRoutes(deps: {
 				agentId,
 				organizationId: ambientOrgId,
 				userId,
+				isAdmin: true,
 			};
 		}
 		if (session.agentId && session.agentId !== agentId) return null;
@@ -455,7 +459,12 @@ export function createAgentHistoryRoutes(deps: {
 			const authorized =
 				ownsHere || (await canUseSystemAgent(agentId, ambientOrgId, userId));
 			if (authorized) {
-				return { agentId, organizationId: ambientOrgId, userId };
+				return {
+					agentId,
+					organizationId: ambientOrgId,
+					userId,
+					isAdmin: false,
+				};
 			}
 			return null;
 		}
@@ -476,6 +485,7 @@ export function createAgentHistoryRoutes(deps: {
 			agentId,
 			organizationId: ownerOrganizations[0],
 			userId,
+			isAdmin: false,
 		};
 	}
 
@@ -637,11 +647,22 @@ export function createAgentHistoryRoutes(deps: {
 		// `?scope=all` widens the list to every conversation for the agent across
 		// platforms (Slack, Telegram, …), not just the requesting user's threads.
 		const listScope = c.req.query("scope") === "all" ? "all" : "user";
+		// DM conversations gate on explicit admin access, not channel membership.
+		// Resolve the org-role half only for the widened list; the existing
+		// platform-admin bypass is already carried on the authorized scope.
+		const isAdmin =
+			listScope === "all" && scope.organizationId
+				? scope.isAdmin ||
+					isAdminOrOwnerRole(
+						await getCachedMembershipRole(scope.organizationId, scope.userId),
+					)
+				: false;
 		const threads = await listAgentThreads({
 			agentId: scope.agentId,
 			organizationId: scope.organizationId,
 			userId: scope.userId,
 			scope: listScope,
+			isAdmin,
 		});
 		return c.json({ threads });
 	});
@@ -832,18 +853,31 @@ export function createAgentHistoryRoutes(deps: {
 				return errorResponse(c, "Conversation not found", 404);
 			}
 		} else {
-			// Platform conversations stay behind the per-agent fence ∩ per-user
-			// channel gate. The channel segment is still parsed out of the id: the
-			// `conversations` row carries no channel column, so there is nothing
-			// else to read it from.
-			const channelVis = await resolveChannelVisibility(getDb(), {
-				organizationId: scope.organizationId,
-				agentId: scope.agentId,
-				userId: scope.userId,
-				allowNotGraphed: scope.allowNotGraphed,
-			});
-			if (!isConversationVisible(conversationId, channelVis)) {
-				return errorResponse(c, "Conversation not found", 404);
+			let bypassChannelFence = false;
+			if (row?.isDirect === true) {
+				// Same DM rule the listing applies: explicit admin access can open
+				// an unbound DM. A non-admin still takes the normal channel fence so
+				// explicitly bound DMs (for example Preview `/link`) remain readable.
+				bypassChannelFence =
+					scope.isAdmin ||
+					isAdminOrOwnerRole(
+						await getCachedMembershipRole(scope.organizationId, scope.userId),
+					);
+			}
+			if (!bypassChannelFence) {
+				// Platform conversations stay behind the per-agent fence ∩ per-user
+				// channel gate. The channel segment is still parsed out of the id: the
+				// `conversations` row carries no channel column, so there is nothing
+				// else to read it from.
+				const channelVis = await resolveChannelVisibility(getDb(), {
+					organizationId: scope.organizationId,
+					agentId: scope.agentId,
+					userId: scope.userId,
+					allowNotGraphed: scope.allowNotGraphed,
+				});
+				if (!isConversationVisible(conversationId, channelVis)) {
+					return errorResponse(c, "Conversation not found", 404);
+				}
 			}
 		}
 

--- a/packages/server/src/gateway/services/agent-thread-list.ts
+++ b/packages/server/src/gateway/services/agent-thread-list.ts
@@ -163,8 +163,20 @@ export async function listAgentThreads(args: {
 	/** "user" (default): only the requesting user's app threads. "all": every
 	 *  conversation for the agent across platforms (Slack, Telegram, …). */
 	scope?: "user" | "all";
+	/**
+	 * Does the requester have admin access to this agent/org? Only consulted for
+	 * DM conversations that the normal channel-membership path cannot admit.
+	 * Defaults to false so a caller that forgets to pass it fails closed.
+	 */
+	isAdmin?: boolean;
 }): Promise<AgentThreadSummary[]> {
-	const { agentId, organizationId, userId, scope = "user" } = args;
+	const {
+		agentId,
+		organizationId,
+		userId,
+		scope = "user",
+		isAdmin = false,
+	} = args;
 	// No org → no tenant scope → nothing to list from the (org-keyed) entity.
 	if (!organizationId) return [];
 
@@ -229,7 +241,16 @@ export async function listAgentThreads(args: {
 			// is safe; the same-channel-across-two-workspaces (Grid) case is likewise
 			// handled by isConversationVisible failing closed on team ambiguity.
 			if (byKey.has(row.conversationId)) continue;
-			if (channelVis && !isConversationVisible(row.conversationId, channelVis)) {
+			// Some DMs are explicitly bound (for example Preview `/link`) and must
+			// keep the existing channel-fence path. Admin access is the safe bypass
+			// for an unbound DM, whose correspondent cannot be mapped portably to a
+			// Lobu user. `isDirect` null (unknown) also keeps the channel fence and
+			// stays fail-closed.
+			if (
+				!(row.isDirect === true && isAdmin) &&
+				channelVis &&
+				!isConversationVisible(row.conversationId, channelVis)
+			) {
 				continue;
 			}
 			byKey.set(row.conversationId, {

--- a/packages/server/src/gateway/services/conversations-store.ts
+++ b/packages/server/src/gateway/services/conversations-store.ts
@@ -51,6 +51,13 @@ export interface ConversationUpsert {
 	kind: ConversationKind;
 	userId?: string | null;
 	title?: string | null;
+	/**
+	 * Platform rows only: true for a 1:1 DM with the bot, false for a group
+	 * channel. Null = unknown (the inbound carried no hint, or the row predates
+	 * the column) and stays fail-closed in the read gate. Never derived from the
+	 * conversation id — no platform encodes DM-ness portably.
+	 */
+	isDirect?: boolean | null;
 	lastActivityAt: Date;
 }
 
@@ -75,11 +82,12 @@ export async function upsertConversation(
 		await sql`
       INSERT INTO public.conversations (
         organization_id, agent_id, platform, conversation_id, thread_id,
-        kind, user_id, title, last_activity_at
+        kind, user_id, title, is_direct, last_activity_at
       ) VALUES (
         ${row.organizationId}, ${row.agentId}, ${row.platform},
         ${row.conversationId}, ${row.threadId}, ${row.kind},
-        ${row.userId ?? null}, ${row.title ?? null}, ${row.lastActivityAt}
+        ${row.userId ?? null}, ${row.title ?? null}, ${row.isDirect ?? null},
+        ${row.lastActivityAt}
       )
       ON CONFLICT (organization_id, agent_id, platform, conversation_id)
       DO UPDATE SET
@@ -90,6 +98,10 @@ export async function upsertConversation(
         title = COALESCE(public.conversations.title, EXCLUDED.title),
         user_id = COALESCE(public.conversations.user_id, EXCLUDED.user_id),
         thread_id = COALESCE(public.conversations.thread_id, EXCLUDED.thread_id),
+        -- Same rule: a conversation does not change between DM and group, so the
+        -- first turn that knows wins. This is what backfills rows written before
+        -- the column existed — they fill in on their next inbound message.
+        is_direct = COALESCE(public.conversations.is_direct, EXCLUDED.is_direct),
         updated_at = now()
     `;
 	} catch (err) {
@@ -116,6 +128,12 @@ export interface ConversationListRow {
 	kind: ConversationKind;
 	userId: string | null;
 	title: string | null;
+	/**
+	 * Platform rows: true = 1:1 DM with the bot, false = group channel, null =
+	 * unknown. A known DM may use the owner/admin bypass; otherwise the read path
+	 * retains its channel-membership fence. Unknown stays fail-closed.
+	 */
+	isDirect: boolean | null;
 	lastActivityAt: Date;
 	createdAt: Date;
 }
@@ -147,11 +165,12 @@ export async function findConversationById(args: {
 		kind: ConversationKind;
 		user_id: string | null;
 		title: string | null;
+		is_direct: boolean | null;
 		last_activity_at: Date | null;
 		created_at: Date;
 	}>`
     SELECT platform, conversation_id, thread_id, kind, user_id, title,
-           last_activity_at, created_at
+           is_direct, last_activity_at, created_at
     FROM public.conversations
     WHERE organization_id = ${organizationId}
       AND agent_id = ${agentId}
@@ -168,6 +187,7 @@ export async function findConversationById(args: {
 		kind: r.kind,
 		userId: r.user_id,
 		title: r.title,
+		isDirect: r.is_direct,
 		lastActivityAt: r.last_activity_at ?? r.created_at,
 		createdAt: r.created_at,
 	};
@@ -188,11 +208,12 @@ export async function getConversation(args: {
 		kind: ConversationKind;
 		user_id: string | null;
 		title: string | null;
+		is_direct: boolean | null;
 		last_activity_at: Date | null;
 		created_at: Date;
 	}>`
     SELECT platform, conversation_id, thread_id, kind, user_id, title,
-           last_activity_at, created_at
+           is_direct, last_activity_at, created_at
     FROM public.conversations
     WHERE organization_id = ${organizationId}
       AND agent_id = ${agentId}
@@ -210,6 +231,7 @@ export async function getConversation(args: {
 		kind: r.kind,
 		userId: r.user_id,
 		title: r.title,
+		isDirect: r.is_direct,
 		lastActivityAt: r.last_activity_at ?? r.created_at,
 		createdAt: r.created_at,
 	};
@@ -310,11 +332,12 @@ export async function listConversations(args: {
 		kind: ConversationKind;
 		user_id: string | null;
 		title: string | null;
+		is_direct: boolean | null;
 		last_activity_at: Date | null;
 		created_at: Date;
 	}>`
     SELECT platform, conversation_id, thread_id, kind, user_id, title,
-           last_activity_at, created_at
+           is_direct, last_activity_at, created_at
     FROM public.conversations
     WHERE organization_id = ${organizationId}
       AND agent_id = ${agentId}
@@ -342,6 +365,7 @@ export async function listConversations(args: {
 		kind: r.kind,
 		userId: r.user_id,
 		title: r.title,
+		isDirect: r.is_direct,
 		lastActivityAt: r.last_activity_at ?? r.created_at,
 		createdAt: r.created_at,
 	}));


### PR DESCRIPTION
## Summary

- Telegram/Slack **DMs were invisible to every requester**, including the person in the conversation. `listAgentThreads(scope:"all")` gates platform rows on the agent's *bound channels*, and DMs are deliberately never bound (auto-materializing one would mint a Behavior row per correspondent). The fence could only ever fail closed on them — by construction, not by policy, so no ACL configuration could fix it.
- Store the surface classification rather than deriving it: platform conversation ids carry no portable DM marker, but the inbound delivery always knows. New nullable `conversations.is_direct`, written from an explicit `isDirect` the message bridge puts on `platformMetadata`.
- Owner/admin is a **bypass over** the channel fence, not a replacement — explicitly bound DMs (Preview `/link`, claim onboarding) keep reaching plain members through the normal fence. The role rule matches what `manage_conversations.get` already enforces for platform conversations.

Two things worth a reviewer's attention:

**`isDirect` is deliberately not the existing `isGroup`.** The interaction-click path derives `isGroup` from the conversationId/channelId relationship, which describes *threading*, not the original surface — reusing it would mislabel a click as a group message. That path omits the hint, so the row stores NULL and stays fail-closed.

**The read route needed the same branch.** Without it the listing hands out a row that 404s on open. Its `scope.isAdmin` is the narrower *platform*-admin flag, so the org role is resolved separately.

Existing rows backfill themselves — the upsert COALESCEs the first known value, so a conversation gains `is_direct` on its next inbound message. No id-shape heuristic backfill; that fragility is the reason the column exists. The column is nullable and additive with no `QUERYABLE_SCHEMA` change, so this is a single-release migration.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: full server vitest suite + targeted gateway `bun test`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### RED — before the fix

```
 ❯ src/__tests__/integration/agent-thread-list-scope-all.test.ts (15 tests | 1 failed)
   × lists a DM for an owner/admin, whose channel is unbound and always will be
     → expected undefined to be defined
 Tests  1 failed | 14 passed (15)
```

### GREEN — after the fix

```
 ✓ src/__tests__/integration/agent-thread-list-scope-all.test.ts (16 tests) 363ms
 Tests  16 passed (16)
```

Full server suite:

```
 Test Files  363 passed (363)
      Tests  3139 passed | 2 skipped (3141)
```

Gateway (`bun test`, added route- and bridge-level coverage):

```
packages/server/src/gateway/__tests__/agent-history-routes.test.ts    24 pass  0 fail
packages/server/src/gateway/__tests__/message-handler-bridge.test.ts  64 pass  0 fail
```

### Mutation testing

Both new rules were mutation-checked rather than assumed:

- DM gate forced to always admit → killed by 2 tests.
- Owner/admin made to *replace* the fence instead of bypassing it (the regression this shape exists to prevent) → killed by `an explicitly bound DM > stays visible to a plain member via the channel fence, without admin`.

## Notes

Prod rows carry `is_direct = NULL` until written, so an existing DM surfaces after its next inbound message rather than immediately on deploy.

Follow-up, not in this PR: the per-agent channel fence still cannot express a connection-wide binding, which is the separate `connections.agent_id` removal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->