### PR TITLE
ci(mac): run the standalone Swift tests in mac-build-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -908,12 +908,12 @@ jobs:
           fi
 
   # Standalone Swift tests + a cheap end-to-end Xcode build for the Mac app.
-  # `mac-release.yml` is workflow_dispatch only, so a rename or path move
-  # inside the owletto submodule (Mac source lives at
+  # `mac-release.yml` runs only for manual dispatches and published releases,
+  # so a rename or path move inside the owletto submodule (Mac source lives at
   # `packages/owletto/apps/mac/`) can silently break the release pipeline and
-  # only surface the next time someone triggers a release. Build-only (no
-  # archive, no signing, no notarize) is enough to prove the Xcode project +
-  # submodule layout still compose.
+  # surface only during a release. Build-only (no archive, no signing, no
+  # notarize) is enough to prove the Xcode project + submodule layout still
+  # compose.
   #
   # Runner cost is bounded by the filter job above — the macOS runner is
   # only allocated when the submodule pointer, the release workflow, the
@@ -946,14 +946,11 @@ jobs:
         if: steps.submodule.outputs.stubbed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: echo "::notice::Submodule stubbed on fork PR — skipping Mac smoke build."
 
-      # The Mac app has no XCTest target — the Xcode project carries a single
-      # `Owletto` scheme — so `apps/mac/Tests/*.swift` are standalone @main
-      # executables that nothing discovers on its own. Before this step they
-      # ran only when someone pasted the swiftc line out of a file header,
-      # which is how the WatcherDecodingTests header went unbuildable for
-      # weeks. The runner compiles and runs all of them in ~15s, so it is
-      # nearly free next to the Xcode build below — and it runs first because
-      # a failure here is far more informative than a link error there.
+      # The Mac app has no XCTest target, so xcodebuild does not discover the
+      # standalone @main tests under apps/mac/Tests — before this step they ran
+      # only when someone pasted a swiftc line out of a file header, which is
+      # how WatcherDecodingTests stopped compiling on 2026-07-05 and stayed
+      # broken. Runs before the app build so a failure names the assertion.
       - name: Run standalone Swift tests
         if: steps.submodule.outputs.stubbed != 'true'
         run: packages/owletto/apps/mac/Tests/run-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -900,7 +900,7 @@ jobs:
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if echo "$changed" | grep -E '^(packages/owletto($|/)|\.github/workflows/mac-release\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
+          if echo "$changed" | grep -E '^(packages/owletto($|/)|\.github/workflows/mac-release\.yml$|\.github/workflows/ci\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -916,8 +916,9 @@ jobs:
   # compose.
   #
   # Runner cost is bounded by the filter job above — the macOS runner is
-  # only allocated when the submodule pointer, the release workflow, the
-  # submodule setup action, or `.gitmodules` changes.
+  # only allocated when the submodule pointer, the release workflow, this
+  # workflow, the submodule setup action, or `.gitmodules` changes. This
+  # workflow is in the filter so a PR editing this job can't skip it.
   mac-build-smoke:
     needs: mac-build-smoke-filter
     if: needs.mac-build-smoke-filter.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -907,12 +907,13 @@ jobs:
             echo "::notice::No paths affecting the Mac build changed — skipping mac-build-smoke."
           fi
 
-  # Cheap end-to-end Xcode build for the Mac app. `mac-release.yml` is
-  # workflow_dispatch only, so a rename or path move inside the owletto
-  # submodule (Mac source lives at `packages/owletto/apps/mac/`) can silently
-  # break the release pipeline and only surface the next time someone
-  # triggers a release. Build-only (no archive, no signing, no notarize)
-  # is enough to prove the Xcode project + submodule layout still compose.
+  # Standalone Swift tests + a cheap end-to-end Xcode build for the Mac app.
+  # `mac-release.yml` is workflow_dispatch only, so a rename or path move
+  # inside the owletto submodule (Mac source lives at
+  # `packages/owletto/apps/mac/`) can silently break the release pipeline and
+  # only surface the next time someone triggers a release. Build-only (no
+  # archive, no signing, no notarize) is enough to prove the Xcode project +
+  # submodule layout still compose.
   #
   # Runner cost is bounded by the filter job above — the macOS runner is
   # only allocated when the submodule pointer, the release workflow, the
@@ -944,6 +945,18 @@ jobs:
       - name: Skip on fork PRs without submodule access
         if: steps.submodule.outputs.stubbed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: echo "::notice::Submodule stubbed on fork PR — skipping Mac smoke build."
+
+      # The Mac app has no XCTest target — the Xcode project carries a single
+      # `Owletto` scheme — so `apps/mac/Tests/*.swift` are standalone @main
+      # executables that nothing discovers on its own. Before this step they
+      # ran only when someone pasted the swiftc line out of a file header,
+      # which is how the WatcherDecodingTests header went unbuildable for
+      # weeks. The runner compiles and runs all of them in ~15s, so it is
+      # nearly free next to the Xcode build below — and it runs first because
+      # a failure here is far more informative than a link error there.
+      - name: Run standalone Swift tests
+        if: steps.submodule.outputs.stubbed != 'true'
+        run: packages/owletto/apps/mac/Tests/run-tests.sh
 
       - name: Build (unsigned, no archive)
         if: steps.submodule.outputs.stubbed != 'true'


### PR DESCRIPTION
## What

Wires `apps/mac/Tests/run-tests.sh` (owletto#658) into the existing `mac-build-smoke` job, and bumps the submodule pointer to pick it up along with owletto#659.

## Why

The Mac app has no XCTest target — `Owletto.xcodeproj` carries a single `Owletto` scheme — so every test under `apps/mac/Tests/` is a self-contained `@main` executable that compiles the production sources it exercises and nothing else. Nine of them existed and **none ran in CI**. They ran only when a human pasted the swiftc line out of a file header.

That included the two added this week to guard the device finalize loop — the code that decides durable delivery state for a Behavior run, where the failure modes are re-spawning a CLI the server didn't ask for, burning a finalize attempt on a retry, or answering an ambiguous delivery with a fabricated outcome.

## It found the drift immediately

`WatcherDecodingTests` has been unbuildable since 2026-07-05, when `LobuClient.swift` grew a `DeviceConnectorManifests` reference:

```
apps/mac/Owletto/LobuClient.swift:554:38: error: cannot find 'DeviceConnectorManifests' in scope
FAIL (build): WatcherDecodingTests
```

Three and a half weeks with the test pinning Behavior-id decoding across gateway shapes (string vs number, `behavior_id` vs `watcher_id`) silently not compiling. Header fixed in owletto#658.

## Cost

The job already allocates a macOS runner under exactly the right path filter (submodule pointer, `mac-release.yml`, the submodule action, `.gitmodules`), so the marginal cost is ~15s on a job already paying for an Xcode build. The tests run *before* the build so a failure names the assertion rather than surfacing as a link error.

## Submodule

`packages/owletto` → `2dbe678c`, picking up:
- owletto#658 — the runner + the `WatcherDecodingTests` header fix
- owletto#659 — comment explaining why the finalize safety cap may report a terminal failure without violating the ambiguous-delivery rule (comment only, no behaviour change)

## Evidence

Exact CI invocation, from the lobu checkout root:

```
$ packages/owletto/apps/mac/Tests/run-tests.sh
AnyEncodableTests: all checks passed
BinaryResolutionTests: all checks passed
CompleteBehaviorResponseTests: all checks passed
DispatcherResumeTests: all checks passed
ExitReportDeliveryTests: all checks passed
StreamBatchingTests: all checks passed
TurnPromptTests: all checks passed
WatcherDecodingTests: all checks passed
WhatsAppCursorTests: all checks passed

Swift standalone tests: 9 passed, 0 failed
exit=0
```

The runner is a test harness, so its guards were mutation-tested — each fires (detail in owletto#658).

`make pre-pr`: clean, all 6 gates, re-run on the settled tree after the submodule pointer moved.

## Note

`mac-build-smoke` is **not** in the required-check list, so this reports on mac-affecting PRs but does not block merge. Adding it is a branch-protection change and therefore a separate, explicit decision.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a standalone Swift test phase to macOS build validation.
  * Tests are skipped when the macOS component is unavailable.

* **Documentation**
  * Clarified that macOS CI performs build-only Xcode validation without archiving, signing, or notarization.

* **Chores**
  * Updated the referenced macOS component revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->