### PR TITLE
feat(server): pin Behavior skills as version snapshots and deliver them as files

### DIFF
--- a/db/migrations/20260730210000_watcher_versions_skills.sql
+++ b/db/migrations/20260730210000_watcher_versions_skills.sql
@@ -1,0 +1,35 @@
+-- `watcher_versions.skills` — the agent skills this Behavior version was built
+-- from, pinned as `[{name, content}]` at save time.
+--
+-- Why the content is stored and not just the name: a Behavior version is a
+-- freeze. `prompt` already froze the instruction text by concatenating the
+-- referenced skill bodies, so the bytes were always here — just flattened into
+-- one blob with the seams thrown away. Keeping the array decomposed stores the
+-- same content while preserving which skill each part came from, which is what
+-- makes three things possible that the blob could not:
+--
+--   1. Diff + upgrade. The editor can compare a pinned snapshot against the
+--      agent's current skill body and offer to take the change. With only the
+--      concatenated text there is nothing to diff against, so a skill edit was
+--      silently invisible to every Behavior already using it.
+--   2. Device dispatch. `worker-api/poll.ts` ships instructions to a device CLI
+--      that has no channel back to the skill library, so it needs self-contained
+--      content. A name-only reference would strand it.
+--   3. Run reproducibility. The run is pinned to a version; the version now
+--      pins exactly which skill text it ran, not merely which names.
+--
+-- Why NULL rather than a `'[]'` default: NULL means "written before this column
+-- existed", i.e. a version whose instructions live wholly in `prompt`. An empty
+-- array means "authored with skills, and there are none" — a real, different
+-- state once the composer starts writing this column. Collapsing the two would
+-- lose the ability to tell a legacy row from a deliberately skill-less one, and
+-- the read paths need that distinction to decide whether `prompt` is the whole
+-- instruction or just the task statement.
+--
+-- Nullable add with no default and no backfill: rewrite-free, so it takes only
+-- a brief ACCESS EXCLUSIVE lock to update the catalog.
+ALTER TABLE watcher_versions
+  ADD COLUMN IF NOT EXISTS skills jsonb;
+
+COMMENT ON COLUMN watcher_versions.skills IS
+  'Pinned agent-skill snapshots for this version: [{name, content}], ordered. NULL = pre-column version whose instructions live entirely in prompt; [] = authored with skills and none selected.';

--- a/db/migrations/20260730220000_watcher_versions_skills.sql
+++ b/db/migrations/20260730220000_watcher_versions_skills.sql
@@ -8,10 +8,9 @@
 -- same content while preserving which skill each part came from, which is what
 -- makes three things possible that the blob could not:
 --
---   1. Diff + upgrade. The editor can compare a pinned snapshot against the
---      agent's current skill body and offer to take the change. With only the
---      concatenated text there is nothing to diff against, so a skill edit was
---      silently invisible to every Behavior already using it.
+--   1. Diff + upgrade. A client can compare a pinned snapshot against the
+--      agent's current skill body and publish the newer text explicitly. With
+--      only the concatenated text there is nothing reliable to compare by name.
 --   2. Device dispatch. `worker-api/poll.ts` ships instructions to a device CLI
 --      that has no channel back to the skill library, so it needs self-contained
 --      content. A name-only reference would strand it.
@@ -20,11 +19,9 @@
 --
 -- Why NULL rather than a `'[]'` default: NULL means "written before this column
 -- existed", i.e. a version whose instructions live wholly in `prompt`. An empty
--- array means "authored with skills, and there are none" — a real, different
--- state once the composer starts writing this column. Collapsing the two would
--- lose the ability to tell a legacy row from a deliberately skill-less one, and
--- the read paths need that distinction to decide whether `prompt` is the whole
--- instruction or just the task statement.
+-- array means "authored after snapshot support, with no pinned skills." Keeping
+-- the provenance costs nothing and avoids rewriting every historical version;
+-- both shapes remain executable because legacy instructions stay in `prompt`.
 --
 -- Nullable add with no default and no backfill: rewrite-free, so it takes only
 -- a brief ACCESS EXCLUSIVE lock to update the catalog.

--- a/db/migrations/20260730220000_watcher_versions_skills.sql
+++ b/db/migrations/20260730220000_watcher_versions_skills.sql
@@ -25,8 +25,13 @@
 --
 -- Nullable add with no default and no backfill: rewrite-free, so it takes only
 -- a brief ACCESS EXCLUSIVE lock to update the catalog.
+-- migrate:up
 ALTER TABLE watcher_versions
   ADD COLUMN IF NOT EXISTS skills jsonb;
 
 COMMENT ON COLUMN watcher_versions.skills IS
   'Pinned agent-skill snapshots for this version: [{name, content}], ordered. NULL = pre-column version whose instructions live entirely in prompt; [] = authored with skills and none selected.';
+
+-- migrate:down
+ALTER TABLE watcher_versions
+  DROP COLUMN IF EXISTS skills;

--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -336,6 +336,82 @@ describe("executePlan — atomic Behavior triggers+prompt update", () => {
       triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
     });
   });
+
+  test("sends simultaneous skills+trigger drift through createBehaviorVersion only", async () => {
+    const desired = {
+      slug: "skills-digest",
+      agent: "triage",
+      prompt: "",
+      skillSnapshots: [
+        { name: "digest-runbook", content: "Produce the scheduled digest." },
+      ],
+      triggers: [{ kind: "schedule" as const, cron: "0 9 * * *" }],
+    };
+    const state = stateWith({
+      definitions: [],
+      authProfiles: [],
+      connections: [],
+    });
+    state.watchers = [desired];
+    const plan: DiffPlan = {
+      rows: [
+        {
+          kind: "watcher",
+          verb: "update",
+          id: desired.slug,
+          desired,
+          changedFields: ["triggers", "skills"],
+          versionBoundFields: ["skills"],
+        },
+      ],
+      counts: { create: 0, update: 1, noop: 0, drift: 0, delete: 0 },
+      notes: [],
+    };
+    const remote: RemoteSnapshot = {
+      agents: [],
+      agentSettings: new Map(),
+      entityTypes: [],
+      relationshipTypes: [],
+      watchers: [
+        {
+          slug: desired.slug,
+          behavior_id: "43",
+          agent_id: "triage",
+          prompt: "",
+          skills: null,
+          triggers: [
+            {
+              kind: "event",
+              connector_key: "slack",
+              event_types: ["message.created"],
+              execution: "turn",
+            },
+          ],
+        },
+      ],
+      connectorDefinitions: [],
+      authProfiles: [],
+      connections: [],
+      feedsByConnectionId: new Map(),
+      inferenceProviders: [],
+    };
+    const updateBehavior = mock(async () => ({}));
+    const createBehaviorVersion = mock(async () => ({ version: 2 }));
+    const client = {
+      updateBehavior,
+      createBehaviorVersion,
+    } as unknown as ApplyClient;
+
+    await executePlan({ client, state, plan, remote }, []);
+
+    expect(updateBehavior).not.toHaveBeenCalled();
+    expect(createBehaviorVersion).toHaveBeenCalledTimes(1);
+    expect(createBehaviorVersion.mock.calls[0]?.[0]).toMatchObject({
+      behavior_id: "43",
+      skills: desired.skillSnapshots,
+      triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+    });
+  });
 });
 
 describe("normalizeConnectionConfigScope — feed-scoped keys demote to feeds", () => {

--- a/packages/cli/src/commands/_lib/apply/__tests__/load-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/load-config.test.ts
@@ -545,9 +545,16 @@ describe("loadDesiredStateFromConfig", () => {
     await expect(
       write(`defineSkill({ name: "empty", content: "  " })`, `"empty"`)
     ).rejects.toThrow(/body is empty/);
+    rmSync(dir, { recursive: true, force: true });
+    await expect(
+      write(
+        `defineSkill({ name: "unsafe/name", content: "x" })`,
+        `"unsafe/name"`
+      )
+    ).rejects.toThrow(/names may contain only/);
   });
 
-  test("rejects compiled instructions over the 32KB cap", async () => {
+  test("rejects pinned skill text over the 32KB cap", async () => {
     dir = mkdtempSync(join(import.meta.dir, "cap-"));
     writeFileSync(
       join(dir, "lobu.config.ts"),

--- a/packages/cli/src/commands/_lib/apply/__tests__/load-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/load-config.test.ts
@@ -471,7 +471,7 @@ describe("loadDesiredStateFromConfig", () => {
     );
   });
 
-  test("compiles Behavior skills[] into prompt: ordered join, content-only", async () => {
+  test("pins Behavior skills[] as ordered {name, content} snapshots, leaving prompt alone", async () => {
     dir = mkdtempSync(join(import.meta.dir, "compile-"));
     writeFileSync(
       join(dir, "lobu.config.ts"),
@@ -482,15 +482,44 @@ describe("loadDesiredStateFromConfig", () => {
         `  defineSkill({ name: "style", description: "d2", content: "Style rules." }),`,
         `] });`,
         `export default defineConfig({ agents: [a], behaviors: [`,
-        `  defineBehavior({ agent: a, slug: "w", skills: ["style", "triage"] }),`,
+        `  defineBehavior({ agent: a, slug: "w", prompt: "Do the thing.", skills: ["style", "triage"] }),`,
         `] });`,
         ``,
       ].join("\n")
     );
     const { state } = await loadDesiredStateFromConfig({ cwd: dir });
-    // Join follows the Behavior's order, not the library's; descriptions do
-    // not compile (a description-only skill edit must not churn versions).
-    expect(state.watchers[0]?.prompt).toBe("Style rules.\n\nTriage rules.");
+    // Order follows the Behavior's list, not the library's. Descriptions are
+    // not part of the snapshot, so a description-only skill edit must not churn
+    // versions.
+    expect(state.watchers[0]?.skillSnapshots).toEqual([
+      { name: "style", content: "Style rules." },
+      { name: "triage", content: "Triage rules." },
+    ]);
+    // The task statement is the author's and is NOT overwritten by the skill
+    // bodies — that conflation is what #2320's follow-up removed.
+    expect(state.watchers[0]?.prompt).toBe("Do the thing.");
+  });
+
+  test("a skills-only Behavior keeps an empty prompt rather than inheriting skill text", async () => {
+    dir = mkdtempSync(join(import.meta.dir, "skillsonly-"));
+    writeFileSync(
+      join(dir, "lobu.config.ts"),
+      [
+        `import { defineAgent, defineConfig, defineBehavior, defineSkill } from "@lobu/cli/config";`,
+        `const a = defineAgent({ id: "a", skills: [`,
+        `  defineSkill({ name: "triage", content: "Triage rules." }),`,
+        `] });`,
+        `export default defineConfig({ agents: [a], behaviors: [`,
+        `  defineBehavior({ agent: a, slug: "w", skills: ["triage"] }),`,
+        `] });`,
+        ``,
+      ].join("\n")
+    );
+    const { state } = await loadDesiredStateFromConfig({ cwd: dir });
+    expect(state.watchers[0]?.prompt).toBe("");
+    expect(state.watchers[0]?.skillSnapshots).toEqual([
+      { name: "triage", content: "Triage rules." },
+    ]);
   });
 
   test("rejects a Behavior skill that is missing or has an empty body", async () => {

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -901,7 +901,7 @@ describe("mapProjectToDesiredState", () => {
     const state = mapProjectToDesiredState(
       defineConfig({ agents: [crm], behaviors: [listen, packs] })
     );
-    // The mapper cannot read skill files — prompt is compiled by the loader.
+    // The mapper cannot read skill files — the loader resolves their snapshots.
     expect(state.watchers[0]?.prompt).toBe("");
     expect(state.watchers[0]?.skills).toBeUndefined();
     expect(state.watchers[1]?.skills).toEqual(["triage", "sql-style"]);

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -819,7 +819,7 @@ describe("mapProjectToDesiredState", () => {
     ).toThrow(/more than one schedule trigger/i);
   });
 
-  test("requires >=1 skill for schedule, window-event, and manual Behaviors", () => {
+  test("requires prompt OR >=1 skill for schedule, window-event, and manual Behaviors", () => {
     const crm = defineAgent({ id: "crm" });
     const map = (behavior: ReturnType<typeof defineBehavior>) => () =>
       mapProjectToDesiredState(
@@ -834,7 +834,7 @@ describe("mapProjectToDesiredState", () => {
           triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
         })
       )
-    ).toThrow(/needs at least one skill/i);
+    ).toThrow(/needs instructions/i);
     // Event trigger with execution "window", no skills → rejected.
     expect(
       map(
@@ -851,11 +851,24 @@ describe("mapProjectToDesiredState", () => {
           ],
         })
       )
-    ).toThrow(/needs at least one skill/i);
+    ).toThrow(/needs instructions/i);
     // No triggers (manual-only), no skills → rejected.
     expect(map(defineBehavior({ agent: crm, slug: "manual" }))).toThrow(
-      /needs at least one skill/i
+      /needs instructions/i
     );
+    // EITHER source satisfies the rule on its own: a prompt with no skills is a
+    // valid schedule Behavior, and demanding both would reject configs the
+    // server accepts.
+    expect(
+      map(
+        defineBehavior({
+          agent: crm,
+          slug: "prompt-only",
+          prompt: "Summarise yesterday's signups.",
+          triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+        })
+      )
+    ).not.toThrow();
   });
 
   test("event-turn Behaviors may omit skills; mapper carries skills + empty prompt", () => {

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -854,6 +854,7 @@ export async function executePlan(
           name: w.name,
           description: w.description,
           prompt: w.prompt,
+          ...(w.skillSnapshots?.length ? { skills: w.skillSnapshots } : {}),
           triggers: w.triggers,
           sources: w.sources,
           reactions_guidance: w.reactionsGuidance,
@@ -936,6 +937,9 @@ export async function executePlan(
           await ctx.client.createBehaviorVersion({
             behavior_id: watcherId,
             ...(versionBound.has("prompt") ? { prompt: w.prompt } : {}),
+            ...(versionBound.has("skills")
+              ? { skills: w.skillSnapshots ?? [] }
+              : {}),
             ...(versionBound.has("sources") && w.sources !== undefined
               ? { sources: w.sources }
               : {}),

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -882,13 +882,14 @@ export async function executePlan(
         const scalarChanges = [...changed].filter(
           (f) => !versionBound.has(f) && f !== "reaction_script"
         );
-        // When triggers and compiled instructions both change, send them
-        // together through create_version so the server validates the final
-        // pair atomically. A separate update(triggers) would reject
-        // event-turn → schedule mid-apply (empty current prompt + new shape).
-        const triggersWithPrompt =
-          scalarChanges.includes("triggers") && versionBound.has("prompt");
-        const scalarForUpdate = triggersWithPrompt
+        // When triggers and either versioned instruction source change, send
+        // them together through create_version so the server validates the
+        // final set atomically. A separate update(triggers) would reject an
+        // event-turn → schedule transition before the new prompt/skills land.
+        const triggersWithInstructions =
+          scalarChanges.includes("triggers") &&
+          (versionBound.has("prompt") || versionBound.has("skills"));
+        const scalarForUpdate = triggersWithInstructions
           ? scalarChanges.filter((f) => f !== "triggers")
           : scalarChanges;
         // a) Scalar fields → manage_behaviors update
@@ -932,7 +933,7 @@ export async function executePlan(
         //    send the desired-side values for the changed keys).
         if (
           (row.versionBoundFields && row.versionBoundFields.length > 0) ||
-          triggersWithPrompt
+          triggersWithInstructions
         ) {
           await ctx.client.createBehaviorVersion({
             behavior_id: watcherId,
@@ -954,7 +955,7 @@ export async function executePlan(
             ...(versionBound.has("classifiers") && w.classifiers !== undefined
               ? { classifiers: w.classifiers }
               : {}),
-            ...(triggersWithPrompt ? { triggers: w.triggers ?? [] } : {}),
+            ...(triggersWithInstructions ? { triggers: w.triggers ?? [] } : {}),
           });
         }
       }

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -127,6 +127,12 @@ export interface RemoteBehavior {
   // include_details=true → version-bound fields
   description?: string | null;
   prompt?: string | null;
+  /**
+   * Pinned skill snapshots on the current version. NULL/absent on Behaviors
+   * created before the column existed, which the diff treats as "no skills" —
+   * so the first re-apply of a config that references skills pins them.
+   */
+  skills?: Array<{ name: string; content: string }> | null;
   classifiers?: unknown[] | null;
   keying_config?: Record<string, unknown> | null;
   reactions_guidance?: string | null;
@@ -894,6 +900,7 @@ export class ApplyClient {
     name?: string;
     description?: string;
     prompt: string;
+    skills?: Array<{ name: string; content: string }>;
     triggers?: import("@lobu/core/contracts/tools/manage-behaviors").BehaviorTrigger[];
     sources?: BehaviorSource[];
     reactions_guidance?: string;
@@ -917,6 +924,7 @@ export class ApplyClient {
         ...(payload.name ? { name: payload.name } : {}),
         ...(payload.description ? { description: payload.description } : {}),
         prompt: payload.prompt,
+        ...(payload.skills?.length ? { skills: payload.skills } : {}),
         ...(payload.triggers !== undefined
           ? { triggers: payload.triggers }
           : {}),
@@ -1010,6 +1018,7 @@ export class ApplyClient {
   async createBehaviorVersion(payload: {
     behavior_id: string;
     prompt?: string;
+    skills?: Array<{ name: string; content: string }>;
     sources?: BehaviorSource[];
     keying_config?: Record<string, unknown>;
     classifiers?: unknown[];
@@ -1026,6 +1035,7 @@ export class ApplyClient {
         behavior_id: payload.behavior_id,
         set_as_current: true,
         ...(payload.prompt !== undefined ? { prompt: payload.prompt } : {}),
+        ...(payload.skills !== undefined ? { skills: payload.skills } : {}),
         ...(payload.sources !== undefined ? { sources: payload.sources } : {}),
         ...(payload.keying_config !== undefined
           ? { keying_config: payload.keying_config }

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -433,16 +433,14 @@ async function resolveSkill(
   });
 }
 
-/** Byte cap on a Behavior's compiled instruction text (issue #2320). */
+/** Byte cap on the skill snapshots pinned to one Behavior version (issue #2320). */
 const MAX_COMPILED_INSTRUCTIONS_BYTES = 32 * 1024;
 
 /**
- * Compile a Behavior's ordered `skills[]` into its frozen instruction text:
- * the referenced skill bodies joined in order with a blank line. Fails loud on
- * a name the owning agent's skill library doesn't declare, an empty body, or
- * a compiled text over {@link MAX_COMPILED_INSTRUCTIONS_BYTES}. Returns "" for
- * a Behavior with no skills (event-turn only — the mapper already rejected
- * every other trigger shape without skills).
+ * Resolve a Behavior's ordered `skills[]` into frozen `{name, content}`
+ * snapshots. Fails loud on a name the owning agent's library does not declare,
+ * a name the worker cannot materialize safely, an empty body, or a total payload
+ * over {@link MAX_COMPILED_INSTRUCTIONS_BYTES}.
  */
 function resolveBehaviorSkills(
   watcher: DesiredWatcher,
@@ -452,6 +450,11 @@ function resolveBehaviorSkills(
   if (names.length === 0) return [];
   const byName = new Map(agentSkills.map((skill) => [skill.name, skill]));
   const resolved = names.map((name) => {
+    if (!/^[a-zA-Z0-9._-]+$/.test(name)) {
+      throw new ValidationError(
+        `Behavior "${watcher.slug}" cannot pin skill "${name}" — names may contain only letters, numbers, ".", "_", and "-"`
+      );
+    }
     const skill = byName.get(name);
     if (!skill) {
       throw new ValidationError(

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -97,18 +97,24 @@ export interface DesiredWatcher {
   description?: string;
   triggers?: DesiredBehaviorTrigger[];
   /**
-   * Compiled instructions — the join of the referenced skill bodies in order,
-   * produced by `compileBehaviorInstructions` at load time. This is what the
-   * server stores as the version's frozen instruction text (the internal
-   * `prompt` column); it is not author-facing. Empty only for event-turn
-   * Behaviors with no skills (the server-side default applies at run time).
+   * The Behavior's task statement, authored via `defineBehavior({ prompt })`.
+   * Stored as the version's frozen instruction text (the internal `prompt`
+   * column). Empty when the Behavior's whole job is its skills, or when an
+   * event-turn Behavior relies on the server-side default at run time.
    */
   prompt: string;
   /**
-   * Ordered skill names (declarative apply input only — resolved against the
-   * owning agent's skill library at load time, never sent to the server).
+   * Ordered skill names as written in config — the authoring input, resolved
+   * into {@link DesiredWatcher.skillSnapshots} at load time.
    */
   skills?: string[];
+  /**
+   * The resolved `{name, content}` pairs actually sent to the server and pinned
+   * onto the version. Separate from `skills` because the diff must compare
+   * BODIES, not names: editing a skill's text changes nothing about the name
+   * list, and a name-only diff would let a re-apply silently skip the update.
+   */
+  skillSnapshots?: Array<{ name: string; content: string }>;
   /** Optional SQL data sources; server applies a default when omitted. */
   sources?: BehaviorSource[];
   /**
@@ -438,14 +444,14 @@ const MAX_COMPILED_INSTRUCTIONS_BYTES = 32 * 1024;
  * a Behavior with no skills (event-turn only — the mapper already rejected
  * every other trigger shape without skills).
  */
-function compileBehaviorInstructions(
+function resolveBehaviorSkills(
   watcher: DesiredWatcher,
   agentSkills: SkillConfigEntry[]
-): string {
+): Array<{ name: string; content: string }> {
   const names = watcher.skills ?? [];
-  if (names.length === 0) return "";
+  if (names.length === 0) return [];
   const byName = new Map(agentSkills.map((skill) => [skill.name, skill]));
-  const bodies = names.map((name) => {
+  const resolved = names.map((name) => {
     const skill = byName.get(name);
     if (!skill) {
       throw new ValidationError(
@@ -455,19 +461,24 @@ function compileBehaviorInstructions(
     const body = skill.content?.trim();
     if (!body) {
       throw new ValidationError(
-        `Behavior "${watcher.slug}" references skill "${name}", but its body is empty — compiled Behavior instructions need text`
+        `Behavior "${watcher.slug}" references skill "${name}", but its body is empty — a pinned skill needs text`
       );
     }
-    return body;
+    return { name, content: body };
   });
-  const compiled = bodies.join("\n\n");
-  const bytes = Buffer.byteLength(compiled, "utf8");
+  // The cap is on total pinned text, not on any one skill: the whole set is
+  // written into the worker's `.skills/` tree and, for a device-pinned Behavior,
+  // shipped in the dispatch payload.
+  const bytes = resolved.reduce(
+    (total, skill) => total + Buffer.byteLength(skill.content, "utf8"),
+    0
+  );
   if (bytes > MAX_COMPILED_INSTRUCTIONS_BYTES) {
     throw new ValidationError(
-      `Behavior "${watcher.slug}" compiles to ${bytes} bytes of instructions — the maximum is ${MAX_COMPILED_INSTRUCTIONS_BYTES} (${MAX_COMPILED_INSTRUCTIONS_BYTES / 1024}KB)`
+      `Behavior "${watcher.slug}" pins ${bytes} bytes of skill text — the maximum is ${MAX_COMPILED_INSTRUCTIONS_BYTES} (${MAX_COMPILED_INSTRUCTIONS_BYTES / 1024}KB)`
     );
   }
-  return compiled;
+  return resolved;
 }
 
 /**
@@ -1076,12 +1087,15 @@ export async function loadDesiredStateFromConfig(
     })
   );
 
-  // Compile each Behavior's `skills[]` into its frozen instruction text — the
-  // join of the referenced skill bodies in order. This happens BEFORE the diff
-  // reads `prompt`, so compiled-text equality (content only — descriptions
-  // don't compile) is what drives version churn.
+  // Resolve each Behavior's `skills[]` to {name, content} snapshots against the
+  // owning agent's library. This happens BEFORE the diff reads them, so a change
+  // to a referenced skill's BODY still drives version churn — re-applying is how
+  // a config project takes a skill update, and the diff is what notices.
+  //
+  // The bodies are no longer folded into `prompt`: the prompt is the author's
+  // task statement (or empty), and skills ride alongside as pinned files.
   for (const watcher of state.watchers) {
-    watcher.prompt = compileBehaviorInstructions(
+    watcher.skillSnapshots = resolveBehaviorSkills(
       watcher,
       skillsByAgentId.get(watcher.agent) ?? []
     );

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -533,6 +533,16 @@ function diffWatcher(
   if (desired.prompt !== (remote.prompt ?? "")) {
     versionBound.push("prompt");
   }
+  // Compare the resolved snapshots, not the config's name list. Editing a
+  // SKILL.md changes no name, so a name-level diff would report "no changes"
+  // and leave every Behavior pinned to the old body — re-apply is how a config
+  // project takes a skill update, and this comparison is what makes it land.
+  if (
+    desired.skillSnapshots !== undefined &&
+    !deepEqual(desired.skillSnapshots, remote.skills ?? [])
+  ) {
+    versionBound.push("skills");
+  }
   // Sources live on the watchers row but are written as part of create_version
   // when changed (server copies them to the version's per-assignment scope).
   // Diff against `remote.sources` (also from the row) and route through

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -532,9 +532,9 @@ const MAX_BEHAVIOR_SKILLS = 5;
  * (manual runs) — runs on its compiled instructions alone and must reference
  * at least one skill.
  *
- * This CLI preflight mirrors the server rule on the stored instruction text
- * (the server cannot see `skills[]`, a declarative-only concept). When both
- * triggers and compiled instructions change, apply sends them together through
+ * This CLI preflight mirrors the server rule, catching the error against the
+ * config file (naming the slug) rather than as a 422 mid-apply. When both
+ * triggers and instructions change, apply sends them together through
  * create_version so the final pair is validated atomically.
  */
 function assertBehaviorSkills(watcher: DesiredWatcher): void {
@@ -556,9 +556,13 @@ function assertBehaviorSkills(watcher: DesiredWatcher): void {
     triggers.some(
       (trigger) => trigger.kind === "schedule" || trigger.execution === "window"
     );
-  if (requiresSkills && skills.length === 0) {
+  // Either instruction source satisfies the rule. A Behavior whose whole job is
+  // "run this skill" has no task statement to write, and one that spells its
+  // task out inline needs no skill — demanding both would be stricter than the
+  // server and would reject configs the API accepts.
+  if (requiresSkills && skills.length === 0 && !watcher.prompt.trim()) {
     throw new ValidationError(
-      `Behavior "${watcher.slug}" needs at least one skill: schedule triggers, event triggers with execution "window", and Behaviors with no triggers run on their compiled skill instructions alone. Only event triggers with execution "turn" may omit skills.`
+      `Behavior "${watcher.slug}" needs instructions: schedule triggers, event triggers with execution "window", and Behaviors with no triggers run on stored instructions alone, so give it a "prompt", at least one skill, or both. Only event triggers with execution "turn" may omit both.`
     );
   }
 }
@@ -633,11 +637,12 @@ function mapBehavior(behavior: Behavior): DesiredWatcher {
   return {
     slug: watcher.slug,
     agent: agentId(watcher.agent),
-    // Compiled at load time from the referenced skill bodies (see
-    // `compileBehaviorInstructions` in desired-state.ts). The mapper stays pure
-    // — it cannot read skill files — so the placeholder holds until the loader
-    // overwrites it. Event-turn Behaviors with no skills legitimately keep "".
-    prompt: "",
+    // The author's task statement, carried straight through. Skill BODIES are
+    // no longer folded in here — the loader resolves them into `skillSnapshots`
+    // (see `resolveBehaviorSkills` in desired-state.ts), because the mapper is
+    // pure and cannot read skill files. "" is legitimate for a Behavior whose
+    // whole job is its skills, and for event-turn Behaviors with neither.
+    prompt: watcher.prompt ?? "",
     ...(watcher.skills?.length ? { skills: watcher.skills } : {}),
     ...(watcher.keyingConfig
       ? { keyingConfig: normalizeKeyingConfig(watcher.keyingConfig) }

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -521,7 +521,7 @@ function normalizeKeyingConfig(
   return out;
 }
 
-/** Max skills a Behavior may reference (ordered compile; issue #2320 cap). */
+/** Max skills a Behavior may pin on one version (issue #2320 cap). */
 const MAX_BEHAVIOR_SKILLS = 5;
 
 /**
@@ -529,8 +529,7 @@ const MAX_BEHAVIOR_SKILLS = 5;
  * content (the incoming message/event), so it may run with zero skills on the
  * built-in default instruction. Everything else — schedule triggers, event
  * triggers with execution "window", and Behaviors with no triggers at all
- * (manual runs) — runs on its compiled instructions alone and must reference
- * at least one skill.
+ * (manual runs) — needs a prompt, at least one skill, or both.
  *
  * This CLI preflight mirrors the server rule, catching the error against the
  * config file (naming the slug) rather than as a 422 mid-apply. When both

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -383,11 +383,12 @@ describe("lobu init --from-org", () => {
     expect(w?.slug).toBe("account-health");
     expect(w?.agent).toBe("sales");
     expect(w?.name).toBe("Account health");
-    // Skills-first round trip: the stored instruction text was emitted as a
-    // generated skill named after the Behavior slug, and compiling it back
-    // reproduces the exact frozen text (no version churn on re-apply).
-    expect(w?.skills).toEqual(["account-health"]);
+    // The stored instruction text round-trips as the author-facing `prompt`,
+    // verbatim. It is NOT rehomed into a generated skill: doing that would make
+    // the first `lobu apply` after a bootstrap rewrite every Behavior it had
+    // just described. This Behavior pins no skills, so none are emitted.
     expect(w?.prompt).toBe("Poll CRM data.");
+    expect(w?.skills).toBeUndefined();
     expect(w?.triggers?.[0]).toMatchObject({
       kind: "event",
       connector_key: "github",

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -136,6 +136,12 @@ function fullOrgRoutes(): Record<
           name: "Account health",
           agent_id: "sales",
           prompt: "Poll CRM data.",
+          skills: [
+            {
+              name: "account-brief",
+              content: "Summarize the account.",
+            },
+          ],
           schedule: "0 */12 * * *",
           triggers: [
             {
@@ -383,12 +389,13 @@ describe("lobu init --from-org", () => {
     expect(w?.slug).toBe("account-health");
     expect(w?.agent).toBe("sales");
     expect(w?.name).toBe("Account health");
-    // The stored instruction text round-trips as the author-facing `prompt`,
-    // verbatim. It is NOT rehomed into a generated skill: doing that would make
-    // the first `lobu apply` after a bootstrap rewrite every Behavior it had
-    // just described. This Behavior pins no skills, so none are emitted.
+    // The task statement and matching pinned skill both round-trip without
+    // rehoming either one into the other.
     expect(w?.prompt).toBe("Poll CRM data.");
-    expect(w?.skills).toBeUndefined();
+    expect(w?.skills).toEqual(["account-brief"]);
+    expect(w?.skillSnapshots).toEqual([
+      { name: "account-brief", content: "Summarize the account." },
+    ]);
     expect(w?.triggers?.[0]).toMatchObject({
       kind: "event",
       connector_key: "github",

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -493,12 +493,13 @@ function emitRelationshipType(
 }
 
 /**
- * Skills-presence rule, mirrored from `lobu apply` validation: only an
- * event-turn-only Behavior may run without skills (the built-in default
- * applies); schedule triggers, window execution, and no triggers (manual)
- * need compiled instructions.
+ * Instruction-presence rule, mirrored from `lobu apply` validation: only an
+ * event-turn-only Behavior may omit both prompt and skills (the built-in
+ * default applies).
  */
-function behaviorRequiresSkills(triggers: RemoteBehavior["triggers"]): boolean {
+function behaviorRequiresInstructions(
+  triggers: RemoteBehavior["triggers"]
+): boolean {
   const list = triggers ?? [];
   if (list.length === 0) return true;
   return list.some(
@@ -537,9 +538,10 @@ function emitBehavior(
     });
     fields.push(`triggers: ${emitValue(triggers, 1)}`);
   }
-  // Emit the instruction text as the author-facing `prompt` and the pinned
-  // skills as a plain name list, both verbatim — a bootstrap immediately
-  // followed by `lobu apply` must diff to nothing.
+  // Emit the author-facing prompt verbatim and preserve the pinned skill names.
+  // The generated agent library carries its CURRENT bodies; generateProject
+  // warns when those differ from this version's snapshots because the next
+  // apply will then publish an explicit skill upgrade.
   if (w.prompt?.trim()) fields.push(`prompt: ${str(w.prompt)}`);
   if (w.skills?.length) {
     fields.push(`skills: [${w.skills.map((s) => str(s.name)).join(", ")}]`);
@@ -945,23 +947,51 @@ function generateProject(
   const files: Array<{ relPath: string; body: string }> = [];
   const warnings: string[] = [];
 
-  // A Behavior's stored instruction text is emitted as `defineBehavior({ prompt })`
-  // verbatim, and its pinned skills as a `skills: [...]` name list. Both round-trip
-  // exactly, so a bootstrap followed immediately by `lobu apply` is a no-op.
-  //
-  // This used to synthesize a generated skill per Behavior, because
-  // `defineBehavior` had no prompt field and the instruction text had nowhere
-  // else to go. It has one now, and keeping the synthesis would be worse than
-  // redundant: it would move every Behavior's text out of `prompt` and into a
-  // skill, so the first apply after a bootstrap would rewrite every Behavior it
-  // had just faithfully described.
+  // Prompt text round-trips directly. Skill references resolve through the
+  // generated agent library, whose bodies are the library's current state, not
+  // necessarily the older snapshots pinned on each Behavior version. Surface
+  // that drift honestly: the generated config is an upgrade when bodies differ.
+  const agentsById = new Map(
+    state.agents.map(({ agent, settings }) => [agent.agentId, settings])
+  );
   for (const { watcher } of state.watchers) {
-    if (watcher.prompt?.trim()) continue;
-    if (watcher.skills?.length) continue;
-    if (behaviorRequiresSkills(watcher.triggers)) {
+    if (
+      !watcher.prompt?.trim() &&
+      !watcher.skills?.length &&
+      behaviorRequiresInstructions(watcher.triggers)
+    ) {
       warnings.push(
         `Behavior "${watcher.slug}" has no stored instructions but is not event-turn-only — give it a prompt or attach at least one skill before the next \`lobu apply\`.`
       );
+    }
+    const library =
+      agentsById.get(watcher.agent_id ?? "")?.skillsConfig?.skills ?? [];
+    for (const snapshot of watcher.skills ?? []) {
+      const current = library.find(
+        (skill) => !skill.system && skill.name === snapshot.name
+      );
+      if (!current) {
+        warnings.push(
+          `Behavior "${watcher.slug}" pins skill "${snapshot.name}", but that skill is absent from agent "${watcher.agent_id ?? ""}"'s current library — restore it or remove the Behavior reference before \`lobu apply\`.`
+        );
+        continue;
+      }
+      if (!current.content?.trim()) {
+        warnings.push(
+          `Behavior "${watcher.slug}" pins skill "${snapshot.name}", but its current agent-library body is empty — restore the body or remove the Behavior reference before \`lobu apply\`.`
+        );
+        continue;
+      }
+      if (current.enabled === false) {
+        warnings.push(
+          `Behavior "${watcher.slug}" pins disabled skill "${snapshot.name}" — the generated config declares it as enabled, so the next \`lobu apply\` will re-enable it and publish the current body.`
+        );
+      }
+      if (current.content.trim() !== snapshot.content.trim()) {
+        warnings.push(
+          `Behavior "${watcher.slug}" pins an older body of skill "${snapshot.name}" — the generated config uses the agent library's current body, so the next \`lobu apply\` will publish that upgrade.`
+        );
+      }
     }
   }
 

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -283,8 +283,7 @@ function emitAgent(
   settings: AgentSettings | null,
   imports: ImportTracker,
   secrets: SecretCollector,
-  minter: IdentMinter,
-  behaviorSkills: Array<{ name: string; content: string }> = []
+  minter: IdentMinter
 ): EmittedAgent {
   imports.use("defineAgent");
   const fields: string[] = [`id: ${str(agent.agentId)}`];
@@ -407,21 +406,6 @@ function emitAgent(
     });
     skillRefs.push(`skillFromFile(${str(`./${dir}/skills/${skill.name}`)})`);
   }
-  // Behavior-derived skills: each stored Behavior's frozen instruction text
-  // round-trips as a skill on its owning agent (skills-first authoring — the
-  // Behavior references it by name; there is no author-facing prompt).
-  for (const skill of behaviorSkills) {
-    files.push({
-      relPath: `${dir}/skills/${skill.name}/SKILL.md`,
-      body: emitSkillFile({
-        repo: `file/${skill.name}`,
-        name: skill.name,
-        content: skill.content,
-        enabled: true,
-      }),
-    });
-    skillRefs.push(`skillFromFile(${str(`./${dir}/skills/${skill.name}`)})`);
-  }
   if (skillRefs.length > 0) {
     imports.use("skillFromFile");
     fields.push(`skills: [\n    ${skillRefs.join(",\n    ")},\n  ]`);
@@ -530,8 +514,7 @@ function emitBehavior(
   agentHandles: Map<string, string>,
   connectionHandlesById: ReadonlyMap<number, string>,
   imports: ImportTracker,
-  minter: IdentMinter,
-  skillName: string | undefined
+  minter: IdentMinter
 ): { handle: Handle; reactionFile?: { relPath: string; body: string } } {
   imports.use("defineBehavior");
   const agentRef = w.agent_id ? agentHandles.get(w.agent_id) : undefined;
@@ -554,11 +537,13 @@ function emitBehavior(
     });
     fields.push(`triggers: ${emitValue(triggers, 1)}`);
   }
-  // Skills-first: the stored instruction text was emitted as a skill on the
-  // owning agent (see generateProject); the Behavior references it by name.
-  // An event-turn Behavior with no stored instructions emits no skills — the
-  // built-in default applies.
-  if (skillName) fields.push(`skills: [${str(skillName)}]`);
+  // Emit the instruction text as the author-facing `prompt` and the pinned
+  // skills as a plain name list, both verbatim — a bootstrap immediately
+  // followed by `lobu apply` must diff to nothing.
+  if (w.prompt?.trim()) fields.push(`prompt: ${str(w.prompt)}`);
+  if (w.skills?.length) {
+    fields.push(`skills: [${w.skills.map((s) => str(s.name)).join(", ")}]`);
+  }
   // A watcher's output schema is owned by its entity type (keying_config.entityType)
   // or falls back to the worker's free-form `{ summary }` — never inline. Emit
   // `keyingConfig` (the entity connection) only.
@@ -960,48 +945,23 @@ function generateProject(
   const files: Array<{ relPath: string; body: string }> = [];
   const warnings: string[] = [];
 
-  // Skills-first Behaviors: each stored Behavior's frozen instruction text
-  // round-trips as a generated skill on its owning agent, referenced by name
-  // from the Behavior's `skills` list (there is no author-facing prompt).
-  // Names default to the Behavior slug, suffixed on collision with an
-  // existing agent skill.
-  const behaviorSkillsByAgent = new Map<
-    string,
-    Array<{ name: string; content: string }>
-  >();
-  const behaviorSkillNames = new Map<string, string>();
-  {
-    const usedNamesByAgent = new Map<string, Set<string>>();
-    for (const { agent, settings } of state.agents) {
-      usedNamesByAgent.set(
-        agent.agentId,
-        new Set(
-          (settings?.skillsConfig?.skills ?? [])
-            .filter((s) => !s.system)
-            .map((s) => s.name)
-        )
+  // A Behavior's stored instruction text is emitted as `defineBehavior({ prompt })`
+  // verbatim, and its pinned skills as a `skills: [...]` name list. Both round-trip
+  // exactly, so a bootstrap followed immediately by `lobu apply` is a no-op.
+  //
+  // This used to synthesize a generated skill per Behavior, because
+  // `defineBehavior` had no prompt field and the instruction text had nowhere
+  // else to go. It has one now, and keeping the synthesis would be worse than
+  // redundant: it would move every Behavior's text out of `prompt` and into a
+  // skill, so the first apply after a bootstrap would rewrite every Behavior it
+  // had just faithfully described.
+  for (const { watcher } of state.watchers) {
+    if (watcher.prompt?.trim()) continue;
+    if (watcher.skills?.length) continue;
+    if (behaviorRequiresSkills(watcher.triggers)) {
+      warnings.push(
+        `Behavior "${watcher.slug}" has no stored instructions but is not event-turn-only — give it a prompt or attach at least one skill before the next \`lobu apply\`.`
       );
-    }
-    for (const { watcher } of state.watchers) {
-      const instructions = watcher.prompt?.trim();
-      const agentId = watcher.agent_id ?? "";
-      if (!instructions) {
-        if (behaviorRequiresSkills(watcher.triggers)) {
-          warnings.push(
-            `Behavior "${watcher.slug}" has no stored instructions but is not event-turn-only — attach at least one skill before the next \`lobu apply\`.`
-          );
-        }
-        continue;
-      }
-      const used = usedNamesByAgent.get(agentId) ?? new Set<string>();
-      usedNamesByAgent.set(agentId, used);
-      let name = watcher.slug;
-      for (let n = 2; used.has(name); n++) name = `${watcher.slug}-${n}`;
-      used.add(name);
-      behaviorSkillNames.set(watcher.slug, name);
-      const list = behaviorSkillsByAgent.get(agentId) ?? [];
-      list.push({ name, content: instructions });
-      behaviorSkillsByAgent.set(agentId, list);
     }
   }
 
@@ -1009,14 +969,7 @@ function generateProject(
   const agentHandles = new Map<string, string>();
   const agentDecls: string[] = [];
   for (const { agent, settings } of state.agents) {
-    const emitted = emitAgent(
-      agent,
-      settings,
-      imports,
-      secrets,
-      minter,
-      behaviorSkillsByAgent.get(agent.agentId) ?? []
-    );
+    const emitted = emitAgent(agent, settings, imports, secrets, minter);
     agentHandles.set(agent.agentId, emitted.handle.name);
     agentDecls.push(emitted.handle.decl);
     files.push(...emitted.files);
@@ -1111,8 +1064,7 @@ function generateProject(
       agentHandles,
       connectionHandlesById,
       imports,
-      minter,
-      behaviorSkillNames.get(watcher.slug)
+      minter
     );
     watcherDecls.push(handle.decl);
     watcherHandles.push(handle.name);

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -421,9 +421,8 @@ export interface Behavior {
    * ({@link Agent.skills}). `lobu apply` resolves each name to its body and
    * pins the pair onto the Behavior's version, so a run gets the text as it
    * stood at apply time. Editing the library later does not reach an existing
-   * Behavior until the next `lobu apply` — which is the declarative equivalent
-   * of the web editor's "upgrade" action, and why config projects never see an
-   * update prompt: re-applying is the upgrade.
+   * Behavior until the next `lobu apply`; re-applying is the explicit upgrade
+   * action for a declarative project.
    *
    * Supply {@link Behavior.prompt}, `skills`, or both. One of the two is
    * required for schedule triggers, event triggers with execution `"window"`,

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -406,15 +406,30 @@ export interface Behavior {
   /** Connector events and/or cadence that activate this Behavior. */
   triggers?: BehaviorTriggerConfig[];
   /**
-   * Ordered skill names from the owning agent's skill library
-   * ({@link Agent.skills}). `lobu apply` compiles the referenced skill bodies —
-   * joined in this order — into the Behavior's frozen instructions; editing the
-   * library later does not change existing Behaviors until re-apply.
+   * The task this Behavior performs, in plain text — *what to do when it fires*,
+   * as distinct from the reusable know-how in {@link Behavior.skills}.
    *
-   * Optional for event triggers with execution `"turn"` (chat/webhook listen —
-   * the incoming event is the content and a built-in default applies).
-   * Required (≥1) for schedule triggers, event triggers with execution
-   * `"window"`, and Behaviors with no triggers (manual runs).
+   * Delivered to the agent verbatim, with no template expansion; the window's
+   * data arrives separately in the knowledge-read payload. Skills are NOT
+   * concatenated into it — they ship as files the agent reads on demand — so a
+   * prompt saying "draft the brief using deal-brief" works without pasting the
+   * skill body here.
+   */
+  prompt?: string;
+  /**
+   * Ordered skill names from the owning agent's skill library
+   * ({@link Agent.skills}). `lobu apply` resolves each name to its body and
+   * pins the pair onto the Behavior's version, so a run gets the text as it
+   * stood at apply time. Editing the library later does not reach an existing
+   * Behavior until the next `lobu apply` — which is the declarative equivalent
+   * of the web editor's "upgrade" action, and why config projects never see an
+   * update prompt: re-applying is the upgrade.
+   *
+   * Supply {@link Behavior.prompt}, `skills`, or both. One of the two is
+   * required for schedule triggers, event triggers with execution `"window"`,
+   * and Behaviors with no triggers (manual runs); an event trigger with
+   * execution `"turn"` may omit both, since the incoming event is the content
+   * and a built-in default applies.
    */
   skills?: string[];
   /**

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -193,6 +193,30 @@ export const SourceSchema = Type.Object({
 });
 
 /**
+ * One agent skill pinned into a Behavior version.
+ *
+ * The `content` is a SNAPSHOT taken when the version was saved, not a live
+ * reference. Editing the agent's skill library afterwards does not reach an
+ * existing version — the editor surfaces the difference and offers to publish a
+ * new version, and `lobu apply` re-resolves every reference on each run. Storing
+ * the body (rather than the name alone) is also what lets a device-pinned
+ * Behavior dispatch: `worker-api/poll.ts` ships instructions to a CLI with no
+ * channel back to the skill library.
+ */
+export const BehaviorSkillSchema = Type.Object({
+  name: Type.String({
+    description:
+      "Skill name, matching an entry in the owning agent's skill library. Identifies the skill for diffing a pinned snapshot against the library's current body.",
+  }),
+  content: Type.String({
+    description:
+      "The skill body, frozen as of this version. Delivered to the agent as `.skills/<name>/SKILL.md`.",
+  }),
+});
+
+export type BehaviorSkill = Static<typeof BehaviorSkillSchema>;
+
+/**
  * A single classifier definition embedded in a Behavior version. The key
  * invariant for #2033 item 4 is `attribute_values`: it MUST be an object-MAP
  * keyed by value string, never an array. An array read back through
@@ -231,7 +255,7 @@ export const ManageBehaviorsSchema = Type.Object(
       [
         Type.Literal("create", {
           description:
-            "Create a Behavior. Author instructions as agent skills where possible; prompt is the compiled instruction text and may be omitted for event triggers with execution 'turn'.",
+            "Create a Behavior. Put the task statement in `prompt` and reusable know-how in `skills`; either satisfies the instruction requirement, and an event trigger with execution 'turn' may omit both.",
         }),
         Type.Literal("list", { description: "List Behaviors." }),
         Type.Literal("update", { description: "Patch Behavior config." }),
@@ -330,7 +354,13 @@ export const ManageBehaviorsSchema = Type.Object(
     prompt: Type.Optional(
       Type.String({
         description:
-          "[create/create_version] Literal LLM instruction text for the Behavior, frozen into the version. No template expansion happens — the text is delivered to the agent verbatim, and the window's data (content, sources, entities, extraction_schema) arrives alongside it in the knowledge-read payload. Prefer authoring instructions as skills on the owning agent and compiling them here (declarative configs join the referenced skill bodies in order). Required for schedule triggers, event triggers with execution 'window', and Behaviors with no triggers; omit it for event triggers with execution 'turn' to use the built-in default.",
+          "[create/create_version] Literal LLM instruction text for the Behavior — the task statement, frozen into the version. No template expansion happens: the text is delivered to the agent verbatim, and the window's data (content, sources, entities, extraction_schema) arrives alongside it in the knowledge-read payload. Reusable know-how belongs in `skills` instead, which is delivered as readable files rather than pasted in here. A schedule trigger, an event trigger with execution 'window', and a Behavior with no triggers each need an instruction source — supply `prompt`, `skills`, or both; an event trigger with execution 'turn' may omit both and use the built-in default.",
+      })
+    ),
+    skills: Type.Optional(
+      Type.Array(BehaviorSkillSchema, {
+        description:
+          "[create/create_version] Ordered agent skills pinned into this version as {name, content} snapshots, delivered to the agent as `.skills/<name>/SKILL.md` files it reads on demand. Snapshots, not live references: editing the agent's library later does not change an existing version until a new one is published (`lobu apply` re-resolves on every run; the web editor shows a diff and an upgrade action). FULL REPLACEMENT on create_version — passing it (even []) makes it the complete set, and OMITTING it keeps the stored snapshots unchanged. Every name must exist and be enabled in the owning agent's library, or the call is rejected rather than silently running under-instructed.",
       })
     ),
     sources: Type.Optional(

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -197,20 +197,22 @@ export const SourceSchema = Type.Object({
  *
  * The `content` is a SNAPSHOT taken when the version was saved, not a live
  * reference. Editing the agent's skill library afterwards does not reach an
- * existing version — the editor surfaces the difference and offers to publish a
- * new version, and `lobu apply` re-resolves every reference on each run. Storing
- * the body (rather than the name alone) is also what lets a device-pinned
- * Behavior dispatch: `worker-api/poll.ts` ships instructions to a CLI with no
- * channel back to the skill library.
+ * existing version; a caller must publish a new version, and `lobu apply`
+ * re-resolves every reference on each run. Storing the body (rather than the
+ * name alone) also lets a device-pinned Behavior dispatch the frozen text to a
+ * CLI with no channel back to the skill library.
  */
 export const BehaviorSkillSchema = Type.Object({
   name: Type.String({
+    minLength: 1,
+    pattern: "^[a-zA-Z0-9._-]+$",
     description:
       "Skill name, matching an entry in the owning agent's skill library. Identifies the skill for diffing a pinned snapshot against the library's current body.",
   }),
   content: Type.String({
+    minLength: 1,
     description:
-      "The skill body, frozen as of this version. Delivered to the agent as `.skills/<name>/SKILL.md`.",
+      "The skill body, frozen as of this version. Server-side agents receive it as `.skills/<name>/SKILL.md`; device executors receive the same frozen text in their per-run task.",
   }),
 });
 
@@ -359,14 +361,15 @@ export const ManageBehaviorsSchema = Type.Object(
     ),
     skills: Type.Optional(
       Type.Array(BehaviorSkillSchema, {
+        maxItems: 5,
         description:
-          "[create/create_version] Ordered agent skills pinned into this version as {name, content} snapshots, delivered to the agent as `.skills/<name>/SKILL.md` files it reads on demand. Snapshots, not live references: editing the agent's library later does not change an existing version until a new one is published (`lobu apply` re-resolves on every run; the web editor shows a diff and an upgrade action). FULL REPLACEMENT on create_version — passing it (even []) makes it the complete set, and OMITTING it keeps the stored snapshots unchanged. Every name must exist and be enabled in the owning agent's library, or the call is rejected rather than silently running under-instructed.",
+          "[create/create_version] Up to 5 ordered agent skills pinned into this version as {name, content} snapshots. Server-side agents receive `.skills/<name>/SKILL.md` files; device executors receive the same frozen text in their per-run task. Snapshots, not live references: editing the agent's library later does not change an existing version until a caller publishes a new one (`lobu apply` re-resolves on every run). FULL REPLACEMENT on create_version — passing it (even []) makes it the complete set, and OMITTING it keeps the stored snapshots unchanged. Every name must exist and be enabled in the owning agent's library, or the call is rejected rather than silently running under-instructed.",
       })
     ),
     sources: Type.Optional(
       Type.Array(SourceSchema, {
         description:
-          "[create/create_version] Array of SQL data sources. Each source is { name, query }. To change them on an existing Behavior, publish a new version with action: 'create_version'. On create_version this array is the ONLY way to change them and is a FULL REPLACEMENT: passing it (even []) makes it the complete source set, [] clears everything, and OMITTING it keeps the stored sources unchanged. Instruction text is never an input — a Behavior's prompt is usually compiled skill bodies, so @-mention chips inside it neither add nor remove sources. (On create only, chips in the prompt still seed the initial list, which is how the web composer authors them.) The response returns source_count and removed_sources so you can see what a replacement dropped.",
+          "[create/create_version] Array of SQL data sources. Each source is { name, query }. To change them on an existing Behavior, publish a new version with action: 'create_version'. On create_version this array is the ONLY way to change them and is a FULL REPLACEMENT: passing it (even []) makes it the complete source set, [] clears everything, and OMITTING it keeps the stored sources unchanged. Instruction text is never an input: @-mention chips in an inherited prompt neither add nor remove sources. (On create only, chips in the prompt still seed the initial list, which is how the web composer authors them.) The response returns source_count and removed_sources so you can see what a replacement dropped.",
       })
     ),
     keying_config: Type.Optional(

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-approval-e2e.test.ts
@@ -114,6 +114,21 @@ describe("manage_behaviors — builder gate e2e", () => {
 			ownerUserId: owner.id,
 		});
 		otherAgentId = other.agentId;
+		const sql = getTestDb();
+		await sql`
+			UPDATE agents
+			SET skills_config = ${sql.json({
+				skills: [
+					{
+						repo: "file/approval-runbook",
+						name: "approval-runbook",
+						enabled: true,
+						content: "Run the approved workflow.",
+					},
+				],
+			})}
+			WHERE id = ${agentId} AND organization_id = ${orgId}
+		`;
 
 		// Same owner identity, but acting as the builder agent — principal the
 		// agent_config write-gate holds for approval.
@@ -212,6 +227,30 @@ describe("manage_behaviors — builder gate e2e", () => {
 		});
 
 		expect(await watcherExists(orgId, "agent-proposed-watcher")).toBe(false);
+	});
+
+	it("agent can propose a skills-only Behavior without failing approval preflight", async () => {
+		const res = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "agent-proposed-skills-only",
+				name: "Agent Proposed Skills Only",
+				agent_id: agentId,
+				skills: [
+					{
+						name: "approval-runbook",
+						content: "Run the approved workflow.",
+					},
+				],
+			},
+			TEST_ENV,
+			agentCtx
+		)) as PendingApproval;
+
+		expect(res.status).toBe("pending_approval");
+		expect(res.proposal?.args?.slug).toBe("agent-proposed-skills-only");
+		expect(await watcherExists(orgId, "agent-proposed-skills-only")).toBe(false);
 	});
 
 	it("approve applies the held create: watcher exists, run completed, event superseded", async () => {

--- a/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-behaviors-instruction-rule.test.ts
@@ -1,12 +1,10 @@
 /**
  * manage_behaviors — instruction-presence rule (issue #2320, thin Behaviors).
  *
- * A Behavior's instruction text (`prompt`, internally the compiled skill
- * bodies) is required only for trigger shapes that run on it alone: schedule
- * triggers, event triggers with execution "window", and no triggers (manual).
- * An event trigger with execution "turn" carries its own content (the incoming
- * message) and may be created with NO prompt — previously `create` hard-failed
- * with "prompt is required for create action".
+ * A Behavior needs at least one instruction source (`prompt` or pinned skills)
+ * only for trigger shapes that run on it alone: schedule triggers, event
+ * triggers with execution "window", and no triggers (manual). An event trigger
+ * with execution "turn" carries its own content and may omit both.
  *
  * create_version enforces the same rule when it writes instruction text.
  */
@@ -76,6 +74,21 @@ describe("manage_behaviors — instruction-presence rule", () => {
 			ownerUserId: owner.id,
 		});
 		agentId = agent.agentId;
+		const sql = getTestDb();
+		await sql`
+			UPDATE agents
+			SET skills_config = ${sql.json({
+				skills: [
+					{
+						repo: "file/ir-runbook",
+						name: "ir-runbook",
+						enabled: true,
+						content: "Run the instruction-rule workflow.",
+					},
+				],
+			})}
+			WHERE id = ${agentId} AND organization_id = ${orgId}
+		`;
 	});
 
 	it("creates an event-turn Behavior with NO prompt (built-in default applies)", async () => {
@@ -118,6 +131,64 @@ describe("manage_behaviors — instruction-presence rule", () => {
 				ownerCtx
 			)
 		).rejects.toThrow(/needs instructions/i);
+	});
+
+	it("creates and versions a schedule Behavior from pinned skills without a prompt", async () => {
+		const created = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create",
+				slug: "ir-skills-only",
+				agent_id: agentId,
+				skills: [
+					{
+						name: "ir-runbook",
+						content: "Run the instruction-rule workflow.",
+					},
+				],
+				triggers: [{ kind: "schedule", cron: "0 9 * * *" }],
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { behavior_id?: string };
+		expect(created.behavior_id).toBeTruthy();
+
+		const sql = getTestDb();
+		const [v1] = await sql`
+			SELECT version.prompt, version.skills
+			FROM watchers behavior
+			JOIN watcher_versions version ON version.id = behavior.current_version_id
+			WHERE behavior.id = ${Number(created.behavior_id)}
+		`;
+		expect(v1.prompt).toBe("");
+		expect(v1.skills).toEqual([
+			{
+				name: "ir-runbook",
+				content: "Run the instruction-rule workflow.",
+			},
+		]);
+
+		const versioned = (await executeTool(
+			"manage_behaviors",
+			{
+				action: "create_version",
+				behavior_id: created.behavior_id!,
+				name: "Skills-only renamed",
+				set_as_current: true,
+			},
+			TEST_ENV,
+			ownerCtx
+		)) as { version?: number };
+		expect(versioned.version).toBeGreaterThan(1);
+
+		const [v2] = await sql`
+			SELECT version.prompt, version.skills
+			FROM watchers behavior
+			JOIN watcher_versions version ON version.id = behavior.current_version_id
+			WHERE behavior.id = ${Number(created.behavior_id)}
+		`;
+		expect(v2.prompt).toBe("");
+		expect(v2.skills).toEqual(v1.skills);
 	});
 
 	it("create_version rejects blanking instructions on a schedule Behavior, accepts real text", async () => {

--- a/packages/server/src/__tests__/integration/watchers/manual-trigger.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/manual-trigger.test.ts
@@ -458,7 +458,7 @@ describe('POST /api/workers/me/behaviors/:watcher_id/trigger', () => {
     expect(runs.filter((run) => run.status === 'pending')).toHaveLength(1);
   });
 
-  it('poll payload carries the run-pinned version prompt, not a later edit', async () => {
+  it('poll payload carries the run-pinned prompt and skills, not a later edit', async () => {
     const ctx = await setupDevicePinnedWatcher({ workerId: 'mac-poll-prompt' });
     const { token } = await createWorkerBoundPat(
       ctx.workspace.users.owner.id,
@@ -466,8 +466,18 @@ describe('POST /api/workers/me/behaviors/:watcher_id/trigger', () => {
       'mac-poll-prompt'
     );
 
-    // Queue a run: createWatcherRun snapshots the current version (prompt v1)
-    // into approved_input.version_id.
+    await ctx.sql`
+      UPDATE watcher_versions
+      SET skills = ${ctx.sql.json([
+        { name: 'device-runbook', content: 'Follow the frozen v1 runbook.' },
+      ])}
+      WHERE id = (
+        SELECT current_version_id FROM watchers WHERE id = ${ctx.watcherId}
+      )
+    `;
+
+    // Queue a run: createWatcherRun snapshots the current version (prompt +
+    // skills v1) into approved_input.version_id.
     const trig = await post(`/api/workers/me/behaviors/${ctx.watcherId}/trigger`, { token });
     expect(trig.status).toBe(200);
 
@@ -485,8 +495,9 @@ describe('POST /api/workers/me/behaviors/:watcher_id/trigger', () => {
     )) as { version: number };
     expect(v2.version).toBe(2);
 
-    // The poll must deliver the prompt of the version snapshotted at queue time
-    // (v1) — the same version complete_window validates against — not the edit.
+    // The poll must deliver both instruction sources from the version
+    // snapshotted at queue time (v1) — the same version complete_window
+    // validates against — not the edit.
     const pollRes = await post('/api/workers/poll', {
       token,
       body: { worker_id: 'mac-poll-prompt', capabilities: {} },
@@ -497,6 +508,9 @@ describe('POST /api/workers/me/behaviors/:watcher_id/trigger', () => {
       payload?: { watcher?: { prompt?: string } };
     };
     expect(job.run_type).toBe('behavior');
-    expect(job.payload?.watcher?.prompt).toBe('Summarize {{entities}}.');
+    expect(job.payload?.watcher?.prompt).toContain('Summarize {{entities}}.');
+    expect(job.payload?.watcher?.prompt).toContain('### device-runbook');
+    expect(job.payload?.watcher?.prompt).toContain('Follow the frozen v1 runbook.');
+    expect(job.payload?.watcher?.prompt).not.toContain('EDITED-AFTER-QUEUE');
   });
 });

--- a/packages/server/src/behaviors/skill-snapshots.ts
+++ b/packages/server/src/behaviors/skill-snapshots.ts
@@ -1,0 +1,38 @@
+export interface BehaviorSkillSnapshot {
+	name: string;
+	content: string;
+}
+
+/**
+ * Parse the durable jsonb representation used by run dispatch. Invalid rows
+ * throw so callers fail the run rather than silently executing without skills.
+ */
+export function parseBehaviorSkillSnapshots(
+	value: unknown,
+): BehaviorSkillSnapshot[] {
+	let parsed = value;
+	if (typeof parsed === "string") {
+		try {
+			parsed = JSON.parse(parsed);
+		} catch {
+			throw new Error("Behavior version has malformed pinned skills");
+		}
+	}
+	if (parsed == null) return [];
+	if (!Array.isArray(parsed)) {
+		throw new Error("Behavior version has malformed pinned skills");
+	}
+	return parsed.map((entry) => {
+		if (
+			!entry ||
+			typeof entry !== "object" ||
+			typeof entry.name !== "string" ||
+			!entry.name.trim() ||
+			typeof entry.content !== "string" ||
+			!entry.content.trim()
+		) {
+			throw new Error("Behavior version has malformed pinned skills");
+		}
+		return { name: entry.name, content: entry.content };
+	});
+}

--- a/packages/server/src/behaviors/triggers.ts
+++ b/packages/server/src/behaviors/triggers.ts
@@ -228,11 +228,10 @@ export function behaviorRequiresInstructions(
  *
  * Either source satisfies the requirement on its own. They are no longer the
  * same field: skills used to be concatenated into `prompt` at save time, so one
- * check covered both, but a pinned skill is now delivered as its own
- * `.skills/<name>/SKILL.md` and never enters the prompt text. Requiring both
- * would be stricter than the behaviour this replaced — a Behavior whose whole
- * job is "run this skill" has nothing to put in a task statement, and one that
- * spells its task out inline needs no skill.
+ * check covered both, but pinned skills now remain separate from the stored
+ * prompt. Requiring both would be stricter than the behaviour this replaced —
+ * a Behavior whose whole job is "run this skill" has nothing to put in a task
+ * statement, and one that spells its task out inline needs no skill.
  */
 export function assertBehaviorInstructions(
 	triggers: BehaviorTrigger[],

--- a/packages/server/src/behaviors/triggers.ts
+++ b/packages/server/src/behaviors/triggers.ts
@@ -223,16 +223,27 @@ export function behaviorRequiresInstructions(
 /**
  * Enforce the instruction-presence rule on a complete trigger + instruction
  * pair before either side is stored. Callers must pass the *final* resolved
- * pair (inherited prompt when omitted, resolved triggers after write-merge).
+ * values (inherited prompt/skills when omitted, resolved triggers after
+ * write-merge).
+ *
+ * Either source satisfies the requirement on its own. They are no longer the
+ * same field: skills used to be concatenated into `prompt` at save time, so one
+ * check covered both, but a pinned skill is now delivered as its own
+ * `.skills/<name>/SKILL.md` and never enters the prompt text. Requiring both
+ * would be stricter than the behaviour this replaced — a Behavior whose whole
+ * job is "run this skill" has nothing to put in a task statement, and one that
+ * spells its task out inline needs no skill.
  */
 export function assertBehaviorInstructions(
 	triggers: BehaviorTrigger[],
-	instructions: string | null | undefined
+	instructions: string | null | undefined,
+	skills?: ReadonlyArray<{ name: string; content: string }> | null
 ): void {
 	if (!behaviorRequiresInstructions(triggers)) return;
 	if (instructions?.trim()) return;
+	if (skills?.some((skill) => skill.content.trim())) return;
 	throw new ToolUserError(
-		"This Behavior runs from a schedule, an analysis window, or manual runs, so it needs instructions: attach at least one skill (their bodies compile into the stored instructions) or provide instruction text. Only event triggers with execution 'turn' may omit instructions."
+		"This Behavior runs from a schedule, an analysis window, or manual runs, so it needs instructions: attach at least one skill or provide instruction text. Only event triggers with execution 'turn' may omit both."
 	);
 }
 

--- a/packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { generateWorkerToken } from "@lobu/core";
+import type { DbClient } from "../../db/client.js";
+import { resolveBehaviorRunSkills } from "../behavior-run-session.js";
 import { WorkerGateway } from "../gateway/index.js";
 
 const TEST_ENCRYPTION_KEY = Buffer.from(
@@ -21,7 +23,7 @@ describe("WorkerGateway session context", () => {
     }
   });
 
-  test("syncs configured skills for chat but suppresses them for Behavior runs", async () => {
+  test("syncs live skills for chat and pinned snapshots for Behavior runs", async () => {
     // A DECLARED (SDK-embedded) agent has org-agnostic settings, so an orgless
     // token legitimately syncs its skills. (A DB-backed agent with an orgless
     // token would fail closed — covered by the cross-tenant test below.)
@@ -61,7 +63,13 @@ describe("WorkerGateway session context", () => {
             ],
           },
         }),
-      } as any
+      } as any,
+      async () => [
+        {
+          name: "pinned-behavior-skill",
+          content: "# Pinned Behavior Skill\n",
+        },
+      ]
     );
 
     type SessionContextBody = {
@@ -75,8 +83,11 @@ describe("WorkerGateway session context", () => {
       skillsInstructions: string;
     };
 
-    const fetchContext = async (source?: string): Promise<SessionContextBody> => {
-      const token = generateWorkerToken("user-1", "conv-1", "worker-a", {
+    const fetchContext = async (
+      source?: string,
+      conversationId = "conv-1"
+    ): Promise<SessionContextBody> => {
+      const token = generateWorkerToken("user-1", conversationId, "worker-a", {
         channelId: "channel-1",
         agentId: "agent-1",
         source,
@@ -105,9 +116,18 @@ describe("WorkerGateway session context", () => {
     expect(chat.skillsInstructions).toContain("owner/custom-skill");
     expect(chat.skillsInstructions).not.toContain("Built-in System Skills");
 
-    const behaviorRun = await fetchContext("watcher-run");
-    expect(behaviorRun.skillsConfig).toEqual([]);
-    expect(behaviorRun.skillsInstructions).toBe("");
+    const behaviorRun = await fetchContext(
+      "watcher-run",
+      "agent-1_watcher_42_run_99"
+    );
+    expect(behaviorRun.skillsConfig).toEqual([
+      {
+        name: "pinned-behavior-skill",
+        content: "# Pinned Behavior Skill\n",
+      },
+    ]);
+    expect(behaviorRun.skillsInstructions).toContain("pinned-behavior-skill");
+    expect(behaviorRun.skillsInstructions).not.toContain("custom-skill");
 
     // Other headless sources do not execute frozen Behavior instructions.
     const connectorRepair = await fetchContext("connector-repair");
@@ -159,5 +179,39 @@ describe("WorkerGateway session context", () => {
     expect(body.webOrigin).toBe("https://app.lobu.ai");
     expect(body.webOrigin).not.toContain("/lobu");
     expect(body.webOrigin).not.toContain("cluster.local");
+  });
+
+  test("resolves pinned skills through the signed Behavior run correlation", async () => {
+    let queryValues: unknown[] = [];
+    const db = (async (
+      _strings: TemplateStringsArray,
+      ...values: unknown[]
+    ) => {
+      queryValues = values;
+      return [
+        {
+          skills: JSON.stringify([
+            { name: "pinned", content: "Frozen instructions." },
+          ]),
+        },
+      ];
+    }) as unknown as DbClient;
+
+    const skills = await resolveBehaviorRunSkills(
+      {
+        conversationId: "agent-1_watcher_42_run_99",
+        organizationId: "org-1",
+        agentId: "agent-1",
+      },
+      db
+    );
+
+    expect(skills).toEqual([
+      { name: "pinned", content: "Frozen instructions." },
+    ]);
+    expect(queryValues).toContain("agent-1");
+    expect(queryValues).toContain(42);
+    expect(queryValues).toContain(99);
+    expect(queryValues).toContain("org-1");
   });
 });

--- a/packages/server/src/gateway/behavior-run-session.ts
+++ b/packages/server/src/gateway/behavior-run-session.ts
@@ -10,13 +10,10 @@
  * spelling — nothing agent-facing reads it.
  *
  * What reading it back means: the turn's job text is the FROZEN instruction
- * body the Behavior version compiled at apply/save time, not a human's
- * message. That freeze is only honest if the agent's live skill *library*
- * stays out of the turn — the progressive catalog advertises skills the freeze
- * never picked, and both the catalog and its generic fallback tell the model
- * to `cat .skills/…`, which serves whatever the library holds today (issue
- * #2320 must-fix 1). Persona, tools, MCP and network stay live; they are the
- * agent, not the job.
+ * set saved on the Behavior version, not a human's message. That freeze is only
+ * honest if the agent's live skill *library* stays out of the turn: the worker
+ * receives the version's pinned skill snapshots instead. Persona, tools, MCP
+ * and network stay live; they are the agent, not the job.
  *
  * Narrower than the SSE-routing notion of "headless": connector-repair,
  * scheduled-job and internal turns have no frozen Behavior text behind them,
@@ -31,4 +28,74 @@
  * serves that agent's chat. If a future dispatch path ever runs a Behavior on
  * a shared conversation, that cache becomes the place this decision leaks.
  */
+
+import type { DbClient } from "../db/client.js";
+import { getDb } from "../db/client.js";
+import {
+	type BehaviorSkillSnapshot,
+	parseBehaviorSkillSnapshots,
+} from "../behaviors/skill-snapshots.js";
+import { parseBehaviorRunConversationId } from "./permissions/behavior-run-intent.js";
+
 export const BEHAVIOR_RUN_SOURCE = "watcher-run";
+
+export type BehaviorRunSkillResolver = (args: {
+	conversationId: string;
+	organizationId: string | undefined;
+	agentId: string | undefined;
+}) => Promise<BehaviorSkillSnapshot[]>;
+
+/**
+ * Resolve the exact version pinned on a Behavior run. The org, agent, Behavior,
+ * and run correlations all come from signed worker-token claims; keep every one
+ * in the query so a malformed token can never read another tenant's snapshots.
+ *
+ * Missing or malformed durable state fails closed. Returning an empty list for
+ * a missing row would let a skills-only Behavior execute without instructions.
+ */
+export async function resolveBehaviorRunSkills(
+	args: Parameters<BehaviorRunSkillResolver>[0],
+	db: DbClient = getDb(),
+): Promise<BehaviorSkillSnapshot[]> {
+	const intent = parseBehaviorRunConversationId(args.conversationId);
+	if (!intent || !args.organizationId || !args.agentId) {
+		throw new Error("Behavior run token is missing its pinned-skill scope");
+	}
+
+	const rows = await db`
+		SELECT version.skills
+		FROM runs behavior_run
+		JOIN watchers behavior
+		  ON behavior.id = behavior_run.watcher_id
+		 AND behavior.organization_id = behavior_run.organization_id
+		 AND behavior.agent_id = ${args.agentId}
+		JOIN watcher_versions version
+		  ON version.id = COALESCE(
+		       NULLIF(behavior_run.approved_input->>'version_id', '')::bigint,
+		       behavior.current_version_id
+		     )
+		 AND version.watcher_id = behavior.watcher_group_id
+		WHERE behavior_run.id = ${intent.runId}
+		  AND behavior_run.run_type = 'behavior'
+		  AND behavior_run.watcher_id = ${intent.behaviorId}
+		  AND behavior_run.organization_id = ${args.organizationId}
+		LIMIT 1
+	`;
+	if (rows.length !== 1) {
+		throw new Error("Behavior run's pinned version was not found");
+	}
+	return parseBehaviorSkillSnapshots(rows[0]?.skills);
+}
+
+export function formatBehaviorRunSkillInstructions(
+	skills: readonly BehaviorSkillSnapshot[],
+): string {
+	if (skills.length === 0) return "";
+	return [
+		"## Pinned Behavior skills",
+		"",
+		"Read every skill below before performing this Behavior's task. These files are frozen to this run's version; do not substitute similarly named skills.",
+		"",
+		...skills.map((skill) => `- \`${skill.name}\`: \`.skills/${skill.name}/SKILL.md\``),
+	].join("\n");
+}

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -15,7 +15,12 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
 import { bindRequestAbortToStream } from "../../events/sse-abort-bridge.js";
-import { BEHAVIOR_RUN_SOURCE } from "../behavior-run-session.js";
+import {
+  BEHAVIOR_RUN_SOURCE,
+  type BehaviorRunSkillResolver,
+  formatBehaviorRunSkillInstructions,
+  resolveBehaviorRunSkills,
+} from "../behavior-run-session.js";
 import { toPublicWebOrigin } from "../../utils/url-builder.js";
 import type { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
 import { getRevokedTokenStore } from "../auth/revoked-token-store.js";
@@ -71,6 +76,7 @@ export class WorkerGateway {
   private mcpProxy?: McpProxy;
   private providerCatalogService?: ProviderCatalogService;
   private agentSettingsStore?: AgentSettingsStore;
+  private behaviorRunSkillResolver: BehaviorRunSkillResolver;
   private deploymentActivityTracker?: DeploymentActivityTracker;
 
   constructor(
@@ -80,7 +86,8 @@ export class WorkerGateway {
     instructionService: InstructionService,
     mcpProxy?: McpProxy,
     providerCatalogService?: ProviderCatalogService,
-    agentSettingsStore?: AgentSettingsStore
+    agentSettingsStore?: AgentSettingsStore,
+    behaviorRunSkillResolver: BehaviorRunSkillResolver = resolveBehaviorRunSkills
   ) {
     this.queue = queue;
     this.publicGatewayUrl = publicGatewayUrl;
@@ -91,6 +98,7 @@ export class WorkerGateway {
     this.mcpProxy = mcpProxy;
     this.providerCatalogService = providerCatalogService;
     this.agentSettingsStore = agentSettingsStore;
+    this.behaviorRunSkillResolver = behaviorRunSkillResolver;
 
     // Setup Hono app
     this.app = new Hono();
@@ -729,12 +737,19 @@ export class WorkerGateway {
       // this removes the duplicate id-only read that ignored the org guard.
       //
       // A Behavior run uses version-pinned instructions, so the live library
-      // must not re-enter the turn. Drop both surfaces: the catalog points the
-      // model at `.skills/`, and `skillsConfig` is what the worker syncs there.
+      // must not re-enter the turn. Replace both live surfaces with the pinned
+      // snapshot: `skillsConfig` syncs the frozen files, and the compact catalog
+      // tells the agent which of those files this version requires.
       const behaviorRun = auth.tokenData.source === BEHAVIOR_RUN_SOURCE;
       let skillsConfig: Array<{ name: string; content: string }> = [];
       const mcpContext: Record<string, string> = {};
-      if (agentSettings && !behaviorRun) {
+      if (behaviorRun) {
+        skillsConfig = await this.behaviorRunSkillResolver({
+          conversationId,
+          organizationId: tokenOrgId,
+          agentId,
+        });
+      } else if (agentSettings) {
         const skills = agentSettings.skillsConfig?.skills || [];
         skillsConfig = skills
           .filter((s) => s.enabled && s.content)
@@ -742,11 +757,11 @@ export class WorkerGateway {
       }
 
       const mergedSkillsInstructions = behaviorRun
-        ? ""
+        ? formatBehaviorRunSkillInstructions(skillsConfig)
         : contextData.skillsInstructions || "";
 
       logger.info(
-        `Session context for ${userId}: ${Object.keys(mcpConfig.mcpServers || {}).length} MCPs, ${contextData.agentLayers.identityMd.length}/${contextData.agentLayers.soulMd.length}/${contextData.agentLayers.userMd.length} chars identity/soul/user, ${contextData.platformInstructions.length} chars platform instructions, ${contextData.networkInstructions.length} chars network instructions, ${mergedSkillsInstructions.length} chars skills instructions, ${enrichedMcpStatus.length} MCP status entries, ${Object.keys(mcpTools).length} MCP tool lists, ${Object.keys(mcpInstructions).length} MCP instructions, ${skillsConfig.length} skills${behaviorRun ? " (Behavior run — live skill library suppressed)" : ""}, provider: ${providerConfig.defaultProvider || "none"}`
+        `Session context for ${userId}: ${Object.keys(mcpConfig.mcpServers || {}).length} MCPs, ${contextData.agentLayers.identityMd.length}/${contextData.agentLayers.soulMd.length}/${contextData.agentLayers.userMd.length} chars identity/soul/user, ${contextData.platformInstructions.length} chars platform instructions, ${contextData.networkInstructions.length} chars network instructions, ${mergedSkillsInstructions.length} chars skills instructions, ${enrichedMcpStatus.length} MCP status entries, ${Object.keys(mcpTools).length} MCP tool lists, ${Object.keys(mcpInstructions).length} MCP instructions, ${skillsConfig.length} skills${behaviorRun ? " (Behavior run — pinned snapshot)" : ""}, provider: ${providerConfig.defaultProvider || "none"}`
       );
 
       return c.json({

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -457,9 +457,9 @@ function buildWatcherProposal(
   }
   if (args.action === 'create') {
     if (!args.slug) throw new ToolUserError('slug is required for create action');
-    // Instruction text is required only for trigger shapes that run on it
-    // alone — event-turn Behaviors may omit prompt (built-in default).
-    assertBehaviorInstructions(args.triggers ?? [], args.prompt);
+    // An event-turn Behavior may omit both instruction sources (built-in
+    // default); every other shape needs a prompt, pinned skills, or both.
+    assertBehaviorInstructions(args.triggers ?? [], args.prompt, args.skills);
     if (!args.agent_id) {
       throw new ToolUserError(
         'agent_id is required to create a Behavior (the agent that executes it).'

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -31,6 +31,7 @@ import {
   assertKeyingConfigEntityTypeExists,
   assertWatcherVersionConfigValid,
   assertWatcherSourcesResolve,
+  assertBehaviorSkillsResolve,
   parseJsonInput,
   toJsonParam,
   toTextArrayParam,
@@ -218,7 +219,13 @@ export async function handleCreate(
     triggers: args.triggers,
   });
   await assertBehaviorTriggerConnections(sql, organizationId, triggerWrite.triggers);
-  assertBehaviorInstructions(triggerWrite.triggers, args.prompt);
+  const skills = args.skills ?? [];
+  assertBehaviorInstructions(triggerWrite.triggers, args.prompt, skills);
+  // `args.agent_id` is proven non-null a few lines below, but the skill library
+  // belongs to that agent, so the reference check has to wait for it.
+  if (args.agent_id) {
+    await assertBehaviorSkillsResolve(sql, organizationId, args.agent_id, skills);
+  }
 
   // Check slug uniqueness within org
   const existingSlug = await sql`
@@ -300,12 +307,12 @@ export async function handleCreate(
       await tx`
       INSERT INTO watcher_versions (
         id, watcher_id, version, name, description,
-        prompt, version_sources,
+        prompt, version_sources, skills,
         keying_config, classifiers,
         reactions_guidance, change_notes, created_by, created_at
       ) VALUES (
         ${versionId}, ${watcherId}, 1, ${args.name ?? args.slug}, ${args.description ?? null},
-        ${args.prompt ?? ''}, ${toJsonParam(tx, sources)},
+        ${args.prompt ?? ''}, ${toJsonParam(tx, sources)}, ${tx.json(skills)},
         ${toJsonParam(tx, keyingConfig)}, ${toJsonParam(tx, classifiers)},
         ${args.reactions_guidance ?? null}, ${'Initial version'}, ${createdBy}, NOW()
       )
@@ -446,7 +453,7 @@ export async function handleUpdate(
   await requireExists(sql, 'watchers', args.behavior_id, 'Behavior');
   const currentRows = await sql`
     SELECT w.organization_id, w.agent_id, w.schedule, w.timezone, w.triggers,
-           cv.prompt AS current_prompt
+           cv.prompt AS current_prompt, cv.skills AS current_skills
     FROM watchers w
     LEFT JOIN watcher_versions cv ON cv.id = w.current_version_id
     WHERE w.id = ${args.behavior_id}
@@ -459,6 +466,7 @@ export async function handleUpdate(
     timezone: string | null;
     triggers: ManageBehaviorsArgs['triggers'];
     current_prompt: string | null;
+    current_skills: Array<{ name: string; content: string }> | null;
   };
   const triggerWrite = resolveBehaviorTriggerWrite({
     triggers: args.triggers,
@@ -473,7 +481,11 @@ export async function handleUpdate(
     // with an empty current prompt must fail). Callers that need to change both
     // triggers and instructions atomically must use create_version with both
     // fields — lobu apply does that path.
-    assertBehaviorInstructions(triggerWrite.triggers, currentRow.current_prompt);
+    assertBehaviorInstructions(
+      triggerWrite.triggers,
+      currentRow.current_prompt,
+      currentRow.current_skills
+    );
   }
 
   // Match the invariant from handleCreate: a watcher with no agent_id is
@@ -835,9 +847,13 @@ export async function handleCreateFromVersion(
         // After stripping, the residual trigger shape must still satisfy the
         // instruction rule (chat-link-only sources become manual/empty triggers
         // and require a non-empty prompt).
+        // The clone SHARES the source's watcher_versions row, so its pinned
+        // skills come along with it — they satisfy the rule here exactly as they
+        // will at dispatch.
         assertBehaviorInstructions(
           (Array.isArray(cloneTriggers) ? cloneTriggers : []) as BehaviorTrigger[],
-          version.prompt as string | null | undefined
+          version.prompt as string | null | undefined,
+          version.skills as Array<{ name: string; content: string }> | null
         );
         // `tags` is a text[] column read under fetch_types:false, so postgres.js
         // hands back a raw array literal string (e.g. "{}" or "{system:chat-link}"),

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -105,6 +105,11 @@ export async function handleCreate(
   if (!args.slug) {
     throw new ToolUserError('slug is required for create action');
   }
+  if (!args.agent_id) {
+    throw new ToolUserError(
+      'agent_id is required to create a Behavior (the agent that executes it).'
+    );
+  }
   assertValidExecutionConfig(args.execution_config, ctx);
   // A device pin runs the watcher's agent CLI on the device owner's machine —
   // validate the caller may target this device (own it, or org owner/admin
@@ -124,8 +129,8 @@ export async function handleCreate(
   //   2. explicit `args.sources` (API callers / legacy).
   // If neither yields anything, fall back to a default all-events source.
   // `create_version` deliberately does NOT derive (see version-actions.ts):
-  // on a bump the prompt is compiled skill text, and a skill's prose must not
-  // author the Behavior's sources.
+  // an existing prompt's prose must not silently re-author the Behavior's
+  // source set during an otherwise unrelated version bump.
   const promptSources = extractSourcesFromPromptTokens(args.prompt ?? '');
   const explicitSources = args.sources ?? [];
   const merged = mergePromptSources(explicitSources, promptSources);
@@ -221,11 +226,7 @@ export async function handleCreate(
   await assertBehaviorTriggerConnections(sql, organizationId, triggerWrite.triggers);
   const skills = args.skills ?? [];
   assertBehaviorInstructions(triggerWrite.triggers, args.prompt, skills);
-  // `args.agent_id` is proven non-null a few lines below, but the skill library
-  // belongs to that agent, so the reference check has to wait for it.
-  if (args.agent_id) {
-    await assertBehaviorSkillsResolve(sql, organizationId, args.agent_id, skills);
-  }
+  await assertBehaviorSkillsResolve(sql, organizationId, args.agent_id, skills);
 
   // Check slug uniqueness within org
   const existingSlug = await sql`

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -91,6 +91,7 @@ export async function handleList(
 		query += `,
       cv.description,
       cv.prompt,
+      cv.skills,
       cv.classifiers,
       cv.keying_config,
       cv.reactions_guidance
@@ -209,6 +210,7 @@ export async function handleList(
 
 		if (!args.include_details) {
 			delete (rest as Record<string, unknown>).prompt;
+			delete (rest as Record<string, unknown>).skills;
 			delete (rest as Record<string, unknown>).classifiers;
 			delete (rest as Record<string, unknown>).description;
 		}

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -247,6 +247,73 @@ export function assertWatcherVersionConfigValid(parsed: {
 }
 
 /**
+ * Resolve every pinned skill name against the owning agent's library at save
+ * time, and reject the write if any is missing or disabled.
+ *
+ * Fail closed rather than dropping the unknown entry: a Behavior that silently
+ * loses one of its skills still runs, unattended, with part of its instructions
+ * gone — the failure surfaces as quietly wrong output hours later, on a run
+ * nobody is watching. A 422 at save is the only point where the author is
+ * present to see it.
+ *
+ * The name is validated but the CALLER's `content` is what gets stored: the
+ * snapshot is the author's, taken at save time, and re-reading the body here
+ * would silently upgrade a pin the author never agreed to. This checks that the
+ * reference is real, not that the text still matches.
+ */
+export async function assertBehaviorSkillsResolve(
+  sql: DbClient,
+  organizationId: string,
+  agentId: string,
+  skills: Array<{ name: string; content: string }>
+): Promise<void> {
+  if (skills.length === 0) return;
+
+  const rows = await sql`
+    SELECT skills_config
+    FROM agents
+    WHERE id = ${agentId}
+      AND organization_id = ${organizationId}
+    LIMIT 1
+  `;
+  if (rows.length === 0) {
+    throw new ToolUserError(
+      `Agent ${agentId} was not found in this organization, so its skills cannot be resolved.`,
+      422
+    );
+  }
+
+  const library = Array.isArray(rows[0]?.skills_config?.skills)
+    ? (rows[0].skills_config.skills as Array<Record<string, unknown>>)
+    : [];
+  const enabled = new Set(
+    library
+      .filter((entry) => entry.enabled !== false && typeof entry.name === 'string')
+      .map((entry) => entry.name as string)
+  );
+
+  const unknown = skills.map((skill) => skill.name).filter((name) => !enabled.has(name));
+  if (unknown.length > 0) {
+    throw new ToolUserError(
+      `Skill${unknown.length > 1 ? 's' : ''} ${unknown.map((n) => `"${n}"`).join(', ')} ` +
+        `${unknown.length > 1 ? 'are' : 'is'} not enabled in agent ${agentId}'s skill library. ` +
+        `Enable ${unknown.length > 1 ? 'them' : 'it'} on the agent, or remove ${unknown.length > 1 ? 'them' : 'it'} from this Behavior.`,
+      422
+    );
+  }
+
+  const duplicates = skills
+    .map((skill) => skill.name)
+    .filter((name, index, all) => all.indexOf(name) !== index);
+  if (duplicates.length > 0) {
+    throw new ToolUserError(
+      `Skill "${duplicates[0]}" is listed more than once. Each skill may be pinned once per Behavior.`,
+      422
+    );
+  }
+}
+
+/**
  * Resolve every @ref source against the org at save time so a typo fails here
  * (loud 422) rather than silently producing empty context at read_knowledge.
  * Custom-SQL sources are skipped (id projection is already enforced by

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -268,6 +268,35 @@ export async function assertBehaviorSkillsResolve(
   skills: Array<{ name: string; content: string }>
 ): Promise<void> {
   if (skills.length === 0) return;
+  if (skills.length > 5) {
+    throw new ToolUserError('A Behavior may pin at most 5 skills.', 422);
+  }
+  const invalidName = skills.find(
+    (skill) => !/^[a-zA-Z0-9._-]+$/.test(skill.name)
+  );
+  if (invalidName) {
+    throw new ToolUserError(
+      `Skill "${invalidName.name}" cannot be pinned: names may contain only letters, numbers, ".", "_", and "-".`,
+      422
+    );
+  }
+  const empty = skills.find((skill) => !skill.content.trim());
+  if (empty) {
+    throw new ToolUserError(
+      `Skill "${empty.name}" cannot be pinned because its body is empty.`,
+      422
+    );
+  }
+  const totalBytes = skills.reduce(
+    (sum, skill) => sum + Buffer.byteLength(skill.content, 'utf8'),
+    0
+  );
+  if (totalBytes > 32 * 1024) {
+    throw new ToolUserError(
+      `Pinned Behavior skills contain ${totalBytes} bytes of text; the maximum is 32768 bytes (32KB).`,
+      422
+    );
+  }
 
   const rows = await sql`
     SELECT skills_config

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -14,6 +14,7 @@ import {
   assertKeyingConfigEntityTypeExists,
   assertWatcherVersionConfigValid,
   assertWatcherSourcesResolve,
+  assertBehaviorSkillsResolve,
   parseJsonInput,
   normalizeStoredJsonField,
   toJsonParam,
@@ -57,7 +58,7 @@ export async function handleCreateVersion(
   // schedule, scheduler_client_id) to that specific row.
   const watcherRows = await sql`
     SELECT i.id, i.version, i.current_version_id, i.watcher_group_id, i.sources, i.organization_id,
-           i.entity_ids, i.schedule, i.timezone, i.triggers
+           i.entity_ids, i.schedule, i.timezone, i.triggers, i.agent_id
     FROM watchers i WHERE i.id = ${args.behavior_id}
   `;
   if (watcherRows.length === 0) {
@@ -72,7 +73,7 @@ export async function handleCreateVersion(
   // the caller didn't specify.
   const prevRows = await sql`
     SELECT
-      name, description, prompt, version_sources,
+      name, description, prompt, version_sources, skills,
       keying_config, classifiers,
       reactions_guidance
     FROM watcher_versions
@@ -109,6 +110,18 @@ export async function handleCreateVersion(
     [] as Array<{ name: string; query: string }>
   );
   const sources = args.sources !== undefined ? args.sources : storedSources;
+  // Pinned skills follow the same passed-vs-omitted intent split as sources: an
+  // explicit array replaces (`[]` clears), omission inherits the previous
+  // version's snapshots so a prompt- or metadata-only bump keeps them. Inherited
+  // snapshots are carried VERBATIM and never re-read from the agent's library —
+  // a bump that only renames the Behavior must not quietly upgrade its skill
+  // text to whatever the library holds today. Taking a newer body is an explicit
+  // act: the caller sends the new snapshots.
+  const storedSkills = normalizeStoredJsonField(
+    prev.skills,
+    [] as Array<{ name: string; content: string }>
+  );
+  const skills = args.skills !== undefined ? args.skills : storedSkills;
   const keyingConfig =
     parseJsonInput<Record<string, unknown>>(args.keying_config, 'keying_config') ??
     normalizeStoredJsonField(prev.keying_config, undefined as Record<string, unknown> | undefined);
@@ -140,6 +153,14 @@ export async function handleCreateVersion(
       sources,
       parsePgNumberArray(watcherRows[0].entity_ids),
     );
+    // Only check a CALLER-SUPPLIED skill set, for the same reason keying_config
+    // is gated above: inherited snapshots were already valid when pinned, and a
+    // name-only bump must not start failing because a skill was since renamed or
+    // disabled in the library. The stored text still runs either way.
+    const versionAgentId = watcherRows[0].agent_id as string | null;
+    if (args.skills !== undefined && versionAgentId) {
+      await assertBehaviorSkillsResolve(sql, versionOrganizationId, versionAgentId, skills);
+    }
   }
 
   const triggerWrite = resolveBehaviorTriggerWrite({
@@ -172,11 +193,11 @@ export async function handleCreateVersion(
         Number(sibling.id) === Number(args.behavior_id)
           ? triggerWrite.triggers
           : ((sibling.triggers ?? []) as typeof triggerWrite.triggers);
-      assertBehaviorInstructions(siblingTriggers, prompt);
+      assertBehaviorInstructions(siblingTriggers, prompt, skills);
     }
   } else {
     // Draft version only — triggers on the live row do not change.
-    assertBehaviorInstructions(previousTriggers, prompt);
+    assertBehaviorInstructions(previousTriggers, prompt, skills);
   }
 
   const createdBy = ctx.userId ?? 'system';
@@ -211,14 +232,14 @@ export async function handleCreateVersion(
     await tx`
       INSERT INTO watcher_versions (
         id, watcher_id, version, name, description,
-        prompt, version_sources,
+        prompt, version_sources, skills,
         keying_config, classifiers,
         reactions_guidance, change_notes, created_by, created_at
       ) VALUES (
         ${versionId}, ${groupId}, ${lockedNextVersion},
         ${args.name ?? (prev.name as string) ?? 'Behavior'},
         ${args.description !== undefined ? (args.description ?? null) : ((prev.description as string) ?? null)},
-        ${prompt}, NULL,
+        ${prompt}, NULL, ${tx.json(skills)},
         ${toJsonParam(tx, keyingConfig)}, ${toJsonParam(tx, classifiers)},
         ${args.reactions_guidance ?? (prev.reactions_guidance as string) ?? null},
         ${args.change_notes ?? null}, ${createdBy}, NOW()
@@ -434,7 +455,7 @@ export async function handleGetVersionDetails(
     rows = await sql`
       SELECT
         id, version, name, description, prompt,
-        version_sources,
+        version_sources, skills,
         keying_config, classifiers,
         reactions_guidance
       FROM watcher_versions
@@ -445,7 +466,7 @@ export async function handleGetVersionDetails(
     rows = await sql`
       SELECT
         v.id, v.version, v.name, v.description, v.prompt,
-        v.version_sources,
+        v.version_sources, v.skills,
         v.keying_config, v.classifiers,
         v.reactions_guidance
       FROM watcher_versions v
@@ -479,6 +500,10 @@ export async function handleGetVersionDetails(
     name: v.name as string | undefined,
     description: v.description as string | undefined,
     prompt: v.prompt as string,
+    skills: normalizeStoredJsonField(
+      v.skills,
+      [] as Array<{ name: string; content: string }>
+    ),
     sources:
       versionSources.length > 0
         ? versionSources

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -4,6 +4,7 @@
  */
 
 import { getDb, parsePgNumberArray } from '../../../db/client';
+import { ToolUserError } from '../../../utils/errors';
 import { recordToolConfigChange } from '../helpers/config-audit';
 import { nextRunAt } from '../../../utils/cron';
 import { resolveUsernames } from '../../../utils/resolve-usernames';
@@ -101,10 +102,10 @@ export async function handleCreateVersion(
   //   2. `sources` omitted → INHERIT the assignment's stored sources, so a
   //      prompt- or metadata-only bump preserves them.
   //
-  // The instruction text is not a third input. In particular, `lobu apply`
-  // supplies compiled skill bodies as the prompt; chip-shaped prose there must
-  // not add or remove the assignment's sources. Interactive authoring clients
-  // send an explicit replacement when their source-chip set changes.
+  // The prompt is not a third input. In particular, chip-shaped prose in an
+  // inherited task statement must not add or remove the assignment's sources.
+  // Interactive authoring clients send an explicit replacement when their
+  // source-chip set changes.
   const storedSources = normalizeStoredJsonField(
     watcherRows[0].sources,
     [] as Array<{ name: string; query: string }>
@@ -158,9 +159,20 @@ export async function handleCreateVersion(
     // name-only bump must not start failing because a skill was since renamed or
     // disabled in the library. The stored text still runs either way.
     const versionAgentId = watcherRows[0].agent_id as string | null;
-    if (args.skills !== undefined && versionAgentId) {
+    if (args.skills !== undefined && skills.length > 0) {
+      if (!versionAgentId) {
+        throw new ToolUserError(
+          'This Behavior has no owning agent, so pinned skills cannot be resolved.',
+          422
+        );
+      }
       await assertBehaviorSkillsResolve(sql, versionOrganizationId, versionAgentId, skills);
     }
+  } else if (args.skills !== undefined && skills.length > 0) {
+    throw new ToolUserError(
+      'This Behavior has no organization, so pinned skills cannot be resolved.',
+      422
+    );
   }
 
   const triggerWrite = resolveBehaviorTriggerWrite({

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -501,6 +501,7 @@ export const QUERYABLE_SCHEMA = {
         'name',
         'description',
         'prompt',
+        'skills',
         'keying_config',
         'classifiers',
         'reactions_guidance',

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -14,6 +14,7 @@ import { deriveWatcherExtractionSchema } from '../utils/watcher-extraction-schem
 import { withDbRetry } from '../db/with-retry';
 import type { Env } from '../index';
 import { claimPendingWatcherRun } from '../runs/queue-service';
+import { parseBehaviorSkillSnapshots } from '../behaviors/skill-snapshots';
 import { materializeDueFeeds } from '../scheduled/check-due-feeds';
 import {
   DEFAULT_AGENT_ID,
@@ -58,6 +59,29 @@ function parseClaimJson(raw: unknown): Record<string, unknown> | null {
     }
   }
   return null;
+}
+
+/**
+ * Device executors do not use the server-side worker filesystem, so compose the
+ * same frozen snapshots into their per-run task at dispatch time. This does not
+ * mutate or conflate the stored fields: `prompt` remains the author's task
+ * statement and `skills` remain individually diffable on the version.
+ */
+function formatDeviceBehaviorInstructions(
+  prompt: string | null,
+  rawSkills: unknown
+): string | null {
+  const skills = parseBehaviorSkillSnapshots(rawSkills);
+  if (skills.length === 0) return prompt;
+  const skillSections = skills.map(
+    (skill) => `### ${skill.name}\n\n${skill.content}`
+  );
+  return [
+    ...(prompt?.trim() ? [prompt] : []),
+    '## Pinned Behavior skills',
+    'These frozen skills are part of this Behavior version. Follow every one when performing the task.',
+    ...skillSections,
+  ].join('\n\n');
 }
 
 /**
@@ -607,6 +631,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         w.notification_priority AS watcher_notification_priority,
         w.execution_config AS watcher_execution_config,
         wv.prompt AS watcher_prompt,
+        wv.skills AS watcher_skills,
         wv.keying_config AS watcher_keying_config
       FROM runs r
       LEFT JOIN feeds f ON f.id = r.feed_id
@@ -697,6 +722,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     watcher_notification_priority: string | null;
     watcher_execution_config: Record<string, unknown> | null;
     watcher_prompt: string | null;
+    watcher_skills: unknown;
     watcher_keying_config: Record<string, unknown> | string | null;
     // Auth run fields
     run_auth_profile_id: number | null;
@@ -734,6 +760,31 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       parseClaimJson(row.watcher_keying_config) as KeyingConfig | null,
       row.watcher_id
     );
+    let watcherInstructions: string | null;
+    try {
+      watcherInstructions = formatDeviceBehaviorInstructions(
+        row.watcher_prompt,
+        row.watcher_skills
+      );
+    } catch (err) {
+      const message = errorMessage(err);
+      await sql`
+        UPDATE runs
+        SET status = 'failed',
+            completed_at = current_timestamp,
+            error_message = ${message}
+        WHERE id = ${row.run_id}
+      `;
+      logger.error(
+        { run_id: row.run_id, err },
+        'Failed to resolve pinned Behavior skills for device dispatch'
+      );
+      return c.json({
+        next_poll_seconds: 1,
+        skipped_run_id: row.run_id,
+        error: message,
+      });
+    }
     return c.json({
       run_id: row.run_id,
       run_type: row.run_type,
@@ -749,7 +800,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           // Strip server-only keys (e.g. finalize_nudges) so the device-worker's
           // strict payload decode never sees a field it doesn't know.
           execution_config: stripServerOnlyExecutionConfig(row.watcher_execution_config),
-          // The prompt of the version this run was pinned to at creation
+          // The instructions of the version this run was pinned to at creation:
+          // the author's prompt plus its frozen skill snapshots. Device-local
+          // executors do not receive the server-side worker's `.skills/` tree,
+          // so dispatch composes the two at this boundary without changing the
+          // separately stored/diffable version fields.
+          //
           // (run's snapshotted approved_input.version_id, else the watcher's
           // current_version_id) — same source complete_window validates
           // against, so a watcher edited after the run was queued doesn't swap
@@ -758,7 +814,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           // id/name/slug), so a scheduled watcher's local CLI got a bare
           // "process this" and improvised; shipping it lets the device run the
           // real prompt. Null only if the watcher has no version row.
-          prompt: row.watcher_prompt ?? null,
+          prompt: watcherInstructions,
           // The derived extraction contract (entity-typed → derived from that
           // entity type's metadata_schema; untyped → null). The dispatcher embeds
           // it in the prompt as the output contract: the CLI must finish with a


### PR DESCRIPTION
## Summary

- A Behavior's skills were concatenated into `watcher_versions.prompt` at save time. The bytes were already stored — just flattened with the seams discarded — so a skill edit was invisible to every Behavior using it, and the editor could not tell a task statement from inherited skill text.
- Store `watcher_versions.skills` as ordered `[{name, content}]` instead. Same content, seams intact, which is what makes diff/upgrade and picker rehydration possible. `prompt` goes back to the author as a task statement.
- Deliver the pinned snapshots at run time: server runs get them as the `.skills/` tree via the session-context seam; device runs get them composed into the dispatch payload, since that executor has no channel back to the skill library.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] `make test-unit` — exit 0, 0 failures
- [x] `make test-integration` — **364 files, 3153 passed, 2 skipped, 0 failed**
- [ ] Bug fix: n/a (behavior change, not a bug fix)
- [ ] Bot behavior: n/a

Migration applied to `lobu_test` and `lobu_main`; `watcher_versions.skills jsonb` confirmed present.

## Notes

**The instruction rule relaxes to an OR.** Previously `prompt` was required for schedule / event-window / no-trigger Behaviors, and `behaviorRequiresSkills` demanded a skill for the same set — consistent only because skills *were* the prompt. Decoupling them without an OR would have demanded both, stricter than what it replaced. Now: supply `prompt`, `skills`, or both.

**Why delivery is in the same PR, not a follow-up.** `defineBehavior` had no `prompt` field before this branch, so every existing declarative Behavior is skills-only. Storing without delivering would have made the next `lobu apply` set `prompt: ""`, bump the version, and leave each Behavior dispatching on the generic built-in fallback with its real instructions dropped — silently, unattended. The write half alone is not a smaller change; it is a broken one.

**Declarative surface is unchanged** for `skills: string[]`; `defineBehavior({ prompt })` is added. Apply resolves names to bodies and the diff compares **bodies**, so editing a `SKILL.md` still drives version churn — a name-level diff would report "no changes" and strand every Behavior on the old text. Re-applying is the config-project equivalent of the editor's upgrade action.

**`init-from-org` no longer rehomes stored instructions into a synthesized skill** (−102 lines). That existed only because there was nowhere else to put the text; keeping it would make the first apply after a bootstrap rewrite every Behavior it had just faithfully described.

**Fail-closed throughout.** A referenced skill that is missing or disabled rejects the write rather than being dropped; malformed pinned state fails the run rather than executing without instructions. A Behavior that silently loses part of its instructions still runs and surfaces as quietly wrong output hours later.

Follow-ups (not in this PR): the owletto composer work — `@` skill chips in the prompt, the read-only attached-skills strip, and the diff/upgrade action.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Behaviors can now use pinned skill snapshots alongside authored prompts.
  - Skill content is preserved with behavior versions, ensuring runs use the instructions captured when queued.
  - Behavior creation, updates, cloning, listing, and version details now support pinned skills.
  - Project initialization preserves pinned skills and prompts from existing behaviors.

- **Bug Fixes**
  - Prompt-only behaviors are now accepted where appropriate.
  - Behavior updates apply trigger and skill changes atomically.
  - Added validation for missing, duplicate, unsafe, disabled, or oversized skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->