### PR TITLE
fix(review): make the review harness survive a single-CLI outage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,6 +596,16 @@ jobs:
         # Three other sections say the opposite; this pins the one direction.
         run: bun test scripts/__tests__/review-prompt-env-blockers.test.ts
 
+      - name: Review output schema dialect
+        # prompts/review-output-schema.json is handed to BOTH reviewer CLIs —
+        # `claude --json-schema` and `codex exec --output-schema` — and the
+        # review gate fails closed on a schema either one rejects. A stray
+        # draft-2020-12 `$schema` meta-ref made claude refuse the file outright
+        # ("no schema with key or ref …"), which surfaced only under a codex
+        # quota outage and read as a dead reviewer, not a bad key. Pins the
+        # schema to the reference-free shape both CLIs load.
+        run: bun test scripts/__tests__/review-output-schema.test.ts
+
       - name: Raw-array SQL-param gate
         # packages/server's postgres.js client runs fetch_types:false, where a raw
         # JS array bound as a query param serializes to a malformed array literal

--- a/prompts/review-output-schema.json
+++ b/prompts/review-output-schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "description": "Lobu merge-review verdict. Judge the diff against the requested base and report concrete changed-path defects only.",
   "additionalProperties": false,

--- a/scripts/__tests__/review-output-schema.test.ts
+++ b/scripts/__tests__/review-output-schema.test.ts
@@ -35,10 +35,12 @@ const REPO_ROOT = resolve(import.meta.dir, "..", "..");
 const SCHEMA_FILE = join(REPO_ROOT, "prompts/review-output-schema.json");
 
 /**
- * Keys that make `claude --json-schema` refuse the file outright. A dialect
- * declaration is optional metadata for both CLIs — neither infers anything
- * from it — so removing it costs nothing and dropping it from the whitelist
- * is the whole fix.
+ * `$schema` and `$id` point the loader at a document it will not fetch —
+ * claude refuses the file outright with "no schema with key or ref …". Local
+ * `$defs`/`$ref` DO load in the claude CLI (verified: a `#/$defs/…` schema
+ * round-trips), but they are reference machinery a flat verdict schema does
+ * not need, so the guard keeps the file reference-free instead of tracking
+ * which CLI tolerates which indirection.
  */
 function unsupportedKeys(schema: Record<string, unknown>): string[] {
   return ["$schema", "$id", "$ref", "$defs"].filter((key) => key in schema);
@@ -61,7 +63,7 @@ describe("review output schema stays loadable by both reviewer CLIs", () => {
   const raw = readFileSync(SCHEMA_FILE, "utf8");
   const schema = JSON.parse(raw) as Record<string, any>;
 
-  it("declares no meta-schema reference claude cannot resolve", () => {
+  it("stays reference-free so both reviewer CLIs load it", () => {
     expect(unsupportedKeys(schema)).toEqual([]);
   });
 

--- a/scripts/__tests__/review-output-schema.test.ts
+++ b/scripts/__tests__/review-output-schema.test.ts
@@ -1,0 +1,115 @@
+/**
+ * `prompts/review-output-schema.json` is handed to BOTH reviewer CLIs by
+ * `scripts/review.sh` — `claude --json-schema "$(cat …)"` and `codex exec
+ * --output-schema …`. The two accept overlapping but not identical dialects,
+ * and `review.sh` fails closed: a schema either CLI rejects produces no
+ * verdict, `finalize_review_status error`, and a red `pi-review` status. That
+ * check is required with `enforce_admins` on, so a one-key schema edit can
+ * block every merge in the repo.
+ *
+ * That is exactly what happened. The file opened with
+ *
+ *   "$schema": "https://json-schema.org/draft/2020-12/schema"
+ *
+ * and `claude --json-schema` cannot resolve that meta-schema reference:
+ *
+ *   Error: --json-schema is not a valid JSON Schema: no schema with key or
+ *   ref "https://json-schema.org/draft/2020-12/schema"
+ *
+ * It exits before reading the prompt, so the failure looks like a dead
+ * reviewer rather than a bad key. codex accepts the file either way, so the
+ * repo ran for as long as codex was the selected reviewer and only broke on
+ * the fallback — the worst shape for a gate, because it is discovered under a
+ * quota outage when there is no second reviewer to fall back to.
+ *
+ * The keys asserted here are the ones whose absence a reviewer only reports
+ * as "no schema-valid JSON verdict", which reads as a model failure and sends
+ * the next person to re-run the review instead of to this file.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "bun:test";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const SCHEMA_FILE = join(REPO_ROOT, "prompts/review-output-schema.json");
+
+/**
+ * Keys that make `claude --json-schema` refuse the file outright. A dialect
+ * declaration is optional metadata for both CLIs — neither infers anything
+ * from it — so removing it costs nothing and dropping it from the whitelist
+ * is the whole fix.
+ */
+function unsupportedKeys(schema: Record<string, unknown>): string[] {
+  return ["$schema", "$id", "$ref", "$defs"].filter((key) => key in schema);
+}
+
+/**
+ * `required` naming a property that does not exist is the other way this file
+ * fails closed: codex's structured-output mode rejects the schema, and the
+ * error surfaces as an empty verdict rather than as a schema complaint.
+ */
+function danglingRequired(schema: {
+  required?: string[];
+  properties?: Record<string, unknown>;
+}): string[] {
+  const properties = schema.properties ?? {};
+  return (schema.required ?? []).filter((name) => !(name in properties));
+}
+
+describe("review output schema stays loadable by both reviewer CLIs", () => {
+  const raw = readFileSync(SCHEMA_FILE, "utf8");
+  const schema = JSON.parse(raw) as Record<string, any>;
+
+  it("declares no meta-schema reference claude cannot resolve", () => {
+    expect(unsupportedKeys(schema)).toEqual([]);
+  });
+
+  it("flags the draft-2020-12 declaration that broke the claude reviewer", () => {
+    expect(
+      unsupportedKeys({
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        type: "object",
+      })
+    ).toEqual(["$schema"]);
+  });
+
+  it("requires only properties it defines", () => {
+    expect(danglingRequired(schema)).toEqual([]);
+  });
+
+  it("flags a required name with no matching property", () => {
+    expect(
+      danglingRequired({
+        required: ["bugs", "typo_field"],
+        properties: { bugs: { type: "number" } },
+      })
+    ).toEqual(["typo_field"]);
+  });
+
+  it("keeps the closed-object shape codex's structured output needs", () => {
+    expect(schema.type).toBe("object");
+    expect(schema.additionalProperties).toBe(false);
+  });
+
+  it("still carries the fields review.sh reads out of the verdict", () => {
+    // review.sh pipes the verdict through `jq -r .<field>` and validates each
+    // one before posting the status; a field dropped here fails the gate for
+    // every PR, not just the one that dropped it.
+    for (const field of [
+      "bug_free_confidence",
+      "bugs",
+      "slop",
+      "simplicity",
+      "blockers",
+      "change_type",
+      "behavior_change_risk",
+      "tests_adequate",
+      "suggested_fixes",
+      "notes",
+      "categories",
+    ]) {
+      expect(schema.required).toContain(field);
+    }
+  });
+});

--- a/scripts/lib/__tests__/review-reviewer.test.sh
+++ b/scripts/lib/__tests__/review-reviewer.test.sh
@@ -94,6 +94,30 @@ if grep -Eiq 'herdr|CLAUDE_REVIEW_HERDR' "$review_script"; then
   fail "review.sh must not reference Herdr (inline-only reviewer)"
 fi
 
+# review-fix.sh is the selector's other consumer (step 5 of "Ship a change").
+# Unlike review.sh it posts no status, so when it was hard-wired to codex
+# (`command -v codex || exit 1`) a codex outage silently skipped the whole
+# fixer pass, with nothing anywhere to record that a quality pass never ran.
+# Pin the structure that regressed: the shared selector, an invocation arm per
+# CLI, the model allowlist, and the write tools that make the claude arm a
+# fixer rather than a review whose findings go nowhere.
+review_fix_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/review-fix.sh"
+grep -Fq '. "$SCRIPT_DIR/lib/review-reviewer.sh"' "$review_fix_script" ||
+  fail "review-fix.sh must source the shared reviewer lib"
+grep -Fq 'FIXER_CLI="$(review_select_reviewer' "$review_fix_script" ||
+  fail "review-fix.sh must pick its CLI through review_select_reviewer"
+grep -Fq 'review_validate_claude_model "$CLAUDE_REVIEW_MODEL"' "$review_fix_script" ||
+  fail "review-fix.sh must fail closed on disallowed Claude fixer models"
+grep -Fq 'codex exec' "$review_fix_script" ||
+  fail "review-fix.sh must keep its codex invocation arm"
+grep -Fq 'claude -p' "$review_fix_script" ||
+  fail "review-fix.sh must keep its claude invocation arm"
+grep -Eq -- '--tools [^[:space:]]*Edit[^[:space:]]*Write' "$review_fix_script" ||
+  fail "review-fix.sh claude arm must carry the Edit/Write tools that make it a fixer"
+if grep -Fq 'command -v codex >/dev/null' "$review_fix_script"; then
+  fail "review-fix.sh must not gate every run on codex being installed"
+fi
+
 echo "review reviewer selection tests passed"
 
 # --- pi-review gate matrix -------------------------------------------------

--- a/scripts/review-fix.sh
+++ b/scripts/review-fix.sh
@@ -4,7 +4,17 @@
 # BEFORE `make review` posts a pi-review status. Posts nothing; commits
 # nothing. The driving agent inspects the edits (shown at the end), commits,
 # then runs `make review` once on the settled HEAD.
+#
+# Reviewer selection matches review.sh — REVIEWER_CLI=auto|codex|claude. This
+# step is mandated by AGENTS.md but is not a gate: unlike review.sh it posts no
+# status, so a reviewer outage here silently skips the fixer instead of failing
+# a check. Being hard-wired to one CLI therefore costs a whole quality pass
+# whenever that CLI is unavailable, with nothing to signal it happened.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/review-reviewer.sh
+. "$SCRIPT_DIR/lib/review-reviewer.sh"
 
 cd "$(dirname "$0")/.."
 
@@ -43,20 +53,45 @@ if git diff --quiet "$BASE_BRANCH...HEAD" 2>/dev/null && git diff --quiet && git
   exit 0
 fi
 
-command -v codex >/dev/null 2>&1 || { echo ">> codex not found on PATH" >&2; exit 1; }
+FIXER_CLI="$(review_select_reviewer "${REVIEWER_CLI:-auto}")"
+CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"
+CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
+if [ "$FIXER_CLI" = "claude" ]; then
+  review_validate_claude_model "$CLAUDE_REVIEW_MODEL" || exit $?
+fi
+command -v "$FIXER_CLI" >/dev/null 2>&1 || { echo ">> $FIXER_CLI not found on PATH" >&2; exit 1; }
 
 LAST_MSG_FILE="$(mktemp /tmp/lobu-review-fix.XXXXXX)"
 trap 'rm -f "$LAST_MSG_FILE"' EXIT
 
-echo ">> pre-review fixer (codex, base $BASE_BRANCH) — edits the working tree, posts nothing"
-CODEX_ARGS=(codex exec --sandbox workspace-write --output-last-message "$LAST_MSG_FILE" --ephemeral)
-if [ -n "${CODEX_REVIEW_MODEL:-}" ]; then
-  CODEX_ARGS+=(--model "$CODEX_REVIEW_MODEL")
-fi
+echo ">> pre-review fixer ($FIXER_CLI, base $BASE_BRANCH) — edits the working tree, posts nothing"
 
 set +e
-env BASE_BRANCH="$BASE_BRANCH" "${CODEX_ARGS[@]}" "$(cat "$PROMPT_FILE")" < /dev/null > /dev/null
-FIXER_EXIT=$?
+case "$FIXER_CLI" in
+  codex)
+    CODEX_ARGS=(codex exec --sandbox workspace-write --output-last-message "$LAST_MSG_FILE" --ephemeral)
+    if [ -n "${CODEX_REVIEW_MODEL:-}" ]; then
+      CODEX_ARGS+=(--model "$CODEX_REVIEW_MODEL")
+    fi
+    env BASE_BRANCH="$BASE_BRANCH" "${CODEX_ARGS[@]}" "$(cat "$PROMPT_FILE")" < /dev/null > /dev/null
+    FIXER_EXIT=$?
+    ;;
+  claude)
+    # `--output-last-message` has no claude equivalent; its stdout IS the
+    # summary, so capture that instead of discarding it as the codex arm does.
+    # Edit/Write are the point of this pass — without them it is a review that
+    # cannot fix anything.
+    env BASE_BRANCH="$BASE_BRANCH" \
+      claude -p "$(cat "$PROMPT_FILE")" \
+        --model "$CLAUDE_REVIEW_MODEL" \
+        --effort "$CLAUDE_REVIEW_EFFORT" \
+        --output-format text \
+        --no-session-persistence \
+        --tools Bash,Read,Grep,LS,Edit,Write \
+        --permission-mode bypassPermissions < /dev/null > "$LAST_MSG_FILE"
+    FIXER_EXIT=$?
+    ;;
+esac
 set -e
 
 echo

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -351,6 +351,10 @@ fi
 # --- agent review -----------------------------------------------------------
 
 PROMPT_FILE="$(pwd)/prompts/review-prompt.md"
+# Shared by both reviewer CLIs below, which do NOT accept the same dialect:
+# `claude --json-schema` refuses a `$schema` meta-reference outright ("no
+# schema with key or ref …") while codex ignores it. The schema therefore
+# declares no dialect — see scripts/__tests__/review-output-schema.test.ts.
 SCHEMA_FILE="$(pwd)/prompts/review-output-schema.json"
 [ -f "$PROMPT_FILE" ] || { echo "prompt not found: $PROMPT_FILE" >&2; exit 2; }
 [ -f "$SCHEMA_FILE" ] || { echo "schema not found: $SCHEMA_FILE" >&2; exit 2; }


### PR DESCRIPTION
## Summary
The review harness has two independent single-points-of-failure on codex, and both hide themselves. Codex ran out of credits today, which surfaced them together.

**1. `prompts/review-output-schema.json` declared `$schema: draft/2020-12`.** `scripts/review.sh` hands one schema file to both reviewer CLIs, but `claude --json-schema` cannot resolve that meta-reference and exits **before reading the prompt**; codex ignores the key. So the repo only broke on the claude fallback — exactly where it lands during a codex outage, with no second reviewer left. `pi-review` is required with `enforce_admins` on, so this blocked every merge.

**2. `scripts/review-fix.sh` was hard-wired to codex** (`command -v codex || exit 1`) while `review.sh` already honoured `REVIEWER_CLI=auto|codex|claude`. `REVIEWER_CLI=claude make review-fix` was accepted and silently ignored. This one is worse than a broken gate: review-fix posts no status, so an outage doesn't fail a check — the mandated step (AGENTS.md "Ship a change" #5) just doesn't happen, and nothing records that a quality pass was skipped.

Same class — the review tooling must survive either CLI being down — so they ship together.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit`, `bash scripts/lib/__tests__/review-reviewer.test.sh`, `bun test scripts/__tests__/review-output-schema.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### red — schema as it was on `main`

```
$ claude -p "…" --json-schema "$(cat prompts/review-output-schema.json)" --output-format text
Error: --json-schema is not a valid JSON Schema: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
```

### green — same invocation with `$schema` removed

```
$ claude -p "…" --json-schema "$(jq 'del(."$schema")' prompts/review-output-schema.json)" --output-format text
{"bug_free_confidence":50,"bugs":0,"slop":0,"simplicity":50,"blockers":[],"change_type":"chore",
 "behavior_change_risk":"none","tests_adequate":true,"suggested_fixes":[],"notes":"test",
 "categories":{"src":0,"tests":0,"docs":0,"config":0,"deps":0,"migrations":0,"ci":0,"generated":0}}
```

A schema-valid verdict, which is what `review.sh` gates on.

### red→green for the fixer arm

```
$ REVIEWER_CLI=claude make review-fix          # before
>> pre-review fixer (codex, base origin/main)  # the override is ignored
ERROR: You've hit your usage limit … try again at Aug 5th

$ REVIEWER_CLI=claude make review-fix          # after
>> pre-review fixer (claude, base origin/main) — edits the working tree, posts nothing
========== fixer summary ==========
Fixer pass complete. All touched tests green …
```

That fixer pass is in this PR's history: it caught that the schema guard was wired into **no CI step** (a guard that never runs guards nothing), and corrected a false claim in my own comment — I had written that `$id`/`$ref`/`$defs` also make claude refuse the file; it verified a local `#/$defs/…` schema round-trips fine, and only the unresolvable `$schema` meta-ref is refused.

### guards, mutation-tested

```
# re-add "$schema":                    1 fail  (declares no meta-schema reference)
# revert review-fix.sh to codex-only:  FAIL: review-fix.sh must source the shared reviewer lib
# strip Edit,Write from the claude arm: FAIL: claude arm must carry the Edit/Write tools
# restored:                            review reviewer selection tests passed / 6 pass 0 fail
```

## Notes
**codex evidence is partial, and I want that on the record.** codex is out of credits until Aug 5, so it could not round-trip the edited schema. What I did verify: `codex exec --output-schema` accepts the file identically **with and without** the key — both runs get past local schema validation and die at the same quota error — so local validation is unaffected. The remote structured-output call is untested against the edited file, and the codex arm of `review-fix.sh` is unchanged but also unexercised today.

The claude arm runs `--permission-mode bypassPermissions` while the codex arm is sandboxed to `workspace-write`. That asymmetry matches existing `review.sh` precedent, and with `Bash` in the tool list the tool-level sandbox is symbolic anyway — flagging rather than silently widening it.

Structural assertions went into `scripts/lib/__tests__/review-reviewer.test.sh` rather than a new file: it already holds the identical class of greps for `review.sh` and already runs in CI, and it already covers selector/model-allowlist *behavior*, so a separate TS test would have been two homes for one thing.

Found while shipping #2371, where this blocked the merge and I had to strip the key in the working tree to get a review at all.
