### PR TITLE
feat(server): reject a prompt that references an unpinned skill

### DIFF
--- a/packages/server/src/__tests__/unit/prompt-skill-tokens-pinned.test.ts
+++ b/packages/server/src/__tests__/unit/prompt-skill-tokens-pinned.test.ts
@@ -2,7 +2,7 @@
  * A prompt `@[skill:…]` chip must have a matching entry in `skills[]`.
  *
  * Ref tokens are never stripped — nothing in the instruction path rewrites them
- * (grep `PROMPT_REF_TOKEN`: the only consumer is source derivation) — so an
+ * (grep `PROMPT_REF_TOKEN`: every consumer only reads the prompt) — so an
  * unpinned chip does not fail loudly, it degrades: the agent reads the literal
  * `@[skill:deploy-runbook:Deploy runbook](/…)` as if it were guidance, with no
  * `.skills/` file behind it. Silent wrong instructions are worse than a 422.

--- a/packages/server/src/__tests__/unit/prompt-skill-tokens-pinned.test.ts
+++ b/packages/server/src/__tests__/unit/prompt-skill-tokens-pinned.test.ts
@@ -1,0 +1,118 @@
+/**
+ * A prompt `@[skill:…]` chip must have a matching entry in `skills[]`.
+ *
+ * Ref tokens are never stripped — nothing in the instruction path rewrites them
+ * (grep `PROMPT_REF_TOKEN`: the only consumer is source derivation) — so an
+ * unpinned chip does not fail loudly, it degrades: the agent reads the literal
+ * `@[skill:deploy-runbook:Deploy runbook](/…)` as if it were guidance, with no
+ * `.skills/` file behind it. Silent wrong instructions are worse than a 422.
+ *
+ * The check is deliberately ONE-directional. A pinned skill with no chip is
+ * legal — that is the declarative path (`defineBehavior({ skills: [...] })`
+ * carries no prompt at all), and rejecting it would strand every CLI-authored
+ * Behavior.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { assertPromptSkillTokensPinned } from "../../tools/admin/manage_behaviors/shared";
+import { extractSkillNamesFromPromptTokens } from "../../watchers/source-refs";
+
+const chip = (name: string, label = name) =>
+	`@[skill:${name}:${label}](/acme/agents/a/skills/${name})`;
+
+describe("extractSkillNamesFromPromptTokens", () => {
+	it("reads the id out of a skill chip, not the label", () => {
+		expect(
+			extractSkillNamesFromPromptTokens(
+				`Run ${chip("deploy-runbook", "Deploy runbook")} nightly.`,
+			),
+		).toEqual(["deploy-runbook"]);
+	});
+
+	it("ignores every other ref kind", () => {
+		// These are sources or scoping, and each already has its own handling.
+		// A skill token must not become a source and a source must not become a
+		// pinned skill.
+		const prompt = [
+			"@[feed:inbox:Inbox](/acme/feeds/inbox)",
+			"@[connection:42:Stripe](/acme/connectors/stripe/42)",
+			"@[entity:7:Spotify](/acme/company/spotify)",
+			"@[metric:asset.spend:Spend](/acme/metrics/asset.spend)",
+		].join(" ");
+		expect(extractSkillNamesFromPromptTokens(prompt)).toEqual([]);
+	});
+
+	it("de-dupes repeats but keeps first-seen order", () => {
+		expect(
+			extractSkillNamesFromPromptTokens(
+				`${chip("b")} then ${chip("a")} then ${chip("b")}`,
+			),
+		).toEqual(["b", "a"]);
+	});
+
+	it("returns nothing for a prompt with no tokens", () => {
+		expect(extractSkillNamesFromPromptTokens("Summarize yesterday.")).toEqual(
+			[],
+		);
+		expect(extractSkillNamesFromPromptTokens("")).toEqual([]);
+	});
+});
+
+describe("assertPromptSkillTokensPinned", () => {
+	it("accepts a chip whose skill is pinned", () => {
+		expect(() =>
+			assertPromptSkillTokensPinned(`Follow ${chip("deploy-runbook")}.`, [
+				{ name: "deploy-runbook" },
+			]),
+		).not.toThrow();
+	});
+
+	it("rejects a chip with no pinned entry", () => {
+		expect(() =>
+			assertPromptSkillTokensPinned(`Follow ${chip("deploy-runbook")}.`, []),
+		).toThrow(/deploy-runbook/);
+	});
+
+	it("names every unpinned skill, not just the first", () => {
+		expect(() =>
+			assertPromptSkillTokensPinned(`${chip("alpha")} ${chip("beta")}`, []),
+		).toThrow(/"alpha", "beta"/);
+	});
+
+	it("rejects when only SOME chips are pinned", () => {
+		// The realistic drift: the composer sent a stale skills array after the
+		// author added one more chip.
+		expect(() =>
+			assertPromptSkillTokensPinned(`${chip("alpha")} ${chip("beta")}`, [
+				{ name: "alpha" },
+			]),
+		).toThrow(/"beta"/);
+	});
+
+	it("allows a pinned skill that the prompt never mentions", () => {
+		// The declarative path: `defineBehavior({ skills: [...] })` has no prompt.
+		expect(() =>
+			assertPromptSkillTokensPinned(null, [{ name: "deploy-runbook" }]),
+		).not.toThrow();
+		expect(() =>
+			assertPromptSkillTokensPinned("Summarize yesterday.", [
+				{ name: "deploy-runbook" },
+			]),
+		).not.toThrow();
+	});
+
+	it("is a no-op when there is neither a chip nor a pin", () => {
+		expect(() => assertPromptSkillTokensPinned(undefined, undefined)).not.toThrow();
+		expect(() => assertPromptSkillTokensPinned("", null)).not.toThrow();
+	});
+
+	it("matches on the skill name, not on label text that happens to collide", () => {
+		// A chip labelled "alpha" whose actual skill id is "beta" must be checked
+		// as "beta" — otherwise a rename shows green while pinning the wrong body.
+		expect(() =>
+			assertPromptSkillTokensPinned(`@[skill:beta:alpha](/x)`, [
+				{ name: "alpha" },
+			]),
+		).toThrow(/"beta"/);
+	});
+});

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -32,6 +32,7 @@ import {
   assertWatcherVersionConfigValid,
   assertWatcherSourcesResolve,
   assertBehaviorSkillsResolve,
+  assertPromptSkillTokensPinned,
   parseJsonInput,
   toJsonParam,
   toTextArrayParam,
@@ -226,6 +227,7 @@ export async function handleCreate(
   await assertBehaviorTriggerConnections(sql, organizationId, triggerWrite.triggers);
   const skills = args.skills ?? [];
   assertBehaviorInstructions(triggerWrite.triggers, args.prompt, skills);
+  assertPromptSkillTokensPinned(args.prompt, skills);
   await assertBehaviorSkillsResolve(sql, organizationId, args.agent_id, skills);
 
   // Check slug uniqueness within org

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -15,6 +15,7 @@ import { queryProjectsIdColumn } from '../../../utils/execute-data-sources';
 import {
   validateWatcherSourceRef,
   resolveWatcherSourcesForSave,
+  extractSkillNamesFromPromptTokens,
 } from '../../../watchers/source-refs';
 import type { ToolContext } from '../../registry';
 import { normalizeBehaviorTags } from '@lobu/core/contracts/tools/manage-behaviors';
@@ -340,6 +341,37 @@ export async function assertBehaviorSkillsResolve(
       422
     );
   }
+}
+
+/**
+ * Every `@[skill:…]` chip in the prompt must have a pinned entry in `skills[]`.
+ *
+ * Ref tokens survive into the instructions verbatim — nothing strips them (see
+ * `extractSourcesFromPromptTokens`) — so an unpinned chip does not fail, it
+ * degrades: the agent reads the literal `@[skill:deploy-runbook:…](…)` as if it
+ * were guidance, with no `.skills/` file behind it. The web composer always
+ * sends both halves; a CLI or MCP caller writing the token by hand can send the
+ * prompt alone, and that is the case this catches.
+ *
+ * Names only — the pinned BODY still comes from the caller, never from a
+ * save-time read of the live library.
+ */
+export function assertPromptSkillTokensPinned(
+  prompt: string | null | undefined,
+  skills: ReadonlyArray<{ name: string }> | null | undefined
+): void {
+  const referenced = extractSkillNamesFromPromptTokens(prompt ?? '');
+  if (referenced.length === 0) return;
+  const pinned = new Set((skills ?? []).map((skill) => skill.name));
+  const missing = referenced.filter((name) => !pinned.has(name));
+  if (missing.length === 0) return;
+  throw new ToolUserError(
+    `The prompt references skill${missing.length > 1 ? 's' : ''} ` +
+      `${missing.map((n) => `"${n}"`).join(', ')} that ${missing.length > 1 ? 'are' : 'is'} not ` +
+      `pinned on this Behavior. Pass ${missing.length > 1 ? 'them' : 'it'} in "skills" so the body is ` +
+      `frozen with this version, or remove the reference from the prompt.`,
+    422
+  );
 }
 
 /**

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -214,6 +214,9 @@ export async function handleCreateVersion(
   }
   // Both branches above write the SAME resolved prompt+skills pair, so the
   // chip/pin agreement is checked once here rather than inside either arm.
+  // Unconditional, unlike the caller-supplied-only gates above: those consult
+  // the live library (which drifts), while this reads only the pair being
+  // written — a pair that passed at its own write time passes again on inherit.
   assertPromptSkillTokensPinned(prompt, skills);
 
   const createdBy = ctx.userId ?? 'system';

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -16,6 +16,7 @@ import {
   assertWatcherVersionConfigValid,
   assertWatcherSourcesResolve,
   assertBehaviorSkillsResolve,
+  assertPromptSkillTokensPinned,
   parseJsonInput,
   normalizeStoredJsonField,
   toJsonParam,
@@ -211,6 +212,9 @@ export async function handleCreateVersion(
     // Draft version only — triggers on the live row do not change.
     assertBehaviorInstructions(previousTriggers, prompt, skills);
   }
+  // Both branches above write the SAME resolved prompt+skills pair, so the
+  // chip/pin agreement is checked once here rather than inside either arm.
+  assertPromptSkillTokensPinned(prompt, skills);
 
   const createdBy = ctx.userId ?? 'system';
   let versionId = 0;

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -242,6 +242,32 @@ export function extractSourcesFromPromptTokens(prompt: string): WatcherSource[] 
 }
 
 /**
+ * Skill names referenced by `@[skill:<name>:<label>](…)` tokens in a prompt.
+ *
+ * Deliberately NOT part of `PROMPT_KIND_TO_MODE` — a skill is not a source, and
+ * this does not derive anything the caller did not send. The caller supplies
+ * `skills[{name, content}]` and the pinned body comes from THAT; resolving the
+ * body here would re-read the live library at save time and silently upgrade a
+ * pin, which is the one thing the snapshot model exists to prevent.
+ *
+ * De-duped, order preserved. Malformed tokens are skipped, matching
+ * `extractSourcesFromPromptTokens`.
+ */
+export function extractSkillNamesFromPromptTokens(prompt: string): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const m of prompt.matchAll(PROMPT_REF_TOKEN)) {
+    const [, kind, id] = m;
+    if (kind !== 'skill') continue;
+    const name = (id ?? '').trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+  }
+  return names;
+}
+
+/**
  * Merge prompt-derived sources into an explicit sources list, de-duping by
  * query and keeping output-field names unique. Explicit sources win (they keep
  * their names/order); prompt sources fill in the rest.


### PR DESCRIPTION
## Summary
Completes #2371. That PR made the server store and deliver pinned skill snapshots; nothing in the browser wrote them — `owletto/src/lib/behavior-skills.ts` still compiled skill bodies into `prompt` and sent no `skills` array, so the feature was reachable only from `lobu apply` and MCP. This adds the composer (owletto#661) and the one server-side guard it needs.

**The guard.** Nothing strips ref tokens — grep `PROMPT_REF_TOKEN`, the only consumer is source derivation — so a `@[skill:…]` chip with no matching entry in `skills[]` does not fail, it **degrades**: the agent reads the literal `@[skill:deploy-runbook:Deploy runbook](/…)` as if it were guidance, with no `.skills/` file behind it. Silent wrong instructions are worse than a 422.

Checked at both write paths (`create`, `create_version`), **names only**. The pinned body still comes from the caller — resolving it here would re-read the live library at save time and silently upgrade a pin, which is exactly what the snapshot model exists to prevent.

**Deliberately one-directional.** A pinned skill with *no* chip is legal: that is the declarative path (`defineBehavior({ skills: [...] })` carries no prompt at all), and rejecting it would strand every CLI-authored Behavior.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit`, `bun test src/__tests__/unit/prompt-skill-tokens-pinned.test.ts` (11), `behavior-instructions-rule.test.ts` (5); owletto `bunx vitest run` — 129 files / 1138 tests
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Guard, mutation-tested

```
$ bun test src/__tests__/unit/prompt-skill-tokens-pinned.test.ts
 11 pass  0 fail

# mutate: `if (referenced.length === 0) return` -> `>= 0` (guard never fires)
 7 pass  4 fail        <- exactly the four rejection cases

# restored
 11 pass  0 fail
```

The four that fail are the ones that matter: a chip with no pin, several unpinned chips named together, a *partially* pinned set (the realistic drift — composer sent a stale array after one more chip was added), and a chip whose id differs from its label, which must be checked on the id or a rename shows green while pinning the wrong body.

### The bug the old regression test caught in my own draft

owletto#634 added a test asserting an author with an empty skill library gets a link to the skills page. My first draft rendered that link only in the `else` of the validation error — and an empty library and an unsatisfied instruction requirement co-occur on **every blank new-Behavior form**. So the link vanished exactly when it was needed, which is the same stranding #634 wrote the test for. Fixed in the component, not the test.

## Notes
**This is the second half of a two-PR change; merge owletto#661 first.** The pointer bump is in this PR.

Design decision worth recording: prompt chips are a *rendering* of the `skills[]` array, not an independent declaration. The alternative — deriving `skills` from prompt tokens server-side, one source of truth — was rejected because it forces a save-time read of skill bodies (silently upgrading pins) and resolves skills-only declarative Behaviors to zero skills. That second failure mode is the one caught before shipping #2371.

Also verified while closing out #2371: it is live on prod and a real Behavior ran through the new path — `Session context for watcher_71: … 0 skills (Behavior run — pinned snapshot)`, run 810538.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->