### PR TITLE
fix(agent-worker): stop network-enabled agent turns crashing on __filename

### DIFF
--- a/packages/agent-worker/scripts/build-worker-bundle.mjs
+++ b/packages/agent-worker/scripts/build-worker-bundle.mjs
@@ -26,7 +26,7 @@ import { buildPublishedDeclaration } from "./published-declaration.mjs";
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgDir = join(here, "..");
 
-const result = await esbuild.build({
+const buildOptions = {
   absWorkingDir: pkgDir,
   entryPoints: [join(pkgDir, "src/index.ts")],
   outfile: join(pkgDir, "dist/index.bundle.mjs"),
@@ -59,12 +59,65 @@ const result = await esbuild.build({
     },
   ],
   // esbuild emits require() calls when inlining CJS-flavoured workspace source;
-  // ESM output has no require, so provide one. Per-module __filename/__dirname
-  // shims are emitted by esbuild itself, so don't add them here.
+  // ESM output has no require, so provide one.
+  //
+  // It does NOT follow that __filename/__dirname are equally covered. esbuild
+  // only synthesises those for modules it treats as CJS; in a TS/ESM source
+  // module a bare `__filename` is just an unbound global and is emitted
+  // verbatim. Under bun that still resolves (bun defines it in ESM), so such a
+  // bundle passes every in-repo check and then throws `ReferenceError` under
+  // node, which is what actually runs the published worker. The scan below
+  // fails the build rather than shipping that again.
   banner: {
     js: "import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);",
   },
+};
+
+// Fail the build on any CJS-ism that node's ESM does not define. A bare
+// `__filename`/`__dirname` surviving into this bundle is a latent
+// `ReferenceError` for every installed user, invisible in-repo because bun
+// defines both (#2153 class).
+//
+// Detection is a probe pass with `define`, never written to disk: esbuild
+// substitutes a define only for an *unbound* reference and leaves
+// locally-declared bindings (including its own CJS shims) alone, so a surviving
+// sentinel means exactly "used without being defined" — no hand-rolled scope
+// analysis, no false positives on modules that shim correctly.
+//
+// It runs BEFORE the real build so a rejected bundle is never written: leaving
+// a broken dist/ on disk is how a later step reads a stale artifact and goes
+// green (see the tsconfig.tsbuildinfo note below for the same failure mode).
+const CJS_GLOBALS = ["__filename", "__dirname"];
+const sentinelFor = (name) => `__LOBU_UNBOUND${name}__`;
+const probe = await esbuild.build({
+  ...buildOptions,
+  write: false,
+  sourcemap: false,
+  metafile: false,
+  logLevel: "silent",
+  define: Object.fromEntries(
+    CJS_GLOBALS.map((name) => [name, JSON.stringify(sentinelFor(name))])
+  ),
 });
+const probeText = probe.outputFiles[0].text;
+const unbound = CJS_GLOBALS.filter((name) =>
+  probeText.includes(sentinelFor(name))
+);
+if (unbound.length > 0) {
+  console.error(
+    `\n[build-worker-bundle] FAILED: ${unbound.join(", ")} used without being defined.\n` +
+      "  This bundle is ESM and runs under node (see buildWorkerInvocation in\n" +
+      "  server/src/gateway/orchestration/deployment-manager.ts), where these are\n" +
+      "  NOT ambient — it would throw ReferenceError at runtime. Bun defines them,\n" +
+      "  so every in-repo check stays green.\n" +
+      "  Fix: derive from import.meta.url, e.g.\n" +
+      "    createRequire(import.meta.url)\n" +
+      "    const __dirname = dirname(fileURLToPath(import.meta.url))"
+  );
+  process.exit(1);
+}
+
+const result = await esbuild.build(buildOptions);
 
 // tsc is incremental: after `rm -rf dist` a stale tsconfig.tsbuildinfo makes it
 // exit 0 having emitted nothing, which would publish a typeless bundle with no

--- a/packages/agent-worker/src/__tests__/egress-fetch-node-esm.test.ts
+++ b/packages/agent-worker/src/__tests__/egress-fetch-node-esm.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The published `@lobu/worker` runs under **node**, not bun.
+ *
+ * `dist/index.bundle.mjs` is ESM, and node's ESM has no ambient `__filename`.
+ * Bun's ESM *does* define it, so every in-repo path (tests, `make dev`,
+ * `scripts/cli-smoke.sh`) is green while `npx @lobu/cli` crashes on the first
+ * agent turn with `ReferenceError: __filename is not defined`.
+ *
+ * Nothing else in CI can see this: the gateway picks the worker entrypoint by
+ * file extension (`gateway/config/index.ts` → `src/index.ts` in-repo,
+ * `dist/index.bundle.mjs` installed) and `buildWorkerInvocation`
+ * (`orchestration/deployment-manager.ts`) spawns `.ts` under bun and `.mjs`
+ * under node. In-repo we only ever take the bun path.
+ *
+ * So this test reproduces the shipped shape directly: bundle the module with
+ * the same esbuild settings `scripts/build-worker-bundle.mjs` uses, then run it
+ * under a real `node` binary.
+ */
+
+import { describe, expect, test } from "bun:test";
+import esbuild from "esbuild";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgDir = fileURLToPath(new URL("../..", import.meta.url));
+
+/** Resolve a real `node` (the test runner itself is bun). */
+function findNode(): string | null {
+  const which = spawnSync("which", ["node"], { encoding: "utf8" });
+  const path = which.stdout?.trim();
+  return which.status === 0 && path ? path : null;
+}
+
+describe("egress-fetch under node ESM (the published worker's runtime)", () => {
+  test("buildEgressFetch spawns the egress worker without a ReferenceError", () => {
+    const node = findNode();
+    if (!node) {
+      throw new Error(
+        "no `node` on PATH — this test asserts node-ESM behaviour and cannot be skipped silently"
+      );
+    }
+
+    // Emit inside the package, not $TMPDIR: `createRequire(...).resolve`
+    // walks up from the bundle's own directory, exactly as it does from the
+    // installed `dist/index.bundle.mjs`. A temp dir would fail on `undici`
+    // for reasons that have nothing to do with what is under test.
+    const dir = mkdtempSync(join(pkgDir, ".egress-esm-"));
+    try {
+      const bundle = join(dir, "egress.mjs");
+
+      // Same knobs as scripts/build-worker-bundle.mjs. The banner is the one
+      // esbuild needs for inlined CJS `require()` — note it does NOT define
+      // `__filename`, which is exactly the gap under test.
+      esbuild.buildSync({
+        absWorkingDir: pkgDir,
+        entryPoints: [join(pkgDir, "src/embedded/egress-fetch.ts")],
+        outfile: bundle,
+        bundle: true,
+        platform: "node",
+        target: "node22",
+        format: "esm",
+        conditions: ["bun", "import", "module", "default"],
+        banner: {
+          js: "import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);",
+        },
+      });
+
+      // `buildEgressFetch` spawns the shared egress worker eagerly whenever a
+      // proxy is configured — the branch a scaffolded project always takes,
+      // because `lobu init` writes WORKER_ALLOWED_DOMAINS and the gateway
+      // turns that into HTTP_PROXY for the worker.
+      const driver = join(dir, "driver.mjs");
+      writeFileSync(
+        driver,
+        [
+          `import { buildEgressFetch } from ${JSON.stringify(bundle)};`,
+          "class NetworkAccessDenied extends Error {",
+          "  constructor(url, reason) { super(`${url}: ${reason}`); }",
+          "}",
+          "buildEgressFetch(NetworkAccessDenied);",
+          'console.log("EGRESS_OK");',
+          "process.exit(0);",
+        ].join("\n")
+      );
+
+      const run = spawnSync(node, [driver], {
+        cwd: pkgDir,
+        encoding: "utf8",
+        timeout: 60_000,
+        env: { ...process.env, HTTP_PROXY: "http://127.0.0.1:1" },
+      });
+
+      const output = `${run.stdout || ""}${run.stderr || ""}`;
+      expect(output).not.toContain("__filename is not defined");
+      expect(output).not.toContain("ReferenceError");
+      expect(run.stdout || "").toContain("EGRESS_OK");
+      expect(run.status).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent-worker/src/embedded/egress-fetch.ts
+++ b/packages/agent-worker/src/embedded/egress-fetch.ts
@@ -40,7 +40,6 @@
  * only while requests are in flight.
  */
 
-import { createRequire } from "node:module";
 import { Worker } from "node:worker_threads";
 import type { SecureFetch } from "just-bash";
 
@@ -267,7 +266,27 @@ function ensureWorker(): Worker {
   const worker = new Worker(WORKER_SOURCE, {
     eval: true,
     workerData: {
-      undiciPath: createRequire(__filename).resolve("undici"),
+      // `require.resolve`, not `createRequire(__filename)`: this package emits
+      // BOTH a CJS `dist/index.js` (tsc, the declared package entry) and an ESM
+      // `dist/index.bundle.mjs` (esbuild, what the gateway actually spawns —
+      // `.mjs` → node, `.ts` → bun, see `buildWorkerInvocation` in
+      // server/src/gateway/orchestration/deployment-manager.ts).
+      //
+      // `__filename` is ambient in the CJS output and in bun's ESM, but NOT in
+      // node's ESM — so it typechecked, ran fine in-repo under bun, and threw
+      // `ReferenceError` for every installed CLI user on their first agent turn.
+      // `import.meta.url` is the mirror-image trap: tsc rejects it under
+      // `module: CommonJS`. `require` is the one binding defined on both paths
+      // (ambient in CJS; supplied by the bundle's own `createRequire` banner),
+      // and under node it resolves to an absolute path either way.
+      //
+      // Bun is the third path (`src/index.ts`, spawned in-repo) and there
+      // `require.resolve` returns the bare specifier rather than a path. That
+      // is harmless *because* undici is loaded only by `forProxy`, which only
+      // `nodeFetch` calls, which only runs when `!isBun` — the Bun branch uses
+      // native fetch and never reads this value. If undici ever gains a
+      // Bun-side consumer, this must resolve to a real path first.
+      undiciPath: require.resolve("undici"),
     },
   });
   worker.unref();


### PR DESCRIPTION
## Summary
- **Agent turns crash on the published CLI** with `ReferenceError: __filename is not defined` on `@lobu/cli@14.7.1`. Reproduced on Node **22.22.2 and 26.5.0** — not version-specific.
- `egress-fetch.ts:270` used `createRequire(__filename)`. `__filename` is ambient in this package's CJS tsc output and in **bun's** ESM, but not in **node's** ESM — which is exactly what runs the published worker (`config/index.ts` resolves `dist/index.bundle.mjs` when installed; `buildWorkerInvocation` spawns `.mjs` under node, `.ts` under bun). In-repo we only ever take the bun path.
- Prod chat is unaffected (Slack + Telegram verified replying) — prod uses the non-embedded worker deployment.

## Who it hits
Any agent with a **network allow-list** (`network: { allowed: [...] }`) — i.e. any agent that can use `curl`/`wget`, which is the norm for anything that fetches. The worker's bash bootstrap only builds the egress transport when the list is non-empty:

```ts
const egressFetch = allowedDomains.length > 0
  ? buildEgressFetch(NetworkAccessDeniedError) : undefined;
```

and `buildEgressFetch` is what spawns the egress worker thread that carried the crash. An agent with **no** allow-list never reaches it and is unaffected.

I originally wrote "every agent turn" here. That was too broad, and I found it out the honest way: the first draft of the artifact smoke gate (#2378) went **green** against this provably-broken 14.7.1 because its test agent had no allow-list. Corrected once the gate could actually fail.

## Why CI never caught it
`scripts/cli-smoke.sh` **cannot** catch this class. It sets `LOBU_BIN` to the source tree, so the gateway always resolves `src/index.ts` and always spawns it under **bun**, where `__filename` is defined. The `.mjs`/node path only exists in an installed artifact, which nothing in CI installs. #2378 adds that gate.

## Fix
`require.resolve("undici")` — the one binding defined on all three paths (ambient in CJS, banner-supplied in the ESM bundle, present under bun). `import.meta.url` is the mirror-image trap: tsc rejects it under `module: CommonJS`.

Plus the hole that let it ship: `build-worker-bundle.mjs` asserted a `require` shim but assumed esbuild also synthesises `__filename`/`__dirname`. It only does that for CJS-flavoured sources — in a TS/ESM module a bare `__filename` is emitted verbatim. A probe pass using esbuild `define` (which substitutes only *unbound* references, leaving correctly-shimmed modules alone) now fails the build **before** writing `dist/`.

## Test plan
- [x] `make pre-pr` clean
- [x] Tests run: `bun test packages/agent-worker/src/__tests__/` → **815 pass, 12 skip, 0 fail**
- [x] Bug fix: red→fix→green outputs pasted below

### red — unit level
New test bundles the module with production esbuild settings and runs it under a real `node`:

```
ReferenceError: __filename is not defined in ES module scope
    at ensureWorker (.../egress.mjs:181:33)
    at buildEgressFetch (.../egress.mjs:248:32)
Node.js v26.5.0
(fail) buildEgressFetch spawns the egress worker without a ReferenceError
 0 pass, 1 fail
```

### green — unit level
```
bun test v1.3.5
 1 pass
 0 fail
 4 expect() calls
```

### red→green at the ARTIFACT level (the one that matters)
Installed `@lobu/cli@14.7.1` from npm, scaffolded a project with a network allow-list, ran a real turn:

```
== a real agent turn ==
  [FAIL] lobu chat did not return the model's reply (exit=1)
💥 Worker crashed (ReferenceError): __filename is not defined
[error] [worker] Worker execution failed: {"name":"ReferenceError","message":"__filename is not defined"}
  smoke summary: 11 passed, 2 failed
```

Then swapped **only** `node_modules/@lobu/worker/dist/index.bundle.mjs` for the bundle built from this branch, same install otherwise, same turn:

```
$ lobu chat "say the safe word" -c local
ARTIFACT_SMOKE_OK
worker crashes in run log: 0
```

### the build gate bites (mutation test — bug reintroduced)
```
[build-worker-bundle] FAILED: __filename used without being defined.
  This bundle is ESM and runs under node ... where these are NOT ambient —
  it would throw ReferenceError at runtime. Bun defines them, so every
  in-repo check stays green.
```

### shipped outputs both carry a working form
```
dist/index.bundle.mjs:3137   undiciPath: __require.resolve("undici")
dist/embedded/egress-fetch.js:249   undiciPath: require.resolve("undici"),
```
(`__require` is esbuild's helper, which aliases to the banner's `createRequire(import.meta.url)`.)

## Notes
`require.resolve` returns the bare specifier under bun rather than a path. That is safe **because** undici is only loaded by `forProxy` → `nodeFetch` → `!isBun`; the Bun branch uses native fetch and never reads the value. Commented at the call site so a future Bun-side consumer doesn't trip on it.

`make review-fix` could not run — codex quota is exhausted until Aug 5 (#2372). `make review` (claude/fable) posted: **bug_free 92, simplicity 85, slop 5, 0 bugs, 0 blockers, risk low**.