### PR TITLE
fix(server): let `lobu run` boot embedded Postgres in a root shell

### DIFF
--- a/packages/server/src/__tests__/embedded-pg-options.test.ts
+++ b/packages/server/src/__tests__/embedded-pg-options.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { embeddedPgOptions } from "../embedded-runtime";
 
 // #1364: embedded Postgres must initdb with an always-present locale so `lobu run`
@@ -15,5 +15,46 @@ describe("embeddedPgOptions", () => {
 		expect(opts.databaseDir).toBe("/var/lib/lobu/pg");
 		expect(opts.port).toBe(6123);
 		expect(opts.persistent).toBe(true);
+	});
+});
+
+// Postgres refuses to run as root, so `lobu run` died on first boot for anyone
+// in a root shell — the default on a VPS, in WSL, in LXC, and in most Docker
+// images. `createPostgresUser` lets embedded-postgres create a `postgres` user
+// to drop into. It has to be conditional in BOTH directions: off as root is the
+// original crash, on as non-root makes embedded-postgres shell out to
+// `groupadd`/`useradd` regardless (its uid lookup returns `{}` when not root),
+// which fails on macOS and as an unprivileged Linux user.
+describe("embeddedPgOptions createPostgresUser (root boot)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("creates a postgres user when running as root", () => {
+		vi.spyOn(process, "getuid").mockReturnValue(0);
+		expect(embeddedPgOptions("/tmp/pgdata", 5599).createPostgresUser).toBe(
+			true,
+		);
+	});
+
+	it("does NOT create a postgres user when running unprivileged", () => {
+		vi.spyOn(process, "getuid").mockReturnValue(501);
+		expect(embeddedPgOptions("/tmp/pgdata", 5599).createPostgresUser).toBe(
+			false,
+		);
+	});
+
+	it("treats a missing getuid (Windows) as not-root", () => {
+		const original = process.getuid;
+		// biome-ignore lint/performance/noDelete: emulating the Windows shape,
+		// where `process.getuid` is genuinely absent rather than undefined.
+		delete (process as { getuid?: unknown }).getuid;
+		try {
+			expect(embeddedPgOptions("/tmp/pgdata", 5599).createPostgresUser).toBe(
+				false,
+			);
+		} finally {
+			process.getuid = original;
+		}
 	});
 });

--- a/packages/server/src/embedded-runtime.ts
+++ b/packages/server/src/embedded-runtime.ts
@@ -127,7 +127,35 @@ export function embeddedPgOptions(databaseDir: string, port: number) {
 		port,
 		persistent: true,
 		initdbFlags: ["--locale=C", "--encoding=UTF8"],
+		createPostgresUser: runningAsRoot(),
 	};
+}
+
+/**
+ * True only when the process is genuinely uid 0.
+ *
+ * `createPostgresUser` MUST be conditional, not always-on. Postgres refuses to
+ * run as root, so a root shell — the default on a VPS, in WSL, in an LXC
+ * container, and in most Docker images — dies on first boot with:
+ *
+ *   You are running this script as root. Postgres does not support running as
+ *   root. ... set the `createPostgresUser` option to true.
+ *
+ * That killed `lobu run`, the landing page's own quickstart, for those users.
+ * With the flag set, embedded-postgres creates a `postgres` user/group and
+ * chowns the data dir to it.
+ *
+ * But turning it on unconditionally breaks everyone else. When not root,
+ * embedded-postgres's `getUidAndGid()` short-circuits to `{}`, so the
+ * "no uid and no gid" branch fires and it runs `groupadd`/`useradd` anyway —
+ * which fails on macOS (no such commands) and as an unprivileged Linux user
+ * (EPERM), turning a working boot into "Failed to create and initialize a new
+ * user on this system." So gate on the actual uid.
+ *
+ * `process.getuid` is undefined on Windows; absent means "not root".
+ */
+function runningAsRoot(): boolean {
+	return typeof process.getuid === "function" && process.getuid() === 0;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **`lobu run` dies on first boot for anyone in a root shell.** Root is the default in a VPS shell, WSL, an LXC container and most Docker images — #2153's reporter was at `root@sqlserver2025:/my-lobu#`.
- `embeddedPgOptions()` never passed `createPostgresUser`, so embedded-postgres refused to start.
- Set it — but **only when actually uid 0**, because the naive fix breaks everyone else.

## Why it has to be conditional in both directions
Turning `createPostgresUser` on unconditionally would be a worse bug than the one it fixes. When not root, embedded-postgres's `getUidAndGid()` short-circuits to `{}`:

```js
getUidAndGid(name = 'postgres') {
    if (!this.isRootUser) { return {}; }      // <-- empty, not "found"
```

so this branch fires for every non-root user:

```js
if (this.options.createPostgresUser
    && !('uid' in permissionIds) && !('gid' in permissionIds)) {
    yield execAsync('groupadd postgres');     // no such command on macOS
    yield execAsync('useradd -g postgres postgres');   // EPERM unprivileged
```

turning a working boot into `Failed to create and initialize a new user on this system.` `process.getuid` is undefined on Windows; absent is treated as not-root.

## Test plan
- [x] `make pre-pr` clean
- [x] Tests run: `bunx vitest run src/__tests__/embedded-pg-options.test.ts` → **5 passed**
- [x] Bug fix: red→fix→green outputs pasted below

### green
```
 ✓ src/__tests__/embedded-pg-options.test.ts (5 tests) 2ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### red — mutation-tested in BOTH directions
The new tests are worthless unless they fail for each way of getting this wrong, so both mutants were run:

**Mutant 1 — option absent (exactly the shipped bug):**
```
 × creates a postgres user when running as root
 × does NOT create a postgres user when running unprivileged
 × treats a missing getuid (Windows) as not-root
 Tests  3 failed | 2 passed (5)
```

**Mutant 2 — `createPostgresUser: true` unconditionally (the naive fix):**
```
 ✓ creates a postgres user when running as root
 × does NOT create a postgres user when running unprivileged
 × treats a missing getuid (Windows) as not-root
 Tests  2 failed | 3 passed (5)
```

## Notes
This is one of two blockers on a Linux self-host: **as root you fail here first; as non-root you get past it and fail on the pgvector glibc floor** (#2376). Both are needed for `lobu run` to come up on e.g. Debian 12 or Ubuntu 22.04.

Verification here is unit-level — a real root-shell boot on Linux still hits #2376's glibc wall, so the full end-to-end path can only be confirmed once the rebuilt pgvector artifacts land. Saying that explicitly rather than claiming an e2e I did not run.

`make review-fix` could not run — codex quota exhausted until Aug 5 (#2372).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->