### PR TITLE
ci: gate the published artifact, not just the monorepo

### DIFF
--- a/.github/workflows/published-artifact-smoke.yml
+++ b/.github/workflows/published-artifact-smoke.yml
@@ -1,0 +1,117 @@
+name: Published-artifact smoke
+
+# Installs @lobu/cli FROM NPM into a clean container and drives the landing
+# page's quickstart end to end — init, validate, run, and one REAL agent turn.
+#
+# This is the gate for the "works from the monorepo, broken from the artifact"
+# class (#2186, #2231, __filename, GLIBC_2.38, uid-0). `ci.yml`'s cli-smoke job
+# walks every command but points at the SOURCE TREE, which pins four things at
+# once — tarball-vs-source, bun-vs-node, root-vs-not, and the runner's glibc —
+# and each pin hid one of those bugs. The bun/node one is structural: the
+# gateway picks the worker entrypoint by extension and spawns `.ts` under bun,
+# `.mjs` under node, so in-repo it can only ever take the bun path.
+#
+# Deliberately keyless: reuses the deterministic mock provider from
+# scripts/sdk-e2e/, so no secret is required and the run is reproducible.
+
+on:
+  # Every merge to main. The artifact on the registry is the PREVIOUS release,
+  # so this is a standing check that what users can install right now still
+  # works — it would have been red continuously through the __filename, glibc
+  # and uid-0 breakages instead of waiting for someone to file an issue.
+  push:
+    branches: [main]
+  # After a release publishes, verify what actually landed on the registry.
+  workflow_run:
+    workflows: ["Publish Packages"]
+    types: [completed]
+  # Daily canary. The registry can break without us pushing anything (a
+  # dependency yanks a version, a transitive install changes), and a bad
+  # release otherwise sits undetected until a user files an issue.
+  schedule:
+    - cron: "0 7 * * *"
+  # On demand, e.g. to check a specific version after a hotfix.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: npm version or dist-tag to smoke
+        default: latest
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    # Each cell is an axis that hid a real, shipped bug. Keep all four.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # glibc 2.36. Older than the 2.38 the pgvector prebuilt wanted, and
+          # `node:22-slim` IS bookworm — the most obvious base a self-hoster
+          # picks. This cell is what catches a too-new prebuilt.
+          - { name: bookworm-nonroot, image: "node:22-bookworm-slim", as_root: false }
+          # Root is the default in a VPS shell, WSL, LXC and most Docker
+          # images. Postgres refuses to run as root, so this cell catches a
+          # missing `createPostgresUser`.
+          - { name: bookworm-root, image: "node:22-bookworm-slim", as_root: true }
+          # glibc 2.41 control. If bookworm fails and trixie passes, the
+          # failure is a glibc floor and not a general breakage — that
+          # distinction is most of the debugging.
+          - { name: trixie-nonroot, image: "node:22-trixie-slim", as_root: false }
+          # The oldest LTS we claim to support; catches a floor that clears
+          # bookworm but not 22.04.
+          - { name: jammy-nonroot, image: "ubuntu:22.04", as_root: false }
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    timeout-minutes: 25
+    steps:
+      - name: Install prerequisites
+        run: |
+          set -eux
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git procps psmisc
+
+          # ubuntu:22.04 has no node at all; the node:* images already do.
+          if ! command -v node >/dev/null 2>&1; then
+            curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+            apt-get install -y --no-install-recommends nodejs
+          fi
+
+          node --version
+          getconf GNU_LIBC_VERSION || ldd --version | head -1
+
+      - uses: actions/checkout@v7
+
+      # Only the mock-provider harness is used from the checkout; everything
+      # under test comes from npm.
+      - name: Smoke the published artifact
+        env:
+          LOBU_VERSION: ${{ inputs.version || 'latest' }}
+        run: |
+          set -u
+          chmod +x scripts/published-artifact-smoke.sh
+
+          if [ "${{ matrix.as_root }}" = "true" ]; then
+            echo ">> running as root (uid $(id -u))"
+            scripts/published-artifact-smoke.sh
+          else
+            # The container starts as root, so drop to an unprivileged user.
+            # Everything the script touches lives under its own $WORK/$HOME.
+            useradd -m -s /bin/bash smoke
+            chown -R smoke:smoke .
+            su smoke -c "env LOBU_VERSION='$LOBU_VERSION' \
+              SMOKE_WORK=/tmp/lobu-artifact-smoke-smoke \
+              bash scripts/published-artifact-smoke.sh"
+          fi
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-logs-${{ matrix.name }}
+          path: /tmp/lobu-artifact-smoke*/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -20,6 +20,26 @@
 # configured chat platform can't be driven unattended -- those are exercised at
 # the "runs + fails gracefully" level or logged as SKIP with the reason.
 #
+# WHAT THIS GATE STRUCTURALLY CANNOT CATCH -- do not assume otherwise.
+# LOBU_BIN below points at the SOURCE TREE, which silently pins four things:
+#
+#   tarball-vs-source   this runs the monorepo, never an `npm install`ed build
+#   bun-vs-node         the gateway picks the worker entrypoint by EXTENSION
+#                       (gateway/config/index.ts -> src/index.ts in-repo,
+#                       dist/index.bundle.mjs installed) and
+#                       buildWorkerInvocation spawns .ts under bun, .mjs under
+#                       node. In-repo we can only ever take the bun path.
+#   root-vs-not         CI runs unprivileged
+#   glibc               CI runs a modern-glibc runner
+#
+# Each of those hid a real shipped bug (#2186, `__filename is not defined`,
+# the uid-0 embedded-postgres refusal, the GLIBC_2.38 pgvector floor). Walking
+# MORE commands here cannot help: the failing path does not exist in-repo.
+# scripts/published-artifact-smoke.sh owns those axes -- it installs from the
+# registry and runs a real agent turn as root and non-root, on old and new
+# glibc. Add packaging/runtime-environment coverage THERE, command coverage
+# HERE.
+#
 # Kept ASCII-only on purpose: a stray non-ASCII byte hugging a $var expansion is
 # swallowed into the variable name under a UTF-8 locale ("unbound variable").
 #

--- a/scripts/published-artifact-smoke.sh
+++ b/scripts/published-artifact-smoke.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+#
+# Published-artifact smoke: install @lobu/cli FROM NPM into a clean container
+# and drive the landing page's own quickstart end to end.
+#
+# Why this exists, and why cli-smoke.sh is not enough.
+#
+# Every "I can't get started" issue we have shipped has the same shape: it
+# works from the monorepo and is broken from the published artifact. Nothing in
+# CI installed what we published, so the whole class was invisible:
+#
+#   #2186     unpublished private dep — the tarball could not resolve @lobu/*
+#   #2231     no `lobu` on PATH inside the app image
+#   __filename  bundle is ESM-under-node; bun defines it, node does not
+#   GLIBC_2.38  pgvector prebuilt built on too new a runner
+#   uid 0     embedded-postgres refuses to run as root
+#
+# `scripts/cli-smoke.sh` walks the whole command surface, but it points
+# LOBU_BIN at the SOURCE TREE, which pins four things at once — and each pin
+# hides one of the bugs above:
+#
+#   source tree, not the tarball  ->  #2186, missing bin, packaging breakage
+#   .ts entry, so spawned by bun  ->  __filename (node's ESM has no such global)
+#   non-root runner               ->  uid-0 embedded-postgres refusal
+#   modern-glibc runner           ->  GLIBC_2.38 pgvector floor
+#
+# The bun one is structural, not incidental: the gateway picks the worker
+# entrypoint by extension (`gateway/config/index.ts` resolves `src/index.ts`
+# in-repo and `dist/index.bundle.mjs` when installed), and
+# `buildWorkerInvocation` spawns `.ts` under bun, `.mjs` under node. In-repo we
+# can only ever take the bun path. cli-smoke could not catch `__filename` no
+# matter how many commands it walked.
+#
+# So this gate varies exactly those axes: real tarball, real `node`, root AND
+# non-root, old AND new glibc — and it runs a REAL AGENT TURN, because the turn
+# is the only thing that exercises the worker's egress bootstrap.
+#
+# No provider key: it reuses the deterministic mock provider from
+# scripts/sdk-e2e/, so this needs no secrets and is reproducible.
+#
+# Usage:
+#   scripts/published-artifact-smoke.sh [version]     # default: latest
+#
+# Env:
+#   LOBU_VERSION   npm version/tag to install (default "latest")
+#   SMOKE_AS_USER  unprivileged username to drop to (default: run as-is)
+#   GW_PORT        gateway port (default 8799)
+#   MOCK_PORT      mock provider port (default 11439)
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARNESS="$REPO_ROOT/scripts/sdk-e2e"
+LOBU_VERSION="${1:-${LOBU_VERSION:-latest}}"
+GW_PORT="${GW_PORT:-8799}"
+MOCK_PORT="${MOCK_PORT:-11439}"
+MOCK_REPLY="ARTIFACT_SMOKE_OK"
+
+WORK="${SMOKE_WORK:-/tmp/lobu-artifact-smoke}"
+rm -rf "$WORK"; mkdir -p "$WORK"
+export HOME="$WORK/home"; mkdir -p "$HOME"
+
+PASSES=0; FAILS=0
+pass() { echo "  [OK]   $*"; PASSES=$((PASSES + 1)); }
+fail() { echo "  [FAIL] $*" >&2; FAILS=$((FAILS + 1)); }
+note() { echo ""; echo "== $* =="; }
+
+MOCK_PID=""
+cleanup() {
+  [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null
+  pkill -f "lobu-artifact-smoke.*run" 2>/dev/null
+  return 0
+}
+trap cleanup EXIT
+
+echo "================================================================"
+echo "  published-artifact smoke"
+echo "    version : @lobu/cli@$LOBU_VERSION"
+echo "    node    : $(node --version 2>/dev/null || echo MISSING)"
+echo "    uid     : $(id -u) ($(id -un))"
+echo "    glibc   : $(getconf GNU_LIBC_VERSION 2>/dev/null || ldd --version 2>&1 | head -1)"
+echo "================================================================"
+
+# ---------------------------------------------------------------------------
+# 1. Install from the registry. This is the step cli-smoke never performs.
+# ---------------------------------------------------------------------------
+note "install @lobu/cli@$LOBU_VERSION from npm"
+INSTALL_DIR="$WORK/install"; mkdir -p "$INSTALL_DIR"
+(
+  cd "$INSTALL_DIR" || exit 1
+  npm init -y >/dev/null 2>&1
+  npm install --no-audit --no-fund "@lobu/cli@$LOBU_VERSION" 2>&1 | tail -5
+)
+LOBU_BIN="$INSTALL_DIR/node_modules/.bin/lobu"
+if [ ! -x "$LOBU_BIN" ]; then
+  fail "npm install did not produce an executable lobu bin at $LOBU_BIN"
+  echo "RESULT: published-artifact smoke FAILED (install)"; exit 1
+fi
+pass "installed, bin present"
+
+RESOLVED="$("$LOBU_BIN" --version 2>&1 | tr -d '[:space:]')"
+if [ -n "$RESOLVED" ]; then pass "lobu --version -> $RESOLVED"; else fail "lobu --version produced nothing"; fi
+
+# The worker bundle is the artifact that actually has to load under node.
+WORKER_BUNDLE="$INSTALL_DIR/node_modules/@lobu/worker/dist/index.bundle.mjs"
+if [ -f "$WORKER_BUNDLE" ]; then
+  pass "worker bundle present ($(wc -c < "$WORKER_BUNDLE" | tr -d ' ') bytes)"
+else
+  fail "no worker bundle at $WORKER_BUNDLE — the agent turn cannot work"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Deterministic provider, so a real turn needs no key.
+# ---------------------------------------------------------------------------
+note "start the mock provider on :$MOCK_PORT"
+MOCK_PORT="$MOCK_PORT" MOCK_REPLY="$MOCK_REPLY" \
+  node "$HARNESS/mock-openai.mjs" > "$WORK/mock.log" 2>&1 &
+MOCK_PID=$!
+for _ in $(seq 1 20); do
+  curl -sf --max-time 2 "http://127.0.0.1:$MOCK_PORT/v1/models" >/dev/null 2>&1 && break
+  sleep 1
+done
+if curl -sf --max-time 2 "http://127.0.0.1:$MOCK_PORT/v1/models" >/dev/null 2>&1; then
+  pass "mock provider answering"
+else
+  fail "mock provider never came up"; echo "RESULT: FAILED (mock)"; exit 1
+fi
+
+PROVIDERS="$WORK/providers.json"
+node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));const port=process.argv[2];for(const g of j.providers||[])for(const s of g.providers||[])if(s.upstreamBaseUrl)s.upstreamBaseUrl=s.upstreamBaseUrl.replace(/:\d+/,":"+port);fs.writeFileSync(process.argv[3],JSON.stringify(j,null,2))' \
+  "$HARNESS/providers.json" "$MOCK_PORT" "$PROVIDERS"
+export LOBU_PROVIDER_REGISTRY_PATH="$PROVIDERS"
+
+# ---------------------------------------------------------------------------
+# 3. The quickstart: init -> validate -> run.
+# ---------------------------------------------------------------------------
+note "lobu init (the landing page's own first step)"
+PROJ="$WORK/proj"; mkdir -p "$PROJ"
+( cd "$PROJ" && "$LOBU_BIN" init . -y --here --provider gemini ) > "$WORK/init.log" 2>&1
+if grep -qi "Lobu initialized" "$WORK/init.log"; then pass "lobu init"; else fail "lobu init"; tail -20 "$WORK/init.log" >&2; fi
+
+# `network.allowed` is LOAD-BEARING, not decoration, and the key name matters.
+#
+# The worker's bash bootstrap only builds the egress transport when the agent
+# has a non-empty allow-list:
+#
+#   const egressFetch = allowedDomains.length > 0
+#     ? buildEgressFetch(NetworkAccessDeniedError) : undefined;
+#
+# and `buildEgressFetch` is what spawns the egress worker thread — the code
+# that carried the `__filename` crash. An agent with no allow-list never
+# reaches it.
+#
+# Use `allowed`, NOT `allowedDomains`. The CLI's public `NetworkConfig`
+# (cli/src/config/define.ts) is `{ allowed, denied }`; `allowedDomains` is the
+# internal core name, and a config carrying it is accepted and then silently
+# dropped — `lobu agent config get` comes back `networkConfig: {}`. Both
+# earlier drafts of this gate did exactly that and went GREEN against a 14.7.1
+# that is provably broken. A gate that cannot fail is worse than no gate.
+cat > "$PROJ/lobu.config.ts" <<'TS'
+import { defineAgent, defineConfig, secret } from "@lobu/cli/config";
+
+const echo = defineAgent({
+  id: "echo", name: "Echo", dir: "./agents/echo",
+  providers: [{ id: "mock", model: "mock-model", key: secret("MOCK_API_KEY") }],
+  network: { allowed: ["127.0.0.1", "localhost"] },
+});
+
+export default defineConfig({ agents: [echo] });
+TS
+
+# WORKER_ALLOWED_DOMAINS is what `lobu init` writes for a real user, and it is
+# what makes the gateway hand the worker an HTTP_PROXY — which is what makes
+# `buildEgressFetch` spawn the egress worker eagerly. Without it the turn never
+# touches the code path that carried the __filename crash.
+{
+  printf '\n'
+  echo "MOCK_API_KEY=mock-key-artifact-smoke"
+  echo "WORKER_ALLOWED_DOMAINS=127.0.0.1,localhost"
+  echo "LOBU_DISABLE_SYSTEMD_RUN=1"
+} >> "$PROJ/.env"
+
+( cd "$PROJ" && "$LOBU_BIN" validate ) > "$WORK/validate.log" 2>&1
+if grep -qi "is valid" "$WORK/validate.log"; then pass "lobu validate"; else fail "lobu validate"; tail -20 "$WORK/validate.log" >&2; fi
+
+note "lobu run (embedded Postgres + pgvector on THIS glibc, as THIS uid)"
+RUN_LOG="$WORK/run.log"
+( cd "$PROJ" && "$LOBU_BIN" run --port "$GW_PORT" > "$RUN_LOG" 2>&1 ) &
+for _ in $(seq 1 180); do
+  grep -qiE "Apply complete|auto-apply skipped|Apply halted" "$RUN_LOG" 2>/dev/null && break
+  sleep 1
+done
+if grep -qi "Apply complete" "$RUN_LOG"; then
+  pass "lobu run booted + auto-applied"
+else
+  fail "lobu run never came up"
+  # Name the two failures this gate exists to catch, so the log reads itself.
+  if grep -qi "GLIBC_" "$RUN_LOG"; then
+    echo "         ^ pgvector prebuilt needs a newer glibc than this base has" >&2
+  fi
+  if grep -qi "running this script as root" "$RUN_LOG"; then
+    echo "         ^ embedded-postgres refused to run as root (createPostgresUser)" >&2
+  fi
+  tail -40 "$RUN_LOG" >&2
+  echo ""
+  echo "  smoke summary: $PASSES passed, $FAILS failed"
+  echo "RESULT: published-artifact smoke FAILED (boot)"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 4. THE point of this gate: one real agent turn, under node, from the tarball.
+#    This is the assertion cli-smoke structurally cannot make.
+# ---------------------------------------------------------------------------
+note "a real agent turn (the __filename / worker-packaging assertion)"
+( cd "$PROJ" && "$LOBU_BIN" whoami -c local ) > /dev/null 2>&1
+CHAT_OUT="$WORK/chat.log"
+( cd "$PROJ" && timeout 120 "$LOBU_BIN" chat "say the safe word" -c local ) > "$CHAT_OUT" 2>&1
+CHAT_RC=$?
+
+if grep -qF "$MOCK_REPLY" "$CHAT_OUT"; then
+  pass "lobu chat returned the model's reply ($MOCK_REPLY)"
+else
+  fail "lobu chat did not return the model's reply (exit=$CHAT_RC)"
+  if grep -qiE "__filename|__dirname|is not defined" "$CHAT_OUT" "$RUN_LOG" 2>/dev/null; then
+    echo "         ^ a CJS global leaked into the ESM worker bundle; node has no such" >&2
+    echo "           binding (bun does, which is why in-repo checks stay green)" >&2
+  fi
+  tail -30 "$CHAT_OUT" >&2
+fi
+
+# A crash inside the worker can still exit 0 at the CLI, so assert on the log
+# too — this is how the __filename break looked to a user: a "successful"
+# command with a dead worker behind it.
+if grep -qiE "Worker crashed|ReferenceError|is not defined" "$RUN_LOG" 2>/dev/null; then
+  fail "the worker logged a crash during the turn"
+  grep -iE "Worker crashed|ReferenceError|is not defined" "$RUN_LOG" | head -5 >&2
+else
+  pass "no worker crash in the run log"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. MCP surface. The memory MCP server is in-process, so it exercises the
+#    published server bundle's tool registration and JSON-RPC plumbing — a
+#    different packaging path from the worker bundle above, and the one every
+#    MCP client (Claude, ChatGPT, the SDK) actually talks to.
+# ---------------------------------------------------------------------------
+note "MCP (memory server + admin tool dispatch) from the installed artifact"
+
+MCP_OUT="$WORK/mcp.log"
+
+( cd "$PROJ" && timeout 60 "$LOBU_BIN" memory health -c local ) > "$MCP_OUT" 2>&1
+if grep -qF "ok: true" "$MCP_OUT"; then
+  pass "lobu memory health (MCP server reachable)"
+else
+  fail "lobu memory health did not report ok"; tail -15 "$MCP_OUT" >&2
+fi
+
+# Listing tools proves the server registered its tool schemas, not merely that
+# the process is up — an empty registry still answers a health check.
+( cd "$PROJ" && timeout 60 "$LOBU_BIN" memory run -c local ) > "$MCP_OUT" 2>&1
+if grep -qE "[0-9]+ tool\(s\)" "$MCP_OUT"; then
+  pass "lobu memory run (tools registered: $(grep -oE '[0-9]+ tool\(s\)' "$MCP_OUT" | head -1))"
+else
+  fail "lobu memory run listed no tools"; tail -15 "$MCP_OUT" >&2
+fi
+
+# A real tool INVOCATION, not just discovery — round-trips request and response
+# through the MCP transport.
+( cd "$PROJ" && timeout 60 "$LOBU_BIN" call manage_feeds -c local --arg "action=list_feeds" ) > "$MCP_OUT" 2>&1
+MCP_RC=$?
+if [ "$MCP_RC" -eq 0 ]; then
+  pass "lobu call manage_feeds list_feeds (MCP tool invocation)"
+else
+  fail "MCP tool invocation failed (exit=$MCP_RC)"; tail -15 "$MCP_OUT" >&2
+fi
+
+( cd "$PROJ" && timeout 60 "$LOBU_BIN" call --list -c local ) > "$MCP_OUT" 2>&1
+if grep -qE "tool\(s\)" "$MCP_OUT"; then
+  pass "lobu call --list (admin tool surface)"
+else
+  fail "lobu call --list exposed no tools"; tail -15 "$MCP_OUT" >&2
+fi
+
+echo ""
+echo "================================================================"
+echo "  smoke summary: $PASSES passed, $FAILS failed"
+echo "================================================================"
+if [ "$FAILS" -gt 0 ]; then
+  echo "RESULT: published-artifact smoke FAILED"; exit 1
+fi
+echo "RESULT: published-artifact smoke PASSED (@lobu/cli@$RESOLVED)"


### PR DESCRIPTION
## Summary
Every "I can't get started" issue we have shipped has one shape: **works from the monorepo, broken from the published artifact.** Nothing in CI ever installed what we published, so the whole class was invisible.

`cli-smoke` walks every command but points `LOBU_BIN` at the **source tree**, which silently pins four things — and each pin hid a real shipped bug:

| axis cli-smoke pins | bug it hid |
|---|---|
| source tree, never an `npm install` | #2186 unpublished private dep; #2231 no `lobu` on PATH |
| `.ts` entry ⇒ spawned by **bun** | `__filename is not defined` (#2375) |
| unprivileged runner | uid-0 embedded-postgres refusal (#2377) |
| modern-glibc runner | `GLIBC_2.38` pgvector floor (#2376) |

The bun one is **structural**, not incidental: the gateway picks the worker entrypoint by *file extension* (`gateway/config/index.ts` → `src/index.ts` in-repo, `dist/index.bundle.mjs` installed) and `buildWorkerInvocation` spawns `.ts` under bun, `.mjs` under node. In-repo we can only ever take the bun path. **Walking more commands in cli-smoke cannot help — the failing path does not exist in-repo.**

## What this adds
`scripts/published-artifact-smoke.sh` — installs `@lobu/cli` **from npm**, then runs the landing page's own quickstart: `init` → `validate` → `run` → a **real agent turn** → the **MCP surface** (memory server health, tool registration, a real tool invocation, admin tool dispatch).

Matrix, one cell per axis that hid a bug:

| cell | base | glibc | uid | catches |
|---|---|---|---|---|
| bookworm-nonroot | `node:22-bookworm-slim` | 2.36 | 1000 | too-new pgvector prebuilt (`node:22-slim` IS bookworm) |
| bookworm-root | `node:22-bookworm-slim` | 2.36 | 0 | missing `createPostgresUser` |
| trixie-nonroot | `node:22-trixie-slim` | 2.41 | 1000 | control — isolates "glibc floor" from "generally broken" |
| jammy-nonroot | `ubuntu:22.04` | 2.35 | 1000 | a floor that clears bookworm but not 22.04 |

**Triggers:** merge to `main` (the registry artifact is the *previous* release, so this is a standing check that what users can install right now still works), after a publish completes, daily at 07:00, and on demand for a specific version.

**No secrets required** — reuses the deterministic mock provider from `scripts/sdk-e2e/`.

## Test plan
- [x] `make pre-pr` clean
- [x] Bug fix / gate: red→green outputs pasted below
- [x] Gate validated against a known-broken release, then against a fixed build

### red — the gate against the currently-published 14.7.1
```
== a real agent turn (the __filename / worker-packaging assertion) ==
  [FAIL] lobu chat did not return the model's reply (exit=1)
         ^ a CJS global leaked into the ESM worker bundle; node has no such
           binding (bun does, which is why in-repo checks stay green)
💥 Worker crashed (ReferenceError): __filename is not defined
  [FAIL] the worker logged a crash during the turn

== MCP (memory server + admin tool dispatch) from the installed artifact ==
  [OK]   lobu memory health (MCP server reachable)
  [OK]   lobu memory run (tools registered: 6 tool(s))
  [OK]   lobu call manage_feeds list_feeds (MCP tool invocation)
  [OK]   lobu call --list (admin tool surface)

  smoke summary: 11 passed, 2 failed
RESULT: published-artifact smoke FAILED
```
Exit 1 — and the diagnostic names the cause rather than leaving a bare stack trace.

### green — same install, worker bundle swapped for the #2375 build
```
$ lobu chat "say the safe word" -c local
ARTIFACT_SMOKE_OK
worker crashes in run log: 0
```

## The part worth reviewing hardest
**Two earlier drafts of this gate went GREEN against a provably broken 14.7.1.** Twice:

1. The test agent had no `network.allowed`, so the worker's bash bootstrap never built the egress transport (`allowedDomains.length > 0 ? buildEgressFetch(...) : undefined`) and never reached the crashing code.
2. The fix attempt used `network: { allowedDomains: [...] }` — the **internal core** key. The CLI's public `NetworkConfig` is `{ allowed, denied }`, so the config was accepted and silently dropped (`lobu agent config get` → `networkConfig: {}`).

Both traps are documented at the call site. A gate that cannot fail is worse than no gate, so please sanity-check that this one still can.

## Notes on scope — deliberately NOT duplicating existing gates
The three existing e2e gates all run **from source** and keep their axes:
- `sdk-e2e.sh` — SDK lifecycle depth (apply → prune → worker turn → connector → client)
- `cli-smoke.sh` — command-surface breadth
- `managed-e2e.sh` — managed-connector OAuth across two instances

This one owns a genuinely new axis: **from the registry, across runtime environments**. It stays deliberately narrow (only the packaging-sensitive slice) rather than becoming a second cli-smoke. `cli-smoke.sh` now documents what it structurally cannot catch and points here, so the next packaging bug isn't chased by adding more commands there.

`make review-fix` could not run — codex quota exhausted until Aug 5 (#2372).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated smoke testing for published CLI packages across multiple Linux distributions, Node.js environments, and privilege levels.
  * Expanded end-to-end validation to cover project setup, agent interactions, gateway startup, MCP health, tool discovery, invocation, and administration.
  * Added diagnostic logs and cleanup handling to simplify failure investigation.
* **Documentation**
  * Documented the coverage and limitations of existing CLI smoke tests and published-artifact validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->