### PR TITLE
fix(server): report an MCP client's registered name, not its driver

### DIFF
--- a/packages/cli/src/commands/clients.ts
+++ b/packages/cli/src/commands/clients.ts
@@ -20,7 +20,6 @@ interface ClientRecord {
   status: string;
   authState: string;
   lastSeenAt: number | null;
-  firstParty: boolean;
 }
 
 export async function clientsListCommand(
@@ -55,12 +54,11 @@ export async function clientsListCommand(
     const agent = record.assignedAgentName
       ? chalk.dim(` → ${record.assignedAgentName}`)
       : "";
-    const firstParty = record.firstParty ? chalk.dim(" [lobu]") : "";
     const lastSeen = record.lastSeenAt
       ? chalk.dim(`  last seen ${new Date(record.lastSeenAt).toISOString()}`)
       : "";
     console.log(
-      `  ${dot} ${chalk.bold(title)} ${chalk.dim(`(${record.kind})`)}${platform}${agent}${firstParty}${lastSeen}`
+      `  ${dot} ${chalk.bold(title)} ${chalk.dim(`(${record.kind})`)}${platform}${agent}${lastSeen}`
     );
     if (record.kind === "mcp") {
       console.log(chalk.dim(`    id: ${record.id}`));

--- a/packages/server/src/lobu/__tests__/client-routes-identity.test.ts
+++ b/packages/server/src/lobu/__tests__/client-routes-identity.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Repro probe: the listed identity of an MCP client must be what it REGISTERED
+ * as, not what happens to be driving the current session.
+ *
+ * `oauth_clients.client_name` is set once at dynamic registration.
+ * `metadata.last_client_info.name` is overwritten on every MCP `initialize`,
+ * and it reflects the PROCESS holding the connection — so an Owletto Mac build
+ * driven by the Claude Code SDK reports `claude-code`.
+ *
+ * Letting clientInfo win made two things wrong at once, both measured on prod
+ * 2026-07-30 (19 rows, all 19 mismatched):
+ *   - the displayed vendor was the driver, not the app: "Owletto for Mac" and
+ *     "Lobu CLI" both rendered as "claude-code", ChatGPT as "openai-mcp"
+ *   - `firstParty` keyed off that polluted name, so Lobu's own surfaces lost
+ *     their badge whenever a third-party runtime drove them — that field is
+ *     now deleted rather than repaired (see the third test)
+ *
+ * Both fixtures below are copied from real prod rows.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from '../../gateway/__tests__/helpers/db-setup.js';
+import { authStash, installRouteTestMocks } from './helpers/route-test-mocks';
+
+installRouteTestMocks();
+
+const ORG = 'org-identity';
+const USER = 'u-owner';
+
+/** Prod row: registered "Owletto for Mac", driven by the Claude Code SDK. */
+const MAC_CLIENT = 'mcp_client_owletto_mac';
+/** Prod row: registered "ChatGPT", reports itself as "openai-mcp". */
+const CHATGPT_CLIENT = 'mcp_client_chatgpt';
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+}, 60_000);
+
+async function importClientRoutes() {
+  const mod = await import('../client-routes.js');
+  return mod.clientRoutes;
+}
+
+async function seed(): Promise<void> {
+  const { getDb } = await import('../../db/client.js');
+  const sql = getDb();
+
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${USER}, 'Owner', 'owner@test', true, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG}, ${ORG}, ${ORG})
+    ON CONFLICT (id) DO NOTHING
+  `;
+
+  // Registered as "Owletto for Mac" but every session reports `claude-code`,
+  // because the Mac app drives its MCP connection through the Claude Code SDK.
+  await sql`
+    INSERT INTO oauth_clients (id, client_name, software_id, software_version, redirect_uris, metadata)
+    VALUES (
+      ${MAC_CLIENT}, 'Owletto for Mac', 'owletto-mac', '0.1.0',
+      ARRAY['http://127.0.0.1:59123/callback']::text[],
+      ${sql.json({
+        last_client_info: { name: 'claude-code', version: '2.1.198' },
+        last_user_agent: 'claude-code/2.1.198 (sdk-cli)',
+      })}
+    )
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO oauth_clients (id, client_name, redirect_uris, metadata)
+    VALUES (
+      ${CHATGPT_CLIENT}, 'ChatGPT',
+      ARRAY['https://chatgpt.com/connector/oauth/vZ8jgAUNyIH4']::text[],
+      ${sql.json({
+        last_client_info: { name: 'openai-mcp', version: '1.0.0' },
+        last_user_agent: 'openai-mcp/1.0.0',
+      })}
+    )
+    ON CONFLICT (id) DO NOTHING
+  `;
+
+  for (const clientId of [MAC_CLIENT, CHATGPT_CLIENT]) {
+    await sql`
+      INSERT INTO oauth_tokens (
+        id, token_type, token_hash, client_id, user_id, organization_id,
+        scope, expires_at, created_at
+      ) VALUES (
+        ${`tok_${clientId}`}, 'access', ${`hash_${clientId}`}, ${clientId}, ${USER}, ${ORG},
+        'mcp:read', now() + interval '1 hour', now()
+      )
+      ON CONFLICT (id) DO NOTHING
+    `;
+  }
+}
+
+interface ListedClient {
+  id: string;
+  title: string | null;
+  drivenBy: string | null;
+}
+
+async function listClients(): Promise<Map<string, ListedClient>> {
+  const routes = await importClientRoutes();
+  const res = await routes.request('/');
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { clients: ListedClient[] };
+  return new Map(body.clients.map((c) => [c.id, c]));
+}
+
+describe('MCP client identity', () => {
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seed();
+    authStash.organizationId = ORG;
+    authStash.memberRole = 'owner';
+  });
+
+  test('the listed title is the registered name, not the driving process', async () => {
+    const clients = await listClients();
+
+    // Before the fix both of these returned the clientInfo name, so the UI
+    // showed "claude-code" for a Lobu product and "openai-mcp" for ChatGPT.
+    expect(clients.get(MAC_CLIENT)?.title).toBe('Owletto for Mac');
+    expect(clients.get(CHATGPT_CLIENT)?.title).toBe('ChatGPT');
+  });
+
+  test('the driving process is still reported, on its own field', async () => {
+    // clientInfo answers a genuinely useful but DIFFERENT question — what is
+    // driving the connection. Keeping it costs nothing once it stops
+    // overriding identity.
+    const clients = await listClients();
+
+    expect(clients.get(MAC_CLIENT)?.drivenBy).toBe('claude-code');
+    expect(clients.get(CHATGPT_CLIENT)?.drivenBy).toBe('openai-mcp');
+  });
+
+  test('no client is classified as first-party by its self-asserted name', async () => {
+    // `firstParty` used to be derived from a hardcoded software-id allowlist
+    // plus a "lobu*" name-prefix match. The allowlist went stale at the
+    // Lobu→Owletto rename (that staleness was half this bug), and the prefix
+    // fallback let any registration claim the category by naming itself.
+    // Both signals are supplied by the client at registration, so neither can
+    // classify anything. Its only consumers were two cosmetic labels; the
+    // field is gone rather than re-derived.
+    const clients = await listClients();
+
+    for (const client of clients.values()) {
+      expect(client).not.toHaveProperty('firstParty');
+    }
+  });
+});

--- a/packages/server/src/lobu/client-routes.ts
+++ b/packages/server/src/lobu/client-routes.ts
@@ -24,44 +24,12 @@ type MessagingClientRecord = {
 	externalUrl: string | null;
 	linkedUserName: null;
 	linkedUserEmail: null;
-	/** True for Lobu's own surfaces (CLI, Mac/iOS bridges) — never for messaging clients. */
-	firstParty: false;
 	details: {
 		connectionId: string | null;
 		description: string | null;
 		connectionMetadata: Record<string, unknown> | null;
 	};
 };
-
-/**
- * Software ids Lobu's own surfaces register with — the exact, non-spoofable
- * signal for first-party clients. (Keep in sync with the CLI / bridge clients.)
- */
-const LOBU_FIRST_PARTY_SOFTWARE_IDS = new Set([
-	"lobu-cli",
-	"lobu",
-	"lobu-mac-bridge",
-	"lobu-ios-bridge",
-	"lobu-bridge",
-]);
-
-/**
- * Recognises Lobu's first-party surfaces (CLI, Mac/iOS bridges) so the UI can
- * fold them into a "your devices & tools" group instead of listing them
- * alongside third-party MCP apps. Prefers the exact software-id allowlist;
- * the "Lobu …" client-name check is a best-effort fallback for clients that
- * register without a known software id (and could in theory be spoofed — this
- * is a display category, not an access boundary).
- */
-function isFirstPartyLobuClient(
-	name: string | null,
-	softwareId: string | null,
-): boolean {
-	const s = (softwareId ?? "").trim().toLowerCase();
-	if (s && LOBU_FIRST_PARTY_SOFTWARE_IDS.has(s)) return true;
-	const n = (name ?? "").trim().toLowerCase();
-	return n === "lobu" || n.startsWith("lobu ") || n.startsWith("lobu-");
-}
 
 function withOrg(c: any, fn: () => Promise<Response>): Promise<Response> {
 	const organizationId = c.get("organizationId");
@@ -179,7 +147,6 @@ async function listMessagingClients(options: {
 			externalUrl: externalUrlForMessagingIdentity(platform, row.user_id),
 			linkedUserName: null,
 			linkedUserEmail: null,
-			firstParty: false as const,
 			details: {
 				connectionId: null,
 				description: null,
@@ -254,15 +221,22 @@ routes.get("/", mcpAuth, async (c) => {
 
 				if (agentId && assignedAgentId !== agentId) return null;
 
-				const title =
-					asNonEmptyString(clientInfo?.name) ||
-					asNonEmptyString(client.client_name);
+				// Identity is what the client REGISTERED as. `clientInfo.name` is
+				// rewritten on every MCP `initialize` and names the process
+				// driving the connection, not the app — an Owletto Mac build
+				// driven by the Claude Code SDK reports `claude-code`. Letting it
+				// win renamed every row on prod (19/19 mismatched, 2026-07-30).
+				// It stays available as `drivenBy`, which is a real question.
+				const registeredName = asNonEmptyString(client.client_name);
+				const drivenBy = asNonEmptyString(clientInfo?.name);
+				const title = registeredName || drivenBy;
 				const softwareId = asNonEmptyString(client.software_id);
 
 				return {
 					id: client.client_id,
 					kind: "mcp" as const,
 					title,
+					drivenBy,
 					registrationGroupKey:
 						client.client_name && client.owner_user_id
 							? JSON.stringify([
@@ -292,7 +266,6 @@ routes.get("/", mcpAuth, async (c) => {
 							: null,
 					linkedUserName: client.user_name ?? null,
 					linkedUserEmail: client.user_email ?? null,
-					firstParty: isFirstPartyLobuClient(title, softwareId),
 					details: {
 						softwareVersion: client.software_version ?? null,
 						redirectUris: client.redirect_uris,


### PR DESCRIPTION
## What

`GET /api/:orgSlug/clients` resolved a client's title as `clientInfo.name || client_name`.

`client_name` is written once at dynamic registration. `metadata.last_client_info.name` is overwritten on every MCP `initialize` and names the **process driving the connection**, not the app. Letting the driver win renamed every row.

Measured on prod 2026-07-30 — **all 19 rows** display their driver rather than the app:

| Registered as | Displayed as |
|---|---|
| Owletto for Mac (x3) | `claude-code` |
| Lobu CLI | `claude-code` |
| Claude (x2) | `claude-code` |
| ChatGPT | `openai-mcp` |
| Codex (x2) | `codex-mcp-client` |

The consequence is not cosmetic: **two different products render as the same row title**. The Connected apps page shows `claude-code` twice — 2 registrations (Claude) and 5 (Owletto for Mac) — so Revoke is unattributable. You cannot tell which grant you are about to kill.

Identity is now the registered name; the driver stays available as `drivenBy`, which answers a real but different question.

## `firstParty` deleted rather than repaired

It was derived from a hardcoded software-id allowlist plus a `lobu*` name-prefix fallback. The allowlist went stale at the Lobu→Owletto rename, so every Mac and Owletto-CLI row lost its badge — that staleness was half this bug. Both inputs are supplied by the client at registration, so neither can classify anything; the code's own comment says it is "a display category, not an access boundary".

Its only consumers were two cosmetic labels: a badge on `/connectors/apps` and a dim `[lobu]` in `lobu clients`. Extending the allowlist would have been patching the instance.

## Red → green

Before (new test against the current code):
```
expect(clients.get(MAC_CLIENT)?.title).toBe('Owletto for Mac')
  Expected: "Owletto for Mac"
  Received: "claude-code"
expect(clients.get(MAC_CLIENT)?.drivenBy).toBe('claude-code')
  Expected: "claude-code"
  Received: undefined
0 pass, 3 fail
```

After:
```
3 pass, 0 fail, 9 expect() calls
```

Full `src/lobu/__tests__` directory: **118 pass, 0 fail** (15 files).
`make pre-pr`: clean. `make review-fix`: no edits needed; it mutation-tested the new test (flipping the title preference back turns it red).

Verified against a booted server with prod-shaped fixtures, not just tests:

```
title (shown)      drivenBy       firstParty?  kind
Owletto for Mac    claude-code    absent       mcp
Lobu CLI           lobu-memory    absent       mcp
ChatGPT            openai-mcp     absent       mcp
Claude             claude-code    absent       mcp
```

## Side effect

`client-session-routes.ts` already joined `client_name`, so the two surfaces now agree on a client's name instead of contradicting each other.

## Follow-up (not in this PR)

The owletto side drops `firstParty` from `apps.tsx` and `lib/api/clients.ts` and binds `drivenBy`. Between the two merges the "Lobu" badge silently stops rendering on a page already slated for deletion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->