### PR TITLE
fix(server): parse oauth_clients array columns at the read boundary

### DIFF
--- a/packages/server/src/auth/oauth/__tests__/client-array-columns.test.ts
+++ b/packages/server/src/auth/oauth/__tests__/client-array-columns.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Repro probe: `oauth_clients` array columns must reach callers as arrays.
+ *
+ * The gateway pool runs with `fetch_types: false`, so postgres.js hands back
+ * `text[]` columns as the raw literal `{a,b}` — a STRING. `toOAuthClient`
+ * passed those through while declaring them `string[]`, so the type lied and
+ * every consumer silently got a string.
+ *
+ * Two consequences, one cosmetic and one not:
+ *   - `redirectUris.join(...)` threw in the web UI (measured against prod
+ *     2026-07-31: `"{https://claude.ai/api/mcp/auth_callback}"`)
+ *   - `client.redirect_uris.includes(candidate)` in the authorize path
+ *     degraded from array membership to SUBSTRING matching, so a candidate
+ *     that merely appears inside the stored literal was accepted. Same for
+ *     `grant_types.includes('authorization_code')`.
+ *
+ * `parsePgTextArray` already existed in `db/client.ts`; the boundary just
+ * never called it.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from '../../../gateway/__tests__/helpers/db-setup.js';
+
+const CLIENT = 'mcp_client_arraycols';
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+}, 60_000);
+
+async function seed(): Promise<void> {
+  const { getDb } = await import('../../../db/client.js');
+  const sql = getDb();
+  await sql`
+    INSERT INTO oauth_clients (
+      id, client_name, redirect_uris, grant_types, response_types, contacts
+    ) VALUES (
+      ${CLIENT}, 'Array Cols',
+      ARRAY['https://app.example.com/callback', 'https://alt.example.com/cb']::text[],
+      ARRAY['authorization_code', 'refresh_token']::text[],
+      ARRAY['code']::text[],
+      ARRAY['ops@example.com']::text[]
+    )
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+async function loadClient() {
+  const { getDb } = await import('../../../db/client.js');
+  const { OAuthClientsStore } = await import('../clients.js');
+  return new OAuthClientsStore(getDb()).getClient(CLIENT);
+}
+
+describe('oauth_clients array columns', () => {
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seed();
+  });
+
+  test('array columns arrive as arrays, not Postgres literals', async () => {
+    const client = await loadClient();
+    expect(client).toBeTruthy();
+
+    expect(Array.isArray(client?.redirect_uris)).toBe(true);
+    expect(client?.redirect_uris).toEqual([
+      'https://app.example.com/callback',
+      'https://alt.example.com/cb',
+    ]);
+    expect(client?.grant_types).toEqual(['authorization_code', 'refresh_token']);
+    expect(client?.response_types).toEqual(['code']);
+    expect(client?.contacts).toEqual(['ops@example.com']);
+  });
+
+  test('redirect-uri membership is exact, not substring', async () => {
+    const client = await loadClient();
+
+    // Every one of these is a substring of the raw literal
+    // `{https://app.example.com/callback,https://alt.example.com/cb}` and so
+    // passed `.includes()` while the value was still a string.
+    for (const forged of [
+      'https://app.example.com/call',
+      'app.example.com/callback',
+      'com/callback,https://alt.example.com',
+      '{https://app.example.com/callback',
+    ]) {
+      expect(client?.redirect_uris.includes(forged)).toBe(false);
+    }
+
+    expect(client?.redirect_uris.includes('https://app.example.com/callback')).toBe(
+      true
+    );
+  });
+
+  test('grant-type membership is exact, not substring', async () => {
+    const client = await loadClient();
+
+    expect(client?.grant_types?.includes('authorization_cod')).toBe(false);
+    expect(client?.grant_types?.includes('authorization_code')).toBe(true);
+  });
+});

--- a/packages/server/src/auth/oauth/__tests__/client-array-columns.test.ts
+++ b/packages/server/src/auth/oauth/__tests__/client-array-columns.test.ts
@@ -88,9 +88,9 @@ describe('oauth_clients array columns', () => {
       expect(client?.redirect_uris.includes(forged)).toBe(false);
     }
 
-    expect(client?.redirect_uris.includes('https://app.example.com/callback')).toBe(
-      true
-    );
+    // `toContain` on an array is exact element membership, so this stays a
+    // real membership assertion (and does not read as URL substring matching).
+    expect(client?.redirect_uris).toContain('https://app.example.com/callback');
   });
 
   test('grant-type membership is exact, not substring', async () => {

--- a/packages/server/src/auth/oauth/clients.ts
+++ b/packages/server/src/auth/oauth/clients.ts
@@ -7,7 +7,7 @@
 
 import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
 import type { DbClient } from '../../db/client';
-import { pgTextArray } from '../../db/client';
+import { pgTextArray, parsePgTextArray } from '../../db/client';
 import { recordLifecycleEvent } from '../../utils/insert-event';
 import type { OAuthClient, OAuthClientMetadata, StoredOAuthClient } from './types';
 import { generateClientId, generateClientSecret } from './utils';
@@ -369,19 +369,24 @@ export class OAuthClientsStore {
       client_secret_expires_at: stored.client_secret_expires_at
         ? Math.floor(new Date(stored.client_secret_expires_at).getTime() / 1000)
         : undefined,
-      redirect_uris: stored.redirect_uris,
+      // `text[]` columns arrive as the raw literal `{a,b}` because the pool
+      // runs `fetch_types: false`. Parse at this boundary — it is the single
+      // read path for both getClient() and listClientsByOrganization(), and
+      // callers do membership tests (`redirect_uris.includes(...)`) that
+      // silently degrade to substring matching against a string.
+      redirect_uris: parsePgTextArray(stored.redirect_uris),
       token_endpoint_auth_method:
         (stored.token_endpoint_auth_method as
           | 'none'
           | 'client_secret_post'
           | 'client_secret_basic') || 'none',
-      grant_types: stored.grant_types,
-      response_types: stored.response_types,
+      grant_types: parsePgTextArray(stored.grant_types),
+      response_types: parsePgTextArray(stored.response_types),
       client_name: stored.client_name || undefined,
       client_uri: stored.client_uri || undefined,
       logo_uri: stored.logo_uri || undefined,
       scope: stored.scope || undefined,
-      contacts: stored.contacts || undefined,
+      contacts: stored.contacts ? parsePgTextArray(stored.contacts) : undefined,
       tos_uri: stored.tos_uri || undefined,
       policy_uri: stored.policy_uri || undefined,
       software_id: stored.software_id || undefined,

--- a/packages/server/src/db/__tests__/client.test.ts
+++ b/packages/server/src/db/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { pgBigintArray, pgTextArray } from '../client';
+import { parsePgTextArray, pgBigintArray, pgTextArray } from '../client';
 
 describe('database array helpers', () => {
   it('formats bigint arrays as PostgreSQL literals', () => {
@@ -9,5 +9,38 @@ describe('database array helpers', () => {
 
   it('formats text arrays as PostgreSQL literals', () => {
     expect(pgTextArray(['alpha', 'beta'])).toBe('{"alpha","beta"}');
+  });
+
+  it('parses PostgreSQL text array literals', () => {
+    expect(parsePgTextArray('{a,b}')).toEqual(['a', 'b']);
+    expect(parsePgTextArray('{}')).toEqual([]);
+    expect(parsePgTextArray(null)).toEqual([]);
+    expect(parsePgTextArray(['already', 'array'])).toEqual([
+      'already',
+      'array',
+    ]);
+    expect(parsePgTextArray('{"c d"}')).toEqual(['c d']);
+    expect(parsePgTextArray('{"say \\"hi\\"","back\\\\slash"}')).toEqual([
+      'say "hi"',
+      'back\\slash',
+    ]);
+  });
+
+  it('keeps commas inside quoted elements', () => {
+    // PostgreSQL quotes any element containing a comma, so this is ONE
+    // element; splitting on every comma shredded it into two invalid ones.
+    expect(
+      parsePgTextArray(
+        '{"https://app.example.com/callback?tags=a,b",https://alt.example.com/cb}'
+      )
+    ).toEqual([
+      'https://app.example.com/callback?tags=a,b',
+      'https://alt.example.com/cb',
+    ]);
+  });
+
+  it('round-trips pgTextArray output', () => {
+    const values = ['https://x/cb?tags=a,b', 'say "hi"', 'plain'];
+    expect(parsePgTextArray(pgTextArray(values))).toEqual(values);
   });
 });

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -92,6 +92,10 @@ export function tsTimeOrNull(value: unknown): number | undefined {
  * Parse a value that may be a JS array or a PostgreSQL array literal
  * (`{a,b,"c d"}`) into a string array. Quoted elements are unquoted and
  * `\"` / `\\` escapes are resolved.
+ *
+ * The separator is only a separator OUTSIDE quotes: PostgreSQL quotes any
+ * element containing a comma, so `{"https://x/cb?tags=a,b"}` is ONE element.
+ * Splitting on every comma would shred it into two invalid ones.
  */
 export function parsePgTextArray(
   raw: string | string[] | null | undefined
@@ -101,13 +105,36 @@ export function parsePgTextArray(
   const inner =
     raw.startsWith('{') && raw.endsWith('}') ? raw.slice(1, -1) : raw;
   if (inner === '') return [];
-  return inner.split(',').map((v) => {
-    const trimmed = v.trim();
-    if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-      return trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  const out: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  let quoted = false;
+  let escaped = false;
+  for (const ch of inner) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
     }
-    return trimmed;
-  });
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+      if (inQuotes) quoted = true;
+      continue;
+    }
+    if (ch === ',' && !inQuotes) {
+      out.push(quoted ? current : current.trim());
+      current = '';
+      quoted = false;
+      continue;
+    }
+    current += ch;
+  }
+  out.push(quoted ? current : current.trim());
+  return out;
 }
 
 /**


### PR DESCRIPTION
## What

The gateway pool runs `fetch_types: false`, so postgres.js returns `text[]` columns as the raw literal `{a,b}` — a **string**. `toOAuthClient` passed those through while declaring them `string[]`, so the type lied and every consumer received a string.

## The part that isn't cosmetic

`provider.ts:567` validates redirect URIs with `client.redirect_uris.includes(redirectUri)`. On a string, `.includes()` is **substring matching, not array membership**.

For a client registered with `{https://app.example.com/callback,https://alt.example.com/cb}`, all four of these were accepted as valid redirect URIs:

```
https://app.example.com/call           (truncation)
app.example.com/callback               (scheme stripped)
com/callback,https://alt.example.com   (spans the array separator)
{https://app.example.com/callback      (includes the literal's brace)
```

`grant_types.includes('authorization_code')` at `provider.ts:122` had the same weakness.

Practical exploitability is **low** — dynamic client registration is open, so an attacker registers their own client and already controls its redirect, giving no cross-client escalation. But the check was not doing what it claimed, and the type asserted otherwise.

## Fix

One call site: `toOAuthClient`, the single read path behind both `getClient()` and `listClientsByOrganization()`. It now uses `parsePgTextArray` — a helper that **already existed** in `db/client.ts` and is used correctly in 17 other places. The boundary simply never called it.

Covers `redirect_uris`, `grant_types`, `response_types`, `contacts`.

Also fixes the web UI crash that surfaced this: `redirectUris.join(...)` threw on the new client detail view, because prod returns `"{https://claude.ai/api/mcp/auth_callback}"`.

## Red → green

Before:
```
expect(client?.redirect_uris.includes('https://app.example.com/call')).toBe(false)
  Expected: false
  Received: true
expect(client?.grant_types?.includes('authorization_cod')).toBe(false)
  Expected: false
  Received: true
0 pass, 3 fail
```

After:
```
3 pass, 0 fail, 13 expect() calls
```

`src/auth/oauth/__tests__` + `src/lobu/__tests__`: **120 pass, 0 fail** (16 files).
`make pre-pr`: clean.

## Not fixed here

11 other ARRAY columns: `entity_ids` across five tables, `entities.enabled_classifiers`, `watchers.tags`, `watcher_versions.{recommended,required}_source_types`, `event_classifications.values`.

The codebase currently handles this three ways — parse in TS (17 sites), cast via `to_jsonb` in SQL, and raw. Closing the class means auditing each remaining site for which pattern it uses; that deserves its own PR rather than riding this one.

## Follow-up: `parsePgTextArray` and quoted commas

Review pointed out the helper itself split on every comma. PostgreSQL quotes any element containing a comma, so a valid literal like `{"https://app.example.com/callback?tags=a,b"}` is ONE element, and `split(',')` shredded it into two invalid ones. The helper now scans the literal, treating the separator as a separator only outside quotes:

```ts
if (ch === '"') { inQuotes = !inQuotes; if (inQuotes) quoted = true; continue; }
if (ch === ',' && !inQuotes) {
  out.push(quoted ? current : current.trim());
  current = ''; quoted = false; continue;
}
```

Escape handling (`\"`, `\\`) and the lenient trim for unquoted elements are unchanged, and `parsePgTextArray(pgTextArray(v))` now round-trips values containing commas and quotes. Covered in `packages/server/src/db/__tests__/client.test.ts`. This is a fix at the helper, so the other 17 call sites get it too.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth client data handling so array-based settings are returned correctly.
  * Fixed matching for redirect URIs and grant types to use exact values rather than partial text matches.

* **Tests**
  * Added coverage for PostgreSQL array values and OAuth client loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
