### PR TITLE
ci: boot the app image on every merge, and gate releases on it

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -213,6 +213,61 @@ jobs:
             https://api.github.com/user/packages/container/lobu-app/visibility \
             -d '{"visibility":"public"}' || true
 
+  # App-image smoke. Deliberately runs AFTER build-app has pushed, not before.
+  #
+  # `connector-parity-smoke` gates the push because a broken worker must never
+  # reach the registry. This one is the opposite shape on purpose: it needs the
+  # pushed tag to exist so it can smoke the EXACT artifact Flux will roll out,
+  # rather than a rebuild that could differ. So it cannot block the rollout —
+  # but it does fail the workflow, which reddens main and is what stops a
+  # release being cut on a broken image.
+  #
+  # Nothing else runs the app image. build-images only builds it, and CI's
+  # suites run from source. That gap shipped #2231 (no `lobu` on PATH in the
+  # image) and #2183 (app image serving 404s for its own assets) — both with
+  # every check green.
+  app-image-smoke:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [generate-tag, build-app]
+    if: needs.generate-tag.outputs.should_publish == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    services:
+      postgres:
+        image: pgvector/pgvector:pg18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: lobu_app_smoke
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/lobu_app_smoke
+    steps:
+      # Only the smoke script is used from the checkout; the image under test
+      # comes from the registry.
+      - uses: actions/checkout@v7
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Smoke the pushed app image
+        run: |
+          chmod +x scripts/app-image-smoke.sh
+          scripts/app-image-smoke.sh \
+            "${REGISTRY}/${IMAGE_NAME_APP}:${{ needs.generate-tag.outputs.tag }}"
+
   build-worker:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     # Gate the worker push (and transitively the app push, which `needs:
@@ -338,9 +393,12 @@ jobs:
   # `slack-devops` Provider uses (devops channel) so cluster-side and CI-side
   # deploy failures land in one place. Webhook lives in the SLACK_DEPLOY_WEBHOOK_URL
   # repo secret; if unset the curl is skipped, never failing the job.
+  # app-image-smoke is in `needs` too: it runs after the tag is already pushed,
+  # so when it fails Flux may already be rolling a broken image — exactly the
+  # case that must ping, not just redden the workflow.
   notify-failure:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [generate-tag, connector-parity-smoke, build-worker, build-embeddings-service, build-app]
+    needs: [generate-tag, connector-parity-smoke, build-worker, build-embeddings-service, build-app, app-image-smoke]
     if: >-
       failure()
       && needs.generate-tag.outputs.should_publish == 'true'
@@ -365,6 +423,6 @@ jobs:
           # First line of commit/release summary only, JSON-escaped via jq.
           first_line=$(printf '%s' "$RUN_SUMMARY" | head -n1)
           payload=$(jq -nc \
-            --arg text "<@U09513HH1N1> :rotating_light: build-images failed on \`${REF_NAME}\` — sibling image tags may be incomplete. <${RUN_URL}|run> · <${COMMIT_URL}|${SHA_SHORT:0:7}> by ${ACTOR}\n> ${first_line}" \
+            --arg text "<@U09513HH1N1> :rotating_light: build-images failed on \`${REF_NAME}\` — sibling image tags may be incomplete, or the pushed app image failed its smoke. <${RUN_URL}|run> · <${COMMIT_URL}|${SHA_SHORT:0:7}> by ${ACTOR}\n> ${first_line}" \
             '{text: $text}')
           curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -33,6 +33,51 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Refuse to publish off a commit whose post-merge image smoke is red.
+      #
+      # `app-image-smoke` (in build-images.yml) BOOTS the app image built from
+      # this exact commit. If that is failing, the tree is known-broken at
+      # runtime and a release would ship it — every bug this guards against
+      # (#2231, #2183, __filename, GLIBC_2.38, uid-0) was green on every check
+      # that does not run the artifact.
+      #
+      # Deliberately NOT gated on "Published-artifact smoke": that one installs
+      # `@lobu/cli@latest` from npm, i.e. the PREVIOUS release. It is red
+      # precisely when a fix is waiting to be published, so gating on it would
+      # deadlock the release that repairs it. Its job is to alert on what users
+      # can install right now, and to verify the new version after publishing.
+      - name: Require a green app-image smoke for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          echo "publishing from ${sha}"
+
+          # Newest run of build-images for this SHA. `head_sha` filters server
+          # side so a busy main can't push ours off the first page.
+          run=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/build-images.yml/runs?head_sha=${sha}&per_page=1" \
+            --jq 'if (.workflow_runs | length) == 0 then "missing"
+                  else "\(.workflow_runs[0].status) \(.workflow_runs[0].conclusion // "none")" end')
+          status="${run%% *}"
+          conclusion="${run#* }"
+          echo "build-images status: ${status}, conclusion: ${conclusion}"
+
+          if [ "$status" = "missing" ]; then
+            echo "::error::No build-images run for ${sha}. The app image for this commit has never been built or smoked; publish would ship an unverified tree."
+            exit 1
+          fi
+          if [ "$status" != "completed" ]; then
+            echo "::error::build-images for ${sha} is still '${status}'. Wait for the app-image smoke to finish, then re-run this publish."
+            exit 1
+          fi
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::build-images for ${sha} concluded '${conclusion}'. The app image smoke is not green — fix main before releasing."
+            exit 1
+          fi
+          echo "app-image smoke green for ${sha} — proceeding."
+
       - uses: ./.github/actions/setup-submodule
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}

--- a/scripts/app-image-smoke.sh
+++ b/scripts/app-image-smoke.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# App-image smoke: BOOT the lobu-app image that was just pushed and exercise the
+# surfaces a user actually touches — HTTP health, the web UI and every asset it
+# references, the MCP mount, the in-container `lobu` CLI, and the connector
+# runtime.
+#
+# Why this exists, and why building the image is not enough.
+#
+# `build-images.yml` builds and pushes app/worker/embeddings, and Flux rolls the
+# tag out. Nothing in that path ever RUNS the app image. The whole "image builds
+# green, container is broken" class was therefore invisible:
+#
+#   #2231   no `lobu` on PATH inside the image — the CLI shipped, unreachable
+#   #2183   app image serves 404s for assets the built SPA references
+#   #430    execute tool dead in prod — isolated-vm (a V8 addon) cannot load
+#           under the bun the container then ran on
+#
+# `connector-parity-smoke` already learned this lesson for the WORKER image (it
+# `docker run`s the self-check rather than trusting the build). This is the same
+# move for the APP image, which is the one users and the browser talk to.
+#
+# It runs AFTER `build-app` has pushed, deliberately: a failure here must not
+# block the push or Flux's rollout, but it does fail the workflow — so main goes
+# red and a release cannot be cut on a broken image.
+#
+# Keyless: needs only a Postgres with pgvector. No provider key, no secrets.
+#
+# Usage: app-image-smoke.sh <image-ref>
+# Env:   DATABASE_URL  postgres with pgvector (required)
+#        APP_PORT      host port to bind (default 8787)
+
+set -uo pipefail
+
+IMAGE="${1:?usage: app-image-smoke.sh <image-ref>}"
+APP_PORT="${APP_PORT:-8787}"
+: "${DATABASE_URL:?DATABASE_URL must point at a pgvector-enabled Postgres}"
+
+BASE="http://127.0.0.1:${APP_PORT}"
+CID=""
+PASS=0
+FAIL=0
+
+note() { echo ""; echo "== $* =="; }
+ok()   { echo "  ok   — $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL — $*"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  if [ -n "$CID" ]; then
+    echo ""
+    echo "---- container logs (tail) ----"
+    docker logs --tail 120 "$CID" 2>&1 || true
+    docker rm -f "$CID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo "================================================================"
+echo " app-image smoke"
+echo "   image: ${IMAGE}"
+echo "================================================================"
+
+# ---------------------------------------------------------------------------
+# 1. Boot. --network host so the container reaches the Postgres service on
+#    127.0.0.1 and publishes 8787 on the runner without port-mapping games.
+# ---------------------------------------------------------------------------
+note "boot"
+CID=$(docker run -d --network host \
+  -e "DATABASE_URL=${DATABASE_URL}" \
+  -e "JWT_SECRET=app-image-smoke-not-a-real-secret" \
+  -e "ALLOW_DB_CREATE=1" \
+  -e "PORT=${APP_PORT}" \
+  "$IMAGE")
+if [ -z "$CID" ]; then
+  echo "RESULT: app-image smoke FAILED (docker run could not start the container)"
+  exit 1
+fi
+echo "  container ${CID:0:12}"
+
+# Migrations run at start, so allow a generous window. Poll /health rather than
+# sleeping: a fixed sleep either wastes time or flakes.
+booted=false
+for _ in $(seq 1 90); do
+  if curl -fsS --max-time 3 "${BASE}/health" >/dev/null 2>&1; then
+    booted=true
+    break
+  fi
+  if [ -z "$(docker ps -q --filter "id=${CID}")" ]; then
+    bad "container exited before serving /health"
+    break
+  fi
+  sleep 2
+done
+
+if [ "$booted" != true ]; then
+  bad "/health never became ready"
+  echo ""
+  echo "RESULT: app-image smoke FAILED (boot)"
+  exit 1
+fi
+ok "/health responded"
+
+# ---------------------------------------------------------------------------
+# 2. The in-container CLI (#2231). It shipped but was not on PATH, so
+#    `docker exec <container> lobu ...` — the documented self-host recipe —
+#    failed for every self-hoster while every build stayed green.
+# ---------------------------------------------------------------------------
+note "in-container CLI"
+if docker exec "$CID" lobu --version >/dev/null 2>&1; then
+  ok "\`lobu --version\` resolves on PATH"
+else
+  bad "\`lobu\` is not runnable inside the image (#2231 regression)"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Worker-entrypoint invariant.
+#
+#    `gateway/config/index.ts` picks the worker entrypoint by probing for
+#    `packages/agent-worker/src/index.ts`, and `buildWorkerInvocation` spawns a
+#    `.ts` under bun but a `.mjs` under node. Both halves must hold or the image
+#    silently falls to the bundle-under-node path — the one that raised
+#    `ReferenceError: __filename is not defined` for CLI users.
+#
+#    Asserting the two preconditions is what keeps that scoping true over time;
+#    dropping `src/` from the Dockerfile COPY, or dropping bun from the runtime
+#    stage, would each flip prod onto the broken path with no other signal.
+# ---------------------------------------------------------------------------
+note "worker entrypoint"
+if docker exec "$CID" test -f /app/packages/agent-worker/src/index.ts; then
+  ok "agent-worker src/index.ts present (resolves to the .ts entrypoint)"
+else
+  bad "agent-worker src/index.ts missing — worker would fall back to dist/index.bundle.mjs under node"
+fi
+if docker exec "$CID" bun --version >/dev/null 2>&1; then
+  ok "bun present in the runtime stage (can spawn the .ts entrypoint)"
+else
+  bad "bun missing — a .ts worker entrypoint cannot be spawned"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. The web UI, and every asset it references (#2183).
+#
+#    Fetching `/` alone proves nothing: the SPA shell is served by a catch-all,
+#    so it returns 200 even when the built bundle was never copied. The real
+#    check is to parse the script/link refs out of the served HTML and demand
+#    each one resolve — that is precisely the failure users saw as a blank page.
+# ---------------------------------------------------------------------------
+note "web UI + referenced assets"
+html=$(curl -fsS --max-time 10 "$BASE/" 2>/dev/null)
+if [ -z "$html" ]; then
+  bad "GET / returned nothing"
+else
+  ok "GET / served HTML ($(printf '%s' "$html" | wc -c | tr -d ' ') bytes)"
+
+  assets=$(printf '%s' "$html" \
+    | grep -oE '(src|href)="[^"]+\.(js|css|mjs)"' \
+    | sed -E 's/^(src|href)="//; s/"$//' \
+    | sort -u)
+
+  if [ -z "$assets" ]; then
+    bad "no js/css assets referenced by / — the SPA bundle is very likely missing"
+  else
+    n=0
+    missing=0
+    for a in $assets; do
+      url="$a"
+      case "$a" in
+        http*) ;;
+        /*) url="${BASE}${a}" ;;
+        *)  url="${BASE}/${a}" ;;
+      esac
+      code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url")
+      n=$((n + 1))
+      if [ "$code" != "200" ]; then
+        bad "asset ${a} -> HTTP ${code}"
+        missing=$((missing + 1))
+      fi
+    done
+    if [ "$missing" -eq 0 ]; then
+      ok "all ${n} referenced assets returned 200"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. MCP is mounted. Unauthenticated we expect an auth challenge, NOT a 404 —
+#    401 proves the handler is wired; 404 means the route vanished.
+# ---------------------------------------------------------------------------
+note "MCP mount"
+mcp_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+  -X POST -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  "${BASE}/mcp")
+case "$mcp_code" in
+  401|403) ok "/mcp challenged an unauthenticated call (HTTP ${mcp_code})" ;;
+  404)     bad "/mcp returned 404 — the MCP handler is not mounted" ;;
+  000)     bad "/mcp did not respond (connection failed)" ;;
+  5*)      bad "/mcp returned HTTP ${mcp_code}" ;;
+  *)       ok "/mcp responded (HTTP ${mcp_code})" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 6. Connector runtime, inside the APP image.
+#
+#    `connector-parity-smoke` runs this on the worker image and the host CLI,
+#    but the app image is a third build with its own COPY list — and the bug it
+#    guards against (#1035-class: a missing `COPY packages/core` leaving a
+#    dangling transitive import) is a per-image packaging mistake. Same check,
+#    third surface.
+# ---------------------------------------------------------------------------
+note "connector runtime (app image)"
+if docker exec "$CID" lobu connector runtime-self-check --json >/tmp/app-image-selfcheck.json 2>&1; then
+  ok "connector runtime resolves + compiles + executes"
+else
+  bad "connector runtime self-check failed"
+  tail -30 /tmp/app-image-selfcheck.json 2>/dev/null || true
+fi
+
+echo ""
+echo "  smoke summary: ${PASS} passed, ${FAIL} failed"
+if [ "$FAIL" -ne 0 ]; then
+  echo "RESULT: app-image smoke FAILED"
+  exit 1
+fi
+echo "RESULT: app-image smoke PASSED"


### PR DESCRIPTION
## What

Nothing in CI ever **ran** the app image. `build-images.yml` builds and pushes it, Flux rolls the tag out, and CI's suites run from source. The whole "image builds green, container is broken" class was therefore invisible — `#2231` (the `lobu` CLI shipped but was not on PATH) and `#2183` (app image serving 404s for its own assets) both shipped with every check green.

`connector-parity-smoke` already learned this for the **worker** image: it `docker run`s the self-check rather than trusting the build. This is the same move for the **app** image, the one users and the browser actually talk to.

### `app-image-smoke` (build-images.yml)

Runs **after** `build-app` has pushed, deliberately:

- it cannot block the push or Flux's rollout;
- it smokes the **exact tag Flux will deploy**, not a rebuild that might differ;
- it fails the workflow, so **main goes red** — which is what stops a release.

| check | guards |
|---|---|
| `/health` serves | boot regressions |
| `lobu --version` in-container | **#2231** — CLI shipped, unreachable |
| `src/index.ts` **and** `bun` present | keeps prod on the `.ts`/bun worker entrypoint, off the `__filename` path |
| every asset referenced by `/` returns 200 | **#2183** — the 404 hunt |
| `/mcp` challenges rather than 404s | MCP handler unmounted |
| connector self-check | packaging drift, third image |

It is keyless — a pgvector Postgres service is the only dependency.

### Release gate (publish-packages.yml)

Refuses to publish unless `build-images` is **green for the publishing SHA**, and fails closed on a missing or still-running run.

Deliberately **not** gated on `Published-artifact smoke`: that installs `@lobu/cli@latest`, i.e. the *previous* release, so it is red precisely when a fix is waiting to ship. Gating on it would deadlock the release that repairs it.

## Evidence

The asset check — the novel logic — mutation-tested against the real built SPA (`packages/owletto/dist/index.html`, 2 assets):

```
A: assets present     ->  ok   — all 2 referenced assets returned 200      (1 passed, 0 failed)
B: one asset removed  ->  FAIL — asset /assets/index-B8x-ua8I.js -> HTTP 404  (0 passed, 1 failed)
```

Context for why this matters — the sibling npm gate ran on main for the first time today and each matrix cell caught a **different** shipped bug against the published artifact:

```
trixie-nonroot     ReferenceError: __filename is not defined        (#2375)
bookworm-root      Postgres does not support running as root        (#2377)
bookworm/jammy     vector.so: version `GLIBC_2.38' not found        (#2376/#2379)
```

## Not verified

**The boot/exec/MCP steps have never been executed** — no docker on the authoring machine. `bash -n` is clean, the YAML parses, and the job graph is confirmed, but the first run on main is the real test and I expect to fix one or two things there. Calling that out rather than implying coverage I don't have.

`make review-fix` ran and made three changes, all kept: a guard for an empty container id, distinguishing "still running" from "no run found" in the release gate, and adding `app-image-smoke` to `notify-failure`'s `needs` so a post-push failure pings devops instead of only reddening the workflow. It also corrected my `#430` attribution — I checked the CHANGELOG and the fixer was right.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->