### PR TITLE
fix(ci): give the app-image smoke an ENCRYPTION_KEY

### DIFF
--- a/scripts/app-image-smoke.sh
+++ b/scripts/app-image-smoke.sh
@@ -65,9 +65,14 @@ echo "================================================================"
 #    127.0.0.1 and publishes 8787 on the runner without port-mapping games.
 # ---------------------------------------------------------------------------
 note "boot"
+# A real generated key, not LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY=1. The escape
+# hatch would boot too, but it takes a different startup branch than prod does,
+# and the point of this gate is to exercise the path operators actually run.
+# Throwaway: the container and its database are destroyed at the end of the job.
 CID=$(docker run -d --network host \
   -e "DATABASE_URL=${DATABASE_URL}" \
   -e "JWT_SECRET=app-image-smoke-not-a-real-secret" \
+  -e "ENCRYPTION_KEY=$(openssl rand -base64 32)" \
   -e "ALLOW_DB_CREATE=1" \
   -e "PORT=${APP_PORT}" \
   "$IMAGE")
@@ -77,10 +82,12 @@ if [ -z "$CID" ]; then
 fi
 echo "  container ${CID:0:12}"
 
-# Migrations run at start, so allow a generous window. Poll /health rather than
-# sleeping: a fixed sleep either wastes time or flakes.
+# Migrations run at start against a BLANK database — the full ledger from the
+# baseline, measured at ~113s on a runner — so the window has to clear that with
+# room for a slower runner, not just the steady-state restart case. Poll /health
+# rather than sleeping: a fixed sleep either wastes time or flakes.
 booted=false
-for _ in $(seq 1 90); do
+for _ in $(seq 1 150); do
   if curl -fsS --max-time 3 "${BASE}/health" >/dev/null 2>&1; then
     booted=true
     break


### PR DESCRIPTION
## Red → cause → fix

`app-image-smoke` (added in #2382) went red on its first run. **The image was fine.** The gate was wrong.

Container log, in order:

```
Migrations complete
[metrics] Prometheus metrics initialized
[DB] PostgreSQL singleton pool created
[schema-check] schema version up to date
[DB] LISTEN/NOTIFY probe ok
[MultiTenantProvider] Initialized

  Lobu needs an encryption key to store secrets (provider keys, tokens).
```

Migrations applied cleanly, the schema check passed, the DB probe succeeded — then the server refused to start because `ENCRYPTION_KEY` was unset. That is **correct fail-closed behaviour with a good error message**; the smoke simply never provided one.

## Changes

1. **Generate a real key** (`openssl rand -base64 32`) rather than setting `LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY=1`. The escape hatch would also boot, but it takes a different startup branch than operators run, and the point of this gate is to exercise the real one. Throwaway — the container and its database die with the job.

2. **Boot window 180s → 300s.** Migrations against a *blank* database took **~113s** on the runner (`00:58:53` → `01:00:48`). The old window would have cleared that by well under a minute, which is not enough margin on a slower runner. This is a measured number, not a guess.

## What this run proved about the harness

Worth recording, since #2382 shipped with the boot path unverified: the smoke **detected the non-booting container, dumped the container logs, and those logs diagnosed the cause in one pass** — no second run needed. The detection and diagnostics work; only the environment was wrong.

## Not verified

The remaining checks (in-container CLI, worker-entrypoint invariant, asset 404 hunt, MCP mount, connector self-check) have **still never executed** — the boot failure short-circuited before reaching them. This PR gets us past boot; the next main run is their first real test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->