### PR TITLE
ci: verify prod after every rollout

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,101 @@
+name: Prod smoke
+
+# Verifies the DEPLOYED system, which nothing else does.
+#
+#   app-image-smoke        is the image broken?   (boots with its OWN env + db)
+#   published-artifact-…   can users install it?  (npm tarball, 4 environments)
+#   THIS                   did the rollout land, and does prod work with the
+#                          REAL Helm config, ingress, TLS and database?
+#
+# An image smoke cannot catch a missing Helm env var, a broken ingress route, an
+# expired certificate, or Flux rolling a tag whose migration failed against real
+# data — it boots with its own environment. So this is not redundant with it.
+#
+# It is deliberately NOT a release gate: by the time it is red, users are
+# already affected, and prod depends on third parties and provider quota. Gating
+# releases on it would block shipping for reasons unrelated to the release. It
+# detects and alarms; app-image-smoke is what gates.
+#
+# Read-only: `events` is append-only, so a smoke that writes cannot clean up
+# after itself. Every request is a GET or an unauthenticated POST expected to be
+# rejected.
+
+on:
+  # After images are pushed. Flux rolls out asynchronously, so the job waits for
+  # the merge commit to actually appear in prod's reported revision rather than
+  # assuming the push means it is live.
+  workflow_run:
+    workflows: ["Build and Push Images"]
+    types: [completed]
+  # Continuous canary. A certificate expires, a node drains, a dependency fails
+  # — none of which involve us pushing anything.
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      url:
+        description: Base URL to smoke
+        default: https://app.lobu.ai
+      expect_sha:
+        description: Require this commit to be live (ancestor test)
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    # `types: [completed]` fires on failed and cancelled builds too. A failed
+    # build pushes no image, so the rollout gate would wait ROLLOUT_WAIT for a
+    # SHA that can never deploy and then page Slack — duplicating the alarm
+    # build-images' own notify-failure already sent. The scheduled canary
+    # still covers plain health.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      # Full history: the rollout gate runs `git merge-base --is-ancestor`
+      # against the SHA prod reports, which a shallow clone cannot resolve.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Smoke prod
+        env:
+          PROD_URL: ${{ inputs.url || 'https://app.lobu.ai' }}
+          # On a workflow_run, require the commit that triggered the image build
+          # to actually be live. On a schedule there is no specific commit to
+          # wait for, so the rollout gate is skipped and this is a pure health
+          # canary.
+          EXPECT_SHA: >-
+            ${{ inputs.expect_sha
+                || (github.event_name == 'workflow_run'
+                    && github.event.workflow_run.head_sha)
+                || '' }}
+          # Flux polls the registry then rolls the deployment; ~10min covers a
+          # normal rollout without turning a genuinely stuck deploy into a
+          # 25-minute job.
+          ROLLOUT_WAIT: ${{ github.event_name == 'workflow_run' && '600' || '0' }}
+        run: |
+          chmod +x scripts/prod-smoke.sh
+          scripts/prod-smoke.sh
+
+      # Same devops channel the Flux notification-controller and build-images'
+      # notify-failure post to, so cluster-side and CI-side breakage land in one
+      # place. Skipped when the webhook is unset; never fails the job itself.
+      - name: Post failure to Slack devops
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET: ${{ inputs.url || 'https://app.lobu.ai' }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_DEPLOY_WEBHOOK_URL not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -nc --arg text \
+            ":rotating_light: prod smoke FAILED against ${TARGET} — <${RUN_URL}|run>" \
+            '{text: $text}')
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/scripts/prod-smoke.sh
+++ b/scripts/prod-smoke.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# Prod smoke: verify the DEPLOYED system, not an artifact.
+#
+# The other two gates each answer a question this one cannot:
+#
+#   app-image-smoke        is the image broken?      (boots with its OWN env + db)
+#   published-artifact-…   can users install it?     (npm tarball, 4 environments)
+#   THIS                   did the rollout land, and does prod work with the
+#                          REAL Helm config, ingress, TLS, and database?
+#
+# Nothing here overlaps. An image smoke can never catch a missing Helm env var,
+# a broken ingress route, an expired certificate, or Flux rolling a tag whose
+# migration failed against real data — it boots with its own environment. Equally
+# this can never gate a release: by the time it is red, users are already broken.
+# It is a detector and an alarm, not a gate.
+#
+# READ-ONLY BY CONSTRUCTION. `events` is append-only, so a smoke that writes
+# cannot clean up after itself. Every request below is a GET or an
+# unauthenticated POST that is expected to be REJECTED. Nothing is created.
+#
+# Usage: prod-smoke.sh [base-url]
+# Env:
+#   PROD_URL       base URL (default https://app.lobu.ai)
+#   EXPECT_SHA     if set, require this commit to be an ancestor of the
+#                  deployed revision — i.e. "the rollout actually landed"
+#   ROLLOUT_WAIT   seconds to wait for EXPECT_SHA to appear (default 0 = no wait)
+
+set -uo pipefail
+
+BASE="${1:-${PROD_URL:-https://app.lobu.ai}}"
+BASE="${BASE%/}"
+EXPECT_SHA="${EXPECT_SHA:-}"
+ROLLOUT_WAIT="${ROLLOUT_WAIT:-0}"
+
+PASS=0
+FAIL=0
+note() { echo ""; echo "== $* =="; }
+ok()   { echo "  ok   — $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL — $*"; FAIL=$((FAIL + 1)); }
+
+echo "================================================================"
+echo " prod smoke — ${BASE}"
+echo "================================================================"
+
+# ---------------------------------------------------------------------------
+# 1. Liveness + the deployed revision.
+#
+#    /health returns {status, version, revision, build_time, environment};
+#    `revision` is APP_GIT_SHA baked into the image at build time.
+# ---------------------------------------------------------------------------
+note "health"
+health=$(curl -fsS --max-time 15 "${BASE}/health" 2>/dev/null)
+if [ -z "$health" ]; then
+  bad "GET /health returned nothing — prod is down or unreachable"
+  echo ""
+  echo "RESULT: prod smoke FAILED (unreachable)"
+  exit 1
+fi
+
+status=$(printf '%s' "$health" | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
+revision=$(printf '%s' "$health" | sed -n 's/.*"revision":"\([^"]*\)".*/\1/p')
+environment=$(printf '%s' "$health" | sed -n 's/.*"environment":"\([^"]*\)".*/\1/p')
+version=$(printf '%s' "$health" | sed -n 's/.*"version":"\([^"]*\)".*/\1/p')
+
+if [ "$status" = "ok" ]; then
+  ok "/health status=ok"
+else
+  bad "/health status='${status}'"
+fi
+echo "       version=${version} revision=${revision} environment=${environment}"
+
+if [ "$revision" = "unknown" ] || [ -z "$revision" ]; then
+  bad "deployed revision is unknown — APP_GIT_SHA was not baked into the image"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Readiness. Distinct from liveness on purpose: /health is dependency-free
+#    (a DB blip must not CrashLoop the pod), /health/ready proves the pod can
+#    actually reach the database. Only the latter says "serving traffic".
+# ---------------------------------------------------------------------------
+note "readiness"
+ready_code=$(curl -s -o /tmp/prod-smoke-ready.json -w '%{http_code}' --max-time 15 "${BASE}/health/ready")
+if [ "$ready_code" = "200" ]; then
+  ok "/health/ready 200 — pod can reach the database"
+else
+  bad "/health/ready ${ready_code} — $(head -c 200 /tmp/prod-smoke-ready.json 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Rollout gate (opt-in).
+#
+#    Ancestor test, NOT equality: prod may be several commits ahead. Argument
+#    order matters — EXPECT_SHA first, deployed second. Reversed, it accepts a
+#    stale deploy. And EXPECT_SHA must be the SQUASH commit: a squash merge
+#    writes a new commit with no ancestry link to the branch head, so gating on
+#    the branch head exits 1 forever (PR #2280 has identical trees and still
+#    fails).
+# ---------------------------------------------------------------------------
+if [ -n "$EXPECT_SHA" ]; then
+  note "rollout"
+  waited=0
+  landed=false
+  while :; do
+    cur=$(curl -fsS --max-time 15 "${BASE}/health" 2>/dev/null \
+      | sed -n 's/.*"revision":"\([^"]*\)".*/\1/p')
+    if [ -n "$cur" ] && git merge-base --is-ancestor "$EXPECT_SHA" "$cur" 2>/dev/null; then
+      landed=true
+      break
+    fi
+    [ "$waited" -ge "$ROLLOUT_WAIT" ] && break
+    sleep 30
+    waited=$((waited + 30))
+  done
+
+  if [ "$landed" = true ]; then
+    ok "${EXPECT_SHA:0:12} is live (deployed ${cur:0:12})"
+  else
+    bad "${EXPECT_SHA:0:12} is NOT in the deployed revision ${cur:0:12} after ${waited}s"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 4. The web UI and every asset it references.
+#
+#    The SPA shell is served by a catch-all, so `/` returns 200 even when the
+#    built bundle never made it into the image. Parsing the refs out of the
+#    served HTML and demanding each resolve is what actually catches the blank
+#    page users saw in #2183 — here against the real ingress and CDN path.
+# ---------------------------------------------------------------------------
+note "web UI + referenced assets"
+html=$(curl -fsS --max-time 20 "${BASE}/" 2>/dev/null)
+if [ -z "$html" ]; then
+  bad "GET / returned nothing"
+else
+  ok "GET / served HTML ($(printf '%s' "$html" | wc -c | tr -d ' ') bytes)"
+  assets=$(printf '%s' "$html" \
+    | grep -oE '(src|href)="[^"]+\.(js|css|mjs)"' \
+    | sed -E 's/^(src|href)="//; s/"$//' \
+    | sort -u)
+  if [ -z "$assets" ]; then
+    bad "no js/css assets referenced by / — SPA bundle likely missing"
+  else
+    n=0; missing=0
+    for a in $assets; do
+      case "$a" in
+        http*) url="$a" ;;
+        /*)    url="${BASE}${a}" ;;
+        *)     url="${BASE}/${a}" ;;
+      esac
+      code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$url")
+      n=$((n + 1))
+      [ "$code" != "200" ] && { bad "asset ${a} -> HTTP ${code}"; missing=$((missing + 1)); }
+    done
+    [ "$missing" -eq 0 ] && ok "all ${n} referenced assets returned 200"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. MCP is mounted and CHALLENGES. 401/403 is the pass: it proves the handler
+#    is wired AND that it refuses anonymous callers. A 200 here would mean prod
+#    is serving MCP unauthenticated, which is worse than a 404.
+# ---------------------------------------------------------------------------
+note "MCP mount"
+mcp_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
+  -X POST -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  "${BASE}/mcp")
+case "$mcp_code" in
+  401|403) ok "/mcp challenged an anonymous call (HTTP ${mcp_code})" ;;
+  404)     bad "/mcp returned 404 — MCP handler is not mounted" ;;
+  200)     bad "/mcp answered an ANONYMOUS initialize with 200 — auth is not enforced" ;;
+  *)       bad "/mcp unexpected HTTP ${mcp_code}" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 6. OAuth discovery. MCP clients (ChatGPT, Claude Desktop, Cursor) bootstrap
+#    from this document; if it stops resolving, every browser-managed client
+#    silently fails to connect while /mcp itself still looks healthy.
+# ---------------------------------------------------------------------------
+note "OAuth discovery"
+oauth_code=$(curl -s -o /tmp/prod-smoke-oauth.json -w '%{http_code}' --max-time 20 \
+  "${BASE}/.well-known/oauth-authorization-server")
+if [ "$oauth_code" = "200" ] && grep -q "issuer" /tmp/prod-smoke-oauth.json 2>/dev/null; then
+  ok "/.well-known/oauth-authorization-server serves an issuer"
+else
+  bad "/.well-known/oauth-authorization-server -> HTTP ${oauth_code}"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. TLS expiry. A certificate is the one dependency that breaks with no deploy
+#    and no code change, and it takes the whole surface down at once.
+# ---------------------------------------------------------------------------
+note "TLS"
+host="${BASE#https://}"; host="${host%%/*}"
+end=$(echo | openssl s_client -servername "$host" -connect "${host}:443" 2>/dev/null \
+  | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)
+if [ -z "$end" ]; then
+  bad "could not read the TLS certificate for ${host}"
+else
+  end_s=$(date -d "$end" +%s 2>/dev/null || date -j -f "%b %d %T %Y %Z" "$end" +%s 2>/dev/null)
+  if [ -z "$end_s" ]; then
+    ok "certificate expires ${end} (could not parse for comparison)"
+  else
+    days=$(( (end_s - $(date +%s)) / 86400 ))
+    if [ "$days" -lt 10 ]; then
+      bad "TLS certificate expires in ${days} days (${end})"
+    else
+      ok "TLS certificate valid for ${days} more days"
+    fi
+  fi
+fi
+
+echo ""
+echo "  prod smoke: ${PASS} passed, ${FAIL} failed"
+if [ "$FAIL" -ne 0 ]; then
+  echo "RESULT: prod smoke FAILED"
+  exit 1
+fi
+echo "RESULT: prod smoke PASSED"


### PR DESCRIPTION
## The gap

`app.lobu.ai` appeared **nowhere** in `.github/` or `scripts/`. Nothing verified the deployed system.

That is not covered by the other two gates, and cannot be:

| layer | question | can it gate a release? |
|---|---|---|
| `app-image-smoke` | is the image broken? — boots with its **own** env + db | **yes**, this is the gate |
| `published-artifact-smoke` | can users install it? — npm tarball, 4 environments | no (tests the *previous* release) |
| **this** | did the rollout land, does prod work with the **real** Helm config, ingress, TLS, database? | **no** — by then users are broken |

An image smoke can never catch a missing Helm variable, a broken ingress route, an expired certificate, or Flux rolling a tag whose migration failed against real data. It boots with its own environment.

## Checks

| check | catches what nothing else can |
|---|---|
| `/health` + revision | prod down; `APP_GIT_SHA` not baked in |
| `/health/ready` | pod up but **cannot reach the DB** — liveness is deliberately dependency-free, so only this means "serving" |
| rollout ancestry (opt-in) | Flux never rolled, or rolled a different tag |
| UI + every referenced asset | the `#2183` blank-page class, through the **real ingress** |
| `/mcp` challenges | handler unmounted — and a **200 also fails**, since that means anonymous MCP access |
| OAuth discovery | ChatGPT/Claude Desktop/Cursor silently cannot connect while `/mcp` still looks healthy |
| TLS expiry < 10d | the one dependency that breaks with **no deploy at all** |

## Design calls

**Read-only by construction.** `events` is append-only, so a smoke that writes cannot clean up after itself. Every request is a GET or an unauthenticated POST expected to be rejected.

**Alarms, does not gate.** Prod depends on third parties and provider quota — the Z_AI 429 has been intermittently failing turns since 07-29. A release gate keyed on this would block shipping for reasons unrelated to the release. Failures post to the same devops Slack as `build-images`' `notify-failure`.

**Rollout gate is an ancestor test with the squash commit first.** Equality would fail whenever prod is legitimately ahead; reversed arguments would accept a stale deploy; and a squash merge breaks ancestry from the branch head (#2280).

## Evidence

Against live `app.lobu.ai` — **7 passed, 0 failed**. Mutation-tested using a natural experiment from today's merges:

```
EXPECT_SHA = a deployed commit    ->  ok   — 6ed5c185eb5a is live
EXPECT_SHA = an undeployed commit ->  FAIL — not in deployed revision
rollout-miss exit=1 · bad-base exit=1 · unreachable exit=1
```

Re-verified after `make review-fix` edited the script, and re-ran the failure paths — mid-session prod rolled forward, so the original "undeployed" SHA became deployed and correctly returned 0; retested with a genuinely undeployed SHA.

`review-fix` caught a real bug I had missed: `workflow_run` with `types: [completed]` fires on **failed** builds too, which push no image — so the rollout gate would have waited the full `ROLLOUT_WAIT` for a SHA that can never deploy, then paged Slack, duplicating the alarm `notify-failure` already sent. Guarded on `conclusion == 'success'`.

## Not verified

The **workflow wiring** has never fired — `workflow_run` and the `ROLLOUT_WAIT` branch are exercised only by a real rollout. The script itself is fully verified; the trigger plumbing is not.

## Follow-up

No real-provider agent turn exists after deploy (`providers-live.yml` is weekly; the npm smoke uses a mock). Agreed design: gate on prod's `/health.revision` **changing** rather than a timer, plus a 1h floor — one turn per distinct deployment. Blocked on a `LOBU_API_TOKEN` secret and a decision on which org absorbs the permanent `events` rows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated production smoke tests covering service health, deployment status, database readiness, web assets, authentication, OAuth discovery, and TLS certificates.
  * Smoke tests can run after successful image builds, on a recurring schedule, or manually.
  * Added optional notifications for failed production checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->