### PR TITLE
ci(prod-smoke): wait for rollout on manual runs with expect_sha

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -39,6 +39,9 @@ on:
       expect_sha:
         description: Require this commit to be live (ancestor test)
         required: false
+      rollout_wait:
+        description: Seconds to wait for expect_sha to appear (default 600 when expect_sha is set)
+        required: false
 
 permissions:
   contents: read
@@ -74,8 +77,14 @@ jobs:
                 || '' }}
           # Flux polls the registry then rolls the deployment; ~10min covers a
           # normal rollout without turning a genuinely stuck deploy into a
-          # 25-minute job.
-          ROLLOUT_WAIT: ${{ github.event_name == 'workflow_run' && '600' || '0' }}
+          # 25-minute job. Any run that expects a SHA gets that wait, including a
+          # manual spot-check dispatched right after a merge; a manual run with
+          # no expect_sha has nothing to wait for.
+          ROLLOUT_WAIT: >-
+            ${{ inputs.rollout_wait
+                || ((github.event_name == 'workflow_run' || inputs.expect_sha)
+                    && '600')
+                || '0' }}
         run: |
           chmod +x scripts/prod-smoke.sh
           scripts/prod-smoke.sh

--- a/scripts/prod-smoke.sh
+++ b/scripts/prod-smoke.sh
@@ -32,6 +32,14 @@ BASE="${1:-${PROD_URL:-https://app.lobu.ai}}"
 BASE="${BASE%/}"
 EXPECT_SHA="${EXPECT_SHA:-}"
 ROLLOUT_WAIT="${ROLLOUT_WAIT:-0}"
+# ROLLOUT_WAIT feeds `[ ... -ge ... ]` in the rollout loop; a non-integer would
+# make that test error forever and spin until the job timeout instead of failing.
+case "$ROLLOUT_WAIT" in
+  *[!0-9]*)
+    echo "ROLLOUT_WAIT must be a non-negative integer (seconds), got: ${ROLLOUT_WAIT}" >&2
+    exit 1
+    ;;
+esac
 
 PASS=0
 FAIL=0


### PR DESCRIPTION
Follow-up to #2384, which was already merged when this review comment came in.

`EXPECT_SHA` is wired for `workflow_dispatch`, but `ROLLOUT_WAIT` was keyed only on the event name, so a manual spot-check with `expect_sha` set got zero wait: the ancestry gate ran once against a rollout still in flight, failed, and paged Slack. The wait now follows whether a SHA is expected at all, with an optional explicit override:

```yaml
ROLLOUT_WAIT: >-
  ${{ inputs.rollout_wait
      || ((github.event_name == 'workflow_run' || inputs.expect_sha)
          && '600')
      || '0' }}
```

A manual run without `expect_sha` still gets `0`, since the script skips the ancestry gate entirely in that case and has nothing to wait for.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

## Review validation (2026-08-01)

Red (previous expression):
```
manual with expect_sha: before=0
```

Green (settled patch):
```
manual with expect_sha: after=600 expected=600
manual without expect_sha: after=0 expected=0
manual explicit override: after=90 expected=90
successful image workflow: after=600 expected=600
ROLLOUT_WAIT=10m: exit=1, fail-fast validation message
```

`make pre-pr`: clean after `make review-fix`. The fixer added the `ROLLOUT_WAIT` integer guard and the full gate was rerun on the settled two-file diff.