### PR TITLE
refactor(connect): reserve the /connectors/ route segments, bump owletto

### DIFF
--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -27,7 +27,6 @@ export const OWNER_ROUTE_SEGMENTS = [
   "activity",
   "agents",
   "connectors",
-  "devices",
   "memory",
   "members",
   "settings",
@@ -53,6 +52,9 @@ export const REMOVED_OWNER_SEGMENTS = [
   "environments",
   "infrastructure",
   "inference-providers",
+  // Removed 2026-07-31 by the connect-surface merge: the devices page folded
+  // into /connectors (per-device detail lives at /connectors/device/{id}).
+  "devices",
 ] as const;
 
 /**
@@ -153,3 +155,35 @@ export const SANDBOX_ROW_KEY_PREFIX = "sandbox:";
  * runtime registry (`listGatewayRuntimeProviderIds`).
  */
 export const SANDBOX_PROVIDER_KEY_PREFIX = "sandbox-provider:";
+
+/**
+ * Path segments under `/connectors/` that are real routes, not connector keys:
+ * `/connectors/device/{id}`, `/connectors/client/{id}`, `/connectors/app/{id}`,
+ * plus the static `create` flow and `deployments` pages.
+ *
+ * Model providers and sandboxes are namespaced INTO the `$connectorKey` param
+ * with a `prefix:` because they share that one detail route. Devices, clients
+ * and first-party apps get their own static segments instead — readable URLs
+ * with no percent-encoded colon — which means a connector may not claim these
+ * keys: `/connectors/device/42` would resolve to the device route, and the
+ * connection page it was meant to open would be unreachable. Enforced at
+ * install time by `validateConnectorMetadata`.
+ */
+export const CONNECTOR_SUBROUTE_SEGMENTS = [
+  "device",
+  "client",
+  "app",
+  "create",
+  "deployments",
+] as const;
+
+/**
+ * Whether a connector key would be shadowed by a `/connectors/*` subroute.
+ * Compared lowercased: the router matches static segments case-insensitively
+ * (no `caseSensitive` option is set), so `Device` is shadowed like `device`.
+ */
+export function isReservedConnectorKey(key: string): boolean {
+  return (CONNECTOR_SUBROUTE_SEGMENTS as readonly string[]).includes(
+    key.toLowerCase()
+  );
+}

--- a/packages/server/src/utils/__tests__/connector-reserved-key.test.ts
+++ b/packages/server/src/utils/__tests__/connector-reserved-key.test.ts
@@ -1,0 +1,45 @@
+/**
+ * A connector key may not collide with a static `/connectors/` route segment.
+ *
+ * `/connectors/<key>/<connectionId>` is a catch-all param, and TanStack Router
+ * matches a static sibling first — so a connector installed as `device` would
+ * have every connection page it owns swallowed by the device detail route. The
+ * install is rejected at metadata validation, the gate the source-backed
+ * install paths (source_url, source_uri, source_code, bundled catalog) go
+ * through. mcp_url installs skip it, but their keys are always `mcp.`-prefixed
+ * and can never equal a bare route segment.
+ */
+import { describe, expect, test } from 'vitest';
+import { CONNECTOR_SUBROUTE_SEGMENTS } from '@lobu/core';
+import { validateConnectorMetadata } from '../connector-compiler';
+
+const base = { name: 'Anything', version: '1.0.0' };
+
+describe('validateConnectorMetadata reserved keys', () => {
+  test.each(CONNECTOR_SUBROUTE_SEGMENTS)('rejects %s', (key) => {
+    expect(() => validateConnectorMetadata({ ...base, key })).toThrow(/reserved/);
+  });
+
+  // The guard must cover every segment the router actually declares, not a
+  // hand-copied subset: a new `/connectors/<segment>/$id` route added without
+  // touching the reserved list is exactly the case that would slip through.
+  test('covers every declared subroute segment', () => {
+    expect([...CONNECTOR_SUBROUTE_SEGMENTS].sort()).toEqual([
+      'app',
+      'client',
+      'create',
+      'deployments',
+      'device',
+    ]);
+  });
+
+  // The router matches static segments case-insensitively, so casing must not
+  // sneak a reserved key past the guard.
+  test('rejects a reserved key regardless of case', () => {
+    expect(() => validateConnectorMetadata({ ...base, key: 'Device' })).toThrow(/reserved/);
+  });
+
+  test('accepts an ordinary key', () => {
+    expect(() => validateConnectorMetadata({ ...base, key: 'slack' })).not.toThrow();
+  });
+});

--- a/packages/server/src/utils/connector-compiler.ts
+++ b/packages/server/src/utils/connector-compiler.ts
@@ -8,6 +8,7 @@
 import { EXTERNAL_RUNTIME_DEPS } from '@lobu/connector-worker/compile';
 import type { ConnectorAgentTooling } from '@lobu/connector-sdk';
 import { type CompileResult, compileSource, extractMetadata } from './compiler-core';
+import { isReservedConnectorKey } from './reserved';
 
 export interface ConnectorMetadata {
   key: string;
@@ -175,5 +176,15 @@ export async function extractConnectorMetadata(compiledCode: string): Promise<Co
 export function validateConnectorMetadata(metadata: ConnectorMetadata): void {
   if (!metadata.key || !metadata.name || !metadata.version) {
     throw new Error('Connector must have key, name, and version.');
+  }
+  // The web app routes `/connectors/<key>/<connectionId>` against a catch-all
+  // param, and static sibling segments (CONNECTOR_SUBROUTE_SEGMENTS) win the
+  // match. A connector installed under one of those names would have every
+  // connection page it owns shadowed by an unrelated route — reject the
+  // install rather than ship a connector whose pages are unreachable.
+  if (isReservedConnectorKey(metadata.key)) {
+    throw new Error(
+      `Connector key '${metadata.key}' is reserved by a /connectors/ route. Pick another key.`
+    );
   }
 }

--- a/packages/server/src/utils/reserved.ts
+++ b/packages/server/src/utils/reserved.ts
@@ -3,6 +3,7 @@
  * Canonical definitions live in `@lobu/core`.
  */
 export {
+  isReservedConnectorKey,
   isReservedEntityTypeSlug,
   RESERVED_ENTITY_TYPE_SLUGS,
   RESERVED_PATHS_SET,


### PR DESCRIPTION
## What

Bumps the owletto pointer to lobu-ai/owletto#663 (the connectors-surface merge) and reserves the route segments that PR introduced.

The web app routes `/connectors/device/{id}`, `/connectors/client/{id}` and `/connectors/app/{id}` as static segments beside the `$connectorKey` catch-all. TanStack Router matches a static sibling first, so a connector installed under one of those keys — or `create` / `deployments`, which were already there — would have every connection page it owns (`/connectors/<key>/<connectionId>`) silently swallowed by an unrelated detail route.

Rejected at `validateConnectorMetadata`, the one gate every source-backed install path shares (source_url, source_uri, source_code, bundled catalog). `mcp_url` installs skip that gate, but their keys are always `mcp.`-prefixed and can never equal a bare segment. Compared lowercased — the router sets no `caseSensitive` option, so `Device` is shadowed exactly like `device`.

`devices` moves from `OWNER_ROUTE_SEGMENTS` to `REMOVED_OWNER_SEGMENTS`: the standalone page is gone, folded into `/connectors`. Behaviour-neutral — every consumer (core's two spreads, owletto's `RESERVED_OWNER_SEGMENTS_SET`) reads the union of both lists.

## Why a guard rather than a comment

The previous round of this work left `CONNECTOR_SUBROUTE_SEGMENTS` exported and unread — a documented reservation nothing enforced. It was also a hand-copied subset: two of the five real static siblings were missing. The test asserts the constant equals what the router actually declares, so the next `/connectors/<segment>/$id` route added without touching the list fails here rather than in production.

## Verified

```
$ bun test ./packages/server/src/utils/__tests__/connector-reserved-key.test.ts ./packages/core/src/__tests__/reserved.test.ts
 12 pass
 0 fail
```

Mutation check: with the guard removed, the three reject cases fail; with the segment list back at three entries, the coverage case fails.

`make pre-pr` clean (build, strict typecheck, knip, biome, naming, gateway-LLM gates). No bundled connector uses a reserved key.

## Screens

The UI this pointer bump ships: [screenshot tour](https://claude.ai/code/artifact/015b124a-e4ee-49ea-8c56-f04373c11638).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented connector metadata keys from conflicting with reserved connector routes.
  - Added case-insensitive validation with clearer installation errors.
  - Updated the legacy `devices` route reservation to reflect its replacement route.

- **Tests**
  - Added coverage for reserved connector keys, route coverage, case variations, and valid ordinary keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->