### PR TITLE
feat(server): org-scope the classification engine and expose it as manage_classifiers apply

### DIFF
--- a/packages/core/src/contracts/tools/manage-classifiers.ts
+++ b/packages/core/src/contracts/tools/manage-classifiers.ts
@@ -22,6 +22,10 @@ export const ManageClassifiersSchema = Type.Object({
       Type.Literal("classify", {
         description: "Manual single/batch classification.",
       }),
+      Type.Literal("apply", {
+        description:
+          "Run a classifier over specific content ids (embedding match, no LLM). Re-running re-labels: it replaces prior embedding results and never touches manual/LLM ones. Use after editing a classifier — run generate_embeddings first.",
+      }),
     ],
     { description: "Action to perform" }
   ),
@@ -133,10 +137,18 @@ export const ManageClassifiersSchema = Type.Object({
       }
     )
   ),
+  content_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      minItems: 1,
+      maxItems: 2000,
+      description:
+        "[apply] Content ids to classify. Get them with a read-only SQL query first, then pass them here. Ids outside your organization, or without an embedding, are skipped and reported — never silently dropped.",
+    })
+  ),
   classifier_slug: Type.Optional(
     Type.String({
       description:
-        '[classify] Classifier slug (e.g., "sentiment", "bug-severity")',
+        '[classify/apply] Classifier slug (e.g., "sentiment", "bug-severity")',
     })
   ),
   value: Type.Optional(

--- a/packages/server/src/__tests__/integration/classifiers/classification-execute-query.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classification-execute-query.test.ts
@@ -82,6 +82,7 @@ describe('executeClassificationQuery (full embedding pipeline)', () => {
 
     const results = await executeClassificationQuery({
       mode: 'content_ids',
+      organizationId: org.id,
       enabledClassifiers: ['cq-sentiment'],
       content_ids: [Number(event.id)],
     });
@@ -132,6 +133,7 @@ describe('executeClassificationQuery (full embedding pipeline)', () => {
 
     const results = await executeClassificationQuery({
       mode: 'content_ids',
+      organizationId: org.id,
       enabledClassifiers: ['cq-fallback'],
       content_ids: [Number(event.id)],
     });
@@ -147,5 +149,91 @@ describe('executeClassificationQuery (full embedding pipeline)', () => {
     expect(rows[0].met).toBe('false');
     expect(rows[0].best_match_attribute).toBe('positive'); // closest, even if below threshold
     expect(rows[0].vals).toBe('{unknown}'); // fallback_value
+  });
+
+  // Org isolation. `content_ids` mode selected purely on `f.id IN (...)`, so a caller
+  // could classify another organization's events just by naming their ids. Unreachable
+  // while the reconciliation cron (which derives ids from one org's own entity) was the
+  // only caller; reachable as soon as an agent-facing action passes ids directly.
+  it('refuses to classify an event belonging to another organization', async () => {
+    await cleanupTestDatabase();
+    const callerOrg = await createTestOrganization({ name: 'CQ Caller Org' });
+    const victimOrg = await createTestOrganization({ name: 'CQ Victim Org' });
+    const user = await createTestUser({ email: 'cq-iso@test.com' });
+
+    const facetId = await seedFacet({
+      orgId: callerOrg.id,
+      createdBy: user.id,
+      slug: 'cq-isolation',
+      positiveSlot: 0,
+      negativeSlot: 1,
+      minSimilarity: 0.5,
+      fallbackValue: null,
+    });
+
+    // Would match `positive` at cosine 1.0 if it were ever reached.
+    const victimEvent = await createTestEvent({
+      organization_id: victimOrg.id,
+      content: 'excellent and amazing',
+      embedding: basisVector(0),
+    });
+
+    const results = await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: callerOrg.id,
+      enabledClassifiers: ['cq-isolation'],
+      content_ids: [Number(victimEvent.id)],
+    });
+
+    expect(results).toEqual([]);
+
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT 1 FROM event_classifications
+      WHERE event_id = ${Number(victimEvent.id)} AND classifier_id = ${facetId}
+    `) as Array<unknown>;
+    expect(rows).toHaveLength(0);
+  });
+
+  // Classifier-template isolation: same slug in two orgs must not cross over. The
+  // template lookup matched on slug alone, so the caller could match against another
+  // org's attribute definitions.
+  it('does not match against another organization’s classifier of the same slug', async () => {
+    await cleanupTestDatabase();
+    const callerOrg = await createTestOrganization({ name: 'CQ Slug Caller' });
+    const otherOrg = await createTestOrganization({ name: 'CQ Slug Other' });
+    const user = await createTestUser({ email: 'cq-slug@test.com' });
+
+    // Only the OTHER org defines this slug. The caller org has no such classifier.
+    await seedFacet({
+      orgId: otherOrg.id,
+      createdBy: user.id,
+      slug: 'cq-shared-slug',
+      positiveSlot: 0,
+      negativeSlot: 1,
+      minSimilarity: 0.5,
+      fallbackValue: null,
+    });
+
+    const callerEvent = await createTestEvent({
+      organization_id: callerOrg.id,
+      content: 'excellent and amazing',
+      embedding: basisVector(0),
+    });
+
+    const results = await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: callerOrg.id,
+      enabledClassifiers: ['cq-shared-slug'],
+      content_ids: [Number(callerEvent.id)],
+    });
+
+    expect(results).toEqual([]);
+
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT 1 FROM event_classifications WHERE event_id = ${Number(callerEvent.id)}
+    `) as Array<unknown>;
+    expect(rows).toHaveLength(0);
   });
 });

--- a/packages/server/src/__tests__/integration/classifiers/classifiers-apply-skip-reasons.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifiers-apply-skip-reasons.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Pins `manage_classifiers apply`'s skip-reason bookkeeping against a fixture
+ * that puts every reason in ONE call.
+ *
+ * Why this file exists: the value of `apply` is not the classified count — the
+ * engine already produced that. It is that an id which did NOT get classified
+ * comes back with a reason that is TRUE. That reason is computed by a precheck
+ * that duplicates the engine's target selection, and a duplicate drifts. Three
+ * separate rounds of review on this PR each found a different drift, all with
+ * the same shape: a real condition reported under the wrong name, which sends
+ * the reader after a bug that does not exist.
+ *   1. precheck ignored `embedding_model` → a stale-model vector counted as
+ *      embedded, and its (absent) score was blamed on `below_threshold`.
+ *   2. precheck omitted `watcher_id IS NULL` → a Behavior-owned classifier of
+ *      the same slug counted as "found", and its zero results likewise.
+ *   3. precheck read `events` while the engine reads `current_event_records` →
+ *      a superseded event counted as reachable, same false blame.
+ *   4. (found by writing this file) fixing 3 by selecting THROUGH the view made
+ *      a superseded event indistinguishable from a foreign one, so it was
+ *      reported as `not_in_organization` — a tenancy accusation about the org's
+ *      own event.
+ *
+ * Nothing about the classified/skipped split changes under any of those, which
+ * is exactly why they survived: only an assertion on the REASON catches them.
+ * Each event below is engineered to sit in exactly one bucket, so a precheck
+ * that collapses two conditions moves an id between buckets and fails here.
+ *
+ * Real pgvector, real engine, no mocks. 768-dim one-hot basis vectors, so cosine
+ * is exact: identical basis → 1.0, orthogonal → 0.0.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { manageClassifiers } from '../../../tools/admin/manage_classifiers';
+import type { ToolContext } from '../../../tools/registry';
+import { getConfiguredEmbeddingModel } from '../../../utils/embeddings';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestAgent,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const DIM = 768;
+
+/** One-hot 768-dim unit vector (1 at `slot`, 0 elsewhere). */
+function basisVector(slot: number): number[] {
+  const v = new Array<number>(DIM).fill(0);
+  v[slot] = 1;
+  return v;
+}
+
+interface ApplyData {
+  requested: number;
+  classified: number;
+  skipped: Record<string, number>;
+  sample_skipped: Array<{ id: number; reason: string }>;
+}
+
+describe('manage_classifiers apply — skip reasons', () => {
+  it('reports every id under the one reason that is actually true', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Apply Reasons Org' });
+    const other = await createTestOrganization({ name: 'Apply Reasons Other Org' });
+    const user = await createTestUser({ email: 'apply-reasons@test.com' });
+
+    // positive == basis 0, negative == basis 1, threshold 0.5, NO fallback — so
+    // an event on basis 7 is orthogonal to both and genuinely scores below.
+    const attributeValues = {
+      positive: { embedding: basisVector(0) },
+      negative: { embedding: basisVector(1) },
+    };
+    // Seeded in the CALLER's org only. The other org deliberately has no
+    // classifier: its event must be excluded by the org filter, not by failing
+    // to find a template. (It could not have one anyway — `classify_facet`'s
+    // unique constraint is (entity_id, watcher_id, slug) with no organization_id,
+    // so a global slug is first-come-first-served across all tenants.)
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO classify_facet (
+        organization_id, slug, name, attribute_key, status, created_by,
+        watcher_id, entity_ids, min_similarity, fallback_value, attribute_values
+      ) VALUES (
+        ${org.id}, 'apply-reasons', 'apply reasons classifier', 'apply-reasons', 'active', ${user.id},
+        NULL, NULL, 0.5, NULL, ${JSON.stringify(attributeValues)}::jsonb
+      )
+    `;
+
+    // One event per bucket. Every one of these WOULD classify if the condition
+    // under test were not present — that is what makes the reason load-bearing.
+    const classifiable = await createTestEvent({
+      organization_id: org.id,
+      content: 'in org, live, embedded with the configured model',
+      embedding: basisVector(0),
+    });
+    const orthogonal = await createTestEvent({
+      organization_id: org.id,
+      content: 'in org, live, embedded, but similar to neither attribute',
+      embedding: basisVector(7),
+    });
+    const unembedded = await createTestEvent({
+      organization_id: org.id,
+      content: 'in org, live, never embedded',
+    });
+    const staleModel = await createTestEvent({
+      organization_id: org.id,
+      content: 'in org, live, embedded under a model the engine no longer reads',
+      // A REAL vector, deliberately stamped with the wrong model — that is the
+      // whole point of this row. `event_embeddings.embedding_model` is NOT NULL,
+      // so a stale stamp is the only way a vector can exist and still be
+      // invisible to the engine, which is the production case (model rotated,
+      // backfill not yet run). Drop the `embedding` line and this row silently
+      // degrades into a duplicate of `unembedded`.
+      embedding: basisVector(0),
+      embedding_model: 'legacy-embedding-model-v0',
+    });
+    const superseded = await createTestEvent({
+      organization_id: org.id,
+      content: 'in org, embedded, would match — but a newer revision replaced it',
+      embedding: basisVector(0),
+    });
+    const foreign = await createTestEvent({
+      organization_id: other.id,
+      content: 'another org, live, embedded, would match',
+      embedding: basisVector(0),
+    });
+    const unknownId = 999_999_999;
+
+    // Supersede as production does: the newer row claims the older, and the
+    // older carries the denormalized back-edge that the view filters on.
+    const replacement = await createTestEvent({
+      organization_id: org.id,
+      content: 'the newer revision',
+      embedding: basisVector(0),
+    });
+    await sql`UPDATE events SET supersedes_event_id = ${superseded.id} WHERE id = ${replacement.id}`;
+    await sql`UPDATE events SET superseded_by = ${replacement.id} WHERE id = ${superseded.id}`;
+
+    // Fixture guard: `staleModel` must actually HAVE a vector, or it collapses
+    // into `unembedded` and the not_embedded count still reads 2 for the wrong
+    // reason. This exact collapse happened once while writing this file.
+    const staleRows = (await sql`
+      SELECT embedding_model FROM event_embeddings
+      WHERE event_id = ${staleModel.id} AND chunk_index = 0
+    `) as unknown as Array<{ embedding_model: string }>;
+    expect(staleRows.map((r) => r.embedding_model)).toEqual(['legacy-embedding-model-v0']);
+
+    const ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      // `apply` is owner-admin tier, so the role AND the MCP scope both have to
+      // clear — reaching the handler at all is part of what this pins.
+      scopes: ['mcp:admin'],
+    } as ToolContext;
+
+    const requested = [
+      Number(classifiable.id),
+      Number(orthogonal.id),
+      Number(unembedded.id),
+      Number(staleModel.id),
+      Number(superseded.id),
+      Number(foreign.id),
+      unknownId,
+    ];
+
+    const result = await manageClassifiers(
+      { action: 'apply', classifier_slug: 'apply-reasons', content_ids: requested } as never,
+      {} as never,
+      ctx
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as ApplyData;
+
+    expect(data.requested).toBe(7);
+    expect(data.classified).toBe(1);
+    expect(data.skipped).toEqual({
+      not_embedded: 2, // never embedded + stale model stamp
+      not_in_organization: 2, // another org's event + an id that does not exist
+      superseded: 1,
+      below_threshold: 1,
+    });
+
+    // Counts alone would survive two ids swapping buckets, so pin the exact
+    // id→reason pairing. This is the assertion the four drifts would have failed.
+    expect(
+      [...data.sample_skipped]
+        .map((s) => ({ id: Number(s.id), reason: s.reason }))
+        .sort((a, b) => a.id - b.id)
+    ).toEqual(
+      [
+        { id: Number(orthogonal.id), reason: 'below_threshold' },
+        { id: Number(unembedded.id), reason: 'not_embedded' },
+        { id: Number(staleModel.id), reason: 'not_embedded' },
+        { id: Number(superseded.id), reason: 'superseded' },
+        { id: Number(foreign.id), reason: 'not_in_organization' },
+        { id: unknownId, reason: 'not_in_organization' },
+      ].sort((a, b) => a.id - b.id)
+    );
+
+    // The reasons must describe what the engine actually did: only the one
+    // classifiable event has a row, and the foreign event was never touched.
+    const written = (await sql`
+      SELECT event_id FROM event_classifications ORDER BY event_id
+    `) as unknown as Array<{ event_id: number }>;
+    expect(written.map((r) => Number(r.event_id))).toEqual([Number(classifiable.id)]);
+  });
+
+  it('does not count a Behavior-owned classifier of the same slug as the one to apply', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Apply Behavior-Owned Org' });
+    const user = await createTestUser({ email: 'apply-behavior@test.com' });
+    const sql = getTestDb();
+
+    // Only a Behavior-scoped classifier carries this slug. The engine ignores it
+    // (it selects `watcher_id IS NULL`), so `apply` must fail loudly rather than
+    // report a successful run that classified nothing.
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const [behavior] = (await sql`
+      INSERT INTO watchers (organization_id, agent_id, watcher_group_id, name, created_by, status)
+      VALUES (${org.id}, ${agent.agentId}, 0, 'owning behavior', ${user.id}, 'active')
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    await sql`
+      INSERT INTO classify_facet (
+        organization_id, slug, name, attribute_key, status, created_by,
+        watcher_id, entity_ids, min_similarity, fallback_value, attribute_values
+      ) VALUES (
+        ${org.id}, 'behavior-owned', 'behavior owned', 'behavior-owned', 'active', ${user.id},
+        ${behavior.id}, NULL, 0.5, NULL,
+        ${JSON.stringify({ positive: { embedding: basisVector(0) } })}::jsonb
+      )
+    `;
+
+    const event = await createTestEvent({
+      organization_id: org.id,
+      content: 'would match the behavior-owned classifier exactly',
+      embedding: basisVector(0),
+    });
+
+    const result = await manageClassifiers(
+      {
+        action: 'apply',
+        classifier_slug: 'behavior-owned',
+        content_ids: [Number(event.id)],
+      } as never,
+      {} as never,
+      {
+        organizationId: org.id,
+        userId: user.id,
+        memberRole: 'owner',
+        isAuthenticated: true,
+        tokenType: 'oauth',
+        scopedToOrg: false,
+        scopes: ['mcp:admin'],
+      } as ToolContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('behavior-owned');
+  });
+
+  it('stamps the configured embedding model on fixtures, so the stale-model bucket means what it says', async () => {
+    // Guards the fixture itself: if createTestEvent stopped stamping the
+    // configured model, EVERY event would land in not_embedded and the first
+    // test would still pass its `not_embedded: 2` assertion for the wrong reason.
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Apply Fixture Guard Org' });
+    const event = await createTestEvent({
+      organization_id: org.id,
+      content: 'stamped',
+      embedding: basisVector(0),
+    });
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT embedding_model FROM event_embeddings
+      WHERE event_id = ${event.id} AND chunk_index = 0
+    `) as unknown as Array<{ embedding_model: string | null }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].embedding_model).toBe(getConfiguredEmbeddingModel());
+  });
+});

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -723,7 +723,7 @@ manage_schedules: create=admin list=admin update=admin pause=admin cancel=admin 
 manage_behaviors: create=admin list=read+public update=admin create_version=admin complete_window=write trigger=admin delete=admin set_reaction_script=admin get_versions=read+public get_version_details=read+public get_component_reference=read+public submit_feedback=admin get_feedback=read+public list_promoted=read create_from_version=admin ?=read
 get_behavior: read+public ?=read+public
 read_knowledge: read+public ?=read+public
-manage_classifiers: create=admin list=read+public generate_embeddings=admin delete=admin classify=admin ?=read
+manage_classifiers: create=admin list=read+public generate_embeddings=admin delete=admin classify=admin apply=admin ?=read
 manage_view_templates: set=admin get=read+public rollback=admin remove_tab=admin clear=admin ?=read
 list_organizations: read ?=read
 list_metrics: read ?=read

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -44,6 +44,11 @@ describe('requiresOwnerAdmin', () => {
   it('should require admin for manage_classifiers mutating actions', () => {
     expect(requiresOwnerAdmin('manage_classifiers', { action: 'create' }, false)).toBe(true);
     expect(requiresOwnerAdmin('manage_classifiers', { action: 'classify' }, false)).toBe(true);
+    // `apply` writes event_classifications in bulk. The pinned access-matrix
+    // fixture would also catch a regression, but it is a snapshot — this states
+    // the requirement directly, and names the tier a reader should expect.
+    expect(requiresOwnerAdmin('manage_classifiers', { action: 'apply' }, false)).toBe(true);
+    expect(isPublicReadable('manage_classifiers', { action: 'apply' })).toBe(false);
   });
 
   it('should require admin for manage_operations execute; approve/reject are write-tier (handler enforces admin-or-run-owner)', () => {

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -141,6 +141,9 @@ export const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
 		"generate_embeddings",
 		"delete",
 		"classify",
+		// `apply` persists rows into event_classifications for arbitrary
+		// caller-supplied content ids — a mutation, same tier as `classify`.
+		"apply",
 	]),
 	manage_view_templates: new Set(["set", "rollback", "remove_tab", "clear"]),
 };

--- a/packages/server/src/scheduled/classification-reconciliation.ts
+++ b/packages/server/src/scheduled/classification-reconciliation.ts
@@ -55,6 +55,7 @@ async function getEnabledClassifiers(entityId: string | number): Promise<string[
 
 interface EntityRow {
   entity_id: number;
+  organization_id: string;
 }
 
 export async function runClassificationReconciliation(_env: Env): Promise<{
@@ -72,7 +73,7 @@ export async function runClassificationReconciliation(_env: Env): Promise<{
     // purpose: the inline path covers them, and a query that walked
     // inheritance would defeat the GIN partial index on enabled_classifiers.
     const entities = await sql<EntityRow>`
-      SELECT DISTINCT ent.id AS entity_id
+      SELECT DISTINCT ent.id AS entity_id, ent.organization_id
       FROM entities ent
       WHERE ent.enabled_classifiers IS NOT NULL
         AND cardinality(ent.enabled_classifiers) > 0
@@ -162,6 +163,7 @@ export async function runClassificationReconciliation(_env: Env): Promise<{
         try {
           const results = await executeClassificationQuery({
             mode: 'entity',
+            organizationId: entity.organization_id,
             entity_id: entityId,
             enabledClassifiers,
           });

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -557,6 +557,19 @@ async function handleClassify(
  * dropped by a WHERE clause — reporting the count is what keeps that from
  * looking like a successful no-op.
  */
+/**
+ * Why an id the caller asked for produced no classification. These are the
+ * engine's own target-selection conjuncts, in the order it applies them.
+ */
+type SkipReason = 'not_in_organization' | 'superseded' | 'not_embedded' | 'below_threshold';
+
+const SKIP_REASON_TEXT: Record<SkipReason, string> = {
+  not_in_organization: 'not in this organization',
+  superseded: 'superseded',
+  not_embedded: 'not embedded',
+  below_threshold: 'below min_similarity',
+};
+
 async function runApply(
   args: ManageClassifiersArgs,
   ctx: ToolContext
@@ -596,33 +609,42 @@ async function runApply(
   // Partition the request BEFORE classifying so each skip has a real reason
   // rather than being inferred from a missing result.
   //
-  // Every clause here mirrors the engine's target selection, because the whole
-  // value of this action is that a skip reason is TRUE. Three ways it can drift,
-  // each of which silently reports the wrong reason:
-  //   - relation: the engine reads `current_event_records`, so a superseded
-  //     event is invisible to it. Reading `events` here would call that event
-  //     reachable and then blame `below_threshold`.
+  // The engine's target set is (in this org) AND (live) AND (has a representative
+  // vector). Each of those three is evaluated SEPARATELY here, because the value
+  // of this action is not just the classified/skipped split — it is that the
+  // stated reason is TRUE. Collapsing any two of them reports a real condition
+  // under a false name:
+  //   - live: read from `events` and derive liveness from `superseded_by`, NOT
+  //     from `current_event_records`. The view is the right relation for the
+  //     ENGINE, but selecting through it here makes a superseded event
+  //     indistinguishable from a foreign one, and it gets reported as
+  //     `not_in_organization` — sending the reader after a tenancy bug that does
+  //     not exist. Reading the base table without the liveness split is the
+  //     opposite error: the event looks reachable and gets blamed on
+  //     `below_threshold`.
   //   - chunk/model: the engine joins the representative vector (chunk 0 AND the
   //     configured model), so a stale-model vector is not an embedding to it.
+  //     Ignoring the model stamp reports `below_threshold` for a row that the
+  //     engine never scored at all.
   //   - organization: the engine is org-scoped, as is this.
-  const reachable = (await sql`
+  const inOrg = (await sql`
     SELECT e.id,
+           (e.superseded_by IS NULL) AS is_live,
            EXISTS (
              SELECT 1 FROM event_embeddings emb
              WHERE emb.event_id = e.id
                AND emb.chunk_index = 0
                AND emb.embedding_model = ${getConfiguredEmbeddingModel()}
            ) AS has_embedding
-    FROM current_event_records e
+    FROM events e
     WHERE e.organization_id = ${ctx.organizationId}
       AND e.id = ANY(${pgBigintArray(requestedIds)}::bigint[])
-  `) as unknown as Array<{ id: number; has_embedding: boolean }>;
+  `) as unknown as Array<{ id: number; is_live: boolean; has_embedding: boolean }>;
 
-  const reachableIds = new Set(reachable.map((r) => Number(r.id)));
-  const embeddedIds = reachable.filter((r) => r.has_embedding).map((r) => Number(r.id));
-
-  const skippedNotInOrg = requestedIds.filter((id) => !reachableIds.has(id));
-  const skippedNoEmbedding = reachable.filter((r) => !r.has_embedding).map((r) => Number(r.id));
+  const byId = new Map(inOrg.map((r) => [Number(r.id), r]));
+  const embeddedIds = inOrg
+    .filter((r) => r.is_live && r.has_embedding)
+    .map((r) => Number(r.id));
 
   let classifiedIds: number[] = [];
   if (embeddedIds.length > 0) {
@@ -634,34 +656,50 @@ async function runApply(
     });
     classifiedIds = [...new Set(results.map((r) => Number(r.content_id)))];
   }
+  const classified = new Set(classifiedIds);
 
-  // Embedded, in-org, and still unclassified means every attribute value scored
-  // below the classifier's min_similarity and no fallback_value is set.
-  const classifiedSet = new Set(classifiedIds);
-  const skippedBelowThreshold = embeddedIds.filter((id) => !classifiedSet.has(id));
+  // One pass, in the engine's own conjunct order, so an id can only ever carry
+  // the FIRST condition it actually fails. Counts and samples are derived from
+  // this single list rather than from parallel filters, so they cannot disagree.
+  const skipped: Array<{ id: number; reason: SkipReason }> = [];
+  for (const id of requestedIds) {
+    const row = byId.get(id);
+    // An id this org cannot see is indistinguishable from one that never
+    // existed, and both are equally "not yours to classify".
+    if (!row) skipped.push({ id, reason: 'not_in_organization' });
+    else if (!row.is_live) skipped.push({ id, reason: 'superseded' });
+    else if (!row.has_embedding) skipped.push({ id, reason: 'not_embedded' });
+    // In-org, live, embedded and still unclassified means every attribute value
+    // scored below min_similarity and no fallback_value is set.
+    else if (!classified.has(id)) skipped.push({ id, reason: 'below_threshold' });
+  }
+
+  const counts: Record<SkipReason, number> = {
+    not_in_organization: 0,
+    superseded: 0,
+    not_embedded: 0,
+    below_threshold: 0,
+  };
+  for (const s of skipped) counts[s.reason]++;
+
+  const detail = (Object.entries(counts) as Array<[SkipReason, number]>)
+    .filter(([, n]) => n > 0)
+    .map(([reason, n]) => `${n} ${SKIP_REASON_TEXT[reason]}`);
 
   return {
     success: true,
     action: 'apply',
     message:
       `Classified ${classifiedIds.length}/${requestedIds.length} with "${args.classifier_slug}"` +
-      (skippedNoEmbedding.length > 0 ? `; ${skippedNoEmbedding.length} not embedded` : '') +
-      (skippedNotInOrg.length > 0 ? `; ${skippedNotInOrg.length} not in this organization` : '') +
-      (skippedBelowThreshold.length > 0
-        ? `; ${skippedBelowThreshold.length} below min_similarity`
-        : ''),
+      (detail.length > 0 ? `; ${detail.join('; ')}` : ''),
     data: {
       requested: requestedIds.length,
       classified: classifiedIds.length,
-      skipped: {
-        not_embedded: skippedNoEmbedding.length,
-        not_in_organization: skippedNotInOrg.length,
-        below_threshold: skippedBelowThreshold.length,
-      },
-      // Bounded samples: enough to debug a bad classifier without returning
-      // thousands of ids into the agent's context.
-      sample_skipped_not_embedded: skippedNoEmbedding.slice(0, 20),
-      sample_skipped_below_threshold: skippedBelowThreshold.slice(0, 20),
+      skipped: counts,
+      // Bounded sample: enough to go look at the actual events behind a
+      // disappointing run, without returning thousands of ids into the agent's
+      // context. Truncation is visible from `skipped` vs this length.
+      sample_skipped: skipped.slice(0, 20),
     },
   };
 }

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -28,6 +28,7 @@ import type { Env } from '../../index';
 import { executeClassificationQuery } from '../../utils/classification-query';
 import {
   generateEmbeddings as generateEmbeddingsViaService,
+  getConfiguredEmbeddingModel,
   isValidEmbedding,
 } from '../../utils/embeddings';
 import logger from '../../utils/logger';
@@ -556,7 +557,7 @@ async function handleClassify(
  * dropped by a WHERE clause — reporting the count is what keeps that from
  * looking like a successful no-op.
  */
-async function handleApply(
+async function runApply(
   args: ManageClassifiersArgs,
   ctx: ToolContext
 ): Promise<ManageClassifiersResult> {
@@ -572,11 +573,15 @@ async function handleApply(
   // Dedupe so the counts below describe distinct events, not request repeats.
   const requestedIds = [...new Set(args.content_ids)];
 
+  // Mirrors the engine's classifier-template lookup exactly (org + active +
+  // watcher_id IS NULL). Diverging here would report a watcher-owned classifier
+  // as "found" and then blame its zero results on min_similarity.
   const classifierRows = (await sql`
     SELECT cf.id AS classifier_id
     FROM classify_facet cf
     WHERE cf.slug = ${args.classifier_slug}
       AND cf.status = 'active'
+      AND cf.watcher_id IS NULL
       AND cf.organization_id = ${ctx.organizationId}
   `) as unknown as Array<{ classifier_id: number }>;
 
@@ -590,11 +595,16 @@ async function handleApply(
 
   // Partition the request BEFORE classifying so each skip has a real reason
   // rather than being inferred from a missing result.
+  // `has_embedding` has to match the engine's representative-vector join
+  // (chunk 0 AND the configured model), or an event whose only chunk-0 vector is
+  // from a stale model reads as embedded and gets the wrong skip reason.
   const reachable = (await sql`
     SELECT e.id,
            EXISTS (
              SELECT 1 FROM event_embeddings emb
-             WHERE emb.event_id = e.id AND emb.chunk_index = 0
+             WHERE emb.event_id = e.id
+               AND emb.chunk_index = 0
+               AND emb.embedding_model = ${getConfiguredEmbeddingModel()}
            ) AS has_embedding
     FROM events e
     WHERE e.organization_id = ${ctx.organizationId}
@@ -647,6 +657,30 @@ async function handleApply(
       sample_skipped_below_threshold: skippedBelowThreshold.slice(0, 20),
     },
   };
+}
+
+/**
+ * Same failure contract as `classify`: a thrown DB/engine error comes back as a
+ * `manage_classifiers` result with `success: false`, not a raw exception out of
+ * `routeAction`.
+ */
+async function handleApply(
+  args: ManageClassifiersArgs,
+  ctx: ToolContext
+): Promise<ManageClassifiersResult> {
+  try {
+    return await runApply(args, ctx);
+  } catch (error) {
+    logger.error(
+      { error, classifier_slug: args.classifier_slug, requested: args.content_ids?.length ?? 0 },
+      'Failed to apply classifier over content ids'
+    );
+    return {
+      success: false,
+      action: 'apply',
+      message: error instanceof Error ? error.message : 'Failed to apply classifier',
+    };
+  }
 }
 
 async function updateSingleClassification(

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -546,18 +546,6 @@ async function handleClassify(
 }
 
 /**
- * Run a classifier's embedding match over caller-supplied content ids.
- *
- * This is the agent-facing entry to the same engine the reconciliation cron
- * uses; the cron only ever reaches it in `entity` mode, so org-scoped feeds
- * (events with no entity link) had no way to be classified at all.
- *
- * Every id that does not produce a classification is reported with a reason.
- * The engine filters on `fe.embedding IS NOT NULL`, so an unembedded event is
- * dropped by a WHERE clause — reporting the count is what keeps that from
- * looking like a successful no-op.
- */
-/**
  * Why an id the caller asked for produced no classification. These are the
  * engine's own target-selection conjuncts, in the order it applies them.
  */
@@ -570,6 +558,18 @@ const SKIP_REASON_TEXT: Record<SkipReason, string> = {
   below_threshold: 'below min_similarity',
 };
 
+/**
+ * Run a classifier's embedding match over caller-supplied content ids.
+ *
+ * This is the agent-facing entry to the same engine the reconciliation cron
+ * uses; the cron only ever reaches it in `entity` mode, so org-scoped feeds
+ * (events with no entity link) had no way to be classified at all.
+ *
+ * Every id that does not produce a classification is reported with a reason.
+ * The engine filters on `fe.embedding IS NOT NULL`, so an unembedded event is
+ * dropped by a WHERE clause — reporting the count is what keeps that from
+ * looking like a successful no-op.
+ */
 async function runApply(
   args: ManageClassifiersArgs,
   ctx: ToolContext

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -11,6 +11,9 @@
  *
  * Manual classification:
  * - classify: Update content classification manually (single or batch)
+ *
+ * Bulk classification:
+ * - apply: Run a classifier's embedding match over given content ids
  */
 
 import {
@@ -20,8 +23,9 @@ import {
   type ManageClassifiersResult,
 } from '@lobu/core/contracts/tools/manage-classifiers';
 import type { DbClient } from '../../db/client';
-import { getDb } from '../../db/client';
+import { getDb, pgBigintArray } from '../../db/client';
 import type { Env } from '../../index';
+import { executeClassificationQuery } from '../../utils/classification-query';
 import {
   generateEmbeddings as generateEmbeddingsViaService,
   isValidEmbedding,
@@ -137,6 +141,7 @@ export const manageClassifiers = withValidatedArgs(
     generate_embeddings: flatAction((args, ctx, env) => handleGenerateEmbeddings(args, env, ctx)),
     delete: flatAction(handleDelete),
     classify: flatAction(handleClassify),
+    apply: flatAction(handleApply),
   })
 );
 
@@ -537,6 +542,111 @@ async function handleClassify(
       message: error instanceof Error ? error.message : 'Failed to update classification',
     };
   }
+}
+
+/**
+ * Run a classifier's embedding match over caller-supplied content ids.
+ *
+ * This is the agent-facing entry to the same engine the reconciliation cron
+ * uses; the cron only ever reaches it in `entity` mode, so org-scoped feeds
+ * (events with no entity link) had no way to be classified at all.
+ *
+ * Every id that does not produce a classification is reported with a reason.
+ * The engine filters on `fe.embedding IS NOT NULL`, so an unembedded event is
+ * dropped by a WHERE clause — reporting the count is what keeps that from
+ * looking like a successful no-op.
+ */
+async function handleApply(
+  args: ManageClassifiersArgs,
+  ctx: ToolContext
+): Promise<ManageClassifiersResult> {
+  const sql = getDb();
+
+  if (!args.classifier_slug) {
+    return { success: false, action: 'apply', message: 'classifier_slug is required' };
+  }
+  if (!args.content_ids || args.content_ids.length === 0) {
+    return { success: false, action: 'apply', message: 'content_ids is required and must be non-empty' };
+  }
+
+  // Dedupe so the counts below describe distinct events, not request repeats.
+  const requestedIds = [...new Set(args.content_ids)];
+
+  const classifierRows = (await sql`
+    SELECT cf.id AS classifier_id
+    FROM classify_facet cf
+    WHERE cf.slug = ${args.classifier_slug}
+      AND cf.status = 'active'
+      AND cf.organization_id = ${ctx.organizationId}
+  `) as unknown as Array<{ classifier_id: number }>;
+
+  if (classifierRows.length === 0) {
+    return {
+      success: false,
+      action: 'apply',
+      message: `Classifier not found or inactive: ${args.classifier_slug}`,
+    };
+  }
+
+  // Partition the request BEFORE classifying so each skip has a real reason
+  // rather than being inferred from a missing result.
+  const reachable = (await sql`
+    SELECT e.id,
+           EXISTS (
+             SELECT 1 FROM event_embeddings emb
+             WHERE emb.event_id = e.id AND emb.chunk_index = 0
+           ) AS has_embedding
+    FROM events e
+    WHERE e.organization_id = ${ctx.organizationId}
+      AND e.id = ANY(${pgBigintArray(requestedIds)}::bigint[])
+  `) as unknown as Array<{ id: number; has_embedding: boolean }>;
+
+  const reachableIds = new Set(reachable.map((r) => Number(r.id)));
+  const embeddedIds = reachable.filter((r) => r.has_embedding).map((r) => Number(r.id));
+
+  const skippedNotInOrg = requestedIds.filter((id) => !reachableIds.has(id));
+  const skippedNoEmbedding = reachable.filter((r) => !r.has_embedding).map((r) => Number(r.id));
+
+  let classifiedIds: number[] = [];
+  if (embeddedIds.length > 0) {
+    const results = await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: ctx.organizationId,
+      content_ids: embeddedIds,
+      enabledClassifiers: [args.classifier_slug],
+    });
+    classifiedIds = [...new Set(results.map((r) => Number(r.content_id)))];
+  }
+
+  // Embedded, in-org, and still unclassified means every attribute value scored
+  // below the classifier's min_similarity and no fallback_value is set.
+  const classifiedSet = new Set(classifiedIds);
+  const skippedBelowThreshold = embeddedIds.filter((id) => !classifiedSet.has(id));
+
+  return {
+    success: true,
+    action: 'apply',
+    message:
+      `Classified ${classifiedIds.length}/${requestedIds.length} with "${args.classifier_slug}"` +
+      (skippedNoEmbedding.length > 0 ? `; ${skippedNoEmbedding.length} not embedded` : '') +
+      (skippedNotInOrg.length > 0 ? `; ${skippedNotInOrg.length} not in this organization` : '') +
+      (skippedBelowThreshold.length > 0
+        ? `; ${skippedBelowThreshold.length} below min_similarity`
+        : ''),
+    data: {
+      requested: requestedIds.length,
+      classified: classifiedIds.length,
+      skipped: {
+        not_embedded: skippedNoEmbedding.length,
+        not_in_organization: skippedNotInOrg.length,
+        below_threshold: skippedBelowThreshold.length,
+      },
+      // Bounded samples: enough to debug a bad classifier without returning
+      // thousands of ids into the agent's context.
+      sample_skipped_not_embedded: skippedNoEmbedding.slice(0, 20),
+      sample_skipped_below_threshold: skippedBelowThreshold.slice(0, 20),
+    },
+  };
 }
 
 async function updateSingleClassification(

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -595,9 +595,16 @@ async function runApply(
 
   // Partition the request BEFORE classifying so each skip has a real reason
   // rather than being inferred from a missing result.
-  // `has_embedding` has to match the engine's representative-vector join
-  // (chunk 0 AND the configured model), or an event whose only chunk-0 vector is
-  // from a stale model reads as embedded and gets the wrong skip reason.
+  //
+  // Every clause here mirrors the engine's target selection, because the whole
+  // value of this action is that a skip reason is TRUE. Three ways it can drift,
+  // each of which silently reports the wrong reason:
+  //   - relation: the engine reads `current_event_records`, so a superseded
+  //     event is invisible to it. Reading `events` here would call that event
+  //     reachable and then blame `below_threshold`.
+  //   - chunk/model: the engine joins the representative vector (chunk 0 AND the
+  //     configured model), so a stale-model vector is not an embedding to it.
+  //   - organization: the engine is org-scoped, as is this.
   const reachable = (await sql`
     SELECT e.id,
            EXISTS (
@@ -606,7 +613,7 @@ async function runApply(
                AND emb.chunk_index = 0
                AND emb.embedding_model = ${getConfiguredEmbeddingModel()}
            ) AS has_embedding
-    FROM events e
+    FROM current_event_records e
     WHERE e.organization_id = ${ctx.organizationId}
       AND e.id = ANY(${pgBigintArray(requestedIds)}::bigint[])
   `) as unknown as Array<{ id: number; has_embedding: boolean }>;

--- a/packages/server/src/utils/classification-query.ts
+++ b/packages/server/src/utils/classification-query.ts
@@ -87,6 +87,18 @@ interface ClassificationQueryOptions {
   mode: 'entity' | 'content_ids';
 
   /**
+   * Owning organization. REQUIRED: both the target-content and the
+   * classifier-template lookups filter on it. Before this was threaded through,
+   * `content_ids` mode selected purely on `f.id IN (...)` and the template
+   * lookup purely on `cf.slug IN (...)`, so a caller could classify another
+   * org's events, or match against another org's classifier of the same slug.
+   * That was unreachable while the only caller was the reconciliation cron
+   * (which derives ids from one org's own entity); it becomes reachable the
+   * moment an agent-facing action can pass ids directly.
+   */
+  organizationId: string;
+
+  /**
    * Enabled classifier slugs
    */
   enabledClassifiers: string[];
@@ -191,8 +203,10 @@ async function fetchTargetContent(
 
   if (mode === 'content_ids') {
     const contentIds = options.content_ids!;
-    const contentPlaceholders = contentIds.map((_, i) => `$${i + 1}`).join(', ');
+    const contentPlaceholders = contentIds.map((_, i) => `$${i + 2}`).join(', ');
 
+    // $1 is the org; ids start at $2. Org-scoping here is what makes the
+    // agent-facing `apply` action safe to expose — see ClassificationQueryOptions.
     targetRows = await sql.unsafe(
       `SELECT DISTINCT
          f.id,
@@ -203,9 +217,10 @@ async function fetchTargetContent(
        FROM current_event_records f
        LEFT JOIN current_event_records parent ON parent.origin_id = f.origin_parent_id
        ${repEmbeddingJoins}
-       WHERE f.id IN (${contentPlaceholders})
+       WHERE f.organization_id = $1
+         AND f.id IN (${contentPlaceholders})
          AND fe.embedding IS NOT NULL`,
-      contentIds
+      [options.organizationId, ...contentIds]
     );
   } else if (mode === 'entity') {
     const entityId = options.entity_id!;
@@ -216,8 +231,9 @@ async function fetchTargetContent(
        FROM classify_facet cf
        WHERE cf.slug IN (${classifierPlaceholders})
          AND cf.status = 'active'
-         AND cf.watcher_id IS NULL`,
-      enabledClassifiers
+         AND cf.watcher_id IS NULL
+         AND cf.organization_id = $${enabledClassifiers.length + 1}`,
+      [...enabledClassifiers, options.organizationId]
     );
     const classifierIds = classifierRows.map((r) => r.classifier_id);
 
@@ -287,7 +303,8 @@ async function fetchTargetContent(
 async function fetchClassifierTemplates(
   sql: DbClient,
   enabledClassifiers: string[],
-  targetContent: TargetContent[]
+  targetContent: TargetContent[],
+  organizationId: string
 ): Promise<ClassifierTemplate[]> {
   if (targetContent.length === 0) return [];
 
@@ -310,8 +327,9 @@ async function fetchClassifierTemplates(
      FROM classify_facet cf
      WHERE cf.slug IN (${classifierPlaceholders})
        AND cf.status = 'active'
-       AND cf.watcher_id IS NULL`,
-    enabledClassifiers
+       AND cf.watcher_id IS NULL
+       AND cf.organization_id = $${enabledClassifiers.length + 1}`,
+    [...enabledClassifiers, organizationId]
   );
 
   // Collect unique entity_ids from target content for scoping
@@ -461,12 +479,17 @@ function generateParentClassifications(
 
 // ── Step 6: Fetch all classifier version slugs for parent lookups ──────
 
-async function fetchAllClassifierVersions(sql: DbClient): Promise<ClassifierVersionLookup[]> {
+async function fetchAllClassifierVersions(
+  sql: DbClient,
+  organizationId: string
+): Promise<ClassifierVersionLookup[]> {
   return sql.unsafe<ClassifierVersionLookup>(
     `SELECT cf.slug, cf.id as classifier_id
      FROM classify_facet cf
-     WHERE cf.status = 'active' AND cf.watcher_id IS NULL`,
-    []
+     WHERE cf.status = 'active'
+       AND cf.watcher_id IS NULL
+       AND cf.organization_id = $1`,
+    [organizationId]
   );
 }
 
@@ -608,7 +631,12 @@ export async function executeClassificationQuery(
     }
 
     // Step 2: Fetch classifier templates (attribute_values expanded in TypeScript)
-    const templates = await fetchClassifierTemplates(sql, enabledClassifiers, targetContent);
+    const templates = await fetchClassifierTemplates(
+      sql,
+      enabledClassifiers,
+      targetContent,
+      options.organizationId
+    );
     if (templates.length === 0) {
       logger.info({ mode }, '[Classification Query] No classifier templates found');
       return [];
@@ -621,7 +649,7 @@ export async function executeClassificationQuery(
     const bestMatches = determineBestMatches(similarities);
 
     // Step 5: Build parent classifications from parent_mapping
-    const classifierVersionRows = await fetchAllClassifierVersions(sql);
+    const classifierVersionRows = await fetchAllClassifierVersions(sql, options.organizationId);
     const classifierVersionLookup = new Map(
       classifierVersionRows.map((r) => [r.slug, r])
     );


### PR DESCRIPTION
## What

The embedding classification engine already supports `mode: 'content_ids'` — classify an arbitrary set of events, **no entity link required** — and has integration coverage for it. Nothing could reach it: the only production caller is the reconciliation cron, which hardcodes `mode: 'entity'`.

That mattered because the cron's candidate query requires `e.entity_ids @> ARRAY[ent.id]`. On a real workspace, 100% of X and LinkedIn events have no entity link (X 1132/1132, LinkedIn 175/175 over 7 days), so **no org-scoped connector feed could be classified at all**, and `event_classifications` was empty org-wide.

This exposes that path as `manage_classifiers: apply`, and closes the org-isolation hole that exposing it surfaced.

## Security fix (red → green)

`content_ids` mode selected purely on `f.id IN (...)`; the classifier-template lookup purely on `cf.slug IN (...)`. Neither filtered by organization. Unreachable while a trusted cron derived ids from one org's own entity — a direct cross-tenant bug the moment an agent can pass ids.

Both queries, plus the parent-slug lookup, now filter on `organization_id`, threaded through `ClassificationQueryOptions` so the check lives at the **engine**, not at each caller.

**RED** (org filters reverted, fix otherwise in place):

```
 ✓ matches the closest attribute by cosine and writes the classification (met_threshold) 221ms
 ✓ falls back when the best cosine is below min_similarity 162ms
 × refuses to classify an event belonging to another organization 155ms
   → expected [ { content_id: 3 } ] to deeply equal []
 × does not match against another organization's classifier of the same slug 175ms
   → expected [ { content_id: 4 } ] to deeply equal []
 Tests  2 failed | 2 passed (4)
```

**GREEN** (fix restored):

```
 ✓ src/__tests__/integration/classifiers/classification-execute-query.test.ts (4 tests) 702ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## The `apply` action

Runs a classifier's embedding match (no LLM) over caller-supplied ids, and **reports every id it did not classify**, split by reason: `not_embedded`, `not_in_organization`, `below_threshold`, plus bounded id samples.

That accounting is the point. The engine drops unembedded events via `fe.embedding IS NOT NULL` — a WHERE clause, not an error — so without it a run that classified nothing is indistinguishable from a successful one.

Re-running re-labels: `upsertClassifications` deletes only `NOT is_manual AND source='embedding'`, so agent- and user-authored classifications survive. Editing a classifier therefore needs no version bookkeeping — `generate_embeddings`, then `apply` again.

## Why this shape

Classification is a **scaling valve, not a pipeline stage**. Measured on this workload, Behavior runtime is output-bound, not input-bound: cutting the prompt payload 59% (325 KB → 132 KB) left runtime unchanged (~79s → ~82s), because ~67s of an 84s run is decoding the digest. So pre-classifying buys nothing until a candidate set is too large to pass at all. This adds the escape hatch for that case without putting anything new in the hot path.

## Test plan

- [x] `make pre-pr` — clean (build, typecheck, knip, lint, exposed-surface naming, gateway-llm gate)
- [x] Integration suite for the touched file, on ephemeral embedded Postgres + pgvector: 4/4
- [x] Red→green captured above by reverting only the org filters
- [ ] `make review-fix` — **could not run**: codex is over quota (`try again at Aug 5th`). It made zero changes; diff stat identical before and after.

## Risk

`ClassificationQueryOptions.organizationId` is required, so every call site must pass it — the compiler enforces this and there are two (the cron and the new action). The cron now selects `ent.organization_id` alongside `ent.id`. No migration, no schema change, no change to the existing `entity` mode's semantics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an action to run classifiers on selected content without using an LLM.
  * Added bulk classification for up to 2,000 content items, with duplicate handling and classified/skipped results.
  * Restricted bulk classifier application to authorized administrators.

* **Bug Fixes**
  * Improved organization-level data isolation during classification.
  * Prevented content and classifier templates from other organizations from being used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->