### PR TITLE
feat(server): dry-run feed syncs that execute for real and persist nothing

### DIFF
--- a/db/migrations/20260731020000_runs_dry_run.sql
+++ b/db/migrations/20260731020000_runs_dry_run.sql
@@ -1,0 +1,62 @@
+-- `runs.dry_run` — execute a connector sync for real, persist nothing.
+--
+-- Why this is needed at all: `lobu connector run` only accepts `browser_session`
+-- profiles, and that is not an oversight. Browser sessions are the device-pinned
+-- carve-out in the credential rules (packages/server/AGENTS.md), so the CLI may
+-- legitimately hold them. OAuth and API-key credentials are durable stored
+-- credentials that must never leave the gateway, so a connector using them can
+-- only be exercised where the credentials already live — server side. Until now
+-- the only way to do that was a real sync, which really persists.
+--
+-- How it is enforced, and why that shape. The dry path does NOT skip the
+-- writes; it runs the identical ingest code against a transaction and rolls
+-- back. The set of things a dry run must not do is open-ended — it grows every
+-- time anyone adds a write to the ingest path — while the set it must keep is
+-- closed (the preview, and the run row's own lifecycle). Enumerating the closed
+-- set and letting the transaction cover the open one means a write added later
+-- is handled without its author knowing this feature exists. It also makes the
+-- answer trustworthy: because the real INSERTs execute, a dry run reports a
+-- constraint violation or bad cast exactly as the real path would, instead of
+-- previewing rows that could never land. The only writes needing an explicit
+-- guard are the ones that escape Postgres (ArtifactStore blob upload, Behavior
+-- run dispatch, detached auto-linking, transcription) — a category a reviewer
+-- can check mechanically rather than a list to memorize.
+--
+-- Why a column on `runs` rather than a parallel table or an in-memory flag:
+-- the sync already IS a run, the flag has to survive the worker round-trip
+-- (worker executes, POSTs batches back, the SERVER decides what to persist in
+-- `worker-api/run-lifecycle.ts`), and any replica may serve that callback. An
+-- in-memory map would be wrong on a second pod.
+--
+-- `dry_run_preview` holds what WOULD have been ingested. Deliberately capped and
+-- marked `truncated` rather than unbounded: a sync can emit thousands of items,
+-- and the point is to show an operator the shape of the output, not to become a
+-- second copy of `events`. It lives on `runs` — not `events` — precisely because
+-- `runs` is mutable working state while `events` is append-only; a preview that
+-- landed in `events` could never be cleaned up.
+--
+-- What a dry run does NOT promise: `idx_runs_active_sync_per_feed` is a partial
+-- unique index on (feed_id) for active syncs and does not distinguish dry from
+-- real, so a dry run occupies the feed's one active-sync slot. A scheduled sync
+-- arriving mid-dry-run is skipped for that tick (and picked up on the next one),
+-- and triggering dry while a real sync is active returns "already pending or
+-- running". That is deliberate — a dry run and a real sync hitting the same
+-- remote concurrently is worse than a one-tick delay, and the reaper bounds how
+-- long a stuck dry run can hold the slot. It also does not promise the REMOTE
+-- system is untouched: "persists nothing" is a statement about Lobu's database,
+-- not about side effects a connector performs upstream (marking read, etc.).
+--
+-- NOT NULL DEFAULT false is safe to add in one statement on PG11+ (the default
+-- is stored in the catalog, no table rewrite), so no backfill step is needed.
+-- Existing rows read as false, which is the correct meaning: everything written
+-- before this column existed really did persist.
+
+ALTER TABLE public.runs
+  ADD COLUMN IF NOT EXISTS dry_run boolean DEFAULT false NOT NULL,
+  ADD COLUMN IF NOT EXISTS dry_run_preview jsonb;
+
+COMMENT ON COLUMN public.runs.dry_run IS
+  'When true the connector executes for real but the server persists nothing: no events, no entity creation, no artifact materialization, no checkpoint advance, no feed sync-state bookkeeping, no transcription queueing. Set at run creation; enforced in worker-api/run-lifecycle.ts (stream + complete) and scheduled/check-stalled-executions.ts (a reaped dry run is never retried as a real sync and never stamps feed failure state).';
+
+COMMENT ON COLUMN public.runs.dry_run_preview IS
+  'What a dry run WOULD have ingested: {items: [...], total, truncated}. Capped — see DRY_RUN_PREVIEW_LIMIT in worker-api/run-lifecycle.ts. NULL for normal runs.';

--- a/db/migrations/20260731020000_runs_dry_run.sql
+++ b/db/migrations/20260731020000_runs_dry_run.sql
@@ -51,6 +51,7 @@
 -- Existing rows read as false, which is the correct meaning: everything written
 -- before this column existed really did persist.
 
+-- migrate:up
 ALTER TABLE public.runs
   ADD COLUMN IF NOT EXISTS dry_run boolean DEFAULT false NOT NULL,
   ADD COLUMN IF NOT EXISTS dry_run_preview jsonb;
@@ -60,3 +61,8 @@ COMMENT ON COLUMN public.runs.dry_run IS
 
 COMMENT ON COLUMN public.runs.dry_run_preview IS
   'What a dry run WOULD have ingested: {items: [...], total, truncated}. Capped — see DRY_RUN_PREVIEW_LIMIT in worker-api/run-lifecycle.ts. NULL for normal runs.';
+
+-- migrate:down
+ALTER TABLE public.runs
+  DROP COLUMN IF EXISTS dry_run_preview,
+  DROP COLUMN IF EXISTS dry_run;

--- a/packages/cli/src/commands/_lib/connector-run-cmd.ts
+++ b/packages/cli/src/commands/_lib/connector-run-cmd.ts
@@ -12,7 +12,10 @@
  *
  * Scope (v1): browser_session profiles only. OAuth / env / interactive
  * profiles need credentials the CLI doesn't have; they require gateway-side
- * execution (a separate trigger_feed dry_run path, not yet wired).
+ * execution — `manage_feeds` action `trigger_feed` with `dry_run: true`, which
+ * runs the connector for real on the server and persists nothing (runs.dry_run).
+ * Note this command needs no dry_run flag of its own: it ALREADY persists
+ * nothing, because it never reaches the server's ingest path at all.
  *
  * Execution uses SubprocessExecutor (the same one the worker daemon uses),
  * not an in-process executor — bugs in connector code don't take the CLI
@@ -234,7 +237,7 @@ export async function connectorRun(
   // live on the server and can't be safely materialized in the CLI process.
   if (profile.profile_kind !== "browser_session") {
     throw new Error(
-      `Profile kind '${profile.profile_kind}' is not supported by \`lobu connector run\` (v1 supports only browser_session). Use the server-side trigger_feed path for OAuth/env-based profiles.`
+      `Profile kind '${profile.profile_kind}' is not supported by \`lobu connector run\` (v1 supports only browser_session) — its credentials are durable and never leave the gateway. To test this connector without persisting anything, run it server-side: manage_feeds action 'trigger_feed' with dry_run: true. The connector executes for real; no events, entities, attachments or checkpoint advance are written.`
     );
   }
 

--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -188,6 +188,13 @@ export const TriggerFeedAction = Type.Object({
     description: "Trigger an immediate sync run for a collected feed.",
   }),
   feed_id: Type.Number({ description: "Feed ID to trigger sync for" }),
+  dry_run: Type.Optional(
+    Type.Boolean({
+      description:
+        "Execute the connector for real but persist nothing in Lobu — no events, no entities, no attachments, and the feed's checkpoint and sync state do not move. The run executes asynchronously; once it completes, a capped preview of what would have been ingested is on the run's dry_run_preview, visible via read_feed's recent_runs. Use this to test a connector whose credentials are OAuth or API-key based; those never leave the gateway, so the sync can only run server-side. Two limits worth knowing: it does not undo side effects the connector causes UPSTREAM (marking a message read, etc.), and it occupies the feed's single active-sync slot while it runs, so a scheduled sync landing mid-run is skipped until the next tick.",
+      default: false,
+    })
+  ),
 });
 
 // ============================================
@@ -288,6 +295,10 @@ export const ManageFeedsResultSchema = Type.Union([
     triggered: Type.Literal(true),
     run_id: Type.Integer(),
     feed_id: Type.Integer(),
+    // Present and true only for a dry run. Echoed back so a caller that passed
+    // `dry_run` can confirm the run really was created dry — silently ignoring
+    // the flag and persisting anyway is the one failure mode that matters here.
+    dry_run: Type.Optional(Type.Boolean()),
   }),
   Type.Object({
     action: Type.Literal("trigger_feed"),

--- a/packages/server/src/__tests__/integration/feed-dry-run-persists-nothing.test.ts
+++ b/packages/server/src/__tests__/integration/feed-dry-run-persists-nothing.test.ts
@@ -1,0 +1,358 @@
+/**
+ * `runs.dry_run` — the connector executes for real, the server persists nothing.
+ *
+ * Why this test is shaped as a NEGATIVE assertion.
+ *
+ * The value of a dry run is entirely in what it does NOT do, and every one of
+ * those writes lives in `streamContent`, on a path that already worked. A test
+ * that only asserted "the preview came back" would pass just as happily against
+ * a build that also wrote every event — which is the one outcome that makes the
+ * feature worse than useless, because an operator would be told "nothing was
+ * persisted" while their workspace filled up.
+ *
+ * So the assertions are: after a dry batch, `events` is empty, the feed's
+ * `checkpoint` is byte-identical to what it was, and the feed's schedule state
+ * (`next_run_at`, `last_sync_status`) has not moved. The positive assertion —
+ * the preview exists and counts correctly — is secondary.
+ *
+ * The control cases are what make the dry ones meaningful: the SAME batch /
+ * completion through a NON-dry run must persist, or the tests would pass on a
+ * build where streamContent silently dropped everything.
+ *
+ * Both halves of the run lifecycle are covered, because the writes are split
+ * across them: streamContent owns events / entities / attachments / mid-run
+ * checkpoints, while completeWorkerJob owns the feed's sync bookkeeping —
+ * last_sync_status, consecutive_failures, next_run_at, and the FINAL
+ * checkpoint advance. Guarding only the stream half would still let a dry
+ * run's completion move the cursor.
+ */
+
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { completeWorkerJob, streamContent } from '../../worker-api';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization } from '../setup/test-fixtures';
+
+const WORKER_ID = 'worker-dry';
+const FEED_CHECKPOINT = { cursor: 'original-cursor' };
+
+function mockWorkerCtx(body: unknown): {
+  ctx: Context<{ Bindings: Env }>;
+  result: () => { body: unknown; status: number };
+} {
+  let captured: { body: unknown; status: number } = { body: undefined, status: 200 };
+  const ctx = {
+    req: { json: async () => body },
+    var: {},
+    json: (b: unknown, status?: number) => {
+      captured = { body: b, status: status ?? 200 };
+      return captured as unknown as Response;
+    },
+  } as unknown as Context<{ Bindings: Env }>;
+  return { ctx, result: () => captured };
+}
+
+async function seed(dryRun: boolean): Promise<{
+  orgId: string;
+  feedId: number;
+  runId: number;
+}> {
+  const sql = getTestDb();
+  const org = await createTestOrganization();
+
+  const conn = (await sql`
+    INSERT INTO connections
+      (organization_id, connector_key, status, visibility, slug, created_at, updated_at)
+    VALUES
+      (${org.id}, 'rss', 'active', 'org', ${`rss-dry-${dryRun}`}, NOW(), NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+
+  const feed = (await sql`
+    INSERT INTO feeds
+      (organization_id, connection_id, feed_key, status, schedule, checkpoint,
+       last_sync_status, next_run_at, created_at, updated_at)
+    VALUES
+      (${org.id}, ${conn[0].id}, 'items', 'active', '0 */6 * * *',
+       ${sql.json(FEED_CHECKPOINT)}, 'success', '2099-01-01T00:00:00Z', NOW(), NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+
+  const run = (await sql`
+    INSERT INTO runs
+      (organization_id, run_type, feed_id, connection_id, connector_key,
+       connector_version, status, claimed_by, dry_run, created_at)
+    VALUES
+      (${org.id}, 'sync', ${feed[0].id}, ${conn[0].id}, 'rss', '1.0.0',
+       'running', ${WORKER_ID}, ${dryRun}, NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+
+  return { orgId: org.id, feedId: feed[0].id, runId: run[0].id };
+}
+
+function batchFor(runId: number) {
+  return {
+    run_id: runId,
+    worker_id: WORKER_ID,
+    // A checkpoint IS supplied. That matters: the dry path must decline to
+    // advance it even though the connector offered a new one.
+    checkpoint: { cursor: 'advanced-cursor' },
+    items: [
+      {
+        id: 'dry-item-1',
+        title: 'First item',
+        payload_text: 'body one',
+        payload_type: 'text',
+        occurred_at: new Date().toISOString(),
+      },
+      {
+        id: 'dry-item-2',
+        title: 'Second item',
+        payload_text: 'body two',
+        payload_type: 'text',
+        occurred_at: new Date().toISOString(),
+      },
+    ],
+  };
+}
+
+describe('feed dry run persists nothing', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('writes no events, does not advance the checkpoint, and leaves feed schedule state untouched', async () => {
+    const sql = getTestDb();
+    const { orgId, feedId, runId } = await seed(true);
+
+    const before = (await sql`
+      SELECT checkpoint, next_run_at, last_sync_status FROM feeds WHERE id = ${feedId}
+    `) as Array<Record<string, unknown>>;
+
+    const { ctx, result } = mockWorkerCtx(batchFor(runId));
+    await streamContent(ctx);
+
+    expect(result().status).toBe(200);
+    expect((result().body as { dry_run?: boolean }).dry_run).toBe(true);
+    // The items were seen and counted — the connector really did run.
+    expect((result().body as { total_items: number }).total_items).toBe(2);
+
+    // THE assertion: nothing landed in the append-only table.
+    const events = (await sql`
+      SELECT id FROM events WHERE organization_id = ${orgId}
+    `) as Array<{ id: number }>;
+    expect(events).toHaveLength(0);
+
+    // The checkpoint did not move, even though the batch offered a new one.
+    // If it had, the rows this dry run previewed would be skipped by the next
+    // REAL sync — silently losing data the operator was only inspecting.
+    const after = (await sql`
+      SELECT checkpoint, next_run_at, last_sync_status FROM feeds WHERE id = ${feedId}
+    `) as Array<Record<string, unknown>>;
+    expect(after[0].checkpoint).toEqual(FEED_CHECKPOINT);
+    expect(after[0].checkpoint).toEqual(before[0].checkpoint);
+    expect(after[0].next_run_at).toEqual(before[0].next_run_at);
+    expect(after[0].last_sync_status).toEqual(before[0].last_sync_status);
+
+    // The run's own checkpoint column is likewise untouched.
+    const runRow = (await sql`
+      SELECT checkpoint, dry_run_preview FROM runs WHERE id = ${runId}
+    `) as Array<{ checkpoint: unknown; dry_run_preview: Record<string, unknown> }>;
+    expect(runRow[0].checkpoint).toBeNull();
+
+    // Secondary: the preview describes what WOULD have been ingested.
+    const preview = runRow[0].dry_run_preview;
+    expect(preview.total).toBe(2);
+    expect(preview.truncated).toBe(false);
+    expect((preview.items as Array<{ origin_id: string }>).map((i) => i.origin_id)).toEqual([
+      'dry-item-1',
+      'dry-item-2',
+    ]);
+  });
+
+  it('caps the stored preview across batches while total keeps counting', async () => {
+    const sql = getTestDb();
+    const { runId } = await seed(true);
+
+    const itemsOf = (prefix: string, n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        id: `${prefix}-${i}`,
+        title: `Item ${prefix}-${i}`,
+        payload_text: 'body',
+        payload_type: 'text',
+        occurred_at: new Date().toISOString(),
+      }));
+
+    // Two batches of 30 against a 50-item cap. The JS-side cap only bounds one
+    // request's payload, so without the SQL-side re-cap the stored array would
+    // grow to 60 here — and by up to 50 per batch on a long sync.
+    for (const prefix of ['b1', 'b2']) {
+      const { ctx, result } = mockWorkerCtx({
+        run_id: runId,
+        worker_id: WORKER_ID,
+        items: itemsOf(prefix, 30),
+      });
+      await streamContent(ctx);
+      expect(result().status).toBe(200);
+    }
+
+    const rows = (await sql`
+      SELECT dry_run_preview FROM runs WHERE id = ${runId}
+    `) as Array<{
+      dry_run_preview: { items: Array<{ origin_id: string }>; total: number; truncated: boolean };
+    }>;
+    const preview = rows[0].dry_run_preview;
+    expect(preview.items).toHaveLength(50);
+    // Earliest-first: the cap keeps the head of the stream, not the tail.
+    expect(preview.items[0].origin_id).toBe('b1-0');
+    expect(preview.items[49].origin_id).toBe('b2-19');
+    expect(preview.total).toBe(60);
+    expect(preview.truncated).toBe(true);
+  });
+
+  it('CONTROL: the same batch on a non-dry run does persist', async () => {
+    const sql = getTestDb();
+    const { orgId, feedId, runId } = await seed(false);
+
+    const { ctx } = mockWorkerCtx(batchFor(runId));
+    await streamContent(ctx);
+
+    // Without this case the test above would pass on a build where
+    // streamContent dropped every batch on the floor.
+    const events = (await sql`
+      SELECT id FROM events WHERE organization_id = ${orgId}
+    `) as Array<{ id: number }>;
+    expect(events.length).toBeGreaterThan(0);
+
+    const after = (await sql`
+      SELECT checkpoint FROM feeds WHERE id = ${feedId}
+    `) as Array<{ checkpoint: Record<string, unknown> }>;
+    expect(after[0].checkpoint).toEqual({ cursor: 'advanced-cursor' });
+
+    const runRow = (await sql`
+      SELECT dry_run_preview FROM runs WHERE id = ${runId}
+    `) as Array<{ dry_run_preview: unknown }>;
+    expect(runRow[0].dry_run_preview).toBeNull();
+  });
+
+  const feedSyncState = (feedId: number) => {
+    const sql = getTestDb();
+    return sql`
+      SELECT checkpoint, next_run_at, last_sync_status, last_sync_at,
+             last_error, consecutive_failures, items_collected, status
+      FROM feeds WHERE id = ${feedId}
+    ` as Promise<Array<Record<string, unknown>>>;
+  };
+
+  it('completing a dry run finalizes the run but stamps no feed sync state and no checkpoint', async () => {
+    const sql = getTestDb();
+    const { feedId, runId } = await seed(true);
+
+    const before = await feedSyncState(feedId);
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      status: 'success',
+      items_collected: 2,
+      // A final checkpoint IS offered — the dry path must decline it.
+      checkpoint: { cursor: 'advanced-cursor' },
+    });
+    await completeWorkerJob(ctx);
+    expect((result().body as { success: boolean }).success).toBe(true);
+
+    // The run row itself is real working state: it finalizes normally...
+    const run = (await sql`
+      SELECT status, checkpoint FROM runs WHERE id = ${runId}
+    `) as Array<{ status: string; checkpoint: unknown }>;
+    expect(run[0].status).toBe('completed');
+    // ...but never records the would-be cursor, matching the stream-time guard.
+    expect(run[0].checkpoint).toBeNull();
+
+    // Feed sync state is byte-identical: no checkpoint advance, no
+    // last_sync_* stamp, no next_run_at move.
+    const after = await feedSyncState(feedId);
+    expect(after[0]).toEqual(before[0]);
+  });
+
+  it('a FAILED dry run does not touch failure bookkeeping (consecutive_failures, backoff, pause)', async () => {
+    const { feedId, runId } = await seed(true);
+
+    const before = await feedSyncState(feedId);
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      status: 'failed',
+      error_message: 'connector blew up',
+    });
+    await completeWorkerJob(ctx);
+    expect((result().body as { success: boolean }).success).toBe(true);
+
+    // A dry run's failure is the operator's information, not the feed's
+    // history: no consecutive_failures increment, no last_error, no backoff
+    // or auto-pause that would degrade the REAL schedule.
+    const after = await feedSyncState(feedId);
+    expect(after[0]).toEqual(before[0]);
+  });
+
+  it('CONTROL: completing a non-dry run does stamp feed sync state', async () => {
+    const { feedId, runId } = await seed(false);
+
+    const { ctx } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      status: 'success',
+      items_collected: 2,
+      checkpoint: { cursor: 'advanced-cursor' },
+    });
+    await completeWorkerJob(ctx);
+
+    // Without this the dry cases above would pass on a build where
+    // completeWorkerJob stopped writing feed state for everyone.
+    const after = await feedSyncState(feedId);
+    expect(after[0].checkpoint).toEqual({ cursor: 'advanced-cursor' });
+    expect(after[0].last_sync_at).not.toBeNull();
+    expect(after[0].last_sync_status).toBe('success');
+  });
+});
+
+/**
+ * The reason the dry path runs the REAL inserts against a rolled-back
+ * transaction rather than skipping them.
+ *
+ * A dry run exists to answer "would this sync work?". An implementation that
+ * validated the items and then declined to insert them would answer that
+ * question by not asking it: anything the database itself rejects — a
+ * constraint, a trigger, a NOT NULL, a bad cast — would be invisible, and the
+ * operator would be told "2 items would be ingested" about data that can never
+ * land. These tests pin the property that makes the answer trustworthy.
+ */
+describe('dry run exercises the real write path', () => {
+  it('surfaces a database-level failure instead of reporting success', async () => {
+    const { runId } = await seed(true);
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      items: [
+        {
+          id: 'bad-item',
+          title: 'Unpersistable',
+          payload_text: 'body',
+          payload_type: 'text',
+          // Not a timestamp. The real path fails on this at INSERT time; a dry
+          // run must fail identically rather than cheerfully previewing it.
+          occurred_at: 'definitely-not-a-timestamp',
+        },
+      ],
+    });
+    await streamContent(ctx);
+
+    expect(result().status).toBe(500);
+    expect((result().body as { dry_run?: boolean }).dry_run).toBeUndefined();
+  });
+
+});

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -248,7 +248,11 @@ async function resolveActiveConnectorVersion(
  * the run ID, or null if skipped — a duplicate active sync run, or an
  * unresolvable orphan feed that was soft-deleted (see softDeleteOrphanFeed).
  */
-async function createSyncRunWithClient(sql: DbClient, feedId: number): Promise<number | null> {
+async function createSyncRunWithClient(
+  sql: DbClient,
+  feedId: number,
+  dryRun = false
+): Promise<number | null> {
   // Check if there's already a pending/running run for this feed
   const existing = await sql`
     SELECT id FROM runs
@@ -347,7 +351,26 @@ async function createSyncRunWithClient(sql: DbClient, feedId: number): Promise<n
   const nextRunAt = feed.schedule
     ? nextRunAtFromCron(feed.schedule, new Date(), feed.timezone)
     : null;
-  const inserted = await sql`
+  // A dry run inserts the run row and stops there. The sibling `UPDATE feeds`
+  // below is a real side effect — it stamps `last_sync_status = 'pending'`,
+  // clears `last_error`, and rolls `next_run_at` forward to the next cron slot.
+  // Letting a dry run do that would move the feed's schedule and overwrite the
+  // recorded outcome of the last REAL sync, which is exactly the state a dry
+  // run exists to leave untouched.
+  const inserted = dryRun
+    ? await sql`
+    INSERT INTO runs (
+      organization_id, run_type, feed_id, connection_id,
+      connector_key, connector_version, status, approval_status, created_at,
+      dry_run
+    ) VALUES (
+      ${feed.organization_id}, 'sync', ${feedId}, ${feed.connection_id},
+      ${feed.connector_key}, ${connectorVersion}, 'pending', 'auto', current_timestamp,
+      true
+    )
+    RETURNING id
+  `
+    : await sql`
     WITH inserted AS (
       INSERT INTO runs (
         organization_id, run_type, feed_id, connection_id,
@@ -378,16 +401,23 @@ async function createSyncRunWithClient(sql: DbClient, feedId: number): Promise<n
 export async function createSyncRun(
   feedId: number,
   _env: Env,
-  db?: DbClient
+  db?: DbClient,
+  // Defaults false so all four existing call sites (connect/routes, app-install,
+  // check-due-feeds, manage_feeds) keep persisting. Only an explicit opt-in is
+  // dry — a flag that defaulted the other way would silently stop real syncs.
+  opts?: { dryRun?: boolean }
 ): Promise<number | null> {
   const sql = db ?? getDb();
+  const dryRun = opts?.dryRun === true;
 
   try {
     if (db) {
-      return await createSyncRunWithClient(sql, feedId);
+      return await createSyncRunWithClient(sql, feedId, dryRun);
     }
 
-    return await sql.begin(async (tx) => createSyncRunWithClient(tx, feedId));
+    return await sql.begin(async (tx) =>
+      createSyncRunWithClient(tx, feedId, dryRun)
+    );
   } catch (error) {
     if (isUniqueViolation(error, 'idx_runs_active_sync_per_feed')) {
       logger.info(`[queue] Skipping run creation for feed ${feedId} - duplicate active sync run`);

--- a/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
+++ b/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
@@ -54,6 +54,8 @@ interface SeedRunOpts {
 	/** Defaults to 'auto' (worker-claimable). Set 'pending' for a human-approval run. */
 	approvalStatus?: "auto" | "pending" | "approved" | "rejected" | "expired";
 	createdAtAgoDays?: number;
+	/** runs.dry_run — the connector executes for real, the server persists nothing. */
+	dryRun?: boolean;
 }
 
 async function seedRun(opts: SeedRunOpts): Promise<number> {
@@ -74,10 +76,10 @@ async function seedRun(opts: SeedRunOpts): Promise<number> {
 	const rows = (await sql.unsafe(
 		`INSERT INTO runs (
        organization_id, run_type, feed_id, status, approval_status,
-       claimed_at, last_heartbeat_at, claimed_by, created_at
+       claimed_at, last_heartbeat_at, claimed_by, created_at, dry_run
      ) VALUES (
        $1, $2, $3, $4, $5,
-       ${claimInterval}, ${hbInterval}, 'test-worker', ${createdAt}
+       ${claimInterval}, ${hbInterval}, 'test-worker', ${createdAt}, $6
      )
      RETURNING id`,
 		[
@@ -86,6 +88,7 @@ async function seedRun(opts: SeedRunOpts): Promise<number> {
 			opts.feedId ?? null,
 			opts.status,
 			opts.approvalStatus ?? "auto",
+			opts.dryRun ?? false,
 		],
 	)) as unknown as Array<{ id: number | string }>;
 	return Number(rows[0].id);
@@ -607,5 +610,92 @@ describe("reapStaleRuns — atomic timeout + retry (lobu#862)", () => {
 		const byStatus = Object.fromEntries(counts.map((r) => [r.status, r.n]));
 		expect(byStatus.pending).toBe(3);
 		expect(byStatus.timeout).toBe(3);
+	});
+});
+
+/**
+ * A dry run (`runs.dry_run`) executes the connector for real but the server
+ * persists nothing. The reaper is the one path that can undo that AFTER the
+ * run was created: it re-queues a stale sync as a fresh run, and that INSERT
+ * does not carry `dry_run`. Without a guard, a dry run that lost its worker
+ * would come back as a REAL sync and persist everything the operator asked to
+ * only preview — silently, on a timer, with no one watching.
+ *
+ * The never-claimed path is the same class of bug in the other direction: it
+ * stamps the FEED failed, increments consecutive_failures, backs off
+ * next_run_at and can auto-pause. Those record the outcome of real syncs; a
+ * dry run must not degrade the real schedule.
+ *
+ * The non-dry controls for both live above ("a stale never-claimed sync is
+ * finalized without an immediate retry" and "a stale sync run gets timed out
+ * AND a retry queued in one statement") — without them these tests would pass
+ * against a reaper that had stopped working entirely.
+ */
+describe("reapStaleRuns — dry runs are reaped but never resurrected", () => {
+	test("a stale claimed dry sync is timed out and NOT retried as a real sync", async () => {
+		const feedId = 7171;
+		await seedFeed(feedId);
+		const dryId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "sync",
+			feedId,
+			dryRun: true,
+		});
+
+		const result = await reapStaleRuns();
+
+		// Reaped — a dry run still has to be finalized, it is real working state.
+		expect(result.reaped).toBe(1);
+		expect(await statusOf(dryId)).toBe("timeout");
+		// But never re-queued. This is THE assertion: a retry here would be a
+		// persisting sync the operator never asked for.
+		expect(result.retriesCreated).toBe(0);
+
+		const sql = getDb();
+		const requeued = (await sql`
+      SELECT id, dry_run FROM runs
+      WHERE feed_id = ${feedId} AND run_type = 'sync' AND status = 'pending'
+    `) as unknown as Array<{ id: number | string; dry_run: boolean }>;
+		expect(requeued).toHaveLength(0);
+	});
+
+	test("a stale never-claimed dry sync stamps no feed failure state", async () => {
+		const feedId = 7272;
+		await seedFeed(feedId);
+		const sql = getDb();
+		await sql`
+      UPDATE feeds
+      SET last_sync_status = 'success',
+          next_run_at = current_timestamp + INTERVAL '1 hour'
+      WHERE id = ${feedId}
+    `;
+		const [before] = (await sql`
+      SELECT last_sync_status, last_error, consecutive_failures, next_run_at, status
+      FROM feeds WHERE id = ${feedId}
+    `) as unknown as Array<Record<string, unknown>>;
+
+		const dryId = await seedRun({
+			status: "pending",
+			lastHeartbeatAgoSeconds: null,
+			runType: "sync",
+			feedId,
+			createdAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			dryRun: true,
+		});
+
+		const result = await reapStaleRuns();
+
+		expect(result.reaped).toBe(1);
+		expect(await statusOf(dryId)).toBe("timeout");
+
+		// Feed row is byte-identical: no 'failed' stamp, no failure increment,
+		// no backoff of next_run_at, no auto-pause.
+		const [after] = (await sql`
+      SELECT last_sync_status, last_error, consecutive_failures, next_run_at, status
+      FROM feeds WHERE id = ${feedId}
+    `) as unknown as Array<Record<string, unknown>>;
+		expect(after).toEqual(before);
 	});
 });

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -153,7 +153,7 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
           FROM stale_candidates c
           WHERE r.id = c.id
           RETURNING r.id, r.run_type, r.feed_id, r.connection_id, r.connector_key,
-                    r.connector_version, r.organization_id, c.stale_status
+                    r.connector_version, r.organization_id, r.dry_run, c.stale_status
         ),
         retries AS (
           INSERT INTO public.runs (
@@ -167,6 +167,12 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
           WHERE t.run_type = 'sync'
             AND t.stale_status IN ('claimed', 'running')
             AND t.feed_id IS NOT NULL
+            -- Never retry a dry run. This INSERT does not carry the dry_run
+            -- flag, so a retried dry run would come back as a REAL sync that
+            -- persists everything the operator asked to only preview. A dry
+            -- run is also an interactive one-shot — reaping it as 'timeout'
+            -- and letting the operator re-trigger is the correct outcome.
+            AND NOT t.dry_run
             AND NOT EXISTS (
               -- Look for an unrelated active sync run on the same feed.
               -- Exclude timed_out.id because in PostgreSQL the sibling
@@ -214,6 +220,10 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
           FROM timed_out t
           WHERE t.run_type = 'sync'
             AND t.stale_status = 'pending'
+            -- A never-claimed dry run must not stamp the feed failed, back off
+            -- next_run_at, or auto-pause — those record the outcome of REAL
+            -- syncs, which a dry run leaves untouched (see runs.dry_run).
+            AND NOT t.dry_run
             AND t.feed_id = f.id
           RETURNING f.id, f.consecutive_failures, f.status
         )
@@ -223,7 +233,12 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
           (SELECT count(*)::int FROM timed_out
             WHERE run_type = 'sync'
               AND stale_status IN ('claimed', 'running')
-              AND feed_id IS NOT NULL) AS sync_eligible,
+              AND feed_id IS NOT NULL
+              -- Same NOT dry_run predicate as the retries CTE. A dry run is
+              -- never eligible for retry, so counting it here would inflate
+              -- skippedRetries below and attribute the skip to "another
+              -- active sync run exists", which would be false.
+              AND NOT dry_run) AS sync_eligible,
           (SELECT coalesce(
              json_agg(json_build_object(
                'id', id,

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -429,7 +429,8 @@ async function handleReadFeed(
   }
 
   const runs = await sql`
-    SELECT id, status, items_collected, error_message, created_at, completed_at, checkpoint, connector_version
+    SELECT id, status, items_collected, error_message, created_at, completed_at, checkpoint, connector_version,
+           dry_run, dry_run_preview
     FROM runs
     WHERE feed_id = ${args.feed_id} AND run_type = 'sync'
     ORDER BY created_at DESC
@@ -937,10 +938,20 @@ async function handleTriggerFeed(
     return { error: `Feed is ${feed.status}, must be active to trigger sync` };
   }
 
-  const runId = await createSyncRun(args.feed_id, env);
+  const dryRun = args.dry_run === true;
+  const runId = await createSyncRun(args.feed_id, env, undefined, { dryRun });
   if (runId === null) {
     return { action: 'trigger_feed', message: 'Sync already pending or running for this feed' };
   }
 
-  return { action: 'trigger_feed', triggered: true, run_id: runId, feed_id: args.feed_id };
+  // `dry_run` is echoed only when true, and only because it was honoured. A
+  // caller cannot otherwise distinguish "ran dry" from "flag silently dropped
+  // and everything persisted", which is the one outcome that would matter.
+  return {
+    action: 'trigger_feed',
+    triggered: true,
+    run_id: runId,
+    feed_id: args.feed_id,
+    ...(dryRun ? { dry_run: true } : {}),
+  };
 }

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -596,13 +596,21 @@ async function applyTraits(
  * traits onto the resolved entity. Rules are loaded from the connector
  * definition (poll/sync path).
  */
-export async function applyEventAttributions(params: {
-  connectorKey: string;
-  connectionId?: number | null;
-  feedKey: string | null;
-  orgId: string;
-  items: BatchItem[];
-}): Promise<void> {
+export async function applyEventAttributions(
+  params: {
+    connectorKey: string;
+    connectionId?: number | null;
+    feedKey: string | null;
+    orgId: string;
+    items: BatchItem[];
+  },
+  // Optional transaction handle, same contract the webhook path already uses via
+  // resolveEventAttributionsForItems: the entity match/create/trait writes land
+  // on the caller's tx instead of the singleton. The sync dry-run path threads
+  // its rolled-back tx here so auto-created entities disappear with the events
+  // that referenced them. Omitted → getDb().
+  sql?: DbClient
+): Promise<void> {
   if (!params.feedKey || params.items.length === 0) return;
 
   const rulesByKind = await loadEventAttributionRules({
@@ -612,13 +620,16 @@ export async function applyEventAttributions(params: {
   });
   if (Object.keys(rulesByKind).length === 0) return;
 
-  await resolveLinksByKind({
-    connectorKey: params.connectorKey,
-    connectionId: params.connectionId,
-    orgId: params.orgId,
-    items: params.items,
-    rulesByKind,
-  });
+  await resolveLinksByKind(
+    {
+      connectorKey: params.connectorKey,
+      connectionId: params.connectionId,
+      orgId: params.orgId,
+      items: params.items,
+      rulesByKind,
+    },
+    sql ?? getDb()
+  );
 }
 
 /**

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -62,6 +62,16 @@ type DbClient = ReturnType<typeof getDb>;
 type SqlFragment = ReturnType<DbClient>;
 
 /**
+ * Caps on `runs.dry_run_preview`. A dry run exists so an operator can see the
+ * SHAPE of what a connector would ingest; it is not a second copy of `events`,
+ * and an uncapped preview of a feed that emits thousands of long-bodied items
+ * would be a large jsonb write on every batch. `total` in the stored preview is
+ * always the true count, so truncation is visible rather than silent.
+ */
+const DRY_RUN_PREVIEW_LIMIT = 50;
+const DRY_RUN_CONTENT_CHARS = 500;
+
+/**
  * Atomic terminal-state transition guarded on `status = 'running' AND
  * claimed_by = worker_id`. If the run was already finalized by another path
  * (e.g. the gateway reaped it on a timeout and the worker reports in late) or
@@ -222,6 +232,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 		// Look up run details for event columns
 		const runRows = (await sql`
     SELECT r.feed_id, r.connection_id, r.connector_key, r.organization_id,
+           r.dry_run,
            f.feed_key, f.entity_ids
     FROM runs r
     LEFT JOIN feeds f ON f.id = r.feed_id
@@ -231,6 +242,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 			connection_id: number | null;
 			connector_key: string;
 			organization_id: string;
+			dry_run: boolean;
 			feed_key: string | null;
 			entity_ids: number[] | null;
 		}>;
@@ -242,34 +254,83 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 		const run = runRows[0];
 		const entityIds = parsePgNumberArray(run.entity_ids);
 
-		// Connector-emitted inline attachments (e.g. whatsapp.local voice notes)
-		// come over the wire as base64 in `attachment.data`. Materialize each into
-		// the ArtifactStore before the row hits events.attachments — the events
-		// table is not a binary store. Audio attachments are queued for async
-		// transcription after insert.
-		const { items: materializedItems, pendingTranscriptions } =
-			await materializeInlineAttachments(batch.items);
-		batch.items = materializedItems as typeof batch.items;
+		// A dry run executes the connector for real — same code, same credentials,
+		// same validation, the same INSERTs — and then throws the writes away by
+		// rolling back. Read from the run row rather than the request so a worker
+		// cannot elect to skip writes, and so any replica handling this callback
+		// reaches the same decision.
+		//
+		// Why rollback rather than a guard on each write. The set of things a dry
+		// run must NOT do is open-ended — it grows every time anyone adds a write
+		// to this path, and nothing makes them notice. The set it must KEEP is
+		// closed: the preview, and that's it. So the code enumerates the closed
+		// set and lets the transaction cover the open one. A write added below
+		// tomorrow is rolled back without anyone remembering this feature exists.
+		//
+		// The bonus is the point of the feature: because the real INSERTs actually
+		// run, a dry run answers "would this sync work?" honestly. A constraint
+		// violation, a bad enum or a NOT NULL surfaces exactly as it would on the
+		// real path. Skipping the insert would have reported success on data that
+		// could never land.
+		//
+		// What rollback does NOT cover is anything that leaves Postgres, and those
+		// are guarded individually below (marked ESCAPES THE TX). That is a
+		// mechanically checkable category — "does this call escape the tx?" — not
+		// a list someone has to keep in their head.
+		const isDry = run.dry_run === true;
+		const dryPreview: Array<Record<string, unknown>> = [];
 
-		// Resolve or create entities declared via eventKinds[kind].attributions
-		// before inserting events. One query per (entityType, matchField) per
-		// batch — cheap compared to the per-event inserts that follow.
-		await applyEventAttributions({
-			connectorKey: run.connector_key,
-			connectionId: run.connection_id,
-			feedKey: run.feed_key,
-			orgId: run.organization_id,
-			items: batch.items,
-		});
+		// The whole batch, parameterised on a DB handle. The real path passes the
+		// singleton and behaves exactly as before (statement-per-autocommit — this
+		// refactor deliberately does not put production's hot path inside one long
+		// transaction). The dry path passes a tx that is rolled back.
+		const ingestBatch = async (db: DbClient) => {
+			// Connector-emitted inline attachments (e.g. whatsapp.local voice notes)
+			// come over the wire as base64 in `attachment.data`. Materialize each into
+			// the ArtifactStore before the row hits events.attachments — the events
+			// table is not a binary store. Audio attachments are queued for async
+			// transcription after insert.
+			//
+			// ESCAPES THE TX: this uploads a blob to the ArtifactStore, which no
+			// Postgres rollback can retract. Because the blob is written before the
+			// row that would reference it, a dry run doing this would leave an
+			// orphaned artifact behind — storage that quietly accumulates.
+			let pendingTranscriptions: Awaited<
+				ReturnType<typeof materializeInlineAttachments>
+			>["pendingTranscriptions"] = [];
+			if (!isDry) {
+				const { items: materializedItems, pendingTranscriptions: pending } =
+					await materializeInlineAttachments(batch.items);
+				batch.items = materializedItems as typeof batch.items;
+				pendingTranscriptions = pending;
+			}
 
-		let totalItems = 0;
-		const rejectedItems: Array<{
-			id: string;
-			semantic_type?: string;
-			errors: string[];
-		}> = [];
+			// Resolve or create entities declared via eventKinds[kind].attributions
+			// before inserting events. One query per (entityType, matchField) per
+			// batch — cheap compared to the per-event inserts that follow.
+			//
+			// Runs on a dry run too, against `db`: it creates entity rows, and those
+			// roll back with everything else. Running it is what makes the inserts
+			// below realistic — events carry the entity ids it resolves.
+			await applyEventAttributions(
+				{
+					connectorKey: run.connector_key,
+					connectionId: run.connection_id,
+					feedKey: run.feed_key,
+					orgId: run.organization_id,
+					items: batch.items,
+				},
+				db
+			);
 
-		for (const item of batch.items) {
+			let totalItems = 0;
+			const rejectedItems: Array<{
+				id: string;
+				semantic_type?: string;
+				errors: string[];
+			}> = [];
+
+			for (const item of batch.items) {
 			try {
 				const itemOriginType = item.origin_type ?? null;
 				const itemSemanticType =
@@ -347,6 +408,15 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 					},
 					{
 						onConflictUpdate: true,
+						// Dry path only: the tx that gets rolled back — the INSERT
+						// genuinely executes, so every constraint, trigger and NOT NULL
+						// is exercised for real. The real path must NOT pass `db` even
+						// though it equals the singleton: a caller-supplied `sql` makes
+						// insertEvent skip its advisory-lock dedup transaction (the
+						// caller's tx is assumed to be the atomic scope), and that lock
+						// is what serializes concurrent ingests of the same
+						// (connection_id, origin_id) across replicas.
+						sql: isDry ? db : undefined,
 						afterPersist: async (persisted, tx) => {
 							for (const [draftIndex, draft] of (
 								item.behavior_signals ?? []
@@ -370,10 +440,20 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 						},
 					}
 				);
-				await dispatchBehaviorRunsBestEffort(activations);
+				// ESCAPES THE TX: this dispatches real Behavior runs to the worker
+				// fleet. The activation ROWS roll back with the tx, but a dispatched
+				// agent run has already left the database — it would run against, and
+				// react to, an event that is about to cease to exist.
+				if (!isDry) {
+					await dispatchBehaviorRunsBestEffort(activations);
+				}
 				if (inserted) {
 					totalItems++;
-					if (entityIds.length > 0) {
+					// ESCAPES THE TX: detached (`.catch(() => {})`) and writes through
+					// the getDb() singleton, not `db`, so its writes would commit
+					// independently of the rollback — and race it, since nothing awaits
+					// them.
+					if (entityIds.length > 0 && !isDry) {
 						autoLinkEvent({
 							eventId: Number(inserted.id),
 							entityIds,
@@ -382,6 +462,27 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 							organizationId: run.organization_id,
 						}).catch(() => {});
 					}
+					// Captured after a successful insert, so the preview describes rows
+					// that really did land (and would land again on a real sync) rather
+					// than rows we merely hoped would.
+					if (isDry && dryPreview.length < DRY_RUN_PREVIEW_LIMIT) {
+						dryPreview.push({
+							origin_id: item.id,
+							title: item.title,
+							semantic_type: itemSemanticType,
+							payload_type: item.payload_type,
+							occurred_at: item.occurred_at,
+							author_name: item.author_name,
+							source_url: item.source_url,
+							// Bounded: a preview is for eyeballing shape, and some
+							// connectors emit very large bodies.
+							content_preview:
+								typeof item.payload_text === "string"
+									? item.payload_text.slice(0, DRY_RUN_CONTENT_CHARS)
+									: null,
+							attachment_count: item.attachments?.length ?? 0,
+						});
+					}
 				}
 			} catch (err) {
 				console.error("[stream] Insert failed for item", item.id, ":", err);
@@ -389,24 +490,105 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 			}
 		}
 
-		// Kick off background transcription for any audio attachments
-		// materialized above. Runs detached — never blocks the stream-batch ack.
-		triggerAudioTranscriptions(run.organization_id, pendingTranscriptions);
+			// ESCAPES THE TX: transcription is an external, paid API call, and it
+			// is fired detached so nothing awaits it. `pendingTranscriptions` is
+			// already empty on a dry run (nothing was materialized above), but the
+			// guard stays so this cannot start costing money if materialization
+			// ever grows a dry path.
+			if (!isDry) {
+				triggerAudioTranscriptions(run.organization_id, pendingTranscriptions);
+			}
 
-		// Update feed + run checkpoint if provided (so mid-run state like QR codes
-		// surface in UI via recent_runs[0].checkpoint before the run completes).
-		if (batch.checkpoint) {
-			if (run.feed_id) {
-				await sql`
+			// Update feed + run checkpoint if provided (so mid-run state like QR
+			// codes surface in UI via recent_runs[0].checkpoint before the run
+			// completes). No dry-run guard: on a dry run these write to the tx and
+			// vanish with it, which is exactly right — advancing the feed checkpoint
+			// would silently change what the NEXT real sync collects, making the
+			// rows this run previewed unreachable.
+			if (batch.checkpoint) {
+				if (run.feed_id) {
+					await db`
       UPDATE feeds
-      SET checkpoint = ${sql.json(batch.checkpoint)},
+      SET checkpoint = ${db.json(batch.checkpoint)},
           updated_at = current_timestamp
       WHERE id = ${run.feed_id}
     `;
+				}
+				await db`
+      UPDATE runs
+      SET checkpoint = ${db.json(batch.checkpoint)}
+      WHERE id = ${batch.run_id}
+    `;
 			}
+
+			return { totalItems, rejectedItems };
+		};
+
+		// The real path: singleton handle, autocommit per statement, byte-for-byte
+		// the behaviour that shipped before dry runs existed.
+		//
+		// The dry path: the same closure against a transaction, then an unconditional
+		// rollback. postgres.js rolls back when the `begin` callback throws, so the
+		// throw IS the mechanism — a sentinel, not an error condition. Catching only
+		// that exact object means a genuine failure inside the batch still propagates
+		// to the 500 handler below instead of being swallowed as "rolled back fine".
+		const DRY_RUN_ROLLBACK = Symbol("dry-run-rollback");
+		let outcome: Awaited<ReturnType<typeof ingestBatch>> | null = null;
+		if (isDry) {
+			try {
+				await sql.begin(async (tx) => {
+					outcome = await ingestBatch(tx);
+					throw DRY_RUN_ROLLBACK;
+				});
+			} catch (err) {
+				if (err !== DRY_RUN_ROLLBACK) throw err;
+			}
+		} else {
+			outcome = await ingestBatch(sql);
+		}
+		// Unreachable: ingestBatch either assigns `outcome` or throws (and a throw
+		// that is not the rollback sentinel is rethrown above). Asserted rather
+		// than defaulted to {totalItems: 0} — TypeScript cannot see the assignment
+		// through the transaction closure, and a silent zero here would report
+		// "ingested nothing" for a batch that may well have ingested plenty.
+		if (outcome === null) {
+			throw new Error("[stream] batch completed without an outcome");
+		}
+		const { totalItems, rejectedItems } = outcome as Awaited<
+			ReturnType<typeof ingestBatch>
+		>;
+
+		if (isDry) {
+			// Written AFTER the rollback, on the singleton — this is the one thing a
+			// dry run keeps, so it must not be inside the transaction it discards.
+			// Accumulates across batches: a sync streams many, and the preview should
+			// describe the whole run rather than only its last chunk. The per-batch
+			// JS cap only bounds one request's payload, so the stored array is
+			// re-capped here — without the ordinality slice a long sync would grow
+			// the preview by up to DRY_RUN_PREVIEW_LIMIT per batch, unbounded.
+			// `total` counts everything that would have been ingested even past the
+			// cap, so the number stays honest when `items` is truncated.
 			await sql`
       UPDATE runs
-      SET checkpoint = ${sql.json(batch.checkpoint)}
+      SET dry_run_preview = jsonb_build_object(
+            'items',
+            (SELECT COALESCE(jsonb_agg(e.value ORDER BY e.ord), '[]'::jsonb)
+             FROM jsonb_array_elements(
+               COALESCE(dry_run_preview -> 'items', '[]'::jsonb)
+                 || ${sql.json(dryPreview)}::jsonb
+             ) WITH ORDINALITY AS e(value, ord)
+             WHERE e.ord <= ${DRY_RUN_PREVIEW_LIMIT}),
+            'total',
+            COALESCE((dry_run_preview ->> 'total')::int, 0) + ${totalItems},
+            'truncated',
+            LEAST(
+              jsonb_array_length(
+                COALESCE(dry_run_preview -> 'items', '[]'::jsonb)
+                  || ${sql.json(dryPreview)}::jsonb
+              ),
+              ${DRY_RUN_PREVIEW_LIMIT}
+            ) < COALESCE((dry_run_preview ->> 'total')::int, 0) + ${totalItems}
+          )
       WHERE id = ${batch.run_id}
     `;
 		}
@@ -414,6 +596,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 		return c.json({
 			batches_received: 1,
 			total_items: totalItems,
+			...(isDry && { dry_run: true }),
 			...(rejectedItems.length > 0 && { rejected_items: rejectedItems }),
 		});
 	} catch (err: unknown) {
@@ -457,6 +640,14 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 		// completion resurrects a reaped run and the feed/auth bookkeeping below
 		// double-applies (consecutive_failures, items_collected, next_run_at,
 		// auth_data). The failed path also stamps exit diagnostics.
+		//
+		// The checkpoint write is CASE-guarded on `dry_run` in SQL (rather than
+		// read-then-branch in JS) so the guard rides the same atomic UPDATE as the
+		// terminal transition: a dry run's row never records the connector's final
+		// checkpoint, matching the streamContent guard on the mid-run write.
+		const dryGuardedCheckpoint = sql`
+          checkpoint = CASE WHEN dry_run THEN checkpoint
+                       ELSE COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint) END`;
 		const updatedRuns = (await finalizeRun(sql, {
 			runId: req.run_id,
 			workerId: req.worker_id,
@@ -465,20 +656,19 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 				req.status === "failed"
 					? sql`,
           items_collected = ${req.items_collected ?? 0},
-          error_message = ${req.error_message ?? null},
-          checkpoint = COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint),
+          error_message = ${req.error_message ?? null},${dryGuardedCheckpoint},
           output_tail = ${req.output_tail ?? null},
           exit_code = ${req.exit_code ?? null},
           exit_signal = ${req.exit_signal ?? null},
           exit_reason = ${req.exit_reason ?? null}`
 					: sql`,
           items_collected = ${req.items_collected ?? 0},
-          error_message = ${req.error_message ?? null},
-          checkpoint = COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint)`,
-			returning: sql`feed_id, connection_id`,
+          error_message = ${req.error_message ?? null},${dryGuardedCheckpoint}`,
+			returning: sql`feed_id, connection_id, dry_run`,
 		})) as unknown as Array<{
 			feed_id: number | null;
 			connection_id: number | null;
+			dry_run: boolean;
 		}>;
 
 		if (updatedRuns.length === 0) {
@@ -499,8 +689,28 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 		// Update the feed's sync state
 		const runRows = updatedRuns;
 		const feedId = runRows[0]?.feed_id;
+		const isDry = runRows[0]?.dry_run === true;
 
-		if (feedId) {
+		// Never for a dry run: this block stamps last_sync_at/status, resets or
+		// increments consecutive_failures, adds items_collected, ADVANCES THE FEED
+		// CHECKPOINT, and moves next_run_at (with backoff/auto-pause on failure).
+		// Every one of those durably changes what the next REAL sync does or how
+		// the feed reports its last real outcome — exactly the state a dry run
+		// exists to leave untouched.
+		//
+		// Why this stays an explicit guard while streamContent uses a rolled-back
+		// transaction instead. Two reasons, and they are the reasons — not an
+		// oversight to be tidied up later:
+		//
+		//  1. This function's write set is closed and cannot grow the way an
+		//     item-ingest loop grows: it finalizes one run row and stamps one feed
+		//     row. One guard covers one block; there is no open set to lose track of.
+		//  2. The keep/discard sets are INTERLEAVED. A dry run must still finalize
+		//     its own run row — that is real working state, and finalizeRun's whole
+		//     purpose is that the terminal transition is atomic. Rolling back here
+		//     would mean lifting the run update out of the transaction and giving up
+		//     that guarantee to buy uniformity. Not a trade worth making.
+		if (feedId && !isDry) {
 			const feedRows = (await sql`
       SELECT schedule, timezone FROM feeds WHERE id = ${feedId}
     `) as unknown as Array<{
@@ -591,7 +801,14 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 			}
 		}
 
-		// Persist refreshed browser auth data on the auth profile
+		// Persist refreshed browser auth data on the auth profile.
+		//
+		// Deliberately NOT gated on dry_run: this is credential liveness, not
+		// ingested data. Session-state connectors (browser cookies, Baileys creds)
+		// rotate their tokens on every real connect — the connector genuinely ran,
+		// so discarding the rotation would leave the profile holding invalidated
+		// credentials and break the next REAL sync. "Persist nothing" means the
+		// workspace's data, never the auth state the run consumed.
 		const connectionId = runRows[0]?.connection_id;
 		if (req.status === "success" && req.auth_update && connectionId) {
 			const connectionRows = (await sql`


### PR DESCRIPTION
## Summary

- Adds `runs.dry_run`: a feed sync that executes the connector **for real** and persists nothing. This is the only way to test a connector whose credentials are OAuth or API-key based — those are durable stored credentials that never leave the gateway (`packages/server/AGENTS.md`), so `lobu connector run` legitimately refuses them and the sync can only happen server-side. Until now the only server-side path was a real sync, which really writes: into append-only `events`, plus entities, artifacts, and an advanced checkpoint. So there was no way to try an OAuth connector without permanently mutating the workspace.
- The dry path does **not** skip the writes. It runs the identical ingest code against a transaction and rolls back. The set of things a dry run must not do is open-ended — it grows every time anyone adds a write to the ingest path — while the set it must keep is closed (the preview, and the run row's own lifecycle). Enumerating the closed set and letting the transaction cover the open one means a write added later is handled without its author knowing this feature exists.
- That also makes the answer trustworthy: because the real INSERTs execute, a dry run surfaces a constraint violation or bad cast exactly as the real path would, instead of previewing rows that could never land.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` (167 pass), targeted integration suites
- [x] Bug fix: red→fix→green (mutation evidence below)
- [ ] If bot behavior: n/a

### Live e2e — real connector, real worker, real ingest path

Booted `make dev` (embedded Postgres, so the migration applied through the **production** migration path and is recorded in `schema_migrations` as `20260731020000` — vitest uses a different runner). Seeded an `rss` feed against `hnrss.org`. Same feed, same connector, same worker; one run dry, one not:

| | dry run | control (non-dry) |
|---|---|---|
| `events` | **0** | **20** |
| feed `checkpoint` | `E2E-ORIGINAL` (unchanged) | advanced — real cursor, 20 item ids |
| feed `last_sync_status` | `success` (unchanged) | stamped |
| feed `items_collected` | **0** | **20** |
| run `checkpoint` | `NULL` | populated |
| `dry_run_preview` | 20 items, `truncated=false` | `NULL` |

The dry run's own row records `items_collected=20`, so the connector genuinely executed — this is not a path that quietly did nothing.

### Mutation evidence

| mutation | result |
|---|---|
| remove `throw DRY_RUN_ROLLBACK` (dry run commits) | RED — "writes no events" fails |
| restore the old skip-the-insert design | RED — 2 tests fail, incl. the DB-failure test |
| remove `AND NOT t.dry_run` from the retries CTE | RED — "never retried as a real sync" fails |
| remove `AND NOT t.dry_run` from the pending-feed CTE | RED — feed-failure-state test fails |
| remove the SQL preview re-cap | RED — cross-batch cap test fails |

## Notes

### Two bugs `make review-fix` caught in my own work — worth calling out

1. **Advisory-lock bypass on the real path.** I passed `sql: db` to `insertEvent` unconditionally, reasoning it was a no-op since `db` is the singleton on the real path. It is not: `insert-event.ts:481` guards on `!options.sql`, so supplying the handle at all makes `insertEvent` skip its advisory-lock dedup — the lock that serializes concurrent ingests of the same `(connection_id, origin_id)` across replicas. That would have re-opened the duplicate-row race in the ingest hot path. Now `sql: isDry ? db : undefined`.
2. **Preview cap was unbounded across batches.** The JS `DRY_RUN_PREVIEW_LIMIT` bounded one request's array; the SQL then concatenated without limit, so a long sync grew `dry_run_preview.items` by up to 50 per batch — violating the cap the constant, the migration comment and the tool description all promise. Re-capped in SQL with an ordinality slice; `truncated` computed from the capped length.

Neither was caught by the test suite or two clean `pre-pr` runs.

### Known untested invariant

Nothing pins `sql: isDry ? db : undefined`. Single-threaded behaviour is identical with or without the advisory lock, so only a concurrency test could catch a regression here. The reason it must stay is documented at the call site. Flagging rather than leaving it silent.

### Deliberate asymmetry

`completeWorkerJob` keeps an explicit `!isDry` guard instead of the rollback, for two reasons documented in the code: its write set is closed (one run row, one feed row) and cannot grow like an item-ingest loop; and its keep/discard sets are interleaved — a dry run must still finalize its own run row, and `finalizeRun` exists to make that transition atomic. Rolling back there would mean lifting that update out of the transaction to buy uniformity.

### Scope note

`lobu connector run` gains no `--dry-run` flag: it already persists nothing (it never reaches the server's ingest path). Its stale header comment predicted "a separate trigger_feed dry_run path, not yet wired" — that comment and the OAuth-refusal error message are updated to point at what now exists.

### Reviewer availability

`make review-fix` was run via `REVIEWER_CLI=claude` (Fable). The default codex path is unavailable — usage limit until Aug 5.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->