### PR TITLE
fix(server): stop the catalog scan warning about files that were never connectors

### DIFF
--- a/packages/server/src/utils/__tests__/connector-metadata-resolution.test.ts
+++ b/packages/server/src/utils/__tests__/connector-metadata-resolution.test.ts
@@ -20,7 +20,10 @@ import { join } from 'node:path';
 import { createConnectorCompiler } from '@lobu/connector-worker/compile';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { formatMetadataExtractionError } from '../compiler-core';
-import { extractConnectorMetadata } from '../connector-compiler';
+import {
+  extractConnectorMetadata,
+  NO_CONNECTOR_RUNTIME_ERROR,
+} from '../connector-compiler';
 
 const CONNECTOR_SOURCE = `
 import { ConnectorRuntime } from '@lobu/connector-sdk';
@@ -116,4 +119,42 @@ describe('formatMetadataExtractionError', () => {
     );
     expect(formatted).not.toContain('npm install');
   });
+});
+
+/**
+ * `connector-catalog` routes "file exports no ConnectorRuntime" outcomes to
+ * debug instead of warn by matching NO_CONNECTOR_RUNTIME_ERROR against the
+ * error message — the throw happens in a subprocess and crosses back as
+ * `process.send({ error: error.message })`, so a string is the only channel.
+ *
+ * This pins the coupling, not the wording: the runner interpolates the same
+ * constant, so rewording it moves both sides together and stays green. What
+ * turns it red is breaking the coupling — replacing the
+ * `${JSON.stringify(NO_CONNECTOR_RUNTIME_ERROR)}` interpolation with a
+ * hardcoded literal — at which point the catalog stops recognising its own
+ * sentinel and every not-a-connector file silently routes back to `warn`.
+ */
+describe('non-connector files are identifiable, not just failures', () => {
+  test('a module with no ConnectorRuntime rejects with exactly NO_CONNECTOR_RUNTIME_ERROR', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'lobu-nonconnector-'));
+    try {
+      const modulePath = join(dir, 'support_module.ts');
+      // Shaped like the real offenders: a plain support module that exports
+      // helpers and no class with sync()/execute().
+      writeFileSync(
+        modulePath,
+        'export const NAMESPACES = ["github"];\n' +
+          'export function normalize(v: string) { return v.toLowerCase(); }\n'
+      );
+
+      const { compileConnectorFromFile } = createConnectorCompiler();
+      const compiled = await compileConnectorFromFile(modulePath);
+
+      await expect(extractConnectorMetadata(compiled)).rejects.toThrow(
+        NO_CONNECTOR_RUNTIME_ERROR
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30_000);
 });

--- a/packages/server/src/utils/connector-catalog.ts
+++ b/packages/server/src/utils/connector-catalog.ts
@@ -8,7 +8,10 @@ import {
 } from "@lobu/connector-worker/compile";
 import { getErrorMessage } from "@lobu/core";
 import { getConnectorCloudAvailability } from "./connector-cloud-gate";
-import { extractConnectorMetadata } from "./connector-compiler";
+import {
+	extractConnectorMetadata,
+	NO_CONNECTOR_RUNTIME_ERROR,
+} from "./connector-compiler";
 import logger from "./logger";
 
 const DEFAULT_CONNECTOR_DIR_CANDIDATES = [
@@ -238,10 +241,27 @@ async function extractConnectorCatalogMetadata(
 		metadataCache.set(filePath, { mtimeMs: fileStat.mtimeMs, value });
 		return value;
 	} catch (error) {
-		logger.warn(
-			{ file_path: filePath, error: getErrorMessage(error) },
-			"Skipping connector catalog entry after metadata extraction failed",
-		);
+		const message = getErrorMessage(error);
+		// "No ConnectorRuntime class" is the expected outcome for the support
+		// modules that live alongside connectors in the same directory (see
+		// NO_CONNECTOR_RUNTIME_ERROR): the scan compiles every `.ts` it finds, so
+		// discovering that a file is not a connector is normal control flow, and
+		// warning on it made a first `lobu run` print seven "metadata extraction
+		// failed" lines that read as a broken install. Real failures — a compile
+		// error, a missing connector SDK — still warn, because those DO mean a
+		// connector the user expects is missing.
+		const notAConnector = message.includes(NO_CONNECTOR_RUNTIME_ERROR);
+		if (notAConnector) {
+			logger.debug(
+				{ file_path: filePath },
+				"Skipping catalog entry: file exports no ConnectorRuntime",
+			);
+		} else {
+			logger.warn(
+				{ file_path: filePath, error: message },
+				"Skipping connector catalog entry after metadata extraction failed",
+			);
+		}
 		metadataCache.set(filePath, { mtimeMs: fileStat.mtimeMs, value: null });
 		return null;
 	}

--- a/packages/server/src/utils/connector-compiler.ts
+++ b/packages/server/src/utils/connector-compiler.ts
@@ -52,6 +52,23 @@ export interface ConnectorMetadata {
   supportsExecute?: boolean;
 }
 
+/**
+ * Emitted when a compiled file exports no ConnectorRuntime class.
+ *
+ * This is the "it isn't a connector" signal, not a malfunction: the catalog
+ * scan compiles every `.ts` in the connectors directory, and that directory
+ * legitimately also holds support modules (identity modules, egress guards,
+ * behavior-event definitions) which were never meant to be connectors.
+ *
+ * It is a shared constant rather than two copies of a sentence because the
+ * throw happens inside CONNECTOR_RUNNER_CODE — a subprocess — and comes back
+ * over `process.send({ error: error.message })`. A string is the only channel
+ * available, so the two sides are pinned to one exported literal instead of
+ * matching prose that a later reword would silently desynchronise.
+ */
+export const NO_CONNECTOR_RUNTIME_ERROR =
+  "No ConnectorRuntime class found in compiled code. Expected a class with sync() and execute() methods.";
+
 const CONNECTOR_RUNNER_CODE = `
 import { pathToFileURL } from 'node:url';
 
@@ -86,9 +103,7 @@ async function main() {
     }
 
     if (!RuntimeClass) {
-      throw new Error(
-        'No ConnectorRuntime class found in compiled code. Expected a class with sync() and execute() methods.'
-      );
+      throw new Error(${JSON.stringify(NO_CONNECTOR_RUNTIME_ERROR)});
     }
 
     const instance = new RuntimeClass();


### PR DESCRIPTION
## Summary

- A first `lobu run` on a freshly scaffolded project printed **seven** `Metadata extraction failed: No ConnectorRuntime class found` warnings before the server had done anything wrong. Found while running the project-variant matrix against the published `@lobu/cli@14.8.0`.
- Cause: `collectConnectorSourceFiles` treats every `.ts` in the connectors directory as a connector candidate, and that directory also holds support modules that were never connectors — `connector-identity-module.ts`, `db-egress-guard.ts`, `*-identity.ts`, `*-behavior-events.ts`.
- Discovering that a file is not a connector is normal control flow for a directory scan, and the code already knew it: the `CatalogManifest` comment records `null` as *"file carries no ConnectorRuntime class (utility/index file)"*. Only the log disagreed. That outcome moves to `debug`; real failures (compile error, unresolvable connector SDK) still `warn`, because those DO mean a connector the user expects is missing.

**Behaviour is unchanged** — same files skipped, same `null` cached, same catalog served. Only the log level moves.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bunx vitest run src/utils/__tests__/connector-metadata-resolution.test.ts` — 6 passed
- [x] Bug fix: red→green below
- [ ] If bot behavior: n/a

### Red → green

The guard is the shared `NO_CONNECTOR_RUNTIME_ERROR` constant. Breaking the coupling — replacing the runner's `${JSON.stringify(NO_CONNECTOR_RUNTIME_ERROR)}` interpolation with a hardcoded literal — unroutes the match and restores the warnings:

```
RED (runner throws a hardcoded literal instead of the constant):
  × non-connector files are identifiable > a module with no ConnectorRuntime
    rejects with exactly NO_CONNECTOR_RUNTIME_ERROR   60ms
  Tests  1 failed | 5 passed (6)

GREEN (restored):
  Tests  6 passed (6)
```

Note on what that test does **not** buy, stated because the obvious reading is wrong: rewording the constant is safe and stays green, since the runner interpolates the same constant and both sides move together (verified by mutation). What it catches is the coupling being broken.

## Notes

### Why a string sentinel rather than a typed error

The throw happens inside `CONNECTOR_RUNNER_CODE`, which runs in a **subprocess** and reports back via `process.send({ error: error.message })`. A string is the only channel that exists, so subclassing isn't available. Pinning both sides to one exported literal is the next best thing: a later reword moves them together instead of silently unrouting the match, and the coupling is greppable.

### Deliberately out of scope

`packages/connector-worker/src/executor/child-runner.ts:530` carries a similar but distinct sentence. That is a different subprocess in a different package on the **execute** path — the catalog never sees it, and its failure there is a real error, not a discovery outcome. Unifying them would widen this branch for no behavioural gain.

### Reviewer availability

`make review-fix` was run via `REVIEWER_CLI=claude` (Fable); the default codex path is unavailable until Aug 5 (usage limit).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->