### PR TITLE
fix(server): make the classification engine reachable by agents

### DIFF
--- a/packages/core/src/contracts/tools/manage-classifiers.ts
+++ b/packages/core/src/contracts/tools/manage-classifiers.ts
@@ -9,7 +9,8 @@ export const ManageClassifiersSchema = Type.Object({
     [
       // Template CRUD
       Type.Literal("create", {
-        description: "Create a classifier (must belong to a Behavior).",
+        description:
+          "Create a classifier. Org-level by default; pass behavior_id to scope it to one Behavior.",
       }),
       Type.Literal("list", { description: "List classifiers with filters." }),
       Type.Literal("generate_embeddings", {
@@ -40,7 +41,7 @@ export const ManageClassifiersSchema = Type.Object({
   behavior_id: Type.Optional(
     Type.String({
       description:
-        "[create] Persisted Behavior ID (`behavior_id`) returned by manage_behaviors (numeric string; required)",
+        "[create] Persisted Behavior ID returned by manage_behaviors (numeric string). OMIT for an org-level classifier — only those are matched by `apply` and the reconciliation job. Pass it only to scope the classifier to a single Behavior.",
     })
   ),
   classifier_id: Type.Optional(

--- a/packages/server/src/__tests__/integration/classifiers/classifiers-agent-reachable.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifiers-agent-reachable.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The classification engine was reachable in principle and unreachable in
+ * practice. Two independent gaps, both pinned here.
+ *
+ * 1. `create` REQUIRED `behavior_id` and inserted it as `classify_facet.watcher_id`.
+ *    Every engine template lookup in `classification-query.ts` filters
+ *    `cf.watcher_id IS NULL`. So every classifier creatable
+ *    through the tool or the ClientSDK was invisible to the engine forever —
+ *    `apply` and the reconciliation cron would both report a clean, successful,
+ *    zero-result run. Measured in prod 2026-07-31: the `buremba` org held 5
+ *    classifiers, all Behavior-owned, and 0 classifications; the org with
+ *    working classifications held 23, all `watcher_id IS NULL` and predating the
+ *    required-`behavior_id` rule.
+ *
+ * 2. `apply` existed on the MCP tool but not in the agent-facing SDK, so no
+ *    agent could call the one verb that classifies without an entity link.
+ *
+ * A Behavior-owned classifier is still a legitimate thing (Behavior-scoped
+ * extraction config); it is simply not what the embedding engine matches. That
+ * distinction is asserted rather than assumed, so nobody "fixes" this later by
+ * loosening the engine's filter.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parsePgTextArray } from '../../../db/client';
+import { METHOD_METADATA } from '../../../sandbox/method-metadata';
+import { buildClassifiersNamespace } from '../../../sandbox/namespaces/classifiers';
+import { manageClassifiers } from '../../../tools/admin/manage_classifiers';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestAgent,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const DIM = 768;
+
+function basisVector(slot: number): number[] {
+  const v = new Array<number>(DIM).fill(0);
+  v[slot] = 1;
+  return v;
+}
+
+/** Supplying embeddings inline keeps `create` off the embedding service. */
+const ATTRIBUTE_VALUES = {
+  positive: { description: 'Positive', examples: ['great'], embedding: basisVector(0) },
+  negative: { description: 'Negative', examples: ['awful'], embedding: basisVector(1) },
+};
+
+function adminCtx(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'owner',
+    isAuthenticated: true,
+    tokenType: 'oauth',
+    scopedToOrg: false,
+    scopes: ['mcp:admin'],
+  } as ToolContext;
+}
+
+describe('classifiers reachable by agents', () => {
+  it('creates an engine-matchable classifier when no Behavior owns it, and applies it', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Reachable Org' });
+    const user = await createTestUser({ email: 'reachable@test.com' });
+    const ctx = adminCtx(org.id, user.id);
+    const sql = getTestDb();
+
+    const created = await manageClassifiers(
+      {
+        action: 'create',
+        slug: 'agent-made',
+        name: 'Agent made',
+        attribute_key: 'agent-made',
+        attribute_values: ATTRIBUTE_VALUES,
+        min_similarity: 0.5,
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(created.success).toBe(true);
+
+    // The whole point: no owning Behavior means the engine can see it.
+    const rows = (await sql`
+      SELECT watcher_id, status FROM classify_facet
+      WHERE slug = 'agent-made' AND organization_id = ${org.id}
+    `) as unknown as Array<{ watcher_id: number | null; status: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].watcher_id).toBeNull();
+    expect(rows[0].status).toBe('active');
+
+    // And `list` must show it back to the agent that created it — the old
+    // `fc.watcher_id IS NOT NULL` list filter hid every org-level classifier.
+    const listed = await manageClassifiers(
+      { action: 'list' } as never,
+      {} as never,
+      ctx
+    );
+    expect(listed.success).toBe(true);
+    const listedSlugs = (
+      (listed.data as { classifiers: Array<{ slug: string }> }).classifiers
+    ).map((c) => c.slug);
+    expect(listedSlugs).toContain('agent-made');
+
+    const event = await createTestEvent({
+      organization_id: org.id,
+      content: 'great',
+      embedding: basisVector(0),
+    });
+
+    const applied = await manageClassifiers(
+      {
+        action: 'apply',
+        classifier_slug: 'agent-made',
+        content_ids: [Number(event.id)],
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(applied.success).toBe(true);
+    expect((applied.data as { classified: number }).classified).toBe(1);
+
+    const written = (await sql`
+      SELECT "values", source FROM event_classifications WHERE event_id = ${event.id}
+    `) as unknown as Array<{ values: unknown; source: string }>;
+    expect(written).toHaveLength(1);
+    expect(written[0].source).toBe('embedding');
+    // `values` is text[]; under fetch_types:false it reads back as "{positive}".
+    expect(parsePgTextArray(written[0].values)).toEqual(['positive']);
+  });
+
+  it('still accepts an owning Behavior, and that classifier stays outside the engine', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Behavior Owned Org' });
+    const user = await createTestUser({ email: 'behavior-owned@test.com' });
+    const ctx = adminCtx(org.id, user.id);
+    const sql = getTestDb();
+
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const [behavior] = (await sql`
+      INSERT INTO watchers (organization_id, agent_id, watcher_group_id, name, created_by, status)
+      VALUES (${org.id}, ${agent.agentId}, 0, 'owner', ${user.id}, 'active')
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    const created = await manageClassifiers(
+      {
+        action: 'create',
+        slug: 'behavior-made',
+        name: 'Behavior made',
+        attribute_key: 'behavior-made',
+        attribute_values: ATTRIBUTE_VALUES,
+        behavior_id: String(behavior.id),
+        min_similarity: 0.5,
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(created.success).toBe(true);
+
+    const rows = (await sql`
+      SELECT watcher_id FROM classify_facet
+      WHERE slug = 'behavior-made' AND organization_id = ${org.id}
+    `) as unknown as Array<{ watcher_id: number | null }>;
+    expect(Number(rows[0].watcher_id)).toBe(Number(behavior.id));
+
+    // Deliberate, not a bug: the embedding engine matches org-level classifiers
+    // only. `apply` must say so instead of reporting a successful empty run.
+    const event = await createTestEvent({
+      organization_id: org.id,
+      content: 'great',
+      embedding: basisVector(0),
+    });
+    const applied = await manageClassifiers(
+      {
+        action: 'apply',
+        classifier_slug: 'behavior-made',
+        content_ids: [Number(event.id)],
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(applied.success).toBe(false);
+    expect(applied.message).toContain('behavior-made');
+  });
+
+  it('exposes apply on the agent SDK surface', () => {
+    const namespace = buildClassifiersNamespace(
+      adminCtx('org', 'user'),
+      {} as never
+    );
+    // Without this an agent cannot classify anything that has no entity link,
+    // which is the only reason the verb exists.
+    expect(typeof namespace.apply).toBe('function');
+    expect(METHOD_METADATA['classifiers.apply']).toBeDefined();
+    expect(METHOD_METADATA['classifiers.apply'].access).toBe('admin');
+  });
+});

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -341,7 +341,7 @@ describe("method-metadata", () => {
 			["classifiers.classify", ["classifier_slug: string", "'llm' | 'user'"]],
 			[
 				"classifiers.create",
-				["behavior_id: string", "attribute_values", "examples: string[]"],
+				["behavior_id?: string", "attribute_values", "examples: string[]"],
 			],
 		];
 		for (const [path, fragments] of expectations) {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -938,12 +938,12 @@ export default async (_ctx, client) => {
 	},
 	"classifiers.create": {
 		summary:
-			"Create a classifier template. REQUIRES `behavior_id` (the owning Behavior) plus `slug`, `name`, and `attribute_key`. `attribute_values` is an OBJECT keyed by value slug — each entry needs a `description` and `examples` (string array), not a flat list.",
+			"Create a classifier template. Requires `slug`, `name`, and `attribute_key`. `attribute_values` is an OBJECT keyed by value slug — each entry needs a `description` and `examples` (string array), not a flat list. OMIT `behavior_id` for an org-level classifier, which is the only kind `apply` and the reconciliation job can match; pass it only to scope the classifier to one Behavior.",
 		access: "admin",
 		signature:
-			"classifiers.create(input: { slug: string; name: string; attribute_key: string; behavior_id: string; attribute_values?: Record<string, { description: string; examples: string[] }>; entity_id?: number; min_similarity?: number; fallback_value?: unknown; description?: string }): Promise<unknown>",
+			"classifiers.create(input: { slug: string; name: string; attribute_key: string; behavior_id?: string; attribute_values?: Record<string, { description: string; examples: string[] }>; entity_id?: number; min_similarity?: number; fallback_value?: unknown; description?: string }): Promise<unknown>",
 		example:
-			"await client.classifiers.create({ slug: 'sentiment', name: 'Sentiment', attribute_key: 'sentiment', behavior_id: '42', attribute_values: { positive: { description: 'Positive tone', examples: ['Great work!'] } } });",
+			"await client.classifiers.create({ slug: 'sentiment', name: 'Sentiment', attribute_key: 'sentiment', attribute_values: { positive: { description: 'Positive tone', examples: ['Great work!'] } } });",
 	},
 	"classifiers.generateEmbeddings": {
 		summary: "Generate embeddings for attribute values (cost-heavy).",
@@ -963,6 +963,16 @@ export default async (_ctx, client) => {
 			"classifiers.classify(input: { classifier_slug: string; content_id?: number; value?: string | null; reasoning?: string; classifications?: Array<{ content_id: number; value: string | null; reasoning?: string }>; source?: 'llm' | 'user' }): Promise<unknown>",
 		example:
 			"await client.classifiers.classify({ classifier_slug: 'sentiment', content_id: 101, value: 'positive', source: 'user' });",
+	},
+	"classifiers.apply": {
+		summary:
+			"Run a classifier's embedding match over content ids you supply and STORE the labels. Needs no entity link, so this is how org-scoped feed content gets classified. Returns `classified` plus a `skipped` breakdown (not_in_organization | superseded | not_embedded | below_threshold) — a zero result always says why. Only matches org-level classifiers (those created without `behavior_id`).",
+		access: "admin",
+		cost: "expensive",
+		signature:
+			"classifiers.apply(input: { classifier_slug: string; content_ids: number[] }): Promise<unknown>",
+		example:
+			"await client.classifiers.apply({ classifier_slug: 'sentiment', content_ids: [101, 102, 103] });",
 	},
 
 	// viewTemplates

--- a/packages/server/src/sandbox/namespaces/classifiers.ts
+++ b/packages/server/src/sandbox/namespaces/classifiers.ts
@@ -24,7 +24,9 @@ export interface ClassifierCreateInput {
 		}
 	>;
 	entity_id?: number;
-	behavior_id: string;
+	/** Omit for an org-level classifier (the only kind `apply` and the
+	 *  reconciliation job match); set to scope to a single Behavior. */
+	behavior_id?: string;
 	min_similarity?: number;
 	fallback_value?: unknown;
 	created_by?: string;
@@ -45,6 +47,18 @@ export interface ClassifierClassifyInput {
 	reasoning?: string;
 }
 
+/**
+ * `apply` runs the classifier's embedding match over content ids you supply.
+ * Unlike the reconciliation cron it needs no entity link, so it is the only way
+ * to classify org-scoped feed content. Ids that produce no classification come
+ * back with a reason (`not_in_organization` | `superseded` | `not_embedded` |
+ * `below_threshold`) rather than as a silent shortfall.
+ */
+export interface ClassifierApplyInput {
+	classifier_slug: string;
+	content_ids: number[];
+}
+
 export interface ClassifiersNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
 	list(input?: { entity_id?: number; status?: string }): Promise<unknown>;
@@ -55,6 +69,7 @@ export interface ClassifiersNamespace {
 	}): Promise<unknown>;
 	delete(input: { classifier_id: number }): Promise<unknown>;
 	classify(input: ClassifierClassifyInput): Promise<unknown>;
+	apply(input: ClassifierApplyInput): Promise<unknown>;
 }
 
 export function buildClassifiersNamespace(
@@ -70,5 +85,6 @@ export function buildClassifiersNamespace(
 		generateEmbeddings: (input) => action("generate_embeddings", input),
 		delete: (input) => action("delete", input),
 		classify: (input) => action("classify", input),
+		apply: (input) => action("apply", input),
 	};
 }

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -165,27 +165,27 @@ async function handleCreate(
     };
   }
 
-  if (!args.behavior_id) {
-    return {
-      success: false,
-      action: 'create',
-      message: 'Missing required field: behavior_id. Classifiers must be associated with a Behavior.',
-    };
-  }
-
   const entityId = args.entity_id ?? null;
-  const behaviorId = args.behavior_id;
+  // Optional on purpose. `behavior_id` becomes `classify_facet.watcher_id`, and
+  // every embedding-engine lookup filters `cf.watcher_id IS NULL` — so while
+  // this was required, EVERY classifier creatable through this tool or the
+  // ClientSDK was invisible to the engine, and `apply`/the reconciliation cron
+  // reported clean zero-result runs over it. Omit it for an org-level
+  // classifier the engine can match; pass it for a Behavior-scoped one.
+  const behaviorId = args.behavior_id ?? null;
 
-  const watcher = await sql`
-    SELECT id FROM watchers
-    WHERE id = ${behaviorId} AND organization_id = ${ctx.organizationId}
-  `;
-  if (watcher.length === 0) {
-    return {
-      success: false,
-      action: 'create',
-      message: `Behavior not found: ${behaviorId}`,
-    };
+  if (behaviorId !== null) {
+    const watcher = await sql`
+      SELECT id FROM watchers
+      WHERE id = ${behaviorId} AND organization_id = ${ctx.organizationId}
+    `;
+    if (watcher.length === 0) {
+      return {
+        success: false,
+        action: 'create',
+        message: `Behavior not found: ${behaviorId}`,
+      };
+    }
   }
 
   if (entityId !== null) {
@@ -264,7 +264,12 @@ async function handleList(
   // repeated E2E runs left deprecated rows visible in the ordinary list (#2051).
   const statusFilter = args.status ?? 'active';
 
-  const conditions: string[] = ['fc.watcher_id IS NOT NULL', 'fc.organization_id = $1'];
+  // No watcher_id filter: org-level classifiers (watcher_id IS NULL) are the
+  // kind `create` now produces by default and the only kind the engine matches.
+  // The old `fc.watcher_id IS NOT NULL` condition hid every one of them from
+  // the agent that had just created it (and left the NULLS LAST ordering below
+  // dead).
+  const conditions: string[] = ['fc.organization_id = $1'];
   const params: unknown[] = [ctx.organizationId];
   let paramIdx = 2;
 

--- a/packages/server/src/utils/classification-query.ts
+++ b/packages/server/src/utils/classification-query.ts
@@ -7,7 +7,7 @@
  * Vector operations (cosine similarity) are computed in TypeScript.
  */
 
-import { type DbClient, getDb, pgTextArray } from '../db/client';
+import { type DbClient, getDb, parsePgNumberArray, pgTextArray } from '../db/client';
 import { entityLinkMatchSql } from './content-search';
 import { configuredEmbeddingModelSqlLiteral } from './embeddings';
 import logger from './logger';
@@ -290,7 +290,11 @@ async function fetchTargetContent(
 
       return {
         id: row.id,
-        entity_ids: row.entity_ids,
+        // `entity_ids` is bigint[]; under fetch_types:false it arrives as the raw
+        // literal "{1,2}" (or "{}"), never a JS array. The scope check flatMaps
+        // these into a Set — flatMap doesn't flatten strings, so the Set would
+        // hold the raw literal and numeric membership tests would never match.
+        entity_ids: parsePgNumberArray(row.entity_ids),
         parent_id: row.parent_id,
         combined_embedding: combined,
       };
@@ -340,7 +344,11 @@ async function fetchClassifierTemplates(
 
   for (const row of rows) {
     // Scope check: classifier must be global (empty entity_ids) OR overlap with target content entity_ids
-    const classifierEntityIds = row.entity_ids ?? [];
+    // Same raw-array read as above. Without the parse, "{}" is a 2-char string:
+    // the length guard passes and `.some` throws TypeError. `manage_classifiers
+    // create` writes ARRAY[]::bigint[] rather than NULL, so every org-level
+    // classifier it creates would crash the engine on this line.
+    const classifierEntityIds = parsePgNumberArray(row.entity_ids ?? []);
     if (
       classifierEntityIds.length > 0 &&
       !classifierEntityIds.some((id) => targetEntityIds.has(id))


### PR DESCRIPTION
## What

Three defects that together made the embedding classifier unusable for anything an agent or user could create. Follow-up to #2389, which exposed `apply` but could not be used with any classifier the API can produce.

**1. Nothing creatable was engine-matchable.** `create` required `behavior_id` and wrote it to `classify_facet.watcher_id`, while every engine lookup filters `cf.watcher_id IS NULL` (`classification-query.ts` 234 / 330 / 490). So every classifier created through the tool or the ClientSDK was invisible to the engine forever, and `apply` / the reconciliation cron reported clean, successful, zero-result runs over it. `behavior_id` is now optional — omit it for an org-level classifier, pass it to scope to one Behavior.

**2. `apply` was invisible to agents.** Absent from `sandbox/namespaces/classifiers.ts` and `METHOD_METADATA`, so no agent could call the one verb that classifies content with no entity link.

**3. A crash that defect 1 was hiding.** `classify_facet.entity_ids` and `current_event_records.entity_ids` are `bigint[]`, which under `fetch_types:false` read back as the raw literal `"{}"` rather than a JS array. `"{}"` is 2 characters, so the `length > 0` guard passed and `.some` threw `TypeError`. The sibling read put the literal into a `Set` where no numeric membership test could ever match. Both now go through `parsePgNumberArray`.

## Prod evidence for 1

Read-only query, 2026-07-31:

| org | classifiers | `watcher_id IS NULL` | classifications |
|---|---|---|---|
| working | 23 | 23 | 2187 |
| other | 5 | 0 | 0 |

The 23 that work all predate the required-`behavior_id` rule.

## Red → green

Red (before the fixes):
```
× creates an engine-matchable classifier when no Behavior owns it, and applies it
  → expected false to be true            (create rejected: behavior_id required)
× exposes apply on the agent SDK surface
  → expected 'undefined' to be 'function'
```

After fixing 1, defect 3 surfaced:
```
TypeError: classifierEntityIds.some is not a function
  at fetchClassifierTemplates (classification-query.ts:346:28)
```

Green:
```
Test Files  9 passed (9)      Tests  23 passed (23)   (classifier integration)
23 pass 0 fail                                        (method-metadata unit)
```

## Notes

A Behavior-owned classifier remains legitimate (Behavior-scoped extraction config) — it is simply not what the embedding engine matches. The test asserts that distinction explicitly so nobody "fixes" this later by loosening the engine's filter.

## Known gap, not addressed here

`classify_facet_unique_per_insight` is `UNIQUE NULLS NOT DISTINCT (entity_id, watcher_id, slug)` with no `organization_id`, so a global classifier slug is first-come-first-served across all tenants. Schema change, separate PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->