### PR TITLE
fix(agent-worker): report why exec-sandbox is unavailable instead of guessing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1075,6 +1075,57 @@ jobs:
       - name: CLI runtime self-check (host)
         run: node packages/cli/bin/lobu.js connector runtime-self-check --json
 
+  # Measurement, not a gate. `probeSandboxStrategy()` returns "none" on the
+  # managed cluster because bubblewrap cannot create a user namespace there
+  # (uid_map is runtime-restricted — charts/lobu/values.yaml records the
+  # measurement), so contributed CLIs exit 127 by design. bwrap is not the only
+  # possible backend, and this job answers the open question "is systemd-run
+  # --user even available to us?" with a fact instead of an assumption.
+  #
+  # Deliberately `continue-on-error`: nothing depends on the answer yet, and a
+  # runner without a user session must not redden main. Read the summary, do
+  # not gate on it. No checkout: the probe only inspects the runner itself.
+  exec-sandbox-backend-probe:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    continue-on-error: true
+    steps:
+      - name: Report available exec-sandbox backends
+        run: |
+          echo "### exec-sandbox backend probe" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if command -v bwrap >/dev/null 2>&1; then
+            if bwrap --unshare-user --unshare-pid --ro-bind /usr /usr \
+                 --proc /proc --dev /dev -- /usr/bin/true >/tmp/bwrap.err 2>&1; then
+              echo "- bwrap: **isolation works**" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "- bwrap: present but refused — \`$(head -c 200 /tmp/bwrap.err)\`" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "- bwrap: not installed" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # The actual open question. --user needs a systemd user session; a
+          # container without one fails here, which is itself the answer.
+          if command -v systemd-run >/dev/null 2>&1; then
+            if systemd-run --user --scope --quiet /bin/true >/tmp/sdr.err 2>&1; then
+              echo "- systemd-run --user: **works** (viable alternative backend)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "- systemd-run --user: present but failed — \`$(head -c 200 /tmp/sdr.err)\`" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "- systemd-run: not installed" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Both knobs: unprivileged_userns_clone is the Debian patch (absent on
+          # Ubuntu 24.04), apparmor_restrict_unprivileged_userns is what actually
+          # governs userns on this runner's distro.
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "kernel.unprivileged_userns_clone=$(sysctl -n kernel.unprivileged_userns_clone 2>/dev/null || echo 'unset')" >> "$GITHUB_STEP_SUMMARY"
+          echo "kernel.apparmor_restrict_unprivileged_userns=$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 'unset')" >> "$GITHUB_STEP_SUMMARY"
+          cat "$GITHUB_STEP_SUMMARY"
+
   # The prebuilt pgvector libraries are committed binaries, so nothing in the
   # normal build/test path ever looks at them — `make build-packages` copies the
   # file, it does not link against it. That blind spot shipped a `vector.so`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1096,7 +1096,17 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if command -v bwrap >/dev/null 2>&1; then
-            if bwrap --unshare-user --unshare-pid --ro-bind /usr /usr \
+            # Bind set mirrors probeBwrap() in exec-sandbox.ts. /lib64 is not
+            # optional: /usr/bin/true's ELF interpreter is
+            # /lib64/ld-linux-*.so, so binding only /usr makes exec fail with
+            # an execvp error even where userns works — the probe would then
+            # report "present but refused" and name the wrong cause, which is
+            # the exact failure this PR exists to remove.
+            if bwrap --unshare-user --unshare-pid \
+                 --ro-bind /usr /usr \
+                 --ro-bind-try /lib /lib \
+                 --ro-bind-try /lib64 /lib64 \
+                 --ro-bind-try /bin /bin \
                  --proc /proc --dev /dev -- /usr/bin/true >/tmp/bwrap.err 2>&1; then
               echo "- bwrap: **isolation works**" >> "$GITHUB_STEP_SUMMARY"
             else

--- a/packages/agent-worker/src/__tests__/exec-sandbox.test.ts
+++ b/packages/agent-worker/src/__tests__/exec-sandbox.test.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import {
   type SandboxStrategy,
   describeNoSandbox,
+  formatBwrapOverrideError,
   formatNoSandboxReport,
   probeSandboxStrategy,
   resetSandboxProbeForTests,
@@ -61,10 +62,18 @@ describe("probeSandboxStrategy", () => {
     }
   });
 
+  // Host-conditional on purpose, and deliberately narrow: what needs the real
+  // code path here is that an unhonourable override THROWS rather than quietly
+  // degrading to kind:"none". The wording is asserted by the
+  // `formatBwrapOverrideError` tests, which run on every host — leaving message
+  // assertions here would make the production branch (a Linux userns refusal)
+  // untestable anywhere but a Linux box that also blocks userns.
   test("explicit override fails closed when backend unavailable", () => {
     if (process.platform !== "darwin") return;
     process.env.LOBU_EXEC_SANDBOX = "bwrap";
-    expect(() => probeSandboxStrategy()).toThrow(/bubblewrap is unavailable/);
+    expect(() => probeSandboxStrategy()).toThrow(
+      /LOBU_EXEC_SANDBOX=bwrap was requested but cannot be honoured/
+    );
   });
 
   test("cache invalidates when override env changes", () => {
@@ -360,7 +369,7 @@ const linuxBwrapWorks = (() => {
   });
   if (!bwrapPath) return false;
   try {
-    // Mirror `bwrapDeliversIsolation` in exec-sandbox.ts. /lib64 must be
+    // Mirror `probeBwrap` in exec-sandbox.ts. /lib64 must be
     // bound because /usr/bin/true's ELF interpreter is /lib64/ld-linux-*.so.
     execFileSync(
       bwrapPath,
@@ -638,5 +647,49 @@ describe("describeNoSandbox / formatNoSandboxReport", () => {
   test("an unsupported platform says so instead of naming a backend", () => {
     const other = formatNoSandboxReport("win32", {});
     expect(other).toContain("No sandbox backend is implemented");
+  });
+});
+
+/**
+ * The explicit-override throw is the SECOND site that carried the same wrong
+ * prescription, and it is the one an operator hits deliberately — they set
+ * LOBU_EXEC_SANDBOX=bwrap precisely because they want to know why the sandbox
+ * is not active. Sending them after an already-installed package there is worse
+ * than in the passive warning, not better.
+ *
+ * Both sites now route through `explainBwrapUnavailable`, so these assertions
+ * are what stops the two diagnoses drifting apart again.
+ */
+describe("formatBwrapOverrideError", () => {
+  test("still fails closed and names the override that was requested", () => {
+    const msg = formatBwrapOverrideError({
+      isolated: false,
+      reason: "not_found",
+    });
+    expect(msg).toContain("LOBU_EXEC_SANDBOX=bwrap");
+    expect(msg).toContain("cannot be honoured");
+  });
+
+  test("a userns refusal does not tell the operator to install anything", () => {
+    const msg = formatBwrapOverrideError({
+      isolated: false,
+      reason: "unshare_denied",
+      detail: "bwrap: setting up uid map: Permission denied",
+    });
+    expect(msg).toContain("setting up uid map: Permission denied");
+    expect(msg).toContain("not a missing package");
+    expect(msg).not.toContain("Installing it enables");
+    // The old text pointed at a sysctl that does not even exist on Ubuntu
+    // 24.04, where AppArmor governs userns instead.
+    expect(msg).not.toContain("unprivileged_userns_clone=1");
+  });
+
+  test("a missing bubblewrap is still allowed to say install it", () => {
+    const msg = formatBwrapOverrideError({
+      isolated: false,
+      reason: "not_found",
+    });
+    expect(msg).toContain("not found on PATH");
+    expect(msg).toContain("Installing it enables");
   });
 });

--- a/packages/agent-worker/src/__tests__/exec-sandbox.test.ts
+++ b/packages/agent-worker/src/__tests__/exec-sandbox.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { promisify } from "node:util";
 import {
   type SandboxStrategy,
+  describeNoSandbox,
+  formatNoSandboxReport,
   probeSandboxStrategy,
   resetSandboxProbeForTests,
   wrapInvocation,
@@ -569,5 +571,72 @@ describeBwrap("bwrap escape matrix", () => {
     if (r.ok) {
       expect(r.stdout.trim()).not.toBe("0");
     }
+  });
+});
+
+/**
+ * The diagnostic is the whole point of this surface on hosts that cannot
+ * sandbox: contributed CLIs exit 127 by design there, and the only thing
+ * standing between an operator and a wasted afternoon is whether the log names
+ * the real cause. The old message prescribed "Install bubblewrap" for every
+ * no-sandbox outcome, which on the managed cluster is wrong twice over —
+ * bubblewrap may already be present, and the refusal is a uid_map runtime
+ * restriction no package can fix.
+ *
+ * These pin the distinction that matters: a MISSING bubblewrap is the one case
+ * where installing something helps and is the only case allowed to say so.
+ */
+describe("describeNoSandbox / formatNoSandboxReport", () => {
+  test("the live call names the platform and the loss of isolation", () => {
+    const msg = describeNoSandbox();
+    expect(msg).toContain(`platform=${process.platform}`);
+    expect(msg).toContain("host privileges");
+  });
+
+  test("a MISSING bubblewrap is the only case that recommends installing it", () => {
+    const missing = formatNoSandboxReport("linux", {
+      bwrap: { isolated: false, reason: "not_found" },
+    });
+    expect(missing).toContain("was not found on PATH");
+    expect(missing).toContain("Installing it enables");
+  });
+
+  test("a userns refusal is reported as host policy, never as a missing package", () => {
+    const denied = formatNoSandboxReport("linux", {
+      bwrap: {
+        isolated: false,
+        reason: "unshare_denied",
+        detail: "bwrap: setting up uid map: Permission denied",
+      },
+    });
+    // The kernel's own words survive to the operator — that is the whole point.
+    expect(denied).toContain("setting up uid map: Permission denied");
+    expect(denied).toContain("not a missing package");
+    expect(denied).toContain("charts/lobu/values.yaml");
+    // And it must NOT tell them to install anything: on the managed cluster
+    // that advice costs an afternoon and changes nothing.
+    expect(denied).not.toContain("Installing it enables");
+  });
+
+  test("macOS reports the probed path rather than Linux advice", () => {
+    const mac = formatNoSandboxReport("darwin", {
+      sandboxExec: { path: "/usr/bin/sandbox-exec", present: false },
+    });
+    expect(mac).toContain("/usr/bin/sandbox-exec");
+    expect(mac).toContain("not present");
+    expect(mac).not.toContain("bubblewrap");
+  });
+
+  test("a present sandbox-exec is never misreported as missing", () => {
+    const mac = formatNoSandboxReport("darwin", {
+      sandboxExec: { path: "/usr/bin/sandbox-exec", present: true },
+    });
+    expect(mac).toContain("Inconsistent probe");
+    expect(mac).not.toContain("not present");
+  });
+
+  test("an unsupported platform says so instead of naming a backend", () => {
+    const other = formatNoSandboxReport("win32", {});
+    expect(other).toContain("No sandbox backend is implemented");
   });
 });

--- a/packages/agent-worker/src/embedded/exec-sandbox.ts
+++ b/packages/agent-worker/src/embedded/exec-sandbox.ts
@@ -12,10 +12,14 @@
  *     data paths (~/.ssh, ~/.aws, /etc, /Users, keychains, etc.) and writes
  *     restricted to the workspace.
  *   - "bwrap" (Linux) — true deny-default via bind mounts; only the workspace
- *     and ro system paths are visible. Probed at startup with a real spawn
- *     because `--unshare-user` requires `kernel.unprivileged_userns_clone=1`.
+ *     and ro system paths are visible. Probed at startup with a real spawn,
+ *     because whether `--unshare-user` is permitted is a host policy question
+ *     with no single knob to read: the Debian `kernel.unprivileged_userns_clone`
+ *     sysctl does not exist on Ubuntu 24.04 (AppArmor governs it there), and a
+ *     container runtime can restrict `uid_map` regardless of either. Only an
+ *     actual spawn answers it.
  *   - "none" — no sandbox available; commands run with host privileges. A
- *     warning is logged once at probe time.
+ *     warning is logged once at probe time reporting what was observed.
  *
  * Override with LOBU_EXEC_SANDBOX={auto,bwrap,sandbox-exec,off}. Explicit
  * overrides fail closed: requesting `bwrap` on a host without bubblewrap is a
@@ -99,63 +103,22 @@ function envOverride(): SandboxKind | null {
  * present and would not help if it weren't.
  */
 type BwrapProbe =
-  | { isolated: true }
+  | { isolated: true; path: string }
   | { isolated: false; reason: "not_found" }
   | { isolated: false; reason: "unshare_denied"; detail: string };
 
 /**
- * Shared by the boolean predicate and the reporting probe so the two can never
- * answer about different flag sets — a drift that would make the diagnostic
- * describe a probe the selection path never ran.
- */
-const BWRAP_ISOLATION_PROBE_ARGS = [
-  "--unshare-user",
-  "--unshare-pid",
-  "--unshare-ipc",
-  "--unshare-uts",
-  "--unshare-net",
-  "--ro-bind",
-  "/usr",
-  "/usr",
-  "--ro-bind-try",
-  "/lib",
-  "/lib",
-  "--ro-bind-try",
-  "/lib64",
-  "/lib64",
-  "--ro-bind-try",
-  "/bin",
-  "/bin",
-  "--proc",
-  "/proc",
-  "--dev",
-  "/dev",
-  "--",
-  "/usr/bin/true",
-];
-
-/**
  * Run bwrap with the same unshare flags we use in production but against
- * `/bin/true`. If user namespaces aren't available (kernel disabled, seccomp
- * profile blocking `unshare(CLONE_NEWUSER)`), this fails — and we should
- * surface it rather than silently degrade to "no sandbox".
- */
-function bwrapDeliversIsolation(bwrapPath: string): boolean {
-  try {
-    execFileSync(bwrapPath, BWRAP_ISOLATION_PROBE_ARGS, {
-      stdio: "ignore",
-      timeout: 3000,
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Same probe, but keeps what it learned. `probeBwrap` is what the reporting
- * path uses; `bwrapDeliversIsolation` stays as the boolean predicate the
- * strategy selection already reads, so selection behaviour is untouched.
+ * `/bin/true`, and keep what was learned. If user namespaces aren't available
+ * (kernel disabled, seccomp profile blocking `unshare(CLONE_NEWUSER)`), this
+ * fails — and the reason is what every caller needs, because "not installed"
+ * and "installed but refused" call for opposite responses.
+ *
+ * This is the single probe: strategy selection, the explicit-override error and
+ * the no-sandbox warning all read it. An earlier split — a boolean predicate
+ * for selection plus a reporting probe alongside it — let the diagnostic
+ * describe a probe selection had never run. One function cannot drift from
+ * itself.
  */
 function probeBwrap(): BwrapProbe {
   const bwrapPath = which("bwrap");
@@ -163,11 +126,36 @@ function probeBwrap(): BwrapProbe {
     return { isolated: false, reason: "not_found" };
   }
   try {
-    execFileSync(bwrapPath, BWRAP_ISOLATION_PROBE_ARGS, {
-      stdio: "pipe",
-      timeout: 3000,
-    });
-    return { isolated: true };
+    execFileSync(
+      bwrapPath,
+      [
+        "--unshare-user",
+        "--unshare-pid",
+        "--unshare-ipc",
+        "--unshare-uts",
+        "--unshare-net",
+        "--ro-bind",
+        "/usr",
+        "/usr",
+        "--ro-bind-try",
+        "/lib",
+        "/lib",
+        "--ro-bind-try",
+        "/lib64",
+        "/lib64",
+        "--ro-bind-try",
+        "/bin",
+        "/bin",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--",
+        "/usr/bin/true",
+      ],
+      { stdio: "pipe", timeout: 3000 }
+    );
+    return { isolated: true, path: bwrapPath };
   } catch (err) {
     // The stderr of a refused unshare is the actionable part ("No permissions
     // to creating new namespace", "setting up uid map: Permission denied").
@@ -212,15 +200,11 @@ export function probeSandboxStrategy(): SandboxStrategy {
       );
     }
     if (override === "bwrap") {
-      const p = which("bwrap");
-      if (p && fs.existsSync(p) && bwrapDeliversIsolation(p)) {
-        return setCache(key, { kind: "bwrap", path: p });
+      const probe = probeBwrap();
+      if (probe.isolated) {
+        return setCache(key, { kind: "bwrap", path: probe.path });
       }
-      throw new Error(
-        `[exec-sandbox] LOBU_EXEC_SANDBOX=bwrap but bubblewrap is unavailable ` +
-          `or user namespaces are blocked. Install bubblewrap and ensure ` +
-          `kernel.unprivileged_userns_clone=1 (or seccomp profile permits unshare).`
-      );
+      throw new Error(formatBwrapOverrideError(probe));
     }
   }
 
@@ -232,16 +216,19 @@ export function probeSandboxStrategy(): SandboxStrategy {
     }
   }
 
+  // Probed once and reused for the warning below, so the message can never
+  // describe a different probe run than the one that decided the strategy.
+  let linuxBwrap: BwrapProbe | undefined;
   if (process.platform === "linux") {
-    const p = which("bwrap");
-    if (p && fs.existsSync(p) && bwrapDeliversIsolation(p)) {
-      return setCache(key, { kind: "bwrap", path: p });
+    linuxBwrap = probeBwrap();
+    if (linuxBwrap.isolated) {
+      return setCache(key, { kind: "bwrap", path: linuxBwrap.path });
     }
   }
 
   if (!warnedNoSandbox) {
     warnedNoSandbox = true;
-    console.warn(`[exec-sandbox] ${describeNoSandbox()}`);
+    console.warn(`[exec-sandbox] ${describeNoSandbox(linuxBwrap)}`);
   }
   return setCache(key, { kind: "none" });
 }
@@ -262,7 +249,7 @@ export function probeSandboxStrategy(): SandboxStrategy {
  * kernel's own refusal text when there is one. The remedy is only stated in the
  * case where a remedy exists.
  */
-export function describeNoSandbox(): string {
+export function describeNoSandbox(alreadyProbed?: BwrapProbe): string {
   if (process.platform === "darwin") {
     const p = which("sandbox-exec") ?? "/usr/bin/sandbox-exec";
     return formatNoSandboxReport(process.platform, {
@@ -272,7 +259,54 @@ export function describeNoSandbox(): string {
   if (process.platform !== "linux") {
     return formatNoSandboxReport(process.platform, {});
   }
-  return formatNoSandboxReport(process.platform, { bwrap: probeBwrap() });
+  // Callers that already probed pass their result in rather than spawning bwrap
+  // a second time — the probe costs a process spawn, and a second one could in
+  // principle disagree with the one that actually decided the strategy.
+  return formatNoSandboxReport(process.platform, {
+    bwrap: alreadyProbed ?? probeBwrap(),
+  });
+}
+
+/**
+ * Message for `LOBU_EXEC_SANDBOX=bwrap` on a host that cannot honour it. Fails
+ * closed exactly as before — only the wording changes.
+ *
+ * It previously prescribed "Install bubblewrap and ensure
+ * kernel.unprivileged_userns_clone=1" for *both* causes, the same defect this
+ * change fixes in the auto path's warning. An operator who set the override on
+ * the managed cluster was sent after a package that was already installed, and
+ * after a sysctl that does not exist on Ubuntu 24.04.
+ *
+ * Pure and exported for the same reason as `formatNoSandboxReport`: the branch
+ * that matters in production is a userns refusal, which is otherwise assertable
+ * only on a Linux host that also happens to block userns.
+ */
+export function formatBwrapOverrideError(
+  probe: Extract<BwrapProbe, { isolated: false }>
+): string {
+  return (
+    `[exec-sandbox] LOBU_EXEC_SANDBOX=bwrap was requested but cannot be ` +
+    `honoured. ${explainBwrapUnavailable(probe)}`
+  );
+}
+
+/**
+ * The reason-specific half of the diagnosis, shared by the no-sandbox warning
+ * and the explicit-override throw so the two can never disagree about the same
+ * host. Only `not_found` is allowed to recommend installing anything.
+ */
+function explainBwrapUnavailable(
+  probe: Extract<BwrapProbe, { isolated: false }>
+): string {
+  if (probe.reason === "not_found") {
+    return `bubblewrap (bwrap) was not found on PATH. Installing it enables the sandbox on hosts whose kernel permits unprivileged user namespaces.`;
+  }
+  return (
+    `bubblewrap is installed but could not create a user namespace: ${probe.detail}. ` +
+    `This is a host/runtime policy (unprivileged userns or uid_map restricted), not a missing package — ` +
+    `installing bubblewrap again will not change it. On the managed cluster this is the expected state and ` +
+    `contributed CLIs are refused by design; see charts/lobu/values.yaml.`
+  );
 }
 
 /**
@@ -311,15 +345,7 @@ export function formatNoSandboxReport(
     // print a confident story about a state that shouldn't exist.
     return `${head} Inconsistent probe: bubblewrap reported working isolation on re-probe but was not selected. Please report this — it indicates a bug in strategy selection, not a host misconfiguration.`;
   }
-  if (probe.reason === "not_found") {
-    return `${head} bubblewrap (bwrap) was not found on PATH. Installing it enables the sandbox on hosts whose kernel permits unprivileged user namespaces.`;
-  }
-  return (
-    `${head} bubblewrap is installed but could not create a user namespace: ${probe.detail}. ` +
-    `This is a host/runtime policy (unprivileged userns or uid_map restricted), not a missing package — ` +
-    `installing bubblewrap again will not change it. On the managed cluster this is the expected state and ` +
-    `contributed CLIs are refused by design; see charts/lobu/values.yaml.`
-  );
+  return `${head} ${explainBwrapUnavailable(probe)}`;
 }
 
 /** For tests: forget the cached strategy + warning state. */

--- a/packages/agent-worker/src/embedded/exec-sandbox.ts
+++ b/packages/agent-worker/src/embedded/exec-sandbox.ts
@@ -88,6 +88,53 @@ function envOverride(): SandboxKind | null {
 }
 
 /**
+ * What the bwrap isolation probe observed. The reason is kept rather than
+ * collapsed to a boolean because "bubblewrap is not installed" and "bubblewrap
+ * is installed but the kernel/seccomp policy refuses unshare(CLONE_NEWUSER)"
+ * call for opposite responses, and only the first is fixable by installing
+ * anything. On the managed cluster it is always the second — see
+ * charts/lobu/values.yaml, which records that no securityContext change can
+ * enable it because uid_map is runtime-restricted — so telling an operator to
+ * "install bubblewrap" there sends them after a package that is already
+ * present and would not help if it weren't.
+ */
+type BwrapProbe =
+  | { isolated: true }
+  | { isolated: false; reason: "not_found" }
+  | { isolated: false; reason: "unshare_denied"; detail: string };
+
+/**
+ * Shared by the boolean predicate and the reporting probe so the two can never
+ * answer about different flag sets — a drift that would make the diagnostic
+ * describe a probe the selection path never ran.
+ */
+const BWRAP_ISOLATION_PROBE_ARGS = [
+  "--unshare-user",
+  "--unshare-pid",
+  "--unshare-ipc",
+  "--unshare-uts",
+  "--unshare-net",
+  "--ro-bind",
+  "/usr",
+  "/usr",
+  "--ro-bind-try",
+  "/lib",
+  "/lib",
+  "--ro-bind-try",
+  "/lib64",
+  "/lib64",
+  "--ro-bind-try",
+  "/bin",
+  "/bin",
+  "--proc",
+  "/proc",
+  "--dev",
+  "/dev",
+  "--",
+  "/usr/bin/true",
+];
+
+/**
  * Run bwrap with the same unshare flags we use in production but against
  * `/bin/true`. If user namespaces aren't available (kernel disabled, seccomp
  * profile blocking `unshare(CLONE_NEWUSER)`), this fails — and we should
@@ -95,38 +142,46 @@ function envOverride(): SandboxKind | null {
  */
 function bwrapDeliversIsolation(bwrapPath: string): boolean {
   try {
-    execFileSync(
-      bwrapPath,
-      [
-        "--unshare-user",
-        "--unshare-pid",
-        "--unshare-ipc",
-        "--unshare-uts",
-        "--unshare-net",
-        "--ro-bind",
-        "/usr",
-        "/usr",
-        "--ro-bind-try",
-        "/lib",
-        "/lib",
-        "--ro-bind-try",
-        "/lib64",
-        "/lib64",
-        "--ro-bind-try",
-        "/bin",
-        "/bin",
-        "--proc",
-        "/proc",
-        "--dev",
-        "/dev",
-        "--",
-        "/usr/bin/true",
-      ],
-      { stdio: "ignore", timeout: 3000 }
-    );
+    execFileSync(bwrapPath, BWRAP_ISOLATION_PROBE_ARGS, {
+      stdio: "ignore",
+      timeout: 3000,
+    });
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Same probe, but keeps what it learned. `probeBwrap` is what the reporting
+ * path uses; `bwrapDeliversIsolation` stays as the boolean predicate the
+ * strategy selection already reads, so selection behaviour is untouched.
+ */
+function probeBwrap(): BwrapProbe {
+  const bwrapPath = which("bwrap");
+  if (!bwrapPath || !fs.existsSync(bwrapPath)) {
+    return { isolated: false, reason: "not_found" };
+  }
+  try {
+    execFileSync(bwrapPath, BWRAP_ISOLATION_PROBE_ARGS, {
+      stdio: "pipe",
+      timeout: 3000,
+    });
+    return { isolated: true };
+  } catch (err) {
+    // The stderr of a refused unshare is the actionable part ("No permissions
+    // to creating new namespace", "setting up uid map: Permission denied").
+    // Swallowing it is what left operators with a bare exit 127 and a warning
+    // that named the wrong cause.
+    const e = err as { stderr?: Buffer | string; message?: string };
+    const stderr =
+      typeof e.stderr === "string" ? e.stderr : (e.stderr?.toString() ?? "");
+    const detail = (stderr.trim() || e.message || "unknown error")
+      .split("\n")
+      .slice(0, 2)
+      .join(" ")
+      .slice(0, 300);
+    return { isolated: false, reason: "unshare_denied", detail };
   }
 }
 
@@ -186,13 +241,85 @@ export function probeSandboxStrategy(): SandboxStrategy {
 
   if (!warnedNoSandbox) {
     warnedNoSandbox = true;
-    console.warn(
-      `[exec-sandbox] No sandbox available on platform=${process.platform}. ` +
-        `Spawned binaries will run with host privileges. ` +
-        `Install bubblewrap (Linux) or check sandbox-exec (macOS).`
-    );
+    console.warn(`[exec-sandbox] ${describeNoSandbox()}`);
   }
   return setCache(key, { kind: "none" });
+}
+
+/**
+ * Describe what the probe actually observed, rather than prescribing a remedy.
+ *
+ * The previous message said "Install bubblewrap (Linux) or check sandbox-exec
+ * (macOS)" for every no-sandbox outcome. On the managed cluster that is wrong
+ * twice: bubblewrap may already be installed, and installing it cannot help,
+ * because the refusal is the runtime's uid_map restriction rather than a
+ * missing package (charts/lobu/values.yaml records the measurement). An
+ * operator who follows that advice loses time and still ends up with
+ * contributed CLIs exiting 127 — which is the intended, documented behaviour
+ * for that environment, not a fault to chase.
+ *
+ * So: report the platform, what was looked for, what was found, and the
+ * kernel's own refusal text when there is one. The remedy is only stated in the
+ * case where a remedy exists.
+ */
+export function describeNoSandbox(): string {
+  if (process.platform === "darwin") {
+    const p = which("sandbox-exec") ?? "/usr/bin/sandbox-exec";
+    return formatNoSandboxReport(process.platform, {
+      sandboxExec: { path: p, present: fs.existsSync(p) },
+    });
+  }
+  if (process.platform !== "linux") {
+    return formatNoSandboxReport(process.platform, {});
+  }
+  return formatNoSandboxReport(process.platform, { bwrap: probeBwrap() });
+}
+
+/**
+ * Pure formatter: given observed facts, produce the report. Separated from the
+ * gathering so every branch is reachable in a test on any host — otherwise the
+ * Linux userns wording (the case that actually matters in production) could
+ * only ever be asserted on a Linux CI box that also happens to block userns,
+ * and would silently go uncovered everywhere else.
+ */
+export function formatNoSandboxReport(
+  platform: string,
+  observed: {
+    sandboxExec?: { path: string; present: boolean };
+    bwrap?: BwrapProbe;
+  }
+): string {
+  const head = `No sandbox available on platform=${platform}; spawned binaries run with host privileges.`;
+
+  if (observed.sandboxExec !== undefined) {
+    const { path: execPath, present } = observed.sandboxExec;
+    if (present) {
+      // Reaching here means selection and reporting disagree; say so rather
+      // than misreport a binary that exists as missing.
+      return `${head} Inconsistent probe: sandbox-exec exists at ${execPath} but was not selected. Please report this — it indicates a bug in strategy selection, not a host misconfiguration.`;
+    }
+    return `${head} Probed sandbox-exec at ${execPath}: not present. Expected on stock macOS — a trimmed or non-standard image is the usual cause.`;
+  }
+
+  const probe = observed.bwrap;
+  if (!probe) {
+    return `${head} No sandbox backend is implemented for this platform (bwrap is Linux-only, sandbox-exec macOS-only).`;
+  }
+
+  if (probe.isolated) {
+    // Reaching here means selection and reporting disagree; say so rather than
+    // print a confident story about a state that shouldn't exist.
+    return `${head} Inconsistent probe: bubblewrap reported working isolation on re-probe but was not selected. Please report this — it indicates a bug in strategy selection, not a host misconfiguration.`;
+  }
+  if (probe.reason === "not_found") {
+    return `${head} bubblewrap (bwrap) was not found on PATH. Installing it enables the sandbox on hosts whose kernel permits unprivileged user namespaces.`;
+  }
+  return (
+    `${head} bubblewrap is installed but could not create a user namespace: ${probe.detail}. ` +
+    `This is a host/runtime policy (unprivileged userns or uid_map restricted), not a missing package — ` +
+    `installing bubblewrap again will not change it. On the managed cluster this is the expected state and ` +
+    `contributed CLIs are refused by design; see charts/lobu/values.yaml.`
+  );
 }
 
 /** For tests: forget the cached strategy + warning state. */


### PR DESCRIPTION
## Summary

- `bwrapDeliversIsolation`'s own comment says a failed isolation probe is something *"we should surface rather than silently degrade"* — then throws the reason away in a bare `catch {}`. Every no-sandbox outcome printed one prescription: *"Install bubblewrap (Linux) or check sandbox-exec (macOS)"*.
- On the managed cluster that is wrong twice. bubblewrap **is** installed, and installing it could not help anyway: the refusal is the runtime's `uid_map` restriction, which `charts/lobu/values.yaml` already records as unfixable by any `securityContext` change. An operator who follows that advice chases a package that is already present and still ends up with contributed CLIs exiting 127 — the intended, documented behaviour there, not a fault to chase.
- The report now states what was **observed**, and offers a remedy only in the one case where a remedy exists (bwrap genuinely absent).

**Selection behaviour is unchanged.** `bwrapDeliversIsolation` remains the predicate strategy selection reads; `probeBwrap` is a separate reporting path. Both read one shared `BWRAP_ISOLATION_PROBE_ARGS`, so they can never end up answering about different flag sets — a drift that would make the diagnostic describe a probe selection never ran.

Also adds `exec-sandbox-backend-probe` to CI as a **measurement, not a gate**: bwrap status, whether `systemd-run --user` is viable as an alternative backend, and both userns sysctls. `continue-on-error: true` — nothing depends on the answer yet, and a runner without a user session must not redden main.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test packages/agent-worker/src/__tests__/exec-sandbox.test.ts` — 37 pass / 12 skip (bwrap matrix is Linux-only)
- [x] Bug fix: red→fix→green below
- [ ] If bot behavior: n/a

### Red → green

Mutation: drop `${probe.detail}` from the userns branch and restore the old universal prescription — i.e. put back exactly the message this PR removes.

```
RED
  Expected to contain: "setting up uid map: Permission denied"
  Received: "No sandbox available on platform=linux; spawned binaries run with
  host privileges. Install bubblewrap (Linux) or check sandbox-exec (macOS). ..."
  (fail) describeNoSandbox / formatNoSandboxReport > a userns refusal is
         reported as host policy, never as a missing package
   36 pass | 12 skip | 1 fail

GREEN (restored)
   37 pass | 12 skip | 0 fail
```

## Notes

### Why `formatNoSandboxReport` is split out as a pure function

The branch that matters in production is the Linux userns refusal. Gathering and formatting together, it would be assertable only on a Linux CI box that *also* happens to block userns — so it would silently go uncovered everywhere, including here. Splitting the pure formatter makes every branch reachable on any host.

### Why the CI job is `continue-on-error`

It answers an open question (*is `systemd-run --user` available to us as an alternative backend?*) with a fact instead of an assumption. Nothing reads the answer yet. Read the step summary; do not gate on it. No checkout — the probe only inspects the runner.

### Not in scope

Contributed CLIs exiting 127 on the managed cluster stays intended and documented. This PR changes only what the log *says*, never which strategy is selected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->