### PR TITLE
chore(submodule): bump owletto pointer to current main

### DIFF
--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -454,18 +454,29 @@ describe('device connector manifests', () => {
   it('admits os.shell on macOS and does not let one unknown key drop its siblings', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
 
-    // Prime the poll handler's module-level due-feed-materialize cooldown, as
-    // the first test in this file does and for the same reason: the suite runs
-    // singleFork + isolate:false, so whether a preceding poll left the cooldown
-    // hot changes what this one does. Without it this test failed ~2 runs in 7.
-    const primer = await poll(workerId, []);
-    expect(primer.status).toBe(200);
-
     // Synthetic sibling on purpose. A real key like `apple.screen_time` also
     // exists in the bundled device-connector catalog, which puts it on a
     // different reconcile path and makes the result depend on catalog state
     // rather than on the allowlist under test.
-    const shell = manifest({ key: 'os.shell', required_capability: 'os.shell' });
+    // Distinct display name is load-bearing, not cosmetic. `ensureDeviceConnectorWired`
+    // runs per key under Promise.allSettled with an advisory lock keyed on
+    // (userId, connectorKey), so two manifests sharing a name race
+    // ensureUniqueConnectionSlug: one connection INSERT loses on
+    // connections_org_slug_unique and allSettled swallows it, leaving the
+    // sibling's definition unwired. That is a test-only collision here, but see
+    // the note below — the race itself is not test-only.
+    //
+    // NOT test-only: two same-named device-manifest connectors wired in one
+    // reconcile pass can genuinely lose a connection INSERT in production. It
+    // self-heals on the next poll (slug suffixing), and today's real manifests
+    // all carry distinct names, so it is latent rather than live. Tracked
+    // separately — fixing the swallowed unique violation in
+    // ensureDeviceConnectorWired is a different concern from this allowlist.
+    const shell = manifest({
+      key: 'os.shell',
+      required_capability: 'os.shell',
+      name: 'OS Shell Probe',
+    });
     const sibling = manifest();
 
     const res = await poll(workerId, [shell, sibling], 'macos', {

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -529,6 +529,7 @@ describe('device connector manifests', () => {
     expect(await readDefinition(orgId, 'apple.screen_time')).not.toBeNull();
     expect(await readDefinition(orgId, 'apple.computer_use')).not.toBeNull();
     expect(await readDefinition(orgId, 'local.directory')).not.toBeNull();
+    expect(await readDefinition(orgId, 'os.shell')).not.toBeNull();
     expect(await readDefinition(orgId, 'chrome.history')).toBeNull();
 
     const whatsapp = await readDefinition(orgId, 'whatsapp.local');

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -438,6 +438,52 @@ describe('device connector manifests', () => {
     expect(await readDefinition(orgId, 'chrome.history')).toBeNull();
   });
 
+  /**
+   * `os.shell` is admitted for macOS, and — the part that actually bit — an
+   * unrecognised key does not merely drop itself. It sets
+   * `accepted = false` for the whole payload, and the caller then declines to
+   * replace the device's inventory at all, so every OTHER connector on that
+   * device disappears with it. That is deliberate (a malformed poll must not
+   * look like removal), which is exactly why the key allowlist must not lag
+   * behind the capability allowlist in @lobu/core.
+   *
+   * Asserted here with a synthetic manifest rather than relying on the
+   * real-Owletto-manifests test above: that one only covers `os.shell` for as
+   * long as owletto happens to ship `os_shell.json`.
+   */
+  it('admits os.shell on macOS and does not let one unknown key drop its siblings', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+
+    // Prime the poll handler's module-level due-feed-materialize cooldown, as
+    // the first test in this file does and for the same reason: the suite runs
+    // singleFork + isolate:false, so whether a preceding poll left the cooldown
+    // hot changes what this one does. Without it this test failed ~2 runs in 7.
+    const primer = await poll(workerId, []);
+    expect(primer.status).toBe(200);
+
+    // Synthetic sibling on purpose. A real key like `apple.screen_time` also
+    // exists in the bundled device-connector catalog, which puts it on a
+    // different reconcile path and makes the result depend on catalog state
+    // rather than on the allowlist under test.
+    const shell = manifest({ key: 'os.shell', required_capability: 'os.shell' });
+    const sibling = manifest();
+
+    const res = await poll(workerId, [shell, sibling], 'macos', {
+      'os.shell': true,
+      screentime: true,
+    });
+    expect(res.status).toBe(200);
+
+    // The sibling survives. This is the whole regression: pre-fix, `os.shell`
+    // was rejected by the key allowlist, which set accepted=false for the
+    // entire payload and left apple.screen_time uninstalled alongside it.
+    //
+    // Deliberately NOT asserting that os.shell's own definition materializes —
+    // it declares no feeds, and what reconcile does with a feedless device
+    // connector is a separate question this test has no business pinning.
+    expect(await readDefinition(orgId)).not.toBeNull();
+  });
+
   it('drops a manifest that still declares removed entityLinks rules', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
     const legacyManifest = manifest({

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -264,9 +264,19 @@ function compareSemverish(a: string, b: string): number {
   return a.localeCompare(b);
 }
 
+// Device-connector keys the platform's bridge is allowed to register. A key
+// outside this list rejects the WHOLE poll payload (see `accepted` above), so a
+// new on-device connector must land here in the same change that ships its
+// manifest — `os.shell` is the Mac shell connector (owletto#669), whose
+// `os.shell` capability is already allowlisted in `@lobu/core`.
 function connectorKeyAllowedForPlatform(platform: string, key: string): boolean {
   if (platform === 'macos') {
-    return key.startsWith('apple.') || key === 'local.directory' || key === 'whatsapp.local';
+    return (
+      key.startsWith('apple.') ||
+      key === 'local.directory' ||
+      key === 'whatsapp.local' ||
+      key === 'os.shell'
+    );
   }
   if (platform === 'chrome-extension') {
     return key === 'chrome' || key.startsWith('chrome.');


### PR DESCRIPTION
## Summary

- owletto#669 (`os.shell` connector for device-bound shell commands) merged without the parent pointer bump, so `check-drift` — a **required** check — fails on every open PR until this lands. Found it blocking #2395.

Pinned `21fc1c33` → `dd21025a`.

**Verified forward-only**, since a stale submodule pointer is the classic way to silently revert merged work:

```
$ git -C packages/owletto merge-base --is-ancestor 21fc1c33 dd21025a && echo ok
ok
```

The old pointer is an ancestor of the new one, so nothing merged is being undone. Commits picked up:

```
dd21025a fix(mac): poll at action interval when os.shell is enabled (#670)
fdcb39ff chore: update images
387439d8 feat(mac): add os.shell connector for device-bound shell commands (#669)
5d0b3fec chore: update images
1cb6eeec chore: update images
28fa0f33 chore: update images
621c0d15 chore: update images
5ef2d7af chore: update images
```

`dd21025a` landed on owletto/main after this branch first pinned `fdcb39ff`, reddening `check-drift` again; the pointer was advanced to catch it. Its diff is Swift-only (`apps/mac/Owletto/AppState.swift`) and touches no `ConnectorManifests/`, so the real-manifest parity test below is unaffected.

## No longer pointer-only: the gateway had to learn `os.shell`

The bump alone red the `integration` job — `device-connector-manifests.test.ts` polls with the *real* Mac manifests and asserts each one installs, and after the bump **zero** definitions installed (`expected null not to be null` on `apple.screen_time`, which the bump does not touch). Cause is the macOS device-manifest key allowlist: it recognized `apple.*`, `local.directory`, and `whatsapp.local`, so `os.shell` threw. A single throw sets `accepted = false`, which drops the **entire** poll payload, not just the offending manifest — hence a new connector taking every existing one down with it.

```ts
function connectorKeyAllowedForPlatform(platform: string, key: string): boolean {
  if (platform === 'macos') {
    return (
      key.startsWith('apple.') ||
      key === 'local.directory' ||
      key === 'whatsapp.local' ||
      key === 'os.shell'
    );
  }
  // ...
}
```

The matching `os.shell` *capability* was already allowlisted in `@lobu/core` (`OS_CAPABILITIES`), so this is the one remaining gate. The parity test now asserts `os.shell` installs too, so the next on-device connector fails loudly on its own key instead of silently voiding the whole inventory.

## Test plan
- [x] Ran the manifest validator over all 10 real `apps/mac/Owletto/ConnectorManifests/*.json`: red before (`os_shell.json` → `key-not-allowed-for-macos`, payload rejected), all 10 `ok` after
- [x] `integration` job is the gate for the parity test — see CI on this PR
- [ ] Bug fix: n/a (CI-surfaced gate, covered by the existing parity test)
- [ ] If bot behavior: n/a

## Notes

Branched fresh from `origin/main`. Worth flagging: a leftover `feat/owletto-pointer-bump` worktree from a previous bump still pinned `260a9861`, which is now *behind* main — reusing it would have pushed the pointer backwards. Hence the dated branch name and the ancestry assertion above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS device integrations now support shell-based operating system manifests.
  * Existing macOS connectors continue to work when additional unknown manifest keys are present.

* **Bug Fixes**
  * Fixed macOS manifest validation so supported shell configurations are accepted without affecting sibling connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
