### PR TITLE
feat(server): surface trigger_feed's dry_run on the ClientSDK

### DIFF
--- a/packages/server/src/__tests__/integration/feeds-sdk-trigger-dry-run.test.ts
+++ b/packages/server/src/__tests__/integration/feeds-sdk-trigger-dry-run.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `client.feeds.trigger({ feed_id, dry_run: true })` reaches the dry path.
+ *
+ * The declared SDK input type is no runtime guarantee: sandbox scripts are
+ * transpiled by esbuild, which strips types without checking them, and
+ * `feeds.trigger` just forwards its input through `createActionCaller` to the
+ * `trigger_feed` action. So these tests exercise the real chain — namespace →
+ * action caller → manage_feeds → TriggerFeedAction → createSyncRun — and read
+ * the persisted `runs` row rather than trusting the returned payload.
+ *
+ * The non-dry control is what gives the dry assertions meaning: without it, a
+ * build that hardcoded `dry_run = true` on every triggered run would pass.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { buildFeedsNamespace } from '../../sandbox/namespaces/feeds';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  createTestConnection,
+  createTestConnectorDefinition,
+  seedOwnerContext,
+} from '../setup/test-fixtures';
+
+async function seedFeed(slug: string): Promise<{
+  feedId: number;
+  ctx: Awaited<ReturnType<typeof seedOwnerContext>>['ctx'];
+}> {
+  const sql = getTestDb();
+  const { org, ctx } = await seedOwnerContext();
+
+  // Org-scoped, not the global catalog row: `resolveActiveConnectorVersion`
+  // resolves on (connector_key, org), and a global-only definition makes
+  // createSyncRun soft-delete the feed as an orphan and return null — which the
+  // handler then reports as "Sync already pending or running".
+  await createTestConnectorDefinition({
+    key: 'rss',
+    name: 'RSS',
+    organization_id: org.id,
+  });
+  const conn = await createTestConnection({
+    organization_id: org.id,
+    connector_key: 'rss',
+    slug,
+  });
+
+  const feed = (await sql`
+    INSERT INTO feeds
+      (organization_id, connection_id, feed_key, status, checkpoint,
+       created_at, updated_at)
+    VALUES
+      (${org.id}, ${conn.id}, 'items', 'active', ${sql.json({ cursor: 'c0' })},
+       NOW(), NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+
+  return { feedId: Number(feed[0].id), ctx };
+}
+
+describe('client.feeds.trigger dry_run', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('marks the queued run dry when the SDK caller asks for it', async () => {
+    const sql = getTestDb();
+    const { feedId, ctx } = await seedFeed('rss-sdk-dry');
+
+    const feeds = buildFeedsNamespace(ctx, {} as Env);
+    await feeds.trigger({ feed_id: feedId, dry_run: true });
+
+    const runs = (await sql`
+      SELECT dry_run FROM runs WHERE feed_id = ${feedId}
+    `) as Array<{ dry_run: boolean }>;
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].dry_run).toBe(true);
+  });
+
+  it('leaves the run persistent when dry_run is omitted', async () => {
+    const sql = getTestDb();
+    const { feedId, ctx } = await seedFeed('rss-sdk-wet');
+
+    const feeds = buildFeedsNamespace(ctx, {} as Env);
+    await feeds.trigger({ feed_id: feedId });
+
+    const runs = (await sql`
+      SELECT dry_run FROM runs WHERE feed_id = ${feedId}
+    `) as Array<{ dry_run: boolean }>;
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].dry_run).toBe(false);
+  });
+
+  it('does not let a caller-supplied action key redirect the dry flag', async () => {
+    // `createActionCaller` strips a caller `action` before forcing the real
+    // one. Asserted here because the dry flag rides the same payload: if that
+    // strip regressed, `dry_run` could arrive at a handler that ignores it and
+    // the caller would get a persistent run while being told it was dry.
+    const sql = getTestDb();
+    const { feedId, ctx } = await seedFeed('rss-sdk-spoof');
+
+    const feeds = buildFeedsNamespace(ctx, {} as Env);
+    await feeds.trigger({
+      feed_id: feedId,
+      dry_run: true,
+      action: 'delete_feed',
+    } as { feed_id: number; dry_run?: boolean });
+
+    const runs = (await sql`
+      SELECT dry_run FROM runs WHERE feed_id = ${feedId}
+    `) as Array<{ dry_run: boolean }>;
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].dry_run).toBe(true);
+
+    const feed = (await sql`
+      SELECT status FROM feeds WHERE id = ${feedId}
+    `) as Array<{ status: string }>;
+    expect(feed[0].status).toBe('active');
+  });
+});

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -873,9 +873,13 @@ export default async (_ctx, client) => {
 		example: "await client.feeds.delete({ feed_id: 42 });",
 	},
 	"feeds.trigger": {
-		summary: "Trigger an immediate sync for a feed (external side-effect).",
+		summary:
+			"Trigger an immediate sync for a feed (external side-effect). Pass dry_run: true to execute the connector for real but persist nothing — no events, entities or attachments, and the feed's checkpoint and sync state do not move; the run executes asynchronously, and once it completes a capped preview of what would have been ingested is on its dry_run_preview, readable via feeds.get. Use it to test a feed's config or credentials without writing to the workspace. Two limits: it cannot undo side effects the connector causes UPSTREAM (marking a message read, etc.), and it occupies the feed's single active-sync slot while it runs.",
 		access: "external",
-		example: "await client.feeds.trigger({ feed_id: 42 });",
+		signature:
+			"feeds.trigger(input: { feed_id: number; dry_run?: boolean }): Promise<unknown>",
+		example:
+			"await client.feeds.trigger({ feed_id: 42 });\n// Validate without writing anything; read the preview via feeds.get once the run completes:\nawait client.feeds.trigger({ feed_id: 42, dry_run: true });",
 	},
 
 	// authProfiles

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -44,7 +44,16 @@ export interface FeedsNamespace {
 		timezone?: string | null;
 	}): Promise<unknown>;
 	delete(input: { feed_id: number }): Promise<unknown>;
-	trigger(input: { feed_id: number }): Promise<unknown>;
+	trigger(input: {
+		feed_id: number;
+		/**
+		 * Run the connector for real but persist nothing — no events, entities or
+		 * attachments, and the feed's checkpoint and sync state stay put. Once the
+		 * run completes, a capped preview of what would have been ingested is on
+		 * its `dry_run_preview`, readable via `feeds.get`.
+		 */
+		dry_run?: boolean;
+	}): Promise<unknown>;
 }
 
 export function buildFeedsNamespace(


### PR DESCRIPTION
## Summary

- `runs.dry_run` (#2390) shipped with `manage_feeds` as its only proven caller. On the ClientSDK — the surface agents actually write against — `feeds.trigger` declared `{ feed_id: number }` and its discovery metadata said nothing about the flag, so **an agent had no way to learn it exists**.
- This widens the declared type and documents it in `method-metadata`, which is what `search_sdk` renders.

**No behaviour change.** `feeds.trigger` never called `createSyncRun`; it forwards its input verbatim through `createActionCaller` to the `trigger_feed` action, whose TypeBox schema has accepted `dry_run` since the flag shipped. Sandbox scripts are transpiled by esbuild, which strips types without checking them, so the narrow declared type never blocked anything at runtime either.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bunx vitest run src/__tests__/integration/feeds-sdk-trigger-dry-run.test.ts` — 3 passed
- [x] Bug fix: n/a — this documents existing behaviour; evidence below is the *inverse* of red→green
- [ ] If bot behavior: n/a

### Evidence: the behaviour pre-existed

The usual red→green would be misleading here, so the check is the opposite one — the new tests pass against **completely unmodified source**:

```
=== source reverted; only the new test file present ===
?? src/__tests__/integration/feeds-sdk-trigger-dry-run.test.ts
=== run against UNMODIFIED source ===
 ✓ feeds-sdk-trigger-dry-run.test.ts (3 tests)
      Tests  3 passed (3)
```

With the change:

```
      Tests  3 passed (3)
```

That is why the tests are the load-bearing part of this PR: *widening a type to match behaviour* and *adding behaviour* are indistinguishable in a diff without them.

## Notes

### What the tests actually exercise

The real chain — namespace → `createActionCaller` → `manage_feeds` → `TriggerFeedAction` → `createSyncRun` — reading the persisted `runs` row rather than trusting the returned payload.

- **dry** — `trigger({ feed_id, dry_run: true })` ⇒ `runs.dry_run = true`
- **control** — `trigger({ feed_id })` ⇒ `runs.dry_run = false`. Without it, a build that hardcoded `dry_run = true` on every triggered run would pass.
- **spoof** — a caller-supplied `action` key is still stripped by `createActionCaller`. Included because the dry flag rides that same payload: if the strip regressed, `dry_run` could reach a handler that ignores it and the caller would be told "dry" while getting a persistent run.

### A fixture trap worth recording

`createTestConnectorDefinition` defaults to `organization_id: null` (the global catalog row), but `resolveActiveConnectorVersion` resolves on `(connector_key, org)`. With a global-only definition, `createSyncRun` soft-deletes the feed as an orphan and returns `null` — which `handleTriggerFeed` then reports as **"Sync already pending or running for this feed"**. That message is misleading for anything that isn't actually a duplicate run; worth a separate look, not touched here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->