### PR TITLE
fix(server): tell the caller why no sync run was queued

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
@@ -78,7 +78,8 @@ describe('createSyncRun cloud gate (postgres) — queue-time', () => {
     const { feedId } = await setupPostgresFeed();
 
     process.env.LOBU_CLOUD_MODE = '1';
-    const runId = await createSyncRun(feedId, {} as Env, sql);
+    const created = await createSyncRun(feedId, {} as Env, sql);
+    const runId = created.ok ? created.runId : null;
 
     expect(runId).not.toBeNull();
     const runs = await sql`SELECT status FROM runs WHERE feed_id = ${feedId}`;
@@ -90,7 +91,8 @@ describe('createSyncRun cloud gate (postgres) — queue-time', () => {
     const { feedId } = await setupPostgresFeed();
 
     process.env.LOBU_CLOUD_MODE = undefined;
-    const runId = await createSyncRun(feedId, {} as Env, sql);
+    const created = await createSyncRun(feedId, {} as Env, sql);
+    const runId = created.ok ? created.runId : null;
 
     expect(runId).not.toBeNull();
     const runs = await sql`SELECT status FROM runs WHERE feed_id = ${feedId}`;

--- a/packages/server/src/__tests__/integration/connectors/sync-run-orphan-feed.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/sync-run-orphan-feed.test.ts
@@ -45,7 +45,8 @@ describe('createSyncRun orphan-feed handling (#1012)', () => {
     const feedId = Number((feed as { id: number }).id);
 
     // Pre-fix: threw "has no compiled code and no bundled source file".
-    const runId = await createSyncRun(feedId, {} as Env, sql);
+    const created = await createSyncRun(feedId, {} as Env, sql);
+    const runId = created.ok ? created.runId : null;
     expect(runId).toBeNull();
 
     const [after] = await sql`SELECT deleted_at FROM feeds WHERE id = ${feedId}`;

--- a/packages/server/src/__tests__/integration/events/scheduling-contract.test.ts
+++ b/packages/server/src/__tests__/integration/events/scheduling-contract.test.ts
@@ -214,7 +214,8 @@ describe('scheduler and worker ingestion contracts', () => {
       RETURNING id
     `;
 
-    const runId = await createSyncRun(Number(feed.id), {} as Env, sql);
+    const created = await createSyncRun(Number(feed.id), {} as Env, sql);
+    const runId = created.ok ? created.runId : null;
     expect(runId).not.toBeNull();
 
     const [queuedFeed] = await sql`

--- a/packages/server/src/__tests__/integration/trigger-feed-skip-reason.test.ts
+++ b/packages/server/src/__tests__/integration/trigger-feed-skip-reason.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `trigger_feed` must say WHY no run was queued.
+ *
+ * `createSyncRun` declines for five distinct reasons — an active run already
+ * exists, the feed is gone, the connector is cloud-restricted, the connector was
+ * uninstalled, or its version has no runnable code — and it used to signal all
+ * five with a bare `null`. `handleTriggerFeed` rendered that as:
+ *
+ *     "Sync already pending or running for this feed"
+ *
+ * which is true for exactly one of them. For the other four an operator is told
+ * to wait for a run that does not exist and never will. This is not
+ * hypothetical: it cost a debugging cycle in this repo when a fixture created a
+ * globally-scoped connector definition, `resolveActiveConnectorVersion` found
+ * nothing for the org, the feed was soft-deleted as an orphan, and the tool
+ * reported a pending sync.
+ *
+ * The uninstalled-connector case is the one asserted here because it is the one
+ * that actually misled someone, and because it is reachable without stubbing
+ * `createSyncRun` — the whole point is to exercise the real skip path rather
+ * than a mocked return value.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { manageFeeds } from '../../tools/admin/manage_feeds';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  createTestConnection,
+  createTestConnectorDefinition,
+  seedOwnerContext,
+} from '../setup/test-fixtures';
+
+async function seedFeed(opts: { orgScopedDefinition: boolean }) {
+  const sql = getTestDb();
+  const { org, ctx } = await seedOwnerContext();
+
+  await createTestConnectorDefinition({
+    key: 'rss',
+    name: 'RSS',
+    // The switch under test. Org-scoped resolves and the run queues; global-only
+    // is invisible to resolveActiveConnectorVersion, which retires the feed as
+    // an orphan and declines — the case that used to report "already pending".
+    ...(opts.orgScopedDefinition ? { organization_id: org.id } : {}),
+  });
+  const conn = await createTestConnection({
+    organization_id: org.id,
+    connector_key: 'rss',
+    slug: `rss-skip-${opts.orgScopedDefinition ? 'ok' : 'orphan'}`,
+  });
+
+  const feed = (await sql`
+    INSERT INTO feeds
+      (organization_id, connection_id, feed_key, status, checkpoint, created_at, updated_at)
+    VALUES
+      (${org.id}, ${conn.id}, 'items', 'active', ${sql.json({ cursor: 'c0' })}, NOW(), NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+
+  return { feedId: Number(feed[0].id), ctx };
+}
+
+describe('trigger_feed skip reasons', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('does not claim a sync is pending when the connector is uninstalled', async () => {
+    const { feedId, ctx } = await seedFeed({ orgScopedDefinition: false });
+
+    const res = (await manageFeeds(
+      { action: 'trigger_feed', feed_id: feedId },
+      {} as Env,
+      ctx
+    )) as { action?: string; message?: string; triggered?: boolean };
+
+    expect(res.triggered).toBeUndefined();
+    // The actionable part: name the real cause.
+    expect(res.message).toContain('no longer installed');
+    // And explicitly NOT the old catch-all, which sent operators off to wait
+    // for a run that was never created.
+    expect(res.message).not.toContain('already pending');
+  });
+
+  it('still reports a genuine duplicate as already pending', async () => {
+    const { feedId, ctx } = await seedFeed({ orgScopedDefinition: true });
+
+    const first = (await manageFeeds(
+      { action: 'trigger_feed', feed_id: feedId },
+      {} as Env,
+      ctx
+    )) as { triggered?: boolean; run_id?: number };
+    expect(first.triggered).toBe(true);
+
+    // Second trigger while the first run is still active — this is the one
+    // case the old message was right about, and it must stay right.
+    const second = (await manageFeeds(
+      { action: 'trigger_feed', feed_id: feedId },
+      {} as Env,
+      ctx
+    )) as { message?: string; triggered?: boolean };
+
+    expect(second.triggered).toBeUndefined();
+    expect(second.message).toContain('already pending or running');
+  });
+});

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -42,7 +42,7 @@ import {
 } from '../tools/admin/helpers/connection-helpers';
 import { registerConnectorWebhook } from './webhook-registration';
 import { mergeOAuthScopeAuthData, normalizeScopeList } from '../auth/oauth/scopes';
-import { createSyncRun } from '../runs/queue-service';
+import { createSyncRun, describeSyncRunSkip } from '../runs/queue-service';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 import { buildConnectionsUrl, getOrganizationSlug, getPublicWebUrl } from '../utils/url-builder';
 import {
@@ -331,11 +331,11 @@ connectRoutes.post('/:token/validate', requireConnectToken, async (c) => {
   });
 
   const feedId = Number(feed.id);
-  const runId = await createSyncRun(feedId, c.env as unknown as Env);
-
-  if (!runId) {
-    return c.json({ error: 'Failed to create validation run (may already be in progress)' }, 409);
+  const created = await createSyncRun(feedId, c.env as unknown as Env);
+  if (!created.ok) {
+    return c.json({ error: describeSyncRunSkip(created.reason) }, 409);
   }
+  const runId = created.runId;
 
   logger.info(
     { connection_id: tokenRow.connection_id, run_id: runId, feed_id: feedId },

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -744,7 +744,12 @@ export async function autoProvisionGithubIssueFeeds(params: {
 	const sql = getDb();
 	const enqueue =
 		params.enqueueSyncRun ??
-		((feedId: number) => createSyncRun(feedId, {} as never, sql));
+		(async (feedId: number) => {
+			const created = await createSyncRun(feedId, {} as never, sql);
+			// Callers here only record run ids; the skip reason is already logged
+			// by createSyncRun and this path has no surface to report it on.
+			return created.ok ? created.runId : null;
+		});
 
 	for (const repo of repos) {
 		// Create the issues feed for this repo, DB-enforced idempotent on

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -244,15 +244,51 @@ async function resolveActiveConnectorVersion(
 }
 
 /**
- * Create a pending sync run for a feed (within an existing client/tx). Returns
- * the run ID, or null if skipped — a duplicate active sync run, or an
- * unresolvable orphan feed that was soft-deleted (see softDeleteOrphanFeed).
+ * Why no sync run was queued. The reasons differ in remedy — `already_active`
+ * resolves itself when the current run finishes, while the others never will
+ * (the two connector reasons also retire the feed) — so callers that surface
+ * a skip to a human must render the specific reason, not a catch-all.
+ */
+export type SyncRunSkipReason =
+  | 'already_active'
+  | 'feed_not_found'
+  | 'cloud_restricted'
+  | 'connector_uninstalled'
+  | 'connector_version_unrunnable';
+
+export type CreateSyncRunResult =
+  | { ok: true; runId: number }
+  | { ok: false; reason: SyncRunSkipReason };
+
+/** Operator-facing sentence per cause. Kept beside the reasons so a new reason
+ *  cannot be added without deciding what a human should be told. */
+export function describeSyncRunSkip(reason: SyncRunSkipReason): string {
+  switch (reason) {
+    case 'already_active':
+      return 'Sync already pending or running for this feed';
+    case 'feed_not_found':
+      return 'Feed not found';
+    case 'cloud_restricted':
+      return 'This connector cannot run on Lobu Cloud yet, so no sync was queued';
+    case 'connector_uninstalled':
+      return 'The connector is no longer installed in this workspace; the feed has been retired';
+    case 'connector_version_unrunnable':
+      return 'The connector version has no runnable code; the feed has been retired';
+  }
+}
+
+/**
+ * Create a pending sync run for a feed (within an existing client/tx). Skips
+ * with a `SyncRunSkipReason` instead of queueing when a run is already active,
+ * the feed is missing or cloud-restricted, or the connector resolves to
+ * nothing runnable — the connector cases also soft-delete the feed (see
+ * softDeleteOrphanFeed).
  */
 async function createSyncRunWithClient(
   sql: DbClient,
   feedId: number,
   dryRun = false
-): Promise<number | null> {
+): Promise<CreateSyncRunResult> {
   // Check if there's already a pending/running run for this feed
   const existing = await sql`
     SELECT id FROM runs
@@ -266,7 +302,7 @@ async function createSyncRunWithClient(
     logger.info(
       `[queue] Skipping run creation for feed ${feedId} - already has pending/running run`
     );
-    return null;
+    return { ok: false, reason: 'already_active' };
   }
 
   // Get feed details (including pinned_version)
@@ -279,7 +315,7 @@ async function createSyncRunWithClient(
   `;
   if (feedRows.length === 0) {
     logger.warn(`[queue] Feed ${feedId} not found`);
-    return null;
+    return { ok: false, reason: 'feed_not_found' };
   }
   const feed = feedRows[0] as {
     organization_id: string;
@@ -301,7 +337,7 @@ async function createSyncRunWithClient(
       { feedId, connector_key: feed.connector_key },
       '[queue] Skipping sync run for cloud-restricted connector under LOBU_CLOUD_MODE'
     );
-    return null;
+    return { ok: false, reason: 'cloud_restricted' };
   }
 
   // Resolve connector version: pinned_version → connector_definitions.version,
@@ -324,7 +360,7 @@ async function createSyncRunWithClient(
         feed,
         'no active connector_definition for (connector_key, org).'
       );
-      return null;
+      return { ok: false, reason: 'connector_uninstalled' };
     }
     if (resolved.reason === 'no-version') {
       throw new Error(
@@ -342,7 +378,7 @@ async function createSyncRunWithClient(
       feed,
       `no compiled code and no bundled source for version '${resolved.version}'.`
     );
-    return null;
+    return { ok: false, reason: 'connector_version_unrunnable' };
   }
   const connectorVersion = resolved.version;
 
@@ -395,7 +431,7 @@ async function createSyncRunWithClient(
   logger.info(
     `[queue] Created sync run ${runId} for feed ${feedId} (${feed.connector_key}, version=${connectorVersion})`
   );
-  return runId;
+  return { ok: true, runId };
 }
 
 export async function createSyncRun(
@@ -406,7 +442,7 @@ export async function createSyncRun(
   // check-due-feeds, manage_feeds) keep persisting. Only an explicit opt-in is
   // dry — a flag that defaulted the other way would silently stop real syncs.
   opts?: { dryRun?: boolean }
-): Promise<number | null> {
+): Promise<CreateSyncRunResult> {
   const sql = db ?? getDb();
   const dryRun = opts?.dryRun === true;
 
@@ -421,7 +457,9 @@ export async function createSyncRun(
   } catch (error) {
     if (isUniqueViolation(error, 'idx_runs_active_sync_per_feed')) {
       logger.info(`[queue] Skipping run creation for feed ${feedId} - duplicate active sync run`);
-      return null;
+      // Lost the race against a concurrent trigger — indistinguishable, from
+      // here, from having found that run on the way in.
+      return { ok: false, reason: 'already_active' };
     }
     logger.error({ error }, `[queue] Failed to create sync run for feed ${feedId}`);
     throw error;

--- a/packages/server/src/scheduled/check-due-feeds.ts
+++ b/packages/server/src/scheduled/check-due-feeds.ts
@@ -65,7 +65,14 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
     },
     createRun: async (feed) => {
       const created = await createSyncRun(feed.id, env, sql);
-      if (!created.ok) return 'skipped';
+      if (!created.ok) {
+        // A skip is no longer necessarily a race: the connector may be
+        // cloud-restricted, uninstalled, or have no runnable version.
+        logger.debug(
+          `[CheckDueFeeds] Skipped feed ${feed.id} (${feed.connector_key}/${feed.feed_key}): ${created.reason}`
+        );
+        return 'skipped';
+      }
       const runId = created.runId;
       logger.debug(
         `[CheckDueFeeds] Created run ${runId} for feed ${feed.id} (${feed.connector_key}/${feed.feed_key})`
@@ -77,7 +84,7 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
     },
     onDone: ({ runsCreated, skipped }) => {
       if (runsCreated > 0) {
-        logger.info(`[CheckDueFeeds] Created ${runsCreated} runs (${skipped} skipped due to race)`);
+        logger.info(`[CheckDueFeeds] Created ${runsCreated} runs (${skipped} skipped)`);
       }
     },
   });

--- a/packages/server/src/scheduled/check-due-feeds.ts
+++ b/packages/server/src/scheduled/check-due-feeds.ts
@@ -64,8 +64,9 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
       logger.info(`[CheckDueFeeds] Found ${feeds.length} due feeds`);
     },
     createRun: async (feed) => {
-      const runId = await createSyncRun(feed.id, env, sql);
-      if (runId === null) return 'skipped';
+      const created = await createSyncRun(feed.id, env, sql);
+      if (!created.ok) return 'skipped';
+      const runId = created.runId;
       logger.debug(
         `[CheckDueFeeds] Created run ${runId} for feed ${feed.id} (${feed.connector_key}/${feed.feed_key})`
       );

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -48,7 +48,7 @@ import { recordChangeEvent } from '../../utils/insert-event';
 import { recordToolConfigChange } from './helpers/config-audit';
 import logger from '../../utils/logger';
 import { syncOAuthConnectionsForAuthProfile } from '../../utils/oauth-connection-state';
-import { createSyncRun } from '../../runs/queue-service';
+import { createSyncRun, describeSyncRunSkip } from '../../runs/queue-service';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../../utils/run-statuses';
 import type { ToolContext } from '../registry';
 import { action, defineActionTool } from './action-tool';
@@ -939,10 +939,11 @@ async function handleTriggerFeed(
   }
 
   const dryRun = args.dry_run === true;
-  const runId = await createSyncRun(args.feed_id, env, undefined, { dryRun });
-  if (runId === null) {
-    return { action: 'trigger_feed', message: 'Sync already pending or running for this feed' };
+  const created = await createSyncRun(args.feed_id, env, undefined, { dryRun });
+  if (!created.ok) {
+    return { action: 'trigger_feed', message: describeSyncRunSkip(created.reason) };
   }
+  const runId = created.runId;
 
   // `dry_run` is echoed only when true, and only because it was honoured. A
   // caller cannot otherwise distinguish "ran dry" from "flag silently dropped


### PR DESCRIPTION
## Summary

`createSyncRun` declines for **five** distinct reasons — an active run already exists, the feed is gone, the connector is cloud-restricted, the connector was uninstalled, or its version has no runnable code — and signalled all five with a bare `null`. `trigger_feed` rendered that as:

> Sync already pending or running for this feed

which is true for exactly one of them. For the other four an operator is told to wait for a run that does not exist and never will.

Not hypothetical — it cost a debugging cycle in this repo: a fixture created a globally-scoped connector definition, `resolveActiveConnectorVersion` found nothing for the org, the feed was soft-deleted as an orphan, and the tool reported a pending sync.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: 4 affected suites, 14 passed
- [x] Bug fix: red→fix→green below
- [ ] If bot behavior: n/a

### Red → green

Mutation restores the old catch-all message:

```
RED
  × does not claim a sync is pending when the connector is uninstalled
    → expected 'Sync already pending or running for t…' to contain 'no longer installed'
  ✓ still reports a genuine duplicate as already pending
   Tests  1 failed | 1 passed (2)

GREEN
   Tests  2 passed (2)
```

The duplicate-run control stays **green under that mutation**, so the suite is not merely asserting the new wording everywhere — it still pins the one case the old message got right.

## Notes

### Why the return type changed

Patching the message string alone is not possible: one `null` cannot be disambiguated at the call site. The return type becomes `{ ok: true; runId } | { ok: false; reason }`, and the compiler then found every caller:

| call site | change |
|---|---|
| `manage_feeds` | the user-facing fix |
| `connect/routes` | now reports the real reason in its 409 (see below) |
| `check-due-feeds` | collapses to the same `'skipped'` it already returned |
| `app-install` | collapses to the same `runId \| null` it already recorded |

The last two are behaviour-neutral by construction — they consume only truthiness.

### Same defect found at a second call site

`make review-fix` routed `connect/routes`' 409 through the same descriptions. The env_keys validation flow carried its own vague variant — *"Failed to create validation run (may already be in progress)"* — of exactly this bug. Fixing the class rather than the instance, per AGENTS.md.

### Why `describeSyncRunSkip` sits next to the reason union

So a sixth skip cause cannot be added without deciding what a human is told. That property's absence is what caused this in the first place; a `switch` over a closed union makes the omission a compile error rather than a silent fallthrough to the wrong sentence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added specific explanations when sync runs are skipped, including duplicate runs, missing feeds, cloud restrictions, and unavailable connectors.
  * Feed validation and administrative triggers now return actionable skip messages instead of generic errors.
  * Improved handling of sync-run creation outcomes across automatic and scheduled synchronization.

* **Tests**
  * Added coverage confirming accurate skip reasons for unavailable connectors and duplicate triggers.
  * Updated integration tests for the structured sync-run creation result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->