### PR TITLE
fix(server): retry the device-connector wire when its slug races a sibling

### DIFF
--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -458,20 +458,13 @@ describe('device connector manifests', () => {
     // exists in the bundled device-connector catalog, which puts it on a
     // different reconcile path and makes the result depend on catalog state
     // rather than on the allowlist under test.
-    // Distinct display name is load-bearing, not cosmetic. `ensureDeviceConnectorWired`
-    // runs per key under Promise.allSettled with an advisory lock keyed on
-    // (userId, connectorKey), so two manifests sharing a name race
-    // ensureUniqueConnectionSlug: one connection INSERT loses on
-    // connections_org_slug_unique and allSettled swallows it, leaving the
-    // sibling's definition unwired. That is a test-only collision here, but see
-    // the note below — the race itself is not test-only.
-    //
-    // NOT test-only: two same-named device-manifest connectors wired in one
-    // reconcile pass can genuinely lose a connection INSERT in production. It
-    // self-heals on the next poll (slug suffixing), and today's real manifests
-    // all carry distinct names, so it is latent rather than live. Tracked
-    // separately — fixing the swallowed unique violation in
-    // ensureDeviceConnectorWired is a different concern from this allowlist.
+    // Distinct display name keeps this test independent of the connection-slug
+    // race: two manifests sharing a name race ensureUniqueConnectionSlug under
+    // Promise.allSettled (the advisory lock is keyed on (userId, connectorKey),
+    // not the slug), and the loser's INSERT trips connections_org_slug_unique.
+    // ensureDeviceConnectorWired now retries that collision once — covered by
+    // device-reconcile-slug-race.test.ts — but the allowlist under test here
+    // has nothing to do with slugs, so the names stay distinct anyway.
     const shell = manifest({
       key: 'os.shell',
       required_capability: 'os.shell',

--- a/packages/server/src/__tests__/integration/device-reconcile-slug-race.test.ts
+++ b/packages/server/src/__tests__/integration/device-reconcile-slug-race.test.ts
@@ -1,5 +1,5 @@
 /**
- * Two device manifests sharing a display name must both wire.
+ * A device connector whose slug is taken out from under it must still wire.
  *
  * `ensureDeviceConnectorWired` derives a connection slug from the manifest's
  * display NAME, and `connections_org_slug_unique` enforces uniqueness per ORG —
@@ -14,6 +14,14 @@
  * device-connector-manifests.test.ts, where a sibling intermittently failed to
  * install.
  *
+ * The regression guard FORCES that interleaving instead of hoping for it: an
+ * uncommitted transaction squats on the exact slug the wire is about to
+ * compute, and is committed only once the wire's INSERT is observed parked on
+ * the unique index. Two live sibling manifests would reproduce it only
+ * probabilistically — a 15-round loop still left roughly a 1-in-8 chance of
+ * every round missing the collision, i.e. of the pre-fix code passing its own
+ * regression test.
+ *
  * Driven through the real poll endpoint rather than a hand-built
  * `device_workers` row — capabilities are stored in a shape poll owns, and a
  * fixture that guesses it wrong reconciles nothing and passes for the wrong
@@ -21,17 +29,21 @@
  * green). A stubbed rejection would be worse: it would pass against any
  * wrapper and prove nothing about the path that actually fails.
  *
- * Asserts the OUTCOME (both wired, distinct slugs) rather than a log line,
+ * Asserts the OUTCOME (wired, with the suffixed slug) rather than a log line,
  * because the fix makes the failure stop happening rather than merely become
  * visible.
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { generateSecureToken } from '../../auth/oauth/utils';
+import { slugifyConnectionName } from '../../utils/connections';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { post } from '../setup/test-helpers';
 
 const SHARED_NAME = 'Colliding Device Connector';
+/** The slug the wire computes from `SHARED_NAME` when nothing has claimed it. */
+const BASE_SLUG = slugifyConnectionName(SHARED_NAME);
+const SQUATTER_KEY = 'apple.collide_squatter';
 
 function manifestFor(key: string, capability: string) {
   return {
@@ -65,7 +77,16 @@ function manifestFor(key: string, capability: string) {
   };
 }
 
-async function pollWithCollidingManifests() {
+/** A promise plus its resolver, for handing control between two live tasks. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+async function seedFleet() {
   const sql = getTestDb();
   const userId = `user_${generateSecureToken(4)}`;
   const orgId = `org-wirefail-${generateSecureToken(4)}`;
@@ -90,22 +111,50 @@ async function pollWithCollidingManifests() {
     INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
     VALUES (${userId}, ${workerId}, 'macos', '0.1.0', ${sql.json([])}, 'Colliding Mac', ${orgId})
   `;
+  return { userId, orgId, workerId };
+}
 
-  const res = await post('/api/workers/poll', {
+function pollManifests(workerId: string, manifests: Array<ReturnType<typeof manifestFor>>) {
+  return post('/api/workers/poll', {
     body: {
       worker_id: workerId,
       platform: 'macos',
       app_version: '9.9.0',
       label: 'Colliding Mac',
       capabilities: { screentime: true, photos: true },
-      connector_manifests: [
-        manifestFor('apple.collide_one', 'screentime'),
-        manifestFor('apple.collide_two', 'photos'),
-      ],
+      connector_manifests: manifests,
     },
   });
-  expect(res.status).toBe(200);
-  return { userId, orgId };
+}
+
+/**
+ * Resolve once a backend is parked on `blockerPid`'s uncommitted row while
+ * inserting into `connections` — i.e. once the slug collision has actually
+ * happened. Waiting on this condition rather than on a fixed delay is what
+ * makes the collision deterministic: releasing the squatter any earlier would
+ * let the wire see the committed row and suffix its slug on the first try,
+ * exercising nothing.
+ */
+async function waitForWireBlockedOn(blockerPid: number): Promise<void> {
+  const sql = getTestDb();
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    const rows = (await sql`
+      SELECT count(*)::int AS blocked
+      FROM pg_stat_activity a
+      WHERE ${blockerPid}::int = ANY(pg_blocking_pids(a.pid))
+        AND a.query ILIKE '%INSERT INTO connections%'
+    `) as unknown as Array<{ blocked: number }>;
+    if ((rows[0]?.blocked ?? 0) > 0) return;
+    if (Date.now() > deadline) {
+      throw new Error(
+        'Timed out waiting for the device-connector wire to block on the squatted slug — ' +
+          'the wire no longer computes it from the manifest display name, so this test ' +
+          'is no longer forcing the collision it claims to force.'
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
 }
 
 describe('device connector slug race', () => {
@@ -113,35 +162,96 @@ describe('device connector slug race', () => {
     await cleanupTestDatabase();
   });
 
+  it('retries the wire when a concurrent insert takes the slug it computed', async () => {
+    const sql = getTestDb();
+    const { userId, orgId, workerId } = await seedFleet();
+
+    const squatterReady = deferred<number>();
+    const releaseSquatter = deferred<void>();
+
+    // Hold an UNCOMMITTED connection on the slug the wire is about to compute.
+    // `ensureUniqueConnectionSlug`'s SELECT cannot see it under READ COMMITTED,
+    // so the wire computes BASE_SLUG and its INSERT parks on the unique index
+    // until this transaction resolves — exactly the interleaving a sibling
+    // manifest produces in the field, minus the coin flip.
+    const squatter = sql.begin(async (tx) => {
+      await tx`
+        INSERT INTO connections (
+          organization_id, connector_key, slug, display_name, status,
+          auth_profile_id, app_auth_profile_id, config, created_by, visibility
+        ) VALUES (
+          ${orgId}, ${SQUATTER_KEY}, ${BASE_SLUG}, ${SHARED_NAME}, 'active',
+          NULL, NULL, NULL, ${userId}, 'private'
+        )
+      `;
+      const pidRows = (await tx`SELECT pg_backend_pid()::int AS pid`) as unknown as Array<{
+        pid: number;
+      }>;
+      squatterReady.resolve(pidRows[0].pid);
+      await releaseSquatter.promise;
+    });
+
+    let status: number;
+    try {
+      const squatterPid = await squatterReady.promise;
+      const polled = pollManifests(workerId, [manifestFor('apple.collide_one', 'screentime')]);
+      await waitForWireBlockedOn(squatterPid);
+      releaseSquatter.resolve();
+      // COMMIT: the parked INSERT wakes into the unique violation.
+      await squatter;
+      status = (await polled).status;
+    } finally {
+      // Never leave the squatter's transaction open if the wait above threw.
+      releaseSquatter.resolve();
+      await squatter.catch(() => {});
+    }
+    expect(status).toBe(200);
+
+    const conns = (await sql`
+      SELECT connector_key, slug FROM connections
+      WHERE organization_id = ${orgId} AND deleted_at IS NULL
+      ORDER BY connector_key
+    `) as unknown as Array<{ connector_key: string; slug: string }>;
+
+    // The connector must be wired. Pre-fix the unique violation escaped the
+    // wire and the row was simply absent — that absence is the whole defect,
+    // and it is what made an unrelated test flake ~1 run in 8.
+    expect(
+      conns.map((c) => c.connector_key),
+      'the wire lost the slug race and never retried'
+    ).toEqual(['apple.collide_one', SQUATTER_KEY]);
+
+    // And the retry must resolve the collision by suffixing against the now
+    // visible winner, not by betting on the same slug again.
+    expect(conns.find((c) => c.connector_key === 'apple.collide_one')?.slug).toBe(
+      `${BASE_SLUG}-2`
+    );
+  }, 60_000);
+
   it('wires both connectors when two manifests share a display name', async () => {
     const sql = getTestDb();
+    const { orgId, workerId } = await seedFleet();
 
-    // Repeated because the collision is probabilistic: the two wires must
-    // interleave between ensureUniqueConnectionSlug and the INSERT. Every round
-    // must succeed, so a round that happens not to collide is harmless — but
-    // across 15 rounds the race is overwhelmingly likely to fire at least once,
-    // and pre-fix it did so in roughly 1 run in 8.
-    for (let round = 0; round < 15; round++) {
-      const { orgId } = await pollWithCollidingManifests();
+    // The field scenario, end-to-end: two sibling manifests, one display name,
+    // both expected to land with distinct slugs. Whether the two wires actually
+    // interleave here is up to the scheduler, so this is a smoke check on the
+    // real shape of the bug — the forced-collision test above is the guard.
+    const res = await pollManifests(workerId, [
+      manifestFor('apple.collide_one', 'screentime'),
+      manifestFor('apple.collide_two', 'photos'),
+    ]);
+    expect(res.status).toBe(200);
 
-      const conns = (await sql`
-        SELECT connector_key, slug FROM connections
-        WHERE organization_id = ${orgId} AND deleted_at IS NULL
-        ORDER BY connector_key
-      `) as Array<{ connector_key: string; slug: string }>;
+    const conns = (await sql`
+      SELECT connector_key, slug FROM connections
+      WHERE organization_id = ${orgId} AND deleted_at IS NULL
+      ORDER BY connector_key
+    `) as unknown as Array<{ connector_key: string; slug: string }>;
 
-      // Both must be wired. Pre-fix the loser of the slug race was absent here
-      // — that absence is the whole defect, and it is what made an unrelated
-      // test flake ~1 run in 8.
-      expect(
-        conns.map((c) => c.connector_key),
-        `round ${round}: a connector failed to wire`
-      ).toEqual(['apple.collide_one', 'apple.collide_two']);
-
-      // And the retry must resolve the collision by suffixing, not by
-      // colliding again — two identical slugs would mean the unique index is
-      // not actually enforcing what this test assumes.
-      expect(new Set(conns.map((c) => c.slug)).size, `round ${round}: slugs collided`).toBe(2);
-    }
-  }, 180_000);
+    expect(conns.map((c) => c.connector_key), 'a connector failed to wire').toEqual([
+      'apple.collide_one',
+      'apple.collide_two',
+    ]);
+    expect(new Set(conns.map((c) => c.slug)).size, 'slugs collided').toBe(2);
+  }, 60_000);
 });

--- a/packages/server/src/__tests__/integration/device-reconcile-slug-race.test.ts
+++ b/packages/server/src/__tests__/integration/device-reconcile-slug-race.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Two device manifests sharing a display name must both wire.
+ *
+ * `ensureDeviceConnectorWired` derives a connection slug from the manifest's
+ * display NAME, and `connections_org_slug_unique` enforces uniqueness per ORG —
+ * but the advisory lock meant to serialize the wire is keyed on
+ * (userId, connectorKey). Lock scope and uniqueness scope are not the same
+ * scope, so two DIFFERENT connector keys take two DIFFERENT locks, run
+ * concurrently, compute the same free slug, and the loser's INSERT trips the
+ * constraint. The source comment asserting this "can't be raced" was wrong.
+ *
+ * The loser was then absent from `connections` until the next poll. That is how
+ * this was found: as an unexplained ~1-in-8 flake in
+ * device-connector-manifests.test.ts, where a sibling intermittently failed to
+ * install.
+ *
+ * Driven through the real poll endpoint rather than a hand-built
+ * `device_workers` row — capabilities are stored in a shape poll owns, and a
+ * fixture that guesses it wrong reconciles nothing and passes for the wrong
+ * reason (observed: a hand-built row wired zero connectors and still went
+ * green). A stubbed rejection would be worse: it would pass against any
+ * wrapper and prove nothing about the path that actually fails.
+ *
+ * Asserts the OUTCOME (both wired, distinct slugs) rather than a log line,
+ * because the fix makes the failure stop happening rather than merely become
+ * visible.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { generateSecureToken } from '../../auth/oauth/utils';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { post } from '../setup/test-helpers';
+
+const SHARED_NAME = 'Colliding Device Connector';
+
+function manifestFor(key: string, capability: string) {
+  return {
+    key,
+    version: '0.1.0',
+    // Same display name on both — this is the collision under test.
+    name: SHARED_NAME,
+    description: 'Device manifest used to force a connection-slug collision.',
+    required_capability: capability,
+    runtime: { platforms: ['macos'] },
+    auth_schema: { methods: [{ type: 'none' }] },
+    feeds_schema: {
+      snapshots: {
+        key: 'snapshots',
+        name: 'Snapshots',
+        configSchema: { type: 'object', properties: {} },
+        eventKinds: {
+          snapshot: {
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id'],
+              properties: {
+                source: { type: 'string' },
+                origin_id: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+async function pollWithCollidingManifests() {
+  const sql = getTestDb();
+  const userId = `user_${generateSecureToken(4)}`;
+  const orgId = `org-wirefail-${generateSecureToken(4)}`;
+  const workerId = `wk-${generateSecureToken(6)}`;
+
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, 'Wire Failure Owner', ${`${userId}@test.local`}, true, NOW(), NOW())
+  `;
+  await sql`
+    INSERT INTO "organization" (id, name, slug, visibility, metadata, "createdAt")
+    VALUES (
+      ${orgId}, 'Wire Failure Org', ${orgId}, 'private',
+      ${sql.json({ personal_org_for_user_id: userId })}, NOW()
+    )
+  `;
+  await sql`
+    INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`mem_${generateSecureToken(4)}`}, ${orgId}, ${userId}, 'owner', NOW())
+  `;
+  await sql`
+    INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
+    VALUES (${userId}, ${workerId}, 'macos', '0.1.0', ${sql.json([])}, 'Colliding Mac', ${orgId})
+  `;
+
+  const res = await post('/api/workers/poll', {
+    body: {
+      worker_id: workerId,
+      platform: 'macos',
+      app_version: '9.9.0',
+      label: 'Colliding Mac',
+      capabilities: { screentime: true, photos: true },
+      connector_manifests: [
+        manifestFor('apple.collide_one', 'screentime'),
+        manifestFor('apple.collide_two', 'photos'),
+      ],
+    },
+  });
+  expect(res.status).toBe(200);
+  return { userId, orgId };
+}
+
+describe('device connector slug race', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('wires both connectors when two manifests share a display name', async () => {
+    const sql = getTestDb();
+
+    // Repeated because the collision is probabilistic: the two wires must
+    // interleave between ensureUniqueConnectionSlug and the INSERT. Every round
+    // must succeed, so a round that happens not to collide is harmless — but
+    // across 15 rounds the race is overwhelmingly likely to fire at least once,
+    // and pre-fix it did so in roughly 1 run in 8.
+    for (let round = 0; round < 15; round++) {
+      const { orgId } = await pollWithCollidingManifests();
+
+      const conns = (await sql`
+        SELECT connector_key, slug FROM connections
+        WHERE organization_id = ${orgId} AND deleted_at IS NULL
+        ORDER BY connector_key
+      `) as Array<{ connector_key: string; slug: string }>;
+
+      // Both must be wired. Pre-fix the loser of the slug race was absent here
+      // — that absence is the whole defect, and it is what made an unrelated
+      // test flake ~1 run in 8.
+      expect(
+        conns.map((c) => c.connector_key),
+        `round ${round}: a connector failed to wire`
+      ).toEqual(['apple.collide_one', 'apple.collide_two']);
+
+      // And the retry must resolve the collision by suffixing, not by
+      // colliding again — two identical slugs would mean the unique index is
+      // not actually enforcing what this test assumes.
+      expect(new Set(conns.map((c) => c.slug)).size, `round ${round}: slugs collided`).toBe(2);
+    }
+  }, 180_000);
+});

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -20,7 +20,7 @@ import {
 } from '../utils/connector-catalog';
 import { extractConnectorMetadata, type ConnectorMetadata } from '../utils/connector-compiler';
 import { upsertConnectorDefinitionRecords } from '../utils/connector-definition-install';
-import { ensureUniqueConnectionSlug } from '../utils/connections';
+import { ensureUniqueConnectionSlug, isConnectionSlugUniqueViolation } from '../utils/connections';
 import { clearDevicePinTombstoneIfPinned } from '../utils/device-pin-tombstones';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
@@ -347,7 +347,7 @@ async function ensureDeviceConnectorWired(
     }
 
     let connectionId: number | undefined;
-    await sql.begin(async (tx) => {
+    const wireOnce = () => sql.begin(async (tx) => {
       // Serialize per (user, connector): two concurrent polls / two devices
       // both reach here, but only one holds the lock at a time, so the
       // existence-check-then-insert below is atomic.
@@ -402,11 +402,22 @@ async function ensureDeviceConnectorWired(
       }
       if (!connectionId) {
         // Stable slug for `lobu apply` diffing — same generation path as
-        // manage_connections. No insert-retry here: this whole block runs
-        // under a `pg_advisory_xact_lock` keyed on (userId, connectorKey) plus
-        // the existence check above, so the slug can't be raced for this
-        // (org, connector, user) tuple — and a unique violation would abort
-        // the surrounding transaction, making a retry pointless anyway.
+        // manage_connections.
+        //
+        // The advisory lock above does NOT make this race-free, contrary to
+        // what this comment used to claim. The lock is keyed on
+        // (userId, connectorKey), but the slug derives from the connector's
+        // DISPLAY NAME and uniqueness is enforced per-ORG by
+        // `connections_org_slug_unique`. Two different connector keys take two
+        // different locks and run concurrently, so two connectors sharing a
+        // display name compute the same free slug and the loser's INSERT trips
+        // the constraint. Reproduced: see
+        // device-reconcile-slug-race.test.ts. Lock scope and
+        // uniqueness scope simply are not the same scope.
+        //
+        // The retry lives OUTSIDE this transaction (at the wireOnce call
+        // site below), because an aborted transaction cannot be continued —
+        // which is the one thing the old comment got right.
         const slug = await ensureUniqueConnectionSlug({
           organizationId,
           connectorKey,
@@ -465,6 +476,27 @@ async function ensureDeviceConnectorWired(
       // serving the capability, or leave it unpinned when several do.
       await reconcilePin(tx, connectionId);
     });
+
+    try {
+      await wireOnce();
+    } catch (err) {
+      // Retry ONCE, and only for the slug collision described above. The
+      // retry recomputes the slug against a tree that now contains the
+      // winner's committed row, so it converges on `<base>-2` rather than
+      // repeating the same losing bet.
+      //
+      // Bounded at one attempt deliberately. The next poll is the real retry
+      // budget for this reconcile — it already heals the collision — so this
+      // exists to avoid a spurious error-level log and a poll-cycle delay,
+      // not to guarantee convergence here. Anything unbounded would be a
+      // second retry budget layered on the existing one.
+      if (!isConnectionSlugUniqueViolation(err)) throw err;
+      logger.info(
+        { userId, connectorKey, organizationId },
+        '[device-connectors] Connection slug raced a concurrent wire; retrying once'
+      );
+      await wireOnce();
+    }
 
     if (connectionId) {
       logger.info(


### PR DESCRIPTION
## Summary

`ensureDeviceConnectorWired` derives a connection slug from the manifest's display **name**, and `connections_org_slug_unique` enforces uniqueness per **org** — but the advisory lock meant to serialize the wire is keyed on `(userId, connectorKey)`.

**Lock scope and uniqueness scope are not the same scope.** Two *different* connector keys take two *different* locks, run concurrently under `Promise.allSettled`, compute the same free slug, and the loser's INSERT trips the constraint. The loser was then absent from `connections` until the next poll.

The source carried a comment asserting the opposite — that the slug *"can't be raced for this (org, connector, user) tuple"* — which is corrected here rather than left to mislead the next reader.

This is how it was found: an unexplained **~1-in-8 flake** in `device-connector-manifests.test.ts`, where a sibling connector intermittently failed to install.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `device-reconcile-slug-race` + `device-connector-manifests` — 14 passed, 2 skipped
- [x] Bug fix: red→fix→green below
- [ ] If bot behavior: n/a

### Red → green

The regression test forces the collision instead of hoping for it: an uncommitted transaction squats on the slug the wire is about to compute, and is committed only once that wire's INSERT is observed parked on `connections_org_slug_unique`. The earlier 15-round loop was probabilistic — at a ~1-in-8 per-round collision rate it had roughly a 13% chance of the pre-fix code passing its own regression test, which is exactly what run 3 below shows for the unforced sibling case.

```
RED (retry removed) — 3/3 runs
  × retries the wire when a concurrent insert takes the slug it computed
    → the wire lost the slug race and never retried:
      expected [ 'apple.collide_squatter' ]
      to deeply equal [ 'apple.collide_one', 'apple.collide_squatter' ]

  (unforced sibling test, same 3 runs: × × ✓ — the flake this replaces)

GREEN (retry restored) — 3/3 runs
  ✓ retries the wire when a concurrent insert takes the slug it computed
  ✓ wires both connectors when two manifests share a display name
  Test Files 2 passed | Tests 14 passed | 2 skipped
```

## Notes

### What this is NOT — a correction

I originally reported this as *"`Promise.allSettled` swallows the error."* **That was wrong.** `ensureDeviceConnectorWired` already catches and logs at `error` level, so the failure was always visible. A logging-only fix was written, found to be dead code, and reverted. The real defect is the check-then-act slug race above.

### Why the retry is bounded at one attempt

It sits **outside** the transaction, because an aborted transaction cannot be continued — the one thing the old comment got right. One attempt is deliberate: the next poll is the real retry budget and already heals this, so the retry exists to avoid a spurious error-level log and a poll-cycle delay, not to guarantee convergence here. Anything unbounded would be a second retry budget layered on the existing one, which AGENTS.md's coordination brake warns against.

### Why the reproducer goes through the poll endpoint

A hand-built `device_workers` row **reconciled zero connectors and the test still passed** — capabilities are stored in a shape `poll` owns, and guessing it wrong produces a green test that exercises nothing. A stubbed rejection would be worse: it would pass against any wrapper and prove nothing about the path that actually fails.

### Follow-on comment update

The note added in #2396 said this race was "tracked separately"; it now points at the fix and the new test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting devices concurrently, preventing naming conflicts between connectors.
  * Added a bounded retry for transient connection conflicts while preserving existing handling for other errors.

* **Tests**
  * Added coverage for concurrent device reconciliation scenarios with duplicate display names.
  * Streamlined regression test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->