### PR TITLE
fix(server): let a Behavior define its own classifier

### DIFF
--- a/packages/server/src/__tests__/integration/classifiers/classifiers-behavior-created.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifiers-behavior-created.test.ts
@@ -1,0 +1,179 @@
+/**
+ * A Behavior must be able to DEFINE a classifier, not just use one.
+ *
+ * `manage_classifiers` create/apply/classify/delete sit in `OWNER_ADMIN_ACTIONS`,
+ * but `action-router.ts` returns early for a system context — so a Behavior
+ * reaction (`userId: null`, `memberRole: null`, `isAuthenticated: true`, exactly
+ * what `watchers/reaction-executor.ts` builds) is NOT stopped by the admin gate.
+ * It got all the way to the INSERT and died there instead:
+ *
+ *     null value in column "created_by" of relation "classify_facet"
+ *     violates not-null constraint
+ *
+ * `created_by` was resolved as `args.created_by ?? ctx.userId`, and a Behavior
+ * has no user identity. Measured before the fix: `list`, `apply` and `classify`
+ * all succeeded for a Behavior; `create` was the ONLY unreachable verb — which
+ * is precisely what blocked an agent from inventing a classifier to automate its
+ * own work. The failure surfaced as a raw Postgres 23502, not a ToolUserError,
+ * so the agent got a constraint dump instead of guidance.
+ *
+ * `classify_facet.created_by` carries no foreign key (the table has none), so a
+ * sentinel is valid — this does not smuggle a fake row into `user`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { manageClassifiers } from '../../../tools/admin/manage_classifiers';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const DIM = 768;
+function basisVector(slot: number): number[] {
+  const v = new Array<number>(DIM).fill(0);
+  v[slot] = 1;
+  return v;
+}
+
+const ATTRIBUTE_VALUES = {
+  positive: { description: 'Positive', examples: ['great'], embedding: basisVector(0) },
+  negative: { description: 'Negative', examples: ['awful'], embedding: basisVector(1) },
+};
+
+/**
+ * Mirrors the reaction context in `watchers/reaction-executor.ts`: no user, no
+ * member role, authenticated, scope check not applicable. Deliberately sets no
+ * `agentId` — the reaction executor doesn't either.
+ */
+function behaviorCtx(organizationId: string): ToolContext {
+  return {
+    organizationId,
+    userId: null,
+    memberRole: null,
+    isAuthenticated: true,
+    tokenType: 'session',
+    scopes: ['*'],
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  } as unknown as ToolContext;
+}
+
+describe('a Behavior can define and use its own classifier', () => {
+  it('creates one with no user identity, then applies it end to end', async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const org = await createTestOrganization({ name: 'Behavior Author Org' });
+    const ctx = behaviorCtx(org.id);
+    const sql = getTestDb();
+
+    const created = await manageClassifiers(
+      {
+        action: 'create',
+        slug: 'agent-invented',
+        name: 'Agent invented',
+        attribute_key: 'agent-invented',
+        attribute_values: ATTRIBUTE_VALUES,
+        min_similarity: 0.5,
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(created.success).toBe(true);
+
+    // NOT NULL satisfied without inventing a user row.
+    const rows = (await sql`
+      SELECT created_by, watcher_id FROM classify_facet
+      WHERE slug = 'agent-invented' AND organization_id = ${org.id}
+    `) as unknown as Array<{ created_by: string; watcher_id: number | null }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].created_by).toBe('system');
+    // Org-level, so the embedding engine can actually match it.
+    expect(rows[0].watcher_id).toBeNull();
+
+    // The point of defining it: the same Behavior can immediately use it.
+    const event = await createTestEvent({
+      organization_id: org.id,
+      content: 'great',
+      embedding: basisVector(0),
+    });
+    const applied = await manageClassifiers(
+      {
+        action: 'apply',
+        classifier_slug: 'agent-invented',
+        content_ids: [Number(event.id)],
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(applied.success).toBe(true);
+    expect((applied.data as { classified: number }).classified).toBe(1);
+  });
+
+  it('still prefers a real user id when one is available', async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const org = await createTestOrganization({ name: 'Human Author Org' });
+    const user = await createTestUser({ email: 'human-author@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const sql = getTestDb();
+
+    // The sentinel must be a LAST resort — a human-authored classifier keeps
+    // real attribution, otherwise the fix would erase authorship org-wide.
+    const created = await manageClassifiers(
+      {
+        action: 'create',
+        slug: 'human-made',
+        name: 'Human made',
+        attribute_key: 'human-made',
+        attribute_values: ATTRIBUTE_VALUES,
+      } as never,
+      {} as never,
+      {
+        organizationId: org.id,
+        userId: user.id,
+        memberRole: 'owner',
+        isAuthenticated: true,
+        tokenType: 'oauth',
+        scopedToOrg: false,
+        scopes: ['mcp:admin'],
+      } as ToolContext
+    );
+    expect(created.success).toBe(true);
+
+    const rows = (await sql`
+      SELECT created_by FROM classify_facet WHERE slug = 'human-made' AND organization_id = ${org.id}
+    `) as unknown as Array<{ created_by: string }>;
+    expect(rows[0].created_by).toBe(user.id);
+  });
+
+  it('honours an explicit created_by over both', async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const org = await createTestOrganization({ name: 'Explicit Author Org' });
+    const sql = getTestDb();
+
+    const created = await manageClassifiers(
+      {
+        action: 'create',
+        slug: 'explicit',
+        name: 'Explicit',
+        attribute_key: 'explicit',
+        attribute_values: ATTRIBUTE_VALUES,
+        created_by: 'importer-job',
+      } as never,
+      {} as never,
+      behaviorCtx(org.id)
+    );
+    expect(created.success).toBe(true);
+
+    const rows = (await sql`
+      SELECT created_by FROM classify_facet WHERE slug = 'explicit' AND organization_id = ${org.id}
+    `) as unknown as Array<{ created_by: string }>;
+    expect(rows[0].created_by).toBe('importer-job');
+  });
+});

--- a/packages/server/src/__tests__/integration/classifiers/classifiers-behavior-created.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifiers-behavior-created.test.ts
@@ -11,11 +11,12 @@
  *     violates not-null constraint
  *
  * `created_by` was resolved as `args.created_by ?? ctx.userId`, and a Behavior
- * has no user identity. Measured before the fix: `list`, `apply` and `classify`
- * all succeeded for a Behavior; `create` was the ONLY unreachable verb — which
- * is precisely what blocked an agent from inventing a classifier to automate its
- * own work. The failure surfaced as a raw Postgres 23502, not a ToolUserError,
- * so the agent got a constraint dump instead of guidance.
+ * has no user identity. Measured on a Behavior context before the fix: `list`
+ * and `apply` both succeeded, so `create` was the verb blocking an agent from
+ * inventing a classifier to automate its own work. (`classify` and `delete`
+ * were not exercised; neither writes `created_by`.) The failure surfaced as a
+ * raw Postgres 23502, not a ToolUserError, so the agent got a constraint dump
+ * instead of guidance.
  *
  * `classify_facet.created_by` carries no foreign key (the table has none), so a
  * sentinel is valid — this does not smuggle a fake row into `user`.

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -215,10 +215,22 @@ async function handleCreate(
     };
   }
 
-  // created_by has a FK to user(id) — fall back to ctx.userId, not a literal
-  // string. Anonymous public reads can't reach this code path (the route is
-  // admin-gated), so ctx.userId is non-null here.
-  const createdBy = args.created_by ?? ctx.userId;
+  // `created_by` is NOT NULL and carries NO foreign key — `classify_facet` has
+  // no FK at all (9 NOT NULLs, a PK, one unique index), so any stable
+  // identifier satisfies it. The previous comment here asserted an FK to
+  // `user(id)` that does not exist, and concluded from "the route is
+  // admin-gated" that `ctx.userId` is non-null. Both halves were wrong:
+  // `action-router.ts` returns early for a system context, so a Behavior
+  // reaction (userId null, memberRole null) skips the admin gate and reached
+  // this INSERT with no identity — dying on the NOT NULL as a raw Postgres
+  // 23502. `list`, `apply` and `classify` all worked for a Behavior; `create`
+  // was the one verb it could not reach, which is what made ad-hoc
+  // agent-defined classification impossible.
+  //
+  // Sentinel matches the existing precedent in manage_entity.ts
+  // (`ctx.agentId ?? ctx.userId ?? "system"`); a Behavior sets neither userId
+  // nor agentId, so it lands on 'system'.
+  const createdBy = args.created_by ?? ctx.userId ?? ctx.agentId ?? 'system';
   // Config lives on the single classify_facet row now (no version table) — hydrate embeddings first,
   // then one insert carrying identity + config.
   const { attributeValues: withEmbeddings, generatedCount } = await hydrateAttributeEmbeddings(

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -223,13 +223,14 @@ async function handleCreate(
   // `action-router.ts` returns early for a system context, so a Behavior
   // reaction (userId null, memberRole null) skips the admin gate and reached
   // this INSERT with no identity — dying on the NOT NULL as a raw Postgres
-  // 23502. `list`, `apply` and `classify` all worked for a Behavior; `create`
-  // was the one verb it could not reach, which is what made ad-hoc
-  // agent-defined classification impossible.
+  // 23502. Measured on a Behavior context: `list` and `apply` both succeeded,
+  // so `create` was the verb blocking ad-hoc agent-defined classification.
+  // (`classify` and `delete` were not exercised; neither writes `created_by`.)
   //
-  // Sentinel matches the existing precedent in manage_entity.ts
-  // (`ctx.agentId ?? ctx.userId ?? "system"`); a Behavior sets neither userId
-  // nor agentId, so it lands on 'system'.
+  // The 'system' sentinel follows the manage_entity.ts precedent
+  // (`ctx.agentId ?? ctx.userId ?? "system"`), but userId stays first here to
+  // preserve the pre-existing user attribution when both are set. A Behavior
+  // sets neither, so it lands on 'system'.
   const createdBy = args.created_by ?? ctx.userId ?? ctx.agentId ?? 'system';
   // Config lives on the single classify_facet row now (no version table) — hydrate embeddings first,
   // then one insert carrying identity + config.


### PR DESCRIPTION
## Summary
- `manage_classifiers` create/apply/classify/delete sit in `OWNER_ADMIN_ACTIONS`, but `action-router.ts:33` returns early for a system context — so a Behavior reaction (`userId: null`, `memberRole: null`) is **not** stopped by the admin gate. It reached the INSERT and died there on `created_by` being NOT NULL.
- `created_by` was `args.created_by ?? ctx.userId`, and a Behavior has no user identity. Measured on a Behavior context: `list` and `apply` both succeeded, so `create` was the verb blocking an agent from inventing a classifier to automate its own work — the whole point of ad-hoc classification.
- The old comment justified this with *"created_by has a FK to user(id)"* and *"the route is admin-gated, so ctx.userId is non-null here."* Both halves are false. `classify_facet` has **no foreign key at all** — 9 NOT NULLs, a PK, and one unique index, verified against the live schema by reading every constraint on the table.
- Fix is the fallback chain `args.created_by ?? ctx.userId ?? ctx.agentId ?? 'system'`. `userId` deliberately stays ahead of the sentinel so human attribution is untouched; a pinned test asserts that.

Failure mode was a raw Postgres `23502` surfaced to the agent rather than a `ToolUserError` — not silent, but useless as guidance.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests: `bunx vitest run src/__tests__/integration/classifiers/` — **10 files, 26 tests passed**
- [x] Bug fix: red→fix→green below

**RED** (handler reverted to `origin/main`, tests kept):
```
 × creates one with no user identity, then applies it end to end
   → null value in column "created_by" of relation "classify_facet" violates not-null constraint
 ✓ still prefers a real user id when one is available
 ✓ honours an explicit created_by over both
      Tests  1 failed | 2 passed (3)
```
The two passing are controls: they prove the fix does not simply stamp everything `system`.

**GREEN**:
```
 ✓ classifiers-behavior-created.test.ts (3 tests)
      Tests  3 passed (3)
```

## Notes
The Behavior context in the test mirrors `watchers/reaction-executor.ts:48-58` field for field, including `scopes: ['*']` and deliberately no `agentId` — the reaction executor sets none.

Follows #2389/#2394 (engine reachable by agents) and #2402 (labels readable once written). This is the last gap in the chain: define → apply → read back.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->