### PR TITLE
fix(server): scope classifier slug uniqueness to the organization

### DIFF
--- a/db/migrations/20260731140000_classify_facet_org_scoped_unique.sql
+++ b/db/migrations/20260731140000_classify_facet_org_scoped_unique.sql
@@ -1,0 +1,43 @@
+-- migrate:up
+
+-- `classify_facet_unique_per_insight` was UNIQUE (entity_id, watcher_id, slug)
+-- with NO organization_id, so a classifier slug is currently unique across the
+-- WHOLE INSTALL rather than within a tenant. The three-column key was inherited
+-- verbatim from `event_classifiers` in 20260622320000 to match the extraction
+-- upsert's ON CONFLICT target; that table had the same omission and nobody
+-- re-derived the key when classify_facet became multi-tenant.
+--
+-- The practical effect is org-level classifiers (entity_id NULL, watcher_id
+-- NULL), which is exactly what `manage_classifiers create` produces and the only
+-- kind `apply` can match. Two tenants cannot both hold `sentiment`: the second
+-- one's create dies on a unique violation naming another tenant's row. Measured
+-- on prod 2026-07-31 — 29 classifiers, and only 3 sit in that globally-unique
+-- bucket (`impact`, `test-classifier`, `post-sentiment`) across 2 orgs. They
+-- collide on nothing today purely because the slugs happen to differ, so this is
+-- latent rather than firing: the next org to pick a taken slug hits it.
+--
+-- organization_id is NOT NULL on this table (verified against prod), so adding
+-- it to the key introduces no NULL-matching subtlety. NULLS NOT DISTINCT is
+-- retained for entity_id/watcher_id, which ARE nullable and whose NULLs must
+-- keep colliding — that is what makes "one org-level classifier per slug per
+-- org" an enforced constraint rather than an unchecked convention.
+--
+-- Strictly a widening: every key unique under the old constraint stays unique
+-- under the new one, so no existing row can conflict and no backfill is needed.
+
+ALTER TABLE classify_facet DROP CONSTRAINT IF EXISTS classify_facet_unique_per_insight;
+-- squawk-ignore disallowed-unique-constraint,prefer-robust-stmts,constraint-missing-not-valid -- config-scale table (29 rows on prod); brief lock acceptable; dbmate wraps in a transaction
+ALTER TABLE classify_facet ADD CONSTRAINT classify_facet_unique_per_insight
+    UNIQUE NULLS NOT DISTINCT (organization_id, entity_id, watcher_id, slug);
+
+COMMENT ON CONSTRAINT classify_facet_unique_per_insight ON classify_facet IS
+    'One classifier per (org, entity, behavior, slug). organization_id leads because slugs are tenant-scoped names, not global ones; the extraction upsert in classifier-extraction.ts must target these four columns exactly.';
+
+-- migrate:down
+
+-- Narrowing, so this aborts if two tenants have since taken the same slug —
+-- correctly. Resolve the duplicates first; PITR is the alternative.
+ALTER TABLE classify_facet DROP CONSTRAINT IF EXISTS classify_facet_unique_per_insight;
+-- squawk-ignore disallowed-unique-constraint,prefer-robust-stmts,constraint-missing-not-valid -- rollback path; same config-scale table, brief lock acceptable
+ALTER TABLE classify_facet ADD CONSTRAINT classify_facet_unique_per_insight
+    UNIQUE NULLS NOT DISTINCT (entity_id, watcher_id, slug);

--- a/packages/server/src/__tests__/integration/classifiers/classifications-read-scope.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifications-read-scope.test.ts
@@ -163,10 +163,11 @@ describe('event_classifications read scope', () => {
       organization_id: theirs.id,
       content: 'another tenant’s post',
     });
-    // Distinct slugs: `classify_facet_unique_per_insight` is UNIQUE NULLS NOT
-    // DISTINCT (entity_id, watcher_id, slug) with NO organization_id, so two
-    // tenants cannot hold the same org-level slug. Sidestepped here rather than
-    // asserted — the missing tenancy column is its own bug, not this one.
+    // Distinct slugs are a historical artifact: `classify_facet_unique_per_insight`
+    // once had no organization_id, so two tenants could not hold the same
+    // org-level slug. The key is org-scoped now (classifier-slug-tenancy.test.ts
+    // asserts that); the distinct slugs merely keep this test about the read
+    // predicate.
     const foreignClassifier = await seedClassifier(theirs.id, foreignUser.id, 'sentiment-theirs');
     await classify(Number(foreign.id), foreignClassifier, 'positive');
 

--- a/packages/server/src/__tests__/integration/classifiers/classifier-slug-tenancy.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifier-slug-tenancy.test.ts
@@ -1,0 +1,198 @@
+/**
+ * A classifier slug is a tenant-scoped name, not a global one.
+ *
+ * `classify_facet_unique_per_insight` was UNIQUE NULLS NOT DISTINCT
+ * (entity_id, watcher_id, slug) — no organization_id. Org-level classifiers are
+ * exactly (entity_id NULL, watcher_id NULL, slug), which is what
+ * `manage_classifiers create` produces and the only kind `apply` and the
+ * reconciliation job can match. So the FIRST tenant to create `sentiment` took
+ * the name away from every other tenant in the install, and the second one's
+ * create died on a unique violation naming a row it cannot see.
+ *
+ * Measured on prod 2026-07-31: 29 classifiers, 3 of them in that globally
+ * unique bucket across 2 orgs. They coexist only because the slugs happen to
+ * differ — the bug is latent, not dormant.
+ *
+ * These tests go through `manageClassifiers` rather than raw SQL: the tool is
+ * the surface a tenant actually collides on.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { manageClassifiers } from '../../../tools/admin/manage_classifiers';
+import { createClassifiersForWatcher } from '../../../watchers/classifier-extraction';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const DIM = 768;
+function basisVector(slot: number): number[] {
+  const v = new Array<number>(DIM).fill(0);
+  v[slot] = 1;
+  return v;
+}
+
+const ATTRIBUTE_VALUES = {
+  positive: { description: 'Positive', examples: ['great'], embedding: basisVector(0) },
+  negative: { description: 'Negative', examples: ['awful'], embedding: basisVector(1) },
+};
+
+function ownerCtx(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'owner',
+    isAuthenticated: true,
+    tokenType: 'oauth',
+    scopedToOrg: false,
+    allowCrossOrg: false,
+    scopes: ['mcp:admin'],
+  } as ToolContext;
+}
+
+async function orgWithOwner(name: string, email: string) {
+  const org = await createTestOrganization({ name });
+  const user = await createTestUser({ email });
+  await addUserToOrganization(user.id, org.id, 'owner');
+  return { org, ctx: ownerCtx(org.id, user.id) };
+}
+
+function createSentiment(ctx: ToolContext) {
+  return manageClassifiers(
+    {
+      action: 'create',
+      slug: 'sentiment',
+      name: 'Sentiment',
+      attribute_key: 'sentiment',
+      attribute_values: ATTRIBUTE_VALUES,
+    } as never,
+    {} as never,
+    ctx
+  );
+}
+
+describe('classifier slugs are scoped per organization', () => {
+  it('lets two tenants each hold an org-level `sentiment`', async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const a = await orgWithOwner('Tenant A', 'tenant-a@test.example.com');
+    const b = await orgWithOwner('Tenant B', 'tenant-b@test.example.com');
+    const sql = getTestDb();
+
+    // Before the org-scoped key this pair was the whole bug: the first create
+    // succeeded and the second raised 23505 on classify_facet_unique_per_insight.
+    expect((await createSentiment(a.ctx)).success).toBe(true);
+    expect((await createSentiment(b.ctx)).success).toBe(true);
+
+    const rows = (await sql`
+      SELECT organization_id, id FROM classify_facet WHERE slug = 'sentiment'
+      ORDER BY id
+    `) as unknown as Array<{ organization_id: string; id: number }>;
+
+    // Two distinct rows, one per tenant — not one row silently shared.
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.organization_id))).toEqual(new Set([a.org.id, b.org.id]));
+    expect(rows[0].id).not.toBe(rows[1].id);
+  });
+
+  it('still refuses a duplicate org-level slug inside one tenant', async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const a = await orgWithOwner('Tenant Solo', 'solo@test.example.com');
+    const sql = getTestDb();
+
+    // Widening to per-org must not degrade into "no uniqueness at all" —
+    // `apply` resolves a classifier BY SLUG, so a tenant holding two rows for
+    // one slug makes which-one-wins arbitrary.
+    expect((await createSentiment(a.ctx)).success).toBe(true);
+    const second = await createSentiment(a.ctx);
+    expect(second.success).toBe(false);
+
+    const [{ n }] = (await sql`
+      SELECT count(*)::int AS n FROM classify_facet
+      WHERE slug = 'sentiment' AND organization_id = ${a.org.id}
+    `) as unknown as Array<{ n: number }>;
+    expect(n).toBe(1);
+  });
+
+  it('keeps entity-scoped slugs independent per tenant too', async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const a = await orgWithOwner('Entity Tenant A', 'ent-a@test.example.com');
+    const b = await orgWithOwner('Entity Tenant B', 'ent-b@test.example.com');
+    const sql = getTestDb();
+
+    // The NULLS NOT DISTINCT arms still have to work: entity_id/watcher_id are
+    // nullable and their NULLs must keep colliding WITHIN a tenant. Here both
+    // rows carry the same non-null entity_id, so only organization_id separates
+    // them — the exact case the old 3-column key conflated.
+    const sharedEntityId = 4242;
+    for (const t of [a, b]) {
+      await sql`
+        INSERT INTO classify_facet (organization_id, slug, name, attribute_key, status, created_by, entity_id)
+        VALUES (${t.org.id}, 'shared-entity-slug', 'Shared', 'shared', 'active', 'system', ${sharedEntityId})
+      `;
+    }
+
+    const [{ n }] = (await sql`
+      SELECT count(*)::int AS n FROM classify_facet WHERE slug = 'shared-entity-slug'
+    `) as unknown as Array<{ n: number }>;
+    expect(n).toBe(2);
+  });
+
+  it('the extraction upsert resolves the new 4-column conflict target', async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const a = await orgWithOwner('Upsert Tenant A', 'ups-a@test.example.com');
+    const b = await orgWithOwner('Upsert Tenant B', 'ups-b@test.example.com');
+
+    // An ON CONFLICT column list must resolve to a live unique index at
+    // execution time, not at parse time — so retargeting the upsert without
+    // running it would leave "no unique or exclusion constraint matching the
+    // ON CONFLICT specification" to fire in prod. This is the only test that
+    // executes it. classify_facet has no FKs, so the ids are arbitrary.
+    const def = {
+      slug: 'extracted',
+      name: 'Extracted v1',
+      source_path: '$.items[*]',
+      value_field: 'value',
+    };
+    const sql = getTestDb();
+    const watcherId = 9001;
+    const entityId = 9002;
+
+    const [firstId] = await createClassifiersForWatcher(sql, watcherId, entityId, [def], {
+      createdBy: 'system',
+      organizationId: a.org.id,
+    });
+
+    // Re-apply in the same tenant: the conflict arm fires — same row, name refreshed.
+    const [againId] = await createClassifiersForWatcher(
+      sql,
+      watcherId,
+      entityId,
+      [{ ...def, name: 'Extracted v2' }],
+      { createdBy: 'system', organizationId: a.org.id }
+    );
+    expect(againId).toBe(firstId);
+
+    // Same (entity, watcher, slug) in ANOTHER tenant: a new row, not an update
+    // of tenant A's — the exact pair the old 3-column key conflated.
+    const [otherId] = await createClassifiersForWatcher(sql, watcherId, entityId, [def], {
+      createdBy: 'system',
+      organizationId: b.org.id,
+    });
+    expect(otherId).not.toBe(firstId);
+
+    const rows = (await sql`
+      SELECT organization_id, name FROM classify_facet WHERE slug = 'extracted' ORDER BY id
+    `) as unknown as Array<{ organization_id: string; name: string }>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ organization_id: a.org.id, name: 'Extracted v2' });
+    expect(rows[1]).toEqual({ organization_id: b.org.id, name: 'Extracted v1' });
+  });
+});

--- a/packages/server/src/__tests__/integration/classifiers/classifiers-apply-skip-reasons.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifiers-apply-skip-reasons.test.ts
@@ -72,9 +72,9 @@ describe('manage_classifiers apply — skip reasons', () => {
     };
     // Seeded in the CALLER's org only. The other org deliberately has no
     // classifier: its event must be excluded by the org filter, not by failing
-    // to find a template. (It could not have one anyway — `classify_facet`'s
-    // unique constraint is (entity_id, watcher_id, slug) with no organization_id,
-    // so a global slug is first-come-first-served across all tenants.)
+    // to find a template. (Slugs are org-scoped, so the other org COULD hold
+    // its own 'apply-reasons' — leaving it out keeps the exclusion attributable
+    // to the org filter alone.)
     const sql = getTestDb();
     await sql`
       INSERT INTO classify_facet (

--- a/packages/server/src/__tests__/integration/classifiers/classify-facet-sole-table.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classify-facet-sole-table.test.ts
@@ -2,7 +2,7 @@
  * P4 FINAL steady state: classify_facet is the ONE classifier table — event_classifiers and
  * event_classifier_versions are dropped. Proves the inverted table stands on its own: it
  * self-generates ids, backs event_classifications via the repointed FK, and enforces the
- * (entity_id, watcher_id, slug) uniqueness the watcher-extraction upsert relies on.
+ * (organization_id, entity_id, watcher_id, slug) uniqueness the watcher-extraction upsert relies on.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -45,7 +45,8 @@ describe('classify_facet is the sole classifier table (P4 final)', () => {
     expect(rows).toHaveLength(1);
     expect(Number(rows[0].classifier_id)).toBe(Number(c.id));
 
-    // The (entity_id, watcher_id, slug) NULLS NOT DISTINCT unique (extraction upsert target) is enforced.
+    // The (organization_id, entity_id, watcher_id, slug) NULLS NOT DISTINCT unique
+    // (extraction upsert target) is enforced — same org here, so the dup collides.
     await expect(
       sql`
         INSERT INTO classify_facet (organization_id, slug, name, attribute_key, status, created_by)

--- a/packages/server/src/watchers/classifier-extraction.ts
+++ b/packages/server/src/watchers/classifier-extraction.ts
@@ -403,7 +403,12 @@ export async function createClassifiersForWatcher(
 	classifierDefs: ClassifierDefinition[],
 	options: {
 		createdBy: string;
-		organizationId?: string | null;
+		// Required, not `string | null`. It is part of the ON CONFLICT key below,
+		// and `classify_facet.organization_id` is NOT NULL — so the old
+		// `organizationId ?? null` could only ever produce a 23502, never a
+		// tenant-less classifier. The sole caller (manage_behaviors/crud.ts)
+		// already passes `ctx.organizationId` unconditionally.
+		organizationId: string;
 	},
 ): Promise<number[]> {
 	const classifierIds: number[] = [];
@@ -441,7 +446,7 @@ export async function createClassifiersForWatcher(
         ${entityId},
         ${entityIdsLiteral}::bigint[],
         ${watcherId},
-        ${options.organizationId ?? null},
+        ${options.organizationId},
         ${def.slug},
         'active',
         ${options.createdBy},
@@ -449,9 +454,17 @@ export async function createClassifiersForWatcher(
         0.7,
         ${sql.json(extractionConfig as any)}
       )
-      ON CONFLICT (entity_id, watcher_id, slug) DO UPDATE
+      -- Must match classify_facet_unique_per_insight exactly, organization_id
+      -- included: Postgres resolves an ON CONFLICT column list to a specific
+      -- unique index, so the old 3-column target stops resolving and this INSERT
+      -- would fail outright once the constraint is org-scoped.
+      --
+      -- The dropped \`organization_id = COALESCE(classify_facet.organization_id,
+      -- EXCLUDED.organization_id)\` was unreachable: the column is NOT NULL, so
+      -- the left arm never yielded NULL, and it is now a key column anyway —
+      -- a conflicting row necessarily already holds this exact value.
+      ON CONFLICT (organization_id, entity_id, watcher_id, slug) DO UPDATE
       SET name = EXCLUDED.name,
-          organization_id = COALESCE(classify_facet.organization_id, EXCLUDED.organization_id),
           updated_at = NOW()
       RETURNING id
     `;


### PR DESCRIPTION
## What

`classify_facet_unique_per_insight` was `UNIQUE NULLS NOT DISTINCT (entity_id, watcher_id, slug)` — **no `organization_id`**. A classifier slug was unique across the whole install rather than within a tenant.

The three-column key was inherited verbatim from `event_classifiers` in `20260622320000` to match the extraction upsert's `ON CONFLICT` target; that table had the same omission, and nobody re-derived the key when `classify_facet` became multi-tenant.

## Why it matters

It bites **org-level** classifiers (`entity_id NULL, watcher_id NULL`) — exactly what `manage_classifiers create` produces, and the only kind `apply` and the reconciliation cron can match. The first tenant to create `sentiment` took the name from every other tenant; the second one's `create` dies on a unique violation naming a row it cannot see.

Measured on prod 2026-07-31: **29 classifiers, 3 in that globally-unique bucket across 2 orgs.** They coexist only because the slugs happen to differ — latent, not dormant.

## Red → green

Red (migration removed, test unchanged):

```
× lets two tenants each hold an org-level `sentiment`
  PostgresError: duplicate key value violates unique constraint "classify_facet_unique_per_insight"
    ❯ handleCreate src/tools/admin/manage_classifiers.ts:242:34
× keeps entity-scoped slugs independent per tenant too
  PostgresError: duplicate key value violates unique constraint "classify_facet_unique_per_insight"

Tests  2 failed | 1 passed (3)
```

Green:

```
✓ src/__tests__/integration/classifiers/classifier-slug-tenancy.test.ts (4 tests)

Test Files  12 passed (12)
     Tests  36 passed (36)
```

## Notes

- The migration is strictly a **widening** — every key unique under the old constraint stays unique under the new one, so no row can conflict and no backfill is needed.
- `organization_id` is `NOT NULL` on this table (verified against prod), so adding it to the key introduces no NULL-matching subtlety. `NULLS NOT DISTINCT` is retained for the nullable `entity_id`/`watcher_id`.
- The extraction upsert's `ON CONFLICT` target moves with the constraint. Postgres resolves the column list to a specific unique index, so leaving it at three columns would fail the INSERT outright — and `classifier-slug-tenancy.test.ts` now **executes** `createClassifiersForWatcher` rather than only reading it, which is the only thing that would have caught that.
- Its `COALESCE(organization_id, EXCLUDED.organization_id)` arm is dropped as unreachable: the column is `NOT NULL` and is now itself a key column.

## Out of scope, flagged

`manage_behaviors/crud.ts:333` throws `'Authenticated user is required to create Behavior classifiers'` when `ctx.userId` is null — the same null-identity shape as #2405, but there it is a deliberate policy guard raising a clear error, not a raw constraint dump. Changing it would change auth semantics, so it is left alone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->