### PR TITLE
fix(server): model-stamp classifier label vectors so a model swap can't compare across spaces

### DIFF
--- a/db/migrations/20260731150000_classify_facet_label_vector_model_stamp.sql
+++ b/db/migrations/20260731150000_classify_facet_label_vector_model_stamp.sql
@@ -1,0 +1,86 @@
+-- migrate:up
+
+-- Stamp every existing classifier label vector with the model that produced it.
+--
+-- `classify_facet.attribute_values[value].embedding` is cosine-compared against
+-- `event_embeddings.embedding`. The event side has been model-scoped since
+-- 20260526120000 (stamp) / 20260618140000 (NOT NULL, part of the PK), because
+-- vectors from different models are not comparable even at equal dimensionality.
+-- The label side never got a stamp, so it is the half a model swap leaves
+-- behind — and cosine over two incompatible 768-dim spaces returns a plausible
+-- number rather than an error, so classification keeps running and silently
+-- assigns wrong labels.
+--
+-- The engine now drops any label vector whose stamp is not the configured model.
+-- Without this backfill that guard would treat all 208 existing vectors
+-- (28 classifiers, measured on prod 2026-07-31) as unknown-provenance and stop
+-- classifying at deploy — so this migration is what makes the guard a no-op for
+-- data that is in fact fine.
+--
+-- The stamp is DERIVED, not hardcoded: label vectors were produced by whatever
+-- model the install has been running, so read that off event_embeddings rather
+-- than assuming the default. Prod holds exactly one distinct value
+-- (Xenova/bge-base-en-v1.5, 2,060,864 rows), and an install with no events at
+-- all falls back to the code default. The aggregate is a one-time full scan of a
+-- ~2M-row table in the deploy hook (seconds); it is the "run the aggregation in
+-- a migration, never per request" case, and nothing reads it again afterwards.
+--
+-- Idempotent: only entries with a vector AND no stamp are touched, so a re-run
+-- is a no-op. Deliberately does NOT invent a stamp for entries with no vector —
+-- a stamp must never outlive the vector it describes.
+
+WITH prevailing AS (
+    SELECT COALESCE(
+        (SELECT embedding_model
+           FROM public.event_embeddings
+          GROUP BY embedding_model
+          ORDER BY count(*) DESC
+          LIMIT 1),
+        'Xenova/bge-base-en-v1.5'
+    ) AS model
+)
+UPDATE public.classify_facet cf
+SET attribute_values = (
+        SELECT jsonb_object_agg(
+            e.key,
+            CASE
+                WHEN jsonb_typeof(e.value) = 'object'
+                 AND jsonb_typeof(e.value -> 'embedding') = 'array'
+                 AND NOT (e.value ? 'embedding_model')
+                THEN e.value || jsonb_build_object('embedding_model', (SELECT model FROM prevailing))
+                ELSE e.value
+            END
+        )
+          FROM jsonb_each(cf.attribute_values) e
+    ),
+    updated_at = now()
+WHERE jsonb_typeof(cf.attribute_values) = 'object'
+  -- Guards the jsonb_object_agg above: over zero rows it returns NULL, which
+  -- would blank the column. An entry-less `{}` cannot reach the SET.
+  AND EXISTS (
+        SELECT 1
+          FROM jsonb_each(cf.attribute_values) e
+         WHERE jsonb_typeof(e.value) = 'object'
+           AND jsonb_typeof(e.value -> 'embedding') = 'array'
+           AND NOT (e.value ? 'embedding_model')
+    );
+
+-- migrate:down
+
+-- Strip the stamp back out. Vectors are left in place — they were never
+-- rewritten, only annotated.
+UPDATE public.classify_facet cf
+SET attribute_values = (
+        SELECT jsonb_object_agg(
+            e.key,
+            CASE WHEN jsonb_typeof(e.value) = 'object'
+                 THEN e.value - 'embedding_model'
+                 ELSE e.value END
+        )
+          FROM jsonb_each(cf.attribute_values) e
+    )
+WHERE jsonb_typeof(cf.attribute_values) = 'object'
+  AND EXISTS (
+        SELECT 1 FROM jsonb_each(cf.attribute_values) e
+         WHERE jsonb_typeof(e.value) = 'object' AND e.value ? 'embedding_model'
+    );

--- a/packages/server/src/__tests__/integration/classifiers/classification-execute-query.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classification-execute-query.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { executeClassificationQuery } from '../../../utils/classification-query';
+import { getConfiguredEmbeddingModel } from '../../../utils/embeddings';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestEvent, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
 
@@ -41,9 +42,13 @@ async function seedFacet(opts: {
   fallbackValue: string | null;
 }): Promise<number> {
   const sql = getTestDb();
+  // Stamped, because the engine drops label vectors whose model is not the
+  // configured one — an unstamped fixture models a row that cannot exist after
+  // the 20260731150000 backfill, and would silently test nothing.
+  const embedding_model = getConfiguredEmbeddingModel();
   const attributeValues = {
-    positive: { embedding: basisVector(opts.positiveSlot) },
-    negative: { embedding: basisVector(opts.negativeSlot) },
+    positive: { embedding: basisVector(opts.positiveSlot), embedding_model },
+    negative: { embedding: basisVector(opts.negativeSlot), embedding_model },
   };
   const [row] = (await sql`
     INSERT INTO classify_facet (

--- a/packages/server/src/__tests__/integration/classifiers/classifier-label-vector-backfill.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifier-label-vector-backfill.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The 20260731150000 backfill, executed against rows that actually need it.
+ *
+ * This migration is load-bearing in a way the guard it supports is not: the
+ * classification engine now drops label vectors whose stamp is not the
+ * configured model, so if the backfill does nothing, all 208 existing prod
+ * vectors (28 classifiers) read as unknown-provenance and every classifier
+ * stops classifying the moment this deploys. The guard is the safety net; the
+ * backfill is what keeps it a no-op for data that is in fact fine.
+ *
+ * The suite's own migration run happens before any test data exists, so it
+ * proves only that the SQL parses. These tests seed the pre-migration shape and
+ * run the real statement out of the migration file — no second copy of the
+ * transform to drift from it.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestEvent, createTestOrganization } from '../../setup/test-fixtures';
+
+const MIGRATION = '20260731150000_classify_facet_label_vector_model_stamp.sql';
+
+/**
+ * The `migrate:up` half of the real migration file. Resolved by walking up to
+ * the repo root rather than a fixed `../../../../../..` so the test does not
+ * silently read nothing if the file ever moves.
+ */
+function migrationUpSql(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 10; i++) {
+    try {
+      const candidates = readdirSync(join(dir, 'db', 'migrations'));
+      if (candidates.includes(MIGRATION)) {
+        const raw = readFileSync(join(dir, 'db', 'migrations', MIGRATION), 'utf8');
+        const up = raw.split('-- migrate:down')[0].replace('-- migrate:up', '');
+        expect(up).toContain('classify_facet');
+        return up;
+      }
+    } catch {
+      // not this level — keep walking
+    }
+    dir = join(dir, '..');
+  }
+  throw new Error(`could not locate db/migrations/${MIGRATION}`);
+}
+
+const DIM = 768;
+function basisVector(slot: number): number[] {
+  const v = new Array<number>(DIM).fill(0);
+  v[slot] = 1;
+  return v;
+}
+
+/**
+ * The pre-migration shape: a vector, no stamp.
+ *
+ * `sql.json(...)`, NOT `JSON.stringify(...)::jsonb` — the latter binds the text
+ * as a parameter that lands as a jsonb STRING (`jsonb_typeof` = 'string'), i.e.
+ * double-encoded. The read paths JSON-parse twice and hide it, but the migration
+ * works in SQL, where its `jsonb_typeof(attribute_values) = 'object'` guard
+ * correctly skips such a row — so a stringify-seeded fixture tests nothing and
+ * reports it as the migration failing. Production writes through `sql.json`.
+ */
+async function seedUnstamped(
+  organizationId: string,
+  slug: string,
+  values: Record<string, unknown>
+): Promise<number> {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    INSERT INTO classify_facet (organization_id, slug, name, attribute_key, status, created_by, attribute_values)
+    VALUES (${organizationId}, ${slug}, ${slug}, ${slug}, 'active', 'system', ${sql.json(values as never)})
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+
+  // Fail loud if the fixture is not the shape production stores, rather than
+  // letting a mis-seeded row masquerade as a migration bug.
+  const [check] = (await sql`
+    SELECT jsonb_typeof(attribute_values) AS t FROM classify_facet WHERE id = ${Number(row.id)}
+  `) as unknown as Array<{ t: string }>;
+  expect(check.t).toBe('object');
+
+  return Number(row.id);
+}
+
+async function attributeValues(id: number): Promise<Record<string, Record<string, unknown>>> {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    SELECT attribute_values FROM classify_facet WHERE id = ${id}
+  `) as unknown as Array<{ attribute_values: Record<string, Record<string, unknown>> }>;
+  return row.attribute_values;
+}
+
+describe('classifier label-vector backfill migration', () => {
+  it('stamps unstamped vectors with the model the install actually runs', async () => {
+    await cleanupTestDatabase();
+    const sql = getTestDb();
+    const org = await createTestOrganization({ name: 'Backfill Org' });
+
+    // The stamp is DERIVED from event_embeddings, not hardcoded — so an install
+    // running a non-default model gets its own value. Prove that by making the
+    // prevailing model something other than the code default.
+    const installModel = 'Xenova/some-other-model';
+    await createTestEvent({
+      organization_id: org.id,
+      content: 'anything',
+      embedding: basisVector(0),
+    });
+    await sql`UPDATE event_embeddings SET embedding_model = ${installModel}`;
+
+    const id = await seedUnstamped(org.id, 'legacy', {
+      positive: { description: 'Positive', examples: ['great'], embedding: basisVector(0) },
+      negative: { description: 'Negative', examples: ['awful'], embedding: basisVector(1) },
+    });
+
+    await sql.unsafe(migrationUpSql());
+
+    const after = await attributeValues(id);
+    expect(after.positive.embedding_model).toBe(installModel);
+    expect(after.negative.embedding_model).toBe(installModel);
+    // Annotated, not rewritten — the vectors themselves must survive intact.
+    expect(after.positive.embedding).toHaveLength(DIM);
+    expect((after.positive.embedding as number[])[0]).toBe(1);
+    expect(after.positive.description).toBe('Positive');
+    expect(after.positive.examples).toEqual(['great']);
+  });
+
+  it('leaves vector-less entries unstamped and empty maps intact', async () => {
+    await cleanupTestDatabase();
+    const sql = getTestDb();
+    const org = await createTestOrganization({ name: 'Backfill Edge Org' });
+
+    const noVector = await seedUnstamped(org.id, 'no-vector', {
+      positive: { description: 'Positive', examples: ['great'] },
+    });
+    // `jsonb_object_agg` over zero rows returns NULL. Without the EXISTS guard
+    // in the WHERE clause this row's column would be blanked outright, which is
+    // considerably worse than the bug being fixed.
+    const empty = await seedUnstamped(org.id, 'empty', {});
+
+    await sql.unsafe(migrationUpSql());
+
+    // A stamp must never describe a vector that is not there.
+    expect(await attributeValues(noVector)).toEqual({
+      positive: { description: 'Positive', examples: ['great'] },
+    });
+    expect(await attributeValues(empty)).toEqual({});
+  });
+
+  it('is idempotent and never overwrites an existing stamp', async () => {
+    await cleanupTestDatabase();
+    const sql = getTestDb();
+    const org = await createTestOrganization({ name: 'Backfill Idempotent Org' });
+
+    await createTestEvent({
+      organization_id: org.id,
+      content: 'anything',
+      embedding: basisVector(0),
+    });
+    await sql`UPDATE event_embeddings SET embedding_model = 'model-A'`;
+
+    // A row already stamped by a DIFFERENT model is genuinely stale and must
+    // stay that way — re-blessing it as current would resurrect exactly the
+    // silent cross-space comparison this whole change exists to stop.
+    const id = await seedUnstamped(org.id, 'mixed', {
+      fresh: { embedding: basisVector(0), embedding_model: 'model-B' },
+      legacy: { embedding: basisVector(1) },
+    });
+
+    await sql.unsafe(migrationUpSql());
+    const once = await attributeValues(id);
+    expect(once.fresh.embedding_model).toBe('model-B');
+    expect(once.legacy.embedding_model).toBe('model-A');
+
+    await sql.unsafe(migrationUpSql());
+    expect(await attributeValues(id)).toEqual(once);
+  });
+});

--- a/packages/server/src/__tests__/integration/classifiers/classifier-label-vector-model-stamp.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifier-label-vector-model-stamp.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Classifier label vectors must carry the model that produced them.
+ *
+ * `classify_facet.attribute_values[value].embedding` is cosine-compared against
+ * `event_embeddings.embedding`. The EVENT side is model-scoped everywhere —
+ * content search, this engine's own target fetch, and the backfill's staleness
+ * predicate all pin `embedding_model` — because vectors from different models
+ * are not comparable even at equal dimensionality. The LABEL side had no stamp,
+ * so an `EMBEDDINGS_MODEL` swap left it behind entirely.
+ *
+ * The failure is silent, which is what makes it worth a test: cosine between two
+ * unrelated 768-dim spaces returns a confident-looking number instead of
+ * throwing, so classification keeps producing labels and they are simply wrong.
+ * Nothing in the pipeline reports an error.
+ *
+ * Measured on prod 2026-07-31: 28 classifiers, 208 label vectors, 0 stamped —
+ * against 2,060,864 event vectors that are 100% stamped.
+ */
+
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { manageClassifiers } from '../../../tools/admin/manage_classifiers';
+import type { ToolContext } from '../../../tools/registry';
+import { executeClassificationQuery } from '../../../utils/classification-query';
+import { DEFAULT_EMBEDDING_MODEL } from '../../../utils/embeddings';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const DIM = 768;
+function basisVector(slot: number): number[] {
+  const v = new Array<number>(DIM).fill(0);
+  v[slot] = 1;
+  return v;
+}
+
+/** Identical to the event vector below, so similarity is 1.0 when it is used. */
+const ATTRIBUTE_VALUES = {
+  positive: { description: 'Positive', examples: ['great'], embedding: basisVector(0) },
+};
+
+function ownerCtx(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'owner',
+    isAuthenticated: true,
+    tokenType: 'oauth',
+    scopedToOrg: false,
+    allowCrossOrg: false,
+    scopes: ['mcp:admin'],
+  } as ToolContext;
+}
+
+async function seedOrgWithClassifier(slug: string) {
+  await cleanupTestDatabase();
+  await seedSystemEntityTypes();
+  const org = await createTestOrganization({ name: 'Stamp Org' });
+  const user = await createTestUser({ email: `${slug}@test.example.com` });
+  await addUserToOrganization(user.id, org.id, 'owner');
+  const ctx = ownerCtx(org.id, user.id);
+
+  const created = await manageClassifiers(
+    {
+      action: 'create',
+      slug,
+      name: slug,
+      attribute_key: slug,
+      attribute_values: ATTRIBUTE_VALUES,
+      min_similarity: 0.5,
+    } as never,
+    {} as never,
+    ctx
+  );
+  expect(created.success).toBe(true);
+
+  const event = await createTestEvent({
+    organization_id: org.id,
+    content: 'great',
+    embedding: basisVector(0),
+  });
+
+  return { org, ctx, eventId: Number(event.id), slug };
+}
+
+function classify(orgId: string, slug: string, eventId: number) {
+  return executeClassificationQuery({
+    mode: 'content_ids',
+    organizationId: orgId,
+    content_ids: [eventId],
+    enabledClassifiers: [slug],
+  } as never);
+}
+
+/**
+ * The durable evidence: what the engine actually persisted for this event.
+ *
+ * `unnest` rather than reading the column directly — the pool runs with
+ * `fetch_types: false`, so a text[] arrives as the raw literal `{positive}`
+ * (one string), which compares unequal to `['positive']` in a way that looks
+ * like a logic failure.
+ */
+async function storedLabels(eventId: number): Promise<string[]> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT unnest("values") AS v FROM event_classifications WHERE event_id = ${eventId}
+  `) as unknown as Array<{ v: string }>;
+  return rows.map((r) => r.v);
+}
+
+/**
+ * Minimal stand-in for the embeddings service. `generate_embeddings` is a
+ * network call by design (vectors come from a dedicated service), and the
+ * regeneration path is exactly what makes a model swap self-repairing — so it
+ * is worth exercising for real rather than asserting around.
+ *
+ * Echoes `model` back as whatever the deployment is configured for, because
+ * `generateEmbeddings` refuses a response whose model disagrees.
+ */
+async function withStubEmbeddingsService<T>(run: () => Promise<T>): Promise<T> {
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => {
+      body += c;
+    });
+    req.on('end', () => {
+      const { texts } = JSON.parse(body || '{}') as { texts: string[] };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          embeddings: texts.map(() => basisVector(0)),
+          dimensions: DIM,
+          model: process.env.EMBEDDINGS_MODEL || DEFAULT_EMBEDDING_MODEL,
+        })
+      );
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  process.env.EMBEDDINGS_SERVICE_URL = `http://127.0.0.1:${port}`;
+  try {
+    return await run();
+  } finally {
+    delete process.env.EMBEDDINGS_SERVICE_URL;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+afterEach(() => {
+  delete process.env.EMBEDDINGS_MODEL;
+});
+
+describe('classifier label vectors are model-stamped', () => {
+  it('stamps the configured model when create generates the vectors', async () => {
+    const { org, slug } = await seedOrgWithClassifier('stamped-on-create');
+    const sql = getTestDb();
+
+    const [row] = (await sql`
+      SELECT attribute_values FROM classify_facet
+      WHERE slug = ${slug} AND organization_id = ${org.id}
+    `) as unknown as Array<{ attribute_values: Record<string, { embedding_model?: string }> }>;
+
+    // The vector and its provenance are stored together, mirroring the
+    // event_embeddings row shape.
+    expect(row.attribute_values.positive.embedding_model).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+
+  it('classifies normally while the stamp matches the configured model', async () => {
+    const { org, slug, eventId } = await seedOrgWithClassifier('matching-stamp');
+
+    // Control for the test below: this exact setup DOES produce a label, so a
+    // zero result there is attributable to the stamp and nothing else.
+    await classify(org.id, slug, eventId);
+    expect(await storedLabels(eventId)).toEqual(['positive']);
+  });
+
+  it('drops label vectors from a different model instead of comparing across spaces', async () => {
+    const { org, slug, eventId } = await seedOrgWithClassifier('foreign-stamp');
+    const sql = getTestDb();
+    const newModel = 'Xenova/multilingual-e5-base';
+
+    // The state that actually makes this dangerous is POST-backfill, and getting
+    // there matters: simply flipping EMBEDDINGS_MODEL is not enough to reproduce
+    // it, because `fetchTargetContent` scopes event_embeddings by model too, so
+    // the EVENT vector disappears along with the label vector and nothing is
+    // compared at all. A first draft of this test passed against unfixed code
+    // for exactly that reason — vacuously, having proven nothing.
+    //
+    // So: re-embed the event under the new model, as the documented swap
+    // procedure does. Now the event vector IS found, the label vector is still
+    // bge, and they are the two halves of a cross-space cosine. Unfixed, this
+    // returns 1.0 and writes a confident 'positive'.
+    await sql`
+      INSERT INTO event_embeddings (event_id, embedding_model, chunk_index, embedding)
+      VALUES (${eventId}, ${newModel}, 0, ${JSON.stringify(basisVector(0))}::vector)
+    `;
+    process.env.EMBEDDINGS_MODEL = newModel;
+
+    await classify(org.id, slug, eventId);
+    expect(await storedLabels(eventId)).toEqual([]);
+
+    // And the stored vector is left intact for `generate_embeddings` to replace,
+    // not destroyed by the read path.
+    const [row] = (await sql`
+      SELECT attribute_values FROM classify_facet
+      WHERE slug = ${slug} AND organization_id = ${org.id}
+    `) as unknown as Array<{
+      attribute_values: Record<string, { embedding?: number[]; embedding_model?: string }>;
+    }>;
+    expect(row.attribute_values.positive.embedding).toHaveLength(DIM);
+    expect(row.attribute_values.positive.embedding_model).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+
+  it('treats a stale stamp as missing so generate_embeddings re-embeds it', async () => {
+    const { org, ctx, slug } = await seedOrgWithClassifier('regenerates-stale');
+    const sql = getTestDb();
+
+    const [before] = (await sql`
+      SELECT id FROM classify_facet WHERE slug = ${slug} AND organization_id = ${org.id}
+    `) as unknown as Array<{ id: number }>;
+
+    // A swap must be repairable by the documented procedure alone. Without
+    // stale-means-regenerate, generate_embeddings reports "all values already
+    // have embeddings" and the classifier stays dead until someone thinks to
+    // pass force_regenerate.
+    process.env.EMBEDDINGS_MODEL = 'Xenova/multilingual-e5-base';
+
+    const regenerated = await withStubEmbeddingsService(() =>
+      manageClassifiers(
+        { action: 'generate_embeddings', classifier_id: Number(before.id) } as never,
+        { EMBEDDINGS_SERVICE_URL: process.env.EMBEDDINGS_SERVICE_URL } as never,
+        ctx
+      )
+    );
+    expect(regenerated.success).toBe(true);
+    expect((regenerated.data as { generated_embeddings: number }).generated_embeddings).toBe(1);
+
+    const [after] = (await sql`
+      SELECT attribute_values FROM classify_facet WHERE id = ${Number(before.id)}
+    `) as unknown as Array<{ attribute_values: Record<string, { embedding_model?: string }> }>;
+    expect(after.attribute_values.positive.embedding_model).toBe('Xenova/multilingual-e5-base');
+  });
+});

--- a/packages/server/src/__tests__/integration/classifiers/classifiers-apply-skip-reasons.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifiers-apply-skip-reasons.test.ts
@@ -66,9 +66,12 @@ describe('manage_classifiers apply — skip reasons', () => {
 
     // positive == basis 0, negative == basis 1, threshold 0.5, NO fallback — so
     // an event on basis 7 is orthogonal to both and genuinely scores below.
+    // Stamped: the engine drops label vectors whose model is not the configured
+    // one, so an unstamped fixture would make this suite pass vacuously.
+    const labelModel = getConfiguredEmbeddingModel();
     const attributeValues = {
-      positive: { embedding: basisVector(0) },
-      negative: { embedding: basisVector(1) },
+      positive: { embedding: basisVector(0), embedding_model: labelModel },
+      negative: { embedding: basisVector(1), embedding_model: labelModel },
     };
     // Seeded in the CALLER's org only. The other org deliberately has no
     // classifier: its event must be excluded by the org filter, not by failing
@@ -232,7 +235,7 @@ describe('manage_classifiers apply — skip reasons', () => {
       ) VALUES (
         ${org.id}, 'behavior-owned', 'behavior owned', 'behavior-owned', 'active', ${user.id},
         ${behavior.id}, NULL, 0.5, NULL,
-        ${JSON.stringify({ positive: { embedding: basisVector(0) } })}::jsonb
+        ${JSON.stringify({ positive: { embedding: basisVector(0), embedding_model: getConfiguredEmbeddingModel() } })}::jsonb
       )
     `;
 

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -42,40 +42,99 @@ export { ManageClassifiersResultSchema, ManageClassifiersSchema };
 // Typeers
 // ============================================
 
+/**
+ * Generate any missing or stale label vectors and stamp each with the model
+ * that produced it.
+ *
+ * A label vector lives inside `attribute_values[value].embedding` and is cosine-
+ * compared against `event_embeddings.embedding`. Event vectors are model-scoped
+ * on every path that touches them (search, the classification engine, the
+ * backfill's staleness predicate) precisely because vectors from different
+ * models are NOT comparable even at equal dimensionality. Label vectors had no
+ * stamp at all, so they were the one side of that comparison that a model swap
+ * left behind: cosine over two incompatible 768-dim spaces returns a plausible
+ * number rather than an error, so classification would keep "working" and
+ * quietly assign wrong labels.
+ *
+ * A stale stamp is therefore treated exactly like a missing embedding —
+ * regenerate it — which also means the existing `EMBEDDINGS_MODEL` swap
+ * procedure repairs classifiers by itself instead of needing a manual
+ * `force_regenerate` sweep nobody would remember to run.
+ */
 async function hydrateAttributeEmbeddings(
   attributeValues: Record<
     string,
-    { description: string; examples: string[]; embedding?: number[] | null }
+    {
+      description: string;
+      examples: string[];
+      embedding?: number[] | null;
+      embedding_model?: string | null;
+    }
   >,
   env: Env,
   options: { forceRegenerate?: boolean } = {}
 ): Promise<{
   attributeValues: Record<
     string,
-    { description: string; examples: string[]; embedding?: number[] }
+    {
+      description: string;
+      examples: string[];
+      embedding?: number[];
+      embedding_model?: string;
+    }
   >;
   generatedCount: number;
 }> {
-  const updated: Record<string, { description: string; examples: string[]; embedding?: number[] }> =
-    {};
+  const configuredModel = getConfiguredEmbeddingModel();
+  const updated: Record<
+    string,
+    {
+      description: string;
+      examples: string[];
+      embedding?: number[];
+      embedding_model?: string;
+    }
+  > = {};
   const valuesToEmbed: string[] = [];
 
   for (const [value, config] of Object.entries(attributeValues)) {
     const hasEmbedding = isValidEmbedding(config.embedding ?? null);
-    if (!hasEmbedding || options.forceRegenerate) {
+    // A DIFFERENT stamp means stale — regenerate. A MISSING stamp does not:
+    // this function also runs on `create`, where the vector was just handed to
+    // us by a caller running this same deployment, and where discarding it
+    // would both throw away supplied input and force a live embeddings-service
+    // round-trip on a path that never needed one. So an unstamped vector is
+    // adopted at the configured model — the identical assumption
+    // `ensureEmbedding` already makes for worker-supplied vectors, since the
+    // configured model is the only provenance available either way.
+    //
+    // That is safe rather than optimistic because genuinely legacy rows do not
+    // survive to be read here: the backfill migration stamps all 208 of them at
+    // deploy, deriving the value from event_embeddings.
+    const isForeignModel =
+      config.embedding_model != null && config.embedding_model !== configuredModel;
+    const reusable = hasEmbedding && !isForeignModel;
+    if (!reusable || options.forceRegenerate) {
       valuesToEmbed.push(value);
     }
     updated[value] = {
       description: config.description,
       examples: config.examples,
-      embedding: hasEmbedding ? (config.embedding as number[]) : undefined,
+      // Vector and stamp move together — never carry a vector past its stamp,
+      // and never leave a stamp describing a vector that is no longer there.
+      embedding: reusable ? (config.embedding as number[]) : undefined,
+      embedding_model: reusable ? configuredModel : undefined,
     };
   }
 
   if (valuesToEmbed.length > 0) {
     const embeddings = await generateEmbeddingsViaService(valuesToEmbed, env);
     valuesToEmbed.forEach((value, index) => {
-      updated[value] = { ...updated[value], embedding: embeddings[index] };
+      updated[value] = {
+        ...updated[value],
+        embedding: embeddings[index],
+        embedding_model: configuredModel,
+      };
     });
   }
 

--- a/packages/server/src/utils/classification-query.ts
+++ b/packages/server/src/utils/classification-query.ts
@@ -9,7 +9,7 @@
 
 import { type DbClient, getDb, parsePgNumberArray, pgTextArray } from '../db/client';
 import { entityLinkMatchSql } from './content-search';
-import { configuredEmbeddingModelSqlLiteral } from './embeddings';
+import { configuredEmbeddingModelSqlLiteral, getConfiguredEmbeddingModel } from './embeddings';
 import logger from './logger';
 
 /**
@@ -341,6 +341,8 @@ async function fetchClassifierTemplates(
 
   // Expand attribute_values JSON into individual templates in TypeScript
   const templates: ClassifierTemplate[] = [];
+  const configuredModel = getConfiguredEmbeddingModel();
+  let staleTemplates = 0;
 
   for (const row of rows) {
     // Scope check: classifier must be global (empty entity_ids) OR overlap with target content entity_ids
@@ -363,6 +365,20 @@ async function fetchClassifierTemplates(
       const embeddingArr = attrObj.embedding as number[] | undefined;
       if (!embeddingArr) continue;
 
+      // The event side of this comparison is model-scoped (fetchTargetContent
+      // joins event_embeddings ON embedding_model = the configured model), so
+      // the label side must be too. Cosine across two different 768-dim spaces
+      // returns a confident-looking number instead of an error, which is the
+      // whole hazard: without this guard an EMBEDDINGS_MODEL swap keeps
+      // classifying and silently assigns wrong labels.
+      //
+      // Dropped rather than compared, and counted so the operator sees a real
+      // reason instead of a bare "No classifier templates found".
+      if (attrObj.embedding_model !== configuredModel) {
+        staleTemplates++;
+        continue;
+      }
+
       const parentMapping = attrObj.parent as Record<string, string> | undefined;
 
       templates.push({
@@ -374,6 +390,19 @@ async function fetchClassifierTemplates(
         template_embedding: embeddingArr,
       });
     }
+  }
+
+  if (staleTemplates > 0) {
+    logger.warn(
+      {
+        staleTemplates,
+        usableTemplates: templates.length,
+        configuredModel,
+        classifiers: enabledClassifiers,
+      },
+      '[Classification Query] Dropped label vectors embedded by a different model — ' +
+        'run manage_classifiers generate_embeddings to re-embed them under the configured model'
+    );
   }
 
   return templates;

--- a/packages/server/src/watchers/classifier-extraction.ts
+++ b/packages/server/src/watchers/classifier-extraction.ts
@@ -17,6 +17,7 @@ import {
 import type { Env } from "../index";
 import {
 	generateEmbeddings,
+	getConfiguredEmbeddingModel,
 	isValidEmbedding,
 	validateEmbeddingsService,
 } from "../utils/embeddings";
@@ -116,6 +117,13 @@ interface AttributeValue {
 	description: string;
 	examples: string[];
 	embedding?: number[] | null;
+	/**
+	 * Which model produced `embedding`. Set whenever a vector is stored, and
+	 * read by the classification engine, which drops any label vector not
+	 * matching the configured model rather than cosine-comparing across two
+	 * incompatible spaces. Absent means "unknown provenance" → treated as stale.
+	 */
+	embedding_model?: string | null;
 	parent?: Record<string, string>; // { "parent-slug": "parent-value" }
 }
 
@@ -280,8 +288,15 @@ function normalizeValue(
 	let bestMatch: string | null = null;
 	let bestSimilarity = 0;
 
+	const configuredModel = getConfiguredEmbeddingModel();
 	for (const [existing, config] of Object.entries(existingValues)) {
 		if (!hasValidEmbedding(config.embedding)) continue;
+		// Same cross-space hazard as the classification engine, one step earlier:
+		// `newEmbedding` came from the configured model, so an existing value
+		// embedded under a different one cannot be compared against it. Skipping
+		// degrades to exact string match for that pair — a spurious NEW value at
+		// worst, never a wrong auto-merge into an unrelated label.
+		if (config.embedding_model !== configuredModel) continue;
 
 		const similarity = cosineSimilarity(newEmbedding, config.embedding);
 		if (similarity > bestSimilarity) {
@@ -314,16 +329,35 @@ function ensureEmbedding(
 	workerEmbedding?: number[],
 ): AttributeValue {
 	if (hasValidEmbedding(workerEmbedding)) {
-		return { ...config, embedding: workerEmbedding };
+		// Stamped with the configured model, not with something the worker
+		// reported: `getConfiguredEmbeddingModel()` reads the same EMBEDDINGS_MODEL
+		// env var the worker and the embeddings service read, so it is the only
+		// provenance available here. If a worker were ever pinned to a different
+		// model this stamp would be wrong — but it would have been silently
+		// wrong-and-unlabelled before, and the engine now has something to check.
+		return {
+			...config,
+			embedding: workerEmbedding,
+			embedding_model: getConfiguredEmbeddingModel(),
+		};
 	}
 
 	if (hasValidEmbedding(config.embedding)) {
-		return config;
+		// Adopt an unstamped vector at the configured model — the same rule
+		// hydrateAttributeEmbeddings applies, for the same reason: the configured
+		// model is the only provenance available. A foreign stamp is preserved
+		// as-is; this path never destroys a vector, the engine just won't use it
+		// until generate_embeddings re-embeds it.
+		return {
+			...config,
+			embedding_model: config.embedding_model ?? getConfiguredEmbeddingModel(),
+		};
 	}
 
 	// No embedding available — store without embedding, similarity matching
-	// will fall back to exact string match for this value.
-	return { ...config, embedding: null };
+	// will fall back to exact string match for this value. Clear any stamp with
+	// it so a stamp never outlives the vector it describes.
+	return { ...config, embedding: null, embedding_model: null };
 }
 
 // ============================================


### PR DESCRIPTION
## What

`classify_facet.attribute_values[value].embedding` is cosine-compared against `event_embeddings.embedding`. The **event** side is model-scoped everywhere — content search, this engine's own target fetch, the backfill's staleness predicate — because vectors from different models are not comparable even at equal dimensionality. The **label** side carried no stamp at all.

So label vectors were the half an `EMBEDDINGS_MODEL` swap leaves behind. And the failure is silent: cosine between two unrelated 768-dim spaces returns a confident-looking number rather than throwing, so classification keeps emitting labels and they are simply wrong.

Measured on prod 2026-07-31: **28 classifiers, 208 label vectors, 0 stamped** — against 2,060,864 event vectors that are 100% stamped, all one model (`Xenova/bge-base-en-v1.5`).

## Change

- **Writers stamp.** `hydrateAttributeEmbeddings` (create / `generate_embeddings`) and `ensureEmbedding` (the Behavior extraction path) both record the configured model. That value is *verified*, not assumed — `generateEmbeddings` already refuses a service response whose `model` disagrees with `EMBEDDINGS_MODEL`.
- **Both cosine consumers guard.** The engine drops foreign-model templates and logs a countable reason instead of a bare `No classifier templates found`; `normalizeValue` skips foreign-model values when deduping (degrading to exact string match — a spurious new value at worst, never a wrong auto-merge).
- **A stale stamp is treated as a missing embedding**, so `generate_embeddings` repairs a swap on its own rather than needing someone to remember `force_regenerate`.
- **A *missing* stamp is adopted, not discarded** — `hydrate` also runs on `create`, where the vector was just supplied by a caller on this same deployment. Discarding it would throw away input and force a needless service round-trip.
- **The backfill derives the stamp** from `event_embeddings` rather than hardcoding, so an install on a non-default model gets its own value.

## Red → green

Red (fix reverted, tests unchanged) — note the second line, which is the actual bug:

```
× stamps the configured model when create generates the vectors
  → expected undefined to be 'Xenova/bge-base-en-v1.5'
× drops label vectors from a different model instead of comparing across spaces
  → expected [ 'positive' ] to deeply equal []
× treats a stale stamp as missing so generate_embeddings re-embeds it
  → expected +0 to be 1

Tests  3 failed | 1 passed (4)
```

Green:

```
Test Files  13 passed (13)
     Tests  39 passed (39)
```

## Two traps worth recording

**The obvious reproducer proves nothing.** A first draft of the drop test just flipped `EMBEDDINGS_MODEL` — and passed against unfixed code, because `fetchTargetContent` scopes `event_embeddings` by model too, so the *event* vector vanishes alongside the label vector and nothing is compared at all. The test now re-embeds the event under the new model first (as the documented swap procedure does), which is the state where the cross-space cosine actually happens.

**The backfill needed its own test, and it caught a fixture bug.** The suite's migration run happens before any test data exists, so it only proves the SQL parses. `classifier-label-vector-backfill.test.ts` seeds the pre-migration shape and executes the real statement read out of the migration file. Writing it surfaced that `${JSON.stringify(v)}::jsonb` stores a jsonb **string** (double-encoded, `jsonb_typeof` = `'string'`) — the read paths parse twice and hide it, but the migration's `= 'object'` guard correctly skips such a row. The fixture now uses `sql.json` (what production uses) and asserts `jsonb_typeof = 'object'` so a mis-seeded row can never masquerade as a migration bug.

Rehearsed against prod inside a rolled-back transaction: **175 entries stamped**.

## Deploy ordering

The backfill is what keeps the new guard a no-op for data that is fine. If it did nothing, all 208 existing vectors would read as unknown-provenance and every classifier would stop classifying at deploy. Migration runs in the pre-deploy hook, so it lands first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->