### PR TITLE
test(server): store classifier fixtures the way production does

### DIFF
--- a/packages/server/src/__tests__/integration/classifiers/classification-execute-query.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classification-execute-query.test.ts
@@ -56,10 +56,22 @@ async function seedFacet(opts: {
       watcher_id, entity_ids, min_similarity, fallback_value, attribute_values
     ) VALUES (
       ${opts.orgId}, ${opts.slug}, ${`${opts.slug} classifier`}, ${opts.slug}, 'active', ${opts.createdBy},
-      NULL, NULL, ${opts.minSimilarity}, ${opts.fallbackValue}, ${JSON.stringify(attributeValues)}::jsonb
+      NULL, NULL, ${opts.minSimilarity}, ${opts.fallbackValue}, ${sql.json(attributeValues as never)}
     )
     RETURNING id
   `) as Array<{ id: number }>;
+
+  // `sql.json`, not `JSON.stringify(...)::jsonb` — the latter binds the text as
+  // a parameter that lands as a jsonb STRING (`jsonb_typeof` = 'string'), i.e.
+  // double-encoded. This same mistake in RunsQueue shipped to prod: it broke
+  // every `action_input ->> 'field'` reader and 403'd workers via the snapshot
+  // ownership verifier. Assert the shape so a fixture can never again store
+  // something production does not.
+  const [shape] = (await sql`
+    SELECT jsonb_typeof(attribute_values) AS t FROM classify_facet WHERE id = ${Number(row.id)}
+  `) as Array<{ t: string }>;
+  expect(shape.t).toBe('object');
+
   return Number(row.id);
 }
 
@@ -120,7 +132,17 @@ describe('executeClassificationQuery (full embedding pipeline)', () => {
     const org = await createTestOrganization({ name: 'CQ Org 2' });
     const user = await createTestUser({ email: 'cq2@test.com' });
 
-    // event embedding (basis 3) is orthogonal to both attributes → best cosine 0.0 < 0.99
+    // Leans toward `positive` (0.949) over `negative` (0.316), and BOTH are
+    // below the 0.99 threshold — so `best_match_attribute` below is a real
+    // winner rather than a coin flip.
+    //
+    // This previously used basis 3, orthogonal to both attributes: cosine
+    // exactly 0.0 each, so "closest" was a tie and the assertion only held
+    // because of the order attributes happened to come back in. Under jsonb
+    // that order is jsonb's own (key length, then bytewise — so `negative`
+    // sorts before `positive`), not authoring order, and the tie flipped. The
+    // old fixture stored a double-encoded jsonb *string*, which preserved
+    // authoring order and hid it.
     const facetId = await seedFacet({
       orgId: org.id,
       createdBy: user.id,
@@ -130,10 +152,13 @@ describe('executeClassificationQuery (full embedding pipeline)', () => {
       minSimilarity: 0.99,
       fallbackValue: 'unknown',
     });
+    const leaningPositive = new Array<number>(DIM).fill(0);
+    leaningPositive[2] = 0.3;
+    leaningPositive[4] = 0.1;
     const event = await createTestEvent({
       organization_id: org.id,
       content: 'neutral content matching nothing',
-      embedding: basisVector(3),
+      embedding: leaningPositive,
     });
 
     const results = await executeClassificationQuery({

--- a/packages/server/src/__tests__/integration/classifiers/classifiers-apply-skip-reasons.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifiers-apply-skip-reasons.test.ts
@@ -85,7 +85,7 @@ describe('manage_classifiers apply — skip reasons', () => {
         watcher_id, entity_ids, min_similarity, fallback_value, attribute_values
       ) VALUES (
         ${org.id}, 'apply-reasons', 'apply reasons classifier', 'apply-reasons', 'active', ${user.id},
-        NULL, NULL, 0.5, NULL, ${JSON.stringify(attributeValues)}::jsonb
+        NULL, NULL, 0.5, NULL, ${sql.json(attributeValues as never)}
       )
     `;
 
@@ -235,7 +235,7 @@ describe('manage_classifiers apply — skip reasons', () => {
       ) VALUES (
         ${org.id}, 'behavior-owned', 'behavior owned', 'behavior-owned', 'active', ${user.id},
         ${behavior.id}, NULL, 0.5, NULL,
-        ${JSON.stringify({ positive: { embedding: basisVector(0), embedding_model: getConfiguredEmbeddingModel() } })}::jsonb
+        ${sql.json({ positive: { embedding: basisVector(0), embedding_model: getConfiguredEmbeddingModel() } } as never)}
       )
     `;
 


### PR DESCRIPTION
## What

The classifier fixtures bound `attribute_values` as `${JSON.stringify(v)}::jsonb`, which lands as a jsonb **string** (`jsonb_typeof = 'string'`) rather than an object — double-encoded. The read paths JSON-parse twice and hide it, so the suites passed while storing a shape production never writes.

This is not hypothetical. The identical mistake in `RunsQueue` reached prod and is documented at `runs-queue.ts:313` — it broke every `action_input ->> 'field'` reader and 403'd workers through the snapshot ownership verifier. It also cost time earlier today: it made the #2407 backfill migration look broken when the migration was correct and the fixture was not.

## The masked test

Switching to `sql.json` immediately turned one test red — and it was a test that never tested what it claimed:

```
× falls back when the best cosine is below min_similarity
  → expected 'negative' to be 'positive'
```

`falls back when the best cosine is below min_similarity` asserted `best_match_attribute === 'positive'` on an event embedded at basis 3 — **orthogonal to both attributes**, cosine exactly 0.0 each. "Closest" was a tie, decided entirely by attribute iteration order.

Under real jsonb that order is jsonb's own (key length, then bytewise — so `negative` sorts before `positive`), not authoring order. The double-encoded string preserved authoring order, so the tie happened to land on `positive` and the assertion looked meaningful.

The event vector now leans genuinely positive (cosine 0.949 vs 0.316) with both still under the 0.99 threshold, so the assertion has a real winner to name and the fallback behaviour is still what is under test.

## Guard

`seedFacet` now asserts `jsonb_typeof(attribute_values) = 'object'` after inserting, so a fixture cannot silently reintroduce the double-encoded shape.

## Scope

`agent-transcript-snapshot.test.ts` also matches the grep and is **deliberately left alone** — it reproduces the broken shape on purpose as a regression test for the RunsQueue incident.

```
Test Files  14 passed (14)
     Tests  43 passed (43)
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->