### PR TITLE
feat(server): let a caller choose the embedding model instead of one global

### DIFF
--- a/packages/core/src/contracts/tools/manage-classifiers.ts
+++ b/packages/core/src/contracts/tools/manage-classifiers.ts
@@ -112,6 +112,12 @@ export const ManageClassifiersSchema = Type.Object({
         "[generate_embeddings] Force regenerate existing embeddings (default: false)",
     })
   ),
+  embedding_model: Type.Optional(
+    Type.String({
+      description:
+        "[create/generate_embeddings/apply] Embedding model to use. Defaults to this deployment's configured model; only set it to work in a different vector space. Label vectors and event vectors must share a model — a classifier embedded under one model matches nothing when applied under another, and `apply` will report every id as not_embedded until the events are embedded under the same model.",
+    })
+  ),
 
   // Manual classification fields
   content_id: Type.Optional(

--- a/packages/server/src/__tests__/integration/classifiers/classifier-embedding-model-param.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifier-embedding-model-param.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Classification under a NON-DEFAULT embedding model.
+ *
+ * `event_embeddings` has been keyed `(event_id, embedding_model, chunk_index)`
+ * since 20260618140000, and both write paths (insert-event's `upsertEmbedding`,
+ * the worker's `completeEmbeddings`) already take the model per row — two models
+ * have always been able to coexist in storage. Nothing could ever *choose* one:
+ * every read scoped itself to `getConfiguredEmbeddingModel()`, a process-global.
+ *
+ * These tests pin the property that makes the parameter worth having — that a
+ * non-default model is actually honoured end to end — rather than only that the
+ * default still works. A threading change like this fails silently in the
+ * direction the default-path tests cannot see: miss one site and it keeps
+ * reading the configured model while its neighbour reads the requested one, and
+ * cosine across two 768-dim spaces returns a confident number instead of an
+ * error. That is the same failure class the label-vector stamp (#2407) exists to
+ * prevent, reachable a second way.
+ *
+ * `EMBEDDINGS_MODEL` is never touched here: the point is that a caller can work
+ * in another space WITHOUT a deployment-wide swap.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { manageClassifiers } from '../../../tools/admin/manage_classifiers';
+import type { ToolContext } from '../../../tools/registry';
+import { executeClassificationQuery } from '../../../utils/classification-query';
+import { getConfiguredEmbeddingModel } from '../../../utils/embeddings';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const DIM = 768;
+/** A second model name. Never installed anywhere — it only has to be a distinct string. */
+const OTHER_MODEL = 'Xenova/multilingual-e5-base';
+
+function basisVector(slot: number): number[] {
+  const v = new Array<number>(DIM).fill(0);
+  v[slot] = 1;
+  return v;
+}
+
+function ownerCtx(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'owner',
+    isAuthenticated: true,
+    tokenType: 'oauth',
+    scopedToOrg: false,
+    allowCrossOrg: false,
+    scopes: ['mcp:admin'],
+  } as ToolContext;
+}
+
+/**
+ * Seed a classifier whose label vector is stamped `labelModel`, and one event
+ * whose vector is stamped `eventModel`.
+ *
+ * The label vector is written directly rather than through `create`, because
+ * `create` hydrates via the embeddings service and this suite is about which
+ * model the READ paths scope to — not about the service round-trip (covered by
+ * classifier-label-vector-model-stamp.test.ts). Both vectors are basis 0, so
+ * cosine is exactly 1.0 whenever the two are actually compared: any non-match
+ * below is a scoping decision, never a numeric one.
+ */
+async function seed(opts: { slug: string; labelModel: string; eventModel: string }) {
+  await cleanupTestDatabase();
+  await seedSystemEntityTypes();
+  const org = await createTestOrganization({ name: 'Model Param Org' });
+  const user = await createTestUser({ email: `${opts.slug}@test.example.com` });
+  await addUserToOrganization(user.id, org.id, 'owner');
+
+  const sql = getTestDb();
+  const attributeValues = {
+    positive: {
+      description: 'Positive',
+      examples: ['great'],
+      embedding: basisVector(0),
+      embedding_model: opts.labelModel,
+    },
+  };
+  const [facet] = (await sql`
+    INSERT INTO classify_facet (
+      organization_id, slug, name, attribute_key, status, created_by,
+      watcher_id, entity_ids, min_similarity, fallback_value, attribute_values
+    ) VALUES (
+      ${org.id}, ${opts.slug}, ${opts.slug}, ${opts.slug}, 'active', ${user.id},
+      NULL, NULL, 0.5, NULL, ${sql.json(attributeValues as never)}
+    ) RETURNING id
+  `) as Array<{ id: number }>;
+
+  const event = await createTestEvent({
+    organization_id: org.id,
+    content: 'great',
+    embedding: basisVector(0),
+    embedding_model: opts.eventModel,
+  });
+
+  return {
+    org,
+    ctx: ownerCtx(org.id, user.id),
+    eventId: Number(event.id),
+    facetId: Number(facet.id),
+  };
+}
+
+/** What the engine actually persisted. `unnest` because fetch_types:false returns text[] raw. */
+async function storedLabels(eventId: number): Promise<string[]> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT unnest("values") AS v FROM event_classifications WHERE event_id = ${eventId}
+  `) as unknown as Array<{ v: string }>;
+  return rows.map((r) => r.v);
+}
+
+describe('classification under a caller-supplied embedding model', () => {
+  afterEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('classifies when BOTH sides live in the requested non-default model', async () => {
+    const { org, eventId } = await seed({
+      slug: 'mp-both-other',
+      labelModel: OTHER_MODEL,
+      eventModel: OTHER_MODEL,
+    });
+
+    const results = await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: org.id,
+      content_ids: [eventId],
+      enabledClassifiers: ['mp-both-other'],
+      embeddingModel: OTHER_MODEL,
+    });
+
+    expect(results).toEqual([{ content_id: eventId }]);
+    expect(await storedLabels(eventId)).toEqual(['positive']);
+  });
+
+  // The inverse of the test above, and the one that actually catches a missed
+  // call site: identical data, only the requested model differs. If either side
+  // still resolved the model from the global, this would classify.
+  it('classifies NOTHING when the same data is requested under the configured model', async () => {
+    const { org, eventId } = await seed({
+      slug: 'mp-both-other-default-read',
+      labelModel: OTHER_MODEL,
+      eventModel: OTHER_MODEL,
+    });
+
+    const results = await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: org.id,
+      content_ids: [eventId],
+      enabledClassifiers: ['mp-both-other-default-read'],
+    });
+
+    expect(results).toEqual([]);
+    expect(await storedLabels(eventId)).toEqual([]);
+  });
+
+  // Half-migrated corpus: labels re-embedded under the new model, events not yet.
+  // Must produce nothing rather than a cross-space cosine.
+  it('refuses to compare a requested-model label against a configured-model event', async () => {
+    const { org, eventId } = await seed({
+      slug: 'mp-split',
+      labelModel: OTHER_MODEL,
+      eventModel: getConfiguredEmbeddingModel(),
+    });
+
+    const results = await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: org.id,
+      content_ids: [eventId],
+      enabledClassifiers: ['mp-split'],
+      embeddingModel: OTHER_MODEL,
+    });
+
+    expect(results).toEqual([]);
+    expect(await storedLabels(eventId)).toEqual([]);
+  });
+
+  it('still uses the configured model when no override is passed', async () => {
+    const configured = getConfiguredEmbeddingModel();
+    const { org, eventId } = await seed({
+      slug: 'mp-default',
+      labelModel: configured,
+      eventModel: configured,
+    });
+
+    const results = await executeClassificationQuery({
+      mode: 'content_ids',
+      organizationId: org.id,
+      content_ids: [eventId],
+      enabledClassifiers: ['mp-default'],
+    });
+
+    expect(results).toEqual([{ content_id: eventId }]);
+    expect(await storedLabels(eventId)).toEqual(['positive']);
+  });
+
+  // `apply`'s skip reasons are the agent-visible surface, and the probe that
+  // produces them is a SEPARATE query from the engine's join. If the two resolve
+  // the model independently the event passes the probe, gets dropped by the
+  // engine, and is reported `below_threshold` — a claim that it was scored and
+  // lost, about a row that was never scored at all.
+  it('reports not_embedded (never below_threshold) for an event absent from the requested model', async () => {
+    const { ctx, eventId } = await seed({
+      slug: 'mp-apply-skip',
+      labelModel: OTHER_MODEL,
+      eventModel: getConfiguredEmbeddingModel(),
+    });
+
+    const result = (await manageClassifiers(
+      {
+        action: 'apply',
+        classifier_slug: 'mp-apply-skip',
+        content_ids: [eventId],
+        embedding_model: OTHER_MODEL,
+      } as never,
+      {} as never,
+      ctx
+    )) as {
+      success: boolean;
+      data?: { classified: number; skipped: Record<string, number> };
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.data?.classified).toBe(0);
+    expect(result.data?.skipped.not_embedded).toBe(1);
+    expect(result.data?.skipped.below_threshold).toBe(0);
+  });
+
+  it('rejects a model identifier that would be inlined into SQL', async () => {
+    const { org, eventId } = await seed({
+      slug: 'mp-injection',
+      labelModel: OTHER_MODEL,
+      eventModel: OTHER_MODEL,
+    });
+
+    await expect(
+      executeClassificationQuery({
+        mode: 'content_ids',
+        organizationId: org.id,
+        content_ids: [eventId],
+        enabledClassifiers: ['mp-injection'],
+        embeddingModel: "x' OR '1'='1",
+      })
+    ).rejects.toThrow(/not a valid model identifier/);
+  });
+});

--- a/packages/server/src/__tests__/integration/events/embedding-model-swap-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/events/embedding-model-swap-e2e.test.ts
@@ -21,7 +21,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { searchContentByText } from '../../../utils/content-search';
 import type { Env } from '../../../index';
 import { insertEvent } from '../../../utils/insert-event';
-import { needsEmbeddingSql } from '../../../utils/embeddings';
+import { getConfiguredEmbeddingModel, needsEmbeddingSql } from '../../../utils/embeddings';
 import { completeEmbeddings } from '../../../worker-api';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
@@ -270,7 +270,7 @@ describe('embedding model swap E2E (Finding #3)', () => {
     // Flagged as needing embedding by the shared stale rule, so the backfill
     // produces a properly-stamped vector for it.
     const staleRows = (await sql.unsafe(
-      `SELECT e.id FROM events e WHERE e.id = ${Number(legacy.id)} AND ${needsEmbeddingSql('e')}`
+      `SELECT e.id FROM events e WHERE e.id = ${Number(legacy.id)} AND ${needsEmbeddingSql('e', getConfiguredEmbeddingModel())}`
     )) as Array<{ id: number }>;
     expect(staleRows.map((r) => Number(r.id))).toContain(legacy.id);
   });

--- a/packages/server/src/__tests__/unit/embeddings-model-guard.test.ts
+++ b/packages/server/src/__tests__/unit/embeddings-model-guard.test.ts
@@ -4,15 +4,17 @@
  * service reports a different model, generateEmbeddings must FAIL LOUD rather
  * than returning vectors that would be compared across incompatible spaces.
  *
- * Also covers configuredEmbeddingModelSqlLiteral's validation (it is inlined
- * into SQL, so an unsafe value must be rejected).
+ * Also covers resolveEmbeddingModel's validation of the CONFIGURED model (it is
+ * inlined into SQL via embeddingModelSqlLiteral, so an unsafe value must be
+ * rejected).
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import {
-  configuredEmbeddingModelSqlLiteral,
+  embeddingModelSqlLiteral,
   generateEmbeddings,
   getConfiguredEmbeddingModel,
+  resolveEmbeddingModel,
 } from '../../utils/embeddings';
 
 // biome-ignore lint/suspicious/noExplicitAny: minimal Env stub for the util
@@ -51,7 +53,7 @@ describe('server generateEmbeddings model guard (Finding #3)', () => {
   it('rejects a service model that differs from the configured model', async () => {
     stubFetch({ model: 'some-other-model-v2', dimensions: 768, embeddings: [vec768()] });
     await expect(generateEmbeddings(['hi'], ENV)).rejects.toThrow(
-      /returned model 'some-other-model-v2' but this deployment is configured/
+      /returned model 'some-other-model-v2' but 'Xenova\/bge-base-en-v1\.5' was requested/
     );
   });
 
@@ -69,14 +71,16 @@ describe('server generateEmbeddings model guard (Finding #3)', () => {
   });
 });
 
-describe('configuredEmbeddingModelSqlLiteral', () => {
-  it('quotes a valid model name', () => {
+describe('configured-model SQL literal', () => {
+  it('quotes a valid configured model name', () => {
     process.env.EMBEDDINGS_MODEL = 'Xenova/bge-base-en-v1.5';
-    expect(configuredEmbeddingModelSqlLiteral()).toBe("'Xenova/bge-base-en-v1.5'");
+    expect(embeddingModelSqlLiteral(getConfiguredEmbeddingModel())).toBe(
+      "'Xenova/bge-base-en-v1.5'"
+    );
   });
 
-  it('rejects an unsafe model identifier (SQL-injection / whitespace)', () => {
+  it('rejects an unsafe configured model (SQL-injection / whitespace)', () => {
     process.env.EMBEDDINGS_MODEL = "x'; DROP TABLE event_embeddings; --";
-    expect(() => configuredEmbeddingModelSqlLiteral()).toThrow(/not a valid model identifier/);
+    expect(() => resolveEmbeddingModel()).toThrow(/not a valid model identifier/);
   });
 });

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -950,9 +950,12 @@ export default async (_ctx, client) => {
 			"await client.classifiers.create({ slug: 'sentiment', name: 'Sentiment', attribute_key: 'sentiment', attribute_values: { positive: { description: 'Positive tone', examples: ['Great work!'] } } });",
 	},
 	"classifiers.generateEmbeddings": {
-		summary: "Generate embeddings for attribute values (cost-heavy).",
+		summary:
+			"Generate embeddings for attribute values (cost-heavy). `embedding_model` picks the vector space; it defaults to the deployment's configured model, and must match the model the events were embedded under or `apply` will match nothing.",
 		access: "admin",
 		cost: "expensive",
+		signature:
+			"classifiers.generateEmbeddings(input: { classifier_id: number; force_regenerate?: boolean; embedding_model?: string }): Promise<unknown>",
 	},
 	"classifiers.delete": {
 		summary: "Delete a classifier.",
@@ -970,11 +973,11 @@ export default async (_ctx, client) => {
 	},
 	"classifiers.apply": {
 		summary:
-			"Run a classifier's embedding match over content ids you supply and STORE the labels. Needs no entity link, so this is how org-scoped feed content gets classified. Returns `classified` plus a `skipped` breakdown (not_in_organization | superseded | not_embedded | below_threshold) — a zero result always says why. Only matches org-level classifiers (those created without `behavior_id`).",
+			"Run a classifier's embedding match over content ids you supply and STORE the labels. Needs no entity link, so this is how org-scoped feed content gets classified. Returns `classified` plus a `skipped` breakdown (not_in_organization | superseded | not_embedded | below_threshold) — a zero result always says why. Only matches org-level classifiers (those created without `behavior_id`). `embedding_model` selects the vector space for BOTH the labels and the events; ids with no vector in that model are reported `not_embedded`.",
 		access: "admin",
 		cost: "expensive",
 		signature:
-			"classifiers.apply(input: { classifier_slug: string; content_ids: number[] }): Promise<unknown>",
+			"classifiers.apply(input: { classifier_slug: string; content_ids: number[]; embedding_model?: string }): Promise<unknown>",
 		example:
 			"await client.classifiers.apply({ classifier_slug: 'sentiment', content_ids: [101, 102, 103] });",
 	},

--- a/packages/server/src/sandbox/namespaces/classifiers.ts
+++ b/packages/server/src/sandbox/namespaces/classifiers.ts
@@ -11,6 +11,8 @@ import type { ToolContext } from "../../tools/registry";
 import { createActionCaller } from "./action-call";
 
 export interface ClassifierCreateInput {
+	/** Model to embed the label vectors under; defaults to the configured one. */
+	embedding_model?: string;
 	slug: string;
 	name: string;
 	description?: string;
@@ -57,6 +59,13 @@ export interface ClassifierClassifyInput {
 export interface ClassifierApplyInput {
 	classifier_slug: string;
 	content_ids: number[];
+	/**
+	 * Vector space to match in; defaults to the deployment's configured model.
+	 * The classifier's label vectors must already live in this model too (embed
+	 * them with `generateEmbeddings({ embedding_model })`), and so must the
+	 * events — ids without a vector in this model come back `not_embedded`.
+	 */
+	embedding_model?: string;
 }
 
 export interface ClassifiersNamespace {
@@ -66,6 +75,8 @@ export interface ClassifiersNamespace {
 	generateEmbeddings(input: {
 		classifier_id: number;
 		force_regenerate?: boolean;
+		/** Model to embed the label vectors under; defaults to the configured one. */
+		embedding_model?: string;
 	}): Promise<unknown>;
 	delete(input: { classifier_id: number }): Promise<unknown>;
 	classify(input: ClassifierClassifyInput): Promise<unknown>;

--- a/packages/server/src/scheduled/classification-reconciliation.ts
+++ b/packages/server/src/scheduled/classification-reconciliation.ts
@@ -18,7 +18,7 @@ import { getDb, pgTextArray } from '../db/client';
 import type { Env } from '../index';
 import { executeClassificationQuery } from '../utils/classification-query';
 import { entityLinkMatchSql } from '../utils/content-search';
-import { configuredEmbeddingModelSqlLiteral } from '../utils/embeddings';
+import { embeddingModelSqlLiteral, getConfiguredEmbeddingModel } from '../utils/embeddings';
 import logger from '../utils/logger';
 
 const MAX_ENTITIES_PER_RUN = 10; // Process up to 10 entities per cron run
@@ -148,7 +148,7 @@ export async function runClassificationReconciliation(_env: Env): Promise<{
             WHERE ${sql.unsafe(entityLinkMatchSql(`${Number(entityId)}::bigint`, 'ev'))}
               AND EXISTS (SELECT 1 FROM event_embeddings emb
                 WHERE emb.event_id = ev.id AND emb.chunk_index = 0
-                  AND emb.embedding_model = ${sql.unsafe(configuredEmbeddingModelSqlLiteral())})
+                  AND emb.embedding_model = ${sql.unsafe(embeddingModelSqlLiteral(getConfiguredEmbeddingModel()))})
             GROUP BY ev.id
           ) per_event
           WHERE per_event.classified_count < ${expectedCount}

--- a/packages/server/src/scheduled/trigger-embed-backfill.ts
+++ b/packages/server/src/scheduled/trigger-embed-backfill.ts
@@ -7,7 +7,7 @@
  */
 
 import { getDb } from '../db/client';
-import { needsEmbeddingSql } from '../utils/embeddings';
+import { getConfiguredEmbeddingModel, needsEmbeddingSql } from '../utils/embeddings';
 import type { Env } from '../index';
 import logger from '../utils/logger';
 import { isQueryCanceled, isUniqueViolation } from '../utils/pg-errors';
@@ -74,8 +74,11 @@ interface OrgBatch {
 // the worker fetch. Correlated anti-join lets the planner drive off `events`
 // (and the partial index) instead of hash-joining the whole event_embeddings
 // table. (The contract release adds the long-content "needs tail chunks" arm.)
+// The deployment's configured model, not a caller override: this is the
+// background job that fills the default space, and the run it creates is
+// drained by a worker reading the same env var.
 function needsEmbeddingPredicate(): string {
-  return needsEmbeddingSql('e');
+  return needsEmbeddingSql('e', getConfiguredEmbeddingModel());
 }
 
 // current_event_records masks superseded rows with this anti-join. We query the

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -28,7 +28,7 @@ import type { Env } from '../../index';
 import { executeClassificationQuery } from '../../utils/classification-query';
 import {
   generateEmbeddings as generateEmbeddingsViaService,
-  getConfiguredEmbeddingModel,
+  resolveEmbeddingModel,
   isValidEmbedding,
 } from '../../utils/embeddings';
 import logger from '../../utils/logger';
@@ -72,7 +72,7 @@ async function hydrateAttributeEmbeddings(
     }
   >,
   env: Env,
-  options: { forceRegenerate?: boolean } = {}
+  options: { forceRegenerate?: boolean; embeddingModel?: string } = {}
 ): Promise<{
   attributeValues: Record<
     string,
@@ -85,7 +85,11 @@ async function hydrateAttributeEmbeddings(
   >;
   generatedCount: number;
 }> {
-  const configuredModel = getConfiguredEmbeddingModel();
+  // The model these label vectors will live in. Defaults to the deployment's
+  // configured model; an override embeds the labels into whichever space the
+  // caller intends to classify in, which is the only way label and event
+  // vectors can be made to agree under a non-default model.
+  const targetModel = resolveEmbeddingModel(options.embeddingModel);
   const updated: Record<
     string,
     {
@@ -112,7 +116,7 @@ async function hydrateAttributeEmbeddings(
     // survive to be read here: the backfill migration stamps all 208 of them at
     // deploy, deriving the value from event_embeddings.
     const isForeignModel =
-      config.embedding_model != null && config.embedding_model !== configuredModel;
+      config.embedding_model != null && config.embedding_model !== targetModel;
     const reusable = hasEmbedding && !isForeignModel;
     if (!reusable || options.forceRegenerate) {
       valuesToEmbed.push(value);
@@ -123,17 +127,17 @@ async function hydrateAttributeEmbeddings(
       // Vector and stamp move together — never carry a vector past its stamp,
       // and never leave a stamp describing a vector that is no longer there.
       embedding: reusable ? (config.embedding as number[]) : undefined,
-      embedding_model: reusable ? configuredModel : undefined,
+      embedding_model: reusable ? targetModel : undefined,
     };
   }
 
   if (valuesToEmbed.length > 0) {
-    const embeddings = await generateEmbeddingsViaService(valuesToEmbed, env);
+    const embeddings = await generateEmbeddingsViaService(valuesToEmbed, env, targetModel);
     valuesToEmbed.forEach((value, index) => {
       updated[value] = {
         ...updated[value],
         embedding: embeddings[index],
-        embedding_model: configuredModel,
+        embedding_model: targetModel,
       };
     });
   }
@@ -295,7 +299,8 @@ async function handleCreate(
   // then one insert carrying identity + config.
   const { attributeValues: withEmbeddings, generatedCount } = await hydrateAttributeEmbeddings(
     args.attribute_values,
-    env
+    env,
+    { embeddingModel: args.embedding_model }
   );
 
   const classifierResult = await sql`
@@ -428,7 +433,7 @@ async function handleGenerateEmbeddings(
   const { attributeValues: updatedValues, generatedCount } = await hydrateAttributeEmbeddings(
     attributeValues,
     env,
-    { forceRegenerate: args.force_regenerate }
+    { forceRegenerate: args.force_regenerate, embeddingModel: args.embedding_model }
   );
 
   // Config + embeddings live on the single classify_facet row now.
@@ -663,6 +668,12 @@ async function runApply(
   // Dedupe so the counts below describe distinct events, not request repeats.
   const requestedIds = [...new Set(args.content_ids)];
 
+  // Resolved once and used for BOTH the has_embedding probe and the engine
+  // call. If the probe checked one model and the engine another, an event
+  // would pass the probe and then be dropped by the engine's join — landing in
+  // `below_threshold`, which would be a lie about a row that was never scored.
+  const embeddingModel = resolveEmbeddingModel(args.embedding_model);
+
   // Mirrors the engine's classifier-template lookup exactly (org + active +
   // watcher_id IS NULL). Diverging here would report a watcher-owned classifier
   // as "found" and then blame its zero results on min_similarity.
@@ -700,7 +711,8 @@ async function runApply(
   //     opposite error: the event looks reachable and gets blamed on
   //     `below_threshold`.
   //   - chunk/model: the engine joins the representative vector (chunk 0 AND the
-  //     configured model), so a stale-model vector is not an embedding to it.
+  //     SAME model resolved above), so a stale-model vector is not an embedding
+  //     to it.
   //     Ignoring the model stamp reports `below_threshold` for a row that the
   //     engine never scored at all.
   //   - organization: the engine is org-scoped, as is this.
@@ -711,7 +723,7 @@ async function runApply(
              SELECT 1 FROM event_embeddings emb
              WHERE emb.event_id = e.id
                AND emb.chunk_index = 0
-               AND emb.embedding_model = ${getConfiguredEmbeddingModel()}
+               AND emb.embedding_model = ${embeddingModel}
            ) AS has_embedding
     FROM events e
     WHERE e.organization_id = ${ctx.organizationId}
@@ -730,6 +742,7 @@ async function runApply(
       organizationId: ctx.organizationId,
       content_ids: embeddedIds,
       enabledClassifiers: [args.classifier_slug],
+      embeddingModel,
     });
     classifiedIds = [...new Set(results.map((r) => Number(r.content_id)))];
   }

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -16,7 +16,7 @@ import type { Env } from '../index';
 import { autoLinkEvent } from '../utils/auto-linker';
 import { ToolUserError } from '../utils/errors';
 import { validateSaveContentSemanticType } from '../utils/event-kind-validation';
-import { needsEmbeddingSql } from '../utils/embeddings';
+import { getConfiguredEmbeddingModel, needsEmbeddingSql } from '../utils/embeddings';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
 import {
@@ -496,7 +496,7 @@ async function saveContentImpl(
   // row is already searchable — reporting a hardcoded 'pending' would be wrong.
   const savedId = Number(row.id);
   const [readiness] = await sql`
-    SELECT ${sql.unsafe(needsEmbeddingSql('e'))} AS needs_embedding
+    SELECT ${sql.unsafe(needsEmbeddingSql('e', getConfiguredEmbeddingModel()))} AS needs_embedding
     FROM events e WHERE e.id = ${savedId}
   `;
   const searchable = readiness ? !readiness.needs_embedding : false;

--- a/packages/server/src/utils/__tests__/embedding-model-resolution.test.ts
+++ b/packages/server/src/utils/__tests__/embedding-model-resolution.test.ts
@@ -1,0 +1,194 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import {
+  DEFAULT_EMBEDDING_MODEL,
+  embeddingModelSqlLiteral,
+  generateEmbeddings,
+  getConfiguredEmbeddingModel,
+  needsEmbeddingSql,
+  resolveEmbeddingModel,
+} from '../embeddings';
+
+const OTHER_MODEL = 'Xenova/multilingual-e5-base';
+
+describe('resolveEmbeddingModel', () => {
+  const original = process.env.EMBEDDINGS_MODEL;
+  afterEach(() => {
+    if (original === undefined) delete process.env.EMBEDDINGS_MODEL;
+    else process.env.EMBEDDINGS_MODEL = original;
+  });
+
+  it('falls back to the configured model when nothing is requested', () => {
+    delete process.env.EMBEDDINGS_MODEL;
+    expect(resolveEmbeddingModel()).toBe(DEFAULT_EMBEDDING_MODEL);
+    expect(resolveEmbeddingModel(undefined)).toBe(DEFAULT_EMBEDDING_MODEL);
+    expect(resolveEmbeddingModel(null)).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+
+  // A caller threading an optional field through can easily hand us '' — that is
+  // "not specified", not a model named empty string, which would otherwise
+  // produce `embedding_model = ''` and match no rows at all.
+  it('treats blank and whitespace-only as unspecified', () => {
+    delete process.env.EMBEDDINGS_MODEL;
+    expect(resolveEmbeddingModel('')).toBe(DEFAULT_EMBEDDING_MODEL);
+    expect(resolveEmbeddingModel('   ')).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+
+  it('honours an explicit override', () => {
+    expect(resolveEmbeddingModel(OTHER_MODEL)).toBe(OTHER_MODEL);
+  });
+
+  it('an override wins over the configured model', () => {
+    process.env.EMBEDDINGS_MODEL = 'Xenova/some-other-thing';
+    expect(resolveEmbeddingModel(OTHER_MODEL)).toBe(OTHER_MODEL);
+  });
+
+  // The resolved value is inlined into SQL as a literal, so validation is not
+  // cosmetic — it is the only thing between a caller-supplied string and the
+  // query text.
+  it.each([
+    ["x' OR '1'='1", 'quote break-out'],
+    ['model; DROP TABLE events', 'statement separator'],
+    ['-- comment', 'leading dash'],
+    ['a'.repeat(200), 'over length'],
+  ])('rejects %s (%s)', (bad) => {
+    expect(() => resolveEmbeddingModel(bad)).toThrow(/not a valid model identifier/);
+  });
+});
+
+describe('embeddingModelSqlLiteral', () => {
+  it('quotes a valid model', () => {
+    expect(embeddingModelSqlLiteral(OTHER_MODEL)).toBe(`'${OTHER_MODEL}'`);
+  });
+
+  // Re-validates rather than trusting its caller: this is the last point before
+  // the value becomes query text.
+  it('rejects an unsafe model even when handed one directly', () => {
+    expect(() => embeddingModelSqlLiteral("x' OR '1'='1")).toThrow(/not a valid model identifier/);
+  });
+});
+
+describe('needsEmbeddingSql', () => {
+  it('scopes the staleness predicate to the model it is given', () => {
+    const sql = needsEmbeddingSql('e', OTHER_MODEL);
+    expect(sql).toContain(`emb.embedding_model = '${OTHER_MODEL}'`);
+    expect(sql).toContain('emb.event_id = e.id');
+    expect(sql).toContain('emb.chunk_index = 0');
+  });
+
+  // Discovery and the worker fetch must fill the SAME space. Different models
+  // produce different predicates — if they ever passed different values, the
+  // backfill would hand the worker events it considers already done, forever.
+  it('produces a different predicate per model', () => {
+    expect(needsEmbeddingSql('e', OTHER_MODEL)).not.toBe(
+      needsEmbeddingSql('e', getConfiguredEmbeddingModel())
+    );
+  });
+});
+
+/**
+ * Stand-in for the embeddings service that reports whichever model it is told to
+ * report, so the guard can be exercised in both directions.
+ */
+async function withService<T>(
+  reportModel: (requested: string | undefined) => string,
+  run: (env: Env) => Promise<T>
+): Promise<T> {
+  const seen: Array<Record<string, unknown>> = [];
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => {
+      body += c;
+    });
+    req.on('end', () => {
+      const payload = JSON.parse(body || '{}') as { texts?: string[]; model?: string };
+      seen.push(payload);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          embeddings: (payload.texts ?? []).map(() => new Array<number>(768).fill(0.1)),
+          dimensions: 768,
+          model: reportModel(payload.model),
+        })
+      );
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  try {
+    return await run({
+      EMBEDDINGS_SERVICE_URL: `http://127.0.0.1:${port}`,
+      __seen: seen,
+    } as unknown as Env);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe('generateEmbeddings model negotiation', () => {
+  it('sends the requested model to the service', async () => {
+    await withService(
+      (requested) => requested ?? DEFAULT_EMBEDDING_MODEL,
+      async (env) => {
+        await generateEmbeddings(['hello'], env, OTHER_MODEL);
+        const seen = (env as unknown as { __seen: Array<{ model?: string }> }).__seen;
+        expect(seen).toHaveLength(1);
+        expect(seen[0].model).toBe(OTHER_MODEL);
+      }
+    );
+  });
+
+  it('sends the configured model when none is requested', async () => {
+    await withService(
+      (requested) => requested ?? DEFAULT_EMBEDDING_MODEL,
+      async (env) => {
+        await generateEmbeddings(['hello'], env);
+        const seen = (env as unknown as { __seen: Array<{ model?: string }> }).__seen;
+        expect(seen[0].model).toBe(getConfiguredEmbeddingModel());
+      }
+    );
+  });
+
+  /**
+   * The case this guard exists for. The LOCAL backend pins one model per process
+   * and ignores `payload.model` entirely, so asking it for a model it does not
+   * serve gets you default-model vectors with a 200. Without this check the
+   * caller would stamp those vectors as the requested model and poison the very
+   * table the stamp exists to keep honest — a silent write, not a failed read.
+   */
+  it('throws when the service serves a model other than the one requested', async () => {
+    await withService(
+      () => DEFAULT_EMBEDDING_MODEL,
+      async (env) => {
+        await expect(generateEmbeddings(['hello'], env, OTHER_MODEL)).rejects.toThrow(
+          /returned model .* but .* was requested/
+        );
+      }
+    );
+  });
+
+  it('accepts a matching non-default model', async () => {
+    await withService(
+      () => OTHER_MODEL,
+      async (env) => {
+        const out = await generateEmbeddings(['hello'], env, OTHER_MODEL);
+        expect(out).toHaveLength(1);
+        expect(out[0]).toHaveLength(768);
+      }
+    );
+  });
+
+  it('rejects an invalid model before contacting the service', async () => {
+    await withService(
+      () => DEFAULT_EMBEDDING_MODEL,
+      async (env) => {
+        await expect(generateEmbeddings(['hello'], env, "x' OR '1'='1")).rejects.toThrow(
+          /not a valid model identifier/
+        );
+        expect((env as unknown as { __seen: unknown[] }).__seen).toHaveLength(0);
+      }
+    );
+  });
+});

--- a/packages/server/src/utils/classification-query.ts
+++ b/packages/server/src/utils/classification-query.ts
@@ -9,7 +9,7 @@
 
 import { type DbClient, getDb, parsePgNumberArray, pgTextArray } from '../db/client';
 import { entityLinkMatchSql } from './content-search';
-import { configuredEmbeddingModelSqlLiteral, getConfiguredEmbeddingModel } from './embeddings';
+import { embeddingModelSqlLiteral, resolveEmbeddingModel } from './embeddings';
 import logger from './logger';
 
 /**
@@ -113,6 +113,22 @@ interface ClassificationQueryOptions {
    * For mode='content_ids': Specific content IDs to classify
    */
   content_ids?: number[];
+
+  /**
+   * Embedding model to classify in. Defaults to the deployment's configured
+   * model. Scopes BOTH sides of every cosine comparison — the event vectors
+   * joined from `event_embeddings` and the label vectors read from
+   * `classify_facet.attribute_values` — so the two can never be drawn from
+   * different spaces.
+   *
+   * A model with no vectors yields no matches rather than an error: the event
+   * join finds nothing and the templates are all filtered out. That is the
+   * correct read of "this corpus is not embedded under that model", but it is
+   * indistinguishable from "nothing matched" at this layer, so agent-facing
+   * callers must report the emptiness themselves (see `manage_classifiers`'
+   * `not_embedded` skip reason).
+   */
+  embeddingModel?: string;
 }
 
 // ── Internal types for intermediate data ───────────────────────────────
@@ -176,7 +192,8 @@ interface ClassifierVersionLookup {
 
 async function fetchTargetContent(
   sql: DbClient,
-  options: ClassificationQueryOptions
+  options: ClassificationQueryOptions,
+  embeddingModel: string
 ): Promise<TargetContent[]> {
   const { mode, enabledClassifiers } = options;
 
@@ -196,8 +213,8 @@ async function fetchTargetContent(
   // current_event_records no longer carries an embedding (multi-vector). For
   // classification the representative chunk_index=0 vector (lead content) stands
   // in for "the event's embedding" — same semantics as the pre-chunking single
-  // vector. Scoped to the configured model so we never compare across spaces.
-  const embModel = configuredEmbeddingModelSqlLiteral();
+  // vector. Scoped to the requested model so we never compare across spaces.
+  const embModel = embeddingModelSqlLiteral(embeddingModel);
   const repEmbeddingJoins = `LEFT JOIN event_embeddings fe ON fe.event_id = f.id AND fe.chunk_index = 0 AND fe.embedding_model = ${embModel}
        LEFT JOIN event_embeddings pe ON pe.event_id = parent.id AND pe.chunk_index = 0 AND pe.embedding_model = ${embModel}`;
 
@@ -308,7 +325,8 @@ async function fetchClassifierTemplates(
   sql: DbClient,
   enabledClassifiers: string[],
   targetContent: TargetContent[],
-  organizationId: string
+  organizationId: string,
+  embeddingModel: string
 ): Promise<ClassifierTemplate[]> {
   if (targetContent.length === 0) return [];
 
@@ -341,7 +359,6 @@ async function fetchClassifierTemplates(
 
   // Expand attribute_values JSON into individual templates in TypeScript
   const templates: ClassifierTemplate[] = [];
-  const configuredModel = getConfiguredEmbeddingModel();
   let staleTemplates = 0;
 
   for (const row of rows) {
@@ -366,15 +383,19 @@ async function fetchClassifierTemplates(
       if (!embeddingArr) continue;
 
       // The event side of this comparison is model-scoped (fetchTargetContent
-      // joins event_embeddings ON embedding_model = the configured model), so
-      // the label side must be too. Cosine across two different 768-dim spaces
-      // returns a confident-looking number instead of an error, which is the
-      // whole hazard: without this guard an EMBEDDINGS_MODEL swap keeps
+      // joins event_embeddings ON embedding_model = the SAME `embeddingModel`
+      // passed here), so the label side must be too. Cosine across two different
+      // 768-dim spaces returns a confident-looking number instead of an error,
+      // which is the whole hazard: without this guard a model swap keeps
       // classifying and silently assigns wrong labels.
+      //
+      // Both sides take the model from one resolved value in
+      // executeClassificationQuery — deliberately not re-read from config here,
+      // because two independent reads is exactly how the two sides drift apart.
       //
       // Dropped rather than compared, and counted so the operator sees a real
       // reason instead of a bare "No classifier templates found".
-      if (attrObj.embedding_model !== configuredModel) {
+      if (attrObj.embedding_model !== embeddingModel) {
         staleTemplates++;
         continue;
       }
@@ -397,11 +418,11 @@ async function fetchClassifierTemplates(
       {
         staleTemplates,
         usableTemplates: templates.length,
-        configuredModel,
+        embeddingModel,
         classifiers: enabledClassifiers,
       },
       '[Classification Query] Dropped label vectors embedded by a different model — ' +
-        'run manage_classifiers generate_embeddings to re-embed them under the configured model'
+        'run manage_classifiers generate_embeddings to re-embed them under this model'
     );
   }
 
@@ -657,13 +678,18 @@ export async function executeClassificationQuery(
     return [];
   }
 
+  // Resolved ONCE and passed to both fetches. Event vectors and label vectors
+  // are the two sides of every cosine below; resolving the model separately per
+  // side is how they would come to disagree.
+  const embeddingModel = resolveEmbeddingModel(options.embeddingModel);
+
   try {
     const sql = getDb();
 
     // Step 1: Fetch target content with embeddings
-    const targetContent = await fetchTargetContent(sql, options);
+    const targetContent = await fetchTargetContent(sql, options, embeddingModel);
     if (targetContent.length === 0) {
-      logger.info({ mode }, '[Classification Query] No target content to classify');
+      logger.info({ mode, embeddingModel }, '[Classification Query] No target content to classify');
       return [];
     }
 
@@ -672,7 +698,8 @@ export async function executeClassificationQuery(
       sql,
       enabledClassifiers,
       targetContent,
-      options.organizationId
+      options.organizationId,
+      embeddingModel
     );
     if (templates.length === 0) {
       logger.info({ mode }, '[Classification Query] No classifier templates found');

--- a/packages/server/src/utils/content-search/search-path.ts
+++ b/packages/server/src/utils/content-search/search-path.ts
@@ -6,7 +6,7 @@ import type { Env } from '../../index';
 import { type DbClient, pgTextArray } from '../../db/client';
 import { buildConnectionFilter, buildFeedFilter, buildOrderByClause, buildRunFilter } from '../content-query-filters';
 import { parseDateAlias, toEndOfDay } from '../date-aliases';
-import { configuredEmbeddingModelSqlLiteral, generateEmbeddings } from '../embeddings';
+import { embeddingModelSqlLiteral, generateEmbeddings, resolveEmbeddingModel } from '../embeddings';
 import { toVectorLiteral } from '../entity-management';
 import logger from '../logger';
 import { validateNumericId } from '../sql-validation';
@@ -49,12 +49,17 @@ export async function searchContentBySingleQuery(
   const fetchLimit = useDateFeed ? limit + 1 : limit;
   const trimmedQuery = queryText.trim();
 
+  // One resolution for both the query vector and the stored vectors it is ranked
+  // against — see `modelScopeFor` below. Resolving per side is how a query
+  // embedded by one model comes to be compared against another's rows.
+  const embeddingModel = resolveEmbeddingModel();
+
   let queryEmbedding: number[] | null = options.query_embedding?.length
     ? options.query_embedding
     : null;
   if (!queryEmbedding && env?.EMBEDDINGS_SERVICE_URL) {
     try {
-      const embeddings = await generateEmbeddings([trimmedQuery], env);
+      const embeddings = await generateEmbeddings([trimmedQuery], env, embeddingModel);
       queryEmbedding = embeddings[0] ?? null;
     } catch (err) {
       logger.warn(
@@ -187,14 +192,14 @@ export async function searchContentBySingleQuery(
   const vecParam = vectorParamIdx ? `$${vectorParamIdx}::vector` : 'NULL::vector';
   const minSimilarityParam = `$${minSimilarityParamIdx}::numeric`;
   // Vector-space integrity: only compare against rows stamped with the EXACT
-  // model this deployment is configured for. A NULL stamp (legacy row written
-  // before stamping) is NOT comparable — its true model is unknown, so comparing
-  // it against the configured query vector could mix incompatible spaces. Such
+  // model the query vector above was produced under. A NULL stamp (legacy row
+  // written before stamping) is NOT comparable — its true model is unknown, so
+  // comparing it against the query vector could mix incompatible spaces. Such
   // rows are excluded from vector ranking until the backfill restamps them (see
-  // trigger-embed-backfill, which treats NULL as stale). The model is server
-  // config, inlined as a validated literal (`<alias>` substituted per CTE).
-  const configuredModelLiteral = configuredEmbeddingModelSqlLiteral();
-  const modelScopeFor = (alias: string) => `${alias}.embedding_model = ${configuredModelLiteral}`;
+  // trigger-embed-backfill, which treats NULL as stale). Inlined as a validated
+  // literal (`<alias>` substituted per CTE).
+  const modelLiteral = embeddingModelSqlLiteral(embeddingModel);
+  const modelScopeFor = (alias: string) => `${alias}.embedding_model = ${modelLiteral}`;
   // Best-chunk-per-event similarity (multi-vector). current_event_records no
   // longer carries an embedding (an event has N chunk vectors, not one), so
   // vector scoring correlates into event_embeddings and takes the closest chunk
@@ -204,7 +209,7 @@ export async function searchContentBySingleQuery(
   // the single place the chunk→event collapse lives; both query paths use it.
   const bestChunkSimExpr = (alias: string) =>
     `(SELECT MAX(1 - (emb.embedding <=> ${vecParam})) FROM event_embeddings emb
-      WHERE emb.event_id = ${alias}.id AND emb.embedding_model = ${configuredModelLiteral})`;
+      WHERE emb.event_id = ${alias}.id AND emb.embedding_model = ${modelLiteral})`;
   const matchCondition = hasEmbedding
     ? `(${textMatchExpr} OR (${bestChunkSimExpr('f')}) >= ${minSimilarityParam})`
     : textMatchExpr;

--- a/packages/server/src/utils/embeddings.ts
+++ b/packages/server/src/utils/embeddings.ts
@@ -31,39 +31,64 @@ export function getConfiguredEmbeddingModel(): string {
 }
 
 /**
- * SQL-safe string literal for the configured model, for inlining into a query
- * builder where threading another bound parameter would be error-prone. The
- * value is server config (not user input); we still validate it against the
- * service's model-name allowlist and reject otherwise — fail closed rather than
- * risk injection.
+ * Resolve the embedding model an operation should read/write, given an optional
+ * caller-supplied override. Falls back to the deployment's configured model, so
+ * every existing call site keeps its current behaviour by passing nothing.
+ *
+ * A non-default model is only meaningful where vectors under it actually exist
+ * — `event_embeddings` is keyed `(event_id, embedding_model, chunk_index)`, so
+ * two models coexist in storage, but a model with no rows reads as "nothing is
+ * embedded" rather than as an error. Callers that expose this to an agent should
+ * surface that emptiness (see `manage_classifiers`' `not_embedded` skip reason)
+ * instead of reporting a silent zero-result.
+ *
+ * Validated here rather than at each call site: the override reaches SQL as an
+ * inlined literal via `embeddingModelSqlLiteral`, and one unvalidated path is
+ * all it takes.
  */
-export function configuredEmbeddingModelSqlLiteral(): string {
-  const model = getConfiguredEmbeddingModel();
+export function resolveEmbeddingModel(requested?: string | null): string {
+  const model = requested?.trim() || getConfiguredEmbeddingModel();
   if (!MODEL_NAME_PATTERN.test(model)) {
     throw new Error(
-      `EMBEDDINGS_MODEL '${model}' is not a valid model identifier (allowed: ${MODEL_NAME_PATTERN}).`
+      `Embedding model '${model}' is not a valid model identifier (allowed: ${MODEL_NAME_PATTERN}).`
     );
   }
-  return `'${model}'`;
+  return model;
 }
 
 /**
- * SQL predicate: does the event aliased `eventAlias` need (re)embedding under the
- * configured model? True when it has no representative (chunk 0) vector for this
- * model — covering "never embedded", a stale model, and a NULL stamp. Centralized
- * so the backfill discovery and the worker fetch can never disagree on what
- * "stale" means. Correlates on `eventAlias`.
+ * SQL-safe string literal for an embedding model, for inlining into a query
+ * builder where threading another bound parameter would be error-prone. Always
+ * route the value through `resolveEmbeddingModel` first — this re-validates
+ * rather than trusting the caller, because an unvalidated model string inlined
+ * here is a straight injection.
+ */
+export function embeddingModelSqlLiteral(model: string): string {
+  return `'${resolveEmbeddingModel(model)}'`;
+}
+
+/**
+ * SQL predicate: does the event aliased `eventAlias` need (re)embedding under
+ * `model`? True when it has no representative (chunk 0) vector for that model —
+ * covering "never embedded", a stale model, and a NULL stamp. Centralized so the
+ * backfill discovery and the worker fetch can never disagree on what "stale"
+ * means. Correlates on `eventAlias`.
+ *
+ * The model is an explicit argument, not a global read: discovery and the worker
+ * fetch MUST agree on which space they are filling, and defaulting it here would
+ * let those two sites silently diverge the moment one of them is given an
+ * override and the other is not.
  *
  * Expand phase: chunking is not enabled yet (one row per event), so this is the
  * chunk-0 existence check only. The CONTRACT release adds the "long content but
  * no tail chunks" arm once the worker actually produces tail chunks — adding it
  * now would re-queue long events forever (they'd never get a chunk >= 1).
  */
-export function needsEmbeddingSql(eventAlias: string): string {
-  const model = configuredEmbeddingModelSqlLiteral();
+export function needsEmbeddingSql(eventAlias: string, model: string): string {
+  const literal = embeddingModelSqlLiteral(model);
   const e = eventAlias;
   return `NOT EXISTS (SELECT 1 FROM event_embeddings emb
-    WHERE emb.event_id = ${e}.id AND emb.embedding_model = ${model} AND emb.chunk_index = 0)`;
+    WHERE emb.event_id = ${e}.id AND emb.embedding_model = ${literal} AND emb.chunk_index = 0)`;
 }
 
 const DEFAULT_TIMEOUT_MS = 30000;
@@ -125,12 +150,19 @@ export async function validateEmbeddingsService(env: Env): Promise<void> {
  *
  * @param texts - Array of texts to embed
  * @param env - Environment with embeddings service configuration
+ * @param model - Model to embed under; defaults to the deployment's configured model
  * @returns Array of 768-dimensional embedding vectors
  */
-export async function generateEmbeddings(texts: string[], env: Env): Promise<number[][]> {
+export async function generateEmbeddings(
+  texts: string[],
+  env: Env,
+  model?: string | null
+): Promise<number[][]> {
   if (texts.length === 0) {
     return [];
   }
+
+  const requestedModel = resolveEmbeddingModel(model);
 
   const url = resolveEmbeddingServiceUrl(env);
   const parsedTimeout = Number.parseInt(env.EMBEDDINGS_TIMEOUT_MS || '', 10);
@@ -150,7 +182,7 @@ export async function generateEmbeddings(texts: string[], env: Env): Promise<num
     const response = await fetch(`${url}/api/embeddings`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ texts }),
+      body: JSON.stringify({ texts, model: requestedModel }),
       signal: controller.signal,
     });
 
@@ -190,13 +222,20 @@ export async function generateEmbeddings(texts: string[], env: Env): Promise<num
     // stored rows MUST come from the same model those rows are scoped to. If the
     // service reports a different model, fail loud rather than silently
     // comparing across incompatible vector spaces.
+    //
+    // Checked against the REQUESTED model, not the configured one. A caller
+    // asking for a non-default model is the case this guard most needs to cover:
+    // the local backend pins one model per process and ignores an unsupported
+    // request, so without this the caller would silently get default-model
+    // vectors back and stamp them as the requested model — poisoning the very
+    // table the model stamp exists to keep clean.
     if (payload.model) {
-      const configuredModel = getConfiguredEmbeddingModel();
-      if (payload.model !== configuredModel) {
+      if (payload.model !== requestedModel) {
         throw new Error(
-          `Embeddings service returned model '${payload.model}' but this deployment is ` +
-            `configured for '${configuredModel}'. Refusing to compare across incompatible ` +
-            `vector spaces — align EMBEDDINGS_MODEL on the server and the embeddings service.`
+          `Embeddings service returned model '${payload.model}' but '${requestedModel}' was ` +
+            `requested. Refusing to compare across incompatible vector spaces — align ` +
+            `EMBEDDINGS_MODEL on the server and the embeddings service, or use a service ` +
+            `that can serve the requested model.`
         );
       }
       logger.debug({ model: payload.model }, '[Embeddings] Service model');

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -40,7 +40,7 @@ import {
 import { toSecretRefAuthData } from "../utils/auth-credential-secrets";
 import { autoLinkEvent } from "../utils/auto-linker";
 import { nextRunAt as nextRunAtFromCron } from "../utils/cron";
-import { needsEmbeddingSql } from "../utils/embeddings";
+import { getConfiguredEmbeddingModel, needsEmbeddingSql } from "../utils/embeddings";
 import { applyEventAttributions } from "../utils/entity-link-upsert";
 import { errorMessage } from "../utils/errors";
 import { validateConnectorEventSemanticType } from "../utils/event-kind-validation";
@@ -1550,7 +1550,7 @@ export async function fetchEventsForEmbedding(c: Context<{ Bindings: Env }>) {
 			`SELECT e.id, e.payload_text, e.title
        FROM events e
        WHERE e.id IN (${placeholders})
-         AND ${needsEmbeddingSql("e")}`,
+         AND ${needsEmbeddingSql("e", getConfiguredEmbeddingModel())}`,
 			safeIds
 		);
 


### PR DESCRIPTION
## Summary
- `event_embeddings` has been keyed `(event_id, embedding_model, chunk_index)` since June and **both write paths already take the model per row** — two models have always been able to coexist in storage. Nothing could ever *choose* one: every read resolved `getConfiguredEmbeddingModel()` independently, so the model was a deployment-wide constant.
- Threads the model through as an explicit parameter **defaulting to the configured one**, so every existing caller is unchanged. Agent-facing surface is `manage_classifiers`' new `embedding_model` on create/update/generate_embeddings/apply.
- Motivation is measured, not speculative: the only alternative — an `EMBEDDINGS_MODEL` swap — is an outage, not a degradation. Search and classification both scope reads to the configured model, so on flip they return nothing until each row is re-embedded, and the embed dispatcher's ceiling (`*/5` cron × 1 org/tick × 100 events = **28,800/day**, against **599,765** live embeddable events) puts recovery at **~21 days**.

## What changed

| | before | after |
|---|---|---|
| `configuredEmbeddingModelSqlLiteral()` | reads the global | `embeddingModelSqlLiteral(model)` |
| `needsEmbeddingSql(alias)` | reads the global | `needsEmbeddingSql(alias, model)` — **required**, not defaulted |
| `generateEmbeddings(texts, env)` | guard vs *configured* | `(texts, env, model?)`, guard vs **requested** |
| — | — | `resolveEmbeddingModel(requested?)` validates + falls back |

Two places deliberately take the model as a **required** argument rather than defaulting it:

- `needsEmbeddingSql` — backfill discovery and the worker fetch must fill the *same* space. A default is precisely how those two would silently diverge and hand the worker events it already considers done.
- `fetchClassifierTemplates` — `executeClassificationQuery` resolves **once** and passes the same value to the event join and the label filter. Those are the two sides of every cosine; resolving per side is how they come to disagree, and cosine across two 768-dim spaces returns a confident number rather than an error.

In `apply`, the `has_embedding` probe and the engine share one resolved value. Drift there doesn't just miss — it reports `below_threshold` for a row the engine never scored, which is a **false reason**, not a shortfall.

The `generateEmbeddings` guard now checks the **requested** model. This matters because the local backend pins one model per process and ignores `payload.model` entirely: without it, a caller asking for another model gets default-model vectors back with a 200 and stamps them under the requested name — a silent write into the very table the stamp exists to keep honest.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: **1074 passed (91 files)** across `integration/classifiers`, `integration/events`, `utils/__tests__`; `bun test embeddings-model-guard` 5/5
- [x] New: 6 integration + 17 unit tests
- [ ] Bug fix red→green — n/a, this is a capability, so **mutation testing** stands in (below)

### Mutation testing

Tests here assert the *non-default* model is honoured, not merely that the default still works — a threading change fails silently in the direction default-path tests cannot see. Three mutations, each reintroducing a plausible missed call site:

| mutation | result |
|---|---|
| event side ignores the parameter, re-reads the global | **2 tests red** |
| label side ignores the parameter, re-reads the global | **1 test red** |
| `apply` probe drifts from the engine | **1 test red** |

The third produced exactly the failure predicted above — `not_embedded: 0`, meaning the event passed the probe and would have been blamed on `below_threshold`:

```
× reports not_embedded (never below_threshold) for an event absent from the requested model
  → expected +0 to be 1
```

## Notes
- **No behaviour change without an explicit override.** Prod remains `local` backend + `Xenova/bge-base-en-v1.5` (helm sets neither var; the DB agrees — 1 distinct model across 2,060,979 rows).
- **This PR does not yet make a non-default model usable end to end.** The local embeddings backend caches one pipeline per process and ignores `payload.model`, so requesting another model fails closed at the new guard with a clear message. A keyed pipeline cache in `packages/embeddings` is the follow-up; splitting it keeps this diff (which carries all the cross-space risk) reviewable on its own.
- Search keeps a single resolution feeding both the query vector and the row scope, but takes **no** override — exposing one is a product-surface decision and nothing sets it yet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional embedding model selection for classifier creation, embedding generation, and application.
  * Classification now ensures event and classifier vectors use the same selected model.
  * Added clearer results when content has not been embedded for the selected model.
  * Invalid or incompatible embedding models are rejected with validation feedback.

* **Bug Fixes**
  * Improved embedding freshness checks across search, indexing, backfill, and classification workflows.
  * Prevented comparisons between vectors generated by different models.

* **Tests**
  * Added comprehensive coverage for model selection, validation, compatibility, and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->