### PR TITLE
fix(mac-release): stamp CFBundleVersion so Sparkle stops re-staging every release

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -319,6 +319,16 @@ jobs:
       # Sparkle helpers" step after archive re-signs each helper leaf-first
       # with --options runtime + --timestamp, then re-signs the umbrella
       # Owletto.app so the new helper signatures are sealed into the parent.
+      #
+      # CURRENT_PROJECT_VERSION must be overridden alongside MARKETING_VERSION.
+      # Info.plist maps CFBundleVersion to $(CURRENT_PROJECT_VERSION), whose
+      # pbxproj value is the placeholder `1`, while the appcast publisher below
+      # passes `--build "$VERSION"` into <sparkle:version>. Sparkle compares
+      # <sparkle:version> against the INSTALLED app's CFBundleVersion, so
+      # shipping `1` made every release look permanently newer than itself:
+      # installed apps re-downloaded and re-staged the same DMG on every check
+      # forever (observed on a Mac holding both 14.5.0 and 14.8.0 staged).
+      # MARKETING_VERSION alone only fixes the human-readable string.
       - name: Archive (signed)
         if: steps.mode.outputs.signed == 'true'
         env:
@@ -335,6 +345,7 @@ jobs:
             "DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }}"
             ENABLE_HARDENED_RUNTIME=YES
             "MARKETING_VERSION=${{ steps.v.outputs.version }}"
+            "CURRENT_PROJECT_VERSION=${{ steps.v.outputs.version }}"
           )
           if [ "${{ steps.profile.outputs.installed }}" = "true" ]; then
             ARGS+=("PROVISIONING_PROFILE_SPECIFIER=$PROFILE_NAME")
@@ -390,7 +401,8 @@ jobs:
             -project packages/owletto/apps/mac/Owletto.xcodeproj -scheme Owletto -configuration Release \
             -archivePath "$RUNNER_TEMP/Owletto.xcarchive" archive \
             CODE_SIGNING_ALLOWED=NO \
-            MARKETING_VERSION="${{ steps.v.outputs.version }}"
+            MARKETING_VERSION="${{ steps.v.outputs.version }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.v.outputs.version }}"
           # arm64 apps must carry at least an ad-hoc signature to launch at all;
           # this also lets users do right-click → Open past "unidentified
           # developer". A real Developer ID + notarization removes that prompt.

--- a/scripts/build-owletto-mac.sh
+++ b/scripts/build-owletto-mac.sh
@@ -7,6 +7,7 @@
 #   make owletto-mac                  # build → /tmp/owletto-build/.../Owletto.app
 #   make owletto-mac INSTALL=1        # also replace /Applications/Owletto.app
 #   make owletto-mac INSTALL=1 OPEN=1 # install and launch
+#   VERSION=14.8.1-dev make owletto-mac   # stamp a specific version
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -15,6 +16,20 @@ MAC="$ROOT/packages/owletto/apps/mac"
 DERIVED="${DERIVED:-/tmp/owletto-build}"
 TEAM_ID="CCV9Q352W3"
 SIGN_ID="Developer ID Application"
+# Stamp a version instead of inheriting the pbxproj placeholders
+# (MARKETING_VERSION=0.1.0, CURRENT_PROJECT_VERSION=1). Two failures come from
+# leaving them alone, and this script is the Release+Developer ID+/Applications
+# path, so the DEBUG guard in OwlettoUpdater does not apply:
+#   1. The app reports app_version 0.1.0 to the server, which is
+#      indistinguishable from a real release and hid for weeks that two paired
+#      Macs were running local builds.
+#   2. CFBundleVersion=1 is below every appcast <sparkle:version>, so Sparkle
+#      treats a release as newer forever and silently replaces the build you
+#      deliberately made — re-downloading and re-staging on every check.
+# The default sorts above any real release so a dev build is never clobbered.
+# Override for a build meant to be superseded by a later release:
+#   VERSION=14.8.1-dev make owletto-mac
+VERSION="${VERSION:-99.0.0-dev}"
 
 die() { echo "error: $*" >&2; exit 1; }
 
@@ -32,7 +47,7 @@ EOF
 )"
 fi
 
-echo ">> Building Owletto (Release, $SIGN_ID)..."
+echo ">> Building Owletto (Release, $SIGN_ID, version $VERSION)..."
 (
   cd "$MAC"
   xcodebuild -scheme Owletto -configuration Release \
@@ -41,6 +56,8 @@ echo ">> Building Owletto (Release, $SIGN_ID)..."
     CODE_SIGN_IDENTITY="$SIGN_ID" \
     DEVELOPMENT_TEAM="$TEAM_ID" \
     ENABLE_HARDENED_RUNTIME=YES \
+    MARKETING_VERSION="$VERSION" \
+    CURRENT_PROJECT_VERSION="$VERSION" \
     build
 )
 


### PR DESCRIPTION
## Summary
- `Info.plist` maps `CFBundleVersion` to `$(CURRENT_PROJECT_VERSION)`, whose pbxproj value is the placeholder `1`, and every `xcodebuild` invocation overrode only `MARKETING_VERSION`. The appcast publisher passes `--build "$VERSION"` into `<sparkle:version>`, and **Sparkle compares that against the installed app's `CFBundleVersion`** — so `14.8.0 > 1` held even for an app that already *was* 14.8.0. Every install re-downloaded and re-staged the same DMG on every check, forever.
- Stamps `CURRENT_PROJECT_VERSION` alongside `MARKETING_VERSION` at **all three** xcodebuild sites: both workflow archive paths (signed + ad-hoc) and `scripts/build-owletto-mac.sh`.
- The script matters as much as CI: it builds `-configuration Release` with Developer ID and installs to `/Applications`, so `OwlettoUpdater`'s `#if DEBUG` guard does not apply. **It is what produced the `0.1.0` builds on both paired Macs**, which for weeks looked indistinguishable from real releases in `device_workers.app_version`.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming) — run twice, once per diff revision
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] Tests run — no unit/integration surface; this is build-time version stamping, only provable by building

### red — the shipped release, straight from the published DMG

```
$ curl -sL -o v1480.dmg .../releases/download/lobu-v14.8.0/Owletto.dmg
$ hdiutil attach -nobrowse -quiet -mountpoint mnt1480 v1480.dmg
$ defaults read mnt1480/Owletto.app/Contents/Info.plist CFBundleShortVersionString
14.8.0
$ defaults read mnt1480/Owletto.app/Contents/Info.plist CFBundleVersion
1
```

Against the live appcast, which advertises `<sparkle:version>14.8.0</sparkle:version>` — so a machine
*running 14.8.0* still evaluates `14.8.0 > 1` and re-stages. Observed in the wild on a Mac mini holding
**two** staged installs simultaneously (14.5.0 from 2026-07-28 and 14.8.0 from 2026-07-31), neither ever applied.

### green — same archive command shape as the fixed workflow

```
$ xcodebuild ... MARKETING_VERSION=14.8.1-dev CURRENT_PROJECT_VERSION=14.8.1 archive
$ defaults read Owletto.app/Contents/Info.plist CFBundleShortVersionString
14.8.1-dev
$ defaults read Owletto.app/Contents/Info.plist CFBundleVersion
14.8.1
```

### green — `scripts/build-owletto-mac.sh`, executed

```
$ DERIVED=/tmp/owletto-greencheck ./scripts/build-owletto-mac.sh
>> Building Owletto (Release, Developer ID Application, version 99.0.0-dev)...
>> Built: /tmp/owletto-greencheck/Build/Products/Release/Owletto.app
$ defaults read .../Owletto.app/Contents/Info.plist CFBundleShortVersionString
99.0.0-dev
$ defaults read .../Owletto.app/Contents/Info.plist CFBundleVersion
99.0.0-dev
```

## Notes

**Behavior change worth a deliberate ack:** the dev script now defaults to `99.0.0-dev`, which sorts
*above* every real release, so Sparkle will never silently replace a build you deliberately made — the
exact failure that left two staged DMGs on the mini. Override when you *want* a later release to
supersede the build: `VERSION=14.8.1-dev make owletto-mac`.

**Second, independent defect — not fixed here.** Correcting the version comparison does not make an
unattended Mac ever *apply* an update: Sparkle's `Autoupdate` waits for the host app to terminate, and a
menubar `LSUIElement` app on a headless machine never quits (observed parked ~2h). That is why two
builds were staged rather than one. Deserves its own issue.

**Only provable by a real release run.** After the next tagged release, confirm the built app's
`CFBundleVersion` equals the tag version and that an up-to-date install stops re-staging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS release builds now consistently use the resolved release version for app and update metadata.
  * Development builds support an explicit version override, with the selected version displayed during the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->