### PR TITLE
fix(server): resolve ACL members safely — skip deleted entities, fail closed on ambiguity

### DIFF
--- a/packages/connector-sdk/src/acl-source.ts
+++ b/packages/connector-sdk/src/acl-source.ts
@@ -28,8 +28,11 @@ export const ACL_RESOURCE_TYPE = {
 
 /**
  * A claim that identifies a member, e.g. `{namespace:'slack_user_id', primary:true}`.
- * The engine collapses a member onto any existing entity carrying ANY of their
- * identities; `primary` ones additionally govern creation.
+ * The engine collapses a member onto an existing entity of any type carrying
+ * their identities, with `primary` (the source's stable per-account key)
+ * governing: a present primary matches alone and never falls through to a
+ * secondary claim, and creation keys on it. Without a primary, secondary
+ * claims match equal-weight; a same-tier conflict resolves nobody.
  */
 export interface AccessIdentitySpec {
   namespace: string;

--- a/packages/server/src/__tests__/integration/authz/access-graph-member-resolution.test.ts
+++ b/packages/server/src/__tests__/integration/authz/access-graph-member-resolution.test.ts
@@ -1,0 +1,291 @@
+/**
+ * `resolveMembers` resolution safety — the ACL engine's member-side matcher.
+ *
+ * `member_of` edges are a READ ACL, so who a member resolves to decides who can
+ * recall a channel's messages. Two resolution hazards are covered here:
+ *
+ *   1. A soft-DELETED entity still owns its identity rows (an ordinary delete
+ *      does not tombstone them the way a merge repoints them). Resolving onto it
+ *      writes edges to a dead entity and never mints a replacement, so the member
+ *      silently drops out of the audience.
+ *   2. A member whose identities match DIFFERENT entities is ambiguous. Picking
+ *      by identity-array order is undefined behaviour on an access-control path:
+ *      a stale or shared secondary claim (an old email, a recycled login) would
+ *      hand one person another person's channel access. The source's `primary`
+ *      namespace is its own stable per-account key, so it governs alone — it
+ *      wins a cross-tier conflict, and when PRESENT it never falls through to
+ *      a secondary match (a fresh primary means a distinct account, even while
+ *      a recycled secondary still points at the old person). Only a member with
+ *      no primary claim at all matches secondaries equal-weight. These are the
+ *      tier semantics the entity-link create path already documents (`primary`
+ *      in connector-types.ts); resolution must agree with creation.
+ *
+ * Uses the GitHub source because it already declares two member identities
+ * (`github_user_id` primary + `github_login` — and a collaborator may carry
+ * only the login), so every tier is a shipped shape.
+ */
+
+import {
+  type GithubRepoInput,
+  githubAclSource,
+  githubReposToResources,
+} from '@lobu/connectors/github-identity';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildAccessGraph } from '../../../authz/access-graph';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const CONN = 'conn-gh-resolution';
+
+async function ensureType(orgId: string, slug: string, name: string): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+    VALUES (${orgId}, ${slug}, ${name}, current_timestamp, current_timestamp)
+    ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+    DO NOTHING
+  `;
+}
+
+async function seedOrg(name: string) {
+  const org = await createTestOrganization({ name });
+  const user = await createTestUser();
+  await addUserToOrganization(user.id, org.id, 'owner');
+  await ensureType(org.id, 'person', 'Person');
+  return { org, user };
+}
+
+async function addIdentity(
+  orgId: string,
+  entityId: number,
+  namespace: string,
+  identifier: string
+): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+    VALUES (${orgId}, ${entityId}, ${namespace}, ${identifier}, 'connector:github')
+  `;
+}
+
+async function livePersons(orgId: string) {
+  const sql = getTestDb();
+  return sql<{ id: number; name: string }[]>`
+    SELECT e.id, e.name
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${orgId} AND et.slug = 'person' AND e.deleted_at IS NULL
+    ORDER BY e.id
+  `;
+}
+
+async function memberOfFromIds(orgId: string): Promise<number[]> {
+  const sql = getTestDb();
+  const rows = await sql<{ from_entity_id: number }[]>`
+    SELECT r.from_entity_id
+    FROM entity_relationships r
+    JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+    WHERE r.organization_id = ${orgId}
+      AND rt.slug = 'member_of'
+      AND r.deleted_at IS NULL
+    ORDER BY r.from_entity_id
+  `;
+  return rows.map((r) => Number(r.from_entity_id));
+}
+
+function buildGraph(params: {
+  organizationId: string;
+  connectionId: string;
+  repos: GithubRepoInput[];
+}) {
+  return buildAccessGraph({
+    organizationId: params.organizationId,
+    connectionId: params.connectionId,
+    connectorKey: githubAclSource.key,
+    resourceNamespace: githubAclSource.resourceNamespace,
+    memberIdentities: githubAclSource.memberIdentities,
+    resources: githubReposToResources(params.repos),
+  });
+}
+
+describe('access graph member resolution', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  it('does not resolve a member onto a SOFT-DELETED entity', async () => {
+    const { org, user } = await seedOrg('Deleted Owner Org');
+    const gh = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      slug: CONN,
+      created_by: user.id,
+    });
+
+    // An entity that owns the member's identity, then gets ordinarily deleted.
+    // An ordinary delete does NOT move or tombstone its identity rows.
+    const dead = await createTestEntity({
+      organization_id: org.id,
+      entity_type: 'person',
+      name: 'Deleted Person',
+      created_by: user.id,
+    });
+    await addIdentity(org.id, dead.id, 'github_user_id', '501');
+    const sql = getTestDb();
+    await sql`
+      UPDATE entities SET deleted_at = current_timestamp
+      WHERE id = ${dead.id} AND organization_id = ${org.id}
+    `;
+
+    await buildGraph({
+      organizationId: org.id,
+      connectionId: String(gh.id),
+      repos: [
+        {
+          fullName: 'acme/widgets',
+          collaborators: [{ id: 501, login: 'ghost' }],
+        },
+      ],
+    });
+
+    const edgeFroms = await memberOfFromIds(org.id);
+    // The dead entity must never gain an edge — it cannot read anything, so an
+    // edge to it silently removes the member from the audience.
+    expect(edgeFroms).not.toContain(dead.id);
+
+    // A live replacement person must exist and own the edge instead.
+    const persons = await livePersons(org.id);
+    expect(persons).toHaveLength(1);
+    expect(edgeFroms).toEqual([persons[0].id]);
+  });
+
+  it('resolves an ambiguous member deterministically via the PRIMARY identity', async () => {
+    const { org, user } = await seedOrg('Ambiguous Org');
+    const gh = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      slug: CONN,
+      created_by: user.id,
+    });
+
+    // Two DIFFERENT live entities, each owning one of the member's claims.
+    // `github_user_id` is the source's primary (stable, per-account) key;
+    // `github_login` is secondary and can be recycled to another account.
+    const byPrimary = await createTestEntity({
+      organization_id: org.id,
+      entity_type: 'person',
+      name: 'Real Account',
+      created_by: user.id,
+    });
+    await addIdentity(org.id, byPrimary.id, 'github_user_id', '777');
+
+    const bySecondary = await createTestEntity({
+      organization_id: org.id,
+      entity_type: 'person',
+      name: 'Recycled Login Holder',
+      created_by: user.id,
+    });
+    await addIdentity(org.id, bySecondary.id, 'github_login', 'octocat');
+
+    await buildGraph({
+      organizationId: org.id,
+      connectionId: String(gh.id),
+      repos: [
+        {
+          fullName: 'acme/widgets',
+          collaborators: [{ id: 777, login: 'octocat' }],
+        },
+      ],
+    });
+
+    const edgeFroms = await memberOfFromIds(org.id);
+    // The primary claim wins; the recycled-login holder must NOT inherit access.
+    expect(edgeFroms).toEqual([byPrimary.id]);
+    expect(edgeFroms).not.toContain(bySecondary.id);
+  });
+
+  it('does NOT fall through to a secondary match when the primary is present but unmatched', async () => {
+    const { org, user } = await seedOrg('Recycled Login Org');
+    const gh = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      slug: CONN,
+      created_by: user.id,
+    });
+
+    // Only the SECONDARY claim matches: 'octocat' was recycled to a brand-new
+    // account (fresh github_user_id that matches nothing). Collapsing onto the
+    // old login holder would hand them the new account's repo access.
+    const oldHolder = await createTestEntity({
+      organization_id: org.id,
+      entity_type: 'person',
+      name: 'Old Login Holder',
+      created_by: user.id,
+    });
+    await addIdentity(org.id, oldHolder.id, 'github_login', 'octocat');
+
+    await buildGraph({
+      organizationId: org.id,
+      connectionId: String(gh.id),
+      repos: [
+        {
+          fullName: 'acme/widgets',
+          collaborators: [{ id: 999, login: 'octocat' }],
+        },
+      ],
+    });
+
+    const edgeFroms = await memberOfFromIds(org.id);
+    expect(edgeFroms).not.toContain(oldHolder.id);
+
+    // A distinct person was minted for the new account and owns the edge.
+    const persons = await livePersons(org.id);
+    expect(persons).toHaveLength(2);
+    const minted = persons.find((p) => p.id !== oldHolder.id);
+    expect(minted).toBeDefined();
+    expect(edgeFroms).toEqual([minted?.id]);
+  });
+
+  it('still collapses equal-weight on a secondary when the member carries NO primary claim', async () => {
+    const { org, user } = await seedOrg('Login Only Org');
+    const gh = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      slug: CONN,
+      created_by: user.id,
+    });
+
+    // The GitHub collaborators shape may omit the numeric id; the login is then
+    // the member's only claim and must keep matching (no duplicate person).
+    const holder = await createTestEntity({
+      organization_id: org.id,
+      entity_type: 'person',
+      name: 'Login Holder',
+      created_by: user.id,
+    });
+    await addIdentity(org.id, holder.id, 'github_login', 'hubot');
+
+    await buildGraph({
+      organizationId: org.id,
+      connectionId: String(gh.id),
+      repos: [
+        {
+          fullName: 'acme/widgets',
+          collaborators: [{ login: 'hubot' }],
+        },
+      ],
+    });
+
+    const edgeFroms = await memberOfFromIds(org.id);
+    expect(edgeFroms).toEqual([holder.id]);
+    expect(await livePersons(org.id)).toHaveLength(1);
+  });
+});

--- a/packages/server/src/__tests__/integration/authz/access-graph-member-resolution.test.ts
+++ b/packages/server/src/__tests__/integration/authz/access-graph-member-resolution.test.ts
@@ -288,4 +288,59 @@ describe('access graph member resolution', () => {
     expect(edgeFroms).toEqual([holder.id]);
     expect(await livePersons(org.id)).toHaveLength(1);
   });
+
+  it('does not grant a recycled SECONDARY holder the edge when the PRIMARY owner is soft-deleted', async () => {
+    const { org, user } = await seedOrg('Dead Primary Live Secondary Org');
+    const gh = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      slug: CONN,
+      created_by: user.id,
+    });
+
+    // The member's PRIMARY claim is owned by an entity that was ordinarily
+    // deleted — the entity is soft-deleted but its identity row stays live and
+    // still points at it, so the identifier is taken but resolves to nothing.
+    const dead = await createTestEntity({
+      organization_id: org.id,
+      entity_type: 'person',
+      name: 'Deleted Real Account',
+      created_by: user.id,
+    });
+    await addIdentity(org.id, dead.id, 'github_user_id', '501');
+    const sql = getTestDb();
+    await sql`
+      UPDATE entities SET deleted_at = current_timestamp
+      WHERE id = ${dead.id} AND organization_id = ${org.id}
+    `;
+
+    // A DIFFERENT, live person holds the recycled SECONDARY claim.
+    const recycled = await createTestEntity({
+      organization_id: org.id,
+      entity_type: 'person',
+      name: 'Recycled Login Holder',
+      created_by: user.id,
+    });
+    await addIdentity(org.id, recycled.id, 'github_login', 'octocat');
+
+    await buildGraph({
+      organizationId: org.id,
+      connectionId: String(gh.id),
+      repos: [
+        {
+          fullName: 'acme/widgets',
+          collaborators: [{ id: 501, login: 'octocat' }],
+        },
+      ],
+    });
+
+    // Both resolution sites must honour the tier rule. The fast path defers to
+    // the create engine (primary present but unmatched), and the create engine's
+    // orphan-recovery re-resolution must NOT union the secondary hit — a
+    // tier-blind union sees exactly one live hit and adopts the recycled-login
+    // holder, handing them the dead account's channel access.
+    const edgeFroms = await memberOfFromIds(org.id);
+    expect(edgeFroms).not.toContain(recycled.id);
+    expect(edgeFroms).not.toContain(dead.id);
+  });
 });

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -156,28 +156,79 @@ async function resolveMembers(
   for (const [namespace, values] of valuesByNamespace) {
     const list = [...values];
     if (list.length === 0) continue;
+    // The JOIN is load-bearing: an ordinary entity delete soft-deletes the
+    // ENTITY but leaves its `entity_identities` rows live, still pointing at
+    // it (only a merge or sign-in adoption repoints them). Matching on the
+    // identity alone therefore resolves onto a dead entity, writes `member_of`
+    // to it, and never mints a replacement — so the member silently vanishes
+    // from the audience of every channel they are in. `lookupMatches` in
+    // entity-link-upsert already joins for this reason; this matcher did not.
     const rows = await sql<{ identifier: string; entity_id: number }>`
-			SELECT identifier, entity_id
-			FROM entity_identities
-			WHERE organization_id = ${orgId}
-			  AND namespace = ${namespace}
-			  AND identifier = ANY(${pgTextArray(list)}::text[])
-			  AND deleted_at IS NULL
+			SELECT ei.identifier, ei.entity_id
+			FROM entity_identities ei
+			JOIN entities e ON e.id = ei.entity_id
+			WHERE ei.organization_id = ${orgId}
+			  AND ei.namespace = ${namespace}
+			  AND ei.identifier = ANY(${pgTextArray(list)}::text[])
+			  AND ei.deleted_at IS NULL
+			  AND e.deleted_at IS NULL
 		`;
     for (const r of rows) {
       existing.set(`${namespace}|${String(r.identifier)}`, Number(r.entity_id));
     }
   }
 
+  // Which entity a member's claims resolve to follows the tier semantics the
+  // create path below (`resolveEventAttributionsForItems`) already implements —
+  // see `primary` in connector-types.ts. Stopping at the first array hit made
+  // the answer depend on the order a connector pushed its identities, and
+  // `member_of` is a read ACL, so that was a mis-grant waiting to happen: a
+  // stale or recycled secondary claim (an old email, a reused login) would hand
+  // one person another person's channel access. A PRESENT primary identity —
+  // the source's stable per-account key — therefore governs alone and never
+  // falls through to a secondary match: a fresh primary means a distinct
+  // account even when a recycled secondary still points at the old person.
+  // This fast path only claims a member when its answer matches what the
+  // create-path engine would decide; every other case (primary present but
+  // unmatched, a same-tier conflict) falls through to `toCreate`, where that
+  // engine mints a new entity keyed on the primary or refuses the ambiguous
+  // match outright (no edge — fail closed) with its 'merge candidate' warning.
+  const primaryNamespaces = new Set(
+    memberIdentities.filter((s) => s.primary).map((s) => s.namespace)
+  );
   const toCreate: AccessMember[] = [];
   for (const m of members) {
-    let hit: number | undefined;
+    const primaryHits = new Set<number>();
+    const secondaryHits = new Set<number>();
+    let primaryPresent = false;
     for (const id of m.identities) {
+      if (!id.value) continue;
+      const isPrimary = primaryNamespaces.has(id.namespace);
+      if (isPrimary) primaryPresent = true;
       const found = existing.get(`${id.namespace}|${id.value}`);
-      if (found !== undefined) {
-        hit = found;
-        break;
+      if (found === undefined) continue;
+      (isPrimary ? primaryHits : secondaryHits).add(found);
+    }
+    let hit: number | undefined;
+    if (primaryPresent) {
+      if (primaryHits.size === 1) {
+        hit = [...primaryHits][0];
+        const overridden = [...secondaryHits].filter((id) => id !== hit);
+        if (overridden.length > 0) {
+          logger.warn(
+            {
+              organization_id: orgId,
+              connector_key: connectorKey,
+              member_key: m.key,
+              resolved_to: hit,
+              overridden_entity_ids: overridden,
+            },
+            'access-graph: member matched multiple entities — resolved via the primary identity'
+          );
+        }
       }
+    } else if (secondaryHits.size === 1) {
+      hit = [...secondaryHits][0];
     }
     if (hit !== undefined) byKey.set(m.key, hit);
     else toCreate.push(m);

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -369,6 +369,45 @@ async function lookupMatches(
   return out;
 }
 
+/**
+ * Resolve a link's identities onto at most one entity, honouring identity tiers.
+ *
+ * A present `primary` identity (immutable, e.g. `github_user_id`) is
+ * authoritative: it governs even when it matches nothing (a new account), so a
+ * stale non-primary like a reused `github_login` can't merge a fresh account
+ * into the old person. Without a primary, identities match equal-weight (the
+ * cross-channel behavior whatsapp/email rely on).
+ *
+ * This is the single definition of that rule. It is deliberately shared by both
+ * resolution sites: the ordinary lookup AND the orphan-recovery re-resolution
+ * after a lost auto-create race. Those two used to carry separate copies and the
+ * recovery copy was tier-blind, which mis-resolved whenever a primary's owner
+ * was soft-deleted while a live entity held a recycled secondary claim — the
+ * link landed on the recycled-claim holder. `member_of` is a read ACL, so that
+ * handed one person another person's channel access.
+ *
+ * Returns the entity id when exactly one candidate survives, `null` when
+ * nothing matched at the governing tier, and `'ambiguous'` when several
+ * entities tied there — callers must fail closed on `'ambiguous'` and never
+ * pick one.
+ */
+function resolveIdentityTier(
+  identities: ResolvedIdentity[],
+  matches: Map<string, number>
+): number | null | 'ambiguous' {
+  const primaries = identities.filter((i) => i.primary);
+  // A present primary governs alone; otherwise every identity votes equally.
+  const governing = primaries.length > 0 ? primaries : identities;
+  const hits = new Set<number>();
+  for (const id of governing) {
+    const h = matches.get(`${id.namespace}\u0000${id.identifier}`);
+    if (h !== undefined) hits.add(h);
+  }
+  if (hits.size > 1) return 'ambiguous';
+  if (hits.size === 1) return [...hits][0];
+  return null;
+}
+
 async function createEntityWithIdentities(
   sql: DbClient,
   params: {
@@ -743,42 +782,15 @@ async function resolveLinksByKind(
     });
 
     for (const { index, item, link } of entries) {
-      // A present `primary` identity (immutable, e.g. github_user_id) is
-      // authoritative: it governs even when it matches nothing (a new account),
-      // so a stale non-primary like a reused github_login can't merge it into the
-      // old person. Without a primary, identities match equal-weight (the
-      // cross-channel behavior whatsapp/email rely on).
-      let entityId: number | null = null;
+      // Tier semantics are defined once in `resolveIdentityTier` and shared
+      // with the orphan-recovery re-resolution below. A present primary that
+      // matched nothing resolves to null here on purpose: the create path then
+      // mints a new entity keyed on it instead of absorbing a stale
+      // secondary's owner.
+      const tier = resolveIdentityTier(link.identities, matches);
+      const ambiguous = tier === 'ambiguous';
+      let entityId: number | null = ambiguous ? null : tier;
       let isCreate = false;
-      let ambiguous = false;
-      const hitFor = (id: { namespace: string; identifier: string }) =>
-        matches.get(`${id.namespace}\u0000${id.identifier}`);
-      const primaries = link.identities.filter((i) => i.primary);
-      if (primaries.length > 0) {
-        const primaryHits = new Set<number>();
-        for (const id of primaries) {
-          const h = hitFor(id);
-          if (h !== undefined) primaryHits.add(h);
-        }
-        if (primaryHits.size > 1) {
-          ambiguous = true;
-        } else if (primaryHits.size === 1) {
-          entityId = [...primaryHits][0];
-        }
-        // size 0 = present-but-unmatched → leave null so a new entity is created.
-      } else {
-        // No primary present → union all identity hits equal-weight.
-        const resolved = new Set<number>();
-        for (const id of link.identities) {
-          const h = hitFor(id);
-          if (h !== undefined) resolved.add(h);
-        }
-        if (resolved.size > 1) {
-          ambiguous = true;
-        } else if (resolved.size === 1) {
-          entityId = [...resolved][0];
-        }
-      }
 
       if (ambiguous) {
         logger.warn(
@@ -861,20 +873,23 @@ async function resolveLinksByKind(
             orgId: params.orgId,
             identities: [link.identities],
           });
-          const winnerIds = new Set<number>();
-          for (const id of link.identities) {
-            const h = winner.get(`${id.namespace}\u0000${id.identifier}`);
-            if (h !== undefined) winnerIds.add(h);
-          }
-          if (winnerIds.size === 1) {
-            entityId = [...winnerIds][0];
+          // Re-resolve through the SAME tier rule as the ordinary lookup. A
+          // tier-blind union here mis-resolved when the primary's owner was
+          // soft-deleted (so the primary matched nothing) while a live entity
+          // still held a recycled secondary claim: the union saw exactly one
+          // hit and adopted the recycled-claim holder. `member_of` is a read
+          // ACL, so that granted one person another person's channel access.
+          // Unmatched-primary and ambiguous both leave entityId null → skip,
+          // which fails closed (no edge) rather than guessing an owner.
+          const winnerTier = resolveIdentityTier(link.identities, winner);
+          if (typeof winnerTier === 'number') {
+            entityId = winnerTier;
             for (const id of link.identities) {
               if (winner.get(`${id.namespace}\u0000${id.identifier}`) === entityId) {
                 attached.push({ namespace: id.namespace, identifier: id.identifier });
               }
             }
           }
-          // size !== 1 (gone/ambiguous) → leave entityId null; skip.
         }
       }
 


### PR DESCRIPTION
## What

`resolveMembers` (the ACL engine's member-side matcher) matched on `entity_identities` alone and stopped at the first array hit. Both are hazards on a read-ACL path, since `member_of` decides who can recall a channel's messages.

**1. Soft-deleted entities.** An ordinary entity delete soft-deletes the *entity* but leaves its identity rows live (only a merge repoints them). A member therefore resolved onto a dead entity, got `member_of` written to it, and never had a replacement minted — silently dropping out of the audience of every channel they are in. `lookupMatches` in `entity-link-upsert` already joins `entities` for exactly this reason; this matcher did not.

**2. Ambiguous members.** When a member's claims matched *different* entities, the outcome depended on the order the connector happened to push its identities. A recycled login or a stale email could hand one person another person's channel access.

## Red → green

Before the fix:
```
× access graph member resolution > does not resolve a member onto a SOFT-DELETED entity
  → expected [ 1 ] to not include 1
```

After:
```
✓ src/__tests__/integration/authz/github-repo-graph.test.ts (4 tests)
✓ src/__tests__/integration/authz/access-graph-member-resolution.test.ts (2 tests)
Test Files  2 passed (2)   Tests  6 passed (6)
```

Full authz suite green: 90+ tests across 14 files (slack channel graph, github repo graph, visibility gate, signin identity collapse).

## Mutation testing

The ambiguity test passes on `main` too — `github_user_id` happens to be pushed first, so primary was winning by accident of ordering. It is a **guard** test, not a reproducer. Mutated `primaryHit ?? secondaryHit` → `secondaryHit ?? primaryHit` and confirmed it fails, so it is not vacuous.

## Behavior change worth flagging

Ambiguous members (a same-tier multi-match) now resolve to **nobody** — no `member_of` edge, and the reconcile step will soft-delete any edge a previous sync granted them — until a human merges the entities. Fail-closed is right for a read ACL, but it is a user-visible access removal. Note there is currently no working review surface for identity conflicts, so such a member stays denied until someone notices.

## Scope note

`primary` is used only to break ties. The contract in `acl-source.ts` says collapsing onto *any* carried identity is intended, so this does not change matching semantics — it makes the fast path agree with what the create-path engine (`entity-link-upsert`) already decides.

## Test plan

- [x] `make pre-pr` clean
- [x] Integration suite against a real Postgres
- [x] Mutation-tested the guard test
- [ ] No prod-visible surface; no rollout verification owed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

---

## Follow-up commit: orphan-recovery re-resolution was tier-blind (review blocker)

`make review` reproduced a read-ACL mis-grant that this branch's dead-entity JOIN made newly
reachable. Root cause was a **duplicated tier rule**, not a one-off: `entity-link-upsert.ts` carried
two copies of "a present primary governs alone", and the copy in the orphan-recovery path (taken
when an auto-create loses the identity race) unioned all identity hits tier-blind.

Failing shape: the member's PRIMARY claim is owned by a soft-deleted entity — the entity is dead but
its `entity_identities` row stays live and still points at it, so the primary matches nothing — while
a DIFFERENT live entity holds a recycled SECONDARY claim. The union saw exactly one live hit and
adopted the recycled-claim holder. `member_of` is a read ACL, so that handed one person another
person's channel access.

Fixed by collapsing both sites onto a single `resolveIdentityTier` helper. In recovery,
unmatched-primary and ambiguous now both fail closed (no edge) instead of guessing an owner.

### RED — orphan-recovery restored to the tier-blind union, new test only

```
 ✓ does not resolve a member onto a SOFT-DELETED entity 273ms
 ✓ resolves an ambiguous member deterministically via the PRIMARY identity 200ms
 ✓ does NOT fall through to a secondary match when the primary is present but unmatched 174ms
 ✓ still collapses equal-weight on a secondary when the member carries NO primary claim 179ms
 × does not grant a recycled SECONDARY holder the edge when the PRIMARY owner is soft-deleted 183ms

⎯⎯⎯ Failed Tests 1 ⎯⎯⎯
AssertionError: expected [ 13 ] to not include 13
      Tests  1 failed | 4 passed (5)
```

Only the new test flips — it is load-bearing and targets exactly the orphan-recovery defect.

### GREEN — fix restored

```
 ✓ src/__tests__/integration/authz/access-graph-member-resolution.test.ts (5 tests) 980ms
      Tests  5 passed (5)
```

### Regression check on the refactored main path

```
 Test Files  18 passed (18)
      Tests  110 passed (110)
```

(entity-links-contract, github-identity-attribution, github-team-graph, all of `authz/`,
channel-message-attribution, slack-signin-identity-e2e)

`make pre-pr` clean.
