### PR TITLE
fix(server): roll Behavior windows forward instead of re-completing the same period

### DIFF
--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -8,6 +8,7 @@
 
 import {
   addBehaviorPeriod,
+  alignToBehaviorWindowStart,
   getFinerBehaviorGranularities,
   inferBehaviorGranularityFromSchedule,
   type BehaviorTimeGranularity,
@@ -949,8 +950,28 @@ async function getBehaviorImpl(
       let windowEnd: Date;
 
       if (latestEnd) {
-        // Continue from where we left off.
-        windowStart = new Date(latestEnd);
+        // Continue from the period AFTER the last one, aligned. Same rule as
+        // `computePendingWindow` (utils/window-utils), which is what actually
+        // dispatches — this is only the preview of it, and a preview that
+        // disagrees with the dispatcher tells the agent one period and hands it
+        // another. Aligning matters because `window_end` is not reliably an
+        // exclusive boundary: agents write windows through `complete_window`
+        // and prod holds both conventions, so `new Date(latestEnd)` could start
+        // the preview at `…T23:59:59.999Z`.
+        const latestEndDate = new Date(latestEnd);
+        windowStart = alignToBehaviorWindowStart(latestEndDate, timeGranularity);
+        if (windowStart < latestEndDate) {
+          windowStart = addBehaviorPeriod(windowStart, timeGranularity);
+        }
+        // The dispatcher's clamp, too: when the last window IS the current
+        // period, `computePendingWindow` re-dispatches the current period
+        // (superseding its head) rather than minting a future one. Without
+        // this the preview advertises tomorrow while the dispatcher hands
+        // out today.
+        const alignedNow = alignToBehaviorWindowStart(now, timeGranularity);
+        if (windowStart > alignedNow) {
+          windowStart = alignedNow;
+        }
       } else {
         // No windows yet — find the earliest unprocessed event for this
         // entity. Unbounded by occurred_at: pi review (#481) flagged that
@@ -965,16 +986,19 @@ async function getBehaviorImpl(
           [args.behavior_id, ...entityLinkParams]
         );
         const earliest = earliestResult[0]?.earliest as string | null;
-        windowStart = earliest ? new Date(earliest) : now;
+        // Aligned too: an arbitrary event timestamp would preview a window
+        // starting mid-period, which is not a period the dispatcher can emit.
+        windowStart = alignToBehaviorWindowStart(
+          earliest ? new Date(earliest) : now,
+          timeGranularity
+        );
       }
 
-      // Calculate window end based on granularity
+      // A full period, never truncated at `now`. Truncating made the preview
+      // disagree with what `computePendingWindow` actually dispatches (it always
+      // emits a whole period), and a partial end is not a window any run can be
+      // given.
       windowEnd = addBehaviorPeriod(windowStart, timeGranularity);
-
-      // Don't go past now
-      if (windowEnd > now) {
-        windowEnd = now;
-      }
 
       nextWindow = {
         start: windowStart.toISOString(),

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -56,6 +56,7 @@ import {
   ensureIsoString,
   ensureNumber,
   foldUnprocessedRanges,
+  nextBehaviorWindowStart,
   parseBigintArray,
 } from '../utils/window-utils';
 import { buildLatestWatcherRunJoinSql } from '../watchers/automation';
@@ -243,6 +244,7 @@ interface WatcherQueryRow {
   sel_version_reactions_guidance: string | null;
   // Latest window end (folded MAX(window_end) lookup)
   latest_window_end: string | null;
+  latest_window_start: string | null;
   // jsonb_agg of identity scopes for primary entity
   entity_scopes: Array<{ namespace: string; identifier: string }> | null;
 }
@@ -563,6 +565,12 @@ async function getBehaviorImpl(
         sv.reactions_guidance as sel_version_reactions_guidance,
         -- Latest window end for the unprocessedCount bound.
         (SELECT MAX(window_end) FROM canvas_windows WHERE watcher_id = i.id) as latest_window_end,
+        -- Latest window START drives the next_window preview, so it chains off
+        -- exactly what computePendingWindow chains off. Chaining the preview off
+        -- the END instead makes the two disagree by a full period on a legacy
+        -- row stored with an inclusive 23:59:59.999 end.
+        (SELECT window_start FROM canvas_windows WHERE watcher_id = i.id
+          ORDER BY window_start DESC LIMIT 1) as latest_window_start,
         -- Identity scopes for the primary entity (entity_ids[1]) — drives
         -- the entity-link UNION in the unprocessedCount query.
         (SELECT jsonb_agg(jsonb_build_object('namespace', namespace, 'identifier', identifier))
@@ -840,6 +848,7 @@ async function getBehaviorImpl(
       (STANDARD_IDENTITY_NAMESPACES as readonly string[]).includes(s.namespace)
     );
     const latestEnd = watcherRow.latest_window_end;
+    const latestStart = watcherRow.latest_window_start;
     // Two entity-link fragments: one with `$1 = watcher_id` reserved (for
     // queries that join on the watcher's windows), one without (for queries
     // that only need the entity scope). Sharing one fragment and passing a
@@ -949,29 +958,13 @@ async function getBehaviorImpl(
       let windowStart: Date;
       let windowEnd: Date;
 
-      if (latestEnd) {
-        // Continue from the period AFTER the last one, aligned. Same rule as
-        // `computePendingWindow` (utils/window-utils), which is what actually
-        // dispatches — this is only the preview of it, and a preview that
-        // disagrees with the dispatcher tells the agent one period and hands it
-        // another. Aligning matters because `window_end` is not reliably an
-        // exclusive boundary: agents write windows through `complete_window`
-        // and prod holds both conventions, so `new Date(latestEnd)` could start
-        // the preview at `…T23:59:59.999Z`.
-        const latestEndDate = new Date(latestEnd);
-        windowStart = alignToBehaviorWindowStart(latestEndDate, timeGranularity);
-        if (windowStart < latestEndDate) {
-          windowStart = addBehaviorPeriod(windowStart, timeGranularity);
-        }
-        // The dispatcher's clamp, too: when the last window IS the current
-        // period, `computePendingWindow` re-dispatches the current period
-        // (superseding its head) rather than minting a future one. Without
-        // this the preview advertises tomorrow while the dispatcher hands
-        // out today.
-        const alignedNow = alignToBehaviorWindowStart(now, timeGranularity);
-        if (windowStart > alignedNow) {
-          windowStart = alignedNow;
-        }
+      if (latestStart) {
+        // The dispatcher's own rule, called — not reimplemented. `get_behavior`
+        // only PREVIEWS what `computePendingWindow` will hand the run, so a
+        // second copy here is a second thing to keep in sync, and it already
+        // drifted once (preview chained off window_end, dispatcher off
+        // window_start — a full period apart on legacy rows).
+        windowStart = nextBehaviorWindowStart(new Date(latestStart), now, timeGranularity);
       } else {
         // No windows yet — find the earliest unprocessed event for this
         // entity. Unbounded by occurred_at: pi review (#481) flagged that

--- a/packages/server/src/utils/__tests__/compute-pending-window.test.ts
+++ b/packages/server/src/utils/__tests__/compute-pending-window.test.ts
@@ -36,7 +36,7 @@
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
-import { computePendingWindow } from '../window-utils';
+import { computePendingWindow, nextBehaviorWindowStart } from '../window-utils';
 import { cleanupTestDatabase, getTestDb } from '../../__tests__/setup/test-db';
 import { createTestOrganization, createTestUser } from '../../__tests__/setup/test-fixtures';
 
@@ -283,5 +283,61 @@ describe('computePendingWindow', () => {
 
     expect(windowStart.toISOString().endsWith('T00:00:00.000Z')).toBe(true);
     expect(windowEnd.getTime() - windowStart.getTime()).toBe(DAY_MS);
+  });
+});
+
+/**
+ * The rule itself, at a fixed instant and with no database.
+ *
+ * `get_behavior`'s `next_window` PREVIEWS what `computePendingWindow`
+ * dispatches. While those were two implementations they drifted — the preview
+ * chained off `window_end` and the dispatcher off `window_start`, a full period
+ * apart on a legacy row with an inclusive end, so the agent was shown one
+ * window and the run was handed another. They now share this function, and
+ * these cases pin the shared contract rather than either caller.
+ */
+describe('nextBehaviorWindowStart', () => {
+  const NOW = new Date('2026-07-31T17:26:00.000Z');
+
+  it('advances one aligned period from the previous start', () => {
+    expect(
+      nextBehaviorWindowStart(new Date('2026-07-30T00:00:00.000Z'), NOW, 'daily').toISOString()
+    ).toBe('2026-07-31T00:00:00.000Z');
+  });
+
+  // Both boundary conventions, and a corrupt start, must land on the same period.
+  it.each([
+    ['aligned start', '2026-07-30T00:00:00.000Z'],
+    ['inclusive-end-derived start', '2026-07-30T23:59:59.999Z'],
+    ['mid-period start', '2026-07-30T11:17:03.221Z'],
+  ])('normalises a %s to the same next period', (_label, stored) => {
+    expect(nextBehaviorWindowStart(new Date(stored), NOW, 'daily').toISOString()).toBe(
+      '2026-07-31T00:00:00.000Z'
+    );
+  });
+
+  it('caps at the current period instead of minting a future one', () => {
+    // Today is already done — a sub-daily cron must get today again, not tomorrow.
+    expect(
+      nextBehaviorWindowStart(new Date('2026-07-31T00:00:00.000Z'), NOW, 'daily').toISOString()
+    ).toBe('2026-07-31T00:00:00.000Z');
+  });
+
+  it('still catches up one period at a time when far behind', () => {
+    expect(
+      nextBehaviorWindowStart(new Date('2026-01-10T00:00:00.000Z'), NOW, 'daily').toISOString()
+    ).toBe('2026-01-11T00:00:00.000Z');
+  });
+
+  it('starts one aligned period back when there is no previous window', () => {
+    expect(nextBehaviorWindowStart(null, NOW, 'daily').toISOString()).toBe(
+      '2026-07-30T00:00:00.000Z'
+    );
+  });
+
+  it('aligns weekly to Monday', () => {
+    const out = nextBehaviorWindowStart(new Date('2026-06-28T23:59:59.999Z'), NOW, 'weekly');
+    expect(out.getUTCDay()).toBe(1);
+    expect(out.toISOString()).toBe('2026-06-29T00:00:00.000Z');
   });
 });

--- a/packages/server/src/utils/__tests__/compute-pending-window.test.ts
+++ b/packages/server/src/utils/__tests__/compute-pending-window.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Window rollover for scheduled Behaviors.
+ *
+ * `canvas_windows` is a VIEW over `canvas_state` event chains: one row per chain
+ * ROOT, content from the chain HEAD. The ROOT carries the period. So "did the
+ * window roll over" is really "did a new root get created", and the only thing
+ * that decides it is the (window_start, granularity) pair the run is dispatched
+ * with — `findCanvasHead` matches on it, and a match means supersede-in-place
+ * instead of a new period.
+ *
+ * The bug this pins: `computePendingWindow` chained the next window off the
+ * previous window's `window_end`. That is only correct if `window_end` is an
+ * EXCLUSIVE boundary, and prod stores both conventions in one table (measured
+ * 2026-07-31: daily 29 inclusive `23:59:59.999` vs 32 exclusive `00:00:00`;
+ * weekly 28 vs 2). Chaining off an inclusive end starts the next window at
+ * `…T23:59:59.999Z` — a day minus a millisecond off — and 14 of 102 prod
+ * windows are misaligned that way.
+ *
+ * Two distinct failures fall out, both silent:
+ *
+ *  1. The `windowEnd > currentPeriodEnd` clamp collapses a misaligned window to
+ *     ZERO duration (`23:59:59.999` → `00:00:00`). Five such windows exist on
+ *     prod and all five have `content_analyzed = 0` — a Behavior that analyzed
+ *     nothing and reported success.
+ *  2. The misaligned start never matches a fresh period, so no new root is
+ *     created, so `lastWindow` never advances, so the scheduler re-dispatches
+ *     the same window forever. Behavior 71 ran hourly for a full day writing
+ *     into the previous day's window (dispatched `2026-07-30T23:59:59.999Z`,
+ *     wrote `2026-07-30T00:00:00.000Z`).
+ *
+ * The fix must ALSO not run away in the other direction: granularity has no
+ * 'hourly' (`BEHAVIOR_TIME_GRANULARITIES` is daily/weekly/monthly/quarterly),
+ * so an hourly cron necessarily gets a DAILY window and must re-dispatch the
+ * SAME period all day. "Always advance one period" would mint tomorrow's window
+ * at 00:01 and march into the future.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { computePendingWindow } from '../window-utils';
+import { cleanupTestDatabase, getTestDb } from '../../__tests__/setup/test-db';
+import { createTestOrganization, createTestUser } from '../../__tests__/setup/test-fixtures';
+
+/**
+ * Insert a canvas ROOT event for `watcherId` covering [start, end).
+ *
+ * Written as a raw `canvas_state` event because that is what a window IS — the
+ * view derives from it. `end` is caller-supplied precisely so both boundary
+ * conventions can be exercised.
+ */
+async function seedWindow(opts: {
+  orgId: string;
+  userId: string;
+  watcherId: number;
+  granularity: string;
+  start: string;
+  end: string;
+}): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO events (
+      organization_id, origin_id, semantic_type, payload_type, payload_data,
+      occurred_at, created_by, metadata
+    ) VALUES (
+      ${opts.orgId}, ${`canvas_${opts.watcherId}_${opts.start}`}, 'canvas_state',
+      'json_template', ${sql.json({ items: [] } as never)},
+      ${opts.end}, ${opts.userId},
+      ${sql.json({
+        watcher_id: opts.watcherId,
+        granularity: opts.granularity,
+        window_start: opts.start,
+        window_end: opts.end,
+        content_analyzed: 0,
+      } as never)}
+    )
+  `;
+}
+
+async function seedOrg() {
+  await cleanupTestDatabase();
+  const org = await createTestOrganization({ name: 'Window Org' });
+  const user = await createTestUser({ email: 'window@test.example.com' });
+  return { orgId: org.id, userId: user.id };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('computePendingWindow', () => {
+  afterEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  // The behaviour-71 failure, reduced. A daily window closed with an INCLUSIVE
+  // end must still roll the period forward to the next midnight.
+  it('rolls forward to the next aligned period after an inclusive-end window', async () => {
+    const { orgId, userId } = await seedOrg();
+    const watcherId = 9001;
+    await seedWindow({
+      orgId,
+      userId,
+      watcherId,
+      granularity: 'daily',
+      start: '2026-07-30T00:00:00.000Z',
+      end: '2026-07-30T23:59:59.999Z', // inclusive convention
+    });
+
+    const { windowStart, windowEnd } = await computePendingWindow(
+      getTestDb(),
+      watcherId,
+      'daily'
+    );
+
+    // Must be the NEXT day at midnight — not 23:59:59.999, and not 7/30 again.
+    expect(windowStart.toISOString()).toBe('2026-07-31T00:00:00.000Z');
+    expect(windowEnd.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+  });
+
+  it('rolls forward identically when the previous end was exclusive', async () => {
+    const { orgId, userId } = await seedOrg();
+    const watcherId = 9002;
+    await seedWindow({
+      orgId,
+      userId,
+      watcherId,
+      granularity: 'daily',
+      start: '2026-07-30T00:00:00.000Z',
+      end: '2026-07-31T00:00:00.000Z', // exclusive convention
+    });
+
+    const { windowStart, windowEnd } = await computePendingWindow(
+      getTestDb(),
+      watcherId,
+      'daily'
+    );
+
+    expect(windowStart.toISOString()).toBe('2026-07-31T00:00:00.000Z');
+    expect(windowEnd.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+  });
+
+  // Self-heal: the 14 already-misaligned prod rows must recover on their own,
+  // without a data migration rewriting window identities.
+  it('recovers from an already-misaligned stored window', async () => {
+    const { orgId, userId } = await seedOrg();
+    const watcherId = 9003;
+    await seedWindow({
+      orgId,
+      userId,
+      watcherId,
+      granularity: 'daily',
+      start: '2026-07-29T23:59:59.999Z', // corrupt start, as found on prod
+      end: '2026-07-30T23:59:59.999Z',
+    });
+
+    const { windowStart, windowEnd } = await computePendingWindow(
+      getTestDb(),
+      watcherId,
+      'daily'
+    );
+
+    expect(windowStart.toISOString()).toBe('2026-07-30T00:00:00.000Z');
+    expect(windowEnd.toISOString()).toBe('2026-07-31T00:00:00.000Z');
+    expect(windowStart.getUTCHours()).toBe(0);
+  });
+
+  // Gap 2. No window may ever be shorter than its granularity — that is what
+  // produced five 0-second windows with content_analyzed = 0.
+  it('never produces a degenerate window, whatever the stored boundary', async () => {
+    const { orgId, userId } = await seedOrg();
+    const cases = [
+      { id: 9101, start: '2026-07-23T23:59:59.999Z', end: '2026-07-24T00:00:00.000Z' },
+      { id: 9102, start: '2026-07-24T23:59:59.999Z', end: '2026-07-25T00:00:00.000Z' },
+      { id: 9103, start: '2026-07-25T00:00:00.000Z', end: '2026-07-25T23:59:59.999Z' },
+    ];
+    for (const c of cases) {
+      await seedWindow({
+        orgId,
+        userId,
+        watcherId: c.id,
+        granularity: 'daily',
+        start: c.start,
+        end: c.end,
+      });
+    }
+
+    for (const c of cases) {
+      const { windowStart, windowEnd } = await computePendingWindow(
+        getTestDb(),
+        c.id,
+        'daily'
+      );
+      const duration = windowEnd.getTime() - windowStart.getTime();
+      expect(duration, `watcher ${c.id} window duration`).toBe(DAY_MS);
+      expect(windowStart.toISOString().endsWith('T00:00:00.000Z')).toBe(true);
+    }
+  });
+
+  // The other direction. An hourly cron gets a DAILY window (there is no hourly
+  // granularity), so every run inside the same day must resolve to the SAME
+  // period — otherwise `replace_existing` can't refresh today's digest and the
+  // Behavior mints future windows instead.
+  it('re-dispatches the CURRENT period rather than minting a future one', async () => {
+    const { orgId, userId } = await seedOrg();
+    const watcherId = 9004;
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    const todayIso = today.toISOString();
+    const tomorrowIso = new Date(today.getTime() + DAY_MS).toISOString();
+
+    // Today's window is already complete — the state after the first run of the day.
+    await seedWindow({
+      orgId,
+      userId,
+      watcherId,
+      granularity: 'daily',
+      start: todayIso,
+      end: tomorrowIso,
+    });
+
+    const { windowStart, windowEnd } = await computePendingWindow(
+      getTestDb(),
+      watcherId,
+      'daily'
+    );
+
+    // Still today. Advancing here would mint tomorrow's window before tomorrow.
+    expect(windowStart.toISOString()).toBe(todayIso);
+    expect(windowEnd.toISOString()).toBe(tomorrowIso);
+  });
+
+  // Backfill must still walk forward one period at a time when genuinely behind.
+  it('catches up one period per run when behind', async () => {
+    const { orgId, userId } = await seedOrg();
+    const watcherId = 9005;
+    await seedWindow({
+      orgId,
+      userId,
+      watcherId,
+      granularity: 'daily',
+      start: '2026-01-10T00:00:00.000Z',
+      end: '2026-01-11T00:00:00.000Z',
+    });
+
+    const { windowStart, windowEnd } = await computePendingWindow(
+      getTestDb(),
+      watcherId,
+      'daily'
+    );
+
+    expect(windowStart.toISOString()).toBe('2026-01-11T00:00:00.000Z');
+    expect(windowEnd.toISOString()).toBe('2026-01-12T00:00:00.000Z');
+  });
+
+  it('aligns weekly windows to the week boundary', async () => {
+    const { orgId, userId } = await seedOrg();
+    const watcherId = 9006;
+    await seedWindow({
+      orgId,
+      userId,
+      watcherId,
+      granularity: 'weekly',
+      start: '2026-06-22T00:00:00.000Z', // a Monday
+      end: '2026-06-28T23:59:59.999Z', // inclusive, as stored on prod
+    });
+
+    const { windowStart, windowEnd } = await computePendingWindow(
+      getTestDb(),
+      watcherId,
+      'weekly'
+    );
+
+    expect(windowStart.toISOString()).toBe('2026-06-29T00:00:00.000Z');
+    expect(windowEnd.toISOString()).toBe('2026-07-06T00:00:00.000Z');
+    expect(windowStart.getUTCDay()).toBe(1); // Monday
+  });
+
+  it('starts from an aligned period when the Behavior has no windows yet', async () => {
+    await seedOrg();
+
+    const { windowStart, windowEnd } = await computePendingWindow(
+      getTestDb(),
+      9007,
+      'daily'
+    );
+
+    expect(windowStart.toISOString().endsWith('T00:00:00.000Z')).toBe(true);
+    expect(windowEnd.getTime() - windowStart.getTime()).toBe(DAY_MS);
+  });
+});

--- a/packages/server/src/utils/window-utils.ts
+++ b/packages/server/src/utils/window-utils.ts
@@ -92,56 +92,72 @@ export function foldUnprocessedRanges(
 /**
  * Compute the pending window dates for a watcher.
  *
- * Logic:
- * - Finds the last completed window for this watcher
- * - Computes the next window period based on granularity
- * - If no previous windows, uses "now minus one period" as the start
+ * Returns a period-aligned window of exactly one granularity period:
+ * `[aligned start, start + 1 period)`. The end is EXCLUSIVE.
+ *
+ * Chains off the last window's `window_start`, never its `window_end`. Using
+ * the end assumes it is an exclusive boundary, and it is not reliably one:
+ * windows are written by agents through `complete_window`, and prod holds both
+ * conventions in the same table (measured 2026-07-31 — daily: 29 rows ending
+ * `23:59:59.999` vs 32 ending `00:00:00`; weekly: 28 vs 2). Chaining off an
+ * inclusive end starts the next window a day-minus-a-millisecond early, which
+ * then (a) collapses to a ZERO-length window once clamped — five such windows
+ * exist on prod, every one with `content_analyzed = 0` — and (b) never matches
+ * a fresh period in `findCanvasHead`, so no new chain root is created, so this
+ * function keeps returning the same window forever (Behavior 71 spent a full
+ * day re-completing the previous day's window).
+ *
+ * Re-aligning the stored start also makes the 14 already-misaligned prod rows
+ * self-heal on their next run, with no migration rewriting window identities.
+ *
+ * The period never runs ahead of the clock: `BEHAVIOR_TIME_GRANULARITIES` has
+ * no 'hourly', so an hourly cron necessarily gets a DAILY window and every run
+ * inside a day must resolve to that SAME day for `replace_existing` to refresh
+ * it. Advancing unconditionally would mint tomorrow's window at 00:01 and march
+ * into the future. Hence the clamp to the current period rather than a cap on
+ * the end — a clamped END is what produced the zero-length windows.
  */
 export async function computePendingWindow(
   sql: DbClient,
   watcherId: number,
   granularity: BehaviorTimeGranularity
 ): Promise<WindowDates> {
-  // Find the last completed leaf window for this watcher (canvas_windows =
-  // one row per chain root, so this is the latest completed period). Zero-
-  // content windows are durable cursor progress too; otherwise empty periods
-  // can be reprocessed forever.
+  // Latest period this Behavior has a chain root for (canvas_windows = one row
+  // per root). Ordered by window_start because that is the field being chained;
+  // ordering by window_end would re-introduce the boundary ambiguity above.
+  // Zero-content windows are durable cursor progress too, otherwise empty
+  // periods get reprocessed forever.
   const lastWindow = await sql`
-    SELECT window_end
+    SELECT window_start
     FROM canvas_windows
     WHERE watcher_id = ${watcherId}
-    ORDER BY window_end DESC
+    ORDER BY window_start DESC
     LIMIT 1
   `;
 
   const now = new Date();
-  let windowStart: Date;
-  let windowEnd: Date;
+  const alignedNow = alignToBehaviorWindowStart(now, granularity);
 
+  let windowStart: Date;
   if (lastWindow.length > 0) {
-    // Continue from where the last window ended
-    windowStart = new Date(lastWindow[0].window_end as string);
+    // Next period after the last one, re-aligned so a corrupt stored start
+    // cannot propagate. Capped at the current period: being "done" with today
+    // means today gets re-analysed (and superseded), not that tomorrow starts.
+    const lastStart = alignToBehaviorWindowStart(
+      new Date(lastWindow[0].window_start as string),
+      granularity
+    );
+    const nextStart = addBehaviorPeriod(lastStart, granularity);
+    windowStart = nextStart > alignedNow ? alignedNow : nextStart;
   } else {
     // No previous windows - start from aligned "now minus one period"
     windowStart = alignToBehaviorWindowStart(subtractBehaviorPeriod(now, granularity), granularity);
   }
 
-  // Compute window end based on granularity
-  windowEnd = addBehaviorPeriod(windowStart, granularity);
-
-  // Cap window_end at aligned now (don't process future dates)
-  const alignedNow = alignToBehaviorWindowStart(now, granularity);
-  // For current period, use end of period instead of aligned start
-  const currentPeriodEnd = addBehaviorPeriod(alignedNow, granularity);
-  if (windowEnd > currentPeriodEnd) {
-    windowEnd = currentPeriodEnd;
-  }
-
-  // Ensure window_start is before window_end
-  if (windowStart >= windowEnd) {
-    // If window is too small, extend back by one period
-    windowStart = subtractBehaviorPeriod(windowEnd, granularity);
-  }
+  // Always a full period. `windowStart <= alignedNow` by construction, so this
+  // can never exceed the current period's end and never needs clamping — which
+  // is what keeps it from degenerating.
+  const windowEnd = addBehaviorPeriod(windowStart, granularity);
 
   return { windowStart, windowEnd };
 }

--- a/packages/server/src/utils/window-utils.ts
+++ b/packages/server/src/utils/window-utils.ts
@@ -136,23 +136,11 @@ export async function computePendingWindow(
   `;
 
   const now = new Date();
-  const alignedNow = alignToBehaviorWindowStart(now, granularity);
-
-  let windowStart: Date;
-  if (lastWindow.length > 0) {
-    // Next period after the last one, re-aligned so a corrupt stored start
-    // cannot propagate. Capped at the current period: being "done" with today
-    // means today gets re-analysed (and superseded), not that tomorrow starts.
-    const lastStart = alignToBehaviorWindowStart(
-      new Date(lastWindow[0].window_start as string),
-      granularity
-    );
-    const nextStart = addBehaviorPeriod(lastStart, granularity);
-    windowStart = nextStart > alignedNow ? alignedNow : nextStart;
-  } else {
-    // No previous windows - start from aligned "now minus one period"
-    windowStart = alignToBehaviorWindowStart(subtractBehaviorPeriod(now, granularity), granularity);
-  }
+  const windowStart = nextBehaviorWindowStart(
+    lastWindow.length > 0 ? new Date(lastWindow[0].window_start as string) : null,
+    now,
+    granularity
+  );
 
   // Always a full period. `windowStart <= alignedNow` by construction, so this
   // can never exceed the current period's end and never needs clamping — which
@@ -160,6 +148,48 @@ export async function computePendingWindow(
   const windowEnd = addBehaviorPeriod(windowStart, granularity);
 
   return { windowStart, windowEnd };
+}
+
+/**
+ * The period a Behavior should analyse next, given the start of its most recent
+ * window (or null if it has none).
+ *
+ * Pure and exported because TWO call sites need it and they must not drift:
+ * `computePendingWindow` above, which is what actually dispatches, and
+ * `get_behavior`'s `next_window`, which only PREVIEWS the dispatch. While those
+ * were two implementations they disagreed by a full period on legacy rows —
+ * telling the agent one window and handing the run another. One rule, one
+ * implementation, no drift.
+ *
+ * Takes the last window's START, never its end: `window_end` is not reliably an
+ * exclusive boundary (agents write windows through `complete_window`, and prod
+ * holds both conventions), so chaining off it starts the next period a
+ * millisecond short of a full one.
+ *
+ * `now` is a parameter rather than read here so the rule stays a pure function
+ * of its inputs and can be tested at a chosen instant.
+ */
+export function nextBehaviorWindowStart(
+  lastWindowStart: Date | null,
+  now: Date,
+  granularity: BehaviorTimeGranularity
+): Date {
+  const alignedNow = alignToBehaviorWindowStart(now, granularity);
+
+  if (!lastWindowStart) {
+    // Nothing analysed yet — start one aligned period back.
+    return alignToBehaviorWindowStart(subtractBehaviorPeriod(now, granularity), granularity);
+  }
+
+  // Next period after the last one, re-aligned so a corrupt stored start cannot
+  // propagate. Capped at the current period: being "done" with today means today
+  // gets re-analysed (and superseded), not that tomorrow starts — granularity has
+  // no 'hourly', so a sub-daily cron must keep resolving to the same day.
+  const nextStart = addBehaviorPeriod(
+    alignToBehaviorWindowStart(lastWindowStart, granularity),
+    granularity
+  );
+  return nextStart > alignedNow ? alignedNow : nextStart;
 }
 
 /**


### PR DESCRIPTION
## Summary
- A window is not a row. `canvas_windows` is a **VIEW** over `canvas_state` event chains — one row per chain ROOT, content from the HEAD. The ROOT carries the period, so "did the window roll over" means "was a new root created", and the only thing deciding that is the `(window_start, granularity)` pair the run is dispatched with: `findCanvasHead` matches on it, and a match supersedes in place instead of opening a new period.
- `computePendingWindow` chained the next window off the previous window's `window_end`, which is only correct if that end is **exclusive**. It isn't reliably one — agents write windows through `complete_window` and prod holds both conventions in the same table.
- Result: **14 of 102 prod windows are misaligned**, across Behaviors 3, 4, 5, 69, 71.

| granularity | ends `23:59:59.999` (inclusive) | ends `00:00:00` (exclusive) |
|---|---|---|
| daily | 29 | 32 |
| weekly | 28 | 2 |

## Two silent failures

**1. Zero-length windows.** The `windowEnd > currentPeriodEnd` clamp collapsed a misaligned window to 0 seconds (`23:59:59.999` → `00:00:00`). Five exist on prod and **every one has `content_analyzed = 0`** — a Behavior that analysed nothing and reported success.

**2. A window that never advances.** A misaligned start never matches a fresh period → no new root → the lookup never advances → the scheduler re-dispatches the same window forever.

Behavior 71 ("Social interest radar", hourly) spent a full day writing into the previous day's window:

| | value |
|---|---|
| dispatched | `2026-07-30T23:59:59.999Z` |
| written | `2026-07-30T00:00:00.000Z` |
| scheduled runs affected | 13, all `completed` |

The content was correct (80 events, all from 7/31) — it was filed under the wrong day, forever, with no new period ever opening.

## Fix

Chain off `window_start`, re-aligned, plus one period. Independent of which end convention a row was written with, and **self-healing** for the 14 existing misaligned rows — no migration rewriting window identities. The end is always a full period, so it cannot degenerate; the clamp that produced the zero-length windows is deleted.

The period is capped at the current one rather than advancing unconditionally. `BEHAVIOR_TIME_GRANULARITIES` has **no 'hourly'**, so an hourly cron necessarily gets a *daily* window and every run inside a day must resolve to that same day for `replace_existing` to refresh it. Advancing unconditionally would mint tomorrow's window at 00:01 and march into the future — a test pins this.

`get_behavior`'s `next_window` preview carried a second copy of the same chaining and *additionally* truncated the end at `now`, advertising a period the dispatcher would never emit. Aligned to the same rule (fix the class, not the instance).

## Test plan
- [x] `make pre-pr` clean
- [x] Tests: **1099 passed** across `integration/watchers`, `integration/behaviors`, `utils/__tests__`, `catalog` (77 files); `bun test unit/watchers` 7/7
- [x] Bug fix red→green below

### Red (against the old logic)
```
× rolls forward to the next aligned period after an inclusive-end window
  → expected '2026-07-30T23:59:59.999Z' to be '2026-07-31T00:00:00.000Z'
× recovers from an already-misaligned stored window
  → expected '2026-07-30T23:59:59.999Z' to be '2026-07-30T00:00:00.000Z'
× never produces a degenerate window, whatever the stored boundary
× aligns weekly windows to the week boundary
  → expected '2026-06-28T23:59:59.999Z' to be '2026-06-29T00:00:00.000Z'
  Tests  4 failed | 4 passed (8)
```

### Green
```
  Tests  8 passed (8)
```

The two tests that already passed are the guards the fix must not break — current-period re-dispatch, and one-period-per-run backfill catch-up.

### Mutation testing
| mutation | result |
|---|---|
| re-chain off `window_end` | 2 red |
| drop the re-alignment | 2 red |
| remove the current-period cap | 1 red |

## Notes
- **Not addressed:** `computePendingWindow` doesn't filter by granularity, so a Behavior whose granularity changed chains off the other granularity's latest window. Pre-existing and orthogonal.
- **Follow-up worth considering:** `complete_window` never checks the agent's `window_start` against the dispatched one — that's what let this stay invisible. On prod, period mismatches on *scheduled* runs occur only on the broken Behaviors (3, 4, 5, 71); the one healthy scheduled Behavior matches 3/3. Deliberately not bundled here: it converts a silent bug into a hard failure, and should land only after this fix is verified live.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved behavior window alignment for daily and weekly periods.
  * Prevented zero-duration and truncated windows during rollover and preview.
  * Improved recovery from misaligned or missing window history.
  * Ensured pending windows progress correctly through backfill and current-period updates.

* **Tests**
  * Added comprehensive coverage for window alignment, rollover, recovery, backfill, and empty-history scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->