### PR TITLE
fix(server): stop minting chat identity from a redeemed preview code

### DIFF
--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -161,13 +161,20 @@ export function registerBuiltInCommands(
   registry.register({
     name: "link",
     description:
-      "Link this chat to a Lobu agent — `<code>` from `lobu run`, or `<agentId>` once you've linked here before",
+      "Link this chat to a Lobu agent — `<code>` from `lobu run`, or `<agentId>` if you connected this Slack workspace to Lobu",
     handler: async (ctx: CommandContext) => {
       const arg = ctx.args.trim();
       const cmd = ctx.platform === "slack" ? "/lobu link" : "/link";
+      // The codeless `<agentId>` shortcut needs a `chat_user_identities` row,
+      // and only the Slack install claim writes those — so it never applies on
+      // other platforms. Don't promise it there.
+      const agentIdHint =
+        ctx.platform === "slack"
+          ? " (If you connected this workspace to Lobu, `/lobu link <agentId>` works too.)"
+          : "";
       if (!arg) {
         await ctx.reply(
-					`Usage: \`${cmd} <code>\` — get a code by running \`lobu run\` on a Preview-enabled agent. (Once you've linked here once, \`${cmd} <agentId>\` works too.)`,
+					`Usage: \`${cmd} <code>\` — get a code by running \`lobu run\` on a Preview-enabled agent.${agentIdHint}`,
         );
         return;
       }
@@ -184,7 +191,6 @@ export function registerBuiltInCommands(
         teamId: ctx.teamId,
         channelId,
         surfaceType,
-        platformUserId: ctx.userId,
 				connectionId: ctx.connectionId,
 				connectionOrganizationId: ctx.organizationId,
       });
@@ -205,8 +211,11 @@ export function registerBuiltInCommands(
           );
           return;
         case "not_found": {
-          // Not a valid code — but if this user has linked here before, treat
-          // the arg as an agent id and re-bind directly (no fresh code needed).
+          // Not a valid code — but if we already know who this chat user is,
+          // treat the arg as an agent id and re-bind directly (no fresh code
+          // needed). Identity comes only from the Slack install claim
+          // (slack-claim.ts), never from redeeming a code: the same mapping
+          // authorizes Slack approvals, so a pasted code must not mint it.
           const lobuUserId = await resolveChatUserIdentity(
             ctx.platform,
             ctx.teamId,
@@ -234,7 +243,7 @@ export function registerBuiltInCommands(
             return;
           }
           await ctx.reply(
-						"That link code is invalid or expired. Run `lobu run` again to get a fresh one.",
+						`That link code is invalid or expired. Run \`lobu run\` again to get a fresh one.${agentIdHint}`,
           );
           return;
         }

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -160,8 +160,9 @@ export function registerBuiltInCommands(
   // is reached as the `link` subcommand — not a bare `/link`.)
   registry.register({
     name: "link",
-    description:
-      "Link this chat to a Lobu agent — `<code>` from `lobu run`, or `<agentId>` if you connected this Slack workspace to Lobu",
+    // `/help` renders this on every platform, so it stays code-only; the
+    // Slack-only `<agentId>` shortcut is surfaced by `agentIdHint` below.
+    description: "Link this chat to a Lobu agent with a `<code>` from `lobu run`",
     handler: async (ctx: CommandContext) => {
       const arg = ctx.args.trim();
       const cmd = ctx.platform === "slack" ? "/lobu link" : "/link";

--- a/packages/server/src/lobu/stores/chat-identity.ts
+++ b/packages/server/src/lobu/stores/chat-identity.ts
@@ -55,7 +55,7 @@ export async function resolveChatUserIdentity(
  * is a deliberate operation that must delete the old row first.
  *
  * Pass a transaction handle as `sql` to link atomically with a surrounding
- * write (e.g. the link-claim path); omit it to run on the pooled connection.
+ * write; omit it to run on the pooled connection.
  */
 export async function linkChatUserIdentity(
 	opts: {

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -13,7 +13,10 @@ import {
 import { getDb } from "../../db/client.js";
 import { registerBuiltInCommands } from "../../gateway/commands/built-in-commands.js";
 import type { Env } from "../../index";
-import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
+import {
+  linkChatUserIdentity,
+  resolveChatUserIdentity,
+} from "../../lobu/stores/chat-identity.js";
 import {
   bindChatToAgentForOwner,
   bindChatToPreviewAgent,
@@ -37,8 +40,9 @@ const CLAIM_SLACK_CONNECTION = "claim-slack";
 const CLAIM_TELEGRAM_CONNECTION = "claim-telegram";
 
 let ORG_ID = "";
-// A real `user` row — `consumePreviewClaim` records `chat_user_identities`
-// (FK → "user"), so the claim's `createdBy` must be an actual user.
+// A real `user` row — the binding attributes the chat Behavior's `created_by`
+// from the claim's `createdBy`, resolved against `"user"`, so it must be an
+// actual user.
 let USER_ID = "";
 
 async function clearChatBehaviors(): Promise<void> {
@@ -337,9 +341,9 @@ describe("Slack Preview claims + channel Behaviors", () => {
     });
     expect((rows[0] as { agent_id: string }).agent_id).toBe(AGENT_ID);
 
-    // After a successful link this user's identity is recorded, so a non-code
-    // arg is treated as an agent id — an unknown one surfaces the friendly
-    // "no agent" message, no throw.
+    // Redeeming a code does NOT record who this Slack user is — a code is not
+    // identity proof. So the codeless `<agentId>` shortcut stays unavailable
+    // and the arg is reported as a bad code rather than resolved as an agent.
     const replies2: string[] = [];
     await registry.tryHandle("link", {
       userId: "U1",
@@ -354,7 +358,8 @@ describe("Slack Preview claims + channel Behaviors", () => {
         replies2.push(text);
       },
     });
-    expect(replies2.join("\n")).toMatch(/no agent `demo-agent-BADBAD`/i);
+    expect(replies2.join("\n")).not.toMatch(/no agent `demo-agent-BADBAD`/i);
+    expect(replies2.join("\n")).toMatch(/invalid or expired/i);
   });
 });
 
@@ -602,25 +607,24 @@ describe("chat-user identity + codeless re-link by agent id", () => {
       teamId: ID_TEAM,
       channelId: canonicalSlackChannelId(channelId),
       surfaceType: "dm",
-      platformUserId: SLACK_USER,
       connectionId: ID_CONNECTION,
       connectionOrganizationId: idOrgId,
     });
   }
 
-  test("consuming a code records the chat-user → Lobu-user identity", async () => {
+  test("consuming a code binds the chat but records NO chat-user identity", async () => {
     const bound = await mintAndConsume(ID_AGENT, "D900");
     expect(bound).toMatchObject({ status: "bound", agentId: ID_AGENT });
 
+    // A pasted code does not prove the redeemer is the minter, and the
+    // identity row authorizes Slack approval clicks and the in-chat
+    // builder-admin grant — so redemption must record none.
     const rows = await getDb()`
       SELECT lobu_user_id FROM chat_user_identities
       WHERE platform = 'slack' AND team_id = ${ID_TEAM} AND platform_user_id = ${SLACK_USER}
     `;
-    expect(rows).toHaveLength(1);
-    expect((rows[0] as { lobu_user_id: string }).lobu_user_id).toBe(lobuUserId);
-
-    expect(await resolveChatUserIdentity("slack", ID_TEAM, SLACK_USER)).toBe(lobuUserId);
-    expect(await resolveChatUserIdentity("slack", ID_TEAM, "U_NOBODY")).toBeNull();
+    expect(rows).toHaveLength(0);
+    expect(await resolveChatUserIdentity("slack", ID_TEAM, SLACK_USER)).toBeNull();
   });
 
   test("bindChatToAgentForOwner re-binds to an agent in the user's org, refuses others", async () => {
@@ -655,8 +659,16 @@ describe("chat-user identity + codeless re-link by agent id", () => {
   });
 
   test("/lobu link <agentId> re-binds without a code once the user has linked here", async () => {
-    // First, a real link establishes the identity.
+    // The identity must come from a real Slack install claim, NOT from
+    // redeeming a preview code — redemption deliberately records none. Seed it
+    // the way the install-claim path does so the codeless shortcut is covered.
     await mintAndConsume(ID_AGENT, "D903");
+    await linkChatUserIdentity({
+      platform: "slack",
+      teamId: ID_TEAM,
+      platformUserId: SLACK_USER,
+      lobuUserId,
+    });
 
     const registry = new CommandRegistry();
     registerBuiltInCommands(registry, { agentSettingsStore: {} as never });

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -2,7 +2,6 @@ import { createHash, randomInt } from "node:crypto";
 import { slugify } from "@lobu/core";
 import type { Context } from "hono";
 import { getDb } from "../db/client";
-import { linkChatUserIdentity } from "../lobu/stores/chat-identity";
 import { maybeSendSlackWorkspaceWelcome } from "../gateway/connections/slack-connection-coordinator";
 import { parseJsonBody } from "../gateway/routes/shared/helpers";
 import { SecretStoreRegistry } from "../gateway/secrets";
@@ -281,9 +280,7 @@ async function upsertBinding(
  * Platform-agnostic: the caller supplies the `platform`, the canonical
  * `channelId` form that platform's message handler looks bindings up by (for
  * Slack: `canonicalSlackChannelId`), the workspace/`teamId` if the platform has
- * one, the resolved `surfaceType` (dm vs channel), and — when available — the
- * sender's platform user id, which is recorded against the code-minter's Lobu
- * account in `chat_user_identities` so later links can skip the code.
+ * one, and the resolved `surfaceType` (dm vs channel).
  */
 export async function consumePreviewClaim(args: {
 	code: string;
@@ -292,8 +289,6 @@ export async function consumePreviewClaim(args: {
 	teamId?: string;
 	channelId: string;
 	surfaceType: SurfaceType;
-	/** Sender's platform user id (e.g. Slack `U…`), if known. */
-	platformUserId?: string;
 	/** Runtime connection id handling the command. Required for a
 	 * connection-scoped claim; hosted preview claims intentionally omit it. */
 	connectionId?: string;
@@ -306,7 +301,6 @@ export async function consumePreviewClaim(args: {
 		teamId,
 		channelId,
 		surfaceType,
-		platformUserId,
 		connectionId,
 		connectionOrganizationId,
 	} = args;
@@ -371,30 +365,13 @@ export async function consumePreviewClaim(args: {
 			claim.createdBy,
 		);
 
-		// The code was minted by an authenticated `lobu run` and is ASSUMED to be
-		// redeemed by the same person. Record the chat-platform → Lobu-user link so
-		// they can re-bind chats with `/lobu link <agentId>` without a fresh code.
-		//
-		// SECURITY: this mapping is also what authorizes Slack approval-button
-		// clicks (interaction-bridge resolveSlackActionReviewer), so a claim code
-		// is effectively a credential for the minter's account — never paste one
-		// in a shared channel. Two guards here: (1) an already-linked Slack user
-		// is NEVER silently re-bound to a different Lobu account by a later code;
-		// (2) the approval path additionally requires the mapped user to be an
-		// org admin/owner. Real identity proof (Slack OAuth / email match) is a
-		// follow-up.
-		if (claim.createdBy && platformUserId) {
-			await linkChatUserIdentity(
-				{
-					platform,
-					teamId,
-					platformUserId,
-					lobuUserId: claim.createdBy,
-				},
-				tx,
-			);
-		}
-
+		// Redemption binds the chat and NOTHING ELSE — deliberately no
+		// chat-platform → Lobu-user identity. A claim code is paste-able and does
+		// not prove the redeemer is the minter, while a `chat_user_identities`
+		// row authorizes Slack approval clicks (`interaction-bridge`
+		// resolveSlackActionReviewer) and the in-chat builder-admin grant.
+		// Identity is established only by the Slack install claim
+		// (slack-claim.ts), which links identities proven via Slack sign-in.
 		return {
 			status: "bound" as const,
 			agentId: claim.agentId,


### PR DESCRIPTION
## What

Redeeming a `/lobu link <code>` wrote a `chat_user_identities` row on the **assumption** that
whoever redeemed the code is whoever minted it. That row is read by two authorization paths:

- Slack approval-button clicks (`interaction-bridge` → `resolveSlackActionReviewer`)
- the in-chat builder-admin grant (`message-consumer`)

So a paste-able preview code was effectively a credential for the minter's Lobu account — anyone
who saw one in a shared channel could redeem it and inherit their approval authority. The write
site said this in its own comment and called real identity proof "a follow-up". This is that
follow-up.

An assumption cannot back an authorization decision, and there is nothing to repoint it to — so
**redemption now binds the chat and records no identity at all**.

## What is NOT changed

`/lobu link`, the preview-claim system, and the `lobu run` dev loop all work exactly as before.
This removes one write, not a feature. Identity continues to come from the Slack **install claim**
(`slack-claim.ts`), which is a genuinely different thing: gated on Slack's live `is_admin`/`is_owner`
verdict, team-scoped, canonicalized, and explicitly refusing to write an unscoped identity
(`if (!id.teamId) continue`).

## Cost, stated honestly

The codeless `/lobu link <agentId>` shortcut now requires having connected the workspace to Lobu.
It was **never** available on Telegram — no path writes an identity row there — so the help copy
stopped promising it on non-Slack platforms.

## Testing

`make pre-pr` clean (build, typecheck, knip, lint, exposed-surface naming).

```
 slack-preview.test.ts      21 passed (21)
 dm-link-e2e + dm-link-message-e2e     2 pass, 0 fail, 14 expect() calls
```

The guard is inverted rather than deleted — `consuming a code binds the chat but records NO
chat-user identity` asserts zero rows and a null `resolveChatUserIdentity`. The codeless-rebind
test now seeds identity the way the install claim does, so that path keeps its coverage instead of
silently losing it.

## Context

Part of the `chat_user_identities` removal sequence. The next step (repointing readers) is
**blocked on a design problem worth flagging**: `chat_user_identities` is keyed
`(platform, team_id, platform_user_id)` while better-auth `account` is unique on
`(providerId, accountId)` with **no team** — the team is only recoverable from an `idToken` JWT
claim that is empty on older rows. Slack `U…` ids are unique per workspace, not globally, so a bare
`accountId` lookup can resolve one workspace's user onto another workspace's Lobu account. Any
reader repoint has to key on team and fail closed when it can't.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the Slack `/link` command with clearer guidance for linking agents using a Slack-specific shortcut.
* **Bug Fixes**
  * Preview-code redemption no longer creates chat identity records unexpectedly.
  * Improved invalid-code messaging to clarify when identity-based relinking is available.
* **Documentation**
  * Clarified how chat identity linking handles transactions and pooled connections.
  * Updated Slack linking guidance and redemption behavior in related documentation and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->