### PR TITLE
refactor(server): resolve chat identity from the entity graph, drop chat_user_identities

### DIFF
--- a/db/migrations/20260801120000_entity_identities_global_lookup_index.sql
+++ b/db/migrations/20260801120000_entity_identities_global_lookup_index.sql
@@ -1,0 +1,30 @@
+-- migrate:up transaction:false
+
+-- Index the GLOBAL (namespace, identifier) direction on entity_identities.
+--
+-- Chat-identity resolution ("which Lobu user is this Slack workspace user?")
+-- now reads the entity graph instead of the dedicated `chat_user_identities`
+-- table. That question is deliberately cross-org: one human's `$member` exists
+-- once per org, and an inbound Slack event carries no org.
+--
+-- No existing index covers `(namespace, identifier)` without a leading
+-- `organization_id` (`idx_entity_identities_live_unique` leads with it; the
+-- rest key on entity_id / merged_from / connection_id), so an org-less lookup
+-- could only be answered by a sequential scan. This is the supporting index
+-- for it.
+--
+-- NOT unique, on purpose: the same external principal legitimately maps to a
+-- different entity in each org, and the org-scoped unique index still enforces
+-- the real invariant. The reader fails closed when a principal resolves to more
+-- than one DISTINCT auth user.
+--
+-- CONCURRENTLY (single statement, transaction:false) so building it never locks
+-- out writers during the Helm migration hook.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_entity_identities_global_lookup
+    ON entity_identities (namespace, identifier)
+    WHERE deleted_at IS NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_entity_identities_global_lookup;

--- a/db/migrations/20260801120010_drop_chat_user_identities.sql
+++ b/db/migrations/20260801120010_drop_chat_user_identities.sql
@@ -1,0 +1,48 @@
+-- migrate:up
+
+-- Drop `chat_user_identities`. Its job moved to the entity graph.
+--
+-- The table mapped `(platform, team_id, platform_user_id) → lobu_user_id`
+-- globally. Every reader now resolves the same fact from
+-- `entity_identities(namespace = 'slack_user_id')`, whose identifier is the
+-- composite workspace-scoped `TEAM:USER` key — so the workspace scoping that
+-- made this table correct is carried in the key itself, not in a column.
+--
+-- Why this is not a downgrade:
+--   * The stamp is written by `persistLoginSlackIdentity` on every Slack OAuth
+--     sign-in AND token refresh, resolving the team from the id_token claim
+--     with a userinfo fallback, and refusing to write a bare unscoped id.
+--   * The install-claim path re-stamps idempotently, including the Grid
+--     ENTERPRISE key (`E…`) that OAuth alone cannot prove.
+--   * Readers fail closed: a principal resolving to more than one DISTINCT auth
+--     user returns null rather than picking one.
+--
+-- The one writer that is NOT replaced is the preview-code redemption removed
+-- earlier in this sequence: it recorded an ASSUMED identity (that the redeemer
+-- is the code's minter) into a table that authorizes Slack approval clicks.
+-- Dropping it is the point, not a casualty.
+--
+-- No data migration. Every row this table held is derivable from, and already
+-- present in, the graph for any user who has signed in with Slack; a user who
+-- has not re-stamps on their next sign-in. There are no external consumers —
+-- `git grep chat_user_identities origin/main` is confined to this table's own
+-- readers, all of which are repointed in this change.
+
+DROP TABLE IF EXISTS chat_user_identities;
+
+-- migrate:down
+
+-- Recreates the (empty) structure only. The mappings themselves are not
+-- recoverable from here — they live in entity_identities now, and re-deriving
+-- them would mean re-deciding the workspace scoping this table encoded in
+-- columns and the graph encodes in the key.
+
+CREATE TABLE IF NOT EXISTS chat_user_identities (
+    platform text NOT NULL,
+    team_id text DEFAULT ''::text NOT NULL,
+    platform_user_id text NOT NULL,
+    lobu_user_id text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (platform, team_id, platform_user_id)
+);

--- a/db/migrations/20260801120010_drop_chat_user_identities.sql
+++ b/db/migrations/20260801120010_drop_chat_user_identities.sql
@@ -28,6 +28,7 @@
 -- `git grep chat_user_identities origin/main` is confined to this table's own
 -- readers, all of which are repointed in this change.
 
+-- squawk-ignore ban-drop-table -- the point of this migration; every reader is repointed at entity_identities in this change
 DROP TABLE IF EXISTS chat_user_identities;
 
 -- migrate:down

--- a/packages/server/src/__tests__/integration/gateway/builder-admin-grant-composition.test.ts
+++ b/packages/server/src/__tests__/integration/gateway/builder-admin-grant-composition.test.ts
@@ -29,6 +29,7 @@ import {
   createTestOrganization,
   createTestUser,
   insertChatConnectionRow,
+  linkSlackIdentityInGraph,
 } from '../../setup/test-fixtures';
 
 const WORKSPACE_TEAM = 'T_WORKSPACE';
@@ -37,13 +38,17 @@ const SLACK_USER = 'U_COMPOSE';
 /** A BYO runtime connection id — stored under slug `agentconn-<id>`. */
 const BYO_CONNECTION_ID = 'conn-compose-1';
 
-async function linkSlackIdentity(teamId: string, lobuUserId: string): Promise<void> {
-  await getTestDb()`
-    INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
-    VALUES ('slack', ${teamId}, ${SLACK_USER}, ${lobuUserId}, now())
-    ON CONFLICT (platform, team_id, platform_user_id)
-      DO UPDATE SET lobu_user_id = EXCLUDED.lobu_user_id, updated_at = now()
-  `;
+async function linkSlackIdentity(
+  organizationId: string,
+  teamId: string,
+  lobuUserId: string
+): Promise<void> {
+  await linkSlackIdentityInGraph({
+    organizationId,
+    userId: lobuUserId,
+    teamId,
+    slackUserId: SLACK_USER,
+  });
 }
 
 async function seedOwnerBuilder(): Promise<{
@@ -81,7 +86,7 @@ describe('Builder admin grant — payload metadata → tenant → grant composit
     const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
     await seedGridConnection(orgId);
     // The identity is linked under the Grid E… key, while the event carries T….
-    await linkSlackIdentity(ENTERPRISE_TEAM, userId);
+    await linkSlackIdentity(orgId, ENTERPRISE_TEAM, userId);
 
     const keys = await resolveGrantTeamKeys({
       platform: 'slack',
@@ -115,7 +120,7 @@ describe('Builder admin grant — payload metadata → tenant → grant composit
   it('prefers platformMetadata.teamId over the routing key', async () => {
     const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
     // Linked under the real workspace id; the routing key is the string 'slack'.
-    await linkSlackIdentity(WORKSPACE_TEAM, userId);
+    await linkSlackIdentity(orgId, WORKSPACE_TEAM, userId);
 
     const keys = await resolveGrantTeamKeys({
       platform: 'slack',
@@ -161,7 +166,7 @@ describe('Builder admin grant — payload metadata → tenant → grant composit
   it('withholds the alternate — and the grant — when the install is paused', async () => {
     const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
     await seedGridConnection(orgId, 'paused');
-    await linkSlackIdentity(ENTERPRISE_TEAM, userId);
+    await linkSlackIdentity(orgId, ENTERPRISE_TEAM, userId);
 
     const keys = await resolveGrantTeamKeys({
       platform: 'slack',

--- a/packages/server/src/__tests__/integration/gateway/builder-admin-tools-platform-identity.test.ts
+++ b/packages/server/src/__tests__/integration/gateway/builder-admin-tools-platform-identity.test.ts
@@ -6,7 +6,7 @@
  * user id. Before the fix the `member.userId = ${userId}` join never matched, so
  * an org owner driving the builder/system agent from Slack silently lost the
  * admin-tool grant. The fix maps platform id → lobu user via
- * `chat_user_identities` first (collision-safe: an ambiguous link grants
+ * the workspace-scoped Slack identity first (collision-safe: an ambiguous link grants
  * nothing).
  *
  * Red→green: with `platform:'slack'` the grant only lands once the resolver maps
@@ -22,6 +22,7 @@ import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
   addUserToOrganization,
   createTestAgent,
+  linkSlackIdentityInGraph,
   createTestOrganization,
   createTestUser,
 } from '../../setup/test-fixtures';
@@ -30,16 +31,17 @@ const SLACK_TEAM = 'T_WI02';
 const SLACK_USER = 'U_WI02';
 
 async function linkSlackIdentity(opts: {
+  organizationId: string;
   teamId: string;
   platformUserId: string;
   lobuUserId: string;
 }): Promise<void> {
-  await getTestDb()`
-    INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
-    VALUES ('slack', ${opts.teamId}, ${opts.platformUserId}, ${opts.lobuUserId}, now())
-    ON CONFLICT (platform, team_id, platform_user_id)
-      DO UPDATE SET lobu_user_id = EXCLUDED.lobu_user_id, updated_at = now()
-  `;
+  await linkSlackIdentityInGraph({
+    organizationId: opts.organizationId,
+    userId: opts.lobuUserId,
+    teamId: opts.teamId,
+    slackUserId: opts.platformUserId,
+  });
 }
 
 /** Point org.system_agent_id at an agent (the builder gate requires the match). */
@@ -70,6 +72,7 @@ describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', (
   it('grants builder tools for a Slack run once the platform id maps to the owner', async () => {
     const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
     await linkSlackIdentity({
+      organizationId: orgId,
       teamId: SLACK_TEAM,
       platformUserId: SLACK_USER,
       lobuUserId: userId,
@@ -109,6 +112,7 @@ describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', (
     // The resolver is team-scoped, so resolving for SLACK_TEAM finds no link and
     // the owner of the OTHER workspace can't ride this org's builder grant.
     await linkSlackIdentity({
+      organizationId: orgId,
       teamId: 'T_OTHER',
       platformUserId: SLACK_USER,
       lobuUserId: other.id,
@@ -145,6 +149,7 @@ describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', (
     const agent = await createTestAgent({ organizationId: org.id });
     await setSystemAgent(org.id, agent.agentId);
     await linkSlackIdentity({
+      organizationId: org.id,
       teamId: SLACK_TEAM,
       platformUserId: SLACK_USER,
       lobuUserId: user.id,
@@ -162,11 +167,12 @@ describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', (
   });
 
   it('grants via alternateTeamId when the link is under the enterprise key (Grid E… vs T…)', async () => {
-    // Managed enterprise installs key chat_user_identities on E…; inbound
+    // Managed enterprise installs key the identity on E…; inbound
     // events carry the workspace T…. Callers pass connection external_tenant_id
     // as alternateTeamId — exact team-scoped, not a global U… collapse.
     const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
     await linkSlackIdentity({
+      organizationId: orgId,
       teamId: 'E_ENTERPRISE',
       platformUserId: SLACK_USER,
       lobuUserId: userId,
@@ -187,6 +193,7 @@ describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', (
   it('does not grant when only an unrelated team has the link (no alternate)', async () => {
     const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
     await linkSlackIdentity({
+      organizationId: orgId,
       teamId: 'E_ENTERPRISE',
       platformUserId: SLACK_USER,
       lobuUserId: userId,

--- a/packages/server/src/__tests__/integration/gateway/slack-home-inbox-team-scope.test.ts
+++ b/packages/server/src/__tests__/integration/gateway/slack-home-inbox-team-scope.test.ts
@@ -39,23 +39,24 @@ import {
   createTestEvent,
   createTestOrganization,
   createTestUser,
+  linkSlackIdentityInGraph,
 } from '../../setup/test-fixtures';
 
 const COLLIDING_SLACK_USER_ID = 'U_COLLIDE';
 
-/** Link a Slack (team_id, platform_user_id) → Lobu user, as the link/preview path does. */
+/** Link a Slack (team, user) → Lobu user, as Slack sign-in does. */
 async function linkSlackIdentity(opts: {
+  organizationId: string;
   teamId: string;
   platformUserId: string;
   lobuUserId: string;
 }): Promise<void> {
-  const sql = getTestDb();
-  await sql`
-    INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
-    VALUES ('slack', ${opts.teamId}, ${opts.platformUserId}, ${opts.lobuUserId}, now())
-    ON CONFLICT (platform, team_id, platform_user_id)
-      DO UPDATE SET lobu_user_id = EXCLUDED.lobu_user_id, updated_at = now()
-  `;
+  await linkSlackIdentityInGraph({
+    organizationId: opts.organizationId,
+    userId: opts.lobuUserId,
+    teamId: opts.teamId,
+    slackUserId: opts.platformUserId,
+  });
 }
 
 /** Deliver one notification (events row + notification_targets row) to a user. */
@@ -93,6 +94,7 @@ async function seedWorkspaceUser(opts: {
   const user = await createTestUser();
   await addUserToOrganization(user.id, org.id, 'owner');
   await linkSlackIdentity({
+    organizationId: org.id,
     teamId: opts.teamId,
     platformUserId: COLLIDING_SLACK_USER_ID,
     lobuUserId: user.id,
@@ -143,30 +145,6 @@ describe('resolveSlackHomeUserInbox team_id scoping (cross-workspace isolation)'
     expect(inboxB!.orgSlug).toBe(b.orgSlug);
     expect(inboxB!.items.map((i) => i.title)).toEqual(['B-notif']);
     expect(inboxB!.items.map((i) => i.title)).not.toContain('A-notif');
-  });
-
-  it('resolves the hosted-preview path via the empty team_id', async () => {
-    // The preview connection writes identity rows with team_id=''. A colliding
-    // workspace identity (team_id='T_OTHER') for the same Slack user must not
-    // bleed into the preview ('') lookup.
-    const preview = await seedWorkspaceUser({
-      teamId: '',
-      orgSlug: 'preview-org',
-      notifTitle: 'preview-notif',
-      resourceUrl: '/preview-org/items/9',
-    });
-    await seedWorkspaceUser({
-      teamId: 'T_OTHER',
-      orgSlug: 'other-org',
-      notifTitle: 'other-notif',
-      resourceUrl: '/other-org/items/9',
-    });
-
-    const inbox = await resolveSlackHomeUserInbox(COLLIDING_SLACK_USER_ID, '');
-    expect(inbox).not.toBeNull();
-    expect(inbox!.orgSlug).toBe(preview.orgSlug);
-    expect(inbox!.items.map((i) => i.title)).toEqual(['preview-notif']);
-    expect(inbox!.items.map((i) => i.title)).not.toContain('other-notif');
   });
 
   it('returns null when no identity matches the (team_id, user) pair', async () => {

--- a/packages/server/src/__tests__/integration/stores/active-chat-connection-tenant.test.ts
+++ b/packages/server/src/__tests__/integration/stores/active-chat-connection-tenant.test.ts
@@ -2,7 +2,7 @@
  * `resolveActiveChatConnectionTenant` — the second identity key used by the
  * Builder admin-tool grant.
  *
- * Slack Grid keys `chat_user_identities` on the enterprise `E…` while inbound
+ * Slack Grid keys the linked Slack identity on the enterprise `E…` while inbound
  * events carry the workspace `T…`, so the grant path resolves a connection's
  * `external_tenant_id` and retries the identity lookup under it. That makes this
  * read PRIVILEGE-ADJACENT: a row returned here widens an authz lookup, so the

--- a/packages/server/src/__tests__/integration/tools/entity-approval-owner-routing.test.ts
+++ b/packages/server/src/__tests__/integration/tools/entity-approval-owner-routing.test.ts
@@ -181,6 +181,32 @@ describe("owner-routed approvals — DM delivery tier selection", () => {
 		expect(await resolveOwnerDmTarget(orgId, stranger.id)).toBeNull();
 	});
 
+	it("FAILS CLOSED when one user holds two Slack ids under the same team", async () => {
+		// The stamps are org-scoped rows and are never deleted when superseded, so
+		// a user in two orgs — or whose Slack account id changed inside one
+		// workspace — can hold two DISTINCT ids under the same `TEAM:` prefix.
+		// The caller uses this as a DM RECIPIENT, so picking arbitrarily would
+		// send the owner DM to a stale Slack account and lose it silently.
+		const twin = await createTestUser({ name: "Two Workspaces One Team" });
+		await addUserToOrganization(twin.id, orgId, "member");
+		const otherOrg = await createTestOrganization({ name: "Second Org" });
+		await addUserToOrganization(twin.id, otherOrg.id, "member");
+		await linkSlackIdentityInGraph({
+			organizationId: orgId,
+			userId: twin.id,
+			teamId: "TDUPTEAM",
+			slackUserId: "U-FIRST",
+		});
+		await linkSlackIdentityInGraph({
+			organizationId: otherOrg.id,
+			userId: twin.id,
+			teamId: "TDUPTEAM",
+			slackUserId: "U-SECOND",
+		});
+
+		expect(await resolveSlackUserIdForUser(twin.id, "TDUPTEAM")).toBeNull();
+	});
+
 	it("matches the team prefix literally — `_` in a team id is not a LIKE wildcard", async () => {
 		// `_` is legal in a team id AND a single-char LIKE wildcard, so an
 		// unescaped prefix `T_DMOWNER:%` would also match `TXDMOWNER:…` and hand

--- a/packages/server/src/__tests__/integration/tools/entity-approval-owner-routing.test.ts
+++ b/packages/server/src/__tests__/integration/tools/entity-approval-owner-routing.test.ts
@@ -12,6 +12,7 @@
 
 import { beforeAll, describe, expect, it } from "vitest";
 import { getDb } from "../../../db/client";
+import { resolveSlackUserIdForUser } from "../../../lobu/stores/chat-identity";
 import { resolveOwnerDmTarget } from "../../../notifications/service";
 import { proposeEntityFieldChange } from "../../../tools/admin/entity-field-approval";
 import type { ToolContext } from "../../../tools/registry";
@@ -25,6 +26,7 @@ import {
 	createTestOrganization,
 	createTestUser,
 	insertChatConnectionRow,
+	linkSlackIdentityInGraph,
 } from "../../setup/test-fixtures";
 
 const TEAM_ID = "T-OWNERROUTE";
@@ -163,11 +165,12 @@ describe("owner-routed approvals — DM delivery tier selection", () => {
 	});
 
 	it("picks the owner's Slack identity in the connected workspace", async () => {
-		const sql = getTestDb();
-		await sql`
-      INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id)
-      VALUES ('slack', ${TEAM_ID}, 'U-DMOWNER', ${owner.id})
-    `;
+		await linkSlackIdentityInGraph({
+			organizationId: orgId,
+			userId: owner.id,
+			teamId: TEAM_ID,
+			slackUserId: "U-DMOWNER",
+		});
 		const target = await resolveOwnerDmTarget(orgId, owner.id);
 		expect(target).toEqual({ connectionId, slackUserId: "U-DMOWNER" });
 	});
@@ -176,5 +179,23 @@ describe("owner-routed approvals — DM delivery tier selection", () => {
 		const stranger = await createTestUser({ name: "No Identity" });
 		await addUserToOrganization(stranger.id, orgId, "member");
 		expect(await resolveOwnerDmTarget(orgId, stranger.id)).toBeNull();
+	});
+
+	it("matches the team prefix literally — `_` in a team id is not a LIKE wildcard", async () => {
+		// `_` is legal in a team id AND a single-char LIKE wildcard, so an
+		// unescaped prefix `T_DMOWNER:%` would also match `TXDMOWNER:…` and hand
+		// back a user id from the wrong workspace.
+		const roamer = await createTestUser({ name: "Wildcard Roamer" });
+		await addUserToOrganization(roamer.id, orgId, "member");
+		await linkSlackIdentityInGraph({
+			organizationId: orgId,
+			userId: roamer.id,
+			teamId: "TXDMOWNER",
+			slackUserId: "U-ROAMER",
+		});
+		expect(await resolveSlackUserIdForUser(roamer.id, "TXDMOWNER")).toBe(
+			"U-ROAMER",
+		);
+		expect(await resolveSlackUserIdForUser(roamer.id, "T_DMOWNER")).toBeNull();
 	});
 });

--- a/packages/server/src/__tests__/setup/test-fixtures.ts
+++ b/packages/server/src/__tests__/setup/test-fixtures.ts
@@ -6,6 +6,7 @@
  */
 
 import { COMPILE_CONFIG_HASH } from '@lobu/connector-worker/compile';
+import { normalizeSlackUserId } from '@lobu/connectors/slack-identity';
 import { serializeSigned } from 'hono/utils/cookie';
 import { hashClientSecret } from '../../auth/oauth/clients';
 import { slugify } from '@lobu/core';
@@ -14,6 +15,7 @@ import { pgBigintArray, pgTextArray } from '../../db/client';
 import { ensureUniqueConnectionSlug } from '../../utils/connections';
 import { getConfiguredEmbeddingModel } from '../../utils/embeddings';
 import type { ToolContext } from '../../tools/registry';
+import { provisionMemberAndCoreIdentities } from '../../auth/subject-identities';
 import { getTestDb } from './test-db';
 
 const TEST_SYSTEM_ORG_ID = 'default';
@@ -952,4 +954,49 @@ export async function createCanvasWindow(options: {
   }
 
   return windowId;
+}
+
+/**
+ * Link a Slack workspace user to a Lobu user the way production does: provision
+ * the user's `$member` in the org (which writes the `auth_user_id` identity)
+ * and stamp the workspace-scoped `TEAM:USER` `slack_user_id` identity onto it.
+ *
+ * This replaces seeding the old `chat_user_identities` table. Going through the
+ * real provisioning call matters — the resolver joins `slack_user_id` to
+ * `auth_user_id` with `source_connector = 'auth:signup'`, so a hand-rolled
+ * INSERT that skipped that would pass while production failed.
+ */
+export async function linkSlackIdentityInGraph(opts: {
+  organizationId: string;
+  userId: string;
+  teamId: string;
+  slackUserId: string;
+}): Promise<void> {
+  const sql = getTestDb();
+  const users = await sql<{ email: string | null }>`
+    SELECT email FROM "user" WHERE id = ${opts.userId} LIMIT 1
+  `;
+  const email = users[0]?.email;
+  if (!email) throw new Error(`no user row for ${opts.userId}`);
+
+  const { memberEntityId } = await provisionMemberAndCoreIdentities(
+    opts.organizationId,
+    { userId: opts.userId, email }
+  );
+
+  const identifier = normalizeSlackUserId(opts.teamId, opts.slackUserId);
+  if (!identifier) {
+    throw new Error(
+      `unnormalizable Slack identity: ${opts.teamId}/${opts.slackUserId}`
+    );
+  }
+  await sql`
+    INSERT INTO entity_identities (
+      organization_id, entity_id, namespace, identifier, source_connector
+    ) VALUES (
+      ${opts.organizationId}, ${memberEntityId}, 'slack_user_id', ${identifier}, 'auth:signup'
+    )
+    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    DO NOTHING
+  `;
 }

--- a/packages/server/src/auth/subject-identities.ts
+++ b/packages/server/src/auth/subject-identities.ts
@@ -441,9 +441,21 @@ export async function stampSlackIdentityForUser(
 	slackUserId: string,
 ): Promise<void> {
 	const combined = normalizeSlackUserId(teamId, slackUserId);
-	if (!combined) return;
+	if (!combined) {
+		log.debug(
+			{ userId },
+			"slack-identity: missing team_id or user id — skipping slack_user_id stamp",
+		);
+		return;
+	}
 	const memberOrgs = await resolveMemberOrgsForUser(userId);
-	if (memberOrgs.length === 0) return;
+	if (memberOrgs.length === 0) {
+		log.debug(
+			{ userId },
+			"slack-identity: no tenant $member yet — skipping slack_user_id stamp",
+		);
+		return;
+	}
 	const sql = getDb();
 	for (const org of memberOrgs) {
 		const outcome = await adoptSlackIdentityOntoMember(
@@ -456,7 +468,11 @@ export async function stampSlackIdentityForUser(
 			// A different `$member` in this org already holds this Slack id. Two
 			// humans cannot share one workspace account — never silently reassign.
 			log.warn(
-				{ userId, organizationId: org.tenantOrganizationId, identifier: combined },
+				{
+					userId,
+					organizationId: org.tenantOrganizationId,
+					memberEntityId: org.memberEntityId,
+				},
 				"slack-identity: slack_user_id already claimed by a different $member — leaving it alone",
 			);
 		}

--- a/packages/server/src/auth/subject-identities.ts
+++ b/packages/server/src/auth/subject-identities.ts
@@ -420,3 +420,45 @@ export async function persistLoginSlackIdentity(
 		);
 	}
 }
+
+/**
+ * Stamp a workspace-scoped Slack identity onto a user's `$member` in every org
+ * they belong to, idempotently and failing closed on conflict.
+ *
+ * This is the same write `persistLoginSlackIdentity` performs, exposed for the
+ * install-claim path. That path needs it for a key OAuth alone cannot supply:
+ * on Slack Grid the install row is keyed by the ENTERPRISE id (`E…`) while a
+ * sign-in only ever proves the WORKSPACE id (`T…`), and inbound events may
+ * carry either. Without the enterprise stamp the `E…` lookup resolves nothing
+ * and the installer silently loses Builder admin tools.
+ *
+ * Refuses to write an unscoped id: `normalizeSlackUserId` returns null without
+ * a team, and two workspaces can share a bare `U…`.
+ */
+export async function stampSlackIdentityForUser(
+	userId: string,
+	teamId: string | null | undefined,
+	slackUserId: string,
+): Promise<void> {
+	const combined = normalizeSlackUserId(teamId, slackUserId);
+	if (!combined) return;
+	const memberOrgs = await resolveMemberOrgsForUser(userId);
+	if (memberOrgs.length === 0) return;
+	const sql = getDb();
+	for (const org of memberOrgs) {
+		const outcome = await adoptSlackIdentityOntoMember(
+			sql,
+			org.tenantOrganizationId,
+			org.memberEntityId,
+			combined,
+		);
+		if (outcome === "conflict") {
+			// A different `$member` in this org already holds this Slack id. Two
+			// humans cannot share one workspace account — never silently reassign.
+			log.warn(
+				{ userId, organizationId: org.tenantOrganizationId, identifier: combined },
+				"slack-identity: slack_user_id already claimed by a different $member — leaving it alone",
+			);
+		}
+	}
+}

--- a/packages/server/src/gateway/__tests__/interaction-bridge-owner-approval.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-owner-approval.test.ts
@@ -12,6 +12,7 @@ import {
   createTestEntity,
   createTestOrganization,
   createTestUser,
+  linkSlackIdentityInGraph,
 } from "../../__tests__/setup/test-fixtures.js";
 import { getDb } from "../../db/client.js";
 import { proposeEntityFieldChange } from "../../tools/admin/entity-field-approval.js";
@@ -83,10 +84,12 @@ async function seedApprovalFixture(): Promise<Fixture> {
     ["U-OTHER", other.id],
   ];
   for (const [slackId, lobuId] of identities) {
-    await sql`
-      INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id)
-      VALUES ('slack', ${TEAM_ID}, ${slackId}, ${lobuId})
-    `;
+    await linkSlackIdentityInGraph({
+      organizationId: org.id,
+      userId: lobuId,
+      teamId: TEAM_ID,
+      slackUserId: slackId,
+    });
   }
 
   const entity = await createTestEntity({

--- a/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
@@ -6,6 +6,7 @@ import {
   createTestEntity,
   createTestOrganization,
   createTestUser,
+  linkSlackIdentityInGraph,
 } from "../../__tests__/setup/test-fixtures.js";
 import { getDb } from "../../db/client.js";
 import { proposeEntityFieldChange } from "../../tools/admin/entity-field-approval.js";
@@ -266,10 +267,12 @@ describe("Slack block_actions → run-approval entity_field_change (Tier B)", ()
     const org = await createTestOrganization({ name: "Run Approval Webhook Org" });
     const admin = await createTestUser({ name: "Admin Reviewer" });
     await addUserToOrganization(admin.id, org.id, "admin");
-    await getDb()`
-      INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id)
-      VALUES ('slack', ${TEAM_ID}, 'U-ADMIN-RA', ${admin.id})
-    `;
+    await linkSlackIdentityInGraph({
+      organizationId: org.id,
+      userId: admin.id,
+      teamId: TEAM_ID,
+      slackUserId: "U-ADMIN-RA",
+    });
 
     const entity = await createTestEntity({
       name: "Payment Gateway Latency",

--- a/packages/server/src/gateway/__tests__/slack-claim-http-authority.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim-http-authority.test.ts
@@ -11,6 +11,7 @@ import {
 const USER_ID = "claim-user";
 const TEAM_ID = "T-CLAIM";
 const SLACK_USER_ID = "U-ADMIN";
+const ORG_ID = "org-1";
 
 beforeAll(async () => {
   await ensureDbForGatewayTests();
@@ -29,11 +30,57 @@ beforeEach(async () => {
   `;
 }, 30_000);
 
+/**
+ * Seed the claimer's workspace-scoped Slack identity the way Slack sign-in
+ * does: a `$member` entity carrying both `auth_user_id` and the composite
+ * `TEAM:USER` `slack_user_id`. `resolveClaimingUserSlackIdentities` reads this
+ * graph shape, so seeding anything less would pass here and fail in production.
+ */
 async function linkSlackUser(teamId: string): Promise<void> {
-  await getDb()`
-    INSERT INTO chat_user_identities (
-      platform, team_id, platform_user_id, lobu_user_id, updated_at
-    ) VALUES ('slack', ${teamId}, ${SLACK_USER_ID}, ${USER_ID}, now())
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug, "createdAt")
+    VALUES (${ORG_ID}, 'Acme', 'acme', now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`m-${USER_ID}`}, ${ORG_ID}, ${USER_ID}, 'owner', now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  const types = await sql<{ id: number }>`
+    INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+    VALUES (${ORG_ID}, '$member', 'Member', now(), now())
+    ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+    DO UPDATE SET updated_at = now()
+    RETURNING id
+  `;
+  const entities = await sql<{ id: number }>`
+    INSERT INTO entities (
+      name, slug, organization_id, created_by, entity_type_id, created_at, updated_at
+    ) VALUES (
+      'Claim User', ${`member-${USER_ID}`}, ${ORG_ID}, ${USER_ID}, ${types[0].id}, now(), now()
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING id
+  `;
+  let entityId = entities[0]?.id;
+  if (entityId === undefined) {
+    const existing = await sql<{ id: number }>`
+      SELECT id FROM entities
+      WHERE organization_id = ${ORG_ID} AND slug = ${`member-${USER_ID}`}
+      LIMIT 1
+    `;
+    entityId = existing[0].id;
+  }
+  await sql`
+    INSERT INTO entity_identities (
+      organization_id, entity_id, namespace, identifier, source_connector
+    ) VALUES
+      (${ORG_ID}, ${entityId}, 'auth_user_id', ${USER_ID}, 'auth:signup'),
+      (${ORG_ID}, ${entityId}, 'slack_user_id', ${`${teamId.toUpperCase()}:${SLACK_USER_ID.toUpperCase()}`}, 'auth:signup')
+    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    DO NOTHING
   `;
 }
 
@@ -51,7 +98,7 @@ function claimProvider(usersInfo: ReturnType<typeof mock>) {
     })),
     resolveActiveOrgSlug: mock(async () => null),
     resolveClaimerSlackIdentities: resolveClaimingUserSlackIdentities,
-    linkChatUserIdentity: mock(async () => {}),
+    stampSlackIdentityForUser: mock(async () => {}),
     usersInfo,
     claim: mock(async () => ({ installationId: "unused" })),
   });

--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -16,6 +16,7 @@ import { ClaimMoveBlockedError } from "../connections/connection-claim.js";
 import { slackClaimProvider } from "../connections/slack-claim.js";
 import type { SlackClaimProviderDeps } from "../connections/slack-claim.js";
 import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
+import { normalizeSlackUserId } from "@lobu/connectors/slack-identity";
 
 const TEAM = "T-CLAIM";
 
@@ -38,10 +39,10 @@ function pendingInstall(
 function makeDeps(overrides: Partial<SlackClaimProviderDeps> = {}): {
   deps: SlackClaimProviderDeps;
   claim: ReturnType<typeof mock>;
-  linkChatUserIdentity: ReturnType<typeof mock>;
+  stampSlackIdentityForUser: ReturnType<typeof mock>;
 } {
   const claim = mock(async () => ({ installationId: "slackinst-bound" }));
-  const linkChatUserIdentity = mock(async () => {});
+  const stampSlackIdentityForUser = mock(async () => {});
   const deps: SlackClaimProviderDeps = {
     resolvePending: mock(async () => pendingInstall()),
     resolveActiveOrgSlug: mock(async () => null),
@@ -49,22 +50,23 @@ function makeDeps(overrides: Partial<SlackClaimProviderDeps> = {}): {
     resolveClaimerSlackIdentities: mock(async () => [
       { teamId: TEAM, slackUserId: "U-ADMIN" },
     ]),
-    linkChatUserIdentity,
+    stampSlackIdentityForUser,
     usersInfo: mock(async () => ({ isAdmin: true, isOwner: false })),
     claim,
     ...overrides,
   };
-  return { deps, claim, linkChatUserIdentity };
+  return { deps, claim, stampSlackIdentityForUser };
 }
 
 /** The `{teamId, platformUserId}` pairs a bind linked, for order-free asserts. */
 function linkedPairs(
   linkMock: ReturnType<typeof mock>,
 ): Array<{ teamId: string | undefined; platformUserId: string }> {
-  return linkMock.mock.calls.map((c) => {
-    const opts = c[0] as { teamId?: string; platformUserId: string };
-    return { teamId: opts.teamId, platformUserId: opts.platformUserId };
-  });
+  // stampSlackIdentityForUser(userId, teamId, slackUserId) — positional.
+  return linkMock.mock.calls.map((c) => ({
+    teamId: c[1] as string | undefined,
+    platformUserId: c[2] as string,
+  }));
 }
 
 describe("slackClaimProvider.authorize", () => {
@@ -299,7 +301,7 @@ describe("slackClaimProvider.bind", () => {
  */
 describe("slackClaimProvider.bind — identity linking", () => {
   test("links every team-scoped identity the claimer signed in with", async () => {
-    const { deps, linkChatUserIdentity } = makeDeps({
+    const { deps, stampSlackIdentityForUser } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => [
         { teamId: TEAM, slackUserId: "U-ADMIN" },
         { teamId: "T-OTHER", slackUserId: "U-ELSEWHERE" },
@@ -311,18 +313,18 @@ describe("slackClaimProvider.bind — identity linking", () => {
       "user-1",
       false,
     );
-    expect(linkedPairs(linkChatUserIdentity)).toEqual([
+    expect(linkedPairs(stampSlackIdentityForUser)).toEqual([
       { teamId: TEAM, platformUserId: "U-ADMIN" },
       { teamId: "T-OTHER", platformUserId: "U-ELSEWHERE" },
     ]);
     // Every link is written for the CLAIMING user, never a third party.
-    for (const call of linkChatUserIdentity.mock.calls) {
-      expect((call[0] as { lobuUserId: string }).lobuUserId).toBe("user-1");
+    for (const call of stampSlackIdentityForUser.mock.calls) {
+      expect(call[0] as string).toBe("user-1");
     }
   });
 
   test("does not persist an unscoped identity from an account without an id_token", async () => {
-    const { deps, linkChatUserIdentity } = makeDeps({
+    const { deps, stampSlackIdentityForUser } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => [
         { teamId: "", slackUserId: "U-ADMIN" },
       ]),
@@ -333,14 +335,14 @@ describe("slackClaimProvider.bind — identity linking", () => {
       "user-1",
       false,
     );
-    expect(linkChatUserIdentity).not.toHaveBeenCalled();
+    expect(stampSlackIdentityForUser).not.toHaveBeenCalled();
   });
 
   test("does NOT link the installer's U… when a different admin claims a plain workspace", async () => {
     // The takeover case: U-ADMIN claims an install performed by U-INSTALLER on
     // a plain workspace. Linking the installer id here would hand U-ADMIN the
     // installer's identity — and Builder admin tools on that U….
-    const { deps, linkChatUserIdentity } = makeDeps({
+    const { deps, stampSlackIdentityForUser } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => [
         { teamId: TEAM, slackUserId: "U-ADMIN" },
       ]),
@@ -351,18 +353,18 @@ describe("slackClaimProvider.bind — identity linking", () => {
       "user-1",
       false,
     );
-    expect(linkedPairs(linkChatUserIdentity)).toEqual([
+    expect(linkedPairs(stampSlackIdentityForUser)).toEqual([
       { teamId: TEAM, platformUserId: "U-ADMIN" },
     ]);
     expect(
-      linkedPairs(linkChatUserIdentity).some(
+      linkedPairs(stampSlackIdentityForUser).some(
         (p) => p.platformUserId === "U-INSTALLER",
       ),
     ).toBe(false);
   });
 
   test("stamps the install team key when the claimer IS the installer (plain: same team + same U…)", async () => {
-    const { deps, linkChatUserIdentity } = makeDeps({
+    const { deps, stampSlackIdentityForUser } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => [
         { teamId: TEAM, slackUserId: "U-INSTALLER" },
       ]),
@@ -373,17 +375,17 @@ describe("slackClaimProvider.bind — identity linking", () => {
       "user-1",
       false,
     );
-    expect(linkedPairs(linkChatUserIdentity)).toContainEqual({
+    expect(linkedPairs(stampSlackIdentityForUser)).toContainEqual({
       teamId: TEAM,
       platformUserId: "U-INSTALLER",
     });
-    expect(linkChatUserIdentity).toHaveBeenCalledTimes(1);
+    expect(stampSlackIdentityForUser).toHaveBeenCalledTimes(1);
   });
 
   test("plain workspace: matching U… on a DIFFERENT team does not stamp the install key", async () => {
     // Plain-workspace `U…` ids are workspace-LOCAL, so the same U… on another
     // team is a different human. Only same-team + same-U counts.
-    const { deps, linkChatUserIdentity } = makeDeps({
+    const { deps, stampSlackIdentityForUser } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => [
         { teamId: "T-OTHER", slackUserId: "U-INSTALLER" },
       ]),
@@ -394,17 +396,17 @@ describe("slackClaimProvider.bind — identity linking", () => {
       "user-1",
       false,
     );
-    expect(linkedPairs(linkChatUserIdentity)).toEqual([
+    expect(linkedPairs(stampSlackIdentityForUser)).toEqual([
       { teamId: "T-OTHER", platformUserId: "U-INSTALLER" },
     ]);
     // No row under the INSTALL's team — that would be the collision takeover.
     expect(
-      linkedPairs(linkChatUserIdentity).some((p) => p.teamId === TEAM),
+      linkedPairs(stampSlackIdentityForUser).some((p) => p.teamId === TEAM),
     ).toBe(false);
   });
 
   test("Grid: matching U… on any team DOES stamp the install key (U is enterprise-global)", async () => {
-    const { deps, linkChatUserIdentity } = makeDeps({
+    const { deps, stampSlackIdentityForUser } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => [
         { teamId: "T-OTHER", slackUserId: "U-INSTALLER" },
       ]),
@@ -419,7 +421,7 @@ describe("slackClaimProvider.bind — identity linking", () => {
       "user-1",
       false,
     );
-    expect(linkedPairs(linkChatUserIdentity)).toContainEqual({
+    expect(linkedPairs(stampSlackIdentityForUser)).toContainEqual({
       teamId: TEAM,
       platformUserId: "U-INSTALLER",
     });
@@ -433,7 +435,7 @@ describe("slackClaimProvider.bind — identity linking", () => {
     // the claimed installer silently loses Builder admin tools. Worse, the
     // case-insensitive already-linked check would suppress the canonical
     // write, so the uppercase row never gets created either.
-    const { deps, linkChatUserIdentity } = makeDeps({
+    const { deps, stampSlackIdentityForUser } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => [
         { teamId: "t-claim", slackUserId: "u-installer" },
       ]),
@@ -444,22 +446,20 @@ describe("slackClaimProvider.bind — identity linking", () => {
       "user-1",
       false,
     );
-    const pairs = linkedPairs(linkChatUserIdentity);
-    // The canonical uppercase key MUST exist — it's what inbound events use.
-    expect(pairs).toContainEqual({
-      teamId: TEAM,
-      platformUserId: "U-INSTALLER",
-    });
-    // And no raw-case row should be persisted alongside it.
-    expect(
-      pairs.some(
-        (p) => p.teamId === "t-claim" || p.platformUserId === "u-installer",
-      ),
-    ).toBe(false);
+    // Canonicalization is `stampSlackIdentityForUser`'s job (it runs every
+    // write through `normalizeSlackUserId`), so assert the KEY that reaches the
+    // graph rather than the raw arguments — that is what an inbound event
+    // matches against.
+    const keys = linkedPairs(stampSlackIdentityForUser).map((p) =>
+      normalizeSlackUserId(p.teamId, p.platformUserId),
+    );
+    expect(keys).toContain(`${TEAM}:U-INSTALLER`);
+    // And no raw-case key survives normalization.
+    expect(keys.some((k) => k !== k?.toUpperCase())).toBe(false);
   });
 
   test("a claimer with no proven identities links nothing", async () => {
-    const { deps, linkChatUserIdentity } = makeDeps({
+    const { deps, stampSlackIdentityForUser } = makeDeps({
       resolveClaimerSlackIdentities: mock(async () => []),
     });
     await slackClaimProvider(deps).bind(
@@ -468,14 +468,14 @@ describe("slackClaimProvider.bind — identity linking", () => {
       "user-1",
       false,
     );
-    expect(linkChatUserIdentity).not.toHaveBeenCalled();
+    expect(stampSlackIdentityForUser).not.toHaveBeenCalled();
   });
 
   test("a link failure is swallowed — the claim still returns its bindingId", async () => {
     // The claim is already committed when linking runs; a link error must not
     // fail the bind the user is waiting on. Identity can be healed later.
     const { deps } = makeDeps({
-      linkChatUserIdentity: mock(async () => {
+      stampSlackIdentityForUser: mock(async () => {
         throw new Error("db down");
       }),
     });

--- a/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
@@ -260,16 +260,20 @@ describe("Slack platform bridge", () => {
         { title: "No link", url: null, isRead: true },
       ],
     }));
-    registerSlackAppHome(h.chat, connection(), {
-      publicGatewayUrl: "https://gw.example/",
-      resolveUserInbox,
-    });
+    registerSlackAppHome(
+      h.chat,
+      connection({ metadata: { botUsername: "Lobster", teamId: "T_HOME" } }),
+      {
+        publicGatewayUrl: "https://gw.example/",
+        resolveUserInbox,
+      }
+    );
     const publishHomeView = mock(async () => undefined);
     await h.open("U123", publishHomeView);
 
-    // resolveUserInbox is called with (slackUserId, teamId). The connection()
-    // helper has no metadata.teamId, so teamId falls back to '' (preview/unknown).
-    expect(resolveUserInbox).toHaveBeenCalledWith("U123", "");
+    // resolveUserInbox is called with (slackUserId, teamId) — always the
+    // connection's real workspace, never an unscoped lookup.
+    expect(resolveUserInbox).toHaveBeenCalledWith("U123", "T_HOME");
     const text = blocksText(publishHomeView.mock.calls[0]![1] as any);
     expect(text).toContain("Notifications");
     expect(text).toContain("2 unread");
@@ -295,6 +299,20 @@ describe("Slack platform bridge", () => {
     // Must be scoped to the connection's workspace — a different workspace's
     // identity row with the same platform_user_id must NOT be returned.
     expect(resolveUserInbox).toHaveBeenCalledWith("U123", "T_WORKSPACE");
+  });
+
+  test("skips the inbox lookup entirely when the connection has no team_id", async () => {
+    const h = makeHomeChat();
+    const resolveUserInbox = mock(async () => null);
+    // A connection with no workspace cannot be scoped, and Slack `U…` ids are
+    // unique per workspace — so resolve nothing rather than an unscoped inbox.
+    registerSlackAppHome(h.chat, connection(), {
+      publicGatewayUrl: "https://gw.example/",
+      resolveUserInbox,
+    });
+    const publishHomeView = mock(async () => undefined);
+    await h.open("U123", publishHomeView);
+    expect(resolveUserInbox).not.toHaveBeenCalled();
   });
 
   test("omits the notifications section when the user has no linked inbox", async () => {
@@ -330,7 +348,10 @@ describe("Slack platform bridge", () => {
     const h = makeHomeChat();
     registerSlackAppHome(
       h.chat,
-      connection({ settings: { previewMode: true } }),
+      connection({
+        metadata: { botUsername: "Lobster", teamId: "T_PREVIEW" },
+        settings: { previewMode: true },
+      }),
       {
         publicGatewayUrl: "https://gw.example",
         resolveUserInbox: mock(async () => ({

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -166,9 +166,9 @@ export function registerBuiltInCommands(
     handler: async (ctx: CommandContext) => {
       const arg = ctx.args.trim();
       const cmd = ctx.platform === "slack" ? "/lobu link" : "/link";
-      // The codeless `<agentId>` shortcut needs a `chat_user_identities` row,
-      // and only the Slack install claim writes those — so it never applies on
-      // other platforms. Don't promise it there.
+      // The codeless `<agentId>` shortcut needs a workspace-scoped Slack
+      // identity, which only Slack sign-in and the install claim write — so it
+      // never applies on other platforms. Don't promise it there.
       const agentIdHint =
         ctx.platform === "slack"
           ? " (If you connected this workspace to Lobu, `/lobu link <agentId>` works too.)"
@@ -214,7 +214,7 @@ export function registerBuiltInCommands(
         case "not_found": {
           // Not a valid code — but if we already know who this chat user is,
           // treat the arg as an agent id and re-bind directly (no fresh code
-          // needed). Identity comes only from the Slack install claim
+          // needed). Identity comes only from Slack sign-in / the install claim
           // (slack-claim.ts), never from redeeming a code: the same mapping
           // authorizes Slack approvals, so a pasted code must not mint it.
           const lobuUserId = await resolveChatUserIdentity(

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -29,6 +29,7 @@ import {
   resolveSecretValue,
 } from "../secrets/index.js";
 import { resolveAgentOptions } from "../services/platform-helpers.js";
+import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
 import { ChatIdentityInstructionProvider } from "./chat-identity-instruction-provider.js";
 import { configsEqual } from "./config-equal.js";
 import { ConversationStateStore } from "./conversation-state-store.js";
@@ -171,11 +172,10 @@ const SLACK_HOME_NOTIFICATION_LIMIT = 5;
  * The viewing Slack user's personal notification inbox for the App Home tab.
  *
  * `app_home_opened` carries no team_id, so the team_id must come from the
- * connection's own metadata. For workspace installs this is the real Slack team
- * id; for the hosted-preview connection (no OAuth, single workspace) it is the
- * empty string, which is how the preview path writes identity rows. Scoping by
- * team_id prevents a platform_user_id collision across workspaces from leaking
- * one workspace user's inbox onto another. Returns null when the user has no
+ * connection's own metadata (the caller skips this entirely for a connection
+ * without one — identity is always workspace-scoped now). Scoping by team_id
+ * prevents a platform_user_id collision across workspaces from leaking one
+ * workspace user's inbox onto another. Returns null when the user has no
  * linked identity — the home tab then shows the setup prompt instead.
  * Notifications are the user's own, so they span all their orgs; `resource_url`
  * already carries each item's org slug for the deep link.
@@ -186,13 +186,12 @@ export async function resolveSlackHomeUserInbox(
 ): Promise<SlackHomeInbox | null> {
   try {
     const db = getDb();
-    const idRows = (await db`
-      SELECT lobu_user_id FROM chat_user_identities
-      WHERE platform = 'slack' AND team_id = ${teamId} AND platform_user_id = ${slackUserId}
-      LIMIT 2
-    `) as unknown as { lobu_user_id: string }[];
-    if (idRows.length !== 1) return null;
-    const lobuUserId = idRows[0].lobu_user_id;
+    const lobuUserId = await resolveChatUserIdentity(
+      "slack",
+      teamId,
+      slackUserId,
+    );
+    if (!lobuUserId) return null;
 
     const [itemRows, unreadRows, orgRows] = await Promise.all([
       db`

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -28,6 +28,7 @@ import {
 } from "./pending-interaction-store.js";
 import { resolveChatTarget } from "./platforms/shared.js";
 import type { PlatformConnection } from "./types.js";
+import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
 
 const logger = createLogger("chat-interaction-bridge");
 
@@ -129,8 +130,8 @@ function actionEventTeamId(
 
 /**
  * Map the clicking Slack user to a Lobu member allowed to decide this run:
- * exactly ONE chat_user_identities row for (team, platform user) that joins to
- * an org member, AND that member is an admin/owner OR the run's recorded field
+ * exactly ONE workspace-scoped Slack identity for (team, platform user) that
+ * joins to an org member, AND that member is an admin/owner OR the run's recorded field
  * owner (`ownerUserId`). A non-admin member who is not the owner resolves null,
  * same as an unverified account.
  */
@@ -144,20 +145,18 @@ async function resolveSlackActionReviewer(params: {
 	if (connection.platform !== "slack") return null;
 	if (!connection.organizationId || !platformUserId || teamId == null)
 		return null;
+	const userId = await resolveChatUserIdentity("slack", teamId, platformUserId);
+	if (!userId) return null;
 	const sql = getDb();
-	const rows = await sql<{ user_id: string; role: string }>`
-    SELECT c.lobu_user_id AS user_id, m.role
-    FROM chat_user_identities c
-    JOIN "member" m
-      ON m."userId" = c.lobu_user_id
-     AND m."organizationId" = ${connection.organizationId}
-    WHERE c.platform = 'slack'
-      AND c.team_id = ${teamId}
-      AND c.platform_user_id = ${platformUserId}
+	const rows = await sql<{ role: string }>`
+    SELECT m.role
+    FROM "member" m
+    WHERE m."userId" = ${userId}
+      AND m."organizationId" = ${connection.organizationId}
     LIMIT 2
   `;
 	if (rows.length !== 1) return null;
-	const { user_id: userId, role } = rows[0];
+	const { role } = rows[0];
 	const isAdmin = role === "admin" || role === "owner";
 	const isOwner = ownerUserId != null && userId === ownerUserId;
 	if (!isAdmin && !isOwner) return null;

--- a/packages/server/src/gateway/connections/slack-claim-identities.ts
+++ b/packages/server/src/gateway/connections/slack-claim-identities.ts
@@ -4,9 +4,9 @@ import { getDb, type DbClient } from "../../db/client.js";
 
 /**
  * Resolve all of the signed-in user's Slack identities as team/user pairs.
- * The entity graph and Better Auth account are OAuth-backed sources; the direct
- * chat-user mapping is written by the one-time `/lobu link` flow. The provider
- * guard consumes these pairs before org selection, exact-team scopes ordinary
+ * Both sources are OAuth-backed: the entity graph (stamped on sign-in and by
+ * the install claim) and the Better Auth account row. The provider guard
+ * consumes these pairs before org selection, exact-team scopes ordinary
  * workspace claims, and separately restricts bare-user matches to Grid.
  */
 export async function resolveClaimingUserSlackIdentities(
@@ -57,25 +57,13 @@ export async function resolveClaimingUserSlackIdentities(
     })
     .filter((x): x is { teamId: string; slackUserId: string } => x !== null);
 
-  // `/lobu link` records a direct, immutable Slack workspace-user → Lobu-user
-  // association here. This is the canonical identity used by Slack interaction
-  // and message routing, and it may exist even when the entity graph was never
-  // populated and the linked Better Auth account predates a stored id_token.
-  // Preserve both dimensions: authorizeSlackClaim will accept this only for the
-  // pending install's exact team, then still require Slack's live admin/owner
-  // verdict for the linked U… id. A link in another workspace grants nothing.
-  const linkedRows = (await sql`
-    SELECT team_id, platform_user_id
-    FROM chat_user_identities
-    WHERE platform = 'slack' AND lobu_user_id = ${userId}
-  `) as Array<{ team_id: string; platform_user_id: string }>;
-  const fromLinkedChatUsers = linkedRows.map((row) => ({
-    teamId: row.team_id.toUpperCase(),
-    slackUserId: row.platform_user_id.toUpperCase(),
-  }));
-
+  // `fromGraph` above IS the third source that used to be read from
+  // `chat_user_identities`: sign-in stamps the same workspace-scoped
+  // `TEAM:USER` key onto the user's `$member`, so reading the table as well
+  // only ever returned rows the graph already had. `fromAccounts` still covers
+  // the account-without-a-graph-stamp case.
   const seen = new Set<string>();
-  return [...fromGraph, ...fromAccounts, ...fromLinkedChatUsers].filter((x) => {
+  return [...fromGraph, ...fromAccounts].filter((x) => {
     const key = `${x.teamId}:${x.slackUserId}`;
     if (seen.has(key)) return false;
     seen.add(key);

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -56,17 +56,16 @@ export interface SlackClaimProviderDeps {
     userId: string,
   ): Promise<Array<{ teamId: string; slackUserId: string }>>;
   /**
-   * Persist a `(platform, team_id, platform_user_id) → lobu_user_id` link. The
-   * store fails closed on re-binding an already-linked key to a DIFFERENT user
-   * (see `linkChatUserIdentity`), so a forged call cannot take over an identity.
-   * Injected so `bind`'s post-claim linking is testable without a live DB.
+   * Stamp a workspace-scoped Slack identity onto the user's `$member` in each
+   * of their orgs. Fails closed when another `$member` already holds the id, so
+   * a forged call cannot take over an identity. Injected so `bind`'s post-claim
+   * linking is testable without a live DB.
    */
-  linkChatUserIdentity(opts: {
-    platform: string;
-    teamId?: string;
-    platformUserId: string;
-    lobuUserId: string;
-  }): Promise<void>;
+  stampSlackIdentityForUser(
+    userId: string,
+    teamId: string | null | undefined,
+    slackUserId: string,
+  ): Promise<void>;
   /** `users.info` admin/owner flags for the claimer. */
   usersInfo: SlackWebApi["usersInfo"];
   /**
@@ -180,26 +179,22 @@ export function slackClaimProvider(
         // later event team ids that match the install row still resolve.
         try {
           const identities = await deps.resolveClaimerSlackIdentities(userId);
-          // Persist only identities with a proven team scope. Older Better Auth
+          // Stamp only identities with a proven team scope. Older Better Auth
           // accounts without an id_token resolve with an empty team; their bare
           // user proof is useful for Grid installer matching below but must not
-          // create an unscoped chat identity.
+          // create an unscoped identity — two workspaces can share a `U…`.
           //
-          // Keys are CANONICALIZED to uppercase. The entity-graph source yields
-          // the raw `team:user` identifier, and `resolveChatUserIdentity` is an
-          // exact SQL match with no folding — a row stored as `t-claim/u-…`
-          // could never serve an inbound Slack event carrying `T-CLAIM/U-…`,
-          // so the claimer would silently lose Builder admin tools. Writing
-          // canonical keys also keeps this loop consistent with the
-          // case-insensitive installer checks below.
+          // Most of these are already in the graph (sign-in stamps them). This
+          // loop is idempotent and heals the case where a Better Auth account
+          // exists but the sign-in stamp never landed — e.g. the user had no
+          // `$member` yet when they first signed in.
           for (const id of identities) {
             if (!id.teamId) continue;
-            await deps.linkChatUserIdentity({
-              platform: "slack",
-              teamId: id.teamId.toUpperCase(),
-              platformUserId: id.slackUserId.toUpperCase(),
-              lobuUserId: userId,
-            });
+            await deps.stampSlackIdentityForUser(
+              userId,
+              id.teamId,
+              id.slackUserId,
+            );
           }
           // Ensure the install's tenant key (T… or Grid E…) is linked ONLY when
           // the claimer is proven to be the installer, without rewriting the
@@ -227,12 +222,7 @@ export function slackClaimProvider(
             !installIdentityAlreadyLinked &&
             pending.installerUserId
           ) {
-            await deps.linkChatUserIdentity({
-              platform: "slack",
-              teamId: installTeam,
-              platformUserId: installer,
-              lobuUserId: userId,
-            });
+            await deps.stampSlackIdentityForUser(userId, installTeam, installer);
           }
         } catch (err) {
           // Swallow — claim already committed; identity can be healed later.

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -404,17 +404,20 @@ async function buildSlackHomeBlocks(
     { type: "divider" },
   ];
 
-  // Personal notifications, for users who've linked a Lobu identity (both
-  // preview and BYO connections). Scoped by teamId to prevent cross-workspace
-  // leaks when platform_user_id collides across Slack workspaces. Preview
-  // connections write identity rows with team_id='', so we pass '' there.
+  // Personal notifications, for users who've linked a Lobu identity. Scoped by
+  // teamId to prevent cross-workspace leaks when platform_user_id collides
+  // across Slack workspaces — Slack `U…` ids are unique per workspace, not
+  // globally. A connection with no team cannot be scoped, so it resolves no
+  // inbox rather than an unscoped one. (This used to fall back to `''`, which
+  // matched the rows preview-code redemption wrote with an empty team; that
+  // writer is gone and identity is now always workspace-scoped.)
   const teamId =
     typeof connection.metadata?.teamId === "string"
       ? connection.metadata.teamId
-      : "";
+      : null;
   let inbox: SlackHomeInbox | null = null;
   try {
-    inbox = (await deps.resolveUserInbox?.(userId, teamId)) ?? null;
+    inbox = teamId ? ((await deps.resolveUserInbox?.(userId, teamId)) ?? null) : null;
   } catch (error) {
     logger.warn(
       { error, userId },

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -202,8 +202,9 @@ interface SlackAppHomeDeps {
   /**
    * Resolves the viewing Slack user's personal notification inbox, or null when
    * they have no linked Lobu identity. `teamId` scopes the lookup to the
-   * correct Slack workspace (empty string for hosted-preview connections, which
-   * write identity rows with team_id=''). Read-only; failures degrade to no inbox.
+   * correct Slack workspace and is always a real workspace id — a connection
+   * without one is not looked up at all, since a Slack `U…` is only unique
+   * within a workspace. Read-only; failures degrade to no inbox.
    */
   resolveUserInbox?: (
     slackUserId: string,

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -120,9 +120,9 @@ export async function resolveBuilderAdminTools(args: {
   if (!args.agentId || !args.organizationId || !args.userId) return undefined;
   try {
     // Map a platform user id to its linked Lobu user before the member join.
-    // resolveChatUserIdentity is workspace-scoped (keyed on the PK
-    // platform+team_id+platform_user_id) and returns null when the id isn't
-    // linked, so a grant is only ever made for a linked, known user.
+    // resolveChatUserIdentity is workspace-scoped (the identity key is the
+    // composite TEAM:USER) and returns null when the id isn't linked, so a
+    // grant is only ever made for a linked, known user.
     const platform = args.platform;
     const isChatPlatform =
       platform != null && platform !== "api" && platform !== "";

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -58,7 +58,6 @@ import { slackClaimProvider } from "./gateway/connections/slack-claim";
 import { resolveClaimingUserSlackIdentities } from "./gateway/connections/slack-claim-identities";
 import { autoLinkBuilderAndWelcome } from "./gateway/connections/slack-claim-onboarding";
 import { createSlackWebApi } from "./gateway/connections/slack-web";
-import { linkChatUserIdentity } from "./lobu/stores/chat-identity";
 import {
 	getMaxReservedLocks,
 	getReservedLockCount,
@@ -948,6 +947,7 @@ app.post("/api/workers/complete-action", completeActionRun);
 // Bridge that lets connector-worker fleets dispatch chrome connector actions
 // against a paired Owletto extension. See dispatch-chrome-action.ts.
 import { dispatchChromeAction } from "./worker-api/dispatch-chrome-action";
+import { stampSlackIdentityForUser } from "./auth/subject-identities";
 
 app.post("/api/workers/dispatch-chrome-action", dispatchChromeAction);
 app.post("/api/workers/complete-embeddings", completeEmbeddings);
@@ -2510,7 +2510,7 @@ function buildSlackClaimProvider(): ClaimProvider {
 				: null;
 		},
 		resolveClaimerSlackIdentities: resolveClaimingUserSlackIdentities,
-		linkChatUserIdentity,
+		stampSlackIdentityForUser,
 		usersInfo: (botToken, uid) => createSlackWebApi().usersInfo(botToken, uid),
 		claim: async (pending, organizationId, confirmMove) => {
 			const core = getLobuCoreServices();

--- a/packages/server/src/lobu/stores/chat-identity.ts
+++ b/packages/server/src/lobu/stores/chat-identity.ts
@@ -97,7 +97,7 @@ export async function resolveSlackUserIdForUser(
 	// LIKE metacharacters so the prefix matches literally.
 	const likePrefix = prefix.replace(/([\\%_])/g, "\\$1");
 	const rows = await getDb()<{ identifier: string }>`
-    SELECT slack_ei.identifier
+    SELECT DISTINCT slack_ei.identifier
     FROM entity_identities auth_ei
     JOIN entities e
       ON e.id = auth_ei.entity_id
@@ -113,9 +113,14 @@ export async function resolveSlackUserIdForUser(
       AND auth_ei.source_connector = 'auth:signup'
       AND auth_ei.deleted_at IS NULL
       AND slack_ei.identifier LIKE ${`${likePrefix}%`}
-    LIMIT 1
+    LIMIT 2
   `;
-	const identifier = rows[0]?.identifier;
-	if (!identifier) return null;
-	return identifier.slice(prefix.length) || null;
+	// FAILS CLOSED on ambiguity, exactly like `resolveChatUserIdentity`. The
+	// stamps are org-scoped rows and are never deleted when superseded, so a user
+	// who joins a second org, or whose Slack account id changes inside one
+	// workspace, can hold two DISTINCT ids under the same `TEAM:` prefix. The
+	// caller uses this as a DM recipient — picking arbitrarily sends the owner DM
+	// to a stale Slack user and loses it silently.
+	if (rows.length !== 1) return null;
+	return rows[0].identifier.slice(prefix.length) || null;
 }

--- a/packages/server/src/lobu/stores/chat-identity.ts
+++ b/packages/server/src/lobu/stores/chat-identity.ts
@@ -1,14 +1,24 @@
+import { SLACK_IDENTITY, normalizeSlackUserId } from "@lobu/connectors/slack-identity";
 import { getDb } from "../../db/client.js";
 
 /**
- * Cross-connector chat-identity mapping: `(platform, team_id, platform_user_id)
- * → lobu_user_id`.
+ * Resolve a chat-platform user to the Lobu `user` they are, using the entity
+ * graph as the source of truth.
  *
- * The `chat_user_identities` table is platform-agnostic — Slack, Telegram, or a
- * custom connector all link the same way. This module is the generic seam for
- * resolving and linking those identities so callers don't reach into any one
- * connector's module (e.g. `preview/slack`). It maps a PLATFORM user id (what a
- * connector run carries) to the canonical Lobu `user` it's linked to.
+ * This used to read a dedicated `chat_user_identities` table. It no longer
+ * does: the same fact is already recorded, better, by `persistLoginSlackIdentity`
+ * (auth/subject-identities.ts) on every Slack OAuth sign-in and token refresh.
+ * That writer stamps `entity_identities(namespace = 'slack_user_id')` with a
+ * WORKSPACE-SCOPED `TEAM:USER` key onto the signer's `$member` in each org they
+ * belong to, resolving the team from the id_token claim with a userinfo
+ * fallback — and refuses to write anything when it cannot establish the team.
+ *
+ * Workspace scoping is not optional here. Two Slack workspaces can legitimately
+ * contain the same bare `U…`, so a lookup keyed on the user id alone would map
+ * one workspace's person onto another workspace's Lobu account. Callers use this
+ * to grant privilege (approval clicks, builder-admin tools, owner re-bind), so
+ * that would be a mis-grant, not merely a wrong answer. The composite
+ * `TEAM:USER` identifier carries the scope in the key itself.
  *
  * NOTE: this is a 1:1 platform-identity → user link, NOT cross-platform identity
  * CONSOLIDATION (one human's Slack + Telegram + custom identities merged to one
@@ -19,13 +29,15 @@ import { getDb } from "../../db/client.js";
 /**
  * The Lobu user id a chat-platform user has linked to, or null.
  *
- * Scoped by workspace: `platform_user_id` is only unique WITHIN a workspace, so
- * the same id can map to different Lobu users across workspaces. This query
- * filters on all three columns of the `(platform, team_id, platform_user_id)`
- * primary key, so it returns at most one row — the workspace scoping is what
- * makes the lookup unambiguous. Callers use this to grant privilege (builder
- * admin tools, owner re-bind), so an unlinked id must resolve to null, never to
- * the wrong user.
+ * Slack-only by construction: `slack_user_id` is the only chat namespace any
+ * writer populates. Every other platform resolves null, which is the correct
+ * fail-closed answer — an unlinked id must never resolve to the wrong user.
+ *
+ * FAILS CLOSED on ambiguity. The identity rows are org-scoped, so one human in
+ * several orgs yields several rows; they normally all carry the same
+ * `auth_user_id` because the same authenticated human signed in. If two
+ * DISTINCT Lobu users are reachable from one workspace principal the graph is
+ * inconsistent, and this returns null rather than picking one.
  *
  * Callers that may hold a Grid enterprise id (`E…`) OR a workspace id (`T…`)
  * should try both keys themselves (e.g. message team + connection
@@ -36,41 +48,74 @@ export async function resolveChatUserIdentity(
 	teamId: string | undefined,
 	platformUserId: string,
 ): Promise<string | null> {
+	if (platform !== "slack") return null;
+	// Same normalizer the writer uses, so the key matches byte-for-byte. Returns
+	// null when the team is missing/malformed — never a bare, unscoped id.
+	const combined = normalizeSlackUserId(teamId, platformUserId);
+	if (!combined) return null;
+
 	const rows = await getDb()<{ lobu_user_id: string }>`
-    SELECT lobu_user_id FROM chat_user_identities
-    WHERE platform = ${platform} AND team_id = ${teamId ?? ""} AND platform_user_id = ${platformUserId}
-    LIMIT 1
+    SELECT DISTINCT auth_ei.identifier AS lobu_user_id
+    FROM entity_identities slack_ei
+    JOIN entities e
+      ON e.id = slack_ei.entity_id
+     AND e.organization_id = slack_ei.organization_id
+     AND e.deleted_at IS NULL
+    JOIN entity_identities auth_ei
+      ON auth_ei.organization_id = slack_ei.organization_id
+     AND auth_ei.entity_id = slack_ei.entity_id
+     AND auth_ei.namespace = 'auth_user_id'
+     AND auth_ei.source_connector = 'auth:signup'
+     AND auth_ei.deleted_at IS NULL
+    WHERE slack_ei.namespace = ${SLACK_IDENTITY.USER_ID}
+      AND slack_ei.identifier = ${combined}
+      AND slack_ei.deleted_at IS NULL
+    LIMIT 2
   `;
-	return rows[0]?.lobu_user_id ?? null;
+	if (rows.length !== 1) return null;
+	return rows[0].lobu_user_id;
 }
 
 /**
- * Link a chat-platform identity to a Lobu user. Generic across connectors.
+ * The REVERSE lookup: the workspace-scoped Slack user id a Lobu user has in
+ * `teamId`, or null. Used to address an owner directly in a workspace one of
+ * the org's bot connections lives in.
  *
- * Safety guard: an already-linked `(platform, team_id, platform_user_id)` is
- * NEVER silently re-bound to a DIFFERENT Lobu user by a later call — the
- * `ON CONFLICT … WHERE lobu_user_id = EXCLUDED.lobu_user_id` predicate only
- * touches `updated_at` when the mapping is unchanged, so a stale/malicious
- * re-link is a no-op rather than an account takeover. Re-binding to a new user
- * is a deliberate operation that must delete the old row first.
- *
- * Pass a transaction handle as `sql` to link atomically with a surrounding
- * write; omit it to run on the pooled connection.
+ * Same source of truth as `resolveChatUserIdentity`, walked the other way:
+ * from the `$member` carrying this `auth_user_id` to the `slack_user_id`
+ * stamped on it. The prefix match is on the composite `TEAM:USER` key, so it
+ * stays workspace-scoped and index-usable (no leading wildcard).
  */
-export async function linkChatUserIdentity(
-	opts: {
-		platform: string;
-		teamId?: string;
-		platformUserId: string;
-		lobuUserId: string;
-	},
-	sql: ReturnType<typeof getDb> = getDb(),
-): Promise<void> {
-	await sql`
-    INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
-    VALUES (${opts.platform}, ${opts.teamId ?? ""}, ${opts.platformUserId}, ${opts.lobuUserId}, now())
-    ON CONFLICT (platform, team_id, platform_user_id)
-      DO UPDATE SET updated_at = now()
-      WHERE chat_user_identities.lobu_user_id = EXCLUDED.lobu_user_id
+export async function resolveSlackUserIdForUser(
+	userId: string,
+	teamId: string,
+): Promise<string | null> {
+	const prefix = `${teamId.toUpperCase()}:`;
+	// `_` is a LIKE wildcard AND a character `normalizeSlackUserId` accepts in a
+	// team id, so an unescaped pattern like `T_ACME:%` would also match
+	// `TXACME:…` — returning a user id from the wrong workspace. Escape all
+	// LIKE metacharacters so the prefix matches literally.
+	const likePrefix = prefix.replace(/([\\%_])/g, "\\$1");
+	const rows = await getDb()<{ identifier: string }>`
+    SELECT slack_ei.identifier
+    FROM entity_identities auth_ei
+    JOIN entities e
+      ON e.id = auth_ei.entity_id
+     AND e.organization_id = auth_ei.organization_id
+     AND e.deleted_at IS NULL
+    JOIN entity_identities slack_ei
+      ON slack_ei.organization_id = auth_ei.organization_id
+     AND slack_ei.entity_id = auth_ei.entity_id
+     AND slack_ei.namespace = ${SLACK_IDENTITY.USER_ID}
+     AND slack_ei.deleted_at IS NULL
+    WHERE auth_ei.namespace = 'auth_user_id'
+      AND auth_ei.identifier = ${userId}
+      AND auth_ei.source_connector = 'auth:signup'
+      AND auth_ei.deleted_at IS NULL
+      AND slack_ei.identifier LIKE ${`${likePrefix}%`}
+    LIMIT 1
   `;
+	const identifier = rows[0]?.identifier;
+	if (!identifier) return null;
+	return identifier.slice(prefix.length) || null;
 }

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -3,6 +3,7 @@ import { getDb, pgTextArray } from "../db/client";
 import { resolveBoundChannelRows } from "../gateway/channels/bound-channels";
 import { getChatInstanceManager, isLobuGatewayRunning } from "../lobu/gateway";
 import logger from "../utils/logger";
+import { resolveSlackUserIdForUser } from "../lobu/stores/chat-identity.js";
 
 interface CreateNotificationParams {
 	organizationId: string;
@@ -27,7 +28,7 @@ interface CreateNotificationParams {
 	/**
 	 * Lobu user who owns the change under review (field-change approvals).
 	 * When set, bot delivery tries the owner's Slack DM FIRST — resolved via
-	 * chat_user_identities against a connected workspace — and only falls back
+	 * the owner's workspace-scoped Slack identity — and only falls back
 	 * to the configured-target/org-wide channel chain when the owner has no
 	 * Slack identity or the DM fails. In-app inbox targeting is unaffected.
 	 */
@@ -158,8 +159,8 @@ export async function resolveBotDeliveryTargets(
 /**
  * Owner-routed delivery target: the Slack identity of `ownerUserId` in a
  * workspace one of the org's bot connections lives in. Reverse-looks-up
- * chat_user_identities (platform='slack', team matching the connection's
- * binding team) per candidate connection, most-recently-bound first via
+ * the workspace-scoped Slack identity on the owner's `$member` (team matching
+ * the connection's binding team) per candidate connection, most-recently-bound first via
  * resolveBotDeliveryTargets order. Null when the owner has no Slack identity in
  * any connected workspace — the caller falls back to channel delivery.
  * Exported for testing the tier-selection logic against a real DB.
@@ -173,25 +174,18 @@ export async function resolveOwnerDmTarget(
 		organizationId,
 		connectionId ?? null,
 	);
-	const sql = getDb();
 	const seen = new Set<string>();
 	for (const target of targets) {
 		if (target.platform !== "slack" || target.teamId == null) continue;
 		const key = `${target.connectionId}:${target.teamId}`;
 		if (seen.has(key)) continue;
 		seen.add(key);
-		const rows = await sql<{ platform_user_id: string }>`
-      SELECT platform_user_id FROM chat_user_identities
-      WHERE platform = 'slack'
-        AND team_id = ${target.teamId}
-        AND lobu_user_id = ${ownerUserId}
-      LIMIT 1
-    `;
-		if (rows[0]?.platform_user_id) {
-			return {
-				connectionId: target.connectionId,
-				slackUserId: rows[0].platform_user_id,
-			};
+		const slackUserId = await resolveSlackUserIdForUser(
+			ownerUserId,
+			target.teamId,
+		);
+		if (slackUserId) {
+			return { connectionId: target.connectionId, slackUserId };
 		}
 	}
 	return null;

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -9,14 +9,12 @@ import {
   createTestOrganization,
   createTestUser,
   insertChatConnectionRow,
+  linkSlackIdentityInGraph,
 } from "../../__tests__/setup/test-fixtures.js";
 import { getDb } from "../../db/client.js";
 import { registerBuiltInCommands } from "../../gateway/commands/built-in-commands.js";
 import type { Env } from "../../index";
-import {
-  linkChatUserIdentity,
-  resolveChatUserIdentity,
-} from "../../lobu/stores/chat-identity.js";
+import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
 import {
   bindChatToAgentForOwner,
   bindChatToPreviewAgent,
@@ -146,7 +144,6 @@ describe("Slack Preview claims + channel Behaviors", () => {
   beforeEach(async () => {
     const sql = getDb();
     await clearChatBehaviors();
-    await sql`DELETE FROM chat_user_identities`;
     await sql`DELETE FROM oauth_states WHERE scope = 'slack-preview-claim'`;
   });
 
@@ -590,7 +587,6 @@ describe("chat-user identity + codeless re-link by agent id", () => {
   beforeEach(async () => {
     const sql = getDb();
     await clearChatBehaviors();
-    await sql`DELETE FROM chat_user_identities`;
     await sql`DELETE FROM oauth_states WHERE scope = 'slack-preview-claim'`;
   });
 
@@ -616,15 +612,13 @@ describe("chat-user identity + codeless re-link by agent id", () => {
     const bound = await mintAndConsume(ID_AGENT, "D900");
     expect(bound).toMatchObject({ status: "bound", agentId: ID_AGENT });
 
-    // A pasted code does not prove the redeemer is the minter, and the
-    // identity row authorizes Slack approval clicks and the in-chat
-    // builder-admin grant — so redemption must record none.
-    const rows = await getDb()`
-      SELECT lobu_user_id FROM chat_user_identities
-      WHERE platform = 'slack' AND team_id = ${ID_TEAM} AND platform_user_id = ${SLACK_USER}
-    `;
-    expect(rows).toHaveLength(0);
-    expect(await resolveChatUserIdentity("slack", ID_TEAM, SLACK_USER)).toBeNull();
+    // A pasted code does not prove the redeemer is the minter, and chat
+    // identity authorizes Slack approval clicks and the in-chat builder-admin
+    // grant — so redemption must establish none. Identity comes only from
+    // Slack sign-in / the install claim, neither of which ran here.
+    expect(
+      await resolveChatUserIdentity("slack", ID_TEAM, SLACK_USER),
+    ).toBeNull();
   });
 
   test("bindChatToAgentForOwner re-binds to an agent in the user's org, refuses others", async () => {
@@ -659,15 +653,15 @@ describe("chat-user identity + codeless re-link by agent id", () => {
   });
 
   test("/lobu link <agentId> re-binds without a code once the user has linked here", async () => {
-    // The identity must come from a real Slack install claim, NOT from
-    // redeeming a preview code — redemption deliberately records none. Seed it
-    // the way the install-claim path does so the codeless shortcut is covered.
+    // The identity must come from a real Slack sign-in / install claim, NOT
+    // from redeeming a preview code — redemption deliberately records none.
+    // Seed the graph the way those paths do so the shortcut stays covered.
     await mintAndConsume(ID_AGENT, "D903");
-    await linkChatUserIdentity({
-      platform: "slack",
+    await linkSlackIdentityInGraph({
+      organizationId: idOrgId,
+      userId: lobuUserId,
       teamId: ID_TEAM,
-      platformUserId: SLACK_USER,
-      lobuUserId,
+      slackUserId: SLACK_USER,
     });
 
     const registry = new CommandRegistry();

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -1,4 +1,8 @@
 import { CommandRegistry } from "@lobu/core";
+import {
+  SLACK_IDENTITY,
+  normalizeSlackUserId,
+} from "@lobu/connectors/slack-identity";
 import type { Context } from "hono";
 import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { cleanupTestDatabase } from "../../__tests__/setup/test-db.js";
@@ -616,6 +620,19 @@ describe("chat-user identity + codeless re-link by agent id", () => {
     // identity authorizes Slack approval clicks and the in-chat builder-admin
     // grant — so redemption must establish none. Identity comes only from
     // Slack sign-in / the install claim, neither of which ran here.
+    //
+    // Assert on the ROW, not just the resolver: `resolveChatUserIdentity` also
+    // returns null for an identity with no live `auth_user_id` link, so it
+    // would stay green even if redemption wrote an orphan `slack_user_id`.
+    const stamped = await getDb()<{ n: number }>`
+      SELECT count(*)::int AS n
+      FROM entity_identities
+      WHERE organization_id = ${idOrgId}
+        AND namespace = ${SLACK_IDENTITY.USER_ID}
+        AND identifier = ${normalizeSlackUserId(ID_TEAM, SLACK_USER)}
+        AND deleted_at IS NULL
+    `;
+    expect(stamped[0].n).toBe(0);
     expect(
       await resolveChatUserIdentity("slack", ID_TEAM, SLACK_USER),
     ).toBeNull();

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -367,7 +367,7 @@ export async function consumePreviewClaim(args: {
 
 		// Redemption binds the chat and NOTHING ELSE — deliberately no
 		// chat-platform → Lobu-user identity. A claim code is paste-able and does
-		// not prove the redeemer is the minter, while a `chat_user_identities`
+		// not prove the redeemer is the minter, while a chat-user identity
 		// row authorizes Slack approval clicks (`interaction-bridge`
 		// resolveSlackActionReviewer) and the in-chat builder-admin grant.
 		// Identity is established only by the Slack install claim


### PR DESCRIPTION
## What

Deletes `chat_user_identities`. Its job — "which Lobu user is this Slack workspace user?" — moves to
the entity graph, which already records the same fact from an OAuth-verified source.

## Why not better-auth `account` (the obvious answer, and wrong)

`chat_user_identities` is keyed `(platform, team_id, platform_user_id)`. `account` is unique on
`(providerId, accountId)` — **no team**. Slack `U…` ids are unique *within* a workspace, not
globally, so a lookup keyed on `accountId` alone maps one workspace's user onto another's. That is a
mis-grant on the approval path, and the codebase already says so out loud:

> `chat-instance-manager.ts:177` — `team_id` prevents a platform_user_id collision across workspaces
> from leaking one workspace user's inbox onto another

## The actual replacement

`entity_identities(namespace = 'slack_user_id')` stores the composite **`TEAM:USER`** key, so
workspace scoping lives in the key instead of a column. `persistLoginSlackIdentity` already writes it
on **every** Slack OAuth sign-in and token refresh, for every org the user has a `$member` in,
resolving the team from the id_token claim with a userinfo fallback — and refusing to write a bare
id, for exactly this reason:

> `null` = missing team id or malformed → NEVER write a bare, un-scoped id (two workspaces can share
> a `U…`)

All six readers now share one resolver that **fails closed** when a principal reaches more than one
distinct auth user: Slack approval authz, App Home inbox, owner-DM routing, builder-admin grant,
codeless re-bind, install claiming.

### The one write OAuth cannot supply

On Slack **Grid** the install row is keyed by the ENTERPRISE id (`E…`) while a sign-in only ever
proves the WORKSPACE id (`T…`), and inbound events carry either. That write is redirected into the
graph via a new `stampSlackIdentityForUser` rather than dropped — losing it would silently strip
Builder admin tools from Grid installers. Canonicalization moves into the stamper, so exactly one
place normalizes.

### Removed as dead, not migrated

The empty-`team_id` App Home fallback. `slack-platform-bridge.ts` passed `''` *solely* to match rows
preview-code redemption wrote with an empty team; that writer is gone, so an unscoped lookup is now
impossible rather than merely unused.

## A real bug this found

`resolveSlackUserIdForUser` matches the team prefix with `LIKE`. `_` is both a LIKE wildcard **and** a
character `normalizeSlackUserId` accepts in a team id — so an unescaped `T_ACME:%` also matches
`TXACME:…`, returning a Slack user id from the wrong workspace. Escaped, with a reproducer.

**RED** (escape removed):
```
× matches the team prefix literally — `_` in a team id is not a LIKE wildcard
AssertionError: expected 'U-ROAMER' to be null
      Tests  1 failed | 5 passed (6)
```
**GREEN** (escape restored): 6/6.

## Testing

`make pre-pr` clean.

```
 vitest   Test Files  45 passed (45)      Tests  356 passed (356)
 bun      37 pass, 0 fail, 98 expect() calls across 6 files
```

Test seeding moved to a shared `linkSlackIdentityInGraph` fixture that calls the real
`provisionMemberAndCoreIdentities` — a hand-rolled INSERT skipping `source_connector='auth:signup'`
would have passed here while production failed. The cross-workspace collision test and the Grid
enterprise-key test both still pass against the graph; those are the invariants that matter.

## Verification still owed (prod-only)

Whether any live user resolved through `chat_user_identities` but has no graph stamp. Such a user
self-heals on their next Slack sign-in (the writer fires on `account.update.after` too), but until
then they would lose Builder admin tools / approval rights. Worth a row count before rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack identities now resolve consistently across workspaces and organizations.
  * Slack sign-in and installation claims can securely associate workspace identities with members.
  * Inbox, notifications, approvals, and authorization now use workspace-scoped identity matching.

* **Bug Fixes**
  * Prevented unscoped or similarly prefixed workspace identities from matching incorrectly.
  * Improved handling when workspace identifiers are missing or ambiguous.

* **Refactor**
  * Consolidated Slack identity storage and resolution into the shared identity system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->