### PR TITLE
fix(server): type keying_config and split entity display name from its stable key

### DIFF
--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -115,9 +115,11 @@ export type BehaviorSource = Static<typeof BehaviorSourceSchema>;
  * Setting this is what binds a Behavior to an entity type, and that binding
  * drives THREE things at once: the extraction schema handed to the agent, the
  * `complete_window` validation of `extracted_data`, and the promotion of each
- * keyed row into an entity. A field name that does not match here fails silently
- * — the derive returns null and all three are skipped — so the shape is declared
- * rather than left as free-form JSON.
+ * keyed row into an entity. Under a free-form JSON contract a mistyped field
+ * name failed silently — an unresolvable entity_path or entity_type skips
+ * schema derivation and promotion, and a wrong key_fields name yields empty
+ * keys and promotes nothing — so the shape is declared rather than left as
+ * free-form JSON.
  */
 export const BehaviorKeyingConfigSchema = Type.Object({
   entity_path: Type.String({
@@ -139,7 +141,7 @@ export const BehaviorKeyingConfigSchema = Type.Object({
     Type.String({
       minLength: 1,
       description:
-        "Entity-type slug the keyed rows are promoted into. Must match the stored slug EXACTLY — entity-type creation slugifies (`social_signal` becomes `social-signal`), and a near-miss silently disables validation and promotion. Omit to derive a slug from the last segment of entity_path.",
+        "Entity-type slug the keyed rows are promoted into. Pass the STORED slug — entity-type creation slugifies (`social_signal` is stored as `social-signal`); a slug that resolves to no type is rejected at create with 422. Omit to derive one from the last segment of entity_path (slugified and singularized: `analysis.results.problems` → `problem`); a derived slug is not checked at create, and if it resolves to no type at run time, promotion is silently skipped.",
     })
   ),
   name_fields: Type.Optional(
@@ -416,10 +418,19 @@ export const ManageBehaviorsSchema = Type.Object(
       })
     ),
     keying_config: Type.Optional(
-      Type.Composite([BehaviorKeyingConfigSchema], {
-        description:
-          "[create/create_version] Binds extracted rows to an entity type: computes a stable key per row, validates extracted_data against that type's metadata_schema, and promotes each row into an entity.",
-      })
+      Type.Union(
+        [
+          // Callers may pass a pre-serialized JSON string (parsed by
+          // parseJsonInput, then shape-checked against
+          // BehaviorKeyingConfigSchema) or the object directly.
+          Type.String(),
+          BehaviorKeyingConfigSchema,
+        ],
+        {
+          description:
+            "[create/create_version] Binds extracted rows to an entity type: computes a stable key per row, validates extracted_data against that type's metadata_schema, and promotes each row into an entity.",
+        }
+      )
     ),
     classifiers: Type.Optional(
       Type.Union(

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -109,6 +109,49 @@ export const BehaviorSourceSchema = Type.Object({
 });
 export type BehaviorSource = Static<typeof BehaviorSourceSchema>;
 
+/**
+ * Stable-key + promotion config for a Behavior's extracted rows.
+ *
+ * Setting this is what binds a Behavior to an entity type, and that binding
+ * drives THREE things at once: the extraction schema handed to the agent, the
+ * `complete_window` validation of `extracted_data`, and the promotion of each
+ * keyed row into an entity. A field name that does not match here fails silently
+ * — the derive returns null and all three are skipped — so the shape is declared
+ * rather than left as free-form JSON.
+ */
+export const BehaviorKeyingConfigSchema = Type.Object({
+  entity_path: Type.String({
+    minLength: 1,
+    description:
+      "Dotted path to the array of extracted rows inside extracted_data (e.g. `items`, `analysis.results.problems`).",
+  }),
+  key_fields: Type.Array(Type.String({ minLength: 1 }), {
+    minItems: 1,
+    description:
+      "Fields whose values compose each row's stable key. Pick values that do NOT change between runs — the key is the entity's identity across windows.",
+  }),
+  key_output_field: Type.String({
+    minLength: 1,
+    description:
+      "Field the computed stable key is stamped onto. The agent must not emit it; it is excluded from the entity's synced fields.",
+  }),
+  entity_type: Type.Optional(
+    Type.String({
+      minLength: 1,
+      description:
+        "Entity-type slug the keyed rows are promoted into. Must match the stored slug EXACTLY — entity-type creation slugifies (`social_signal` becomes `social-signal`), and a near-miss silently disables validation and promotion. Omit to derive a slug from the last segment of entity_path.",
+    })
+  ),
+  name_fields: Type.Optional(
+    Type.Array(Type.String({ minLength: 1 }), {
+      minItems: 1,
+      description:
+        "Fields used to build the entity's human-readable display name. Defaults to key_fields, which is usually wrong when the key is an opaque id — identity wants a value that never changes, a name wants one a person can read.",
+    })
+  ),
+});
+export type BehaviorKeyingConfig = Static<typeof BehaviorKeyingConfigSchema>;
+
 export const BehaviorExecutionConfigSchema = Type.Object(
   {
     timeout_seconds: Type.Optional(
@@ -373,9 +416,9 @@ export const ManageBehaviorsSchema = Type.Object(
       })
     ),
     keying_config: Type.Optional(
-      Type.Any({
+      Type.Composite([BehaviorKeyingConfigSchema], {
         description:
-          "[create/create_version] Config for stable key generation across windows.",
+          "[create/create_version] Binds extracted rows to an entity type: computes a stable key per row, validates extracted_data against that type's metadata_schema, and promotes each row into an entity.",
       })
     ),
     classifiers: Type.Optional(

--- a/packages/server/src/__tests__/unit/keying-config-shape.test.ts
+++ b/packages/server/src/__tests__/unit/keying-config-shape.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { assertKeyingConfigShape } from '../../tools/admin/manage_behaviors/shared';
+import {
+  assertKeyingConfigShape,
+  parseJsonInput,
+} from '../../tools/admin/manage_behaviors/shared';
 
 const valid = {
   entity_path: 'items',
@@ -46,6 +49,22 @@ describe('assertKeyingConfigShape', () => {
     ).toThrow(/Invalid keying_config/);
   });
 
+  // The failure this contract exists to stop: a misspelled OPTIONAL field
+  // satisfies every required field, so the schema alone accepts it and the
+  // caller silently loses the binding.
+  it('rejects a misspelled optional field alongside valid required ones', () => {
+    expect(() => assertKeyingConfigShape({ ...valid, nameFields: ['author'] })).toThrow(
+      /unknown field\(s\) nameFields/
+    );
+    expect(() => assertKeyingConfigShape({ ...valid, entityType: 'social-signal' })).toThrow(
+      /unknown field\(s\) entityType/
+    );
+  });
+
+  it('lists the allowed fields when it rejects an unknown one', () => {
+    expect(() => assertKeyingConfigShape({ ...valid, nope: 1 })).toThrow(/Allowed: .*name_fields/);
+  });
+
   it('rejects an empty key_fields array', () => {
     expect(() => assertKeyingConfigShape({ ...valid, key_fields: [] })).toThrow(
       /Invalid keying_config/
@@ -56,6 +75,33 @@ describe('assertKeyingConfigShape', () => {
     expect(() => assertKeyingConfigShape({ ...valid, entity_path: 42 })).toThrow(
       /Invalid keying_config/
     );
+  });
+
+  // The wire contract accepts a pre-serialized string, so the same guard has to
+  // hold after parseJsonInput — that path is what bypassed the tool schema.
+  describe('via the serialized-string wire form', () => {
+    const check = (raw: string) =>
+      assertKeyingConfigShape(parseJsonInput(raw, 'keying_config'));
+
+    it('accepts a valid serialized config', () => {
+      expect(() => check(JSON.stringify({ ...valid, name_fields: ['author'] }))).not.toThrow();
+    });
+
+    it('rejects a misspelled optional field', () => {
+      expect(() => check(JSON.stringify({ ...valid, nameFields: ['author'] }))).toThrow(
+        /unknown field\(s\) nameFields/
+      );
+    });
+
+    it('rejects a missing required field', () => {
+      expect(() => check(JSON.stringify({ entity_path: 'items' }))).toThrow(
+        /Invalid keying_config/
+      );
+    });
+
+    it('rejects a serialized null rather than treating it as omitted', () => {
+      expect(() => check('null')).toThrow(/Invalid keying_config/);
+    });
   });
 
   it('reports the offending path in the message', () => {

--- a/packages/server/src/__tests__/unit/keying-config-shape.test.ts
+++ b/packages/server/src/__tests__/unit/keying-config-shape.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+import { assertKeyingConfigShape } from '../../tools/admin/manage_behaviors/shared';
+
+const valid = {
+  entity_path: 'items',
+  key_fields: ['source_origin_id'],
+  key_output_field: 'stable_key',
+};
+
+describe('assertKeyingConfigShape', () => {
+  it('accepts a minimal valid config', () => {
+    expect(() => assertKeyingConfigShape(valid)).not.toThrow();
+  });
+
+  it('accepts the optional entity_type and name_fields', () => {
+    expect(() =>
+      assertKeyingConfigShape({
+        ...valid,
+        entity_type: 'social-signal',
+        name_fields: ['author'],
+      })
+    ).not.toThrow();
+  });
+
+  it('treats null/undefined as "not supplied" so inherited configs are untouched', () => {
+    expect(() => assertKeyingConfigShape(null)).not.toThrow();
+    expect(() => assertKeyingConfigShape(undefined)).not.toThrow();
+  });
+
+  it('rejects a missing required field', () => {
+    expect(() => assertKeyingConfigShape({ entity_path: 'items' })).toThrow(/Invalid keying_config/);
+  });
+
+  it('rejects a misspelled key field name rather than silently ignoring it', () => {
+    // The whole point of typing this: `keyFields` used to be accepted and then
+    // dropped, disabling validation and promotion with no error.
+    expect(() =>
+      assertKeyingConfigShape({
+        entity_path: 'items',
+        keyFields: ['source_origin_id'],
+        key_output_field: 'stable_key',
+      })
+    ).toThrow(/Invalid keying_config/);
+  });
+
+  it('rejects an empty key_fields array', () => {
+    expect(() => assertKeyingConfigShape({ ...valid, key_fields: [] })).toThrow(
+      /Invalid keying_config/
+    );
+  });
+
+  it('rejects a wrongly-typed field', () => {
+    expect(() => assertKeyingConfigShape({ ...valid, entity_path: 42 })).toThrow(
+      /Invalid keying_config/
+    );
+  });
+
+  it('reports the offending path in the message', () => {
+    expect(() => assertKeyingConfigShape({ ...valid, key_output_field: '' })).toThrow(
+      /key_output_field/
+    );
+  });
+});

--- a/packages/server/src/__tests__/unit/keying-config-shape.test.ts
+++ b/packages/server/src/__tests__/unit/keying-config-shape.test.ts
@@ -61,6 +61,16 @@ describe('assertKeyingConfigShape', () => {
     );
   });
 
+  // `key in properties` walks Object.prototype, so these names would read as
+  // declared fields. They arrive as real own keys via JSON.parse.
+  it.each(['constructor', 'toString', '__proto__', 'hasOwnProperty'])(
+    'rejects the prototype-named key %s',
+    (key) => {
+      const parsed = JSON.parse(JSON.stringify({ ...valid, [key]: 'x' }));
+      expect(() => assertKeyingConfigShape(parsed)).toThrow(/unknown field/);
+    }
+  );
+
   it('lists the allowed fields when it rejects an unknown one', () => {
     expect(() => assertKeyingConfigShape({ ...valid, nope: 1 })).toThrow(/Allowed: .*name_fields/);
   });

--- a/packages/server/src/__tests__/unit/keying-config-shape.test.ts
+++ b/packages/server/src/__tests__/unit/keying-config-shape.test.ts
@@ -22,9 +22,12 @@ describe('assertKeyingConfigShape', () => {
     ).not.toThrow();
   });
 
-  it('treats null/undefined as "not supplied" so inherited configs are untouched', () => {
-    expect(() => assertKeyingConfigShape(null)).not.toThrow();
+  it('treats undefined as "not supplied" so inherited configs are untouched', () => {
     expect(() => assertKeyingConfigShape(undefined)).not.toThrow();
+  });
+
+  it('rejects null — a serialized JSON `null` is supplied input, not omission', () => {
+    expect(() => assertKeyingConfigShape(null)).toThrow(/Invalid keying_config/);
   });
 
   it('rejects a missing required field', () => {

--- a/packages/server/src/__tests__/unit/promote-keyed-entity-name.test.ts
+++ b/packages/server/src/__tests__/unit/promote-keyed-entity-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { buildEntityName } from '../promote-keyed-entities';
+import { buildEntityName } from '../../utils/promote-keyed-entities';
 import type { KeyingConfig } from '../../types/watchers';
 
 const base: KeyingConfig = {

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -29,6 +29,7 @@ import {
 import {
   assertAgentExists,
   assertKeyingConfigEntityTypeExists,
+  assertKeyingConfigShape,
   assertWatcherVersionConfigValid,
   assertWatcherSourcesResolve,
   assertBehaviorSkillsResolve,
@@ -122,6 +123,9 @@ export async function handleCreate(
 
   // Parse JSON inputs
   const keyingConfig = parseJsonInput<Record<string, unknown>>(args.keying_config, 'keying_config');
+  // String inputs pass the wire union unparsed — enforce the declared shape
+  // here so both input forms meet the same contract.
+  assertKeyingConfigShape(keyingConfig);
   const classifiers = parseJsonInput<unknown[]>(args.classifiers, 'classifiers');
 
   // Build sources array. Sources are authored two ways and merged here:

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -449,9 +449,29 @@ export async function assertAgentExists(
  * Only `undefined` counts as omitted: the tool contract has no null member, so
  * a serialized JSON `null` string is a caller-supplied value and is rejected
  * rather than silently inheriting the previous version's config.
+ *
+ * Unknown keys are rejected HERE rather than via `additionalProperties: false`
+ * on the shared schema. A misspelled OPTIONAL field (`nameFields`, `entityType`)
+ * satisfies every required field, so the schema alone accepts it and the caller
+ * silently loses the display-name or entity-type binding — the exact silent-void
+ * failure this contract exists to stop. The schema stays open because it is also
+ * `get_behavior`'s output shape, where a legacy stored config with extra keys
+ * must still round-trip; this guard only ever sees caller input.
  */
 export function assertKeyingConfigShape(keyingConfig: unknown): void {
   if (keyingConfig === undefined) return;
+  if (keyingConfig !== null && typeof keyingConfig === 'object' && !Array.isArray(keyingConfig)) {
+    const unknown = Object.keys(keyingConfig).filter(
+      (key) => !(key in BehaviorKeyingConfigSchema.properties)
+    );
+    if (unknown.length > 0) {
+      const allowed = Object.keys(BehaviorKeyingConfigSchema.properties).join(', ');
+      throw new ToolUserError(
+        `Invalid keying_config: unknown field(s) ${unknown.slice(0, 3).join(', ')}. Allowed: ${allowed}.`,
+        400
+      );
+    }
+  }
   if (Value.Check(BehaviorKeyingConfigSchema, keyingConfig)) return;
   // Dedupe by path — TypeBox emits both `Expected required property` and
   // `Expected <type>` for one missing field (same as validate-args).

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -439,22 +439,6 @@ export async function assertAgentExists(
 }
 
 /**
- * Resolve `keying_config.entity_type` against the org before it is persisted.
- *
- * An entity-typed Behavior derives its whole output contract from the named
- * type's `metadata_schema`. When the type does not exist,
- * `deriveWatcherExtractionSchema()` returns null and complete_window SKIPS
- * extraction validation entirely — so a typo does not fail loudly, it silently
- * VOIDS the contract the Behavior was created to enforce. Its sibling
- * `entity_id` is already existence-checked at create, so validating here makes
- * the pair consistent.
- *
- * Uses the same tenant-first-then-public-catalog visibility rule as
- * `resolveEntityTypeMetadataSchema()` (watcher-extraction-schema.ts) so a type
- * that derivation CAN see is never rejected here — checking existence only, as
- * a type legitimately may carry no metadata_schema yet.
- */
-/**
  * Shape-check a CALLER-SUPPLIED keying_config after parseJsonInput. An
  * object-typed input is already validated by the tool schema, but the wire
  * contract also accepts a pre-serialized JSON string (see the keying_config
@@ -481,6 +465,22 @@ export function assertKeyingConfigShape(
   throw new ToolUserError(`Invalid keying_config: ${errs.join('; ')}`, 400);
 }
 
+/**
+ * Resolve `keying_config.entity_type` against the org before it is persisted.
+ *
+ * An entity-typed Behavior derives its whole output contract from the named
+ * type's `metadata_schema`. When the type does not exist,
+ * `deriveWatcherExtractionSchema()` returns null and complete_window SKIPS
+ * extraction validation entirely — so a typo does not fail loudly, it silently
+ * VOIDS the contract the Behavior was created to enforce. Its sibling
+ * `entity_id` is already existence-checked at create, so validating here makes
+ * the pair consistent.
+ *
+ * Uses the same tenant-first-then-public-catalog visibility rule as
+ * `resolveEntityTypeMetadataSchema()` (watcher-extraction-schema.ts) so a type
+ * that derivation CAN see is never rejected here — checking existence only, as
+ * a type legitimately may carry no metadata_schema yet.
+ */
 export async function assertKeyingConfigEntityTypeExists(
   sql: DbClient,
   organizationId: string,

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -18,7 +18,11 @@ import {
   extractSkillNamesFromPromptTokens,
 } from '../../../watchers/source-refs';
 import type { ToolContext } from '../../registry';
-import { normalizeBehaviorTags } from '@lobu/core/contracts/tools/manage-behaviors';
+import { Value } from '@sinclair/typebox/value';
+import {
+  BehaviorKeyingConfigSchema,
+  normalizeBehaviorTags,
+} from '@lobu/core/contracts/tools/manage-behaviors';
 
 // ============================================
 // Types
@@ -450,6 +454,33 @@ export async function assertAgentExists(
  * that derivation CAN see is never rejected here — checking existence only, as
  * a type legitimately may carry no metadata_schema yet.
  */
+/**
+ * Shape-check a CALLER-SUPPLIED keying_config after parseJsonInput. An
+ * object-typed input is already validated by the tool schema, but the wire
+ * contract also accepts a pre-serialized JSON string (see the keying_config
+ * union in ManageBehaviorsSchema), which passes validation as Type.String and
+ * would otherwise store any shape. Never call this on stored/inherited
+ * configs — rows written before the contract existed must stay loadable.
+ */
+export function assertKeyingConfigShape(
+  keyingConfig: Record<string, unknown> | null | undefined
+): void {
+  if (keyingConfig == null) return;
+  if (Value.Check(BehaviorKeyingConfigSchema, keyingConfig)) return;
+  // Dedupe by path — TypeBox emits both `Expected required property` and
+  // `Expected <type>` for one missing field (same as validate-args).
+  const seen = new Set<string>();
+  const errs: string[] = [];
+  for (const e of Value.Errors(BehaviorKeyingConfigSchema, keyingConfig)) {
+    const path = e.path || '/';
+    if (seen.has(path)) continue;
+    seen.add(path);
+    errs.push(`${path}: ${e.message}`);
+    if (errs.length >= 3) break;
+  }
+  throw new ToolUserError(`Invalid keying_config: ${errs.join('; ')}`, 400);
+}
+
 export async function assertKeyingConfigEntityTypeExists(
   sql: DbClient,
   organizationId: string,

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -461,8 +461,10 @@ export async function assertAgentExists(
 export function assertKeyingConfigShape(keyingConfig: unknown): void {
   if (keyingConfig === undefined) return;
   if (keyingConfig !== null && typeof keyingConfig === 'object' && !Array.isArray(keyingConfig)) {
+    // `Object.hasOwn`, not `in`: `in` walks Object.prototype, so prototype-named
+    // own keys (`constructor`, `toString`, `__proto__`) would pass as declared.
     const unknown = Object.keys(keyingConfig).filter(
-      (key) => !(key in BehaviorKeyingConfigSchema.properties)
+      (key) => !Object.hasOwn(BehaviorKeyingConfigSchema.properties, key)
     );
     if (unknown.length > 0) {
       const allowed = Object.keys(BehaviorKeyingConfigSchema.properties).join(', ');

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -445,11 +445,13 @@ export async function assertAgentExists(
  * union in ManageBehaviorsSchema), which passes validation as Type.String and
  * would otherwise store any shape. Never call this on stored/inherited
  * configs — rows written before the contract existed must stay loadable.
+ *
+ * Only `undefined` counts as omitted: the tool contract has no null member, so
+ * a serialized JSON `null` string is a caller-supplied value and is rejected
+ * rather than silently inheriting the previous version's config.
  */
-export function assertKeyingConfigShape(
-  keyingConfig: Record<string, unknown> | null | undefined
-): void {
-  if (keyingConfig == null) return;
+export function assertKeyingConfigShape(keyingConfig: unknown): void {
+  if (keyingConfig === undefined) return;
   if (Value.Check(BehaviorKeyingConfigSchema, keyingConfig)) return;
   // Dedupe by path — TypeBox emits both `Expected required property` and
   // `Expected <type>` for one missing field (same as validate-args).

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -13,6 +13,7 @@ import type { ToolContext } from '../../registry';
 import type { ManageBehaviorsArgs, ManageBehaviorsResult } from '../manage_behaviors';
 import {
   assertKeyingConfigEntityTypeExists,
+  assertKeyingConfigShape,
   assertWatcherVersionConfigValid,
   assertWatcherSourcesResolve,
   assertBehaviorSkillsResolve,
@@ -124,8 +125,15 @@ export async function handleCreateVersion(
     [] as Array<{ name: string; content: string }>
   );
   const skills = args.skills !== undefined ? args.skills : storedSkills;
+  // Shape-check ONLY the caller-supplied value (string inputs pass the wire
+  // union unparsed); the inherited stored config may predate the contract.
+  const callerKeyingConfig = parseJsonInput<Record<string, unknown>>(
+    args.keying_config,
+    'keying_config'
+  );
+  assertKeyingConfigShape(callerKeyingConfig);
   const keyingConfig =
-    parseJsonInput<Record<string, unknown>>(args.keying_config, 'keying_config') ??
+    callerKeyingConfig ??
     normalizeStoredJsonField(prev.keying_config, undefined as Record<string, unknown> | undefined);
   const classifiers =
     parseJsonInput<unknown[]>(args.classifiers, 'classifiers') ??

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -13,6 +13,8 @@ import {
   type BehaviorTrigger,
   BehaviorSourceSchema,
   type BehaviorSource,
+  BehaviorKeyingConfigSchema,
+  type BehaviorKeyingConfig,
 } from '@lobu/core/contracts/tools/manage-behaviors';
 
 type WatcherSource = BehaviorSource;
@@ -79,24 +81,12 @@ export type WatcherWindow = Static<typeof WatcherWindowSchema>;
 // ============================================
 
 /**
- * Configuration for computing stable entity keys.
- * Used to generate deterministic keys for merging entities across windows.
+ * Configuration for computing stable entity keys, and for promoting each keyed
+ * row into an entity. Declared in `@lobu/core` so the MCP tool contract and the
+ * server-side readers cannot drift.
  */
-export const KeyingConfigSchema = Type.Object({
-  entity_path: Type.String(),
-  key_fields: Type.Array(Type.String()),
-  key_output_field: Type.String(),
-  /**
-   * Entity-type slug the keyed rows are promoted into (P2 phase 1). When
-   * omitted, promotion derives a slug from the last segment of `entity_path`
-   * (e.g. `analysis.results.problems` → `problem`). The type must already
-   * exist in the watcher's org (or the public catalog); if it can't be
-   * resolved, promotion is skipped for this window rather than failing the
-   * completion.
-   */
-  entity_type: Type.Optional(Type.String()),
-});
-export type KeyingConfig = Static<typeof KeyingConfigSchema>;
+export const KeyingConfigSchema = BehaviorKeyingConfigSchema;
+export type KeyingConfig = BehaviorKeyingConfig;
 
 // ============================================
 // Version Info (for listing available versions)

--- a/packages/server/src/utils/__tests__/promote-keyed-entity-name.test.ts
+++ b/packages/server/src/utils/__tests__/promote-keyed-entity-name.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+import { buildEntityName } from '../promote-keyed-entities';
+import type { KeyingConfig } from '../../types/watchers';
+
+const base: KeyingConfig = {
+  entity_path: 'items',
+  key_fields: ['source_origin_id'],
+  key_output_field: 'stable_key',
+  entity_type: 'social-signal',
+};
+
+const row = {
+  source_origin_id: 'li_home_DijYQTynIqrc0TEZ7DKkGr03_yFuvvOspQH46vLcMuk',
+  author: 'Adam Cohen',
+  platform: 'linkedin',
+  priority: 'high',
+};
+
+describe('buildEntityName', () => {
+  it('names from name_fields when set, leaving the opaque key as identity only', () => {
+    const name = buildEntityName(row, { ...base, name_fields: ['author'] }, 'stable-abc');
+    expect(name).toBe('Adam Cohen');
+  });
+
+  it('joins multiple name_fields in the given order', () => {
+    const name = buildEntityName(row, { ...base, name_fields: ['author', 'platform'] }, 'stable-abc');
+    expect(name).toBe('Adam Cohen · linkedin');
+  });
+
+  it('falls back to key_fields when name_fields is absent', () => {
+    expect(buildEntityName(row, base, 'stable-abc')).toBe(row.source_origin_id);
+  });
+
+  it('falls back to key_fields when name_fields is present but empty', () => {
+    const name = buildEntityName(row, { ...base, name_fields: [] }, 'stable-abc');
+    expect(name).toBe(row.source_origin_id);
+  });
+
+  it('skips name_fields that carry no value rather than emitting a blank segment', () => {
+    const name = buildEntityName(row, { ...base, name_fields: ['missing', 'author'] }, 'stable-abc');
+    expect(name).toBe('Adam Cohen');
+  });
+
+  it('falls back to the stable key when no name field resolves', () => {
+    const name = buildEntityName(row, { ...base, name_fields: ['nope'] }, 'stable-abc');
+    expect(name).toBe('stable-abc');
+  });
+});

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -177,16 +177,24 @@ function resolveEntityTypeSlug(config: KeyingConfig): string {
 }
 
 /**
- * Build a human-readable entity name from the configured key fields' RAW values
- * (not the slugified key). Falls back to the stable key when no field carries a
- * value.
+ * Build a human-readable entity name from RAW field values (not the slugified
+ * key). Falls back to the stable key when no field carries a value.
+ *
+ * Prefers `name_fields` and falls back to `key_fields`. The two are separate on
+ * purpose: a stable key must never change between runs, so it is usually an
+ * opaque id (`li_home_DijYQ…`), which makes a terrible display name. Keying on
+ * the readable field instead would tie the entity's identity to a value that can
+ * be edited upstream — a renamed author would orphan the entity and promote a
+ * duplicate.
  */
-function buildEntityName(
+export function buildEntityName(
   entityRecord: Record<string, unknown>,
   config: KeyingConfig,
   stableKey: string
 ): string {
-  const parts = config.key_fields
+  const nameFields =
+    config.name_fields && config.name_fields.length > 0 ? config.name_fields : config.key_fields;
+  const parts = nameFields
     .map((field) => entityRecord[field])
     .filter((v): v is string | number => v !== null && v !== undefined && String(v).trim().length > 0)
     .map((v) => String(v).trim());


### PR DESCRIPTION
## What

Three fixes to `keying_config`, all found while wiring Behavior 71 (social radar) to promote entities on prod.

**1. `keying_config` was `Type.Any` in the public contract.** A mistyped field name was accepted and then silently ignored: `deriveWatcherExtractionSchema` returns null, and `complete_window` skips extraction validation AND entity promotion with no error anywhere. Declares `BehaviorKeyingConfigSchema` in `@lobu/core`; `packages/server/src/types/watchers.ts` re-exports it instead of keeping a second definition.

**2. The string-input path was still unvalidated.** The wire contract accepts a pre-serialized JSON string as well as an object (same as `classifiers`), so an object-only schema would reject existing string callers while leaving that path unchecked. Keeps the union and shape-checks the parsed value via `assertKeyingConfigShape` on `create` and `create_version`. Only the caller-supplied value is checked — an inherited stored config may predate the contract.

**3. `buildEntityName` read the display name from `key_fields`.** That forces one field to be both identity and label, which have opposite stability requirements — a stable key must not change between runs, so it is usually an opaque id. Promoted entities on prod came out named `li_home_DijYQTynIqrc0TEZ7DKkGr03_yFuvvOspQH46vLcMuk`. Adds optional `name_fields`, falling back to `key_fields`.

Keying on the readable field instead is not a workaround: a renamed author would change the stable key, orphan the entity, and promote a duplicate.

## Red → green

Both new suites are mutation-tested.

**`buildEntityName`** — revert to `config.key_fields`:
```
RED:    2 pass, 4 fail
          Expected: "stable-abc"
          Received: "li_home_DijYQTynIqrc0TEZ7DKkGr03_yFuvvOspQH46vLcMuk"
GREEN:  6 pass, 0 fail
```
The 2 passing under mutation are the fallback cases, which behave identically either way.

**`assertKeyingConfigShape`** — stub the guard to `if (true) return;`:
```
RED:    3 pass, 5 fail
GREEN:  8 pass, 0 fail
```

## Test placement

Both files live in `packages/server/src/__tests__/unit/`. That directory is excluded in `packages/server/vitest.config.ts` and is the only server path `make test-unit` collects. At their first locations (`src/utils/__tests__`, `src/tools/admin/manage_behaviors/__tests__`) they were run by **neither** gate, and vitest's `include: ["src/**/*.test.ts"]` would have collected them and failed on the `bun:test` imports.

## Gates

- `make pre-pr` — clean, 6/6 (re-run after rebase onto #2420)
- `make test-unit` — 1 pre-existing failure: `exec-sandbox-extra.test.ts` "LOBU_EXEC_SANDBOX=bwrap on a host without it throws" (bubblewrap not on PATH on macOS). **Verified pre-existing**: identical failure on the unmodified `main` checkout.

## Emitted schema

```json
"required": ["entity_path", "key_fields", "key_output_field"],
"properties": { "entity_path", "key_fields", "key_output_field", "entity_type", "name_fields" }
```

## Not covered

`name_fields` is not prod-verified — it needs this merged and deployed before Behavior 71 can use it. Prod currently accepts the field (contract is `Type.Any` there) and ignores it, so the entity names stay opaque ids until rollout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured configuration for extracting fields, generating stable keys, identifying entity types, and selecting display-name fields.
  * Display names now prioritize configured name fields, with fallbacks to key fields or the stable key.

* **Bug Fixes**
  * Added validation for behavior keying configurations during creation and updates.
  * Invalid configurations now produce clear errors identifying problematic fields.
  * Shared configuration definitions improve consistency across behavior management and entity promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->