### PR TITLE
fix(server): normalize canonical chat channel ids

### DIFF
--- a/packages/server/src/gateway/__tests__/chat-interaction-fanout-crosspod.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-interaction-fanout-crosspod.test.ts
@@ -55,6 +55,7 @@ import {
 const ORG = "test-org-fanout";
 const CONN = "conn-slack-fanout";
 const USER = "U_FANOUT";
+const CHANNEL = "slack:D095";
 
 /**
  * Poll `check` until it returns true or `timeoutMs` elapses, throwing on
@@ -134,7 +135,11 @@ function makeChat(threadPost: ReturnType<typeof mock>) {
   return {
     onAction: mock((_handler: any) => undefined),
     // DM path: conversationId === channelId → bridge calls chat.channel().
-    channel: mock((_key: string) => ({ post: threadPost })),
+    // Worker-token routing carries the canonical platform-prefixed channel id.
+    // The Chat SDK expects that exact key; a double prefix is unroutable.
+    channel: mock((key: string) =>
+      key === CHANNEL ? { post: threadPost } : null
+    ),
     getAdapter: mock((_platform: string) => null),
     createThread: null,
   };
@@ -159,8 +164,8 @@ const slackQuestion: PostedQuestion = {
   id: "q_fanout_1",
   userId: USER,
   // DM: conversationId === channelId so resolveThread takes the channel path.
-  conversationId: "D095",
-  channelId: "D095",
+  conversationId: CHANNEL,
+  channelId: CHANNEL,
   teamId: "T1",
   connectionId: CONN,
   platform: "slack",

--- a/packages/server/src/gateway/connections/__tests__/chat-target-resolver.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/chat-target-resolver.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, mock, test } from "bun:test";
+import { resolveChatTarget } from "../platforms/shared.js";
+
+describe("resolveChatTarget", () => {
+  test("routes a canonical platform-prefixed DM channel without double-prefixing it", async () => {
+    const target = { post: mock(async () => undefined) };
+    const channel = mock((key: string) =>
+      key === "slack:D095" ? target : null
+    );
+
+    const resolved = await resolveChatTarget(
+      { channel },
+      "slack",
+      {
+        channelId: "slack:D095",
+        conversationId: "slack:D095",
+      }
+    );
+
+    expect(resolved).toBe(target);
+    expect(channel).toHaveBeenCalledWith("slack:D095");
+  });
+
+  test("prefixes a raw channel id from a direct platform caller", async () => {
+    const target = { post: mock(async () => undefined) };
+    const channel = mock((key: string) =>
+      key === "slack:D095" ? target : null
+    );
+
+    const resolved = await resolveChatTarget(
+      { channel },
+      "slack",
+      {
+        channelId: "D095",
+        conversationId: "D095",
+      }
+    );
+
+    expect(resolved).toBe(target);
+    expect(channel).toHaveBeenCalledWith("slack:D095");
+  });
+});

--- a/packages/server/src/gateway/connections/platforms/shared.ts
+++ b/packages/server/src/gateway/connections/platforms/shared.ts
@@ -6,6 +6,7 @@
 
 import { createLogger } from "@lobu/core";
 import type { Readable } from "node:stream";
+import { stripPlatformPrefix } from "../../channels/bound-channels.js";
 import type { IFileHandler } from "../../platform/file-handler.js";
 import type { ChatPlatformInstance, PlatformRoutingInfo } from "./types.js";
 
@@ -100,7 +101,11 @@ export async function resolveChatTarget(
   }
 ): Promise<any | null> {
   const { channelId, conversationId, responseThreadId, currentMessage } = opts;
-  const channelKey = `${platform}:${channelId}`;
+  // Worker/session routing uses canonical platform-prefixed channel ids, while
+  // a few direct platform callers still pass the raw id. Chat SDK channel keys
+  // are canonical, so normalize idempotently instead of producing an
+  // unroutable value such as `slack:slack:D0123`.
+  const channelKey = `${platform}:${stripPlatformPrefix(platform, channelId)}`;
 
   // If we have a full thread ID (e.g. telegram:{chatId}:{topicId}), use
   // createThread so the response lands in the correct forum topic.
@@ -231,7 +236,9 @@ export function createChatSdkFileHandler(
         instance,
         {
           threadId: options.threadTs,
-          channelKey: `${platform}:${options.channelId}`,
+          // Same idempotent normalization as resolveChatTarget: token-bound
+          // worker channel ids are already canonical platform-prefixed.
+          channelKey: `${platform}:${stripPlatformPrefix(platform, options.channelId)}`,
         },
         {
           raw: options.initialComment || "",

--- a/packages/server/src/gateway/connections/platforms/slack.ts
+++ b/packages/server/src/gateway/connections/platforms/slack.ts
@@ -6,6 +6,7 @@
  * capability.)
  */
 
+import { stripPlatformPrefix } from "../../channels/bound-channels.js";
 import type { IFileHandler } from "../../platform/file-handler.js";
 import { SlackInstructionProvider } from "../slack-instruction-provider.js";
 import { isSlackConfig } from "../types.js";
@@ -28,14 +29,17 @@ function createSlackFileHandler(
     channelId: string,
     conversationId?: string
   ): { channel: string; threadTs?: string } => {
+    // Token-bound worker channel ids are canonical (`slack:D0123`); strip so
+    // the fallbacks below can't rebuild a double-prefixed key.
+    const nativeChannel = stripPlatformPrefix("slack", channelId);
     if (conversationId?.startsWith("slack:")) {
       const [, channel, threadTs] = conversationId.split(":");
       return {
-        channel: channel || channelId,
+        channel: channel || nativeChannel,
         threadTs: threadTs && threadTs !== "" ? threadTs : undefined,
       };
     }
-    return { channel: channelId };
+    return { channel: nativeChannel };
   };
 
   return {


### PR DESCRIPTION
## Summary
- Preserve canonical platform-prefixed channel IDs when resolving Chat SDK post targets instead of producing keys such as `slack:slack:D…`.
- Apply the same normalization to Chat SDK file delivery and Slack upload fallbacks.
- Cover both canonical worker-token routing and raw direct-platform callers, including the cross-replica interaction-card seam.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted `bun test` suites (89 interaction tests before fixer; 38 resolver, cross-replica, file-route, and response-bridge tests after fixer)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Red

```text
resolveChatTarget > routes a canonical platform-prefixed DM channel without double-prefixing it
Expected: target
Received: null
0 pass, 1 fail
```

Production reproducer on deployed `a7f74461`: the worker's real `run_sdk` call created approval `ta_6477e3ec-3fb1-4118-bbad-b30030b68d24`, then the interaction bridge logged `Failed to post tool approval interaction`; Slack received no button.

### Green

```text
resolveChatTarget canonical + raw-id tests: 2 pass, 0 fail
cross-replica interaction card delivery: 2 pass, 0 fail
resolver + cross-replica + file routes + response bridge: 38 pass, 0 fail
make pre-pr: clean
```

## Notes
- `make test-unit` ran 836 tests: 823 passed, 12 skipped, and the known unrelated macOS-only `exec-sandbox-extra.test.ts` message assertion failed (`bubblewrap is unavailable` vs the current fuller diagnostic). Targeted suites and `make pre-pr` are clean.
- Live Slack approval-click E2E will be rerun after rollout; the initial live run is what exposed this delivery bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->