### PR TITLE
fix(server): route Grid interactive approvals

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
@@ -532,6 +532,56 @@ describe("SlackConnectionCoordinator", () => {
     expect(forwarded).toEqual([seeded.id]);
   });
 
+  test("Grid: an enterprise-only interactive payload routes to the org-wide install", async () => {
+    const forwarded: Array<{ connectionId: string; body: string }> = [];
+    const appStore = makeAppInstallationStore();
+    const secretStore = makeSecretStore();
+    const seeded = await upsertSlackInstallByTeam(
+      appStore,
+      secretStore,
+      "org-acme",
+      "E-GRID",
+      {
+        botToken: "xoxb-grid-wide",
+        enterpriseId: "E-GRID",
+        isEnterpriseInstall: true,
+      },
+    );
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        listSlackConnections: async () => [],
+        getAppInstallationStore: () => appStore,
+        getSecretStore: () => secretStore,
+        forwardWebhook: mock(async (connectionId: string, request: Request) => {
+          forwarded.push({ connectionId, body: await request.text() });
+          return new Response("ok");
+        }),
+      }),
+    );
+
+    // Org-wide Grid block_actions payloads may omit `team` entirely. The
+    // enterprise id is still authoritative and must reach the already-selected
+    // managed connection instead of the adapter's tokenless OAuth fallback.
+    const payload = {
+      type: "block_actions",
+      team: null,
+      enterprise: { id: "E-GRID", name: "Acme Grid" },
+      user: { id: "U-ACTOR" },
+      actions: [{ action_id: "tool:req-grid:1h", value: "1h" }],
+    };
+    const body = new URLSearchParams({ payload: JSON.stringify(payload) }).toString();
+    const response = await coordinator.handleAppWebhook(
+      new Request("https://gateway.example.com/slack/actions", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwarded).toEqual([{ connectionId: seeded.id, body }]);
+  });
+
   test("Grid: the enterprise fallback is exact — a foreign enterprise id misses", async () => {
     // The fallback must not leak across Grids: an install for E-GRID must NOT be
     // returned when resolving a different enterprise id.

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -435,7 +435,13 @@ export class SlackConnectionCoordinator {
         }
         return response;
       }
+    }
 
+    // Enterprise Grid interactive payloads can omit `team` entirely and carry
+    // only the enterprise id. Keep BYO routing team-scoped above, but allow the
+    // managed-install and pending-install paths to resolve that org-wide key.
+    const installTenantId = teamId ?? enterpriseId;
+    if (installTenantId) {
       // 2) An OAuth-installed workspace (the "Add to Slack" path). The install
       //    is an `app_installations` row (provider=slack), not a BYO `connections` chat row;
       //    the manager hydrates an agentless Slack instance from it (the
@@ -455,7 +461,7 @@ export class SlackConnectionCoordinator {
       //     Grid enterprise that has exactly one (non-org-wide) install and no
       //     org-wide one; still by enterprise_id, but only when unambiguous.
       const installation =
-        (await getSlackInstallByTeamId(store, teamId)) ??
+        (teamId ? await getSlackInstallByTeamId(store, teamId) : null) ??
         (enterpriseId
           ? ((await getSlackEnterpriseInstall(store, enterpriseId)) ??
             (await getSlackInstallByEnterpriseId(store, enterpriseId)))
@@ -477,7 +483,10 @@ export class SlackConnectionCoordinator {
       // 3) A workspace that installed Lobu but hasn't been CLAIMED into a Lobu
       //    org yet (a `pending` install). Don't silently drop their messages —
       //    reply with the connect link so a workspace admin can finish setup.
-      const pending = await resolveSlackPendingByTenant(teamId, enterpriseId);
+      const pending = await resolveSlackPendingByTenant(
+        installTenantId,
+        enterpriseId,
+      );
       if (pending) {
         return await this.replyUnclaimedWorkspace(
           pending.botToken,


### PR DESCRIPTION
## Summary

- Route Enterprise Grid interactive payloads that omit `team` through the org-wide managed Slack installation using their authoritative enterprise ID.
- Keep BYO connections team-scoped and preserve the original signed request body when forwarding.
- Cover the production payload shape with a coordinator regression test.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` / targeted `bun test <path>`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

Targeted suites:

```text
27 pass
0 fail
84 expect() calls
Ran 27 tests across 2 files. [8.26s]
```

`make test-unit` result: 823 pass, 12 skip, with one unrelated host-specific failure in `exec-sandbox-extra.test.ts` because `LOBU_EXEC_SANDBOX=bwrap` is asserted on macOS where bwrap is unavailable. The required CI unit suite will provide the Linux signal.

### Red

With the production fix absent, the enterprise-only payload skipped managed-install routing and reached the tokenless OAuth fallback:

```text
bun test v1.3.5 (1e86cebd)

packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts:
(fail) SlackConnectionCoordinator > Grid: an enterprise-only interactive payload routes to the org-wide install
Slack signing secret is not configured. Set SLACK_SIGNING_SECRET.

0 pass
1 fail
Ran 1 test across 1 file.
```

### Green

```text
bun test v1.3.5 (1e86cebd)

packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts:
(pass) SlackConnectionCoordinator > Grid: an enterprise-only interactive payload routes to the org-wide install [54.13ms]

1 pass
0 fail
2 expect() calls
Ran 1 test across 1 file. [3.98s]
```

## Notes

Live end-to-end verification will be repeated against the deployed squash commit: send a fresh Slack DM, approve `run_sdk`, confirm grant storage and tool execution in production logs, and confirm the returned agent IDs in Slack.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack Enterprise Grid event routing when requests omit a team ID.
  * Organization-wide installations can now receive interactive events and connection-link responses reliably.
  * Exact team matching remains prioritized when team information is available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->