### PR TITLE
fix(server): route same-org Grid install aliases

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
@@ -141,8 +141,9 @@ function makeAppInstallationStore(): TrackedAppStore {
 					r.metadata[key] === value &&
 					r.metadata[flagKey] === true,
 			);
-			// Unambiguous only — 2+ matches ⇒ null (see resolveActiveByMetadataFlag).
-			return matches.length === 1 ? matches[0] : null;
+			matches.sort((a, b) => b.updatedAt - a.updatedAt || b.id - a.id);
+			const organizationIds = new Set(matches.map((r) => r.organizationId));
+			return organizationIds.size === 1 ? (matches[0] ?? null) : null;
 		},
 		getByTenantAndOrg: async (key: any, org: string) => {
       const matches = rows.filter(
@@ -580,6 +581,64 @@ describe("SlackConnectionCoordinator", () => {
 
     expect(response.status).toBe(200);
     expect(forwarded).toEqual([{ connectionId: seeded.id, body }]);
+  });
+
+  test("Grid: an enterprise-only action routes the newest same-org install alias", async () => {
+    const forwarded: string[] = [];
+    const appStore = makeAppInstallationStore();
+    const secretStore = makeSecretStore();
+    await upsertSlackInstallByTeam(
+      appStore,
+      secretStore,
+      "org-acme",
+      "T-GRID-HOME",
+      {
+        botToken: "xoxb-old-alias",
+        enterpriseId: "E-GRID",
+        isEnterpriseInstall: true,
+      },
+    );
+    const canonical = await upsertSlackInstallByTeam(
+      appStore,
+      secretStore,
+      "org-acme",
+      "E-GRID",
+      {
+        botToken: "xoxb-current-alias",
+        enterpriseId: "E-GRID",
+        isEnterpriseInstall: true,
+      },
+    );
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        listSlackConnections: async () => [],
+        getAppInstallationStore: () => appStore,
+        getSecretStore: () => secretStore,
+        forwardWebhook: mock(async (connectionId: string) => {
+          forwarded.push(connectionId);
+          return new Response("ok");
+        }),
+      }),
+    );
+
+    const body = new URLSearchParams({
+      payload: JSON.stringify({
+        type: "block_actions",
+        team: null,
+        enterprise: { id: "E-GRID" },
+        actions: [{ action_id: "tool:req-grid-alias:1h", value: "1h" }],
+      }),
+    }).toString();
+    const response = await coordinator.handleAppWebhook(
+      new Request("https://gateway.example.com/slack/actions", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwarded).toEqual([canonical.id]);
   });
 
   test("Grid: the enterprise fallback is exact — a foreign enterprise id misses", async () => {

--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -614,6 +614,107 @@ describe("Grid install-model routing (per-workspace + org-wide enterprise)", () 
     expect(routed?.id).toBe(orgWide.id);
   });
 
+  test("same-org T/E aliases route to the newest org-wide install", async () => {
+    const { store, secretStore, slack } = build();
+    const ENT = "E_ALIAS";
+    await seedAgentRow("alias-agent", { organizationId: "org-alias" });
+    await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-alias",
+      "T_ALIAS_HOME",
+      {
+        botToken: "xoxb-old-alias",
+        enterpriseId: ENT,
+        isEnterpriseInstall: true,
+      },
+    );
+    const canonical = await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-alias",
+      ENT,
+      {
+        botToken: "xoxb-current-alias",
+        enterpriseId: ENT,
+        isEnterpriseInstall: true,
+      },
+    );
+
+    expect((await slack.getSlackEnterpriseInstall(store, ENT))?.id).toBe(
+      canonical.id,
+    );
+  });
+
+  test("enterprise uninstall stops EVERY same-org org-wide alias, not just the newest", async () => {
+    // The uninstall invalidated the ONE token both alias rows share. Stopping
+    // only the resolved (newest) alias would leave the stale one active — and
+    // then resolvable — so sibling events would route to the dead token.
+    const { store, secretStore, slack } = build();
+    const ENT = "E_UNINSTALL_ALIAS";
+    await seedAgentRow("alias-agent", { organizationId: "org-alias" });
+    const older = await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-alias",
+      "T_ALIAS_HOME",
+      {
+        botToken: "xoxb-old-alias",
+        enterpriseId: ENT,
+        isEnterpriseInstall: true,
+      },
+    );
+    const canonical = await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-alias",
+      ENT,
+      {
+        botToken: "xoxb-current-alias",
+        enterpriseId: ENT,
+        isEnterpriseInstall: true,
+      },
+    );
+
+    const stopped = await slack.revokeSlackInstallsForUninstall(store, {
+      enterpriseId: ENT,
+    });
+
+    expect(new Set(stopped)).toEqual(new Set([older.id, canonical.id]));
+    expect(await slack.getSlackEnterpriseInstall(store, ENT)).toBeNull();
+  });
+
+  test("org-wide aliases spanning Lobu orgs still fail closed", async () => {
+    const { store, secretStore, slack } = build();
+    const ENT = "E_CROSS_ORG_ALIAS";
+    await seedAgentRow("alias-a", { organizationId: "org-alias-a" });
+    await seedAgentRow("alias-b", { organizationId: "org-alias-b" });
+    await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-alias-a",
+      "T_ALIAS_A",
+      {
+        botToken: "xoxb-alias-a",
+        enterpriseId: ENT,
+        isEnterpriseInstall: true,
+      },
+    );
+    await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-alias-b",
+      "T_ALIAS_B",
+      {
+        botToken: "xoxb-alias-b",
+        enterpriseId: ENT,
+        isEnterpriseInstall: true,
+      },
+    );
+
+    expect(await slack.getSlackEnterpriseInstall(store, ENT)).toBeNull();
+  });
+
   test("sole per-workspace Grid install still routes by enterprise_id (no org-wide install)", async () => {
     // A Grid enterprise with exactly ONE (non-org-wide) install: the legacy
     // sole-active fallback must keep working, and the org-wide resolver returns

--- a/packages/server/src/lobu/stores/app-installation-store.ts
+++ b/packages/server/src/lobu/stores/app-installation-store.ts
@@ -193,18 +193,20 @@ export interface AppInstallationStore {
   ): Promise<AppInstallationRow | null>;
 
   /**
-   * Resolve the SOLE active install for a provider app whose `metadata[key]`
-   * equals `value` AND whose `metadata[flagKey]` is boolean `true` — unambiguous
-   * only. Distinct from {@link resolveSoleActiveByMetadata}: it filters to rows
-   * carrying a truthy flag, so a match survives even when OTHER (non-flagged)
-   * installs share the same `value`.
+   * Resolve an active install for a provider app whose `metadata[key]` equals
+   * `value` AND whose `metadata[flagKey]` is boolean `true`. Distinct from
+   * {@link resolveSoleActiveByMetadata}: it filters to rows carrying a truthy
+   * flag, so a match survives even when OTHER (non-flagged) installs share the
+   * same `value`.
    *
    * Its Slack consumer routes a Grid ORG-WIDE install (`is_enterprise_install`)
    * by `enterprise_id`: Slack allows exactly one org-wide install per enterprise,
    * so this is unambiguous EVEN WHEN per-workspace installs of sibling teams also
    * exist under the same enterprise — which is precisely the case
    * {@link resolveSoleActiveByMetadata} could not handle (it saw 2+ and gave up).
-   * Returns null when none match or, defensively, when 2+ flagged rows match.
+   * Multiple flagged aliases owned by the SAME organization are one authority
+   * boundary, so return the most recently updated row. Multiple organizations
+   * remain ambiguous and fail closed with null.
    */
   resolveActiveByMetadataFlag(
     provider: string,
@@ -497,8 +499,10 @@ export function createPostgresAppInstallationStore(): AppInstallationStore {
       const sql = getDb();
       // Match active installs where metadata[key] = value AND metadata[flagKey]
       // is JSON boolean true. `key`/`flagKey` are bound as `->>` / `->` operands,
-      // never spliced into SQL. LIMIT 2 detects (defensively) an impossible
-      // duplicate org-wide install; Slack guarantees at most one per enterprise.
+      // never spliced into SQL. Historical tenant-key transitions can leave a
+      // T-keyed and E-keyed alias for one Slack org-wide installation. They are
+      // safe to coalesce only inside one Lobu org; aliases spanning orgs remain
+      // ambiguous and fail closed. app_installations is bounded config state.
       const rows = await sql`
         SELECT * FROM app_installations
         WHERE provider = ${provider}
@@ -506,9 +510,13 @@ export function createPostgresAppInstallationStore(): AppInstallationStore {
           AND status = 'active'
           AND metadata ->> ${key} = ${value}
           AND (metadata -> ${flagKey}) = 'true'::jsonb
-        LIMIT 2
+        ORDER BY updated_at DESC, id DESC
       `;
-      return rows.length === 1 ? rowToInstallation(rows[0]) : null;
+      if (rows.length === 0) return null;
+      const organizationIds = new Set(
+        rows.map((row) => row.organization_id as string),
+      );
+      return organizationIds.size === 1 ? rowToInstallation(rows[0]) : null;
     },
 
     async getById(id) {

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -421,7 +421,7 @@ export async function getSlackInstallByTeamId(
  * each with its own install; the enterprise id alone can't say which one a
  * sibling-workspace event belongs to, so this resolves ONLY when exactly one
  * active install exists for the enterprise (see
- * {@link AppInstallationStore.resolveActiveByEnterprise}). Ambiguous (2+) or none
+ * {@link AppInstallationStore.resolveSoleActiveByMetadata}). Ambiguous (2+) or none
  * ⇒ null, and the caller falls through to the pending / default paths exactly as
  * the team-id miss does.
  */
@@ -439,13 +439,12 @@ export async function getSlackInstallByEnterpriseId(
 }
 
 /**
- * Resolve the ORG-WIDE (Grid) install for an enterprise: the single active
- * install with `is_enterprise_install=true` for this `enterprise_id`. Slack
- * permits exactly ONE org-wide install per enterprise, so this is unambiguous
- * even when per-workspace installs of sibling teams also exist under the same
- * enterprise — unlike {@link getSlackInstallByEnterpriseId}, which gives up on
- * 2+ matches. This is the routing key that lets one enterprise install serve
- * every sibling workspace's events, replacing the sole-active workaround.
+ * Resolve the ORG-WIDE (Grid) install for an enterprise. Slack permits exactly
+ * one org-wide app installation per enterprise. Lobu may retain both a
+ * historical T-keyed row and its canonical E-keyed alias during a tenant-key
+ * transition; when every alias belongs to one Lobu org, the store selects the
+ * newest. Aliases spanning Lobu orgs still fail closed. This is the routing key
+ * that lets one enterprise install serve every sibling workspace's events.
  */
 export async function getSlackEnterpriseInstall(
   store: AppInstallationStore,
@@ -659,7 +658,9 @@ export async function markSlackInstallStopped(
  * Resolves the affected install WITHOUT assuming the event carries a team id:
  *   - when `team_id` is present, the exact per-workspace install;
  *   - otherwise, the ORG-WIDE install keyed on `enterprise_id` (a Grid org-wide
- *     uninstall often carries only the enterprise id, no team id).
+ *     uninstall often carries only the enterprise id, no team id) — plus every
+ *     same-org T/E-keyed alias of it, since aliases share the invalidated token
+ *     (see {@link getSlackEnterpriseInstall}).
  * A per-workspace uninstall thus stops only that workspace's row; a sibling's
  * separately-installed row (matched by its own team id) is untouched. Returns the
  * external ids that were stopped (may be empty — an already-inactive or unknown
@@ -675,7 +676,25 @@ export async function revokeSlackInstallsForUninstall(
     if (byTeam) toStop.set(byTeam.id, byTeam);
   } else if (tenant.enterpriseId) {
     const orgWide = await getSlackEnterpriseInstall(store, tenant.enterpriseId);
-    if (orgWide) toStop.set(orgWide.id, orgWide);
+    if (orgWide) {
+      toStop.set(orgWide.id, orgWide);
+      // Same-org T/E-keyed aliases are ONE Slack org-wide installation sharing
+      // the token this uninstall just invalidated. Stop every alias — stopping
+      // only the resolved (newest) row would leave the stale alias active, and
+      // the resolver would then route sibling events to the dead token.
+      const orgRows = await store.listByProviderAndOrg(
+        SLACK_PROVIDER,
+        orgWide.organizationId
+      );
+      for (const raw of orgRows) {
+        if (raw.status !== "active") continue;
+        if (raw.providerAppId !== SLACK_PROVIDER_APP_ID) continue;
+        if (raw.metadata.enterprise_id !== tenant.enterpriseId) continue;
+        if (raw.metadata.is_enterprise_install !== true) continue;
+        const alias = toSlackRow(raw);
+        if (alias) toStop.set(alias.id, alias);
+      }
+    }
   }
   for (const id of toStop.keys()) {
     await markSlackInstallStopped(store, id);


### PR DESCRIPTION
## Summary
- Route duplicate Slack Enterprise Grid T/E installation aliases only when every active alias belongs to the same Lobu organization, selecting the newest canonical install.
- Preserve the cross-organization ambiguity fence.
- Revoke every same-org alias on enterprise uninstall so a stale alias cannot become routable with invalid credentials.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted `bun test` across Slack coordinator, install projection, and interaction bridge — 61 pass, 0 fail
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: production Slack approval E2E after rollout

## Red → green
Red, before same-org alias coalescing:
```
(fail) SlackConnectionCoordinator > Grid: an enterprise-only action routes the newest same-org install alias
Slack signing secret is not configured. Set SLACK_SIGNING_SECRET.
0 pass, 1 fail
```

Green, after the fix and fixer pass:
```
61 pass
0 fail
206 expect() calls
Ran 61 tests across 3 files.
```

The regression matrix includes real Postgres tests for:
- same-org T/E aliases selecting the newest active install;
- aliases spanning Lobu organizations failing closed;
- enterprise uninstall stopping every same-org alias.

## Notes
Production E2E on the deployed predecessor exposed this exact path: approval `ta_7608bea4-0d30-4dfa-97d2-e5937d085525` reached Slack but the click logged `Could not resolve token for interactive payload` because two active aliases represented the same Grid install in one Lobu org.

A full local `make test-unit` snapshot had one pre-existing macOS-only sandbox assertion failure in `exec-sandbox-extra.test.ts` (823 pass, 12 skip, 1 fail); the Linux CI unit check is the merge gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->