### PR TITLE
fix(server): authenticate approved tool execution

### DIFF
--- a/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
@@ -111,8 +111,17 @@ describe("Slack block_actions → registerActionHandlers (Tier B integration)", 
       toolName: "create_issue",
       args: { title: "from slack" },
       agentId: "agent-1",
-      userId: "user-1",
-			organizationId: "org-1",
+      userId: "U_SLACK",
+      organizationId: "org-1",
+      conversationId: "slack:dm:123",
+      channelId: "slack:D123",
+      teamId: "T123",
+      connectionId: "432",
+      platform: "slack",
+      source: "chat",
+      adminTools: ["run_sdk"],
+      adminActorUserId: "auth-user-1",
+      deploymentName: "lobu-builder",
     };
     await storePendingTool("req-slack-1", pending, 24 * 60 * 60);
 
@@ -154,6 +163,25 @@ describe("Slack block_actions → registerActionHandlers (Tier B integration)", 
     expect(agentId).toBe("agent-1");
     expect(pattern).toBe("/mcp/github/tools/create_issue");
     expect(h.executeToolDirect).toHaveBeenCalledTimes(1);
+    expect(h.executeToolDirect.mock.calls[0]).toEqual([
+      "agent-1",
+      "U_SLACK",
+      "github",
+      "create_issue",
+      { title: "from slack" },
+      {
+        organizationId: "org-1",
+        conversationId: "slack:dm:123",
+        channelId: "slack:D123",
+        teamId: "T123",
+        connectionId: "432",
+        platform: "slack",
+        source: "chat",
+        adminTools: ["run_sdk"],
+        adminActorUserId: "auth-user-1",
+        deploymentName: "lobu-builder",
+      },
+    ]);
     expect(h.postMessage).toHaveBeenCalled();
   });
 

--- a/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
@@ -21,8 +21,9 @@ import {
   expect,
   test,
 } from "bun:test";
-import { generateWorkerToken } from "@lobu/core";
+import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
 import { orgContext } from "../../lobu/stores/org-context.js";
+import { takePendingTool } from "../auth/mcp/pending-tool-store.js";
 import { McpProxy } from "../auth/mcp/proxy.js";
 import { McpToolCache } from "../auth/mcp/tool-cache.js";
 import { GrantStore } from "../permissions/grant-store.js";
@@ -521,6 +522,63 @@ describe("tool registry collision — same tool name on two MCPs", () => {
 // ---------------------------------------------------------------------------
 
 describe("tool approval — onToolBlocked and wildcard grants", () => {
+  test("durable approval preserves the signed direct-auth claims", async () => {
+    const toolCache = new McpToolCache();
+    const grantStore = new GrantStore();
+    const configSource = createConfigSource({
+      "lobu-memory": {
+        id: "lobu-memory",
+        upstreamUrl: "http://lobu.internal/acme/mcp",
+        internal: true,
+      },
+    });
+    const proxy = new McpProxy(configSource, { toolCache, grantStore });
+    let requestId = "";
+    proxy.onToolBlocked = async (id) => {
+      requestId = id;
+    };
+    orgContext.run({ organizationId: "test-org" }, () => {
+      toolCache.set("lobu-memory", [{ name: "run_sdk" }], "agent1");
+    });
+    const token = generateWorkerToken("U_SLACK", "slack:dm:123", "lobu-builder", {
+      channelId: "slack:D123",
+      teamId: "T123",
+      agentId: "agent1",
+      organizationId: "test-org",
+      connectionId: "432",
+      platform: "slack",
+      source: "chat",
+      adminTools: ["run_sdk"],
+      adminActorUserId: "auth-user-1",
+    });
+
+    const response = await proxy.getApp().request("/lobu-memory/tools/run_sdk", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ script: "return client.agents.list({})" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(requestId).toStartWith("ta_");
+    expect(await takePendingTool(requestId)).toMatchObject({
+      userId: "U_SLACK",
+      agentId: "agent1",
+      organizationId: "test-org",
+      conversationId: "slack:dm:123",
+      channelId: "slack:D123",
+      teamId: "T123",
+      connectionId: "432",
+      platform: "slack",
+      source: "chat",
+      adminTools: ["run_sdk"],
+      adminActorUserId: "auth-user-1",
+      deploymentName: "lobu-builder",
+    });
+  });
+
   test("onToolBlocked fires once; subsequent blocked-no-channel when no handler", async () => {
     const toolCache = new McpToolCache();
     const grantStore = new GrantStore();
@@ -885,6 +943,287 @@ describe("concurrent tool calls", () => {
 // ---------------------------------------------------------------------------
 
 describe("executeToolDirect", () => {
+  test("approved internal execution initializes a missing replica-local MCP session before the tool call", async () => {
+    const configSource = createConfigSource({
+      "lobu-memory": {
+        id: "lobu-memory",
+        upstreamUrl: "http://lobu.internal/acme/mcp",
+        internal: true,
+      },
+    });
+    const proxy = new McpProxy(configSource, {});
+    const requestHeaders: Headers[] = [];
+    let toolCalls = 0;
+
+    globalThis.fetch = async (_input, init) => {
+      requestHeaders.push(new Headers(init?.headers));
+      const body = JSON.parse(String(init?.body)) as { method: string };
+      if (body.method === "initialize") {
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 0, result: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json", "Mcp-Session-Id": "session-1" },
+        });
+      }
+      if (body.method === "notifications/initialized") {
+        return new Response(null, { status: 202 });
+      }
+      toolCalls++;
+      const initialized = new Headers(init?.headers).get("mcp-session-id") === "session-1";
+      return new Response(
+        JSON.stringify(
+          initialized
+            ? {
+                jsonrpc: "2.0",
+                id: 1,
+                result: { content: [{ type: "text", text: "approved" }], isError: false },
+              }
+            : { jsonrpc: "2.0", id: 1, error: { code: -32000, message: "Server not initialized" } },
+        ),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    const result = await proxy.executeToolDirect(
+      "agent1",
+      "approving-user",
+      "lobu-memory",
+      "run_sdk",
+      { script: "return client.agents.list({})" },
+      {
+        organizationId: "org-1",
+        conversationId: "slack:dm:123",
+        channelId: "slack:D123",
+        adminTools: ["run_sdk"],
+        adminActorUserId: "approving-user",
+      },
+    );
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "approved" }],
+      isError: false,
+    });
+    expect(toolCalls).toBe(1);
+    expect(requestHeaders).toHaveLength(3);
+    for (const headers of requestHeaders) {
+      expect(headers.get("authorization")).toMatch(/^Bearer /);
+      expect(headers.get("x-lobu-memory-direct-auth")).toBe("1");
+    }
+  });
+
+  test("approved execution re-initializes and retries once when the cached session went stale mid-call", async () => {
+    const configSource = createConfigSource({
+      "lobu-memory": {
+        id: "lobu-memory",
+        upstreamUrl: "http://lobu.internal/acme/mcp",
+        internal: true,
+      },
+    });
+    const proxy = new McpProxy(configSource, {});
+    let initCount = 0;
+    let toolCalls = 0;
+
+    globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { method: string };
+      if (body.method === "initialize") {
+        initCount++;
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 0, result: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json", "Mcp-Session-Id": `session-${initCount}` },
+        });
+      }
+      if (body.method === "notifications/initialized") {
+        return new Response(null, { status: 202 });
+      }
+      toolCalls++;
+      // The first session the upstream handed out is already gone by the time
+      // the tool call arrives — only the re-initialized session succeeds.
+      const sessionId = new Headers(init?.headers).get("mcp-session-id");
+      return new Response(
+        JSON.stringify(
+          sessionId === "session-2"
+            ? {
+                jsonrpc: "2.0",
+                id: 1,
+                result: { content: [{ type: "text", text: "approved" }], isError: false },
+              }
+            : { jsonrpc: "2.0", id: 1, error: { code: -32000, message: "Session not found" } },
+        ),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    const result = await proxy.executeToolDirect(
+      "agent1",
+      "approving-user",
+      "lobu-memory",
+      "run_sdk",
+      { script: "return client.agents.list({})" },
+      {
+        organizationId: "org-1",
+        conversationId: "slack:dm:123",
+        channelId: "slack:D123",
+      },
+    );
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "approved" }],
+      isError: false,
+    });
+    expect(initCount).toBe(2);
+    expect(toolCalls).toBe(2);
+  });
+
+  test("approved execution re-initializes and retries once on an upstream 404 (unknown session)", async () => {
+    const configSource = createConfigSource({
+      "lobu-memory": {
+        id: "lobu-memory",
+        upstreamUrl: "http://lobu.internal/acme/mcp",
+        internal: true,
+      },
+    });
+    const proxy = new McpProxy(configSource, {});
+    let initCount = 0;
+    let toolCalls = 0;
+
+    globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { method: string };
+      if (body.method === "initialize") {
+        initCount++;
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 0, result: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json", "Mcp-Session-Id": `session-${initCount}` },
+        });
+      }
+      if (body.method === "notifications/initialized") {
+        return new Response(null, { status: 202 });
+      }
+      toolCalls++;
+      const sessionId = new Headers(init?.headers).get("mcp-session-id");
+      if (sessionId !== "session-2") {
+        return new Response("Session not found", { status: 404 });
+      }
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { content: [{ type: "text", text: "approved" }], isError: false },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    const result = await proxy.executeToolDirect(
+      "agent1",
+      "approving-user",
+      "lobu-memory",
+      "run_sdk",
+      { script: "return client.agents.list({})" },
+      {
+        organizationId: "org-1",
+        conversationId: "slack:dm:123",
+        channelId: "slack:D123",
+      },
+    );
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "approved" }],
+      isError: false,
+    });
+    expect(initCount).toBe(2);
+    expect(toolCalls).toBe(2);
+  });
+
+  test("refuses internal execution when the pending row lacks signed routing context", async () => {
+    const configSource = createConfigSource({
+      "lobu-memory": {
+        id: "lobu-memory",
+        upstreamUrl: "http://lobu.internal/acme/mcp",
+        internal: true,
+      },
+    });
+    const proxy = new McpProxy(configSource, {});
+    let fetched = false;
+    globalThis.fetch = async () => {
+      fetched = true;
+      return new Response("unreachable", { status: 500 });
+    };
+
+    const result = await proxy.executeToolDirect(
+      "agent1",
+      "approving-user",
+      "lobu-memory",
+      "run_sdk",
+      { script: "return client.agents.list({})" },
+      { organizationId: "org-1", conversationId: "slack:dm:123" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("missing signed routing context");
+    expect(fetched).toBe(false);
+  });
+
+  test("approved internal tool execution authenticates with a fresh scoped worker token", async () => {
+    const configSource = createConfigSource({
+      "lobu-memory": {
+        id: "lobu-memory",
+        upstreamUrl: "http://lobu.internal/acme/mcp",
+        internal: true,
+      },
+    });
+    const proxy = new McpProxy(configSource, {});
+    let requestHeaders = new Headers();
+
+    globalThis.fetch = async (_input, init) => {
+      requestHeaders = new Headers(init?.headers);
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { content: [{ type: "text", text: "approved" }], isError: false },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+
+    const result = await proxy.executeToolDirect(
+      "agent1",
+      "approving-user",
+      "lobu-memory",
+      "run_sdk",
+      { script: "return client.agents.list({})" },
+      {
+        organizationId: "org-1",
+        conversationId: "slack:dm:123",
+        channelId: "slack:D123",
+        connectionId: "432",
+        platform: "slack",
+        source: "chat",
+        adminTools: ["run_sdk"],
+        adminActorUserId: "approving-user",
+        deploymentName: "lobu-builder",
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(requestHeaders.get("x-lobu-memory-direct-auth")).toBe("1");
+    const authorization = requestHeaders.get("authorization");
+    expect(authorization).toMatch(/^Bearer /);
+    const token = verifyWorkerToken(authorization?.slice("Bearer ".length) ?? "");
+    expect(token).toMatchObject({
+      userId: "approving-user",
+      agentId: "agent1",
+      organizationId: "org-1",
+      conversationId: "slack:dm:123",
+      channelId: "slack:D123",
+      connectionId: "432",
+      platform: "slack",
+      source: "chat",
+      adminTools: ["run_sdk"],
+      adminActorUserId: "approving-user",
+      deploymentName: "lobu-builder",
+    });
+  });
+
   test("executes tool directly and returns result", async () => {
     const configSource = createConfigSource({
       "direct-mcp": {

--- a/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
+++ b/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
@@ -20,6 +20,13 @@ export interface PendingToolInvocation {
   conversationId?: string;
   teamId?: string;
   connectionId?: string;
+  platform?: string;
+  source?: string;
+  /** Preserve the signed per-turn builder admin limit across approval resume. */
+  adminTools?: string[];
+  /** Canonical Lobu user bound to adminTools; present iff adminTools is present. */
+  adminActorUserId?: string;
+  deploymentName?: string;
 }
 
 export async function storePendingTool(

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
 	createLogger,
+	generateWorkerToken,
 	getErrorMessage,
 	type GuardrailRegistry,
 	runGuardrailInstances,
@@ -35,6 +36,19 @@ import { McpUpstreamClient } from "./proxy-upstream.js";
 import type { CachedMcpServer, McpTool, McpToolCache } from "./tool-cache.js";
 
 const logger = createLogger("mcp-proxy");
+
+export interface DirectToolExecutionOptions {
+	organizationId: string;
+	conversationId?: string;
+	channelId?: string;
+	teamId?: string;
+	connectionId?: string;
+	platform?: string;
+	source?: string;
+	adminTools?: string[];
+	adminActorUserId?: string;
+	deploymentName?: string;
+}
 
 export class McpProxy {
 	// Tool-approval cards may sit in-thread for a long time before the user
@@ -106,7 +120,7 @@ export class McpProxy {
 		mcpId: string,
 		toolName: string,
 		args: Record<string, unknown>,
-		options: { organizationId: string },
+		options: DirectToolExecutionOptions,
 	): Promise<{
 		content: Array<{ type: string; text: string }>;
 		isError: boolean;
@@ -118,7 +132,7 @@ export class McpProxy {
 				mcpId,
 				toolName,
 				args,
-				options.organizationId,
+				options,
 			),
 		);
 	}
@@ -129,11 +143,12 @@ export class McpProxy {
 		mcpId: string,
 		toolName: string,
 		args: Record<string, unknown>,
-		organizationId: string,
+		options: DirectToolExecutionOptions,
 	): Promise<{
 		content: Array<{ type: string; text: string }>;
 		isError: boolean;
 	}> {
+		const { organizationId } = options;
 		const httpServer = await this.configService.getHttpServer(
 			mcpId,
 			agentId,
@@ -145,8 +160,34 @@ export class McpProxy {
 				isError: true,
 			};
 		}
+		let directAuthToken: string | undefined;
+		if (httpServer.internal) {
+			if (!options.conversationId || !options.channelId) {
+				return {
+					content: [{ type: "text", text: "Approved tool execution is missing signed routing context" }],
+					isError: true,
+				};
+			}
+			directAuthToken = generateWorkerToken(
+				userId,
+				options.conversationId,
+				options.deploymentName ?? `tool-approval:${agentId}`,
+				{
+					channelId: options.channelId,
+					teamId: options.teamId,
+					agentId,
+					organizationId,
+					connectionId: options.connectionId,
+					platform: options.platform,
+					source: options.source,
+					adminTools: options.adminTools,
+					adminActorUserId: options.adminActorUserId,
+				},
+			);
+		}
 
 		const scopeKey = computeScopeKey(userId);
+		const sessionKey = buildSessionKey(agentId, mcpId, scopeKey);
 
 		const jsonRpcBody = JSON.stringify({
 			jsonrpc: "2.0",
@@ -156,14 +197,43 @@ export class McpProxy {
 		});
 
 		try {
-			const response = await this.upstream.sendUpstreamRequest(
-				httpServer,
-				agentId,
-				mcpId,
-				"POST",
-				jsonRpcBody,
-				scopeKey,
-			);
+			// Approval webhooks can land on a different gateway replica than the
+			// blocked call. Upstream MCP sessions are intentionally replica-local,
+			// so initialize on this replica before resuming the tool.
+			if (!this.upstream.getSession(sessionKey)) {
+				await this.upstream.reinitializeSession(
+					httpServer,
+					agentId,
+					mcpId,
+					scopeKey,
+					directAuthToken,
+				);
+			}
+
+			const sendToolCall = () =>
+				this.upstream.sendUpstreamRequest(
+					httpServer,
+					agentId,
+					mcpId,
+					"POST",
+					jsonRpcBody,
+					scopeKey,
+					directAuthToken,
+				);
+			let response = await sendToolCall();
+			if (response.status === 404) {
+				await response.body?.cancel().catch(() => {
+					/* noop */
+				});
+				await this.upstream.reinitializeSession(
+					httpServer,
+					agentId,
+					mcpId,
+					scopeKey,
+					directAuthToken,
+				);
+				response = await sendToolCall();
+			}
 
 			if (!response.ok) {
 				const text = await response.text();
@@ -178,14 +248,39 @@ export class McpProxy {
 				};
 			}
 
-			const json = (await parseJsonRpcResponse(response)) as {
+			let json = (await parseJsonRpcResponse(response)) as {
 				result?: {
 					content?: Array<{ type: string; text: string }>;
 					isError?: boolean;
 				};
 				content?: Array<{ type: string; text: string }>;
 				isError?: boolean;
+				error?: { code?: number; message?: string };
 			};
+			if (json.error && /not initialized|session not found/i.test(json.error.message ?? "")) {
+				await this.upstream.reinitializeSession(
+					httpServer,
+					agentId,
+					mcpId,
+					scopeKey,
+					directAuthToken,
+				);
+				response = await sendToolCall();
+				if (!response.ok) {
+					const text = await response.text();
+					return {
+						content: [{ type: "text", text: `Tool call failed: ${response.status} ${text}` }],
+						isError: true,
+					};
+				}
+				json = (await parseJsonRpcResponse(response)) as typeof json;
+			}
+			if (json.error) {
+				return {
+					content: [{ type: "text", text: json.error.message ?? JSON.stringify(json.error) }],
+					isError: true,
+				};
+			}
 			const result = json.result || json;
 			return {
 				content: result.content || [
@@ -586,6 +681,11 @@ export class McpProxy {
 				conversationId: tokenData.conversationId || "",
 				teamId: tokenData.teamId,
 				connectionId: tokenData.connectionId,
+				platform: tokenData.platform,
+				source: tokenData.source,
+				adminTools: tokenData.adminTools,
+				adminActorUserId: tokenData.adminActorUserId,
+				deploymentName: tokenData.deploymentName,
 			},
 			this.PENDING_TOOL_TTL,
 		).catch((err: unknown) =>

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -341,7 +341,18 @@ export function createGatewayApp(
               pending.mcpId,
               pending.toolName,
               pending.args,
-              { organizationId: pending.organizationId },
+              {
+                organizationId: pending.organizationId,
+                conversationId: pending.conversationId,
+                channelId: pending.channelId,
+                teamId: pending.teamId,
+                connectionId: pending.connectionId,
+                platform: pending.platform,
+                source: pending.source,
+                adminTools: pending.adminTools,
+                adminActorUserId: pending.adminActorUserId,
+                deploymentName: pending.deploymentName,
+              },
             );
             return { success: true, result } as any;
           }

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -10,6 +10,7 @@ import {
   type PendingToolInvocation,
 	takePendingTool,
 } from "../auth/mcp/pending-tool-store.js";
+import type { DirectToolExecutionOptions } from "../auth/mcp/proxy.js";
 import type {
   InteractionService,
   PostedLinkButton,
@@ -39,7 +40,7 @@ type ExecuteToolDirectFn = (
   mcpId: string,
   toolName: string,
 	args: Record<string, unknown>,
-	options: { organizationId: string },
+	options: DirectToolExecutionOptions,
 ) => Promise<{
   content: Array<{ type: string; text: string }>;
   isError: boolean;
@@ -1142,7 +1143,18 @@ export function registerActionHandlers(
             pending.mcpId,
             pending.toolName,
 						pending.args,
-						{ organizationId },
+						{
+							organizationId,
+							conversationId: pending.conversationId,
+							channelId: pending.channelId,
+							teamId: pending.teamId,
+							connectionId: pending.connectionId,
+							platform: pending.platform,
+							source: pending.source,
+							adminTools: pending.adminTools,
+							adminActorUserId: pending.adminActorUserId,
+							deploymentName: pending.deploymentName,
+						},
           );
 
           const resultText = result.content.map((c) => c.text).join("\n");


### PR DESCRIPTION
## Summary
- Preserve the original verified worker-token claims in durable pending tool approvals and mint a fresh scoped token when an approved internal MCP call resumes.
- Initialize the replica-local MCP session on the gateway replica handling the approval, with one stale-session retry.
- Keep the builder admin-tool allowlist paired with its canonical Lobu actor and fail closed when signed routing context is absent.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Targeted tests: 66 pass, 0 fail across MCP proxy, Slack webhook bridge, and action handlers
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] Production Slack approval E2E after rollout

## Red → green
Missing direct-auth bearer, reproduced before the fix:
```
(fail) executeToolDirect > approved internal tool execution authenticates with a fresh scoped worker token
Received value must be a string: null
0 pass, 1 fail
```

Missing replica-local MCP initialization, reproduced before the fix:
```
(fail) executeToolDirect > approved internal execution initializes a missing replica-local MCP session
Received: { content: [{ text: ...Server not initialized... }], isError: false }
0 pass, 1 fail
```

Green after the final fixer pass:
```
66 pass
0 fail
200 expect() calls
Ran 66 tests across 3 files.
```

## Notes
Production Slack approval `ta_d6ea69c8-d496-4f96-a693-6743653b83ed` reached resumed execution after #2425 but returned `401 Authentication required. Use OAuth or API key.` The direct-auth marker was present, but the internal request had no bearer token.

The full local `make test-unit` snapshot remains at the unrelated macOS-only bwrap assertion: 823 pass, 12 skip, 1 fail. Linux CI unit is the merge gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack tool-approval execution by preserving conversation, channel, connection, deployment, and administrative context.
  * Increased reliability of internal tool execution by recovering from stale or missing sessions and retrying eligible failures.
  * Added stronger validation for approval routing and authentication context.
  * Ensured approved tools execute with the correct scoped permissions and metadata across gateway instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->