### PR TITLE
fix(server): pair admin allowlist with its canonical actor

### DIFF
--- a/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
@@ -24,6 +24,7 @@ import {
 import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import { takePendingTool } from "../auth/mcp/pending-tool-store.js";
+import type { DirectToolExecutionOptions } from "../auth/mcp/proxy.js";
 import { McpProxy } from "../auth/mcp/proxy.js";
 import { McpToolCache } from "../auth/mcp/tool-cache.js";
 import { GrantStore } from "../permissions/grant-store.js";
@@ -1222,6 +1223,58 @@ describe("executeToolDirect", () => {
       adminActorUserId: "approving-user",
       deploymentName: "lobu-builder",
     });
+  });
+
+  test("approved internal execution drops an admin allowlist that has no canonical actor", async () => {
+    const configSource = createConfigSource({
+      "lobu-memory": {
+        id: "lobu-memory",
+        upstreamUrl: "http://lobu.internal/acme/mcp",
+        internal: true,
+      },
+    });
+    const proxy = new McpProxy(configSource, {});
+    let requestHeaders = new Headers();
+
+    globalThis.fetch = async (_input, init) => {
+      requestHeaders = new Headers(init?.headers);
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { content: [{ type: "text", text: "approved" }], isError: false },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+
+    const result = await proxy.executeToolDirect(
+      "agent1",
+      "approving-user",
+      "lobu-memory",
+      "run_sdk",
+      { script: "return client.agents.list({})" },
+      // Legacy/tampered pending row: allowlist with no verified actor. The
+      // paired type forbids constructing this, so the cast reproduces what a
+      // persisted payload can still deserialize into.
+      {
+        organizationId: "org-1",
+        conversationId: "slack:dm:123",
+        channelId: "slack:D123",
+        adminTools: ["run_sdk"],
+      } as DirectToolExecutionOptions,
+    );
+
+    expect(result.isError).toBe(false);
+    const authorization = requestHeaders.get("authorization");
+    const token = verifyWorkerToken(authorization?.slice("Bearer ".length) ?? "");
+    // Minting the unpaired claims produces a token the verifier rejects
+    // outright (401 on resume); pairing drops the admin tier and the resumed
+    // call still authenticates as a plain, non-admin worker.
+    expect(token).not.toBeNull();
+    expect(token?.userId).toBe("approving-user");
+    expect(token?.adminTools).toBeUndefined();
+    expect(token?.adminActorUserId).toBeUndefined();
   });
 
   test("executes tool directly and returns result", async () => {

--- a/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
+++ b/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
@@ -9,7 +9,7 @@ import { getDb } from "../../../db/client.js";
 
 const SCOPE = "pending-tool";
 
-export interface PendingToolInvocation {
+interface PendingToolInvocationFields {
   mcpId: string;
   toolName: string;
   args: Record<string, unknown>;
@@ -22,11 +22,41 @@ export interface PendingToolInvocation {
   connectionId?: string;
   platform?: string;
   source?: string;
-  /** Preserve the signed per-turn builder admin limit across approval resume. */
-  adminTools?: string[];
-  /** Canonical Lobu user bound to adminTools; present iff adminTools is present. */
-  adminActorUserId?: string;
   deploymentName?: string;
+}
+
+/**
+ * The signed per-turn builder admin limit and the canonical Lobu actor it is
+ * bound to, preserved across approval resume. Modeled as a PAIR, not two
+ * independent optional fields: the resumed call mints a worker token carrying
+ * this allowlist, so an allowlist with no verified actor must never be
+ * constructible or round-trippable as valid.
+ */
+export type PendingAdminGrant =
+  | { adminTools: string[]; adminActorUserId: string }
+  | { adminTools?: undefined; adminActorUserId?: undefined };
+
+export type PendingToolInvocation = PendingToolInvocationFields &
+  PendingAdminGrant;
+
+/**
+ * Fail closed on an unpaired admin grant: drop the tier entirely rather than
+ * defaulting an actor. A legacy or tampered payload carrying an allowlist with
+ * no actor (or an actor with no allowlist) resumes as a plain, non-admin call.
+ */
+export function pairAdminGrant(
+  adminTools: string[] | undefined,
+  adminActorUserId: string | undefined,
+): PendingAdminGrant {
+  if (!adminTools?.length || !adminActorUserId) return {};
+  return { adminTools, adminActorUserId };
+}
+
+function withPairedAdminGrant(
+  payload: PendingToolInvocation,
+): PendingToolInvocation {
+  const { adminTools, adminActorUserId, ...rest } = payload;
+  return { ...rest, ...pairAdminGrant(adminTools, adminActorUserId) };
 }
 
 export async function storePendingTool(
@@ -76,7 +106,7 @@ export async function listPendingToolsForConversation(
   `;
 	return rows.map((r) => {
 		const row = r as { id: string; payload: PendingToolInvocation };
-		return { ...row.payload, requestId: row.id };
+		return { ...withPairedAdminGrant(row.payload), requestId: row.id };
 	});
 }
 
@@ -98,7 +128,8 @@ export async function takePendingTool(
     RETURNING payload
   `;
   if (rows.length === 0) return null;
-	return (rows[0] as { payload: PendingToolInvocation }).payload ?? null;
+	const payload = (rows[0] as { payload: PendingToolInvocation }).payload;
+	return payload ? withPairedAdminGrant(payload) : null;
 }
 
 /** Active tool approvals belonging to this Behavior run's agent session. */

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -17,7 +17,11 @@ import { recordGuardrailTrip } from "../../guardrails/audit.js";
 import { requiresToolApproval } from "../../permissions/approval-policy.js";
 import type { GrantStore } from "../../permissions/grant-store.js";
 import type { AgentSettingsStore } from "../settings/agent-settings-store.js";
-import { storePendingTool } from "./pending-tool-store.js";
+import {
+	pairAdminGrant,
+	type PendingAdminGrant,
+	storePendingTool,
+} from "./pending-tool-store.js";
 import { handleProxyRequest } from "./proxy-forward.js";
 import {
 	handleCallTool,
@@ -37,7 +41,7 @@ import type { CachedMcpServer, McpTool, McpToolCache } from "./tool-cache.js";
 
 const logger = createLogger("mcp-proxy");
 
-export interface DirectToolExecutionOptions {
+export type DirectToolExecutionOptions = {
 	organizationId: string;
 	conversationId?: string;
 	channelId?: string;
@@ -45,10 +49,8 @@ export interface DirectToolExecutionOptions {
 	connectionId?: string;
 	platform?: string;
 	source?: string;
-	adminTools?: string[];
-	adminActorUserId?: string;
 	deploymentName?: string;
-}
+} & PendingAdminGrant;
 
 export class McpProxy {
 	// Tool-approval cards may sit in-thread for a long time before the user
@@ -180,8 +182,8 @@ export class McpProxy {
 					connectionId: options.connectionId,
 					platform: options.platform,
 					source: options.source,
-					adminTools: options.adminTools,
-					adminActorUserId: options.adminActorUserId,
+					// Unpaired admin grant → mint without the admin tier at all.
+					...pairAdminGrant(options.adminTools, options.adminActorUserId),
 				},
 			);
 		}
@@ -683,8 +685,7 @@ export class McpProxy {
 				connectionId: tokenData.connectionId,
 				platform: tokenData.platform,
 				source: tokenData.source,
-				adminTools: tokenData.adminTools,
-				adminActorUserId: tokenData.adminActorUserId,
+				...pairAdminGrant(tokenData.adminTools, tokenData.adminActorUserId),
 				deploymentName: tokenData.deploymentName,
 			},
 			this.PENDING_TOOL_TTL,

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -7,7 +7,10 @@ import { cors } from "hono/cors";
 import { secureHeaders } from "hono/secure-headers";
 import { createPostgresAppInstallationStore } from "../../lobu/stores/app-installation-store.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
-import { takePendingTool } from "../auth/mcp/pending-tool-store.js";
+import {
+  pairAdminGrant,
+  takePendingTool,
+} from "../auth/mcp/pending-tool-store.js";
 import { setEnvResolver } from "../auth/mcp/string-substitution.js";
 import { createAuthProfileLabel } from "../auth/settings/auth-profiles-manager.js";
 import { SystemEnvStore } from "../auth/system-env-store.js";
@@ -350,8 +353,7 @@ export function createGatewayApp(
                 connectionId: pending.connectionId,
                 platform: pending.platform,
                 source: pending.source,
-                adminTools: pending.adminTools,
-                adminActorUserId: pending.adminActorUserId,
+                ...pairAdminGrant(pending.adminTools, pending.adminActorUserId),
                 deploymentName: pending.deploymentName,
               },
             );

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -7,6 +7,7 @@ import { ENTITY_CHANGE_ACTION_KEYS } from "../../tools/admin/entity-field-approv
 import { manageOperations } from "../../tools/admin/manage_operations.js";
 import type { ToolContext } from "../../tools/registry.js";
 import {
+	pairAdminGrant,
   type PendingToolInvocation,
 	takePendingTool,
 } from "../auth/mcp/pending-tool-store.js";
@@ -1151,8 +1152,7 @@ export function registerActionHandlers(
 							connectionId: pending.connectionId,
 							platform: pending.platform,
 							source: pending.source,
-							adminTools: pending.adminTools,
-							adminActorUserId: pending.adminActorUserId,
+							...pairAdminGrant(pending.adminTools, pending.adminActorUserId),
 							deploymentName: pending.deploymentName,
 						},
           );


### PR DESCRIPTION
Follow-up to #2426 (already merged), addressing a CodeRabbit review finding on it.

A pending tool approval carried `adminTools` and `adminActorUserId` as two independent optional fields, with the "actor present iff allowlist present" invariant living only in a doc comment. A persisted row with an allowlist and no actor was therefore constructible, and the resume path minted a worker token from it — the verifier rejects that unpaired token outright, so the approved call died with a 401 instead of simply resuming without the admin tier.

The pairing is now a type, so an unpaired record cannot be constructed, plus a runtime pairing helper that fails closed on anything deserialized from `oauth_states`:

```ts
export type PendingAdminGrant =
  | { adminTools: string[]; adminActorUserId: string }
  | { adminTools?: undefined; adminActorUserId?: undefined };

export function pairAdminGrant(
  adminTools: string[] | undefined,
  adminActorUserId: string | undefined,
): PendingAdminGrant {
  if (!adminTools?.length || !adminActorUserId) return {};
  return { adminTools, adminActorUserId };
}
```

`PendingToolInvocation` and `DirectToolExecutionOptions` both intersect that union, `takePendingTool` / `listPendingToolsForConversation` normalize legacy or tampered payloads through `pairAdminGrant`, and the token mint in `executeToolDirect` spreads the paired result so an unpaired grant drops the admin tier rather than minting claims that fail verification.

Red → green on the new regression test (`mcp-proxy-edge-cases.test.ts`):

```
(fail) executeToolDirect > approved internal execution drops an admin allowlist that has no canonical actor
expect(received).not.toBeNull()  // Received: null
[error] [worker-auth] Worker token rejected: adminTools and adminActorUserId must be set together
0 pass, 1 fail
```

```
41 pass, 0 fail  (mcp-proxy-edge-cases)
6 pass, 0 fail   (interaction-bridge-slack-webhook)
2 pass, 0 fail   (durable-replay-claim-parity)
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->