### PR TITLE
fix(server): route scoped hosted preview delivery

### DIFF
--- a/db/migrations/20260801150000_preview_connection_workspace_scope.sql
+++ b/db/migrations/20260801150000_preview_connection_workspace_scope.sql
@@ -1,0 +1,62 @@
+-- migrate:up transaction:false
+
+-- `previewMode` is the hosted-bot identity. The bot's real workspace may be
+-- persisted in external_tenant_id for delivery scoping and ACL verification, so
+-- tenantlessness cannot define or protect the global preview slot. Build the
+-- stronger index before dropping the legacy tenantless-only index: if a second
+-- preview connection exists, the migration fails closed and the old protection
+-- remains in place.
+--
+-- Heal an INVALID carcass inline so every retry can rebuild it. PostgreSQL
+-- considers an INVALID index to exist, which makes CREATE ... IF NOT EXISTS a
+-- silent no-op after a failed concurrent build.
+DO $heal$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'uniq_preview_connection_per_platform_all'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.uniq_preview_connection_per_platform_all';
+  END IF;
+END
+$heal$;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uniq_preview_connection_per_platform_all
+    ON public.connections (connector_key)
+    WHERE config -> 'settings' -> 'previewMode' = 'true'::jsonb
+      AND credential_mode IS NOT NULL
+      AND deleted_at IS NULL;
+
+DROP INDEX CONCURRENTLY IF EXISTS public.uniq_preview_connection_per_platform_conn;
+
+-- migrate:down transaction:false
+
+DO $heal$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'uniq_preview_connection_per_platform_conn'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.uniq_preview_connection_per_platform_conn';
+  END IF;
+END
+$heal$;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uniq_preview_connection_per_platform_conn
+    ON public.connections (connector_key)
+    WHERE config -> 'settings' -> 'previewMode' = 'true'::jsonb
+      AND external_tenant_id IS NULL
+      AND credential_mode IS NOT NULL
+      AND deleted_at IS NULL;
+
+DROP INDEX CONCURRENTLY IF EXISTS public.uniq_preview_connection_per_platform_all;

--- a/packages/server/src/__tests__/integration/conversations/authorization.test.ts
+++ b/packages/server/src/__tests__/integration/conversations/authorization.test.ts
@@ -170,7 +170,7 @@ describe("conversation authorization", () => {
 			agentId: "concierge",
 			connectionId: "preview-conn",
       settings: { previewMode: true },
-      metadata: {}, // hosted-preview invariant: no teamId
+      metadata: {}, // legacy tenantless hosted connection: serves all its bindings
     });
 		await seedBinding({
 			organizationId: tenantOrg.id,
@@ -218,57 +218,88 @@ describe("conversation authorization", () => {
   });
 
 	it("invariant: a SECOND preview connection per platform is rejected (single hosted bot owns the slot)", async () => {
-    const hostOrg = await createTestOrganization();
-    const tenantOrg = await createTestOrganization();
+		const hostOrg = await createTestOrganization();
+		const tenantOrg = await createTestOrganization();
 		await createTestAgent({ organizationId: hostOrg.id, agentId: "concierge" });
 		await createTestAgent({ organizationId: tenantOrg.id, agentId: "sneaky" });
-    await seedSlackConnection({
-      organizationId: hostOrg.id,
+		await seedSlackConnection({
+			organizationId: hostOrg.id,
 			agentId: "concierge",
 			connectionId: "preview-1",
-      settings: { previewMode: true },
-      metadata: {},
-    });
-    // A tenant trying to stand up a competing team-less preview connection (the
-    // cross-org hijack vector) must hit the partial unique index and fail.
-    await expect(
-      seedSlackConnection({
-        organizationId: tenantOrg.id,
+			settings: { previewMode: true },
+			metadata: { teamId: "T_ONE" },
+		});
+		// A tenant trying to stand up a competing preview connection (the cross-org
+		// hijack vector) must hit the partial unique index even when both rows carry
+		// real workspace ids.
+		await expect(
+			seedSlackConnection({
+				organizationId: tenantOrg.id,
 				agentId: "sneaky",
 				connectionId: "preview-2",
-        settings: { previewMode: true },
-        metadata: {},
+				settings: { previewMode: true },
+				metadata: { teamId: "T_TWO" },
 			}),
-    ).rejects.toThrow();
-  });
+		).rejects.toThrow();
+	});
 
-	it("cross-org guardrail: a previewMode connection WITH a teamId is never borrowed", async () => {
-    const hostOrg = await createTestOrganization();
-    const tenantOrg = await createTestOrganization();
+	it("cross-org: resolves a previewMode binding when its workspace matches the connection", async () => {
+		const hostOrg = await createTestOrganization();
+		const tenantOrg = await createTestOrganization();
 		await createTestAgent({ organizationId: hostOrg.id, agentId: "concierge" });
 		await createTestAgent({
 			organizationId: tenantOrg.id,
 			agentId: "food-ordering",
 		});
 
-    await seedSlackConnection({
-      organizationId: hostOrg.id,
+		await seedSlackConnection({
+			organizationId: hostOrg.id,
 			agentId: "concierge",
 			connectionId: "preview-conn",
-      settings: { previewMode: true },
-			metadata: { teamId: "T_REAL" }, // not a hosted preview bot
+			settings: { previewMode: true },
+			metadata: { teamId: "T_REAL" },
 		});
 		await seedBinding({
 			organizationId: tenantOrg.id,
 			agentId: "food-ordering",
 			connectionId: "preview-conn",
 			channelId: "slack:C0LUNCH",
-    });
+			teamId: "T_REAL",
+		});
+
+		expect(
+			await resolveAddressableTargets("food-ordering", tenantOrg.id),
+		).toHaveLength(1);
+	});
+
+	it("cross-org guardrail: rejects a previewMode binding from another workspace", async () => {
+		const hostOrg = await createTestOrganization();
+		const tenantOrg = await createTestOrganization();
+		await createTestAgent({ organizationId: hostOrg.id, agentId: "concierge" });
+		await createTestAgent({
+			organizationId: tenantOrg.id,
+			agentId: "food-ordering",
+		});
+
+		await seedSlackConnection({
+			organizationId: hostOrg.id,
+			agentId: "concierge",
+			connectionId: "preview-conn",
+			settings: { previewMode: true },
+			metadata: { teamId: "T_HOST" },
+		});
+		await seedBinding({
+			organizationId: tenantOrg.id,
+			agentId: "food-ordering",
+			connectionId: "preview-conn",
+			channelId: "slack:C0LUNCH",
+			teamId: "T_OTHER",
+		});
 
 		expect(
 			await resolveAddressableTargets("food-ordering", tenantOrg.id),
 		).toEqual([]);
-  });
+	});
 
   // --- Tenant-escape + revocation ---
 

--- a/packages/server/src/__tests__/integration/migrations/invalid-index-heal-migration.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/invalid-index-heal-migration.test.ts
@@ -91,6 +91,15 @@ const HEAL_MIGRATIONS = [
         ON connector_versions (id)
     `,
 	},
+	{
+		// Inline heal + build before retiring the weaker preview-slot index.
+		files: ["20260801150000_preview_connection_workspace_scope.sql"],
+		index: "uniq_preview_connection_per_platform_all",
+		seedSql: `
+      CREATE INDEX IF NOT EXISTS uniq_preview_connection_per_platform_all
+        ON connections (id)
+    `,
+	},
 ] as const;
 
 function resolveMigrationsDir(): string {

--- a/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
@@ -237,7 +237,7 @@ describe("resolveBotDeliveryTargets", () => {
 			agentId: "concierge",
 			connectionId: "preview-conn",
       settings: { previewMode: true },
-      metadata: {}, // hosted preview invariant: no teamId
+      metadata: {}, // legacy tenantless hosted connection: serves all its bindings
     });
     await seedBinding({
       organizationId: tenantOrg.id, // binding lives in the TENANT org, not the conn's org
@@ -307,31 +307,59 @@ describe("resolveBotDeliveryTargets", () => {
     expect(await resolveBotDeliveryTargets(tenantOrg.id)).toEqual([]);
   });
 
-	it("cross-org guardrail: a previewMode connection WITH metadata.teamId is not used cross-org", async () => {
-    const hostOrg = await createTestOrganization();
-    const tenantOrg = await createTestOrganization();
+	it("cross-org: delivers through a previewMode connection when its workspace matches the binding", async () => {
+		const hostOrg = await createTestOrganization();
+		const tenantOrg = await createTestOrganization();
 		await createTestAgent({ organizationId: hostOrg.id, agentId: "concierge" });
 		await createTestAgent({
 			organizationId: tenantOrg.id,
 			agentId: "food-ordering",
 		});
 
-    await seedSlackConnection({
-      organizationId: hostOrg.id,
+		await seedSlackConnection({
+			organizationId: hostOrg.id,
 			agentId: "concierge",
 			connectionId: "preview-conn",
-      settings: { previewMode: true },
-			metadata: { teamId: "T_HOST" }, // a real workspace-bound install, not the hosted preview
-    });
-    await seedBinding({
-      organizationId: tenantOrg.id,
+			settings: { previewMode: true },
+			metadata: { teamId: "T_HOST" },
+		});
+		await seedBinding({
+			organizationId: tenantOrg.id,
 			agentId: "food-ordering",
 			connectionId: "preview-conn",
 			channelId: "slack:C0LUNCH",
-    });
+			teamId: "T_HOST",
+		});
 
-    expect(await resolveBotDeliveryTargets(tenantOrg.id)).toEqual([]);
-  });
+		expect(await resolveBotDeliveryTargets(tenantOrg.id)).toHaveLength(1);
+	});
+
+	it("cross-org guardrail: does not deliver a previewMode binding from another workspace", async () => {
+		const hostOrg = await createTestOrganization();
+		const tenantOrg = await createTestOrganization();
+		await createTestAgent({ organizationId: hostOrg.id, agentId: "concierge" });
+		await createTestAgent({
+			organizationId: tenantOrg.id,
+			agentId: "food-ordering",
+		});
+
+		await seedSlackConnection({
+			organizationId: hostOrg.id,
+			agentId: "concierge",
+			connectionId: "preview-conn",
+			settings: { previewMode: true },
+			metadata: { teamId: "T_HOST" },
+		});
+		await seedBinding({
+			organizationId: tenantOrg.id,
+			agentId: "food-ordering",
+			connectionId: "preview-conn",
+			channelId: "slack:C0LUNCH",
+			teamId: "T_OTHER",
+		});
+
+		expect(await resolveBotDeliveryTargets(tenantOrg.id)).toEqual([]);
+	});
 
 	it("does not double-deliver when the org owns its own connection on that channel", async () => {
     const hostOrg = await createTestOrganization();

--- a/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
@@ -849,7 +849,7 @@ describe("SlackConnectionCoordinator", () => {
           return new Response(`${connectionId}:${await request.text()}`);
         }),
         // The shared/hosted connection is the only safe no-team-match default:
-        // it is explicitly previewMode and carries no teamId.
+        // the explicit previewMode marker (unique per platform) identifies it.
         listSlackConnections: async () => [
           createSlackConnection(
             "conn-default",
@@ -895,9 +895,9 @@ describe("SlackConnectionCoordinator", () => {
           createSlackConnection("conn-tenant", { teamId: "T1" }),
           createSlackConnection(
             "conn-preview",
+            { teamId: "T_HOST" },
             {},
-            {},
-						{ allowGroups: true, previewMode: true },
+            { allowGroups: true, previewMode: true },
           ),
         ],
 			}),

--- a/packages/server/src/gateway/channels/bound-channels.ts
+++ b/packages/server/src/gateway/channels/bound-channels.ts
@@ -13,22 +13,22 @@
  *   (B) hosted-preview cross-org: a binding under THIS org served by the shared
  *       preview connection (which lives in a DIFFERENT org under a placeholder
  *       agent). A `/lobu link <code>` writes the binding under the linking org,
- *       so it never matches branch A's (org, agent) join. Gated HARD to
- *       previewMode connections with no `metadata.teamId` (the hosted-bot
- *       invariant) and NOT joined on agent_id, so a normal tenant bot is never
- *       borrowed cross-org. A NOT EXISTS skips channels the org/agent already
- *       owns via branch A (no double-resolve / double-post).
+ *       so it never matches branch A's (org, agent) join. Gated HARD to the
+ *       single previewMode connection per platform and, when that connection is
+ *       workspace-scoped, to bindings from the same workspace. It is NOT joined
+ *       on agent_id, so the hosted connection's placeholder agent does not hide
+ *       tenant bindings. A NOT EXISTS skips channels the org/agent already owns
+ *       via branch A (no double-resolve / double-post).
  *
  * `agentId` (optional) scopes BOTH branches to one agent — set for the
  * conversation tools (an agent may only address ITS OWN bindings), omitted for
  * org-wide notification delivery. `connectionId` (optional) narrows to a single
  * connection (used by targeted notify).
  *
- * Single-workspace assumption: with one hosted preview connection per platform
- * today, (B) matches on platform alone. When a second hosted workspace appears,
- * persist its team id and add `AND pc.settings->>'hostedWorkspaceTeamId' =
- * b.team_id` so a binding only resolves the connection installed in its
- * workspace (channel ids are workspace-scoped, not global).
+ * The preview connection's first-class tenant id is useful routing scope, not a
+ * reason to disable hosted delivery. A legacy tenantless preview connection may
+ * serve all of its bindings; a workspace-scoped one serves only matching team
+ * bindings because channel ids are workspace-scoped, not global.
  */
 import type { DbClient } from "../../db/client.js";
 import { runtimeConnectionIdToSlug } from "../../lobu/stores/connections-projection.js";
@@ -94,7 +94,8 @@ export async function resolveBoundChannelRows(
 
         -- (B) hosted-preview cross-org: this org's (agent's) bindings via the
         -- shared preview connection. NO agent_id join on the preview conn; gated
-        -- to previewMode + no teamId so a normal bot is never borrowed.
+        -- to the single previewMode connection per platform and, when scoped,
+        -- the same workspace as the binding.
         SELECT
           b.runtime_connection_id AS id,
           b.platform, b.channel_id, b.team_id, b.created_at
@@ -103,7 +104,10 @@ export async function resolveBoundChannelRows(
           AND b.connection_status = 'active'
           AND b.credential_mode IS NOT NULL
           AND b.preview_mode
-          AND b.connection_team_id IS NULL
+          AND (
+            b.connection_team_id IS NULL
+            OR b.team_id = b.connection_team_id
+          )
           ${agentFilterB}
           ${connFilterB}
           -- Skip channels the org/agent already owns via branch A.

--- a/packages/server/src/gateway/connections/__tests__/multi-tenant-integration.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/multi-tenant-integration.test.ts
@@ -179,7 +179,8 @@ describe("multi-tenant gateway/connections — Slack routing isolation", () => {
         organizationId: "org-shared",
         config: { platform: "slack", botToken: "xoxb-preview" },
         settings: { allowGroups: true, previewMode: true },
-        // No teamId → the hosted shared-app / preview connection.
+        // The previewMode marker (not teamId absence) makes this the hosted
+        // shared-app / preview connection; legacy rows carry no teamId.
         metadata: {},
         status: "active",
         createdAt: Date.now(),
@@ -187,7 +188,7 @@ describe("multi-tenant gateway/connections — Slack routing isolation", () => {
       });
     });
     // A team-scoped tenant row coexists; the fallback must still pick the
-    // non-team-scoped preview row, not the tenant row.
+    // preview row, not the tenant row.
     await seedSlackConnection(connectionStore, orgContext, {
       orgId: "org-A",
       agentId: "agent-A",

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -365,13 +365,16 @@ export class SlackConnectionCoordinator {
    * team_id (url_verification challenges, events with no extractable team).
    *
    * Only the hosted shared-app / preview connection is a safe default: it is
-   * explicitly marked `settings.previewMode === true` and belongs to no
-   * specific tenant. Everything else is tenant-owned — a team-scoped row
-   * obviously so, but ALSO a plain org-owned row with empty metadata (a BYO
-   * connection created without an OAuth install never gets a `metadata.teamId`,
-   * yet still carries that org's bot token). Forwarding an unmatched-team
-   * webhook to any tenant-owned row would let one tenant's bot act on (and
-   * reply with its own bot token to) another tenant's Slack traffic.
+   * explicitly marked `settings.previewMode === true`, with a global unique
+   * index guaranteeing one such connection per platform. Its real workspace id
+   * may be persisted for scoped delivery and ACL checks; the explicit marker,
+   * not missing identity, distinguishes it from tenant-owned bots. Everything
+   * else is tenant-owned — a team-scoped row obviously so, but ALSO a plain
+   * org-owned row with empty metadata (a BYO connection created without an
+   * OAuth install never gets a `metadata.teamId`, yet still carries that org's
+   * bot token). Forwarding an unmatched-team webhook to any tenant-owned row
+   * would let one tenant's bot act on (and reply with its own bot token to)
+   * another tenant's Slack traffic.
    * `listSlackConnections()` is platform-scoped only (the public `/api/v1/app-webhooks/slack`
    * route carries no org context, so the store's per-tenant predicate doesn't
    * apply) — so we must require the explicit preview marker and otherwise fail
@@ -382,9 +385,7 @@ export class SlackConnectionCoordinator {
     const connections = await this.deps.listSlackConnections();
     return (
       connections.find(
-        (connection) =>
-          connection.settings?.previewMode === true &&
-          !connection.metadata?.teamId
+        (connection) => connection.settings?.previewMode === true
       ) || null
     );
   }

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -87,17 +87,14 @@ interface BotDeliveryTarget {
  *       `(org, agent)` JOIN misses it on BOTH columns and proactive
  *       notifications silently drop. This branch resolves the org's bindings
  *       through the shared preview connection, mirroring the inbound
- *       concrete-connection routing. It is gated HARD to previewMode
- *       connections with no `metadata.teamId` (the hosted-bot invariant, same as
- *       `getDefaultConnection`) and is NOT joined on `agent_id`, so a normal
- *       tenant bot can never be used to deliver cross-org.
+ *       concrete-connection routing. It is gated HARD to the single previewMode
+ *       connection per platform and, when that connection is workspace-scoped,
+ *       to bindings from the same workspace. It is NOT joined on `agent_id`, so
+ *       the hosted connection's placeholder agent does not hide tenant bindings.
  *
- * Single-workspace assumption: with exactly one hosted preview connection per
- * platform today, (B) matches on platform alone. When a second hosted workspace
- * appears, persist its Slack team id (e.g. `settings.hostedWorkspaceTeamId`) and
- * add `AND ac.settings->>'hostedWorkspaceTeamId' = b.team_id` so a subscription only
- * resolves the connection actually installed in its workspace (Slack channel ids
- * are workspace-scoped, not global).
+ * A legacy tenantless hosted connection can serve all of its bindings. A
+ * workspace-scoped hosted connection serves only bindings carrying that same
+ * team id, so channel ids cannot collide across workspaces.
  *
  * Exported for testing the delivery path against a real DB.
  */


### PR DESCRIPTION
## Summary

- Keep hosted Slack preview delivery working after the connection self-heals its real workspace tenant id.
- Scope cross-org preview routing to bindings from the same Slack workspace while preserving legacy tenantless bindings.
- Enforce one preview-mode connection per platform regardless of whether a workspace tenant id is present.
- Heal INVALID concurrent-index leftovers inline so failed migration attempts retry without dropping uniqueness protection.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted Vitest/Bun suites plus full server integration suite
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Delivery routing red

Against the old routing predicate, the two new workspace-scoped delivery cases failed:

```
FAIL src/__tests__/integration/conversations/authorization.test.ts
  cross-org: resolves a previewMode binding when its workspace matches the connection
  expected [] to have a length of 1 but got 0

FAIL src/__tests__/integration/notifications/bot-delivery.test.ts
  cross-org: delivers through a previewMode connection when its workspace matches the binding
  expected [] to have a length of 1 but got 0

Test Files  2 failed (2)
Tests       2 failed | 20 passed (22)
```

### Delivery routing green

```
Test Files  2 passed (2)
Tests       24 passed (24)

bun test coordinator + multi-tenant isolation:
26 pass
0 fail

full server suite:
Test Files  378 passed (378)
Tests       3263 passed | 2 skipped (3265)
```

### Migration retry red

Without the inline INVALID-index heal, replaying after a simulated failed concurrent build skipped the existing invalid index:

```
relation "uniq_preview_connection_per_platform_all" already exists, skipping

Test Files  1 failed (1)
Tests       1 failed | 6 passed (7)

Expected: { exists: true, valid: true }
Received: { exists: true, valid: false }
```

### Migration retry green

```
Test Files  1 passed (1)
Tests       7 passed (7)

migration lint:
0 issues

make pre-pr:
all 6 gates clean
```

## Notes

- The migration heals INVALID leftovers inline on both up and down retries.
- It builds the stronger unique index before dropping the legacy one, so duplicate preview rows fail closed instead of weakening protection.
- The local `make test-unit` run has one unrelated current-main macOS failure in `exec-sandbox-extra.test.ts`: the assertion expects `bubblewrap is unavailable`, while the current message says `bubblewrap (bwrap) was not found on PATH`. This branch does not touch agent-worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hosted preview connections can now be scoped to a workspace while maintaining secure matching.
  * Preview connections are recognized through explicit preview-mode settings, including connections with workspace metadata.
  * Matching workspace bindings can resolve successfully across supported delivery and authorization flows.

* **Bug Fixes**
  * Prevented preview connections from being used when their workspace scope does not match.
  * Improved uniqueness enforcement for active preview connections requiring credentials.
  * Improved recovery when preview connection uniqueness indexes are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->