### PR TITLE
fix(ui): expose MCP client attribution

### DIFF
--- a/packages/server/src/lobu/__tests__/client-routes-identity.test.ts
+++ b/packages/server/src/lobu/__tests__/client-routes-identity.test.ts
@@ -58,6 +58,14 @@ async function seed(): Promise<void> {
     VALUES (${ORG}, ${ORG}, ${ORG})
     ON CONFLICT (id) DO NOTHING
   `;
+  const { ensureMemberEntity } = await import('../../utils/member-entity.js');
+  await ensureMemberEntity({
+    organizationId: ORG,
+    userId: USER,
+    name: 'Owner',
+    email: 'owner@test',
+    role: 'owner',
+  });
 
   // Registered as "Owletto for Mac" but every session reports `claude-code`,
   // because the Mac app drives its MCP connection through the Claude Code SDK.
@@ -104,6 +112,7 @@ interface ListedClient {
   id: string;
   title: string | null;
   drivenBy: string | null;
+  linkedUserEntitySlug: string | null;
 }
 
 async function listClients(): Promise<Map<string, ListedClient>> {
@@ -139,6 +148,12 @@ describe('MCP client identity', () => {
 
     expect(clients.get(MAC_CLIENT)?.drivenBy).toBe('claude-code');
     expect(clients.get(CHATGPT_CLIENT)?.drivenBy).toBe('openai-mcp');
+  });
+
+  test('links the granting user to their workspace member entity', async () => {
+    const clients = await listClients();
+
+    expect(clients.get(CHATGPT_CLIENT)?.linkedUserEntitySlug).toBe('owner');
   });
 
   test('no client is classified as first-party by its self-asserted name', async () => {

--- a/packages/server/src/lobu/client-routes.ts
+++ b/packages/server/src/lobu/client-routes.ts
@@ -24,6 +24,7 @@ type MessagingClientRecord = {
 	externalUrl: string | null;
 	linkedUserName: null;
 	linkedUserEmail: null;
+	linkedUserEntitySlug: null;
 	details: {
 		connectionId: string | null;
 		description: string | null;
@@ -147,6 +148,7 @@ async function listMessagingClients(options: {
 			externalUrl: externalUrlForMessagingIdentity(platform, row.user_id),
 			linkedUserName: null,
 			linkedUserEmail: null,
+			linkedUserEntitySlug: null,
 			details: {
 				connectionId: null,
 				description: null,
@@ -206,6 +208,37 @@ routes.get("/", mcpAuth, async (c) => {
 			}
 		}
 
+		const memberEntitySlugs = new Map<string, string>();
+		const ownerUserIds = [
+			...new Set(
+				oauthClients
+					.map((client) => client.owner_user_id)
+					.filter((userId): userId is string => Boolean(userId)),
+			),
+		];
+		if (ownerUserIds.length > 0) {
+			const rows = await sql`
+        SELECT ei.identifier AS user_id, e.slug
+        FROM entity_identities ei
+        JOIN entities e
+          ON e.id = ei.entity_id
+         AND e.organization_id = ei.organization_id
+         AND e.deleted_at IS NULL
+        JOIN entity_types et
+          ON et.id = e.entity_type_id
+         AND et.organization_id = e.organization_id
+         AND et.slug = '$member'
+        WHERE ei.organization_id = ${organizationId}
+          AND ei.namespace = 'auth_user_id'
+          AND ei.source_connector = 'auth:signup'
+          AND ei.deleted_at IS NULL
+          AND ei.identifier = ANY(${pgTextArray(ownerUserIds)}::text[])
+      `;
+			for (const row of rows as Array<{ user_id: string; slug: string }>) {
+				memberEntitySlugs.set(row.user_id, row.slug);
+			}
+		}
+
 		const mcpClients = oauthClients
 			.map((client) => {
 				const metadata = asRecord(client.metadata);
@@ -231,6 +264,9 @@ routes.get("/", mcpAuth, async (c) => {
 				const drivenBy = asNonEmptyString(clientInfo?.name);
 				const title = registeredName || drivenBy;
 				const softwareId = asNonEmptyString(client.software_id);
+				const linkedMemberSlug = client.owner_user_id
+					? memberEntitySlugs.get(client.owner_user_id)
+					: null;
 
 				return {
 					id: client.client_id,
@@ -266,6 +302,7 @@ routes.get("/", mcpAuth, async (c) => {
 							: null,
 					linkedUserName: client.user_name ?? null,
 					linkedUserEmail: client.user_email ?? null,
+					linkedUserEntitySlug: linkedMemberSlug ?? null,
 					details: {
 						softwareVersion: client.software_version ?? null,
 						redirectUris: client.redirect_uris,


### PR DESCRIPTION
## Summary
- resolve each OAuth client owner to the canonical workspace `$member` entity in the client inventory API
- make the Activity source label link to the MCP client detail page while retaining the sidebar-to-filtered-Activity flow
- show all selected client IDs and the granting user in Activity and on client detail

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted server and Owletto suites plus the full Owletto suite
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red
- server client identity: 3 passed, 1 failed — `linkedUserEntitySlug` was `undefined` instead of `owner`
- Owletto Activity: 9 passed, 1 failed — no link named `From Claude Desktop`

### Green
- `bun test packages/server/src/lobu/__tests__/client-routes-identity.test.ts`: 4 passed
- `bun run test -- src/components/entity-tabs/events-tab/events-tab.test.tsx src/lib/connectors/client-rows.test.ts`: 20 passed
- Owletto `bun run test`: 129 files passed, 1,142 tests passed
- settled `make pre-pr`: passed

## Notes
- Owletto UI change merged first: https://github.com/lobu-ai/owletto/pull/682
- local browser proof rendered source name, every selected client ID, and the linked granting member
- clicking `From ChatGPT` opened `/connectors/client/<client_id>`
- clicking the granting user opened the canonical `$member` entity page
- production screenshots will be captured after rollout

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Client listings now include the associated workspace member for clients granted through OAuth.
  * ChatGPT and MCP client records can be linked to the user who authorized access, improving identity visibility in client management.

* **Bug Fixes**
  * Corrected client identity associations so authorized clients are connected to the appropriate active workspace member.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->