### PR TITLE
feat(behaviors): persist social radar event threads

### DIFF
--- a/db/migrations/20260801170000_events_idempotency_key_index.sql
+++ b/db/migrations/20260801170000_events_idempotency_key_index.sql
@@ -1,0 +1,38 @@
+-- migrate:up transaction:false
+
+-- Behavior reaction scripts are retried after a failure. Their durable writes
+-- need a database-enforced idempotency key so a retry cannot create a second
+-- knowledge event or notification after the first attempt committed.
+--
+-- The key lives in a Lobu-reserved metadata field because both knowledge and
+-- notification records are append-only events. It is absent from ordinary and
+-- domain-authored metadata, keeping this index small and avoiding collisions
+-- with historical event schemas. Organization scope lets separate workspaces
+-- reuse the same producer key safely.
+--
+-- Heal an INVALID carcass inline so every retry can rebuild it. Both production
+-- and embedded migration runners split transaction:false sections into
+-- top-level statements, so the DO block and concurrent build run unwrapped.
+DO $heal$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'idx_events_org_idempotency_key'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX public.idx_events_org_idempotency_key';
+  END IF;
+END
+$heal$;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_events_org_idempotency_key
+  ON public.events (organization_id, (metadata->>'_lobu_idempotency_key'))
+  WHERE metadata ? '_lobu_idempotency_key';
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_org_idempotency_key;

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -142,6 +142,44 @@ describe("filterPostsSinceCheckpoint", () => {
 });
 
 describe("buildHomeFeedEvents", () => {
+  test("uses the scraped post permalink when LinkedIn exposes one", () => {
+    const [event] = buildHomeFeedEvents(
+      [
+        {
+          id: "opaque_component_key",
+          body: "Feed post Ada Lovelace • 1st A durable agents post with enough body text",
+          author: "Ada Lovelace",
+          post_url:
+            "/feed/update/urn:li:activity:7345678901234567890?utm_source=feed",
+        },
+      ],
+      new Date("2026-08-01T12:00:00.000Z")
+    );
+
+    expect(event.source_url).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:7345678901234567890"
+    );
+  });
+
+  test("builds a permalink from the share id embedded in current feed cards", () => {
+    const [event] = buildHomeFeedEvents(
+      [
+        {
+          id: "opaque_component_key",
+          body: "Feed post Ada Lovelace • 1st A durable agents post with enough body text",
+          author: "Ada Lovelace",
+          post_identity:
+            "translatable-commentary-ContentUrnShareUrn(shareUrn=ShareUrn(shareId=7485276857911828480))",
+        },
+      ],
+      new Date("2026-08-01T12:00:00.000Z")
+    );
+
+    expect(event.source_url).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:activity:7485276857911828480"
+    );
+  });
+
   test("maps a token-id row to li_home_<token> with /feed/ source_url", () => {
     const occurredAt = new Date("2026-05-29T12:00:00.000Z");
     const events = buildHomeFeedEvents(

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -175,8 +175,27 @@ describe("buildHomeFeedEvents", () => {
       new Date("2026-08-01T12:00:00.000Z")
     );
 
+    // A shareId is not an activity id; keep the source URN namespace.
     expect(event.source_url).toBe(
-      "https://www.linkedin.com/feed/update/urn:li:activity:7485276857911828480"
+      "https://www.linkedin.com/feed/update/urn:li:share:7485276857911828480"
+    );
+  });
+
+  test("keeps the ugcPost namespace for ugcPostId feed cards", () => {
+    const [event] = buildHomeFeedEvents(
+      [
+        {
+          id: "opaque_component_key",
+          body: "Feed post Ada Lovelace • 1st A durable agents post with enough body text",
+          author: "Ada Lovelace",
+          post_identity: "urn:li:ugcPost:7485276857911828481",
+        },
+      ],
+      new Date("2026-08-01T12:00:00.000Z")
+    );
+
+    expect(event.source_url).toBe(
+      "https://www.linkedin.com/feed/update/urn:li:ugcPost:7485276857911828481"
     );
   });
 

--- a/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
+++ b/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  KnowledgeSaveResult,
+  ReactionClient,
+  ReactionContext,
+} from "@lobu/connector-sdk";
+import runReaction from "../social-interest-radar.reaction";
+
+function context(): ReactionContext {
+  return {
+    extracted_data: {
+      digest_title: "Social interest radar",
+      analysis_summary: "One useful post",
+      items: [
+        {
+          platform: "linkedin",
+          author: "Ada",
+          snippet: "Reliable agents need durable state.",
+          why: "Directly relevant to Lobu's delivery model.",
+          priority: "high",
+          source_origin_id: "linkedin:activity:123",
+          source_event_id: 101,
+          suggested_action: "Reply with the event-sourcing design.",
+        },
+      ],
+    },
+    entities: [],
+    window: {
+      id: 44,
+      run_id: 88,
+      behavior_id: 71,
+      window_start: "2026-08-01T15:00:00.000Z",
+      window_end: "2026-08-01T16:00:00.000Z",
+      granularity: "hour",
+      content_analyzed: 1,
+    },
+    behavior: {
+      id: 71,
+      slug: "social-interest-radar",
+      name: "Social interest radar (X + LinkedIn)",
+      version: 9,
+    },
+    organization_id: "org-1",
+    organization_slug: "buremba",
+  };
+}
+
+function clientWithSaveResult(saveResult: KnowledgeSaveResult) {
+  const saves: Record<string, unknown>[] = [];
+  const notifications: Record<string, unknown>[] = [];
+  const client = {
+    knowledge: {
+      save: async (input: Record<string, unknown>) => {
+        saves.push(input);
+        return saveResult;
+      },
+    },
+    notifications: {
+      send: async (input: Record<string, unknown>) => {
+        notifications.push(input);
+        return { ok: true };
+      },
+    },
+  } as unknown as ReactionClient;
+  return { client, saves, notifications };
+}
+
+describe("social interest radar reaction", () => {
+  it("persists a threaded reply and links the notification to both events", async () => {
+    const fixture = clientWithSaveResult({
+      id: 501,
+      created: true,
+      metadata: { producer_run_key: "run:88" },
+    });
+
+    await runReaction(context(), fixture.client);
+
+    expect(fixture.saves).toHaveLength(1);
+    expect(fixture.saves[0]).toMatchObject({
+      parent_event_id: 101,
+      idempotency_key: "social-radar:source:linkedin:activity:123",
+      semantic_type: "social_signal",
+      payload_type: "markdown",
+    });
+    expect(fixture.notifications).toEqual([
+      expect.objectContaining({
+        resource_url: "/buremba/memory?content_ids=101,501",
+        idempotency_key: "social-radar:notification:run:88",
+      }),
+    ]);
+  });
+
+  it("does not notify again when a later run re-ranks an existing post", async () => {
+    const fixture = clientWithSaveResult({
+      id: 501,
+      created: false,
+      metadata: { producer_run_key: "run:77" },
+    });
+
+    await runReaction(context(), fixture.client);
+
+    expect(fixture.saves).toHaveLength(1);
+    expect(fixture.notifications).toHaveLength(0);
+  });
+
+  it("lets the original run retry its idempotent notification", async () => {
+    const fixture = clientWithSaveResult({
+      id: 501,
+      created: false,
+      metadata: { producer_run_key: "run:88" },
+    });
+
+    await runReaction(context(), fixture.client);
+
+    expect(fixture.notifications).toHaveLength(1);
+    expect(fixture.notifications[0]?.idempotency_key).toBe(
+      "social-radar:notification:run:88"
+    );
+  });
+
+  it("keeps the digest within the notification service limit", async () => {
+    const longContext = context();
+    const extracted = longContext.extracted_data as {
+      items: Array<{ why: string }>;
+    };
+    extracted.items[0].why = "x".repeat(1_200);
+    const fixture = clientWithSaveResult({
+      id: 501,
+      created: true,
+      metadata: { producer_run_key: "run:88" },
+    });
+
+    await runReaction(longContext, fixture.client);
+
+    expect(String(fixture.notifications[0]?.body).length).toBe(1000);
+  });
+});

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -731,11 +731,19 @@ export function buildHomeFeedEvents(
       metadata.author_profile_url = profileUrlFor(authorSlug);
     }
 
-    const embeddedActivityId = row.post_identity?.match(
-      /(?:shareId|ugcPostId)=(\d{6,})|urn:li:activity:(\d{6,})/i
+    // Keep the identifier in its own URN namespace. share/ugcPost ids are not
+    // activity ids, so relabelling a bare `shareId=` digit string as
+    // `urn:li:activity:` can build a permalink to an unrelated post.
+    const embeddedUrn = row.post_identity?.match(
+      /(?:(shareId|ugcPostId)=|urn:li:(activity|share|ugcPost):)(\d{6,})/i
+    );
+    const embeddedId = embeddedUrn?.[3];
+    const embeddedNamespace = linkedInUrnNamespace(
+      embeddedUrn?.[1] ?? embeddedUrn?.[2] ?? ""
     );
     const postUrl = normalizeLinkedInPostUrl(
-      row.post_url ?? embeddedActivityId?.[1] ?? embeddedActivityId?.[2] ?? ""
+      row.post_url ??
+        (embeddedId ? `urn:li:${embeddedNamespace}:${embeddedId}` : "")
     );
 
     events.push({
@@ -811,9 +819,21 @@ type PrepareCommentResult = {
 };
 
 /**
+ * Canonical casing for the LinkedIn URN namespace an id came from. share and
+ * ugcPost ids live in different id spaces than activity ids, so the namespace
+ * has to survive normalization; /feed/update/ resolves all three.
+ */
+function linkedInUrnNamespace(token: string): "activity" | "share" | "ugcPost" {
+  const normalized = token.toLowerCase();
+  if (normalized === "shareid" || normalized === "share") return "share";
+  if (normalized === "ugcpostid" || normalized === "ugcpost") return "ugcPost";
+  return "activity";
+}
+
+/**
  * Normalize a post URL or activity id into a linkedin.com update URL.
- * Accepts full URLs, `urn:li:activity:…`, bare activity digits, or
- * `/feed/update/…` paths.
+ * Accepts full URLs, `urn:li:activity:…` / `urn:li:share:…` /
+ * `urn:li:ugcPost:…`, bare activity digits, or `/feed/update/…` paths.
  */
 export function normalizeLinkedInPostUrl(input: string): string | null {
   const raw = input.trim();
@@ -825,10 +845,12 @@ export function normalizeLinkedInPostUrl(input: string): string | null {
     return `https://www.linkedin.com/feed/update/urn:li:activity:${bareId}`;
   }
 
-  // urn:li:activity:123 or activity:123
-  const urnMatch = raw.match(/(?:urn:li:)?activity:(\d{6,})/i);
+  // urn:li:activity:123, urn:li:share:123, urn:li:ugcPost:123, or the bare
+  // `activity:123` shorthand.
+  const urnMatch = raw.match(/(?:urn:li:)?(activity|share|ugcPost):(\d{6,})/i);
   if (urnMatch && !raw.includes("://") && !raw.startsWith("/")) {
-    return `https://www.linkedin.com/feed/update/urn:li:activity:${urnMatch[1]}`;
+    const ns = linkedInUrnNamespace(urnMatch[1] ?? "");
+    return `https://www.linkedin.com/feed/update/urn:li:${ns}:${urnMatch[2] ?? ""}`;
   }
 
   try {
@@ -846,12 +868,14 @@ export function normalizeLinkedInPostUrl(input: string): string | null {
     if (host !== "linkedin.com" && !host.endsWith(".linkedin.com")) {
       return null;
     }
-    // Prefer canonical feed/update URLs when we can extract an activity id.
-    const activityId = `${u.pathname}${u.search}`.match(
-      /(?:urn(?::|%3A)li(?::|%3A))?activity(?::|%3A|-)(\d{6,})/i
-    )?.[1];
-    if (activityId) {
-      return `https://www.linkedin.com/feed/update/urn:li:activity:${activityId}`;
+    // Prefer canonical feed/update URLs when we can extract a post id, keeping
+    // whichever URN namespace the source URL used.
+    const urnInUrl = `${u.pathname}${u.search}`.match(
+      /(?:urn(?::|%3A)li(?::|%3A))?(activity|share|ugcPost)(?::|%3A|-)(\d{6,})/i
+    );
+    if (urnInUrl) {
+      const ns = linkedInUrnNamespace(urnInUrl[1] ?? "");
+      return `https://www.linkedin.com/feed/update/urn:li:${ns}:${urnInUrl[2] ?? ""}`;
     }
     return null;
   } catch {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -336,6 +336,10 @@ interface HomeFeedRow {
    * heuristic when present.
    */
   author_control_label?: string;
+  /** Exact post permalink when the rendered card exposes a feed/update anchor. */
+  post_url?: string;
+  /** Rendered identifier containing LinkedIn's stable shareId / ugcPostId. */
+  post_identity?: string;
   /** Every profile/company anchor in the card, each with its accessible name. */
   links?: HomeFeedLink[];
 }
@@ -380,6 +384,21 @@ const HOME_FEED_SCRAPE_CONFIG = {
       selector: 'button[aria-label*="control menu for post by"]',
       take: "attr",
       attr: "aria-label",
+    },
+    post_url: {
+      // The opaque componentkey cannot be converted back into an activity id,
+      // so capture a canonical link while the real rendered DOM is available.
+      selector: 'a[href*="/feed/update/"]',
+      take: "attr",
+      attr: "href",
+    },
+    post_identity: {
+      // Current feed cards embed the durable id in a translatable-commentary
+      // element id even when every visible anchor points back to /feed/.
+      selector:
+        '[id*="shareId="], [id*="ugcPostId="], [id*="urn:li:activity:"]',
+      take: "attr",
+      attr: "id",
     },
     links: {
       // Every profile/company anchor with its accessible name, so
@@ -635,10 +654,11 @@ export function isHomeFeedNoise(body: string): boolean {
 }
 
 /**
- * Map cs_scrape home-feed rows to event envelopes. The componentkey token is
- * not a numeric activity id, so there is no /feed/update permalink — source_url
- * stays at /feed/. Home-feed posts expose no reliable timestamp, so the caller
- * stamps occurred_at with the sync time.
+ * Map cs_scrape home-feed rows to event envelopes. Prefer a /feed/update anchor
+ * or stable activity id embedded in the card DOM; otherwise source_url falls
+ * back to /feed/.
+ * Home-feed posts expose no reliable timestamp, so the caller stamps
+ * occurred_at with the sync time.
  */
 export function buildHomeFeedEvents(
   rows: HomeFeedRow[],
@@ -710,6 +730,13 @@ export function buildHomeFeedEvents(
       metadata.author_profile_url = profileUrlFor(authorSlug);
     }
 
+    const embeddedActivityId = row.post_identity?.match(
+      /(?:shareId|ugcPostId)=(\d{6,})|urn:li:activity:(\d{6,})/i
+    );
+    const postUrl = normalizeLinkedInPostUrl(
+      row.post_url ?? embeddedActivityId?.[1] ?? embeddedActivityId?.[2] ?? ""
+    );
+
     events.push({
       origin_id: `li_home_${row.id}`,
       payload_text: row.body,
@@ -717,9 +744,7 @@ export function buildHomeFeedEvents(
       // Feed posts expose no reliable timestamp; use the sync time.
       occurred_at: occurredAt,
       origin_type: "post",
-      // Token id is NOT a numeric activity id, so we cannot build a
-      // urn:li:activity permalink — link to the feed itself.
-      source_url: "https://www.linkedin.com/feed/",
+      source_url: postUrl ?? "https://www.linkedin.com/feed/",
       metadata,
     });
   }

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -7,6 +7,7 @@ import {
   defineConnection,
   defineEntityType,
   defineRelationshipType,
+  reactionFromFile,
 } from "@lobu/cli/config";
 import type GoogleTakeoutConnector from "./google-takeout.connector.ts";
 import type InstagramTakeoutConnector from "./instagram-takeout.connector.ts";
@@ -16,6 +17,7 @@ import type SpotifyConnector from "./spotify.connector.ts";
 import type TwitterTakeoutConnector from "./twitter-takeout.connector.ts";
 import type WhatsAppCloudConnector from "./whatsapp.cloud.connector.ts";
 import type MidasConnector from "./midas.connector.ts";
+import type SocialInterestRadarReaction from "./social-interest-radar.reaction.ts";
 
 const hourlyTaskCollaboratorSkill = defineSkill({
   name: "hourly-task-collaborator",
@@ -925,7 +927,161 @@ const mentions = defineRelationshipType({
   description: "Auto-discovered content reference",
 });
 
+const voiceProfile = defineEntityType({
+  key: "voice-profile",
+  name: "Voice profile",
+  description:
+    "How the member sounds (mode=voice) or what they engage with (mode=taste) on one channel. Human analogue of agent identity/soul.",
+  metadata: { icon: "🎙️", color: "#F59E0B" },
+  properties: {
+    mode: {
+      type: "string",
+      enum: ["voice", "taste"],
+      "x-table-label": "Mode",
+      "x-table-column": true,
+    },
+    channel: {
+      type: "string",
+      enum: ["core", "x", "linkedin", "reddit", "instagram"],
+      "x-table-label": "Channel",
+      "x-table-column": true,
+    },
+    summary: { type: "string" },
+    themes: { type: "array", items: { type: "string" } },
+    prefers: { type: "array", items: { type: "string" } },
+    avoids: { type: "array", items: { type: "string" } },
+    confidence: {
+      type: "string",
+      enum: ["low", "medium", "high"],
+      "x-table-label": "Confidence",
+      "x-table-column": true,
+    },
+    evidence_count: {
+      type: "number",
+      "x-table-label": "Evidence",
+      "x-table-column": true,
+    },
+    evidence_from: { type: "string", format: "date" },
+    evidence_to: { type: "string", format: "date" },
+    sample_event_ids: { type: "array", items: { type: "number" } },
+    profile_key: { type: "string" },
+  },
+});
+
+// Deprecated compatibility declaration. The radar now writes threaded events
+// with keyingConfig: null, but prune must retain this type while historical
+// social-signal entity rows still exist. Remove it only through an explicit
+// data migration; it is not part of the active output path.
+const socialSignal = defineEntityType({
+  key: "social-signal",
+  name: "Social Signal",
+  description:
+    "Deprecated historical entity rows from the former Social Interest Radar output path.",
+  metadata: { icon: "radar" },
+  properties: {
+    platform: {
+      type: "string",
+      enum: ["x", "linkedin"],
+      description: "Source platform",
+    },
+    author: {
+      type: "string",
+      minLength: 1,
+      description: 'Post author (never "unknown")',
+    },
+    snippet: { type: "string", description: "Excerpt of the post" },
+    why: {
+      type: "string",
+      minLength: 1,
+      description: "Why this matches taste — specific to this item",
+    },
+    priority: { type: "string", enum: ["high", "normal", "low"] },
+    source_origin_id: {
+      type: "string",
+      description: "Stable events.origin_id of the source post",
+    },
+    source_event_id: {
+      type: "integer",
+      description: "Originating event id (unstable across re-sync)",
+    },
+    suggested_action: { type: "string", description: "Concrete next step" },
+  },
+  required: ["platform", "author", "why", "priority", "source_origin_id"],
+});
+
 // ── Behaviors (must be declared under prune or apply deletes them) ─
+
+const voiceProfileSynthesis = defineBehavior({
+  agent: personalAgent,
+  slug: "voice-profile-synth-v2",
+  name: "Voice profile synthesis",
+  tags: ["voice", "identity", "social"],
+  triggers: [
+    { kind: "schedule", cron: "40 6 * * 1", skip_if_unchanged: false },
+  ],
+  notification: { channel: "canvas", priority: "low" },
+  minCooldownSeconds: 3600,
+  keyingConfig: {
+    entityType: "voice-profile",
+    entityPath: "profiles",
+    keyFields: ["channel", "mode"],
+    keyOutputField: "profile_key",
+  },
+  sources: {
+    authored_recent:
+      "SELECT id, occurred_at, connector_key, origin_type, left(payload_text, 400) AS payload_text, metadata FROM events WHERE payload_text IS NOT NULL AND length(payload_text) >= 40 AND occurred_at > now() - interval '21 days' AND ((connector_key = 'twitter.takeout' AND origin_type IN ('reply','tweet')) OR (connector_key = 'x' AND origin_type IN ('tweet','reply') AND lower(coalesce(metadata->>'author_handle','')) = 'buremba') OR (connector_key IN ('linkedin','linkedin.takeout') AND origin_type = 'message')) ORDER BY occurred_at DESC LIMIT 200",
+    engaged_recent:
+      "SELECT id, occurred_at, connector_key, origin_type, left(payload_text, 300) AS payload_text, metadata FROM events WHERE payload_text IS NOT NULL AND length(payload_text) >= 20 AND occurred_at > now() - interval '21 days' AND ((connector_key IN ('x','twitter.takeout') AND origin_type IN ('liked_tweet','bookmark')) OR (connector_key = 'instagram.takeout' AND origin_type IN ('like','saved','comment'))) ORDER BY occurred_at DESC LIMIT 200",
+    existing_profiles: {
+      context: true,
+      query:
+        "SELECT NULL::bigint AS id, v.name, v.metadata, v.updated_at FROM entities v WHERE v.entity_type = 'voice-profile' AND v.deleted_at IS NULL ORDER BY v.updated_at DESC LIMIT 20",
+    },
+  },
+  prompt:
+    'Refine Burak\'s voice-profile entities.\nexisting_profiles is historical truth. authored_recent/engaged_recent refine last ~21d only.\nALWAYS re-emit all existing profiles. Return JSON:\n{ "profiles":[{ "name","channel","mode","profile_key","summary","themes","prefers","avoids","confidence","evidence_count","evidence_from","evidence_to","sample_event_ids" }], "analysis_summary":"..." }\nNever invent channel=core.',
+  reactionsGuidance:
+    "ALWAYS re-emit every existing_profiles row (same channel/mode/profile_key). Refine if recent evidence; never return empty profiles[] when existing_profiles non-empty.",
+});
+
+const socialInterestRadar = defineBehavior({
+  agent: personalAgent,
+  slug: "social-interest-radar-v2",
+  name: "Social interest radar (X + LinkedIn)",
+  tags: ["social", "x", "linkedin", "notifications"],
+  triggers: [
+    { kind: "schedule", cron: "25 * * * *", skip_if_unchanged: false },
+  ],
+  notification: { channel: "both", priority: "normal" },
+  minCooldownSeconds: 1800,
+  keyingConfig: null,
+  sources: {
+    recent_social:
+      "SELECT id, origin_id, occurred_at, payload_text, source_url, metadata, connector_key, origin_type FROM events WHERE connector_key IN ('x','linkedin') AND ((connector_key='x' AND origin_type IN ('tweet','bookmark')) OR (connector_key='linkedin' AND origin_type='post')) AND payload_text IS NOT NULL ORDER BY occurred_at DESC LIMIT 80",
+    already_emitted: {
+      context: true,
+      query:
+        "SELECT id, metadata->>'source_origin_id' AS source_origin_id FROM events WHERE semantic_type = 'social_signal' AND occurred_at > now() - interval '7 days' ORDER BY occurred_at DESC LIMIT 400",
+    },
+    voice_profiles: {
+      context: true,
+      query:
+        "SELECT NULL::bigint AS id, v.name, v.metadata, v.updated_at FROM entities v WHERE v.entity_type='voice-profile' AND v.deleted_at IS NULL ORDER BY v.updated_at DESC LIMIT 20",
+    },
+    known_people: {
+      context: true,
+      query:
+        "SELECT id, name, metadata FROM entities WHERE entity_type='person' AND deleted_at IS NULL AND (metadata ? 'x_handle' OR metadata ? 'linkedin_url' OR metadata ? 'company') ORDER BY updated_at DESC LIMIT 40",
+    },
+  },
+  prompt:
+    'Rank at most 8 new, high-signal X or LinkedIn posts for Burak. Use voice_profiles for taste and known_people for relationship context. Prefer AI, agents, infrastructure, developer tools, people he knows, launches, funding, and technical substance; ignore engagement bait, generic memes, and ads. Read LinkedIn authors from metadata.author and X authors from metadata.author_handle. Never use "unknown" when an author field exists. For each item, copy the source row\'s id to source_event_id and origin_id to source_origin_id, explain a specific why, and give a concrete suggested_action. Prefer posts not present in already_emitted. Return only the extracted data required by the reaction schema; the deterministic reaction persists threaded replies and sends the notification.',
+  reactionsGuidance:
+    "Rank with voice profiles. The deterministic reaction owns reply-event persistence, retry deduplication, and notification delivery.",
+  reaction: reactionFromFile<typeof SocialInterestRadarReaction>(
+    "./social-interest-radar.reaction.ts"
+  ),
+});
 
 const hourlyTaskCollaborator = defineBehavior({
   agent: personalAgent,
@@ -1013,9 +1169,16 @@ export default defineConfig({
     trip,
     goal,
     learning,
+    voiceProfile,
+    socialSignal,
   ],
   relationships: [worksAt, memberOf, mentions],
-  behaviors: [hourlyTaskCollaborator, duplicateEntityResolution],
+  behaviors: [
+    hourlyTaskCollaborator,
+    duplicateEntityResolution,
+    voiceProfileSynthesis,
+    socialInterestRadar,
+  ],
   connections: [
     midasConnection,
     revolutConnection,

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -1,0 +1,154 @@
+/**
+ * Deterministic delivery for the Social Interest Radar Behavior.
+ *
+ * The model ranks posts and explains why they matter. This reaction owns every
+ * durable side effect: one reply event per source post, followed by one digest
+ * notification linking to the source/reply threads. Both writes carry durable
+ * idempotency keys because the reaction executor retries a failed script.
+ */
+import type {
+  KnowledgeSaveResult,
+  ReactionClient,
+  ReactionContext,
+} from "@lobu/connector-sdk";
+
+export const input = {
+  type: "object",
+  properties: {
+    digest_title: { type: "string", minLength: 1, maxLength: 200 },
+    analysis_summary: { type: "string" },
+    items: {
+      type: "array",
+      maxItems: 8,
+      items: {
+        type: "object",
+        properties: {
+          platform: { enum: ["x", "linkedin"] },
+          author: { type: "string", minLength: 1 },
+          snippet: { type: "string" },
+          why: { type: "string", minLength: 1 },
+          priority: { enum: ["high", "normal", "low"] },
+          source_origin_id: { type: "string", minLength: 1 },
+          source_event_id: { type: "integer", minimum: 1 },
+          suggested_action: { type: "string", minLength: 1 },
+        },
+        required: [
+          "platform",
+          "author",
+          "snippet",
+          "why",
+          "priority",
+          "source_origin_id",
+          "source_event_id",
+          "suggested_action",
+        ],
+      },
+    },
+  },
+  required: ["digest_title", "analysis_summary", "items"],
+};
+
+interface RadarItem {
+  platform: "x" | "linkedin";
+  author: string;
+  snippet: string;
+  why: string;
+  priority: "high" | "normal" | "low";
+  source_origin_id: string;
+  source_event_id: number;
+  suggested_action: string;
+}
+
+interface RadarOutput {
+  digest_title: string;
+  analysis_summary: string;
+  items: RadarItem[];
+}
+
+function producerRunKey(ctx: ReactionContext): string {
+  return ctx.window.run_id != null
+    ? `run:${ctx.window.run_id}`
+    : `window:${ctx.window.id}:version:${ctx.behavior.version}`;
+}
+
+function belongsToProducer(
+  result: KnowledgeSaveResult,
+  producerKey: string
+): boolean {
+  return result.created || result.metadata.producer_run_key === producerKey;
+}
+
+function notificationBody(lines: string[]): string {
+  const body = lines.join("\n");
+  return body.length <= 1000 ? body : `${body.slice(0, 997)}...`;
+}
+
+export default async (
+  ctx: ReactionContext,
+  client: ReactionClient
+): Promise<void> => {
+  const output = ctx.extracted_data as unknown as RadarOutput;
+  if (output.items.length === 0) return;
+
+  const producerKey = producerRunKey(ctx);
+  const delivered: Array<{ item: RadarItem; replyId: number }> = [];
+
+  for (const item of output.items) {
+    const reply = await client.knowledge.save({
+      content: [
+        item.why,
+        "",
+        `Suggested action: ${item.suggested_action}`,
+      ].join("\n"),
+      title: `${item.author} on ${item.platform}`,
+      author: "personal-agent",
+      semantic_type: "social_signal",
+      payload_type: "markdown",
+      parent_event_id: item.source_event_id,
+      idempotency_key: `social-radar:source:${item.source_origin_id}`,
+      metadata: {
+        ...item,
+        producer_run_key: producerKey,
+        behavior_id: ctx.behavior.id,
+        window_id: ctx.window.id,
+      },
+      behavior_source: {
+        behavior_id: ctx.behavior.id,
+        window_id: ctx.window.id,
+      },
+    });
+
+    // A later Behavior run may rank the same post again. knowledge.save returns
+    // its original event, but only the run that first created it should notify.
+    // A retry of THAT run still qualifies through the stored producer key.
+    if (belongsToProducer(reply, producerKey)) {
+      delivered.push({ item, replyId: reply.id });
+    }
+  }
+
+  if (delivered.length === 0) return;
+
+  const contentIds = delivered.flatMap(({ item, replyId }) => [
+    item.source_event_id,
+    replyId,
+  ]);
+  const resourceUrl = `/${encodeURIComponent(ctx.organization_slug)}/memory?content_ids=${contentIds.join(",")}`;
+  const body = notificationBody(
+    delivered.map(
+      ({ item }) =>
+        `[${item.priority}] ${item.author} (${item.platform}) — ${item.why}`
+    )
+  );
+
+  await client.notifications.send({
+    title: output.digest_title,
+    body,
+    recipients: "admins",
+    resource_url: resourceUrl,
+    idempotency_key: `social-radar:notification:${producerKey}`,
+    behavior_source: {
+      behavior_id: ctx.behavior.id,
+      window_id: ctx.window.id,
+    },
+  });
+};

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -521,6 +521,39 @@ describe("apply diff — watchers", () => {
     ).toEqual(["prompt"]);
   });
 
+  test("explicit null keying clears a remote entity binding", () => {
+    const desired = buildState([], {
+      watchers: [{ ...desiredWatcher, keyingConfig: null }],
+    });
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [
+        {
+          slug: "weekly-digest",
+          name: "Weekly digest",
+          agent_id: "triage",
+          prompt: "Produce a digest.",
+          triggers: [{ kind: "schedule", cron: "0 9 * * 1" }],
+          keying_config: {
+            entity_type: "social-signal",
+            entity_path: "items",
+            key_fields: ["source_origin_id"],
+            key_output_field: "stable_key",
+          },
+        },
+      ],
+    };
+
+    const row = computeDiff(desired, remote).rows.find(
+      (candidate) => candidate.kind === "watcher"
+    );
+    expect(row?.verb).toBe("update");
+    expect(row?.changedFields).toContain("keying_config");
+    expect(
+      (row as { versionBoundFields?: string[] }).versionBoundFields
+    ).toContain("keying_config");
+  });
+
   test("reaction_script declared → always re-pushed (idempotent)", () => {
     const desired = buildState([], {
       watchers: [

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -190,6 +190,21 @@ describe("mapProjectToDesiredState", () => {
     ]);
   });
 
+  test("preserves explicit null keying so apply can untype a Behavior", () => {
+    const agent = defineAgent({ id: "radar" });
+    const behavior = defineBehavior({
+      agent,
+      slug: "social-radar",
+      prompt: "Rank social posts.",
+      keyingConfig: null,
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ agents: [agent], behaviors: [behavior] })
+    );
+
+    expect(state.watchers[0]?.keyingConfig).toBeNull();
+  });
+
   test("BYO chat connection carries credentialMode + resolves secret config", () => {
     const slack = defineConnection({
       slug: "team-slack",

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -911,7 +911,7 @@ export class ApplyClient {
     min_cooldown_seconds?: number;
     tags?: string[];
     agent_kind?: string;
-    keying_config?: Record<string, unknown>;
+    keying_config?: Record<string, unknown> | null;
     classifiers?: unknown[];
   }): Promise<{ behavior_id?: string }> {
     const { body } = await this.request<{ behavior_id?: string }>(
@@ -1020,7 +1020,7 @@ export class ApplyClient {
     prompt?: string;
     skills?: Array<{ name: string; content: string }>;
     sources?: BehaviorSource[];
-    keying_config?: Record<string, unknown>;
+    keying_config?: Record<string, unknown> | null;
     classifiers?: unknown[];
     reactions_guidance?: string;
     change_notes?: string;

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -141,7 +141,8 @@ export interface DesiredWatcher {
   /** Optional agent-kind override (e.g. "background", "notifier"). */
   agentKind?: string;
   /** Stable key generation across windows. */
-  keyingConfig?: Record<string, unknown>;
+  /** Stable-key binding; explicit null clears an existing binding. */
+  keyingConfig?: Record<string, unknown> | null;
   /** Classifier definitions for extraction (server-side feature). */
   classifiers?: unknown[];
 }

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -561,7 +561,7 @@ function diffWatcher(
   }
   if (
     desired.keyingConfig !== undefined &&
-    !deepEqual(desired.keyingConfig, remote.keying_config ?? {})
+    !deepEqual(desired.keyingConfig, remote.keying_config ?? null)
   ) {
     versionBound.push("keying_config");
   }

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -643,8 +643,13 @@ function mapBehavior(behavior: Behavior): DesiredWatcher {
     // whole job is its skills, and for event-turn Behaviors with neither.
     prompt: watcher.prompt ?? "",
     ...(watcher.skills?.length ? { skills: watcher.skills } : {}),
-    ...(watcher.keyingConfig
-      ? { keyingConfig: normalizeKeyingConfig(watcher.keyingConfig) }
+    ...(watcher.keyingConfig !== undefined
+      ? {
+          keyingConfig:
+            watcher.keyingConfig === null
+              ? null
+              : normalizeKeyingConfig(watcher.keyingConfig),
+        }
       : {}),
     ...(watcher.name ? { name: watcher.name } : {}),
     ...(watcher.description ? { description: watcher.description } : {}),

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -446,7 +446,7 @@ export interface Behavior {
     keyFields?: string[];
     keyOutputField?: string;
     [k: string]: unknown;
-  };
+  } | null;
   /**
    * Named SQL data sources. Value is either a query string or
    * `{ query, context? }` — `context: true` marks a context-only source

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -247,6 +247,7 @@ export type {
   EntityUpdateInput,
   KnowledgeReadInput,
   KnowledgeSaveInput,
+  KnowledgeSaveResult,
   KnowledgeSearchInput,
   NotificationsSendInput,
 } from './reaction-client-types.js';

--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -40,6 +40,15 @@ export interface KnowledgeSaveInput {
   metadata?: Record<string, unknown>;
   title?: string;
   slug?: string;
+  author?: string;
+  payload_type?: "text" | "markdown" | "json_template" | "media" | "empty";
+  source_url?: string;
+  /** Event this content answers; stored as a durable thread edge. */
+  parent_event_id?: number;
+  /** Stable producer key used to collapse reaction retries. */
+  idempotency_key?: string;
+  occurred_at?: string;
+  behavior_source?: { behavior_id: number; window_id: number };
 }
 
 export interface KnowledgeReadInput {
@@ -50,6 +59,12 @@ export interface KnowledgeReadInput {
   until?: string;
   limit?: number;
   entity_ids?: number[];
+}
+
+export interface KnowledgeSaveResult {
+  id: number;
+  created: boolean;
+  metadata: Record<string, unknown>;
 }
 
 // ── Entities ─────────────────────────────────────────────────────────────────
@@ -107,6 +122,8 @@ export interface NotificationsSendInput {
   recipients?: "admins" | "all" | string[];
   /** Relative URL the notification links to (e.g. `/acme/entities`). */
   resource_url?: string;
+  /** Stable producer key used to collapse retried sends. */
+  idempotency_key?: string;
   /** Deliver only through this specific bot connection (its id). */
   connection_id?: string;
   /** Arbitrary JSON payload appended to the body as formatted JSON. */
@@ -129,7 +146,7 @@ export interface NotificationsSendInput {
 export interface ReactionClient {
   knowledge: {
     search(input: KnowledgeSearchInput): Promise<unknown>;
-    save(input: KnowledgeSaveInput): Promise<unknown>;
+    save(input: KnowledgeSaveInput): Promise<KnowledgeSaveResult>;
     read(input: KnowledgeReadInput): Promise<unknown>;
     delete(input: number | { event_id?: number; event_ids?: number[]; reason?: string }): Promise<unknown>;
   };

--- a/packages/connector-sdk/src/reaction-sdk.ts
+++ b/packages/connector-sdk/src/reaction-sdk.ts
@@ -43,4 +43,6 @@ export interface ReactionContext {
   };
   /** Organization context */
   organization_id: string;
+  /** Stable workspace slug for relative app permalinks. */
+  organization_slug: string;
 }

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -425,10 +425,11 @@ export const ManageBehaviorsSchema = Type.Object(
           // BehaviorKeyingConfigSchema) or the object directly.
           Type.String(),
           BehaviorKeyingConfigSchema,
+          Type.Null(),
         ],
         {
           description:
-            "[create/create_version] Binds extracted rows to an entity type: computes a stable key per row, validates extracted_data against that type's metadata_schema, and promotes each row into an entity.",
+            "[create/create_version] Binds extracted rows to an entity type: computes a stable key per row, validates extracted_data against that type's metadata_schema, and promotes each row into an entity. Pass null on create_version to remove an existing binding and make the Behavior reaction-only.",
         }
       )
     ),

--- a/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
@@ -174,4 +174,46 @@ describe('saveContent > occurred_at default', () => {
     `;
     expect(Number(count.n)).toBe(1);
   });
+
+  it('does not let caller metadata set the reserved idempotency key', async () => {
+    const metadata = {
+      source_origin_id: 'caller-authored-post',
+      _lobu_idempotency_key: 'caller-controlled-key',
+    };
+
+    const first = (await saveContent(
+      {
+        entity_ids: [entityId],
+        content: 'First event with caller-authored metadata.',
+        semantic_type: 'note',
+        metadata,
+      } as never,
+      {} as never,
+      ctx()
+    )) as { id: number };
+    const second = (await saveContent(
+      {
+        entity_ids: [entityId],
+        content: 'Second event with the same caller-authored metadata.',
+        semantic_type: 'note',
+        metadata,
+      } as never,
+      {} as never,
+      ctx()
+    )) as { id: number };
+
+    expect(second.id).not.toBe(first.id);
+    const sql = getTestDb();
+    const rows = await sql`
+      SELECT metadata
+      FROM events
+      WHERE id IN (${first.id}, ${second.id})
+      ORDER BY id
+    `;
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.metadata)).toEqual([
+      { source_origin_id: 'caller-authored-post' },
+      { source_origin_id: 'caller-authored-post' },
+    ]);
+  });
 });

--- a/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
@@ -111,4 +111,67 @@ describe('saveContent > occurred_at default', () => {
     `;
     expect(new Date(row.occurred_at as string).toISOString()).toBe(explicit);
   });
+
+  it('stores a first-class reply edge and inherits the source URL', async () => {
+    const parent = (await saveContent(
+      {
+        entity_ids: [entityId],
+        content: 'Original LinkedIn post.',
+        semantic_type: 'note',
+        source_url: 'https://www.linkedin.com/feed/update/urn:li:activity:123',
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx()
+    )) as { id: number };
+
+    const reply = (await saveContent(
+      {
+        entity_ids: [entityId],
+        content: 'This matters because it is a concrete agent-infrastructure signal.',
+        semantic_type: 'note',
+        parent_event_id: parent.id,
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx()
+    )) as { id: number };
+
+    const sql = getTestDb();
+    const [row] = await sql`
+      SELECT child.origin_parent_id, parent.origin_id AS expected_parent_origin_id,
+             child.source_url
+      FROM events child
+      JOIN events parent ON parent.id = ${parent.id}
+      WHERE child.id = ${reply.id}
+    `;
+    expect(row.origin_parent_id).toBe(row.expected_parent_origin_id);
+    expect(row.source_url).toBe(
+      'https://www.linkedin.com/feed/update/urn:li:activity:123'
+    );
+  });
+
+  it('returns the original event for a repeated idempotency key', async () => {
+    const input = {
+      entity_ids: [entityId],
+      content: 'A retry-safe Behavior reply.',
+      semantic_type: 'note',
+      idempotency_key: 'behavior:71:source:stable-post-1',
+      metadata: { source_origin_id: 'stable-post-1' },
+    } as never;
+
+    const results = (await Promise.all(
+      Array.from({ length: 6 }, () => saveContent(input, {} as never, ctx()))
+    )) as Array<{ id: number }>;
+
+    expect(new Set(results.map((result) => result.id)).size).toBe(1);
+    const sql = getTestDb();
+    const [count] = await sql`
+      SELECT count(*)::int AS n
+      FROM events
+      WHERE organization_id = ${org.id}
+        AND metadata->>'_lobu_idempotency_key' = 'behavior:71:source:stable-post-1'
+    `;
+    expect(Number(count.n)).toBe(1);
+  });
 });

--- a/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
-import { resolveBotDeliveryTargets } from "../../../notifications/service";
+import {
+	createNotificationForUsers,
+	resolveBotDeliveryTargets,
+} from "../../../notifications/service";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import { createTestBehaviorSubscription } from "../../setup/behavior-subscriptions";
 import {
@@ -124,6 +127,44 @@ describe("resolveBotDeliveryTargets", () => {
 				teamId: "T_TEST",
 			},
 		]);
+	});
+
+	it("deduplicates a retried notification by idempotency key", async () => {
+		const org = await createTestOrganization();
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const params = {
+			organizationId: org.id,
+			type: "agent_message" as const,
+			title: "Social signal",
+			body: "A retry-safe Behavior notification.",
+			resourceUrl: `/${org.slug}/memory?content_ids=42`,
+			idempotencyKey: "behavior:71:run:9001:notification",
+		};
+
+		await Promise.all(
+			Array.from({ length: 6 }, () =>
+				createNotificationForUsers([user.id], params as never),
+			),
+		);
+
+		const sql = getTestDb();
+		const [events] = await sql`
+			SELECT count(*)::int AS n
+			FROM events
+			WHERE organization_id = ${org.id}
+			  AND semantic_type = 'notification'
+			  AND metadata->>'_lobu_idempotency_key' = ${params.idempotencyKey}
+		`;
+		const [targets] = await sql`
+			SELECT count(*)::int AS n
+			FROM notification_targets nt
+			JOIN events e ON e.id = nt.event_id
+			WHERE e.organization_id = ${org.id}
+			  AND e.metadata->>'_lobu_idempotency_key' = ${params.idempotencyKey}
+		`;
+		expect(Number(events.n)).toBe(1);
+		expect(Number(targets.n)).toBe(1);
 	});
 
 	it("returns nothing for a connection with no binding", async () => {

--- a/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
@@ -12,6 +12,8 @@ import {
 	createNotificationForUsers,
 	resolveBotDeliveryTargets,
 } from "../../../notifications/service";
+import { notify } from "../../../tools/admin/notify";
+import type { ToolContext } from "../../../tools/registry";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import { createTestBehaviorSubscription } from "../../setup/behavior-subscriptions";
 import {
@@ -165,6 +167,32 @@ describe("resolveBotDeliveryTargets", () => {
 		`;
 		expect(Number(events.n)).toBe(1);
 		expect(Number(targets.n)).toBe(1);
+	});
+
+	it("reports zero notified recipients when notify deduplicates a retry", async () => {
+		const org = await createTestOrganization();
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const ctx = {
+			organizationId: org.id,
+			userId: user.id,
+			memberRole: "owner",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopedToOrg: false,
+			allowCrossOrg: true,
+			scopes: ["mcp:admin"],
+			sourceContext: null,
+		} as ToolContext;
+		const args = {
+			action: "send" as const,
+			title: "Social signal",
+			body: "A retry-safe Behavior notification.",
+			idempotency_key: "behavior:71:run:9002:notification",
+		};
+
+		expect(await notify(args, {} as never, ctx)).toEqual({ notified_count: 1 });
+		expect(await notify(args, {} as never, ctx)).toEqual({ notified_count: 0 });
 	});
 
 	it("returns nothing for a connection with no binding", async () => {

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -707,6 +707,39 @@ describe('watcher CRUD', () => {
     await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
   });
 
+  it('clears entity promotion when create_version receives keying_config: null', async () => {
+    const created = (await owner.behaviors.create({
+      entity_id: entityId,
+      slug: 'clear-keying-config-watcher',
+      name: 'Clear Keying Config Watcher',
+      prompt: 'Extract companies.',
+      agent_id: agentId,
+      keying_config: {
+        entity_type: 'company',
+        entity_path: 'items',
+        key_fields: ['name'],
+        key_output_field: 'stable_key',
+      },
+    })) as { behavior_id: string };
+
+    await owner.behaviors.createVersion({
+      behavior_id: created.behavior_id,
+      keying_config: null,
+      change_notes: 'switch to reaction-only output',
+    });
+
+    const sql = getTestDb();
+    const [row] = await sql`
+      SELECT wv.keying_config AS version_keying_config
+      FROM watchers w
+      JOIN watcher_versions wv ON wv.id = w.current_version_id
+      WHERE w.id = ${created.behavior_id}
+    `;
+    expect(row.version_keying_config).toBeNull();
+
+    await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
+  });
+
   it('round-trips execution_config through create → list → update', async () => {
     const created = (await owner.behaviors.create({
       entity_id: entityId,

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -19,6 +19,8 @@ interface CreateNotificationParams {
 	resourceType?: string | null;
 	resourceId?: string | null;
 	resourceUrl?: string | null;
+	/** Stable producer key used to collapse retried notification sends. */
+	idempotencyKey?: string | null;
 	/** When set, deliver only through this specific bot connection */
 	connectionId?: string | null;
 	/** When set, deliver only to this Behavior-subscribed channel. */
@@ -293,8 +295,8 @@ async function deliverToBotConnections(
 export async function createNotificationForUsers(
 	userIds: string[],
 	params: Omit<CreateNotificationParams, "userId">,
-): Promise<void> {
-	if (userIds.length === 0) return;
+): Promise<{ created: boolean }> {
+	if (userIds.length === 0) return { created: false };
 	const sql = getDb();
 
 	// fetch_types:false safe: entity_ids is a `{n,...}` literal (or NULL) cast to
@@ -304,7 +306,7 @@ export async function createNotificationForUsers(
 			? `{${params.entityIds.join(",")}}`
 			: null;
 
-	await sql.begin(async (tx) => {
+	const created = await sql.begin(async (tx) => {
 		const inserted = (await tx`
       INSERT INTO events
         (organization_id, entity_ids, title, payload_text, payload_type, semantic_type,
@@ -322,12 +324,18 @@ export async function createNotificationForUsers(
 					resource_type: params.resourceType ?? null,
 					resource_id: params.resourceId ?? null,
 					resource_url: params.resourceUrl ?? null,
+					...(params.idempotencyKey
+						? { _lobu_idempotency_key: params.idempotencyKey }
+						: {}),
 				})}
       )
+      ON CONFLICT (organization_id, (metadata->>'_lobu_idempotency_key'))
+        WHERE metadata ? '_lobu_idempotency_key'
+      DO NOTHING
       RETURNING id
     `) as unknown as Array<{ id: number }>;
 		const eventId = inserted[0]?.id;
-		if (!eventId) return;
+		if (!eventId) return false;
 
 		await tx`
       INSERT INTO notification_targets (event_id, user_id)
@@ -335,7 +343,9 @@ export async function createNotificationForUsers(
       FROM unnest(${pgTextArray(userIds)}::text[]) AS u(uid)
       ON CONFLICT DO NOTHING
     `;
+		return true;
 	});
+	if (!created) return { created: false };
 
 	// Deliver to bot connections (fire-and-forget). The bot delivery targets
 	// the org's connection default channels and is identical for every user in
@@ -346,6 +356,7 @@ export async function createNotificationForUsers(
 			"[Notifications] Failed to deliver to bot connections",
 		),
 	);
+	return { created: true };
 }
 
 export async function listNotifications(opts: {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -493,7 +493,7 @@ export default async (_ctx, client) => {
 			"Send a notification to org users. Writes an `agent_message` notification (in-app inbox) and fans it out to the org's active bot connections (Slack/Telegram) — the way a Behavior reaction surfaces its digest to a chat channel. Pass an optional `card` (a `chat` CardElement) for rich cross-platform rendering, and `behavior_source` when firing from a reaction.",
 		access: "write",
 		signature:
-			"notifications.send(input: { title: string; body?: string; card?: CardElement; recipients?: 'admins' | 'all' | string[]; resource_url?: string; connection_id?: string; data?: object; behavior_source?: { behavior_id: number; window_id: number } }): Promise<{ notified_count: number }>",
+			"notifications.send(input: { title: string; body?: string; card?: CardElement; recipients?: 'admins' | 'all' | string[]; resource_url?: string; idempotency_key?: string; connection_id?: string; data?: object; behavior_source?: { behavior_id: number; window_id: number } }): Promise<{ notified_count: number }>",
 		example:
 			"await client.notifications.send({ title: 'Weekly funnel digest', body: '3 new leads...', behavior_source: { behavior_id: ctx.window.behavior_id, window_id: ctx.window.id } });",
 		usageExample: `// Push a Behavior digest to the org's Slack/Telegram connections + inbox.

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -34,6 +34,13 @@ export interface KnowledgeSaveInput {
 	metadata?: Record<string, unknown>;
 	title?: string;
 	slug?: string;
+	author?: string;
+	payload_type?: "text" | "markdown" | "json_template" | "media" | "empty";
+	source_url?: string;
+	parent_event_id?: number;
+	idempotency_key?: string;
+	occurred_at?: string;
+	behavior_source?: { behavior_id: number; window_id: number };
 }
 
 export interface KnowledgeReadInput {

--- a/packages/server/src/sandbox/namespaces/notifications.ts
+++ b/packages/server/src/sandbox/namespaces/notifications.ts
@@ -33,6 +33,8 @@ export interface NotificationsSendInput {
 	recipients?: "admins" | "all" | string[];
 	/** Relative URL the notification links to (e.g. `/acme/entities`). */
 	resource_url?: string;
+	/** Stable producer key used to collapse retried sends. */
+	idempotency_key?: string;
 	/** Deliver only through this specific bot connection (its id). */
 	connection_id?: string;
 	/** Arbitrary JSON payload appended to the body as formatted JSON. */

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -716,9 +716,10 @@ export async function handleCompleteWindow(
   const watcherMetaRows = await watcherMetaSql`
     SELECT w.reaction_script_compiled, w.entity_ids,
            w.organization_id, w.current_version_id,
-           w.name,
+           w.name, o.slug AS organization_slug,
            wv.version as watcher_version
     FROM watchers w
+    JOIN organization o ON o.id = w.organization_id
     LEFT JOIN watcher_versions wv ON w.current_version_id = wv.id
     WHERE w.id = ${result.behavior_id}
   `;
@@ -779,6 +780,7 @@ export async function handleCompleteWindow(
           version: Number(row.watcher_version ?? 1),
         },
         organization_id: orgId,
+        organization_slug: String(row.organization_slug),
       };
 
       const MAX_ATTEMPTS = 3;

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -133,8 +133,13 @@ export async function handleCreateVersion(
   );
   assertKeyingConfigShape(callerKeyingConfig);
   const keyingConfig =
-    callerKeyingConfig ??
-    normalizeStoredJsonField(prev.keying_config, undefined as Record<string, unknown> | undefined);
+    args.keying_config === null
+      ? null
+      : (callerKeyingConfig ??
+        normalizeStoredJsonField(
+          prev.keying_config,
+          undefined as Record<string, unknown> | undefined
+        ));
   const classifiers =
     parseJsonInput<unknown[]>(args.classifiers, 'classifiers') ??
     normalizeStoredJsonField(prev.classifiers, undefined as unknown[] | undefined);

--- a/packages/server/src/tools/admin/notify.ts
+++ b/packages/server/src/tools/admin/notify.ts
@@ -43,6 +43,14 @@ const SendAction = Type.Object({
   resource_url: Type.Optional(
     Type.String({ description: 'Relative URL to link the notification to (e.g. /acme/entities)' })
   ),
+  idempotency_key: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: 300,
+      description:
+        'Stable producer key. Repeating a send with the same key returns success without creating or delivering a duplicate.',
+    })
+  ),
   connection_id: Type.Optional(
     Type.String({
       description:
@@ -160,21 +168,24 @@ async function handleSend(
     if (rows.length > 0) canvasEntityIds = [Number(rows[0].entity_id)];
   }
 
-  await createNotificationForUsers(userIds, {
+  const notification = await createNotificationForUsers(userIds, {
     organizationId: ctx.organizationId,
     type: 'agent_message',
     title: args.title,
     body,
     resourceUrl: args.resource_url ?? null,
+    idempotencyKey: args.idempotency_key ?? null,
     connectionId: args.connection_id ?? null,
     card: (args.card as CardElement | undefined) ?? null,
     entityIds: canvasEntityIds,
   });
 
-  emit(ctx.organizationId, { keys: ['notifications', 'notifications-unread-count'] });
+  if (notification.created) {
+    emit(ctx.organizationId, { keys: ['notifications', 'notifications-unread-count'] });
+  }
 
   // Track watcher reaction if attribution source is provided
-  if (args.behavior_source) {
+  if (notification.created && args.behavior_source) {
     await trackWatcherReaction({
       organizationId: ctx.organizationId,
       watcherId: args.behavior_source.behavior_id,

--- a/packages/server/src/tools/admin/notify.ts
+++ b/packages/server/src/tools/admin/notify.ts
@@ -198,5 +198,5 @@ async function handleSend(
     });
   }
 
-  return { notified_count: userIds.length };
+  return { notified_count: notification.created ? userIds.length : 0 };
 }

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -488,9 +488,15 @@ async function saveContentImpl(
 
   // Reserved delivery metadata is added only after the caller-authored event
   // metadata passes its event-kind schema. It is platform bookkeeping, not a
-  // domain field the entity type needs to declare.
+  // domain field the entity type needs to declare. Strip it from caller
+  // metadata unconditionally. A key smuggled in that way (e.g. metadata copied
+  // forward from a prior KnowledgeSaveResult) would land on the row without
+  // going through the preflight read or the unique-violation reconciliation,
+  // surfacing a raw Postgres conflict on collision.
+  const { _lobu_idempotency_key: _reservedIdempotencyKey, ...callerMetadata } =
+    args.metadata ?? {};
   const eventMetadata: Record<string, unknown> = {
-    ...(args.metadata ?? {}),
+    ...callerMetadata,
     ...(args.idempotency_key ? { _lobu_idempotency_key: args.idempotency_key } : {}),
   };
 

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -11,7 +11,7 @@ import { normalizeAuthUserId, normalizeEmail } from '@lobu/connector-sdk/identit
 import { type Static, Type } from '@sinclair/typebox';
 import { hasRequiredMcpScope } from '../auth/tool-access';
 import { resolveChannelEntityId } from '../authz/channel-entity';
-import { getDb } from '../db/client';
+import { type DbClient, getDb, parsePgNumberArray } from '../db/client';
 import type { Env } from '../index';
 import { autoLinkEvent } from '../utils/auto-linker';
 import { ToolUserError } from '../utils/errors';
@@ -26,6 +26,7 @@ import {
 } from '../utils/org-guidance';
 import { ensureMemberEntityType } from '../utils/member-entity-type';
 import { requireWriteAccess } from '../utils/organization-access';
+import { isUniqueViolation } from '../utils/pg-errors';
 import { validateTemplateHandlers } from '../utils/validate-json-template';
 import { trackWatcherReaction } from '../utils/watcher-reactions';
 import { isSystemContext } from './access-control';
@@ -53,6 +54,36 @@ function isSupersededByUniqueViolation(error: unknown): boolean {
     err.constraint_name === 'idx_events_superseded_by' ||
     (typeof err.message === 'string' && err.message.includes('idx_events_superseded_by'))
   );
+}
+
+async function findIdempotentEvent(
+  sql: DbClient,
+  organizationId: string,
+  idempotencyKey: string
+): Promise<
+  | (Awaited<ReturnType<typeof insertEvent>> & { metadata: Record<string, unknown> })
+  | undefined
+> {
+  const rows = await sql`
+    SELECT id, entity_ids, origin_id, title, semantic_type, created_at, metadata
+    FROM events
+    WHERE organization_id = ${organizationId}
+      AND metadata ? '_lobu_idempotency_key'
+      AND metadata->>'_lobu_idempotency_key' = ${idempotencyKey}
+    LIMIT 1
+  `;
+  if (rows.length === 0) return undefined;
+  const row = rows[0];
+  return {
+    id: Number(row.id),
+    entity_ids: parsePgNumberArray(row.entity_ids),
+    origin_id: String(row.origin_id ?? ''),
+    title: row.title == null ? null : String(row.title),
+    semantic_type: String(row.semantic_type),
+    created_at: String(row.created_at),
+    change: 'unchanged',
+    metadata: (row.metadata ?? {}) as Record<string, unknown>,
+  };
 }
 
 // ============================================
@@ -113,6 +144,21 @@ export const SaveContentSchema = Type.Object({
   source_url: Type.Optional(
     Type.String({ description: 'URL of the original source for this content.' })
   ),
+  parent_event_id: Type.Optional(
+    Type.Integer({
+      minimum: 1,
+      description:
+        'Event this content answers. The saved event is threaded under the source and inherits its source_url when one is not supplied.',
+    })
+  ),
+  idempotency_key: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: 300,
+      description:
+        'Stable producer key. Repeating a save with the same key returns the original event instead of appending a duplicate.',
+    })
+  ),
   occurred_at: Type.Optional(
     Type.String({
       description: 'When the event actually happened (ISO 8601). Defaults to now if omitted.',
@@ -169,6 +215,10 @@ interface SaveContentResult {
   indexing_status: 'pending' | 'completed';
   /** Convenience mirror of `indexing_status === 'completed'`. */
   searchable: boolean;
+  /** True only for the call that appended the event; false on an idempotent replay. */
+  created: boolean;
+  /** Metadata on the durable event (the original metadata on an idempotent replay). */
+  metadata: Record<string, unknown>;
   exact_read: { method: 'client.knowledge.read'; content_ids: [number] };
 }
 
@@ -403,55 +453,127 @@ async function saveContentImpl(
     }
   }
 
+  // 5b. Resolve the source event for a first-class reply. `origin_parent_id`
+  // stores the source's stable external origin, so the child continues to
+  // thread under the current source row even when a connector re-sync
+  // supersedes the exact event id the Behavior originally read.
+  let parentOriginId: string | null = null;
+  let parentSourceUrl: string | null = null;
+  if (args.parent_event_id !== undefined) {
+    const parentRows = await sql`
+      SELECT origin_id, source_url
+      FROM events
+      WHERE id = ${args.parent_event_id}
+        AND organization_id = ${ctx.organizationId}
+      LIMIT 1
+    `;
+    if (parentRows.length === 0) {
+      throw new ToolUserError(
+        `Cannot reply to event ${args.parent_event_id}: not found in this organization`,
+        404
+      );
+    }
+    parentOriginId = String(parentRows[0].origin_id ?? '');
+    if (!parentOriginId) {
+      throw new ToolUserError(
+        `Cannot reply to event ${args.parent_event_id}: source has no origin id`,
+        422
+      );
+    }
+    parentSourceUrl = parentRows[0].source_url ? String(parentRows[0].source_url) : null;
+  }
+
   // 6. Insert into events
   const externalId = `uc_${crypto.randomUUID()}`;
 
+  // Reserved delivery metadata is added only after the caller-authored event
+  // metadata passes its event-kind schema. It is platform bookkeeping, not a
+  // domain field the entity type needs to declare.
+  const eventMetadata: Record<string, unknown> = {
+    ...(args.metadata ?? {}),
+    ...(args.idempotency_key ? { _lobu_idempotency_key: args.idempotency_key } : {}),
+  };
+
   let row: Awaited<ReturnType<typeof insertEvent>>;
-  try {
-    row = await insertEvent({
-      entityIds: finalEntityIds,
-      organizationId: ctx.organizationId,
-      originId: externalId,
-      title: args.title,
-      payloadType,
-      content: args.content ?? null,
-      payloadData: args.payload_data,
-      payloadTemplate: args.payload_template ?? null,
-      attachments: args.attachments,
-      authorName: args.author,
-      sourceUrl: args.source_url ?? null,
-      // The schema promises "Defaults to now if omitted" — honor it. A NULL
-      // occurred_at makes the event invisible to watcher windows (window
-      // content filters on occurred_at within [window_start, window_end)).
-      occurredAt: args.occurred_at ?? new Date().toISOString(),
-      semanticType,
-      metadata: args.metadata,
-      createdBy: ctx.userId,
-      clientId: ctx.clientId,
-      supersedesEventId: args.supersedes_event_id ?? null,
-    });
-  } catch (error) {
-    // The "already superseded?" SELECT above is non-atomic: two concurrent
-    // supersedes of the same target both pass the read, both INSERT, and the
-    // loser hits the partial unique index idx_events_superseded_by with a raw
-    // 23505. The unique index protects the invariant (no data loss) — surface
-    // it as a clean 409 user error instead of a raw DB error + Sentry alert.
-    if (
-      args.supersedes_event_id &&
-      isSupersededByUniqueViolation(error)
-    ) {
+  let inserted = true;
+  let persistedMetadata = eventMetadata;
+  const prior = args.idempotency_key
+    ? await findIdempotentEvent(sql, ctx.organizationId, args.idempotency_key)
+    : undefined;
+  if (prior) {
+    if (prior.semantic_type !== semanticType) {
       throw new ToolUserError(
-        `Cannot supersede event ${args.supersedes_event_id}: already superseded by a concurrent write`,
+        `Idempotency key '${args.idempotency_key}' already belongs to semantic type '${prior.semantic_type}'`,
         409
       );
     }
-    throw error;
+    row = prior;
+    inserted = false;
+    persistedMetadata = prior.metadata;
+  } else {
+    try {
+      row = await insertEvent({
+        entityIds: finalEntityIds,
+        organizationId: ctx.organizationId,
+        originId: externalId,
+        title: args.title,
+        payloadType,
+        content: args.content ?? null,
+        payloadData: args.payload_data,
+        payloadTemplate: args.payload_template ?? null,
+        attachments: args.attachments,
+        authorName: args.author,
+        sourceUrl: args.source_url ?? parentSourceUrl,
+        // The schema promises "Defaults to now if omitted" — honor it. A NULL
+        // occurred_at makes the event invisible to watcher windows (window
+        // content filters on occurred_at within [window_start, window_end)).
+        occurredAt: args.occurred_at ?? new Date().toISOString(),
+        semanticType,
+        metadata: eventMetadata,
+        parentOriginId,
+        createdBy: ctx.userId,
+        clientId: ctx.clientId,
+        supersedesEventId: args.supersedes_event_id ?? null,
+      });
+    } catch (error) {
+      // Two replicas may race after the preflight read. The unique index is the
+      // lock; the loser resolves and returns the winner's durable event.
+      if (
+        args.idempotency_key &&
+        isUniqueViolation(error, 'idx_events_org_idempotency_key')
+      ) {
+        const winner = await findIdempotentEvent(
+          sql,
+          ctx.organizationId,
+          args.idempotency_key
+        );
+        if (!winner) throw error;
+        if (winner.semantic_type !== semanticType) {
+          throw new ToolUserError(
+            `Idempotency key '${args.idempotency_key}' already belongs to semantic type '${winner.semantic_type}'`,
+            409
+          );
+        }
+        row = winner;
+        inserted = false;
+        persistedMetadata = winner.metadata;
+      } else if (args.supersedes_event_id && isSupersededByUniqueViolation(error)) {
+        // The "already superseded?" SELECT above is non-atomic: two concurrent
+        // supersedes can both pass the read. Surface the index conflict cleanly.
+        throw new ToolUserError(
+          `Cannot supersede event ${args.supersedes_event_id}: already superseded by a concurrent write`,
+          409
+        );
+      } else {
+        throw error;
+      }
+    }
   }
 
   // 6b. Auto-link: scan content for entity name mentions.
   // Awaited so the background work doesn't outlive the tool call and reject
   // into an unhandled promise after the DB pool has been torn down.
-  if (finalEntityIds.length > 0) {
+  if (inserted && finalEntityIds.length > 0) {
     await autoLinkEvent({
       eventId: Number(row.id),
       entityIds: finalEntityIds,
@@ -469,12 +591,13 @@ async function saveContentImpl(
       entity_ids: finalEntityIds,
       semantic_type: semanticType,
       supersedes: args.supersedes_event_id,
+      idempotent_replay: !inserted,
     },
-    'Content saved via save_memory'
+    inserted ? 'Content saved via save_memory' : 'Content save replay returned existing event'
   );
 
   // Track watcher reaction if attribution source is provided
-  if (args.behavior_source) {
+  if (inserted && args.behavior_source) {
     await trackWatcherReaction({
       organizationId: ctx.organizationId,
       watcherId: args.behavior_source.behavior_id,
@@ -511,13 +634,15 @@ async function saveContentImpl(
     durable_at: String(row.created_at),
     indexing_status: searchable ? 'completed' : 'pending',
     searchable,
-		// `knowledge.read` takes `content_ids` (array) — a singular `content_id`
-		// is rejected as an unknown argument, so the self-documenting hint must
-		// use the exact shape the reader accepts.
-		exact_read: {
-			method: 'client.knowledge.read',
-			content_ids: [savedId],
-		},
+    created: inserted,
+    metadata: persistedMetadata,
+    // `knowledge.read` takes `content_ids` (array) — a singular `content_id`
+    // is rejected as an unknown argument, so the self-documenting hint must
+    // use the exact shape the reader accepts.
+    exact_read: {
+      method: 'client.knowledge.read',
+      content_ids: [savedId],
+    },
   };
   if (args.supersedes_event_id) {
     result.supersedes_event_id = args.supersedes_event_id;

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -493,8 +493,8 @@ async function saveContentImpl(
   // forward from a prior KnowledgeSaveResult) would land on the row without
   // going through the preflight read or the unique-violation reconciliation,
   // surfacing a raw Postgres conflict on collision.
-  const { _lobu_idempotency_key: _reservedIdempotencyKey, ...callerMetadata } =
-    args.metadata ?? {};
+  const callerMetadata: Record<string, unknown> = { ...(args.metadata ?? {}) };
+  delete callerMetadata._lobu_idempotency_key;
   const eventMetadata: Record<string, unknown> = {
     ...callerMetadata,
     ...(args.idempotency_key ? { _lobu_idempotency_key: args.idempotency_key } : {}),


### PR DESCRIPTION
## Summary

- Persist one deterministic `social_signal` child event for each selected X/LinkedIn source event, with `parent_event_id`, stable `origin_parent_id`, inherited `source_url`, and write-time idempotency.
- Point the notification at a relative Memory thread containing both source and reply events, so the click shows the original post, its external link, and the agent's answer.
- Let `keying_config: null` explicitly clear entity promotion. Social Radar no longer creates `social-signal` entities; `voice-profile` remains the durable taste input, and the old type is retained only as a historical prune guard.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted reaction, LinkedIn, CLI apply, event, notification, and Behavior CRUD suites
- [x] Bug fix: red→fix→green outputs pasted below
- [x] If bot behavior: ran the Social Interest Radar reaction tests

### Red

Live authenticated notification click before the fix:

```text
/buremba/agents/lobu-builder/chat/https:/app.lobu.ai/buremba/agents/personal-agent/behaviors/71
Page not found
```

The Behavior's ranked output was projected into `social-signal` entities and its notification targeted the Behavior page; there was no durable source→answer event edge for the Activity/Memory UI to render.

### Green

```text
Social Radar reaction + LinkedIn connector: 104 pass, 0 fail
CLI declarative apply suites:             108 pass, 0 fail
Server event/notification suites:           43 pass, 0 fail
Reserved-key event + notification suites:   17 pass, 0 fail
Behavior CRUD integration suite:             26 pass, 0 fail
Migration lint:                               0 errors
make pre-pr:                                  clean
```

Coverage includes:

```text
persists a threaded reply and links the notification to both events
does not notify again when a later run re-ranks an existing post
stores a first-class reply edge and inherits the source URL
returns the original event for a repeated idempotency key
clears entity promotion when create_version receives keying_config: null
preserves explicit null keying so apply can untype a Behavior
```

## Notes

- Owletto #683 and Lobu #2434 independently merged/deployed the legacy absolute-notification 404 fix while this branch was in progress. The redundant Owletto #679 was closed; this PR contains no UI/submodule diff.
- `make review-fix` was attempted on the settled diff. Fable is quota-blocked; Opus exceeded the local three-minute process ceiling and made no working-tree changes. The required posted `make review` remains the merge gate.
- The partial unique index uses the reserved metadata key `_lobu_idempotency_key`; the migration heals an invalid prior concurrent index before recreating it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Social Interest Radar automation with voice-profile context, threaded knowledge entries, and linked digest notifications.
  * Added threaded content saving with source inheritance and replay-safe idempotency support.
  * Added optional idempotency keys for notifications to prevent duplicate deliveries.
  * Added support for clearing behavior keying configuration during updates.
  * LinkedIn feed items now use canonical post URLs when available.

* **Bug Fixes**
  * Improved concurrent retry handling to avoid duplicate events, notifications, and side effects.

* **Tests**
  * Expanded coverage for URL normalization, retries, threading, and configuration clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up: idempotency hardening

### Red

```text
saveContent > does not let caller metadata set the reserved idempotency key
PostgresError: duplicate key value violates unique constraint "idx_events_org_idempotency_key"

notify > reports zero notified recipients when notify deduplicates a retry
Expected: { notified_count: 0 }
Received: { notified_count: 1 }
```

### Green

```text
Server event + notification integration: 19 pass, 0 fail
LinkedIn connector including share/ugcPost URN preservation: 101 pass, 0 fail
make pre-pr on final rebased HEAD: clean
```