### PR TITLE
chore(ci): use GitHub-hosted runners

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -69,7 +69,7 @@ env:
 
 jobs:
   generate-tag:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       tag: ${{ steps.tags.outputs.tag }}
       semver: ${{ steps.tags.outputs.semver }}
@@ -105,7 +105,7 @@ jobs:
   # amd64-only (no QEMU/arm64): a smoke gate, not a release. Reuses the same GHA
   # buildx cache scope as `build-worker` so this doesn't double the build cost.
   connector-parity-smoke:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [generate-tag]
     if: needs.generate-tag.outputs.should_publish == 'true'
     timeout-minutes: 25
@@ -117,11 +117,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Build worker image (amd64, load, no push)
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64
@@ -129,6 +129,8 @@ jobs:
           load: true
           push: false
           tags: lobu-worker:parity-smoke
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
 
       - name: Worker image self-check (docker run --network=none)
         run: |
@@ -136,7 +138,7 @@ jobs:
             bun src/bin.ts self-check --json
 
   build-app:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: needs.generate-tag.outputs.should_publish == 'true'
     # Push the app image LAST. Flux's ImageUpdateAutomation only watches
     # the app image policy, but the chart applies one shared tag to app,
@@ -167,8 +169,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
         uses: docker/login-action@v4
@@ -188,7 +190,7 @@ jobs:
             type=raw,value=latest,enable=${{ needs.generate-tag.outputs.is_stable == 'true' }}
 
       - name: Build and push App image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ env.BUILD_PLATFORMS }}
@@ -196,6 +198,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=app
+          cache-to: type=gha,mode=min,scope=app
           build-args: |
             CACHEBUST=${{ github.sha }}
             APP_GIT_SHA=${{ github.sha }}
@@ -227,7 +231,7 @@ jobs:
   # image) and #2183 (app image serving 404s for its own assets) — both with
   # every check green.
   app-image-smoke:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [generate-tag, build-app]
     if: needs.generate-tag.outputs.should_publish == 'true'
     timeout-minutes: 20
@@ -269,7 +273,7 @@ jobs:
             "${REGISTRY}/${IMAGE_NAME_APP}:${{ needs.generate-tag.outputs.tag }}"
 
   build-worker:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # Gate the worker push (and transitively the app push, which `needs:
     # build-worker`) on the parity smoke passing.
     needs: [generate-tag, connector-parity-smoke]
@@ -285,8 +289,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
         uses: docker/login-action@v4
@@ -306,7 +310,7 @@ jobs:
             type=raw,value=latest,enable=${{ needs.generate-tag.outputs.is_stable == 'true' }}
 
       - name: Build and push Worker image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ env.BUILD_PLATFORMS }}
@@ -316,6 +320,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # Share the buildx cache scope with the connector-parity-smoke job so
           # its amd64 layers are reused here (only the arm64 leg is new work).
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
 
       - name: Make image public
         run: |
@@ -327,7 +333,7 @@ jobs:
             -d '{"visibility":"public"}' || true
 
   build-embeddings-service:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [generate-tag]
     if: needs.generate-tag.outputs.should_publish == 'true'
     permissions:
@@ -341,8 +347,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
         uses: docker/login-action@v4
@@ -362,7 +368,7 @@ jobs:
             type=raw,value=latest,enable=${{ needs.generate-tag.outputs.is_stable == 'true' }}
 
       - name: Build and push Embeddings Service image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ env.BUILD_PLATFORMS }}
@@ -370,6 +376,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Make image public
         run: |
@@ -397,7 +405,7 @@ jobs:
   # so when it fails Flux may already be rolling a broken image — exactly the
   # case that must ping, not just redden the workflow.
   notify-failure:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [generate-tag, connector-parity-smoke, build-worker, build-embeddings-service, build-app, app-image-smoke]
     if: >-
       failure()

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -376,8 +376,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=embeddings
+          cache-to: type=gha,mode=max,scope=embeddings
 
       - name: Make image public
         run: |

--- a/.github/workflows/build-pgvector-embedded.yml
+++ b/.github/workflows/build-pgvector-embedded.yml
@@ -131,7 +131,7 @@ jobs:
 
   open-pr:
     needs: build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   # waiting behind DB setup. Worker tests run under bun (full suite, not the
   # cherry-picked subset that used to live here).
   unit:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -187,7 +187,7 @@ jobs:
   # mock OpenAI-compatible provider (no provider key needed). A failure here
   # fails CI → the PR goes red. See scripts/sdk-e2e.sh.
   sdk-e2e:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -232,7 +232,7 @@ jobs:
   # HOME and walks the whole command surface, asserting each runs or fails
   # gracefully. A failure here fails CI → the PR goes red. See scripts/cli-smoke.sh.
   cli-smoke:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -270,7 +270,7 @@ jobs:
   # white-screen" packaging bugs. Build uses the same `bun run build` path as
   # docker/app/Dockerfile. Forks without the deploy key get a stub and skip.
   frontend:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
@@ -308,9 +308,8 @@ jobs:
         run: cd packages/owletto && bun run build
 
       - name: Install Google Chrome for SPA boot smoke
-        # Ubuntu apt chromium/chromium-browser is a *snap* shim. Snap will not
-        # launch under Blacksmith's runner cgroup:
-        #   "is not a snap cgroup for tag snap.chromium.chromium"
+        # Ubuntu apt chromium/chromium-browser is a *snap* shim rather than a
+        # directly runnable browser binary.
         # Playwright's bundled browser also fights monorepo patchright/playwright
         # revision skew. Install real Google Chrome .deb (non-snap) and point
         # the smoke at it.
@@ -337,7 +336,7 @@ jobs:
   # APIs in places, and (2) the sandbox runtime requires isolated-vm which
   # is a V8 native addon that bun cannot load.
   integration:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     services:
       postgres:
@@ -500,7 +499,7 @@ jobs:
           fail_ci_if_error: false
 
   format-lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -632,7 +631,7 @@ jobs:
           bash scripts/lib/__tests__/review-upstream-guard.test.sh
 
   typecheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -704,7 +703,7 @@ jobs:
     # uses (scripts/migrate-up.mjs), so a migration that only the prod runner
     # can apply (e.g. transaction:false heal-DO + CONCURRENTLY) is validated
     # here instead of silently diverging from `dbmate up`.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     services:
       postgres:
@@ -888,7 +887,7 @@ jobs:
   # never matches. Use git diff against the PR base instead. On push events
   # (main) there's no PR object, so default to running the smoke job.
   mac-build-smoke-filter:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
@@ -932,7 +931,7 @@ jobs:
   mac-build-smoke:
     needs: mac-build-smoke-filter
     if: needs.mac-build-smoke-filter.outputs.run == 'true'
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: macos-15
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -981,7 +980,7 @@ jobs:
   # list, so we diff against the PR base. On push (main) there's no PR object,
   # so default to running.
   connector-parity-smoke-filter:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
@@ -1019,7 +1018,7 @@ jobs:
   connector-parity-smoke:
     needs: connector-parity-smoke-filter
     if: needs.connector-parity-smoke-filter.outputs.run == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
@@ -1032,15 +1031,15 @@ jobs:
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       # Build the worker image for amd64 only (no QEMU/arm64 — this is a smoke
       # gate, not a release) and load it into the local daemon instead of
       # pushing. Reuse the GHA buildx cache shared with build-images.yml so this
       # leg doesn't pay a cold worker build.
       - name: Build worker image (amd64, load, no push)
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64
@@ -1048,6 +1047,8 @@ jobs:
           load: true
           push: false
           tags: lobu-worker:parity-smoke
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
 
       # The real prod runtime contract: run the built image's self-check with NO
       # network, so a green result can't depend on reaching anything external.
@@ -1086,7 +1087,7 @@ jobs:
   # runner without a user session must not redden main. Read the summary, do
   # not gate on it. No checkout: the probe only inspects the runner itself.
   exec-sandbox-backend-probe:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     continue-on-error: true
     steps:
@@ -1147,7 +1148,7 @@ jobs:
   # so a future rebuild on a newer base can't silently reintroduce it. Cheap
   # enough (seconds, no deps) that it runs unfiltered.
   pgvector-glibc-floor:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/codex-auto-approve.yml
+++ b/.github/workflows/codex-auto-approve.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   approve:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     # Event-driven runs are gated to Codex authors. Scheduled sweeps and
     # manual dispatches always run.

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
 
@@ -43,7 +43,7 @@ jobs:
   publish:
     needs: lint
     if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   triage-issue:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/lobu-apply-atlas.yml
+++ b/.github/workflows/lobu-apply-atlas.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   apply:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -77,7 +77,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: macos-15
     if: >-
       github.event_name == 'workflow_dispatch'
       || startsWith(github.event.release.tag_name, 'lobu-v')

--- a/.github/workflows/merge-integrity.yml
+++ b/.github/workflows/merge-integrity.yml
@@ -28,7 +28,7 @@ jobs:
   # button before the damage.
   base-branch-guard:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
 
@@ -46,7 +46,7 @@ jobs:
     if: |
       github.event_name != 'pull_request'
       || (github.event.action == 'closed' && github.event.pull_request.merged == true)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -54,7 +54,7 @@ jobs:
     # build-images' own notify-failure already sent. The scheduled canary
     # still covers plain health.
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
       # Full history: the rollout gate runs `git merge-base --is-ancestor`

--- a/.github/workflows/providers-live.yml
+++ b/.github/workflows/providers-live.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   live-providers:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   publish-packages:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: production
     env:

--- a/.github/workflows/release-image-audit.yml
+++ b/.github/workflows/release-image-audit.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   audit:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     environment: production
     outputs:
@@ -42,7 +42,7 @@ jobs:
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       # Delegate the actual publish to publish-packages.yml so there's

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   static-guards:
     name: Static security guards
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v7
@@ -49,7 +49,7 @@ jobs:
 
   bun-security-tests:
     name: Security tests (bun:test)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     services:
       postgres:
@@ -131,7 +131,7 @@ jobs:
 
   vitest-security-tests:
     name: Security tests (vitest)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     services:
       postgres:

--- a/.github/workflows/submodule-drift.yml
+++ b/.github/workflows/submodule-drift.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   check-drift:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   audit:
     name: bun audit
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
@@ -40,7 +40,7 @@ jobs:
 
   trivy:
     name: Trivy (vuln + secret + misconfig)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read

--- a/scripts/install-bubblewrap.sh
+++ b/scripts/install-bubblewrap.sh
@@ -28,9 +28,7 @@ if [ -z "$installed" ]; then
   exit 1
 fi
 
-# Only flip the AppArmor userns restriction when the kernel exposes it
-# (GitHub-hosted ubuntu-24.04). Blacksmith's Firecracker microVMs don't
-# restrict unprivileged user namespaces and lack this sysctl key.
+# Only flip the AppArmor userns restriction when the runner kernel exposes it.
 if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
   sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 fi


### PR DESCRIPTION
## Summary

- move all 43 Blacksmith runner labels to GitHub-hosted `ubuntu-24.04` / `macos-15` runners
- replace the five Blacksmith Docker builder/build actions with official Docker actions and isolated GitHub Actions cache scopes
- remove vendor-specific comments, including via merged Owletto PR #686, and pin current `owletto/main`

## Test plan

- [x] `make pre-pr` clean (fresh build + typecheck + knip + lint + exposed-surface naming)
- [x] `actionlint -shellcheck= -pyflakes= -ignore `unexpected key description` .github/workflows/*.yml`
- [x] `git diff --check`
- [x] Red: `git grep -i -l blacksmith origin/main -- .` found 19 tracked Lobu files plus 2 Owletto comments
- [x] Green: repository-wide search found zero Blacksmith or useblacksmith references
- [x] Full PR workflow suite green on GitHub-hosted runners, including integration and Docker image parity smoke

## Notes

- `make review-fix` and `make review` were attempted with Fable explicitly selected, but Fable quota was exhausted. No Opus fallback was used, per request.
- Current comparison: the last Blacksmith CI run completed in 4m29s; this GitHub-hosted run took 11m52s for its longest job, making Blacksmith about 2.6x faster.
- Historical comparison around the original migration: 21 successful PR CI runs before Blacksmith had a 12.2-minute median; the first 30 after had a 4.45-minute median, about 2.7x faster / 64% less runner time. This is observational, not an identical-SHA A/B test.
- Owletto PR: https://github.com/lobu-ai/owletto/pull/686