### PR TITLE
test(server): remove abort timing flake

### DIFF
--- a/packages/server/src/__tests__/unit/sandbox/abort.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/abort.test.ts
@@ -20,15 +20,12 @@ describe("sandbox sleep", () => {
     await expect(sleepAgainstAbort(30_001, signal)).rejects.toThrow(/SleepLimitExceeded/);
   });
 
-  it("rejects promptly with the overall script abort reason", async () => {
+  it("rejects an active sleep with the overall script abort reason", async () => {
     const controller = new AbortController();
-    setTimeout(() => controller.abort(new Error("TimeoutError: script deadline")), 10);
-    const started = Date.now();
+    const sleeping = sleepAgainstAbort(1_000, controller.signal);
+    controller.abort(new Error("TimeoutError: script deadline"));
 
-    await expect(sleepAgainstAbort(1_000, controller.signal)).rejects.toThrow(
-      /script deadline/,
-    );
-    expect(Date.now() - started).toBeLessThan(200);
+    await expect(sleeping).rejects.toThrow(/script deadline/);
   });
 });
 

--- a/packages/server/src/__tests__/unit/sandbox/abort.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/abort.test.ts
@@ -23,9 +23,10 @@ describe("sandbox sleep", () => {
   it("rejects an active sleep with the overall script abort reason", async () => {
     const controller = new AbortController();
     const sleeping = sleepAgainstAbort(1_000, controller.signal);
-    controller.abort(new Error("TimeoutError: script deadline"));
+    const reason = new Error("TimeoutError: script deadline");
+    controller.abort(reason);
 
-    await expect(sleeping).rejects.toThrow(/script deadline/);
+    await expect(sleeping).rejects.toBe(reason);
   });
 });
 


### PR DESCRIPTION
## Summary

- replace a scheduler-sensitive 200ms wall-clock assertion with deterministic cancellation of an already-active sleep
- keep the behavioral contract: aborting the signal must reject with the script deadline reason instead of waiting for the 1s sleep

## Test plan

- [x] Red: post-merge GitHub-hosted unit job failed at `abort.test.ts:31`: expected elapsed `< 200`, received `216`
- [x] Green: `bun test packages/server/src/__tests__/unit/sandbox/abort.test.ts` — 7 pass, 0 fail
- [x] Green: targeted file passed 20/20 consecutive runs
- [x] `make pre-pr`
- [ ] `make test-unit` after a fresh build: 823 pass, 12 skip, 1 unrelated host-specific bwrap expectation failed on macOS; the PR unit job is the Linux gate

## Notes

- `make review-fix` was attempted with Fable; quota remains exhausted. No Opus fallback was used, per request.
- Red run: https://github.com/lobu-ai/lobu/actions/runs/30774314175/job/91566766498

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated abort handling coverage to verify immediate cancellation during an active sleep.
  * Continued validating that the script deadline reason is correctly propagated.
  * Improved test determinism by removing timing-dependent delays and elapsed-time assertions.
  * No changes were made to exported or public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- The Owletto pointer is also advanced to current `owletto/main` so the required drift gate remains valid.
