### PR TITLE
perf(ci): parallelize integration and package builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+# Least-privilege GITHUB_TOKEN for every job in this workflow. No job writes to
+# the GitHub API (no artifacts, no `gh`, no comments); the submodule checkout
+# authenticates with OWLETTO_WEB_DEPLOY_KEY, not the token.
+permissions:
+  contents: read
+
 # Auto-cancel superseded runs on a PR so a force-push/rebase doesn't leave the
 # previous (now-stale) run burning ~10 parallel jobs to completion. `main`
 # pushes are never cancelled (ref is unique per push) so deploy-side gating is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,13 +331,21 @@ jobs:
         if: steps.submodule.outputs.stubbed != 'true'
         run: cd packages/owletto && bun run smoke:boot
 
-  # Backend integration tests need a real Postgres + pgvector. We run them
-  # under Node (not bun) for two reasons: (1) the vitest suite uses Node-only
-  # APIs in places, and (2) the sandbox runtime requires isolated-vm which
-  # is a V8 native addon that bun cannot load.
-  integration:
+  # Backend integration tests need a real Postgres + pgvector. The Vitest
+  # files share a module graph and database within one process, so each shard
+  # remains single-forked; the shards themselves get isolated runners and
+  # databases. This preserves the hermeticity constraints in vitest.config.ts
+  # while removing the old 5-7 minute serial Vitest step from CI's critical
+  # path. `integration` below remains the stable required check and fails
+  # closed unless every shard and Bun/Postgres suite succeeds.
+  server-integration-vitest:
+    name: integration-vitest (${{ matrix.shard }}/3)
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     services:
       postgres:
         image: pgvector/pgvector:pg18
@@ -412,7 +420,7 @@ jobs:
 
       - name: Verify Postgres health (fail fast if pgvector setup is broken)
         run: |
-          for i in {1..20}; do
+          for _ in {1..20}; do
             if pg_isready -h 127.0.0.1 -p 5433 -U postgres; then break; fi
             sleep 1
           done
@@ -429,7 +437,7 @@ jobs:
           PGPASSWORD=postgres psql -h 127.0.0.1 -p 5433 -U postgres \
             -c "ALTER SYSTEM SET maintenance_work_mem='256MB'" -c "SELECT pg_reload_conf()"
 
-      - name: server integration suite (vitest under Node)
+      - name: server integration suite shard ${{ matrix.shard }}/3 (vitest under Node)
         working-directory: packages/server
         # Fail-closed double gate (#1216): vitest's exit code alone went green
         # on a run with 8 failed tests (a `beforeExit` hook from a transitive
@@ -439,10 +447,83 @@ jobs:
         # report (crashed run) also fails.
         run: |
           node node_modules/.bin/vitest run --reporter=default --reporter=json --outputFile.json="$RUNNER_TEMP/vitest-report.json" \
+            --shard=${{ matrix.shard }}/3 \
             --coverage.enabled --coverage.provider=v8 --coverage.reporter=lcov --coverage.reportsDirectory=coverage
-          # vitest writes coverage/lcov.info; rename so later bun steps don't clobber it.
-          mv coverage/lcov.info coverage/vitest.lcov.info
+          mv coverage/lcov.info coverage/vitest-shard-${{ matrix.shard }}.lcov.info
           node ../../scripts/assert-vitest-report-clean.mjs "$RUNNER_TEMP/vitest-report.json"
+
+      - name: Upload server integration coverage shard ${{ matrix.shard }}/3
+        if: always()
+        uses: codecov/codecov-action@v7
+        with:
+          directory: packages/server/coverage
+          flags: server-integration-vitest-${{ matrix.shard }}
+          fail_ci_if_error: false
+
+  # The bun:test suites need Postgres but are intentionally separate from
+  # Vitest: they use bun's runner and several gateway directories need their
+  # own process for module/fixture isolation. Running this job alongside the
+  # Vitest shards removes another ~2 minutes from the serial critical path.
+  server-integration-bun:
+    name: integration-bun
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: pgvector/pgvector:pg18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: lobu_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/lobu_test
+      DB_POOL_MAX: '5'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-submodule
+        with:
+          deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages server depends on
+        run: |
+          cd packages/core && bun run build && cd ../..
+          cd packages/connector-sdk && bun run build && cd ../..
+          cd packages/embeddings && bun run build && cd ../..
+          cd packages/connector-worker && bun run build && cd ../..
+          cd packages/pgvector-embedded && bun run build && cd ../..
+
+      - name: Verify Postgres health (fail fast if pgvector setup is broken)
+        run: |
+          for _ in {1..20}; do
+            if pg_isready -h 127.0.0.1 -p 5433 -U postgres; then break; fi
+            sleep 1
+          done
+          PGPASSWORD=postgres psql -h 127.0.0.1 -p 5433 -U postgres -d lobu_test \
+            -c "CREATE EXTENSION IF NOT EXISTS vector"
+
+      - name: Raise maintenance_work_mem for ivfflat index builds
+        run: |
+          PGPASSWORD=postgres psql -h 127.0.0.1 -p 5433 -U postgres \
+            -c "ALTER SYSTEM SET maintenance_work_mem='256MB'" -c "SELECT pg_reload_conf()"
 
       - name: server gateway suites (bun:test, needs Postgres)
         # The gateway bun:test files are excluded from vitest (vitest.config.ts)
@@ -489,14 +570,33 @@ jobs:
           bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__ --coverage
           mv coverage/lcov.info coverage/server-postgres-other.lcov.info
 
-      - name: Upload server integration coverage
+      - name: Upload server Bun/Postgres coverage
         if: always()
         uses: codecov/codecov-action@v7
         with:
-          # vitest + every instrumented bun:test step above write into this dir.
           directory: packages/server/coverage
-          flags: server-integration
+          flags: server-integration-bun
           fail_ci_if_error: false
+
+  # Keep the branch-protection context stable while the expensive work fans
+  # out above. Matrix failures collapse into `needs.*.result == failure`, and
+  # this job runs under `always()` so a failed/cancelled dependency cannot turn
+  # into a skipped required check.
+  integration:
+    if: always()
+    needs: [server-integration-vitest, server-integration-bun]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every backend integration job
+        env:
+          VITEST_RESULT: ${{ needs.server-integration-vitest.result }}
+          BUN_RESULT: ${{ needs.server-integration-bun.result }}
+        run: |
+          echo "Vitest matrix: $VITEST_RESULT"
+          echo "Bun/Postgres: $BUN_RESULT"
+          test "$VITEST_RESULT" = success
+          test "$BUN_RESULT" = success
 
   format-lint:
     runs-on: ubuntu-24.04
@@ -834,7 +934,7 @@ jobs:
         # fresh sessions pick it up). Wait for readiness first (this job has no
         # health-wait step of its own).
         run: |
-          for i in {1..20}; do
+          for _ in {1..20}; do
             if pg_isready -h 127.0.0.1 -p 5432 -U postgres; then break; fi
             sleep 1
           done

--- a/Makefile
+++ b/Makefile
@@ -38,24 +38,9 @@ typecheck:
 	fi
 	@echo "✅ Typecheck clean."
 
-# Build all TypeScript packages in dependency order
+# Build all TypeScript packages in dependency-aware parallel layers.
 build-packages:
-	@echo "📦 Building all TypeScript packages..."
-	@for pkg in core plugin-api plugin-host plugin-toolkit plugin-memory plugin-conversations plugin-media plugin-mcp pgvector-embedded connector-sdk client agent-worker embeddings connector-worker promptfoo-provider; do \
-		echo "   📦 Building packages/$$pkg..."; \
-		( cd packages/$$pkg && bun run build ) || exit $$?; \
-	done
-	@echo "   📦 Building packages/server bundle..."
-	@( cd packages/server && bun run build:server ) || exit $$?
-	@if [ -f packages/owletto/package.json ]; then \
-		echo "   📦 Building packages/owletto (web UI)..."; \
-		( cd packages/owletto && bun run build ) || exit $$?; \
-	else \
-		echo "   ⚠️  packages/owletto absent — CLI will ship headless (API only)"; \
-	fi
-	@echo "   📦 Building packages/cli..."
-	@( cd packages/cli && bun run build ) || exit $$?
-	@echo "✅ All packages built successfully!"
+	@node scripts/build-packages.mjs
 
 # Ensure packages/owletto is initialized; warn on drift but don't auto-fix
 # (drift may be active feature-branch work — clobbering it silently is worse than the warning).

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -35,7 +35,7 @@ Root `AGENTS.md` holds the invariants and the workflow. This file holds the mech
 
 **Phantom `TS2305: Module '@lobu/core' has no exported member 'X'` inside a worktree.** The worktree's own `@lobu/*` dists are missing, so tsc resolves through the *main checkout's* stale dist. Build the worktree's dists (`make build-packages`). `packages/core` is `composite: true`, so use `bunx tsc --build --force` — a plain `rm -rf dist` leaves a stale `tsconfig.tsbuildinfo` behind. Diagnose with `bunx tsc --noEmit --traceResolution 2>&1 | grep "@lobu/core"`.
 
-**A new workspace package must be added to three build lists or CI fails while local passes.** In dependency order: the `build-packages` loop in `Makefile`, the unit job's inline build step in `.github/workflows/ci.yml` (it builds packages individually, not via make), and `build:packages` in the root `package.json`. Symptom is `TS2307: Cannot find module '@lobu/<pkg>'` cascading into implicit-any noise. Reproduce locally with `rm -rf packages/<pkg>/dist` then typecheck.
+**A new workspace package must be added to both build graphs or CI fails while local passes.** Add it at the correct dependency layer in `scripts/build-packages.mjs` and to the unit job's inline build step in `.github/workflows/ci.yml` (the unit job intentionally builds a narrower package set). `make build-packages` and root `build:packages` both call the script, so there is no third list. Symptom is `TS2307: Cannot find module '@lobu/<pkg>'` cascading into implicit-any noise. Reproduce locally with `rm -rf packages/<pkg>/dist` then typecheck.
 
 **Inter-package deps are always `"@lobu/*": "workspace:*"`.** Never a hardcoded version or caret range — the root `package.json` is the single source of version truth.
 
@@ -77,6 +77,8 @@ Both helpers are exported from `packages/server/src/db/client.ts`. `sql.array(a)
 **`could not create shared memory segment: No space left on device` on macOS.** The SHMMNI limit, not disk. Reap detached segments: `ipcs -mob`, then `ipcrm -m <id>` for entries with `nattch=0` **only**.
 
 **Integration suite prerequisites.** Node 22 is the repo default (`.node-version`); Lobu accepts Node 22–24 and 26+, while Node 25 boots without the SDK sandbox. Global setup uses `DATABASE_URL` if set, otherwise spawns an ephemeral embedded Postgres + pgvector.
+
+**Vitest 3.2.6 `list --shard=N/M` prints every file, even though `run --shard=N/M` partitions correctly.** Do not use `vitest list` to prove shard coverage. Run each shard with the JSON reporter and compare `testResults`: the three-way CI split owns 126 of 378 files per shard, with no overlap at execution time.
 
 **`make dev` is not the test harness.** It migrates its owned local per-branch database and boots the app, but that does not exercise the branches a relevant unit or integration suite covers.
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:coverage": "bun test packages/core/src packages/plugin-api/src packages/plugin-host/src packages/plugin-toolkit/src packages/plugin-memory/src packages/plugin-conversations/src packages/plugin-media/src packages/plugin-mcp/src packages/client/src packages/agent-worker/src --coverage",
     "typecheck": "tsc --noEmit",
     "dev": "./scripts/dev-native.sh",
-    "build:packages": "cd packages/core && bun run build && cd ../plugin-api && bun run build && cd ../plugin-host && bun run build && cd ../plugin-toolkit && bun run build && cd ../plugin-memory && bun run build && cd ../plugin-conversations && bun run build && cd ../plugin-media && bun run build && cd ../plugin-mcp && bun run build && cd ../pgvector-embedded && bun run build && cd ../connector-sdk && bun run build && cd ../client && bun run build && cd ../agent-worker && bun run build && cd ../embeddings && bun run build && cd ../connector-worker && bun run build && cd ../promptfoo-provider && bun run build && cd ../server && bun run build:server && cd .. && if [ -f owletto/package.json ]; then (cd owletto && bun run build); else echo '[build:packages] owletto submodule absent — CLI ships headless (API only)'; fi && cd cli && bun run build",
+    "build:packages": "node scripts/build-packages.mjs",
     "build:lobu": "cd packages/embeddings && bun run build && cd ../..",
     "watch:packages": "tsc -b --watch packages/core packages/agent-worker",
     "test:packages": "cd packages/core && bun run test && cd ../agent-worker && bun run test",

--- a/scripts/build-packages.mjs
+++ b/scripts/build-packages.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+function packageBuild(packageName, script = "build") {
+  return {
+    label: `packages/${packageName}`,
+    cwd: fileURLToPath(new URL(`../packages/${packageName}/`, import.meta.url)),
+    args: ["run", script],
+  };
+}
+
+function runBuild(build) {
+  console.log(`   📦 Building ${build.label}...`);
+  return new Promise((resolve) => {
+    const child = spawn("bun", build.args, {
+      cwd: build.cwd,
+      env: process.env,
+      stdio: "inherit",
+    });
+    child.on("error", (error) => resolve({ ...build, error }));
+    child.on("exit", (code, signal) => resolve({ ...build, code, signal }));
+  });
+}
+
+async function runLayer(label, builds) {
+  console.log(
+    `🔹 ${label} (${builds.length} parallel build${builds.length === 1 ? "" : "s"})`
+  );
+  const results = await Promise.all(builds.map(runBuild));
+  const failures = results.filter(
+    (result) => result.error || result.code !== 0
+  );
+  if (failures.length === 0) return;
+
+  for (const failure of failures) {
+    const detail =
+      failure.error?.message ??
+      `exit ${failure.code ?? "unknown"}${failure.signal ? ` (${failure.signal})` : ""}`;
+    console.error(`❌ ${failure.label}: ${detail}`);
+  }
+  throw new Error(
+    `${failures.length} package build${failures.length === 1 ? "" : "s"} failed in ${label}`
+  );
+}
+
+const layers = [
+  [
+    "foundations",
+    [
+      "core",
+      "plugin-api",
+      "pgvector-embedded",
+      "client",
+      "embeddings",
+      "promptfoo-provider",
+    ].map((name) => packageBuild(name)),
+  ],
+  [
+    "contracts",
+    ["plugin-host", "plugin-toolkit", "connector-sdk"].map((name) =>
+      packageBuild(name)
+    ),
+  ],
+  [
+    "plugins",
+    ["plugin-memory", "plugin-conversations", "plugin-media", "plugin-mcp"].map(
+      (name) => packageBuild(name)
+    ),
+  ],
+  [
+    "runtimes",
+    ["agent-worker", "connector-worker"].map((name) => packageBuild(name)),
+  ],
+];
+
+const applications = [packageBuild("server", "build:server")];
+if (existsSync(new URL("../packages/owletto/package.json", import.meta.url))) {
+  applications.push(packageBuild("owletto"));
+} else {
+  console.warn(
+    "⚠️  packages/owletto absent — CLI will ship headless (API only)"
+  );
+}
+layers.push(["applications", applications]);
+layers.push(["distribution", [packageBuild("cli")]]);
+
+console.log("📦 Building all TypeScript packages by dependency layer...");
+try {
+  for (const [label, builds] of layers) await runLayer(label, builds);
+  console.log("✅ All packages built successfully!");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- split the 378-file server Vitest integration suite into three isolated GitHub Actions shards, each with its own pgvector service
- run the Bun/Postgres gateway suites alongside Vitest and preserve `integration` as a fail-closed required-check aggregator
- replace duplicated sequential package-build lists with one dependency-aware parallel build graph used by both `make build-packages` and `bun run build:packages`

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Workflow schema: `actionlint -shellcheck= .github/workflows/ci.yml`
- [x] Real shard execution with embedded Postgres and the existing JSON fail-closed guard:
  - shard 1/3: 126 files, 899 tests, 0 failures
  - shard 2/3: 126 files, 1,382 tests, 0 failures
  - shard 3/3: 126 files, 1,003 tests, 0 failures
- [x] `make build-packages` and `bun run build:packages`
- [x] Build failure injection: removing `bun` from child PATH returns non-zero in the foundations layer and does not advance
- [ ] `make test-unit`: 823 pass, 12 skip, 1 unrelated local macOS bwrap expectation failure; the required Linux unit job is the execution gate

## Red -> green evidence

Red baseline on GitHub-hosted main CI: https://github.com/lobu-ai/lobu/actions/runs/30775528229

- workflow: 7m58s
- integration job: 7m54s
- sequential Vitest: 4m40s
- sequential gateway Bun suites: 2m05s

Green local execution:

- all 378 Vitest files execute exactly once across three 126-file shards; 3,284 tests pass
- dependency-layer package build: 68.70s sequential baseline -> 40.78s parallel locally (indicative; PR CI is the authoritative hosted-runner benchmark)

## Notes

- `integration` remains the required branch-protection context. It runs under `always()` and fails unless both the Vitest matrix and Bun/Postgres job report `success`; failed or cancelled dependencies cannot become a skipped green gate.
- Standard GitHub-hosted runners remain the recommended path for this public repository. They are free; persistent self-hosted runners are unsafe for untrusted public PR code. A later dedicated-runner experiment should use ephemeral ARC runners on an isolated node pool only.
- `make review-fix` was attempted with Fable; quota remains exhausted. No Opus fallback was used, per request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Package builds now run in dependency order, with independent packages built in parallel for faster and more reliable results.
  - Build failures are clearly reported and correctly return a failed status.

- **Testing & CI**
  - Integration tests now run across multiple parallel test shards.
  - Coverage reports are separated by test run to prevent collisions.
  - CI permissions are restricted to read-only repository access.

- **Documentation**
  - Updated build and testing guidance, including instructions for verifying sharded test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->