### PR TITLE
fix(server): secure root embedded Postgres traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ packages/*/~/
 .mac-cli-auth-e2e/
 examples/lobu-crm/evals/tool-surface/last-run.json
 examples/lobu-crm/evals/discovery-surface/last-run.json
+# Interrupted embedded Postgres traversal-test fixtures.
+.lobu-pgtrav-*

--- a/packages/server/src/__tests__/embedded-pg-traversal.test.ts
+++ b/packages/server/src/__tests__/embedded-pg-traversal.test.ts
@@ -1,0 +1,298 @@
+import {
+	chmodSync,
+	chownSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	symlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	ensureEmbeddedPostgresIdentity,
+	ensureEmbeddedPgTraversal,
+	type EmbeddedPostgresIdentity,
+} from "../embedded-runtime";
+
+// Root-mode boot: embedded-postgres refuses to run as root, so it drops the
+// cluster to a `postgres` user. That user must be able to *traverse* every
+// ancestor of the paths it touches — the embedded binaries and the datadir — or
+// the setuid spawn dies with EACCES before exec. Grant only that OS group
+// traverse access (`g+x`, never read/write), then restore the original
+// ownership/mode when PostgreSQL stops.
+describe("ensureEmbeddedPgTraversal", () => {
+	const dirs: string[] = [];
+	const originalCwd = process.cwd();
+	const processGid = process.getgid?.();
+	const alternateGroups =
+		process.getgroups?.().filter((gid) => gid !== processGid) ?? [];
+	afterEach(() => {
+		process.chdir(originalCwd);
+		while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+	});
+
+	function fixture(): string {
+		// Keep the fixture below the repo rather than macOS's protected per-user
+		// temp root (`sunlnk`), whose mode cannot be changed even by its owner.
+		const root = mkdtempSync(join(originalCwd, ".lobu-pgtrav-"));
+		dirs.push(root);
+		return root;
+	}
+
+	function postgresIdentity(): EmbeddedPostgresIdentity {
+		const uid = typeof process.getuid === "function" ? process.getuid() : 501;
+		const gid = typeof process.getgid === "function" ? process.getgid() : 20;
+		return { uid: uid + 1, gid, groups: new Set([gid]) };
+	}
+
+	it("grants scoped traversal on inaccessible ancestors and restores it", () => {
+		const root = fixture();
+		const home = join(root, "home");
+		const cache = join(home, "npx", "node_modules", "@lobu", "cli");
+		mkdirSync(cache, { recursive: true });
+		chmodSync(home, 0o700);
+		chmodSync(join(home, "npx"), 0o700);
+
+		const lease = ensureEmbeddedPgTraversal([cache], postgresIdentity());
+
+		expect(lease.granted).toContain(home);
+		expect(lease.granted).toContain(join(home, "npx"));
+		expect(lstatSync(home).mode & 0o010).toBe(0o010);
+		expect(lstatSync(home).mode & 0o001).toBe(0);
+		expect(lstatSync(join(home, "npx")).mode & 0o010).toBe(0o010);
+		expect(lstatSync(join(home, "npx")).mode & 0o001).toBe(0);
+		// An already-traversable component is left alone.
+		expect(lease.granted).not.toContain(cache);
+
+		lease.restore();
+		expect(lstatSync(home).mode & 0o777).toBe(0o700);
+		expect(lstatSync(join(home, "npx")).mode & 0o777).toBe(0o700);
+	});
+
+	it("is idempotent — a second run grants nothing new", () => {
+		const root = fixture();
+		const home = join(root, "home");
+		const target = join(home, "npx");
+		mkdirSync(target, { recursive: true });
+		chmodSync(home, 0o700);
+		const identity = postgresIdentity();
+
+		const first = ensureEmbeddedPgTraversal([target], identity);
+		expect(lstatSync(home).mode & 0o010).toBe(0o010);
+
+		const second = ensureEmbeddedPgTraversal([target], identity);
+		expect(second.granted).toEqual([]);
+		second.restore();
+		first.restore();
+		expect(lstatSync(home).mode & 0o777).toBe(0o700);
+	});
+
+	it("no-ops when every component is already traversable", () => {
+		const root = fixture();
+		chmodSync(root, 0o755);
+		const lease = ensureEmbeddedPgTraversal([root], postgresIdentity());
+		expect(lease.granted).toEqual([]);
+		lease.restore();
+	});
+
+	it("creates a missing datadir ancestor and makes it traversable (cold boot)", () => {
+		const root = fixture();
+		const dataRoot = join(root, "home", ".lobu");
+		// Reproduce the 0077 umask of a root container that created the parent.
+		const previousUmask = process.umask(0o077);
+		try {
+			const lease = ensureEmbeddedPgTraversal([dataRoot], postgresIdentity());
+			expect(lease.granted).toContain(dataRoot);
+			expect(lstatSync(dataRoot).isDirectory()).toBe(true);
+			expect(lstatSync(dataRoot).mode & 0o010).toBe(0o010);
+			expect(lstatSync(dataRoot).mode & 0o001).toBe(0);
+			lease.restore();
+			expect(lstatSync(dataRoot).mode & 0o777).toBe(0o700);
+		} finally {
+			process.umask(previousUmask);
+		}
+	});
+
+	it("walks absolute parents for the documented relative file://. shape", () => {
+		const root = fixture();
+		const restricted = join(root, "restricted");
+		const project = join(restricted, "project");
+		mkdirSync(project, { recursive: true });
+		chmodSync(project, 0o700);
+		process.chdir(project);
+		chmodSync(restricted, 0o700);
+
+		const lease = ensureEmbeddedPgTraversal([".lobu"], postgresIdentity());
+
+		expect(lease.granted).toContain(restricted);
+		expect(lease.granted).toContain(project);
+		expect(lstatSync(restricted).mode & 0o010).toBe(0o010);
+		lease.restore();
+		expect(lstatSync(restricted).mode & 0o777).toBe(0o700);
+	});
+
+	it("walks both a symlink's lexical ancestors and its real target", () => {
+		const root = fixture();
+		const lexicalParent = join(root, "lexical");
+		const realParent = join(root, "real");
+		const realTarget = join(realParent, "native");
+		mkdirSync(lexicalParent);
+		mkdirSync(realTarget, { recursive: true });
+		chmodSync(lexicalParent, 0o700);
+		chmodSync(realParent, 0o700);
+		const link = join(lexicalParent, "native");
+		symlinkSync(realTarget, link);
+
+		const lease = ensureEmbeddedPgTraversal([link], postgresIdentity());
+
+		expect(lease.granted).toContain(lexicalParent);
+		expect(lease.granted).toContain(realParent);
+		expect(lstatSync(lexicalParent).mode & 0o010).toBe(0o010);
+		expect(lstatSync(realParent).mode & 0o010).toBe(0o010);
+		lease.restore();
+		expect(lstatSync(lexicalParent).mode & 0o777).toBe(0o700);
+		expect(lstatSync(realParent).mode & 0o777).toBe(0o700);
+	});
+
+	it.skipIf(processGid === undefined || alternateGroups.length < 2)(
+		"temporarily reassigns group ownership without granting group read/write",
+		() => {
+			const root = fixture();
+			const target = join(root, "private");
+			mkdirSync(target);
+			chownSync(target, process.getuid!(), alternateGroups[1]!);
+			chmodSync(target, 0o750);
+			const original = lstatSync(target);
+			const chowns: Array<[string, number, number]> = [];
+			const operations: string[] = [];
+			const identity: EmbeddedPostgresIdentity = {
+				uid: original.uid + 1,
+				gid: alternateGroups[0]!,
+				groups: new Set([processGid!, alternateGroups[0]!]),
+			};
+
+			const lease = ensureEmbeddedPgTraversal([target], identity, {
+				chmod: (path, mode) => {
+					operations.push(`chmod:${String(path)}:${mode.toString(8)}`);
+					chmodSync(path, mode);
+				},
+				chown: (path, uid, gid) => {
+					operations.push(`chown:${String(path)}:${uid}:${gid}`);
+					chowns.push([String(path), uid, gid]);
+					chownSync(path, uid, gid);
+				},
+			});
+
+			expect(operations.slice(0, 3)).toEqual([
+				`chmod:${target}:700`,
+				`chown:${target}:${original.uid}:${identity.gid}`,
+				`chmod:${target}:710`,
+			]);
+			expect(chowns).toContainEqual([target, original.uid, identity.gid]);
+			expect(lstatSync(target).gid).toBe(identity.gid);
+			expect(lstatSync(target).mode & 0o070).toBe(0o010);
+			lease.restore();
+			expect(operations.slice(-3)).toEqual([
+				`chmod:${target}:700`,
+				`chown:${target}:${original.uid}:${original.gid}`,
+				`chmod:${target}:750`,
+			]);
+			expect(chowns).toContainEqual([target, original.uid, original.gid]);
+			expect(lstatSync(target).gid).toBe(original.gid);
+			expect(lstatSync(target).mode & 0o777).toBe(0o750);
+		},
+	);
+
+	it("fails closed and rolls back an already-applied grant", () => {
+		const root = fixture();
+		const target = join(root, "private");
+		mkdirSync(target);
+		chmodSync(target, 0o700);
+		chmodSync(root, 0o700);
+		let chmodCalls = 0;
+
+		expect(() =>
+			ensureEmbeddedPgTraversal([target], postgresIdentity(), {
+				chown: chownSync,
+				// The walk grants leaf-first, so failing on the SECOND chmod leaves
+				// `target` already widened to 0o710. Asserting it is 0o700 after the
+				// throw therefore proves the rollback ran, not merely that the failed
+				// grant was never applied.
+				chmod: (path, mode) => {
+					chmodCalls++;
+					if (chmodCalls === 2) throw new Error("read-only mount");
+					chmodSync(path, mode);
+				},
+			}),
+		).toThrow(/Could not grant the postgres OS user traversal/);
+		expect(lstatSync(target).mode & 0o777).toBe(0o700);
+		expect(lstatSync(root).mode & 0o777).toBe(0o700);
+	});
+});
+
+describe("ensureEmbeddedPostgresIdentity", () => {
+	it("returns an existing non-root postgres identity", () => {
+		const run = vi.fn((command: string, args: string[]) => {
+			expect(command).toBe("id");
+			if (args[0] === "-u") return "101";
+			if (args[0] === "-g") return "102";
+			if (args[0] === "-G") return "102 103";
+			throw new Error(`unexpected args: ${args.join(" ")}`);
+		});
+
+		expect(ensureEmbeddedPostgresIdentity(run)).toEqual({
+			uid: 101,
+			gid: 102,
+			groups: new Set([102, 103]),
+		});
+		expect(run).toHaveBeenCalledTimes(3);
+	});
+
+	it("creates the postgres group/user before returning their identity", () => {
+		let exists = false;
+		const run = vi.fn((command: string, args: string[]) => {
+			if (command === "groupadd") return "";
+			if (command === "useradd") {
+				exists = true;
+				return "";
+			}
+			if (!exists) throw new Error("no such user");
+			if (args[0] === "-u") return "201";
+			if (args[0] === "-g") return "202";
+			if (args[0] === "-G") return "202";
+			throw new Error(`unexpected args: ${args.join(" ")}`);
+		});
+
+		expect(ensureEmbeddedPostgresIdentity(run).uid).toBe(201);
+		expect(run).toHaveBeenCalledWith("groupadd", ["-f", "postgres"]);
+		expect(run).toHaveBeenCalledWith("useradd", [
+			"-g",
+			"postgres",
+			"postgres",
+		]);
+	});
+
+	it("reports an actionable error when the identity cannot be created", () => {
+		expect(() =>
+			ensureEmbeddedPostgresIdentity(() => {
+				throw new Error("command unavailable");
+			}),
+		).toThrow(/could not resolve or create it with groupadd\/useradd/);
+	});
+
+	it("rejects a postgres identity that resolves to uid 0", () => {
+		const run = vi.fn((command: string, args: string[]) => {
+			if (command === "groupadd" || command === "useradd") return "";
+			if (args[0] === "-u") return "0";
+			if (args[0] === "-g") return "0";
+			if (args[0] === "-G") return "0";
+			throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
+		});
+
+		expect(() => ensureEmbeddedPostgresIdentity(run)).toThrow(
+			/postgres OS user unexpectedly resolves to uid 0/,
+		);
+		expect(run).toHaveBeenCalledTimes(3);
+	});
+});

--- a/packages/server/src/__tests__/embedded-runtime-boot-failure.test.ts
+++ b/packages/server/src/__tests__/embedded-runtime-boot-failure.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const postgres = vi.hoisted(() => ({
+	initialise: vi.fn<() => Promise<void>>(),
+	start: vi.fn<() => Promise<void>>(),
+	stop: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("embedded-postgres", () => ({
+	default: class FakeEmbeddedPostgres {
+		initialise = postgres.initialise;
+		start = postgres.start;
+		stop = postgres.stop;
+	},
+}));
+
+vi.mock("@lobu/pgvector-embedded", () => ({
+	injectPgvector: vi.fn(),
+	resolveEmbeddedNativeDir: () => process.cwd(),
+}));
+
+import { startEmbeddedRuntime } from "../embedded-runtime";
+
+describe("startEmbeddedRuntime boot failure cleanup", () => {
+	const roots: string[] = [];
+	const originalDatabaseUrl = process.env.DATABASE_URL;
+	const originalPgSslMode = process.env.PGSSLMODE;
+	const originalSingleUser = process.env.LOBU_SINGLE_USER;
+
+	beforeEach(() => {
+		postgres.initialise.mockResolvedValue();
+		postgres.start.mockRejectedValue(new Error("postgres start failed"));
+		postgres.stop.mockImplementation(() => new Promise(() => undefined));
+		vi.spyOn(process, "getuid").mockReturnValue(501);
+		const root = mkdtempSync(join(tmpdir(), "lobu-pg-start-failure-"));
+		roots.push(root);
+		process.env.DATABASE_URL = `file://${root}`;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		postgres.initialise.mockReset();
+		postgres.start.mockReset();
+		postgres.stop.mockReset();
+		if (originalDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+		else process.env.DATABASE_URL = originalDatabaseUrl;
+		if (originalPgSslMode === undefined) delete process.env.PGSSLMODE;
+		else process.env.PGSSLMODE = originalPgSslMode;
+		if (originalSingleUser === undefined) delete process.env.LOBU_SINGLE_USER;
+		else process.env.LOBU_SINGLE_USER = originalSingleUser;
+		while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+	});
+
+	it("does not call the dependency's hanging stop() after start() rejects", async () => {
+		await expect(startEmbeddedRuntime()).rejects.toThrow("postgres start failed");
+
+		expect(postgres.initialise).toHaveBeenCalledOnce();
+		expect(postgres.start).toHaveBeenCalledOnce();
+		expect(postgres.stop).not.toHaveBeenCalled();
+	});
+});

--- a/packages/server/src/embedded-runtime.ts
+++ b/packages/server/src/embedded-runtime.ts
@@ -9,12 +9,22 @@
  * `server.ts` hands to the shared `createServerLifecycle()` spine.
  */
 
-import { fork } from "node:child_process";
-import { existsSync, readFileSync, symlinkSync } from "node:fs";
+import { execFileSync, fork } from "node:child_process";
+import {
+	chmodSync,
+	chownSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readFileSync,
+	realpathSync,
+	symlinkSync,
+} from "node:fs";
+import type { Stats } from "node:fs";
 import http from "node:http";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
 import {
@@ -158,6 +168,281 @@ function runningAsRoot(): boolean {
 	return typeof process.getuid === "function" && process.getuid() === 0;
 }
 
+export interface EmbeddedPostgresIdentity {
+	uid: number;
+	gid: number;
+	groups: Set<number>;
+}
+
+export type IdentityCommand = (command: string, args: string[]) => string;
+
+const runIdentityCommand: IdentityCommand = (command, args) =>
+	execFileSync(command, args, {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	}).trim();
+
+function parseIdentityNumber(value: string, label: string): number {
+	const parsed = Number.parseInt(value.trim(), 10);
+	if (!Number.isSafeInteger(parsed) || parsed < 0) {
+		throw new Error(`Invalid ${label} returned for the postgres user: ${value}`);
+	}
+	return parsed;
+}
+
+function readPostgresIdentity(run: IdentityCommand): EmbeddedPostgresIdentity {
+	const uid = parseIdentityNumber(run("id", ["-u", "postgres"]), "uid");
+	const gid = parseIdentityNumber(run("id", ["-g", "postgres"]), "gid");
+	const groups = new Set(
+		run("id", ["-G", "postgres"])
+			.split(/\s+/)
+			.filter(Boolean)
+			.map((value) => parseIdentityNumber(value, "supplementary gid")),
+	);
+	groups.add(gid);
+	return { uid, gid, groups };
+}
+
+const ROOT_POSTGRES_IDENTITY_ERROR =
+	"The postgres OS user unexpectedly resolves to uid 0";
+
+function requireNonRootPostgresIdentity(
+	identity: EmbeddedPostgresIdentity,
+): EmbeddedPostgresIdentity {
+	if (identity.uid === 0) throw new Error(ROOT_POSTGRES_IDENTITY_ERROR);
+	return identity;
+}
+
+/**
+ * Resolve the non-root OS identity used by embedded-postgres, creating it on a
+ * fresh root-only Linux host before we need to grant it directory traversal.
+ *
+ * embedded-postgres performs the same groupadd/useradd bootstrap inside
+ * initialise(), but that is too late to establish narrowly-scoped access to
+ * its bundled binaries. Doing it here lets Lobu grant the postgres group (and
+ * only that group) execute access instead of making `/root` world-traversable.
+ */
+export function ensureEmbeddedPostgresIdentity(
+	run: IdentityCommand = runIdentityCommand,
+): EmbeddedPostgresIdentity {
+	try {
+		return requireNonRootPostgresIdentity(readPostgresIdentity(run));
+	} catch (initialError) {
+		if (
+			initialError instanceof Error &&
+			initialError.message === ROOT_POSTGRES_IDENTITY_ERROR
+		) {
+			throw initialError;
+		}
+		try {
+			// `-f` makes an already-existing group a success, including a race with
+			// another Lobu process performing the same first-boot bootstrap.
+			run("groupadd", ["-f", "postgres"]);
+			try {
+				run("useradd", ["-g", "postgres", "postgres"]);
+			} catch {
+				// A concurrent creator may have won after our first `id`; the read
+				// below is the authority and still fails closed if no user exists.
+			}
+			return requireNonRootPostgresIdentity(readPostgresIdentity(run));
+		} catch (cause) {
+			if (
+				cause instanceof Error &&
+				cause.message === ROOT_POSTGRES_IDENTITY_ERROR
+			) {
+				throw cause;
+			}
+			throw new Error(
+				"Root-mode embedded PostgreSQL requires a non-root 'postgres' OS user, " +
+					"but Lobu could not resolve or create it with groupadd/useradd.",
+				{ cause: cause ?? initialError },
+			);
+		}
+	}
+}
+
+export interface TraversalMutation {
+	chmod: typeof chmodSync;
+	chown: typeof chownSync;
+}
+
+interface TraversalGrant {
+	dir: string;
+	uid: number;
+	gid: number;
+	mode: number;
+	groupChanged: boolean;
+}
+
+export interface EmbeddedPgTraversalLease {
+	granted: string[];
+	restore: () => void;
+}
+
+function postgresCanTraverse(
+	stat: Stats,
+	identity: EmbeddedPostgresIdentity,
+): boolean {
+	if (stat.uid === identity.uid) return (stat.mode & 0o100) !== 0;
+	if (identity.groups.has(stat.gid)) return (stat.mode & 0o010) !== 0;
+	return (stat.mode & 0o001) !== 0;
+}
+
+function traversalModeGrant(
+	stat: Stats,
+	identity: EmbeddedPostgresIdentity,
+): { bit: number; groupChanged: boolean } {
+	if (stat.uid === identity.uid) return { bit: 0o100, groupChanged: false };
+	if (identity.groups.has(stat.gid)) {
+		return { bit: 0o010, groupChanged: false };
+	}
+	return { bit: 0o010, groupChanged: stat.gid !== identity.gid };
+}
+
+function restoreTraversalGrants(
+	grants: TraversalGrant[],
+	mutation: TraversalMutation,
+): void {
+	const failures: string[] = [];
+	for (const grant of [...grants].reverse()) {
+		try {
+			if (grant.groupChanged) {
+				// Strip the temporary group's permissions before returning ownership;
+				// otherwise the original group bits briefly apply to postgres.
+				mutation.chmod(grant.dir, grant.mode & ~0o070);
+				mutation.chown(grant.dir, grant.uid, grant.gid);
+			}
+			mutation.chmod(grant.dir, grant.mode);
+		} catch (err) {
+			failures.push(
+				`${grant.dir}: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+	if (failures.length > 0) {
+		throw new Error(
+			`Could not restore embedded PostgreSQL traversal permissions:\n${failures.join("\n")}`,
+		);
+	}
+}
+
+/**
+ * Make every lexical and resolved ancestor of `paths` traversable by the
+ * postgres OS identity that a root boot drops the embedded cluster to.
+ *
+ * With `createPostgresUser` (see `embeddedPgOptions`), embedded-postgres runs
+ * initdb/postgres setuid'd to a `postgres` user it creates. That child must be
+ * able to *traverse* each directory on the paths it touches, or the spawn dies
+ * with `EACCES` before exec — and the dependency's spawn has no `'error'`
+ * handler, so an unhandled `'error'` event takes down the whole process with
+ * the misleading `Emitted 'error' event on ChildProcess instance` crash. The
+ * realistic triggers, both seen on the landing-page quickstart:
+ *
+ *   - the native binaries live in the npx cache under `/root`, which is `0700`
+ *     on `node:` images, so `npx @lobu/cli` installs them exactly where the
+ *     dropped user cannot reach them;
+ *   - `<root>/.lobu` is created root-owned and stays `0700` under a `0077`
+ *     umask, so the child cannot traverse into the `pgdata` leaf (which
+ *     embedded-postgres chowns to it).
+ *
+ * Grant only the matching identity class traverse access (`u+x` when postgres
+ * owns the directory, otherwise `g+x`) on exactly the directories that lack
+ * it. When the directory's group must be temporarily changed to postgres, mask
+ * group read/write so the reassignment cannot expose directory contents. This
+ * avoids making `/root` or an arbitrary user-selected data ancestor
+ * traversable by every local account.
+ * The returned lease restores every original uid/gid/mode after PostgreSQL
+ * stops; a failed partial grant is rolled back before the error propagates. A
+ * SIGKILLed process cannot restore, and the grant then persists: the next boot
+ * sees the ancestor as already traversable, so it grants — and therefore
+ * records — nothing to undo. Root embedded mode is single-instance per host;
+ * two concurrent root processes could otherwise share an ancestor lease and
+ * let the first teardown revoke traversal from the second.
+ *
+ * Targets are made absolute before walking, so the documented `file://.` data
+ * root cannot stop at lexical `.`. Existing symlinks contribute both their
+ * lexical path and real target path, since the child must traverse both.
+ */
+export function ensureEmbeddedPgTraversal(
+	paths: string[],
+	identity: EmbeddedPostgresIdentity,
+	mutation: TraversalMutation = { chmod: chmodSync, chown: chownSync },
+): EmbeddedPgTraversalLease {
+	const grants: TraversalGrant[] = [];
+	const visited = new Set<string>();
+	let restored = false;
+	try {
+		for (const target of paths) {
+			const absolute = resolve(target);
+			if (!existsSync(absolute)) mkdirSync(absolute, { recursive: true });
+			const walks = new Set([absolute, realpathSync(absolute)]);
+			for (const walk of walks) {
+				for (let dir = walk; ; ) {
+					if (!visited.has(dir)) {
+						visited.add(dir);
+						const stat = lstatSync(dir);
+						if (stat.isDirectory() && !postgresCanTraverse(stat, identity)) {
+							const modeGrant = traversalModeGrant(stat, identity);
+							const grant: TraversalGrant = {
+								dir,
+								uid: stat.uid,
+								gid: stat.gid,
+								mode: stat.mode & 0o7777,
+								groupChanged: modeGrant.groupChanged,
+							};
+							grants.push(grant);
+							if (grant.groupChanged) {
+								// Remove the old group's permissions before assigning the
+								// postgres group, then add back traverse-only below.
+								mutation.chmod(dir, grant.mode & ~0o070);
+								mutation.chown(dir, stat.uid, identity.gid);
+							}
+							const grantedMode = grant.groupChanged
+								? (grant.mode & ~0o060) | modeGrant.bit
+								: grant.mode | modeGrant.bit;
+							mutation.chmod(dir, grantedMode);
+							const updated = lstatSync(dir);
+							if (!postgresCanTraverse(updated, identity)) {
+								throw new Error("permission update did not grant traversal");
+							}
+						}
+					}
+					const parent = dirname(dir);
+					if (parent === dir) break;
+					dir = parent;
+				}
+			}
+		}
+	} catch (cause) {
+		try {
+			restoreTraversalGrants(grants, mutation);
+		} catch (rollbackError) {
+			throw new AggregateError(
+				[cause, rollbackError],
+				"Embedded PostgreSQL traversal grant failed and could not be fully rolled back",
+			);
+		}
+		throw new Error(
+			"Could not grant the postgres OS user traversal to the embedded PostgreSQL binaries/data directory.",
+			{ cause },
+		);
+	}
+	if (grants.length > 0) {
+		logger.info(
+			{ dirs: grants.map(({ dir }) => dir), gid: identity.gid },
+			"Granted postgres identity traversal on embedded PostgreSQL ancestors",
+		);
+	}
+	return {
+		granted: grants.map(({ dir }) => dir),
+		restore: () => {
+			if (restored) return;
+			restoreTraversalGrants(grants, mutation);
+			restored = true;
+		},
+	};
+}
+
 /**
  * Ensure the @embedded-postgres platform binary's SONAME symlinks exist.
  *
@@ -236,38 +521,108 @@ export async function startEmbeddedRuntime(): Promise<EmbeddedRuntime> {
 
 	const pgPort =
 		parseInt(process.env.LOBU_PG_PORT || "", 10) || (await findFreePort());
+
+	// Root mode drops the cluster to a `postgres` user (see runningAsRoot). Give
+	// only that OS identity traversal through restrictive binary/datadir ancestors;
+	// retain the lease for rollback on boot failure and restoration after stop.
+	const traversalLease = runningAsRoot()
+		? ensureEmbeddedPgTraversal(
+				[nativeDir, join(dataRoot, ".lobu")],
+				ensureEmbeddedPostgresIdentity(),
+			)
+		: null;
+	let exitRestore: (() => void) | null = null;
+	const restoreTraversal = () => {
+		if (!traversalLease) return;
+		// Restore BEFORE detaching the exit hook: the lifecycle wraps every
+		// teardown step in `safe()`, which swallows a throw, so the hook is the
+		// only retry left if this partially fails. `restore()` is idempotent once
+		// it succeeds, so keeping the hook attached on failure is safe.
+		traversalLease.restore();
+		if (exitRestore) {
+			process.off("exit", exitRestore);
+			exitRestore = null;
+		}
+	};
+	if (traversalLease) {
+		// Boot can still fail later in migrations/bootstrap, before the shared
+		// lifecycle registers signal teardown. `reportBootFailure()` exits
+		// synchronously, so retain a synchronous last-resort restoration hook.
+		exitRestore = () => {
+			try {
+				traversalLease.restore();
+			} catch (error) {
+				process.stderr.write(
+					`Failed to restore embedded PostgreSQL traversal permissions on exit: ${error instanceof Error ? error.message : String(error)}\n`,
+				);
+			}
+		};
+		process.once("exit", exitRestore);
+	}
 	const pg = new EmbeddedPostgres(embeddedPgOptions(pgDataDir, pgPort));
 
-	// initdb refuses a non-empty datadir; skip it when the cluster already
-	// exists so restarts reuse the same data instead of erroring.
-	if (!existsSync(join(pgDataDir, "PG_VERSION"))) {
-		logger.info({ pgDataDir }, "Initialising embedded PostgreSQL cluster");
-		await pg.initialise();
+	let embeddingsChild: Awaited<ReturnType<typeof startEmbeddings>> | null = null;
+	let postgresStarted = false;
+	try {
+		// initdb refuses a non-empty datadir; skip it when the cluster already
+		// exists so restarts reuse the same data instead of erroring.
+		if (!existsSync(join(pgDataDir, "PG_VERSION"))) {
+			logger.info({ pgDataDir }, "Initialising embedded PostgreSQL cluster");
+			await pg.initialise();
+		}
+		await pg.start();
+		postgresStarted = true;
+
+		const databaseUrl = `postgresql://postgres:postgres@127.0.0.1:${pgPort}/postgres?sslmode=disable`;
+		process.env.DATABASE_URL = databaseUrl;
+		logger.info({ port: pgPort }, "Embedded PostgreSQL ready");
+
+		embeddingsChild = await startEmbeddings();
+
+		return {
+			databaseUrl,
+			dataDir: pgDataDir,
+			databaseReadiness: () => runMigrations(databaseUrl),
+			// Install-operator + default-agent provisioning, shared with the
+			// external-DB `lobu run` path (see local-bootstrap.ts).
+			preListenHooks: buildLocalBootstrapHooks(databaseUrl),
+			// Runs after stopLobuGateway + closeDbSingleton so gateway connections
+			// release before the embeddings child + PG child are stopped. Restore
+			// ancestor ownership/modes only after postgres no longer needs them.
+			extraTeardown: [
+				() => {
+					embeddingsChild?.kill();
+				},
+				() => pg.stop(),
+				() => restoreTraversal(),
+			],
+		};
+	} catch (error) {
+		embeddingsChild?.kill();
+		const cleanupErrors: unknown[] = [];
+		// embedded-postgres leaves its process field set when start() rejects,
+		// even though the child has already closed. Calling stop() then waits for
+		// a second exit event that can never arrive and hangs boot cleanup forever.
+		if (postgresStarted) {
+			try {
+				await pg.stop();
+			} catch (cleanupError) {
+				cleanupErrors.push(cleanupError);
+			}
+		}
+		try {
+			restoreTraversal();
+		} catch (cleanupError) {
+			cleanupErrors.push(cleanupError);
+		}
+		if (cleanupErrors.length > 0) {
+			throw new AggregateError(
+				[error, ...cleanupErrors],
+				"Embedded PostgreSQL boot failed and cleanup was incomplete",
+			);
+		}
+		throw error;
 	}
-	await pg.start();
-
-	const databaseUrl = `postgresql://postgres:postgres@127.0.0.1:${pgPort}/postgres?sslmode=disable`;
-	process.env.DATABASE_URL = databaseUrl;
-	logger.info({ port: pgPort }, "Embedded PostgreSQL ready");
-
-	const embeddingsChild = await startEmbeddings();
-
-	return {
-		databaseUrl,
-		dataDir: pgDataDir,
-		databaseReadiness: () => runMigrations(databaseUrl),
-		// Install-operator + default-agent provisioning, shared with the
-		// external-DB `lobu run` path (see local-bootstrap.ts).
-		preListenHooks: buildLocalBootstrapHooks(databaseUrl),
-		// Runs after stopLobuGateway + closeDbSingleton so gateway connections
-		// release before the embeddings child + PG child are stopped.
-		extraTeardown: [
-			() => {
-				embeddingsChild?.kill();
-			},
-			() => pg.stop(),
-		],
-	};
 }
 
 /**


### PR DESCRIPTION
## Summary

- Make root-mode embedded PostgreSQL bootstrap resolve/create the non-root `postgres` identity before spawning bundled binaries.
- Grant only that identity's group temporary execute-only traversal on restrictive lexical and symlink-resolved ancestors; never expose `/root` via `o+x`.
- Restore exact uid/gid/mode on graceful teardown and boot failure, fail closed on permission mutations, and cover relative `file://.` plus cold-boot paths.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted Vitest suites and server TypeScript check
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red — currently published CLI (`@lobu/cli@14.8.0`)

Fresh `node:22-bookworm` pod, run as root with `/root` mode `0700`:

```text
$ cd /tmp && npx -y @lobu/cli@14.8.0 run
Error: spawn /root/.npm/_npx/47151eb6b83bdd5a/node_modules/@embedded-postgres/linux-x64/native/bin/initdb EACCES
...
code: 'EACCES'
...
Node.js v22.23.2
```

`/root` remained `0700`; the dropped `postgres` child could not traverse the npx cache, so boot crashed before exec.

### Green — focused regression suite

```text
$ cd packages/server && bunx vitest run \
    src/__tests__/embedded-pg-traversal.test.ts \
    src/__tests__/embedded-pg-options.test.ts \
    src/__tests__/embedded-pg-symlinks.test.ts
Test Files  3 passed (3)
Tests       22 passed (22)

$ bunx tsc --noEmit
# exit 0
```

The regression suites cover scoped group execute, exposure-free temporary group reassignment and restoration ordering, exact restoration, idempotence, a missing datadir under umask `0077`, relative `file://.`, lexical and real symlink ancestors, rollback after a partial mutation, existing/created/failed/uid-0 `postgres` identities, and a rejected `pg.start()` whose dependency-level `stop()` would otherwise hang forever.

### Green — packed CLI root E2E

Built and packed this branch, installed it into a fresh `node:22-bookworm` pod, and ran from `/root/private/project` with `DATABASE_URL=file://.`. Before boot, `/root`, `/root/private`, and `/root/private/project` were all `0700 root:root`.

```text
during boot: /root, /root/private, /root/private/project = 0710 root:postgres
              no ancestor received o+x
GET /api/health = 200 {"status":"healthy",...}
after SIGTERM: all three ancestors = 0700 root:root
```

A second boot intentionally failed after database initialization by omitting the encryption key. The synchronous exit fallback again restored all three ancestors exactly to `0700 root:root`.

## Notes

This is the runtime fix only. The independent GitHub-release/package-publish ordering race is being fixed as a separate concern before the next version is cut.
