### PR TITLE
fix(server): bound tool request hydration

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import type { ContentItem } from '@lobu/connector-sdk';
 import { REDACTED_SENTINEL } from '@lobu/core';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { SCOPE_CHECK_NOT_APPLICABLE } from '../../../auth/tool-access';
@@ -6,6 +7,7 @@ import { recordToolInvocationAudit } from '../../../tools/audit';
 import { getDb } from '../../../db/client';
 import type { Env } from '../../../index';
 import { type AuthContext, executeTool } from '../../../tools/execute';
+import { hydrateToolInvocationRequests } from '../../../tools/get_content/render';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
   addUserToOrganization,
@@ -190,6 +192,63 @@ describe('tool invocation audit coverage', () => {
       limit: 1,
       org_slug: orgSlug,
     });
+  });
+
+  it('does not inline exact requests into audit list results', async () => {
+    const row = await latestAuditRow(orgId, 'query_sql');
+    expect(row).not.toBeNull();
+    // Guard the guard: the stored row must actually carry a request, or the
+    // absence assertions below would pass on a row that never had one.
+    expect(row!.payload_data).toHaveProperty('request');
+
+    const result = (await executeTool(
+      'read_knowledge',
+      { semantic_type: 'audit', sort_by: 'date', sort_order: 'desc', limit: 100 },
+      {} as Env,
+      authCtxFor('session')
+    )) as {
+      content: Array<{ id: string | number; payload_data: Record<string, unknown> }>;
+    };
+    const listed = result.content.find((item) => String(item.id) === String(row!.id));
+    expect(listed).toBeDefined();
+    expect(listed!.payload_data).not.toHaveProperty('request');
+    expect(listed!.payload_data).not.toHaveProperty('request_status');
+    expect(listed!.payload_data).not.toHaveProperty('request_bytes');
+  });
+
+  it('restores every copy when an exact read contains duplicate event ids', async () => {
+    const row = await latestAuditRow(orgId, 'query_sql');
+    expect(row).not.toBeNull();
+    const firstPayload = structuredClone(row!.payload_data);
+    const secondPayload = structuredClone(row!.payload_data);
+    const items = [
+      {
+        id: Number(row!.id),
+        semantic_type: 'audit',
+        origin_type: 'tool_invocation',
+        payload_data: firstPayload,
+      },
+      {
+        id: Number(row!.id),
+        semantic_type: 'audit',
+        origin_type: 'tool_invocation',
+        payload_data: secondPayload,
+      },
+    ];
+
+    await hydrateToolInvocationRequests({
+      sql: getDb(),
+      // Only the four discriminating fields above are read; the rest of
+      // ContentItem is irrelevant to the strip/restore index.
+      items: items as unknown as ContentItem[],
+      organizationId: orgId,
+      userId: ownerId,
+      memberRole: 'owner',
+      restoreRequests: true,
+    });
+
+    expect(firstPayload).toHaveProperty('request');
+    expect(secondPayload).toHaveProperty('request');
   });
 
   it('strips `request` from audit rows ONLY, leaving other events untouched', async () => {

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -401,7 +401,12 @@ async function getContentImpl(
       }
     }
 
-    if (args.content_ids && args.content_ids.length > 0) {
+    // One flag, two consumers: it picks the fetch strategy here and gates
+    // verbatim-request hydration below. Kept as a single binding so the read
+    // bound can never drift from the branch it is supposed to describe.
+    const isExactIdRead = Boolean(args.content_ids?.length);
+
+    if (isExactIdRead) {
       ({ rawContent, total, chainTotal, pageInfo } = await fetchByContentIds({
         args,
         sql,
@@ -600,12 +605,18 @@ async function getContentImpl(
       baseUrl,
       excerptsMap,
     });
+    // Verbatim requests are served ONLY on an explicit `content_ids` read. A
+    // list or search page is an ambient read — inlining every retained request
+    // there would spray each caller's exact SQL/script across pages nobody
+    // asked for it on, and would grow with the page size rather than with the
+    // caller's intent.
     await hydrateToolInvocationRequests({
       sql,
       items: contentItems,
       organizationId: ctx.organizationId,
       userId: ctx.userId,
       memberRole: ctx.memberRole,
+      restoreRequests: isExactIdRead,
     });
 
     // Stamp a LIVE pending-proposal count onto every change_set card. The

--- a/packages/server/src/tools/get_content/render.ts
+++ b/packages/server/src/tools/get_content/render.ts
@@ -23,11 +23,19 @@ const AUDIT_REQUEST_KEYS = ['request', 'request_status', 'request_bytes'] as con
  * A tool-invocation audit row retains the caller's VERBATIM request (see
  * `recordToolInvocationAudit`), which only its author or a workspace admin may
  * read. Content rows arrive with those keys still on `payload_data`, so this
- * strips them from EVERY audit item first — an unauthorized caller and an
- * unrecognized role leave them stripped — and puts them back only on the rows
- * whose `created_by` clears the gate. Authorship is the one thing the content
- * row does not carry, so it is the only thing re-read here; a failed re-read
- * rejects rather than serving a half-gated page.
+ * strips them from EVERY audit item first — list/search results never inline
+ * them, and an unauthorized caller or unrecognized role leaves them stripped.
+ * Explicit event-id reads put them back only on rows whose `created_by` clears
+ * the gate. Authorship is the one thing the content row does not carry, so it
+ * is the only thing re-read here; a failed re-read rejects rather than serving
+ * a half-gated page.
+ *
+ * The strip index maps an id to a LIST of entries, not one: an exact-id read
+ * expands the requested ids through `resolved_ids`, whose run arm and
+ * supersede-walk arm can each claim the same event under a different (and
+ * deliberately non-colliding) chain key, so the join emits that event twice and
+ * `buildContentItems` parses a SEPARATE payload object for each row. Keying one
+ * entry per id would restore only the last copy and leave the rest stripped.
  */
 export async function hydrateToolInvocationRequests(opts: {
   sql: DbClient;
@@ -35,12 +43,13 @@ export async function hydrateToolInvocationRequests(opts: {
   organizationId: string;
   userId: string | null;
   memberRole: string | null;
+  restoreRequests: boolean;
 }): Promise<void> {
-  const { sql, items, organizationId, userId, memberRole } = opts;
+  const { sql, items, organizationId, userId, memberRole, restoreRequests } = opts;
   const isAdmin = isAdminOrOwnerRole(memberRole);
   const stripped = new Map<
     number,
-    { payload: Record<string, unknown>; fields: Record<string, unknown> }
+    Array<{ payload: Record<string, unknown>; fields: Record<string, unknown> }>
   >();
 
   for (const item of items) {
@@ -54,10 +63,14 @@ export async function hydrateToolInvocationRequests(opts: {
       fields[key] = payload[key];
       delete payload[key];
     }
-    if (Object.keys(fields).length > 0) stripped.set(Number(item.id), { payload, fields });
+    if (Object.keys(fields).length === 0) continue;
+    const id = Number(item.id);
+    const entries = stripped.get(id) ?? [];
+    entries.push({ payload, fields });
+    stripped.set(id, entries);
   }
 
-  if (stripped.size === 0 || (!isAdmin && userId == null)) return;
+  if (!restoreRequests || stripped.size === 0 || (!isAdmin && userId == null)) return;
 
   const rows = await sql<{ id: number; created_by: string | null }>`
     SELECT id, created_by
@@ -70,8 +83,9 @@ export async function hydrateToolInvocationRequests(opts: {
 
   for (const row of rows) {
     if (!isAdmin && row.created_by !== userId) continue;
-    const entry = stripped.get(Number(row.id));
-    if (entry) Object.assign(entry.payload, entry.fields);
+    const entries = stripped.get(Number(row.id));
+    if (!entries) continue;
+    for (const entry of entries) Object.assign(entry.payload, entry.fields);
   }
 }
 


### PR DESCRIPTION
## Summary

- Keep exact tool requests out of ambient Activity list/search pages; restore them only for explicit `content_ids` reads after the existing creator/admin authorization check.
- Preserve every item when an internal result array contains duplicate event IDs instead of restoring only the last copy.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `cd packages/server && bunx vitest run src/__tests__/integration/mcp/tool-invocation-audit.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Red

```text
❯ src/__tests__/integration/mcp/tool-invocation-audit.test.ts (20 tests | 2 failed)
× does not inline exact requests into audit list results
  expected payload_data to not have property "request"
× restores every copy when an exact read contains duplicate event ids
  expected firstPayload to have property "request"

Test Files  1 failed (1)
Tests       2 failed | 18 passed (20)
```

### Green

```text
✓ src/__tests__/integration/mcp/tool-invocation-audit.test.ts (20 tests)

Test Files  1 passed (1)
Tests       20 passed (20)
```

Also verified `packages/server` with `bun run typecheck`.

## Notes

`make test-unit` reached 823 pass / 12 skip with one unrelated existing macOS assertion failure in `packages/agent-worker/src/__tests__/exec-sandbox-extra.test.ts`: the test expects the old phrase `bubblewrap is unavailable`, while current `origin/main` emits `bubblewrap (bwrap) was not found on PATH`. This branch does not touch that package or test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->