### PR TITLE
fix(server): surface cross-workspace GitHub installs

### DIFF
--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -653,6 +653,65 @@ export const ManageConnectionsResultSchema = Type.Union([
     message: Type.String(),
     view_url: Type.Optional(Type.String()),
   }),
+  Type.Object({
+    action: Type.Literal("connect"),
+    status: Type.Literal("connected_in_other_workspace"),
+    connector_key: Type.String(),
+    current_workspace: Type.Object({
+      id: Type.String(),
+      slug: Type.String(),
+      name: Type.String(),
+    }),
+    accessible_workspaces: Type.Array(
+      Type.Object({
+        workspace: Type.Object({
+          id: Type.String(),
+          slug: Type.String(),
+          name: Type.String(),
+        }),
+        connection: Type.Object({
+          id: Type.Integer(),
+          slug: Type.String(),
+          display_name: Type.Union([Type.String(), Type.Null()]),
+          status: Type.Literal("active"),
+        }),
+        switch_workspace: Type.Object({
+          next_action: Type.Literal("switch_workspace"),
+          organization_id: Type.String(),
+          organization_slug: Type.String(),
+          view_url: Type.String(),
+        }),
+      })
+    ),
+    install_app_here: Type.Object({
+      next_action: Type.Literal("install_app"),
+      install_url: Type.String(),
+    }),
+    // Carried over from the `setup_required` continuation this variant replaces:
+    // `install_app_here.install_url` still pins this `setup_attempt_id`, so the
+    // caller can poll for the install callback landing exactly as it would on the
+    // ordinary install path.
+    setup_attempt_id: Type.Optional(Type.String()),
+    completion_check: Type.Optional(ConnectCompletionCheck),
+    transfer_installation_here: Type.Optional(
+      Type.Object({
+        next_action: Type.Literal("transfer_installation_here"),
+        requires_confirmation: Type.Literal(true),
+        warning: Type.String(),
+        options: Type.Array(
+          Type.Object({
+            source_workspace: Type.Object({
+              id: Type.String(),
+              slug: Type.String(),
+            }),
+            source_installation_id: Type.Integer(),
+            transfer_url: Type.String(),
+          })
+        ),
+      })
+    ),
+    instructions: Type.String(),
+  }),
   // Setup-required continuation — a NON-TERMINAL, actionable outcome that MUST
   // survive run_sdk/query_sdk as a return value (no `error` key). Distinct from
   // the `pending_auth` OAuth-pending variant: that already created a connection

--- a/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
@@ -10,11 +10,12 @@
  * generic `app_installation`-primary connector rather than github specifically.
  */
 
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
 import { manageAuthProfiles } from "../../../tools/admin/manage_auth_profiles";
 import { manageConnections } from "../../../tools/admin/manage_connections";
+import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
 import { getTestDb } from "../../setup/test-db";
 import { initWorkspaceProvider } from "../../../workspace";
 import {
@@ -26,6 +27,13 @@ import {
 
 const TEST_ENV = {} as Env;
 const CONNECTOR_KEY = "demo.appinstall.guard";
+const PROVIDER_APP_ID = "demo-app-install-guard";
+const OTHER_PROVIDER_APP_ID = "other-demo-app-install-guard";
+const previousDemoAppId = process.env.DEMO_APP_ID;
+const seededConnectorDefinitions: Array<{
+	organizationId: string;
+	connectorKey: string;
+}> = [];
 
 function ctxFor(organizationId: string, userId: string): ToolContext {
 	return {
@@ -49,18 +57,26 @@ function ctxFor(organizationId: string, userId: string): ToolContext {
  * env_keys). The fallbacks let the selection-aware guard be exercised: a create
  * that targets oauth (auth_profile_slug) or env (config DEMO_TOKEN) must pass.
  */
-async function seedAppInstallConnector(organizationId: string): Promise<void> {
+async function seedAppInstallConnector(
+	organizationId: string,
+	opts?: {
+		provider: "github";
+		installShape: "github-app";
+		connectorKey?: string;
+	},
+): Promise<void> {
+	const connectorKey = opts?.connectorKey ?? CONNECTOR_KEY;
 	await createTestConnectorDefinition({
-		key: CONNECTOR_KEY,
+		key: connectorKey,
 		name: "Demo App Install Guard",
 		organization_id: organizationId,
 		auth_schema: {
 			methods: [
 				{
 					type: "app_installation",
-					provider: "slack",
+					provider: opts?.provider ?? "slack",
 					providerInstance: "cloud",
-					installShape: "oauth-code-exchange",
+					installShape: opts?.installShape ?? "oauth-code-exchange",
 					appIdKey: "DEMO_APP_ID",
 					privateKeyKey: "DEMO_APP_PRIVATE_KEY",
 				},
@@ -77,6 +93,7 @@ async function seedAppInstallConnector(organizationId: string): Promise<void> {
 		},
 		feeds_schema: { items: {} },
 	});
+	seededConnectorDefinitions.push({ organizationId, connectorKey });
 }
 
 /**
@@ -125,14 +142,37 @@ async function connectionCount(organizationId: string): Promise<number> {
 }
 
 beforeAll(async () => {
+	process.env.DEMO_APP_ID = PROVIDER_APP_ID;
 	await initWorkspaceProvider();
+});
+
+afterAll(() => {
+	if (previousDemoAppId === undefined) delete process.env.DEMO_APP_ID;
+	else process.env.DEMO_APP_ID = previousDemoAppId;
 });
 
 afterEach(async () => {
 	const sql = getTestDb();
-	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
-	await sql`DELETE FROM auth_profiles WHERE connector_key = ${CONNECTOR_KEY}`;
-	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
+	for (const { organizationId, connectorKey } of seededConnectorDefinitions) {
+		await sql`
+			DELETE FROM connections
+			WHERE organization_id = ${organizationId}
+				AND connector_key = ${connectorKey}
+		`;
+		await sql`
+			DELETE FROM auth_profiles
+			WHERE organization_id = ${organizationId}
+				AND connector_key = ${connectorKey}
+		`;
+		await sql`
+			DELETE FROM connector_definitions
+			WHERE organization_id = ${organizationId}
+				AND key = ${connectorKey}
+		`;
+	}
+	seededConnectorDefinitions.length = 0;
+	await sql`DELETE FROM app_installations WHERE provider_app_id = ${PROVIDER_APP_ID}`;
+	await sql`DELETE FROM app_installations WHERE provider_app_id = ${OTHER_PROVIDER_APP_ID}`;
 });
 
 describe("manage_connections — app_installation create guard", () => {
@@ -208,6 +248,273 @@ describe("manage_connections — app_installation create guard", () => {
 		// id, so returning an "any active Slack connection" poll would be unsafe.
 		expect(res).not.toHaveProperty("completion_check");
 		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("connect reports an active installation in another accessible workspace", async () => {
+		const currentOrg = await createTestOrganization({
+			name: "Current App Install Org",
+		});
+		const connectedOrg = await createTestOrganization({
+			name: "Connected App Install Org",
+		});
+		const otherInstanceOrg = await createTestOrganization({
+			name: "Other Provider Instance Org",
+		});
+		const otherAppOrg = await createTestOrganization({
+			name: "Other Provider App Org",
+		});
+		const installOnlyOrg = await createTestOrganization({
+			name: "Install Only Org",
+		});
+		// The caller is a plain member here, and the connection belongs to someone
+		// else privately — the workspace must stay invisible to this listing.
+		const memberOnlyOrg = await createTestOrganization({
+			name: "Member Only Private Org",
+		});
+		const user = await createTestUser();
+		const otherUser = await createTestUser();
+		await addUserToOrganization(user.id, currentOrg.id, "owner");
+		await addUserToOrganization(user.id, connectedOrg.id, "owner");
+		await addUserToOrganization(user.id, otherInstanceOrg.id, "owner");
+		await addUserToOrganization(user.id, otherAppOrg.id, "owner");
+		await addUserToOrganization(user.id, installOnlyOrg.id, "owner");
+		await addUserToOrganization(user.id, memberOnlyOrg.id, "member");
+		await addUserToOrganization(otherUser.id, memberOnlyOrg.id, "owner");
+		await seedAppInstallConnector(currentOrg.id, {
+			provider: "github",
+			installShape: "github-app",
+			connectorKey: "github",
+		});
+		await seedAppInstallConnector(connectedOrg.id, {
+			provider: "github",
+			installShape: "github-app",
+			connectorKey: "github",
+		});
+		await seedAppInstallConnector(otherInstanceOrg.id, {
+			provider: "github",
+			installShape: "github-app",
+			connectorKey: "github",
+		});
+		await seedAppInstallConnector(otherAppOrg.id, {
+			provider: "github",
+			installShape: "github-app",
+			connectorKey: "github",
+		});
+		await seedAppInstallConnector(installOnlyOrg.id, {
+			provider: "github",
+			installShape: "github-app",
+			connectorKey: "github",
+		});
+		await seedAppInstallConnector(memberOnlyOrg.id, {
+			provider: "github",
+			installShape: "github-app",
+			connectorKey: "github",
+		});
+
+		const store = createPostgresAppInstallationStore();
+		const install = await store.upsert({
+			organizationId: connectedOrg.id,
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "T-DEMO-CONNECTED-ELSEWHERE",
+			status: "active",
+		});
+		const otherInstanceInstall = await store.upsert({
+			organizationId: otherInstanceOrg.id,
+			provider: "github",
+			providerInstance: "github.example.test",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "T-DEMO-OTHER-INSTANCE",
+			status: "active",
+		});
+		const otherAppInstall = await store.upsert({
+			organizationId: otherAppOrg.id,
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: OTHER_PROVIDER_APP_ID,
+			externalTenantId: "T-DEMO-OTHER-APP",
+			status: "active",
+		});
+		const installOnly = await store.upsert({
+			organizationId: installOnlyOrg.id,
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "T-DEMO-INSTALL-ONLY",
+			status: "active",
+		});
+		const memberOnlyInstall = await store.upsert({
+			organizationId: memberOnlyOrg.id,
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "T-DEMO-MEMBER-ONLY",
+			status: "active",
+		});
+		const sql = getTestDb();
+		await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status, config, created_by
+			) VALUES (
+				${connectedOrg.id}, 'github', 'connected-elsewhere',
+				'Connected Elsewhere', 'active',
+				${sql.json({ installation_ref: install.id })}, ${user.id}
+			)
+		`;
+		await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status, config, created_by
+			) VALUES (
+				${otherAppOrg.id}, 'github', 'other-provider-app',
+				'Other Provider App', 'active',
+				${sql.json({ installation_ref: otherAppInstall.id })}, ${user.id}
+			)
+		`;
+		await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status, config, created_by
+			) VALUES (
+				${otherInstanceOrg.id}, 'github', 'other-instance',
+				'Other Instance', 'active',
+				${sql.json({ installation_ref: otherInstanceInstall.id })}, ${user.id}
+			)
+		`;
+		await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status, visibility,
+				config, created_by
+			) VALUES (
+				${memberOnlyOrg.id}, 'github', 'member-only-private',
+				'Member Only Private', 'active', 'private',
+				${sql.json({ installation_ref: memberOnlyInstall.id })}, ${otherUser.id}
+			)
+		`;
+
+		const res = await manageConnections(
+			{
+				action: "connect",
+				connector_key: "github",
+			},
+			TEST_ENV,
+			ctxFor(currentOrg.id, user.id),
+		);
+
+		expect(res).toMatchObject({
+			action: "connect",
+			status: "connected_in_other_workspace",
+			connector_key: "github",
+			current_workspace: { id: currentOrg.id },
+			accessible_workspaces: [
+				{
+					workspace: { id: connectedOrg.id },
+					connection: { slug: "connected-elsewhere", status: "active" },
+					switch_workspace: {
+						next_action: "switch_workspace",
+						organization_id: connectedOrg.id,
+					},
+				},
+			],
+		});
+		// Only the workspace whose connection the caller can actually see is listed:
+		// the member-only workspace's PRIVATE connection (owned by someone else)
+		// must not leak its slug — nor an installation the caller could transfer.
+		expect(
+			(res as { accessible_workspaces: unknown[] }).accessible_workspaces,
+		).toHaveLength(1);
+		expect(JSON.stringify(res)).not.toContain("member-only-private");
+		expect(JSON.stringify(res)).not.toContain("other-provider-app");
+		expect(res).toHaveProperty(
+			"transfer_installation_here.next_action",
+			"transfer_installation_here",
+		);
+		const transferOptions = (
+			res as {
+				transfer_installation_here: {
+					options: Array<{
+						source_installation_id: number;
+						transfer_url: string;
+					}>;
+				};
+			}
+		).transfer_installation_here.options;
+		expect(transferOptions).toHaveLength(2);
+		expect(
+			transferOptions.some(
+				(option) => option.source_installation_id === install.id,
+			),
+		).toBe(true);
+		const installOnlyOption = transferOptions.find(
+			(option) => option.source_installation_id === installOnly.id,
+		);
+		expect(installOnlyOption).toMatchObject({
+			source_installation_id: installOnly.id,
+		});
+		expect(installOnlyOption?.transfer_url).toContain(
+			`source_installation_id=${installOnly.id}`,
+		);
+		expect(res).not.toHaveProperty("accessible_workspaces.0.connection.config");
+		// The install_url the caller is sent to still pins the attempt id, so the
+		// poll affordance from the plain setup_required continuation survives.
+		expect(res).toHaveProperty("setup_attempt_id");
+		expect(res).toHaveProperty(
+			"install_app_here.install_url",
+			expect.stringContaining(
+				`setup_attempt_id=${(res as { setup_attempt_id: string }).setup_attempt_id}`,
+			),
+		);
+		expect(res).toHaveProperty("completion_check.call.sdk_method");
+		const currentGithubRows = await sql`
+			SELECT id FROM connections
+			WHERE organization_id = ${currentOrg.id}
+				AND connector_key = 'github'
+				AND deleted_at IS NULL
+		`;
+		expect(currentGithubRows).toHaveLength(0);
+
+		await sql`
+			DELETE FROM connections
+			WHERE organization_id = ${connectedOrg.id}
+				AND config ->> 'installation_ref' = ${String(install.id)}
+		`;
+		const installOnlyResult = await manageConnections(
+			{ action: "connect", connector_key: "github" },
+			TEST_ENV,
+			ctxFor(currentOrg.id, user.id),
+		);
+		expect(installOnlyResult).toMatchObject({
+			status: "connected_in_other_workspace",
+			accessible_workspaces: [],
+		});
+		expect(installOnlyResult).toHaveProperty(
+			"instructions",
+			expect.stringContaining(
+				"GitHub App installation is active in another workspace you administer",
+			),
+		);
+
+		const patResult = await manageConnections(
+			{ action: "connect", connector_key: "github" },
+			TEST_ENV,
+			{ ...ctxFor(currentOrg.id, user.id), tokenType: "pat" },
+		);
+		expect(patResult).toMatchObject({
+			action: "connect",
+			status: "setup_required",
+			next_action: "install_app",
+		});
+		expect(patResult).not.toHaveProperty("accessible_workspaces");
+
+		const invalidGatewayUrlResult = await manageConnections(
+			{ action: "connect", connector_key: "github" },
+			TEST_ENV,
+			{ ...ctxFor(currentOrg.id, user.id), baseUrl: "not-a-valid-url" },
+		);
+		expect(invalidGatewayUrlResult).toMatchObject({
+			action: "connect",
+			status: "setup_required",
+			next_action: "install_app",
+		});
 	});
 
 	it("create WITH installation_ref in config is allowed past the guard (the callback's shape)", async () => {

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-callback.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-callback.test.ts
@@ -15,7 +15,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "../../../db/client";
 import { linkGithubAppInstallation } from "../../../gateway/routes/public/app-install";
-import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
+import {
+	CrossOrgTransferBlockedError,
+	createPostgresAppInstallationStore,
+} from "../../../lobu/stores/app-installation-store";
 import { getTestDb } from "../../setup/test-db";
 import { initWorkspaceProvider } from "../../../workspace";
 import {
@@ -176,5 +179,176 @@ describe("GitHub App install callback — link installation", () => {
 			WHERE provider_app_id = ${PROVIDER_APP_ID} AND external_tenant_id = '9100'
 		`) as unknown as Array<{ n: number }>;
 		expect(installCount[0].n).toBe(1);
+	});
+
+	it("allows the same GitHub App to have different installation ids in different orgs", async () => {
+		const firstOrg = await createTestOrganization({ name: "First GitHub Org" });
+		const secondOrg = await createTestOrganization({ name: "Second GitHub Org" });
+		await seedGithubConnector(firstOrg.id);
+		await seedGithubConnector(secondOrg.id);
+		const store = createPostgresAppInstallationStore();
+
+		await linkGithubAppInstallation({
+			organizationId: firstOrg.id,
+			installationId: "9150",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+		});
+		await linkGithubAppInstallation({
+			organizationId: secondOrg.id,
+			installationId: "9151",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+		});
+
+		const first = await store.resolveActiveByTenant({
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "9150",
+		});
+		const second = await store.resolveActiveByTenant({
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "9151",
+		});
+		expect(first?.organizationId).toBe(firstOrg.id);
+		expect(second?.organizationId).toBe(secondOrg.id);
+	});
+
+	it("refuses to transfer an active installation to another org without confirmation", async () => {
+		const sourceOrg = await createTestOrganization({ name: "GitHub Source Org" });
+		const targetOrg = await createTestOrganization({ name: "GitHub Target Org" });
+		await seedGithubConnector(sourceOrg.id);
+		await seedGithubConnector(targetOrg.id);
+		const store = createPostgresAppInstallationStore();
+
+		const source = await linkGithubAppInstallation({
+			organizationId: sourceOrg.id,
+			installationId: "9200",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+			metadata: { account_login: "source-account" },
+		});
+
+		await expect(
+			linkGithubAppInstallation({
+				organizationId: targetOrg.id,
+				installationId: "9200",
+				store,
+				providerAppId: PROVIDER_APP_ID,
+				metadata: { account_login: "source-account" },
+			}),
+		).rejects.toBeInstanceOf(CrossOrgTransferBlockedError);
+
+		const active = await store.resolveActiveByTenant({
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "9200",
+		});
+		expect(active?.organizationId).toBe(sourceOrg.id);
+
+		const sql = getDb();
+		const [sourceConnection] = (await sql`
+			SELECT status FROM connections WHERE id = ${source.connectionId}
+		`) as unknown as Array<{ status: string }>;
+		expect(sourceConnection.status).toBe("active");
+		expect(
+			await sql`
+				SELECT id FROM connections
+				WHERE organization_id = ${targetOrg.id}
+					AND connector_key = 'github'
+					AND deleted_at IS NULL
+			`,
+		).toHaveLength(0);
+
+		// Even a malformed cross-org reference to the source install id must not be
+		// revoked: the transfer transaction scopes both the install id and source org.
+		const [unrelatedTargetConnection] = (await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status, config
+			) VALUES (
+				${targetOrg.id}, 'github', 'unrelated-target', 'Unrelated Target',
+				'active', ${sql.json({ installation_ref: source.installId })}
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: number }>;
+
+		const transferred = await linkGithubAppInstallation({
+			organizationId: targetOrg.id,
+			installationId: "9200",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+			metadata: { account_login: "source-account" },
+			confirmTransfer: true,
+			transferSourceOrganizationId: sourceOrg.id,
+		});
+		const movedActive = await store.resolveActiveByTenant({
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "9200",
+		});
+		expect(movedActive?.organizationId).toBe(targetOrg.id);
+		expect(transferred.connectionId).toBeGreaterThan(0);
+
+		const [revokedSource] = (await sql`
+			SELECT status, error_message
+			FROM connections WHERE id = ${source.connectionId}
+		`) as unknown as Array<{ status: string; error_message: string | null }>;
+		expect(revokedSource.status).toBe("revoked");
+		expect(revokedSource.error_message).toContain(
+			"transferred to another workspace",
+		);
+		const [unrelatedAfterTransfer] = (await sql`
+			SELECT status FROM connections WHERE id = ${unrelatedTargetConnection.id}
+		`) as unknown as Array<{ status: string }>;
+		expect(unrelatedAfterTransfer.status).toBe("active");
+	});
+
+	it("fails closed when the approved source stops owning the installation", async () => {
+		const sourceOrg = await createTestOrganization({ name: "Race Source Org" });
+		const targetOrg = await createTestOrganization({ name: "Race Target Org" });
+		await seedGithubConnector(sourceOrg.id);
+		await seedGithubConnector(targetOrg.id);
+		const store = createPostgresAppInstallationStore();
+
+		const source = await linkGithubAppInstallation({
+			organizationId: sourceOrg.id,
+			installationId: "9250",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+		});
+		await store.setStatus(source.installId, "suspended");
+
+		await expect(
+			linkGithubAppInstallation({
+				organizationId: targetOrg.id,
+				installationId: "9250",
+				store,
+				providerAppId: PROVIDER_APP_ID,
+				confirmTransfer: true,
+				transferSourceOrganizationId: sourceOrg.id,
+			}),
+		).rejects.toBeInstanceOf(CrossOrgTransferBlockedError);
+		expect(
+			await store.resolveActiveByTenant({
+				provider: "github",
+				providerInstance: "cloud",
+				providerAppId: PROVIDER_APP_ID,
+				externalTenantId: "9250",
+			}),
+		).toBeNull();
+		const sql = getDb();
+		expect(
+			await sql`
+				SELECT id FROM connections
+				WHERE organization_id = ${targetOrg.id}
+					AND connector_key = 'github'
+					AND deleted_at IS NULL
+			`,
+		).toHaveLength(0);
 	});
 });

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
@@ -21,6 +21,7 @@ import {
 	type AppInstallRouterDeps,
 	autoProvisionGithubIssueFeeds,
 	createAppInstallRoutes,
+	linkGithubAppInstallation,
 } from "../../../gateway/routes/public/app-install";
 import { createGithubInstallStateStore } from "../../../gateway/auth/oauth/state-store";
 import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
@@ -120,6 +121,8 @@ function buildRouter(
 			| undefined;
 		/** Repos the (mocked) /installation/repositories enumeration returns. */
 		installationRepos?: Array<{ owner: string; name: string }>;
+		/** Lobu workspaces where the completing user is owner/admin. */
+		adminOrganizationIds?: string[];
 	} = {},
 ): {
 	router: ReturnType<typeof createAppInstallRoutes>;
@@ -170,6 +173,9 @@ function buildRouter(
 		// fixation test drives a state org ≠ installOrgId → not a member → reject.
 		verifyInstallOrgAccess: async (_c, organizationId) =>
 			organizationId === installOrgId,
+		verifyInstallOrgAdminAccess: async (_c, organizationId) =>
+			(opts.adminOrganizationIds ??
+				(installOrgId ? [installOrgId] : [])).includes(organizationId),
 		getPublicGatewayUrl: () =>
 			opts.publicGatewayUrl === undefined
 				? PUBLIC_GATEWAY_URL
@@ -1061,6 +1067,157 @@ describe("GitHub App install callback — auto-provision feeds", () => {
 });
 
 describe("GitHub App install callback — re-bind recovery (user-auth flow)", () => {
+	it("an unconfirmed install of another workspace's installation is 409, zero mutation", async () => {
+		const sourceOrg = await createTestOrganization({
+			name: "Unconfirmed Transfer Source",
+		});
+		const targetOrg = await createTestOrganization({
+			name: "Unconfirmed Transfer Target",
+		});
+		await seedGithubConnector(sourceOrg.id);
+		await seedGithubConnector(targetOrg.id);
+		const store = createPostgresAppInstallationStore();
+		const source = await linkGithubAppInstallation({
+			organizationId: sourceOrg.id,
+			installationId: "6560",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+		});
+		// A plain (non-transfer) install state for the target org — the shape a
+		// GitHub-owner reaches by re-installing the SAME installation elsewhere.
+		const state = await createGithubInstallStateStore().create({
+			organizationId: targetOrg.id,
+		});
+		const { router } = buildRouter(targetOrg.id, {
+			installations: { 6560: { login: "installer-user", type: "User" } },
+		});
+
+		const response = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=6560&setup_action=install&state=${state}&code=valid-oauth-code`,
+			),
+		);
+
+		expect(response.status).toBe(409);
+		expect(await response.text()).toContain("active in another Lobu workspace");
+		// Ownership stayed with the source org, and the target got nothing.
+		const active = await store.resolveActiveByTenant({
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "6560",
+		});
+		expect(active?.organizationId).toBe(sourceOrg.id);
+		expect(await installCount(targetOrg.id)).toBe(0);
+		expect(await connectionCount(targetOrg.id)).toBe(0);
+		const sql = getDb();
+		const [sourceConnection] = (await sql`
+			SELECT status FROM connections WHERE id = ${source.connectionId}
+		`) as unknown as Array<{ status: string }>;
+		expect(sourceConnection.status).toBe("active");
+	});
+
+	it("explicit transfer requires both workspace admins and signs the exact installation", async () => {
+		const sourceOrg = await createTestOrganization({ name: "Transfer Source Org" });
+		const targetOrg = await createTestOrganization({ name: "Transfer Target Org" });
+		await seedGithubConnector(sourceOrg.id);
+		await seedGithubConnector(targetOrg.id);
+		const source = await linkGithubAppInstallation({
+			organizationId: sourceOrg.id,
+			installationId: "6540",
+			store: createPostgresAppInstallationStore(),
+			providerAppId: PROVIDER_APP_ID,
+		});
+		// The installation remains owned by the source workspace even if its
+		// connection was deleted; explicit transfer must not dead-end in that state.
+		const sql = getDb();
+		await sql`DELETE FROM connections WHERE id = ${source.connectionId}`;
+
+		const forbidden = buildRouter(targetOrg.id, {
+			adminOrganizationIds: [targetOrg.id],
+		});
+		const forbiddenResponse = await forbidden.router.fetch(
+			new Request(
+				`http://gw.test/github/app/install?recovery=1&confirm_transfer=1&source_installation_id=${source.installId}`,
+			),
+		);
+		expect(forbiddenResponse.status).toBe(403);
+
+		const allowed = buildRouter(targetOrg.id, {
+			adminOrganizationIds: [sourceOrg.id, targetOrg.id],
+		});
+		const response = await allowed.router.fetch(
+			new Request(
+				`http://gw.test/github/app/install?recovery=1&confirm_transfer=1&source_installation_id=${source.installId}`,
+			),
+		);
+		expect(response.status).toBe(302);
+		const location = response.headers.get("location") ?? "";
+		expect(location).toContain("https://github.com/login/oauth/authorize");
+		const state = new URL(location).searchParams.get("state");
+		const peeked = await createGithubInstallStateStore().peek(state as string);
+		expect(peeked).toMatchObject({
+			organizationId: targetOrg.id,
+			recovery: true,
+			confirmTransfer: true,
+			transferInstallationId: "6540",
+			transferSourceOrganizationId: sourceOrg.id,
+		});
+	});
+
+	it("a signed exact transfer moves ownership and revokes the source connection", async () => {
+		const sourceOrg = await createTestOrganization({
+			name: "Transfer Callback Source",
+		});
+		const targetOrg = await createTestOrganization({
+			name: "Transfer Callback Target",
+		});
+		await seedGithubConnector(sourceOrg.id);
+		await seedGithubConnector(targetOrg.id);
+		const store = createPostgresAppInstallationStore();
+		const source = await linkGithubAppInstallation({
+			organizationId: sourceOrg.id,
+			installationId: "6550",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+		});
+		const state = await createGithubInstallStateStore().create({
+			organizationId: targetOrg.id,
+			recovery: true,
+			confirmTransfer: true,
+			transferInstallationId: "6550",
+			transferSourceOrganizationId: sourceOrg.id,
+		});
+		const { router } = buildRouter(targetOrg.id, {
+			adminOrganizationIds: [sourceOrg.id, targetOrg.id],
+			installations: {
+				6550: { login: "installer-user", type: "User" },
+			},
+			// The exact signed id means this deliberately remains ambiguous: transfer
+			// must not fall back to guessing the user's sole installation.
+			soleInstallation: "ambiguous",
+		});
+
+		const response = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?state=${state}&code=valid-oauth-code`,
+			),
+		);
+		expect(response.status).toBe(200);
+		const active = await store.resolveActiveByTenant({
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "6550",
+		});
+		expect(active?.organizationId).toBe(targetOrg.id);
+		const sql = getDb();
+		const [sourceConnection] = (await sql`
+			SELECT status FROM connections WHERE id = ${source.connectionId}
+		`) as unknown as Array<{ status: string }>;
+		expect(sourceConnection.status).toBe("revoked");
+	});
+
 	it("start route routes through GitHub user-auth (recovery) when an install row already exists", async () => {
 		const org = await createTestOrganization({ name: "Recovery Start Org" });
 		await seedGithubConnector(org.id);
@@ -1178,6 +1335,33 @@ describe("GitHub App install callback — re-bind recovery (user-auth flow)", ()
 			),
 		);
 		expect(res.status).toBe(400);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("ignores an exact transfer id unless signed transfer confirmation is present", async () => {
+		const org = await createTestOrganization({
+			name: "Recovery Unsigned Transfer Id Org",
+		});
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+			recovery: true,
+			transferInstallationId: "6650",
+		});
+		const { router } = buildRouter(org.id, {
+			installations: {
+				6650: { login: "installer-user", type: "User" },
+			},
+			soleInstallation: "ambiguous",
+		});
+
+		const response = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?state=${state}&code=valid-oauth-code`,
+			),
+		);
+		expect(response.status).toBe(400);
 		expect(await installCount(org.id)).toBe(0);
 		expect(await connectionCount(org.id)).toBe(0);
 	});

--- a/packages/server/src/gateway/__tests__/slack-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-routes.test.ts
@@ -140,6 +140,7 @@ describe("slack OAuth install routes", () => {
         const fromCtx = c.get("organizationId" as never) as string | null | undefined;
         return typeof fromCtx === "string" && fromCtx === organizationId;
       },
+      verifyInstallOrgAdminAccess: async () => false,
       getPublicGatewayUrl: () => "https://gateway.example.com",
       // The generic engine mounts /slack/install + /slack/oauth_callback from
       // this declared oauth-code-exchange integration; EVERY callback now parks

--- a/packages/server/src/gateway/auth/oauth/state-store.ts
+++ b/packages/server/src/gateway/auth/oauth/state-store.ts
@@ -196,6 +196,16 @@ interface GithubInstallStateData {
    */
   recovery?: boolean;
   /**
+   * Signed proof that an owner/admin deliberately chose to move an installation
+   * from another Lobu workspace. The callback never trusts a query parameter for
+   * this decision; only this single-use Postgres-backed state flag can authorize
+   * the cross-workspace transfer.
+   */
+  confirmTransfer?: boolean;
+  /** Exact installation and source org selected by the explicit transfer URL. */
+  transferInstallationId?: string;
+  transferSourceOrganizationId?: string;
+  /**
    * Opaque correlation id minted by the connection setup continuation. It is
    * carried through GitHub's signed state and stamped on the linked connection
    * so the initiating agent can distinguish this callback from older installs.

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -52,6 +52,7 @@ import {
 import { createPublicFileRoutes } from "../routes/public/files.js";
 import {
   resolveInstallOrgId,
+  verifyInstallOrgAdminAccess,
   verifyInstallOrgAccess,
 } from "../routes/public/install-org.js";
 import { createLandingRoutes } from "../routes/public/landing.js";
@@ -699,6 +700,7 @@ export function createGatewayApp(
         installationStore: createPostgresAppInstallationStore(),
         resolveInstallOrgId,
         verifyInstallOrgAccess,
+        verifyInstallOrgAdminAccess,
         getPublicGatewayUrl: () => coreServices.getPublicGatewayUrl(),
         integrations: (bundledIntegrationConnectors ?? []).map((integration) => ({
           connectorKey: integration.connectorKey,

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -52,7 +52,10 @@ import {
 	getAppInstallationAuthMethods,
 	normalizeConnectorAuthSchema,
 } from "../../../utils/connector-auth.js";
-import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
+import {
+	CrossOrgTransferBlockedError,
+	type AppInstallationStore,
+} from "../../../lobu/stores/app-installation-store.js";
 import { exchangeCodeForTokens } from "../../../connect/oauth-providers.js";
 import {
 	createGithubInstallStateStore,
@@ -417,8 +420,9 @@ export interface LinkGithubInstallationResult {
  * the org's `github` connector connection so its `config.installation_ref` points
  * at the install. Pure of HTTP — the route is a thin wrapper, and tests drive
  * this directly. Idempotent: re-running for the same (org, installation_id)
- * refreshes the install (reject/transfer upsert) and reuses an existing linked
- * connection instead of creating a duplicate.
+ * refreshes the install and reuses an existing linked connection instead of
+ * creating a duplicate. A different-org active owner is rejected unless the
+ * caller carries explicit, signed, admin-approved transfer confirmation.
  */
 export async function linkGithubAppInstallation(params: {
 	organizationId: string;
@@ -430,6 +434,9 @@ export async function linkGithubAppInstallation(params: {
 	metadata?: Record<string, unknown>;
 	createdBy?: string | null;
 	setupAttemptId?: string;
+	/** Explicit, signed, admin-approved move from another Lobu workspace. */
+	confirmTransfer?: boolean;
+	transferSourceOrganizationId?: string;
 }): Promise<LinkGithubInstallationResult> {
 	const sql = getDb();
 	const accountLogin =
@@ -437,10 +444,10 @@ export async function linkGithubAppInstallation(params: {
 			? (params.metadata.account_login as string)
 			: null;
 
-	// 1. Upsert the install row (reject/transfer ownership on the active-tenant
-	//    invariant — same-org reinstall refreshes in place, different-org install
-	//    transfers ownership). auth_profile_id stays null: the GitHub App
-	//    credential (app id + private key) lives in gateway env, not auth_profiles.
+	// 1. Upsert the install row under the active-tenant invariant. Same-org
+	//    reinstall refreshes in place; a different-org owner fails closed unless
+	//    this callback carried signed transfer confirmation. auth_profile_id stays
+	//    null: the App credential lives in gateway env, not auth_profiles.
 	const install = await params.store.upsert({
 		organizationId: params.organizationId,
 		provider: GITHUB_PROVIDER,
@@ -449,6 +456,19 @@ export async function linkGithubAppInstallation(params: {
 		externalTenantId: params.installationId,
 		status: "active",
 		metadata: params.metadata ?? {},
+		blockCrossOrgTransfer:
+			params.confirmTransfer !== true || !params.transferSourceOrganizationId,
+		expectedTransferOwnerOrganizationId:
+			params.confirmTransfer === true
+				? params.transferSourceOrganizationId
+				: undefined,
+		revokeConnectionsOnTransfer:
+			params.confirmTransfer === true
+				? {
+						errorMessage:
+							"GitHub App installation transferred to another workspace",
+					}
+				: undefined,
 	});
 
 	// 2 + 3. Find-or-create the connection bound to this install, serialized by a
@@ -912,6 +932,11 @@ export interface AppInstallRouterDeps {
 		c: import("hono").Context,
 		organizationId: string,
 	): Promise<boolean>;
+	/** Owner/admin authorization required for a cross-workspace transfer. */
+	verifyInstallOrgAdminAccess(
+		c: import("hono").Context,
+		organizationId: string,
+	): Promise<boolean>;
 	/**
 	 * The public gateway base URL (e.g. `https://app.lobu.ai`) used to build the
 	 * OAuth `redirect_uri`, which must equal the App's registered Callback URL.
@@ -1018,10 +1043,11 @@ async function verifyInstallationOwnership(params: {
 	clientSecret: string | undefined;
 	/**
 	 * The installation_id GitHub passed on the install redirect. `undefined` only
-	 * in the recovery flow (GitHub's user-auth redirect omits it); then it is
-	 * DERIVED from the user's sole ACCESSIBLE installation via
+	 * in an ordinary recovery flow (GitHub's user-auth redirect omits it); then it
+	 * is DERIVED from the user's sole ACCESSIBLE installation via
 	 * `fetchSoleInstallation` and re-subjected to the full ownership check (so the
-	 * derived id is admin-verified, not merely access-verified).
+	 * derived id is admin-verified, not merely access-verified). An explicit
+	 * transfer instead supplies the exact installation id from signed state.
 	 */
 	installationId: number | undefined;
 	/** True when this is the recovery (user-authorization) flow. */
@@ -1075,15 +1101,17 @@ async function verifyInstallationOwnership(params: {
 		};
 	}
 
-	// Recovery: GitHub's user-auth redirect carries no installation_id, so derive
-	// it from the user's sole ACCESSIBLE installation for this App. ACCESS is not
-	// admin — the derived id is then run through the IDENTICAL ownership check
-	// below (personal-owner or active org admin), so recovery never relaxes a
-	// guard; it only supplies the id GitHub omitted. Ambiguous (>1 installation)
-	// and none are both rejected rather than guessing.
+	// Ordinary recovery: GitHub's user-auth redirect carries no installation_id,
+	// so derive it from the user's sole ACCESSIBLE installation for this App. An
+	// explicit transfer already carries the exact id in signed state and skips
+	// this ambiguous derivation. ACCESS is not admin — the derived id is then run
+	// through the IDENTICAL ownership check below (personal-owner or active org
+	// admin), so recovery never relaxes a guard; it only supplies the id GitHub
+	// omitted. Ambiguous (>1 installation) and none are both rejected rather than
+	// guessing.
 	let installationId = params.installationId;
 	let account: InstallationAccount | null | undefined;
-	if (params.recovery) {
+	if (params.recovery && installationId === undefined) {
 		const sole = await params.fetchSoleInstallation(userToken);
 		if (sole === undefined) {
 			return {
@@ -1262,6 +1290,19 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				401,
 			);
 		}
+		const confirmTransfer = c.req.query("confirm_transfer") === "1";
+		if (
+			confirmTransfer &&
+			!(await deps.verifyInstallOrgAdminAccess(c, orgId))
+		) {
+			return c.html(
+				renderOAuthErrorPage(
+					"transfer_forbidden",
+					"Only an owner or admin of the target workspace can transfer a GitHub App installation into it.",
+				),
+				403,
+			);
+		}
 
 		const method = await getOrgAppInstallationMethod(
 			orgId,
@@ -1281,6 +1322,60 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 			);
 		}
 
+		let transferInstallationId: string | undefined;
+		let transferSourceOrganizationId: string | undefined;
+		if (confirmTransfer) {
+			const sourceInstallationId = Number(
+				c.req.query("source_installation_id"),
+			);
+			if (!Number.isInteger(sourceInstallationId) || sourceInstallationId <= 0) {
+				return c.html(
+					renderOAuthErrorPage(
+						"invalid_transfer_source",
+						"Choose a specific source installation from the connector setup result before transferring.",
+					),
+					400,
+				);
+			}
+			const sql = getDb();
+			const sourceRows = (await sql`
+				SELECT ai.organization_id, ai.external_tenant_id
+				FROM app_installations ai
+				WHERE ai.id = ${sourceInstallationId}
+				  AND ai.provider = ${GITHUB_PROVIDER}
+				  AND ai.provider_instance = ${GITHUB_PROVIDER_INSTANCE}
+				  AND ai.provider_app_id = ${appId}
+				  AND ai.status = 'active'
+				LIMIT 1
+			`) as unknown as Array<{
+				organization_id: string;
+				external_tenant_id: string;
+			}>;
+			const source = sourceRows[0];
+			if (!source || source.organization_id === orgId) {
+				return c.html(
+					renderOAuthErrorPage(
+						"invalid_transfer_source",
+						"The selected source is no longer an active GitHub App installation in another workspace.",
+					),
+					409,
+				);
+			}
+			if (
+				!(await deps.verifyInstallOrgAdminAccess(c, source.organization_id))
+			) {
+				return c.html(
+					renderOAuthErrorPage(
+						"transfer_forbidden",
+						"You must be an owner or admin in both the source and target workspaces to transfer this installation.",
+					),
+					403,
+				);
+			}
+			transferInstallationId = source.external_tenant_id;
+			transferSourceOrganizationId = source.organization_id;
+		}
+
 		// Decide recovery vs fresh install. Explicit `?recovery=1`, or this org
 		// already has an app_installations row for this App (a prior bind exists, so
 		// the install page would dead-end). Recovery needs the App's OAuth client id
@@ -1296,13 +1391,30 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				: undefined;
 		const clientId = creds?.clientId;
 		const alreadyHasInstallRow = await orgHasGithubInstallRow(orgId, appId);
-		const useRecovery = (explicitRecovery || alreadyHasInstallRow) && !!clientId;
+		if (confirmTransfer && !clientId) {
+			return c.html(
+				renderOAuthErrorPage(
+					"github_app_oauth_not_configured",
+					"The GitHub App user-authorization flow is required to confirm a transfer, but it is not configured on this gateway.",
+				),
+				503,
+			);
+		}
+		const useRecovery =
+			(confirmTransfer || explicitRecovery || alreadyHasInstallRow) && !!clientId;
 
 		const stateStore = createGithubInstallStateStore();
 		if (useRecovery && clientId) {
 			const state = await stateStore.create({
 				organizationId: orgId,
 				recovery: true,
+				...(confirmTransfer ? { confirmTransfer: true } : {}),
+				...(transferInstallationId
+					? { transferInstallationId }
+					: {}),
+				...(transferSourceOrganizationId
+					? { transferSourceOrganizationId }
+					: {}),
 				...(setupAttemptId ? { setupAttemptId } : {}),
 			});
 			const callbackUrl = githubInstallCallbackUrl(
@@ -1469,6 +1581,61 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				503,
 			);
 		}
+		if (installState.confirmTransfer === true) {
+			if (!(await deps.verifyInstallOrgAdminAccess(c, orgId))) {
+				return c.html(
+					renderOAuthErrorPage(
+						"transfer_forbidden",
+						"Your target-workspace owner/admin permission could not be confirmed. The GitHub App installation was not moved.",
+					),
+					403,
+				);
+			}
+			const transferInstallationId = installState.transferInstallationId;
+			const transferSourceOrganizationId =
+				installState.transferSourceOrganizationId;
+			if (!transferInstallationId || !transferSourceOrganizationId) {
+				return c.html(
+					renderOAuthErrorPage(
+						"invalid_transfer_state",
+						"This transfer confirmation is incomplete. Return to connector setup and choose the source connection again.",
+					),
+					400,
+				);
+			}
+			const incumbent = await deps.installationStore.resolveActiveByTenant({
+				provider: GITHUB_PROVIDER,
+				providerInstance: GITHUB_PROVIDER_INSTANCE,
+				providerAppId: appId,
+				externalTenantId: transferInstallationId,
+			});
+			if (
+				!incumbent ||
+				incumbent.organizationId !== transferSourceOrganizationId
+			) {
+				return c.html(
+					renderOAuthErrorPage(
+						"transfer_source_changed",
+						"The installation is no longer active in the workspace that was approved. Nothing was moved; start again from connector setup.",
+					),
+					409,
+				);
+			}
+			if (
+				!(await deps.verifyInstallOrgAdminAccess(
+					c,
+					transferSourceOrganizationId,
+				))
+			) {
+				return c.html(
+					renderOAuthErrorPage(
+						"transfer_forbidden",
+						"Your owner/admin permission in the source workspace could not be confirmed. The installation was not moved.",
+					),
+					403,
+				);
+			}
+		}
 
 		// Ownership proof. The signed state proves WHICH org initiated, but NOT that
 		// the caller OWNS the supplied installation_id (an enumerable integer).
@@ -1480,24 +1647,32 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		// Prove it via OAuth-during-install — ALL of this runs BEFORE any DB write,
 		// so every failure returns 4xx/503 with zero mutation.
 		//
-		// Non-recovery: validate the installation_id GitHub passed. Recovery: it is
-		// absent (passed as undefined) and verifyInstallationOwnership derives it
-		// from /user/installations, then runs the identical ownership check.
-		let suppliedInstallationId: number | undefined;
+		// Non-recovery validates the installation_id GitHub passed. Ordinary recovery
+		// passes undefined and derives it from /user/installations. Explicit transfer
+		// recovery uses the exact id preserved in signed state. Every path then runs
+		// the identical ownership check.
+		// Only a state that ALSO carries `confirmTransfer` may supply the id this
+		// way — that is the flag the transfer guards above are keyed on, so an id
+		// without it would skip both the incumbent-owner and dual-admin checks.
+		let suppliedInstallationId =
+			installState.confirmTransfer === true &&
+			installState.transferInstallationId
+				? Number(installState.transferInstallationId)
+				: undefined;
 		if (!isRecovery) {
 			suppliedInstallationId = Number((installationIdRaw ?? "").trim());
-			if (
-				!Number.isInteger(suppliedInstallationId) ||
-				suppliedInstallationId <= 0
-			) {
-				return c.html(
-					renderOAuthErrorPage(
-						"invalid_request",
-						"The GitHub install callback carried an invalid installation_id.",
-					),
-					400,
-				);
-			}
+		}
+		if (
+			suppliedInstallationId !== undefined &&
+			(!Number.isInteger(suppliedInstallationId) || suppliedInstallationId <= 0)
+		) {
+			return c.html(
+				renderOAuthErrorPage(
+					"invalid_request",
+					"The GitHub install callback carried an invalid installation_id.",
+				),
+				400,
+			);
 		}
 		// The redirect_uri must EXACTLY equal the App's registered Callback URL.
 		// Derive it from the public gateway base — NOT c.req.url, which behind the
@@ -1595,6 +1770,9 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				installationId: String(installationId),
 				store: deps.installationStore,
 				providerAppId: appId,
+				confirmTransfer: consumed.confirmTransfer === true,
+				transferSourceOrganizationId:
+					consumed.transferSourceOrganizationId,
 				...(consumed.setupAttemptId
 					? { setupAttemptId: consumed.setupAttemptId }
 					: {}),
@@ -1690,6 +1868,30 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				}),
 			);
 		} catch (error) {
+			if (error instanceof CrossOrgTransferBlockedError) {
+				const confirmedTransfer = consumed.confirmTransfer === true;
+				logger.warn(
+					{
+						organization_id: orgId,
+						installation_id: installationId,
+						owner_organization_id: error.ownerOrganizationId,
+					},
+					confirmedTransfer
+						? "GitHub App transfer blocked because the approved source changed"
+						: "GitHub App transfer blocked pending explicit confirmation",
+				);
+				return c.html(
+					renderOAuthErrorPage(
+						confirmedTransfer
+							? "transfer_source_changed"
+							: "transfer_confirmation_required",
+						confirmedTransfer
+							? "The installation is no longer active in the workspace that was approved. Nothing was moved; start again from connector setup."
+							: "This GitHub App installation is active in another Lobu workspace. Nothing was changed. Return to the connector setup result and choose the explicit admin-confirmed transfer action if you intend to move it here.",
+					),
+					409,
+				);
+			}
 			logger.error(
 				{
 					organization_id: orgId,
@@ -2035,6 +2237,11 @@ export interface InstallEngineDeps {
 		c: import("hono").Context,
 		organizationId: string,
 	): Promise<boolean>;
+	/** Owner/admin authorization for GitHub cross-workspace transfers. */
+	verifyInstallOrgAdminAccess(
+		c: import("hono").Context,
+		organizationId: string,
+	): Promise<boolean>;
 	/** The public gateway base URL used to build OAuth `redirect_uri`s. */
 	getPublicGatewayUrl?(): string | undefined;
 	/** The bundled integration connectors to mount install routes for. */
@@ -2073,6 +2280,7 @@ export function createInstallRoutes(deps: InstallEngineDeps): Hono {
 					installationStore: deps.installationStore,
 					resolveInstallOrgId: deps.resolveInstallOrgId,
 					verifyInstallOrgAccess: deps.verifyInstallOrgAccess,
+					verifyInstallOrgAdminAccess: deps.verifyInstallOrgAdminAccess,
 					getPublicGatewayUrl: deps.getPublicGatewayUrl,
 				}),
 			);

--- a/packages/server/src/gateway/routes/public/install-org.ts
+++ b/packages/server/src/gateway/routes/public/install-org.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "@lobu/core";
 import type { Context } from "hono";
 import { getDb } from "../../../db/client.js";
+import { isAdminOrOwnerRole } from "../../../tools/access-control.js";
 import {
   getCachedMembershipRole,
   getCachedOrgBySlug,
@@ -168,6 +169,26 @@ export async function verifyInstallOrgAccess(
   if (userId) {
     const role = await getCachedMembershipRole(organizationId, userId);
     return role !== null;
+  }
+  const single = await resolveSingleTenantOrgId();
+  return single !== null && single === organizationId;
+}
+
+/**
+ * Stronger install authorization for destructive ownership moves. Ordinary app
+ * installation completion needs plain membership; moving an installation between
+ * workspaces requires owner/admin, and the GitHub transfer flow calls this for
+ * BOTH the source and the target org — one demoted, one claimed.
+ */
+export async function verifyInstallOrgAdminAccess(
+  c: Context,
+  organizationId: string
+): Promise<boolean> {
+  const userId = readUserId(c);
+  if (userId) {
+    return isAdminOrOwnerRole(
+      await getCachedMembershipRole(organizationId, userId)
+    );
   }
   const single = await resolveSingleTenantOrgId();
   return single !== null && single === organizationId;

--- a/packages/server/src/lobu/stores/app-installation-store.ts
+++ b/packages/server/src/lobu/stores/app-installation-store.ts
@@ -1,4 +1,4 @@
-import { getDb, tsTime } from "../../db/client.js";
+import { getDb, pgTextArray, tsTime } from "../../db/client.js";
 
 /** Advisory-lock tag that serializes activation for one tenant tuple. */
 function activeTenantLockTag(key: AppInstallationTenantKey): string {
@@ -101,6 +101,21 @@ export interface AppInstallationUpsert extends AppInstallationTenantKey {
    */
   blockCrossOrgTransfer?: boolean;
   /**
+   * When a confirmed transfer demotes an installation owned by another org,
+   * revoke connections bound to the demoted installation in the SAME database
+   * transaction. This prevents the source workspace from continuing to present
+   * an active connection after webhook/token routing has moved away. Historical
+   * feeds and events are retained; revoked connections no longer dispatch.
+   */
+  revokeConnectionsOnTransfer?: { errorMessage: string };
+  /**
+   * Source org the caller explicitly approved moving FROM. Checked under the
+   * tenant advisory lock; if the approved source no longer owns it (including
+   * no active owner), the transfer fails closed instead of claiming or revoking
+   * an unapproved workspace.
+   */
+  expectedTransferOwnerOrganizationId?: string;
+  /**
    * Extends {@link blockCrossOrgTransfer} to a SECONDARY grouping key: an active
    * install owned by a different org whose `metadata[key] === value` also trips
    * the fence, even if its tenant tuple differs. This closes the Slack Grid
@@ -133,13 +148,19 @@ export interface AppInstallationUpsert extends AppInstallationTenantKey {
 }
 
 /**
- * Thrown by {@link AppInstallationStore.upsert} when `blockCrossOrgTransfer` is
- * set and an active install for the tuple is owned by a different org. Carries
- * that org's id so the caller can surface it.
+ * Thrown by {@link AppInstallationStore.upsert} when a cross-org claim is
+ * refused: either `blockCrossOrgTransfer` is set and a different org holds the
+ * active install, or `expectedTransferOwnerOrganizationId` no longer matches the
+ * tuple's active owner. Carries the ACTUAL owning org id so the caller can
+ * surface it — `null` when the tuple has no active owner at all.
  */
 export class CrossOrgTransferBlockedError extends Error {
-  constructor(readonly ownerOrganizationId: string) {
-    super("Active install owned by a different org; transfer not confirmed");
+  constructor(readonly ownerOrganizationId: string | null) {
+    super(
+      ownerOrganizationId
+        ? "Active install owned by a different org; transfer not confirmed"
+        : "Approved source no longer owns an active install"
+    );
     this.name = "CrossOrgTransferBlockedError";
   }
 }
@@ -153,9 +174,11 @@ export interface AppInstallationStore {
    * tenant tuple at a time.
    *  - Same-org reinstall (an active row for the tuple already owned by
    *    `organizationId`): updates that row in place.
-   *  - Different-org install: TRANSFERS ownership — the prior active row is
-   *    demoted (status -> 'suspended') and a new active row is inserted/
-   *    activated, atomically in ONE transaction.
+   *  - Different-org install: by default TRANSFERS ownership — the prior active
+   *    row is demoted (status -> 'suspended') and a new active row is inserted/
+   *    activated, atomically in ONE transaction. Callers may instead fence the
+   *    claim with `blockCrossOrgTransfer`, or require one exact approved source
+   *    with `expectedTransferOwnerOrganizationId`.
    *
    * Converges under concurrent callers across replicas: the work runs in a
    * transaction and the partial unique index `app_installations_active_tenant`
@@ -387,11 +410,34 @@ export function createPostgresAppInstallationStore(): AppInstallationStore {
           }
         }
 
+        if (install.expectedTransferOwnerOrganizationId) {
+          const foreign = await tx`
+            SELECT organization_id FROM app_installations
+            WHERE provider = ${install.provider}
+              AND provider_instance = ${install.providerInstance}
+              AND provider_app_id = ${install.providerAppId}
+              AND external_tenant_id = ${install.externalTenantId}
+              AND status = 'active'
+              AND organization_id <> ${install.organizationId}
+            LIMIT 1
+          `;
+          // `LIMIT 1` means this is the tuple's single active foreign owner, or
+          // null when nobody owns it (it was suspended/revoked between the
+          // caller's approval and this transaction). Both mismatches fail closed,
+          // and the error carries the ACTUAL owner so the caller's log doesn't
+          // assert an ownership that isn't there.
+          const currentOwner =
+            (foreign[0]?.organization_id as string | undefined) ?? null;
+          if (currentOwner !== install.expectedTransferOwnerOrganizationId) {
+            throw new CrossOrgTransferBlockedError(currentOwner);
+          }
+        }
+
         // Demote any active row for this tuple owned by a DIFFERENT org — a
         // transfer takes the single active slot from the prior owner. (A same-org
         // active row is left as-is; it becomes the row we refresh below.) This is
         // a no-op when no different-org active row exists.
-        await tx`
+        const transferredRows = (await tx`
           UPDATE app_installations
           SET status = 'suspended', updated_at = now()
           WHERE provider = ${install.provider}
@@ -400,7 +446,32 @@ export function createPostgresAppInstallationStore(): AppInstallationStore {
             AND external_tenant_id = ${install.externalTenantId}
             AND status = 'active'
             AND organization_id <> ${install.organizationId}
-        `;
+          RETURNING id, organization_id
+        `) as unknown as Array<{ id: number; organization_id: string }>;
+
+        if (
+          install.revokeConnectionsOnTransfer &&
+          transferredRows.length > 0
+        ) {
+          const transferredIds = transferredRows.map((row) => String(row.id));
+          const transferredOrganizationIds = transferredRows.map(
+            (row) => row.organization_id
+          );
+          await tx`
+            UPDATE connections
+            SET status = 'revoked',
+                error_message = ${install.revokeConnectionsOnTransfer.errorMessage},
+                updated_at = now()
+            WHERE deleted_at IS NULL
+              AND status <> 'revoked'
+              AND organization_id = ANY(
+                ${pgTextArray(transferredOrganizationIds)}::text[]
+              )
+              AND config ->> 'installation_ref' = ANY(
+                ${pgTextArray(transferredIds)}::text[]
+              )
+          `;
+        }
 
         // Find an EXISTING row for the TARGET (org, tuple) — active or demoted —
         // so an install/reinstall/return-transfer REACTIVATES that single row in

--- a/packages/server/src/tools/admin/helpers/connect-setup-continuation.ts
+++ b/packages/server/src/tools/admin/helpers/connect-setup-continuation.ts
@@ -160,8 +160,21 @@ export function appInstallationSetupContinuation(params: {
 	setupUrl?: string;
 }): ManageConnectionsResult {
 	const { action, connectorKey, setup, setupUrl } = params;
-	const setupAttemptId =
-		setup.provider === "github" && setup.install_url ? randomUUID() : undefined;
+	let setupAttemptId: string | undefined;
+	let installUrl = setup.install_url;
+	if (setup.provider === "github" && setup.install_url) {
+		const candidateSetupAttemptId = randomUUID();
+		try {
+			installUrl = appendSetupAttemptId(
+				setup.install_url,
+				candidateSetupAttemptId,
+			);
+			setupAttemptId = candidateSetupAttemptId;
+		} catch {
+			// A malformed configured gateway URL must not turn setup guidance into a
+			// tool failure. Return the original continuation without polling metadata.
+		}
+	}
 	return buildConnectionSetupContinuation({
 		action,
 		connectorKey,
@@ -174,10 +187,7 @@ export function appInstallationSetupContinuation(params: {
 		installShape: setup.install_shape,
 		setupInstructions: setup.setup_instructions,
 		setupUrl,
-		installUrl:
-			setup.install_url && setupAttemptId
-				? appendSetupAttemptId(setup.install_url, setupAttemptId)
-				: setup.install_url,
+		installUrl,
 		provider: setup.provider,
 		completionCheck: setupAttemptId
 			? installedConnectorPoll(connectorKey, setupAttemptId)

--- a/packages/server/src/tools/admin/helpers/connector-setup-errors.ts
+++ b/packages/server/src/tools/admin/helpers/connector-setup-errors.ts
@@ -8,6 +8,7 @@ export type ConnectorSetupError = {
 	error_code: "connector_setup_required";
 	connector_key: string;
 	provider: string;
+	provider_instance?: string;
 	install_type: "app_installation" | "oauth_app_profile";
 	next_action: "install_app" | "configure_oauth_app" | "open_setup";
 	setup_url?: string;
@@ -53,6 +54,9 @@ export function buildAppInstallationSetupError(params: {
 		provider: params.method.provider,
 		install_type: "app_installation",
 		next_action: installUrl ? "install_app" : "open_setup",
+		...(params.method.providerInstance
+			? { provider_instance: params.method.providerInstance }
+			: {}),
 		...(params.setupUrl ? { setup_url: params.setupUrl } : {}),
 		...(installUrl ? { install_url: installUrl } : {}),
 		...(params.method.installShape

--- a/packages/server/src/tools/admin/helpers/cross-workspace-app-install.ts
+++ b/packages/server/src/tools/admin/helpers/cross-workspace-app-install.ts
@@ -1,0 +1,218 @@
+import { getDb } from "../../../db/client";
+import {
+	getOrgAppInstallationMethod,
+	resolveAppInstallCredentials,
+} from "../../../gateway/installation/app-install-credentials";
+import { buildConnectionsUrl } from "../../../utils/url-builder";
+import { isAdminOrOwnerRole } from "../../access-control";
+import type { ToolContext } from "../../registry";
+import type {
+	ManageConnectionsResult,
+} from "../manage_connections/schemas";
+import type { ConnectorSetupError } from "./connector-setup-errors";
+
+interface CrossWorkspaceConnectionRow {
+	source_installation_id: number;
+	organization_id: string;
+	organization_slug: string;
+	organization_name: string;
+	connection_id: number | null;
+	connection_slug: string | null;
+	display_name: string | null;
+	source_member_role: string;
+}
+
+function hasVisibleConnection(
+	row: CrossWorkspaceConnectionRow,
+): row is CrossWorkspaceConnectionRow & {
+	connection_id: number;
+	connection_slug: string;
+} {
+	return row.connection_id !== null && row.connection_slug !== null;
+}
+
+export async function buildCrossWorkspaceAppInstallResult(params: {
+	connectorKey: string;
+	ctx: ToolContext;
+	setup: ConnectorSetupError;
+	setupContinuation: ManageConnectionsResult;
+	ownerSlug: string | null;
+	baseUrl: string | undefined;
+}): Promise<ManageConnectionsResult> {
+	const {
+		connectorKey,
+		ctx,
+		setup,
+		setupContinuation,
+		ownerSlug,
+		baseUrl,
+	} = params;
+	const { organizationId, userId } = ctx;
+	if (
+		!userId ||
+		(ctx.tokenType !== "oauth" && ctx.tokenType !== "session") ||
+		connectorKey !== "github" ||
+		setup.provider !== "github" ||
+		setup.install_shape !== "github-app" ||
+		!setup.provider_instance ||
+		!ownerSlug ||
+		!("install_url" in setupContinuation) ||
+		typeof setupContinuation.install_url !== "string"
+	) {
+		return setupContinuation;
+	}
+
+	// GitHub transfer validation uses the configured App id as part of the exact
+	// installation identity. Apply the same predicate during discovery so every
+	// offered transfer option can pass that later validation.
+	const method = await getOrgAppInstallationMethod(
+		organizationId,
+		connectorKey,
+		setup.provider,
+	);
+	const providerAppId = method
+		? resolveAppInstallCredentials(method).appId
+		: undefined;
+	if (!providerAppId) return setupContinuation;
+
+	// Installations remain workspace-scoped. Include an active install when the
+	// caller administers its workspace even if its connection was deleted; attach
+	// only a connection the caller could see when one still exists.
+	const sql = getDb();
+	const otherRows = (await sql`
+		SELECT ai.id AS source_installation_id,
+		       o.id AS organization_id, o.slug AS organization_slug,
+		       o.name AS organization_name, c.id AS connection_id,
+		       c.slug AS connection_slug, c.display_name,
+		       m.role AS source_member_role
+		FROM "member" m
+		JOIN organization o ON o.id = m."organizationId"
+		JOIN app_installations ai ON ai.organization_id = o.id
+		LEFT JOIN LATERAL (
+		  SELECT candidate.id, candidate.slug, candidate.display_name
+		  FROM connections candidate
+		  WHERE candidate.organization_id = o.id
+		    AND candidate.connector_key = ${connectorKey}
+		    AND candidate.status = 'active'
+		    AND candidate.deleted_at IS NULL
+		    AND candidate.config ->> 'installation_ref' = ai.id::text
+		    AND (
+		      m.role IN ('owner', 'admin')
+		      OR candidate.visibility = 'org'
+		      OR candidate.created_by = ${userId}
+		    )
+		  ORDER BY candidate.id ASC
+		  LIMIT 1
+		) c ON TRUE
+		WHERE m."userId" = ${userId}
+		  AND o.id <> ${organizationId}
+		  AND ai.status = 'active'
+		  AND ai.provider = ${setup.provider}
+		  AND ai.provider_instance = ${setup.provider_instance}
+		  AND ai.provider_app_id = ${providerAppId}
+		  AND (c.id IS NOT NULL OR m.role IN ('owner', 'admin'))
+		ORDER BY o.slug ASC, ai.id ASC
+	`) as unknown as CrossWorkspaceConnectionRow[];
+	if (otherRows.length === 0) return setupContinuation;
+
+	// A malformed configured gateway URL must not turn setup guidance into a
+	// tool failure. The plain continuation remains actionable for configuration.
+	let installUrl: URL;
+	try {
+		installUrl = new URL(setupContinuation.install_url);
+	} catch {
+		return setupContinuation;
+	}
+	installUrl.searchParams.set("org", ownerSlug);
+
+	const currentRows = (await sql`
+		SELECT name FROM organization WHERE id = ${organizationId} LIMIT 1
+	`) as unknown as Array<{ name: string }>;
+	const canTransferTarget = isAdminOrOwnerRole(ctx.memberRole);
+	const transferOptions = canTransferTarget
+		? otherRows
+				.filter((row) => isAdminOrOwnerRole(row.source_member_role))
+				.map((row) => {
+					const transferUrl = new URL(installUrl);
+					transferUrl.searchParams.set("recovery", "1");
+					transferUrl.searchParams.set("confirm_transfer", "1");
+					transferUrl.searchParams.set(
+						"source_installation_id",
+						String(row.source_installation_id),
+					);
+					return {
+						source_workspace: {
+							id: row.organization_id,
+							slug: row.organization_slug,
+						},
+						source_installation_id: row.source_installation_id,
+						transfer_url: transferUrl.toString(),
+					};
+				})
+		: [];
+	const accessibleWorkspaces = otherRows
+		.filter(hasVisibleConnection)
+		.map((row) => ({
+			workspace: {
+				id: row.organization_id,
+				slug: row.organization_slug,
+				name: row.organization_name,
+			},
+			connection: {
+				id: Number(row.connection_id),
+				slug: row.connection_slug,
+				display_name: row.display_name,
+				status: "active" as const,
+			},
+			switch_workspace: {
+				next_action: "switch_workspace" as const,
+				organization_id: row.organization_id,
+				organization_slug: row.organization_slug,
+				view_url: buildConnectionsUrl(
+					row.organization_slug,
+					baseUrl,
+					connectorKey,
+				),
+			},
+		}));
+	const locationInstructions =
+		accessibleWorkspaces.length > 0
+			? "This connector is already active in another workspace you can access. Switch to that workspace or install a different provider tenant here."
+			: "This GitHub App installation is active in another workspace you administer. Install a different provider tenant here.";
+
+	return {
+		action: "connect",
+		status: "connected_in_other_workspace",
+		connector_key: connectorKey,
+		current_workspace: {
+			id: organizationId,
+			slug: ownerSlug,
+			name: currentRows[0]?.name ?? ownerSlug,
+		},
+		accessible_workspaces: accessibleWorkspaces,
+		install_app_here: {
+			next_action: "install_app",
+			install_url: installUrl.toString(),
+		},
+		...("setup_attempt_id" in setupContinuation &&
+		typeof setupContinuation.setup_attempt_id === "string"
+			? { setup_attempt_id: setupContinuation.setup_attempt_id }
+			: {}),
+		...("completion_check" in setupContinuation &&
+		setupContinuation.completion_check
+			? { completion_check: setupContinuation.completion_check }
+			: {}),
+		...(transferOptions.length > 0
+			? {
+					transfer_installation_here: {
+						next_action: "transfer_installation_here" as const,
+						requires_confirmation: true as const,
+						warning:
+							"Each option moves one exact GitHub App installation here and revokes the source-workspace connections bound to it.",
+						options: transferOptions,
+					},
+				}
+			: {}),
+		instructions: `${locationInstructions}${transferOptions.length > 0 ? " To move one exact installation, use its explicit transfer option; owner/admin rights are required in both workspaces." : ""} No connection data or credentials are shared across workspaces.`,
+	};
+}

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -62,6 +62,7 @@ import {
 	type ConnectionSetupNextAction,
 } from "../../helpers/connect-setup-continuation";
 import { createConnectionSetupBundle } from "../../helpers/interactive-connection-setup";
+import { buildCrossWorkspaceAppInstallResult } from "../../helpers/cross-workspace-app-install";
 
 export async function handleConnect(
 	args: Extract<ConnectionsArgs, { action: "connect" }>,
@@ -125,11 +126,19 @@ export async function handleConnect(
 		// Setup-required continuation: the App install callback creates the active
 		// connection itself, so do NOT instruct a retry of connect. The guard's
 		// ConnectorSetupError already carries the absolute install_url.
-		return appInstallationSetupContinuation({
+		const setupContinuation = appInstallationSetupContinuation({
 			action: "connect",
 			connectorKey: args.connector_key,
 			setup: appInstallGuard,
 			setupUrl: await buildAppInstallationSetupUrl(ctx, args.connector_key),
+		});
+		return buildCrossWorkspaceAppInstallResult({
+			connectorKey: args.connector_key,
+			ctx,
+			setup: appInstallGuard,
+			setupContinuation,
+			ownerSlug,
+			baseUrl,
 		});
   }
 


### PR DESCRIPTION
## Summary

- Return `connected_in_other_workspace` to interactive OAuth/session callers when the requested GitHub connector is active in another workspace they can access, while keeping connection data and PAT contexts workspace-scoped.
- Keep distinct GitHub installation IDs active across Lobu workspaces; fence the same exact installation ID against silent transfer.
- Add an explicit, signed, single-use transfer flow requiring owner/admin rights in both workspaces, re-verifying GitHub ownership, failing closed on ownership races, and atomically revoking source connections without deleting history.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Targeted integration tests run against Postgres
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red

```text
17 pass
2 fail

Expected promise that rejects; received resolved

Expected: status: connected_in_other_workspace
Received: status: setup_required, next_action: install_app
```

### Green

```text
58 pass
0 fail
233 expect() calls
Ran 58 tests across 3 files.
```

Focused files:

```text
packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
packages/server/src/__tests__/integration/connectors/github-app-install-callback.test.ts
packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
```

Final `make pre-pr`:

```text
✅ pre-pr gates clean.
```

## Notes

The separate pending-run approval-page bug is not part of this diff; it was already fixed by #2229. This PR does not transfer or mutate the live GitHub installation during verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for connections already active in another workspace, including workspace switching and local installation.
  * Added secure, administrator-confirmed transfers of GitHub connections between workspaces.
  * Added setup progress tracking for GitHub installations.
* **Bug Fixes**
  * Improved handling of invalid links, missing or suspended installations, and conflicting ownership.
  * Prevented unauthorized or unconfirmed transfers from changing existing connections.
* **Security**
  * Added administrator authorization and signed, single-use transfer confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

