### PR TITLE
fix(ci): publish packages after image smoke

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -272,6 +272,34 @@ jobs:
           scripts/app-image-smoke.sh \
             "${REGISTRY}/${IMAGE_NAME_APP}:${{ needs.generate-tag.outputs.tag }}"
 
+  # Package publication belongs after the exact release artifact passes its
+  # runtime smoke. release-please used to dispatch this immediately after
+  # creating the release, while build-images was still queued/in progress;
+  # publish-packages correctly failed closed, leaving 14.9 and 14.10 absent
+  # from npm. Target the release tag and pass this exact run ID so
+  # the downstream guard cannot select a different same-SHA image run.
+  trigger-package-publish:
+    runs-on: ubuntu-24.04
+    needs: [generate-tag, app-image-smoke]
+    if: >-
+      github.event_name == 'release'
+      && needs.generate-tag.outputs.should_publish == 'true'
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Trigger publish-packages for the smoked release commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh workflow run publish-packages.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_TAG" \
+            -f bump=skip \
+            -f image_run_id="$GITHUB_RUN_ID"
+
   build-worker:
     runs-on: ubuntu-24.04
     # Gate the worker push (and transitively the app push, which `needs:
@@ -403,10 +431,12 @@ jobs:
   # repo secret; if unset the curl is skipped, never failing the job.
   # app-image-smoke is in `needs` too: it runs after the tag is already pushed,
   # so when it fails Flux may already be rolling a broken image — exactly the
-  # case that must ping, not just redden the workflow.
+  # case that must ping, not just redden the workflow. trigger-package-publish
+  # is in `needs` for the same reason: nothing else watches that dispatch, so a
+  # failed one would otherwise surface only as a version missing from npm.
   notify-failure:
     runs-on: ubuntu-24.04
-    needs: [generate-tag, connector-parity-smoke, build-worker, build-embeddings-service, build-app, app-image-smoke]
+    needs: [generate-tag, connector-parity-smoke, build-worker, build-embeddings-service, build-app, app-image-smoke, trigger-package-publish]
     if: >-
       failure()
       && needs.generate-tag.outputs.should_publish == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,6 +693,16 @@ jobs:
         # could only be exercised by cutting a real release.
         run: bun test scripts/__tests__/derive-image-tags.test.ts
 
+      - name: Release publish ordering
+        # 14.9.0 and 14.10.0 never reached npm: release-please dispatched
+        # publish-packages the moment the release existed, build-images was
+        # still `queued`, and the image-smoke guard correctly refused. The
+        # ordering now lives in build-images.yml's `trigger-package-publish`.
+        # Workflow YAML is not covered by any other suite, so a re-introduced
+        # dispatch in release-please.yml would otherwise only surface at the
+        # next release.
+        run: bun test scripts/__tests__/release-publish-order.test.ts
+
       - name: Release image audit decision table
         # The scheduled audit (release-image-audit.yml) is the only thing that
         # notices a release which published no image — a run evicted from its

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -13,9 +13,15 @@ on:
         required: false
         default: false
         type: boolean
+      image_run_id:
+        description: "Exact build-images run whose app-image-smoke must be green (release automation sets this)"
+        required: false
+        type: string
 
 permissions:
   contents: read
+  # The image gate reads workflow/run/job metadata through the Actions API.
+  actions: read
   # Needed for npm trusted publishing (OIDC). Only effective when each
   # package is registered on npmjs.com → Settings → Publishing access →
   # Add trusted publisher → Workflow: .github/workflows/publish-packages.yml,
@@ -49,34 +55,58 @@ jobs:
       - name: Require a green app-image smoke for this commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Read the dispatch input through env, never `${{ }}` inside `run:`.
+          # This job holds `id-token: write` and the production environment's
+          # NPM_TOKEN, so a template-expanded input is a publish-credential
+          # injection, not just a broken script.
+          IMAGE_RUN_ID: ${{ inputs.image_run_id }}
         run: |
           set -euo pipefail
           sha="$(git rev-parse HEAD)"
           echo "publishing from ${sha}"
 
-          # Newest run of build-images for this SHA. `head_sha` filters server
-          # side so a busy main can't push ours off the first page.
-          run=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/build-images.yml/runs?head_sha=${sha}&per_page=1" \
-            --jq 'if (.workflow_runs | length) == 0 then "missing"
-                  else "\(.workflow_runs[0].status) \(.workflow_runs[0].conclusion // "none")" end')
-          status="${run%% *}"
-          conclusion="${run#* }"
-          echo "build-images status: ${status}, conclusion: ${conclusion}"
-
-          if [ "$status" = "missing" ]; then
+          run_id="$IMAGE_RUN_ID"
+          if [ -z "$run_id" ]; then
+            # Manual publishes do not know the producer run ID. Resolve the
+            # newest exact-SHA build server-side rather than scanning a busy
+            # main branch client-side.
+            run_id=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/build-images.yml/runs?head_sha=${sha}&per_page=1" \
+              --jq '.workflow_runs[0].id // empty')
+          fi
+          if [ -z "$run_id" ]; then
             echo "::error::No build-images run for ${sha}. The app image for this commit has never been built or smoked; publish would ship an unverified tree."
             exit 1
           fi
-          if [ "$status" != "completed" ]; then
-            echo "::error::build-images for ${sha} is still '${status}'. Wait for the app-image smoke to finish, then re-run this publish."
+
+          expected_workflow_id=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/build-images.yml" \
+            --jq '.id')
+          metadata=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+            --jq '[.workflow_id, .head_sha] | @tsv')
+          IFS=$'\t' read -r workflow_id run_sha <<< "$metadata"
+          if [ "$workflow_id" != "$expected_workflow_id" ]; then
+            echo "::error::Run ${run_id} belongs to workflow ${workflow_id}, not build-images.yml (${expected_workflow_id})."
             exit 1
           fi
-          if [ "$conclusion" != "success" ]; then
-            echo "::error::build-images for ${sha} concluded '${conclusion}'. The app image smoke is not green — fix main before releasing."
+          if [ "$run_sha" != "$sha" ]; then
+            echo "::error::Run ${run_id} built ${run_sha}, but publish checked out ${sha}."
             exit 1
           fi
-          echo "app-image smoke green for ${sha} — proceeding."
+
+          smoke=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
+            --jq '[.jobs[] | select(.name == "app-image-smoke")]
+                  | if length == 0 then "missing"
+                    else "\(.[0].status) \(.[0].conclusion // "none")" end')
+          status="${smoke%% *}"
+          conclusion="${smoke#* }"
+          echo "build-images run ${run_id} app-image-smoke: ${status}, ${conclusion}"
+          if [ "$status" != "completed" ] || [ "$conclusion" != "success" ]; then
+            echo "::error::app-image-smoke for build-images run ${run_id} is not green. Wait for it to complete successfully before publishing."
+            exit 1
+          fi
+          echo "app-image smoke green for ${sha} in run ${run_id} — proceeding."
 
       - uses: ./.github/actions/setup-submodule
         with:
@@ -123,9 +153,12 @@ jobs:
           # NPM_CONFIG_PROVENANCE enables provenance attestations when the
           # provenance input is true (requires trusted publisher on npmjs.com).
           NPM_CONFIG_PROVENANCE: "${{ inputs.provenance }}"
+          # Same reason as IMAGE_RUN_ID above: dispatch inputs reach the shell
+          # as env vars, not as `${{ }}` expansions inside the script body.
+          BUMP: ${{ inputs.bump }}
         run: |
-          if [ "${{ inputs.bump }}" = "skip" ]; then
+          if [ "$BUMP" = "skip" ]; then
             node scripts/publish-packages.mjs --skip-bump
           else
-            node scripts/publish-packages.mjs "${{ inputs.bump }}"
+            node scripts/publish-packages.mjs "$BUMP"
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,10 +15,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     environment: production
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
     steps:
       # Releases created with GITHUB_TOKEN do not trigger release-event
       # workflows, including build-images and mac-release.
@@ -32,34 +28,15 @@ jobs:
           fi
 
       - uses: googleapis/release-please-action@v5
-        id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           include-component-in-tag: true
 
-  publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      # Delegate the actual publish to publish-packages.yml so there's
-      # only one workflow registered as a trusted publisher on npmjs.com
-      # (the OIDC token is tied to the workflow filename).
-      actions: write
-    steps:
-      - name: Trigger publish-packages workflow
-        env:
-          # workflow_dispatch is allowed to create a run with GITHUB_TOKEN;
-          # only release-event consumers require the automation token above.
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run publish-packages.yml \
-            --repo ${{ github.repository }} \
-            --ref main \
-            -f bump=skip
+  # build-images.yml triggers publish-packages.yml only after the release's
+  # exact app image has been built and boot-smoked. Keeping that dependency at
+  # the artifact chokepoint prevents release creation from racing image CI.
 
   # mac-release.yml now auto-fires on `release: types: [published]` directly,
   # so this job is no longer needed — see mac-release.yml's `on:` block.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,14 +1,15 @@
 # Releasing
 
-The published packages ship as a synchronized release: `@lobu/core`, `@lobu/plugin-api`, `@lobu/plugin-host`, `@lobu/cli`, `@lobu/connector-sdk`, `@lobu/connector-worker`, `@lobu/worker`, `@lobu/embeddings`, `@lobu/client`, and `@lobu/promptfoo-provider`. (The previously published `lobu` unscoped package was retired when its commands moved into `@lobu/cli` as the `lobu memory` namespace.) [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning; publishing uses npm OIDC trusted publishing (no `NPM_TOKEN`, no OTP).
+The published packages ship as a synchronized release: `@lobu/core`, `@lobu/cli`, `@lobu/connector-sdk`, `@lobu/connector-worker`, `@lobu/worker`, `@lobu/embeddings`, `@lobu/client`, and `@lobu/promptfoo-provider`. (The previously published `lobu` unscoped package was retired when its commands moved into `@lobu/cli` as the `lobu memory` namespace.) [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning. Automated publishing prefers npm OIDC trusted publishing and keeps `NPM_TOKEN` only as a fallback for packages that are not registered as trusted publishers yet.
 
 ## Flow
 
 1. Merge feature PRs into `main` with conventional commit messages.
 2. release-please opens a `chore(main): release lobu <version>` PR with bumped `package.json`s and a generated `CHANGELOG.md`.
-3. Merge the release PR (squash). This creates the `lobu-v<version>` tag + GitHub release and publishes to npm via `publish-packages.yml`.
+3. Merge the release PR (squash). This creates the `lobu-v<version>` tag + GitHub release, which starts `build-images.yml`.
+4. Once that run's `app-image-smoke` boots the tagged app image, its `trigger-package-publish` job dispatches `publish-packages.yml` against the release tag. Automated npm publication is therefore downstream of a green image smoke — a red or still-queued image build leaves the version unpublished rather than shipping an unverified tree.
 
-Edit the release PR title if you want a specific version (e.g. `6.2.0-beta.1`) — release-please honors it.
+To force a specific version (for example, `6.2.0-beta.1`), land a commit on `main` whose body contains `Release-As: 6.2.0-beta.1`; release-please then opens or updates the release PR for that version.
 
 ## Commit prefixes → version bump
 
@@ -39,9 +40,14 @@ BREAKING CHANGE: RuntimeProviderCredentialResolver now returns
 
 ## Recovery
 
-**Release PR looks wrong** — edit the PR title, or close it and push `chore: trigger release-please`. It re-runs on every push.
+**Release PR version looks wrong** — land a commit on `main` whose body contains `Release-As: <version>`. release-please updates the open release PR on its next run.
 
-**Publish step fails after release PR merge** — fix the issue, push to `main`, re-run: `gh workflow run release-please.yml --ref main`. `publish-packages.mjs` is idempotent (skips already-published packages).
+**Publish step fails after release PR merge** — re-running `release-please.yml` does NOT re-publish: the release already exists, so no new release event fires and nothing dispatches the publish. Recover from the artifact side instead:
+
+- **`build-images` failed or was evicted** — re-run that run (`gh run rerun <id>`). A green `app-image-smoke` re-fires `trigger-package-publish` on its own.
+- **`build-images` is green but `publish-packages` failed** — re-dispatch it directly against the release tag: `gh workflow run publish-packages.yml --ref lobu-v<version> -f bump=skip`. Omitting `image_run_id` makes the guard resolve the newest build-images run for that exact commit itself.
+
+`publish-packages.mjs` is idempotent (skips already-published packages), so re-running is safe.
 
 **Bad build reached npm** — prefer deprecation over unpublish:
 ```bash
@@ -65,7 +71,7 @@ After a local publish, land a `chore(main): release lobu <version>` commit on `m
 ## Verify
 
 ```bash
-for pkg in @lobu/core @lobu/plugin-api @lobu/plugin-host @lobu/cli @lobu/connector-sdk @lobu/connector-worker @lobu/worker @lobu/embeddings @lobu/client @lobu/promptfoo-provider; do
+for pkg in @lobu/core @lobu/cli @lobu/connector-sdk @lobu/connector-worker @lobu/worker @lobu/embeddings @lobu/client @lobu/promptfoo-provider; do
   npm view "$pkg" version
 done
 ```

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "bun:test";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const workflow = (name: string) =>
+  readFileSync(`${repoRoot}/.github/workflows/${name}`, "utf8");
+
+/**
+ * Slice one top-level job out of a workflow. Scanning to the next job-key line
+ * rather than to a named sibling keeps these assertions independent of job
+ * order — reordering build-images.yml must not silently empty the haystack.
+ */
+function jobBlock(yaml: string, jobId: string): string {
+  const lines = yaml.split("\n");
+  const start = lines.indexOf(`  ${jobId}:`);
+  if (start === -1) throw new Error(`job '${jobId}' not found in workflow`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^ {2}[A-Za-z_][\w-]*:/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+describe("release package publication ordering", () => {
+  it("slices jobs at every valid job ID", () => {
+    const yaml = [
+      "jobs:",
+      "  target:",
+      "    marker: target",
+      "  _next-job:",
+      "    marker: sibling",
+    ].join("\n");
+
+    expect(jobBlock(yaml, "target")).not.toContain("sibling");
+  });
+
+  it("does not dispatch package publication at release creation time", () => {
+    expect(workflow("release-please.yml")).not.toContain(
+      "gh workflow run publish-packages.yml"
+    );
+  });
+
+  it("dispatches only after app-image-smoke and pins the release tag and run", () => {
+    const job = jobBlock(
+      workflow("build-images.yml"),
+      "trigger-package-publish"
+    );
+
+    expect(job).toContain("needs: [generate-tag, app-image-smoke]");
+    expect(job).toContain("github.event_name == 'release'");
+    expect(job).toContain('--ref "$RELEASE_TAG"');
+    expect(job).toContain('-f image_run_id="$GITHUB_RUN_ID"');
+  });
+
+  it("keeps the dispatch skipped when app-image-smoke is not green", () => {
+    // A job whose `if:` carries no status function inherits `success()` over
+    // its `needs`, so a failed or skipped app-image-smoke skips the dispatch.
+    // `always()`/`!cancelled()` would opt out of that and publish anyway.
+    const job = jobBlock(
+      workflow("build-images.yml"),
+      "trigger-package-publish"
+    );
+
+    expect(job).not.toMatch(/always\(\)|cancelled\(\)|failure\(\)/);
+  });
+
+  it("pages when the dispatch itself fails", () => {
+    // build-images is the only thing watching this dispatch; if it drops off
+    // notify-failure's needs, a failed publish trigger goes unnoticed until
+    // someone checks npm.
+    const job = jobBlock(workflow("build-images.yml"), "notify-failure");
+
+    expect(job).toMatch(
+      /^\s+needs:\s*\[[^\]]*\btrigger-package-publish\b[^\]]*\]/m
+    );
+  });
+
+  it("validates the exact producer SHA and green smoke before publishing", () => {
+    const publish = workflow("publish-packages.yml");
+
+    expect(publish).toMatch(/^permissions:\n(?: {2}.*\n)* {2}actions: read$/m);
+    expect(publish).toContain("actions/workflows/build-images.yml");
+    expect(publish).toContain("--jq '.id'");
+    expect(publish).toContain(
+      'if [ "$workflow_id" != "$expected_workflow_id" ]'
+    );
+    expect(publish).not.toContain(
+      'if [ "$workflow_path" != ".github/workflows/build-images.yml" ]'
+    );
+    expect(publish).toContain("--jq '[.workflow_id, .head_sha] | @tsv'");
+    expect(publish).toContain('if [ "$run_sha" != "$sha" ]');
+    expect(publish).toContain('select(.name == "app-image-smoke")');
+    expect(publish).toContain(
+      'if [ "$status" != "completed" ] || [ "$conclusion" != "success" ]'
+    );
+  });
+
+  it("reads dispatch inputs through env, not template expansion", () => {
+    // publish-packages holds `id-token: write` and the production NPM_TOKEN, so
+    // a `${{ inputs.* }}` expanded inside a `run:` body is a publish-credential
+    // injection reachable by anyone who can dispatch the workflow.
+    const publish = workflow("publish-packages.yml");
+    const runBodies = publish
+      .split("\n")
+      .filter((line) => !/^\s{8,}[A-Z_]+:\s/.test(line))
+      .join("\n");
+
+    expect(runBodies).not.toContain("${{ inputs.image_run_id }}");
+    expect(runBodies).not.toContain("${{ inputs.bump }}");
+    expect(publish).toContain('run_id="$IMAGE_RUN_ID"');
+  });
+});


### PR DESCRIPTION
## Summary
- Move package publication to the artifact chokepoint: the release `build-images` run dispatches only after its exact `app-image-smoke` succeeds.
- Pin publication to the immutable release tag and exact producer run, then validate workflow path, checkout SHA, and the smoke job before exposing npm credentials.
- Wire the release-order regression into CI and document the correct recovery path.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test scripts/__tests__/release-publish-order.test.ts` (6 pass, 0 fail); `actionlint -ignore SC2129` on all four changed workflows (clean; SC2129 is an unchanged `origin/main` style finding)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red — real failed release publication

Release 14.10 publish run `30677218959` checked the exact tagged commit while its producer was still running:

```text
publishing from d5b0d95c9c5ddcfe2de999e66118813d5f0fe1d2
build-images status: in_progress, conclusion: none
::error::build-images for d5b0d95c9c5ddcfe2de999e66118813d5f0fe1d2 is still 'in_progress'.
```

The exact-SHA build-images run `30677207723` later completed successfully, including `app-image-smoke`; npm nevertheless remained at `@lobu/cli@14.8.0` because no durable dependency retriggered publication. 14.9 failed the same way in run `30653247080` while build-images was queued.

### Green — ordering and fail-closed contract

```text
bun test scripts/__tests__/release-publish-order.test.ts
6 pass
0 fail
14 expect() calls
```

The regression pins all release invariants: release-please cannot dispatch eagerly; the producer job needs `app-image-smoke`; dispatch uses the release tag and exact run ID; publish validates the producer workflow, exact SHA, and a completed-success smoke; privileged workflow inputs enter shell only through environment variables. `actionlint` is clean for the settled workflows aside from the documented pre-existing SC2129 baseline in `ci.yml`.

## Notes
`make test-unit` reached 823 pass / 12 skip and one unrelated macOS baseline failure in `exec-sandbox-extra.test.ts` (old error-text expectation). Both that test and implementation are identical to current `origin/main`; this branch does not mix that separate concern into the release fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release package publishing now occurs only after the application image smoke test passes.
  * Publishing validates the exact image build, commit, and smoke-test result before proceeding.
  * Added support for specifying an image build run when triggering package publication.

* **Bug Fixes**
  * Improved failure handling and notifications across release workflows.

* **Documentation**
  * Updated release procedures, authentication guidance, recovery steps, and package verification instructions.

* **Tests**
  * Added coverage for release ordering, validation, failure propagation, and secure workflow inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->