### PR TITLE
fix(submodule): align owletto behavior contracts

### DIFF
--- a/packages/server/src/lobu/__tests__/agent-routes-list-counts.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-list-counts.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Cross-repo wire coverage for the Owletto agent list.
+ *
+ * The database and internal engine still call these rows watchers, but the
+ * public AgentItem contract is Behavior-facing: owletto declares
+ * `behaviorCount`, so the server has to emit that key. Nothing in owletto reads
+ * the field today, so a key mismatch produces no type error and no visibly
+ * broken screen — this server-side assertion is the only thing that catches it.
+ */
+import { beforeAll, beforeEach, expect, test } from "bun:test";
+import {
+	ensureDbForGatewayTests,
+	resetTestDatabase,
+	seedAgentRow,
+} from "../../gateway/__tests__/helpers/db-setup.js";
+import { authStash, installRouteTestMocks } from "./helpers/route-test-mocks";
+
+installRouteTestMocks();
+
+const ORG = "org-agent-list-counts";
+const AGENT = "counted-agent";
+
+beforeAll(async () => {
+	await ensureDbForGatewayTests();
+}, 60_000);
+
+beforeEach(async () => {
+	await resetTestDatabase();
+	await seedAgentRow(AGENT, { organizationId: ORG, name: "Counted Agent" });
+	// The stashes are process-global and shared with every other file in this
+	// directory (they all run in one `bun test` process), so set every field this
+	// file depends on rather than inheriting a neighbour's last value.
+	authStash.user = {
+		id: "u1",
+		name: "Test",
+		email: "u1@test",
+		emailVerified: true,
+	};
+	authStash.organizationId = ORG;
+	authStash.authSource = "session";
+	authStash.mcpAuthInfo = null;
+
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	await sql`
+		INSERT INTO "user" (
+			id, name, email, "emailVerified", "createdAt", "updatedAt"
+		) VALUES (
+			'test-user', 'Test User', 'test-user@example.com', true, now(), now()
+		)
+	`;
+	// One active Behavior plus one archived one: the count query filters on
+	// status, so the archived row is what keeps `behaviorCount: 1` from passing
+	// on a mere "some rows exist" read.
+	await sql`
+		INSERT INTO watchers (
+			id, organization_id, slug, name, agent_id, created_by,
+			watcher_group_id, status
+		) VALUES (
+			9001, ${ORG}, 'counted-behavior', 'Counted Behavior', ${AGENT},
+			'test-user', 9001, 'active'
+		), (
+			9002, ${ORG}, 'archived-behavior', 'Archived Behavior', ${AGENT},
+			'test-user', 9002, 'archived'
+		)
+	`;
+});
+
+test("GET / exposes active watcher rows as behaviorCount", async () => {
+	const { agentRoutes } = await import("../agent-routes.js");
+	const response = await agentRoutes.request("/");
+	expect(response.status).toBe(200);
+
+	const body = (await response.json()) as {
+		agents: Array<Record<string, unknown>>;
+	};
+	const agent = body.agents.find((item) => item.agentId === AGENT);
+	expect(agent).toMatchObject({ agentId: AGENT, behaviorCount: 1 });
+	expect(agent).not.toHaveProperty("watcherCount");
+});

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -467,7 +467,7 @@ routes.get("/", async (c) => {
 			connectionCount: countMap.get(a.agentId) ?? 0,
 			activeConnectionCount: activeCountMap.get(a.agentId) ?? 0,
 			clientCount: clientCountMap.get(a.agentId)?.size ?? 0,
-			watcherCount: watcherCountMap.get(a.agentId) ?? 0,
+			behaviorCount: watcherCountMap.get(a.agentId) ?? 0,
 			userCount: userCountMap.get(a.agentId) ?? 0,
 			platforms: platformsMap.get(a.agentId) ?? [],
 			providers: providersMap.get(a.agentId) ?? [],


### PR DESCRIPTION
## Summary
- pin Owletto to merged main commit `c89d8a60d4ff137ec936e90aa49190c2f571d084`, including the persisted Behavior-event and macOS payload compatibility repair from owletto#692
- expose the agent-list count using the public `behaviorCount` field expected by Owletto while retaining internal watcher vocabulary
- add endpoint-level coverage for the public count key and active-only semantics

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: focused endpoint test; full `packages/server/src/lobu/__tests__` co-run (120 pass); Owletto full test suite (1154 pass), production build, Swift `TurnPromptTests`, and Swift `DispatcherResumeTests`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Red
With the pre-fix server response, the real endpoint test failed:
```text
Expected: { agentId: "counted-agent", behaviorCount: 1 }
Received: { agentId: "counted-agent", watcherCount: 1, ... }
0 pass, 1 fail
```
The Owletto regressions on its former main also failed with missing persisted `watcher_*` metadata, `watcher_batch_reject`, and Swift `DecodingError.keyNotFound` for the current server `watcher` payload envelope.

### Green
```text
(pass) GET / exposes active watcher rows as behaviorCount
1 pass, 0 fail, 3 expect() calls
check-exposed-surface-naming: clean — no agent-facing watcher on exposed surface.
```
Owletto: 129 files / 1154 tests pass; production build and browser bundle check pass; both Swift executable suites pass.

## Notes
- Upstream repair: https://github.com/lobu-ai/owletto/pull/692
- `watcher` remains permitted internal engine/database vocabulary; all public API/UI contracts remain Behavior-facing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Renamed the agent list count field from `watcherCount` to `behaviorCount`.
  * Ensured the count reflects active behaviors only; archived behaviors are excluded.

* **Tests**
  * Added coverage confirming the updated response field and active behavior counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->