### PR TITLE
fix(server): exclude command sessions from Recent

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/client-sessions-route.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/client-sessions-route.test.ts
@@ -28,6 +28,7 @@ describe('client sessions activity route', () => {
   let ownerId: string;
   let clientId: string;
   let clientName: string;
+  let commandClientId: string;
   let otherOrgId: string;
 
   function auditCtx(overrides: Partial<ToolContext> = {}): ToolContext {
@@ -83,6 +84,11 @@ describe('client sessions activity route', () => {
     clientName = 'Sessions Probe App';
     const oauthClient = await createTestOAuthClient({ client_name: clientName });
     clientId = oauthClient.client_id;
+    const commandClient = await createTestOAuthClient({
+      client_name: 'Lobu CLI',
+      software_id: 'lobu-cli',
+    });
+    commandClientId = commandClient.client_id;
     token = (
       await createTestAccessToken(owner.id, org.id, oauthClient.client_id, {
         scope: 'mcp:read mcp:write mcp:admin',
@@ -119,6 +125,10 @@ describe('client sessions activity route', () => {
       WHERE organization_id = ${orgId} AND conversation_id = 'sess-alpha'
     `;
     await recordCall('sess-beta', 'search_sdk');
+
+    // Command clients create transport sessions for individual invocations;
+    // they belong in client activity, not the conversation-only Recent list.
+    await recordCall('sess-command', 'run_sdk', { clientId: commandClientId });
 
     // Cross-org session: must never appear for orgSlug.
     await recordCall('sess-foreign', 'search_memory', {
@@ -208,6 +218,7 @@ describe('client sessions activity route', () => {
 
     const ids = body.sessions.map((s) => s.sessionId);
     expect(ids).toEqual([
+      'sess-command',
       'sess-beta',
       'sess-alpha',
       'sess-tool-cap',
@@ -257,6 +268,16 @@ describe('client sessions activity route', () => {
 
   it('honors the bounded result limit', async () => {
     const res = await get(`/api/${orgSlug}/clients/sessions?limit=1`, { token });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sessions: Array<{ sessionId: string }> };
+    expect(body.sessions.map((session) => session.sessionId)).toEqual(['sess-command']);
+  });
+
+  it('can exclude command-client sessions before applying the result limit', async () => {
+    const res = await get(
+      `/api/${orgSlug}/clients/sessions?conversation_only=true&limit=1`,
+      { token }
+    );
     expect(res.status).toBe(200);
     const body = (await res.json()) as { sessions: Array<{ sessionId: string }> };
     expect(body.sessions.map((session) => session.sessionId)).toEqual(['sess-beta']);

--- a/packages/server/src/lobu/client-session-routes.ts
+++ b/packages/server/src/lobu/client-session-routes.ts
@@ -12,6 +12,7 @@ import type { Env } from "../index";
  */
 const routes = new Hono<{ Bindings: Env }>();
 const ACTIVITY_WINDOW_DAYS = 14;
+const LOBU_COMMAND_CLIENT_SOFTWARE_ID = "lobu-cli";
 
 interface SessionRow {
 	conversation_id: string;
@@ -56,6 +57,7 @@ routes.get("/", mcpAuth, async (c) => {
 		Math.max(Number.isNaN(rawLimit) ? 20 : rawLimit, 1),
 		100,
 	);
+	const conversationOnly = c.req.query("conversation_only") === "true";
 	const sql = getDb();
 	const rows = await sql<SessionRow>`
     -- The one aggregate left on this path. It groups the org's LIVE
@@ -94,6 +96,10 @@ routes.get("/", mcpAuth, async (c) => {
       -- its default now() timestamps with a placeholder action.
       AND mc.call_count > 0
       AND mc.last_activity_at > now() - make_interval(days => ${ACTIVITY_WINDOW_DAYS})
+      AND (
+        NOT ${conversationOnly}
+        OR oc.software_id IS DISTINCT FROM ${LOBU_COMMAND_CLIENT_SOFTWARE_ID}
+      )
     ORDER BY mc.last_activity_at DESC LIMIT ${limit}
   `;
 	return c.json({


### PR DESCRIPTION
## Summary

- add a conversation-only mode to the materialized MCP session endpoint
- exclude stable `software_id = lobu-cli` command transports before ordering and limiting Recent
- pin merged Owletto #697, which requests that mode and fixes duplicate-looking active rows

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted server Vitest plus complete Owletto suite
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red

Before the server filter, the new regression test returned the command transport even in conversation-only mode:

```text
expected [ sess-command ] to deeply equal [ sess-beta ]
1 failed
```

Before the UI fix, the focused sidebar suite showed the duplicate-looking state:

```text
FAIL expected ChatGPT conversation, received Untitled conversation
FAIL expected client-filtered MCP row not to have bg-sidebar-accent
2 failed
```

### Green

```text
client-sessions-route.test.ts (5 tests)
Test Files  1 passed (1)
Tests       5 passed (5)
```

```text
Owletto Test Files  129 passed (129)
Owletto Tests       1154 passed (1154)
```

`make pre-pr` completed clean.

## Notes

- Owletto PR: https://github.com/lobu-ai/owletto/pull/697
- The default Activity endpoint deliberately still includes Lobu CLI calls. Only the sidebar request sets `conversation_only=true`; this fixes Recent without deleting command audit activity.
- `make review-fix` was attempted on the settled diff but the configured Claude reviewer reported its weekly quota exhausted and made no changes.
