### PR TITLE
fix(server): preserve command-session classification

### DIFF
--- a/db/migrations/20260803140000_mcp_conversation_client_software_id.sql
+++ b/db/migrations/20260803140000_mcp_conversation_client_software_id.sql
@@ -1,0 +1,37 @@
+-- migrate:up
+ALTER TABLE public.mcp_client_conversations
+  ADD COLUMN IF NOT EXISTS client_software_id text;
+
+UPDATE public.mcp_client_conversations mc
+SET client_software_id = oc.software_id
+FROM public.oauth_clients oc
+WHERE mc.client_id = oc.id
+  AND mc.client_software_id IS NULL;
+
+-- Stamp at the database boundary so writes from older replicas in a rolling
+-- deploy are classified before a later client deletion clears `client_id`.
+CREATE OR REPLACE FUNCTION public.stamp_mcp_conversation_client_software_id()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.client_software_id IS NULL AND NEW.client_id IS NOT NULL THEN
+    SELECT software_id INTO NEW.client_software_id
+    FROM public.oauth_clients
+    WHERE id = NEW.client_id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS stamp_mcp_conversation_client_software_id
+  ON public.mcp_client_conversations;
+CREATE TRIGGER stamp_mcp_conversation_client_software_id
+  BEFORE INSERT OR UPDATE OF client_id
+  ON public.mcp_client_conversations
+  FOR EACH ROW EXECUTE FUNCTION public.stamp_mcp_conversation_client_software_id();
+
+-- migrate:down
+DROP TRIGGER IF EXISTS stamp_mcp_conversation_client_software_id
+  ON public.mcp_client_conversations;
+DROP FUNCTION IF EXISTS public.stamp_mcp_conversation_client_software_id();
+ALTER TABLE public.mcp_client_conversations
+  DROP COLUMN IF EXISTS client_software_id;

--- a/packages/server/src/__tests__/integration/mcp/client-sessions-route.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/client-sessions-route.test.ts
@@ -129,6 +129,9 @@ describe('client sessions activity route', () => {
     // Command clients create transport sessions for individual invocations;
     // they belong in client activity, not the conversation-only Recent list.
     await recordCall('sess-command', 'run_sdk', { clientId: commandClientId });
+    // Revocation removes the display client row. The write-time software-id
+    // stamp must continue to classify the retained activity afterward.
+    await getDb()`DELETE FROM oauth_clients WHERE id = ${commandClientId}`;
 
     // Cross-org session: must never appear for orgSlug.
     await recordCall('sess-foreign', 'search_memory', {
@@ -251,6 +254,10 @@ describe('client sessions activity route', () => {
     const beta = body.sessions.find((s) => s.sessionId === 'sess-beta')!;
     expect(beta.callCount).toBe(1);
     expect(beta.pendingInteractionCount).toBe(0);
+
+    const command = body.sessions.find((s) => s.sessionId === 'sess-command')!;
+    expect(command.clientId).toBeNull();
+    expect(command.clientName).toBeNull();
 
     const capped = body.sessions.find((s) => s.sessionId === 'sess-tool-cap')!;
     expect(capped.tools).toHaveLength(8);

--- a/packages/server/src/lobu/client-session-routes.ts
+++ b/packages/server/src/lobu/client-session-routes.ts
@@ -98,7 +98,7 @@ routes.get("/", mcpAuth, async (c) => {
       AND mc.last_activity_at > now() - make_interval(days => ${ACTIVITY_WINDOW_DAYS})
       AND (
         NOT ${conversationOnly}
-        OR oc.software_id IS DISTINCT FROM ${LOBU_COMMAND_CLIENT_SOFTWARE_ID}
+        OR mc.client_software_id IS DISTINCT FROM ${LOBU_COMMAND_CLIENT_SOFTWARE_ID}
       )
     ORDER BY mc.last_activity_at DESC LIMIT ${limit}
   `;


### PR DESCRIPTION
## Summary

- persist OAuth client software identity on materialized MCP conversation rows
- filter Recent with that durable projection after an OAuth client is revoked
- stamp writes at the database boundary so rolling old replicas remain safe

## Test plan

- [x] make pre-pr clean on the exact settled tree before PR #2457 merged
- [x] focused server integration suite: 5 passed
- [x] migration lint: 0 issues
- [x] review-fix reproduced and fixed the bug

### Red

Using the original join predicate after ON DELETE SET NULL returned the revoked CLI session:

```text
[{"conversation_id":"sess-command"}]
```

### Green

With the projected software identity, retained CLI activity is excluded after client deletion:

```text
client-sessions-route.test.ts (5 tests)
Test Files  1 passed (1)
Tests       5 passed (5)
```

## Notes

This is the follow-up from the review-fix race on #2457: that PR merged while the fixer was still running, so this isolates the verified durable correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation classification for command-only sessions, including activity retained after the associated OAuth client is removed.
  * Session listings now correctly show unavailable client details as blank when the client record no longer exists.
* **Data Updates**
  * Conversation records now retain the originating client software identifier for more reliable filtering and classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->