### PR TITLE
fix(ci): fail closed on private Helm chart

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -65,10 +65,16 @@ jobs:
           chart_package="$(ls /tmp/lobu-*.tgz | head -1)"
           helm push "$chart_package" oci://ghcr.io/${{ github.repository_owner }}/charts
 
-      - name: Make chart package public
+      - name: Verify chart package is public
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
         run: |
-          gh api -X PATCH "/orgs/${OWNER}/packages/container/charts%2Flobu/visibility" \
-            -f visibility=public || true
+          visibility="$(
+            gh api "/orgs/${OWNER}/packages/container/charts%2Flobu" \
+              --jq '.visibility'
+          )"
+          if [ "$visibility" != "public" ]; then
+            echo "::error::ghcr.io/${OWNER}/charts/lobu is ${visibility}, not public. GitHub package visibility can only be changed from the package settings UI."
+            exit 1
+          fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -49,6 +49,8 @@ BREAKING CHANGE: RuntimeProviderCredentialResolver now returns
 
 `publish-packages.mjs` is idempotent (skips already-published packages), so re-running is safe.
 
+**Helm publish says the chart package is private** — GitHub does not expose a package-visibility update API. A package administrator must open the `charts/lobu` package settings once and change its visibility to **Public**. Organization owners have admin permission to organization packages. Re-run the failed Helm workflow afterward. The workflow verifies the live package visibility and fails closed; it never treats a private chart as a successful public release.
+
 **Bad build reached npm** — prefer deprecation over unpublish:
 ```bash
 npm deprecate '@lobu/core@<bad-version>' "broken build, use <good-version>"

--- a/scripts/__tests__/release-publish-order.test.ts
+++ b/scripts/__tests__/release-publish-order.test.ts
@@ -113,4 +113,17 @@ describe("release package publication ordering", () => {
     expect(runBodies).not.toContain("${{ inputs.bump }}");
     expect(publish).toContain('run_id="$IMAGE_RUN_ID"');
   });
+
+  it("fails closed when the published Helm chart is not public", () => {
+    const publish = jobBlock(workflow("helm-chart.yml"), "publish");
+
+    expect(publish).not.toContain("/visibility");
+    expect(publish).not.toContain("|| true");
+    expect(publish).toContain(
+      'gh api "/orgs/${OWNER}/packages/container/charts%2Flobu"'
+    );
+    expect(publish).toContain("--jq '.visibility'");
+    expect(publish).toContain('if [ "$visibility" != "public" ]');
+    expect(publish).toContain("exit 1");
+  });
 });


### PR DESCRIPTION
## Summary

- Replace the nonexistent GitHub Packages visibility PATCH with a live visibility read after Helm push.
- Fail the release job when `charts/lobu` is not public instead of swallowing the API failure.
- Document GitHub’s one-time package-admin recovery step and pin the behavior with a workflow regression test.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test scripts/__tests__/release-publish-order.test.ts`; `helm lint charts/lobu`; `helm template lobu charts/lobu --namespace lobu`
- [x] Bug fix: red→fix→green outputs pasted below
- [x] If bot behavior: not applicable

### Red

Live 14.11 Helm publication reported success, but the package metadata remained `visibility: private`, anonymous `helm show chart` returned HTTP 401, and the workflow log showed:

```text
gh: Not Found (HTTP 404)
... PATCH /orgs/lobu-ai/packages/container/charts%2Flobu/visibility
... || true
```

The regression test against that workflow failed as expected:

```text
7 pass
1 fail
Expected to not contain: "/visibility"
Received: ... /visibility ... || true
```

### Green

```text
8 pass
0 fail
26 expect() calls

1 chart(s) linted, 0 chart(s) failed
check-exposed-surface-naming: clean — no agent-facing watcher on exposed surface.
pre-pr gates clean.
```

Mutation proof: removing the live `--jq .visibility` extraction makes the focused suite fail 1/8; restoring it returns 8/8.

## Notes

GitHub exposes package visibility changes only in package settings. A package administrator must make `charts/lobu` public once; after that this gate prevents future private-chart false greens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Helm chart publishing now verifies that the chart package is public after publishing.
  - Releases fail safely when the package remains private instead of continuing silently.

- **Documentation**
  - Added recovery steps for making a private chart public and rerunning a failed release.

- **Tests**
  - Added coverage confirming visibility checks use the expected endpoint and correctly reject non-public packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->