### PR TITLE
fix(server): preserve backslashes in score filters

### DIFF
--- a/packages/server/src/__tests__/integration/events/get-content-score-path-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-score-path-attribution.test.ts
@@ -43,6 +43,8 @@ const AGENT_A = 'agent_score_path_a';
 const AGENT_B = 'agent_score_path_b';
 const BEHAVIOR_A = 910_001;
 const BEHAVIOR_B = 910_002;
+const QUOTED_SEMANTIC_TYPE = 'score"quoted';
+const BACKSLASH_SEMANTIC_TYPE = 'score\\backslash';
 
 async function registerClient(opts: {
   id: string;
@@ -68,6 +70,7 @@ async function insertAttributedEvent(opts: {
   title: string;
   clientId: string | null;
   agentId: string | null;
+  semanticType?: string;
   score: number;
   occurredAt: Date;
 }): Promise<number> {
@@ -85,7 +88,7 @@ async function insertAttributedEvent(opts: {
       ${opts.title},
       'text',
       ${opts.title},
-      'content',
+      ${opts.semanticType ?? 'content'},
       'test.connector',
       ${opts.clientId},
       ${sql.json(opts.agentId ? { agent_id: opts.agentId } : {})},
@@ -171,6 +174,28 @@ describe('getContent > score path honours forwarded filters', () => {
       score: 50,
       occurredAt: new Date(t0.getTime() + 2000),
     });
+    await insertAttributedEvent({
+      organizationId: org.id,
+      entityId,
+      connectionId: connection.id,
+      title: 'quoted semantic type',
+      clientId: null,
+      agentId: null,
+      semanticType: QUOTED_SEMANTIC_TYPE,
+      score: 40,
+      occurredAt: new Date(t0.getTime() + 3000),
+    });
+    await insertAttributedEvent({
+      organizationId: org.id,
+      entityId,
+      connectionId: connection.id,
+      title: 'backslash semantic type',
+      clientId: null,
+      agentId: null,
+      semanticType: BACKSLASH_SEMANTIC_TYPE,
+      score: 30,
+      occurredAt: new Date(t0.getTime() + 4000),
+    });
 
     const sql = getTestDb();
     await sql`
@@ -199,10 +224,30 @@ describe('getContent > score path honours forwarded filters', () => {
       ctx
     );
     expect(result.content.map((c) => c.title).sort()).toEqual([
+      'backslash semantic type',
       'chatgpt high score row',
       'cli low score row',
+      'quoted semantic type',
       'unattributed row',
     ]);
+  });
+
+  it('semantic_type preserves quotes and backslashes in PostgreSQL arrays', async () => {
+    const result = await getContent(
+      {
+        entity_id: entityId,
+        sort_by: 'score',
+        semantic_type: [QUOTED_SEMANTIC_TYPE, BACKSLASH_SEMANTIC_TYPE],
+        limit: 100,
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(result.content.map((c) => c.title).sort()).toEqual([
+      'backslash semantic type',
+      'quoted semantic type',
+    ]);
+    expect(result.total).toBe(2);
   });
 
   it('client_ids scopes score-sorted rows to that client', async () => {

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -220,7 +220,7 @@ async function buildFilterConditionsAndJoins(
     const types = Array.isArray(filters.semantic_type)
       ? filters.semantic_type
       : [filters.semantic_type];
-    params.push(`{${types.map((t) => `"${t.replace(/"/g, '\\"')}"`).join(',')}}`);
+    params.push(pgTextArray(types));
     filterConditions.push(`f.semantic_type = ANY($${paramIndex++}::text[])`);
   }
 


### PR DESCRIPTION
## Summary

- replace the score-path semantic-type array's bespoke PostgreSQL serializer with the shared `pgTextArray()` helper
- preserve backslashes as well as quotes in filtered `semantic_type` values
- add DB-backed coverage for both result and count paths

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted server integration and DB-helper unit suites
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red

```text
FAIL getContent > score path honours forwarded filters
  × semantic_type preserves quotes and backslashes in PostgreSQL arrays
Expected:
  ["backslash semantic type", "quoted semantic type"]
Received:
  ["quoted semantic type"]
Test Files  1 failed (1)
Tests       1 failed | 6 passed (7)
```

### Green

```text
✓ get-content-score-path-attribution.test.ts (7 tests)
Test Files  1 passed (1)
Tests       7 passed (7)

✓ client.test.ts (5 tests)
Test Files  1 passed (1)
Tests       5 passed (5)

make pre-pr: all 6 gates clean
```

## Notes

- Fixes CodeQL alert #239 (`js/incomplete-sanitization`) on current `main`.
- The retired internal-rename PR #2452 remains closed; this is an isolated security fix with no schema or vocabulary cutover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed content score filtering for semantic types containing quotes or backslashes.
  * Ensured score-path results preserve these values and report accurate totals.
* **Tests**
  * Added regression coverage for special-character semantic types and updated expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->