### PR TITLE
fix(server): exclude agent worker sessions from Recent

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/client-sessions-route.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/client-sessions-route.test.ts
@@ -133,6 +133,21 @@ describe('client sessions activity route', () => {
     // stamp must continue to classify the retained activity afterward.
     await getDb()`DELETE FROM oauth_clients WHERE id = ${commandClientId}`;
 
+    // Agent workers use the internal `lobu-worker` PAT identity. Each worker
+    // MCP transport is an implementation detail of an agent turn, not a host
+    // conversation that belongs in Recent.
+    await recordCall('sess-worker', 'query_sdk', {
+      clientId: 'lobu-worker',
+      tokenType: 'pat',
+      agentId: 'personal-agent',
+    } as Partial<ToolContext>);
+    await db`
+      UPDATE mcp_client_conversations
+      SET first_activity_at = now() - interval '30 minutes',
+        last_activity_at = now() - interval '30 minutes'
+      WHERE organization_id = ${orgId} AND conversation_id = 'sess-worker'
+    `;
+
     // Cross-org session: must never appear for orgSlug.
     await recordCall('sess-foreign', 'search_memory', {
       organizationId: otherOrgId,
@@ -223,6 +238,7 @@ describe('client sessions activity route', () => {
     expect(ids).toEqual([
       'sess-command',
       'sess-beta',
+      'sess-worker',
       'sess-alpha',
       'sess-tool-cap',
       'sess-pat',
@@ -259,6 +275,11 @@ describe('client sessions activity route', () => {
     expect(command.clientId).toBeNull();
     expect(command.clientName).toBeNull();
 
+    const worker = body.sessions.find((s) => s.sessionId === 'sess-worker')!;
+    expect(worker.clientId).toBeNull();
+    expect(worker.clientName).toBeNull();
+    expect(worker.agentId).toBe('personal-agent');
+
     const capped = body.sessions.find((s) => s.sessionId === 'sess-tool-cap')!;
     expect(capped.tools).toHaveLength(8);
 
@@ -280,14 +301,17 @@ describe('client sessions activity route', () => {
     expect(body.sessions.map((session) => session.sessionId)).toEqual(['sess-command']);
   });
 
-  it('can exclude command-client sessions before applying the result limit', async () => {
+  it('can exclude command-client and internal worker sessions from conversations', async () => {
     const res = await get(
-      `/api/${orgSlug}/clients/sessions?conversation_only=true&limit=1`,
+      `/api/${orgSlug}/clients/sessions?conversation_only=true&limit=100`,
       { token }
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as { sessions: Array<{ sessionId: string }> };
-    expect(body.sessions.map((session) => session.sessionId)).toEqual(['sess-beta']);
+    const ids = body.sessions.map((session) => session.sessionId);
+    expect(ids).toContain('sess-beta');
+    expect(ids).not.toContain('sess-command');
+    expect(ids).not.toContain('sess-worker');
   });
 
   it('hides a title-only row and retains its title after the first tool call', async () => {

--- a/packages/server/src/lobu/client-session-routes.ts
+++ b/packages/server/src/lobu/client-session-routes.ts
@@ -13,6 +13,7 @@ import type { Env } from "../index";
 const routes = new Hono<{ Bindings: Env }>();
 const ACTIVITY_WINDOW_DAYS = 14;
 const LOBU_COMMAND_CLIENT_SOFTWARE_ID = "lobu-cli";
+const LOBU_WORKER_CLIENT_IDENTITY = "lobu-worker";
 
 interface SessionRow {
 	conversation_id: string;
@@ -98,7 +99,10 @@ routes.get("/", mcpAuth, async (c) => {
       AND mc.last_activity_at > now() - make_interval(days => ${ACTIVITY_WINDOW_DAYS})
       AND (
         NOT ${conversationOnly}
-        OR mc.client_software_id IS DISTINCT FROM ${LOBU_COMMAND_CLIENT_SOFTWARE_ID}
+        OR (
+          mc.client_software_id IS DISTINCT FROM ${LOBU_COMMAND_CLIENT_SOFTWARE_ID}
+          AND mc.client_identity IS DISTINCT FROM ${LOBU_WORKER_CLIENT_IDENTITY}
+        )
       )
     ORDER BY mc.last_activity_at DESC LIMIT ${limit}
   `;


### PR DESCRIPTION
## Summary

- exclude internal `lobu-worker` MCP transports from the conversation-only Recent endpoint
- retain those rows in the unfiltered client Activity API
- cover the live production row shape without hiding legitimate agent-bound OAuth/PAT clients

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Targeted integration: `cd packages/server && bunx vitest run src/__tests__/integration/mcp/client-sessions-route.test.ts` — 5 passed
- [x] `make test-unit` — 823 passed, 12 skipped, 1 unrelated order-dependent `exec-sandbox` failure; the exact failing file passes 40/40 in isolation
- [x] Bug fix: red→fix→green outputs below

### Red

```text
FAIL client sessions activity route > can exclude command-client and internal worker sessions from conversations
AssertionError: expected [ sess-beta, sess-worker, … ] to not include sess-worker
Test Files 1 failed (1)
Tests 1 failed | 4 passed (5)
```

### Green

```text
✓ src/__tests__/integration/mcp/client-sessions-route.test.ts (5 tests)
Test Files 1 passed (1)
Tests 5 passed (5)
```

## Notes

Live production evidence before the fix: Buremba had 11 recent rows with `client_identity=lobu-worker`, `client_id=NULL`, and `agent_id=personal-agent`, plus one for `lobu-builder`; `conversation_only=true` returned them as generic MCP conversations.

`make review-fix` was attempted after the settled diff but Claude reported the weekly quota exhausted until Aug 5 and made no changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation-only session views now exclude internal worker sessions alongside command-line sessions.
  * General session listings correctly include internal worker sessions with their associated agent information and no client identity.
  * Updated integration coverage verifies session filtering and listing behavior across supported session types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->