### PR TITLE
fix(server): accept legacy chat webhook routes

### DIFF
--- a/packages/server/src/__tests__/webhook-signatures.test.ts
+++ b/packages/server/src/__tests__/webhook-signatures.test.ts
@@ -11,8 +11,8 @@
  *     performs the edge `v0` signing + freshness verify (replay defense) and,
  *     only on success, delegates everything to
  *     `ChatInstanceManager.handleChatAppWebhook`, which fans out to the
- *     adapter described above. The bespoke `/slack/events` route was folded
- *     into this generic endpoint.
+ *     adapter described above. The historical `/slack/events` URL remains an
+ *     alias for already-installed apps and enters this same verified path.
  */
 
 import { createHmac } from "node:crypto";
@@ -144,6 +144,7 @@ describe("slack app-webhook provider route", () => {
           handleDelivery: createChatWebhookDelivery({ handleChatAppWebhook }),
         }),
       ],
+      legacyProviderRoutes: [{ path: "/slack/events", provider: "slack" }],
       resolveAppWebhookSecret: async () => SIGNING_SECRET,
     });
   }
@@ -205,6 +206,21 @@ describe("slack app-webhook provider route", () => {
     const body = JSON.stringify({ type: "event_callback" });
 
     const res = await router.fetch(delivery(body, nowTs()));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("forwarded");
+  });
+
+  it("keeps the pre-consolidation Slack webhook URL working", async () => {
+    const handler = vi.fn(async () => new Response("forwarded", { status: 200 }));
+    const router = makeRouter(handler);
+    const body = JSON.stringify({ command: "/lobu", text: "help" });
+    const timestamp = nowTs();
+    const request = delivery(body, timestamp);
+    const legacyRequest = new Request("http://gateway.test/slack/events", request);
+
+    const res = await router.fetch(legacyRequest);
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(res.status).toBe(200);

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -630,6 +630,7 @@ export function createGatewayApp(
     // set); otherwise the route reports the provider unknown (404).
     const appWebhookSecretStore = coreServices.getSecretStore();
     const appWebhookProviders: AppWebhookProvider[] = [];
+    const legacyChatWebhookRoutes: Array<{ path: string; provider: string }> = [];
     const declaredSecretEnvKeys: Record<string, string | undefined> = {};
     for (const integration of bundledIntegrationConnectors ?? []) {
       // Reference resolveAppInstallCredentials so the declared env-var contract
@@ -653,6 +654,13 @@ export function createGatewayApp(
       > = {};
       if (deliveryKind === "chat") {
         const provider = integration.provider;
+        // Chat integrations predating the shared app-webhook router were
+        // installed with `/<provider>/events`. Keep those installations live;
+        // the alias enters the same declared signature verifier below.
+        legacyChatWebhookRoutes.push({
+          path: `/${provider}/events`,
+          provider,
+        });
         deliveryHooks.handleDelivery = createChatWebhookDelivery({
           handleChatAppWebhook: (req) =>
             chatInstanceManager.handleChatAppWebhook(provider, req),
@@ -678,6 +686,7 @@ export function createGatewayApp(
         installationStore: createPostgresAppInstallationStore(),
         secretStore: appWebhookSecretStore,
         providers: appWebhookProviders,
+        legacyProviderRoutes: legacyChatWebhookRoutes,
         resolveAppWebhookSecret: createDefaultAppWebhookSecretResolver(
           appWebhookSecretStore,
           declaredSecretEnvKeys,

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -36,7 +36,7 @@
  */
 
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { createLogger } from "@lobu/core";
 import type { StoredConnection } from "@lobu/core";
 import type { ConnectorWebhookSchema } from "@lobu/connector-sdk";
@@ -981,6 +981,12 @@ export interface AppWebhookRouterDeps {
 	/** Provider plugins keyed by `provider` (the `:provider` path param). */
 	providers: AppWebhookProvider[];
 	/**
+	 * Historical provider URLs that already-installed apps may still call.
+	 * Every alias enters the exact same verification and delivery path as the
+	 * canonical `/api/v1/app-webhooks/:provider` endpoint.
+	 */
+	legacyProviderRoutes?: ReadonlyArray<{ path: string; provider: string }>;
+	/**
 	 * Resolve the APP-LEVEL webhook secret for a provider. Returns undefined
 	 * when no secret is configured — the router then fails closed (401), never
 	 * accepting an unverifiable delivery.
@@ -1029,8 +1035,7 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 	const providers = new Map(deps.providers.map((p) => [p.provider, p]));
 	const routeLogger = deps.logger ?? logger;
 
-	router.post("/api/v1/app-webhooks/:provider", async (c) => {
-		const providerName = c.req.param("provider");
+	const handleProviderWebhook = async (c: Context, providerName: string) => {
 		const provider = providers.get(providerName);
 		if (!provider) {
 			// Unknown provider: no plugin to verify with. 404, not 500.
@@ -1224,7 +1229,16 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 			);
 			return json(500, { error: "Failed to land delivery" });
 		}
-	});
+	};
+
+	router.post("/api/v1/app-webhooks/:provider", (c) =>
+		handleProviderWebhook(c, c.req.param("provider")),
+	);
+	for (const legacyRoute of deps.legacyProviderRoutes ?? []) {
+		router.post(legacyRoute.path, (c) =>
+			handleProviderWebhook(c, legacyRoute.provider),
+		);
+	}
 
 	return router;
 }


### PR DESCRIPTION
## Summary
- preserve historical /<provider>/events URLs for already-installed chat apps
- route aliases through the same declared signature verification and delivery pipeline
- generate aliases for every declared chat integration rather than special-casing Slack

## Test plan
- [x] make pre-pr clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: focused webhook-signatures and slack-routes suites
- [x] Bug fix: red→fix→green outputs pasted below
- [x] Live red reproduced from LobuSandbox: signed POST /lobu/slack/events returned 404 and Slack reported that /lobu did not respond

Red:
webhook-signatures.test.ts: 8 passed, 1 failed; legacy /slack/events invoked the delivery handler 0 times.

Green:
webhook-signatures.test.ts: 9 passed, 0 failed.
slack-routes.test.ts isolated rerun: 16 passed, 0 failed.
make pre-pr: clean.

## Notes
Live green will be verified in #lobu-buremba-test after rollout, including a fresh Buremba link and the resulting Recent row on /buremba/activity.