### PR TITLE
fix(server): close MCP discovery contract gaps

### DIFF
--- a/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
@@ -341,7 +341,9 @@ describe('entity schema CRUD', () => {
 					name: 'Wrong Schema Shape',
 					properties: { title: { type: 'string' } },
 				} as never)
-			).rejects.toThrow(/properties.*metadata_schema/i);
+			).rejects.toThrow(
+				/unknown argument\(s\): properties.*search_sdk 'entitySchema\.createType'/i,
+			);
 		});
   });
 

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -1234,6 +1234,7 @@ describe('MCP Authentication', () => {
         expect(tool.description).toBeDefined();
         expect(typeof tool.description).toBe('string');
       }
+      expect(JSON.stringify(result.tools)).not.toMatch(/watcher/i);
     });
   });
 

--- a/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
@@ -387,7 +387,9 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 			{ action: "create", entity_type: "product", name: "Ephemeral Product" },
 			TEST_ENV,
 			authCtx
-		)) as { entity?: { id: number } };
+		)) as { entity?: { id: number }; next_steps?: string[] };
+		expect(created.next_steps?.join("\n")).not.toMatch(/manage_[a-z_]+/);
+		expect(created.next_steps?.join("\n")).toContain("client.connections.connect");
 		const maybeId = created.entity?.id;
 		expect(maybeId).toBeDefined();
 		const id = maybeId as number;

--- a/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
@@ -390,9 +390,11 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 		)) as { entity?: { id: number }; next_steps?: string[] };
 		expect(created.next_steps?.join("\n")).not.toMatch(/manage_[a-z_]+/);
 		expect(created.next_steps?.join("\n")).toContain("client.connections.connect");
+		expect(created.next_steps?.join("\n")).toContain("client.feeds.trigger");
 		const maybeId = created.entity?.id;
 		expect(maybeId).toBeDefined();
 		const id = maybeId as number;
+		expect(created.next_steps?.join("\n")).toContain(`entity_ids: [${id}]`);
 
 		await executeTool(
 			"manage_entity",

--- a/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
@@ -391,6 +391,8 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 		expect(created.next_steps?.join("\n")).not.toMatch(/manage_[a-z_]+/);
 		expect(created.next_steps?.join("\n")).toContain("client.connections.connect");
 		expect(created.next_steps?.join("\n")).toContain("client.feeds.trigger");
+		expect(created.next_steps?.join("\n")).toContain("kind: 'schedule'");
+		expect(created.next_steps?.join("\n")).toContain("timezone: '<IANA timezone>'");
 		const maybeId = created.entity?.id;
 		expect(maybeId).toBeDefined();
 		const id = maybeId as number;

--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -89,20 +89,20 @@ describe('buildWorkspaceInstructions render fixes', () => {
       )
     `;
 
-    // Legacy engine vocabulary can still exist in stored, user-authored schemas.
-    // It must not leak through the public MCP tool descriptions: the agent-facing
-    // product name is Behavior, and raw internal field names are not actionable.
+    // Tenant-authored descriptions and similarly named fields are user data, while
+    // exact reserved engine fields are internal implementation details.
     await sql`
       INSERT INTO entity_types (slug, name, description, metadata_schema, organization_id)
       VALUES (
         'legacy-automation',
         'Legacy Automation',
-        'Created by a watcher',
+        'A club for bird watchers',
         ${sql.json({
           type: 'object',
           properties: {
             window_id: { type: 'number', description: 'Watcher window that produced it' },
             watcher_id: { type: 'number', description: 'Watcher that wrote it' },
+            watcher_count: { type: 'number', description: 'Number of bird watchers' },
           },
         })},
         ${org.id}
@@ -163,9 +163,10 @@ describe('buildWorkspaceInstructions render fixes', () => {
     expect(out).toContain('- legacy ("Legacy") — fields: sku, price (Unit price in EUR)');
   });
 
-  it('uses Behavior terminology and hides internal watcher fields in MCP instructions', async () => {
+  it('preserves tenant watcher language while hiding exact internal engine fields', async () => {
     const out = await buildWorkspaceInstructions(org.id);
-    expect(out).not.toMatch(/watchers?/i);
+    expect(out).toContain('A club for bird watchers');
+    expect(out).toContain('watcher_count (Number of bird watchers)');
     expect(out).not.toContain('watcher_id');
     expect(out).toContain('window_id (Behavior window that produced it)');
   });

--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -89,6 +89,26 @@ describe('buildWorkspaceInstructions render fixes', () => {
       )
     `;
 
+    // Legacy engine vocabulary can still exist in stored, user-authored schemas.
+    // It must not leak through the public MCP tool descriptions: the agent-facing
+    // product name is Behavior, and raw internal field names are not actionable.
+    await sql`
+      INSERT INTO entity_types (slug, name, description, metadata_schema, organization_id)
+      VALUES (
+        'legacy-automation',
+        'Legacy Automation',
+        'Created by a watcher',
+        ${sql.json({
+          type: 'object',
+          properties: {
+            window_id: { type: 'number', description: 'Watcher window that produced it' },
+            watcher_id: { type: 'number', description: 'Watcher that wrote it' },
+          },
+        })},
+        ${org.id}
+      )
+    `;
+
     // Relationship type with a description.
     await sql`
       INSERT INTO entity_relationship_types (slug, name, description, organization_id)
@@ -141,6 +161,13 @@ describe('buildWorkspaceInstructions render fixes', () => {
     const out = await buildWorkspaceInstructions(org.id);
     // jsonb canonicalizes key order (shorter keys first): sku before price.
     expect(out).toContain('- legacy ("Legacy") — fields: sku, price (Unit price in EUR)');
+  });
+
+  it('uses Behavior terminology and hides internal watcher fields in MCP instructions', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).not.toMatch(/watchers?/i);
+    expect(out).not.toContain('watcher_id');
+    expect(out).toContain('window_id (Behavior window that produced it)');
   });
 
   it('renders relationship type descriptions', async () => {

--- a/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
@@ -171,7 +171,7 @@ describe("createActionCaller", () => {
 		// recover against `client.feeds.get`.
 		const handler = async () => {
 			throw new ToolUserError(
-				"Invalid arguments for manage_feeds: /feed_id: Expected required property",
+				"Invalid arguments for manage_feeds: unknown argument(s): limit — valid arguments for action 'read_feed' are: action, feed_id, connection_id",
 			);
 		};
 		const { action } = createActionCaller(
@@ -186,7 +186,10 @@ describe("createActionCaller", () => {
 		expect(thrown).toBeInstanceOf(ToolUserError);
 		expect(thrown.message).not.toMatch(/manage_feeds/);
 		expect(thrown.message).toMatch(/client\.feeds\.get/);
-		expect(thrown.message).toMatch(/feed_id/);
+		expect(thrown.message).toMatch(/unknown argument\(s\): limit/);
+		expect(thrown.message).not.toMatch(/\baction\b/);
+		expect(thrown.message).not.toMatch(/connection_id/);
+		expect(thrown.message).toContain("search_sdk 'feeds.get'");
 	});
 
 	it("derives a CAMEL-CASE public method from a snake_case action when none is supplied", async () => {

--- a/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
@@ -224,6 +224,24 @@ describe("createActionCaller", () => {
 		expect(thrown.message).toBe("Invalid arguments for manage_feeds: boom");
 	});
 
+	it("leaves non-validator errors from namespaced callers untouched", async () => {
+		const message =
+			"Connector rejected the request — valid arguments are: retry_after";
+		const handler = async () => {
+			throw new ToolUserError(message);
+		};
+		const { action } = createActionCaller(
+			handler as never,
+			{} as never,
+			{} as never,
+			"feeds",
+		);
+		const thrown = (await action("trigger_feed", {}).catch(
+			(e: unknown) => e,
+		)) as ToolUserError;
+		expect(thrown.message).toBe(message);
+	});
+
 	it("returns a queued approval even when its mutation success is false", async () => {
 		const queued = {
 			success: false,

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { ToolContext } from "../../../tools/registry";
-import { sdkSearch } from "../../../tools/sdk_search";
+import {
+	isSdkOnlyDiscoveryQuery,
+	sdkSearch,
+} from "../../../tools/sdk_search";
 
 const stubEnv = {} as never;
 
@@ -27,6 +30,20 @@ const adminCtx: ToolContext = {
 };
 
 describe("sdkSearch", () => {
+	it.each(["agents", "entitySchema", "AUTHprofiles", "client.feeds", "feeds.create"])(
+		"treats exact SDK query %s as method-only discovery",
+		(query) => {
+			expect(isSdkOnlyDiscoveryQuery(query)).toBe(true);
+		},
+	);
+
+	it.each(["google.calendar", "website", "connections sync run"])(
+		"still allows connector discovery for %s",
+		(query) => {
+			expect(isSdkOnlyDiscoveryQuery(query)).toBe(false);
+		},
+	);
+
 	it("returns drill-down for an exact path", async () => {
 		const result = await sdkSearch(
 			{ query: "behaviors.list" },

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -319,6 +319,31 @@ describe("sdkSearch", () => {
 	});
 
 	it.each([
+		["feeds.get", ["limit?: number", "search_term?: string"]],
+		["feeds.readMany", ["timeout_ms?: number", "search_term?: string"]],
+		[
+			"feeds.create",
+			[
+				"entity_ids?: number[]",
+				"timezone?: string",
+				"virtual?: boolean",
+				"manual-only",
+				"feeds.trigger",
+			],
+		],
+		[
+			"feeds.update",
+			["replace_config?: boolean", "schedule?: string | null", "timezone?: string | null"],
+		],
+	])("documents the complete public %s contract", async (path, fields) => {
+		const result = await sdkSearch({ query: path }, stubEnv, adminCtx);
+		expect(result.match_count).toBe(1);
+		for (const field of fields) {
+			expect(result.results[0], path).toContain(field);
+		}
+	});
+
+	it.each([
 		[
 			"operations.getRun",
 			"operations.getRun(run_id: number)",

--- a/packages/server/src/__tests__/unit/utils/openapi-strict.test.ts
+++ b/packages/server/src/__tests__/unit/utils/openapi-strict.test.ts
@@ -1,7 +1,18 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import type { RawDispatchTool } from "../../../tools/registry";
 import { getRawDispatchTools } from "../../../tools/registry";
-import { generateStrictToolPaths } from "../../../utils/openapi-generator";
+import {
+	generateOpenAPISpec,
+	generateStrictToolPaths,
+} from "../../../utils/openapi-generator";
+
+describe("generateOpenAPISpec", () => {
+	it("uses public Behavior terminology throughout ChatGPT metadata", () => {
+		const spec = generateOpenAPISpec("https://example.test");
+		expect(JSON.stringify(spec)).not.toMatch(/watcher/i);
+		expect(spec.servers[0]?.description).toContain("Behaviors");
+	});
+});
 
 /**
  * The strict projection is the single TypeBox source rendered for the typed
@@ -79,5 +90,6 @@ describe("generateStrictToolPaths", () => {
 		const json = JSON.stringify(paths);
 		expect(json).not.toContain('"$id"');
 		expect(json).not.toContain('"static"');
+		expect(json).not.toMatch(/watcher/i);
 	});
 });

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -677,13 +677,13 @@ export default async (_ctx, client) => {
 	},
 	"connections.connect": {
 		summary:
-			"Recommended connector setup entry point. Handles every auth family; the result's `status` tells you what to do next. status 'active' (auth-none, e.g. rss or hackernews) or 'pending_auth' (OAuth waiting on the user) BOTH carry a `connection_id`. status 'setup_required' is a continuation — `connection_id` is OPTIONAL there (may be absent); follow `next_action` / `resume_call` / `completion_check` and only call feeds.create once the result actually carries a connection_id. Once you have a connection_id you must create a feed on it to collect data — connect() alone syncs nothing.",
+			"Recommended connector setup entry point. Handles every auth family; the result's `status` tells you what to do next. status 'active' (auth-none, e.g. rss or hackernews) or 'pending_auth' (OAuth waiting on the user) BOTH carry a `connection_id`. status 'setup_required' is a continuation — `connection_id` is OPTIONAL there (may be absent); follow `next_action` / `resume_call` / `completion_check`. After auth is complete, create a feed and either schedule or trigger it; connect() alone syncs nothing.",
 		access: "admin",
 		example:
 			"const c = await client.connections.connect({ connector_key: 'rss' }); // c.connection_id",
-		usageExample: `// Two-hop: connect() creates the connection; feeds.create() starts the
-// collection. connect() ALONE does not sync anything — you must create a feed
-// on the returned connection_id with a connector-declared feed_key
+		usageExample: `// Three-hop: connect() creates the connection, feeds.create() defines the
+// sync target, and feeds.trigger() collects now. The feed can instead carry a
+// schedule. Use the returned connection_id with a connector-declared feed_key
 // (search_sdk '<connector>' lists the feed keys, e.g. rss → 'articles').
 export default async (_ctx, client) => {
   const c = await client.connections.connect({ connector_key: 'rss' });
@@ -693,11 +693,12 @@ export default async (_ctx, client) => {
   // via client.catalog.listInstalled({ kinds: ['connectors'] }) (each entry's
   // detail.feeds_schema[feed_key]) if you're unsure what to pass. For rss's
   // 'articles' feed that's { feed_urls: [...] }.
-  return client.feeds.create({
+  const { feed } = await client.feeds.create({
     connection_id: c.connection_id,
     feed_key: 'articles',
     config: { feed_urls: ['https://example.com/feed.xml'] },
   });
+  return client.feeds.trigger({ feed_id: feed.id });
 };`,
 	},
 	"connections.connectManaged": {
@@ -861,7 +862,7 @@ export default async (_ctx, client) => {
 			"Get a feed by id. Collected feeds return feed metadata and recent runs, not stored records; search collected records with knowledge.search/search_memory or client.query. Virtual feeds return live rows.",
 		access: "read",
 		signature:
-			"feeds.get(input: { feed_id: number; limit?: number }): Promise<unknown>",
+			"feeds.get(input: { feed_id: number; limit?: number; search_term?: string }): Promise<unknown>",
 		example: "const feed = await client.feeds.get({ feed_id: 42 });",
 	},
 	"feeds.readMany": {
@@ -869,20 +870,25 @@ export default async (_ctx, client) => {
 			"Read several feeds in parallel with per-feed successes/failures. Collected feeds return metadata and recent runs; virtual feeds return live rows. Search collected records with knowledge.search/search_memory or client.query.",
 		access: "read",
 		signature:
-			"feeds.readMany(input: { feed_ids: number[]; limit?: number }): Promise<unknown>",
+			"feeds.readMany(input: { feed_ids: number[]; limit?: number; timeout_ms?: number; search_term?: string }): Promise<unknown>",
 		example:
 			"const feeds = await client.feeds.readMany({ feed_ids: [42, 43], limit: 25 });",
 	},
 	"feeds.create": {
 		summary:
-			"Create a data-sync feed for a connection — this is what actually starts collecting data. Needs the `connection_id` from connections.connect and a connector-declared `feed_key` (search_sdk '<connector>' lists the keys, e.g. rss → 'articles'). Pass connector-specific settings (like the feed urls) in `config`.",
+			"Create a collected or virtual feed for a connection. A collected feed is manual-only unless `schedule` is set; call feeds.trigger to collect immediately. A virtual feed reads live and never syncs. Needs the `connection_id` from connections.connect and a connector-declared `feed_key` (search_sdk '<connector>' lists the keys, e.g. rss → 'articles'). Pass connector-specific settings (like feed URLs) in `config`.",
 		access: "admin",
 		signature:
-			"feeds.create(input: { connection_id: number; feed_key: string; config?: object; display_name?: string; schedule?: string }): Promise<unknown>",
+			"feeds.create(input: { connection_id: number; feed_key: string; display_name?: string; entity_ids?: number[]; config?: object; schedule?: string | null; timezone?: string; virtual?: boolean }): Promise<unknown>",
 		example:
 			"await client.feeds.create({ connection_id: 42, feed_key: 'articles', config: { feed_urls: ['https://example.com/feed.xml'] } });",
 	},
-	"feeds.update": { summary: "Update a feed.", access: "admin" },
+	"feeds.update": {
+		summary: "Update a feed.",
+		access: "admin",
+		signature:
+			"feeds.update(input: { feed_id: number; display_name?: string; status?: 'active' | 'paused'; entity_ids?: number[]; config?: object; replace_config?: boolean; schedule?: string | null; timezone?: string | null }): Promise<unknown>",
+	},
 	"feeds.delete": {
 		summary: "Delete a feed.",
 		access: "admin",

--- a/packages/server/src/sandbox/namespaces/action-call.ts
+++ b/packages/server/src/sandbox/namespaces/action-call.ts
@@ -140,9 +140,11 @@ function rewriteInternalToolName(
 	publicMethod: string,
 ): unknown {
 	if (!sdkNamespace || !(err instanceof ToolUserError)) return err;
+	const internalValidatorPrefix = /Invalid arguments for manage_[a-z_]+/;
+	if (!internalValidatorPrefix.test(err.message)) return err;
 	const rewritten = err.message
 		.replace(
-			/Invalid arguments for manage_[a-z_]+/,
+			internalValidatorPrefix,
 			`Invalid arguments for client.${sdkNamespace}.${publicMethod}`,
 		)
 		// The valid-args list is scoped to the INTERNAL action (`for action

--- a/packages/server/src/sandbox/namespaces/action-call.ts
+++ b/packages/server/src/sandbox/namespaces/action-call.ts
@@ -148,7 +148,16 @@ function rewriteInternalToolName(
 		// The valid-args list is scoped to the INTERNAL action (`for action
 		// 'read_feed'`) — drop that fragment once the public method already names
 		// the call, so no internal action name survives in the message.
-		.replace(/ for action '[a-z_]+'/, "");
+		.replace(/ for action '[a-z_]+'/, "")
+		// A shared admin-tool schema lists every field for every action. That list
+		// is both internal (`action`) and wrong for named SDK methods (for example,
+		// conversations.list used to advertise send-only fields). Keep the actual
+		// unknown/missing-field detail, then route the caller to the authoritative
+		// public signature instead of leaking the raw union schema.
+		.replace(
+			/ — valid arguments are: .+$/,
+			` — run search_sdk '${sdkNamespace}.${publicMethod}' for the public signature`,
+		);
 	if (rewritten === err.message) return err;
 	// ClientSdkActionError carries extra fields — but it is raised by THIS module
 	// from a result value, never by the arg validator, so a match here is always

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -16,15 +16,29 @@ export interface FeedsCreateInput {
 	display_name?: string;
 	entity_ids?: number[];
 	config?: Record<string, unknown>;
-	schedule?: string;
+	schedule?: string | null;
 	/** IANA zone the schedule is evaluated in; omit for server time (UTC). */
 	timezone?: string;
+	/** Read live through connector query/search instead of scheduling collection. */
+	virtual?: boolean;
 }
 
 export interface FeedsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(input?: { connection_id?: number; feed_ids?: number[] }): Promise<unknown>;
-	get(input: { feed_id: number; search_term?: string }): Promise<unknown>;
+	list(input?: {
+		connection_id?: number;
+		feed_ids?: number[];
+		entity_id?: number;
+		status?: "active" | "paused";
+		health?: "healthy" | "failing";
+		limit?: number;
+		offset?: number;
+	}): Promise<unknown>;
+	get(input: {
+		feed_id: number;
+		limit?: number;
+		search_term?: string;
+	}): Promise<unknown>;
 	readMany(input: {
 		feed_ids: number[];
 		limit?: number;
@@ -36,10 +50,11 @@ export interface FeedsNamespace {
 	update(input: {
 		feed_id: number;
 		display_name?: string;
-		status?: string;
+		status?: "active" | "paused";
 		entity_ids?: number[];
 		config?: Record<string, unknown>;
-		schedule?: string;
+		replace_config?: boolean;
+		schedule?: string | null;
 		/** IANA zone for the schedule; null clears it (server time). */
 		timezone?: string | null;
 	}): Promise<unknown>;

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -232,7 +232,7 @@ export async function handleCompleteWindow(
   if (watcherRows.length === 0) {
     throw new Error(
       `Behavior ${watcherId} not found. ` +
-        "It may have been deleted. Use manage_behaviors with action='list' to see available Behaviors."
+        'It may have been deleted. Use client.behaviors.list() via query_sdk to see available Behaviors.'
     );
   }
 

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -527,7 +527,7 @@ export async function assertOutputEntityTypesExist(
     `;
     if (rows.length === 0) {
       throw new ToolUserError(
-        `Unknown entity type '${entityType}' in outputs.${name}. Use manage_entity_schema(schema_type="entity_type", action="list") to list available types or create a custom type first.`,
+        `Unknown entity type '${entityType}' in outputs.${name}. Use client.entitySchema.listTypes() to list available types or client.entitySchema.createType(...) to create a custom type first.`,
         422
       );
     }

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -454,7 +454,7 @@ async function handleConnectImpl(
   if (splitConfig.feedConfig) {
     return {
       error:
-        "Feed-scoped config belongs on feeds. Create the connection first, then use manage_feeds(action='create_feed') for sync target settings.",
+        'Feed-scoped config belongs on feeds. Create the connection first, then use client.feeds.create({ connection_id, feed_key, config }) for sync target settings.',
       setup_url: setupUrl,
     };
   }

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -260,7 +260,7 @@ async function handleConnectImpl(
       instructions:
         "A pending connection already exists. Send the connect_url to the user to complete OAuth authorization." +
         (pendingScopeWarning ? ` ${pendingScopeWarning}` : "") +
-        ` Poll with action='get' until status='active'.`,
+        " Poll with client.connections.get(connection_id) via query_sdk until status='active'.",
     };
   }
 
@@ -774,6 +774,6 @@ async function handleConnectImpl(
     instructions:
       `Send the connect_url to the user to complete OAuth authorization with ${oauthMethod.provider}.` +
       (personalScopeWarning ? ` ${personalScopeWarning}` : "") +
-      ` Poll this connection with action='get' until status='active'.`,
+      " Poll with client.connections.get(connection_id) via query_sdk until status='active'.",
   };
 }

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1045,7 +1045,7 @@ export async function handleCreate(
   if (splitConfig.feedConfig) {
     return {
       error:
-        "Feed-scoped config belongs on feeds. Create the connection first, then use manage_feeds(action='create_feed') for sync target settings.",
+        'Feed-scoped config belongs on feeds. Create the connection first, then use client.feeds.create({ connection_id, feed_key, config }) for sync target settings.',
     };
   }
 
@@ -1686,7 +1686,7 @@ export async function handleUpdate(
   if (splitConfig.feedConfig) {
     return {
       error:
-        "Feed-scoped config belongs on feeds. Use manage_feeds(action='update_feed') for sync target settings.",
+        'Feed-scoped config belongs on feeds. Use client.feeds.update({ feed_id, config }) for sync target settings.',
     };
   }
 

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -375,7 +375,7 @@ async function handleCreate(
 		// Root entity (no parent)
 		nextSteps.push(
 			`Use client.connections.connect({ connector_key: '<connector_key>' }), client.feeds.create({ connection_id: <connection_id>, feed_key: '<feed_key>', entity_ids: [${entity.id}], config: {} }) to target this entity, then client.feeds.trigger({ feed_id: <feed_id> }) to collect now.`,
-			`Use client.behaviors.create({ entity_id: ${entity.id}, slug: '<slug>', agent_id: '<agent_id>', prompt: '<prompt>', sources: [] }) to schedule a Behavior.`,
+			`Use client.behaviors.create({ entity_id: ${entity.id}, slug: '<slug>', agent_id: '<agent_id>', prompt: '<prompt>', sources: [], triggers: [{ kind: 'schedule', cron: '<cron>', timezone: '<IANA timezone>' }] }) to schedule a Behavior.`,
 		);
 	} else {
 		// Child entity (has parent)

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -374,14 +374,14 @@ async function handleCreate(
 	if (!entity.parent_id) {
 		// Root entity (no parent)
 		nextSteps.push(
-			`Use manage_connections(action='create') to install a connector, then manage_feeds(action='create_feed', entity_ids=[${entity.id}]) to target this entity.`,
-			`Use manage_behaviors(action='create', entity_id=${entity.id}) to schedule Behaviors.`,
+			"Use client.connections.connect({ connector_key: '<connector_key>' }), then client.feeds.create({ connection_id: <connection_id>, feed_key: '<feed_key>', config: {} }) to start collection.",
+			`Use client.behaviors.create({ entity_id: ${entity.id}, slug: '<slug>', agent_id: '<agent_id>', prompt: '<prompt>', sources: [] }) to schedule a Behavior.`,
 		);
 	} else {
 		// Child entity (has parent)
 		nextSteps.push(
 			`${entityTypeLabel} belongs to ${entity.parent_name ? `"${entity.parent_name}"` : "parent"} (ID: ${entity.parent_id}).`,
-			`Use manage_connections(action='create') to install a connector, then manage_feeds(action='create_feed', entity_ids=[${entity.id}]) to target this entity.`,
+			"Use client.connections.connect({ connector_key: '<connector_key>' }), then client.feeds.create({ connection_id: <connection_id>, feed_key: '<feed_key>', config: {} }) to start collection.",
 		);
 	}
 

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -374,14 +374,14 @@ async function handleCreate(
 	if (!entity.parent_id) {
 		// Root entity (no parent)
 		nextSteps.push(
-			"Use client.connections.connect({ connector_key: '<connector_key>' }), then client.feeds.create({ connection_id: <connection_id>, feed_key: '<feed_key>', config: {} }) to start collection.",
+			`Use client.connections.connect({ connector_key: '<connector_key>' }), client.feeds.create({ connection_id: <connection_id>, feed_key: '<feed_key>', entity_ids: [${entity.id}], config: {} }) to target this entity, then client.feeds.trigger({ feed_id: <feed_id> }) to collect now.`,
 			`Use client.behaviors.create({ entity_id: ${entity.id}, slug: '<slug>', agent_id: '<agent_id>', prompt: '<prompt>', sources: [] }) to schedule a Behavior.`,
 		);
 	} else {
 		// Child entity (has parent)
 		nextSteps.push(
 			`${entityTypeLabel} belongs to ${entity.parent_name ? `"${entity.parent_name}"` : "parent"} (ID: ${entity.parent_id}).`,
-			"Use client.connections.connect({ connector_key: '<connector_key>' }), then client.feeds.create({ connection_id: <connection_id>, feed_key: '<feed_key>', config: {} }) to start collection.",
+			`Use client.connections.connect({ connector_key: '<connector_key>' }), client.feeds.create({ connection_id: <connection_id>, feed_key: '<feed_key>', entity_ids: [${entity.id}], config: {} }) to target this entity, then client.feeds.trigger({ feed_id: <feed_id> }) to collect now.`,
 		);
 	}
 

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -2262,7 +2262,7 @@ async function requireApprovalAuthority(
 		return;
 	}
 	throw new Error(
-		`Action manage_operations.${action} requires admin or owner access. Ask an organization owner to grant elevated access.`,
+		`This operation (${action}) requires admin or owner access. Ask an organization owner to grant elevated access.`,
 	);
 }
 

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -336,7 +336,7 @@ async function getBehaviorImpl(
 
   if (!args.behavior_id) {
     throw new Error(
-      "behavior_id is required. Use manage_behaviors with action='list' to discover Behaviors."
+      "behavior_id is required. Use client.behaviors.list() via query_sdk to discover Behaviors."
     );
   }
 

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -238,6 +238,24 @@ function normalizeQueryTerm(term: string): string {
 	return lower.startsWith("client.") ? lower.slice("client.".length) : lower;
 }
 
+/** Whether a discovery query names only the ClientSDK surface, not a connector. */
+export function isSdkOnlyDiscoveryQuery(query: string): boolean {
+	const q = query.trim();
+	const normalized = normalizeQueryTerm(q);
+	const firstSegment = normalized.split(".")[0];
+	const isSdkNamespace = NAMESPACES.some(
+		(ns) => ns.toLowerCase() === firstSegment,
+	);
+	const isExactNamespace = NAMESPACES.some(
+		(ns) => ns.toLowerCase() === normalized,
+	);
+	return (
+		/^client\b/i.test(q) ||
+		isExactNamespace ||
+		(q.includes(".") && isSdkNamespace)
+	);
+}
+
 export const sdkSearch = withValidatedArgs(
 	"search_sdk",
 	SdkSearchSchema,
@@ -252,20 +270,16 @@ async function sdkSearchImpl(
 	// Unified-catalog search (executor pattern): a query like "website" or "slack"
 	// names a CONNECTOR, not an SDK method, so pure method search returns nothing
 	// useful. Search live connectors and surface them (+ lifecycle) ABOVE method
-	// docs. Skip the connector lookup ONLY for genuine method paths — a
-	// `client.`-prefixed term, or a dotted path whose FIRST segment is a real SDK
-	// namespace (`feeds.create`). A dotted CONNECTOR id (`google.calendar`) must
-	// still be searched: its first segment (`google`) is not an SDK namespace.
+	// docs. Skip the connector lookup ONLY for genuine SDK intent — a bare
+	// namespace, a `client.`-prefixed term, or a dotted path whose FIRST segment
+	// is a real SDK namespace (`feeds.create`). A dotted CONNECTOR id
+	// (`google.calendar`) must still be searched: its first segment (`google`) is
+	// not an SDK namespace.
 	const q = args.query.trim();
-	// NAMESPACES preserves SDK casing (entitySchema, authProfiles); the query is
-	// lowercased — compare case-insensitively so `entitySchema.listTypes` is
-	// recognized as a method path.
-	const firstSegment = normalizeQueryTerm(q).split(".")[0];
-	const isSdkNamespace = NAMESPACES.some(
-		(ns) => ns.toLowerCase() === firstSegment
-	);
-	const looksLikeMethodPath =
-		/^client\b/i.test(q) || (q.includes(".") && isSdkNamespace);
+	// Bare namespaces are just as explicit as dotted method paths. Searching the
+	// connector catalog for `agents`/`feeds` used to prepend unrelated connector
+	// matches ahead of the namespace methods the caller explicitly requested.
+	const looksLikeMethodPath = isSdkOnlyDiscoveryQuery(q);
 	const connectorHits = looksLikeMethodPath
 		? []
 		: await searchLiveConnectors(q, env, ctx);

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -1427,7 +1427,7 @@ async function formatEntityResult(
     const pausedConnections = connections?.filter((c) => c.status === 'paused').length || 0;
 
     if (activeConnections === 0 && pausedConnections === 0) {
-      suggestion = `Entity "${primaryEntity.name}" found with no connections. Use manage_connections to add one and start collection.`;
+      suggestion = `Entity "${primaryEntity.name}" found with no connections. Use client.connections.connect({ connector_key: '<connector_key>' }) via run_sdk to add one and start collection.`;
     } else if (activeConnections === 0 && pausedConnections > 0) {
       suggestion = `Entity "${primaryEntity.name}" has ${pausedConnections} paused connection(s). Reactivate a connection to resume collection.`;
     } else {

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -1427,7 +1427,7 @@ async function formatEntityResult(
     const pausedConnections = connections?.filter((c) => c.status === 'paused').length || 0;
 
     if (activeConnections === 0 && pausedConnections === 0) {
-      suggestion = `Entity "${primaryEntity.name}" found with no connections. Use client.connections.connect({ connector_key: '<connector_key>' }) via run_sdk to add one and start collection.`;
+      suggestion = `Entity "${primaryEntity.name}" found with no connections. Use search_sdk to choose a connector and feed, then run_sdk with client.connections.connect({ connector_key: '<connector_key>' }), client.feeds.create({ connection_id: <connection_id>, feed_key: '<feed_key>', entity_ids: [${primaryEntity.id}], config: {} }) to target this entity, and client.feeds.trigger({ feed_id: <feed_id> }) to collect now.`;
     } else if (activeConnections === 0 && pausedConnections > 0) {
       suggestion = `Entity "${primaryEntity.name}" has ${pausedConnections} paused connection(s). Reactivate a connection to resume collection.`;
     } else {

--- a/packages/server/src/utils/__tests__/entity-management-schema-search.test.ts
+++ b/packages/server/src/utils/__tests__/entity-management-schema-search.test.ts
@@ -92,14 +92,16 @@ describe('entity-management schema search path', () => {
     const user = await createTestUser();
     await addUserToOrganization(user.id, tenant.id, 'owner');
 
-    await expect(
-      createEntity({
+    const createUnknown = createEntity({
         entity_type: 'never_registered_anywhere',
         name: 'Should Fail',
         organization_id: tenant.id,
         created_by: user.id,
-      } as Parameters<typeof createEntity>[0])
-    ).rejects.toThrow(/Unknown entity type/i);
+      } as Parameters<typeof createEntity>[0]);
+
+    await expect(createUnknown).rejects.toThrow(/Unknown entity type/i);
+    await expect(createUnknown).rejects.toThrow(/client\.entitySchema\.listTypes\(\)/);
+    await expect(createUnknown).rejects.not.toThrow(/manage_entity_schema/);
   });
 
   it('does not search private orgs that the caller is not a member of', async () => {

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -458,7 +458,7 @@ export async function createEntity(
   `;
 	if (typeRow.length === 0) {
 		throw new ToolUserError(
-			`Unknown entity type '${data.entity_type}'. Use manage_entity_schema(schema_type="entity_type", action="list") to list available types or create a custom type first.`,
+			`Unknown entity type '${data.entity_type}'. Use client.entitySchema.listTypes() to list available types or client.entitySchema.createType(...) to create a custom type first.`,
 			400,
 		);
 	}

--- a/packages/server/src/utils/openapi-generator.ts
+++ b/packages/server/src/utils/openapi-generator.ts
@@ -255,7 +255,7 @@ export function generateOpenAPISpec(serverUrl: string) {
     servers: [
       {
         url: serverUrl,
-        description: 'Get watchers for entities',
+        description: 'Manage workspace knowledge and Behaviors',
       },
     ],
     paths,

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -15,6 +15,13 @@ function singleLine(value: unknown): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
 }
 
+/** Translate stored legacy engine prose to the agent-facing product name. */
+function publicDescription(value: unknown): string {
+  return singleLine(value)
+    .replace(/\bwatchers\b/gi, 'Behaviors')
+    .replace(/\bwatcher\b/gi, 'Behavior');
+}
+
 /**
  * Render a metadata schema's fields as a compact `name (description)` list.
  * Accepts both a real JSON Schema (descends into `.properties` — the old
@@ -33,8 +40,9 @@ function renderSchemaFields(schema: unknown): string {
   }
   if (!props) return '';
   return Object.entries(props)
+    .filter(([field]) => !/watcher/i.test(field))
     .map(([field, def]) => {
-      const desc = singleLine((def as Record<string, unknown> | null)?.description);
+      const desc = publicDescription((def as Record<string, unknown> | null)?.description);
       return desc ? `${field} (${desc})` : field;
     })
     .join(', ');
@@ -72,7 +80,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
     ]);
 
     const entityTypeLines = entityTypeRows.map((et: any) => {
-      const desc = singleLine(et.description);
+      const desc = publicDescription(et.description);
       const fields = renderSchemaFields(et.metadata_schema);
       return `- ${et.slug} ("${et.name}")${desc ? ` — ${desc}` : ''}${fields ? ` — fields: ${fields}` : ''}`;
     });
@@ -88,7 +96,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       if (rt.is_symmetric) parts.push('symmetric');
       if (inverseSlug) parts.push(`inverse: ${inverseSlug}`);
       const meta = parts.length > 0 ? ` (${parts.join(', ')})` : '';
-      const desc = singleLine(rt.description);
+      const desc = publicDescription(rt.description);
       relTypeLines.push(`- ${slug}${meta}${desc ? ` — ${desc}` : ''}`);
     }
 
@@ -127,9 +135,11 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       if (kindEntries.length === 0) continue;
 
       const kindLines = kindEntries.map(([kind, def]) => {
-        const desc = def.description ?? '';
+        const desc = publicDescription(def.description);
         const metaFields = def.metadataSchema?.properties
-          ? Object.keys(def.metadataSchema.properties as Record<string, unknown>).join(', ')
+          ? Object.keys(def.metadataSchema.properties as Record<string, unknown>)
+              .filter((field) => !/watcher/i.test(field))
+              .join(', ')
           : '';
         const parts = [desc, metaFields ? `metadata: ${metaFields}` : '']
           .filter(Boolean)
@@ -196,8 +206,8 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
         const detail =
           localOps.length > 0
             ? localOps.join(', ')
-            : 'operations via `manage_operations.list_available`';
-        const desc = singleLine(conn.description);
+            : 'operations via `client.operations.listAvailable()`';
+        const desc = publicDescription(conn.description);
         sections.push(`- ${conn.key}${desc ? ` (${desc})` : ''}: ${detail}`);
       }
     }
@@ -210,7 +220,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       'A connector may be INSTALLED for this org yet absent from the global catalog, so always check installed connectors before concluding a source is unsupported:',
       '- Find the connector: `search_sdk` with the source/topic word (e.g. "website", "slack") returns any matching live connector + its feed keys + lifecycle. Or list them: `query_sdk` → `client.catalog.listInstalled({ kinds: ["connectors"] })` (installed = ready to configure; each item\'s `detail.feeds_schema` keys are the feed_key values) and `client.catalog.listCatalog({ kinds: ["connectors"] })` (global, installable) and `client.connections.list()` (already configured).',
       '- Lifecycle: `run_sdk` → `client.connections.connect({ connector_key })` → `client.feeds.create({ connection_id, feed_key, config })` → `client.feeds.trigger({ feed_id })`; then verify with `query_sql` on the events table and search with `search_memory`.',
-      'For reads beyond search_memory, prefer `query_sdk` with a TS script. For writes (entity CRUD, watchers, classifiers, connections, feeds, view templates, operations), use `run_sdk`. Use `search_sdk` to discover method names.',
+      'For reads beyond search_memory, prefer `query_sdk` with a TS script. For writes (entity CRUD, Behaviors, classifiers, connections, feeds, view templates, operations), use `run_sdk`. Use `search_sdk` to discover method names.',
       '',
       '### Saving (do this automatically)',
       'When the user shares any of these, save immediately:',

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -15,9 +15,24 @@ function singleLine(value: unknown): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
 }
 
-/** Translate stored legacy engine prose to the agent-facing product name. */
-function publicDescription(value: unknown): string {
-  return singleLine(value)
+const INTERNAL_BEHAVIOR_SCHEMA_FIELDS = new Set([
+  'acting_watcher_id',
+  'analyzed_by_watcher_id',
+  'exclude_watcher_id',
+  'source_watcher_id',
+  'watcher_id',
+  'watcher_ids',
+]);
+
+function isInternalBehaviorSchemaField(field: string): boolean {
+  return INTERNAL_BEHAVIOR_SCHEMA_FIELDS.has(field.toLowerCase());
+}
+
+/** Translate engine vocabulary only on known internal fields. */
+function publicFieldDescription(field: string, value: unknown): string {
+  const description = singleLine(value);
+  if (field.toLowerCase() !== 'window_id') return description;
+  return description
     .replace(/\bwatchers\b/gi, 'Behaviors')
     .replace(/\bwatcher\b/gi, 'Behavior');
 }
@@ -40,9 +55,12 @@ function renderSchemaFields(schema: unknown): string {
   }
   if (!props) return '';
   return Object.entries(props)
-    .filter(([field]) => !/watcher/i.test(field))
+    .filter(([field]) => !isInternalBehaviorSchemaField(field))
     .map(([field, def]) => {
-      const desc = publicDescription((def as Record<string, unknown> | null)?.description);
+      const desc = publicFieldDescription(
+        field,
+        (def as Record<string, unknown> | null)?.description
+      );
       return desc ? `${field} (${desc})` : field;
     })
     .join(', ');
@@ -80,7 +98,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
     ]);
 
     const entityTypeLines = entityTypeRows.map((et: any) => {
-      const desc = publicDescription(et.description);
+      const desc = singleLine(et.description);
       const fields = renderSchemaFields(et.metadata_schema);
       return `- ${et.slug} ("${et.name}")${desc ? ` — ${desc}` : ''}${fields ? ` — fields: ${fields}` : ''}`;
     });
@@ -96,7 +114,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       if (rt.is_symmetric) parts.push('symmetric');
       if (inverseSlug) parts.push(`inverse: ${inverseSlug}`);
       const meta = parts.length > 0 ? ` (${parts.join(', ')})` : '';
-      const desc = publicDescription(rt.description);
+      const desc = singleLine(rt.description);
       relTypeLines.push(`- ${slug}${meta}${desc ? ` — ${desc}` : ''}`);
     }
 
@@ -135,10 +153,10 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       if (kindEntries.length === 0) continue;
 
       const kindLines = kindEntries.map(([kind, def]) => {
-        const desc = publicDescription(def.description);
+        const desc = singleLine(def.description);
         const metaFields = def.metadataSchema?.properties
           ? Object.keys(def.metadataSchema.properties as Record<string, unknown>)
-              .filter((field) => !/watcher/i.test(field))
+              .filter((field) => !isInternalBehaviorSchemaField(field))
               .join(', ')
           : '';
         const parts = [desc, metaFields ? `metadata: ${metaFields}` : '']
@@ -207,7 +225,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
           localOps.length > 0
             ? localOps.join(', ')
             : 'operations via `client.operations.listAvailable()`';
-        const desc = publicDescription(conn.description);
+        const desc = singleLine(conn.description);
         sections.push(`- ${conn.key}${desc ? ` (${desc})` : ''}: ${detail}`);
       }
     }


### PR DESCRIPTION
## Summary

- remove legacy `watcher` engine vocabulary from ChatGPT-visible MCP tool descriptions, OpenAPI metadata, and stored legacy workspace metadata
- keep exact ClientSDK namespace searches method-only while preserving free-text and dotted connector discovery
- rewrite internal action-union validation leaks and stale `manage_*` recovery hints to public ClientSDK guidance
- align the public feed namespace and `search_sdk` signatures with fields the runtime already accepts, including explicit create → trigger guidance
- add outer `tools/list`, discovery, validation, workspace-instruction, mutation-result, and feed-contract regressions

## Test plan

- [x] `make pre-pr` clean (build, strict typecheck, knip, lint, exposed-surface naming, gateway LLM gate)
- [x] Focused unit suite: 70 passed
- [x] Focused integration suite: 119 passed, 2 intentional skips
- [x] Bug fix: red → fix → green evidence below
- [x] Production MCP baseline audited directly across all six connected tools

### Red

Production ChatGPT tool metadata exposed legacy references on all six tools, including:

```
window_id: "Watcher window this task belongs to"
stable_key: "Stable key for the task watcher"
watcher_id: "Related watcher ID"
For writes (... watchers, ...)
```

Production OpenAPI exposed the same engine term:

```
servers[0].description = "Get watchers for entities"
watcher references = 1
```

Exact discovery was polluted:

```
search_sdk("agents") -> telegram / discord connector hits before ClientSDK agent methods
search_sdk("feeds")  -> jira / rss / linear connector hits before ClientSDK feed methods
```

Public SDK validation and result guidance leaked internal or incomplete contracts:

```
client.conversations.list({ limit: 1 })
-> internal action union + unrelated send-only fields

client.entities.create(...)
-> manage_* recovery paths; feed guidance omitted entity_ids and the required trigger/schedule step

search_sdk("feeds.create")
-> omitted runtime-supported entity_ids, timezone, virtual, and nullable schedule
```

The added regressions fail on those exact paths before the fix. The feed-contract test was red 4/4 before metadata/type alignment.

### Green

```
focused MCP unit tests:        70 passed, 0 failed
focused MCP integration:      119 passed, 2 intentional skips
make pre-pr:                   6/6 clean
OpenAPI server description:   "Manage workspace knowledge and Behaviors"
OpenAPI watcher references:   0
```

The integration suite covers MCP auth and raw `tools/list`, every registry tool via the model-free E2E plan, exact namespace discovery, workspace instructions, public schema recovery, and a real entity create → soft-delete round trip with mutation guidance assertions.

## Notes

The production baseline audit also verified invalid bearer rejection, organization scoping, read/write separation, SQL column/verb restrictions, dry-run non-persistence, entity create/read/soft-delete cleanup, memory idempotency, and append-only tombstoning.

`make review-fix` ran with the user-authorized Codex `gpt-5.6-sol` reviewer at `xhigh`. It found and fixed the feed discovery/runtime mismatches, incomplete create/trigger guidance, and an over-broad validation-error rewrite; the resulting red tests are green above. No Fable or Claude reviewer was used.

### Reviewer-found regressions

The posted Sol xhigh review reproduced two additional guidance bugs before merge:

```
"A club for bird watchers" -> "A club for bird Behaviors"
watcher_count -> omitted
client.behaviors.create({ ..., sources: [] }) to schedule a Behavior -> actually manual-only
```

Both are fixed and pinned:

```
workspace instruction regression: 26 passed
all-tools model-free E2E:        29 passed
full make pre-pr after fixes:    6/6 clean
```

Tenant-authored descriptions and similarly named fields are now preserved; only exact reserved engine keys are hidden. The Behavior next-step example now includes an explicit schedule trigger with cron and timezone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded feed management with scheduling, time zones, virtual feeds, search, pagination, filtering, and configuration updates.
  * Improved SDK discovery so SDK-specific searches return more relevant methods without unrelated connector results.
* **Improvements**
  * Updated guidance to use client SDK APIs for connections, feeds, behaviors, operations, and entity types.
  * Improved setup instructions and follow-up actions after creating entities or connections.
  * Replaced legacy “watcher” terminology with “Behavior” in workspace guidance and metadata.
  * Clarified validation errors with cleaner, more actionable SDK suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->