### PR TITLE
fix(server): park Behaviors until provider quota reset

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -301,6 +301,12 @@ export interface ThreadResponsePayload {
    * the provider's sentence; `errorCode` selects the CTA link.
    */
   error?: string;
+  /**
+   * Original terminal error used only for durable run bookkeeping when an
+   * output guardrail replaces the user-visible error text. Gateway-owned;
+   * renderers must never expose this field to clients.
+   */
+  bookkeepingError?: string;
   errorCode?: string;
   /** Non-secret provider/model targeting for the error CTA. */
   errorContext?: AgentErrorContext;

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -1233,7 +1233,7 @@ describe("watcher automation contract", () => {
 			expect(dupeJson.idempotent).toBe(true);
 		});
 
-		it("complete-behavior endpoint marks the run failed when error is supplied", async () => {
+		it("complete-behavior endpoint parks a failed run until provider quota resets", async () => {
 			const { sql, dbClient, workspace, watcherId, agent } =
 				await createAutomatedWatcher();
 			const granularity = inferBehaviorGranularityFromSchedule("0 9 * * *");
@@ -1263,12 +1263,18 @@ describe("watcher automation contract", () => {
         WHERE id = ${queued.runId}
       `;
 
+			const resetAt = new Date(Date.now() + 48 * 60 * 60 * 1000);
+			const providerReset = resetAt
+				.toISOString()
+				.replace("T", " ")
+				.replace(/\.\d{3}Z$/, "");
+			const error = `429 Limit Exhausted. Your limit will reset at ${providerReset}`;
 			const response = await post(
 				`/api/workers/me/runs/${queued.runId}/complete-behavior`,
 				{
 					body: {
 						worker_id: workerId,
-						error: "claude binary not found",
+						error,
 						duration_ms: 12,
 						exit_reason: "crash",
 						exit_code: 127,
@@ -1285,7 +1291,7 @@ describe("watcher automation contract", () => {
         WHERE id = ${queued.runId}
       `;
 			expect(String(run.status)).toBe("failed");
-			expect(String(run.error_message)).toBe("claude binary not found");
+			expect(String(run.error_message)).toBe(error);
 			// No watcher_windows row on failure.
 			expect(run.window_id).toBeNull();
 			expect(Number(run.exit_code)).toBe(127);
@@ -1295,6 +1301,13 @@ describe("watcher automation contract", () => {
         SELECT id FROM events WHERE run_id = ${queued.runId} AND semantic_type = 'canvas_state'
       `;
 			expect(windows).toHaveLength(0);
+
+			const [watcher] = await sql`
+        SELECT next_run_at FROM watchers WHERE id = ${watcherId}
+      `;
+			expect(new Date(watcher.next_run_at as string).getTime()).toBe(
+				Math.floor(resetAt.getTime() / 1000) * 1000 + 60_000
+			);
 		});
 
 		it("complete-behavior endpoint refuses non-Behavior run types", async () => {

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -246,8 +246,11 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
     );
 
     const sql = getTestDb();
-    const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    const [run] = await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
     expect(run.status).toBe("failed");
+    expect(run.error_message).toBe(
+      "Message blocked by guardrail: require-tool"
+    );
 
     const after = await cursorOf(watcherId);
     const expectedNotBefore =

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -241,6 +241,34 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
     expect(after.getTime()).toBe(staleCursor.getTime());
   });
 
+  it("parks a scheduled Behavior after a quota-exhausted event dispatch", async () => {
+    const resetAt = new Date(Date.now() + 6 * 60 * 60 * 1000);
+    const providerReset = resetAt
+      .toISOString()
+      .replace("T", " ")
+      .replace(/\.\d{3}Z$/, "");
+    const { watcherId, runId } = await createDueWatcherWithDispatchedRun({
+      slug: "park-event-until-provider-reset",
+      messageId: "msg-event-provider-reset",
+      dispatchSource: "event",
+    });
+
+    await resolveWatcherRunsByMessageIds(["msg-event-provider-reset"], {
+      ok: false,
+      error: `429 Weekly/Monthly Limit Exhausted. Your limit will reset at ${providerReset}`,
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+    });
+
+    const sql = getTestDb();
+    const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+
+    const after = await cursorOf(watcherId);
+    const expectedNotBefore =
+      Math.floor(resetAt.getTime() / 1000) * 1000 + 60_000;
+    expect(after.getTime()).toBe(expectedNotBefore);
+  });
+
   it("leaves the cursor alone while a finalize nudge requeues the run", async () => {
     const { watcherId, staleCursor } = await createDueWatcherWithDispatchedRun({
       slug: "no-advance-on-requeue",

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { ApiResponseRenderer } from "../../../gateway/api/response-renderer";
+import { ChatResponseBridge } from "../../../gateway/connections/chat-response-bridge";
 import { materializeDueWatcherRuns } from "../../../watchers/automation";
 import { resolveWatcherRunsByMessageIds } from "../../../watchers/run-completion";
 import {
   advanceWatcherSchedule,
   parseProviderQuotaResetAt,
+  providerQuotaResetNotBefore,
 } from "../../../watchers/schedule-cursor";
 import { getTestDb } from "../../setup/test-db";
 import { createTestAgent, createTestEntity } from "../../setup/test-fixtures";
@@ -73,6 +75,7 @@ async function createDueWatcherWithDispatchedRun(opts: {
   return {
     sql,
     organizationId: workspace.org.id,
+    agentId: agent.agentId,
     watcherId,
     runId: Number(run.id),
     staleCursor,
@@ -84,6 +87,25 @@ async function cursorOf(watcherId: number): Promise<Date> {
   const [row] =
     await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
   return new Date(row.next_run_at as string);
+}
+
+function chatResponseBridge(organizationId: string): ChatResponseBridge {
+  const target = { post: async () => ({ id: "posted" }) };
+  const manager = {
+    getInstance: () => ({
+      connection: {
+        platform: "telegram",
+        organizationId,
+      },
+      chat: {
+        channel: () => target,
+      },
+    }),
+    getPublicGatewayUrl: () => "",
+  };
+  return new ChatResponseBridge(
+    manager as unknown as ConstructorParameters<typeof ChatResponseBridge>[0]
+  );
 }
 
 describe("provider quota reset parsing", () => {
@@ -122,6 +144,10 @@ describe("provider quota reset parsing", () => {
     "2026-07-31 12:60:00",
     "2026-07-31 12:00:60",
     "2026-07-31 12:00:00+24:00",
+    "2026-07-31 12:00:00+bad",
+    "2026-07-31 12:00:000",
+    "2026-07-31T12:00:00.1234Z",
+    "2026-07-31x",
   ])("rejects invalid reset timestamp %s", (timestamp) => {
     expect(
       parseProviderQuotaResetAt(
@@ -129,6 +155,23 @@ describe("provider quota reset parsing", () => {
         new Date("2026-01-01T00:00:00.000Z")
       )
     ).toBeNull();
+  });
+
+  it("requires the structured quota code", () => {
+    const message = "Your limit will reset at 2026-07-31 12:00:00";
+    const now = new Date("2026-07-31T10:00:00.000Z");
+
+    expect(
+      providerQuotaResetNotBefore(
+        message,
+        "PROVIDER_QUOTA_EXHAUSTED",
+        now
+      )?.toISOString()
+    ).toBe("2026-07-31T12:01:00.000Z");
+    expect(
+      providerQuotaResetNotBefore(message, "NO_MODEL_CONFIGURED", now)
+    ).toBeNull();
+    expect(providerQuotaResetNotBefore(message, undefined, now)).toBeNull();
   });
 });
 
@@ -267,6 +310,160 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
     const expectedNotBefore =
       Math.floor(resetAt.getTime() / 1000) * 1000 + 60_000;
     expect(after.getTime()).toBe(expectedNotBefore);
+  });
+
+  it("does not shorten a quota park when another run finishes later", async () => {
+    const resetAt = new Date(Date.now() + 6 * 60 * 60 * 1000);
+    const providerReset = resetAt
+      .toISOString()
+      .replace("T", " ")
+      .replace(/\.\d{3}Z$/, "");
+    const { sql, watcherId } = await createDueWatcherWithDispatchedRun({
+      slug: "preserve-provider-reset",
+      messageId: "msg-provider-reset-first",
+    });
+    await resolveWatcherRunsByMessageIds(["msg-provider-reset-first"], {
+      ok: false,
+      error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+    });
+    await sql`
+      INSERT INTO runs (organization_id, run_type, watcher_id, status,
+                        dispatched_message_id, approved_input)
+      SELECT organization_id, 'behavior', ${watcherId}, 'running',
+             'msg-ordinary-error-second',
+             ${sql.json({ finalize_nudge_count: 99, dispatch_source: "scheduled" })}
+      FROM watchers
+      WHERE id = ${watcherId}
+    `;
+    await resolveWatcherRunsByMessageIds(["msg-ordinary-error-second"], {
+      ok: false,
+      error: "provider disconnected",
+    });
+
+    const expectedNotBefore =
+      Math.floor(resetAt.getTime() / 1000) * 1000 + 60_000;
+    expect((await cursorOf(watcherId)).getTime()).toBe(expectedNotBefore);
+  });
+
+  it("parks a reply-to-source Behavior on a coded quota error", async () => {
+    const resetAt = new Date(Date.now() + 6 * 60 * 60 * 1000);
+    const providerReset = resetAt
+      .toISOString()
+      .replace("T", " ")
+      .replace(/\.\d{3}Z$/, "");
+    const { watcherId, organizationId, agentId } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "park-chat-reply-until-provider-reset",
+        messageId: "msg-chat-provider-reset",
+        dispatchSource: "event",
+      });
+
+    await chatResponseBridge(organizationId).handleError(
+      {
+        messageId: "msg-chat-provider-reset",
+        channelId: "chat-provider-reset",
+        conversationId: "chat-provider-reset",
+        userId: "watcher-test",
+        teamId: "telegram",
+        organizationId,
+        platform: "telegram",
+        timestamp: Date.now(),
+        error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        platformMetadata: {
+          connectionId: "chat-test",
+          chatId: "chat-provider-reset",
+          organizationId,
+          agentId,
+          behaviorId: watcherId,
+        },
+      },
+      "test-session"
+    );
+
+    const after = await cursorOf(watcherId);
+    const expectedNotBefore =
+      Math.floor(resetAt.getTime() / 1000) * 1000 + 60_000;
+    expect(after.getTime()).toBe(expectedNotBefore);
+  });
+
+  it("does not park a reply-to-source Behavior from another organization", async () => {
+    const resetAt = new Date(Date.now() + 6 * 60 * 60 * 1000);
+    const providerReset = resetAt
+      .toISOString()
+      .replace("T", " ")
+      .replace(/\.\d{3}Z$/, "");
+    const { watcherId, staleCursor, organizationId, agentId } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "reject-cross-org-chat-parking",
+        messageId: "msg-cross-org-provider-reset",
+        dispatchSource: "event",
+      });
+
+    await chatResponseBridge(organizationId).handleError(
+      {
+        messageId: "msg-cross-org-provider-reset",
+        channelId: "cross-org-provider-reset",
+        conversationId: "cross-org-provider-reset",
+        userId: "watcher-test",
+        teamId: "telegram",
+        organizationId: "another-organization",
+        platform: "telegram",
+        timestamp: Date.now(),
+        error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        platformMetadata: {
+          connectionId: "chat-test",
+          chatId: "cross-org-provider-reset",
+          organizationId: "another-organization",
+          agentId,
+          behaviorId: watcherId,
+        },
+      },
+      "test-session"
+    );
+
+    expect((await cursorOf(watcherId)).getTime()).toBe(staleCursor.getTime());
+  });
+
+  it("does not park another agent's Behavior in the same organization", async () => {
+    const resetAt = new Date(Date.now() + 6 * 60 * 60 * 1000);
+    const providerReset = resetAt
+      .toISOString()
+      .replace("T", " ")
+      .replace(/\.\d{3}Z$/, "");
+    const { watcherId, staleCursor, organizationId } =
+      await createDueWatcherWithDispatchedRun({
+        slug: "reject-cross-agent-chat-parking",
+        messageId: "msg-cross-agent-provider-reset",
+        dispatchSource: "event",
+      });
+
+    await chatResponseBridge(organizationId).handleError(
+      {
+        messageId: "msg-cross-agent-provider-reset",
+        channelId: "cross-agent-provider-reset",
+        conversationId: "cross-agent-provider-reset",
+        userId: "watcher-test",
+        teamId: "telegram",
+        organizationId,
+        platform: "telegram",
+        timestamp: Date.now(),
+        error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        platformMetadata: {
+          connectionId: "chat-test",
+          chatId: "cross-agent-provider-reset",
+          organizationId,
+          agentId: "another-agent",
+          behaviorId: watcherId,
+        },
+      },
+      "test-session"
+    );
+
+    expect((await cursorOf(watcherId)).getTime()).toBe(staleCursor.getTime());
   });
 
   it("leaves the cursor alone while a finalize nudge requeues the run", async () => {

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -5,6 +5,7 @@ import { materializeDueWatcherRuns } from "../../../watchers/automation";
 import { resolveWatcherRunsByMessageIds } from "../../../watchers/run-completion";
 import {
   advanceWatcherSchedule,
+  deviceProviderQuotaResetNotBefore,
   parseProviderQuotaResetAt,
   providerQuotaResetNotBefore,
 } from "../../../watchers/schedule-cursor";
@@ -157,6 +158,22 @@ describe("provider quota reset parsing", () => {
     ).toBeNull();
   });
 
+  it("requires quota evidence for unclassified device stderr", () => {
+    const now = new Date("2026-07-31T10:00:00.000Z");
+    expect(
+      deviceProviderQuotaResetNotBefore(
+        "429 Limit Exhausted. Your limit will reset at 2026-07-31 12:00:00",
+        now
+      )?.toISOString()
+    ).toBe("2026-07-31T12:01:00.000Z");
+    expect(
+      deviceProviderQuotaResetNotBefore(
+        "Authentication session resets at 2026-07-31 12:00:00",
+        now
+      )
+    ).toBeNull();
+  });
+
   it("requires the structured quota code", () => {
     const message = "Your limit will reset at 2026-07-31 12:00:00";
     const now = new Date("2026-07-31T10:00:00.000Z");
@@ -222,10 +239,10 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
         userId: "watcher-test",
         teamId: "api",
         timestamp: Date.now(),
-        error: `429 Weekly/Monthly Limit Exhausted. Your limit will reset at ${providerReset}`,
+        error: "Message blocked by guardrail: require-tool",
+        bookkeepingError: `429 Weekly/Monthly Limit Exhausted. Your limit will reset at ${providerReset}`,
         errorCode: "PROVIDER_QUOTA_EXHAUSTED",
-      },
-      "test-session"
+      }
     );
 
     const sql = getTestDb();
@@ -359,28 +376,25 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
         dispatchSource: "event",
       });
 
-    await chatResponseBridge(organizationId).handleError(
-      {
-        messageId: "msg-chat-provider-reset",
-        channelId: "chat-provider-reset",
-        conversationId: "chat-provider-reset",
-        userId: "watcher-test",
-        teamId: "telegram",
+    await chatResponseBridge(organizationId).parkQuotaExhaustedBehavior({
+      messageId: "msg-chat-provider-reset",
+      channelId: "chat-provider-reset",
+      conversationId: "chat-provider-reset",
+      userId: "watcher-test",
+      teamId: "telegram",
+      organizationId,
+      platform: "telegram",
+      timestamp: Date.now(),
+      error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+      platformMetadata: {
+        connectionId: "chat-test",
+        chatId: "chat-provider-reset",
         organizationId,
-        platform: "telegram",
-        timestamp: Date.now(),
-        error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
-        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
-        platformMetadata: {
-          connectionId: "chat-test",
-          chatId: "chat-provider-reset",
-          organizationId,
-          agentId,
-          behaviorId: watcherId,
-        },
+        agentId,
+        behaviorId: watcherId,
       },
-      "test-session"
-    );
+    });
 
     const after = await cursorOf(watcherId);
     const expectedNotBefore =
@@ -401,28 +415,25 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
         dispatchSource: "event",
       });
 
-    await chatResponseBridge(organizationId).handleError(
-      {
-        messageId: "msg-cross-org-provider-reset",
-        channelId: "cross-org-provider-reset",
-        conversationId: "cross-org-provider-reset",
-        userId: "watcher-test",
-        teamId: "telegram",
+    await chatResponseBridge(organizationId).parkQuotaExhaustedBehavior({
+      messageId: "msg-cross-org-provider-reset",
+      channelId: "cross-org-provider-reset",
+      conversationId: "cross-org-provider-reset",
+      userId: "watcher-test",
+      teamId: "telegram",
+      organizationId: "another-organization",
+      platform: "telegram",
+      timestamp: Date.now(),
+      error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+      platformMetadata: {
+        connectionId: "chat-test",
+        chatId: "cross-org-provider-reset",
         organizationId: "another-organization",
-        platform: "telegram",
-        timestamp: Date.now(),
-        error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
-        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
-        platformMetadata: {
-          connectionId: "chat-test",
-          chatId: "cross-org-provider-reset",
-          organizationId: "another-organization",
-          agentId,
-          behaviorId: watcherId,
-        },
+        agentId,
+        behaviorId: watcherId,
       },
-      "test-session"
-    );
+    });
 
     expect((await cursorOf(watcherId)).getTime()).toBe(staleCursor.getTime());
   });
@@ -440,28 +451,25 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
         dispatchSource: "event",
       });
 
-    await chatResponseBridge(organizationId).handleError(
-      {
-        messageId: "msg-cross-agent-provider-reset",
-        channelId: "cross-agent-provider-reset",
-        conversationId: "cross-agent-provider-reset",
-        userId: "watcher-test",
-        teamId: "telegram",
+    await chatResponseBridge(organizationId).parkQuotaExhaustedBehavior({
+      messageId: "msg-cross-agent-provider-reset",
+      channelId: "cross-agent-provider-reset",
+      conversationId: "cross-agent-provider-reset",
+      userId: "watcher-test",
+      teamId: "telegram",
+      organizationId,
+      platform: "telegram",
+      timestamp: Date.now(),
+      error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+      platformMetadata: {
+        connectionId: "chat-test",
+        chatId: "cross-agent-provider-reset",
         organizationId,
-        platform: "telegram",
-        timestamp: Date.now(),
-        error: `429 Limit Exhausted. Your limit will reset at ${providerReset}`,
-        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
-        platformMetadata: {
-          connectionId: "chat-test",
-          chatId: "cross-agent-provider-reset",
-          organizationId,
-          agentId: "another-agent",
-          behaviorId: watcherId,
-        },
+        agentId: "another-agent",
+        behaviorId: watcherId,
       },
-      "test-session"
-    );
+    });
 
     expect((await cursorOf(watcherId)).getTime()).toBe(staleCursor.getTime());
   });

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { ApiResponseRenderer } from "../../../gateway/api/response-renderer";
 import { materializeDueWatcherRuns } from "../../../watchers/automation";
 import { resolveWatcherRunsByMessageIds } from "../../../watchers/run-completion";
-import { advanceWatcherSchedule } from "../../../watchers/schedule-cursor";
+import {
+  advanceWatcherSchedule,
+  parseProviderQuotaResetAt,
+} from "../../../watchers/schedule-cursor";
 import { getTestDb } from "../../setup/test-db";
 import { createTestAgent, createTestEntity } from "../../setup/test-fixtures";
 import { TestWorkspace } from "../../setup/test-mcp-client";
@@ -82,6 +86,37 @@ async function cursorOf(watcherId: number): Promise<Date> {
   return new Date(row.next_run_at as string);
 }
 
+describe("provider quota reset parsing", () => {
+  it("treats a date-only reset as UTC and adds boundary grace", () => {
+    const reset = parseProviderQuotaResetAt(
+      "429 Limit Exhausted. Your limit will reset at 2026-07-31",
+      new Date("2026-07-30T12:00:00.000Z")
+    );
+
+    expect(reset?.toISOString()).toBe("2026-07-31T00:01:00.000Z");
+  });
+
+  it("ignores missing or already-past reset timestamps", () => {
+    const now = new Date("2026-07-31T12:00:00.000Z");
+
+    expect(parseProviderQuotaResetAt("429 Limit Exhausted", now)).toBeNull();
+    expect(
+      parseProviderQuotaResetAt("Your limit will reset at 2026-07-31", now)
+    ).toBeNull();
+  });
+
+  it("keeps the boundary grace when the reset time just passed", () => {
+    const now = new Date("2026-07-31T12:00:30.000Z");
+
+    expect(
+      parseProviderQuotaResetAt(
+        "Your limit will reset at 2026-07-31 12:00:00",
+        now
+      )?.toISOString()
+    ).toBe("2026-07-31T12:01:00.000Z");
+  });
+});
+
 describe("a terminally failed Behavior run advances next_run_at", () => {
   it("advances the cursor when the agent turn returns an error", async () => {
     const { watcherId, runId, staleCursor } =
@@ -105,6 +140,44 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
     const after = await cursorOf(watcherId);
     expect(after.getTime()).toBeGreaterThan(staleCursor.getTime());
     expect(after.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("parks a quota-exhausted Behavior through the provider reset boundary", async () => {
+    const resetAt = new Date(Date.now() + 6 * 60 * 60 * 1000);
+    const providerReset = resetAt
+      .toISOString()
+      .replace("T", " ")
+      .replace(/\.\d{3}Z$/, "");
+    const { watcherId, runId } = await createDueWatcherWithDispatchedRun({
+      slug: "park-until-provider-reset",
+      messageId: "msg-provider-reset",
+    });
+
+    const renderer = new ApiResponseRenderer({
+      broadcast() {},
+    } as unknown as ConstructorParameters<typeof ApiResponseRenderer>[0]);
+    await renderer.handleError(
+      {
+        messageId: "msg-provider-reset",
+        channelId: "api-provider-reset",
+        conversationId: "api-provider-reset",
+        userId: "watcher-test",
+        teamId: "api",
+        timestamp: Date.now(),
+        error: `429 Weekly/Monthly Limit Exhausted. Your limit will reset at ${providerReset}`,
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+      },
+      "test-session"
+    );
+
+    const sql = getTestDb();
+    const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+
+    const after = await cursorOf(watcherId);
+    const expectedNotBefore =
+      Math.floor(resetAt.getTime() / 1000) * 1000 + 60_000;
+    expect(after.getTime()).toBe(expectedNotBefore);
   });
 
   it("advances the cursor when the agent never calls complete_window", async () => {

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -115,6 +115,21 @@ describe("provider quota reset parsing", () => {
       )?.toISOString()
     ).toBe("2026-07-31T12:01:00.000Z");
   });
+
+  it.each([
+    "2026-02-31",
+    "2026-07-31 24:00:00",
+    "2026-07-31 12:60:00",
+    "2026-07-31 12:00:60",
+    "2026-07-31 12:00:00+24:00",
+  ])("rejects invalid reset timestamp %s", (timestamp) => {
+    expect(
+      parseProviderQuotaResetAt(
+        `Your limit will reset at ${timestamp}`,
+        new Date("2026-01-01T00:00:00.000Z")
+      )
+    ).toBeNull();
+  });
 });
 
 describe("a terminally failed Behavior run advances next_run_at", () => {

--- a/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
+++ b/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
@@ -38,6 +38,7 @@ function createConsumer(overrides?: {
   };
   const sseManager = {
     broadcast: mock(() => undefined),
+    hasActiveConnection: mock(() => true),
   };
   const consumer = new UnifiedThreadResponseConsumer(
     queue as any,
@@ -425,12 +426,52 @@ describe("UnifiedThreadResponseConsumer dead-letters instead of silent drops", (
   });
 });
 
+describe("UnifiedThreadResponseConsumer API guardrail bookkeeping", () => {
+  test("preserves the raw provider error while redacting user-visible output", async () => {
+    const handleError = mock(async () => undefined);
+    const { consumer } = createConsumer({
+      renderer: { handleError, handleCompletion: mock(async () => undefined) },
+    });
+    const scanner = (consumer as any).outputGuardrail;
+    scanner.registry = {};
+    scanner.settingsStore = {};
+    scanner.scanFinal = mock(async () => ({
+      guardrail: "require-tool",
+      reason: "required tool was not called",
+    }));
+
+    const raw =
+      "429 Limit Exhausted. Your limit will reset at 2026-08-04 06:00:00";
+    await consumer.handleThreadResponse({
+      id: "job-api-quota",
+      data: {
+        messageId: "m-api-quota",
+        channelId: "api:quota",
+        conversationId: "api:quota",
+        userId: "u1",
+        teamId: "api",
+        platform: "api",
+        timestamp: 0,
+        error: raw,
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        toolsUsed: [],
+        platformMetadata: { agentId: "agent-1", organizationId: "org-1" },
+      },
+    });
+
+    const delivered = handleError.mock.calls[0]?.[0] as any;
+    expect(delivered.error).toMatch(/Message blocked by guardrail/);
+    expect(delivered.bookkeepingError).toBe(raw);
+  });
+});
+
 describe("UnifiedThreadResponseConsumer Chat SDK hydrate-on-claim", () => {
   test("throws for Chat SDK connection responses this replica cannot serve", async () => {
     // ensureDeliverable=false means hydration failed (deleted/stopped row or
     // an exclusive transport leased elsewhere) — fail the job so the retry
     // can land on a replica that can serve it.
     const chatResponseBridge = {
+      parkQuotaExhaustedBehavior: mock(async () => undefined),
       ensureDeliverable: mock(async () => false),
       handleCompletion: mock(async () => undefined),
       handleError: mock(async () => undefined),
@@ -446,8 +487,36 @@ describe("UnifiedThreadResponseConsumer Chat SDK hydrate-on-claim", () => {
     expect(platformRegistry.get).not.toHaveBeenCalled();
   });
 
+  test("parks quota errors before checking whether the chat connection is deliverable", async () => {
+    const chatResponseBridge = {
+      parkQuotaExhaustedBehavior: mock(async () => undefined),
+      ensureDeliverable: mock(async () => false),
+      handleCompletion: mock(async () => undefined),
+      handleError: mock(async () => undefined),
+    };
+    const { consumer } = createConsumer({ chatResponseBridge });
+
+    await expect(
+      consumer.handleThreadResponse({
+        id: "job-quota",
+        data: {
+          ...basePayload,
+          processedMessageIds: undefined,
+          error:
+            "429 Limit Exhausted. Your limit will reset at 2026-08-04 06:00:00",
+          errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        },
+      })
+    ).rejects.toThrow(/cannot be served by this gateway instance/);
+
+    expect(chatResponseBridge.parkQuotaExhaustedBehavior).toHaveBeenCalledTimes(1);
+    expect(chatResponseBridge.ensureDeliverable).toHaveBeenCalledTimes(1);
+    expect(chatResponseBridge.handleError).not.toHaveBeenCalled();
+  });
+
   test("routes Chat SDK responses after hydrating on the claiming replica", async () => {
     const chatResponseBridge = {
+      parkQuotaExhaustedBehavior: mock(async () => undefined),
       ensureDeliverable: mock(async () => true),
       handleCompletion: mock(async () => undefined),
       handleError: mock(async () => undefined),

--- a/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
@@ -90,6 +90,7 @@ function mintToken(opts?: {
   omitOrganizationId?: boolean;
   omitConnectionId?: boolean;
   omitResponseThreadId?: boolean;
+  runId?: number;
 }): string {
   return generateWorkerToken("user-1", "conv-1", DEPLOYMENT, {
     channelId: "chan-1",
@@ -102,7 +103,7 @@ function mintToken(opts?: {
     ...(opts?.omitResponseThreadId
       ? {}
       : { responseThreadId: "slack:chan-1:conv-1" }),
-    runId: 1,
+    runId: opts?.runId ?? 1,
     messageId: "m1",
   });
 }
@@ -128,6 +129,7 @@ async function postWorkerResponse(
     omitTokenOrganizationId?: boolean;
     omitTokenConnectionId?: boolean;
     omitTokenResponseThreadId?: boolean;
+    tokenRunId?: number;
   }
 ): Promise<Response> {
   const gateway = makeGateway();
@@ -140,6 +142,7 @@ async function postWorkerResponse(
           omitOrganizationId: opts?.omitTokenOrganizationId,
           omitConnectionId: opts?.omitTokenConnectionId,
           omitResponseThreadId: opts?.omitTokenResponseThreadId,
+          runId: opts?.tokenRunId,
         })}`,
         host: "gateway.example.com",
         "content-type": "application/json",
@@ -282,6 +285,69 @@ describe("POST /worker/response — authoritative tenant", () => {
     });
   });
 
+  test("binds reply Behavior routing to the signed turn row, not worker metadata", async () => {
+    await armLiveTurn("m1");
+    const trustedRunId = Number(
+      await queue.send(`thread_message_${DEPLOYMENT}`, {
+        userId: "user-1",
+        conversationId: "conv-1",
+        messageId: "m1",
+        channelId: "chan-1",
+        teamId: "team-1",
+        agentId: "agent-1",
+        organizationId: "org-1",
+        platform: "slack",
+        platformMetadata: { behaviorId: 41 },
+      })
+    );
+
+    const res = await postWorkerResponse(
+      {
+        messageId: "m1",
+        conversationId: "conv-spoofed",
+        error: "429 Limit Exhausted. Your limit will reset at 2026-08-04 06:00:00",
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        platformMetadata: { behaviorId: 99 },
+      },
+      { tokenRunId: trustedRunId }
+    );
+    expect(res.status).toBe(200);
+
+    const { input } = await latestThreadResponse();
+    expect(input.platformMetadata?.behaviorId).toBe(41);
+  });
+
+  test("drops reply Behavior routing when the signed turn row has no Behavior", async () => {
+    await armLiveTurn("m1");
+    const trustedRunId = Number(
+      await queue.send(`thread_message_${DEPLOYMENT}`, {
+        userId: "user-1",
+        conversationId: "conv-1",
+        messageId: "m1",
+        channelId: "chan-1",
+        teamId: "team-1",
+        agentId: "agent-1",
+        organizationId: "org-1",
+        platform: "slack",
+        platformMetadata: {},
+      })
+    );
+
+    const res = await postWorkerResponse(
+      {
+        messageId: "m1",
+        error: "429 Limit Exhausted. Your limit will reset at 2026-08-04 06:00:00",
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        platformMetadata: { behaviorId: 99 },
+      },
+      { tokenRunId: trustedRunId }
+    );
+    expect(res.status).toBe(200);
+
+    const { input } = await latestThreadResponse();
+    expect(input.platformMetadata?.behaviorId).toBeUndefined();
+  });
+
   test("an orgless worker token cannot inject a body organization id", async () => {
     const res = await postWorkerResponse(
       {
@@ -312,6 +378,7 @@ describe("POST /worker/response — authoritative tenant", () => {
           chatId: "C-SPOOFED",
           responseThreadId: "thread-spoofed",
           senderId: "sender-spoofed",
+          behaviorId: 99,
         },
         customEvent: {
           name: "chat-interaction",

--- a/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
+++ b/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
@@ -72,6 +72,16 @@ describe("ApiResponseRenderer.handleCompletion finalText repair", () => {
     const complete = broadcasts.find((b) => b.event === "complete");
     expect(complete?.data.finalText).toBeUndefined();
   });
+
+  test("retries durable run resolution before broadcasting completion", async () => {
+    const { renderer, broadcasts } = makeRenderer();
+    resolveRunsMock.mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(
+      renderer.handleCompletion(basePayload({ finalText: "done" }), "session-key")
+    ).rejects.toThrow("database unavailable");
+    expect(broadcasts).toEqual([]);
+  });
 });
 
 describe("ApiResponseRenderer.handleCompletion suggestion embed", () => {

--- a/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
+++ b/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
@@ -12,6 +12,11 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { ApiResponseRenderer } from "../response-renderer.js";
 import type { ThreadResponsePayload } from "../../infrastructure/queue/types.js";
 
+const resolveRunsMock = mock(async () => ({ resolved: 0 }));
+mock.module("../../../watchers/run-completion.js", () => ({
+  resolveWatcherRunsByMessageIds: resolveRunsMock,
+}));
+
 function makeRenderer() {
   const broadcasts: Array<{ key: string; event: string; data: any }> = [];
   const sseManager = {
@@ -22,6 +27,11 @@ function makeRenderer() {
   const renderer = new ApiResponseRenderer(sseManager as never);
   return { renderer, broadcasts };
 }
+
+beforeEach(() => {
+  resolveRunsMock.mockReset();
+  resolveRunsMock.mockResolvedValue({ resolved: 0 });
+});
 
 const basePayload = (over: Partial<ThreadResponsePayload>): ThreadResponsePayload =>
   ({
@@ -140,5 +150,21 @@ describe("ApiResponseRenderer.handleError targeting context", () => {
         errorContext: { provider: "z-ai", model: "glm-5.2" },
       });
     }
+  });
+
+  test("retries durable run resolution before broadcasting an error", async () => {
+    const { renderer, broadcasts } = makeRenderer();
+    resolveRunsMock.mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(
+      renderer.handleError(
+        basePayload({
+          error: "Your limit will reset at 2026-08-04 12:00:00",
+          errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        }),
+        "session-key"
+      )
+    ).rejects.toThrow("database unavailable");
+    expect(broadcasts).toEqual([]);
   });
 });

--- a/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
+++ b/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
@@ -135,6 +135,7 @@ describe("ApiResponseRenderer.handleCompletion suggestion embed", () => {
     // undefined = "no change" to the SPA.
     expect(broadcasts.find((b) => b.event === "complete")?.data.suggestions).toBeUndefined();
     expect(readMock).not.toHaveBeenCalled();
+    expect(resolveRunsMock).not.toHaveBeenCalled();
   });
 });
 
@@ -160,6 +161,27 @@ describe("ApiResponseRenderer.handleError targeting context", () => {
         errorContext: { provider: "z-ai", model: "glm-5.2" },
       });
     }
+  });
+
+  test("uses raw provider text only for quota parsing, not persisted run text", async () => {
+    const { renderer } = makeRenderer();
+    const raw = "429 Limit Exhausted. Your limit will reset at 2026-08-04 12:00:00";
+
+    await renderer.handleError(basePayload({
+      error: "Message blocked by guardrail: require-tool",
+      bookkeepingError: raw,
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+    }), "session-key");
+
+    expect(resolveRunsMock).toHaveBeenCalledWith(
+      new Set(["m1"]),
+      {
+        ok: false,
+        error: "Message blocked by guardrail: require-tool",
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        quotaResetError: raw,
+      }
+    );
   });
 
   test("retries durable run resolution before broadcasting an error", async () => {

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -178,6 +178,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
       await this.resolveWatcherRunsFromPayload(payload, {
         ok: false,
         error: "agent error",
+        errorCode: code,
       });
       return;
     }
@@ -205,6 +206,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
     await this.resolveWatcherRunsFromPayload(payload, {
       ok: false,
       error: typeof errorText === "string" ? errorText : "agent error",
+      errorCode: code,
     });
   }
 
@@ -217,7 +219,9 @@ export class ApiResponseRenderer implements ResponseRenderer {
    */
   private async resolveWatcherRunsFromPayload(
     payload: ThreadResponsePayload,
-    result: { ok: true } | { ok: false; error: string }
+    result:
+      | { ok: true }
+      | { ok: false; error: string; errorCode?: string }
   ): Promise<void> {
     const ids = new Set<string>();
     if (payload.messageId) ids.add(payload.messageId);

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -81,6 +81,11 @@ export class ApiResponseRenderer implements ResponseRenderer {
       return;
     }
 
+    // Complete durable Behavior bookkeeping before delivering the terminal SSE
+    // event. A database failure must reject the thread-response job so it can
+    // retry; delivering first would acknowledge the turn with its run still due.
+    await this.resolveWatcherRunsFromPayload(payload, { ok: true });
+
     // Resolve the current suggestion set for this conversation and decide
     // whether to attach it to `complete` (this turn produced it), clear it
     // (this turn produced none — stale chips must not linger), or leave it
@@ -110,8 +115,6 @@ export class ApiResponseRenderer implements ResponseRenderer {
     });
 
     logger.info(`Broadcast completion to session ${sessionId}`);
-
-    await this.resolveWatcherRunsFromPayload(payload, { ok: true });
   }
 
   /**
@@ -186,6 +189,12 @@ export class ApiResponseRenderer implements ResponseRenderer {
       spec?.message ??
       labelProviderErrorBody(payload.error, payload.errorContext?.provider);
 
+    await this.resolveWatcherRunsFromPayload(payload, {
+      ok: false,
+      error: typeof errorText === "string" ? errorText : "agent error",
+      errorCode: code,
+    });
+
     const errorEvent = {
       type: "error",
       error: errorText,
@@ -202,12 +211,6 @@ export class ApiResponseRenderer implements ResponseRenderer {
     this.sseManager.broadcast(sessionId, "agent-error", errorEvent);
 
     logger.error(`Broadcast error to session ${sessionId}: ${errorText}`);
-
-    await this.resolveWatcherRunsFromPayload(payload, {
-      ok: false,
-      error: typeof errorText === "string" ? errorText : "agent error",
-      errorCode: code,
-    });
   }
 
   /**
@@ -228,13 +231,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
     for (const id of payload.processedMessageIds ?? []) {
       if (id) ids.add(id);
     }
-    try {
-      await resolveWatcherRunsByMessageIds(ids, result);
-    } catch (error) {
-      logger.error("Failed to resolve watcher runs from terminal API payload", {
-        error,
-      });
-    }
+    await resolveWatcherRunsByMessageIds(ids, result);
   }
 
   /**

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -83,7 +83,8 @@ export class ApiResponseRenderer implements ResponseRenderer {
 
     // Complete durable Behavior bookkeeping before delivering the terminal SSE
     // event. A database failure must reject the thread-response job so it can
-    // retry; delivering first would acknowledge the turn with its run still due.
+    // retry; delivering first could acknowledge a turn whose run is unresolved
+    // and whose schedule is still due.
     await this.resolveWatcherRunsFromPayload(payload, { ok: true });
 
     // Resolve the current suggestion set for this conversation and decide
@@ -191,7 +192,9 @@ export class ApiResponseRenderer implements ResponseRenderer {
 
     await this.resolveWatcherRunsFromPayload(payload, {
       ok: false,
-      error: typeof errorText === "string" ? errorText : "agent error",
+      error:
+        payload.bookkeepingError ??
+        (typeof errorText === "string" ? errorText : "agent error"),
       errorCode: code,
     });
 

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -81,11 +81,16 @@ export class ApiResponseRenderer implements ResponseRenderer {
       return;
     }
 
-    // Complete durable Behavior bookkeeping before delivering the terminal SSE
-    // event. A database failure must reject the thread-response job so it can
-    // retry; delivering first could acknowledge a turn whose run is unresolved
-    // and whose schedule is still due.
-    await this.resolveWatcherRunsFromPayload(payload, { ok: true });
+    // Error rows are terminalized in handleError before delivery. Running the
+    // success resolver again after the error was already broadcast creates a
+    // redundant DB dependency and can cause duplicate delivery on retry.
+    if (!payload.error) {
+      // Complete durable Behavior bookkeeping before delivering the terminal SSE
+      // event. A database failure must reject the thread-response job so it can
+      // retry; delivering first could acknowledge a turn whose run is unresolved
+      // and whose schedule is still due.
+      await this.resolveWatcherRunsFromPayload(payload, { ok: true });
+    }
 
     // Resolve the current suggestion set for this conversation and decide
     // whether to attach it to `complete` (this turn produced it), clear it
@@ -192,10 +197,12 @@ export class ApiResponseRenderer implements ResponseRenderer {
 
     await this.resolveWatcherRunsFromPayload(payload, {
       ok: false,
-      error:
-        payload.bookkeepingError ??
-        (typeof errorText === "string" ? errorText : "agent error"),
+      // Persist only the guarded/user-visible text. The raw provider string is
+      // used solely to parse a reset boundary and must never reappear through
+      // Behavior run metadata.
+      error: typeof errorText === "string" ? errorText : "agent error",
       errorCode: code,
+      quotaResetError: payload.bookkeepingError,
     });
 
     const errorEvent = {
@@ -227,7 +234,12 @@ export class ApiResponseRenderer implements ResponseRenderer {
     payload: ThreadResponsePayload,
     result:
       | { ok: true }
-      | { ok: false; error: string; errorCode?: string }
+      | {
+          ok: false;
+          error: string;
+          errorCode?: string;
+          quotaResetError?: string;
+        }
   ): Promise<void> {
     const ids = new Set<string>();
     if (payload.messageId) ids.add(payload.messageId);

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -176,8 +176,8 @@ export class ChatResponseBridge implements ResponseRenderer {
    * hits a known provider quota boundary. These turns intentionally have no
    * Behavior run row, so the API run terminalizer cannot move their cursor.
    *
-   * The worker-carried Behavior id is never trusted by itself: the authenticated
-   * gateway-stamped organization and agent must own it. Database errors propagate
+   * The gateway-restored Behavior id is still scoped to the authenticated
+   * organization and agent that own it. Database errors propagate
    * so the durable thread-response job retries instead of delivering an error
    * while leaving the Behavior immediately due.
    */

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -181,9 +181,8 @@ export class ChatResponseBridge implements ResponseRenderer {
    * so the durable thread-response job retries instead of delivering an error
    * while leaving the Behavior immediately due.
    */
-  private async parkQuotaExhaustedBehavior(
-    payload: ThreadResponsePayload,
-    ctx: ResponseContext
+  async parkQuotaExhaustedBehavior(
+    payload: ThreadResponsePayload
   ): Promise<void> {
     const notBefore = providerQuotaResetNotBefore(
       payload.error ?? "",
@@ -191,7 +190,8 @@ export class ChatResponseBridge implements ResponseRenderer {
     );
     if (!notBefore) return;
 
-    const behaviorId = readPlatformMetadata(payload.platformMetadata).behaviorId;
+    const metadata = readPlatformMetadata(payload.platformMetadata);
+    const behaviorId = metadata.behaviorId;
     if (
       typeof behaviorId !== "number" ||
       !Number.isSafeInteger(behaviorId) ||
@@ -200,10 +200,9 @@ export class ChatResponseBridge implements ResponseRenderer {
       return;
     }
 
-    const organizationId = this.resolveOrganizationId(payload, ctx);
-    if (!organizationId) return;
-    const agentId = this.resolveAgentId(payload, ctx);
-    if (!agentId) return;
+    const organizationId = payload.organizationId ?? metadata.organizationId;
+    const agentId = metadata.agentId;
+    if (!organizationId || !agentId) return;
 
     const sql = getDb();
     await sql.begin(async (tx) => {
@@ -696,8 +695,6 @@ export class ChatResponseBridge implements ResponseRenderer {
 
     const ctx = this.extractResponseContext(payload);
     if (!ctx) return;
-
-    await this.parkQuotaExhaustedBehavior(payload, ctx);
 
     const { connectionId, channelId } = ctx;
     const key = `${channelId}:${payload.conversationId}`;

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -24,6 +24,10 @@ import {
   type RenderedAgentError,
   renderAgentError,
 } from "../../utils/url-builder.js";
+import {
+  advanceScheduleAfterTerminalFailure,
+  providerQuotaResetNotBefore,
+} from "../../watchers/schedule-cursor.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import {
   OutputGuardrailScanner,
@@ -165,6 +169,61 @@ export class ChatResponseBridge implements ResponseRenderer {
     return typeof fromConnection === "string" && fromConnection
       ? fromConnection
       : undefined;
+  }
+
+  /**
+   * Park the scheduled side of a reply-to-source Behavior when its event turn
+   * hits a known provider quota boundary. These turns intentionally have no
+   * Behavior run row, so the API run terminalizer cannot move their cursor.
+   *
+   * The worker-carried Behavior id is never trusted by itself: the authenticated
+   * gateway-stamped organization and agent must own it. Database errors propagate
+   * so the durable thread-response job retries instead of delivering an error
+   * while leaving the Behavior immediately due.
+   */
+  private async parkQuotaExhaustedBehavior(
+    payload: ThreadResponsePayload,
+    ctx: ResponseContext
+  ): Promise<void> {
+    const notBefore = providerQuotaResetNotBefore(
+      payload.error ?? "",
+      payload.errorCode
+    );
+    if (!notBefore) return;
+
+    const behaviorId = readPlatformMetadata(payload.platformMetadata).behaviorId;
+    if (
+      typeof behaviorId !== "number" ||
+      !Number.isSafeInteger(behaviorId) ||
+      behaviorId < 1
+    ) {
+      return;
+    }
+
+    const organizationId = this.resolveOrganizationId(payload, ctx);
+    if (!organizationId) return;
+    const agentId = this.resolveAgentId(payload, ctx);
+    if (!agentId) return;
+
+    const sql = getDb();
+    await sql.begin(async (tx) => {
+      const owned = await tx<{ id: number }>`
+        SELECT id
+        FROM watchers
+        WHERE id = ${behaviorId}
+          AND organization_id = ${organizationId}
+          AND agent_id = ${agentId}
+          AND status = 'active'
+        LIMIT 1
+      `;
+      if (owned.length === 0) return;
+      await advanceScheduleAfterTerminalFailure(
+        tx,
+        behaviorId,
+        "event",
+        notBefore
+      );
+    });
   }
 
   /**
@@ -637,6 +696,8 @@ export class ChatResponseBridge implements ResponseRenderer {
 
     const ctx = this.extractResponseContext(payload);
     if (!ctx) return;
+
+    await this.parkQuotaExhaustedBehavior(payload, ctx);
 
     const { connectionId, channelId } = ctx;
     const key = `${channelId}:${payload.conversationId}`;

--- a/packages/server/src/gateway/connections/platform-metadata.ts
+++ b/packages/server/src/gateway/connections/platform-metadata.ts
@@ -54,8 +54,9 @@ export interface PlatformMetadata {
   /** Outbound: client-side message id correlation. */
   clientMessageId?: string;
   /**
-   * Inbound Behavior id for reply-to-source delivery. Treat it as untrusted
-   * until the response bridge scopes it to the authenticated organization and agent.
+   * Per-turn Behavior id for reply-to-source delivery. Worker responses must
+   * restore it from the durable row named by the signed per-run token, never
+   * from the response body; the response bridge also verifies ownership.
    */
   behaviorId?: number;
 }

--- a/packages/server/src/gateway/connections/platform-metadata.ts
+++ b/packages/server/src/gateway/connections/platform-metadata.ts
@@ -54,9 +54,9 @@ export interface PlatformMetadata {
   /** Outbound: client-side message id correlation. */
   clientMessageId?: string;
   /**
-   * Per-turn Behavior id for reply-to-source delivery. Worker responses must
-   * restore it from the durable row named by the signed per-run token, never
-   * from the response body; the response bridge also verifies ownership.
+   * Per-turn Behavior id for reply-to-source delivery. The gateway restores it
+   * from the durable row named by the signed per-run token, never from the
+   * response body; the response bridge also verifies ownership.
    */
   behaviorId?: number;
 }

--- a/packages/server/src/gateway/connections/platform-metadata.ts
+++ b/packages/server/src/gateway/connections/platform-metadata.ts
@@ -53,6 +53,11 @@ export interface PlatformMetadata {
   traceparent?: string;
   /** Outbound: client-side message id correlation. */
   clientMessageId?: string;
+  /**
+   * Inbound Behavior id for reply-to-source delivery. Treat it as untrusted
+   * until the response bridge scopes it to the authenticated organization and agent.
+   */
+  behaviorId?: number;
 }
 
 /**

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -372,11 +372,12 @@ export class WorkerGateway {
    * Resolve the reply-to-source Behavior selected for this exact queued turn.
    *
    * platformMetadata in a worker response is attacker-controlled. The signed
-   * per-run token carries only runs.id; re-reading that durable gateway-written
-   * row binds the Behavior id to the planner decision without putting per-turn
-   * state on the deployment-lifetime fallback token. Missing per-run identity
-   * degrades safely to no schedule mutation. Database errors propagate so a
-   * terminal quota reply is retried rather than delivered with an untrusted id.
+   * per-run token carries the queued runs.id rather than a Behavior id;
+   * re-reading that durable gateway-written row binds the Behavior id to the
+   * planner decision without putting per-turn state on the deployment-lifetime
+   * fallback token. Missing per-run identity degrades safely to no schedule
+   * mutation. Database errors propagate so a terminal quota reply is retried
+   * rather than delivered with an untrusted id.
    */
   private async resolveTrustedBehaviorId(
     tokenData: WorkerTokenData

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -6,6 +6,7 @@ import type {
   WorkerTokenData,
 } from "@lobu/core";
 import {
+  AgentErrorCode,
 	createLogger,
 	generateWorkerToken,
 	encrypt,
@@ -14,6 +15,7 @@ import {
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
+import { getDb } from "../../db/client.js";
 import { bindRequestAbortToStream } from "../../events/sse-abort-bridge.js";
 import {
   BEHAVIOR_RUN_SOURCE,
@@ -367,6 +369,71 @@ export class WorkerGateway {
   }
 
   /**
+   * Resolve the reply-to-source Behavior selected for this exact queued turn.
+   *
+   * platformMetadata in a worker response is attacker-controlled. The signed
+   * per-run token carries only runs.id; re-reading that durable gateway-written
+   * row binds the Behavior id to the planner decision without putting per-turn
+   * state on the deployment-lifetime fallback token. Missing per-run identity
+   * degrades safely to no schedule mutation. Database errors propagate so a
+   * terminal quota reply is retried rather than delivered with an untrusted id.
+   */
+  private async resolveTrustedBehaviorId(
+    tokenData: WorkerTokenData
+  ): Promise<number | undefined> {
+    const { runId, organizationId, agentId, messageId } = tokenData;
+    if (
+      typeof runId !== "number" ||
+      !Number.isSafeInteger(runId) ||
+      runId < 1 ||
+      !organizationId ||
+      !agentId
+    ) {
+      return undefined;
+    }
+
+    const rows = await getDb()<{
+      payload: {
+        organizationId?: unknown;
+        agentId?: unknown;
+        messageId?: unknown;
+        platformMetadata?: unknown;
+      } | null;
+    }>`
+      SELECT CASE
+        WHEN jsonb_typeof(action_input) = 'string'
+          THEN (action_input #>> '{}')::jsonb
+        ELSE action_input
+      END AS payload
+      FROM public.runs
+      WHERE id = ${runId}
+        AND run_type = 'chat_message'
+        AND organization_id = ${organizationId}
+      LIMIT 1
+    `;
+    const payload = rows[0]?.payload;
+    if (
+      !payload ||
+      payload.organizationId !== organizationId ||
+      payload.agentId !== agentId ||
+      (messageId && payload.messageId !== messageId)
+    ) {
+      return undefined;
+    }
+
+    const metadata = payload.platformMetadata;
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+      return undefined;
+    }
+    const behaviorId = (metadata as { behaviorId?: unknown }).behaviorId;
+    return typeof behaviorId === "number" &&
+      Number.isSafeInteger(behaviorId) &&
+      behaviorId > 0
+      ? behaviorId
+      : undefined;
+  }
+
+  /**
    * Handle HTTP response from worker
    */
   private async handleWorkerResponse(c: Context): Promise<Response> {
@@ -389,6 +456,10 @@ export class WorkerGateway {
       // token and retain only non-routing metadata from the body. In particular,
       // an absent connectionId must remove a body-supplied value rather than
       // turning a non-chat run into a cross-tenant Chat delivery.
+      const trustedBehaviorId =
+        responseData.errorCode === AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED
+          ? await this.resolveTrustedBehaviorId(auth.tokenData)
+          : undefined;
       const tokenRouting = {
         userId: auth.tokenData.userId,
         conversationId: auth.tokenData.conversationId,
@@ -407,6 +478,7 @@ export class WorkerGateway {
         teamId: tokenRouting.teamId,
         source: auth.tokenData.source,
         senderId: tokenRouting.userId,
+        behaviorId: trustedBehaviorId,
       };
       const platformMetadata =
         responseData.platformMetadata &&

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -222,6 +222,9 @@ export class UnifiedThreadResponseConsumer {
       // polling transport leased to another replica) — then fail the job so the retry lands
       // somewhere that can, instead of silently completing an undelivered reply.
       const chatConnectionId = data.platformMetadata?.connectionId as string | undefined;
+      if (chatConnectionId && data.error) {
+        await this.chatResponseBridge?.parkQuotaExhaustedBehavior(data);
+      }
       if (await this.chatResponseBridge?.ensureDeliverable(data)) {
         const sessionKey = `${data.userId}:${data.originalMessageId || data.messageId}`;
         await this.routeToRenderer(this.chatResponseBridge!, data, sessionKey);
@@ -397,6 +400,13 @@ export class UnifiedThreadResponseConsumer {
     const isApiRow =
       (data.platform || data.teamId) === "api" &&
       !data.platformMetadata?.connectionId;
+
+    // Preserve the original terminal error before output guardrails replace the
+    // user-visible text. The API renderer consumes this field only for durable
+    // Behavior scheduling; it is never included in an SSE event.
+    if (typeof data.error === "string") {
+      data = { ...data, bookkeepingError: data.error };
+    }
 
     // Finalize the conversation's suggestion set at the terminal boundary,
     // BEFORE the SSE owner-gate below. This must run whether or not any pod

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -10,7 +10,13 @@ import {
 
 type WatcherTerminalResult =
 	| { ok: true }
-	| { ok: false; error: string; errorCode?: string };
+	| {
+			ok: false;
+			error: string;
+			errorCode?: string;
+			/** Raw provider text used only to parse a quota reset boundary. */
+			quotaResetError?: string;
+		};
 
 /**
  * How many times a watcher run that finished its agent turn WITHOUT calling
@@ -251,7 +257,7 @@ export async function resolveWatcherRunsByMessageIds(
 
 		if (!result.ok) {
 			const notBefore = providerQuotaResetNotBefore(
-				result.error,
+				result.quotaResetError ?? result.error,
 				result.errorCode
 			);
 			if (

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -1,11 +1,17 @@
+import { AgentErrorCode } from "@lobu/core";
 import type { DbClient } from "../db/client";
 import { getDb, pgTextArray } from "../db/client";
 import { listPendingToolsForRun } from "../gateway/auth/mcp/pending-tool-store";
 import logger from "../utils/logger";
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
-import { advanceScheduleAfterTerminalFailure } from "./schedule-cursor";
+import {
+	advanceScheduleAfterTerminalFailure,
+	parseProviderQuotaResetAt,
+} from "./schedule-cursor";
 
-type WatcherTerminalResult = { ok: true } | { ok: false; error: string };
+type WatcherTerminalResult =
+	| { ok: true }
+	| { ok: false; error: string; errorCode?: string };
 
 /**
  * How many times a watcher run that finished its agent turn WITHOUT calling
@@ -159,7 +165,8 @@ export async function markWatcherRunCompleted(
 async function markWatcherRunFailed(
 	sql: DbClient,
 	runId: number,
-	message: string
+	message: string,
+	notBefore?: Date | null
 ): Promise<boolean> {
 	return sql.begin(async (tx) => {
 		const [failed] = await tx<{
@@ -178,7 +185,8 @@ async function markWatcherRunFailed(
 		await advanceScheduleAfterTerminalFailure(
 			tx,
 			failed.watcher_id == null ? null : Number(failed.watcher_id),
-			failed.dispatch_source
+			failed.dispatch_source,
+			notBefore
 		);
 		return true;
 	});
@@ -243,7 +251,20 @@ export async function resolveWatcherRunsByMessageIds(
 		if (!Number.isFinite(runId)) continue;
 
 		if (!result.ok) {
-			if (await markWatcherRunFailed(sql, runId, result.error)) resolved++;
+			const notBefore =
+				result.errorCode === AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED
+					? parseProviderQuotaResetAt(result.error)
+					: null;
+			if (
+				await markWatcherRunFailed(
+					sql,
+					runId,
+					result.error,
+					notBefore
+				)
+			) {
+				resolved++;
+			}
 			continue;
 		}
 

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -1,4 +1,3 @@
-import { AgentErrorCode } from "@lobu/core";
 import type { DbClient } from "../db/client";
 import { getDb, pgTextArray } from "../db/client";
 import { listPendingToolsForRun } from "../gateway/auth/mcp/pending-tool-store";
@@ -6,7 +5,7 @@ import logger from "../utils/logger";
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
 import {
 	advanceScheduleAfterTerminalFailure,
-	parseProviderQuotaResetAt,
+	providerQuotaResetNotBefore,
 } from "./schedule-cursor";
 
 type WatcherTerminalResult =
@@ -251,10 +250,10 @@ export async function resolveWatcherRunsByMessageIds(
 		if (!Number.isFinite(runId)) continue;
 
 		if (!result.ok) {
-			const notBefore =
-				result.errorCode === AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED
-					? parseProviderQuotaResetAt(result.error)
-					: null;
+			const notBefore = providerQuotaResetNotBefore(
+				result.error,
+				result.errorCode
+			);
 			if (
 				await markWatcherRunFailed(
 					sql,

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -24,7 +24,66 @@ export function parseProviderQuotaResetAt(
 	if (!match) return null;
 
 	const [, date, hour, minute, second, milliseconds, rawZone] = match;
+	const [yearText, monthText, dayText] = date.split("-");
+	const year = Number(yearText);
+	const month = Number(monthText);
+	const day = Number(dayText);
+	const hourValue = Number(hour ?? "0");
+	const minuteValue = Number(minute ?? "0");
+	const secondValue = Number(second ?? "0");
+	const millisecondValue = Number(milliseconds ?? "0");
+	const daysInMonth = [
+		31,
+		year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28,
+		31,
+		30,
+		31,
+		30,
+		31,
+		31,
+		30,
+		31,
+		30,
+		31,
+	][month - 1];
+	if (
+		!Number.isInteger(year) ||
+		!Number.isInteger(month) ||
+		month < 1 ||
+		month > 12 ||
+		!Number.isInteger(day) ||
+		day < 1 ||
+		daysInMonth === undefined ||
+		day > daysInMonth ||
+		!Number.isInteger(hourValue) ||
+		hourValue < 0 ||
+		hourValue > 23 ||
+		!Number.isInteger(minuteValue) ||
+		minuteValue < 0 ||
+		minuteValue > 59 ||
+		!Number.isInteger(secondValue) ||
+		secondValue < 0 ||
+		secondValue > 59 ||
+		!Number.isInteger(millisecondValue) ||
+		millisecondValue < 0 ||
+		millisecondValue > 999
+	) {
+		return null;
+	}
+
 	const normalizedZone = rawZone?.toUpperCase();
+	if (normalizedZone && normalizedZone !== "Z") {
+		const offsetHour = Number(normalizedZone.slice(1, 3));
+		const offsetMinute = Number(normalizedZone.slice(-2));
+		if (
+			!Number.isInteger(offsetHour) ||
+			offsetHour > 23 ||
+			!Number.isInteger(offsetMinute) ||
+			offsetMinute > 59
+		) {
+			return null;
+		}
+	}
 	const zone = normalizedZone
 		? normalizedZone === "Z" || normalizedZone.includes(":")
 			? normalizedZone

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -1,3 +1,4 @@
+import { AgentErrorCode } from "@lobu/core";
 import type { DbClient } from "../db/client";
 import { nextRunAt } from "../utils/cron";
 import logger from "../utils/logger";
@@ -19,7 +20,7 @@ export function parseProviderQuotaResetAt(
 	now: Date = new Date()
 ): Date | null {
 	const match = message.match(
-		/\breset(?:s)?\s+(?:at|on)\s+(\d{4}-\d{2}-\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?(Z|[+-]\d{2}:?\d{2})?)?/i
+		/\breset(?:s)?\s+(?:at|on)\s+(\d{4}-\d{2}-\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?(Z|[+-]\d{2}:?\d{2})?)?(?![ T]\d{2}:)(?![0-9A-Za-z:+-]|\.\d)/i
 	);
 	if (!match) return null;
 
@@ -31,7 +32,6 @@ export function parseProviderQuotaResetAt(
 	const hourValue = Number(hour ?? "0");
 	const minuteValue = Number(minute ?? "0");
 	const secondValue = Number(second ?? "0");
-	const millisecondValue = Number(milliseconds ?? "0");
 	const daysInMonth = [
 		31,
 		year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28,
@@ -47,26 +47,17 @@ export function parseProviderQuotaResetAt(
 		31,
 	][month - 1];
 	if (
-		!Number.isInteger(year) ||
-		!Number.isInteger(month) ||
 		month < 1 ||
 		month > 12 ||
-		!Number.isInteger(day) ||
 		day < 1 ||
 		daysInMonth === undefined ||
 		day > daysInMonth ||
-		!Number.isInteger(hourValue) ||
 		hourValue < 0 ||
 		hourValue > 23 ||
-		!Number.isInteger(minuteValue) ||
 		minuteValue < 0 ||
 		minuteValue > 59 ||
-		!Number.isInteger(secondValue) ||
 		secondValue < 0 ||
-		secondValue > 59 ||
-		!Number.isInteger(millisecondValue) ||
-		millisecondValue < 0 ||
-		millisecondValue > 999
+		secondValue > 59
 	) {
 		return null;
 	}
@@ -75,12 +66,7 @@ export function parseProviderQuotaResetAt(
 	if (normalizedZone && normalizedZone !== "Z") {
 		const offsetHour = Number(normalizedZone.slice(1, 3));
 		const offsetMinute = Number(normalizedZone.slice(-2));
-		if (
-			!Number.isInteger(offsetHour) ||
-			offsetHour > 23 ||
-			!Number.isInteger(offsetMinute) ||
-			offsetMinute > 59
-		) {
+		if (offsetHour > 23 || offsetMinute > 59) {
 			return null;
 		}
 	}
@@ -104,11 +90,29 @@ export function parseProviderQuotaResetAt(
 }
 
 /**
+ * Resolve a provider reset boundary for a terminal error.
+ *
+ * Structured worker/API paths must explicitly classify the error as quota
+ * exhaustion; this prevents an unrelated provider sentence containing
+ * "reset at" from moving a schedule.
+ */
+export function providerQuotaResetNotBefore(
+	message: string,
+	errorCode?: string,
+	now: Date = new Date()
+): Date | null {
+	if (errorCode !== AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED) {
+		return null;
+	}
+	return parseProviderQuotaResetAt(message, now);
+}
+
+/**
  * Move a watcher's `next_run_at` forward to the next cron tick after now.
  *
  * The target is `nextRunAt(schedule, now)` unless the caller supplies a later
- * `notBefore` boundary, so repeated completions within a cron interval converge
- * to the same upcoming tick while terminal quota errors can park until reset.
+ * `notBefore` boundary. The write never moves an existing cursor backward, so
+ * overlapping completions cannot erase a quota park.
  * (Basing it on `max(now, next_run_at)` instead compounded the schedule: each
  * manual trigger's completion pushed an already-future `next_run_at` one more
  * tick out, so N manual runs silently skipped N cron slots.)
@@ -176,7 +180,7 @@ export async function advanceWatcherSchedule(
 
 	await sql`
     UPDATE watchers
-    SET next_run_at = ${target}::timestamptz,
+    SET next_run_at = GREATEST(next_run_at, ${target}::timestamptz),
         updated_at = NOW()
     WHERE id = ${watcherId}
   `;

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -2,11 +2,54 @@ import type { DbClient } from "../db/client";
 import { nextRunAt } from "../utils/cron";
 import logger from "../utils/logger";
 
+const PROVIDER_RESET_GRACE_MS = 60_000;
+
+/**
+ * Extract the reset timestamp from provider quota errors such as:
+ *
+ * - "Your limit will reset at 2026-07-31"
+ * - "Your limit will reset at 2026-07-10 04:32:47"
+ *
+ * Providers frequently omit a timezone. Treat an omitted zone as UTC rather
+ * than the gateway host's local time so replicas in different regions agree.
+ * The one-minute grace avoids retrying at the exact reset boundary.
+ */
+export function parseProviderQuotaResetAt(
+	message: string,
+	now: Date = new Date()
+): Date | null {
+	const match = message.match(
+		/\breset(?:s)?\s+(?:at|on)\s+(\d{4}-\d{2}-\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?(Z|[+-]\d{2}:?\d{2})?)?/i
+	);
+	if (!match) return null;
+
+	const [, date, hour, minute, second, milliseconds, rawZone] = match;
+	const normalizedZone = rawZone?.toUpperCase();
+	const zone = normalizedZone
+		? normalizedZone === "Z" || normalizedZone.includes(":")
+			? normalizedZone
+			: `${normalizedZone.slice(0, 3)}:${normalizedZone.slice(3)}`
+		: "Z";
+	const timestamp =
+		`${date}T${hour ?? "00"}:${minute ?? "00"}:${second ?? "00"}.` +
+		`${milliseconds?.padEnd(3, "0") ?? "000"}${zone}`;
+	const parsed = new Date(timestamp);
+	const notBeforeMs = parsed.getTime() + PROVIDER_RESET_GRACE_MS;
+	if (
+		!Number.isFinite(parsed.getTime()) ||
+		notBeforeMs <= now.getTime()
+	) {
+		return null;
+	}
+	return new Date(notBeforeMs);
+}
+
 /**
  * Move a watcher's `next_run_at` forward to the next cron tick after now.
  *
- * The target is always `nextRunAt(schedule, now)`, so repeated completions
- * within a cron interval converge to the same upcoming tick.
+ * The target is `nextRunAt(schedule, now)` unless the caller supplies a later
+ * `notBefore` boundary, so repeated completions within a cron interval converge
+ * to the same upcoming tick while terminal quota errors can park until reset.
  * (Basing it on `max(now, next_run_at)` instead compounded the schedule: each
  * manual trigger's completion pushed an already-future `next_run_at` one more
  * tick out, so N manual runs silently skipped N cron slots.)
@@ -31,7 +74,8 @@ import logger from "../utils/logger";
  */
 export async function advanceWatcherSchedule(
 	sql: DbClient,
-	watcherId: number | null | undefined
+	watcherId: number | null | undefined,
+	notBefore?: Date | null
 ): Promise<void> {
 	if (watcherId == null) return;
 	const rows = await sql`
@@ -63,9 +107,17 @@ export async function advanceWatcherSchedule(
 		return;
 	}
 
+	const notBeforeMs = notBefore?.getTime();
+	const target =
+		typeof notBeforeMs === "number" &&
+		Number.isFinite(notBeforeMs) &&
+		notBeforeMs > new Date(nextTick).getTime()
+			? new Date(notBeforeMs).toISOString()
+			: nextTick;
+
 	await sql`
     UPDATE watchers
-    SET next_run_at = ${nextTick}::timestamptz,
+    SET next_run_at = ${target}::timestamptz,
         updated_at = NOW()
     WHERE id = ${watcherId}
   `;
@@ -85,8 +137,9 @@ export async function advanceWatcherSchedule(
 export async function advanceScheduleAfterTerminalFailure(
 	sql: DbClient,
 	watcherId: number | null | undefined,
-	dispatchSource: string | null | undefined
+	dispatchSource: string | null | undefined,
+	notBefore?: Date | null
 ): Promise<void> {
 	if (dispatchSource === "event") return;
-	await advanceWatcherSchedule(sql, watcherId);
+	await advanceWatcherSchedule(sql, watcherId, notBefore);
 }

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -183,9 +183,10 @@ export async function advanceWatcherSchedule(
 }
 
 /**
- * Advance after terminal failure unless the run came from an event. Event
- * delivery is independent of the cron cursor, so advancing it would skip the
- * next scheduled activation. Call inside the failure transaction.
+ * Advance after terminal failure unless the run came from an event with no
+ * explicit retry boundary. Ordinary event delivery is independent of the cron
+ * cursor, but a provider quota boundary must park any scheduled activation too.
+ * Call inside the failure transaction.
  *
  * Shared deliberately: three paths mark a Behavior run failed — agent dispatch
  * (`failWatcherRun`), turn resolution (`resolveWatcherRunsByMessageIds`), and
@@ -199,6 +200,6 @@ export async function advanceScheduleAfterTerminalFailure(
 	dispatchSource: string | null | undefined,
 	notBefore?: Date | null
 ): Promise<void> {
-	if (dispatchSource === "event") return;
+	if (dispatchSource === "event" && notBefore == null) return;
 	await advanceWatcherSchedule(sql, watcherId, notBefore);
 }

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -108,7 +108,24 @@ export function providerQuotaResetNotBefore(
 }
 
 /**
- * Move a watcher's `next_run_at` forward to the next cron tick after now.
+ * Device CLI reports do not carry a structured error code, so require both an
+ * explicit reset timestamp and provider-quota wording before moving a durable
+ * schedule. This prevents unrelated stderr such as "session resets at ..."
+ * from parking a Behavior.
+ */
+export function deviceProviderQuotaResetNotBefore(
+	message: string,
+	now: Date = new Date()
+): Date | null {
+	const hasQuotaEvidence =
+		/credit balance is too low|insufficient (?:credits?|balance|funds|quota)\b|billing_hard_limit_reached|payment required|exceeded your current quota|out of credits?\b|weekly\/monthly limit exhausted|limit exhausted|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
+			message
+		);
+	return hasQuotaEvidence ? parseProviderQuotaResetAt(message, now) : null;
+}
+
+/**
+ * Move a watcher's `next_run_at` forward without shortening its current park.
  *
  * The target is `nextRunAt(schedule, now)` unless the caller supplies a later
  * `notBefore` boundary. The write never moves an existing cursor backward, so
@@ -190,13 +207,8 @@ export async function advanceWatcherSchedule(
  * Advance after terminal failure unless the run came from an event with no
  * explicit retry boundary. Ordinary event delivery is independent of the cron
  * cursor, but a provider quota boundary must park any scheduled activation too.
- * Call inside the failure transaction.
- *
- * Shared deliberately: three paths mark a Behavior run failed — agent dispatch
- * (`failWatcherRun`), turn resolution (`resolveWatcherRunsByMessageIds`), and
- * the device-CLI `/complete-behavior` endpoint. Written out three times the
- * carve-out drifts, and a diff-scoped reviewer only ever sees one copy. Keep it
- * here rather than re-inlining.
+ * Call inside the caller's terminal-state transaction. Run-backed failures and
+ * reply-to-source turns share this policy so their event carve-out cannot drift.
  */
 export async function advanceScheduleAfterTerminalFailure(
 	sql: DbClient,

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -57,7 +57,7 @@ import {
 } from "../watchers/run-completion";
 import {
 	advanceScheduleAfterTerminalFailure,
-	parseProviderQuotaResetAt,
+	deviceProviderQuotaResetNotBefore,
 } from "../watchers/schedule-cursor";
 import { authorizeRunForWorker } from "./shared";
 
@@ -1188,7 +1188,7 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 				typeof approved.dispatch_source === "string"
 					? approved.dispatch_source
 					: null,
-				parseProviderQuotaResetAt(reason)
+				deviceProviderQuotaResetNotBefore(reason)
 			);
 			return true;
 		});

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -55,7 +55,10 @@ import {
 	bumpDeviceFinalizeNudge,
 	resolveFinalizeNudgeBudget,
 } from "../watchers/run-completion";
-import { advanceScheduleAfterTerminalFailure } from "../watchers/schedule-cursor";
+import {
+	advanceScheduleAfterTerminalFailure,
+	parseProviderQuotaResetAt,
+} from "../watchers/schedule-cursor";
 import { authorizeRunForWorker } from "./shared";
 
 type DbClient = ReturnType<typeof getDb>;
@@ -1184,7 +1187,8 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 				watcherId,
 				typeof approved.dispatch_source === "string"
 					? approved.dispatch_source
-					: null
+					: null,
+				parseProviderQuotaResetAt(reason)
 			);
 			return true;
 		});


### PR DESCRIPTION
## Summary
- Preserve classified provider errors through the API terminal-response path.
- Parse explicit quota reset timestamps and park scheduled Behaviors until the later of the normal cron tick or reset boundary plus a one-minute grace.
- Keep run failure, audit evidence, and schedule-cursor movement in the existing transaction.

## Test plan
- [x] `make pre-pr`  clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Targeted DB-backed integration tests and renderer tests
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red
Before the implementation, the added DB-backed test failed because the cursor moved to the next cron tick instead of the provider reset:

```text
1 failed, 11 passed
AssertionError: expected 1785772800000 to be >= 1785791083540
```

### Green

```text
failed-run-advances-schedule.test.ts: 21 passed, 0 failed
response-renderer-finaltext.test.ts: 6 passed, 0 failed
bun run typecheck: passed
make pre-pr: passed
```

`make test-unit` also ran 1,707 passing tests and 13 skips. It exposed one pre-existing assertion mismatch in `packages/agent-worker/src/__tests__/exec-sandbox-extra.test.ts`: implementation test expects `/bubblewrap is unavailable/`, while current `origin/main` emits the newer fail-closed message. This branch has no changes under `packages/agent-worker`.

## Notes
- Addresses the quota retry-storm portion of #2350. Provider failover and broader budget/circuit-breaker work remain separate follow-ups.
- Provider reset parsing now rejects impossible calendar dates, invalid clock values, and invalid UTC offsets.
- Quota failures from event-triggered runs also park the Behavior’s scheduled activation, while ordinary event failures leave the cron cursor unchanged.
- No schema migration.
- No production data was read or modified while implementing this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider quota-exhaustion errors now pause failed runs until the provider’s quota reset time, plus a one-minute grace period.
  * Reset times without an explicit timezone are interpreted consistently as UTC.
  * Invalid, missing, or elapsed reset times no longer cause runs to wait indefinitely.
  * Scheduled retries respect the later of the provider reset boundary and next scheduled run.
  * Quota errors are preserved for internal tracking while user-facing error messages remain appropriately protected.
  * Reply routing now uses validated behavior information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Xhigh review follow-up

A `gpt-5.6-sol` Codex review with `model_reasoning_effort="xhigh"` found that device-pinned and reply-to-source Behaviors bypassed the original API terminal path. The follow-up closes every terminal seam:

- API/headless terminal responses finish durable run bookkeeping before SSE delivery and retry on database failure.
- Mac/device exit reports parse explicit provider reset boundaries inside the existing failure transaction.
- Reply-to-source chat turns park only the Behavior owned by the authenticated organization and agent.
- Schedule cursor updates are monotonic, so an overlapping ordinary completion cannot shorten an existing quota park.
- Malformed or partially valid reset timestamps are rejected.

Validation on the settled diff:

```text
watcher integration suites: 75 passed, 0 failed
ChatResponseBridge suite: 30 passed, 0 failed
ApiResponseRenderer suite: 7 passed, 0 failed
make pre-pr: passed
make review-fix: completed, no unresolved findings
```
