### PR TITLE
fix(server): secure first managed OAuth connect

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/managed-connect-consent-only.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/managed-connect-consent-only.test.ts
@@ -44,6 +44,7 @@ async function seedManagedConnector(opts: {
   visibility: 'public' | 'private';
   /** Managed oauth_app state: 'active' (default) | 'revoked' | 'absent'. */
   appState?: 'active' | 'revoked' | 'absent';
+  envCredentialKeys?: { clientId: string; clientSecret: string };
 }) {
   const appState = opts.appState ?? 'active';
   const { org, user, ctx } = await seedOwnerContext({
@@ -65,8 +66,8 @@ async function seedManagedConnector(opts: {
           requiredScopes: ['read'],
           authorizationUrl: 'https://demo.example/authorize',
           tokenUrl: 'https://demo.example/token',
-          clientIdKey: 'DEMO_CLIENT_ID',
-          clientSecretKey: 'DEMO_CLIENT_SECRET',
+          clientIdKey: opts.envCredentialKeys?.clientId ?? 'DEMO_CLIENT_ID',
+          clientSecretKey: opts.envCredentialKeys?.clientSecret ?? 'DEMO_CLIENT_SECRET',
         },
       ],
     },
@@ -133,6 +134,47 @@ describe('Stage 3 — managed-connect creates a consent-only connection', () => 
       ctx
     )) as { error?: string };
     expect(feedResult.error).toMatch(/consent-only/i);
+  });
+
+  it('the first env-backed connect is consent_only when it provisions the managed app', async () => {
+    const clientIdKey = 'MANAGED_FIRST_CONNECT_CLIENT_ID';
+    const clientSecretKey = 'MANAGED_FIRST_CONNECT_CLIENT_SECRET';
+    const { ctx, connectorKey } = await seedManagedConnector({
+      visibility: 'public',
+      appState: 'absent',
+      envCredentialKeys: { clientId: clientIdKey, clientSecret: clientSecretKey },
+    });
+    process.env[clientIdKey] = 'managed-first-connect-client';
+    process.env[clientSecretKey] = 'managed-first-connect-secret';
+
+    try {
+      const result = (await manageConnections(
+        { action: 'connect', connector_key: connectorKey },
+        TEST_ENV,
+        ctx
+      )) as { connection_id?: number; status?: string; error?: string };
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe('pending_auth');
+      expect(result.connection_id).toBeDefined();
+      const connectionId = Number(result.connection_id);
+
+      const sql = getTestDb();
+      const connRows = (await sql`
+        SELECT config FROM connections WHERE id = ${connectionId} LIMIT 1
+      `) as unknown as Array<{ config: Record<string, unknown> | null }>;
+      expect(connRows[0]?.config?.consent_only).toBe(true);
+
+      const feedResult = (await manageFeeds(
+        { action: 'create_feed', connection_id: connectionId, feed_key: 'items' },
+        TEST_ENV,
+        ctx
+      )) as { error?: string };
+      expect(feedResult.error).toMatch(/consent-only/i);
+    } finally {
+      delete process.env[clientIdKey];
+      delete process.env[clientSecretKey];
+    }
   });
 
   it('a managed connector in a PRIVATE org is an ordinary connection (no consent_only)', async () => {

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -274,6 +274,32 @@ async function handleConnectImpl(
     oauthAccountCreatedBy: requireManaged ? userId : undefined,
   });
 
+	const isOAuthConnect =
+		authSelection.preferredMethodType === "oauth" &&
+		(authSelection.selectedKind === "none" ||
+			authSelection.selectedKind === "oauth_account");
+	// Resolve/provision the app before deriving managed-connector policy. On the
+	// first env-backed connect there is no oauth_app row yet; doing this only
+	// after INSERT meant that first grant missed consent_only even though every
+	// later grant was managed. Persist the app first so the same durable signal
+	// drives both the policy decision and OAuth token creation.
+	if (isOAuthConnect && authSelection.oauthMethod && !authSelection.appAuthProfile) {
+		authSelection.appAuthProfile =
+			(await getPrimaryAuthProfileForKind({
+				organizationId,
+				connectorKey: args.connector_key,
+				profileKind: "oauth_app",
+				provider: authSelection.oauthMethod.provider,
+			})) ??
+			(await ensureEnvBackedOAuthAppProfile({
+				organizationId,
+				connectorKey: args.connector_key,
+				connectorName: connector.name,
+				method: authSelection.oauthMethod,
+				createdBy: userId,
+			}));
+	}
+
   const hasNoAuth =
 		!authSelection.oauthMethod &&
 		!authSelection.envMethod &&
@@ -465,7 +491,7 @@ async function handleConnectImpl(
   // the member's local instance). The consent_only flag lives in the trusted
   // connection `config` (where managedBy lives), and the manage_feeds guard
   // already refuses to create feeds on a consent_only connection.
-  const isManagedConnect = authSelection.oauthMethod
+  const isManagedConnect = isOAuthConnect && authSelection.oauthMethod
     ? await isManagedPublicOrgConnect({
         organizationId,
         connectorKey: args.connector_key,


### PR DESCRIPTION
## Summary
- provision or resolve the OAuth app before deriving managed-public policy
- mark the very first env-backed managed grant `consent_only`, not only later grants
- keep non-OAuth auth selections out of the managed delegation path

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Targeted integration: `managed-connect-consent-only.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red
```text
FAIL ... the first env-backed connect is consent_only when it provisions the managed app
AssertionError: expected undefined to be true
Tests 1 failed | 5 passed
```

### Green
```text
✓ managed-connect-consent-only.test.ts (6 tests)
Test Files 1 passed (1)
Tests 6 passed (6)
```

## Notes
Found while dogfooding the new public `lobu-cloud` managed-auth workspace. The first production Gmail bootstrap connection had `config: null`; after the app profile existed, the next connection correctly had `config.consent_only: true` and zero feeds.