### PR TITLE
feat(server): add managed auth onboarding

### DIFF
--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -495,6 +495,32 @@ export const ConnectAction = Type.Object({
   ),
 });
 
+export const ConnectManagedAction = Type.Object({
+  action: Type.Literal("connect_managed", {
+    description:
+      "Connect through a managed OAuth offer advertised by a public Lobu org. Validates the live offer, enrolls the signed-in user in that org, and returns a provider consent URL. The resulting cloud connection is private, consent-only, and has no feeds.",
+  }),
+  managed_by_org: Type.String({
+    description:
+      "Public organization slug from organizations.list managed_auth metadata",
+  }),
+  connector_key: Type.String({
+    description: "Connector key advertised by that managed_auth offer",
+  }),
+  display_name: Type.Optional(
+    Type.String({ description: "Human-readable name for the consent grant" })
+  ),
+  slug: Type.Optional(
+    Type.String({ description: "Stable identifier for the consent grant" })
+  ),
+  config: Type.Optional(
+    Type.Record(Type.String(), Type.Any(), {
+      description:
+        "Non-secret connection config, such as requested optional scopes",
+    })
+  ),
+});
+
 export const ToggleConnectorLoginAction = Type.Object({
   action: Type.Literal("toggle_connector_login", {
     description:
@@ -932,6 +958,10 @@ export type ConnectionConnectInput = Omit<
   Static<typeof ConnectAction>,
   "action"
 >;
+export type ConnectionConnectManagedInput = Omit<
+  Static<typeof ConnectManagedAction>,
+  "action"
+>;
 export type ConnectionCreateInput = Omit<Static<typeof CreateAction>, "action">;
 export type ConnectionUpdateInput = Omit<Static<typeof UpdateAction>, "action">;
 export type InstallConnectorInput = Omit<
@@ -966,6 +996,7 @@ export type ConnectionsArgs =
   | Static<typeof GetAction>
   | Static<typeof CreateAction>
   | Static<typeof ConnectAction>
+  | Static<typeof ConnectManagedAction>
   | Static<typeof UpdateAction>
   | Static<typeof ApplyChatConnectionAction>
   | Static<typeof DeleteAction>

--- a/packages/server/src/__tests__/integration/managed-auth-onboarding.test.ts
+++ b/packages/server/src/__tests__/integration/managed-auth-onboarding.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Managed-auth onboarding must be self-describing and usable by a brand-new
+ * Lobu user. The user starts in their own workspace, discovers a public org's
+ * managed OAuth offer, joins it, and creates their own consent-only grant.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createAuthProfile } from '../../utils/auth-profiles';
+import { initWorkspaceProvider } from '../../workspace';
+import { TestApiClient } from '../setup/test-mcp-client';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../setup/test-fixtures';
+
+async function seedManagedGoogleOrg() {
+  const org = await createTestOrganization({
+    name: 'Managed Connectors',
+    slug: 'managed-connectors',
+    visibility: 'public',
+  });
+
+  for (const [key, name] of [
+    ['google.gmail', 'Gmail'],
+    ['google.calendar', 'Google Calendar'],
+  ] as const) {
+    await createTestConnectorDefinition({
+      key,
+      name,
+      organization_id: org.id,
+      auth_schema: {
+        methods: [
+          {
+            type: 'oauth',
+            provider: 'google',
+            requiredScopes: ['openid'],
+            authorizationUrl: 'https://accounts.example/authorize',
+            tokenUrl: 'https://accounts.example/token',
+            clientIdKey: 'GOOGLE_CLIENT_ID',
+            clientSecretKey: 'GOOGLE_CLIENT_SECRET',
+          },
+        ],
+      },
+      feeds_schema: { items: {} },
+    });
+  }
+
+  // A connector-bound Google app is provider-wide, so it can serve both Gmail
+  // and Calendar. Discovery must mirror the runtime profile resolver.
+  await createAuthProfile({
+    organizationId: org.id,
+    connectorKey: 'google.gmail',
+    displayName: 'Managed Google App',
+    profileKind: 'oauth_app',
+    provider: 'google',
+    authData: {
+      GOOGLE_CLIENT_ID: 'managed-client-id',
+      GOOGLE_CLIENT_SECRET: 'managed-client-secret',
+    },
+  });
+
+  return org;
+}
+
+describe('managed-auth onboarding', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('discovers live managed OAuth offers before login without knowing the org slug', async () => {
+    const managed = await seedManagedGoogleOrg();
+
+    const client = await TestApiClient.for({
+      organizationId: managed.id,
+      userId: null,
+      memberRole: null,
+      scopedToOrg: false,
+    });
+    const organizations = await client.organizations.list();
+    const offer = organizations.find((organization) => organization.slug === managed.slug);
+
+    expect(offer).toMatchObject({
+      slug: 'managed-connectors',
+      is_member: false,
+      managed_auth: {
+        credential_mode: 'managed',
+        requires_user_login: true,
+        requires_user_consent: true,
+        join_required: true,
+        connect_method: 'connections.connectManaged',
+        local_bootstrap_command: 'lobu init --from-org managed-connectors',
+        connectors: [
+          {
+            connector_key: 'google.calendar',
+            provider: 'google',
+            managed_by_org: 'managed-connectors',
+          },
+          {
+            connector_key: 'google.gmail',
+            provider: 'google',
+            managed_by_org: 'managed-connectors',
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify(offer)).not.toContain('managed-client-secret');
+    await expect(
+      client.connections.connectManaged({
+        managed_by_org: managed.slug,
+        connector_key: 'google.gmail',
+      })
+    ).rejects.toThrow(/requires workspace membership with write access/i);
+  });
+
+  it('auto-joins the signed-in user when managed connect starts', async () => {
+    const home = await createTestOrganization({ name: 'Fresh User Home' });
+    const user = await createTestUser({ email: 'fresh-user@example.com' });
+    await addUserToOrganization(user.id, home.id, 'owner');
+    const managed = await seedManagedGoogleOrg();
+
+    const client = await TestApiClient.for({
+      organizationId: home.id,
+      userId: user.id,
+      memberRole: 'owner',
+      scopedToOrg: false,
+    });
+
+    const first = (await client.connections.connectManaged({
+      managed_by_org: managed.slug,
+      connector_key: 'google.gmail',
+    })) as { connection_id: number; status: string };
+    expect(first).toMatchObject({
+      connection_id: expect.any(Number),
+      status: 'pending_auth',
+    });
+    await expect(
+      client.connections.connectManaged({
+        managed_by_org: managed.slug,
+        connector_key: 'google.gmail',
+      })
+    ).resolves.toMatchObject({
+      connection_id: first.connection_id,
+      status: 'pending_auth',
+    });
+
+    const organizations = await client.organizations.list();
+    expect(organizations.find((organization) => organization.slug === managed.slug)).toMatchObject({
+      is_member: true,
+      managed_auth: { join_required: false },
+    });
+  });
+
+  it('creates only the caller-owned consent grant and no cloud feeds', async () => {
+    const home = await createTestOrganization({ name: 'Fresh User Home' });
+    const user = await createTestUser({ email: 'fresh-user@example.com' });
+    await addUserToOrganization(user.id, home.id, 'owner');
+    const managed = await seedManagedGoogleOrg();
+
+    const homeClient = await TestApiClient.for({
+      organizationId: home.id,
+      userId: user.id,
+      memberRole: 'owner',
+      scopedToOrg: false,
+    });
+    const result = (await homeClient.connections.connectManaged({
+      managed_by_org: managed.slug,
+      connector_key: 'google.gmail',
+    })) as { connection_id?: number; status?: string };
+
+    expect(result).toMatchObject({
+      connection_id: expect.any(Number),
+      status: 'pending_auth',
+    });
+
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT created_by, visibility, config
+      FROM connections
+      WHERE id = ${result.connection_id}
+      LIMIT 1
+    `) as unknown as Array<{
+      created_by: string;
+      visibility: string;
+      config: Record<string, unknown> | null;
+    }>;
+    expect(rows[0]).toMatchObject({
+      created_by: user.id,
+      visibility: 'private',
+      config: { consent_only: true },
+    });
+
+    const feeds = await sql`SELECT 1 FROM feeds WHERE connection_id = ${result.connection_id}`;
+    expect(feeds).toHaveLength(0);
+  });
+
+  it('rejects a connector that the public org does not actively offer without joining', async () => {
+    const home = await createTestOrganization({ name: 'Fresh User Home' });
+    const user = await createTestUser({ email: 'fresh-user@example.com' });
+    await addUserToOrganization(user.id, home.id, 'owner');
+    const managed = await seedManagedGoogleOrg();
+
+    const client = await TestApiClient.for({
+      organizationId: home.id,
+      userId: user.id,
+      memberRole: 'owner',
+      scopedToOrg: false,
+    });
+    await expect(
+      client.connections.connectManaged({
+        managed_by_org: managed.slug,
+        connector_key: 'github',
+      })
+    ).rejects.toThrow(/No active managed OAuth offer/i);
+
+    const sql = getTestDb();
+    const memberships = await sql`
+      SELECT 1
+      FROM "member"
+      WHERE "organizationId" = ${managed.id}
+        AND "userId" = ${user.id}
+    `;
+    expect(memberships).toHaveLength(0);
+  });
+});

--- a/packages/server/src/__tests__/integration/managed-auth-onboarding.test.ts
+++ b/packages/server/src/__tests__/integration/managed-auth-onboarding.test.ts
@@ -62,7 +62,65 @@ async function seedManagedGoogleOrg() {
     },
   });
 
+  // The OAuth app is provider-wide, but this connector prefers env auth. It
+  // must not be advertised because a bare managed connect would follow the env
+  // path rather than start provider consent.
+  await createTestConnectorDefinition({
+    key: 'google.env-first',
+    name: 'Google env-first',
+    organization_id: org.id,
+    auth_schema: {
+      methods: [
+        { type: 'env_keys', fields: [{ key: 'GOOGLE_TOKEN' }] },
+        {
+          type: 'oauth',
+          provider: 'google',
+          requiredScopes: ['openid'],
+          authorizationUrl: 'https://accounts.example/authorize',
+          tokenUrl: 'https://accounts.example/token',
+          clientIdKey: 'GOOGLE_CLIENT_ID',
+          clientSecretKey: 'GOOGLE_CLIENT_SECRET',
+        },
+      ],
+    },
+    feeds_schema: { items: {} },
+  });
+
   return org;
+}
+
+async function seedHybridManagedConnector(organizationId: string) {
+  await createTestConnectorDefinition({
+    key: 'hybrid.oauth',
+    name: 'Hybrid OAuth',
+    organization_id: organizationId,
+    auth_schema: {
+      methods: [
+        { type: 'app_installation', provider: 'hybrid' },
+        {
+          type: 'oauth',
+          provider: 'hybrid',
+          requiredScopes: ['profile'],
+          authorizationUrl: 'https://hybrid.example/authorize',
+          tokenUrl: 'https://hybrid.example/token',
+          clientIdKey: 'HYBRID_CLIENT_ID',
+          clientSecretKey: 'HYBRID_CLIENT_SECRET',
+        },
+      ],
+    },
+    feeds_schema: { items: {} },
+  });
+  await createAuthProfile({
+    organizationId,
+    connectorKey: 'hybrid.oauth',
+    displayName: 'Managed Hybrid App',
+    profileKind: 'oauth_app',
+    provider: 'hybrid',
+    authData: {
+      HYBRID_CLIENT_ID: 'hybrid-client-id',
+      HYBRID_CLIENT_SECRET: 'hybrid-client-secret',
+    },
+  });
 }
 
 describe('managed-auth onboarding', () => {
@@ -154,6 +212,30 @@ describe('managed-auth onboarding', () => {
     expect(organizations.find((organization) => organization.slug === managed.slug)).toMatchObject({
       is_member: true,
       managed_auth: { join_required: false },
+    });
+  });
+
+  it('uses managed OAuth when ordinary bare connects prefer app installation', async () => {
+    const home = await createTestOrganization({ name: 'Fresh User Home' });
+    const user = await createTestUser({ email: 'fresh-user@example.com' });
+    await addUserToOrganization(user.id, home.id, 'owner');
+    const managed = await seedManagedGoogleOrg();
+    await seedHybridManagedConnector(managed.id);
+
+    const client = await TestApiClient.for({
+      organizationId: home.id,
+      userId: user.id,
+      memberRole: 'owner',
+      scopedToOrg: false,
+    });
+    await expect(
+      client.connections.connectManaged({
+        managed_by_org: managed.slug,
+        connector_key: 'hybrid.oauth',
+      })
+    ).resolves.toMatchObject({
+      connection_id: expect.any(Number),
+      status: 'pending_auth',
     });
   });
 

--- a/packages/server/src/__tests__/integration/managed-auth-onboarding.test.ts
+++ b/packages/server/src/__tests__/integration/managed-auth-onboarding.test.ts
@@ -215,6 +215,48 @@ describe('managed-auth onboarding', () => {
     });
   });
 
+  it('never reuses another user\'s managed OAuth account', async () => {
+    const home = await createTestOrganization({ name: 'Second User Home' });
+    const firstUser = await createTestUser({ email: 'first-user@example.com' });
+    const secondUser = await createTestUser({ email: 'second-user@example.com' });
+    await addUserToOrganization(secondUser.id, home.id, 'owner');
+    const managed = await seedManagedGoogleOrg();
+    const firstUsersProfile = await createAuthProfile({
+      organizationId: managed.id,
+      connectorKey: 'google.gmail',
+      displayName: 'First User Gmail',
+      profileKind: 'oauth_account',
+      provider: 'google',
+      authData: { access_token: 'first-user-token' },
+      createdBy: firstUser.id,
+    });
+
+    const client = await TestApiClient.for({
+      organizationId: home.id,
+      userId: secondUser.id,
+      memberRole: 'owner',
+      scopedToOrg: false,
+    });
+    const result = (await client.connections.connectManaged({
+      managed_by_org: managed.slug,
+      connector_key: 'google.gmail',
+    })) as { connection_id?: number; status?: string; connect_url?: string };
+
+    expect(result).toMatchObject({
+      connection_id: expect.any(Number),
+      status: 'pending_auth',
+      connect_url: expect.any(String),
+    });
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT auth_profile_id, created_by
+      FROM connections
+      WHERE id = ${result.connection_id}
+    `) as unknown as Array<{ auth_profile_id: number | null; created_by: string }>;
+    expect(rows[0]).toEqual({ auth_profile_id: null, created_by: secondUser.id });
+    expect(rows[0]?.auth_profile_id).not.toBe(firstUsersProfile.id);
+  });
+
   it('uses managed OAuth when ordinary bare connects prefer app installation', async () => {
     const home = await createTestOrganization({ name: 'Fresh User Home' });
     const user = await createTestUser({ email: 'fresh-user@example.com' });

--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -233,6 +233,17 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 		expect(hits[0]).toContain("provider data stays local");
 	});
 
+	it("still surfaces connectors when optional managed-auth discovery fails", async () => {
+		const deps = makeDeps();
+		deps.listOrganizations = async () => {
+			throw new Error("managed-auth discovery unavailable");
+		};
+
+		const hits = await searchLiveConnectors("website", env, ctx, deps);
+		expect(hits).toHaveLength(1);
+		expect(hits[0]).toContain("connector 'website'");
+	});
+
 	it("does NOT recommend installConnector for a non-installable catalog entry", async () => {
 		// The review-caught bug: a stale/unavailable catalog entry
 		// (installable:false) was still told to run installConnector, which is

--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -57,6 +57,7 @@ function makeDeps(over?: {
 	// the real filter and proves an active connection is found regardless of how
 	// many other connections exist).
 	connectionsByKey?: Record<string, Array<{ status: string }>>;
+	organizations?: Array<Record<string, unknown>>;
 }): ConnectorDiscoveryDeps {
 	return {
 		manageCatalog: (async (args: { action: string }) =>
@@ -69,6 +70,7 @@ function makeDeps(over?: {
 			const rows = args.status ? all.filter((c) => c.status === args.status) : all;
 			return { connections: rows };
 		}) as never,
+		listOrganizations: async () => (over?.organizations ?? []) as never,
 	};
 }
 
@@ -184,6 +186,51 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 		const hits = await searchLiveConnectors("slack", env, ctx, makeDeps());
 		expect(hits.some((h) => h.includes("'slack'") && /CATALOG/.test(h))).toBe(true);
 		expect(hits.some((h) => /installConnector/.test(h))).toBe(true);
+	});
+
+	it("surfaces the exact managed-auth org and local-data lifecycle for a matching connector", async () => {
+		const deps = makeDeps({
+			catalog: {
+				catalogs: {
+					connectors: {
+						entries: [
+							{ id: "google.gmail", name: "Gmail", description: "Email search and sync" },
+						],
+					},
+				},
+			},
+			organizations: [
+				{
+					id: "managed-org",
+					slug: "lobu-cloud",
+					name: "Lobu Cloud",
+					is_member: false,
+					visibility: "public",
+					managed_auth: {
+						credential_mode: "managed",
+						requires_user_login: true,
+						requires_user_consent: true,
+						join_required: true,
+						connect_method: "connections.connectManaged",
+						local_bootstrap_command: "lobu init --from-org lobu-cloud",
+						connectors: [
+							{
+								connector_key: "google.gmail",
+								provider: "google",
+								managed_by_org: "lobu-cloud",
+							},
+						],
+					},
+				},
+			],
+		});
+
+		const hits = await searchLiveConnectors("gmail", env, ctx, deps);
+		expect(hits).toHaveLength(1);
+		expect(hits[0]).toContain("public org 'lobu-cloud'");
+		expect(hits[0]).toContain("connections.connectManaged");
+		expect(hits[0]).toContain("lobu init --from-org lobu-cloud");
+		expect(hits[0]).toContain("provider data stays local");
 	});
 
 	it("does NOT recommend installConnector for a non-installable catalog entry", async () => {

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -73,12 +73,18 @@ describe('requiresOwnerAdmin', () => {
     ).toBe(true);
   });
 
-  it('should allow members to create + reauthenticate their own connections', () => {
-    // `manage_connections.create` and `reauthenticate` are member-write; the
+  it('should allow members to create, managed-connect, and reauthenticate their own connections', () => {
+    // `manage_connections.create`, `connect_managed`, and `reauthenticate` are member-write; the
     // handler enforces app_auth_profile_slug must match the org default for
     // non-admins, so non-admins can't bring an alternate OAuth client.
     expect(requiresOwnerAdmin('manage_connections', { action: 'create' }, false)).toBe(false);
     expect(requiresMemberWrite('manage_connections', { action: 'create' }, false)).toBe(true);
+    expect(
+      requiresOwnerAdmin('manage_connections', { action: 'connect_managed' }, false)
+    ).toBe(false);
+    expect(
+      requiresMemberWrite('manage_connections', { action: 'connect_managed' }, false)
+    ).toBe(true);
     expect(requiresOwnerAdmin('manage_connections', { action: 'reauthenticate' }, false)).toBe(
       false
     );
@@ -716,7 +722,7 @@ query_sql: read ?=read
 run_sdk: write ?=write
 manage_entity: create=write update=write list=read+public get=read+public delete=admin link=write unlink=write update_link=write list_links=read+public merge=admin resolve_duplicates=admin unmerge=admin ?=read
 manage_entity_schema: list=read+public get=read+public create=admin update=admin delete=admin audit=read+public add_rule=admin remove_rule=admin list_rules=read+public ?=read
-manage_connections: list_connector_groups=read+public list=read+public get=read+public create=write connect=admin update=write apply_chat_connection=admin delete=admin reauthenticate=write test=admin install_connector=admin uninstall_connector=admin get_connector_source=admin validate_connector_source=admin update_connector_source=admin rollback_connector_version=admin toggle_connector_login=admin update_connector_auth=admin update_connector_default_config=admin set_channel_about=admin ?=read
+manage_connections: list_connector_groups=read+public list=read+public get=read+public create=write connect=admin connect_managed=write update=write apply_chat_connection=admin delete=admin reauthenticate=write test=admin install_connector=admin uninstall_connector=admin get_connector_source=admin validate_connector_source=admin update_connector_source=admin rollback_connector_version=admin toggle_connector_login=admin update_connector_auth=admin update_connector_default_config=admin set_channel_about=admin ?=read
 manage_catalog: list_catalog=read+public list_installed=read+public ?=read
 manage_agents: list=read+public get=read+public create=admin update=admin delete=admin set_system_agent=admin ?=read
 manage_conversations: list=read get=read send=write ?=read

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -26,7 +26,12 @@ export const MEMBER_WRITE_ACTIONS: Record<string, Set<string> | null> = {
 	// auth profile / display name / device pin; the handler enforces
 	// `created_by === ctx.userId` plus the same per-field role gates as
 	// create (app_auth_profile pinned-default, target-profile ownership).
-	manage_connections: new Set(["create", "update", "reauthenticate"]),
+	manage_connections: new Set([
+		"create",
+		"connect_managed",
+		"update",
+		"reauthenticate",
+	]),
 	// Members create / reconnect their own oauth_account profile. The handler
 	// gates `profile_kind` against role so env / oauth_app / browser_session
 	// stay admin-only. `get_auth_profile` is public-read because it returns the
@@ -73,7 +78,8 @@ export const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
 		"remove_rule",
 	]),
 	manage_connections: new Set([
-		// `create`, `update`, `reauthenticate` are in MEMBER_WRITE_ACTIONS —
+		// `create`, `connect_managed`, `update`, and `reauthenticate` are in
+		// MEMBER_WRITE_ACTIONS —
 		// members install / edit their own connections (handler enforces
 		// created_by === ctx.userId + app_auth_profile slug override + role
 		// gates).

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -42,7 +42,7 @@ export const METHOD_METADATA: Record<string, MethodMetadata> = {
 	// organizations
 	"organizations.list": {
 		summary:
-			"List organizations the authenticated user belongs to, plus public orgs they can read.",
+			"List organizations the authenticated user belongs to, plus public orgs they can read. Public managed-OAuth providers carry structured managed_auth metadata with connector keys, the connect method, consent/login requirements, and the local bootstrap command.",
 		access: "read",
 		example: "const orgs = await client.organizations.list();",
 	},
@@ -699,6 +699,15 @@ export default async (_ctx, client) => {
     config: { feed_urls: ['https://example.com/feed.xml'] },
   });
 };`,
+	},
+	"connections.connectManaged": {
+		summary:
+			"Use a live managed OAuth offer from organizations.list. Validates the public provider, automatically joins the signed-in user to that org, and returns a consent URL. The cloud keeps only the caller-owned consent grant with zero feeds; after consent, `lobu init --from-org <managed_by_org>` generates the local `managedBy` connection config so data access runs locally.",
+		access: "write",
+		signature:
+			"connections.connectManaged(input: { managed_by_org: string; connector_key: string; display_name?: string; slug?: string; config?: object }): Promise<unknown>",
+		example:
+			"await client.connections.connectManaged({ managed_by_org: '<organizations.list offer>', connector_key: 'google.gmail' });",
 	},
 	"connections.update": {
 		summary:

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -9,6 +9,7 @@
 
 import type {
 	ConnectionConnectInput,
+	ConnectionConnectManagedInput,
 	ConnectionCreateInput,
 	ConnectionUpdateInput,
 	GetConnectorSourceInput,
@@ -23,6 +24,7 @@ import type { ToolContext } from "../../tools/registry";
 import { createActionCaller, idArg } from "./action-call";
 
 export type ConnectionsConnectInput = ConnectionConnectInput;
+export type ConnectionsConnectManagedInput = ConnectionConnectManagedInput;
 export type ConnectionsCreateInput = ConnectionCreateInput;
 export type ConnectionsUpdateInput = ConnectionUpdateInput;
 export type ConnectionsInstallConnectorInput = InstallConnectorInput;
@@ -43,6 +45,7 @@ export interface ConnectionsNamespace {
 	get(connection_id: number): Promise<unknown>;
 	create(input: ConnectionsCreateInput): Promise<unknown>;
 	connect(input: ConnectionsConnectInput): Promise<unknown>;
+	connectManaged(input: ConnectionsConnectManagedInput): Promise<unknown>;
 	update(input: ConnectionsUpdateInput): Promise<unknown>;
 	delete(connection_id: number): Promise<unknown>;
 	reauthenticate(connection_id: number): Promise<unknown>;
@@ -96,6 +99,8 @@ export function buildConnectionsNamespace(
 			}),
 		create: (input) => action("create", input),
 		connect: (input) => action("connect", input),
+		connectManaged: (input) =>
+			action("connect_managed", input, "connectManaged"),
 		update: (input) => action("update", input),
 		delete: async (connection_id) =>
 			action("delete", {

--- a/packages/server/src/sandbox/namespaces/organizations.ts
+++ b/packages/server/src/sandbox/namespaces/organizations.ts
@@ -16,6 +16,7 @@ export interface OrgSummary {
 	name: string;
 	is_member: boolean;
 	visibility: "public" | "private";
+	managed_auth?: OrgInfo["managed_auth"];
 }
 
 export interface OrganizationsNamespace {
@@ -34,6 +35,17 @@ export interface OrganizationsNamespace {
 export function buildOrganizationsNamespace(
 	ctx: ToolContext,
 ): OrganizationsNamespace {
+	const summarize = (organization: OrgInfo): OrgSummary => ({
+		id: organization.id,
+		slug: organization.slug,
+		name: organization.name,
+		is_member: organization.is_member,
+		visibility: organization.visibility,
+		...(organization.managed_auth
+			? { managed_auth: organization.managed_auth }
+			: {}),
+	});
+
 	return {
 		async list(options) {
 			const provider = getWorkspaceProvider();
@@ -41,13 +53,7 @@ export function buildOrganizationsNamespace(
 				options?.search,
 				ctx.userId,
 			);
-			return orgs.map((o: OrgInfo) => ({
-				id: o.id,
-				slug: o.slug,
-				name: o.name,
-				is_member: o.is_member,
-				visibility: o.visibility,
-			}));
+			return orgs.map(summarize);
 		},
 		async current() {
 			const provider = getWorkspaceProvider();
@@ -66,13 +72,7 @@ export function buildOrganizationsNamespace(
 					visibility: "public",
 				};
 			}
-			return {
-				id: current.id,
-				slug: current.slug,
-				name: current.name,
-				is_member: current.is_member,
-				visibility: current.visibility,
-			};
+			return summarize(current);
 		},
 	};
 }

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -715,6 +715,7 @@ export async function resolveConnectionAuthSelection(params: {
   authProfileSlug?: string | null;
   appAuthProfileSlug?: string | null;
   deviceWorkerId?: string | null;
+  oauthAccountCreatedBy?: string | null;
 }): Promise<AuthSelectionResult> {
   const { organizationId, connectorKey } = params;
   const oauthMethod = getOAuthMethods(params.authSchema)[0] ?? null;
@@ -758,6 +759,7 @@ export async function resolveConnectionAuthSelection(params: {
           connectorKey,
           profileKind: 'oauth_account',
           provider: oauthMethod.provider,
+          createdBy: params.oauthAccountCreatedBy,
         })
       : null);
 

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -31,6 +31,7 @@ import {
 } from "./manage_connections/handlers/auth-actions";
 import { handleSetChannelAbout } from "./manage_connections/handlers/channel-about";
 import { handleConnect } from "./manage_connections/handlers/connect";
+import { handleConnectManaged } from "./manage_connections/handlers/connect-managed";
 import {
 	handleGetConnectorSource,
 	handleInstallConnector,
@@ -54,6 +55,7 @@ import {
 import {
 	ApplyChatConnectionAction,
 	ConnectAction,
+	ConnectManagedAction,
 	CreateAction,
 	DeleteAction,
 	GetAction,
@@ -87,6 +89,7 @@ const manageConnectionsTool = defineActionTool("manage_connections", {
 	get: action(GetAction, handleGet),
 	create: action(CreateAction, handleCreate),
 	connect: action(ConnectAction, handleConnect),
+	connect_managed: action(ConnectManagedAction, handleConnectManaged),
 	update: action(UpdateAction, handleUpdate),
 	apply_chat_connection: action(
 		ApplyChatConnectionAction,

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect-managed.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect-managed.ts
@@ -1,0 +1,59 @@
+import type { ToolContext } from '../../../registry';
+import { joinPublicOrganization } from '../../../../workspace/join-public';
+import { resolveManagedAuthConnectorOffer } from '../../../../workspace/managed-auth-discovery';
+import type { ConnectionsArgs, ManageConnectionsResult } from '../schemas';
+import { handleRequiredManagedConnect } from './connect';
+
+/**
+ * Start a managed OAuth grant from any workspace context.
+ *
+ * The public org + active app profile are revalidated from Postgres before the
+ * user is enrolled. handleConnect then revalidates the managed signal at the
+ * insertion chokepoint (`requireManaged`) so a concurrent visibility/profile
+ * change cannot fall through to an ordinary cloud-synced connection.
+ */
+export async function handleConnectManaged(
+	args: Extract<ConnectionsArgs, { action: 'connect_managed' }>,
+	ctx: ToolContext,
+): Promise<ManageConnectionsResult> {
+	if (!ctx.isAuthenticated || !ctx.userId) {
+		return { error: 'Lobu login is required before using managed auth.' };
+	}
+
+	const offer = await resolveManagedAuthConnectorOffer({
+		organizationSlug: args.managed_by_org,
+		connectorKey: args.connector_key,
+	});
+	if (!offer) {
+		return {
+			error: `No active managed OAuth offer for connector '${args.connector_key}' was found in public org '${args.managed_by_org}'. Discover organizations.list again before retrying.`,
+		};
+	}
+
+	const membership = await joinPublicOrganization({
+		userId: ctx.userId,
+		orgSlug: offer.organizationSlug,
+	});
+	if (membership.status === 'not_found' || membership.status === 'not_public') {
+		return {
+			error: `Managed auth org '${args.managed_by_org}' is no longer available. Discover organizations.list again before retrying.`,
+		};
+	}
+
+	return handleRequiredManagedConnect(
+		{
+			action: 'connect',
+			connector_key: args.connector_key,
+			...(args.display_name ? { display_name: args.display_name } : {}),
+			...(args.slug ? { slug: args.slug } : {}),
+			...(args.config ? { config: args.config } : {}),
+		},
+		{
+			...ctx,
+			organizationId: offer.organizationId,
+			memberRole: membership.role,
+			scopedToOrg: true,
+			allowCrossOrg: false,
+		},
+	);
+}

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect-managed.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect-managed.ts
@@ -7,10 +7,10 @@ import { handleRequiredManagedConnect } from './connect';
 /**
  * Start a managed OAuth grant from any workspace context.
  *
- * The public org + active app profile are revalidated from Postgres before the
- * user is enrolled. handleConnect then revalidates the managed signal at the
- * insertion chokepoint (`requireManaged`) so a concurrent visibility/profile
- * change cannot fall through to an ordinary cloud-synced connection.
+ * The public org + active app profile are validated from Postgres before the
+ * user is enrolled. The joined organization supplies the cross-org context,
+ * and handleConnect refuses to create an ordinary cloud-synced connection if
+ * the managed signal no longer holds.
  */
 export async function handleConnectManaged(
 	args: Extract<ConnectionsArgs, { action: 'connect_managed' }>,
@@ -20,11 +20,11 @@ export async function handleConnectManaged(
 		return { error: 'Lobu login is required before using managed auth.' };
 	}
 
-	const offer = await resolveManagedAuthConnectorOffer({
+	const organizationSlug = await resolveManagedAuthConnectorOffer({
 		organizationSlug: args.managed_by_org,
 		connectorKey: args.connector_key,
 	});
-	if (!offer) {
+	if (!organizationSlug) {
 		return {
 			error: `No active managed OAuth offer for connector '${args.connector_key}' was found in public org '${args.managed_by_org}'. Discover organizations.list again before retrying.`,
 		};
@@ -32,7 +32,7 @@ export async function handleConnectManaged(
 
 	const membership = await joinPublicOrganization({
 		userId: ctx.userId,
-		orgSlug: offer.organizationSlug,
+		orgSlug: organizationSlug,
 	});
 	if (membership.status === 'not_found' || membership.status === 'not_public') {
 		return {
@@ -50,7 +50,7 @@ export async function handleConnectManaged(
 		},
 		{
 			...ctx,
-			organizationId: offer.organizationId,
+			organizationId: membership.organizationId,
 			memberRole: membership.role,
 			scopedToOrg: true,
 			allowCrossOrg: false,

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -68,20 +68,20 @@ export async function handleConnect(
 	args: Extract<ConnectionsArgs, { action: "connect" }>,
 	ctx: ToolContext,
 ): Promise<ManageConnectionsResult> {
-	return handleConnectImpl(args, ctx, {});
+	return handleConnectImpl(args, ctx, false);
 }
 
 export async function handleRequiredManagedConnect(
 	args: Extract<ConnectionsArgs, { action: "connect" }>,
 	ctx: ToolContext,
 ): Promise<ManageConnectionsResult> {
-	return handleConnectImpl(args, ctx, { requireManaged: true });
+	return handleConnectImpl(args, ctx, true);
 }
 
 async function handleConnectImpl(
 	args: Extract<ConnectionsArgs, { action: "connect" }>,
 	ctx: ToolContext,
-	options: { requireManaged?: boolean },
+	requireManaged: boolean,
 ): Promise<ManageConnectionsResult> {
   const sql = getDb();
   const { organizationId, userId } = ctx;
@@ -127,16 +127,22 @@ async function handleConnectImpl(
   // App install callback. Selection-aware: a connect that supplies an auth
   // profile / app profile / env creds / managedBy resolves to a different method
   // and is allowed through.
-  const appInstallGuard = await rejectUnboundAppInstallationCreate({
-    organizationId,
-    authSchema: connector.auth_schema,
-    config: args.config,
-    connectorKey: args.connector_key,
-    authProfileSlug: args.auth_profile_slug,
-    appAuthProfileSlug: args.app_auth_profile_slug,
-    gatewayBaseUrl: getGatewayBaseUrl(ctx),
-    setupUrl,
-  });
+  // connect_managed is already an explicit, live-validated OAuth selection.
+  // A connector may prefer app_installation for ordinary bare connects while
+  // still exposing OAuth as its first account-auth method; do not redirect the
+  // managed route into the app-install flow.
+  const appInstallGuard = requireManaged
+    ? null
+    : await rejectUnboundAppInstallationCreate({
+        organizationId,
+        authSchema: connector.auth_schema,
+        config: args.config,
+        connectorKey: args.connector_key,
+        authProfileSlug: args.auth_profile_slug,
+        appAuthProfileSlug: args.app_auth_profile_slug,
+        gatewayBaseUrl: getGatewayBaseUrl(ctx),
+        setupUrl,
+      });
   if (appInstallGuard) {
 		// Setup-required continuation: the App install callback creates the active
 		// connection itself, so do NOT instruct a retry of connect. The guard's
@@ -215,7 +221,7 @@ async function handleConnectImpl(
       AND c.connector_key = ${args.connector_key}
       AND c.status = 'pending_auth'
       AND c.deleted_at IS NULL
-			${options.requireManaged ? sql`AND c.config->>'consent_only' = 'true'` : sql``}
+			${requireManaged ? sql`AND c.config->>'consent_only' = 'true'` : sql``}
       ${explicitSlug ? sql`AND c.slug = ${explicitSlug}` : sql``}
       ${deviceBinding.deviceWorkerId ? sql`AND c.device_worker_id = ${deviceBinding.deviceWorkerId}` : sql``}
       ${userId ? sql`AND c.created_by = ${userId}` : sql``}
@@ -465,7 +471,7 @@ async function handleConnectImpl(
         provider: authSelection.oauthMethod.provider,
       })
     : false;
-	if (options.requireManaged && !isManagedConnect) {
+	if (requireManaged && !isManagedConnect) {
 		return {
 			error:
 				"Managed OAuth is no longer available for this connector. Discover managed_auth offers again before retrying.",

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -68,6 +68,21 @@ export async function handleConnect(
 	args: Extract<ConnectionsArgs, { action: "connect" }>,
 	ctx: ToolContext,
 ): Promise<ManageConnectionsResult> {
+	return handleConnectImpl(args, ctx, {});
+}
+
+export async function handleRequiredManagedConnect(
+	args: Extract<ConnectionsArgs, { action: "connect" }>,
+	ctx: ToolContext,
+): Promise<ManageConnectionsResult> {
+	return handleConnectImpl(args, ctx, { requireManaged: true });
+}
+
+async function handleConnectImpl(
+	args: Extract<ConnectionsArgs, { action: "connect" }>,
+	ctx: ToolContext,
+	options: { requireManaged?: boolean },
+): Promise<ManageConnectionsResult> {
   const sql = getDb();
   const { organizationId, userId } = ctx;
 	const resumeCall = buildSafeConnectionResumeCall(
@@ -200,6 +215,7 @@ export async function handleConnect(
       AND c.connector_key = ${args.connector_key}
       AND c.status = 'pending_auth'
       AND c.deleted_at IS NULL
+			${options.requireManaged ? sql`AND c.config->>'consent_only' = 'true'` : sql``}
       ${explicitSlug ? sql`AND c.slug = ${explicitSlug}` : sql``}
       ${deviceBinding.deviceWorkerId ? sql`AND c.device_worker_id = ${deviceBinding.deviceWorkerId}` : sql``}
       ${userId ? sql`AND c.created_by = ${userId}` : sql``}
@@ -449,6 +465,12 @@ export async function handleConnect(
         provider: authSelection.oauthMethod.provider,
       })
     : false;
+	if (options.requireManaged && !isManagedConnect) {
+		return {
+			error:
+				"Managed OAuth is no longer available for this connector. Discover managed_auth offers again before retrying.",
+		};
+	}
   const connectionConfigToInsert =
     isManagedConnect || splitConfig.connectionConfig
       ? {

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -271,6 +271,7 @@ async function handleConnectImpl(
     authProfileSlug: args.auth_profile_slug,
     appAuthProfileSlug: args.app_auth_profile_slug,
     deviceWorkerId: deviceBinding.deviceWorkerId,
+    oauthAccountCreatedBy: requireManaged ? userId : undefined,
   });
 
   const hasNoAuth =

--- a/packages/server/src/tools/admin/manage_connections/schemas.ts
+++ b/packages/server/src/tools/admin/manage_connections/schemas.ts
@@ -1,6 +1,7 @@
 export {
 	ApplyChatConnectionAction,
 	ConnectAction,
+	ConnectManagedAction,
 	CreateAction,
 	DeleteAction,
 	GetAction,

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -33,7 +33,7 @@ export interface ConnectorDiscoveryDeps {
 const DEFAULT_DEPS: ConnectorDiscoveryDeps = {
   manageCatalog,
   manageConnections,
-  listOrganizations: (userId) =>
+  listOrganizations: async (userId) =>
     getWorkspaceProvider().listOrganizations(undefined, userId),
 };
 
@@ -104,7 +104,10 @@ export async function searchLiveConnectors(
       manageCatalog({ action: 'list_catalog', kinds: ['connectors'] } as never, env, ctx) as Promise<{
         catalogs?: { connectors?: { entries?: unknown } };
       }>,
-      deps.listOrganizations(ctx.userId),
+      // Managed-auth offers enrich the normal connector result, but they are
+      // not required to discover connectors that are already installed or in
+      // the catalog. Keep that base path available if org discovery fails.
+      deps.listOrganizations(ctx.userId).catch(() => []),
     ]);
     const installed = asArray<{
       id: string;

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -21,13 +21,21 @@ import { manageCatalog } from './admin/manage_catalog';
 import { manageConnections } from './admin/manage_connections';
 import type { Env } from '../index';
 import type { ToolContext } from './registry';
+import { getWorkspaceProvider } from '../workspace';
+import type { OrgInfo } from '../workspace/types';
 
 export interface ConnectorDiscoveryDeps {
   manageCatalog: typeof manageCatalog;
   manageConnections: typeof manageConnections;
+  listOrganizations: (userId: string) => Promise<OrgInfo[]>;
 }
 
-const DEFAULT_DEPS: ConnectorDiscoveryDeps = { manageCatalog, manageConnections };
+const DEFAULT_DEPS: ConnectorDiscoveryDeps = {
+  manageCatalog,
+  manageConnections,
+  listOrganizations: (userId) =>
+    getWorkspaceProvider().listOrganizations(undefined, userId),
+};
 
 function asArray<T = Record<string, unknown>>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
@@ -89,13 +97,14 @@ export async function searchLiveConnectors(
   if (!ctx.userId) return [];
   const lines: string[] = [];
   try {
-    const [inst, cat] = await Promise.all([
+    const [inst, cat, organizations] = await Promise.all([
       manageCatalog({ action: 'list_installed', kinds: ['connectors'] } as never, env, ctx) as Promise<{
         installed?: { connectors?: { items?: unknown } };
       }>,
       manageCatalog({ action: 'list_catalog', kinds: ['connectors'] } as never, env, ctx) as Promise<{
         catalogs?: { connectors?: { entries?: unknown } };
       }>,
+      deps.listOrganizations(ctx.userId),
     ]);
     const installed = asArray<{
       id: string;
@@ -109,6 +118,32 @@ export async function searchLiveConnectors(
       detail?: { installable?: boolean; installability_message?: string; installability_reason?: string };
     }>(cat.catalogs?.connectors?.entries);
     const installedIds = new Set(installed.map((i) => i.id));
+    const managedOffers = new Map<
+      string,
+      Array<{
+        organizationSlug: string;
+        joinRequired: boolean;
+        connectMethod: 'connections.connectManaged';
+        localBootstrapCommand: string;
+      }>
+    >();
+    for (const organization of organizations) {
+      for (const offer of organization.managed_auth?.connectors ?? []) {
+        const entries = managedOffers.get(offer.connector_key) ?? [];
+        entries.push({
+          organizationSlug: offer.managed_by_org,
+          joinRequired: organization.managed_auth?.join_required ?? !organization.is_member,
+          connectMethod: organization.managed_auth!.connect_method,
+          localBootstrapCommand: organization.managed_auth!.local_bootstrap_command,
+        });
+        managedOffers.set(offer.connector_key, entries);
+      }
+    }
+    const withManagedAuth = (connectorKey: string, line: string): string => {
+      const offer = managedOffers.get(connectorKey)?.[0];
+      if (!offer) return line;
+      return `${line} Managed OAuth is available from public org '${offer.organizationSlug}' (Lobu login and one-time provider consent required; ${offer.joinRequired ? 'membership is added automatically' : 'already joined'}). Start it with run_sdk → client.${offer.connectMethod}({ managed_by_org: '${offer.organizationSlug}', connector_key: '${connectorKey}' }); after consent, \`${offer.localBootstrapCommand}\` generates the local managedBy config so provider data stays local.`;
+    };
 
     // Only the installed connectors that MATCH the query need a status — resolve
     // their connections. Two targeted probes per connector rather than a single
@@ -154,24 +189,24 @@ export async function searchLiveConnectors(
         : `This connector has no data feeds — it exposes operations/actions. Discover them via query_sdk → client.operations.listAvailable({ connector_key: '${i.id}' }) and run with client.operations.execute.`;
       const status = bestStatus(i.id);
       if (status && USABLE.has(status)) {
-        lines.push(
+        lines.push(withManagedAuth(i.id,
           `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED and CONNECTED (active connection).${feedKeysNote} ${useHint} Get the connection_id via query_sdk → client.connections.list({ connector_key: '${i.id}' }).`
-        );
+        ));
       } else if (status) {
         // Connection exists but is NOT usable (revoked/error/paused/pending) —
         // repair it before use.
-        lines.push(
+        lines.push(withManagedAuth(i.id,
           `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED with a connection that needs attention (status: ${status}).${feedKeysNote} Reauthenticate/repair before use: run_sdk → client.connections.reauthenticate(<connection_id>) (or reconnect). Find the connection via query_sdk → client.connections.list({ connector_key: '${i.id}' }).`
-        );
+        ));
       } else if (hasFeeds) {
-        lines.push(
+        lines.push(withManagedAuth(i.id,
           `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED, not yet configured.${feedKeysNote} Lifecycle: run_sdk → client.connections.connect({ connector_key: '${i.id}' }) → client.feeds.create({ connection_id, feed_key: ${feedKeyHint}, config }) → client.feeds.trigger({ feed_id }); then query_sql on events or search_memory to read. Use search_sdk 'feeds.create feeds.trigger' for signatures.`
-        );
+        ));
       } else {
         // Feedless connector, not yet connected — connect, then use operations.
-        lines.push(
+        lines.push(withManagedAuth(i.id,
           `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED, not yet connected. It has no data feeds — it exposes operations/actions. Lifecycle: run_sdk → client.connections.connect({ connector_key: '${i.id}' }); then query_sdk → client.operations.listAvailable({ connector_key: '${i.id}' }) and run with client.operations.execute.`
-        );
+        ));
       }
     }
     for (const c of catalog) {
@@ -189,9 +224,9 @@ export async function searchLiveConnectors(
         );
         continue;
       }
-      lines.push(
+      lines.push(withManagedAuth(c.id,
         `connector '${c.id}' (${c.name ?? c.id}) — in the global CATALOG, not yet installed here. Install with run_sdk → client.connections.installConnector({ connector_id: '${c.id}' }), then connect + create feed.`
-      );
+      ));
     }
   } catch {
     return [];

--- a/packages/server/src/tools/organizations.ts
+++ b/packages/server/src/tools/organizations.ts
@@ -43,6 +43,6 @@ async function listOrganizationsImpl(
     is_member: o.is_member,
     is_current: ctx.currentOrganizationId !== null && o.id === ctx.currentOrganizationId,
     visibility: o.visibility,
+    ...(o.managed_auth ? { managed_auth: o.managed_auth } : {}),
   }));
 }
-

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -246,7 +246,7 @@ const INTERNAL_DISPATCH_TOOLS: ToolDefinition[] = [
   {
     name: 'list_organizations',
     description:
-      'List organizations the authenticated user belongs to, plus any public workspaces the session can read. SDK alternative: client.organizations.list via `query_sdk` / `run_sdk`.',
+      'List organizations the authenticated user belongs to, plus any public workspaces the session can read. Managed connector providers include structured managed_auth onboarding metadata. SDK alternative: client.organizations.list via `query_sdk` / `run_sdk`.',
     inputSchema: ListOrganizationsSchema,
     annotations: { ...READ_ONLY, title: 'List organizations' },
     handler: async () => {

--- a/packages/server/src/utils/auth-profiles.ts
+++ b/packages/server/src/utils/auth-profiles.ts
@@ -615,6 +615,7 @@ export async function getPrimaryAuthProfileForKind(params: {
   profileKind: AuthProfileKind;
   provider?: string | null;
   deviceWorkerId?: string | null;
+  createdBy?: string | null;
 }): Promise<AuthProfileRow | null> {
   const sql = getDb();
 
@@ -680,6 +681,11 @@ export async function getPrimaryAuthProfileForKind(params: {
       AND profile_kind = ${params.profileKind}
       AND connector_key = ${params.connectorKey}
       AND status = 'active'
+      ${
+        params.profileKind === 'oauth_account' && params.createdBy !== undefined
+          ? sql`AND created_by IS NOT DISTINCT FROM ${params.createdBy ?? null}`
+          : sql``
+      }
     ORDER BY updated_at DESC, id DESC
     LIMIT 1
   `;

--- a/packages/server/src/workspace/managed-auth-discovery.ts
+++ b/packages/server/src/workspace/managed-auth-discovery.ts
@@ -1,0 +1,98 @@
+import { getDb, pgTextArray } from '../db/client';
+
+export interface ManagedAuthConnectorOffer {
+  connector_key: string;
+  provider: string;
+}
+
+/**
+ * List OAuth connectors backed by an active managed app in public orgs.
+ *
+ * This deliberately mirrors getPrimaryAuthProfileForKind's provider fallback:
+ * an active provider-wide Google app can serve both Gmail and Calendar even
+ * when the profile's connector_key names only one of them. Only identifiers
+ * are returned; app credentials and profile metadata never leave the server.
+ */
+export async function listManagedAuthConnectorOffers(
+  organizationIds: string[],
+): Promise<Map<string, ManagedAuthConnectorOffer[]>> {
+  if (organizationIds.length === 0) return new Map();
+
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT DISTINCT
+      d.organization_id,
+      d.key AS connector_key,
+      lower(method->>'provider') AS provider
+    FROM connector_definitions d
+    JOIN "organization" o ON o.id = d.organization_id
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(d.auth_schema->'methods') = 'array'
+          THEN d.auth_schema->'methods'
+        ELSE '[]'::jsonb
+      END
+    ) method
+    WHERE d.organization_id = ANY(${pgTextArray(organizationIds)}::text[])
+      AND d.status = 'active'
+      AND o.visibility = 'public'
+      AND method->>'type' = 'oauth'
+      AND NULLIF(method->>'provider', '') IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM auth_profiles ap
+        WHERE ap.organization_id = d.organization_id
+          AND ap.profile_kind = 'oauth_app'
+          AND ap.status = 'active'
+          AND (
+            ap.connector_key = d.key
+            OR lower(ap.provider) = lower(method->>'provider')
+          )
+      )
+    ORDER BY d.organization_id, d.key
+  `) as unknown as Array<{
+    organization_id: string;
+    connector_key: string;
+    provider: string;
+  }>;
+
+  const byOrganization = new Map<string, ManagedAuthConnectorOffer[]>();
+  for (const row of rows) {
+    const offers = byOrganization.get(row.organization_id) ?? [];
+    offers.push({ connector_key: row.connector_key, provider: row.provider });
+    byOrganization.set(row.organization_id, offers);
+  }
+  return byOrganization;
+}
+
+export async function resolveManagedAuthConnectorOffer(params: {
+  organizationSlug: string;
+  connectorKey: string;
+}): Promise<{
+  organizationId: string;
+  organizationSlug: string;
+  provider: string;
+} | null> {
+  const sql = getDb();
+  const organizations = (await sql`
+    SELECT id, slug
+    FROM "organization"
+    WHERE slug = ${params.organizationSlug}
+      AND visibility = 'public'
+    LIMIT 1
+  `) as unknown as Array<{ id: string; slug: string }>;
+  const organization = organizations[0];
+  if (!organization) return null;
+
+  const offers = await listManagedAuthConnectorOffers([organization.id]);
+  const offer = offers
+    .get(organization.id)
+    ?.find((candidate) => candidate.connector_key === params.connectorKey);
+  return offer
+    ? {
+        organizationId: organization.id,
+        organizationSlug: organization.slug,
+        provider: offer.provider,
+      }
+    : null;
+}

--- a/packages/server/src/workspace/managed-auth-discovery.ts
+++ b/packages/server/src/workspace/managed-auth-discovery.ts
@@ -1,6 +1,6 @@
 import { getDb, pgTextArray } from '../db/client';
 
-export interface ManagedAuthConnectorOffer {
+interface ManagedAuthConnectorOffer {
   connector_key: string;
   provider: string;
 }
@@ -8,10 +8,11 @@ export interface ManagedAuthConnectorOffer {
 /**
  * List OAuth connectors backed by an active managed app in public orgs.
  *
- * This deliberately mirrors getPrimaryAuthProfileForKind's provider fallback:
- * an active provider-wide Google app can serve both Gmail and Calendar even
- * when the profile's connector_key names only one of them. Only identifiers
- * are returned; app credentials and profile metadata never leave the server.
+ * This mirrors runtime auth selection: only a connector whose first declared
+ * oauth/env_keys/browser method is OAuth is offered. The profile resolver's
+ * provider fallback lets an active provider-wide Google app serve both Gmail
+ * and Calendar even when the profile names only one. Only identifiers are
+ * returned; app credentials and profile metadata never leave the server.
  */
 export async function listManagedAuthConnectorOffers(
   organizationIds: string[],
@@ -23,21 +24,27 @@ export async function listManagedAuthConnectorOffers(
     SELECT DISTINCT
       d.organization_id,
       d.key AS connector_key,
-      lower(method->>'provider') AS provider
+      lower(preferred_method.method->>'provider') AS provider
     FROM connector_definitions d
     JOIN "organization" o ON o.id = d.organization_id
-    CROSS JOIN LATERAL jsonb_array_elements(
-      CASE
-        WHEN jsonb_typeof(d.auth_schema->'methods') = 'array'
-          THEN d.auth_schema->'methods'
-        ELSE '[]'::jsonb
-      END
-    ) method
+    CROSS JOIN LATERAL (
+      SELECT candidate.method
+      FROM jsonb_array_elements(
+        CASE
+          WHEN jsonb_typeof(d.auth_schema->'methods') = 'array'
+            THEN d.auth_schema->'methods'
+          ELSE '[]'::jsonb
+        END
+      ) WITH ORDINALITY candidate(method, position)
+      WHERE candidate.method->>'type' IN ('oauth', 'env_keys', 'browser')
+      ORDER BY candidate.position
+      LIMIT 1
+    ) preferred_method
     WHERE d.organization_id = ANY(${pgTextArray(organizationIds)}::text[])
       AND d.status = 'active'
       AND o.visibility = 'public'
-      AND method->>'type' = 'oauth'
-      AND NULLIF(method->>'provider', '') IS NOT NULL
+      AND preferred_method.method->>'type' = 'oauth'
+      AND NULLIF(preferred_method.method->>'provider', '') IS NOT NULL
       AND EXISTS (
         SELECT 1
         FROM auth_profiles ap
@@ -46,7 +53,7 @@ export async function listManagedAuthConnectorOffers(
           AND ap.status = 'active'
           AND (
             ap.connector_key = d.key
-            OR lower(ap.provider) = lower(method->>'provider')
+            OR lower(ap.provider) = lower(preferred_method.method->>'provider')
           )
       )
     ORDER BY d.organization_id, d.key
@@ -68,11 +75,7 @@ export async function listManagedAuthConnectorOffers(
 export async function resolveManagedAuthConnectorOffer(params: {
   organizationSlug: string;
   connectorKey: string;
-}): Promise<{
-  organizationId: string;
-  organizationSlug: string;
-  provider: string;
-} | null> {
+}): Promise<string | null> {
   const sql = getDb();
   const organizations = (await sql`
     SELECT id, slug
@@ -88,11 +91,5 @@ export async function resolveManagedAuthConnectorOffer(params: {
   const offer = offers
     .get(organization.id)
     ?.find((candidate) => candidate.connector_key === params.connectorKey);
-  return offer
-    ? {
-        organizationId: organization.id,
-        organizationSlug: organization.slug,
-        provider: offer.provider,
-      }
-    : null;
+  return offer ? organization.slug : null;
 }

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -18,6 +18,7 @@ import type {
   ResolvedOwner,
   WorkspaceProvider,
 } from './types';
+import { listManagedAuthConnectorOffers } from './managed-auth-discovery';
 import {
   memberRoleCache,
   orgSlugCache,
@@ -642,32 +643,56 @@ export class MultiTenantProvider implements WorkspaceProvider {
 
   async listOrganizations(search?: string, userId?: string | null): Promise<OrgInfo[]> {
     const sql = getDb();
+    let organizations: OrgInfo[];
 
     if (!userId) {
       const params: string[] = [];
       const searchClause = search ? `AND o.name ILIKE $${params.push(`%${search}%`)}` : '';
 
-      return sql.unsafe(
+      organizations = (await sql.unsafe(
         `SELECT o.id, o.name, o.slug, o.logo, o.description, o."createdAt" as created_at, false as is_member, o.visibility
          FROM "organization" o
          WHERE o.visibility = 'public' ${searchClause}
          ORDER BY o.name ASC`,
         params
-      );
+      )) as unknown as OrgInfo[];
+    } else {
+      const params: string[] = [userId];
+      const searchClause = search ? `AND o.name ILIKE $${params.push(`%${search}%`)}` : '';
+
+      organizations = (await sql.unsafe(
+        `SELECT o.id, o.name, o.slug, o.logo, o.description, o."createdAt" as created_at,
+                (m."userId" IS NOT NULL) as is_member, o.visibility
+         FROM "organization" o
+         LEFT JOIN "member" m ON o.id = m."organizationId" AND m."userId" = $1
+         WHERE (m."userId" IS NOT NULL OR o.visibility = 'public') ${searchClause}
+         ORDER BY o.name ASC`,
+        params
+      )) as unknown as OrgInfo[];
     }
 
-    const params: string[] = [userId];
-    const searchClause = search ? `AND o.name ILIKE $${params.push(`%${search}%`)}` : '';
-
-    return sql.unsafe(
-      `SELECT o.id, o.name, o.slug, o.logo, o.description, o."createdAt" as created_at,
-              (m."userId" IS NOT NULL) as is_member, o.visibility
-       FROM "organization" o
-       LEFT JOIN "member" m ON o.id = m."organizationId" AND m."userId" = $1
-       WHERE (m."userId" IS NOT NULL OR o.visibility = 'public') ${searchClause}
-       ORDER BY o.name ASC`,
-      params
+    const offers = await listManagedAuthConnectorOffers(
+      organizations.map((organization) => organization.id)
     );
+    return organizations.map((organization) => {
+      const connectors = offers.get(organization.id);
+      if (!connectors?.length) return organization;
+      return {
+        ...organization,
+        managed_auth: {
+          credential_mode: 'managed' as const,
+          requires_user_login: true as const,
+          requires_user_consent: true as const,
+          join_required: !organization.is_member,
+          connect_method: 'connections.connectManaged' as const,
+          local_bootstrap_command: `lobu init --from-org ${organization.slug}`,
+          connectors: connectors.map((connector) => ({
+            ...connector,
+            managed_by_org: organization.slug,
+          })),
+        },
+      };
+    });
   }
 
   async getAuthConfig(env: Env): Promise<AuthConfigData> {

--- a/packages/server/src/workspace/types.ts
+++ b/packages/server/src/workspace/types.ts
@@ -31,6 +31,19 @@ export interface OrgInfo {
   created_at: string;
   is_member: boolean;
   visibility: 'public' | 'private';
+  managed_auth?: {
+    credential_mode: 'managed';
+    requires_user_login: true;
+    requires_user_consent: true;
+    join_required: boolean;
+    connect_method: 'connections.connectManaged';
+    local_bootstrap_command: string;
+    connectors: Array<{
+      connector_key: string;
+      provider: string;
+      managed_by_org: string;
+    }>;
+  };
 }
 
 export interface AuthConfigData {


### PR DESCRIPTION
## Summary
- Advertise live public managed OAuth offers through structured `organizations.list()` metadata, without exposing credentials or hardcoding `lobu-cloud`.
- Add `client.connections.connectManaged(...)`: validate the live offer, auto-join a signed-in user, and create only a private caller-owned consent grant with zero cloud feeds.
- Keep discovery aligned with runtime auth precedence and preserve ordinary connector search when optional managed-auth lookup is unavailable.
- Teach connector discovery the exact org, login/consent boundary, managed connect call, and local `lobu init --from-org <slug>` path.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] DB-backed managed-auth integration suite
- [x] Focused unit regression suites
- [x] Bug fixes include red -> fix -> green evidence
- [x] Final Codex semantic review on exact head: 0 bugs, 0 blockers
- [ ] `make test-unit` fully clean: existing unrelated agent-worker assertion mismatch remains (details below)

### Feature red

`cd packages/server && bunx vitest run src/__tests__/integration/managed-auth-onboarding.test.ts`

```text
Test Files  1 failed (1)
Tests       3 failed | 1 passed (4)
- managed_auth metadata was missing
- client.connections.connectManaged is not a function (2 tests)
```

### Feature green

```text
Test Files  1 passed (1)
Tests       5 passed (5)
```

### Codex review red

`bun test packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts`

```text
29 pass
10 fail
DATABASE_URL is required escaped before Promise.all could observe the catalog promises
```

`bun test packages/server/src/__tests__/unit/connector-discovery.test.ts`

```text
17 pass
1 fail
managed-auth discovery failure erased an otherwise valid Website connector result
```

Two-user managed OAuth regression before the isolation fix:

```text
expected pending_auth, received active
second user reused the first user's active managed OAuth account
```

### Codex review green

```text
bun test packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts \
  packages/server/src/__tests__/unit/connector-discovery.test.ts \
  packages/server/src/auth/__tests__/tool-access.test.ts \
  packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts

145 pass
0 fail
```

```text
cd packages/server && bunx vitest run src/__tests__/integration/managed-auth-onboarding.test.ts

Test Files  1 passed (1)
Tests       6 passed (6)
```

```text
cd packages/server && bunx vitest run \
  src/utils/__tests__/auth-profiles.test.ts \
  src/__tests__/integration/managed-auth-onboarding.test.ts

Test Files  2 passed (2)
Tests       10 passed (10)
```

```text
make pre-pr
all 6 pre-PR gates clean
```

## Notes
- `make test-unit`: 823 pass, 12 skip, 1 unrelated baseline failure in `packages/agent-worker/src/__tests__/exec-sandbox-extra.test.ts`; test expects `bubblewrap is unavailable`, runtime says `bubblewrap (bwrap) was not found on PATH`. The same failure reproduces on untouched `origin/main`, and both involved files are unchanged on this branch.
- Final Codex semantic review on exact head `8889a2187c8f85f0f1a9c7bab428d96e18705b68`: bug-free 85, 0 bugs, 0 blockers, tests adequate.
- Live clean-account OAuth E2E is gated on merge and production rollout; planned account: `emre.kabakci@gmail.com`.
