### PR TITLE
fix(db): apply skipped Behavior output migration

### DIFF
--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: lobu
 description: Lobu Platform - Never forget anything. User content analysis with AI.
 type: application
-version: 14.12.0
-appVersion: 14.12.0
+version: 14.12.1
+appVersion: 14.12.1
 keywords:
   - lobu
   - content

--- a/db/migrations/20260803191113_behavior_outputs.sql
+++ b/db/migrations/20260803191113_behavior_outputs.sql
@@ -1,3 +1,5 @@
+-- This migration was renamed from version 20260803140000 after that ledger
+-- version collided with mcp_conversation_client_software_id in production.
 -- Hard-cut the single entity-only configuration over to named durable outputs.
 -- Existing versions are converted before the retired column is dropped in this
 -- same transaction. Stable-key identities gain the output name, allowing one
@@ -404,6 +406,6 @@ COMMENT ON COLUMN watcher_versions.outputs IS
 DO $migration$
 BEGIN
   RAISE EXCEPTION
-    '20260803140000_behavior_outputs is an irreversible hard cutover; restore from backup instead of recreating the retired API';
+    '20260803191113_behavior_outputs is an irreversible hard cutover; restore from backup instead of recreating the retired API';
 END
 $migration$;

--- a/packages/server/src/__tests__/integration/migrations/behavior-outputs-migration.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/behavior-outputs-migration.test.ts
@@ -13,7 +13,7 @@ import { cleanupTestDatabase } from '../../setup/test-db';
 import { createTestAgent } from '../../setup/test-fixtures';
 import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
 
-const MIGRATION = '20260803140000_behavior_outputs.sql';
+const MIGRATION = '20260803191113_behavior_outputs.sql';
 
 function resolveMigrationsDir(): string {
   let dir = __dirname;

--- a/packages/server/src/db/__tests__/migration-loader.test.ts
+++ b/packages/server/src/db/__tests__/migration-loader.test.ts
@@ -1,0 +1,24 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { listMigrationFiles } from '../migration-loader';
+
+describe('listMigrationFiles', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'migration-loader-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('fails closed when two files share one schema_migrations version', () => {
+    writeFileSync(path.join(dir, '20260803140000_behavior_outputs.sql'), '');
+    writeFileSync(path.join(dir, '20260803140000_mcp_client_id.sql'), '');
+
+    expect(() => listMigrationFiles(dir)).toThrow(/duplicate migration version 20260803140000/i);
+  });
+});

--- a/packages/server/src/db/migration-loader.ts
+++ b/packages/server/src/db/migration-loader.ts
@@ -1,10 +1,31 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+const MIGRATION_FILENAME_RE = /^(\d+)_[^/]+\.sql$/;
+
+export function assertUniqueMigrationVersions(files: string[]): void {
+  const ownerByVersion = new Map<string, string>();
+  for (const file of files) {
+    const match = MIGRATION_FILENAME_RE.exec(file);
+    if (!match) continue;
+    const version = match[1]!;
+    const owner = ownerByVersion.get(version);
+    if (owner) {
+      throw new Error(
+        `Duplicate migration version ${version}: ${owner} and ${file}. ` +
+          'Each schema_migrations ledger version must identify exactly one file.'
+      );
+    }
+    ownerByVersion.set(version, file);
+  }
+}
+
 export function listMigrationFiles(migrationsDir: string): string[] {
-  return readdirSync(migrationsDir)
+  const files = readdirSync(migrationsDir)
     .filter((file) => file.endsWith('.sql'))
     .sort();
+  assertUniqueMigrationVersions(files);
+  return files;
 }
 
 export type MigrationSection = {

--- a/packages/server/src/utils/__tests__/schema-version-check.test.ts
+++ b/packages/server/src/utils/__tests__/schema-version-check.test.ts
@@ -54,6 +54,15 @@ describe('readExpectedSchemaVersion', () => {
   it('returns null for an empty directory', () => {
     expect(readExpectedSchemaVersion(dir)).toBeNull();
   });
+
+  it('fails closed when two migration files share one ledger version', () => {
+    writeFileSync(path.join(dir, '20260803140000_behavior_outputs.sql'), '');
+    writeFileSync(path.join(dir, '20260803140000_mcp_client_id.sql'), '');
+
+    expect(() => readExpectedSchemaVersion(dir)).toThrow(
+      /duplicate migration version 20260803140000/i
+    );
+  });
 });
 
 describe('compareSchemaVersions', () => {

--- a/packages/server/src/utils/schema-version-check.ts
+++ b/packages/server/src/utils/schema-version-check.ts
@@ -19,6 +19,7 @@
 
 import { readdirSync } from 'node:fs';
 import type { DbClient } from '../db/client';
+import { assertUniqueMigrationVersions } from '../db/migration-loader';
 import logger from './logger';
 
 const MIGRATION_FILENAME_RE = /^(\d+)_[^/]+\.sql$/;
@@ -40,6 +41,8 @@ export function readExpectedSchemaVersion(migrationsDir: string): string | null 
     );
     return null;
   }
+
+  assertUniqueMigrationVersions(entries);
 
   let max: string | null = null;
   for (const name of entries) {

--- a/scripts/__tests__/migrate-up-duplicate-version.test.ts
+++ b/scripts/__tests__/migrate-up-duplicate-version.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const MIGRATE_UP = join(REPO_ROOT, "scripts/migrate-up.mjs");
+
+describe("migrate-up migration ledger versions", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "migrate-up-versions-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects duplicate versions before connecting to Postgres", () => {
+    writeFileSync(
+      join(dir, "20260803140000_behavior_outputs.sql"),
+      "-- migrate:up\nSELECT 1;"
+    );
+    writeFileSync(
+      join(dir, "20260803140000_mcp_client_id.sql"),
+      "-- migrate:up\nSELECT 1;"
+    );
+
+    const result = Bun.spawnSync(["node", MIGRATE_UP], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        DATABASE_URL: "postgres://postgres:postgres@127.0.0.1:1/unreachable",
+        MIGRATIONS_DIR: dir,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toMatch(
+      /duplicate migration version 20260803140000/i
+    );
+  });
+});

--- a/scripts/migrate-up.mjs
+++ b/scripts/migrate-up.mjs
@@ -24,9 +24,23 @@ if (!databaseUrl) {
 }
 
 function listMigrationFiles(dir) {
-  return readdirSync(dir)
+  const files = readdirSync(dir)
     .filter((file) => file.endsWith(".sql"))
     .sort();
+  const ownerByVersion = new Map();
+  for (const file of files) {
+    const version = /^(\d+)_[^/]+\.sql$/.exec(file)?.[1];
+    if (!version) continue;
+    const owner = ownerByVersion.get(version);
+    if (owner) {
+      throw new Error(
+        `Duplicate migration version ${version}: ${owner} and ${file}. ` +
+          "Each schema_migrations ledger version must identify exactly one file."
+      );
+    }
+    ownerByVersion.set(version, file);
+  }
+  return files;
 }
 
 function parseTransactionOption(markerLine) {
@@ -160,6 +174,7 @@ async function applyMigration(sqlClient, section, version) {
   await recordMigration(sqlClient, version);
 }
 
+const migrationFiles = listMigrationFiles(migrationsDir);
 const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
 let migrationLockHeld = false;
 
@@ -180,7 +195,7 @@ try {
   );
   const applied = new Set(appliedRows.map((r) => r.version));
 
-  for (const file of listMigrationFiles(migrationsDir)) {
+  for (const file of migrationFiles) {
     const version = file.split("_")[0] ?? "";
     if (applied.has(version)) continue;
     const up = loadMigrationUp(migrationsDir, file);


### PR DESCRIPTION
## Summary
- rename the never-applied Behavior output migration from colliding ledger version `20260803140000` to unique version `20260803191113`
- fail closed on duplicate migration versions in the production migration runner, embedded migration loader, and boot-time schema assertion
- bump the Helm chart to `14.12.1` so Flux performs the mandatory quiesced one-time migration

## Production evidence
Production was serving #2461 (`a1aa7f192898692fb346dc6574152d30011d8beb`), but `BEGIN READ ONLY` verification in the `owletto` database showed:

```text
schema_migrations 20260803140000: present
mcp client_software_id column + trigger: present
watcher_versions.keying_config: present
watcher_versions.outputs: absent
live watcher_key identities: 432
live v2 fixed-size identities: 0
```

The colliding MCP migration claimed the shared version first, so the migration runner correctly skipped every other file with that ledger ID. The Behavior migration body never ran.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] targeted server suite: 19/19
- [x] Helm lint, default render, mandatory-quiescence render, disabled-worker render, and executable migration failure recovery
- [x] Squawk: 0 issues
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red

```text
migration-loader: expected duplicate migration version error; received undefined
schema-version-check: expected duplicate migration version error; received undefined
migrate-up: expected duplicate migration version error; received ECONNREFUSED (runner tried Postgres first)
production: keying_config=true, outputs=false, live_v2_fixed68=0, live_non_v2=432
```

### Green

```text
migrate-up duplicate-version guard: 1/1
migration loader + boot schema assertion: 14/14
Behavior output migration: 5/5
combined targeted suite: 19/19
Helm failure recovery: passed
Squawk: Found 0 issues
make pre-pr: all six gates clean
```

## Rollout
1. Merge only after every required and spawned CI check reports green.
2. Flux sees chart `14.12.1`, quiesces the old app and worker replicas, and applies migration `20260803191113` transactionally.
3. Gate on the squash commit ancestry in the deployed `/health` revision.
4. Verify under `BEGIN READ ONLY`: migration ledger row present, `keying_config` absent, `outputs` present, 123 live fixed-size v2 claims, 309 retired claims, zero live non-v2 claims, zero missing provenance, and zero duplicate live keys.
5. Run the full read-only production smoke before resuming the hourly task Behavior.

## Notes
`make review-fix` was attempted on the settled diff, but Claude's weekly quota is exhausted until Aug 5; it made no working-tree changes. The required posted review will use the authorized Codex reviewer fallback.
