### PR TITLE
fix(example): preserve Behavior source linkage

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1111,7 +1111,7 @@ const hourlyTaskCollaborator = defineBehavior({
   },
   sources: {
     recent_signals:
-      "SELECT id AS source_event_id, COALESCE('connection:' || connection_id::text, 'connector:' || connector_key, 'event') AS source_scope, COALESCE(origin_id, 'event:' || id::text) AS source_origin_id, occurred_at, title, payload_text, semantic_type, connector_key, metadata FROM events WHERE semantic_type IN ('message','thread','reminder','calendar_event','note') ORDER BY occurred_at DESC LIMIT 200",
+      "SELECT id, id AS source_event_id, COALESCE('connection:' || connection_id::text, 'connector:' || connector_key, 'event') AS source_scope, COALESCE(origin_id, 'event:' || id::text) AS source_origin_id, occurred_at, title, payload_text, semantic_type, connector_key, metadata FROM events WHERE semantic_type IN ('message','thread','reminder','calendar_event','note') ORDER BY occurred_at DESC LIMIT 200",
     // context-only: existing tasks are dedup reference data, not window signal
     task_list: {
       context: true,


### PR DESCRIPTION
## Summary
- Project the canonical `id` column required for Behavior window linkage.
- Keep the existing `source_event_id` alias for task provenance.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun packages/cli/src/index.ts validate`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red

```text
POST /api/buremba/manage_behaviors failed: Behavior validation failed: source "recent_signals": query must project an "id" column
```

### Green

```text
~ entity-type task
~ behavior hourly-task-collaborator (prompt, skills, sources, outputs)
Apply complete.
```

The production rollout remained schedule-paused during this validation and the one-time identity re-key.