### PR TITLE
fix(embeddings): exit the forked server when its parent dies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,14 @@ jobs:
           bun test packages/connectors --coverage
           mv coverage/lcov.info coverage/connectors.lcov.info
 
+      - name: embeddings (bun:test)
+        # Previously unrun in CI: the embeddings HTTP suite and the
+        # orphan-reap subprocess regression (forks the real server under
+        # Node via tsx; binds ports 18951-18953). No Postgres needed.
+        run: |
+          bun test packages/embeddings --coverage
+          mv coverage/lcov.info coverage/embeddings.lcov.info
+
       - name: example connectors (bun:test)
         # Unbundled connectors live under examples/; mock @lobu/connector-sdk
         # so Playwright/Baileys never load in CI.
@@ -170,7 +178,7 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v7
         with:
-          files: coverage/core-cli.lcov.info,coverage/plugin-runtime.lcov.info,coverage/agent-worker.lcov.info,coverage/server-units.lcov.info,coverage/server-units-auth.lcov.info,coverage/server-units-activity.lcov.info,coverage/server-units-compiler.lcov.info,coverage/connector-worker.lcov.info,coverage/client-promptfoo.lcov.info,coverage/connector-sdk.lcov.info,coverage/connectors.lcov.info
+          files: coverage/core-cli.lcov.info,coverage/plugin-runtime.lcov.info,coverage/agent-worker.lcov.info,coverage/server-units.lcov.info,coverage/server-units-auth.lcov.info,coverage/server-units-activity.lcov.info,coverage/server-units-compiler.lcov.info,coverage/connector-worker.lcov.info,coverage/client-promptfoo.lcov.info,coverage/connector-sdk.lcov.info,coverage/connectors.lcov.info,coverage/embeddings.lcov.info
           flags: unit
           fail_ci_if_error: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
         # Previously unrun in CI: the embeddings HTTP suite and the
         # orphan-reap subprocess regression (forks the real server under
         # Node via tsx; binds ports 18951-18953). No Postgres needed.
+        # Bounded: if the orphan regression reappears the most likely
+        # symptom is this step hanging on an open child handle.
+        timeout-minutes: 5
         run: |
           bun test packages/embeddings --coverage
           mv coverage/lcov.info coverage/embeddings.lcov.info

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ test-unit:
 	@bun test packages/connector-worker
 	@bun test packages/client packages/promptfoo-provider
 	@bun test packages/connector-sdk
+	@bun test packages/embeddings
 	@bun test examples/personal-agent
 	@bun test examples/brand-intelligence
 

--- a/packages/embeddings/src/__tests__/orphan-reap.test.ts
+++ b/packages/embeddings/src/__tests__/orphan-reap.test.ts
@@ -29,46 +29,68 @@ function spawnServer(opts: {
 	port: number;
 	ipc?: boolean;
 	preload?: string;
-}): ReturnType<typeof spawn> {
+}): { child: ReturnType<typeof spawn>; sawLine: (line: string) => boolean } {
 	const args: string[] = [];
 	if (opts.preload) args.push("--import", opts.preload);
 	args.push("--import", "tsx", SERVER);
-	return spawn("node", args, {
+	const child = spawn("node", args, {
 		cwd: PKG_ROOT,
 		stdio: ["ignore", "pipe", "pipe", ...(opts.ipc === false ? [] : ["ipc"] as const)],
 		env: { ...process.env, PORT: String(opts.port) },
 	});
+	// Rolling buffer from spawn time: pipe chunks can split the target line,
+	// and output emitted before a waiter attaches must not be lost.
+	let buffer = "";
+	child.stdout?.on("data", (chunk: Buffer) => {
+		buffer += chunk.toString();
+	});
+	return { child, sawLine: (line: string) => buffer.includes(line) };
 }
 
-function waitForLine(child: ReturnType<typeof spawn>, line: string): Promise<boolean> {
+// Wait until the rolling stdout buffer contains `line`, or the child exits.
+function waitForLine(
+	child: ReturnType<typeof spawn>,
+	sawLine: (line: string) => boolean,
+	line: string
+): Promise<boolean> {
 	return new Promise((resolve) => {
+		if (sawLine(line)) {
+			resolve(true);
+			return;
+		}
 		const timer = setTimeout(() => resolve(false), 15000);
-		child.stdout?.on("data", (chunk: Buffer) => {
-			if (chunk.toString().includes(line)) {
+		const poll = setInterval(() => {
+			if (sawLine(line)) {
 				clearTimeout(timer);
+				clearInterval(poll);
 				resolve(true);
 			}
-		});
+		}, 50);
 		child.on("exit", () => {
 			clearTimeout(timer);
-			resolve(false);
+			clearInterval(poll);
+			resolve(sawLine(line));
 		});
 	});
 }
 
 describe("orphan reap (forked embeddings server, node runtime)", () => {
 	test("exits 143 when IPC closes after startup", async () => {
-		const child = spawnServer({ port: 18951 });
+		const { child, sawLine } = spawnServer({ port: 18951 });
 		const timer = setTimeout(() => child.kill("SIGKILL"), 20000);
-		const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-			child.on("exit", (code, signal) => resolve({ code, signal }));
-		});
-		expect(await waitForLine(child, "Listening on port")).toBe(true);
-		child.disconnect();
-		const { code, signal } = await exit;
-		clearTimeout(timer);
-		expect(signal).toBeNull();
-		expect(code).toBe(EXIT_REAPED);
+		try {
+			const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+				child.on("exit", (code, signal) => resolve({ code, signal }));
+			});
+			expect(await waitForLine(child, sawLine, "Listening on port")).toBe(true);
+			child.disconnect();
+			const { code, signal } = await exit;
+			expect(signal).toBeNull();
+			expect(code).toBe(EXIT_REAPED);
+		} finally {
+			clearTimeout(timer);
+			if (child.exitCode === null) child.kill("SIGKILL");
+		}
 	}, 30000);
 
 	test("exits 143 when the channel is already gone at handler registration (startup race)", async () => {
@@ -90,28 +112,37 @@ describe("orphan reap (forked embeddings server, node runtime)", () => {
 				"await new Promise((r) => setTimeout(r, 100));\n"
 		);
 
-		const child = spawnServer({ port: 18952, preload });
+		const { child } = spawnServer({ port: 18952, preload });
 		const timer = setTimeout(() => child.kill("SIGKILL"), 20000);
-		const { code, signal } = await new Promise<{
-			code: number | null;
-			signal: NodeJS.Signals | null;
-		}>((resolve) => {
-			child.on("exit", (code, signal) => resolve({ code, signal }));
-		});
-		clearTimeout(timer);
-		expect(signal).toBeNull();
-		expect(code).toBe(EXIT_REAPED);
+		try {
+			const { code, signal } = await new Promise<{
+				code: number | null;
+				signal: NodeJS.Signals | null;
+			}>((resolve) => {
+				child.on("exit", (code, signal) => resolve({ code, signal }));
+			});
+			expect(signal).toBeNull();
+			expect(code).toBe(EXIT_REAPED);
+		} finally {
+			clearTimeout(timer);
+			if (child.exitCode === null) child.kill("SIGKILL");
+		}
 	}, 30000);
 
 	test("standalone spawn without IPC keeps running (guard is inert)", async () => {
-		const child = spawnServer({ port: 18953, ipc: false });
+		const { child, sawLine } = spawnServer({ port: 18953, ipc: false });
 		try {
-			expect(await waitForLine(child, "Listening on port 18953")).toBe(true);
+			expect(await waitForLine(child, sawLine, "Listening on port 18953")).toBe(true);
 			// Still alive a beat later — no IPC channel means nothing to reap it.
 			await new Promise((r) => setTimeout(r, 500));
 			expect(child.exitCode).toBeNull();
 		} finally {
 			child.kill("SIGKILL");
+			// Await the actual exit so the test never ends with a dying child.
+			await new Promise<void>((resolve) => {
+				if (child.exitCode !== null) resolve();
+				else child.on("exit", () => resolve());
+			});
 		}
 	}, 30000);
 });

--- a/packages/embeddings/src/__tests__/orphan-reap.test.ts
+++ b/packages/embeddings/src/__tests__/orphan-reap.test.ts
@@ -1,0 +1,117 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
+
+// Orphan-reap regression: the embedded runtime fork()s this server and only
+// kills it in graceful teardown, so the server must exit when its IPC channel
+// closes. These tests spawn the REAL server under Node (the production
+// runtime — `node dist/server.js`, via tsx for the TS source) and observe the
+// exit. No mocks: the guard runs at module top-level, so only a fresh process
+// per scenario exercises register-vs-check ordering honestly.
+
+const PKG_ROOT = join(import.meta.dir, "..", "..");
+const SERVER = join(import.meta.dir, "..", "server.ts");
+const EXIT_REAPED = 143; // 128 + SIGTERM — "killed externally" convention.
+
+const temporaryDirs: string[] = [];
+afterAll(() => {
+	for (const dir of temporaryDirs) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+// Spawn the server under node+tsx. `ipc: false` models standalone `npm start`
+// (no IPC channel); `preload` runs before the server module and can close the
+// channel from the child side to model a parent death during module load.
+function spawnServer(opts: {
+	port: number;
+	ipc?: boolean;
+	preload?: string;
+}): ReturnType<typeof spawn> {
+	const args: string[] = [];
+	if (opts.preload) args.push("--import", opts.preload);
+	args.push("--import", "tsx", SERVER);
+	return spawn("node", args, {
+		cwd: PKG_ROOT,
+		stdio: ["ignore", "pipe", "pipe", ...(opts.ipc === false ? [] : ["ipc"] as const)],
+		env: { ...process.env, PORT: String(opts.port) },
+	});
+}
+
+function waitForLine(child: ReturnType<typeof spawn>, line: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const timer = setTimeout(() => resolve(false), 15000);
+		child.stdout?.on("data", (chunk: Buffer) => {
+			if (chunk.toString().includes(line)) {
+				clearTimeout(timer);
+				resolve(true);
+			}
+		});
+		child.on("exit", () => {
+			clearTimeout(timer);
+			resolve(false);
+		});
+	});
+}
+
+describe("orphan reap (forked embeddings server, node runtime)", () => {
+	test("exits 143 when IPC closes after startup", async () => {
+		const child = spawnServer({ port: 18951 });
+		const timer = setTimeout(() => child.kill("SIGKILL"), 20000);
+		const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+			child.on("exit", (code, signal) => resolve({ code, signal }));
+		});
+		expect(await waitForLine(child, "Listening on port")).toBe(true);
+		child.disconnect();
+		const { code, signal } = await exit;
+		clearTimeout(timer);
+		expect(signal).toBeNull();
+		expect(code).toBe(EXIT_REAPED);
+	}, 30000);
+
+	test("exits 143 when the channel is already gone at handler registration (startup race)", async () => {
+		// Node does not replay a 'disconnect' emitted before a listener exists.
+		// The preload closes the channel from the child side BEFORE server.ts
+		// evaluates, which is exactly the state a parent death during module
+		// load leaves: process.connected false, the event already dropped.
+		// Without the `process.connected` re-check the server would leak here.
+		const dir = mkdtempSync(join(tmpdir(), "lobu-orphan-preload-"));
+		temporaryDirs.push(dir);
+		const preload = join(dir, "disconnect-preload.mjs");
+		// The yield forces the event loop to process the channel close while no
+		// listener exists, so 'disconnect' is dropped for real — without it Node
+		// defers the event until after registration and the plain listener alone
+		// would pass this test.
+		writeFileSync(
+			preload,
+			"if (process.connected) process.disconnect();\n" +
+				"await new Promise((r) => setTimeout(r, 100));\n"
+		);
+
+		const child = spawnServer({ port: 18952, preload });
+		const timer = setTimeout(() => child.kill("SIGKILL"), 20000);
+		const { code, signal } = await new Promise<{
+			code: number | null;
+			signal: NodeJS.Signals | null;
+		}>((resolve) => {
+			child.on("exit", (code, signal) => resolve({ code, signal }));
+		});
+		clearTimeout(timer);
+		expect(signal).toBeNull();
+		expect(code).toBe(EXIT_REAPED);
+	}, 30000);
+
+	test("standalone spawn without IPC keeps running (guard is inert)", async () => {
+		const child = spawnServer({ port: 18953, ipc: false });
+		try {
+			expect(await waitForLine(child, "Listening on port 18953")).toBe(true);
+			// Still alive a beat later — no IPC channel means nothing to reap it.
+			await new Promise((r) => setTimeout(r, 500));
+			expect(child.exitCode).toBeNull();
+		} finally {
+			child.kill("SIGKILL");
+		}
+	}, 30000);
+});

--- a/packages/embeddings/src/server.ts
+++ b/packages/embeddings/src/server.ts
@@ -216,6 +216,15 @@ app.post("/api/embeddings", async (c) => {
 	}
 });
 
+// When forked by the embedded runtime (startEmbeddings), exit if the parent
+// dies without a graceful teardown — otherwise the child is orphaned and leaks
+// until killed by hand. Standalone `npm start` has no IPC channel, so
+// process.send is undefined and this never fires. Same pattern as
+// connector-worker child-runner.ts installParentDeathHandlers().
+if (process.send) {
+	process.on("disconnect", () => process.exit(143));
+}
+
 const port = Number.parseInt(process.env.PORT || String(DEFAULT_PORT), 10);
 
 serve({

--- a/packages/embeddings/src/server.ts
+++ b/packages/embeddings/src/server.ts
@@ -221,8 +221,14 @@ app.post("/api/embeddings", async (c) => {
 // until killed by hand. Standalone `npm start` has no IPC channel, so
 // process.send is undefined and this never fires. Same pattern as
 // connector-worker child-runner.ts installParentDeathHandlers().
+//
+// Register the listener BEFORE checking process.connected: Node does not
+// replay a 'disconnect' emitted before a listener exists, and the parent can
+// die mid-module-load (imports run before this line). Register-then-check is
+// gap-free — no event can be processed between two synchronous statements.
 if (process.send) {
 	process.on("disconnect", () => process.exit(143));
+	if (!process.connected) process.exit(143);
 }
 
 const port = Number.parseInt(process.env.PORT || String(DEFAULT_PORT), 10);


### PR DESCRIPTION
## Summary
- the embedded runtime `fork()`s the `@lobu/embeddings` server and only kills it in graceful teardown (`embedded-runtime.ts` `startEmbeddings`); any non-graceful parent exit (SIGKILL, crash) orphans the child to launchd, where it leaks until killed by hand — 31 leaked `@lobu/embeddings` servers accumulated this way (some months old)
- register a `disconnect` handler in the embeddings server that exits (143) when the IPC channel closes; the `process.send` guard keeps standalone `npm start` (no IPC channel) alive
- close the startup race flagged in review: Node drops a `disconnect` emitted before a listener exists, so the handler registers first and then exits immediately when `process.connected` is already false (register-then-check is gap-free)
- matches the existing repo convention in `packages/connector-worker/src/executor/child-runner.ts` (`installParentDeathHandlers`)

## Test plan
- [x] make pre-pr clean (build + typecheck + lint + exposed-surface + gateway-llm gates), twice (initial + post-review fix)
- [x] `bun test packages/embeddings/src` — 24/24 pass (21 existing + 3 new subprocess tests)
- [x] Bug fix: red→fix→green against the real built server, all cases verified:

Red (unfixed dist forked with IPC, parent SIGKILLed):
child pid alive 4s after parent death — leaked, reproducing the orphan.

Green (fixed dist, parent SIGKILLed):
child exited (143) on IPC disconnect.

Startup race (channel dropped before handler registration):
new `orphan-reap.test.ts` spawns the real server under Node (via tsx) with a preload that closes the IPC channel and yields, so `disconnect` is emitted with no listener and dropped — without the `process.connected` re-check the child leaks until SIGKILL (red), with it exits 143 (green).

Graceful parent exit (fixed dist):
child exited via disconnect — unchanged behavior.

Standalone `node dist/server.js` (no IPC):
stays alive and listening — guard works, `process.send` undefined.

## Notes
No API/config surface change. Effective once shipped in the next CLI/server release; the 31 already-leaked processes were killed manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embedded runtime processes now shut down cleanly when their parent process disconnects, including during startup.
  * Standalone processes without a parent connection remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->