### PR TITLE
fix(slack): clarify and fence hosted workspace linking

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
@@ -65,7 +65,6 @@ const exchangeOAuthCode = mock(
 );
 const openDm = mock(async () => "D-INSTALLER");
 const postMessage = mock(async () => undefined);
-
 async function loadCoordinator() {
 	const mod = await import("../connections/slack-connection-coordinator.js");
 	return mod.completeSlackPendingInstall;
@@ -182,12 +181,18 @@ describe("completeSlackPendingInstall — installer claim DM", () => {
 		];
 		expect(botToken).toBe("xoxb-installer-token");
 		expect(channel).toBe("D-INSTALLER");
+		expect(text).toContain(
+			"<https://app.lobu.ai/connector/slack/connection?ref=T-CLAIM|Choose the Lobu organization for this installation>",
+		);
+		expect(text).toContain("`/lobu link CODE`");
+		expect(text).toContain("Lobu's hosted Slack workspace");
+		expect(text).toContain("workspace link from `lobu run`");
 
 		// The posted text embeds the provider-agnostic connect URL with the team id
 		// as the ref — no secret token (authority is the Slack workspace-admin
 		// check at claim time).
 		const match = text.match(
-			/https:\/\/app\.lobu\.ai\/connector\/slack\/connection\?ref=([^&\s]+)/,
+			/https:\/\/app\.lobu\.ai\/connector\/slack\/connection\?ref=([^&\s|>]+)/,
 		);
 		expect(match).not.toBeNull();
 		const [, refParam] = match as RegExpMatchArray;

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -206,11 +206,20 @@ export function registerBuiltInCommands(
 						`This code can't be used in a ${result.surfaceType === "dm" ? "DM" : "channel"}. Check the agent's \`preview.${ctx.platform}.surfaces\` setting.`,
 					);
 					return;
-				case "connection_mismatch":
+				case "connection_mismatch": {
+					const allowedLocation =
+						ctx.platform === "slack"
+							? "Lobu's hosted Slack workspace or a Slack workspace"
+							: "Lobu's hosted preview bot or a chat connection";
+					const currentLocation =
+						ctx.platform === "slack"
+							? "this Slack workspace"
+							: "this chat connection";
 					await ctx.reply(
-						"That link code belongs to a different connection. Generate a new code for this bot.",
-          );
-          return;
+						`That code can only be used with ${allowedLocation} connected to the same Lobu organization as the agent. Open the preview link from \`lobu run\`, or connect ${currentLocation} to the agent's organization.`,
+					);
+					return;
+				}
         case "not_found": {
           // Not a valid code — but if we already know who this chat user is,
           // treat the arg as an agent id and re-bind directly (no fresh code

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -116,8 +116,8 @@ export async function completeSlackPendingInstall(
 }
 
 /**
- * DM the installer a single-use claim link so they can connect the freshly
- * parked (pending) workspace to their Lobu account. Best-effort: any failure is
+ * DM the installer the organization-selection link for the freshly parked
+ * (pending) workspace. Best-effort: any failure is
  * logged and swallowed — the install stays parked and claimable via the app.
  */
 async function dmProviderClaimLink(
@@ -135,7 +135,7 @@ async function dmProviderClaimLink(
     return;
   }
   const claimUrl = `${webBase}/connector/slack/connection?ref=${encodeURIComponent(teamId)}`;
-  const text = `👋 Thanks for adding Lobu to your workspace! Connect it to your Lobu account to finish setup: ${claimUrl}`;
+  const text = `👋 Thanks for adding Lobu! <${claimUrl}|Choose the Lobu organization for this installation>. Using Lobu's hosted Slack workspace instead? Leave this installation unconnected, open the workspace link from \`lobu run\`, and run the shown \`/lobu link CODE\` command in the channel or DM you want to use.`;
   try {
     const dm = await web.openDm(botToken, installerUserId);
     await web.postMessage(botToken, dm, text);
@@ -612,7 +612,7 @@ export class SlackConnectionCoordinator {
     const webBase = getConfiguredPublicOrigin()?.replace(/\/+$/, "");
     if (!webBase) return ack;
     const claimUrl = `${webBase}/connector/slack/connection?ref=${encodeURIComponent(teamId)}`;
-    const text = `👋 This Slack workspace isn't connected to Lobu yet. A workspace admin can connect it here: ${claimUrl}`;
+    const text = `👋 This Slack installation isn't connected to a Lobu organization yet. A workspace admin can <${claimUrl}|choose its Lobu organization>. Using Lobu's hosted Slack workspace instead? Leave this installation unconnected, open the workspace link from \`lobu run\`, and run the shown \`/lobu link CODE\` command there.`;
     try {
       await createSlackWebApi().postMessage(botToken, event.channel, text);
     } catch (error) {

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -40,8 +40,13 @@ const OTHER_AGENT_ID = "other-agent";
 const TEAM_ID = "T_DEVELOPER";
 const CLAIM_SLACK_CONNECTION = "claim-slack";
 const CLAIM_TELEGRAM_CONNECTION = "claim-telegram";
+const FOREIGN_SLACK_CONNECTION = "foreign-slack";
+const FOREIGN_PREVIEW_CONNECTION = "foreign-preview-slack";
+const FOREIGN_STRING_PREVIEW_CONNECTION = "foreign-string-preview-slack";
+const FOREIGN_TELEGRAM_CONNECTION = "foreign-telegram";
 
 let ORG_ID = "";
+let FOREIGN_ORG_ID = "";
 // A real `user` row — the binding attributes the chat Behavior's `created_by`
 // from the claim's `createdBy`, resolved against `"user"`, so it must be an
 // actual user.
@@ -143,6 +148,44 @@ describe("Slack Preview claims + channel Behaviors", () => {
 		credentialMode: "managed",
 		status: "active",
 	});
+	const foreignOrg = await createTestOrganization({
+		name: "Foreign Slack Org",
+		slug: "foreign-slack-org",
+	});
+	FOREIGN_ORG_ID = foreignOrg.id;
+	await insertChatConnectionRow({
+		id: FOREIGN_SLACK_CONNECTION,
+		organizationId: FOREIGN_ORG_ID,
+		platform: "slack",
+		credentialMode: "managed",
+		status: "active",
+		metadata: { teamId: "T_FOREIGN" },
+	});
+	await insertChatConnectionRow({
+		id: FOREIGN_PREVIEW_CONNECTION,
+		organizationId: FOREIGN_ORG_ID,
+		platform: "slack",
+		credentialMode: "managed",
+		settings: { previewMode: true },
+		status: "active",
+		metadata: { teamId: "T_HOSTED" },
+	});
+	await insertChatConnectionRow({
+		id: FOREIGN_STRING_PREVIEW_CONNECTION,
+		organizationId: FOREIGN_ORG_ID,
+		platform: "slack",
+		credentialMode: "managed",
+		settings: { previewMode: "true" },
+		status: "active",
+		metadata: { teamId: "T_STRING_PREVIEW" },
+	});
+	await insertChatConnectionRow({
+		id: FOREIGN_TELEGRAM_CONNECTION,
+		organizationId: FOREIGN_ORG_ID,
+		platform: "telegram",
+		credentialMode: "managed",
+		status: "active",
+	});
   });
 
   beforeEach(async () => {
@@ -241,6 +284,104 @@ describe("Slack Preview claims + channel Behaviors", () => {
     expect(
       await consumeSlack({ code, teamId: TEAM_ID, channelId: "D123" })
     ).toEqual({ status: "not_found" });
+  });
+
+  test("a hosted code crosses orgs only through a boolean-marked preview connection", async () => {
+    const code = await createClaim(AGENT_ID);
+    for (const { connectionId, teamId } of [
+      { connectionId: FOREIGN_SLACK_CONNECTION, teamId: "T_FOREIGN" },
+      {
+        connectionId: FOREIGN_STRING_PREVIEW_CONNECTION,
+        teamId: "T_STRING_PREVIEW",
+      },
+    ]) {
+      const refused = await consumePreviewClaim({
+        code,
+        platform: "slack",
+        teamId,
+        channelId: canonicalSlackChannelId("CFOREIGN"),
+        surfaceType: "channel",
+        connectionId,
+        connectionOrganizationId: FOREIGN_ORG_ID,
+      });
+      expect(refused).toEqual({ status: "connection_mismatch" });
+    }
+    expect(
+      await listTestBehaviorSubscriptions({ platform: "slack" })
+    ).toHaveLength(0);
+
+    // A real preview marker is still scoped to its persisted Slack workspace.
+    const wrongHostedWorkspace = await consumePreviewClaim({
+      code,
+      platform: "slack",
+      teamId: "T_OTHER_HOSTED",
+      channelId: canonicalSlackChannelId("COTHERHOSTED"),
+      surfaceType: "channel",
+      connectionId: FOREIGN_PREVIEW_CONNECTION,
+      connectionOrganizationId: FOREIGN_ORG_ID,
+    });
+    expect(wrongHostedWorkspace).toEqual({ status: "connection_mismatch" });
+
+    // Refusals do not consume the code. The same cross-org claim is valid on
+    // the deliberately shared preview connection in its actual workspace.
+    const hosted = await consumePreviewClaim({
+      code,
+      platform: "slack",
+      teamId: "T_HOSTED",
+      channelId: canonicalSlackChannelId("CHOSTED"),
+      surfaceType: "channel",
+      connectionId: FOREIGN_PREVIEW_CONNECTION,
+      connectionOrganizationId: FOREIGN_ORG_ID,
+    });
+    expect(hosted).toMatchObject({ status: "bound", agentId: AGENT_ID });
+    const subscriptions = await listTestBehaviorSubscriptions({
+      platform: "slack",
+    });
+    expect(subscriptions).toHaveLength(1);
+    expect(subscriptions[0]).toMatchObject({
+      organization_id: ORG_ID,
+      agent_id: AGENT_ID,
+      channel_id: "slack:CHOSTED",
+      team_id: "T_HOSTED",
+    });
+  });
+
+  test("the link command explains the hosted-or-same-org boundary per platform", async () => {
+    const registry = new CommandRegistry();
+    registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+    for (const scenario of [
+      {
+        platform: "slack",
+        connectionId: FOREIGN_SLACK_CONNECTION,
+        expectedHostedCopy: "Lobu's hosted Slack workspace",
+        expectedCurrentCopy: "this Slack workspace",
+      },
+      {
+        platform: "telegram",
+        connectionId: FOREIGN_TELEGRAM_CONNECTION,
+        expectedHostedCopy: "Lobu's hosted preview bot",
+        expectedCurrentCopy: "this chat connection",
+      },
+    ] as const) {
+      const replies: string[] = [];
+      await registry.tryHandle("link", {
+        userId: "U1",
+        channelId: "CFOREIGN-COMMAND",
+        teamId: scenario.platform === "slack" ? "T_FOREIGN" : undefined,
+        isGroup: true,
+        platform: scenario.platform,
+        connectionId: scenario.connectionId,
+        organizationId: FOREIGN_ORG_ID,
+        args: await createClaim(AGENT_ID, ["dm", "channel"], scenario.platform),
+        reply: async (text: string) => {
+          replies.push(text);
+        },
+      });
+      const reply = replies.join("\n");
+      expect(reply).toContain(scenario.expectedHostedCopy);
+      expect(reply).toContain(scenario.expectedCurrentCopy);
+      expect(reply).toContain("same Lobu organization");
+    }
   });
 
   test("re-linking a channel rebinds it to the new agent (last link wins)", async () => {

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -325,6 +325,7 @@ export async function consumePreviewClaim(args: {
 					AND organization_id = ${claim.organizationId}
 					AND slug = ${runtimeConnectionIdToSlug(connectionId)}
 					AND connector_key = ${platform}
+					AND credential_mode IS NOT NULL
 					AND status = 'active'
 					AND deleted_at IS NULL
 				LIMIT 1
@@ -332,13 +333,29 @@ export async function consumePreviewClaim(args: {
 			if (matched.length === 0)
 				return { status: "connection_mismatch" as const };
 		} else {
+			// A hosted claim may cross organizations only through the deliberately
+			// shared preview connection for the workspace handling the command. A normal
+			// managed/BYO installation must belong to the claimed agent's org; otherwise
+			// the Behavior would be written under the agent org but inbound messages
+			// would stay scoped to the connection org and could never fire.
 			if (!connectionId) return { status: "connection_mismatch" as const };
 			const matched = await tx<{ id: number }>`
 				SELECT id FROM connections
 				WHERE slug = ${runtimeConnectionIdToSlug(connectionId)}
 					AND connector_key = ${platform}
+					AND credential_mode IS NOT NULL
 					AND status = 'active'
 					AND deleted_at IS NULL
+					AND (
+						organization_id = ${claim.organizationId}
+						OR (
+							config->'settings'->'previewMode' = 'true'::jsonb
+							AND (
+								external_tenant_id IS NULL
+								OR external_tenant_id = ${teamId ?? null}
+							)
+						)
+					)
 					${connectionOrganizationId ? tx`AND organization_id = ${connectionOrganizationId}` : tx``}
 				LIMIT 2
 			`;


### PR DESCRIPTION
## Summary

- render the Slack organization claim as a named Slack link and explain the separate hosted-workspace path
- reject `/lobu link` redemption on an ordinary foreign managed/BYO workspace while allowing the deliberately shared preview connection
- scope hosted redemption to the preview connection's actual Slack workspace and require the authoritative JSON boolean marker
- make mismatch guidance accurate for Slack and Telegram

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted Bun + Vitest suites
- [x] Bug fix: red→fix→green outputs pasted below
- [x] If bot behavior: live hosted Slack channel and DM exercised before release; repeat after rollout

### Red

Installer copy test:
```
Expected a Slack mrkdwn named organization link.
Received: Thanks for adding Lobu to your workspace! Connect it to your Lobu account to finish setup: https://app.lobu.ai/connector/slack/connection?ref=T-CLAIM
```

Tenancy test:
```
Expected: { status: "connection_mismatch" }
Received: { status: "bound", ... }
```

### Green

```
bun test ./packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
2 pass, 0 fail

cd packages/server && bunx vitest run src/preview/__tests__/slack-preview.test.ts
23 tests passed

make pre-pr
pre-pr gates clean
```

## Notes

PR #2465 was unrelated legacy webhook-alias work and has been closed as obsolete. This PR changes the actual canonical Slack onboarding and link-redemption paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Slack connection guidance with clearer organization selection and hosted workspace instructions.
  * Added more specific `/link` messages for location and connection mismatches.

* **Bug Fixes**
  * Improved validation of Slack preview connections, including workspace and organization scoping.
  * Prevented inactive, deleted, credential-less, or incorrectly scoped connections from being claimed.
  * Clarified connection links and workspace-link instructions in Slack messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->