### PR TITLE
chore(docs): migrate browser verification from agent-browser to Owletto

### DIFF
--- a/docs/BROWSER_TESTING.md
+++ b/docs/BROWSER_TESTING.md
@@ -1,6 +1,6 @@
 # Browser-driven verification (authenticated)
 
-For any UI verification that needs a signed-in session (past the auth wall), use the `agent-browser` CLI with a session cookie minted from the DB. The user's regular Chrome doesn't expose a remote-debug port, so `--auto-connect` will land on the wrong tab — mint a cookie instead.
+For any UI verification that needs a signed-in session (past the auth wall), mint a session cookie from the DB and drive the **paired Owletto extension** through the Lobu connector-operations bridge (`lobu call manage_operations`, or the SDK `operations` namespace). This runs in the user's real logged-in Chrome — no separate headless browser, no CDP, no extra browser tooling to install.
 
 ## Scope
 
@@ -20,10 +20,16 @@ SECRET=$(grep '^BETTER_AUTH_SECRET=' .env | cut -d= -f2-)
 SECRET=$(kubectl exec -n summaries-prod \
   $(kubectl get pod -n summaries-prod -l app.kubernetes.io/name=lobu-app -o name | head -1 | sed 's|pod/||') \
   -- printenv BETTER_AUTH_SECRET)
+```
 
-# Session token from the DB (prod DB serves both targets)
-DB="$(grep '^DATABASE_URL=' .env | cut -d= -f2-)"
-TOKEN=$(psql "$DB" -tAc "SELECT token FROM session WHERE \"userId\" = '<user_id>' AND \"expiresAt\" > NOW() ORDER BY \"updatedAt\" DESC LIMIT 1")
+Session token from the DB. With no local `DATABASE_URL` set, exec psql inside the prod DB pod (the prod DB serves both targets):
+
+```bash
+DBURL=$(kubectl exec -n summaries-prod <lobu-app-pod> -- printenv DATABASE_URL)
+PGPASS=$(printf '%s' "$DBURL" | sed -E 's#.*://[^:]+:([^@]+)@.*#\1#')
+TOKEN=$(kubectl exec -n summaries-prod lobu-ai-prod-db-1 -- \
+  env PGPASSWORD="$PGPASS" psql -h lobu-ai-prod-db-pooler -U summaries -d owletto -tAc \
+  "SELECT token FROM session WHERE \"userId\" = '<user_id>' AND \"expiresAt\" > NOW() ORDER BY \"updatedAt\" DESC LIMIT 1")
 ```
 
 ## Sign the cookie
@@ -40,51 +46,68 @@ SIGNED=$(SECRET="$SECRET" TOKEN="$TOKEN" node -e '
 
 Cookie name is `__Secure-better-auth.session_token` whenever the baseURL is `https://` (prod and Tailscale dev qualify; only plain-http localhost uses the unprefixed `better-auth.session_token`).
 
-## Drive the browser
+## Find the Chrome connection
+
+Browser actions dispatch to a paired Chrome extension connection (usually org `buremba`):
 
 ```bash
-agent-browser --session lobu-verify open "https://app.lobu.ai/"
-agent-browser --session lobu-verify eval "document.cookie='__Secure-better-auth.session_token=$SIGNED; path=/; secure; samesite=lax'"
-agent-browser --session lobu-verify open "https://app.lobu.ai/<path>"
-agent-browser --session lobu-verify wait --text "<expected text>" --timeout 25000
-agent-browser --session lobu-verify snapshot -i      # find @refs
-agent-browser --session lobu-verify click @e13        # interact
-agent-browser --session lobu-verify screenshot --full /tmp/out.png
-agent-browser --session lobu-verify close
+lobu call manage_connections --org buremba --arg action=list --raw
 ```
 
-## Driving the paired Owletto extension (connector debugging)
+Pick the `chrome` connector with `status: active` on the machine whose browser you want to drive. `operations.listAvailable({ connection_id })` reports per-target `readiness` and `execution_targets` — use it to check the device is actually online before a long verification.
 
-The cookie-forging above and `claude-in-chrome` both drive a *separate* browser that lacks the user's real logged-in sessions — Revolut, for instance, redirects them to `sso.revolut.com/signin`. To run JS or browser actions in the **paired Owletto extension** (the Chrome that holds the user's live sessions, which is what extension-scrape connectors like Revolut/LinkedIn use), go through the connector-operations bridge instead. No deploy required.
+## Drive the browser
 
-`lobu connector run` is the wrong tool here — it only does local Playwright/CDP against a `browser_session` auth profile, so it errors `Missing --auth-profile` for device-worker connectors (Revolut has no auth profile).
+Multi-step verifications are one `run_sdk` script (the tab id threads through every call):
 
-For one-off actions, the `lobu call` CLI is the quickest path (usually org `buremba`; connection id from `lobu call manage_connections --org buremba --arg action=list --raw`):
+```bash
+lobu call run_sdk --arg script='
+export default async (ctx, client) => {
+  const CHROME = <chrome-connection-id>;
+  const COOKIE = "<SIGNED>";
+  // 1. Open the app origin in a fresh background tab.
+  const nav = await client.operations.execute({
+    connection_id: CHROME, operation_key: "navigate",
+    input: { url: "https://app.lobu.ai/", open_in_new_tab: true, wait_for_load: true },
+  });
+  const tab = nav.output.tab_id;
+  // 2. Plant the signed session cookie.
+  await client.operations.execute({
+    connection_id: CHROME, operation_key: "evaluate",
+    input: { tab_id: tab, expression: `document.cookie='"'"'__Secure-better-auth.session_token=${COOKIE}; path=/; secure; samesite=lax'"'"'`, await_promise: false },
+  });
+  // 3. Navigate the SAME tab to the authenticated page.
+  await client.operations.execute({
+    connection_id: CHROME, operation_key: "navigate",
+    input: { tab_id: tab, url: "https://app.lobu.ai/<path>", wait_for_load: true },
+  });
+  // 4. Assert on the DOM (title/text/refs), or use get_accessibility_tree / screenshot.
+  const probe = await client.operations.execute({
+    connection_id: CHROME, operation_key: "evaluate",
+    input: { tab_id: tab, expression: `(async () => { await new Promise(r => setTimeout(r, 3000)); return { title: document.title, snippet: document.body.innerText.slice(0, 300) }; })()`, await_promise: true },
+  });
+  // 5. Clean up the tab when done.
+  await client.operations.execute({ connection_id: CHROME, operation_key: "close_tab", input: { tab_id: tab } });
+  return probe.output;
+};
+' --raw
+```
+
+For one-off actions, `lobu call manage_operations` is quicker:
 
 ```bash
 lobu call manage_operations --org buremba --arg action=execute \
   --arg connection_id=<chrome-connection-id> --arg operation_key=navigate \
-  --arg input:='{"url":"https://app.slack.com/...","wait_for_load":true,"open_in_new_tab":true}' --raw
+  --arg input:='{"url":"https://app.lobu.ai/<path>","wait_for_load":true,"open_in_new_tab":true}' --raw
 ```
 
-For multi-step scripts, use the SDK `operations` namespace via `lobu memory exec` / `run_sdk`:
+Chrome ops: `navigate` (new tab, existing `tab_id`, or `persistent` agent window), `evaluate`, `get_accessibility_tree` (`filter: interactive|visible|all`), `wait_for_selector`, `click_ref`, `type_ref`, `screenshot`, `show_notification`, `network_intercept_*`, `close_tab`.
 
-```js
-// chrome connection id: client.connections.list() → connector_key 'chrome'
-const ops = await client.operations.listAvailable({ connection_id: CHROME_CONN_ID });
-// navigate opens a fresh background tab in the paired Chrome and returns tab_id
-const nav = await client.operations.execute({
-  connection_id: CHROME_CONN_ID, operation_key: 'navigate',
-  input: { url: 'https://app.revolut.com/transactions', open_in_new_tab: true, wait_for_load: true },
-});
-// evaluate runs arbitrary JS on that tab and returns the JSON-serialised result
-await client.operations.execute({
-  connection_id: CHROME_CONN_ID, operation_key: 'evaluate',
-  input: { tab_id: nav.output.tab_id, expression: '(async()=>{ /* read DOM */ return out })()', await_promise: true },
-});
-```
+## Driving the paired Owletto extension (connector debugging)
 
-`operations.execute` → `dispatchChromeActionToExtension` (`worker-api/dispatch-chrome-action.ts`) → device-worker queue → the paired extension — the same bridge the office-bot Deliveroo connector uses. Chrome ops: `navigate`, `evaluate`, `get_accessibility_tree`, `wait_for_selector`, `click_ref`, `type_ref`, `screenshot`, `show_notification`, `network_intercept_*`, `close_tab`.
+The recipe above drives the same **paired Owletto extension** that extension-scrape connectors (Revolut, LinkedIn) use — the Chrome that holds the user's live sessions. Anything said there applies: `operations.execute` → `dispatchChromeActionToExtension` → device-worker queue → the paired extension. No deploy required.
+
+`lobu connector run` is the wrong tool here — it only does local Playwright/CDP against a `browser_session` auth profile, so it errors `Missing --auth-profile` for device-worker connectors (Revolut has no auth profile).
 
 Gotchas:
 - `search_sdk operations` surfaces the `operations` namespace and current method signatures. Use `Object.keys(client)` inside a `run_sdk` script only when checking discovery/runtime parity.

--- a/scripts/e2e-browser.sh
+++ b/scripts/e2e-browser.sh
@@ -5,9 +5,14 @@
 # reused from every agent session. The extension's fixed manifest "key" pins
 # its ID regardless of where it's loaded from, so the extension's
 # chrome.storage.local (gateway URL + access/refresh tokens + workerId) lives
-# in the --profile dir and survives restarts — and carries across worktrees,
+# in the profile dir and survives restarts — and carries across worktrees,
 # because the ID never changes. So you pair once and reuse forever, exactly
 # like installing Owletto.app once.
+#
+# Chrome is launched directly (agent-browser is retired). Driving it
+# afterwards — navigate, snapshot, click, screenshot — goes through the
+# paired extension's connector-operations bridge, NOT this script; see
+# docs/BROWSER_TESTING.md.
 #
 # Usage:
 #   scripts/e2e-browser.sh              # extension = current worktree, open its gateway
@@ -15,21 +20,14 @@
 #   make e2e-browser                    # same, from a worktree root
 #
 # Stable handles — reuse these verbatim from any agent session:
-#   profile   ~/.config/lobu-dev/chrome   (--profile: persists pairing/cookies/storage)
-#   session   owletto                      (--session: the daemon-managed browser)
+#   profile   ~/.config/lobu-dev/chrome   (persists pairing/cookies/storage)
 #
-# Drive it after launch:
-#   agent-browser --session owletto snapshot -i      # refs for click/fill
-#   agent-browser --session owletto open <url>        # navigate
-#   agent-browser --session owletto close             # shut it down
-#
-# The headed window may close when left idle, but the daemon keeps the
-# session's launch config: the next `agent-browser --session owletto <cmd>`
-# (or re-running this script) revives the browser WITH the extension. So a
-# vanished window is not a re-pair — just poke the session.
+# The headed window may close when left idle, but Chrome keeps the profile:
+# re-running this script revives the browser WITH the extension. So a
+# vanished window is not a re-pair — just re-run.
 #
 # After editing extension source, reload it (chrome://extensions -> reload) or
-# re-run with --restart (the --extension flag only applies at browser launch).
+# re-run with --restart (--load-extension only applies at browser launch).
 # Mac e2e needs no equivalent: the installed Owletto.app reads
 # ~/.config/lobu/config.json on every popover, so worktree Lobu contexts
 # registered by task-setup show up in its picker automatically.
@@ -39,8 +37,15 @@ set -euo pipefail
 restart=0
 [[ "${1:-}" == "--restart" ]] && restart=1
 
-command -v agent-browser >/dev/null 2>&1 || {
-  echo "error: agent-browser not on PATH (npm i -g agent-browser, or brew install agent-browser)" >&2
+chrome=""
+for candidate in \
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary" \
+  "/Applications/Chromium.app/Contents/MacOS/Chromium"; do
+  [[ -x "$candidate" ]] && { chrome="$candidate"; break; }
+done
+[[ -n "$chrome" ]] || {
+  echo "error: no Chrome/Chromium found under /Applications" >&2
   exit 1
 }
 
@@ -57,39 +62,40 @@ fi
 url="http://localhost:$port"
 
 profile="$HOME/.config/lobu-dev/chrome"
-session="owletto"
 mkdir -p "$profile"
 
-# Decide reuse vs (re)launch. A session can linger in the daemon's list after
-# its browser window has died, so don't trust `session list` alone — probe the
-# actual browser with a gateway-independent navigation (about:blank succeeds
-# even when `make dev` is down). RESTART=1 always relaunches.
-relaunch=1
-if [[ $restart -eq 0 ]] \
-  && agent-browser session list 2>/dev/null | grep -qE "^[[:space:]]*${session}$"; then
-  if agent-browser --session "$session" open "about:blank" >/dev/null 2>&1; then
-    relaunch=0
-  else
-    echo "-> '$session' session was stale (browser gone); relaunching"
-    agent-browser --session "$session" close >/dev/null 2>&1 || true
-  fi
-elif [[ $restart -eq 1 ]]; then
-  agent-browser --session "$session" close >/dev/null 2>&1 || true
+# A running harness is any Chrome process bound to this profile dir.
+running() { pgrep -f "user-data-dir=$profile" >/dev/null 2>&1; }
+
+if [[ $restart -eq 1 ]] && running; then
+  echo "-> --restart: stopping the running harness"
+  pkill -f "user-data-dir=$profile" 2>/dev/null || true
+  for _ in $(seq 1 20); do running || break; sleep 0.5; done
+  running && { echo "error: harness did not stop; kill it manually" >&2; exit 1; }
 fi
 
-if [[ $relaunch -eq 0 ]]; then
-  echo "-> reusing running '$session' session"
+if running; then
+  echo "-> reusing running harness (profile: $profile)"
   echo "   (use --restart to reload the extension after source/worktree changes)"
-  # Non-fatal: a down gateway shouldn't fail the harness — the browser is up.
-  agent-browser --session "$session" open "$url" >/dev/null 2>&1 || true
 else
-  agent-browser --session "$session" --profile "$profile" --extension "$ext" --headed open "$url" >/dev/null 2>&1 || true
-  echo "-> launched '$session'"
-  echo "   profile:   $profile"
-  echo "   extension: $ext"
+  echo "-> launching harness (profile: $profile)"
 fi
+
+# Chrome launched against an already-running profile forwards the URL to the
+# existing instance and exits, so this one command covers both first launch
+# and "open the gateway". --load-extension only takes effect on a cold start.
+# Detach: the raw Chrome binary blocks in the foreground otherwise.
+nohup "$chrome" \
+  --user-data-dir="$profile" \
+  --load-extension="$ext" \
+  --no-first-run \
+  --no-default-browser-check \
+  "$url" >/dev/null 2>&1 &
+disown || true
 
 echo "OK Owletto e2e browser ready"
 echo "   gateway:   $url"
+echo "   profile:   $profile"
+echo "   extension: $ext"
 echo "   sidepanel: set 'Server URL' to $url the first time you pair against this worktree"
-echo "   drive it:  agent-browser --session $session snapshot -i"
+echo "   drive it:  docs/BROWSER_TESTING.md (Owletto connector-operations bridge)"


### PR DESCRIPTION
## Summary
- agent-browser is retired from this machine (npm package uninstalled, skills/config references removed); AGENTS.md already points browser automation at the paired Owletto extension, but the recipe doc it references still described agent-browser, and `scripts/e2e-browser.sh` hard-depended on the uninstalled binary
- `docs/BROWSER_TESTING.md`: driving recipe now goes through the connector-operations bridge (`lobu call manage_operations` / `run_sdk`), matching the flow verified live end-to-end against app.lobu.ai: mint cookie → navigate → plant cookie → authenticated page → DOM probe → close_tab. Cookie-forging sections kept; the DB-token step now documents the prod-pod psql path for when no local `DATABASE_URL` is set
- `scripts/e2e-browser.sh`: launches/reuses Chrome directly with `--user-data-dir` + `--load-extension` (detached — the raw macOS binary blocks in the foreground otherwise); driving afterwards goes through the extension bridge per the doc. Same stable profile (`~/.config/lobu-dev/chrome`), so existing pairing survives

## Test plan
- [x] make pre-pr clean (docs/scripts-only change)
- [x] Docs recipe executed live via lobu CLI: signed-in org content rendered in the paired Chrome through navigate/evaluate/close_tab ops (device worker responded, tab cleaned up)
- [x] e2e-browser.sh exercised on this machine: cold launch (detached, exit 0), reuse path, --restart path, clean stop
- [x] `git grep agent-browser origin/main` after change: only the historical "retired" comment in the script header

## Notes
No code/API surface change. `pi-review` on this PR will post once the reviewer CLIs quota resets (codex/claude both exhausted at time of writing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated browser testing documentation covering connection discovery, multi-step automation guidance, tab cleanup, and environment readiness checks.

* **Chores**
  * Browser automation scripts now launch and manage Chrome directly with persistent profile support and improved process restart handling.
  * Enhanced session-token retrieval with support for production database environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->