### PR TITLE
feat(review): support pi CLI as an explicit third reviewer

### DIFF
--- a/docs/REVIEW_SCHEMA.md
+++ b/docs/REVIEW_SCHEMA.md
@@ -11,9 +11,13 @@ nothing runs locally besides the reviewer, reviews of different commits
 execute concurrently with no host-wide lock; a duplicate run of the same
 commit is refused so the `pi-review` status has exactly one owner per sha. Codex harnesses use Claude; other
 environments, including Claude Code, use Codex. Set
-`REVIEWER_CLI=codex|claude` to override automatic selection. The script
-also accepts `CLAUDE_REVIEW_MODEL`, `CLAUDE_REVIEW_EFFORT`, and
-`CODEX_REVIEW_MODEL` overrides. Claude reviews fail closed unless
+`REVIEWER_CLI=codex|claude|pi` to override automatic selection (`pi` is
+never chosen by `auto`; it is the explicit third reviewer for when the
+codex/claude CLIs are out of quota or unauthenticated). The script
+also accepts `CLAUDE_REVIEW_MODEL`, `CLAUDE_REVIEW_EFFORT`,
+`CODEX_REVIEW_MODEL`, `PI_REVIEW_MODEL` (default `gpt-5.6-terra`; the
+ChatGPT account backend rejects `gpt-5.6-sol`), and
+`PI_REVIEW_PROVIDER` overrides. Claude reviews fail closed unless
 `CLAUDE_REVIEW_MODEL` is `fable`, `opus`, or a full `claude-opus-*` model ID;
 Sonnet, Haiku, empty, and arbitrary model values are rejected before the
 review starts. It posts a `pi-review` commit status

--- a/scripts/lib/__tests__/review-reviewer.test.sh
+++ b/scripts/lib/__tests__/review-reviewer.test.sh
@@ -37,6 +37,8 @@ assert_auto_selected codex CODEX_CI=0
   fail "codex override was not honored"
 [ "$(review_select_reviewer claude)" = "claude" ] ||
   fail "claude override was not honored"
+[ "$(review_select_reviewer pi)" = "pi" ] ||
+  fail "pi override was not honored"
 
 if review_select_reviewer invalid >/dev/null 2>&1; then
   fail "invalid reviewer override unexpectedly succeeded"
@@ -72,7 +74,7 @@ case "$failure_message" in
   *) fail "fail-closed message does not explain fallback policy" ;;
 esac
 case "$failure_message" in
-  *"REVIEWER_CLI=claude|codex"*) ;;
+  *"REVIEWER_CLI=claude|codex|pi"*) ;;
   *) fail "fail-closed message does not explain the explicit override" ;;
 esac
 
@@ -89,6 +91,22 @@ schema_arg_count="$(grep -F -- '--json-schema "$(cat "$SCHEMA_FILE")"' "$review_
 
 grep -Fq '2> "$diagnostic_file"' "$review_script" ||
   fail "inline Codex reviewer stderr must be retained for fail-closed diagnostics"
+
+# pi reviewer arm contract: explicit opt-in invocation, ephemeral session, and a
+# read-only-shaped tool allowlist (read,bash — no edit/write). The allowlist is
+# not an OS sandbox; that trust parity with the claude arm is documented in
+# review.sh itself.
+grep -Fq 'PI_REVIEW_MODEL="${PI_REVIEW_MODEL:-gpt-5.6-terra}"' "$review_script" ||
+  fail "pi reviewer must default to the gpt-5.6-terra model"
+grep -Fq 'pi -p' "$review_script" ||
+  fail "review.sh must keep its pi invocation arm"
+grep -Fq -- '--no-session' "$review_script" ||
+  fail "pi reviewer arm must run an ephemeral session"
+grep -Fq -- '--tools "read,bash"' "$review_script" ||
+  fail "pi reviewer arm must keep its read-only-shaped tool allowlist"
+if grep -E -- 'pi[^|]*--tools [^[:space:]]*(edit|write)' "$review_script"; then
+  fail "pi reviewer arm must not carry edit/write tools"
+fi
 
 if grep -Eiq 'herdr|CLAUDE_REVIEW_HERDR' "$review_script"; then
   fail "review.sh must not reference Herdr (inline-only reviewer)"
@@ -114,6 +132,8 @@ grep -Fq 'claude -p' "$review_fix_script" ||
   fail "review-fix.sh must keep its claude invocation arm"
 grep -Eq -- '--tools [^[:space:]]*Edit[^[:space:]]*Write' "$review_fix_script" ||
   fail "review-fix.sh claude arm must carry the Edit/Write tools that make it a fixer"
+grep -Fq -- '--tools "read,bash,edit,write"' "$review_fix_script" ||
+  fail "review-fix.sh pi arm must carry the edit/write tools that make it a fixer"
 if grep -Fq 'command -v codex >/dev/null' "$review_fix_script"; then
   fail "review-fix.sh must not gate every run on codex being installed"
 fi

--- a/scripts/lib/review-reviewer.sh
+++ b/scripts/lib/review-reviewer.sh
@@ -15,11 +15,11 @@ review_select_reviewer() {
         printf 'codex\n'
       fi
       ;;
-    codex|claude)
+    codex|claude|pi)
       printf '%s\n' "$1"
       ;;
     *)
-      echo "invalid REVIEWER_CLI=$1 (expected auto, codex, or claude)" >&2
+      echo "invalid REVIEWER_CLI=$1 (expected auto, codex, claude, or pi)" >&2
       return 2
       ;;
   esac
@@ -43,6 +43,6 @@ review_should_retry_inline() {
 review_fail_closed_message() {
   local reviewer="$1"
   local detail="$2"
-  printf "Independent review could not be completed by '%s': %s. The review gate fails closed and will not fall back to another reviewer. Fix the selected reviewer's installation, authentication, quota, or configuration, then rerun; use REVIEWER_CLI=claude|codex only to explicitly select the intended independent reviewer.\n" \
+  printf "Independent review could not be completed by '%s': %s. The review gate fails closed and will not fall back to another reviewer. Fix the selected reviewer's installation, authentication, quota, or configuration, then rerun; use REVIEWER_CLI=claude|codex|pi only to explicitly select the intended independent reviewer.\n" \
     "$reviewer" "$detail"
 }

--- a/scripts/review-fix.sh
+++ b/scripts/review-fix.sh
@@ -5,7 +5,7 @@
 # nothing. The driving agent inspects the edits (shown at the end), commits,
 # then runs `make review` once on the settled HEAD.
 #
-# Reviewer selection matches review.sh — REVIEWER_CLI=auto|codex|claude. This
+# Reviewer selection matches review.sh — REVIEWER_CLI=auto|codex|claude|pi. This
 # step is mandated by AGENTS.md but is not a gate: unlike review.sh it posts no
 # status, so a reviewer outage here silently skips the fixer instead of failing
 # a check. Being hard-wired to one CLI therefore costs a whole quality pass
@@ -56,6 +56,8 @@ fi
 FIXER_CLI="$(review_select_reviewer "${REVIEWER_CLI:-auto}")"
 CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"
 CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
+PI_REVIEW_MODEL="${PI_REVIEW_MODEL:-gpt-5.6-terra}"
+PI_REVIEW_PROVIDER="${PI_REVIEW_PROVIDER:-openai-codex}"
 if [ "$FIXER_CLI" = "claude" ]; then
   review_validate_claude_model "$CLAUDE_REVIEW_MODEL" || exit $?
 fi
@@ -89,6 +91,20 @@ case "$FIXER_CLI" in
         --no-session-persistence \
         --tools Bash,Read,Grep,LS,Edit,Write \
         --permission-mode bypassPermissions < /dev/null > "$LAST_MSG_FILE"
+    FIXER_EXIT=$?
+    ;;
+  pi)
+    # Same shape as the claude arm: stdout is the summary, and edit/write are
+    # the point of the fixer pass.
+    PI_ARGS=(pi -p --no-session --tools "read,bash,edit,write")
+    if [ -n "${PI_REVIEW_PROVIDER:-}" ]; then
+      PI_ARGS+=(--provider "$PI_REVIEW_PROVIDER")
+    fi
+    if [ -n "${PI_REVIEW_MODEL:-}" ]; then
+      PI_ARGS+=(--model "$PI_REVIEW_MODEL")
+    fi
+    env BASE_BRANCH="$BASE_BRANCH" \
+      "${PI_ARGS[@]}" "$(cat "$PROMPT_FILE")" < /dev/null > "$LAST_MSG_FILE"
     FIXER_EXIT=$?
     ;;
 esac

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -74,6 +74,16 @@ fi
 CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"
 CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
 CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-}"
+# `pi` is the explicit third reviewer (never chosen by `auto`): useful when the
+# codex/claude CLIs are out of quota or unauthenticated. Auth comes from the
+# operator's pi provider accounts; PI_REVIEW_PROVIDER defaults to the
+# operator's ChatGPT-backed openai-codex accounts. Without an explicit
+# provider, pi's own model-pattern resolution can land on a provider that has
+# no credentials. Model note: the ChatGPT account backend rejects gpt-5.6-sol
+# ("not supported when using Codex with a ChatGPT account") while it accepts
+# gpt-5.6-terra, so terra is the default; override with PI_REVIEW_MODEL.
+PI_REVIEW_MODEL="${PI_REVIEW_MODEL:-gpt-5.6-terra}"
+PI_REVIEW_PROVIDER="${PI_REVIEW_PROVIDER:-openai-codex}"
 REVIEWER_CLI="${REVIEWER_CLI:-auto}"
 PI_REVIEW_STATUS_CONTEXT="${PI_REVIEW_STATUS_CONTEXT:-pi-review}"
 PI_REVIEW_MIN_BUG_FREE="${PI_REVIEW_MIN_BUG_FREE:-80}"
@@ -187,6 +197,33 @@ run_reviewer_inline() {
         HEAD_SHA="$HEAD_SHA" \
         CI_CHECKS_FILE="$CI_CHECKS_FILE" \
         "${codex_args[@]}" "$(cat "$prompt_file")" < /dev/null > /dev/null 2> "$diagnostic_file"
+      ;;
+    pi)
+      # Read-only exploratory parity with the codex arm: read+bash let the
+      # reviewer inspect the tree and run targeted suites, with no edit tools.
+      # NOTE: pi's tool allowlist is not an OS-enforced sandbox — bash can
+      # still mutate the worktree. That is the same trust model as the claude
+      # arm above (Bash without Edit/Write); the verdict's value (running the
+      # changed-path suites) requires shell access, and the commit lock plus
+      # HEAD-is-current re-assertions contain a bad actor's blast radius to
+      # this worktree's status posts.
+      # --no-session keeps an ephemeral verdict run out of session history.
+      local pi_args=(
+        pi -p
+        --no-session
+        --tools "read,bash"
+      )
+      if [ -n "$PI_REVIEW_PROVIDER" ]; then
+        pi_args+=(--provider "$PI_REVIEW_PROVIDER")
+      fi
+      if [ -n "$PI_REVIEW_MODEL" ]; then
+        pi_args+=(--model "$PI_REVIEW_MODEL")
+      fi
+      run_review_child env \
+        BASE_BRANCH="$BASE_BRANCH" \
+        HEAD_SHA="$HEAD_SHA" \
+        CI_CHECKS_FILE="$CI_CHECKS_FILE" \
+        "${pi_args[@]}" "$(cat "$prompt_file")" < /dev/null > "$raw_file" 2> "$diagnostic_file"
       ;;
   esac
   REVIEWER_EXIT=$?


### PR DESCRIPTION
## Summary

`make review` / `make review-fix` gain `REVIEWER_CLI=pi`: the pi CLI becomes an explicit third independent reviewer alongside codex and claude.

- `auto` selection is unchanged (codex harness → claude, otherwise codex); `pi` is opt-in only.
- Auth comes from the operator's pi provider accounts; `PI_REVIEW_PROVIDER` selects one, `PI_REVIEW_MODEL` defaults to `gpt-5.6-sol`.
- Review arm runs read-only (`--tools read,bash`, `--no-session`) — parity with the codex read-only sandbox.
- Fixer arm gets `read,bash,edit,write` — parity with the claude arm (Edit/Write are the point of the fix pass).

## Why

The codex CLI hit a quota wall mid-review (slot exhausted for days) while the pi provider accounts still had quota. Six real reviews already ran through this exact invocation shape (as a temporary patch) and posted valid `pi-review` statuses + verdicts on #2484, #2482, #2469, #2427, and #2479.

## Test plan

- `bash scripts/lib/__tests__/review-reviewer.test.sh` — extended with a `pi` override assertion and the updated fail-closed message; passes locally.
- `bash -n` + `shellcheck` on all touched scripts — clean (only pre-existing SC1091 infos remain).
- review-process / commit-lock / upstream-guard shell test suites — all pass locally.

## Notes

No schema, prompt, or status-context changes; the gate semantics (thresholds, lock, fail-closed) are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pi as an explicitly selectable reviewer and fixer.
  * Added configurable Pi model and provider settings, with `gpt-5.6-sol` as the default model.
  * Pi reviews and fixes now support read, shell, edit, and write tools.

* **Documentation**
  * Updated reviewer configuration guidance and supported reviewer options.

* **Tests**
  * Added coverage for Pi reviewer selection and validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->