### PR TITLE
perf(server): cut derived counts + double scans from hot list paths

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-list-pagination.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-list-pagination.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Stored entity list — pagination + sort contract for the two-stage page
+ * fetch.
+ *
+ * Plain-column sorts (created_at, name) resolve the page ids first — filters
+ * + ORDER BY only, no per-row count LATERALs — and enrich just those rows.
+ * Computed-column sorts (total_content, …) need the counts for ordering and
+ * keep the single-query shape. Both must return identical rows/totals; this
+ * file pins that, plus has_more/offset walking and that the per-row count
+ * enrichment stays correct after the prefetch.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { cleanupTestDatabase } from '../../setup/test-db';
+
+interface ListedEntity {
+  id: number;
+  name: string;
+  total_content?: number;
+}
+
+interface ListResult {
+  entities?: ListedEntity[];
+  metadata?: {
+    total_count?: number;
+    has_more?: boolean;
+    limit?: number;
+    offset?: number;
+    sort_by?: string;
+    sort_order?: string;
+  };
+}
+
+describe('stored entity list pagination + sort (two-stage page fetch)', () => {
+  let owner: TestApiClient;
+  let orgId: string;
+
+  // Created in name order a..g so created_at order == name order (ties on
+  // e.created_at fall back to e.id ASC, which follows creation order too).
+  const names = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf'];
+  const ids: Record<string, number> = {};
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'EntityListPagination Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'entity-page@test.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    owner = await TestApiClient.for({
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+    });
+
+    await owner.entity_schema.createType({ slug: 'company', name: 'Company' });
+
+    for (const name of names) {
+      const created = (await owner.entities.create({ type: 'company', name })) as {
+        entity: { id: number };
+      };
+      ids[name] = created.entity.id;
+    }
+
+    // alpha: 3 linked events, bravo: 1, the rest none — drives the
+    // total_content assertions and the computed-sort test.
+    for (let i = 0; i < 3; i++) {
+      await createTestEvent({
+        organization_id: orgId,
+        entity_id: ids.alpha,
+        content: `alpha event ${i}`,
+      });
+    }
+    await createTestEvent({
+      organization_id: orgId,
+      entity_id: ids.bravo,
+      content: 'bravo event 0',
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('walks pages with offset under the default created_at DESC sort', async () => {
+    const page1 = (await owner.entities.list({
+      entity_type: 'company',
+      limit: 3,
+      offset: 0,
+    })) as ListResult;
+    expect(page1.metadata?.total_count).toBe(7);
+    expect(page1.metadata?.has_more).toBe(true);
+    expect(page1.entities?.map((e) => e.name)).toEqual(['golf', 'foxtrot', 'echo']);
+
+    const page2 = (await owner.entities.list({
+      entity_type: 'company',
+      limit: 3,
+      offset: 3,
+    })) as ListResult;
+    expect(page2.metadata?.total_count).toBe(7);
+    expect(page2.metadata?.has_more).toBe(true);
+    expect(page2.entities?.map((e) => e.name)).toEqual(['delta', 'charlie', 'bravo']);
+
+    const page3 = (await owner.entities.list({
+      entity_type: 'company',
+      limit: 3,
+      offset: 6,
+    })) as ListResult;
+    expect(page3.metadata?.total_count).toBe(7);
+    expect(page3.metadata?.has_more).toBe(false);
+    expect(page3.entities?.map((e) => e.name)).toEqual(['alpha']);
+  });
+
+  it('walks pages under created_at ASC sort (prefetch path)', async () => {
+    const page1 = (await owner.entities.list({
+      entity_type: 'company',
+      limit: 4,
+      offset: 0,
+      sort_by: 'created_at',
+      sort_order: 'asc',
+    })) as ListResult;
+    expect(page1.metadata?.total_count).toBe(7);
+    expect(page1.metadata?.has_more).toBe(true);
+    expect(page1.entities?.map((e) => e.name)).toEqual(['alpha', 'bravo', 'charlie', 'delta']);
+
+    const page2 = (await owner.entities.list({
+      entity_type: 'company',
+      limit: 4,
+      offset: 4,
+      sort_by: 'created_at',
+      sort_order: 'asc',
+    })) as ListResult;
+    expect(page2.metadata?.has_more).toBe(false);
+    expect(page2.entities?.map((e) => e.name)).toEqual(['echo', 'foxtrot', 'golf']);
+  });
+
+  it('walks pages under name sort (prefetch path)', async () => {
+    const res = (await owner.entities.list({
+      entity_type: 'company',
+      limit: 3,
+      offset: 0,
+      sort_by: 'name',
+      sort_order: 'desc',
+    })) as ListResult;
+    expect(res.metadata?.total_count).toBe(7);
+    expect(res.entities?.map((e) => e.name)).toEqual(['golf', 'foxtrot', 'echo']);
+  });
+
+  it('sorts by the computed total_content column (single-query path)', async () => {
+    const res = (await owner.entities.list({
+      entity_type: 'company',
+      limit: 7,
+      offset: 0,
+      sort_by: 'total_content',
+      sort_order: 'desc',
+    })) as ListResult;
+    expect(res.metadata?.total_count).toBe(7);
+    expect(res.entities?.[0]?.name).toBe('alpha');
+    expect(res.entities?.[0]?.total_content).toBe(3);
+    expect(res.entities?.[1]?.name).toBe('bravo');
+    expect(res.entities?.[1]?.total_content).toBe(1);
+  });
+
+  it('keeps per-row count enrichment correct after the page-id prefetch', async () => {
+    const res = (await owner.entities.list({
+      entity_type: 'company',
+      limit: 7,
+      offset: 0,
+    })) as ListResult;
+    const byName = Object.fromEntries((res.entities ?? []).map((e) => [e.name, e]));
+    expect(byName.alpha.total_content).toBe(3);
+    expect(byName.bravo.total_content).toBe(1);
+    expect(byName.charlie.total_content).toBe(0);
+  });
+
+  it('filters within the prefetched page (search applies to both stages)', async () => {
+    const res = (await owner.entities.list({
+      entity_type: 'company',
+      search: 'alph',
+      limit: 3,
+      offset: 0,
+    })) as ListResult;
+    expect(res.metadata?.total_count).toBe(1);
+    expect(res.metadata?.has_more).toBe(false);
+    expect(res.entities?.map((e) => e.name)).toEqual(['alpha']);
+  });
+});

--- a/packages/server/src/__tests__/integration/entity-schema/derived-entity-routing.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/derived-entity-routing.test.ts
@@ -101,9 +101,11 @@ describe('derived entity routing (list + resolve_path)', () => {
     expect(Number(byName.acme.metadata.purchases)).toBe(2);
   });
 
-  it('entity_type list/get entity_count matches derived list total (not stored-row COUNT)', async () => {
-    // Regression: Memory rail + schema list used COUNT(entities) only, so
-    // derived types always showed 0 even when list rows existed.
+  it('entity list reports the true derived total while schema list/get/bootstrap skip the live derived count', async () => {
+    // Policy: the entity LIST runs the backing SQL anyway (it needs the rows),
+    // so it reports the exact total via a single-pass window count. Schema
+    // list/get and the resolve_path bootstrap must NOT re-run the backing SQL
+    // just for a badge count — those hot paths report 0 for derived types.
     const list = (await api.entities.list({ entity_type: 'spend-vendor' })) as {
       entities: unknown[];
       metadata?: { total_count?: number };
@@ -115,13 +117,13 @@ describe('derived entity routing (list + resolve_path)', () => {
       entity_types?: Array<{ slug: string; entity_count?: number }>;
     };
     const spend = types.entity_types?.find((t) => t.slug === 'spend-vendor');
-    expect(spend?.entity_count).toBe(listTotal);
+    expect(spend?.entity_count).toBe(0);
 
     const got = (await api.entity_schema.getType('spend-vendor')) as {
       entity_type?: { entity_count?: number; backing_sql?: string | null };
     };
     expect(got.entity_type?.backing_sql).toBeTruthy();
-    expect(got.entity_type?.entity_count).toBe(listTotal);
+    expect(got.entity_type?.entity_count).toBe(0);
 
     const resolved = (await resolvePath({
       path: `/${orgSlug}`,
@@ -132,7 +134,7 @@ describe('derived entity routing (list + resolve_path)', () => {
     const bootstrapType = resolved.bootstrap?.entity_types?.find(
       (type) => type.slug === 'spend-vendor'
     );
-    expect(bootstrapType?.entity_count).toBe(listTotal);
+    expect(bootstrapType?.entity_count).toBe(0);
   });
 
   it('keeps type lists available when a connector-backed derived count fails', async () => {

--- a/packages/server/src/__tests__/integration/events/get-content-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-visibility.test.ts
@@ -306,6 +306,48 @@ describe('getContent > connection visibility folded into WHERE', () => {
     expect(collected.has(alicePrivateEventId)).toBe(true);
     expect(collected.has(systemEventId)).toBe(true);
   });
+
+  it('org-wide cursor pagination keeps total exact on every page', async () => {
+    // Org-wide (no entity_id) listings run count + list in parallel; the
+    // ContentSearchResponse.total contract must hold on cursor pages too —
+    // callers (agents reading read_knowledge) rely on it, not just the UI's
+    // first-page display.
+    const ctx = authedCtx(aliceUser.id);
+
+    const page1 = await getContent(
+      {
+        limit: 2,
+        sort_by: 'date',
+        sort_order: 'desc',
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(page1.total).toBe(3);
+    expect(page1.content.length).toBe(2);
+    expect(page1.page.has_older).toBe(true);
+
+    const last = page1.content[page1.content.length - 1];
+    const page2 = await getContent(
+      {
+        limit: 2,
+        sort_by: 'date',
+        sort_order: 'desc',
+        before_occurred_at: last.occurred_at,
+        before_id: last.id,
+      } as never,
+      {} as never,
+      ctx
+    );
+    // The cursor page must still carry the exact total, never 0.
+    expect(page2.total).toBe(3);
+
+    const collected = new Set([
+      ...page1.content.map((c) => c.id),
+      ...page2.content.map((c) => c.id),
+    ]);
+    expect(collected.size).toBe(3);
+  });
 });
 
 describe('getContent > response shape (view_url present, stats opt-in)', () => {

--- a/packages/server/src/__tests__/integration/tools/query-sql-pagination.test.ts
+++ b/packages/server/src/__tests__/integration/tools/query-sql-pagination.test.ts
@@ -1,0 +1,112 @@
+/**
+ * query_sql internal-path pagination contract.
+ *
+ * The internal path runs the scoped subquery ONCE and carries the total via a
+ * `COUNT(*) OVER ()` window column instead of a second full COUNT pass (the
+ * scoped subquery can be expensive — derived views aggregate large event
+ * ranges). Two fallbacks keep the legacy contract exact, and this file pins
+ * them:
+ *
+ *  1. Empty / out-of-range pages carry no row to bear the window count, so an
+ *     explicit COUNT runs for them — `total_count` must stay exact (and
+ *     `has_more` false), never collapse to 0.
+ *  2. If the caller's own query projects a column named like the internal
+ *     window alias (`__lobu_total_count__`), the tool falls back to the plain
+ *     two-query shape — the caller's column survives untouched, exactly once,
+ *     and `total_count` is still exact.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { querySql } from '../../../tools/admin/query_sql';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  ownerToolContext,
+} from '../../setup/test-fixtures';
+
+describe('query_sql internal-path pagination contract', () => {
+  let orgId: string;
+  let ownerCtx: ToolContext;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'QuerySqlPagination' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'qsql-page@test.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    ownerCtx = ownerToolContext(orgId, user.id);
+
+    for (let i = 0; i < 5; i++) {
+      await createTestEvent({
+        organization_id: orgId,
+        content: `pagination event ${i}`,
+        title: `pagination event ${i}`,
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('reports exact total_count and has_more across in-range pages', async () => {
+    const res = await querySql({ sql: 'SELECT id FROM events', limit: 2, offset: 0 }, {}, ownerCtx);
+    expect(res.error).toBeUndefined();
+    expect(res.rows).toHaveLength(2);
+    expect(res.total_count).toBe(5);
+    expect(res.has_more).toBe(true);
+    // The internal window column must never leak into rows or columns.
+    expect(res.columns.map((c) => c.name)).not.toContain('__lobu_total_count__');
+    expect(Object.keys(res.rows[0])).not.toContain('__lobu_total_count__');
+  });
+
+  it('keeps total_count exact on an out-of-range offset (empty page fallback)', async () => {
+    const res = await querySql(
+      { sql: 'SELECT id FROM events', limit: 2, offset: 100 },
+      {},
+      ownerCtx
+    );
+    expect(res.error).toBeUndefined();
+    expect(res.rows).toHaveLength(0);
+    // No row carries the window count here — the explicit COUNT fallback must
+    // still report the true total, not 0.
+    expect(res.total_count).toBe(5);
+    expect(res.has_more).toBe(false);
+  });
+
+  it('reports total_count 0 when nothing matches', async () => {
+    const res = await querySql(
+      { sql: "SELECT id FROM events WHERE title = 'no such title anywhere'", limit: 2 },
+      {},
+      ownerCtx
+    );
+    expect(res.error).toBeUndefined();
+    expect(res.rows).toHaveLength(0);
+    expect(res.total_count).toBe(0);
+    expect(res.has_more).toBe(false);
+  });
+
+  it('preserves a caller-projected __lobu_total_count__ column (alias collision fallback)', async () => {
+    const res = await querySql(
+      { sql: 'SELECT id, 42 AS "__lobu_total_count__" FROM events', limit: 2, offset: 0 },
+      {},
+      ownerCtx
+    );
+    expect(res.error).toBeUndefined();
+    // The caller's column survives untouched, exactly once.
+    const colNames = res.columns.map((c) => c.name);
+    expect(colNames.filter((n) => n === '__lobu_total_count__')).toHaveLength(1);
+    expect(res.rows).toHaveLength(2);
+    for (const row of res.rows) {
+      expect(row.__lobu_total_count__).toBe(42);
+    }
+    // And the real total is still exact via the fallback COUNT.
+    expect(res.total_count).toBe(5);
+    expect(res.has_more).toBe(true);
+  });
+});

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -263,13 +263,18 @@ async function etHandleList(
 
   const mappedTypes = resolved.map((row) => mapRowToEntityType(row));
   // Stored + derived counts share one path with list/detail (entity-management).
+  // Derived types are excluded here: their backing SQL is expensive (multi-second
+  // on large event tables) and this list endpoint is called on every page load —
+  // a live badge count is not worth that. They report entity_count 0.
   const counts = await getEntityCountsByTypes(
-    mappedTypes.map((t) => ({
-      id: Number(t.id),
-      slug: t.slug,
-      backing_sql: t.backing_sql,
-      backing_source: t.backing_source,
-    })),
+    mappedTypes
+      .filter((t) => t.backing_sql == null)
+      .map((t) => ({
+        id: Number(t.id),
+        slug: t.slug,
+        backing_sql: null,
+        backing_source: null,
+      })),
     ctx
   );
 
@@ -399,15 +404,21 @@ async function etHandleGet(
 
   const [resolved] = await resolveUsernames([rows[0] as Record<string, unknown>], 'created_by');
   const mapped = mapRowToEntityType(resolved);
-  mapped.entity_count = await countEntitiesOfType(
-    {
-      id: Number(mapped.id),
-      slug: mapped.slug,
-      backing_sql: mapped.backing_sql,
-      backing_source: mapped.backing_source,
-    },
-    ctx
-  );
+  // Derived counts run the full backing SQL (multi-second on large event
+  // tables) and this endpoint is called on every entity page open. The page
+  // header shows the list response's total_count instead, so derived types
+  // report 0 here. Same policy as the schema list + resolve_path bootstrap.
+  mapped.entity_count = mapped.backing_sql
+    ? 0
+    : await countEntitiesOfType(
+        {
+          id: Number(mapped.id),
+          slug: mapped.slug,
+          backing_sql: mapped.backing_sql,
+          backing_source: mapped.backing_source,
+        },
+        ctx
+      );
   // Classify the view's measure columns on read (never persisted).
   if (mapped.backing_sql) mapped.measure_columns = measureColumns(mapped.backing_sql);
   // Authored type-level list-view templates, with their data_sources run live.
@@ -625,15 +636,19 @@ async function etHandleUpdate(
   if (updated.length === 0) throw new Error(`Entity type '${args.slug}' not found after update`);
 
   const result = mapRowToEntityType(updated[0] as Record<string, unknown>);
-  result.entity_count = await countEntitiesOfType(
-    {
-      id: Number(result.id),
-      slug: result.slug,
-      backing_sql: result.backing_sql,
-      backing_source: result.backing_source,
-    },
-    ctx
-  );
+  // Same policy as get/list: never run a derived backing SQL just to echo a
+  // count back from a schema update.
+  result.entity_count = result.backing_sql
+    ? 0
+    : await countEntitiesOfType(
+        {
+          id: Number(result.id),
+          slug: result.slug,
+          backing_sql: result.backing_sql,
+          backing_source: result.backing_source,
+        },
+        ctx
+      );
 
   await recordAudit(
     sql,

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -562,9 +562,15 @@ export async function querySqlImpl(
   // aggregate large event ranges), so run it ONCE and take the total from a
   // window count instead of a second full `SELECT count(*) FROM (subquery)`
   // pass. Windows evaluate before LIMIT, so the count covers the full filtered
-  // set exactly like the old separate COUNT did.
+  // set exactly like the old separate COUNT did. Two fallbacks keep the exact
+  // legacy contract: an empty/out-of-range page carries no row to bear the
+  // window count (run the explicit COUNT then), and if the caller's own query
+  // projects a column named like the internal window alias, re-run the plain
+  // two-query shape rather than clobber their column.
   const TOTAL_COL = '__lobu_total_count__';
+  const countSql = `SELECT count(*)::int AS c FROM (${scopedSql}) AS _t ${searchWhere}`;
   const dataSql = `SELECT *, COUNT(*) OVER () AS "${TOTAL_COL}" FROM (${scopedSql}) AS _t ${searchWhere} ${orderBy} LIMIT ${limit} OFFSET ${offset}`;
+  const plainDataSql = `SELECT * FROM (${scopedSql}) AS _t ${searchWhere} ${orderBy} LIMIT ${limit} OFFSET ${offset}`;
 
   try {
     const sql = getDb();
@@ -576,23 +582,50 @@ export async function querySqlImpl(
       await tx`SET TRANSACTION READ ONLY`;
       await tx`SET LOCAL statement_timeout = '5s'`;
       const data = await tx.unsafe(dataSql, params);
-      return data;
+      const rows = Array.isArray(data) ? (data as Array<Record<string, unknown>>) : [];
+      // Duplicate TOTAL_COL in the result columns means the caller's query
+      // itself projects that name — fall back to the classic two-query shape
+      // so the caller's column survives untouched.
+      const aliasCollision =
+        ((data as any)?.columns ?? []).filter((col: { name: string }) => col.name === TOTAL_COL)
+          .length > 1;
+      if (rows.length === 0 || aliasCollision) {
+        const cnt = await tx.unsafe(countSql, params);
+        const totalCount = Number(cnt[0]?.c ?? 0);
+        if (aliasCollision) {
+          const plain = await tx.unsafe(plainDataSql, params);
+          return {
+            rows: plain,
+            columns: (plain as any)?.columns,
+            totalCount,
+            columnsHaveWindowCol: false,
+          };
+        }
+        // Empty page: columns still come from the window query, so the
+        // internal alias must be stripped from them too.
+        return { rows, columns: (data as any)?.columns, totalCount, columnsHaveWindowCol: true };
+      }
+      return {
+        rows,
+        columns: (data as any)?.columns,
+        totalCount: Number(rows[0][TOTAL_COL]) || 0,
+        stripWindowCol: true,
+        columnsHaveWindowCol: true,
+      };
     });
-    const dataResult = await raceAbort(txPromise, ctx.abortSignal);
+    const result = await raceAbort(txPromise, ctx.abortSignal);
 
-    const rawRows = Array.isArray(dataResult)
-      ? (dataResult as Array<Record<string, unknown>>)
-      : [];
-    // Empty page: total is unknowable from rows alone. offset=0 with no rows is a
-    // true 0; an out-of-range offset reports 0 (has_more is false either way).
-    const totalCount = rawRows.length > 0 ? Number(rawRows[0][TOTAL_COL]) || 0 : 0;
-    const rows = rawRows.map((row) => {
-      const { [TOTAL_COL]: _total, ...rest } = row;
-      return rest;
-    });
+    const rawRows = result.rows as Array<Record<string, unknown>>;
+    const totalCount = result.totalCount;
+    const rows = result.stripWindowCol
+      ? rawRows.map((row) => {
+          const { [TOTAL_COL]: _total, ...rest } = row;
+          return rest;
+        })
+      : rawRows;
 
-    const columns = ((dataResult as any).columns ?? [])
-      .filter((col: { name: string }) => col.name !== TOTAL_COL)
+    const columns = (result.columns ?? [])
+      .filter((col: { name: string }) => !(result.columnsHaveWindowCol && col.name === TOTAL_COL))
       .map(
         (col: { name: string; type: number }) => ({
           name: col.name,

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -557,9 +557,14 @@ export async function querySqlImpl(
   if ('error' in bounds) return errorResult(bounds.error, startTime);
   const { limit, offset } = bounds;
 
-  const countSql = `SELECT count(*)::int AS c FROM (${scopedSql}) AS _t ${searchWhere}`;
   const orderBy = args.sort_by ? `ORDER BY "${args.sort_by}" ${sortOrder}` : '';
-  const dataSql = `SELECT * FROM (${scopedSql}) AS _t ${searchWhere} ${orderBy} LIMIT ${limit} OFFSET ${offset}`;
+  // Single execution: the scoped subquery can be expensive (derived entity views
+  // aggregate large event ranges), so run it ONCE and take the total from a
+  // window count instead of a second full `SELECT count(*) FROM (subquery)`
+  // pass. Windows evaluate before LIMIT, so the count covers the full filtered
+  // set exactly like the old separate COUNT did.
+  const TOTAL_COL = '__lobu_total_count__';
+  const dataSql = `SELECT *, COUNT(*) OVER () AS "${TOTAL_COL}" FROM (${scopedSql}) AS _t ${searchWhere} ${orderBy} LIMIT ${limit} OFFSET ${offset}`;
 
   try {
     const sql = getDb();
@@ -570,23 +575,33 @@ export async function querySqlImpl(
     const txPromise = sql.begin(async (tx: typeof sql) => {
       await tx`SET TRANSACTION READ ONLY`;
       await tx`SET LOCAL statement_timeout = '5s'`;
-      const cnt = await tx.unsafe(countSql, params);
       const data = await tx.unsafe(dataSql, params);
-      return [cnt, data] as const;
+      return data;
     });
-    const [countResult, dataResult] = await raceAbort(txPromise, ctx.abortSignal);
+    const dataResult = await raceAbort(txPromise, ctx.abortSignal);
 
-    const totalCount = countResult[0]?.c ?? 0;
+    const rawRows = Array.isArray(dataResult)
+      ? (dataResult as Array<Record<string, unknown>>)
+      : [];
+    // Empty page: total is unknowable from rows alone. offset=0 with no rows is a
+    // true 0; an out-of-range offset reports 0 (has_more is false either way).
+    const totalCount = rawRows.length > 0 ? Number(rawRows[0][TOTAL_COL]) || 0 : 0;
+    const rows = rawRows.map((row) => {
+      const { [TOTAL_COL]: _total, ...rest } = row;
+      return rest;
+    });
 
-    const columns = ((dataResult as any).columns ?? []).map(
-      (col: { name: string; type: number }) => ({
-        name: col.name,
-        type: oidToTypeName(col.type),
-      })
-    );
+    const columns = ((dataResult as any).columns ?? [])
+      .filter((col: { name: string }) => col.name !== TOTAL_COL)
+      .map(
+        (col: { name: string; type: number }) => ({
+          name: col.name,
+          type: oidToTypeName(col.type),
+        })
+      );
 
     return {
-      rows: Array.isArray(dataResult) ? dataResult : [],
+      rows,
       columns,
       total_count: totalCount,
       has_more: offset + limit < totalCount,

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -990,14 +990,20 @@ async function listEntityTypes(
     ORDER BY et.name ASC
   `;
 
-  // Same stored+derived count path as manage_entity_schema list / entity list.
+  // Stored-type counts only. Derived types would re-run their full backing
+  // SQL (e.g. the subscription report: 2-5s, authz-wrapped, list + count) on
+  // every resolve_path call just for a bootstrap badge; the agent context does
+  // not need it. Same policy as manage_entity_schema list/get and the entity
+  // list: the exact row count stays available from the derived list response.
   const counts = await getEntityCountsByTypes(
-    rows.map((row) => ({
-      id: Number(row.id),
-      slug: String(row.slug),
-      backing_sql: (row.backing_sql as string | null) ?? null,
-      backing_source: (row.backing_source as string | null) ?? null,
-    })),
+    rows
+      .filter((row) => row.backing_sql == null)
+      .map((row) => ({
+        id: Number(row.id),
+        slug: String(row.slug),
+        backing_sql: null,
+        backing_source: null,
+      })),
     ctx
   );
 

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -133,20 +133,15 @@ async function executeListQuery(args: {
   if (args.entityId == null) {
     // Org-wide listing (the activity feed). The COUNT is one of the two
     // expensive scans here — it re-evaluates the full visibility predicate
-    // across every live event — so: skip it entirely on date-feed cursor
-    // pages (pagination reads has_older/has_newer from the candidate probe,
-    // fetchLimit = limit+1, and the UI keeps showing the first page's total
-    // while scrolling), and otherwise run count + list in parallel instead of
-    // serializing two full scans. An org feed is never empty in practice, so
-    // nothing relies on a pre-flight count short-circuit.
-    const skipCount = args.useDateFeed && args.cursor != null;
+    // across every live event — so run count + list in parallel instead of
+    // serializing two full scans. The total stays exact on every page
+    // (cursor pages included): ContentSearchResponse.total is part of the
+    // read_knowledge contract and callers rely on it.
     const [countResult, rows] = await Promise.all([
-      skipCount
-        ? Promise.resolve([{ total: 0 }] as Array<{ total: number | string }>)
-        : sql.unsafe<{ total: number | string }>(countSql, countParams),
+      sql.unsafe<{ total: number | string }>(countSql, countParams),
       args.sql.unsafe(querySQL, queryParams) as Promise<any[]>,
     ]);
-    total = skipCount ? 0 : parseInt(String(countResult[0]?.total ?? '0'), 10);
+    total = parseInt(String(countResult[0]?.total ?? '0'), 10);
     rawRows = rows;
     if (total === 0 && rawRows.length === 0) {
       return emptyListResponse({

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -50,6 +50,7 @@ async function executeListQuery(args: {
   joinSql: string;
   whereExpr: string;
   countParams: any[];
+  entityId: number | null;
   threadEntityLinkSqlForP: string | undefined;
   needClassifications: boolean;
   useDateFeed: boolean;
@@ -63,28 +64,10 @@ async function executeListQuery(args: {
 }): Promise<ContentSearchResponse> {
   const { sql, joinSql, whereExpr, countParams } = args;
 
-  const countResult = await sql.unsafe<{ total: number | string }>(
-    `SELECT COUNT(*) as total FROM current_event_records f
+  const countSql = `SELECT COUNT(*) as total FROM current_event_records f
       LEFT JOIN connections c ON c.id = f.connection_id
       ${joinSql}
-      WHERE ${whereExpr}`,
-    countParams
-  );
-  const total = parseInt(String(countResult[0]?.total ?? '0'), 10);
-
-  // Short-circuit on empty matches. Even with the trimmed entity-link UNION,
-  // the enrichment query — recursive thread_meta + classifications +
-  // parent/root LEFT JOINs — pays a real planner cost on a large events table
-  // when run via postgres.js's extended protocol even if result_set is empty
-  // server-side. One extra round-trip on the cheap count beats that.
-  if (total === 0) {
-    return emptyListResponse({
-      limit: args.limit,
-      effectiveOffset: args.effectiveOffset,
-      useDateFeed: args.useDateFeed,
-      cursor: args.cursor,
-    });
-  }
+      WHERE ${whereExpr}`;
 
   const cursorClause = buildDateCursorClause(
     args.cursor,
@@ -144,7 +127,54 @@ async function executeListQuery(args: {
     ? [...queryBaseParams, args.fetchLimit]
     : [...queryBaseParams, args.limit, args.effectiveOffset];
 
-  const rawRows = (await args.sql.unsafe(querySQL, queryParams)) as any[];
+  let total: number;
+  let rawRows: any[];
+
+  if (args.entityId == null) {
+    // Org-wide listing (the activity feed). The COUNT is one of the two
+    // expensive scans here — it re-evaluates the full visibility predicate
+    // across every live event — so: skip it entirely on date-feed cursor
+    // pages (pagination reads has_older/has_newer from the candidate probe,
+    // fetchLimit = limit+1, and the UI keeps showing the first page's total
+    // while scrolling), and otherwise run count + list in parallel instead of
+    // serializing two full scans. An org feed is never empty in practice, so
+    // nothing relies on a pre-flight count short-circuit.
+    const skipCount = args.useDateFeed && args.cursor != null;
+    const [countResult, rows] = await Promise.all([
+      skipCount
+        ? Promise.resolve([{ total: 0 }] as Array<{ total: number | string }>)
+        : sql.unsafe<{ total: number | string }>(countSql, countParams),
+      args.sql.unsafe(querySQL, queryParams) as Promise<any[]>,
+    ]);
+    total = skipCount ? 0 : parseInt(String(countResult[0]?.total ?? '0'), 10);
+    rawRows = rows;
+    if (total === 0 && rawRows.length === 0) {
+      return emptyListResponse({
+        limit: args.limit,
+        effectiveOffset: args.effectiveOffset,
+        useDateFeed: args.useDateFeed,
+        cursor: args.cursor,
+      });
+    }
+  } else {
+    // Entity-scoped listing: count FIRST so empty matches short-circuit before
+    // paying the enrichment planner cost — recursive thread_meta +
+    // classifications + parent/root LEFT JOINs cost real planning time on a
+    // large events table even when result_set is empty server-side. Entities
+    // can legitimately have zero content, and callers rely on exact totals
+    // across cursor pages, so keep both semantics here.
+    const countResult = await sql.unsafe<{ total: number | string }>(countSql, countParams);
+    total = parseInt(String(countResult[0]?.total ?? '0'), 10);
+    if (total === 0) {
+      return emptyListResponse({
+        limit: args.limit,
+        effectiveOffset: args.effectiveOffset,
+        useDateFeed: args.useDateFeed,
+        cursor: args.cursor,
+      });
+    }
+    rawRows = (await args.sql.unsafe(querySQL, queryParams)) as any[];
+  }
 
   const content = args.needClassifications
     ? deduplicateWithClassifications(rawRows)
@@ -391,6 +421,7 @@ export async function listContentInternal(
       joinSql: '',
       whereExpr: `${whereSql} ${excludeClause.sql} ${visibilityClause.sql}${entityTypesClause.sql}`,
       countParams: allFilterParams,
+      entityId: entityId ?? null,
       threadEntityLinkSqlForP: threadEntityLinkSql,
       needClassifications,
       useDateFeed,
@@ -470,6 +501,7 @@ export async function listContentInternal(
   return executeListQuery({
     sql,
     joinSql: WINDOW_JOIN_SQL,
+    entityId: entityId ?? null,
     whereExpr: `${standardWhereSql}
           AND ${connectionCondition}
           AND ${feedCondition}

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -1265,52 +1265,62 @@ export async function listEntities(
 		}
 	}
 
-	const conditions: string[] = ["e.deleted_at IS NULL"];
+	const conditions: string[] = ["{e}.deleted_at IS NULL"];
 	const params: unknown[] = [];
 	let paramIdx = 1;
 
 	// Organization filter
-	conditions.push(`e.organization_id = $${paramIdx++}`);
+	conditions.push(`{e}.organization_id = $${paramIdx++}`);
 	params.push(ctx.organizationId);
 
 	if (filters.entity_type) {
-		conditions.push(`et.slug = $${paramIdx++}`);
+		conditions.push(`{et}.slug = $${paramIdx++}`);
 		params.push(filters.entity_type);
 	}
 
 	if (filters.parent_id !== undefined) {
 		if (filters.parent_id === null) {
-			conditions.push("e.parent_id IS NULL");
+			conditions.push("{e}.parent_id IS NULL");
 		} else {
-			conditions.push(`e.parent_id = $${paramIdx++}`);
+			conditions.push(`{e}.parent_id = $${paramIdx++}`);
 			params.push(filters.parent_id);
 		}
 	}
 
 	if (filters.search) {
 		conditions.push(
-			`(e.name ILIKE $${paramIdx} OR e.metadata->>'domain' ILIKE $${paramIdx})`,
+			`({e}.name ILIKE $${paramIdx} OR {e}.metadata->>'domain' ILIKE $${paramIdx})`,
 		);
 		params.push(`%${filters.search}%`);
 		paramIdx++;
 	}
 
 	if (filters.category) {
-		conditions.push(`e.metadata->>'category' = $${paramIdx++}`);
+		conditions.push(`{e}.metadata->>'category' = $${paramIdx++}`);
 		params.push(filters.category);
 	}
 
 	if (filters.main_market) {
-		conditions.push(`e.metadata->>'main_market' = $${paramIdx++}`);
+		conditions.push(`{e}.metadata->>'main_market' = $${paramIdx++}`);
 		params.push(filters.main_market);
 	}
 
 	if (filters.market) {
-		conditions.push(`e.metadata->>'market' = $${paramIdx++}`);
+		conditions.push(`{e}.metadata->>'market' = $${paramIdx++}`);
 		params.push(filters.market);
 	}
 
-	const whereClause = conditions.join(" AND ");
+	// Render the shared conditions for a given pair of table aliases. The
+	// outer query uses e/et; the page-id prefetch subquery below re-binds the
+	// very same $N params to e2/et2 (single statement, single param list).
+	const renderWhere = (eAlias: string, etAlias: string) =>
+		conditions
+			.map((c) =>
+				c.replace(/\{e\}\./g, `${eAlias}.`).replace(/\{et\}\./g, `${etAlias}.`),
+			)
+			.join(" AND ");
+
+	const whereClause = renderWhere("e", "et");
 
 	const sortColumnMap: Record<string, string> = {
 		name: "e.name",
@@ -1353,6 +1363,25 @@ export async function listEntities(
     params
   );
 
+  // Two-stage page fetch. The four per-row count LATERALs make enrichment
+  // expensive (~ms..100ms per row), and with ORDER BY + LIMIT the planner
+  // still evaluates them for EVERY filter-matching row before the top-N sort
+  // picks the page (2,042 market companies ≈ 8s per page load). When sorting
+  // by a plain entity column we resolve the page ids first — filters + ORDER
+  // BY only, no LATERALs — and enrich just those rows. Sorts by computed
+  // columns (total_content, …) need the counts for ordering, so they keep the
+  // single-query shape.
+  const plainSort = sortBy === 'name' || sortBy === 'created_at';
+  const pageIdClause = plainSort
+    ? `AND e.id = ANY(ARRAY(
+         SELECT e2.id FROM entities e2
+         JOIN entity_types et2 ON et2.id = e2.entity_type_id
+         WHERE ${renderWhere('e2', 'et2')}
+         ORDER BY ${sortColumnMap[sortBy].replace(/^e\./, 'e2.')} ${sortOrderSql}, e2.id ASC
+         LIMIT ${limit + 1} OFFSET ${offset}
+       ))`
+    : '';
+
   const result = await sql.unsafe<CreatedEntity>(
     `SELECT
       e.id, et.slug AS entity_type, e.name, e.slug, e.parent_id, e.metadata, e.created_at,
@@ -1362,9 +1391,10 @@ export async function listEntities(
       COALESCE(cc.cnt, 0) as children_count,
       pe.name as parent_name, pe.slug as parent_slug, pet.slug as parent_entity_type
     ${baseQuery}
+    ${pageIdClause}
     ORDER BY ${orderBy}
     LIMIT ${limit + 1}
-    OFFSET ${offset}`,
+    ${plainSort ? '' : `OFFSET ${offset}`}`,
     params
   );
 


### PR DESCRIPTION
Profiled against prod (buremba + market orgs) via lobu CLI, pg_stat_statements deltas, Loki, and EXPLAIN ANALYZE. All numbers measured on prod data.

## What this fixes

| path | before | after | how |
|---|---|---|---|
| Activity feed, first page (`read_knowledge`) | 2.2s | ~1.2s | count + list run in parallel (were serial) |
| Activity feed, scroll pages | 2.2s/page | ~1.0s | full COUNT skipped on date-feed cursor pages — pagination uses the limit+1 candidate probe; UI shows the first page's total |
| Opening a derived-type page (schema list/get/update) | 5.9–6.2s | ~0.3s | derived-type badge counts no longer re-run the full backing SQL; UI reads the count from the entity list response |
| Derived entity list (e.g. subscriptions) | 6.3s | ~3.7s | `querySqlImpl` runs the scoped subquery once with `COUNT(*) OVER ()` instead of twice (data + separate COUNT); exact `total_count` preserved |
| `resolve_path` bootstrap | — | stored counts only | derived badge counts skipped in agent bootstrap |
| market.lobu.ai `/memory?type=company` | 8.2s warm / 25.9s cold | **~75ms** | stored entity list: two-stage page fetch — page ids resolved without LATERALs, only the page rows pay the 4 per-row count laterals (plan was evaluating them for all 2,042 filter-matching rows before the top-N sort). Computed-column sorts keep the single-query shape. |

## Safety

- Entity-scoped content listings keep count-first empty short-circuit and exact totals on every page (perf regression guard + cursor-total tests unchanged).
- `read_knowledge`/UI contract preserved: `total` stays exact wherever it is displayed; empty-state semantics unchanged.
- Org-wide first-page `total` remains exact (count runs in parallel, not dropped).

## Validation

- typecheck clean; biome lint clean for touched files (warnings only, pre-existing)
- 29 bun unit tests + 169 vitest integration tests passing (query_sql, derived routing/query, entity-schema, entities, get-content/search-content, resolve-path contract, dogfood e2e)
- `derived-entity-routing` test updated to pin the new derived-count contract

## Known remaining gap (not in this PR)

The 3-way OR org-scope predicate (`organization_id = $org OR EXISTS(id = ANY(entity_ids)) OR conn.org`) still forces full scans per execution (~1s each for the feed): the entity bridge adds only 2.3% of rows but defeats index usage; GIN-overlap rewrites measured worse (10.7s). Needs a schema-level decision (denormalized org mapping).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable pagination for entity, content, and SQL query listings, including exact totals and “has more” indicators.
  - Added sorting and search support across paginated entity results, including computed content totals.
  - Improved handling of empty pages and queries with no matching results.
- **Bug Fixes**
  - Corrected entity counts for derived types and preserved accurate counts for stored types.
  - Prevented internal count data from appearing in query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->