### PR TITLE
perf(server): denormalize org-scope bridge into events.linked_org_ids

### DIFF
--- a/db/migrations/20260804170000_events_linked_org_ids.sql
+++ b/db/migrations/20260804170000_events_linked_org_ids.sql
@@ -1,0 +1,110 @@
+-- Org-scope bridge, denormalized (schema part 1: column + view).
+-- The GIN index lives in 20260804170001 so it can build CONCURRENTLY —
+-- CREATE INDEX CONCURRENTLY can't run inside a transaction, and db:lint
+-- (squawk) bans non-concurrent index builds on the hot events table.
+--
+-- Org-scoped reads (content feed, derived views, data sources) must answer:
+-- "is this event visible to org X?" An event is in scope when ANY of:
+--   1. it was stamped to X directly (`events.organization_id`),
+--   2. one of its `entity_ids` belongs to an entity of X, or
+--   3. the connection that produced it belongs to X.
+--
+-- Branches 2+3 were evaluated as per-row OR/EXISTS subplans over the whole
+-- live-events table (~422k subplan executions, ~1-2s per query on prod) and
+-- defeated every index on the outer scan. This column folds branches 2+3 into
+-- a single GIN-indexed array computed AT WRITE TIME (entity orgs and the
+-- connection's org are immutable; events are append-only and merges never
+-- rewrite them), turning the scope predicate into two indexable conditions:
+--
+--   organization_id = $org OR linked_org_ids @> ARRAY[$org]
+--
+-- Semantics are EXACTLY the old bridge: orgs of the stamped entities and of
+-- the producing connection, minus the event's own org. `{}` means "no linked
+-- orgs"; NULL only exists on rows predating the backfill.
+
+-- migrate:up
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS linked_org_ids text[];
+
+-- Recreate the live-events view to expose the column (eventOrgScope in
+-- execute-data-sources.ts predicates over this view).
+CREATE OR REPLACE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id,
+    e.linked_org_ids
+   FROM public.events e
+  WHERE e.superseded_by IS NULL;
+
+-- migrate:down
+CREATE OR REPLACE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id
+   FROM public.events e
+  WHERE e.superseded_by IS NULL;
+
+ALTER TABLE public.events DROP COLUMN IF EXISTS linked_org_ids;

--- a/db/migrations/20260804170001_events_linked_org_ids_gin.sql
+++ b/db/migrations/20260804170001_events_linked_org_ids_gin.sql
@@ -1,0 +1,18 @@
+-- migrate:up transaction:false
+
+-- Org-scope bridge, denormalized (schema part 2: GIN index).
+-- Companion to 20260804170000_events_linked_org_ids.sql, split out because
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction and db:lint
+-- (squawk) bans non-concurrent builds on the hot events table. One statement
+-- per transaction:false migration — dbmate sends the block as one
+-- simple-query batch and CONCURRENTLY can't share it.
+--
+-- Serves the denormalized org-scope predicate:
+--   organization_id = $org OR linked_org_ids @> ARRAY[$org]
+-- The containment branch BitmapOrs with the organization_id btree branch.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_linked_org_ids
+  ON public.events USING gin (linked_org_ids);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_linked_org_ids;

--- a/packages/server/src/__tests__/integration/events/linked-org-ids.test.ts
+++ b/packages/server/src/__tests__/integration/events/linked-org-ids.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Denormalized org-scope bridge: `events.linked_org_ids` + the flag-gated
+ * predicate in buildOrgScopeWhere.
+ *
+ * Pins:
+ *  1. Write-time computation: cross-org entity links and cross-org
+ *     connections land in the column, the event's own org is excluded, and
+ *     unlinked events get '{}'.
+ *  2. Predicate parity: with LOBU_LINKED_ORG_SCOPE=1 an org-scoped feed shows
+ *     exactly the bridge-visible events the legacy OR/EXISTS predicate shows —
+ *     including them when linked, excluding them when not.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { getContent } from "../../../tools/get_content";
+import type { ToolContext } from "../../../tools/registry";
+import { insertEvent } from "../../../utils/insert-event";
+import { getDb } from "../../../db/client";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestConnection,
+	createTestConnectorDefinition,
+	createTestEntity,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+describe("events.linked_org_ids + LOBU_LINKED_ORG_SCOPE parity", () => {
+	let orgA: Awaited<ReturnType<typeof createTestOrganization>>;
+	let orgB: Awaited<ReturnType<typeof createTestOrganization>>;
+	let userB: Awaited<ReturnType<typeof createTestUser>>;
+	let entityB: Awaited<ReturnType<typeof createTestEntity>>;
+	let connBId: number;
+
+	let linkedEventId: number; // org A event linked to org B's entity
+	let connLinkedEventId: number; // org A event via org B's connection
+	let plainEventId: number; // org A event, no bridge to B
+	let selfLinkedEventId: number; // org A event linked to org A entity only
+
+	function orgBCtx(): ToolContext {
+		return {
+			organizationId: orgB.id,
+			userId: userB.id,
+			memberRole: "owner",
+			isAuthenticated: true,
+			tokenType: "oauth",
+			scopedToOrg: false,
+			allowCrossOrg: true,
+			scopes: ["mcp:read"],
+		};
+	}
+
+	const visibleIds = async (): Promise<Set<number>> => {
+		const res = await getContent(
+			{ limit: 50, sort_by: "date", sort_order: "desc" } as never,
+			{} as never,
+			orgBCtx(),
+		);
+		return new Set(res.content.map((c) => c.id as number));
+	};
+
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+		await cleanupTestDatabase();
+
+		orgA = await createTestOrganization({ name: "Bridge Org A" });
+		orgB = await createTestOrganization({ name: "Bridge Org B" });
+		userB = await createTestUser({ email: "bridge-b@test.com" });
+		await addUserToOrganization(userB.id, orgB.id, "owner");
+
+		entityB = await createTestEntity({
+			name: "Org B Entity",
+			organization_id: orgB.id,
+		});
+
+		await createTestConnectorDefinition({
+			key: "bridge-connector",
+			name: "Bridge Connector",
+			organization_id: orgB.id,
+		});
+		const connB = await createTestConnection({
+			organization_id: orgB.id,
+			connector_key: "bridge-connector",
+			entity_ids: [entityB.id],
+			visibility: "org",
+			created_by: userB.id,
+			display_name: "Org B conn",
+		});
+		connBId = connB.id;
+
+		linkedEventId = (
+			await insertEvent({
+				organizationId: orgA.id,
+				entityIds: [entityB.id],
+				originId: "bridge-linked-event",
+				semanticType: "note",
+				content: "org A event linked to org B entity",
+			})
+		).id;
+
+		connLinkedEventId = (
+			await insertEvent({
+				organizationId: orgA.id,
+				entityIds: [],
+				connectionId: connBId,
+				connectorKey: "bridge-connector",
+				originId: "bridge-conn-event",
+				semanticType: "note",
+				content: "org A event via org B connection",
+			})
+		).id;
+
+		plainEventId = (
+			await insertEvent({
+				organizationId: orgA.id,
+				entityIds: [],
+				originId: "bridge-plain-event",
+				semanticType: "note",
+				content: "org A event with no bridge",
+			})
+		).id;
+
+		const entityA = await createTestEntity({
+			name: "Org A Entity",
+			organization_id: orgA.id,
+		});
+		selfLinkedEventId = (
+			await insertEvent({
+				organizationId: orgA.id,
+				entityIds: [entityA.id],
+				originId: "bridge-self-event",
+				semanticType: "note",
+				content: "org A event linked to org A entity only",
+			})
+		).id;
+	}, 60_000);
+
+	afterEach(() => {
+		delete process.env.LOBU_LINKED_ORG_SCOPE;
+	});
+
+	afterAll(async () => {
+		delete process.env.LOBU_LINKED_ORG_SCOPE;
+		await cleanupTestDatabase();
+	});
+
+	it("computes linked_org_ids at insert: cross-org links in, own org out", async () => {
+		const sql = getDb();
+		// SQL-side containment/cardinality assertions — robust to how the driver
+		// surfaces text[] (JS array vs literal).
+		const rows = await sql`
+      SELECT
+        id,
+        linked_org_ids @> ARRAY[${orgB.id}]::text[] AS has_b,
+        cardinality(linked_org_ids) AS n
+      FROM events
+      WHERE id IN (${linkedEventId}, ${connLinkedEventId}, ${plainEventId}, ${selfLinkedEventId})
+    `;
+		const byId = new Map(rows.map((r) => [Number(r.id), r]));
+
+		expect(byId.get(linkedEventId)?.has_b).toBe(true);
+		expect(byId.get(linkedEventId)?.n).toBe(1);
+		expect(byId.get(connLinkedEventId)?.has_b).toBe(true);
+		expect(byId.get(connLinkedEventId)?.n).toBe(1);
+		expect(byId.get(plainEventId)?.n).toBe(0);
+		// Own-org entity link is excluded — no bridge to self.
+		expect(byId.get(selfLinkedEventId)?.n).toBe(0);
+	});
+
+	it("legacy predicate (flag off): org B sees exactly the bridged events", async () => {
+		const ids = await visibleIds();
+		expect(ids.has(linkedEventId)).toBe(true);
+		expect(ids.has(connLinkedEventId)).toBe(true);
+		expect(ids.has(plainEventId)).toBe(false);
+		expect(ids.has(selfLinkedEventId)).toBe(false);
+	});
+
+	it("denormalized predicate (flag on) is parity with the legacy bridge", async () => {
+		process.env.LOBU_LINKED_ORG_SCOPE = "1";
+		const ids = await visibleIds();
+		expect(ids.has(linkedEventId)).toBe(true);
+		expect(ids.has(connLinkedEventId)).toBe(true);
+		expect(ids.has(plainEventId)).toBe(false);
+		expect(ids.has(selfLinkedEventId)).toBe(false);
+	});
+});

--- a/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
+++ b/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
@@ -86,3 +86,44 @@ describe('buildScopedQuery events CTE — per-user connection visibility (S0)', 
     expect(params[0]).toBe('org_test');
   });
 });
+
+
+describe('buildScopedQuery org scope — denormalized linked_org_ids seam', () => {
+  it('flag off (default): legacy OR/EXISTS bridge over entities + connection', () => {
+    delete process.env.LOBU_LINKED_ORG_SCOPE;
+    const { sql } = buildScopedQuery('SELECT * FROM events', ['events'], {
+      organizationId: 'org_test',
+    });
+    expect(sql).toContain('EXISTS (SELECT 1 FROM public.entities ent');
+    expect(sql).toContain('EXISTS (SELECT 1 FROM public.connections con');
+    expect(sql).not.toContain('linked_org_ids');
+  });
+
+  it('flag on: events CTE uses the GIN-indexed containment predicate', () => {
+    process.env.LOBU_LINKED_ORG_SCOPE = '1';
+    try {
+      const { sql } = buildScopedQuery('SELECT * FROM events', ['events'], {
+        organizationId: 'org_test',
+      });
+      expect(sql).toContain('ev.linked_org_ids @> ARRAY[');
+      expect(sql).not.toContain('EXISTS (SELECT 1 FROM public.entities ent');
+      expect(sql).not.toContain('EXISTS (SELECT 1 FROM public.connections con');
+    } finally {
+      delete process.env.LOBU_LINKED_ORG_SCOPE;
+    }
+  });
+
+  it('flag on: event_classifications visibility EXISTS uses the same seam', () => {
+    process.env.LOBU_LINKED_ORG_SCOPE = '1';
+    try {
+      const { sql } = buildScopedQuery(
+        'SELECT excerpts FROM event_classifications',
+        ['event_classifications'],
+        { organizationId: 'org_test' }
+      );
+      expect(sql).toContain('ev.linked_org_ids @> ARRAY[');
+    } finally {
+      delete process.env.LOBU_LINKED_ORG_SCOPE;
+    }
+  });
+});

--- a/packages/server/src/gateway/connections/webhook-ingest.ts
+++ b/packages/server/src/gateway/connections/webhook-ingest.ts
@@ -612,7 +612,21 @@ export async function handleWebhookIngest(
 				await tx`
 					UPDATE events
 					SET entity_ids = COALESCE(${entityIdsValue}::bigint[], entity_ids),
-					    metadata = metadata || ${tx.json(attribution.metadata ?? {})}
+					    metadata = metadata || ${tx.json(attribution.metadata ?? {})},
+					    linked_org_ids = (
+					      SELECT COALESCE(array_agg(DISTINCT x.o), '{}'::text[])
+					      FROM (
+					        SELECT ent.organization_id AS o
+					        FROM public.entities ent
+					        WHERE ent.id = ANY(COALESCE(${entityIdsValue}::bigint[], events.entity_ids))
+					        UNION ALL
+					        SELECT c.organization_id AS o
+					        FROM public.connections c
+					        WHERE c.id = events.connection_id
+					      ) x
+					      WHERE x.o IS NOT NULL
+					        AND (x.o <> events.organization_id OR events.organization_id IS NULL)
+					    )
 					WHERE id = ${inserted.id}
 				`;
 			}

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -165,7 +165,12 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     // which doesn't expose the column — and never usefully can: the Stage-2
     // flip makes the view `WHERE superseded_by IS NULL`, so through the view
     // the column is always NULL. Lineage queries belong on the raw table.
-    events: new Set(['superseded_by']),
+    // linked_org_ids: internal org-scope bridge (migration 20260804170000). The
+    // view exposes it so eventOrgScope can use the GIN-indexed containment
+    // predicate, but the raw array is not a user query surface — scoping is
+    // enforced by the typed tools, not by callers probing which other orgs an
+    // event bridges to.
+    events: new Set(['superseded_by', 'linked_org_ids']),
     connections: new Set(['credentials']),
     // Large per-connector JSONB blobs — too big and structure-dependent to expose
     // via raw SQL. Callers should hit the typed connector handler instead.

--- a/packages/server/src/utils/content-search/visibility.ts
+++ b/packages/server/src/utils/content-search/visibility.ts
@@ -6,6 +6,7 @@
 import { compileConnectionFkVisibility } from '../../authz/connection-visibility';
 import { compileResourceVisibility } from '../../authz/resource-visibility';
 import type { AuthzScope } from '../../authz/scope';
+import { useLinkedOrgScope } from '../linked-org-ids';
 import { validateNumericId } from '../sql-validation';
 
 /**
@@ -57,6 +58,15 @@ export function buildOrgScopeWhere(options: {
   if (options.entity_id || !options.organization_id) return { sql: '', params: [] };
 
   const p = `$${options.baseParamIndex}::text`;
+  // Denormalized bridge (events.linked_org_ids, write-once at INSERT): folds
+  // the entity + connection branches into one GIN-indexed condition instead
+  // of per-row OR/EXISTS subplans. Gated until the one-time backfill is done.
+  if (useLinkedOrgScope()) {
+    return {
+      sql: `AND (f.organization_id = ${p} OR f.linked_org_ids @> ARRAY[${p}]::text[])`,
+      params: [options.organization_id],
+    };
+  }
   const directCond = `f.organization_id = ${p}`;
   const entityCond = `EXISTS (SELECT 1 FROM entities ent_org WHERE ent_org.id = ANY(f.entity_ids) AND ent_org.organization_id = ${p})`;
   const connCond = `c.organization_id = ${p}`;

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -18,6 +18,7 @@
 import { Dialect, ast, parse as parseSql } from '@polyglot-sql/sdk';
 import { type DbClient, pgTextArray } from '../db/client';
 import logger from './logger';
+import { useLinkedOrgScope } from './linked-org-ids';
 import {
   compileConnectionFkVisibility,
   compileConnectionRowVisibility,
@@ -453,8 +454,10 @@ export function buildScopedQuery(
   // the check-security-patterns string-concat guard, and this fragment is far
   // enough from the whitelisted for-loop below that no `security-allowed:`
   // annotation covers it. Keep it concat-free rather than allowlisting it.
-  const eventOrgScope = (alias: string): string =>
-    `(${alias}.organization_id = ${orgP}
+  const eventOrgScope = (alias: string): string => useLinkedOrgScope()
+    ? `(${alias}.organization_id = ${orgP}
+      OR ${alias}.linked_org_ids @> ARRAY[${orgP}]::text[])`
+    : `(${alias}.organization_id = ${orgP}
       OR EXISTS (SELECT 1 FROM public.entities ent
         WHERE ent.id = ANY(${alias}.entity_ids) AND ent.organization_id = ${orgP})
       OR EXISTS (SELECT 1 FROM public.connections con

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -354,7 +354,8 @@ export async function insertEvent(
       connector_key, connection_id, feed_key, feed_id, run_id,
       semantic_type, client_id, created_by,
       interaction_type, interaction_status, interaction_input_schema, interaction_input,
-      interaction_output, interaction_error, supersedes_event_id
+      interaction_output, interaction_error, supersedes_event_id,
+      linked_org_ids
     ) VALUES (
       ${entityIdsValue}::bigint[],
       ${params.organizationId},
@@ -386,7 +387,21 @@ export async function insertEvent(
       ${params.interactionInput ? sql.json(params.interactionInput) : null},
       ${params.interactionOutput ? sql.json(params.interactionOutput) : null},
       ${params.interactionError ?? null},
-      ${supersedesEventId}
+      ${supersedesEventId},
+      (
+        SELECT COALESCE(array_agg(DISTINCT x.o), '{}'::text[])
+        FROM (
+          SELECT ent.organization_id AS o
+          FROM public.entities ent
+          WHERE ent.id = ANY(${entityIdsValue}::bigint[])
+          UNION ALL
+          SELECT c.organization_id AS o
+          FROM public.connections c
+          WHERE c.id = ${params.connectionId ?? null}
+        ) x
+        WHERE x.o IS NOT NULL
+          AND (x.o <> ${params.organizationId}::text OR ${params.organizationId}::text IS NULL)
+      )
     )
     RETURNING id, entity_ids, origin_id, title, semantic_type, created_at
   `;

--- a/packages/server/src/utils/linked-org-ids.ts
+++ b/packages/server/src/utils/linked-org-ids.ts
@@ -1,0 +1,31 @@
+/**
+ * Denormalized org-scope bridge (`events.linked_org_ids`).
+ *
+ * Org-scoped reads (content feed, derived views, data sources) answer "is
+ * this event visible to org X?" via:
+ *
+ *   organization_id = $org OR linked_org_ids @> ARRAY[$org]
+ *
+ * instead of the legacy per-row OR/EXISTS bridge (entities in `entity_ids`
+ * plus the producing connection), which defeated every index on the outer
+ * scan. The array folds both bridge branches into one GIN-indexed column.
+ *
+ * The column is WRITE-ONCE: set at INSERT (and in the webhook-attribution
+ * tail of the same atomic write) and never updated — events are append-only,
+ * and the inputs (entity orgs, connection org) are immutable, so the
+ * insert-time value stays correct forever. Known documented edge: the
+ * entity-tree deletion prune removes ids from `events.entity_ids` without
+ * touching this frozen column, so an event stays bridge-visible in a deleted
+ * cross-org entity's org until superseded (over-visibility only).
+ *
+ * `{}` = no linked orgs. NULL = pre-backfill rows only.
+ */
+
+/**
+ * Rollout gate for reading the denormalized bridge in org-scope predicates.
+ * Flip ON only after the one-time backfill has completed for every org —
+ * pre-backfill rows carry NULL and would lose bridge visibility otherwise.
+ */
+export function useLinkedOrgScope(): boolean {
+	return process.env.LOBU_LINKED_ORG_SCOPE === "1";
+}

--- a/scripts/backfill-linked-org-ids.ts
+++ b/scripts/backfill-linked-org-ids.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env bun
+
+/**
+ * One-time backfill of `events.linked_org_ids` (migration
+ * 20260804170000_events_linked_org_ids).
+ *
+ * ─── Why this exists ─────────────────────────────────────────────────────────
+ * Org-scoped reads (content feed, derived views, data sources) used a per-row
+ * OR/EXISTS bridge — "any of entity_ids is one of our entities, or the
+ * producing connection is ours" — which defeated every index and cost ~1-2s
+ * per query on prod. The migration added `linked_org_ids text[]` folding both
+ * bridge branches into one GIN-indexed column, computed AT WRITE TIME by the
+ * insert path going forward. Rows that existed before the migration carry
+ * NULL; this backfill fills them with the exact same expression.
+ *
+ * ─── Ordering contract ───────────────────────────────────────────────────────
+ * Run this to completion BEFORE flipping LOBU_LINKED_ORG_SCOPE=1: pre-backfill
+ * rows carry NULL and would lose bridge visibility under the new predicate.
+ *
+ * ─── Exactly what it does ────────────────────────────────────────────────────
+ * Walks events by id range in batches. Per batch, two statements:
+ *   1. Rows with no entity_ids and no connection_id get '{}' (no probe).
+ *   2. The rest get DISTINCT orgs of their stamped entities plus their
+ *      connection's org, minus the event's own org — the same computation the
+ *      insert path writes (packages/server/src/utils/insert-event.ts).
+ * Only rows still NULL are touched, so the script is idempotent and
+ * resumable (kill it anytime; rerun continues where it stopped).
+ *
+ * ─── Safety ──────────────────────────────────────────────────────────────────
+ *   - DRY-RUN by default; pass --execute to write.
+ *   - Plain autocommit statements (no long transaction, no lock buildup).
+ *   - Batch size is small (default 5000) so no statement trips
+ *     statement_timeout or blocks writers.
+ *
+ * DATABASE_URL must point at the target database.
+ */
+
+import { parseArgs as parseNodeArgs } from "node:util";
+import { getDb } from "../packages/server/src/db/client";
+
+const { values: args } = parseNodeArgs({
+  options: {
+    execute: { type: "boolean", default: false },
+    batch: { type: "string", default: "5000" },
+    "start-id": { type: "string", default: "0" },
+  },
+});
+
+const EXECUTE = Boolean(args.execute);
+const BATCH = Math.max(100, Number(args.batch ?? 5000));
+const START_ID = Number(args["start-id"] ?? 0);
+
+async function main() {
+  const sql = getDb();
+
+  const bounds = await sql`SELECT min(id) AS lo, max(id) AS hi FROM events`;
+  const lo0 = Number(bounds[0]?.lo ?? 0);
+  const hi = Number(bounds[0]?.hi ?? 0);
+  if (hi === 0) {
+    console.log("no events; nothing to do");
+    return;
+  }
+  let lo = Math.max(lo0, START_ID);
+
+  const remaining = await sql`
+		SELECT count(*)::int AS n FROM events WHERE linked_org_ids IS NULL AND id >= ${lo}
+	`;
+  console.log(
+    `events range ${lo0}..${hi}, backfill starts at ${lo}, ${remaining[0]?.n} rows still NULL`
+  );
+  if (!EXECUTE) {
+    console.log("DRY-RUN: nothing written. Pass --execute to backfill.");
+    return;
+  }
+
+  const started = Date.now();
+  let done = 0;
+
+  for (; lo <= hi; lo += BATCH) {
+    const batchHi = Math.min(lo + BATCH - 1, hi);
+
+    // 1. Unlinked rows: no entities, no connection → empty set, no probes.
+    const empty = await sql`
+			UPDATE events
+			SET linked_org_ids = '{}'::text[]
+			WHERE id BETWEEN ${lo} AND ${batchHi}
+			  AND linked_org_ids IS NULL
+			  AND (entity_ids IS NULL OR cardinality(entity_ids) = 0)
+			  AND connection_id IS NULL
+		`;
+
+    // 2. Linked rows: DISTINCT orgs of stamped entities + connection org,
+    //    minus the event's own org. Same expression as the insert path.
+    const linked = await sql`
+			UPDATE events e
+			SET linked_org_ids = (
+				SELECT COALESCE(array_agg(DISTINCT x.o), '{}'::text[])
+				FROM (
+					SELECT ent.organization_id AS o
+					FROM public.entities ent
+					WHERE ent.id = ANY(e.entity_ids)
+					UNION ALL
+					SELECT c.organization_id AS o
+					FROM public.connections c
+					WHERE c.id = e.connection_id
+				) x
+				WHERE x.o IS NOT NULL
+				  AND (x.o <> e.organization_id OR e.organization_id IS NULL)
+			)
+			WHERE e.id BETWEEN ${lo} AND ${batchHi}
+			  AND e.linked_org_ids IS NULL
+		`;
+
+    done += empty.count + linked.count;
+    if (empty.count + linked.count > 0 || batchHi >= hi) {
+      const pct = Math.min(100, ((batchHi - lo0 + 1) / (hi - lo0 + 1)) * 100);
+      console.log(
+        `  ${lo}..${batchHi}: ${empty.count} empty + ${linked.count} linked (total ${done}, ${pct.toFixed(1)}%, ${Math.round((Date.now() - started) / 1000)}s)`
+      );
+    }
+  }
+
+  const left =
+    await sql`SELECT count(*)::int AS n FROM events WHERE linked_org_ids IS NULL`;
+  console.log(
+    `done: ${done} rows backfilled in ${Math.round((Date.now() - started) / 1000)}s; NULL rows left: ${left[0]?.n}`
+  );
+  if (Number(left[0]?.n) === 0) {
+    console.log("safe to flip LOBU_LINKED_ORG_SCOPE=1");
+  }
+  await sql.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Follow-up to #2488 — removes the last known slow-path tax: the org-scope OR/EXISTS bridge predicate.

## Problem (measured on prod)

Every org-scoped read (activity feed, derived views like subscriptions, data-source queries) wraps `events` in:

```
org = $1 OR EXISTS(id = ANY(entity_ids) ...) OR EXISTS(connection ...)
```

The planner evaluates the EXISTS subplans **per row** (~422k executions) and can't drive any branch from an index — a ~1-2s tax per execution even when the query wants a tiny slice (the subscription view needs 12k of 772k live rows).

## Fix

`events.linked_org_ids text[]` folds both bridge branches into one GIN-indexed column, **written once at INSERT, never updated** (events are append-only; entity/connection orgs are immutable; merges never rewrite entity_ids):

```
organization_id = $org OR linked_org_ids @> ARRAY[$org]
```

Expected: feed ~0.2-0.4s, subscription view ~0.5-1s (was ~4s post-#2488).

Two migrations (split for CONCURRENTLY):
- `20260804170000` — column + `current_event_records` view recreation (transactional)
- `20260804170001` — `CREATE INDEX CONCURRENTLY` GIN, `transaction:false`

## Rollout (two-phase by design)

1. Merge + deploy: migrations, insert-path maintenance, seams gated **off** by default.
2. Run `scripts/backfill-linked-org-ids.ts --execute` (dry-run default, idempotent, resumable, batched).
3. Flip `LOBU_LINKED_ORG_SCOPE=1` — seams switch to the indexed predicate.

## Semantics

Exactly the legacy bridge: DISTINCT orgs of stamped entities + connection's org, minus the event's own org. Parity-pinned by integration tests (flag-on vs flag-off visibility) and buildScopedQuery seam tests for both CTEs. Documented edge: the entity-delete prune mutates `entity_ids` without touching the frozen column (over-visibility only, cross-org deleted entities).

No `event_id` stored anywhere else; no runtime updates to events beyond the existing atomic webhook-attribution write. Column intentionally omitted from QUERYABLE_SCHEMA (internal scoping mechanism, not a user query surface).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved event visibility across related organizations when linked-organization scope is enabled.
  * Events now account for organizations associated through linked entities and connections.
  * Existing events can be populated with linked-organization information through a resumable backfill process.

* **Bug Fixes**
  * Prevented duplicate organization associations and excluded an event’s own organization from linked results.
  * Improved consistency between event visibility checks and organization relationships.
  * Added coverage for cross-organization links, unlinked events, and same-organization relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->