### PR TITLE
ci(registry): publish server.json to the MCP Registry via OIDC

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,47 @@
+name: Publish MCP Registry
+
+# Publishes the root server.json (MCP Registry manifest, server name
+# io.github.lobu-ai/lobu) to the official MCP Registry at
+# registry.modelcontextprotocol.io.
+#
+# Auth is GitHub Actions OIDC: the registry grants publish rights for
+# io.github.lobu-ai/* to workflows running in this org's repos, so there are
+# no long-lived secrets and no interactive OAuth login to maintain. Re-run
+# this workflow after every server.json change (e.g. a version bump).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required by `mcp-publisher login github-oidc` to mint an OIDC token that
+  # the registry exchanges for a short-lived publish JWT.
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          version=1.8.0
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSL -o checksums.txt \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/registry_${version}_checksums.txt"
+          grep " mcp-publisher_linux_amd64.tar.gz$" checksums.txt | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          sudo install mcp-publisher /usr/local/bin/mcp-publisher
+
+      - name: Validate server.json
+        run: mcp-publisher validate
+
+      - name: Login with GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to the official MCP Registry
+        run: mcp-publisher publish


### PR DESCRIPTION
## Summary

Adds a manual workflow that publishes the root `server.json` to the official MCP Registry using `mcp-publisher login github-oidc`.

## Why

The interactive `mcp-publisher login github` device flow currently yields a personal-namespace-only grant (the registry's `/user/memberships/orgs` lookup degrades silently on any 403), blocking publication of `io.github.lobu-ai/lobu`. OIDC auth is granted by repository owner (`io.github.lobu-ai/*` for workflows in this org), needs no human OAuth step, and leaves no long-lived secrets.

## Scope

Adds `.github/workflows/publish-mcp-registry.yml` only. No runtime changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered release workflow for validating and publishing the MCP server to the official registry.
  * Included secure authentication and verification steps to help ensure only validated package metadata is published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->