### PR TITLE
perf(server): query cost-attribution ledger + runs retention index

### DIFF
--- a/db/migrations/20260804220000_runs_terminal_completed_at_idx.sql
+++ b/db/migrations/20260804220000_runs_terminal_completed_at_idx.sql
@@ -1,0 +1,23 @@
+-- migrate:up transaction:false
+
+-- Runs-retention cleanup runs constantly (check-stalled-executions + the
+-- runs-queue pruners) deleting terminal runs older than their retention
+-- window. The "find rows to delete" subquery filters
+--   status IN (terminal) AND completed_at < now() - N days
+-- but there is no index on completed_at, so every sweep did a full seq scan
+-- of `runs` (~294k rows, removing ~98k per parallel worker) to match a
+-- handful of rows — the steady-state backlog is tiny because the sweep keeps
+-- it drained. pg_stat: ~20k calls × ~700ms mean.
+--
+-- Partial index on completed_at for terminal statuses lets the sweep range
+-- scan directly to the old rows instead of scanning the whole table. One
+-- statement per transaction:false migration (CONCURRENTLY can't share a
+-- batch).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runs_terminal_completed_at
+  ON public.runs (completed_at)
+  WHERE status IN ('completed', 'failed', 'timeout', 'cancelled')
+    AND completed_at IS NOT NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_runs_terminal_completed_at;

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -152,6 +152,13 @@ interface QuerySqlCoverage {
 const MAX_SUGGESTED_VIRTUAL_FEEDS = 5;
 const VIRTUAL_FEED_SUGGESTED_LIMIT = 25;
 
+// Cost-attribution ledger: a single expensive user/derived query is how an org
+// degrades the shared DB for everyone (precedent: the 3.5s subscription view).
+// Anything at or above this gets an alertable, structured entry so expensive
+// queries can be rolled up per org in Loki and cross-referenced against
+// pg_stat_statements for the normalized SQL.
+const SLOW_QUERY_COST_MS = 500;
+
 /**
  * Coerce + clamp the page bounds. TypeBox schemas aren't runtime-validated in
  * this codebase, so a non-number limit/offset would otherwise interpolate as a
@@ -633,12 +640,26 @@ export async function querySqlImpl(
         })
       );
 
+    const executionTimeMs = Date.now() - startTime;
+    if (executionTimeMs >= SLOW_QUERY_COST_MS) {
+      logger.warn(
+        {
+          org_id: targetOrgId,
+          user_id: ctx.userId,
+          execution_time_ms: executionTimeMs,
+          row_count: rows.length,
+          total_count: totalCount,
+          tables: tableRefs,
+        },
+        'query_sql slow/expensive query (cost ledger)'
+      );
+    }
     return {
       rows,
       columns,
       total_count: totalCount,
       has_more: offset + limit < totalCount,
-      execution_time_ms: Date.now() - startTime,
+      execution_time_ms: executionTimeMs,
       coverage: await virtualFeedCoverageForEventsQuery(
         tableRefs,
         authzScopeFromToolContext({ organizationId: targetOrgId, userId: ctx.userId }),


### PR DESCRIPTION
Follow-up to the pg_stat_statements fleet-cost audit (after #2488/#2490). Two independent DB-load reductions:

## 1. Cost-attribution ledger (observability)

`querySqlImpl` is the single seam for every `query_sql` call and every derived-view list/count. It now emits an alertable structured `warn` for any query **≥ 500 ms**:

```json
{ "org_id", "user_id", "execution_time_ms", "row_count", "total_count", "tables" }
```

This is the missing 'early warning' — it would have flagged the 3.5 s subscription view automatically (per-org rollup in Loki + cross-reference to `pg_stat_statements` for the normalized SQL) instead of by hand.

## 2. Runs retention index (load)

The retention sweep deletes terminal runs via `status IN (terminal) AND completed_at < now() - N days`, but there was **no `completed_at` index**, so each sweep seq-scanned ~294k `runs` rows to match a tiny (already-drained) backlog. pg_stat: **~20k calls × ~700 ms mean**.

`idx_runs_terminal_completed_at` (CONCURRENTLY, partial on terminal statuses) turns it into a range scan over only the genuinely old rows.

## Verification
- typecheck clean; `query_sql` unit tests pass; `table-schema` drift 19/19.
- squawk: 0 issues on the migration.
- No behavior change; logging is additive, index is additive.