### PR TITLE
fix(ci): download registry asset under its checksummed filename

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -29,12 +29,12 @@ jobs:
         run: |
           set -euo pipefail
           version=1.8.0
-          curl -fsSL -o mcp-publisher.tar.gz \
+          curl -fsSL -o mcp-publisher_linux_amd64.tar.gz \
             "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/mcp-publisher_linux_amd64.tar.gz"
           curl -fsSL -o checksums.txt \
             "https://github.com/modelcontextprotocol/registry/releases/download/v${version}/registry_${version}_checksums.txt"
           grep " mcp-publisher_linux_amd64.tar.gz$" checksums.txt | sha256sum -c -
-          tar xzf mcp-publisher.tar.gz mcp-publisher
+          tar xzf mcp-publisher_linux_amd64.tar.gz mcp-publisher
           sudo install mcp-publisher /usr/local/bin/mcp-publisher
 
       - name: Validate server.json


### PR DESCRIPTION
The first publish run failed at `sha256sum -c`: the tarball was downloaded as `mcp-publisher.tar.gz` while the checksum file references `mcp-publisher_linux_amd64.tar.gz`. Download under the checksummed name so verification and extraction match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publishing reliability by using the correct platform-specific publisher archive during download and extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->