### PR TITLE
feat(behaviors): workspace-level Behaviors with one executor (agent/device/manual)

### DIFF
--- a/db/migrations/20260805120000_watchers_agent_id_nullable.sql
+++ b/db/migrations/20260805120000_watchers_agent_id_nullable.sql
@@ -1,4 +1,4 @@
--- migrate:up
+-- migrate:up transaction:false
 
 -- Behaviors (watchers) are org-level goals whose executor can be a managed
 -- agent OR a device pin (device_worker_id), and manual-only Behaviors have no
@@ -14,7 +14,14 @@
 --
 -- LOCK SAFETY: ALTER COLUMN … DROP NOT NULL on a nullable-backed column is a
 -- `relcache` catalog-only change with no table rewrite and no ACCESS EXCLUSIVE
--- scan, so it is safe to run in one statement.
+-- scan, so it is safe to run in one statement (hence `transaction:false` —
+-- there is no second statement to group with).
+--
+-- squawk-ignore ban-drop-not-null -- agentless rows are the point of this
+-- migration: manual-only and device-pinned Behaviors carry no agent_id, and the
+-- executor matrix (assertBehaviorExecutorsResolve) rejects automated
+-- agentless rows at write time, so clients only ever read a null here for
+-- shapes the app now explicitly allows.
 ALTER TABLE public.watchers
   ALTER COLUMN agent_id DROP NOT NULL;
 

--- a/db/migrations/20260805120000_watchers_agent_id_nullable.sql
+++ b/db/migrations/20260805120000_watchers_agent_id_nullable.sql
@@ -1,0 +1,26 @@
+-- migrate:up
+
+-- Behaviors (watchers) are org-level goals whose executor can be a managed
+-- agent OR a device pin (device_worker_id), and manual-only Behaviors have no
+-- automated triggers at all — their runs stay pending for any connected MCP
+-- client to execute and complete. All three shapes are valid, so agent_id is
+-- no longer mandatory.
+--
+-- The scheduler/event SELECTs already gate on
+-- "device_worker_id IS NOT NULL OR (agent_id IS NOT NULL AND …)", so a null
+-- agent with a device pin still fires; a null agent with no device pin is a
+-- manual-only Behavior. The validation matrix (assertBehaviorExecutorsResolve)
+-- enforces these shapes at write time.
+--
+-- LOCK SAFETY: ALTER COLUMN … DROP NOT NULL on a nullable-backed column is a
+-- `relcache` catalog-only change with no table rewrite and no ACCESS EXCLUSIVE
+-- scan, so it is safe to run in one statement.
+ALTER TABLE public.watchers
+  ALTER COLUMN agent_id DROP NOT NULL;
+
+-- migrate:down
+
+-- Reversing SET NOT NULL would fail if any agentless row now exists; only an
+-- operator who has already removed/purged such rows may roll back.
+ALTER TABLE public.watchers
+  ALTER COLUMN agent_id SET NOT NULL;

--- a/db/migrations/20260805120000_watchers_agent_id_nullable.sql
+++ b/db/migrations/20260805120000_watchers_agent_id_nullable.sql
@@ -14,20 +14,14 @@
 --
 -- LOCK SAFETY: ALTER COLUMN … DROP NOT NULL on a nullable-backed column is a
 -- `relcache` catalog-only change with no table rewrite and no ACCESS EXCLUSIVE
--- scan, so it is safe to run in one statement (hence `transaction:false` —
--- there is no second statement to group with).
---
--- squawk-ignore ban-drop-not-null -- agentless rows are the point of this
--- migration: manual-only and device-pinned Behaviors carry no agent_id, and the
--- executor matrix (assertBehaviorExecutorsResolve) rejects automated
--- agentless rows at write time, so clients only ever read a null here for
--- shapes the app now explicitly allows.
-ALTER TABLE public.watchers
-  ALTER COLUMN agent_id DROP NOT NULL;
+-- scan, so it is safe to run in one statement.
+-- squawk-ignore prefer-robust-stmts,ban-drop-not-null -- single catalog-only statement; agentless rows are the point of this migration — manual-only and device-pinned Behaviors carry no agent_id, and the executor matrix rejects automated agentless rows at write time
+ALTER TABLE public.watchers ALTER COLUMN agent_id DROP NOT NULL;
 
--- migrate:down
+-- migrate:down transaction:false
 
 -- Reversing SET NOT NULL would fail if any agentless row now exists; only an
--- operator who has already removed/purged such rows may roll back.
-ALTER TABLE public.watchers
-  ALTER COLUMN agent_id SET NOT NULL;
+-- operator who has already removed/purged such rows may roll back. Single
+-- statement, catalog-only.
+-- squawk-ignore prefer-robust-stmts,adding-not-nullable-field -- rollback path restoring the baseline constraint, only run after agentless rows are purged
+ALTER TABLE public.watchers ALTER COLUMN agent_id SET NOT NULL;

--- a/examples/personal-agent/revolut-transactions.connector.ts
+++ b/examples/personal-agent/revolut-transactions.connector.ts
@@ -900,7 +900,7 @@ export default class RevolutTransactionsConnector extends ConnectorRuntime {
     return {
       events: [
         {
-          origin_id: "revolut-balances-" + Date.now(),
+          origin_id: `revolut-balances-${Date.now()}`,
           occurred_at: new Date(),
           semantic_type: "balance_raw",
           payload_text:

--- a/packages/cli/bin/lobu.js
+++ b/packages/cli/bin/lobu.js
@@ -22,21 +22,7 @@
   const major = Number.parseInt(current.split(".")[0], 10);
   if (!Number.isFinite(major) || major < MIN_NODE_MAJOR) {
     process.stderr.write(
-      [
-        "",
-        `  Lobu needs Node.js ${MIN_NODE_MAJOR} or newer — you're on Node ${current}.`,
-        "",
-        "  (Lobu runs agent code in an isolated-vm sandbox whose native builds",
-        `   only cover Node ${MIN_NODE_MAJOR}–24 and 26+, so ${MIN_NODE_MAJOR} is the minimum.)`,
-        "",
-        "  Install a supported Node, then re-run:",
-        "    • nvm:   nvm install 22 && nvm use 22",
-        "    • fnm:   fnm install 22 && fnm use 22",
-        "    • brew:  brew install node@22",
-        "",
-        "  Check your version with:  node --version",
-        "",
-      ].join("\n") + "\n"
+      `\n  Lobu needs Node.js ${MIN_NODE_MAJOR} or newer — you're on Node ${current}.\n\n  (Lobu runs agent code in an isolated-vm sandbox whose native builds\n   only cover Node ${MIN_NODE_MAJOR}–24 and 26+, so ${MIN_NODE_MAJOR} is the minimum.)\n\n  Install a supported Node, then re-run:\n    • nvm:   nvm install 22 && nvm use 22\n    • fnm:   fnm install 22 && fnm use 22\n    • brew:  brew install node@22\n\n  Check your version with:  node --version\n\n`
     );
     process.exit(1);
   }

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -859,7 +859,6 @@ export async function executePlan(
           sources: w.sources,
           reactions_guidance: w.reactionsGuidance,
           device_worker_id: w.deviceWorkerId,
-          scheduler_client_id: w.schedulerClientId,
           notification_channel: w.notificationChannel,
           notification_priority: w.notificationPriority,
           min_cooldown_seconds: w.minCooldownSeconds,
@@ -903,9 +902,6 @@ export async function executePlan(
               : {}),
             ...(scalarForUpdate.includes("device_worker_id")
               ? { device_worker_id: w.deviceWorkerId ?? null }
-              : {}),
-            ...(scalarForUpdate.includes("scheduler_client_id")
-              ? { scheduler_client_id: w.schedulerClientId ?? null }
               : {}),
             ...(scalarForUpdate.includes("notification_channel") &&
             w.notificationChannel

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -117,7 +117,6 @@ export interface RemoteBehavior {
   triggers?: import("@lobu/core/contracts/tools/manage-behaviors").BehaviorTrigger[];
   device_worker_id?: string | null;
   goal_id?: number | null;
-  scheduler_client_id?: string | null;
   agent_kind?: string | null;
   notification_channel?: string | null;
   notification_priority?: string | null;
@@ -905,7 +904,6 @@ export class ApplyClient {
     sources?: BehaviorSource[];
     reactions_guidance?: string;
     device_worker_id?: string;
-    scheduler_client_id?: string;
     notification_channel?: "canvas" | "notification" | "both";
     notification_priority?: "low" | "normal" | "high";
     min_cooldown_seconds?: number;
@@ -935,9 +933,6 @@ export class ApplyClient {
         ...(payload.device_worker_id !== undefined
           ? { device_worker_id: payload.device_worker_id }
           : {}),
-        ...(payload.scheduler_client_id !== undefined
-          ? { scheduler_client_id: payload.scheduler_client_id }
-          : {}),
         ...(payload.notification_channel !== undefined
           ? { notification_channel: payload.notification_channel }
           : {}),
@@ -966,15 +961,14 @@ export class ApplyClient {
    * outputs / classifiers) require `createBehaviorVersion`
    * instead.
    *
-   * `null` clears nullable fields (device_worker_id, scheduler_client_id,
-   * agent_kind) per the server contract.
+   * `null` clears nullable fields (device_worker_id, agent_kind) per the
+   * server contract.
    */
   async updateBehavior(payload: {
     behavior_id: string;
     triggers?: import("@lobu/core/contracts/tools/manage-behaviors").BehaviorTrigger[];
     agent_id?: string;
     device_worker_id?: string | null;
-    scheduler_client_id?: string | null;
     notification_channel?: "canvas" | "notification" | "both";
     notification_priority?: "low" | "normal" | "high";
     min_cooldown_seconds?: number;
@@ -988,9 +982,6 @@ export class ApplyClient {
       ...(payload.agent_id !== undefined ? { agent_id: payload.agent_id } : {}),
       ...(payload.device_worker_id !== undefined
         ? { device_worker_id: payload.device_worker_id }
-        : {}),
-      ...(payload.scheduler_client_id !== undefined
-        ? { scheduler_client_id: payload.scheduler_client_id }
         : {}),
       ...(payload.notification_channel !== undefined
         ? { notification_channel: payload.notification_channel }

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -128,8 +128,6 @@ export interface DesiredWatcher {
   reactionsGuidance?: string;
   /** UUID of a device worker to pin this watcher's runs to (see `device_workers.id`). */
   deviceWorkerId?: string;
-  /** MCP client id that should auto-run this watcher. */
-  schedulerClientId?: string;
   /** Where firings surface — defaults to canvas server-side. */
   notificationChannel?: "canvas" | "notification" | "both";
   /** Priority class used by the dispatcher interrupt budget. */

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -493,12 +493,6 @@ function diffWatcher(
     scalar.push("device_worker_id");
   }
   if (
-    desired.schedulerClientId !== undefined &&
-    desired.schedulerClientId !== (remote.scheduler_client_id ?? undefined)
-  ) {
-    scalar.push("scheduler_client_id");
-  }
-  if (
     desired.notificationChannel !== undefined &&
     desired.notificationChannel !== (remote.notification_channel ?? undefined)
   ) {

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -8,6 +8,45 @@ const BehaviorTriggerMatchValueSchema = Type.Union([
 ]);
 
 /**
+ * Per-trigger executor override ("when -> who"). A Behavior is an org-level
+ * goal with one durable contract (prompt / outputs / reaction / budget); its
+ * triggers may route activations to different executors:
+ *
+ *  - `agent`  — a managed Lobu agent executes the run (server dispatch lane).
+ *  - `device` — the pinned device worker's local CLI executes it (device
+ *    lane); `agent_kind` picks the local executor, omitted = device default.
+ *
+ * Omit to use the Behavior's own executor (`agent_id` / `device_worker_id`).
+ * Every event/schedule trigger must resolve to an executor (its own override
+ * or the Behavior default); manual activations are open — any connected MCP
+ * client may complete them, so manual triggers carry no executor.
+ */
+export const BehaviorRespondWithSchema = Type.Union(
+  [
+    Type.Object(
+      {
+        kind: Type.Literal("agent"),
+        agent_id: Type.String({ minLength: 1, maxLength: 128 }),
+      },
+      { additionalProperties: false }
+    ),
+    Type.Object(
+      {
+        kind: Type.Literal("device"),
+        device_worker_id: Type.String({ minLength: 1, maxLength: 64 }),
+        agent_kind: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
+      },
+      { additionalProperties: false }
+    ),
+  ],
+  {
+    description:
+      "Executor override for this activation: a managed agent, or a device worker (with optional local executor kind). Omit to use the Behavior's own executor. Manual activations are open to any connected client and ignore this field.",
+  }
+);
+export type BehaviorRespondWith = Static<typeof BehaviorRespondWithSchema>;
+
+/**
  * Connector event activation for a Behavior. Triggers and context sources are
  * deliberately separate: a trigger decides when to run, while a source only
  * decides which durable data is available to that run.
@@ -63,6 +102,7 @@ export const BehaviorEventTriggerSchema = Type.Object(
         default: true,
       })
     ),
+    respond_with: Type.Optional(BehaviorRespondWithSchema),
   },
   { additionalProperties: false }
 );
@@ -82,6 +122,7 @@ export const BehaviorScheduleTriggerSchema = Type.Object(
       })
     ),
     skip_if_unchanged: Type.Optional(Type.Boolean({ default: true })),
+    respond_with: Type.Optional(BehaviorRespondWithSchema),
   },
   { additionalProperties: false }
 );
@@ -510,11 +551,20 @@ export const ManageBehaviorsSchema = Type.Object(
         description: "[list] Sort direction (default: desc).",
       })
     ),
-    scheduler_client_id: Type.Optional(
-      Type.Union([Type.String(), Type.Null()], {
-        description:
-          "[create/update/create_version] Optional MCP client ID that should auto-run this Behavior. Null clears it.",
-      })
+    run_status: Type.Optional(
+      Type.Union(
+        [
+          Type.Literal("pending"),
+          Type.Literal("claimed"),
+          Type.Literal("running"),
+          Type.Literal("completed"),
+          Type.Literal("failed"),
+        ],
+        {
+          description:
+            "[list] Filter by each Behavior's latest run status (active runs take precedence). Discovery for executors: run_status='pending' lists Behaviors with unhandled runs — manual-open pending runs are completable by any client via complete_window.",
+        }
+      )
     ),
     device_worker_id: Type.Optional(
       Type.Union([Type.String(), Type.Null()], {
@@ -741,7 +791,6 @@ export type BehaviorUpdatePatch = Pick<
   | "execution_config"
   | "triggers"
   | "agent_id"
-  | "scheduler_client_id"
   | "tags"
   | "device_worker_id"
   | "agent_kind"
@@ -784,7 +833,7 @@ export function normalizeBehaviorTags(values: unknown): string[] {
  *   - tags → normalizeBehaviorTags (trim/drop-empty/dedupe)
  *   - notification_channel ?? 'canvas', notification_priority ?? 'normal',
  *     min_cooldown_seconds ?? 0
- *   - null-clearable scalars (agent_id/scheduler_client_id/
+ *   - null-clearable scalars (agent_id/
  *     device_worker_id/agent_kind) and execution_config keep null (a real clear
  *     the write applies) — NOT coerced to undefined, which would hide the clear.
  */
@@ -800,8 +849,6 @@ export function normalizeBehaviorUpdatePatch(
     patch.execution_config = args.execution_config ?? null;
   if (args.triggers !== undefined) patch.triggers = args.triggers;
   if (args.agent_id !== undefined) patch.agent_id = args.agent_id ?? null;
-  if (args.scheduler_client_id !== undefined)
-    patch.scheduler_client_id = args.scheduler_client_id ?? null;
   if (args.tags !== undefined) patch.tags = normalizeBehaviorTags(args.tags);
   if (args.device_worker_id !== undefined)
     patch.device_worker_id = args.device_worker_id ?? null;
@@ -1019,6 +1066,7 @@ export const ListBehaviorsSchema = Type.Pick(ManageBehaviorsSchema, [
   "include_details",
   "order_by",
   "order_dir",
+  "run_status",
   "limit",
 ]);
 

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -7,7 +7,6 @@ const BehaviorTriggerMatchValueSchema = Type.Union([
   Type.Null(),
 ]);
 
-
 /**
  * Connector event activation for a Behavior. Triggers and context sources are
  * deliberately separate: a trigger decides when to run, while a source only

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -7,44 +7,6 @@ const BehaviorTriggerMatchValueSchema = Type.Union([
   Type.Null(),
 ]);
 
-/**
- * Per-trigger executor override ("when -> who"). A Behavior is an org-level
- * goal with one durable contract (prompt / outputs / reaction / budget); its
- * triggers may route activations to different executors:
- *
- *  - `agent`  — a managed Lobu agent executes the run (server dispatch lane).
- *  - `device` — the pinned device worker's local CLI executes it (device
- *    lane); `agent_kind` picks the local executor, omitted = device default.
- *
- * Omit to use the Behavior's own executor (`agent_id` / `device_worker_id`).
- * Every event/schedule trigger must resolve to an executor (its own override
- * or the Behavior default); manual activations are open — any connected MCP
- * client may complete them, so manual triggers carry no executor.
- */
-export const BehaviorRespondWithSchema = Type.Union(
-  [
-    Type.Object(
-      {
-        kind: Type.Literal("agent"),
-        agent_id: Type.String({ minLength: 1, maxLength: 128 }),
-      },
-      { additionalProperties: false }
-    ),
-    Type.Object(
-      {
-        kind: Type.Literal("device"),
-        device_worker_id: Type.String({ minLength: 1, maxLength: 64 }),
-        agent_kind: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
-      },
-      { additionalProperties: false }
-    ),
-  ],
-  {
-    description:
-      "Executor override for this activation: a managed agent, or a device worker (with optional local executor kind). Omit to use the Behavior's own executor. Manual activations are open to any connected client and ignore this field.",
-  }
-);
-export type BehaviorRespondWith = Static<typeof BehaviorRespondWithSchema>;
 
 /**
  * Connector event activation for a Behavior. Triggers and context sources are
@@ -102,7 +64,6 @@ export const BehaviorEventTriggerSchema = Type.Object(
         default: true,
       })
     ),
-    respond_with: Type.Optional(BehaviorRespondWithSchema),
   },
   { additionalProperties: false }
 );
@@ -122,7 +83,6 @@ export const BehaviorScheduleTriggerSchema = Type.Object(
       })
     ),
     skip_if_unchanged: Type.Optional(Type.Boolean({ default: true })),
-    respond_with: Type.Optional(BehaviorRespondWithSchema),
   },
   { additionalProperties: false }
 );

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -1168,7 +1168,15 @@ describe('watcher CRUD', () => {
         name: 'CFV Manual Base',
         prompt: 'Manual only.',
         sources: [{ name: 'content', query: 'SELECT id FROM events' }],
-      })) as { behavior_id: string };
+      })) as { behavior_id: string; view_url?: string };
+
+      // The Behavior route is workspace-level, so an agentless Behavior gets a
+      // link like any other. Gating view_url on agent_id left exactly the rows
+      // this feature adds (device-pinned / manual-only) with no way for an MCP
+      // agent to hand the user a link. Asserted on the path, not the origin:
+      // a local packages/owletto/dist flips the builder to a relative URL.
+      expect(base.view_url).toContain(`/behaviors/${base.behavior_id}`);
+
       const [row] = await sql<{ current_version_id: number }[]>`
         SELECT current_version_id FROM watchers WHERE id = ${base.behavior_id}
       `;
@@ -1184,6 +1192,21 @@ describe('watcher CRUD', () => {
       `;
       expect(clone.agent_id).toBeNull();
       expect(clone.device_worker_id).toBeNull();
+
+      // Same for the read paths an agent actually calls.
+      const listed = (await owner.behaviors.manage({
+        action: 'list',
+        entity_id: entityId,
+      })) as { behaviors?: Array<{ behavior_id?: string; id?: string; view_url?: string }> };
+      const listedBase = (listed.behaviors ?? []).find(
+        (b) => String(b.behavior_id ?? b.id) === String(base.behavior_id)
+      );
+      expect(listedBase?.view_url).toContain(`/behaviors/${base.behavior_id}`);
+
+      const fetched = (await owner.behaviors.get({
+        behavior_id: base.behavior_id,
+      })) as { view_url?: string };
+      expect(fetched.view_url).toContain(`/behaviors/${base.behavior_id}`);
 
       await owner.behaviors.delete({
         behavior_ids: [base.behavior_id, cloneId],

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -1090,4 +1090,104 @@ describe('watcher CRUD', () => {
       await owner.behaviors.delete({ behavior_ids: [created.behavior_id] });
     });
   });
+
+  describe('create_from_version executor cloning', () => {
+    async function seedDevice(worker: string): Promise<string> {
+      const sql = getTestDb();
+      const rows = (await sql`
+        INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label, organization_id)
+        VALUES (${ownerUserId}, ${worker}, 'macos', ${sql.json([])}, 'CFV Device', ${ownerOrgId})
+        RETURNING id
+      `) as unknown as Array<{ id: string }>;
+      return String(rows[0].id);
+    }
+
+    it('clones a device-pinned behavior and copies the device pin (no executor flip, no zombie)', async () => {
+      const sql = getTestDb();
+      const deviceId = await seedDevice('cfv-device-pin');
+      const target = (await owner.entities.create({
+        type: 'company',
+        name: 'CFV Device Clone Target',
+      })) as { entity: { id: number } };
+
+      // Device-pinned (agent present for skills anchoring, device wins at
+      // dispatch). The old clone path copied only agent_id, silently dropping
+      // device_worker_id + agent_kind — a clone that flipped from device
+      // execution to server/agent dispatch. The clone must carry the pin.
+      const base = (await owner.behaviors.manage({
+        action: 'create',
+        entity_id: entityId,
+        slug: 'cfv-device-base',
+        name: 'CFV Device Base',
+        prompt: 'Track on device.',
+        triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
+        agent_id: agentId,
+        device_worker_id: deviceId,
+        agent_kind: 'codex',
+      })) as { behavior_id: string };
+      const [row] = await sql<{ current_version_id: number }[]>`
+        SELECT current_version_id FROM watchers WHERE id = ${base.behavior_id}
+      `;
+      const versionId = Number(row?.current_version_id);
+
+      const res = (await owner.behaviors.createFromVersion({
+        version_id: versionId,
+        entity_ids: [target.entity.id],
+      })) as { created: Array<{ behavior_id: string }> };
+      const cloneId = res.created[0].behavior_id;
+
+      const [clone] = await sql`
+        SELECT agent_id, device_worker_id, agent_kind,
+               triggers::text AS triggers
+        FROM watchers WHERE id = ${cloneId}
+      `;
+      expect(clone.agent_id).toBe(agentId);
+      expect(clone.device_worker_id).toBe(deviceId);
+      expect(clone.agent_kind).toBe('codex');
+      // The schedule trigger is preserved and still resolves via the device pin.
+      expect(clone.triggers).toMatch(/schedule/);
+
+      await owner.behaviors.delete({
+        behavior_ids: [base.behavior_id, cloneId],
+      });
+    });
+
+    it('creates and clones an agentless manual-only behavior (executor optional)', async () => {
+      const sql = getTestDb();
+      const target = (await owner.entities.create({
+        type: 'company',
+        name: 'CFV Manual Clone Target',
+      })) as { entity: { id: number } };
+
+      // No triggers → manual-only → executor optional. Both create and the
+      // clone must accept an executor-less row (agent_id nullable, no device
+      // pin) — the manual activation stays pending for any MCP client.
+      const base = (await owner.behaviors.create({
+        entity_id: entityId,
+        slug: 'cfv-manual-base',
+        name: 'CFV Manual Base',
+        prompt: 'Manual only.',
+        sources: [{ name: 'content', query: 'SELECT id FROM events' }],
+      })) as { behavior_id: string };
+      const [row] = await sql<{ current_version_id: number }[]>`
+        SELECT current_version_id FROM watchers WHERE id = ${base.behavior_id}
+      `;
+      const versionId = Number(row?.current_version_id);
+
+      const res = (await owner.behaviors.createFromVersion({
+        version_id: versionId,
+        entity_ids: [target.entity.id],
+      })) as { created: Array<{ behavior_id: string }> };
+      const cloneId = res.created[0].behavior_id;
+      const [clone] = await sql`
+        SELECT agent_id, device_worker_id FROM watchers WHERE id = ${cloneId}
+      `;
+      expect(clone.agent_id).toBeNull();
+      expect(clone.device_worker_id).toBeNull();
+
+      await owner.behaviors.delete({
+        behavior_ids: [base.behavior_id, cloneId],
+      });
+    });
+  });
 });

--- a/packages/server/src/__tests__/unit/behavior-executors.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-executors.test.ts
@@ -3,85 +3,43 @@ import type { BehaviorTriggerInput } from "../../tools/admin/manage_behaviors/ex
 import {
 	assertBehaviorExecutorsResolve,
 	resolveBehaviorExecutor,
-	resolveTriggerExecutor,
 } from "../../tools/admin/manage_behaviors/executors";
 
-const eventTrigger = (
-	respondWith?: BehaviorTriggerInput["respond_with"],
-): BehaviorTriggerInput => ({
+const eventTrigger = (): BehaviorTriggerInput => ({
 	kind: "event",
 	connector_key: "github",
 	event_types: ["pull_request.created"],
-	...(respondWith ? { respond_with: respondWith } : {}),
 });
 
-const scheduleTrigger = (
-	respondWith?: BehaviorTriggerInput["respond_with"],
-): BehaviorTriggerInput => ({
+const scheduleTrigger = (): BehaviorTriggerInput => ({
 	kind: "schedule",
 	cron: "0 9 * * *",
-	...(respondWith ? { respond_with: respondWith } : {}),
-});
-
-describe("resolveTriggerExecutor", () => {
-	test("explicit respond_with agent override wins over defaults", () => {
-		const resolved = resolveTriggerExecutor(
-			eventTrigger({ kind: "agent", agent_id: "agent-b" }),
-			{ agentId: "agent-a", deviceWorkerId: "device-1" },
-		);
-		expect(resolved).toEqual({ kind: "agent", agentId: "agent-b" });
-	});
-
-	test("explicit respond_with device override wins over defaults", () => {
-		const resolved = resolveTriggerExecutor(eventTrigger({
-			kind: "device",
-			device_worker_id: "device-9",
-			agent_kind: "claude-code",
-		}), { agentId: "agent-a" });
-		expect(resolved).toEqual({
-			kind: "device",
-			deviceWorkerId: "device-9",
-			agentKind: "claude-code",
-		});
-	});
-
-	// Legacy dual rows carried both agent_id and device_worker_id and always
-	// ran on the device lane (#802). The fallback MUST be device-pin-first or
-	// existing device-pinned behaviors flip to server dispatch.
-	test("fallback prefers the device pin over the agent", () => {
-		const resolved = resolveTriggerExecutor(eventTrigger(), {
-			agentId: "agent-a",
-			deviceWorkerId: "device-1",
-			agentKind: "codex",
-		});
-		expect(resolved).toEqual({
-			kind: "device",
-			deviceWorkerId: "device-1",
-			agentKind: "codex",
-		});
-	});
-
-	test("fallback uses the agent when no device pin", () => {
-		const resolved = resolveTriggerExecutor(scheduleTrigger(), {
-			agentId: "agent-a",
-		});
-		expect(resolved).toEqual({ kind: "agent", agentId: "agent-a" });
-	});
-
-	test("no executor anywhere resolves to null", () => {
-		expect(resolveTriggerExecutor(eventTrigger(), {})).toBeNull();
-	});
 });
 
 describe("resolveBehaviorExecutor", () => {
-	test("device-first at the behavior level too", () => {
+	// Legacy dual rows carried both agent_id and device_worker_id and always
+	// ran on the device lane (#802). Resolution MUST be device-pin-first or
+	// existing device-pinned behaviors flip to server dispatch.
+	test("device pin takes precedence over the agent", () => {
 		expect(
 			resolveBehaviorExecutor({ agentId: "a", deviceWorkerId: "d" }),
 		).toEqual({ kind: "device", deviceWorkerId: "d", agentKind: null });
-		expect(resolveBehaviorExecutor({ agentId: "a" })).toEqual({
+	});
+
+	test("agent resolves when there is no device pin", () => {
+		expect(resolveBehaviorExecutor({ agentId: "agent-a" })).toEqual({
 			kind: "agent",
-			agentId: "a",
+			agentId: "agent-a",
 		});
+	});
+
+	test("device carries its runtime kind", () => {
+		expect(
+			resolveBehaviorExecutor({ deviceWorkerId: "d", agentKind: "codex" }),
+		).toEqual({ kind: "device", deviceWorkerId: "d", agentKind: "codex" });
+	});
+
+	test("no executor resolves to null", () => {
 		expect(resolveBehaviorExecutor({})).toBeNull();
 	});
 });
@@ -89,45 +47,30 @@ describe("resolveBehaviorExecutor", () => {
 describe("assertBehaviorExecutorsResolve", () => {
 	test("manual-only behaviors (no triggers) pass with or without an executor", () => {
 		expect(() => assertBehaviorExecutorsResolve([], {})).not.toThrow();
-		expect(() =>
-			assertBehaviorExecutorsResolve(undefined, {}),
-		).not.toThrow();
+		expect(() => assertBehaviorExecutorsResolve(undefined, {})).not.toThrow();
 		expect(() =>
 			assertBehaviorExecutorsResolve([], { agentId: "a" }),
 		).not.toThrow();
 	});
 
-	test("automated triggers require a Behavior-level executor", () => {
-		expect(() =>
-			assertBehaviorExecutorsResolve([eventTrigger()], {}),
-		).toThrow(/Behavior-level executor/);
+	test("automated behaviors require an executor", () => {
+		expect(() => assertBehaviorExecutorsResolve([eventTrigger()], {})).toThrow(
+			/executor/,
+		);
 		expect(() =>
 			assertBehaviorExecutorsResolve([scheduleTrigger()], {}),
-		).toThrow(/Behavior-level executor/);
+		).toThrow(/executor/);
 	});
 
-	// respond_with is a pure override: it can never be the sole executor,
-	// because the scheduler/event SELECTs gate on row-level columns — an
-	// override-only behavior would validate but never fire.
-	test("override-only executors are rejected", () => {
+	test("an agent satisfies automated triggers", () => {
 		expect(() =>
-			assertBehaviorExecutorsResolve(
-				[eventTrigger({ kind: "agent", agent_id: "agent-b" })],
-				{},
-			),
-		).toThrow(/Behavior-level executor/);
-	});
-
-	test("behavior-level executor satisfies all automated triggers", () => {
-		expect(() =>
-			assertBehaviorExecutorsResolve(
-				[
-					eventTrigger({ kind: "agent", agent_id: "agent-b" }),
-					scheduleTrigger(),
-				],
-				{ agentId: "agent-a" },
-			),
+			assertBehaviorExecutorsResolve([eventTrigger(), scheduleTrigger()], {
+				agentId: "agent-a",
+			}),
 		).not.toThrow();
+	});
+
+	test("a device pin satisfies automated triggers", () => {
 		expect(() =>
 			assertBehaviorExecutorsResolve([eventTrigger()], {
 				deviceWorkerId: "device-1",

--- a/packages/server/src/__tests__/unit/behavior-executors.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-executors.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import type { BehaviorTriggerInput } from "../../tools/admin/manage_behaviors/executors";
+import {
+	assertBehaviorExecutorsResolve,
+	resolveBehaviorExecutor,
+	resolveTriggerExecutor,
+} from "../../tools/admin/manage_behaviors/executors";
+
+const eventTrigger = (
+	respondWith?: BehaviorTriggerInput["respond_with"],
+): BehaviorTriggerInput => ({
+	kind: "event",
+	connector_key: "github",
+	event_types: ["pull_request.created"],
+	...(respondWith ? { respond_with: respondWith } : {}),
+});
+
+const scheduleTrigger = (
+	respondWith?: BehaviorTriggerInput["respond_with"],
+): BehaviorTriggerInput => ({
+	kind: "schedule",
+	cron: "0 9 * * *",
+	...(respondWith ? { respond_with: respondWith } : {}),
+});
+
+describe("resolveTriggerExecutor", () => {
+	test("explicit respond_with agent override wins over defaults", () => {
+		const resolved = resolveTriggerExecutor(
+			eventTrigger({ kind: "agent", agent_id: "agent-b" }),
+			{ agentId: "agent-a", deviceWorkerId: "device-1" },
+		);
+		expect(resolved).toEqual({ kind: "agent", agentId: "agent-b" });
+	});
+
+	test("explicit respond_with device override wins over defaults", () => {
+		const resolved = resolveTriggerExecutor(eventTrigger({
+			kind: "device",
+			device_worker_id: "device-9",
+			agent_kind: "claude-code",
+		}), { agentId: "agent-a" });
+		expect(resolved).toEqual({
+			kind: "device",
+			deviceWorkerId: "device-9",
+			agentKind: "claude-code",
+		});
+	});
+
+	// Legacy dual rows carried both agent_id and device_worker_id and always
+	// ran on the device lane (#802). The fallback MUST be device-pin-first or
+	// existing device-pinned behaviors flip to server dispatch.
+	test("fallback prefers the device pin over the agent", () => {
+		const resolved = resolveTriggerExecutor(eventTrigger(), {
+			agentId: "agent-a",
+			deviceWorkerId: "device-1",
+			agentKind: "codex",
+		});
+		expect(resolved).toEqual({
+			kind: "device",
+			deviceWorkerId: "device-1",
+			agentKind: "codex",
+		});
+	});
+
+	test("fallback uses the agent when no device pin", () => {
+		const resolved = resolveTriggerExecutor(scheduleTrigger(), {
+			agentId: "agent-a",
+		});
+		expect(resolved).toEqual({ kind: "agent", agentId: "agent-a" });
+	});
+
+	test("no executor anywhere resolves to null", () => {
+		expect(resolveTriggerExecutor(eventTrigger(), {})).toBeNull();
+	});
+});
+
+describe("resolveBehaviorExecutor", () => {
+	test("device-first at the behavior level too", () => {
+		expect(
+			resolveBehaviorExecutor({ agentId: "a", deviceWorkerId: "d" }),
+		).toEqual({ kind: "device", deviceWorkerId: "d", agentKind: null });
+		expect(resolveBehaviorExecutor({ agentId: "a" })).toEqual({
+			kind: "agent",
+			agentId: "a",
+		});
+		expect(resolveBehaviorExecutor({})).toBeNull();
+	});
+});
+
+describe("assertBehaviorExecutorsResolve", () => {
+	test("manual-only behaviors (no triggers) pass with or without an executor", () => {
+		expect(() => assertBehaviorExecutorsResolve([], {})).not.toThrow();
+		expect(() =>
+			assertBehaviorExecutorsResolve(undefined, {}),
+		).not.toThrow();
+		expect(() =>
+			assertBehaviorExecutorsResolve([], { agentId: "a" }),
+		).not.toThrow();
+	});
+
+	test("automated triggers require a Behavior-level executor", () => {
+		expect(() =>
+			assertBehaviorExecutorsResolve([eventTrigger()], {}),
+		).toThrow(/Behavior-level executor/);
+		expect(() =>
+			assertBehaviorExecutorsResolve([scheduleTrigger()], {}),
+		).toThrow(/Behavior-level executor/);
+	});
+
+	// respond_with is a pure override: it can never be the sole executor,
+	// because the scheduler/event SELECTs gate on row-level columns — an
+	// override-only behavior would validate but never fire.
+	test("override-only executors are rejected", () => {
+		expect(() =>
+			assertBehaviorExecutorsResolve(
+				[eventTrigger({ kind: "agent", agent_id: "agent-b" })],
+				{},
+			),
+		).toThrow(/Behavior-level executor/);
+	});
+
+	test("behavior-level executor satisfies all automated triggers", () => {
+		expect(() =>
+			assertBehaviorExecutorsResolve(
+				[
+					eventTrigger({ kind: "agent", agent_id: "agent-b" }),
+					scheduleTrigger(),
+				],
+				{ agentId: "agent-a" },
+			),
+		).not.toThrow();
+		expect(() =>
+			assertBehaviorExecutorsResolve([eventTrigger()], {
+				deviceWorkerId: "device-1",
+			}),
+		).not.toThrow();
+	});
+});

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -141,7 +141,10 @@ describe('requiresOwnerAdmin', () => {
     expect(requiresOwnerAdmin('manage_behaviors', { action: 'set_reaction_script' }, false)).toBe(
       true
     );
-    expect(requiresOwnerAdmin('manage_behaviors', { action: 'trigger' }, false)).toBe(true);
+    // `trigger` is write-tier (manual activation — the open execution lane),
+    // guarded per-behavior by requireWatcherAccess in the handler, like
+    // `complete_window`. It is execution, not administration.
+    expect(requiresOwnerAdmin('manage_behaviors', { action: 'trigger' }, false)).toBe(false);
     expect(requiresOwnerAdmin('manage_behaviors', { action: 'create_from_version' }, false)).toBe(
       true
     );
@@ -731,7 +734,7 @@ manage_auth_profiles: list_auth_profiles=read+public get_auth_profile=read+publi
 manage_operations: list_available=read+public execute=admin list_runs=read+public get_run=read+public list_activity=read+public approve=write reject=write approve_batch=write reject_batch=write ?=read
 notify: send=admin ?=admin
 manage_schedules: create=admin list=admin update=admin pause=admin cancel=admin ?=admin
-manage_behaviors: create=admin list=read+public update=admin create_version=admin complete_window=write trigger=admin delete=admin set_reaction_script=admin get_versions=read+public get_version_details=read+public get_component_reference=read+public submit_feedback=admin get_feedback=read+public list_promoted=read create_from_version=admin ?=read
+manage_behaviors: create=admin list=read+public update=admin create_version=admin complete_window=write trigger=write delete=admin set_reaction_script=admin get_versions=read+public get_version_details=read+public get_component_reference=read+public submit_feedback=admin get_feedback=read+public list_promoted=read create_from_version=admin ?=read
 get_behavior: read+public ?=read+public
 read_knowledge: read+public ?=read+public
 manage_classifiers: create=admin list=read+public generate_embeddings=admin delete=admin classify=admin apply=admin ?=read

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -42,8 +42,10 @@ export const MEMBER_WRITE_ACTIONS: Record<string, Set<string> | null> = {
 	// gateway MCP into the spawned CLI; device tokens carry mcp:write, not
 	// admin). The handler still enforces org/entity write access via
 	// requireWatcherAccess; watcher ADMINISTRATION (create/update/delete/…)
-	// stays admin-tier below.
-	manage_behaviors: new Set(["complete_window"]),
+	// stays admin-tier below. `trigger` is write-tier: manual activation is the
+	// open lane — any member (or their MCP client) may fire a Behavior and
+	// complete the resulting run.
+	manage_behaviors: new Set(["complete_window", "trigger"]),
 	// `approve`/`reject` (and their `*_batch` forms) are write-tier so the
 	// recorded FIELD OWNER of an entity-change proposal (a plain member) can
 	// decide their own run. The handler enforces admin-or-run-owner per run — a
@@ -122,12 +124,12 @@ export const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
 	// admin-or-run-owner); only `execute` is unconditionally admin.
 	manage_operations: new Set(["execute"]),
 	manage_behaviors: new Set([
-		// `complete_window` is in MEMBER_WRITE_ACTIONS — it's the agent result
-		// path (server workers + device CLI over MCP), not administration.
+		// `complete_window` and `trigger` are in MEMBER_WRITE_ACTIONS — the
+		// execution path (server workers + device CLI + manual MCP clients),
+		// not administration.
 		"create",
 		"update",
 		"create_version",
-		"trigger",
 		"delete",
 		"set_reaction_script",
 		"submit_feedback",

--- a/packages/server/src/behaviors/activation.ts
+++ b/packages/server/src/behaviors/activation.ts
@@ -7,6 +7,7 @@ import {
   type BehaviorEventRunQueued,
   createBehaviorEventRun,
 } from "../runs/queue-service";
+import { resolveTriggerExecutor } from "../tools/admin/manage_behaviors/executors";
 import logger from "../utils/logger";
 import { dispatchPendingWatcherRuns } from "../watchers/automation";
 import { matchingBehaviorTriggers } from "./event-trigger";
@@ -14,7 +15,9 @@ import { matchingBehaviorTriggers } from "./event-trigger";
 export interface MatchingBehaviorActivation {
   behaviorId: number;
   organizationId: string;
-  agentId: string;
+  /** Resolved executor agent — null when this trigger routes to a device. */
+  agentId: string | null;
+
   deviceWorkerId: string | null;
   agentKind: string | null;
   model: string | null;
@@ -29,6 +32,12 @@ export interface MatchingBehaviorActivation {
   trigger: BehaviorEventTrigger;
 }
 
+/** A reply target always carries a managed agent — device-routed matches are
+ * demoted to the background lane in {@link planBehaviorActivations}. */
+export interface ChatReplyActivation extends MatchingBehaviorActivation {
+  agentId: string;
+}
+
 export interface BehaviorActivationResult extends BehaviorEventRunQueued {
   behaviorId: number;
   trigger: BehaviorEventTrigger;
@@ -36,7 +45,7 @@ export interface BehaviorActivationResult extends BehaviorEventRunQueued {
 
 export interface BehaviorActivationPlan {
   signal: ConnectorTriggerSignal;
-  replyTargets: MatchingBehaviorActivation[];
+  replyTargets: ChatReplyActivation[];
   backgroundTargets: MatchingBehaviorActivation[];
 }
 
@@ -57,14 +66,18 @@ export function planBehaviorActivations(
   signal: ConnectorTriggerSignal,
   matches: MatchingBehaviorActivation[],
 ): BehaviorActivationPlan {
-  const replyTargets: MatchingBehaviorActivation[] = [];
+  const replyTargets: ChatReplyActivation[] = [];
   const backgroundTargets: MatchingBehaviorActivation[] = [];
   for (const match of matches) {
+    // Chat-turn replies need a managed agent on the server side — a trigger
+    // routed to a device (agentId null) cannot host a live turn, so it takes
+    // the durable background lane instead.
     if (
+      match.agentId != null &&
       (match.trigger.execution ?? "turn") === "turn" &&
       (match.trigger.output ?? "silent") === "reply_to_source"
     ) {
-      replyTargets.push(match);
+      replyTargets.push({ ...match, agentId: match.agentId });
     } else {
       backgroundTargets.push(match);
     }
@@ -112,7 +125,7 @@ export async function findMatchingBehaviorActivations(
 		FROM watchers w
 		JOIN watcher_versions v ON v.id = w.current_version_id
 		WHERE w.status = 'active'
-		  AND w.agent_id IS NOT NULL
+		  AND (w.agent_id IS NOT NULL OR w.device_worker_id IS NOT NULL)
 		  AND ${triggerFilter}
 		  ${organizationFilter}
 		ORDER BY w.id ASC
@@ -134,13 +147,25 @@ export async function findMatchingBehaviorActivations(
       signal,
     );
     if (!trigger) continue;
-    matches.push({
-      behaviorId: Number(row.id),
-      organizationId: String(row.organization_id),
-      agentId: String(row.agent_id),
+    // Per-trigger executor resolution ("when -> who"): the matched trigger's
+    // respond_with override wins, else the Behavior-level agent/device. The
+    // create/update matrix guarantees automated triggers resolve; skip
+    // defensively if a legacy row slips through.
+    const executor = resolveTriggerExecutor(trigger, {
+      agentId: row.agent_id as string | null,
       deviceWorkerId:
         typeof row.device_worker_id === "string" ? row.device_worker_id : null,
       agentKind: typeof row.agent_kind === "string" ? row.agent_kind : null,
+    });
+    if (!executor) continue;
+    matches.push({
+      behaviorId: Number(row.id),
+      organizationId: String(row.organization_id),
+      agentId: executor.kind === "agent" ? executor.agentId : null,
+      deviceWorkerId:
+        executor.kind === "device" ? executor.deviceWorkerId : null,
+      agentKind:
+        executor.kind === "device" ? executor.agentKind : null,
       model: typeof row.model === "string" ? row.model : null,
       instructions: typeof row.prompt === "string" ? row.prompt : "",
       minCooldownSeconds: Number(row.min_cooldown_seconds ?? 0),

--- a/packages/server/src/behaviors/activation.ts
+++ b/packages/server/src/behaviors/activation.ts
@@ -7,7 +7,7 @@ import {
   type BehaviorEventRunQueued,
   createBehaviorEventRun,
 } from "../runs/queue-service";
-import { resolveTriggerExecutor } from "../tools/admin/manage_behaviors/executors";
+import { resolveBehaviorExecutor } from "../tools/admin/manage_behaviors/executors";
 import logger from "../utils/logger";
 import { dispatchPendingWatcherRuns } from "../watchers/automation";
 import { matchingBehaviorTriggers } from "./event-trigger";
@@ -147,11 +147,10 @@ export async function findMatchingBehaviorActivations(
       signal,
     );
     if (!trigger) continue;
-    // Per-trigger executor resolution ("when -> who"): the matched trigger's
-    // respond_with override wins, else the Behavior-level agent/device. The
-    // create/update matrix guarantees automated triggers resolve; skip
-    // defensively if a legacy row slips through.
-    const executor = resolveTriggerExecutor(trigger, {
+    // Executor resolution: a Behavior has exactly one executor (agent or
+    // device pin). The create/update matrix guarantees automated Behaviors
+    // resolve; skip defensively if a legacy row slips through.
+    const executor = resolveBehaviorExecutor({
       agentId: row.agent_id as string | null,
       deviceWorkerId:
         typeof row.device_worker_id === "string" ? row.device_worker_id : null,

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -29,8 +29,8 @@ import {
 import { resolveSlackBotIdentity } from "../../authz/slack-acl-sync.js";
 import {
   type BehaviorActivationPlan,
+  type ChatReplyActivation,
   dispatchBehaviorRunsBestEffort,
-  type MatchingBehaviorActivation,
   planBehaviorActivationsForRuntimeConnection,
   queueBehaviorActivations,
   type RuntimeConnectionBehaviorLookup,
@@ -1173,7 +1173,7 @@ export class MessageHandlerBridge {
     // `createBehaviorEventRun` makes for background targets above. Claiming the
     // same cursor here is what stops `min_cooldown_seconds` being a debounce on
     // one half of the feature and a silent no-op on the other.
-    const replyTargetsOffCooldown: MatchingBehaviorActivation[] = [];
+    const replyTargetsOffCooldown: ChatReplyActivation[] = [];
     for (const candidate of replyBehaviors) {
       // `minCooldownSeconds` is a feature-enabled hint carried on the match, so
       // an ordinary chat Behavior (the 0 default) costs no extra round-trip and

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -30,7 +30,12 @@ type WatcherDispatchSource = 'scheduled' | 'manual' | 'event';
 
 export interface WatcherRunPayload {
   watcher_id: number;
-  agent_id: string;
+  /**
+   * The managed agent executing this run. Absent for device-executed runs
+   * (the device lane claims via `device_worker_id`) and for manual runs open
+   * to any connected MCP client.
+   */
+  agent_id?: string;
   window_start: string;
   window_end: string;
   dispatch_source: WatcherDispatchSource;
@@ -494,7 +499,7 @@ async function createWatcherRunWithClient(
   params: {
     organizationId: string;
     watcherId: number;
-    agentId: string;
+    agentId?: string | null;
     windowStart: string;
     windowEnd: string;
     dispatchSource: WatcherDispatchSource;
@@ -537,7 +542,7 @@ async function createWatcherRunWithClient(
 
   const payload: WatcherRunPayload = {
     watcher_id: params.watcherId,
-    agent_id: params.agentId,
+    agent_id: params.agentId ?? undefined,
     window_start: params.windowStart,
     window_end: params.windowEnd,
     dispatch_source: params.dispatchSource,
@@ -591,7 +596,7 @@ export async function createWatcherRun(
   params: {
     organizationId: string;
     watcherId: number;
-    agentId: string;
+    agentId?: string | null;
     windowStart: string;
     windowEnd: string;
     dispatchSource: WatcherDispatchSource;
@@ -699,7 +704,7 @@ export async function createBehaviorEventRun(
   params: {
     organizationId: string;
     watcherId: number;
-    agentId: string;
+    agentId?: string | null;
     trigger: BehaviorEventTrigger;
     signal: ConnectorTriggerSignal;
     deviceWorkerId?: string | null;
@@ -822,7 +827,7 @@ export async function createBehaviorEventRun(
       : Number(versionRows[0]?.current_version_id);
     const payload: WatcherRunPayload = {
       watcher_id: params.watcherId,
-      agent_id: params.agentId,
+      agent_id: params.agentId ?? undefined,
       window_start: signalWindowStart,
       window_end: signalWindowEnd,
       dispatch_source: 'event',

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -567,7 +567,7 @@ export default async (_ctx, client) => {
 	},
 	"behaviors.update": {
 		summary:
-			"Update runtime config only: triggers, agent_id, model_config, execution_config, scheduler_client_id, device_worker_id, agent_kind, notification_channel, notification_priority, min_cooldown_seconds, tags. Version-owned fields (name, description, prompt, sources) are immutable here — use createVersion. Status is not patchable here (a Behavior is retired via delete → archived).",
+			"Update runtime config only: triggers, agent_id, model_config, execution_config, device_worker_id, agent_kind, notification_channel, notification_priority, min_cooldown_seconds, tags. Version-owned fields (name, description, prompt, sources) are immutable here — use createVersion. Status is not patchable here (a Behavior is retired via delete → archived).",
 		access: "admin",
 	},
 	"behaviors.createVersion": {

--- a/packages/server/src/sandbox/namespaces/behaviors.ts
+++ b/packages/server/src/sandbox/namespaces/behaviors.ts
@@ -43,7 +43,6 @@ export interface BehaviorCreateInput {
 	reactions_guidance?: string;
 	reaction_script?: string;
 	agent_id?: string;
-	scheduler_client_id?: string;
 	model_config?: Record<string, unknown>;
 	execution_config?: BehaviorExecutionConfig;
 	tags?: string[];
@@ -53,7 +52,6 @@ export interface BehaviorUpdateInput {
 	behavior_id: BehaviorId;
 	triggers?: BehaviorTrigger[];
 	agent_id?: string;
-	scheduler_client_id?: string;
 	model_config?: Record<string, unknown>;
 	/** `null` clears a previously-saved config back to NULL/defaults. */
 	execution_config?: BehaviorExecutionConfig | null;

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -532,7 +532,6 @@ const WATCHER_PATCHABLE_FIELDS = [
   // patch them only via triggers, not as direct writable fields.
   'triggers',
   'agent_id',
-  'scheduler_client_id',
   'tags',
   'device_worker_id',
   'agent_kind',
@@ -629,7 +628,6 @@ const WATCHER_APPROVAL_FIELD_TITLES: Record<string, string> = {
   reaction_script: 'Reaction script',
   execution_config: 'Execution config',
   device_worker_id: 'Device worker',
-  scheduler_client_id: 'Scheduler client',
   agent_kind: 'Agent kind',
   sources: 'Sources',
   model_config: 'Model config',

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -775,7 +775,7 @@ async function queueWatcherWriteForApproval(
   const ownerAgentId = args.agent_id ?? (current?.agent_id as string | null | undefined) ?? null;
   const settingsReviewUrl =
     args.action === 'update' && args.behavior_id != null && ownerAgentId
-      ? await buildBehaviorSettingsUrl(baseUrl, ctx.organizationId, ownerAgentId, args.behavior_id, {
+      ? await buildBehaviorSettingsUrl(baseUrl, ctx.organizationId, args.behavior_id, {
           runId,
         }).catch(() => null)
       : null;

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -767,14 +767,13 @@ async function queueWatcherWriteForApproval(
   const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
   // An `update` is config-shaped, so its review surface is the watcher edit form
   // prefilled via `?run_id=` (WI-0.3, watcher parity with manage_agents): the
-  // reviewer sees the proposed change in the real form and Approves/Rejects. The
-  // route is nested under the OWNING agent (an update may reassign the owner via
-  // args.agent_id, so prefer the proposed owner, else the current one). create /
-  // create_from_version / set_reaction_script etc. aren't a single-form review,
-  // so they keep the run permalink (valid across the supersede chain on approve).
-  const ownerAgentId = args.agent_id ?? (current?.agent_id as string | null | undefined) ?? null;
+  // reviewer sees the proposed change in the real form and Approves/Rejects.
+  // The route is the workspace-level Behaviors section (agent-owned and
+  // agentless alike). create / create_from_version / set_reaction_script etc.
+  // aren't a single-form review, so they keep the run permalink (valid across
+  // the supersede chain on approve).
   const settingsReviewUrl =
-    args.action === 'update' && args.behavior_id != null && ownerAgentId
+    args.action === 'update' && args.behavior_id != null
       ? await buildBehaviorSettingsUrl(baseUrl, ctx.organizationId, args.behavior_id, {
           runId,
         }).catch(() => null)

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -165,13 +165,24 @@ export async function handleCompleteWindow(
   await requireWatcherAccess(pgSql, [String(watcherId)], ctx, 'write');
 
   if (watcherRunId == null) {
+    // Prefer an active (dispatched) run; otherwise a pending manual-open run
+    // (no agent/device pin) waiting for an external completer.
     const runRows = await sql`
       SELECT id
       FROM runs
       WHERE watcher_id = ${watcherId}
         AND run_type = 'behavior'
-        AND status = 'running'
-      ORDER BY created_at DESC
+        AND (
+          status = 'running'
+          OR (
+            status = 'pending'
+            AND (approved_input->>'agent_id' IS NULL OR approved_input->>'agent_id' = '')
+            AND (approved_input->>'device_worker_id' IS NULL OR approved_input->>'device_worker_id' = '')
+          )
+        )
+      ORDER BY
+        CASE WHEN status = 'running' THEN 0 ELSE 1 END,
+        created_at DESC
       LIMIT 1
     `;
     if (runRows.length > 0 && runRows[0].id != null) {
@@ -180,6 +191,26 @@ export async function handleCompleteWindow(
     }
   } else if (provenanceMetadata.watcher_run_id == null) {
     provenanceMetadata.watcher_run_id = watcherRunId;
+  }
+
+  // Manual-open runs (no agent, no device pin) pend for any connected MCP
+  // client — there is no claim step, so the completing client transitions the
+  // run pending->running here. Best-effort and race-safe: concurrent completers
+  // both see an active run, and the completion transition below is idempotent.
+  // Addressed runs (agent dispatch / device lane) never match this filter, so
+  // an external client cannot hijack a dispatched run.
+  if (watcherRunId != null && Number.isFinite(watcherRunId)) {
+    await sql`
+      UPDATE runs
+      SET status = 'running',
+          claimed_at = COALESCE(claimed_at, current_timestamp)
+      WHERE id = ${watcherRunId}
+        AND watcher_id = ${watcherId}
+        AND run_type = 'behavior'
+        AND status = 'pending'
+        AND (approved_input->>'agent_id' IS NULL OR approved_input->>'agent_id' = '')
+        AND (approved_input->>'device_worker_id' IS NULL OR approved_input->>'device_worker_id' = '')
+    `;
   }
 
   // ============================================

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -394,7 +394,7 @@ export async function handleCreate(
   let viewUrl: string | undefined;
 
   if (organizationSlug && args.agent_id) {
-    viewUrl = buildBehaviorUrl(organizationSlug, args.agent_id, watcherId as number, baseUrl);
+    viewUrl = buildBehaviorUrl(organizationSlug, watcherId as number, baseUrl);
   }
 
   logger.info(`[manage_behaviors] Created watcher ${watcherId} with slug '${args.slug}'`);

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -27,7 +27,6 @@ import {
   type BehaviorUpdatePatch,
 } from '@lobu/core/contracts/tools/manage-behaviors';
 import {
-  assertAgentExists,
   assertOutputEntityTypesExist,
   assertOutputEventTypesExist,
   assertOutputsShape,
@@ -778,6 +777,7 @@ export async function handleCreateFromVersion(
   // reaction with no extraction contract, silently running free-form.
   const versionRows = await sql`
     SELECT wv.*, w.organization_id, w.schedule, w.timezone, w.triggers, w.sources, w.agent_id,
+           w.device_worker_id::text AS device_worker_id, w.agent_kind,
            w.model_config, w.execution_config, w.tags, w.watcher_group_id,
            w.reaction_script, w.reaction_script_compiled, w.reaction_input_schema
     FROM watcher_versions wv
@@ -793,19 +793,26 @@ export async function handleCreateFromVersion(
       `Access denied: Behavior version ${args.version_id} does not belong to your organization`
     );
   }
-  if (!version.agent_id) {
-    // Source watcher has no agent — cloning would silently inherit null and
-    // produce active zombies the scheduler skips. Same invariant as handleCreate.
-    throw new ToolUserError(
-      `Source Behavior version ${args.version_id} has no agent_id; assign an agent on the source before cloning.`
-    );
-  }
-
-  // The source's agent_id is copied verbatim onto every clone, and a version can
-  // outlive the agent it named (agent_id has no FK, so a deleted agent leaves the
-  // reference dangling). Resolve it once here so the fan-out cannot mint a whole
-  // batch of Behaviors the scheduler will never run.
-  await assertAgentExists(sql, organizationId, version.agent_id as string);
+  // The clone strips chat-link steer/reply triggers (a second agent turn for
+  // the same message), so the matrix runs on the STRIPPED shape — an agentless
+  // source whose only automated triggers were chat-link responders must be
+  // allowed to clone as manual-only, and a source that strips down to nothing
+  // must not land executor-less automated rows. Every automated clone needs an
+  // executor; manual-only clones may be executor-less (same invariant as
+  // handleCreate/handleUpdate).
+  const cloneTriggers = stripChatLinkTriggers(version.triggers) as BehaviorTrigger[];
+  const cloneDefaults: BehaviorExecutorDefaults = {
+    agentId: (version.agent_id as string | null) ?? null,
+    deviceWorkerId: (version.device_worker_id as string | null) ?? null,
+    agentKind: (version.agent_kind as string | null) ?? null,
+  };
+  // The executor is copied verbatim onto every clone, and a version can
+  // outlive the executor it names (agent_id/device_worker_id have no FK, so a
+  // deleted agent/device leaves the reference dangling). Resolve + authorize
+  // once here so the fan-out cannot mint a batch of Behaviors the scheduler
+  // will never run — or store a device pin the caller may not target.
+  assertBehaviorExecutorsResolve(cloneTriggers, cloneDefaults);
+  await assertBehaviorExecutorsAuthorized(sql, organizationId, cloneDefaults, ctx);
 
   // Reject cross-org entity_ids before cloning: a watcher attached to another
   // org's entity links its synced/extracted content to a non-existent in-org
@@ -894,7 +901,7 @@ export async function handleCreateFromVersion(
         // Entity clones must not inherit chat-link steer/reply triggers (or the
         // system:chat-link tag): those bind a live channel responder, and
         // cloning them would create a second agent turn for the same message.
-        const cloneTriggers = stripChatLinkTriggers(version.triggers);
+        // cloneTriggers is computed once above (it does not depend on entity).
         // After stripping, the residual trigger shape must still satisfy the
         // instruction rule (chat-link-only sources become manual/empty triggers
         // and require a non-empty prompt).
@@ -920,7 +927,7 @@ export async function handleCreateFromVersion(
         await tx`
           INSERT INTO watchers (
             id, name, slug, organization_id, entity_ids,
-            schedule, timezone, next_run_at, triggers, agent_id, model_config, execution_config, sources, version,
+            schedule, timezone, next_run_at, triggers, agent_id, device_worker_id, agent_kind, model_config, execution_config, sources, version,
             current_version_id, tags, status, created_by, created_at, updated_at,
             watcher_group_id, source_watcher_id,
             reaction_script, reaction_script_compiled, reaction_input_schema
@@ -929,6 +936,8 @@ export async function handleCreateFromVersion(
             ${`{${entityId}}`}::bigint[],
             ${version.schedule ?? null}, ${version.timezone ?? null}, ${version.schedule ? nextRunAt(version.schedule as string, new Date(), version.timezone as string | null) : null}, ${toJsonParam(tx, cloneTriggers)},
             ${version.agent_id ?? null},
+            ${version.device_worker_id ?? null},
+            ${version.agent_kind ?? null},
             ${toJsonParam(tx, version.model_config)}, ${toJsonParam(tx, version.execution_config)}, ${toJsonParam(tx, clonedSources)},
             ${(version.version as number) ?? 1}, ${sharedVersionId}, ${toTextArrayParam(cloneTags)}::text[],
             'active', ${createdBy}, NOW(), NOW(),
@@ -1006,6 +1015,8 @@ export async function handleCreateFromVersion(
         timezone: version.timezone ?? null,
         triggers: version.triggers ?? [],
         agent_id: version.agent_id ?? null,
+        device_worker_id: (version.device_worker_id as string | null) ?? null,
+        agent_kind: (version.agent_kind as string | null) ?? null,
         version: (version.version as number) ?? 1,
         current_version_id: p.sharedVersionId,
         watcher_group_id: p.groupId,

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -204,9 +204,9 @@ export async function handleCreate(
   // Both of these are free-text columns with NO database foreign key, so an
   // unresolvable id is accepted by the INSERT and only shows up as a Behavior
   // that never runs (agent_id) or one whose output contract is silently voided
-  // (agent_id). The executor matrix catches unresolvable executors up front —
-  // every automated Behavior needs an executor; manual-only Behaviors (no
-  // triggers) may be executor-less.
+  // (outputs' entity/event targets). The executor matrix catches unresolvable
+  // executors up front — every automated Behavior needs an executor;
+  // manual-only Behaviors (no triggers) may be executor-less.
   const executorDefaults: BehaviorExecutorDefaults = {
     agentId: args.agent_id ?? null,
     deviceWorkerId: args.device_worker_id ?? null,

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -389,7 +389,9 @@ export async function handleCreate(
   const baseUrl = getPublicWebUrl(ctx.requestUrl, ctx.baseUrl);
   let viewUrl: string | undefined;
 
-  if (organizationSlug && args.agent_id) {
+  // The route is workspace-level, so it no longer needs an owning agent —
+  // device-pinned and manual-only Behaviors get a link too.
+  if (organizationSlug) {
     viewUrl = buildBehaviorUrl(organizationSlug, watcherId as number, baseUrl);
   }
 

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -206,9 +206,8 @@ export async function handleCreate(
   // unresolvable id is accepted by the INSERT and only shows up as a Behavior
   // that never runs (agent_id) or one whose output contract is silently voided
   // (agent_id). The executor matrix catches unresolvable executors up front —
-  // every automated trigger must resolve to its own respond_with override or
-  // the Behavior-level agent/device; manual-only Behaviors (no triggers) may
-  // be executor-less.
+  // every automated Behavior needs an executor; manual-only Behaviors (no
+  // triggers) may be executor-less.
   const executorDefaults: BehaviorExecutorDefaults = {
     agentId: args.agent_id ?? null,
     deviceWorkerId: args.device_worker_id ?? null,
@@ -232,9 +231,8 @@ export async function handleCreate(
   });
   assertBehaviorOutputsUseWindowExecution(triggerWrite.triggers, outputs);
   await assertBehaviorTriggerConnections(sql, organizationId, triggerWrite.triggers);
-  // Executor matrix (after triggers resolve): every automated trigger must
-  // resolve to its own respond_with override or the Behavior-level
-  // agent/device; manual-only Behaviors (no triggers) may be executor-less.
+  // Executor matrix (after triggers resolve): every automated Behavior needs
+  // an executor; manual-only Behaviors (no triggers) may be executor-less.
   assertBehaviorExecutorsResolve(
     triggerWrite.triggers as BehaviorTriggerInput[],
     executorDefaults
@@ -242,7 +240,6 @@ export async function handleCreate(
   await assertBehaviorExecutorsAuthorized(
     sql,
     organizationId,
-    triggerWrite.triggers as BehaviorTriggerInput[],
     executorDefaults,
     ctx
   );
@@ -535,12 +532,10 @@ export async function handleUpdate(
     );
   }
 
-  // Executor matrix on the EFFECTIVE state (patch over the current row): every
-  // automated trigger in the resulting trigger shape must resolve to its own
-  // respond_with override or the Behavior-level agent/device. This replaces the
-  // old zombie rule — clearing agent_id is fine when a device pin or per-trigger
-  // responders still resolve, and manual-only Behaviors (no triggers) may be
-  // executor-less.
+  // Executor matrix on the EFFECTIVE state (patch over the current row): an
+  // automated Behavior needs an executor. Clearing agent_id is fine when a
+  // device pin remains (device precedence), and manual-only Behaviors (no
+  // triggers) may be executor-less.
   const effectiveDefaults: BehaviorExecutorDefaults = {
     agentId: args.agent_id !== undefined ? args.agent_id : currentRow.agent_id,
     deviceWorkerId:
@@ -557,7 +552,6 @@ export async function handleUpdate(
   await assertBehaviorExecutorsAuthorized(
     sql,
     ctx.organizationId,
-    triggerWrite.triggers as BehaviorTriggerInput[],
     effectiveDefaults,
     ctx
   );

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -42,6 +42,13 @@ import {
   summarizeResults,
   type WatcherOperationResult,
 } from './shared';
+import {
+  type BehaviorExecutorDefaults,
+  type BehaviorTriggerInput,
+  assertBehaviorExecutorsAuthorized,
+  assertBehaviorExecutorsResolve,
+  resolveBehaviorExecutor,
+} from './executors';
 import { getErrorMessage } from '@lobu/core';
 import { DEFAULT_BEHAVIOR_SOURCE_QUERY, extractSourcesFromPromptTokens, mergePromptSources } from '../../../watchers/source-refs';
 import {
@@ -109,16 +116,7 @@ export async function handleCreate(
   if (!args.slug) {
     throw new ToolUserError('slug is required for create action');
   }
-  if (!args.agent_id) {
-    throw new ToolUserError(
-      'agent_id is required to create a Behavior (the agent that executes it).'
-    );
-  }
   assertValidExecutionConfig(args.execution_config, ctx);
-  // A device pin runs the watcher's agent CLI on the device owner's machine —
-  // validate the caller may target this device (own it, or org owner/admin
-  // over a device attached to the org) before storing it.
-  await assertDeviceWorkerAccess(sql, args.device_worker_id, ctx);
 
   // entity_id is optional: omit it for an org-scoped/global watcher.
   const entityId = args.entity_id;
@@ -157,17 +155,6 @@ export async function handleCreate(
     classifiers,
     sources,
   });
-
-  if (!args.agent_id) {
-    // The scheduler joins on `agent_id IS NOT NULL` (see
-    // packages/server/src/watchers/automation.ts:469), so a watcher without
-    // an agent has no way to execute. Schema-wise `agent_id` is `Type.Optional`
-    // because the field is shared across all manage_behaviors actions, but
-    // create enforces it: a watcher with no owning agent is a zombie row.
-    throw new ToolUserError(
-      'agent_id is required to create a Behavior (the agent that executes it).'
-    );
-  }
 
   interface EntityRow {
     entity_type: string;
@@ -218,8 +205,16 @@ export async function handleCreate(
   // Both of these are free-text columns with NO database foreign key, so an
   // unresolvable id is accepted by the INSERT and only shows up as a Behavior
   // that never runs (agent_id) or one whose output contract is silently voided
+  // (agent_id). The executor matrix catches unresolvable executors up front —
+  // every automated trigger must resolve to its own respond_with override or
+  // the Behavior-level agent/device; manual-only Behaviors (no triggers) may
+  // be executor-less.
+  const executorDefaults: BehaviorExecutorDefaults = {
+    agentId: args.agent_id ?? null,
+    deviceWorkerId: args.device_worker_id ?? null,
+    agentKind: args.agent_kind ?? null,
+  };
   // Resolve entity output targets BEFORE the row is written.
-  await assertAgentExists(sql, organizationId, args.agent_id);
   await assertOutputEntityTypesExist(sql, organizationId, outputs);
   await assertOutputEventTypesExist(
     organizationId,
@@ -237,10 +232,36 @@ export async function handleCreate(
   });
   assertBehaviorOutputsUseWindowExecution(triggerWrite.triggers, outputs);
   await assertBehaviorTriggerConnections(sql, organizationId, triggerWrite.triggers);
+  // Executor matrix (after triggers resolve): every automated trigger must
+  // resolve to its own respond_with override or the Behavior-level
+  // agent/device; manual-only Behaviors (no triggers) may be executor-less.
+  assertBehaviorExecutorsResolve(
+    triggerWrite.triggers as BehaviorTriggerInput[],
+    executorDefaults
+  );
+  await assertBehaviorExecutorsAuthorized(
+    sql,
+    organizationId,
+    triggerWrite.triggers as BehaviorTriggerInput[],
+    executorDefaults,
+    ctx
+  );
   const skills = args.skills ?? [];
   assertBehaviorInstructions(triggerWrite.triggers, args.prompt, skills);
   assertPromptSkillTokensPinned(args.prompt, skills);
-  await assertBehaviorSkillsResolve(sql, organizationId, args.agent_id, skills);
+  // v1 constraint: skill bodies resolve against ONE agent library at save
+  // time — the Behavior-level default executor when it is an agent.
+  // Per-trigger responders reuse these frozen bodies at dispatch.
+  const defaultExecutor = resolveBehaviorExecutor(executorDefaults);
+  if (skills.length > 0) {
+    if (!defaultExecutor || defaultExecutor.kind !== 'agent') {
+      throw new ToolUserError(
+        'skills require a Behavior-level agent executor: skills compile against the default agent’s library. Set agent_id, or remove skills for device-executed / manual-only Behaviors.',
+        422
+      );
+    }
+    await assertBehaviorSkillsResolve(sql, organizationId, defaultExecutor.agentId, skills);
+  }
 
   // Check slug uniqueness within org
   const existingSlug = await sql`
@@ -286,7 +307,7 @@ export async function handleCreate(
       await tx`
       INSERT INTO watchers (
         id, name, slug, organization_id, entity_ids,
-        schedule, timezone, next_run_at, triggers, agent_id, scheduler_client_id, model_config, sources, version,
+        schedule, timezone, next_run_at, triggers, agent_id, model_config, sources, version,
         current_version_id, tags, status, created_by, created_at, updated_at,
         watcher_group_id,
         device_worker_id, agent_kind,
@@ -297,7 +318,7 @@ export async function handleCreate(
         ${watcherId}, ${args.name ?? args.slug}, ${args.slug}, ${organizationId},
         ${`{${entityIdsArray.join(',')}}`}::bigint[],
         ${triggerWrite.schedule}, ${triggerWrite.timezone}, ${nextRunAtVal}, ${tx.json(triggerWrite.triggers)},
-        ${args.agent_id ?? null}, ${args.scheduler_client_id ?? null},
+        ${args.agent_id ?? null},
         ${sql.json(args.model_config || {})}, ${sql.json(sources)},
         1, NULL, ${toTextArrayParam(args.tags || [])}::text[],
         'active', ${createdBy}, NOW(), NOW(),
@@ -415,7 +436,6 @@ export async function handleCreate(
         triggers: triggerWrite.triggers,
         agent_id: args.agent_id ?? null,
         agent_kind: args.agent_kind ?? null,
-        scheduler_client_id: args.scheduler_client_id ?? null,
         device_worker_id: args.device_worker_id ?? null,
         model_config: args.model_config ?? {},
         execution_config: args.execution_config ?? null,
@@ -468,6 +488,7 @@ export async function handleUpdate(
   await requireExists(sql, 'watchers', args.behavior_id, 'Behavior');
   const currentRows = await sql`
     SELECT w.organization_id, w.agent_id, w.schedule, w.timezone, w.triggers,
+           w.device_worker_id::text AS device_worker_id, w.agent_kind,
            cv.prompt AS current_prompt, cv.skills AS current_skills,
            cv.outputs AS current_outputs
     FROM watchers w
@@ -478,6 +499,8 @@ export async function handleUpdate(
   const currentRow = currentRows[0] as {
     organization_id: string;
     agent_id: string | null;
+    device_worker_id: string | null;
+    agent_kind: string | null;
     schedule: string | null;
     timezone: string | null;
     triggers: ManageBehaviorsArgs['triggers'];
@@ -512,35 +535,38 @@ export async function handleUpdate(
     );
   }
 
-  // Match the invariant from handleCreate: a watcher with no agent_id is
-  // a zombie the scheduler will never run (automation joins on
-  // `agent_id IS NOT NULL`). Reject explicit nulling, and reject updates
-  // that would leave a scheduled watcher orphaned.
-  if (args.agent_id === null) {
-    throw new ToolUserError(
-      'agent_id cannot be set to null — every Behavior must have an owning agent.'
-    );
-  }
-  if (args.triggers !== undefined && triggerWrite.schedule && args.agent_id === undefined) {
-    const currentAgentId = currentRow.agent_id;
-    if (currentAgentId === null) {
-      throw new ToolUserError(
-        'Cannot schedule a Behavior with no owning agent. Assign agent_id in the same update.'
-      );
-    }
-  }
-  // Same unresolvable-reference hole as create: `agent_id` has no FK, so
-  // re-pointing a Behavior at a nonexistent/cross-org agent would silently
-  // strand it (the scheduler joins on agents). Fence on ctx.organizationId —
-  // the same org the UPDATE below scopes to.
-  await assertAgentExists(sql, ctx.organizationId, args.agent_id);
+  // Executor matrix on the EFFECTIVE state (patch over the current row): every
+  // automated trigger in the resulting trigger shape must resolve to its own
+  // respond_with override or the Behavior-level agent/device. This replaces the
+  // old zombie rule — clearing agent_id is fine when a device pin or per-trigger
+  // responders still resolve, and manual-only Behaviors (no triggers) may be
+  // executor-less.
+  const effectiveDefaults: BehaviorExecutorDefaults = {
+    agentId: args.agent_id !== undefined ? args.agent_id : currentRow.agent_id,
+    deviceWorkerId:
+      args.device_worker_id !== undefined
+        ? args.device_worker_id
+        : currentRow.device_worker_id,
+    agentKind:
+      args.agent_kind !== undefined ? args.agent_kind : currentRow.agent_kind,
+  };
+  assertBehaviorExecutorsResolve(
+    triggerWrite.triggers as BehaviorTriggerInput[],
+    effectiveDefaults
+  );
+  await assertBehaviorExecutorsAuthorized(
+    sql,
+    ctx.organizationId,
+    triggerWrite.triggers as BehaviorTriggerInput[],
+    effectiveDefaults,
+    ctx
+  );
 
   const updatedFields: string[] = [];
   if (args.model_config !== undefined) updatedFields.push('model_config');
   if (args.execution_config !== undefined) updatedFields.push('execution_config');
   if (args.triggers !== undefined) updatedFields.push('triggers');
   if (args.agent_id !== undefined) updatedFields.push('agent_id');
-  if (args.scheduler_client_id !== undefined) updatedFields.push('scheduler_client_id');
   if (args.tags !== undefined) updatedFields.push('tags');
   if (args.device_worker_id !== undefined) updatedFields.push('device_worker_id');
   if (args.agent_kind !== undefined) updatedFields.push('agent_kind');
@@ -587,7 +613,6 @@ export async function handleUpdate(
       triggers = CASE WHEN ${has('triggers')} THEN ${toJsonParam(sql, patch.triggers)} ELSE triggers END,
       next_run_at = CASE WHEN ${touchesCadence} THEN ${nextRunAtVal}::timestamptz ELSE next_run_at END,
       agent_id = CASE WHEN ${has('agent_id')} THEN ${patch.agent_id ?? null} ELSE agent_id END,
-      scheduler_client_id = CASE WHEN ${has('scheduler_client_id')} THEN ${patch.scheduler_client_id ?? null} ELSE scheduler_client_id END,
       tags = CASE WHEN ${has('tags')} THEN ${toTextArrayParam(patch.tags ?? [])}::text[] ELSE tags END,
       device_worker_id = CASE WHEN ${has('device_worker_id')} THEN ${patch.device_worker_id ?? null}::uuid ELSE device_worker_id END,
       agent_kind = CASE WHEN ${has('agent_kind')} THEN ${patch.agent_kind ?? null} ELSE agent_kind END,
@@ -758,7 +783,7 @@ export async function handleCreateFromVersion(
   // new assignment would have no reactions — or (dropping the input schema) a
   // reaction with no extraction contract, silently running free-form.
   const versionRows = await sql`
-    SELECT wv.*, w.organization_id, w.schedule, w.timezone, w.triggers, w.sources, w.agent_id, w.scheduler_client_id,
+    SELECT wv.*, w.organization_id, w.schedule, w.timezone, w.triggers, w.sources, w.agent_id,
            w.model_config, w.execution_config, w.tags, w.watcher_group_id,
            w.reaction_script, w.reaction_script_compiled, w.reaction_input_schema
     FROM watcher_versions wv
@@ -901,7 +926,7 @@ export async function handleCreateFromVersion(
         await tx`
           INSERT INTO watchers (
             id, name, slug, organization_id, entity_ids,
-            schedule, timezone, next_run_at, triggers, agent_id, scheduler_client_id, model_config, execution_config, sources, version,
+            schedule, timezone, next_run_at, triggers, agent_id, model_config, execution_config, sources, version,
             current_version_id, tags, status, created_by, created_at, updated_at,
             watcher_group_id, source_watcher_id,
             reaction_script, reaction_script_compiled, reaction_input_schema
@@ -909,7 +934,7 @@ export async function handleCreateFromVersion(
             ${watcherId}, ${watcherName}, ${watcherSlug}, ${organizationId},
             ${`{${entityId}}`}::bigint[],
             ${version.schedule ?? null}, ${version.timezone ?? null}, ${version.schedule ? nextRunAt(version.schedule as string, new Date(), version.timezone as string | null) : null}, ${toJsonParam(tx, cloneTriggers)},
-            ${version.agent_id ?? null}, ${version.scheduler_client_id ?? null},
+            ${version.agent_id ?? null},
             ${toJsonParam(tx, version.model_config)}, ${toJsonParam(tx, version.execution_config)}, ${toJsonParam(tx, clonedSources)},
             ${(version.version as number) ?? 1}, ${sharedVersionId}, ${toTextArrayParam(cloneTags)}::text[],
             'active', ${createdBy}, NOW(), NOW(),
@@ -987,7 +1012,6 @@ export async function handleCreateFromVersion(
         timezone: version.timezone ?? null,
         triggers: version.triggers ?? [],
         agent_id: version.agent_id ?? null,
-        scheduler_client_id: version.scheduler_client_id ?? null,
         version: (version.version as number) ?? 1,
         current_version_id: p.sharedVersionId,
         watcher_group_id: p.groupId,

--- a/packages/server/src/tools/admin/manage_behaviors/executors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/executors.ts
@@ -1,27 +1,28 @@
 /**
- * Executor resolution for Behaviors — the "when -> who" matrix.
+ * Executor resolution for Behaviors.
  *
  * A Behavior is an org-level goal with one durable contract (prompt, outputs,
- * reaction script, budget). Its triggers may route activations to different
- * executors via a per-trigger `respond_with` override:
+ * reaction script, budget) and exactly ONE executor:
  *
- *  - `{ kind: "agent", agent_id }` — managed Lobu agent (server dispatch lane)
- *  - `{ kind: "device", device_worker_id, agent_kind? }` — device worker lane
- *  - omitted — fall back to the Behavior's own executor
- *    (`agent_id` / `device_worker_id`)
+ *  - `agent_id` — a managed Lobu agent executes runs (server dispatch lane)
+ *  - `device_worker_id` — the pinned device worker's local CLI executes them
+ *    (device lane); `agent_kind` picks the local runtime, null = device
+ *    default
+ *
+ * Triggers are the "when" and carry no executor of their own.
  *
  * Resolution rules enforced here (create/update):
  *
- *  - Every event/schedule trigger MUST resolve to an executor — its own
- *    override or the Behavior default. An automated activation with no
- *    executor is a zombie: there is no lane that could ever run it.
+ *  - Every automated Behavior (any event/schedule trigger) MUST have an
+ *    executor — an automated activation with no executor is a zombie: there
+ *    is no lane that could ever run it (the scheduler/event SELECTs gate on
+ *    the row-level columns).
  *  - A Behavior with NO triggers is manual-only: executor is optional. Manual
  *    activations are open — any connected MCP client may execute and complete
  *    them (write-tier `complete_window`), so they are never addressed.
  */
 import type {
   BehaviorEventTrigger,
-  BehaviorRespondWith,
   BehaviorScheduleTrigger,
 } from "@lobu/core/contracts/tools/manage-behaviors";
 import type { DbClient } from "../../../db/client";
@@ -34,7 +35,7 @@ export type BehaviorTriggerInput =
   | BehaviorEventTrigger
   | BehaviorScheduleTrigger;
 
-/** Behavior-level executor defaults (columns on the watchers row). */
+/** Behavior-level executor (columns on the watchers row). */
 export interface BehaviorExecutorDefaults {
   agentId?: string | null;
   deviceWorkerId?: string | null;
@@ -49,24 +50,13 @@ export type ResolvedExecutor =
       agentKind: string | null;
     };
 
-/** Resolve one trigger's executor: its own override, else the defaults.
- * Default precedence is DEVICE PIN FIRST: legacy dual rows carried both
- * agent_id and device_worker_id and always ran on the device lane (#802) —
- * agent-first fallback would silently flip those runs to server dispatch. */
-export function resolveTriggerExecutor(
-  trigger: { respond_with?: BehaviorRespondWith } | null | undefined,
+/** Resolve the Behavior's executor.
+ * Precedence is DEVICE PIN FIRST: legacy dual rows carried both agent_id and
+ * device_worker_id and always ran on the device lane (#802) — agent-first
+ * fallback would silently flip those runs to server dispatch. */
+export function resolveBehaviorExecutor(
   defaults: BehaviorExecutorDefaults
 ): ResolvedExecutor | null {
-  const override = trigger?.respond_with;
-  if (override) {
-    return override.kind === "agent"
-      ? { kind: "agent", agentId: override.agent_id }
-      : {
-          kind: "device",
-          deviceWorkerId: override.device_worker_id,
-          agentKind: override.agent_kind ?? null,
-        };
-  }
   if (defaults.deviceWorkerId) {
     return {
       kind: "device",
@@ -80,105 +70,44 @@ export function resolveTriggerExecutor(
   return null;
 }
 
-/** The Behavior-level default executor (what an override-less trigger uses). */
-export function resolveBehaviorExecutor(
-  defaults: BehaviorExecutorDefaults
-): ResolvedExecutor | null {
-  return resolveTriggerExecutor(null, defaults);
-}
-
-function describeTrigger(trigger: BehaviorTriggerInput, index: number): string {
-  if (trigger.kind === "event") {
-    return `event trigger ${index + 1} (${trigger.connector_key})`;
-  }
-  return `schedule trigger ${index + 1} (${trigger.cron})`;
-}
-
 /**
  * Structural matrix check. Rules:
- *  - Automated Behaviors (any event/schedule trigger) MUST have a
- *    Behavior-level executor (agent_id or device_worker_id). Per-trigger
- *    respond_with is a pure OVERRIDE of which executor runs — it can never be
- *    the sole source of one, because the scheduler/event SELECTs gate on the
- *    row-level columns; an override-only Behavior would validate but never
- *    fire.
- *  - Every automated trigger must resolve (always true once the default
- *    exists; kept for clarity and future trigger-level validation).
+ *  - Automated Behaviors (any event/schedule trigger) MUST have an executor.
+ *    Triggers carry no executor of their own, and the scheduler/event SELECTs
+ *    gate on the row-level columns — an executor-less automated Behavior
+ *    would validate but never fire.
  *  - Manual-only Behaviors (no triggers) pass with or without an executor.
  */
 export function assertBehaviorExecutorsResolve(
   triggers: BehaviorTriggerInput[] | null | undefined,
   defaults: BehaviorExecutorDefaults
 ): void {
-  const automated = (triggers ?? []).filter(
-    (trigger): trigger is BehaviorTriggerInput =>
-      trigger.kind === "event" || trigger.kind === "schedule"
+  const automated = (triggers ?? []).some(
+    (trigger) => trigger.kind === "event" || trigger.kind === "schedule"
   );
-  if (automated.length === 0) return;
+  if (!automated) return;
   if (!resolveBehaviorExecutor(defaults)) {
     throw new ToolUserError(
-      "Automated Behaviors need a Behavior-level executor: set agent_id (managed agent) or device_worker_id (device). Trigger respond_with overrides which executor runs, but cannot be the only one. Manual-only Behaviors (no triggers) may omit both."
+      "Automated Behaviors need an executor: set agent_id (managed agent) or device_worker_id (device). Manual-only Behaviors (no triggers) may omit both."
     );
   }
-  automated.forEach((trigger, index) => {
-    if (!resolveTriggerExecutor(trigger, defaults)) {
-      throw new ToolUserError(
-        `${describeTrigger(trigger, index)} has no executor: set respond_with on the trigger or agent_id/device_worker_id on the Behavior.`
-      );
-    }
-  });
 }
 
 /**
  * DB-level authorization for every executor the Behavior references: the
- * Behavior-level device pin (ALWAYS, even when an agent default shadows it in
- * resolution — storing a pin the caller may not target is itself the exploit),
- * the Behavior-level agent, and every per-trigger override. Deduped.
+ * device pin (ALWAYS, even when an agent shadows it in resolution — storing a
+ * pin the caller may not target is itself the exploit) and the agent.
  */
 export async function assertBehaviorExecutorsAuthorized(
   sql: DbClient,
   organizationId: string,
-  triggers: BehaviorTriggerInput[] | null | undefined,
   defaults: BehaviorExecutorDefaults,
   ctx: ToolContext
 ): Promise<void> {
-  const executors: ResolvedExecutor[] = [];
   if (defaults.deviceWorkerId) {
-    executors.push({
-      kind: "device",
-      deviceWorkerId: defaults.deviceWorkerId,
-      agentKind: defaults.agentKind ?? null,
-    });
+    await assertDeviceWorkerAccess(sql, defaults.deviceWorkerId, ctx);
   }
   if (defaults.agentId) {
-    executors.push({ kind: "agent", agentId: defaults.agentId });
-  }
-  for (const trigger of triggers ?? []) {
-    if (trigger.kind !== "event" && trigger.kind !== "schedule") continue;
-    const override = trigger.respond_with;
-    if (!override) continue;
-    executors.push(
-      override.kind === "agent"
-        ? { kind: "agent", agentId: override.agent_id }
-        : {
-            kind: "device",
-            deviceWorkerId: override.device_worker_id,
-            agentKind: override.agent_kind ?? null,
-          }
-    );
-  }
-
-  const seenAgents = new Set<string>();
-  const seenDevices = new Set<string>();
-  for (const executor of executors) {
-    if (executor.kind === "agent") {
-      if (seenAgents.has(executor.agentId)) continue;
-      seenAgents.add(executor.agentId);
-      await assertAgentExists(sql, organizationId, executor.agentId);
-    } else {
-      if (seenDevices.has(executor.deviceWorkerId)) continue;
-      seenDevices.add(executor.deviceWorkerId);
-      await assertDeviceWorkerAccess(sql, executor.deviceWorkerId, ctx);
-    }
+    await assertAgentExists(sql, organizationId, defaults.agentId);
   }
 }

--- a/packages/server/src/tools/admin/manage_behaviors/executors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/executors.ts
@@ -1,0 +1,184 @@
+/**
+ * Executor resolution for Behaviors — the "when -> who" matrix.
+ *
+ * A Behavior is an org-level goal with one durable contract (prompt, outputs,
+ * reaction script, budget). Its triggers may route activations to different
+ * executors via a per-trigger `respond_with` override:
+ *
+ *  - `{ kind: "agent", agent_id }` — managed Lobu agent (server dispatch lane)
+ *  - `{ kind: "device", device_worker_id, agent_kind? }` — device worker lane
+ *  - omitted — fall back to the Behavior's own executor
+ *    (`agent_id` / `device_worker_id`)
+ *
+ * Resolution rules enforced here (create/update):
+ *
+ *  - Every event/schedule trigger MUST resolve to an executor — its own
+ *    override or the Behavior default. An automated activation with no
+ *    executor is a zombie: there is no lane that could ever run it.
+ *  - A Behavior with NO triggers is manual-only: executor is optional. Manual
+ *    activations are open — any connected MCP client may execute and complete
+ *    them (write-tier `complete_window`), so they are never addressed.
+ */
+import type {
+  BehaviorEventTrigger,
+  BehaviorRespondWith,
+  BehaviorScheduleTrigger,
+} from "@lobu/core/contracts/tools/manage-behaviors";
+import type { DbClient } from "../../../db/client";
+import { ToolUserError } from "../../../utils/errors";
+import type { ToolContext } from "../../registry";
+import { assertDeviceWorkerAccess } from "../behavior-device-access";
+import { assertAgentExists } from "./shared";
+
+export type BehaviorTriggerInput =
+  | BehaviorEventTrigger
+  | BehaviorScheduleTrigger;
+
+/** Behavior-level executor defaults (columns on the watchers row). */
+export interface BehaviorExecutorDefaults {
+  agentId?: string | null;
+  deviceWorkerId?: string | null;
+  agentKind?: string | null;
+}
+
+export type ResolvedExecutor =
+  | { kind: "agent"; agentId: string }
+  | {
+      kind: "device";
+      deviceWorkerId: string;
+      agentKind: string | null;
+    };
+
+/** Resolve one trigger's executor: its own override, else the defaults.
+ * Default precedence is DEVICE PIN FIRST: legacy dual rows carried both
+ * agent_id and device_worker_id and always ran on the device lane (#802) —
+ * agent-first fallback would silently flip those runs to server dispatch. */
+export function resolveTriggerExecutor(
+  trigger: { respond_with?: BehaviorRespondWith } | null | undefined,
+  defaults: BehaviorExecutorDefaults
+): ResolvedExecutor | null {
+  const override = trigger?.respond_with;
+  if (override) {
+    return override.kind === "agent"
+      ? { kind: "agent", agentId: override.agent_id }
+      : {
+          kind: "device",
+          deviceWorkerId: override.device_worker_id,
+          agentKind: override.agent_kind ?? null,
+        };
+  }
+  if (defaults.deviceWorkerId) {
+    return {
+      kind: "device",
+      deviceWorkerId: defaults.deviceWorkerId,
+      agentKind: defaults.agentKind ?? null,
+    };
+  }
+  if (defaults.agentId) {
+    return { kind: "agent", agentId: defaults.agentId };
+  }
+  return null;
+}
+
+/** The Behavior-level default executor (what an override-less trigger uses). */
+export function resolveBehaviorExecutor(
+  defaults: BehaviorExecutorDefaults
+): ResolvedExecutor | null {
+  return resolveTriggerExecutor(null, defaults);
+}
+
+function describeTrigger(trigger: BehaviorTriggerInput, index: number): string {
+  if (trigger.kind === "event") {
+    return `event trigger ${index + 1} (${trigger.connector_key})`;
+  }
+  return `schedule trigger ${index + 1} (${trigger.cron})`;
+}
+
+/**
+ * Structural matrix check. Rules:
+ *  - Automated Behaviors (any event/schedule trigger) MUST have a
+ *    Behavior-level executor (agent_id or device_worker_id). Per-trigger
+ *    respond_with is a pure OVERRIDE of which executor runs — it can never be
+ *    the sole source of one, because the scheduler/event SELECTs gate on the
+ *    row-level columns; an override-only Behavior would validate but never
+ *    fire.
+ *  - Every automated trigger must resolve (always true once the default
+ *    exists; kept for clarity and future trigger-level validation).
+ *  - Manual-only Behaviors (no triggers) pass with or without an executor.
+ */
+export function assertBehaviorExecutorsResolve(
+  triggers: BehaviorTriggerInput[] | null | undefined,
+  defaults: BehaviorExecutorDefaults
+): void {
+  const automated = (triggers ?? []).filter(
+    (trigger): trigger is BehaviorTriggerInput =>
+      trigger.kind === "event" || trigger.kind === "schedule"
+  );
+  if (automated.length === 0) return;
+  if (!resolveBehaviorExecutor(defaults)) {
+    throw new ToolUserError(
+      "Automated Behaviors need a Behavior-level executor: set agent_id (managed agent) or device_worker_id (device). Trigger respond_with overrides which executor runs, but cannot be the only one. Manual-only Behaviors (no triggers) may omit both."
+    );
+  }
+  automated.forEach((trigger, index) => {
+    if (!resolveTriggerExecutor(trigger, defaults)) {
+      throw new ToolUserError(
+        `${describeTrigger(trigger, index)} has no executor: set respond_with on the trigger or agent_id/device_worker_id on the Behavior.`
+      );
+    }
+  });
+}
+
+/**
+ * DB-level authorization for every executor the Behavior references: the
+ * Behavior-level device pin (ALWAYS, even when an agent default shadows it in
+ * resolution — storing a pin the caller may not target is itself the exploit),
+ * the Behavior-level agent, and every per-trigger override. Deduped.
+ */
+export async function assertBehaviorExecutorsAuthorized(
+  sql: DbClient,
+  organizationId: string,
+  triggers: BehaviorTriggerInput[] | null | undefined,
+  defaults: BehaviorExecutorDefaults,
+  ctx: ToolContext
+): Promise<void> {
+  const executors: ResolvedExecutor[] = [];
+  if (defaults.deviceWorkerId) {
+    executors.push({
+      kind: "device",
+      deviceWorkerId: defaults.deviceWorkerId,
+      agentKind: defaults.agentKind ?? null,
+    });
+  }
+  if (defaults.agentId) {
+    executors.push({ kind: "agent", agentId: defaults.agentId });
+  }
+  for (const trigger of triggers ?? []) {
+    if (trigger.kind !== "event" && trigger.kind !== "schedule") continue;
+    const override = trigger.respond_with;
+    if (!override) continue;
+    executors.push(
+      override.kind === "agent"
+        ? { kind: "agent", agentId: override.agent_id }
+        : {
+            kind: "device",
+            deviceWorkerId: override.device_worker_id,
+            agentKind: override.agent_kind ?? null,
+          }
+    );
+  }
+
+  const seenAgents = new Set<string>();
+  const seenDevices = new Set<string>();
+  for (const executor of executors) {
+    if (executor.kind === "agent") {
+      if (seenAgents.has(executor.agentId)) continue;
+      seenAgents.add(executor.agentId);
+      await assertAgentExists(sql, organizationId, executor.agentId);
+    } else {
+      if (seenDevices.has(executor.deviceWorkerId)) continue;
+      seenDevices.add(executor.deviceWorkerId);
+      await assertDeviceWorkerAccess(sql, executor.deviceWorkerId, ctx);
+    }
+  }
+}

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -55,7 +55,6 @@ export async function handleList(
       i.agent_id,
       i.device_worker_id,
       i.last_fired_at,
-      i.scheduler_client_id,
       i.model_config,
       i.execution_config,
       i.sources,
@@ -141,6 +140,14 @@ export async function handleList(
 	} else {
 		// Default to active watchers only (exclude archived)
 		conditions.push(`i.status = 'active'`);
+	}
+
+	// Discovery filter for executors: match the LATEST run per Behavior (the
+	// lateral join prioritizes active runs), e.g. pending manual-open runs.
+	if (args.run_status) {
+		conditions.push(`wr.status = $${paramCount}`);
+		params.push(args.run_status);
+		paramCount++;
 	}
 
 	query += ` WHERE ${conditions.join(" AND ")}`;

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -199,7 +199,7 @@ export async function handleList(
 
 		const viewUrl =
 			orgSlug && watcher.agent_id
-				? buildBehaviorUrl(orgSlug, watcher.agent_id, watcherId, baseUrl)
+				? buildBehaviorUrl(orgSlug, watcherId, baseUrl)
 				: undefined;
 
 		const { organization_id: _orgId, ...rest } = watcher;

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -198,10 +198,11 @@ export async function handleList(
 		const countData = counts.get(watcherId) || { pending: 0, historical: 0 };
 		const orgSlug = orgSlugMap.get(watcher.organization_id as string) ?? null;
 
-		const viewUrl =
-			orgSlug && watcher.agent_id
-				? buildBehaviorUrl(orgSlug, watcherId, baseUrl)
-				: undefined;
+		// Workspace-level route: agentless (device-pinned / manual-only)
+		// Behaviors carry a view_url just like agent-owned ones.
+		const viewUrl = orgSlug
+			? buildBehaviorUrl(orgSlug, watcherId, baseUrl)
+			: undefined;
 
 		const { organization_id: _orgId, ...rest } = watcher;
 

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -83,7 +83,8 @@ export async function handleList(
       parent.slug as parent_slug,
       pet.slug as parent_entity_type,
       i.current_version_id,
-      (SELECT COUNT(*) FROM canvas_windows iw WHERE iw.watcher_id = i.id) as windows_count
+      (SELECT COUNT(*) FROM canvas_windows iw WHERE iw.watcher_id = i.id) as windows_count,
+      (SELECT COUNT(DISTINCT iw.client_id) FROM canvas_windows iw WHERE iw.watcher_id = i.id AND iw.client_id IS NOT NULL) as processing_client_count
   `;
 
 	if (args.include_details) {

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -229,10 +229,10 @@ export async function handleCreateVersion(
   }
 
   // Executor matrix on the LIVE row (set_as_current writes triggers to it):
-  // same rules as create/update — automated triggers need a Behavior-level
-  // executor, and every referenced executor must be authorized. Without this,
-  // create_version (the primary authoring path — `lobu apply`, owletto edit)
-  // could land zombie triggers or unvalidated respond_with overrides.
+  // same rules as create/update — automated Behaviors need an executor, and
+  // every referenced executor must be authorized. Without this, create_version
+  // (the primary authoring path — `lobu apply`, owletto edit) could land
+  // zombie triggers.
   const setAsCurrentForMatrix = args.set_as_current !== false;
   if (setAsCurrentForMatrix && versionOrganizationId && triggersChanged) {
     const rowDefaults: BehaviorExecutorDefaults = {
@@ -248,7 +248,6 @@ export async function handleCreateVersion(
     await assertBehaviorExecutorsAuthorized(
       sql,
       versionOrganizationId,
-      triggerWrite.triggers as BehaviorTriggerInput[],
       rowDefaults,
       ctx
     );

--- a/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/version-actions.ts
@@ -12,6 +12,12 @@ import { getNextNumericId } from '../helpers/db-helpers';
 import type { ToolContext } from '../../registry';
 import type { ManageBehaviorsArgs, ManageBehaviorsResult } from '../manage_behaviors';
 import {
+  type BehaviorExecutorDefaults,
+  type BehaviorTriggerInput,
+  assertBehaviorExecutorsAuthorized,
+  assertBehaviorExecutorsResolve,
+} from './executors';
+import {
   assertOutputEntityTypesExist,
   assertOutputEventTypesExist,
   assertOutputsShape,
@@ -60,10 +66,11 @@ export async function handleCreateVersion(
   // and version rows live on the group root, so we read from and write to
   // `watcher_id = watcher_group_id`. The arg's watcher_id is only used to
   // identify the group and to apply the per-assignment writes (sources,
-  // schedule, scheduler_client_id) to that specific row.
+  // schedule) to that specific row.
   const watcherRows = await sql`
     SELECT i.id, i.version, i.current_version_id, i.watcher_group_id, i.sources, i.organization_id,
-           i.entity_ids, i.schedule, i.timezone, i.triggers, i.agent_id
+           i.entity_ids, i.schedule, i.timezone, i.triggers, i.agent_id,
+           i.device_worker_id::text AS device_worker_id, i.agent_kind
     FROM watchers i WHERE i.id = ${args.behavior_id}
   `;
   if (watcherRows.length === 0) {
@@ -221,6 +228,32 @@ export async function handleCreateVersion(
     );
   }
 
+  // Executor matrix on the LIVE row (set_as_current writes triggers to it):
+  // same rules as create/update — automated triggers need a Behavior-level
+  // executor, and every referenced executor must be authorized. Without this,
+  // create_version (the primary authoring path — `lobu apply`, owletto edit)
+  // could land zombie triggers or unvalidated respond_with overrides.
+  const setAsCurrentForMatrix = args.set_as_current !== false;
+  if (setAsCurrentForMatrix && versionOrganizationId && triggersChanged) {
+    const rowDefaults: BehaviorExecutorDefaults = {
+      agentId: (watcherRows[0].agent_id as string | null) ?? null,
+      deviceWorkerId:
+        (watcherRows[0].device_worker_id as string | null) ?? null,
+      agentKind: (watcherRows[0].agent_kind as string | null) ?? null,
+    };
+    assertBehaviorExecutorsResolve(
+      triggerWrite.triggers as BehaviorTriggerInput[],
+      rowDefaults
+    );
+    await assertBehaviorExecutorsAuthorized(
+      sql,
+      versionOrganizationId,
+      triggerWrite.triggers as BehaviorTriggerInput[],
+      rowDefaults,
+      ctx
+    );
+  }
+
   // Final-state instruction rule. The prompt version is group-shared
   // (cascades to every assignment), while triggers are per-assignment — so
   // when set_as_current, validate the new prompt against every sibling's
@@ -296,7 +329,7 @@ export async function handleCreateVersion(
     // Update watcher to new version if set_as_current (default: true).
     // Group-shared fields (current_version_id, version, name) cascade to
     // every watcher in the group; per-assignment fields (sources,
-    // schedule, scheduler_client_id) update only the targeted row.
+    // schedule) update only the targeted row.
     if (setAsCurrent) {
       const shouldUpdateTriggers = args.triggers !== undefined;
       const scheduleValue = triggerWrite.schedule;
@@ -331,7 +364,6 @@ export async function handleCreateVersion(
         UPDATE watchers
         SET
           sources = ${tx.json(sources)},
-          scheduler_client_id = CASE WHEN ${args.scheduler_client_id !== undefined} THEN ${args.scheduler_client_id ?? null} ELSE scheduler_client_id END,
           schedule = CASE WHEN ${touchesCadence} THEN ${scheduleValue} ELSE schedule END,
           timezone = CASE WHEN ${touchesCadence} THEN ${timezoneValue} ELSE timezone END,
           triggers = CASE WHEN ${touchesCadence} THEN ${tx.json(triggerWrite.triggers)} ELSE triggers END,

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -220,6 +220,7 @@ interface WatcherQueryRow {
   next_run_at: string | null;
   agent_id: string | null;
   device_worker_id: string | null;
+  agent_kind: string | null;
   version: number;
   current_version_id: number | null;
   entity_ids: string | number[];
@@ -545,6 +546,7 @@ async function getBehaviorImpl(
         i.next_run_at,
         i.agent_id,
         i.device_worker_id,
+        i.agent_kind,
         i.version,
         i.current_version_id,
         i.entity_ids,
@@ -787,6 +789,7 @@ async function getBehaviorImpl(
       next_run_at: watcherRow.next_run_at,
       agent_id: watcherRow.agent_id,
       device_worker_id: watcherRow.device_worker_id ?? null,
+      agent_kind: watcherRow.agent_kind ?? null,
       version: pinnedVersion,
       sources: watcherSources,
       prompt: version?.prompt as string | undefined,
@@ -1088,7 +1091,7 @@ async function getBehaviorImpl(
     : null;
   const viewUrl =
     organizationSlug && watcherRow?.agent_id
-      ? buildBehaviorUrl(organizationSlug, watcherRow.agent_id, args.behavior_id, baseUrl)
+      ? buildBehaviorUrl(organizationSlug, args.behavior_id, baseUrl)
       : undefined;
 
   const result: GetBehaviorResult = {

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -1089,10 +1089,11 @@ async function getBehaviorImpl(
   const organizationSlug = watcherRow?.organization_id
     ? await getOrganizationSlug(watcherRow.organization_id)
     : null;
-  const viewUrl =
-    organizationSlug && watcherRow?.agent_id
-      ? buildBehaviorUrl(organizationSlug, args.behavior_id, baseUrl)
-      : undefined;
+  // Workspace-level route: agentless (device-pinned / manual-only) Behaviors
+  // get the same link as agent-owned ones.
+  const viewUrl = organizationSlug
+    ? buildBehaviorUrl(organizationSlug, args.behavior_id, baseUrl)
+    : undefined;
 
   const result: GetBehaviorResult = {
     windows: formattedWindows,

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -220,7 +220,6 @@ interface WatcherQueryRow {
   next_run_at: string | null;
   agent_id: string | null;
   device_worker_id: string | null;
-  scheduler_client_id: string | null;
   version: number;
   current_version_id: number | null;
   entity_ids: string | number[];
@@ -546,7 +545,6 @@ async function getBehaviorImpl(
         i.next_run_at,
         i.agent_id,
         i.device_worker_id,
-        i.scheduler_client_id,
         i.version,
         i.current_version_id,
         i.entity_ids,
@@ -789,7 +787,6 @@ async function getBehaviorImpl(
       next_run_at: watcherRow.next_run_at,
       agent_id: watcherRow.agent_id,
       device_worker_id: watcherRow.device_worker_id ?? null,
-      scheduler_client_id: watcherRow.scheduler_client_id,
       version: pinnedVersion,
       sources: watcherSources,
       prompt: version?.prompt as string | undefined,

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -132,6 +132,8 @@ export const WatcherMetadataSchema = Type.Object({
    * to a specific device worker. NULL/undefined means any worker can claim.
    */
   device_worker_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  /** Preferred local agent runtime on the pinned device; null = device default. */
+  agent_kind: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   scheduler_client_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   version: Type.Integer(),
   sources: Type.Array(WatcherSourceSchema),

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -152,51 +152,47 @@ describe('buildBehaviorSettingsUrl', () => {
     const url = await buildBehaviorSettingsUrl(
       'https://app.lobu.com/lobu',
       'org-1',
-      'lobu-builder',
       7
     );
-    expect(url).toBe('https://app.lobu.com/acme/agents/lobu-builder/behaviors/7');
+    expect(url).toBe('https://app.lobu.com/acme/behaviors/7');
   });
 
   it('appends ?run_id when a review run is given', async () => {
     const url = await buildBehaviorSettingsUrl(
       'https://app.lobu.com/lobu',
       'org-1',
-      'lobu-builder',
       7,
       { runId: 42 }
     );
-    expect(url).toBe('https://app.lobu.com/acme/agents/lobu-builder/behaviors/7?run_id=42');
+    expect(url).toBe('https://app.lobu.com/acme/behaviors/7?run_id=42');
   });
 
-  it('accepts a string Behavior id and percent-encodes agent + slug', async () => {
+  it('accepts a string Behavior id and percent-encodes the slug', async () => {
     const url = await buildBehaviorSettingsUrl(
       'https://app.lobu.com',
       'org-special',
-      'my agent/id',
       '7'
     );
-    expect(url).toBe('https://app.lobu.com/acme%2Fteam/agents/my%20agent%2Fid/behaviors/7');
+    expect(url).toBe('https://app.lobu.com/acme%2Fteam/behaviors/7');
   });
 
   it('returns null when the org slug cannot be resolved', async () => {
     expect(
-      await buildBehaviorSettingsUrl('https://app.lobu.com', 'unknown-org', 'a', 7)
+      await buildBehaviorSettingsUrl('https://app.lobu.com', 'unknown-org', 7)
     ).toBeNull();
   });
 
   it('returns null when any required piece is missing', async () => {
-    expect(await buildBehaviorSettingsUrl(undefined, 'org-1', 'a', 7)).toBeNull();
-    expect(await buildBehaviorSettingsUrl('https://x', undefined, 'a', 7)).toBeNull();
-    expect(await buildBehaviorSettingsUrl('https://x', 'org-1', undefined, 7)).toBeNull();
-    expect(await buildBehaviorSettingsUrl('https://x', 'org-1', 'a', undefined)).toBeNull();
+    expect(await buildBehaviorSettingsUrl(undefined, 'org-1', 7)).toBeNull();
+    expect(await buildBehaviorSettingsUrl('https://x', undefined, 7)).toBeNull();
+    expect(await buildBehaviorSettingsUrl('https://x', 'org-1', undefined)).toBeNull();
   });
 });
 
 describe('buildBehaviorUrl', () => {
   it('builds the canonical Behavior detail route and strips embedded /lobu', () => {
-    expect(buildBehaviorUrl('acme/team', 'agent one', 7, 'https://app.lobu.com/lobu')).toBe(
-      'https://app.lobu.com/acme%2Fteam/agents/agent%20one/behaviors/7'
+    expect(buildBehaviorUrl('acme/team', 7, 'https://app.lobu.com/lobu')).toBe(
+      'https://app.lobu.com/acme%2Fteam/behaviors/7'
     );
   });
 });

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -85,24 +85,22 @@ export async function buildAgentSettingsUrl(
  * {@link buildAgentSettingsUrl}: `?run_id=<id>` prefills the Behavior edit form
  * with the proposed change for Approve/Reject.
  *
- * A Behavior is owned by an agent (`watchers.agent_id`), so the route is nested
- * under that agent — the caller passes the owning agent id (from the current
- * Behavior row). Returns null when any required piece is missing; the producer
- * falls back to the run permalink.
+ * Behaviors live in the workspace-level Behaviors section (agent-owned and
+ * agentless alike), so no agent id is needed. Returns null when any required
+ * piece is missing; the producer falls back to the run permalink.
  */
 export async function buildBehaviorSettingsUrl(
   publicGatewayUrl: string | undefined,
   organizationId: string | undefined,
-  agentId: string | undefined,
   behaviorId: string | number | undefined,
   opts?: { runId?: number }
 ): Promise<string | null> {
-  if (!publicGatewayUrl || !organizationId || !agentId || behaviorId == null) {
+  if (!publicGatewayUrl || !organizationId || behaviorId == null) {
     return null;
   }
   const slug = await getOrganizationSlug(organizationId).catch(() => null);
   if (!slug) return null;
-  const base = buildBehaviorUrl(slug, agentId, behaviorId, publicGatewayUrl);
+  const base = buildBehaviorUrl(slug, behaviorId, publicGatewayUrl);
   return opts?.runId ? `${base}?run_id=${opts.runId}` : base;
 }
 
@@ -320,15 +318,14 @@ export function buildEntityUrl(info: EntityInfo, baseUrl?: string): string {
   return withBaseUrl(normalizeBaseUrl(baseUrl), `/${info.ownerSlug}/${segments.join('/')}`);
 }
 
-/** Build the canonical agent-owned Behavior detail URL. */
+/** Build the canonical Behavior detail URL (workspace-level Behaviors section). */
 export function buildBehaviorUrl(
   ownerSlug: string,
-  agentId: string,
   behaviorId: string | number,
   baseUrl?: string
 ): string {
   const webOrigin = normalizeBaseUrl(baseUrl)?.replace(/\/lobu$/, '');
-  const path = `/${encodeURIComponent(ownerSlug)}/agents/${encodeURIComponent(agentId)}/behaviors/${encodeURIComponent(String(behaviorId))}`;
+  const path = `/${encodeURIComponent(ownerSlug)}/behaviors/${encodeURIComponent(String(behaviorId))}`;
   return withBaseUrl(webOrigin, path);
 }
 

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
-	resolveTriggerExecutor,
+	resolveBehaviorExecutor,
 } from "../tools/admin/manage_behaviors/executors";
 import {
 	inferBehaviorGranularityFromSchedule,
@@ -240,27 +240,18 @@ async function enqueueWatcherRunForRecord(
 		throw new Error(`Behavior ${watcher.id} is not active.`);
 	}
 
-	// Executor resolution ("when -> who"): a schedule trigger's respond_with
-	// override wins, else the Behavior-level agent/device. Manual activations
-	// may legitimately resolve to nothing — the run stays pending for any
-	// connected MCP client to execute and complete.
-	const scheduleTrigger = (watcher.triggers ?? []).find(
-		(candidate): candidate is { respond_with?: unknown } =>
-			Boolean(candidate) &&
-			typeof candidate === "object" &&
-			(candidate as Record<string, unknown>).kind === "schedule",
-	);
-	const executor = resolveTriggerExecutor(
-		scheduleTrigger as { respond_with?: never } | undefined,
-		{
-			agentId: watcher.agent_id ?? null,
-			deviceWorkerId: watcher.device_worker_id ?? null,
-			agentKind: watcher.agent_kind ?? null,
-		},
-	);
+	// Executor resolution: a Behavior has exactly one executor (agent or
+	// device pin). Manual activations may legitimately resolve to nothing —
+	// the run stays pending for any connected MCP client to execute and
+	// complete.
+	const executor = resolveBehaviorExecutor({
+		agentId: watcher.agent_id ?? null,
+		deviceWorkerId: watcher.device_worker_id ?? null,
+		agentKind: watcher.agent_kind ?? null,
+	});
 	if (!executor && dispatchSource !== "manual") {
 		throw new Error(
-			`Behavior ${watcher.id} has no executor for ${dispatchSource} activation (need agent_id, device_worker_id, or a trigger respond_with).`
+			`Behavior ${watcher.id} has no executor for ${dispatchSource} activation (need agent_id or device_worker_id).`
 		);
 	}
 
@@ -279,15 +270,8 @@ async function enqueueWatcherRunForRecord(
 			windowStart: windowStart.toISOString(),
 			windowEnd: windowEnd.toISOString(),
 			dispatchSource,
-			// An explicit agent executor (e.g. a respond_with override on a
-			// device-pinned Behavior) must NOT inherit the row pin, or the run
-			// stays device-lane and the override is silently ignored.
 			deviceWorkerId:
-				executor == null
-					? (watcher.device_worker_id ?? null)
-					: executor.kind === "device"
-						? executor.deviceWorkerId
-						: null,
+				executor?.kind === "device" ? executor.deviceWorkerId : null,
 			agentKind:
 				executor?.kind === "device" ? executor.agentKind : null,
 			sourceFingerprint,

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "node:crypto";
 import {
+	resolveTriggerExecutor,
+} from "../tools/admin/manage_behaviors/executors";
+import {
 	inferBehaviorGranularityFromSchedule,
 	type BehaviorTimeGranularity,
 } from "@lobu/connector-sdk";
@@ -139,7 +142,6 @@ export function parseWatcherRunPayload(
 
 	if (
 		!Number.isFinite(watcherId) ||
-		!agentId ||
 		!windowStart ||
 		!windowEnd ||
 		(dispatchSource !== "scheduled" &&
@@ -174,7 +176,10 @@ export function parseWatcherRunPayload(
 
 	return {
 		watcher_id: watcherId,
-		agent_id: agentId,
+		// Optional: device-pinned runs carry only the pin, and manual-open
+		// runs carry neither. The dispatch guard below fails runs that reach
+		// the server lane without an agent.
+		agent_id: agentId || undefined,
 		window_start: windowStart,
 		window_end: windowEnd,
 		dispatch_source: dispatchSource,
@@ -235,8 +240,28 @@ async function enqueueWatcherRunForRecord(
 		throw new Error(`Behavior ${watcher.id} is not active.`);
 	}
 
-	if (!watcher.agent_id) {
-		throw new Error(`Behavior ${watcher.id} is not assigned to a Lobu agent.`);
+	// Executor resolution ("when -> who"): a schedule trigger's respond_with
+	// override wins, else the Behavior-level agent/device. Manual activations
+	// may legitimately resolve to nothing — the run stays pending for any
+	// connected MCP client to execute and complete.
+	const scheduleTrigger = (watcher.triggers ?? []).find(
+		(candidate): candidate is { respond_with?: unknown } =>
+			Boolean(candidate) &&
+			typeof candidate === "object" &&
+			(candidate as Record<string, unknown>).kind === "schedule",
+	);
+	const executor = resolveTriggerExecutor(
+		scheduleTrigger as { respond_with?: never } | undefined,
+		{
+			agentId: watcher.agent_id ?? null,
+			deviceWorkerId: watcher.device_worker_id ?? null,
+			agentKind: watcher.agent_kind ?? null,
+		},
+	);
+	if (!executor && dispatchSource !== "manual") {
+		throw new Error(
+			`Behavior ${watcher.id} has no executor for ${dispatchSource} activation (need agent_id, device_worker_id, or a trigger respond_with).`
+		);
 	}
 
 	const granularity = inferBehaviorGranularityFromSchedule(watcher.schedule);
@@ -250,12 +275,21 @@ async function enqueueWatcherRunForRecord(
 		{
 			organizationId: watcher.organization_id,
 			watcherId: watcher.id,
-			agentId: watcher.agent_id,
+			agentId: executor?.kind === "agent" ? executor.agentId : null,
 			windowStart: windowStart.toISOString(),
 			windowEnd: windowEnd.toISOString(),
 			dispatchSource,
-			deviceWorkerId: watcher.device_worker_id ?? null,
-			agentKind: watcher.agent_kind ?? null,
+			// An explicit agent executor (e.g. a respond_with override on a
+			// device-pinned Behavior) must NOT inherit the row pin, or the run
+			// stays device-lane and the override is silently ignored.
+			deviceWorkerId:
+				executor == null
+					? (watcher.device_worker_id ?? null)
+					: executor.kind === "device"
+						? executor.deviceWorkerId
+						: null,
+			agentKind:
+				executor?.kind === "device" ? executor.agentKind : null,
 			sourceFingerprint,
 		},
 		sql
@@ -1098,6 +1132,11 @@ async function claimWatcherRun(
           r.approved_input->>'device_worker_id' IS NULL
           OR r.approved_input->>'device_worker_id' = ''
         )
+        -- Runs with NO agent and NO device pin are manual-open: any connected
+        -- MCP client may execute and complete them (write-tier
+        -- complete_window). The server dispatcher must leave them pending.
+        AND r.approved_input->>'agent_id' IS NOT NULL
+        AND r.approved_input->>'agent_id' <> ''
         ${specificRunClause}
       ORDER BY r.created_at ASC
       FOR UPDATE SKIP LOCKED
@@ -1260,6 +1299,7 @@ async function dispatchWatcherRun(
 	}
 
 	if (
+		!payload.agent_id ||
 		!(await ensureWatcherAgentExists(
 			sql,
 			run.organization_id,
@@ -1269,7 +1309,9 @@ async function dispatchWatcherRun(
 		await failWatcherRun(
 			sql,
 			run.id,
-			`Assigned agent "${payload.agent_id}" does not exist in this organization.`
+			payload.agent_id
+				? `Assigned agent "${payload.agent_id}" does not exist in this organization.`
+				: "Behavior run has no assigned agent (device-pinned and manual-open runs do not dispatch server-side)."
 		);
 		return "failed";
 	}

--- a/packages/server/src/worker-api/behavior-trigger.ts
+++ b/packages/server/src/worker-api/behavior-trigger.ts
@@ -125,9 +125,6 @@ export async function triggerBehaviorForDevice(c: Context<{ Bindings: Env }>) {
   if ((watcher.status ?? 'active') !== 'active') {
     return c.json({ error: 'Behavior is not active' }, 409);
   }
-  if (!watcher.agent_id) {
-    return c.json({ error: 'Behavior has no agent assigned' }, 409);
-  }
 
   // Enqueue (or re-use) the run. `enqueueWatcherRunForWatcher` delegates to
   // `createWatcherRun`, which checks for an active run in the same watcher_id


### PR DESCRIPTION
## Summary
- Move Behaviors from agent-scoped to workspace-level, one first-class section.
- One executor per behavior: managed agent / device pin / manual-only. Executors are resolved and authorized at write time (create, update, clone) so no executor-less zombie can be created.
- Fix two review MAJORs: `create_from_version` clones now go through the executor matrix and copy the device pin; the UI edit path routes device-pin changes through `updateBehavior` (owletto submodule bump).
- Drop `watchers.agent_id NOT NULL` (new migration) because manual-only / device-only behaviors are now valid.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `watchers-crud.test.ts` 29/29 incl. new `create_from_version executor cloning` describe; unit 826 pass; owletto `create-behavior-form.test.tsx` + `behaviors-new-page.test.tsx` green
- [x] Bug fix red→fix→green: device-pin clone test fails when INSERT drops the pin mutation → passes with fix; owletto device-pin routing test fails on old path → passes
- [x] Migration applied to `lobu_test`; `is_nullable=YES`; format-check green

## Notes
- Also folds two pre-existing `useTemplate` lint fixes (`packages/cli/bin/lobu.js`, `examples/personal-agent/revolut-transactions.connector.ts`) — biome 2.4.13 flags them on `origin/main` itself, which blocked CI.
- Depends on owletto PR for the UI half of the MAJOR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Behaviors can run on pinned devices or remain manual-only without an assigned agent.
  * Added filtering by behavior run status.
  * Behavior cloning preserves device execution settings and trigger configuration.
  * Behavior links now use workspace-level URLs.
* **Bug Fixes**
  * Improved executor selection, validation, authorization, and run completion handling.
  * Manual runs can be safely claimed and completed without an assigned executor.
* **Access**
  * Members with write access can now trigger behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->