### PR TITLE
chore(client): regenerate generated types from the live OpenAPI

### DIFF
--- a/packages/client/src/generated/sdk.gen.ts
+++ b/packages/client/src/generated/sdk.gen.ts
@@ -389,7 +389,7 @@ export const manageCatalog = <ThrowOnError extends boolean = false>(
   });
 
 /**
- * Agent management (incl
+ * Agent management
  *
  * Agent management. SDK alternative: client.agents.
  */
@@ -667,7 +667,7 @@ export const manageViewTemplates = <ThrowOnError extends boolean = false>(
 /**
  * List organizations the authenticated user belongs to, plus any public workspaces the session can read
  *
- * List organizations the authenticated user belongs to, plus any public workspaces the session can read. SDK alternative: client.organizations.list via `query_sdk` / `run_sdk`.
+ * List organizations the authenticated user belongs to, plus any public workspaces the session can read. Managed connector providers include structured managed_auth onboarding metadata. SDK alternative: client.organizations.list via `query_sdk` / `run_sdk`.
  */
 export const listOrganizations = <ThrowOnError extends boolean = false>(
   options: Options<ListOrganizationsData, ThrowOnError>,

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1987,6 +1987,34 @@ export type ManageConnectionsData = {
       }
     | {
         /**
+         * Connect through a managed OAuth offer advertised by a public Lobu org. Validates the live offer, enrolls the signed-in user in that org, and returns a provider consent URL. The resulting cloud connection is private, consent-only, and has no feeds.
+         */
+        action: "connect_managed";
+        /**
+         * Public organization slug from organizations.list managed_auth metadata
+         */
+        managed_by_org: string;
+        /**
+         * Connector key advertised by that managed_auth offer
+         */
+        connector_key: string;
+        /**
+         * Human-readable name for the consent grant
+         */
+        display_name?: string;
+        /**
+         * Stable identifier for the consent grant
+         */
+        slug?: string;
+        /**
+         * Non-secret connection config, such as requested optional scopes
+         */
+        config?: {
+          [key: string]: unknown;
+        };
+      }
+    | {
+        /**
          * Patch a connection's settings, status, slug, device binding, or (chat connections) fallback agent.
          */
         action: "update";
@@ -2793,14 +2821,9 @@ export type ManageAgentsData = {
     /**
      * Action to perform
      */
-    action:
-      | "list"
-      | "get"
-      | "create"
-      | "update"
-      | "delete";
+    action: "list" | "get" | "create" | "update" | "delete";
     /**
-     * [get/create/update/delete] Agent ID (lowercase slug, e.g. "builder").
+     * [get/create/update/delete] Agent ID (lowercase slug, e.g. "support").
      */
     agent_id?: string;
     /**
@@ -4298,9 +4321,9 @@ export type ManageBehaviorsData = {
      */
     order_dir?: "asc" | "desc";
     /**
-     * [create/update/create_version] Optional MCP client ID that should auto-run this Behavior. Null clears it.
+     * [list] Filter by each Behavior's latest run status (active runs take precedence). Discovery for executors: run_status='pending' lists Behaviors with unhandled runs — manual-open pending runs are completable by any client via complete_window.
      */
-    scheduler_client_id?: string | null;
+    run_status?: "pending" | "claimed" | "running" | "completed" | "failed";
     /**
      * [create/update] Optional device worker UUID to pin this Behavior to (when its inputs live on that device). Null clears the pin.
      */
@@ -4805,6 +4828,7 @@ export type GetBehaviorResponses = {
       next_run_at?: string | null;
       agent_id?: string | null;
       device_worker_id?: string | null;
+      agent_kind?: string | null;
       scheduler_client_id?: string | null;
       version: number;
       sources: Array<{


### PR DESCRIPTION
## Summary
- The generated `@lobu/client` types had drifted from the server contract across several merges. Regenerated with `bun run generate` against a booted server on current `main` (`317323f70`). No hand edits.
- Surfaced drift from more than one PR — most notably `connect_managed` was missing from `manage_connections` entirely, so SDK consumers could not see that action at all.

### What changed
| Surface | Change |
| --- | --- |
| `ManageBehaviorsData` | `scheduler_client_id` (removed in #2499) → `run_status` filter |
| `GetBehaviorResponses` | adds `agent_kind` |
| `ManageConnectionsData` | adds the whole `connect_managed` action |
| `listOrganizations` | description now mentions `managed_auth` onboarding metadata |
| `manage_agents` | repairs a truncated description (`"Agent management (incl"`), updates the `agent_id` example |

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming), EXIT=0
- [x] Generated against a live booted server, not a checked-in spec snapshot: `LOBU_OPENAPI_URL=http://127.0.0.1:9291/lobu/api/docs/openapi.json bun run generate`
- [x] Diff contains only generator output — `git diff --name-only origin/main...HEAD` is exactly the two `src/generated/*` files

## Notes
- `scheduler_client_id` deliberately **survives** in `GetBehaviorResponses`. That is not client drift: `WatcherMetadataSchema` (`packages/server/src/types/watchers.ts:137`) still declares it, so the live OpenAPI still advertises it. But #2499 changed `get_behavior` to return `agent_kind` in its place, so the response schema now declares a field the handler never populates — a client reading `behavior.scheduler_client_id` gets `undefined` against a `string | null` type. That is a server contract fix, out of scope here.
- Nothing in CI enforces this file's freshness (`check-drift` passes with it stale), which is why it accumulated silently.