### PR TITLE
feat(server): retain declared literal args on generic audit rows

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -381,6 +381,20 @@ describe('tool invocation audit coverage', () => {
       'must-not-reach-the-audit-log'
     );
     expect(row!.payload_data.args_preview_redacted).toContain(REDACTED_SENTINEL);
+    // Audit fires on FAILED validation, so `action` here carries a value the
+    // schema never declared. Only DECLARED literals survive, so it must not.
+    expect(row!.payload_data.args_preview_redacted).not.toContain('nope');
+  });
+
+  it('retains the declared action discriminator against the real tool schema', async () => {
+    await executeTool('manage_connections', { action: 'list' }, {} as Env, authCtxFor('pat'));
+
+    const row = await latestAuditRow(orgId, 'manage_connections');
+    expect(row).not.toBeNull();
+    expect(row!.payload_data.success).toBe(true);
+    // `action: 'list'` is one of the tool's own compile-time literals, so it
+    // carries no caller content and is readable in the ledger.
+    expect(row!.payload_data.args_preview_redacted).toContain('"action":"list"');
   });
 
   it('args_sha256 is computed over SANITIZED args — a secret value cannot be verified against the hash', async () => {

--- a/packages/server/src/__tests__/unit/audit-arg-sanitizer.test.ts
+++ b/packages/server/src/__tests__/unit/audit-arg-sanitizer.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'bun:test';
+import { REDACTED_SENTINEL } from '@lobu/core';
+import { Type } from '@sinclair/typebox';
+import { sanitizeAuditArgs } from '../../tools/audit-args';
+
+/**
+ * Mirrors a real `manage_*` tool: `defineActionTool` derives `Type.Union` of
+ * per-action variants, each carrying an `action` literal. Built with TypeBox
+ * rather than hand-written JSON so the test also pins the serialized shape the
+ * sanitizer reads (`anyOf` + `const`).
+ */
+const ACTION_TOOL_SCHEMA = Type.Union([
+  Type.Object({
+    action: Type.Literal('list_available'),
+    connection_id: Type.Optional(Type.Number()),
+    limit: Type.Optional(Type.Number()),
+  }),
+  Type.Object({
+    action: Type.Literal('execute'),
+    operation_key: Type.String(),
+    input: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+    dry_run: Type.Optional(Type.Boolean()),
+  }),
+]);
+
+describe('sanitizeAuditArgs', () => {
+  it('retains a declared literal discriminator', () => {
+    expect(
+      sanitizeAuditArgs({ action: 'list_available', limit: 25 }, ACTION_TOOL_SCHEMA)
+    ).toEqual({ action: 'list_available', limit: REDACTED_SENTINEL });
+  });
+
+  it('retains the literal from any variant of the union', () => {
+    expect(
+      sanitizeAuditArgs({ action: 'execute', operation_key: 'navigate' }, ACTION_TOOL_SCHEMA)
+    ).toEqual({ action: 'execute', operation_key: REDACTED_SENTINEL });
+  });
+
+  it('sentinels a declared key whose value is not a declared literal', () => {
+    // Audit fires on FAILED validation too: `action` can arrive carrying
+    // arbitrary pasted text, which must never survive.
+    expect(sanitizeAuditArgs({ action: 'sk-live-abcdef123456' }, ACTION_TOOL_SCHEMA)).toEqual({
+      action: REDACTED_SENTINEL,
+    });
+  });
+
+  it('sentinels the NAME of a key the schema does not declare', () => {
+    expect(sanitizeAuditArgs({ authorization: 'Bearer abc' }, ACTION_TOOL_SCHEMA)).toEqual({
+      [REDACTED_SENTINEL]: REDACTED_SENTINEL,
+    });
+  });
+
+  it('keeps booleans and null, which are structural', () => {
+    expect(
+      sanitizeAuditArgs(
+        { action: 'execute', dry_run: true, input: null },
+        ACTION_TOOL_SCHEMA
+      )
+    ).toEqual({ action: 'execute', dry_run: true, input: null });
+  });
+
+  it('never retains a literal below the top level', () => {
+    // A nested object is caller-shaped even when a leaf happens to equal a
+    // declared constant, so both its keys and its values collapse.
+    expect(
+      sanitizeAuditArgs(
+        { action: 'execute', input: { action: 'execute', url: 'https://x.test' } },
+        ACTION_TOOL_SCHEMA
+      )
+    ).toEqual({
+      action: 'execute',
+      input: { [REDACTED_SENTINEL]: REDACTED_SENTINEL },
+    });
+  });
+
+  it('collapses a key to name-only when one union branch is open', () => {
+    const schema = Type.Object({
+      mode: Type.Union([Type.Literal('fast'), Type.String()]),
+      kind: Type.Union([Type.Literal('a'), Type.Literal('b')]),
+    });
+    expect(sanitizeAuditArgs({ mode: 'fast', kind: 'b' }, schema)).toEqual({
+      mode: REDACTED_SENTINEL,
+      kind: 'b',
+    });
+  });
+
+  it('honors a flat enum declaration', () => {
+    const schema = Type.Object({
+      action: Type.Unsafe<string>({ type: 'string', enum: ['list', 'get'] }),
+    });
+    expect(sanitizeAuditArgs({ action: 'list' }, schema)).toEqual({ action: 'list' });
+    expect(sanitizeAuditArgs({ action: 'drop table' }, schema)).toEqual({
+      action: REDACTED_SENTINEL,
+    });
+  });
+
+  it('sentinels every leaf when the tool has no schema', () => {
+    expect(sanitizeAuditArgs({ action: 'list_available' }, undefined)).toEqual({
+      [REDACTED_SENTINEL]: REDACTED_SENTINEL,
+    });
+  });
+
+  it('treats absent args as an empty call', () => {
+    // Reachable: the REST tool proxy passes `await c.req.json()` straight
+    // through, so a `null` body arrives here despite the declared type.
+    expect(sanitizeAuditArgs(null, ACTION_TOOL_SCHEMA)).toEqual({});
+    expect(sanitizeAuditArgs(undefined, ACTION_TOOL_SCHEMA)).toEqual({});
+  });
+
+  it('sanitizes array items without retaining their contents', () => {
+    const schema = Type.Object({ ids: Type.Array(Type.Number()) });
+    expect(sanitizeAuditArgs({ ids: [1, 2] }, schema)).toEqual({
+      ids: [REDACTED_SENTINEL, REDACTED_SENTINEL],
+    });
+  });
+});

--- a/packages/server/src/tools/audit-args.ts
+++ b/packages/server/src/tools/audit-args.ts
@@ -1,0 +1,144 @@
+/**
+ * Argument sanitizer behind the GENERIC audit summary fields (`args_sha256`,
+ * `args_preview_redacted`). `run_sdk` and `query_sql` build their own payloads
+ * and never reach it; every other tool does — including `query_sdk`, which is
+ * summarized here AND separately retains its verbatim request.
+ *
+ * Contract: a generic entry persists the SHAPE of a call plus the parts of it
+ * that are provably not caller content. Concretely, a leaf survives only when
+ *
+ *   - it is a boolean, null, or undefined (one bit / absence — structural), or
+ *   - it sits at the TOP level under a key the tool's own input schema
+ *     declares, AND the schema constrains that key to a closed set of literals
+ *     (`const` / `enum` / a union of them), AND the value is a member of that
+ *     set.
+ *
+ * The membership test is what makes the second case safe. Audit fires on
+ * FAILED validation too, so an `action`-typed key can arrive carrying arbitrary
+ * pasted text; comparing against the declared set means the retained value is
+ * always one of N compile-time constants from our own schema, never something
+ * the caller authored. A single non-literal branch anywhere in a key's schema
+ * (e.g. a bare `Type.String()` in one union variant) collapses that key back to
+ * name-only, because then no closed set exists to check against — as does any
+ * composition we do not parse, since every tool schema is TypeBox and TypeBox
+ * emits unions as `anyOf`.
+ *
+ * Everything else — free text, identifiers, numbers, nested objects — becomes
+ * the sentinel. Identifier-shaped secrets (`sk-live-…`) are indistinguishable
+ * from slugs, so no shape heuristic is applied. Repeated sentinel keys merge;
+ * that collapse is part of recording shape, not content.
+ */
+
+import { REDACTED_SENTINEL } from '@lobu/core';
+
+/** A closed set of declared literals, or null when the key is unconstrained. */
+type DeclaredValues = Set<string | number> | null;
+
+interface SchemaLike {
+  properties?: Record<string, unknown>;
+  anyOf?: unknown[];
+  const?: unknown;
+  enum?: unknown[];
+}
+
+function asSchema(value: unknown): SchemaLike | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as SchemaLike)
+    : null;
+}
+
+/** Literal kinds worth retaining. Booleans and null survive on their own path. */
+function isRetainableLiteral(value: unknown): value is string | number {
+  return typeof value === 'string' || typeof value === 'number';
+}
+
+/**
+ * The closed set of values a property schema allows, or null when it admits
+ * anything (a plain string/number/object, or a union with one such branch).
+ */
+function literalValues(schema: unknown): DeclaredValues {
+  const node = asSchema(schema);
+  if (!node) return null;
+  if (node.const !== undefined) {
+    return isRetainableLiteral(node.const) ? new Set([node.const]) : null;
+  }
+  if (Array.isArray(node.enum)) {
+    return node.enum.every(isRetainableLiteral)
+      ? new Set(node.enum as Array<string | number>)
+      : null;
+  }
+  const branches = node.anyOf;
+  if (!Array.isArray(branches) || branches.length === 0) return null;
+  const merged = new Set<string | number>();
+  for (const branch of branches) {
+    const values = literalValues(branch);
+    // One open branch means the key is not literal-constrained after all.
+    if (!values) return null;
+    for (const value of values) merged.add(value);
+  }
+  return merged;
+}
+
+/**
+ * Top-level keys the tool declares, mapped to their closed value set (null when
+ * unconstrained). Union-schema tools (`Type.Union` of per-action variants)
+ * expose their properties under `anyOf`, so variants are walked as well as the
+ * root; a key declared by several variants keeps the union of their literals,
+ * and drops to null the moment any variant leaves it open.
+ */
+function declaredArgShape(schema: unknown): Map<string, DeclaredValues> {
+  const shape = new Map<string, DeclaredValues>();
+  const root = asSchema(schema);
+  if (!root) return shape;
+  const variants = [root, ...(root.anyOf ?? []).map(asSchema)];
+  for (const variant of variants) {
+    if (!variant?.properties) continue;
+    for (const [key, propSchema] of Object.entries(variant.properties)) {
+      const values = literalValues(propSchema);
+      if (!shape.has(key)) {
+        shape.set(key, values);
+        continue;
+      }
+      const existing = shape.get(key);
+      if (existing == null || values == null) {
+        shape.set(key, null);
+        continue;
+      }
+      for (const value of values) existing.add(value);
+    }
+  }
+  return shape;
+}
+
+function sanitizeLeaves(
+  value: unknown,
+  shape: ReadonlyMap<string, DeclaredValues>,
+  topLevel: boolean
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeLeaves(item, shape, false));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => {
+        const declared = topLevel && shape.has(key);
+        const allowed = declared ? shape.get(key) : null;
+        const retained =
+          allowed && isRetainableLiteral(nested) && allowed.has(nested)
+            ? nested
+            : sanitizeLeaves(nested, shape, false);
+        return [declared ? key : REDACTED_SENTINEL, retained];
+      })
+    );
+  }
+  if (typeof value === 'boolean' || value === null || value === undefined) return value;
+  return REDACTED_SENTINEL;
+}
+
+/** Sanitize a generic tool call's args against the tool's own input schema. */
+export function sanitizeAuditArgs(
+  args: Record<string, unknown> | null | undefined,
+  schema: unknown
+): unknown {
+  return sanitizeLeaves(args ?? {}, declaredArgShape(schema), true);
+}

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -1,8 +1,8 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { REDACTED_SENTINEL } from '@lobu/core';
 import { currentMcpActivityEventMetadata } from '../lobu/stores/mcp-client-conversations';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
+import { sanitizeAuditArgs } from './audit-args';
 import { AUDIT_SEMANTIC_TYPE } from './constants';
 import { getTool, type ToolContext } from './registry';
 
@@ -76,50 +76,6 @@ function redactPreview(value: string): string {
   // Redact BEFORE truncating: slicing first can split a quoted credential and
   // the unbalanced quote defeats the pattern, leaking the visible fragment.
   return redactSensitiveText(value).slice(0, MAX_PREVIEW_CHARS);
-}
-
-/**
- * Generic audit summaries persist the SHAPE of a call, never its content.
- * Nothing caller-controlled survives: values are sentineled except
- * booleans/nulls (provably structural — one bit), and property NAMES are kept
- * only when the tool's own input schema declares them at the top level —
- * audit also fires on FAILED validation, so arbitrary pasted text can arrive
- * as a value of an enum-typed key or even AS a key, and identifier-shaped
- * secrets (`sk-live-…`) are indistinguishable from slugs. Repeated sentinel
- * keys merge; that collapse is part of recording shape, not content.
- */
-function schemaPropertyNames(toolName: string): Set<string> {
-  const schema = getTool(toolName)?.inputSchema as
-    | {
-        properties?: Record<string, unknown>;
-        anyOf?: Array<{ properties?: Record<string, unknown> } | undefined>;
-      }
-    | undefined;
-  const names = new Set<string>();
-  for (const props of [schema?.properties, ...(schema?.anyOf ?? []).map((v) => v?.properties)]) {
-    if (props) for (const key of Object.keys(props)) names.add(key);
-  }
-  return names;
-}
-
-function sanitizeArgLeaves(
-  value: unknown,
-  trustedKeys: ReadonlySet<string>,
-  topLevel: boolean
-): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => sanitizeArgLeaves(item, trustedKeys, false));
-  }
-  if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, nested]) => [
-        topLevel && trustedKeys.has(key) ? key : REDACTED_SENTINEL,
-        sanitizeArgLeaves(nested, trustedKeys, false),
-      ])
-    );
-  }
-  if (typeof value === 'boolean' || value === null || value === undefined) return value;
-  return REDACTED_SENTINEL;
 }
 
 function asObject(value: unknown): Record<string, unknown> {
@@ -225,14 +181,16 @@ function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown
   ) {
     return null;
   }
-  // The preview and hash are built from the SANITIZED args: every string leaf
-  // becomes the sentinel unless its key is a known structural discriminator.
-  // A raw or pattern-redacted serialization would persist free-text values
-  // (and an unsalted credential-derived digest) whenever a secret hides in a
-  // shape no pattern enumerates. These two fields record only the call shape;
-  // request-bearing tools additionally retain their exact args below.
+  // The preview and hash are built from the SANITIZED args: a leaf survives
+  // only when it is structural (boolean/null) or is a member of the closed
+  // literal set the tool's own schema declares for that top-level key — see
+  // `sanitizeAuditArgs`. A raw or pattern-redacted serialization would persist
+  // free-text values (and an unsalted credential-derived digest) whenever a
+  // secret hides in a shape no pattern enumerates. These two fields record the
+  // call shape and its declared discriminators; request-bearing tools
+  // additionally retain their exact args below.
   const sanitizedArgsJson = JSON.stringify(
-    sanitizeArgLeaves(params.args ?? {}, schemaPropertyNames(params.toolName), true)
+    sanitizeAuditArgs(params.args, getTool(params.toolName)?.inputSchema)
   );
   const reportedFailure =
     result.error != null ||


### PR DESCRIPTION
## What

Generic tool-invocation audit entries sentineled **every** value, so the highest-volume tools recorded nothing usable. Measured on prod (`buremba`, 54,092 rows):

```
manage_operations  {"limit":"__LOBU_REDACTED__","action":"__LOBU_REDACTED__"}
manage_connections {"action":"__LOBU_REDACTED__"}
```

A value that equals one of the tool schema's **own declared literals** is one of N compile-time constants — it cannot carry caller content. Those are now retained after an explicit membership check; everything else is unchanged.

The sanitizer moves to `packages/server/src/tools/audit-args.ts` (pure, schema-in/args-out) so it is unit-testable without the tool registry.

## Why the membership check, not the type

Audit fires on **FAILED** validation too, so an `action`-typed key can arrive carrying arbitrary pasted text. Trusting the declared *type* would persist it; comparing the value against the declared *set* cannot. A key with one open union branch (e.g. `Type.Union([Type.Literal('fast'), Type.String()])`) has no closed set and collapses back to name-only.

Unchanged: free text, identifiers, numbers, every nested leaf, and all key names that the schema does not declare.

## Evidence

New unit suite `audit-arg-sanitizer.test.ts` (11 tests, synthetic TypeBox schemas) + a new integration test against the **real** `manage_connections` schema.

Green:
```
$ bun test packages/server/src/__tests__/unit/audit-arg-sanitizer.test.ts
 11 pass  0 fail

$ bunx vitest run src/__tests__/integration/mcp/tool-invocation-audit.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

Mutation (`allowed && isRetainableLiteral(...)` → `false && ...`, i.e. revert to the old name-only behaviour):
```
unit:        4 pass | 6 fail
integration: 20 passed | 1 failed
  × retains the declared action discriminator against the real tool schema
```
Restored → green again.

`make pre-pr` clean (build, typecheck, knip, biome, naming, gateway-llm gates).

## Note for consumers

`args_sha256` semantics change for action-discriminated tools: previews that used to collide on the sentinel now differ by action.