### PR TITLE
fix(behaviors): list resolves org slug for org-scoped Behaviors

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -1212,5 +1212,40 @@ describe('watcher CRUD', () => {
         behavior_ids: [base.behavior_id, cloneId],
       });
     });
+
+    it('list resolves organization_slug and view_url for an ORG-SCOPED behavior (no entity)', async () => {
+      // The regression this guards: list projected `e.organization_id` from a
+      // LEFT JOIN on entities, so a Behavior with empty entity_ids — the common
+      // prod shape — carried a NULL org, which stranded the slug lookup and
+      // dropped BOTH organization_slug and view_url. Every earlier view_url
+      // assertion here passed only because it attached an entity_id.
+      const base = (await owner.behaviors.manage({
+        action: 'create',
+        slug: 'org-scoped-url-check',
+        name: 'Org Scoped URL Check',
+        prompt: 'Org-scoped, no entity.',
+        agent_id: agentId,
+      })) as { behavior_id: string };
+
+      const listed = (await owner.behaviors.manage({
+        action: 'list',
+      })) as {
+        behaviors?: Array<{
+          behavior_id?: string;
+          organization_slug?: string | null;
+          view_url?: string;
+          entity_id?: number | null;
+        }>;
+      };
+      const row = (listed.behaviors ?? []).find(
+        (b) => String(b.behavior_id) === String(base.behavior_id)
+      );
+      expect(row).toBeDefined();
+      expect(row?.entity_id ?? null).toBeNull();
+      expect(row?.organization_slug).toBeTruthy();
+      expect(row?.view_url).toContain(`/behaviors/${base.behavior_id}`);
+
+      await owner.behaviors.delete({ behavior_ids: [base.behavior_id] });
+    });
   });
 });

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -77,7 +77,12 @@ export async function handleList(
       et.slug AS entity_type,
       e.name as entity_name,
       e.slug as entity_slug,
-      e.organization_id,
+      -- The Behavior's OWN org, not the entity's. The entities join is a LEFT
+      -- JOIN, so an org-scoped Behavior (empty entity_ids — the common shape)
+      -- yielded NULL here, which stranded the slug lookup below and dropped
+      -- both organization_slug and view_url from every such row.
+      -- watchers.organization_id is NOT NULL, so this always resolves.
+      i.organization_id,
       parent.id as parent_id,
       parent.name as parent_name,
       parent.slug as parent_slug,


### PR DESCRIPTION
## Summary
- `handleList` projected `e.organization_id` — the **entity's** org, from a `LEFT JOIN entities`. A Behavior with empty `entity_ids` (org-scoped, the shape prod actually runs) carried a NULL org, which stranded the `getOrganizationSlug` lookup and dropped **both** `organization_slug` and `view_url` from every such row.
- The `WHERE` clause was always correctly scoped to `i.organization_id`; only the projection was wrong. `watchers.organization_id` is `NOT NULL`, so the fix always resolves.

Found while prod-verifying #2499. That PR made `view_url` work for agentless Behaviors, but the fix was **inert on the list path in prod** because of this older defect — the integration test added there passed only because its fixture attached an `entity_id`.

## Evidence from prod (before the fix)
`manage_behaviors list` on `buremba`, all 14 active Behaviors:
```
{"id":"78","agent":"lobu-guide","org":null}   <- organization_slug null, view_url absent
{"id":"77","agent":"lobu-guide","org":null}
{"id":"76","agent":"lobu-builder","org":null}
```
`get_behavior` on the same row, same deploy — correct, because `get_behavior.ts:555` already selects `i.organization_id`:
```
view_url: https://app.lobu.ai/buremba/behaviors/78
```
DB confirms the data was never the problem:
```
 id | organization_id                      | slug
 78 | 8dc12bdd-5d8c-4768-a2e9-a18005cc5ebd | buremba
```

## Test plan
Red → green on a NEW test that creates an **org-scoped** Behavior (no `entity_id`) — the case the existing assertions structurally could not catch.

**Red** (with `e.organization_id` restored):
```
× list resolves organization_slug and view_url for an ORG-SCOPED behavior (no entity)
AssertionError: expected null to be truthy
  Tests  1 failed | 29 skipped (30)
```
**Green** (with `i.organization_id`):
```
✓ src/__tests__/integration/watchers/watchers-crud.test.ts (30 tests)
  Test Files  1 passed (1)
       Tests  30 passed (30)
```
- [x] Full `watchers-crud.test.ts` 30/30 against real Postgres
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming), EXIT=0

## Notes
- Grepped the class: `get_behavior.ts:555` already uses `i.organization_id`; every other `e.organization_id` in `packages/server/src` is a JOIN/WHERE predicate on a genuine entity query, not a misprojection. `list.ts` was the only instance.
- Prod-verify owed after rollout: re-run the same `manage_behaviors list` check and confirm `organization_slug` and `view_url` are populated.