### PR TITLE
fix(behaviors): drop scheduler_client_id from the get_behavior response

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4829,7 +4829,6 @@ export type GetBehaviorResponses = {
       agent_id?: string | null;
       device_worker_id?: string | null;
       agent_kind?: string | null;
-      scheduler_client_id?: string | null;
       version: number;
       sources: Array<{
         name: string;

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -134,7 +134,6 @@ export const WatcherMetadataSchema = Type.Object({
   device_worker_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   /** Preferred local agent runtime on the pinned device; null = device default. */
   agent_kind: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-  scheduler_client_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   version: Type.Integer(),
   sources: Type.Array(WatcherSourceSchema),
   prompt: Type.Optional(Type.String()),

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -196,6 +196,14 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
       'last_repair_at',
       'last_repair_post_hash',
     ]),
+    // scheduler_client_id: retired with the Behavior scheduler rework in #2499,
+    // which stopped writing it and replaced it with agent_kind on the read path.
+    // Prod has it NULL on every row. Schema exposure is removed ahead of the
+    // two-phase column drop, so the physical column outlives its
+    // QUERYABLE_SCHEMA entry until the phase-2 migration.
+    // Keyed by the QUERYABLE_SCHEMA entry name (`behaviors`), not the physical
+    // table (`watchers`) — this map is indexed by `t.name` from that schema.
+    behaviors: new Set(['scheduler_client_id']),
     user: new Set(['email', 'phoneNumber', 'phoneNumberVerified']),
   };
 

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -458,7 +458,6 @@ export const QUERYABLE_SCHEMA = {
         'triggers',
         'next_run_at',
         'agent_id',
-        'scheduler_client_id',
         'model_config',
         'execution_config',
         'status',


### PR DESCRIPTION
## Summary
`WatcherMetadataSchema` declared `scheduler_client_id`, but #2499 changed `get_behavior` to select `agent_kind` in its place. The response contract promised `string | null` and delivered `undefined` on every call.

This also withdraws the column from `QUERYABLE_SCHEMA`'s agent-facing `behaviors` view, since an always-`NULL` column is noise in a `query_sql` surface.

## Why this is safe to delete rather than repair
- **Unpopulatable.** `scheduler_client_id` was removed from the `manage_behaviors` write contract in #2499, so nothing can set it again.
- **Unpopulated.** Prod, re-verified directly against the DB (not inherited from an earlier claim):
  ```
  SELECT count(*) FILTER (WHERE scheduler_client_id IS NOT NULL), count(*) FROM watchers;
  0 | 78
  ```
- **Unreferenced.** No hits in `packages/owletto/src`, `packages/cli`, `packages/agent-worker`, or `packages/connectors` (checked against `origin/main`, not just the working tree).

## Deliberately NOT in this PR
- The physical `watchers.scheduler_client_id` column — dropping it needs a migration and buys nothing while it is inert. It is declared `INTENTIONALLY_OMITTED` instead, following the convention already set by `connector_definitions.default_repair_agent_id`: schema exposure is withdrawn ahead of the two-phase column drop, so the physical column outlives its `QUERYABLE_SCHEMA` entry until the phase-2 migration.

## Red → green

**Red** (CI on this branch, before the fix):
```
FAIL src/utils/__tests__/table-schema.test.ts
  > QUERYABLE_SCHEMA vs database (drift detection)
  > should have every DB column listed in the schema (or intentionally omitted)
AssertionError: DB columns missing from QUERYABLE_SCHEMA:
  behaviors.scheduler_client_id
```

**Green** (local, after declaring the omission):
```
 ✓ src/utils/__tests__/table-schema.test.ts (19 tests) 82ms
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

**Mutation proof.** The map is indexed by `t.name` from `QUERYABLE_SCHEMA`, which is the *view* name `behaviors`, not the physical table `watchers`. Keying the entry on `watchers` compiles, reads plausibly, and does nothing — the test still failed with the identical message. That wrong-key run is the evidence this entry is load-bearing rather than decorative.

## Test plan
- [x] `bunx vitest run src/utils/__tests__/table-schema.test.ts` — 19/19
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming + gateway-llm)