### PR TITLE
feat(server): surface a retained tool request from the activity UI

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/tool-invocation-audit.test.ts
@@ -176,10 +176,11 @@ describe('tool invocation audit coverage', () => {
       userId: 'another-user',
       memberRole: 'member',
     });
-    // A non-author member gets neither the request nor the marker that one exists.
+    // A non-author member gets no request and no size — only the retention
+    // outcome, which names what the ledger did rather than any part of the call.
     expect(memberPayload).not.toHaveProperty('request');
-    expect(memberPayload).not.toHaveProperty('request_status');
     expect(memberPayload).not.toHaveProperty('request_bytes');
+    expect(memberPayload.request_status).toBe('complete');
 
     const adminPayload = await readAuditEvent(eventId, {
       ...authCtxFor('session'),
@@ -212,8 +213,11 @@ describe('tool invocation audit coverage', () => {
     const listed = result.content.find((item) => String(item.id) === String(row!.id));
     expect(listed).toBeDefined();
     expect(listed!.payload_data).not.toHaveProperty('request');
-    expect(listed!.payload_data).not.toHaveProperty('request_status');
     expect(listed!.payload_data).not.toHaveProperty('request_bytes');
+    // `request_status` DOES survive a list read: it is the only signal a card
+    // has that a body exists to open, and without it the UI cannot offer any
+    // route to the exact-id read that serves one (to the author or an admin).
+    expect(listed!.payload_data.request_status).toBe('complete');
   });
 
   it('restores every copy when an exact read contains duplicate event ids', async () => {

--- a/packages/server/src/tools/get_content/render.ts
+++ b/packages/server/src/tools/get_content/render.ts
@@ -16,8 +16,15 @@ import { AUDIT_SEMANTIC_TYPE } from '../constants';
 import type { ContentRow } from './types';
 import { parseRecordArray, toNumberOrUndefined } from './types';
 
-/** Payload keys a tool-invocation audit row carries about its request. */
-const AUDIT_REQUEST_KEYS = ['request', 'request_status', 'request_bytes'] as const;
+/**
+ * Gated payload keys: the request itself and its size. `request_status` is
+ * deliberately NOT here — it names a retention outcome
+ * (`complete`/`too_large`/`unavailable`) rather than any part of the call, and
+ * a list row must keep it so the UI can tell that a body exists to open. With
+ * it stripped, the only affordance for reading a request was a hand-written
+ * URL: nothing in the app could know which rows had one.
+ */
+const AUDIT_REQUEST_KEYS = ['request', 'request_bytes'] as const;
 
 /**
  * A tool-invocation audit row retains the caller's VERBATIM request (see


### PR DESCRIPTION
Pairs with owletto#723 (pointer bumped in this PR).

## What

A tool-invocation audit row stores the caller's verbatim `request`, served **only** on an exact-id read (`?content_ids=N`) and **only** to its author or a workspace admin. That part is unchanged.

The problem was reachability: list reads stripped `request_status` alongside `request`, so no card could tell that a body existed, and audit rows carry no `run_id` so their cards were inert. The only route to the read that serves a request was a hand-written URL — the stored bodies had no in-app route at all.

- `render.ts`: `request_status` no longer gated. It names a **retention outcome** (`complete`/`too_large`/`unavailable`), not any part of the call. `request` and `request_bytes` stay gated exactly as before.
- owletto#723: a row whose `request_status` is `complete` peeks by `content_ids`. `too_large`/`unavailable` have no stored body and stay inert (they already explain themselves inline).

## Evidence

`bunx vitest run src/__tests__/integration/mcp/tool-invocation-audit.test.ts` → **21 passed**.
`bunx vitest run src/components/entity-tabs/events-tab/event-card-peek.test.tsx` → **9 passed**.

Mutation, server (put `request_status` back in `AUDIT_REQUEST_KEYS`):
```
× keeps the request on the event but exposes it only through the authorized event read path
× does not inline exact requests into audit list results
  Tests  2 failed | 19 passed (21)
```
Mutation, owletto (disable the `content_ids` arm of `peekHref`):
```
× opens a runless audit row by content_ids, the only read that serves the request
  Tests  1 failed | 8 passed (9)
```
Both restored → green.

`make pre-pr` clean. `make review-fix` (Fable) found and fixed a real defect in the first draft: the peek gated on `request_status != null`, which would have made `too_large`/`unavailable` rows clickable with nothing to open; narrowed to `=== "complete"` with a test pinning both inert statuses.

Gate behaviour is unchanged and still pinned both ways (`tool-invocation-audit.test.ts:174-195`): non-author `member` → request withheld; non-author `admin` → request restored.

## Owed

Before/after screenshots for `make ui-review`. Capture was set up (local backend on the worktree DB, seeded from the integration fixtures, frontend proxied to it) but the paired Chrome extension went offline mid-capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Audit event and list views now consistently display whether a request is complete.
  - Request contents and raw request data remain hidden unless access is authorized.
  - Improved consistency between individual audit-event reads and audit-list results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->