### PR TITLE
feat(behaviors): tell a completer when its payload was discarded

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -1009,6 +1009,76 @@ describe("watcher automation contract", () => {
 			expect(second.skipped_reason).toBe("already_completed");
 		});
 
+		// The open manual lane has ONE pending run that every client races for, so
+		// both racers carry the SAME run id while having DIFFERENT client ids.
+		// Client identity must outrank the run, or the loser is reported as a
+		// self-replay in exactly the case this signal exists for.
+		it("prefers client identity over the shared run id when clients race one run", async () => {
+			const { api, watcherId } = await createAutomatedWatcher();
+			const sql = getTestDb();
+			for (const id of ["race-client-a", "race-client-b"]) {
+				await sql`
+					INSERT INTO oauth_clients (id, client_id_issued_at, redirect_uris, client_name)
+					VALUES (${id}, NOW(), ARRAY['https://example.test/cb'], ${id})
+					ON CONFLICT (id) DO NOTHING
+				`;
+			}
+			// events.run_id is FK'd to runs, so the shared run must really exist.
+			// Inserted directly: `trigger` needs the embedded gateway, which this
+			// harness does not boot.
+			const [orgRow] = await sql<{ organization_id: string }[]>`
+				SELECT organization_id FROM watchers WHERE id = ${watcherId}
+			`;
+			const [runRow] = await sql<{ id: number }[]>`
+				INSERT INTO runs
+					(organization_id, run_type, watcher_id, status, approval_status, created_at)
+				VALUES
+					(${orgRow.organization_id}, 'behavior', ${watcherId}, 'running', 'auto', current_timestamp)
+				RETURNING id
+			`;
+			const sharedRunId = Number(runRow.id);
+			expect(sharedRunId).toBeGreaterThan(0);
+
+			const windowStart = new Date(
+				Date.now() - 4 * 60 * 60 * 1000
+			).toISOString();
+			const windowEnd = new Date().toISOString();
+			const env = { JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env;
+			const mint = () =>
+				generateWindowToken(
+					{
+						watcher_id: watcherId,
+						window_start: windowStart,
+						window_end: windowEnd,
+						granularity: "daily",
+						content_count: 0,
+						content_ids: [],
+					},
+					env
+				);
+
+			const winner = (await api.behaviors.completeWindow({
+				behavior_id: String(watcherId),
+				window_token: await mint(),
+				extracted_data: { summary: "winner" },
+				client_id: "race-client-a",
+				behavior_run_id: sharedRunId,
+			})) as { window_id: number; skipped_reason?: string };
+			expect(winner.skipped_reason).toBeUndefined();
+
+			// Same run, different client. Ranking sameRun first would call this a
+			// self-replay; it is another client losing the race.
+			const loser = (await api.behaviors.completeWindow({
+				behavior_id: String(watcherId),
+				window_token: await mint(),
+				extracted_data: { summary: "loser" },
+				client_id: "race-client-b",
+				behavior_run_id: sharedRunId,
+			})) as { window_id: number; skipped_reason?: string };
+			expect(loser.window_id).toBe(winner.window_id);
+			expect(loser.skipped_reason).toBe("completed_by_other_client");
+		});
+
 		// Fail closed: the agent exiting cleanly WITHOUT calling complete_window
 		// means no real work was recorded — the run must fail (and the schedule
 		// advance), mirroring the server-side dispatch guard. This is exactly

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -894,6 +894,121 @@ describe("watcher automation contract", () => {
 			expect(replaced.reaction_status).not.toBe("skipped");
 		});
 
+		// A completion that lands on an existing head WITHOUT replace_existing
+		// silently discards the caller's payload. Replaying your own completion
+		// and losing the window to another MCP client produce identical responses,
+		// so a client that did real work cannot tell its output was dropped.
+		// skipped_reason names which case it was.
+		it("reports skipped_reason when a completion is discarded onto an existing head", async () => {
+			const { api, watcherId } = await createAutomatedWatcher();
+			const windowStart = new Date(
+				Date.now() - 2 * 60 * 60 * 1000
+			).toISOString();
+			const windowEnd = new Date().toISOString();
+			const env = { JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env;
+			const mint = () =>
+				generateWindowToken(
+					{
+						watcher_id: watcherId,
+						window_start: windowStart,
+						window_end: windowEnd,
+						granularity: "daily",
+						content_count: 0,
+						content_ids: [],
+					},
+					env
+				);
+
+			// events.client_id is FK'd to oauth_clients, so an unregistered id is
+			// stored as NULL and attribution silently degrades. Register both
+			// clients so the attributed branches are actually exercised — without
+			// these rows the assertions below pass only as 'already_completed'.
+			const sql = getTestDb();
+			for (const id of ["mcp-client-a", "mcp-client-b"]) {
+				await sql`
+					INSERT INTO oauth_clients (id, client_id_issued_at, redirect_uris, client_name)
+					VALUES (${id}, NOW(), ARRAY['https://example.test/cb'], ${id})
+					ON CONFLICT (id) DO NOTHING
+				`;
+			}
+
+			const first = (await api.behaviors.completeWindow({
+				behavior_id: String(watcherId),
+				window_token: await mint(),
+				extracted_data: { summary: "v1" },
+				client_id: "mcp-client-a",
+			})) as { window_id: number; skipped_reason?: string };
+			// The write that actually stored a payload carries no skip reason.
+			expect(first.skipped_reason).toBeUndefined();
+
+			// Same client → a harmless replay of its own completion.
+			const replay = (await api.behaviors.completeWindow({
+				behavior_id: String(watcherId),
+				window_token: await mint(),
+				extracted_data: { summary: "v2 discarded" },
+				client_id: "mcp-client-a",
+			})) as {
+				window_id: number;
+				window_created: boolean;
+				skipped_reason?: string;
+			};
+			expect(replay.window_id).toBe(first.window_id);
+			expect(replay.window_created).toBe(false);
+			expect(replay.skipped_reason).toBe("replayed_own_completion");
+
+			// A different MCP client hitting the same window is the case worth
+			// distinguishing: its payload is dropped even though it did the work.
+			const other = (await api.behaviors.completeWindow({
+				behavior_id: String(watcherId),
+				window_token: await mint(),
+				extracted_data: { summary: "v3 from another client" },
+				client_id: "mcp-client-b",
+			})) as { window_id: number; skipped_reason?: string };
+			expect(other.window_id).toBe(first.window_id);
+			expect(other.skipped_reason).toBe("completed_by_other_client");
+		});
+
+		// Attribution degrades honestly. A caller with no registered client id
+		// (PAT / device — events.client_id ends up NULL) still learns its payload
+		// was dropped, but the response must NOT claim another client wrote the
+		// head. Guessing 'completed_by_other_client' here would fire on every
+		// ordinary unattributed replay and make the field useless.
+		it("reports already_completed when the head writer cannot be attributed", async () => {
+			const { api, watcherId } = await createAutomatedWatcher();
+			const windowStart = new Date(
+				Date.now() - 3 * 60 * 60 * 1000
+			).toISOString();
+			const windowEnd = new Date().toISOString();
+			const env = { JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env;
+			const mint = () =>
+				generateWindowToken(
+					{
+						watcher_id: watcherId,
+						window_start: windowStart,
+						window_end: windowEnd,
+						granularity: "daily",
+						content_count: 0,
+						content_ids: [],
+					},
+					env
+				);
+
+			const first = (await api.behaviors.completeWindow({
+				behavior_id: String(watcherId),
+				window_token: await mint(),
+				extracted_data: { summary: "v1" },
+			})) as { window_id: number; skipped_reason?: string };
+			expect(first.skipped_reason).toBeUndefined();
+
+			const second = (await api.behaviors.completeWindow({
+				behavior_id: String(watcherId),
+				window_token: await mint(),
+				extracted_data: { summary: "v2 discarded" },
+			})) as { window_id: number; skipped_reason?: string };
+			expect(second.window_id).toBe(first.window_id);
+			expect(second.skipped_reason).toBe("already_completed");
+		});
+
 		// Fail closed: the agent exiting cleanly WITHOUT calling complete_window
 		// means no real work was recorded — the run must fail (and the schedule
 		// advance), mirroring the server-side dispatch guard. This is exactly

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -503,19 +503,25 @@ export async function handleCompleteWindow(
       // differ — otherwise say plainly that the payload was dropped without
       // guessing who wrote the head. Guessing 'other client' on absent ids
       // would fire on every ordinary replay.
+      // Client identity OUTRANKS run identity, and the order matters. A
+      // manual-open Behavior has ONE pending run that every client races for,
+      // so two different clients completing it both carry the same run id.
+      // Ranking the run first would report the loser as a self-replay in
+      // precisely the scenario this signal exists for. The run is only a
+      // fallback for callers with no registered client id.
       const bothClients =
         existingHead.clientId != null && provenanceClientId != null;
       const bothRuns = existingHead.runId != null && watcherRunId != null;
-      const sameClient =
-        bothClients && existingHead.clientId === provenanceClientId;
-      const sameRun = bothRuns && existingHead.runId === watcherRunId;
-      const differentClient =
-        bothClients && existingHead.clientId !== provenanceClientId;
-      const differentRun = bothRuns && existingHead.runId !== watcherRunId;
-      if (sameClient || sameRun) {
-        skippedReason = 'replayed_own_completion';
-      } else if (differentClient || differentRun) {
-        skippedReason = 'completed_by_other_client';
+      if (bothClients) {
+        skippedReason =
+          existingHead.clientId === provenanceClientId
+            ? 'replayed_own_completion'
+            : 'completed_by_other_client';
+      } else if (bothRuns) {
+        skippedReason =
+          existingHead.runId === watcherRunId
+            ? 'replayed_own_completion'
+            : 'completed_by_other_client';
       } else {
         skippedReason = 'already_completed';
       }

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -83,6 +83,19 @@ export async function handleCompleteWindow(
   /** True when replace_existing superseded the head — the canvas changed, so
    *  reactions fire and the schedule advances like a fresh completion. */
   head_superseded: boolean;
+  /** Set only when the submitted payload was NOT stored because a head already
+   *  existed and `replace_existing` was not requested — otherwise this response
+   *  is indistinguishable from a successful write. Retry with
+   *  `replace_existing: true` to overwrite deliberately.
+   *
+   *  Attribution is best-effort: `already_completed` means the payload was
+   *  dropped but the writer could not be identified (events.client_id is FK'd
+   *  to oauth_clients, so PAT/device callers store NULL, and a manual-open
+   *  window may carry no run id). It is NOT a weaker form of the other two. */
+  skipped_reason?:
+    | 'replayed_own_completion'
+    | 'completed_by_other_client'
+    | 'already_completed';
   reaction_status: 'success' | 'failed' | 'skipped';
   reaction_error?: string;
 }> {
@@ -429,6 +442,11 @@ export async function handleCompleteWindow(
     let canvasRevisionId!: number;
     let windowCreated = false;
     let headSuperseded = false;
+    let skippedReason:
+      | 'replayed_own_completion'
+      | 'completed_by_other_client'
+      | 'already_completed'
+      | undefined;
     const canvasEntityId = await ensureCanvasEntity({
       tx,
       watcherId: Number(watcherId),
@@ -470,6 +488,37 @@ export async function handleCompleteWindow(
       // window identity is the existing chain root.
       windowId = existingHead.rootEventId;
       canvasRevisionId = existingHead.id;
+      // The caller's payload is DISCARDED here. Replaying your own completion
+      // and losing a race to another MCP client are indistinguishable from the
+      // outside — both just return the existing window — so a client that did
+      // real work has no way to know its output was dropped. Name which case
+      // this was so it can be logged or retried with replace_existing.
+      // Manual-open Behaviors (no agent, no device pin) are the shape where a
+      // second client can legitimately show up: the run pends for whoever
+      // claims it first.
+      // Attribution is best-effort and often UNAVAILABLE: events.client_id has
+      // an FK to oauth_clients, so `canvasClientId` above nulls out for PAT and
+      // device callers, and a manual-open window may carry no run id. Only
+      // claim a verdict backed by two present ids that actually match or
+      // differ — otherwise say plainly that the payload was dropped without
+      // guessing who wrote the head. Guessing 'other client' on absent ids
+      // would fire on every ordinary replay.
+      const bothClients =
+        existingHead.clientId != null && provenanceClientId != null;
+      const bothRuns = existingHead.runId != null && watcherRunId != null;
+      const sameClient =
+        bothClients && existingHead.clientId === provenanceClientId;
+      const sameRun = bothRuns && existingHead.runId === watcherRunId;
+      const differentClient =
+        bothClients && existingHead.clientId !== provenanceClientId;
+      const differentRun = bothRuns && existingHead.runId !== watcherRunId;
+      if (sameClient || sameRun) {
+        skippedReason = 'replayed_own_completion';
+      } else if (differentClient || differentRun) {
+        skippedReason = 'completed_by_other_client';
+      } else {
+        skippedReason = 'already_completed';
+      }
     } else if (existingHead && args.replace_existing) {
       // Supersede the current head, copying the root's period metadata. Loser of
       // a concurrent supersede hits idx_events_superseded_by → 23505 → 409. The
@@ -769,6 +818,7 @@ export async function handleCompleteWindow(
       content_linked: batchContentIds.length,
       window_created: windowCreated,
       head_superseded: headSuperseded,
+      ...(skippedReason ? { skipped_reason: skippedReason } : {}),
     };
   });
 

--- a/packages/server/src/utils/canvas-events.ts
+++ b/packages/server/src/utils/canvas-events.ts
@@ -196,9 +196,25 @@ export async function ensureCanvasEntity(params: {
 export async function findCanvasHead(
   tx: DbClient,
   period: { watcherId: number; granularity: string; windowStart: string }
-): Promise<{ id: number; rootEventId: number; payloadData: Record<string, unknown> } | null> {
-  const rows = await tx<{ id: number | string; root_event_id: number | string | null; payload_data: unknown }>`
-    SELECT e.id, (e.metadata->>'root_event_id')::bigint AS root_event_id, e.payload_data
+): Promise<{
+  id: number;
+  rootEventId: number;
+  payloadData: Record<string, unknown>;
+  /** Who wrote the current head. Lets a caller tell "I am replaying my own
+   * completion" from "another client already answered this window", which are
+   * otherwise indistinguishable — both just skip the write. */
+  clientId: string | null;
+  runId: number | null;
+} | null> {
+  const rows = await tx<{
+    id: number | string;
+    root_event_id: number | string | null;
+    payload_data: unknown;
+    client_id: string | null;
+    run_id: number | string | null;
+  }>`
+    SELECT e.id, (e.metadata->>'root_event_id')::bigint AS root_event_id, e.payload_data,
+           e.client_id, e.run_id
     FROM events e
     WHERE e.semantic_type = 'canvas_state'
       AND (e.metadata->>'watcher_id')::bigint = ${period.watcherId}
@@ -214,5 +230,11 @@ export async function findCanvasHead(
     rows[0].payload_data && typeof rows[0].payload_data === 'object'
       ? (rows[0].payload_data as Record<string, unknown>)
       : {};
-  return { id, rootEventId, payloadData };
+  return {
+    id,
+    rootEventId,
+    payloadData,
+    clientId: rows[0].client_id ?? null,
+    runId: rows[0].run_id != null ? Number(rows[0].run_id) : null,
+  };
 }


### PR DESCRIPTION
## Summary
`complete_window` silently drops the caller's payload when a head already exists and `replace_existing` was not requested. Replaying your own completion and losing the window to another MCP client returned **identical** responses, so a client that ran a model and produced real output had no way to know it was dropped.

Adds an optional `skipped_reason` to the response. Purely additive — no change to `window_created`, `head_superseded`, or the data model, and **no per-client canvas fork**: the chain stays keyed on `(watcher_id, granularity, window_start)`.

```ts
skipped_reason?: 'replayed_own_completion' | 'completed_by_other_client' | 'already_completed'
```

Set only in the discard branch; absent when the payload was written.

## Attribution degrades honestly — this is the subtle part
`events.client_id` is FK'd to `oauth_clients`, so `complete-window.ts:452-457` nulls any unregistered id: **PAT and device callers store NULL**, and a manual-open window may carry no run id. So in many real calls neither side has an identity.

A verdict is therefore claimed only when two *present* ids match or differ; otherwise the response is `already_completed`, meaning "dropped, writer unknown" rather than a guess.

My first version defaulted to `completed_by_other_client` on any mismatch. The test caught it immediately (`expected 'completed_by_other_client' to be 'replayed_own_completion'`) — it would have fired on every ordinary unattributed replay and made the field actively misleading.

## Test plan
Two tests in `automation-contract.test.ts`, both mutation-proven.

- Attributed: registers `mcp-client-a`/`mcp-client-b` in `oauth_clients` so the attributed branches genuinely exercise. **Without those rows they silently pass as `already_completed`** — the exact false-green this PR is about.
- Unattributed: no registered client → `already_completed`, and specifically NOT `completed_by_other_client`.

**Mutation** (collapse the branch to a constant `skippedReason = 'already_completed'`):
```
× reports skipped_reason when a completion is discarded onto an existing head
AssertionError: expected 'already_completed' to be 'replayed_own_completion'
  Tests  1 failed | 1 passed | 45 skipped (47)
```
**Restored:**
```
Test Files  1 passed (1)
     Tests  47 passed (47)
```
- [x] `make pre-pr` clean, EXIT=0

## Notes
- Context: `manage_behaviors trigger` moved to member-write tier in #2499 and manual-only Behaviors are open to any connected client, so multiple clients answering one window is newly reachable.
- Deliberately NOT included: per-client canvas state. Forking the chain per client would break "what is the state of this window" for every reader (UI, `get_behavior`, reaction scripts, declared outputs) to fix a conflict that only exists because two clients did the same job.
- `findCanvasHead` gains `clientId`/`runId`; the other caller (`feedback.ts:269`) ignores the added fields.