### PR TITLE
fix(server): bound every event source by limit, not just the primary

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/behavior-mode-source-limit.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/behavior-mode-source-limit.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Behavior-mode `limit` must bound EVERY event source, not just the primary one.
+ *
+ * `queryContentData` builds its page descriptor with a hardcoded
+ * `sourceName: 'content'`, and `wrapQuery` used to apply the LIMIT only when
+ * `sourceName === page.sourceName`. Every other event source therefore ran
+ * unbounded — and all of them are returned to the caller under `sources`. So a
+ * Behavior with more than one source ignored `limit` entirely: the caller asked
+ * for 2 rows and got the whole window back on the secondary source.
+ *
+ * That is what made Behavior 5 unreadable in prod. The sandbox counts every SDK
+ * result as it crosses the isolate boundary, so an unbounded `sources` blob blew
+ * the output cap before the script could filter anything — `limit: 1` and
+ * `limit: 5` failed identically.
+ *
+ * The guard: seed more rows than the limit into two distinct feeds, ask for
+ * fewer, and require BOTH sources to be capped and to report their truncation
+ * through `sources_page`.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestConnection,
+	createTestEntity,
+	createTestEvent,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+import { TestApiClient } from "../../setup/test-mcp-client";
+
+/** Rows seeded per feed. Must exceed PAGE_LIMIT so truncation is observable. */
+const ROWS_PER_FEED = 3;
+/** What the caller asks for. Below ROWS_PER_FEED on purpose. */
+const PAGE_LIMIT = 2;
+
+describe("behavior-mode limit bounds every event source", () => {
+	let owner: TestApiClient;
+	let orgId: string;
+	let agentId: string;
+	let entityId: number;
+	let primaryFeedId: number;
+	let secondaryFeedId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "Source Limit Org" });
+		orgId = org.id;
+		const user = await createTestUser({ email: "source-limit@test.com" });
+		await addUserToOrganization(user.id, org.id, "owner");
+		owner = await TestApiClient.for({
+			organizationId: org.id,
+			userId: user.id,
+			memberRole: "owner",
+		});
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+		});
+		agentId = agent.agentId;
+
+		const entity = await createTestEntity({
+			name: "Source Limit Target",
+			entity_type: "company",
+			organization_id: orgId,
+			created_by: user.id,
+		});
+		entityId = Number(entity.id);
+
+		// Two connections, each with its own `default` feed. They are referenced
+		// by feed id rather than `@feed:default` — that ref matches on feed_key
+		// and compiles to `feed_id IN (both)`, so each named source would read
+		// both feeds identically and the per-source distinction would vanish.
+		primaryFeedId = await seedFeed("primary-source-limit", "primary");
+		secondaryFeedId = await seedFeed("secondary-source-limit", "secondary");
+	});
+
+	/** A connection + its default feed, carrying ROWS_PER_FEED events. */
+	async function seedFeed(slug: string, label: string): Promise<number> {
+		const sql = getTestDb();
+		const connection = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "test.connector",
+			display_name: `Source Limit ${label}`,
+			slug,
+		});
+		const [feed] = await sql<{ id: number | string }[]>`
+      SELECT id FROM feeds WHERE connection_id = ${connection.id} AND feed_key = 'default'
+    `;
+		const feedId = Number(feed.id);
+		for (let i = 0; i < ROWS_PER_FEED; i++) {
+			await createTestEvent({
+				entity_id: entityId,
+				organization_id: orgId,
+				connection_id: connection.id,
+				feed_id: feedId,
+				content: `${label} row ${i}`,
+				// Distinct timestamps so keyset ordering is deterministic. Kept within
+				// seconds of now so the `since: 'today'` window can't lose rows across
+				// a midnight boundary.
+				occurred_at: new Date(Date.now() - i * 1000),
+			});
+		}
+		return feedId;
+	}
+
+	it("caps a secondary event source at the requested limit", async () => {
+		const created = (await owner.behaviors.create({
+			entity_id: entityId,
+			slug: "multi-source-limit",
+			name: "Multi Source Limit",
+			prompt: "Summarize {{content}} alongside {{secondary}}.",
+			agent_id: agentId,
+			sources: [
+				{ name: "content", query: `@feed:${primaryFeedId}` },
+				{ name: "secondary", query: `@feed:${secondaryFeedId}` },
+			],
+		})) as { behavior_id: string };
+
+		const result = (await owner.knowledge.read({
+			behavior_id: created.behavior_id,
+			since: "today",
+			until: "today",
+			limit: PAGE_LIMIT,
+		})) as {
+			sources: Record<string, unknown[]>;
+			sources_page?: Record<
+				string,
+				{ returned: number; limit: number; has_more: boolean }
+			>;
+		};
+
+		// The primary source was always bounded — assert it to prove the fixture
+		// really did seed more rows than the limit, so the secondary assertion
+		// below is measuring the bug and not an empty window.
+		expect(result.sources.content).toHaveLength(PAGE_LIMIT);
+
+		// THE regression. Before the fix this returned all ROWS_PER_FEED rows.
+		expect(result.sources.secondary).toHaveLength(PAGE_LIMIT);
+
+		// Truncation is reported, not silent — a caller can tell a fully-read
+		// source from a capped one.
+		expect(result.sources_page?.secondary).toEqual({
+			returned: PAGE_LIMIT,
+			limit: PAGE_LIMIT,
+			has_more: true,
+		});
+		expect(result.sources_page?.content).toEqual({
+			returned: PAGE_LIMIT,
+			limit: PAGE_LIMIT,
+			has_more: true,
+		});
+	});
+
+	it("reports has_more false when a source fits inside the limit", async () => {
+		const created = (await owner.behaviors.create({
+			entity_id: entityId,
+			slug: "multi-source-fits",
+			name: "Multi Source Fits",
+			prompt: "Summarize {{content}} alongside {{secondary}}.",
+			agent_id: agentId,
+			sources: [
+				{ name: "content", query: `@feed:${primaryFeedId}` },
+				{ name: "secondary", query: `@feed:${secondaryFeedId}` },
+			],
+		})) as { behavior_id: string };
+
+		const roomy = ROWS_PER_FEED + 1;
+		const result = (await owner.knowledge.read({
+			behavior_id: created.behavior_id,
+			since: "today",
+			until: "today",
+			limit: roomy,
+		})) as {
+			sources: Record<string, unknown[]>;
+			sources_page?: Record<
+				string,
+				{ returned: number; limit: number; has_more: boolean }
+			>;
+		};
+
+		expect(result.sources.secondary).toHaveLength(ROWS_PER_FEED);
+		expect(result.sources_page?.secondary).toEqual({
+			returned: ROWS_PER_FEED,
+			limit: roomy,
+			has_more: false,
+		});
+	});
+});

--- a/packages/server/src/tools/get_content/behavior-mode.ts
+++ b/packages/server/src/tools/get_content/behavior-mode.ts
@@ -69,6 +69,7 @@ async function queryContentData(
   sourcesContent: Record<string, unknown[]>;
   allContent: unknown[];
   page?: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } };
+  sourcesPage: Record<string, { returned: number; limit: number; has_more: boolean }>;
   totalCount: number;
   totalCountChars: number;
 }> {
@@ -97,14 +98,22 @@ async function queryContentData(
 	throwOnError: params.throwOnSourceError,
     wrapQuery: page
       ? (scopedQuery, queryParams, sourceName) => {
-          if (sourceName !== page.sourceName || !eventSourceNames.has(sourceName)) return scopedQuery;
+          // Bound EVERY event source, not just the cursor-bearing one. All of
+          // them land in `sources` on the response, and the sandbox counts
+          // every SDK result as it crosses the isolate boundary — an unbounded
+          // secondary source blows the output cap no matter what the script
+          // keeps. Only the primary source carries the keyset cursor; the rest
+          // are capped at the same page size and report truncation through
+          // `sources_page`, so a bounded read is never silent.
+          if (!eventSourceNames.has(sourceName)) return scopedQuery;
+          const isCursorSource = sourceName === page.sourceName;
 
           const nextParams = [...queryParams];
           const where: string[] = [
             '_watcher_page.id IS NOT NULL',
             '_watcher_page.occurred_at IS NOT NULL',
           ];
-          if (page.beforeOccurredAt && page.beforeId) {
+          if (isCursorSource && page.beforeOccurredAt && page.beforeId) {
             nextParams.push(page.beforeOccurredAt);
             const occurredAtParam = `$${nextParams.length}`;
             nextParams.push(page.beforeId);
@@ -185,7 +194,23 @@ async function queryContentData(
   }
 
   let pageResult: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } } | undefined;
+  // Per-source truncation. Every event source fetches `limit + 1` rows to
+  // detect overflow, so the sentinel row must be trimmed off the secondary
+  // sources too. Only the primary source gets a cursor; the rest report
+  // `has_more` so a caller can tell a truncated window from the whole one.
+  const sourcesPage: Record<string, { returned: number; limit: number; has_more: boolean }> = {};
   if (page) {
+    for (const sourceName of eventSourceNames) {
+      if (sourceName === page.sourceName) continue;
+      const rows = results[sourceName] ?? [];
+      const hasMore = rows.length > page.limit;
+      if (hasMore) results[sourceName] = rows.slice(0, page.limit);
+      sourcesPage[sourceName] = {
+        returned: (results[sourceName] ?? []).length,
+        limit: page.limit,
+        has_more: hasMore,
+      };
+    }
     const rows = results[page.sourceName] ?? [];
     const trimmed = rows.slice(0, page.limit);
     const hasMore = rows.length > page.limit;
@@ -193,6 +218,11 @@ async function queryContentData(
     const last = trimmed[trimmed.length - 1] as Record<string, unknown> | undefined;
     const lastOccurredAt = last?.occurred_at;
     const lastId = Number(last?.id);
+    sourcesPage[page.sourceName] = {
+      returned: trimmed.length,
+      limit: page.limit,
+      has_more: hasMore,
+    };
     pageResult = {
       has_more: hasMore,
       ...(hasMore && lastOccurredAt && Number.isFinite(lastId)
@@ -248,6 +278,7 @@ async function queryContentData(
 
   return {
     sourcesContent: results as Record<string, unknown[]>,
+    sourcesPage,
     allContent,
     page: pageResult,
     totalCount,
@@ -452,6 +483,7 @@ export async function handleBehaviorMode(
     sourcesContent,
     allContent,
     page: contentPage,
+    sourcesPage,
     totalCount,
     totalCountChars,
   } = contentData;
@@ -572,6 +604,9 @@ export async function handleBehaviorMode(
     window_end: windowEndIso,
     extraction_schema: templateExtractionSchema ?? undefined,
     sources: sourcesContent as Record<string, ContentItem[]>,
+    // Per-source page state. Every event source is capped at `limit`, so this
+    // is how a caller tells a fully-read source from a truncated one.
+    sources_page: sourcesPage,
     entities: boundEntities.length > 0 ? boundEntities : undefined,
     classifiers: classifiers.length > 0 ? classifiers : undefined,
     unprocessed_ranges: unprocessedRanges,

--- a/packages/server/src/tools/get_content/types.ts
+++ b/packages/server/src/tools/get_content/types.ts
@@ -71,6 +71,22 @@ export const GetContentResultSchema = Type.Object({
   extraction_schema: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
   sources: Type.Optional(Type.Record(Type.String(), Type.Array(Type.Unknown()))),
   /**
+   * Per-source page state, keyed by source name. Every event source is capped
+   * at the request's `limit`; this is how a caller distinguishes a fully-read
+   * source from a truncated one. Only the primary source carries a cursor (see
+   * `page.next_cursor`); the rest report `has_more` alone.
+   */
+  sources_page: Type.Optional(
+    Type.Record(
+      Type.String(),
+      Type.Object({
+        returned: Type.Integer(),
+        limit: Type.Integer(),
+        has_more: Type.Boolean(),
+      })
+    )
+  ),
+  /**
    * Behavior-bound entities as structured rows (id, name, type, metadata,
    * field_controls). field_controls marks human-owned field values the agent
    * must not overwrite without new evidence.


### PR DESCRIPTION
## Summary
- Behavior mode applied its `LIMIT` only to the source literally named `content` (a hardcoded `page.sourceName`). **Every other event source ran unbounded** and still landed in the returned `sources` blob, so a Behavior with more than one source ignored `limit` entirely.
- This is why Behavior 5 was unreadable in prod: the sandbox counts every SDK result as it crosses the isolate boundary, so an unbounded secondary source blew the output cap before the script could filter anything. `limit: 1` and `limit: 5` failed identically.
- Every event source is now capped at the requested page size, and truncation is reported through a new `sources_page` field so a bounded read is never silent. Only the primary source carries the keyset cursor.

No new API parameter: `limit` already existed and simply wasn't being applied. `sources_page` is additive and optional.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted `vitest run src/__tests__/integration/watchers/behavior-mode-source-limit.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

### RED (fix reverted)
```
 × behavior-mode limit bounds every event source > caps a secondary event source at the requested limit
 × behavior-mode limit bounds every event source > reports has_more false when a source fits inside the limit
AssertionError: expected [ { id: 4, …(22) }, …(2) ] to have a length of 2 but got 3
AssertionError: expected undefined to deeply equal { returned: 3, limit: 4, …(1) }
 Test Files  1 failed (1)
      Tests  2 failed (2)
```
The secondary source returned all 3 seeded rows when the caller asked for 2.

### GREEN (fix restored)
```
 ✓ src/__tests__/integration/watchers/behavior-mode-source-limit.test.ts (2 tests) 402ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

## Notes

**Mutation-check caveat, stated honestly.** The two halves of this fix are not equally covered:
- Neutering the **JS trim loop** goes red exactly on the regression assertion. The response contract is genuinely tested.
- Reverting the **SQL `wrapQuery` guard alone survives** — the JS trim caps the response anyway, and because compiled sources already order `occurred_at DESC`, the SQL-side bound is indistinguishable at the API surface. That half is a server-memory/perf bound (don't pull an unbounded window out of an append-only table) and is not provable through the response shape.

**Known gap, deliberately not fixed here.** Streaming `channel`-kind sources (chat feeds) are still returned unbounded — same class of bug, and `channelMessagesSelect` projects `id`/`occurred_at` so the wrapper would work mechanically. Capping chat context at the page limit with no cursor could starve recap Behaviors of their window, which is a product call rather than a mechanical fix. Flagging rather than silently deciding.

**Pre-existing behavior mirrored, not introduced.** The hardcoded `page.sourceName: 'content'` still produces a phantom empty `content` key when no source is named `content`; `sources_page` now mirrors that same key.
