### PR TITLE
fix(server): report device liveness truthfully instead of a 20-minute guess

### DIFF
--- a/packages/server/src/__tests__/integration/device-liveness-window.test.ts
+++ b/packages/server/src/__tests__/integration/device-liveness-window.test.ts
@@ -1,0 +1,161 @@
+/**
+ * A device that stopped polling must be reported offline within the liveness
+ * window, and the report must say how stale it is.
+ *
+ * Measured on prod 2026-08-05: a chrome extension whose poll loop died was
+ * reported `readiness: "ready", executable: true` for the full 18 minutes it
+ * was dead, because `device_online` was `last_seen_at > now() - 20 minutes`.
+ * Every dispatch in that window sat for the 60s queue budget and then failed
+ * with "the device may be offline" — a guess the server had the data to
+ * answer. The window is now 120s and the staleness is stated, not implied.
+ *
+ * The fixtures below sit at 5 minutes stale: OFFLINE under the current window,
+ * ONLINE under the old one. That gap is the regression this file pins.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { manageConnections } from "../../tools/admin/manage_connections";
+import { describeRunDeviceLastSeen } from "../../tools/admin/device-action-wait";
+import type { ToolContext } from "../../tools/registry";
+import { DEVICE_ONLINE_WINDOW_SECONDS } from "../../utils/device-liveness";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestConnection,
+	createTestConnectorDefinition,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
+
+const CONNECTOR_KEY = "apple.computer_use";
+/** Dead long enough for the current window, alive under the old 20-minute one. */
+const STALE_SECONDS = 5 * 60;
+
+describe("device liveness window", () => {
+	let orgId: string;
+	let userId: string;
+	let ctx: ToolContext;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, user, ctx: ownerCtx } = await seedOwnerContext({
+			orgName: "Device Liveness Org",
+		});
+		orgId = org.id;
+		userId = user.id;
+		ctx = ownerCtx;
+		await createTestConnectorDefinition({
+			key: CONNECTOR_KEY,
+			name: "Apple Computer Use",
+			organization_id: orgId,
+			auth_schema: { methods: [{ type: "none" }] },
+		});
+	});
+
+	async function seedDevice(
+		staleSeconds: number,
+		label: string,
+	): Promise<{ connectionId: number; deviceId: string }> {
+		const sql = getTestDb();
+		const lastSeen = new Date(Date.now() - staleSeconds * 1000).toISOString();
+		const [dw] = (await sql`
+			INSERT INTO device_workers (
+				user_id, worker_id, platform, capabilities, label, organization_id, last_seen_at
+			) VALUES (
+				${userId}, ${`wk_${staleSeconds}_${Date.now()}`}, 'macos',
+				${sql.json([])}, ${label}, ${orgId}, ${lastSeen}
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: string }>;
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: CONNECTOR_KEY,
+			created_by: userId,
+			createDefaultFeed: false,
+		});
+		await sql`UPDATE connections SET device_worker_id = ${dw.id} WHERE id = ${conn.id}`;
+		return { connectionId: conn.id, deviceId: dw.id };
+	}
+
+	async function listConnection(connectionId: number) {
+		const result = (await manageConnections(
+			{ action: "list" },
+			{} as Env,
+			ctx,
+		)) as { connections: Array<Record<string, unknown>> };
+		return result.connections.find((c) => c.id === connectionId);
+	}
+
+	it("reports a device that stopped polling 5 minutes ago as offline", async () => {
+		// Under the old 20-minute window this row came back device_online: true
+		// and nothing downstream could tell the device was gone.
+		const { connectionId } = await seedDevice(STALE_SECONDS, "Stale Mac");
+		const row = await listConnection(connectionId);
+		expect(row).toBeDefined();
+		expect(row?.device_online).toBe(false);
+		expect(row?.device_status).toBe("offline");
+	});
+
+	it("still reports a device polling within the window as online", async () => {
+		const { connectionId } = await seedDevice(10, "Live Mac");
+		const row = await listConnection(connectionId);
+		expect(row?.device_online).toBe(true);
+		expect(row?.device_status ?? null).toBeNull();
+	});
+
+	it("holds the boundary: just inside online, just outside offline", async () => {
+		const inside = await seedDevice(DEVICE_ONLINE_WINDOW_SECONDS - 30, "Inside");
+		const outside = await seedDevice(DEVICE_ONLINE_WINDOW_SECONDS + 30, "Outside");
+		expect((await listConnection(inside.connectionId))?.device_online).toBe(true);
+		expect((await listConnection(outside.connectionId))?.device_online).toBe(false);
+	});
+
+	it("connections.test explains the staleness rather than just 'offline'", async () => {
+		const { connectionId } = await seedDevice(STALE_SECONDS, "Stale Mac 2");
+		const result = (await manageConnections(
+			{ action: "test", connection_id: connectionId },
+			{} as Env,
+			ctx,
+		)) as Record<string, unknown>;
+		expect(result.device_online).toBe(false);
+		expect(result.status).toBe("warning");
+		expect(String(result.message)).toContain("last polled 5m ago");
+	});
+
+	it("names the silent device in the dispatch timeout diagnostic", async () => {
+		const sql = getTestDb();
+		const { connectionId } = await seedDevice(18 * 60, "Burak's MacBook Chrome");
+		const [run] = (await sql`
+			INSERT INTO runs (organization_id, connection_id, run_type, status, connector_key)
+			VALUES (${orgId}, ${connectionId}, 'action', 'pending', ${CONNECTOR_KEY})
+			RETURNING id
+		`) as unknown as Array<{ id: number }>;
+
+		const described = await describeRunDeviceLastSeen(Number(run.id), orgId);
+		// The exact sentence an operator reads when a dispatch times out. It has
+		// to name the device and the age — "may be offline" is what sent a whole
+		// session chasing a server-side fault that did not exist.
+		expect(described).toBe(
+			`device "Burak's MacBook Chrome" last polled 18m ago`,
+		);
+	});
+
+	it("degrades to a safe string when the run has no paired device", async () => {
+		const sql = getTestDb();
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: CONNECTOR_KEY,
+			created_by: userId,
+			createDefaultFeed: false,
+		});
+		const [run] = (await sql`
+			INSERT INTO runs (organization_id, connection_id, run_type, status, connector_key)
+			VALUES (${orgId}, ${conn.id}, 'action', 'pending', ${CONNECTOR_KEY})
+			RETURNING id
+		`) as unknown as Array<{ id: number }>;
+		expect(await describeRunDeviceLastSeen(Number(run.id), orgId)).toBe(
+			"run has no paired device",
+		);
+	});
+});

--- a/packages/server/src/__tests__/integration/dispatch-chrome-autobind.test.ts
+++ b/packages/server/src/__tests__/integration/dispatch-chrome-autobind.test.ts
@@ -139,7 +139,7 @@ describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
     // under the old ORDER BY last_seen_at DESC rule.
     await sql`
       UPDATE device_workers
-      SET last_seen_at = now() - interval '2 minutes'
+      SET last_seen_at = now() - interval '30 seconds'
       WHERE id = ${pinned}::uuid
     `;
     const fresher = await seedExtWorker(userId, orgId, { online: true });
@@ -157,7 +157,7 @@ describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
     const preferred = await seedExtWorker(userId, orgId, { online: true });
     await sql`
       UPDATE device_workers
-      SET last_seen_at = now() - interval '3 minutes'
+      SET last_seen_at = now() - interval '45 seconds'
       WHERE id = ${preferred}::uuid
     `;
     const fresher = await seedExtWorker(userId, orgId, { online: true });
@@ -213,7 +213,7 @@ describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
     const mini = await seedExtWorker(userId, orgId, { online: true });
     await sql`
       UPDATE device_workers
-      SET last_seen_at = now() - interval '1 minute'
+      SET last_seen_at = now() - interval '15 seconds'
       WHERE id = ${mini}::uuid
     `;
     const macbook = await seedExtWorker(userId, orgId, { online: true });
@@ -250,7 +250,7 @@ describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
     const sticky = await seedExtWorker(userId, orgId, { online: true });
     await sql`
       UPDATE device_workers
-      SET last_seen_at = now() - interval '2 minutes'
+      SET last_seen_at = now() - interval '30 seconds'
       WHERE id = ${preferred}::uuid
     `;
     const stickyConn = await seedChromeConn(orgId, userId, sticky);
@@ -287,7 +287,7 @@ describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
     const older = await seedExtWorker(userId, orgId, { online: true });
     await sql`
       UPDATE device_workers
-      SET last_seen_at = now() - interval '3 minutes'
+      SET last_seen_at = now() - interval '45 seconds'
       WHERE id = ${older}::uuid
     `;
     const fresher = await seedExtWorker(userId, orgId, { online: true });
@@ -309,7 +309,7 @@ describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
     const fresh = await seedExtWorker(userId, orgId, { online: true });
     await sql`
       UPDATE device_workers
-      SET last_seen_at = now() - interval '1 minute'
+      SET last_seen_at = now() - interval '15 seconds'
       WHERE id = ${sticky}::uuid
     `;
     // Prefer sticky for no-preference path; this test exercises preferred=fresh.
@@ -352,7 +352,7 @@ describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
     const workerA = await seedExtWorker(userId, orgId, { online: true });
     await sql`
       UPDATE device_workers
-      SET last_seen_at = now() - interval '2 minutes'
+      SET last_seen_at = now() - interval '30 seconds'
       WHERE id = ${workerA}::uuid
     `;
     const workerB = await seedExtWorker(userId, orgId, { online: true });

--- a/packages/server/src/__tests__/unit/device-liveness.test.ts
+++ b/packages/server/src/__tests__/unit/device-liveness.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  DEVICE_ONLINE_WINDOW_SECONDS,
+  describeDeviceLastSeen,
+} from '../../utils/device-liveness';
+
+const NOW = new Date('2026-08-05T14:00:00.000Z');
+const ago = (seconds: number) => new Date(NOW.getTime() - seconds * 1000);
+
+describe('DEVICE_ONLINE_WINDOW_SECONDS', () => {
+  it('leaves headroom over the worst measured healthy poll gap', () => {
+    // Prod 2026-08-05: the slowest LIVE worker's max inter-poll gap was 11.6s.
+    // A window at or under that would flap healthy devices to offline.
+    expect(DEVICE_ONLINE_WINDOW_SECONDS).toBeGreaterThan(12 * 5);
+  });
+
+  it('stays within the dispatch queue budget by a small factor', () => {
+    // QUEUE_BUDGET_MS is 60s (device-action-wait). "Online" has to imply a
+    // dispatch right now stands a real chance of being claimed; the old
+    // 20-minute window was 20x the budget and promised what dispatch could
+    // not deliver.
+    expect(DEVICE_ONLINE_WINDOW_SECONDS).toBeLessThanOrEqual(60 * 2);
+  });
+});
+
+describe('describeDeviceLastSeen', () => {
+  it('reports a never-seen device rather than pretending it is fresh', () => {
+    expect(describeDeviceLastSeen(null, NOW)).toBe('has never polled');
+    expect(describeDeviceLastSeen(undefined, NOW)).toBe('has never polled');
+    expect(describeDeviceLastSeen('not-a-date', NOW)).toBe('has never polled');
+  });
+
+  it('uses seconds inside the first minute', () => {
+    expect(describeDeviceLastSeen(ago(3), NOW)).toBe('last polled 3s ago');
+    expect(describeDeviceLastSeen(ago(59), NOW)).toBe('last polled 59s ago');
+  });
+
+  it('rolls up to minutes, hours and days', () => {
+    expect(describeDeviceLastSeen(ago(60), NOW)).toBe('last polled 1m ago');
+    // The outage that motivated this: 18 minutes reported as online.
+    expect(describeDeviceLastSeen(ago(18 * 60), NOW)).toBe('last polled 18m ago');
+    expect(describeDeviceLastSeen(ago(2 * 3600), NOW)).toBe('last polled 2h ago');
+    expect(describeDeviceLastSeen(ago(3 * 86400), NOW)).toBe('last polled 3d ago');
+  });
+
+  it('accepts a timestamp string, as postgres hands it back', () => {
+    expect(describeDeviceLastSeen(ago(90).toISOString(), NOW)).toBe(
+      'last polled 1m ago'
+    );
+  });
+
+  it('treats clock skew into the future as just now, not a negative age', () => {
+    expect(describeDeviceLastSeen(new Date(NOW.getTime() + 5_000), NOW)).toBe(
+      'last polled just now'
+    );
+  });
+});

--- a/packages/server/src/tools/admin/device-action-wait.ts
+++ b/packages/server/src/tools/admin/device-action-wait.ts
@@ -9,6 +9,35 @@
  */
 
 import { getDb } from '../../db/client';
+import { describeDeviceLastSeen } from '../../utils/device-liveness';
+
+/**
+ * How long the device pinned to this run's connection has been silent.
+ * Runs only on the pre-claim timeout path, so the extra round-trip costs
+ * nothing on the happy path. Never throws: a diagnostic that can fail the
+ * operation it is diagnosing is worse than no diagnostic.
+ */
+export async function describeRunDeviceLastSeen(
+  runId: number,
+  organizationId: string
+): Promise<string> {
+  try {
+    const rows = (await getDb()`
+      SELECT dw.label, dw.last_seen_at
+      FROM runs r
+      JOIN connections c ON c.id = r.connection_id
+      JOIN device_workers dw ON dw.id = c.device_worker_id
+      WHERE r.id = ${runId} AND r.organization_id = ${organizationId}
+      LIMIT 1
+    `) as Array<{ label: string | null; last_seen_at: Date | string | null }>;
+    const row = rows[0];
+    if (!row) return 'run has no paired device';
+    const age = describeDeviceLastSeen(row.last_seen_at);
+    return row.label ? `device "${row.label}" ${age}` : `device ${age}`;
+  } catch {
+    return 'device liveness unavailable';
+  }
+}
 
 // Deadline strategy: two phases.
 //
@@ -99,6 +128,26 @@ export async function waitForDeviceActionRun(
     await new Promise((r) => setTimeout(r, POLL_MS));
   }
 
+  // Which phase timed out decides what the operator needs to hear. A run that
+  // was never CLAIMED failed because no device asked for it, and the server
+  // knows exactly how long that device has been quiet — say so instead of
+  // "the device may be offline", which sends the reader looking for a fault
+  // that is already measured here. A run that WAS claimed died mid-execution
+  // on the device, where last_seen tells you nothing.
+  // Looked up ONCE and used for both the stored `runs.error_message` and the
+  // string returned to the caller below — those are two different readers of
+  // the same failure and both used to say "may be offline".
+  const deviceDiagnostic =
+    claimedAtMs != null
+      ? null
+      : await describeRunDeviceLastSeen(runId, organizationId);
+  const timeoutMessage =
+    deviceDiagnostic == null
+      ? 'waitForDeviceActionRun: device claimed the run but did not complete in time'
+      : `waitForDeviceActionRun: no device claimed the run within ${Math.round(
+          QUEUE_BUDGET_MS / 1000
+        )}s (${deviceDiagnostic})`;
+
   // Atomic timeout finalization. The WHERE clause matches only non-
   // terminal states; if the worker raced us and posted completion
   // between our last SELECT and this UPDATE, this UPDATE is a no-op
@@ -107,7 +156,7 @@ export async function waitForDeviceActionRun(
     UPDATE runs
     SET status = 'timeout',
         completed_at = current_timestamp,
-        error_message = ${'waitForDeviceActionRun: device worker did not complete in time'}
+        error_message = ${timeoutMessage}
     WHERE id = ${runId}
       AND organization_id = ${organizationId}
       AND status IN ('pending', 'running')
@@ -145,8 +194,8 @@ export async function waitForDeviceActionRun(
   return {
     status: 'timeout',
     error_message:
-      claimedAtMs != null
+      deviceDiagnostic == null
         ? `Run ${runId} claimed but the device worker didn't finish within ${POST_CLAIM_BUDGET_MS}ms.`
-        : `Run ${runId} was never claimed within ${QUEUE_BUDGET_MS}ms — the chrome-extension / device worker may be offline.`,
+        : `Run ${runId} was never claimed within ${QUEUE_BUDGET_MS}ms — ${deviceDiagnostic}.`,
   };
 }

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -5,6 +5,10 @@
 import { isRetryable, type ToolErrorCode } from '@lobu/core';
 import { getDb } from '../../../../db/client';
 import {
+  DEVICE_ONLINE_WINDOW_SECONDS,
+  describeDeviceLastSeen,
+} from '../../../../utils/device-liveness';
+import {
   getAuthProfileById,
   getBrowserSessionReadiness,
   normalizeAuthValues,
@@ -173,7 +177,8 @@ export async function handleTest(
            c.status,
            c.device_worker_id,
            dw.label AS device_label,
-           COALESCE(dw.last_seen_at > now() - interval '20 minutes', false) AS device_online,
+           dw.last_seen_at AS device_last_seen_at,
+           COALESCE(dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS}), false) AS device_online,
            cd.auth_schema
     FROM connections c
     LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
@@ -319,8 +324,8 @@ export async function handleTest(
   // Auth-free device connections such as apple.computer_use run on a paired
   // device, not an auth profile — so a null profile is expected. Report whether
   // the paired device is online instead of the misleading "No auth profile
-  // configured" warning. The 20-minute freshness window mirrors the readiness
-  // rule used across operations/feeds listings.
+  // configured" warning. The DEVICE_ONLINE_WINDOW_SECONDS freshness window
+  // mirrors the readiness rule used across operations/feeds listings.
   //
   // This must precede the no-auth check: device connectors like apple.computer_use
   // declare `auth_schema.methods: [{ type: 'none' }]`, so testing no-auth first would
@@ -339,7 +344,9 @@ export async function handleTest(
           status: 'warning',
           // Offline is transient — the device may reconnect — so this is
           // retryable, mirroring the CDP-unreachable branch above.
-          message: `Device '${deviceName}' is offline — bring it online to execute`,
+          message: `Device '${deviceName}' is offline (${describeDeviceLastSeen(
+            conn.device_last_seen_at
+          )}) — bring it online to execute`,
           device_online: false,
           ...testErrorFields('NETWORK'),
         };

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -38,6 +38,7 @@ import {
   getAuthProfileBySlug,
   getBrowserSessionReadiness,
 } from "../../../../utils/auth-profiles";
+import { DEVICE_ONLINE_WINDOW_SECONDS } from "../../../../utils/device-liveness";
 import {
 	DEVICE_PIN_TOMBSTONE_MESSAGES,
 	effectiveConnectionErrorMessage,
@@ -284,10 +285,10 @@ export async function handleList(
            dw.platform AS device_platform,
            dw.worker_id AS device_worker_handle,
            dw.last_seen_at AS device_last_seen_at,
-           (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes') AS device_online,
+           (dw.id IS NOT NULL AND dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})) AS device_online,
            CASE
              WHEN c.device_worker_id IS NOT NULL
-              AND NOT (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes')
+              AND NOT (dw.id IS NOT NULL AND dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS}))
              THEN 'offline'
            END AS device_status,
            -- event_count intentionally omitted from list responses: the
@@ -476,10 +477,10 @@ export async function handleGet(
            dw.platform AS device_platform,
            dw.worker_id AS device_worker_handle,
            dw.last_seen_at AS device_last_seen_at,
-           (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes') AS device_online,
+           (dw.id IS NOT NULL AND dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})) AS device_online,
            CASE
              WHEN c.device_worker_id IS NOT NULL
-              AND NOT (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes')
+              AND NOT (dw.id IS NOT NULL AND dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS}))
              THEN 'offline'
            END AS device_status,
            (SELECT COUNT(*) FROM current_event_records e WHERE e.connection_id = c.id)::int AS event_count,

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -31,6 +31,7 @@ import {
   type ManageFeedsResult,
 } from '@lobu/core/contracts/tools/manage-feeds';
 import { getDb, pgBigintArray } from '../../db/client';
+import { DEVICE_ONLINE_WINDOW_SECONDS } from '../../utils/device-liveness';
 import { authzScopeFromToolContext } from '../../authz/scope';
 import {
   feedLinkedEntityIdsSql,
@@ -224,10 +225,10 @@ async function handleListFeeds(
            dw.label AS device_label,
            dw.platform AS device_platform,
            dw.last_seen_at AS device_last_seen_at,
-           (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes') AS device_online,
+           (dw.id IS NOT NULL AND dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})) AS device_online,
            CASE
              WHEN c.device_worker_id IS NOT NULL
-              AND NOT (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes')
+              AND NOT (dw.id IS NOT NULL AND dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS}))
              THEN 'offline'
            END AS device_status,
            cd.name AS connector_name,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -75,6 +75,10 @@ import type {
 	OperationDescriptor,
 } from "../../operations/types";
 import { createConnectorOperationRun } from "../../runs/queue-service";
+import {
+	DEVICE_ONLINE_WINDOW_SECONDS,
+	describeDeviceLastSeen,
+} from "../../utils/device-liveness";
 import { resolveConnectorCodeForKey } from "../../utils/ensure-connector-installed";
 import { ToolUserError } from "../../utils/errors";
 import { resolveExecutionAuth } from "../../utils/execution-context";
@@ -167,6 +171,7 @@ type OperationTargetRow = {
 	config: Record<string, unknown> | null;
 	device_worker_id: string | null;
 	device_online: boolean;
+	device_last_seen_at: Date | string | null;
 	device_bound: boolean;
 	auth_profile_kind: string | null;
 	auth_profile_slug: string | null;
@@ -459,11 +464,17 @@ function executionTargetFromRow(
 		};
 	}
 	if (row.device_bound && !row.device_online) {
+		// Say HOW stale, not just "offline". The caller's next question is
+		// always "since when" — answering it here is the difference between
+		// "my device died 20 minutes ago" and a dispatch that stalls for the
+		// queue budget before failing with a guess.
 		return {
 			...base,
 			status: "device_offline",
 			executable: false,
-			reason: "The connection's paired device is offline.",
+			reason: `The connection's paired device is offline (${describeDeviceLastSeen(
+				row.device_last_seen_at,
+			)}).`,
 		};
 	}
 	return {
@@ -806,7 +817,8 @@ async function loadVisibleOperationTargets(
 		        ap.profile_kind AS auth_profile_kind,
 		        ap.slug AS auth_profile_slug,
 		        ap.auth_data AS auth_data,
-		        COALESCE(dw.last_seen_at > now() - interval '20 minutes', false) AS device_online,
+		        COALESCE(dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS}), false) AS device_online,
+		        dw.last_seen_at AS device_last_seen_at,
 		        (c.device_worker_id IS NOT NULL OR latest.runtime IS NOT NULL) AS device_bound
 		 FROM connections c
 		 LEFT JOIN device_workers dw ON dw.id = c.device_worker_id

--- a/packages/server/src/utils/device-liveness.ts
+++ b/packages/server/src/utils/device-liveness.ts
@@ -1,0 +1,60 @@
+/**
+ * How fresh a device worker's `last_seen_at` must be for the device to count
+ * as online, and how to describe that freshness to a human.
+ *
+ * `device_workers.last_seen_at` is written on every `/api/workers/poll` and on
+ * device registration — nowhere else — so it is a true liveness signal rather
+ * than a config timestamp.
+ *
+ * ## Why 2 minutes
+ *
+ * The window was 20 minutes, duplicated across nine inline query sites plus a
+ * local constant in dispatch-chrome-action. Measured on prod 2026-08-05 over
+ * ~50 minutes of poll traffic, every LIVE worker — both
+ * platforms, four devices — polled far faster than that:
+ *
+ *     source                     polls   median gap   p95      max gap
+ *     fleet worker (in-cluster)   1811       1.5s      5.0s      5.3s
+ *     chrome-extension (device)    550       7.3s     10.3s     11.6s
+ *     chrome-extension (device)    442       5.4s      7.3s    546.9s ← outage
+ *
+ * The worst gap for a healthy worker was 11.6s, so 120s leaves ~10x headroom
+ * for a network blip or a rolling deploy, while collapsing the window in which
+ * a dead device still reports "online" from 20 minutes to 2.
+ *
+ * That window was not academic: an extension whose poll loop died was reported
+ * `readiness: "ready", executable: true` for the full 18 minutes it was dead,
+ * and every dispatch to it stalled for the 60s queue budget and then failed
+ * with "the device may be offline" — a guess the server had the data to
+ * answer. Keeping this comfortably under `QUEUE_BUDGET_MS` x2 means "online"
+ * now implies "a dispatch right now has a real chance of being claimed".
+ *
+ * There is no known device class that polls slower; if one is ever added, it
+ * must either poll within this window or the reporting has to become
+ * per-platform — do not widen this back to cover it silently.
+ */
+export const DEVICE_ONLINE_WINDOW_SECONDS = 120;
+
+/**
+ * Human-readable age of a device's last poll, for `reason` strings and
+ * dispatch errors. Deliberately coarse: the caller needs "is this stale and
+ * roughly how stale", not milliseconds.
+ */
+export function describeDeviceLastSeen(
+  lastSeenAt: Date | string | null | undefined,
+  now: Date = new Date()
+): string {
+  if (lastSeenAt == null) return 'has never polled';
+  const seen = lastSeenAt instanceof Date ? lastSeenAt : new Date(lastSeenAt);
+  const ms = seen.getTime();
+  if (!Number.isFinite(ms)) return 'has never polled';
+  const seconds = Math.round((now.getTime() - ms) / 1000);
+  // A worker that polled "in the future" is a clock-skew artifact, not news.
+  if (seconds < 0) return 'last polled just now';
+  if (seconds < 60) return `last polled ${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `last polled ${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `last polled ${hours}h ago`;
+  return `last polled ${Math.floor(hours / 24)}d ago`;
+}

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -21,6 +21,7 @@ import { captureServerError } from '../sentry';
 import { errorMessage } from '../utils/errors';
 import { recordLifecycleEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
+import { DEVICE_ONLINE_WINDOW_SECONDS } from '../utils/device-liveness';
 import {
   DEVICE_MOVED_TOMBSTONE,
   DEVICE_REMOVED_TOMBSTONE,
@@ -53,7 +54,7 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
         dw.capabilities,
         dw.label,
         dw.last_seen_at,
-        (dw.last_seen_at > now() - interval '20 minutes') AS online,
+        (dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})) AS online,
         dw.organization_id,
         o.name AS organization_name,
         o.slug AS organization_slug,

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -25,15 +25,12 @@ import { compileConnectionRowVisibility } from '../authz/connection-visibility';
 import { getDb, pgTextArray } from '../db/client';
 import type { Env } from '../index';
 import { waitForDeviceActionRun } from '../tools/admin/device-action-wait';
+import { DEVICE_ONLINE_WINDOW_SECONDS } from '../utils/device-liveness';
 import { DEVICE_PIN_TOMBSTONE_MESSAGES } from '../utils/device-pin-tombstones';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { isUniqueViolation } from '../utils/pg-errors';
 import { createConnectorOperationRun } from '../runs/queue-service';
-
-// Online window for chrome extension device workers, in minutes. Matches
-// the /api/me/devices "online" flag.
-const DEVICE_ONLINE_WINDOW_MINUTES = 20;
 
 /** Live unique index: one chrome connection per (org, device_worker) pin. */
 const CHROME_DEVICE_PIN_UNIQUE = 'idx_connections_org_connector_device_live';
@@ -139,7 +136,7 @@ export async function resolveOnlineChromeConnection(
      AND pinned.organization_id = con.organization_id
      AND pinned.platform = 'chrome-extension'
      AND pinned.capabilities::jsonb @> '["browser.debugger"]'::jsonb
-     AND pinned.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
+     AND pinned.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
     WHERE con.organization_id = ${organizationId}
       AND con.connector_key = 'chrome'
       AND con.status = 'active'
@@ -155,7 +152,7 @@ export async function resolveOnlineChromeConnection(
     WHERE dw.organization_id = ${organizationId}
       AND dw.platform = 'chrome-extension'
       AND dw.capabilities::jsonb @> '["browser.debugger"]'::jsonb
-      AND dw.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
+      AND dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
     ORDER BY dw.last_seen_at DESC
   `) as Array<{ id: string }>;
 
@@ -476,7 +473,7 @@ export async function resolveOnlineChromeConnection(
     WHERE dw.organization_id = ${organizationId}
       AND dw.platform = 'chrome-extension'
       AND dw.capabilities::jsonb @> '["browser.debugger"]'::jsonb
-      AND dw.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
+      AND dw.last_seen_at > now() - make_interval(secs => ${DEVICE_ONLINE_WINDOW_SECONDS})
       AND NOT EXISTS (
         SELECT 1
         FROM connections con


### PR DESCRIPTION
## The bug, measured on prod

A chrome extension's poll loop died at 13:26 UTC and did not resume until it was manually reloaded at 13:44. For those 18 minutes:

- `operations.listAvailable` returned `readiness: "ready", executable: true, "Connection is ready for execution."` — **identical** to its output when the device was healthy.
- Every dispatch inserted a run, waited the full 60s queue budget, and failed with `"the chrome-extension / device worker may be offline"` — a guess.
- The run ledger shows `claimed_by = NULL` on rows that were fully claimable. The server was fine; nothing asked for them, and nothing said so.

Root cause: `device_online` is `last_seen_at > now() - interval '20 minutes'`. The outage was 18 minutes, so the flag never flipped — it would have gone false two minutes *after* the reload already fixed it.

## Why 120 seconds

Every **live** worker on prod polls far faster than the old window, measured over ~50 minutes of `/api/workers/poll` traffic:

| source | polls | median gap | p95 | max gap |
|---|---|---|---|---|
| fleet worker (in-cluster) | 1811 | 1.5s | 5.0s | 5.3s |
| chrome-extension device | 550 | 7.3s | 10.3s | 11.6s |
| chrome-extension device | 442 | 5.4s | 7.3s | 546.9s ← the outage |

Worst healthy gap: **11.6s**. 120s is ~10x that, and sits inside the 60s dispatch budget it implicitly promises. Sampling `device_workers` 100s apart confirmed both platforms (`chrome-extension` and `macos`) poll on the same fast cadence when alive — there is no slow-polling device class the old window was protecting.

## What changed

- **Twelve sites → one constant.** The literal appeared in two spellings — `interval '20 minutes'` (9 sites) and a separate `DEVICE_ONLINE_WINDOW_MINUTES = 20` used via `make_interval(mins => …)` in `dispatch-chrome-action.ts` (3 sites). The second spelling is why the first grep missed it; `make review-fix` caught it.
- **Both timeout messages.** `waitForDeviceActionRun` had two — one stored in `runs.error_message`, one returned to the caller. Only the second is what a user actually sees, and both said "may be offline". They now share one lookup: `Run 858369 was never claimed within 60000ms — device "Burak's MacBook Chrome" last polled 18m ago.`
- **Both offline reasons** (`list_available`, `connections.test`) now carry the age. No schema change — the age goes in the existing `reason`/`message` string.

## Behavior change worth calling out

`device_online` is read on the **reporting** path (`executionTargetFromRow`) *and* on the **dispatch-selection** path (`resolveOnlineChromeConnection`). A device silent for 2–20 minutes was previously dispatch-eligible; it now fails fast with `"The Chrome extension selected for this connection is offline…"` instead of stalling 60s. That is the intended improvement — a device silent >2 minutes polls every 5-10s when healthy, so it was not going to claim the run anyway — but it is a real change and wants a prod-verify after rollout. `failIfPreferredOffline` still prevents falling back to a *different* browser when a specific device is targeted.

## Evidence

Green:
```
$ bunx vitest run <device + dispatch cluster: 6 files>
 Test Files  6 passed (6)
      Tests  40 passed (40)

$ bun test packages/server/src/__tests__/unit/device-liveness.test.ts
 7 pass  0 fail
```

Mutation 1 — restore the old window (`DEVICE_ONLINE_WINDOW_SECONDS = 1200`):
```
integration:  2 failed | 4 passed
  × reports a device that stopped polling 5 minutes ago as offline
  × connections.test explains the staleness rather than just 'offline'
unit:         1 fail | 6 pass
```
Mutation 2 — restore the guess in the dispatch diagnostic:
```
integration:  1 failed | 5 passed
  × names the silent device in the dispatch timeout diagnostic
```
Both restored → green. `make pre-pr` clean.

The new fixtures sit at 5 minutes stale: offline under the new window, **online under the old one** — that gap is the regression this pins. `dispatch-chrome-autobind.test.ts` fixtures moved from 1-3 minutes to 15-45 seconds; they encoded "this device is alive", which only held under a 20-minute window.

## Not fixed here

The client-side poll loops that die and never reconnect (both the Chrome extension and the Mac app were observed frozen today) live in another repo. This PR makes the server tell the truth about them; it does not revive them.