### PR TITLE
refactor(server): one cheap workspace-counts payload on resolve_path

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -5868,13 +5868,7 @@ export type ResolvePathResponses = {
         color: string | null;
         entity_count: number;
       }>;
-      summary: {
-        total_content: number;
-        active_connections: number;
-        behaviors_count: number;
-        agents_count: number;
-        devices_count: number;
-      };
+      total_content: number;
       recent_content: Array<{
         id: number;
         entity_ids: Array<number>;
@@ -5908,6 +5902,13 @@ export type ResolvePathResponses = {
         favicon_domain: string | null;
       }>;
     } | null;
+    counts: {
+      connections: number;
+      behaviors: number;
+      agents: number;
+      devices: number;
+      clients: number;
+    };
     redirect: {
       to: string;
     } | null;

--- a/packages/server/src/__tests__/integration/pages/resolve-path-counts.test.ts
+++ b/packages/server/src/__tests__/integration/pages/resolve-path-counts.test.ts
@@ -1,0 +1,157 @@
+/**
+ * `resolve_path.counts` — the always-on tally of what a workspace has.
+ *
+ * These numbers drive nav badges and onboarding states, so a wrong one is not
+ * a cosmetic slip: it tells someone their workspace is set up when it isn't,
+ * or offers setup to a workspace that is already running. The org-wide count
+ * previously read `connector_definitions`, which is a catalog of installable
+ * connectors rather than anything the user connected — a workspace with zero
+ * connections reported one. That case is asserted first.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+
+interface Counts {
+  connections: number;
+  behaviors: number;
+  agents: number;
+  devices: number;
+  clients: number;
+}
+
+interface Fixture {
+  orgId: string;
+  orgSlug: string;
+  userId: string;
+  token: string;
+}
+
+async function resolveCounts(
+  fixture: Fixture,
+  args: Record<string, unknown> = {}
+): Promise<Counts> {
+  const response = await post(`/api/${fixture.orgSlug}/resolve_path`, {
+    body: { path: `/${fixture.orgSlug}`, ...args },
+    token: fixture.token,
+  });
+  if (response.status >= 400) {
+    const body = (await response.json()) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${response.status}`);
+  }
+  const result = (await response.json()) as { counts?: Counts };
+  if (!result.counts) throw new Error('resolve_path returned no counts');
+  return result.counts;
+}
+
+describe('resolve_path workspace counts', () => {
+  let fixture: Fixture;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({
+      name: 'Counts Org',
+      slug: 'counts-org',
+    });
+    const user = await createTestUser({ email: 'counts@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const access = await createTestAccessToken(
+      user.id,
+      org.id,
+      (await createTestOAuthClient({ client_name: 'Counts Session' })).client_id
+    );
+    fixture = {
+      orgId: org.id,
+      orgSlug: org.slug,
+      userId: user.id,
+      token: access.token,
+    };
+  });
+
+  it('counts connections the user made, not connectors they could install', async () => {
+    // An installable connector in the catalog is not a connection. This is the
+    // regression: counting `connector_definitions` here reported 1.
+    await createTestConnectorDefinition({
+      key: 'countable-connector',
+      name: 'Countable Connector',
+      organization_id: fixture.orgId,
+    });
+
+    expect((await resolveCounts(fixture)).connections).toBe(0);
+
+    const connection = await createTestConnection({
+      organization_id: fixture.orgId,
+      connector_key: 'countable-connector',
+    });
+    expect((await resolveCounts(fixture)).connections).toBe(1);
+
+    // Soft-deleted connections are gone from the user's point of view.
+    const sql = getTestDb();
+    await sql`UPDATE connections SET deleted_at = NOW() WHERE id = ${connection.id}`;
+    expect((await resolveCounts(fixture)).connections).toBe(0);
+  });
+
+  it('counts MCP clients that authorized into the org, not just those registered to it', async () => {
+    // The connected-apps inventory lists a client if it is registered to the
+    // org OR holds a token in it. A count that checked only `organization_id`
+    // would under-report every client that authorized in — which is most of
+    // them, since dynamic registration leaves `organization_id` null.
+    const before = (await resolveCounts(fixture)).clients;
+
+    const registered = await createTestOAuthClient({ client_name: 'Registered' });
+    const sql = getTestDb();
+    await sql`
+      UPDATE oauth_clients SET organization_id = ${fixture.orgId}
+      WHERE id = ${registered.client_id}
+    `;
+    expect((await resolveCounts(fixture)).clients).toBe(before + 1);
+
+    const authorized = await createTestOAuthClient({ client_name: 'Authorized' });
+    await createTestAccessToken(fixture.userId, fixture.orgId, authorized.client_id);
+    expect((await resolveCounts(fixture)).clients).toBe(before + 2);
+
+    // Registered nowhere and holding no token here: not this workspace's.
+    await createTestOAuthClient({ client_name: 'Stranger' });
+    expect((await resolveCounts(fixture)).clients).toBe(before + 2);
+  });
+
+  it('counts active behaviors', async () => {
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO watchers
+        (organization_id, created_by, watcher_group_id, name, status,
+         notification_channel, notification_priority, min_cooldown_seconds,
+         created_at, updated_at)
+      VALUES
+        (${fixture.orgId}, ${fixture.userId}, 0, 'Live', 'active',
+         'notification', 'normal', 0, NOW(), NOW()),
+        (${fixture.orgId}, ${fixture.userId}, 0, 'Archived', 'archived',
+         'notification', 'normal', 0, NOW(), NOW())
+    `;
+    expect((await resolveCounts(fixture)).behaviors).toBe(1);
+  });
+
+  it('returns counts without include_bootstrap', async () => {
+    // The whole point of moving these out of the bootstrap payload: a page
+    // that only needs to know whether the workspace is empty should not have
+    // to pull entity types, feeds and recent content to find out.
+    const counts = await resolveCounts(fixture, { include_bootstrap: false });
+    expect(counts).toEqual({
+      connections: expect.any(Number),
+      behaviors: expect.any(Number),
+      agents: expect.any(Number),
+      devices: expect.any(Number),
+      clients: expect.any(Number),
+    });
+  });
+});

--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -520,14 +520,15 @@ function buildWorkspaceModel(
   const canonicalPath = `/${organization.slug}`;
   const canonicalUrl = absoluteUrl(canonicalPath, origin);
   const bootstrap = resolvedPath.bootstrap;
-  const summary = bootstrap?.summary;
+  const totalContent = bootstrap?.total_content ?? 0;
+  const counts = resolvedPath.counts;
   const description = truncateText(
     organization.description?.trim() ||
       `Public workspace for ${organization.name} with ${formatCountLabel(
-        summary?.total_content ?? 0,
+        totalContent,
         'knowledge item'
-      )}, ${formatCountLabel(summary?.active_connections ?? 0, 'connector')}, and ${formatCountLabel(
-        summary?.behaviors_count ?? 0,
+      )}, ${formatCountLabel(counts.connections, 'connector')}, and ${formatCountLabel(
+        counts.behaviors,
         'behavior'
       )}.`,
     180
@@ -537,14 +538,14 @@ function buildWorkspaceModel(
     {
       title: 'Workspace Summary',
       html: renderStatList([
-        { label: 'Knowledge', value: formatCountLabel(summary?.total_content ?? 0, 'item') },
+        { label: 'Knowledge', value: formatCountLabel(totalContent, 'item') },
         {
           label: 'Connectors',
-          value: formatCountLabel(summary?.active_connections ?? 0, 'active connector'),
+          value: formatCountLabel(counts.connections, 'connector'),
         },
         {
           label: 'Behaviors',
-          value: formatCountLabel(summary?.behaviors_count ?? 0, 'active behavior'),
+          value: formatCountLabel(counts.behaviors, 'active behavior'),
         },
       ]),
     },

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -170,15 +170,30 @@ const BootstrapEntityTypeSummarySchema = Type.Object({
   entity_count: Type.Integer(),
 });
 
-const BootstrapScopeSummarySchema = Type.Object({
-  total_content: Type.Integer(),
-  active_connections: Type.Integer(),
-  behaviors_count: Type.Integer(),
-  // Org-level regardless of the focused entity (sidebar nav badges).
-  agents_count: Type.Integer(),
+/**
+ * How much of each thing the workspace has. Every field counts a bounded
+ * config table — tens of rows, not history — so the whole struct costs one
+ * cheap round trip and rides every resolve rather than hiding behind
+ * `include_bootstrap`. That is the point: nav badges and onboarding states
+ * need to know whether a workspace is empty on pages that have no reason to
+ * pull a bootstrap payload, and asking them to fetch whole lists to find out
+ * is what this replaces.
+ *
+ * Content counts are deliberately absent — they aggregate `events`, which
+ * grows without bound, so they stay in `bootstrap` where the one consumer
+ * that needs them already asks.
+ */
+const WorkspaceCountsSchema = Type.Object({
+  connections: Type.Integer(),
+  behaviors: Type.Integer(),
+  agents: Type.Integer(),
   // Devices are owned by the requesting user, not the org — count is per-user.
-  devices_count: Type.Integer(),
+  devices: Type.Integer(),
+  // MCP client registrations ("agents you brought"), counted with the same
+  // predicate the connected-apps inventory lists by.
+  clients: Type.Integer(),
 });
+type WorkspaceCounts = Static<typeof WorkspaceCountsSchema>;
 
 const BootstrapContentItemSchema = Type.Object({
   id: Type.Integer(),
@@ -217,7 +232,12 @@ const BootstrapConnectorDefinitionSchema = Type.Object({
 
 export const ResolvePathBootstrapSchema = Type.Object({
   entity_types: Type.Array(BootstrapEntityTypeSummarySchema),
-  summary: BootstrapScopeSummarySchema,
+  /**
+   * Live event rows in scope. Unlike `counts`, this aggregates an append-only
+   * table, so its cost grows with history — it stays bootstrap-gated and out
+   * of the always-on payload.
+   */
+  total_content: Type.Integer(),
   recent_content: Type.Array(BootstrapContentItemSchema),
   recent_feeds: Type.Array(BootstrapFeedItemSchema),
   connector_definitions: Type.Array(BootstrapConnectorDefinitionSchema),
@@ -225,7 +245,6 @@ export const ResolvePathBootstrapSchema = Type.Object({
 export type ResolvePathBootstrap = Static<typeof ResolvePathBootstrapSchema>;
 // Handlers reference these by name; alias each from its schema.
 type BootstrapEntityTypeSummary = Static<typeof BootstrapEntityTypeSummarySchema>;
-type BootstrapScopeSummary = Static<typeof BootstrapScopeSummarySchema>;
 type BootstrapContentItem = Static<typeof BootstrapContentItemSchema>;
 type BootstrapFeedItem = Static<typeof BootstrapFeedItemSchema>;
 type BootstrapConnectorDefinition = Static<typeof BootstrapConnectorDefinitionSchema>;
@@ -265,6 +284,7 @@ export const ResolvePathResultSchema = Type.Object({
   children: Type.Array(ChildEntitySchema),
   siblings: Type.Array(SiblingEntitySchema),
   bootstrap: Type.Union([ResolvePathBootstrapSchema, Type.Null()]),
+  counts: WorkspaceCountsSchema,
   redirect: Type.Union([Type.Object({ to: Type.String() }), Type.Null()]),
 });
 export type ResolvePathResult = Static<typeof ResolvePathResultSchema>;
@@ -389,10 +409,11 @@ async function _resolvePath(
   let entitySegments: string[];
 
   if (remaining.length === 0) {
-    const bootstrap = args.include_bootstrap
-      ? await fetchBootstrap(sql, ctx, workspace, null)
-      : null;
-    return emptyResult(workspace, bootstrap);
+    const [bootstrap, counts] = await Promise.all([
+      args.include_bootstrap ? fetchBootstrap(sql, ctx, workspace, null) : null,
+      resolveWorkspaceCounts(sql, workspace, ctx.userId),
+    ]);
+    return emptyResult(workspace, bootstrap, counts);
   }
 
   entitySegments = remaining;
@@ -525,6 +546,9 @@ async function _resolvePath(
       }
       const redirect = await resolveMergedEntityRedirect(sql, workspace, segment, parentId);
       if (redirect) {
+        // A redirect response is followed, not rendered — the client re-resolves
+        // at `redirect.to` and gets real counts there. Spending a query to fill
+        // a field nothing reads would be pure latency, so leave it zeroed.
         return { ...emptyResult(workspace, null), redirect };
       }
       throw new ToolUserError(
@@ -745,9 +769,10 @@ async function _resolvePath(
     }));
   }
 
-  const bootstrap = args.include_bootstrap
-    ? await fetchBootstrap(sql, ctx, workspace, resolvedEntity)
-    : null;
+  const [bootstrap, counts] = await Promise.all([
+    args.include_bootstrap ? fetchBootstrap(sql, ctx, workspace, resolvedEntity) : null,
+    resolveWorkspaceCounts(sql, workspace, ctx.userId),
+  ]);
 
   return {
     workspace,
@@ -757,6 +782,7 @@ async function _resolvePath(
     children,
     siblings,
     bootstrap,
+    counts,
     redirect: null,
   };
 }
@@ -914,7 +940,8 @@ async function resolveDerivedLeaf(
 
 function emptyResult(
   workspace: ResolvedWorkspace,
-  bootstrap: ResolvePathBootstrap | null
+  bootstrap: ResolvePathBootstrap | null,
+  counts: WorkspaceCounts = EMPTY_WORKSPACE_COUNTS
 ): ResolvePathResult {
   return {
     workspace,
@@ -924,6 +951,7 @@ function emptyResult(
     children: [],
     siblings: [],
     bootstrap,
+    counts,
     redirect: null,
   };
 }
@@ -937,22 +965,16 @@ async function fetchBootstrap(
   if (workspace.type !== 'organization') {
     return {
       entity_types: [],
-      summary: {
-        total_content: 0,
-        active_connections: 0,
-        behaviors_count: 0,
-        agents_count: 0,
-        devices_count: 0,
-      },
+      total_content: 0,
       recent_content: [],
       recent_feeds: [],
       connector_definitions: [],
     };
   }
 
-  const [entityTypes, summary, recentContent, recentFeeds] = await Promise.all([
+  const [entityTypes, totalContent, recentContent, recentFeeds] = await Promise.all([
     listEntityTypes(sql, ctx),
-    fetchScopeSummary(sql, workspace.id, entity, ctx.userId),
+    fetchContentCount(sql, workspace.id, entity),
     fetchRecentContent(sql, workspace.id, entity?.id ?? null),
     fetchRecentFeeds(sql, workspace.id, entity?.id ?? null),
   ]);
@@ -963,7 +985,7 @@ async function fetchBootstrap(
 
   return {
     entity_types: entityTypes,
-    summary,
+    total_content: totalContent,
     recent_content: recentContent,
     recent_feeds: recentFeeds,
     connector_definitions: connectorDefinitions,
@@ -1018,73 +1040,115 @@ async function listEntityTypes(
   }));
 }
 
-async function fetchScopeSummary(
+const EMPTY_WORKSPACE_COUNTS: WorkspaceCounts = {
+  connections: 0,
+  behaviors: 0,
+  agents: 0,
+  devices: 0,
+  clients: 0,
+};
+
+/**
+ * A user space has no org-scoped config to count, so it skips the query
+ * entirely rather than issuing one guaranteed to return zeros.
+ */
+function resolveWorkspaceCounts(
+  sql: DbClient,
+  workspace: ResolvedWorkspace,
+  userId: string | null
+): Promise<WorkspaceCounts> {
+  return workspace.type === 'organization'
+    ? fetchWorkspaceCounts(sql, workspace.id, userId)
+    : Promise.resolve(EMPTY_WORKSPACE_COUNTS);
+}
+
+/**
+ * Every count the nav and onboarding surfaces need, in one round trip.
+ *
+ * All five aggregate bounded config tables, so the cost is flat in history
+ * size and this can run on every resolve. Keeping them in one statement is
+ * what makes that true — the previous split (agents/devices in one query,
+ * connections/behaviors in another) paid two round trips for five scalars.
+ *
+ * `clients` mirrors the predicate in `OAuthClientsStore.listClientsByOrganization`
+ * — registered to this org, or holding a token in it — so the number agrees
+ * with the connected-apps inventory the user can actually see. Counting
+ * `organization_id` alone would under-report every client that authorized in
+ * without registering here.
+ */
+async function fetchWorkspaceCounts(
   sql: DbClient,
   organizationId: string,
-  entity: ResolvedEntityDetails | null,
   userId: string | null
-): Promise<BootstrapScopeSummary> {
-  // Agents are org-scoped; devices are owned by the requesting user. Both are
-  // sidebar-nav badges that don't narrow with the focused entity, so fetch
-  // them regardless of `entity`.
-  const [navRow] = await sql`
-    SELECT
-      (
-        SELECT COUNT(*)::int
-        FROM agents a
-        WHERE a.organization_id = ${organizationId}
-      ) AS agents_count,
-      (
-        SELECT COUNT(*)::int
-        FROM device_workers dw
-        WHERE dw.user_id = ${userId}
-      ) AS devices_count
-  `;
-  const agentsCount = Number((navRow as { agents_count?: number } | undefined)?.agents_count) || 0;
-  const devicesCount =
-    Number((navRow as { devices_count?: number } | undefined)?.devices_count) || 0;
-
-  if (entity) {
-    return {
-      total_content: entity.total_content,
-      active_connections: entity.active_connections,
-      behaviors_count: entity.behaviors_count,
-      agents_count: agentsCount,
-      devices_count: devicesCount,
-    };
-  }
-
+): Promise<WorkspaceCounts> {
   const [row] = await sql`
     SELECT
       (
         SELECT COUNT(*)::int
-        FROM current_event_records ev
-        WHERE ev.organization_id = ${organizationId}
-          -- Exclude null-shaped internal events (P1 corrections) from the org content count.
-          AND ev.semantic_type <> 'correction'
-      ) AS total_content,
-      (
-        SELECT COUNT(*)::int
-        FROM connector_definitions cd
-        WHERE cd.organization_id = ${organizationId}
-          AND cd.status = 'active'
-      ) AS active_connections,
+        FROM connections cn
+        WHERE cn.organization_id = ${organizationId}
+          AND cn.deleted_at IS NULL
+      ) AS connections,
       (
         SELECT COUNT(*)::int
         FROM watchers w
         WHERE w.organization_id = ${organizationId}
           AND w.status = 'active'
-      ) AS behaviors_count
+      ) AS behaviors,
+      (
+        SELECT COUNT(*)::int
+        FROM agents a
+        WHERE a.organization_id = ${organizationId}
+      ) AS agents,
+      (
+        SELECT COUNT(*)::int
+        FROM device_workers dw
+        WHERE dw.user_id = ${userId}
+      ) AS devices,
+      (
+        SELECT COUNT(*)::int
+        FROM oauth_clients oc
+        WHERE oc.organization_id = ${organizationId}
+           OR EXISTS (
+             SELECT 1 FROM oauth_tokens ot
+             WHERE ot.client_id = oc.id
+               AND ot.organization_id = ${organizationId}
+           )
+      ) AS clients
   `;
-
+  const counts = row as Partial<Record<keyof WorkspaceCounts, number>> | undefined;
   return {
-    total_content: Number((row as { total_content?: number } | undefined)?.total_content) || 0,
-    active_connections:
-      Number((row as { active_connections?: number } | undefined)?.active_connections) || 0,
-    behaviors_count: Number((row as { behaviors_count?: number } | undefined)?.behaviors_count) || 0,
-    agents_count: agentsCount,
-    devices_count: devicesCount,
+    connections: Number(counts?.connections) || 0,
+    behaviors: Number(counts?.behaviors) || 0,
+    agents: Number(counts?.agents) || 0,
+    devices: Number(counts?.devices) || 0,
+    clients: Number(counts?.clients) || 0,
   };
+}
+
+/**
+ * Live event rows in scope. This one aggregates an append-only table, so it
+ * is deliberately NOT part of `fetchWorkspaceCounts` — it is reached only
+ * through `include_bootstrap`, so only callers that render bootstrap content
+ * (the public page renderer, the workspace landing route) pay for it. An
+ * entity scope reuses the count already computed while resolving that entity
+ * rather than running a second pass over the same rows.
+ */
+async function fetchContentCount(
+  sql: DbClient,
+  organizationId: string,
+  entity: ResolvedEntityDetails | null
+): Promise<number> {
+  if (entity) return entity.total_content;
+
+  const [row] = await sql`
+    SELECT COUNT(*)::int AS total_content
+    FROM current_event_records ev
+    WHERE ev.organization_id = ${organizationId}
+      -- Exclude null-shaped internal events (P1 corrections) from the org content count.
+      AND ev.semantic_type <> 'correction'
+  `;
+  return Number((row as { total_content?: number } | undefined)?.total_content) || 0;
 }
 
 async function fetchRecentContent(


### PR DESCRIPTION
## Summary

- `BootstrapScopeSummary` fused counts over **bounded config tables** with a `COUNT` over `current_event_records` that **grows with history**. The expensive half forced the whole struct behind `include_bootstrap`, so the cheap half was unavailable to the pages that need it — which is why empty states currently fetch whole lists to learn whether they're empty.
- Split by cost: `counts` (connections, behaviors, agents, devices, **clients**) now rides every resolve; `total_content` stays bootstrap-gated where its only consumer — the public page renderer — already asks.
- Two round trips become one. `agents_count`/`devices_count` were the second trip and had **no consumer anywhere** (`git grep origin/main` → schema + generated types only).

### Defects fixed by the split

**1. `active_connections` counted the wrong table.** Org-wide it was `COUNT(*) FROM connector_definitions WHERE status='active'` — the catalog of *installable* connectors, not anything connected. Meanwhile the entity branch computed the same-named field as `COUNT(DISTINCT connector_key)` over `feeds → connections`. One name, two meanings, and the org-wide one was simply wrong:

| | connector_definitions | connections |
|---|---|---|
| fresh empty workspace | 1 | **0** |
| prod org | 54 | **74** |

Public workspace pages have been rendering that number as "active connectors".

**2. `clients` was missing entirely**, so nothing could tell whether a workspace had any MCP client registered. It mirrors the predicate in `OAuthClientsStore.listClientsByOrganization` — registered to the org **or** holding a token in it — so the count agrees with the connected-apps inventory. Counting `organization_id` alone under-reports every client that authorized in without registering (dynamic registration leaves it null).

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `vitest run src/__tests__/integration/pages/` → 19/19; plus `all-tools-e2e`, `tool-input-fuzz`, `entity-schema/`, `event-render-auto-default` → 74/74
- [x] Bug fix: red→fix→green pasted below

### red → green

New contract test `resolve-path-counts.test.ts` (4 tests). Both fixes mutation-verified — the old source restored, test confirmed red, fix restored, green.

**Mutation 1** — `connections` counting `connector_definitions` (the shipped behavior):

```
× counts connections the user made, not connectors they could install
  → expected 1 to be +0 // Object.is equality
  Tests  1 failed | 3 passed (4)
```

**Mutation 2** — `clients` checking only `oc.organization_id`:

```
× counts MCP clients that authorized into the org, not just those registered to it
  → expected 1 to be 2 // Object.is equality
  Tests  1 failed | 3 passed (4)
```

**Green (both restored):**

```
✓ src/__tests__/integration/pages/public-pages-contract.test.ts (8 tests)
✓ src/__tests__/integration/pages/resolve-path-contract.test.ts  (7 tests)
✓ src/__tests__/integration/pages/resolve-path-counts.test.ts    (4 tests)
  Test Files  3 passed (3)
       Tests  19 passed (19)
```

## Notes

**Breaking response change:** `bootstrap.summary` is gone; `bootstrap.total_content` and top-level `counts` replace it. `packages/client/src/generated/types.gen.ts` is regenerated from the live OpenAPI (the diff is exactly this change — no unrelated drift). No frontend reads `.summary` today, so nothing breaks in-repo.

**Follow-up (separate PR, owletto):** drop the now-stale `BootstrapScopeSummary` interface in `packages/owletto/src/lib/api/entities.ts` and consume `counts` for the activity/onboarding empty states. That's the PR this one unblocks.

**Known, not addressed here:** the entity branch still runs an unconditional `COUNT` over `current_event_records` on every entity resolve (349k rows on prod) to populate `entity.total_content`, which the SPA discards — only public pages render it. Fixing that properly means a write-time counter + migration, so it's its own change.

**Residual risk:** the `clients` count uses `OR EXISTS (oauth_tokens …)`, which is a semi-join rather than a pure bounded-table scan. It matches the existing `listClientsByOrganization` read path precedent.