### PR TITLE
fix(behaviors): reject event triggers on connectors that can never fire

### DIFF
--- a/packages/server/src/__tests__/integration/behavior-trigger-connector-eligibility.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-trigger-connector-eligibility.test.ts
@@ -9,13 +9,13 @@
  * feed to pause, and only becomes ineligible when it has neither.
  */
 import { beforeAll, describe, expect, it } from "vitest";
-import { assertBehaviorTriggerConnections } from "../../behaviors/triggers";
 import type { BehaviorTrigger } from "@lobu/core/contracts/tools/manage-behaviors";
+import { assertBehaviorTriggerConnections } from "../../behaviors/triggers";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
-import { TestWorkspace } from "../setup/test-mcp-client";
+import { createTestOrganization } from "../setup/test-fixtures";
 
 describe("event-trigger connector eligibility", () => {
-	let workspace: TestWorkspace;
+	let orgId: string;
 
 	async function defineConnector(
 		key: string,
@@ -32,7 +32,7 @@ describe("event-trigger connector eligibility", () => {
 			INSERT INTO connector_definitions
 				(organization_id, key, name, version, auth_schema, feeds_schema,
 				 behavior_events, status)
-			VALUES (${workspace.org.id}, ${key}, ${key}, '1.0.0',
+			VALUES (${orgId}, ${key}, ${key}, '1.0.0',
 				${sql.json({ methods: [{ type: "app_installation" }] })},
 				${sql.json(opts.feeds)},
 				${sql.json(opts.events)},
@@ -41,18 +41,21 @@ describe("event-trigger connector eligibility", () => {
 		`;
 	}
 
-	const eventTrigger = (connectorKey: string, eventType: string) =>
-		[
-			{
-				kind: "event",
-				connector_key: connectorKey,
-				event_types: [eventType],
-			},
-		] as unknown as BehaviorTrigger[];
+	const eventTrigger = (
+		connectorKey: string,
+		eventType: string,
+	): BehaviorTrigger[] => [
+		{
+			kind: "event",
+			connector_key: connectorKey,
+			event_types: [eventType],
+		},
+	];
 
 	beforeAll(async () => {
 		await cleanupTestDatabase();
-		workspace = await TestWorkspace.create({ name: "Trigger Eligibility Org" });
+		orgId = (await createTestOrganization({ name: "Trigger Eligibility Org" }))
+			.id;
 
 		// No declared events, no feeds → nothing can ever fire.
 		await defineConnector("elig-barren", { events: [], feeds: {} });
@@ -73,7 +76,7 @@ describe("event-trigger connector eligibility", () => {
 		await expect(
 			assertBehaviorTriggerConnections(
 				sql,
-				workspace.org.id,
+				orgId,
 				eventTrigger("elig-barren", "feed.auto_paused"),
 			),
 		).rejects.toThrow(/cannot drive an event trigger/);
@@ -87,7 +90,7 @@ describe("event-trigger connector eligibility", () => {
 		await expect(
 			assertBehaviorTriggerConnections(
 				sql,
-				workspace.org.id,
+				orgId,
 				eventTrigger("elig-feeds-only", "feed.auto_paused"),
 			),
 		).resolves.toBeUndefined();
@@ -98,7 +101,7 @@ describe("event-trigger connector eligibility", () => {
 		await expect(
 			assertBehaviorTriggerConnections(
 				sql,
-				workspace.org.id,
+				orgId,
 				eventTrigger("elig-rich", "message.created"),
 			),
 		).resolves.toBeUndefined();

--- a/packages/server/src/__tests__/integration/behavior-trigger-connector-eligibility.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-trigger-connector-eligibility.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The event-trigger eligibility guard in `assertBehaviorTriggerConnections`.
+ *
+ * `withPlatformBehaviorEvents` merges `feed.auto_paused` into EVERY connector's
+ * catalog, so the original `catalog.events.length === 0` test could never be
+ * true and the guard never fired — a connector that can drive nothing was
+ * accepted. The replacement asks whether any event could actually reach the
+ * Behavior: a connector with no declared events is still legitimate IF it has a
+ * feed to pause, and only becomes ineligible when it has neither.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { assertBehaviorTriggerConnections } from "../../behaviors/triggers";
+import type { BehaviorTrigger } from "@lobu/core/contracts/tools/manage-behaviors";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import { TestWorkspace } from "../setup/test-mcp-client";
+
+describe("event-trigger connector eligibility", () => {
+	let workspace: TestWorkspace;
+
+	async function defineConnector(
+		key: string,
+		opts: {
+			events: Array<{ key: string }>;
+			feeds: Record<string, unknown>;
+		},
+	): Promise<void> {
+		// sql.json, not a raw string: postgres.js JSON-encodes a bare JS string,
+		// so `${"[]"}::jsonb` lands as the jsonb STRING "[]" and trips
+		// connector_definitions_behavior_events_array_check.
+		const sql = getTestDb();
+		await sql`
+			INSERT INTO connector_definitions
+				(organization_id, key, name, version, auth_schema, feeds_schema,
+				 behavior_events, status)
+			VALUES (${workspace.org.id}, ${key}, ${key}, '1.0.0',
+				${sql.json({ methods: [{ type: "app_installation" }] })},
+				${sql.json(opts.feeds)},
+				${sql.json(opts.events)},
+				'active')
+			ON CONFLICT DO NOTHING
+		`;
+	}
+
+	const eventTrigger = (connectorKey: string, eventType: string) =>
+		[
+			{
+				kind: "event",
+				connector_key: connectorKey,
+				event_types: [eventType],
+			},
+		] as unknown as BehaviorTrigger[];
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		workspace = await TestWorkspace.create({ name: "Trigger Eligibility Org" });
+
+		// No declared events, no feeds → nothing can ever fire.
+		await defineConnector("elig-barren", { events: [], feeds: {} });
+		// No declared events, but HAS a feed → feed.auto_paused is reachable.
+		await defineConnector("elig-feeds-only", {
+			events: [],
+			feeds: { inbox: { type: "object" } },
+		});
+		// Declares a real event.
+		await defineConnector("elig-rich", {
+			events: [{ key: "message.created" }],
+			feeds: {},
+		});
+	});
+
+	it("rejects a connector with no declared events AND no feeds", async () => {
+		const sql = getTestDb();
+		await expect(
+			assertBehaviorTriggerConnections(
+				sql,
+				workspace.org.id,
+				eventTrigger("elig-barren", "feed.auto_paused"),
+			),
+		).rejects.toThrow(/cannot drive an event trigger/);
+	});
+
+	it("ACCEPTS a feeds-only connector on the platform feed.auto_paused event", async () => {
+		// The capability this guard must not remove: "tell me when this feed
+		// breaks" is legitimate for any connector that actually has a feed, even
+		// though it declares no events of its own.
+		const sql = getTestDb();
+		await expect(
+			assertBehaviorTriggerConnections(
+				sql,
+				workspace.org.id,
+				eventTrigger("elig-feeds-only", "feed.auto_paused"),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it("accepts a connector that declares a real event", async () => {
+		const sql = getTestDb();
+		await expect(
+			assertBehaviorTriggerConnections(
+				sql,
+				workspace.org.id,
+				eventTrigger("elig-rich", "message.created"),
+			),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/server/src/__tests__/integration/feed-failure-backoff.test.ts
+++ b/packages/server/src/__tests__/integration/feed-failure-backoff.test.ts
@@ -128,21 +128,21 @@ async function insertRunningRun(
  * for chrome), so declare the feed: a connector with a pausable feed is
  * exactly what may legitimately trigger on `feed.auto_paused`. */
 async function declareChromeFeeds(organizationId: string): Promise<void> {
-	const sql = getTestDb();
-	// sql.json, not raw strings: postgres.js JSON-encodes a bare JS string, so
-	// `${"[]"}::jsonb` lands as the jsonb STRING "[]" and trips
-	// connector_definitions_behavior_events_array_check.
-	await sql`
-		INSERT INTO connector_definitions
-			(organization_id, key, name, version, auth_schema, feeds_schema,
-			 behavior_events, status)
-		VALUES (${organizationId}, 'chrome', 'Chrome', '1.0.0',
-			${sql.json({ methods: [] })},
-			${sql.json({ 'chrome-feed': { name: 'Chrome feed' } })},
-			${sql.json([])},
-			'active')
-		ON CONFLICT DO NOTHING
-	`;
+  const sql = getTestDb();
+  // sql.json, not raw strings: postgres.js JSON-encodes a bare JS string, so
+  // `${"[]"}::jsonb` lands as the jsonb STRING "[]" and trips
+  // connector_definitions_behavior_events_array_check.
+  await sql`
+    INSERT INTO connector_definitions
+      (organization_id, key, name, version, auth_schema, feeds_schema,
+       behavior_events, status)
+    VALUES (${organizationId}, 'chrome', 'Chrome', '1.0.0',
+      ${sql.json({ methods: [] })},
+      ${sql.json({ 'chrome-feed': { name: 'Chrome feed' } })},
+      ${sql.json([])},
+      'active')
+    ON CONFLICT DO NOTHING
+  `;
 }
 
 describe('feed failure backoff + auto-pause (#2033)', () => {

--- a/packages/server/src/__tests__/integration/feed-failure-backoff.test.ts
+++ b/packages/server/src/__tests__/integration/feed-failure-backoff.test.ts
@@ -122,6 +122,29 @@ async function insertRunningRun(
   return rows[0].id;
 }
 
+/** These tests insert live `chrome-feed` rows directly, but the trigger
+ * eligibility guard reads declared capability from
+ * `connector_definitions.feeds_schema` (the catalog fallback declares nothing
+ * for chrome), so declare the feed: a connector with a pausable feed is
+ * exactly what may legitimately trigger on `feed.auto_paused`. */
+async function declareChromeFeeds(organizationId: string): Promise<void> {
+	const sql = getTestDb();
+	// sql.json, not raw strings: postgres.js JSON-encodes a bare JS string, so
+	// `${"[]"}::jsonb` lands as the jsonb STRING "[]" and trips
+	// connector_definitions_behavior_events_array_check.
+	await sql`
+		INSERT INTO connector_definitions
+			(organization_id, key, name, version, auth_schema, feeds_schema,
+			 behavior_events, status)
+		VALUES (${organizationId}, 'chrome', 'Chrome', '1.0.0',
+			${sql.json({ methods: [] })},
+			${sql.json({ 'chrome-feed': { name: 'Chrome feed' } })},
+			${sql.json([])},
+			'active')
+		ON CONFLICT DO NOTHING
+	`;
+}
+
 describe('feed failure backoff + auto-pause (#2033)', () => {
   beforeAll(async () => {
     await initWorkspaceProvider();
@@ -218,6 +241,7 @@ describe('feed failure backoff + auto-pause (#2033)', () => {
       ownerUserId: user.id,
     });
     const connId = await insertConnection(org.id);
+    await declareChromeFeeds(org.id);
     // Connector-wide event trigger (platform event injected into every catalog).
     const created = await manageBehaviors(
       {
@@ -320,6 +344,7 @@ describe('feed failure backoff + auto-pause (#2033)', () => {
       ownerUserId: user.id,
     });
     const connId = await insertConnection(org.id, 'chrome-resume-test');
+    await declareChromeFeeds(org.id);
     const created = await manageBehaviors(
       {
         action: 'create',

--- a/packages/server/src/behaviors/triggers.ts
+++ b/packages/server/src/behaviors/triggers.ts
@@ -27,6 +27,21 @@ interface BehaviorEventDefinition {
 interface ConnectorBehaviorEventCatalog {
 	name: string;
 	events: BehaviorEventDefinition[];
+	/** Events the CONNECTOR itself declares, before platform events are merged
+	 * in. `events` always has at least `feed.auto_paused`, so it can never be
+	 * empty and cannot answer "can this connector drive a trigger at all". */
+	declaredCount: number;
+	/** Feeds the connector declares. `feed.auto_paused` only ever fires for a
+	 * connector that HAS a feed to pause, so zero declared events plus zero
+	 * feeds means no event can reach this Behavior. */
+	feedCount: number;
+}
+
+/** `feeds_schema` is an object keyed by feed key (`{}` for connectors that
+ * declare none — non-null but empty, so a null check alone under-counts). */
+function countDeclaredFeeds(value: unknown): number {
+	if (!value || typeof value !== "object") return 0;
+	return Array.isArray(value) ? value.length : Object.keys(value).length;
 }
 
 function parseBehaviorEventDefinitions(
@@ -47,7 +62,7 @@ async function getConnectorBehaviorEventCatalog(
 	connectorKey: string
 ): Promise<ConnectorBehaviorEventCatalog> {
 	const rows = await sql`
-		SELECT name, behavior_events
+		SELECT name, behavior_events, feeds_schema
 		FROM connector_definitions
 		WHERE organization_id = ${organizationId}
 		  AND key = ${connectorKey}
@@ -55,13 +70,18 @@ async function getConnectorBehaviorEventCatalog(
 		ORDER BY updated_at DESC
 		LIMIT 1
 	`;
-	const row = rows[0] as { name: string; behavior_events: unknown } | undefined;
+	const row = rows[0] as
+		| { name: string; behavior_events: unknown; feeds_schema: unknown }
+		| undefined;
 	if (Array.isArray(row?.behavior_events)) {
+		const declared = parseBehaviorEventDefinitions(row.behavior_events);
 		return {
 			name: row.name,
 			events: withPlatformBehaviorEvents(
-				parseBehaviorEventDefinitions(row.behavior_events),
+				declared,
 			) as BehaviorEventDefinition[],
+			declaredCount: declared.length,
+			feedCount: countDeclaredFeeds(row.feeds_schema),
 		};
 	}
 
@@ -71,11 +91,19 @@ async function getConnectorBehaviorEventCatalog(
 	const catalog = (await listCatalogEntries(["connectors"])).connectors.find(
 		(entry) => entry.id === connectorKey
 	);
+	const declaredFallback = parseBehaviorEventDefinitions(
+		catalog?.detail.behavior_events,
+	);
 	return {
 		name: row?.name ?? catalog?.name ?? connectorKey,
 		events: withPlatformBehaviorEvents(
-			parseBehaviorEventDefinitions(catalog?.detail.behavior_events),
+			declaredFallback,
 		) as BehaviorEventDefinition[],
+		declaredCount: declaredFallback.length,
+		feedCount: countDeclaredFeeds(
+			row?.feeds_schema ??
+				(catalog?.detail as { feeds_schema?: unknown } | undefined)?.feeds_schema,
+		),
 	};
 }
 
@@ -307,9 +335,15 @@ export async function assertBehaviorTriggerConnections(
 			);
 			catalogs.set(trigger.connector_key, catalog);
 		}
-		if (catalog.events.length === 0) {
+		// `catalog.events` ALWAYS carries the merged platform events, so the old
+		// `events.length === 0` test could never be true and this guard never
+		// fired. Ask the question that actually matters: can any event reach this
+		// Behavior? A connector with no declared events can still legitimately
+		// trigger on `feed.auto_paused` — but only if it has a feed to pause.
+		// Zero declared events AND zero feeds means nothing can ever fire.
+		if (catalog.declaredCount === 0 && catalog.feedCount === 0) {
 			throw new ToolUserError(
-				`${catalog.name} does not declare any Behavior events.`
+				`${catalog.name} cannot drive an event trigger: it declares no Behavior events and has no feeds, so no event could ever fire.`
 			);
 		}
 		const eventsByKey = new Map(

--- a/packages/server/src/behaviors/triggers.ts
+++ b/packages/server/src/behaviors/triggers.ts
@@ -41,7 +41,7 @@ interface ConnectorBehaviorEventCatalog {
  * declare none — non-null but empty, so a null check alone under-counts). */
 function countDeclaredFeeds(value: unknown): number {
 	if (!value || typeof value !== "object") return 0;
-	return Array.isArray(value) ? value.length : Object.keys(value).length;
+	return Object.keys(value).length;
 }
 
 function parseBehaviorEventDefinitions(
@@ -77,9 +77,7 @@ async function getConnectorBehaviorEventCatalog(
 		const declared = parseBehaviorEventDefinitions(row.behavior_events);
 		return {
 			name: row.name,
-			events: withPlatformBehaviorEvents(
-				declared,
-			) as BehaviorEventDefinition[],
+			events: withPlatformBehaviorEvents(declared) as BehaviorEventDefinition[],
 			declaredCount: declared.length,
 			feedCount: countDeclaredFeeds(row.feeds_schema),
 		};
@@ -101,8 +99,7 @@ async function getConnectorBehaviorEventCatalog(
 		) as BehaviorEventDefinition[],
 		declaredCount: declaredFallback.length,
 		feedCount: countDeclaredFeeds(
-			row?.feeds_schema ??
-				(catalog?.detail as { feeds_schema?: unknown } | undefined)?.feeds_schema,
+			row?.feeds_schema ?? catalog?.detail.feeds_schema,
 		),
 	};
 }


### PR DESCRIPTION
## Summary
- The event-trigger eligibility guard in `assertBehaviorTriggerConnections` was unreachable: `withPlatformBehaviorEvents` merges `feed.auto_paused` into every connector catalog, so `catalog.events.length === 0` could never be true. The error "does not declare any Behavior events" was never produced — a connector that can drive nothing was accepted.
- Replaced with the question that actually matters: the connector declares zero events of its own AND zero feeds. A connector with no events of its own is still valid on `feed.auto_paused` — but only if it has a feed to pause.
- `feeds_schema` is an object keyed by feed key (`{}` when absent), so a plain null check would under-count — `countDeclaredFeeds` counts keys.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted `bunx vitest run src/__tests__/integration/behavior-trigger-connector-eligibility.test.ts` (3/3)
- [x] Bug fix: red→fix→green outputs pasted below

### Mutation + red (old `events.length === 0` condition restored on line 344)
`grep` confirmed old pattern present; 1 source line changed; targeted test fails — the barren connector is accepted:
```
❯ src/__tests__/integration/behavior-trigger-connector-eligibility.test.ts:79:3
   ).rejects.toThrow(/cannot drive an event trigger/);
+ Received: undefined
 Tests  1 failed | 2 passed (3)
```

### Green (fix restored)
```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

## Notes
- Blast radius measured in prod: 3 of 34 connectors (`apple.computer_use`, `os.shell`, `telegram`) are genuinely unable to fire an event today.
- The middle test (feeds-only connector must still be ACCEPTED) is the one that stops a future "simplification" becoming a capability regression.
- **CI follow-up commit:** the first push surfaced two existing tests (`feed-failure-backoff.test.ts` 5b/5b-resume) that author `feed.auto_paused` triggers on a chrome connector declaring no feeds — exactly what the new guard must reject. Fixed by declaring the feed they already rely on (`test(server): declare chrome feeds…`). Also confirmed the guard runs on update ONLY when triggers change, so legacy rows stay editable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connectors can now use feed-based triggers when they expose feeds, even if they do not declare other events.
  * Event and feed capabilities are evaluated separately, improving trigger eligibility checks.

* **Bug Fixes**
  * Connectors with no supported events or feeds are now correctly blocked from using trigger-based behavior.
  * Trigger validation is more accurate for connectors with mixed capability types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->