### PR TITLE
fix(ci): key each UI review proof to the Lobu PR that owns it

### DIFF
--- a/scripts/__tests__/ui-review-command.test.ts
+++ b/scripts/__tests__/ui-review-command.test.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { approvalCommand } from "../lib/ui-review-proof";
+import { approvalCommand, buildProofBody } from "../lib/ui-review-proof";
 
 const UI_REVIEW_SCRIPT = resolve(import.meta.dir, "..", "ui-review.ts");
 const BASE_POINTER = "1".repeat(40);
@@ -265,6 +265,105 @@ describe("ui-review command", () => {
       context: "ui-review",
       state: "pending",
     });
+  });
+
+  it("keeps its own proof when another Lobu PR pins the same Owletto commit", () => {
+    const fixture = createFixture();
+    const state = readState(fixture.stateFile);
+    const proofEndpoint = "repos/lobu-ai/owletto/issues/712/comments";
+    state.comments[proofEndpoint] = [
+      {
+        id: 800,
+        body: buildProofBody({
+          version: 1,
+          lobu_repo: "lobu-ai/lobu",
+          lobu_pr: 2499,
+          lobu_base_owletto_sha: BASE_POINTER,
+          owletto_sha: HEAD_POINTER,
+          owletto_pr: 712,
+          artifact_url: "https://claude.ai/code/artifact/other-pr",
+        }),
+        created_at: "2026-08-04T11:00:00Z",
+        updated_at: "2026-08-04T11:00:00Z",
+        html_url: "https://github.com/comment/800",
+        user: { login: "agent" },
+      },
+      {
+        id: 801,
+        body: buildProofBody({
+          version: 1,
+          lobu_repo: "lobu-ai/lobu",
+          lobu_pr: 2500,
+          lobu_base_owletto_sha: BASE_POINTER,
+          owletto_sha: HEAD_POINTER,
+          owletto_pr: 712,
+          artifact_url: "https://claude.ai/code/artifact/ours",
+        }),
+        created_at: "2026-08-04T12:00:00Z",
+        updated_at: "2026-08-04T12:00:00Z",
+        html_url: "https://github.com/comment/801",
+        user: { login: "agent" },
+      },
+      {
+        id: 802,
+        body: approvalCommand(HEAD_POINTER),
+        created_at: "2026-08-04T12:01:00Z",
+        updated_at: "2026-08-04T12:01:00Z",
+        html_url: "https://github.com/comment/802",
+        user: { login: "buremba" },
+      },
+    ];
+    writeFileSync(fixture.stateFile, JSON.stringify(state));
+
+    const result = runUiReview(fixture);
+
+    expectExit(result, 0);
+    const finalState = readState(fixture.stateFile);
+    expect(
+      finalState.calls
+        .filter((call) => call.endpoint.includes("/statuses/"))
+        .at(-1)?.payload
+    ).toMatchObject({ context: "ui-review", state: "success" });
+    expect(finalState.comments[proofEndpoint]?.[0]?.body).toContain(
+      "https://claude.ai/code/artifact/other-pr"
+    );
+  });
+
+  it("adds its proof beside another PR's instead of overwriting it", () => {
+    const fixture = createFixture();
+    const state = readState(fixture.stateFile);
+    const proofEndpoint = "repos/lobu-ai/owletto/issues/712/comments";
+    state.comments[proofEndpoint] = [
+      {
+        id: 800,
+        body: buildProofBody({
+          version: 1,
+          lobu_repo: "lobu-ai/lobu",
+          lobu_pr: 2499,
+          lobu_base_owletto_sha: BASE_POINTER,
+          owletto_sha: HEAD_POINTER,
+          owletto_pr: 712,
+          artifact_url: "https://claude.ai/code/artifact/other-pr",
+        }),
+        created_at: "2026-08-04T11:00:00Z",
+        updated_at: "2026-08-04T11:00:00Z",
+        html_url: "https://github.com/comment/800",
+        user: { login: "agent" },
+      },
+    ];
+    writeFileSync(fixture.stateFile, JSON.stringify(state));
+
+    const result = runUiReview(fixture, {
+      ARTIFACT: "https://claude.ai/code/artifact/ours",
+    });
+
+    expectExit(result, 3);
+    const comments = readState(fixture.stateFile).comments[proofEndpoint] ?? [];
+    expect(comments[0]?.body).toContain(
+      "https://claude.ai/code/artifact/other-pr"
+    );
+    expect(comments).toHaveLength(2);
+    expect(comments[1]?.body).toContain("https://claude.ai/code/artifact/ours");
   });
 
   it("stays pending until a later exact approval comment, then passes", () => {

--- a/scripts/__tests__/ui-review-proof.test.ts
+++ b/scripts/__tests__/ui-review-proof.test.ts
@@ -3,6 +3,7 @@ import {
   approvalCommand,
   buildProofBody,
   findApproval,
+  findProofComment,
   isHttpsArtifact,
   parseProof,
   proofMatches,
@@ -54,6 +55,31 @@ describe("UI review proof", () => {
         `discussion <!-- lobu-ui-review-proof ${JSON.stringify(proof)} -->`
       )
     ).toBeNull();
+  });
+
+  it("picks the proof this Lobu PR owns when several share one Owletto PR", () => {
+    const foreign: UiReviewProof = { ...proof, lobu_pr: 2499 };
+    const fork: UiReviewProof = { ...proof, lobu_repo: "fork/lobu" };
+    const comment = (body: string, id: string): UiReviewComment => ({
+      body,
+      created_at: "2026-08-04T10:00:00Z",
+      html_url: `https://github.com/lobu-ai/owletto/pull/712#${id}`,
+      user: { login: "agent" },
+    });
+    const comments = [
+      comment("just discussing the proof", "chatter"),
+      comment(buildProofBody(foreign), "foreign"),
+      comment(buildProofBody(fork), "fork"),
+      comment(buildProofBody(proof), "ours"),
+    ];
+
+    expect(
+      findProofComment(comments, "lobu-ai/lobu", 2500)?.html_url
+    ).toEndWith("#ours");
+    expect(
+      findProofComment(comments, "lobu-ai/lobu", 2499)?.html_url
+    ).toEndWith("#foreign");
+    expect(findProofComment(comments, "lobu-ai/lobu", 2501)).toBeUndefined();
   });
 
   it("binds approval to both ends of the deployed Owletto range", () => {

--- a/scripts/lib/ui-review-proof.ts
+++ b/scripts/lib/ui-review-proof.ts
@@ -98,6 +98,22 @@ export function parseProof(body: string): UiReviewProof | null {
   }
 }
 
+/**
+ * Selects the proof this Lobu PR owns. Several Lobu PRs can pin the same
+ * Owletto squash commit and therefore share one Owletto PR, so the marker
+ * alone does not identify a proof — the encoded `lobu_repo`/`lobu_pr` does.
+ */
+export function findProofComment<Comment extends UiReviewComment>(
+  comments: Comment[],
+  lobuRepo: string,
+  lobuPr: number
+): Comment | undefined {
+  return comments.find((comment) => {
+    const proof = parseProof(comment.body);
+    return proof?.lobu_repo === lobuRepo && proof.lobu_pr === lobuPr;
+  });
+}
+
 export function proofMatches(
   proof: UiReviewProof,
   lobuRepo: string,

--- a/scripts/ui-review.ts
+++ b/scripts/ui-review.ts
@@ -5,6 +5,7 @@ import {
   approvalCommand,
   buildProofBody,
   findApproval,
+  findProofComment,
   isHttpsArtifact,
   type OwlettoPullRequest,
   parseProof,
@@ -15,7 +16,6 @@ import {
 } from "./lib/ui-review-proof";
 
 const STATUS_CONTEXT = "ui-review";
-const PROOF_MARKER = "<!-- lobu-ui-review-proof ";
 const PARENT_MARKER = "<!-- lobu-ui-review-marker -->";
 
 interface PullRequestView {
@@ -145,13 +145,12 @@ function findComment(
   );
 }
 
-function upsertComment(
+function writeComment(
   repo: string,
   issue: number,
-  marker: string,
+  existing: ApiComment | undefined,
   body: string
 ): ApiComment {
-  const existing = findComment(repo, issue, marker);
   if (existing) {
     return ghApi<ApiComment>(
       `repos/${repo}/issues/comments/${existing.id}`,
@@ -162,6 +161,15 @@ function upsertComment(
   return ghApi<ApiComment>(`repos/${repo}/issues/${issue}/comments`, "POST", {
     body,
   });
+}
+
+function upsertComment(
+  repo: string,
+  issue: number,
+  marker: string,
+  body: string
+): ApiComment {
+  return writeComment(repo, issue, findComment(repo, issue, marker), body);
 }
 
 function getPointer(repo: string, commit: string): string {
@@ -317,9 +325,7 @@ function main(): number {
   let comments = ghApiPages<ApiComment>(
     `repos/${owlettoRepo}/issues/${owlettoPr.number}/comments`
   );
-  let proofComment = comments.find((comment) =>
-    comment.body.startsWith(PROOF_MARKER)
-  );
+  let proofComment = findProofComment(comments, lobuRepo, parentPr.number);
   let currentProof = proofComment ? parseProof(proofComment.body) : null;
   const exactProof =
     currentProof &&
@@ -359,10 +365,10 @@ function main(): number {
       owletto_pr: owlettoPr.number,
       artifact_url: options.artifactUrl,
     };
-    proofComment = upsertComment(
+    proofComment = writeComment(
       owlettoRepo,
       owlettoPr.number,
-      PROOF_MARKER,
+      proofComment,
       buildProofBody(currentProof)
     );
     comments = ghApiPages<ApiComment>(


### PR DESCRIPTION
## Summary
Two Lobu PRs can pin the same Owletto squash commit, so they share one Owletto PR — #2508 and #2511 did exactly that. The gate located *the* proof with `comments.find(c => c.body.startsWith(PROOF_MARKER))` and rewrote it in place via `upsertComment(..., PROOF_MARKER, ...)`, which matches on the same prefix. Whichever PR ran the gate last took the other's comment.

The marker is not an identity. The proof payload already carries `lobu_repo` and `lobu_pr`; this keys selection and the write on that instead.

Two failures this removes, both silent:

- **The victim's gate broke.** With the thief's proof first in the list, `proofMatches` failed for the real owner, so `make ui-review` reported `UI proof missing; rerun make ui-review with ARTIFACT=...` — a PR whose proof was posted, and approved, being told it has none.
- **The victim's approval was reset.** `findApproval` only accepts comments newer than `proofComment.updated_at`. PATCHing the shared comment bumped that timestamp, so an already-granted `/ui-approve` silently stopped counting.

`upsertComment` now delegates to a `writeComment(repo, issue, existing, body)` that takes the comment to update rather than a prefix to search for; the proof path passes the comment it selected by owner. There is no separate "fail loudly on rebind" guard because once the key is right, overwriting another PR's proof is unreachable — a runtime check for it would be dead code. The second test below is what holds that property.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: targeted `bun test scripts/__tests__/ui-review-proof.test.ts scripts/__tests__/ui-review-command.test.ts` (15/15)
- [x] Bug fix: red→fix→green outputs pasted below

Three tests: one unit test on `findProofComment` (skips a foreign `lobu_pr`, a foreign `lobu_repo`, and marker-shaped chatter), and two end-to-end runs against the mock GitHub harness — the victim path and the theft path.

### Red — mutation restores the two old call sites (12 insertions, 3 deletions in `scripts/ui-review.ts`; `grep -c 'comment.body.startsWith(PROOF_MARKER)'` = 1)

```
error: expected exit 0, got 2: No current proof on https://github.com/lobu-ai/owletto/pull/712. Rerun with ARTIFACT=<hosted HTTPS comparison>.
(fail) ui-review command > keeps its own proof when another Lobu PR pins the same Owletto commit

error: expect(received).toContain(expected)
Expected to contain: "https://claude.ai/code/artifact/other-pr"
Received: "<!-- lobu-ui-review-proof eyJ2ZXJzaW9uIjoxLCJsb2J1X3JlcG8iOiJsb2J1LWFpL2xvYnUiLCJsb2J1X3ByIjoyNTAwLCJ... -->\n## UI review required\n\nThis proof covers the Owletto version proposed by lobu-ai/lobu#2500.
(fail) ui-review command > adds its proof beside another PR's instead of overwriting it

 4 pass
 2 fail
```

The received body in the second failure is the thief's proof sitting at the victim's comment id — the overwrite, verbatim.

### Green — fix restored (`grep -c` = 0)

```
 15 pass
 0 fail
 38 expect() calls
Ran 15 tests across 2 files. [3.70s]
```

## Notes
- Existing proof comments keep working: the marker and the encoded payload are unchanged, so a proof already posted for a PR is still found — by its payload now rather than its position.
- Not addressed here: `/ui-approve <owletto_sha>` is keyed by the Owletto SHA alone, so one admin approval still satisfies every Lobu PR pinning that SHA whose proof predates it. That is defensible — the approved UI is byte-identical — but it is a separate decision from proof ownership.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review verification so proofs from multiple pull requests and repositories are handled correctly.
  * Preserved existing proofs when adding a new proof instead of overwriting unrelated entries.
  * Improved matching of proof comments to the requested repository and pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->