### PR TITLE
fix(server): park a Behavior for a day when the provider balance is empty

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -227,6 +227,9 @@ describe("provider quota reset parsing", () => {
     // Gemini's per-minute free-tier 429 reuses OpenAI's billing wording but
     // names a retry horizon — the horizon is what marks it self-healing.
     "429 You exceeded your current quota, please check your plan and billing details. Please retry in 26.5s.",
+    // Every spelling of a named horizon, including the quoted header form.
+    "429 insufficient quota; retryDelay: 26s",
+    "429 out of credits (Retry-After: 30)",
   ])("does not park a self-healing rate limit (%s)", (message) => {
     const now = new Date("2026-08-05T10:00:00.000Z");
 

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -174,6 +174,78 @@ describe("provider quota reset parsing", () => {
     ).toBeNull();
   });
 
+  it("parks a reset-less balance exhaustion for a day", () => {
+    const now = new Date("2026-08-05T10:00:00.000Z");
+
+    expect(
+      providerQuotaResetNotBefore(
+        "z.ai returned an error: 429 Insufficient balance or no resource package",
+        "PROVIDER_QUOTA_EXHAUSTED",
+        now
+      )?.toISOString()
+    ).toBe("2026-08-06T10:00:00.000Z");
+    expect(
+      deviceProviderQuotaResetNotBefore(
+        "429 Insufficient balance or no resource package",
+        now
+      )?.toISOString()
+    ).toBe("2026-08-06T10:00:00.000Z");
+    // No "429"/rate-limit token: balance wording alone must count as device
+    // quota evidence.
+    expect(
+      deviceProviderQuotaResetNotBefore(
+        "Insufficient balance or no resource package",
+        now
+      )?.toISOString()
+    ).toBe("2026-08-06T10:00:00.000Z");
+    // OpenAI's insufficient_quota billing message names no retry horizon.
+    expect(
+      providerQuotaResetNotBefore(
+        "429 You exceeded your current quota, please check your plan and billing details.",
+        "PROVIDER_QUOTA_EXHAUSTED",
+        now
+      )?.toISOString()
+    ).toBe("2026-08-06T10:00:00.000Z");
+  });
+
+  it("prefers a named reset over the balance park", () => {
+    const now = new Date("2026-08-05T10:00:00.000Z");
+
+    expect(
+      providerQuotaResetNotBefore(
+        "429 Insufficient balance. Your limit will reset at 2026-08-05 12:00:00",
+        "PROVIDER_QUOTA_EXHAUSTED",
+        now
+      )?.toISOString()
+    ).toBe("2026-08-05T12:01:00.000Z");
+  });
+
+  it.each([
+    "Gemini returned an error: 429 status code (no body)",
+    "429 Too Many Requests",
+    "rate limit exceeded, retry shortly",
+    // Gemini's per-minute free-tier 429 reuses OpenAI's billing wording but
+    // names a retry horizon — the horizon is what marks it self-healing.
+    "429 You exceeded your current quota, please check your plan and billing details. Please retry in 26.5s.",
+  ])("does not park a self-healing rate limit (%s)", (message) => {
+    const now = new Date("2026-08-05T10:00:00.000Z");
+
+    expect(
+      providerQuotaResetNotBefore(message, "PROVIDER_QUOTA_EXHAUSTED", now)
+    ).toBeNull();
+    expect(deviceProviderQuotaResetNotBefore(message, now)).toBeNull();
+  });
+
+  it("still requires quota classification for balance wording", () => {
+    const now = new Date("2026-08-05T10:00:00.000Z");
+    const message = "Insufficient balance";
+
+    expect(
+      providerQuotaResetNotBefore(message, "NO_MODEL_CONFIGURED", now)
+    ).toBeNull();
+    expect(providerQuotaResetNotBefore(message, undefined, now)).toBeNull();
+  });
+
   it("requires the structured quota code", () => {
     const message = "Your limit will reset at 2026-07-31 12:00:00";
     const now = new Date("2026-07-31T10:00:00.000Z");
@@ -330,6 +402,35 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
     const expectedNotBefore =
       Math.floor(resetAt.getTime() / 1000) * 1000 + 60_000;
     expect(after.getTime()).toBe(expectedNotBefore);
+  });
+
+  it("parks an hourly Behavior for a day when the provider balance is empty", async () => {
+    const { watcherId, runId } = await createDueWatcherWithDispatchedRun({
+      slug: "park-empty-balance-for-a-day",
+      messageId: "msg-empty-balance",
+    });
+    const before = Date.now();
+
+    await resolveWatcherRunsByMessageIds(["msg-empty-balance"], {
+      ok: false,
+      error:
+        "z.ai returned an error: 429 Insufficient balance or no resource package",
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+    });
+
+    const sql = getTestDb();
+    const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+
+    // Without the park this lands on the next hourly tick (< 1h out), which is
+    // exactly the one-failed-run-per-tick burn the park exists to stop.
+    const after = await cursorOf(watcherId);
+    expect(after.getTime()).toBeGreaterThanOrEqual(
+      before + 24 * 60 * 60 * 1000
+    );
+    expect(after.getTime()).toBeLessThanOrEqual(
+      Date.now() + 24 * 60 * 60 * 1000
+    );
   });
 
   it("does not shorten a quota park when another run finishes later", async () => {

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -116,11 +116,14 @@ const PROVIDER_BALANCE_PARK_MS = 24 * 60 * 60 * 1000;
  * still runs immediately because parking only moves the cron cursor.
  */
 function balanceExhaustedNotBefore(message: string, now: Date): Date | null {
-	// A provider-named retry horizon ("Please retry in 26s", retryDelay) means
-	// the limit is windowed, not a balance — Gemini attaches one to its
-	// per-minute free-tier 429s while reusing OpenAI's billing wording
-	// ("exceeded your current quota"). Never day-park those.
-	if (/retry (?:in|after)\s|retry[_-]?delay/i.test(message)) return null;
+	// A provider-named retry horizon ("Please retry in 26s", `retryDelay`, a
+	// quoted `Retry-After:` header) means the limit is windowed, not a balance —
+	// Gemini attaches one to its per-minute free-tier 429s while reusing
+	// OpenAI's billing wording ("exceeded your current quota"). Never day-park
+	// those. The separator class covers every spelling of the header because a
+	// missed horizon costs a wrong day-park, while a spurious one costs only the
+	// pre-existing one-run-per-tick.
+	if (/\bretry[-_ ]?(?:in|after|delay)\b/i.test(message)) return null;
 	return PROVIDER_BALANCE_EXHAUSTED.test(message)
 		? new Date(now.getTime() + PROVIDER_BALANCE_PARK_MS)
 		: null;

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -90,11 +90,51 @@ export function parseProviderQuotaResetAt(
 }
 
 /**
+ * A depleted balance is not a rate limit: it does not tick back on a timer, so
+ * the provider has no reset to name and never will until a human tops the
+ * account up. Retrying one of these on every cron tick burns a failed run per
+ * tick forever — z.ai's "429 Insufficient balance or no resource package" cost
+ * ~85 of them across two Behaviors before anyone looked.
+ *
+ * Matched strictly on balance/billing wording, NOT on the broader quota
+ * evidence set: a windowed rate limit ("too many requests", Gemini's bodyless
+ * 429) DOES self-heal, often within the minute, and parking it for a day would
+ * be far worse than one wasted run per tick.
+ */
+const PROVIDER_BALANCE_EXHAUSTED =
+	/credit balance is too low|insufficient (?:credits?|balance|funds)\b|no resource package|billing_hard_limit_reached|payment required|exceeded your current quota|out of credits?\b|no credits remaining/i;
+
+const PROVIDER_BALANCE_PARK_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Fallback boundary for a terminal quota error the provider did not date.
+ *
+ * Deliberately a fixed park rather than an escalating backoff: the recovery
+ * signal is a human adding funds, which no amount of waiting predicts, and a
+ * growing park would need durable per-provider attempt state to compute. A flat
+ * day bounds the waste at one run instead of one per tick, and a manual trigger
+ * still runs immediately because parking only moves the cron cursor.
+ */
+function balanceExhaustedNotBefore(message: string, now: Date): Date | null {
+	// A provider-named retry horizon ("Please retry in 26s", retryDelay) means
+	// the limit is windowed, not a balance — Gemini attaches one to its
+	// per-minute free-tier 429s while reusing OpenAI's billing wording
+	// ("exceeded your current quota"). Never day-park those.
+	if (/retry (?:in|after)\s|retry[_-]?delay/i.test(message)) return null;
+	return PROVIDER_BALANCE_EXHAUSTED.test(message)
+		? new Date(now.getTime() + PROVIDER_BALANCE_PARK_MS)
+		: null;
+}
+
+/**
  * Resolve a provider reset boundary for a terminal error.
  *
  * Structured worker/API paths must explicitly classify the error as quota
  * exhaustion; this prevents an unrelated provider sentence containing
  * "reset at" from moving a schedule.
+ *
+ * A named reset always wins — it is the provider's own answer. Only when there
+ * is none do we fall back to the balance-exhaustion park.
  */
 export function providerQuotaResetNotBefore(
 	message: string,
@@ -104,24 +144,36 @@ export function providerQuotaResetNotBefore(
 	if (errorCode !== AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED) {
 		return null;
 	}
-	return parseProviderQuotaResetAt(message, now);
+	return (
+		parseProviderQuotaResetAt(message, now) ??
+		balanceExhaustedNotBefore(message, now)
+	);
 }
 
 /**
- * Device CLI reports do not carry a structured error code, so require both an
- * explicit reset timestamp and provider-quota wording before moving a durable
- * schedule. This prevents unrelated stderr such as "session resets at ..."
+ * Device CLI reports do not carry a structured error code, so require
+ * provider-quota wording before moving a durable schedule, plus either the
+ * provider's own reset timestamp or balance-exhaustion wording for the
+ * boundary. This prevents unrelated stderr such as "session resets at ..."
  * from parking a Behavior.
  */
 export function deviceProviderQuotaResetNotBefore(
 	message: string,
 	now: Date = new Date()
 ): Date | null {
+	// Balance wording is quota evidence by definition; composing the matchers
+	// keeps them in lockstep so a new balance alternate cannot silently fail to
+	// park on this path.
 	const hasQuotaEvidence =
-		/credit balance is too low|insufficient (?:credits?|balance|funds|quota)\b|billing_hard_limit_reached|payment required|exceeded your current quota|out of credits?\b|weekly\/monthly limit exhausted|limit exhausted|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
+		PROVIDER_BALANCE_EXHAUSTED.test(message) ||
+		/insufficient quota\b|limit exhausted|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
 			message
 		);
-	return hasQuotaEvidence ? parseProviderQuotaResetAt(message, now) : null;
+	if (!hasQuotaEvidence) return null;
+	return (
+		parseProviderQuotaResetAt(message, now) ??
+		balanceExhaustedNotBefore(message, now)
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

- A depleted provider **balance** is not a rate limit: it names no reset and never self-heals until a human tops the account up. `providerQuotaResetNotBefore` only parked on a parseable `reset at <date>`, so z.ai's `429 Insufficient balance or no resource package` fell through to the plain cron advance and burned **one failed run every tick, indefinitely** — ~85 runs across Behaviors 5 and 71 on 2026-08-03 before anyone looked.
- Falls back to a flat **24h park** when a terminal quota error carries balance/billing wording and no date. A provider-named reset still wins.
- Self-healing limits are excluded two ways: the balance matcher is narrower than the quota-evidence set (Gemini's bodyless 429, "too many requests" never match), and **any message naming a retry horizon** (`retry in 26.5s`, `retryDelay`) never parks — Gemini's per-minute free-tier 429 reuses OpenAI's `exceeded your current quota` billing wording verbatim.

Both helpers are the chokepoint the three terminal paths already route through (`run-completion.ts` cloud turns, `run-lifecycle.ts` device CLI, `chat-response-bridge.ts` reply-to-source), so no new call sites.

Part of #2350 — this is the "gap 2" refinement the issue's triage comment left open. Provider **failover** (gap 1) still needs the product decision and is untouched.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `vitest run src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts` (embedded PG18)
- [x] Bug fix: red→fix→green outputs pasted below

### Red (tests written, fix reverted)

```
 ❯ src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts (38 tests | 2 failed) 623ms
   × provider quota reset parsing > parks a reset-less balance exhaustion for a day 4ms
     → expected undefined to be '2026-08-06T10:00:00.000Z' // Object.is equality
   × a terminally failed Behavior run advances next_run_at > parks an hourly Behavior for a day when the provider balance is empty 15ms
     → expected 1785945600000 to be greater than or equal to 1786031496261

 Test Files  1 failed (1)
      Tests  2 failed | 36 passed (38)
```

`1785945600000` is the next hourly cron tick — precisely the one-failed-run-per-tick burn.

### Green (fix applied)

```
 ✓ src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts (39 tests) 642ms
 Test Files  1 passed (1)
      Tests  39 passed (39)
```

### Mutation check — the retry-horizon guard is load-bearing

Deleted the `retry (in|after)|retryDelay` line from `balanceExhaustedNotBefore` (verified the source no longer contains it), reran:

```
mutation applied: horizon guard removed
   × provider quota reset parsing > does not park a self-healing rate limit (429 You exceeded your current quota, please check your plan and billing details. Please retry in 26.5s.) 6ms
 Test Files  1 failed (1)
      Tests  1 failed | 38 passed (39)
```

Restored, green again.

## Notes

**Why a flat 24h and not an escalating backoff.** The recovery signal is a human adding funds, which no wait predicts, and a growing park would need durable per-provider attempt state to compute. A flat day bounds the waste at one run instead of one per tick, and a manual trigger still runs immediately — parking only moves the cron cursor, and the due predicate excludes `dispatch_source = 'manual'`.

**Residual risk, deliberately shipped.** On the device-CLI path, balance wording alone is now sufficient evidence (previously it also required a parseable reset date), so a stray `payment required` in unrelated stderr would day-park a Behavior. Every alternate in the matcher is a real provider billing phrase, and the follow-up (provider-health writeback onto `inference_providers.status`, so an exhausted provider is *visible* rather than silently parked) is what makes a wrong park cheap to spot. Flagging rather than pre-narrowing.
