### PR TITLE
feat(config): add Qwen / DashScope as a connectable provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,7 @@ OPENAI_API_KEY=
 GROQ_API_KEY=
 GEMINI_API_KEY=
 OPENROUTER_API_KEY=
+DASHSCOPE_API_KEY=
 
 # ===========================================
 # EXECUTION SETTINGS

--- a/config/providers.json
+++ b/config/providers.json
@@ -329,7 +329,7 @@
     },
     {
       "id": "qwen",
-      "name": "Qwen / DashScope",
+      "name": "Qwen",
       "description": "Alibaba Cloud DashScope & Qwen models",
       "providers": [
         {

--- a/config/providers.json
+++ b/config/providers.json
@@ -328,6 +328,32 @@
       ]
     },
     {
+      "id": "qwen",
+      "name": "Qwen / DashScope",
+      "description": "Alibaba Cloud DashScope & Qwen models",
+      "providers": [
+        {
+          "displayName": "Qwen",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=alibabacloud.com&sz=128",
+          "envVarName": "DASHSCOPE_API_KEY",
+          "upstreamBaseUrl": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          "apiKeyInstructions": "Get your API key from the <a href=\"https://dashscope.console.aliyun.com/apiKey\" target=\"_blank\" class=\"text-blue-600 hover:underline\">DashScope Console</a>",
+          "apiKeyPlaceholder": "sk-...",
+          "sdkCompat": "openai",
+          "modalities": ["text"],
+          "defaultModel": "qwen-max",
+          "modelsEndpoint": "/models",
+          "models": [
+            "qwen-max",
+            "qwen-plus",
+            "qwen-turbo",
+            "qwen2.5-coder-32b-instruct",
+            "qwen2.5-72b-instruct"
+          ]
+        }
+      ]
+    },
+    {
       "id": "xai",
       "name": "xAI",
       "description": "Grok models by xAI. Sign in with SuperGrok / X Premium+ (device code) or paste an API key from the xAI Console.",


### PR DESCRIPTION
## What

Adds a **Qwen / DashScope** provider group to `config/providers.json` so a DashScope key can be connected from provider settings like any other API-key provider, plus the matching `DASHSCOPE_API_KEY` line in `.env.example`.

## Why config-only

The runtime already derives everything else from `envVarName`:

- `api-key-provider-module.ts:132` computes `baseUrlEnvVar` as `envVarName.replace("_KEY", "_BASE_URL")` → `DASHSCOPE_API_BASE_URL`
- `registerDynamicProvider()` (`session-runner.ts:797`) installs that into `DEFAULT_PROVIDER_BASE_URL_ENV` at startup

A hardcoded `DEFAULT_PROVIDER_BASE_URL_ENV` entry would **shadow** that derivation — `registerDynamicProvider` skips registration when the id is already present — so the hardcoded value could silently drift from `providers.json`. That map is documented as a fallback for providers *absent* from the config, so this change deliberately adds **zero TypeScript**.

The added field set is a strict subset of an existing sibling provider's (`groq`), minus `stt`.

## Test plan

- `config/providers.json` parses; qwen block field set verified against the `groq` entry
- `bun test packages/agent-worker/src/__tests__/model-resolver-harden.test.ts` → 34 pass / 0 fail
- Pre-commit biome + `tsc --noEmit` clean
- `providers-live.yml` skips the Qwen row until a `DASHSCOPE_API_KEY` repo secret exists, so scheduled live-provider CI is unaffected

## Risk

Low. Additive config for a provider nobody is connected to yet; no existing provider row is touched.