### PR TITLE
chore: ignore pi and codex agent-harness artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,9 @@ examples/lobu-crm/evals/tool-surface/last-run.json
 examples/lobu-crm/evals/discovery-surface/last-run.json
 # Interrupted embedded Postgres traversal-test fixtures.
 .lobu-pgtrav-*
+
+# Agent-harness scratch output written into the checkout by pi and codex:
+# subagent transcripts/prompts (.pi-subagents) and generated HTML
+# visualizations (.codex). Local run artifacts, never project sources.
+.pi-subagents/
+.codex/


### PR DESCRIPTION
## What

Adds `.pi-subagents/` and `.codex/` to `.gitignore`.

## Why

Both agent harnesses write scratch output into the checkout root:

- `.pi-subagents/artifacts/` — subagent prompts, transcripts (`*.jsonl`), outputs and usage metadata, named `<runId>_<role>_<n>_<kind>`
- `.codex/visualizations/` — generated standalone HTML visualizations

These are local run artifacts, not project sources. Left untracked they appear in every `git status`, and a stray `git add -A` can sweep 1.4 MB of transcripts into an unrelated PR.

## Test plan

- `git status` in a checkout containing both directories now reports a clean tree
- Nothing currently tracked matches either pattern, so no file leaves the index (`git ls-files | grep -E '^\.(pi-subagents|codex)/'` is empty)

## Risk

None. Ignore-only; no tracked file is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded internal agent-harness files and generated artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->