### PR TITLE
feat(server): record inference-provider health from terminal worker turns

### DIFF
--- a/packages/agent-worker/src/__tests__/provider-slug-stamp.test.ts
+++ b/packages/agent-worker/src/__tests__/provider-slug-stamp.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The success-side half of provider health: `signalCompletion()` must carry the
+ * Lobu provider slug that resolution picked, because the gateway clears an
+ * `inference_providers` error only when a completion names the provider that
+ * served it (`recordProviderHealth` in the worker gateway).
+ *
+ * The error-side half already travels as `errorContext.provider`. Without this
+ * stamp the mark would be write-only: a workspace that recovered would keep
+ * reading `error` forever.
+ */
+
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import type { WorkerTransportConfig } from "@lobu/core";
+import { HttpWorkerTransport } from "../gateway/gateway-integration";
+import type { ResponseData } from "../gateway/types";
+
+const baseConfig: WorkerTransportConfig = {
+  gatewayUrl: "https://test-gateway.example.com",
+  workerToken: "test-worker-token",
+  userId: "U123",
+  channelId: "C123",
+  conversationId: "CONV123",
+  originalMessageTs: "1700000000.000100",
+  teamId: "T123",
+  platform: "slack",
+};
+
+let originalFetch: typeof globalThis.fetch;
+let sentPayloads: ResponseData[];
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  sentPayloads = [];
+  globalThis.fetch = (async (...args: Parameters<typeof globalThis.fetch>) => {
+    const init = args[1];
+    if (init?.body) sentPayloads.push(JSON.parse(init.body as string));
+    return new Response(null, { status: 200 });
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("the completion carries the recorded provider slug", async () => {
+  const transport = new HttpWorkerTransport(baseConfig);
+  transport.recordProviderSlug("z-ai");
+
+  await transport.signalCompletion();
+
+  expect(sentPayloads.at(-1)?.providerSlug).toBe("z-ai");
+});
+
+test("a turn that never resolved a model claims no provider", async () => {
+  const transport = new HttpWorkerTransport(baseConfig);
+
+  await transport.signalCompletion();
+
+  // Absent, not empty-string: the gateway must read this as "no signal", which
+  // leaves an existing error mark in place rather than clearing it.
+  expect(sentPayloads.at(-1)).not.toHaveProperty("providerSlug");
+});
+
+test("re-resolution within a turn stamps the provider that ran last", async () => {
+  const transport = new HttpWorkerTransport(baseConfig);
+  transport.recordProviderSlug("gemini");
+  transport.recordProviderSlug("z-ai");
+
+  await transport.signalCompletion();
+
+  expect(sentPayloads.at(-1)?.providerSlug).toBe("z-ai");
+});
+
+test("an error row does not claim the provider is healthy", async () => {
+  const transport = new HttpWorkerTransport(baseConfig);
+  transport.recordProviderSlug("z-ai");
+
+  await transport.signalError(
+    new Error("429 Insufficient balance"),
+    "PROVIDER_QUOTA_EXHAUSTED",
+    { provider: "z-ai" }
+  );
+
+  const sent = sentPayloads.at(-1);
+  expect(sent).not.toHaveProperty("providerSlug");
+  expect(sent?.errorContext?.provider).toBe("z-ai");
+});

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -58,6 +58,12 @@ export class HttpWorkerTransport implements WorkerTransport {
    */
   private repliedInBand = false;
   /**
+   * Lobu provider slug model resolution picked for this turn, stamped on the
+   * terminal completion. Undefined until resolution runs, so a turn that fails
+   * before it reports no provider rather than a wrong one.
+   */
+  private providerSlug: string | undefined;
+  /**
    * Once-per-turn latch for user-facing errors. Three uncoordinated emitters
    * can report the SAME failed turn — `worker.ts`'s result-false branch,
    * `worker.ts`'s catch branch, and `sse-client.ts`'s outer catch — and every
@@ -120,6 +126,15 @@ export class HttpWorkerTransport implements WorkerTransport {
    */
   recordInBandReply(): void {
     this.repliedInBand = true;
+  }
+
+  /**
+   * Latch the Lobu provider slug that resolution picked for this turn, so the
+   * terminal completion can tell the gateway which provider just proved
+   * healthy. Mirrors how `errorContext.provider` attributes a failure.
+   */
+  recordProviderSlug(slug: string): void {
+    this.providerSlug = slug;
   }
 
   async signalDone(finalDelta?: string): Promise<void> {
@@ -238,6 +253,10 @@ export class HttpWorkerTransport implements WorkerTransport {
         // in-band" AND "worker too old to report" alike, and both must render
         // the reply. Fails toward delivering, never toward silence.
         ...(this.repliedInBand ? { repliedInBand: true } : {}),
+        // Success-side health signal: this provider just served a turn end to
+        // end, so the gateway can clear any error it recorded for it. Omitted
+        // when resolution never ran — silence, not a claim of health.
+        ...(this.providerSlug ? { providerSlug: this.providerSlug } : {}),
       })
     );
   }

--- a/packages/agent-worker/src/runtime/worker.ts
+++ b/packages/agent-worker/src/runtime/worker.ts
@@ -599,6 +599,13 @@ export class LobuAgentWorker implements WorkerExecutor {
         this.resolvedProvider = provider;
         this.resolvedProviderSlug = providerSlug;
         this.resolvedModelId = modelId;
+        // Same fact, second consumer: the terminal completion carries the slug
+        // so the gateway can clear this provider's recorded error health. Uses
+        // the transport latch (not the field above) because the completion is
+        // built inside the transport — see `recordInBandReply`.
+        if (this.workerTransport instanceof HttpWorkerTransport) {
+          this.workerTransport.recordProviderSlug(providerSlug);
+        }
       },
       loadImageAttachments: () => this.loadImageAttachments(),
       maybeRunPreCompactionMemoryFlush: (p) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -296,6 +296,17 @@ export interface ThreadResponsePayload {
    */
   repliedInBand?: boolean;
   /**
+   * Lobu provider slug that actually served this turn, stamped on the
+   * COMPLETION row only. It is the success-side counterpart of
+   * `errorContext.provider`: together they let the gateway keep an org's
+   * `inference_providers` health current — an error marks the row, and the
+   * next turn that provider serves clears it.
+   *
+   * Absent means "worker too old to report" (or no model was resolved), which
+   * reads as "no health signal", never as "healthy".
+   */
+  providerSlug?: string;
+  /**
    * Raw error message. When provider context is available, the gateway labels
    * the source and unwraps the common JSON message envelope without rewording
    * the provider's sentence; `errorCode` selects the CTA link.

--- a/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
@@ -14,6 +14,12 @@
  *    stale-SSE clock — otherwise the idle reaper scales a long-running worker to
  *    0 mid-turn. Asserted via a stub tracker injected with
  *    `setDeploymentActivityTracker`.
+ *
+ * The final describe covers the other durable fact terminal rows carry:
+ * inference-provider health writeback (`recordProviderHealth`) — a
+ * quota/credential error marks the org's `inference_providers` row, the next
+ * completion that provider serves clears it, and the org always comes from the
+ * signed token, never the body.
  */
 
 import {
@@ -548,5 +554,146 @@ describe("POST /worker/response — deployment idle clock (#12)", () => {
     expect(statusRes.status).toBe(200);
     await new Promise((r) => setTimeout(r, 20));
     expect(touched).toContain(DEPLOYMENT);
+  });
+});
+
+describe("POST /worker/response — inference-provider health", () => {
+  /** Insert a live provider row for org-1 the way the settings UI would. */
+  async function seedProvider(
+    slug: string,
+    status = "active"
+  ): Promise<void> {
+    await getDb()`
+      INSERT INTO inference_providers
+        (organization_id, slug, kind, api_key_ref, capabilities, status)
+      VALUES ('org-1', ${slug}, 'openai',
+              ${`secret://org-1/${slug}`}, '{}'::jsonb, ${status})
+    `;
+  }
+
+  async function providerHealth(
+    slug: string,
+    organizationId = "org-1"
+  ): Promise<{ status: string; error_message: string | null }> {
+    const rows = await getDb()<{ status: string; error_message: string | null }>`
+      SELECT status, error_message FROM inference_providers
+      WHERE organization_id = ${organizationId} AND slug = ${slug}
+    `;
+    if (!rows[0]) throw new Error(`provider ${slug} not found`);
+    return rows[0];
+  }
+
+  test("a quota-exhausted terminal error marks the provider that produced it", async () => {
+    await seedProvider("z-ai");
+
+    const res = await postWorkerResponse({
+      messageId: "m1",
+      conversationId: "conv-1",
+      error: "429 Insufficient balance or no resource package",
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+      errorContext: { provider: "z-ai", model: "glm-5.2" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await providerHealth("z-ai")).toEqual({
+      status: "error",
+      error_message: "429 Insufficient balance or no resource package",
+    });
+  });
+
+  test("a credential failure marks it too", async () => {
+    await seedProvider("z-ai");
+
+    await postWorkerResponse({
+      messageId: "m1",
+      conversationId: "conv-1",
+      error: "401 invalid api key",
+      errorCode: "PROVIDER_AUTH",
+      errorContext: { provider: "z-ai" },
+    });
+
+    expect((await providerHealth("z-ai")).status).toBe("error");
+  });
+
+  test("an unrelated failure leaves provider health alone", async () => {
+    await seedProvider("z-ai");
+
+    await postWorkerResponse({
+      messageId: "m1",
+      conversationId: "conv-1",
+      error: "the agent didn't finish responding in time",
+      errorCode: "AGENT_TIMEOUT",
+      errorContext: { provider: "z-ai" },
+    });
+
+    expect((await providerHealth("z-ai")).status).toBe("active");
+  });
+
+  test("the next completion that provider serves clears the error", async () => {
+    await seedProvider("z-ai", "error");
+
+    const res = await postWorkerResponse({
+      messageId: "m1",
+      conversationId: "conv-1",
+      finalText: "done",
+      toolsUsed: [],
+      providerSlug: "z-ai",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await providerHealth("z-ai")).toEqual({
+      status: "active",
+      error_message: null,
+    });
+  });
+
+  test("a completion from a DIFFERENT provider does not clear the failing one", async () => {
+    await seedProvider("z-ai", "error");
+    await seedProvider("gemini");
+
+    await postWorkerResponse({
+      messageId: "m1",
+      conversationId: "conv-1",
+      finalText: "done",
+      providerSlug: "gemini",
+    });
+
+    expect((await providerHealth("z-ai")).status).toBe("error");
+  });
+
+  test("a worker too old to report a slug is not read as healthy", async () => {
+    await seedProvider("z-ai", "error");
+
+    await postWorkerResponse({
+      messageId: "m1",
+      conversationId: "conv-1",
+      finalText: "done",
+    });
+
+    expect((await providerHealth("z-ai")).status).toBe("error");
+  });
+
+  test("a compromised worker cannot mark another tenant's provider", async () => {
+    await getDb()`
+      INSERT INTO organization (id, name, slug)
+      VALUES ('org-2', 'Other', 'other')
+      ON CONFLICT (id) DO NOTHING
+    `;
+    await getDb()`
+      INSERT INTO inference_providers
+        (organization_id, slug, kind, api_key_ref, capabilities, status)
+      VALUES ('org-2', 'z-ai', 'openai', 'secret://org-2/z-ai', '{}'::jsonb, 'active')
+    `;
+
+    // The token says org-1; the body names a slug that only org-2 owns.
+    await postWorkerResponse({
+      messageId: "m1",
+      conversationId: "conv-1",
+      error: "429 Insufficient balance",
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+      errorContext: { provider: "z-ai" },
+    });
+
+    expect((await providerHealth("z-ai", "org-2")).status).toBe("active");
   });
 });

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import type {
+  AgentErrorContext,
   ConfigProviderMeta,
   InstructionContext,
   WorkerTokenData,
@@ -32,7 +33,11 @@ import type { McpTool } from "../auth/mcp/tool-cache.js";
 import { isUnresolvedModelRef } from "../auth/model-sentinel.js";
 import type { ProviderCatalogService } from "../auth/provider-catalog.js";
 import { composeEffectiveModelRef } from "../auth/settings/model-selection.js";
-import { getOrgDefaultModel } from "../../lobu/stores/provider-secrets.js";
+import {
+  clearInferenceProviderError,
+  getOrgDefaultModel,
+  markInferenceProviderUnhealthy,
+} from "../../lobu/stores/provider-secrets.js";
 import type { IMessageQueue } from "../infrastructure/queue/index.js";
 import {
   commitTerminalReply,
@@ -435,6 +440,68 @@ export class WorkerGateway {
   }
 
   /**
+   * Keep the org's `inference_providers` health current from terminal worker
+   * rows: a quota/credential failure marks the provider that produced it, and
+   * the next turn that provider serves clears the mark.
+   *
+   * This is the one place both signals arrive — every worker terminal row
+   * lands on `/response` — so the two halves cannot drift apart the way two
+   * separate hooks would.
+   *
+   * **Errors are swallowed, deliberately, and it is safe to swallow them.**
+   * `status` is display-only: nothing in credential resolution or model routing
+   * reads it (see `markInferenceProviderUnhealthy`). A dropped write costs a
+   * stale label, so
+   * failing a delivered turn over one would trade a real outcome for a cosmetic
+   * one. That is why this swallows its own errors instead of propagating them
+   * — it is not durable dispatch/delivery state.
+   *
+   * The slug comes from the worker body while the org comes from the signed
+   * token, so the worst a compromised worker can do is mislabel a provider its
+   * own organization already owns.
+   */
+  private async recordProviderHealth(
+    organizationId: string | undefined,
+    responseData: {
+      error?: string;
+      errorCode?: string;
+      errorContext?: AgentErrorContext;
+      providerSlug?: string;
+    }
+  ): Promise<void> {
+    if (!organizationId) return;
+    try {
+      const failingSlug = responseData.errorContext?.provider;
+      if (
+        failingSlug &&
+        (responseData.errorCode === AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED ||
+          responseData.errorCode === AgentErrorCode.PROVIDER_AUTH)
+      ) {
+        await markInferenceProviderUnhealthy(
+          organizationId,
+          failingSlug,
+          responseData.error || responseData.errorCode
+        );
+        return;
+      }
+      // Only the completion row carries `providerSlug`; the `error` guard keeps
+      // that true even if a future error path starts stamping it.
+      if (responseData.providerSlug && !responseData.error) {
+        await clearInferenceProviderError(
+          organizationId,
+          responseData.providerSlug
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        `[WORKER-GATEWAY] Failed to record provider health for ${organizationId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  /**
    * Handle HTTP response from worker
    */
   private async handleWorkerResponse(c: Context): Promise<Response> {
@@ -520,6 +587,12 @@ export class WorkerGateway {
           ...tokenMetadata,
         },
       };
+
+      // Awaited, not fire-and-forget: it returns without touching the database
+      // unless the row is terminal, so the per-delta hot path pays nothing,
+      // while terminal rows get a deterministic write instead of one racing the
+      // response. It still swallows its own errors — see the method.
+      await this.recordProviderHealth(tokenRouting.organizationId, responseData);
 
       // Deployment idle clock (`EmbeddedWorkerEntry.lastActivity`) feeds the
       // idle reaper (WORKER_IDLE_CLEANUP_MINUTES). Mid-turn liveness still

--- a/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
@@ -11,11 +11,13 @@ import {
   getTestDb,
 } from '../../../__tests__/setup/test-db';
 import {
+  clearInferenceProviderError,
   createInferenceProvider,
   ensureOAuthInferenceProvider,
   getInferenceProviderBySlug,
   getOrgDefaultModel,
   listInferenceProviders,
+  markInferenceProviderUnhealthy,
   readOrgSharedProviderApiKey,
   resolveInferenceProviderConfig,
   rotateInferenceProviderKey,
@@ -285,5 +287,120 @@ describe('inference-provider store', () => {
     // A no-op on a missing slug must leave the current default intact.
     expect(await setInferenceProviderDefault(ORG, 'ghost')).toBe('not_found');
     expect(await getOrgDefaultModel(ORG)).toBe('openai/gpt-x');
+  });
+});
+
+describe('inference-provider health writeback', () => {
+  const createProvider = async (slug: string) => {
+    const created = await createInferenceProvider({
+      organizationId: ORG,
+      slug,
+      kind: 'openai',
+      apiKey: 'k1',
+      capabilities: { text: { model: 'gpt-x' } },
+    });
+    if ('error' in created) throw new Error(`expected ${slug} to be created`);
+    return created;
+  };
+
+  const listed = async (slug: string) =>
+    (await listInferenceProviders(ORG)).find((p) => p.slug === slug);
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  afterEach(async () => {
+    const db = getTestDb();
+    await db`TRUNCATE inference_providers, agent_secrets`;
+  });
+
+  it('marks a failing provider and surfaces the reason on the list', async () => {
+    await createProvider('z-ai');
+    expect((await listed('z-ai'))?.status).toBe('active');
+
+    await markInferenceProviderUnhealthy(
+      ORG,
+      'z-ai',
+      '429 Insufficient balance or no resource package'
+    );
+
+    const row = await listed('z-ai');
+    expect(row?.status).toBe('error');
+    expect(row?.errorMessage).toBe(
+      '429 Insufficient balance or no resource package'
+    );
+    // updated_at dates the failure for the settings UI.
+    expect(Date.parse(row?.updatedAt ?? '')).toBeGreaterThan(0);
+  });
+
+  it('truncates a runaway provider message instead of storing the payload', async () => {
+    await createProvider('z-ai');
+
+    await markInferenceProviderUnhealthy(ORG, 'z-ai', 'x'.repeat(5000));
+
+    expect((await listed('z-ai'))?.errorMessage).toHaveLength(500);
+  });
+
+  it('clears the error after the provider serves a turn', async () => {
+    await createProvider('z-ai');
+    await markInferenceProviderUnhealthy(ORG, 'z-ai', 'no balance');
+
+    await clearInferenceProviderError(ORG, 'z-ai');
+
+    const row = await listed('z-ai');
+    expect(row?.status).toBe('active');
+    expect(row?.errorMessage).toBeNull();
+  });
+
+  it('never overwrites an operator-disabled provider in either direction', async () => {
+    await createProvider('z-ai');
+    const db = getTestDb();
+    await db`
+      UPDATE inference_providers SET status = 'disabled'
+      WHERE organization_id = ${ORG} AND slug = 'z-ai'
+    `;
+
+    await markInferenceProviderUnhealthy(ORG, 'z-ai', 'no balance');
+    expect((await listed('z-ai'))?.status).toBe('disabled');
+
+    // Traffic must not re-enable what an operator switched off.
+    await clearInferenceProviderError(ORG, 'z-ai');
+    expect((await listed('z-ai'))?.status).toBe('disabled');
+  });
+
+  it('scopes both writes to the organization and the slug', async () => {
+    await createProvider('z-ai');
+    await createProvider('openai');
+    const other = await createInferenceProvider({
+      organizationId: 'org-other-tenant',
+      slug: 'z-ai',
+      kind: 'openai',
+      apiKey: 'k2',
+      capabilities: { text: { model: 'gpt-x' } },
+    });
+    if ('error' in other) throw new Error('expected other-tenant create');
+
+    await markInferenceProviderUnhealthy(ORG, 'z-ai', 'no balance');
+
+    expect((await listed('z-ai'))?.status).toBe('error');
+    expect((await listed('openai'))?.status).toBe('active');
+    const crossTenant = (await listInferenceProviders('org-other-tenant')).find(
+      (p) => p.slug === 'z-ai'
+    );
+    expect(crossTenant?.status).toBe('active');
+  });
+
+  it('is a no-op for a soft-deleted provider', async () => {
+    const created = await createProvider('z-ai');
+    await softDeleteInferenceProvider(ORG, 'z-ai');
+
+    await markInferenceProviderUnhealthy(ORG, 'z-ai', 'no balance');
+
+    const db = getTestDb();
+    const [row] = await db`
+      SELECT status FROM inference_providers WHERE id = ${created.id}
+    `;
+    expect(row.status).toBe('active');
   });
 });

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -99,7 +99,16 @@ export interface InferenceProviderListItem {
 	capabilities: InferenceCapabilities;
 	hasCustomUpstream: boolean;
 	status: string;
+	/**
+	 * Why the provider last failed terminally, when `status = 'error'`. Written
+	 * by `markInferenceProviderUnhealthy` from the provider's own message, so a
+	 * workspace whose Behaviors went quiet can read the cause here instead of
+	 * seeing a row that still says `active`.
+	 */
+	errorMessage: string | null;
 	createdAt: string;
+	/** When the row (including its health) last changed — dates the error above. */
+	updatedAt: string;
 	/** This row is the org's default inference provider (the model-resolution tail). */
 	isDefault: boolean;
 }
@@ -632,11 +641,16 @@ export async function listInferenceProviders(
 	const sql = getDb();
 	const rows = (await sql`
 		SELECT id, slug, kind, display_name, capabilities, has_custom_upstream,
-		       status, created_at, is_default
+		       status, error_message, created_at, updated_at, is_default
 		FROM inference_providers
 		WHERE organization_id = ${organizationId} AND deleted_at IS NULL
 		ORDER BY slug
-	`) as Array<Omit<RawInferenceProviderRow, "organization_id" | "api_key_ref">>;
+	`) as Array<
+		Omit<RawInferenceProviderRow, "organization_id" | "api_key_ref"> & {
+			error_message: string | null;
+			updated_at: string | Date;
+		}
+	>;
 	return rows.map((r) => ({
 		id: Number(r.id),
 		slug: r.slug,
@@ -645,12 +659,81 @@ export async function listInferenceProviders(
 		capabilities: r.capabilities ?? {},
 		hasCustomUpstream: r.has_custom_upstream,
 		status: r.status,
+		errorMessage: r.error_message,
 		createdAt:
 			r.created_at instanceof Date
 				? r.created_at.toISOString()
 				: String(r.created_at),
+		updatedAt:
+			r.updated_at instanceof Date
+				? r.updated_at.toISOString()
+				: String(r.updated_at),
 		isDefault: r.is_default,
 	}));
+}
+
+/**
+ * Longest provider message kept on the row. Provider errors routinely carry a
+ * stack, a request id and a docs URL; the settings UI needs the sentence, not
+ * the payload, and this column is read on every provider-list request.
+ */
+const PROVIDER_ERROR_MESSAGE_LIMIT = 500;
+
+/**
+ * Record that an org's inference provider failed terminally on a quota or
+ * credential error, so the settings page can say WHY a workspace's Behaviors
+ * stopped instead of showing a row that still reads `active`.
+ *
+ * **Observational only.** Nothing in credential resolution or model routing
+ * reads `status` — every reference in this file is a SELECT for display — so a
+ * missed, stale or duplicated write can never strand a workspace or reroute a
+ * turn. That is exactly why the caller treats a failure here as best-effort:
+ * this is not durable dispatch/delivery state, and failing a delivered turn to
+ * protect a status label would trade a real outcome for a cosmetic one.
+ *
+ * `disabled` is an operator decision and is never overwritten.
+ */
+export async function markInferenceProviderUnhealthy(
+	organizationId: string,
+	slug: string,
+	errorMessage: string,
+): Promise<void> {
+	const sql = getDb();
+	await sql`
+		UPDATE inference_providers
+		SET status = 'error',
+		    error_message = ${errorMessage.slice(0, PROVIDER_ERROR_MESSAGE_LIMIT)},
+		    updated_at = now()
+		WHERE organization_id = ${organizationId}
+		  AND slug = ${slug}
+		  AND deleted_at IS NULL
+		  AND status <> 'disabled'
+	`;
+}
+
+/**
+ * Clear a provider's error health after a turn it served completed.
+ *
+ * The `status = 'error'` predicate is what keeps this off the hot path: the
+ * healthy case matches no row, so a successful turn costs one indexed no-op
+ * UPDATE rather than a write. It also means a `disabled` row cannot be
+ * resurrected by traffic — only an operator re-enables it.
+ */
+export async function clearInferenceProviderError(
+	organizationId: string,
+	slug: string,
+): Promise<void> {
+	const sql = getDb();
+	await sql`
+		UPDATE inference_providers
+		SET status = 'active',
+		    error_message = NULL,
+		    updated_at = now()
+		WHERE organization_id = ${organizationId}
+		  AND slug = ${slug}
+		  AND deleted_at IS NULL
+		  AND status = 'error'
+	`;
 }
 
 interface OrgDefaultModelRow {


### PR DESCRIPTION
## Summary

When a workspace's inference provider ran dry, its `inference_providers` row kept reading `active` while every Behavior failed. Nothing anywhere wrote provider health, so the only way to find the cause was to group `runs.error_message` by hand — which is how buremba's z.ai balance exhaustion (`429 Insufficient balance or no resource package`) went unnoticed for two days and ~85 failed runs.

Both halves of the signal already pass through `POST /worker/response`, so the writeback lives there and the two cannot drift apart:

- a terminal `PROVIDER_QUOTA_EXHAUSTED` / `PROVIDER_AUTH` marks the provider named by `errorContext.provider` as `status = 'error'` carrying the provider's own message (truncated to 500 chars);
- the next completion that provider serves clears it, via a new `providerSlug` the worker stamps on the completion row — the success-side counterpart of `errorContext.provider`, following the existing `repliedInBand` latch pattern.

`errorMessage` and `updatedAt` are added additively to the provider-list response so the settings page can say why and when.

No schema change: `inference_providers.status` (`active|disabled|error`) and `error_message` have existed since the table was created.

Follows #2521 (parking a Behavior when the balance is empty) — that one stops the burn, this one makes the cause visible. Part of #2350; provider **failover** (gap 1) still needs the product decision and is untouched.

### Design properties worth checking

- **Observational, so routing stays fail-open.** Nothing in credential resolution or model routing reads `status` — verified with `git grep status origin/main -- provider-secrets.ts`, every reference is a SELECT for display. A dropped write costs a stale label, never a stranded workspace. That is why `recordProviderHealth` swallows its own errors rather than failing a delivered turn; it is not durable dispatch/delivery state.
- **Awaited, not fire-and-forget.** It returns without touching the DB unless the row is terminal, so the per-delta hot path pays nothing while terminal rows get a deterministic write instead of one racing the response.
- **`disabled` is an operator decision** and is never overwritten in either direction. The clear is predicated on `status = 'error'`, so a healthy turn is an indexed no-op, and traffic can never re-enable what an operator switched off.
- **Tenant safety.** The org comes from the signed worker token, the slug from the body — so the worst a compromised worker can do is mislabel a provider its own organization already owns. Pinned by a test.
- **Only quota/auth mark the row.** `PROVIDER_UNKNOWN_MODEL` / `PROVIDER_BASE_URL_UNRESOLVED` are configuration errors, not provider health, so they deliberately do not.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: store suite 15/15 (vitest, embedded PG18), gateway handler suite 17/17 (`bun test`, real Hono handler + real DB), agent-worker transport suite 4/4
- [x] Bug fix: mutation evidence pasted below

### Mutation evidence

New capability, so the meaningful proof is that each guard is load-bearing. Four mutations, each verified as actually applied to the source before running:

**A — dropped `AND status <> 'disabled'` from `markInferenceProviderUnhealthy`**
```
A applied: disabled guard removed from mark
   × inference-provider health writeback > never overwrites an operator-disabled provider in either direction 137ms
      Tests  1 failed | 14 passed (15)
```

**B — dropped `AND status = 'error'` from `clearInferenceProviderError`**
```
B applied: error-only guard removed from clear
   × inference-provider health writeback > never overwrites an operator-disabled provider in either direction 124ms
      Tests  1 failed | 14 passed (15)
```

**C — broadened the errorCode allowlist to any code**
```
C applied: errorCode allowlist broadened to any code
(fail) POST /worker/response — inference-provider health > an unrelated failure leaves provider health alone
 16 pass
 1 fail
```

**D — removed the `providerSlug` stamp from `signalCompletion`**
```
(fail) the completion carries the recorded provider slug
(fail) re-resolution within a turn stamps the provider that ran last
 2 pass
 2 fail
```

All four restored, all suites green:
```
 17 pass  0 fail    (gateway handler)
      Tests  15 passed (15)    (store)
 4 pass  0 fail     (agent-worker stamp)
```

## Notes

**Not verified end-to-end against a live provider.** The gateway tests drive the real Hono `/response` handler against a real Postgres and assert the row transitions, and the agent-worker test asserts the slug reaches the completion body — but no test runs a real worker against a real exhausted provider. The seam between `onModelResolved` and the transport latch is covered by typecheck plus the in-process transport test, not by a booted worker. Worth a prod spot-check after rollout: exhaust a provider, confirm the settings row flips to `error`, then confirm a successful turn clears it.
