### PR TITLE
fix(core): share the provider balance-exhaustion vocabulary with the worker classifier

### DIFF
--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -246,6 +246,31 @@ describe("classifyError", () => {
     );
   });
 
+  test("recognizes the balance phrasings that previously lived only in the schedule parker's list", () => {
+    // Captured verbatim from prod 2026-08-05 (org `buremba`, provider `openai`,
+    // agent routed to openai/gpt-4o-mini): the worker logged a bare
+    // `{"name":"Error","message":"You have no credits remaining…"}` because no
+    // pre-split worker pattern matched this sentence. `undefined` here is not a
+    // cosmetic miss — it silently disables TWO downstream features that gate on
+    // the code: `providerQuotaResetNotBefore` (24h Behavior park) and
+    // `recordProviderHealth` (marking the provider row unhealthy). Both shipped
+    // believing this message classified.
+    expect(
+      classifyError(
+        new Error(
+          "You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/."
+        )
+      )
+    ).toBe("PROVIDER_QUOTA_EXHAUSTED");
+
+    // z.ai's balance wording, likewise only in the server-side list until now.
+    expect(
+      classifyError(
+        new Error("No resource package or the balance is insufficient")
+      )
+    ).toBe("PROVIDER_QUOTA_EXHAUSTED");
+  });
+
   test("recognizes Gemini MALFORMED_FUNCTION_CALL as a provider tool-call failure", () => {
     expect(
       classifyError(

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -2,6 +2,7 @@ import {
   AgentErrorCode,
   createLogger,
   getSentry,
+  PROVIDER_BALANCE_EXHAUSTED,
   type WorkerTransport,
 } from "@lobu/core";
 import { getProviderAuthHintFromError } from "../shared/provider-auth-hints";
@@ -74,11 +75,7 @@ export function classifyError(error: unknown): AgentErrorCode | undefined {
   // carries none of the quota vocabulary below — so without this clause it fell
   // through to `undefined` and surfaced as a raw `💥 Worker crashed: 400 {…}`
   // JSON blob in the user's chat.
-  if (
-    /credit balance is too low|insufficient (?:credits?|balance|funds|quota)\b|billing_hard_limit_reached|payment required|exceeded your current quota|out of credits?\b/i.test(
-      message
-    )
-  )
+  if (PROVIDER_BALANCE_EXHAUSTED.test(message))
     return AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED;
 
   if (

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -309,6 +309,31 @@ export const AGENT_ERRORS: Record<AgentErrorCode, AgentErrorSpec> = {
   },
 };
 
+/**
+ * Provider says: the key is VALID, the account just cannot spend — a balance,
+ * credit, or billing-limit wall rather than a windowed rate limit.
+ *
+ * Lives in core because two packages must agree on it and previously did not:
+ * `classifyError` (agent-worker) turns the message into
+ * `PROVIDER_QUOTA_EXHAUSTED`, and `providerQuotaResetNotBefore` (server) parks
+ * a Behavior for a day on the same wording. They were maintained as separate
+ * literals and drifted in both directions: the server list learned OpenAI's
+ * "no credits remaining" and z.ai's "no resource package" while the worker's
+ * did not, and the worker matched "insufficient quota" while the server's park
+ * list did not. Because the server gates on the code the worker assigns, the
+ * first drift silently disabled BOTH the day-park and the provider-health
+ * writeback for OpenAI balance exhaustion (observed in prod 2026-08-05). This
+ * union closes both — which deliberately promotes reset-less "insufficient
+ * quota" wording (OpenAI/Azure billing) into the day-park; the retry-horizon
+ * guard in `balanceExhaustedNotBefore` keeps windowed 429s out of it.
+ *
+ * Keep this to balance/billing wording only. Windowed limits ("too many
+ * requests", a bare 429) classify as quota too, but must NOT day-park — they
+ * self-heal, often within the minute.
+ */
+export const PROVIDER_BALANCE_EXHAUSTED =
+  /credit balance is too low|insufficient (?:credits?|balance|funds|quota)\b|no resource package|billing_hard_limit_reached|payment required|exceeded your current quota|out of credits?\b|no credits remaining/i;
+
 /** Parse an `AgentErrorCode` from an unknown value (payload/DB boundary). */
 export function toAgentErrorCode(value: unknown): AgentErrorCode | undefined {
   if (typeof value !== "string") return undefined;

--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -198,10 +198,32 @@ describe("provider quota reset parsing", () => {
         now
       )?.toISOString()
     ).toBe("2026-08-06T10:00:00.000Z");
+    // Captured verbatim from prod 2026-08-05. This wording reached the parker
+    // only because the message list moved into core: it lived here but NOT in
+    // the worker's `classifyError`, which assigns the very errorCode this
+    // function gates on — so the park could never fire for it in production.
+    expect(
+      providerQuotaResetNotBefore(
+        "You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing/.",
+        "PROVIDER_QUOTA_EXHAUSTED",
+        now
+      )?.toISOString()
+    ).toBe("2026-08-06T10:00:00.000Z");
     // OpenAI's insufficient_quota billing message names no retry horizon.
     expect(
       providerQuotaResetNotBefore(
         "429 You exceeded your current quota, please check your plan and billing details.",
+        "PROVIDER_QUOTA_EXHAUSTED",
+        now
+      )?.toISOString()
+    ).toBe("2026-08-06T10:00:00.000Z");
+    // Widened by the shared core literal: "insufficient quota" was previously
+    // worker-only (classification without a park). Reset-less, it is billing
+    // wording (OpenAI/Azure insufficient_quota) and now day-parks; the windowed
+    // variant with a named horizon stays unparked (case below).
+    expect(
+      providerQuotaResetNotBefore(
+        "429 You have insufficient quota for this request.",
         "PROVIDER_QUOTA_EXHAUSTED",
         now
       )?.toISOString()

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -1,4 +1,4 @@
-import { AgentErrorCode } from "@lobu/core";
+import { AgentErrorCode, PROVIDER_BALANCE_EXHAUSTED } from "@lobu/core";
 import type { DbClient } from "../db/client";
 import { nextRunAt } from "../utils/cron";
 import logger from "../utils/logger";
@@ -90,20 +90,21 @@ export function parseProviderQuotaResetAt(
 }
 
 /**
+ * How long a depleted balance parks a schedule.
+ *
  * A depleted balance is not a rate limit: it does not tick back on a timer, so
  * the provider has no reset to name and never will until a human tops the
  * account up. Retrying one of these on every cron tick burns a failed run per
  * tick forever — z.ai's "429 Insufficient balance or no resource package" cost
  * ~85 of them across two Behaviors before anyone looked.
  *
- * Matched strictly on balance/billing wording, NOT on the broader quota
- * evidence set: a windowed rate limit ("too many requests", Gemini's bodyless
- * 429) DOES self-heal, often within the minute, and parking it for a day would
- * be far worse than one wasted run per tick.
+ * The wording that qualifies lives in `PROVIDER_BALANCE_EXHAUSTED` (core),
+ * shared with the worker's `classifyError` — see the note there for why it is
+ * not defined locally. It matches balance/billing wording only, NOT the broader
+ * quota evidence set: a windowed rate limit ("too many requests", Gemini's
+ * bodyless 429) DOES self-heal, often within the minute, and parking it for a
+ * day would be far worse than one wasted run per tick.
  */
-const PROVIDER_BALANCE_EXHAUSTED =
-	/credit balance is too low|insufficient (?:credits?|balance|funds)\b|no resource package|billing_hard_limit_reached|payment required|exceeded your current quota|out of credits?\b|no credits remaining/i;
-
 const PROVIDER_BALANCE_PARK_MS = 24 * 60 * 60 * 1000;
 
 /**
@@ -169,7 +170,7 @@ export function deviceProviderQuotaResetNotBefore(
 	// park on this path.
 	const hasQuotaEvidence =
 		PROVIDER_BALANCE_EXHAUSTED.test(message) ||
-		/insufficient quota\b|limit exhausted|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
+		/limit exhausted|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
 			message
 		);
 	if (!hasQuotaEvidence) return null;


### PR DESCRIPTION
## What

`classifyError` (agent-worker) and `providerQuotaResetNotBefore` (server) each kept their **own copy** of the balance/billing message list. They drifted: the server's copy learned OpenAI's `no credits remaining` and z.ai's `no resource package`; the worker's did not.

The parker gates on the errorCode the **worker** assigns:

```ts
if (errorCode !== AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED) return null;
```

So a message only the server recognised could never reach the server. That silently disabled **both** features built on this code for OpenAI balance exhaustion:

- the 24h Behavior park (#2521)
- the provider-health writeback (#2525)

This moves the literal into `@lobu/core` as `PROVIDER_BALANCE_EXHAUSTED` and has both sides import it.

## Red → green

Reproducer uses the verbatim prod message.

**Red** (before the fix):
```
264 |     ).toBe("PROVIDER_QUOTA_EXHAUSTED");
error: expect(received).toBe(expected)
Expected: "PROVIDER_QUOTA_EXHAUSTED"
Received: undefined
(fail) classifyError > recognizes every balance phrasing the schedule parker already parks on
 0 pass / 1 fail
```

**Green** (after):
```
 16 pass  0 fail  51 expect() calls   (agent-worker/error-handler.test.ts)
 41 pass  0 fail                      (server failed-run-advances-schedule.test.ts)
```

**Mutation check** — deleting `|no credits remaining` from the shared literal in core turns the new test red again (`1 fail`), then restoring it returns `16 pass`. The guard bites.

## Live evidence (prod, 2026-08-05)

Pointed `lobu-guide` at the out-of-credit `openai` provider and ran a real turn:

```
[worker] Worker execution failed: {"name":"Error",
  "message":"You have no credits remaining. Add credits to continue using the API
   at https://platform.openai.com/settings/organization/billing/.","stack":"..."}
```

`inference_providers` row for `(buremba, openai)` stayed `status=active`, `updated_at=2026-07-29` — the mark path never fired. Agent config was restored immediately after.

The **clear** path was verified working in the same session: seeding the `gemini` row to `error` and running a successful turn cleared it to `active` 12s later, confirming `providerSlug` → `recordProviderHealth` → `clearInferenceProviderError` is sound. Only the classification input was missing.

## Note on the approach

Keying on the provider's structured error code (`insufficient_quota`) would be better than prose. It is not available: `@mariozechner/pi-ai` flattens the provider error before we see it —

```js
// dist/providers/openai-completions.js
output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
throw new Error(output.errorMessage || "Provider returned an error stop reason");
```

HTTP status, `error.code`, and `error.type` are all discarded inside the dependency. Classifying at the gateway proxy (which sees the raw response) is the real fix and is tracked separately; this PR restores the contract that already exists.

## Gates

- `make pre-pr` clean
- `make review-fix` applied and verified (it removed a now-redundant `insufficient quota` alternate from the device evidence regex and documented the one intentional widening)