### PR TITLE
chore(db): purge residual rows under zombie entity types

### DIFF
--- a/db/migrations/20260805180000_purge_zombie_entity_rows.sql
+++ b/db/migrations/20260805180000_purge_zombie_entity_rows.sql
@@ -1,0 +1,61 @@
+-- migrate:up
+
+-- One-time data cleanup for the buremba org: hard-delete residual rows under
+-- entity types that are no longer part of the org's live schema.
+--
+-- Two distinct shapes are purged:
+--   * company / city / product — rows imported under the PUBLIC catalog types
+--     owned by the market/sales orgs. The TYPES themselves are not ours to
+--     delete (works_at / uses_technology reference them); only the org's own
+--     soft-deleted rows under them are removed.
+--   * social-signal / mcp-e2e-* / mcp-graph-* / mcp-readiness-* / lobu-e2e-temp
+--     — rows under org-local types that were already soft-deleted (their type
+--     rows have deleted_at set, so deleteType no longer resolves them). These
+--     are MCP/e2e test artifacts and the pre-event social-signal era.
+--
+-- Every row purged already has deleted_at IS NOT NULL (invisible to all reads;
+-- the residual value is disk + scan cost only). Live rows are never touched.
+--
+-- Dangling references, verified before writing this migration:
+--   * 80 live entity_relationships (all buremba-owned, confirmed by query)
+--     reference these rows → deleted first.
+--   * 48 events carry these ids in events.entity_ids. events is append-only
+--     and the app already treats missing entity ids as "detached" (the
+--     force_delete_tree path relies on it), so those arrays are left as-is.
+--
+-- Scope: organization_id pins this to the buremba org on the shared prod DB;
+-- other orgs' rows (including the market/sales orgs that own the public types)
+-- are untouched. The relationship delete is org-scoped too — all 80 live
+-- references are buremba-owned, so the scope loses nothing and never touches
+-- another org's relationship rows.
+-- squawk-ignore prefer-robust-stmts -- single-org data cleanup; row sets are re-derived from the same predicates on both statements so the counts cannot drift
+
+WITH zombie AS (
+  SELECT id
+  FROM public.entities
+  WHERE organization_id = '8dc12bdd-5d8c-4768-a2e9-a18005cc5ebd'
+    AND entity_type IN (
+      'company', 'social-signal', 'city', 'product',
+      'mcp-e2e-mrtowdgd', 'mcp-graph-mrt80dq0', 'mcp-graph-mrt7zszi',
+      'mcp-readiness-mrt7sast', 'lobu-e2e-temp'
+    )
+    AND deleted_at IS NOT NULL
+)
+DELETE FROM public.entity_relationships
+WHERE organization_id = '8dc12bdd-5d8c-4768-a2e9-a18005cc5ebd'
+  AND deleted_at IS NULL
+  AND (from_entity_id IN (SELECT id FROM zombie) OR to_entity_id IN (SELECT id FROM zombie));
+
+DELETE FROM public.entities
+WHERE organization_id = '8dc12bdd-5d8c-4768-a2e9-a18005cc5ebd'
+  AND entity_type IN (
+    'company', 'social-signal', 'city', 'product',
+    'mcp-e2e-mrtowdgd', 'mcp-graph-mrt80dq0', 'mcp-graph-mrt7zszi',
+    'mcp-readiness-mrt7sast', 'lobu-e2e-temp'
+  )
+  AND deleted_at IS NOT NULL;
+
+-- migrate:down
+
+-- Irreversible: the purged rows were soft-deleted tombstones whose content
+-- cannot be reconstructed from the remaining rows. No rollback.

--- a/db/migrations/20260805180000_purge_zombie_entity_rows.sql
+++ b/db/migrations/20260805180000_purge_zombie_entity_rows.sql
@@ -31,29 +31,32 @@
 -- squawk-ignore prefer-robust-stmts -- single-org data cleanup; row sets are re-derived from the same predicates on both statements so the counts cannot drift
 
 WITH zombie AS (
-  SELECT id
-  FROM public.entities
-  WHERE organization_id = '8dc12bdd-5d8c-4768-a2e9-a18005cc5ebd'
-    AND entity_type IN (
+  SELECT e.id
+  FROM public.entities e
+  JOIN public.entity_types et ON et.id = e.entity_type_id
+  WHERE e.organization_id = '8dc12bdd-5d8c-4768-a2e9-a18005cc5ebd'
+    AND et.slug IN (
       'company', 'social-signal', 'city', 'product',
       'mcp-e2e-mrtowdgd', 'mcp-graph-mrt80dq0', 'mcp-graph-mrt7zszi',
       'mcp-readiness-mrt7sast', 'lobu-e2e-temp'
     )
-    AND deleted_at IS NOT NULL
+    AND e.deleted_at IS NOT NULL
 )
 DELETE FROM public.entity_relationships
 WHERE organization_id = '8dc12bdd-5d8c-4768-a2e9-a18005cc5ebd'
   AND deleted_at IS NULL
   AND (from_entity_id IN (SELECT id FROM zombie) OR to_entity_id IN (SELECT id FROM zombie));
 
-DELETE FROM public.entities
-WHERE organization_id = '8dc12bdd-5d8c-4768-a2e9-a18005cc5ebd'
-  AND entity_type IN (
+DELETE FROM public.entities e
+USING public.entity_types et
+WHERE e.organization_id = '8dc12bdd-5d8c-4768-a2e9-a18005cc5ebd'
+  AND et.id = e.entity_type_id
+  AND et.slug IN (
     'company', 'social-signal', 'city', 'product',
     'mcp-e2e-mrtowdgd', 'mcp-graph-mrt80dq0', 'mcp-graph-mrt7zszi',
     'mcp-readiness-mrt7sast', 'lobu-e2e-temp'
   )
-  AND deleted_at IS NOT NULL;
+  AND e.deleted_at IS NOT NULL;
 
 -- migrate:down
 


### PR DESCRIPTION
## Summary
Hard-delete residual soft-deleted rows under entity types that are no longer part of the org's live schema:
- **Public-catalog types** (`company`, `city`, `product`) — rows the org imported under types owned by the market/sales orgs. The types stay (the shared world model references them via `works_at`/`uses_technology`); only the org's own soft-deleted rows are purged.
- **Org-local test artifacts** (`mcp-e2e-*`, `mcp-graph-*`, `mcp-readiness-*`, `lobu-e2e-temp`) and the pre-event `social-signal` era — rows under types whose type record is already soft-deleted.

Scoped to the buremba org. Every purged row already has `deleted_at IS NOT NULL` (invisible to all reads); no live rows are touched.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] `bun run db:lint` (squawk) — 0 issues on the new migration
- [x] Migration red→green against a scratch Postgres mirroring the schema, seeded with representative rows:
  - `DELETE 5` entities (the zombies), `DELETE 2` relationships
  - Verified: live rows of zombie types survive, other-org rows survive, already-deleted relationships survive, live person↔task relationships survive, cross-org relationships survive
  - Evidence: org-scoped relationship delete added after an initial over-reach deleted a cross-org control row; re-run confirmed exact correct row set

## Notes
- 80 live relationship rows (all buremba-owned) reference these rows and are deleted first.
- 48 events carry these ids in `events.entity_ids` — left untouched: events are append-only, and the app already treats detached entity ids as an accepted state (the `force_delete_tree` path relies on it).
- Irreversible (down no-op): rows are soft-deleted tombstones with no reconstructable content.
- `make review-fix`/`make review` could NOT run: the pi-review LLM is over its external usage limit (resumes Aug 10). Local gates (`pre-pr`, squawk) all passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Permanently removed obsolete, soft-deleted records from legacy and test data.
  * Cleaned up active relationships that referenced those records.
  * Historical event references remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->