### PR TITLE
feat(server): keyed supersede for Behavior event outputs

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4235,6 +4235,10 @@ export type ManageBehaviorsData = {
                  * Semantic type assigned to every event in this output array.
                  */
                 event: string;
+                /**
+                 * One to four metadata fields whose exact string values compose each draft's stable identity across Behavior runs (e.g. channel + mode for per-channel voice profiles). Every key field must be present in every draft's `metadata`; changing the fields, their order, the output name, or the semantic type changes identity. When set, each run supersedes the current head event with the same key values.
+                 */
+                key?: Array<string>;
               };
         }
       | null;
@@ -4858,6 +4862,10 @@ export type GetBehaviorResponses = {
                * Semantic type assigned to every event in this output array.
                */
               event: string;
+              /**
+               * One to four metadata fields whose exact string values compose each draft's stable identity across Behavior runs (e.g. channel + mode for per-channel voice profiles). Every key field must be present in every draft's `metadata`; changing the fields, their order, the output name, or the semantic type changes identity. When set, each run supersedes the current head event with the same key values.
+               */
+              key?: Array<string>;
             };
       } | null;
       classifiers?: Array<unknown>;

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -146,6 +146,13 @@ export type BehaviorEntityOutput = Static<typeof BehaviorEntityOutputSchema>;
 /**
  * Persist each row as an append-only event. The semantic type is fixed by the
  * Behavior version; the row supplies the standard event draft fields.
+ *
+ * With `key`, the draft's key fields (read from its `metadata`) compose a
+ * stable identity: each run supersedes the current head event carrying the
+ * same key values instead of appending a sibling, so the type keeps exactly
+ * one current event per key while history stays append-only. This is the event
+ * analogue of the entity output's keyed upsert — use it for refined-over-time
+ * state (voice profiles, digests, statuses) rather than per-source-item logs.
  */
 export const BehaviorEventOutputSchema = Type.Object(
   {
@@ -155,6 +162,15 @@ export const BehaviorEventOutputSchema = Type.Object(
       description:
         "Semantic type assigned to every event in this output array.",
     }),
+    key: Type.Optional(
+      Type.Array(Type.String({ minLength: 1, maxLength: 128 }), {
+        minItems: 1,
+        maxItems: 4,
+        uniqueItems: true,
+        description:
+          "One to four metadata fields whose exact string values compose each draft's stable identity across Behavior runs (e.g. channel + mode for per-channel voice profiles). Every key field must be present in every draft's `metadata`; changing the fields, their order, the output name, or the semantic type changes identity. When set, each run supersedes the current head event with the same key values.",
+      })
+    ),
   },
   { additionalProperties: false }
 );

--- a/packages/server/src/__tests__/integration/watchers/behavior-event-outputs.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/behavior-event-outputs.test.ts
@@ -193,6 +193,138 @@ describe('Behavior event outputs', () => {
     ).rejects.toThrow(/duplicate.*idempotency/i);
   });
 
+  it('supersedes the prior event per key, keeping history append-only', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Keyed Event Output Org' });
+    const ownerUserId = workspace.users.owner.id;
+    const parent = await createTestEntity({
+      name: 'Subject',
+      organization_id: workspace.org.id,
+      created_by: ownerUserId,
+    });
+    const agent = await createTestAgent({
+      organizationId: workspace.org.id,
+      ownerUserId,
+      agentId: 'keyed-output-agent',
+    });
+    const api = await TestApiClient.for({
+      organizationId: workspace.org.id,
+      userId: ownerUserId,
+      memberRole: 'owner',
+    });
+    const created = (await api.behaviors.create({
+      entity_id: parent.id,
+      slug: 'keyed-output-behavior',
+      prompt: 'Emit refined voice profiles.',
+      triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
+      outputs: { profiles: { event: 'observation', key: ['channel', 'mode'] } },
+      agent_id: agent.agentId,
+    })) as { behavior_id: string };
+    const watcherId = Number(created.behavior_id);
+
+    const baseParams = {
+      outputName: 'profiles',
+      output: { event: 'observation', key: ['channel', 'mode'] },
+      watcherId,
+      organizationId: workspace.org.id,
+      boundEntityIds: [parent.id],
+      validContentIds: new Set<number>(),
+      occurredAt: new Date().toISOString(),
+      createdBy: ownerUserId,
+    };
+    const persist = (rows: unknown[], windowId: number) =>
+      sql.begin((tx) =>
+        persistBehaviorEventOutput({
+          tx: tx as unknown as DbClient,
+          rows,
+          windowId,
+          canvasRevisionId: windowId,
+          runId: null,
+          ...baseParams,
+        })
+      );
+
+    // Run 1: two profiles under distinct keys.
+    await persist(
+      [
+        { content: 'X voice v1', metadata: { channel: 'x', mode: 'voice' } },
+        { content: 'X taste v1', metadata: { channel: 'x', mode: 'taste' } },
+      ],
+      9001
+    );
+    let rows = await sql<{
+      id: number;
+      payload_text: string;
+      supersedes_event_id: number | null;
+      superseded_by: number | null;
+    }>`
+      SELECT id, payload_text, supersedes_event_id, superseded_by
+      FROM events
+      WHERE organization_id = ${workspace.org.id}
+        AND metadata->>'behavior_output' = 'profiles'
+      ORDER BY id
+    `;
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((row) => row.supersedes_event_id === null)).toHaveLength(2);
+
+    // Run 2: refine only the x:voice profile. The new event supersedes the old
+    // head; x:taste is untouched and still a head.
+    await persist([{ content: 'X voice v2', metadata: { channel: 'x', mode: 'voice' } }], 9002);
+    rows = await sql<{
+      id: number;
+      payload_text: string;
+      supersedes_event_id: number | null;
+      superseded_by: number | null;
+    }>`
+      SELECT id, payload_text, supersedes_event_id, superseded_by
+      FROM events
+      WHERE organization_id = ${workspace.org.id}
+        AND metadata->>'behavior_output' = 'profiles'
+      ORDER BY id
+    `;
+    expect(rows).toHaveLength(3);
+    const v1 = rows.find((row) => row.payload_text === 'X voice v1');
+    const v2 = rows.find((row) => row.payload_text === 'X voice v2');
+    const taste = rows.find((row) => row.payload_text === 'X taste v1');
+    expect(v1).toMatchObject({ supersedes_event_id: null, superseded_by: v2?.id ?? null });
+    expect(v2).toMatchObject({ supersedes_event_id: v1?.id ?? null, superseded_by: null });
+    expect(taste).toMatchObject({ supersedes_event_id: null, superseded_by: null });
+
+    // A keyed supersede must match a legacy (pre-Behavior) head by metadata,
+    // not just the producing Behavior — a migrated seed event becomes the
+    // supersede target of the first run.
+    const legacy = await sql<{ id: number }>`
+      INSERT INTO events (
+        organization_id, origin_id, title, payload_text, semantic_type, client_id, metadata
+      ) VALUES (
+        ${workspace.org.id}, ${'legacy-seed'}, ${'Legacy'}, ${'X voice legacy'},
+        ${'observation'}, NULL, ${sql.json({ channel: 'x', mode: 'voice' })}
+      )
+      RETURNING id
+    `;
+    await persist([{ content: 'X voice v3', metadata: { channel: 'x', mode: 'voice' } }], 9003);
+    const v3 = await sql<{ id: number; supersedes_event_id: number | null }>`
+      SELECT id, supersedes_event_id
+      FROM events
+      WHERE organization_id = ${workspace.org.id} AND payload_text = 'X voice v3'
+    `;
+    expect(v3[0].supersedes_event_id).toBe(legacy[0].id);
+
+    // Missing key field and duplicate key within one array are rejected.
+    await expect(
+      persist([{ content: 'no key', metadata: { channel: 'x' } }], 9004)
+    ).rejects.toThrow(/missing required key field/);
+    await expect(
+      persist(
+        [
+          { content: 'dup 1', metadata: { channel: 'y', mode: 'voice' } },
+          { content: 'dup 2', metadata: { channel: 'y', mode: 'voice' } },
+        ],
+        9005
+      )
+    ).rejects.toThrow(/duplicate key/);
+  });
+
   it('rejects the loser when concurrent output versions reuse a key for different event types', async () => {
     const sql = getTestDb();
     const workspace = await TestWorkspace.create({ name: 'Behavior Event Output Race Org' });

--- a/packages/server/src/__tests__/unit/behavior-outputs-shape.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-outputs-shape.test.ts
@@ -49,6 +49,24 @@ describe('assertOutputsShape', () => {
     ).toThrow(/exactly one/);
   });
 
+  it('accepts keyed event outputs and enforces the key field shape', () => {
+    expect(() =>
+      assertOutputsShape({ profiles: { event: 'voice_profile', key: ['channel', 'mode'] } })
+    ).not.toThrow();
+    expect(
+      Value.Check(BehaviorEventOutputSchema, {
+        event: 'voice_profile',
+        key: ['channel', 'mode'],
+      })
+    ).toBe(true);
+    expect(
+      Value.Check(BehaviorEventOutputSchema, { event: 'voice_profile', key: [] })
+    ).toBe(false);
+    expect(
+      Value.Check(BehaviorEventOutputSchema, { event: 'voice_profile', key: ['channel', 'channel'] })
+    ).toBe(false);
+  });
+
   it('rejects misspelled and prototype-named fields', () => {
     expect(() => assertOutputsShape({ items: { ...valid.items, keyFields: ['id'] } })).toThrow(
       /unknown field\(s\) keyFields/

--- a/packages/server/src/utils/persist-behavior-event-output.ts
+++ b/packages/server/src/utils/persist-behavior-event-output.ts
@@ -50,12 +50,52 @@ async function findByIdempotencyKey(
   return rows[0] ?? null;
 }
 
+/**
+ * The current head event for a keyed event output: the latest row of the
+ * output's semantic type whose metadata carries the given key field values and
+ * that nothing has superseded yet. `superseded_by IS NULL` identifies heads —
+ * the insert-time dual-write stamps the replaced row's `superseded_by`, so a
+ * key keeps exactly one current event while history stays append-only. The
+ * match is scoped by (org, semantic type, key values) — deliberately NOT by
+ * `behavior_id`, so a migrated/legacy event that predates the Behavior becomes
+ * the supersede target of its first run rather than a duplicate.
+ */
+async function findCurrentHeadByKey(
+  tx: DbClient,
+  organizationId: string,
+  semanticType: string,
+  keyFields: readonly string[],
+  metadata: Record<string, unknown>
+): Promise<number | null> {
+  const keyJson: Record<string, string> = {};
+  for (const field of keyFields) {
+    const value = metadata[field];
+    const str =
+      value === undefined || value === null ? null : String(value).trim();
+    if (!str) return null;
+    keyJson[field] = str;
+  }
+  const rows = await tx<{ id: number }>`
+    SELECT id
+    FROM events
+    WHERE organization_id = ${organizationId}
+      AND semantic_type = ${semanticType}
+      AND superseded_by IS NULL
+      AND metadata @> ${tx.json(keyJson)}
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1
+  `;
+  return rows[0]?.id ?? null;
+}
+
 /** Persist one declared event array atomically with its Canvas window. */
 export async function persistBehaviorEventOutput(
   params: PersistBehaviorEventOutputParams
 ): Promise<InsertedEvent[]> {
   if (!Array.isArray(params.rows) || params.rows.length === 0) return [];
   const seenIdempotencyKeys = new Set<string>();
+  const keyFields = params.output.key ?? null;
+  const seenKeyValues = new Set<string>();
   for (let index = 0; index < params.rows.length; index++) {
     const draft = params.rows[index] as EventDraft;
     if (typeof draft?.idempotency_key !== 'string') continue;
@@ -74,6 +114,40 @@ export async function persistBehaviorEventOutput(
     const draft = params.rows[index] as EventDraft;
     const metadata = { ...(draft.metadata ?? {}) };
     delete metadata._lobu_idempotency_key;
+
+    // Keyed event output: resolve the current head for this key and supersede
+    // it, so the type keeps exactly one current event per key. A missing key
+    // field is a malformed draft (the model must emit every declared key
+    // field); a duplicate key within one array would otherwise double-supersede
+    // the same head, so it is rejected up front.
+    let supersedesEventId: number | null = null;
+    if (keyFields) {
+      const missing = keyFields.filter((f) => {
+        const v = metadata[f];
+        return v === undefined || v === null || String(v).trim() === '';
+      });
+      if (missing.length > 0) {
+        throw new ToolUserError(
+          `outputs.${params.outputName}[${index}] is missing required key field(s) in metadata: ${missing.join(', ')}.`,
+          422
+        );
+      }
+      const keyValue = keyFields.map((f) => `${f}=${String(metadata[f]).trim()}`).join('&');
+      if (seenKeyValues.has(keyValue)) {
+        throw new ToolUserError(
+          `outputs.${params.outputName} contains a duplicate key (${keyFields.join(', ')}) at item ${index}.`,
+          422
+        );
+      }
+      seenKeyValues.add(keyValue);
+      supersedesEventId = await findCurrentHeadByKey(
+        params.tx,
+        params.organizationId,
+        params.output.event,
+        keyFields,
+        metadata
+      );
+    }
 
     const kindValidation = await validateSaveContentSemanticType(
       params.output.event,
@@ -159,6 +233,7 @@ export async function persistBehaviorEventOutput(
               originType: params.output.event,
               metadata: eventMetadata,
               parentOriginId,
+              supersedesEventId,
               runId: params.runId,
               createdBy: params.createdBy ?? null,
             },


### PR DESCRIPTION
## Summary
Declared Behavior event outputs gain an optional `key` field, mirroring the entity output contract (`{ entity, key }` vs `{ event, key }`). Each run resolves the current head event carrying the same key values (org + semantic type scoped, `superseded_by IS NULL`) and supersedes it — a Behavior keeps exactly one current event per key while history stays append-only.

This is the primitive that refined-over-time event artifacts (voice profiles, digests, statuses) need:
- `save_memory` from a Behavior window is currently unreliable in prod (run's session `client_id` trips `events_client_id_fkey` + timeouts — verified live, see notes).
- Unkeyed event outputs can only append, so "refine the latest" had no expressible path.

Key values are read from each draft's `metadata`; missing key fields and duplicate keys within one output array are rejected at persist time.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Unit: `behavior-outputs-shape.test.ts` — 12 pass (new: keyed event outputs accepted; empty/duplicate keys rejected)
- [x] Integration: `behavior-event-outputs.test.ts` — 4 pass (new: supersede per key keeps history append-only; x:voice refined → old head gets `superseded_by`, new event `supersedes_event_id`; unrelated key untouched; legacy pre-Behavior seed event becomes the supersede target of the first run; missing-key + duplicate-key rejected)

## Notes
- The event output `key` is a schema/API surface addition (core contract + validation). Confirmed with you before building (repo rule: surface API changes first).
- Follow-up (separate): the `events_client_id_fkey` failure in Behavior-window `save_memory` is a latent bug worth fixing independently — it affects all behavior-session saves, not just this feature.
- The voice-profile Behavior itself is a DB config change on the live org (pending this server PR deploying): outputs `{ profiles: { event: "voice_profile", key: ["channel","mode"] } }`, both Behaviors' sources re-pointed to `voice_profile` events, 4 existing profile entities already migrated to events.
- `make review-fix`/`make review` blocked: pi-review LLM over external usage limit until ~Aug 10. Local gates all green.