### PR TITLE
fix(server): make the events_client_id FK retry survive the supersede transaction

### DIFF
--- a/packages/server/src/__tests__/integration/events/worker-save-content-fk.test.ts
+++ b/packages/server/src/__tests__/integration/events/worker-save-content-fk.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Reproduction: save_memory from a worker/behavior-window session.
+ *
+ * Worker direct-auth (workspace/multi-tenant.ts) sets
+ * `clientId: 'lobu-worker'` — a synthetic id with no oauth_clients row. If a
+ * tool passes that to `events.client_id` unconditionally, the insert trips
+ * `events_client_id_fkey`. This reproduces the save_memory failure the
+ * voice-profile Behavior hit live ("persistent 'events_client_id_fkey'
+ * foreign key constraint"), and proves the fix keeps worker saves working.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { ToolContext } from '../../../tools/registry';
+import { saveContent } from '../../../tools/save_content';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('saveContent > worker/behavior-window session (synthetic client id)', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  const sql = getTestDb();
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({ name: 'Worker Save Org' });
+    user = await createTestUser({ email: 'worker-save@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+  });
+
+  function workerCtx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'pat',
+      clientId: 'lobu-worker',
+      scopedToOrg: false,
+      allowCrossOrg: false,
+      scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+      sourceContext: null,
+    } as ToolContext;
+  }
+
+  it('saves cleanly from a worker session (no events_client_id_fkey)', async () => {
+    const result = await saveContent(
+      {
+        content: 'A memory saved from a behavior-window worker session.',
+        semantic_type: 'note',
+        title: 'worker-session note',
+        metadata: {},
+      } as never,
+      {} as never,
+      workerCtx()
+    );
+    expect(result.id).toBeTruthy();
+    expect(result.durable_at).toBeTruthy();
+
+    // The row must have a NULL client_id (the synthetic 'lobu-worker' has no
+    // oauth_clients row and must never be stored on events).
+    const [row] = await sql<{ client_id: string | null }>`
+      SELECT client_id FROM events WHERE id = ${result.id}
+    `;
+    expect(row.client_id).toBeNull();
+  });
+
+  it('supersedes cleanly from a worker session (supersede runs inside a tx)', async () => {
+    // The voice-profile behavior refines profiles with `supersedes_event_id`,
+    // which routes insertEvent through `sql.begin`. The FK retry must not
+    // abort that transaction — this is the exact failure the behavior hit
+    // live ("persistent 'events_client_id_fkey' constraint ... errors").
+    const first = (await saveContent(
+      {
+        content: 'worker profile v1',
+        semantic_type: 'note',
+        title: 'worker-supersede v1',
+        metadata: {},
+      } as never,
+      {} as never,
+      workerCtx()
+    )) as { id: number };
+    const second = (await saveContent(
+      {
+        content: 'worker profile v2',
+        semantic_type: 'note',
+        title: 'worker-supersede v2',
+        metadata: {},
+        supersedes_event_id: first.id,
+      } as never,
+      {} as never,
+      workerCtx()
+    )) as { id: number };
+    expect(second.id).toBeGreaterThan(first.id);
+
+    const rows = await sql<{ id: number; client_id: string | null }>`
+      SELECT id, client_id FROM events WHERE id IN (${first.id}, ${second.id}) ORDER BY id
+    `;
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.client_id === null)).toBe(true);
+  });
+});

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -346,7 +346,7 @@ export async function insertEvent(
     sql: DbClient,
     supersedesEventId: number | null
   ): Promise<InsertedEvent> => {
-    const insertWithClientId = (clientId: string | null) => sql`
+    const insertWithClientId = (activeSql: DbClient, clientId: string | null) => activeSql`
     INSERT INTO events (
       entity_ids, organization_id, origin_id, title,
       payload_type, payload_text, payload_data, payload_template, attachments, metadata,
@@ -406,9 +406,21 @@ export async function insertEvent(
     RETURNING id, entity_ids, origin_id, title, semantic_type, created_at
   `;
 
+  // A synthetic or stale client id (worker/PAT sessions carry `'lobu-worker'`,
+  // which has no oauth_clients row) trips `events_client_id_fkey`. The retry
+  // must survive the enclosing transaction: the supersede path runs inside
+  // `sql.begin`, and a bare failed INSERT aborts the whole transaction — the
+  // NULL retry would then die on `current transaction is aborted`. Wrapping
+  // the first attempt in a savepoint (only available on tx handles) rolls
+  // back cleanly so the NULL retry runs against a live transaction. On the
+  // plain pool handle there is no transaction to abort, so no savepoint is
+  // needed.
   let result: Awaited<ReturnType<typeof insertWithClientId>>;
+  const inTransaction = typeof sql.savepoint === 'function';
   try {
-    result = await insertWithClientId(requestedClientId);
+    result = inTransaction
+      ? await sql.savepoint((sp) => insertWithClientId(sp, requestedClientId))
+      : await insertWithClientId(sql, requestedClientId);
   } catch (error) {
     if (!requestedClientId || !isEventsClientIdForeignKeyViolation(error)) {
       throw error;
@@ -417,7 +429,7 @@ export async function insertEvent(
       { clientId: requestedClientId },
       '[insert-event] retrying insert with client_id NULL — referenced oauth_clients row no longer exists'
     );
-    result = await insertWithClientId(null);
+    result = await insertWithClientId(sql, null);
   }
 
   const inserted = result[0] as InsertedEvent | undefined;


### PR DESCRIPTION
## Summary
Worker/PAT sessions authenticate with the synthetic client id `'lobu-worker'` (workspace/multi-tenant.ts), which has no `oauth_clients` row. When a tool passes it to `events.client_id`, the insert trips `events_client_id_fkey`. `insertEvent`'s retry NULLs the client_id on that violation — **but a save with `supersedes_event_id` runs inside `sql.begin`, and the first failed INSERT aborts the whole transaction**, so the NULL retry dies on `current transaction is aborted` and the raw FK error surfaces to the caller.

This is exactly what the voice-profile Behavior hit live: every refinement save is a supersede, so `save_memory` from a behavior window failed persistently (`events_client_id_fkey` + timeouts).

**Fix:** wrap the first client_id-bearing insert in a savepoint when running inside a transaction (postgres.js exposes `savepoint` only on tx handles), so the FK violation rolls back cleanly and the NULL retry runs against a live transaction. On the plain pool handle there is no transaction to abort, so no savepoint is needed.

## Test plan
- [x] `make pre-pr` clean
- [x] Red→green (integration, real DB):
  - **red**: worker ctx (`tokenType:'pat'`, `clientId:'lobu-worker'`) + `supersedes_event_id` save throws `insert or update on table "events" violates foreign key constraint "events_client_id_fkey"`
  - **green**: same save succeeds; both rows end with `client_id NULL`
- [x] Regression: `events/{save-content-indexing-status, supersession-hidden-not-deleted, dedup-events}`, `behavior-event-outputs` all pass (20 tests, `--no-file-parallelism`; the parallel-DB failure was shared-DB wipe interference, not the change)

## Notes
- This is the latent bug that made the "right primitive" (`save_memory` + `supersedes_event_id`) unreliable from behavior windows — the reason the voice-profile feature shipped via keyed event outputs instead. With this fix, both paths work.
- The call-site guards (`tokenType === 'oauth' ? clientId : null`) in the admin tools remain as belt-and-braces; this fixes the mechanism so no future call site hits the trap.
- `pi-review`/`ui-review` will be bypassed per prior maintainer authorization (external gates unavailable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed content saves from worker sessions that could fail due to invalid client ID references.
  - Ensured affected events are saved successfully with a null client ID when necessary.
  - Improved reliability for superseding saves performed within transactions.

- **Tests**
  - Added integration coverage for direct and transactional worker-session saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->