### PR TITLE
fix(server): keep NULL and future-dated events off the top of the activity feed

### DIFF
--- a/packages/server/src/__tests__/integration/events/date-feed-ordering.test.ts
+++ b/packages/server/src/__tests__/integration/events/date-feed-ordering.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Integration test: chronological feed ordering is NULL- and future-safe.
+ *
+ * Prod bug (reported on /activity): the newest-first event feed pinned a
+ * 9-day-old suggestion card to the top and then a wall of recurring Google
+ * Calendar instances dated 30 years in the future. Two root causes:
+ *
+ *  1. NULL occurred_at. Postgres `ORDER BY occurred_at DESC` defaults to NULLS
+ *     FIRST, so an event whose source timestamp was never recorded sorts as
+ *     the newest regardless of age. The orderings now key on the EFFECTIVE
+ *     occurrence time — COALESCE(occurred_at, created_at) — which is exactly
+ *     what the API already surfaced for such rows, and the keyset cursor uses
+ *     the same key so NULL rows stay reachable across pages.
+ *  2. Future-dated events. A recurring series expanded a year ahead has
+ *     `occurred_at > now()`, which is a scheduled item, not "activity", and it
+ *     monopolized the first page. The chronological list now excludes
+ *     not-yet-occurred events unless the caller explicitly asks for a future
+ *     window via an `until` past now (or an `after` cursor past now).
+ *
+ * This file pins both: future events are absent from the default feed, NULL
+ * occurred_at rows still surface but rank by their record time, an explicit
+ * future `until` re-includes future events, and cursor pagination stays
+ * consistent.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { pgBigintArray } from '../../../db/client';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe('getContent > chronological feed ordering (NULL + future occurred_at)', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+
+  let futureFarId: number;
+  let futureNearId: number;
+  let recentId: number;
+  let yesterdayId: number;
+  let oldId: number;
+  let nullOccurredId: number;
+
+  let entityFutureId: number;
+  let entityRecentId: number;
+
+  function ctx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    } as ToolContext;
+  }
+
+  async function insertNullOccurredEvent(opts: {
+    organization_id: string;
+    title: string;
+    created_at: Date;
+  }): Promise<number> {
+    const sql = getTestDb();
+    const rows = await sql`
+      INSERT INTO events (organization_id, entity_ids, origin_id, title, payload_type,
+                          payload_text, semantic_type, occurred_at, connector_key, created_at)
+      VALUES (${opts.organization_id}, ${pgBigintArray([])}::bigint[],
+              'null-occurred-' || floor(random() * 1000000)::int, ${opts.title}, 'text',
+              ${opts.title}, 'content', NULL, 'test.connector', ${opts.created_at})
+      RETURNING id
+    `;
+    return Number(rows[0].id);
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Date Feed Ordering Org' });
+    user = await createTestUser({ email: 'date-feed-order@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    entity = await createTestEntity({
+      name: 'Date Feed Ordering Entity',
+      organization_id: org.id,
+    });
+
+    const now = Date.now();
+
+    futureFarId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_ids: [],
+        title: 'future far',
+        content: 'far future recurring instance',
+        occurred_at: new Date(now + 30 * DAY),
+      })
+    ).id;
+    futureNearId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_ids: [],
+        title: 'future near',
+        content: 'later today',
+        occurred_at: new Date(now + 2 * HOUR),
+      })
+    ).id;
+    recentId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_ids: [],
+        title: 'recent',
+        content: 'an hour ago',
+        occurred_at: new Date(now - HOUR),
+      })
+    ).id;
+    yesterdayId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_ids: [],
+        title: 'yesterday',
+        content: 'a day ago',
+        occurred_at: new Date(now - 26 * HOUR),
+      })
+    ).id;
+    oldId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_ids: [],
+        title: 'old',
+        content: 'sixty days ago',
+        occurred_at: new Date(now - 60 * DAY),
+      })
+    ).id;
+    nullOccurredId = await insertNullOccurredEvent({
+      organization_id: org.id,
+      title: 'null occurred at',
+      // A NULL occurred_at row ranks by its record time (COALESCE with
+      // created_at). Pin it to 3 days ago so it sorts between `yesterday` and
+      // `old` deterministically instead of at the top (the prod bug) or
+      // dependent on insert order.
+      created_at: new Date(now - 3 * DAY),
+    });
+
+    // Entity-scoped set, to pin the guard on the entity-link branch too.
+    entityFutureId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        title: 'entity future',
+        content: 'entity-scoped future instance',
+        occurred_at: new Date(now + 7 * DAY),
+      })
+    ).id;
+    entityRecentId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        title: 'entity recent',
+        content: 'entity-scoped recent event',
+        occurred_at: new Date(now - HOUR),
+      })
+    ).id;
+  });
+
+  it('default newest-first feed excludes future events and ranks NULL occurred_at by record time', async () => {
+    const result = await getContent(
+      { sort_by: 'date', sort_order: 'desc', limit: 100 } as never,
+      {} as never,
+      ctx()
+    );
+    const ids = result.content.map((item) => Number(item.id));
+    const titles = result.content.map((item) => item.title);
+
+    // Future-dated rows are not "activity" — excluded entirely.
+    expect(ids).not.toContain(futureFarId);
+    expect(ids).not.toContain(futureNearId);
+    expect(ids).not.toContain(entityFutureId);
+
+    // The NULL occurred_at row must still surface (real activity whose source
+    // timestamp was never recorded) and rank by its record time (3 days ago),
+    // not pin itself to the top of the feed.
+    expect(ids).toContain(nullOccurredId);
+    const nullIndex = titles.indexOf('null occurred at');
+    expect(nullIndex).toBeGreaterThan(titles.indexOf('yesterday'));
+    expect(nullIndex).toBeLessThan(titles.indexOf('old'));
+
+    // Order is newest-first for dated rows.
+    expect(titles.indexOf('recent')).toBeLessThan(titles.indexOf('yesterday'));
+    expect(titles.indexOf('yesterday')).toBeLessThan(titles.indexOf('old'));
+  });
+
+  it('an explicit future `until` re-includes future-dated events, newest first', async () => {
+    const until = new Date(Date.now() + 40 * DAY).toISOString().slice(0, 10);
+    const result = await getContent(
+      { sort_by: 'date', sort_order: 'desc', limit: 100, until } as never,
+      {} as never,
+      ctx()
+    );
+    const ids = result.content.map((item) => Number(item.id));
+    const titles = result.content.map((item) => item.title);
+
+    expect(ids).toContain(futureFarId);
+    expect(ids).toContain(futureNearId);
+    // Future events rank as the newest now that they are in scope.
+    expect(titles.indexOf('future far')).toBeLessThan(titles.indexOf('recent'));
+    expect(titles.indexOf('future near')).toBeLessThan(titles.indexOf('recent'));
+  });
+
+  it('cursor pagination walks every non-future event exactly once', async () => {
+    const collected: number[] = [];
+    let beforeOccurredAt: string | null = null;
+    let beforeId: number | null = null;
+
+    for (let page = 0; page < 10; page++) {
+      const result = await getContent(
+        {
+          sort_by: 'date',
+          sort_order: 'desc',
+          limit: 2,
+          ...(beforeOccurredAt != null && beforeId != null
+            ? { before_occurred_at: beforeOccurredAt, before_id: beforeId }
+            : {}),
+        } as never,
+        {} as never,
+        ctx()
+      );
+      for (const item of result.content) collected.push(Number(item.id));
+      if (!result.page.has_older) break;
+      const last = result.content[result.content.length - 1];
+      beforeOccurredAt = last.occurred_at;
+      beforeId = Number(last.id);
+    }
+
+    // The full walk is exactly the dated events + the NULL row (ranked by its
+    // record time), no future row, and no duplicate (cursor drift would
+    // duplicate or drop a row).
+    expect(new Set(collected)).toEqual(
+      new Set([recentId, yesterdayId, oldId, nullOccurredId, entityRecentId])
+    );
+    expect(collected).toHaveLength(5);
+    expect(collected).not.toContain(futureFarId);
+    expect(collected).not.toContain(futureNearId);
+    expect(collected).not.toContain(entityFutureId);
+  });
+
+  it('entity-scoped feeds apply the same future guard', async () => {
+    const result = await getContent(
+      { entity_id: entity.id, sort_by: 'date', sort_order: 'desc', limit: 100 } as never,
+      {} as never,
+      ctx()
+    );
+    const ids = result.content.map((item) => Number(item.id));
+    expect(ids).toContain(entityRecentId);
+    expect(ids).not.toContain(entityFutureId);
+  });
+});

--- a/packages/server/src/utils/__tests__/content-query-filters.test.ts
+++ b/packages/server/src/utils/__tests__/content-query-filters.test.ts
@@ -76,29 +76,33 @@ describe('buildRunFilter', () => {
 });
 
 describe('buildOrderByClause', () => {
+  // The recency key is the EFFECTIVE occurrence time — COALESCE with
+  // created_at — so a row whose occurred_at was never recorded still ranks by
+  // when it was recorded instead of pinning itself to the top of a
+  // newest-first feed (Postgres ORDER BY ... DESC defaults to NULLS FIRST).
   it('should build date descending by default', () => {
     const result = buildOrderByClause();
-    expect(result).toContain('occurred_at DESC');
+    expect(result).toContain('COALESCE(f.occurred_at, f.created_at) DESC');
   });
 
   it('should build score ordering', () => {
     const result = buildOrderByClause('score', 'desc');
     expect(result).toContain('score DESC');
-    expect(result).toContain('occurred_at DESC');
+    expect(result).toContain('COALESCE(f.occurred_at, f.created_at) DESC');
   });
 
   it('should build date ascending', () => {
     const result = buildOrderByClause('date', 'asc');
-    expect(result).toContain('occurred_at ASC');
+    expect(result).toContain('COALESCE(f.occurred_at, f.created_at) ASC');
   });
 
   it('should use custom table alias', () => {
     const result = buildOrderByClause('date', 'desc', 'e');
-    expect(result).toContain('e.occurred_at');
+    expect(result).toContain('COALESCE(e.occurred_at, e.created_at)');
   });
 
   it('should use f alias for final_select context', () => {
     const result = buildOrderByClause('date', 'desc', 'rs', 'final_select');
-    expect(result).toContain('f.occurred_at');
+    expect(result).toContain('COALESCE(f.occurred_at, f.created_at)');
   });
 });

--- a/packages/server/src/utils/content-query-filters.ts
+++ b/packages/server/src/utils/content-query-filters.ts
@@ -129,8 +129,13 @@ export function buildOrderByClause(
   const validSortOrder = sortOrder === 'asc' ? 'ASC' : 'DESC';
   const alias = context === 'final_select' ? 'f' : tableAlias;
 
+  // Order by the effective occurrence time — COALESCE(occurred_at, created_at).
+  // A row whose source timestamp was never recorded must rank by its record
+  // time (which is exactly what the API surfaces for such rows), not sort as
+  // the newest: Postgres `ORDER BY occurred_at DESC` defaults to NULLS FIRST,
+  // pinning a straggler NULL row to the top of the activity feed.
   if (sortBy === 'score') {
-    return `${alias}.score ${validSortOrder}, ${alias}.occurred_at DESC, ${alias}.id DESC`;
+    return `${alias}.score ${validSortOrder}, COALESCE(${alias}.occurred_at, ${alias}.created_at) DESC, ${alias}.id DESC`;
   }
-  return `${alias}.occurred_at ${validSortOrder}, ${alias}.id ${validSortOrder}`;
+  return `COALESCE(${alias}.occurred_at, ${alias}.created_at) ${validSortOrder}, ${alias}.id ${validSortOrder}`;
 }

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -476,7 +476,7 @@ export async function getNormalizedScoreContent(
       -- always '{}'. Kept empty for response-shape parity with the date-sort path.
       '{}'::jsonb as classifications
     FROM scored_content sc
-    ORDER BY sc.calculated_score DESC, sc.occurred_at DESC, sc.id DESC
+    ORDER BY sc.calculated_score DESC, COALESCE(sc.occurred_at, sc.created_at) DESC, sc.id DESC
     LIMIT ${limit} OFFSET ${offset}
   `;
 

--- a/packages/server/src/utils/content-search/__tests__/date-order.test.ts
+++ b/packages/server/src/utils/content-search/__tests__/date-order.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for the chronological-feed ordering/cursor helpers in
+ * content-search/types.ts.
+ *
+ * The recency key is the EFFECTIVE occurrence time — COALESCE(occurred_at,
+ * created_at) — so a row whose source timestamp was never recorded ranks by
+ * its record time (exactly what the API surfaces for such rows) instead of
+ * pinning itself to the top of a newest-first feed: Postgres
+ * `ORDER BY occurred_at DESC` defaults to NULLS FIRST, which is what put a
+ * 9-day-old NULL-timestamp approval card above everything in prod.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildDateCandidateOrderBy, buildDateCursorClause } from '../types';
+
+describe('buildDateCandidateOrderBy', () => {
+  it('orders newest-first on the effective occurrence time (desc)', () => {
+    expect(buildDateCandidateOrderBy(null, 'f')).toBe(
+      'COALESCE(f.occurred_at, f.created_at) DESC, f.id DESC'
+    );
+  });
+
+  it('orders oldest-first on the effective occurrence time for an after cursor', () => {
+    const cursor = { direction: 'after' as const, occurredAtIso: 'x', id: 1 };
+    expect(buildDateCandidateOrderBy(cursor, 'fi')).toBe(
+      'COALESCE(fi.occurred_at, fi.created_at) ASC, fi.id ASC'
+    );
+  });
+});
+
+describe('buildDateCursorClause', () => {
+  const cursor = {
+    direction: 'before' as const,
+    occurredAtIso: '2026-07-28T03:04:17.894Z',
+    id: 4669806,
+  };
+
+  it('keyset-comparison uses the effective occurrence time so NULL rows stay reachable', () => {
+    const clause = buildDateCursorClause(
+      cursor,
+      'COALESCE(f.occurred_at, f.created_at)',
+      'f.id',
+      1
+    );
+    expect(clause.sql).toBe(
+      'AND (COALESCE(f.occurred_at, f.created_at) < $1::timestamptz OR (COALESCE(f.occurred_at, f.created_at) = $1::timestamptz AND f.id < $2::bigint))'
+    );
+    expect(clause.params).toEqual([cursor.occurredAtIso, cursor.id]);
+  });
+});

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -71,7 +71,7 @@ async function executeListQuery(args: {
 
   const cursorClause = buildDateCursorClause(
     args.cursor,
-    'f.occurred_at',
+    'COALESCE(f.occurred_at, f.created_at)',
     'f.id',
     countParams.length + 1
   );
@@ -89,7 +89,8 @@ async function executeListQuery(args: {
       WITH RECURSIVE candidate_set AS (
         SELECT
           f.id,
-          f.occurred_at
+          f.occurred_at,
+          f.created_at
         FROM current_event_records f
         LEFT JOIN connections c ON c.id = f.connection_id
         ${joinSql}
@@ -101,6 +102,8 @@ async function executeListQuery(args: {
       result_set AS (
         SELECT
           cs.id,
+          cs.occurred_at,
+          cs.created_at,
           (SELECT COUNT(*) FROM candidate_set) as cursor_fetched_count
         FROM candidate_set cs
         ORDER BY ${buildDateCandidateOrderBy(args.cursor, 'cs')}
@@ -190,6 +193,31 @@ async function executeListQuery(args: {
   };
 }
 
+/**
+ * Chronological-feed guard: exclude events that have not occurred yet.
+ *
+ * A future-dated row is a scheduled item, not "activity", so ranking it as the
+ * newest would let a far-future recurring series (calendar instances expanded
+ * a year ahead) monopolize the first page of the activity feed. The guard is
+ * lifted only when the caller explicitly asks for a future window — an `until`
+ * past now or an `after` cursor past now. NULL occurred_at rows are kept: they
+ * are real activity whose source timestamp was never recorded, and the
+ * COALESCE(occurred_at, created_at) ordering ranks them by record time instead
+ * of pinning the top.
+ */
+function buildFutureOccurredAtClause(
+  untilDate: Date | null,
+  cursor: ReturnType<typeof resolveDateCursor>
+): { sql: string } {
+  const nowMs = Date.now();
+  const asksForFuture =
+    (untilDate != null && untilDate.getTime() > nowMs) ||
+    (cursor?.direction === 'after' &&
+      new Date(cursor.occurredAtIso).getTime() > nowMs);
+  if (asksForFuture) return { sql: '' };
+  return { sql: 'AND (f.occurred_at IS NULL OR f.occurred_at <= now())' };
+}
+
 export async function listContentInternal(
   sql: DbClient,
   options: ContentSearchOptions & { offset?: number },
@@ -205,6 +233,7 @@ export async function listContentInternal(
 
   const sinceDate = options.since ? parseDateAlias(options.since).date : null;
   const untilDate = options.until ? toEndOfDay(parseDateAlias(options.until).date) : null;
+  const futureClause = buildFutureOccurredAtClause(untilDate, cursor);
   const connectionIdsArray =
     options.connection_ids && options.connection_ids.length > 0 ? options.connection_ids : null;
   const feedIdsArray =
@@ -414,7 +443,7 @@ export async function listContentInternal(
     return executeListQuery({
       sql,
       joinSql: '',
-      whereExpr: `${whereSql} ${excludeClause.sql} ${visibilityClause.sql}${entityTypesClause.sql}`,
+      whereExpr: `${whereSql} ${excludeClause.sql} ${visibilityClause.sql}${entityTypesClause.sql} ${futureClause.sql}`,
       countParams: allFilterParams,
       entityId: entityId ?? null,
       threadEntityLinkSqlForP: threadEntityLinkSql,
@@ -503,7 +532,7 @@ export async function listContentInternal(
           AND ${runCondition}
           ${excludeClause.sql}
           ${visibilityClause.sql}
-          ${orgScope.sql}${entityTypesClause.sql}`,
+          ${orgScope.sql}${entityTypesClause.sql} ${futureClause.sql}`,
     countParams,
     threadEntityLinkSqlForP: standardEntityLinkSqlForP,
     needClassifications,

--- a/packages/server/src/utils/content-search/search-path.ts
+++ b/packages/server/src/utils/content-search/search-path.ts
@@ -236,9 +236,12 @@ export async function searchContentBySingleQuery(
   // Tiebreaker for score-sorted branches: (id % 997) spreads near-tied rows pseudo-uniformly
   // across the ID space so that near-duplicate content (e.g. LoCoMo conversation sessions) does
   // not collapse onto the most-recent cluster via the occurred_at/id fallback. The final
-  // occurred_at/id tiebreaker stays for full determinism when hashes also collide.
-  const outerScoreTiebreaker = '(f.id % 997) ASC, f.occurred_at DESC, f.id DESC';
-  const innerScoreTiebreaker = '(fi.id % 997) ASC, fi.occurred_at DESC, fi.id DESC';
+  // occurred_at/id tiebreaker stays for full determinism when hashes also collide — keyed on the
+  // effective time so a NULL-source-timestamp row ranks by its record time.
+  const outerScoreTiebreaker =
+    '(f.id % 997) ASC, COALESCE(f.occurred_at, f.created_at) DESC, f.id DESC';
+  const innerScoreTiebreaker =
+    '(fi.id % 997) ASC, COALESCE(fi.occurred_at, fi.created_at) DESC, fi.id DESC';
 
   if (hasEmbedding) {
     // Clamp to [0, 1] so callers can't accidentally invert the weighting.
@@ -299,7 +302,12 @@ export async function searchContentBySingleQuery(
   // When hasEmbedding, two params (vector + min_similarity) follow baseParamIdx;
   // otherwise neither is bound, so the cursor params resume at baseParamIdx.
   const cursorBaseParamIdx = baseParamIdx + (hasEmbedding ? 2 : 0);
-  const cursorClause = buildDateCursorClause(cursor, 'fi.occurred_at', 'fi.id', cursorBaseParamIdx);
+  const cursorClause = buildDateCursorClause(
+    cursor,
+    'COALESCE(fi.occurred_at, fi.created_at)',
+    'fi.id',
+    cursorBaseParamIdx
+  );
   const limitParamIdx = cursorBaseParamIdx + cursorClause.params.length;
   const offsetParamIdx = limitParamIdx + 1;
   const validatedLimit = validateNumericId(limit, 'limit');
@@ -380,7 +388,7 @@ export async function searchContentBySingleQuery(
   }
 
   const nonDateFilteredIdsCteSql = `filtered_ids AS (
-        SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, ${bestSimSelect} AS best_sim, f.search_tsv
+        SELECT f.id, f.score, f.occurred_at, f.created_at, f.title, f.payload_text, ${bestSimSelect} AS best_sim, f.search_tsv
         FROM current_event_records f
         ${useCandidatePath ? 'JOIN search_candidates sc ON sc.id = f.id' : ''}
         LEFT JOIN connections c ON c.id = f.connection_id
@@ -394,7 +402,7 @@ export async function searchContentBySingleQuery(
   const querySQL = useDateFeed
     ? `
       WITH RECURSIVE filtered_ids AS (
-        SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, ${bestSimSelect} AS best_sim, f.search_tsv
+        SELECT f.id, f.score, f.occurred_at, f.created_at, f.title, f.payload_text, ${bestSimSelect} AS best_sim, f.search_tsv
         FROM current_event_records f
         LEFT JOIN connections c ON c.id = f.connection_id
         LEFT JOIN watcher_window_events iwf
@@ -410,6 +418,7 @@ export async function searchContentBySingleQuery(
         SELECT
           fi.id,
           fi.occurred_at,
+          fi.created_at,
           ${textRankExpr} as text_rank,
           ${similarityExpr} as similarity,
           ${combinedScoreExpr} as combined_score
@@ -424,6 +433,7 @@ export async function searchContentBySingleQuery(
           cs.text_rank,
           cs.similarity,
           cs.combined_score,
+          cs.created_at,
           (SELECT total_count FROM full_count) as total_count,
           (SELECT COUNT(*) FROM candidate_set) as cursor_fetched_count
         FROM candidate_set cs

--- a/packages/server/src/utils/content-search/types.ts
+++ b/packages/server/src/utils/content-search/types.ts
@@ -234,10 +234,16 @@ export function buildDateCursorClause(
 }
 
 export function buildDateCandidateOrderBy(cursor: DateCursor | null, tableAlias: string): string {
+  // Order by the effective occurrence time — COALESCE(occurred_at, created_at)
+  // — in both directions. An event whose source timestamp was never recorded
+  // must rank by its record time (which is exactly what the API surfaces for
+  // such rows), not sort as the newest/oldest or drop out of keyset pagination:
+  // Postgres `ORDER BY occurred_at DESC` defaults to NULLS FIRST, pinning a
+  // straggler NULL row to the top of a newest-first feed.
   if (cursor?.direction === 'after') {
-    return `${tableAlias}.occurred_at ASC, ${tableAlias}.id ASC`;
+    return `COALESCE(${tableAlias}.occurred_at, ${tableAlias}.created_at) ASC, ${tableAlias}.id ASC`;
   }
-  return `${tableAlias}.occurred_at DESC, ${tableAlias}.id DESC`;
+  return `COALESCE(${tableAlias}.occurred_at, ${tableAlias}.created_at) DESC, ${tableAlias}.id DESC`;
 }
 
 export function buildPageInfo(params: {


### PR DESCRIPTION
## Summary
The newest-first activity feed (`/activity`) pinned a 9-day-old approval card to the top and buried real activity behind ~244 recurring Google Calendar instances dated 30 years out (2053–2056). Two root causes in the chronological list ordering:

- **NULL `occurred_at`**: Postgres `ORDER BY occurred_at DESC` defaults to NULLS FIRST, so an event whose source timestamp was never recorded sorted as the newest regardless of age (the top card had `occurred_at = NULL`). The ordering — and the keyset cursor, which must use the same key — now `COALESCE(occurred_at, created_at)`, the exact value the API already surfaced for such rows (`render.ts`). NULL rows now rank by record time and stay reachable across cursor pages instead of being dropped after page one.
- **Future-dated events**: a recurring series expanded a year ahead has `occurred_at > now()`, which is a scheduled item, not "activity". The chronological list now excludes not-yet-occurred events unless the caller explicitly asks for a future window via an `until` past now or an `after` cursor past now.

Applied across the list, search, and score paths. Behavior-mode already used `NULLS LAST` and is untouched. No connector change: future calendar instances remain stored/searchable (including via an explicit future `until`).

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: new integration test (`date-feed-ordering.test.ts`) + new unit tests (`date-order.test.ts`, updated `content-query-filters.test.ts`); full `events/` integration dir (37 files / 175 tests) green; targeted list/search/visibility/classification suites green
- [x] Bug fix: red→fix→green outputs below
- [ ] E2E over the booted server's `read_knowledge` HTTP endpoint — **green, see below**

## Red → fix → green
**Red** (fix reverted, focused integration test) — reproduces the exact prod symptom; NULL row (id 6) pins the top, future rows (ids 1/2/7) fill the newest slots:
```
❯ date-feed-ordering.test.ts (4 tests | 3 failed)
    → expected [ 6, 1, 7, 2, 8, 3, 4, 5 ] to not include 1
    → expected Set{ 6, 1, 7, 2, 8, 3, 4, 5 } to deeply equal Set{ 3, 4, 5, 6, 8 }
    → expected [ 7, 8 ] to not include 7
```

**Green** (fix restored):
```
✓ date-feed-ordering.test.ts (4 tests)       ✓ content-query-filters.test.ts (16)
✓ date-order.test.ts (3)                     Test Files 3 passed · Tests 23 passed
✓ events/ integration dir: 37 files, 175 tests passed
```

**E2E** (booted `make dev`, seeded org with the prod shape, `POST /api/e2e-order-fix/read_knowledge`):
```
before fix (mutation): [NULL row first, then future rows]   →   after fix:
total: 3 | recent (now-1h) | null occurred at (now-3d) | old (now-60d)   # future excluded
P1: read_knowledge completed | recent (has_older: true)
P2(cursor): null occurred at | old (has_older: false)                     # NULL row reachable via cursor
```

## Notes
- Pre-existing, unrelated: `make test-unit` shows 1 failure on `packages/agent-worker/src/__tests__/exec-sandbox-extra.test.ts:87` — it asserts the regex `/bubblewrap is unavailable/` but `probeSandboxStrategy` now emits `"bubblewrap (bwrap) was not found on PATH..."`. Fails on hosts without bwrap; present on `origin/main` (verified), not touched by this branch.
- `make review-fix` could not run: external codex API hit its usage limit (no working-tree changes made before the error).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chronological feed ordering for items without an occurrence date by using their creation date as a fallback.
  * Prevented future-dated events from appearing in standard feeds unless the requested time range explicitly includes them.
  * Improved cursor-based pagination to avoid skipped or duplicated events.
  * Applied consistent ordering and future-event handling to search and entity-specific feeds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->