### PR TITLE
fix(server): apply the future-event guard to classification stats too

### DIFF
--- a/packages/server/src/__tests__/integration/events/date-feed-ordering.test.ts
+++ b/packages/server/src/__tests__/integration/events/date-feed-ordering.test.ts
@@ -55,6 +55,7 @@ describe('getContent > chronological feed ordering (NULL + future occurred_at)',
 
   let entityFutureId: number;
   let entityRecentId: number;
+  let facetId: number;
 
   function ctx(): ToolContext {
     return {
@@ -175,6 +176,27 @@ describe('getContent > chronological feed ordering (NULL + future occurred_at)',
         occurred_at: new Date(now - HOUR),
       })
     ).id;
+
+    // Classify one future-dated and one recent event with the same facet, to
+    // pin the classification-stats aggregate to the SAME future guard as the
+    // list: the distribution over a wider set than the rows it labels is wrong.
+    const sql = getTestDb();
+    const [facet] = await sql<{ id: number }[]>`
+      INSERT INTO classify_facet (organization_id, slug, name, attribute_key, status,
+                                  created_by, entity_ids, attribute_values, min_similarity)
+      VALUES (${org.id}, 'order-kind', 'Order kind', 'order_kind', 'active', ${user.id},
+              ARRAY[]::bigint[], ${sql.json({ alpha: { description: 'A', examples: [] } })}, 0.7)
+      RETURNING id
+    `;
+    facetId = Number(facet.id);
+    for (const eventId of [futureFarId, recentId]) {
+      await sql`
+        INSERT INTO event_classifications (event_id, classifier_id, watcher_id, window_id,
+                                           "values", confidences, source, is_manual)
+        VALUES (${eventId}, ${facetId}, NULL, NULL, ${'{alpha}'}::text[],
+                ${sql.json({ alpha: 1 })}, 'user', true)
+      `;
+    }
   });
 
   it('default newest-first feed excludes future events and ranks NULL occurred_at by record time', async () => {
@@ -267,5 +289,29 @@ describe('getContent > chronological feed ordering (NULL + future occurred_at)',
     const ids = result.content.map((item) => Number(item.id));
     expect(ids).toContain(entityRecentId);
     expect(ids).not.toContain(entityFutureId);
+  });
+
+  it('classification stats apply the same future guard as the list', async () => {
+    // The list excludes future-dated rows; the filter-chip distribution must
+    // label the SAME set. `order-kind` is classified on the future row and the
+    // recent row — a distribution over a wider set would count 2.
+    const result = await getContent(
+      {
+        sort_by: 'date',
+        sort_order: 'desc',
+        limit: 100,
+        include_classification: 'summary',
+        classification_filters: { 'order-kind': ['alpha'] },
+      } as never,
+      {} as never,
+      ctx()
+    );
+
+    const ids = result.content.map((item) => Number(item.id));
+    expect(ids).toContain(recentId);
+    expect(ids).not.toContain(futureFarId);
+
+    const alpha = result.classification_stats?.['order-kind']?.['alpha'];
+    expect(alpha).toBe(1);
   });
 });

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -8,6 +8,7 @@ import { type DbClient, pgBigintArray, pgTextArray } from '../../db/client';
 import {
   buildConnectionVisibilityClause,
   buildEntityLinkUnion,
+  buildFutureOccurredAtClause,
   fetchEntityIdentityScopes,
 } from '../../utils/content-search';
 import logger from '../../utils/logger';
@@ -589,6 +590,17 @@ export async function fetchClassificationStats(opts: {
   if (untilDate) {
     conditions.push(`f.occurred_at <= $${paramIndex++}`);
     params.push(untilDate.toISOString());
+  }
+  // The chronological LIST excludes not-yet-occurred events (see
+  // buildFutureOccurredAtClause); a distribution over a wider set than the rows
+  // it labels is wrong, so apply the same guard to the stats scope. Only on the
+  // list path (no query): search still returns future-dated rows and its stats
+  // must match that result set.
+  if (!args.query) {
+    const futureGuard = buildFutureOccurredAtClause(untilDate, null).sql;
+    if (futureGuard) {
+      conditions.push(futureGuard.replace(/^AND\s+/, ''));
+    }
   }
   let windowJoinSql = '';
   if (args.window_id) {

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -19,6 +19,8 @@ export {
 
 export { buildConnectionVisibilityClause, buildOrgScopeWhere } from './content-search/visibility';
 
+export { buildFutureOccurredAtClause } from './content-search/types';
+
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { listContentInternal } from './content-search/list-path';

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -23,6 +23,7 @@ import { buildFinalSelect, deduplicateWithClassifications } from './sql-fragment
 import {
   buildDateCandidateOrderBy,
   buildDateCursorClause,
+  buildFutureOccurredAtClause,
   buildPageInfo,
   emptyListResponse,
   isDateFeedMode,
@@ -191,31 +192,6 @@ async function executeListQuery(args: {
       fetchedCount: rawRows[0]?.cursor_fetched_count,
     }),
   };
-}
-
-/**
- * Chronological-feed guard: exclude events that have not occurred yet.
- *
- * A future-dated row is a scheduled item, not "activity", so ranking it as the
- * newest would let a far-future recurring series (calendar instances expanded
- * a year ahead) monopolize the first page of the activity feed. The guard is
- * lifted only when the caller explicitly asks for a future window — an `until`
- * past now or an `after` cursor past now. NULL occurred_at rows are kept: they
- * are real activity whose source timestamp was never recorded, and the
- * COALESCE(occurred_at, created_at) ordering ranks them by record time instead
- * of pinning the top.
- */
-function buildFutureOccurredAtClause(
-  untilDate: Date | null,
-  cursor: ReturnType<typeof resolveDateCursor>
-): { sql: string } {
-  const nowMs = Date.now();
-  const asksForFuture =
-    (untilDate != null && untilDate.getTime() > nowMs) ||
-    (cursor?.direction === 'after' &&
-      new Date(cursor.occurredAtIso).getTime() > nowMs);
-  if (asksForFuture) return { sql: '' };
-  return { sql: 'AND (f.occurred_at IS NULL OR f.occurred_at <= now())' };
 }
 
 export async function listContentInternal(

--- a/packages/server/src/utils/content-search/types.ts
+++ b/packages/server/src/utils/content-search/types.ts
@@ -246,6 +246,34 @@ export function buildDateCandidateOrderBy(cursor: DateCursor | null, tableAlias:
   return `COALESCE(${tableAlias}.occurred_at, ${tableAlias}.created_at) DESC, ${tableAlias}.id DESC`;
 }
 
+/**
+ * Chronological-feed guard: exclude events that have not occurred yet.
+ *
+ * A future-dated row is a scheduled item, not "activity", so ranking it as the
+ * newest would let a far-future recurring series (calendar instances expanded
+ * a year ahead) monopolize the first page of the activity feed. The guard is
+ * lifted only when the caller explicitly asks for a future window — an `until`
+ * past now or an `after` cursor past now. NULL occurred_at rows are kept: they
+ * are real activity whose source timestamp was never recorded, and the
+ * COALESCE(occurred_at, created_at) ordering ranks them by record time instead
+ * of pinning the top.
+ *
+ * The returned fragment carries a leading `AND` for appending to a WHERE body;
+ * callers building a `conditions` array strip it (see fetchClassificationStats).
+ */
+export function buildFutureOccurredAtClause(
+  untilDate: Date | null,
+  cursor: DateCursor | null
+): { sql: string } {
+  const nowMs = Date.now();
+  const asksForFuture =
+    (untilDate != null && untilDate.getTime() > nowMs) ||
+    (cursor?.direction === 'after' &&
+      new Date(cursor.occurredAtIso).getTime() > nowMs);
+  if (asksForFuture) return { sql: '' };
+  return { sql: 'AND (f.occurred_at IS NULL OR f.occurred_at <= now())' };
+}
+
 export function buildPageInfo(params: {
   limit: number;
   offset: number;


### PR DESCRIPTION
## Summary
The chronological list (merged #2535) excludes not-yet-occurred events — calendar instances expanded ahead are scheduled items, not "activity". But `fetchClassificationStats` did not get the same guard: its distribution counted future-dated rows the list hides, violating the code's own invariant ("the distribution over a wider set than the rows it labels is simply wrong"). Filter-chip counts over-counted and could page the user into rows that render nothing.

Moves `buildFutureOccurredAtClause` from `list-path.ts` to `content-search/types` (shared) and applies it to the stats scope on the list path (no query). Search still returns future-dated rows, so its stats stay unfiltered — consistent with the search result set.

## Test plan
- [x] `make pre-pr` clean
- [x] New regression in `date-feed-ordering.test.ts`; full `events/` integration dir 38 files / 178 tests green
- [x] Bug fix: red→fix→green below

## Red → fix → green
**Red** (new regression, stats unguarded): classify one future + one recent event as `order-kind:alpha`; list mode reports the chip count as 2 while the list shows 1.
```
→ expected 2 to be 1 // Object.is equality
```
**Green** (after fix): `5/5 date-feed-ordering.test.ts`, `178/178 events/ integration dir`.

## Notes
- Data gap, not code: prod has exactly 1 `occurred_at IS NULL` row (the buremba suggestion card) and 262 future-dated rows. The ordering fix (#2535) already renders both correctly; a follow-up backfill migration (`SET occurred_at = created_at WHERE occurred_at IS NULL`) would restore the no-NULL invariant if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Classification statistics now consistently exclude future-dated events, matching chronological feed results.
  * Events without an occurrence date continue to be included.
  * Explicit requests for future date ranges still return future events as expected.

* **Tests**
  * Added integration coverage validating classification statistics for feeds containing both recent and future events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->