### PR TITLE
fix(core): validate agent_kind against the device executor registry

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4335,9 +4335,9 @@ export type ManageBehaviorsData = {
      */
     device_worker_id?: string | null;
     /**
-     * [create/update] Optional agent kind override for this Behavior (e.g. "background", "notifier"). Null clears the override.
+     * [create/update] Which local CLI a device-pinned Behavior runs on. Only meaningful alongside device_worker_id. Null (the default) uses whatever agent the device itself is set to. A kind the device has no executor for fails at dispatch, so this is validated here rather than accepted and discovered later.
      */
-    agent_kind?: string | null;
+    agent_kind?: "claude-code" | "codex" | "opencode" | "pi" | "agy" | null;
     /**
      * [create/update] Where firings surface: "canvas" (default), "notification" (OS notification), or "both".
      */
@@ -5160,6 +5160,15 @@ export type ReadKnowledgeResponses = {
     };
     sources?: {
       [key: string]: unknown | Array<unknown>;
+    };
+    sources_page?: {
+      [key: string]:
+        | unknown
+        | {
+            returned: number;
+            limit: number;
+            has_more: boolean;
+          };
     };
     entities?: Array<unknown>;
     classifiers?: Array<unknown>;

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -261,6 +261,28 @@ export type BehaviorExecutionConfig = Static<
   typeof BehaviorExecutionConfigSchema
 >;
 
+/**
+ * Local CLI runtimes a device-pinned Behavior can name in `agent_kind`.
+ *
+ * This is the write-side half of a contract whose other half lives in the Mac
+ * app: the device registers one executor per `AgentSpec` and resolves the
+ * Behavior's kind against that registry at dispatch. A kind with no executor
+ * there produces a run that fails on the device with "no local agent executor
+ * configured", so accepting an arbitrary string here only defers the failure
+ * to a place nobody is watching (#2504).
+ *
+ * Adding a CLI means adding an `AgentSpec` on the device AND a literal here —
+ * the device cannot yet advertise its runnable kinds, so the server has no way
+ * to derive this list.
+ */
+const DEVICE_AGENT_KIND_LITERALS = [
+  Type.Literal("claude-code"),
+  Type.Literal("codex"),
+  Type.Literal("opencode"),
+  Type.Literal("pi"),
+  Type.Literal("agy"),
+];
+
 // ============================================
 // Typebox Schema (Flattened for MCP)
 // ============================================
@@ -548,9 +570,9 @@ export const ManageBehaviorsSchema = Type.Object(
       })
     ),
     agent_kind: Type.Optional(
-      Type.Union([Type.String(), Type.Null()], {
+      Type.Union([...DEVICE_AGENT_KIND_LITERALS, Type.Null()], {
         description:
-          '[create/update] Optional agent kind override for this Behavior (e.g. "background", "notifier"). Null clears the override.',
+          "[create/update] Which local CLI a device-pinned Behavior runs on. Only meaningful alongside device_worker_id. Null (the default) uses whatever agent the device itself is set to. A kind the device has no executor for fails at dispatch, so this is validated here rather than accepted and discovered later.",
       })
     ),
     notification_channel: Type.Optional(

--- a/packages/server/src/__tests__/unit/behavior-executors.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-executors.test.ts
@@ -4,6 +4,9 @@ import {
 	assertBehaviorExecutorsResolve,
 	resolveBehaviorExecutor,
 } from "../../tools/admin/manage_behaviors/executors";
+import { getTool } from "../../tools/registry";
+import { validateToolArgs } from "../../tools/validate-args";
+import { ToolUserError } from "../../utils/errors";
 
 const eventTrigger = (): BehaviorTriggerInput => ({
 	kind: "event",
@@ -76,5 +79,47 @@ describe("assertBehaviorExecutorsResolve", () => {
 				deviceWorkerId: "device-1",
 			}),
 		).not.toThrow();
+	});
+});
+
+// `agent_kind` names the local CLI the device spawns. It was a free-text
+// column with no FK and a free-text schema, so an unknown value wrote a
+// Behavior that resolved to no executor on the device and failed at dispatch
+// — the write path never objected (#2504). Worse, the schema's own examples
+// were "background" and "notifier", neither of which has ever had an
+// executor, so an agent following the contract wrote a dead Behavior.
+describe("manage_behaviors agent_kind", () => {
+	// Validate the schema the registry actually serves, not a direct import —
+	// this is the copy every write lane (MCP, run_sdk, REST) resolves.
+	const schema = getTool("manage_behaviors")?.inputSchema;
+	if (!schema) throw new Error("manage_behaviors is not in the tool registry");
+
+	const write = (agentKind: unknown) =>
+		validateToolArgs("manage_behaviors", schema, {
+			action: "create",
+			slug: "s",
+			name: "n",
+			prompt: "p",
+			device_worker_id: "device-1",
+			agent_kind: agentKind,
+		});
+
+	// Every kind the Mac dispatcher registers an executor for. Adding a CLI
+	// to AgentSpec.all without adding it here makes it unselectable.
+	test.each(["claude-code", "codex", "opencode", "pi", "agy"])(
+		"accepts %s",
+		(kind) => {
+			expect(() => write(kind)).not.toThrow();
+		},
+	);
+
+	test("accepts null — the device's own default agent", () => {
+		expect(() => write(null)).not.toThrow();
+	});
+
+	test("rejects a kind no executor implements", () => {
+		expect(() => write("gemini-cli")).toThrow(ToolUserError);
+		expect(() => write("background")).toThrow(ToolUserError);
+		expect(() => write("claude_code")).toThrow(ToolUserError);
 	});
 });


### PR DESCRIPTION
## Summary

- `agent_kind` names the local CLI a device-pinned Behavior spawns. It was free text in the tool schema and a free-text column with no FK, so an unknown value was accepted at write time and only surfaced on the device as `no local agent executor configured` — a failure nobody watches (#2504).
- The schema made this worse than a missing check: it advertised `"background"` and `"notifier"` as examples. Neither has ever had an executor in either repo, so an agent following the contract wrote a Behavior that could never run.
- Narrowed to the five kinds the Mac dispatcher registers an `AgentSpec` for. Validation lands at `tools/validate-args.ts`, the chokepoint every write lane already routes through (MCP tool, `run_sdk` sandbox, REST), so no per-call-site check was added.

```diff
-agent_kind?: string | null;
+agent_kind?: "claude-code" | "codex" | "opencode" | "pi" | "agy" | null;
```

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming + gateway-llm)
- [x] Tests run: `bun test packages/server/src/__tests__/unit` — 857 pass, 16 skip, 0 fail
- [x] Bug fix: red→fix→green outputs pasted below

**RED** (new test against the unmodified schema — an agent kind that was *removed* from the product sails through):

```
117 | 	test("rejects a kind no executor implements", () => {
118 | 		expect(() => write("gemini-cli")).toThrow(ToolUserError);
                                          ^
error: expect(received).toThrow(expected)
Expected constructor: ToolUserError
Received function did not throw
Received value: {
  action: "create", slug: "s", name: "n", prompt: "p",
  device_worker_id: "device-1", agent_kind: "gemini-cli",
}

 14 pass
 1 fail
```

**GREEN** (after narrowing the union):

```
 15 pass
 0 fail
 20 expect() calls
Ran 15 tests across 1 file.
```

Mutation check: reverting the schema to `Type.String()` puts the test back to red; restoring goes green. The three rejected values are chosen to cover the real failure shapes — `gemini-cli` (a kind removed from the product in owletto e6efee23), `background` (what the old description told agents to write), and `claude_code` (a plausible typo).

## Notes

**Unrelated regen drift rides along.** `types.gen.ts` also gains a `sources_page` hunk in `ReadKnowledgeResponses`. That contract landed on `origin/main` without a client regen, so `packages/client/src/generated` was already stale before this branch — `git grep sources_page origin/main` hits `tools/get_content/behavior-mode.ts` but not the generated client. Regen is all-or-nothing, and the client-regen CI gate requires the hunk, so stripping it would fail CI.

**Scope.** Write-side only. Existing `watchers.agent_kind` rows outside the allowlist are untouched, and an update that omits the field keeps its stored value. Prod currently holds only `agy` and `NULL`, so there is nothing to migrate.

**Deploy coupling this introduces:** adding a CLI to the Mac app now needs a literal here before it can be selected. That is the deliberate tradeoff — the device cannot yet advertise its runnable kinds through `device_workers.capabilities` (those are permission grants, not agent kinds), so the server has no way to derive the list. Retiring this list is tracked as part of the #2504 follow-up.

Found while triaging #2503 / #2504.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting from the following device-local CLI agents: Claude Code, Codex, OpenCode, Pi, and Agy.
  * Agent selections can also be cleared by setting the value to null.

* **Bug Fixes**
  * Prevented unsupported or legacy agent selections from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->