### PR TITLE
fix(cli): mint hosted-chat link codes after the gateway is reachable

### DIFF
--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -363,3 +363,39 @@ describe("autoApplyLocalProject — org is pinned to the local-init slug (#1366)
     ).resolves.toBeUndefined();
   });
 });
+
+describe("lobu run hosted-chat link-code ordering", () => {
+  const devSource = readFileSync(
+    join(here, "..", "commands", "dev.ts"),
+    "utf8"
+  );
+
+  test("mints preview codes only after the gateway is spawned", () => {
+    // Regression guard for the startup race: printPreviewInstructions POSTs
+    // /preview/claims, which fails with "fetch failed" if the embedded gateway
+    // isn't listening yet. It must be called from the announceLocalSignIn
+    // then-chain (after reachability + auto-apply), never the pre-spawn banner.
+    const spawnIndex = devSource.indexOf('const child = spawn("node"');
+    const chainCallIndex = devSource.indexOf(
+      "printPreviewInstructions(cwd)",
+      devSource.indexOf("announceLocalSignIn")
+    );
+
+    expect(spawnIndex).toBeGreaterThan(-1);
+    expect(chainCallIndex).toBeGreaterThan(spawnIndex);
+    // No call may appear anywhere before the spawn (the pre-spawn banner was
+    // the race: the gateway isn't listening yet, so the claim POST 404s).
+    const beforeSpawn = devSource.slice(0, spawnIndex);
+    expect(beforeSpawn.includes("printPreviewInstructions(cwd)")).toBe(false);
+  });
+
+  test("surfaces the failure reason plus concrete recovery steps", () => {
+    expect(devSource).toContain("Reason:");
+    expect(devSource).toContain(
+      "To get a link code, complete these steps against Lobu Cloud, then restart"
+    );
+    expect(devSource).toContain("lobu login");
+    expect(devSource).toContain("lobu org set <slug>");
+    expect(devSource).toContain("lobu apply");
+  });
+});

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -313,7 +313,6 @@ export async function devCommand(
   }
 
   if (!options.quiet) {
-    await printPreviewInstructions(cwd);
     console.log(chalk.cyan(`\n  Starting Lobu...\n`));
     console.log(chalk.dim(`  bundle:        ${bundlePath}`));
     if (mode === "external") {
@@ -404,7 +403,7 @@ export async function devCommand(
   // persists the session as the `local` CLI context so `lobu chat -c local`
   // works without a separate `lobu login`.
   void announceLocalSignIn(gatewayUrl, mode === "embedded").then(
-    ({ ready: localContextReady, localOrgSlug }) => {
+    async ({ ready: localContextReady, localOrgSlug }) => {
       // Once the `local` context is confirmed registered + active, push the
       // project's lobu.config.ts into the embedded DB so the scaffolded agent is
       // usable via `lobu chat -c local …` with no separate `lobu apply`.
@@ -418,7 +417,14 @@ export async function devCommand(
           hasLobuConfig: existsSync(join(cwd, "lobu.config.ts")),
         })
       ) {
-        return autoApplyLocalProject(cwd, gatewayUrl, localOrgSlug);
+        await autoApplyLocalProject(cwd, gatewayUrl, localOrgSlug);
+      }
+      // Mint hosted-chat link codes only AFTER the gateway is reachable and the
+      // project is applied. printPreviewInstructions POSTs /preview/claims; if
+      // run from the pre-spawn banner it races the server boot and every hosted
+      // connection prints a bogus "Could not create a slack preview code".
+      if (!options.quiet) {
+        await printPreviewInstructions(cwd);
       }
     }
   );
@@ -842,15 +848,17 @@ async function printPreviewInstructions(cwd: string): Promise<void> {
           `  Could not create a ${platform} preview code for ${agentId}.`
         )
       );
-      console.log(
-        chalk.dim(
-          "  Make sure the agent has been synced with `lobu apply` and try again."
-        )
-      );
-      if (process.env.DEBUG) {
+      const reason = error instanceof Error ? error.message : String(error);
+      // Surface the real cause instead of only blaming `lobu apply`. Common
+      // cases: the claim needs a Lobu Cloud org session (run `lobu login` +
+      // `lobu org set <slug>` + `lobu apply` there), or the agent is missing
+      // from that org.
+      if (reason) {
+        console.log(chalk.dim(`  Reason: ${reason}`));
+      } else {
         console.log(
           chalk.dim(
-            `  ${error instanceof Error ? error.message : String(error)}`
+            "  Make sure the agent has been synced with `lobu apply` and try again."
           )
         );
       }

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -849,19 +849,30 @@ async function printPreviewInstructions(cwd: string): Promise<void> {
         )
       );
       const reason = error instanceof Error ? error.message : String(error);
-      // Surface the real cause instead of only blaming `lobu apply`. Common
-      // cases: the claim needs a Lobu Cloud org session (run `lobu login` +
-      // `lobu org set <slug>` + `lobu apply` there), or the agent is missing
-      // from that org.
-      if (reason) {
-        console.log(chalk.dim(`  Reason: ${reason}`));
-      } else {
-        console.log(
-          chalk.dim(
-            "  Make sure the agent has been synced with `lobu apply` and try again."
-          )
-        );
-      }
+      // Surface the real cause instead of only blaming `lobu apply`, and give
+      // the concrete actions the user must take. The hosted Slack/Telegram bot
+      // binds to the agent in Lobu Cloud, so a claim needs a cloud org session
+      // with the agent applied there.
+      console.log(chalk.dim(`  Reason: ${reason}`));
+      console.log();
+      console.log(
+        chalk.dim(
+          "  To get a link code, complete these steps against Lobu Cloud, then restart `lobu run`:"
+        )
+      );
+      console.log(chalk.dim("    lobu login"));
+      console.log(chalk.dim("    lobu org set <slug>"));
+      console.log(chalk.dim("    lobu apply"));
+      console.log(
+        chalk.dim(
+          `    restart \`lobu run\` (it will print the \`/lobu link <code>\` command under "Hosted chat")`
+        )
+      );
+      console.log(
+        chalk.dim(
+          "  Then join the hosted Lobu workspace and DM @Lobu with that command.\n"
+        )
+      );
     }
   }
   console.log();


### PR DESCRIPTION
## Summary
- `lobu run` printed a bogus "Could not create a <platform> preview code" for every hosted-chat connection on a fresh boot: `printPreviewInstructions` ran from the pre-spawn banner (before the embedded gateway listened on the port), so its `/preview/claims` POST always failed with `fetch failed`.
- Moved the hosted-chat link-code minting into the `announceLocalSignIn(...).then()` chain — after the gateway is reachable and the local project is auto-applied — mirroring the existing `waitForServerReachable` pattern already used by `announceLocalSignIn`.
- Improved the error path: the catch now prints the real `Reason:` (e.g. "Run `lobu apply` first so the preview bot can bind to this agent in Lobu Cloud") instead of always blaming `lobu apply`, and the cause was previously hidden behind `DEBUG=1`.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Red→fix→green live (pod, real `lobu run` invocation):
  - RED (CLI 14.14.0): startup prints `Could not create a slack preview code for scout.` / `Make sure the agent has been synced with lobu apply and try again.` / `fetch failed`
  - GREEN (fixed build): the POST reaches the running server (returns a real 404, no `fetch failed`) and prints `Reason: POST /api/local-install/preview/claims failed: Run `lobu apply` first so the preview bot can bind to this agent in Lobu Cloud.`
- [ ] `make review` once on settled HEAD

## Notes
- The remaining 404 is environmental, not a bug: the hosted Slack preview bot binds to a Lobu Cloud org, and this test host has no cloud session/org (`lobu org list` → none). With `lobu login` + a cloud org + `lobu apply` there, the same path mints the code.
- `dev.js` is the bundled CLI entry; the fix is in `packages/cli/src/commands/dev.ts` (built via `make build-packages`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hosted-chat preview instructions now appear only after the development server is ready and local setup is complete.
  * Preview-claim failures now display the specific error reason and provide expanded recovery steps, including actionable commands for resolving issues.
  * Improved startup messaging helps clarify when preview access is available and how to recover when claiming a preview fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Red→fix→green evidence

- RED (CLI 14.14.0, fresh `lobu run` with hosted slack connection):
  ```
  Hosted chat
  Could not create a slack preview code for scout.
  Make sure the agent has been synced with `lobu apply` and try again.
  fetch failed
  ```
- GREEN (fixed build, same pod + cloud org applied):
  ```
  Hosted chat
  agent:    scout
  platform: slack
  expires:  2026-08-06T01:33:42.912Z
  1. Join the hosted Lobu slack workspace: https://lobu.ai/slack
  2. DM @Lobu there: /lobu link scout-QP3L1R
  ```
  The claim POST reached the running server (no `fetch failed`); the link code was minted.

- Regression tests added (dev.test.ts): structural guards that (a) `printPreviewInstructions` is never called before the server spawn, and (b) the failure path prints `Reason:` + concrete recovery steps. Verified red (mutation → 1 fail) → green (fixed → 21 pass).
