### PR TITLE
fix(server): floor the Behavior window at one period so lag cannot freeze

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -5155,6 +5155,16 @@ export type ReadKnowledgeResponses = {
     window_token?: string;
     window_start?: string;
     window_end?: string;
+    window_lag?: {
+      last_window_start: string | null;
+      current_period_start: string;
+      periods_behind: number;
+      granularity: string;
+      periods_skipped: number;
+      skipped_from: string | null;
+      skipped_to: string | null;
+      guidance?: string;
+    };
     extraction_schema?: {
       [key: string]: unknown;
     };

--- a/packages/server/src/__tests__/integration/behaviors/window-lag-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/window-lag-visibility.test.ts
@@ -1,0 +1,321 @@
+/**
+ * End-to-end: a Behavior whose window cursor has fallen behind can see that it
+ * has, and can act on it — through the real handlers against a real database.
+ *
+ * The prod failure this closes (Behavior 2, measured 2026-08-06): a daily
+ * Behavior whose device stopped claiming runs fell fifty days behind. Its
+ * occasional successful runs each advanced the window cursor by exactly one day
+ * while the calendar advanced one day too, so the gap froze rather than closed.
+ * Those runs were not failing — the late windows carry `content_analyzed = 40`.
+ * It read forty real Hacker News stories and drafted replies to threads a month
+ * dead, and reported success. Nothing in the dispatch ever said the window was
+ * stale, and from inside a run a stale window is indistinguishable from a fresh
+ * one.
+ *
+ * The fix is a floor in the dispatch, not a hint to the run: a Behavior is never
+ * handed a window older than one period, so the gap closes on the next successful
+ * run whatever model is driving it. Telling the run about the skip is what is
+ * left over — the one decision that is genuinely its own.
+ *
+ * So this suite proves, in order:
+ *   1. a lagging Behavior is dispatched the CURRENT window, not cursor + 1
+ *   2. one completion of that window collapses fifty days of backlog
+ *   3. the skipped span is named, in JSON and in the markdown a model reads
+ *   4. none of it fires on a healthy Behavior
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { DbClient } from "../../../db/client";
+import type { Env } from "../../../index";
+import { formatToolResult } from "../../../formatting/markdown-formatter";
+import { manageBehaviors } from "../../../tools/admin/manage_behaviors";
+import { handleBehaviorMode } from "../../../tools/get_content/behavior-mode";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createCanvasWindow,
+	createTestAgent,
+	createTestEvent,
+	seedOwnerContext,
+} from "../../setup/test-fixtures";
+
+const ENV = { JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env;
+const DAY_MS = 86_400_000;
+
+const dayStart = (offsetDays: number): Date => {
+	const d = new Date(Date.now() - offsetDays * DAY_MS);
+	d.setUTCHours(0, 0, 0, 0);
+	return d;
+};
+
+type BehaviorContent = {
+	window_token: string;
+	window_start: string;
+	window_end: string;
+	window_lag?: {
+		last_window_start: string | null;
+		current_period_start: string;
+		periods_behind: number;
+		granularity: string;
+		periods_skipped: number;
+		skipped_from: string | null;
+		skipped_to: string | null;
+		guidance?: string;
+	};
+};
+
+describe("Behavior window lag is visible and actionable", () => {
+	let orgId: string;
+	let userId: string;
+	let ctx: Awaited<ReturnType<typeof seedOwnerContext>>["ctx"];
+	let behaviorId: number;
+	let sql: DbClient;
+
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+	});
+
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		const seeded = await seedOwnerContext();
+		orgId = seeded.org.id;
+		userId = seeded.user.id;
+		ctx = seeded.ctx;
+		sql = getTestDb() as unknown as DbClient;
+
+		const agent = await createTestAgent({
+			organizationId: orgId,
+			ownerUserId: userId,
+		});
+		const created = await manageBehaviors(
+			{
+				action: "create",
+				slug: "stale-daily",
+				name: "Stale daily Behavior",
+				prompt: "Draft replies to the day's stories.",
+				agent_id: agent.agentId,
+				sources: [
+					{
+						name: "stories",
+						query:
+							"SELECT id, occurred_at, payload_text FROM events WHERE semantic_type = 'message' ORDER BY occurred_at DESC",
+					},
+				],
+				triggers: [{ kind: "schedule", cron: "0 14 * * *" }],
+			},
+			ENV,
+			ctx,
+		);
+		if (created.action !== "create" || !("behavior_id" in created)) {
+			throw new Error("Behavior creation did not complete");
+		}
+		behaviorId = Number(created.behavior_id);
+
+		// Content in both the stale period and the current one, so a window that
+		// resolves to either has something real to read. This is what made the
+		// prod case so quiet: the stale run DID return content.
+		for (const offset of [50, 0]) {
+			await createTestEvent({
+				organization_id: orgId,
+				semantic_type: "message",
+				content: `story from ${offset} days ago`,
+				occurred_at: new Date(dayStart(offset).getTime() + 3600_000),
+			});
+		}
+	});
+
+	/** Freeze the cursor `daysBack` days in the past, as an outage would. */
+	const seedStaleCursor = async (daysBack: number) => {
+		const windowStart = dayStart(daysBack);
+		await createCanvasWindow({
+			watcherId: behaviorId,
+			organizationId: orgId,
+			granularity: "daily",
+			windowStart,
+			windowEnd: new Date(windowStart.getTime() + DAY_MS),
+			contentAnalyzed: 40,
+			createdBy: userId,
+		});
+		return windowStart;
+	};
+
+	const read = async (args: Record<string, unknown> = {}) =>
+		(await handleBehaviorMode({ behavior_id: behaviorId, ...args }, ENV, sql, {
+			organizationId: orgId,
+			userId,
+		})) as BehaviorContent;
+
+	// THE FIX, at the dispatch. The old rule handed this run `staleStart + 1` —
+	// June 18 for a Behavior sitting in August — and needed fifty more successful
+	// runs to reach the present. No agent cooperation is involved here.
+	it("dispatches the current window, not cursor + 1, when fifty periods behind", async () => {
+		const staleStart = await seedStaleCursor(50);
+		const content = await read();
+
+		expect(content.window_start).toBe(dayStart(1).toISOString());
+		expect(content.window_start).not.toBe(
+			new Date(staleStart.getTime() + DAY_MS).toISOString(),
+		);
+		expect(content.window_lag).toBeDefined();
+		// The WINDOW is one period old — the healthy resting value. The cursor is
+		// still fifty back until something completes.
+		expect(content.window_lag?.periods_behind).toBe(1);
+		expect(content.window_lag?.last_window_start).toBe(staleStart.toISOString());
+		expect(content.window_lag?.granularity).toBe("daily");
+		// June 18 through August 4, in prod's terms: everything between the cursor
+		// and the window now being handed out.
+		expect(content.window_lag?.periods_skipped).toBe(48);
+		expect(content.window_lag?.skipped_from).toBe(dayStart(49).toISOString());
+		expect(content.window_lag?.skipped_to).toBe(dayStart(2).toISOString());
+	});
+
+	// THE PAYOFF. One ordinary completion of the ordinary dispatched window —
+	// no `since`/`until`, no notice acted on, nothing the model had to work out.
+	it("collapses fifty days of backlog in one ordinary run", async () => {
+		await seedStaleCursor(50);
+
+		const dispatched = await read();
+		const completion = await manageBehaviors(
+			{
+				action: "complete_window",
+				behavior_id: String(behaviorId),
+				window_token: dispatched.window_token,
+				extracted_data: { summary: "Analysed the dispatched window." },
+			},
+			ENV,
+			ctx,
+		);
+		expect(completion.action).toBe("complete_window");
+
+		const afterCursor = await sql`
+			SELECT window_start FROM canvas_windows
+			WHERE watcher_id = ${behaviorId}
+			ORDER BY window_start DESC LIMIT 1
+		`;
+		expect(new Date(afterCursor[0].window_start as string).toISOString()).toBe(
+			dayStart(1).toISOString(),
+		);
+
+		// And it stays closed: the next dispatch chains normally instead of
+		// sticking to the floor, and the skip notice goes quiet.
+		const next = await read();
+		expect(next.window_start).toBe(dayStart(0).toISOString());
+		expect(next.window_lag?.periods_skipped).toBe(0);
+		expect(formatToolResult("read_knowledge", next)).not.toContain("Skipped Periods");
+	});
+
+	it("names the skipped span in the markdown a model actually reads", async () => {
+		await seedStaleCursor(50);
+		const md = formatToolResult("read_knowledge", await read());
+
+		expect(md).toContain("Skipped Periods");
+		expect(md).toContain("48 daily period(s)");
+		// The affordance — a run that is not told it may read the span back will
+		// never read it back.
+		expect(md).toContain("since");
+		expect(md).toContain("until");
+		// `watcher` is internal DB vocabulary and must not reach an agent surface.
+		expect(md.toLowerCase()).not.toContain("watcher");
+	});
+
+	// The false positive this measurement was rewritten to kill. A daily Behavior
+	// that ran yesterday has a cursor TWO periods back at the moment its next run
+	// reads — the cursor is the period the previous run completed. Prod Behavior 79
+	// (`0 4 * * *`) sits exactly here every day; a cursor-based threshold would
+	// have warned it on every healthy run.
+	it("stays silent for a Behavior that is keeping up", async () => {
+		await seedStaleCursor(2);
+		const content = await read();
+
+		expect(content.window_start).toBe(dayStart(1).toISOString());
+		expect(content.window_lag?.periods_behind).toBe(1);
+		expect(content.window_lag?.periods_skipped).toBe(0);
+		expect(content.window_lag?.guidance).toBeUndefined();
+		expect(formatToolResult("read_knowledge", content)).not.toContain("Skipped Periods");
+	});
+
+	it("aligns an agent-chosen range instead of storing an inclusive end", async () => {
+		await seedStaleCursor(50);
+		const target = dayStart(3);
+		const content = await read({
+			since: target.toISOString().slice(0, 10),
+			until: target.toISOString().slice(0, 10),
+		});
+
+		expect(content.window_start).toBe(target.toISOString());
+		// Exclusive, period-aligned — not `23:59:59.999`, the second boundary
+		// convention that produced prod's five zero-length windows.
+		expect(content.window_end).toBe(new Date(target.getTime() + DAY_MS).toISOString());
+		expect(content.window_end).not.toContain("23:59:59");
+	});
+
+	// An agent that deliberately reads an OLD span is not being skipped past —
+	// it chose that window. Reporting a skip there would be a lie, and the notice
+	// would fire on every page of a deliberate backfill.
+	it("reports age but no skip for a deliberate backfill read", async () => {
+		const staleStart = await seedStaleCursor(50);
+		const old = dayStart(60).toISOString().slice(0, 10);
+		const content = await read({ since: old, until: old });
+
+		expect(content.window_lag?.periods_behind).toBe(60);
+		expect(content.window_lag?.periods_skipped).toBe(0);
+		expect(content.window_lag?.guidance).toBeUndefined();
+		expect(content.window_lag?.last_window_start).toBe(staleStart.toISOString());
+	});
+
+	// Backfilling an older period must never drag the cursor backwards, or
+	// draining a backlog would undo the catch-up. This is the safety property the
+	// guidance states outright, so it has to actually hold.
+	it("keeps the cursor when an older period is backfilled afterwards", async () => {
+		await seedStaleCursor(50);
+		const dispatched = await read();
+		await manageBehaviors(
+			{
+				action: "complete_window",
+				behavior_id: String(behaviorId),
+				window_token: dispatched.window_token,
+				extracted_data: { summary: "current" },
+			},
+			ENV,
+			ctx,
+		);
+
+		const old = dayStart(20).toISOString().slice(0, 10);
+		const backfill = await read({ since: old, until: old });
+		await manageBehaviors(
+			{
+				action: "complete_window",
+				behavior_id: String(behaviorId),
+				window_token: backfill.window_token,
+				extracted_data: { summary: "backfilled" },
+			},
+			ENV,
+			ctx,
+		);
+
+		const next = await read();
+		expect(next.window_start).toBe(dayStart(0).toISOString());
+		expect(next.window_lag?.last_window_start).toBe(dayStart(1).toISOString());
+		expect(next.window_lag?.periods_skipped).toBe(0);
+	});
+
+	// The floor moves what is ASKED FOR, never what was DONE. A Behavior whose
+	// runs all fail keeps reporting its real cursor, so catching up cannot be
+	// mistaken for a Behavior that is actually working.
+	it("does not advance the cursor without a completed run", async () => {
+		const staleStart = await seedStaleCursor(50);
+
+		await read();
+		await read();
+
+		const cursor = await sql`
+			SELECT window_start FROM canvas_windows
+			WHERE watcher_id = ${behaviorId}
+			ORDER BY window_start DESC LIMIT 1
+		`;
+		expect(new Date(cursor[0].window_start as string).toISOString()).toBe(
+			staleStart.toISOString(),
+		);
+		expect((await read()).window_lag?.last_window_start).toBe(staleStart.toISOString());
+	});
+});

--- a/packages/server/src/__tests__/unit/behavior-window-lag.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-window-lag.test.ts
@@ -1,0 +1,541 @@
+/**
+ * A Behavior has two cursors and they advance by different rules.
+ *
+ * The SCHEDULE cursor (`watchers.next_run_at`) is recomputed from `now`, so a
+ * missed occurrence is never replayed. The WINDOW cursor
+ * (`max(canvas_windows.window_start)`) advances one period per COMPLETED window.
+ * Wall-clock moves one period per period, so under pure chaining a Behavior that
+ * falls behind stays behind: the gap freezes at whatever width the outage left
+ * it, and closing it would take one successful run per missed period.
+ *
+ * Prod Behavior 2 ("HN engagement — draft replies", daily) measured 2026-08-06:
+ * newest window `2026-06-17`, written by a run on `2026-07-15`. Drift by window,
+ * monotonic — covers 06-06 written 06-11 (5d), 06-14 written 06-27 (13d), 06-15
+ * written 07-08 (23d), 06-17 written 07-15 (28d). It was not failing: those late
+ * windows carry `content_analyzed = 40`. It read forty real Hacker News stories
+ * and drafted real replies to threads a month dead, and reported success.
+ *
+ * The fix is a FLOOR in `nextBehaviorWindowStart`: never hand out a window older
+ * than one period. That closes any gap in a single run without the agent having
+ * to notice anything, which is the only form of this fix that holds for every
+ * model. What the run is then told is the span the server skipped, and the one
+ * decision left to it — whether that span is worth reading back.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { formatToolResult } from "../../formatting/markdown-formatter";
+import {
+	alignRequestedWindow,
+	computeWindowLag,
+	describeWindowLag,
+	nextBehaviorWindowStart,
+	parseBehaviorWindowDate,
+} from "../../utils/window-utils";
+
+const iso = (d: Date) => d.toISOString();
+
+// `alignRequestedWindow` is pure UTC — every boundary in window-utils is
+// `setUTC*`, and the local zone is normalized away earlier by
+// `parseBehaviorWindowDate`. So its fixtures are UTC instants, and these
+// assertions hold identically under every TZ.
+const utcDate = (y: number, mo: number, d: number, h = 0, mi = 0, s = 0) =>
+	new Date(Date.UTC(y, mo - 1, d, h, mi, s));
+
+/**
+ * The guarantee. Everything else in this file reports; only this closes the gap,
+ * and it does so without the agent participating at all.
+ */
+describe("nextBehaviorWindowStart — the floor", () => {
+	// THE REGRESSION. Prod Behavior 2: cursor at June 17, clock at August 6.
+	// Chaining alone hands out June 18 and would need fifty more successful runs
+	// to reach the present. The floor hands out yesterday, once.
+	test("a fifty-period gap closes in one run", () => {
+		const next = nextBehaviorWindowStart(
+			new Date("2026-06-17T00:00:00.000Z"),
+			new Date("2026-08-06T09:30:00.000Z"),
+			"daily",
+		);
+		expect(iso(next)).toBe("2026-08-05T00:00:00.000Z");
+		expect(iso(next)).not.toBe("2026-06-18T00:00:00.000Z");
+	});
+
+	// ...and stays closed. The run after the catch-up chains normally rather than
+	// sticking to the floor, which is what makes this a one-off correction and not
+	// a Behavior permanently pinned to yesterday.
+	test("the run after a catch-up chains normally", () => {
+		const next = nextBehaviorWindowStart(
+			new Date("2026-08-05T00:00:00.000Z"),
+			new Date("2026-08-07T09:30:00.000Z"),
+			"daily",
+		);
+		expect(iso(next)).toBe("2026-08-06T00:00:00.000Z");
+	});
+
+	// The healthy steady state must be untouched: a once-per-period Behavior
+	// analyses the period that just closed. If the floor moved this to "today" it
+	// would hand every daily Behavior a half-finished period.
+	test("a healthy daily Behavior still gets the period that just closed", () => {
+		const next = nextBehaviorWindowStart(
+			new Date("2026-08-04T00:00:00.000Z"),
+			new Date("2026-08-06T14:00:00.000Z"),
+			"daily",
+		);
+		expect(iso(next)).toBe("2026-08-05T00:00:00.000Z");
+	});
+
+	// A sub-daily cron gets the SAME day every run so `replace_existing` can
+	// refresh it. The floor must not push this backwards to yesterday.
+	test("a sub-period cron keeps resolving to the current period", () => {
+		const next = nextBehaviorWindowStart(
+			new Date("2026-08-06T00:00:00.000Z"),
+			new Date("2026-08-06T14:00:00.000Z"),
+			"daily",
+		);
+		expect(iso(next)).toBe("2026-08-06T00:00:00.000Z");
+	});
+
+	test("never hands out a future window", () => {
+		const next = nextBehaviorWindowStart(
+			new Date("2026-09-01T00:00:00.000Z"),
+			new Date("2026-08-06T09:30:00.000Z"),
+			"daily",
+		);
+		expect(next.getTime()).toBeLessThanOrEqual(Date.UTC(2026, 7, 6));
+	});
+
+	test("a fresh Behavior starts one aligned period back", () => {
+		expect(iso(nextBehaviorWindowStart(null, new Date("2026-08-06T14:00:00.000Z"), "daily"))).toBe(
+			"2026-08-05T00:00:00.000Z",
+		);
+	});
+
+	// `setUTCMonth(month - 1)` on a 31st rolls FORWARD — Feb 31 becomes Mar 3 —
+	// so subtracting a period from the raw `now` handed a monthly Behavior run on
+	// the 31st the month it was already on. Aligning first is what fixes it.
+	test("a monthly Behavior on the 31st gets the previous month, not this one", () => {
+		expect(
+			iso(nextBehaviorWindowStart(null, new Date("2026-03-31T12:00:00.000Z"), "monthly")),
+		).toBe("2026-02-01T00:00:00.000Z");
+	});
+
+	test("floors at every granularity", () => {
+		// Weekly: 2026-08-03 is the Monday of the current week, so the floor is the
+		// Monday before it.
+		expect(
+			iso(
+				nextBehaviorWindowStart(
+					new Date("2026-01-05T00:00:00.000Z"),
+					new Date("2026-08-06T00:00:00.000Z"),
+					"weekly",
+				),
+			),
+		).toBe("2026-07-27T00:00:00.000Z");
+		expect(
+			iso(
+				nextBehaviorWindowStart(
+					new Date("2026-01-01T00:00:00.000Z"),
+					new Date("2026-08-06T00:00:00.000Z"),
+					"monthly",
+				),
+			),
+		).toBe("2026-07-01T00:00:00.000Z");
+		expect(
+			iso(
+				nextBehaviorWindowStart(
+					new Date("2025-01-01T00:00:00.000Z"),
+					new Date("2026-08-06T00:00:00.000Z"),
+					"quarterly",
+				),
+			),
+		).toBe("2026-04-01T00:00:00.000Z");
+	});
+
+	// A corrupt stored start must not propagate. Prod holds 14 windows written
+	// with an inclusive `23:59:59.999` end and misaligned starts.
+	test("re-aligns a misaligned stored cursor", () => {
+		expect(
+			iso(
+				nextBehaviorWindowStart(
+					new Date("2026-08-04T23:59:59.999Z"),
+					new Date("2026-08-06T14:00:00.000Z"),
+					"daily",
+				),
+			),
+		).toBe("2026-08-05T00:00:00.000Z");
+	});
+});
+
+describe("computeWindowLag", () => {
+	// THE FALSE POSITIVE this measurement was rewritten to kill. Measured against
+	// the CURSOR, a perfectly healthy daily Behavior reads as two periods behind
+	// at the moment its run calls read_knowledge — the cursor is the period the
+	// PREVIOUS run completed. Prod Behavior 79 (`0 4 * * *`) sits exactly here
+	// every day, so any cursor-based threshold fires on healthy runs. Measured
+	// against the WINDOW being handed out, it is one.
+	test("a healthy daily Behavior is one period behind, not two", () => {
+		const lag = computeWindowLag(
+			new Date("2026-08-04T00:00:00.000Z"),
+			new Date("2026-08-05T00:00:00.000Z"),
+			new Date("2026-08-06T14:00:00.000Z"),
+			"daily",
+		);
+		expect(lag.periodsBehind).toBe(1);
+		expect(lag.periodsSkipped).toBe(0);
+		expect(lag.skippedFrom).toBeNull();
+		expect(iso(lag.currentPeriodStart)).toBe("2026-08-06T00:00:00.000Z");
+	});
+
+	test("a sub-period cron on the current window reads as zero", () => {
+		const lag = computeWindowLag(
+			new Date("2026-08-06T00:00:00.000Z"),
+			new Date("2026-08-06T00:00:00.000Z"),
+			new Date("2026-08-06T14:00:00.000Z"),
+			"daily",
+		);
+		expect(lag.periodsBehind).toBe(0);
+		expect(lag.periodsSkipped).toBe(0);
+	});
+
+	// The prod case after the floor: cursor still at June 17, window now August 5,
+	// so June 18 through August 4 — 48 days — are skipped and named.
+	test("names the span the floor skipped", () => {
+		const lag = computeWindowLag(
+			new Date("2026-06-17T00:00:00.000Z"),
+			new Date("2026-08-05T00:00:00.000Z"),
+			new Date("2026-08-06T09:30:00.000Z"),
+			"daily",
+		);
+		expect(lag.periodsBehind).toBe(1);
+		expect(lag.periodsSkipped).toBe(48);
+		expect(iso(lag.skippedFrom as Date)).toBe("2026-06-18T00:00:00.000Z");
+		expect(iso(lag.skippedTo as Date)).toBe("2026-08-04T00:00:00.000Z");
+	});
+
+	// A deliberate backfill read is not a skip: the agent asked for an old window,
+	// so it is genuinely old, and nothing was jumped over to produce it.
+	test("an agent-chosen backfill window reports age but no skip", () => {
+		const lag = computeWindowLag(
+			new Date("2026-08-04T00:00:00.000Z"),
+			new Date("2026-06-17T00:00:00.000Z"),
+			new Date("2026-08-06T09:30:00.000Z"),
+			"daily",
+		);
+		expect(lag.periodsBehind).toBe(50);
+		expect(lag.periodsSkipped).toBe(0);
+	});
+
+	// Prod holds windows stored with misaligned starts; the count must not shift.
+	test("aligns a misaligned stored cursor before counting the skip", () => {
+		const lag = computeWindowLag(
+			new Date("2026-06-17T23:59:59.999Z"),
+			new Date("2026-08-05T00:00:00.000Z"),
+			new Date("2026-08-06T09:30:00.000Z"),
+			"daily",
+		);
+		expect(lag.periodsSkipped).toBe(48);
+	});
+
+	test("counts whole periods at every granularity", () => {
+		expect(
+			computeWindowLag(
+				null,
+				new Date("2026-06-01T00:00:00.000Z"),
+				new Date("2026-08-06T00:00:00.000Z"),
+				"weekly",
+			).periodsBehind,
+		).toBe(9);
+		expect(
+			computeWindowLag(
+				null,
+				new Date("2026-02-15T00:00:00.000Z"),
+				new Date("2026-08-06T00:00:00.000Z"),
+				"monthly",
+			).periodsBehind,
+		).toBe(6);
+		expect(
+			computeWindowLag(
+				null,
+				new Date("2025-11-15T00:00:00.000Z"),
+				new Date("2026-08-06T00:00:00.000Z"),
+				"quarterly",
+			).periodsBehind,
+		).toBe(3);
+	});
+
+	// A Behavior that has never completed a window skipped nothing — there is no
+	// cursor to have jumped away from.
+	test("a Behavior with no windows yet has skipped nothing", () => {
+		const lag = computeWindowLag(
+			null,
+			new Date("2026-08-05T00:00:00.000Z"),
+			new Date("2026-08-06T09:30:00.000Z"),
+			"daily",
+		);
+		expect(lag.periodsSkipped).toBe(0);
+		expect(lag.skippedFrom).toBeNull();
+		expect(lag.skippedTo).toBeNull();
+	});
+
+	// The floor caps at the current period, so a future window should be
+	// impossible — but prod has held future-dated rows and a negative age would
+	// render as nonsense.
+	test("a window ahead of the clock clamps to zero, never negative", () => {
+		const lag = computeWindowLag(
+			null,
+			new Date("2026-09-01T00:00:00.000Z"),
+			new Date("2026-08-06T09:30:00.000Z"),
+			"daily",
+		);
+		expect(lag.periodsBehind).toBe(0);
+	});
+});
+
+describe("alignRequestedWindow", () => {
+	// The regression. `toEndOfDay` produced `23:59:59.999`, the INCLUSIVE
+	// convention that `computePendingWindow` documents as the source of prod's
+	// five zero-length windows — and it disagrees with the `>= start AND < end`
+	// filter `executeDataSources` applies, so the last millisecond of the range
+	// was silently excluded from the events it read.
+	test("the end is exclusive, not 23:59:59.999", () => {
+		const { windowEnd } = alignRequestedWindow(
+			utcDate(2026, 6, 1),
+			utcDate(2026, 6, 30),
+			"daily",
+		);
+		expect(iso(windowEnd)).toBe("2026-07-01T00:00:00.000Z");
+		expect(iso(windowEnd)).not.toContain("23:59:59");
+	});
+
+	// A multi-period span is the whole point: the unprocessed-ranges formatter
+	// tells a daily Behavior to read whole months. Aligning must not collapse
+	// that to one day.
+	test("preserves a multi-period span", () => {
+		const { windowStart, windowEnd } = alignRequestedWindow(
+			utcDate(2026, 6, 1),
+			utcDate(2026, 6, 30),
+			"daily",
+		);
+		expect(iso(windowStart)).toBe("2026-06-01T00:00:00.000Z");
+		expect(windowEnd.getTime() - windowStart.getTime()).toBe(30 * 86_400_000);
+	});
+
+	test("a mid-period start is aligned down to the period boundary", () => {
+		const { windowStart } = alignRequestedWindow(
+			utcDate(2026, 6, 17, 13, 45, 12),
+			utcDate(2026, 6, 17, 13, 45, 12),
+			"daily",
+		);
+		expect(iso(windowStart)).toBe("2026-06-17T00:00:00.000Z");
+	});
+
+	// since === until means "just this period", and must yield a real period
+	// rather than the zero-length window that broke five prod rows.
+	test("a single-period request yields exactly one period", () => {
+		const { windowStart, windowEnd } = alignRequestedWindow(
+			utcDate(2026, 6, 17),
+			utcDate(2026, 6, 17, 23),
+			"daily",
+		);
+		expect(iso(windowStart)).toBe("2026-06-17T00:00:00.000Z");
+		expect(iso(windowEnd)).toBe("2026-06-18T00:00:00.000Z");
+	});
+
+	// An inverted range must not produce a window that ends before it starts.
+	test("an inverted range degrades to one period, never negative", () => {
+		const { windowStart, windowEnd } = alignRequestedWindow(
+			utcDate(2026, 6, 17),
+			utcDate(2026, 6, 1),
+			"daily",
+		);
+		expect(windowEnd.getTime()).toBeGreaterThan(windowStart.getTime());
+		expect(iso(windowEnd)).toBe("2026-06-18T00:00:00.000Z");
+	});
+
+	test("monthly granularity spans whole months", () => {
+		const { windowStart, windowEnd } = alignRequestedWindow(
+			utcDate(2026, 6, 17),
+			utcDate(2026, 8, 2),
+			"monthly",
+		);
+		expect(iso(windowStart)).toBe("2026-06-01T00:00:00.000Z");
+		expect(iso(windowEnd)).toBe("2026-09-01T00:00:00.000Z");
+	});
+});
+
+/**
+ * The JSON field is the contract; this markdown is what an LLM run actually
+ * reads. A field the model never sees fixes nothing, so the rendered surface is
+ * pinned here too — including the sentence that tells the run it may choose a
+ * different span, which is the entire point of the change.
+ */
+describe("read_knowledge markdown — skipped periods", () => {
+	// Built exactly as behavior-mode builds it, guidance included — the formatter
+	// renders the SAME string the JSON payload carries, so a fixture without it
+	// would test a shape production never emits.
+	const lagFor = (periodsSkipped: number) => {
+		const guidance = describeWindowLag({
+			skippedFrom: periodsSkipped > 0 ? new Date("2026-06-18T00:00:00.000Z") : null,
+			skippedTo: periodsSkipped > 0 ? new Date("2026-08-04T00:00:00.000Z") : null,
+			periodsSkipped,
+			granularity: "daily",
+		});
+		return {
+			last_window_start: "2026-06-17T00:00:00.000Z",
+			current_period_start: "2026-08-06T00:00:00.000Z",
+			periods_behind: 1,
+			granularity: "daily",
+			periods_skipped: periodsSkipped,
+			skipped_from: periodsSkipped > 0 ? "2026-06-18T00:00:00.000Z" : null,
+			skipped_to: periodsSkipped > 0 ? "2026-08-04T00:00:00.000Z" : null,
+			...(guidance ? { guidance } : {}),
+		};
+	};
+
+	const render = (periodsSkipped: number) =>
+		formatToolResult("read_knowledge", {
+			total: 40,
+			content: [],
+			page: { limit: 100, offset: 0, has_more: false },
+			window_token: "tok",
+			window_start: "2026-08-05T00:00:00.000Z",
+			window_end: "2026-08-06T00:00:00.000Z",
+			window_lag: lagFor(periodsSkipped),
+		});
+
+	// Silent on every healthy run — nothing is skipped when the window chains
+	// straight off the cursor, so there is no threshold here to tune and nothing
+	// training a model to scroll past a notice it sees every time.
+	test("says nothing when no periods were skipped", () => {
+		expect(render(0)).not.toContain("Skipped Periods");
+	});
+
+	test("names the skipped span once the floor has jumped", () => {
+		const md = render(48);
+		expect(md).toContain("Skipped Periods");
+		expect(md).toContain("48 daily period(s)");
+		expect(md).toContain("2026-06-18T00:00:00.000Z");
+		expect(md).toContain("2026-08-04T00:00:00.000Z");
+	});
+
+	test("tells the run it can read the skipped span back", () => {
+		const md = render(48);
+		expect(md).toContain("since");
+		expect(md).toContain("until");
+		expect(md).toContain("read_knowledge");
+	});
+
+	// The safety property is the reason a run can act on this without risk, so it
+	// has to be stated, not implied.
+	test("states that a backfill cannot drag the cursor back", () => {
+		expect(render(48)).toContain("cannot make this Behavior stale again");
+	});
+
+	// `watcher` is internal DB vocabulary and must never reach an agent-facing
+	// surface — `make pre-pr` fails the build on it.
+	test("uses Behavior vocabulary, never watcher", () => {
+		expect(render(48).toLowerCase()).not.toContain("watcher");
+	});
+
+	test("a Behavior with no lag field renders unchanged", () => {
+		const md = formatToolResult("read_knowledge", {
+			total: 0,
+			content: [],
+			page: { limit: 100, offset: 0, has_more: false },
+			window_token: "tok",
+			window_start: "2026-08-06T00:00:00.000Z",
+			window_end: "2026-08-07T00:00:00.000Z",
+		});
+		expect(md).toContain("Behavior Window");
+		expect(md).not.toContain("Skipped Periods");
+	});
+});
+
+/**
+ * `get_behavior.pending_analysis.next_action` hands an MCP client a literal
+ * `read_knowledge` call for the window it just previewed. That suggestion has to
+ * round-trip: feeding its `since`/`until` back through `alignRequestedWindow`
+ * must reproduce the previewed window exactly, or the server is telling clients
+ * to write windows the dispatcher would never emit.
+ *
+ * It did not. `until` was `next_window.end` — the EXCLUSIVE boundary — so a
+ * one-day window was advertised as a two-day range.
+ */
+describe("next_action round-trips to the previewed window", () => {
+	// Mirrors the construction in get_behavior.ts: `until` is the last instant
+	// inside the window, rendered as a date.
+	const suggest = (start: string, end: string) => ({
+		since: start.split("T")[0],
+		until: new Date(new Date(end).getTime() - 1).toISOString().split("T")[0],
+	});
+
+	test.each([
+		["daily", "2026-06-18T00:00:00.000Z", "2026-06-19T00:00:00.000Z"],
+		["weekly", "2026-06-15T00:00:00.000Z", "2026-06-22T00:00:00.000Z"],
+		["monthly", "2026-06-01T00:00:00.000Z", "2026-07-01T00:00:00.000Z"],
+		["quarterly", "2026-04-01T00:00:00.000Z", "2026-07-01T00:00:00.000Z"],
+	] as const)("%s", (granularity, start, end) => {
+		const { since, until } = suggest(start, end);
+		const round = alignRequestedWindow(
+			parseBehaviorWindowDate(since),
+			parseBehaviorWindowDate(until),
+			granularity,
+		);
+		expect(iso(round.windowStart)).toBe(start);
+		expect(iso(round.windowEnd)).toBe(end);
+	});
+
+	// The bug, pinned directly: the exclusive end as `until` widens by a period.
+	test("passing the exclusive end as until widens the window", () => {
+		const wrong = alignRequestedWindow(
+			parseBehaviorWindowDate("2026-06-18"),
+			parseBehaviorWindowDate("2026-06-19"),
+			"daily",
+		);
+		expect(iso(wrong.windowEnd)).toBe("2026-06-20T00:00:00.000Z");
+	});
+});
+
+/**
+ * The timezone trap, pinned. `parseDateAlias` returns midnight in the SERVER's
+ * local zone; window boundaries are UTC. East of UTC that local midnight is
+ * still the PREVIOUS UTC day, so aligning it with `setUTCHours` wrote the
+ * 2026-08-05 window for "give me 2026-08-06" — and `get_behavior.next_action`
+ * hands clients exactly such a date string, so the server's own suggestion did
+ * not round-trip on an east-of-UTC deployment. (West of UTC the day is lost
+ * inside parseDateAlias's ISO branch before alignment ever runs — that trap is
+ * shared with every `since`/`until` consumer and out of this branch's reach.)
+ *
+ * Only the e2e caught this; every unit assertion above passes in UTC either way.
+ */
+describe("parseBehaviorWindowDate is timezone-stable", () => {
+	// `bun test` runs with TZ=UTC, where a local date and a UTC date are the same
+	// instant — so this suite is only meaningful under an explicit TZ. Run it as:
+	//   TZ=America/New_York bun test src/__tests__/unit/behavior-window-lag.test.ts
+	//   TZ=Europe/Istanbul  bun test ...
+	// Both must be green. The previous version of this block fed `new Date(y,m,d)`
+	// into the aligner and asserted a UTC day; under TZ=UTC that is a tautology,
+	// which is exactly how the production bug survived every unit test.
+	test("a bare YYYY-MM-DD is that UTC day, in any zone", () => {
+		expect(iso(parseBehaviorWindowDate("2026-08-06"))).toBe("2026-08-06T00:00:00.000Z");
+		expect(iso(parseBehaviorWindowDate("2026-01-01"))).toBe("2026-01-01T00:00:00.000Z");
+		// Whitespace is tolerated the same way parseDateAlias tolerates it.
+		expect(iso(parseBehaviorWindowDate("  2026-08-06 "))).toBe("2026-08-06T00:00:00.000Z");
+	});
+
+	test("the window it produces is that day, in any zone", () => {
+		const day = parseBehaviorWindowDate("2026-08-06");
+		const { windowStart, windowEnd } = alignRequestedWindow(day, day, "daily");
+		expect(iso(windowStart)).toBe("2026-08-06T00:00:00.000Z");
+		expect(iso(windowEnd)).toBe("2026-08-07T00:00:00.000Z");
+	});
+
+	// Aliases are relative to the server clock by definition; what must hold is
+	// that the day they land on is expressed as UTC midnight, never a local one.
+	test("an alias resolves to a UTC midnight", () => {
+		const today = parseBehaviorWindowDate("today");
+		expect(today.getUTCHours()).toBe(0);
+		expect(today.getUTCMinutes()).toBe(0);
+		expect(today.getUTCSeconds()).toBe(0);
+		expect(today.getUTCMilliseconds()).toBe(0);
+	});
+});

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -757,6 +757,28 @@ function formatGetBehaviorResult(result: any, _options: FormatterOptions): strin
 }
 
 /**
+ * Tell the run which periods were skipped to bring this Behavior current.
+ *
+ * Silent unless something actually was skipped, which never happens on a healthy
+ * run — `window_lag.guidance` is absent whenever `periods_skipped` is zero, so
+ * the threshold lives in `describeWindowLag` and there is none to tune here.
+ *
+ * The catching-up itself is not this notice's job: `nextBehaviorWindowStart`
+ * floors the dispatched window at one period, so the gap closes whether or not
+ * the run reads a word of this. What is left is the one decision that is the
+ * run's — whether the skipped span is worth reading back.
+ */
+function formatWindowLag(lag: any): string {
+  // The prose is `describeWindowLag`'s string, the SAME one the JSON payload
+  // carries as `guidance` — Behavior runs read this response as JSON through
+  // run_sdk and never render markdown, so the payload is the surface that
+  // matters; this render is for clients that do read markdown.
+  const guidance = typeof lag?.guidance === 'string' ? lag.guidance : '';
+  if (!guidance) return '';
+  return `## \u23F3 Skipped Periods\n\n${guidance}\n\n`;
+}
+
+/**
  * Format unprocessed ranges as markdown with read_knowledge call examples
  */
 function formatUnprocessedRanges(ranges: any[], watcherId?: string): string {
@@ -1149,6 +1171,7 @@ function formatGetContentResult(result: any, _options: FormatterOptions): string
     window_token,
     window_start,
     window_end,
+    window_lag,
     extraction_schema,
     sources,
     entities,
@@ -1171,6 +1194,8 @@ function formatGetContentResult(result: any, _options: FormatterOptions): string
       md += `- **Sources**: ${Object.keys(sources).join(', ')}\n`;
     }
     md += '\n';
+
+    md += formatWindowLag(window_lag);
 
     if (extraction_schema) {
       md += `### Extraction Schema\n\n\`\`\`json\n${JSON.stringify(extraction_schema, null, 2)}\n\`\`\`\n\n`;

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -1015,7 +1015,14 @@ async function getBehaviorImpl(
           params: {
             behavior_id: args.behavior_id,
             since: nextWindow.start.split('T')[0],
-            until: nextWindow.end.split('T')[0],
+            // `until` is INCLUSIVE — the last day inside the window — while
+            // `next_window.end` is the exclusive boundary. Passing the exclusive
+            // end straight through suggested a call one whole period too wide
+            // (a daily window advertised as `since=06-18&until=06-19`, which
+            // `alignRequestedWindow` reads as two days), so a client following
+            // the server's own suggestion wrote a window shaped like no period
+            // the dispatcher can emit.
+            until: new Date(new Date(nextWindow.end).getTime() - 1).toISOString().split('T')[0],
           },
           description:
             'Fetch content for analysis. Response includes window_token for complete_window action.',

--- a/packages/server/src/tools/get_content/behavior-mode.ts
+++ b/packages/server/src/tools/get_content/behavior-mode.ts
@@ -12,14 +12,21 @@ import { inferBehaviorGranularityFromSchedule } from '@lobu/connector-sdk';
 import { type DbClient, parsePgNumberArray } from '../../db/client';
 import type { Env } from '../../index';
 import type { Outputs, UnprocessedRange, WatcherSource } from '../../types/watchers';
-import { parseDateAlias, toEndOfDay } from '../../utils/date-aliases';
 import { type DataSourceContext, executeDataSources } from '../../utils/execute-data-sources';
 import logger from '../../utils/logger';
 import { runMetric } from '../../metrics/run-metric';
 import { getRecentFeedbackSummary } from '../../utils/watcher-feedback';
 import { getAvailableOperations, getPastReactionsSummary } from '../../utils/watcher-reactions';
 import { deriveWatcherExtractionSchema } from '../../utils/watcher-extraction-schema';
-import { computePendingWindow, foldUnprocessedRanges } from '../../utils/window-utils';
+import {
+  alignRequestedWindow,
+  computePendingWindow,
+  computeWindowLag,
+  describeWindowLag,
+  foldUnprocessedRanges,
+  parseBehaviorWindowDate,
+  readWindowCursor,
+} from '../../utils/window-utils';
 import {
   DEFAULT_BEHAVIOR_SOURCE_QUERY,
   type NormalizedWatcherSource,
@@ -440,14 +447,36 @@ export async function handleBehaviorMode(
   }));
 
   // Compute window dates - use since/until if provided, else compute pending window
-  let windowStart: Date, windowEnd: Date;
+  let windowStart: Date, windowEnd: Date, windowCursor: Date | null;
   if (args.since && args.until) {
-    // Use provided date range for the window
-    windowStart = parseDateAlias(args.since).date;
-    windowEnd = toEndOfDay(parseDateAlias(args.until).date);
+    // An agent-chosen range, aligned to the granularity so an agent-written
+    // window is indistinguishable in shape from a server-computed one.
+    ({ windowStart, windowEnd } = alignRequestedWindow(
+      parseBehaviorWindowDate(args.since),
+      parseBehaviorWindowDate(args.until),
+      timeGranularity
+    ));
+    windowCursor = await readWindowCursor(sql, watcherId);
   } else {
-    ({ windowStart, windowEnd } = await computePendingWindow(sql, watcherId, timeGranularity));
+    ({ windowStart, windowEnd, cursor: windowCursor } = await computePendingWindow(
+      sql,
+      watcherId,
+      timeGranularity
+    ));
   }
+
+  // How the window being handed out sits against the clock, and which periods
+  // (if any) were skipped to produce it. Measured against the WINDOW, not the
+  // cursor: at the moment a run reads, the cursor is the period the PREVIOUS run
+  // completed, so a healthy daily Behavior is two periods behind by that measure
+  // and one by this one.
+  const windowLag = computeWindowLag(windowCursor, windowStart, new Date(), timeGranularity);
+  const windowLagNote = describeWindowLag({
+    skippedFrom: windowLag.skippedFrom,
+    skippedTo: windowLag.skippedTo,
+    periodsSkipped: windowLag.periodsSkipped,
+    granularity: timeGranularity,
+  });
 
   // NOTE: Window creation is deferred to complete_window action
   // This allows batched processing where each batch creates its own window
@@ -602,6 +631,19 @@ export async function handleBehaviorMode(
     window_token: windowToken,
     window_start: windowStartIso,
     window_end: windowEndIso,
+    window_lag: {
+      last_window_start: windowCursor ? windowCursor.toISOString() : null,
+      current_period_start: windowLag.currentPeriodStart.toISOString(),
+      periods_behind: windowLag.periodsBehind,
+      granularity: timeGranularity,
+      periods_skipped: windowLag.periodsSkipped,
+      skipped_from: windowLag.skippedFrom ? windowLag.skippedFrom.toISOString() : null,
+      skipped_to: windowLag.skippedTo ? windowLag.skippedTo.toISOString() : null,
+      // The numbers alone did not change what a run did (see describeWindowLag).
+      // Behavior runs read this through run_sdk as JSON, so the guidance has to
+      // be IN the payload, not only in the markdown a tool-call client renders.
+      ...(windowLagNote ? { guidance: windowLagNote } : {}),
+    },
     extraction_schema: templateExtractionSchema ?? undefined,
     sources: sourcesContent as Record<string, ContentItem[]>,
     // Per-source page state. Every event source is capped at `limit`, so this

--- a/packages/server/src/tools/get_content/types.ts
+++ b/packages/server/src/tools/get_content/types.ts
@@ -68,6 +68,48 @@ export const GetContentResultSchema = Type.Object({
   window_token: Type.Optional(Type.String()),
   window_start: Type.Optional(Type.String()),
   window_end: Type.Optional(Type.String()),
+  /**
+   * How the window above sits against the clock, and what was skipped to get it.
+   *
+   * `window_start` alone cannot tell a run whether it is current: a stale window
+   * and a fresh one look identical from inside the run. Prod Behavior 2 drafted
+   * replies to month-dead Hacker News threads for weeks because nothing said so.
+   *
+   * Raw facts, deliberately — no staleness flag. A run that decides a skipped
+   * span is worth draining can read it by passing `since`/`until`, and the window
+   * it completes is whatever span it read.
+   */
+  window_lag: Type.Optional(
+    Type.Object({
+      /** Start of the newest window this Behavior has actually completed. */
+      last_window_start: Type.Union([Type.String(), Type.Null()]),
+      current_period_start: Type.String(),
+      /**
+       * Age of the window above, in whole periods. One is the healthy resting
+       * value for a Behavior that runs once per period (it analyses the period
+       * that just closed); zero for a cron that fires several times per period.
+       */
+      periods_behind: Type.Integer(),
+      granularity: Type.String(),
+      /**
+       * Periods between `last_window_start` and the window above that no run will
+       * ever be dispatched for, because the server moved the window forward to
+       * bring a lagging Behavior current. Zero on every healthy run.
+       */
+      periods_skipped: Type.Integer(),
+      skipped_from: Type.Union([Type.String(), Type.Null()]),
+      /** Inclusive — the last period actually skipped. */
+      skipped_to: Type.Union([Type.String(), Type.Null()]),
+      /**
+       * The skip in words, present only when `periods_skipped` is non-zero. A
+       * Behavior run reads this response as JSON through `run_sdk`, so the
+       * affordance — that it may re-read a skipped span with `since`/`until`, and
+       * that doing so cannot drag the cursor back — has to travel in the payload.
+       * Reporting only numbers was measured NOT to change what a run did.
+       */
+      guidance: Type.Optional(Type.String()),
+    })
+  ),
   extraction_schema: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
   sources: Type.Optional(Type.Record(Type.String(), Type.Array(Type.Unknown()))),
   /**

--- a/packages/server/src/utils/__tests__/compute-pending-window.test.ts
+++ b/packages/server/src/utils/__tests__/compute-pending-window.test.ts
@@ -33,6 +33,14 @@
  * so an hourly cron necessarily gets a DAILY window and must re-dispatch the
  * SAME period all day. "Always advance one period" would mint tomorrow's window
  * at 00:01 and march into the future.
+ *
+ * Fixtures here are RELATIVE to the clock, not absolute dates. `computePendingWindow`
+ * now floors the window at `now - 1 period` so a lagging Behavior catches up in one
+ * run, which means a fixture pinned to a fixed past date is always floored — and a
+ * test about boundary conventions would silently become a test about the floor,
+ * passing for the wrong reason. Seed a chain that is genuinely current and the
+ * assertions stay about what they were written for. The floor itself is pinned
+ * separately, below and in `__tests__/unit/behavior-window-lag.test.ts`.
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -84,6 +92,22 @@ async function seedOrg() {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** Start of the UTC day `offsetDays` back from now. */
+const dayStart = (offsetDays: number): Date => {
+  const d = new Date(Date.now() - offsetDays * DAY_MS);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+};
+
+/** Start of the Monday `offsetWeeks` back from the current week. */
+const weekStart = (offsetWeeks: number): Date => {
+  const d = new Date(Date.now() - offsetWeeks * 7 * DAY_MS);
+  const dayOfWeek = d.getUTCDay();
+  d.setUTCDate(d.getUTCDate() - (dayOfWeek === 0 ? 6 : dayOfWeek - 1));
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+};
+
 describe('computePendingWindow', () => {
   afterEach(async () => {
     await cleanupTestDatabase();
@@ -94,13 +118,14 @@ describe('computePendingWindow', () => {
   it('rolls forward to the next aligned period after an inclusive-end window', async () => {
     const { orgId, userId } = await seedOrg();
     const watcherId = 9001;
+    const previous = dayStart(2);
     await seedWindow({
       orgId,
       userId,
       watcherId,
       granularity: 'daily',
-      start: '2026-07-30T00:00:00.000Z',
-      end: '2026-07-30T23:59:59.999Z', // inclusive convention
+      start: previous.toISOString(),
+      end: new Date(previous.getTime() + DAY_MS - 1).toISOString(), // inclusive convention
     });
 
     const { windowStart, windowEnd } = await computePendingWindow(
@@ -109,21 +134,22 @@ describe('computePendingWindow', () => {
       'daily'
     );
 
-    // Must be the NEXT day at midnight — not 23:59:59.999, and not 7/30 again.
-    expect(windowStart.toISOString()).toBe('2026-07-31T00:00:00.000Z');
-    expect(windowEnd.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+    // The NEXT day at midnight — not 23:59:59.999, and not the seeded day again.
+    expect(windowStart.toISOString()).toBe(dayStart(1).toISOString());
+    expect(windowEnd.toISOString()).toBe(dayStart(0).toISOString());
   });
 
   it('rolls forward identically when the previous end was exclusive', async () => {
     const { orgId, userId } = await seedOrg();
     const watcherId = 9002;
+    const previous = dayStart(2);
     await seedWindow({
       orgId,
       userId,
       watcherId,
       granularity: 'daily',
-      start: '2026-07-30T00:00:00.000Z',
-      end: '2026-07-31T00:00:00.000Z', // exclusive convention
+      start: previous.toISOString(),
+      end: dayStart(1).toISOString(), // exclusive convention
     });
 
     const { windowStart, windowEnd } = await computePendingWindow(
@@ -132,22 +158,25 @@ describe('computePendingWindow', () => {
       'daily'
     );
 
-    expect(windowStart.toISOString()).toBe('2026-07-31T00:00:00.000Z');
-    expect(windowEnd.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+    expect(windowStart.toISOString()).toBe(dayStart(1).toISOString());
+    expect(windowEnd.toISOString()).toBe(dayStart(0).toISOString());
   });
 
   // Self-heal: the 14 already-misaligned prod rows must recover on their own,
-  // without a data migration rewriting window identities.
+  // without a data migration rewriting window identities. The corrupt start is a
+  // period boundary minus a millisecond, exactly as prod stores it — chaining off
+  // it unaligned would carry the `23:59:59.999` into the next window forever.
   it('recovers from an already-misaligned stored window', async () => {
     const { orgId, userId } = await seedOrg();
     const watcherId = 9003;
+    const corruptStart = new Date(dayStart(2).getTime() + DAY_MS - 1);
     await seedWindow({
       orgId,
       userId,
       watcherId,
       granularity: 'daily',
-      start: '2026-07-29T23:59:59.999Z', // corrupt start, as found on prod
-      end: '2026-07-30T23:59:59.999Z',
+      start: corruptStart.toISOString(),
+      end: new Date(dayStart(1).getTime() + DAY_MS - 1).toISOString(),
     });
 
     const { windowStart, windowEnd } = await computePendingWindow(
@@ -156,8 +185,8 @@ describe('computePendingWindow', () => {
       'daily'
     );
 
-    expect(windowStart.toISOString()).toBe('2026-07-30T00:00:00.000Z');
-    expect(windowEnd.toISOString()).toBe('2026-07-31T00:00:00.000Z');
+    expect(windowStart.toISOString()).toBe(dayStart(1).toISOString());
+    expect(windowEnd.toISOString()).toBe(dayStart(0).toISOString());
     expect(windowStart.getUTCHours()).toBe(0);
   });
 
@@ -226,8 +255,11 @@ describe('computePendingWindow', () => {
     expect(windowEnd.toISOString()).toBe(tomorrowIso);
   });
 
-  // Backfill must still walk forward one period at a time when genuinely behind.
-  it('catches up one period per run when behind', async () => {
+  // The contract this branch changed. Walking forward one period per run never
+  // closed a gap — the clock advances a period per period too — so prod Behavior 2
+  // sat 50 days behind for weeks. A Behavior months behind is now dispatched the
+  // period that just closed, and catches up in a single run.
+  it('jumps to the current period when far behind, not one period per run', async () => {
     const { orgId, userId } = await seedOrg();
     const watcherId = 9005;
     await seedWindow({
@@ -245,20 +277,22 @@ describe('computePendingWindow', () => {
       'daily'
     );
 
-    expect(windowStart.toISOString()).toBe('2026-01-11T00:00:00.000Z');
-    expect(windowEnd.toISOString()).toBe('2026-01-12T00:00:00.000Z');
+    expect(windowStart.toISOString()).toBe(dayStart(1).toISOString());
+    expect(windowEnd.toISOString()).toBe(dayStart(0).toISOString());
+    expect(windowStart.toISOString()).not.toBe('2026-01-11T00:00:00.000Z');
   });
 
   it('aligns weekly windows to the week boundary', async () => {
     const { orgId, userId } = await seedOrg();
     const watcherId = 9006;
+    const previousWeek = weekStart(2);
     await seedWindow({
       orgId,
       userId,
       watcherId,
       granularity: 'weekly',
-      start: '2026-06-22T00:00:00.000Z', // a Monday
-      end: '2026-06-28T23:59:59.999Z', // inclusive, as stored on prod
+      start: previousWeek.toISOString(), // a Monday
+      end: new Date(previousWeek.getTime() + 7 * DAY_MS - 1).toISOString(), // inclusive, as stored on prod
     });
 
     const { windowStart, windowEnd } = await computePendingWindow(
@@ -267,8 +301,8 @@ describe('computePendingWindow', () => {
       'weekly'
     );
 
-    expect(windowStart.toISOString()).toBe('2026-06-29T00:00:00.000Z');
-    expect(windowEnd.toISOString()).toBe('2026-07-06T00:00:00.000Z');
+    expect(windowStart.toISOString()).toBe(weekStart(1).toISOString());
+    expect(windowEnd.toISOString()).toBe(weekStart(0).toISOString());
     expect(windowStart.getUTCDay()).toBe(1); // Monday
   });
 
@@ -323,10 +357,13 @@ describe('nextBehaviorWindowStart', () => {
     ).toBe('2026-07-31T00:00:00.000Z');
   });
 
-  it('still catches up one period at a time when far behind', () => {
+  // The floor. Chaining alone returns 2026-01-11 here and needs one successful run
+  // per missed day to reach the present, so a gap freezes instead of closing —
+  // prod Behavior 2 sat 50 days behind on exactly this. Never older than one period.
+  it('jumps to the previous period when far behind, not one period at a time', () => {
     expect(
       nextBehaviorWindowStart(new Date('2026-01-10T00:00:00.000Z'), NOW, 'daily').toISOString()
-    ).toBe('2026-01-11T00:00:00.000Z');
+    ).toBe('2026-07-30T00:00:00.000Z');
   });
 
   it('starts one aligned period back when there is no previous window', () => {
@@ -335,9 +372,18 @@ describe('nextBehaviorWindowStart', () => {
     );
   });
 
+  // Chaining a weekly Behavior lands on a Monday...
   it('aligns weekly to Monday', () => {
+    const out = nextBehaviorWindowStart(new Date('2026-07-19T23:59:59.999Z'), NOW, 'weekly');
+    expect(out.getUTCDay()).toBe(1);
+    expect(out.toISOString()).toBe('2026-07-20T00:00:00.000Z');
+  });
+
+  // ...and so does the floor, which is a separate code path and could have landed
+  // mid-week by subtracting seven days from an unaligned instant.
+  it('floors weekly to a Monday too', () => {
     const out = nextBehaviorWindowStart(new Date('2026-06-28T23:59:59.999Z'), NOW, 'weekly');
     expect(out.getUTCDay()).toBe(1);
-    expect(out.toISOString()).toBe('2026-06-29T00:00:00.000Z');
+    expect(out.toISOString()).toBe('2026-07-20T00:00:00.000Z');
   });
 });

--- a/packages/server/src/utils/window-utils.ts
+++ b/packages/server/src/utils/window-utils.ts
@@ -11,11 +11,18 @@ import {
   type BehaviorTimeGranularity,
 } from '@lobu/connector-sdk';
 import type { DbClient } from '../db/client';
+import { parseDateAlias } from './date-aliases';
 import type { UnprocessedRange } from '../types/watchers';
 
 interface WindowDates {
   windowStart: Date;
   windowEnd: Date;
+  /**
+   * The cursor this window was chained off — `readWindowCursor`'s result, handed
+   * back so a caller that also needs to report lag does not re-query for a value
+   * this function just read.
+   */
+  cursor: Date | null;
 }
 
 /** Row shape for a `DATE_TRUNC('month', ...)` aggregate of total events per month. */
@@ -122,32 +129,256 @@ export async function computePendingWindow(
   watcherId: number,
   granularity: BehaviorTimeGranularity
 ): Promise<WindowDates> {
-  // Latest period this Behavior has a chain root for (canvas_windows = one row
-  // per root). Ordered by window_start because that is the field being chained;
-  // ordering by window_end would re-introduce the boundary ambiguity above.
-  // Zero-content windows are durable cursor progress too, otherwise empty
-  // periods get reprocessed forever.
-  const lastWindow = await sql`
-    SELECT window_start
-    FROM canvas_windows
-    WHERE watcher_id = ${watcherId}
-    ORDER BY window_start DESC
-    LIMIT 1
-  `;
-
-  const now = new Date();
-  const windowStart = nextBehaviorWindowStart(
-    lastWindow.length > 0 ? new Date(lastWindow[0].window_start as string) : null,
-    now,
-    granularity
-  );
+  const cursor = await readWindowCursor(sql, watcherId);
+  const windowStart = nextBehaviorWindowStart(cursor, new Date(), granularity);
 
   // Always a full period. `windowStart <= alignedNow` by construction, so this
   // can never exceed the current period's end and never needs clamping — which
   // is what keeps it from degenerating.
   const windowEnd = addBehaviorPeriod(windowStart, granularity);
 
+  return { windowStart, windowEnd, cursor };
+}
+
+/**
+ * The Behavior's window cursor: the start of the latest period it has a canvas
+ * chain root for, or null if it has none.
+ *
+ * `canvas_windows` holds one row per root, so this is a bounded per-Behavior
+ * lookup, not a history aggregation. Ordered by `window_start` because that is
+ * the field being chained; ordering by `window_end` would re-introduce the
+ * boundary ambiguity documented on `computePendingWindow`. Zero-content windows
+ * count as durable cursor progress too, otherwise empty periods get reprocessed
+ * forever.
+ *
+ * Shared by `computePendingWindow` (which advances it) and the lag reported to
+ * the agent (which describes it), so the two can never disagree about where the
+ * cursor is.
+ */
+export async function readWindowCursor(
+  sql: DbClient,
+  watcherId: number
+): Promise<Date | null> {
+  const rows = await sql`
+    SELECT window_start
+    FROM canvas_windows
+    WHERE watcher_id = ${watcherId}
+    ORDER BY window_start DESC
+    LIMIT 1
+  `;
+  return rows.length > 0 ? new Date(rows[0].window_start as string) : null;
+}
+
+/**
+ * Resolve an agent-supplied `since`/`until` to a UTC instant.
+ *
+ * Window boundaries are UTC everywhere in this file (`alignToBehaviorWindowStart`
+ * is all `setUTCHours`), but `parseDateAlias` normalizes every result to midnight
+ * in the SERVER's LOCAL zone — and the two disagree by a full day in BOTH
+ * directions:
+ *
+ *   UTC-5  `new Date('2026-08-06')` is UTC midnight = local Aug 5 19:00, so
+ *          `.setHours(0,0,0,0)` lands on Aug 5. The agent asked for the 6th and
+ *          would have written the 5th.
+ *   UTC+3  the same call lands on local Aug 6 = `2026-08-05T21:00Z`, which
+ *          `alignToBehaviorWindowStart` then snaps back to Aug 5. Same wrong day,
+ *          reached by a different route.
+ *
+ * `get_behavior.next_action` hands MCP clients exactly such a `YYYY-MM-DD` string,
+ * so the server's own suggested call did not round-trip on any non-UTC
+ * deployment. A calendar date is a UTC day here, so parse it as one directly and
+ * never let the local zone touch it.
+ *
+ * Aliases (`today`, `7d`, `last_week`) are relative to the server's clock by
+ * definition, so those still go through `parseDateAlias`; only their resulting
+ * calendar day is reinterpreted as UTC.
+ *
+ * Caught by the e2e on a west-of-UTC machine (it asked for 2026-08-06 and got the
+ * 2026-08-05 window). Invisible to every unit test, which all pass in UTC.
+ */
+export function parseBehaviorWindowDate(value: string): Date {
+  const trimmed = value.trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return new Date(`${trimmed}T00:00:00.000Z`);
+  }
+  const local = parseDateAlias(trimmed).date;
+  return new Date(Date.UTC(local.getFullYear(), local.getMonth(), local.getDate()));
+}
+
+/**
+ * Align an agent-requested `since`/`until` span onto granularity boundaries.
+ *
+ * Deliberately does NOT clamp to a single period. The backfill affordance
+ * depends on being able to ask for a wider span — the unprocessed-ranges
+ * formatter suggests whole months to a daily Behavior — so the span is
+ * preserved and only its edges move.
+ *
+ * The end is aligned UP to the next period start, making it EXCLUSIVE. The
+ * previous behaviour ran `until` through `toEndOfDay`, storing an inclusive
+ * `23:59:59.999`; that is the second boundary convention `computePendingWindow`
+ * documents as the source of prod's zero-length windows, and it disagrees with
+ * the `>= start AND < end` filter `executeDataSources` applies. An agent-written
+ * window is now indistinguishable in shape from a server-computed one.
+ */
+export function alignRequestedWindow(
+  since: Date,
+  until: Date,
+  granularity: BehaviorTimeGranularity
+): { windowStart: Date; windowEnd: Date } {
+  const windowStart = alignToBehaviorWindowStart(since, granularity);
+  const alignedUntil = alignToBehaviorWindowStart(until, granularity);
+  // `until` is inclusive as the caller means it ("through June 30"), so the
+  // period containing it is part of the span and the exclusive end is the
+  // period after that one. A same-period since/until yields exactly one period
+  // rather than a zero-length window.
+  const windowEnd = addBehaviorPeriod(
+    alignedUntil < windowStart ? windowStart : alignedUntil,
+    granularity
+  );
   return { windowStart, windowEnd };
+}
+
+/**
+ * How the window a run is about to analyse sits against the clock.
+ *
+ * Two different facts, and conflating them is a bug this function was rewritten
+ * to fix. `periodsBehind` measures the WINDOW BEING HANDED OUT, not the cursor.
+ * Measured against the cursor, a perfectly healthy daily Behavior reads as two
+ * periods behind at the moment its run calls `read_knowledge` — the cursor is the
+ * period completed by the PREVIOUS run, and the pending window is the one after
+ * that. Prod Behavior 79 (`0 4 * * *`) sits exactly there every single day. Any
+ * staleness threshold applied to the cursor therefore fires on healthy runs.
+ *
+ * `periodsSkipped` is the span the floor in `nextBehaviorWindowStart` jumped
+ * over: the periods between the cursor and the window now being handed out, which
+ * no run will ever be dispatched for. Zero on every healthy run, because the
+ * window chains directly off the cursor. This is a statement about what the
+ * server DID, not a judgment — which is why it needs no threshold.
+ *
+ * Deliberately still raw facts: no `is_stale` flag. Whether a skipped span is
+ * worth draining depends on what the Behavior is FOR — a drafting Behavior wants
+ * to skip, a metrics one wants every period because the gaps are its data — and
+ * that judgment lives in the prompt, which this function will never see.
+ */
+export function computeWindowLag(
+  cursor: Date | null,
+  windowStart: Date,
+  now: Date,
+  granularity: BehaviorTimeGranularity
+): {
+  currentPeriodStart: Date;
+  periodsBehind: number;
+  skippedFrom: Date | null;
+  skippedTo: Date | null;
+  periodsSkipped: number;
+} {
+  const currentPeriodStart = alignToBehaviorWindowStart(now, granularity);
+  const alignedWindow = alignToBehaviorWindowStart(windowStart, granularity);
+  // Whole periods between the two aligned instants. Arithmetic rather than a
+  // loop so a window years adrift costs the same as one a day adrift, and exact
+  // because every alignment is UTC — no DST to round over.
+  const periodsBehind = Math.max(
+    0,
+    wholePeriodsBetween(alignedWindow, currentPeriodStart, granularity)
+  );
+
+  // The period the window WOULD have covered by chaining. When the floor moved
+  // the window past it, everything from here to the window is skipped.
+  const chained = cursor
+    ? addBehaviorPeriod(alignToBehaviorWindowStart(cursor, granularity), granularity)
+    : null;
+  const periodsSkipped =
+    chained && chained < alignedWindow
+      ? wholePeriodsBetween(chained, alignedWindow, granularity)
+      : 0;
+
+  return {
+    currentPeriodStart,
+    periodsBehind,
+    skippedFrom: periodsSkipped > 0 ? chained : null,
+    // Inclusive: the last period actually skipped is the one before the window.
+    skippedTo:
+      periodsSkipped > 0
+        ? alignToBehaviorWindowStart(
+            subtractBehaviorPeriod(alignedWindow, granularity),
+            granularity
+          )
+        : null,
+    periodsSkipped,
+  };
+}
+
+/**
+ * The lag stated in words, or null when there is nothing to say.
+ *
+ * This exists because reporting the NUMBER was not enough. Measured 2026-08-06
+ * against a live run: a Behavior seeded fifty periods behind, handed
+ * `periods_behind: 50`, analysed the stale window anyway and advanced the cursor
+ * by exactly one period — the prod pathology reproduced WITH the lag field in
+ * place. Behavior runs reach knowledge through `run_sdk`, which returns JSON, so
+ * all the model ever saw was four numbers inside a thirteen-key object. The
+ * prose lived in the markdown formatter, on a path Behavior runs never take.
+ *
+ * So the guidance travels WITH the data, on every surface.
+ *
+ * What it SAYS changed once the floor landed. It no longer asks a run to rescue a
+ * stuck cursor — `nextBehaviorWindowStart` now does that deterministically, for
+ * every model — it reports the span the server skipped in order to get current,
+ * and offers the one decision that is genuinely the run's: whether that span is
+ * worth reading.
+ *
+ * No threshold. It speaks exactly when periods were skipped, which never happens
+ * on a healthy run, so there is no number to tune and nothing training a model to
+ * ignore a notice it sees every time. The previous `periodsBehind >= 2` rule
+ * would have fired on every healthy daily Behavior — see `computeWindowLag`.
+ *
+ * Worded without attributing the skip to anything. A gap between the cursor and
+ * the window can be the floor jumping a lagging Behavior forward OR the agent
+ * asking for a later span itself, and the payload cannot tell the two apart;
+ * claiming the server moved the window would be false on the second path.
+ */
+export function describeWindowLag(lag: {
+  skippedFrom: Date | null;
+  skippedTo: Date | null;
+  periodsSkipped: number;
+  granularity: BehaviorTimeGranularity;
+}): string | null {
+  if (lag.periodsSkipped < 1 || !lag.skippedFrom || !lag.skippedTo) return null;
+  return (
+    `${lag.periodsSkipped} ${lag.granularity} period(s) between this Behavior's last completed ` +
+    `window and the one above were skipped — ${lag.skippedFrom.toISOString()} through ` +
+    `${lag.skippedTo.toISOString()} — and no run will be dispatched for them. ` +
+    "If this Behavior's purpose needs that span, read it " +
+    'explicitly: call read_knowledge again with `since`/`until` covering it and complete the ' +
+    'token that call returns. Completing an older window records it without moving the cursor ' +
+    'back, so draining the backlog cannot make this Behavior stale again. If only recent ' +
+    'periods matter for what this Behavior does, ignore this and analyse the window above.'
+  );
+}
+
+const MS_PER_DAY = 86_400_000;
+
+function wholePeriodsBetween(
+  from: Date,
+  to: Date,
+  granularity: BehaviorTimeGranularity
+): number {
+  switch (granularity) {
+    case 'daily':
+      return Math.round((to.getTime() - from.getTime()) / MS_PER_DAY);
+    case 'weekly':
+      return Math.round((to.getTime() - from.getTime()) / (MS_PER_DAY * 7));
+    case 'monthly':
+      return monthsBetween(from, to);
+    case 'quarterly':
+      return Math.trunc(monthsBetween(from, to) / 3);
+  }
+}
+
+function monthsBetween(from: Date, to: Date): number {
+  return (
+    (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth())
+  );
 }
 
 /**
@@ -175,21 +406,47 @@ export function nextBehaviorWindowStart(
   granularity: BehaviorTimeGranularity
 ): Date {
   const alignedNow = alignToBehaviorWindowStart(now, granularity);
+  // The oldest window a current Behavior is ever handed. Aligned BEFORE the
+  // subtraction: `setUTCMonth(month - 1)` on the 29th–31st rolls FORWARD
+  // (Feb 31 → Mar 3), so subtracting from a raw `now` handed a monthly Behavior
+  // run on the 31st the window it was already on.
+  const previousPeriod = alignToBehaviorWindowStart(
+    subtractBehaviorPeriod(alignedNow, granularity),
+    granularity
+  );
 
   if (!lastWindowStart) {
     // Nothing analysed yet — start one aligned period back.
-    return alignToBehaviorWindowStart(subtractBehaviorPeriod(now, granularity), granularity);
+    return previousPeriod;
   }
 
   // Next period after the last one, re-aligned so a corrupt stored start cannot
-  // propagate. Capped at the current period: being "done" with today means today
-  // gets re-analysed (and superseded), not that tomorrow starts — granularity has
-  // no 'hourly', so a sub-daily cron must keep resolving to the same day.
-  const nextStart = addBehaviorPeriod(
+  // propagate.
+  const chained = addBehaviorPeriod(
     alignToBehaviorWindowStart(lastWindowStart, granularity),
     granularity
   );
-  return nextStart > alignedNow ? alignedNow : nextStart;
+
+  // THE FLOOR, and the reason this file changed. Chaining advances one period per
+  // COMPLETED window while the clock advances one period per period, so a gap
+  // never closes on its own — it freezes at whatever width the outage left. Prod
+  // Behavior 2 sat 50 days behind, drafting replies to month-dead Hacker News
+  // threads one June day at a time, and would have needed 50 more successful runs
+  // to reach the present.
+  //
+  // Refusing to hand out a window older than one period closes any gap in a
+  // single run, for every model, with no agent cooperation. That is the part
+  // guidance cannot buy: prose changes the odds, a floor changes the guarantee.
+  //
+  // Only the window ASKED FOR moves. The cursor still advances solely when a run
+  // completes a window, so a Behavior whose runs all fail keeps reporting its full
+  // lag rather than looking current — the floor cannot mask a broken Behavior.
+  const floored = chained < previousPeriod ? previousPeriod : chained;
+
+  // Capped at the current period: being "done" with today means today gets
+  // re-analysed (and superseded), not that tomorrow starts — granularity has no
+  // 'hourly', so a sub-daily cron must keep resolving to the same day.
+  return floored > alignedNow ? alignedNow : floored;
 }
 
 /**


### PR DESCRIPTION
## Summary

- A Behavior's window cursor advanced **one period per completed window** while the clock advanced one period per period, so a gap never closed — it froze at whatever width the outage left. Prod Behavior 2 sat 50 days behind, drafting replies to month-dead Hacker News threads one June day at a time, and reported success on every run.
- `nextBehaviorWindowStart` now **floors the dispatched window at `now - 1 period`**. Any gap closes on the next successful run, for every model, with no agent cooperation. The cursor still advances only on a real completion, so a Behavior whose runs all fail keeps reporting its real lag — the floor cannot mask a broken Behavior.
- `window_lag` reports what the floor did (`periods_skipped` / `skipped_from` / `skipped_to` + `guidance`). Behavior runs read this through `run_sdk` as JSON and never render markdown, so the prose travels in the payload; the formatter renders that same string.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: 37 unit under 4 timezones, 8 integration (real handlers + real DB), 281 behaviors+watchers integration, 895 server unit
- [x] Bug fix: red→fix→green outputs pasted below

### Red → green

The defect, pinned. With the floor removed (`chained < previousPeriod ? previousPeriod : chained` → `chained`):

```
--- M1: delete the floor ---
 36 pass  2 fail
```

```
× a fifty-period gap closes in one run
  Expected: "2026-08-05T00:00:00.000Z"
  Received: "2026-06-18T00:00:00.000Z"
```

Restored:

```
 37 pass  0 fail
```

Integration, against a real database — a Behavior seeded with a cursor 50 days back is dispatched **yesterday**, not June 18:

```
[complete_window] Created canvas window 11 for watcher 1
  (2026-08-05T00:00:00.000Z - 2026-08-06T00:00:00.000Z)
 Tests  8 passed (8)
```

### Mutation coverage

Every mutation was verified to land (`grep -c` on the source before/after) and each went red, then green on restore:

| Mutation | Result |
|---|---|
| Delete the floor | 2 fail |
| Floor at `alignedNow` instead of `now - 1` | 5 fail |
| Subtract the period from a raw `now` | 1 fail |
| Measure lag from the cursor again | 4 fail (integration) |

### Timezone matrix

`bun test` runs under `TZ=UTC`, where a local date and a UTC date are the same instant — which is how the date bug below survived every unit test. Re-run explicitly:

```
UTC                   37 pass  0 fail
America/New_York      37 pass  0 fail
Europe/Istanbul       37 pass  0 fail
Pacific/Kiritimati    37 pass  0 fail
```

## Notes

Also fixed, each found while proving the above:

- **`periods_behind` measured the cursor.** At the moment a run calls `read_knowledge`, the cursor is the period the *previous* run completed — so a healthy daily Behavior reads as **2 periods behind**. Prod Behavior 79 (`0 4 * * *`) sits exactly there every day, and the earlier `>= 2` guidance threshold would have fired on every healthy daily run. It now measures the window being handed out (healthy = 1), and the notice speaks only when periods were actually skipped, so there is no threshold left to tune.
- **Month-end rollover.** `subtractBehaviorPeriod` was applied to a raw `now`; `setUTCMonth(month - 1)` on the 29th–31st rolls *forward* (Feb 31 → Mar 3), so a monthly Behavior run on the 31st was handed the month it was already on. Aligned before subtracting.
- **`alignRequestedWindow`** replaces `toEndOfDay` for agent-chosen `since`/`until`. The inclusive `23:59:59.999` end produced prod's five zero-length windows and disagrees with the `>= start AND < end` filter applied on the read.
- **`get_behavior.next_action`** suggested the *exclusive* end as `until`, so a client following the server's own suggestion wrote a window one period too wide.
- **`parseBehaviorWindowDate`** — a bare `YYYY-MM-DD` is that UTC day. `parseDateAlias` normalizes to *local* midnight, which disagrees with UTC window boundaries by a full day in both directions.

### Follow-ups (not in this PR)

- Prod Behavior 2 needs a manual hand regardless: its device has not claimed a run since 2026-07-18, so no dispatch change reaches it.
- `unprocessed_ranges` is dead for **77 of 80** prod Behaviors (gated on `entity_ids &&`). Un-gating it would turn a 3/80 breach of "request paths never aggregate history" into 80/80 — it is a `GROUP BY DATE_TRUNC('month')` over `current_event_records` on a read path. The correct fix materializes coverage at write time.
- Repin freeze: a device pin is frozen into `approved_input`, so repointing leaves the stale pending run blocking the new one via the anti-join.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visibility into delayed behavior windows, including lag, skipped periods, and recovery guidance.
  * Explicit date ranges now align with the behavior’s schedule granularity.
  * Behavior results include window status details in JSON and Markdown.
  * Next-action dates now accurately reflect the final day of the suggested window.

* **Bug Fixes**
  * Improved handling of stale, malformed, future, and incomplete behavior windows.
  * Prevented cursor regressions and ensured skipped periods are reported accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->