### PR TITLE
fix(chart): skip the pre-upgrade quiesce when no migration is pending

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -767,6 +767,17 @@ jobs:
         # schema to the reference-free shape both CLIs load.
         run: bun test scripts/__tests__/review-output-schema.test.ts
 
+      - name: Migration runner guards
+        # migrate-up.mjs --check-pending exit status 3 is the ONLY status that
+        # lets the chart's pre-upgrade hook skip its scale-to-zero quiesce
+        # (charts/lobu/files/migrate-upgrade.sh). These pin the fail-closed
+        # paths: an unreachable ledger, a missing DATABASE_URL, or a duplicate
+        # migration version must never read as "nothing pending", or an
+        # incompatible migration applies while the old pods are still serving.
+        run: |
+          bun test scripts/__tests__/migrate-up-check-pending.test.ts
+          bun test scripts/__tests__/migrate-up-duplicate-version.test.ts
+
       - name: Raw-array SQL-param gate
         # packages/server's postgres.js client runs fetch_types:false, where a raw
         # JS array bound as a query param serializes to a malformed array literal
@@ -1087,6 +1098,21 @@ jobs:
             echo "::error::$pending migrations still pending after dbmate up"
             exit 1
           fi
+
+      - name: Pending-check contract (pre-upgrade quiesce fast path)
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/lobu_ci?sslmode=disable
+        # charts/lobu/files/migrate-upgrade.sh skips its scale-to-zero quiesce
+        # only on --check-pending exit status 3. Pin both real-database
+        # answers here, where every migration was just applied: a complete
+        # ledger reports 3, and one unapplied file reports 0 (quiesce).
+        run: |
+          pending_rc=0; node scripts/migrate-up.mjs --check-pending || pending_rc=$?
+          test "$pending_rc" -eq 3
+          printf -- '-- migrate:up\nSELECT 1;\n' > db/migrations/99999999999999_pending_probe.sql
+          pending_rc=0; node scripts/migrate-up.mjs --check-pending || pending_rc=$?
+          rm db/migrations/99999999999999_pending_probe.sql
+          test "$pending_rc" -eq 0
 
       # The committed pgvector libraries bypass normal TypeScript builds. Keep
       # their ABI floor in this already-required, Docker-capable policy job

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -54,6 +54,7 @@ jobs:
           grep -q 'name: install-kubectl' /tmp/lobu-quiesced-upgrade.yaml
           grep -q 'trap restore_on_failure EXIT' /tmp/lobu-quiesced-upgrade.yaml
           grep -q 'migration failed with status' /tmp/lobu-quiesced-upgrade.yaml
+          grep -q 'name: MIGRATION_PENDING_CHECK' /tmp/lobu-quiesced-upgrade.yaml
           grep -q '"helm.sh/hook-weight": "0"' /tmp/lobu-quiesced-upgrade.yaml
 
           helm template lobu charts/lobu --namespace lobu --is-upgrade \

--- a/charts/lobu/files/migrate-upgrade.sh
+++ b/charts/lobu/files/migrate-upgrade.sh
@@ -8,6 +8,7 @@ app_selector=${APP_SELECTOR:?APP_SELECTOR is required}
 worker_deployment=${WORKER_DEPLOYMENT:-}
 worker_selector=${WORKER_SELECTOR:-}
 timeout=${QUIESCE_TIMEOUT:-300s}
+pending_check=${MIGRATION_PENDING_CHECK:-}
 quiescence_started=0
 app_replicas=absent
 worker_replicas=absent
@@ -51,6 +52,32 @@ restore_on_failure() {
   exit "$status"
 }
 
+# Quiescing scales the app to zero for the length of a pod restart, which the
+# ingress answers with 503. Only a schema change needs that window, and most
+# deploys ship none, so ask the ledger first. Fail closed: only the check's
+# definitive "nothing pending" status (3) skips the quiesce -- an unset check
+# or any other status, including a crash, still quiesces.
+migrations_pending() {
+  if [ -z "$pending_check" ]; then
+    echo 'no pending-migration check configured; quiescing'
+    return 0
+  fi
+  set +e
+  # Word splitting is intended: the check is configured as a full command line.
+  $pending_check
+  pending_status=$?
+  set -e
+  # 3 is CHECK_PENDING_NONE_EXIT in scripts/migrate-up.mjs -- the one status
+  # that means "the ledger was read and it is complete".
+  if [ "$pending_status" -eq 3 ]; then
+    return 1
+  fi
+  if [ "$pending_status" -ne 0 ]; then
+    echo "pending-migration check failed with status $pending_status; quiescing" >&2
+  fi
+  return 0
+}
+
 quiesce_deployment() {
   deployment=$1
   selector=$2
@@ -77,17 +104,21 @@ trap restore_on_failure EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-app_replicas=$(deployment_replicas "$app_deployment")
-if [ -n "$worker_deployment" ]; then
-  worker_replicas=$(deployment_replicas "$worker_deployment")
-fi
+if migrations_pending; then
+  app_replicas=$(deployment_replicas "$app_deployment")
+  if [ -n "$worker_deployment" ]; then
+    worker_replicas=$(deployment_replicas "$worker_deployment")
+  fi
 
-quiescence_started=1
-quiesce_deployment "$app_deployment" "$app_selector" "$app_replicas"
-if [ -n "$worker_deployment" ]; then
-  quiesce_deployment "$worker_deployment" "$worker_selector" "$worker_replicas"
+  quiescence_started=1
+  quiesce_deployment "$app_deployment" "$app_selector" "$app_replicas"
+  if [ -n "$worker_deployment" ]; then
+    quiesce_deployment "$worker_deployment" "$worker_selector" "$worker_replicas"
+  fi
+  echo 'all old database clients are quiesced; running migration'
+else
+  echo 'no pending migrations; skipping quiesce so Helm can roll without downtime'
 fi
-echo 'all old database clients are quiesced; running migration'
 
 "$@"
 echo 'migration completed; Helm may apply the new deployments'

--- a/charts/lobu/templates/migration-job.yaml
+++ b/charts/lobu/templates/migration-job.yaml
@@ -97,6 +97,10 @@ spec:
             {{- if .Release.IsUpgrade }}
             - name: KUBECTL_BIN
               value: /migration-tools/kubectl
+            - name: MIGRATIONS_DIR
+              value: /app/db/migrations
+            - name: MIGRATION_PENDING_CHECK
+              value: "node /app/scripts/migrate-up.mjs --check-pending"
             - name: NAMESPACE
               value: {{ .Release.Namespace | quote }}
             - name: APP_DEPLOYMENT

--- a/charts/lobu/tests/migrate-upgrade-recovery.sh
+++ b/charts/lobu/tests/migrate-upgrade-recovery.sh
@@ -39,6 +39,14 @@ exit "${MIGRATION_EXIT_CODE:-0}"
 MIGRATE
 chmod +x "$test_dir/migrate"
 
+pending_log="$test_dir/pending.log"
+cat >"$test_dir/pending-check" <<'PENDING'
+#!/bin/sh
+printf 'pending-check\n' >>"$PENDING_LOG"
+exit "${PENDING_EXIT_CODE:-0}"
+PENDING
+chmod +x "$test_dir/pending-check"
+
 set +e
 COMMAND_LOG="$command_log" \
 MIGRATION_LOG="$migration_log" \
@@ -119,5 +127,74 @@ if grep -q '^scale deployment' "$command_log"; then
   echo 'deployment lookup failure unexpectedly scaled a deployment' >&2
   exit 1
 fi
+
+# A deploy that ships no schema change must not touch the running deployments:
+# scaling the app to zero here is the 503 window with nothing to show for it.
+: >"$command_log"
+: >"$migration_log"
+: >"$pending_log"
+COMMAND_LOG="$command_log" \
+MIGRATION_LOG="$migration_log" \
+PENDING_LOG="$pending_log" \
+KUBECTL_BIN="$test_dir/kubectl" \
+NAMESPACE=lobu \
+APP_DEPLOYMENT=lobu-app \
+APP_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=api' \
+WORKER_DEPLOYMENT=lobu-worker \
+WORKER_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=worker' \
+MIGRATION_PENDING_CHECK="$test_dir/pending-check" \
+PENDING_EXIT_CODE=3 \
+  sh "$orchestrator" "$test_dir/migrate"
+
+if ! grep -Fxq 'pending-check' "$pending_log"; then
+  echo 'orchestrator never consulted the pending-migration check' >&2
+  exit 1
+fi
+grep -Fxq 'migrate' "$migration_log"
+if [ -s "$command_log" ]; then
+  echo 'no-pending-migration deploy unexpectedly ran kubectl:' >&2
+  cat "$command_log" >&2
+  exit 1
+fi
+
+# Fail closed: a check that cannot answer must still quiesce.
+: >"$command_log"
+: >"$migration_log"
+COMMAND_LOG="$command_log" \
+MIGRATION_LOG="$migration_log" \
+PENDING_LOG="$pending_log" \
+KUBECTL_BIN="$test_dir/kubectl" \
+NAMESPACE=lobu \
+APP_DEPLOYMENT=lobu-app \
+APP_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=api' \
+WORKER_DEPLOYMENT=lobu-worker \
+WORKER_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=worker' \
+MIGRATION_PENDING_CHECK="$test_dir/pending-check" \
+PENDING_EXIT_CODE=7 \
+  sh "$orchestrator" "$test_dir/migrate"
+
+grep -Fxq 'scale deployment lobu-app --replicas=0' "$command_log"
+grep -Fxq 'scale deployment lobu-worker --replicas=0' "$command_log"
+grep -Fxq 'migrate' "$migration_log"
+
+# A real pending migration still gets the full quiesce.
+: >"$command_log"
+: >"$migration_log"
+COMMAND_LOG="$command_log" \
+MIGRATION_LOG="$migration_log" \
+PENDING_LOG="$pending_log" \
+KUBECTL_BIN="$test_dir/kubectl" \
+NAMESPACE=lobu \
+APP_DEPLOYMENT=lobu-app \
+APP_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=api' \
+WORKER_DEPLOYMENT=lobu-worker \
+WORKER_SELECTOR='app.kubernetes.io/instance=lobu,app.kubernetes.io/component=worker' \
+MIGRATION_PENDING_CHECK="$test_dir/pending-check" \
+PENDING_EXIT_CODE=0 \
+  sh "$orchestrator" "$test_dir/migrate"
+
+grep -Fxq 'scale deployment lobu-app --replicas=0' "$command_log"
+grep -Fxq 'scale deployment lobu-worker --replicas=0' "$command_log"
+grep -Fxq 'migrate' "$migration_log"
 
 echo 'migration upgrade failure recovery passed'

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -328,10 +328,14 @@ healthCheck:
 migrations:
   enabled: false
   # Incompatible migrations cannot run while an old app or worker still uses
-  # the previous schema. Every migration upgrade records the current replica
-  # counts, scales both deployments to zero, and waits for their pods to
-  # terminate before migrating. A failed migration restores those counts;
-  # after success Helm applies the new release's configured replica counts.
+  # the previous schema. An upgrade first asks the schema_migrations ledger
+  # whether anything is pending (migrate-up.mjs --check-pending); if nothing
+  # is, the deployments keep serving and Helm rolls without downtime. When a
+  # migration is pending -- or the check cannot answer -- the upgrade records
+  # the current replica counts, scales both deployments to zero, and waits for
+  # their pods to terminate before migrating. A failed migration restores
+  # those counts; after success Helm applies the new release's configured
+  # replica counts.
   quiesceBeforeUpgrade:
     image: bitnami/kubectl@sha256:9e369df7ab3386b736d162348f167bcc02cb4ba3f5203e9151be854437d6e0af
     pullPolicy: IfNotPresent

--- a/scripts/__tests__/migrate-up-check-pending.test.ts
+++ b/scripts/__tests__/migrate-up-check-pending.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+const MIGRATE_UP = join(REPO_ROOT, "scripts/migrate-up.mjs");
+
+/** charts/lobu/files/migrate-upgrade.sh only skips its quiesce on this status. */
+const NOTHING_PENDING = 3;
+
+function runCheckPending(env: Record<string, string>) {
+  return Bun.spawnSync(["node", MIGRATE_UP, "--check-pending"], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+describe("migrate-up --check-pending", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "migrate-up-check-pending-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("fails closed when the ledger cannot be read", () => {
+    writeFileSync(
+      join(dir, "20260803140000_behavior_outputs.sql"),
+      "-- migrate:up\nSELECT 1;"
+    );
+
+    const result = runCheckPending({
+      DATABASE_URL: "postgres://postgres:postgres@127.0.0.1:1/unreachable",
+      MIGRATIONS_DIR: dir,
+    });
+
+    // An unreachable database must never read as "nothing pending" -- that is
+    // the status that lets the pre-upgrade hook skip its quiesce.
+    expect(result.exitCode).not.toBe(NOTHING_PENDING);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toMatch(
+      /could not determine pending migrations/i
+    );
+  });
+
+  it("fails closed when DATABASE_URL is missing", () => {
+    const result = runCheckPending({
+      DATABASE_URL: "",
+      MIGRATIONS_DIR: dir,
+    });
+
+    expect(result.exitCode).not.toBe(NOTHING_PENDING);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("fails closed on a duplicate migration version", () => {
+    writeFileSync(
+      join(dir, "20260803140000_behavior_outputs.sql"),
+      "-- migrate:up\nSELECT 1;"
+    );
+    writeFileSync(
+      join(dir, "20260803140000_mcp_client_id.sql"),
+      "-- migrate:up\nSELECT 1;"
+    );
+
+    const result = runCheckPending({
+      DATABASE_URL: "postgres://postgres:postgres@127.0.0.1:1/unreachable",
+      MIGRATIONS_DIR: dir,
+    });
+
+    expect(result.exitCode).not.toBe(NOTHING_PENDING);
+  });
+});

--- a/scripts/migrate-up.mjs
+++ b/scripts/migrate-up.mjs
@@ -10,11 +10,25 @@
  * Usage:
  *   DATABASE_URL=... node scripts/migrate-up.mjs
  *   MIGRATIONS_DIR=/app/db/migrations node scripts/migrate-up.mjs
+ *   DATABASE_URL=... node scripts/migrate-up.mjs --check-pending
+ *
+ * --check-pending applies nothing. It reports whether any migration file is
+ * missing from the ledger and encodes the answer in the exit status, so the
+ * chart's pre-upgrade hook can skip its scale-to-zero quiesce on the common
+ * deploy that ships no schema change:
+ *   0 - at least one migration is pending (the caller must quiesce)
+ *   3 - the ledger is complete, nothing is pending (safe to skip the quiesce)
+ *   1 - the answer could not be determined (the caller must quiesce)
+ * Only the definitive 3 unlocks the fast path; every other status, including a
+ * crash, leaves the caller quiescing.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import postgres from "postgres";
 
+const CHECK_PENDING_NONE_EXIT = 3;
+
+const checkPendingOnly = process.argv.slice(2).includes("--check-pending");
 const migrationsDir =
   process.env.MIGRATIONS_DIR || join(process.cwd(), "db/migrations");
 const databaseUrl = process.env.DATABASE_URL;
@@ -177,6 +191,37 @@ async function applyMigration(sqlClient, section, version) {
 const migrationFiles = listMigrationFiles(migrationsDir);
 const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
 let migrationLockHeld = false;
+
+if (checkPendingOnly) {
+  // Read-only: no ledger table creation and no advisory lock, so this can run
+  // while the old replicas are still serving. A version present in the ledger
+  // but absent from disk is not pending — only the other direction blocks.
+  let pending;
+  try {
+    const appliedRows = await sql.unsafe(
+      `SELECT version FROM public.schema_migrations`
+    );
+    const applied = new Set(appliedRows.map((r) => r.version));
+    pending = migrationFiles.filter(
+      (file) => !applied.has(file.split("_")[0] ?? "")
+    );
+  } catch (error) {
+    console.error(
+      `ERROR: could not determine pending migrations: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    await sql.end({ timeout: 1 }).catch(() => undefined);
+    process.exit(1);
+  }
+  await sql.end({ timeout: 1 }).catch(() => undefined);
+  if (pending.length === 0) {
+    console.log("No pending migrations");
+    process.exit(CHECK_PENDING_NONE_EXIT);
+  }
+  console.log(`Pending migrations (${pending.length}): ${pending.join(", ")}`);
+  process.exit(0);
+}
 
 try {
   await sql.unsafe(`


### PR DESCRIPTION
## Summary

- Every Helm upgrade scaled `app` and `worker` to **zero replicas** before running migrations, so Traefik answered `503` for the length of a pod restart — on every deploy, whether or not the deploy shipped a schema change.
- Measured on prod from `kube_deployment_status_replicas_available`: **63 zero-availability windows in 14 days, all of them on 2026-08-03 or later**, ~30–60s each. The quiesce hook landed in a1aa7f1 (#2461) at `18:52:12 UTC` on 08-03; the first zero-availability window is `18:53:30 UTC` — 78 seconds later. Zero windows in the 11 days before.
- The quiesce is only needed when a migration is actually pending. This makes it conditional, so the common no-schema-change deploy rolls normally under the chart's existing `maxSurge: 1 / maxUnavailable: 0` strategy.

`maxUnavailable: 0` never protected this path because `kubectl scale --replicas=0` is not a rolling update, and a PodDisruptionBudget does not apply to scale operations.

### Design

`scripts/migrate-up.mjs --check-pending` diffs the migration files against the `public.schema_migrations` ledger and encodes the answer in its exit status. It is strictly read-only: no ledger table creation, no advisory lock, so it runs while the old replicas still serve.

```
0 - at least one migration is pending (caller must quiesce)
3 - ledger complete, nothing pending  (safe to skip the quiesce)
1 - could not determine               (caller must quiesce)
```

`charts/lobu/files/migrate-upgrade.sh` **fails closed**: only the definitive `3` skips the quiesce. An unset check, a non-zero status, an unreachable database, or a crashed check all still quiesce. When it skips, it makes no kubectl calls at all.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit`, `sh charts/lobu/tests/migrate-upgrade-recovery.sh`, `bun test scripts/__tests__/migrate-up-check-pending.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red → green

New chart tests against the **`origin/main`** orchestrator (red) and this branch (green):

```
===== RED (origin/main orchestrator) =====
EXIT=1
restoring deployment lobu-worker to 3 replicas
all old database clients are quiesced; running migration
migration completed; Helm may apply the new deployments
orchestrator never consulted the pending-migration check

===== GREEN (this branch) =====
EXIT=0
no pending migrations; skipping quiesce so Helm can roll without downtime
pending-migration check failed with status 7; quiescing
all old database clients are quiesced; running migration
migration upgrade failure recovery passed
```

### Mutation check

Broke the fail-closed path so an unreadable ledger reports "nothing pending":

```
-    process.exit(1);
+    process.exit(CHECK_PENDING_NONE_EXIT);
```

```
expect(result.exitCode).not.toBe(NOTHING_PENDING);
error: expect(received).not.toBe(expected)
Expected: not 3
(fail) migrate-up --check-pending > fails closed when the ledger cannot be read
 2 pass, 1 fail
```

Reverted → 3 pass.

### Verified against the real prod ledger

Single read-only `SELECT` through the `lobu-ai-prod-db-r` replica:

```
A) real prod ledger + real db/migrations   -> "No pending migrations"          exit 3  (skip quiesce)
B) same ledger + one unapplied migration   -> "Pending migrations (1): ..."    exit 0  (quiesce)
```

Prod is confirmed `RollingUpdate maxSurge:1 maxUnavailable:0` with `app.workspaces.enabled: false`, so the skipped path rolls without dropping below 2 available replicas.

### CI wiring (from the `review-fix` pass)

`scripts/__tests__` is not covered by `make test-unit` (which enumerates package paths), so CI runs those files individually. The new test file was wired into nothing — and `migrate-up-duplicate-version.test.ts` turned out to be unwired for the same reason, so both are added in one pass:

- `ci.yml` gates job — **Migration runner guards**: runs both `scripts/__tests__` migration files.
- `ci.yml` migration-replay job — **Pending-check contract**: proves the real-database contract (exit 3 on the freshly-migrated ledger, exit 0 with one unapplied file) in the job that already applies every migration to a live Postgres.
- `helm-chart.yml` — render grep for `name: MIGRATION_PENDING_CHECK`; without it, dropping the env from the template would silently regress to always-quiesce via the shell's "not configured" path.

## Notes

Follow-ups deliberately **not** in this branch (separate concerns):

- Both `summaries-app-lobu-app` replicas are scheduled on the same node with no `topologySpreadConstraints` / `podAntiAffinity` — a single node loss removes 100% of capacity.
- Traefik runs without access logs (`--log.level=INFO` only), so 503s are not directly countable; the measurement above is from kube-state-metrics availability, not observed responses.

Post-merge verification owed: watch `kube_deployment_status_replicas_available{deployment="summaries-app-lobu-app"}` across the next deploy and confirm it never reaches 0.
