### PR TITLE
feat(chart): alert on zero available replicas and spread them across nodes

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -65,6 +65,25 @@ jobs:
           grep -q 'name: WORKER_SELECTOR' /tmp/lobu-worker-disabled-upgrade.yaml
           test "$(grep -c -- '- lobu-worker' /tmp/lobu-worker-disabled-upgrade.yaml)" -eq 2
 
+      - name: Availability hardening stays wired
+        # Both of these are silent when dropped: replicas would simply schedule
+        # onto one node again, and a short full outage would go back to firing
+        # nothing (every other availability alert carries `for: 15m`, which a
+        # ~40s outage can never satisfy — see lobu#2543).
+        run: |
+          helm template lobu charts/lobu --namespace lobu \
+            --set metrics.prometheusRule.enabled=true \
+            >/tmp/lobu-availability.yaml
+          grep -q 'topologySpreadConstraints:' /tmp/lobu-availability.yaml
+          grep -q 'topologyKey: kubernetes.io/hostname' /tmp/lobu-availability.yaml
+          grep -q 'alert: LobuAppNoAvailableReplicas' /tmp/lobu-availability.yaml
+          # A `for:` longer than the outage is exactly the bug this replaces.
+          if grep -A6 'alert: LobuAppNoAvailableReplicas' /tmp/lobu-availability.yaml \
+            | grep -qE '^\s+for: [1-9]'; then
+            echo "LobuAppNoAvailableReplicas must not carry a nonzero for: window" >&2
+            exit 1
+          fi
+
       - name: Exercise migration failure recovery
         run: sh charts/lobu/tests/migrate-upgrade-recovery.sh
 

--- a/charts/lobu/templates/deployment.yaml
+++ b/charts/lobu/templates/deployment.yaml
@@ -31,6 +31,15 @@ spec:
       {{- with .Values.app.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
       {{- end }}
+      {{- if .Values.app.topologySpread.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.app.topologySpread.maxSkew }}
+          topologyKey: {{ .Values.app.topologySpread.topologyKey }}
+          whenUnsatisfiable: {{ .Values.app.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "lobu.appSelectorLabels" . | nindent 14 }}
+      {{- end }}
       containers:
         - name: app
           image: {{ include "lobu.appImage" . }}

--- a/charts/lobu/templates/prometheusrule.yaml
+++ b/charts/lobu/templates/prometheusrule.yaml
@@ -14,6 +14,28 @@ metadata:
     {{- end }}
 spec:
   groups:
+    # Deploy-time availability. Every state-based availability alert in the
+    # stack (KubeDeploymentReplicasMismatch, KubePodNotReady,
+    # KubeDeploymentRolloutStuck, LobuAppRolloutStalled) carries `for: 15m`,
+    # so none of them can fire for a short full outage. lobu#2543: the
+    # pre-upgrade quiesce scaled the app to zero replicas on EVERY deploy for
+    # ~40s, 63 times over 14 days, and nothing alerted — it was found only
+    # because a human noticed intermittent 503s. Requires kube-state-metrics.
+    - name: lobu-availability
+      rules:
+        # min_over_time turns a brief EVENT into a condition that persists long
+        # enough to alert on, which a `for:` window fundamentally cannot do:
+        # `for` requires the outage to still be happening N minutes later.
+        - alert: LobuAppNoAvailableReplicas
+          expr: |
+            min_over_time(kube_deployment_status_replicas_available{namespace="{{ .Release.Namespace }}",deployment="{{ include "lobu.fullname" . }}-app"}[10m]) == 0
+          for: 0m
+          labels:
+            severity: critical
+            service: lobu
+          annotations:
+            summary: "Lobu app had zero available replicas in the last 10m"
+            description: "{{ include "lobu.fullname" . }}-app dropped to 0 available replicas, so the ingress served 503 for that window. Deploy-related unless a node was lost: check whether the pre-upgrade migration hook quiesced (kubectl logs job/{{ include "lobu.fullname" . }}-migrate) and whether it should have — it only quiesces when a migration is actually pending."
     - name: lobu-watchers
       rules:
         # Heartbeat / dead-man's-switch. The 12-day outage (lobu#1046) was a

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -149,6 +149,19 @@ app:
     size: 20Gi
     storageClass: ""
 
+  # Keep replicas off a single node. Without this the scheduler is free to put
+  # every replica on one node, where one node loss removes all capacity and the
+  # PodDisruptionBudget cannot help (it does not apply to node failure).
+  # ScheduleAnyway is deliberate: a hard DoNotSchedule would leave a replica
+  # unschedulable when the only other node is cordoned or full, trading a
+  # colocation risk for a guaranteed capacity loss. Soft spreads whenever the
+  # cluster can and degrades to colocation rather than to nothing.
+  topologySpread:
+    enabled: true
+    topologyKey: kubernetes.io/hostname
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+
 # Worker deployment settings
 worker:
   enabled: true


### PR DESCRIPTION
## Summary

Follow-up to #2543. That PR stopped the app being scaled to zero on every deploy; this one addresses the two reasons it went unnoticed for three days and the reason it could have been worse.

- **Nothing in the cluster could detect it.** Every availability alert carries `for: 15m` — `KubeDeploymentReplicasMismatch`, `KubePodNotReady`, `KubeDeploymentRolloutStuck`, and `LobuAppRolloutStalled` (`deploy-rules.yaml:57`). The outages were **~40 seconds**, so none of them could fire. The app hit zero available replicas 63 times in 14 days and alerted nothing; it was found only because a human noticed intermittent 503s.
- **Both app replicas schedule onto the same node.** No `topologySpreadConstraints`, no `podAntiAffinity`. One node loss removes 100% of capacity, and the PDB cannot help — it does not apply to node failure.

### `LobuAppNoAvailableReplicas`

A `for:` window fundamentally cannot catch a brief outage: it requires the condition to *still hold* N minutes later. `min_over_time(...[10m]) == 0` instead turns the brief **event** into a condition that persists long enough to alert on.

Backtested against 14 days of real Prometheus data in `summaries-prod`:

```
FIRES     @ 2026-08-06T02:36:00Z  (during known outage 02:34:30)
silent    @ 2026-08-06T01:00:00Z  (quiet period)
FIRES     @ 2026-08-05T23:10:00Z  (during known outage 23:08:00)
silent    @ 2026-08-05T10:00:00Z  (quiet period)
```

Complements rather than duplicates `LobuAppRolloutStalled`: that one is warning-level for a *stuck* rollout, this is critical for a *total* outage.

### `topologySpread`

`whenUnsatisfiable: ScheduleAnyway` is deliberate. A hard `DoNotSchedule` would leave a replica unschedulable whenever the only other node is cordoned or full — trading a colocation risk for a guaranteed capacity loss. Soft spreads whenever the cluster can and degrades to colocation rather than to nothing.

## Test plan

- [x] `make pre-pr` clean (verified by output content — `pre-pr gates clean` — not by exit code)
- [x] Tests run: `helm template` render + parse, CI assertion block executed locally
- [x] Bug fix: red→green below
- [ ] If bot behavior: not applicable

### The CI assertions catch the regressions

Both additions are silent when dropped — replicas would just schedule onto one node again, and a short outage would go back to firing nothing. So the guards are themselves tested:

```
=== GREEN: current chart ===        PASS
=== RED 1: topologySpread disabled ===  MISS topologySpreadConstraints
=== RED 2: prometheusRule disabled ===  MISS alert
=== RED 3: mutate for: 0m -> for: 15m === guard CAUGHT the nonzero for: window
```

RED 3 matters most: a `for:` window longer than the outage is *exactly* the bug being replaced, so the guard refuses to let the new alert acquire one.

### Render

```
topologySpreadConstraints:
- labelSelector:
    matchLabels:
      app.kubernetes.io/component: api
      app.kubernetes.io/instance: summaries-app
      app.kubernetes.io/name: lobu
  maxSkew: 1
  topologyKey: kubernetes.io/hostname
  whenUnsatisfiable: ScheduleAnyway

alert: LobuAppNoAvailableReplicas | for: 0m
  expr: min_over_time(kube_deployment_status_replicas_available{namespace="summaries-prod",deployment="summaries-app-lobu-app"}[10m]) == 0
```

The selector matches the app pod template labels key-for-key, so the constraint is not vacuous.

## Notes

**Nothing here reaches prod until the chart version bumps.** The HelmChart uses `reconcileStrategy: ChartVersion` and its artifact is still packaged at `14.14.0`, so Flux renders the pre-fix chart even though the GitRepository already has `8c5d46f`. This is why #2543 is merged but **not yet live** — verified empirically: the 03:28 rollout still scaled to zero. Release PR #2487 (`14.15.0`) is what unparks both PRs.

That gating is itself worth fixing separately: a chart change that looks merged and silently does not deploy is the same class of problem as this whole incident. Switching to `reconcileStrategy: Revision` would deploy chart commits on merge — best sequenced *after* the quiesce fix is actually live, since it increases upgrade frequency.

Deliberately **not** changed:
- The PrometheusRule is still named `{{ fullname }}-watchers` despite now carrying a `lobu-availability` group. Renaming deletes/recreates the CR on upgrade, resetting the `for:` clock on any pending watcher alert — a real operational cost for a cosmetic gain.
- `strategy: Recreate` when `app.workspaces.enabled`. I initially flagged this as a latent downtime trap; it isn't. The workspaces PVC is `ReadWriteOnce`, so old and new pods cannot mount it simultaneously and `Recreate` is required for correctness.

Known limitations:
- `min_over_time == 0` cannot fire if kube-state-metrics itself stops reporting (`TargetDown` covers that).
- The alert will fire once on a genuinely fresh install, during the ~10m window where available=0 before first boot completes.
