### PR TITLE
fix(server): honour an explicit provider/model ref from any config layer

### DIFF
--- a/packages/server/src/gateway/__tests__/platform-helpers-model-resolution.test.ts
+++ b/packages/server/src/gateway/__tests__/platform-helpers-model-resolution.test.ts
@@ -284,3 +284,102 @@ describe("resolveAgentId", () => {
     expect(createCount).toBe(0);
   });
 });
+
+/**
+ * Routing must honour an explicit `<provider>/<model>` ref whatever LAYER supplied it.
+ *
+ * The worker only reroutes away from the gateway's `defaultProvider` when
+ * `allowInstalledProviderOverride` is set, and that flag is
+ * `rawOptions.behaviorModelOverride === true` (agent-worker
+ * `runtime/session-runner.ts`). Dispatch sites set `behaviorModelOverride` only
+ * alongside an explicit per-run override (e.g. the request body in
+ * `gateway/routes/public/agent.ts`) — but the layered fallback runs AFTER that,
+ * and resolves an equally explicit ref out of `agent.models[0]` or the org
+ * default. Nothing re-derived the flag, so an agent-level provider choice was
+ * silently dropped for routing.
+ *
+ * Measured on prod 2026-08-06: org `buremba` had agent `personal-agent` pinned to
+ * `gemini/gemini-2.5-pro`, no Behavior override, and NO z-ai provider, secret, or
+ * system key of its own — yet 79 runs over three days failed with
+ * `z.ai returned an error: 429 Insufficient balance`. Setting a per-Behavior
+ * `execution_config.model` (which flips the flag) fixed it immediately: 4/4 runs
+ * completed against prior success rates of 19% and 41%. That is the natural
+ * experiment this test pins.
+ */
+describe("explicit model refs mark the routing override", () => {
+  const storeWith = (models: string[]) =>
+    ({ getSettings: async () => ({ models }) as any }) as any;
+
+  test("an agent-level <provider>/<model> ref marks the override", async () => {
+    const resolved = await resolveAgentOptions(
+      "agent-1",
+      {},
+      storeWith(["gemini/gemini-2.5-pro"]),
+      "org-1",
+    );
+
+    expect(resolved.model).toBe("gemini/gemini-2.5-pro");
+    // Without this the worker ignores the `gemini/` prefix and routes to
+    // whatever module the gateway published as `defaultProvider`.
+    expect(resolved.behaviorModelOverride).toBe(true);
+  });
+
+  test("a per-behavior override still marks the override", async () => {
+    const resolved = await resolveAgentOptions(
+      "agent-1",
+      { model: "qwen/qwen3.8-max-preview", behaviorModelOverride: true },
+      storeWith(["gemini/gemini-2.5-pro"]),
+      "org-1",
+    );
+
+    expect(resolved.model).toBe("qwen/qwen3.8-max-preview");
+    expect(resolved.behaviorModelOverride).toBe(true);
+  });
+
+  // The flag authorizes rerouting to an explicitly NAMED provider. A ref with no
+  // provider segment names none, so it must not authorize anything — the worker
+  // would have nothing to route to and would fall through to defaultProvider
+  // anyway, but claiming an override we cannot honour is a lie in the payload.
+  test("an unqualified agent model does NOT mark the override", async () => {
+    const resolved = await resolveAgentOptions(
+      "agent-1",
+      {},
+      storeWith(["gpt-4o"]),
+      "org-1",
+    );
+
+    expect(resolved.model).toBe("gpt-4o");
+    expect(resolved.behaviorModelOverride).toBeUndefined();
+  });
+
+  // A malformed per-request override is dropped in favour of the agent default
+  // (existing behaviour). The flag must follow the ref that actually WON, not the
+  // one that was rejected.
+  test("a rejected 'auto' override falls back and marks the agent ref", async () => {
+    const resolved = await resolveAgentOptions(
+      "agent-1",
+      { model: "auto", behaviorModelOverride: true },
+      storeWith(["gemini/gemini-2.5-pro"]),
+      "org-1",
+    );
+
+    expect(resolved.model).toBe("gemini/gemini-2.5-pro");
+    expect(resolved.behaviorModelOverride).toBe(true);
+  });
+
+  // The clearing branch: a rejected override arrives with the flag already true,
+  // and the winning fallback ref names no provider. Merely spreading baseOptions
+  // would leave the stale `true` authorizing a ref that cannot be routed — the
+  // flag must be cleared along with the rejected override.
+  test("a rejected override does NOT leave a stale flag on an unqualified fallback", async () => {
+    const resolved = await resolveAgentOptions(
+      "agent-1",
+      { model: "auto", behaviorModelOverride: true },
+      storeWith(["gpt-4o"]),
+      "org-1",
+    );
+
+    expect(resolved.model).toBe("gpt-4o");
+    expect(resolved.behaviorModelOverride).toBeUndefined();
+  });
+});

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -16,6 +16,26 @@ import type { BehaviorSubscriptionService } from "../channels/behavior-subscript
 const logger = createLogger("platform-helpers");
 
 /**
+ * Does this string name a provider AND a model, i.e. `<provider>/<model>`?
+ *
+ * The single shape test for both things that depend on it: whether a per-request
+ * override is well-formed enough to win, and whether the resolved ref authorizes
+ * the worker to route away from the gateway's `defaultProvider`. They were one
+ * inlined expression and one missing check; a ref either names its provider or
+ * it does not, and both callers need the same answer.
+ *
+ * `auto` is rejected as the model half: it is gone repo-wide, and a legacy
+ * `<provider>/auto` binding names no concrete model to route.
+ */
+function isQualifiedModelRef(ref: string | undefined): boolean {
+  if (!ref) return false;
+  const slash = ref.indexOf("/");
+  return (
+    slash > 0 && slash < ref.length - 1 && ref.slice(slash + 1) !== "auto"
+  );
+}
+
+/**
  * Resolve agent options by merging base options with per-agent settings.
  * Priority: agent settings > config defaults.
  */
@@ -56,13 +76,7 @@ export async function resolveAgentOptions(
   // gate (deployment-manager backstop) still validates the resulting ref.
   const rawOverride =
     typeof baseOptions.model === "string" ? baseOptions.model.trim() : "";
-  const overrideSlash = rawOverride.indexOf("/");
-  const behaviorOverride =
-    overrideSlash > 0 &&
-    overrideSlash < rawOverride.length - 1 &&
-    rawOverride.slice(overrideSlash + 1) !== "auto"
-      ? rawOverride
-      : "";
+  const behaviorOverride = isQualifiedModelRef(rawOverride) ? rawOverride : "";
   if (rawOverride && !behaviorOverride) {
     logger.warn(
       { agentId, rejectedOverride: rawOverride },
@@ -85,6 +99,34 @@ export async function resolveAgentOptions(
     mergedOptions.model = effectiveModelRef;
   } else {
     delete mergedOptions.model;
+  }
+
+  // Routing honours an explicit `<provider>/<model>` ref only when the payload
+  // authorizes it: the worker's model-resolver reroutes away from the gateway's
+  // `defaultProvider` solely under `allowInstalledProviderOverride`, which is
+  // `rawOptions.behaviorModelOverride === true` (agent-worker
+  // `runtime/session-runner.ts`). Dispatch sites set that flag only alongside an
+  // explicit per-run override (request-body `model`, tool `args.model`, Behavior
+  // `execution_config.model`) — i.e. BEFORE the layered fallback above has run —
+  // and the platform paths (message-handler-bridge, chat-instance-manager) never
+  // set it at all. So a ref that is just as explicit, but arrived from
+  // `agent.models[0]` or the org default, never authorized anything, and the run
+  // was routed to whatever module the gateway published as `defaultProvider` via
+  // its credentialed fallback scan.
+  //
+  // Prod 2026-08-06: org `buremba` pinned its agent to `gemini/gemini-2.5-pro`,
+  // set no per-Behavior override, and had no z-ai provider, secret or system key
+  // of its own — yet 79 runs in three days died on `z.ai 429 Insufficient
+  // balance`. Adding a per-Behavior override (which flips this flag) fixed it
+  // outright. The layer a ref came from was never supposed to change where it
+  // routes, so re-derive the flag from the ref that actually WON.
+  //
+  // Cleared, not just set: a rejected malformed override must not leave a stale
+  // `true` authorizing a fallback ref that names no provider at all.
+  if (isQualifiedModelRef(effectiveModelRef)) {
+    mergedOptions.behaviorModelOverride = true;
+  } else {
+    delete mergedOptions.behaviorModelOverride;
   }
 
   if (settings.networkConfig) {


### PR DESCRIPTION
## Summary

- The worker reroutes away from the gateway's `defaultProvider` **only** under `allowInstalledProviderOverride` = `rawOptions.behaviorModelOverride` (`agent-worker/src/runtime/session-runner.ts:812`). Dispatch sites set that flag only alongside an explicit per-run override — request-body `model`, tool `args.model`, Behavior `execution_config.model` — i.e. **before** `resolveAgentOptions` runs its layered fallback. Two of the five callers never set it at all.
- So a ref that is just as explicit, but resolved out of `agent.models[0]` or the org default, authorized nothing. The run was routed to whichever module the gateway published as `defaultProvider` via its credentialed fallback scan, **silently discarding the provider the org actually chose**.
- `resolveAgentOptions` now re-derives the flag from the ref that actually won. The layer a ref arrived from was never supposed to change where it routes.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: 894 unit (`make test-unit`, exit 0), 332 files / 2910 tests integration (exit 0), 19 targeted
- [x] Bug fix: red→fix→green outputs pasted below

### The reproducer is a prod A/B I ran by accident

Org `buremba`, agent `personal-agent` pinned to `gemini/gemini-2.5-pro`, no Behavior override, and **no z-ai provider row, secret, or system key anywhere in the org**:

```
watcher_id  status     n   error
5           failed     39  z.ai returned an error: 429 Insufficient balance or no resource package
5           completed  10
71          failed     40  z.ai returned an error: 429 Insufficient balance or no resource package
71          completed  31
```

Setting a per-Behavior `execution_config.model` — the one thing that flips this flag — fixed it outright:

```
865580  behavior 5   completed
865583  behavior 71  completed
865618  behavior 5   completed
865622  behavior 71  completed
```

4/4 against prior success rates of 19% and 41%; P(luck) ≈ 0.6%.

### Red → green

With the re-derivation removed:

```
(fail) an agent-level <provider>/<model> ref marks the override
(fail) a rejected override does NOT leave a stale flag on an unqualified fallback
 17 pass  2 fail
```

Restored — one failure per branch, so both the set and the clear path are pinned:

```
 19 pass  0 fail
```

## Notes

**Why the flag is cleared as well as set.** A rejected malformed override (`auto`, or a bare model id) must not leave a stale `true` authorizing a fallback ref that names no provider at all.

**Rerouting stays fail-safe at the worker.** `model-resolver.ts` only reroutes when the prefix names an **installed** provider route, so an uninstalled prefix falls through exactly as before. I audited every `agents.models` ref on prod against that org's installed provider slugs:

| prefix | refs | installed | example |
|---|---|---|---|
| gemini | 4 | yes | `gemini/gemini-2.5-flash` |
| qwen | 4 | yes | `qwen/qwen3.8-max` |
| openrouter | 4 | yes | `openrouter/anthropic/claude-sonnet-5` |
| z-ai | 2 | no | `z-ai/glm-5.2` |
| openai | 2 | yes | `openai/gpt-4o-mini` |
| nvidia / deepseek-ai / deepseek | 1 each | no | — |
| xai | 1 | yes | `xai/grok-4` |

Every stored prefix is a real Lobu provider slug, and the OpenRouter ref keeps its `openrouter/` prefix — so the foreign-namespace ambiguity the worker documents (`anthropic/claude-sonnet-4` meaning *OpenRouter's* model) is not reachable from prod data. Uninstalled prefixes (`z-ai`, `nvidia`, `deepseek*`) cannot reroute and behave as today.

**Caller-side assignments deliberately left in place.** They remain correct for direct-queue dispatch. Removing them would require proving every queue consumer re-resolves, which I have not done, and getting it wrong regresses the per-Behavior override path currently working in prod.

### Follow-up, not in this PR

`deployment-manager.ts` `if (!primaryProvider)` accepts `candidate.hasSystemKey()` in its fallback scan, so a deployment-wide key can make a provider primary for an org that never configured it. That is very likely how `z-ai` became `defaultProvider` here, and it deserves its own fix rather than being conflated with this one.