### PR TITLE
fix(charts): scope the app topology spread to one ReplicaSet revision

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -76,6 +76,12 @@ jobs:
             >/tmp/lobu-availability.yaml
           grep -q 'topologySpreadConstraints:' /tmp/lobu-availability.yaml
           grep -q 'topologyKey: kubernetes.io/hostname' /tmp/lobu-availability.yaml
+          # Without matchLabelKeys the constraint renders, passes every other
+          # assertion, and intermittently colocates every replica anyway -- it
+          # computes skew against the outgoing revision's pods. That is how it
+          # shipped in 14.15.0, where it held both replicas on one node for 76
+          # minutes and then spread correctly on the next two rollouts.
+          grep -q 'pod-template-hash' /tmp/lobu-availability.yaml
           grep -q 'alert: LobuAppNoAvailableReplicas' /tmp/lobu-availability.yaml
           # A `for:` longer than the outage is exactly the bug this replaces.
           if grep -A6 'alert: LobuAppNoAvailableReplicas' /tmp/lobu-availability.yaml \

--- a/charts/lobu/templates/deployment.yaml
+++ b/charts/lobu/templates/deployment.yaml
@@ -36,6 +36,20 @@ spec:
         - maxSkew: {{ .Values.app.topologySpread.maxSkew }}
           topologyKey: {{ .Values.app.topologySpread.topologyKey }}
           whenUnsatisfiable: {{ .Values.app.topologySpread.whenUnsatisfiable }}
+          # Scope the skew calculation to one ReplicaSet revision. The selector
+          # below matches on component/instance/name, which the OUTGOING
+          # revision's pods also carry, so during a rolling update the
+          # scheduler counts pods that are about to terminate. Whether the new
+          # revision lands spread then depends on how termination interleaves
+          # with scheduling -- it is intermittent, not a guaranteed failure.
+          # Measured in prod on 2026-08-06 with the unscoped constraint live
+          # (kube_pod_info, 3 consecutive rollouts): the 02:34 rollout put both
+          # replicas on node 13b25e5d and left them there for 76 minutes, while
+          # the 03:50 and 04:31 rollouts happened to spread correctly. Because
+          # whenUnsatisfiable is ScheduleAnyway the bad outcome is never
+          # reported, so the constraint looks applied either way.
+          matchLabelKeys:
+            - pod-template-hash
           labelSelector:
             matchLabels:
               {{- include "lobu.appSelectorLabels" . | nindent 14 }}

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -156,6 +156,13 @@ app:
   # unschedulable when the only other node is cordoned or full, trading a
   # colocation risk for a guaranteed capacity loss. Soft spreads whenever the
   # cluster can and degrades to colocation rather than to nothing.
+  # The template pairs this with matchLabelKeys: [pod-template-hash]. That is
+  # load-bearing, not a refinement: without it the skew domain includes the
+  # OUTGOING ReplicaSet during a rolling update, so whether the new revision
+  # ends up spread depends on how old-pod termination interleaves with new-pod
+  # scheduling. It is intermittent, not a guaranteed failure -- which is the
+  # trap. A rollout that happens to spread is not evidence the scoping is
+  # unnecessary, and ScheduleAnyway means the bad outcome never reports.
   topologySpread:
     enabled: true
     topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Summary
- The `topologySpreadConstraints` shipped in 14.15.0 renders correctly but **only works by luck**. Its `labelSelector` matches name/instance/component, which the *outgoing* revision's pods also carry, so during a rolling update the scheduler counts pods that are about to terminate. Whether the new revision lands spread depends on how termination interleaves with scheduling.
- `matchLabelKeys: [pod-template-hash]` restricts the skew domain to the incoming ReplicaSet, making the spread deterministic.
- The CI guard now asserts `pod-template-hash` renders, because every other assertion in that step passes without it.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [ ] Tests run — n/a, chart-template + CI-guard change; covered by the Helm Chart workflow below
- [x] Bug fix: red→fix→green outputs pasted below

### Live-cluster evidence

Measured with `kube_pod_info` over three consecutive rollouts on 2026-08-06, with the **unscoped** constraint live:

| rollout | placement |
|---|---|
| 02:34 | **both replicas on node `13b25e5d`** — held for 76 min (02:35–03:51) |
| 03:50 | spread 1/1 |
| 04:31 | spread 1/1 |

Both worker nodes were `Ready` and under 10% CPU throughout, so the scheduler had a free node during the 02:34 rollout and chose not to use it.

The important part is that this is **intermittent, not deterministic** — which is the trap. `whenUnsatisfiable: ScheduleAnyway` never reports the bad outcome, so a rollout that happens to spread looks like proof the constraint works. Two of the three above would have "passed" a spot check.

### Red → green (the CI guard)

Because the constraint is inert-but-plausible, the reproducer runs against the guard itself.

**Red** — render `origin/main`'s chart (`git archive origin/main charts/lobu`) and run the "Availability hardening stays wired" step:

```
topologySpreadConstraints:          PRESENT   <- old assertions all PASS
topologyKey: kubernetes.io/hostname PRESENT
pod-template-hash:                  MISSING   <- new guard FAILS
```

**Green** — same step against this branch: all assertions including `pod-template-hash` pass, `for:` check passes, `helm lint` clean. `pod-template-hash` appears exactly once in the rendered output (the field, not a comment), so the assertion is real.

### API support

Verified rather than assumed: `matchLabelKeys` is beta-on-by-default since k8s 1.27, prod is k3s v1.32.8, and `kubectl patch deploy summaries-app-lobu-app --dry-run=server` round-trips the field intact against the real API server (live deployment confirmed unchanged).

## Notes
Per `reconcileStrategy: ChartVersion`, this chart change is **inert in prod until the next release-please version bump past 14.15.0** — the prod-verify gate must wait on that release rolling out, not on this merge. Merging also does not relocate the current pods; scheduling is decided once at placement time.

Post-merge verification caveat, stated up front: because the unfixed behaviour spreads correctly *some* of the time, observing a spread after the next rollout does **not** by itself prove the fix works. The deterministic check is that the applied Deployment spec contains `matchLabelKeys: [pod-template-hash]`; the spread observation is a necessary consistency check, not proof of causation.