### PR TITLE
fix(server): let an explicit model ref outrank the deployment default provider

### DIFF
--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -75,13 +75,12 @@ describe("resolveModelRef", () => {
     expect(result.modelId).toBe("anthropic/claude-sonnet-4");
   });
 
-  test("behavior override switches to another installed provider", () => {
+  test("an explicit ref switches to another installed provider", () => {
     const result = resolveModelRef("z-ai/glm-5.2", {
       defaultModel: "claude/claude-sonnet-4-5",
       defaultProvider: "anthropic",
       defaultProviderSlug: "claude",
       installedProviderRoutes: { claude: "anthropic", "z-ai": "z-ai" },
-      allowInstalledProviderOverride: true,
     });
 
     expect(result.provider).toBe("z-ai");
@@ -89,30 +88,60 @@ describe("resolveModelRef", () => {
     expect(result.modelId).toBe("glm-5.2");
   });
 
-  test("behavior override resolves auto against the selected installed provider", () => {
+  test("an explicit ref resolves auto against the selected installed provider", () => {
     const result = resolveModelRef("z-ai/auto", {
       defaultModel: "claude/claude-sonnet-4-5",
       defaultProvider: "anthropic",
       defaultProviderSlug: "claude",
       installedProviderRoutes: { claude: "anthropic", "z-ai": "z-ai" },
-      allowInstalledProviderOverride: true,
     });
 
     expect(result.provider).toBe("z-ai");
     expect(result.modelId).toBe(DEFAULT_PROVIDER_MODELS["z-ai"]);
   });
 
-  test("behavior override routes a Lobu provider ID to its upstream runtime slug", () => {
+  test("an explicit ref routes a Lobu provider ID to its upstream runtime slug", () => {
     const result = resolveModelRef("claude/claude-sonnet-4-5", {
       defaultModel: "z-ai/glm-5.2",
       defaultProvider: "z-ai",
       installedProviderRoutes: { claude: "anthropic", "z-ai": "z-ai" },
-      allowInstalledProviderOverride: true,
     });
 
     expect(result.provider).toBe("anthropic");
     expect(result.providerSlug).toBe("claude");
     expect(result.modelId).toBe("claude-sonnet-4-5");
+  });
+
+  test("an agent-level ref routes to its own provider, not the deployment default", () => {
+    // Prod 2026-08-06 (org `buremba`): the agent was pinned to
+    // `gemini/gemini-2.5-pro` with no per-Behavior override, yet the gateway
+    // published `z-ai` as `defaultProvider` from its credentialed fallback
+    // scan — and 79 runs in three days died on `z.ai 429 Insufficient balance`
+    // for an org that has no z-ai provider, secret or key of its own.
+    // `defaultProvider` is a deployment-level fact; the ref is a run-level one.
+    // The ref wins whenever its prefix names an installed provider.
+    const result = resolveModelRef("gemini/gemini-2.5-pro", {
+      defaultModel: "gemini/gemini-2.5-pro",
+      defaultProvider: "z-ai",
+      installedProviderRoutes: { gemini: "gemini", openai: "openai" },
+    });
+
+    expect(result.provider).toBe("gemini");
+    expect(result.providerSlug).toBe("gemini");
+    expect(result.modelId).toBe("gemini-2.5-pro");
+  });
+
+  test("an uninstalled prefix still falls through to the configured provider", () => {
+    // The installed-route guard is what keeps rerouting fail-safe: `z-ai` is
+    // not installed here, so the ref cannot conjure a provider the org never
+    // configured.
+    const result = resolveModelRef("z-ai/glm-5.2", {
+      defaultProvider: "qwen",
+      installedProviderRoutes: { qwen: "qwen" },
+    });
+
+    expect(result.provider).toBe("qwen");
+    expect(result.modelId).toBe("z-ai/glm-5.2");
   });
 
   test("falls back to overrides.defaultModel when rawModelRef is empty", () => {
@@ -168,30 +197,53 @@ describe("resolveModelRef", () => {
     expect(result.modelId).toBe("anthropic/claude-sonnet-4");
   });
 
-  test("base model stays on OpenRouter when its vendor prefix is also an installed provider", () => {
-    const result = resolveModelRef("openai/gpt-4o", {
-      defaultModel: "openai/gpt-4o",
-      defaultProvider: "openrouter",
-      installedProviderRoutes: { openrouter: "openrouter", openai: "openai" },
+  test("an OpenRouter ref keeps its own prefix and its vendor namespace intact", () => {
+    // How Lobu actually stores an OpenRouter model: "<lobu-slug>/<model>", so
+    // the vendor namespace rides INSIDE the ref. This is why a bare vendor
+    // prefix is never ambiguous — an OpenRouter ref always says so up front.
+    // Verified against every `agents.models` ref on prod 2026-08-06.
+    const result = resolveModelRef("openrouter/openai/gpt-4o", {
+      defaultModel: "qwen/qwen3.8-max",
+      defaultProvider: "qwen",
+      installedProviderRoutes: { openrouter: "openrouter", qwen: "qwen" },
     });
 
     expect(result.provider).toBe("openrouter");
-    // Regression guard: this case asserted only provider/modelId, so a CTA
-    // misattribution to "openai" passed green here. OpenRouter serves this
-    // model, so OpenRouter owns the CTA.
+    // Regression guard: asserting only provider/modelId let a CTA
+    // misattribution pass green here. OpenRouter serves this model, so
+    // OpenRouter owns the CTA.
     expect(result.providerSlug).toBe("openrouter");
     expect(result.modelId).toBe("openai/gpt-4o");
   });
 
-  test("OpenRouter vendor model changes do not switch providers without an explicit behavior signal", () => {
-    const result = resolveModelRef("openai/gpt-4o-mini", {
-      defaultModel: "openai/gpt-4o",
+  test("the same OpenRouter ref stays put when OpenRouter is also the default", () => {
+    const result = resolveModelRef("openrouter/openai/gpt-4o", {
+      defaultModel: "openrouter/openai/gpt-4o",
       defaultProvider: "openrouter",
       installedProviderRoutes: { openrouter: "openrouter", openai: "openai" },
     });
 
     expect(result.provider).toBe("openrouter");
-    expect(result.modelId).toBe("openai/gpt-4o-mini");
+    expect(result.modelId).toBe("openai/gpt-4o");
+  });
+
+  test("a bare vendor prefix naming an installed provider routes to that provider", () => {
+    // "openai/gpt-4o-mini" is a Lobu ref for the installed OpenAI provider, not
+    // OpenRouter's namespace — OpenRouter's would be
+    // "openrouter/openai/gpt-4o-mini". The installed route is what it means.
+    const result = resolveModelRef("openai/gpt-4o-mini", {
+      defaultModel: "qwen/qwen3.8-max",
+      defaultProvider: "qwen",
+      installedProviderRoutes: {
+        openrouter: "openrouter",
+        openai: "openai",
+        qwen: "qwen",
+      },
+    });
+
+    expect(result.provider).toBe("openai");
+    expect(result.providerSlug).toBe("openai");
+    expect(result.modelId).toBe("gpt-4o-mini");
   });
 
   test("configured provider: a redundant self-prefix is stripped (z-ai/glm-4.7 → glm-4.7)", () => {
@@ -399,43 +451,33 @@ describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
 });
 
 describe("resolveModelRef — providerSlug must describe the REQUESTED model", () => {
-  test("an explicitly-prefixed model keeps its OWN slug, not the default provider's", () => {
+  test("an explicitly-prefixed model routes AND attributes to its own provider", () => {
     // Observed live: agent models = ["gemini/gemini-2.5-flash"], but the
     // session context published defaultProvider="openai" (the gateway's
-    // "first credentialed module" scan). The old code took the
-    // `if (defaultProvider)` branch and returned providerSlug="openai", so the
-    // failure CTA linked to `inference-provider:openai` while the `?model=`
-    // param correctly said `gemini/gemini-2.5-flash` — sending the user to
-    // connect the WRONG provider.
+    // "first credentialed module" scan). Attribution used to be the only thing
+    // corrected here — the run still RAN on openai, which is the mis-routing
+    // this resolver now refuses. gemini is installed, so the ref wins outright
+    // and the CTA follows it.
     const result = resolveModelRef("gemini/gemini-2.5-flash", {
       defaultProvider: "openai",
       defaultProviderSlug: "openai",
       // The gateway could NOT match this model to a provider, so its
-      // credentialed-fallback scan published openai. That is exactly what
-      // `defaultProviderServesModel: false` reports — openai does not serve
-      // the requested model, so it must not own the failure CTA.
+      // credentialed-fallback scan published openai.
       defaultProviderServesModel: false,
-      // gemini IS installed here — it just has no usable key, which is why the
-      // gateway fell back to publishing openai as defaultProvider.
       installedProviderRoutes: { openai: "openai", gemini: "gemini" },
     });
 
-    // The CTA must name the provider the run ASKED for.
+    expect(result.provider).toBe("gemini");
     expect(result.providerSlug).toBe("gemini");
-    // Routing itself is unchanged (the gateway owns that decision) and the ref
-    // keeps its namespace — stripping a FOREIGN prefix here would break
-    // OpenRouter-style refs like "anthropic/claude-sonnet-4".
-    expect(result.provider).toBe("openai");
-    expect(result.modelId).toBe("gemini/gemini-2.5-flash");
+    expect(result.modelId).toBe("gemini-2.5-flash");
   });
 
-  test("a SERVING provider keeps the CTA even when the prefix names another installed provider", () => {
-    // The mirror of the fallback case above, and why an installed-provider
-    // match cannot decide attribution on its own. OpenRouter is configured AND
-    // serves this model; "openai" here is OpenRouter's vendor namespace, not a
-    // request for the OpenAI provider — even though standalone OpenAI is also
-    // installed and the prefix matches it.
-    const result = resolveModelRef("openai/gpt-4o", {
+  test("a SERVING provider keeps the CTA even when its model names another installed provider", () => {
+    // Why an installed-provider match cannot decide attribution on its own.
+    // OpenRouter is configured AND serves this model; the "openai" inside the
+    // ref is OpenRouter's vendor namespace, not a request for the OpenAI
+    // provider — even though standalone OpenAI is also installed.
+    const result = resolveModelRef("openrouter/openai/gpt-4o", {
       defaultProvider: "openrouter",
       defaultProviderSlug: "openrouter",
       // The gateway MATCHED the model to OpenRouter.
@@ -487,14 +529,17 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
   test("an older gateway (field absent) keeps the pre-existing attribution", () => {
     // Back-compat: a gateway that predates `defaultProviderServesModel` sends
     // nothing. Absent must mean "serves" so a stale gateway keeps today's
-    // behavior instead of acquiring a NEW misattribution.
-    const result = resolveModelRef("openai/gpt-4o", {
-      defaultProvider: "openrouter",
-      defaultProviderSlug: "openrouter",
-      installedProviderRoutes: { openai: "openai", openrouter: "openrouter" },
+    // behavior instead of acquiring a NEW misattribution. Exact mirror of the
+    // `defaultModel` case above, which reattributes to gemini on `serves:
+    // false` — drop the field and the default provider keeps the CTA.
+    const result = resolveModelRef("", {
+      defaultModel: "gemini/gemini-2.5-flash",
+      defaultProvider: "openai",
+      defaultProviderSlug: "openai",
+      installedProviderRoutes: { openai: "openai", gemini: "gemini" },
     });
 
-    expect(result.providerSlug).toBe("openrouter");
+    expect(result.providerSlug).toBe("openai");
   });
 
   test("a bare model id still inherits the configured default provider", () => {

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -208,7 +208,6 @@ export function resolveModelRef(
     defaultProvider?: string;
     defaultProviderSlug?: string;
     installedProviderRoutes?: Record<string, string>;
-    allowInstalledProviderOverride?: boolean;
     /**
      * Gateway-supplied: did `defaultProvider` actually MATCH the requested
      * model, or was it fallback-picked? Drives failure-CTA attribution only —
@@ -244,23 +243,24 @@ export function resolveModelRef(
     );
   }
 
-  // A per-behavior model override can deliberately select another installed
-  // provider (for example, a watcher using z-ai while its base agent uses
-  // Claude). Prefer that explicit provider only when the prefix names a real
-  // installed provider, and route its Lobu ID to the upstream runtime slug
-  // (for example, claude → anthropic). This preserves model namespaces such as
-  // OpenRouter's "anthropic/claude-sonnet-4", where "anthropic" is not a
-  // separately installed provider and the configured OpenRouter route must win.
-  // Switching also requires an explicit behavior-override signal from the
-  // gateway. A slash prefix alone is ambiguous: OpenRouter model namespaces
-  // such as "openai/gpt-4o" must stay on OpenRouter even when standalone OpenAI
-  // is installed alongside it.
+  // An explicit "<provider>/<model>" ref selects its own provider — a Behavior
+  // running on z-ai while its base agent uses Claude, or simply an agent pinned
+  // to a provider the deployment does not publish as its default. `defaultProvider`
+  // is a deployment-level fact and the ref is a run-level one, so the ref wins;
+  // its Lobu ID is routed to the upstream runtime slug (claude → anthropic).
+  //
+  // The installed-route guard is what keeps this fail-safe. It preserves model
+  // namespaces such as OpenRouter's "anthropic/claude-sonnet-4", where
+  // "anthropic" is not a separately installed provider and the configured
+  // OpenRouter route must win, and it stops an uninstalled prefix from
+  // conjuring a provider the org never configured. Lobu stores refs as
+  // "<lobu-slug>/<model>", so OpenRouter's own entry keeps its prefix
+  // ("openrouter/openai/gpt-4o") and never collides with an installed OpenAI.
   const explicitParts = normalizedRaw?.split("/").filter(Boolean) ?? [];
   const explicitProvider = explicitParts[0];
   if (
     explicitParts.length >= 2 &&
     explicitProvider &&
-    overrides?.allowInstalledProviderOverride === true &&
     overrides?.installedProviderRoutes?.[explicitProvider] &&
     explicitProvider !== defaultProvider &&
     explicitProvider !== defaultProviderSlug
@@ -338,8 +338,8 @@ export function resolveModelRef(
     // pre-existing attribution rather than acquiring a new misattribution.
     // Derived from the RESOLVED `modelRef`, not `normalizedRaw`: when the run
     // carries no explicit model the ref comes from `defaultModel`, and
-    // `explicitParts` (which exists to gate behavior-override ROUTING on an
-    // explicit request) is empty — so attribution would silently fall back to
+    // `explicitParts` (which gates explicit-ref ROUTING on a ref the run
+    // itself supplied) is empty — so attribution would silently fall back to
     // the serving provider and reproduce the very bug this fixes.
     const attributionParts = modelRef.split("/").filter(Boolean);
     const attributionProvider = attributionParts[0];

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -809,7 +809,6 @@ export async function runAISession(
     defaultProvider: pc.defaultProvider,
     defaultProviderSlug: pc.defaultProviderSlug,
     installedProviderRoutes: pc.installedProviderRoutes,
-    allowInstalledProviderOverride: rawOptions.behaviorModelOverride === true,
     defaultProviderServesModel: pc.defaultProviderServesModel,
   });
   // Map gateway slug to model-registry provider name (e.g. "z-ai" → "zai")

--- a/packages/server/src/gateway/__tests__/platform-helpers-model-resolution.test.ts
+++ b/packages/server/src/gateway/__tests__/platform-helpers-model-resolution.test.ts
@@ -286,31 +286,28 @@ describe("resolveAgentId", () => {
 });
 
 /**
- * Routing must honour an explicit `<provider>/<model>` ref whatever LAYER supplied it.
+ * The payload carries the resolved REF and nothing else — routing is the ref's
+ * own business, decided by `resolveModelRef` in the worker.
  *
- * The worker only reroutes away from the gateway's `defaultProvider` when
- * `allowInstalledProviderOverride` is set, and that flag is
- * `rawOptions.behaviorModelOverride === true` (agent-worker
- * `runtime/session-runner.ts`). Dispatch sites set `behaviorModelOverride` only
- * alongside an explicit per-run override (e.g. the request body in
- * `gateway/routes/public/agent.ts`) — but the layered fallback runs AFTER that,
- * and resolves an equally explicit ref out of `agent.models[0]` or the org
- * default. Nothing re-derived the flag, so an agent-level provider choice was
- * silently dropped for routing.
+ * There used to be a permission flag (`behaviorModelOverride` here,
+ * `allowInstalledProviderOverride` at the worker) that a `<provider>/<model>`
+ * ref needed before it was allowed to beat the gateway's `defaultProvider`.
+ * Only the per-run dispatch sites set it, so a ref that was just as explicit but
+ * arrived from `agent.models[0]` or the org default authorized nothing.
  *
  * Measured on prod 2026-08-06: org `buremba` had agent `personal-agent` pinned to
  * `gemini/gemini-2.5-pro`, no Behavior override, and NO z-ai provider, secret, or
  * system key of its own — yet 79 runs over three days failed with
- * `z.ai returned an error: 429 Insufficient balance`. Setting a per-Behavior
- * `execution_config.model` (which flips the flag) fixed it immediately: 4/4 runs
- * completed against prior success rates of 19% and 41%. That is the natural
- * experiment this test pins.
+ * `z.ai returned an error: 429 Insufficient balance`. `defaultProvider` is a
+ * deployment-level fact and the ref is a run-level one, so the precedence was
+ * backwards; the flag is gone and the ref always wins. These tests pin that the
+ * resolver still picks the right ref and never re-grows a routing flag.
  */
-describe("explicit model refs mark the routing override", () => {
+describe("the layered fallback resolves the ref and adds no routing flag", () => {
   const storeWith = (models: string[]) =>
     ({ getSettings: async () => ({ models }) as any }) as any;
 
-  test("an agent-level <provider>/<model> ref marks the override", async () => {
+  test("an agent-level <provider>/<model> ref wins with no flag attached", async () => {
     const resolved = await resolveAgentOptions(
       "agent-1",
       {},
@@ -319,28 +316,22 @@ describe("explicit model refs mark the routing override", () => {
     );
 
     expect(resolved.model).toBe("gemini/gemini-2.5-pro");
-    // Without this the worker ignores the `gemini/` prefix and routes to
-    // whatever module the gateway published as `defaultProvider`.
-    expect(resolved.behaviorModelOverride).toBe(true);
+    expect(resolved.behaviorModelOverride).toBeUndefined();
   });
 
-  test("a per-behavior override still marks the override", async () => {
+  test("a per-behavior override still wins over the agent default", async () => {
     const resolved = await resolveAgentOptions(
       "agent-1",
-      { model: "qwen/qwen3.8-max-preview", behaviorModelOverride: true },
+      { model: "qwen/qwen3.8-max-preview" },
       storeWith(["gemini/gemini-2.5-pro"]),
       "org-1",
     );
 
     expect(resolved.model).toBe("qwen/qwen3.8-max-preview");
-    expect(resolved.behaviorModelOverride).toBe(true);
+    expect(resolved.behaviorModelOverride).toBeUndefined();
   });
 
-  // The flag authorizes rerouting to an explicitly NAMED provider. A ref with no
-  // provider segment names none, so it must not authorize anything — the worker
-  // would have nothing to route to and would fall through to defaultProvider
-  // anyway, but claiming an override we cannot honour is a lie in the payload.
-  test("an unqualified agent model does NOT mark the override", async () => {
+  test("an unqualified agent model is passed through as-is", async () => {
     const resolved = await resolveAgentOptions(
       "agent-1",
       {},
@@ -352,29 +343,25 @@ describe("explicit model refs mark the routing override", () => {
     expect(resolved.behaviorModelOverride).toBeUndefined();
   });
 
-  // A malformed per-request override is dropped in favour of the agent default
-  // (existing behaviour). The flag must follow the ref that actually WON, not the
-  // one that was rejected.
-  test("a rejected 'auto' override falls back and marks the agent ref", async () => {
+  // A malformed per-request override is dropped in favour of the agent default.
+  test("a rejected 'auto' override falls back to the agent ref", async () => {
     const resolved = await resolveAgentOptions(
       "agent-1",
-      { model: "auto", behaviorModelOverride: true },
+      { model: "auto" },
       storeWith(["gemini/gemini-2.5-pro"]),
       "org-1",
     );
 
     expect(resolved.model).toBe("gemini/gemini-2.5-pro");
-    expect(resolved.behaviorModelOverride).toBe(true);
+    expect(resolved.behaviorModelOverride).toBeUndefined();
   });
 
-  // The clearing branch: a rejected override arrives with the flag already true,
-  // and the winning fallback ref names no provider. Merely spreading baseOptions
-  // would leave the stale `true` authorizing a ref that cannot be routed — the
-  // flag must be cleared along with the rejected override.
-  test("a rejected override does NOT leave a stale flag on an unqualified fallback", async () => {
+  // The clearing branch that used to exist alongside the flag: a rejected
+  // override must still fall through to a ref that names no provider at all.
+  test("a rejected override falls through to an unqualified agent ref", async () => {
     const resolved = await resolveAgentOptions(
       "agent-1",
-      { model: "auto", behaviorModelOverride: true },
+      { model: "auto" },
       storeWith(["gpt-4o"]),
       "org-1",
     );

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1429,7 +1429,6 @@ export function createAgentApi(config: AgentApiConfig): Hono {
         provider: session.provider || "claude",
         model: behaviorModel ?? session.model,
         nixConfig: session.nixConfig,
-        ...(behaviorModel ? { behaviorModelOverride: true } : {}),
       };
       const agentOptions = await resolveAgentOptions(
         realAgentId,

--- a/packages/server/src/gateway/services/agent-threads.ts
+++ b/packages/server/src/gateway/services/agent-threads.ts
@@ -189,7 +189,6 @@ export async function enqueueAgentMessage(
     agentOptions: {
       provider: session.provider || "claude",
       model: args.model ?? session.model,
-      ...(args.model ? { behaviorModelOverride: true } : {}),
     },
     networkConfig: session.networkConfig,
   });

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -18,11 +18,10 @@ const logger = createLogger("platform-helpers");
 /**
  * Does this string name a provider AND a model, i.e. `<provider>/<model>`?
  *
- * The single shape test for both things that depend on it: whether a per-request
- * override is well-formed enough to win, and whether the resolved ref authorizes
- * the worker to route away from the gateway's `defaultProvider`. They were one
- * inlined expression and one missing check; a ref either names its provider or
- * it does not, and both callers need the same answer.
+ * The shape test for whether a per-request override is well-formed enough to
+ * win the layered fallback below. Routing itself needs no authorization from
+ * this side: the worker's `resolveModelRef` honours any explicit ref whose
+ * prefix names an installed provider.
  *
  * `auto` is rejected as the model half: it is gone repo-wide, and a legacy
  * `<provider>/auto` binding names no concrete model to route.
@@ -99,34 +98,6 @@ export async function resolveAgentOptions(
     mergedOptions.model = effectiveModelRef;
   } else {
     delete mergedOptions.model;
-  }
-
-  // Routing honours an explicit `<provider>/<model>` ref only when the payload
-  // authorizes it: the worker's model-resolver reroutes away from the gateway's
-  // `defaultProvider` solely under `allowInstalledProviderOverride`, which is
-  // `rawOptions.behaviorModelOverride === true` (agent-worker
-  // `runtime/session-runner.ts`). Dispatch sites set that flag only alongside an
-  // explicit per-run override (request-body `model`, tool `args.model`, Behavior
-  // `execution_config.model`) — i.e. BEFORE the layered fallback above has run —
-  // and the platform paths (message-handler-bridge, chat-instance-manager) never
-  // set it at all. So a ref that is just as explicit, but arrived from
-  // `agent.models[0]` or the org default, never authorized anything, and the run
-  // was routed to whatever module the gateway published as `defaultProvider` via
-  // its credentialed fallback scan.
-  //
-  // Prod 2026-08-06: org `buremba` pinned its agent to `gemini/gemini-2.5-pro`,
-  // set no per-Behavior override, and had no z-ai provider, secret or system key
-  // of its own — yet 79 runs in three days died on `z.ai 429 Insufficient
-  // balance`. Adding a per-Behavior override (which flips this flag) fixed it
-  // outright. The layer a ref came from was never supposed to change where it
-  // routes, so re-derive the flag from the ref that actually WON.
-  //
-  // Cleared, not just set: a rejected malformed override must not leave a stale
-  // `true` authorizing a fallback ref that names no provider at all.
-  if (isQualifiedModelRef(effectiveModelRef)) {
-    mergedOptions.behaviorModelOverride = true;
-  } else {
-    delete mergedOptions.behaviorModelOverride;
   }
 
   if (settings.networkConfig) {

--- a/packages/server/src/scheduled/__tests__/wake-agent-delivery.test.ts
+++ b/packages/server/src/scheduled/__tests__/wake-agent-delivery.test.ts
@@ -138,10 +138,7 @@ describe("runWakeAgentTask chat delivery dispatch", () => {
     );
 
     expect(enqueued).toHaveLength(1);
-    expect(enqueued[0].agentOptions).toEqual({
-      model: "openai/gpt-5",
-      behaviorModelOverride: true,
-    });
+    expect(enqueued[0].agentOptions).toEqual({ model: "openai/gpt-5" });
   });
 
   test("leaves agentOptions empty when no per-schedule model is set", async () => {
@@ -229,7 +226,7 @@ describe("runWakeAgentTask chat delivery dispatch", () => {
   });
 });
 
-test("internal API-thread dispatch marks a supplied model as a behavior override", async () => {
+test("internal API-thread dispatch forwards a supplied model in agentOptions", async () => {
   const enqueued: MessagePayload[] = [];
   const deps = {
     sessionManager: {
@@ -260,10 +257,7 @@ test("internal API-thread dispatch marks a supplied model as a behavior override
     }
   );
 
-  expect(enqueued[0].agentOptions).toMatchObject({
-    model: "z-ai/glm-5.2",
-    behaviorModelOverride: true,
-  });
+  expect(enqueued[0].agentOptions).toMatchObject({ model: "z-ai/glm-5.2" });
 });
 
 test("#2: createThreadForAgent STORES organizationId on the session", async () => {

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -534,9 +534,7 @@ export async function runWakeAgentTask(
           organizationId: orgId,
           source: 'scheduled-job',
         },
-        agentOptions: behaviorModel
-          ? { model: behaviorModel, behaviorModelOverride: true }
-          : {},
+        agentOptions: behaviorModel ? { model: behaviorModel } : {},
       })
     );
     return;

--- a/packages/server/src/tools/admin/manage_conversations.ts
+++ b/packages/server/src/tools/admin/manage_conversations.ts
@@ -244,7 +244,6 @@ async function handleSend(
     {
       provider: "claude",
       model: behaviorModel,
-      ...(behaviorModel ? { behaviorModelOverride: true } : {}),
     },
     agentSettingsStore,
     ctx.organizationId,


### PR DESCRIPTION
## Summary

- `defaultProvider` is a **deployment-level** fact; a `<provider>/<model>` ref is a **run-level** one. The worker routed by the deployment default and required a permission flag (`allowInstalledProviderOverride`, fed by `behaviorModelOverride`) before a ref was allowed to win. That precedence was backwards, and this deletes the flag: an explicit ref routes to its own provider whenever `installedProviderRoutes[prefix]` exists.
- #2547 (`1f0c004b`) was the interim server-side patch — it re-derived the flag from the ref that actually won so the gateway stopped dropping agent-level provider choices. This replaces it with the end state, so the flag, its mapping in `session-runner.ts`, the re-derivation block in `platform-helpers.ts`, and all four now-inert caller-side assignments are gone.
- **The installed-route guard stays** and is what keeps rerouting fail-safe: an uninstalled prefix (`z-ai`, `nvidia`, `deepseek*` on prod today) cannot conjure a provider the org never configured, and falls through exactly as before.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` (exit 0), `make test-integration` (exit 0 — 392 files / 3456 tests), targeted `bun test` on both resolver suites
- [x] Bug fix: red→fix→green outputs pasted below
- [x] Booted the stack and exercised the real dispatch path (A/B below)

### Live A/B on a booted stack

Unit tests pin the resolver; this pins the dispatch. Booted the worktree (embedded Postgres + embedded worker), seeded an agent whose allow-list is `["gemini/gemini-2.5-flash", "openai/gpt-4.1"]` so the gateway publishes **gemini** as `defaultProvider`, then sent a message pinned to `openai/gpt-4.1` and toggled **only** `model-resolver.ts` between runs:

| | resolver output | upstream actually called |
|---|---|---|
| pre-fix | `rawProvider=gemini modelId=openai/gpt-4.1` | `/api/proxy/gemini/…/chat/completions` |
| post-fix | `rawProvider=openai modelId=gpt-4.1` | `/api/proxy/openai/…/chat/completions` |

Both runs logged identical resolver inputs — `raw=openai/gpt-4.1 defaultProvider=gemini routes={"gemini":"gemini","openai":"openai"}` — so the provider swap is attributable to the single toggled file. The pre-fix row *is* the prod failure mode: the ref's provider ignored and the full `openai/gpt-4.1` string shipped verbatim to the wrong upstream, which 404s.

Trap worth recording: the embedded worker loads `@lobu/worker` **in-process at server boot** and `tsx watch` only watches `packages/server`, so the first three A/B attempts measured the same stale module twice and showed gemini for both arms. A rebuilt bundle is not enough — the dev server needs a full restart per toggle. A temporary probe line that never printed is what caught it.

### Red → green

The reproducer is the prod signature: an agent pinned to `gemini/gemini-2.5-pro`, no per-Behavior override, and a `defaultProvider` of `z-ai` that the org never configured.

Before the fix (`packages/agent-worker/src/__tests__/model-resolver.test.ts`):

```
expect(result.provider).toBe("gemini");
Expected: "gemini"
Received: "z-ai"

(fail) resolveModelRef > an agent-level ref routes to its own provider, not the deployment default
 51 pass
 1 fail
```

After:

```
packages/agent-worker/src/__tests__/model-resolver.test.ts:
packages/agent-worker/src/__tests__/model-resolver-harden.test.ts:
 87 pass
 0 fail
 162 expect() calls
```

### The prod A/B behind it

Org `buremba`, agent `personal-agent` pinned to `gemini/gemini-2.5-pro`, **no** z-ai provider row, secret, or system key anywhere in the org:

```
watcher_id  status     n   error
5           failed     39  z.ai returned an error: 429 Insufficient balance or no resource package
5           completed  10
71          failed     40  z.ai returned an error: 429 Insufficient balance or no resource package
71          completed  31
```

Setting a per-Behavior `execution_config.model` — the one thing that flipped the flag — fixed it: 4/4 runs completed against prior success rates of 19% and 41%.

## Notes

**Why the flag's stated justification does not hold.** The resolver's own comment said OpenRouter namespaces like `openai/gpt-4o` "must stay on OpenRouter even when standalone OpenAI is installed". Lobu stores refs as `<lobu-slug>/<model>`, so OpenRouter's are `openrouter/openai/gpt-4o` — the vendor namespace rides *inside* the ref and the prefix is never ambiguous. Re-audited every `agents.models` ref on prod 2026-08-06:

| prefix | refs | in an org where it is installed | example |
|---|---|---|---|
| gemini | 4 | 4 | `gemini/gemini-2.5-flash` |
| qwen | 4 | 4 | `qwen/qwen3.8-max` |
| openrouter | 4 | 1 | `openrouter/anthropic/claude-sonnet-5` |
| z-ai | 2 | 0 | `z-ai/glm-5.2` |
| openai | 2 | 2 | `openai/gpt-4o-mini` |
| nvidia / deepseek-ai / deepseek | 1 each | 0 | — |
| xai | 1 | 1 | `xai/grok-4` |

Every stored prefix is a real Lobu provider slug, every OpenRouter ref keeps its `openrouter/` prefix, and **no org has OpenRouter as its default provider** — so the ambiguity the flag existed to protect against is not reachable from prod data. The flag also failed to protect consistently: a per-Behavior override carrying the *same* ambiguous ref was already permitted to reroute.

**Blast radius.** This changes the server↔worker dispatch contract, so the worker image must be rebuilt and rolled out — not just the server. `installedProviderRoutes`, `providerBaseUrlMappings`, and `credentialPlaceholders` are all built from the same `effectiveProviders` set in `gateway/index.ts`, so any provider that can now be a reroute target already has its proxy base URL published. A provider that is *installed* but has no usable credential now fails loudly with the existing "provider is not connected / no gateway routing URL" error instead of silently running on the fallback provider — which is the intended trade.

**Orgs whose routing changes on rollout** (agent `models[0]` prefix ≠ published default, prefix installed and `active`): `8dc12bdd…` → gemini, `UdNAH1…` → gemini, `org_lobucrm` → xai. All three provider rows are `active` with real key refs.

### Follow-ups, not in this PR

- `gateway/orchestration/deployment-manager.ts` `if (!primaryProvider)` accepts `candidate.hasSystemKey()` in its fallback scan, so a deployment-wide key can make a provider primary for an org that never configured it. That is very likely how `z-ai` became `defaultProvider` for `buremba`, and it is an independent defect.
- `buremba` Behaviors 5/20/70/71 still carry the `execution_config.model` pins added as the 2026-08-06 workaround. Once this is live they should be removed and the runs re-verified — the end state should not need them.
