### PR TITLE
fix(agent-worker): route real OpenAI dynamic models through the Responses API

### DIFF
--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_PROVIDER_MODELS,
   PROVIDER_REGISTRY_ALIASES,
   registerDynamicProvider,
+  resolveDynamicModelApi,
   resolveModelRef,
 } from "../runtime/model-resolver";
 
@@ -447,6 +448,38 @@ describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
       providerBaseUrl: undefined,
     });
     expect(model.baseUrl).toBe("https://api.openai.com/v1");
+  });
+});
+
+describe("resolveDynamicModelApi — real OpenAI uses the Responses API", () => {
+  test("real OpenAI (rawProvider 'openai') routes to openai-responses", () => {
+    // gpt-5.6-sol (a reasoning model) 400s over /chat/completions when the
+    // turn uses function tools; the Responses API is the only tool-capable
+    // transport. pi-ai's static registry routes every real OpenAI model
+    // through openai-responses — the dynamic path must match.
+    expect(resolveDynamicModelApi("openai", "openai")).toBe("openai-responses");
+  });
+
+  test("third-party openai-compatible providers keep openai-completions", () => {
+    // groq / z-ai / gemini / nvidia share the "openai" registry alias but only
+    // speak the completions protocol — they must NOT be routed to responses.
+    for (const rawProvider of [
+      "groq",
+      "z-ai",
+      "gemini",
+      "nvidia",
+      "together-ai",
+    ]) {
+      expect(resolveDynamicModelApi(rawProvider, "openai")).toBe(
+        "openai-completions"
+      );
+    }
+  });
+
+  test("non-openai registry aliases resolve through the alias map", () => {
+    expect(resolveDynamicModelApi("my-claude", "anthropic")).toBe(
+      "anthropic-messages"
+    );
   });
 });
 

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -96,6 +96,29 @@ export const PIAI_API_BY_REGISTRY_ALIAS: Record<string, PiAiApi> =
   );
 
 /**
+ * Resolve the pi-ai wire adapter for a DYNAMIC model entry (one not present in
+ * pi-ai's static registry).
+ *
+ * Real OpenAI is the one exception to the alias-map default: pi-ai's static
+ * registry routes every real OpenAI model (gpt-4o, gpt-4.1, gpt-5, …) through
+ * the `openai-responses` adapter, and reasoning models like gpt-5.6-sol reject
+ * function tools over /chat/completions ("Function tools with reasoning_effort
+ * are not supported for gpt-5.6-sol in /v1/chat/completions"). The registry
+ * alias cannot make this call — both protocols share the "openai" alias and
+ * the alias map collapses to completions — so the adapter is keyed on the raw
+ * gateway slug: real OpenAI (`rawProvider === "openai"`) gets responses, while
+ * every third-party openai-compatible endpoint (groq, z-ai, gemini, nvidia,
+ * together-ai, org BYO providers, …) keeps completions.
+ */
+export function resolveDynamicModelApi(
+  rawProvider: string,
+  registryProvider: string
+): PiAiApi | undefined {
+  if (rawProvider === "openai") return "openai-responses";
+  return PIAI_API_BY_REGISTRY_ALIAS[registryProvider];
+}
+
+/**
  * Register a config-driven provider at runtime.
  * Extends the base URL env, default model, and registry alias maps
  * so resolveModelRef() and the worker can handle the provider.

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -35,9 +35,9 @@ import {
   DEFAULT_PROVIDER_BASE_URL_ENV,
   getModelDynamic,
   openOrCreateSessionManager,
-  PIAI_API_BY_REGISTRY_ALIAS,
   PROVIDER_REGISTRY_ALIASES,
   registerDynamicProvider,
+  resolveDynamicModelApi,
   resolveModelRef,
 } from "./model-resolver";
 import { createLobuResourceLoader } from "./pi-resources";
@@ -922,7 +922,7 @@ export async function runAISession(
       // OpenAI-compatible (openai, nvidia, together-ai, z.ai, …) or any org BYO
       // provider whose slug differs from its registry alias. Resolve the pi-ai
       // adapter from the provider's protocol; default to openai-completions.
-      const api = PIAI_API_BY_REGISTRY_ALIAS[registryProvider];
+      const api = resolveDynamicModelApi(rawProvider, registryProvider);
       logger.info(
         `Creating dynamic model entry for ${rawProvider}/${modelId} (${api ?? "openai-completions"})`
       );


### PR DESCRIPTION
## Summary
pi-ai's static registry sends every real OpenAI model (gpt-4o, gpt-4.1, gpt-5, ...) over the `openai-responses` adapter, but Lobu's dynamic-model path (used when a model is not in the static registry — e.g. `gpt-5.6-sol`) collapsed the shared `openai` registry alias to `openai-completions`. The registry alias cannot distinguish the two protocols (both map to alias `openai`), so reasoning models rejected function tools over `/chat/completions` with a 400:

```
Function tools with reasoning_effort are not supported for gpt-5.6-sol in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.
```

## Change
Key the wire adapter on the raw gateway slug instead of the registry alias:
- Real OpenAI (`rawProvider === "openai"`) → `openai-responses`
- Third-party openai-compatible endpoints (groq, z-ai, gemini, nvidia, together-ai, org BYO) → `openai-completions` (unchanged)

New pure helper `resolveDynamicModelApi(rawProvider, registryProvider)` in `model-resolver.ts`; `session-runner.ts` uses it.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Targeted tests: `bun test packages/agent-worker/src/__tests__/model-resolver.test.ts` (56 pass); full worker suite 830 pass
- [x] Bug fix: red→fix→green outputs below

### Red→green evidence
**Red** (fix reverted — responses branch removed, old alias-map behavior):
```
(fail) resolveDynamicModelApi — real OpenAI uses the Responses API > real OpenAI (rawProvider 'openai') routes to openai-responses [0.88ms]
 55 pass
 1 fail
```

**Green** (fix restored):
```
 56 pass
 0 fail
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic model API selection for OpenAI models.
  * Ensured third-party OpenAI-compatible providers use the appropriate completions protocol.
  * Correctly mapped non-OpenAI provider aliases to their supported APIs.

* **Tests**
  * Added coverage for dynamic API selection across OpenAI, compatible providers, and other registered providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->