### PR TITLE
feat(server): give keyed Behavior event outputs a stable identity

### DIFF
--- a/db/migrations/20260806120000_events_identity_key.sql
+++ b/db/migrations/20260806120000_events_identity_key.sql
@@ -105,7 +105,12 @@ CREATE OR REPLACE VIEW public.current_event_records AS
 
 -- migrate:down
 
-CREATE OR REPLACE VIEW public.current_event_records AS
+-- CREATE OR REPLACE VIEW cannot DROP a column (42P16), so the rollback must
+-- DROP the view, recreate it without the identity columns, then drop the
+-- columns the view no longer references. (The same latent flaw exists in
+-- 20260804170000's down — this one does not copy it.)
+DROP VIEW public.current_event_records;
+CREATE VIEW public.current_event_records AS
  SELECT e.id,
     e.organization_id,
     e.entity_ids,

--- a/db/migrations/20260806120000_events_identity_key.sql
+++ b/db/migrations/20260806120000_events_identity_key.sql
@@ -1,0 +1,150 @@
+-- migrate:up
+
+-- Stable THING-identity for event rows (schema only).
+--
+-- `events.id` is a stored-VERSION id: every supersede mints a new one. So it
+-- cannot answer "which live row is the current version of this thing?", which
+-- is exactly what a keyed Behavior output has to ask on every run. Nothing else
+-- on the row can answer it either:
+--
+--   * origin_id is scoped per CONNECTION (idx_events_connection_origin_id) and
+--     that scope is erasable — events_connection_id_fkey is ON DELETE SET NULL,
+--     so deleting a connection nulls connection_id on its entire history. Prod
+--     carries 53,093 live rows in that state, sharing origin_ids with nothing
+--     to disambiguate them and zero supersedes ever recorded.
+--   * metadata->>'_lobu_idempotency_key' is unique over ALL rows (that is the
+--     guarantee) where identity must be unique over LIVE rows only, and its
+--     value must DIFFER per write where identity must be IDENTICAL across
+--     versions. One column cannot hold both.
+--   * an expression index over the declared metadata fields — the shape
+--     idx_canvas_chain_root uses — works only because canvas_state's key fields
+--     are static. Keyed outputs declare theirs at runtime, per Behavior.
+--
+-- Uniqueness is declared PER NAMESPACE (one partial index per namespace that
+-- claims it) rather than as one blanket index. entity_identities took the
+-- blanket route and its per-namespace `uniquePerOrg` knob has sat with zero
+-- consumers ever since, unable to express that email_domain is not unique.
+--
+-- Adoption of pre-existing rows is deliberately NOT done here. The key is
+-- computed by computeStableKey()/formatBehaviorEventIdentity() in
+-- packages/server/src/utils/stable-keys.ts, and mirroring that encoding in SQL
+-- would mean two implementations of one algorithm kept in step by a test —
+-- where any drift silently stamps keys no run can probe for. Instead
+-- scripts/backfill-event-identity.ts stamps existing rows out of band using the
+-- real function. See docs/MIGRATIONS.md for the out-of-band backfill pattern.
+
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS identity_ns  text;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS identity_key text;
+
+COMMENT ON COLUMN public.events.identity_ns IS
+    'Identity namespace of the writer that claims this row has a stable cross-version identity (e.g. behavior_event). NULL for one-shot events, which have no "current version".';
+COMMENT ON COLUMN public.events.identity_key IS
+    'Stable identity of the THING this row is a version of, within identity_ns. Server-derived (stable-keys.ts), never model-authored. Set together with identity_ns or not at all.';
+
+-- NOT VALID keeps the ALTER off a full-table scan under lock. The VALIDATE
+-- lives in its own migration (20260806120030): in THIS transaction the ADD
+-- CONSTRAINT's ACCESS EXCLUSIVE lock is held until COMMIT, so a same-migration
+-- VALIDATE would run its full heap scan while still holding AEL on events —
+-- the exact stall NOT VALID exists to avoid. In a separate transaction it
+-- takes only SHARE UPDATE EXCLUSIVE and writes proceed. NOT VALID already
+-- checks every new INSERT and UPDATE; only pre-existing rows go unproven
+-- until then.
+ALTER TABLE public.events
+    DROP CONSTRAINT IF EXISTS events_identity_pair;
+
+ALTER TABLE public.events
+    ADD CONSTRAINT events_identity_pair
+    CHECK ((identity_ns IS NULL) = (identity_key IS NULL)) NOT VALID;
+
+-- Expose the identity through current_event_records, the live-event view that
+-- query_sql/validateAndScopeQuery read (execute-data-sources.ts). The view's
+-- column list is hand-maintained by each migration that adds an events column;
+-- without the pair here a query_sql SELECT of identity_* against a live event
+-- fails with "column does not exist" even though the raw table has them.
+CREATE OR REPLACE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id,
+    e.linked_org_ids,
+    e.identity_ns,
+    e.identity_key
+   FROM public.events e
+  WHERE e.superseded_by IS NULL;
+
+-- migrate:down
+
+CREATE OR REPLACE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id,
+    e.linked_org_ids
+   FROM public.events e
+  WHERE e.superseded_by IS NULL;
+
+ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_identity_pair;
+ALTER TABLE public.events DROP COLUMN IF EXISTS identity_key;
+ALTER TABLE public.events DROP COLUMN IF EXISTS identity_ns;

--- a/db/migrations/20260806120010_events_identity_key_index.sql
+++ b/db/migrations/20260806120010_events_identity_key_index.sql
@@ -1,0 +1,44 @@
+-- migrate:up transaction:false
+
+-- Stable THING-identity for event rows (schema part 2: the constraint).
+-- Companion to 20260806120000, split out because CREATE INDEX CONCURRENTLY
+-- cannot run inside a transaction and db:lint (squawk) bans non-concurrent
+-- builds on the hot events table. One statement per transaction:false
+-- migration — dbmate sends the block as one simple-query batch and
+-- CONCURRENTLY can't share it.
+--
+-- THIS INDEX IS THE FIX. `persistBehaviorEventOutput` resolves the current head
+-- with a SELECT and INSERTs inside the caller's transaction; under READ
+-- COMMITTED a second run whose probe lands before the first COMMITS sees no
+-- head, so both insert with supersedes_event_id = NULL and both stay live —
+-- permanently, silently, no error. idx_events_superseded_by cannot catch that
+-- because it is unique on supersedes_event_id, which is NULL on both rows.
+--
+-- Keyed on the CHAIN ROOT (supersedes_event_id IS NULL), NOT on the live head
+-- (superseded_by IS NULL) — the same shape as idx_canvas_chain_root, and for
+-- the same reason. insertEvent INSERTs the successor and only then stamps the
+-- predecessor's superseded_by (the dual-write in insert-event.ts), so between
+-- those two statements BOTH rows are live. A live-head index would therefore reject every
+-- ordinary sequential supersede, not just the concurrent duplicate. Root
+-- uniqueness sidesteps that window entirely: a successor carries a non-NULL
+-- supersedes_event_id and is simply not in the index.
+--
+-- One live head per identity then falls out of two constraints together: at
+-- most one ROOT per identity (here) and at most one successor per row
+-- (idx_events_superseded_by, unique on supersedes_event_id). A chain cannot
+-- fork, and a second chain cannot start.
+--
+-- Scoped to identity_ns = 'behavior_event' so uniqueness is a per-namespace
+-- claim: a namespace that wants it declares its own index, one that does not
+-- simply has none. entity_identities instead enforces a single blanket index
+-- across all namespaces, which is why its `uniquePerOrg` knob exists, is
+-- declared false for email_domain, and has never had a consumer.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_events_identity_root_behavior
+  ON public.events (organization_id, identity_key)
+  WHERE supersedes_event_id IS NULL
+    AND identity_key IS NOT NULL
+    AND identity_ns = 'behavior_event';
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_identity_root_behavior;

--- a/db/migrations/20260806120020_events_identity_head_probe_index.sql
+++ b/db/migrations/20260806120020_events_identity_head_probe_index.sql
@@ -1,0 +1,34 @@
+-- migrate:up transaction:false
+
+-- Stable THING-identity for event rows (schema part 3: the probe index).
+-- Companion to 20260806120010, in its own file for the same reason: CREATE
+-- INDEX CONCURRENTLY cannot share a transaction, and dbmate sends a
+-- transaction:false block as one simple-query batch.
+--
+-- The root index (20260806120010) is the CONSTRAINT; it cannot also serve the
+-- head PROBE. `findCurrentHeadByIdentity` looks up the live head — `WHERE
+-- organization_id = $1 AND identity_ns = 'behavior_event' AND identity_key =
+-- $2 AND superseded_by IS NULL` — and a partial index is usable only when the
+-- query implies its predicate. The probe's `superseded_by IS NULL` does not
+-- imply the root index's `supersedes_event_id IS NULL` (a chain's head is
+-- usually NOT its root), so without this index the planner falls back to
+-- idx_events_live_org_created and FILTERS the org's whole live set per probe —
+-- the same O(org history) shape as the `metadata @>` probe this branch removes
+-- (measured 970 ms at prod scale), and worst exactly on the common no-head
+-- first-run path, which scans everything before concluding nothing matches.
+--
+-- Non-unique on purpose. insertEvent inserts the successor before stamping the
+-- predecessor's superseded_by, so both rows are briefly live inside that
+-- transaction and a UNIQUE live-head index would reject every ordinary
+-- supersede (why the constraint keys the ROOT instead). As a plain probe index
+-- the transient second entry is harmless, and the stamp removes the replaced
+-- row from the index automatically.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_identity_head_behavior
+  ON public.events (organization_id, identity_key)
+  WHERE superseded_by IS NULL
+    AND identity_key IS NOT NULL
+    AND identity_ns = 'behavior_event';
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_identity_head_behavior;

--- a/db/migrations/20260806120030_events_identity_pair_validate.sql
+++ b/db/migrations/20260806120030_events_identity_pair_validate.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+
+-- Stable THING-identity for event rows (schema part 4: validate the CHECK).
+--
+-- Split from 20260806120000 on purpose. There the ADD CONSTRAINT ... NOT VALID
+-- takes a brief ACCESS EXCLUSIVE lock that is held until that transaction
+-- commits, so validating in the same migration would run the full heap scan of
+-- events while still holding AEL — a hard stall on the hottest table. In its
+-- own transaction VALIDATE takes only SHARE UPDATE EXCLUSIVE: reads and writes
+-- proceed while it scans. Every existing row has both columns NULL and
+-- satisfies the CHECK trivially, so this cannot fail; it exists so the
+-- constraint reads as validated in the catalog rather than carrying NOT VALID
+-- forever.
+
+-- Rerunnable: VALIDATE on an already-valid constraint is a no-op. squawk
+-- cannot see that (or the dbmate-managed transaction), hence the ignore.
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE public.events VALIDATE CONSTRAINT events_identity_pair;
+
+-- migrate:down
+
+-- Nothing to undo: validation is catalog state on a constraint that
+-- 20260806120000's down migration drops.
+SELECT 1;

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4238,7 +4238,7 @@ export type ManageBehaviorsData = {
                  */
                 event: string;
                 /**
-                 * One to four metadata fields whose exact string values compose each draft's stable identity across Behavior runs (e.g. channel + mode for per-channel voice profiles). Every key field must be present in every draft's `metadata`; changing the fields, their order, the output name, or the semantic type changes identity. When set, each run supersedes the current head event with the same key values.
+                 * One to four metadata fields whose exact values compose each draft's stable identity across Behavior runs (e.g. channel + mode for per-channel voice profiles). Every key field must be present in every draft's `metadata` and be a non-blank string, safe integer, or boolean — the type is part of the identity, so 3 and "3" are different keys. Changing the fields, their order, or the semantic type changes identity and starts a new chain. When set, each run supersedes the current event carrying the same key values.
                  */
                 key?: Array<string>;
               };
@@ -4865,7 +4865,7 @@ export type GetBehaviorResponses = {
                */
               event: string;
               /**
-               * One to four metadata fields whose exact string values compose each draft's stable identity across Behavior runs (e.g. channel + mode for per-channel voice profiles). Every key field must be present in every draft's `metadata`; changing the fields, their order, the output name, or the semantic type changes identity. When set, each run supersedes the current head event with the same key values.
+               * One to four metadata fields whose exact values compose each draft's stable identity across Behavior runs (e.g. channel + mode for per-channel voice profiles). Every key field must be present in every draft's `metadata` and be a non-blank string, safe integer, or boolean — the type is part of the identity, so 3 and "3" are different keys. Changing the fields, their order, or the semantic type changes identity and starts a new chain. When set, each run supersedes the current event carrying the same key values.
                */
               key?: Array<string>;
             };

--- a/packages/core/src/contracts/tools/manage-behaviors.ts
+++ b/packages/core/src/contracts/tools/manage-behaviors.ts
@@ -153,6 +153,14 @@ export type BehaviorEntityOutput = Static<typeof BehaviorEntityOutputSchema>;
  * one current event per key while history stays append-only. This is the event
  * analogue of the entity output's keyed upsert — use it for refined-over-time
  * state (voice profiles, digests, statuses) rather than per-source-item logs.
+ *
+ * The identity is derived server-side and stored on the row (`events.identity_*`),
+ * so it is scoped to the semantic type rather than to the Behavior: an event that
+ * predates the Behavior now maintaining it can be adopted into the chain, and
+ * "exactly one current per key" is a unique-index guarantee rather than a
+ * convention two concurrent runs can silently break. Rows carrying no identity
+ * are inert — never a supersede target — so a keyed output cannot capture an
+ * unrelated event that happens to share metadata.
  */
 export const BehaviorEventOutputSchema = Type.Object(
   {
@@ -168,7 +176,7 @@ export const BehaviorEventOutputSchema = Type.Object(
         maxItems: 4,
         uniqueItems: true,
         description:
-          "One to four metadata fields whose exact string values compose each draft's stable identity across Behavior runs (e.g. channel + mode for per-channel voice profiles). Every key field must be present in every draft's `metadata`; changing the fields, their order, the output name, or the semantic type changes identity. When set, each run supersedes the current head event with the same key values.",
+          "One to four metadata fields whose exact values compose each draft's stable identity across Behavior runs (e.g. channel + mode for per-channel voice profiles). Every key field must be present in every draft's `metadata` and be a non-blank string, safe integer, or boolean — the type is part of the identity, so 3 and \"3\" are different keys. Changing the fields, their order, or the semantic type changes identity and starts a new chain. When set, each run supersedes the current event carrying the same key values.",
       })
     ),
   },

--- a/packages/server/src/__tests__/integration/watchers/behavior-event-outputs.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/behavior-event-outputs.test.ts
@@ -3,6 +3,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import type { DbClient } from '../../../db/client';
 import { createWatcherRun } from '../../../runs/queue-service';
 import { persistBehaviorEventOutput } from '../../../utils/persist-behavior-event-output';
+import {
+  BEHAVIOR_EVENT_IDENTITY_NS,
+  computeStableKey,
+  formatBehaviorEventIdentity,
+} from '../../../utils/stable-keys';
 import { computePendingWindow } from '../../../utils/window-utils';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestAgent, createTestEntity, createTestEvent } from '../../setup/test-fixtures';
@@ -290,10 +295,12 @@ describe('Behavior event outputs', () => {
     expect(v2).toMatchObject({ supersedes_event_id: v1?.id ?? null, superseded_by: null });
     expect(taste).toMatchObject({ supersedes_event_id: null, superseded_by: null });
 
-    // A keyed supersede must match a legacy (pre-Behavior) head by metadata,
-    // not just the producing Behavior — a migrated seed event becomes the
-    // supersede target of the first run.
-    const legacy = await sql<{ id: number }>`
+    // An unkeyed row carrying the same metadata is INERT: identity is stamped by
+    // the writer, never inferred from metadata at read time. A row nothing
+    // claimed identity for cannot be hijacked as a supersede target — which is
+    // what the old `metadata @>` probe did, and why a shrunk key declaration
+    // could silently supersede a DIFFERENT key's head.
+    const unkeyed = await sql<{ id: number }>`
       INSERT INTO events (
         organization_id, origin_id, title, payload_text, semantic_type, client_id, metadata
       ) VALUES (
@@ -308,12 +315,47 @@ describe('Behavior event outputs', () => {
       FROM events
       WHERE organization_id = ${workspace.org.id} AND payload_text = 'X voice v3'
     `;
-    expect(v3[0].supersedes_event_id).toBe(legacy[0].id);
+    // The run extends its OWN chain (v2 was the head), and leaves the unkeyed
+    // row exactly as it found it.
+    expect(v3[0].supersedes_event_id).toBe(v2?.id);
+    const untouched = await sql<{ superseded_by: number | null; identity_key: string | null }>`
+      SELECT superseded_by, identity_key FROM events WHERE id = ${unkeyed[0].id}
+    `;
+    expect(untouched[0]).toMatchObject({ superseded_by: null, identity_key: null });
 
-    // Missing key field and duplicate key within one array are rejected.
+    // Pre-existing rows are adopted DELIBERATELY, by scripts/backfill-event-identity.ts
+    // stamping the identity the writer computes — not by a lucky metadata match at
+    // runtime. Once stamped, the chain is the Behavior's to extend. This is the
+    // same call the backfill makes.
+    const adopted = await sql<{ id: number }>`
+      INSERT INTO events (
+        organization_id, origin_id, title, payload_text, semantic_type, client_id,
+        metadata, identity_ns, identity_key
+      ) VALUES (
+        ${workspace.org.id}, ${'migrated-seed'}, ${'Migrated'}, ${'Y voice legacy'},
+        ${'observation'}, NULL, ${sql.json({ channel: 'y', mode: 'voice' })},
+        ${BEHAVIOR_EVENT_IDENTITY_NS},
+        ${formatBehaviorEventIdentity(
+          'observation',
+          computeStableKey({ channel: 'y', mode: 'voice' }, ['channel', 'mode'])
+        )}
+      )
+      RETURNING id
+    `;
+    await persist([{ content: 'Y voice v1', metadata: { channel: 'y', mode: 'voice' } }], 9006);
+    const adoptedNext = await sql<{ supersedes_event_id: number | null }>`
+      SELECT supersedes_event_id
+      FROM events
+      WHERE organization_id = ${workspace.org.id} AND payload_text = 'Y voice v1'
+    `;
+    expect(adoptedNext[0].supersedes_event_id).toBe(adopted[0].id);
+
+    // Missing key field and duplicate key within one array are rejected. The
+    // message comes from computeStableKey — the one validator — so it names the
+    // offending field rather than the declaration as a whole.
     await expect(
       persist([{ content: 'no key', metadata: { channel: 'x' } }], 9004)
-    ).rejects.toThrow(/missing required key field/);
+    ).rejects.toThrow(/invalid key \(channel, mode\).*'mode' must be present/);
     await expect(
       persist(
         [

--- a/packages/server/src/__tests__/integration/watchers/behavior-keyed-output-race.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/behavior-keyed-output-race.test.ts
@@ -159,4 +159,101 @@ describe('Behavior keyed event outputs > concurrent runs', () => {
     expect(successor.supersedes_event_id).toBe(root.id);
     expect(live[0].id).toBe(successor.id);
   });
+
+  it('recovers when two runs supersede the SAME committed head (superseded_by collision)', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Keyed Race Org' });
+    const organizationId = workspace.org.id;
+    const watcherId = 4242;
+
+    /** One Behaviour run persisting a single keyed draft. */
+    const persistRun = (tx: DbClient, canvasRevisionId: number) =>
+      persistBehaviorEventOutput({
+        tx,
+        rows: [
+          {
+            title: 'Voice profile',
+            content: `Refinement from canvas ${canvasRevisionId}.`,
+            metadata: { channel: 'x', mode: 'taste' },
+          },
+        ],
+        outputName: 'profiles',
+        output: KEYED_OUTPUT,
+        watcherId,
+        organizationId,
+        windowId: 1,
+        canvasRevisionId,
+        runId: null,
+        boundEntityIds: [],
+        validContentIds: new Set<number>(),
+        occurredAt: new Date().toISOString(),
+      });
+
+    // Seed a committed head for the key first — the state two runs then both
+    // probe and both try to supersede. (The first test starts from NO head,
+    // which collides on the ROOT index; this one needs a head so both inserts
+    // are successors of the SAME row and collide on idx_events_superseded_by.)
+    await sql.begin(async (tx) => {
+      await persistRun(tx as unknown as DbClient, 2000);
+    });
+    const seedHead = await sql<{ id: number }[]>`
+      SELECT id FROM events
+      WHERE organization_id = ${organizationId} AND identity_key IS NOT NULL
+    `;
+    expect(seedHead).toHaveLength(1);
+
+    // ── Force the interleaving ────────────────────────────────────────────
+    // A inserts a successor of the committed head and parks. B probes against
+    // that state (A's row is not yet visible), sees the SAME committed head,
+    // and inserts its own successor of it — which blocks on A's uncommitted
+    // tuple in idx_events_superseded_by. That is the first-attempt collision
+    // the recovery path must also handle.
+    let signalAInserted!: () => void;
+    const aInserted = new Promise<void>((resolve) => {
+      signalAInserted = resolve;
+    });
+    let releaseA!: () => void;
+    const aMayCommit = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+
+    const runA = sql.begin(async (tx) => {
+      await persistRun(tx as unknown as DbClient, 2001);
+      signalAInserted();
+      await aMayCommit;
+    });
+
+    await aInserted;
+    const runB = sql.begin(async (tx) => {
+      await persistRun(tx as unknown as DbClient, 2002);
+    });
+
+    try {
+      await waitForBlockedInsert(sql);
+    } finally {
+      releaseA();
+    }
+    await Promise.all([runA, runB]);
+
+    const all = await sql<{ id: number; supersedes_event_id: number | null }[]>`
+      SELECT id, supersedes_event_id FROM events
+      WHERE organization_id = ${organizationId} AND semantic_type = 'voice_profile'
+      ORDER BY id
+    `;
+    const live = await sql<{ id: number }[]>`
+      SELECT id FROM events
+      WHERE organization_id = ${organizationId}
+        AND semantic_type = 'voice_profile'
+        AND superseded_by IS NULL
+    `;
+
+    // Seed + A + B all survive (append-only), but they form ONE chain: exactly
+    // one live row, B re-probed after its first-attempt superseded_by collision
+    // and retried as a successor of A's row rather than surfacing a raw 23505.
+    expect(all).toHaveLength(3);
+    expect(live).toHaveLength(1);
+    expect(all[0].supersedes_event_id).toBeNull();
+    expect(all[1].supersedes_event_id).toBe(all[0].id);
+    expect(all[2].supersedes_event_id).toBe(all[1].id);
+  });
 });

--- a/packages/server/src/__tests__/integration/watchers/behavior-keyed-output-race.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/behavior-keyed-output-race.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Keyed Behavior event outputs must keep EXACTLY ONE live event per key.
+ *
+ * `persistBehaviorEventOutput` resolves the current head with a SELECT and then
+ * INSERTs inside the caller's transaction. Under READ COMMITTED a second run
+ * whose probe lands before the first run COMMITS sees no head, so both insert
+ * with `supersedes_event_id = NULL` and both stay live — permanently, silently,
+ * with no error raised. `idx_events_superseded_by` cannot catch it because it is
+ * unique on `supersedes_event_id`, which is NULL on both rows.
+ *
+ * This is not a timing test. The interleaving is forced: transaction A is held
+ * open after its insert until B has probed and committed, which is exactly the
+ * state two Behaviour runs on two replicas are in when their windows overlap.
+ */
+import type { Sql } from 'postgres';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { DbClient } from '../../../db/client';
+import { persistBehaviorEventOutput } from '../../../utils/persist-behavior-event-output';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+const KEYED_OUTPUT = {
+  event: 'voice_profile',
+  key: ['channel', 'mode'],
+} as const;
+
+/**
+ * Block until some backend is waiting on a transaction lock — the state a
+ * conflicting INSERT enters while the tuple it collides with is still
+ * uncommitted. Polls on a THIRD connection, so it observes A and B rather than
+ * participating. Throws instead of hanging, so a version of this suite where the
+ * race stops being reachable fails loudly rather than silently testing nothing.
+ */
+async function waitForBlockedInsert(sql: Sql, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await sql<{ n: number }[]>`
+      SELECT count(*)::int AS n
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND wait_event_type = 'Lock'
+        AND query ILIKE '%INSERT INTO events%'
+    `;
+    if (rows[0].n > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(
+    'no INSERT ever blocked on the identity constraint — the concurrent interleaving was not reached, so this test would prove nothing'
+  );
+}
+
+describe('Behavior keyed event outputs > concurrent runs', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('keeps exactly one live event per key when two runs interleave', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Keyed Race Org' });
+    const organizationId = workspace.org.id;
+    const watcherId = 4242;
+
+    /** One Behaviour run persisting a single keyed draft. */
+    const persistRun = (tx: DbClient, canvasRevisionId: number) =>
+      persistBehaviorEventOutput({
+        tx,
+        rows: [
+          {
+            title: 'Voice profile',
+            content: `Refinement from canvas ${canvasRevisionId}.`,
+            metadata: { channel: 'x', mode: 'taste' },
+          },
+        ],
+        outputName: 'profiles',
+        output: KEYED_OUTPUT,
+        watcherId,
+        organizationId,
+        windowId: 1,
+        // A distinct canvas revision per run — that is what a real second run
+        // produces, and it keeps the two runs off the idempotency-key index so
+        // the keyed identity is the only thing that can prevent a duplicate.
+        canvasRevisionId,
+        runId: null,
+        boundEntityIds: [],
+        validContentIds: new Set<number>(),
+        occurredAt: new Date().toISOString(),
+      });
+
+    // ── Force the interleaving ────────────────────────────────────────────
+    // A inserts, then parks with its transaction still OPEN. B therefore probes
+    // against a database where A's row is not yet visible.
+    let signalAInserted!: () => void;
+    const aInserted = new Promise<void>((resolve) => {
+      signalAInserted = resolve;
+    });
+    let releaseA!: () => void;
+    const aMayCommit = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+
+    const runA = sql.begin(async (tx) => {
+      await persistRun(tx as unknown as DbClient, 1001);
+      signalAInserted();
+      await aMayCommit;
+    });
+
+    await aInserted;
+    // B must NOT be awaited before A is released: once the identity constraint
+    // exists, B's insert blocks on A's uncommitted conflicting tuple — which is
+    // the constraint working — so awaiting B here would deadlock the test
+    // against itself rather than exercise the race.
+    const runB = sql.begin(async (tx) => {
+      await persistRun(tx as unknown as DbClient, 1002);
+    });
+
+    // Releasing A here directly would be a COIN FLIP, not a race: A usually
+    // commits while B is still acquiring its connection, so B's probe finds the
+    // committed head and performs an ordinary supersede. Measured — the retry
+    // branch was entered 0 times in 3 runs, i.e. the interesting path was never
+    // executed and a mutation to it did not fail this test.
+    //
+    // Wait for B to be genuinely BLOCKED on A's uncommitted tuple instead. That
+    // state is only reachable once B has already probed and seen no head (a
+    // READ COMMITTED SELECT never blocks), so it pins the exact interleaving:
+    // both runs believe they are creating the first version of this key.
+    // releaseA in finally: if the wait times out, A must still commit so the
+    // failure surfaces as the timeout's message, not as a hung pool teardown.
+    try {
+      await waitForBlockedInsert(sql);
+    } finally {
+      releaseA();
+    }
+    await Promise.all([runA, runB]);
+
+    const live = await sql<{ id: number; supersedes_event_id: number | null }[]>`
+      SELECT id, supersedes_event_id
+      FROM events
+      WHERE organization_id = ${organizationId}
+        AND semantic_type = 'voice_profile'
+        AND superseded_by IS NULL
+      ORDER BY id
+    `;
+
+    // Both rows must survive — events is append-only — but only one may be live.
+    const all = await sql<{ id: number; supersedes_event_id: number | null }[]>`
+      SELECT id, supersedes_event_id FROM events
+      WHERE organization_id = ${organizationId} AND semantic_type = 'voice_profile'
+      ORDER BY id
+    `;
+    expect(all).toHaveLength(2);
+    expect(live).toHaveLength(1);
+
+    // And the survivors form ONE chain, which is what proves the recovery path
+    // ran rather than the constraint merely rejecting B outright. B's first
+    // insert hit 23505 on idx_events_identity_root_behavior, so it re-probed,
+    // found A's now-committed row, and retried as A's successor.
+    const [root, successor] = all;
+    expect(root.supersedes_event_id).toBeNull();
+    expect(successor.supersedes_event_id).toBe(root.id);
+    expect(live[0].id).toBe(successor.id);
+  });
+});

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -99,6 +99,26 @@ interface InsertEventParams {
   interactionError?: string | null;
   supersedesEventId?: number | null;
 
+  /**
+   * Stable identity of the THING this row is a version of, for writers that
+   * have one. `events.id` is a stored-version id — a supersede mints a new one
+   * — so it can never serve as cross-version identity.
+   *
+   * Namespaces that claim uniqueness get their own partial unique index over
+   * chain ROOTS (see `idx_events_identity_root_behavior`), which is what makes
+   * "exactly one current version per thing" a database guarantee rather than a
+   * convention two concurrent writers can silently violate. Roots, not live
+   * heads: this function inserts the successor before stamping the
+   * predecessor's `superseded_by`, so both are briefly live and a live-head
+   * index would reject every ordinary supersede. Uniqueness is declared per
+   * namespace on purpose: `entity_identities` enforces one blanket index across
+   * every namespace and has carried a dead `uniquePerOrg` knob ever since.
+   *
+   * Rows with no stable identity (messages, notes, tombstones, change audits)
+   * leave this unset — there is no "current version of" a one-shot event.
+   */
+  identity?: { ns: string; key: string } | null;
+
   /** Audit */
   createdBy?: string | null;
   clientId?: string | null;
@@ -355,6 +375,7 @@ export async function insertEvent(
       semantic_type, client_id, created_by,
       interaction_type, interaction_status, interaction_input_schema, interaction_input,
       interaction_output, interaction_error, supersedes_event_id,
+      identity_ns, identity_key,
       linked_org_ids
     ) VALUES (
       ${entityIdsValue}::bigint[],
@@ -388,6 +409,8 @@ export async function insertEvent(
       ${params.interactionOutput ? sql.json(params.interactionOutput) : null},
       ${params.interactionError ?? null},
       ${supersedesEventId},
+      ${params.identity?.ns ?? null},
+      ${params.identity?.key ?? null},
       (
         SELECT COALESCE(array_agg(DISTINCT x.o), '{}'::text[])
         FROM (

--- a/packages/server/src/utils/persist-behavior-event-output.ts
+++ b/packages/server/src/utils/persist-behavior-event-output.ts
@@ -1,9 +1,14 @@
 import type { DbClient } from '../db/client';
 import type { EventOutput } from '../types/watchers';
-import { ToolUserError } from './errors';
+import { errorMessage, ToolUserError } from './errors';
 import { insertEvent, type InsertedEvent } from './insert-event';
 import { isUniqueViolation } from './pg-errors';
 import { validateSaveContentSemanticType } from './event-kind-validation';
+import {
+  BEHAVIOR_EVENT_IDENTITY_NS,
+  computeStableKey,
+  formatBehaviorEventIdentity,
+} from './stable-keys';
 
 interface EventDraft {
   content: string;
@@ -51,38 +56,46 @@ async function findByIdempotencyKey(
 }
 
 /**
- * The current head event for a keyed event output: the latest row of the
- * output's semantic type whose metadata carries the given key field values and
- * that nothing has superseded yet. `superseded_by IS NULL` identifies heads —
- * the insert-time dual-write stamps the replaced row's `superseded_by`, so a
- * key keeps exactly one current event while history stays append-only. The
- * match is scoped by (org, semantic type, key values) — deliberately NOT by
- * `behavior_id`, so a migrated/legacy event that predates the Behavior becomes
- * the supersede target of its first run rather than a duplicate.
+ * The current head event for a keyed event output, by stable identity.
+ *
+ * `superseded_by IS NULL` identifies heads — the insert-time dual-write stamps
+ * the replaced row's `superseded_by`, so a key keeps exactly one current event
+ * while history stays append-only.
+ *
+ * The lookup is scoped by (org, identity) and deliberately NOT by `behavior_id`:
+ * an event carrying a keyed identity may predate the Behavior that now maintains
+ * it — prod's first four `voice_profile` rows were written by a migration with
+ * no `behavior_id`. Behavior-scoping would leave those permanently unadoptable.
+ *
+ * Adoption of such rows is a DELIBERATE one-time act
+ * (scripts/backfill-event-identity.ts stamping the identity this same function
+ * computes), never an ambient effect of a run matching some metadata. A row that
+ * nothing claimed an identity for is inert: it is not a supersede candidate, and
+ * a run extends only its own chain.
+ *
+ * This replaces a `metadata @>` containment probe that was wrong in three
+ * ways. It stringified key values before matching type-sensitive jsonb, so a
+ * numeric or whitespace-padded value never matched its own head and every run
+ * appended another live one. Containment is SUBSET matching, so shrinking a
+ * declared key silently superseded a DIFFERENT key's head. And with no GIN
+ * index on `events.metadata` it degraded to a bitmap heap scan over the org's
+ * whole history — measured at 970 ms per probe against 1.2 ms via
+ * idx_events_identity_head_behavior, whose predicate matches this WHERE
+ * exactly (the root index serves the CONSTRAINT, not this probe: heads are
+ * usually not roots).
  */
-async function findCurrentHeadByKey(
+async function findCurrentHeadByIdentity(
   tx: DbClient,
   organizationId: string,
-  semanticType: string,
-  keyFields: readonly string[],
-  metadata: Record<string, unknown>
+  identityKey: string
 ): Promise<number | null> {
-  const keyJson: Record<string, string> = {};
-  for (const field of keyFields) {
-    const value = metadata[field];
-    const str =
-      value === undefined || value === null ? null : String(value).trim();
-    if (!str) return null;
-    keyJson[field] = str;
-  }
   const rows = await tx<{ id: number }>`
     SELECT id
     FROM events
     WHERE organization_id = ${organizationId}
-      AND semantic_type = ${semanticType}
+      AND identity_ns = ${BEHAVIOR_EVENT_IDENTITY_NS}
+      AND identity_key = ${identityKey}
       AND superseded_by IS NULL
-      AND metadata @> ${tx.json(keyJson)}
-    ORDER BY created_at DESC, id DESC
     LIMIT 1
   `;
   return rows[0]?.id ?? null;
@@ -132,37 +145,41 @@ export async function persistBehaviorEventOutput(
     const metadata = { ...(draft.metadata ?? {}) };
     delete metadata._lobu_idempotency_key;
 
-    // Keyed event output: resolve the current head for this key and supersede
-    // it, so the type keeps exactly one current event per key. A missing key
-    // field is a malformed draft (the model must emit every declared key
-    // field); a duplicate key within one array would otherwise double-supersede
+    // Keyed event output: derive the draft's stable identity, resolve the
+    // current head for it, and supersede that head — so the type keeps exactly
+    // one current event per key. The identity is derived SERVER-SIDE from the
+    // declared key fields, never taken from the model: prod's `profile_key`
+    // shows why, having drifted from `x:taste` to `x_taste` between two runs of
+    // the same Behavior. A duplicate key within one array would double-supersede
     // the same head, so it is rejected up front.
     let supersedesEventId: number | null = null;
+    let identityKey: string | null = null;
     if (keyFields) {
-      const missing = keyFields.filter((f) => {
-        const v = metadata[f];
-        return v === undefined || v === null || String(v).trim() === '';
-      });
-      if (missing.length > 0) {
+      // computeStableKey enforces the whole field contract — present, non-blank,
+      // scalar, safe integer, within the field-count and byte bounds — and
+      // type-tags each value so numeric 3 and string '3' stay distinct
+      // identities instead of being collapsed by String().
+      let stableKey: string;
+      try {
+        stableKey = computeStableKey(metadata, keyFields);
+      } catch (error) {
         throw new ToolUserError(
-          `outputs.${params.outputName}[${index}] is missing required key field(s) in metadata: ${missing.join(', ')}.`,
+          `outputs.${params.outputName}[${index}] has an invalid key (${keyFields.join(', ')}): ${errorMessage(error)}`,
           422
         );
       }
-      const keyValue = keyFields.map((f) => `${f}=${String(metadata[f]).trim()}`).join('&');
-      if (seenKeyValues.has(keyValue)) {
+      identityKey = formatBehaviorEventIdentity(params.output.event, stableKey);
+      if (seenKeyValues.has(identityKey)) {
         throw new ToolUserError(
           `outputs.${params.outputName} contains a duplicate key (${keyFields.join(', ')}) at item ${index}.`,
           422
         );
       }
-      seenKeyValues.add(keyValue);
-      supersedesEventId = await findCurrentHeadByKey(
+      seenKeyValues.add(identityKey);
+      supersedesEventId = await findCurrentHeadByIdentity(
         params.tx,
         params.organizationId,
-        params.output.event,
-        keyFields,
-        metadata
+        identityKey
       );
     }
 
@@ -250,33 +267,76 @@ export async function persistBehaviorEventOutput(
       window_id: params.windowId,
       window_revision_id: params.canvasRevisionId,
     };
-    try {
-      inserted.push(
-        await params.tx.savepoint((sp) =>
-          insertEvent(
-            {
-              entityIds: params.boundEntityIds,
-              organizationId: params.organizationId,
-              originId,
-              title: draft.title ?? null,
-              payloadType: draft.payload_type ?? 'text',
-              content: draft.content,
-              authorName: draft.author ?? null,
-              sourceUrl: draft.source_url ?? parentSourceUrl,
-              occurredAt: draft.occurred_at ?? params.occurredAt,
-              semanticType: params.output.event,
-              originType: params.output.event,
-              metadata: eventMetadata,
-              parentOriginId,
-              supersedesEventId,
-              runId: params.runId,
-              createdBy: params.createdBy ?? null,
-            },
-            { sql: sp }
-          )
+    const writeEvent = (headId: number | null) =>
+      params.tx.savepoint((sp) =>
+        insertEvent(
+          {
+            entityIds: params.boundEntityIds,
+            organizationId: params.organizationId,
+            originId,
+            title: draft.title ?? null,
+            payloadType: draft.payload_type ?? 'text',
+            content: draft.content,
+            authorName: draft.author ?? null,
+            sourceUrl: draft.source_url ?? parentSourceUrl,
+            occurredAt: draft.occurred_at ?? params.occurredAt,
+            semanticType: params.output.event,
+            originType: params.output.event,
+            metadata: eventMetadata,
+            parentOriginId,
+            supersedesEventId: headId,
+            identity: identityKey
+              ? { ns: BEHAVIOR_EVENT_IDENTITY_NS, key: identityKey }
+              : null,
+            runId: params.runId,
+            createdBy: params.createdBy ?? null,
+          },
+          { sql: sp }
         )
       );
+
+    try {
+      inserted.push(await writeEvent(supersedesEventId));
     } catch (error) {
+      // A concurrent run committed a head for this identity between our probe
+      // and our insert. The unique index rejected us rather than letting both
+      // rows stay live, which is the whole point — re-resolve the winner and
+      // supersede it. One retry only: a second rejection means yet another run
+      // beat us, and returning a 409 to a Behavior window is the correct
+      // fail-closed outcome rather than looping.
+      if (
+        identityKey &&
+        isUniqueViolation(error, 'idx_events_identity_root_behavior')
+      ) {
+        const winnerHead = await findCurrentHeadByIdentity(
+          params.tx,
+          params.organizationId,
+          identityKey
+        );
+        if (winnerHead === null) throw error;
+        try {
+          inserted.push(await writeEvent(winnerHead));
+        } catch (retryError) {
+          // Two ways the retry can still lose, and both mean the same thing —
+          // a third writer moved the chain under us. The retry inserts a
+          // SUCCESSOR (supersedes_event_id is non-NULL), so it is not in the
+          // root index; it collides on idx_events_superseded_by instead, which
+          // is unique on supersedes_event_id and rejects a second successor for
+          // the head we just read. Accept either as the same lost race rather
+          // than surfacing a raw 23505.
+          if (
+            isUniqueViolation(retryError, 'idx_events_identity_root_behavior') ||
+            isUniqueViolation(retryError, 'idx_events_superseded_by')
+          ) {
+            throw new ToolUserError(
+              `outputs.${params.outputName}[${index}] lost a concurrent write for its key (${(keyFields ?? []).join(', ')}); retry the completion.`,
+              409
+            );
+          }
+          throw retryError;
+        }
+        continue;
+      }
       if (!isUniqueViolation(error, 'idx_events_org_idempotency_key')) throw error;
       const winner = await findByIdempotencyKey(
         params.tx,

--- a/packages/server/src/utils/persist-behavior-event-output.ts
+++ b/packages/server/src/utils/persist-behavior-event-output.ts
@@ -304,9 +304,21 @@ export async function persistBehaviorEventOutput(
       // supersede it. One retry only: a second rejection means yet another run
       // beat us, and returning a 409 to a Behavior window is the correct
       // fail-closed outcome rather than looping.
+      //
+      // Two indices can reject the FIRST attempt, depending on which head both
+      // runs probed:
+      //   * root collision — neither saw a head, both inserted roots
+      //     (supersedes_event_id IS NULL, so idx_events_superseded_by cannot
+      //     see them);
+      //   * superseded_by collision — both saw the SAME committed head and both
+      //     inserted successors of it (a successor is not in the root index, so
+      //     only the superseded_by index can catch it).
+      // Either way the recovery is identical: re-resolve the winner and retry
+      // as its successor.
       if (
         identityKey &&
-        isUniqueViolation(error, 'idx_events_identity_root_behavior')
+        (isUniqueViolation(error, 'idx_events_identity_root_behavior') ||
+          isUniqueViolation(error, 'idx_events_superseded_by'))
       ) {
         const winnerHead = await findCurrentHeadByIdentity(
           params.tx,

--- a/packages/server/src/utils/persist-behavior-event-output.ts
+++ b/packages/server/src/utils/persist-behavior-event-output.ts
@@ -56,6 +56,33 @@ async function findByIdempotencyKey(
 }
 
 /**
+ * Recover from a concurrent duplicate completion: `idx_events_org_idempotency_key`
+ * rejected our insert because another run committed the same idempotency key
+ * between our probe and our write. Adopt that committed row instead of
+ * surfacing a raw 23505. Shared by the first-attempt catch and the identity
+ * retry — a duplicate completion can race BOTH indices at once (two concurrent
+ * runs of the same output carry the same per-item key, and may also probe the
+ * same identity head), and either order must dedupe, not crash.
+ */
+async function recoverIdempotencyWinner(
+  tx: DbClient,
+  organizationId: string,
+  event: string,
+  idempotencyKey: string,
+  cause: unknown
+): Promise<InsertedEvent> {
+  const winner = await findByIdempotencyKey(tx, organizationId, idempotencyKey);
+  if (!winner) throw cause;
+  if (winner.semantic_type !== event) {
+    throw new ToolUserError(
+      `Behavior output idempotency key already belongs to '${winner.semantic_type}'.`,
+      409
+    );
+  }
+  return winner;
+}
+
+/**
  * The current head event for a keyed event output, by stable identity.
  *
  * `superseded_by IS NULL` identifies heads — the insert-time dual-write stamps
@@ -329,13 +356,15 @@ export async function persistBehaviorEventOutput(
         try {
           inserted.push(await writeEvent(winnerHead));
         } catch (retryError) {
-          // Two ways the retry can still lose, and both mean the same thing —
-          // a third writer moved the chain under us. The retry inserts a
-          // SUCCESSOR (supersedes_event_id is non-NULL), so it is not in the
+          // The retry can lose three ways, and the first two mean the same
+          // thing — a third writer moved the chain under us. The retry inserts
+          // a SUCCESSOR (supersedes_event_id is non-NULL), so it is not in the
           // root index; it collides on idx_events_superseded_by instead, which
           // is unique on supersedes_event_id and rejects a second successor for
           // the head we just read. Accept either as the same lost race rather
-          // than surfacing a raw 23505.
+          // than surfacing a raw 23505. The third is a concurrent duplicate
+          // completion (shared explicit idempotency key) that won the write —
+          // dedupe onto its row rather than crashing, same as the first attempt.
           if (
             isUniqueViolation(retryError, 'idx_events_identity_root_behavior') ||
             isUniqueViolation(retryError, 'idx_events_superseded_by')
@@ -345,23 +374,30 @@ export async function persistBehaviorEventOutput(
               409
             );
           }
+          if (isUniqueViolation(retryError, 'idx_events_org_idempotency_key')) {
+            inserted.push(
+              await recoverIdempotencyWinner(
+                params.tx,
+                params.organizationId,
+                params.output.event,
+                idempotencyKey,
+                retryError
+              )
+            );
+            continue;
+          }
           throw retryError;
         }
         continue;
       }
       if (!isUniqueViolation(error, 'idx_events_org_idempotency_key')) throw error;
-      const winner = await findByIdempotencyKey(
+      const winner = await recoverIdempotencyWinner(
         params.tx,
         params.organizationId,
-        idempotencyKey
+        params.output.event,
+        idempotencyKey,
+        error
       );
-      if (!winner) throw error;
-      if (winner.semantic_type !== params.output.event) {
-        throw new ToolUserError(
-          `Behavior output idempotency key already belongs to '${winner.semantic_type}'.`,
-          409
-        );
-      }
       inserted.push(winner);
     }
   }

--- a/packages/server/src/utils/stable-keys.ts
+++ b/packages/server/src/utils/stable-keys.ts
@@ -12,6 +12,10 @@ export const MAX_STABLE_KEY_COMPONENT_BYTES = 256;
 
 const STABLE_KEY_VERSION = 'v1';
 const BEHAVIOR_ENTITY_IDENTITY_VERSION = 'v2';
+const BEHAVIOR_EVENT_IDENTITY_VERSION = 'v1';
+
+/** `events.identity_ns` for a keyed Behavior event output. */
+export const BEHAVIOR_EVENT_IDENTITY_NS = 'behavior_event';
 
 /**
  * Scope a stable tuple to the Behavior output and its declared entity type.
@@ -27,6 +31,29 @@ export function formatBehaviorEntityIdentity(
   const scopedTuple = `${watcherId}::${outputName}::${entityTypeSlug}::${stableKey}`;
   const digest = createHash('sha256').update(scopedTuple, 'utf8').digest('hex');
   return `${BEHAVIOR_ENTITY_IDENTITY_VERSION}::${digest}`;
+}
+
+/**
+ * Scope a stable tuple to a keyed EVENT output's semantic type.
+ *
+ * Deliberately NOT scoped by Behavior, unlike the entity sibling above. An
+ * event carrying a keyed identity may predate the Behavior that now maintains
+ * it — prod's first four `voice_profile` rows were written by a migration with
+ * no `behavior_id` and were adopted (superseded) by the Behavior's first run.
+ * Watcher-scoping would have made those rows unadoptable and left them live
+ * forever beside the Behavior's own. Entities can afford watcher-scoping
+ * because an entity is only ever created by its Behavior; events cannot.
+ *
+ * The digest keeps every contract-valid tuple inside PostgreSQL's B-tree key
+ * limit; the exact key fields remain in `metadata` for inspection.
+ */
+export function formatBehaviorEventIdentity(
+  semanticType: string,
+  stableKey: string
+): string {
+  const scopedTuple = `${semanticType}::${stableKey}`;
+  const digest = createHash('sha256').update(scopedTuple, 'utf8').digest('hex');
+  return `${BEHAVIOR_EVENT_IDENTITY_VERSION}::${digest}`;
 }
 
 function encode(value: string): string {

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -403,7 +403,9 @@ export const QUERYABLE_SCHEMA = {
           'interaction_input',
           'interaction_output',
           'interaction_error',
-          'supersedes_event_id'
+          'supersedes_event_id',
+          'identity_ns',
+          'identity_key'
         ),
       ],
     },

--- a/scripts/backfill-event-identity.ts
+++ b/scripts/backfill-event-identity.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+
+/**
+ * One-time adoption of `events.identity_ns` / `events.identity_key` for keyed
+ * Behavior EVENT outputs (migration 20260806120000_events_identity_key).
+ *
+ * ─── Why this exists ─────────────────────────────────────────────────────────
+ * A keyed output declares `{ event: "voice_profile", key: ["channel","mode"] }`
+ * and must keep exactly one live event per key. From this migration on,
+ * insertEvent stamps the identity at write time and
+ * idx_events_identity_root_behavior enforces one chain ROOT per key. Rows that
+ * existed before carry NULL, so the first post-deploy run would probe by
+ * identity, find nothing, insert a fresh root, and leave the old chain live —
+ * manufacturing exactly the duplicate the index exists to prevent. This script
+ * stamps them first.
+ *
+ * ─── Why not in the migration ────────────────────────────────────────────────
+ * The key is computed by computeStableKey()/formatBehaviorEventIdentity()
+ * (packages/server/src/utils/stable-keys.ts): base64url, per-scalar type tags,
+ * a UTF-16 field-name budget, safe-integer canonicalisation, JS trim semantics.
+ * Restating that in SQL means two implementations of one algorithm, and any
+ * drift between them stamps a key no run can ever probe for — the exact failure
+ * this adoption is meant to prevent, made silent. So the migration adds columns
+ * only and adoption calls the real function.
+ *
+ * ─── Ordering contract ───────────────────────────────────────────────────────
+ * Run to completion BEFORE any keyed Behavior runs on the new build. The unique
+ * index may be in place already: it is empty while every identity_key is NULL,
+ * and once populated a genuinely duplicated key surfaces as a 23505 naming the
+ * offending row rather than as a whole-migration abort. That is the intended
+ * failure mode — two live chains for one key is a data question, not something
+ * this script should pick a winner for.
+ *
+ * ─── Exactly what it does ────────────────────────────────────────────────────
+ * Reads the keyed EVENT outputs of every CURRENT Behavior version (historical
+ * versions may declare a superseded key and would offer a second candidate
+ * identity for the same row), then stamps every matching event — superseded
+ * versions included, because identity belongs to the THING, not to one version
+ * of it, and the index constrains roots, which are usually superseded.
+ *
+ * Rows whose metadata does not satisfy the key contract are SKIPPED, not
+ * guessed: they stay NULL and therefore inert, exactly as they are today.
+ *
+ * ─── Safety ──────────────────────────────────────────────────────────────────
+ *   - DRY-RUN by default; pass --execute to write.
+ *   - Idempotent and resumable: only still-NULL rows are touched.
+ *   - Batched autocommit updates; no long transaction, no lock buildup.
+ *
+ * DATABASE_URL must point at the target database.
+ */
+
+import { parseArgs as parseNodeArgs } from "node:util";
+import { getDb } from "../packages/server/src/db/client";
+import {
+  BEHAVIOR_EVENT_IDENTITY_NS,
+  computeStableKey,
+  formatBehaviorEventIdentity,
+} from "../packages/server/src/utils/stable-keys";
+
+const { values: args } = parseNodeArgs({
+  options: {
+    execute: { type: "boolean", default: false },
+    batch: { type: "string", default: "500" },
+  },
+});
+
+const EXECUTE = Boolean(args.execute);
+const BATCH = Math.max(50, Number(args.batch ?? 500));
+
+type KeyedOutput = {
+  organization_id: string;
+  semantic_type: string;
+  key_fields: string[];
+};
+
+type Candidate = {
+  id: number;
+  metadata: Record<string, unknown> | null;
+};
+
+async function main() {
+  const sql = getDb();
+
+  // Current versions only — a superseded declaration would offer a second
+  // candidate identity for the same event.
+  //
+  // key_fields stays JSONB rather than text[]: the pool runs with
+  // fetch_types:false, so a Postgres array arrives as the raw literal string
+  // "{channel,mode}" while jsonb is parsed into a real JS array.
+  const outputs = await sql<KeyedOutput>`
+		SELECT DISTINCT
+			w.organization_id,
+			o.value ->> 'event' AS semantic_type,
+			o.value -> 'key' AS key_fields
+		FROM watchers w
+		JOIN watcher_versions wv ON wv.id = w.current_version_id
+		CROSS JOIN LATERAL jsonb_each(wv.outputs) o
+		WHERE o.value ->> 'event' IS NOT NULL
+		  AND jsonb_typeof(o.value -> 'key') = 'array'
+	`;
+
+  if (outputs.length === 0) {
+    console.log("no keyed event outputs declared; nothing to do");
+    await sql.end();
+    return;
+  }
+
+  // Two Behaviors in one org keying the same semantic type differently is not
+  // resolvable here: each claims a different identity for the same row, and
+  // whichever won would leave the other probing for a key that does not exist.
+  const byScope = new Map<string, KeyedOutput[]>();
+  for (const output of outputs) {
+    const scope = `${output.organization_id}::${output.semantic_type}`;
+    byScope.set(scope, [...(byScope.get(scope) ?? []), output]);
+  }
+  const conflicts = [...byScope.entries()].filter(([, v]) => v.length > 1);
+  if (conflicts.length > 0) {
+    console.error(
+      `conflicting key declarations for: ${conflicts.map(([k]) => k).join(", ")}`
+    );
+    console.error("reconcile the Behavior declarations before adopting.");
+    process.exit(1);
+  }
+
+  console.log(
+    `${outputs.length} keyed event output(s): ${outputs
+      .map((o) => `${o.semantic_type}[${o.key_fields.join(",")}]`)
+      .join(", ")}`
+  );
+
+  let stamped = 0;
+  let skipped = 0;
+
+  for (const output of outputs) {
+    // Walk forward by id rather than re-reading "identity_key IS NULL". Skipped
+    // rows stay NULL by design, so a NULL-only predicate would hand back the
+    // same unrepresentable rows on every batch and never terminate.
+    let cursor = 0;
+    let outputStamped = 0;
+    let outputSkipped = 0;
+
+    for (;;) {
+      const candidates = await sql<Candidate>`
+				SELECT id, metadata
+				FROM events
+				WHERE organization_id = ${output.organization_id}
+				  AND semantic_type = ${output.semantic_type}
+				  AND identity_key IS NULL
+				  AND id > ${cursor}
+				ORDER BY id
+				LIMIT ${BATCH}
+			`;
+      if (candidates.length === 0) break;
+      cursor = candidates[candidates.length - 1].id;
+
+      for (const row of candidates) {
+        let identityKey: string;
+        try {
+          identityKey = formatBehaviorEventIdentity(
+            output.semantic_type,
+            computeStableKey(row.metadata ?? {}, output.key_fields)
+          );
+        } catch {
+          // Metadata does not satisfy the key contract, so no run could ever
+          // compute an identity for it either. Leave it NULL and inert.
+          outputSkipped++;
+          continue;
+        }
+        if (!EXECUTE) {
+          outputStamped++;
+          continue;
+        }
+        // One statement per row: a batched VALUES join buys nothing at this
+        // scale and a 23505 here must name the row it collided on. Two live
+        // chain roots for one key is a data question, not something this script
+        // should pick a winner for.
+        await sql`
+					UPDATE events
+					SET identity_ns  = ${BEHAVIOR_EVENT_IDENTITY_NS},
+					    identity_key = ${identityKey}
+					WHERE id = ${row.id} AND identity_key IS NULL
+				`;
+        outputStamped++;
+      }
+    }
+
+    stamped += outputStamped;
+    skipped += outputSkipped;
+    console.log(
+      `  ${output.semantic_type}[${output.key_fields.join(",")}]: ${
+        EXECUTE ? "stamped" : "would stamp"
+      } ${outputStamped}, skipped ${outputSkipped}`
+    );
+  }
+
+  if (!EXECUTE) {
+    console.log(
+      `DRY-RUN: ${stamped} row(s) would be stamped, ${skipped} skipped. Pass --execute to adopt.`
+    );
+    await sql.end();
+    return;
+  }
+
+  console.log(
+    `done: ${stamped} stamped, ${skipped} skipped (metadata cannot satisfy the declared key)`
+  );
+  await sql.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Keyed Behavior event outputs must keep exactly one live event per key, but `events.id` is a stored-version id and the old `metadata @>` containment probe was wrong in three ways: it stringified key values before type-sensitive jsonb matching (numeric/whitespace-padded values never matched their own head, so every run appended another live one); containment is subset matching (shrinking a declared key silently superseded a DIFFERENT key's head); and with no GIN index on `events.metadata` it degraded to a bitmap heap scan over the org's whole history (~970ms per probe).

Fixes it at the schema, not the probe:
- `events.identity_ns` / `events.identity_key` columns, stamped **server-side** by the writer from the declared key fields (`computeStableKey`), never model-authored
- `idx_events_identity_root_behavior` — unique partial index over chain ROOTS, making "exactly one current version per key" a DB guarantee rather than a convention two concurrent replicas can silently break (the dual-write window between INSERT and the `superseded_by` stamp is why the constraint keys roots, not live heads)
- `idx_events_identity_head_behavior` — non-unique probe index matching the head lookup's WHERE exactly (1.2ms vs 970ms)
- fail-closed one-retry recovery when a concurrent run wins the identity race, else a clean 409
- `scripts/backfill-event-identity.ts` — conflict-detecting, batched, dry-run-by-default adoption of pre-migration rows, stamping via the real `computeStableKey`/`formatBehaviorEventIdentity` (not a SQL mirror of the algorithm)
- identity exposed through `QUERYABLE_SCHEMA` + `current_event_records` so `query_sql` can read it
- existing legacy rows stay NULL and therefore inert — a keyed run never hijacks an event nobody claimed an identity for

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Integration: `behavior-event-outputs.test.ts` + new `behavior-keyed-output-race.test.ts` (forced concurrent interleaving via a blocked INSERT) — 5/5 green
- [x] Full watchers + utils suites: 1178 tests green
- [x] `query_sql` integration suites green after exposing the columns
- [x] Migrations apply cleanly via `scripts/migrate-up.mjs` (the prod runner) on a fresh DB; squawk lint clean on all 4 files
- [x] Backfill script exercised end-to-end on a scratch DB: dry-run → execute → idempotent re-run → conflict detection exits 1

## Notes
Rollout ordering: run `scripts/backfill-event-identity.ts` (dry-run first) BEFORE any keyed Behavior run lands on the new build, so pre-existing rows are adopted into their chains rather than leaving live duplicates. The unique index may be in place already — it's empty while every `identity_key` is NULL, and a genuinely duplicated key surfaces as a 23505 naming the row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Behavior events now support stable identities across versions, enabling reliable supersession and adoption of existing events.
  - Event records expose identity and supersession information for querying.
  - Concurrent event writes are handled safely, preserving a single current event per identity.
  - Added a resumable, dry-run-capable tool for assigning identities to eligible existing events.

- **Bug Fixes**
  - Improved keyed-event matching to avoid incorrectly superseding unrelated events.
  - Added clearer validation for missing, invalid, unsafe, or oversized event keys.

- **Documentation**
  - Clarified event identity behavior and supported key value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->