### PR TITLE
feat(server): stamp runs.outcome taxonomy at every Behavior terminal writer

### DIFF
--- a/db/migrations/20260807000000_runs_outcome.sql
+++ b/db/migrations/20260807000000_runs_outcome.sql
@@ -1,0 +1,32 @@
+-- Outcome taxonomy for terminal runs (evals PR 1, lobu#2564).
+--
+-- A terminal run's `status` says HOW it ended (completed/failed/timeout); it
+-- does not say WHOSE FAULT it was. The July-2026 z.ai quota storm read as a
+-- 61-78% Behavior "prompt regression" because 2,200+ provider 429s and ~370
+-- genuine agent protocol violations landed in the same `failed` bucket.
+--
+-- `outcome` classifies a terminal run at WRITE TIME (request paths never
+-- aggregate history):
+--   infra_error  - provider/platform/config fault; the run is not evidence
+--                  about the agent (quota, auth, worker death, dispatch
+--                  failure, timeout).
+--   agent_error  - the agent ran and misbehaved (finalize miss, CLI crash);
+--                  quality-relevant.
+--   scoreable    - completed cleanly; judgeable by the eval layer.
+-- NULL          - non-terminal, cancelled, a non-behavior completed/failed
+--                 run (their writers don't stamp: agent_error/scoreable are
+--                 agent-run concepts — eval reads filter run_type='behavior'),
+--                 or predating the backfill
+--                 (scripts/backfill-run-outcomes.ts fills history by calling
+--                 the real classifier, never a SQL mirror of it).
+--
+-- Single classifier: packages/server/src/runs/run-outcome.ts.
+
+-- migrate:up
+ALTER TABLE public.runs
+  ADD COLUMN IF NOT EXISTS outcome text
+  CONSTRAINT runs_outcome_check
+  CHECK (outcome = ANY (ARRAY['infra_error'::text, 'agent_error'::text, 'scoreable'::text]));
+
+-- migrate:down
+ALTER TABLE public.runs DROP COLUMN IF EXISTS outcome;

--- a/packages/server/src/__tests__/integration/watchers/completed-run-model-provenance.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/completed-run-model-provenance.test.ts
@@ -78,6 +78,12 @@ async function modelUsedOf(runId: number): Promise<string | null> {
 	return (row?.model_used as string | null) ?? null;
 }
 
+async function outcomeOf(runId: number): Promise<string | null> {
+	const sql = getTestDb();
+	const [row] = await sql`SELECT outcome FROM runs WHERE id = ${runId}`;
+	return (row?.outcome as string | null) ?? null;
+}
+
 describe("a completed Behavior run records who executed it", () => {
 	it("replaces the 'external-client' placeholder with the real executor", async () => {
 		const { runId } = await createDispatchedRun({
@@ -91,6 +97,23 @@ describe("a completed Behavior run records who executed it", () => {
 		});
 
 		expect(await modelUsedOf(runId)).toBe("lobu-agent");
+		expect(await outcomeOf(runId)).toBe("scoreable");
+	});
+
+	it("stamps a failed run's outcome from the terminal error (quota → infra_error)", async () => {
+		const { runId } = await createDispatchedRun({
+			slug: "outcome-quota-fail",
+			messageId: "msg-outcome-quota-fail",
+			modelUsed: null,
+		});
+
+		await resolveWatcherRunsByMessageIds(["msg-outcome-quota-fail"], {
+			ok: false,
+			error:
+				"z.ai returned an error:\n429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-08-01",
+		});
+
+		expect(await outcomeOf(runId)).toBe("infra_error");
 	});
 
 	it("stamps a run that never had any model recorded", async () => {

--- a/packages/server/src/__tests__/unit/behavior-health.test.ts
+++ b/packages/server/src/__tests__/unit/behavior-health.test.ts
@@ -17,6 +17,37 @@ describe("computeBehaviorHealth", () => {
 		expect(result.health).toBe("degraded");
 		expect(result.last_scheduling_error).toBe("No model is configured");
 		expect(result.reasons.join(" ")).toContain("No model is configured");
+		expect(result.last_run_outcome).toBeNull();
+	});
+
+	it("labels the degraded reason with the stamped run outcome", () => {
+		const result = computeBehaviorHealth(
+			{
+				status: "active",
+				nextRunAt: new Date(NOW + 60_000).toISOString(),
+				latestRunStatus: "failed",
+				latestRunError: "z.ai returned an error:\n429 Weekly/Monthly Limit Exhausted",
+				latestRunOutcome: "infra_error",
+			},
+			NOW,
+		);
+		expect(result.health).toBe("degraded");
+		expect(result.last_run_outcome).toBe("infra_error");
+		expect(result.reasons.join(" ")).toContain("latest run failed (infra_error)");
+	});
+
+	it("echoes a scoreable outcome on a healthy behavior", () => {
+		const result = computeBehaviorHealth(
+			{
+				status: "active",
+				nextRunAt: new Date(NOW + 60_000).toISOString(),
+				latestRunStatus: "completed",
+				latestRunOutcome: "scoreable",
+			},
+			NOW,
+		);
+		expect(result.health).toBe("healthy");
+		expect(result.last_run_outcome).toBe("scoreable");
 	});
 
 	it("degrades on a timeout latest run too", () => {

--- a/packages/server/src/__tests__/unit/runs/run-outcome.test.ts
+++ b/packages/server/src/__tests__/unit/runs/run-outcome.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { AgentErrorCode } from "@lobu/core";
+import { classifyRunOutcome } from "../../../runs/run-outcome";
+
+describe("classifyRunOutcome", () => {
+	it("marks completed runs scoreable", () => {
+		expect(classifyRunOutcome({ status: "completed" })).toBe("scoreable");
+	});
+
+	it("marks every timeout infra_error regardless of message", () => {
+		expect(classifyRunOutcome({ status: "timeout" })).toBe("infra_error");
+		expect(
+			classifyRunOutcome({
+				status: "timeout",
+				errorMessage:
+					"Behavior run remained pending for over 2 hours without being claimed",
+			}),
+		).toBe("infra_error");
+	});
+
+	it("returns null for non-terminal and cancelled runs", () => {
+		for (const status of ["pending", "claimed", "running", "cancelled"]) {
+			expect(classifyRunOutcome({ status })).toBeNull();
+		}
+	});
+
+	it("maps every catalogued AgentErrorCode to infra_error", () => {
+		for (const code of Object.values(AgentErrorCode)) {
+			expect(
+				classifyRunOutcome({
+					status: "failed",
+					errorCode: code,
+					errorMessage: "irrelevant",
+				}),
+			).toBe("infra_error");
+		}
+	});
+
+	// The message corpus below is verbatim from prod (14-day window, 2026-08-06)
+	// — the z.ai quota storm that motivated the taxonomy plus the long tail.
+	const PROD_INFRA_MESSAGES = [
+		"z.ai returned an error:\n429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-08-01",
+		"429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-31 04:32:47",
+		"429 Usage limit reached for 5 hour. Your limit will reset at 2026-07-24 09:00:22",
+		"z.ai returned an error:\n429 Insufficient balance or no resource package. Please recharge.",
+		"Gemini returned an error:\n429 status code (no body)",
+		"The agent didn't finish responding in time. This is usually temporary — please try again.",
+		"The operation timed out.",
+		'Failed to create or resume Lobu agent session (401): {"success":false,"error":"Unauthorized"}',
+		'Failed to enqueue Lobu Behavior message (401): {"success":false,"error":"Unauthorized"}',
+		"no local agent executor configured for agent_kind='opencode'",
+		"claude exited via SIGKILL after 300s timeout",
+		"agy exited with status 1: Authentication required. Please visit the URL to log in:\n  https://example.com",
+		"Behavior run blocked on tool approval after 2 attempt(s): lobu-memory/run_sdk queued for human approval, so complete_window never ran.",
+	];
+
+	it.each(
+		PROD_INFRA_MESSAGES,
+	)("classifies prod infra message as infra_error: %s", (message) => {
+		expect(
+			classifyRunOutcome({ status: "failed", errorMessage: message }),
+		).toBe("infra_error");
+	});
+
+	const PROD_AGENT_MESSAGES = [
+		"Agent reply finished without calling run_sdk (client.behaviors.completeWindow) after 2 attempt(s). No active tool approval was found, so check that the assigned agent has the lobu-memory MCP attached.",
+		"Device CLI exited without calling completeWindow after 2 attempt(s). Use the lobu skill + `lobu memory exec` (knowledge.read → completeWindow) or MCP query_sdk/run_sdk.",
+		"claude exited with non-zero status 1",
+	];
+
+	it.each(
+		PROD_AGENT_MESSAGES,
+	)("classifies prod agent-fault message as agent_error: %s", (message) => {
+		expect(
+			classifyRunOutcome({ status: "failed", errorMessage: message }),
+		).toBe("agent_error");
+	});
+
+	it("defaults unknown failures to agent_error (fail toward visibility)", () => {
+		expect(
+			classifyRunOutcome({
+				status: "failed",
+				errorMessage: "manual reclaim after e2e prep",
+			}),
+		).toBe("agent_error");
+		expect(classifyRunOutcome({ status: "failed" })).toBe("agent_error");
+	});
+});

--- a/packages/server/src/runs/run-outcome.ts
+++ b/packages/server/src/runs/run-outcome.ts
@@ -1,0 +1,122 @@
+/**
+ * Outcome taxonomy for terminal runs (evals PR 1, lobu#2564).
+ *
+ * `runs.status` says HOW a run ended; `runs.outcome` says whose fault it was —
+ * which is the question every quality read actually asks. The July-2026 z.ai
+ * quota storm was misread as a prompt regression because provider 429s and
+ * genuine agent protocol violations shared the `failed` bucket.
+ *
+ * This is THE classifier, and its stamping scope is deliberate:
+ *  - every Behavior-run terminal-status writer stamps
+ *    `outcome = classifyRunOutcome(...)` in the same UPDATE;
+ *  - every `status = 'timeout'` writer and every poll.ts dispatch-failure
+ *    writer stamps regardless of run_type — those classifications are
+ *    message-independent (a timeout or a run the agent never received is
+ *    infra for any run type);
+ *  - connector/internal-queue/builder completed+failed writers do NOT stamp:
+ *    agent_error/scoreable are agent-run concepts, and the message patterns
+ *    below are tuned on Behavior-run failures. Eval reads filter
+ *    `run_type = 'behavior'`.
+ * The historical backfill (scripts/backfill-run-outcomes.ts) mirrors exactly
+ * that scope by calling this exact function — never a SQL re-encoding of it.
+ *
+ * Classification prefers structure over string-matching:
+ *  1. `completed` → scoreable; `timeout` → infra_error (every timeout class —
+ *     unclaimed, heartbeat-stale, coarse TTL, SIGKILL time budget — is a
+ *     platform condition, not agent evidence).
+ *  2. A known `AgentErrorCode` → infra_error. The catalog (core/errors.ts) is
+ *     exclusively provider/worker/config failures today; an agent-fault code
+ *     added there must be mapped here explicitly.
+ *  3. Message patterns, ordered agent-protocol → infra → agent-process, with
+ *     unknown failures defaulting to agent_error: fail toward VISIBILITY. An
+ *     unrecognized failure shows up in the quality-relevant bucket and gets a
+ *     pattern added here, rather than being silently excused as infra.
+ */
+
+import { AgentErrorCode } from "@lobu/core";
+
+export type RunOutcome = "infra_error" | "agent_error" | "scoreable";
+
+const KNOWN_AGENT_ERROR_CODES: ReadonlySet<string> = new Set(
+	Object.values(AgentErrorCode),
+);
+
+/**
+ * The agent ran its turn and violated the Behavior protocol. Matches the
+ * cloud finalize miss (run-completion.ts describeFinalizeMiss) and the device
+ * variant (run-lifecycle.ts completeBehaviorRun) — both phrase the miss as
+ * "without calling".
+ */
+const AGENT_PROTOCOL_PATTERNS: readonly RegExp[] = [
+	/without calling (?:run_sdk|completeWindow|complete_window)/i,
+];
+
+/**
+ * Provider/platform/config faults. Sources, in prod-frequency order (14-day
+ * corpus, 2026-08-06): provider quota 429s (2,209 of 2,651 failures), the
+ * provider-error formatter shape (`url-builder.ts` labelProviderErrorBody),
+ * synthesized worker texts from the AGENT_ERRORS catalog, gateway
+ * session/enqueue failures, executor config, and approval walls (a headless
+ * run blocked on a human approval is an environment condition, not agent
+ * evidence).
+ */
+const INFRA_PATTERNS: readonly RegExp[] = [
+	/returned an error:/i,
+	/\b429\b/,
+	/rate limit/i,
+	/quota/i,
+	/limit exhausted/i,
+	/limit reached/i,
+	/insufficient balance/i,
+	/billing/i,
+	/\b401\b/,
+	/unauthorized/i,
+	/authentication required/i,
+	/timed? ?out/i,
+	/didn't finish responding/i,
+	/couldn't start/i,
+	/stopped unexpectedly/i,
+	/provider rejected its own tool call/i,
+	/no model is configured/i,
+	/remained pending/i,
+	/blocked on tool approval/i,
+	/no local agent executor/i,
+	/worker sandbox/i,
+	/failed to (?:create|resume|enqueue)/i,
+];
+
+/**
+ * Classify a terminal run. Returns null for non-terminal statuses and for
+ * `cancelled` (a human choice — neither infra nor agent evidence).
+ */
+export function classifyRunOutcome(input: {
+	status: string;
+	errorCode?: string | null;
+	errorMessage?: string | null;
+}): RunOutcome | null {
+	switch (input.status) {
+		case "completed":
+			return "scoreable";
+		case "timeout":
+			return "infra_error";
+		case "failed":
+			break;
+		default:
+			return null;
+	}
+
+	if (input.errorCode && KNOWN_AGENT_ERROR_CODES.has(input.errorCode)) {
+		return "infra_error";
+	}
+
+	const message = input.errorMessage ?? "";
+	if (AGENT_PROTOCOL_PATTERNS.some((p) => p.test(message))) {
+		return "agent_error";
+	}
+	if (INFRA_PATTERNS.some((p) => p.test(message))) {
+		return "infra_error";
+	}
+	// Unknown failures (incl. agent-process crashes like "claude exited with
+	// non-zero status 1") land here: fail toward visibility.
+	return "agent_error";
+}

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -44,6 +44,7 @@ import { intervals } from '../config/intervals';
 import { feedBackoff } from '../connectors/feed-backoff';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
+import { classifyRunOutcome } from '../runs/run-outcome';
 import { expireStaleConnectTokens } from '../utils/connect-tokens';
 import logger from '../utils/logger';
 import { reconcileWatcherRuns, sweepStaleWatcherRuns } from '../watchers/automation';
@@ -145,6 +146,7 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
         timed_out AS (
           UPDATE public.runs r
           SET status = 'timeout',
+              outcome = ${classifyRunOutcome({ status: "timeout" })},
               completed_at = current_timestamp,
               error_message = CASE
                 WHEN c.stale_status = 'pending' THEN ${claimErrorMessage}

--- a/packages/server/src/scheduled/stale-run-sweeper.ts
+++ b/packages/server/src/scheduled/stale-run-sweeper.ts
@@ -24,6 +24,7 @@
 
 import { PG_INTERVAL_PATTERN } from "../config/intervals";
 import type { DbClient } from "../db/client";
+import { classifyRunOutcome } from "../runs/run-outcome";
 
 interface StaleRunSweepSpec {
 	/** `runs.run_type` values covered by this sweep. */
@@ -162,13 +163,18 @@ export async function markStaleRunsAsTimeout(
 	const result = await sql.unsafe(
 		`UPDATE runs
      SET status = 'timeout',
+         outcome = $3,
          completed_at = current_timestamp,
          error_message = CASE
            WHEN ${hasHeartbeatSql(spec.heartbeatSemantics)} THEN $1
            ELSE $2
          END
      WHERE ${buildStaleRunWhereSql(spec)}`,
-		[spec.heartbeatErrorMessage, spec.coarseErrorMessage],
+		[
+			spec.heartbeatErrorMessage,
+			spec.coarseErrorMessage,
+			classifyRunOutcome({ status: "timeout" }),
+		],
 	);
 	return Number(result.count ?? 0);
 }

--- a/packages/server/src/tools/admin/device-action-wait.ts
+++ b/packages/server/src/tools/admin/device-action-wait.ts
@@ -9,6 +9,7 @@
  */
 
 import { getDb } from '../../db/client';
+import { classifyRunOutcome } from '../../runs/run-outcome';
 import { describeDeviceLastSeen } from '../../utils/device-liveness';
 
 /**
@@ -155,6 +156,7 @@ export async function waitForDeviceActionRun(
   const updated = (await sql`
     UPDATE runs
     SET status = 'timeout',
+        outcome = ${classifyRunOutcome({ status: 'timeout' })},
         completed_at = current_timestamp,
         error_message = ${timeoutMessage}
     WHERE id = ${runId}

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -34,6 +34,7 @@ import type { ToolContext } from '../../registry';
 import type { ManageBehaviorsArgs } from '../manage_behaviors';
 import { normalizeExtractedData, parseJson, requireWatcherAccess } from './shared';
 import { getErrorMessage } from '@lobu/core';
+import { classifyRunOutcome } from "../../../runs/run-outcome";
 
 // Initialize AJV for JSON Schema validation
 // removeAdditional: true strips fields like 'embedding' that workers add but aren't in the schema
@@ -755,6 +756,7 @@ export async function handleCompleteWindow(
       const completedRows = await tx`
         UPDATE runs
         SET status = 'completed',
+            outcome = ${classifyRunOutcome({ status: "completed" })},
             window_id = ${windowId},
             model_used = COALESCE(
               ${explicitProvenanceModel},

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -70,6 +70,7 @@ export async function handleList(
       i.source_watcher_id::text AS source_behavior_id,
       wr.id as behavior_run_id,
       wr.status as behavior_run_status,
+      wr.outcome as behavior_run_outcome,
       wr.error_message as behavior_run_error,
       wr.created_at as behavior_run_created_at,
       wr.completed_at as behavior_run_completed_at,
@@ -256,6 +257,7 @@ export async function handleList(
 				| string
 				| null
 				| undefined,
+			latestRunOutcome: watcher.behavior_run_outcome,
 		});
 
 		return {
@@ -269,6 +271,7 @@ export async function handleList(
 				health_reasons: behaviorHealth.reasons,
 			}),
 			last_scheduling_error: behaviorHealth.last_scheduling_error,
+			last_run_outcome: behaviorHealth.last_run_outcome,
 		};
 	});
 

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -229,6 +229,7 @@ interface WatcherQueryRow {
   organization_id: string | null;
   watcher_run_id: number | null;
   watcher_run_status: string | null;
+  watcher_run_outcome: string | null;
   watcher_run_error: string | null;
   watcher_run_created_at: string | null;
   watcher_run_completed_at: string | null;
@@ -582,6 +583,7 @@ async function getBehaviorImpl(
         -- Latest run via lateral
         wr.id as watcher_run_id,
         wr.status as watcher_run_status,
+        wr.outcome as watcher_run_outcome,
         wr.error_message as watcher_run_error,
         wr.created_at as watcher_run_created_at,
         wr.completed_at as watcher_run_completed_at
@@ -778,6 +780,7 @@ async function getBehaviorImpl(
       latestRunStatus: watcherRow.watcher_run_status,
       latestRunCreatedAt: watcherRow.watcher_run_created_at,
       latestRunError: watcherRow.watcher_run_error,
+      latestRunOutcome: watcherRow.watcher_run_outcome,
     });
 
     watcherMetadata = {
@@ -812,6 +815,11 @@ async function getBehaviorImpl(
                 | 'failed'
                 | 'cancelled'
                 | 'timeout',
+              outcome: (watcherRow.watcher_run_outcome ?? undefined) as
+                | 'infra_error'
+                | 'agent_error'
+                | 'scoreable'
+                | undefined,
               error_message: watcherRow.watcher_run_error ?? undefined,
               created_at: watcherRow.watcher_run_created_at,
               completed_at: watcherRow.watcher_run_completed_at,
@@ -822,6 +830,7 @@ async function getBehaviorImpl(
         health_reasons: behaviorHealth.reasons,
       }),
       last_scheduling_error: behaviorHealth.last_scheduling_error,
+      last_run_outcome: behaviorHealth.last_run_outcome,
     };
   }
 

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -114,6 +114,14 @@ const WatcherRunSchema = Type.Object({
     Type.Literal('cancelled'),
     Type.Literal('timeout'),
   ]),
+  /** Write-time outcome classification (runs.outcome); omitted when unstamped. */
+  outcome: Type.Optional(
+    Type.Union([
+      Type.Literal('infra_error'),
+      Type.Literal('agent_error'),
+      Type.Literal('scoreable'),
+    ])
+  ),
   error_message: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   created_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   completed_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
@@ -157,6 +165,8 @@ export const WatcherMetadataSchema = Type.Object({
   health_reasons: Type.Optional(Type.Array(Type.String())),
   /** Latest run error surfaced alongside the health verdict. */
   last_scheduling_error: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  /** Latest run's write-time outcome classification (null until stamped). */
+  last_run_outcome: Type.Optional(Type.Union([Type.String(), Type.Null()])),
 });
 export type WatcherMetadata = Static<typeof WatcherMetadataSchema>;
 

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -28,6 +28,7 @@ import { ensureCanvasEntity, findCanvasHead } from "../utils/canvas-events";
 import { insertEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
 import { isUniqueViolation } from "../utils/pg-errors";
+import { classifyRunOutcome } from "../runs/run-outcome";
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
 import { computePendingWindow } from "../utils/window-utils";
 import {
@@ -113,7 +114,7 @@ export function buildLatestWatcherRunJoinSql(
 ): string {
 	return `
     LEFT JOIN LATERAL (
-      SELECT r.id, r.status, r.error_message, r.created_at, r.completed_at
+      SELECT r.id, r.status, r.outcome, r.error_message, r.created_at, r.completed_at
       FROM runs r
       WHERE r.watcher_id = ${watcherAlias}.id
         AND r.run_type = 'behavior'
@@ -365,6 +366,7 @@ async function markWatcherRunFailedIdempotent(
 		}>`
       UPDATE runs
       SET status = 'failed',
+          outcome = ${classifyRunOutcome({ status: "failed", errorMessage: message })},
           completed_at = current_timestamp,
           error_message = ${message}
       WHERE id = ${runId}
@@ -631,6 +633,7 @@ async function finalizeStalePendingWatcherRuns(
 			const result = await tx`
         UPDATE runs
         SET status = 'timeout',
+            outcome = ${classifyRunOutcome({ status: "timeout" })},
             completed_at = current_timestamp,
             error_message = ${`Behavior run remained pending for over ${staleInterval} without being claimed`}
         WHERE id = ${candidate.id}

--- a/packages/server/src/watchers/behavior-health.ts
+++ b/packages/server/src/watchers/behavior-health.ts
@@ -63,6 +63,13 @@ export interface BehaviorHealthInput {
   latestRunCreatedAt?: string | Date | null;
   /** Latest run `error_message`, surfaced as `last_scheduling_error`. */
   latestRunError?: string | null;
+  /**
+   * Latest run `runs.outcome` (infra_error/agent_error/scoreable), stamped at
+   * write time by the terminal-status writers. Separates "the platform broke"
+   * from "the agent misbehaved" in the degraded reason — the distinction the
+   * July-2026 z.ai quota storm lacked. NULL on pre-backfill rows.
+   */
+  latestRunOutcome?: string | null;
 }
 
 export interface BehaviorHealth {
@@ -71,6 +78,8 @@ export interface BehaviorHealth {
   reasons: string[];
   /** Latest run error, echoed for convenience (null when none). */
   last_scheduling_error: string | null;
+  /** Latest run outcome classification, echoed for convenience (null when unstamped). */
+  last_run_outcome: string | null;
 }
 
 function toMs(value: string | Date | null | undefined): number | null {
@@ -100,20 +109,25 @@ export function computeBehaviorHealth(
 ): BehaviorHealth {
   const reasons: string[] = [];
   const lastError = input.latestRunError ?? null;
+  const lastOutcome = input.latestRunOutcome ?? null;
 
   // Archived behaviors are intentionally idle and therefore healthy.
   if (input.status !== 'active') {
-    return { health: 'healthy', reasons, last_scheduling_error: lastError };
+    return {
+      health: 'healthy',
+      reasons,
+      last_scheduling_error: lastError,
+      last_run_outcome: lastOutcome,
+    };
   }
 
   const runInFlight = IN_FLIGHT_RUN_STATUSES.has(input.latestRunStatus ?? '');
 
   if (FAILED_RUN_STATUSES.has(input.latestRunStatus ?? '')) {
-    reasons.push(
-      lastError
-        ? `latest run ${input.latestRunStatus}: ${lastError}`
-        : `latest run ${input.latestRunStatus}`,
-    );
+    const label = lastOutcome
+      ? `latest run ${input.latestRunStatus} (${lastOutcome})`
+      : `latest run ${input.latestRunStatus}`;
+    reasons.push(lastError ? `${label}: ${lastError}` : label);
   }
 
   // Missed firing: next_run_at is well in the past and nothing is dispatching.
@@ -138,5 +152,6 @@ export function computeBehaviorHealth(
     health: reasons.length > 0 ? 'degraded' : 'healthy',
     reasons,
     last_scheduling_error: lastError,
+    last_run_outcome: lastOutcome,
   };
 }

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -1,6 +1,7 @@
 import type { DbClient } from "../db/client";
 import { getDb, pgTextArray } from "../db/client";
 import { listPendingToolsForRun } from "../gateway/auth/mcp/pending-tool-store";
+import { classifyRunOutcome } from "../runs/run-outcome";
 import logger from "../utils/logger";
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
 import {
@@ -154,6 +155,7 @@ export async function markWatcherRunCompleted(
 	await sql`
     UPDATE runs
     SET status = 'completed',
+        outcome = ${classifyRunOutcome({ status: "completed" })},
         window_id = ${windowId},
         completed_at = current_timestamp,
         error_message = NULL,
@@ -171,7 +173,8 @@ async function markWatcherRunFailed(
 	sql: DbClient,
 	runId: number,
 	message: string,
-	notBefore?: Date | null
+	notBefore?: Date | null,
+	errorCode?: string | null
 ): Promise<boolean> {
 	return sql.begin(async (tx) => {
 		const [failed] = await tx<{
@@ -180,6 +183,7 @@ async function markWatcherRunFailed(
 		}>`
       UPDATE runs
       SET status = 'failed',
+          outcome = ${classifyRunOutcome({ status: "failed", errorCode, errorMessage: message })},
           completed_at = current_timestamp,
           error_message = ${message}
       WHERE id = ${runId}
@@ -265,7 +269,8 @@ export async function resolveWatcherRunsByMessageIds(
 					sql,
 					runId,
 					result.error,
-					notBefore
+					notBefore,
+					result.errorCode
 				)
 			) {
 				resolved++;

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -33,6 +33,12 @@ import { recordLifecycleEvent } from '../utils/insert-event';
 import { isCloudMode } from '../utils/cloud-mode';
 import { normalizeAdvertisedCapabilities } from './shared';
 import { storedManifestMap, validateDeviceConnectorManifests } from './device-manifests';
+import type { RunOutcome } from '../runs/run-outcome';
+
+// A failure at the DISPATCH stage means the agent never ran: the run is not
+// evidence about the agent regardless of the message, so no message
+// classification applies.
+const DISPATCH_FAILURE_OUTCOME: RunOutcome = 'infra_error';
 
 const DUE_FEEDS_LOCK_KEY = 71001;
 const DUE_FEED_MATERIALIZE_COOLDOWN_MS = 5000;
@@ -732,6 +738,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       await sql`
         UPDATE runs
         SET status = 'failed',
+            outcome = ${DISPATCH_FAILURE_OUTCOME},
             completed_at = current_timestamp,
             error_message = ${message}
         WHERE id = ${row.run_id}
@@ -831,6 +838,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       await sql`
         UPDATE runs
         SET status = 'failed',
+            outcome = ${DISPATCH_FAILURE_OUTCOME},
             completed_at = current_timestamp,
             error_message = ${message}
         WHERE id = ${row.run_id}
@@ -875,6 +883,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       await sql`
         UPDATE runs
         SET status = 'failed',
+            outcome = ${DISPATCH_FAILURE_OUTCOME},
             completed_at = current_timestamp,
             error_message = ${message}
         WHERE id = ${row.run_id}

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -60,6 +60,7 @@ import {
 	deviceProviderQuotaResetNotBefore,
 } from "../watchers/schedule-cursor";
 import { authorizeRunForWorker } from "./shared";
+import { classifyRunOutcome } from "../runs/run-outcome";
 
 type DbClient = ReturnType<typeof getDb>;
 type SqlFragment = ReturnType<DbClient>;
@@ -1165,6 +1166,7 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 			const failedRows = (await tx`
         UPDATE runs
         SET status = 'failed',
+            outcome = ${classifyRunOutcome({ status: "failed", errorMessage: reason })},
             completed_at = current_timestamp,
             error_message = ${reason},
             output_tail = ${output ? output.slice(-2000) : null},
@@ -1328,6 +1330,7 @@ export async function completeBehaviorRun(c: Context<{ Bindings: Env }>) {
 			workerId: body.worker_id,
 			status: "completed",
 			extraSet: sql`,
+        outcome = ${classifyRunOutcome({ status: "completed" })},
         window_id = NULL,
         error_message = NULL,
         model_used = COALESCE(

--- a/scripts/backfill-run-outcomes.ts
+++ b/scripts/backfill-run-outcomes.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env bun
+
+/**
+ * One-time backfill of `runs.outcome` (migration 20260807000000_runs_outcome).
+ *
+ * ─── Why this exists ─────────────────────────────────────────────────────────
+ * Terminal-status writers stamp `outcome` at write time going forward; rows
+ * that existed before the migration carry NULL. This fills history by calling
+ * THE classifier (packages/server/src/runs/run-outcome.ts) per row — never a
+ * SQL re-encoding of its rules — so backfilled rows and live rows agree by
+ * construction.
+ *
+ * ─── Exactly what it does ────────────────────────────────────────────────────
+ * Walks the rows the live write path stamps — Behavior runs in any terminal
+ * status (`completed`/`failed`/`timeout`) plus `timeout` rows of every
+ * run_type (the shared reapers stamp those message-independently) — by id
+ * range in batches, classifies each row from (status, error_message) in TS,
+ * and writes the outcomes back with one UPDATE ... FROM (VALUES ...) per
+ * batch. Only rows still NULL are touched, so the script is idempotent and
+ * resumable.
+ *
+ * Non-behavior `completed`/`failed` rows are NOT walked: their live writers
+ * don't stamp either (agent_error/scoreable are agent-run concepts and the
+ * classifier's message patterns are tuned on Behavior failures), so walking
+ * them here would mint labels the write path never produces. `cancelled` rows
+ * are skipped (classifier returns null: a human choice is neither infra nor
+ * agent evidence) — same as the write path. Historical non-behavior dispatch
+ * failures stay NULL (they are plain `failed` rows we cannot identify by
+ * message), unlike future ones which poll.ts stamps.
+ *
+ * ─── Safety ──────────────────────────────────────────────────────────────────
+ *   - DRY-RUN by default; pass --execute to write.
+ *   - Plain autocommit statements, small batches (default 5000).
+ *
+ * DATABASE_URL must point at the target database.
+ */
+
+import { parseArgs as parseNodeArgs } from "node:util";
+import {
+  getDb,
+  pgBigintArray,
+  pgTextArray,
+} from "../packages/server/src/db/client";
+import {
+  classifyRunOutcome,
+  type RunOutcome,
+} from "../packages/server/src/runs/run-outcome";
+
+const { values: args } = parseNodeArgs({
+  options: {
+    execute: { type: "boolean", default: false },
+    batch: { type: "string", default: "5000" },
+    "start-id": { type: "string", default: "0" },
+  },
+});
+
+const EXECUTE = Boolean(args.execute);
+const BATCH = Math.max(100, Number(args.batch ?? 5000));
+let cursor = Math.max(0, Number(args["start-id"] ?? 0));
+
+const sql = getDb();
+
+let scanned = 0;
+const written: Record<RunOutcome, number> = {
+  infra_error: 0,
+  agent_error: 0,
+  scoreable: 0,
+};
+
+for (;;) {
+  const rows = (await sql`
+    SELECT id, status, error_message
+    FROM runs
+    WHERE id > ${cursor}
+      AND outcome IS NULL
+      AND (
+        (run_type = 'behavior' AND status IN ('completed', 'failed'))
+        OR status = 'timeout'
+      )
+    ORDER BY id ASC
+    LIMIT ${BATCH}
+  `) as unknown as Array<{
+    id: number | string;
+    status: string;
+    error_message: string | null;
+  }>;
+  if (rows.length === 0) break;
+
+  cursor = Number(rows[rows.length - 1].id);
+  scanned += rows.length;
+
+  const classified = rows.flatMap((row) => {
+    const outcome = classifyRunOutcome({
+      status: row.status,
+      errorMessage: row.error_message,
+    });
+    return outcome ? [{ id: Number(row.id), outcome }] : [];
+  });
+  for (const c of classified) written[c.outcome]++;
+
+  if (EXECUTE && classified.length > 0) {
+    // fetch_types:false — never bind a raw JS array; format `{...}` literals
+    // (same convention as insert-event.ts / pgTextArray).
+    const ids = pgBigintArray(classified.map((c) => c.id));
+    const outcomes = pgTextArray(classified.map((c) => c.outcome));
+    await sql`
+      UPDATE runs r
+      SET outcome = v.outcome
+      FROM (
+        SELECT * FROM unnest(${ids}::bigint[], ${outcomes}::text[]) AS t(id, outcome)
+      ) v
+      WHERE r.id = v.id
+        AND r.outcome IS NULL
+    `;
+  }
+
+  console.log(
+    `${EXECUTE ? "wrote" : "dry-run"} through id ${cursor} — scanned ${scanned}, ` +
+      `infra ${written.infra_error} / agent ${written.agent_error} / scoreable ${written.scoreable}`
+  );
+}
+
+console.log(
+  `${EXECUTE ? "DONE" : "DRY-RUN DONE (pass --execute to write)"}: scanned ${scanned}, ` +
+    `infra_error ${written.infra_error}, agent_error ${written.agent_error}, scoreable ${written.scoreable}`
+);
+process.exit(0);


### PR DESCRIPTION
## Summary

Evals PR 1 of #2564 — outcome taxonomy for terminal runs.

- `runs.status` says HOW a run ended; nothing says WHOSE FAULT it was. The July z.ai quota storm read as a 61–78% "prompt regression" because provider 429s and genuine agent protocol violations shared the `failed` bucket. Prod today (14 days): 2,901 behavior runs, 91% `failed` — of which 2,209 are provider 429s (infra), 367 are finalize misses (agent), 239 completed.
- Adds `runs.outcome` (`infra_error` | `agent_error` | `scoreable`), classified by ONE pure function (`packages/server/src/runs/run-outcome.ts`) and stamped at write time inside every behavior terminal-status writer (cloud completion/failure, complete_window, reapers/sweepers, device exit report, dispatch-stage failures) plus every `status='timeout'` writer regardless of run_type — all four enumerated, including the device-action wait reaper. Backfill script calls the real classifier — no SQL re-encoding — and walks exactly the rows the live write path stamps (`run_type='behavior'` terminals + all-run-type timeouts), so backfilled and live rows agree by construction.
- Surfaces it: `behavior_run.outcome` + `last_run_outcome` on get_behavior/list, and the behavior-health degraded reason now reads `latest run failed (infra_error): …` so infra noise and agent regression are visually distinct.

Classification rules (validated against the verbatim prod error corpus, unit-tested):
- `completed` → `scoreable`; `timeout` → `infra_error` (every timeout class is a platform condition); `cancelled`/non-terminal → NULL.
- `failed` + known `AgentErrorCode` → `infra_error` (the catalog is exclusively provider/worker/config today).
- `failed` + finalize-miss message → `agent_error`; approval-wall ("blocked on tool approval") → `infra_error` (environment, not agent evidence); known infra patterns (429/quota/auth/timeouts/dispatch) → `infra_error`.
- Unknown failures default to `agent_error` — fail toward visibility: a novel failure shows up in the quality-relevant bucket and earns a pattern here, instead of being silently excused as infra.
- Dispatch-stage failures (`poll.ts`, agent never ran) stamp `infra_error` by construction.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` (exit 0); targeted vitest integration `completed-run-model-provenance` + `failed-run-advances-schedule` (48/48); `bun test` unit `run-outcome.test.ts` (21 pass, verbatim prod corpus) + `behavior-health.test.ts` (8 pass)
- [x] Mutation check on the new integration asserts — stamps removed → exactly the 2 new tests fail; restored → green:

Red (outcome stamps removed from `markWatcherRunCompleted`/`markWatcherRunFailed`):
```
❯ completed-run-model-provenance.test.ts (7 tests | 2 failed)
  × replaces the 'external-client' placeholder with the real executor
  × stamps a failed run's outcome from the terminal error (quota → infra_error)
Tests  2 failed | 5 passed (7)
```

Green (restored):
```
Test Files  2 passed (2)
Tests  48 passed (48)
```

- Migration squawk-clean locally (`squawk-cli@2.58.0`, 0 issues).

## Notes

- Part of #2564 (evals umbrella). PR 2 (`run_type='behavior_eval'` + capture mode) builds on `outcome='scoreable'` as the judge's admission filter.
- Post-merge: run `scripts/backfill-run-outcomes.ts` against prod (dry-run first — it prints the bucket split; expected ≈ 2,209/367/239 on the 14-day window, larger over full history), then spot-check `last_run_outcome` on the degraded Behaviors list.
- The connector-lane and generic sweepers stamp timeouts for all run types (timeout→infra is run-type-agnostic); non-behavior `completed`/`failed` writers (sync/action/auth finalize, builder/http-operation runs) deliberately do NOT stamp — `agent_error`/`scoreable` are agent-run concepts and the message patterns are tuned on Behavior failures. Eval reads filter `run_type='behavior'`.
- A pre-review fixer pass (claude CLI) tightened two things on the settled diff: stamped the fourth timeout writer (`device-action-wait.ts`) and narrowed the backfill scan WHERE to mirror the write-path scope exactly (previously it would have minted labels for historical sync/connector runs that live writers never stamp).
