### PR TITLE
fix(core): reserve top-level SPA routes so path parsing never reads them as org slugs

### DIFF
--- a/packages/core/src/reserved.ts
+++ b/packages/core/src/reserved.ts
@@ -86,6 +86,14 @@ export const RESERVED_PATHS = [
   "cdn",
   "docs",
   "mail",
+  // Top-level SPA routes that are NOT org namespaces (`packages/owletto/src/app`):
+  // path parsing and the server's owner resolution must never read these as an
+  // org slug. `connectors` is already reserved above as an owner route.
+  "connector",
+  "oauth",
+  "orgs",
+  "slack",
+  "dashboard",
 ] as const;
 
 export const RESERVED_PATHS_SET: ReadonlySet<string> = new Set(RESERVED_PATHS);


### PR DESCRIPTION
## Summary

First-class `/{owner}/{type}` URLs (#740 / owletto) put non-reserved first segments in the URL bar on per-org subdomains; `getPathScope` misread them as org slugs and every org-scoped API call 404'd. This adds the missing top-level routes (`connector`, `oauth`, `orgs`, `slack`, `dashboard`) to `RESERVED_PATHS` so SPA path parsing and server owner resolution agree on what is an org slug.

The org-scope fix itself is in the owletto pointer bump (commit `e3183cb5`).

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Owletto full suite green (146 files / 1254 tests) incl. new 14-case regression matrix
- [x] Bug fix: red→fix→green outputs in owletto PR #741

## Notes

- The `RESERVED_PATHS` additions are additive denylist entries; personal-org provisioning and `resolve_path` already consume the list, and no org legitimately uses these route-word slugs.
- Closes the divergence flagged in owletto review: `__root`'s hand-maintained reserved list and the core list are now one.