### PR TITLE
fix(personal-agent): correct X author handle in voice-profile source

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -1038,7 +1038,7 @@ const voiceProfileSynthesis = defineBehavior({
   },
   sources: {
     authored_recent:
-      "SELECT id, occurred_at, connector_key, origin_type, left(payload_text, 400) AS payload_text, metadata FROM events WHERE payload_text IS NOT NULL AND length(payload_text) >= 40 AND occurred_at > now() - interval '21 days' AND ((connector_key = 'twitter.takeout' AND origin_type IN ('reply','tweet')) OR (connector_key = 'x' AND origin_type IN ('tweet','reply') AND lower(coalesce(metadata->>'author_handle','')) = 'buremba') OR (connector_key IN ('linkedin','linkedin.takeout') AND origin_type = 'message')) ORDER BY occurred_at DESC LIMIT 200",
+      "SELECT id, occurred_at, connector_key, origin_type, left(payload_text, 400) AS payload_text, metadata FROM events WHERE payload_text IS NOT NULL AND length(payload_text) >= 40 AND occurred_at > now() - interval '21 days' AND ((connector_key = 'twitter.takeout' AND origin_type IN ('reply','tweet')) OR (connector_key = 'x' AND origin_type IN ('tweet','reply') AND lower(coalesce(metadata->>'author_handle','')) = 'bu7emba') OR (connector_key IN ('linkedin','linkedin.takeout') AND origin_type = 'message')) ORDER BY occurred_at DESC LIMIT 200",
     engaged_recent:
       "SELECT id, occurred_at, connector_key, origin_type, left(payload_text, 300) AS payload_text, metadata FROM events WHERE payload_text IS NOT NULL AND length(payload_text) >= 20 AND occurred_at > now() - interval '21 days' AND ((connector_key IN ('x','twitter.takeout') AND origin_type IN ('liked_tweet','bookmark')) OR (connector_key = 'instagram.takeout' AND origin_type IN ('like','saved','comment'))) ORDER BY occurred_at DESC LIMIT 200",
     existing_profiles: {


### PR DESCRIPTION
## What

The `voice-profile-synthesis` Behavior's `authored_recent` source filters X posts on `metadata->>'author_handle' = 'buremba'`. The real handle is **`bu7emba`**, so the X arm of that source matched zero rows on every run since it was written.

Found while auditing why the `buremba` org's Behaviors run on schedule but produce nothing durable.

## Red → green

Same query, same 21-day window, prod `buremba` org — only the handle literal differs.

**Red** (`= 'buremba'`):
```
 rows_returned
---------------
             0
```

**Green** (`= 'bu7emba'`):
```
 rows_returned
---------------
            12
```

Corroborating: `SELECT lower(metadata->>'author_handle'), origin_type, count(*) FROM events WHERE connector_key IN ('x','twitter.takeout') AND lower(metadata->>'author_handle') IN ('buremba','bu7emba') GROUP BY 1,2` returns `bu7emba/tweet 24` and `bu7emba/bookmark 1`. `buremba` has never appeared as an author_handle.

The source's other two arms are `twitter.takeout` and `linkedin.takeout`, both on paused connections, so the whole source was returning empty — the Behavior has been synthesizing a voice profile from nothing.

## Scope

One line. `grep` over `origin/main` for `author_handle` confirms this is the only hardcoded handle literal in the repo; `examples/personal-agent/lobu.config.ts:172` is an alias-based eventSet mapping and is correct as written.

## Note for the reviewer

`examples/personal-agent/lobu.config.ts` has drifted from the live Behavior in the `buremba` org, independently of this change. Live version 6 declares `outputs.profiles` as an **event** output (`{ key: ["channel","mode"], event: "voice_profile" }`) and reads `existing_profiles` from `events WHERE semantic_type = 'voice_profile'`; this config still declares an **entity** output and reads from `entities`. Running `lobu apply` from this file would revert that migration. I did not touch it here — flagging so nobody applies this config assuming it is current.

## Gates

`make pre-pr` clean (typecheck, knip, biome, exposed-surface naming, gateway-llm gate).