### PR TITLE
feat(server): replay a Behavior run as a captured eval

### DIFF
--- a/db/migrations/20260807120000_behavior_eval_run_type.sql
+++ b/db/migrations/20260807120000_behavior_eval_run_type.sql
@@ -1,0 +1,51 @@
+-- Allow `run_type = 'behavior_eval'` (evals PR 2, lobu#2564).
+--
+-- An eval run replays a real Behavior window to score it. It reuses the `runs`
+-- table rather than taking a column or a table of its own, which is what makes
+-- it invisible to the ~18 existing `run_type = 'behavior'` predicates in the
+-- scheduler, the reapers, and behavior-health: evals are excluded from all of
+-- them for free, and only the execution path opts back in.
+--
+-- Side effects are not executed for this run type — the server derives
+-- `executionMode = 'capture'` from it at session creation
+-- (gateway/permissions/behavior-run-intent.ts) and carries it as a signed
+-- worker-token claim. See packages/server/src/runs/run-types.ts.
+--
+-- EXPAND-only: widening a CHECK never invalidates an existing row, and NOT
+-- VALID + VALIDATE keeps the table-scan off the exclusive-lock window (same
+-- shape as 20260720140000). The list is that migration's FINAL contract step
+-- (its up drops 'watcher' after the backfill) plus 'behavior_eval' — the
+-- retired 'watcher' value must NOT be re-legalized here.
+
+-- migrate:up
+ALTER TABLE public.runs
+  DROP CONSTRAINT IF EXISTS runs_run_type_check;
+ALTER TABLE public.runs
+  ADD CONSTRAINT runs_run_type_check CHECK (
+    run_type = ANY (ARRAY[
+      'sync'::text, 'action'::text, 'embed_backfill'::text,
+      'behavior'::text, 'behavior_eval'::text,
+      'auth'::text, 'chat_message'::text,
+      'schedule'::text, 'agent_run'::text, 'internal'::text, 'task'::text
+    ])
+  ) NOT VALID;
+ALTER TABLE public.runs
+  VALIDATE CONSTRAINT runs_run_type_check;
+
+-- migrate:down
+-- Eval replays are derived, disposable rows — without this the VALIDATE below
+-- fails on any behavior_eval row and the down cannot run.
+DELETE FROM public.runs WHERE run_type = 'behavior_eval';
+
+ALTER TABLE public.runs
+  DROP CONSTRAINT IF EXISTS runs_run_type_check;
+ALTER TABLE public.runs
+  ADD CONSTRAINT runs_run_type_check CHECK (
+    run_type = ANY (ARRAY[
+      'sync'::text, 'action'::text, 'embed_backfill'::text,
+      'behavior'::text, 'auth'::text, 'chat_message'::text,
+      'schedule'::text, 'agent_run'::text, 'internal'::text, 'task'::text
+    ])
+  ) NOT VALID;
+ALTER TABLE public.runs
+  VALIDATE CONSTRAINT runs_run_type_check;

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3945,6 +3945,12 @@ export type NotifyData = {
       [key: string]: unknown;
     };
     /**
+     * Turn this notification into a QUESTION the recipient answers, instead of an FYI. JSON Schema for the answer. Pass {} for a plain yes/no decision (renders as Approve/Reject inline, in-app and in chat). Pass a single required enum property to offer one-click named options. Pass several properties to collect fields (the recipient gets a form; give each property a `title` — without one the form labels the field with its full `description`). Properties must be flat: nested objects do not render. Answering records the result and emits it — read it back with manage_operations get_run.
+     */
+    input_schema?: {
+      [key: string]: unknown;
+    };
+    /**
      * Attribution source when notification is triggered by a Behavior reaction
      */
     behavior_source?: {
@@ -4889,6 +4895,7 @@ export type GetBehaviorResponses = {
           | "failed"
           | "cancelled"
           | "timeout";
+        outcome?: "infra_error" | "agent_error" | "scoreable";
         error_message?: string | null;
         created_at?: string | null;
         completed_at?: string | null;
@@ -4896,6 +4903,7 @@ export type GetBehaviorResponses = {
       health?: "healthy" | "degraded";
       health_reasons?: Array<string>;
       last_scheduling_error?: string | null;
+      last_run_outcome?: string | null;
     };
     pending_analysis?: {
       unprocessed_count: number;

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -48,6 +48,14 @@ export interface WorkerTokenData {
    * interactive (browser-driven) runs.
    */
   source?: string;
+  /**
+   * Side-effect mode for this run, derived server-side from `runs.run_type`
+   * when the session was authorized. `capture` marks an eval replay: mutating
+   * work is recorded and NOT performed. Absent means live — see the rollout
+   * note in gateway/orchestration/worker-token-claims.ts. Signed, so a worker
+   * cannot promote itself to live.
+   */
+  executionMode?: "live" | "capture";
   sessionKey?: string;
   traceId?: string;
   /** Unique token ID — enables targeted revocation. */
@@ -142,6 +150,8 @@ export interface WorkerTokenOptions {
   platform?: string;
   /** Headless run origin — see WorkerTokenData.source. */
   source?: string;
+  /** Side-effect mode — see WorkerTokenData.executionMode. */
+  executionMode?: "live" | "capture";
   sessionKey?: string;
   traceId?: string;
   /**
@@ -202,6 +212,7 @@ function generateToken(
     timestamp: Date.now(),
     platform: options.platform,
     source: options.source,
+    executionMode: options.executionMode,
     sessionKey: options.sessionKey,
     traceId: options.traceId,
     jti,

--- a/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
@@ -1,0 +1,265 @@
+/**
+ * An eval replay must not be able to damage the Behavior it is scoring.
+ *
+ * `complete_window` is the one write lane that does NOT go through the SDK
+ * sandbox, so the capture claim has to be honoured by the handler itself. The
+ * danger is specific: an eval replays the SAME window as its source run, so the
+ * canvas chain root (watcher + granularity + window_start) is byte-identical.
+ * A `replace_existing: true` completion from an eval would therefore supersede
+ * the REAL Behavior's canvas head and unlink its content.
+ *
+ * Proves, against real Postgres:
+ *   1. A live completion writes a canvas head (the control).
+ *   2. A capture completion of that same window with `replace_existing: true`
+ *      leaves that head byte-identical and creates no new window.
+ *   3. The extraction it would have written is recorded on the eval run's
+ *      `dry_run_preview`, which is what PR 3 scores.
+ *   4. The reaction script does not fire.
+ */
+
+import { inferBehaviorGranularityFromSchedule } from '@lobu/connector-sdk';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { DbClient } from '../../../db/client';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { handleCompleteWindow } from '../../../tools/admin/manage_behaviors/complete-window';
+import { createEvalRun } from '../../../runs/eval-runs';
+import { createWatcherRun } from '../../../runs/queue-service';
+import { findCanvasHead } from '../../../utils/canvas-events';
+import { computePendingWindow } from '../../../utils/window-utils';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity, createTestEvent } from '../../setup/test-fixtures';
+import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
+
+const TEST_ENV: Env = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: 'test-jwt-secret-for-testing-only',
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+};
+
+const LIVE_EXTRACTION = { summary: 'the real completion' };
+const EVAL_EXTRACTION = { summary: 'the replay would have written this instead' };
+
+function toolCtx(
+  organizationId: string,
+  userId: string,
+  executionMode: 'live' | 'capture'
+): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+    executionMode,
+  };
+}
+
+async function setup() {
+  const sql = getTestDb();
+  const dbClient = sql as unknown as DbClient;
+  const workspace = await TestWorkspace.create({ name: 'Eval Capture Org' });
+  const ownerUserId = workspace.users.owner.id;
+
+  const parentEntity = await createTestEntity({
+    name: 'Parent Brand',
+    organization_id: workspace.org.id,
+    created_by: ownerUserId,
+  });
+
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId,
+    agentId: 'eval-capture-agent',
+    name: 'Eval Capture Agent',
+  });
+
+  const behavior = (await workspace.owner.behaviors.create({
+    entity_id: parentEntity.id,
+    slug: 'eval-capture-behavior',
+    name: 'Eval Capture Behavior',
+    prompt: 'Summarize activity for {{entities}}.',
+    triggers: [{ kind: 'schedule', cron: '0 9 * * *' }],
+    agent_id: agent.agentId,
+  })) as { behavior_id: string };
+  const watcherId = Number(behavior.behavior_id);
+
+  await sql`UPDATE watchers SET next_run_at = NOW() - INTERVAL '10 minutes' WHERE id = ${watcherId}`;
+
+  await createTestEvent({
+    entity_id: parentEntity.id,
+    organization_id: workspace.org.id,
+    content: 'Something happened worth summarizing.',
+    occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+  });
+
+  const api = await TestApiClient.for({
+    organizationId: workspace.org.id,
+    userId: ownerUserId,
+    memberRole: 'owner',
+  });
+
+  const granularity = inferBehaviorGranularityFromSchedule('0 9 * * *');
+  const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
+
+  const queued = await createWatcherRun({
+    organizationId: workspace.org.id,
+    watcherId,
+    agentId: agent.agentId,
+    windowStart: windowStart.toISOString(),
+    windowEnd: windowEnd.toISOString(),
+    dispatchSource: 'scheduled',
+  });
+  await sql`
+    UPDATE runs SET status = 'running', claimed_at = NOW(), claimed_by = ${`lobu:${agent.agentId}`}
+    WHERE id = ${queued.runId}
+  `;
+
+  const knowledge = (await api.knowledge.read({ behavior_id: watcherId })) as {
+    window_token: string;
+  };
+
+  return {
+    sql,
+    orgId: workspace.org.id,
+    ownerUserId,
+    watcherId,
+    sourceRunId: queued.runId,
+    windowToken: knowledge.window_token,
+    canvasPeriod: {
+      watcherId,
+      granularity,
+      windowStart: windowStart.toISOString(),
+    },
+  };
+}
+
+describe('an eval replay cannot overwrite the Behavior it is scoring', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('leaves the live canvas head intact and records the extraction instead', async () => {
+    const ctx = await setup();
+    const { sql, orgId, ownerUserId, watcherId, sourceRunId, windowToken, canvasPeriod } = ctx;
+
+    // 1. The control: a real completion writes a real canvas head.
+    const live = await handleCompleteWindow(
+      {
+        action: 'complete_window',
+        behavior_id: String(watcherId),
+        window_token: windowToken,
+        extracted_data: LIVE_EXTRACTION,
+        behavior_run_id: sourceRunId,
+      } as never,
+      TEST_ENV,
+      toolCtx(orgId, ownerUserId, 'live')
+    );
+    expect(live.window_created).toBe(true);
+    expect(live.captured).toBeUndefined();
+
+    // Read the head through the SAME accessor production uses, so the test
+    // cannot pass by looking somewhere the writer does not write.
+    const headBefore = await findCanvasHead(sql as unknown as DbClient, canvasPeriod);
+    expect(headBefore).not.toBeNull();
+
+    // Mark the source run terminal so it can be replayed.
+    await sql`
+      UPDATE runs SET status = 'completed', completed_at = NOW() WHERE id = ${sourceRunId}
+    `;
+
+    // 2. The attack: replay the SAME window as an eval, asking to REPLACE.
+    const evalRun = await createEvalRun(
+      { sourceRunId, caseKey: 'overwrite-attempt' },
+      sql as unknown as DbClient
+    );
+    expect(evalRun?.created).toBe(true);
+
+    const captured = await handleCompleteWindow(
+      {
+        action: 'complete_window',
+        behavior_id: String(watcherId),
+        window_token: windowToken,
+        extracted_data: EVAL_EXTRACTION,
+        replace_existing: true,
+        behavior_run_id: evalRun?.runId,
+      } as never,
+      TEST_ENV,
+      toolCtx(orgId, ownerUserId, 'capture')
+    );
+
+    // 3. The real head is untouched — assert this FIRST, so a regression
+    // reports the damage itself rather than a missing response flag.
+    const headAfter = await findCanvasHead(sql as unknown as DbClient, canvasPeriod);
+    expect(headAfter?.id).toBe(headBefore?.id);
+    expect(headAfter?.payloadData).toEqual(headBefore?.payloadData);
+    expect(headAfter?.payloadData).toMatchObject(LIVE_EXTRACTION);
+
+    // And exactly one canvas head still exists — the eval added no second chain.
+    const [{ count }] = await sql<{ count: string }[]>`
+      SELECT count(*) AS count FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${watcherId}
+        AND superseded_by IS NULL
+    `;
+    expect(Number(count)).toBe(1);
+
+    // Only now the response shape.
+    expect(captured.captured).toBe(true);
+    expect(captured.head_superseded).toBe(false);
+    expect(captured.window_created).toBe(false);
+    // The reaction block triggers on content_linked > 0 — a capture run must
+    // never reach it.
+    expect(captured.reaction_status).toBe('skipped');
+
+    // 4. What the eval WOULD have written is on the run, for PR 3 to score.
+    const [preview] = await sql<
+      {
+        dry_run: boolean;
+        dry_run_preview: {
+          captured: string;
+          extracted_data: Record<string, unknown>;
+          replace_existing: boolean;
+        };
+      }[]
+    >`
+      SELECT dry_run, dry_run_preview FROM runs WHERE id = ${evalRun?.runId ?? 0}
+    `;
+    expect(preview.dry_run).toBe(true);
+    expect(preview.dry_run_preview.captured).toBe('complete_window');
+    expect(preview.dry_run_preview.extracted_data).toMatchObject(EVAL_EXTRACTION);
+    // The intent is recorded even though it was refused.
+    expect(preview.dry_run_preview.replace_existing).toBe(true);
+  });
+
+  it('does not stamp dry_run onto a real Behavior run', async () => {
+    const ctx = await setup();
+    const { sql, orgId, ownerUserId, watcherId, sourceRunId, windowToken } = ctx;
+
+    // A forged capture claim naming a LIVE run: the UPDATE is guarded on
+    // run_type, so the real run must not be marked as a dry run.
+    await handleCompleteWindow(
+      {
+        action: 'complete_window',
+        behavior_id: String(watcherId),
+        window_token: windowToken,
+        extracted_data: EVAL_EXTRACTION,
+        behavior_run_id: sourceRunId,
+      } as never,
+      TEST_ENV,
+      toolCtx(orgId, ownerUserId, 'capture')
+    );
+
+    const [row] = await sql<{ dry_run: boolean | null; dry_run_preview: unknown }[]>`
+      SELECT dry_run, dry_run_preview FROM runs WHERE id = ${sourceRunId}
+    `;
+    expect(row.dry_run ?? false).toBe(false);
+    expect(row.dry_run_preview).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
@@ -24,6 +24,7 @@ import type { Env } from '../../../index';
 import type { ToolContext } from '../../../tools/registry';
 import { handleCompleteWindow } from '../../../tools/admin/manage_behaviors/complete-window';
 import { createEvalRun } from '../../../runs/eval-runs';
+import { BEHAVIOR_EVAL_RUN_TYPE } from '../../../runs/run-types';
 import { createWatcherRun } from '../../../runs/queue-service';
 import { findCanvasHead } from '../../../utils/canvas-events';
 import { computePendingWindow } from '../../../utils/window-utils';
@@ -236,6 +237,52 @@ describe('an eval replay cannot overwrite the Behavior it is scoring', () => {
     expect(preview.dry_run_preview.extracted_data).toMatchObject(EVAL_EXTRACTION);
     // The intent is recorded even though it was refused.
     expect(preview.dry_run_preview.replace_existing).toBe(true);
+  });
+
+  it('a live completer with no run id never adopts an in-flight eval run', async () => {
+    const ctx = await setup();
+    const { sql, orgId, ownerUserId, watcherId, sourceRunId, windowToken } = ctx;
+
+    // The live run stays RUNNING — it is the one a completion should land on.
+    // An eval replay of the same Behavior is also running and is NEWER, so the
+    // fallback lookup's "prefer running, then newest" ordering would pick the
+    // EVAL if it were not scoped to the caller's own lane.
+    const evalRun = await createEvalRun(
+      { sourceRunId, caseKey: 'race' },
+      sql as unknown as DbClient
+    );
+    await sql`UPDATE runs SET status = 'running' WHERE id = ${evalRun?.runId ?? 0}`;
+
+    // A LIVE completion that omits behavior_run_id entirely.
+    const live = await handleCompleteWindow(
+      {
+        action: 'complete_window',
+        behavior_id: String(watcherId),
+        window_token: windowToken,
+        extracted_data: LIVE_EXTRACTION,
+      } as never,
+      TEST_ENV,
+      toolCtx(orgId, ownerUserId, 'live')
+    );
+    expect(live.captured).toBeUndefined();
+
+    // The completion landed on the LIVE run. If the lookup had adopted the
+    // eval, this run would still be sitting there with no window.
+    const [liveRow] = await sql<{ status: string; window_id: number | null }[]>`
+      SELECT status, window_id FROM runs WHERE id = ${sourceRunId}
+    `;
+    expect(liveRow.window_id).not.toBe(null);
+    expect(liveRow.status).toBe('completed');
+
+    // And the eval is untouched: still running, still windowless.
+    const [evalRow] = await sql<
+      { status: string; window_id: number | null; run_type: string }[]
+    >`
+      SELECT status, window_id, run_type FROM runs WHERE id = ${evalRun?.runId ?? 0}
+    `;
+    expect(evalRow.run_type).toBe(BEHAVIOR_EVAL_RUN_TYPE);
+    expect(evalRow.window_id).toBe(null);
+    expect(evalRow.status).toBe('running');
   });
 
   it('does not stamp dry_run onto a real Behavior run', async () => {

--- a/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
@@ -285,6 +285,46 @@ describe('an eval replay cannot overwrite the Behavior it is scoring', () => {
     expect(evalRow.status).toBe('running');
   });
 
+  it('a live completer cannot claim or complete a pending eval by passing its id', async () => {
+    const ctx = await setup();
+    const { sql, orgId, ownerUserId, watcherId, sourceRunId, windowToken } = ctx;
+
+    const evalRun = await createEvalRun(
+      { sourceRunId, caseKey: 'claim' },
+      sql as unknown as DbClient
+    );
+    // Make it look like a manual-open run (no agent/device pin) — the only
+    // shape the claim UPDATE will touch.
+    await sql`
+      UPDATE runs
+      SET approved_input = approved_input - 'agent_id' - 'device_worker_id'
+      WHERE id = ${evalRun?.runId ?? 0}
+    `;
+
+    // A LIVE completion naming the eval's run id explicitly.
+    await handleCompleteWindow(
+      {
+        action: 'complete_window',
+        behavior_id: String(watcherId),
+        window_token: windowToken,
+        extracted_data: LIVE_EXTRACTION,
+        behavior_run_id: evalRun?.runId,
+      } as never,
+      TEST_ENV,
+      toolCtx(orgId, ownerUserId, 'live')
+    );
+
+    // The eval was neither claimed into 'running' nor completed with a window.
+    const [evalRow] = await sql<
+      { status: string; window_id: number | null; claimed_at: string | null }[]
+    >`
+      SELECT status, window_id, claimed_at FROM runs WHERE id = ${evalRun?.runId ?? 0}
+    `;
+    expect(evalRow.status).toBe('pending');
+    expect(evalRow.window_id).toBe(null);
+    expect(evalRow.claimed_at).toBe(null);
+  });
+
   it('does not stamp dry_run onto a real Behavior run', async () => {
     const ctx = await setup();
     const { sql, orgId, ownerUserId, watcherId, sourceRunId, windowToken } = ctx;

--- a/packages/server/src/__tests__/integration/runs/eval-run-capture.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-run-capture.test.ts
@@ -24,6 +24,9 @@ let sourceRunId: number;
 
 const payload = {
 	watcher_id: 0,
+	// A server-dispatchable source: `createEvalRun` refuses device-pinned and
+	// manual-open runs, because neither eval lane could ever claim the clone.
+	agent_id: "11111111-2222-3333-4444-555555555555",
 	window_start: "2026-08-01T00:00:00.000Z",
 	window_end: "2026-08-01T01:00:00.000Z",
 	dispatch_source: "scheduled",
@@ -127,6 +130,32 @@ describe("createEvalRun", () => {
 		expect(await createEvalRun({ sourceRunId: sync.id, caseKey: "x" }, sql)).toBe(
 			null,
 		);
+	});
+
+	// A clone no lane can claim would sit `pending` forever, and since the claim
+	// guards are same-lane it would wedge every later eval of that Behavior.
+	// Nothing reaps a stranded pending eval, so refuse at mint instead.
+	test.each([
+		[
+			"device-pinned",
+			{ ...payload, device_worker_id: "99999999-8888-7777-6666-555555555555" },
+		],
+		["manual-open", { ...payload, agent_id: undefined }],
+	])("refuses to replay a %s run it could never dispatch", async (_l, input) => {
+		const [run] = await sql<{ id: number }[]>`
+      INSERT INTO runs (
+        organization_id, run_type, watcher_id, approval_status, status,
+        approved_input, completed_at, created_at
+      ) VALUES (
+        ${organizationId}, 'behavior', ${behaviorId}, 'auto', 'completed',
+        ${sql.json({ ...input, watcher_id: behaviorId } as never)},
+        current_timestamp, current_timestamp
+      )
+      RETURNING id
+    `;
+		expect(
+			await createEvalRun({ sourceRunId: run.id, caseKey: "undispatchable" }, sql),
+		).toBe(null);
 	});
 });
 

--- a/packages/server/src/__tests__/integration/runs/eval-run-capture.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-run-capture.test.ts
@@ -1,0 +1,169 @@
+/**
+ * End-to-end shape of an eval replay: a real Behavior run is cloned into a
+ * `behavior_eval` run, the execution path accepts it, and the scheduling and
+ * health predicates do not see it.
+ */
+
+import { beforeAll, describe, expect, test } from "vitest";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+import { createEvalRun } from "../../../runs/eval-runs";
+import {
+	BEHAVIOR_EVAL_RUN_TYPE,
+	executionModeForRunType,
+} from "../../../runs/run-types";
+
+const sql = getTestDb();
+
+let organizationId: string;
+let behaviorId: number;
+let sourceRunId: number;
+
+const payload = {
+	watcher_id: 0,
+	window_start: "2026-08-01T00:00:00.000Z",
+	window_end: "2026-08-01T01:00:00.000Z",
+	dispatch_source: "scheduled",
+	version_id: 42,
+};
+
+beforeAll(async () => {
+	// Start from an empty schema. Behavior ids are handed out by a MAX(id)+1
+	// helper, not by `watchers_id_seq`, so any earlier file that created a
+	// Behavior leaves the sequence BEHIND the table — and the explicit
+	// `nextval` below then collides on `insights_pkey`. Truncating first keeps
+	// this suite independent of what ran before it.
+	await cleanupTestDatabase();
+
+	const org = await createTestOrganization();
+	organizationId = org.id;
+	const creator = await createTestUser();
+
+	// watchers.watcher_group_id is NOT NULL and self-referential for a new
+	// Behavior — mint the id first, same shape as operations-getrun-internal.
+	const [behavior] = (await sql`
+    WITH next_id AS (
+      SELECT nextval('watchers_id_seq')::integer AS id
+    )
+    INSERT INTO watchers (
+      id, watcher_group_id, organization_id, created_by, name, slug, schedule, status
+    )
+    SELECT id, id, ${organizationId}, ${creator.id}, 'Eval Source', 'eval-src', '0 * * * *', 'active'
+    FROM next_id
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	behaviorId = Number(behavior.id);
+
+	const [run] = await sql<{ id: number }[]>`
+    INSERT INTO runs (
+      organization_id, run_type, watcher_id, approval_status, status,
+      approved_input, completed_at, created_at
+    ) VALUES (
+      ${organizationId}, 'behavior', ${behaviorId}, 'auto', 'completed',
+      ${sql.json({ ...payload, watcher_id: behaviorId })},
+      current_timestamp, current_timestamp
+    )
+    RETURNING id
+  `;
+	sourceRunId = run.id;
+});
+
+describe("createEvalRun", () => {
+	test("clones the source run's frozen payload verbatim", async () => {
+		const result = await createEvalRun(
+			{ sourceRunId, caseKey: "case-1" },
+			sql,
+		);
+		expect(result?.created).toBe(true);
+
+		const [row] = await sql<
+			{ run_type: string; status: string; approved_input: typeof payload }[]
+		>`
+      SELECT run_type, status, approved_input FROM runs WHERE id = ${result?.runId ?? 0}
+    `;
+		expect(row.run_type).toBe(BEHAVIOR_EVAL_RUN_TYPE);
+		expect(row.status).toBe("pending");
+		// The window and version must match the original question exactly.
+		expect(row.approved_input.window_start).toBe(payload.window_start);
+		expect(row.approved_input.window_end).toBe(payload.window_end);
+		expect(row.approved_input.version_id).toBe(payload.version_id);
+	});
+
+	test("the cloned run resolves to capture mode", async () => {
+		const [row] = await sql<{ run_type: string }[]>`
+      SELECT run_type FROM runs
+      WHERE run_type = ${BEHAVIOR_EVAL_RUN_TYPE} AND watcher_id = ${behaviorId}
+      LIMIT 1
+    `;
+		expect(executionModeForRunType(row.run_type)).toBe("capture");
+	});
+
+	test("is idempotent per (source run, case key)", async () => {
+		const again = await createEvalRun({ sourceRunId, caseKey: "case-1" }, sql);
+		expect(again?.created).toBe(false);
+
+		const [{ count }] = await sql<{ count: string }[]>`
+      SELECT count(*) AS count FROM runs
+      WHERE idempotency_key = ${`behavior_eval:${sourceRunId}:case-1`}
+    `;
+		expect(Number(count)).toBe(1);
+	});
+
+	test("a distinct case key queues a separate trial", async () => {
+		const second = await createEvalRun({ sourceRunId, caseKey: "case-2" }, sql);
+		expect(second?.created).toBe(true);
+		expect(second?.runId).not.toBe(sourceRunId);
+	});
+
+	test("refuses to replay something that is not a Behavior run", async () => {
+		const [sync] = await sql<{ id: number }[]>`
+      INSERT INTO runs (organization_id, run_type, status, created_at)
+      VALUES (${organizationId}, 'sync', 'completed', current_timestamp)
+      RETURNING id
+    `;
+		expect(await createEvalRun({ sourceRunId: sync.id, caseKey: "x" }, sql)).toBe(
+			null,
+		);
+	});
+});
+
+describe("eval runs are invisible to the Behavior scheduling predicates", () => {
+	// This is the property the run_type design buys: ~18 existing predicates say
+	// `run_type = 'behavior'`, so an eval never competes with, suppresses, or
+	// degrades the Behavior it is replaying — with no code change in any of them.
+	test("the pending-per-behavior unique index does not count evals", async () => {
+		const [{ count }] = await sql<{ count: string }[]>`
+      SELECT count(*) AS count FROM runs
+      WHERE watcher_id = ${behaviorId}
+        AND run_type = ${BEHAVIOR_EVAL_RUN_TYPE}
+        AND status = 'pending'
+    `;
+		// Two pending evals coexist — impossible for run_type='behavior'.
+		expect(Number(count)).toBeGreaterThanOrEqual(2);
+
+		// And a real Behavior run can still be queued alongside them.
+		const [live] = await sql<{ id: number }[]>`
+      INSERT INTO runs (
+        organization_id, run_type, watcher_id, approval_status, status,
+        approved_input, created_at
+      ) VALUES (
+        ${organizationId}, 'behavior', ${behaviorId}, 'auto', 'pending',
+        ${sql.json({ ...payload, watcher_id: behaviorId })}, current_timestamp
+      )
+      RETURNING id
+    `;
+		expect(live.id).toBeGreaterThan(0);
+	});
+
+	test("a behavior-scoped latest-run read skips evals", async () => {
+		const rows = await sql<{ run_type: string }[]>`
+      SELECT run_type FROM runs
+      WHERE watcher_id = ${behaviorId} AND run_type = 'behavior'
+    `;
+		expect(rows.length).toBeGreaterThan(0);
+		expect(rows.every((r) => r.run_type === "behavior")).toBe(true);
+	});
+});

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -2121,6 +2121,43 @@ describe("watcher automation contract", () => {
 			expect(recoveredEval.run_type).toBe(BEHAVIOR_EVAL_RUN_TYPE);
 		});
 
+		it("a failing eval never moves the live Behavior's schedule", async () => {
+			const { sql, watcherId } = await createAutomatedWatcher();
+			await materializeDueWatcherRuns({} as Env);
+
+			const [source] = await sql<{ id: number }>`
+				UPDATE runs SET status = 'completed', completed_at = NOW()
+				WHERE watcher_id = ${watcherId} AND run_type = ${BEHAVIOR_RUN_TYPE}
+				RETURNING id
+			`;
+			const evalRun = await createEvalRun(
+				{ sourceRunId: source.id, caseKey: "schedule" },
+				sql as unknown as DbClient
+			);
+
+			const [before] = await sql<{ next_run_at: string | null }>`
+				SELECT next_run_at FROM watchers WHERE id = ${watcherId}
+			`;
+
+			// Drive the eval through the dispatch lane. Under vitest the embedded
+			// gateway is down, so it takes a `failWatcherRun` path — the same one
+			// a session-create or message-POST failure takes in prod.
+			await dispatchPendingWatcherRuns({} as Env);
+
+			const [evalRow] = await sql<{ status: string }>`
+				SELECT status FROM runs WHERE id = ${evalRun?.runId ?? 0}
+			`;
+			expect(evalRow.status).toBe("failed");
+
+			// The cron cursor of the Behavior it was only replaying is untouched,
+			// and specifically not parked at NULL.
+			const [after] = await sql<{ next_run_at: string | null }>`
+				SELECT next_run_at FROM watchers WHERE id = ${watcherId}
+			`;
+			expect(after.next_run_at).toEqual(before.next_run_at);
+			expect(after.next_run_at).not.toBeNull();
+		});
+
 		it("times out an eval that crashed mid-turn, leaving the live run alone", async () => {
 			const { sql, watcherId } = await createAutomatedWatcher();
 			await materializeDueWatcherRuns({} as Env);

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -16,7 +16,12 @@ import { getDb } from "../../../db/client";
 import { ApiResponseRenderer } from "../../../gateway/api/response-renderer";
 import { UnifiedThreadResponseConsumer } from "../../../gateway/platform/unified-thread-consumer";
 import type { Env } from "../../../index";
+import { createEvalRun } from "../../../runs/eval-runs";
 import { createWatcherRun } from "../../../runs/queue-service";
+import {
+	BEHAVIOR_EVAL_RUN_TYPE,
+	BEHAVIOR_RUN_TYPE,
+} from "../../../runs/run-types";
 import { nextRunAt } from "../../../utils/cron";
 import { generateWindowToken } from "../../../utils/jwt";
 import { computePendingWindow } from "../../../utils/window-utils";
@@ -2071,6 +2076,106 @@ describe("watcher automation contract", () => {
 			expect(recovered.status).toBe("pending");
 			expect(recovered.claimed_by).toBeNull();
 			expect(recovered.claimed_at).toBeNull();
+		});
+
+		it("recovers an orphaned eval claim, which nothing else would clear", async () => {
+			const { sql, watcherId } = await createAutomatedWatcher();
+			await materializeDueWatcherRuns({} as Env);
+
+			// Complete the materialized run so it is a valid eval source, then
+			// replay it. The eval inherits `dispatch_source` verbatim.
+			const [source] = await sql<{ id: number }>`
+				UPDATE runs SET status = 'completed', completed_at = NOW()
+				WHERE watcher_id = ${watcherId} AND run_type = ${BEHAVIOR_RUN_TYPE}
+				RETURNING id
+			`;
+			const evalRun = await createEvalRun(
+				{ sourceRunId: source.id, caseKey: "orphan" },
+				sql as unknown as DbClient
+			);
+			expect(evalRun?.created).toBe(true);
+
+			// Strand it exactly as a dispatcher crash between claim and POST would.
+			await sql`
+				UPDATE runs
+				SET status = 'claimed',
+					claimed_by = 'lobu-dispatcher',
+					claimed_at = NOW() - INTERVAL '10 minutes'
+				WHERE id = ${evalRun?.runId ?? 0}
+			`;
+
+			const result = await runWatcherAutomationTick({} as Env);
+			// The reaper's whole contract: the stranded eval is released. Scoped
+			// to `behavior` alone this is 0 and the eval lane stays wedged.
+			expect(result.reset).toBe(1);
+
+			// Deliberately NOT asserting a final status. The same tick's dispatch
+			// phase adopts the freshly-pending eval and fails it here on
+			// `isLobuGatewayRunning()`, which is false under vitest — an
+			// environment limit, not a lane one. That it gets that far is the
+			// point: the dispatcher does claim `behavior_eval` rows.
+			const [recoveredEval] = await sql<{ run_type: string }>`
+				SELECT run_type FROM runs WHERE id = ${evalRun?.runId ?? 0}
+			`;
+			// Recovery must never relabel an eval into the live lane.
+			expect(recoveredEval.run_type).toBe(BEHAVIOR_EVAL_RUN_TYPE);
+		});
+
+		it("times out an eval that crashed mid-turn, leaving the live run alone", async () => {
+			const { sql, watcherId } = await createAutomatedWatcher();
+			await materializeDueWatcherRuns({} as Env);
+
+			const [source] = await sql<{ id: number }>`
+				UPDATE runs SET status = 'completed', completed_at = NOW()
+				WHERE watcher_id = ${watcherId} AND run_type = ${BEHAVIOR_RUN_TYPE}
+				RETURNING id
+			`;
+			const evalRun = await createEvalRun(
+				{ sourceRunId: source.id, caseKey: "stale" },
+				sql as unknown as DbClient
+			);
+
+			// Running, claimed long ago, and never heartbeated past the claim —
+			// the coarse backstop shape for a crashed executor.
+			await sql`
+				UPDATE runs
+				SET status = 'running',
+					claimed_at = NOW() - INTERVAL '5 hours',
+					last_heartbeat_at = NOW() - INTERVAL '5 hours'
+				WHERE id = ${evalRun?.runId ?? 0}
+			`;
+
+			// A live run for the SAME Behavior, freshly claimed — must survive.
+			const live = await createWatcherRun({
+				organizationId: (
+					await sql<{ organization_id: string }>`
+						SELECT organization_id FROM runs WHERE id = ${source.id}
+					`
+				)[0].organization_id,
+				watcherId,
+				agentId: undefined,
+				windowStart: new Date(Date.now() - 3600_000).toISOString(),
+				windowEnd: new Date().toISOString(),
+				dispatchSource: "manual",
+			});
+			await sql`
+				UPDATE runs SET status = 'running', claimed_at = NOW(),
+					last_heartbeat_at = NOW()
+				WHERE id = ${live.runId}
+			`;
+
+			const swept = await sweepStaleWatcherRuns(getDb());
+			expect(swept.timedOut).toBeGreaterThanOrEqual(1);
+
+			const [stale] = await sql<{ status: string }>`
+				SELECT status FROM runs WHERE id = ${evalRun?.runId ?? 0}
+			`;
+			expect(stale.status).toBe("timeout");
+
+			const [survivor] = await sql<{ status: string }>`
+				SELECT status FROM runs WHERE id = ${live.runId}
+			`;
+			expect(survivor.status).toBe("running");
 		});
 
 		// End-to-end regression for the 12-day outage: a stuck active run carrying a

--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -509,14 +509,20 @@ async function connectionCanDisableTriggers(db: postgres.Sql): Promise<boolean> 
 async function fixSchemaConstraints(db: postgres.Sql): Promise<void> {
   try {
     // runs.run_type needs the connector lanes plus the lobu-queue lanes. Keep
-    // this in sync with db/migrations/20260429060000_extend_runs_for_lobu_queue.sql
-    // and db/migrations/20260720140000_rename_run_type_watcher_to_behavior.sql
-    // (the 'watcher' lane was renamed to 'behavior').
+    // this in sync with db/migrations/20260429060000_extend_runs_for_lobu_queue.sql,
+    // db/migrations/20260720140000_rename_run_type_watcher_to_behavior.sql
+    // (the 'watcher' lane was renamed to 'behavior'), and
+    // db/migrations/20260807120000_behavior_eval_run_type.sql.
+    //
+    // This runs on every cleanupTestDatabase(), so a lane missing here is
+    // re-narrowed away between tests: the migration applies at setup, the first
+    // cleanup silently reverts it, and the INSERT fails with
+    // `runs_run_type_check` long after the migration looked fine.
     await db.unsafe(`
       ALTER TABLE IF EXISTS runs DROP CONSTRAINT IF EXISTS runs_run_type_check;
       ALTER TABLE IF EXISTS runs ADD CONSTRAINT runs_run_type_check
         CHECK (run_type IN (
-          'sync','action','behavior','embed_backfill','auth',
+          'sync','action','behavior','behavior_eval','embed_backfill','auth',
           'chat_message','schedule','agent_run','internal','task'
         ));
     `);

--- a/packages/server/src/__tests__/unit/eval-capture-mode.test.ts
+++ b/packages/server/src/__tests__/unit/eval-capture-mode.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Capture mode is a security boundary: an eval replay must not be able to talk
+ * its way back into performing side effects. These tests pin the two hops
+ * where that could go wrong — minting the signed claim, and honouring it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildWorkerTokenClaims } from "../../gateway/orchestration/worker-token-claims";
+import { resolveSandboxDryRun } from "../../tools/sdk_run";
+
+const base = {
+	channelId: "api_watcher_7",
+	agentId: "agent_1",
+	organizationId: "org_1",
+	platform: "api",
+};
+
+describe("buildWorkerTokenClaims — executionMode", () => {
+	test("carries capture through to the signed claim", () => {
+		const claims = buildWorkerTokenClaims({
+			...base,
+			platformMetadata: { executionMode: "capture" },
+		});
+		expect(claims.executionMode).toBe("capture");
+	});
+
+	test("a live Behavior run carries no claim", () => {
+		const claims = buildWorkerTokenClaims({
+			...base,
+			platformMetadata: { source: "watcher-run" },
+		});
+		expect(claims.executionMode).toBeUndefined();
+	});
+
+	// The claim is minted from platformMetadata, which is assembled server-side
+	// — but only the exact literal may ever be honoured, so a value that reached
+	// the bag by any other route cannot mint a mode we would act on.
+	test.each([
+		["live", "live"],
+		["uppercase", "CAPTURE"],
+		["padded", " capture"],
+		["truthy object", { toString: () => "capture" }],
+		["number", 1],
+		["boolean", true],
+		["null", null],
+	])("%s does not mint a capture claim", (_label, value) => {
+		const claims = buildWorkerTokenClaims({
+			...base,
+			platformMetadata: { executionMode: value },
+		});
+		expect(claims.executionMode).toBeUndefined();
+	});
+
+	test("an absent bag is not a capture run", () => {
+		expect(
+			buildWorkerTokenClaims({ ...base, platformMetadata: {} }).executionMode,
+		).toBeUndefined();
+	});
+});
+
+describe("resolveSandboxDryRun — capture forcing", () => {
+	test("a capture run captures even when the agent asks for a live run", () => {
+		expect(
+			resolveSandboxDryRun({
+				executionMode: "capture",
+				sdkMode: "full",
+				agentDryRun: false,
+			}),
+		).toBe(true);
+	});
+
+	test("capture holds on the read-mode surface too", () => {
+		expect(
+			resolveSandboxDryRun({
+				executionMode: "capture",
+				sdkMode: "read",
+				agentDryRun: false,
+			}),
+		).toBe(true);
+	});
+
+	test("a live run still executes for real", () => {
+		expect(
+			resolveSandboxDryRun({
+				executionMode: "live",
+				sdkMode: "full",
+				agentDryRun: false,
+			}),
+		).toBe(false);
+		expect(
+			resolveSandboxDryRun({
+				executionMode: null,
+				sdkMode: "full",
+				agentDryRun: false,
+			}),
+		).toBe(false);
+	});
+
+	test("the agent's own dry_run opt-in still works on a live run", () => {
+		expect(
+			resolveSandboxDryRun({
+				executionMode: null,
+				sdkMode: "full",
+				agentDryRun: true,
+			}),
+		).toBe(true);
+	});
+});

--- a/packages/server/src/__tests__/unit/eval-capture-mode.test.ts
+++ b/packages/server/src/__tests__/unit/eval-capture-mode.test.ts
@@ -6,7 +6,11 @@
 
 import { describe, expect, test } from "bun:test";
 import { buildWorkerTokenClaims } from "../../gateway/orchestration/worker-token-claims";
-import { resolveSandboxDryRun } from "../../tools/sdk_run";
+import {
+	CAPTURE_DISPATCH_PATHS,
+	resolveSandboxDryRun,
+} from "../../tools/sdk_run";
+import { isSkippedUnderDryRun } from "../../sandbox/run-script";
 
 const base = {
 	channelId: "api_watcher_7",
@@ -104,5 +108,60 @@ describe("resolveSandboxDryRun — capture forcing", () => {
 				agentDryRun: true,
 			}),
 		).toBe(true);
+	});
+});
+
+describe("the finalize call survives the capture skip", () => {
+	// The blocker this pins: the dispatch prompt tells an eval to finalize via
+	// `client.behaviors.completeWindow`, which is access 'write'. The sandbox's
+	// blanket dry-run skip would swallow exactly that call, so the run ends with
+	// no window, gets nudged into a SECOND full replay, and is then failed with
+	// "finished without calling run_sdk" — about a call it did make.
+	const capture = (path: string, access = "write") =>
+		isSkippedUnderDryRun({
+			dryRun: true,
+			dryRunDispatchPaths: CAPTURE_DISPATCH_PATHS,
+			access,
+			path,
+		});
+
+	test("completeWindow is dispatched, not skipped, under capture", () => {
+		expect(capture("behaviors.completeWindow")).toBe(false);
+	});
+
+	test("every other write still captures", () => {
+		expect(capture("conversations.send")).toBe(true);
+		expect(capture("entities.create")).toBe(true);
+		expect(capture("feeds.sync", "external")).toBe(true);
+	});
+
+	test("an agent-requested dry_run skips completeWindow too", () => {
+		// sdk_run passes the carve-out ONLY for executionMode 'capture'. With no
+		// dispatch paths the agent's own preview keeps skipping everything, which
+		// is what `dry_run: true` means.
+		expect(
+			isSkippedUnderDryRun({
+				dryRun: true,
+				dryRunDispatchPaths: undefined,
+				access: "write",
+				path: "behaviors.completeWindow",
+			}),
+		).toBe(true);
+	});
+
+	test("a live run dispatches everything", () => {
+		expect(
+			isSkippedUnderDryRun({
+				dryRun: false,
+				access: "write",
+				path: "conversations.send",
+			}),
+		).toBe(false);
+	});
+
+	test("the carve-out stays minimal", () => {
+		// A growing allowlist means capture is leaking. Each addition needs its
+		// handler to enforce capture itself.
+		expect(CAPTURE_DISPATCH_PATHS.length).toBe(1);
 	});
 });

--- a/packages/server/src/__tests__/unit/runs/run-types.test.ts
+++ b/packages/server/src/__tests__/unit/runs/run-types.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+	BEHAVIOR_EVAL_RUN_TYPE,
+	BEHAVIOR_RUN_TYPE,
+	BEHAVIOR_RUN_TYPES,
+	executionModeForRunType,
+} from "../../../runs/run-types";
+
+describe("executionModeForRunType", () => {
+	test("a real Behavior run executes for real", () => {
+		expect(executionModeForRunType(BEHAVIOR_RUN_TYPE)).toBe("live");
+	});
+
+	test("an eval replay captures", () => {
+		expect(executionModeForRunType(BEHAVIOR_EVAL_RUN_TYPE)).toBe("capture");
+	});
+
+	// The whole point of deriving the mode rather than passing it: anything we
+	// do not positively recognise as a live Behavior must not reach the outside
+	// world. A future run type that forgets to declare itself captures.
+	test.each([
+		["sync", "sync"],
+		["chat_message", "chat_message"],
+		["a run type invented later", "behavior_eval_v2"],
+		["empty string", ""],
+		["null", null],
+		["undefined", undefined],
+	])("%s fails closed to capture", (_label, runType) => {
+		expect(executionModeForRunType(runType)).toBe("capture");
+	});
+
+	test("only the exact literal is live — no prefix or case slack", () => {
+		for (const near of ["Behavior", "behavior ", " behavior", "behaviour"]) {
+			expect(executionModeForRunType(near)).toBe("capture");
+		}
+	});
+});
+
+describe("BEHAVIOR_RUN_TYPES", () => {
+	test("is exactly the two execution-path run types", () => {
+		expect([...BEHAVIOR_RUN_TYPES].sort()).toEqual(
+			["behavior", "behavior_eval"].sort(),
+		);
+	});
+
+	test("every member has a defined mode, and exactly one is live", () => {
+		const live = BEHAVIOR_RUN_TYPES.filter(
+			(t) => executionModeForRunType(t) === "live",
+		);
+		expect(live).toEqual([BEHAVIOR_RUN_TYPE]);
+	});
+});

--- a/packages/server/src/auth/oauth/types.ts
+++ b/packages/server/src/auth/oauth/types.ts
@@ -236,6 +236,12 @@ export interface AuthInfo {
    * internal tools. Absent for every non-admin-tools caller.
    */
   adminTools?: string[] | null;
+  /**
+   * Signed side-effect mode from the worker token
+   * (WorkerTokenData.executionMode). 'capture' marks an eval replay whose
+   * mutating work must be recorded rather than performed.
+   */
+  executionMode?: 'live' | 'capture' | null;
 }
 
 // ============================================

--- a/packages/server/src/gateway/behavior-run-session.ts
+++ b/packages/server/src/gateway/behavior-run-session.ts
@@ -36,6 +36,7 @@ import {
 	parseBehaviorSkillSnapshots,
 } from "../behaviors/skill-snapshots.js";
 import { parseBehaviorRunConversationId } from "./permissions/behavior-run-intent.js";
+import { BEHAVIOR_RUN_TYPES_PG } from "../runs/run-types.js";
 
 export const BEHAVIOR_RUN_SOURCE = "watcher-run";
 
@@ -76,7 +77,7 @@ export async function resolveBehaviorRunSkills(
 		     )
 		 AND version.watcher_id = behavior.watcher_group_id
 		WHERE behavior_run.id = ${intent.runId}
-		  AND behavior_run.run_type = 'behavior'
+		  AND behavior_run.run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
 		  AND behavior_run.watcher_id = ${intent.behaviorId}
 		  AND behavior_run.organization_id = ${args.organizationId}
 		LIMIT 1

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -13,6 +13,9 @@
  * claims (runId+messageId for the per-run token, traceId for the deployment
  * token) stay with each caller.
  */
+
+import type { ExecutionMode } from "../../runs/run-types.js";
+
 export interface WorkerTokenClaimsArgs {
 	channelId: string;
 	teamId?: string;
@@ -77,6 +80,7 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
 	connectionId?: string;
 	responseThreadId?: string;
 	source?: string;
+	executionMode?: ExecutionMode;
 	runtimeProviderId?: string;
 	sandboxId?: string;
 	allowedDomains?: string[];
@@ -103,6 +107,19 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
 		source:
 			typeof args.platformMetadata?.source === "string"
 				? args.platformMetadata.source
+				: undefined,
+		// Only the literal 'capture' is honoured, and it originates server-side
+		// from the run row (behavior-run-intent.ts) — never from a caller.
+		//
+		// An absent claim means live. That direction is deliberate: making
+		// "absent" mean capture would, for the length of a rollout, silence
+		// every real Behavior still running on a token minted before this
+		// deploy. The claim is instead kept honest at its source — an eval run
+		// cannot obtain a session without `verifyBehaviorRunIntent` deriving
+		// its mode from `runs.run_type` — and that chain is covered by tests.
+		executionMode:
+			args.platformMetadata?.executionMode === "capture"
+				? "capture"
 				: undefined,
 		runtimeProviderId,
 		sandboxId: runtimeProviderId ? args.sandboxId : undefined,

--- a/packages/server/src/gateway/permissions/behavior-run-intent.ts
+++ b/packages/server/src/gateway/permissions/behavior-run-intent.ts
@@ -17,6 +17,11 @@
 
 import { hashToken } from "../../auth/oauth/utils.js";
 import { type DbClient, getDb } from "../../db/client.js";
+import {
+	BEHAVIOR_RUN_TYPES_PG,
+	type ExecutionMode,
+	executionModeForRunType,
+} from "../../runs/run-types.js";
 import logger from "../../utils/logger.js";
 
 /**
@@ -61,6 +66,13 @@ export function parseBehaviorRunConversationId(
  * claimed by the dispatcher, and the request bears the short-lived internal
  * OAuth token minted by that dispatcher. Run state alone is not a capability:
  * an ordinary same-org agent owner can observe or guess an in-flight run id.
+ *
+ * Returns the session's {@link ExecutionMode} on success and null on refusal.
+ * This is also where an eval run's `capture` mode ORIGINATES: the run row is
+ * already being read here to decide whether the session may exist at all, so
+ * the mode is derived from the same row under the same authorization — never
+ * taken from the caller, and never re-derived downstream from the
+ * conversationId string.
  */
 export async function verifyBehaviorRunIntent(
 	args: {
@@ -69,8 +81,8 @@ export async function verifyBehaviorRunIntent(
 		accessToken: string | null;
 	},
 	db?: DbClient,
-): Promise<boolean> {
-	if (!args.organizationId || !args.accessToken) return false;
+): Promise<ExecutionMode | null> {
+	if (!args.organizationId || !args.accessToken) return null;
 	const { runId, behaviorId } = args.intent;
 	if (
 		!Number.isSafeInteger(runId) ||
@@ -78,18 +90,18 @@ export async function verifyBehaviorRunIntent(
 		!Number.isSafeInteger(behaviorId) ||
 		behaviorId < 1
 	) {
-		return false;
+		return null;
 	}
 	try {
 		const sql = db ?? getDb();
 		const tokenHash = hashToken(args.accessToken);
-		const rows = await sql`
-	      SELECT 1
+		const rows = (await sql`
+	      SELECT behavior_run.run_type
 	      FROM runs behavior_run
 	      JOIN oauth_tokens service_token
 	        ON service_token.token_hash = ${tokenHash}
 	      WHERE behavior_run.id = ${runId}
-	        AND behavior_run.run_type = 'behavior'
+	        AND behavior_run.run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
 	        AND behavior_run.watcher_id = ${behaviorId}
 	        AND behavior_run.organization_id = ${args.organizationId}
 	        AND behavior_run.claimed_by = ${SERVER_DISPATCHER}
@@ -100,13 +112,14 @@ export async function verifyBehaviorRunIntent(
 	        AND service_token.revoked_at IS NULL
 	        AND service_token.expires_at > NOW()
 	      LIMIT 1
-	    `;
-		return rows.length > 0;
+	    `) as unknown as Array<{ run_type: string }>;
+		if (rows.length === 0) return null;
+		return executionModeForRunType(rows[0].run_type);
 	} catch (error) {
 		logger.warn(
 			{ error, runId, behaviorId, organizationId: args.organizationId },
 			"[agent] Could not verify a Behavior run intent — refusing the session",
 		);
-		return false;
+		return null;
 	}
 }

--- a/packages/server/src/gateway/routes/internal/audio.ts
+++ b/packages/server/src/gateway/routes/internal/audio.ts
@@ -11,6 +11,7 @@ import type { TranscriptionService } from "../../services/transcription-service.
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
 import { authenticateWorker } from "./middleware.js";
 import type { WorkerContext } from "./types.js";
+import { captureSideEffect } from "./capture-mode.js";
 
 const logger = createLogger("internal-audio-routes");
 
@@ -51,6 +52,9 @@ export function createAudioRoutes(
       if (!agentId) {
         return errorResponse(c, "Missing agentId in worker context", 400);
       }
+
+      const captured = captureSideEffect(c, "audio.synthesize", { voice, speed });
+      if (captured) return captured;
 
       logger.info("Synthesizing audio", {
         agentId,

--- a/packages/server/src/gateway/routes/internal/capture-mode.ts
+++ b/packages/server/src/gateway/routes/internal/capture-mode.ts
@@ -1,0 +1,77 @@
+/**
+ * Capture-mode guard for internal worker routes (evals PR 2, lobu#2564).
+ *
+ * The SDK lane already captures: `sandbox/run-script.ts` skips and records any
+ * method whose `METHOD_METADATA` access is not `read`, and `tools/sdk_run.ts`
+ * forces that path on for a capture run. But the agent framework also calls a
+ * handful of internal routes DIRECTLY, without going through the SDK — sending
+ * a real chat message, posting an interaction card, delivering files into the
+ * conversation, executing in a sandbox, generating billable media. Those are
+ * the ones that would still reach the outside world during an eval replay.
+ *
+ * This guard is the one thing those routes need. It reads the signed
+ * `executionMode` claim off the already-verified worker token — no DB lookup,
+ * no re-derivation from the conversationId — and, when the run is a capture
+ * run, records the attempt and answers with a success-shaped body so the agent
+ * continues its turn normally. A capture run that got an error back would
+ * mostly be measuring its own retry logic, which is not the behaviour we want
+ * to score.
+ */
+
+import type { Context } from "hono";
+import logger from "../../../utils/logger.js";
+import { getVerifiedWorker } from "../shared/helpers.js";
+import type { WorkerContext } from "./types.js";
+
+/**
+ * True when this worker's run must not perform side effects. Sourced from the
+ * signed token claim set at session creation from `runs.run_type`.
+ */
+function isCaptureRun(c: Context<WorkerContext>): boolean {
+	return getVerifiedWorker(c).executionMode === "capture";
+}
+
+/**
+ * Short-circuit a mutating internal route when the run is an eval replay.
+ * Returns a Response to return immediately, or null to proceed for real.
+ *
+ * `action` names the side effect that did not happen (e.g.
+ * `conversations.send`); `details` is the payload worth scoring later. Both go
+ * to the run log, which is what an eval reads back to judge what the agent
+ * TRIED to do.
+ *
+ * `responseBody` overrides the default `{ success, captured, ... }` body for
+ * routes whose caller parses a specific contract off a 2xx rather than just
+ * checking `ok` — e.g. `runtime.exec`, where the worker reads
+ * `{ stdout, exitCode }` and an absent exitCode is reported to the agent as
+ * the command failing (exit 1), which would send a capture run into retry
+ * loops instead of continuing its turn.
+ */
+export function captureSideEffect(
+	c: Context<WorkerContext>,
+	action: string,
+	details: Record<string, unknown>,
+	responseBody?: Record<string, unknown>,
+): Response | null {
+	if (!isCaptureRun(c)) return null;
+	const worker = getVerifiedWorker(c);
+	logger.info(
+		{
+			evalCapture: true,
+			action,
+			details,
+			agentId: worker.agentId,
+			organizationId: worker.organizationId,
+			conversationId: worker.conversationId,
+		},
+		`[eval-capture] suppressed ${action} for a capture run`,
+	);
+	return c.json(
+		responseBody ?? {
+			success: true,
+			captured: true,
+			action,
+			message: "Recorded but not performed: this run is an evaluation replay.",
+		},
+	);
+}

--- a/packages/server/src/gateway/routes/internal/conversations.ts
+++ b/packages/server/src/gateway/routes/internal/conversations.ts
@@ -19,6 +19,7 @@ import {
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
 import { authenticateWorker } from "./middleware.js";
 import type { WorkerContext } from "./types.js";
+import { captureSideEffect } from "./capture-mode.js";
 
 const logger = createLogger("conversations-routes");
 
@@ -183,6 +184,14 @@ export function createConversationsRoutes(): Hono<WorkerContext> {
         }
         target = resolved;
       }
+
+      const captured = captureSideEffect(c, "conversations.send", {
+        platform: target.platform,
+        channelId: target.channelId,
+        threadId: threadId ?? null,
+        text,
+      });
+      if (captured) return captured;
 
       const manager = getChatInstanceManager();
       if (!manager?.postToConversation) {

--- a/packages/server/src/gateway/routes/internal/files.ts
+++ b/packages/server/src/gateway/routes/internal/files.ts
@@ -11,6 +11,7 @@ import type { PlatformRegistry } from "../../platform.js";
 import type { IFileHandler } from "../../platform/file-handler.js";
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
 import { authenticateWorker } from "./middleware.js";
+import { captureSideEffect } from "./capture-mode.js";
 import type { WorkerContext } from "./types.js";
 
 const logger = createLogger("file-routes");
@@ -111,6 +112,18 @@ export function createFileRoutes(
 
       const filename = (formData.get("filename") as string) || file.name;
       const initialComment = formData.get("comment") as string | null;
+
+      // Delivery into the conversation is a side effect: the media plugins
+      // generate content and then land it here, so this is where a capture
+      // run's attachment attempt is recorded instead of delivered. Callers
+      // only require a 2xx (`upload.response.ok`), so the generic body works.
+      const captured = captureSideEffect(c, "files.upload", {
+        filename,
+        mimeType: file.type || null,
+        size: file.size,
+        voiceMessage,
+      });
+      if (captured) return captured;
 
       logger.info(
         `Worker uploading file ${filename} via ${worker.platform || "unknown"} for conversation ${worker.conversationId} to conversation ${conversationId}${voiceMessage ? " as voice message" : ""}`
@@ -213,6 +226,14 @@ export function createFileRoutes(
       if (!fileEntries || fileEntries.length === 0) {
         return errorResponse(c, "No files provided", 400);
       }
+
+      const captured = captureSideEffect(c, "files.upload_batch", {
+        count: fileEntries.length,
+        filenames: fileEntries
+          .filter((entry): entry is File => entry instanceof File)
+          .map((entry) => entry.name),
+      });
+      if (captured) return captured;
 
       logger.info(
         `Worker uploading ${fileEntries.length} files for conversation ${worker.conversationId}`

--- a/packages/server/src/gateway/routes/internal/images.ts
+++ b/packages/server/src/gateway/routes/internal/images.ts
@@ -10,6 +10,7 @@ import type { ImageGenerationService } from "../../services/image-generation-ser
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
 import { authenticateWorker } from "./middleware.js";
 import type { WorkerContext } from "./types.js";
+import { captureSideEffect } from "./capture-mode.js";
 
 const logger = createLogger("internal-image-routes");
 
@@ -36,6 +37,7 @@ export function createImageRoutes(
       if (!prompt || typeof prompt !== "string") {
         return errorResponse(c, "prompt is required and must be a string", 400);
       }
+
       if (prompt.length > 4000) {
         return errorResponse(c, "prompt must be 4000 characters or less", 400);
       }
@@ -44,6 +46,11 @@ export function createImageRoutes(
       if (!agentId) {
         return errorResponse(c, "Missing agentId in worker context", 400);
       }
+
+      // After validation, before the billable call: a capture run must see the
+      // same 400s a live run would, and only the side effect is suppressed.
+      const captured = captureSideEffect(c, "images.generate", { prompt, size });
+      if (captured) return captured;
 
       logger.info("Generating image", {
         agentId,

--- a/packages/server/src/gateway/routes/internal/interactions.ts
+++ b/packages/server/src/gateway/routes/internal/interactions.ts
@@ -16,6 +16,7 @@ import { persistSuggestion } from "../../suggestions/persist-suggestion.js";
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
 import { authenticateWorker } from "./middleware.js";
 import type { WorkerContext } from "./types.js";
+import { captureSideEffect } from "./capture-mode.js";
 
 const logger = createLogger("internal-interaction-routes");
 
@@ -59,6 +60,13 @@ export function createInteractionRoutes(
         logger.info(
           `Posting ${interactionType} for conversation ${conversationId}`
         );
+
+        const captured = captureSideEffect(c, "interactions.create", {
+          interactionType,
+          conversationId,
+          platform,
+        });
+        if (captured) return captured;
 
         if (interactionType === "link_button") {
           const posted = await interactionService.postLinkButton(
@@ -191,6 +199,14 @@ export function createInteractionRoutes(
           400
         );
       }
+
+      // After validation: a capture run takes the same empty-prompts and
+      // missing-org paths a live run would, and only the delivery is suppressed.
+      const captured = captureSideEffect(c, "suggestions.create", {
+        conversationId,
+        prompts,
+      });
+      if (captured) return captured;
 
       logger.info(
         `Sending suggestions to conversation ${conversationId} (${prompts.length} prompts)`

--- a/packages/server/src/gateway/routes/internal/runtime.ts
+++ b/packages/server/src/gateway/routes/internal/runtime.ts
@@ -8,6 +8,7 @@ import { type PackageProvisionResult, RuntimeInfrastructureError } from "../../r
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
 import { authenticateWorker } from "./middleware.js";
 import type { WorkerContext } from "./types.js";
+import { captureSideEffect } from "./capture-mode.js";
 
 const logger = createLogger("internal-runtime");
 
@@ -57,6 +58,24 @@ export function createRuntimeRoutes(): Hono<WorkerContext> {
       if (!body || typeof body.command !== "string" || !body.command.trim()) {
         return errorResponse(c, "Missing command", 400);
       }
+
+      // The worker's exec client (generic-runtime-bash.ts) reads
+      // `{ stdout, exitCode }` off a 2xx and treats a missing exitCode as the
+      // command failing with exit 1 — so the captured body must speak that
+      // contract, or every captured command reads as a silent failure and the
+      // replay measures the agent's retry loop instead of its intent.
+      const captured = captureSideEffect(
+        c,
+        "runtime.exec",
+        { command: body.command },
+        {
+          captured: true,
+          stdout:
+            "lobu: capture run — this command was recorded but not executed (evaluation replay).\n",
+          exitCode: 0,
+        },
+      );
+      if (captured) return captured;
 
       let credentials = await resolveRuntimeCredentials(
         provider,

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -762,14 +762,18 @@ export function createAgentApi(config: AgentApiConfig): Hono {
     // its short-lived internal token HERE — the one place the intent enters
     // the system — so downstream code can trust the packed correlation.
     const behaviorIntent = intent?.kind === "behavior_run" ? intent : null;
-    if (
-      behaviorIntent &&
-      !(await verifyBehaviorRunIntent({
-        intent: behaviorIntent,
-        organizationId: tokenOrganizationId,
-        accessToken: tokenFromHeader(c),
-      }))
-    ) {
+    // Non-null only for a verified Behavior session. 'capture' means the run is
+    // an eval replay: it is derived from the run row here, travels as a signed
+    // worker-token claim, and is what stops the agent touching the outside
+    // world. See packages/server/src/runs/run-types.ts.
+    const behaviorExecutionMode = behaviorIntent
+      ? await verifyBehaviorRunIntent({
+          intent: behaviorIntent,
+          organizationId: tokenOrganizationId,
+          accessToken: tokenFromHeader(c),
+        })
+      : null;
+    if (behaviorIntent && !behaviorExecutionMode) {
       logger.warn(
         {
           runId: behaviorIntent.runId,
@@ -930,6 +934,9 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       ...(tokenOrganizationId ? { organizationId: tokenOrganizationId } : {}),
       dryRun: effectiveDryRun,
       intent: behaviorIntent ?? undefined,
+      ...(behaviorExecutionMode
+        ? { executionMode: behaviorExecutionMode }
+        : {}),
     };
     await sessMgr.setSession(session);
 
@@ -1550,6 +1557,9 @@ export function createAgentApi(config: AgentApiConfig): Hono {
           traceparent: traceparent || undefined,
           dryRun: session.dryRun || false,
           intent: session.intent,
+          ...(session.executionMode
+            ? { executionMode: session.executionMode }
+            : {}),
           ...(ingestedFiles.length > 0 ? { files: ingestedFiles } : {}),
           ...(bangBash ? { bangBash } : {}),
         },

--- a/packages/server/src/gateway/services/watcher-run-thread.ts
+++ b/packages/server/src/gateway/services/watcher-run-thread.ts
@@ -1,5 +1,6 @@
 import { getDb, pgBigintArray } from "../../db/client.js";
 import { paginateSessionMessages } from "./session-message-page.js";
+import { BEHAVIOR_RUN_TYPES_PG } from "../../runs/run-types.js";
 
 /**
  * Read the latest N durable watcher runs for one watcher, newest first, ready
@@ -81,7 +82,7 @@ export async function readWatcherRunThreads(args: {
 			WHERE r.organization_id = ${organizationId}
 			  AND r.watcher_id = ${watcherId}
 			  AND w.agent_id = ${agentId}
-			  AND r.run_type = 'behavior'
+			  AND r.run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
 			ORDER BY COALESCE(r.completed_at, r.created_at) DESC, r.id DESC
 			LIMIT ${limit}
 		)

--- a/packages/server/src/gateway/session.ts
+++ b/packages/server/src/gateway/session.ts
@@ -1,4 +1,5 @@
 import type { NetworkConfig, NixConfig } from "@lobu/core";
+import type { ExecutionMode } from "../runs/run-types.js";
 
 /**
  * Platform-agnostic session types and utilities
@@ -48,6 +49,14 @@ export interface ThreadSession {
   dryRun?: boolean;
   /** Internal automation intent for one-shot system sessions. */
   intent?: { kind: "behavior_run"; runId: number; behaviorId: number };
+  /**
+   * Server-derived side-effect mode for a verified Behavior session. Set once
+   * from the run row at session creation (behavior-run-intent.ts) and never
+   * from the caller; `capture` marks an eval replay whose writes must be
+   * recorded instead of performed. Carried onto the queue payload and then
+   * into the signed worker token, so enforcement never re-derives it.
+   */
+  executionMode?: ExecutionMode;
 }
 
 /**

--- a/packages/server/src/runs/eval-runs.ts
+++ b/packages/server/src/runs/eval-runs.ts
@@ -1,0 +1,135 @@
+/**
+ * Creating eval runs (evals PR 2, lobu#2564).
+ *
+ * An eval run replays a real Behavior run's frozen dispatch payload — the same
+ * window bounds, the same behavior version, the same trigger signal — so the
+ * agent sees what it saw the first time. What differs is only the run type,
+ * which the server turns into `executionMode = 'capture'` at session creation:
+ * the replay records what the agent tried to do instead of doing it.
+ *
+ * `runs.approved_input` is the frozen payload and is copied VERBATIM. Do not
+ * recompute the window here: a recomputed window is a different question than
+ * the one the original run answered, and the comparison stops meaning
+ * anything.
+ *
+ * PR 3's promote flow calls this too — it is the one way an eval run is minted.
+ */
+
+import { type DbClient, getDb } from "../db/client.js";
+import logger from "../utils/logger.js";
+import { BEHAVIOR_EVAL_RUN_TYPE, BEHAVIOR_RUN_TYPE } from "./run-types.js";
+
+export interface CreateEvalRunResult {
+	runId: number;
+	sourceRunId: number;
+	behaviorId: number;
+	created: boolean;
+}
+
+/**
+ * Clone a terminal Behavior run into a pending eval replay.
+ *
+ * `caseKey` scopes idempotency: re-running with the same (sourceRunId,
+ * caseKey) reuses the in-flight eval rather than queueing a second one. Pass a
+ * distinct key (an attempt number, a case id) to run the same source run
+ * several times — which is the point, since a single trial is not a
+ * measurement.
+ *
+ * Returns null when the source run does not exist, is not a Behavior run, or
+ * carries no frozen payload to replay.
+ */
+export async function createEvalRun(
+	params: { sourceRunId: number; caseKey: string },
+	db?: DbClient,
+): Promise<CreateEvalRunResult | null> {
+	const sql = db ?? getDb();
+	const idempotencyKey = `behavior_eval:${params.sourceRunId}:${params.caseKey}`;
+
+	const source = (await sql`
+    SELECT id, organization_id, watcher_id, approved_input
+    FROM runs
+    WHERE id = ${params.sourceRunId}
+      AND run_type = ${BEHAVIOR_RUN_TYPE}
+    LIMIT 1
+  `) as unknown as Array<{
+		id: number | string;
+		organization_id: string | null;
+		watcher_id: number | null;
+		approved_input: unknown;
+	}>;
+
+	if (source.length === 0) {
+		logger.warn(
+			{ sourceRunId: params.sourceRunId },
+			"[evals] No such Behavior run to replay",
+		);
+		return null;
+	}
+	const row = source[0];
+	if (!row.organization_id || !row.watcher_id || !row.approved_input) {
+		logger.warn(
+			{ sourceRunId: params.sourceRunId },
+			"[evals] Behavior run has no frozen dispatch payload — nothing to replay",
+		);
+		return null;
+	}
+
+	const inserted = (await sql`
+    INSERT INTO runs (
+      organization_id,
+      run_type,
+      watcher_id,
+      approval_status,
+      status,
+      approved_input,
+      idempotency_key,
+      created_at
+    ) VALUES (
+      ${row.organization_id},
+      ${BEHAVIOR_EVAL_RUN_TYPE},
+      ${row.watcher_id},
+      'auto',
+      'pending',
+      ${sql.json(row.approved_input as never)},
+      ${idempotencyKey},
+      current_timestamp
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING id
+  `) as unknown as Array<{ id: number | string }>;
+
+	if (inserted.length === 0) {
+		// The partial unique index on idempotency_key covers pending/claimed/
+		// running only, so this means an identical replay is already in flight.
+		const existing = (await sql`
+      SELECT id FROM runs
+      WHERE idempotency_key = ${idempotencyKey}
+        AND status IN ('pending', 'claimed', 'running')
+      LIMIT 1
+    `) as unknown as Array<{ id: number | string }>;
+		if (existing.length === 0) return null;
+		return {
+			runId: Number(existing[0].id),
+			sourceRunId: Number(row.id),
+			behaviorId: row.watcher_id,
+			created: false,
+		};
+	}
+
+	const runId = Number(inserted[0].id);
+	logger.info(
+		{
+			runId,
+			sourceRunId: params.sourceRunId,
+			behaviorId: row.watcher_id,
+			caseKey: params.caseKey,
+		},
+		"[evals] Queued an eval replay",
+	);
+	return {
+		runId,
+		sourceRunId: Number(row.id),
+		behaviorId: row.watcher_id,
+		created: true,
+	};
+}

--- a/packages/server/src/runs/eval-runs.ts
+++ b/packages/server/src/runs/eval-runs.ts
@@ -74,6 +74,32 @@ export async function createEvalRun(
 		return null;
 	}
 
+	// Refuse a source whose clone no eval lane could ever claim. The cloud
+	// dispatcher skips device-pinned and manual-open runs, and the device poll
+	// lane claims `behavior` only — so such an eval sits `pending` forever, and
+	// because the claim guards are same-lane it wedges every later eval of this
+	// Behavior. Nothing reaps a stranded pending eval either
+	// (`finalizeStalePendingWatcherRuns` is behavior-only by design: it advances
+	// `next_run_at`). Failing loudly at mint beats creating undispatchable work.
+	const payload = row.approved_input as Record<string, unknown>;
+	const agentId =
+		typeof payload.agent_id === "string" ? payload.agent_id.trim() : "";
+	const devicePin =
+		typeof payload.device_worker_id === "string"
+			? payload.device_worker_id.trim()
+			: "";
+	if (devicePin || !agentId) {
+		logger.warn(
+			{
+				sourceRunId: params.sourceRunId,
+				devicePinned: Boolean(devicePin),
+				hasAgent: Boolean(agentId),
+			},
+			"[evals] Behavior run is not server-dispatchable — its replay could never be claimed",
+		);
+		return null;
+	}
+
 	const inserted = (await sql`
     INSERT INTO runs (
       organization_id,

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -25,6 +25,7 @@ import { stableJson } from '../utils/insert-event';
 import logger from '../utils/logger';
 import { isUniqueViolation } from '../utils/pg-errors';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
+import { BEHAVIOR_RUN_TYPES_PG } from "./run-types.js";
 
 type WatcherDispatchSource = 'scheduled' | 'manual' | 'event';
 
@@ -125,13 +126,17 @@ export async function claimPendingWatcherRun(
             claimed_by = ${params.claimedBy}
         WHERE r.id = ${params.runId}
           AND r.watcher_id = ${params.watcherId}
-          AND r.run_type = 'behavior'
+          AND r.run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
           AND r.status = 'pending'
+          -- Same-type guard, deliberately not widened to both run types: one
+          -- Behavior at a time per Behavior, and one eval at a time per
+          -- Behavior, but an eval replay must never be blocked by (or block)
+          -- the real run it is replaying.
           AND NOT EXISTS (
             SELECT 1
             FROM runs active
             WHERE active.watcher_id = r.watcher_id
-              AND active.run_type = 'behavior'
+              AND active.run_type = r.run_type
               AND active.status IN ('claimed', 'running')
           )
         RETURNING r.id

--- a/packages/server/src/runs/run-types.ts
+++ b/packages/server/src/runs/run-types.ts
@@ -24,10 +24,20 @@ export const BEHAVIOR_EVAL_RUN_TYPE = "behavior_eval";
 /**
  * Run types the Behavior execution path accepts: claim, session creation,
  * window completion, run completion — plus the run-thread read, so an eval's
- * transcript can be read back for scoring. Deliberately NOT used by
- * scheduling, coalescing, reaping or health predicates — those stay
- * `= 'behavior'` so evals never compete with, suppress, or degrade a real
- * Behavior.
+ * transcript can be read back for scoring.
+ *
+ * Deliberately NOT used by scheduling, coalescing or health predicates —
+ * those stay `= 'behavior'` so evals never compete with, suppress, or degrade
+ * a real Behavior.
+ *
+ * Reaping splits, and the test is whether the reaper touches anything beyond
+ * the stranded row itself:
+ * - Included — `resetOrphanedWatcherRuns` and `markStaleRunsAsTimeout`. Both
+ *   only release or terminate the run they reap. Excluding evals there does
+ *   not protect the Behavior, it just strands the eval forever, and because
+ *   the claim guards are same-lane that wedges every later eval of it.
+ * - Excluded — `finalizeStalePendingWatcherRuns`, which advances
+ *   `next_run_at`. An eval must never move the live schedule.
  */
 export const BEHAVIOR_RUN_TYPES: readonly string[] = [
 	BEHAVIOR_RUN_TYPE,

--- a/packages/server/src/runs/run-types.ts
+++ b/packages/server/src/runs/run-types.ts
@@ -1,0 +1,63 @@
+/**
+ * Behavior run types and the execution mode derived from them (evals PR 2,
+ * lobu#2564).
+ *
+ * A Behavior run executes for real. An eval run replays a window to score it
+ * and must never touch the outside world. Rather than a second table or an
+ * `is_eval` column, an eval is a `runs.run_type` value — which means the ~18
+ * existing `run_type = 'behavior'` predicates across the scheduler, reapers,
+ * coalescing and behavior-health exclude evals with no code change at all.
+ * Only the execution path opts back in, via {@link BEHAVIOR_RUN_TYPES}.
+ *
+ * The mode is ALWAYS derived here from the run row and never accepted from a
+ * caller: it is computed at session creation (where the run row is already
+ * being read to decide whether the session may exist) and then carried as a
+ * signed worker-token claim, so an agent cannot ask to be live.
+ */
+
+/** A Behavior run whose side effects really happen. */
+export const BEHAVIOR_RUN_TYPE = "behavior";
+
+/** A replay of a Behavior window for scoring. Side effects are captured. */
+export const BEHAVIOR_EVAL_RUN_TYPE = "behavior_eval";
+
+/**
+ * Run types the Behavior execution path accepts: claim, session creation,
+ * window completion, run completion — plus the run-thread read, so an eval's
+ * transcript can be read back for scoring. Deliberately NOT used by
+ * scheduling, coalescing, reaping or health predicates — those stay
+ * `= 'behavior'` so evals never compete with, suppress, or degrade a real
+ * Behavior.
+ */
+export const BEHAVIOR_RUN_TYPES: readonly string[] = [
+	BEHAVIOR_RUN_TYPE,
+	BEHAVIOR_EVAL_RUN_TYPE,
+];
+
+/**
+ * The same list, pre-formatted as a Postgres `text[]` literal.
+ *
+ * Bind THIS at every `run_type = ANY(...)` site, never {@link BEHAVIOR_RUN_TYPES}
+ * itself: the pool runs with `fetch_types: false`, so a raw JS array is sent as
+ * the bare string `behavior,behavior_eval` and Postgres rejects it at runtime
+ * with `malformed array literal` — a query that typechecks and then always
+ * throws. Safe to build by `join` because both values are compile-time
+ * identifier constants with nothing to escape.
+ */
+export const BEHAVIOR_RUN_TYPES_PG = `{${BEHAVIOR_RUN_TYPES.join(",")}}`;
+
+/**
+ * `live` executes side effects; `capture` records what the agent tried to do
+ * and performs none of it.
+ */
+export type ExecutionMode = "live" | "capture";
+
+/**
+ * Fail closed: anything that is not a known live Behavior run captures. A run
+ * type this module has not heard of never gets to write to the outside world.
+ */
+export function executionModeForRunType(
+	runType: string | null | undefined,
+): ExecutionMode {
+	return runType === BEHAVIOR_RUN_TYPE ? "live" : "capture";
+}

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -20,6 +20,24 @@ export interface RunLimits {
 	outputBytes?: number;
 }
 
+/**
+ * Whether one SDK call is skipped-and-recorded rather than dispatched.
+ *
+ * Exported so the capture contract is pinned by a test against THIS expression
+ * rather than a copy of it — a mirrored predicate in a test can never catch a
+ * regression here.
+ */
+export function isSkippedUnderDryRun(args: {
+	dryRun?: boolean;
+	dryRunDispatchPaths?: readonly string[];
+	access: string;
+	path: string;
+}): boolean {
+	if (args.dryRun !== true) return false;
+	if (args.access === "read") return false;
+	return !args.dryRunDispatchPaths?.includes(args.path);
+}
+
 export interface RunScriptOptions {
 	source: string;
 	context?: Record<string, unknown>;
@@ -29,6 +47,22 @@ export interface RunScriptOptions {
 	 * `sideEffectPreview` instead of mutating state or reaching external systems.
 	 */
 	dryRun?: boolean;
+	/**
+	 * SDK paths that still DISPATCH under {@link dryRun}, because the handler
+	 * behind them is itself capture-aware and refuses its own writes.
+	 *
+	 * This exists for exactly one case: an eval replay is told to finalize via
+	 * `client.behaviors.completeWindow`, and the blanket skip would swallow that
+	 * call — leaving the run with no window, so it gets nudged into a second
+	 * full replay and then failed with "finished without calling run_sdk". The
+	 * handler needs to RUN so it can record the extraction and answer
+	 * `captured: true`; it reads the same `executionMode` off its ToolContext
+	 * and writes nothing.
+	 *
+	 * Deliberately NOT populated for an agent-requested `dry_run: true` — there
+	 * the agent asked for a preview and skipping is the correct answer.
+	 */
+	dryRunDispatchPaths?: readonly string[];
 	/**
 	 * Either a pre-built SDK or a builder that receives the wall-clock
 	 * AbortSignal so handlers can race their work against the timeout and
@@ -754,7 +788,12 @@ export async function runScript(
 						orgPath,
 						access,
 						args: traceArgs(args),
-						skipped: options.dryRun === true && access !== "read",
+						skipped: isSkippedUnderDryRun({
+							dryRun: options.dryRun,
+							dryRunDispatchPaths: options.dryRunDispatchPaths,
+							access,
+							path,
+						}),
 					};
 					sdkCallTrace.push(trace);
 					if (trace.skipped) {

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -35,7 +35,11 @@ import type { ManageBehaviorsArgs } from '../manage_behaviors';
 import { normalizeExtractedData, parseJson, requireWatcherAccess } from './shared';
 import { getErrorMessage } from '@lobu/core';
 import { classifyRunOutcome } from "../../../runs/run-outcome";
-import { BEHAVIOR_EVAL_RUN_TYPE, BEHAVIOR_RUN_TYPES_PG } from "../../../runs/run-types.js";
+import {
+  BEHAVIOR_EVAL_RUN_TYPE,
+  BEHAVIOR_RUN_TYPE,
+  BEHAVIOR_RUN_TYPES_PG,
+} from "../../../runs/run-types.js";
 
 /** Cap on the content ids echoed into `dry_run_preview` — the preview exists to
  *  be read, and an unbounded id list on a wide window is neither useful nor
@@ -191,11 +195,19 @@ export async function handleCompleteWindow(
   if (watcherRunId == null) {
     // Prefer an active (dispatched) run; otherwise a pending manual-open run
     // (no agent/device pin) waiting for an external completer.
+    //
+    // Scoped to the CALLER's own lane. This ordering prefers `running` and then
+    // the newest row — which, while an eval replay of this same Behavior is in
+    // flight, is the eval. A live completer that omitted `behavior_run_id`
+    // would otherwise adopt the eval's run and stamp a window onto it, breaking
+    // the "an eval never has a window" invariant PR 3 scores against.
+    const callerRunType =
+      ctx.executionMode === 'capture' ? BEHAVIOR_EVAL_RUN_TYPE : BEHAVIOR_RUN_TYPE;
     const runRows = await sql`
       SELECT id
       FROM runs
       WHERE watcher_id = ${watcherId}
-        AND run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
+        AND run_type = ${callerRunType}
         AND (
           status = 'running'
           OR (
@@ -848,7 +860,7 @@ export async function handleCompleteWindow(
             error_message = NULL
         WHERE id = ${watcherRunId}
           AND watcher_id = ${watcherId}
-          AND run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
+          AND run_type = ${BEHAVIOR_RUN_TYPE}
           AND status IN ('running', 'claimed')
         RETURNING id, approved_input->>'dispatch_source' AS dispatch_source
       `;
@@ -874,7 +886,7 @@ export async function handleCompleteWindow(
               run_metadata = COALESCE(run_metadata, '{}'::jsonb) || ${sql.json(provenanceMetadata)}
           WHERE id = ${watcherRunId}
             AND watcher_id = ${watcherId}
-            AND run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
+            AND run_type = ${BEHAVIOR_RUN_TYPE}
         `;
       }
     }

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -35,6 +35,12 @@ import type { ManageBehaviorsArgs } from '../manage_behaviors';
 import { normalizeExtractedData, parseJson, requireWatcherAccess } from './shared';
 import { getErrorMessage } from '@lobu/core';
 import { classifyRunOutcome } from "../../../runs/run-outcome";
+import { BEHAVIOR_EVAL_RUN_TYPE, BEHAVIOR_RUN_TYPES_PG } from "../../../runs/run-types.js";
+
+/** Cap on the content ids echoed into `dry_run_preview` — the preview exists to
+ *  be read, and an unbounded id list on a wide window is neither useful nor
+ *  cheap to store. Mirrors the capping rationale in worker-api/run-lifecycle. */
+const CAPTURE_PREVIEW_CONTENT_CAP = 200;
 
 // Initialize AJV for JSON Schema validation
 // removeAdditional: true strips fields like 'embedding' that workers add but aren't in the schema
@@ -99,6 +105,10 @@ export async function handleCompleteWindow(
     | 'already_completed';
   reaction_status: 'success' | 'failed' | 'skipped';
   reaction_error?: string;
+  /** Set only on an eval replay (`executionMode = 'capture'`): the extraction
+   *  was recorded on the run's `dry_run_preview` and nothing was written. No
+   *  window exists, so `window_id` is 0. */
+  captured?: true;
 }> {
   const sql = getDb();
   const provenanceClientId = args.client_id ?? ctx.clientId ?? null;
@@ -185,7 +195,7 @@ export async function handleCompleteWindow(
       SELECT id
       FROM runs
       WHERE watcher_id = ${watcherId}
-        AND run_type = 'behavior'
+        AND run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
         AND (
           status = 'running'
           OR (
@@ -220,7 +230,7 @@ export async function handleCompleteWindow(
           claimed_at = COALESCE(claimed_at, current_timestamp)
       WHERE id = ${watcherRunId}
         AND watcher_id = ${watcherId}
-        AND run_type = 'behavior'
+        AND run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
         AND status = 'pending'
         AND (approved_input->>'agent_id' IS NULL OR approved_input->>'agent_id' = '')
         AND (approved_input->>'device_worker_id' IS NULL OR approved_input->>'device_worker_id' = '')
@@ -409,6 +419,73 @@ export async function handleCompleteWindow(
   // ============================================
   const fieldsToStrip = getFieldsToStrip(classifiers);
   const cleanedExtractedData = stripFields(extractedData, Array.from(fieldsToStrip));
+
+  // ============================================
+  // STEP 5: Capture mode — an eval replay records its output, never commits it
+  // ============================================
+  // Everything above is validation and reads, so a capture run takes exactly
+  // the same 400s a live run would and only the side effect diverges.
+  // Everything below is writes: the canvas supersede chain, entity promotion,
+  // output events, classifications, the schedule cursor, and the reaction
+  // script.
+  //
+  // This return is load-bearing, not defensive. An eval replays the SAME window
+  // as the run it scores, so the canvas chain root (watcher + granularity +
+  // window_start) is identical — a `replace_existing` completion from an eval
+  // would supersede the REAL Behavior's head and unlink its content. Returning
+  // here is also what keeps the reaction script from firing, since that block
+  // triggers on `content_linked > 0`.
+  //
+  // The extraction is what PR 3 scores, so it is persisted where a captured
+  // payload already belongs: `runs.dry_run_preview` (see
+  // 20260731020000_runs_dry_run.sql). The `run_type` guard on the UPDATE means
+  // a capture claim can never stamp a real Behavior run.
+  if (ctx.executionMode === 'capture') {
+    if (watcherRunId != null) {
+      await sql`
+        UPDATE runs
+        SET dry_run = true,
+            dry_run_preview = ${sql.json({
+              captured: 'complete_window',
+              behavior_id: String(watcherId),
+              window_start,
+              window_end,
+              granularity,
+              extracted_data: cleanedExtractedData as never,
+              content_ids: batchContentIds.slice(0, CAPTURE_PREVIEW_CONTENT_CAP),
+              content_linked: batchContentIds.length,
+              content_ids_truncated: batchContentIds.length > CAPTURE_PREVIEW_CONTENT_CAP,
+              replace_existing: args.replace_existing === true,
+            })}
+        WHERE id = ${watcherRunId}
+          AND run_type = ${BEHAVIOR_EVAL_RUN_TYPE}
+      `;
+    }
+    logger.info(
+      {
+        evalCapture: true,
+        runId: watcherRunId,
+        watcherId,
+        window_start,
+        window_end,
+        contentLinked: batchContentIds.length,
+      },
+      '[evals] Recorded a complete_window extraction without writing it'
+    );
+    return {
+      action: 'complete_window' as const,
+      behavior_id: String(watcherId),
+      // No window was created, so there is no id to report.
+      window_id: 0,
+      window_start,
+      window_end,
+      content_linked: 0,
+      window_created: false,
+      head_superseded: false,
+      reaction_status: 'skipped' as const,
+      captured: true as const,
+    };
+  }
 
   // ============================================
   // STEP 6: Wrap all DB operations in a transaction
@@ -771,7 +848,7 @@ export async function handleCompleteWindow(
             error_message = NULL
         WHERE id = ${watcherRunId}
           AND watcher_id = ${watcherId}
-          AND run_type = 'behavior'
+          AND run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
           AND status IN ('running', 'claimed')
         RETURNING id, approved_input->>'dispatch_source' AS dispatch_source
       `;
@@ -797,7 +874,7 @@ export async function handleCompleteWindow(
               run_metadata = COALESCE(run_metadata, '{}'::jsonb) || ${sql.json(provenanceMetadata)}
           WHERE id = ${watcherRunId}
             AND watcher_id = ${watcherId}
-            AND run_type = 'behavior'
+            AND run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
         `;
       }
     }

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -35,11 +35,7 @@ import type { ManageBehaviorsArgs } from '../manage_behaviors';
 import { normalizeExtractedData, parseJson, requireWatcherAccess } from './shared';
 import { getErrorMessage } from '@lobu/core';
 import { classifyRunOutcome } from "../../../runs/run-outcome";
-import {
-  BEHAVIOR_EVAL_RUN_TYPE,
-  BEHAVIOR_RUN_TYPE,
-  BEHAVIOR_RUN_TYPES_PG,
-} from "../../../runs/run-types.js";
+import { BEHAVIOR_EVAL_RUN_TYPE, BEHAVIOR_RUN_TYPE } from "../../../runs/run-types.js";
 
 /** Cap on the content ids echoed into `dry_run_preview` — the preview exists to
  *  be read, and an unbounded id list on a wide window is neither useful nor
@@ -192,17 +188,22 @@ export async function handleCompleteWindow(
   const pgSql = createDbClientFromEnv(env);
   await requireWatcherAccess(pgSql, [String(watcherId)], ctx, 'write');
 
+  // The lane this caller belongs to. A live session and an eval replay must
+  // never resolve to, or claim, each other's run: the mode is derived from the
+  // run row at session creation, so a live token carries no capture claim and
+  // would execute the real write path for a window the eval only replays.
+  const callerRunType =
+    ctx.executionMode === 'capture' ? BEHAVIOR_EVAL_RUN_TYPE : BEHAVIOR_RUN_TYPE;
+
   if (watcherRunId == null) {
     // Prefer an active (dispatched) run; otherwise a pending manual-open run
     // (no agent/device pin) waiting for an external completer.
     //
-    // Scoped to the CALLER's own lane. This ordering prefers `running` and then
-    // the newest row — which, while an eval replay of this same Behavior is in
-    // flight, is the eval. A live completer that omitted `behavior_run_id`
-    // would otherwise adopt the eval's run and stamp a window onto it, breaking
-    // the "an eval never has a window" invariant PR 3 scores against.
-    const callerRunType =
-      ctx.executionMode === 'capture' ? BEHAVIOR_EVAL_RUN_TYPE : BEHAVIOR_RUN_TYPE;
+    // Lane-scoped: this ordering prefers `running` and then the newest row —
+    // which, while an eval replay of this same Behavior is in flight, is the
+    // eval. A live completer that omitted `behavior_run_id` would otherwise
+    // adopt the eval's run and stamp a window onto it, breaking the "an eval
+    // never has a window" invariant PR 3 scores against.
     const runRows = await sql`
       SELECT id
       FROM runs
@@ -242,7 +243,12 @@ export async function handleCompleteWindow(
           claimed_at = COALESCE(claimed_at, current_timestamp)
       WHERE id = ${watcherRunId}
         AND watcher_id = ${watcherId}
-        AND run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
+        -- Same lane scoping as the lookup above: a LIVE completer must not be
+        -- able to claim a pending eval by passing its run id. Its token carries
+        -- no capture claim, so it would run the live path and write a real
+        -- canvas for the window the eval was only supposed to replay. Nothing
+        -- mints manual-open evals today; the guard should not permit it anyway.
+        AND run_type = ${callerRunType}
         AND status = 'pending'
         AND (approved_input->>'agent_id' IS NULL OR approved_input->>'agent_id' = '')
         AND (approved_input->>'device_worker_id' IS NULL OR approved_input->>'device_worker_id' = '')

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -65,6 +65,11 @@ export interface AuthContext {
    * role × scope decide). Non-admin-tier actions are unaffected.
    */
   adminTools?: string[] | null;
+  /**
+   * Signed side-effect mode for this run; 'capture' is an eval replay. Read
+   * by sdk_run to force the SDK's per-method capture path.
+   */
+  executionMode?: 'live' | 'capture' | null;
 }
 
 /**
@@ -131,6 +136,7 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
     // `mcp:admin` callers need no grant — every tool is reachable uniformly
     // and role × scope decide, so the old two-tool external allowlist is gone.
     adminTools: mcpAuthInfo?.adminTools ?? null,
+    executionMode: mcpAuthInfo?.executionMode ?? null,
   };
 }
 
@@ -380,5 +386,6 @@ export function toToolContext(authCtx: AuthContext): ToolContext {
     applyId: authCtx.applyId ?? null,
     mcpSessionId: authCtx.mcpSessionId ?? null,
     mcpConversationId: authCtx.mcpConversationId ?? null,
+    executionMode: authCtx.executionMode ?? null,
   };
 }

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -110,6 +110,17 @@ export interface ToolContext {
   applyId?: string | null;
   /** Persistent MCP session id driving this call; null off the MCP transport. */
   mcpSessionId?: string | null;
+  /**
+   * Server-derived side-effect mode for the run driving these tool calls,
+   * carried as a signed worker-token claim. `capture` marks an eval replay:
+   * `run_sdk` then routes every non-read SDK method through the sandbox's
+   * existing capture path, recording the attempted call and its arguments
+   * instead of dispatching it, and `complete_window` records the extraction on
+   * the run's `dry_run_preview` rather than writing the canvas — that lane does
+   * NOT go through the sandbox, so it honours this flag itself.
+   * Null/absent means live.
+   */
+  executionMode?: 'live' | 'capture' | null;
   /** Whether request was authenticated */
   isAuthenticated: boolean;
   /** OAuth client ID that created this request (null for session/anonymous) */

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -143,6 +143,23 @@ export function resolveSandboxDryRun(args: {
   return captureSideEffects || (args.sdkMode === "full" && args.agentDryRun);
 }
 
+/**
+ * SDK paths a CAPTURE run still dispatches, because the handler behind them
+ * enforces capture itself (see `RunScriptOptions.dryRunDispatchPaths`).
+ *
+ * `behaviors.completeWindow` is the finalize step the dispatch prompt asks for
+ * (watchers/automation.ts). Skipping it would leave every eval replay with no
+ * window — which the finalize-nudge reads as "the agent never called run_sdk",
+ * costing a second full replay before failing the run with a misleading error.
+ * `handleCompleteWindow` reads the same `executionMode` and records the
+ * extraction on `runs.dry_run_preview` instead of writing the canvas.
+ *
+ * Empty for an agent-requested `dry_run` — there, skipping IS the answer.
+ */
+export const CAPTURE_DISPATCH_PATHS: readonly string[] = [
+  "behaviors.completeWindow",
+];
+
 async function runSandbox(
   mode: SDKMode,
   args: RunArgs | QueryArgs,
@@ -161,6 +178,8 @@ async function runSandbox(
       sdkMode: mode,
       agentDryRun: "dry_run" in args ? args.dry_run === true : false,
     }),
+    dryRunDispatchPaths:
+      ctx.executionMode === "capture" ? CAPTURE_DISPATCH_PATHS : undefined,
     context: {
       organization_id: ctx.organizationId,
       user_id: ctx.userId,

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -121,6 +121,28 @@ export const SdkScriptResultSchema = Type.Object({
   dry_run: Type.Boolean(),
 });
 
+/**
+ * Whether the sandbox runs in its skip-and-record path for this call.
+ *
+ * An eval replay captures whether the agent asks to or not: the sandbox
+ * already skips every non-read method under `dryRun` and records it with its
+ * arguments (sandbox/run-script.ts), and capture mode is that same path forced
+ * by the server from the signed `executionMode` token claim.
+ *
+ * Capture is OR'd with the agent's own opt-in and never overridden by it — a
+ * capture run cannot be talked back into executing by passing
+ * `dry_run: false`. Exported so that property is pinned by a test against the
+ * real expression rather than a copy of it.
+ */
+export function resolveSandboxDryRun(args: {
+  executionMode?: "live" | "capture" | null;
+  sdkMode: SDKMode;
+  agentDryRun: boolean;
+}): boolean {
+  const captureSideEffects = args.executionMode === "capture";
+  return captureSideEffects || (args.sdkMode === "full" && args.agentDryRun);
+}
+
 async function runSandbox(
   mode: SDKMode,
   args: RunArgs | QueryArgs,
@@ -134,7 +156,11 @@ async function runSandbox(
     sdkMode: mode,
     allowCrossOrg,
     maxAccessLevel: resolveMaxAccessLevel(ctx.memberRole, ctx.scopes),
-    dryRun: mode === "full" && "dry_run" in args && args.dry_run === true,
+    dryRun: resolveSandboxDryRun({
+      executionMode: ctx.executionMode,
+      sdkMode: mode,
+      agentDryRun: "dry_run" in args ? args.dry_run === true : false,
+    }),
     context: {
       organization_id: ctx.organizationId,
       user_id: ctx.userId,

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -40,6 +40,7 @@ import {
 	markWatcherRunCompleted,
 	resolveWatcherRunsByMessageIds,
 } from "./run-completion";
+import { BEHAVIOR_RUN_TYPES_PG } from "../runs/run-types.js";
 
 type WatcherRunStatus =
 	| "pending"
@@ -1106,13 +1107,14 @@ async function claimWatcherRun(
 		const candidates = await tx`
       SELECT r.id, r.organization_id, r.watcher_id, r.approved_input
       FROM runs r
-      WHERE r.run_type = 'behavior'
+      WHERE r.run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
         AND r.status = 'pending'
+        -- Same-type guard: see claimPendingWatcherRun.
         AND NOT EXISTS (
           SELECT 1
           FROM runs active
           WHERE active.watcher_id = r.watcher_id
-            AND active.run_type = 'behavior'
+            AND active.run_type = r.run_type
             AND active.status IN ('claimed', 'running')
         )
         AND (

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -41,6 +41,7 @@ import {
 	resolveWatcherRunsByMessageIds,
 } from "./run-completion";
 import {
+	BEHAVIOR_RUN_TYPE,
 	BEHAVIOR_RUN_TYPES,
 	BEHAVIOR_RUN_TYPES_PG,
 } from "../runs/run-types.js";
@@ -366,6 +367,7 @@ async function markWatcherRunFailedIdempotent(
 	await sql.begin(async (tx) => {
 		const [failed] = await tx<{
 			watcher_id: string | number | null;
+			run_type: string;
 			dispatch_source: string | null;
 		}>`
       UPDATE runs
@@ -375,14 +377,22 @@ async function markWatcherRunFailedIdempotent(
           error_message = ${message}
       WHERE id = ${runId}
         AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-      RETURNING watcher_id, approved_input->>'dispatch_source' AS dispatch_source
+      RETURNING watcher_id, run_type, approved_input->>'dispatch_source' AS dispatch_source
     `;
 		if (!failed) return;
-		await advanceScheduleAfterTerminalFailure(
-			tx,
-			failed.watcher_id == null ? null : Number(failed.watcher_id),
-			failed.dispatch_source
-		);
+		// Same gate as the twin in run-completion.ts. The dispatch lane claims
+		// both run types, so every failure here — session-create, embedded Lobu
+		// unavailable, preflight, message POST — can be an eval. An eval clones
+		// `dispatch_source` verbatim, so ungated it would advance the live cron
+		// cursor of the Behavior it is only replaying, or park it entirely when
+		// the schedule does not parse.
+		if (failed.run_type === BEHAVIOR_RUN_TYPE) {
+			await advanceScheduleAfterTerminalFailure(
+				tx,
+				failed.watcher_id == null ? null : Number(failed.watcher_id),
+				failed.dispatch_source
+			);
+		}
 	});
 }
 

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -40,7 +40,10 @@ import {
 	markWatcherRunCompleted,
 	resolveWatcherRunsByMessageIds,
 } from "./run-completion";
-import { BEHAVIOR_RUN_TYPES_PG } from "../runs/run-types.js";
+import {
+	BEHAVIOR_RUN_TYPES,
+	BEHAVIOR_RUN_TYPES_PG,
+} from "../runs/run-types.js";
 
 type WatcherRunStatus =
 	| "pending"
@@ -567,7 +570,13 @@ export async function sweepStaleWatcherRuns(
 		coarseStaleInterval
 	);
 	const executingTimedOut = await markStaleRunsAsTimeout(sql, {
-		runTypes: ["behavior"],
+		// Both lanes: this is a pure status UPDATE with no schedule-cursor or
+		// canvas side effect, so terminating a crashed eval cannot touch the
+		// Behavior it replays. Without it a `running` eval never reaches a
+		// terminal state and its same-lane claim guard wedges the eval lane.
+		// `finalizeStalePendingWatcherRuns` above stays behavior-only on
+		// purpose — it advances `next_run_at`, which an eval must never do.
+		runTypes: BEHAVIOR_RUN_TYPES,
 		heartbeatSemantics: "beat-after-claim",
 		heartbeatStaleInterval,
 		coarseStaleInterval,
@@ -694,6 +703,11 @@ async function finalizeStalePendingWatcherRuns(
  * - Claimed scheduled and event deliveries retry after a dispatcher crash
  *   before `running`. Manual triggers are not auto-retried; the caller owns
  *   retry policy.
+ * - Covers BOTH behavior lanes. The claim guards are same-lane
+ *   (`active.run_type = r.run_type`), so a crashed eval claim does not block a
+ *   live run — but it does block every later eval of that Behavior, and
+ *   nothing else would ever clear it. Resetting an orphaned eval claim cannot
+ *   touch a live run for the same reason.
  *
  * Module-private: `runWatcherAutomationTick` is the only driver. The
  * stale-claim threshold lives in config/intervals.ts
@@ -710,7 +724,7 @@ async function resetOrphanedWatcherRuns(
         claimed_at = NULL,
         dispatched_message_id = NULL,
         error_message = NULL
-    WHERE run_type = 'behavior'
+    WHERE run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
       AND status = 'claimed'
       AND claimed_by = 'lobu-dispatcher'
       AND claimed_at < now() - ${intervals.watcherOrphanedClaimThreshold}::interval

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -8,6 +8,7 @@ import {
 	advanceScheduleAfterTerminalFailure,
 	providerQuotaResetNotBefore,
 } from "./schedule-cursor";
+import { BEHAVIOR_RUN_TYPE, BEHAVIOR_RUN_TYPES_PG } from "../runs/run-types.js";
 
 type WatcherTerminalResult =
 	| { ok: true }
@@ -179,6 +180,7 @@ async function markWatcherRunFailed(
 	return sql.begin(async (tx) => {
 		const [failed] = await tx<{
 			watcher_id: string | number | null;
+			run_type: string;
 			dispatch_source: string | null;
 		}>`
       UPDATE runs
@@ -188,15 +190,21 @@ async function markWatcherRunFailed(
           error_message = ${message}
       WHERE id = ${runId}
         AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-      RETURNING watcher_id, approved_input->>'dispatch_source' AS dispatch_source
+      RETURNING watcher_id, run_type, approved_input->>'dispatch_source' AS dispatch_source
     `;
 		if (!failed) return false;
-		await advanceScheduleAfterTerminalFailure(
-			tx,
-			failed.watcher_id == null ? null : Number(failed.watcher_id),
-			failed.dispatch_source,
-			notBefore
-		);
+		// Only a REAL Behavior failure moves the schedule. An eval replay copies
+		// the source run's dispatch_source verbatim, so without this gate a
+		// failing eval (a quota 429, a scoring rerun) would advance — or park for
+		// a day — the live Behavior's cron cursor it is merely replaying.
+		if (failed.run_type === BEHAVIOR_RUN_TYPE) {
+			await advanceScheduleAfterTerminalFailure(
+				tx,
+				failed.watcher_id == null ? null : Number(failed.watcher_id),
+				failed.dispatch_source,
+				notBefore
+			);
+		}
 		return true;
 	});
 }
@@ -244,7 +252,7 @@ export async function resolveWatcherRunsByMessageIds(
     SELECT r.id, r.approved_input, w.execution_config
     FROM runs r
     LEFT JOIN watchers w ON w.id = r.watcher_id
-    WHERE r.run_type = 'behavior'
+    WHERE r.run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
       AND r.dispatched_message_id = ANY(${pgTextArray(ids)}::text[])
       AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
   `;

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -8,7 +8,11 @@ import {
 	advanceScheduleAfterTerminalFailure,
 	providerQuotaResetNotBefore,
 } from "./schedule-cursor";
-import { BEHAVIOR_RUN_TYPE, BEHAVIOR_RUN_TYPES_PG } from "../runs/run-types.js";
+import {
+	BEHAVIOR_EVAL_RUN_TYPE,
+	BEHAVIOR_RUN_TYPE,
+	BEHAVIOR_RUN_TYPES_PG,
+} from "../runs/run-types.js";
 
 type WatcherTerminalResult =
 	| { ok: true }
@@ -249,7 +253,7 @@ export async function resolveWatcherRunsByMessageIds(
 
 	const sql = db ?? getDb();
 	const rows = await sql`
-    SELECT r.id, r.approved_input, w.execution_config
+    SELECT r.id, r.run_type, r.approved_input, w.execution_config
     FROM runs r
     LEFT JOIN watchers w ON w.id = r.watcher_id
     WHERE r.run_type = ANY(${BEHAVIOR_RUN_TYPES_PG}::text[])
@@ -261,6 +265,7 @@ export async function resolveWatcherRunsByMessageIds(
 	for (const row of rows) {
 		const typedRow = row as {
 			id: unknown;
+			run_type: string;
 			approved_input: Record<string, unknown> | null;
 			execution_config: Record<string, unknown> | null;
 		};
@@ -294,6 +299,15 @@ export async function resolveWatcherRunsByMessageIds(
 
 		const windowId = await findWindowIdForRun(sql, runId);
 		if (windowId === null) {
+			// An eval replay can NEVER produce a window — capture mode is what
+			// stops it writing one. "No window" is its success shape, not a
+			// finalize miss, so nudging it would buy a second full replay and
+			// then fail the run with a message about a call the agent did make.
+			if (typedRow.run_type === BEHAVIOR_EVAL_RUN_TYPE) {
+				await markWatcherRunCompleted(sql, runId, null, "lobu-agent");
+				resolved++;
+				continue;
+			}
 			// The agent replied but never called complete_window — a soft, usually
 			// non-deterministic miss. Re-dispatch for one more turn (bounded by
 			// finalize_nudge_count) before giving up. The budget is per-watcher

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -359,6 +359,9 @@ export class MultiTenantProvider implements WorkspaceProvider {
           // through so the execute gate lets an admin-tools turn call its
           // allowlisted internal tools.
           adminTools: tokenData.adminTools ?? null,
+          // Signed side-effect mode: 'capture' turns every non-read SDK call
+          // into a recorded no-op (see tools/sdk_run.ts).
+          executionMode: tokenData.executionMode ?? null,
         },
         mcpIsAuthenticated: true,
         organizationId: requestedOrgId,

--- a/scripts/queue-eval-run.ts
+++ b/scripts/queue-eval-run.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+
+/**
+ * Queue an eval replay of a real Behavior run.
+ *
+ *   bun scripts/queue-eval-run.ts --run 873146
+ *   bun scripts/queue-eval-run.ts --run 873146 --key attempt-2
+ *
+ * The replay reuses the source run's frozen dispatch payload and is dispatched
+ * by the normal Behavior dispatcher. Because its `run_type` is `behavior_eval`,
+ * the server derives `executionMode = 'capture'` for the session, so the agent
+ * runs for real but its side effects are recorded rather than performed.
+ *
+ * A script rather than an agent-facing tool on purpose: PR 3 adds the promote
+ * flow and its surface, which needs its own design sign-off. This exists so the
+ * capture path is exercisable end to end today.
+ *
+ * DATABASE_URL must point at the target database.
+ */
+
+import { parseArgs as parseNodeArgs } from "node:util";
+import { getDb } from "../packages/server/src/db/client";
+import { createEvalRun } from "../packages/server/src/runs/eval-runs";
+
+const { values: args } = parseNodeArgs({
+  options: {
+    run: { type: "string" },
+    key: { type: "string", default: "default" },
+  },
+});
+
+const sourceRunId = Number(args.run);
+if (!Number.isSafeInteger(sourceRunId) || sourceRunId < 1) {
+  console.error("--run <behavior run id> is required");
+  process.exit(1);
+}
+
+const sql = getDb();
+const result = await createEvalRun(
+  { sourceRunId, caseKey: String(args.key) },
+  sql
+);
+
+if (!result) {
+  console.error(
+    `No eval run queued for source run ${sourceRunId} — see the log line above for why.`
+  );
+  process.exit(1);
+}
+
+console.log(
+  result.created
+    ? `Queued eval run ${result.runId} replaying behavior run ${result.sourceRunId} (behavior ${result.behaviorId}).`
+    : `Eval run ${result.runId} for behavior run ${result.sourceRunId} is already in flight.`
+);
+process.exit(0);


### PR DESCRIPTION
## Summary

Evals PR 2 of #2564 — a Behavior run can be replayed for scoring without touching the outside world.

- Adds `run_type = 'behavior_eval'`: a replay of a real Behavior run that reuses its frozen `approved_input` (same window bounds, same version, same trigger) so the agent is asked the same question it was asked the first time.
- Adds `executionMode: 'live' | 'capture'`, derived **server-side from the run row** and carried as a **signed worker-token claim**. In capture mode the agent runs for real but its side effects are recorded instead of performed.
- Queue one today: `bun scripts/queue-eval-run.ts --run <behaviorRunId>`.

## Why the mode rides a token claim

A Behavior agent's own tool calls carry **no run identity** — `actingRunId`/`actingWatcherId` are set at exactly one site (the reaction executor), so they are null for everything the agent itself does, and `toToolContext` has nothing to branch on. The options were: re-derive the run from the `conversationId` string on every mutating call (a DB read per call, keyed on a parsed string), or carry the decision.

`verifyBehaviorRunIntent` already `SELECT`s the run row to decide whether the agent session may exist at all, and its WHERE hardcoded `run_type = 'behavior'` — so it was independently the first line that had to change. Deriving the mode there means one function reads the run type, under the authorization that was already happening, and everything downstream inherits it:

| hop | file |
| --- | --- |
| derive from the run row | `gateway/permissions/behavior-run-intent.ts` |
| carry (signed, unforgeable) | `WorkerTokenData.executionMode` via `worker-token-claims.ts` |
| enforce — SDK lane | `tools/sdk_run.ts` → the sandbox's existing capture path |
| enforce — internal routes | `routes/internal/capture-mode.ts` via `getVerifiedWorker` |

## Reusing the capture machinery that already existed

The sandbox **already** skips and records every SDK method whose `METHOD_METADATA` access is not `read` — 131 methods classified (47 read / 25 write / 48 admin / 10 external), fail-closed because an unclassified method resolves to `access: 'unknown'`, which is not `read` (`sandbox/run-script.ts:742-761`). What was missing was activation: `sdk_run` read `args.dry_run`, i.e. the **agent** opted in. Capture mode is the **server** forcing that same path, OR'd and never overridden — a capture run cannot be talked back into executing by passing `dry_run: false`.

The genuinely unguarded lane was the internal routes the agent framework calls **directly**, bypassing the SDK. Those are now guarded: `conversations/send` (real Slack/Telegram posts), `interactions/create`, `suggestions/create`, `runtime/exec`, `images/generate`, `audio/synthesize`, `files/upload(-batch)`. They answer success-shaped so the replay does not end up measuring its own retry logic — `runtime/exec` specifically returns `exitCode: 0`, because the worker reports a missing `exitCode` as exit 1 and every captured command would otherwise look like a silent failure.

`complete_window` is the third lane, and the one with teeth. It does not go through the sandbox, and an eval replays the **same window** as its source run — so the canvas chain root (watcher + granularity + window_start) is byte-identical, and a `replace_existing: true` completion from an eval would supersede the **real** Behavior's canvas head and unlink its content. The handler now returns at the read/write seam: validation and reads happen exactly as they would live, and everything past that point — canvas write, entity promotion, output events, classifications, schedule cursor, reaction script — is skipped. The extraction is recorded on `runs.dry_run_preview`, the column that already means "what would have been written", so PR 3 scores it with no schema change.

## Exclusion comes for free

~18 existing `run_type = 'behavior'` predicates across the scheduler, reapers, coalescing and behavior-health exclude evals with **no code change** — including both partial unique indexes, which are themselves scoped `WHERE run_type = 'behavior'`. Only the execution path opts back in via `BEHAVIOR_RUN_TYPES` (claim, session, window completion, run completion). The two concurrency guards are deliberately narrowed to `active.run_type = r.run_type` rather than widened, so an eval never blocks — or is blocked by — the real run it is replaying.

## Two bugs the tests caught in this branch's own code

Both were introduced here and would have shipped on a green typecheck:

1. **`run_type = ANY(${BEHAVIOR_RUN_TYPES})` threw at runtime, on all 10 sites.** The pool runs `fetch_types: false`, so a raw JS array binds as the bare string `behavior,behavior_eval` and Postgres answers `malformed array literal`. That is every widened execution-path query, including `complete_window` — it typechecked and always threw. Fixed by exporting one pre-formatted `BEHAVIOR_RUN_TYPES_PG` literal so no call site can spell it wrong.
2. **The test harness silently reverts the migration.** `cleanupTestDatabase()` calls `fixSchemaConstraints()`, which re-adds `runs_run_type_check` from a hardcoded list — so the migration applies at setup and the first cleanup narrows it away again. `behavior_eval` added there, with a comment saying why a missing lane fails long after the migration looked fine.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming + gateway-llm)
- [x] `make test-unit` exit 0
- [x] 30 unit tests (`run-types.test.ts`, `eval-capture-mode.test.ts`) + 10 integration tests against real Postgres (`eval-run-capture.test.ts`, `eval-complete-window-capture.test.ts`)
- [x] Mutation-tested — six mutations, each red on exactly the right assertions:

```
MUTATION 1  capture no longer forces dryRun          → 3 fail (12 pass)
MUTATION 2  any truthy value mints a capture claim   → 6 fail (9 pass)
MUTATION 3  eval run minted as a live behavior run   → 4 fail (3 pass)
            incl. "the pending-per-behavior unique index does not count evals"
            — proving the free-exclusion property is load-bearing, not incidental
MUTATION 4  complete_window capture guard disabled   → 1 fail: "expected 5 to be 4"
            the eval SUPERSEDED the real canvas head (event 4 → event 5).
            That is the exact corruption the guard exists to prevent, observed.
MUTATION 5  CAPTURE_DISPATCH_PATHS emptied            → 2 fail, incl. the one
            asserting completeWindow dispatches rather than being skipped.
MUTATION 6  run-id lookup lane scoping reverted       → 1 fail: "expected null
            not to be null" — the live run gets no window because the lookup
            adopted the in-flight eval.
```

Restored after each via `cp` from a backup.

Two further mutations cover the reaper widening added after review:

```
MUTATION 7  resetOrphanedWatcherRuns scoped back to 'behavior'
            → "expected +0 to be 1" — the stranded eval is never released,
              while the live-lane sibling test stays green.
MUTATION 8  sweepStaleWatcherRuns runTypes back to ["behavior"]
            → "expected 0 to be greater than or equal to 1" — a crashed
              eval never reaches a terminal state.
```

Full green re-confirmed: 61/61 integration across the automation and eval
suites, plus 30 unit.

**Run these the CI way.** `bunx vitest` does NOT honor
`vitest.config.ts`'s `singleFork: true` — it runs the files concurrently
against one database, so each file's `cleanupTestDatabase()` truncates the
other's fixtures and you get spurious `Access denied` / `deadlock detected`
failures. CI uses one process per shard plus a dedicated Postgres per shard.
Reproduce with `node node_modules/.bin/vitest run` from `packages/server`.

Mutation 6's test was a **no-op on its first version** — it asserted only that the eval was untouched, which the narrowed completion write already guarantees, so it passed with the fix reverted. Rewritten to assert the LIVE run receives the window, which is the difference the scoping actually makes.

## Known limits, stated rather than discovered later

Evals are invisible to the *scheduler* by the same design that excludes them
from competing with real Behaviors. Liveness reaping is a different question,
and the review pass caught that the original split got it wrong.

A reaper is now included iff it only touches the row it reaps:

- **Included** — `resetOrphanedWatcherRuns` (claimed → pending) and
  `markStaleRunsAsTimeout` (running → timeout). Neither advances a schedule nor
  writes a canvas. Excluding evals here did not protect the Behavior; it
  stranded the eval forever, and since the claim guards are same-lane, one
  wedged row blocked **every later eval of that Behavior**.
- **Excluded** — `finalizeStalePendingWatcherRuns`, which advances
  `next_run_at`. An eval must never move the live schedule.

So reaping is not a uniformly widenable class, and `BEHAVIOR_RUN_TYPES` now
documents which side each reaper falls on.

Genuinely still open, and PR 3 must not assume they are handled:

- `worker-api/poll.ts` claims only `'behavior'`, so an eval of a
  **device-pinned** Behavior sits pending forever. PR 3 either scopes cases to
  server-run Behaviors or extends the poll lane.
- `pending-tool-store.ts` excludes evals, so an eval whose tool call needs
  approval will not resolve.

Neither can damage a live Behavior — they only mean an eval can strand.

## Notes

- **An absent claim means live, deliberately.** Making "absent" mean capture would silence every real Behavior still running on a token minted before the deploy, for the length of a rollout. Audited the chain for a silent-drop risk: the session is persisted as an opaque `JSON.stringify` blob (`state-adapter.ts:203`), so a new field cannot be dropped by a column whitelist. The claim is kept honest at its source instead — an eval cannot get a session without `verifyBehaviorRunIntent` deriving its mode from `runs.run_type`.
- No agent-facing tool surface is added here. Minting an eval run is a script plus one reusable function (`runs/eval-runs.ts`); PR 3's promote flow adds the proper surface with its own sign-off.
- Migration is EXPAND-only (widen a CHECK, `NOT VALID` + `VALIDATE`), same shape as `20260720140000`.

## One capture body is cosmetically wrong (traced, safe, deliberately not fixed)

`plugin-media/generation.ts` reads its response as `arrayBuffer()`, not JSON. A
captured `images.generate` / `audio.synthesize` therefore hands it the JSON
capture body as bytes, with `Content-Type: application/json` and no provider
header — so the plugin uploads those bytes (that upload is itself captured, so
nothing is delivered) and tells the agent *"Image sent successfully (generated
with unknown)"*.

Nothing escapes: no media is generated and no file is delivered, both because
the routes are guarded. The cost is transcript noise — during an eval the agent
believes it sent an image. Left as-is rather than synthesizing placeholder
binary and provider headers per media type, which is more machinery than the
inaccuracy is worth. PR 3 reads the capture log for the real attempt; if the
transcript wording turns out to matter for scoring, fix it then.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Behavior evaluation runs that replay completed runs using frozen inputs.
  - Added capture mode to safely preview SDK actions without performing live side effects.
  - Captured activity can include messages, files, images, audio, runtime commands, and interactions.
  - Added a command-line option for queueing evaluation replays.
- **Bug Fixes**
  - Evaluation runs are isolated from live scheduling, state updates, and downstream writes.
  - Improved replay protection, idempotency, and recovery for interrupted evaluation runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->