### PR TITLE
fix(cli): stop lobu apply from erasing out-of-band metadata_schema keys

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -299,17 +299,29 @@ describe("executePlan — entity-type schema fidelity", () => {
         ],
       },
     };
+    const ownedRemote = {
+      slug: "person",
+      organization_id: "org_acme",
+      properties: { email: { type: "string" } },
+      required: ["email"],
+      schemaExtras,
+    };
+    // computeDiff matches against the ORG-OWNED types only, and stores that
+    // match on the row. The raw snapshot also carries public types from OTHER
+    // orgs, returned AFTER the org's own rows — so a slug→row map rebuilt here
+    // would pick this decoy up and push another org's resolution rules (or, if
+    // it had none, erase the owned ones). Assert the row's match wins.
+    const foreignPublic = {
+      slug: "person",
+      organization_id: "org_public_catalog",
+      schemaExtras: { "x-lobu-resolution": { rules: [] } },
+    };
+    const rowZero = plan.rows[0];
+    if (rowZero?.kind === "entity-type") rowZero.remote = ownedRemote;
     const remote: RemoteSnapshot = {
       agents: [],
       agentSettings: new Map(),
-      entityTypes: [
-        {
-          slug: "person",
-          properties: { email: { type: "string" } },
-          required: ["email"],
-          schemaExtras,
-        },
-      ],
+      entityTypes: [ownedRemote, foreignPublic],
       relationshipTypes: [],
       watchers: [],
       connectorDefinitions: [],

--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -262,6 +262,72 @@ describe("executePlan — BYO chat connection dependencies", () => {
   });
 });
 
+describe("executePlan — entity-type schema fidelity", () => {
+  test("carries the live type's out-of-band metadata_schema keys into the upsert", async () => {
+    const desired = {
+      slug: "person",
+      name: "Person",
+      properties: {
+        email: { type: "string" },
+        handle: { type: "string" },
+      },
+      required: ["email"],
+    };
+    const state = stateWith({
+      definitions: [],
+      authProfiles: [],
+      connections: [],
+    });
+    state.memorySchema.entityTypes = [desired];
+    const plan: DiffPlan = {
+      rows: [
+        {
+          kind: "entity-type",
+          verb: "update",
+          id: desired.slug,
+          desired,
+          changedFields: ["properties"],
+        },
+      ],
+      counts: { create: 0, update: 1, noop: 0, drift: 0, delete: 0 },
+      notes: [],
+    };
+    const schemaExtras = {
+      "x-lobu-resolution": {
+        rules: [
+          { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+        ],
+      },
+    };
+    const remote: RemoteSnapshot = {
+      agents: [],
+      agentSettings: new Map(),
+      entityTypes: [
+        {
+          slug: "person",
+          properties: { email: { type: "string" } },
+          required: ["email"],
+          schemaExtras,
+        },
+      ],
+      relationshipTypes: [],
+      watchers: [],
+      connectorDefinitions: [],
+      authProfiles: [],
+      connections: [],
+      feedsByConnectionId: new Map(),
+      inferenceProviders: [],
+    };
+    const upsertEntityType = mock(async () => ({ updated: true }));
+    const client = { upsertEntityType } as unknown as ApplyClient;
+
+    await executePlan({ client, state, plan, remote }, []);
+
+    expect(upsertEntityType).toHaveBeenCalledTimes(1);
+    expect(upsertEntityType.mock.calls[0]?.[1]).toEqual(schemaExtras);
+  });
+});
+
 describe("executePlan — atomic Behavior triggers+prompt update", () => {
   test("sends simultaneous prompt+trigger drift through createBehaviorVersion only", async () => {
     const desired = {

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -393,6 +393,112 @@ describe("ApplyClient — prune", () => {
     expect(byKey.empty?.eventKinds).toBeUndefined();
   });
 
+  test("metadata_schema keys the config cannot express survive an apply round-trip", async () => {
+    // `x-lobu-resolution` is authored out-of-band (manage_entity_schema / UI /
+    // an agent) and read by the server's entity-resolution policy to decide
+    // whether duplicate entities auto-merge. `lobu.config.ts` has no way to
+    // declare it, and upsertEntityType rebuilds metadata_schema from the flat
+    // properties/required — so it must be carried forward or the next apply
+    // erases the dedupe rules with no diff row and no warning.
+    const resolution = {
+      rules: [
+        {
+          fields: ["email"],
+          normalizer: "email",
+          onMatch: "auto_merge",
+        },
+      ],
+    };
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        const body = JSON.parse(String(init?.body)) as { action?: string };
+        if (body.action === "list") {
+          return new Response(
+            JSON.stringify({
+              entity_types: [
+                {
+                  slug: "person",
+                  metadata_schema: {
+                    type: "object",
+                    properties: { email: { type: "string" } },
+                    required: ["email"],
+                    "x-lobu-resolution": resolution,
+                  },
+                },
+                { slug: "company", metadata_schema: { type: "object" } },
+              ],
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }) as typeof fetch
+    );
+
+    const [person, company] = await client.listEntityTypes();
+    expect(person?.schemaExtras).toEqual({ "x-lobu-resolution": resolution });
+    // A type with nothing but config-owned keys stays undefined (no churn).
+    expect(company?.schemaExtras).toBeUndefined();
+
+    // Re-apply a config that adds a field: properties come from config, the
+    // out-of-band key rides along.
+    await client.upsertEntityType(
+      {
+        slug: "person",
+        properties: {
+          email: { type: "string" },
+          handle: { type: "string" },
+        },
+        required: ["email"],
+      },
+      person?.schemaExtras
+    );
+
+    const posted = JSON.parse(String(calls[1]?.init?.body));
+    expect(posted.metadata_schema).toEqual({
+      type: "object",
+      properties: {
+        email: { type: "string" },
+        handle: { type: "string" },
+      },
+      required: ["email"],
+      "x-lobu-resolution": resolution,
+    });
+  });
+
+  test("config-owned metadata_schema keys win over stale carried-forward ones", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }) as typeof fetch
+    );
+
+    await client.upsertEntityType(
+      { slug: "person", properties: { email: { type: "string" } } },
+      // A malformed extras bag must never shadow the config's own fields —
+      // including `required`, which the config omits here (an empty required
+      // is expressed by NOT sending the key, so a stale one must not ride in).
+      {
+        properties: { stale: { type: "string" } },
+        required: ["stale"],
+        "x-lobu-note": "keep",
+      }
+    );
+
+    const posted = JSON.parse(String(calls[0]?.init?.body));
+    expect(posted.metadata_schema).toEqual({
+      type: "object",
+      properties: { email: { type: "string" } },
+      "x-lobu-note": "keep",
+    });
+  });
+
   test("view template get/set/clear POST manage_view_templates with the right action", async () => {
     const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
     const client = new ApplyClient(

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -797,10 +797,20 @@ export async function executePlan(
   }
 
   // 4) Entity types
+  // The upsert rebuilds `metadata_schema` from the config's flat properties/
+  // required, so hand it the live type's out-of-band top-level keys (e.g.
+  // `x-lobu-resolution`) to carry forward — otherwise every apply erases them
+  // silently, with no diff row and no warning.
+  const remoteEntityTypeBySlug = new Map(
+    ctx.remote.entityTypes.map((t) => [t.slug, t])
+  );
   for (const row of rowsByKind("entity-type")) {
     if (row.kind !== "entity-type") continue;
     if (!row.desired) continue;
-    await ctx.client.upsertEntityType(row.desired);
+    await ctx.client.upsertEntityType(
+      row.desired,
+      remoteEntityTypeBySlug.get(row.desired.slug)?.schemaExtras
+    );
     // View template is a separate, version-appending tool. Reconcile it only on
     // create (when declared) or a flagged change — never every run, so the
     // version history doesn't churn. Declared ⇒ set; omitted-under-prune ⇒ clear.

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -797,20 +797,17 @@ export async function executePlan(
   }
 
   // 4) Entity types
-  // The upsert rebuilds `metadata_schema` from the config's flat properties/
-  // required, so hand it the live type's out-of-band top-level keys (e.g.
-  // `x-lobu-resolution`) to carry forward — otherwise every apply erases them
-  // silently, with no diff row and no warning.
-  const remoteEntityTypeBySlug = new Map(
-    ctx.remote.entityTypes.map((t) => [t.slug, t])
-  );
   for (const row of rowsByKind("entity-type")) {
     if (row.kind !== "entity-type") continue;
     if (!row.desired) continue;
-    await ctx.client.upsertEntityType(
-      row.desired,
-      remoteEntityTypeBySlug.get(row.desired.slug)?.schemaExtras
-    );
+    // The upsert rebuilds `metadata_schema` from the config's flat properties/
+    // required, so hand it the live type's out-of-band top-level keys (e.g.
+    // `x-lobu-resolution`) to carry forward — otherwise every apply erases them
+    // silently, with no diff row and no warning. `row.remote` is the match
+    // computeDiff already made against the ORG-OWNED types only; re-deriving it
+    // from the raw snapshot would let a foreign public type of the same slug
+    // shadow the owned one (see the ownership filter in computeDiff).
+    await ctx.client.upsertEntityType(row.desired, row.remote?.schemaExtras);
     // View template is a separate, version-appending tool. Reconcile it only on
     // create (when declared) or a flagged change — never every run, so the
     // version history doesn't churn. Declared ⇒ set; omitted-under-prune ⇒ clear.

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -75,6 +75,19 @@ export interface RemoteEntityType {
   /** Declared metrics (mirrors {@link DesiredEntityType.metrics}); hoisted from the row's `metrics_config`. */
   metrics?: EntityMetrics;
   /**
+   * Top-level `metadata_schema` keys the config has NO way to express — today
+   * `x-lobu-resolution` (the entity-resolution rules the server reads to decide
+   * whether duplicate entities auto-merge), authored via `manage_entity_schema`
+   * / the UI / an agent rather than `lobu.config.ts`.
+   *
+   * `upsertEntityType` REBUILDS `metadata_schema` from the config's flat
+   * `properties`/`required` and the server stores what it is sent verbatim, so
+   * without carrying these forward every apply would silently erase them. Set
+   * only when the stored schema has at least one such key, so a plain type
+   * stays `undefined`.
+   */
+  schemaExtras?: Record<string, unknown>;
+  /**
    * Owning org id. The list endpoint also returns *public* types from OTHER
    * orgs (`o.visibility = 'public'`), so prune must compare this against the
    * target org and never delete a type this org doesn't own.
@@ -238,11 +251,27 @@ function pickArray<T>(body: Record<string, unknown>, ...keys: string[]): T[] {
 }
 
 /**
+ * The top-level `metadata_schema` keys `lobu.config.ts` owns. Anything else on
+ * the stored schema is authored out-of-band and must survive an apply — see
+ * {@link RemoteEntityType.schemaExtras}.
+ */
+const CONFIG_OWNED_SCHEMA_KEYS: ReadonlySet<string> = new Set([
+  "type",
+  "properties",
+  "required",
+]);
+
+/**
  * The server stores entity-type per-field config as a single `metadata_schema`
  * JSON Schema. The diff compares the desired config's flat `properties`/
  * `required` against the remote snapshot, so hoist them out of the returned
  * `metadata_schema` to the row's top level. Mirrors `upsertEntityType`, which
  * folds the flat fields back into `metadata_schema` when writing.
+ *
+ * Every OTHER top-level key is collected into `schemaExtras` and handed back to
+ * `upsertEntityType` so the rebuild preserves it. Narrowing the read without
+ * that carry-forward is what made `lobu apply` silently drop out-of-band schema
+ * keys such as `x-lobu-resolution`.
  */
 function hoistEntityTypeSchema(
   row: RemoteEntityType & {
@@ -270,6 +299,12 @@ function hoistEntityTypeSchema(
         (v): v is string => typeof v === "string"
       );
     }
+    const extras: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(schema)) {
+      if (CONFIG_OWNED_SCHEMA_KEYS.has(key)) continue;
+      extras[key] = value;
+    }
+    if (Object.keys(extras).length > 0) out.schemaExtras = extras;
   }
   // A type is derived iff it has view SQL; stored types carry no backing, so it
   // compares equal to the desired side without churn. `backing_source` (a
@@ -637,7 +672,16 @@ export class ApplyClient {
   async upsertEntityType(
     // `metadata` is authoring-only — never sent to the server (see
     // DesiredEntityType); extra properties on the passed value are ignored.
-    entity: Omit<DesiredEntityType, "metadata">
+    entity: Omit<DesiredEntityType, "metadata">,
+    /**
+     * The live type's out-of-band `metadata_schema` keys
+     * ({@link RemoteEntityType.schemaExtras}), from the remote snapshot this
+     * apply already fetched. Config-owned keys (`type`/`properties`/`required`)
+     * are stripped from this bag before merging, so config always wins on them
+     * while keys it cannot express (e.g. `x-lobu-resolution`) survive the
+     * rebuild.
+     */
+    schemaExtras?: Record<string, unknown>
   ): Promise<UpsertEntityTypeResult> {
     // The server stores per-type fields as a single `metadata_schema` JSON
     // Schema (`{ type, properties, required }`) — it does NOT read top-level
@@ -658,7 +702,18 @@ export class ApplyClient {
     if (name !== undefined) payload.name = name;
     if (description !== undefined) payload.description = description;
     if (properties !== undefined || required !== undefined) {
+      // Strip config-owned keys from the extras bag so config always wins —
+      // spread order alone would let a stale `required` survive, because the
+      // config's `required` is only spread when non-empty. (When the config
+      // declares neither properties nor required we send no metadata_schema at
+      // all — the server then leaves the stored one alone, extras included.)
+      const extras: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(schemaExtras ?? {})) {
+        if (CONFIG_OWNED_SCHEMA_KEYS.has(key)) continue;
+        extras[key] = value;
+      }
       payload.metadata_schema = {
+        ...extras,
         type: "object",
         properties: properties ?? {},
         ...(required && required.length > 0 ? { required } : {}),


### PR DESCRIPTION
## Summary
- `lobu apply` REBUILDS an entity type's `metadata_schema` from the config's flat `properties`/`required` (`client.ts`), and reads back only `properties`/`required`. Every other top-level key on the stored schema was silently dropped on the next apply — no diff row, no warning.
- The key that matters today is `x-lobu-resolution`, the entity-resolution rules read by `packages/server/src/entity-resolution/policy.ts` (`readEntityResolutionRules`) to decide whether duplicate entities auto-merge. Configuring dedupe rules for `person` was impossible to make durable: the next apply wiped them.
- The server is not lossy — the contract takes arbitrary keys (`Type.Record(Type.String(), Type.Unknown())`) and stores `metadata_schema` verbatim. The CLI was the only lossy hop.

Fix is general, not an allowlist: the read collects every non-config-owned top-level key into `RemoteEntityType.schemaExtras`, and apply hands the *live* type's extras back to `upsertEntityType`, which merges them under the config-owned keys. `type`/`properties`/`required` stay config-owned (and are stripped from the extras bag, so a stale `required` can't ride in when the config omits it); everything else is carried forward verbatim, including keys that don't exist yet.

**Preserve-always, no opt-out.** Removal is deliberately not expressible: prune deletes things the config *could* have declared and didn't, and by definition it cannot declare these. Out-of-band keys are removed out-of-band (`manage_entity_schema`), the same way they were authored. This mirrors the existing `eventKinds` treatment, minus the prune arm.

No diff churn: `diffEntityType` compares named fields only, so `schemaExtras` never appears on either side of the plan.

### Behavior-version audit (same class, checked, no fix needed)
Asked to check whether Behavior versions have the same lossy-rebuild pattern. They do not — scoped out with evidence rather than expanded:

- `createBehaviorVersion` is **field-granular**, not a rebuild: `apply-cmd.ts` sends only the keys `diffWatcher` flagged as changed, and `version-actions.ts` inherits every omitted field from the previous version row (`prompt`, `skills`, `outputs`, `classifiers`, `reactions_guidance`). A field the config never declares is never sent and never cleared.
- `diffWatcher` guards each version-bound field on `desired.X !== undefined`, so an undeclared `sources` / `classifiers` / `reactions_guidance` / `skills` is skipped entirely.
- `outputs` IS reverted when it drifts from config (`!deepEqual(desired.outputs ?? null, remote.outputs ?? null)`) — but that is declarative-by-design and, critically, **visible**: it lands in `changedFields` and prints in the plan. That is the opposite of the entity-type bug, which was invisible. Same for an X-handle changed in the DB against a stale config. Making those preserve-instead-of-revert would break the declarative contract, so it is a config-hygiene issue, not a data-loss bug.
- Also swept the rest of the apply client for read-narrow + write-replace pairs: `listConnections` strips `platform`/`settings`/`chatMetadata`, but only for `credential_mode === "byo"` rows, and those go through `applyChatConnection`, never the `replace_config: true` path in `updateConnection`. `listFeeds` does not narrow. `seed-cmd.ts` has the same payload shape but only ever `action: "create"` and no-ops on "already exists", so it cannot erase an existing type's extras.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming) — `✅ pre-pr gates clean`
- [x] Tests run: `bun test packages/cli` → 511 pass / 1 skip / 0 fail
- [x] Bug fix: red→fix→green outputs pasted below

### Red — mutation applied (both source files restored to `origin/main`, tests untouched)

```
== mutation landed: origin/main lossy rebuild restored ==
    if (properties !== undefined || required !== undefined) {
      payload.metadata_schema = {
        type: "object",
        properties: properties ?? {},
        ...(required && required.length > 0 ? { required } : {}),
      };
    }
    await ctx.client.upsertEntityType(row.desired);
(fail) executePlan — entity-type schema fidelity > carries the live type's out-of-band metadata_schema keys into the upsert [0.80ms]
(fail) ApplyClient — prune > metadata_schema keys the config cannot express survive an apply round-trip [0.26ms]
(fail) ApplyClient — prune > config-owned metadata_schema keys win over stale carried-forward ones [0.12ms]
 57 pass
 3 fail
Ran 60 tests across 2 files. [290.00ms]
```

Failure detail on the round-trip test (the `x-lobu-resolution` block is gone):

```
    const [person, company] = await client.listEntityTypes();
    expect(person?.schemaExtras).toEqual({ "x-lobu-resolution": resolution });
                                   ^
error: expect(received).toEqual(expected)

- {
-   "x-lobu-resolution": {
-     "rules": [
-       {
-         "fields": [
-           "email",
-         ],
-         "normalizer": "email",
-         "onMatch": "auto_merge",
-       },
-     ],
-   },
- }
+ undefined
```

### Green — fix restored, same tests

```
 60 pass
 0 fail
Ran 60 tests across 2 files. [156.00ms]
```

Full package suite:

```
 511 pass
 1 skip
 0 fail
 9 snapshots, 1335 expect() calls
Ran 512 tests across 36 files. [5.76s]
```

## Notes
- `make review-fix` (`REVIEWER_CLI=claude`; codex is out of credits until Aug 10) caught a real gap in the first cut: spread order alone let a stale `required` survive, because the config's `required` is only spread when non-empty. Config-owned keys are now stripped from the extras bag before merging, and the test covers it. Its diff is in this commit.
- **Not verified live.** This was tested against a mocked `fetch` only — deliberately no apply against the prod `buremba` org, since a stray apply is exactly the damage this fixes. Server-side behavior (`metadata_schema` replaced only when the key is present, `CASE ... ELSE metadata_schema`) was read from `manage_entity_schema.ts`, not exercised end to end.
- `check-drift` is currently red on every open PR (owletto/main has `3da851cf` past the pinned SHA); a separate pointer bump should clear it.

### Follow-up commit (`2ba3fb260`) — review blocker, fixed
The first `make review` round flagged a real defect in the first cut: the wiring rebuilt a `slug → remote row` map from the RAW snapshot, but the entity-type list endpoint also returns **public types from other orgs**, after the org's own rows (`computeDiff` filters to `ownedEntityTypes` for exactly this reason). A foreign public `person` would have shadowed the owned one — pushing another org's `x-lobu-resolution` into this org's schema, or, if the foreign type had none, erasing the owned type's extras. That is the same bug this PR fixes, reintroduced through the back door.

Fixed by reading `row.remote?.schemaExtras` — the ownership-filtered match `computeDiff` already made and stores on the row — and deleting the redundant map. The executePlan test now seeds the raw snapshot with a foreign-public `person` decoy carrying *different* extras and asserts the owned type's extras win.

Mutation-checked: with the snapshot map restored the guard is red (`30 pass / 1 fail`), with `row.remote` it is green (`60 pass / 0 fail` across both files). `make pre-pr` clean and `bun test packages/cli` 511 pass / 1 skip / 0 fail on the settled HEAD.
