### PR TITLE
fix(server): surface the Behavior completion stamp on the behaviors listing

### DIFF
--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -55,6 +55,12 @@ export async function handleList(
       i.agent_id,
       i.device_worker_id,
       i.last_fired_at,
+      -- Materialized completion stamp of the most recent completed run,
+      -- written by a trigger on runs. last_fired_at is NOT a substitute: only
+      -- the worker-api terminal-report path stamps it, so runs that finish
+      -- through any other terminal writer leave it NULL or stale and the
+      -- listing renders "Never run" for a Behavior that ran minutes ago.
+      i.last_run_completed_at,
       i.model_config,
       i.execution_config,
       i.sources,


### PR DESCRIPTION
## Summary

- The Behaviors page rendered the wrong "last run" time on every row. `manage_behaviors` `list` never selected `watchers.last_run_completed_at`, so `behaviors-page.tsx` fell back to `last_fired_at` — a column only the worker-api terminal-report and scheduler-dispatch paths write. Schedule-only Behaviors leave it NULL or weeks stale, so the card said "Never run" for a Behavior that had completed minutes earlier.
- The right value was already reachable: the agent sidebar reads `last_run_completed_at` (`packages/server/src/gateway/services/agent-thread-list.ts:283`), so the same page showed the correct time in the sidebar and the wrong one on the card.
- Fix is strictly additive: select `i.last_run_completed_at`, add it to `BehaviorRecord`, and prefer it in the chip with `last_fired_at` kept as the fallback for rows that completed before the stamp existed. Nothing renamed, nothing removed — `last_fired_at` stays load-bearing for the event-trigger debounce and for `manage_schedules`.

Live prod evidence (org `buremba`, all four wrong):

| Behavior | card showed (`last_fired_at`) | truth (`last_run_completed_at`) |
|---|---|---|
| 5 Hourly Task Collaborator | Ran 19 days ago | 2026-08-07 00:00:19Z |
| 71 Social interest radar | Ran 1 day ago | 2026-08-07 00:25:26Z |
| 70 Voice profile synthesis | Next run in 3 days (NULL) | 2026-08-06 23:46:14Z |
| 20 Duplicate entity resolution | **Never run** (NULL) | 2026-08-07 00:02:23Z |

`ListBehaviorsResultSchema` is `Type.Record(Type.String(), Type.Unknown())`, so no core contract needed widening.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming) — `✅ pre-pr gates clean`
- [x] Tests run: `cd packages/owletto && bunx vitest run src/components/behaviors/behaviors-page.test.tsx src/lib/behaviors/model.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

### RED — mutation applied (chip reverted to `lastRunAt={record.last_fired_at ?? null}`, i.e. `origin/main` behaviour)

Mutation is countable: `grep -n "lastRunAt=" src/components/behaviors/behaviors-page.tsx` returned the single-line `record.last_fired_at ?? null` form during the red run, and the three-line `record.last_run_completed_at ?? record.last_fired_at ?? null` form after restoring.

```
 ✓ |node| src/lib/behaviors/model.test.ts (4 tests) 3ms
   × BehaviorsPage (workspace-level) > reads the last run from the completion stamp, not last_fired_at 9ms
     → Unable to find an element with the text: Ran about 3 hours ago. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL |jsdom|  src/components/behaviors/behaviors-page.test.tsx > BehaviorsPage (workspace-level) > reads the last run from the completion stamp, not last_fired_at
TestingLibraryElementError: Unable to find an element with the text: Ran about 3 hours ago. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
 ❯ src/components/behaviors/behaviors-page.test.tsx:203:17
 Test Files  1 failed | 1 passed (2)
      Tests  1 failed | 8 passed (9)
```

### GREEN — fix restored

```
 ✓ |node| src/lib/behaviors/model.test.ts (4 tests) 4ms
 ✓ |jsdom| src/components/behaviors/behaviors-page.test.tsx (5 tests) 119ms
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

### Booted e2e — not just a typecheck

Dev server on `:9346` against a fresh branch DB seeded with the four prod rows above (same timestamps). Same booted app, code swapped between `origin/main` and this branch:

- `origin/main`: `Ran 19 days ago` / `Ran 1 day ago` / `Next run in 3 days` / `Never run` — reproduces prod exactly.
- this branch: `Ran about 1 hour ago` / `Ran 22 minutes ago` / `Ran about 1 hour ago` / `Ran about 1 hour ago`.

The live `POST /api/<org>/manage_behaviors {"action":"list"}` response carries `last_run_completed_at` on this branch and does not on `origin/main`.

## Notes

- Before/after screenshots: https://claude.ai/code/artifact/0fd6b762-b553-49e3-86b0-c0883a6b699d
- `make review-fix` was run with `REVIEWER_CLI=claude` — the default codex reviewer is out of credits until Aug 10 and exits 1 with no summary.
- `check-drift` is red on every open PR right now (owletto/main has `3da851cf` past the pinned SHA). This PR's owletto pointer includes that commit.
