### PR TITLE
fix(connectors): emit calendar_event from google.calendar

### DIFF
--- a/db/migrations/20260807010000_google_calendar_calendar_event_kind.sql
+++ b/db/migrations/20260807010000_google_calendar_calendar_event_kind.sql
@@ -1,0 +1,94 @@
+-- migrate:up
+
+-- Re-stamp historical Google Calendar events onto the shared `calendar_event`
+-- kind that microsoft_outlook and the apple.calendar device connector already
+-- emit. Paired with the connector change in
+-- packages/connectors/src/google_calendar.ts, which flips both the emitted
+-- `origin_type` and the `feeds_schema.events.eventKinds` key in one commit
+-- (`event_kinds` is a closed allowlist once non-empty, so the two must move
+-- together or the feed stops ingesting).
+--
+-- Why an UPDATE and not a connector resync. The standing preference is to
+-- backfill by re-running the real write path, and google_calendar.ts keys on
+-- the stable `calEvent.id`, so a resync WOULD supersede the rows it returns.
+-- It just cannot return most of them:
+--   * the full-sync path windows the request to [now-30d, now+365d]
+--     (google_calendar.ts `timeMin`/`timeMax`), and on the affected prod org
+--     only 20 of 254 rows fall inside that window — 31 are older than the
+--     lookback and 203 are recurring expansions past +365d, out to 2056;
+--   * the incremental path sends only `syncToken`, so it returns just events
+--     that CHANGED since the last sync — approximately none of the backlog.
+-- A resync therefore provably restamps <8% of the history and would leave the
+-- rest split across two vocabularies. This is also not a re-derived encoding
+-- being mirrored in SQL: the new value is a single constant rename, not a
+-- computation the connector owns.
+--
+-- Both columns move because the ingest path stores the connector envelope's
+-- `origin_type` into `origin_type` AND `semantic_type` (prod shows every
+-- google.calendar row as ('event','event')), so post-fix rows will read
+-- ('calendar_event','calendar_event') and history must match.
+--
+-- `events` is append-only for CONTENT — this is a vocabulary correction on
+-- existing rows, not a delete and not a new version, so it edits in place
+-- rather than superseding. Scoped to one connector_key and idempotent: the
+-- `semantic_type = 'event'` predicate makes a re-run match zero rows.
+UPDATE events
+SET semantic_type = 'calendar_event',
+    origin_type = CASE WHEN origin_type = 'event' THEN 'calendar_event' ELSE origin_type END
+WHERE connector_key = 'google.calendar'
+  AND semantic_type = 'event';
+
+-- Bridge the live ingest allowlist across the rollout. Connector writes are
+-- validated against connector_definitions.feeds_schema[feed].eventKinds (a
+-- per-org DB snapshot), which only converges to the bundled code via the
+-- hourly refresh-connector-definitions cron. Without this, new pods emitting
+-- `calendar_event` are rejected against the stale `event`-only allowlist for
+-- up to an hour — and rejection is silent loss, because the run still
+-- completes and advances the Google syncToken past the dropped items. Adding
+-- the key (rather than renaming it) also keeps old pods emitting `event`
+-- valid mid-rollout; the refresh cron then replaces feeds_schema wholesale
+-- from code, which drops the leftover `event` key. Idempotent: the target-key
+-- IS NULL predicate makes a re-run match zero rows.
+UPDATE connector_definitions
+SET feeds_schema = jsonb_set(
+      feeds_schema,
+      '{events,eventKinds,calendar_event}',
+      feeds_schema #> '{events,eventKinds,event}'
+    )
+WHERE key = 'google.calendar'
+  AND feeds_schema #> '{events,eventKinds,event}' IS NOT NULL
+  AND feeds_schema #> '{events,eventKinds,calendar_event}' IS NULL;
+
+-- migrate:down
+
+UPDATE events
+SET semantic_type = 'event',
+    origin_type = CASE WHEN origin_type = 'calendar_event' THEN 'event' ELSE origin_type END
+WHERE connector_key = 'google.calendar'
+  AND semantic_type = 'calendar_event';
+
+-- Mirror of the up-direction allowlist bridge, and a true inverse of it. Two
+-- states have to be undone because the hourly refresh cron may or may not have
+-- run since the up:
+--   * cron already converged feeds_schema to calendar_event-only — `event` has
+--     to be restored, or rolled-back code emitting it is rejected;
+--   * cron has not run yet, so both keys are present — the `calendar_event` the
+--     up-direction added has to come back out, otherwise `down` leaves state the
+--     migration invented behind.
+-- The CASE restores `event` only when it is genuinely missing; the trailing `#-`
+-- always drops `calendar_event`. Idempotent: the guard means a re-run matches
+-- zero rows.
+UPDATE connector_definitions
+SET feeds_schema = (
+      CASE
+        WHEN feeds_schema #> '{events,eventKinds,event}' IS NULL
+          THEN jsonb_set(
+                 feeds_schema,
+                 '{events,eventKinds,event}',
+                 feeds_schema #> '{events,eventKinds,calendar_event}'
+               )
+        ELSE feeds_schema
+      END
+    ) #- '{events,eventKinds,calendar_event}'
+WHERE key = 'google.calendar'
+  AND feeds_schema #> '{events,eventKinds,calendar_event}' IS NOT NULL;

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -22,7 +22,7 @@ import type SocialInterestRadarReaction from "./social-interest-radar.reaction.t
 const hourlyTaskCollaboratorSkill = defineSkill({
   name: "hourly-task-collaborator",
   content:
-    "Review the current hourly window's content and the collaborative task list in the payload's task_list source. The task_list source includes recently closed tasks (metadata status done or dismissed) for reference so you know what is already finished. Return a JSON object with a tasks array matching the provided task schema. Extract only concrete actions Burak or his personal agent should take; ignore advertisements, newsletters, automated notices, passive information, and vague ideas. For every task, copy source_scope, source_origin_id, and source_event_id exactly from its recent_signals row. Set task_key to a short stable machine key for that distinct action within the source (for example send-deck or book-flight); keep the same task_key when only the wording or status changes. Preserve existing tasks instead of restating them. Never re-emit, reopen, or recreate any task whose status is done or dismissed in the task list, even if the originating message still appears in recent signals. Set status to backlog unless there is clear evidence work has started. Assign owner \"Burak\" unless the action can be safely completed by the personal agent. Use ISO-8601 due_date only when a real deadline is present. Include source and a short rationale. Produce at most 12 tasks, ordered by priority.",
+    "Review the current hourly window's content and the collaborative task list in the payload's task_list source. The task_list source includes recently closed tasks (metadata status done or dismissed) for reference so you know what is already finished. Return a JSON object with a tasks array matching the provided task schema. Extract only concrete actions Burak or his personal agent should take; ignore advertisements, newsletters, automated notices, passive information, and vague ideas. For every task, copy source_scope, source_origin_id, and source_event_id exactly from the recent_signals or upcoming_calendar row it came from. The upcoming_calendar source lists confirmed meetings, flights, and events in the next 30 days, ordered soonest first; draw preparation tasks from it only when a concrete action is genuinely needed, and never emit a task that merely restates that an event is scheduled. Set task_key to a short stable machine key for that distinct action within the source (for example send-deck or book-flight); keep the same task_key when only the wording or status changes. Preserve existing tasks instead of restating them. Never re-emit, reopen, or recreate any task whose status is done or dismissed in the task list, even if the originating message still appears in recent signals. Set status to backlog unless there is clear evidence work has started. Assign owner \"Burak\" unless the action can be safely completed by the personal agent. Use ISO-8601 due_date only when a real deadline is present. Include source and a short rationale. Produce at most 12 tasks, ordered by priority.",
 });
 
 const duplicateEntityResolutionRealV3FinalSkill = defineSkill({
@@ -1110,8 +1110,32 @@ const hourlyTaskCollaborator = defineBehavior({
     },
   },
   sources: {
+    // Past-facing conversational signal. `calendar_event` is deliberately NOT in
+    // this filter and `occurred_at <= now()` is deliberately present: calendar
+    // rows are dated when the meeting HAPPENS, so future-dated ones sort ahead of
+    // every message under `occurred_at DESC` and evict the entire window. On prod
+    // 213 of 254 Google Calendar rows are future-dated (mostly two recurring
+    // series expanded out to 2056) — more than the LIMIT 200 window holds.
     recent_signals:
-      "SELECT id, id AS source_event_id, COALESCE('connection:' || connection_id::text, 'connector:' || connector_key, 'event') AS source_scope, COALESCE(origin_id, 'event:' || id::text) AS source_origin_id, occurred_at, title, payload_text, semantic_type, connector_key, metadata FROM events WHERE semantic_type IN ('message','thread','reminder','calendar_event','note') ORDER BY occurred_at DESC LIMIT 200",
+      "SELECT id, id AS source_event_id, COALESCE('connection:' || connection_id::text, 'connector:' || connector_key, 'event') AS source_scope, COALESCE(origin_id, 'event:' || id::text) AS source_origin_id, occurred_at, title, payload_text, semantic_type, connector_key, metadata FROM events WHERE semantic_type IN ('message','thread','reminder','note') AND occurred_at <= now() ORDER BY occurred_at DESC LIMIT 200",
+    // Forward-facing calendar, on its own budget so it can neither starve
+    // recent_signals nor be starved by a busy messaging day. Ascending + a small
+    // LIMIT keeps it to the NEAREST events; the upper bound is what stops the
+    // 2056 recurring expansions from filling it on a sparse calendar.
+    //
+    // 30 days, not 7: measured against prod 2026-08-07, a 7-day window returns
+    // 0 rows (the next real event is 18 days out). Row counts from now-1d:
+    // 7d=0, 30d=4, 60d=5, 90d=7. 30d is the smallest round window that is
+    // non-empty on real data and still covers the next flight; retune here if
+    // the calendar fills in.
+    //
+    // Those counts span BOTH calendar connectors, because this source keys off
+    // `semantic_type` and not `connector_key` — that is the entire point of the
+    // shared vocabulary. Counting google.calendar alone gives 3/4/6 and is the
+    // wrong measurement: the 30-day window's second row is an apple.calendar
+    // holiday.
+    upcoming_calendar:
+      "SELECT id, id AS source_event_id, COALESCE('connection:' || connection_id::text, 'connector:' || connector_key, 'event') AS source_scope, COALESCE(origin_id, 'event:' || id::text) AS source_origin_id, occurred_at, title, payload_text, semantic_type, connector_key, metadata FROM events WHERE semantic_type = 'calendar_event' AND occurred_at BETWEEN now() - interval '1 day' AND now() + interval '30 days' ORDER BY occurred_at ASC LIMIT 20",
     // context-only: existing tasks are dedup reference data, not window signal
     task_list: {
       context: true,

--- a/packages/connectors/src/__tests__/google_calendar.test.ts
+++ b/packages/connectors/src/__tests__/google_calendar.test.ts
@@ -158,6 +158,51 @@ const SCOPE_REJECTION_BODY = JSON.stringify({
   },
 });
 
+describe('GoogleCalendarConnector event kind', () => {
+  test('emits the calendar_event kind shared with the other calendar connectors', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client } = fakeHttp([
+      { items: [calEvent('a', '2026-01-01T10:00:00Z')], nextSyncToken: 'S' },
+    ]);
+    connector.client = () => client;
+
+    const result = await connector.sync({
+      config: { calendar_id: 'primary', max_results: 100 },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    // `calendar_event` is the vocabulary microsoft_outlook and apple.calendar
+    // already emit. A connector-specific synonym here is invisible to any
+    // consumer that filters on the shared kind.
+    expect(result.events[0].origin_type).toBe('calendar_event');
+  });
+
+  test('every emitted origin_type is declared in the feed eventKinds registry', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client } = fakeHttp([
+      { items: [calEvent('a', '2026-01-01T10:00:00Z')], nextSyncToken: 'S' },
+    ]);
+    connector.client = () => client;
+
+    const result = await connector.sync({
+      config: { calendar_id: 'primary', max_results: 100 },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    // `event_kinds` is a CLOSED allowlist once non-empty: the server rejects a
+    // write whose semantic_type is absent from feeds_schema[feed].eventKinds.
+    // Renaming one side without the other silently stops ingestion, so pin
+    // both to each other here.
+    const declared = Object.keys(connector.definition.feeds.events.eventKinds);
+    expect(declared).toContain('calendar_event');
+    for (const event of result.events) {
+      expect(declared).toContain(event.origin_type);
+    }
+  });
+});
+
 describe('GoogleCalendarConnector poisoned sync token recovery', () => {
   test('a 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT on the incremental request drops the token and full-syncs', async () => {
     const connector = new GoogleCalendarConnector();

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -149,7 +149,12 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
           },
         },
         eventKinds: {
-          event: {
+          // `calendar_event`, not `event`: microsoft_outlook and the apple.calendar
+          // device connector both emit this kind, and consumers filter on the shared
+          // vocabulary. This key and the `origin_type` in toEventEnvelope must stay
+          // identical — `event_kinds` is a closed allowlist once non-empty, so a
+          // one-sided rename makes the server reject every write from this feed.
+          calendar_event: {
             description: 'A Google Calendar event',
             metadataSchema: {
               type: 'object',
@@ -649,7 +654,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       author_name: calEvent.organizer?.displayName || calEvent.organizer?.email,
       source_url: calEvent.htmlLink,
       occurred_at: occurredAt,
-      origin_type: 'event',
+      origin_type: 'calendar_event',
       metadata: {
         status: calEvent.status,
         ...(calEvent.location ? { location: calEvent.location } : {}),


### PR DESCRIPTION
## Summary

- Three calendar connectors, two vocabularies. `microsoft_outlook` and the `apple.calendar` device connector both emit `calendar_event`; `google.calendar` emitted a bare `event`. Any consumer filtering on the shared kind silently skipped every Google Calendar row — **254** of them on prod.
- Flips the emitted `origin_type` **and** the `feeds.events.eventKinds` key (with its `metadataSchema`) in one commit. `event_kinds` is a closed allowlist once non-empty, so a one-sided rename would make the server reject every write from this feed.
- Migration restamps history **and** bridges the per-org allowlist across the rollout.
- Splits Behavior 5's sources in `examples/personal-agent/lobu.config.ts`, which the restamp forces (see "This rename is a regression without the source split").

`connector_definitions.feeds_schema` is **code-derived**: `connector-definition-install.ts:322` writes `metadata.feeds` straight into the column. But it only converges via the **hourly** `refresh-connector-definitions` cron (`jobs.ts:288`, `cron: '0 * * * *'`), *not* at deploy. Hence the bridge — without it, new pods emitting `calendar_event` are validated against a stale `event`-only allowlist for up to an hour, and rejection is silent loss because the run still completes and advances the Google `syncToken` past the dropped items.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming) — exit 0
- [x] Tests run: `make test-unit` exit 0; `bun test packages/connectors/src/__tests__/google_calendar.test.ts` 8/8
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: n/a

### Red → green (unit)

Two new tests pin the emitted `origin_type` to the declared `eventKinds` key so the closed-allowlist pairing cannot drift again.

**Red:**
```
expect(result.events[0].origin_type).toBe('calendar_event');
Expected: "calendar_event"   Received: "event"

expect(declared).toContain('calendar_event');
Expected to contain: "calendar_event"   Received: [ "event" ]

 6 pass / 2 fail
```
**Green:** `8 pass / 0 fail / 19 expect() calls`

### Red → green (prod, org `buremba`)

**Red** — Behavior 5's exact `recent_signals`, grouped. Zero `google.calendar`:
```
whatsapp.local,message,72
google.gmail,thread,7
apple.calendar,calendar_event,1
```
The rows exist, stamped with a kind nothing filters for:
```
apple.calendar,calendar_event,8
google.calendar,event,254
```

**Green (projected — backfill ships in this PR, applies at deploy):** the new `upcoming_calendar` source with the rename applied inline returns real, actionable rows spanning **both** calendar connectors — which is the whole point of the shared vocabulary:
```
connection:418  Flight to Pisa (FR 586)                          2026-08-25  google.calendar
connection:388  Summer Bank Holiday (England, Wales, N Ireland)  2026-08-30  apple.calendar
connection:418  Happy birthday!                                  2026-08-31  google.calendar
connection:418  Nick + Burak                                     2026-09-01  google.calendar
```
And `recent_signals` keeps its conversational window intact: `whatsapp 150 / gmail 40 / note 5 / reminder 5`.

### Migration executed against a real database

Not just squawk-linted — run against an embedded Postgres 18 with rows mirroring the prod shape:
```
BEFORE kinds     : [google.calendar → event]
AFTER UP events  : google.calendar ('calendar_event','calendar_event') ×2, (…,NULL) ×1
                   apple.calendar  ('calendar_event',NULL)  UNTOUCHED
                   linkedin.local  ('event','event')        UNTOUCHED
                   google.calendar ('note','note')          UNTOUCHED
AFTER UP kinds   : [google.calendar → calendar_event, google.calendar → event]
metadataSchema carried over: {"description":"A Google Calendar event","metadataSchema":{"type":"object"}}
IDEMPOTENT (re-run is a no-op): true
AFTER DOWN events: identical to BEFORE
AFTER DOWN kinds : [google.calendar → event]   ← exact round-trip
```
`squawk` clean. The first draft's `down` was **not** a true inverse (it left the added `calendar_event` key behind when `event` was still present); that was caught by this run and fixed.

## Notes

### This rename is a regression without the source split

Restamping alone would have made Behavior 5 *worse*. Calendar rows are dated when the meeting **happens**, so under `ORDER BY occurred_at DESC` the future-dated ones sort ahead of every message: **213 of 254** google.calendar rows are future-dated, mostly two recurring series expanded to **2056-07-04**. Measured, the projected post-rename window was **80 of 80 calendar rows** — WhatsApp and Gmail evicted entirely.

So the sources are split into two bounded budgets rather than one widened filter:
- `recent_signals` — drops `calendar_event`, adds `occurred_at <= now()`, `DESC LIMIT 200`.
- `upcoming_calendar` — `semantic_type = 'calendar_event'`, `now()-1d .. now()+30d`, `ASC LIMIT 20`.

**30 days, not 7:** a 7-day window returns **0 rows** on real data (next event is 18 days out). Counts from `now-1d`: `7d=0, 30d=4, 60d=5, 90d=7`. Those span both calendar connectors — counting `google.calendar` alone gives 3/4/6 and is the wrong measurement, since the source keys off `semantic_type`, not `connector_key`.

### ⚠️ Sequencing — the reviewer's most important question

`examples/personal-agent/lobu.config.ts` is the **repo** config. **Prod Behavior 5 needs a matching `behaviors.createVersion` at rollout, or the connector rename regresses it.** This PR deliberately does not run `lobu apply` and does not edit prod Behavior 5: the repo config has known drift from prod (Behavior 70's `outputs` is entity-in-config vs event-in-prod), and PR #2570 (apply round-trip fidelity) is open and unmerged, so an apply would revert a deliberate migration.

Order at rollout: **migration (bridge + restamp) → pods roll → `behaviors.createVersion` for Behavior 5**. The bridge makes the middle step safe; the last step is what keeps Behavior 5 whole.

### Backfill: why a migration and not a resync

A resync *would* supersede rows it returns (`google_calendar.ts` keys on the stable `calEvent.id`) — it just cannot return most of them. Full sync windows to `[now-30d, now+365d]`: only **20 of 254** rows fall inside (31 older, 203 past +365d). Incremental sends only `syncToken`, returning just changed events. A resync provably restamps **<8%** of history.

The migration is an `UPDATE` (never `DELETE FROM events`), scoped to one `connector_key`, idempotent, with a verified round-trip `down`. It moves `origin_type` too because the ingest path stores the envelope's `origin_type` into both columns. No derived state goes stale: `identity_key`/`identity_ns` are NULL on all 254 rows, and no trigger or partial index is keyed on `semantic_type = 'event'`.

### Class grep

`grep -rn "origin_type" packages/connectors/src/*.ts` across all 13 bundled connectors. Every other emission is domain-specific — `commit`, `pull_request`, `issue`, `issue_comment`, `pr_comment`, `discussion`, `stargazer*`, `thread`, `email`, `calendar_event`, `comment`, `post`, `article`, `row`, `video`, `playlist`, `channel_subscription`, `tweet`/`reply`, `dm_message`. **`google.calendar` was the only outlier** — the only case where two connectors named the same real-world thing differently.

Deliberately not changed: `examples/personal-agent/linkedin.connector.ts:3311` emits `origin_type: "event"` for a LinkedIn *networking event* (`Events.csv`) — a different domain concept, no sibling naming the same thing differently, and its feed declares no `eventKinds` (permissive mode).

### Consumers of the literal `'event'`

`git fetch -q origin && git grep -nE "(semantic_type|origin_type|kind)\s*[=:]+\s*['\"]event['\"]" origin/main` → no consumer. The one `IN (...)` hit, `watchers/automation.ts:717`, is `COALESCE(approved_input->>'dispatch_source','scheduled') IN ('scheduled','event')` — unrelated. In prod, no feed config or Behavior source filters on `semantic_type = 'event'`.

### Post-merge prod verification (owed)

```sql
SELECT connector_key, semantic_type, count(*) FROM events
WHERE connector_key = 'google.calendar' GROUP BY 1,2;
-- expect: google.calendar | calendar_event | 254   (zero rows with semantic_type='event')
```
