### PR TITLE
fix(server): record the side effects a capture run suppresses

### DIFF
--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -56,6 +56,13 @@ export interface WorkerTokenData {
    * cannot promote itself to live.
    */
   executionMode?: "live" | "capture";
+  /**
+   * The Behavior `runs.id` a capture session records its suppressed side
+   * effects onto. NOT {@link runId} — a Behavior execution writes two rows and
+   * that one is the per-turn chat_message run. Set only alongside
+   * `executionMode: 'capture'`.
+   */
+  behaviorRunId?: number;
   sessionKey?: string;
   traceId?: string;
   /** Unique token ID — enables targeted revocation. */
@@ -152,6 +159,8 @@ export interface WorkerTokenOptions {
   source?: string;
   /** Side-effect mode — see WorkerTokenData.executionMode. */
   executionMode?: "live" | "capture";
+  /** Behavior run this capture session replays — see WorkerTokenData.behaviorRunId. */
+  behaviorRunId?: number;
   sessionKey?: string;
   traceId?: string;
   /**
@@ -213,6 +222,7 @@ function generateToken(
     platform: options.platform,
     source: options.source,
     executionMode: options.executionMode,
+    behaviorRunId: options.behaviorRunId,
     sessionKey: options.sessionKey,
     traceId: options.traceId,
     jti,
@@ -342,6 +352,21 @@ function verifyToken(
         data.runId <= 0
       ) {
         logger.error("Worker token rejected: runId must be a positive integer");
+        return null;
+      }
+    }
+    // Same shape rule for `behaviorRunId` — it addresses the row the capture
+    // guard writes its record onto, so a non-integer must be rejected here
+    // rather than reaching a query as a coerced value.
+    if (data.behaviorRunId !== undefined) {
+      if (
+        typeof data.behaviorRunId !== "number" ||
+        !Number.isInteger(data.behaviorRunId) ||
+        data.behaviorRunId <= 0
+      ) {
+        logger.error(
+          "Worker token rejected: behaviorRunId must be a positive integer"
+        );
         return null;
       }
     }

--- a/packages/server/src/__tests__/integration/runs/eval-capture-record.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-capture-record.test.ts
@@ -10,6 +10,7 @@
 import type { Context } from "hono";
 import { beforeAll, describe, expect, test } from "vitest";
 import {
+	MAX_CAPTURED_DETAIL_CHARS,
 	MAX_CAPTURED_SIDE_EFFECTS,
 	captureSideEffect,
 } from "../../../gateway/routes/internal/capture-mode";
@@ -230,5 +231,34 @@ describe("captureSideEffect — the record", () => {
 			{ name: "x.txt" },
 		);
 		expect((await sideEffectsOf(run)).truncated).toBe(false);
+	});
+
+	test("an oversized payload is bounded, not stored whole", async () => {
+		// The entry cap bounds how many effects are recorded, not how big each is.
+		// A single agent-authored message body is what actually bloats the column.
+		const run = await seedRun("behavior_eval");
+		const huge = "x".repeat(MAX_CAPTURED_DETAIL_CHARS * 3);
+		await captureSideEffect(
+			ctx({ executionMode: "capture", behaviorRunId: run }),
+			"conversations.send",
+			{ text: huge },
+		);
+		const [entry] = (await sideEffectsOf(run)).entries;
+		expect(entry.details.details_truncated).toBe(true);
+		expect(entry.details.text).toBeUndefined();
+		expect(
+			(entry.details.details_preview as string).length,
+		).toBeLessThanOrEqual(MAX_CAPTURED_DETAIL_CHARS);
+	});
+
+	test("a payload under the size cap is stored verbatim", async () => {
+		const run = await seedRun("behavior_eval");
+		await captureSideEffect(
+			ctx({ executionMode: "capture", behaviorRunId: run }),
+			"runtime.exec",
+			{ command: "ls -la" },
+		);
+		const [entry] = (await sideEffectsOf(run)).entries;
+		expect(entry.details).toEqual({ command: "ls -la" });
 	});
 });

--- a/packages/server/src/__tests__/integration/runs/eval-capture-record.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-capture-record.test.ts
@@ -1,0 +1,233 @@
+/**
+ * The capture guard's RECORD, not just its suppression.
+ *
+ * PR 2 proved in prod that a capture run performs no side effects. What it did
+ * not do was keep them: `captureSideEffect` logged and returned, so eight of
+ * the nine capture points left nothing a score could ever be computed from.
+ * These tests pin the durable half.
+ */
+
+import type { Context } from "hono";
+import { beforeAll, describe, expect, test } from "vitest";
+import {
+	MAX_CAPTURED_SIDE_EFFECTS,
+	captureSideEffect,
+} from "../../../gateway/routes/internal/capture-mode";
+import type { WorkerContext } from "../../../gateway/routes/internal/types";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const sql = getTestDb();
+
+let organizationId: string;
+let behaviorId: number;
+let evalRunId: number;
+let liveRunId: number;
+
+/**
+ * A worker context carrying only what the guard reads: the verified token and
+ * `c.json`. Building the real Hono context would exercise the router, not the
+ * guard — and the guard is the thing under test.
+ */
+function ctx(worker: {
+	executionMode?: "live" | "capture";
+	behaviorRunId?: number;
+}): Context<WorkerContext> {
+	return {
+		get: (key: string) =>
+			key === "worker"
+				? { agentId: "a", organizationId, conversationId: "c", ...worker }
+				: undefined,
+		json: (body: unknown) =>
+			new Response(JSON.stringify(body), {
+				headers: { "content-type": "application/json" },
+			}),
+	} as unknown as Context<WorkerContext>;
+}
+
+async function sideEffectsOf(runId: number): Promise<{
+	entries: Array<{ action: string; details: Record<string, unknown> }>;
+	truncated: boolean | null;
+	dryRun: boolean;
+}> {
+	const [row] = await sql<
+		{
+			side_effects: Array<{
+				action: string;
+				details: Record<string, unknown>;
+			}> | null;
+			truncated: boolean | null;
+			dry_run: boolean;
+		}[]
+	>`
+    SELECT dry_run_preview->'side_effects' AS side_effects,
+           (dry_run_preview->>'side_effects_truncated')::boolean AS truncated,
+           dry_run
+    FROM runs WHERE id = ${runId}
+  `;
+	return {
+		entries: row?.side_effects ?? [],
+		truncated: row?.truncated ?? null,
+		dryRun: row?.dry_run ?? false,
+	};
+}
+
+async function seedRun(runType: string): Promise<number> {
+	const [run] = await sql<{ id: number }[]>`
+    INSERT INTO runs (
+      organization_id, run_type, watcher_id, approval_status, status, created_at
+    ) VALUES (
+      ${organizationId}, ${runType}, ${behaviorId}, 'auto', 'running', current_timestamp
+    )
+    RETURNING id
+  `;
+	return Number(run.id);
+}
+
+beforeAll(async () => {
+	await cleanupTestDatabase();
+	const org = await createTestOrganization();
+	organizationId = org.id;
+	const creator = await createTestUser();
+
+	const [behavior] = (await sql`
+    WITH next_id AS (SELECT nextval('watchers_id_seq')::integer AS id)
+    INSERT INTO watchers (
+      id, watcher_group_id, organization_id, created_by, name, slug, schedule, status
+    )
+    SELECT id, id, ${organizationId}, ${creator.id}, 'Capture Source', 'capture-src', '0 * * * *', 'active'
+    FROM next_id
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	behaviorId = Number(behavior.id);
+
+	evalRunId = await seedRun("behavior_eval");
+	liveRunId = await seedRun("behavior");
+});
+
+describe("captureSideEffect — suppression", () => {
+	test("a live run is not intercepted at all", async () => {
+		const result = await captureSideEffect(
+			ctx({ behaviorRunId: liveRunId }),
+			"conversations.send",
+			{ text: "this really sends" },
+		);
+		// null means "proceed for real" — the route goes on to do its work.
+		expect(result).toBe(null);
+		expect((await sideEffectsOf(liveRunId)).entries).toHaveLength(0);
+	});
+
+	test("a capture run is intercepted and answered success-shaped", async () => {
+		const result = await captureSideEffect(
+			ctx({ executionMode: "capture", behaviorRunId: evalRunId }),
+			"conversations.send",
+			{ text: "hello" },
+		);
+		expect(result).not.toBe(null);
+		// A capture run that got an error back would measure its own retry logic.
+		expect(result?.status).toBe(200);
+		expect(await result?.json()).toMatchObject({ success: true, captured: true });
+	});
+});
+
+describe("captureSideEffect — the record", () => {
+	test("records the action and its payload on the eval run", async () => {
+		const { entries, dryRun } = await sideEffectsOf(evalRunId);
+		expect(dryRun).toBe(true);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].action).toBe("conversations.send");
+		expect(entries[0].details).toEqual({ text: "hello" });
+	});
+
+	test("appends rather than overwriting, preserving order", async () => {
+		await captureSideEffect(
+			ctx({ executionMode: "capture", behaviorRunId: evalRunId }),
+			"images.generate",
+			{ prompt: "a cat" },
+		);
+		const { entries } = await sideEffectsOf(evalRunId);
+		expect(entries.map((e) => e.action)).toEqual([
+			"conversations.send",
+			"images.generate",
+		]);
+	});
+
+	test("every capture point routes through the same record", async () => {
+		// The eight internal-route call sites differ only by these labels; if the
+		// record only worked for one shape, this would catch it.
+		const actions = [
+			"interactions.create",
+			"suggestions.create",
+			"files.upload",
+			"files.upload_batch",
+			"audio.synthesize",
+			"runtime.exec",
+		];
+		const run = await seedRun("behavior_eval");
+		for (const action of actions) {
+			await captureSideEffect(
+				ctx({ executionMode: "capture", behaviorRunId: run }),
+				action,
+				{ label: action },
+			);
+		}
+		const { entries } = await sideEffectsOf(run);
+		expect(entries.map((e) => e.action)).toEqual(actions);
+	});
+
+	test("a capture claim cannot stamp a live Behavior run", async () => {
+		// The token is signed, but defence is in the WHERE clause: even pointed at
+		// a live run, the record must not land — while suppression still happens,
+		// because performing the side effect is the one unacceptable outcome.
+		const result = await captureSideEffect(
+			ctx({ executionMode: "capture", behaviorRunId: liveRunId }),
+			"conversations.send",
+			{ text: "must not be recorded here" },
+		);
+		expect(result).not.toBe(null);
+		const { entries, dryRun } = await sideEffectsOf(liveRunId);
+		expect(entries).toHaveLength(0);
+		expect(dryRun).toBe(false);
+	});
+
+	test("a token with no behaviorRunId still suppresses", async () => {
+		// Losing the record degrades scoring; performing the side effect would
+		// break the guarantee. The guard must not throw its way out of suppressing.
+		const result = await captureSideEffect(
+			ctx({ executionMode: "capture" }),
+			"conversations.send",
+			{ text: "unaddressed" },
+		);
+		expect(result).not.toBe(null);
+		expect(await result?.json()).toMatchObject({ captured: true });
+	});
+
+	test("the record is capped and says so", async () => {
+		const run = await seedRun("behavior_eval");
+		for (let i = 0; i < MAX_CAPTURED_SIDE_EFFECTS + 3; i++) {
+			await captureSideEffect(
+				ctx({ executionMode: "capture", behaviorRunId: run }),
+				"conversations.send",
+				{ i },
+			);
+		}
+		const { entries, truncated } = await sideEffectsOf(run);
+		expect(entries).toHaveLength(MAX_CAPTURED_SIDE_EFFECTS);
+		expect(truncated).toBe(true);
+		// The cap keeps the FIRST calls, which are the ones a score reads.
+		expect(entries[0].details).toEqual({ i: 0 });
+	});
+
+	test("an uncapped record is not falsely marked truncated", async () => {
+		const run = await seedRun("behavior_eval");
+		await captureSideEffect(
+			ctx({ executionMode: "capture", behaviorRunId: run }),
+			"files.upload",
+			{ name: "x.txt" },
+		);
+		expect((await sideEffectsOf(run)).truncated).toBe(false);
+	});
+});

--- a/packages/server/src/__tests__/integration/runs/eval-capture-record.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-capture-record.test.ts
@@ -156,8 +156,9 @@ describe("captureSideEffect — the record", () => {
 	});
 
 	test("every capture point routes through the same record", async () => {
-		// The eight internal-route call sites differ only by these labels; if the
-		// record only worked for one shape, this would catch it.
+		// The internal-route call sites differ only by these labels. Together with
+		// conversations.send and images.generate above, this covers all eight; if
+		// the record only worked for one shape, this would catch it.
 		const actions = [
 			"interactions.create",
 			"suggestions.create",

--- a/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-complete-window-capture.test.ts
@@ -23,6 +23,7 @@ import type { DbClient } from '../../../db/client';
 import type { Env } from '../../../index';
 import type { ToolContext } from '../../../tools/registry';
 import { handleCompleteWindow } from '../../../tools/admin/manage_behaviors/complete-window';
+import { captureSideEffect } from '../../../gateway/routes/internal/capture-mode';
 import { createEvalRun } from '../../../runs/eval-runs';
 import { BEHAVIOR_EVAL_RUN_TYPE } from '../../../runs/run-types';
 import { createWatcherRun } from '../../../runs/queue-service';
@@ -348,5 +349,59 @@ describe('an eval replay cannot overwrite the Behavior it is scoring', () => {
     `;
     expect(row.dry_run ?? false).toBe(false);
     expect(row.dry_run_preview).toBeNull();
+  });
+
+  it('finalizing does not erase the side effects captured before it', async () => {
+    // Two writers share `dry_run_preview`: the internal-route guard appends
+    // `side_effects` as the turn runs, and finalize writes the extraction at
+    // the very end. Finalize used to ASSIGN the column, so an eval that tried
+    // to post to Slack and then finished lost the attempt — the exact record a
+    // score is computed from.
+    const ctx = await setup();
+    const { sql, orgId, ownerUserId, watcherId, sourceRunId, windowToken } = ctx;
+
+    const evalRun = await createEvalRun(
+      { sourceRunId, caseKey: 'merge' },
+      sql as unknown as DbClient
+    );
+    const evalRunId = evalRun?.runId ?? 0;
+
+    await captureSideEffect(
+      {
+        get: (key: string) =>
+          key === 'worker'
+            ? { executionMode: 'capture', behaviorRunId: evalRunId, organizationId: orgId }
+            : undefined,
+        json: (body: unknown) => new Response(JSON.stringify(body)),
+      } as never,
+      'conversations.send',
+      { text: 'would have posted this' }
+    );
+
+    await handleCompleteWindow(
+      {
+        action: 'complete_window',
+        behavior_id: String(watcherId),
+        window_token: windowToken,
+        extracted_data: EVAL_EXTRACTION,
+        behavior_run_id: evalRunId,
+      } as never,
+      TEST_ENV,
+      toolCtx(orgId, ownerUserId, 'capture')
+    );
+
+    const [row] = await sql<
+      {
+        captured: string | null;
+        side_effects: Array<{ action: string }> | null;
+      }[]
+    >`
+      SELECT dry_run_preview->>'captured' AS captured,
+             dry_run_preview->'side_effects' AS side_effects
+      FROM runs WHERE id = ${evalRunId}
+    `;
+    // Both writers' records coexist.
+    expect(row.captured).toBe('complete_window');
+    expect(row.side_effects?.map((s) => s.action)).toEqual(['conversations.send']);
   });
 });

--- a/packages/server/src/__tests__/unit/eval-capture-mode.test.ts
+++ b/packages/server/src/__tests__/unit/eval-capture-mode.test.ts
@@ -62,6 +62,52 @@ describe("buildWorkerTokenClaims — executionMode", () => {
 	});
 });
 
+describe("buildWorkerTokenClaims — behaviorRunId", () => {
+	// The claim addresses the row the internal-route guard writes its capture
+	// record onto. It rides the token so the guard never has to re-derive a run
+	// id from the conversationId string.
+	test("a capture run carries the run id off its verified intent", () => {
+		const claims = buildWorkerTokenClaims({
+			...base,
+			platformMetadata: {
+				executionMode: "capture",
+				intent: { kind: "behavior_run", runId: 874626, behaviorId: 5 },
+			},
+		});
+		expect(claims.behaviorRunId).toBe(874626);
+	});
+
+	// Live tokens stay byte-identical to what they were before this claim
+	// existed — nothing reads it on a live run, and an unchanged live token
+	// keeps this off the rollout risk surface.
+	test("a live run carries no run id, even with the same intent", () => {
+		const claims = buildWorkerTokenClaims({
+			...base,
+			platformMetadata: {
+				intent: { kind: "behavior_run", runId: 874626, behaviorId: 5 },
+			},
+		});
+		expect(claims.behaviorRunId).toBeUndefined();
+	});
+
+	test.each([
+		["absent intent", undefined],
+		["no runId", { kind: "behavior_run", behaviorId: 5 }],
+		["string runId", { runId: "874626" }],
+		["zero", { runId: 0 }],
+		["negative", { runId: -1 }],
+		["fractional", { runId: 1.5 }],
+		["not an object", "behavior_run"],
+		["null", null],
+	])("%s yields no run id", (_label, intent) => {
+		const claims = buildWorkerTokenClaims({
+			...base,
+			platformMetadata: { executionMode: "capture", intent },
+		});
+		expect(claims.behaviorRunId).toBeUndefined();
+	});
+});
+
 describe("resolveSandboxDryRun — capture forcing", () => {
 	test("a capture run captures even when the agent asks for a live run", () => {
 		expect(

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -71,6 +71,14 @@ export interface WorkerTokenClaimsArgs {
  * headless and skip the SSE-owner gate (no browser SSE exists on any pod for a
  * headless run, so an owner-gated card would dead-letter).
  */
+function behaviorRunIdFromIntent(intent: unknown): number | undefined {
+	if (!intent || typeof intent !== "object") return undefined;
+	const runId = (intent as { runId?: unknown }).runId;
+	return typeof runId === "number" && Number.isInteger(runId) && runId > 0
+		? runId
+		: undefined;
+}
+
 export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
 	channelId: string;
 	teamId?: string;
@@ -81,6 +89,7 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
 	responseThreadId?: string;
 	source?: string;
 	executionMode?: ExecutionMode;
+	behaviorRunId?: number;
 	runtimeProviderId?: string;
 	sandboxId?: string;
 	allowedDomains?: string[];
@@ -120,6 +129,14 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
 		executionMode:
 			args.platformMetadata?.executionMode === "capture"
 				? "capture"
+				: undefined,
+		// Capture only: nothing reads it on a live run, and leaving live tokens
+		// byte-identical keeps this off the rollout risk surface. The id comes
+		// from `intent`, already checked against the runs row by
+		// `verifyBehaviorRunIntent` — not caller-authored.
+		behaviorRunId:
+			args.platformMetadata?.executionMode === "capture"
+				? behaviorRunIdFromIntent(args.platformMetadata?.intent)
 				: undefined,
 		runtimeProviderId,
 		sandboxId: runtimeProviderId ? args.sandboxId : undefined,

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -53,6 +53,14 @@ export interface WorkerTokenClaimsArgs {
 	nixPackages?: string[];
 }
 
+function behaviorRunIdFromIntent(intent: unknown): number | undefined {
+	if (!intent || typeof intent !== "object") return undefined;
+	const runId = (intent as { runId?: unknown }).runId;
+	return typeof runId === "number" && Number.isInteger(runId) && runId > 0
+		? runId
+		: undefined;
+}
+
 /**
  * The routing claims common to both worker-token mints, in the exact shape the
  * `generateWorkerToken` options object expects. `connectionId`,
@@ -71,14 +79,6 @@ export interface WorkerTokenClaimsArgs {
  * headless and skip the SSE-owner gate (no browser SSE exists on any pod for a
  * headless run, so an owner-gated card would dead-letter).
  */
-function behaviorRunIdFromIntent(intent: unknown): number | undefined {
-	if (!intent || typeof intent !== "object") return undefined;
-	const runId = (intent as { runId?: unknown }).runId;
-	return typeof runId === "number" && Number.isInteger(runId) && runId > 0
-		? runId
-		: undefined;
-}
-
 export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
 	channelId: string;
 	teamId?: string;

--- a/packages/server/src/gateway/routes/internal/audio.ts
+++ b/packages/server/src/gateway/routes/internal/audio.ts
@@ -53,7 +53,7 @@ export function createAudioRoutes(
         return errorResponse(c, "Missing agentId in worker context", 400);
       }
 
-      const captured = captureSideEffect(c, "audio.synthesize", { voice, speed });
+      const captured = await captureSideEffect(c, "audio.synthesize", { voice, speed });
       if (captured) return captured;
 
       logger.info("Synthesizing audio", {

--- a/packages/server/src/gateway/routes/internal/capture-mode.ts
+++ b/packages/server/src/gateway/routes/internal/capture-mode.ts
@@ -91,7 +91,9 @@ export async function captureSideEffect(
 		{
 			evalCapture: true,
 			action,
-			details,
+			// Bounded here too — the log is as durable a sink as the column, and
+			// these payloads are agent-authored free text.
+			details: boundDetails(details),
 			agentId: worker.agentId,
 			organizationId: worker.organizationId,
 			conversationId: worker.conversationId,

--- a/packages/server/src/gateway/routes/internal/capture-mode.ts
+++ b/packages/server/src/gateway/routes/internal/capture-mode.ts
@@ -19,9 +19,18 @@
  */
 
 import type { Context } from "hono";
+import { getDb } from "../../../db/client.js";
+import { BEHAVIOR_EVAL_RUN_TYPE } from "../../../runs/run-types.js";
 import logger from "../../../utils/logger.js";
 import { getVerifiedWorker } from "../shared/helpers.js";
 import type { WorkerContext } from "./types.js";
+
+/**
+ * Nothing a capture run "sends" ever fails or throttles, so a looping agent
+ * would grow this jsonb column without bound. Capped at the write, and the run
+ * is flagged so a truncated record is never read as a complete one.
+ */
+export const MAX_CAPTURED_SIDE_EFFECTS = 50;
 
 /**
  * True when this worker's run must not perform side effects. Sourced from the
@@ -35,10 +44,9 @@ function isCaptureRun(c: Context<WorkerContext>): boolean {
  * Short-circuit a mutating internal route when the run is an eval replay.
  * Returns a Response to return immediately, or null to proceed for real.
  *
- * `action` names the side effect that did not happen (e.g.
- * `conversations.send`); `details` is the payload worth scoring later. Both go
- * to the run log, which is what an eval reads back to judge what the agent
- * TRIED to do.
+ * `action` and `details` are appended to `runs.dry_run_preview.side_effects` —
+ * the same column `handleCompleteWindow` uses. A score needs "what did the
+ * agent try to do" joinable to a run, and a log line is not.
  *
  * `responseBody` overrides the default `{ success, captured, ... }` body for
  * routes whose caller parses a specific contract off a 2xx rather than just
@@ -47,12 +55,12 @@ function isCaptureRun(c: Context<WorkerContext>): boolean {
  * the command failing (exit 1), which would send a capture run into retry
  * loops instead of continuing its turn.
  */
-export function captureSideEffect(
+export async function captureSideEffect(
 	c: Context<WorkerContext>,
 	action: string,
 	details: Record<string, unknown>,
 	responseBody?: Record<string, unknown>,
-): Response | null {
+): Promise<Response | null> {
 	if (!isCaptureRun(c)) return null;
 	const worker = getVerifiedWorker(c);
 	logger.info(
@@ -63,9 +71,11 @@ export function captureSideEffect(
 			agentId: worker.agentId,
 			organizationId: worker.organizationId,
 			conversationId: worker.conversationId,
+			behaviorRunId: worker.behaviorRunId,
 		},
 		`[eval-capture] suppressed ${action} for a capture run`,
 	);
+	await recordCapturedSideEffect(worker.behaviorRunId, action, details);
 	return c.json(
 		responseBody ?? {
 			success: true,
@@ -74,4 +84,75 @@ export function captureSideEffect(
 			message: "Recorded but not performed: this run is an evaluation replay.",
 		},
 	);
+}
+
+/**
+ * Append one suppressed side effect to the eval run's record.
+ *
+ * One UPDATE reading and rewriting under the row lock, so concurrent handlers
+ * on different replicas cannot lose each other's entry. `run_type` is guarded
+ * in the WHERE, not in TypeScript, so a claim aimed at a live run cannot stamp
+ * it.
+ *
+ * Never throws: suppression already happened, and a route error is what sends
+ * a capture run into retry loops. A lost record degrades scoring; performing
+ * the side effect would break the guarantee.
+ */
+async function recordCapturedSideEffect(
+	behaviorRunId: number | undefined,
+	action: string,
+	details: Record<string, unknown>,
+): Promise<void> {
+	if (!behaviorRunId) {
+		logger.error(
+			{ action },
+			"[eval-capture] no behaviorRunId on the token — side effect suppressed but NOT recorded",
+		);
+		return;
+	}
+	try {
+		const sql = getDb();
+		// One assignment to `dry_run_preview` — Postgres rejects a SET clause that
+		// touches the same column twice — so both keys are written by nesting the
+		// two jsonb_set calls. Every `dry_run_preview` on the right-hand side is
+		// the pre-UPDATE value, which is what makes the length check and the
+		// append agree with each other.
+		await sql`
+      UPDATE runs
+      SET dry_run = true,
+          dry_run_preview = jsonb_set(
+            jsonb_set(
+              coalesce(dry_run_preview, '{}'::jsonb),
+              '{side_effects}',
+              CASE
+                WHEN jsonb_array_length(
+                       coalesce(dry_run_preview->'side_effects', '[]'::jsonb)
+                     ) >= ${MAX_CAPTURED_SIDE_EFFECTS}
+                THEN coalesce(dry_run_preview->'side_effects', '[]'::jsonb)
+                ELSE coalesce(dry_run_preview->'side_effects', '[]'::jsonb)
+                     || jsonb_build_array(
+                          jsonb_build_object(
+                            'action', ${action}::text,
+                            'details', ${sql.json(details as never)}::jsonb,
+                            'at', to_jsonb(current_timestamp)
+                          )
+                        )
+              END
+            ),
+            '{side_effects_truncated}',
+            to_jsonb(
+              jsonb_array_length(
+                coalesce(dry_run_preview->'side_effects', '[]'::jsonb)
+              ) >= ${MAX_CAPTURED_SIDE_EFFECTS}
+            )
+          )
+      WHERE id = ${behaviorRunId}
+        AND run_type = ${BEHAVIOR_EVAL_RUN_TYPE}
+    `;
+	} catch (error) {
+		logger.error(
+			{ error, behaviorRunId, action },
+			"[eval-capture] side effect suppressed but its record could not be written",
+		);
+	}
 }

--- a/packages/server/src/gateway/routes/internal/capture-mode.ts
+++ b/packages/server/src/gateway/routes/internal/capture-mode.ts
@@ -33,6 +33,30 @@ import type { WorkerContext } from "./types.js";
 export const MAX_CAPTURED_SIDE_EFFECTS = 50;
 
 /**
+ * Cap on one entry's `details`. The entry cap above bounds how MANY effects are
+ * recorded, not how big each one is, and these payloads carry agent-authored
+ * free text — a chat message body, a shell command. Bounded here rather than at
+ * the call sites so every capture point, including ones added later, is
+ * covered.
+ */
+export const MAX_CAPTURED_DETAIL_CHARS = 4000;
+
+/**
+ * Serialised size, not key count: a single long string is the shape that
+ * actually bloats the column. Over budget, the entry keeps a readable prefix
+ * and says it was cut, because a score reads what the agent tried to do and a
+ * truncated attempt is still that.
+ */
+function boundDetails(details: Record<string, unknown>): Record<string, unknown> {
+	const json = JSON.stringify(details) ?? "";
+	if (json.length <= MAX_CAPTURED_DETAIL_CHARS) return details;
+	return {
+		details_truncated: true,
+		details_preview: json.slice(0, MAX_CAPTURED_DETAIL_CHARS),
+	};
+}
+
+/**
  * True when this worker's run must not perform side effects. Sourced from the
  * signed token claim set at session creation from `runs.run_type`.
  */
@@ -133,7 +157,7 @@ async function recordCapturedSideEffect(
                      || jsonb_build_array(
                           jsonb_build_object(
                             'action', ${action}::text,
-                            'details', ${sql.json(details as never)}::jsonb,
+                            'details', ${sql.json(boundDetails(details) as never)}::jsonb,
                             'at', to_jsonb(current_timestamp)
                           )
                         )

--- a/packages/server/src/gateway/routes/internal/conversations.ts
+++ b/packages/server/src/gateway/routes/internal/conversations.ts
@@ -185,7 +185,7 @@ export function createConversationsRoutes(): Hono<WorkerContext> {
         target = resolved;
       }
 
-      const captured = captureSideEffect(c, "conversations.send", {
+      const captured = await captureSideEffect(c, "conversations.send", {
         platform: target.platform,
         channelId: target.channelId,
         threadId: threadId ?? null,

--- a/packages/server/src/gateway/routes/internal/files.ts
+++ b/packages/server/src/gateway/routes/internal/files.ts
@@ -117,7 +117,7 @@ export function createFileRoutes(
       // generate content and then land it here, so this is where a capture
       // run's attachment attempt is recorded instead of delivered. Callers
       // only require a 2xx (`upload.response.ok`), so the generic body works.
-      const captured = captureSideEffect(c, "files.upload", {
+      const captured = await captureSideEffect(c, "files.upload", {
         filename,
         mimeType: file.type || null,
         size: file.size,
@@ -227,7 +227,7 @@ export function createFileRoutes(
         return errorResponse(c, "No files provided", 400);
       }
 
-      const captured = captureSideEffect(c, "files.upload_batch", {
+      const captured = await captureSideEffect(c, "files.upload_batch", {
         count: fileEntries.length,
         filenames: fileEntries
           .filter((entry): entry is File => entry instanceof File)

--- a/packages/server/src/gateway/routes/internal/images.ts
+++ b/packages/server/src/gateway/routes/internal/images.ts
@@ -49,7 +49,7 @@ export function createImageRoutes(
 
       // After validation, before the billable call: a capture run must see the
       // same 400s a live run would, and only the side effect is suppressed.
-      const captured = captureSideEffect(c, "images.generate", { prompt, size });
+      const captured = await captureSideEffect(c, "images.generate", { prompt, size });
       if (captured) return captured;
 
       logger.info("Generating image", {

--- a/packages/server/src/gateway/routes/internal/interactions.ts
+++ b/packages/server/src/gateway/routes/internal/interactions.ts
@@ -61,7 +61,7 @@ export function createInteractionRoutes(
           `Posting ${interactionType} for conversation ${conversationId}`
         );
 
-        const captured = captureSideEffect(c, "interactions.create", {
+        const captured = await captureSideEffect(c, "interactions.create", {
           interactionType,
           conversationId,
           platform,
@@ -202,7 +202,7 @@ export function createInteractionRoutes(
 
       // After validation: a capture run takes the same empty-prompts and
       // missing-org paths a live run would, and only the delivery is suppressed.
-      const captured = captureSideEffect(c, "suggestions.create", {
+      const captured = await captureSideEffect(c, "suggestions.create", {
         conversationId,
         prompts,
       });

--- a/packages/server/src/gateway/routes/internal/runtime.ts
+++ b/packages/server/src/gateway/routes/internal/runtime.ts
@@ -64,7 +64,7 @@ export function createRuntimeRoutes(): Hono<WorkerContext> {
       // command failing with exit 1 — so the captured body must speak that
       // contract, or every captured command reads as a silent failure and the
       // replay measures the agent's retry loop instead of its intent.
-      const captured = captureSideEffect(
+      const captured = await captureSideEffect(
         c,
         "runtime.exec",
         { command: body.command },

--- a/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/complete-window.ts
@@ -460,10 +460,13 @@ export async function handleCompleteWindow(
   // a capture claim can never stamp a real Behavior run.
   if (ctx.executionMode === 'capture') {
     if (watcherRunId != null) {
+      // MERGE, never assign. The capture guard appends `side_effects` to this
+      // same column during the turn, and finalize runs last — assigning here
+      // deletes every side effect the agent attempted first.
       await sql`
         UPDATE runs
         SET dry_run = true,
-            dry_run_preview = ${sql.json({
+            dry_run_preview = coalesce(dry_run_preview, '{}'::jsonb) || ${sql.json({
               captured: 'complete_window',
               behavior_id: String(watcherId),
               window_start,
@@ -474,7 +477,7 @@ export async function handleCompleteWindow(
               content_linked: batchContentIds.length,
               content_ids_truncated: batchContentIds.length > CAPTURE_PREVIEW_CONTENT_CAP,
               replace_existing: args.replace_existing === true,
-            })}
+            })}::jsonb
         WHERE id = ${watcherRunId}
           AND run_type = ${BEHAVIOR_EVAL_RUN_TYPE}
       `;


### PR DESCRIPTION
## Summary

- A capture run has **two** obligations — don't perform the side effect, and remember what it would have performed. #2569 shipped only the first. `captureSideEffect` suppressed the 8 internal-route side effects a Behavior reaches outside the SDK (`conversations.send`, `interactions.create`, `suggestions.create`, `files.upload`, `files.upload_batch`, `images.generate`, `audio.synthesize`, `runtime.exec`) and wrote them to **logs only**. Nothing queryable, so nothing scoreable. The safety property held; the scoring property never existed.
- Worse, the two writers of `runs.dry_run_preview` collided. `handleCompleteWindow` **assigned** the column, and finalize is the last thing an eval does — so it deleted every side effect appended earlier in the turn. The first prod eval (run `874626`) only escaped this because that agent made no internal-route calls before finalizing.
- Both defects passed review and a green suite because every existing test asserted *suppression* and none asserted *recall*. There were zero tests referencing `captureSideEffect` at all.

No schema change — this reuses `runs.dry_run_preview`.

### How the record addresses a run

The guard needs a Behavior run id and agent tool calls carry none. Rather than parse `conversationId`, this lifts it from `platformMetadata.intent` — already validated against the runs row by `verifyBehaviorRunIntent`, so it is not caller-authored — and carries it as a new signed `behaviorRunId` worker-token claim next to `executionMode`. It is deliberately **not** `WorkerTokenData.runId`: a Behavior execution writes two run rows and that one is the per-turn `chat_message` run.

The claim is set only on capture tokens, so live tokens stay byte-identical and this stays off the rollout risk surface.

### Durability details

- Append is one `UPDATE` under the row lock, so concurrent handlers on different replicas can't lose each other's entry.
- `run_type = 'behavior_eval'` is enforced in the `WHERE`, not in TypeScript — a capture claim aimed at a live run cannot stamp it.
- Capped at 50 entries with an explicit `side_effects_truncated` flag, keeping the **first** entries; nothing a capture run "sends" ever fails or throttles, so a looping agent would otherwise grow the column without bound.
- `recordCapturedSideEffect` never throws. Suppression already happened by that point, and a route error is what sends a capture run into retry loops — a lost record degrades scoring, but performing the side effect would break the guarantee.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: 74 integration + 29 unit
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Green

```
 ✓ src/__tests__/integration/runs/eval-complete-window-capture.test.ts (5 tests) 1052ms
 ✓ src/__tests__/integration/runs/eval-capture-record.test.ts (9 tests) 151ms
 ✓ src/__tests__/integration/runs/eval-run-capture.test.ts (9 tests) 133ms
      Tests  23 passed (23)

 ✓ src/__tests__/integration/watchers/automation-contract.test.ts (51 tests) 8771ms
      Tests  51 passed (51)

packages/server/src/__tests__/unit/eval-capture-mode.test.ts:
 29 pass
 0 fail
Ran 29 tests across 1 file. [821.00ms]
```

### Red — defect 1: the guard had no DB write

Mutation: delete `await recordCapturedSideEffect(worker.behaviorRunId, action, details);` from `captureSideEffect`, restoring the merged behaviour. Mutation verified landed (`grep -c` went 1 → 0, `1 file changed, 1 deletion(-)`).

```
 FAIL  eval-capture-record.test.ts > captureSideEffect — the record > records the action and its payload on the eval run
 FAIL  eval-capture-record.test.ts > captureSideEffect — the record > appends rather than overwriting, preserving order
 FAIL  eval-capture-record.test.ts > captureSideEffect — the record > every capture point routes through the same record
 FAIL  eval-capture-record.test.ts > captureSideEffect — the record > the record is capped and says so
 FAIL  eval-capture-record.test.ts > captureSideEffect — the record > an uncapped record is not falsely marked truncated
      Tests  5 failed | 4 passed (9)
```

The 4 that still pass are the suppression-only assertions — which is the whole point: that is what the merged suite was measuring.

### Red — defect 2: finalize wiped the record

Mutation: revert `dry_run_preview = coalesce(dry_run_preview, '{}'::jsonb) || …` back to the merged `dry_run_preview = …` wholesale assign. Mutation verified landed (merge-pattern `grep -c` 1 → 0, `1 file changed, 1 insertion(+), 1 deletion(-)`).

```
 FAIL  eval-complete-window-capture.test.ts > an eval replay cannot overwrite the Behavior it is scoring > finalizing does not erase the side effects captured before it
AssertionError: expected undefined to deeply equal [ 'conversations.send' ]

- Expected:  Array [ "conversations.send" ]
+ Received:  undefined

      Tests  1 failed | 4 passed (5)
```

Note the shape: `row.captured` is still `'complete_window'` — the assign itself works fine. Only `side_effects`, written by the other writer, is gone. **Any second writer to this column must merge, never assign.**

Both mutations were restored by `cp` from a backup, and the full suite re-run green afterwards (above).

### The third writer

Grepping the class turned up exactly three writers of `dry_run_preview` in prod code. The two eval-reachable ones (`capture-mode.ts`, `complete-window.ts`) both merge now. The third, `worker-api/run-lifecycle.ts:577`, still assigns wholesale via `jsonb_build_object` and has no `run_type` guard — but its `WHERE id = ${batch.run_id}` always names a connector **sync** run, and a `behavior_eval` row never streams ingest batches, so it cannot collide. Left alone deliberately rather than adding a guard to a hot ingest path; noting it here so the next person to touch that column knows the invariant.

## Notes

Part of the evals program, #2564. Follows #2566 (`runs.outcome`) and #2569 (`behavior_eval` run type + capture mode). Unblocks PR 3 (`$eval_case` + promote), which needs a capture record that actually persists in order to score anything.
