### PR TITLE
fix(server): stop cookie order deciding which session authenticates

### DIFF
--- a/packages/server/src/__tests__/unit/resolve-session.test.ts
+++ b/packages/server/src/__tests__/unit/resolve-session.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import { sessionCookieName } from "../../auth/session-cookie-scope";
+import {
+	resolveSession,
+	sessionCookieCandidates,
+} from "../../auth/resolve-session";
+
+const HOST_ONLY = sessionCookieName(false);
+const SECURE = sessionCookieName(true);
+
+/**
+ * Stand-in for Better Auth's `getSession`, faithful on the one detail that
+ * decides this module: it reads exactly ONE cookie name — the one
+ * `createCookieGetter` derives from `useSecureCookies` — and ignores every
+ * other spelling in the jar. Production issues `__Secure-` cookies, so pass
+ * `SECURE` to model prod and `HOST_ONLY` to model plain-http dev.
+ */
+function fakeAuth(readsName: string, liveValue: string) {
+	const seen: Array<string | null> = [];
+	return {
+		seen,
+		api: {
+			getSession: async ({ headers }: { headers: Headers }) => {
+				const cookie = headers.get("cookie");
+				seen.push(cookie);
+				for (const part of (cookie ?? "").split(";")) {
+					const eq = part.indexOf("=");
+					if (eq === -1) continue;
+					if (part.slice(0, eq).trim() !== readsName) continue;
+					// better-call's parseCookies keeps the FIRST occurrence.
+					return part.slice(eq + 1).trim() === liveValue
+						? { user: { id: "u1" }, session: { token: liveValue } }
+						: null;
+				}
+				return null;
+			},
+		},
+	};
+}
+
+describe("sessionCookieCandidates", () => {
+	test("finds every session cookie, in the order sent", () => {
+		expect(sessionCookieCandidates("")).toEqual([]);
+		expect(sessionCookieCandidates(null)).toEqual([]);
+		expect(sessionCookieCandidates(`${HOST_ONLY}=good`)).toEqual([
+			{ name: HOST_ONLY, value: "good" },
+		]);
+		expect(
+			sessionCookieCandidates(`${HOST_ONLY}=dead; ${HOST_ONLY}=good`),
+		).toEqual([
+			{ name: HOST_ONLY, value: "dead" },
+			{ name: HOST_ONLY, value: "good" },
+		]);
+	});
+
+	test("matches the exact name, never a prefix of a longer one", () => {
+		expect(
+			sessionCookieCandidates(`${HOST_ONLY}_other=x; ${HOST_ONLY}=good`),
+		).toEqual([{ name: HOST_ONLY, value: "good" }]);
+	});
+
+	test("both spellings count, and each keeps its own name", () => {
+		expect(
+			sessionCookieCandidates(`${SECURE}=secure; ${HOST_ONLY}=plain`),
+		).toEqual([
+			{ name: SECURE, value: "secure" },
+			{ name: HOST_ONLY, value: "plain" },
+		]);
+	});
+
+	test("keeps the whole value, including the signature's padding '='", () => {
+		expect(sessionCookieCandidates(`${HOST_ONLY}=tok.c2ln=`)).toEqual([
+			{ name: HOST_ONLY, value: "tok.c2ln=" },
+		]);
+	});
+});
+
+describe("resolveSession", () => {
+	test("passes the request through untouched for a single-cookie jar", async () => {
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({ cookie: `${SECURE}=good` });
+		expect(await resolveSession(auth, headers)).toMatchObject({
+			user: { id: "u1" },
+		});
+		expect(auth.seen).toEqual([`${SECURE}=good`]);
+	});
+
+	test("resolves the live cookie when a dead twin is FIRST — under __Secure-", async () => {
+		// The production spelling. Probing a candidate under any OTHER name is
+		// invisible to Better Auth, so rewriting the jar to the unprefixed
+		// basename would answer `null` for every candidate and lock out every
+		// duplicated jar in prod — a worse brick than the one being fixed.
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({
+			cookie: `${SECURE}=dead; ${SECURE}=good`,
+		});
+		expect(await resolveSession(auth, headers)).toMatchObject({
+			user: { id: "u1" },
+		});
+	});
+
+	test("resolves the live cookie when a dead twin is FIRST — unprefixed", async () => {
+		const auth = fakeAuth(HOST_ONLY, "good");
+		const headers = new Headers({
+			cookie: `${HOST_ONLY}=dead; ${HOST_ONLY}=good`,
+		});
+		expect(await resolveSession(auth, headers)).toMatchObject({
+			user: { id: "u1" },
+		});
+	});
+
+	test("resolves across mixed spellings without collapsing them to one name", async () => {
+		// A jar that outlived an http→https switch holds both names at once.
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({
+			cookie: `${HOST_ONLY}=stale; ${SECURE}=good`,
+		});
+		expect(await resolveSession(auth, headers)).toMatchObject({
+			user: { id: "u1" },
+		});
+	});
+
+	test("stays null when no candidate verifies", async () => {
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({
+			cookie: `${SECURE}=dead; ${SECURE}=alsodead`,
+		});
+		expect(await resolveSession(auth, headers)).toBeNull();
+	});
+
+	test("keeps every other header while probing", async () => {
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({
+			cookie: `${SECURE}=dead; ${SECURE}=good`,
+			origin: "https://app.lobu.ai",
+		});
+		let sawOrigin = true;
+		const wrapped = {
+			seen: auth.seen,
+			api: {
+				getSession: async (opts: { headers: Headers }) => {
+					sawOrigin &&= opts.headers.get("origin") === "https://app.lobu.ai";
+					return auth.api.getSession(opts);
+				},
+			},
+		};
+		await resolveSession(wrapped, headers);
+		expect(sawOrigin).toBe(true);
+	});
+
+	test("bounds how many candidates one request can make it probe", async () => {
+		// The Cookie header is attacker-controlled, and every probe is a session
+		// lookup. A real jar holds a handful of twins at most.
+		const auth = fakeAuth(SECURE, "good");
+		const jar = Array.from(
+			{ length: 40 },
+			(_, i) => `${SECURE}=dead${i}`,
+		).join("; ");
+		expect(await resolveSession(auth, new Headers({ cookie: jar }))).toBeNull();
+		expect(auth.seen.length).toBeLessThanOrEqual(8);
+	});
+});

--- a/packages/server/src/__tests__/unit/resolve-session.test.ts
+++ b/packages/server/src/__tests__/unit/resolve-session.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { sessionCookieName } from "../../auth/session-cookie-scope";
 import {
+	collapseSessionCookies,
 	resolveSession,
 	sessionCookieCandidates,
 } from "../../auth/resolve-session";
@@ -178,5 +179,59 @@ describe("resolveSession", () => {
 		).join("; ");
 		expect(await resolveSession(auth, new Headers({ cookie: jar }))).toBeNull();
 		expect(auth.seen.length).toBeLessThanOrEqual(8);
+	});
+});
+
+/**
+ * Better Auth's own `/api/auth/*` handler resolves the jar itself, so wrapping
+ * `getSession` at our call sites does not reach it. `get-session` is how the web
+ * app asks "am I signed in", so leaving that one order-dependent would keep the
+ * brick visible in the UI with every internal call site already fixed.
+ */
+describe("collapseSessionCookies", () => {
+	test("returns the very same Headers for an ordinary jar", async () => {
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({ cookie: `${SECURE}=good` });
+		// Identity, not equality: the common path must not even copy.
+		expect(await collapseSessionCookies(auth, headers)).toBe(headers);
+	});
+
+	test("reduces a duplicated jar to the live cookie", async () => {
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({
+			cookie: `${SECURE}=dead; other=keep; ${SECURE}=good`,
+		});
+		const out = await collapseSessionCookies(auth, headers);
+		expect(out.get("cookie")).toBe(`other=keep; ${SECURE}=good`);
+	});
+
+	test("strips the session cookie entirely when none verifies", async () => {
+		// Handing Better Auth an arbitrary dead twin would let sign-out act on
+		// it. "Not signed in" is the honest jar.
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({
+			cookie: `${SECURE}=dead; other=keep; ${SECURE}=alsodead`,
+		});
+		const out = await collapseSessionCookies(auth, headers);
+		expect(out.get("cookie")).toBe("other=keep");
+	});
+
+	test("drops the Cookie header when nothing survives stripping", async () => {
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({
+			cookie: `${SECURE}=dead; ${SECURE}=alsodead`,
+		});
+		const out = await collapseSessionCookies(auth, headers);
+		expect(out.get("cookie")).toBeNull();
+	});
+
+	test("keeps every other header", async () => {
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({
+			cookie: `${SECURE}=dead; ${SECURE}=good`,
+			origin: "https://app.lobu.ai",
+		});
+		const out = await collapseSessionCookies(auth, headers);
+		expect(out.get("origin")).toBe("https://app.lobu.ai");
 	});
 });

--- a/packages/server/src/__tests__/unit/resolve-session.test.ts
+++ b/packages/server/src/__tests__/unit/resolve-session.test.ts
@@ -148,6 +148,26 @@ describe("resolveSession", () => {
 		expect(sawOrigin).toBe(true);
 	});
 
+	test("keeps Better Auth's companion cookies in every probe", async () => {
+		// `dont_remember` gates session-expiry refresh and `session_data` is the
+		// cookie cache. Replacing the whole jar with one pair would drop them, so
+		// a duplicated jar would get different refresh semantics from a clean one
+		// — a difference unrelated to which twin is live.
+		const auth = fakeAuth(SECURE, "good");
+		const headers = new Headers({
+			cookie: `better-auth.dont_remember=1; ${SECURE}=dead; other=keep; ${SECURE}=good`,
+		});
+
+		expect(await resolveSession(auth, headers)).toMatchObject({
+			user: { id: "u1" },
+		});
+		// Both probes carried the companions; neither carried the other twin.
+		expect(auth.seen).toEqual([
+			`better-auth.dont_remember=1; other=keep; ${SECURE}=dead`,
+			`better-auth.dont_remember=1; other=keep; ${SECURE}=good`,
+		]);
+	});
+
 	test("bounds how many candidates one request can make it probe", async () => {
 		// The Cookie header is attacker-controlled, and every probe is a session
 		// lookup. A real jar holds a handful of twins at most.

--- a/packages/server/src/__tests__/unit/session-cookie-scope.test.ts
+++ b/packages/server/src/__tests__/unit/session-cookie-scope.test.ts
@@ -3,7 +3,6 @@ import {
 	SESSION_COOKIE_BASENAME,
 	convergeResponseCookieScope,
 	convergeSetCookieScope,
-	countNamedCookies,
 	hostOnlyExpiry,
 	sessionCookieName,
 } from "../../auth/session-cookie-scope";
@@ -23,17 +22,6 @@ describe("session cookie scope convergence", () => {
 	test("names the cookie the way Better Auth does", () => {
 		expect(sessionCookieName(true)).toBe(`__Secure-${SESSION_COOKIE_BASENAME}`);
 		expect(sessionCookieName(false)).toBe(SESSION_COOKIE_BASENAME);
-	});
-
-	test("counts duplicate session cookies in a Cookie header (the brick signal)", () => {
-		const name = sessionCookieName(true);
-		expect(countNamedCookies("", name)).toBe(0);
-		expect(countNamedCookies(`${name}=good`, name)).toBe(1);
-		expect(countNamedCookies(`${name}=dead; ${name}=good`, name)).toBe(2);
-		// A different cookie that merely shares a prefix must not be counted.
-		expect(countNamedCookies(`${name}_other=x; ${name}=good`, name)).toBe(1);
-		// The unprefixed name must not match the __Secure- variant.
-		expect(countNamedCookies(`__Secure-${name}=x`, name)).toBe(0);
 	});
 
 	test("builds a host-only expiry that targets the twin, never the domain cookie", () => {

--- a/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
@@ -64,9 +64,13 @@ describe('duplicate session cookies', () => {
     return body.organizations.map((o) => o.slug);
   }
 
-  // A garbage value that is a syntactically plausible signed cookie but cannot
-  // verify — exactly what a stale twin looks like once its session is revoked.
+  // Garbage values that are syntactically plausible signed cookies — a 44-char
+  // base64 signature, which is the shape better-call checks before it verifies
+  // anything — but cannot pass the HMAC. Exactly what a stale twin looks like
+  // once its session is revoked. Both must fail on the signature, not on shape,
+  // or "every candidate is dead" would prove nothing about verification.
   const DEAD = 'deadbeefdeadbeef.c2lnbmF0dXJlc2lnbmF0dXJlc2lnbmF0dXJlc2lnbmE=';
+  const ALSO_DEAD = 'f00df00df00df00d.c2lnbmF0dXJlc2lnbmF0dXJlc2lnbmF0dXJlc2lnbmE=';
 
   it('authenticates when the live cookie is FIRST in the jar', async () => {
     const slug = 'dup-good-first';
@@ -93,7 +97,7 @@ describe('duplicate session cookies', () => {
 
     // Resolving candidates must not become "authenticate on anything". With no
     // live token in the jar the answer is still no session.
-    expect(await orgSlugsFor(`${name}=${DEAD}; ${name}=${DEAD}2`)).not.toContain(slug);
+    expect(await orgSlugsFor(`${name}=${DEAD}; ${name}=${ALSO_DEAD}`)).not.toContain(slug);
   });
 
   it('is unchanged for the ordinary single-cookie jar', async () => {

--- a/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
@@ -9,22 +9,12 @@ import {
 import { get } from '../../__tests__/setup/test-helpers';
 
 /**
- * A browser can hold the same auth cookie name twice — host-only
- * (`app.lobu.ai`) and domain-scoped (`Domain=.lobu.ai`) — and sends BOTH in one
- * `Cookie` header. Resolution is then decided by position, and the position is
- * not ours to choose:
+ * End-to-end cover for the permanent-login-brick class: a jar holding the same
+ * session cookie twice must authenticate on merit, never on cookie order.
+ * Mechanism and cure: ../resolve-session.ts.
  *
- *   RFC 6265 §5.4  browser sends equal-path cookies oldest-first
- *   better-call    parseCookies keeps the FIRST occurrence (`if (!cookies.has(key))`)
- *   better-auth    getSignedCookie reads that one and stops
- *
- * So a stale twin that happens to be older outranks every later sign-in, and
- * the user is locked out with no in-app escape — signing in again writes a
- * strictly NEWER cookie that can never win. Measured on prod 2026-08-06:
- * `dead; good` resolved to null while `good; dead` resolved to the session.
- *
- * These tests pin the cure: when the jar is ambiguous, resolve it deterministically
- * instead of trusting order.
+ * Runs through the real app stack, so it also pins that the middleware, the
+ * route and Better Auth agree — which a unit test cannot show.
  */
 describe('duplicate session cookies', () => {
   beforeEach(async () => {

--- a/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase } from '../../__tests__/setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestPAT,
+  createTestUser,
+} from '../../__tests__/setup/test-fixtures';
+import { get } from '../../__tests__/setup/test-helpers';
+
+/**
+ * A browser can hold the same auth cookie name twice — host-only
+ * (`app.lobu.ai`) and domain-scoped (`Domain=.lobu.ai`) — and sends BOTH in one
+ * `Cookie` header. Resolution is then decided by position, and the position is
+ * not ours to choose:
+ *
+ *   RFC 6265 §5.4  browser sends equal-path cookies oldest-first
+ *   better-call    parseCookies keeps the FIRST occurrence (`if (!cookies.has(key))`)
+ *   better-auth    getSignedCookie reads that one and stops
+ *
+ * So a stale twin that happens to be older outranks every later sign-in, and
+ * the user is locked out with no in-app escape — signing in again writes a
+ * strictly NEWER cookie that can never win. Measured on prod 2026-08-06:
+ * `dead; good` resolved to null while `good; dead` resolved to the session.
+ *
+ * These tests pin the cure: when the jar is ambiguous, resolve it deterministically
+ * instead of trusting order.
+ */
+describe('duplicate session cookies', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  /**
+   * Mint a real, correctly-signed session cookie the way a browser would get
+   * one, and return both the cookie name and its signed value.
+   */
+  async function realSessionCookie(
+    slug: string,
+    email: string
+  ): Promise<{ name: string; value: string }> {
+    const org = await createTestOrganization({ slug });
+    const user = await createTestUser({ email });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const { token: pat } = await createTestPAT(user.id, org.id, { scope: 'profile:read' });
+
+    const res = await get(`/api/exchange-token?token=${encodeURIComponent(pat)}&next=/`);
+    expect(res.status).toBe(302);
+
+    const setCookie = res.headers
+      .getSetCookie()
+      .find((c) => /^(?:__Secure-)?better-auth\.session_token=[^;]/.test(c));
+    expect(setCookie, 'exchange-token must set a session cookie').toBeTruthy();
+
+    const [pair] = (setCookie as string).split(';');
+    const eq = pair.indexOf('=');
+    return { name: pair.slice(0, eq).trim(), value: pair.slice(eq + 1).trim() };
+  }
+
+  async function orgSlugsFor(cookie: string): Promise<string[]> {
+    const res = await get('/api/organizations', { cookie });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { organizations: Array<{ slug: string }> };
+    return body.organizations.map((o) => o.slug);
+  }
+
+  // A garbage value that is a syntactically plausible signed cookie but cannot
+  // verify — exactly what a stale twin looks like once its session is revoked.
+  const DEAD = 'deadbeefdeadbeef.c2lnbmF0dXJlc2lnbmF0dXJlc2lnbmF0dXJlc2lnbmE=';
+
+  it('authenticates when the live cookie is FIRST in the jar', async () => {
+    const slug = 'dup-good-first';
+    const { name, value } = await realSessionCookie(slug, 'dup-good-first@test.example.com');
+
+    // Control: this direction has always worked, and proves the fixture is sound.
+    expect(await orgSlugsFor(`${name}=${value}; ${name}=${DEAD}`)).toContain(slug);
+  });
+
+  it('authenticates when a DEAD twin is first — the permanent-brick case', async () => {
+    const slug = 'dup-dead-first';
+    const { name, value } = await realSessionCookie(slug, 'dup-dead-first@test.example.com');
+
+    // The brick. Same two cookies, opposite order, and order is decided by the
+    // browser's creation timestamps — not by anything we control. Before the
+    // fix this resolved the dead cookie, returned no session, and no amount of
+    // signing in again could recover it.
+    expect(await orgSlugsFor(`${name}=${DEAD}; ${name}=${value}`)).toContain(slug);
+  });
+
+  it('stays unauthenticated when every candidate is dead', async () => {
+    const slug = 'dup-all-dead';
+    const { name } = await realSessionCookie(slug, 'dup-all-dead@test.example.com');
+
+    // Resolving candidates must not become "authenticate on anything". With no
+    // live token in the jar the answer is still no session.
+    expect(await orgSlugsFor(`${name}=${DEAD}; ${name}=${DEAD}2`)).not.toContain(slug);
+  });
+
+  it('is unchanged for the ordinary single-cookie jar', async () => {
+    const slug = 'dup-single';
+    const { name, value } = await realSessionCookie(slug, 'dup-single@test.example.com');
+
+    expect(await orgSlugsFor(`${name}=${value}`)).toContain(slug);
+  });
+});

--- a/packages/server/src/auth/middleware.ts
+++ b/packages/server/src/auth/middleware.ts
@@ -10,6 +10,7 @@ import { getWorkspaceProvider } from '../workspace';
 import type { ResolveAuthNext } from '../workspace/types';
 import { createAuth } from './index';
 import type { AuthInfo } from './oauth/types';
+import { resolveSession } from './resolve-session';
 
 // Extend Hono context with auth properties
 declare module 'hono' {
@@ -77,7 +78,7 @@ declare module 'hono' {
 export async function requireAuth(c: Context<{ Bindings: Env }>, next: Next) {
   const auth = await createAuth(c.env);
   try {
-    const session = await auth.api.getSession({ headers: c.req.raw.headers });
+    const session = await resolveSession(auth, c.req.raw.headers);
     if (!session || !session.user) {
       return c.json({ error: 'Unauthorized', message: 'Valid session required' }, 401);
     }

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -20,6 +20,7 @@ import { DEFAULT_SCOPES_STRING, filterScopeByRole } from './scopes';
 import type { AuthorizationParams, OAuthClientMetadata, TokenRequestParams } from './types';
 import { createOAuthError, validateRedirectUri } from './utils';
 import { getConfiguredPublicOrigin } from '../../utils/public-origin';
+import { resolveSession } from '../resolve-session';
 
 const oauthRoutes = new Hono<{ Bindings: Env }>();
 
@@ -511,7 +512,7 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
     // Check if user has an active session
     const auth = await createAuth(c.env);
     try {
-      const session = await auth.api.getSession({ headers: c.req.raw.headers });
+      const session = await resolveSession(auth, c.req.raw.headers);
       if (session?.user) {
         // User is logged in — auto-approve and redirect with code
         const code = await provider.createAuthorizationCode(params, session.user.id, null);

--- a/packages/server/src/auth/resolve-session.ts
+++ b/packages/server/src/auth/resolve-session.ts
@@ -87,29 +87,64 @@ function isLive(session: any): boolean {
 }
 
 /**
+ * The jar minus its session cookies — everything a probe must carry unchanged.
+ *
+ * Better Auth reads companions alongside the session token, and they change how
+ * `getSession` behaves: `better-auth.dont_remember` gates session-expiry
+ * refresh, and `better-auth.session_data` is its cookie cache. Dropping the
+ * whole header would give a duplicated jar different refresh semantics from a
+ * clean one — a difference that has nothing to do with which twin is live.
+ */
+function nonSessionCookies(cookieHeader: string | null): string[] {
+  if (!cookieHeader) return [];
+  const kept: string[] = [];
+  for (const part of cookieHeader.split(';')) {
+    const pair = part.trim();
+    if (!pair) continue;
+    const eq = pair.indexOf('=');
+    if (eq === -1) continue;
+    if (SESSION_COOKIE_NAMES.includes(pair.slice(0, eq).trim())) continue;
+    kept.push(pair);
+  }
+  return kept;
+}
+
+/**
  * Resolve the request's session without letting cookie order decide it.
  *
  * Drop-in for `auth.api.getSession({ headers })`. The single-cookie path — every
  * ordinary request — is byte-for-byte the old behaviour and costs nothing extra;
  * the extra lookups happen only for a jar that is already broken.
  *
- * A probe keeps every other header intact and rewrites only `Cookie`, so
- * `Authorization: Bearer` and origin checks behave as before. It also keeps the
- * candidate's own name: renaming it would hide it from `getSession` entirely.
- * Dropping the rest of the jar drops Better Auth's `session_data` cookie cache
- * with it, so a probe always asks the database — correct, and only on the
- * already-broken path.
+ * A probe changes exactly one thing: which session cookie is in the jar. Every
+ * other header survives, so `Authorization: Bearer` and origin checks behave as
+ * before; every non-session cookie survives, so Better Auth's companions still
+ * apply; and the candidate keeps the name it arrived under, because renaming it
+ * would hide it from `getSession` entirely.
+ *
+ * Note an asymmetry worth knowing: the single-cookie path returns whatever
+ * `getSession` returns, ungated, because it must stay byte-for-byte the old
+ * behaviour. The multi-candidate path gates on `isLive`. A session shaped with
+ * a `user` but no `session` would therefore satisfy a caller checking only
+ * `session?.user?.id` on a one-cookie jar and not on a two-cookie one. Better
+ * Auth does not produce that shape today; gating both paths would be the fix if
+ * it ever did.
  */
 export async function resolveSession<A extends SessionReader>(
   auth: A,
   headers: Headers
 ): Promise<SessionOf<A>> {
-  const candidates = sessionCookieCandidates(headers.get('cookie'));
+  const cookieHeader = headers.get('cookie');
+  const candidates = sessionCookieCandidates(cookieHeader);
   if (candidates.length <= 1) return await auth.api.getSession({ headers });
 
+  const companions = nonSessionCookies(cookieHeader);
   for (const candidate of candidates.slice(0, MAX_CANDIDATES)) {
     const single = new Headers(headers);
-    single.set('cookie', `${candidate.name}=${candidate.value}`);
+    single.set(
+      'cookie',
+      [...companions, `${candidate.name}=${candidate.value}`].join('; ')
+    );
     const session = await auth.api.getSession({ headers: single });
     if (isLive(session)) return session;
   }

--- a/packages/server/src/auth/resolve-session.ts
+++ b/packages/server/src/auth/resolve-session.ts
@@ -81,9 +81,18 @@ export function sessionCookieCandidates(
   return candidates;
 }
 
-/** A session object Better Auth considers authenticated. */
+/**
+ * A session object that authenticates someone.
+ *
+ * The predicate is `user`, not `user && session`, because `user` is the weakest
+ * thing any caller requires — `auth/middleware.ts`, `auth/oauth/routes.ts`,
+ * `connect/routes.ts` and `worker-api/auth-runs.ts` all check `session?.user`
+ * alone. Demanding more here would reject, on a duplicated jar, a session those
+ * callers accept on a clean one. A dead cookie yields `null` either way, so this
+ * costs nothing in candidate selection.
+ */
 function isLive(session: any): boolean {
-  return Boolean(session?.user && session.session);
+  return Boolean(session?.user);
 }
 
 /**
@@ -121,47 +130,48 @@ function nonSessionCookies(cookieHeader: string | null): string[] {
  * before; every non-session cookie survives, so Better Auth's companions still
  * apply; and the candidate keeps the name it arrived under, because renaming it
  * would hide it from `getSession` entirely.
- *
- * Note an asymmetry worth knowing: the single-cookie path returns whatever
- * `getSession` returns, ungated, because it must stay byte-for-byte the old
- * behaviour. The multi-candidate path gates on `isLive`. A session shaped with
- * a `user` but no `session` would therefore satisfy a caller checking only
- * `session?.user?.id` on a one-cookie jar and not on a two-cookie one. Better
- * Auth does not produce that shape today; gating both paths would be the fix if
- * it ever did.
  */
 export async function resolveSession<A extends SessionReader>(
   auth: A,
   headers: Headers
 ): Promise<SessionOf<A>> {
-  const cookieHeader = headers.get('cookie');
-  const candidates = sessionCookieCandidates(cookieHeader);
-  if (candidates.length <= 1) return await auth.api.getSession({ headers });
-
-  const companions = nonSessionCookies(cookieHeader);
-  for (const candidate of candidates.slice(0, MAX_CANDIDATES)) {
-    const session = await auth.api.getSession({
-      headers: probeHeaders(headers, companions, candidate),
-    });
-    if (isLive(session)) return session;
-  }
+  const live = await findLiveProbe(auth, headers);
+  if (!live) return await auth.api.getSession({ headers });
   // Every candidate was dead. Resolving on merit must not become "authenticate
   // on anything" — an ambiguous jar with no live token is still no session.
-  return null as SessionOf<A>;
+  return (live.session ?? null) as SessionOf<A>;
 }
 
-/** A copy of `headers` whose jar carries the companions and exactly one twin. */
-function probeHeaders(
-  headers: Headers,
-  companions: string[],
-  candidate: SessionCookieCandidate
-): Headers {
-  const probe = new Headers(headers);
-  probe.set(
-    'cookie',
-    [...companions, `${candidate.name}=${candidate.value}`].join('; ')
-  );
-  return probe;
+/**
+ * Probe an ambiguous jar one candidate at a time, and report what verified.
+ *
+ * `null` means the jar was not ambiguous — one session cookie or none — so the
+ * caller should just use the headers it already has. Otherwise the result
+ * carries the probe headers and the session they produced, and `session` is
+ * `null` when no candidate verified. Returning both means the winning lookup is
+ * never repeated.
+ */
+async function findLiveProbe<A extends SessionReader>(
+  auth: A,
+  headers: Headers
+): Promise<{ headers: Headers; session: SessionOf<A> | null } | null> {
+  const cookieHeader = headers.get('cookie');
+  const candidates = sessionCookieCandidates(cookieHeader);
+  if (candidates.length <= 1) return null;
+
+  const companions = nonSessionCookies(cookieHeader);
+  let last = headers;
+  for (const candidate of candidates.slice(0, MAX_CANDIDATES)) {
+    const probe = new Headers(headers);
+    probe.set(
+      'cookie',
+      [...companions, `${candidate.name}=${candidate.value}`].join('; ')
+    );
+    last = probe;
+    const session = await auth.api.getSession({ headers: probe });
+    if (isLive(session)) return { headers: probe, session };
+  }
+  return { headers: last, session: null };
 }
 
 /**
@@ -182,18 +192,14 @@ export async function collapseSessionCookies<A extends SessionReader>(
   auth: A,
   headers: Headers
 ): Promise<Headers> {
-  const cookieHeader = headers.get('cookie');
-  const candidates = sessionCookieCandidates(cookieHeader);
-  if (candidates.length <= 1) return headers;
+  const live = await findLiveProbe(auth, headers);
+  if (!live) return headers;
+  if (live.session) return live.headers;
 
-  const companions = nonSessionCookies(cookieHeader);
-  for (const candidate of candidates.slice(0, MAX_CANDIDATES)) {
-    const probe = probeHeaders(headers, companions, candidate);
-    if (isLive(await auth.api.getSession({ headers: probe }))) return probe;
-  }
   // No candidate verifies. Send the jar with no session cookie at all rather
   // than an arbitrary dead one: "not signed in" is the honest answer, and it
   // keeps sign-in and sign-out on this request from acting on a dead twin.
+  const companions = nonSessionCookies(headers.get('cookie'));
   const stripped = new Headers(headers);
   if (companions.length > 0) stripped.set('cookie', companions.join('; '));
   else stripped.delete('cookie');

--- a/packages/server/src/auth/resolve-session.ts
+++ b/packages/server/src/auth/resolve-session.ts
@@ -22,12 +22,13 @@
  * what authenticates — never its position in the jar.
  */
 
-/** Better Auth's session cookie, bare and with the `__Secure-` prefix. */
-const SESSION_COOKIE_BASENAME = 'better-auth.session_token';
-const SESSION_COOKIE_NAMES = [
-  SESSION_COOKIE_BASENAME,
-  `__Secure-${SESSION_COOKIE_BASENAME}`,
-];
+import { SESSION_COOKIE_BASENAME, sessionCookieName } from './session-cookie-scope';
+
+/**
+ * Both spellings can be present at once: Better Auth adds the `__Secure-`
+ * prefix only when issuing secure cookies, and a jar can outlive that switch.
+ */
+const SESSION_COOKIE_NAMES = [sessionCookieName(false), sessionCookieName(true)];
 
 /**
  * The minimum of Better Auth's surface this module needs. Deliberately generic:

--- a/packages/server/src/auth/resolve-session.ts
+++ b/packages/server/src/auth/resolve-session.ts
@@ -22,13 +22,27 @@
  * what authenticates — never its position in the jar.
  */
 
-import { SESSION_COOKIE_BASENAME, sessionCookieName } from './session-cookie-scope';
+import { sessionCookieName } from './session-cookie-scope';
 
 /**
  * Both spellings can be present at once: Better Auth adds the `__Secure-`
  * prefix only when issuing secure cookies, and a jar can outlive that switch.
  */
 const SESSION_COOKIE_NAMES = [sessionCookieName(false), sessionCookieName(true)];
+
+/**
+ * How many candidates one request may cost us.
+ *
+ * `Cookie` is attacker-controlled and each probe is a session lookup, so an
+ * unbounded loop turns one unauthenticated request into ~100 of them. A real
+ * jar holds a twin or two (host-only, domain, occasionally a parent domain, and
+ * at most one leftover of the other spelling), so this is far above anything a
+ * browser produces and still bounds the cost.
+ */
+const MAX_CANDIDATES = 8;
+
+/** One session cookie as the jar carries it: its exact name and raw value. */
+type SessionCookieCandidate = { name: string; value: string };
 
 /**
  * The minimum of Better Auth's surface this module needs. Deliberately generic:
@@ -41,23 +55,30 @@ type SessionReader = {
 type SessionOf<A extends SessionReader> = Awaited<ReturnType<A['api']['getSession']>>;
 
 /**
- * Every session-cookie value in a `Cookie` header, in the order sent.
+ * Every session cookie in a `Cookie` header, in the order sent.
+ *
+ * Each candidate keeps the name it arrived under, because that name is what
+ * decides whether Better Auth can see it at all: `getSession` reads exactly one
+ * name, the one `useSecureCookies` derives, and is blind to the other spelling.
  *
  * Values come back raw — only `getSession` can say which of them verify.
  * Matching is on the exact name before `=`, so a `<name>_other` cookie is never
  * mistaken for `<name>`.
  */
-export function sessionCookieCandidates(cookieHeader: string | null | undefined): string[] {
+export function sessionCookieCandidates(
+  cookieHeader: string | null | undefined
+): SessionCookieCandidate[] {
   if (!cookieHeader) return [];
-  const values: string[] = [];
+  const candidates: SessionCookieCandidate[] = [];
   for (const part of cookieHeader.split(';')) {
     const eq = part.indexOf('=');
     if (eq === -1) continue;
-    if (!SESSION_COOKIE_NAMES.includes(part.slice(0, eq).trim())) continue;
+    const name = part.slice(0, eq).trim();
+    if (!SESSION_COOKIE_NAMES.includes(name)) continue;
     const value = part.slice(eq + 1).trim();
-    if (value) values.push(value);
+    if (value) candidates.push({ name, value });
   }
-  return values;
+  return candidates;
 }
 
 /** A session object Better Auth considers authenticated. */
@@ -72,8 +93,12 @@ function isLive(session: any): boolean {
  * ordinary request — is byte-for-byte the old behaviour and costs nothing extra;
  * the extra lookups happen only for a jar that is already broken.
  *
- * Note the candidate header keeps every other header intact and rewrites only
- * `Cookie`, so `Authorization: Bearer` and origin checks behave as before.
+ * A probe keeps every other header intact and rewrites only `Cookie`, so
+ * `Authorization: Bearer` and origin checks behave as before. It also keeps the
+ * candidate's own name: renaming it would hide it from `getSession` entirely.
+ * Dropping the rest of the jar drops Better Auth's `session_data` cookie cache
+ * with it, so a probe always asks the database — correct, and only on the
+ * already-broken path.
  */
 export async function resolveSession<A extends SessionReader>(
   auth: A,
@@ -82,9 +107,9 @@ export async function resolveSession<A extends SessionReader>(
   const candidates = sessionCookieCandidates(headers.get('cookie'));
   if (candidates.length <= 1) return await auth.api.getSession({ headers });
 
-  for (const candidate of candidates) {
+  for (const candidate of candidates.slice(0, MAX_CANDIDATES)) {
     const single = new Headers(headers);
-    single.set('cookie', `${SESSION_COOKIE_BASENAME}=${candidate}`);
+    single.set('cookie', `${candidate.name}=${candidate.value}`);
     const session = await auth.api.getSession({ headers: single });
     if (isLive(session)) return session;
   }

--- a/packages/server/src/auth/resolve-session.ts
+++ b/packages/server/src/auth/resolve-session.ts
@@ -1,0 +1,93 @@
+/**
+ * Session resolution that does not depend on cookie order.
+ *
+ * The same auth cookie name can exist at two scopes at once — host-only
+ * (`app.lobu.ai`) and domain-scoped (`Domain=.lobu.ai`) — and a browser sends
+ * BOTH in one `Cookie` header. Which one authenticates is then decided purely
+ * by position, and the position is not ours to choose:
+ *
+ *   RFC 6265 §5.4  browser sends equal-path cookies oldest-first
+ *   better-call    parseCookies keeps the FIRST occurrence (`if (!cookies.has(key))`)
+ *   better-auth    getSignedCookie reads that one and stops
+ *
+ * So a stale twin that happens to be older silently outranks the real session.
+ * The user is locked out with no in-app escape, because signing in again always
+ * writes the NEWER cookie — the one that can never win. Measured on prod
+ * 2026-08-06: `dead; good` resolved to null, `good; dead` resolved to the
+ * session. Identical cookies; only the order differed.
+ *
+ * `resolveSession` removes the ambiguity at the point of use: with one cookie it
+ * is exactly `getSession`, and with several it asks about each in isolation and
+ * takes the one that actually verifies. Possession of a live session token is
+ * what authenticates — never its position in the jar.
+ */
+
+/** Better Auth's session cookie, bare and with the `__Secure-` prefix. */
+const SESSION_COOKIE_BASENAME = 'better-auth.session_token';
+const SESSION_COOKIE_NAMES = [
+  SESSION_COOKIE_BASENAME,
+  `__Secure-${SESSION_COOKIE_BASENAME}`,
+];
+
+/**
+ * The minimum of Better Auth's surface this module needs. Deliberately generic:
+ * the return type is inferred from the caller's own `auth`, so wrapping
+ * `getSession` never widens what a call site sees.
+ */
+type SessionReader = {
+  api: { getSession: (opts: { headers: Headers }) => Promise<any> };
+};
+type SessionOf<A extends SessionReader> = Awaited<ReturnType<A['api']['getSession']>>;
+
+/**
+ * Every session-cookie value in a `Cookie` header, in the order sent.
+ *
+ * Values come back raw — only `getSession` can say which of them verify.
+ * Matching is on the exact name before `=`, so a `<name>_other` cookie is never
+ * mistaken for `<name>`.
+ */
+export function sessionCookieCandidates(cookieHeader: string | null | undefined): string[] {
+  if (!cookieHeader) return [];
+  const values: string[] = [];
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (!SESSION_COOKIE_NAMES.includes(part.slice(0, eq).trim())) continue;
+    const value = part.slice(eq + 1).trim();
+    if (value) values.push(value);
+  }
+  return values;
+}
+
+/** A session object Better Auth considers authenticated. */
+function isLive(session: any): boolean {
+  return Boolean(session?.user && session.session);
+}
+
+/**
+ * Resolve the request's session without letting cookie order decide it.
+ *
+ * Drop-in for `auth.api.getSession({ headers })`. The single-cookie path — every
+ * ordinary request — is byte-for-byte the old behaviour and costs nothing extra;
+ * the extra lookups happen only for a jar that is already broken.
+ *
+ * Note the candidate header keeps every other header intact and rewrites only
+ * `Cookie`, so `Authorization: Bearer` and origin checks behave as before.
+ */
+export async function resolveSession<A extends SessionReader>(
+  auth: A,
+  headers: Headers
+): Promise<SessionOf<A>> {
+  const candidates = sessionCookieCandidates(headers.get('cookie'));
+  if (candidates.length <= 1) return await auth.api.getSession({ headers });
+
+  for (const candidate of candidates) {
+    const single = new Headers(headers);
+    single.set('cookie', `${SESSION_COOKIE_BASENAME}=${candidate}`);
+    const session = await auth.api.getSession({ headers: single });
+    if (isLive(session)) return session;
+  }
+  // Every candidate was dead. Resolving on merit must not become "authenticate
+  // on anything" — an ambiguous jar with no live token is still no session.
+  return null as SessionOf<A>;
+}

--- a/packages/server/src/auth/resolve-session.ts
+++ b/packages/server/src/auth/resolve-session.ts
@@ -140,15 +140,62 @@ export async function resolveSession<A extends SessionReader>(
 
   const companions = nonSessionCookies(cookieHeader);
   for (const candidate of candidates.slice(0, MAX_CANDIDATES)) {
-    const single = new Headers(headers);
-    single.set(
-      'cookie',
-      [...companions, `${candidate.name}=${candidate.value}`].join('; ')
-    );
-    const session = await auth.api.getSession({ headers: single });
+    const session = await auth.api.getSession({
+      headers: probeHeaders(headers, companions, candidate),
+    });
     if (isLive(session)) return session;
   }
   // Every candidate was dead. Resolving on merit must not become "authenticate
   // on anything" — an ambiguous jar with no live token is still no session.
   return null as SessionOf<A>;
+}
+
+/** A copy of `headers` whose jar carries the companions and exactly one twin. */
+function probeHeaders(
+  headers: Headers,
+  companions: string[],
+  candidate: SessionCookieCandidate
+): Headers {
+  const probe = new Headers(headers);
+  probe.set(
+    'cookie',
+    [...companions, `${candidate.name}=${candidate.value}`].join('; ')
+  );
+  return probe;
+}
+
+/**
+ * Headers with the ambiguity already removed — the jar reduced to its live
+ * session cookie, or to none if no candidate verifies.
+ *
+ * `resolveSession` is for code that wants the session. This is for code that
+ * must hand the request to someone else who will resolve it themselves — namely
+ * Better Auth's own `/api/auth/*` handler, which reads the raw jar and would
+ * otherwise take the first cookie and answer `null` for a bricked browser. That
+ * endpoint is how the web app asks "am I signed in", so leaving it order-
+ * dependent would keep the brick visible in the UI even with every internal
+ * call site fixed.
+ *
+ * Returns `headers` unchanged for an ordinary jar, so the common path is free.
+ */
+export async function collapseSessionCookies<A extends SessionReader>(
+  auth: A,
+  headers: Headers
+): Promise<Headers> {
+  const cookieHeader = headers.get('cookie');
+  const candidates = sessionCookieCandidates(cookieHeader);
+  if (candidates.length <= 1) return headers;
+
+  const companions = nonSessionCookies(cookieHeader);
+  for (const candidate of candidates.slice(0, MAX_CANDIDATES)) {
+    const probe = probeHeaders(headers, companions, candidate);
+    if (isLive(await auth.api.getSession({ headers: probe }))) return probe;
+  }
+  // No candidate verifies. Send the jar with no session cookie at all rather
+  // than an arbitrary dead one: "not signed in" is the honest answer, and it
+  // keeps sign-in and sign-out on this request from acting on a dead twin.
+  const stripped = new Headers(headers);
+  if (companions.length > 0) stripped.set('cookie', companions.join('; '));
+  else stripped.delete('cookie');
+  return stripped;
 }

--- a/packages/server/src/auth/resolve-session.ts
+++ b/packages/server/src/auth/resolve-session.ts
@@ -137,8 +137,9 @@ export async function resolveSession<A extends SessionReader>(
 ): Promise<SessionOf<A>> {
   const live = await findLiveProbe(auth, headers);
   if (!live) return await auth.api.getSession({ headers });
-  // Every candidate was dead. Resolving on merit must not become "authenticate
-  // on anything" — an ambiguous jar with no live token is still no session.
+  // `session` is null when no candidate verified. Resolving on merit must not
+  // become "authenticate on anything": an ambiguous jar with no live token is
+  // still no session.
   return (live.session ?? null) as SessionOf<A>;
 }
 
@@ -160,18 +161,18 @@ async function findLiveProbe<A extends SessionReader>(
   if (candidates.length <= 1) return null;
 
   const companions = nonSessionCookies(cookieHeader);
-  let last = headers;
   for (const candidate of candidates.slice(0, MAX_CANDIDATES)) {
     const probe = new Headers(headers);
     probe.set(
       'cookie',
       [...companions, `${candidate.name}=${candidate.value}`].join('; ')
     );
-    last = probe;
     const session = await auth.api.getSession({ headers: probe });
     if (isLive(session)) return { headers: probe, session };
   }
-  return { headers: last, session: null };
+  // Nothing verified. `headers` here is only a placeholder — every caller
+  // branches on `session` before it reads `headers`.
+  return { headers, session: null };
 }
 
 /**

--- a/packages/server/src/auth/resolve-session.ts
+++ b/packages/server/src/auth/resolve-session.ts
@@ -1,54 +1,30 @@
 /**
  * Session resolution that does not depend on cookie order.
  *
- * The same auth cookie name can exist at two scopes at once — host-only
- * (`app.lobu.ai`) and domain-scoped (`Domain=.lobu.ai`) — and a browser sends
- * BOTH in one `Cookie` header. Which one authenticates is then decided purely
- * by position, and the position is not ours to choose:
- *
- *   RFC 6265 §5.4  browser sends equal-path cookies oldest-first
- *   better-call    parseCookies keeps the FIRST occurrence (`if (!cookies.has(key))`)
- *   better-auth    getSignedCookie reads that one and stops
- *
- * So a stale twin that happens to be older silently outranks the real session.
- * The user is locked out with no in-app escape, because signing in again always
- * writes the NEWER cookie — the one that can never win. Measured on prod
- * 2026-08-06: `dead; good` resolved to null, `good; dead` resolved to the
- * session. Identical cookies; only the order differed.
- *
- * `resolveSession` removes the ambiguity at the point of use: with one cookie it
- * is exactly `getSession`, and with several it asks about each in isolation and
- * takes the one that actually verifies. Possession of a live session token is
- * what authenticates — never its position in the jar.
+ * One auth cookie name can exist at two scopes at once — host-only and
+ * `Domain=`-scoped — and the browser sends both in one header. Position then
+ * decides who authenticates, and position is not ours to choose: RFC 6265 §5.4
+ * sends the oldest first, better-call's `parseCookies` keeps the first
+ * occurrence (`if (!cookies.has(key))`), and `getSignedCookie` reads that one
+ * and stops. An older stale twin therefore outranks every later sign-in, which
+ * can never win because it is always the newer cookie. Prod, 2026-08-06:
+ * `dead; good` → null, `good; dead` → the session.
  */
 
 import { sessionCookieName } from './session-cookie-scope';
 
-/**
- * Both spellings can be present at once: Better Auth adds the `__Secure-`
- * prefix only when issuing secure cookies, and a jar can outlive that switch.
- */
+/** Both spellings coexist: a jar can outlive an http→https switch. */
 const SESSION_COOKIE_NAMES = [sessionCookieName(false), sessionCookieName(true)];
 
 /**
- * How many candidates one request may cost us.
- *
  * `Cookie` is attacker-controlled and each probe is a session lookup, so an
- * unbounded loop turns one unauthenticated request into ~100 of them. A real
- * jar holds a twin or two (host-only, domain, occasionally a parent domain, and
- * at most one leftover of the other spelling), so this is far above anything a
- * browser produces and still bounds the cost.
+ * unbounded loop amplifies one request into ~100. Real jars hold two or three.
  */
 const MAX_CANDIDATES = 8;
 
-/** One session cookie as the jar carries it: its exact name and raw value. */
 type SessionCookieCandidate = { name: string; value: string };
 
-/**
- * The minimum of Better Auth's surface this module needs. Deliberately generic:
- * the return type is inferred from the caller's own `auth`, so wrapping
- * `getSession` never widens what a call site sees.
- */
+/** Generic, so wrapping `getSession` never widens what a call site sees. */
 type SessionReader = {
   api: { getSession: (opts: { headers: Headers }) => Promise<any> };
 };
@@ -57,13 +33,8 @@ type SessionOf<A extends SessionReader> = Awaited<ReturnType<A['api']['getSessio
 /**
  * Every session cookie in a `Cookie` header, in the order sent.
  *
- * Each candidate keeps the name it arrived under, because that name is what
- * decides whether Better Auth can see it at all: `getSession` reads exactly one
- * name, the one `useSecureCookies` derives, and is blind to the other spelling.
- *
- * Values come back raw — only `getSession` can say which of them verify.
- * Matching is on the exact name before `=`, so a `<name>_other` cookie is never
- * mistaken for `<name>`.
+ * Each keeps the name it arrived under: `getSession` reads exactly one name and
+ * is blind to the other spelling, so renaming a candidate hides it entirely.
  */
 export function sessionCookieCandidates(
   cookieHeader: string | null | undefined
@@ -73,6 +44,7 @@ export function sessionCookieCandidates(
   for (const part of cookieHeader.split(';')) {
     const eq = part.indexOf('=');
     if (eq === -1) continue;
+    // Exact name, so `<name>_other` is never mistaken for `<name>`.
     const name = part.slice(0, eq).trim();
     if (!SESSION_COOKIE_NAMES.includes(name)) continue;
     const value = part.slice(eq + 1).trim();
@@ -82,34 +54,25 @@ export function sessionCookieCandidates(
 }
 
 /**
- * A session object that authenticates someone.
- *
- * The predicate is `user`, not `user && session`, because `user` is the weakest
- * thing any caller requires — `auth/middleware.ts`, `auth/oauth/routes.ts`,
- * `connect/routes.ts` and `worker-api/auth-runs.ts` all check `session?.user`
- * alone. Demanding more here would reject, on a duplicated jar, a session those
- * callers accept on a clean one. A dead cookie yields `null` either way, so this
- * costs nothing in candidate selection.
+ * `user`, not `user && session`: four call sites (auth/middleware.ts,
+ * auth/oauth/routes.ts, connect/routes.ts, worker-api/auth-runs.ts) check
+ * `user` alone, so a stricter test would reject on a duplicated jar what they
+ * accept on a clean one.
  */
 function isLive(session: any): boolean {
   return Boolean(session?.user);
 }
 
 /**
- * The jar minus its session cookies — everything a probe must carry unchanged.
- *
- * Better Auth reads companions alongside the session token, and they change how
- * `getSession` behaves: `better-auth.dont_remember` gates session-expiry
- * refresh, and `better-auth.session_data` is its cookie cache. Dropping the
- * whole header would give a duplicated jar different refresh semantics from a
- * clean one — a difference that has nothing to do with which twin is live.
+ * The jar minus its session cookies. Companions must survive a probe:
+ * `better-auth.dont_remember` gates session-expiry refresh, so dropping it
+ * would give a duplicated jar different refresh terms than a clean one.
  */
 function nonSessionCookies(cookieHeader: string | null): string[] {
   if (!cookieHeader) return [];
   const kept: string[] = [];
   for (const part of cookieHeader.split(';')) {
     const pair = part.trim();
-    if (!pair) continue;
     const eq = pair.indexOf('=');
     if (eq === -1) continue;
     if (SESSION_COOKIE_NAMES.includes(pair.slice(0, eq).trim())) continue;
@@ -119,17 +82,10 @@ function nonSessionCookies(cookieHeader: string | null): string[] {
 }
 
 /**
- * Resolve the request's session without letting cookie order decide it.
+ * Drop-in for `auth.api.getSession({ headers })` that resolves on merit.
  *
- * Drop-in for `auth.api.getSession({ headers })`. The single-cookie path — every
- * ordinary request — is byte-for-byte the old behaviour and costs nothing extra;
- * the extra lookups happen only for a jar that is already broken.
- *
- * A probe changes exactly one thing: which session cookie is in the jar. Every
- * other header survives, so `Authorization: Bearer` and origin checks behave as
- * before; every non-session cookie survives, so Better Auth's companions still
- * apply; and the candidate keeps the name it arrived under, because renaming it
- * would hide it from `getSession` entirely.
+ * A one-cookie jar takes the original call unchanged; the extra lookups happen
+ * only for a jar that is already broken.
  */
 export async function resolveSession<A extends SessionReader>(
   auth: A,
@@ -137,20 +93,20 @@ export async function resolveSession<A extends SessionReader>(
 ): Promise<SessionOf<A>> {
   const live = await findLiveProbe(auth, headers);
   if (!live) return await auth.api.getSession({ headers });
-  // `session` is null when no candidate verified. Resolving on merit must not
-  // become "authenticate on anything": an ambiguous jar with no live token is
-  // still no session.
+  // Resolving on merit must not become "authenticate on anything".
   return (live.session ?? null) as SessionOf<A>;
 }
 
 /**
- * Probe an ambiguous jar one candidate at a time, and report what verified.
+ * Probe an ambiguous jar one candidate at a time.
  *
- * `null` means the jar was not ambiguous — one session cookie or none — so the
- * caller should just use the headers it already has. Otherwise the result
- * carries the probe headers and the session they produced, and `session` is
- * `null` when no candidate verified. Returning both means the winning lookup is
- * never repeated.
+ * `null` when the jar is not ambiguous. Otherwise the winning headers and the
+ * session they produced — returning both keeps the lookup from being repeated —
+ * with `session: null` when nothing verified.
+ *
+ * A probe changes exactly one thing: which session cookie is present. Other
+ * headers and other cookies ride along, so `Authorization: Bearer` and origin
+ * checks behave as before.
  */
 async function findLiveProbe<A extends SessionReader>(
   auth: A,
@@ -170,24 +126,18 @@ async function findLiveProbe<A extends SessionReader>(
     const session = await auth.api.getSession({ headers: probe });
     if (isLive(session)) return { headers: probe, session };
   }
-  // Nothing verified. `headers` here is only a placeholder — every caller
-  // branches on `session` before it reads `headers`.
+  // Placeholder headers: every caller branches on `session` before reading them.
   return { headers, session: null };
 }
 
 /**
- * Headers with the ambiguity already removed — the jar reduced to its live
- * session cookie, or to none if no candidate verifies.
+ * The jar with its ambiguity already removed, for code that must hand the
+ * request to a reader that resolves it itself — Better Auth's `/api/auth/*`
+ * handler. That is where `get-session` lives, the call the web app uses to ask
+ * whether it is signed in, so leaving it order-dependent would keep the brick
+ * visible in the UI with every internal call site fixed.
  *
- * `resolveSession` is for code that wants the session. This is for code that
- * must hand the request to someone else who will resolve it themselves — namely
- * Better Auth's own `/api/auth/*` handler, which reads the raw jar and would
- * otherwise take the first cookie and answer `null` for a bricked browser. That
- * endpoint is how the web app asks "am I signed in", so leaving it order-
- * dependent would keep the brick visible in the UI even with every internal
- * call site fixed.
- *
- * Returns `headers` unchanged for an ordinary jar, so the common path is free.
+ * Ordinary jars come back by identity, so the common path does not even copy.
  */
 export async function collapseSessionCookies<A extends SessionReader>(
   auth: A,
@@ -197,9 +147,8 @@ export async function collapseSessionCookies<A extends SessionReader>(
   if (!live) return headers;
   if (live.session) return live.headers;
 
-  // No candidate verifies. Send the jar with no session cookie at all rather
-  // than an arbitrary dead one: "not signed in" is the honest answer, and it
-  // keeps sign-in and sign-out on this request from acting on a dead twin.
+  // Nothing verified. Strip the session cookie rather than pass an arbitrary
+  // dead twin, so sign-in and sign-out on this request cannot act on one.
   const companions = nonSessionCookies(headers.get('cookie'));
   const stripped = new Headers(headers);
   if (companions.length > 0) stripped.set('cookie', companions.join('; '));

--- a/packages/server/src/auth/session-cookie-scope.ts
+++ b/packages/server/src/auth/session-cookie-scope.ts
@@ -3,22 +3,24 @@
  *
  * The same cookie name can exist at two scopes at once — host-only
  * (`app.lobu.ai`) and domain-scoped (`Domain=.lobu.ai`). A browser sends BOTH
- * in one `Cookie` header, the server resolves the FIRST, and RFC 6265 §5.4
- * orders equal-path cookies oldest-first. A stale host-only session cookie is
+ * in one `Cookie` header, Better Auth reads only the FIRST, and RFC 6265 §5.4
+ * orders equal-path cookies oldest-first. A stale host-only session cookie was
  * therefore permanently unbeatable: every later sign-in writes a strictly
- * NEWER cookie that can never take precedence, so the user is locked out of
+ * NEWER cookie that can never take precedence, so the user was locked out of
  * the app with no in-app way to recover. Measured on prod 2026-08-06 —
- * `dead; good` resolves to `null` while `good; dead` resolves to the session.
+ * `dead; good` resolved to `null` while `good; dead` resolved to the session.
  *
  * Host-only twins are produced by any path that sets the session cookie
  * without the configured zone: the `/exchange-token` and `/local-init` deep
  * links used to, and `document.cookie` planting (see docs/BROWSER_TESTING.md)
  * still can.
  *
- * The cure is to make sign-in authoritative. Whenever a response sets a
- * domain-scoped auth cookie, it also expires the host-only twin of that same
- * name, so a single sign-in collapses the jar back to one cookie — which also
- * self-heals an already-bricked browser on its next sign-in.
+ * Two things answer that, and this module is the second one. `resolveSession`
+ * (auth/resolve-session.ts) takes the ordering away from the browser at read
+ * time, so a duplicated jar can no longer lock anyone out. This module then
+ * collapses the jar: whenever a response sets a domain-scoped auth cookie, it
+ * also expires the host-only twin of that same name, so a single sign-in leaves
+ * one cookie behind — self-healing a browser that already carries a twin.
  */
 
 /** Better Auth's session cookie name, before the `__Secure-` prefix. */

--- a/packages/server/src/auth/session-cookie-scope.ts
+++ b/packages/server/src/auth/session-cookie-scope.ts
@@ -36,28 +36,6 @@ export function sessionCookieName(isHttps: boolean): string {
 }
 
 /**
- * Count how many times `name` appears in a `Cookie` request header.
- *
- * More than one is the brick signature: the request carries the same cookie at
- * two scopes and the loser is invisible to every log we keep. Matching is on
- * the exact name before `=`, so neither a `<name>_other` cookie nor a
- * `__Secure-<name>` cookie is mistaken for `<name>`.
- */
-export function countNamedCookies(
-	cookieHeader: string | null | undefined,
-	name: string,
-): number {
-	if (!cookieHeader) return 0;
-	let count = 0;
-	for (const part of cookieHeader.split(";")) {
-		const eq = part.indexOf("=");
-		if (eq === -1) continue;
-		if (part.slice(0, eq).trim() === name) count += 1;
-	}
-	return count;
-}
-
-/**
  * A `Set-Cookie` value that deletes the HOST-ONLY cookie called `name`.
  *
  * Deliberately carries no `Domain` attribute: cookie deletion matches on

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -55,6 +55,7 @@ import {
   exchangeCodeForTokens,
   fetchUserInfoWithRaw,
 } from './oauth-providers';
+import { resolveSession } from '../auth/resolve-session';
 
 interface OAuthAuthConfig {
   provider: string;
@@ -681,7 +682,7 @@ async function resolveConnectActorUserId(
 
   try {
     const auth = await createAuth(c.env, c.req.raw);
-    const session = await auth.api.getSession({ headers: c.req.raw.headers });
+    const session = await resolveSession(auth, c.req.raw.headers);
     return session?.user?.id ?? null;
   } catch {
     return null;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -960,6 +960,7 @@ app.post("/api/workers/complete-action", completeActionRun);
 // against a paired Owletto extension. See dispatch-chrome-action.ts.
 import { dispatchChromeAction } from "./worker-api/dispatch-chrome-action";
 import { stampSlackIdentityForUser } from "./auth/subject-identities";
+import { resolveSession } from './auth/resolve-session';
 
 app.post("/api/workers/dispatch-chrome-action", dispatchChromeAction);
 app.post("/api/workers/complete-embeddings", completeEmbeddings);
@@ -1073,7 +1074,7 @@ app.get("/api/organizations", async (c) => {
 	let userId: string | null = null;
 	try {
 		const auth = await createAuth(c.env);
-		const session = await auth.api.getSession({ headers: c.req.raw.headers });
+		const session = await resolveSession(auth, c.req.raw.headers);
 		userId = session?.session?.userId || null;
 	} catch {
 		// No session
@@ -2387,7 +2388,7 @@ app.post("/api/:orgSlug/join", async (c) => {
 	}
 
 	const auth = await createAuth(c.env);
-	const session = await auth.api.getSession({ headers: c.req.raw.headers });
+	const session = await resolveSession(auth, c.req.raw.headers);
 	const userId = session?.session?.userId;
 	if (!userId) {
 		return c.json(
@@ -2445,7 +2446,7 @@ async function resolveClaimSessionUser(
 ): Promise<string | null> {
 	try {
 		const auth = await createAuth(env);
-		const session = await auth.api.getSession({ headers: req.headers });
+		const session = await resolveSession(auth, req.headers);
 		return session?.user?.id ?? null;
 	} catch {
 		return null;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -652,6 +652,20 @@ app.on(["GET", "POST"], "/api/auth/*", async (c) => {
 			});
 		}
 	}
+	// Better Auth reads the raw jar and takes the FIRST session cookie, so a
+	// browser carrying a stale twin gets `null` from /api/auth/get-session — the
+	// call the web app uses to ask whether it is signed in. Hand it a jar already
+	// reduced to the live cookie. Why: auth/resolve-session.ts.
+	const collapsed = await collapseSessionCookies(auth, request.headers);
+	if (collapsed !== request.headers) {
+		request = new Request(request.url, {
+			method: request.method,
+			headers: collapsed,
+			body: request.method === "GET" || request.method === "HEAD"
+				? undefined
+				: await request.blob(),
+		});
+	}
 	const response = await auth.handler(request);
 	// Collapse the cookie jar back to a single scope, so sign-in is authoritative
 	// for every auth method at once. Why: auth/session-cookie-scope.ts.
@@ -960,7 +974,7 @@ app.post("/api/workers/complete-action", completeActionRun);
 // against a paired Owletto extension. See dispatch-chrome-action.ts.
 import { dispatchChromeAction } from "./worker-api/dispatch-chrome-action";
 import { stampSlackIdentityForUser } from "./auth/subject-identities";
-import { resolveSession } from './auth/resolve-session';
+import { collapseSessionCookies, resolveSession } from './auth/resolve-session';
 
 app.post("/api/workers/dispatch-chrome-action", dispatchChromeAction);
 app.post("/api/workers/complete-embeddings", completeEmbeddings);

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -50,6 +50,7 @@ import {
 	createPostgresAgentConnectionStore,
 } from "./stores/postgres-stores";
 import { getErrorMessage } from "@lobu/core";
+import { resolveSession } from '../auth/resolve-session';
 
 // Cache of (userId → orgId) lookups. Keyed by userId; users only see their
 // own row swap when they leave/join orgs, which doesn't happen often. The
@@ -223,7 +224,7 @@ export function createLobuAuthBridge() {
 		//    Only runs when the request did NOT present an owl_pat_* bearer.
 		try {
 			const auth = await createAuth(c.env, c.req.raw);
-			const session = await auth.api.getSession({ headers: c.req.raw.headers });
+			const session = await resolveSession(auth, c.req.raw.headers);
 			if (session?.user && session.session) {
 				c.set("user", session.user);
 				c.set("session", session.session);

--- a/packages/server/src/worker-api/auth-runs.ts
+++ b/packages/server/src/worker-api/auth-runs.ts
@@ -14,6 +14,7 @@ import { createAuth } from '../auth';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { errorMessage } from '../utils/errors';
+import { resolveSession } from '../auth/resolve-session';
 
 /**
  * GET /api/auth-runs/active?connection_id=X
@@ -32,7 +33,7 @@ export async function getActiveAuthRun(c: Context<{ Bindings: Env }>) {
     }
 
     const auth = await createAuth(c.env, c.req.raw);
-    const session = await auth.api.getSession({ headers: c.req.raw.headers });
+    const session = await resolveSession(auth, c.req.raw.headers);
     const userId = session?.user?.id;
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401);
@@ -73,7 +74,7 @@ export async function getAuthRun(c: Context<{ Bindings: Env }>) {
     }
 
     const auth = await createAuth(c.env, c.req.raw);
-    const session = await auth.api.getSession({ headers: c.req.raw.headers });
+    const session = await resolveSession(auth, c.req.raw.headers);
     const userId = session?.user?.id;
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401);
@@ -171,7 +172,7 @@ export async function postAuthSignal(c: Context<{ Bindings: Env }>) {
     }
 
     const auth = await createAuth(c.env, c.req.raw);
-    const session = await auth.api.getSession({ headers: c.req.raw.headers });
+    const session = await resolveSession(auth, c.req.raw.headers);
     const userId = session?.user?.id;
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401);

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -18,10 +18,6 @@ import type {
   ResolvedOwner,
   WorkspaceProvider,
 } from './types';
-import {
-  countNamedCookies,
-  sessionCookieName,
-} from '../auth/session-cookie-scope';
 import { listManagedAuthConnectorOffers } from './managed-auth-discovery';
 import {
   memberRoleCache,
@@ -533,25 +529,17 @@ export class MultiTenantProvider implements WorkspaceProvider {
       // up — resolveSession decides which one is live.
       const sessionCacheKey = candidates.length === 1 ? candidates[0] : null;
 
-      // A duplicate at a narrower scope shadows the real session and is
-      // otherwise invisible — `get-session` just answers 200 null forever.
-      // Warn so the next occurrence is one log line instead of an afternoon.
-      // Why: auth/session-cookie-scope.ts.
-      for (const name of [
-        sessionCookieName(true),
-        sessionCookieName(false),
-      ]) {
-        const seen = countNamedCookies(cookieHeader, name);
-        if (seen > 1) {
-          // Include the host: a bricked browser emits this on EVERY request,
-          // and without knowing which host issued the twin the line says what
-          // happened but not where to go fix it.
-          logger.warn(
-            `[MultiTenantProvider] ${seen} "${name}" cookies in one request ` +
-              `(host=${c.req.header('host') || 'unknown'}) — a duplicate ` +
-              'at a narrower scope shadows the real session and blocks sign-in until expired'
-          );
-        }
+      // A duplicated session cookie no longer decides anything — resolveSession
+      // picks the live one regardless of order — but it still means the browser
+      // is carrying a twin that should not exist, and it is otherwise invisible.
+      // Log it so the source can be found. Why: auth/session-cookie-scope.ts.
+      if (candidates.length > 1) {
+        // The host matters: it is what identifies which origin planted the twin.
+        logger.warn(
+          `[MultiTenantProvider] ${candidates.length} session cookies in one request ` +
+            `(host=${c.req.header('host') || 'unknown'}) — a duplicate at a narrower ` +
+            'scope; resolving on merit, but the jar should be collapsed on next sign-in'
+        );
       }
 
       let session: { user: any; session: any } | null = null;

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -29,6 +29,7 @@ import {
   ownerCache,
   sessionCache,
 } from './multi-tenant-caches';
+import { resolveSession, sessionCookieCandidates } from '../auth/resolve-session';
 
 /**
  * Path namespaces that don't carry an org context. Authenticated requests to
@@ -526,12 +527,11 @@ export class MultiTenantProvider implements WorkspaceProvider {
     //    plugin, which translates the header into a session lookup before
     //    `auth.api.getSession` runs below.
     try {
-      // Extract session token for cache key
-      const cookieHeader = c.req.header('Cookie') || '';
-      const sessionTokenMatch = cookieHeader.match(
-        /(?:__Secure-)?better-auth\.session_token=([^;]+)/
-      );
-      const sessionCacheKey = sessionTokenMatch?.[1] || null;
+      const candidates = sessionCookieCandidates(c.req.header('Cookie'));
+      // The ordinary jar holds one session cookie and its value is the cache key.
+      // With a duplicate the key is ambiguous, so there is nothing safe to look
+      // up — resolveSession decides which one is live.
+      const sessionCacheKey = candidates.length === 1 ? candidates[0] : null;
 
       // A duplicate at a narrower scope shadows the real session and is
       // otherwise invisible — `get-session` just answers 200 null forever.
@@ -565,7 +565,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
       }
       if (!cacheHit) {
         const auth = await createAuth(c.env);
-        session = await auth.api.getSession({ headers: c.req.raw.headers });
+        session = await resolveSession(auth, c.req.raw.headers);
         // Only cache valid sessions. Caching `null` would let an explicitly
         // revoked or expired session continue to resolve to "no auth" for
         // the cache TTL (30s) instead of returning the upstream's fresh

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -527,18 +527,23 @@ export class MultiTenantProvider implements WorkspaceProvider {
       // The ordinary jar holds one session cookie and its value is the cache key.
       // With a duplicate the key is ambiguous, so there is nothing safe to look
       // up — resolveSession decides which one is live.
-      const sessionCacheKey = candidates.length === 1 ? candidates[0] : null;
+      const sessionCacheKey =
+        candidates.length === 1 ? candidates[0].value : null;
 
       // A duplicated session cookie no longer decides anything — resolveSession
       // picks the live one regardless of order — but it still means the browser
       // is carrying a twin that should not exist, and it is otherwise invisible.
       // Log it so the source can be found. Why: auth/session-cookie-scope.ts.
       if (candidates.length > 1) {
-        // The host matters: it is what identifies which origin planted the twin.
+        // Host and names both matter: the host says which origin planted the
+        // twin, and the names say whether it is a second scope of one name or a
+        // leftover of the other spelling — different causes, different fixes.
         logger.warn(
           `[MultiTenantProvider] ${candidates.length} session cookies in one request ` +
-            `(host=${c.req.header('host') || 'unknown'}) — a duplicate at a narrower ` +
-            'scope; resolving on merit, but the jar should be collapsed on next sign-in'
+            `(host=${c.req.header('host') || 'unknown'}, names=${candidates
+              .map((candidate) => candidate.name)
+              .join(',')}) — resolving on merit, but the jar should be ` +
+            'collapsed on next sign-in'
         );
       }
 


### PR DESCRIPTION
## What

A browser can hold the same auth cookie name at two scopes at once — host-only (`app.lobu.ai`) and domain-scoped (`Domain=.lobu.ai`) — and sends **both** in one `Cookie` header. Which one authenticated was decided purely by position:

| layer | behaviour |
|---|---|
| RFC 6265 §5.4 | browser sends equal-path cookies **oldest-first** |
| better-call `parseCookies` | keeps the **first** occurrence (`if (!cookies.has(key))`) |
| better-auth `getSignedCookie` | reads that one and stops |

None of that is ours to choose. So a stale twin that happens to be older silently outranks the real session — and signing in again cannot help, because a fresh cookie is always the *newer* one. That is the permanent-login-brick incident.

`resolveSession()` removes the ambiguity at the point of use. One cookie: byte-for-byte the old call, no added cost. Several: each candidate is resolved in isolation and the live one wins. **Possession of a valid session token authenticates; its position never does.**

#2558 was containment — it stops new twins being minted and collapses the jar on sign-in. This is the actual fix: it makes an already-poisoned jar resolve correctly on the *next request*, with no sign-in needed.

## Fixed as a class, not an instance

All **12** call sites passed the raw ambiguous header to `getSession`. Every one had the same hole:

```
multi-tenant.ts · lobu/gateway.ts · index.ts (×3) · auth/middleware.ts
auth/oauth/routes.ts · worker-api/auth-runs.ts (×3) · connect/routes.ts
```

## Red → green

Reproduced through the full app stack on embedded Postgres — same user, same two cookies, only the order differs.

**Before**
```
✓ authenticates when the live cookie is FIRST in the jar
× authenticates when a DEAD twin is first — the permanent-brick case
  → AssertionError: expected [] to include 'dup-dead-first'

Tests  1 failed | 3 passed (4)
```

**After**
```
✓ src/auth/__tests__/duplicate-session-cookie.test.ts (4 tests) 670ms

Tests  4 passed (4)
```

**Mutation check** — reverting to the raw header (`candidates.length >= 0`) fails exactly the brick test, 3 passed | 1 failed; restored, 4 passed.

The third test is the guard that stops this becoming "authenticate on anything": an ambiguous jar with no live token is still no session.

## Verification

- `src/auth/__tests__/` — **170/170** pass (includes the pre-existing suites the class-wide change touches)
- `session-cookie-scope.test.ts` — 13/13
- `tsc --noEmit` exit 0 (unpiped; an earlier failure was a stale `@lobu/core` dist predating #2576, clean after rebuild)
- `make pre-pr` — `✅ pre-pr gates clean`

## Also

Consolidated on rebase: one owner for the cookie name, and `countNamedCookies` **deleted** rather than left dead — `sessionCookieCandidates` already returns the values it counted. The duplicate-cookie warning said a twin "blocks sign-in until expired"; this PR makes that false, so the text now says what is true.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication when duplicate session cookies are present.
  * Supports secure and standard session cookies regardless of order.
  * Falls back to valid sessions when an earlier cookie is stale or invalid.
  * Preserves other request cookies and headers during session validation.
  * Limits session-cookie checks to eight candidates for predictable processing.

* **Tests**
  * Added coverage for duplicate, invalid, missing, and mixed session-cookie scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->