### PR TITLE
test(core): assert every worker-token claim survives the round trip

### DIFF
--- a/packages/core/src/__tests__/worker-auth.test.ts
+++ b/packages/core/src/__tests__/worker-auth.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   __resetEncryptionKeyCacheForTests,
@@ -9,6 +11,7 @@ import {
   verifyEgressProxyToken,
   verifyWorkerToken,
   type WorkerTokenData,
+  type WorkerTokenOptions,
 } from "../worker/auth";
 
 // 32-byte key, hex encoded — matches existing encryption.test.ts pattern.
@@ -16,6 +19,46 @@ const TEST_KEY =
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 const ENV_KEYS = ["ENCRYPTION_KEY", "WORKER_TOKEN_TTL_MS"] as const;
+
+/**
+ * Every claim the token can carry, each with a distinct value.
+ *
+ * The previous round-trip test listed eight claims by hand under the name
+ * "all optional fields" and stayed at those eight as the interface grew to 21,
+ * so `executionMode`, `behaviorRunId`, `organizationId`, `runId`, `messageId`,
+ * `source`, `allowedDomains` and `deniedDomains` all shipped with no proof they
+ * survived the token. Deleting `executionMode` from the generated payload left
+ * all 33 tests in this file green, and that claim is what both capture lanes
+ * read — the internal-route guard (`gateway/routes/internal/capture-mode.ts`)
+ * and the SDK lane via `mcpAuthInfo` — so an eval replay would have performed
+ * real side effects against the org it was scoring.
+ *
+ * Kept as one fixture so the round-trip test and the coverage guard below
+ * cannot disagree about what "every claim" means.
+ */
+const ALL_CLAIMS: Required<WorkerTokenOptions> = {
+  channelId: "C-all",
+  teamId: "T-all",
+  agentId: "agent-all",
+  organizationId: "org-all",
+  connectionId: "conn-all",
+  responseThreadId: "slack:C-all:thread-1",
+  platform: "slack",
+  source: "watcher-run",
+  executionMode: "capture",
+  behaviorRunId: 874626,
+  sessionKey: "sess-all",
+  traceId: "trace-all",
+  runId: 4321,
+  messageId: "msg-all",
+  adminTools: ["manage_behaviors"],
+  adminActorUserId: "user-admin",
+  runtimeProviderId: "provider-all",
+  sandboxId: "sandbox-all",
+  allowedDomains: ["allowed.example"],
+  deniedDomains: ["blocked.example"],
+  nixPackages: ["ripgrep"],
+};
 
 describe("worker auth token", () => {
   let saved: Record<string, string | undefined> = {};
@@ -77,26 +120,74 @@ describe("worker auth token", () => {
     expect(d.timestamp).toBeGreaterThan(0);
   });
 
-  test("verifyWorkerToken round-trips all optional fields", () => {
-    const token = generateWorkerToken("user-2", "conv-2", "deploy-B", {
-      channelId: "C2",
-      teamId: "T2",
-      agentId: "agent-x",
-      connectionId: "conn-9",
-      responseThreadId: "slack:C2:thread-9",
-      platform: "slack",
-      sessionKey: "sess-abc",
-      traceId: "trace-zzz",
-    });
-    const d = verifyWorkerToken(token) as WorkerTokenData;
+  test("verifyWorkerToken round-trips EVERY claim", () => {
+    const d = verifyWorkerToken(
+      generateWorkerToken("user-2", "conv-2", "deploy-B", ALL_CLAIMS)
+    ) as WorkerTokenData;
     expect(d).not.toBeNull();
-    expect(d.teamId).toBe("T2");
-    expect(d.agentId).toBe("agent-x");
-    expect(d.connectionId).toBe("conn-9");
-    expect(d.responseThreadId).toBe("slack:C2:thread-9");
-    expect(d.platform).toBe("slack");
-    expect(d.sessionKey).toBe("sess-abc");
-    expect(d.traceId).toBe("trace-zzz");
+    // Projected off the fixture's own keys rather than a written-out list, so
+    // a claim cannot be added to the fixture and then left unasserted. Compared
+    // in one shot so a failure names every dropped claim, not just the first.
+    const roundTripped = Object.fromEntries(
+      Object.keys(ALL_CLAIMS).map((key) => [
+        key,
+        d[key as keyof typeof ALL_CLAIMS],
+      ])
+    );
+    expect(roundTripped).toEqual(ALL_CLAIMS);
+  });
+
+  test("the fixture covers every declared claim", () => {
+    // ALL_CLAIMS is hand-written, and hand-written lists drift — that is
+    // precisely how the eight claims above reached prod uncovered. The
+    // `Required<WorkerTokenOptions>` annotation looks like it prevents that,
+    // but it does NOT: both packages/core/tsconfig.json and the root
+    // tsconfig.json exclude `__tests__`, so this file is never typechecked and
+    // the annotation is documentation. Enforce it at runtime instead.
+    //
+    // Parsed from source, which fails CLOSED: a reformat the pattern can't read
+    // yields no names and fails the comparison below rather than passing empty.
+    const src = readFileSync(
+      fileURLToPath(new URL("../worker/auth.ts", import.meta.url)),
+      "utf8"
+    );
+    const start = src.indexOf("export interface WorkerTokenOptions {");
+    expect(start).toBeGreaterThan(-1);
+    const body = src.slice(start, src.indexOf("\n}", start));
+    const declared = [...body.matchAll(/^\s{2}([a-zA-Z][a-zA-Z0-9]*)\??:/gm)]
+      .map((m) => m[1])
+      .sort();
+    expect(declared).toEqual(Object.keys(ALL_CLAIMS).sort());
+  });
+
+  test("a minimal token carries no claim it was not given", () => {
+    // The eval claims must be ABSENT on an ordinary token, not merely falsy:
+    // `capture-mode.ts` treats absent `executionMode` as live, and the snapshot
+    // route compares a present `runId` for equality. An option the caller never
+    // passed must not arrive as a defaulted value.
+    const d = verifyWorkerToken(
+      generateWorkerToken("user-1", "conv-1", "deploy-A", { channelId: "C1" })
+    ) as WorkerTokenData;
+    expect(d.executionMode).toBeUndefined();
+    expect(d.behaviorRunId).toBeUndefined();
+    expect(d.runId).toBeUndefined();
+  });
+
+  test.each([
+    0, -1, 1.5,
+  ])("a token claiming behaviorRunId=%p is rejected outright", (bad) => {
+    // The claim addresses the row an eval writes its capture record onto, so
+    // a malformed one must kill the whole token rather than quietly arrive
+    // as undefined and route the record nowhere.
+    expect(
+      verifyWorkerToken(
+        generateWorkerToken("user-1", "conv-1", "deploy-A", {
+          channelId: "C1",
+          executionMode: "capture",
+          behaviorRunId: bad,
+        })
+      )
+    ).toBe(null);
   });
 
   test("round-trips an admin-tools allowlist with its distinct auth actor", () => {


### PR DESCRIPTION
## Summary

- `verifyWorkerToken round-trips all optional fields` listed **8 claims by hand** while `WorkerTokenOptions` grew to **21**. It kept its name and kept passing. Eight claims shipped with no proof they survive the token: `executionMode`, `behaviorRunId`, `organizationId`, `runId`, `messageId`, `source`, `allowedDomains`, `deniedDomains`.
- The serious one is `executionMode`. It is what both capture lanes read — the internal-route guard in `gateway/routes/internal/capture-mode.ts` and the SDK lane. **Deleting `executionMode: options.executionMode` from the payload left all 33 tests in this file green**, plus 25 eval integration tests. `isCaptureRun()` would return false, the guard would return `null`, and an eval replay would perform real side effects against the org it was scoring — real messages, real uploads, real commands. That is the worst outcome this feature can produce, and it sat one deleted line behind a fully green suite.
- Also uncovered: `allowedDomains`/`deniedDomains`, the egress allow/deny list for remote sandboxes, and `organizationId`, which is tenant scoping.

Found while adding a round-trip test for `behaviorRunId` (#2576) — that claim turned out to be the least alarming member of a set.

## What this does

Two tests that lock each other together, replacing the drifted one:

- **`round-trips EVERY claim`** mints with a single `ALL_CLAIMS` fixture and compares the verified output projected off the fixture's own keys, so a claim cannot be added to the fixture and left unasserted.
- **`the fixture covers every declared claim`** reads `WorkerTokenOptions` out of source and fails if anything is declared but missing from the fixture.

Chain: declare a claim → coverage guard fails → add it to the fixture → round-trip fails until the payload carries it → green.

**On `Required<WorkerTokenOptions>`:** it is documentation, not enforcement. Both `packages/core/tsconfig.json` and the root `tsconfig.json` exclude `__tests__`, so this file is never typechecked — verified by declaring a probe claim and watching `tsc --noEmit` pass clean. That is why the guard is runtime and parses source. It fails **closed**: an unreadable reformat yields zero names and fails the comparison rather than passing vacuously.

Test-only. No production code changed — `packages/core/src/worker/auth.ts` is untouched.

## Test plan

- [x] `make pre-pr` clean
- [x] Tests run: 38 in this file, 383 across `packages/core` (378 on main, +5 net)
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Red — the gap, measured on main's tests

`executionMode` deleted from the token payload (mutation verified applied: pattern 1→0):

```
packages/core worker-auth.test.ts      33 pass, 0 fail
eval integration (3 suites)            25 pass, 0 fail
```

58 tests green with capture mode entirely disabled.

### Green — every claim now caught

Each claim deleted from the payload one at a time, each mutation verified applied, against the new test:

```
allowedDomains       mutation_applied=yes caught=YES
behaviorRunId        mutation_applied=yes caught=YES
deniedDomains        mutation_applied=yes caught=YES
executionMode        mutation_applied=yes caught=YES
messageId            mutation_applied=yes caught=YES
organizationId       mutation_applied=yes caught=YES
runId                mutation_applied=yes caught=YES
source               mutation_applied=yes caught=YES
adminTools           mutation_applied=yes caught=YES
sandboxId            mutation_applied=yes caught=YES
nixPackages          mutation_applied=yes caught=YES
runtimeProviderId    mutation_applied=yes caught=YES
```

12/12. And the coverage guard, mutated by declaring a new claim absent from the fixture:

```
(fail) worker auth token > the fixture covers every declared claim
 33 pass, 1 fail
```

And the validation block, deleted:

```
3 fail — all behaviorRunId test.each cases
```

`auth.ts` restored via `cp` from backup after every mutation; `git diff` on it is empty.

## Notes

`verifyEgressProxyToken` is **not** a second instance — it and `verifyWorkerToken` are both thin wrappers over the same `verifyToken`, and `generateWorkerTokenPair` mints both through the same `generateToken` with the same options. The claim path is identical and now covered; only the `tokenKind` discriminator differs, which is separately tested.

Follow-ups deliberately not in this branch:

1. **`executionMode` + `behaviorRunId` should be validated as a pair**, the way `adminTools`/`adminActorUserId` already are at `auth.ts:388`. That makes "capture run with no run id" unrepresentable and deletes the fail-soft branch in `capture-mode.ts` rather than handling it. It changes runtime behaviour — a capture token minted before #2576 would start being rejected — so it wants its own PR and a rollout thought, not a test-only one.
2. **Whether `__tests__` should be typechecked at all.** If it were, `Required<WorkerTokenOptions>` would become real enforcement and the source-parsing guard could be deleted outright. Repo-wide config change, out of scope here.
3. The guard's regex only sees fields at two-space indent matching `[a-zA-Z][a-zA-Z0-9]*`. A field named `run_id` or `$claim` would be invisible to both it and the fixture. It fails closed on a reformat, but not on an unusual field name.
