### PR TITLE
test(server): cover the rejection path a real stale twin actually takes

### DIFF
--- a/docs/BROWSER_TESTING.md
+++ b/docs/BROWSER_TESTING.md
@@ -101,15 +101,22 @@ export default async (ctx, client) => {
 ### Always expire the planted cookie (step 5 is not optional)
 
 `document.cookie` writes a **host-only** cookie (`app.lobu.ai`), while a real sign-in writes
-the same name at `Domain=.lobu.ai`. Both then live in the jar, the browser sends both, and the
-server resolves whichever comes **first** — which RFC 6265 §5.4 makes the **oldest**. So a
-leftover planted cookie outranks every subsequent real login, and once its session expires the
-human is locked out of `app.lobu.ai` with no in-app way to recover: each new sign-in mints a
-strictly newer cookie that can never win. This cost a full debugging session on 2026-08-06.
+the same name at `Domain=.lobu.ai`. Both then live in the jar and the browser sends both.
 
-The server now expires the host-only twin whenever it sets a domain-scoped auth cookie
-(`auth/session-cookie-scope.ts`), so a fresh sign-in self-heals a poisoned jar — but do not
-lean on that. Expire what you planted.
+This used to lock the human out of `app.lobu.ai` permanently. Resolution went to whichever
+cookie came **first**, which RFC 6265 §5.4 makes the **oldest**, so a leftover planted cookie
+outranked every later sign-in — and each new sign-in minted a strictly newer cookie that could
+never win. It cost a full debugging session on 2026-08-06.
+
+Two server-side changes closed that:
+
+- `auth/resolve-session.ts` resolves a duplicated jar **on merit** rather than by position, so
+  order no longer decides who authenticates.
+- `auth/session-cookie-scope.ts` expires the host-only twin whenever a response sets a
+  domain-scoped auth cookie, so a sign-in collapses the jar back to one.
+
+**Still expire what you planted.** A planted cookie is a live session that outlives your test,
+and neither change makes an extra session in someone's browser a good idea.
 
 To clear one by hand:
 

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -20,6 +20,7 @@ Root `AGENTS.md` holds the invariants and the workflow. This file holds the mech
 | `could not create shared memory segment: No space left on device` | Testing |
 | A mock that works alone but not in the suite | Testing |
 | A server that is "healthy" suspiciously fast | Testing |
+| An auth-cookie fix that is green in tests but wrong in prod | Testing |
 | `gh run view --log-failed` printing nothing | CI triage |
 | `grep` finding nothing in a CI log you can read | CI triage |
 | `codex exec` / `pi -p` hanging at 0% CPU | Shell & CLI |
@@ -31,7 +32,6 @@ Root `AGENTS.md` holds the invariants and the workflow. This file holds the mech
 | A device manifest edit never reaches `connector_definitions` | Browser & connectors |
 | Changed unpacked-extension code is not active | Browser & connectors |
 | A completed browser action opened on the wrong machine | Browser & connectors |
-| An auth-cookie fix that is green in tests but wrong in prod | Testing |
 | `check-drift` failing on a submodule pointer | Submodule & cross-repo |
 | A rebase that "already upstream"-ed your pointer commit | Submodule & cross-repo |
 
@@ -88,9 +88,9 @@ Both helpers are exported from `packages/server/src/db/client.ts`. `sql.array(a)
 
 **Vitest 3.2.6 `list --shard=N/M` prints every file, even though `run --shard=N/M` partitions correctly.** Do not use `vitest list` to prove shard coverage. Run each shard with the JSON reporter and compare `testResults`: the three-way CI split owns 126 of 378 files per shard, with no overlap at execution time.
 
-**The test env speaks plain HTTP, so it validates the WRONG auth-cookie name.** Better Auth derives the session cookie name from `useSecureCookies`: tests get `better-auth.session_token`, prod gets `__Secure-better-auth.session_token`, and `getSession` reads exactly one of them and is blind to the other. Any code that *constructs* or *matches* that name can therefore pass a full red→green integration test and still fail in prod — this shipped a probe that rewrote every candidate to the bare basename, which would have locked out every duplicated jar in production (caught by `make review-fix`, not by the suite). Use `sessionCookieName(isHttps)` from `auth/session-cookie-scope.ts`, never a literal, and cover **both** spellings explicitly. A unit test with a faked `getSession` is the stronger test here; the full-stack one inherits the harness's http-ness.
+**The test env speaks plain HTTP, so it validates the WRONG auth-cookie name.** Better Auth derives the session cookie name from `useSecureCookies`: tests get `better-auth.session_token`, prod gets `__Secure-better-auth.session_token`, and `getSession` reads exactly one of them and is blind to the other. Any code that *constructs* or *matches* that name can therefore pass a full red→green integration test and still fail in prod — #2578 nearly shipped a probe that rewrote every candidate to the bare basename, which would have locked out every duplicated jar in production (caught by `make review-fix`, not by the suite). Use `sessionCookieName(isHttps)` from `packages/server/src/auth/session-cookie-scope.ts`, never a literal, and cover **both** spellings explicitly. A unit test with a faked `getSession` is the stronger test here; the full-stack one inherits the harness's http-ness.
 
-**A cookie can be rejected two different ways, and the cheap fake only exercises one.** `better-call`'s `getSignedCookie` returns null on a bad HMAC *before the database is consulted*; a real stale twin is correctly signed and dies on the session lookup instead. A hand-written garbage token only ever tests the first path. To test the second, mint a real session and delete its `session` row.
+**A cookie can be rejected two different ways, and the cheap fake only exercises one.** `better-call`'s `getSignedCookie` rejects a bad HMAC *before the database is consulted* (`context.mjs`: it also bails early on any signature that is not 44 base64 chars ending in `=`); a real stale twin is correctly signed and dies on the session lookup instead. A hand-written garbage token only ever tests the first path. To test the second, mint a real session and delete its `session` row.
 
 **`make dev` is not the test harness.** It migrates its owned local per-branch database and boots the app, but that does not exercise the branches a relevant unit or integration suite covers.
 

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -31,6 +31,7 @@ Root `AGENTS.md` holds the invariants and the workflow. This file holds the mech
 | A device manifest edit never reaches `connector_definitions` | Browser & connectors |
 | Changed unpacked-extension code is not active | Browser & connectors |
 | A completed browser action opened on the wrong machine | Browser & connectors |
+| An auth-cookie fix that is green in tests but wrong in prod | Testing |
 | `check-drift` failing on a submodule pointer | Submodule & cross-repo |
 | A rebase that "already upstream"-ed your pointer commit | Submodule & cross-repo |
 
@@ -86,6 +87,10 @@ Both helpers are exported from `packages/server/src/db/client.ts`. `sql.array(a)
 **Integration suite prerequisites.** Node 22 is the repo default (`.node-version`); Lobu accepts Node 22–24 and 26+, while Node 25 boots without the SDK sandbox. Global setup uses `DATABASE_URL` if set, otherwise spawns an ephemeral embedded Postgres + pgvector.
 
 **Vitest 3.2.6 `list --shard=N/M` prints every file, even though `run --shard=N/M` partitions correctly.** Do not use `vitest list` to prove shard coverage. Run each shard with the JSON reporter and compare `testResults`: the three-way CI split owns 126 of 378 files per shard, with no overlap at execution time.
+
+**The test env speaks plain HTTP, so it validates the WRONG auth-cookie name.** Better Auth derives the session cookie name from `useSecureCookies`: tests get `better-auth.session_token`, prod gets `__Secure-better-auth.session_token`, and `getSession` reads exactly one of them and is blind to the other. Any code that *constructs* or *matches* that name can therefore pass a full red→green integration test and still fail in prod — this shipped a probe that rewrote every candidate to the bare basename, which would have locked out every duplicated jar in production (caught by `make review-fix`, not by the suite). Use `sessionCookieName(isHttps)` from `auth/session-cookie-scope.ts`, never a literal, and cover **both** spellings explicitly. A unit test with a faked `getSession` is the stronger test here; the full-stack one inherits the harness's http-ness.
+
+**A cookie can be rejected two different ways, and the cheap fake only exercises one.** `better-call`'s `getSignedCookie` returns null on a bad HMAC *before the database is consulted*; a real stale twin is correctly signed and dies on the session lookup instead. A hand-written garbage token only ever tests the first path. To test the second, mint a real session and delete its `session` row.
 
 **`make dev` is not the test harness.** It migrates its owned local per-branch database and boots the app, but that does not exercise the branches a relevant unit or integration suite covers.
 

--- a/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { cleanupTestDatabase } from '../../__tests__/setup/test-db';
+import { cleanupTestDatabase, getTestDb } from '../../__tests__/setup/test-db';
 import {
   addUserToOrganization,
   createTestOrganization,
@@ -54,6 +54,17 @@ describe('duplicate session cookies', () => {
     return body.organizations.map((o) => o.slug);
   }
 
+  /** Mint an ADDITIONAL session cookie for a PAT that already exists. */
+  async function extraSessionCookie(pat: string): Promise<string> {
+    const res = await get(`/api/exchange-token?token=${encodeURIComponent(pat)}&next=/`);
+    expect(res.status).toBe(302);
+    const setCookie = res.headers
+      .getSetCookie()
+      .find((c) => /^(?:__Secure-)?better-auth\.session_token=[^;]/.test(c));
+    const [pair] = (setCookie as string).split(';');
+    return pair.slice(pair.indexOf('=') + 1).trim();
+  }
+
   // Garbage values that are syntactically plausible signed cookies — a 44-char
   // base64 signature, which is the shape better-call checks before it verifies
   // anything — but cannot pass the HMAC. Exactly what a stale twin looks like
@@ -88,6 +99,34 @@ describe('duplicate session cookies', () => {
     // Resolving candidates must not become "authenticate on anything". With no
     // live token in the jar the answer is still no session.
     expect(await orgSlugsFor(`${name}=${DEAD}; ${name}=${ALSO_DEAD}`)).not.toContain(slug);
+  });
+
+  it('resolves past a VALIDLY SIGNED twin whose session row is gone', async () => {
+    // The tests above kill their twin by breaking the HMAC, which better-call
+    // rejects in getSignedCookie before the database is ever consulted. A real
+    // stale twin is nothing like that: it is correctly signed, and dies on the
+    // session lookup instead. Two different rejection paths inside getSession,
+    // and only this one matches what a poisoned browser actually carries.
+    const slug = 'dup-revoked-first';
+    const org = await createTestOrganization({ slug });
+    const user = await createTestUser({ email: 'dup-revoked@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const { token: pat } = await createTestPAT(user.id, org.id, { scope: 'profile:read' });
+
+    const doomed = await extraSessionCookie(pat);
+    const live = await extraSessionCookie(pat);
+    expect(doomed).not.toBe(live);
+
+    // Revoke the first session at the source, leaving its signature intact.
+    const token = decodeURIComponent(doomed).split('.')[0];
+    const deleted = await getTestDb()`DELETE FROM "session" WHERE token = ${token} RETURNING id`;
+    expect(deleted.length, 'the doomed session must actually be revoked').toBe(1);
+
+    const name = '__Secure-better-auth.session_token'.replace('__Secure-', '');
+    // Signed, revoked, and FIRST — the exact shape of the production brick.
+    expect(await orgSlugsFor(`${name}=${doomed}; ${name}=${live}`)).toContain(slug);
+    // And it is genuinely dead on its own, or the assertion above proves nothing.
+    expect(await orgSlugsFor(`${name}=${doomed}`)).not.toContain(slug);
   });
 
   it('is unchanged for the ordinary single-cookie jar', async () => {

--- a/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/duplicate-session-cookie.test.ts
@@ -23,17 +23,15 @@ describe('duplicate session cookies', () => {
 
   /**
    * Mint a real, correctly-signed session cookie the way a browser would get
-   * one, and return both the cookie name and its signed value.
+   * one, and return both the cookie name and its signed value. Called twice
+   * with the same PAT it mints two independent sessions.
+   *
+   * The name comes back off the wire rather than from a literal: this harness
+   * speaks plain HTTP, so Better Auth drops the `__Secure-` prefix that prod
+   * carries, and a hardcoded spelling would pin the wrong one. See
+   * docs/GOTCHAS.md, Testing.
    */
-  async function realSessionCookie(
-    slug: string,
-    email: string
-  ): Promise<{ name: string; value: string }> {
-    const org = await createTestOrganization({ slug });
-    const user = await createTestUser({ email });
-    await addUserToOrganization(user.id, org.id, 'owner');
-    const { token: pat } = await createTestPAT(user.id, org.id, { scope: 'profile:read' });
-
+  async function exchangeForSessionCookie(pat: string): Promise<{ name: string; value: string }> {
     const res = await get(`/api/exchange-token?token=${encodeURIComponent(pat)}&next=/`);
     expect(res.status).toBe(302);
 
@@ -47,22 +45,24 @@ describe('duplicate session cookies', () => {
     return { name: pair.slice(0, eq).trim(), value: pair.slice(eq + 1).trim() };
   }
 
+  /** Provision an org, an owner and a PAT, then exchange it for a cookie. */
+  async function realSessionCookie(
+    slug: string,
+    email: string
+  ): Promise<{ name: string; value: string }> {
+    const org = await createTestOrganization({ slug });
+    const user = await createTestUser({ email });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const { token: pat } = await createTestPAT(user.id, org.id, { scope: 'profile:read' });
+
+    return await exchangeForSessionCookie(pat);
+  }
+
   async function orgSlugsFor(cookie: string): Promise<string[]> {
     const res = await get('/api/organizations', { cookie });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { organizations: Array<{ slug: string }> };
     return body.organizations.map((o) => o.slug);
-  }
-
-  /** Mint an ADDITIONAL session cookie for a PAT that already exists. */
-  async function extraSessionCookie(pat: string): Promise<string> {
-    const res = await get(`/api/exchange-token?token=${encodeURIComponent(pat)}&next=/`);
-    expect(res.status).toBe(302);
-    const setCookie = res.headers
-      .getSetCookie()
-      .find((c) => /^(?:__Secure-)?better-auth\.session_token=[^;]/.test(c));
-    const [pair] = (setCookie as string).split(';');
-    return pair.slice(pair.indexOf('=') + 1).trim();
   }
 
   // Garbage values that are syntactically plausible signed cookies — a 44-char
@@ -113,20 +113,24 @@ describe('duplicate session cookies', () => {
     await addUserToOrganization(user.id, org.id, 'owner');
     const { token: pat } = await createTestPAT(user.id, org.id, { scope: 'profile:read' });
 
-    const doomed = await extraSessionCookie(pat);
-    const live = await extraSessionCookie(pat);
-    expect(doomed).not.toBe(live);
+    const doomed = await exchangeForSessionCookie(pat);
+    const live = await exchangeForSessionCookie(pat);
+    expect(doomed.value).not.toBe(live.value);
 
     // Revoke the first session at the source, leaving its signature intact.
-    const token = decodeURIComponent(doomed).split('.')[0];
+    // Split on the LAST dot, the way better-call itself does: the signed value
+    // is `<token>.<signature>`, so splitting on the first would truncate any
+    // token that happens to contain one.
+    const signed = decodeURIComponent(doomed.value);
+    const token = signed.slice(0, signed.lastIndexOf('.'));
     const deleted = await getTestDb()`DELETE FROM "session" WHERE token = ${token} RETURNING id`;
     expect(deleted.length, 'the doomed session must actually be revoked').toBe(1);
 
-    const name = '__Secure-better-auth.session_token'.replace('__Secure-', '');
+    const name = live.name;
     // Signed, revoked, and FIRST — the exact shape of the production brick.
-    expect(await orgSlugsFor(`${name}=${doomed}; ${name}=${live}`)).toContain(slug);
+    expect(await orgSlugsFor(`${name}=${doomed.value}; ${name}=${live.value}`)).toContain(slug);
     // And it is genuinely dead on its own, or the assertion above proves nothing.
-    expect(await orgSlugsFor(`${name}=${doomed}`)).not.toContain(slug);
+    expect(await orgSlugsFor(`${name}=${doomed.value}`)).not.toContain(slug);
   });
 
   it('is unchanged for the ordinary single-cookie jar', async () => {


### PR DESCRIPTION
## What

Follow-up consistency pass on #2578. Three gaps, one batch.

### The test gap is the real one

The duplicate-cookie tests killed their twin by breaking the HMAC. `better-call` rejects that inside `getSignedCookie` **before the database is consulted**:

```js
if (signature.length !== 44 || !signature.endsWith("=")) return null;
return await verifySignature(...) ? signedValue : false;
```

A real stale twin is nothing like that — it is correctly signed and dies on the *session lookup*. Two distinct rejection paths through `getSession`, and only the second is what a poisoned browser actually carries. The suite was proving the easy one.

Adds a case that mints two real sessions for one user, deletes the first `session` row, and asserts the live cookie still wins with the revoked one first.

**Mutation-verified** — disabling disambiguation fails the new test *and* the HMAC one:

```
× authenticates when a DEAD twin is first — the permanent-brick case
× resolves past a VALIDLY SIGNED twin whose session row is gone
  Tests  2 failed | 3 passed (5)
```

Restored → 5/5.

### Docs said something false

`docs/BROWSER_TESTING.md` still claimed the server "resolves whichever comes **first**" and that a planted cookie leaves the human "locked out with no in-app way to recover". Both untrue since #2578. Now describes the two halves that actually shipped — `resolve-session.ts` resolving on merit, `session-cookie-scope.ts` collapsing the jar — and keeps *expire what you planted* on its real grounds: a planted cookie is a live session that outlives the test.

### The trap that caused it

`docs/GOTCHAS.md` gains the one that nearly shipped a prod-breaking bug: the test env speaks plain HTTP, so it validates `better-auth.session_token` while prod uses `__Secure-better-auth.session_token`, and `getSession` reads exactly one. A full red→green integration test passed on a probe that would have locked out every duplicated jar in production. Caught by `make review-fix`, not by the suite.

Plus the companion entry: a hand-written garbage token only ever tests the signature path.

## Verification

- `src/auth/__tests__/` — **171/171**
- unit — 30/30
- `make pre-pr` — `✅ pre-pr gates clean`
- Checked and found **correct, no change needed**: `docs/DOCKER.md` and `docker-compose.example.yml` on `AUTH_COOKIE_DOMAIN`; no stale `countNamedCookies` references anywhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Authentication now ignores revoked or stale session cookies and continues with a valid session when available.
  - Prevented authentication failures caused by duplicate cookies with conflicting scopes.

- **Documentation**
  - Added guidance for diagnosing authentication-cookie mismatches.
  - Clarified secure and non-secure cookie testing requirements.
  - Updated browser-testing guidance for cookie cleanup and expiration.

- **Tests**
  - Added coverage for authentication behavior when revoked and active sessions coexist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->