### PR TITLE
fix(core): stop a capture token from silently becoming a live one

### DIFF
--- a/packages/core/src/__tests__/worker-auth.test.ts
+++ b/packages/core/src/__tests__/worker-auth.test.ts
@@ -190,6 +190,59 @@ describe("worker auth token", () => {
     ).toBe(null);
   });
 
+  test.each([
+    "banana",
+    "",
+    "CAPTURE",
+    "dry_run",
+  ])("a token claiming executionMode=%p is rejected, not read as live", (bad) => {
+    // Every consumer tests this claim for equality with "capture", so an
+    // unrecognised value reads as LIVE and lets an eval replay perform real
+    // side effects. Fail the token instead of defaulting it.
+    //
+    // Deliberately minted WITHOUT `behaviorRunId`: with one present the pair
+    // check rejects the token first and this stays green no matter what the
+    // shape check does. Mutation-verified — dropping the shape check turns
+    // these red only in this shape, which is also the reachable hole: a
+    // garbage mode and no run id is exactly what the pair check waves through.
+    expect(
+      verifyWorkerToken(
+        generateWorkerToken("user-1", "conv-1", "deploy-A", {
+          channelId: "C1",
+          executionMode: bad as unknown as "live" | "capture",
+        })
+      )
+    ).toBe(null);
+  });
+
+  test("capture without behaviorRunId is rejected", () => {
+    // A capture run that cannot record is the one state evals must never
+    // reach: side effects are suppressed but nothing says what was suppressed,
+    // so the replay scores as clean while its intent is lost.
+    expect(
+      verifyWorkerToken(
+        generateWorkerToken("user-1", "conv-1", "deploy-A", {
+          channelId: "C1",
+          executionMode: "capture",
+        })
+      )
+    ).toBe(null);
+  });
+
+  test("behaviorRunId without capture is rejected", () => {
+    // The other direction matters too: a live run addressing an eval row would
+    // let real work stamp a capture record onto a run it never replayed.
+    expect(
+      verifyWorkerToken(
+        generateWorkerToken("user-1", "conv-1", "deploy-A", {
+          channelId: "C1",
+          executionMode: "live",
+          behaviorRunId: 874626,
+        })
+      )
+    ).toBe(null);
+  });
+
   test("round-trips an admin-tools allowlist with its distinct auth actor", () => {
     const token = generateWorkerToken("U_SLACK", "conv", "deploy", {
       channelId: "C1",

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -370,6 +370,40 @@ function verifyToken(
         return null;
       }
     }
+    // `executionMode` decides whether the run may touch the outside world, and
+    // every consumer tests it for equality with "capture". An unrecognised
+    // value would therefore read as live and let an eval replay perform real
+    // side effects, so an unknown mode is rejected rather than defaulted.
+    if (
+      data.executionMode !== undefined &&
+      data.executionMode !== "live" &&
+      data.executionMode !== "capture"
+    ) {
+      logger.error(
+        "Worker token rejected: executionMode must be 'live' or 'capture'"
+      );
+      return null;
+    }
+    // The capture pair is inseparable, for the same reason the admin pair
+    // below is: the mode says the run must not perform side effects and
+    // `behaviorRunId` says which row records what it tried to do. A capture
+    // run that cannot record is the state evals must never reach — its side
+    // effects are suppressed but nothing says what was suppressed, so the
+    // replay scores as clean. A diverged pair is either a forged token or a
+    // mint-side bug: `buildWorkerTokenClaims` gates both on one verified
+    // intent, but reads the run id back off `platformMetadata.intent`
+    // separately, where a malformed intent yields undefined on its own.
+    // Reject either way — a rejected token fails the run closed, where
+    // honouring the pair would run an eval nothing can score.
+    if (
+      (data.executionMode === "capture") !==
+      (data.behaviorRunId !== undefined)
+    ) {
+      logger.error(
+        "Worker token rejected: executionMode 'capture' and behaviorRunId must be set together"
+      );
+      return null;
+    }
     // `adminTools` is optional but must be a string[] when present — a forged
     // token with a non-array (or non-string elements) must be rejected, not
     // coerced, before the execute gate trusts it to allow internal tools.

--- a/packages/server/src/gateway/__tests__/durable-replay-claim-parity.test.ts
+++ b/packages/server/src/gateway/__tests__/durable-replay-claim-parity.test.ts
@@ -23,15 +23,21 @@ afterAll(() => {
 });
 
 /**
- * A per-run token is minted once, but it is RE-minted on two other paths:
- * durable replay (`attachFreshRunJobToken`) and mid-turn refresh (the
- * `/worker/token/refresh` route). Both rebuild the claim set by hand, so any
- * claim added to the mint without being added to those mappers is silently
- * dropped the moment a run replays or a long turn rotates its token.
+ * A per-run token is minted once, but its claim set is rebuilt BY HAND on three
+ * further paths: `durableClaims` (persisting to `agent_run_input.token_claims`),
+ * `attachFreshRunJobToken` (the durable-replay remint), and the
+ * `/worker/token/refresh` route. Every claim on `WorkerTokenData` is optional,
+ * so a mapper that forgets one still typechecks — the claim is simply gone the
+ * moment a run replays or a long turn rotates its token.
  *
- * `nixPackages` is the claim that makes a contributed CLI exist on a remote
- * runtime. Losing it on replay reproduces exactly the failure the package
- * claim was added to fix: an authenticated `gh` that was never installed.
+ * This has now happened twice. `nixPackages` was the first: losing it on replay
+ * left an authenticated `gh` that was never installed. The capture pair was the
+ * second, and worse — a dropped `executionMode` reads as live, so an eval
+ * replay stops recording and starts performing real side effects against the
+ * org it is scoring.
+ *
+ * Hence the whole-fixture projection below rather than another hand-picked list
+ * of expectations.
  */
 describe("durable replay preserves every signed claim", () => {
   const claims = {
@@ -54,9 +60,29 @@ describe("durable replay preserves every signed claim", () => {
     allowedDomains: ["api.github.com"],
     deniedDomains: ["evil.example.com"],
     nixPackages: ["gh"],
+    // The capture pair. Dropping it on either hop turns an eval replay back
+    // into a LIVE run: absent `executionMode` reads as live, so the replay
+    // performs for real everything it was supposed to only record. Both are
+    // present because `verifyWorkerToken` rejects one without the other.
+    executionMode: "capture" as const,
+    behaviorRunId: 874626,
   };
 
-  test("the PERSISTED claim set carries nixPackages, not just the remint", async () => {
+  /**
+   * Assert against the WHOLE fixture rather than a hand-picked few. Both this
+   * suite and the mint's own round-trip test previously listed claims by hand
+   * and silently fell behind the interface — `nixPackages` was added for that
+   * reason, and the capture pair was missed the same way afterwards. Comparing
+   * a projection off the fixture's own keys means a claim can never be added
+   * to the fixture and left unasserted; keeping the fixture exhaustive is then
+   * the only discipline required.
+   */
+  const project = (actual: Record<string, unknown> | undefined) =>
+    Object.fromEntries(
+      Object.keys(claims).map((k) => [k, actual?.[k]]),
+    );
+
+  test("the PERSISTED claim set carries every claim, not just the remint", async () => {
     // `durableClaims` is a hand-written mapper feeding
     // agent_run_input.token_claims. A claim the mint signs but that mapper
     // omits is lost at the DATABASE boundary, before attachFreshRunJobToken
@@ -93,13 +119,10 @@ describe("durable replay preserves every signed claim", () => {
 
     // recordAgentRunInput binds the stored payload first, then the claim set.
     const persisted = bound[1];
-    expect(persisted?.allowedDomains).toEqual(["api.github.com"]);
-    expect(persisted?.nixPackages).toEqual(["gh"]);
-    expect(persisted?.adminTools).toEqual(["manage_agents"]);
-    expect(persisted?.adminActorUserId).toBe("auth-user-1");
+    expect(project(persisted)).toEqual(claims);
   });
 
-  test("attachFreshRunJobToken carries nixPackages across a replay remint", () => {
+  test("attachFreshRunJobToken carries every claim across a replay remint", () => {
     const replayed = attachFreshRunJobToken({
       payload: { runId: 7, messageId: "m1" } as never,
       tokenClaims: claims as never,
@@ -107,12 +130,10 @@ describe("durable replay preserves every signed claim", () => {
 
     const decoded = verifyWorkerToken(replayed.runJobToken as string);
 
-    // The egress claims already survive replay; the package claim must too.
-    // Without it the sandbox gets the domain grants for a binary it never
-    // installed — the asymmetry this branch exists to close.
-    expect(decoded?.allowedDomains).toEqual(["api.github.com"]);
-    expect(decoded?.nixPackages).toEqual(["gh"]);
-    expect(decoded?.adminTools).toEqual(["manage_agents"]);
-    expect(decoded?.adminActorUserId).toBe("auth-user-1");
+    // Every claim the fixture carries must survive the remint — the egress
+    // grants, the package list, the admin pair, and the capture pair alike.
+    expect(project(decoded as unknown as Record<string, unknown>)).toEqual(
+      claims,
+    );
   });
 });

--- a/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
@@ -135,6 +135,11 @@ function mintToken(opts: {
     allowedDomains: ["api.example.com"],
     deniedDomains: ["evil.example.com"],
     nixPackages: ["gh"],
+    // Minted as a capture (eval replay) token so refresh is exercised on the
+    // mode that has something to lose. Both halves are required: the verifier
+    // rejects `capture` without a run id.
+    executionMode: "capture",
+    behaviorRunId: 874626,
   });
 }
 
@@ -188,6 +193,12 @@ describe("POST /worker/token/refresh", () => {
     // otherwise stop provisioning the connector's CLI mid-run, leaving an
     // authenticated binary that is no longer installed.
     expect(data!.nixPackages).toEqual(["gh"]);
+    // And the capture pair. This is the one whose loss is silent AND harmful:
+    // a refreshed token without `executionMode` reads as live, so the rest of
+    // the eval replay performs real side effects against the org it is
+    // scoring instead of recording them.
+    expect(data!.executionMode).toBe("capture");
+    expect(data!.behaviorRunId).toBe(874626);
   });
 
   test("REVOCATION: denied (403) once this turn has no live marker", async () => {

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -980,6 +980,13 @@ export class WorkerGateway {
         // And the package claim with them — a long turn that rotates its token
         // would otherwise stop provisioning the connector's CLI mid-run.
         nixPackages: tokenData.nixPackages,
+        // Preserve the capture pair, or a long eval replay silently becomes a
+        // LIVE run the moment its token rotates: absent `executionMode` reads
+        // as live, so every guarded route would start performing real side
+        // effects against the org being scored. Both travel together because
+        // `verifyWorkerToken` rejects one without the other.
+        executionMode: tokenData.executionMode,
+        behaviorRunId: tokenData.behaviorRunId,
       }
     );
 

--- a/packages/server/src/gateway/orchestration/agent-run-input.ts
+++ b/packages/server/src/gateway/orchestration/agent-run-input.ts
@@ -43,6 +43,12 @@ function durableClaims(token: WorkerTokenData): DurableRunTokenClaims {
     // that keeps the domain grants but loses the packages provisions nothing,
     // leaving an authenticated CLI that was never installed.
     nixPackages: token.nixPackages,
+    // Persist the capture pair too, or it is lost at the DATABASE boundary —
+    // before `attachFreshRunJobToken` can preserve it — and a replayed eval
+    // comes back live. `executionMode` is the whole safety property; without
+    // it the replay performs for real everything it should only record.
+    executionMode: token.executionMode,
+    behaviorRunId: token.behaviorRunId,
   };
 }
 
@@ -104,6 +110,12 @@ export function attachFreshRunJobToken(
         allowedDomains: token.allowedDomains,
         deniedDomains: token.deniedDomains,
         nixPackages: token.nixPackages,
+        // Same reason as the refresh mint in gateway/index.ts: dropping the
+        // capture pair here would hand a re-dispatched eval replay a live
+        // token, and the replay would perform for real everything it was
+        // supposed to only record.
+        executionMode: token.executionMode,
+        behaviorRunId: token.behaviorRunId,
       },
     ),
   };

--- a/packages/server/src/gateway/routes/internal/capture-mode.ts
+++ b/packages/server/src/gateway/routes/internal/capture-mode.ts
@@ -111,7 +111,10 @@ export async function captureSideEffect(
 	// suppress-without-record rather than throwing, for the same reason
 	// `recordCapturedSideEffect` swallows its errors: a route error sends a
 	// capture run into retry loops instead of letting it finish its turn.
-	if (worker.behaviorRunId === undefined) {
+	// Falsy rather than `=== undefined`: the verifier already rejects <= 0 and
+	// non-integers, but a future non-token caller reaching this helper with 0 or
+	// NaN should take the log, not address `WHERE id = 0`.
+	if (!worker.behaviorRunId) {
 		logger.error(
 			{ action },
 			"[eval-capture] no behaviorRunId on the token — side effect suppressed but NOT recorded",

--- a/packages/server/src/gateway/routes/internal/capture-mode.ts
+++ b/packages/server/src/gateway/routes/internal/capture-mode.ts
@@ -101,7 +101,24 @@ export async function captureSideEffect(
 		},
 		`[eval-capture] suppressed ${action} for a capture run`,
 	);
-	await recordCapturedSideEffect(worker.behaviorRunId, action, details);
+	// Suppression above is keyed on `executionMode` alone and must stay that
+	// way — gating it on the run id too would let a token missing the id fall
+	// through and perform the side effect. Recording is what needs the id.
+	// `verifyWorkerToken` rejects a capture token that arrives without one, so
+	// in practice this logs nothing; the branch is how that invariant narrows
+	// to `number`, which the token type cannot express (`behaviorRunId` is
+	// required only when the mode is capture). It degrades to
+	// suppress-without-record rather than throwing, for the same reason
+	// `recordCapturedSideEffect` swallows its errors: a route error sends a
+	// capture run into retry loops instead of letting it finish its turn.
+	if (worker.behaviorRunId === undefined) {
+		logger.error(
+			{ action },
+			"[eval-capture] no behaviorRunId on the token — side effect suppressed but NOT recorded",
+		);
+	} else {
+		await recordCapturedSideEffect(worker.behaviorRunId, action, details);
+	}
 	return c.json(
 		responseBody ?? {
 			success: true,
@@ -125,17 +142,10 @@ export async function captureSideEffect(
  * the side effect would break the guarantee.
  */
 async function recordCapturedSideEffect(
-	behaviorRunId: number | undefined,
+	behaviorRunId: number,
 	action: string,
 	details: Record<string, unknown>,
 ): Promise<void> {
-	if (!behaviorRunId) {
-		logger.error(
-			{ action },
-			"[eval-capture] no behaviorRunId on the token — side effect suppressed but NOT recorded",
-		);
-		return;
-	}
 	try {
 		const sql = getDb();
 		// One assignment to `dry_run_preview` — Postgres rejects a SET clause that


### PR DESCRIPTION
## Summary

Two claims decide whether a run may touch the outside world, and `verifyWorkerToken` was checking neither properly.

- **`executionMode` had no shape validation at all.** Every consumer tests it for equality with `"capture"` (`capture-mode.ts`, `sdk_run.ts`, `complete-window.ts`), so any unrecognised value — `"banana"`, `""`, `"CAPTURE"`, `"dry_run"` — reads as **live**. A token carrying garbage in that field would let an eval replay perform real side effects: real messages, real uploads, real commands. Every other claim in this function is shape-checked; this one was skipped.
- **`executionMode` and `behaviorRunId` were independent optionals**, so "capture run with no run id" was representable. That is the state evals must never reach: side effects are suppressed, but nothing records what was suppressed, so the replay scores as clean while its intent is lost.

Both are follow-ups I flagged in #2579. The `executionMode` shape hole was found while writing the test for the pairing one.

## Why this is safe to enforce

`executionMode` and `intent.runId` are both produced by the same `verifyBehaviorRunIntent` call (`gateway/permissions/behavior-run-intent.ts`) — the mode is its return value and the run id is its validated input. They cannot diverge on any real path, so pairing them rejects nothing that is legitimately minted today. This mirrors the `adminTools`/`adminActorUserId` pair rule already in this function.

## Note on where the check does *not* go

Suppression in `capture-mode.ts` stays keyed on `executionMode` alone. Gating it on the run id as well would let a token missing the id fall through the guard and **perform** the side effect — a fail-open. Only the *recording* needs the id, so `recordCapturedSideEffect` now takes a non-optional `number` and the narrowing sits at its call site. That branch is unreachable given the new token rule; it stays so a future mint path degrades to "suppressed but unrecorded" rather than crashing a run.

## Test plan

- [x] `make pre-pr` clean
- [x] Tests: 44 in `worker-auth.test.ts` (38 before, +6), 383 across `packages/core`, 40 in the server eval-capture unit suites
- [x] Bug fix: red→fix→green pasted below
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

### Red — both gaps, measured against `origin/main`'s `auth.ts`

```
(fail) an unknown executionMode is rejected, not read as live
(fail) capture without behaviorRunId is rejected
(fail) behaviorRunId without capture is rejected
 2 pass, 3 fail
```

The 2 passes are the legitimate cases (a valid capture pair round-trips; an ordinary live token verifies), confirming the probe itself is sound rather than failing everything.

### Green

```
 44 pass, 0 fail   (worker-auth.test.ts)
383 pass, 0 fail   (packages/core)
 40 pass, 0 fail   (server eval-capture + run-types unit)
```

### Mutation — each guard deleted individually, marker count verified

```
drop executionMode shape check   marker 1 -> 0   4 fail  (all four executionMode cases)
drop the capture pair check      marker 2 -> 1   2 fail  (both directions)
```

`auth.ts` restored from a `cp` backup after each mutation.

**The first mutation run caught a flaw in my own test.** The `executionMode` cases originally minted a `behaviorRunId` alongside the bad mode, so the *pair* check rejected the token first and the tests stayed green with the shape check deleted — a test that proved nothing. Minting without `behaviorRunId` isolates the shape check, and that is also the genuinely reachable hole: a garbage mode with no run id is exactly what the pair check waves through. Comment at the call site records this so it is not "simplified" back.


## The bigger half: three re-mint paths dropped the pair entirely

Writing the pairing check made this visible, and it is worse than the gap that started the branch. A per-run token is minted once but its claim set is rebuilt **by hand** on three further paths, and none carried the capture claims. Confirmed against `origin/main`, not the working tree (`git grep -c executionMode origin/main -- <files>` → zero in both):

| path | what it does | effect of the drop |
|---|---|---|
| `durableClaims` (`agent-run-input.ts`) | persists to `agent_run_input.token_claims` | lost at the **DB boundary**, before any remint can preserve it |
| `attachFreshRunJobToken` | durable-replay remint | a replayed eval comes back live |
| `/worker/token/refresh` (`gateway/index.ts:949`) | mid-turn rotation | a long eval replay flips to live **mid-turn** |

The refresh mint's own comment says "Mint a fresh token with identical claims" while enumerating 17 of them by name. Every claim on `WorkerTokenData` is optional, so a mapper that forgets one still typechecks.

Consequence: any eval replay long enough to rotate its token, or replayed from durable input, silently stopped capturing and began performing real side effects — messages, uploads, commands — against the org it was scoring. That is the precise failure this feature exists to prevent, and it was reachable on the happy path.

Fixed at all three. Each mutation-verified:

```
drop pair from durableClaims + attachFreshRunJobToken   2 fail
drop pair from the refresh mint                         1 fail (mints a fresh token while THIS turn is live)
```

### The parity suite was already meant to catch this

`durable-replay-claim-parity.test.ts` exists for exactly this class — its docstring says so. It missed the capture pair because it asserted a hand-picked list (`allowedDomains`, `nixPackages`, `adminTools`, `adminActorUserId`). `nixPackages` was itself added after the same drift.

So the assertions are now a projection over the whole fixture:

```js
const project = (actual) =>
  Object.fromEntries(Object.keys(claims).map((k) => [k, actual?.[k]]));
expect(project(persisted)).toEqual(claims);
```

A claim can no longer be added to the fixture and left unasserted; keeping the fixture exhaustive is the only remaining discipline. Same shape as the fix in #2579.

## Notes

Not addressed here: whether `__tests__` should be typechecked repo-wide. No test file in this repo is currently typechecked, which is why these guards are runtime checks rather than types (see #2579).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker-token validation by rejecting invalid execution modes and incomplete capture details.
  * Preserved capture-run information when tokens are refreshed, persisted, or replayed.
  * Prevented capture side effects from being recorded when required run information is missing.
  * Improved consistency of capture details across token handling and replay flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->