### PR TITLE
fix(server): serve the onboarding skill as raw markdown

### DIFF
--- a/packages/server/src/__tests__/unit/http/skill-routes.test.ts
+++ b/packages/server/src/__tests__/unit/http/skill-routes.test.ts
@@ -8,10 +8,10 @@ import { LOBU_SKILL_MARKDOWN } from "../../../skills/lobu-skill.generated";
 describe("public skill route", () => {
   const app = createSkillRoutes();
 
-  it("serves the embedded Lobu skill markdown over HTTP", async () => {
+  it("serves the embedded Lobu skill markdown over HTTP as raw markdown", async () => {
     const res = await app.request("/skill/lobu");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { markdown: string };
-    expect(body.markdown).toBe(LOBU_SKILL_MARKDOWN);
+    expect(res.headers.get("content-type")).toContain("text/markdown");
+    expect(await res.text()).toBe(LOBU_SKILL_MARKDOWN);
   });
 });

--- a/packages/server/src/gateway/routes/public/skill.ts
+++ b/packages/server/src/gateway/routes/public/skill.ts
@@ -6,6 +6,11 @@
  * agent's CLI can fetch it without an MCP session. The content is a
  * committed generated constant (scripts/gen-skill-resource.ts), so it
  * ships identically in prod and local dev.
+ *
+ * Raw markdown (text/markdown), not JSON: the landing copy-prompt tells an
+ * agent to "fetch the Lobu skill" at this URL, and a bash-only agent doing
+ * `curl` should get the skill directly rather than having to unwrap a
+ * `{ markdown }` envelope.
  */
 import { Hono } from "hono";
 import { LOBU_SKILL_MARKDOWN } from "../../../skills/lobu-skill.generated";
@@ -13,7 +18,9 @@ import { LOBU_SKILL_MARKDOWN } from "../../../skills/lobu-skill.generated";
 export function createSkillRoutes() {
   const app = new Hono();
 
-  app.get("/skill/lobu", (c) => c.json({ markdown: LOBU_SKILL_MARKDOWN }));
+  app.get("/skill/lobu", (c) =>
+    c.text(LOBU_SKILL_MARKDOWN, 200, { "Content-Type": "text/markdown; charset=utf-8" })
+  );
 
   return app;
 }


### PR DESCRIPTION
## Summary
GET /api/skill/lobu returned `{ markdown: ... }` JSON, but the landing copy-prompt tells an agent to "fetch the Lobu skill" at that URL. A bash-only agent doing `curl` got an envelope it had to unwrap instead of the skill. Serve `text/markdown` directly so "fetch the skill" works as written.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Targeted `bun test src/__tests__/unit/http/skill-routes.test.ts`
- [x] Bug fix: red→fix→green outputs below

**Red** (route mutated back to `c.json({ markdown })`):
```
(fail) public skill route > serves the embedded Lobu skill markdown over HTTP as raw markdown [1.77ms]
 0 pass / 1 fail
```

**Green** (fix in place):
```
1 pass / 0 fail / 3 expect() calls
```

## Notes
The landing copy-prompt (separate repo PR) points at `lobu.ai/api/skill/lobu` which 404s; this makes the endpoint serve what the prompt promises. No consumer parses the JSON shape — only the route test did (updated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `/skill/lobu` endpoint to return raw skill instructions as Markdown.
  * Added the correct `text/markdown` content type and UTF-8 encoding for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->