### PR TITLE
feat(server): promote a Behavior run into a reusable eval case

### DIFF
--- a/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
@@ -249,6 +249,48 @@ describe("promoteEvalCase", () => {
 		expect(deleted.deleted_at).not.toBeNull();
 	});
 
+	test("repoints a live claim left pointing at a deleted case", async () => {
+		// The REAL delete path: `deleteEntity` does `UPDATE entities SET deleted_at`
+		// and never touches `entity_identities`, so the live claim outlives the row
+		// it names. The sibling test above deletes the claim by hand and therefore
+		// never exercises this. Without the reconciling upsert the claim stays
+		// pointed at the dead row forever, `findEvalCaseByIdentifier` (which joins
+		// live entities) never resolves again, and the identity lock is silently
+		// dead for this (run, key).
+		const first = await promoteEvalCase({ sourceRunId, caseKey: "soft-gone" });
+		expect(first.ok).toBe(true);
+		if (!first.ok) return;
+
+		await sql`
+      UPDATE entities SET deleted_at = current_timestamp
+      WHERE id = ${first.evalCase.entityId}
+    `;
+
+		const second = await promoteEvalCase({ sourceRunId, caseKey: "soft-gone" });
+		expect(second.ok).toBe(true);
+		if (!second.ok) return;
+		expect(second.evalCase.entityId).not.toBe(first.evalCase.entityId);
+
+		// The claim must now name the LIVE case, not the tombstone.
+		const claims = (await sql`
+      SELECT entity_id
+      FROM entity_identities
+      WHERE organization_id = ${organizationId}
+        AND namespace = ${EVAL_CASE_NAMESPACE}
+        AND identifier = ${`${sourceRunId}:soft-gone`}
+        AND deleted_at IS NULL
+    `) as unknown as Array<{ entity_id: number | string }>;
+		expect(claims).toHaveLength(1);
+		expect(Number(claims[0].entity_id)).toBe(second.evalCase.entityId);
+
+		// And the fast path works again: a third promote resolves via the claim.
+		const third = await promoteEvalCase({ sourceRunId, caseKey: "soft-gone" });
+		expect(third.ok).toBe(true);
+		if (!third.ok) return;
+		expect(third.created).toBe(false);
+		expect(third.evalCase.entityId).toBe(second.evalCase.entityId);
+	});
+
 	test("different case keys on one run are different cases", async () => {
 		const a = await promoteEvalCase({ sourceRunId, caseKey: "angle-a" });
 		const b = await promoteEvalCase({ sourceRunId, caseKey: "angle-b" });

--- a/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Promoting a Behavior run into a reusable eval case, and replaying it.
+ *
+ * The load-bearing claims here are that a case is a POINTER (not a copy of the
+ * dispatch payload, which would be free to drift from the run it replays), that
+ * promote and replay agree on what "replayable" means, and that the identity
+ * claim makes a repeat promote resolve to the existing case.
+ */
+
+import { beforeAll, describe, expect, test } from "vitest";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+import {
+	EVAL_CASE_NAMESPACE,
+	promoteEvalCase,
+	replayEvalCase,
+} from "../../../runs/eval-cases";
+import { EVAL_CASE_ENTITY_TYPE_SLUG } from "../../../tools/constants";
+import { BEHAVIOR_EVAL_RUN_TYPE } from "../../../runs/run-types";
+
+const sql = getTestDb();
+
+let organizationId: string;
+let behaviorId: number;
+let sourceRunId: number;
+/** A run the eval lanes could never claim — device-pinned. */
+let devicePinnedRunId: number;
+
+const payload = {
+	watcher_id: 0,
+	agent_id: "11111111-2222-3333-4444-555555555555",
+	window_start: "2026-08-01T00:00:00.000Z",
+	window_end: "2026-08-01T01:00:00.000Z",
+	dispatch_source: "scheduled",
+	version_id: 42,
+};
+
+async function insertBehaviorRun(
+	extraPayload: Record<string, unknown>,
+): Promise<number> {
+	const [run] = await sql<{ id: number }[]>`
+    INSERT INTO runs (
+      organization_id, run_type, watcher_id, approval_status, status,
+      approved_input, completed_at, created_at
+    ) VALUES (
+      ${organizationId}, 'behavior', ${behaviorId}, 'auto', 'completed',
+      ${sql.json({ ...payload, watcher_id: behaviorId, ...extraPayload })},
+      current_timestamp, current_timestamp
+    )
+    RETURNING id
+  `;
+	return run.id;
+}
+
+beforeAll(async () => {
+	// See eval-run-capture.test.ts: Behavior ids come from a MAX(id)+1 helper,
+	// so a Behavior created by an earlier file leaves the sequence behind.
+	await cleanupTestDatabase();
+
+	const org = await createTestOrganization();
+	organizationId = org.id;
+	const creator = await createTestUser();
+	// resolveEntityCreator falls back to an org owner/admin, and
+	// entities.created_by is NOT NULL — without a membership row nothing can be
+	// promoted at all.
+	await addUserToOrganization(creator.id, organizationId, "owner");
+
+	const [behavior] = (await sql`
+    WITH next_id AS (
+      SELECT nextval('watchers_id_seq')::integer AS id
+    )
+    INSERT INTO watchers (
+      id, watcher_group_id, organization_id, created_by, name, slug, schedule, status
+    )
+    SELECT id, id, ${organizationId}, ${creator.id}, 'Eval Case Source', 'eval-case-src', '0 * * * *', 'active'
+    FROM next_id
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	behaviorId = Number(behavior.id);
+
+	sourceRunId = await insertBehaviorRun({});
+	devicePinnedRunId = await insertBehaviorRun({
+		device_worker_id: "device-abc",
+	});
+});
+
+describe("promoteEvalCase", () => {
+	test("creates a $eval_case entity pointing at the source run", async () => {
+		const result = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "case-1",
+			expectation: "names the duplicate groups",
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.created).toBe(true);
+		expect(result.evalCase.sourceRunId).toBe(sourceRunId);
+		expect(result.evalCase.behaviorId).toBe(behaviorId);
+
+		const [entity] = (await sql`
+      SELECT e.metadata, et.slug AS type_slug
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.id = ${result.evalCase.entityId}
+    `) as unknown as Array<{
+			metadata: Record<string, unknown>;
+			type_slug: string;
+		}>;
+
+		expect(entity.type_slug).toBe(EVAL_CASE_ENTITY_TYPE_SLUG);
+		expect(entity.metadata.source_run_id).toBe(sourceRunId);
+		expect(entity.metadata.behavior_id).toBe(behaviorId);
+		expect(entity.metadata.case_key).toBe("case-1");
+		expect(entity.metadata.expectation).toBe("names the duplicate groups");
+		expect(entity.metadata.status).toBe("active");
+	});
+
+	test("stores a pointer, never a copy of the frozen dispatch payload", async () => {
+		// The whole reason a case is a pointer: a copied payload can drift from
+		// the run it claims to replay, and then the case measures a question
+		// nobody asked. Assert the payload is absent rather than merely equal.
+		const result = await promoteEvalCase({ sourceRunId, caseKey: "case-1" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		const [entity] = (await sql`
+      SELECT metadata FROM entities WHERE id = ${result.evalCase.entityId}
+    `) as unknown as Array<{ metadata: Record<string, unknown> }>;
+
+		expect(entity.metadata.approved_input).toBeUndefined();
+		expect(entity.metadata.window_start).toBeUndefined();
+		expect(entity.metadata.agent_id).toBeUndefined();
+	});
+
+	test("is idempotent per (source run, case key)", async () => {
+		const first = await promoteEvalCase({ sourceRunId, caseKey: "repeat" });
+		const second = await promoteEvalCase({ sourceRunId, caseKey: "repeat" });
+
+		expect(first.ok && second.ok).toBe(true);
+		if (!first.ok || !second.ok) return;
+		expect(first.created).toBe(true);
+		expect(second.created).toBe(false);
+		expect(second.evalCase.entityId).toBe(first.evalCase.entityId);
+
+		const claims = (await sql`
+      SELECT count(*)::int AS n
+      FROM entity_identities
+      WHERE organization_id = ${organizationId}
+        AND namespace = ${EVAL_CASE_NAMESPACE}
+        AND identifier = ${`${sourceRunId}:repeat`}
+        AND deleted_at IS NULL
+    `) as unknown as Array<{ n: number }>;
+		expect(claims[0].n).toBe(1);
+
+		// Assert the ENTITY count too, not just the returned contract. Promote has
+		// three layers that each independently return the existing case (the claim
+		// fast path, the slug-collision branch, the post-insert race re-read), so
+		// the return value stays correct even when a layer is broken — while a
+		// stray duplicate entity is silently left behind. Only counting rows
+		// catches that.
+		const entities = (await sql`
+      SELECT count(*)::int AS n
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${organizationId}
+        AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+        AND e.metadata->>'case_key' = 'repeat'
+        AND e.deleted_at IS NULL
+    `) as unknown as Array<{ n: number }>;
+		expect(entities[0].n).toBe(1);
+	});
+
+	test("adopts its own entity when the identity claim is missing", async () => {
+		// The recovery path: a promote that died between the entity insert and its
+		// claim. The slug is already taken by THIS case, so re-promoting must adopt
+		// that row and re-claim it — not mint a second entity beside it.
+		const first = await promoteEvalCase({ sourceRunId, caseKey: "orphaned" });
+		expect(first.ok).toBe(true);
+		if (!first.ok) return;
+
+		await sql`
+      DELETE FROM entity_identities
+      WHERE organization_id = ${organizationId}
+        AND namespace = ${EVAL_CASE_NAMESPACE}
+        AND identifier = ${`${sourceRunId}:orphaned`}
+    `;
+
+		const second = await promoteEvalCase({ sourceRunId, caseKey: "orphaned" });
+		expect(second.ok).toBe(true);
+		if (!second.ok) return;
+		expect(second.evalCase.entityId).toBe(first.evalCase.entityId);
+		expect(second.created).toBe(false);
+
+		const entities = (await sql`
+      SELECT count(*)::int AS n
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${organizationId}
+        AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+        AND e.metadata->>'case_key' = 'orphaned'
+        AND e.deleted_at IS NULL
+    `) as unknown as Array<{ n: number }>;
+		expect(entities[0].n).toBe(1);
+
+		// And the claim is back, so the fast path covers the next promote.
+		const claims = (await sql`
+      SELECT count(*)::int AS n
+      FROM entity_identities
+      WHERE organization_id = ${organizationId}
+        AND namespace = ${EVAL_CASE_NAMESPACE}
+        AND identifier = ${`${sourceRunId}:orphaned`}
+        AND deleted_at IS NULL
+    `) as unknown as Array<{ n: number }>;
+		expect(claims[0].n).toBe(1);
+	});
+
+	test("does not resurrect a deleted case holding the slug", async () => {
+		// `entities_slug_parent_unique` is NOT partial on `deleted_at`, so a retired
+		// case keeps its slug forever. Adopting it would silently un-delete it.
+		const first = await promoteEvalCase({ sourceRunId, caseKey: "retired" });
+		expect(first.ok).toBe(true);
+		if (!first.ok) return;
+
+		await sql`
+      UPDATE entities SET deleted_at = current_timestamp
+      WHERE id = ${first.evalCase.entityId}
+    `;
+		await sql`
+      DELETE FROM entity_identities
+      WHERE organization_id = ${organizationId}
+        AND namespace = ${EVAL_CASE_NAMESPACE}
+        AND identifier = ${`${sourceRunId}:retired`}
+    `;
+
+		const second = await promoteEvalCase({ sourceRunId, caseKey: "retired" });
+		expect(second.ok).toBe(true);
+		if (!second.ok) return;
+		expect(second.created).toBe(true);
+		expect(second.evalCase.entityId).not.toBe(first.evalCase.entityId);
+
+		const [deleted] = (await sql`
+      SELECT deleted_at FROM entities WHERE id = ${first.evalCase.entityId}
+    `) as unknown as Array<{ deleted_at: Date | null }>;
+		expect(deleted.deleted_at).not.toBeNull();
+	});
+
+	test("different case keys on one run are different cases", async () => {
+		const a = await promoteEvalCase({ sourceRunId, caseKey: "angle-a" });
+		const b = await promoteEvalCase({ sourceRunId, caseKey: "angle-b" });
+
+		expect(a.ok && b.ok).toBe(true);
+		if (!a.ok || !b.ok) return;
+		expect(a.evalCase.entityId).not.toBe(b.evalCase.entityId);
+	});
+
+	test("keys that slugify alike stay separate cases", async () => {
+		// `slugifyCaseKey` is lossy, so both keys want the same entity slug — and
+		// `entities_slug_parent_unique` grants it to whoever asks first. Folding
+		// them together would make the second case replay under the FIRST key's
+		// idempotency key, silently answering a question nobody asked.
+		const a = await promoteEvalCase({ sourceRunId, caseKey: "Tone Check" });
+		const b = await promoteEvalCase({ sourceRunId, caseKey: "tone-check" });
+
+		expect(a.ok && b.ok).toBe(true);
+		if (!a.ok || !b.ok) return;
+		expect(b.created).toBe(true);
+		expect(b.evalCase.entityId).not.toBe(a.evalCase.entityId);
+		expect(a.evalCase.caseKey).toBe("Tone Check");
+		expect(b.evalCase.caseKey).toBe("tone-check");
+
+		// And each replays under its OWN key.
+		const runA = await replayEvalCase(a.evalCase.entityId);
+		const runB = await replayEvalCase(b.evalCase.entityId);
+		expect(runA?.runId).not.toBe(runB?.runId);
+	});
+
+	test("refuses a source the replay path could never dispatch", async () => {
+		// The extraction's whole point: promote and replay share one predicate,
+		// so a promoted case is always one that can actually run.
+		const result = await promoteEvalCase({
+			sourceRunId: devicePinnedRunId,
+			caseKey: "pinned",
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.reason).toBe("not_dispatchable");
+
+		const rows = (await sql`
+      SELECT count(*)::int AS n
+      FROM entity_identities
+      WHERE namespace = ${EVAL_CASE_NAMESPACE}
+        AND identifier = ${`${devicePinnedRunId}:pinned`}
+    `) as unknown as Array<{ n: number }>;
+		expect(rows[0].n).toBe(0);
+	});
+
+	test("refuses a run that does not exist", async () => {
+		const result = await promoteEvalCase({
+			sourceRunId: 999_999_999,
+			caseKey: "ghost",
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.reason).toBe("not_found");
+	});
+});
+
+describe("replayEvalCase", () => {
+	test("mints an eval run from the case's source run", async () => {
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "replayable",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		const run = await replayEvalCase(promoted.evalCase.entityId);
+		expect(run).not.toBeNull();
+		if (!run) return;
+		expect(run.sourceRunId).toBe(sourceRunId);
+
+		const [row] = (await sql`
+      SELECT run_type, status, idempotency_key, approved_input
+      FROM runs WHERE id = ${run.runId}
+    `) as unknown as Array<{
+			run_type: string;
+			status: string;
+			idempotency_key: string;
+			approved_input: Record<string, unknown>;
+		}>;
+
+		expect(row.run_type).toBe(BEHAVIOR_EVAL_RUN_TYPE);
+		expect(row.status).toBe("pending");
+		// The case key — not the entity id — scopes replay idempotency.
+		expect(row.idempotency_key).toBe(
+			`behavior_eval:${sourceRunId}:replayable`,
+		);
+		// Resolved from the SOURCE run at replay time, verbatim.
+		expect(row.approved_input.window_start).toBe(payload.window_start);
+	});
+
+	test("returns null for an entity id that does not exist", async () => {
+		const run = await replayEvalCase(999_999_999);
+		expect(run).toBeNull();
+	});
+
+	test("returns null for an entity that is not an eval case", async () => {
+		// `source_run_id` is not a reserved metadata key, so an unrelated entity
+		// carrying one must not be replayable just because the id was passed in.
+		const [type] = (await sql`
+      INSERT INTO entity_types (slug, name, organization_id, created_at, updated_at)
+      VALUES ('note', 'Note', ${organizationId}, current_timestamp, current_timestamp)
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+		const [creator] = (await sql`
+      SELECT "userId" FROM "member" WHERE "organizationId" = ${organizationId} LIMIT 1
+    `) as unknown as Array<{ userId: string }>;
+		const [impostor] = (await sql`
+      INSERT INTO entities (
+        organization_id, entity_type_id, name, slug, metadata,
+        created_by, created_at, updated_at
+      ) VALUES (
+        ${organizationId}, ${type.id}, 'Not A Case', 'not-a-case',
+        ${sql.json({ source_run_id: sourceRunId, case_key: "impostor" })},
+        ${creator.userId}, current_timestamp, current_timestamp
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+		const run = await replayEvalCase(Number(impostor.id));
+		expect(run).toBeNull();
+	});
+});

--- a/packages/server/src/runs/eval-cases.ts
+++ b/packages/server/src/runs/eval-cases.ts
@@ -395,6 +395,21 @@ async function findEvalCaseByIdentifier(
 	};
 }
 
+/**
+ * Claim the (source run, case key) identity for this entity.
+ *
+ * Repoints the claim when — and only when — it currently points at a
+ * soft-deleted entity. `deleteEntity` does `UPDATE entities SET deleted_at` and
+ * never touches `entity_identities`, so after a case is retired the live claim
+ * outlives the row it names. A plain `DO NOTHING` would leave it that way
+ * forever: `findEvalCaseByIdentifier` joins on live entities, so it would never
+ * resolve again and the documented identity lock would be silently dead for
+ * that (run, key) — promotes would keep limping along on slug adoption instead.
+ *
+ * The `WHERE EXISTS (… deleted_at IS NOT NULL)` is what keeps this from
+ * clobbering a live claim: a concurrent replica that legitimately won the
+ * identifier still wins, because its row is live and the update is skipped.
+ */
 async function claimEvalCaseIdentity(
 	sql: DbClient,
 	organizationId: string,
@@ -408,7 +423,13 @@ async function claimEvalCaseIdentity(
       ${organizationId}, ${entityId}, ${EVAL_CASE_NAMESPACE}, ${identifier},
       current_timestamp
     )
-    ON CONFLICT DO NOTHING
+    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    DO UPDATE SET entity_id = EXCLUDED.entity_id, updated_at = current_timestamp
+    WHERE EXISTS (
+      SELECT 1 FROM entities de
+      WHERE de.id = entity_identities.entity_id
+        AND de.deleted_at IS NOT NULL
+    )
   `;
 }
 

--- a/packages/server/src/runs/eval-cases.ts
+++ b/packages/server/src/runs/eval-cases.ts
@@ -1,0 +1,426 @@
+/**
+ * Eval cases (evals PR 3, lobu#2564).
+ *
+ * A case is a real Behavior run somebody decided is worth asking again.
+ * Promoting one freezes that judgement as a `$eval_case` entity so the case set
+ * is a reviewable thing in the workspace — diffable, commentable, owned by a
+ * person — rather than a list of run ids in someone's notes.
+ *
+ * A case stores a POINTER, never a copy. `runs.approved_input` on the source
+ * run is already the frozen dispatch payload and `createEvalRun` copies it
+ * verbatim at replay time; duplicating it onto the case would create a second
+ * copy free to drift from the run it claims to replay, and a case that no
+ * longer matches its source is worse than no case. What the case adds is the
+ * part no `runs` row carries: `expectation`, the human statement of what a good
+ * answer looks like.
+ *
+ * `expectation` has NO consumer yet — PR 4's judge is what reads it. It is
+ * captured now because it has to be written while the person still remembers
+ * why the run mattered; recovering it later from a run id is guesswork.
+ *
+ * Identity is the (source run, case key) pair, claimed in `entity_identities`
+ * under the `eval_case` namespace. The partial unique index
+ * `idx_entity_identities_live_unique (organization_id, namespace, identifier)
+ * WHERE deleted_at IS NULL` is the multi-replica lock, so two operators
+ * promoting the same run concurrently resolve to one case rather than two.
+ */
+
+import { type DbClient, getDb } from "../db/client.js";
+import { EVAL_CASE_ENTITY_TYPE_SLUG } from "../tools/constants.js";
+import logger from "../utils/logger.js";
+import { resolveEntityCreator } from "../utils/resolve-entity-creator.js";
+import {
+	createEvalRun,
+	type CreateEvalRunResult,
+	loadReplayableSource,
+	type ReplaySourceRejection,
+} from "./eval-runs.js";
+
+/** Namespace for the (source run, case key) identity claim in `entity_identities`. */
+export const EVAL_CASE_NAMESPACE = "eval_case";
+
+/**
+ * Declared shape of `$eval_case` metadata.
+ *
+ * `readOnly` on the pointer fields is a HINT to whatever renders the entity —
+ * nothing server-side enforces it, and no write path here consults it. It says
+ * what editing them would mean: repointing a case at a different question while
+ * keeping its comments and history. Promote a new case instead.
+ */
+const EVAL_CASE_METADATA_SCHEMA = {
+	type: "object",
+	properties: {
+		source_run_id: {
+			type: "integer",
+			description: "Behavior run this case replays",
+			readOnly: true,
+			"x-table-column": true,
+		},
+		behavior_id: {
+			type: "integer",
+			description: "Behavior",
+			readOnly: true,
+			"x-table-column": true,
+		},
+		case_key: {
+			type: "string",
+			description: "Distinguishes several cases promoted from one run",
+			readOnly: true,
+		},
+		expectation: {
+			type: "string",
+			description: "What a good answer to this case looks like",
+		},
+		status: {
+			enum: ["active", "retired"],
+			type: "string",
+			description: "Status",
+			"x-table-column": true,
+		},
+	},
+} as const;
+
+export interface EvalCase {
+	entityId: number;
+	organizationId: string;
+	sourceRunId: number;
+	behaviorId: number;
+	caseKey: string;
+}
+
+export type PromoteEvalCaseResult =
+	| { ok: true; evalCase: EvalCase; created: boolean }
+	| {
+			ok: false;
+			reason:
+				| ReplaySourceRejection
+				| "no_attributable_member"
+				| "slug_unavailable";
+	  };
+
+/**
+ * Promote a real Behavior run into a reusable eval case.
+ *
+ * Validates with the SAME predicate the replay path uses
+ * (`loadReplayableSource`), so a promoted case is always one that can actually
+ * run. Promoting a case that would later fail at replay produces a case set
+ * that looks healthy and silently measures nothing.
+ *
+ * Idempotent per (sourceRunId, caseKey): a repeat promote resolves to the
+ * existing case rather than minting a second entity for the same question.
+ */
+export async function promoteEvalCase(
+	params: {
+		sourceRunId: number;
+		caseKey: string;
+		expectation?: string | null;
+		/** Who is promoting. Falls back to an org owner/admin when absent. */
+		createdBy?: string | null;
+	},
+	db?: DbClient,
+): Promise<PromoteEvalCaseResult> {
+	const sql = db ?? getDb();
+	const caseKey = params.caseKey.trim() || "default";
+
+	const loaded = await loadReplayableSource(params.sourceRunId, sql);
+	if (!loaded.ok) return { ok: false, reason: loaded.reason };
+	const source = loaded.source;
+	const identifier = `${source.sourceRunId}:${caseKey}`;
+
+	// Existing claim → reuse (idempotent fast path, and the common case when a
+	// promote is retried after a transient failure).
+	const existing = await findEvalCaseByIdentifier(
+		sql,
+		source.organizationId,
+		identifier,
+	);
+	if (existing) return { ok: true, evalCase: existing, created: false };
+
+	const createdBy = await resolveEntityCreator(
+		sql,
+		source.organizationId,
+		params.createdBy,
+	);
+	if (!createdBy) {
+		// entities.created_by is NOT NULL behind ON DELETE RESTRICT.
+		logger.warn(
+			{ sourceRunId: source.sourceRunId, organizationId: source.organizationId },
+			"[evals] no live member to attribute the eval case to — not promoting",
+		);
+		return { ok: false, reason: "no_attributable_member" };
+	}
+
+	const entityTypeRows = (await sql`
+    INSERT INTO entity_types (
+      slug, name, description, icon, metadata_schema,
+      organization_id, created_at, updated_at
+    )
+    VALUES (
+      ${EVAL_CASE_ENTITY_TYPE_SLUG}, 'Eval case',
+      'A Behavior run promoted into a reusable evaluation case', 'flask-conical',
+      ${sql.json(EVAL_CASE_METADATA_SCHEMA as never)},
+      ${source.organizationId}, current_timestamp, current_timestamp
+    )
+    ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+    DO UPDATE SET updated_at = entity_types.updated_at
+    RETURNING id
+  `) as unknown as Array<{ id: number | string }>;
+	// `ON CONFLICT … DO UPDATE … RETURNING` always yields the row, new or existing.
+	const entityTypeId = Number(entityTypeRows[0].id);
+
+	const placed = await insertCaseEntity({
+		sql,
+		organizationId: source.organizationId,
+		entityTypeId,
+		createdBy,
+		name: `Eval case · run ${source.sourceRunId} · ${caseKey}`,
+		baseSlug: `eval-case-${source.sourceRunId}-${slugifyCaseKey(caseKey)}`,
+		sourceRunId: source.sourceRunId,
+		caseKey,
+		metadata: {
+			source_run_id: source.sourceRunId,
+			behavior_id: source.behaviorId,
+			case_key: caseKey,
+			expectation: params.expectation?.trim() || null,
+			status: "active",
+		},
+	});
+
+	if (placed == null) {
+		logger.warn(
+			{ sourceRunId: source.sourceRunId, caseKey },
+			"[evals] every candidate slug is held by a different case — not promoting",
+		);
+		return { ok: false, reason: "slug_unavailable" };
+	}
+
+	const entityId = placed.entityId;
+	await claimEvalCaseIdentity(sql, source.organizationId, identifier, entityId);
+
+	// A racing replica may have won the claim with ITS entity. Whoever the claim
+	// resolves to is the case; re-read rather than trusting the local insert.
+	const winner = await findEvalCaseByIdentifier(
+		sql,
+		source.organizationId,
+		identifier,
+	);
+	if (winner && winner.entityId !== entityId) {
+		logger.info(
+			{ lostEntityId: entityId, wonEntityId: winner.entityId, identifier },
+			"[evals] lost the eval-case identity race — reusing the winner",
+		);
+		return { ok: true, evalCase: winner, created: false };
+	}
+
+	if (placed.created) {
+		logger.info(
+			{
+				entityId,
+				sourceRunId: source.sourceRunId,
+				behaviorId: source.behaviorId,
+				caseKey,
+			},
+			"[evals] Promoted a Behavior run into an eval case",
+		);
+	}
+	return {
+		ok: true,
+		evalCase: {
+			entityId,
+			organizationId: source.organizationId,
+			sourceRunId: source.sourceRunId,
+			behaviorId: source.behaviorId,
+			caseKey,
+		},
+		created: placed.created,
+	};
+}
+
+/**
+ * Replay a promoted case: mint an eval run from the case's source run.
+ *
+ * The case's own `case_key` scopes replay idempotency, which is what makes
+ * repeat replays safe — `createEvalRun`'s partial unique index covers only
+ * pending/claimed/running, so replaying a case whose last eval FINISHED queues
+ * a fresh one, while replaying a case with an eval still in flight returns that
+ * one instead of stacking duplicates.
+ */
+export async function replayEvalCase(
+	entityId: number,
+	db?: DbClient,
+): Promise<CreateEvalRunResult | null> {
+	const sql = db ?? getDb();
+	// Constrained to the case type: `source_run_id` is not a reserved key, so a
+	// bare id lookup would happily "replay" any unrelated entity carrying one.
+	const rows = (await sql`
+    SELECT e.metadata
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.id = ${entityId}
+      AND e.deleted_at IS NULL
+      AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+    LIMIT 1
+  `) as unknown as Array<{ metadata: Record<string, unknown> | null }>;
+
+	if (rows.length === 0) {
+		logger.warn({ entityId }, "[evals] no such eval case to replay");
+		return null;
+	}
+	const metadata = rows[0].metadata ?? {};
+	const sourceRunId = Number(metadata.source_run_id);
+	const caseKey =
+		typeof metadata.case_key === "string" ? metadata.case_key : "default";
+	if (!Number.isSafeInteger(sourceRunId) || sourceRunId < 1) {
+		logger.warn(
+			{ entityId },
+			"[evals] eval case carries no usable source_run_id — not replaying",
+		);
+		return null;
+	}
+
+	return createEvalRun({ sourceRunId, caseKey }, sql);
+}
+
+/**
+ * How many readable numeric suffixes (`-2`, `-3`, …) to try when the base slug
+ * is taken. Matches promote-keyed-entities' `SLUG_DISAMBIGUATION_ATTEMPTS`.
+ */
+const SLUG_DISAMBIGUATION_ATTEMPTS = 5;
+
+/**
+ * Insert the case entity, tolerating a collision on
+ * `entities_slug_parent_unique (organization_id, COALESCE(parent_id, 0), slug)`.
+ *
+ * The slug cannot be treated as the identity. `slugifyCaseKey` is lossy — a run
+ * promoted under `angle-a`, `angle_a` and `Angle A` produces one slug for three
+ * different questions — and the index is NOT partial on `deleted_at`, so a
+ * retired case keeps holding its slug forever. Adopting whichever row owns the
+ * slug would fold distinct cases together and then replay them under the wrong
+ * `case_key`, which is the wrong idempotency key. So adopt only the row that is
+ * genuinely this (run, key) — the real recovery case, a promote that died
+ * between the insert and its identity claim — and otherwise take a suffixed
+ * slug. The `entity_identities` claim is the identity; the slug is cosmetic.
+ *
+ * Returns null when every candidate slug is held by some other case.
+ */
+async function insertCaseEntity(params: {
+	sql: DbClient;
+	organizationId: string;
+	entityTypeId: number;
+	createdBy: string;
+	name: string;
+	baseSlug: string;
+	sourceRunId: number;
+	caseKey: string;
+	metadata: Record<string, unknown>;
+}): Promise<{ entityId: number; created: boolean } | null> {
+	const { sql } = params;
+	for (let attempt = 1; attempt <= SLUG_DISAMBIGUATION_ATTEMPTS; attempt++) {
+		const slug =
+			attempt === 1 ? params.baseSlug : `${params.baseSlug}-${attempt}`;
+		const inserted = (await sql`
+      INSERT INTO entities (
+        organization_id, entity_type_id, name, slug, metadata,
+        created_by, created_at, updated_at
+      ) VALUES (
+        ${params.organizationId}, ${params.entityTypeId}, ${params.name}, ${slug},
+        ${sql.json(params.metadata as never)}, ${params.createdBy},
+        current_timestamp, current_timestamp
+      )
+      ON CONFLICT DO NOTHING
+      RETURNING id
+    `) as unknown as Array<{ id: number | string }>;
+		if (inserted.length > 0) {
+			return { entityId: Number(inserted[0].id), created: true };
+		}
+
+		// Soft-deleted rows still hold the slug (the index is not partial), so look
+		// without the `deleted_at` filter and only adopt a LIVE matching case.
+		const owner = (await sql`
+      SELECT e.id, e.metadata, e.deleted_at, et.slug AS type_slug
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${params.organizationId}
+        AND COALESCE(e.parent_id, 0) = 0
+        AND e.slug = ${slug}
+      LIMIT 1
+    `) as unknown as Array<{
+			id: number | string;
+			metadata: Record<string, unknown> | null;
+			deleted_at: Date | null;
+			type_slug: string;
+		}>;
+		const row = owner[0];
+		if (
+			row &&
+			row.deleted_at == null &&
+			row.type_slug === EVAL_CASE_ENTITY_TYPE_SLUG &&
+			Number(row.metadata?.source_run_id) === params.sourceRunId &&
+			row.metadata?.case_key === params.caseKey
+		) {
+			return { entityId: Number(row.id), created: false };
+		}
+	}
+	return null;
+}
+
+async function findEvalCaseByIdentifier(
+	sql: DbClient,
+	organizationId: string,
+	identifier: string,
+): Promise<EvalCase | null> {
+	const rows = (await sql`
+    SELECT e.id, e.metadata
+    FROM entity_identities ei
+    JOIN entities e ON e.id = ei.entity_id
+    WHERE ei.organization_id = ${organizationId}
+      AND ei.namespace = ${EVAL_CASE_NAMESPACE}
+      AND ei.identifier = ${identifier}
+      AND ei.deleted_at IS NULL
+      AND e.deleted_at IS NULL
+    LIMIT 1
+  `) as unknown as Array<{
+		id: number | string;
+		metadata: Record<string, unknown> | null;
+	}>;
+	if (rows.length === 0) return null;
+	const metadata = rows[0].metadata ?? {};
+	return {
+		entityId: Number(rows[0].id),
+		organizationId,
+		sourceRunId: Number(metadata.source_run_id),
+		behaviorId: Number(metadata.behavior_id),
+		caseKey:
+			typeof metadata.case_key === "string" ? metadata.case_key : "default",
+	};
+}
+
+async function claimEvalCaseIdentity(
+	sql: DbClient,
+	organizationId: string,
+	identifier: string,
+	entityId: number,
+): Promise<void> {
+	await sql`
+    INSERT INTO entity_identities (
+      organization_id, entity_id, namespace, identifier, created_at
+    ) VALUES (
+      ${organizationId}, ${entityId}, ${EVAL_CASE_NAMESPACE}, ${identifier},
+      current_timestamp
+    )
+    ON CONFLICT DO NOTHING
+  `;
+}
+
+/**
+ * Slug-safe form of a case key. Kept local rather than reusing `slugify`: this
+ * feeds an entity slug that must stay stable for the life of the case, so it
+ * must not drift when the shared slugify helper changes.
+ */
+function slugifyCaseKey(caseKey: string): string {
+	const cleaned = caseKey
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return cleaned || "default";
+}

--- a/packages/server/src/runs/eval-runs.ts
+++ b/packages/server/src/runs/eval-runs.ts
@@ -26,29 +26,40 @@ export interface CreateEvalRunResult {
 	created: boolean;
 }
 
-/**
- * Clone a terminal Behavior run into a pending eval replay.
- *
- * `caseKey` scopes idempotency: re-running with the same (sourceRunId,
- * caseKey) reuses the in-flight eval rather than queueing a second one. Pass a
- * distinct key (an attempt number, a case id) to run the same source run
- * several times — which is the point, since a single trial is not a
- * measurement.
- *
- * Returns null when the source run does not exist, is not a Behavior run, or
- * carries no frozen payload to replay.
- */
-export async function createEvalRun(
-	params: { sourceRunId: number; caseKey: string },
-	db?: DbClient,
-): Promise<CreateEvalRunResult | null> {
-	const sql = db ?? getDb();
-	const idempotencyKey = `behavior_eval:${params.sourceRunId}:${params.caseKey}`;
+/** Why a Behavior run cannot be replayed. Stable strings — callers surface them. */
+export type ReplaySourceRejection =
+	| "not_found"
+	| "no_frozen_payload"
+	| "not_dispatchable";
 
+export interface ReplayableSource {
+	sourceRunId: number;
+	organizationId: string;
+	behaviorId: number;
+	approvedInput: unknown;
+}
+
+export type LoadReplayableSourceResult =
+	| { ok: true; source: ReplayableSource }
+	| { ok: false; reason: ReplaySourceRejection };
+
+/**
+ * Resolve a Behavior run into something an eval can actually replay.
+ *
+ * Extracted so promoting a case and minting a run apply the SAME rule. A case
+ * that passes promote but fails at replay would be a case set that silently
+ * cannot run, which is worse than refusing the promote — so this is the one
+ * definition of "replayable" and both callers ask it.
+ */
+export async function loadReplayableSource(
+	sourceRunId: number,
+	db?: DbClient,
+): Promise<LoadReplayableSourceResult> {
+	const sql = db ?? getDb();
 	const source = (await sql`
     SELECT id, organization_id, watcher_id, approved_input
     FROM runs
-    WHERE id = ${params.sourceRunId}
+    WHERE id = ${sourceRunId}
       AND run_type = ${BEHAVIOR_RUN_TYPE}
     LIMIT 1
   `) as unknown as Array<{
@@ -59,19 +70,16 @@ export async function createEvalRun(
 	}>;
 
 	if (source.length === 0) {
-		logger.warn(
-			{ sourceRunId: params.sourceRunId },
-			"[evals] No such Behavior run to replay",
-		);
-		return null;
+		logger.warn({ sourceRunId }, "[evals] No such Behavior run to replay");
+		return { ok: false, reason: "not_found" };
 	}
 	const row = source[0];
 	if (!row.organization_id || !row.watcher_id || !row.approved_input) {
 		logger.warn(
-			{ sourceRunId: params.sourceRunId },
+			{ sourceRunId },
 			"[evals] Behavior run has no frozen dispatch payload — nothing to replay",
 		);
-		return null;
+		return { ok: false, reason: "no_frozen_payload" };
 	}
 
 	// Refuse a source whose clone no eval lane could ever claim. The cloud
@@ -91,14 +99,48 @@ export async function createEvalRun(
 	if (devicePin || !agentId) {
 		logger.warn(
 			{
-				sourceRunId: params.sourceRunId,
+				sourceRunId,
 				devicePinned: Boolean(devicePin),
 				hasAgent: Boolean(agentId),
 			},
 			"[evals] Behavior run is not server-dispatchable — its replay could never be claimed",
 		);
-		return null;
+		return { ok: false, reason: "not_dispatchable" };
 	}
+
+	return {
+		ok: true,
+		source: {
+			sourceRunId: Number(row.id),
+			organizationId: row.organization_id,
+			behaviorId: row.watcher_id,
+			approvedInput: row.approved_input,
+		},
+	};
+}
+
+/**
+ * Clone a terminal Behavior run into a pending eval replay.
+ *
+ * `caseKey` scopes idempotency: re-running with the same (sourceRunId,
+ * caseKey) reuses the in-flight eval rather than queueing a second one. Pass a
+ * distinct key (an attempt number, a case id) to run the same source run
+ * several times — which is the point, since a single trial is not a
+ * measurement.
+ *
+ * Returns null when the source run does not exist, is not a Behavior run, or
+ * carries no frozen payload to replay.
+ */
+export async function createEvalRun(
+	params: { sourceRunId: number; caseKey: string },
+	db?: DbClient,
+): Promise<CreateEvalRunResult | null> {
+	const sql = db ?? getDb();
+	const idempotencyKey = `behavior_eval:${params.sourceRunId}:${params.caseKey}`;
+
+	const loaded = await loadReplayableSource(params.sourceRunId, sql);
+	if (!loaded.ok) return null;
+	const row = loaded.source;
 
 	const inserted = (await sql`
     INSERT INTO runs (
@@ -111,12 +153,12 @@ export async function createEvalRun(
       idempotency_key,
       created_at
     ) VALUES (
-      ${row.organization_id},
+      ${row.organizationId},
       ${BEHAVIOR_EVAL_RUN_TYPE},
-      ${row.watcher_id},
+      ${row.behaviorId},
       'auto',
       'pending',
-      ${sql.json(row.approved_input as never)},
+      ${sql.json(row.approvedInput as never)},
       ${idempotencyKey},
       current_timestamp
     )
@@ -136,8 +178,8 @@ export async function createEvalRun(
 		if (existing.length === 0) return null;
 		return {
 			runId: Number(existing[0].id),
-			sourceRunId: Number(row.id),
-			behaviorId: row.watcher_id,
+			sourceRunId: row.sourceRunId,
+			behaviorId: row.behaviorId,
 			created: false,
 		};
 	}
@@ -147,15 +189,15 @@ export async function createEvalRun(
 		{
 			runId,
 			sourceRunId: params.sourceRunId,
-			behaviorId: row.watcher_id,
+			behaviorId: row.behaviorId,
 			caseKey: params.caseKey,
 		},
 		"[evals] Queued an eval replay",
 	);
 	return {
 		runId,
-		sourceRunId: Number(row.id),
-		behaviorId: row.watcher_id,
+		sourceRunId: row.sourceRunId,
+		behaviorId: row.behaviorId,
 		created: true,
 	};
 }

--- a/packages/server/src/tools/constants.ts
+++ b/packages/server/src/tools/constants.ts
@@ -11,6 +11,9 @@ export const MEMBER_ENTITY_TYPE_SLUG = '$member';
 /** Slug of the built-in per-Behavior canvas entity type. */
 export const CANVAS_ENTITY_TYPE_SLUG = '$canvas';
 
+/** Slug of the built-in eval-case entity type (evals PR 3, lobu#2564). */
+export const EVAL_CASE_ENTITY_TYPE_SLUG = '$eval_case';
+
 /** Semantic type of tombstone events that supersede "deleted" events. */
 export const TOMBSTONE_SEMANTIC_TYPE = 'tombstone';
 

--- a/packages/server/src/utils/canvas-events.ts
+++ b/packages/server/src/utils/canvas-events.ts
@@ -26,6 +26,7 @@
 
 import type { DbClient } from '../db/client';
 import { CANVAS_ENTITY_TYPE_SLUG } from '../tools/constants';
+import { resolveEntityCreator } from './resolve-entity-creator';
 
 /** Namespace for the per-watcher canvas identity claim in `entity_identities`. */
 export const WATCHER_CANVAS_NAMESPACE = 'watcher_canvas';
@@ -36,29 +37,6 @@ export interface CanvasPeriodMeta {
   granularity: string;
   window_start: string;
   window_end: string;
-}
-
-/**
- * Resolve a live `user(id)` to attribute the canvas entity to. Prefers the
- * caller-supplied id (the watcher's creator — already a live user); otherwise
- * falls back to an org owner/admin. Returns null when the org has no member.
- * Mirrors promote-keyed-entities' resolveCreator.
- */
-async function resolveCanvasCreator(
-  tx: DbClient,
-  organizationId: string,
-  createdBy: string | null | undefined
-): Promise<string | null> {
-  if (createdBy && createdBy.trim().length > 0) return createdBy;
-  const rows = await tx<{ userId: string }>`
-    SELECT "userId"
-    FROM "member"
-    WHERE "organizationId" = ${organizationId}
-    ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
-             "createdAt" ASC
-    LIMIT 1
-  `;
-  return rows.length > 0 ? rows[0].userId : null;
 }
 
 /**
@@ -97,7 +75,7 @@ export async function ensureCanvasEntity(params: {
   `;
   if (existing.length > 0) return Number(existing[0].entity_id);
 
-  const createdBy = await resolveCanvasCreator(tx, organizationId, params.createdBy);
+  const createdBy = await resolveEntityCreator(tx, organizationId, params.createdBy);
   if (!createdBy) {
     // entities.created_by is NOT NULL; without an attributable member we cannot
     // create the canvas entity. The canvas event still gets written (unanchored).

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -53,6 +53,7 @@ import {
 } from './entity-field-merge';
 import logger from './logger';
 import { isUniqueViolation } from './pg-errors';
+import { resolveEntityCreator } from './resolve-entity-creator';
 import { computeStableKey, formatBehaviorEntityIdentity } from './stable-keys';
 
 /** Namespace for the stable-key identity claim in `entity_identities`. */
@@ -123,30 +124,6 @@ export interface PromoteKeyedEntitiesResult {
    */
   changes: PromotedEntityChange[];
 }
-
-/**
- * Resolve a live `user(id)` to attribute created entities to. Prefers the
- * caller-supplied `created_by` (the watcher's creator — already a live user);
- * otherwise falls back to an org owner/admin, mirroring entity-link-upsert's
- * `resolveOrgCreator`. Returns null when the org has no member to attribute to.
- */
-async function resolveCreator(
-  tx: DbClient,
-  organizationId: string,
-  createdBy: string | null | undefined
-): Promise<string | null> {
-  if (createdBy && createdBy.trim().length > 0) return createdBy;
-  const rows = await tx<{ userId: string }>`
-    SELECT "userId"
-    FROM "member"
-    WHERE "organizationId" = ${organizationId}
-    ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
-             "createdAt" ASC
-    LIMIT 1
-  `;
-  return rows.length > 0 ? rows[0].userId : null;
-}
-
 
 /**
  * Build a human-readable entity name from RAW field values (not the slugified
@@ -496,7 +473,7 @@ export async function promoteBehaviorEntityOutput(
     return result;
   }
 
-  const createdBy = await resolveCreator(tx, organizationId, params.createdBy);
+  const createdBy = await resolveEntityCreator(tx, organizationId, params.createdBy);
   if (createdBy == null) {
     logger.warn(
       { watcherId, organizationId },

--- a/packages/server/src/utils/resolve-entity-creator.ts
+++ b/packages/server/src/utils/resolve-entity-creator.ts
@@ -1,0 +1,34 @@
+/**
+ * Attribution for lazily-created system entities.
+ *
+ * `entities.created_by` is NOT NULL behind an ON DELETE RESTRICT FK, so every
+ * entity the server creates on its own behalf — a `$canvas` window, an
+ * `$eval_case`, a promoted keyed row — still needs a real live user to point
+ * at. Callers that already know the responsible person (a Behavior's creator,
+ * the operator promoting a case) pass it through; the rest fall back to the
+ * org's longest-standing owner/admin so the row is attributable to someone who
+ * can actually be asked about it.
+ *
+ * Returns null when the org has no member at all. That is deliberately NOT an
+ * throw: the call sites disagree about what it means — promotion skips, the
+ * canvas still writes its event unanchored — so each one decides.
+ */
+
+import type { DbClient } from '../db/client';
+
+export async function resolveEntityCreator(
+  tx: DbClient,
+  organizationId: string,
+  createdBy: string | null | undefined
+): Promise<string | null> {
+  if (createdBy && createdBy.trim().length > 0) return createdBy;
+  const rows = await tx<{ userId: string }>`
+    SELECT "userId"
+    FROM "member"
+    WHERE "organizationId" = ${organizationId}
+    ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
+             "createdAt" ASC
+    LIMIT 1
+  `;
+  return rows.length > 0 ? rows[0].userId : null;
+}

--- a/scripts/promote-eval-case.ts
+++ b/scripts/promote-eval-case.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+
+/**
+ * Promote a real Behavior run into a reusable eval case, and optionally replay
+ * it straight away.
+ *
+ *   bun scripts/promote-eval-case.ts --run 876554 --expect "names the 4 dupes"
+ *   bun scripts/promote-eval-case.ts --run 876554 --key regression-a --replay
+ *
+ * A script rather than an agent-facing tool for the same reason
+ * `queue-eval-run.ts` is: the trigger surface (SDK verb vs internal route) is
+ * its own design decision and has not been made. This exists so the case set is
+ * buildable today, and so the promote path is exercisable end to end.
+ *
+ * DATABASE_URL must point at the target database.
+ */
+
+import { parseArgs as parseNodeArgs } from "node:util";
+import { getDb } from "../packages/server/src/db/client";
+import {
+  promoteEvalCase,
+  replayEvalCase,
+} from "../packages/server/src/runs/eval-cases";
+
+const { values: args } = parseNodeArgs({
+  options: {
+    run: { type: "string" },
+    key: { type: "string", default: "default" },
+    expect: { type: "string" },
+    replay: { type: "boolean", default: false },
+  },
+});
+
+const sourceRunId = Number(args.run);
+if (!Number.isSafeInteger(sourceRunId) || sourceRunId < 1) {
+  console.error("--run <behavior run id> is required");
+  process.exit(1);
+}
+
+const sql = getDb();
+const result = await promoteEvalCase(
+  {
+    sourceRunId,
+    caseKey: args.key,
+    expectation: args.expect ?? null,
+  },
+  sql
+);
+
+if (!result.ok) {
+  console.error(
+    `Could not promote behavior run ${sourceRunId}: ${result.reason}.`
+  );
+  process.exit(1);
+}
+
+const { evalCase, created } = result;
+console.log(
+  created
+    ? `Promoted behavior run ${evalCase.sourceRunId} into eval case ${evalCase.entityId} (behavior ${evalCase.behaviorId}, key "${evalCase.caseKey}").`
+    : `Eval case ${evalCase.entityId} already covers behavior run ${evalCase.sourceRunId} key "${evalCase.caseKey}".`
+);
+
+if (args.replay) {
+  const run = await replayEvalCase(evalCase.entityId, sql);
+  if (!run) {
+    console.error(`Case ${evalCase.entityId} could not be replayed.`);
+    process.exit(1);
+  }
+  console.log(
+    run.created
+      ? `Queued eval run ${run.runId} for case ${evalCase.entityId}.`
+      : `Eval run ${run.runId} for case ${evalCase.entityId} is already in flight.`
+  );
+}
+
+process.exit(0);

--- a/scripts/queue-eval-run.ts
+++ b/scripts/queue-eval-run.ts
@@ -11,9 +11,10 @@
  * the server derives `executionMode = 'capture'` for the session, so the agent
  * runs for real but its side effects are recorded rather than performed.
  *
- * A script rather than an agent-facing tool on purpose: PR 3 adds the promote
- * flow and its surface, which needs its own design sign-off. This exists so the
- * capture path is exercisable end to end today.
+ * A script rather than an agent-facing tool on purpose: the trigger surface
+ * (SDK verb vs internal route) needs its own design sign-off and has not had
+ * it. PR 3 added the promote flow (`promote-eval-case.ts`) under the same
+ * constraint. This exists so the capture path is exercisable end to end today.
  *
  * DATABASE_URL must point at the target database.
  */


### PR DESCRIPTION
## Summary
- Adds `$eval_case`: a real Behavior run someone decided is worth asking again, frozen as an entity so the case set is reviewable in the workspace instead of a list of run ids in someone's notes. Part of the evals program (#2564), PR 3.
- A case stores a **pointer, never a copy**. `runs.approved_input` is already the frozen dispatch payload and `createEvalRun` copies it verbatim at replay time; a second copy on the case would be free to drift from the run it claims to replay. What the case adds is `expectation` — the part no `runs` row carries.
- `loadReplayableSource` is extracted out of `createEvalRun` so **promote and replay share one predicate**. A case that passes promote but fails at replay is a case set that looks healthy and silently measures nothing.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `vitest run src/__tests__/integration/runs/` → **37 passed** (12 new in `eval-case-promote.test.ts`)
- [x] Regression over both refactored call sites: canvas-entity-type-backfill, metadata-provenance-keys, promotion-gate-fail-closed → 43 passed; `bun test` unit → 35 passed
- [ ] Bug fix: n/a (new capability)

### Mutation evidence
Every new test was mutation-checked, and two rounds changed the code:

| mutation | result |
|---|---|
| promote skips the dispatchability check | **red** (1) |
| case copies the frozen payload into metadata | **red** (1) |
| disable the identity fast path | **green** — survived |
| non-deterministic slug | **green** — survived |
| both of the above together | **green** — survived |
| adopt *any* row owning the slug | **red** (2) |

The three survivors were the useful finding: promote has three layers that each independently return the existing case, so the **return contract stayed correct while a duplicate entity leaked**. The idempotency test asserted only the contract. Added an entity-count assertion, after which the combined mutation goes red.

## Notes
**Slug is deliberately not the identity.** `slugifyCaseKey` is lossy (`Tone Check` and `tone-check` want one slug for two different questions) and `entities_slug_parent_unique` is **not** partial on `deleted_at`, so a retired case holds its slug forever. Adopting whichever row owns the slug would fold distinct cases together and replay them under the wrong idempotency key. We adopt only a row that is genuinely this (run, key, type, live), else take a suffixed slug. `entity_identities` is the identity.

**No schema change.** `$eval_case` is created on demand per org, exactly like `$canvas`.

**Class fix:** collapses two verbatim copies of the org-creator resolver into `resolveEntityCreator` — this change would have been the third. The three `resolveOrgCreator` variants are intentionally left alone: they differ semantically (no `createdBy` override, one cached on a hot path), so folding them in would be a behavior change on a hot path inside an unrelated PR.

**Known limitation, stated plainly:** there is still **no trigger surface**. `createEvalRun`/`promoteEvalCase` have no caller but local scripts, so this gives a committed, reviewable case set that cannot yet run in CI. That is the next decision, not something this PR settles. `expectation` likewise has no consumer until the judge lands.

Part of #2564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for promoting Behavior runs into reusable evaluation cases.
  * Added replay support for evaluation cases, including safeguards against invalid or undispatchable source runs.
  * Added a command-line utility to promote runs and optionally queue replays.
  * Added reliable creator attribution and handling for repeated promotions, missing metadata, and naming conflicts.

* **Documentation**
  * Clarified the current workflow and limitations for queueing evaluation replays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->