### PR TITLE
fix(agent-worker): route an agent's model pin that arrives via defaultModel

### DIFF
--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -483,7 +483,7 @@ describe("resolveDynamicModelApi — real OpenAI uses the Responses API", () => 
   });
 });
 
-describe("resolveModelRef — providerSlug must describe the REQUESTED model", () => {
+describe("resolveModelRef — routing and providerSlug must follow the REQUESTED model", () => {
   test("an explicitly-prefixed model routes AND attributes to its own provider", () => {
     // Observed live: agent models = ["gemini/gemini-2.5-flash"], but the
     // session context published defaultProvider="openai" (the gateway's
@@ -494,9 +494,6 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     const result = resolveModelRef("gemini/gemini-2.5-flash", {
       defaultProvider: "openai",
       defaultProviderSlug: "openai",
-      // The gateway could NOT match this model to a provider, so its
-      // credentialed-fallback scan published openai.
-      defaultProviderServesModel: false,
       installedProviderRoutes: { openai: "openai", gemini: "gemini" },
     });
 
@@ -505,16 +502,14 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     expect(result.modelId).toBe("gemini-2.5-flash");
   });
 
-  test("a SERVING provider keeps the CTA even when its model names another installed provider", () => {
-    // Why an installed-provider match cannot decide attribution on its own.
-    // OpenRouter is configured AND serves this model; the "openai" inside the
-    // ref is OpenRouter's vendor namespace, not a request for the OpenAI
-    // provider — even though standalone OpenAI is also installed.
+  test("a configured provider's OWN vendor namespace is not a foreign pin", () => {
+    // OpenRouter is the configured provider; the "openai" inside the ref is
+    // OpenRouter's vendor namespace, not a request for the OpenAI provider —
+    // even though standalone OpenAI is also installed. The ref's FIRST segment
+    // is what names a provider, and here that is openrouter itself.
     const result = resolveModelRef("openrouter/openai/gpt-4o", {
       defaultProvider: "openrouter",
       defaultProviderSlug: "openrouter",
-      // The gateway MATCHED the model to OpenRouter.
-      defaultProviderServesModel: true,
       installedProviderRoutes: { openai: "openai", openrouter: "openrouter" },
     });
 
@@ -523,56 +518,45 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     expect(result.modelId).toBe("openai/gpt-4o");
   });
 
-  test("attribution follows the RESOLVED model when the run carries no explicit ref", () => {
-    // The common shape: the run has no per-turn model, so the ref comes from
-    // `defaultModel`. Attribution must read the RESOLVED ref — deriving it from
-    // the raw (empty) argument silently skipped reattribution and reproduced the
-    // exact wrong-provider CTA this fix exists to prevent.
-    const result = resolveModelRef("", {
-      defaultModel: "gemini/gemini-2.5-flash",
+  test("the same pin routes identically via rawModelRef and via defaultModel", () => {
+    // How the pin reaches the resolver is not a routing fact. These two calls
+    // describe the same agent — one turn carried a per-turn model, the other
+    // fell back to the agent's configured default — and they must agree.
+    const overrides = {
       defaultProvider: "openai",
       defaultProviderSlug: "openai",
-      defaultProviderServesModel: false,
       installedProviderRoutes: { openai: "openai", gemini: "gemini" },
+    };
+    const viaRaw = resolveModelRef("gemini/gemini-2.5-flash", overrides);
+    const viaDefault = resolveModelRef("", {
+      ...overrides,
+      defaultModel: "gemini/gemini-2.5-flash",
     });
 
-    expect(result.providerSlug).toBe("gemini");
-    // Routing still belongs to the gateway's published provider.
+    expect(viaDefault).toEqual(viaRaw);
+    expect(viaDefault.provider).toBe("gemini");
+    expect(viaDefault.modelId).toBe("gemini-2.5-flash");
+  });
+
+  test("an agent's configured pin ROUTES even when it arrives via defaultModel", () => {
+    // Observed live (buremba, Behavior 20): the agent is pinned to
+    // "openai/gpt-5.6-luna" and OpenAI is installed, but the run carries no
+    // per-turn model — so the pin reaches the resolver as `defaultModel`, not as
+    // `rawModelRef`. The gateway's credentialed-fallback scan published qwen.
+    //
+    // The run executed on QWEN with the literal string "openai/gpt-5.6-luna" as
+    // the model id. Routing must follow the pin exactly as it does for an
+    // explicit ref — how the ref reached the resolver is not a routing fact.
+    const result = resolveModelRef("", {
+      defaultModel: "openai/gpt-5.6-luna",
+      defaultProvider: "qwen",
+      defaultProviderSlug: "qwen",
+      installedProviderRoutes: { qwen: "qwen", openai: "openai" },
+    });
+
     expect(result.provider).toBe("openai");
-  });
-
-  test("an UNINSTALLED aggregator namespace never owns the CTA", () => {
-    // Both gateway facts are required. Here the model was NOT matched
-    // (`serves: false`, so the fallback scan picked OpenRouter), but the
-    // "anthropic" prefix is an OpenRouter vendor namespace — there is no
-    // Anthropic provider installed. Attributing the CTA to it would send the
-    // user to reconnect a provider that does not exist in this deployment.
-    const result = resolveModelRef("anthropic/claude-sonnet-4", {
-      defaultProvider: "openrouter",
-      defaultProviderSlug: "openrouter",
-      defaultProviderServesModel: false,
-      installedProviderRoutes: { openrouter: "openrouter" },
-    });
-
-    expect(result.providerSlug).toBe("openrouter");
-    expect(result.provider).toBe("openrouter");
-    expect(result.modelId).toBe("anthropic/claude-sonnet-4");
-  });
-
-  test("an older gateway (field absent) keeps the pre-existing attribution", () => {
-    // Back-compat: a gateway that predates `defaultProviderServesModel` sends
-    // nothing. Absent must mean "serves" so a stale gateway keeps today's
-    // behavior instead of acquiring a NEW misattribution. Exact mirror of the
-    // `defaultModel` case above, which reattributes to gemini on `serves:
-    // false` — drop the field and the default provider keeps the CTA.
-    const result = resolveModelRef("", {
-      defaultModel: "gemini/gemini-2.5-flash",
-      defaultProvider: "openai",
-      defaultProviderSlug: "openai",
-      installedProviderRoutes: { openai: "openai", gemini: "gemini" },
-    });
-
     expect(result.providerSlug).toBe("openai");
+    expect(result.modelId).toBe("gpt-5.6-luna");
   });
 
   test("a bare model id still inherits the configured default provider", () => {
@@ -588,9 +572,11 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
   test("a provider-INTERNAL namespace keeps the configured provider's slug", () => {
     // OpenRouter's "anthropic/claude-sonnet-4" means "OpenRouter's anthropic
     // model", NOT "switch to the anthropic provider". `anthropic` is not an
-    // installed provider here, so the CTA must stay on openrouter — pointing
-    // it at `anthropic` would send the user to a provider this deployment
-    // does not even have.
+    // installed provider here, so it must neither route nor own the CTA —
+    // pointing either at `anthropic` would send the run, and the user, to a
+    // provider this deployment does not even have. This is the case that makes
+    // a blanket "first segment wins" rule wrong, and it is why the guard is
+    // membership in `installedProviderRoutes`.
     const result = resolveModelRef("anthropic/claude-sonnet-4", {
       defaultProvider: "openrouter",
       defaultProviderSlug: "openrouter",
@@ -601,9 +587,10 @@ describe("resolveModelRef — providerSlug must describe the REQUESTED model", (
     expect(result.modelId).toBe("anthropic/claude-sonnet-4");
   });
 
-  test("no installedProviderRoutes → keep the default attribution (cannot tell them apart)", () => {
+  test("no installedProviderRoutes → stay on the default (cannot tell them apart)", () => {
     // Without the gateway's installed-provider list we cannot distinguish a
-    // real provider request from a provider-internal namespace, so fail safe.
+    // real provider request from a provider-internal namespace, so fail safe:
+    // neither the route nor the CTA leaves the configured provider.
     const result = resolveModelRef("anthropic/claude-sonnet-4", {
       defaultProvider: "openrouter",
       defaultProviderSlug: "openrouter",

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -231,12 +231,6 @@ export function resolveModelRef(
     defaultProvider?: string;
     defaultProviderSlug?: string;
     installedProviderRoutes?: Record<string, string>;
-    /**
-     * Gateway-supplied: did `defaultProvider` actually MATCH the requested
-     * model, or was it fallback-picked? Drives failure-CTA attribution only —
-     * never routing. Absent (older gateway) is treated as "serves".
-     */
-    defaultProviderServesModel?: boolean;
   }
 ): {
   provider: string;
@@ -279,7 +273,16 @@ export function resolveModelRef(
   // conjuring a provider the org never configured. Lobu stores refs as
   // "<lobu-slug>/<model>", so OpenRouter's own entry keeps its prefix
   // ("openrouter/openai/gpt-4o") and never collides with an installed OpenAI.
-  const explicitParts = normalizedRaw?.split("/").filter(Boolean) ?? [];
+  //
+  // Derived from the RESOLVED `modelRef`, not `normalizedRaw`. A pin is a pin
+  // whichever field carries it: most runs have no per-turn model, so the agent's
+  // configured `models[0]` arrives as `defaultModel` and `normalizedRaw` is
+  // empty. Reading the raw argument here skipped the guard for exactly those
+  // runs, and they silently executed on the gateway's fallback-scanned
+  // `defaultProvider` with the foreign ref passed through as the model id
+  // (observed live: "openai/gpt-5.6-luna" sent to qwen). `defaultProvider` is a
+  // fallback-scan result; a configured pin to an INSTALLED provider outranks it.
+  const explicitParts = modelRef.split("/").filter(Boolean);
   const explicitProvider = explicitParts[0];
   if (
     explicitParts.length >= 2 &&
@@ -341,46 +344,16 @@ export function resolveModelRef(
     ) {
       modelId = modelId.slice(defaultProviderSlug.length + 1);
     }
-    // `providerSlug` targets the failure CTA ("Reconnect provider"), so it must
-    // name the provider the run ASKED FOR — not whichever module the gateway
-    // published as `defaultProvider` via its credentialed-fallback scan
-    // (`gateway/index.ts`, `if (!primaryProvider)`). Routing (`provider`) and
-    // `modelId` are untouched.
-    //
-    // Reattribute only when all three hold, because each alone misfires:
-    //   1. `modelId === modelRef` — the self-prefix strip above did not consume
-    //      the prefix, so the name is genuinely foreign.
-    //   2. `defaultProviderServesModel === false` — the gateway did not match
-    //      the model to `defaultProvider`. Without it, OpenRouter's own vendor
-    //      namespace ("openai/gpt-4o") would blame `openai`.
-    //   3. the prefix names an INSTALLED provider — otherwise it is an
-    //      aggregator namespace ("anthropic/…" with no Anthropic installed) and
-    //      the CTA would point at a provider absent from this deployment.
-    //
-    // Absent `defaultProviderServesModel` (older gateway) keeps the
-    // pre-existing attribution rather than acquiring a new misattribution.
-    // Derived from the RESOLVED `modelRef`, not `normalizedRaw`: when the run
-    // carries no explicit model the ref comes from `defaultModel`, and
-    // `explicitParts` (which gates explicit-ref ROUTING on a ref the run
-    // itself supplied) is empty — so attribution would silently fall back to
-    // the serving provider and reproduce the very bug this fixes.
-    const attributionParts = modelRef.split("/").filter(Boolean);
-    const attributionProvider = attributionParts[0];
-    const requestedForeignSlug =
-      attributionParts.length >= 2 &&
-      attributionProvider &&
-      attributionProvider !== defaultProvider &&
-      attributionProvider !== defaultProviderSlug &&
-      modelId === modelRef &&
-      overrides?.defaultProviderServesModel === false &&
-      overrides?.installedProviderRoutes?.[attributionProvider]
-        ? attributionProvider
-        : undefined;
-
+    // Reaching here means the ref did NOT name an installed provider other than
+    // the configured one — it is the configured provider's own model, a bare
+    // model id, or a prefix no installed provider answers to (an aggregator's
+    // internal namespace like "anthropic/claude-sonnet-4" with no Anthropic
+    // installed, or simply a provider this deployment lacks). None of those
+    // names a better route or a reachable CTA target than the configured
+    // provider, so routing and attribution both stay on it.
     return {
       provider: defaultProvider,
-      providerSlug:
-        requestedForeignSlug ?? (defaultProviderSlug || defaultProvider),
+      providerSlug: defaultProviderSlug || defaultProvider,
       modelId,
     };
   }

--- a/packages/agent-worker/src/runtime/session-context.ts
+++ b/packages/agent-worker/src/runtime/session-context.ts
@@ -34,12 +34,6 @@ interface ProviderConfig {
   configProviders?: Record<string, ConfigProviderMeta>;
   /** Installed Lobu provider ID → upstream runtime provider slug. */
   installedProviderRoutes?: Record<string, string>;
-  /**
-   * True when the gateway MATCHED `defaultProvider` to the agent's model;
-   * false when it was picked by the credentialed-fallback scan and therefore
-   * does not serve the requested model. Absent on older gateways.
-   */
-  defaultProviderServesModel?: boolean;
   /** Credential env var placeholders for proxy mode (e.g. Z_AI_API_KEY → "lobu-proxy") */
   credentialPlaceholders?: Record<string, string>;
 }

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -809,7 +809,6 @@ export async function runAISession(
     defaultProvider: pc.defaultProvider,
     defaultProviderSlug: pc.defaultProviderSlug,
     installedProviderRoutes: pc.installedProviderRoutes,
-    defaultProviderServesModel: pc.defaultProviderServesModel,
   });
   // Map gateway slug to model-registry provider name (e.g. "z-ai" → "zai")
   const provider = PROVIDER_REGISTRY_ALIASES[rawProvider] || rawProvider;

--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -105,7 +105,7 @@ async function sessionContextModel(
  */
 async function sessionContextProviderConfig(gateway: WorkerGateway): Promise<{
   defaultProvider?: string;
-  defaultProviderServesModel?: boolean;
+  installedProviderRoutes?: Record<string, string>;
 }> {
   const token = generateWorkerToken("user-1", "conv-1", "worker-a", {
     channelId: "channel-1",
@@ -119,7 +119,7 @@ async function sessionContextProviderConfig(gateway: WorkerGateway): Promise<{
   const body = (await res.json()) as {
     providerConfig?: {
       defaultProvider?: string;
-      defaultProviderServesModel?: boolean;
+      installedProviderRoutes?: Record<string, string>;
     };
   };
   return body.providerConfig ?? {};
@@ -304,20 +304,12 @@ describe("worker model fallback (real DB, both channels)", () => {
     expect(await sessionContextModel(gateway)).toBe("byo2/byo2-model");
   });
 
-  test("CTA attribution: a model-MATCHED provider publishes defaultProviderServesModel=true", async () => {
-    // `defaultProviderServesModel` tells the worker whether the published
-    // `defaultProvider` was MATCHED to the model (findProviderForModel) or
-    // merely picked by the credentialed-fallback scan. The worker gates failure
-    // CTA attribution on it: true means this provider genuinely serves the ref,
-    // so the CTA stays here even when the model's prefix names some OTHER
-    // installed provider (OpenRouter's "openai/gpt-4o" vendor namespace).
-    //
-    // With models PINNED (as here) the allow-list path applies and
-    // `resolveDispatchModel` fails closed, so an unroutable ref is replaced or
-    // yields no provider at all — this branch always sees a matched provider.
-    // The false branch is reached via the ALLOW-ALL path instead (no pinned
-    // models ⇒ `allowedRefs === null` ⇒ no routability check); see the
-    // fallback-picked test below.
+  test("a MATCHED provider is published both as the default and as an installed route", async () => {
+    // `installedProviderRoutes` is the worker's sole routing discriminator: a
+    // model ref may only route away from `defaultProvider` when its prefix names
+    // a provider in this map. So the gateway owes the map an entry for every
+    // provider it actually resolved — here the pinned byo2, which is also the
+    // published default.
     const sql = getDb();
     await sql`DELETE FROM inference_providers WHERE organization_id = ${ORG}`;
     await createInferenceProvider({
@@ -360,10 +352,10 @@ describe("worker model fallback (real DB, both channels)", () => {
 
     const pc = await sessionContextProviderConfig(gateway);
     expect(pc.defaultProvider).toBe("byo2");
-    expect(pc.defaultProviderServesModel).toBe(true);
+    expect(pc.installedProviderRoutes?.byo2).toBeTruthy();
   });
 
-  test("CTA attribution: a FALLBACK-picked provider publishes defaultProviderServesModel=false", async () => {
+  test("a FALLBACK-picked default does not make the requested provider routable", async () => {
     // The live wrong-provider shape. The agent pins NO models, so the policy is
     // ALLOW-ALL (`allowedRefs === null`) and `enforceModelAllowList` returns the
     // requested ref VERBATIM with no routability check — the one path where an
@@ -373,8 +365,12 @@ describe("worker model fallback (real DB, both channels)", () => {
     // The org default names "gemini", which has no installed module here, so
     // findProviderForModel matches nothing and the credentialed-fallback scan
     // publishes byo2 — a provider that does NOT serve the requested model.
-    // Without the false, the worker would pin the failure CTA on byo2 and tell
-    // the user to reconnect a provider they never asked for.
+    //
+    // "gemini" must therefore be ABSENT from `installedProviderRoutes`. That
+    // absence is what stops the worker from rerouting the run to a provider the
+    // gateway could not resolve: the pin is honoured only when the gateway has
+    // published a real route for it, so an unresolvable prefix stays on the
+    // fallback rather than conjuring a provider that cannot serve the call.
     const sql = getDb();
     await sql`DELETE FROM inference_providers WHERE organization_id = ${ORG}`;
     await createInferenceProvider({
@@ -426,7 +422,11 @@ describe("worker model fallback (real DB, both channels)", () => {
 
     const pc = await sessionContextProviderConfig(gateway);
     expect(pc.defaultProvider).toBe("byo2");
-    expect(pc.defaultProviderServesModel).toBe(false);
+    // Assert the map was published and populated FIRST — otherwise the absence
+    // of "gemini" below is satisfied by the map simply being missing, and the
+    // test would keep passing if the gateway stopped publishing routes at all.
+    expect(pc.installedProviderRoutes?.byo2).toBeTruthy();
+    expect(pc.installedProviderRoutes?.gemini).toBeUndefined();
   });
 
   test("R5 #4: an ORGLESS worker token publishes NO model for a db-backed shared id (no cross-org read)", async () => {

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -1038,8 +1038,6 @@ export class WorkerGateway {
     credentialEnvVarName?: string;
     defaultProvider?: string;
     defaultProviderSlug?: string;
-    /** True when defaultProvider was MATCHED to the model, not fallback-picked. */
-    defaultProviderServesModel?: boolean;
     defaultModel?: string;
     cliBackends?: Array<{
       providerId: string;
@@ -1088,16 +1086,6 @@ export class WorkerGateway {
           effectiveProviders
         )
       : undefined;
-
-    // Whether `primaryProvider` was MATCHED to the agent's model, as opposed to
-    // picked by the credentialed-fallback scan below. Only the gateway knows
-    // this: downstream, a matched provider and a fallback one look identical.
-    // The worker needs it to attribute failure CTAs, because a slash prefix is
-    // ambiguous on its own — "openai/gpt-4o" under OpenRouter is OpenRouter's
-    // vendor namespace (matched → blame OpenRouter), while
-    // "gemini/gemini-2.5-flash" under a fallback-selected openai is a genuine
-    // request for gemini (unmatched → blame gemini, not the fallback).
-    const defaultProviderServesModel = !!primaryProvider;
 
     if (!primaryProvider) {
       for (const candidate of effectiveProviders) {
@@ -1200,8 +1188,6 @@ export class WorkerGateway {
       credentialEnvVarName?: string;
       defaultProvider?: string;
       defaultProviderSlug?: string;
-      /** True when defaultProvider was MATCHED to the model, not fallback-picked. */
-      defaultProviderServesModel?: boolean;
       defaultModel?: string;
       cliBackends?: typeof cliBackends;
       providerBaseUrlMappings?: Record<string, string>;
@@ -1224,8 +1210,6 @@ export class WorkerGateway {
       if (upstream?.slug && upstream.slug !== primaryProvider.providerId) {
         result.defaultProviderSlug = primaryProvider.providerId;
       }
-      // Only meaningful alongside a published defaultProvider.
-      result.defaultProviderServesModel = defaultProviderServesModel;
     }
 
     // Only an explicitly configured model is used — Lobu no longer silently


### PR DESCRIPTION
## Summary
- Most runs carry no per-turn model, so an agent's configured `models[0]` reaches `resolveModelRef` as `defaultModel` and `rawModelRef` is empty. The explicit-ref routing guard read the RAW argument, so it never evaluated for those runs — they fell through to the gateway's credentialed-fallback `defaultProvider` and shipped the foreign ref as the model id.
- Observed live (org `buremba`): an agent pinned to `openai/gpt-5.6-luna` with OpenAI installed executed on **qwen**, with the literal string `openai/gpt-5.6-luna` sent as the model id.
- Fix: derive the guard from the RESOLVED `modelRef`. The discriminator is unchanged and still the right one — membership in `installedProviderRoutes` — so an aggregator's internal namespace (`anthropic/claude-sonnet-4` with no Anthropic installed) keeps falling through to the configured provider.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit` (9 files, 0 fail), `bun test packages/agent-worker/src/__tests__/model-resolver.test.ts` (55 pass), `bun test packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts` (12 pass, real DB)
- [x] Bug fix: red→fix→green outputs pasted below

### red (reproducer, before the fix)
```
595 |     expect(result.provider).toBe("openai");
                                  ^
error: expect(received).toBe(expected)
Expected: "openai"
Received: "qwen"
(fail) an agent's configured pin ROUTES even when it arrives via defaultModel
 56 pass
 1 fail
```

### green (after the fix)
```
 55 pass
 0 fail
```

### mutation — M1: revert the routing input to `normalizedRaw`
```
285:  const explicitParts = normalizedRaw?.split("/").filter(Boolean) ?? [];
(fail) the same pin routes identically via rawModelRef and via defaultModel
(fail) an agent's configured pin ROUTES even when it arrives via defaultModel
 54 pass
 2 fail
```
Restored from backup → 56 pass / 0 fail.

### mutation — M2: gateway publishes an empty `installedProviderRoutes`
```
    result.installedProviderRoutes = {};
(fail) a MATCHED provider is published both as the default and as an installed route
 11 pass
 1 fail
```
Restored from backup → 12 pass / 0 fail.

## Notes
This subsumes the `defaultProviderServesModel` attribution patch, which only corrected the failure CTA while the run still executed on the wrong provider. Its three conditions are exactly the routing guard's, so after this fix it is unreachable — the field is removed end to end (gateway → session-context → session-runner) rather than left as dead plumbing.

The two rewritten gateway tests keep their original scenarios and now assert `installedProviderRoutes`, which is the sole routing discriminator. The negative assertion is paired with a positive one so it cannot pass vacuously if the gateway stops publishing the map.

Not verified: no worker was booted for a live end-to-end run. Prod verification is owed after rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model routing when models are explicitly requested or configured as defaults.
  * Preserved configured provider and model information without incorrectly rerouting through another installed provider.
  * Improved handling of provider namespaces, including OpenRouter vendors.
  * Added safer fallback behavior when provider route information is unavailable or unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->