### PR TITLE
fix(server): attach a Behavior run's transcript by conversation id

### DIFF
--- a/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
+++ b/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
@@ -627,6 +627,65 @@ describe("listAgentThreads scope=all", () => {
 		);
 	});
 
+	// Production shape, which every other fixture in this file gets wrong: a
+	// Behavior execution writes TWO run rows. The scheduler's `behavior` row is
+	// what the thread is built from, but the worker is dispatched under a
+	// separate `chat_message` row and posts its snapshot against THAT run id —
+	// it never learns the behavior run id except inside the conversationId. A
+	// snapshot joined on `run_id` therefore matched nothing in prod, and the
+	// behavior page rendered the prompt with no transcript under it at all.
+	it("reads the transcript posted under the sibling dispatch run", async () => {
+		const sql = getTestDb();
+		const [behaviorRun] = await sql<{ id: number }[]>`
+			INSERT INTO runs
+			  (run_type, status, organization_id, watcher_id, window_id,
+			   approval_status, run_metadata, created_at, completed_at)
+			VALUES
+			  ('behavior', 'completed', ${org}, ${WATCHER_ID}, 700004,
+			   'auto', ${sql.json({ prompt_rendered: "Dispatched behavior task" })},
+			   '2026-06-28T04:30:00Z', '2026-06-28T04:31:00Z')
+			RETURNING id
+		`;
+		// The row the worker actually claims: no watcher_id, run_type
+		// 'chat_message'. Its only tie to the Behavior is the conversationId.
+		const [dispatchRun] = await sql<{ id: number }[]>`
+			INSERT INTO runs
+			  (run_type, status, organization_id, approval_status,
+			   created_at, completed_at)
+			VALUES
+			  ('chat_message', 'completed', ${org}, 'auto',
+			   '2026-06-28T04:30:01Z', '2026-06-28T04:30:02Z')
+			RETURNING id
+		`;
+		const jsonl = sessionJsonl("dispatched behavior transcript");
+		await sql`
+			INSERT INTO agent_transcript_snapshot
+			  (organization_id, agent_id, conversation_id, run_id, snapshot_jsonl,
+			   byte_size, terminal_status, created_at)
+			VALUES
+			  (${org}, ${AGENT}, ${`${AGENT}_watcher_${WATCHER_ID}_run_${behaviorRun.id}`},
+			   ${dispatchRun.id}, ${jsonl}, ${Buffer.byteLength(jsonl)}, 'completed',
+			   '2026-06-28T04:31:00Z')
+		`;
+
+		const data = await readWatcherRunThreads({
+			agentId: AGENT,
+			organizationId: org,
+			watcherId: WATCHER_ID,
+			limit: 20,
+		});
+		const run = data.runs.find(
+			(candidate) => candidate.runId === behaviorRun.id,
+		);
+		expect(run).toBeDefined();
+		// The prompt alone is what the broken join left on the page.
+		expect(run?.task).toBe("Dispatched behavior task");
+		expect(run?.messages.length).toBeGreaterThan(0);
+		expect(JSON.stringify(run?.messages)).toContain(
+			"dispatched behavior transcript",
+		);
+	});
+
 	it("keeps terminal approval decisions attached to their watcher run", async () => {
 		const sql = getTestDb();
 		const [watcherRun] = await sql<{ id: number }[]>`

--- a/packages/server/src/gateway/services/watcher-run-thread.ts
+++ b/packages/server/src/gateway/services/watcher-run-thread.ts
@@ -100,7 +100,21 @@ export async function readWatcherRunThreads(args: {
 			FROM public.agent_transcript_snapshot transcript
 			WHERE transcript.organization_id = ${organizationId}
 			  AND transcript.agent_id = ${agentId}
-			  AND transcript.run_id = r.id
+			  -- NOT transcript.run_id = r.id. A Behavior execution writes two run
+			  -- rows: the scheduler's behavior row (r, the one this thread is
+			  -- built from) and the chat_message row the worker actually claims.
+			  -- The worker knows only the run it claimed, so it posts the snapshot
+			  -- against the dispatch run and run_id = r.id matched no snapshot in
+			  -- production. The behavior run id reaches the worker solely inside
+			  -- the conversationId, so that is the join key: POST /api/v1/agents
+			  -- builds it as agentId + _watcher_<behaviorId> + _run_<runId> from a
+			  -- server-VERIFIED behavior_run intent, and rejects any other caller
+			  -- that tries to construct the shape (behavior-run-intent.ts). Equality
+			  -- on (organization_id, agent_id, conversation_id) is the leading
+			  -- prefix of agent_transcript_snapshot_latest, so this stays a seek.
+			  AND transcript.conversation_id =
+			      ${agentId} || '_watcher_' || ${watcherId}::text
+			      || '_run_' || r.id::text
 			  AND transcript.terminal_status = 'completed'
 			ORDER BY transcript.created_at DESC
 			LIMIT 1


### PR DESCRIPTION
## Summary
- A Behavior execution writes **two** run rows: the scheduler's `behavior` row and the `chat_message` row that dispatches the worker. The worker only ever learns the run it claimed, so it posts its transcript snapshot against the **dispatch** run — but `readWatcherRunThreads` joined `agent_transcript_snapshot.run_id` to the *behavior* run id.
- That join has **never** matched in production. Of the 1434 snapshots written in the 30 days before this change, **0** attached to a behavior run; every snapshot ever recorded attaches to a `chat_message` run. Every Behavior page therefore rendered `run.task` (the prompt) and an empty thread, for every Behavior.
- The behavior run id reaches the worker solely inside the conversationId, so that is the join key. Safe to key on: `POST /api/v1/agents` mints `<agentId>_watcher_<behaviorId>_run_<runId>` from a server-verified `behavior_run` intent and rejects any other caller that constructs the shape (`gateway/permissions/behavior-run-intent.ts`). Equality on `(organization_id, agent_id, conversation_id)` is the leading prefix of `agent_transcript_snapshot_latest`, so the lookup stays an index seek.

Why it survived: the existing fixtures stored the snapshot against the behavior run — a shape production never writes. The new test seeds the real one.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `cd packages/server && node ../../node_modules/.bin/vitest run src/__tests__/integration/agent-thread-list-scope-all.test.ts`
- [x] Bug fix: red→fix→green outputs pasted below

### RED (fix reverted to `transcript.run_id = r.id`)
```
 ❯ src/__tests__/integration/agent-thread-list-scope-all.test.ts (19 tests | 1 failed | 18 skipped)
   × listAgentThreads scope=all > reads the transcript posted under the sibling dispatch run

AssertionError: expected 0 to be greater than 0
 ❯ src/__tests__/integration/agent-thread-list-scope-all.test.ts:684:32
    683|   expect(run?.task).toBe("Dispatched behavior task");
    684|   expect(run?.messages.length).toBeGreaterThan(0);
       |                                ^

 Test Files  1 failed (1)
      Tests  1 failed | 18 skipped (19)
```
The run is found and its prompt renders — only the transcript is missing, which is exactly the reported symptom.

### GREEN
```
 ✓ src/__tests__/integration/agent-thread-list-scope-all.test.ts (19 tests) 423ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
```

### Against production data
The corrected join run read-only against the prod DB for Behavior 71 (`personal-agent`) — every completed run now resolves its transcript, failed runs correctly have none:
```
 run_id  status     conversation_id                        jsonl_len
 879654  failed
 878895  failed
 878395  completed  personal-agent_watcher_71_run_878395   331754
 878251  completed  personal-agent_watcher_71_run_878251   334858
 877935  failed
```

### End-to-end in a booted app
Seeded the production shape (behavior run + sibling `chat_message` run + snapshot joined only by conversationId) into a local dev DB using a real 334 KB prod transcript. The HTTP endpoint returns `1 run / 4 messages / 35,690 bytes`, and the Behavior page renders the run thread under the prompt:
```
Run 1 · Completed · 8/7/2026, 5:15:52 PM
Rank at most 8 new, high-signal X or LinkedIn posts for Burak…    ← prompt
query_sdk / run_sdk
I've retrieved the payload: 80 social items (LinkedIn + X)…       ← transcript
Behavior 71 window completed. Summary: …
```

## Notes
Follow-up worth doing separately: the other fixtures in this file still store snapshots against the behavior run. They pass either way now, so they no longer guard this regression — the new test is the guard.