### PR TITLE
fix(server): route an org provider whose slug differs from its kind

### DIFF
--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -382,9 +382,13 @@ describe("worker model fallback (real DB, both channels)", () => {
         text: { base_url: "https://api.byo2.example.com", model: "byo2-model" },
       },
     });
-    // A SECOND org row whose slug is "gemini" with NO custom text upstream:
-    // synthesizeOrgProviderModule returns null for it, so it contributes no
-    // module — yet it IS the org default, so it supplies the requested ref.
+    // A SECOND org row whose slug is "gemini" with NO custom text upstream.
+    // No gemini module is registered in this process, so its `kind` resolves to
+    // no catalog upstream either and synthesizeOrgProviderModule returns null —
+    // it contributes no module, yet it IS the org default, so it supplies the
+    // requested ref. (With a registered gemini module the row WOULD synthesize
+    // against the catalog URL; that fallback is covered in
+    // provider-catalog-org-inference.test.ts.)
     await createInferenceProvider({
       organizationId: ORG,
       slug: "gemini",

--- a/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { type ModuleInterface, moduleRegistry } from "@lobu/core";
+import {
+  type ModuleInterface,
+  moduleRegistry,
+  type SdkCompat,
+} from "@lobu/core";
 import type { InferenceProviderListItem } from "../../../lobu/stores/provider-secrets.js";
-import type { ApiKeyProviderModule } from "../api-key-provider-module.js";
+import {
+  ApiKeyProviderModule as ApiKeyProviderModuleImpl,
+  type ApiKeyProviderModule,
+} from "../api-key-provider-module.js";
 import { ProviderCatalogService } from "../provider-catalog.js";
 
 /**
@@ -27,6 +34,33 @@ function registerFakeModule(
   } as unknown as ModuleInterface);
 }
 
+/**
+ * Register a REAL ApiKeyProviderModule so buildProviderCatalog() resolves both
+ * the protocol AND the catalog upstream URL for that slug. The plain fake above
+ * is not an ApiKeyProviderModule, so it contributes no baseUrl — which is
+ * exactly what a kind with no catalog upstream looks like.
+ */
+function registerCatalogModule(
+  providerId: string,
+  sdkCompat: SdkCompat,
+  upstreamBaseUrl: string
+): void {
+  moduleRegistry.register(
+    new ApiKeyProviderModuleImpl({
+      providerId,
+      slug: providerId,
+      sdkCompat,
+      upstreamBaseUrl,
+      envVarName: `${providerId.toUpperCase()}_API_KEY`,
+      providerDisplayName: providerId,
+      providerIconUrl: "",
+      apiKeyInstructions: "",
+      apiKeyPlaceholder: "",
+      authProfilesManager: { getBestProfile: async () => null } as never,
+    }) as unknown as ModuleInterface
+  );
+}
+
 function clearRegistry(): void {
   (
     moduleRegistry as unknown as { modules: Map<string, ModuleInterface> }
@@ -40,8 +74,9 @@ function clearRegistry(): void {
  *
  * getInstalledModules resolves the agent's `models` list (ordered explicit
  * `<slug>/<model>` refs) into modules: a slug that isn't a providers.json module
- * but matches a custom-upstream org row is synthesized into an
- * ApiKeyProviderModule. The org KEY is never read here — it is injected at
+ * but matches an org row is synthesized into an ApiKeyProviderModule, routed to
+ * the row's own custom upstream when it has one and otherwise to the upstream
+ * its `kind` resolves to. The org KEY is never read here — it is injected at
  * egress by resolveUrlInvariant; the synthetic module only makes the slug appear
  * in the worker provider config and the proxy slug maps. Registration happens
  * per-pod, hydrated from the row (multi-replica safe: no shared in-memory map
@@ -165,7 +200,102 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
     expect(mod.getUpstreamConfig()?.apiKeyHeader).toBe("x-api-key");
   });
 
-  test("does NOT synthesize when the org row has no custom text base_url", async () => {
+  test("an ALIAS slug with no custom upstream routes to its kind's catalog URL", async () => {
+    // The reachable gap: an org creates a provider whose slug differs from its
+    // kind (slug "my-gemini", kind "gemini") and stores a key, but sets no
+    // custom `capabilities.text.base_url` — the common case, since the catalog
+    // already knows where gemini lives. `moduleMap.get("my-gemini")` misses (no
+    // providers.json module answers to the alias), so the row's ONLY route was
+    // synthesis — which used to bail without a row base_url. The row persisted,
+    // listed as configured, and silently never routed.
+    //
+    // The kind's own catalog upstream is a safe fallback: it is a trusted
+    // providers.json URL, not a tenant-defined one, so resolveUrlInvariant
+    // answers `org-credential` and sends the row's own key — never the
+    // exfiltration path a tenant URL would open.
+    registerCatalogModule(
+      "gemini",
+      "openai",
+      "https://generativelanguage.googleapis.com/v1beta/openai"
+    );
+    const registered: Array<{ slug: string; url: string }> = [];
+    const catalog = makeCatalog({
+      models: ["my-gemini/gemini-3-pro"],
+      orgRows: [
+        customUpstreamRow("my-gemini", {
+          kind: "gemini",
+          capabilities: { text: { model: "gemini-3-pro" } },
+          hasCustomUpstream: false,
+        }),
+      ],
+      registerUpstream: (u) =>
+        registered.push({ slug: u.slug, url: u.upstreamBaseUrl }),
+    });
+
+    const modules = await catalog.getInstalledModules("agent-1", "org-1");
+    expect(modules).toHaveLength(1);
+    const mod = modules[0] as ApiKeyProviderModule;
+    expect(mod.providerId).toBe("my-gemini");
+    expect(mod.getUpstreamConfig()?.upstreamBaseUrl).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/openai"
+    );
+    // Registered under the ALIAS slug — that is the name the worker's model ref
+    // carries, so that is what the proxy must answer to.
+    expect(registered).toEqual([
+      {
+        slug: "my-gemini",
+        url: "https://generativelanguage.googleapis.com/v1beta/openai",
+      },
+    ]);
+  });
+
+  test("an OAuth kind contributes NO fallback upstream", async () => {
+    // `chatgpt` and `claude` are in the catalog with a real upstreamBaseUrl but
+    // no usable sdkCompat: that URL answers to a signed-in session, not to a
+    // Bearer API key. The create route already refuses such a row ("it signs in
+    // instead"), so routing must refuse it too — otherwise routing accepts
+    // exactly what creation rejects.
+    //
+    // registerFakeModule (not registerCatalogModule) is the OAuth shape: it is
+    // not an ApiKeyProviderModule, and "device-code" is not an SdkCompat.
+    registerFakeModule("chatgpt", "device-code");
+    const catalog = makeCatalog({
+      models: ["my-chatgpt/gpt-5"],
+      orgRows: [
+        customUpstreamRow("my-chatgpt", {
+          kind: "chatgpt",
+          capabilities: { text: { model: "gpt-5" } },
+          hasCustomUpstream: false,
+        }),
+      ],
+      registerUpstream: () => {},
+    });
+
+    expect(await catalog.getInstalledModules("agent-1", "org-1")).toHaveLength(
+      0
+    );
+  });
+
+  test("a row's OWN base_url still wins over the kind's catalog URL", async () => {
+    // Guards the fallback direction: adding the catalog default must never
+    // re-point an org that deliberately configured its own upstream.
+    registerCatalogModule("gemini", "openai", "https://catalog.example.com/v1");
+    const catalog = makeCatalog({
+      models: ["my-gemini/gemini-3-pro"],
+      orgRows: [customUpstreamRow("my-gemini", { kind: "gemini" })],
+      registerUpstream: () => {},
+    });
+
+    const modules = await catalog.getInstalledModules("agent-1", "org-1");
+    const mod = modules[0] as ApiKeyProviderModule;
+    expect(mod.getUpstreamConfig()?.upstreamBaseUrl).toBe(
+      "https://my-gemini.example.com/v1"
+    );
+  });
+
+  test("does NOT synthesize when neither the row NOR its kind has an upstream", async () => {
+    // No module registered for kind "openai", so the catalog contributes no
+    // fallback URL either — there is genuinely nowhere to route.
     const registered: string[] = [];
     const catalog = makeCatalog({
       models: ["myzai/glm-4.6"],

--- a/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
@@ -250,14 +250,11 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
   });
 
   test("an OAuth kind contributes NO fallback upstream", async () => {
-    // `chatgpt` and `claude` are in the catalog with a real upstreamBaseUrl but
-    // no usable sdkCompat: that URL answers to a signed-in session, not to a
-    // Bearer API key. The create route already refuses such a row ("it signs in
-    // instead"), so routing must refuse it too — otherwise routing accepts
-    // exactly what creation rejects.
-    //
-    // registerFakeModule (not registerCatalogModule) is the OAuth shape: it is
-    // not an ApiKeyProviderModule, and "device-code" is not an SdkCompat.
+    // An OAuth provider (chatgpt, claude) registers as a plain module, not an
+    // ApiKeyProviderModule, so buildProviderCatalog() reports baseUrl "" for it
+    // — there is nothing for an API key to reach. Routing must refuse such a
+    // row, because the create route already does ("it signs in instead"), and
+    // the two disagreeing is what promotes an unroutable row to org default.
     registerFakeModule("chatgpt", "device-code");
     const catalog = makeCatalog({
       models: ["my-chatgpt/gpt-5"],
@@ -265,6 +262,38 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
         customUpstreamRow("my-chatgpt", {
           kind: "chatgpt",
           capabilities: { text: { model: "gpt-5" } },
+          hasCustomUpstream: false,
+        }),
+      ],
+      registerUpstream: () => {},
+    });
+
+    expect(await catalog.getInstalledModules("agent-1", "org-1")).toHaveLength(
+      0
+    );
+  });
+
+  test("a kind with a REACHABLE upstream but no known protocol contributes none either", async () => {
+    // Isolates the `sdkCompat` gate specifically. The test above passes on the
+    // empty baseUrl alone, so it would survive deleting that gate — this one
+    // cannot: the module IS an ApiKeyProviderModule with a real upstream, and
+    // only the unknown protocol stops the fallback.
+    //
+    // Why the gate has to exist: `synthesizeOrgProviderModule` DEFAULTS an
+    // unknown protocol to "openai". Falling back for a kind whose wire protocol
+    // we do not actually know would speak OpenAI at an upstream that may not be,
+    // and send the org's key while doing it.
+    registerCatalogModule(
+      "mystery",
+      "not-a-protocol" as never,
+      "https://mystery.example.com/v1"
+    );
+    const catalog = makeCatalog({
+      models: ["my-mystery/some-model"],
+      orgRows: [
+        customUpstreamRow("my-mystery", {
+          kind: "mystery",
+          capabilities: { text: { model: "some-model" } },
           hasCustomUpstream: false,
         }),
       ],

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -388,14 +388,11 @@ export class ProviderCatalogService {
       orgDefaultSlug = orgRows.find((r) => r.isDefault)?.slug;
       catalogByKind = new Map();
       for (const entry of buildProviderCatalog()) {
-        // A kind with no usable `sdkCompat` is an OAuth provider (chatgpt,
-        // claude) — it has a real `baseUrl`, but that URL only answers to a
-        // signed-in session, not to a Bearer API key. The create route already
-        // refuses such a row ("can't be added with an API key — it signs in
-        // instead"), so contributing its URL here would let routing accept
-        // exactly what creation rejects. Carry the protocol either way for the
-        // synthesizer's own default, but only offer a FALLBACK upstream for a
-        // kind an API key can actually reach.
+        // Only offer a fallback upstream for a kind an API key can actually
+        // reach. A kind with no usable `sdkCompat` (chatgpt) has a real
+        // `baseUrl` that answers to a signed-in session, not a Bearer key.
+        // Carry the protocol either way — the synthesizer needs it — but never
+        // the URL.
         const sdkCompat = isSdkCompat(entry.sdkCompat)
           ? entry.sdkCompat
           : undefined;

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -138,7 +138,7 @@ export function buildProviderCatalog(
 }
 
 /**
- * Reads an org's inference-provider rows (slug + custom-upstream capabilities).
+ * Reads an org's inference-provider rows (slug, `kind`, and capabilities).
  * Injected so ProviderCatalogService can synthesize routable modules for
  * org-defined provider slugs without depending on the store directly.
  */
@@ -237,8 +237,9 @@ export class ProviderCatalogService {
     private authProfilesManager: AuthProfilesManager,
     /**
      * Reads the org's inference_providers rows. When present, an installed
-     * provider slug that isn't a providers.json module is synthesized from a
-     * matching custom-upstream row (see getInstalledModules).
+     * provider slug that isn't a providers.json module is synthesized from the
+     * matching row — routed to the row's own upstream when it has one, else to
+     * the one its `kind` resolves to (see getInstalledModules).
      */
     private listOrgInferenceProviders?: OrgInferenceProviderReader,
     /**
@@ -252,17 +253,31 @@ export class ProviderCatalogService {
 
   /**
    * Synthesize a routable provider module for an org-defined inference-provider
-   * slug that has a custom text upstream. Reuses ApiKeyProviderModule — the org
-   * key itself is NOT read here; it is injected at egress by resolveUrlInvariant
-   * (org-only). This module only makes the slug appear in the worker's provider
-   * config + the proxy's slug maps. Returns null when the row has no custom
-   * `capabilities.text.base_url` (nothing to route to).
+   * slug. Reuses ApiKeyProviderModule — the org key itself is NOT read here; it
+   * is injected at egress by resolveUrlInvariant. This module only makes the
+   * slug appear in the worker's provider config + the proxy's slug maps.
+   *
+   * The upstream is the row's own `capabilities.text.base_url` when it has one,
+   * else `catalogBaseUrl` — the URL the row's `kind` already resolves to in the
+   * providers.json catalog. That fallback is what makes an ALIAS row (slug !==
+   * kind, e.g. slug "my-gemini" kind "gemini") routable: no providers.json
+   * module answers to the alias, so synthesis is its only route, and most such
+   * rows carry no base_url because the catalog already knows where the kind
+   * lives. Without it the row persisted and listed as configured but silently
+   * never routed.
+   *
+   * The fallback does not widen the credential surface: a catalog URL is a
+   * trusted providers.json destination, not a tenant-defined one, so
+   * resolveUrlInvariant answers `org-credential` (send the row's own key) and
+   * never the `org-only` tenant-URL path. Returns null only when neither the
+   * row nor its kind names an upstream — genuinely nowhere to route.
    */
   private synthesizeOrgProviderModule(
     row: InferenceProviderListItem,
-    sdkCompat: SdkCompat
+    sdkCompat: SdkCompat,
+    catalogBaseUrl?: string
   ): ApiKeyProviderModule | null {
-    const textUpstream = row.capabilities.text?.base_url;
+    const textUpstream = row.capabilities.text?.base_url || catalogBaseUrl;
     if (!textUpstream) return null;
 
     const module = new ApiKeyProviderModule({
@@ -321,10 +336,11 @@ export class ProviderCatalogService {
    *
    * Providers.json modules resolve directly. Any slug that isn't a
    * providers.json module is resolved (when `organizationId` is provided) from
-   * the org's inference_providers rows: a matching row with a custom text
-   * upstream is synthesized into a routable ApiKeyProviderModule. Slugs with no
-   * matching custom-upstream row (or when no org is given) are dropped, as
-   * before.
+   * the org's inference_providers rows: a matching row is synthesized into a
+   * routable ApiKeyProviderModule, pointed at the row's own custom text
+   * upstream when it has one and otherwise at the upstream its `kind` resolves
+   * to in the catalog. A slug is dropped only when no row matches, when no org
+   * is given, or when neither the row nor its `kind` names an upstream.
    */
   async getModelPolicy(
     agentId: string,
@@ -359,18 +375,34 @@ export class ProviderCatalogService {
     let orgRows: InferenceProviderListItem[] = [];
     let orgRowsBySlug: Map<string, InferenceProviderListItem> | undefined;
     let orgDefaultSlug: string | undefined;
-    // Protocol per catalog slug, so a synthesized org row routes with the wire
-    // protocol its `kind` declares (openai/anthropic/…), not a hardcoded one.
-    let sdkCompatByKind: Map<string, SdkCompat> | undefined;
+    // Protocol AND upstream per catalog slug, so a synthesized org row routes
+    // with the wire protocol its `kind` declares (openai/anthropic/…) and, when
+    // the row names no upstream of its own, to the URL that kind already
+    // resolves to. Both are looked up by the row's `kind`, never its slug.
+    let catalogByKind:
+      | Map<string, { sdkCompat?: SdkCompat; baseUrl?: string }>
+      | undefined;
     if (organizationId && this.listOrgInferenceProviders) {
       orgRows = await this.listOrgInferenceProviders(organizationId);
       orgRowsBySlug = new Map(orgRows.map((r) => [r.slug, r]));
       orgDefaultSlug = orgRows.find((r) => r.isDefault)?.slug;
-      sdkCompatByKind = new Map();
+      catalogByKind = new Map();
       for (const entry of buildProviderCatalog()) {
-        if (isSdkCompat(entry.sdkCompat)) {
-          sdkCompatByKind.set(entry.slug, entry.sdkCompat);
-        }
+        // A kind with no usable `sdkCompat` is an OAuth provider (chatgpt,
+        // claude) — it has a real `baseUrl`, but that URL only answers to a
+        // signed-in session, not to a Bearer API key. The create route already
+        // refuses such a row ("can't be added with an API key — it signs in
+        // instead"), so contributing its URL here would let routing accept
+        // exactly what creation rejects. Carry the protocol either way for the
+        // synthesizer's own default, but only offer a FALLBACK upstream for a
+        // kind an API key can actually reach.
+        const sdkCompat = isSdkCompat(entry.sdkCompat)
+          ? entry.sdkCompat
+          : undefined;
+        catalogByKind.set(entry.slug, {
+          sdkCompat,
+          baseUrl: sdkCompat ? entry.baseUrl || undefined : undefined,
+        });
       }
     }
 
@@ -432,11 +464,17 @@ export class ProviderCatalogService {
       }
       const row = orgRowsBySlug?.get(providerId);
       if (row) {
-        // Resolve the row's protocol from its catalog `kind`. Unknown/absent ⇒
-        // default to openai (legacy rows created before kind carried a
-        // protocol, and custom endpoints, are OpenAI-compatible).
-        const sdkCompat = sdkCompatByKind?.get(row.kind) ?? "openai";
-        const synthesized = this.synthesizeOrgProviderModule(row, sdkCompat);
+        // Resolve the row's protocol and fallback upstream from its catalog
+        // `kind`. Unknown/absent protocol ⇒ default to openai (legacy rows
+        // created before kind carried a protocol, and custom endpoints, are
+        // OpenAI-compatible). An unknown kind contributes no baseUrl, so such a
+        // row still routes only if it names its own upstream.
+        const catalogEntry = catalogByKind?.get(row.kind);
+        const synthesized = this.synthesizeOrgProviderModule(
+          row,
+          catalogEntry?.sdkCompat ?? "openai",
+          catalogEntry?.baseUrl
+        );
         if (synthesized) modules.push(synthesized);
       }
     }

--- a/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
@@ -147,13 +147,13 @@ describe("POST /inference-providers seeds a routable text model", () => {
 		expect(capabilities?.text?.model).toBe("gemini-2.5-pro");
 	});
 
-	test("an ALIAS slug with no base_url is NOT seeded and does NOT become the org default", async () => {
-		// `getModelPolicy` keys its module map by SLUG: "my-gemini" matches no
-		// static module, and with no `text.base_url` there is nothing to
-		// synthesize either — so the row cannot route. Seeding it would be worse
-		// than useless: a text model is the predicate the org-default promotion
-		// uses, so an unroutable row would become the default for every
-		// allow-all agent in the org.
+	test("an ALIAS slug with no base_url IS seeded — its kind's catalog upstream routes it", async () => {
+		// `getModelPolicy` keys its module map by SLUG, so "my-gemini" matches no
+		// static module and synthesis is the row's only route. Synthesis falls
+		// back to the upstream the row's KIND resolves to, so the row does route
+		// and must be seeded like any other: a text model is the predicate the
+		// org-default promotion uses, and an unseeded row would be passed over
+		// even though it works.
 		const res = await createProvider({
 			slug: "my-gemini",
 			kind: "gemini",
@@ -162,6 +162,27 @@ describe("POST /inference-providers seeds a routable text model", () => {
 		expect(res.status).toBe(201);
 
 		const capabilities = (await readCapabilities("my-gemini")) as {
+			text?: { model?: string; base_url?: string };
+		};
+		expect(capabilities?.text?.model).toBe("gemini-2.5-pro");
+		// Seeding must NOT write the catalog URL onto the row — the row stays
+		// "no custom upstream" so resolveUrlInvariant keeps answering
+		// `org-credential` rather than the tenant-URL `org-only` path.
+		expect(capabilities?.text?.base_url).toBeUndefined();
+	});
+
+	test("a kind absent from the catalog is still NOT seeded — nothing to route to", async () => {
+		// The remaining unroutable shape: no static module answers to the slug,
+		// the row names no upstream, and the kind has none to fall back to.
+		// Seeding it would promote an unroutable row to org default.
+		const res = await createProvider({
+			slug: "my-mystery",
+			kind: "some-unlisted-endpoint",
+			apiKey: "sk-mystery",
+		});
+		expect(res.status).toBe(201);
+
+		const capabilities = (await readCapabilities("my-mystery")) as {
 			text?: { model?: string };
 		};
 		expect(capabilities?.text?.model).toBeUndefined();
@@ -170,7 +191,7 @@ describe("POST /inference-providers seeds a routable text model", () => {
 		const sql = getDb();
 		const rows = (await sql`
       SELECT is_default FROM inference_providers
-      WHERE organization_id = ${ORG} AND slug = 'my-gemini' AND deleted_at IS NULL
+      WHERE organization_id = ${ORG} AND slug = 'my-mystery' AND deleted_at IS NULL
     `) as Array<{ is_default: boolean }>;
 		expect(rows[0]?.is_default).toBe(false);
 	});

--- a/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-provider-create-seeds-model.test.ts
@@ -2,13 +2,19 @@
 
 import {
 	afterAll,
+	afterEach,
 	beforeAll,
 	beforeEach,
 	describe,
 	expect,
 	test,
 } from "bun:test";
-import { __resetEncryptionKeyCacheForTests } from "@lobu/core";
+import {
+	__resetEncryptionKeyCacheForTests,
+	type ModuleInterface,
+	moduleRegistry,
+} from "@lobu/core";
+import { ApiKeyProviderModule } from "../../gateway/auth/api-key-provider-module.js";
 import {
 	ensureDbForGatewayTests,
 	resetTestDatabase,
@@ -23,6 +29,15 @@ const ORG = "org-create-seed";
 const USER = "u-create-seed";
 let savedEncryptionKey: string | undefined;
 let savedRegistryPath: string | undefined;
+let savedModules: Map<string, ModuleInterface> | undefined;
+
+function restoreModules(): void {
+	if (!savedModules) return;
+	(
+		moduleRegistry as unknown as { modules: Map<string, ModuleInterface> }
+	).modules = savedModules;
+	savedModules = undefined;
+}
 
 beforeAll(async () => {
 	savedEncryptionKey = process.env.ENCRYPTION_KEY;
@@ -63,6 +78,59 @@ async function seedOrg(): Promise<void> {
   `;
 }
 
+/**
+ * Register the provider modules the route's seeding predicate consults.
+ *
+ * `wouldRoute` asks `buildProviderCatalog()` — with NO configs — because that
+ * is the exact expression `getModelPolicy` evaluates when it decides whether a
+ * row routes. That reads the MODULE REGISTRY, which a booted server populates
+ * and a bare test process does not. Without these registrations the predicate
+ * answers "nothing routes" and every alias assertion below would pass for the
+ * wrong reason.
+ *
+ * `gemini` registers as a real ApiKeyProviderModule (an API key reaches it);
+ * `claude` as a plain OAuth-shaped module, which is what it actually is — it
+ * has an upstream in providers.json that only a signed-in session can use.
+ */
+function registerCatalogModules(): void {
+	// The registry is a process-wide singleton and `bun test` shares one process
+	// across files. Snapshot before registering so afterEach can put it back —
+	// without that, a leaked `gemini` module changes the answer in
+	// worker-session-context-model-fallback.test.ts, which depends on gemini
+	// being ABSENT. (Observed: that suite failed with "Expected byo2, Received
+	// gemini" the moment these registrations leaked.)
+	savedModules = new Map(
+		(moduleRegistry as unknown as { modules: Map<string, ModuleInterface> })
+			.modules,
+	);
+	moduleRegistry.register(
+		new ApiKeyProviderModule({
+			providerId: "gemini",
+			slug: "gemini",
+			sdkCompat: "openai",
+			upstreamBaseUrl:
+				"https://generativelanguage.googleapis.com/v1beta/openai",
+			envVarName: "GEMINI_API_KEY",
+			providerDisplayName: "Gemini",
+			providerIconUrl: "",
+			apiKeyInstructions: "",
+			apiKeyPlaceholder: "",
+			authProfilesManager: { getBestProfile: async () => null } as never,
+		}) as unknown as ModuleInterface,
+	);
+	moduleRegistry.register({
+		name: "claude-provider",
+		isEnabled: () => true,
+		providerId: "claude",
+		providerDisplayName: "Claude",
+		providerIconUrl: "",
+		authType: "oauth",
+		sdkCompat: "anthropic",
+		hasSystemKey: () => false,
+		getSecretEnvVarNames: () => [],
+	} as unknown as ModuleInterface);
+}
+
 async function createProvider(body: Record<string, unknown>): Promise<Response> {
 	const mod = await import("../agent-routes.js");
 	return await mod.agentRoutes.request("/inference-providers", {
@@ -87,6 +155,7 @@ describe("POST /inference-providers seeds a routable text model", () => {
 	beforeEach(async () => {
 		await resetTestDatabase();
 		await seedOrg();
+		registerCatalogModules();
 		authStash.user = {
 			id: USER,
 			name: "Test",
@@ -97,6 +166,8 @@ describe("POST /inference-providers seeds a routable text model", () => {
 		authStash.authSource = "session";
 		authStash.mcpAuthInfo = null;
 	});
+
+	afterEach(() => restoreModules());
 
 	test("a catalog provider created with NO capabilities gets the catalog default model", async () => {
 		const res = await createProvider({
@@ -169,6 +240,38 @@ describe("POST /inference-providers seeds a routable text model", () => {
 		// "no custom upstream" so resolveUrlInvariant keeps answering
 		// `org-credential` rather than the tenant-URL `org-only` path.
 		expect(capabilities?.text?.base_url).toBeUndefined();
+	});
+
+	test("an OAuth kind is NOT seeded and does NOT become the org default", async () => {
+		// The trap this pins: providers.json gives `claude` BOTH an
+		// `upstreamBaseUrl` and `sdkCompat: "anthropic"`, so a seeding predicate
+		// that trusts providers.json says "this routes". It does not — claude
+		// registers as an OAuth module, not an ApiKeyProviderModule, so
+		// `buildProviderCatalog()` reports baseUrl "" and synthesis refuses it.
+		//
+		// Seeding it anyway would be the worst outcome available: a text model is
+		// what `promoteOldestRunnableProvider` keys on, so the unroutable row
+		// becomes the ORG DEFAULT and breaks every allow-all agent in the org.
+		// The predicate therefore asks the same question routing asks.
+		const res = await createProvider({
+			slug: "my-claude",
+			kind: "claude",
+			apiKey: "sk-ant-test",
+		});
+		expect(res.status).toBe(201);
+
+		const capabilities = (await readCapabilities("my-claude")) as {
+			text?: { model?: string };
+		};
+		expect(capabilities?.text?.model).toBeUndefined();
+
+		const { getDb } = await import("../../db/client.js");
+		const sql = getDb();
+		const rows = (await sql`
+      SELECT is_default FROM inference_providers
+      WHERE organization_id = ${ORG} AND slug = 'my-claude' AND deleted_at IS NULL
+    `) as Array<{ is_default: boolean }>;
+		expect(rows[0]?.is_default).toBe(false);
 	});
 
 	test("a kind absent from the catalog is still NOT seeded — nothing to route to", async () => {

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -912,18 +912,21 @@ routes.post("/inference-providers", async (c) => {
 			);
 		}
 		catalogDefaultModel = configs[kind]?.defaultModel ?? undefined;
-		// From `configs` for the same reason as the default model above: the
-		// catalog only contains modules registered in THIS process, so `entry`
-		// is absent outside a booted server while `configs` always resolves.
+		// Deliberately `buildProviderCatalog()` with NO configs — the EXACT
+		// expression `getModelPolicy` evaluates. These two must agree or the row
+		// is seeded as routable and then dropped at routing, which is worse than
+		// either outcome alone: a text model is what `promoteOldestRunnableProvider`
+		// keys on, so an unroutable row becomes the org DEFAULT and breaks every
+		// allow-all agent in the org.
 		//
-		// Gated on the kind's own `sdkCompat`, mirroring `getModelPolicy`. An
-		// OAuth kind (chatgpt, claude) carries a real `upstreamBaseUrl` that only
-		// answers to a signed-in session — the 400 above is the same refusal, but
-		// it depends on `entry`, which is absent when no module is registered.
-		// Reading the gate off `configs` makes the two agree in every process.
-		catalogBaseUrl = configs[kind]?.sdkCompat
-			? (configs[kind]?.upstreamBaseUrl ?? undefined)
-			: undefined;
+		// Reading `configs[kind].upstreamBaseUrl` here instead looks equivalent
+		// and is not. providers.json gives `claude` both an `upstreamBaseUrl` and
+		// `sdkCompat: "anthropic"`, but claude registers as an OAuth module, not
+		// an ApiKeyProviderModule — so `buildProviderCatalog()` reports baseUrl
+		// "" for it and synthesis refuses it. Trusting providers.json would seed
+		// exactly that unroutable row and promote it to default.
+		catalogBaseUrl =
+			buildProviderCatalog().find((e) => e.slug === kind)?.baseUrl || undefined;
 	} catch (err) {
 		// Fail open on catalog-load errors: don't block creation on a metadata
 		// read. The synthesize path still gates routing downstream.

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -912,21 +912,20 @@ routes.post("/inference-providers", async (c) => {
 			);
 		}
 		catalogDefaultModel = configs[kind]?.defaultModel ?? undefined;
-		// Deliberately `buildProviderCatalog()` with NO configs — the EXACT
-		// expression `getModelPolicy` evaluates. These two must agree or the row
-		// is seeded as routable and then dropped at routing, which is worse than
-		// either outcome alone: a text model is what `promoteOldestRunnableProvider`
-		// keys on, so an unroutable row becomes the org DEFAULT and breaks every
-		// allow-all agent in the org.
+		// The EXACT expression `getModelPolicy` evaluates — argless
+		// `buildProviderCatalog()`, then the same `sdkCompat` gate. These two must
+		// agree: a text model is what `promoteOldestRunnableProvider` keys on, so
+		// a row seeded as routable and then dropped at routing becomes the org
+		// DEFAULT and breaks every allow-all agent in the org.
 		//
-		// Reading `configs[kind].upstreamBaseUrl` here instead looks equivalent
-		// and is not. providers.json gives `claude` both an `upstreamBaseUrl` and
-		// `sdkCompat: "anthropic"`, but claude registers as an OAuth module, not
-		// an ApiKeyProviderModule — so `buildProviderCatalog()` reports baseUrl
-		// "" for it and synthesis refuses it. Trusting providers.json would seed
-		// exactly that unroutable row and promote it to default.
-		catalogBaseUrl =
-			buildProviderCatalog().find((e) => e.slug === kind)?.baseUrl || undefined;
+		// `configs[kind].upstreamBaseUrl` looks equivalent and is not. It gives
+		// `claude` a URL, but claude registers as an OAuth module rather than an
+		// ApiKeyProviderModule, so the catalog reports "" and synthesis refuses
+		// it — trusting providers.json would seed exactly that unroutable row.
+		const catalogEntry = buildProviderCatalog().find((e) => e.slug === kind);
+		catalogBaseUrl = isSdkCompat(catalogEntry?.sdkCompat ?? null)
+			? catalogEntry?.baseUrl || undefined
+			: undefined;
 	} catch (err) {
 		// Fail open on catalog-load errors: don't block creation on a metadata
 		// read. The synthesize path still gates routing downstream.

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -894,6 +894,10 @@ routes.post("/inference-providers", async (c) => {
 	// Read the default from configs because the catalog contains only provider
 	// modules registered in this process.
 	let catalogDefaultModel: string | undefined;
+	// The upstream this `kind` already resolves to. An alias row (slug !== kind)
+	// with no base_url of its own is synthesized against it, so its presence is
+	// what decides whether such a row will route.
+	let catalogBaseUrl: string | undefined;
 	try {
 		const registry = new ProviderRegistryService(resolveProviderRegistryPath());
 		const configs = await registry.getProviderConfigs();
@@ -908,6 +912,18 @@ routes.post("/inference-providers", async (c) => {
 			);
 		}
 		catalogDefaultModel = configs[kind]?.defaultModel ?? undefined;
+		// From `configs` for the same reason as the default model above: the
+		// catalog only contains modules registered in THIS process, so `entry`
+		// is absent outside a booted server while `configs` always resolves.
+		//
+		// Gated on the kind's own `sdkCompat`, mirroring `getModelPolicy`. An
+		// OAuth kind (chatgpt, claude) carries a real `upstreamBaseUrl` that only
+		// answers to a signed-in session — the 400 above is the same refusal, but
+		// it depends on `entry`, which is absent when no module is registered.
+		// Reading the gate off `configs` makes the two agree in every process.
+		catalogBaseUrl = configs[kind]?.sdkCompat
+			? (configs[kind]?.upstreamBaseUrl ?? undefined)
+			: undefined;
 	} catch (err) {
 		// Fail open on catalog-load errors: don't block creation on a metadata
 		// read. The synthesize path still gates routing downstream.
@@ -936,16 +952,20 @@ routes.post("/inference-providers", async (c) => {
 	// predicate `promoteOldestRunnableProvider` uses to choose the org default,
 	// so seeding an unroutable row would promote it to default and break every
 	// allow-all agent in the org. `getModelPolicy` keys its module map by the
-	// row's SLUG, so the row resolves to a module only when either:
-	//   - slug === kind   → the catalog's own static module answers to it, or
-	//   - a text base_url → `synthesizeOrgProviderModule` can build one.
-	// An alias slug with no base_url (slug=my-gemini, kind=gemini) matches
-	// neither and is dropped by the policy — it must not look configured.
+	// row's SLUG, so the row resolves to a module only when one of:
+	//   - slug === kind    → the catalog's own static module answers to it,
+	//   - a text base_url  → `synthesizeOrgProviderModule` routes there, or
+	//   - the kind has a catalog upstream → synthesis falls back to it, which is
+	//     what makes an alias slug (slug=my-gemini, kind=gemini) routable.
+	// Only a kind the catalog does not know at all matches none of these; such a
+	// row is dropped by the policy and must not look configured.
 	const requestedCapabilities =
 		(body.capabilities as InferenceCapabilities) ?? {};
 	const hasTextModel = !!requestedCapabilities.text?.model?.trim();
 	const wouldRoute =
-		slug === kind || !!requestedCapabilities.text?.base_url?.trim();
+		slug === kind ||
+		!!requestedCapabilities.text?.base_url?.trim() ||
+		!!catalogBaseUrl;
 	const capabilities =
 		hasTextModel || !catalogDefaultModel || !wouldRoute
 			? requestedCapabilities
@@ -957,12 +977,12 @@ routes.post("/inference-providers", async (c) => {
 					},
 				};
 	if (!capabilities.text?.model) {
-		// Nothing seeded: unknown kind, no catalog default, or an alias slug with
-		// no upstream to route to. Say so at creation — otherwise the row's only
+		// Nothing seeded: unknown kind, no catalog default, or a kind with no
+		// upstream to fall back to. Say so at creation — otherwise the row's only
 		// symptom is a far-away 400 naming a different provider.
 		logger.warn(
 			{ slug, kind, wouldRoute },
-			"[inference-providers POST] created with no text model — this provider will not route until `capabilities.text.model` is set (an alias slug, where slug !== kind, also needs `capabilities.text.base_url`)"
+			"[inference-providers POST] created with no text model — this provider will not route until `capabilities.text.model` is set (a row whose `kind` is not in the catalog also needs `capabilities.text.base_url`)"
 		);
 	}
 


### PR DESCRIPTION
## What

An org `inference_providers` row whose **slug is not a providers.json module** — an *alias* row, `slug: "my-gemini"`, `kind: "gemini"` — could only become routable through `synthesizeOrgProviderModule`, and synthesis returned `null` unless the row carried its own `capabilities.text.base_url`.

Most alias rows carry none: the catalog already knows where `gemini` lives, so an admin has no reason to type the URL. The row was created (201), listed as configured, and **silently never routed**. Its only downstream symptom was an opaque `400 invalid model ID` naming a different provider.

## Fix

`synthesizeOrgProviderModule` falls back to the upstream the row's `kind` already resolves to. The row's own `base_url` still wins when present.

The create route (`POST /inference-providers`) encoded the same stale rule in its `wouldRoute` seeding predicate — it withheld the catalog default model from exactly the rows this PR makes routable. Updated with it, so the class is fixed rather than the instance.

**OAuth kinds contribute no fallback.** `chatgpt` and `claude` carry a real `upstreamBaseUrl` with no usable `sdkCompat` — that URL answers to a signed-in session, not a Bearer key. The create route already refuses such a row (*"can't be added with an API key — it signs in instead"*), but that check reads `entry`, which is absent when no module is registered in-process. Both sites now gate on `sdkCompat`, so routing cannot accept what creation rejects.

## Security

The fallback does **not** widen the credential surface. A catalog URL is a trusted providers.json destination, so `resolveUrlInvariant` answers `org-credential` (send the row's own key) — never the `org-only` tenant-URL path. The exfiltration guard that path exists for is untouched; `custom` is still `Boolean(row.block.base_url)`.

## Red → green

Reproducer added first, against the unmodified resolver:

```
(fail) an ALIAS slug with no custom upstream routes to its kind's catalog URL
error: expect(received).toHaveLength(expected)
Expected length: 1
Received length: 0
 21 pass
 1 fail
```

After the fix:

```
 42 pass
 0 fail
Ran 42 tests across 3 files. [9.76s]
```

## Mutation checks

Both halves of the fix are covered, proved by reverting each and confirming the matching test dies:

| mutation | result |
|---|---|
| drop `\|\| catalogBaseUrl` in `synthesizeOrgProviderModule` | `(fail) an ALIAS slug with no custom upstream routes to its kind's catalog URL` |
| drop `\|\| !!catalogBaseUrl` in the route's `wouldRoute` | `(fail) an ALIAS slug with no base_url IS seeded` |

Restored, re-ran: 29 pass / 0 fail.

## Blast radius

**Zero rows in prod today.** Every live `inference_providers` row has `slug == kind` (`qwen`, `openai`, `openrouter`, `xai`), so all nine resolve through their static module and never reach synthesis. This fixes a state the product can produce but currently has no instance of.

The one behavioural change to watch after rollout: in the allow-all path every org row is pushed, so an org whose **default** is an alias row that previously dropped will now resolve that row as its first module instead of falling through. That is the fix working, and no such org exists yet.

## Gates

- `make pre-pr` — `PRE_PR_EXIT=0`
- `make review-fix` — applied; its edits were doc-accuracy only and are verified in the diff. Its one open finding (the OAuth-kind fallback) is fixed in this PR with a test.

## Not in scope

The judge-model and org-provider *catalog* surfaces are untouched. This PR does not change `resolveUrlInvariant`, the proxy, or any credential path.

Refs #2564


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Providers can now use trusted catalog endpoints when no custom text endpoint is configured.
  - Alias-based providers can inherit compatible catalog models and upstream URLs.
  - Catalog-compatible providers are recognized as routable during creation.

- **Bug Fixes**
  - OAuth-only and unknown provider kinds no longer receive inappropriate fallback routing.
  - Custom provider URLs continue to take precedence over catalog defaults.
  - Providers without a valid upstream remain unsynthesized and are not promoted as defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->