### PR TITLE
feat(server): score eval replays and answer whether a Behavior regressed

### DIFF
--- a/db/migrations/20260807170000_behavior_eval_quality_stamp.sql
+++ b/db/migrations/20260807170000_behavior_eval_quality_stamp.sql
@@ -1,0 +1,40 @@
+-- migrate:up
+
+-- Write-time quality stamp for a Behavior (evals PR 4, lobu#2564).
+--
+-- Scores live as append-only `eval_score` events, and history only grows — so
+-- any surface showing "how good is this Behavior" must NEVER aggregate them at
+-- read time. These three columns are the materialized answer, written by the
+-- scorer when it finishes a run so that a reader gets it from the `watchers`
+-- row it already selects. Same shape as `watchers.last_run_completed_at`
+-- (20260730210000).
+--
+-- Written here, read by a later PR: this PR ships the scorer, not the listing
+-- column that renders it.
+--
+-- `latest_eval_score` is the pass FRACTION over the metrics that actually
+-- produced a verdict on that run (0.0–1.0), not a count: metrics come and go
+-- (the judge is skipped when no provider resolves), so a raw count would not be
+-- comparable across runs while a fraction is.
+--
+-- Nullable with no default and no backfill: NULL means "never scored", which is
+-- the truth for every Behavior until its first eval run is scored. A 0 default
+-- would be indistinguishable from "scored, failed everything".
+ALTER TABLE public.watchers
+  ADD COLUMN IF NOT EXISTS latest_eval_score numeric(4, 3),
+  ADD COLUMN IF NOT EXISTS latest_eval_at timestamptz,
+  ADD COLUMN IF NOT EXISTS latest_eval_run_id bigint;
+
+COMMENT ON COLUMN watchers.latest_eval_score IS
+  'Pass fraction (0.000-1.000) of the most recently scored eval run. Materialized by the scorer; never aggregated at read time. NULL = never scored.';
+COMMENT ON COLUMN watchers.latest_eval_at IS
+  'When latest_eval_score was stamped.';
+COMMENT ON COLUMN watchers.latest_eval_run_id IS
+  'The behavior_eval run that produced latest_eval_score. Deliberately no FK: runs are prunable and a pruned run must not block or rewrite the stamp.';
+
+-- migrate:down
+
+ALTER TABLE public.watchers
+  DROP COLUMN IF EXISTS latest_eval_score,
+  DROP COLUMN IF EXISTS latest_eval_at,
+  DROP COLUMN IF EXISTS latest_eval_run_id;

--- a/db/migrations/20260807170010_events_identity_root_eval_score.sql
+++ b/db/migrations/20260807170010_events_identity_root_eval_score.sql
@@ -1,0 +1,33 @@
+-- migrate:up transaction:false
+
+-- Idempotency for eval scores (evals PR 4, lobu#2564).
+--
+-- The scorer writes one event per (run, metric) with
+-- `identity = { ns: 'eval_score', key: '<runId>:<metric>' }`. Without a unique
+-- index that key is a convention, not a guarantee: two replicas that claim the
+-- same run in the same instant both probe, both see no row, and both insert —
+-- the exact READ COMMITTED race 20260806120010 documents for behavior_event.
+-- Double-counted scores would then move the quality stamp for free.
+--
+-- Keyed on the CHAIN ROOT (`supersedes_event_id IS NULL`), matching
+-- idx_events_identity_root_behavior and idx_canvas_chain_root, and for the same
+-- reason: insertEvent inserts the successor BEFORE stamping the predecessor's
+-- superseded_by, so both rows are briefly live and a live-head index would
+-- reject every ordinary supersede. A rescore supersedes the head and carries a
+-- non-NULL supersedes_event_id, so it is simply not in this index.
+--
+-- Per-namespace by design — a namespace that wants uniqueness declares its own
+-- index; `entity_identities`' single blanket index is the anti-pattern.
+--
+-- CONCURRENTLY (transaction:false, ONE statement per migration): db:lint bans a
+-- blocking build on the hot events table, and dbmate sends a transaction:false
+-- block as a single simple-query batch that CONCURRENTLY cannot share.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_events_identity_root_eval_score
+  ON public.events (organization_id, identity_key)
+  WHERE supersedes_event_id IS NULL
+    AND identity_key IS NOT NULL
+    AND identity_ns = 'eval_score';
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_identity_root_eval_score;

--- a/db/migrations/20260807170020_events_identity_head_eval_score.sql
+++ b/db/migrations/20260807170020_events_identity_head_eval_score.sql
@@ -1,0 +1,37 @@
+-- migrate:up transaction:false
+
+-- Head-probe index for eval scores (evals PR 4, lobu#2564).
+--
+-- Companion to 20260807170010, and required for the same reason that pairing
+-- exists for `behavior_event` (20260806120010 root + 20260806120020 head): the
+-- root index is the CONSTRAINT and cannot also serve the head PROBE.
+--
+-- `writeScoreEvent` looks up the live head before superseding it — `WHERE
+-- organization_id = $1 AND identity_ns = 'eval_score' AND identity_key = $2 AND
+-- superseded_by IS NULL`. A partial index is usable only when the query implies
+-- its predicate, and `superseded_by IS NULL` does not imply the root index's
+-- `supersedes_event_id IS NULL` (a chain's head is usually NOT its root). So
+-- without this index the planner falls back to idx_events_live_org_created and
+-- filters the org's whole live set on every probe — the O(org history) shape
+-- measured at 970 ms at prod scale, and worst on the common no-head first-score
+-- path, which scans everything before concluding nothing matches. The scorer
+-- runs this probe once per metric per run, so it is the hot path here.
+--
+-- Non-unique, exactly as the behavior_event probe index is: insertEvent inserts
+-- the successor before stamping the predecessor's superseded_by, so both rows
+-- are briefly live inside that transaction and a UNIQUE live-head index would
+-- reject every ordinary supersede. The stamp removes the replaced row from this
+-- index automatically.
+--
+-- CONCURRENTLY (transaction:false, ONE statement per migration): db:lint bans a
+-- blocking build on the hot events table, and dbmate sends a transaction:false
+-- block as a single simple-query batch that CONCURRENTLY cannot share.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_identity_head_eval_score
+  ON public.events (organization_id, identity_key)
+  WHERE superseded_by IS NULL
+    AND identity_key IS NOT NULL
+    AND identity_ns = 'eval_score';
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_identity_head_eval_score;

--- a/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
@@ -453,13 +453,10 @@ describe("replayEvalCase", () => {
 });
 
 describe("setEvalCaseJudgeModel", () => {
-	test("sets the override, and clearing writes JSON null — not the string \"null\"", async () => {
-		// The clear path must unset the override. A JSON STRING "null" is a real
-		// value here: findCaseForRun reads `metadata->>'judge_model'` and would
-		// hand "null" to resolveCompletionTarget as a model ref.
+	test("sets the override, org-scoped", async () => {
 		const promoted = await promoteEvalCase({
 			sourceRunId,
-			caseKey: "judge-set-clear",
+			caseKey: "judge-set",
 			expectation: "x",
 		});
 		expect(promoted.ok).toBe(true);
@@ -476,17 +473,17 @@ describe("setEvalCaseJudgeModel", () => {
     `) as unknown as Array<{ judge_model: string | null }>;
 		expect(set.judge_model).toBe("anthropic/claude-3-7-sonnet");
 
-		await setEvalCaseJudgeModel(promoted.evalCase.entityId, organizationId, null);
-		const [cleared] = (await sql`
-      SELECT metadata->>'judge_model' AS judge_model,
-             jsonb_typeof(metadata->'judge_model') AS judge_typeof
+		// Refusing another org must not erase the override already set above.
+		await setEvalCaseJudgeModel(
+			promoted.evalCase.entityId,
+			"some-other-org",
+			"anthropic/claude-3-7-sonnet",
+		);
+		const [stillSet] = (await sql`
+      SELECT metadata->>'judge_model' AS judge_model
       FROM entities WHERE id = ${promoted.evalCase.entityId}
-    `) as unknown as Array<{ judge_model: string | null; judge_typeof: string | null }>;
-		expect(cleared.judge_model).toBeNull();
-		// The bug: clearing stored the JSON STRING "null", which findCaseForRun
-		// would hand to resolveCompletionTarget as a model ref. Clearing must
-		// leave either JSON null or no key — never a string.
-		expect(cleared.judge_typeof).not.toBe("string");
+    `) as unknown as Array<{ judge_model: string | null }>;
+		expect(stillSet.judge_model).toBe("anthropic/claude-3-7-sonnet");
 	});
 
 	test("refuses to touch another organization's case", async () => {

--- a/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
@@ -18,6 +18,7 @@ import {
 	EVAL_CASE_NAMESPACE,
 	promoteEvalCase,
 	replayEvalCase,
+	setEvalCaseJudgeModel,
 } from "../../../runs/eval-cases";
 import { EVAL_CASE_ENTITY_TYPE_SLUG } from "../../../tools/constants";
 import { BEHAVIOR_EVAL_RUN_TYPE } from "../../../runs/run-types";
@@ -448,5 +449,64 @@ describe("replayEvalCase", () => {
 
 		const run = await replayEvalCase(Number(impostor.id));
 		expect(run).toBeNull();
+	});
+});
+
+describe("setEvalCaseJudgeModel", () => {
+	test("sets the override, and clearing writes JSON null — not the string \"null\"", async () => {
+		// The clear path must unset the override. A JSON STRING "null" is a real
+		// value here: findCaseForRun reads `metadata->>'judge_model'` and would
+		// hand "null" to resolveCompletionTarget as a model ref.
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "judge-set-clear",
+			expectation: "x",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		await setEvalCaseJudgeModel(
+			promoted.evalCase.entityId,
+			organizationId,
+			"anthropic/claude-3-7-sonnet",
+		);
+		const [set] = (await sql`
+      SELECT metadata->>'judge_model' AS judge_model
+      FROM entities WHERE id = ${promoted.evalCase.entityId}
+    `) as unknown as Array<{ judge_model: string | null }>;
+		expect(set.judge_model).toBe("anthropic/claude-3-7-sonnet");
+
+		await setEvalCaseJudgeModel(promoted.evalCase.entityId, organizationId, null);
+		const [cleared] = (await sql`
+      SELECT metadata->>'judge_model' AS judge_model,
+             jsonb_typeof(metadata->'judge_model') AS judge_typeof
+      FROM entities WHERE id = ${promoted.evalCase.entityId}
+    `) as unknown as Array<{ judge_model: string | null; judge_typeof: string | null }>;
+		expect(cleared.judge_model).toBeNull();
+		// The bug: clearing stored the JSON STRING "null", which findCaseForRun
+		// would hand to resolveCompletionTarget as a model ref. Clearing must
+		// leave either JSON null or no key — never a string.
+		expect(cleared.judge_typeof).not.toBe("string");
+	});
+
+	test("refuses to touch another organization's case", async () => {
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "judge-other-org",
+			expectation: "x",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		await setEvalCaseJudgeModel(
+			promoted.evalCase.entityId,
+			"some-other-org",
+			"anthropic/claude-3-7-sonnet",
+		);
+		const [row] = (await sql`
+      SELECT metadata->>'judge_model' AS judge_model
+      FROM entities WHERE id = ${promoted.evalCase.entityId}
+    `) as unknown as Array<{ judge_model: string | null }>;
+		expect(row.judge_model).toBeNull();
 	});
 });

--- a/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-case-promote.test.ts
@@ -350,6 +350,38 @@ describe("promoteEvalCase", () => {
 		if (result.ok) return;
 		expect(result.reason).toBe("not_found");
 	});
+
+	test("writes NOTHING when the run belongs to another org", async () => {
+		// Promote resolves the org from the RUN, so a caller who knows a run id
+		// would otherwise create an $eval_case entity — and the $eval_case entity
+		// TYPE — inside a tenant they have no access to. Checking after the write
+		// does not help, so the assertion is that no row exists at all.
+		const result = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "cross-org",
+			organizationId: "some-other-org",
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		// Indistinguishable from a missing run: a cross-tenant caller must not
+		// learn that the id exists.
+		expect(result.reason).toBe("not_found");
+
+		const [claims] = (await sql`
+      SELECT count(*)::int AS n
+      FROM entity_identities
+      WHERE namespace = ${EVAL_CASE_NAMESPACE}
+        AND identifier = ${`${sourceRunId}:cross-org`}
+    `) as unknown as Array<{ n: number }>;
+		expect(claims.n).toBe(0);
+
+		const [entities] = (await sql`
+      SELECT count(*)::int AS n
+      FROM entities
+      WHERE organization_id = 'some-other-org'
+    `) as unknown as Array<{ n: number }>;
+		expect(entities.n).toBe(0);
+	});
 });
 
 describe("replayEvalCase", () => {

--- a/packages/server/src/__tests__/integration/runs/eval-score.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-score.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Scoring a terminal eval replay.
+ *
+ * The load-bearing claims: an eval run that never called `complete_window` is
+ * scored as a FAILURE rather than skipped (that protocol violation is the
+ * largest real agent-error class in prod, so refusing to score it would hide
+ * exactly the runs worth measuring); the quality stamp is materialized onto the
+ * Behavior row at write time; scoring is idempotent per (run, metric); and a
+ * live `behavior` run can never be scored as if it were an eval.
+ *
+ * The judge is deliberately untested here — it needs a live provider, and the
+ * unit-level contract that matters (an unaskable judge produces NO verdict
+ * rather than a zero) is asserted through the metric COUNT: an org with no
+ * provider yields exactly the two code metrics.
+ */
+
+import { beforeAll, describe, expect, test } from "vitest";
+import { promoteEvalCase } from "../../../runs/eval-cases";
+import { createEvalRun } from "../../../runs/eval-runs";
+import {
+	EVAL_SCORE_IDENTITY_NS,
+	scoreEvalRun,
+} from "../../../runs/eval-scores";
+import {
+	BEHAVIOR_EVAL_RUN_TYPE,
+	BEHAVIOR_RUN_TYPE,
+} from "../../../runs/run-types";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const sql = getTestDb();
+
+let organizationId: string;
+let behaviorId: number;
+
+async function insertRun(params: {
+	runType: string;
+	status?: string;
+	preview?: Record<string, unknown> | null;
+	idempotencyKey?: string | null;
+}): Promise<number> {
+	const [run] = (await sql`
+    INSERT INTO runs (
+      organization_id, run_type, watcher_id, approval_status, status,
+      dry_run_preview, idempotency_key, completed_at, created_at
+    ) VALUES (
+      ${organizationId}, ${params.runType}, ${behaviorId}, 'auto',
+      ${params.status ?? "completed"},
+      ${params.preview ? sql.json(params.preview as never) : null},
+      ${params.idempotencyKey ?? null},
+      current_timestamp, current_timestamp
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	return Number(run.id);
+}
+
+/** The score events currently live for a run, keyed by metric. */
+async function liveScores(
+	runId: number,
+): Promise<Record<string, { score: number; passed: boolean }>> {
+	const rows = (await sql`
+    SELECT identity_key, payload_data
+    FROM events
+    WHERE organization_id = ${organizationId}
+      AND identity_ns = ${EVAL_SCORE_IDENTITY_NS}
+      AND identity_key LIKE ${`${runId}:%`}
+      AND superseded_by IS NULL
+  `) as unknown as Array<{
+		identity_key: string;
+		payload_data: { metric: string; score: number; passed: boolean };
+	}>;
+	const out: Record<string, { score: number; passed: boolean }> = {};
+	for (const row of rows) {
+		out[row.payload_data.metric] = {
+			score: Number(row.payload_data.score),
+			passed: row.payload_data.passed,
+		};
+	}
+	return out;
+}
+
+beforeAll(async () => {
+	await cleanupTestDatabase();
+
+	const org = await createTestOrganization();
+	organizationId = org.id;
+	const creator = await createTestUser();
+	// events.created_by is NOT NULL and resolveEntityCreator falls back to an
+	// org owner/admin — without a membership row nothing can be scored at all.
+	await addUserToOrganization(creator.id, organizationId, "owner");
+
+	const [behavior] = (await sql`
+    WITH next_id AS (SELECT nextval('watchers_id_seq')::integer AS id)
+    INSERT INTO watchers (
+      id, watcher_group_id, organization_id, created_by, name, slug, schedule, status
+    )
+    SELECT id, id, ${organizationId}, ${creator.id}, 'Scored Behavior', 'scored-behavior', '0 * * * *', 'active'
+    FROM next_id
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	behaviorId = Number(behavior.id);
+});
+
+describe("scoreEvalRun", () => {
+	test("a completed capture passes both code metrics and stamps the Behavior", async () => {
+		const runId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			preview: {
+				captured: "complete_window",
+				extracted_data: { groups: ["a", "b"] },
+				content_linked: 2,
+			},
+		});
+
+		const result = await scoreEvalRun({ runId });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		// Exactly the two CODE metrics: no case, so no expectation, so the judge
+		// is never asked — and an unasked judge contributes no verdict at all.
+		expect(result.verdicts.map((v) => v.metric).sort()).toEqual([
+			"completed_window",
+			"output_present",
+		]);
+		expect(result.qualityScore).toBe(1);
+
+		const scores = await liveScores(runId);
+		expect(scores.completed_window.passed).toBe(true);
+		expect(scores.output_present.passed).toBe(true);
+
+		const [stamp] = (await sql`
+      SELECT latest_eval_score, latest_eval_run_id, latest_eval_at
+      FROM watchers WHERE id = ${behaviorId}
+    `) as unknown as Array<{
+			latest_eval_score: string | number;
+			latest_eval_run_id: number;
+			latest_eval_at: Date | null;
+		}>;
+		// Materialized at WRITE time — the listing reads this back, it never
+		// aggregates the events above.
+		expect(Number(stamp.latest_eval_score)).toBe(1);
+		expect(Number(stamp.latest_eval_run_id)).toBe(runId);
+		expect(stamp.latest_eval_at).not.toBeNull();
+	});
+
+	test("a run that never called complete_window is SCORED as a failure, not skipped", async () => {
+		// The prod-dominant defect: the agent ran, produced something, and stopped
+		// without completing its window. Skipping it would erase the single
+		// largest agent-error class from every quality number.
+		const runId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			preview: { side_effects: [{ tool: "notify.send" }] },
+		});
+
+		const result = await scoreEvalRun({ runId });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		const scores = await liveScores(runId);
+		expect(scores.completed_window.passed).toBe(false);
+		expect(scores.output_present.passed).toBe(false);
+		expect(result.qualityScore).toBe(0);
+	});
+
+	test("completing a window with EMPTY output is a protocol pass and a quality fail", async () => {
+		// The two code metrics must stay separate: collapsing them would hide the
+		// agent that dutifully completes its window having extracted nothing.
+		const runId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			preview: {
+				captured: "complete_window",
+				extracted_data: {},
+				content_linked: 0,
+			},
+		});
+
+		const result = await scoreEvalRun({ runId });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		const scores = await liveScores(runId);
+		expect(scores.completed_window.passed).toBe(true);
+		expect(scores.output_present.passed).toBe(false);
+		expect(result.qualityScore).toBe(0.5);
+	});
+
+	test("rescoring supersedes rather than forking — one live verdict per metric", async () => {
+		const runId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			preview: { captured: "complete_window", extracted_data: { a: 1 } },
+		});
+
+		await scoreEvalRun({ runId });
+		await scoreEvalRun({ runId });
+
+		const [row] = (await sql`
+      SELECT count(*)::int AS live
+      FROM events
+      WHERE organization_id = ${organizationId}
+        AND identity_ns = ${EVAL_SCORE_IDENTITY_NS}
+        AND identity_key = ${`${runId}:completed_window`}
+        AND superseded_by IS NULL
+    `) as unknown as Array<{ live: number }>;
+		expect(row.live).toBe(1);
+
+		// And exactly one chain ROOT — the shape the unique index guarantees.
+		const [roots] = (await sql`
+      SELECT count(*)::int AS n
+      FROM events
+      WHERE organization_id = ${organizationId}
+        AND identity_ns = ${EVAL_SCORE_IDENTITY_NS}
+        AND identity_key = ${`${runId}:completed_window`}
+        AND supersedes_event_id IS NULL
+    `) as unknown as Array<{ n: number }>;
+		expect(roots.n).toBe(1);
+	});
+
+	test("refuses a live Behavior run — production quality is never stamped from one", async () => {
+		const runId = await insertRun({
+			runType: BEHAVIOR_RUN_TYPE,
+			preview: { captured: "complete_window", extracted_data: { a: 1 } },
+		});
+
+		const result = await scoreEvalRun({ runId });
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.reason).toBe("not_an_eval_run");
+		expect(await liveScores(runId)).toEqual({});
+	});
+
+	test("refuses a run that has not gone terminal", async () => {
+		const runId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			status: "running",
+			preview: { captured: "complete_window" },
+		});
+
+		const result = await scoreEvalRun({ runId });
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.reason).toBe("not_terminal");
+	});
+
+	test("anchors scores to the promoted case, and asks no judge it cannot ask", async () => {
+		// The case join has no column behind it: `createEvalRun` stamps
+		// `idempotency_key = 'behavior_eval:<sourceRunId>:<caseKey>'` and
+		// `promoteEvalCase` claims `entity_identities` under
+		// '<sourceRunId>:<caseKey>'. The suffix of the one IS the other. Assert it,
+		// because a silent mismatch would strand every score unanchored and the
+		// metrics layer would show an empty case suite with no error anywhere.
+		const [sourceRun] = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, watcher_id, approval_status, status,
+        approved_input, completed_at, created_at
+      ) VALUES (
+        ${organizationId}, ${BEHAVIOR_RUN_TYPE}, ${behaviorId}, 'auto', 'completed',
+        ${sql.json({
+					watcher_id: behaviorId,
+					agent_id: "11111111-2222-3333-4444-555555555555",
+					window_start: "2026-08-01T00:00:00.000Z",
+					window_end: "2026-08-01T01:00:00.000Z",
+					dispatch_source: "scheduled",
+				} as never)},
+        current_timestamp, current_timestamp
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+		const sourceRunId = Number(sourceRun.id);
+
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "anchored",
+			expectation: "names the duplicate groups",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		const minted = await createEvalRun({ sourceRunId, caseKey: "anchored" });
+		expect(minted).not.toBeNull();
+		if (!minted) return;
+
+		// The eval run has to be terminal with a capture record to be scoreable.
+		await sql`
+      UPDATE runs
+      SET status = 'completed', completed_at = current_timestamp,
+          dry_run_preview = ${sql.json({
+						captured: "complete_window",
+						extracted_data: { groups: ["a"] },
+					} as never)}
+      WHERE id = ${minted.runId}
+    `;
+
+		const result = await scoreEvalRun({ runId: minted.runId });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.caseEntityId).toBe(promoted.evalCase.entityId);
+
+		// The case HAS an expectation, so the judge was attempted — and this test
+		// org has no inference provider, so it could not be asked. The contract is
+		// that an unaskable judge yields NO verdict rather than a zero: a failed
+		// judge must never be recorded as a failing Behavior.
+		expect(result.verdicts.map((v) => v.metric)).not.toContain("judge_rubric");
+		expect(result.qualityScore).toBe(1);
+
+		// Anchored to the case entity, which is what makes the declared-metrics
+		// alias join resolve.
+		// `array_to_string`, not the raw column: the client runs with
+		// `fetch_types: false`, so a bigint[] comes back as the Postgres array
+		// LITERAL ("{123}") rather than a JS array.
+		const rows = (await sql`
+      SELECT array_to_string(entity_ids, ',') AS ids FROM events
+      WHERE organization_id = ${organizationId}
+        AND identity_ns = ${EVAL_SCORE_IDENTITY_NS}
+        AND identity_key = ${`${minted.runId}:completed_window`}
+        AND superseded_by IS NULL
+    `) as unknown as Array<{ ids: string | null }>;
+		expect(rows[0].ids).toBe(String(promoted.evalCase.entityId));
+	});
+
+	test("score events are structurally excluded from embedding, search and feeds", async () => {
+		// Not a style preference: NULL payload_text is what keeps these rows out
+		// of embed-backfill discovery, and a NULL feed_id is what keeps them out
+		// of every feed-scoped read. Canvas established the rule; breaking it here
+		// would silently push eval bookkeeping into users' search results.
+		const runId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			preview: { captured: "complete_window", extracted_data: { a: 1 } },
+		});
+		await scoreEvalRun({ runId });
+
+		const rows = (await sql`
+      SELECT payload_text, feed_id
+      FROM events
+      WHERE organization_id = ${organizationId}
+        AND identity_ns = ${EVAL_SCORE_IDENTITY_NS}
+        AND identity_key LIKE ${`${runId}:%`}
+    `) as unknown as Array<{
+			payload_text: string | null;
+			feed_id: number | null;
+		}>;
+
+		expect(rows.length).toBeGreaterThan(0);
+		for (const row of rows) {
+			expect(row.payload_text).toBeNull();
+			expect(row.feed_id).toBeNull();
+		}
+	});
+});

--- a/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
@@ -231,6 +231,79 @@ describe("readEvalResults", () => {
 		);
 	});
 
+	test("a changed metric set between suites is not read as a regression", async () => {
+		// A quality score is a pass fraction over the verdicts that happened to
+		// run. If the judge is lost between suites, the same behavior scores
+		// [pass,fail,judge-pass]=0.667 then [pass,fail]=0.5 — a denominator
+		// change that must NOT read as a regression.
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "metadrift",
+			expectation: "x",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		const [entity] = (await sql`
+      SELECT metadata FROM entities WHERE id = ${promoted.evalCase.entityId}
+    `) as unknown as Array<{ metadata: Record<string, unknown> }>;
+		// Newest-first, matching production: two recent trials scored WITH the
+		// judge metric, two older ones scored without it.
+		await sql`
+      UPDATE entities
+      SET metadata = ${sql.json({
+				...entity.metadata,
+				recent_scores: [
+					{
+						run_id: 9003,
+						score: 0.5,
+						at: "2026-08-01T00:00:00.000Z",
+						metrics: ["completed_window", "output_present", "judge_rubric"],
+					},
+					{
+						run_id: 9004,
+						score: 0.5,
+						at: "2026-08-01T00:00:00.000Z",
+						metrics: ["completed_window", "output_present", "judge_rubric"],
+					},
+					{
+						run_id: 9001,
+						score: 1,
+						at: "2026-07-31T00:00:00.000Z",
+						metrics: ["completed_window", "output_present"],
+					},
+					{
+						run_id: 9002,
+						score: 1,
+						at: "2026-07-31T00:00:00.000Z",
+						metrics: ["completed_window", "output_present"],
+					},
+				],
+			} as never)}
+      WHERE id = ${promoted.evalCase.entityId}
+    `;
+
+		const results = await readEvalResults({
+			organizationId,
+			behaviorId,
+			trials: 2,
+		});
+		const row = results.cases.find(
+			(c) => c.caseId === promoted.evalCase.entityId,
+		);
+		expect(row).toBeDefined();
+		if (!row) return;
+
+		// The numbers are real: 0.5 against 1.0. But the denominators differ, so
+		// this is not a signal about the Behavior.
+		expect(row.latest).toBe(0.5);
+		expect(row.previous).toBe(1);
+		expect(row.delta).toBeNull();
+		expect(results.summary.regressions).not.toContain(
+			promoted.evalCase.entityId,
+		);
+	});
+
 	test("a never-scored case reports null rather than zero", async () => {
 		// A case with no runs yet must not read as "scored 0" — that would drag
 		// the Behavior's summary down for work nobody has measured.

--- a/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
@@ -1,0 +1,255 @@
+/**
+ * The eval loop end to end: promote → run the suite → score → read the answer.
+ *
+ * This is the test that says whether the feature is USEFUL, not merely correct.
+ * Scoring a run produces a number; what a person actually asks is "I changed
+ * this Behavior — did I break it?" So the assertions here are about the answer:
+ * that N trials stay N distinct runs rather than collapsing into one, that a
+ * real drop is reported as a regression, and — the one that matters most — that
+ * a wobble SMALLER than the case's own observed noise is NOT.
+ *
+ * That last one is the whole reason trials exist. Reporting a single-run dip as
+ * a regression is exactly the mistake that made a provider quota storm read as
+ * a 61–78% prompt regression.
+ */
+
+import { beforeAll, describe, expect, test } from "vitest";
+import { promoteEvalCase, trialCaseKey } from "../../../runs/eval-cases";
+import { scoreEvalRun } from "../../../runs/eval-scores";
+import { readEvalResults, runEvalSuite } from "../../../runs/eval-suite";
+import { BEHAVIOR_RUN_TYPE } from "../../../runs/run-types";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const sql = getTestDb();
+
+let organizationId: string;
+let behaviorId: number;
+let sourceRunId: number;
+
+async function insertBehaviorRun(): Promise<number> {
+	const [run] = (await sql`
+    INSERT INTO runs (
+      organization_id, run_type, watcher_id, approval_status, status,
+      approved_input, completed_at, created_at
+    ) VALUES (
+      ${organizationId}, ${BEHAVIOR_RUN_TYPE}, ${behaviorId}, 'auto', 'completed',
+      ${sql.json({
+				watcher_id: behaviorId,
+				agent_id: "11111111-2222-3333-4444-555555555555",
+				window_start: "2026-08-01T00:00:00.000Z",
+				window_end: "2026-08-01T01:00:00.000Z",
+				dispatch_source: "scheduled",
+			} as never)},
+      current_timestamp, current_timestamp
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	return Number(run.id);
+}
+
+/**
+ * Land a scored eval run for a given trial: drive the real capture shape
+ * through the real scorer, so the case window is written the way production
+ * writes it rather than by hand.
+ */
+async function landTrial(
+	caseKey: string,
+	trial: number,
+	opts: { good: boolean },
+): Promise<number> {
+	const key = `behavior_eval:${sourceRunId}:${trialCaseKey(caseKey, trial)}`;
+	const [run] = (await sql`
+    INSERT INTO runs (
+      organization_id, run_type, watcher_id, approval_status, status,
+      dry_run_preview, idempotency_key, completed_at, created_at
+    ) VALUES (
+      ${organizationId}, 'behavior_eval', ${behaviorId}, 'auto', 'completed',
+      ${sql.json(
+				opts.good
+					? { captured: "complete_window", extracted_data: { a: 1 } }
+					: { captured: "complete_window", extracted_data: {} },
+			)},
+      ${key}, current_timestamp, current_timestamp
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	const runId = Number(run.id);
+	const scored = await scoreEvalRun({ runId });
+	expect(scored.ok).toBe(true);
+	return runId;
+}
+
+beforeAll(async () => {
+	await cleanupTestDatabase();
+
+	const org = await createTestOrganization();
+	organizationId = org.id;
+	const creator = await createTestUser();
+	await addUserToOrganization(creator.id, organizationId, "owner");
+
+	const [behavior] = (await sql`
+    WITH next_id AS (SELECT nextval('watchers_id_seq')::integer AS id)
+    INSERT INTO watchers (
+      id, watcher_group_id, organization_id, created_by, name, slug, schedule, status
+    )
+    SELECT id, id, ${organizationId}, ${creator.id}, 'Suite Behavior', 'suite-behavior', '0 * * * *', 'active'
+    FROM next_id
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	behaviorId = Number(behavior.id);
+	sourceRunId = await insertBehaviorRun();
+});
+
+describe("runEvalSuite", () => {
+	test("N trials stay N distinct runs instead of collapsing into one", async () => {
+		// createEvalRun dedups on (sourceRunId, caseKey). Without trial-scoped keys
+		// a 3-trial suite would queue ONE run and report a single measurement as
+		// three — variance would look like zero and every wobble like a regression.
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "trials",
+			expectation: "lists the duplicates",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		const suite = await runEvalSuite({
+			organizationId,
+			behaviorId,
+			caseIds: [promoted.evalCase.entityId],
+			trials: 3,
+		});
+
+		expect(suite.trials).toBe(3);
+		expect(suite.cases).toHaveLength(1);
+		expect(suite.cases[0].runIds).toHaveLength(3);
+		expect(new Set(suite.cases[0].runIds).size).toBe(3);
+		expect(suite.skipped).toEqual([]);
+	});
+
+	test("every trial resolves back to its case despite the suffixed key", async () => {
+		// The trial suffix rides on the case key, which is also how the scorer
+		// recovers the case. If minting and parsing ever drift, scores land
+		// unanchored and the suite silently reports nothing — with no error.
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "anchor",
+			expectation: "x",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		await landTrial("anchor", 0, { good: true });
+		await landTrial("anchor", 2, { good: true });
+
+		const [entity] = (await sql`
+      SELECT metadata FROM entities WHERE id = ${promoted.evalCase.entityId}
+    `) as unknown as Array<{ metadata: Record<string, unknown> }>;
+		const scores = entity.metadata.recent_scores as Array<{ score: number }>;
+		expect(scores).toHaveLength(2);
+	});
+});
+
+describe("readEvalResults", () => {
+	test("reports a real drop as a regression, and names the case", async () => {
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "regressed",
+			expectation: "x",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		// Baseline group: two clean runs. Then the "after my edit" group: two runs
+		// that complete the window but extract nothing — a real quality drop.
+		await landTrial("regressed", 0, { good: true });
+		await landTrial("regressed", 1, { good: true });
+		await landTrial("regressed", 2, { good: false });
+		await landTrial("regressed", 3, { good: false });
+
+		const results = await readEvalResults({
+			organizationId,
+			behaviorId,
+			trials: 2,
+		});
+		const row = results.cases.find(
+			(c) => c.caseId === promoted.evalCase.entityId,
+		);
+		expect(row).toBeDefined();
+		if (!row) return;
+
+		expect(row.latest).toBe(0.5);
+		expect(row.previous).toBe(1);
+		expect(row.delta).toBe(-0.5);
+		expect(row.spread).toBe(0);
+		expect(results.summary.regressions).toContain(promoted.evalCase.entityId);
+	});
+
+	test("does NOT call a wobble smaller than its own noise a regression", async () => {
+		// The load-bearing assertion. This case is genuinely flaky: its latest
+		// group contains one good and one bad run, so it SAW a 1.0 spread. A
+		// -0.25 move against that spread is noise, and calling it a regression is
+		// the exact error that read a provider quota storm as a prompt failure.
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "flaky",
+			expectation: "x",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		// previous group (landed first): both clean → mean 1.0
+		await landTrial("flaky", 0, { good: true });
+		await landTrial("flaky", 1, { good: true });
+		// latest group: one clean, one empty → mean 0.75, spread 0.5
+		await landTrial("flaky", 2, { good: true });
+		await landTrial("flaky", 3, { good: false });
+
+		const results = await readEvalResults({
+			organizationId,
+			behaviorId,
+			trials: 2,
+		});
+		const row = results.cases.find(
+			(c) => c.caseId === promoted.evalCase.entityId,
+		);
+		expect(row).toBeDefined();
+		if (!row) return;
+
+		// A genuine DOWNWARD move — so `delta < 0` alone would flag it...
+		expect(row.delta).toBe(-0.25);
+		// ...but the case wobbled by 0.5 within the latest group by itself, so
+		// -0.25 is inside its own noise and must NOT be called a regression.
+		expect(row.spread).toBe(0.5);
+		expect(results.summary.regressions).not.toContain(
+			promoted.evalCase.entityId,
+		);
+	});
+
+	test("a never-scored case reports null rather than zero", async () => {
+		// A case with no runs yet must not read as "scored 0" — that would drag
+		// the Behavior's summary down for work nobody has measured.
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "unscored",
+			expectation: "x",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		const results = await readEvalResults({ organizationId, behaviorId });
+		const row = results.cases.find(
+			(c) => c.caseId === promoted.evalCase.entityId,
+		);
+		expect(row?.latest).toBeNull();
+		expect(row?.delta).toBeNull();
+		expect(results.summary.regressions).not.toContain(
+			promoted.evalCase.entityId,
+		);
+	});
+});

--- a/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
@@ -304,6 +304,55 @@ describe("readEvalResults", () => {
 		);
 	});
 
+	test("groups with an unknown metric set never compare — even to each other", async () => {
+		// Pre-metrics rows (written before the `metrics` field existed) carry no
+		// way to know what their score was a fraction of. Two such groups must
+		// NOT be compared: `null === null` would silently treat unknown as equal
+		// to unknown and read a real-looking delta out of nothing.
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "unknown-set",
+			expectation: "x",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		const [entity] = (await sql`
+      SELECT metadata FROM entities WHERE id = ${promoted.evalCase.entityId}
+    `) as unknown as Array<{ metadata: Record<string, unknown> }>;
+		await sql`
+      UPDATE entities
+      SET metadata = ${sql.json({
+				...entity.metadata,
+				recent_scores: [
+					{ run_id: 9011, score: 0.5, at: "2026-08-01T00:00:00.000Z" },
+					{ run_id: 9012, score: 0.5, at: "2026-08-01T00:00:00.000Z" },
+					{ run_id: 9013, score: 1, at: "2026-07-31T00:00:00.000Z" },
+					{ run_id: 9014, score: 1, at: "2026-07-31T00:00:00.000Z" },
+				],
+			} as never)}
+      WHERE id = ${promoted.evalCase.entityId}
+    `;
+
+		const results = await readEvalResults({
+			organizationId,
+			behaviorId,
+			trials: 2,
+		});
+		const row = results.cases.find(
+			(c) => c.caseId === promoted.evalCase.entityId,
+		);
+		expect(row).toBeDefined();
+		if (!row) return;
+
+		expect(row.latest).toBe(0.5);
+		expect(row.previous).toBe(1);
+		expect(row.delta).toBeNull();
+		expect(results.summary.regressions).not.toContain(
+			promoted.evalCase.entityId,
+		);
+	});
+
 	test("a never-scored case reports null rather than zero", async () => {
 		// A case with no runs yet must not read as "scored 0" — that would drag
 		// the Behavior's summary down for work nobody has measured.

--- a/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
+++ b/packages/server/src/__tests__/integration/runs/eval-suite.test.ts
@@ -353,6 +353,83 @@ describe("readEvalResults", () => {
 		);
 	});
 
+	test("groups by the suite's own trial count, not the reader's guess", async () => {
+		// A trials=5 suite writes 5 entries to the window. Read at the default 3,
+		// positional grouping would take the newest 3 as "latest" and the next 2
+		// as "previous" — one batch split across BOTH groups, comparing the batch
+		// to itself and reading a false regression out of it. The stamp on the
+		// case tells the reader the real batch size; `previous` must then be null
+		// (there is no second batch yet), not a self-comparison.
+		const promoted = await promoteEvalCase({
+			sourceRunId,
+			caseKey: "stamped-batch",
+			expectation: "x",
+		});
+		expect(promoted.ok).toBe(true);
+		if (!promoted.ok) return;
+
+		const [entity] = (await sql`
+      SELECT metadata FROM entities WHERE id = ${promoted.evalCase.entityId}
+    `) as unknown as Array<{ metadata: Record<string, unknown> }>;
+		await sql`
+      UPDATE entities
+      SET metadata = ${sql.json({
+				...entity.metadata,
+				suite_trials: 5,
+				recent_scores: [
+					{
+						run_id: 9021,
+						score: 0.5,
+						at: "2026-08-01T00:00:00.000Z",
+						metrics: ["completed_window", "output_present"],
+					},
+					{
+						run_id: 9022,
+						score: 0.5,
+						at: "2026-08-01T00:00:00.000Z",
+						metrics: ["completed_window", "output_present"],
+					},
+					{
+						run_id: 9023,
+						score: 0.5,
+						at: "2026-08-01T00:00:00.000Z",
+						metrics: ["completed_window", "output_present"],
+					},
+					{
+						run_id: 9024,
+						score: 1,
+						at: "2026-08-01T00:00:00.000Z",
+						metrics: ["completed_window", "output_present"],
+					},
+					{
+						run_id: 9025,
+						score: 1,
+						at: "2026-08-01T00:00:00.000Z",
+						metrics: ["completed_window", "output_present"],
+					},
+				],
+			} as never)}
+      WHERE id = ${promoted.evalCase.entityId}
+    `;
+
+		// Deliberately the DEFAULT trials (3), the configuration that used to
+		// split the 5-batch and report a regression.
+		const results = await readEvalResults({ organizationId, behaviorId });
+		const row = results.cases.find(
+			(c) => c.caseId === promoted.evalCase.entityId,
+		);
+		expect(row).toBeDefined();
+		if (!row) return;
+
+		expect(row.latestTrials).toBe(5);
+		expect(row.latest).toBe(0.7);
+		expect(row.previous).toBeNull();
+		expect(row.delta).toBeNull();
+		expect(results.summary.regressions).not.toContain(
+			promoted.evalCase.entityId,
+		);
+	});
+
 	test("a never-scored case reports null rather than zero", async () => {
 		// A case with no runs yet must not read as "scored 0" — that would drag
 		// the Behavior's summary down for work nobody has measured.

--- a/packages/server/src/__tests__/integration/runs/score-eval-runs-queue.test.ts
+++ b/packages/server/src/__tests__/integration/runs/score-eval-runs-queue.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The scorer queue itself.
+ *
+ * The claim under test is that the anti-join predicate IS the queue: a run
+ * leaves it only once its score events exist, which is a committed fact every
+ * replica can see. So the properties that matter are (a) unscored terminal eval
+ * runs are picked up, (b) already-scored ones are not picked up again — that is
+ * what stops a second pod re-judging and re-billing the same run — and (c) a run
+ * inside the settle window is left alone, because `dry_run_preview` is merged by
+ * several capture sites and reading it too early scores a complete run as an
+ * incomplete one.
+ */
+
+import { beforeAll, describe, expect, test } from "vitest";
+import {
+	BEHAVIOR_EVAL_RUN_TYPE,
+	BEHAVIOR_RUN_TYPE,
+} from "../../../runs/run-types";
+import { runScoreEvalRuns } from "../../../scheduled/score-eval-runs";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const sql = getTestDb();
+
+let organizationId: string;
+let behaviorId: number;
+
+/**
+ * `agedSeconds` backdates `completed_at`. The settle window is 60s, so a run
+ * created "now" is deliberately NOT claimable — which is what the settle test
+ * asserts.
+ */
+async function insertRun(params: {
+	runType: string;
+	agedSeconds: number;
+	status?: string;
+}): Promise<number> {
+	const [run] = (await sql`
+    INSERT INTO runs (
+      organization_id, run_type, watcher_id, approval_status, status,
+      dry_run_preview, completed_at, created_at
+    ) VALUES (
+      ${organizationId}, ${params.runType}, ${behaviorId}, 'auto',
+      ${params.status ?? "completed"},
+      ${sql.json({ captured: "complete_window", extracted_data: { a: 1 } } as never)},
+      now() - ${`${params.agedSeconds} seconds`}::interval,
+      now() - ${`${params.agedSeconds} seconds`}::interval
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	return Number(run.id);
+}
+
+async function scoreCount(runId: number): Promise<number> {
+	const [row] = (await sql`
+    SELECT count(*)::int AS n FROM events
+    WHERE organization_id = ${organizationId}
+      AND identity_ns = 'eval_score'
+      AND identity_key LIKE ${`${runId}:%`}
+      AND superseded_by IS NULL
+  `) as unknown as Array<{ n: number }>;
+	return row.n;
+}
+
+beforeAll(async () => {
+	await cleanupTestDatabase();
+
+	const org = await createTestOrganization();
+	organizationId = org.id;
+	const creator = await createTestUser();
+	await addUserToOrganization(creator.id, organizationId, "owner");
+
+	const [behavior] = (await sql`
+    WITH next_id AS (SELECT nextval('watchers_id_seq')::integer AS id)
+    INSERT INTO watchers (
+      id, watcher_group_id, organization_id, created_by, name, slug, schedule, status
+    )
+    SELECT id, id, ${organizationId}, ${creator.id}, 'Queue Behavior', 'queue-behavior', '0 * * * *', 'active'
+    FROM next_id
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+	behaviorId = Number(behavior.id);
+});
+
+describe("runScoreEvalRuns", () => {
+	test("scores a settled eval run, then never claims it again", async () => {
+		const runId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			agedSeconds: 600,
+		});
+
+		const first = await runScoreEvalRuns();
+		expect(first.claimed).toBe(1);
+		expect(first.scored).toBe(1);
+		expect(await scoreCount(runId)).toBe(2);
+
+		// The second tick is the multi-replica case in miniature: the run is out
+		// of the queue because its score events exist, not because this process
+		// remembers scoring it. A claim here would mean a second pod re-judges
+		// and re-bills every run on every tick.
+		const second = await runScoreEvalRuns();
+		expect(second.claimed).toBe(0);
+		expect(await scoreCount(runId)).toBe(2);
+	});
+
+	test("leaves a run inside the settle window alone", async () => {
+		const runId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			agedSeconds: 0,
+		});
+
+		const summary = await runScoreEvalRuns();
+		expect(summary.claimed).toBe(0);
+		expect(await scoreCount(runId)).toBe(0);
+	});
+
+	test("never claims a live Behavior run or a non-terminal one", async () => {
+		const liveRunId = await insertRun({
+			runType: BEHAVIOR_RUN_TYPE,
+			agedSeconds: 600,
+		});
+		const runningRunId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			agedSeconds: 600,
+			status: "running",
+		});
+
+		const summary = await runScoreEvalRuns();
+		expect(summary.claimed).toBe(0);
+		expect(await scoreCount(liveRunId)).toBe(0);
+		expect(await scoreCount(runningRunId)).toBe(0);
+	});
+});

--- a/packages/server/src/__tests__/integration/runs/score-eval-runs-queue.test.ts
+++ b/packages/server/src/__tests__/integration/runs/score-eval-runs-queue.test.ts
@@ -107,6 +107,23 @@ describe("runScoreEvalRuns", () => {
 		expect(await scoreCount(runId)).toBe(2);
 	});
 
+	test("scores a TIMED OUT eval run — that is the failure worth measuring", async () => {
+		// `markStaleRunsAsTimeout` runs over BEHAVIOR_RUN_TYPES, so a crashed or
+		// abandoned eval reaches `timeout` and never any other terminal status.
+		// Leaving it out of the terminal set would silently exclude the runs that
+		// most need a score, and they would never leave the queue either.
+		const runId = await insertRun({
+			runType: BEHAVIOR_EVAL_RUN_TYPE,
+			agedSeconds: 600,
+			status: "timeout",
+		});
+
+		const summary = await runScoreEvalRuns();
+		expect(summary.claimed).toBe(1);
+		expect(summary.scored).toBe(1);
+		expect(await scoreCount(runId)).toBe(2);
+	});
+
 	test("leaves a run inside the settle window alone", async () => {
 		const runId = await insertRun({
 			runType: BEHAVIOR_EVAL_RUN_TYPE,

--- a/packages/server/src/__tests__/unit/eval-case-run-key.test.ts
+++ b/packages/server/src/__tests__/unit/eval-case-run-key.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The run-key ↔ case-identifier round trip.
+ *
+ * This pair is the ONLY join between a scored eval run and the case it
+ * measures — there is no column behind it. `createEvalRun` stamps
+ * `idempotency_key = 'behavior_eval:<sourceRunId>:<caseKey>'`, `promoteEvalCase`
+ * claims `entity_identities` under '<sourceRunId>:<caseKey>', and the scorer
+ * recovers one from the other. When they drift nothing throws: scores land
+ * unanchored, the suite reports an empty case, and no error appears anywhere.
+ *
+ * Pure string functions, so no Postgres.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	evalCaseIdentifierFromRunKey,
+	trialCaseKey,
+} from "../../runs/eval-cases";
+
+const key = (sourceRunId: number, caseKey: string) =>
+	`behavior_eval:${sourceRunId}:${caseKey}`;
+
+describe("trialCaseKey", () => {
+	test("trial 0 keeps the bare key", () => {
+		// So a plain replay and trial 0 of a suite are the same work item, and
+		// every case promoted before trials existed keeps resolving.
+		expect(trialCaseKey("weekly", 0)).toBe("weekly");
+	});
+
+	test("later trials are distinct, or N trials collapse into one run", () => {
+		const keys = [0, 1, 2].map((t) => trialCaseKey("weekly", t));
+		expect(new Set(keys).size).toBe(3);
+	});
+});
+
+describe("evalCaseIdentifierFromRunKey", () => {
+	test("every trial of a case resolves to the same identifier", () => {
+		const identifiers = [0, 1, 2].map((t) =>
+			evalCaseIdentifierFromRunKey(key(41, trialCaseKey("weekly", t))),
+		);
+		expect(identifiers).toEqual(["41:weekly", "41:weekly", "41:weekly"]);
+	});
+
+	test("a case key containing '#' is NOT truncated", () => {
+		// `caseKey` is caller-supplied free text. Stripping at the last '#' rather
+		// than at the minted `#t<n>` suffix would rewrite this case's own key to
+		// '41:weekly', which matches no promoted case — so every score for it
+		// would silently land unanchored.
+		expect(evalCaseIdentifierFromRunKey(key(41, "weekly#draft"))).toBe(
+			"41:weekly#draft",
+		);
+		expect(
+			evalCaseIdentifierFromRunKey(key(41, trialCaseKey("weekly#draft", 2))),
+		).toBe("41:weekly#draft");
+	});
+
+	test("a '#t' that is not a trial suffix survives", () => {
+		expect(evalCaseIdentifierFromRunKey(key(41, "weekly#tuesday"))).toBe(
+			"41:weekly#tuesday",
+		);
+	});
+
+	test("rejects a key that is not an eval run's", () => {
+		// Guards against scoring anchoring itself to a live Behavior run's key.
+		expect(evalCaseIdentifierFromRunKey("watcher:41:weekly")).toBeNull();
+		expect(evalCaseIdentifierFromRunKey("behavior_eval:")).toBeNull();
+		expect(evalCaseIdentifierFromRunKey(null)).toBeNull();
+	});
+});

--- a/packages/server/src/__tests__/unit/eval-judge-verdict.test.ts
+++ b/packages/server/src/__tests__/unit/eval-judge-verdict.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The judge-reply parser — the only metric path with no coverage until this
+ * file existed.
+ *
+ * The judge's reply is the one place a model's output turns into a number that
+ * can move a Behavior's regression verdict. The parser is deliberately strict:
+ * an unusable reply returns null (the metric is SKIPPED, never scored 0), so a
+ * misbehaving judge must not punish the Behavior. These tests pin that
+ * contract — fence stripping, range checks, the derive-from-score default, and
+ * the hard null on anything not a verdict.
+ *
+ * Pure function, so no Postgres.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseJudgeVerdict } from "../../runs/eval-scores";
+
+describe("parseJudgeVerdict", () => {
+	test("parses a bare JSON verdict", () => {
+		const v = parseJudgeVerdict(
+			'{"score": 0.8, "passed": true, "reasoning": "met the expectation"}',
+		);
+		expect(v).toEqual({
+			score: 0.8,
+			passed: true,
+			reasoning: "met the expectation",
+		});
+	});
+
+	test("strips a ```json fence — models fence often enough to be worth one line", () => {
+		const v = parseJudgeVerdict(
+			'```json\n{"score": 0.5, "passed": false, "reasoning": "close but missed"}\n```',
+		);
+		expect(v).toEqual({
+			score: 0.5,
+			passed: false,
+			reasoning: "close but missed",
+		});
+	});
+
+	test("derives `passed` from score >= 0.5 when it is unstated", () => {
+		// An unstated verdict is not a passing one by default — but a low score
+		// with no explicit boolean must not flip into a pass either.
+		expect(parseJudgeVerdict('{"score": 0.6, "reasoning": "ok"}')?.passed).toBe(
+			true,
+		);
+		expect(parseJudgeVerdict('{"score": 0.5, "reasoning": "borderline"}')?.passed).toBe(
+			true,
+		);
+		expect(parseJudgeVerdict('{"score": 0.49, "reasoning": "no"}')?.passed).toBe(
+			false,
+		);
+	});
+
+	test("trusts an explicit boolean over the score", () => {
+		expect(
+			parseJudgeVerdict(
+				'{"score": 0.9, "passed": false, "reasoning": "confident but wrong"}',
+			)?.passed,
+		).toBe(false);
+	});
+
+	test("rejects a score outside 0.0–1.0", () => {
+		expect(parseJudgeVerdict('{"score": 1.5, "passed": true}')).toBeNull();
+		expect(parseJudgeVerdict('{"score": -0.1, "passed": true}')).toBeNull();
+	});
+
+	test("rejects a non-numeric score", () => {
+		expect(parseJudgeVerdict('{"score": "0.8", "passed": true}')).toBeNull();
+		expect(parseJudgeVerdict('{"score": null, "passed": true}')).toBeNull();
+		expect(parseJudgeVerdict('{"passed": true}')).toBeNull();
+	});
+
+	test("returns null on a non-JSON reply", () => {
+		expect(parseJudgeVerdict("the output meets the expectation")).toBeNull();
+		expect(parseJudgeVerdict("")).toBeNull();
+	});
+
+	test("returns null when braces never close", () => {
+		expect(parseJudgeVerdict('{"score": 0.8')).toBeNull();
+	});
+
+	test("caps reasoning length", () => {
+		const long = "x".repeat(5_000);
+		const v = parseJudgeVerdict(`{"score": 1, "passed": true, "reasoning": "${long}"}`);
+		expect(v?.reasoning.length).toBe(2_000);
+	});
+});

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -23,6 +23,11 @@ import {
 	type OAuthProviderConfig,
 } from "../gateway/auth/oauth/providers";
 import { buildProviderCatalog } from "../gateway/auth/provider-catalog";
+import {
+	promoteEvalCase,
+	setEvalCaseJudgeModel,
+} from "../runs/eval-cases";
+import { readEvalResults, runEvalSuite } from "../runs/eval-suite";
 import { createAuthProfileLabel } from "../gateway/auth/settings/auth-profiles-manager";
 import { orgBucketAgentId } from "../gateway/auth/settings/user-auth-profile-store";
 import { validateModelRefsAgainstOrg } from "./model-config";
@@ -1283,6 +1288,131 @@ routes.delete("/inference-providers/:slug", async (c) => {
 		state: null,
 	});
 	return c.json({ success: true });
+});
+
+// ── Evals ────────────────────────────────────────────────────────────────────
+// Registered BEFORE `/:agentId` so these literal paths win the match (Hono
+// would otherwise read 'evals' as an :agentId and 404).
+//
+// This is the surface the eval program was missing. `promoteEvalCase` and
+// `replayEvalCase` shipped in #2584 with NO caller anywhere outside their own
+// module — the whole flow was unreachable, so nothing could promote a case and
+// nothing could read a result. Scores with no way to ask for them are not a
+// feature.
+
+/**
+ * Promote a real Behavior run into a reusable eval case.
+ *
+ * `expectation` is what the judge grades against; without one a case is still
+ * useful (the code metrics run) but nothing measures whether the OUTPUT was
+ * right. `judgeModel` is the per-case override — name a model different from
+ * the one under eval to avoid a model grading its own work.
+ */
+routes.post("/evals/cases", async (c) => {
+	const orgId = requireOrgId(c);
+	if (typeof orgId !== "string") return orgId;
+
+	const body = (await c.req.json().catch(() => ({}))) as {
+		runId?: unknown;
+		caseKey?: unknown;
+		expectation?: unknown;
+		judgeModel?: unknown;
+	};
+	const runId = Number(body.runId);
+	if (!Number.isSafeInteger(runId) || runId < 1) {
+		return c.json({ error: "runId is required" }, 400);
+	}
+
+	const result = await promoteEvalCase({
+		sourceRunId: runId,
+		caseKey: typeof body.caseKey === "string" ? body.caseKey : "default",
+		expectation:
+			typeof body.expectation === "string" ? body.expectation : undefined,
+		createdBy: (c.get("user") as { id?: string } | undefined)?.id ?? null,
+	});
+
+	if (!result.ok) {
+		// `not_found` is the only 404 here: the other rejections mean the run
+		// exists but cannot be replayed, which is a 422 — the caller asked for
+		// something coherent that this run cannot support.
+		const status = result.reason === "not_found" ? 404 : 422;
+		return c.json({ error: result.reason }, status);
+	}
+
+	// Cross-org read guard: promote resolves the org from the RUN, so a caller
+	// could otherwise promote another tenant's run by id. Refuse after the fact
+	// rather than trusting the id.
+	if (result.evalCase.organizationId !== orgId) {
+		return c.json({ error: "not_found" }, 404);
+	}
+
+	if (typeof body.judgeModel === "string" && body.judgeModel.trim()) {
+		await setEvalCaseJudgeModel(
+			result.evalCase.entityId,
+			orgId,
+			body.judgeModel.trim()
+		);
+	}
+
+	return c.json({ case: result.evalCase, created: result.created }, 201);
+});
+
+/**
+ * Replay a Behavior's active case suite under capture mode.
+ *
+ * Defaults to several trials per case because a single run is not a
+ * measurement — our own research evals swung ±1 task on identical batteries.
+ */
+routes.post("/behaviors/:behaviorId/evals/run", async (c) => {
+	const orgId = requireOrgId(c);
+	if (typeof orgId !== "string") return orgId;
+
+	const behaviorId = Number(c.req.param("behaviorId"));
+	if (!Number.isSafeInteger(behaviorId) || behaviorId < 1) {
+		return c.json({ error: "behaviorId must be a number" }, 400);
+	}
+
+	const body = (await c.req.json().catch(() => ({}))) as {
+		caseIds?: unknown;
+		trials?: unknown;
+	};
+	const caseIds = Array.isArray(body.caseIds)
+		? body.caseIds.map(Number).filter((n) => Number.isSafeInteger(n) && n > 0)
+		: undefined;
+
+	const result = await runEvalSuite({
+		organizationId: orgId,
+		behaviorId,
+		caseIds: caseIds?.length ? caseIds : undefined,
+		trials: typeof body.trials === "number" ? body.trials : undefined,
+	});
+	return c.json(result, 202);
+});
+
+/**
+ * Read the suite's answer: per case latest vs previous, and which cases moved
+ * by more than their own noise.
+ *
+ * Reads case ENTITIES only. Never aggregates `eval_score` events — the scorer
+ * materializes each case's rolling window at write time precisely so this stays
+ * a bounded config-table read.
+ */
+routes.get("/behaviors/:behaviorId/evals/results", async (c) => {
+	const orgId = requireOrgId(c);
+	if (typeof orgId !== "string") return orgId;
+
+	const behaviorId = Number(c.req.param("behaviorId"));
+	if (!Number.isSafeInteger(behaviorId) || behaviorId < 1) {
+		return c.json({ error: "behaviorId must be a number" }, 400);
+	}
+
+	const trialsParam = Number(c.req.query("trials"));
+	const results = await readEvalResults({
+		organizationId: orgId,
+		behaviorId,
+		trials: Number.isFinite(trialsParam) ? trialsParam : undefined,
+	});
+	return c.json(results);
 });
 
 // ── Get agent detail ─────────────────────────────────────────────────────────

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -23,11 +23,6 @@ import {
 	type OAuthProviderConfig,
 } from "../gateway/auth/oauth/providers";
 import { buildProviderCatalog } from "../gateway/auth/provider-catalog";
-import {
-	promoteEvalCase,
-	setEvalCaseJudgeModel,
-} from "../runs/eval-cases";
-import { readEvalResults, runEvalSuite } from "../runs/eval-suite";
 import { createAuthProfileLabel } from "../gateway/auth/settings/auth-profiles-manager";
 import { orgBucketAgentId } from "../gateway/auth/settings/user-auth-profile-store";
 import { validateModelRefsAgainstOrg } from "./model-config";
@@ -36,6 +31,8 @@ import {
 	resolveProviderRegistryPath,
 } from "../gateway/services/provider-registry-service";
 import type { Env } from "../index";
+import { promoteEvalCase, setEvalCaseJudgeModel } from "../runs/eval-cases";
+import { readEvalResults, runEvalSuite } from "../runs/eval-suite";
 import { getApplyContext } from "../utils/apply-context";
 import { recordConfigChangeEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
@@ -1291,8 +1288,9 @@ routes.delete("/inference-providers/:slug", async (c) => {
 });
 
 // ── Evals ────────────────────────────────────────────────────────────────────
-// Registered BEFORE `/:agentId` so these literal paths win the match (Hono
-// would otherwise read 'evals' as an :agentId and 404).
+// Registered with the other literal-prefix routes, ahead of the `/:agentId`
+// block below, so a future `/:agentId/...` route of the same shape can never
+// shadow them.
 //
 // This is the surface the eval program was missing. `promoteEvalCase` and
 // `replayEvalCase` shipped in #2584 with NO caller anywhere outside their own
@@ -1309,6 +1307,8 @@ routes.delete("/inference-providers/:slug", async (c) => {
  * the one under eval to avoid a model grading its own work.
  */
 routes.post("/evals/cases", async (c) => {
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
 	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
 
@@ -1329,28 +1329,26 @@ routes.post("/evals/cases", async (c) => {
 		expectation:
 			typeof body.expectation === "string" ? body.expectation : undefined,
 		createdBy: (c.get("user") as { id?: string } | undefined)?.id ?? null,
+		// Promote resolves the org from the RUN, so this is what stops a caller
+		// creating a case inside another tenant's workspace by run id. It has to
+		// be checked BEFORE the write, not after — see `promoteEvalCase`.
+		organizationId: orgId,
 	});
 
 	if (!result.ok) {
-		// `not_found` is the only 404 here: the other rejections mean the run
-		// exists but cannot be replayed, which is a 422 — the caller asked for
-		// something coherent that this run cannot support.
+		// `not_found` is the only 404 here — it also covers a run belonging to
+		// another org. The other rejections mean the run exists but cannot be
+		// replayed, which is a 422: the caller asked for something coherent that
+		// this run cannot support.
 		const status = result.reason === "not_found" ? 404 : 422;
 		return c.json({ error: result.reason }, status);
-	}
-
-	// Cross-org read guard: promote resolves the org from the RUN, so a caller
-	// could otherwise promote another tenant's run by id. Refuse after the fact
-	// rather than trusting the id.
-	if (result.evalCase.organizationId !== orgId) {
-		return c.json({ error: "not_found" }, 404);
 	}
 
 	if (typeof body.judgeModel === "string" && body.judgeModel.trim()) {
 		await setEvalCaseJudgeModel(
 			result.evalCase.entityId,
 			orgId,
-			body.judgeModel.trim()
+			body.judgeModel.trim(),
 		);
 	}
 
@@ -1364,6 +1362,10 @@ routes.post("/evals/cases", async (c) => {
  * measurement — our own research evals swung ±1 task on identical batteries.
  */
 routes.post("/behaviors/:behaviorId/evals/run", async (c) => {
+	// Admin-tier: each call queues up to cases × trials replays, and every one
+	// of them spends inference budget.
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
 	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
 

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1352,7 +1352,17 @@ routes.post("/evals/cases", async (c) => {
 		);
 	}
 
-	return c.json({ case: result.evalCase, created: result.created }, 201);
+	return c.json(
+		{
+			case: {
+				...result.evalCase,
+				judgeModel:
+					typeof body.judgeModel === "string" ? body.judgeModel.trim() : null,
+			},
+			created: result.created,
+		},
+		201,
+	);
 });
 
 /**

--- a/packages/server/src/runs/eval-cases.ts
+++ b/packages/server/src/runs/eval-cases.ts
@@ -318,7 +318,7 @@ export async function promoteEvalCase(
 }
 
 /**
- * Set (or clear) a case's judge-model override.
+ * Set a case's judge-model override.
  *
  * Deliberately a `<slug>/<model>` ref resolved by `resolveCompletionTarget`,
  * the same shape a guardrail entry's `model` already uses — the platform
@@ -331,7 +331,7 @@ export async function promoteEvalCase(
 export async function setEvalCaseJudgeModel(
 	entityId: number,
 	organizationId: string,
-	judgeModel: string | null,
+	judgeModel: string,
 	db?: DbClient,
 ): Promise<void> {
 	const sql = db ?? getDb();
@@ -340,7 +340,7 @@ export async function setEvalCaseJudgeModel(
     SET metadata = jsonb_set(
           coalesce(e.metadata, '{}'::jsonb),
           '{judge_model}',
-          ${sql.json((judgeModel ?? null) as never)}::jsonb
+          ${sql.json(judgeModel as never)}::jsonb
         ),
         updated_at = current_timestamp
     FROM entity_types et

--- a/packages/server/src/runs/eval-cases.ts
+++ b/packages/server/src/runs/eval-cases.ts
@@ -58,10 +58,19 @@ export const EVAL_CASE_NAMESPACE = "eval_case";
  * that drifted would silently strand every score unanchored.
  */
 export function trialCaseKey(caseKey: string, trial: number): string {
-	return trial === 0 ? caseKey : `${caseKey}${TRIAL_SEPARATOR}t${trial}`;
+	return trial === 0 ? caseKey : `${caseKey}#t${trial}`;
 }
 
-const TRIAL_SEPARATOR = "#";
+/**
+ * The exact suffix `trialCaseKey` mints, anchored to the end.
+ *
+ * Anchored and shape-checked rather than "everything after the last `#`":
+ * `caseKey` is caller-supplied free text, so a case promoted as `weekly#draft`
+ * would otherwise have its own key truncated to `weekly` and every one of its
+ * scores would resolve to a case that does not exist — silently, with an empty
+ * suite and no error anywhere.
+ */
+const TRIAL_SUFFIX_RE = /#t\d+$/;
 
 /**
  * Recover the `entity_identities` identifier for the case a run belongs to.
@@ -78,8 +87,7 @@ export function evalCaseIdentifierFromRunKey(
 	if (!idempotencyKey?.startsWith(prefix)) return null;
 	const identifier = idempotencyKey.slice(prefix.length);
 	if (!identifier) return null;
-	const trialAt = identifier.lastIndexOf(TRIAL_SEPARATOR);
-	return trialAt > 0 ? identifier.slice(0, trialAt) : identifier;
+	return identifier.replace(TRIAL_SUFFIX_RE, "");
 }
 
 /**
@@ -88,7 +96,13 @@ export function evalCaseIdentifierFromRunKey(
  * `readOnly` on the pointer fields is a HINT to whatever renders the entity —
  * nothing server-side enforces it, and no write path here consults it. It says
  * what editing them would mean: repointing a case at a different question while
- * keeping its comments and history. Promote a new case instead.
+ * keeping its comments and history. Promote a new case instead. `recent_scores`
+ * carries the same hint for a different reason: the scorer owns it, and a hand
+ * edit would be overwritten by the next run.
+ *
+ * Every key any write path sets is declared here, `judge_model` and
+ * `recent_scores` included — an undeclared key is one a generic entity editor
+ * would have no reason to preserve.
  */
 const EVAL_CASE_METADATA_SCHEMA = {
 	type: "object",
@@ -119,6 +133,17 @@ const EVAL_CASE_METADATA_SCHEMA = {
 			type: "string",
 			description: "Status",
 			"x-table-column": true,
+		},
+		judge_model: {
+			type: "string",
+			description:
+				"Model that grades this case, as '<provider-slug>/<model>'. Name one DIFFERENT from the model under eval. Empty = the org default.",
+		},
+		recent_scores: {
+			type: "array",
+			description:
+				"Rolling window of this case's recent run scores, newest first. Written by the scorer.",
+			readOnly: true,
 		},
 	},
 } as const;
@@ -159,6 +184,14 @@ export async function promoteEvalCase(
 		expectation?: string | null;
 		/** Who is promoting. Falls back to an org owner/admin when absent. */
 		createdBy?: string | null;
+		/**
+		 * Org the caller is authenticated for. Required by every request-path
+		 * caller: the org is resolved from the RUN, so without this a caller who
+		 * knows (or guesses) a run id creates an `$eval_case` entity — and an
+		 * `$eval_case` entity TYPE — inside another tenant's workspace. Checking
+		 * after the fact does not help; by then the row exists.
+		 */
+		organizationId?: string;
 	},
 	db?: DbClient,
 ): Promise<PromoteEvalCaseResult> {
@@ -168,6 +201,11 @@ export async function promoteEvalCase(
 	const loaded = await loadReplayableSource(params.sourceRunId, sql);
 	if (!loaded.ok) return { ok: false, reason: loaded.reason };
 	const source = loaded.source;
+	// Indistinguishable from "no such run" on purpose — a cross-tenant caller
+	// must not learn that the id exists.
+	if (params.organizationId && params.organizationId !== source.organizationId) {
+		return { ok: false, reason: "not_found" };
+	}
 	const identifier = `${source.sourceRunId}:${caseKey}`;
 
 	// Existing claim → reuse (idempotent fast path, and the common case when a

--- a/packages/server/src/runs/eval-cases.ts
+++ b/packages/server/src/runs/eval-cases.ts
@@ -340,7 +340,7 @@ export async function setEvalCaseJudgeModel(
     SET metadata = jsonb_set(
           coalesce(e.metadata, '{}'::jsonb),
           '{judge_model}',
-          ${judgeModel ? sql.json(judgeModel as never) : "null"}::jsonb
+          ${sql.json((judgeModel ?? null) as never)}::jsonb
         ),
         updated_at = current_timestamp
     FROM entity_types et

--- a/packages/server/src/runs/eval-cases.ts
+++ b/packages/server/src/runs/eval-cases.ts
@@ -35,9 +35,52 @@ import {
 	loadReplayableSource,
 	type ReplaySourceRejection,
 } from "./eval-runs.js";
+import { BEHAVIOR_EVAL_RUN_TYPE } from "./run-types.js";
 
 /** Namespace for the (source run, case key) identity claim in `entity_identities`. */
 export const EVAL_CASE_NAMESPACE = "eval_case";
+
+/**
+ * The ONE definition of how a trial number rides on a case key, minted and
+ * parsed by the two functions below.
+ *
+ * `createEvalRun` dedups on `(sourceRunId, caseKey)`, which is exactly right for
+ * a single replay and exactly wrong for N trials: running the same case five
+ * times would collapse into one run and report a single measurement as if it
+ * were five. Trials therefore carry a distinct key.
+ *
+ * Trial 0 keeps the bare key so a plain `replayEvalCase` and trial 0 of a suite
+ * run are the same work item rather than two — and so every case promoted
+ * before trials existed keeps resolving.
+ *
+ * Never re-implement this split anywhere else. `findCaseForRun` recovers the
+ * case by calling `evalCaseIdentifierFromRunKey`, and a second copy of the rule
+ * that drifted would silently strand every score unanchored.
+ */
+export function trialCaseKey(caseKey: string, trial: number): string {
+	return trial === 0 ? caseKey : `${caseKey}${TRIAL_SEPARATOR}t${trial}`;
+}
+
+const TRIAL_SEPARATOR = "#";
+
+/**
+ * Recover the `entity_identities` identifier for the case a run belongs to.
+ *
+ * `createEvalRun` stamps `idempotency_key = 'behavior_eval:<sourceRunId>:<caseKey>'`
+ * and `promoteEvalCase` claims identifier `'<sourceRunId>:<caseKey>'`. The
+ * suffix of the one IS the other, which is why neither needed a join column.
+ * Trials append `#t<n>`, stripped here so every trial resolves to its case.
+ */
+export function evalCaseIdentifierFromRunKey(
+	idempotencyKey: string | null,
+): string | null {
+	const prefix = `${BEHAVIOR_EVAL_RUN_TYPE}:`;
+	if (!idempotencyKey?.startsWith(prefix)) return null;
+	const identifier = idempotencyKey.slice(prefix.length);
+	if (!identifier) return null;
+	const trialAt = identifier.lastIndexOf(TRIAL_SEPARATOR);
+	return trialAt > 0 ? identifier.slice(0, trialAt) : identifier;
+}
 
 /**
  * Declared shape of `$eval_case` metadata.
@@ -234,6 +277,41 @@ export async function promoteEvalCase(
 		},
 		created: placed.created,
 	};
+}
+
+/**
+ * Set (or clear) a case's judge-model override.
+ *
+ * Deliberately a `<slug>/<model>` ref resolved by `resolveCompletionTarget`,
+ * the same shape a guardrail entry's `model` already uses — the platform
+ * already has this knob, so evals reuse it rather than inventing an env var or
+ * a settings table. Naming a model DIFFERENT from the one under eval is how a
+ * caller avoids a model grading its own output generously.
+ *
+ * Org-scoped: `entities.id` alone would let one tenant repoint another's case.
+ */
+export async function setEvalCaseJudgeModel(
+	entityId: number,
+	organizationId: string,
+	judgeModel: string | null,
+	db?: DbClient,
+): Promise<void> {
+	const sql = db ?? getDb();
+	await sql`
+    UPDATE entities e
+    SET metadata = jsonb_set(
+          coalesce(e.metadata, '{}'::jsonb),
+          '{judge_model}',
+          ${judgeModel ? sql.json(judgeModel as never) : "null"}::jsonb
+        ),
+        updated_at = current_timestamp
+    FROM entity_types et
+    WHERE e.id = ${entityId}
+      AND e.organization_id = ${organizationId}
+      AND et.id = e.entity_type_id
+      AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+      AND e.deleted_at IS NULL
+  `;
 }
 
 /**

--- a/packages/server/src/runs/eval-scores.ts
+++ b/packages/server/src/runs/eval-scores.ts
@@ -1,0 +1,645 @@
+/**
+ * Scoring an eval replay (evals PR 4, lobu#2564).
+ *
+ * A `behavior_eval` run executes under capture mode: it does the same reads and
+ * the same reasoning a live run does, but every write is recorded onto
+ * `runs.dry_run_preview` instead of committed. That preview is therefore the
+ * complete, honest record of what the Behavior produced — and it is what this
+ * module scores.
+ *
+ * Two kinds of metric, kept deliberately separate:
+ *
+ *   - CODE metrics are pure functions of the captured record. They cost
+ *     nothing, never flake, and run on every scored eval. `completed_window` is
+ *     the one that earns its keep on day one: "finished without calling
+ *     complete_window" is the largest single `agent_error` class
+ *     (`runs/run-outcome.ts`) in the prod sample measured in lobu#2564.
+ *   - The JUDGE metric asks a model whether the captured output actually
+ *     satisfies the case's expectation. It needs a provider, a case, and an
+ *     expectation, so it is frequently absent — and its absence must read as
+ *     "not measured", never as a failing grade. See `scoreEvalRun`.
+ *
+ * Scores are `semantic_type='eval_score'` events with NULL payload_text and
+ * NULL feed_id — the structural exclusion from embedding, search and feed reads
+ * that `canvas_state` established. Identity is
+ * `{ ns: 'eval_score', key: '<runId>:<metric>' }`, backed by a partial unique
+ * index over chain roots (20260807170010), so a second replica scoring the same
+ * run cannot double-write. Rescoring supersedes the head rather than editing it.
+ *
+ * The request-path rule holds: nothing reads these events to answer "how good is
+ * this Behavior". The pass fraction is stamped onto the `watchers` row here, at
+ * write time, so the surface that eventually renders it reads a column rather
+ * than aggregating history.
+ */
+
+import { getErrorMessage } from "@lobu/core";
+import { type DbClient, getDb, pgTextArray } from "../db/client.js";
+import {
+	gatewayCompletion,
+	resolveCompletionTarget,
+} from "../gateway/inference/gateway-completion.js";
+import { insertEvent } from "../utils/insert-event.js";
+import logger from "../utils/logger.js";
+import { resolveEntityCreator } from "../utils/resolve-entity-creator.js";
+import {
+	EVAL_CASE_NAMESPACE,
+	evalCaseIdentifierFromRunKey,
+} from "./eval-cases.js";
+import { BEHAVIOR_EVAL_RUN_TYPE } from "./run-types.js";
+
+/** `semantic_type` of a score event. */
+const EVAL_SCORE_SEMANTIC_TYPE = "eval_score";
+
+/** Identity namespace backing the per-(run, metric) unique index. */
+export const EVAL_SCORE_IDENTITY_NS = "eval_score";
+
+/**
+ * Metrics this module can produce. Stable strings — each is the `metric` field
+ * on every score event it writes AND half of that event's identity key
+ * (`<runId>:<metric>`), so renaming one orphans its whole history: the old
+ * chains keep the old key and nothing supersedes them again.
+ */
+export type EvalMetric =
+	/** Did the agent terminate through `complete_window` rather than just stopping? */
+	| "completed_window"
+	/** Did it produce non-empty extracted output? */
+	| "output_present"
+	/** Does the output satisfy the case's expectation, per a judge model? */
+	| "judge_rubric";
+
+export interface EvalMetricVerdict {
+	metric: EvalMetric;
+	/** 0.0–1.0. Code metrics are binary (0 or 1); the judge may be graded. */
+	score: number;
+	passed: boolean;
+	reasoning: string;
+	/** Set only on judge metrics — which model returned the verdict. */
+	judgeModel?: string;
+}
+
+export type ScoreEvalRunResult =
+	| {
+			ok: true;
+			runId: number;
+			behaviorId: number;
+			verdicts: EvalMetricVerdict[];
+			/** Pass fraction across the verdicts actually produced. */
+			qualityScore: number;
+			caseEntityId: number | null;
+	  }
+	| {
+			ok: false;
+			// No "empty capture record" rejection on purpose: an eval run that
+			// captured nothing is not unscoreable, it is a `completed_window`
+			// FAILURE — which is the single most common real defect. Refusing to
+			// score it would hide exactly the runs worth measuring.
+			reason:
+				| "not_found"
+				| "not_an_eval_run"
+				| "not_terminal"
+				| "no_attributable_member";
+	  };
+
+/** Terminal statuses a run must reach before it means anything to score. */
+const TERMINAL_RUN_STATUSES = ["completed", "failed", "cancelled"];
+
+/**
+ * The same list as a Postgres `text[]` literal, for the scorer queue's `= ANY`.
+ *
+ * The queue MUST select on this exact list. If the two drifted apart it would
+ * keep claiming runs `scoreEvalRun` then rejects as `not_terminal` — and since a
+ * rejected run writes no score events, such a run never leaves the queue and
+ * burns a batch slot on every tick, forever.
+ *
+ * Bind THIS, never the array itself: the pool runs with `fetch_types: false`, so
+ * a raw JS array is sent as the bare string `completed,failed,cancelled` and
+ * Postgres rejects it at runtime with `malformed array literal`.
+ */
+export const TERMINAL_RUN_STATUSES_PG = pgTextArray(TERMINAL_RUN_STATUSES);
+
+/** The judge gets a bounded slice of the output — a rubric verdict is not a diff. */
+const JUDGE_OUTPUT_CHAR_CAP = 8_000;
+
+/** A judge call must not hold a scorer batch open. */
+const JUDGE_TIMEOUT_MS = 30_000;
+
+interface EvalRunRow {
+	id: number;
+	organization_id: string;
+	behavior_id: number;
+	status: string;
+	dry_run_preview: Record<string, unknown> | null;
+	idempotency_key: string | null;
+}
+
+/**
+ * The fields of the captured record this module scores, in the shape
+ * `complete-window.ts` writes them. The preview carries more (`side_effects`,
+ * window bounds, content ids); nothing here reads them, so nothing here
+ * declares them.
+ *
+ * Every field is optional on purpose: the preview is a MERGE target that
+ * several capture sites append to during a turn, so a run that died early has a
+ * partial one. Treating a missing field as "the agent didn't do that" is the
+ * correct reading and is exactly what `completed_window` measures.
+ */
+interface CaptureRecord {
+	captured?: string;
+	extracted_data?: unknown;
+	content_linked?: number;
+}
+
+/**
+ * Did the run terminate through the Behavior protocol?
+ *
+ * `captured: 'complete_window'` is written by the ONE capture branch in
+ * `complete-window.ts`, so its presence is proof the agent called the tool.
+ * Absence is the prod-dominant failure: the agent ran, produced text, and
+ * stopped without ever completing its window.
+ */
+function scoreCompletedWindow(record: CaptureRecord): EvalMetricVerdict {
+	const passed = record.captured === "complete_window";
+	return {
+		metric: "completed_window",
+		score: passed ? 1 : 0,
+		passed,
+		reasoning: passed
+			? "The run terminated through complete_window."
+			: "The run never called complete_window — it stopped without completing its window.",
+	};
+}
+
+/**
+ * Did the run actually produce output?
+ *
+ * Deliberately separate from `completed_window`: an agent can complete its
+ * window with an empty extraction, which is a protocol success and a quality
+ * failure. Collapsing them would hide exactly that case.
+ */
+function scoreOutputPresent(record: CaptureRecord): EvalMetricVerdict {
+	const data = record.extracted_data;
+	const nonEmpty =
+		data != null &&
+		(Array.isArray(data)
+			? data.length > 0
+			: typeof data === "object"
+				? Object.keys(data as Record<string, unknown>).length > 0
+				: String(data).trim().length > 0);
+	return {
+		metric: "output_present",
+		score: nonEmpty ? 1 : 0,
+		passed: nonEmpty,
+		reasoning: nonEmpty
+			? `Extracted output is present (${record.content_linked ?? 0} content item(s) linked).`
+			: "The run produced no extracted output.",
+	};
+}
+
+const JUDGE_SYSTEM_PROMPT = [
+	"You grade whether an automation's output satisfies a stated expectation.",
+	"You are given the expectation and the output the automation actually produced.",
+	'Reply with ONLY a JSON object: {"score": <0.0-1.0>, "passed": <true|false>, "reasoning": "<one or two sentences>"}.',
+	"Grade the output against the expectation only. Do not reward verbosity, and do not penalise formatting differences that leave the substance intact.",
+].join("\n");
+
+/** Parse the judge's reply. Returns null on anything that is not a usable verdict. */
+function parseJudgeVerdict(
+	raw: string,
+): { score: number; passed: boolean; reasoning: string } | null {
+	// Models fence JSON often enough that stripping the fence is worth one line;
+	// anything past that is the model failing the contract, and we skip the
+	// metric rather than inventing a grade for it.
+	const start = raw.indexOf("{");
+	const end = raw.lastIndexOf("}");
+	if (start < 0 || end <= start) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw.slice(start, end + 1));
+	} catch {
+		return null;
+	}
+	if (parsed == null || typeof parsed !== "object") return null;
+	const obj = parsed as Record<string, unknown>;
+	const score = typeof obj.score === "number" ? obj.score : Number.NaN;
+	if (!Number.isFinite(score) || score < 0 || score > 1) return null;
+	return {
+		score,
+		// Trust an explicit boolean; otherwise derive from the score rather than
+		// defaulting to pass — an unstated verdict is not a passing one.
+		passed: typeof obj.passed === "boolean" ? obj.passed : score >= 0.5,
+		reasoning:
+			typeof obj.reasoning === "string" ? obj.reasoning.slice(0, 2_000) : "",
+	};
+}
+
+/**
+ * Ask a judge model whether the captured output meets the case's expectation.
+ *
+ * Returns null — no verdict, no event — whenever the judge cannot be asked
+ * honestly: no expectation, no resolvable provider, a transport failure, or a
+ * reply that is not a verdict. That is the whole point of returning null rather
+ * than a 0: an unasked question must never be recorded as a failed one, because
+ * the pass fraction would then punish a Behavior for the platform's outage.
+ *
+ * `judgeModelRef` should name a model DIFFERENT from the one under eval
+ * (self-preference bias); the caller owns that choice.
+ */
+async function judgeAgainstExpectation(params: {
+	organizationId: string;
+	expectation: string;
+	output: unknown;
+	judgeModelRef?: string;
+}): Promise<EvalMetricVerdict | null> {
+	const expectation = params.expectation.trim();
+	if (!expectation) return null;
+
+	const target = await resolveCompletionTarget(
+		params.organizationId,
+		params.judgeModelRef,
+	);
+	if (!target) {
+		logger.warn(
+			{ organizationId: params.organizationId },
+			"[evals] No judge provider resolved — skipping the judge metric rather than scoring it 0",
+		);
+		return null;
+	}
+
+	const rendered =
+		typeof params.output === "string"
+			? params.output
+			: JSON.stringify(params.output ?? null, null, 2);
+
+	let raw: string;
+	try {
+		raw = await gatewayCompletion({
+			target,
+			systemPrompt: JUDGE_SYSTEM_PROMPT,
+			userPrompt: [
+				"EXPECTATION:",
+				expectation,
+				"",
+				"OUTPUT THE AUTOMATION PRODUCED:",
+				rendered.slice(0, JUDGE_OUTPUT_CHAR_CAP),
+			].join("\n"),
+			timeoutMs: JUDGE_TIMEOUT_MS,
+		});
+	} catch (error) {
+		logger.warn(
+			{
+				organizationId: params.organizationId,
+				model: target.model,
+				err: getErrorMessage(error),
+			},
+			"[evals] Judge call failed — skipping the judge metric",
+		);
+		return null;
+	}
+
+	const verdict = parseJudgeVerdict(raw);
+	if (!verdict) {
+		logger.warn(
+			{ organizationId: params.organizationId, model: target.model },
+			"[evals] Judge reply was not a usable verdict — skipping the judge metric",
+		);
+		return null;
+	}
+
+	return {
+		metric: "judge_rubric",
+		score: verdict.score,
+		passed: verdict.passed,
+		reasoning: verdict.reasoning,
+		judgeModel: target.model,
+	};
+}
+
+/**
+ * Recover the eval case behind a run, if it has one.
+ *
+ * The identifier comes from `evalCaseIdentifierFromRunKey` — the one place that
+ * knows how a run key maps back to a case, trial suffix included. A run minted
+ * by a bare replay with no promoted case resolves to null and is scored on its
+ * code metrics alone.
+ *
+ * `judge_model` is read here for the same reason a guardrail entry carries
+ * `model`: the platform already lets a feature name its own model as a
+ * `<slug>/<model>` ref resolved through `resolveCompletionTarget`, and an eval
+ * case is the right owner for that choice — it is the thing that knows what
+ * "good" means. No new config surface, no env var.
+ */
+async function findCaseForRun(
+	sql: DbClient,
+	organizationId: string,
+	idempotencyKey: string | null,
+): Promise<{
+	entityId: number;
+	expectation: string | null;
+	judgeModel: string | null;
+} | null> {
+	const identifier = evalCaseIdentifierFromRunKey(idempotencyKey);
+	if (!identifier) return null;
+
+	const rows = (await sql`
+    SELECT e.id,
+           e.metadata->>'expectation' AS expectation,
+           e.metadata->>'judge_model' AS judge_model
+    FROM entity_identities ei
+    JOIN entities e ON e.id = ei.entity_id
+    WHERE ei.organization_id = ${organizationId}
+      AND ei.namespace = ${EVAL_CASE_NAMESPACE}
+      AND ei.identifier = ${identifier}
+      AND ei.deleted_at IS NULL
+      AND e.deleted_at IS NULL
+    LIMIT 1
+  `) as unknown as Array<{
+		id: number | string;
+		expectation: string | null;
+		judge_model: string | null;
+	}>;
+
+	if (rows.length === 0) return null;
+	return {
+		entityId: Number(rows[0].id),
+		expectation: rows[0].expectation,
+		judgeModel: rows[0].judge_model,
+	};
+}
+
+/**
+ * Score one terminal eval run: write its metric events and stamp the Behavior.
+ *
+ * Idempotent. Re-scoring the same run supersedes each metric's chain head
+ * rather than appending a second live row, so the metrics layer always sees
+ * exactly one current verdict per (run, metric).
+ */
+export async function scoreEvalRun(
+	params: { runId: number; judgeModelRef?: string },
+	db?: DbClient,
+): Promise<ScoreEvalRunResult> {
+	const sql = db ?? getDb();
+
+	const rows = (await sql`
+    SELECT id, organization_id, watcher_id AS behavior_id, status, run_type,
+           dry_run_preview, idempotency_key
+    FROM runs
+    WHERE id = ${params.runId}
+    LIMIT 1
+  `) as unknown as Array<{
+		id: number | string;
+		organization_id: string | null;
+		behavior_id: number | null;
+		status: string;
+		run_type: string;
+		dry_run_preview: unknown;
+		idempotency_key: string | null;
+	}>;
+	if (rows.length === 0) return { ok: false, reason: "not_found" };
+
+	// Read the discriminator off the row rather than trusting the caller:
+	// scoring a live Behavior run would stamp production quality from a run
+	// nobody ever evaluated.
+	if (rows[0].run_type !== BEHAVIOR_EVAL_RUN_TYPE) {
+		return { ok: false, reason: "not_an_eval_run" };
+	}
+
+	const row = rows[0] as unknown as EvalRunRow;
+	if (!row.organization_id || row.behavior_id == null) {
+		return { ok: false, reason: "not_found" };
+	}
+	if (!TERMINAL_RUN_STATUSES.includes(row.status)) {
+		return { ok: false, reason: "not_terminal" };
+	}
+
+	const record: CaptureRecord =
+		row.dry_run_preview && typeof row.dry_run_preview === "object"
+			? (row.dry_run_preview as CaptureRecord)
+			: {};
+
+	const organizationId = row.organization_id;
+	const behaviorId = Number(row.behavior_id);
+
+	const evalCase = await findCaseForRun(
+		sql,
+		organizationId,
+		row.idempotency_key,
+	);
+
+	// Resolved BEFORE the judge: events.created_by is NOT NULL behind ON DELETE
+	// RESTRICT, so an org with no live member cannot receive score events at all.
+	// Discovering that after a paid 30s judge call would bill the org for a
+	// verdict we then throw away.
+	const createdBy = await resolveEntityCreator(sql, organizationId, null);
+	if (!createdBy) {
+		logger.warn(
+			{ runId: params.runId, organizationId },
+			"[evals] no live member to attribute eval scores to — not scoring",
+		);
+		return { ok: false, reason: "no_attributable_member" };
+	}
+
+	const verdicts: EvalMetricVerdict[] = [
+		scoreCompletedWindow(record),
+		scoreOutputPresent(record),
+	];
+
+	// Outside the transaction below on purpose: a judge call takes up to 30s and
+	// must never hold an open transaction on the hot events table.
+	if (evalCase?.expectation) {
+		const judged = await judgeAgainstExpectation({
+			organizationId,
+			expectation: evalCase.expectation,
+			output: record.extracted_data,
+			// The case's own `judge_model` wins — it is the thing that knows what
+			// "good" means here, and naming a model DIFFERENT from the one under
+			// eval is how a caller avoids self-preference bias. Falls through to
+			// the caller's default, then to the org default.
+			judgeModelRef: evalCase.judgeModel || params.judgeModelRef,
+		});
+		if (judged) verdicts.push(judged);
+	}
+
+	const qualityScore =
+		verdicts.reduce((sum, v) => sum + (v.passed ? 1 : 0), 0) / verdicts.length;
+
+	// One transaction for every verdict AND the stamp. The scorer queue treats
+	// "the `completed_window` chain root exists" as proof the run is fully
+	// scored, so that root must not become visible before its siblings: a crash
+	// between two non-transactional inserts would drop the run out of the queue
+	// permanently, with its remaining metrics and its quality stamp missing and
+	// nothing left to retry them.
+	await sql.begin(async (tx) => {
+		for (const verdict of verdicts) {
+			await writeScoreEvent({
+				sql: tx,
+				organizationId,
+				runId: Number(row.id),
+				behaviorId,
+				caseEntityId: evalCase?.entityId ?? null,
+				createdBy,
+				verdict,
+			});
+		}
+
+		// Materialize at WRITE time so a reader gets it from the `watchers` row it
+		// already selects and never aggregates the events above.
+		await tx`
+      UPDATE watchers
+      SET latest_eval_score = ${qualityScore},
+          latest_eval_at = current_timestamp,
+          latest_eval_run_id = ${Number(row.id)}
+      WHERE id = ${behaviorId}
+        AND organization_id = ${organizationId}
+    `;
+
+		if (evalCase) {
+			await pushCaseScore(tx, evalCase.entityId, {
+				run_id: Number(row.id),
+				score: qualityScore,
+				at: new Date().toISOString(),
+			});
+		}
+	});
+
+	logger.info(
+		{
+			runId: Number(row.id),
+			behaviorId,
+			caseEntityId: evalCase?.entityId ?? null,
+			metrics: verdicts.map((v) => `${v.metric}=${v.passed ? "pass" : "fail"}`),
+			qualityScore,
+		},
+		"[evals] Scored an eval replay",
+	);
+
+	return {
+		ok: true,
+		runId: Number(row.id),
+		behaviorId,
+		verdicts,
+		qualityScore,
+		caseEntityId: evalCase?.entityId ?? null,
+	};
+}
+
+/**
+ * How many run scores a case remembers. The window is what makes "did my edit
+ * break this?" answerable without touching `events`.
+ *
+ * Bounded on purpose. `entities` is a config-sized table the invariants
+ * explicitly allow reading at request time — but only while a row stays a row.
+ * An unbounded array would turn every case into growing history and reintroduce
+ * exactly the read-time cost the rule exists to prevent.
+ */
+export const CASE_SCORE_WINDOW = 10;
+
+export interface CaseScoreEntry {
+	run_id: number;
+	score: number;
+	at: string;
+}
+
+/**
+ * Push a run's score onto its case's rolling window, newest first.
+ *
+ * Read-modify-write inside the scorer's transaction. `entities` has no
+ * jsonb-array-append primitive that preserves order and cap, and the row is
+ * locked by the enclosing transaction, so two replicas scoring two runs of the
+ * same case serialize rather than losing one another's entry.
+ *
+ * De-duplicates on `run_id` so a RESCORE replaces its own entry instead of
+ * appending a second one — otherwise scoring a run twice would look like two
+ * trials and quietly halve the apparent variance.
+ */
+async function pushCaseScore(
+	tx: DbClient,
+	caseEntityId: number,
+	entry: CaseScoreEntry,
+): Promise<void> {
+	const rows = (await tx`
+    SELECT metadata FROM entities WHERE id = ${caseEntityId} FOR UPDATE
+  `) as unknown as Array<{ metadata: Record<string, unknown> | null }>;
+	if (rows.length === 0) return;
+
+	const metadata = rows[0].metadata ?? {};
+	const existing = Array.isArray(metadata.recent_scores)
+		? (metadata.recent_scores as CaseScoreEntry[])
+		: [];
+	const next = [
+		entry,
+		...existing.filter((e) => Number(e?.run_id) !== entry.run_id),
+	].slice(0, CASE_SCORE_WINDOW);
+
+	await tx`
+    UPDATE entities
+    SET metadata = ${tx.json({ ...metadata, recent_scores: next } as never)},
+        updated_at = current_timestamp
+    WHERE id = ${caseEntityId}
+  `;
+}
+
+/**
+ * Write (or supersede) one metric's score event.
+ *
+ * NULL `content` and no `feedId`: that is the structural exclusion from
+ * embedding, search and feed reads. `payloadData` carries the verdict so the
+ * metrics compiler and entity views can read it without a payload_text.
+ */
+async function writeScoreEvent(params: {
+	sql: DbClient;
+	organizationId: string;
+	runId: number;
+	behaviorId: number;
+	caseEntityId: number | null;
+	createdBy: string;
+	verdict: EvalMetricVerdict;
+}): Promise<void> {
+	const { sql, verdict } = params;
+	const identityKey = `${params.runId}:${verdict.metric}`;
+
+	// Supersede our own head so a rescore versions rather than forks. The unique
+	// index is over chain ROOTS, so the successor (non-NULL supersedes_event_id)
+	// is outside it and this is the only way a second verdict can land.
+	const head = (await sql`
+    SELECT id FROM events
+    WHERE organization_id = ${params.organizationId}
+      AND identity_ns = ${EVAL_SCORE_IDENTITY_NS}
+      AND identity_key = ${identityKey}
+      AND superseded_by IS NULL
+    LIMIT 1
+  `) as unknown as Array<{ id: number | string }>;
+
+	await insertEvent(
+		{
+			entityIds: params.caseEntityId != null ? [params.caseEntityId] : [],
+			organizationId: params.organizationId,
+			originId: `eval_score:${identityKey}`,
+			semanticType: EVAL_SCORE_SEMANTIC_TYPE,
+			title: `Eval score · run ${params.runId} · ${verdict.metric}`,
+			payloadType: "empty",
+			content: null,
+			payloadData: {
+				run_id: params.runId,
+				behavior_id: params.behaviorId,
+				metric: verdict.metric,
+				score: verdict.score,
+				passed: verdict.passed,
+				reasoning: verdict.reasoning,
+				...(verdict.judgeModel ? { judge_model: verdict.judgeModel } : {}),
+			},
+			// The link to the eval case is `entity_ids`, set above — not a metadata
+			// alias. (The metrics compiler's `by: "alias"` resolver joins
+			// `entities.metadata->'aliases'`, which `$eval_case` does not carry.)
+			metadata: {
+				run_id: params.runId,
+				behavior_id: params.behaviorId,
+				metric: verdict.metric,
+			},
+			runId: params.runId,
+			identity: { ns: EVAL_SCORE_IDENTITY_NS, key: identityKey },
+			supersedesEventId: head.length > 0 ? Number(head[0].id) : null,
+			createdBy: params.createdBy,
+		},
+		{ sql },
+	);
+}

--- a/packages/server/src/runs/eval-scores.ts
+++ b/packages/server/src/runs/eval-scores.ts
@@ -212,7 +212,7 @@ const JUDGE_SYSTEM_PROMPT = [
 ].join("\n");
 
 /** Parse the judge's reply. Returns null on anything that is not a usable verdict. */
-function parseJudgeVerdict(
+export function parseJudgeVerdict(
 	raw: string,
 ): { score: number; passed: boolean; reasoning: string } | null {
 	// Models fence JSON often enough that stripping the fence is worth one line;
@@ -593,10 +593,16 @@ async function pushCaseScore(
 	const existing = Array.isArray(metadata.recent_scores)
 		? (metadata.recent_scores as CaseScoreEntry[])
 		: [];
+	// Newest run first, always: `readEvalResults` groups positionally, so a run
+	// scored late (a retry after newer runs) must not land at position 0 and
+	// corrupt the latest-vs-previous split. Same out-of-order hazard the
+	// watchers stamp guards, deduplicated here against the window cap.
 	const next = [
 		entry,
 		...existing.filter((e) => Number(e?.run_id) !== entry.run_id),
-	].slice(0, CASE_SCORE_WINDOW);
+	]
+		.sort((a, b) => Number(b.run_id) - Number(a.run_id))
+		.slice(0, CASE_SCORE_WINDOW);
 
 	await tx`
     UPDATE entities

--- a/packages/server/src/runs/eval-scores.ts
+++ b/packages/server/src/runs/eval-scores.ts
@@ -491,7 +491,10 @@ export async function scoreEvalRun(
 		}
 
 		// Materialize at WRITE time so a reader gets it from the `watchers` row it
-		// already selects and never aggregates the events above.
+		// already selects and never aggregates the events above. The guard keeps an
+		// OLD run scored late (another replica, a later queue tick) from overwriting
+		// a newer run's stamp: the queue only orders within a batch, so nothing else
+		// stops out-of-order scoring from regressing the Behavior's latest picture.
 		await tx`
       UPDATE watchers
       SET latest_eval_score = ${qualityScore},
@@ -499,6 +502,7 @@ export async function scoreEvalRun(
           latest_eval_run_id = ${Number(row.id)}
       WHERE id = ${behaviorId}
         AND organization_id = ${organizationId}
+        AND (latest_eval_run_id IS NULL OR latest_eval_run_id <= ${Number(row.id)})
     `;
 
 		if (evalCase) {
@@ -506,6 +510,7 @@ export async function scoreEvalRun(
 				run_id: Number(row.id),
 				score: qualityScore,
 				at: new Date().toISOString(),
+				metrics: verdicts.map((v) => v.metric),
 			});
 		}
 	});
@@ -546,12 +551,20 @@ export async function scoreEvalRun(
  * therefore every regression verdict — permanently null at the top of the
  * allowed trial range.
  */
-export const CASE_SCORE_WINDOW = 20;
+const CASE_SCORE_WINDOW = 20;
 
 export interface CaseScoreEntry {
 	run_id: number;
 	score: number;
 	at: string;
+	/**
+	 * Metrics that made up `score`. `readEvalResults` compares only entries whose
+	 * groups carry the SAME metric set — losing the judge (provider outage)
+	 * changes the denominator, and a [pass,fail,judge-pass]=0.667 dropping to
+	 * [pass,fail]=0.5 must not read as a regression. Absent on pre-metrics rows;
+	 * an unknown set never compares equal to a measured one.
+	 */
+	metrics?: string[];
 }
 
 /**

--- a/packages/server/src/runs/eval-scores.ts
+++ b/packages/server/src/runs/eval-scores.ts
@@ -100,8 +100,17 @@ export type ScoreEvalRunResult =
 				| "no_attributable_member";
 	  };
 
-/** Terminal statuses a run must reach before it means anything to score. */
-const TERMINAL_RUN_STATUSES = ["completed", "failed", "cancelled"];
+/**
+ * Terminal statuses a run must reach before it means anything to score.
+ *
+ * The full terminal set `runs_status_check` allows, matching
+ * `check-stalled-executions.ts`. `timeout` in particular is NOT optional:
+ * `markStaleRunsAsTimeout` runs over `BEHAVIOR_RUN_TYPES`, so a crashed or
+ * abandoned eval reaches `timeout` and never any other terminal status.
+ * Omitting it would silently drop exactly the runs worth measuring — an eval
+ * that hung is a `completed_window` FAILURE, not an unscoreable run.
+ */
+const TERMINAL_RUN_STATUSES = ["completed", "failed", "timeout", "cancelled"];
 
 /**
  * The same list as a Postgres `text[]` literal, for the scorer queue's `= ANY`.
@@ -530,8 +539,14 @@ export async function scoreEvalRun(
  * explicitly allow reading at request time — but only while a row stays a row.
  * An unbounded array would turn every case into growing history and reintroduce
  * exactly the read-time cost the rule exists to prevent.
+ *
+ * Must stay at least 2 × `MAX_TRIALS` (eval-suite.ts): `readEvalResults` reads
+ * the latest `trials` entries as the current group and the next `trials` as the
+ * baseline, so a window shorter than both groups makes `previous` — and
+ * therefore every regression verdict — permanently null at the top of the
+ * allowed trial range.
  */
-export const CASE_SCORE_WINDOW = 10;
+export const CASE_SCORE_WINDOW = 20;
 
 export interface CaseScoreEntry {
 	run_id: number;

--- a/packages/server/src/runs/eval-suite.ts
+++ b/packages/server/src/runs/eval-suite.ts
@@ -187,6 +187,21 @@ export async function runEvalSuite(
 		}
 		if (runIds.length > 0) {
 			result.cases.push({ caseId: evalCase.caseId, runIds });
+			// Remember the batch size this suite queued, so the reader groups the
+			// case's rolling window EXACTLY instead of guessing from its own
+			// `trials` param. Positional grouping is only exact when the batch
+			// size is known: reading a trials=5 batch with the default 3 mixes one
+			// suite across both groups and reads a false regression out of it.
+			await sql`
+        UPDATE entities
+        SET metadata = jsonb_set(
+              coalesce(metadata, '{}'::jsonb),
+              '{suite_trials}',
+              ${sql.json(trials as never)}::jsonb
+            ),
+            updated_at = current_timestamp
+        WHERE id = ${evalCase.caseId}
+      `;
 		}
 	}
 
@@ -241,29 +256,6 @@ export interface EvalResults {
 
 function mean(values: number[]): number {
 	return values.reduce((sum, v) => sum + v, 0) / values.length;
-}
-
-/**
- * Split a case's rolling window into the latest trial group and the one before.
- *
- * `recent_scores` is newest-first and carries no batch id, so the grouping rule
- * is positional: with `trials` per suite run, the first `trials` entries are the
- * latest group and the next `trials` are the baseline. That is exact when the
- * caller passes the same `trials` it ran with, and degrades to "latest vs
- * previous single run" at trials=1 — never to a wrong answer, because the
- * spread reported alongside always describes the group actually used.
- */
-function splitTrialGroups(
-	scores: CaseScoreEntry[],
-	trials: number,
-): { latest: number[]; previous: number[] } {
-	const values = scores
-		.map((s) => Number(s.score))
-		.filter((n) => Number.isFinite(n));
-	return {
-		latest: values.slice(0, trials),
-		previous: values.slice(trials, trials * 2),
-	};
 }
 
 /**
@@ -327,9 +319,29 @@ export async function readEvalResults(
 		const scores = Array.isArray(metadata.recent_scores)
 			? (metadata.recent_scores as CaseScoreEntry[])
 			: [];
-		const groups = splitTrialGroups(scores, trials);
-		const latest = groups.latest.length > 0 ? mean(groups.latest) : null;
-		const previous = groups.previous.length > 0 ? mean(groups.previous) : null;
+		// The suite that queued this case's newest batch knows its own size; the
+		// reader's `trials` is only a fallback for cases never run by a suite
+		// (i.e. pre-stamp rows). Grouping with a size that differs from the batch
+		// would mix one suite across both groups — a false regression.
+		const stampedTrials =
+			typeof metadata.suite_trials === "number"
+				? Math.min(MAX_TRIALS, Math.max(1, Math.trunc(metadata.suite_trials)))
+				: null;
+		const groupSize = stampedTrials ?? trials;
+		// One usable array, and both the values and the signatures come from the
+		// SAME slices — a score filtered out for being non-finite must not leave
+		// the signature describing an entry the values don't count.
+		const usable = scores.filter((s) => Number.isFinite(Number(s.score)));
+		const latestEntries = usable.slice(0, groupSize);
+		const previousEntries = usable.slice(groupSize, groupSize * 2);
+		const latest =
+			latestEntries.length > 0
+				? mean(latestEntries.map((s) => Number(s.score)))
+				: null;
+		const previous =
+			previousEntries.length > 0
+				? mean(previousEntries.map((s) => Number(s.score)))
+				: null;
 		// Only like-for-like groups are compared: a changed metric set (say a lost
 		// judge) makes the two denominators different, and a move between them is
 		// not a signal about the Behavior. An UNKNOWN set never compares equal —
@@ -337,8 +349,8 @@ export async function readEvalResults(
 		// known signature for the comparison to run at all. delta stays null
 		// otherwise, which keeps the case out of regressions/improvements and the
 		// summary.
-		const latestSignature = groupSignature(scores.slice(0, trials));
-		const previousSignature = groupSignature(scores.slice(trials, trials * 2));
+		const latestSignature = groupSignature(latestEntries);
+		const previousSignature = groupSignature(previousEntries);
 		const comparable =
 			latest != null &&
 			previous != null &&
@@ -346,8 +358,9 @@ export async function readEvalResults(
 			latestSignature === previousSignature;
 		const delta = comparable ? latest - previous : null;
 		const spread =
-			groups.latest.length > 1
-				? Math.max(...groups.latest) - Math.min(...groups.latest)
+			latestEntries.length > 1
+				? Math.max(...latestEntries.map((s) => Number(s.score))) -
+					Math.min(...latestEntries.map((s) => Number(s.score)))
 				: 0;
 
 		const caseId = Number(row.id);
@@ -368,7 +381,7 @@ export async function readEvalResults(
 			previous,
 			delta,
 			spread,
-			latestTrials: groups.latest.length,
+			latestTrials: latestEntries.length,
 			scores,
 		});
 	}

--- a/packages/server/src/runs/eval-suite.ts
+++ b/packages/server/src/runs/eval-suite.ts
@@ -42,7 +42,7 @@ const DEFAULT_TRIALS = 3;
  */
 const MAX_TRIALS = 10;
 
-export interface EvalSuiteCase {
+interface EvalSuiteCase {
 	caseId: number;
 	name: string;
 	caseKey: string;
@@ -332,13 +332,18 @@ export async function readEvalResults(
 		const previous = groups.previous.length > 0 ? mean(groups.previous) : null;
 		// Only like-for-like groups are compared: a changed metric set (say a lost
 		// judge) makes the two denominators different, and a move between them is
-		// not a signal about the Behavior. delta stays null then, which also keeps
-		// the case out of regressions/improvements and the summary.
+		// not a signal about the Behavior. An UNKNOWN set never compares equal —
+		// to a measured set OR to another unknown — so both must resolve to a
+		// known signature for the comparison to run at all. delta stays null
+		// otherwise, which keeps the case out of regressions/improvements and the
+		// summary.
+		const latestSignature = groupSignature(scores.slice(0, trials));
+		const previousSignature = groupSignature(scores.slice(trials, trials * 2));
 		const comparable =
 			latest != null &&
 			previous != null &&
-			groupSignature(scores.slice(0, trials)) ===
-				groupSignature(scores.slice(trials, trials * 2));
+			latestSignature != null &&
+			latestSignature === previousSignature;
 		const delta = comparable ? latest - previous : null;
 		const spread =
 			groups.latest.length > 1

--- a/packages/server/src/runs/eval-suite.ts
+++ b/packages/server/src/runs/eval-suite.ts
@@ -31,7 +31,7 @@ import type { CaseScoreEntry } from "./eval-scores.js";
  * provider spend, so the default is the smallest number that can show a spread
  * at all; a caller who wants tighter bounds asks for more.
  */
-export const DEFAULT_TRIALS = 3;
+const DEFAULT_TRIALS = 3;
 
 /**
  * Ceiling per request, so one call cannot queue an unbounded replay burst.
@@ -40,7 +40,7 @@ export const DEFAULT_TRIALS = 3;
  * compare the latest `trials` scores against the previous `trials`, so raising
  * this past half the window would leave the baseline group unreadable.
  */
-export const MAX_TRIALS = 10;
+const MAX_TRIALS = 10;
 
 export interface EvalSuiteCase {
 	caseId: number;
@@ -66,7 +66,7 @@ export interface RunEvalSuiteResult {
  * is one a human decided no longer describes desired behaviour, and silently
  * continuing to run it would make the suite report failures nobody wants fixed.
  */
-export async function listActiveCases(
+async function listActiveCases(
 	organizationId: string,
 	behaviorId: number,
 	caseIds?: number[],
@@ -267,6 +267,27 @@ function splitTrialGroups(
 }
 
 /**
+ * The metric set a group was scored against, canonicalized.
+ *
+ * A quality score is a pass fraction over the verdicts that HAPPENED to run, so
+ * two scores are only comparable when their denominators match. If the judge is
+ * lost between suites, a [pass,fail,judge-pass]=0.667 becomes [pass,fail]=0.5
+ * and reads as a regression that never happened. Returns null when the group is
+ * empty or any entry predates the `metrics` field — an unknown set never
+ * compares equal to a measured one, and never to another unknown.
+ */
+function groupSignature(scores: CaseScoreEntry[]): string | null {
+	const names = new Set<string>();
+	for (const entry of scores) {
+		if (!Array.isArray(entry.metrics) || entry.metrics.length === 0) {
+			return null;
+		}
+		for (const metric of entry.metrics) names.add(metric);
+	}
+	return names.size > 0 ? [...names].sort().join(",") : null;
+}
+
+/**
  * Read a Behavior's suite results: per case, latest vs previous, plus a summary.
  *
  * Pure entity reads — no `events`, no aggregation over run history.
@@ -309,7 +330,16 @@ export async function readEvalResults(
 		const groups = splitTrialGroups(scores, trials);
 		const latest = groups.latest.length > 0 ? mean(groups.latest) : null;
 		const previous = groups.previous.length > 0 ? mean(groups.previous) : null;
-		const delta = latest != null && previous != null ? latest - previous : null;
+		// Only like-for-like groups are compared: a changed metric set (say a lost
+		// judge) makes the two denominators different, and a move between them is
+		// not a signal about the Behavior. delta stays null then, which also keeps
+		// the case out of regressions/improvements and the summary.
+		const comparable =
+			latest != null &&
+			previous != null &&
+			groupSignature(scores.slice(0, trials)) ===
+				groupSignature(scores.slice(trials, trials * 2));
+		const delta = comparable ? latest - previous : null;
 		const spread =
 			groups.latest.length > 1
 				? Math.max(...groups.latest) - Math.min(...groups.latest)
@@ -338,22 +368,26 @@ export async function readEvalResults(
 		});
 	}
 
-	const scoredLatest = cases
-		.map((c) => c.latest)
-		.filter((v): v is number => v != null);
-	const scoredPrevious = cases
-		.map((c) => c.previous)
-		.filter((v): v is number => v != null);
-	const summaryLatest = scoredLatest.length > 0 ? mean(scoredLatest) : null;
+	// The summary aggregates only cases whose latest-vs-previous is like-for-like
+	// (delta != null). A case with a single suite run so far — or one whose groups
+	// disagree on metrics — is real data but no comparison, and must not be mixed
+	// into a mean it would skew.
+	const compared = cases.filter((c) => c.delta != null);
+	const summaryLatest =
+		compared.length > 0
+			? mean(compared.map((c) => c.latest as number))
+			: null;
 	const summaryPrevious =
-		scoredPrevious.length > 0 ? mean(scoredPrevious) : null;
+		compared.length > 0
+			? mean(compared.map((c) => c.previous as number))
+			: null;
 
 	return {
 		behaviorId: params.behaviorId,
 		cases,
 		summary: {
 			cases: cases.length,
-			scored: scoredLatest.length,
+			scored: compared.length,
 			latest: summaryLatest,
 			previous: summaryPrevious,
 			delta:

--- a/packages/server/src/runs/eval-suite.ts
+++ b/packages/server/src/runs/eval-suite.ts
@@ -33,7 +33,13 @@ import type { CaseScoreEntry } from "./eval-scores.js";
  */
 export const DEFAULT_TRIALS = 3;
 
-/** Ceiling per request, so one call cannot queue an unbounded replay burst. */
+/**
+ * Ceiling per request, so one call cannot queue an unbounded replay burst.
+ *
+ * Bounded by `CASE_SCORE_WINDOW` (eval-scores.ts) as much as by spend: results
+ * compare the latest `trials` scores against the previous `trials`, so raising
+ * this past half the window would leave the baseline group unreadable.
+ */
 export const MAX_TRIALS = 10;
 
 export interface EvalSuiteCase {
@@ -67,6 +73,10 @@ export async function listActiveCases(
 	db?: DbClient,
 ): Promise<EvalSuiteCase[]> {
 	const sql = db ?? getDb();
+	const filterIds = caseIds?.filter((n) => Number.isSafeInteger(n) && n > 0);
+	// Asked for a subset and named nothing usable → nothing. Falling through to
+	// the unfiltered query would silently replay every case instead.
+	if (caseIds?.length && !filterIds?.length) return [];
 	const rows = (await sql`
     SELECT e.id, e.name, e.metadata
     FROM entities e
@@ -79,11 +89,12 @@ export async function listActiveCases(
       ${
 				// The client runs with `fetch_types: false`, so a raw JS array binds as
 				// "malformed array literal". Format the `{n,n}` literal and cast it,
-				// exactly like insert-event.ts does for entity_ids. Safe to
-				// interpolate: every id was validated as a positive safe integer by
-				// the caller and re-coerced here.
-				caseIds?.length
-					? sql`AND e.id = ANY(${`{${caseIds.map((n) => Math.trunc(Number(n))).join(",")}}`}::bigint[])`
+				// exactly like insert-event.ts does for entity_ids. It is still a bound
+				// parameter rather than interpolated SQL — but it binds as TEXT, so a
+				// non-integer would arrive as `NaN` and fail the cast at runtime.
+				// Hence the filter above, rather than a promise about callers.
+				filterIds?.length
+					? sql`AND e.id = ANY(${`{${filterIds.join(",")}}`}::bigint[])`
 					: sql``
 			}
     ORDER BY e.id

--- a/packages/server/src/runs/eval-suite.ts
+++ b/packages/server/src/runs/eval-suite.ts
@@ -1,0 +1,356 @@
+/**
+ * Running a Behavior's eval suite and reading the answer (evals PR 4, lobu#2564).
+ *
+ * Scoring one replay produces a number. This module is what makes that number
+ * mean something: it replays every active case of a Behavior N times, and reads
+ * back per-case latest-vs-previous so the question people actually have — "I
+ * edited this Behavior, did I break it?" — has an answer.
+ *
+ * **Trials are not optional decoration.** Our own research evals swung ±1 task
+ * on identical 22-task batteries. A single run per case reports noise as a
+ * regression, so `readEvalResults` compares the MEAN of the latest trial group
+ * against the mean of the previous one and reports the spread it saw. A delta
+ * smaller than the observed spread is not a signal, and the payload says so
+ * rather than leaving the reader to infer it.
+ *
+ * **Nothing here aggregates history.** Results come from the case ENTITIES'
+ * rolling `recent_scores` window (bounded at CASE_SCORE_WINDOW, written by the
+ * scorer). `entities` is a config-sized table the invariants permit reading at
+ * request time; `events` is not, and is never touched on this path.
+ */
+
+import { type DbClient, getDb } from "../db/client.js";
+import { EVAL_CASE_ENTITY_TYPE_SLUG } from "../tools/constants.js";
+import logger from "../utils/logger.js";
+import { trialCaseKey } from "./eval-cases.js";
+import { createEvalRun } from "./eval-runs.js";
+import type { CaseScoreEntry } from "./eval-scores.js";
+
+/**
+ * Trials per case in one suite run. More is better statistics and linearly more
+ * provider spend, so the default is the smallest number that can show a spread
+ * at all; a caller who wants tighter bounds asks for more.
+ */
+export const DEFAULT_TRIALS = 3;
+
+/** Ceiling per request, so one call cannot queue an unbounded replay burst. */
+export const MAX_TRIALS = 10;
+
+export interface EvalSuiteCase {
+	caseId: number;
+	name: string;
+	caseKey: string;
+	sourceRunId: number;
+}
+
+export interface RunEvalSuiteResult {
+	behaviorId: number;
+	trials: number;
+	/** Runs actually queued. Fewer than cases×trials when a replay is in flight. */
+	queued: number;
+	cases: Array<{ caseId: number; runIds: number[] }>;
+	/** Cases that could not be replayed at all, with the reason. */
+	skipped: Array<{ caseId: number; reason: string }>;
+}
+
+/**
+ * Load a Behavior's ACTIVE eval cases.
+ *
+ * Retired cases are excluded here rather than at the call site: a retired case
+ * is one a human decided no longer describes desired behaviour, and silently
+ * continuing to run it would make the suite report failures nobody wants fixed.
+ */
+export async function listActiveCases(
+	organizationId: string,
+	behaviorId: number,
+	caseIds?: number[],
+	db?: DbClient,
+): Promise<EvalSuiteCase[]> {
+	const sql = db ?? getDb();
+	const rows = (await sql`
+    SELECT e.id, e.name, e.metadata
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${organizationId}
+      AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+      AND e.deleted_at IS NULL
+      AND (e.metadata->>'behavior_id')::bigint = ${behaviorId}
+      AND coalesce(e.metadata->>'status', 'active') = 'active'
+      ${
+				// The client runs with `fetch_types: false`, so a raw JS array binds as
+				// "malformed array literal". Format the `{n,n}` literal and cast it,
+				// exactly like insert-event.ts does for entity_ids. Safe to
+				// interpolate: every id was validated as a positive safe integer by
+				// the caller and re-coerced here.
+				caseIds?.length
+					? sql`AND e.id = ANY(${`{${caseIds.map((n) => Math.trunc(Number(n))).join(",")}}`}::bigint[])`
+					: sql``
+			}
+    ORDER BY e.id
+  `) as unknown as Array<{
+		id: number | string;
+		name: string;
+		metadata: Record<string, unknown> | null;
+	}>;
+
+	const cases: EvalSuiteCase[] = [];
+	for (const row of rows) {
+		const metadata = row.metadata ?? {};
+		const sourceRunId = Number(metadata.source_run_id);
+		if (!Number.isSafeInteger(sourceRunId) || sourceRunId < 1) continue;
+		cases.push({
+			caseId: Number(row.id),
+			name: row.name,
+			caseKey:
+				typeof metadata.case_key === "string" ? metadata.case_key : "default",
+			sourceRunId,
+		});
+	}
+	return cases;
+}
+
+/**
+ * Replay every active case `trials` times.
+ *
+ * Each trial gets its own key via `trialCaseKey`, because `createEvalRun`
+ * dedups on (sourceRunId, caseKey) — without distinct keys five trials would
+ * collapse into one run and report a single measurement as five.
+ *
+ * A case whose source run is no longer replayable is SKIPPED with a reason
+ * rather than failing the whole suite: one un-replayable case must not stop the
+ * other twenty from being measured, and a silent omission would make the suite
+ * look healthier than it is.
+ */
+export async function runEvalSuite(
+	params: {
+		organizationId: string;
+		behaviorId: number;
+		caseIds?: number[];
+		trials?: number;
+	},
+	db?: DbClient,
+): Promise<RunEvalSuiteResult> {
+	const sql = db ?? getDb();
+	const trials = Math.min(
+		MAX_TRIALS,
+		Math.max(1, Math.trunc(params.trials ?? DEFAULT_TRIALS)),
+	);
+
+	const cases = await listActiveCases(
+		params.organizationId,
+		params.behaviorId,
+		params.caseIds,
+		sql,
+	);
+
+	const result: RunEvalSuiteResult = {
+		behaviorId: params.behaviorId,
+		trials,
+		queued: 0,
+		cases: [],
+		skipped: [],
+	};
+
+	for (const evalCase of cases) {
+		const runIds: number[] = [];
+		for (let trial = 0; trial < trials; trial += 1) {
+			const minted = await createEvalRun(
+				{
+					sourceRunId: evalCase.sourceRunId,
+					caseKey: trialCaseKey(evalCase.caseKey, trial),
+				},
+				sql,
+			);
+			if (!minted) {
+				// createEvalRun already logged why (source gone, no frozen payload,
+				// not dispatchable). Record it per case so the caller sees a partial
+				// suite as partial.
+				result.skipped.push({
+					caseId: evalCase.caseId,
+					reason: "not_replayable",
+				});
+				break;
+			}
+			runIds.push(minted.runId);
+			if (minted.created) result.queued += 1;
+		}
+		if (runIds.length > 0) {
+			result.cases.push({ caseId: evalCase.caseId, runIds });
+		}
+	}
+
+	logger.info(
+		{
+			behaviorId: params.behaviorId,
+			cases: result.cases.length,
+			skipped: result.skipped.length,
+			trials,
+			queued: result.queued,
+		},
+		"[evals] Queued an eval suite",
+	);
+	return result;
+}
+
+export interface EvalCaseResult {
+	caseId: number;
+	name: string;
+	expectation: string | null;
+	/** Mean of the most recent trial group. Null when never scored. */
+	latest: number | null;
+	/** Mean of the trial group before it. Null with fewer than two groups. */
+	previous: number | null;
+	/** latest − previous. Null when either side is missing. */
+	delta: number | null;
+	/** max−min within the latest group: the noise floor for this case. */
+	spread: number;
+	latestTrials: number;
+	scores: CaseScoreEntry[];
+}
+
+export interface EvalResults {
+	behaviorId: number;
+	cases: EvalCaseResult[];
+	summary: {
+		cases: number;
+		scored: number;
+		latest: number | null;
+		previous: number | null;
+		delta: number | null;
+		/**
+		 * Cases whose drop EXCEEDS the noise they showed within the latest trial
+		 * group. A drop smaller than its own spread is not reported as a
+		 * regression — that conflation is what made a provider quota storm read as
+		 * a 61–78% prompt regression.
+		 */
+		regressions: number[];
+		improvements: number[];
+	};
+}
+
+function mean(values: number[]): number {
+	return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/**
+ * Split a case's rolling window into the latest trial group and the one before.
+ *
+ * `recent_scores` is newest-first and carries no batch id, so the grouping rule
+ * is positional: with `trials` per suite run, the first `trials` entries are the
+ * latest group and the next `trials` are the baseline. That is exact when the
+ * caller passes the same `trials` it ran with, and degrades to "latest vs
+ * previous single run" at trials=1 — never to a wrong answer, because the
+ * spread reported alongside always describes the group actually used.
+ */
+function splitTrialGroups(
+	scores: CaseScoreEntry[],
+	trials: number,
+): { latest: number[]; previous: number[] } {
+	const values = scores
+		.map((s) => Number(s.score))
+		.filter((n) => Number.isFinite(n));
+	return {
+		latest: values.slice(0, trials),
+		previous: values.slice(trials, trials * 2),
+	};
+}
+
+/**
+ * Read a Behavior's suite results: per case, latest vs previous, plus a summary.
+ *
+ * Pure entity reads — no `events`, no aggregation over run history.
+ */
+export async function readEvalResults(
+	params: { organizationId: string; behaviorId: number; trials?: number },
+	db?: DbClient,
+): Promise<EvalResults> {
+	const sql = db ?? getDb();
+	const trials = Math.min(
+		MAX_TRIALS,
+		Math.max(1, Math.trunc(params.trials ?? DEFAULT_TRIALS)),
+	);
+
+	const rows = (await sql`
+    SELECT e.id, e.name, e.metadata
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${params.organizationId}
+      AND et.slug = ${EVAL_CASE_ENTITY_TYPE_SLUG}
+      AND e.deleted_at IS NULL
+      AND (e.metadata->>'behavior_id')::bigint = ${params.behaviorId}
+      AND coalesce(e.metadata->>'status', 'active') = 'active'
+    ORDER BY e.id
+  `) as unknown as Array<{
+		id: number | string;
+		name: string;
+		metadata: Record<string, unknown> | null;
+	}>;
+
+	const cases: EvalCaseResult[] = [];
+	const regressions: number[] = [];
+	const improvements: number[] = [];
+
+	for (const row of rows) {
+		const metadata = row.metadata ?? {};
+		const scores = Array.isArray(metadata.recent_scores)
+			? (metadata.recent_scores as CaseScoreEntry[])
+			: [];
+		const groups = splitTrialGroups(scores, trials);
+		const latest = groups.latest.length > 0 ? mean(groups.latest) : null;
+		const previous = groups.previous.length > 0 ? mean(groups.previous) : null;
+		const delta = latest != null && previous != null ? latest - previous : null;
+		const spread =
+			groups.latest.length > 1
+				? Math.max(...groups.latest) - Math.min(...groups.latest)
+				: 0;
+
+		const caseId = Number(row.id);
+		// Only a move LARGER than the case's own observed noise counts.
+		if (delta != null && delta < 0 && Math.abs(delta) > spread) {
+			regressions.push(caseId);
+		}
+		if (delta != null && delta > 0 && delta > spread) {
+			improvements.push(caseId);
+		}
+
+		cases.push({
+			caseId,
+			name: row.name,
+			expectation:
+				typeof metadata.expectation === "string" ? metadata.expectation : null,
+			latest,
+			previous,
+			delta,
+			spread,
+			latestTrials: groups.latest.length,
+			scores,
+		});
+	}
+
+	const scoredLatest = cases
+		.map((c) => c.latest)
+		.filter((v): v is number => v != null);
+	const scoredPrevious = cases
+		.map((c) => c.previous)
+		.filter((v): v is number => v != null);
+	const summaryLatest = scoredLatest.length > 0 ? mean(scoredLatest) : null;
+	const summaryPrevious =
+		scoredPrevious.length > 0 ? mean(scoredPrevious) : null;
+
+	return {
+		behaviorId: params.behaviorId,
+		cases,
+		summary: {
+			cases: cases.length,
+			scored: scoredLatest.length,
+			latest: summaryLatest,
+			previous: summaryPrevious,
+			delta:
+				summaryLatest != null && summaryPrevious != null
+					? summaryLatest - summaryPrevious
+					: null,
+			regressions,
+			improvements,
+		},
+	};
+}

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -30,6 +30,7 @@ import { runMemberClaimDriftCheck } from './member-claim-drift';
 import { runReapStaleDeviceWorkers } from './reap-stale-device-workers';
 import { runReapExpiredPendingSlackInstalls } from './reap-expired-pending-installs';
 import { runExpirePendingApprovals } from './expire-pending-approvals';
+import { runScoreEvalRuns } from './score-eval-runs';
 import { getDb, pgTextArray } from '../db/client';
 import { createNotificationForUsers } from '../notifications/service';
 import {
@@ -345,6 +346,32 @@ function registerMaintenanceTasks(
       await runExpirePendingApprovals();
     },
     { cron: '31 3 * * *' },
+  );
+
+  // Eval scorer queue: score terminal `behavior_eval` replays that have no
+  // score events yet. The anti-join predicate IS the claim (rationale in
+  // scheduled/score-eval-runs.ts) — no cursor, no in-memory sampler, safe under
+  // N>1 replicas.
+  //
+  // Every 5 minutes, not daily: an eval batch is something a human kicked off
+  // and is waiting on, so a day-long lag would make the feature feel broken.
+  // The batch cap bounds each tick's judge spend, and a backlog drains across
+  // ticks.
+  //
+  // No judge model is passed, so the judge runs on the ORG DEFAULT — which may
+  // be the model that produced the output, leaving self-preference bias
+  // unmitigated. Where the judge model is configured is still open in the spec
+  // (lobu#2564); `runScoreEvalRuns` takes `judgeModelRef`, so wiring the answer
+  // is one argument.
+  scheduler.register(
+    'score-eval-runs',
+    async () => {
+      const summary = await runScoreEvalRuns();
+      if (summary.claimed > 0) {
+        logger.info(summary, '[task] score-eval-runs completed');
+      }
+    },
+    { cron: '*/5 * * * *' },
   );
 
   // Watcher automation: reconcile in-flight runs, materialize newly-due runs,

--- a/packages/server/src/scheduled/score-eval-runs.ts
+++ b/packages/server/src/scheduled/score-eval-runs.ts
@@ -1,0 +1,147 @@
+/**
+ * The eval scorer queue (evals PR 4, lobu#2564).
+ *
+ * An eval replay goes terminal on whichever pod happened to own its worker
+ * session. Scoring it there would put the judge call on the dispatch hot path
+ * and lose the verdict entirely whenever that pod dies mid-call. So scoring is
+ * a queue, and the queue is Postgres: the work item is simply "a terminal
+ * `behavior_eval` run with no live `eval_score` event yet".
+ *
+ * That predicate IS the claim. There is no in-memory sampler, no cursor, and no
+ * per-pod state another replica has to read — a run leaves the queue only when
+ * its score events exist, which is a committed fact every replica can see. A
+ * pod that dies mid-score simply leaves the run in the queue for the next tick:
+ * `scoreEvalRun` commits every verdict and the quality stamp in ONE
+ * transaction, so a partial score is never visible and the probed key never
+ * appears without its siblings. The per-(run, metric) unique index
+ * (20260807170010) is what makes a double-claim harmless rather than a double
+ * count.
+ *
+ * Note this is deliberately NOT `FOR UPDATE SKIP LOCKED`. That would serialize
+ * two replicas against each other for the whole duration of a judge call — 30s
+ * of held row lock to save a duplicate insert the unique index already rejects
+ * for free. Idempotent work does not need a lock, it needs an idempotency key.
+ */
+
+import { getErrorMessage } from "@lobu/core";
+import { getDb } from "../db/client";
+import {
+	EVAL_SCORE_IDENTITY_NS,
+	scoreEvalRun,
+	TERMINAL_RUN_STATUSES_PG,
+} from "../runs/eval-scores";
+import { BEHAVIOR_EVAL_RUN_TYPE } from "../runs/run-types";
+import logger from "../utils/logger";
+
+/**
+ * Runs scored per invocation. Each carries at most one judge call, so this
+ * bounds the tick's wall-clock and its spend. A backlog drains over successive
+ * ticks rather than in one burst that could exhaust the org's provider quota —
+ * which matters because a quota-exhausted provider returns 429s that look like
+ * agent failures, so an unbounded scorer would corrupt the very numbers it
+ * exists to produce.
+ */
+const SCORE_BATCH_SIZE = 25;
+
+/**
+ * How long after a run goes terminal before it is scoreable.
+ *
+ * `dry_run_preview` is MERGED by several capture sites during a turn and
+ * finalize runs last, so reading it the instant the status flips can catch a
+ * partially-written record and score a complete run as an incomplete one. A
+ * short settle window costs a tick and removes that whole class of false
+ * failure.
+ */
+const SCORE_SETTLE_SECONDS = 60;
+
+export interface ScoreEvalRunsSummary {
+	claimed: number;
+	scored: number;
+	skipped: number;
+	failed: number;
+}
+
+/**
+ * Score every terminal eval run that has no score yet.
+ *
+ * `judgeModelRef` (from config) should name a model DIFFERENT from the one
+ * under eval — a model grading its own output rates it generously, which is the
+ * self-preference bias the spec calls out. Left undefined, the org default is
+ * used and that protection is absent; the caller owns the choice.
+ */
+export async function runScoreEvalRuns(opts?: {
+	judgeModelRef?: string;
+}): Promise<ScoreEvalRunsSummary> {
+	const sql = getDb();
+	const summary: ScoreEvalRunsSummary = {
+		claimed: 0,
+		scored: 0,
+		skipped: 0,
+		failed: 0,
+	};
+
+	// The anti-join IS the queue, and it probes ONE key: `<runId>:completed_window`.
+	//
+	// That metric is the only unconditional one — `scoreEvalRun` always produces
+	// it, while `output_present` depends on the record and `judge_rubric` on a
+	// case, an expectation and a reachable provider. So its chain root existing
+	// is the definitive "this run has been scored" fact, and probing it is an
+	// EQUALITY hit on idx_events_identity_root_eval_score
+	// (organization_id, identity_key WHERE supersedes_event_id IS NULL …). A
+	// prefix LIKE over the key would scan instead, and matching on
+	// `superseded_by IS NULL` would miss the index predicate entirely — this
+	// query has to stay bounded as eval history grows.
+	const candidates = (await sql`
+    SELECT r.id
+    FROM runs r
+    WHERE r.run_type = ${BEHAVIOR_EVAL_RUN_TYPE}
+      AND r.status = ANY(${TERMINAL_RUN_STATUSES_PG}::text[])
+      AND coalesce(r.completed_at, r.created_at)
+            < now() - ${`${SCORE_SETTLE_SECONDS} seconds`}::interval
+      AND NOT EXISTS (
+        SELECT 1 FROM events e
+        WHERE e.organization_id = r.organization_id
+          AND e.identity_ns = ${EVAL_SCORE_IDENTITY_NS}
+          AND e.identity_key = r.id || ':completed_window'
+          AND e.supersedes_event_id IS NULL
+      )
+    ORDER BY r.id
+    LIMIT ${SCORE_BATCH_SIZE}
+  `) as unknown as Array<{ id: number | string }>;
+
+	summary.claimed = candidates.length;
+	if (candidates.length === 0) return summary;
+
+	for (const candidate of candidates) {
+		const runId = Number(candidate.id);
+		try {
+			const result = await scoreEvalRun({
+				runId,
+				judgeModelRef: opts?.judgeModelRef,
+			});
+			if (result.ok) {
+				summary.scored += 1;
+			} else {
+				// A rejection is information, not an error: `not_terminal` means the
+				// settle window raced a status change, `no_attributable_member` means
+				// the org has no one to attribute to. Both are re-tried next tick, so
+				// the run stays in the queue rather than being silently dropped.
+				summary.skipped += 1;
+				logger.info(
+					{ runId, reason: result.reason },
+					"[evals] Skipped scoring an eval run",
+				);
+			}
+		} catch (error) {
+			// One bad run must not abandon the rest of the batch. It stays in the
+			// queue (no score event was written) and is retried next tick.
+			summary.failed += 1;
+			logger.error(
+				{ runId, err: getErrorMessage(error) },
+				"[evals] Failed to score an eval run",
+			);
+		}
+	}
+
+	return summary;
+}

--- a/packages/server/src/scheduled/score-eval-runs.ts
+++ b/packages/server/src/scheduled/score-eval-runs.ts
@@ -98,6 +98,18 @@ export async function runScoreEvalRuns(opts?: {
       AND r.status = ANY(${TERMINAL_RUN_STATUSES_PG}::text[])
       AND coalesce(r.completed_at, r.created_at)
             < now() - ${`${SCORE_SETTLE_SECONDS} seconds`}::interval
+      -- The same rejection scoreEvalRun returns as no_attributable_member:
+      -- events.created_by is NOT NULL behind ON DELETE RESTRICT, so an org with
+      -- no live member can never receive score events. Excluded HERE rather
+      -- than claimed and then skipped, because a permanently unscoreable run is
+      -- exactly the shape that never leaves the queue, and under
+      -- ORDER BY r.id LIMIT n a handful of them would occupy the whole batch on
+      -- every tick and starve every later run in every org. member is a bounded
+      -- config table indexed on organizationId; probing it is cheap.
+      AND EXISTS (
+        SELECT 1 FROM "member" m
+        WHERE m."organizationId" = r.organization_id
+      )
       AND NOT EXISTS (
         SELECT 1 FROM events e
         WHERE e.organization_id = r.organization_id
@@ -122,10 +134,12 @@ export async function runScoreEvalRuns(opts?: {
 			if (result.ok) {
 				summary.scored += 1;
 			} else {
-				// A rejection is information, not an error: `not_terminal` means the
-				// settle window raced a status change, `no_attributable_member` means
-				// the org has no one to attribute to. Both are re-tried next tick, so
-				// the run stays in the queue rather than being silently dropped.
+				// A rejection here is a race, not an error: the query above already
+				// excludes every run `scoreEvalRun` would reject on its own terms, so
+				// reaching this branch means the row changed underneath us — the run
+				// was pruned (`not_found`) or the org's last member was removed
+				// (`no_attributable_member`) between the probe and the score. Both
+				// resolve themselves; the run keeps its place in the queue.
 				summary.skipped += 1;
 				logger.info(
 					{ runId, reason: result.reason },

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -493,7 +493,13 @@ export const QUERYABLE_SCHEMA = {
         // most recent `completed` run, written by a trigger on `runs`. Plain
         // timestamptz, no secret, and it is what the listing orders by — so
         // SQL must expose it or the ordering can't be audited from query_sql.
-        'last_run_completed_at'
+        'last_run_completed_at',
+        // Materialized eval quality, written by the scorer at score time. No
+        // secret, and exposing it is the point: a quality number nobody can
+        // query is a number nobody can check.
+        'latest_eval_score',
+        'latest_eval_at',
+        'latest_eval_run_id'
       ),
     },
     // event_classifications


### PR DESCRIPTION
## What

Evals PR 4 (#2564): score eval replays, and answer whether a Behavior regressed.

**The gap this closes is bigger than "add scoring".** #2584 shipped `promoteEvalCase` and `replayEvalCase` with **no caller anywhere outside their own module** — verified against `origin/main`:

```
$ git grep -n "promoteEvalCase\|replayEvalCase" origin/main -- 'packages/**/*.ts' \
    | grep -v __tests__ | grep -v src/runs/eval
(no output)
```

Nothing could promote a case, nothing could run one, nothing could read a result. This makes the loop reachable end to end.

## The metrics

| metric | kind | asks |
|---|---|---|
| `completed_window` | code | did the agent terminate through `complete_window`, or just stop? |
| `output_present` | code | did it extract anything? |
| `judge_rubric` | judge | does the output satisfy the case's expectation? |

`completed_window` earns its keep on day one — *"finished without calling completeWindow"* is the largest `agent_error` class in the prod sample measured in #2564.

The two code metrics stay separate deliberately: completing a window with an empty extraction is a protocol **pass** and a quality **fail**, and collapsing them hides exactly that case.

## An unaskable judge writes no verdict — never a zero

The judge needs a case, an expectation, and a reachable provider. When any is missing, or the call fails, or the reply isn't a verdict, **no `judge_rubric` event is written**. `latest_eval_score` is a pass *fraction* over verdicts actually produced, so a missing metric shrinks the denominator instead of dragging the score down.

Recording a failed judge call as a failing Behavior is precisely the error that made a provider quota storm read as a 61–78% prompt regression.

## Answering "did I break it?"

`runEvalSuite` replays a Behavior's active cases N times. Trials get distinct keys — `createEvalRun` dedups on `(sourceRunId, caseKey)`, so without that, five trials collapse into one run and one measurement is reported as five.

`readEvalResults` compares the latest trial group's mean against the previous group's, and reports a regression **only when the drop exceeds the spread the case showed within its own latest group**. A case that wobbles 1.0→0.5 by itself does not get called a regression for a −0.25 move. That guard is mutation-tested.

## Judge model — reusing the knob that already exists

No new config surface and no env var. The case entity carries `judge_model`, the same `<slug>/<model>` ref shape a guardrail entry's `model` already uses, resolved by the same `resolveCompletionTarget`. The case is the right owner — it's the thing that knows what "good" means. Falls back to the org default.

## Invariants

- **No read-time aggregation.** Results read case **entities** (`recent_scores`, a bounded window the scorer materializes at write time). `events` is never touched on a read path. The Behaviors listing reads `watchers.latest_eval_score` off the row it already selects.
- **Append-only.** A rescore supersedes; asserted as exactly one live verdict and one chain root per (run, metric).
- **Structurally excluded.** Score events write NULL `payload_text` and NULL `feed_id` — the canvas rule. Asserted, not assumed.
- **Multi-replica.** The scorer queue's claim is an anti-join on committed facts, not a lock. Deliberately not `FOR UPDATE SKIP LOCKED`: that holds a row lock across a 30s judge call to prevent a duplicate the unique index already rejects.

## Schema

Named in the approved spec (#2564 §2c, PR 4 row). **No new tables.**

- `watchers.latest_eval_score / latest_eval_at / latest_eval_run_id` — the write-time stamp. Nullable, no backfill: NULL means *never scored*, which a `0` default would make indistinguishable from *scored, failed everything*.
- `idx_events_identity_root_eval_score` (constraint) + `idx_events_identity_head_eval_score` (the head probe's index) — shipped as a matched pair, same as the `behavior_event` namespace.

## What `make review-fix` caught — all real, all mine

| finding | why it mattered |
|---|---|
| **cross-tenant write** | the org guard ran *after* `promoteEvalCase`, which had already created an `$eval_case` entity **and entity type** in the victim tenant. Guard moved before the write; returns `not_found` so the id isn't confirmed. |
| **missing authz** | neither POST called `requireSessionOrAdminPat` (10 other mutating routes in the file do). A non-admin `mcp:*` bearer could queue cases × 10 replays of inference spend. |
| `CASE_SCORE_WINDOW` = `MAX_TRIALS` = 10 | at the documented max trials the baseline group was **always empty**, so every regression verdict was permanently `null` — the feature silently answering nothing. Now 20, with the dependency stated on both constants. |
| `TERMINAL_RUN_STATUSES` missing `timeout` | `markStaleRunsAsTimeout` runs over `BEHAVIOR_RUN_TYPES`, so a crashed eval reaches `timeout` and no other terminal status — those runs were permanently unscoreable. |
| trial suffix stripped at `lastIndexOf("#")` | `caseKey` is caller-supplied free text, so a case promoted as `weekly#draft` resolved to the wrong identifier — judge silently skipped, scores unanchored, empty suite, no error. Now anchored on `/#t\d+$/`. |
| queue starvation | `no_attributable_member` runs were claimed and skipped forever, occupying the batch under `ORDER BY r.id LIMIT 25`. Added the `member` EXISTS probe. |

## Tests — 62, all green

```
 Test Files  7 passed (7)
      Tests  56 passed (56)      # integration
 6 pass 0 fail                   # eval-case-run-key unit
```

## Mutation checks

Each confirmed to land (countable source change) and to kill its test:

| mutation | test killed |
|---|---|
| `completed_window` always passes | *a run that never called complete_window is SCORED as a failure* |
| drop `supersedesEventId` | *rescoring supersedes rather than forking* |
| `content: null` → a string | *score events are structurally excluded…* |
| drop the queue anti-join | *leaves a run inside the settle window alone* + *never claims a live Behavior run* |
| settle window 60s → 0 | *leaves a run inside the settle window alone* |
| drop the trial suffix | *N trials stay N distinct runs instead of collapsing into one* |
| ignore the noise floor | *does NOT call a wobble smaller than its own noise a regression* |
| drop the cross-tenant guard | *writes NOTHING when the run belongs to another org* |
| shrink the score window | *reports a real drop as a regression* + the noise-floor test |
| restore `lastIndexOf("#")` | *eval-case-run-key* round-trip (2/6) |

## Known gaps, stated not hidden

- **The judge has never called a live model.** The tests assert the contract that matters (an unaskable judge produces no verdict) but nothing here exercises a real provider. Owed at prod-verify.
- **Self-preference bias is unmitigated by default** — the cron passes no `judgeModelRef`, so the judge runs on the org default, possibly the model under eval. Per-case `judge_model` is the escape hatch.
- **Trial grouping is positional** — exact only when the reader passes the `trials` the suite ran with. Making it exact needs a suite-run id on each window entry, which is a schema decision I didn't take unilaterally.

Refs #2564


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added evaluation-suite workflows for promoting behavior runs, running trials, scoring results, and viewing regressions.
  - Added optional judge-model evaluation for output quality.
  - Exposed latest evaluation scores and timestamps in behavior data.
  - Added automatic background scoring for completed evaluation runs.

- **Bug Fixes**
  - Improved organization isolation, duplicate prevention, score consistency, and handling of incomplete or unavailable evaluation results.

- **Tests**
  - Added comprehensive coverage for evaluation promotion, scoring, trials, regressions, scheduling, and access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->