### PR TITLE
refactor(core): make @lobu/core/refs the only ref-token grammar, and @ the only source gesture

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -152,6 +152,12 @@
       "bun": "./src/reserved.ts",
       "import": "./dist/reserved.js",
       "require": "./dist/reserved.js"
+    },
+    "./refs": {
+      "types": "./dist/refs.d.ts",
+      "bun": "./src/refs.ts",
+      "import": "./dist/refs.js",
+      "require": "./dist/refs.js"
     }
   },
   "scripts": {

--- a/packages/core/src/__tests__/refs.test.ts
+++ b/packages/core/src/__tests__/refs.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the shared ref-token codec.
+ *
+ * This module is consumed by BOTH the server (`watchers/source-refs.ts`) and
+ * the SPA (`owletto/src/lib/references.ts`). Before consolidation each side
+ * carried its own transcription of the grammar, and the failure mode of a
+ * mismatch is silent: a token the regex does not match is skipped, so the
+ * caller receives `[]` and never an error. The kind-group cases below are the
+ * regression guard for exactly that.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  behaviorSourcesFromPrompt,
+  behaviorSourcesWithRef,
+  mergePromptSources,
+  parseRefs,
+  serializeRef,
+  skillNamesFromPrompt,
+  sqlQueryFromPath,
+  sqlRefPath,
+  stripRefTokens,
+} from "../refs";
+
+describe("ref token grammar", () => {
+  it("round-trips a ref through serialize and parse", () => {
+    const ref = {
+      kind: "feed" as const,
+      id: "issues",
+      label: "GitHub Issues",
+      path: "/acme/connectors/github/7",
+    };
+    expect(parseRefs(serializeRef(ref))).toEqual([ref]);
+  });
+
+  it("lexes a kind containing an underscore", () => {
+    // Narrowing the kind group to [a-z]+ makes this return [] rather than
+    // throwing, which is how an entire chip kind disappears unnoticed.
+    const parsed = parseRefs("@[entity_type:company:Companies](/acme/company)");
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.kind).toBe("entity_type");
+    expect(parsed[0]?.id).toBe("company");
+  });
+
+  it("strips every token kind, underscored ones included", () => {
+    const prompt =
+      "watch @[entity_type:company:Companies](/acme/company) and " +
+      "@[feed:issues:Issues](/acme/f) closely";
+    expect(stripRefTokens(prompt)).toBe("watch   and   closely");
+  });
+
+  it("skips unknown kinds instead of throwing", () => {
+    expect(parseRefs("@[nonsense:1:X](/a) @[feed:k:F](/b)")).toHaveLength(1);
+  });
+});
+
+describe("sql payload codec", () => {
+  it("survives parens, quotes and newlines through the token path group", () => {
+    const query =
+      "SELECT id\nFROM events\nWHERE ts > now() - interval '7 days'";
+    const path = sqlRefPath(query);
+    expect(path).not.toContain(")");
+    expect(path).not.toContain(" ");
+    expect(sqlQueryFromPath(path)).toBe(query);
+  });
+
+  it("returns null for a navigable path", () => {
+    expect(sqlQueryFromPath("/acme/company/spotify")).toBeNull();
+  });
+});
+
+describe("behaviorSourcesFromPrompt", () => {
+  it("compiles entity_type to the @entity: type-slug mode", () => {
+    expect(
+      behaviorSourcesFromPrompt(
+        "@[entity_type:company:Companies](/acme/company)"
+      )
+    ).toEqual([{ name: "companies", query: "@entity:company" }]);
+  });
+
+  it("excludes an entity INSTANCE while including the type", () => {
+    const prompt =
+      "@[entity:42:Spotify](/acme/company/spotify) " +
+      "@[entity_type:company:Companies](/acme/company)";
+    expect(behaviorSourcesFromPrompt(prompt)).toEqual([
+      { name: "companies", query: "@entity:company" },
+    ]);
+  });
+
+  it("decodes a sql chip and de-dupes by query with unique names", () => {
+    const query = "SELECT id FROM events";
+    const prompt = [
+      "@[feed:k1:Issues](/a)",
+      "@[feed:k1:Issues again](/a)",
+      "@[feed:k2:Issues](/b)",
+      `@[sql:recent:Recent](${sqlRefPath(query)})`,
+    ].join(" ");
+    expect(behaviorSourcesFromPrompt(prompt)).toEqual([
+      { name: "issues", query: "@feed:k1" },
+      { name: "issues_2", query: "@feed:k2" },
+      { name: "recent", query },
+    ]);
+  });
+
+  it("never treats a skill chip as a source", () => {
+    expect(behaviorSourcesFromPrompt("@[skill:triage:triage](/a)")).toEqual([]);
+    expect(skillNamesFromPrompt("@[skill:triage:triage](/a)")).toEqual([
+      "triage",
+    ]);
+  });
+});
+
+describe("behaviorSourcesWithRef", () => {
+  it("appends an entity_type ref and leaves an existing duplicate alone", () => {
+    const first = behaviorSourcesWithRef(
+      {
+        kind: "entity_type",
+        id: "company",
+        label: "Companies",
+        path: "/acme/company",
+      },
+      []
+    );
+    expect(first).toEqual([{ name: "companies", query: "@entity:company" }]);
+
+    const again = behaviorSourcesWithRef(
+      {
+        kind: "entity_type",
+        id: "company",
+        label: "Companies",
+        path: "/acme/company",
+      },
+      first
+    );
+    expect(again).toEqual(first);
+  });
+});
+
+describe("mergePromptSources", () => {
+  it("keeps explicit sources first and suffixes colliding prompt names", () => {
+    expect(
+      mergePromptSources(
+        [{ name: "slack", query: "@feed:a" }],
+        [
+          { name: "slack", query: "@connection:7" },
+          { name: "dupe", query: "@feed:a" },
+        ]
+      )
+    ).toEqual([
+      { name: "slack", query: "@feed:a" },
+      { name: "slack_2", query: "@connection:7" },
+    ]);
+  });
+});

--- a/packages/core/src/refs.ts
+++ b/packages/core/src/refs.ts
@@ -20,15 +20,11 @@
  *           ref be re-resolved. For `sql` it is the query payload, not a route.
  * `label` — display name captured at pick time (what the chip shows).
  *
- * THIS FILE IS THE ONLY COPY. It used to exist three times — owletto's
- * `lib/references.ts`, the server's `watchers/source-refs.ts`, and an inline
- * strip-regex in owletto's `lib/behavior-skills.ts` — kept in sync by hand
- * because "the server cannot import the owletto submodule". That reasoning
- * skipped the obvious third option: both already depend on `@lobu/core`, so
- * the grammar belongs here. The duplication was not theoretical — adding the
- * `entity_type` kind meant widening the kind group to allow `_`, and a token
- * that fails to match is dropped SILENTLY (you get `[]`, never an error), so
- * the copy that got missed lost every entity-type chip without complaining.
+ * THIS FILE IS THE ONLY COPY of the grammar. Both consumers — the server
+ * (`watchers/source-refs.ts`) and the SPA (`owletto/src/lib/references.ts`) —
+ * import it; neither may re-derive a token regex locally. A mismatched copy
+ * fails SILENTLY: a token the regex does not match is skipped, so the caller
+ * gets `[]` and never an error.
  */
 
 export type LobuRefKind =
@@ -191,7 +187,7 @@ export const SOURCE_KIND_TO_MODE: Readonly<Record<string, string>> = {
 };
 
 /** Slugify a label into a safe output-field name. */
-export function sourceFieldName(value: string): string {
+function sourceFieldName(value: string): string {
   return (
     value
       .trim()
@@ -342,19 +338,17 @@ export function mergePromptSources(
   fromPrompt: BehaviorSource[]
 ): BehaviorSource[] {
   const merged = [...explicit];
-  const seenQuery = new Set(explicit.map((s) => s.query.trim()));
+  const seenQueries = new Set(explicit.map((s) => s.query.trim()));
   const usedNames = new Set(explicit.map((s) => s.name));
-  for (const src of fromPrompt) {
-    if (seenQuery.has(src.query.trim())) continue;
-    seenQuery.add(src.query.trim());
-    let name = src.name;
-    if (usedNames.has(name)) {
-      let i = 2;
-      while (usedNames.has(`${name}_${i}`)) i += 1;
-      name = `${name}_${i}`;
-    }
-    usedNames.add(name);
-    merged.push({ name, query: src.query });
+  for (const source of fromPrompt) {
+    appendBehaviorSource(
+      merged,
+      seenQueries,
+      usedNames,
+      source.name,
+      source.name,
+      source.query
+    );
   }
   return merged;
 }

--- a/packages/core/src/refs.ts
+++ b/packages/core/src/refs.ts
@@ -1,0 +1,360 @@
+/**
+ * LobuRef — one portable, typed reference to any first-class object the UI can
+ * point at: an entity, entity type, connection, connector, feed, behavior,
+ * member, metric, skill, event, or an inline SQL query. The reference picker
+ * emits these, the chat composer serializes them into a message so an agent
+ * turn can be told "this is about <that object>", and the Behavior create path
+ * compiles the source-bearing ones into `sources[]`.
+ *
+ * Inline wire form (rides inside an ordinary message `content` string — no new
+ * API field):
+ *
+ *   @[entity:42:Spotify](/acme/company/spotify)
+ *   @[entity_type:company:Companies](/acme/company)
+ *   @[sql:recent:Recent events](#sql=SELECT%20…)
+ *
+ * `kind`  — object family (drives worker-side expansion and source compilation).
+ * `id`    — stable id as a string (entity id, connection id, behavior uuid,
+ *           connector key, feed_key, entity-type slug, `type.measure`).
+ * `path`  — frontend route to the object; makes the chip clickable and lets the
+ *           ref be re-resolved. For `sql` it is the query payload, not a route.
+ * `label` — display name captured at pick time (what the chip shows).
+ *
+ * THIS FILE IS THE ONLY COPY. It used to exist three times — owletto's
+ * `lib/references.ts`, the server's `watchers/source-refs.ts`, and an inline
+ * strip-regex in owletto's `lib/behavior-skills.ts` — kept in sync by hand
+ * because "the server cannot import the owletto submodule". That reasoning
+ * skipped the obvious third option: both already depend on `@lobu/core`, so
+ * the grammar belongs here. The duplication was not theoretical — adding the
+ * `entity_type` kind meant widening the kind group to allow `_`, and a token
+ * that fails to match is dropped SILENTLY (you get `[]`, never an error), so
+ * the copy that got missed lost every entity-type chip without complaining.
+ */
+
+export type LobuRefKind =
+  | "entity"
+  | "entity_type"
+  | "connection"
+  | "connector"
+  | "feed"
+  | "behavior"
+  | "member"
+  | "metric"
+  | "sql"
+  | "skill"
+  | "event";
+
+export const LOBU_REF_KINDS: readonly LobuRefKind[] = [
+  "entity",
+  "entity_type",
+  "connection",
+  "connector",
+  "feed",
+  "behavior",
+  "member",
+  "metric",
+  "sql",
+  "skill",
+  "event",
+] as const;
+
+export interface LobuRef {
+  kind: LobuRefKind;
+  id: string;
+  path: string;
+  label: string;
+}
+
+/** `{name, query}` — one entry of a Behavior's `sources[]`. */
+export interface BehaviorSource {
+  name: string;
+  query: string;
+}
+
+export function isLobuRefKind(value: string): value is LobuRefKind {
+  return (LOBU_REF_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * One inline ref token: `@[kind:id:label](path)`.
+ *
+ * Groups: kind, id, label, path.
+ * - kind  — lowercase letters plus `_`, so multi-word kinds (`entity_type`)
+ *           lex. Narrowing this to `[a-z]+` does not throw; it silently stops
+ *           matching, which is how a whole chip kind disappears unnoticed.
+ * - id    — any char except `:` / `]` (a controlled slug).
+ * - label — any char except `]`.
+ * - path  — any char except `)` / whitespace, 0+, so an empty `()` is valid:
+ *           the synthetic "write a SQL query" menu action carries no path.
+ */
+export const REF_TOKEN = /@\[([a-z_]+):([^:\]]*):([^\]]*)\]\(([^)\s]*)\)/g;
+
+/** A fresh, non-global matcher for the same grammar — for callers that want a
+ *  one-shot `.replace()`/`.test()` without inheriting `lastIndex` state. */
+export function refTokenPattern(flags = "g"): RegExp {
+  return new RegExp(REF_TOKEN.source, flags);
+}
+
+/** Serialize one ref to its inline token. Brackets/colons are stripped from the
+ *  label so the token stays unambiguous. */
+export function serializeRef(ref: LobuRef): string {
+  const safeLabel = ref.label.replace(/[[\]]/g, "").trim();
+  const safeId = ref.id.replace(/[[\]:]/g, "");
+  return `@[${ref.kind}:${safeId}:${safeLabel}](${ref.path})`;
+}
+
+/**
+ * Parse every ref token out of a text body, in order. Unknown kinds are skipped
+ * rather than thrown, so arbitrary user text containing `@[...]` never breaks
+ * send.
+ */
+export function parseRefs(text: string): LobuRef[] {
+  const out: LobuRef[] = [];
+  for (const match of text.matchAll(REF_TOKEN)) {
+    const [, kind, id, label, path] = match;
+    if (!kind || !isLobuRefKind(kind) || !path) continue;
+    out.push({ kind, id: id ?? "", label: (label ?? "").trim(), path });
+  }
+  return out;
+}
+
+/** Text with every ref token removed — what the author actually typed. */
+export function stripRefTokens(text: string): string {
+  return text.replace(refTokenPattern(), " ").trim();
+}
+
+// ── SQL payload codec ───────────────────────────────────────────────────────
+
+/**
+ * SQL is the one kind with no first-class object to point at — the query is
+ * authored inline and lives nowhere but the token itself. So a `sql` ref carries
+ * its whole query in the `path` slot, URL-encoded behind a `#sql=` marker.
+ * Encoding turns spaces/parens/newlines into `%xx`, so the token's `path` group
+ * (no space, no `)`) stays satisfied and the query survives the round-trip
+ * verbatim. The `#` marks the path as a payload, not a route — so chip/pill
+ * click opens the edit dialog instead of navigating.
+ */
+const SQL_PATH_PREFIX = "#sql=";
+
+/** `encodeURIComponent` leaves `( ) ' ! * ~` unescaped, but the token's path
+ *  group forbids `)` (it closes the `(...)`) — so we additionally percent-encode
+ *  those sub-delims. `decodeURIComponent` reverses all of it. */
+function encodeSqlPayload(query: string): string {
+  return encodeURIComponent(query).replace(
+    /[()'!*~]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+}
+
+/** Build the `path` for a `sql` ref: `#sql=<urlencoded query>`. */
+export function sqlRefPath(query: string): string {
+  return `${SQL_PATH_PREFIX}${encodeSqlPayload(query)}`;
+}
+
+/** Recover the raw query from a `sql` ref's `path`, or null if it isn't one. */
+export function sqlQueryFromPath(path: string): string | null {
+  if (!path.startsWith(SQL_PATH_PREFIX)) return null;
+  try {
+    return decodeURIComponent(path.slice(SQL_PATH_PREFIX.length));
+  } catch {
+    return null;
+  }
+}
+
+/** True if a path is a SQL payload rather than a navigable route. */
+export function isSqlRefPath(path: string): boolean {
+  return path.startsWith(SQL_PATH_PREFIX);
+}
+
+// ── Behavior source compilation ─────────────────────────────────────────────
+
+/**
+ * Which chip kinds compile to a Behavior source, and the `@mode:` each uses.
+ *
+ * `entity_type` maps to mode `entity` because the source grammar has always
+ * spelled it `@entity:<type_slug>` (every row of one type). The chip kind
+ * cannot ALSO be called `entity`: an `@[entity:…]` chip is an entity *instance*
+ * that scopes the Behavior, and sending an instance id where a type slug
+ * belongs resolves to nothing. Same word, two meanings; the kind keeps them
+ * apart — which is exactly why `entity` is absent from this map.
+ *
+ * `sql` is handled separately (its query rides inline in the path).
+ * `skill`, `behavior`, `member` and `event` are never sources.
+ */
+export const SOURCE_KIND_TO_MODE: Readonly<Record<string, string>> = {
+  feed: "feed",
+  connection: "connection",
+  connector: "connector",
+  channel: "channel",
+  metric: "metric",
+  entity_type: "entity",
+};
+
+/** Slugify a label into a safe output-field name. */
+export function sourceFieldName(value: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_]+/g, "_")
+      .replace(/^_+|_+$/g, "") || "source"
+  );
+}
+
+/**
+ * Append `{name, query}` unless the query is already present, uniquifying the
+ * derived name with a numeric suffix. Shared by the chip codec and the Behavior
+ * sources editor so both name and dedupe identically.
+ */
+function appendBehaviorSource(
+  sources: BehaviorSource[],
+  seenQueries: Set<string>,
+  usedNames: Set<string>,
+  label: string,
+  fallback: string,
+  query: string
+): void {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery || seenQueries.has(normalizedQuery)) return;
+  seenQueries.add(normalizedQuery);
+  let name = sourceFieldName(label || fallback);
+  if (usedNames.has(name)) {
+    let suffix = 2;
+    while (usedNames.has(`${name}_${suffix}`)) suffix += 1;
+    name = `${name}_${suffix}`;
+  }
+  usedNames.add(name);
+  sources.push({ name, query: normalizedQuery });
+}
+
+/**
+ * The source a single reference stands for, appended to `existing`. Returns
+ * `existing` unchanged when the ref carries no query or already appears — the
+ * caller can compare lengths to tell whether anything was added.
+ */
+export function behaviorSourcesWithRef(
+  ref: LobuRef,
+  existing: BehaviorSource[]
+): BehaviorSource[] {
+  const sources = [...existing];
+  const seenQueries = new Set(existing.map((source) => source.query.trim()));
+  const usedNames = new Set(existing.map((source) => source.name));
+  if (ref.kind === "sql") {
+    const query = sqlQueryFromPath(ref.path);
+    if (query) {
+      appendBehaviorSource(
+        sources,
+        seenQueries,
+        usedNames,
+        ref.label,
+        "sql_source",
+        query
+      );
+    }
+    return sources;
+  }
+  const mode = SOURCE_KIND_TO_MODE[ref.kind];
+  const value = ref.id.trim();
+  if (mode && value) {
+    appendBehaviorSource(
+      sources,
+      seenQueries,
+      usedNames,
+      ref.label,
+      value,
+      `@${mode}:${value}`
+    );
+  }
+  return sources;
+}
+
+/**
+ * Derive Behavior `sources[]` from the `@`-mention tokens in a prompt. Each
+ * source-bearing token becomes `{ name, query: '@mode:id' }`; a `sql` token
+ * carries its raw query URL-encoded in the path (`#sql=…`), decoded here to the
+ * SELECT itself. Entity INSTANCES are excluded (they scope the Behavior).
+ *
+ * Returns [] for a prompt with no source tokens. Malformed tokens are skipped
+ * rather than thrown — the server's `assertWatcherSourcesResolve` is what
+ * enforces that every derived source actually resolves against the org.
+ */
+export function behaviorSourcesFromPrompt(
+  text: string,
+  explicit: BehaviorSource[] = []
+): BehaviorSource[] {
+  const sources = [...explicit];
+  const seenQueries = new Set(explicit.map((source) => source.query.trim()));
+  const usedNames = new Set(explicit.map((source) => source.name));
+
+  const push = (label: string, fallback: string, query: string) =>
+    appendBehaviorSource(
+      sources,
+      seenQueries,
+      usedNames,
+      label,
+      fallback,
+      query
+    );
+
+  for (const match of text.matchAll(REF_TOKEN)) {
+    const [, kind, id, label, path] = match;
+    if (!kind) continue;
+    if (kind === "sql") {
+      const query = sqlQueryFromPath(path ?? "");
+      if (query) push(label ?? "", "sql_source", query.trim());
+      continue;
+    }
+    const mode = SOURCE_KIND_TO_MODE[kind];
+    const value = (id ?? "").trim();
+    if (mode && value) push(label ?? "", value, `@${mode}:${value}`);
+  }
+
+  return sources;
+}
+
+/**
+ * Names referenced by `@[skill:<name>:<label>](…)` tokens in a prompt.
+ *
+ * Deliberately NOT part of `SOURCE_KIND_TO_MODE` — a skill is not a source.
+ * De-duped, order preserved; malformed tokens are skipped.
+ */
+export function skillNamesFromPrompt(text: string): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const match of text.matchAll(REF_TOKEN)) {
+    const [, kind, id] = match;
+    if (kind !== "skill") continue;
+    const name = (id ?? "").trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+  }
+  return names;
+}
+
+/**
+ * Merge prompt-derived sources into an explicit list, de-duping by query and
+ * keeping output-field names unique. Explicit sources win (they keep their
+ * names and order); prompt sources fill in the rest.
+ */
+export function mergePromptSources(
+  explicit: BehaviorSource[],
+  fromPrompt: BehaviorSource[]
+): BehaviorSource[] {
+  const merged = [...explicit];
+  const seenQuery = new Set(explicit.map((s) => s.query.trim()));
+  const usedNames = new Set(explicit.map((s) => s.name));
+  for (const src of fromPrompt) {
+    if (seenQuery.has(src.query.trim())) continue;
+    seenQuery.add(src.query.trim());
+    let name = src.name;
+    if (usedNames.has(name)) {
+      let i = 2;
+      while (usedNames.has(`${name}_${i}`)) i += 1;
+      name = `${name}_${i}`;
+    }
+    usedNames.add(name);
+    merged.push({ name, query: src.query });
+  }
+  return merged;
+}

--- a/packages/server/src/__tests__/unit/prompt-skill-tokens-pinned.test.ts
+++ b/packages/server/src/__tests__/unit/prompt-skill-tokens-pinned.test.ts
@@ -2,8 +2,8 @@
  * A prompt `@[skill:…]` chip must have a matching entry in `skills[]`.
  *
  * Ref tokens are never stripped — nothing in the instruction path rewrites them
- * (grep `PROMPT_REF_TOKEN`: every consumer only reads the prompt) — so an
- * unpinned chip does not fail loudly, it degrades: the agent reads the literal
+ * (grep `REF_TOKEN`: every consumer only reads the prompt) — so an unpinned
+ * chip does not fail loudly, it degrades: the agent reads the literal
  * `@[skill:deploy-runbook:Deploy runbook](/…)` as if it were guidance, with no
  * `.skills/` file behind it. Silent wrong instructions are worse than a 422.
  *
@@ -15,15 +15,15 @@
 
 import { describe, expect, it } from "bun:test";
 import { assertPromptSkillTokensPinned } from "../../tools/admin/manage_behaviors/shared";
-import { extractSkillNamesFromPromptTokens } from "../../watchers/source-refs";
+import { skillNamesFromPrompt } from "../../watchers/source-refs";
 
 const chip = (name: string, label = name) =>
 	`@[skill:${name}:${label}](/acme/agents/a/skills/${name})`;
 
-describe("extractSkillNamesFromPromptTokens", () => {
+describe("skillNamesFromPrompt", () => {
 	it("reads the id out of a skill chip, not the label", () => {
 		expect(
-			extractSkillNamesFromPromptTokens(
+			skillNamesFromPrompt(
 				`Run ${chip("deploy-runbook", "Deploy runbook")} nightly.`,
 			),
 		).toEqual(["deploy-runbook"]);
@@ -39,22 +39,18 @@ describe("extractSkillNamesFromPromptTokens", () => {
 			"@[entity:7:Spotify](/acme/company/spotify)",
 			"@[metric:asset.spend:Spend](/acme/metrics/asset.spend)",
 		].join(" ");
-		expect(extractSkillNamesFromPromptTokens(prompt)).toEqual([]);
+		expect(skillNamesFromPrompt(prompt)).toEqual([]);
 	});
 
 	it("de-dupes repeats but keeps first-seen order", () => {
 		expect(
-			extractSkillNamesFromPromptTokens(
-				`${chip("b")} then ${chip("a")} then ${chip("b")}`,
-			),
+			skillNamesFromPrompt(`${chip("b")} then ${chip("a")} then ${chip("b")}`),
 		).toEqual(["b", "a"]);
 	});
 
 	it("returns nothing for a prompt with no tokens", () => {
-		expect(extractSkillNamesFromPromptTokens("Summarize yesterday.")).toEqual(
-			[],
-		);
-		expect(extractSkillNamesFromPromptTokens("")).toEqual([]);
+		expect(skillNamesFromPrompt("Summarize yesterday.")).toEqual([]);
+		expect(skillNamesFromPrompt("")).toEqual([]);
 	});
 });
 

--- a/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
+++ b/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
@@ -80,6 +80,27 @@ describe("extractSourcesFromPromptTokens", () => {
 		]);
 	});
 
+	it("derives an @entity: source from an entity_type token", () => {
+		// The underscore in the kind is the load-bearing part: PROMPT_REF_TOKEN's
+		// kind group must allow it, or this token does not match at all and the
+		// source silently vanishes instead of erroring.
+		const prompt = "review @[entity_type:company:Companies](/o/company)";
+		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+			{ name: "companies", query: "@entity:company" },
+		]);
+	});
+
+	it("keeps entity_type (a type) and entity (an instance) apart", () => {
+		// Both would compile through mode `entity`, but only the type slug is a
+		// legal `@entity:` value — an instance id there would resolve to nothing.
+		const prompt =
+			"for @[entity:42:Spotify](/o/company/spotify) review " +
+			"@[entity_type:company:Companies](/o/company)";
+		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+			{ name: "companies", query: "@entity:company" },
+		]);
+	});
+
 	it("excludes entity tokens (scope, not source)", () => {
 		const prompt =
 			"for @[entity:42:Spotify](/o/company/spotify) watch @[feed:k:Feed](/o/x)";

--- a/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
+++ b/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
@@ -9,10 +9,6 @@ import {
 	watcherSourceKindForRef,
 } from "../../watchers/source-refs";
 
-// `sqlRefPath` is imported, not re-implemented. This file used to carry its own
-// copy of the encoder "mirroring owletto" — a fourth transcription of the same
-// codec, and one that could drift from the thing under test without failing.
-
 describe("watcher source refs", () => {
 	it("parses event-backed refs", () => {
 		expect(parseWatcherSourceRef("@feed:support")).toEqual({
@@ -77,8 +73,8 @@ describe("behaviorSourcesFromPrompt", () => {
 	});
 
 	it("derives an @entity: source from an entity_type token", () => {
-		// The underscore in the kind is the load-bearing part: PROMPT_REF_TOKEN's
-		// kind group must allow it, or this token does not match at all and the
+		// The underscore in the kind is the load-bearing part: REF_TOKEN's kind
+		// group must allow it, or this token does not match at all and the
 		// source silently vanishes instead of erroring.
 		const prompt = "review @[entity_type:company:Companies](/o/company)";
 		expect(behaviorSourcesFromPrompt(prompt)).toEqual([
@@ -125,9 +121,7 @@ describe("behaviorSourcesFromPrompt", () => {
 	});
 
 	it("returns [] for a prompt with no source tokens", () => {
-		expect(behaviorSourcesFromPrompt("just plain instructions")).toEqual(
-			[],
-		);
+		expect(behaviorSourcesFromPrompt("just plain instructions")).toEqual([]);
 	});
 });
 

--- a/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
+++ b/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
@@ -1,6 +1,7 @@
+import { sqlRefPath } from "@lobu/core/refs";
 import { describe, expect, it } from "bun:test";
 import {
-	extractSourcesFromPromptTokens,
+	behaviorSourcesFromPrompt,
 	mergePromptSources,
 	normalizeWatcherSources,
 	parseWatcherSourceRef,
@@ -8,14 +9,9 @@ import {
 	watcherSourceKindForRef,
 } from "../../watchers/source-refs";
 
-/** Mirror of owletto's sqlRefPath: encode the query, additionally escaping the
- *  sub-delims encodeURIComponent leaves raw ( ) ' ! * ~ so the token parses. */
-function sqlRefPath(query: string): string {
-	return `#sql=${encodeURIComponent(query).replace(
-		/[()'!*~]/g,
-		(c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
-	)}`;
-}
+// `sqlRefPath` is imported, not re-implemented. This file used to carry its own
+// copy of the encoder "mirroring owletto" — a fourth transcription of the same
+// codec, and one that could drift from the thing under test without failing.
 
 describe("watcher source refs", () => {
 	it("parses event-backed refs", () => {
@@ -68,12 +64,12 @@ describe("watcher source refs", () => {
 	});
 });
 
-describe("extractSourcesFromPromptTokens", () => {
+describe("behaviorSourcesFromPrompt", () => {
 	it("derives @mode:id sources from feed/connection/connector/metric tokens", () => {
 		const prompt =
 			"summarize @[feed:issues:GitHub Issues](/o/x) and " +
 			"@[connection:7:Slack](/o/y) and @[metric:company.churn:Churn](/o/z)";
-		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+		expect(behaviorSourcesFromPrompt(prompt)).toEqual([
 			{ name: "github_issues", query: "@feed:issues" },
 			{ name: "slack", query: "@connection:7" },
 			{ name: "churn", query: "@metric:company.churn" },
@@ -85,7 +81,7 @@ describe("extractSourcesFromPromptTokens", () => {
 		// kind group must allow it, or this token does not match at all and the
 		// source silently vanishes instead of erroring.
 		const prompt = "review @[entity_type:company:Companies](/o/company)";
-		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+		expect(behaviorSourcesFromPrompt(prompt)).toEqual([
 			{ name: "companies", query: "@entity:company" },
 		]);
 	});
@@ -96,7 +92,7 @@ describe("extractSourcesFromPromptTokens", () => {
 		const prompt =
 			"for @[entity:42:Spotify](/o/company/spotify) review " +
 			"@[entity_type:company:Companies](/o/company)";
-		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+		expect(behaviorSourcesFromPrompt(prompt)).toEqual([
 			{ name: "companies", query: "@entity:company" },
 		]);
 	});
@@ -104,7 +100,7 @@ describe("extractSourcesFromPromptTokens", () => {
 	it("excludes entity tokens (scope, not source)", () => {
 		const prompt =
 			"for @[entity:42:Spotify](/o/company/spotify) watch @[feed:k:Feed](/o/x)";
-		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+		expect(behaviorSourcesFromPrompt(prompt)).toEqual([
 			{ name: "feed", query: "@feed:k" },
 		]);
 	});
@@ -112,7 +108,7 @@ describe("extractSourcesFromPromptTokens", () => {
 	it("recovers a sql token's raw query from its inline #sql= path", () => {
 		const query = "SELECT id FROM events WHERE ts > now() - interval '7 days'";
 		const prompt = `run @[sql:recent:Recent events](${sqlRefPath(query)})`;
-		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+		expect(behaviorSourcesFromPrompt(prompt)).toEqual([
 			{ name: "recent_events", query },
 		]);
 	});
@@ -121,7 +117,7 @@ describe("extractSourcesFromPromptTokens", () => {
 		const prompt =
 			"@[feed:k1:Issues](/o/a) @[feed:k1:Issues again](/o/a) " +
 			"@[feed:k2:Issues](/o/b)";
-		const out = extractSourcesFromPromptTokens(prompt);
+		const out = behaviorSourcesFromPrompt(prompt);
 		expect(out).toEqual([
 			{ name: "issues", query: "@feed:k1" },
 			{ name: "issues_2", query: "@feed:k2" },
@@ -129,7 +125,7 @@ describe("extractSourcesFromPromptTokens", () => {
 	});
 
 	it("returns [] for a prompt with no source tokens", () => {
-		expect(extractSourcesFromPromptTokens("just plain instructions")).toEqual(
+		expect(behaviorSourcesFromPrompt("just plain instructions")).toEqual(
 			[],
 		);
 	});

--- a/packages/server/src/tools/admin/manage_behaviors/crud.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/crud.ts
@@ -49,7 +49,7 @@ import {
   resolveBehaviorExecutor,
 } from './executors';
 import { getErrorMessage } from '@lobu/core';
-import { DEFAULT_BEHAVIOR_SOURCE_QUERY, extractSourcesFromPromptTokens, mergePromptSources } from '../../../watchers/source-refs';
+import { DEFAULT_BEHAVIOR_SOURCE_QUERY, behaviorSourcesFromPrompt, mergePromptSources } from '../../../watchers/source-refs';
 import {
   compileReactionScript,
   extractReactionInputSchema,
@@ -135,7 +135,7 @@ export async function handleCreate(
   // `create_version` deliberately does NOT derive (see version-actions.ts):
   // an existing prompt's prose must not silently re-author the Behavior's
   // source set during an otherwise unrelated version bump.
-  const promptSources = extractSourcesFromPromptTokens(args.prompt ?? '');
+  const promptSources = behaviorSourcesFromPrompt(args.prompt ?? '');
   const explicitSources = args.sources ?? [];
   const merged = mergePromptSources(explicitSources, promptSources);
   const sources: Array<{ name: string; query: string }> =

--- a/packages/server/src/tools/admin/manage_behaviors/shared.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/shared.ts
@@ -15,7 +15,7 @@ import { queryProjectsIdColumn } from '../../../utils/execute-data-sources';
 import {
   validateWatcherSourceRef,
   resolveWatcherSourcesForSave,
-  extractSkillNamesFromPromptTokens,
+  skillNamesFromPrompt,
 } from '../../../watchers/source-refs';
 import { validateSaveContentSemanticType } from '../../../utils/event-kind-validation';
 import type { ToolContext } from '../../registry';
@@ -352,7 +352,7 @@ export async function assertBehaviorSkillsResolve(
  * Every `@[skill:…]` chip in the prompt must have a pinned entry in `skills[]`.
  *
  * Ref tokens survive into the instructions verbatim — nothing strips them (see
- * `extractSourcesFromPromptTokens`) — so an unpinned chip does not fail, it
+ * `behaviorSourcesFromPrompt`) — so an unpinned chip does not fail, it
  * degrades: the agent reads the literal `@[skill:deploy-runbook:…](…)` as if it
  * were guidance, with no `.skills/` file behind it. The web composer always
  * sends both halves; a CLI or MCP caller writing the token by hand can send the
@@ -365,7 +365,7 @@ export function assertPromptSkillTokensPinned(
   prompt: string | null | undefined,
   skills: ReadonlyArray<{ name: string }> | null | undefined
 ): void {
-  const referenced = extractSkillNamesFromPromptTokens(prompt ?? '');
+  const referenced = skillNamesFromPrompt(prompt ?? '');
   if (referenced.length === 0) return;
   const pinned = new Set((skills ?? []).map((skill) => skill.name));
   const missing = referenced.filter((name) => !pinned.has(name));

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -162,18 +162,29 @@ export function parseWatcherSourceRef(query: string): WatcherSourceRef | null {
 // derives the watcher's `sources[]` from these tokens, so the UI just sends the
 // raw prompt and there is no client/server gap. This is a small local mirror of
 // the codec because the server cannot import the owletto submodule.
-const PROMPT_REF_TOKEN = /@\[([a-z]+):([^:\]]*):([^\]]*)\]\(([^)\s]*)\)/g;
+// The kind group allows `_` so multi-word kinds (`entity_type`) lex. Narrowing
+// it back to [a-z]+ does not error — it just stops matching, so every
+// entity-type chip silently vanishes from the derived sources.
+const PROMPT_REF_TOKEN = /@\[([a-z_]+):([^:\]]*):([^\]]*)\]\(([^)\s]*)\)/g;
 const SQL_PATH_PREFIX = '#sql=';
 
 /** Which prompt-token kinds become a watcher source, and the `@mode` each uses.
  *  `entity` scopes the watcher (not a source); `sql` is handled separately (its
- *  query rides inline in the path). watcher/member/event never become sources. */
+ *  query rides inline in the path). watcher/member/event never become sources.
+ *
+ *  `entity_type` and `entity` are deliberately distinct kinds mapping to the
+ *  same `@entity:` mode. The source grammar's `@entity:<value>` has always
+ *  meant an entity TYPE slug (every row of that type — see the compile at
+ *  `case 'entity'`), while an `@[entity:…]` prompt chip is an entity INSTANCE
+ *  the author picked to scope the watcher. Collapsing them would send an
+ *  instance id where a type slug belongs. */
 const PROMPT_KIND_TO_MODE: Record<string, string> = {
   feed: 'feed',
   connection: 'connection',
   connector: 'connector',
   channel: 'channel',
   metric: 'metric',
+  entity_type: 'entity',
 };
 
 /** Slugify a token label into a safe output-field name. */

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -157,153 +157,21 @@ export function parseWatcherSourceRef(query: string): WatcherSourceRef | null {
 
 // ── Prompt-token extraction ────────────────────────────────────────────────
 // The owletto composer serializes a picked reference into the watcher prompt as
-// an inline token `@[kind:id:label](path)` (see owletto's src/lib/references.ts,
-// mirrored in agent-worker's lobu-refs.ts). The backend — not the frontend —
+// an inline token `@[kind:id:label](path)`. The backend — not the frontend —
 // derives the watcher's `sources[]` from these tokens, so the UI just sends the
-// raw prompt and there is no client/server gap. This is a small local mirror of
-// the codec because the server cannot import the owletto submodule.
-// The kind group allows `_` so multi-word kinds (`entity_type`) lex. Narrowing
-// it back to [a-z]+ does not error — it just stops matching, so every
-// entity-type chip silently vanishes from the derived sources.
-const PROMPT_REF_TOKEN = /@\[([a-z_]+):([^:\]]*):([^\]]*)\]\(([^)\s]*)\)/g;
-const SQL_PATH_PREFIX = '#sql=';
+// raw prompt and there is no client/server gap.
+//
+// The grammar lives in `@lobu/core/refs` and is imported by BOTH sides. It used
+// to be a hand-maintained mirror here "because the server cannot import the
+// owletto submodule" — true, and beside the point: both already depend on core.
+// Re-exported below so this module stays the server's single entry point for
+// watcher source concerns.
 
-/** Which prompt-token kinds become a watcher source, and the `@mode` each uses.
- *  `entity` scopes the watcher (not a source); `sql` is handled separately (its
- *  query rides inline in the path). watcher/member/event never become sources.
- *
- *  `entity_type` and `entity` are deliberately distinct kinds mapping to the
- *  same `@entity:` mode. The source grammar's `@entity:<value>` has always
- *  meant an entity TYPE slug (every row of that type — see the compile at
- *  `case 'entity'`), while an `@[entity:…]` prompt chip is an entity INSTANCE
- *  the author picked to scope the watcher. Collapsing them would send an
- *  instance id where a type slug belongs. */
-const PROMPT_KIND_TO_MODE: Record<string, string> = {
-  feed: 'feed',
-  connection: 'connection',
-  connector: 'connector',
-  channel: 'channel',
-  metric: 'metric',
-  entity_type: 'entity',
-};
-
-/** Slugify a token label into a safe output-field name. */
-function promptSourceSlug(value: string): string {
-  return (
-    value
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9_]+/g, '_')
-      .replace(/^_+|_+$/g, '') || 'source'
-  );
-}
-
-/**
- * Derive watcher `sources[]` from the `@`-mention tokens in a prompt. Each
- * feed/connection/connector/metric token becomes `{ name, query: '@mode:id' }`;
- * a `sql` token carries its raw query URL-encoded in the path (`#sql=…`), which
- * is decoded to the SELECT itself. Entities are excluded (they scope the
- * watcher). De-dupes by query; names are made unique with a numeric suffix.
- *
- * Returns [] for a prompt with no source tokens. Malformed tokens are skipped
- * rather than thrown — the downstream `assertWatcherSourcesResolve` is what
- * enforces that every derived source actually resolves against the org.
- */
-export function extractSourcesFromPromptTokens(prompt: string): WatcherSource[] {
-  const sources: WatcherSource[] = [];
-  const seenQuery = new Set<string>();
-  const usedNames = new Set<string>();
-
-  const push = (label: string, fallback: string, query: string) => {
-    if (seenQuery.has(query)) return;
-    seenQuery.add(query);
-    let name = promptSourceSlug(label || fallback);
-    if (usedNames.has(name)) {
-      let i = 2;
-      while (usedNames.has(`${name}_${i}`)) i += 1;
-      name = `${name}_${i}`;
-    }
-    usedNames.add(name);
-    sources.push({ name, query });
-  };
-
-  for (const m of prompt.matchAll(PROMPT_REF_TOKEN)) {
-    const [, kind, id, label, path] = m;
-    if (!kind) continue;
-    if (kind === 'sql') {
-      if (!path?.startsWith(SQL_PATH_PREFIX)) continue;
-      let query: string;
-      try {
-        query = decodeURIComponent(path.slice(SQL_PATH_PREFIX.length)).trim();
-      } catch {
-        continue;
-      }
-      if (!query) continue;
-      push(label ?? '', 'sql_source', query);
-      continue;
-    }
-    const mode = PROMPT_KIND_TO_MODE[kind];
-    if (!mode) continue;
-    const value = (id ?? '').trim();
-    if (!value) continue;
-    push(label ?? '', value, `@${mode}:${value}`);
-  }
-
-  return sources;
-}
-
-/**
- * Skill names referenced by `@[skill:<name>:<label>](…)` tokens in a prompt.
- *
- * Deliberately NOT part of `PROMPT_KIND_TO_MODE` — a skill is not a source, and
- * this does not derive anything the caller did not send. The caller supplies
- * `skills[{name, content}]` and the pinned body comes from THAT; resolving the
- * body here would re-read the live library at save time and silently upgrade a
- * pin, which is the one thing the snapshot model exists to prevent.
- *
- * De-duped, order preserved. Malformed tokens are skipped, matching
- * `extractSourcesFromPromptTokens`.
- */
-export function extractSkillNamesFromPromptTokens(prompt: string): string[] {
-  const names: string[] = [];
-  const seen = new Set<string>();
-  for (const m of prompt.matchAll(PROMPT_REF_TOKEN)) {
-    const [, kind, id] = m;
-    if (kind !== 'skill') continue;
-    const name = (id ?? '').trim();
-    if (!name || seen.has(name)) continue;
-    seen.add(name);
-    names.push(name);
-  }
-  return names;
-}
-
-/**
- * Merge prompt-derived sources into an explicit sources list, de-duping by
- * query and keeping output-field names unique. Explicit sources win (they keep
- * their names/order); prompt sources fill in the rest.
- */
-export function mergePromptSources(
-  explicit: WatcherSource[],
-  fromPrompt: WatcherSource[]
-): WatcherSource[] {
-  const merged = [...explicit];
-  const seenQuery = new Set(explicit.map((s) => s.query.trim()));
-  const usedNames = new Set(explicit.map((s) => s.name));
-  for (const src of fromPrompt) {
-    if (seenQuery.has(src.query.trim())) continue;
-    seenQuery.add(src.query.trim());
-    let name = src.name;
-    if (usedNames.has(name)) {
-      let i = 2;
-      while (usedNames.has(`${name}_${i}`)) i += 1;
-      name = `${name}_${i}`;
-    }
-    usedNames.add(name);
-    merged.push({ name, query: src.query });
-  }
-  return merged;
-}
+export {
+  behaviorSourcesFromPrompt,
+  mergePromptSources,
+  skillNamesFromPrompt,
+} from '@lobu/core/refs';
 
 export function watcherSourceKindForRef(ref: WatcherSourceRef | null): WatcherSourceKind {
   if (!ref) return 'event';

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -161,11 +161,9 @@ export function parseWatcherSourceRef(query: string): WatcherSourceRef | null {
 // derives the watcher's `sources[]` from these tokens, so the UI just sends the
 // raw prompt and there is no client/server gap.
 //
-// The grammar lives in `@lobu/core/refs` and is imported by BOTH sides. It used
-// to be a hand-maintained mirror here "because the server cannot import the
-// owletto submodule" — true, and beside the point: both already depend on core.
-// Re-exported below so this module stays the server's single entry point for
-// watcher source concerns.
+// The grammar itself lives in `@lobu/core/refs`, which both sides import — do
+// not re-derive the token regex here. Re-exported so this module stays the
+// server's single entry point for watcher source concerns.
 
 export {
   behaviorSourcesFromPrompt,


### PR DESCRIPTION
## Summary

Two ways to attach a source to a Behavior collapse into one. `@` in the instructions is
now the single authoring gesture — feed, connection, connector, metric, **entity type**,
and inline **SQL** — and the separate Sources editor leaves the create form.

Underneath, the ref-token grammar had been transcribed three times (owletto's
`lib/references.ts`, the server's `watchers/source-refs.ts`, and an inline strip-regex in
`lib/behavior-skills.ts`), kept in sync by hand on the reasoning that "the server cannot
import the owletto submodule". Both already depend on `@lobu/core`, so the grammar moves
there as `@lobu/core/refs` and the copies become re-exports.

That duplication was not theoretical. Adding the `entity_type` kind required widening the
kind group to allow `_`, and a token the regex does not match is dropped **silently** —
the caller gets `[]`, never an error. The copy that got missed lost every entity-type
chip without complaining.

## Changes

- **new** `packages/core/src/refs.ts` — the only copy of the grammar, plus the
  source-compilation helpers. Exported as `@lobu/core/refs`.
- `packages/server/src/watchers/source-refs.ts` — −149 lines, now a re-export.
- `packages/owletto` — `@` menu gains `entity_type` + SQL; `BehaviorSourcesEditor` drops
  off the create path; `vite.config.ts` registers the new subpath (see below).
- `packages/server/.../prompt-skill-tokens-pinned.test.ts` — updated for the
  `extractSkillNamesFromPromptTokens` → `skillNamesFromPrompt` rename.

## Red → green

The consolidation's headline claim is mutation-tested: narrowing the kind group from
`[a-z_]+` back to `[a-z]+` fails **6 tests**; restored and reconfirmed green.

```
$ bunx vitest run  (owletto, affected suites)
 Test Files  6 passed (6)
      Tests  86 passed (86)
```

## A dev-only break the gates could not see

`@lobu/core` ships a CommonJS `dist`. The new `refs` subpath was imported for runtime
values but not registered in owletto's `vite.config.ts`, so Vite dev served it raw over
ESM and `/behaviors/new` rendered an error page:

```
The requested module '/@fs/…/packages/core/dist/refs.js'
does not provide an export named 'REF_TOKEN'
```

Every gate is structurally blind to this class:

| gate | why it passes anyway |
|---|---|
| `tsc` | resolves `dist/refs.d.ts`, which is correct |
| `vitest` | runs in Node, where CJS → named-export interop works |
| `spa-boot-smoke` | loads the **built** bundle, where `build.commonjsOptions` already applies |

Only the dev server breaks. Caught by booting the page, not by a green typecheck. Fixed
by registering the subpath in `resolve.alias` + `optimizeDeps.include` alongside `errors`
and `reserved`, with a comment stating the rule for the next subpath.

## Submodule pointer

The owletto pointer on this branch had regressed to a commit whose base predates
`bb911798` (#2589) — merging as-is would have reverted owletto #747. Recovered with
`git merge origin/main` inside the submodule (never rebase, per the submodule rule), and
verified: `git merge-base --is-ancestor bb911798 HEAD` now passes.

Owletto PR: lobu-ai/owletto#748

## Verification

- `make pre-pr` — clean (build, typecheck, knip, biome, exposed-surface naming, gateway-llm).
- `make review-fix` — applied and reviewed; its findings are folded in.
- Booted the SPA against `app.lobu.ai` and exercised the surface in a real signed-in
  browser. Before/after proof goes on the owletto PR via `make ui-review`.

## Not verified

Integration tests were not run (no `DATABASE_URL` here), so
`resolveWatcherSourcesForSave` against a real `@entity:<slug>` chip is unverified
end-to-end.