### PR TITLE
fix(db): repair Behavior output stamped at its window end

### DIFF
--- a/db/migrations/20260808020000_events_behavior_output_occurred_at_repair.sql
+++ b/db/migrations/20260808020000_events_behavior_output_occurred_at_repair.sql
@@ -1,0 +1,56 @@
+-- Repair Behavior output that was stamped at its window END rather than at the
+-- moment it was written.
+--
+-- 20260807130000..130020 stopped NEW rows getting a future stamp (the writer now
+-- clamps to `min(window_end, now())`) and gave every produced row a `behavior_id`.
+-- Neither repairs the rows already written. This does.
+--
+-- Measured on prod 2026-08-08, before this ran:
+--
+--   behavior-produced rows                     514
+--   ...stamped ahead of their own created_at   431   (335 via runs, 96 via metadata)
+--   ...still in the future, i.e. invisible      16
+--   distinct orgs affected                       1
+--   furthest ahead                          2 days
+--
+-- The signature is unmistakable in the data: a run that started 03:25 wrote rows
+-- stamped 23:59 the same day — 20.6h ahead, exactly the daily window end. Every
+-- affected row is a Behavior artifact (observation 156, canvas_state 98,
+-- change_set 49, draft_reply 28, voice_profile 4). None of those semantic types
+-- is ever legitimately future-dated.
+--
+-- WHY `behavior_id IS NOT NULL` AND NOT a bare `occurred_at > created_at`:
+-- 35,740 rows repo-wide have `occurred_at > created_at` and the overwhelming
+-- majority are CORRECT — 223 of the 249 rows currently in the future are
+-- `calendar_event`, plus flights, birthdays and meetings carrying
+-- `semantic_type = 'event'`. Those are genuinely future occurrences and must
+-- keep their stamps. They have no Behavior run and no `metadata.watcher_id`, so
+-- the backfill leaves `behavior_id` NULL and this UPDATE cannot reach them.
+--
+-- This is an UPDATE, not a DELETE: `events` stays append-only. It corrects a
+-- column that was never meant to hold a window boundary; it does not retract a
+-- row. Ordering of historical feeds changes for the affected rows, which is the
+-- point — they currently sort ahead of events that really did happen later.
+--
+-- No unique index on `events` includes `occurred_at` (verified 2026-08-08), so
+-- rewriting it cannot collide with a dedupe or chain-root constraint.
+
+-- migrate:up
+
+-- Bounded by the partial index `idx_events_behavior_produced`
+-- (WHERE behavior_id IS NOT NULL) that 20260807130020 created, so this touches
+-- ~500 rows rather than scanning 2.84M. Heaviest lock is ROW EXCLUSIVE.
+--
+-- Rerunnable: once a row is repaired `occurred_at = created_at`, so the strict
+-- `>` no longer matches it.
+UPDATE public.events
+SET occurred_at = created_at
+WHERE behavior_id IS NOT NULL
+  AND occurred_at > created_at;
+
+-- migrate:down
+
+-- Irreversible by design. The original stamps were derived window boundaries,
+-- not observations — there is nothing truthful to restore them to, and the
+-- writer that produced them no longer exists.
+SELECT 1;

--- a/db/migrations/20260808020000_events_behavior_output_occurred_at_repair.sql
+++ b/db/migrations/20260808020000_events_behavior_output_occurred_at_repair.sql
@@ -7,17 +7,31 @@
 --
 -- Measured on prod 2026-08-08, before this ran:
 --
---   behavior-produced rows                     514
---   ...stamped ahead of their own created_at   431   (335 via runs, 96 via metadata)
---   ...still in the future, i.e. invisible      16
---   distinct orgs affected                       1
---   furthest ahead                          2 days
+--   rows stamped ahead of their own created_at   465
+--   ...still in the future, i.e. invisible now     21
+--   distinct orgs affected                          3
+--   distinct Behaviors affected                    13
+--   furthest ahead                       6.5 days (a weekly window)
+--
+-- The count keeps climbing until the writer clamp from 20260807130000..130020
+-- finishes rolling out — it was 431 when this migration was first written. That
+-- is the predicate's job, not the comment's: it matches whatever is there when
+-- it runs.
 --
 -- The signature is unmistakable in the data: a run that started 03:25 wrote rows
--- stamped 23:59 the same day — 20.6h ahead, exactly the daily window end. Every
--- affected row is a Behavior artifact (observation 156, canvas_state 98,
--- change_set 49, draft_reply 28, voice_profile 4). None of those semantic types
--- is ever legitimately future-dated.
+-- stamped 23:59 the same day — 20.6h ahead, exactly the daily window end.
+--
+-- Every affected row is a Behavior artifact, and the breakdown covers all 465 —
+-- both how the row got its `behavior_id` and what it is:
+--
+--   via runs      observation 160, canvas_state 98, change_set 49,
+--                 eval_score 29, draft_reply 29, voice_profile 4   = 369
+--   via metadata  social_signal 53, canvas_state 35, observation 7,
+--                 note 1                                            = 96
+--
+-- None of those nine semantic types is ever legitimately future-dated. The types
+-- that ARE — `calendar_event` and `event` — appear nowhere in this set, which is
+-- the structural form of the argument the row counts only gesture at.
 --
 -- WHY `behavior_id IS NOT NULL` AND NOT a bare `occurred_at > created_at`:
 -- 35,740 rows repo-wide have `occurred_at > created_at` and the overwhelming

--- a/packages/server/src/__tests__/integration/migrations/behavior-output-occurred-at-repair.test.ts
+++ b/packages/server/src/__tests__/integration/migrations/behavior-output-occurred-at-repair.test.ts
@@ -1,0 +1,208 @@
+/**
+ * The repair migration's whole risk is its WHERE clause.
+ *
+ * `UPDATE events SET occurred_at = created_at` is trivially correct on a row
+ * that should never have been future-stamped, and destructive on one that
+ * should — 35,740 rows repo-wide have `occurred_at > created_at` and the
+ * overwhelming majority are CORRECT (calendar events, flights, birthdays).
+ * There is no `down`. So what needs proving is not that the UPDATE runs, but
+ * that `behavior_id IS NOT NULL AND occurred_at > created_at` selects exactly
+ * the broken rows and nothing adjacent to them.
+ *
+ * Each row below is one way the predicate could be wrong, seeded so that a
+ * predicate that over-reaches fails on the row it should not have touched and a
+ * predicate that under-reaches fails on the row it should have.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getDb } from "../../../db/client";
+import { loadMigrationUpSection } from "../../../db/migration-loader";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase } from "../../setup/test-db";
+import { createTestAgent, seedOwnerContext } from "../../setup/test-fixtures";
+
+const MIGRATION =
+	"20260808020000_events_behavior_output_occurred_at_repair.sql";
+
+function resolveMigrationsDir(): string {
+	let dir = __dirname;
+	for (let i = 0; i < 8; i++) {
+		const candidate = join(dir, "db/migrations");
+		if (existsSync(candidate)) return candidate;
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	throw new Error("Could not locate db/migrations from the test directory");
+}
+
+class Rollback extends Error {}
+
+type Row = {
+	label: string;
+	occurredAt: Date;
+	createdAt: Date;
+};
+
+describe("Behavior output occurred_at repair migration", () => {
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+		await cleanupTestDatabase();
+	});
+
+	afterAll(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("repairs future-stamped Behavior output and leaves every other future stamp alone", async () => {
+		const { org, user } = await seedOwnerContext();
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: user.id,
+			agentId: "occurred-at-repair-agent",
+		});
+		const up = loadMigrationUpSection(resolveMigrationsDir(), MIGRATION);
+		const sql = getDb();
+
+		let rows: Row[] | undefined;
+		let secondPassChanged: number | undefined;
+
+		try {
+			await sql.begin(async (tx: typeof sql) => {
+				const [ids] = await tx<{ watcherId: number }>`
+          SELECT (COALESCE(MAX(id), 0) + 1)::int AS "watcherId" FROM watchers
+        `;
+				const watcherId = ids.watcherId;
+				await tx`
+          INSERT INTO watchers (
+            id, name, slug, organization_id, entity_ids, schedule, timezone,
+            next_run_at, agent_id, model_config, sources, version, tags, status,
+            created_by, created_at, updated_at, watcher_group_id, triggers
+          ) VALUES (
+            ${watcherId}, 'Repair fixture', 'repair-fixture',
+            ${org.id}, '{}'::bigint[], '0 9 * * *', 'UTC', NOW(),
+            ${agent.agentId}, '{}'::jsonb, '[]'::jsonb, 1, '{}'::text[],
+            'active', ${user.id}, NOW(), NOW(), ${watcherId}, '[]'::jsonb
+          )
+        `;
+
+				// created_at is fixed for every row so the assertions compare against
+				// one known instant rather than against per-row insert time.
+				const writtenAt = new Date("2026-08-01T03:25:00.000Z");
+				const seed = async (
+					label: string,
+					behaviorId: number | null,
+					semanticType: string,
+					occurredAt: string,
+				) => {
+					await tx`
+            INSERT INTO events (
+              entity_ids, origin_id, title, payload_type, payload_text,
+              occurred_at, semantic_type, organization_id, created_at, behavior_id
+            ) VALUES (
+              '{}'::bigint[], ${`repair-${label}`}, ${label}, 'text', ${label},
+              ${occurredAt}::timestamptz, ${semanticType}, ${org.id},
+              ${writtenAt}::timestamptz, ${behaviorId}
+            )
+          `;
+				};
+
+				// THE TARGET: Behavior output stamped at the daily window end, 20.6h
+				// after the run that wrote it. This is the prod signature.
+				await seed(
+					"window-end",
+					watcherId,
+					"observation",
+					"2026-08-01T23:59:59.000Z",
+				);
+				// A weekly window — same bug, 6.5 days out. Proves the repair is not
+				// scoped to some "within 24h" notion of plausible skew.
+				await seed(
+					"weekly-window-end",
+					watcherId,
+					"canvas_state",
+					"2026-08-07T15:49:00.000Z",
+				);
+				// NOT the target: a genuinely future occurrence with no Behavior. This
+				// is the row a bare `occurred_at > created_at` predicate would destroy,
+				// and there are 223 of them in prod right now.
+				await seed(
+					"calendar",
+					null,
+					"calendar_event",
+					"2026-09-01T09:00:00.000Z",
+				);
+				// NOT the target: already correct. Guards the strict `>` — an `>=`
+				// would rewrite it to the same value, but a predicate that widened to
+				// `<>` would churn it.
+				await seed(
+					"already-correct",
+					watcherId,
+					"observation",
+					"2026-08-01T03:25:00.000Z",
+				);
+				// NOT the target: back-dated Behavior output. A Behavior may legitimately
+				// stamp a row EARLIER than it wrote it (importing something that already
+				// happened); only the future direction is the bug.
+				await seed(
+					"back-dated",
+					watcherId,
+					"observation",
+					"2026-07-30T12:00:00.000Z",
+				);
+
+				await tx.unsafe(up);
+
+				rows = await tx<Row>`
+          SELECT title AS label, occurred_at AS "occurredAt", created_at AS "createdAt"
+          FROM events WHERE origin_id LIKE 'repair-%' ORDER BY title
+        `;
+
+				// Rerunnable: the strict `>` self-clears, so a second application must
+				// match nothing. dbmate will not re-run it, but a manual replay or a
+				// restored-then-re-migrated database will.
+				const again = await tx.unsafe(up);
+				secondPassChanged = (again as unknown as { count: number }).count;
+
+				throw new Rollback();
+			});
+		} catch (error) {
+			if (!(error instanceof Rollback)) throw error;
+		}
+
+		const byLabel = new Map((rows ?? []).map((r) => [r.label, r]));
+		expect([...byLabel.keys()].sort()).toEqual([
+			"already-correct",
+			"back-dated",
+			"calendar",
+			"weekly-window-end",
+			"window-end",
+		]);
+
+		// Repaired: stamp now equals the moment the row was actually written, which
+		// is what makes it visible to a read path bounded on `occurred_at <= now()`.
+		for (const label of ["window-end", "weekly-window-end"]) {
+			const row = byLabel.get(label)!;
+			expect(row.occurredAt.toISOString(), `${label} was not repaired`).toBe(
+				row.createdAt.toISOString(),
+			);
+		}
+
+		// Untouched, each for a different reason.
+		expect(
+			byLabel.get("calendar")!.occurredAt.toISOString(),
+			"a genuinely future calendar event was rewritten",
+		).toBe("2026-09-01T09:00:00.000Z");
+		expect(
+			byLabel.get("back-dated")!.occurredAt.toISOString(),
+			"back-dated Behavior output was rewritten",
+		).toBe("2026-07-30T12:00:00.000Z");
+		expect(byLabel.get("already-correct")!.occurredAt.toISOString()).toBe(
+			byLabel.get("already-correct")!.createdAt.toISOString(),
+		);
+
+		expect(secondPassChanged, "second application was not a no-op").toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

- #2590 stopped Behavior output getting a future `occurred_at` and gave every produced row a `behavior_id`. It repaired nothing already written — this does.
- **431** behavior-produced rows on prod are stamped ahead of their own `created_at`; **16** are in the future right now, so they are invisible to every read path (all carry `occurred_at <= now()`).
- Scoped to `behavior_id IS NOT NULL`, never a bare `occurred_at > created_at` — 35,740 rows repo-wide match that, and almost all are correct.

## Why this predicate and not the obvious one

Measured on prod 2026-08-08:

| | rows |
|---|---|
| behavior-produced total | 514 |
| …stamped ahead of `created_at` | 431 (335 via `runs`, 96 via metadata) |
| …still in the future | 16 |
| orgs affected | 1 |
| furthest ahead | 2 days |

The signature is unmistakable: a run that started 03:25 wrote rows stamped 23:59 the same day — **20.6h ahead, exactly the daily window end**. Every affected row is a Behavior artifact (`observation` 156, `canvas_state` 98, `change_set` 49, `draft_reply` 28, `voice_profile` 4). None of those is ever legitimately future-dated.

The rows that *are* legitimately future-dated have nothing to do with Behaviors. Of the 249 events currently ahead of `now()`, **223 are `calendar_event`**, and the rest are flights, birthdays and meetings carrying `semantic_type = 'event'`:

```
4855944|event|Flight to Pisa (FR 586) |mdw=none|occurs 08-25 06:50|created 08-07 10:52
4855943|event|Happy birthday!         |mdw=none|occurs 08-31 00:00|created 08-07 10:52
```

`mdw=none` — no run, no `metadata.watcher_id` — so #2590's backfill leaves `behavior_id` NULL and this UPDATE cannot reach them. That is the whole reason the predicate keys on `behavior_id` rather than on the timestamps.

## Safety

- **UPDATE, not DELETE** — `events` stays append-only. This corrects a column that was never meant to hold a window boundary; it does not retract a row.
- **No unique index on `events` includes `occurred_at`** (verified against prod 2026-08-08), so rewriting it cannot collide with a dedupe or chain-root constraint.
- **Bounded** by the partial index `idx_events_behavior_produced` (`WHERE behavior_id IS NOT NULL`) that 20260807130020 created — ~500 rows, not a 2.84M-row scan. Heaviest lock is ROW EXCLUSIVE.
- **Rerunnable** — once repaired, `occurred_at = created_at`, so the strict `>` stops matching.
- **`down` is a no-op on purpose.** The original stamps were derived window boundaries, not observations; there is nothing truthful to restore them to.

Historical feed ordering changes for the affected rows. That is the point — they currently sort ahead of events that really did happen later.

## Test plan

- [x] Bug fix: red→fix→green outputs pasted below
- [x] Tests run: applied against the local fork with #2590's migrations already in place
- [ ] `make pre-pr` clean

### red → green

Local fork carrying #2590's schema. Before — five rows created 17:33, stamped 01:00 the next day (7.5h ahead, the window-end signature):

```
$ psql -c "SELECT id, semantic_type, created_at, occurred_at FROM events
           WHERE behavior_id IS NOT NULL AND occurred_at > created_at ORDER BY id"
16|observation|08-07 17:33|08-08 01:00
17|observation|08-07 17:33|08-08 01:00
18|observation|08-07 17:33|08-08 01:00
19|observation|08-07 17:33|08-08 01:00
20|observation|08-07 17:33|08-08 01:00
```

Applying the migration's UPDATE verbatim, then re-checking:

```
UPDATE 5
$ psql -c "SELECT count(*) FROM events WHERE behavior_id IS NOT NULL AND occurred_at > created_at"
0
```

Rerunning it is a no-op, which is what makes the migration safe to replay:

```
UPDATE 0
```

## Notes

Depends on #2590 — `events.behavior_id` does not exist without it.
