### PR TITLE
fix(server): apply analyzed_by_behavior_id on the read paths that dropped it

### DIFF
--- a/packages/server/src/__tests__/integration/behaviors/behavior-output-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/behavior-output-visibility.test.ts
@@ -380,4 +380,67 @@ describe("A Behavior's output is visible when written and still not its own inpu
 			).not.toContain("Someone Else / LinkedIn");
 		}
 	});
+
+	// (6) THE OPPOSITE DIRECTION, ON THE SAME FOUR PATHS.
+	//
+	// `analyzed_by_behavior_id` means "linked into one of this Behavior's
+	// windows" — what it READ, not what it wrote. Two of the four builders
+	// dropped it: the chronological list path applied it only inside its
+	// classification-filter branch, and the search path never applied it. So an
+	// unqualified `?behavior=<id>` drill — which routes to the standard list
+	// branch — returned the whole org stream with a 200. The score and
+	// include-superseded builders already bound it; they are covered here so
+	// the four paths cannot drift apart again.
+	//
+	// The load-bearing assertion is the NEGATIVE one. A dropped filter returns a
+	// superset, and against real data a superset still contains the rows you
+	// expected — which is exactly why this went unnoticed. An id that matches
+	// nothing must return nothing; if it returns rows, the filter is not being
+	// applied at all.
+	it("scopes to what a Behavior analyzed on every read path", async () => {
+		await produceSignal(producerId, "Seth Rosen / X");
+
+		const countFrom = async (
+			behaviorId: number,
+			extra: Record<string, unknown>,
+		) => {
+			const result = await getContent(
+				{ analyzed_by_behavior_id: behaviorId, limit: 20, ...extra },
+				ENV,
+				ctx,
+			);
+			return result.content.length;
+		};
+
+		// Two negatives, because they fail differently. 99999 exists nowhere, so
+		// it catches a filter that was dropped outright. `bystanderId` is a REAL
+		// Behavior in the same org that simply never ran — it catches a filter
+		// that resolves to something permissive (a join that widens, an id that
+		// falls back to "any Behavior") while still looking applied.
+		const NO_SUCH_BEHAVIOR = 99999;
+
+		for (const [pathName, extra] of [
+			["list", {}],
+			// "story", not "Rosen": this filter selects what the Behavior READ, and
+			// the only row in its window is the seeded source event. "Rosen" matches
+			// the row it WROTE, so that intersection is empty for the right reason
+			// and would make this path assert nothing.
+			["search", { query: "story" }],
+			["include_superseded", { include_superseded: true, entity_id: boundEntityId }],
+			["score", { sort_by: "score", entity_id: boundEntityId }],
+		] as const) {
+			expect(
+				await countFrom(NO_SUCH_BEHAVIOR, extra),
+				`${pathName} path ignored analyzed_by_behavior_id and returned unfiltered rows`,
+			).toBe(0);
+			expect(
+				await countFrom(bystanderId, extra),
+				`${pathName} path returned rows for a Behavior that analyzed nothing`,
+			).toBe(0);
+			expect(
+				await countFrom(producerId, extra),
+				`${pathName} path lost the rows the Behavior actually analyzed`,
+			).toBeGreaterThan(0);
+		}
+	});
 });

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -34,6 +34,7 @@ import {
 } from './types';
 import { buildEntityTypesFilterClause } from './entity-types-filter';
 import {
+  buildAnalyzedByBehaviorClause,
   buildConnectionVisibilityClause,
   buildExcludeWatcherClause,
   buildOrgScopeWhere,
@@ -339,12 +340,6 @@ export async function listContentInternal(
         `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = f.id AND iwf.window_id = $${baseParams.length})`
       );
     }
-    if (options.analyzed_by_watcher_id != null) {
-      baseParams.push(options.analyzed_by_watcher_id);
-      baseConditions.push(
-        `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = f.id AND iwf.watcher_id = $${baseParams.length})`
-      );
-    }
     if (options.engagement_min != null) {
       baseParams.push(options.engagement_min);
       baseConditions.push(`f.score >= $${baseParams.length}`);
@@ -409,7 +404,12 @@ export async function listContentInternal(
       options.produced_by_behavior_id,
       paramsBeforeProduced.length + 1
     );
-    const filterParamsBeforeVisibility = [...paramsBeforeProduced, ...producedClause.params];
+    const paramsBeforeAnalyzed = [...paramsBeforeProduced, ...producedClause.params];
+    const analyzedClause = buildAnalyzedByBehaviorClause(
+      options.analyzed_by_watcher_id,
+      paramsBeforeAnalyzed.length + 1
+    );
+    const filterParamsBeforeVisibility = [...paramsBeforeAnalyzed, ...analyzedClause.params];
     const visibilityClause = buildConnectionVisibilityClause({
       organizationId: options.visibility_scope?.organizationId,
       userId: options.visibility_scope?.userId ?? null,
@@ -429,7 +429,7 @@ export async function listContentInternal(
     return executeListQuery({
       sql,
       joinSql: '',
-      whereExpr: `${whereSql} ${excludeClause.sql}${producedClause.sql} ${visibilityClause.sql}${entityTypesClause.sql} ${futureClause.sql}`,
+      whereExpr: `${whereSql} ${excludeClause.sql}${producedClause.sql}${analyzedClause.sql} ${visibilityClause.sql}${entityTypesClause.sql} ${futureClause.sql}`,
       countParams: allFilterParams,
       entityId: entityId ?? null,
       threadEntityLinkSqlForP: threadEntityLinkSql,
@@ -499,7 +499,15 @@ export async function listContentInternal(
     options.produced_by_behavior_id,
     paramsBeforeProducedFilter.length + 1
   );
-  const paramsBeforeVisibility = [...paramsBeforeProducedFilter, ...producedFilterClause.params];
+  const paramsBeforeAnalyzedFilter = [
+    ...paramsBeforeProducedFilter,
+    ...producedFilterClause.params,
+  ];
+  const analyzedFilterClause = buildAnalyzedByBehaviorClause(
+    options.analyzed_by_watcher_id,
+    paramsBeforeAnalyzedFilter.length + 1
+  );
+  const paramsBeforeVisibility = [...paramsBeforeAnalyzedFilter, ...analyzedFilterClause.params];
   const visibilityClause = buildConnectionVisibilityClause({
     organizationId: options.visibility_scope?.organizationId,
     userId: options.visibility_scope?.userId ?? null,
@@ -523,6 +531,7 @@ export async function listContentInternal(
           AND ${runCondition}
           ${excludeClause.sql}
           ${producedFilterClause.sql}
+          ${analyzedFilterClause.sql}
           ${visibilityClause.sql}
           ${orgScope.sql}${entityTypesClause.sql} ${futureClause.sql}`,
     countParams,

--- a/packages/server/src/utils/content-search/search-path.ts
+++ b/packages/server/src/utils/content-search/search-path.ts
@@ -32,6 +32,7 @@ import {
 } from './types';
 import { buildEntityTypesFilterClause } from './entity-types-filter';
 import {
+  buildAnalyzedByBehaviorClause,
   buildConnectionVisibilityClause,
   buildExcludeWatcherClause,
   buildOrgScopeWhere,
@@ -128,11 +129,16 @@ export async function searchContentBySingleQuery(
     options.produced_by_behavior_id,
     producedParamIdx
   );
+  const analyzedParamIdx = producedParamIdx + producedClause.params.length;
+  const analyzedClause = buildAnalyzedByBehaviorClause(
+    options.analyzed_by_watcher_id,
+    analyzedParamIdx
+  );
   // Connection-visibility predicate. Same helper used by every other
   // get_content branch, so authed/unauthed/private/system-event semantics
   // are guaranteed identical across the search/text-query path and the
   // chronological list path.
-  const visibilityParamIdx = producedParamIdx + producedClause.params.length;
+  const visibilityParamIdx = analyzedParamIdx + analyzedClause.params.length;
   const visibilityClause = buildConnectionVisibilityClause({
     organizationId: options.visibility_scope?.organizationId,
     userId: options.visibility_scope?.userId ?? null,
@@ -194,6 +200,7 @@ export async function searchContentBySingleQuery(
           AND ($13::text[] IS NULL OR f.metadata->>'mcp_session_id' = ANY($13::text[]))
           ${excludeClause.sql}
           ${producedClause.sql}
+          ${analyzedClause.sql}
           ${visibilityClause.sql}
           ${orgScope.sql}${entityTypesClause.sql}`;
 
@@ -507,6 +514,7 @@ export async function searchContentBySingleQuery(
     ...orgScope.params,
     ...excludeClause.params,
     ...producedClause.params,
+    ...analyzedClause.params,
     ...visibilityClause.params,
     ...entityTypesClause.params,
     ...searchEntityLinkParams,

--- a/packages/server/src/utils/content-search/visibility.ts
+++ b/packages/server/src/utils/content-search/visibility.ts
@@ -1,7 +1,7 @@
 /**
  * Visibility and org-scope WHERE clause helpers:
  * buildOrgScopeWhere, buildConnectionVisibilityClause, buildExcludeWatcherClause,
- * buildProducedByBehaviorClause.
+ * buildAnalyzedByBehaviorClause, buildProducedByBehaviorClause.
  */
 
 import { compileConnectionFkVisibility } from '../../authz/connection-visibility';
@@ -26,6 +26,34 @@ export function buildExcludeWatcherClause(
     sql: ` AND NOT EXISTS (
     SELECT 1 FROM watcher_window_events exc_iwe
     WHERE exc_iwe.event_id = f.id AND exc_iwe.watcher_id = $${baseParamIndex}::bigint
+  )`,
+    params: [validated],
+  };
+}
+
+/**
+ * Restrict to events a Behavior ANALYZED — the rows that were linked into one
+ * of its windows (`watcher_window_events`). The opposite direction to
+ * {@link buildProducedByBehaviorClause}.
+ *
+ * Shared by the two builders that had each dropped it: the chronological list
+ * path applied it only inside its classification-filter branch, and the search
+ * path never applied it at all. (The score and include-superseded builders
+ * bind their own equivalent EXISTS.) A dropped filter is worse than a rejected
+ * one: the request returns 200 with the org's ENTIRE activity stream, which
+ * looks plausible — an unqualified `?behavior=<id>` drill lands on the
+ * standard list branch, so that drill was unscoped for exactly this reason.
+ */
+export function buildAnalyzedByBehaviorClause(
+  analyzedByWatcherId: number | undefined,
+  baseParamIndex: number
+): { sql: string; params: unknown[] } {
+  if (analyzedByWatcherId === undefined) return { sql: '', params: [] };
+  const validated = validateNumericId(analyzedByWatcherId, 'analyzed_by_watcher_id');
+  return {
+    sql: ` AND EXISTS (
+    SELECT 1 FROM watcher_window_events ana_iwe
+    WHERE ana_iwe.event_id = f.id AND ana_iwe.watcher_id = $${baseParamIndex}::bigint
   )`,
     params: [validated],
   };


### PR DESCRIPTION
## Summary

- `read_knowledge` fans out to four independently assembled SQL builders. Two ignored `analyzed_by_behavior_id` entirely: the chronological list path applied it only inside its classification-filter branch, and the search path never applied it. The score and include-superseded builders bound their own equivalent `EXISTS`, so the filter looked like it worked whenever a drill happened to route through them.
- A dropped filter fails worse than a rejected one — the request returns `200` with the org's entire activity stream, and against real data a superset still contains the rows you expected. An unqualified `?behavior=<id>` drill lands on the standard list branch, so that drill was unscoped. Verified on prod 2026-08-07: `analyzed_by_behavior_id: 99999` returned the same row count as no filter at all.
- Extracts the predicate into `buildAnalyzedByBehaviorClause` next to its `produced_by` sibling and calls it from both broken builders, threading the positional param into the same slot the SQL fragment occupies.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `vitest run src/__tests__/integration/{events,behaviors,watchers,classifiers}` → **88 files / 525 tests passed**
- [x] Bug fix: red→fix→green outputs pasted below

### Red → green

Two reds, one per broken builder, because the loop short-circuits on the first failure and the list failure would otherwise hide the search path.

**Red 1 — filter dropped entirely** (`buildAnalyzedByBehaviorClause` neutered to return `{sql:'',params:[]}`, which is the `origin/main` behavior for both builders):

```
→ list path ignored analyzed_by_behavior_id and returned unfiltered rows: expected 8 to be +0
  Tests  1 failed | 6 passed (7)
```

Eight rows returned for a Behavior id that exists nowhere — the prod symptom exactly.

**Red 2 — search path only**, with the list fix left in place and the search clause replaced by an inert but param-consuming `AND ($N::bigint IS NOT NULL OR TRUE)`, so it fails on semantics rather than on parameter binding:

```
→ search path ignored analyzed_by_behavior_id and returned unfiltered rows: expected 1 to be +0
  Tests  1 failed | 6 passed (7)
```

**Green — both restored:**

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Notes

The new test asserts both directions on all four paths. The negative is the load-bearing one, and it runs twice per path against two ids that fail differently: `99999` exists nowhere and catches a filter dropped outright; `bystanderId` is a real Behavior in the same org that never ran, and catches a filter that resolves to something permissive while still looking applied. The positive assertion (`> 0`) keeps the negative from passing vacuously.

The search case queries `"story"`, not `"Rosen"`: this filter selects what a Behavior **read**, and the only row in its window is the seeded source event. `"Rosen"` matches the row it **wrote**, so that intersection is legitimately empty and would make the path assert nothing.

Follow-up, deliberately not in this branch: `packages/owletto/src/components/behaviors/behavior-detail-content.tsx:143-149` carries a comment justifying its use of `producedByBehaviorId` on the grounds that `analyzed_by_behavior_id` is dropped by the list and search paths. That component's choice stays correct; only the justification goes stale with this merge. Correcting it is a submodule pointer change and owes its own `make ui-review` proof.
