### PR TITLE
fix(examples): resolve radar staging browser via the connections SDK

### DIFF
--- a/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
+++ b/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
@@ -83,7 +83,7 @@ function clientWithRows(options: {
     source_url: string;
     metadata: typeof draftMetadata;
   }>;
-  chrome?: Array<{ id: number }>;
+  chrome?: Array<{ id: number; slug?: string; device_online?: boolean }>;
 }) {
   const queries: string[] = [];
   const notifications: Record<string, unknown>[] = [];
@@ -97,8 +97,16 @@ function clientWithRows(options: {
         return options.signals ?? [];
       if (sql.includes("behavior_output' = 'drafts"))
         return options.drafts ?? [];
-      if (sql.includes("connector_key = 'chrome'")) return options.chrome ?? [];
       throw new Error(`Unexpected query: ${sql}`);
+    },
+    connections: {
+      list: async () => ({
+        connections: (options.chrome ?? []).map((c) => ({
+          slug: "chrome-macbook",
+          device_online: true,
+          ...c,
+        })),
+      }),
     },
     notifications: {
       send: async (input: Record<string, unknown>) => {

--- a/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
+++ b/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
@@ -100,13 +100,16 @@ function clientWithRows(options: {
       throw new Error(`Unexpected query: ${sql}`);
     },
     connections: {
-      list: async () => ({
-        connections: (options.chrome ?? []).map((c) => ({
+      list: async (input?: { offset?: number; limit?: number }) => {
+        const rows = (options.chrome ?? []).map((c) => ({
           slug: "chrome-macbook",
           device_online: true,
           ...c,
-        })),
-      }),
+        }));
+        const offset = input?.offset ?? 0;
+        const limit = input?.limit ?? 50;
+        return { connections: rows.slice(offset, offset + limit) };
+      },
     },
     notifications: {
       send: async (input: Record<string, unknown>) => {
@@ -255,6 +258,38 @@ describe("social interest radar reaction", () => {
         }),
       }),
     ]);
+  });
+
+  it("pages past earlier Chrome connections to find the pinned browser", async () => {
+    const ctx = context();
+    const many = Array.from({ length: 55 }, (_, i) => ({
+      id: 1000 + i,
+      slug: `chrome-other-${i}`,
+      device_online: true,
+    }));
+    many[53] = { id: 432, slug: "chrome-macbook", device_online: true };
+    const fixture = clientWithRows({
+      drafts: [
+        {
+          id: 603,
+          payload_text: "Draft",
+          source_url: "https://x.com/ada/status/123",
+          metadata: {
+            ...draftMetadata,
+            platform: "x",
+            source_connection_id: 411,
+          },
+        },
+      ],
+      chrome: many,
+    });
+
+    await runReaction(ctx, fixture.client);
+
+    expect(fixture.operations).toHaveLength(1);
+    expect(fixture.operations[0]?.input).toMatchObject({
+      browser_connection_id: 432,
+    });
   });
 
   it("stages a persisted draft only once when the same reaction retries", async () => {

--- a/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
+++ b/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
@@ -262,12 +262,12 @@ describe("social interest radar reaction", () => {
 
   it("pages past earlier Chrome connections to find the pinned browser", async () => {
     const ctx = context();
-    const many = Array.from({ length: 55 }, (_, i) => ({
+    const many = Array.from({ length: 510 }, (_, i) => ({
       id: 1000 + i,
       slug: `chrome-other-${i}`,
       device_online: true,
     }));
-    many[53] = { id: 432, slug: "chrome-macbook", device_online: true };
+    many[503] = { id: 432, slug: "chrome-macbook", device_online: true };
     const fixture = clientWithRows({
       drafts: [
         {

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -210,21 +210,31 @@ export default async (
   // physical browser or signed-in account.
   // The connections SDK computes device online/offline server-side; raw SQL
   // cannot reach the worker liveness table (not in the queryable allowlist).
-  const listed = (await client.connections.list({
-    connector_key: "chrome",
-    status: "active",
-    limit: 20,
-  })) as {
-    connections?: Array<{
-      id?: unknown;
-      slug?: string;
-      device_online?: boolean;
-    }>;
-  };
-  const browser = (listed?.connections ?? []).find(
-    (c) => c.slug === "chrome-macbook" && c.device_online === true
-  );
-  const browserConnectionId = Number(browser?.id);
+  // Page through the list so a large org with many Chrome connections cannot
+  // push the pinned browser past the newest-20 default page.
+  let browserConnectionId = 0;
+  for (let offset = 0; offset < 500; offset += 50) {
+    const page = (await client.connections.list({
+      connector_key: "chrome",
+      status: "active",
+      limit: 50,
+      offset,
+    })) as {
+      connections?: Array<{
+        id?: unknown;
+        slug?: string;
+        device_online?: boolean;
+      }>;
+    };
+    const browser = (page?.connections ?? []).find(
+      (c) => c.slug === "chrome-macbook" && c.device_online === true
+    );
+    if (browser) {
+      browserConnectionId = Number(browser.id);
+      break;
+    }
+    if ((page?.connections?.length ?? 0) < 50) break;
+  }
   if (!Number.isSafeInteger(browserConnectionId) || browserConnectionId <= 0) {
     client.log(
       "Interactive browser 'chrome-macbook' is not online; draft event was saved but no browser was guessed."

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -208,21 +208,23 @@ export default async (
   // This is intentionally a stable, human-selected pairing slug. Never pick an
   // arbitrary online Chrome connection: that can stage a draft in the wrong
   // physical browser or signed-in account.
-  const browsers = (await client.query(
-    `SELECT c.id
-     FROM connections c
-     JOIN device_workers d
-       ON d.id = c.device_worker_id
-      AND d.organization_id = c.organization_id
-      AND d.platform = 'chrome-extension'
-      AND d.last_seen_at > now() - interval '20 minutes'
-     WHERE c.connector_key = 'chrome'
-       AND c.slug = 'chrome-macbook'
-       AND c.status = 'active'
-       AND c.deleted_at IS NULL
-     LIMIT 1`
-  )) as Array<{ id: number }>;
-  const browserConnectionId = Number(browsers[0]?.id);
+  // The connections SDK computes device online/offline server-side; raw SQL
+  // cannot reach the worker liveness table (not in the queryable allowlist).
+  const listed = (await client.connections.list({
+    connector_key: "chrome",
+    status: "active",
+    limit: 20,
+  })) as {
+    connections?: Array<{
+      id?: unknown;
+      slug?: string;
+      device_online?: boolean;
+    }>;
+  };
+  const browser = (listed?.connections ?? []).find(
+    (c) => c.slug === "chrome-macbook" && c.device_online === true
+  );
+  const browserConnectionId = Number(browser?.id);
   if (!Number.isSafeInteger(browserConnectionId) || browserConnectionId <= 0) {
     client.log(
       "Interactive browser 'chrome-macbook' is not online; draft event was saved but no browser was guessed."

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -211,9 +211,10 @@ export default async (
   // The connections SDK computes device online/offline server-side; raw SQL
   // cannot reach the worker liveness table (not in the queryable allowlist).
   // Page through the list so a large org with many Chrome connections cannot
-  // push the pinned browser past the newest-20 default page.
+  // push the pinned browser past the newest-50 default page; a short page is
+  // the only terminator, so no arbitrary bound can skip an older browser.
   let browserConnectionId = 0;
-  for (let offset = 0; offset < 500; offset += 50) {
+  for (let offset = 0; ; offset += 50) {
     const page = (await client.connections.list({
       connector_key: "chrome",
       status: "active",

--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -139,6 +139,7 @@ export interface NotificationsSendInput {
  *
  * `client.knowledge`     — read/write/search knowledge events
  * `client.entities`      — CRUD entities and relationships
+ * `client.connections`   — list/get configured connections (server-computed device liveness)
  * `client.notifications` — push a notification to the org's inbox + bot connections (Slack/Telegram)
  * `client.query`         — raw SQL (results as JSON rows)
  * `client.log`           — structured logging (appears in Behavior run logs)
@@ -176,6 +177,21 @@ export interface ReactionClient {
       offset?: number;
     }): Promise<unknown>;
     search(query: string, options?: { limit?: number }): Promise<unknown>;
+  };
+
+  connections: {
+    /** List configured connections; `device_online` is computed server-side. */
+    list(input?: {
+      connector_key?: string;
+      status?: string;
+      entity_id?: number;
+      created_by?: string;
+      connection_ids?: number[];
+      setup_attempt_id?: string;
+      limit?: number;
+      offset?: number;
+    }): Promise<unknown>;
+    get(connection_id: number): Promise<unknown>;
   };
 
   notifications: {


### PR DESCRIPTION
## Summary
- The Social Interest Radar reaction resolved its pinned `chrome-macbook` browser with raw SQL joining `device_workers`, which is **not in the queryable allowlist** — every draft-producing run threw `Unknown table 'device_workers'` right after the notification was sent, then failed all 3 retries. Drafts were saved to memory but never staged in the Mac mini Chrome.
- Replace the raw SQL with `client.connections.list({ connector_key: "chrome", status: "active" })` and select the `chrome-macbook` connection with `device_online === true` (computed server-side from the 120s liveness window).
- Same fix already deployed to live behavior 71 (its stored reaction script was edited and recompiled) — this keeps the canonical example in sync so future `lobu init` installs don't reintroduce the bug.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts` (8 pass)
- [x] Bug fix: red→fix→green outputs below

## Bug fix evidence (red → fix → green)
**Red** — reproduced the exact throw the reaction hits (same SQL through the same `client.query` path):
```
Unknown table 'device_workers' — not in the queryable allowlist, so the query did not run.
```
Confirmed zero `prepare_reply`/`prepare_comment` runs since Aug 3 despite daily drafts; the Aug 2–3 runs were manual tests (no `browser_connection_id` in input).

**Fix** — replace the SQL with the SDK path; deployed to live behavior 71 (`set_reaction_script` compiled clean, `oldSqlGone: true`, `hasNewCode: true`).

**Green** — the SDK path resolves the pinned browser from the same context:
```json
{ "resolved": { "id": 432, "slug": "chrome-macbook", "device_online": true } }
```
and the unit suite passes 8/8 with a mock `client.connections.list`.

## Notes
Full end-to-end staging (draft run → browser) is pending a draft-producing radar run (recent runs produced no draft, so the fixed path returned early as designed); the next hourly run that produces a draft will stage it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser availability detection for the social interest radar.
  * More reliably identifies active Chrome connections and confirms when the expected browser session is online.
  * Improved connection status handling to reduce errors caused by unavailable or incorrectly detected browser sessions.
* **Tests**
  * Added coverage for connection discovery, pagination, and online-status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->