### PR TITLE
fix(server): clarify Slack app-install setup guidance for external CLI users

### DIFF
--- a/packages/server/src/__tests__/unit/tools/admin/helpers/slack-self-install.test.ts
+++ b/packages/server/src/__tests__/unit/tools/admin/helpers/slack-self-install.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { buildAppInstallationSetupError } from "../../../../../tools/admin/helpers/connector-setup-errors";
 import { buildSlackSelfInstallDeepLink } from "../../../../../tools/admin/helpers/slack-self-install";
 
@@ -81,5 +81,69 @@ describe("buildAppInstallationSetupError — self_install_url gating", () => {
 			if (previous === undefined) delete process.env.SLACK_CLIENT_ID;
 			else process.env.SLACK_CLIENT_ID = previous;
 		}
+	});
+});
+
+describe("buildAppInstallationSetupError — hosted install guidance", () => {
+	const previousSlackClientId = process.env.SLACK_CLIENT_ID;
+	const hostedMethod = {
+		type: "app_installation" as const,
+		provider: "slack",
+		clientIdKey: "SLACK_CLIENT_ID",
+		installShape: "oauth-code-exchange" as const,
+		permissions: ["chat:write", "mcp:connect"],
+		events: ["app_mention"],
+	};
+	beforeEach(() => {
+		process.env.SLACK_CLIENT_ID = "client-id";
+	});
+	afterEach(() => {
+		if (previousSlackClientId === undefined) delete process.env.SLACK_CLIENT_ID;
+		else process.env.SLACK_CLIENT_ID = previousSlackClientId;
+	});
+
+	test("explains the org picker and Slack admin requirement after setup_url", () => {
+		const res = buildAppInstallationSetupError({
+			connectorKey: "slack",
+			method: hostedMethod,
+			gatewayBaseUrl: "https://gateway.test/lobu",
+			setupUrl: "https://app.lobu.ai/acme/connectors?install=slack",
+		});
+		expect(res.install_url).toBe("https://gateway.test/lobu/slack/install");
+		expect(res.setup_url).toBe(
+			"https://app.lobu.ai/acme/connectors?install=slack",
+		);
+		expect(res.error).toBe(
+			"Connector 'slack' connects by installing its Slack app into your workspace. Open setup_url to start from this Lobu organization's connectors page. After the app is installed, a Slack workspace admin/owner must choose the destination Lobu organization on the confirmation page to finish connecting it.",
+		);
+	});
+
+	test("explains the org picker after a direct install_url", () => {
+		const res = buildAppInstallationSetupError({
+			connectorKey: "slack",
+			method: hostedMethod,
+			gatewayBaseUrl: "https://gateway.test/lobu",
+		});
+		expect(res.install_url).toBe("https://gateway.test/lobu/slack/install");
+		expect(res.setup_url).toBeUndefined();
+		expect(res.error).toBe(
+			"Connector 'slack' connects by installing its Slack app into your workspace. Open install_url to install it. A Slack workspace admin/owner must then choose the destination Lobu organization on the confirmation page to finish connecting it.",
+		);
+	});
+
+	test("keeps other providers on their callback-driven install_url flow", () => {
+		const res = buildAppInstallationSetupError({
+			connectorKey: "github",
+			method: {
+				type: "app_installation",
+				provider: "github",
+				installShape: "github-app",
+			},
+			gatewayBaseUrl: "https://gateway.test/lobu",
+			setupUrl: "https://app.lobu.ai/acme/connectors?install=github",
+		});
+		expect(res.error).toBe(
+			"Connector 'github' connects by installing its github app. Open install_url to complete the installation. The provider callback creates the connection automatically when it succeeds.",
+		);
 	});
 });

--- a/packages/server/src/tools/admin/helpers/connector-setup-errors.ts
+++ b/packages/server/src/tools/admin/helpers/connector-setup-errors.ts
@@ -79,11 +79,18 @@ export function buildAppInstallationSetupError(params: {
 				})
 			: undefined;
 
-	const error = installUrl
-		? `Connector '${params.connectorKey}' is connected by installing its ${params.method.provider} app. Open install_url to install it, then retry after the installation links the connection.`
-		: selfInstallUrl
-			? `Connector '${params.connectorKey}' has no hosted ${params.method.provider} app configured on this gateway. Create your own app from self_install_url, install it into your workspace, then retry connect with the app's bot token and signing secret.`
-			: `Connector '${params.connectorKey}' requires a ${params.method.provider} app installation. Open setup_url to configure the installation, then retry.`;
+	let error: string;
+	if (installUrl && params.method.provider === "slack") {
+		error = params.setupUrl
+			? `Connector '${params.connectorKey}' connects by installing its Slack app into your workspace. Open setup_url to start from this Lobu organization's connectors page. After the app is installed, a Slack workspace admin/owner must choose the destination Lobu organization on the confirmation page to finish connecting it.`
+			: `Connector '${params.connectorKey}' connects by installing its Slack app into your workspace. Open install_url to install it. A Slack workspace admin/owner must then choose the destination Lobu organization on the confirmation page to finish connecting it.`;
+	} else if (installUrl) {
+		error = `Connector '${params.connectorKey}' connects by installing its ${params.method.provider} app. Open install_url to complete the installation. The provider callback creates the connection automatically when it succeeds.`;
+	} else if (selfInstallUrl) {
+		error = `Connector '${params.connectorKey}' has no hosted ${params.method.provider} app configured on this gateway. Create your own app from self_install_url, install it into your workspace, then retry connect with the app's bot token and signing secret.`;
+	} else {
+		error = `Connector '${params.connectorKey}' requires a ${params.method.provider} app installation. Open setup_url to configure the installation, then retry.`;
+	}
 
 	return {
 		error,


### PR DESCRIPTION
## Summary
- The Slack app-install `setup_required` continuation told external CLI users to "Open install_url … then retry" — the `install_url` is org-agnostic, there is no connect retry (the install callback creates the connection), and nothing mentioned that the connection lands in the *current org* or that only a Slack workspace admin/owner can complete the claim.
- For Slack (`installShape: oauth-code-exchange`), lead with the org-scoped `setup_url` and state the real flow: install the app into the workspace, then a Slack admin/owner picks the destination Lobu organization on the claim page.
- Non-Slack app-install providers keep accurate callback-driven guidance (no misleading "retry").

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `bun test packages/server/src/__tests__/unit/tools/admin/helpers/slack-self-install.test.ts` (7 pass), `vitest run` for `app-installation-create-guard.test.ts` (18 pass) + `connect-setup-continuation.test.ts` (14 pass)
- [x] `make review-fix` unposted fixer pass ran and was verified

## Notes
- Product context: the Slack install org is resolved by session/`?org=` at install time as a hint, then chosen by the Slack admin/owner at claim time from their own Lobu orgs — so external CLI users *can* land it in their own org; this change makes that guidance honest instead of pointing at the org-agnostic install URL and promising a retry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app installation guidance for hosted Slack connections.
  * Added clearer instructions for selecting an organization and completing setup through setup or direct installation links.
  * Preserved automatic callback guidance for other providers and fallback instructions when hosted installation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->