### PR TITLE
fix(activity): render notification source attribution

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3866,8 +3866,13 @@ export type ManageOperationsResponses = {
           interaction_status?: string;
           interaction_inline?: boolean;
           member_run_ids?: Array<number>;
+          platform?: string;
           connection_id?: number;
+          feed_id?: number;
+          feed_key?: string;
+          feed_name?: string;
           behavior_id?: number;
+          behavior_name?: string;
         }>;
         total: number;
         limit: number;

--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -416,8 +416,13 @@ export const ManageOperationsResultSchema = Type.Union([
         /** This interaction can be completed inline from the feed. */
         interaction_inline: Type.Optional(Type.Boolean()),
         member_run_ids: Type.Optional(Type.Array(Type.Integer())),
+        platform: Type.Optional(Type.String()),
         connection_id: Type.Optional(Type.Integer()),
+        feed_id: Type.Optional(Type.Integer()),
+        feed_key: Type.Optional(Type.String()),
+        feed_name: Type.Optional(Type.String()),
         behavior_id: Type.Optional(Type.Integer()),
+        behavior_name: Type.Optional(Type.String()),
       })
     ),
     total: Type.Integer(),

--- a/packages/server/src/__tests__/integration/notifications/mcp-activity-notifications.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/mcp-activity-notifications.test.ts
@@ -11,6 +11,7 @@ import {
   markAllAsRead,
   markAsRead,
 } from '../../../notifications/service';
+import { listOrgActivity } from '../../../tools/admin/manage_operations/activity-feed';
 import { notify } from '../../../tools/admin/notify';
 import { getContent } from '../../../tools/get_content';
 import type { ToolContext } from '../../../tools/registry';
@@ -410,5 +411,22 @@ describe('notification list > source attribution', () => {
     expect(item!.feed_key).toBe('home_feed');
     expect(item!.platform).toBe('attr-notif-connector');
     expect(item!.connection_id).toBe(conn.id);
+
+    const activity = await listOrgActivity({
+      organizationId: org.id,
+      userId: user.id,
+      ownerSlug: org.slug,
+      includeRuns: false,
+    });
+    const card = activity.items.find((entry) => entry.notification_id === ev.id);
+    expect(card).toMatchObject({
+      platform: 'attr-notif-connector',
+      connection_id: conn.id,
+      feed_id: feed.id,
+      feed_key: 'home_feed',
+      feed_name: 'Attr Notif Feed',
+      behavior_id: watcherId,
+      behavior_name: 'Attr Notif Behavior',
+    });
   });
 });

--- a/packages/server/src/tools/admin/manage_operations/activity-feed.ts
+++ b/packages/server/src/tools/admin/manage_operations/activity-feed.ts
@@ -86,8 +86,13 @@ export type ActivityCard = {
 	interaction_choice_field?: string;
 	interaction_choices?: Array<{ value: string; label: string }>;
 	member_run_ids?: number[];
+	platform?: string;
 	connection_id?: number;
+	feed_id?: number;
+	feed_key?: string;
+	feed_name?: string;
 	behavior_id?: number;
+	behavior_name?: string;
 };
 
 type RawCard = ActivityCard & {
@@ -413,6 +418,16 @@ export async function listOrgActivity(opts: {
 					href: resolveNotifHref(opts.ownerSlug, n),
 					unread: n.is_read === false || n.is_read === "f",
 					notification_id: Number(n.id),
+					platform: typeof n.platform === "string" ? n.platform : undefined,
+					connection_id:
+						typeof n.connection_id === "number" ? n.connection_id : undefined,
+					feed_id: typeof n.feed_id === "number" ? n.feed_id : undefined,
+					feed_key: typeof n.feed_key === "string" ? n.feed_key : undefined,
+					feed_name: typeof n.feed_name === "string" ? n.feed_name : undefined,
+					behavior_id:
+						typeof n.behavior_id === "number" ? n.behavior_id : undefined,
+					behavior_name:
+						typeof n.behavior_name === "string" ? n.behavior_name : undefined,
 					run_id: Number.isFinite(approvalRunId) ? approvalRunId : undefined,
 					interaction_type: interactionStatus != null ? interactionType : undefined,
 					interaction_status: interactionStatus,


### PR DESCRIPTION
## Summary
- carry platform, connection, feed, and Behavior attribution from notification rows into manage_operations.list_activity cards
- update the public result contract for those returned fields
- pin merged Owletto PR #751, which preserves the fields through Activity inbox rendering

## Root cause
The notification query returned attribution, but listOrgActivity dropped it. Owletto then rebuilt a synthetic NotificationItem without the same fields, so production showed only the generic Agent label.

## Verification
- targeted server attribution test: 1/1
- focused Activity inbox suite: 12/12
- make pre-pr: clean
- pre-review fixer found and repaired the missing server hop
- initial production proof on content IDs 4881475 and 4881474 confirmed event detail attribution and exposed the inbox gap