### PR TITLE
chore(owletto): ship activity onboarding

### DIFF
--- a/packages/server/src/__tests__/integration/pages/resolve-path-counts.test.ts
+++ b/packages/server/src/__tests__/integration/pages/resolve-path-counts.test.ts
@@ -101,11 +101,10 @@ describe('resolve_path workspace counts', () => {
     expect((await resolveCounts(fixture)).connections).toBe(0);
   });
 
-  it('counts MCP clients that authorized into the org, not just those registered to it', async () => {
-    // The connected-apps inventory lists a client if it is registered to the
-    // org OR holds a token in it. A count that checked only `organization_id`
-    // would under-report every client that authorized in — which is most of
-    // them, since dynamic registration leaves `organization_id` null.
+  it('counts distinct MCP apps with a live grant', async () => {
+    // The Agents page groups repeat registrations for the same app and only
+    // shows a group while at least one grant is live. The compact workspace
+    // count must use those same semantics or onboarding and the sidebar drift.
     const before = (await resolveCounts(fixture)).clients;
 
     const registered = await createTestOAuthClient({ client_name: 'Registered' });
@@ -114,15 +113,33 @@ describe('resolve_path workspace counts', () => {
       UPDATE oauth_clients SET organization_id = ${fixture.orgId}
       WHERE id = ${registered.client_id}
     `;
+    expect((await resolveCounts(fixture)).clients).toBe(before);
+
+    const first = await createTestOAuthClient({ client_name: 'Repeat app' });
+    const second = await createTestOAuthClient({ client_name: 'Repeat app' });
+    await createTestAccessToken(fixture.userId, fixture.orgId, first.client_id);
+    await createTestAccessToken(fixture.userId, fixture.orgId, second.client_id);
     expect((await resolveCounts(fixture)).clients).toBe(before + 1);
 
-    const authorized = await createTestOAuthClient({ client_name: 'Authorized' });
-    await createTestAccessToken(fixture.userId, fixture.orgId, authorized.client_id);
-    expect((await resolveCounts(fixture)).clients).toBe(before + 2);
+    // One revoked registration does not disconnect the grouped app while its
+    // sibling registration still has a live grant.
+    await sql`
+      UPDATE oauth_tokens SET revoked_at = NOW()
+      WHERE client_id = ${first.client_id}
+        AND organization_id = ${fixture.orgId}
+    `;
+    expect((await resolveCounts(fixture)).clients).toBe(before + 1);
+
+    await sql`
+      UPDATE oauth_tokens SET revoked_at = NOW()
+      WHERE client_id = ${second.client_id}
+        AND organization_id = ${fixture.orgId}
+    `;
+    expect((await resolveCounts(fixture)).clients).toBe(before);
 
     // Registered nowhere and holding no token here: not this workspace's.
     await createTestOAuthClient({ client_name: 'Stranger' });
-    expect((await resolveCounts(fixture)).clients).toBe(before + 2);
+    expect((await resolveCounts(fixture)).clients).toBe(before);
   });
 
   it('counts active behaviors', async () => {

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -1070,11 +1070,11 @@ function resolveWorkspaceCounts(
  * what makes that true — the previous split (agents/devices in one query,
  * connections/behaviors in another) paid two round trips for five scalars.
  *
- * `clients` mirrors the predicate in `OAuthClientsStore.listClientsByOrganization`
- * — registered to this org, or holding a token in it — so the number agrees
- * with the connected-apps inventory the user can actually see. Counting
- * `organization_id` alone would under-report every client that authorized in
- * without registering here.
+ * `clients` mirrors the grouped live inventory rendered by AgentsPage: a
+ * registration only counts while it has an active grant, and repeat
+ * registrations from the same named app and user collapse to one row. This
+ * keeps the sidebar count and empty-workspace onboarding aligned with what the
+ * user can actually open on the Agents page without another frontend request.
  */
 async function fetchWorkspaceCounts(
   sql: DbClient,
@@ -1106,14 +1106,26 @@ async function fetchWorkspaceCounts(
         WHERE dw.user_id = ${userId}
       ) AS devices,
       (
-        SELECT COUNT(*)::int
+        SELECT COUNT(DISTINCT CASE
+          WHEN oc.client_name IS NOT NULL AND live_owner.user_id IS NOT NULL
+            THEN 'group:' || jsonb_build_array(
+              oc.client_name,
+              live_owner.user_id,
+              ${organizationId}::text
+            )::text
+          ELSE 'client:' || oc.id
+        END)::int
         FROM oauth_clients oc
-        WHERE oc.organization_id = ${organizationId}
-           OR EXISTS (
-             SELECT 1 FROM oauth_tokens ot
-             WHERE ot.client_id = oc.id
-               AND ot.organization_id = ${organizationId}
-           )
+        JOIN LATERAL (
+          SELECT ot.user_id
+          FROM oauth_tokens ot
+          WHERE ot.client_id = oc.id
+            AND ot.organization_id = ${organizationId}
+            AND ot.revoked_at IS NULL
+            AND ot.expires_at > NOW()
+          ORDER BY ot.created_at DESC, ot.id DESC
+          LIMIT 1
+        ) live_owner ON true
       ) AS clients
   `;
   const counts = row as Partial<Record<keyof WorkspaceCounts, number>> | undefined;


### PR DESCRIPTION
## Summary

- ship the empty-workspace onboarding and sidebar consistency work from Owletto #752
- ship the failed-attention-count correction from Owletto #755
- keep the existing bounded resolve_path query but make its client count match the Agents page: distinct app groups with live grants only
- avoid any additional frontend inventory request

## Test plan

- [x] `make pre-pr` clean on the final head (all six gates)
- [x] Full Owletto suite: 150 files, 1,285 tests passed
- [x] Focused sidebar regression: 18 tests passed
- [x] Focused resolve_path integration: 4 tests passed with embedded Postgres
- [x] Red to green: failed attention request previously rendered Activity 0
- [x] Red to green: revoked and duplicate registrations previously inflated the connected-agent count
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval (not applicable)

## Notes

- audited /local-install, /events, /connectors, /connectors/create, /agents, /behaviors, and /memory in the empty-workspace state
- current Owletto pin: e7e4873c496773101192a819f2b5aa5b8c06789d
- the mandatory independent review was run with Pi first (quota exhausted) and then Codex; Claude was not run
