### PR TITLE
fix(mac): ship durable device connectivity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
@@ -58,7 +58,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -143,7 +143,7 @@
     },
     "packages/client": {
       "name": "@lobu/client",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -152,7 +152,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -176,7 +176,7 @@
     },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
@@ -211,7 +211,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -232,7 +232,7 @@
     },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "dependencies": {
         "@hono/node-server": "^2.0.11",
         "@xenova/transformers": "^2.17.2",
@@ -266,6 +266,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@lobu/connector-sdk": "workspace:*",
         "@lobu/core": "workspace:*",
+        "@modelcontextprotocol/ext-apps": "^1.7.5",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -336,7 +337,7 @@
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -344,7 +345,7 @@
     },
     "packages/plugin-api": {
       "name": "@lobu/plugin-api",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.41",
       },
@@ -369,7 +370,7 @@
     },
     "packages/plugin-host": {
       "name": "@lobu/plugin-host",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "dependencies": {
         "@lobu/plugin-api": "workspace:*",
       },
@@ -438,7 +439,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "14.7.0",
+      "version": "14.18.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",
@@ -1201,6 +1202,8 @@
     "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@1.7.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 


### PR DESCRIPTION
## Summary
- advance the Owletto submodule to merged [owletto#753](https://github.com/lobu-ai/owletto/pull/753)
- pin the Mac device connection independently from CLI currentContext
- keep auth recovery alive and keep idle heartbeats inside the server liveness window
- preserve the existing worker ID for the migrated account, while separating other server accounts

## Verification
- Owletto: 17 standalone Swift suites passed
- Owletto: focused device profile tests passed after rebase
- Owletto: full Debug macOS app build passed
- Lobu: make pre-pr passed
- parent pin exactly matches owletto/main at cb8750b19d326bc72c0e7896be3235ec6219ecb2

## Incident mechanism
An unrelated CLI/worktree context switch silently moved the unattended Mac worker to another account. The selected context briefly had no credentials, and the app invalidated the only timer that could observe recovery. A separate 10-minute idle cadence also exceeded the server 120-second online window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the embedded Owletto component to a newer version.
  * No user-facing feature or behavior changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->