### PR TITLE
feat(mcp): add secure Apps rendering support

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -115,7 +115,7 @@ describe('MCP Authentication', () => {
       expect(response.status).toBe(401);
       const challenge = response.headers.get('WWW-Authenticate');
       expect(challenge).toContain(
-        `resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp/${publicOrg.slug}"`
+        'resource_metadata="http://localhost/.well-known/oauth-protected-resource"'
       );
       expect(challenge).not.toContain('realm=');
     });

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -75,9 +75,11 @@ describe('MCP Authentication', () => {
       });
 
       expect(response.status).toBe(401);
-      expect(response.headers.get('WWW-Authenticate')).toContain(
-        '/.well-known/oauth-protected-resource'
+      const challenge = response.headers.get('WWW-Authenticate');
+      expect(challenge).toContain(
+        'resource_metadata="http://localhost/.well-known/oauth-protected-resource"'
       );
+      expect(challenge).not.toContain('realm=');
     });
 
     // SKIP: post-#438 the unscoped /mcp endpoint refuses ALL anonymous POSTs
@@ -111,9 +113,11 @@ describe('MCP Authentication', () => {
       });
 
       expect(response.status).toBe(401);
-      expect(response.headers.get('WWW-Authenticate')).toContain(
-        '/.well-known/oauth-protected-resource'
+      const challenge = response.headers.get('WWW-Authenticate');
+      expect(challenge).toContain(
+        `resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp/${publicOrg.slug}"`
       );
+      expect(challenge).not.toContain('realm=');
     });
 
     // SKIP: post-#438 unscoped /mcp anonymous initialize returns 401 with no
@@ -1084,7 +1088,15 @@ describe('MCP Authentication', () => {
       // via REST and tools/call by name but are not advertised here.
       const toolNames = result.tools.map((t: any) => t.name);
       expect(toolNames.sort()).toEqual(
-        ['query_sdk', 'query_sql', 'run_sdk', 'save_memory', 'search_memory', 'search_sdk'].sort()
+        [
+          'query_sdk',
+          'query_sql',
+          'render_lobu_view',
+          'run_sdk',
+          'save_memory',
+          'search_memory',
+          'search_sdk',
+        ].sort()
       );
       expect(toolNames).not.toContain('list_organizations');
       expect(toolNames).not.toContain('list_metrics');

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -73,7 +73,8 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
   async function initSession(
     path: string,
     sessionToken = token,
-    agentId?: string
+    agentId?: string,
+    forwardedHeaders: Record<string, string> = {}
   ): Promise<string> {
     const initResponse = await post(path, {
       body: {
@@ -86,13 +87,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
           clientInfo: { name: 'lobu-test', version: '1.0', ...(agentId ? { agentId } : {}) },
         },
       },
+      headers: forwardedHeaders,
       token: sessionToken,
     });
     const sessionId = initResponse.headers.get('mcp-session-id');
     expect(sessionId).toBeTruthy();
     await post(path, {
       body: { jsonrpc: '2.0', method: 'notifications/initialized' },
-      headers: { 'mcp-session-id': sessionId! },
+      headers: { ...forwardedHeaders, 'mcp-session-id': sessionId! },
       token: sessionToken,
     });
     return sessionId!;
@@ -123,9 +125,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         prefersBorder: true,
       })
     );
+    expect(content?._meta?.ui?.domain).toBeUndefined();
   });
 
-  it('advertises description, csp, and domain metadata on resources/list', async () => {
+  it('advertises description and restrictive CSP metadata on resources/list', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
@@ -151,7 +154,8 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     // structured CSP asks the MCP Apps host to apply its restrictive default.
     expect(resource._meta?.ui?.csp).toEqual({});
     expect(resource._meta?.ui?.prefersBorder).toBe(true);
-    expect(resource._meta?.ui?.domain).toMatch(/^https?:\/\//);
+    // Omit ui.domain so the host supplies its isolated default sandbox origin.
+    expect(resource._meta?.ui?.domain).toBeUndefined();
   });
 
   it('advertises a decoupled render tool with UI, OAuth, and safety metadata', async () => {
@@ -366,13 +370,75 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text).toBe(`Approval run ${runId} was not found`);
   });
 
+  it('bounds and redacts server-authored approval fields', async () => {
+    const [run] = await getDb()<{ id: number }>`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status, connector_key, action_key
+      ) VALUES (
+        ${org.id}, 'action', 'pending', 'pending', 'github', 'create_issue'
+      )
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    const fields = Object.fromEntries([
+      ['apiKey', 'top-secret-value'],
+      ...Array.from({ length: 100 }, (_, index) => [`field_${index}`, `value_${index}`]),
+    ]);
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `mcp_app_bounded_approval_${runId}`,
+      title: `${'A'.repeat(220)} — pending approval`,
+      content: 'Review this issue.',
+      semanticType: 'operation',
+      connectorKey: 'github',
+      runId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+      metadata: { fields },
+    });
+
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 212,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: { action: 'review_approval', run_id: runId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const body = await response.json();
+    const view = body.result?.structuredContent;
+    expect(body.result?.isError).not.toBe(true);
+    expect(view?.title).toHaveLength(200);
+    expect(view?.blocks?.[0]?.fields).toHaveLength(100);
+    expect(view?.blocks?.[0]?.fields?.[0]).toEqual({
+      label: 'apiKey',
+      after: '[redacted]',
+    });
+  });
+
   it('returns an MCP reauthorization challenge for a tool-level scope failure', async () => {
     const readlessToken = (
       await createTestAccessToken(owner.id, org.id, client.client_id, {
         scope: 'profile:read',
       })
     ).token;
-    const sessionId = await initSession(`/mcp/${org.slug}`, readlessToken);
+    const forwardedHeaders = {
+      'x-forwarded-host': 'lobu.ai',
+      'x-forwarded-proto': 'https',
+    };
+    const sessionId = await initSession(
+      `/mcp/${org.slug}`,
+      readlessToken,
+      undefined,
+      forwardedHeaders
+    );
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
@@ -386,13 +452,13 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
           },
         },
       },
-      headers: { 'mcp-session-id': sessionId },
+      headers: { ...forwardedHeaders, 'mcp-session-id': sessionId },
       token: readlessToken,
     });
     const body = await response.json();
     expect(body.result?.isError).toBe(true);
     expect(body.result?._meta?.['mcp/www_authenticate']?.[0]).toContain(
-      `resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp/${org.slug}"`
+      `resource_metadata="https://lobu.ai/.well-known/oauth-protected-resource/mcp/${org.slug}"`
     );
     expect(body.result?._meta?.['mcp/www_authenticate']?.[0]).toContain(
       'error="insufficient_scope"'

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -2,10 +2,14 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { insertEvent } from '../../../utils/insert-event';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
   addUserToOrganization,
   createTestAccessToken,
+  createTestAgent,
+  createTestConnection,
   createTestOAuthClient,
   createTestOrganization,
   createTestUser,
@@ -21,6 +25,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
   let owner: Awaited<ReturnType<typeof createTestUser>>;
   let client: Awaited<ReturnType<typeof createTestOAuthClient>>;
+  let actingAgent: Awaited<ReturnType<typeof createTestAgent>>;
   let token: string;
   let tmpRoot: string;
   const prevWebDist = process.env.WEB_DIST_DIR;
@@ -46,6 +51,11 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     org = await createTestOrganization({ name: 'MCP App Org', slug: 'mcp-app-org' });
     owner = await createTestUser({ email: 'mcp-app-owner@test.example.com' });
     await addUserToOrganization(owner.id, org.id, 'owner');
+    actingAgent = await createTestAgent({
+      organizationId: org.id,
+      ownerId: owner.id,
+      agentId: 'mcp-app-render-agent',
+    });
     client = await createTestOAuthClient();
     token = (
       await createTestAccessToken(owner.id, org.id, client.client_id, {
@@ -60,7 +70,11 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  async function initSession(path: string): Promise<string> {
+  async function initSession(
+    path: string,
+    sessionToken = token,
+    agentId?: string
+  ): Promise<string> {
     const initResponse = await post(path, {
       body: {
         jsonrpc: '2.0',
@@ -69,17 +83,17 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         params: {
           protocolVersion: '2025-03-26',
           capabilities: {},
-          clientInfo: { name: 'lobu-test', version: '1.0' },
+          clientInfo: { name: 'lobu-test', version: '1.0', ...(agentId ? { agentId } : {}) },
         },
       },
-      token,
+      token: sessionToken,
     });
     const sessionId = initResponse.headers.get('mcp-session-id');
     expect(sessionId).toBeTruthy();
     await post(path, {
       body: { jsonrpc: '2.0', method: 'notifications/initialized' },
       headers: { 'mcp-session-id': sessionId! },
-      token,
+      token: sessionToken,
     });
     return sessionId!;
   }
@@ -91,7 +105,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction' },
+        params: { uri: 'ui://lobu/interaction/v1' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -100,9 +114,15 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction');
-    expect(content?.mimeType).toBe('text/html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v1');
+    expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-interaction-stub');
+    expect(content?._meta?.ui).toEqual(
+      expect.objectContaining({
+        csp: {},
+        prefersBorder: true,
+      })
+    );
   });
 
   it('advertises description, csp, and domain metadata on resources/list', async () => {
@@ -120,19 +140,104 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v1'
     );
     expect(resource).toBeDefined();
     // description is a typed resource field surfaced in client browsers.
     expect(typeof resource.description).toBe('string');
     expect(resource.description.length).toBeGreaterThan(0);
-    // CSP + domain ride the _meta.ui passthrough (host conventions, SDK $loose).
-    expect(resource._meta?.ui?.csp).toMatch(/script-src/);
+    expect(resource.mimeType).toBe('text/html;profile=mcp-app');
+    // This bundle is self-contained and performs no network requests. An empty
+    // structured CSP asks the MCP Apps host to apply its restrictive default.
+    expect(resource._meta?.ui?.csp).toEqual({});
+    expect(resource._meta?.ui?.prefersBorder).toBe(true);
     expect(resource._meta?.ui?.domain).toMatch(/^https?:\/\//);
   });
 
-  it('returns a pending manage_agents approval as plain text, without tool-result _meta', async () => {
+  it('advertises a decoupled render tool with UI, OAuth, and safety metadata', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: { jsonrpc: '2.0', id: 11, method: 'tools/list' },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const renderTool = body.result?.tools?.find(
+      (tool: { name: string }) => tool.name === 'render_lobu_view'
+    );
+    expect(renderTool).toEqual(
+      expect.objectContaining({
+        annotations: expect.objectContaining({
+          readOnlyHint: true,
+          destructiveHint: false,
+          openWorldHint: false,
+          idempotentHint: true,
+        }),
+        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
+        _meta: expect.objectContaining({
+          securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
+          ui: expect.objectContaining({
+            resourceUri: 'ui://lobu/interaction/v1',
+            visibility: ['model', 'app'],
+          }),
+          'openai/outputTemplate': 'ui://lobu/interaction/v1',
+        }),
+      })
+    );
+
+    for (const tool of body.result?.tools ?? []) {
+      expect(tool.securitySchemes?.[0]?.type).toBe('oauth2');
+      expect(tool.annotations?.readOnlyHint).toEqual(expect.any(Boolean));
+      expect(tool.annotations?.destructiveHint).toEqual(expect.any(Boolean));
+      expect(tool.annotations?.openWorldHint).toEqual(expect.any(Boolean));
+    }
+  });
+
+  it('returns a validated LobuViewV1 with a text fallback from render_lobu_view', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 12,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: {
+            action: 'render',
+            title: 'Release readiness',
+            tone: 'default',
+            blocks: [
+              { type: 'text', label: 'Status', value: 'Ready for review.' },
+              { type: 'code', value: 'sha: 1234abcd' },
+            ],
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    expect(body.result?.structuredContent).toEqual({
+      version: 1,
+      title: 'Release readiness',
+      tone: 'default',
+      blocks: [
+        { type: 'text', label: 'Status', value: 'Ready for review.' },
+        { type: 'code', value: 'sha: 1234abcd' },
+      ],
+      actions: [],
+    });
+    expect(body.result?.content?.[0]?.text).toContain('Release readiness');
+    expect(body.result?.content?.[0]?.text).toContain('Ready for review\\.');
+  });
+
+  it('keeps an approval tool result text-only and renders a safe Lobu review link separately', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`, token, actingAgent.agentId);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
@@ -154,15 +259,147 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.result?.isError).not.toBe(true);
-    // The pending approval still returns its text result, but the tool result no
-    // longer carries an MCP App UI pointer: our own SPA builds the interaction
-    // view CLIENT-side from the SSE card payload, and external-host rendering
-    // (which needs the SERVER to author that view) is a deliberate follow-up.
-    // Assert the pointer is absent so we don't silently re-introduce a `_meta`
-    // that points a host at a bundle it can't feed from raw data.
+    // The mutating tool is not coupled to UI. A separate read-only render call
+    // authors the review view, so model data selection and presentation remain
+    // decoupled and text-only clients still see the pending result.
     expect(body.result?._meta?.ui).toBeUndefined();
     expect(body.result?.structuredContent).toBeUndefined();
-    expect(typeof body.result?.content?.[0]?.text).toBe('string');
+    const text = body.result?.content?.[0]?.text;
+    expect(typeof text).toBe('string');
+    const [approval] = await getDb()<{ run_id: number }>`
+      SELECT run_id
+      FROM current_event_records
+      WHERE organization_id = ${org.id}
+        AND interaction_type = 'approval'
+        AND run_id IS NOT NULL
+      ORDER BY id DESC
+      LIMIT 1
+    `;
+    const runId = Number(approval?.run_id);
+    expect(runId).toBeGreaterThan(0);
+
+    const renderResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 21,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: { action: 'review_approval', run_id: runId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const renderBody = await renderResponse.json();
+    const view = renderBody.result?.structuredContent;
+    expect(view?.version).toBe(1);
+    expect(view?.tone).toBe('warning');
+    expect(view?.actions).toEqual([
+      expect.objectContaining({
+        id: 'review',
+        label: 'Review in Lobu',
+        href: expect.stringMatching(/^https?:\/\//),
+      }),
+    ]);
+    expect(view?.actions?.some((action: { id?: string }) => action.id === 'approve')).toBe(false);
+    expect(view?.actions?.some((action: { id?: string }) => action.id === 'reject')).toBe(false);
+  });
+
+  it('does not render an approval from another member private connection', async () => {
+    const member = await createTestUser({ email: 'mcp-app-member@test.example.com' });
+    await addUserToOrganization(member.id, org.id, 'member');
+    const memberToken = (
+      await createTestAccessToken(member.id, org.id, client.client_id, {
+        scope: 'mcp:read profile:read',
+      })
+    ).token;
+    const privateConnection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      created_by: owner.id,
+      visibility: 'private',
+      createDefaultFeed: false,
+    });
+    const [run] = await getDb()<{ id: number }>`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status, connection_id,
+        connector_key, action_key
+      ) VALUES (
+        ${org.id}, 'action', 'pending', 'pending', ${privateConnection.id},
+        'github', 'create_issue'
+      )
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `mcp_app_private_approval_${runId}`,
+      title: 'Private action — pending approval',
+      content: 'This approval must remain private to the connection owner.',
+      semanticType: 'operation',
+      connectorKey: 'github',
+      connectionId: privateConnection.id,
+      runId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+    });
+
+    const sessionId = await initSession(`/mcp/${org.slug}`, memberToken);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 211,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: { action: 'review_approval', run_id: runId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token: memberToken,
+    });
+    const body = await response.json();
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.structuredContent).toBeUndefined();
+    expect(body.result?.content?.[0]?.text).toBe(`Approval run ${runId} was not found`);
+  });
+
+  it('returns an MCP reauthorization challenge for a tool-level scope failure', async () => {
+    const readlessToken = (
+      await createTestAccessToken(owner.id, org.id, client.client_id, {
+        scope: 'profile:read',
+      })
+    ).token;
+    const sessionId = await initSession(`/mcp/${org.slug}`, readlessToken);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 22,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: {
+            action: 'render',
+            blocks: [{ type: 'text', value: 'scope probe' }],
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token: readlessToken,
+    });
+    const body = await response.json();
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?._meta?.['mcp/www_authenticate']?.[0]).toContain(
+      `resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp/${org.slug}"`
+    );
+    expect(body.result?._meta?.['mcp/www_authenticate']?.[0]).toContain(
+      'error="insufficient_scope"'
+    );
+    expect(body.result?._meta?.['mcp/www_authenticate']?.[0]).toContain(
+      'scope="mcp:read"'
+    );
   });
 
   it('emits structuredContent for a tool that declares an outputSchema', async () => {

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -423,6 +423,118 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     });
   });
 
+  it('renders producer-authored Behavior fields instead of its execution envelope', async () => {
+    const [run] = await getDb()<{ id: number }>`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status, action_key
+      ) VALUES (
+        ${org.id}, 'internal', 'pending', 'pending', 'manage_behaviors'
+      )
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `mcp_app_behavior_approval_${runId}`,
+      title: 'Update Behavior — pending approval',
+      content: 'Builder requested: Update Behavior',
+      semanticType: 'operation',
+      runId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+      interactionInput: { name: 'New name', reaction_script: '' },
+      metadata: {
+        tool: 'manage_behaviors',
+        current: { name: 'Old name', reaction_script: 'return true;' },
+        proposal: {
+          args: {
+            action: 'update',
+            behavior_id: 71,
+            name: 'New name',
+            reaction_script: '',
+          },
+          actingAgentId: 'internal-agent-id',
+          actingWatcherId: '71',
+        },
+      },
+    });
+
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 213,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: { action: 'review_approval', run_id: runId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const body = await response.json();
+    const fields = body.result?.structuredContent?.blocks?.[0]?.fields;
+    expect(body.result?.isError).not.toBe(true);
+    expect(fields).toEqual([
+      { label: 'name', before: 'Old name', after: 'New name' },
+      { label: 'reaction_script', before: 'return true;', after: '' },
+    ]);
+    expect(fields?.map((field: { label: string }) => field.label)).not.toEqual(
+      expect.arrayContaining(['args', 'actingAgentId', 'actingWatcherId'])
+    );
+    expect(body.result?.content?.[0]?.text).toContain('return true; → ""');
+  });
+
+  it('keeps explicit null distinct from an empty string in approval diffs', async () => {
+    const [run] = await getDb()<{ id: number }>`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status, connector_key, action_key
+      ) VALUES (
+        ${org.id}, 'action', 'pending', 'pending', 'github', 'update_issue'
+      )
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `mcp_app_null_approval_${runId}`,
+      title: 'Update issue — pending approval',
+      content: 'Review this issue update.',
+      semanticType: 'operation',
+      connectorKey: 'github',
+      runId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+      interactionInput: { cleared: null, emptied: '' },
+      metadata: { current: { cleared: 'before', emptied: 'before' } },
+    });
+
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 214,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: { action: 'review_approval', run_id: runId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const body = await response.json();
+    expect(body.result?.structuredContent?.blocks?.[0]?.fields).toEqual([
+      { label: 'cleared', before: 'before', after: 'null' },
+      { label: 'emptied', before: 'before', after: '' },
+    ]);
+    expect(body.result?.content?.[0]?.text).toContain('before → null');
+    expect(body.result?.content?.[0]?.text).toContain('before → ""');
+  });
+
   it('returns an MCP reauthorization challenge for a tool-level scope failure', async () => {
     const readlessToken = (
       await createTestAccessToken(owner.id, org.id, client.client_id, {

--- a/packages/server/src/__tests__/integration/public-rest-transport.test.ts
+++ b/packages/server/src/__tests__/integration/public-rest-transport.test.ts
@@ -5,9 +5,8 @@
  * `POST /api/{org}/manage_operations {"action":"list_runs"}` served the same
  * rows anonymously — same data, two doors, opposite answers.
  *
- * These tests pin the boundary itself: which requests `mcpAuth` lets reach a
- * handler at all. They deliberately do NOT exercise the tools; whether the
- * handler then returns rows is `executeTool`'s second gate, covered elsewhere.
+ * These tests pin both transport gates: which requests `mcpAuth` admits and
+ * which registered tools the generic REST dispatcher may execute.
  */
 
 import { Hono } from "hono";
@@ -15,6 +14,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { mcpAuth } from "../../auth/middleware";
 import { REST_TOOL_GET_ROUTES } from "../../http/rest-tool-routes";
 import type { Env } from "../../index";
+import { restToolProxy } from "../../rest-api";
 import { initWorkspaceProvider } from "../../workspace";
 import { clearMultiTenantCachesForTests } from "../../workspace/multi-tenant-caches";
 import { cleanupTestDatabase } from "../setup/test-db";
@@ -176,5 +176,27 @@ describe("public-org REST transport parity", () => {
 				action: "list",
 			})
 		).toBe(401);
+	});
+
+	it("rejects the MCP-only render tool at the generic REST execution route", async () => {
+		const proxyApp = new Hono<{ Bindings: Env }>();
+		proxyApp.post("/api/:orgSlug/:toolName", (c) => restToolProxy(c));
+		const res = await proxyApp.request(
+			"/api/test-org/render_lobu_view",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					action: "render",
+					blocks: [{ type: "text", value: "must stay MCP-only" }],
+				}),
+			},
+			testEnv
+		);
+
+		expect({ status: res.status, body: await res.json() }).toEqual({
+			status: 404,
+			body: { error: "Tool not found: render_lobu_view" },
+		});
 	});
 });

--- a/packages/server/src/__tests__/unit/markdown-lobu-view.test.ts
+++ b/packages/server/src/__tests__/unit/markdown-lobu-view.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test';
+import { formatToolResult } from '../../formatting/markdown-formatter';
+
+describe('render_lobu_view text fallback', () => {
+  it('renders model-selected text literally instead of activating injected markdown', () => {
+    const markdown = formatToolResult('render_lobu_view', {
+      version: 1,
+      title: 'Review [this](https://evil.example)',
+      blocks: [
+        {
+          type: 'text',
+          label: 'Status',
+          value: '[Open attacker site](javascript:alert(1))',
+        },
+        {
+          type: 'diff',
+          fields: [{ label: 'name', before: '**trusted**', after: '<script>bad()</script>' }],
+        },
+      ],
+      actions: [
+        { id: 'bad', label: 'Bad', href: 'javascript:alert(1)' },
+        { id: 'good', label: 'Review', href: 'https://lobu.ai/example/runs/1' },
+      ],
+    });
+
+    expect(markdown).toContain('Review \\[this\\]\\(https://evil\\.example\\)');
+    expect(markdown).toContain('\\[Open attacker site\\]\\(javascript:alert\\(1\\)\\)');
+    expect(markdown).toContain('\\<script\\>bad\\(\\)\\</script\\>');
+    expect(markdown).not.toContain('[Bad](javascript:');
+    expect(markdown).toContain('[Review](https://lobu.ai/example/runs/1)');
+  });
+
+  it('uses a longer code fence when the code contains backticks', () => {
+    const markdown = formatToolResult('render_lobu_view', {
+      version: 1,
+      blocks: [{ type: 'code', value: 'before\n```\nafter' }],
+      actions: [],
+    });
+
+    expect(markdown).toBe('````\nbefore\n```\nafter\n````');
+  });
+});

--- a/packages/server/src/__tests__/unit/markdown-lobu-view.test.ts
+++ b/packages/server/src/__tests__/unit/markdown-lobu-view.test.ts
@@ -39,4 +39,25 @@ describe('render_lobu_view text fallback', () => {
 
     expect(markdown).toBe('````\nbefore\n```\nafter\n````');
   });
+
+  it('distinguishes an empty diff value from a missing value', () => {
+    const markdown = formatToolResult('render_lobu_view', {
+      version: 1,
+      blocks: [
+        {
+          type: 'diff',
+          fields: [
+            { label: 'cleared', before: 'present', after: '' },
+            { label: 'created', after: '' },
+            { label: 'missing', before: 'present' },
+          ],
+        },
+      ],
+      actions: [],
+    });
+
+    expect(markdown).toContain('**cleared**: present → ""');
+    expect(markdown).toContain('**created**: ""');
+    expect(markdown).toContain('**missing**: present → —');
+  });
 });

--- a/packages/server/src/__tests__/unit/mcp-app-render.test.ts
+++ b/packages/server/src/__tests__/unit/mcp-app-render.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import type { Env } from "../../index";
+import { renderLobuView } from "../../tools/mcp_app";
+import type { ToolContext } from "../../tools/registry";
+
+describe("render_lobu_view secure display boundary", () => {
+	it("redacts credential-shaped text from model-selected blocks", async () => {
+		const view = await renderLobuView(
+			{
+				action: "render",
+				blocks: [
+					{ type: "text", value: "Authorization: Bearer abcdefghijklmnop" },
+					{ type: "code", value: "client_secret=super-secret-value" },
+					{ type: "text", value: "ghp_abcdefghijklmnop" },
+				],
+			},
+			{} as Env,
+			{} as ToolContext,
+		);
+
+		expect(view.blocks).toEqual([
+			{ type: "text", value: "Authorization=[redacted]" },
+			{ type: "code", value: "client_secret=[redacted]" },
+			{ type: "text", value: "[redacted]" },
+		]);
+	});
+});

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -10,6 +10,7 @@ import {
 	getMcpTools,
 	getTool,
 	isInternalDispatchTool,
+	isRestDispatchTool,
 } from "../../tools/registry";
 
 /** Agent MCP flat tools (excluding meta scripting/discovery) → SDK dotted path. */
@@ -80,6 +81,8 @@ describe("tool registry split", () => {
 		// The render helper is MCP-only and deliberately does not expand the
 		// ClientSDK/REST agent surface.
 		expect(AGENT_TOOL_NAMES.size).toBe(6);
+		expect(isRestDispatchTool("render_lobu_view")).toBe(false);
+		expect(isRestDispatchTool("search_memory")).toBe(true);
 	});
 
 	it("maps internal flat tools to ClientSDK methods for run_sdk/query_sdk parity", () => {

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -70,12 +70,15 @@ describe("tool registry split", () => {
 			[
 				"query_sdk",
 				"query_sql",
+				"render_lobu_view",
 				"run_sdk",
 				"save_memory",
 				"search_memory",
 				"search_sdk",
 			].sort()
 		);
+		// The render helper is MCP-only and deliberately does not expand the
+		// ClientSDK/REST agent surface.
 		expect(AGENT_TOOL_NAMES.size).toBe(6);
 	});
 

--- a/packages/server/src/auth/oauth/__tests__/resource-challenge.test.ts
+++ b/packages/server/src/auth/oauth/__tests__/resource-challenge.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBearerChallenge,
+  protectedResourceMetadataUrl,
+} from '../resource-challenge';
+
+describe('MCP OAuth resource challenges', () => {
+  it('uses the actual serving origin instead of PUBLIC_GATEWAY_URL', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+    const request = new Request('https://internal.invalid/mcp', {
+      headers: {
+        host: 'lobu.ai',
+        'x-forwarded-host': 'lobu.ai',
+        'x-forwarded-proto': 'https',
+      },
+    });
+
+    expect(protectedResourceMetadataUrl(request)).toBe(
+      'https://lobu.ai/.well-known/oauth-protected-resource'
+    );
+    expect(buildBearerChallenge(request)).toBe(
+      'Bearer resource_metadata="https://lobu.ai/.well-known/oauth-protected-resource"'
+    );
+  });
+
+  it('advertises path-specific metadata for a scoped MCP resource', () => {
+    const request = new Request('https://lobu.ai/mcp/acme');
+    expect(protectedResourceMetadataUrl(request)).toBe(
+      'https://lobu.ai/.well-known/oauth-protected-resource/mcp/acme'
+    );
+    expect(
+      buildBearerChallenge(request, {
+        error: 'invalid_token',
+        errorDescription: 'Expired "access" token',
+      })
+    ).toBe(
+      'Bearer resource_metadata="https://lobu.ai/.well-known/oauth-protected-resource/mcp/acme", error="invalid_token", error_description="Expired \\"access\\" token"'
+    );
+  });
+
+  it('keeps a normal realm challenge for non-MCP HTTP resources', () => {
+    const request = new Request('https://app.lobu.ai/api/acme/private');
+    expect(buildBearerChallenge(request, { error: 'invalid_token' })).toBe(
+      'Bearer realm="https://app.lobu.ai", error="invalid_token"'
+    );
+  });
+});

--- a/packages/server/src/auth/oauth/__tests__/resource-challenge.test.ts
+++ b/packages/server/src/auth/oauth/__tests__/resource-challenge.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'bun:test';
 import {
   buildBearerChallenge,
+  canonicalMcpResourceUrl,
   protectedResourceMetadataUrl,
 } from '../resource-challenge';
 
 describe('MCP OAuth resource challenges', () => {
-  it('uses the actual serving origin instead of PUBLIC_GATEWAY_URL', () => {
-    process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+  it('uses the forwarded serving origin', () => {
     const request = new Request('https://internal.invalid/mcp', {
       headers: {
         host: 'lobu.ai',
@@ -18,6 +18,7 @@ describe('MCP OAuth resource challenges', () => {
     expect(protectedResourceMetadataUrl(request)).toBe(
       'https://lobu.ai/.well-known/oauth-protected-resource'
     );
+    expect(canonicalMcpResourceUrl(request)).toBe('https://lobu.ai/mcp');
     expect(buildBearerChallenge(request)).toBe(
       'Bearer resource_metadata="https://lobu.ai/.well-known/oauth-protected-resource"'
     );

--- a/packages/server/src/auth/oauth/resource-challenge.ts
+++ b/packages/server/src/auth/oauth/resource-challenge.ts
@@ -1,0 +1,50 @@
+import { resolveBaseUrl } from '../base-url';
+
+export interface BearerChallengeOptions {
+  error?: 'invalid_token' | 'insufficient_scope';
+  errorDescription?: string;
+  scope?: string;
+}
+
+function quote(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Resolve the RFC 9728 metadata document for the exact MCP resource being
+ * challenged. This deliberately ignores PUBLIC_GATEWAY_URL: a request served
+ * at lobu.ai must advertise lobu.ai's metadata, not the app.lobu.ai gateway
+ * origin used for unrelated generated links.
+ */
+export function protectedResourceMetadataUrl(request: Request): string {
+  const servingOrigin = resolveBaseUrl({ request, skipEnvOverride: true });
+  const pathname = new URL(request.url).pathname.replace(/\/+$/, '') || '/';
+  if (pathname === '/mcp') {
+    return `${servingOrigin}/.well-known/oauth-protected-resource`;
+  }
+  if (pathname.startsWith('/mcp/')) {
+    return `${servingOrigin}/.well-known/oauth-protected-resource${pathname}`;
+  }
+  return `${servingOrigin}/.well-known/oauth-protected-resource`;
+}
+
+/** Build an RFC 6750 challenge, using RFC 9728 resource_metadata for MCP. */
+export function buildBearerChallenge(
+  request: Request,
+  options: BearerChallengeOptions = {}
+): string {
+  const pathname = new URL(request.url).pathname;
+  const isMcp = pathname === '/mcp' || pathname.startsWith('/mcp/');
+  const servingOrigin = resolveBaseUrl({ request, skipEnvOverride: true });
+  const params = [
+    isMcp
+      ? `resource_metadata=${quote(protectedResourceMetadataUrl(request))}`
+      : `realm=${quote(servingOrigin)}`,
+  ];
+  if (options.error) params.push(`error=${quote(options.error)}`);
+  if (options.errorDescription) {
+    params.push(`error_description=${quote(options.errorDescription)}`);
+  }
+  if (options.scope) params.push(`scope=${quote(options.scope)}`);
+  return `Bearer ${params.join(', ')}`;
+}

--- a/packages/server/src/auth/oauth/resource-challenge.ts
+++ b/packages/server/src/auth/oauth/resource-challenge.ts
@@ -17,8 +17,9 @@ function quote(value: string): string {
  * origin used for unrelated generated links.
  */
 export function protectedResourceMetadataUrl(request: Request): string {
-  const servingOrigin = resolveBaseUrl({ request, skipEnvOverride: true });
-  const pathname = new URL(request.url).pathname.replace(/\/+$/, '') || '/';
+  const resourceUrl = new URL(canonicalMcpResourceUrl(request));
+  const servingOrigin = resourceUrl.origin;
+  const pathname = resourceUrl.pathname;
   if (pathname === '/mcp') {
     return `${servingOrigin}/.well-known/oauth-protected-resource`;
   }
@@ -26,6 +27,13 @@ export function protectedResourceMetadataUrl(request: Request): string {
     return `${servingOrigin}/.well-known/oauth-protected-resource${pathname}`;
   }
   return `${servingOrigin}/.well-known/oauth-protected-resource`;
+}
+
+/** Resolve the externally served MCP resource URL without its query string. */
+export function canonicalMcpResourceUrl(request: Request): string {
+  const servingOrigin = resolveBaseUrl({ request, skipEnvOverride: true });
+  const pathname = new URL(request.url).pathname.replace(/\/+$/, '') || '/';
+  return `${servingOrigin}${pathname}`;
 }
 
 /** Build an RFC 6750 challenge, using RFC 9728 resource_metadata for MCP. */

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -318,6 +318,13 @@ function escapeLobuViewMarkdown(value: unknown, singleLine = false): string {
   return normalized.replace(/([\\`*_[\]{}<>()#+\-.!|>])/g, '\\$1');
 }
 
+function formatLobuViewDiffValue(value: unknown): string {
+  if (value === undefined) return '—';
+  if (value === null) return 'null';
+  const escaped = escapeLobuViewMarkdown(value, true);
+  return escaped === '' ? '""' : escaped;
+}
+
 function formatLobuViewCode(value: unknown): string {
   const code = String(value ?? '');
   const longestRun = Math.max(0, ...Array.from(code.matchAll(/`+/g), (match) => match[0].length));
@@ -351,11 +358,8 @@ function formatLobuViewResult(result: any): string {
       for (const field of block.fields ?? []) {
         markdown += `- **${escapeLobuViewMarkdown(field.label, true)}**: ${
           field.before === undefined
-            ? escapeLobuViewMarkdown(field.after, true)
-            : `${escapeLobuViewMarkdown(field.before || '—', true)} → ${escapeLobuViewMarkdown(
-                field.after || '—',
-                true
-              )}`
+            ? formatLobuViewDiffValue(field.after)
+            : `${formatLobuViewDiffValue(field.before)} → ${formatLobuViewDiffValue(field.after)}`
         }\n`;
       }
       markdown += '\n';

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -293,6 +293,7 @@ export function formatToolResult(
     read_knowledge: formatGetContentResult,
     manage_behaviors: formatManageBehaviorsResult,
     query_sql: formatQuerySqlResult,
+    render_lobu_view: formatLobuViewResult,
   };
 
   const formatter = formatters[toolName];
@@ -309,6 +310,62 @@ export function formatToolResult(
 
   // Fallback: pretty-print JSON
   return `\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``;
+}
+
+function escapeLobuViewMarkdown(value: unknown, singleLine = false): string {
+  const text = String(value ?? '');
+  const normalized = singleLine ? text.replace(/\s+/g, ' ').trim() : text;
+  return normalized.replace(/([\\`*_[\]{}<>()#+\-.!|>])/g, '\\$1');
+}
+
+function formatLobuViewCode(value: unknown): string {
+  const code = String(value ?? '');
+  const longestRun = Math.max(0, ...Array.from(code.matchAll(/`+/g), (match) => match[0].length));
+  const fence = '`'.repeat(Math.max(3, longestRun + 1));
+  return `${fence}\n${code}\n${fence}`;
+}
+
+function safeLobuViewLink(href: unknown): string | null {
+  if (typeof href !== 'string') return null;
+  try {
+    const url = new URL(href);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    return url.href.replace(/\(/g, '%28').replace(/\)/g, '%29');
+  } catch {
+    return null;
+  }
+}
+
+function formatLobuViewResult(result: any): string {
+  let markdown = result.title
+    ? `## ${escapeLobuViewMarkdown(result.title, true)}\n\n`
+    : '';
+  for (const block of result.blocks ?? []) {
+    if (block.type === 'text') {
+      markdown += `${
+        block.label ? `**${escapeLobuViewMarkdown(block.label, true)}**\n\n` : ''
+      }${escapeLobuViewMarkdown(block.value)}\n\n`;
+    } else if (block.type === 'code') {
+      markdown += `${formatLobuViewCode(block.value)}\n\n`;
+    } else if (block.type === 'diff') {
+      for (const field of block.fields ?? []) {
+        markdown += `- **${escapeLobuViewMarkdown(field.label, true)}**: ${
+          field.before === undefined
+            ? escapeLobuViewMarkdown(field.after, true)
+            : `${escapeLobuViewMarkdown(field.before || '—', true)} → ${escapeLobuViewMarkdown(
+                field.after || '—',
+                true
+              )}`
+        }\n`;
+      }
+      markdown += '\n';
+    }
+  }
+  for (const action of result.actions ?? []) {
+    const href = safeLobuViewLink(action.href);
+    if (href) markdown += `[${escapeLobuViewMarkdown(action.label, true)}](${href})\n\n`;
+  }
+  return markdown.trim() || 'Lobu view rendered.';
 }
 
 /**

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -24,7 +24,13 @@ import {
 import type { Context } from 'hono';
 import { bindRequestAbortToStream, type AbortableStream } from './events/sse-abort-bridge';
 import { OAuthClientsStore } from './auth/oauth/clients';
-import { isPublicReadable, resolveMaxAccessLevel } from './auth/tool-access';
+import { buildBearerChallenge } from './auth/oauth/resource-challenge';
+import {
+  getRequiredAccessLevel,
+  hasRequiredMcpScope,
+  isPublicReadable,
+  resolveMaxAccessLevel,
+} from './auth/tool-access';
 import { createDbClientFromEnv } from './db/client';
 import type { Env } from './index';
 import {
@@ -48,6 +54,7 @@ import {
 import { getMcpTools, getTool } from './tools/registry';
 import { validateToolResult } from './tools/validate-args';
 import { formatToolResult } from './formatting/markdown-formatter';
+import { LOBU_INTERACTION_RESOURCE_URI } from './tools/mcp_app';
 import { resolvePublicOrigin } from './utils/public-origin';
 import { buildWorkspaceInstructions } from './utils/workspace-instructions';
 
@@ -148,11 +155,9 @@ const formatRef = { rawJson: false };
  * MCP Apps UI resources (interactive iframe payloads a host renders in a
  * sandboxed iframe). Keyed by `ui://` uri → the built bundle's app dir under
  * owletto's `dist-mcp-apps/`. Served over `resources/read` + the asset route;
- * our own SPA fetches the one bundle and streams it a `{title, blocks, actions}`
- * view it builds CLIENT-side. (Pointing an external MCP host at a bundle via a
- * tool result's `_meta.ui.resourceUri` needs the SERVER to author that view —
- * a deliberate follow-up, so we don't stamp it today.) Adding an app = one
- * entry + its owletto `src/mcp-apps/<dir>` build — no gateway change.
+ * the decoupled `render_lobu_view` tool links to the resource and supplies a
+ * server-authored LobuViewV1 in `structuredContent`. Adding an app = one entry
+ * plus its owletto `src/mcp-apps/<dir>` build — no gateway change.
  */
 const MCP_APP_RESOURCES: Record<
   string,
@@ -161,22 +166,24 @@ const MCP_APP_RESOURCES: Record<
     /** Surfaced on `resources/list` — clients show it in resource browsers. */
     description: string;
     appDir: string;
-    /**
-     * CSP the host should apply to the rendered iframe. The interaction bundle is
-     * postMessage-only (no fetch/XHR/import/remote assets; verified in
-     * `_shared/host.tsx` + `interaction-card.tsx`), so the policy is strict: no
-     * network, scripts/styles same-origin only. Tailwind's runtime style
-     * injection needs `'unsafe-inline'` on `style-src`.
-     */
-    csp: string;
+    /** MCP Apps CSP declarations. Empty means the bundle requests no external
+     * connect, resource, frame, or base-URI domains; its JS/CSS is inlined. */
+    csp: {
+      connectDomains?: string[];
+      resourceDomains?: string[];
+      frameDomains?: string[];
+      baseUriDomains?: string[];
+    };
+    prefersBorder: boolean;
   }
 > = {
-  'ui://lobu/interaction': {
+  [LOBU_INTERACTION_RESOURCE_URI]: {
     name: 'Interaction',
     description:
-      'Interactive approval/question/tool-grant cards rendered in a sandboxed iframe; actions ride a `tools/call` back to the host.',
+      'Interactive Lobu cards rendered in a sandboxed iframe; actions use standard MCP tool calls or host-mediated external links.',
     appDir: 'interaction',
-    csp: "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+    csp: {},
+    prefersBorder: true,
   },
 };
 
@@ -236,13 +243,31 @@ function createServerForContext(
     const allTools = getMcpTools({
       publicOnly,
       maxAccessLevel,
-    }).map((t) => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: t.inputSchema,
-      ...(t.annotations && { annotations: t.annotations }),
-      ...(t.outputSchema && { outputSchema: t.outputSchema }),
-    }));
+    }).map((t) => {
+      const securitySchemes = t.securitySchemes
+        ? publicOnly
+          ? [{ type: 'noauth' as const }, ...t.securitySchemes]
+          : t.securitySchemes
+        : undefined;
+      return {
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+        ...(t.annotations && { annotations: t.annotations }),
+        ...(t.outputSchema && { outputSchema: t.outputSchema }),
+        ...(securitySchemes && { securitySchemes }),
+        ...(t._meta || securitySchemes
+          ? {
+              _meta: {
+                ...(t._meta ?? {}),
+                // ChatGPT's legacy Apps clients read the same declarations
+                // from `_meta`; current MCP clients use the top-level field.
+                ...(securitySchemes && { securitySchemes }),
+              },
+            }
+          : {}),
+      };
+    });
 
     return { tools: allTools };
   });
@@ -255,10 +280,11 @@ function createServerForContext(
         uri,
         name: meta.name,
         description: meta.description,
-        mimeType: 'text/html',
+        mimeType: 'text/html;profile=mcp-app',
         _meta: {
           ui: {
             csp: meta.csp,
+            prefersBorder: meta.prefersBorder,
             // Origin the host should associate with this UI (the gateway that
             // serves the bundle + brokers the `tools/call` actions).
             domain: resolvedOrigin,
@@ -290,7 +316,20 @@ function createServerForContext(
       throw new Error(`MCP App bundle not built for ${uri} (run owletto build:mcp-apps)`);
     }
     return {
-      contents: [{ uri, mimeType: 'text/html', text: html }],
+      contents: [
+        {
+          uri,
+          mimeType: 'text/html;profile=mcp-app',
+          text: html,
+          _meta: {
+            ui: {
+              csp: app.csp,
+              prefersBorder: app.prefersBorder,
+              domain: resolvedOrigin,
+            },
+          },
+        },
+      ],
     };
   });
 
@@ -313,13 +352,6 @@ function createServerForContext(
       const text = formatRef.rawJson
         ? JSON.stringify(result)
         : formatToolResult(name, result, { includeRawJson: false });
-      // NOTE: our own SPA renders interactions (incl. the pending agent-change
-      // approval) through the `ui://lobu/interaction` MCP App, but it builds the
-      // `{title, blocks, actions}` view CLIENT-side from the SSE card payload —
-      // it does not consume this tool result's `_meta`. Rendering for EXTERNAL
-      // MCP hosts (Slack/Claude) needs the SERVER to author that view and stamp
-      // it here; that is a deliberate follow-up. Until then we return plain text
-      // rather than pointing an external host at a bundle it can't feed.
       // When the tool declares an `outputSchema`, also return the result as
       // `structuredContent` (MCP spec: declaring outputSchema implies the result
       // is structured — and a spec-compliant client validates it against the
@@ -355,6 +387,32 @@ function createServerForContext(
         ...(softError ? { isError: true } : {}),
       };
     } catch (error: any) {
+      const tool = getTool(name);
+      const requiredAccess = tool
+        ? getRequiredAccessLevel(name, args ?? {}, tool.annotations?.readOnlyHint === true)
+        : null;
+      const requiredScope =
+        requiredAccess === 'read'
+          ? 'mcp:read'
+          : requiredAccess === 'write'
+            ? 'mcp:write'
+            : requiredAccess === 'admin'
+              ? 'mcp:admin'
+              : null;
+      const scopeChallenge =
+        requiredAccess &&
+        requiredScope &&
+        (authCtx.tokenType === 'oauth' || authCtx.tokenType === 'pat') &&
+        !hasRequiredMcpScope(requiredAccess, authCtx.scopes)
+          ? buildBearerChallenge(
+              new Request(authCtx.requestUrl ?? `${resolvedOrigin}/mcp`),
+              {
+                error: 'insufficient_scope',
+                errorDescription: error?.message ?? 'The token lacks the required MCP scope.',
+                scope: requiredScope,
+              }
+            )
+          : null;
       // Surface the structured taxonomy (lobu#2051 Item 2) when the thrown error
       // carries a code, so the client/agent gets a stable code + retryability +
       // per-call correlation id alongside the human message.
@@ -376,16 +434,14 @@ function createServerForContext(
         ],
         isError: true,
         ...(structuredError ? { structuredContent: { error: structuredError } } : {}),
+        ...(scopeChallenge
+          ? { _meta: { 'mcp/www_authenticate': [scopeChallenge] } }
+          : {}),
       };
     }
   });
 
   return server;
-}
-
-function getProtectedResourceUrl(req: Request): string {
-  const baseUrl = resolvePublicOrigin(req.url);
-  return `${baseUrl}/.well-known/oauth-protected-resource`;
 }
 
 function buildUnauthorizedResponse(req: Request, description: string): Response {
@@ -398,7 +454,7 @@ function buildUnauthorizedResponse(req: Request, description: string): Response 
       status: 401,
       headers: {
         'Content-Type': 'application/json',
-        'WWW-Authenticate': `Bearer realm="${getProtectedResourceUrl(req)}"`,
+        'WWW-Authenticate': buildBearerChallenge(req),
       },
     }
   );

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -24,7 +24,10 @@ import {
 import type { Context } from 'hono';
 import { bindRequestAbortToStream, type AbortableStream } from './events/sse-abort-bridge';
 import { OAuthClientsStore } from './auth/oauth/clients';
-import { buildBearerChallenge } from './auth/oauth/resource-challenge';
+import {
+  buildBearerChallenge,
+  canonicalMcpResourceUrl,
+} from './auth/oauth/resource-challenge';
 import {
   getRequiredAccessLevel,
   hasRequiredMcpScope,
@@ -157,7 +160,7 @@ const formatRef = { rawJson: false };
  * owletto's `dist-mcp-apps/`. Served over `resources/read` + the asset route;
  * the decoupled `render_lobu_view` tool links to the resource and supplies a
  * server-authored LobuViewV1 in `structuredContent`. Adding an app = one entry
- * plus its owletto `src/mcp-apps/<dir>` build — no gateway change.
+ * plus its owletto `src/mcp-apps/<dir>` build — no other gateway plumbing.
  */
 const MCP_APP_RESOURCES: Record<
   string,
@@ -180,7 +183,7 @@ const MCP_APP_RESOURCES: Record<
   [LOBU_INTERACTION_RESOURCE_URI]: {
     name: 'Interaction',
     description:
-      'Interactive Lobu cards rendered in a sandboxed iframe; actions use standard MCP tool calls or host-mediated external links.',
+      'Interactive Lobu cards rendered in a sandboxed iframe with host-mediated external links.',
     appDir: 'interaction',
     csp: {},
     prefersBorder: true,
@@ -224,7 +227,7 @@ const MCP_SKILL_RESOURCES: Record<
 function createServerForContext(
   env: Env,
   authCtx: SessionAuthContext,
-  resolvedOrigin: string
+  challengeResourceUrl: string
 ): Server {
   const server = new Server(
     { name: 'lobu-mcp', version: '0.2.0' },
@@ -261,7 +264,7 @@ function createServerForContext(
               _meta: {
                 ...(t._meta ?? {}),
                 // ChatGPT's legacy Apps clients read the same declarations
-                // from `_meta`; current MCP clients use the top-level field.
+                // from `_meta`; hosts that support the top-level field use it.
                 ...(securitySchemes && { securitySchemes }),
               },
             }
@@ -285,9 +288,6 @@ function createServerForContext(
           ui: {
             csp: meta.csp,
             prefersBorder: meta.prefersBorder,
-            // Origin the host should associate with this UI (the gateway that
-            // serves the bundle + brokers the `tools/call` actions).
-            domain: resolvedOrigin,
           },
         },
       })),
@@ -325,7 +325,6 @@ function createServerForContext(
             ui: {
               csp: app.csp,
               prefersBorder: app.prefersBorder,
-              domain: resolvedOrigin,
             },
           },
         },
@@ -405,7 +404,7 @@ function createServerForContext(
         (authCtx.tokenType === 'oauth' || authCtx.tokenType === 'pat') &&
         !hasRequiredMcpScope(requiredAccess, authCtx.scopes)
           ? buildBearerChallenge(
-              new Request(authCtx.requestUrl ?? `${resolvedOrigin}/mcp`),
+              new Request(challengeResourceUrl),
               {
                 error: 'insufficient_scope',
                 errorDescription: error?.message ?? 'The token lacks the required MCP scope.',
@@ -937,7 +936,7 @@ function createSessionTransport(
   env: Env,
   authCtx: SessionAuthContext,
   sessionIdGenerator: () => string,
-  resolvedOrigin: string
+  challengeResourceUrl: string
 ): { transport: WebStandardStreamableHTTPServerTransport; server: Server } {
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator,
@@ -960,7 +959,7 @@ function createSessionTransport(
       void deletePersistedSession(transport.sessionId);
     }
   };
-  const server = createServerForContext(env, authCtx, resolvedOrigin);
+  const server = createServerForContext(env, authCtx, challengeResourceUrl);
   return { transport, server };
 }
 
@@ -1186,7 +1185,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
             c.env,
             recoveredAuthCtx,
             () => sessionId,
-            resolvePublicOrigin(req.url)
+            canonicalMcpResourceUrl(req)
           );
           await server.connect(transport);
           await initializeRecoveredSession(transport, sessionId, req.url);
@@ -1267,7 +1266,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
       c.env,
       authCtx,
       () => randomUUID(),
-      resolvePublicOrigin(req.url)
+      canonicalMcpResourceUrl(req)
     );
     await server.connect(transport);
     const response = await handleAndMaybeConvert(transport, req, wantsSSE);

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -28,7 +28,12 @@ import {
 } from "./tools/execute";
 import { getContent } from "./tools/get_content";
 import { getBehavior } from "./tools/get_behavior";
-import { getAllTools, getTool, type ToolContext } from "./tools/registry";
+import {
+	getAllTools,
+	getTool,
+	isRestDispatchTool,
+	type ToolContext,
+} from "./tools/registry";
 import {
 	errorMessage,
 	ToolNotRegisteredError,
@@ -278,10 +283,10 @@ export async function restToolAction(
 
 /**
  * POST /api/:orgSlug/:toolName
- * Generic proxy endpoint that forwards to any MCP tool
+ * Generic proxy endpoint for the REST-dispatchable tool surface.
  *
- * This allows all MCP tools to be called via REST API without
- * needing individual wrapper functions for each tool
+ * MCP-only tools are deliberately excluded even though they share the
+ * executable registry with MCP tools/call.
  */
 export async function restToolProxy(
 	c: Context<{ Bindings: Env }>,
@@ -292,6 +297,12 @@ export async function restToolProxy(
 		const toolName = explicitToolName ?? c.req.param("toolName");
 		if (!toolName) {
 			return c.json({ error: "Tool name is required" }, 400);
+		}
+		if (!isRestDispatchTool(toolName)) {
+			if (getTool(toolName)) {
+				throw new ToolUserError(`Tool not found: ${toolName}`, 404);
+			}
+			throw new ToolNotRegisteredError(toolName);
 		}
 		const args: Record<string, unknown> = explicitArgs ?? (await c.req.json());
 		const authCtx = extractAuthContext(c);

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -94,7 +94,19 @@ type RenderLobuViewArgs = Static<typeof RenderLobuViewSchema>;
 type LobuView = Static<typeof LobuViewSchema>;
 
 const SENSITIVE_KEY =
-  /(?:^|[_-])(authorization|cookie|credential|password|secret|token|api[_-]?key)(?:$|[_-])/i;
+  /(?:^|[_-])(authorization|cookie|credential|password|private[_-]?key|secret|token|api[_-]?key)(?:$|[_-])/i;
+const KNOWN_SECRET_SHAPE_RE =
+  /\b(?:sk[-_][a-z0-9_-]{8,}|xox[baprs]-[a-z0-9-]{8,}|gh[pousr]_[a-z0-9_]{12,}|AKIA[A-Z0-9]{16}|eyJ[a-z0-9_-]{8,}\.[a-z0-9_-]{8,}\.[a-z0-9_-]{8,})\b/gi;
+const HEADER_CREDENTIAL_RE =
+  /\b(authorization|proxy-authorization|www-authenticate|set-cookie|cookie)\s*["']?\s*[:=]\s*[^\n]+/gi;
+const AUTH_SCHEME_RE =
+  /\b(bearer|basic|digest)\s+(?:[a-z0-9_-]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s,]+)(?:\s*,\s*[a-z0-9_-]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s,]+))*|[a-z0-9._~+/=:-]+)/gi;
+const SENSITIVE_ASSIGNMENT_RE =
+  /(api[_-]?key|credential|password|private[_-]?key|secret|token)\s*["']?\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s'"}]+)/gi;
+const MAX_TEXT_LENGTH = 20_000;
+const MAX_CODE_LENGTH = 40_000;
+const MAX_LABEL_LENGTH = 120;
+const MAX_TITLE_LENGTH = 200;
 const DIFF_ROUTING_KEYS = new Set([
   'action',
   'agent_id',
@@ -107,21 +119,76 @@ const DIFF_ROUTING_KEYS = new Set([
   'watcher_id',
 ]);
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isSensitiveKey(key: string): boolean {
+  const snakeCase = key.replace(/([a-z0-9])([A-Z])/g, '$1_$2');
+  return SENSITIVE_KEY.test(snakeCase);
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(HEADER_CREDENTIAL_RE, (_match, key: string) => `${key}=[redacted]`)
+    .replace(AUTH_SCHEME_RE, (_match, scheme: string) => `${scheme} [redacted]`)
+    .replace(SENSITIVE_ASSIGNMENT_RE, (_match, key: string) => `${key}=[redacted]`)
+    .replace(KNOWN_SECRET_SHAPE_RE, '[redacted]');
+}
+
+function truncateRedactedText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1)}…`;
+}
+
+function truncateForDisplay(value: string, maxLength: number): string {
+  return truncateRedactedText(redactSensitiveText(value), maxLength);
+}
+
 function redactForDisplay(value: unknown): unknown {
+  if (typeof value === 'string') return redactSensitiveText(value);
   if (Array.isArray(value)) return value.map(redactForDisplay);
-  if (!value || typeof value !== 'object') return value;
+  if (!isRecord(value)) return value;
   return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>).map(([key, inner]) => [
+    Object.entries(value).map(([key, inner]) => [
       key,
-      SENSITIVE_KEY.test(key) ? '[redacted]' : redactForDisplay(inner),
+      isSensitiveKey(key) ? '[redacted]' : redactForDisplay(inner),
     ])
   );
 }
 
-function displayValue(value: unknown): string {
+function displayValue(value: unknown, maxLength = MAX_TEXT_LENGTH): string {
   if (value === undefined || value === null) return '';
-  if (typeof value === 'string') return value;
-  return JSON.stringify(redactForDisplay(value), null, 2);
+  if (typeof value === 'string') return truncateForDisplay(value, maxLength);
+  const serialized = JSON.stringify(redactForDisplay(value), null, 2);
+  return truncateRedactedText(serialized ?? String(value), maxLength);
+}
+
+function sanitizeBlock(
+  block: Static<typeof LobuViewBlockSchema>
+): Static<typeof LobuViewBlockSchema> {
+  if (block.type === 'text') {
+    return {
+      ...block,
+      ...(block.label !== undefined
+        ? { label: truncateForDisplay(block.label, MAX_LABEL_LENGTH) }
+        : {}),
+      value: truncateForDisplay(block.value, MAX_TEXT_LENGTH),
+    };
+  }
+  if (block.type === 'code') {
+    return { ...block, value: truncateForDisplay(block.value, MAX_CODE_LENGTH) };
+  }
+  return {
+    ...block,
+    fields: block.fields.slice(0, 100).map((field) => ({
+      label: truncateForDisplay(field.label, MAX_LABEL_LENGTH) || 'Field',
+      ...(field.before !== undefined
+        ? { before: truncateForDisplay(field.before, MAX_TEXT_LENGTH) }
+        : {}),
+      after: truncateForDisplay(field.after, MAX_TEXT_LENGTH),
+    })),
+  };
 }
 
 function approvalBlocks(row: {
@@ -130,29 +197,25 @@ function approvalBlocks(row: {
   metadata: Record<string, unknown> | null;
 }): Static<typeof LobuViewBlockSchema>[] {
   const metadata = row.metadata ?? {};
-  const proposal =
-    metadata.proposal && typeof metadata.proposal === 'object'
-      ? (metadata.proposal as Record<string, unknown>)
-      : null;
-  const current =
-    metadata.current && typeof metadata.current === 'object'
-      ? (metadata.current as Record<string, unknown>)
-      : null;
-  const fields =
-    metadata.fields && typeof metadata.fields === 'object'
-      ? (metadata.fields as Record<string, unknown>)
-      : null;
+  const proposal = isRecord(metadata.proposal) ? metadata.proposal : null;
+  const current = isRecord(metadata.current) ? metadata.current : null;
+  const fields = isRecord(metadata.fields) ? metadata.fields : null;
   const proposed = fields ?? proposal;
 
   if (proposed) {
     const diffFields = Object.entries(proposed)
       .filter(([key, value]) => !DIFF_ROUTING_KEYS.has(key) && value !== undefined)
+      .slice(0, 100)
       .map(([key, value]) => ({
-        label: key,
+        label: truncateForDisplay(key, MAX_LABEL_LENGTH) || 'Field',
         ...(current && current[key] !== undefined
-          ? { before: displayValue(current[key]) }
+          ? {
+              before: isSensitiveKey(key)
+                ? '[redacted]'
+                : displayValue(current[key]),
+            }
           : {}),
-        after: displayValue(value),
+        after: isSensitiveKey(key) ? '[redacted]' : displayValue(value),
       }));
     if (diffFields.length > 0) return [{ type: 'diff', fields: diffFields }];
   }
@@ -161,7 +224,7 @@ function approvalBlocks(row: {
     return [
       {
         type: 'code',
-        value: JSON.stringify(redactForDisplay(row.interaction_input), null, 2),
+        value: displayValue(row.interaction_input, MAX_CODE_LENGTH),
       },
     ];
   }
@@ -169,7 +232,10 @@ function approvalBlocks(row: {
   return [
     {
       type: 'text',
-      value: row.content || 'Review this pending Lobu action.',
+      value: truncateForDisplay(
+        row.content || 'Review this pending Lobu action.',
+        MAX_TEXT_LENGTH
+      ),
       muted: true,
     },
   ];
@@ -209,7 +275,10 @@ async function buildApprovalView(
   if (!row) throw new ToolUserError(`Approval run ${runId} was not found`, 404);
 
   const status = row.interaction_status ?? 'pending';
-  const title = (row.title ?? `Approval run ${runId}`).replace(/\s+—\s+pending approval$/i, '');
+  const baseTitle = (row.title ?? `Approval run ${runId}`).replace(
+    /\s+—\s+pending approval$/i,
+    ''
+  );
   const actions: LobuView['actions'] = [];
   if (status === 'pending') {
     const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
@@ -229,7 +298,10 @@ async function buildApprovalView(
 
   return {
     version: 1,
-    title: status === 'pending' ? title : `${title} · ${status}`,
+    title: truncateForDisplay(
+      status === 'pending' ? baseTitle : `${baseTitle} · ${status}`,
+      MAX_TITLE_LENGTH
+    ),
     tone: status === 'pending' ? 'warning' : 'default',
     blocks: approvalBlocks({
       content: row.payload_text,
@@ -248,9 +320,11 @@ const renderLobuViewImpl = async (
   if (args.action === 'review_approval') return buildApprovalView(args.run_id, env, ctx);
   return {
     version: 1,
-    ...(args.title ? { title: args.title } : {}),
+    ...(args.title !== undefined
+      ? { title: truncateForDisplay(args.title, MAX_TITLE_LENGTH) }
+      : {}),
     ...(args.tone ? { tone: args.tone } : {}),
-    blocks: args.blocks,
+    blocks: args.blocks.map(sanitizeBlock),
     actions: [],
   };
 };

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -110,6 +110,9 @@ const MAX_TITLE_LENGTH = 200;
 const DIFF_ROUTING_KEYS = new Set([
   'action',
   'agent_id',
+  'acting_agent_id',
+  'acting_watcher_id',
+  'args',
   'base',
   'behavior_id',
   'entity_id',
@@ -126,6 +129,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function isSensitiveKey(key: string): boolean {
   const snakeCase = key.replace(/([a-z0-9])([A-Z])/g, '$1_$2');
   return SENSITIVE_KEY.test(snakeCase);
+}
+
+function isDiffRoutingKey(key: string): boolean {
+  const snakeCase = key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+  return DIFF_ROUTING_KEYS.has(snakeCase);
 }
 
 function redactSensitiveText(value: string): string {
@@ -158,7 +166,8 @@ function redactForDisplay(value: unknown): unknown {
 }
 
 function displayValue(value: unknown, maxLength = MAX_TEXT_LENGTH): string {
-  if (value === undefined || value === null) return '';
+  if (value === undefined) return '';
+  if (value === null) return 'null';
   if (typeof value === 'string') return truncateForDisplay(value, maxLength);
   const serialized = JSON.stringify(redactForDisplay(value), null, 2);
   return truncateRedactedText(serialized ?? String(value), maxLength);
@@ -198,13 +207,18 @@ function approvalBlocks(row: {
 }): Static<typeof LobuViewBlockSchema>[] {
   const metadata = row.metadata ?? {};
   const proposal = isRecord(metadata.proposal) ? metadata.proposal : null;
+  const proposalArgs = proposal && isRecord(proposal.args) ? proposal.args : null;
   const current = isRecord(metadata.current) ? metadata.current : null;
   const fields = isRecord(metadata.fields) ? metadata.fields : null;
-  const proposed = fields ?? proposal;
+  // Prefer the producer-authored review fields. Some approval proposals (most
+  // notably manage_behaviors) are execution envelopes shaped as
+  // `{ args, actingAgentId, actingWatcherId }`; rendering that envelope leaks
+  // routing details and hides the actual field-level change.
+  const proposed = fields ?? row.interaction_input ?? proposalArgs ?? proposal;
 
   if (proposed) {
     const diffFields = Object.entries(proposed)
-      .filter(([key, value]) => !DIFF_ROUTING_KEYS.has(key) && value !== undefined)
+      .filter(([key, value]) => !isDiffRoutingKey(key) && value !== undefined)
       .slice(0, 100)
       .map(([key, value]) => ({
         label: truncateForDisplay(key, MAX_LABEL_LENGTH) || 'Field',

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -181,7 +181,7 @@ function sanitizeBlock(
   }
   return {
     ...block,
-    fields: block.fields.slice(0, 100).map((field) => ({
+    fields: block.fields.map((field) => ({
       label: truncateForDisplay(field.label, MAX_LABEL_LENGTH) || 'Field',
       ...(field.before !== undefined
         ? { before: truncateForDisplay(field.before, MAX_TEXT_LENGTH) }

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -1,0 +1,262 @@
+import { Type, type Static } from '@sinclair/typebox';
+import type { Env } from '../index';
+import { ToolUserError } from '../utils/errors';
+import { buildResourcePermalink } from '../utils/url-builder';
+import { getContent } from './get_content';
+import type { ToolContext } from './registry';
+import { withValidatedArgs } from './validate-args';
+import { getOrgUrlContext } from './view-urls';
+
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v1';
+
+const TextBlockSchema = Type.Object({
+  type: Type.Literal('text'),
+  label: Type.Optional(Type.String({ maxLength: 120 })),
+  value: Type.String({ maxLength: 20_000 }),
+  muted: Type.Optional(Type.Boolean()),
+});
+
+const CodeBlockSchema = Type.Object({
+  type: Type.Literal('code'),
+  value: Type.String({ maxLength: 40_000 }),
+});
+
+const DiffBlockSchema = Type.Object({
+  type: Type.Literal('diff'),
+  fields: Type.Array(
+    Type.Object({
+      label: Type.String({ minLength: 1, maxLength: 120 }),
+      before: Type.Optional(Type.String({ maxLength: 20_000 })),
+      after: Type.String({ maxLength: 20_000 }),
+    }),
+    { maxItems: 100 }
+  ),
+});
+
+export const LobuViewBlockSchema = Type.Union([
+  TextBlockSchema,
+  CodeBlockSchema,
+  DiffBlockSchema,
+]);
+
+const LinkActionSchema = Type.Object({
+  id: Type.String({ minLength: 1, maxLength: 80 }),
+  label: Type.String({ minLength: 1, maxLength: 120 }),
+  variant: Type.Optional(
+    Type.Union([
+      Type.Literal('primary'),
+      Type.Literal('outline'),
+      Type.Literal('ghost'),
+      Type.Literal('destructive'),
+    ])
+  ),
+  icon: Type.Optional(Type.Literal('external')),
+  terminal: Type.Optional(Type.Boolean()),
+  href: Type.String({ minLength: 1, maxLength: 2_048 }),
+});
+
+export const LobuViewSchema = Type.Object({
+  version: Type.Literal(1),
+  title: Type.Optional(Type.String({ maxLength: 200 })),
+  tone: Type.Optional(
+    Type.Union([Type.Literal('warning'), Type.Literal('default'), Type.Literal('bare')])
+  ),
+  blocks: Type.Array(LobuViewBlockSchema, { maxItems: 100 }),
+  actions: Type.Array(LinkActionSchema, { maxItems: 10 }),
+});
+
+const RenderActionSchema = Type.Object({
+  action: Type.Literal('render', {
+    description:
+      'Render a compact final card from model-selected data. Call Lobu data tools first; do not use this for ordinary text answers.',
+  }),
+  title: Type.Optional(Type.String({ maxLength: 200 })),
+  tone: Type.Optional(
+    Type.Union([Type.Literal('warning'), Type.Literal('default'), Type.Literal('bare')])
+  ),
+  blocks: Type.Array(LobuViewBlockSchema, { minItems: 1, maxItems: 100 }),
+});
+
+const ReviewApprovalActionSchema = Type.Object({
+  action: Type.Literal('review_approval', {
+    description:
+      'Render the server-authored review card for one pending Lobu approval run. The card opens Lobu for the human decision.',
+  }),
+  run_id: Type.Integer({ minimum: 1 }),
+});
+
+export const RenderLobuViewSchema = Type.Union([
+  RenderActionSchema,
+  ReviewApprovalActionSchema,
+]);
+
+type RenderLobuViewArgs = Static<typeof RenderLobuViewSchema>;
+type LobuView = Static<typeof LobuViewSchema>;
+
+const SENSITIVE_KEY =
+  /(?:^|[_-])(authorization|cookie|credential|password|secret|token|api[_-]?key)(?:$|[_-])/i;
+const DIFF_ROUTING_KEYS = new Set([
+  'action',
+  'agent_id',
+  'base',
+  'behavior_id',
+  'entity_id',
+  'id',
+  'owner_user_id',
+  'reason',
+  'watcher_id',
+]);
+
+function redactForDisplay(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactForDisplay);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, inner]) => [
+      key,
+      SENSITIVE_KEY.test(key) ? '[redacted]' : redactForDisplay(inner),
+    ])
+  );
+}
+
+function displayValue(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(redactForDisplay(value), null, 2);
+}
+
+function approvalBlocks(row: {
+  content: string | null;
+  interaction_input: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+}): Static<typeof LobuViewBlockSchema>[] {
+  const metadata = row.metadata ?? {};
+  const proposal =
+    metadata.proposal && typeof metadata.proposal === 'object'
+      ? (metadata.proposal as Record<string, unknown>)
+      : null;
+  const current =
+    metadata.current && typeof metadata.current === 'object'
+      ? (metadata.current as Record<string, unknown>)
+      : null;
+  const fields =
+    metadata.fields && typeof metadata.fields === 'object'
+      ? (metadata.fields as Record<string, unknown>)
+      : null;
+  const proposed = fields ?? proposal;
+
+  if (proposed) {
+    const diffFields = Object.entries(proposed)
+      .filter(([key, value]) => !DIFF_ROUTING_KEYS.has(key) && value !== undefined)
+      .map(([key, value]) => ({
+        label: key,
+        ...(current && current[key] !== undefined
+          ? { before: displayValue(current[key]) }
+          : {}),
+        after: displayValue(value),
+      }));
+    if (diffFields.length > 0) return [{ type: 'diff', fields: diffFields }];
+  }
+
+  if (row.interaction_input && Object.keys(row.interaction_input).length > 0) {
+    return [
+      {
+        type: 'code',
+        value: JSON.stringify(redactForDisplay(row.interaction_input), null, 2),
+      },
+    ];
+  }
+
+  return [
+    {
+      type: 'text',
+      value: row.content || 'Review this pending Lobu action.',
+      muted: true,
+    },
+  ];
+}
+
+type ApprovalContentItem = {
+  run_id: number;
+  title: string | null;
+  payload_text: string;
+  interaction_type: 'approval';
+  interaction_status: string | null;
+  interaction_input: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+};
+
+function isApprovalContentItem(value: unknown, runId: number): value is ApprovalContentItem {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return row.run_id === runId && row.interaction_type === 'approval';
+}
+
+async function buildApprovalView(
+  runId: number,
+  env: Env,
+  ctx: ToolContext
+): Promise<LobuView> {
+  // Reuse the canonical knowledge read so connection visibility, public-org
+  // rules, caller identity, and MCP scope checks cannot drift from the event
+  // surface. A direct current_event_records query here would be tenant-fenced
+  // but could bypass a private connection's ACL.
+  const result = await getContent(
+    { run_ids: [runId], limit: 50, sort_by: 'date', sort_order: 'desc' },
+    env,
+    ctx
+  );
+  const row = result.content.find((item) => isApprovalContentItem(item, runId));
+  if (!row) throw new ToolUserError(`Approval run ${runId} was not found`, 404);
+
+  const status = row.interaction_status ?? 'pending';
+  const title = (row.title ?? `Approval run ${runId}`).replace(/\s+—\s+pending approval$/i, '');
+  const actions: LobuView['actions'] = [];
+  if (status === 'pending') {
+    const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
+    const href = buildResourcePermalink(ownerSlug, { kind: 'run', runId }, baseUrl);
+    if (!href) {
+      throw new ToolUserError('The Lobu review link is unavailable for this workspace.', 500);
+    }
+    actions.push({
+      id: 'review',
+      label: 'Review in Lobu',
+      variant: 'primary',
+      icon: 'external',
+      terminal: false,
+      href,
+    });
+  }
+
+  return {
+    version: 1,
+    title: status === 'pending' ? title : `${title} · ${status}`,
+    tone: status === 'pending' ? 'warning' : 'default',
+    blocks: approvalBlocks({
+      content: row.payload_text,
+      interaction_input: row.interaction_input,
+      metadata: row.metadata,
+    }),
+    actions,
+  };
+}
+
+const renderLobuViewImpl = async (
+  args: RenderLobuViewArgs,
+  env: Env,
+  ctx: ToolContext
+): Promise<LobuView> => {
+  if (args.action === 'review_approval') return buildApprovalView(args.run_id, env, ctx);
+  return {
+    version: 1,
+    ...(args.title ? { title: args.title } : {}),
+    ...(args.tone ? { tone: args.tone } : {}),
+    blocks: args.blocks,
+    actions: [],
+  };
+};
+
+export const renderLobuView = withValidatedArgs(
+  'render_lobu_view',
+  RenderLobuViewSchema,
+  renderLobuViewImpl
+);

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -359,6 +359,10 @@ const INTERNAL_TOOL_NAMES: ReadonlySet<string> = new Set(
   INTERNAL_DISPATCH_TOOLS.map((tool) => tool.name)
 );
 
+const REST_DISPATCH_TOOL_NAMES: ReadonlySet<string> = new Set(
+  ALL_DISPATCH_TOOLS.map((tool) => tool.name)
+);
+
 // ============================================
 // Helper Functions
 // ============================================
@@ -376,6 +380,11 @@ export function getTool(name: string): ToolDefinition | undefined {
 
 export function isInternalDispatchTool(name: string): boolean {
   return INTERNAL_TOOL_NAMES.has(name);
+}
+
+/** Whether a registered tool may be invoked through the generic REST proxy. */
+export function isRestDispatchTool(name: string): boolean {
+  return REST_DISPATCH_TOOL_NAMES.has(name);
 }
 
 /**

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -191,6 +191,11 @@ const READ_ONLY = {
   idempotentHint: true,
 } as const;
 
+const READ_ONLY_OPEN_WORLD = {
+  ...READ_ONLY,
+  openWorldHint: true,
+} as const;
+
 const WRITE_WITHOUT_CONFIRM: ToolAnnotations = {
   readOnlyHint: false,
   openWorldHint: false,
@@ -211,7 +216,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     // affordances. See search.ts → PublicSearchSchema.
     publicInputSchema: PublicSearchSchema,
     outputSchema: UnifiedSearchResultSchema,
-    annotations: { ...READ_ONLY, title: 'Search memory' },
+    annotations: { ...READ_ONLY_OPEN_WORLD, title: 'Search memory' },
     securityScopes: ['mcp:read'],
     handler: search,
   },
@@ -241,7 +246,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
       'Read workspace data through typed SDK methods. Query entities, relationships, feeds, operations, metrics, and more. Use this for lookups and searches that do not change data. (For writes: use run_sdk. To discover available methods: use search_sdk. For polling: use await ctx.sleep(ms) in your script.)',
     inputSchema: QuerySchema,
     outputSchema: SdkScriptResultSchema,
-    annotations: { ...READ_ONLY, title: 'Query SDK (read-only)' },
+    annotations: { ...READ_ONLY_OPEN_WORLD, title: 'Query SDK (read-only)' },
     securityScopes: ['mcp:read'],
     handler: querySdkScript,
   },
@@ -535,7 +540,8 @@ type ListedToolOptions = {
 };
 
 /**
- * Agent-facing tools for MCP `tools/list` and external OpenAPI.
+ * Agent-facing tools for MCP `tools/list`. External OpenAPI excludes Apps-only
+ * presentation tools with `includeAppTools: false`.
  */
 export function getMcpTools(options?: ListedToolOptions) {
   return getListedTools(options?.includeAppTools === false ? AGENT_TOOLS : ALL_MCP_TOOLS, options);

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -25,6 +25,12 @@ import { MetricSeriesSchema, metricSeries } from './admin/metric_series';
 import { QueryMetricSchema, queryMetric } from './admin/query_metric';
 import { QuerySqlSchema, querySql } from './admin/query_sql';
 import { ListOrganizationsSchema } from './organizations';
+import {
+  LOBU_INTERACTION_RESOURCE_URI,
+  LobuViewSchema,
+  RenderLobuViewSchema,
+  renderLobuView,
+} from './mcp_app';
 import { ResolvePathSchema, ResolvePathResultSchema, resolvePath } from './resolve_path';
 import { SaveContentSchema, saveContent } from './save_content';
 import { PublicSearchSchema, SearchSchema, UnifiedSearchResultSchema, search } from './search';
@@ -171,6 +177,10 @@ export interface ToolDefinition<T = any> {
    * same schema object here — one source of truth, no drift.
    */
   outputSchema?: any; // JSON Schema
+  /** OAuth scopes advertised to MCP hosts for this tool. */
+  securityScopes?: string[];
+  /** MCP extension metadata (UI resource linkage/visibility, host aliases). */
+  mcpMeta?: Record<string, unknown>;
   handler: (args: T, env: Env, ctx: ToolContext) => Promise<any>;
 }
 
@@ -202,6 +212,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     publicInputSchema: PublicSearchSchema,
     outputSchema: UnifiedSearchResultSchema,
     annotations: { ...READ_ONLY, title: 'Search memory' },
+    securityScopes: ['mcp:read'],
     handler: search,
   },
   {
@@ -210,6 +221,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
       'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
     inputSchema: SaveContentSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },
+    securityScopes: ['mcp:write'],
     handler: saveContent,
   },
   {
@@ -219,6 +231,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     inputSchema: SdkSearchSchema,
     outputSchema: SdkSearchResultSchema,
     annotations: { ...READ_ONLY, title: 'Search SDK docs' },
+    securityScopes: ['mcp:read'],
     handler: sdkSearch,
   },
   // ─── Power tools — TS scripting + raw SQL ─────────────────────────────────
@@ -229,6 +242,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     inputSchema: QuerySchema,
     outputSchema: SdkScriptResultSchema,
     annotations: { ...READ_ONLY, title: 'Query SDK (read-only)' },
+    securityScopes: ['mcp:read'],
     handler: querySdkScript,
   },
   {
@@ -237,6 +251,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
       'Run a paginated, sortable, searchable read-only SQL query (member-safe). Table references auto-scope to the bound org. SELECT FROM events reads persisted/synced content only; virtual feeds are live-only and must be read explicitly with feed or via query_sdk client.feeds.readMany. Results may include coverage.suggested_virtual_feeds. Prefer client.metrics.query for declared measures; use client.query in query_sdk for simple one-shot SQL. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects to another member org.',
     inputSchema: QuerySqlSchema,
     annotations: { ...READ_ONLY, title: 'Query SQL' },
+    securityScopes: ['mcp:read'],
     handler: querySql,
   },
   {
@@ -252,7 +267,29 @@ const AGENT_TOOLS: ToolDefinition[] = [
       idempotentHint: false,
       title: 'Run SDK',
     },
+    securityScopes: ['mcp:write'],
     handler: runSdkScript,
+  },
+];
+
+/** MCP-only presentation tools. They do not expand the REST/OpenAPI/ClientSDK surface. */
+const MCP_APP_TOOLS: ToolDefinition[] = [
+  {
+    name: 'render_lobu_view',
+    description:
+      'Render a compact Lobu card after data has been selected, or render the review card for one pending approval run. Use action="render" only when a visual card materially helps; first call Lobu data tools and pass only the final content. Use action="review_approval" with a run_id returned by a pending action. Text-only clients receive the same information as readable text.',
+    inputSchema: RenderLobuViewSchema,
+    outputSchema: LobuViewSchema,
+    annotations: { ...READ_ONLY, title: 'Render Lobu view' },
+    securityScopes: ['mcp:read'],
+    mcpMeta: {
+      ui: {
+        resourceUri: LOBU_INTERACTION_RESOURCE_URI,
+        visibility: ['model', 'app'],
+      },
+      'openai/outputTemplate': LOBU_INTERACTION_RESOURCE_URI,
+    },
+    handler: renderLobuView,
   },
 ];
 
@@ -307,7 +344,9 @@ const INTERNAL_DISPATCH_TOOLS: ToolDefinition[] = [
   },
 ];
 
+const ALL_MCP_TOOLS: ToolDefinition[] = [...AGENT_TOOLS, ...MCP_APP_TOOLS];
 const ALL_DISPATCH_TOOLS: ToolDefinition[] = [...AGENT_TOOLS, ...INTERNAL_DISPATCH_TOOLS];
+const ALL_EXECUTABLE_TOOLS: ToolDefinition[] = [...ALL_DISPATCH_TOOLS, ...MCP_APP_TOOLS];
 
 export const AGENT_TOOL_NAMES: ReadonlySet<string> = new Set(AGENT_TOOLS.map((tool) => tool.name));
 
@@ -320,7 +359,7 @@ const INTERNAL_TOOL_NAMES: ReadonlySet<string> = new Set(
 // ============================================
 
 const DISPATCH_BY_NAME: Map<string, ToolDefinition> = new Map(
-  ALL_DISPATCH_TOOLS.map((tool) => [tool.name, tool])
+  ALL_EXECUTABLE_TOOLS.map((tool) => [tool.name, tool])
 );
 
 /**
@@ -492,13 +531,14 @@ const listedToolsCache = new Map<string, ReturnType<typeof computeListedTools>>(
 type ListedToolOptions = {
   publicOnly?: boolean;
   maxAccessLevel?: 'read' | 'write' | 'admin';
+  includeAppTools?: boolean;
 };
 
 /**
  * Agent-facing tools for MCP `tools/list` and external OpenAPI.
  */
 export function getMcpTools(options?: ListedToolOptions) {
-  return getListedTools(AGENT_TOOLS, options);
+  return getListedTools(options?.includeAppTools === false ? AGENT_TOOLS : ALL_MCP_TOOLS, options);
 }
 
 /**
@@ -553,7 +593,9 @@ export function getRawDispatchTools(): RawDispatchTool[] {
 function getListedTools(source: ToolDefinition[], options?: ListedToolOptions) {
   const publicOnly = options?.publicOnly ?? false;
   const maxAccessLevel = options?.maxAccessLevel ?? 'admin';
-  const cacheKey = `${source === AGENT_TOOLS ? 'mcp' : 'all'}:${publicOnly ? 1 : 0}:${maxAccessLevel}`;
+  const sourceKey =
+    source === ALL_MCP_TOOLS ? 'mcp' : source === AGENT_TOOLS ? 'agent' : 'all';
+  const cacheKey = `${sourceKey}:${publicOnly ? 1 : 0}:${maxAccessLevel}`;
   let cached = listedToolsCache.get(cacheKey);
   if (!cached) {
     cached = computeListedTools(source, publicOnly, maxAccessLevel);
@@ -581,7 +623,6 @@ function computeListedTools(
         inputSchema = filterSchemaForPublicActions(tool.name, inputSchema);
       }
       if (!inputSchema) return null;
-
       inputSchema = filterSchemaForAccessLevel(
         tool.name,
         inputSchema,
@@ -603,6 +644,10 @@ function computeListedTools(
         description: tool.description,
         inputSchema,
         ...(tool.annotations && { annotations: tool.annotations }),
+        ...(tool.securityScopes && {
+          securitySchemes: [{ type: 'oauth2' as const, scopes: tool.securityScopes }],
+        }),
+        ...(tool.mcpMeta && { _meta: tool.mcpMeta }),
         // outputSchema keeps its discriminated variants (no flattening, no
         // access-level filtering — those are input concerns) but the MCP spec
         // requires a tool's outputSchema to be an OBJECT schema. TypeBox

--- a/packages/server/src/utils/content-search/sql-fragments.ts
+++ b/packages/server/src/utils/content-search/sql-fragments.ts
@@ -66,7 +66,7 @@ const PARENT_ROOT_JOINS_SQL = `
 
 const BASE_COLUMNS_SQL = `f.id, f.entity_ids, f.connection_id, f.feed_id, f.feed_key, f.behavior_id, fd.display_name as feed_name, COALESCE(wv.name, 'Behavior #' || f.behavior_id) as behavior_name, f.payload_text, f.title, f.author_name, f.source_url, f.occurred_at, f.semantic_type,
           f.connector_key as platform, f.origin_id, f.origin_parent_id, f.score, f.metadata, f.payload_type, f.payload_data, f.payload_template, f.attachments, f.origin_type,
-          f.interaction_type, f.interaction_status, f.interaction_input_schema, f.interaction_input, f.interaction_output, f.interaction_error, f.supersedes_event_id`;
+          f.interaction_type, f.interaction_status, f.interaction_input_schema, f.interaction_input, f.interaction_output, f.interaction_error, f.supersedes_event_id, f.run_id`;
 
 const CLASSIFICATION_COLUMNS_SQL = `fcl_all.attribute_key as classifier_attribute_key,
           lc_all."values" as classifier_values,

--- a/packages/server/src/utils/openapi-generator.ts
+++ b/packages/server/src/utils/openapi-generator.ts
@@ -167,7 +167,7 @@ function truncateDescription(text: string, maxLength: number = 300): string {
  * Generates OpenAPI 3.1.0 spec from tool registry
  */
 export function generateOpenAPISpec(serverUrl: string) {
-  const tools = getMcpTools();
+  const tools = getMcpTools({ includeAppTools: false });
   const paths: Record<string, any> = {};
 
   for (const tool of tools) {

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -2,6 +2,7 @@ import { verifyWorkerToken } from '@lobu/core';
 import { getAuthConfig as getAuthConfigFromEnv } from '../auth/config';
 import { createAuth } from '../auth/index';
 import { OAuthProvider } from '../auth/oauth/provider';
+import { buildBearerChallenge } from '../auth/oauth/resource-challenge';
 import type { AuthInfo } from '../auth/oauth/types';
 import { PersonalAccessTokenService } from '../auth/tokens';
 import { isPublicReadable } from '../auth/tool-access';
@@ -273,7 +274,10 @@ export class MultiTenantProvider implements WorkspaceProvider {
           { error: 'invalid_token', error_description: 'Invalid or expired worker token' },
           401,
           {
-            'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+            'WWW-Authenticate': buildBearerChallenge(c.req.raw, {
+              error: 'invalid_token',
+              errorDescription: 'Invalid or expired worker token',
+            }),
           }
         );
       }
@@ -288,7 +292,10 @@ export class MultiTenantProvider implements WorkspaceProvider {
           { error: 'invalid_token', error_description: 'Worker token missing agent context' },
           401,
           {
-            'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+            'WWW-Authenticate': buildBearerChallenge(c.req.raw, {
+              error: 'invalid_token',
+              errorDescription: 'Worker token missing agent context',
+            }),
           }
         );
       }
@@ -316,7 +323,10 @@ export class MultiTenantProvider implements WorkspaceProvider {
           { error: 'invalid_token', error_description: 'Worker token missing admin-tools actor' },
           401,
           {
-            'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+            'WWW-Authenticate': buildBearerChallenge(c.req.raw, {
+              error: 'invalid_token',
+              errorDescription: 'Worker token missing admin-tools actor',
+            }),
           }
         );
       }
@@ -392,7 +402,10 @@ export class MultiTenantProvider implements WorkspaceProvider {
             { error: 'invalid_token', error_description: 'Invalid or expired access token' },
             401,
             {
-              'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+              'WWW-Authenticate': buildBearerChallenge(c.req.raw, {
+                error: 'invalid_token',
+                errorDescription: 'Invalid or expired access token',
+              }),
             }
           );
         }
@@ -634,7 +647,10 @@ export class MultiTenantProvider implements WorkspaceProvider {
         { error: 'invalid_token', error_description: 'Invalid or expired access token' },
         401,
         {
-          'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+          'WWW-Authenticate': buildBearerChallenge(c.req.raw, {
+            error: 'invalid_token',
+            errorDescription: 'Invalid or expired access token',
+          }),
         }
       );
     }
@@ -652,7 +668,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
           error_description: 'Authentication required. Use OAuth or API key.',
         },
         401,
-        { 'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource"` }
+        { 'WWW-Authenticate': buildBearerChallenge(c.req.raw) }
       );
     }
 


### PR DESCRIPTION
## Summary

- advertise the versioned `ui://lobu/interaction/v1` MCP App resource with the standard profile MIME, tool/resource metadata, OAuth security schemes, and path-specific RFC 9728 challenges
- add MCP-only `render_lobu_view` with a small server-authored text/code/diff schema, recursive secret redaction, bounded safe rendering, and an explicit dispatcher guard that keeps it out of REST/OpenAPI/ClientSDK
- keep external MCP approvals fail-closed: the app can display a safe `Review in Lobu` http(s) link, but cannot submit Approve/Reject; Lobu-owned UI retains authenticated inline actions
- render producer-authored approval fields rather than internal execution envelopes, preserve explicit `null` versus empty-string values, and pin the matching Owletto card fix from https://github.com/lobu-ai/owletto/pull/765

## Test plan

- [x] Exact-head `make pre-pr` clean (build + isolated MCP App self-containment check + typecheck + knip + lint + exposed-surface naming)
- [x] Exact-head focused MCP/auth/resource/rendering/ACL/REST tests: 72 passed, 2 intentional skips
- [x] Producer-shaped Behavior approval regression: field-level diff only; no `args`, `actingAgentId`, or `actingWatcherId`
- [x] Null/empty regressions in both server text output and the visible Owletto interaction card
- [x] Owletto `bun run build`, isolated MCP App bundle check, and full Vitest: 153 files, 1295 tests
- [x] Full `make test-integration` clean on the feature tree: server 406 files / 3592 passed / 2 skipped; Lobu route and scheduled 205 passed; connector-worker subprocess E2E 8 passed; all serial gateway lanes green
- [x] Browser protocol harness: initialize, tool-result render, resize, and exact safe open-link routing
- [x] Security regression: private-connection approval is denied to another member; owning user receives only a review link
- [x] REST boundary regression: `POST /api/:orgSlug/render_lobu_view` returns 404 while MCP `tools/call` remains available
- [x] Hosted comparison artifact contains exact parent/Owletto SHAs and returns HTTP 200

## Notes

- Verified against exact head `30da55e196babf9ab4c021a0af5077f3018625b8`.
- Pinned Owletto main SHA: `c3d58e164a3755e6ccd383dac362969c17eeed7e`.
- No table/schema change and no public REST/SDK contract expansion.
- MCP App resource: `ui://lobu/interaction/v1`; MIME: `text/html;profile=mcp-app`.
- UI proof: https://htmlpreview.github.io/?https://gist.githubusercontent.com/buremba/89963c1a4299aba1f83a9007bcd4b6bc/raw/6c3730c4cdc6a22109d75cadd51003183fc61a3d/comparison.html
