### PR TITLE
fix(mcp): harden production app readiness

### DIFF
--- a/packages/cli/src/commands/memory/_lib/mcp.ts
+++ b/packages/cli/src/commands/memory/_lib/mcp.ts
@@ -108,6 +108,7 @@ async function mcpFetch(
   mcpUrl: string,
   body: Record<string, unknown>,
   sessionId?: string,
+  protocolVersion?: string,
   contextName?: string
 ): Promise<{ data: JsonRpcResponse; usedUrl: string; response: Response }> {
   const headers: Record<string, string> = {
@@ -120,6 +121,7 @@ async function mcpFetch(
   headers.Accept = JSON_MCP_ACCEPT;
   if (sessionId) {
     headers["mcp-session-id"] = sessionId;
+    headers["MCP-Protocol-Version"] = protocolVersion ?? MCP_PROTOCOL_VERSION;
   }
 
   const { response: res, usedUrl } = await fetchMcpWithFallback(mcpUrl, {
@@ -150,7 +152,7 @@ async function mcpFetch(
 async function initializeMcpSession(
   mcpUrl: string,
   contextName?: string
-): Promise<{ sessionId: string; usedUrl: string }> {
+): Promise<{ sessionId: string; protocolVersion: string; usedUrl: string }> {
   const { data, usedUrl, response } = await mcpFetch(
     mcpUrl,
     {
@@ -163,6 +165,7 @@ async function initializeMcpSession(
         clientInfo: { name: "lobu-memory", version: "1.0.0" },
       },
     },
+    undefined,
     undefined,
     contextName
   );
@@ -180,6 +183,15 @@ async function initializeMcpSession(
     );
   }
 
+  const protocolVersion = (
+    data.result as { protocolVersion?: unknown } | undefined
+  )?.protocolVersion;
+  if (typeof protocolVersion !== "string" || protocolVersion.length === 0) {
+    throw new ApiError(
+      `MCP initialize via ${usedUrl} did not return a protocolVersion`
+    );
+  }
+
   await mcpFetch(
     mcpUrl,
     {
@@ -187,10 +199,11 @@ async function initializeMcpSession(
       method: "notifications/initialized",
     },
     sessionId,
+    protocolVersion,
     contextName
   );
 
-  return { sessionId, usedUrl };
+  return { sessionId, protocolVersion, usedUrl };
 }
 
 export async function mcpRpc(
@@ -199,7 +212,10 @@ export async function mcpRpc(
   params?: Record<string, unknown>,
   contextName?: string
 ) {
-  const { sessionId } = await initializeMcpSession(mcpUrl, contextName);
+  const { sessionId, protocolVersion } = await initializeMcpSession(
+    mcpUrl,
+    contextName
+  );
   const { data } = await mcpFetch(
     mcpUrl,
     {
@@ -209,6 +225,7 @@ export async function mcpRpc(
       params: params || {},
     },
     sessionId,
+    protocolVersion,
     contextName
   );
 

--- a/packages/cli/src/commands/memory/_lib/memory-auth.test.ts
+++ b/packages/cli/src/commands/memory/_lib/memory-auth.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { MCP_PROTOCOL_VERSION } from "@lobu/core";
 import * as internal from "../../../internal/index.js";
+import { memoryRunCommand } from "../run.js";
 import { mcpRpc } from "./mcp.js";
 import { getSessionForOrg, getUsableToken } from "./memory-auth.js";
-import { memoryRunCommand } from "../run.js";
 
 const CLOUD_MCP_URL = "https://lobu.ai/mcp";
 
@@ -59,11 +60,23 @@ describe("memory auth URL resolution", () => {
       });
       const body = JSON.parse(String(init?.body)) as { method?: string };
       if (body.method === "initialize") {
-        return new Response(JSON.stringify({ result: {} }), {
-          status: 200,
-          headers: { "mcp-session-id": "test-session" },
-        });
+        return new Response(
+          JSON.stringify({
+            result: {
+              protocolVersion: MCP_PROTOCOL_VERSION,
+              capabilities: { tools: {} },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "mcp-session-id": "test-session" },
+          }
+        );
       }
+      expect(init?.headers).toMatchObject({
+        "mcp-session-id": "test-session",
+        "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+      });
       if (body.method === "tools/list") {
         return new Response(
           JSON.stringify({

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -25,7 +25,7 @@ export const TIME = {
  * MCP protocol version this codebase advertises on `initialize` handshakes.
  * Kept in one place so the gateway, CLI, and native runtime stay in lockstep.
  */
-export const MCP_PROTOCOL_VERSION = "2025-03-26";
+export const MCP_PROTOCOL_VERSION = "2025-11-25";
 
 /**
  * Chat platforms Lobu operates a hosted bot for. A project connection using

--- a/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
+++ b/packages/server/src/__tests__/integration/behavior-health-surfacing.test.ts
@@ -21,6 +21,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../../index";
 import { getSchedulerHealth } from "../../scheduled/scheduler-health";
 import { manageBehaviors } from "../../tools/admin/manage_behaviors";
+import { getBehavior } from "../../tools/get_behavior";
 import { computeBehaviorHealth } from "../../watchers/behavior-health";
 import { initWorkspaceProvider } from "../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
@@ -229,6 +230,28 @@ describe("behavior health surfacing (#2033)", () => {
       "Agent never called client.behaviors.completeWindow()",
     );
     expect(JSON.stringify(row)).not.toContain("client.watchers.");
+  });
+
+  it("3.5: get_behavior rewrites legacy persisted run errors everywhere", async () => {
+    const { behaviorId, ctx } = await createScheduledBehavior();
+    await getTestDb()`
+      INSERT INTO runs
+        (organization_id, run_type, watcher_id, status, approval_status,
+         error_message, created_at, completed_at)
+      VALUES
+        (${ctx.organizationId}, 'behavior', ${behaviorId}, 'failed', 'auto',
+         'Agent never called client.watchers.completeWindow()',
+         current_timestamp - interval '2 minutes', current_timestamp - interval '1 minute')
+    `;
+
+    const result = await getBehavior({ behavior_id: String(behaviorId) }, {} as Env, ctx);
+    expect(result.behavior?.behavior_run?.error_message).toBe(
+      "Agent never called client.behaviors.completeWindow()"
+    );
+    expect(result.behavior?.last_scheduling_error).toBe(
+      "Agent never called client.behaviors.completeWindow()"
+    );
+    expect(JSON.stringify(result)).not.toContain("client.watchers.");
   });
 
   it("3.2: getSchedulerHealth surfaces an overdue behavior in issues[]", async () => {

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -7,6 +7,7 @@
  * - Unauthenticated discovery requests
  */
 
+import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
@@ -75,8 +76,8 @@ describe('MCP Authentication', () => {
       });
 
       expect(response.status).toBe(401);
-      expect(response.headers.get('WWW-Authenticate')).toContain(
-        '/.well-known/oauth-protected-resource'
+      expect(response.headers.get('WWW-Authenticate')).toBe(
+        'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp", scope="mcp:read mcp:write"'
       );
     });
 
@@ -355,6 +356,32 @@ describe('MCP Authentication', () => {
 
       expect(result.tools).toBeInstanceOf(Array);
       expect(result.tools.length).toBeGreaterThan(0);
+    });
+
+    it('rejects an OAuth token bound to a different MCP resource', async () => {
+      const { token } = await createTestAccessToken(user.id, org.id, client.client_id, {
+        resource: `http://localhost/mcp/${org.slug}`,
+      });
+
+      await expect(mcpListTools({ token, orgSlug: org2.slug })).rejects.toThrow();
+
+      const response = await post(`/mcp/${org2.slug}`, {
+        body: {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: MCP_PROTOCOL_VERSION,
+            capabilities: {},
+            clientInfo: { name: 'audience-test', version: '1.0.0' },
+          },
+        },
+        token,
+      });
+      expect(response.status).toBe(401);
+      expect(response.headers.get('WWW-Authenticate')).toBe(
+        `Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/mcp/${org2.slug}", scope="mcp:read mcp:write", error="invalid_token"`
+      );
     });
 
     it('allows a public-org scoped OAuth token for a non-member and only exposes public tools', async () => {
@@ -718,10 +745,9 @@ describe('MCP Authentication', () => {
       const aliceSessionId = await initMcpSession(aliceToken);
       const bobSessionId = await initMcpSession(bobToken);
 
-      const response = await del(
-        `/api/${org.slug}/clients/mcp/${sharedClient.client_id}`,
-        { cookie: revokerSession.cookieHeader }
-      );
+      const response = await del(`/api/${org.slug}/clients/mcp/${sharedClient.client_id}`, {
+        cookie: revokerSession.cookieHeader,
+      });
       expect(response.status).toBe(200);
 
       const tokenRows = await getTestDb()`
@@ -1084,7 +1110,15 @@ describe('MCP Authentication', () => {
       // via REST and tools/call by name but are not advertised here.
       const toolNames = result.tools.map((t: any) => t.name);
       expect(toolNames.sort()).toEqual(
-        ['query_sdk', 'query_sql', 'run_sdk', 'save_memory', 'search_memory', 'search_sdk'].sort()
+        [
+          'query_sdk',
+          'query_sql',
+          'render_lobu_view',
+          'run_sdk',
+          'save_memory',
+          'search_memory',
+          'search_sdk',
+        ].sort()
       );
       expect(toolNames).not.toContain('list_organizations');
       expect(toolNames).not.toContain('list_metrics');

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -1,11 +1,16 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { insertEvent } from '../../../utils/insert-event';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
   addUserToOrganization,
   createTestAccessToken,
+  createTestAgent,
+  createTestConnection,
   createTestOAuthClient,
   createTestOrganization,
   createTestUser,
@@ -21,6 +26,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
   let owner: Awaited<ReturnType<typeof createTestUser>>;
   let client: Awaited<ReturnType<typeof createTestOAuthClient>>;
+  let actingAgent: Awaited<ReturnType<typeof createTestAgent>>;
   let token: string;
   let tmpRoot: string;
   const prevWebDist = process.env.WEB_DIST_DIR;
@@ -34,18 +40,25 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     // resolver in index.ts skips this WEB_DIST_DIR and is unaffected. Set this
     // BEFORE any resources/read — the bundle resolver caches misses per process.
     tmpRoot = mkdtempSync(join(tmpdir(), 'lobu-mcp-app-'));
-    mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'interaction'), { recursive: true });
-    writeFileSync(
-      join(tmpRoot, 'dist-mcp-apps', 'interaction', 'index.html'),
-      STUB_HTML
-    );
+    mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'interaction'), {
+      recursive: true,
+    });
+    writeFileSync(join(tmpRoot, 'dist-mcp-apps', 'interaction', 'index.html'), STUB_HTML);
     process.env.WEB_DIST_DIR = join(tmpRoot, 'dist');
 
     await cleanupTestDatabase();
     await seedSystemEntityTypes();
-    org = await createTestOrganization({ name: 'MCP App Org', slug: 'mcp-app-org' });
+    org = await createTestOrganization({
+      name: 'MCP App Org',
+      slug: 'mcp-app-org',
+    });
     owner = await createTestUser({ email: 'mcp-app-owner@test.example.com' });
     await addUserToOrganization(owner.id, org.id, 'owner');
+    actingAgent = await createTestAgent({
+      organizationId: org.id,
+      ownerUserId: owner.id,
+      agentId: 'mcp-app-render-agent',
+    });
     client = await createTestOAuthClient();
     token = (
       await createTestAccessToken(owner.id, org.id, client.client_id, {
@@ -60,38 +73,64 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  async function initSession(path: string): Promise<string> {
+  async function initSession(
+    path: string,
+    options: {
+      sessionToken?: string;
+      agentId?: string;
+      advertiseMcpApps?: boolean;
+      headers?: Record<string, string>;
+    } = {}
+  ): Promise<string> {
+    const sessionToken = options.sessionToken ?? token;
+    const advertiseMcpApps = options.advertiseMcpApps ?? true;
     const initResponse = await post(path, {
       body: {
         jsonrpc: '2.0',
         id: '__test_init__',
         method: 'initialize',
         params: {
-          protocolVersion: '2025-03-26',
-          capabilities: {},
-          clientInfo: { name: 'lobu-test', version: '1.0' },
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: advertiseMcpApps
+            ? {
+                extensions: {
+                  'io.modelcontextprotocol/ui': {
+                    mimeTypes: ['text/html;profile=mcp-app'],
+                  },
+                },
+              }
+            : {},
+          clientInfo: {
+            name: 'lobu-test',
+            version: '1.0',
+            ...(options.agentId ? { agentId: options.agentId } : {}),
+          },
         },
       },
-      token,
+      headers: options.headers,
+      token: sessionToken,
     });
     const sessionId = initResponse.headers.get('mcp-session-id');
     expect(sessionId).toBeTruthy();
     await post(path, {
       body: { jsonrpc: '2.0', method: 'notifications/initialized' },
-      headers: { 'mcp-session-id': sessionId! },
-      token,
+      headers: {
+        'mcp-session-id': sessionId!,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token: sessionToken,
     });
     return sessionId!;
   }
 
-  it('serves the ui://lobu/interaction bundle over resources/read', async () => {
+  it('serves the versioned Lobu interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction' },
+        params: { uri: 'ui://lobu/interaction/v1' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -100,12 +139,19 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction');
-    expect(content?.mimeType).toBe('text/html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v1');
+    expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-interaction-stub');
+    expect(content?._meta?.ui?.csp).toEqual({
+      connectDomains: [],
+      resourceDomains: [],
+      frameDomains: [],
+    });
+    expect(content?._meta?.ui?.prefersBorder).toBe(true);
+    expect(content?._meta?.ui?.domain).toBeUndefined();
   });
 
-  it('advertises description, csp, and domain metadata on resources/list', async () => {
+  it('advertises description and CSP metadata on resources/list without claiming a dedicated app domain', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
@@ -120,19 +166,137 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v1'
     );
     expect(resource).toBeDefined();
     // description is a typed resource field surfaced in client browsers.
     expect(typeof resource.description).toBe('string');
     expect(resource.description.length).toBeGreaterThan(0);
-    // CSP + domain ride the _meta.ui passthrough (host conventions, SDK $loose).
-    expect(resource._meta?.ui?.csp).toMatch(/script-src/);
-    expect(resource._meta?.ui?.domain).toMatch(/^https?:\/\//);
+    // CSP rides the current nested _meta.ui shape. ui.domain is intentionally
+    // absent because it means a dedicated sandbox origin, not the MCP server.
+    expect(resource.mimeType).toBe('text/html;profile=mcp-app');
+    expect(resource._meta?.ui?.csp).toEqual({
+      connectDomains: [],
+      resourceDomains: [],
+      frameDomains: [],
+    });
+    expect(resource._meta?.ui?.prefersBorder).toBe(true);
+    expect(resource._meta?.ui?.domain).toBeUndefined();
   });
 
-  it('returns a pending manage_agents approval as plain text, without tool-result _meta', async () => {
+  it('advertises a dedicated render tool with Apps, OAuth, and safety metadata', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const tool = body.result?.tools?.find(
+      (entry: { name?: string }) => entry.name === 'render_lobu_view'
+    );
+    expect(tool).toEqual(
+      expect.objectContaining({
+        annotations: expect.objectContaining({
+          readOnlyHint: true,
+          destructiveHint: false,
+          openWorldHint: false,
+          idempotentHint: true,
+        }),
+        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
+        _meta: expect.objectContaining({
+          securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
+          ui: expect.objectContaining({
+            resourceUri: 'ui://lobu/interaction/v1',
+            visibility: ['model', 'app'],
+          }),
+          'openai/outputTemplate': 'ui://lobu/interaction/v1',
+        }),
+      })
+    );
+
+    const runSdk = body.result?.tools?.find((entry: { name?: string }) => entry.name === 'run_sdk');
+    expect(runSdk?._meta?.ui).toBeUndefined();
+    for (const listed of body.result?.tools ?? []) {
+      expect(listed.securitySchemes?.[0]?.type).toBe('oauth2');
+      expect(listed.annotations?.readOnlyHint).toEqual(expect.any(Boolean));
+      expect(listed.annotations?.destructiveHint).toEqual(expect.any(Boolean));
+      expect(listed.annotations?.openWorldHint).toEqual(expect.any(Boolean));
+    }
+  });
+
+  it('returns a validated LobuViewV1 with a safe text fallback', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 12,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: {
+            action: 'render',
+            title: 'Release readiness',
+            tone: 'default',
+            blocks: [
+              { type: 'text', label: 'Status', value: 'Ready for review.' },
+              { type: 'code', value: 'sha: 1234abcd' },
+              { type: 'text', label: 'apiKey', value: 'must-not-render' },
+            ],
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    expect(body.result?.structuredContent).toEqual({
+      version: 1,
+      title: 'Release readiness',
+      tone: 'default',
+      blocks: [
+        { type: 'text', label: 'Status', value: 'Ready for review.' },
+        { type: 'code', value: 'sha: 1234abcd' },
+        { type: 'text', label: 'apiKey', value: '[redacted]' },
+      ],
+      actions: [],
+    });
+    expect(body.result?.content?.[0]?.text).toContain('Release readiness');
+    expect(body.result?.content?.[0]?.text).toContain('Ready for review\\.');
+    expect(JSON.stringify(body.result)).not.toContain('must-not-render');
+  });
+
+  it('keeps the text fallback when the client does not advertise MCP Apps support', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`, {
+      advertiseMcpApps: false,
+    });
+    const response = await post(`/mcp/${org.slug}`, {
+      body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      headers: {
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const tool = body.result?.tools?.find(
+      (entry: { name?: string }) => entry.name === 'render_lobu_view'
+    );
+    expect(tool?._meta?.ui).toBeUndefined();
+    expect(typeof tool?.description).toBe('string');
+  });
+
+  it('keeps an approval mutation text-only and renders a safe review link separately', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`, {
+      agentId: actingAgent.agentId,
+    });
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
@@ -154,15 +318,228 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.result?.isError).not.toBe(true);
-    // The pending approval still returns its text result, but the tool result no
-    // longer carries an MCP App UI pointer: our own SPA builds the interaction
-    // view CLIENT-side from the SSE card payload, and external-host rendering
-    // (which needs the SERVER to author that view) is a deliberate follow-up.
-    // Assert the pointer is absent so we don't silently re-introduce a `_meta`
-    // that points a host at a bundle it can't feed from raw data.
+    // The mutating tool is not coupled to UI. A separate read-only call authors
+    // the review view, so text-only clients still receive the pending result.
     expect(body.result?._meta?.ui).toBeUndefined();
     expect(body.result?.structuredContent).toBeUndefined();
     expect(typeof body.result?.content?.[0]?.text).toBe('string');
+
+    const [approval] = await getDb()<{ run_id: number }>`
+      SELECT run_id
+      FROM current_event_records
+      WHERE organization_id = ${org.id}
+        AND interaction_type = 'approval'
+        AND run_id IS NOT NULL
+      ORDER BY id DESC
+      LIMIT 1
+    `;
+    const runId = Number(approval?.run_id);
+    expect(runId).toBeGreaterThan(0);
+    const renderResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 21,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: { action: 'review_approval', run_id: runId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const renderBody = await renderResponse.json();
+    expect(renderBody.result?.isError).not.toBe(true);
+    const view = renderBody.result?.structuredContent;
+    expect(view?.version).toBe(1);
+    expect(view?.tone).toBe('warning');
+    expect(view?.actions).toEqual([
+      expect.objectContaining({
+        id: 'review',
+        label: 'Review in Lobu',
+        href: expect.stringMatching(/^https?:\/\//),
+      }),
+    ]);
+    expect(view?.actions?.some((action: { id?: string }) => action.id === 'approve')).toBe(false);
+    expect(view?.actions?.some((action: { id?: string }) => action.id === 'reject')).toBe(false);
+  });
+
+  it('redacts approval secrets before key context is lost and enforces view limits', async () => {
+    const [run] = await getDb()<{ id: number }>`
+      INSERT INTO runs (organization_id, run_type, status, approval_status)
+      VALUES (${org.id}, 'action', 'pending', 'pending')
+      RETURNING id
+    `;
+    const proposal: Record<string, unknown> = {
+      token: 'plaintext-top-token',
+      apiKey: 'plaintext-top-api-key',
+      settings: {
+        authorization: 'plaintext-nested-authorization',
+        endpoint: 'postgres://user:plaintext-uri-password@example.com/db',
+      },
+    };
+    const current: Record<string, unknown> = {
+      token: 'plaintext-old-token',
+      apiKey: 'plaintext-old-api-key',
+    };
+    for (let index = 0; index < 130; index += 1) {
+      proposal[`field_${index}_${'x'.repeat(150)}`] = `value_${index}_${'y'.repeat(21_000)}`;
+    }
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `mcp_app_secret_approval_${run.id}`,
+      title: `${'Long approval title '.repeat(20)}— pending approval`,
+      content: 'Review the bounded proposal.',
+      semanticType: 'operation',
+      runId: Number(run.id),
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+      metadata: { proposal, current },
+    });
+
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 210,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: { action: 'review_approval', run_id: Number(run.id) },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    const view = body.result?.structuredContent;
+    const serialized = JSON.stringify(view);
+    expect(serialized).not.toContain('plaintext-top-token');
+    expect(serialized).not.toContain('plaintext-top-api-key');
+    expect(serialized).not.toContain('plaintext-old-token');
+    expect(serialized).not.toContain('plaintext-old-api-key');
+    expect(serialized).not.toContain('plaintext-nested-authorization');
+    expect(serialized).not.toContain('plaintext-uri-password');
+    expect(serialized).toContain('[redacted]');
+    expect(view.title.length).toBeLessThanOrEqual(200);
+    expect(view.blocks.length).toBeLessThanOrEqual(100);
+    expect(view.actions.length).toBeLessThanOrEqual(10);
+    const diffFields = view.blocks.flatMap((block: any) => block.fields ?? []);
+    expect(diffFields.length).toBeLessThanOrEqual(100);
+    for (const field of diffFields) {
+      expect(field.label.length).toBeLessThanOrEqual(120);
+      expect(field.before?.length ?? 0).toBeLessThanOrEqual(20_000);
+      expect(field.after.length).toBeLessThanOrEqual(20_000);
+    }
+  });
+
+  it('does not render an approval from another member private connection', async () => {
+    const member = await createTestUser({
+      email: 'mcp-app-member@test.example.com',
+    });
+    await addUserToOrganization(member.id, org.id, 'member');
+    const memberToken = (
+      await createTestAccessToken(member.id, org.id, client.client_id, {
+        scope: 'mcp:read profile:read',
+      })
+    ).token;
+    const privateConnection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      created_by: owner.id,
+      visibility: 'private',
+      createDefaultFeed: false,
+    });
+    const [run] = await getDb()<{ id: number }>`
+      INSERT INTO runs (
+        organization_id, run_type, status, approval_status, connection_id,
+        connector_key, action_key
+      ) VALUES (
+        ${org.id}, 'action', 'pending', 'pending', ${privateConnection.id},
+        'github', 'create_issue'
+      )
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `mcp_app_private_approval_${runId}`,
+      title: 'Private action — pending approval',
+      content: 'This approval must remain private to the connection owner.',
+      semanticType: 'operation',
+      connectorKey: 'github',
+      connectionId: privateConnection.id,
+      runId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+    });
+
+    const sessionId = await initSession(`/mcp/${org.slug}`, {
+      sessionToken: memberToken,
+    });
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 211,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: { action: 'review_approval', run_id: runId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token: memberToken,
+    });
+    const body = await response.json();
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.structuredContent).toBeUndefined();
+    expect(body.result?.content?.[0]?.text).toBe(`Approval run ${runId} was not found`);
+  });
+
+  it('retains the initialized public resource URL in a later scope challenge', async () => {
+    const readlessToken = (
+      await createTestAccessToken(owner.id, org.id, client.client_id, {
+        scope: 'profile:read',
+      })
+    ).token;
+    const sessionId = await initSession(`/mcp/${org.slug}`, {
+      sessionToken: readlessToken,
+      headers: {
+        host: 'internal.service:8787',
+        'x-forwarded-host': 'mcp.public.example',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 22,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: {
+            action: 'render',
+            blocks: [{ type: 'text', value: 'scope probe' }],
+          },
+        },
+      },
+      // Deliberately omit forwarded headers after initialize. The transport
+      // must challenge against the canonical URL retained by the session.
+      headers: { 'mcp-session-id': sessionId },
+      token: readlessToken,
+    });
+    const body = await response.json();
+    const challenge = body.result?._meta?.['mcp/www_authenticate']?.[0];
+    expect(body.result?.isError).toBe(true);
+    expect(challenge).toContain(
+      `resource_metadata="https://mcp.public.example/.well-known/oauth-protected-resource/mcp/${org.slug}"`
+    );
+    expect(challenge).toContain('error="insufficient_scope"');
+    expect(challenge).toContain('scope="mcp:read"');
+    expect(challenge).not.toContain('internal.service');
   });
 
   it('emits structuredContent for a tool that declares an outputSchema', async () => {
@@ -195,5 +572,59 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     // The text content is still present (clients that ignore structuredContent
     // get the same data as text).
     expect(typeof body.result?.content?.[0]?.text).toBe('string');
+  });
+
+  it('keeps x-mcp-format isolated across concurrent MCP sessions', async () => {
+    const jsonSessionId = await initSession(`/mcp/${org.slug}`);
+    const markdownSessionId = await initSession(`/mcp/${org.slug}`);
+
+    // Keep the JSON-formatted request inside its tool handler while a second
+    // request enters the MCP boundary with the default markdown format. A
+    // process-global format flag lets the second request overwrite the first.
+    const jsonRequest = post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: {
+          name: 'query_sdk',
+          arguments: {
+            script:
+              'export default async (ctx) => { await ctx.sleep(150); return { marker: "json-session" }; };',
+          },
+        },
+      },
+      headers: {
+        'mcp-session-id': jsonSessionId,
+        'x-mcp-format': 'json',
+      },
+      token,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const markdownResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'search_sdk', arguments: { query: 'entities.list' } },
+      },
+      headers: { 'mcp-session-id': markdownSessionId },
+      token,
+    });
+
+    expect(markdownResponse.status).toBe(200);
+    const markdownBody = await markdownResponse.json();
+    expect(markdownBody.result?.content?.[0]?.text).toMatch(/^```json/);
+
+    const jsonResponse = await jsonRequest;
+    expect(jsonResponse.status).toBe(200);
+    const jsonBody = await jsonResponse.json();
+    const jsonText = jsonBody.result?.content?.[0]?.text as string;
+    expect(jsonText).toMatch(/^\{/);
+    expect(JSON.parse(jsonText)).toMatchObject({
+      success: true,
+      return_value: { marker: 'json-session' },
+    });
   });
 });

--- a/packages/server/src/__tests__/integration/oauth/agent-claim-discovery.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/agent-claim-discovery.test.ts
@@ -109,6 +109,58 @@ describe('auth.md discovery surface', () => {
 });
 
 describe('user_claimed flow — full loop', () => {
+  it('rejects an MCP device authorization that omits its resource audience', async () => {
+    const app = buildApp();
+    const reg = await call(app, 'POST', '/oauth/register', {
+      body: {
+        client_name: 'Unbound Claim Agent',
+        grant_types: [DEVICE_GRANT, 'refresh_token'],
+        token_endpoint_auth_method: 'none',
+      },
+    });
+    expect(reg.status).toBe(201);
+    const client = (await reg.json()) as { client_id: string };
+
+    const response = await call(app, 'POST', '/oauth/device_authorization', {
+      body: {
+        client_id: client.client_id,
+        scope: 'mcp:read mcp:write',
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()) as { error: string }).toEqual(
+      expect.objectContaining({ error: 'invalid_request' }),
+    );
+  });
+
+  it('rejects a cross-origin resource at the token endpoint before grant exchange', async () => {
+    const app = buildApp();
+    const reg = await call(app, 'POST', '/oauth/register', {
+      body: {
+        client_name: 'Cross-Origin Claim Agent',
+        grant_types: [DEVICE_GRANT, 'refresh_token'],
+        token_endpoint_auth_method: 'none',
+      },
+    });
+    expect(reg.status).toBe(201);
+    const client = (await reg.json()) as { client_id: string };
+
+    const response = await call(app, 'POST', '/oauth/token', {
+      body: {
+        grant_type: DEVICE_GRANT,
+        client_id: client.client_id,
+        device_code: 'not-a-real-device-code',
+        resource: 'https://evil.example/mcp',
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()) as { error: string }).toEqual(
+      expect.objectContaining({ error: 'invalid_request' }),
+    );
+  });
+
   it('agent registers a user by email and collects a scoped credential after consent', async () => {
     const app = buildApp();
     const org = await createTestOrganization({ name: 'Claim Org' });
@@ -155,9 +207,29 @@ describe('user_claimed flow — full loop', () => {
     expect(approve.status).toBe(200);
     expect((await approve.json()) as { status: string }).toEqual({ status: 'approved' });
 
-    // 5. Agent polls and collects the scoped credential.
+    // 5. A mismatched audience is rejected without consuming the one-time
+    // device code, so the correctly bound client can still complete.
+    const mismatch = await call(app, 'POST', '/oauth/token', {
+      body: {
+        grant_type: DEVICE_GRANT,
+        device_code,
+        client_id: client.client_id,
+        resource: `${ORIGIN}/mcp/not-the-authorized-org`,
+      },
+    });
+    expect(mismatch.status).toBe(400);
+    expect((await mismatch.json()) as { error: string }).toMatchObject({
+      error: 'invalid_grant',
+    });
+
+    // 6. Agent polls with the exact audience and collects the scoped credential.
     const tokenRes = await call(app, 'POST', '/oauth/token', {
-      body: { grant_type: DEVICE_GRANT, device_code, client_id: client.client_id },
+      body: {
+        grant_type: DEVICE_GRANT,
+        device_code,
+        client_id: client.client_id,
+        resource: `${ORIGIN}/mcp/${org.slug}`,
+      },
     });
     expect(tokenRes.status).toBe(200);
     const tokens = (await tokenRes.json()) as { access_token: string; scope?: string };

--- a/packages/server/src/__tests__/integration/oauth/device-email-claim.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/device-email-claim.test.ts
@@ -37,6 +37,7 @@ async function pendingUserCode(): Promise<string> {
     body: {
       client_id: client.client_id,
       scope: 'mcp:read mcp:write',
+      resource: 'http://localhost/mcp',
     },
   });
   expect(device.status).toBe(200);

--- a/packages/server/src/__tests__/integration/oauth/discovery.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/discovery.test.ts
@@ -8,6 +8,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import { get } from '../../setup/test-helpers';
+import { __resetPublicOriginCachesForTests } from '../../../utils/public-origin';
 
 describe('OAuth Discovery Endpoints', () => {
   beforeAll(async () => {
@@ -51,6 +52,33 @@ describe('OAuth Discovery Endpoints', () => {
       const authServerOrigin = new URL(body.authorization_servers[0]).origin;
 
       expect(resourceOrigin).toBe(authServerOrigin);
+    });
+
+    it('keeps the configured MCP resource origin when OAuth is served on a workspace host', async () => {
+      const originalPublicGatewayUrl = process.env.PUBLIC_GATEWAY_URL;
+      try {
+        process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+        __resetPublicOriginCachesForTests();
+
+        const response = await get('/.well-known/oauth-protected-resource/mcp/acme', {
+          headers: {
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host': 'acme.lobu.ai',
+          },
+        });
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.resource).toBe('https://app.lobu.ai/mcp/acme');
+        expect(body.authorization_servers).toEqual(['https://acme.lobu.ai']);
+      } finally {
+        if (originalPublicGatewayUrl === undefined) {
+          delete process.env.PUBLIC_GATEWAY_URL;
+        } else {
+          process.env.PUBLIC_GATEWAY_URL = originalPublicGatewayUrl;
+        }
+        __resetPublicOriginCachesForTests();
+      }
     });
   });
 

--- a/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
@@ -142,6 +142,7 @@ describe('Stage 1 — login token carries connections:token', () => {
         grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
         device_code: da.device_code,
         client_id: client.client_id,
+        resource: `${ORIGIN}/mcp/${org.slug}`,
       },
     });
     expect(tokenRes.status).toBe(200);
@@ -222,6 +223,7 @@ describe('Stage 1 — login token carries connections:token', () => {
         client_id: client.client_id,
         redirect_uri: redirectUri,
         code_verifier: verifier,
+        resource: `${ORIGIN}/mcp/${org.slug}`,
       },
     });
     expect(tokenRes.status).toBe(200);

--- a/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
@@ -1,3 +1,4 @@
+import { MCP_PROTOCOL_VERSION } from "@lobu/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Env } from "../../index";
 import { manageOperations } from "../../tools/admin/manage_operations";
@@ -30,6 +31,7 @@ describe("operations.execute backend lifecycle", () => {
 	let mcpConnectionId: number;
 	let secondMcpConnectionId: number;
 	let httpConnectionId: number;
+	let failedTransportCallCount = 0;
 
 	beforeAll(async () => {
 		await cleanupTestDatabase();
@@ -220,7 +222,29 @@ describe("operations.execute backend lifecycle", () => {
 						method: string;
 						params?: Record<string, unknown>;
 					};
+					if (request.method === "initialize") {
+						return new Response(
+							JSON.stringify({
+								jsonrpc: "2.0",
+								id: request.id,
+								result: {
+									protocolVersion: MCP_PROTOCOL_VERSION,
+									capabilities: { tools: {} },
+								},
+							}),
+							{
+								status: 200,
+								headers: {
+									"content-type": "application/json",
+									"mcp-session-id": "operations-backend-session",
+								},
+							},
+						);
+					}
 					if (request.method === "tools/list") {
+						expect(new Headers(init?.headers).get("mcp-protocol-version")).toBe(
+							MCP_PROTOCOL_VERSION,
+						);
 						return jsonResponse({
 							jsonrpc: "2.0",
 							id: request.id,
@@ -241,6 +265,7 @@ describe("operations.execute backend lifecycle", () => {
 							(request.params?.arguments as Record<string, unknown> | undefined)
 								?.fail_transport === true
 						) {
+							failedTransportCallCount++;
 							throw new Error("upstream transport failed");
 						}
 						const authorization = new Headers(init?.headers).get(
@@ -464,6 +489,7 @@ describe("operations.execute backend lifecycle", () => {
 	});
 
 	it("finalizes an upstream MCP run as failed when transport setup throws", async () => {
+		failedTransportCallCount = 0;
 		const result = await manageOperations(
 			{
 				action: "execute",
@@ -488,6 +514,9 @@ describe("operations.execute backend lifecycle", () => {
 			status: "failed",
 			error_message: "upstream transport failed",
 		});
+		// A transport exception is ambiguous: the upstream may have executed the
+		// destructive action before the response was lost. Never retry it here.
+		expect(failedTransportCallCount).toBe(1);
 	});
 
 	it("discovers and executes an OpenAPI HTTP operation", async () => {

--- a/packages/server/src/__tests__/setup/test-fixtures.ts
+++ b/packages/server/src/__tests__/setup/test-fixtures.ts
@@ -504,6 +504,7 @@ export async function createTestAccessToken(
   options?: {
     expiresIn?: number; // seconds
     scope?: string;
+    resource?: string | null;
   }
 ): Promise<TestAccessToken> {
   const sql = getTestDb();
@@ -515,10 +516,10 @@ export async function createTestAccessToken(
   await sql`
     INSERT INTO oauth_tokens (
       id, token_type, token_hash, client_id, user_id, organization_id,
-      scope, expires_at, created_at
+      scope, resource, expires_at, created_at
     ) VALUES (
       ${id}, 'access', ${tokenHash}, ${clientId}, ${userId}, ${organizationId},
-      ${options?.scope || 'mcp:read mcp:write'}, ${expiresAt}, NOW()
+      ${options?.scope || 'mcp:read mcp:write'}, ${options?.resource ?? null}, ${expiresAt}, NOW()
     )
   `;
 

--- a/packages/server/src/__tests__/setup/test-helpers.ts
+++ b/packages/server/src/__tests__/setup/test-helpers.ts
@@ -7,6 +7,7 @@
  * MCP calls perform proper protocol initialization per session (keyed by token).
  */
 
+import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { app, type Env } from '../../index';
 import { initWorkspaceProvider } from '../../workspace';
 
@@ -177,7 +178,7 @@ export async function ensureMcpSession(options?: {
       id: '__test_init__',
       method: 'initialize',
       params: {
-        protocolVersion: '2025-03-26',
+        protocolVersion: MCP_PROTOCOL_VERSION,
         capabilities: {},
         clientInfo: {
           name: 'lobu-test',
@@ -205,7 +206,10 @@ export async function ensureMcpSession(options?: {
       jsonrpc: '2.0',
       method: 'notifications/initialized',
     },
-    headers: { 'mcp-session-id': sessionId },
+    headers: {
+      'mcp-session-id': sessionId,
+      'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+    },
     token: options?.token,
     cookie: options?.cookie,
     env: options?.env,
@@ -251,7 +255,10 @@ export async function mcpRequest<T = any>(
       method,
       params: params || {},
     },
-    headers: { 'mcp-session-id': sessionId },
+    headers: {
+      'mcp-session-id': sessionId,
+      'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+    },
     token: options?.token,
     cookie: options?.cookie,
     env: options?.env,
@@ -281,7 +288,11 @@ export async function mcpToolsCall<T = any>(
       method: 'tools/call',
       params: { name: toolName, arguments: args },
     },
-    headers: { 'X-MCP-Format': 'json', 'mcp-session-id': sessionId },
+    headers: {
+      'X-MCP-Format': 'json',
+      'mcp-session-id': sessionId,
+      'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+    },
     token: options?.token,
     env: options?.env,
   });

--- a/packages/server/src/__tests__/unit/cors-origin.test.ts
+++ b/packages/server/src/__tests__/unit/cors-origin.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { getOwnedOwlettoExtensionIds, isAllowedCorsOrigin } from '../../index';
+import { app, getOwnedOwlettoExtensionIds, isAllowedCorsOrigin } from '../../index';
 import { __resetPublicOriginCachesForTests } from '../../utils/public-origin';
 
 // The Hono CORS middleware in packages/server/src/index.ts must accept
@@ -126,5 +126,50 @@ describe('isAllowedCorsOrigin — regression coverage for pre-existing branches'
 
   test('still rejects an arbitrary third-party origin', () => {
     expect(isAllowedCorsOrigin('https://evil.com', makeEnv(), REQUEST_URL)).toBe(false);
+  });
+});
+
+describe('MCP browser Origin boundary', () => {
+  test('rejects a hostile Origin before authentication or tool dispatch', async () => {
+    const response = await app.fetch(
+      new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://evil.example',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      }),
+      makeEnv()
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: 'forbidden',
+      message: 'Untrusted MCP Origin',
+    });
+  });
+
+  test('allows standard Streamable HTTP headers in browser preflight', async () => {
+    const response = await app.fetch(
+      new Request('http://localhost/mcp/acme', {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'http://localhost',
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers':
+            'authorization,content-type,mcp-session-id,mcp-protocol-version,last-event-id',
+        },
+      }),
+      makeEnv()
+    );
+    expect(response.status).toBe(204);
+    const allowHeaders = response.headers.get('access-control-allow-headers')?.toLowerCase() ?? '';
+    expect(allowHeaders).toContain('mcp-session-id');
+    expect(allowHeaders).toContain('mcp-protocol-version');
+    expect(allowHeaders).toContain('last-event-id');
+    const exposeHeaders = response.headers.get('access-control-expose-headers')?.toLowerCase() ?? '';
+    expect(exposeHeaders).toContain('mcp-session-id');
+    expect(exposeHeaders).toContain('mcp-protocol-version');
+    expect(exposeHeaders).toContain('www-authenticate');
   });
 });

--- a/packages/server/src/__tests__/unit/markdown-lobu-view.test.ts
+++ b/packages/server/src/__tests__/unit/markdown-lobu-view.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+import { formatToolResult } from '../../formatting/markdown-formatter';
+
+describe('render_lobu_view text fallback', () => {
+  it('renders model-selected text literally instead of activating injected markdown', () => {
+    const markdown = formatToolResult('render_lobu_view', {
+      version: 1,
+      title: 'Review [this](https://evil.example)',
+      blocks: [
+        {
+          type: 'text',
+          label: 'Status',
+          value: '[Open attacker site](javascript:alert(1))',
+        },
+        {
+          type: 'diff',
+          fields: [
+            {
+              label: 'name',
+              before: '**trusted**',
+              after: '<script>bad()</script>',
+            },
+          ],
+        },
+      ],
+      actions: [
+        { id: 'bad', label: 'Bad', href: 'javascript:alert(1)' },
+        { id: 'good', label: 'Review', href: 'https://lobu.ai/example/runs/1' },
+      ],
+    });
+
+    expect(markdown).toContain('Review \\[this\\]\\(https://evil\\.example\\)');
+    expect(markdown).toContain('\\[Open attacker site\\]\\(javascript:alert\\(1\\)\\)');
+    expect(markdown).toContain('\\<script\\>bad\\(\\)\\</script\\>');
+    expect(markdown).not.toContain('[Bad](javascript:');
+    expect(markdown).toContain('[Review](https://lobu.ai/example/runs/1)');
+  });
+
+  it('uses a longer code fence when the code contains backticks', () => {
+    const markdown = formatToolResult('render_lobu_view', {
+      version: 1,
+      blocks: [{ type: 'code', value: 'before\n```\nafter' }],
+      actions: [],
+    });
+
+    expect(markdown).toBe('````\nbefore\n```\nafter\n````');
+  });
+});

--- a/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-resource-indicator.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  buildMcpBearerChallenge,
+  canonicalizeMcpResource,
+  getProtectedResourceMetadataUrl,
+} from '../../auth/oauth/resource-indicator.js';
+import { __resetPublicOriginCachesForTests } from '../../utils/public-origin.js';
+
+const originalPublicGatewayUrl = process.env.PUBLIC_GATEWAY_URL;
+
+beforeEach(() => {
+  process.env.PUBLIC_GATEWAY_URL = 'https://app.lobu.ai/lobu';
+  __resetPublicOriginCachesForTests();
+});
+
+afterEach(() => {
+  if (originalPublicGatewayUrl === undefined) {
+    delete process.env.PUBLIC_GATEWAY_URL;
+  } else {
+    process.env.PUBLIC_GATEWAY_URL = originalPublicGatewayUrl;
+  }
+  __resetPublicOriginCachesForTests();
+});
+
+describe('MCP OAuth resource indicators', () => {
+  test('canonicalizes only the root or one org-scoped MCP path', () => {
+    const requestUrl = 'https://app.lobu.ai/mcp/acme';
+
+    expect(canonicalizeMcpResource('https://app.lobu.ai/mcp/acme/', requestUrl)).toBe(
+      'https://app.lobu.ai/mcp/acme'
+    );
+    expect(canonicalizeMcpResource('https://app.lobu.ai/mcp/acme/tools', requestUrl)).toBeNull();
+    expect(canonicalizeMcpResource('https://evil.example/mcp/acme', requestUrl)).toBeNull();
+    expect(canonicalizeMcpResource('https://app.lobu.ai/mcp/acme?admin=1', requestUrl)).toBeNull();
+  });
+
+  test('builds an exact path-specific protected-resource challenge', () => {
+    const requestUrl = 'https://app.lobu.ai/mcp/acme';
+
+    expect(getProtectedResourceMetadataUrl(requestUrl)).toBe(
+      'https://app.lobu.ai/.well-known/oauth-protected-resource/mcp/acme'
+    );
+    expect(buildMcpBearerChallenge(requestUrl, 'invalid_token')).toBe(
+      'Bearer resource_metadata="https://app.lobu.ai/.well-known/oauth-protected-resource/mcp/acme", scope="mcp:read mcp:write", error="invalid_token"'
+    );
+  });
+
+  test('escapes challenge values and advertises the exact missing scope', () => {
+    expect(
+      buildMcpBearerChallenge('https://app.lobu.ai/mcp/acme', {
+        error: 'insufficient_scope',
+        errorDescription: 'Expired "access" \\ token',
+        scope: 'mcp:admin',
+      })
+    ).toBe(
+      'Bearer resource_metadata="https://app.lobu.ai/.well-known/oauth-protected-resource/mcp/acme", scope="mcp:admin", error="insufficient_scope", error_description="Expired \\"access\\" \\\\ token"'
+    );
+  });
+
+  test('uses the configured public origin rather than an internal request host', () => {
+    process.env.PUBLIC_GATEWAY_URL = 'https://lobu.example/lobu';
+    __resetPublicOriginCachesForTests();
+
+    expect(
+      canonicalizeMcpResource('https://lobu.example/mcp/acme', 'http://internal:8787/mcp/acme')
+    ).toBe('https://lobu.example/mcp/acme');
+    expect(getProtectedResourceMetadataUrl('http://internal:8787/mcp/acme')).toBe(
+      'https://lobu.example/.well-known/oauth-protected-resource/mcp/acme'
+    );
+  });
+});

--- a/packages/server/src/__tests__/unit/query-sql-behavior-exposure.test.ts
+++ b/packages/server/src/__tests__/unit/query-sql-behavior-exposure.test.ts
@@ -120,6 +120,25 @@ describe('Defect 3 — the agent-facing surface speaks Behavior', () => {
     );
     expect(sql).toContain('watcher_id');
   });
+
+  it('exposes Behavior lineage aliases and hides the physical watcher names', () => {
+    const names = SAFE_COLUMN_DEFS.get('behaviors')?.map((column) => column.name) ?? [];
+    expect(names).toContain('source_behavior_id');
+    expect(names).toContain('behavior_group_id');
+    expect(names).not.toContain('source_watcher_id');
+    expect(names).not.toContain('watcher_group_id');
+
+    const { sql } = scope('SELECT source_behavior_id, behavior_group_id FROM behaviors');
+    expect(sql).toContain('"source_watcher_id" as "source_behavior_id"');
+    expect(sql).toContain('"watcher_group_id" as "behavior_group_id"');
+  });
+
+  it('rejects the physical Behavior lineage column names', () => {
+    for (const column of ['source_watcher_id', 'watcher_group_id']) {
+      const result = validateTableQuery(`SELECT ${column} FROM behaviors`);
+      expect(result.valid).toBe(false);
+    }
+  });
 });
 
 describe('Defect 4 — a source saved before the rename fails loudly, not silently', () => {

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -10,6 +10,7 @@ import {
 	getMcpTools,
 	getTool,
 	isInternalDispatchTool,
+	isRestDispatchTool,
 } from "../../tools/registry";
 
 /** Agent MCP flat tools (excluding meta scripting/discovery) → SDK dotted path. */
@@ -70,13 +71,19 @@ describe("tool registry split", () => {
 			[
 				"query_sdk",
 				"query_sql",
+				"render_lobu_view",
 				"run_sdk",
 				"save_memory",
 				"search_memory",
 				"search_sdk",
 			].sort()
 		);
+		// The render helper is listed on MCP only: it stays out of
+		// AGENT_TOOL_NAMES, so it never reaches the generated OpenAPI/ClientSDK
+		// agent surface.
 		expect(AGENT_TOOL_NAMES.size).toBe(6);
+		expect(isRestDispatchTool("render_lobu_view")).toBe(false);
+		expect(isRestDispatchTool("manage_connections")).toBe(true);
 	});
 
 	it("maps internal flat tools to ClientSDK methods for run_sdk/query_sdk parity", () => {

--- a/packages/server/src/__tests__/unit/utils/openapi-strict.test.ts
+++ b/packages/server/src/__tests__/unit/utils/openapi-strict.test.ts
@@ -10,6 +10,7 @@ describe("generateOpenAPISpec", () => {
 	it("uses public Behavior terminology throughout ChatGPT metadata", () => {
 		const spec = generateOpenAPISpec("https://example.test");
 		expect(JSON.stringify(spec)).not.toMatch(/watcher/i);
+		expect(spec.paths["/api/{orgSlug}/render_lobu_view"]).toBeUndefined();
 		expect(spec.servers[0]?.description).toContain("Behaviors");
 	});
 });

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -598,9 +598,9 @@ describe('checkToolAccess', () => {
 });
 
 describe('first-party tool-name coverage', () => {
-  // Both surfaces share the same dispatch (`POST /api/:orgSlug/:toolName` →
-  // `restToolProxy` → `executeTool` → `getTool(name)`); tools are listed
-  // uniformly on MCP `tools/list` as well. These tests pin registration.
+  // REST callers dispatch through `restToolProxy` → `executeTool` →
+  // `getTool(name)`, while MCP adds presentation-only Apps tools. These tests
+  // pin registration for the first-party REST callers below.
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const webSrcRoot = join(__dirname, '..', '..', '..', '..', 'web', 'src');
   // The standalone lobu-cli package was merged into @lobu/cli's `memory`

--- a/packages/server/src/auth/oauth/provider.ts
+++ b/packages/server/src/auth/oauth/provider.ts
@@ -130,6 +130,7 @@ export class OAuthProvider {
       WHERE code = ${params.code}
         AND expires_at > NOW()
         AND used_at IS NULL
+        AND (resource IS NULL OR resource = ${params.resource || null})
       RETURNING *
     `;
 
@@ -217,6 +218,12 @@ export class OAuthProvider {
       return createOAuthError('invalid_grant', 'Client ID mismatch');
     }
 
+    if (oldRefreshToken.resource && params.resource !== oldRefreshToken.resource) {
+      return createOAuthError('invalid_grant', 'Refresh request resource must match the original resource');
+    }
+
+    const resource = oldRefreshToken.resource || params.resource || null;
+
     // Use requested scope only if it is a subset of the original grant.
     let scope = oldRefreshToken.scope;
     if (params.scope !== undefined) {
@@ -263,10 +270,10 @@ export class OAuthProvider {
         ) VALUES
           (${accessTokenId}, 'access', ${hashToken(accessToken)},
            ${oldRefreshToken.client_id}, ${oldRefreshToken.user_id}, ${oldRefreshToken.organization_id},
-           ${scope}, ${params.resource || oldRefreshToken.resource}, ${refreshTokenId}, ${accessExpiresAt}),
+           ${scope}, ${resource}, ${refreshTokenId}, ${accessExpiresAt}),
           (${refreshTokenId}, 'refresh', ${hashToken(newRefreshToken)},
            ${oldRefreshToken.client_id}, ${oldRefreshToken.user_id}, ${oldRefreshToken.organization_id},
-           ${scope}, ${params.resource || oldRefreshToken.resource}, ${oldRefreshToken.id}, ${refreshExpiresAt})
+           ${scope}, ${resource}, ${oldRefreshToken.id}, ${refreshExpiresAt})
       `;
     });
 
@@ -276,11 +283,7 @@ export class OAuthProvider {
       expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
       refresh_token: newRefreshToken,
       scope: scope || undefined,
-      ...(oldRefreshToken.resource
-        ? { resource: oldRefreshToken.resource }
-        : params.resource
-          ? { resource: params.resource }
-          : {}),
+      ...(resource ? { resource } : {}),
     };
   }
 
@@ -728,6 +731,7 @@ export class OAuthProvider {
       WHERE device_code = ${params.device_code}
         AND client_id = ${params.client_id}
         AND status = 'approved'
+        AND (resource IS NULL OR resource = ${params.resource || null})
         AND expires_at > NOW()
       RETURNING *
     `;
@@ -748,7 +752,7 @@ export class OAuthProvider {
 
     // Atomic claim returned nothing — check why (pending, denied, expired, or unknown)
     const result = await this.sql`
-      SELECT status, client_id, expires_at FROM oauth_device_codes
+      SELECT status, client_id, expires_at, resource FROM oauth_device_codes
       WHERE device_code = ${params.device_code}
     `;
 
@@ -756,10 +760,14 @@ export class OAuthProvider {
       return createOAuthError('invalid_grant', 'Unknown device_code');
     }
 
-    const deviceCode = result[0] as Pick<StoredDeviceCode, 'status' | 'client_id' | 'expires_at'>;
+    const deviceCode = result[0] as Pick<StoredDeviceCode, 'status' | 'client_id' | 'expires_at' | 'resource'>;
 
     if (deviceCode.client_id !== params.client_id) {
       return createOAuthError('invalid_grant', 'Client ID mismatch');
+    }
+
+    if (deviceCode.resource && params.resource !== deviceCode.resource) {
+      return createOAuthError('invalid_grant', 'Token request resource must match the device authorization resource');
     }
 
     if (new Date(deviceCode.expires_at) <= new Date()) {

--- a/packages/server/src/auth/oauth/resource-indicator.ts
+++ b/packages/server/src/auth/oauth/resource-indicator.ts
@@ -1,0 +1,91 @@
+/**
+ * RFC 8707 resource indicators for the MCP endpoints.
+ *
+ * MCP clients name the exact protected resource they want a token for; the
+ * gateway canonicalizes that value so an audience check is a string compare,
+ * and advertises the matching RFC 9728 metadata URL in `WWW-Authenticate`.
+ */
+
+import { resolvePublicOrigin } from '../../utils/public-origin';
+import { resolveBaseUrl } from '../base-url';
+import { DEFAULT_SCOPES_STRING } from './scopes';
+
+/**
+ * The request URL as the client sees it: the configured public origin, else the
+ * reverse proxy's forwarded origin, plus the request path with any trailing
+ * slash removed.
+ *
+ * Every site in this module — the `WWW-Authenticate` challenge, the
+ * authorize/consent/device/token canonicalization, and the per-request audience
+ * check — starts here, so all four agree on one string. Resolving the origin
+ * differently at any one of them would reject a correctly-bound token behind a
+ * TLS-terminating proxy.
+ */
+export function publicMcpRequestUrl(request: Request): string {
+  const origin = resolveBaseUrl({ request });
+  const pathname = new URL(request.url).pathname.replace(/\/+$/, '') || '/';
+  return `${origin}${pathname}`;
+}
+
+/** Canonical MCP protected-resource URI accepted for OAuth audience binding. */
+export function canonicalizeMcpResource(
+  rawResource: string | null | undefined,
+  requestUrl: string
+): string | null {
+  if (!rawResource) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(rawResource);
+  } catch {
+    return null;
+  }
+  const publicOrigin = resolvePublicOrigin(requestUrl);
+  if (parsed.origin !== publicOrigin || parsed.search || parsed.hash) return null;
+  const path = parsed.pathname.replace(/\/+$/, '') || '/';
+  if (path !== '/mcp' && !/^\/mcp\/[^/]+$/.test(path)) return null;
+  return `${publicOrigin}${path}`;
+}
+
+/** The resource URI the incoming request is addressing, if it is an MCP route. */
+export function getMcpResourceForRequest(requestUrl: string): string | null {
+  const request = new URL(requestUrl);
+  return canonicalizeMcpResource(
+    `${resolvePublicOrigin(requestUrl)}${request.pathname}`,
+    requestUrl
+  );
+}
+
+/** RFC 9728 metadata URL for the resource the request addresses. */
+export function getProtectedResourceMetadataUrl(requestUrl: string): string {
+  const publicOrigin = resolvePublicOrigin(requestUrl);
+  const resource = getMcpResourceForRequest(requestUrl);
+  if (!resource) return `${publicOrigin}/.well-known/oauth-protected-resource`;
+  return `${publicOrigin}/.well-known/oauth-protected-resource${new URL(resource).pathname}`;
+}
+
+export interface McpBearerChallengeOptions {
+  error?: 'invalid_token' | 'insufficient_scope' | string;
+  errorDescription?: string;
+  scope?: string;
+}
+
+function quoteChallengeValue(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+export function buildMcpBearerChallenge(
+  requestUrl: string,
+  errorOrOptions?: string | McpBearerChallengeOptions
+): string {
+  const options: McpBearerChallengeOptions =
+    typeof errorOrOptions === 'string' ? { error: errorOrOptions } : (errorOrOptions ?? {});
+  const params = [
+    `resource_metadata=${quoteChallengeValue(getProtectedResourceMetadataUrl(requestUrl))}`,
+    `scope=${quoteChallengeValue(options.scope ?? DEFAULT_SCOPES_STRING)}`,
+  ];
+  if (options.error) params.push(`error=${quoteChallengeValue(options.error)}`);
+  if (options.errorDescription) {
+    params.push(`error_description=${quoteChallengeValue(options.errorDescription)}`);
+  }
+  return `Bearer ${params.join(', ')}`;
+}

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -16,6 +16,7 @@ import { requireAuth } from '../middleware';
 import { findExistingPersonalOrg } from '../personal-org-provisioning';
 import { buildAuthMd } from './auth-md';
 import { OAuthProvider } from './provider';
+import { canonicalizeMcpResource, publicMcpRequestUrl } from './resource-indicator';
 import { DEFAULT_SCOPES_STRING, filterScopeByRole } from './scopes';
 import type { AuthorizationParams, OAuthClientMetadata, TokenRequestParams } from './types';
 import { createOAuthError, validateRedirectUri } from './utils';
@@ -282,6 +283,12 @@ function setOAuthDiscoveryNoCache(c: { header: (name: string, value: string) => 
   c.header('Pragma', 'no-cache');
 }
 
+function getMetadataMcpResource(request: Request, resourcePath = 'mcp'): string | null {
+  const publicRequestUrl = publicMcpRequestUrl(request);
+  const publicOrigin = new URL(publicRequestUrl).origin;
+  return canonicalizeMcpResource(`${publicOrigin}/${resourcePath}`, publicRequestUrl);
+}
+
 /**
  * GET /.well-known/oauth-protected-resource
  * RFC 9728 - OAuth Protected Resource Metadata
@@ -292,16 +299,21 @@ oauthRoutes.get('/.well-known/oauth-protected-resource/:path{.+}', (c) => {
   const provider = getProvider(c);
   const metadata = provider.getProtectedResourceMetadata();
   const resourcePath = c.req.param('path');
-  const origin = getBaseUrl(c);
-  metadata.resource = `${origin}/${resourcePath}`;
+  const resource = getMetadataMcpResource(c.req.raw, resourcePath);
   setOAuthDiscoveryNoCache(c);
+  if (!resource) return c.json({ error: 'Not Found' }, 404);
+  metadata.resource = resource;
   return c.json(metadata);
 });
 
 oauthRoutes.get('/.well-known/oauth-protected-resource', (c) => {
   const provider = getProvider(c);
+  const metadata = provider.getProtectedResourceMetadata();
+  const resource = getMetadataMcpResource(c.req.raw);
   setOAuthDiscoveryNoCache(c);
-  return c.json(provider.getProtectedResourceMetadata());
+  if (!resource) return c.json({ error: 'Not Found' }, 404);
+  metadata.resource = resource;
+  return c.json(metadata);
 });
 
 /**
@@ -479,6 +491,16 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
 
   const requestedScopes = getRequestedScopes(params.scope);
   const requestedHasMcpScopes = requestedScopes.some((s) => s.startsWith('mcp:'));
+  if (requestedHasMcpScopes) {
+    const resource = canonicalizeMcpResource(params.resource, publicMcpRequestUrl(c.req.raw));
+    if (!resource) {
+      return c.json(
+        createOAuthError('invalid_request', 'A valid same-origin MCP resource is required'),
+        400
+      );
+    }
+    params.resource = resource;
+  }
 
   // Validate client
   const clientResult = await provider.getClientForAuthorization(
@@ -613,6 +635,16 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
   // (personal-org force-bind, mint-child-token) stays gated on the device
   // flow / resource binding, not solely on the scope string.
   const consentHasMcpScopes = hasMcpScopes(body.scope);
+  if (consentHasMcpScopes) {
+    const resource = canonicalizeMcpResource(body.resource, publicMcpRequestUrl(c.req.raw));
+    if (!resource) {
+      return c.json(
+        createOAuthError('invalid_request', 'A valid same-origin MCP resource is required'),
+        400
+      );
+    }
+    body.resource = resource;
+  }
 
   // User denied consent
   if (!body.approved) {
@@ -729,6 +761,32 @@ oauthRoutes.post('/oauth/device_authorization', async (c) => {
 
   if (!body.client_id) {
     return c.json(createOAuthError('invalid_request', 'client_id is required'), 400);
+  }
+
+  const deviceScopes = getRequestedScopes(body.scope);
+  const isDeviceWorkerGrant = deviceScopes.includes('device_worker:run');
+  const deviceHasMcpScopes = deviceScopes.some((scope) => scope.startsWith('mcp:'));
+  if (isDeviceWorkerGrant) {
+    // First-party device pairing selects and force-binds the personal org at
+    // human approval time. Keeping an earlier caller-supplied team resource
+    // would create a token whose OAuth audience disagrees with its org claim.
+    // Leave this compatibility grant unbound; normal MCP device grants may
+    // still opt into an exact RFC 8707 resource below.
+    body.resource = undefined;
+  } else if (deviceHasMcpScopes && !body.resource) {
+    return c.json(
+      createOAuthError('invalid_request', 'resource is required for MCP device authorization'),
+      400
+    );
+  } else if (body.resource) {
+    const resource = canonicalizeMcpResource(body.resource, publicMcpRequestUrl(c.req.raw));
+    if (!resource) {
+      return c.json(
+        createOAuthError('invalid_request', 'The MCP resource must be a valid same-origin URI'),
+        400
+      );
+    }
+    body.resource = resource;
   }
 
   const result = await provider.createDeviceAuthorization(
@@ -1080,8 +1138,19 @@ oauthRoutes.post('/oauth/token', async (c) => {
     return c.json(createOAuthError('invalid_request', 'client_id is required'), 400);
   }
 
+  if (params.resource) {
+    const resource = canonicalizeMcpResource(params.resource, publicMcpRequestUrl(c.req.raw));
+    if (!resource) {
+      return c.json(
+        createOAuthError('invalid_request', 'The MCP resource must be a valid same-origin URI'),
+        400
+      );
+    }
+    params.resource = resource;
+  }
+
   // Handle different grant types
-  let result;
+  let result: Awaited<ReturnType<OAuthProvider['exchangeAuthorizationCode']>>;
 
   switch (params.grant_type) {
     case 'authorization_code':

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -158,6 +158,7 @@ export const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
 export const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {
 	resolve_path: null,
 	search_memory: null,
+	render_lobu_view: null,
 	// SDK method discovery — safe to expose; surfaces no data.
 	search_sdk: null,
 	// Internal read-paths — kept for tests that exercise public-readability

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -293,6 +293,7 @@ export function formatToolResult(
     read_knowledge: formatGetContentResult,
     manage_behaviors: formatManageBehaviorsResult,
     query_sql: formatQuerySqlResult,
+    render_lobu_view: formatLobuViewResult,
   };
 
   const formatter = formatters[toolName];
@@ -309,6 +310,60 @@ export function formatToolResult(
 
   // Fallback: pretty-print JSON
   return `\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``;
+}
+
+function escapeLobuViewMarkdown(value: unknown, singleLine = false): string {
+  const text = String(value ?? '');
+  const normalized = singleLine ? text.replace(/\s+/g, ' ').trim() : text;
+  return normalized.replace(/([\\`*_[\]{}<>()#+\-.!|])/g, '\\$1');
+}
+
+function formatLobuViewCode(value: unknown): string {
+  const code = String(value ?? '');
+  const longestRun = Math.max(0, ...Array.from(code.matchAll(/`+/g), (match) => match[0].length));
+  const fence = '`'.repeat(Math.max(3, longestRun + 1));
+  return `${fence}\n${code}\n${fence}`;
+}
+
+function safeLobuViewLink(href: unknown): string | null {
+  if (typeof href !== 'string') return null;
+  try {
+    const url = new URL(href);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    return url.href.replace(/\(/g, '%28').replace(/\)/g, '%29');
+  } catch {
+    return null;
+  }
+}
+
+function formatLobuViewResult(result: any): string {
+  let markdown = result.title ? `## ${escapeLobuViewMarkdown(result.title, true)}\n\n` : '';
+  for (const block of result.blocks ?? []) {
+    if (block.type === 'text') {
+      markdown += `${
+        block.label ? `**${escapeLobuViewMarkdown(block.label, true)}**\n\n` : ''
+      }${escapeLobuViewMarkdown(block.value)}\n\n`;
+    } else if (block.type === 'code') {
+      markdown += `${formatLobuViewCode(block.value)}\n\n`;
+    } else if (block.type === 'diff') {
+      for (const field of block.fields ?? []) {
+        markdown += `- **${escapeLobuViewMarkdown(field.label, true)}**: ${
+          field.before === undefined
+            ? escapeLobuViewMarkdown(field.after, true)
+            : `${escapeLobuViewMarkdown(field.before || '—', true)} → ${escapeLobuViewMarkdown(
+                field.after || '—',
+                true
+              )}`
+        }\n`;
+      }
+      markdown += '\n';
+    }
+  }
+  for (const action of result.actions ?? []) {
+    const href = safeLobuViewLink(action.href);
+    if (href) markdown += `[${escapeLobuViewMarkdown(action.label, true)}](${href})\n\n`;
+  }
+  return markdown.trim() || 'Lobu view rendered.';
 }
 
 /**

--- a/packages/server/src/gateway/__tests__/grant-store.test.ts
+++ b/packages/server/src/gateway/__tests__/grant-store.test.ts
@@ -24,7 +24,7 @@ describe("GrantStore (PG-backed)", () => {
 
   beforeAll(async () => {
     await ensureDbForGatewayTests();
-  });
+  }, 30_000);
 
   beforeEach(async () => {
     await resetTestDatabase();
@@ -32,7 +32,7 @@ describe("GrantStore (PG-backed)", () => {
     // test in this file so the inserts below succeed.
     await seedAgentRow("agent-1");
     store = new GrantStore();
-  });
+  }, 30_000);
 
   describe("grant", () => {
     test("stores grant without expiry when expiresAt is null", async () => {

--- a/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
@@ -21,7 +21,7 @@ import {
   expect,
   test,
 } from "bun:test";
-import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
+import { generateWorkerToken, MCP_PROTOCOL_VERSION, verifyWorkerToken } from "@lobu/core";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import { takePendingTool } from "../auth/mcp/pending-tool-store.js";
 import type { DirectToolExecutionOptions } from "../auth/mcp/proxy.js";
@@ -68,6 +68,26 @@ function successFetch(body: object = { jsonrpc: "2.0", id: 1, result: { tools: [
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
+}
+
+function initializeResponse(sessionId: string) {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 0,
+      result: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Mcp-Session-Id": sessionId,
+      },
+    }
+  );
 }
 
 const TEST_ENCRYPTION_KEY =
@@ -960,10 +980,7 @@ describe("executeToolDirect", () => {
       requestHeaders.push(new Headers(init?.headers));
       const body = JSON.parse(String(init?.body)) as { method: string };
       if (body.method === "initialize") {
-        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 0, result: {} }), {
-          status: 200,
-          headers: { "Content-Type": "application/json", "Mcp-Session-Id": "session-1" },
-        });
+        return initializeResponse("session-1");
       }
       if (body.method === "notifications/initialized") {
         return new Response(null, { status: 202 });
@@ -1009,6 +1026,9 @@ describe("executeToolDirect", () => {
       expect(headers.get("authorization")).toMatch(/^Bearer /);
       expect(headers.get("x-lobu-memory-direct-auth")).toBe("1");
     }
+    expect(requestHeaders[0]?.get("mcp-protocol-version")).toBeNull();
+    expect(requestHeaders[1]?.get("mcp-protocol-version")).toBe(MCP_PROTOCOL_VERSION);
+    expect(requestHeaders[2]?.get("mcp-protocol-version")).toBe(MCP_PROTOCOL_VERSION);
   });
 
   test("approved execution re-initializes and retries once when the cached session went stale mid-call", async () => {
@@ -1027,10 +1047,7 @@ describe("executeToolDirect", () => {
       const body = JSON.parse(String(init?.body)) as { method: string };
       if (body.method === "initialize") {
         initCount++;
-        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 0, result: {} }), {
-          status: 200,
-          headers: { "Content-Type": "application/json", "Mcp-Session-Id": `session-${initCount}` },
-        });
+        return initializeResponse(`session-${initCount}`);
       }
       if (body.method === "notifications/initialized") {
         return new Response(null, { status: 202 });
@@ -1090,10 +1107,7 @@ describe("executeToolDirect", () => {
       const body = JSON.parse(String(init?.body)) as { method: string };
       if (body.method === "initialize") {
         initCount++;
-        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 0, result: {} }), {
-          status: 200,
-          headers: { "Content-Type": "application/json", "Mcp-Session-Id": `session-${initCount}` },
-        });
+        return initializeResponse(`session-${initCount}`);
       }
       if (body.method === "notifications/initialized") {
         return new Response(null, { status: 202 });
@@ -1175,7 +1189,14 @@ describe("executeToolDirect", () => {
     let requestHeaders = new Headers();
 
     globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { method: string };
       requestHeaders = new Headers(init?.headers);
+      if (body.method === "initialize") {
+        return initializeResponse("session-auth");
+      }
+      if (body.method === "notifications/initialized") {
+        return new Response(null, { status: 202 });
+      }
       return new Response(
         JSON.stringify({
           jsonrpc: "2.0",
@@ -1237,7 +1258,14 @@ describe("executeToolDirect", () => {
     let requestHeaders = new Headers();
 
     globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { method: string };
       requestHeaders = new Headers(init?.headers);
+      if (body.method === "initialize") {
+        return initializeResponse("session-no-admin");
+      }
+      if (body.method === "notifications/initialized") {
+        return new Response(null, { status: 202 });
+      }
       return new Response(
         JSON.stringify({
           jsonrpc: "2.0",
@@ -1286,8 +1314,15 @@ describe("executeToolDirect", () => {
     });
     const proxy = new McpProxy(configSource, {    });
 
-    globalThis.fetch = async () =>
-      new Response(
+    globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { method: string };
+      if (body.method === "initialize") {
+        return initializeResponse("session-direct");
+      }
+      if (body.method === "notifications/initialized") {
+        return new Response(null, { status: 202 });
+      }
+      return new Response(
         JSON.stringify({
           jsonrpc: "2.0",
           id: 1,
@@ -1295,6 +1330,7 @@ describe("executeToolDirect", () => {
         }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       );
+    };
 
     const result = await proxy.executeToolDirect(
       "agent1",

--- a/packages/server/src/gateway/__tests__/mcp-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy.test.ts
@@ -6,7 +6,7 @@ import {
   expect,
   test,
 } from "bun:test";
-import { generateWorkerToken } from "@lobu/core";
+import { generateWorkerToken, MCP_PROTOCOL_VERSION } from "@lobu/core";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import { McpProxy } from "../auth/mcp/proxy.js";
 import { McpToolCache } from "../auth/mcp/tool-cache.js";
@@ -43,10 +43,27 @@ function createMockConfigSource(
 }
 
 function mockUpstreamFetch(responseData: any) {
-  globalThis.fetch = async () => {
-    return new Response(JSON.stringify(responseData), {
+  globalThis.fetch = async (_input, init) => {
+    const request = init?.body ? JSON.parse(String(init.body)) : {};
+    const body =
+      request.method === "initialize"
+        ? {
+            jsonrpc: "2.0",
+            id: 0,
+            result: {
+              protocolVersion: MCP_PROTOCOL_VERSION,
+              capabilities: { tools: {} },
+            },
+          }
+        : responseData;
+    return new Response(JSON.stringify(body), {
       status: 200,
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(request.method === "initialize"
+          ? { "Mcp-Session-Id": "test-session" }
+          : {}),
+      },
     });
   };
 }
@@ -206,6 +223,74 @@ describe("McpProxy", () => {
       expect(body.error).toContain("not found");
     });
 
+    test("accepts a server without tools capability without calling tools/list", async () => {
+      const configSource = createMockConfigSource({
+        "test-mcp": TEST_SERVER,
+      });
+      const proxy = new McpProxy(configSource, {});
+      const app = proxy.getApp();
+      const methods: string[] = [];
+
+      globalThis.fetch = async (_input, init) => {
+        const request = JSON.parse(String(init?.body)) as { method: string };
+        methods.push(request.method);
+        if (request.method === "initialize") {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 0,
+              result: {
+                protocolVersion: MCP_PROTOCOL_VERSION,
+                capabilities: {},
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                "Mcp-Session-Id": "toolless-session",
+              },
+            },
+          );
+        }
+        return new Response(null, { status: 202 });
+      };
+
+      const res = await app.request("/test-mcp/tools", {
+        method: "GET",
+        headers: { Authorization: `Bearer ${validToken}` },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ tools: [] });
+      expect(methods).toEqual(["initialize", "notifications/initialized"]);
+    });
+
+    test("treats an upstream initialize 401 as an unauthenticated empty catalog", async () => {
+      const configSource = createMockConfigSource({
+        "test-mcp": TEST_SERVER,
+      });
+      const proxy = new McpProxy(configSource, {});
+      const app = proxy.getApp();
+      let fetchCount = 0;
+
+      globalThis.fetch = async () => {
+        fetchCount++;
+        return new Response("authentication required", {
+          status: 401,
+          headers: { "WWW-Authenticate": "Bearer" },
+        });
+      };
+
+      const res = await app.request("/test-mcp/tools", {
+        method: "GET",
+        headers: { Authorization: `Bearer ${validToken}` },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ tools: [] });
+      expect(fetchCount).toBe(1);
+    });
+
     test("returns 502 on upstream error", async () => {
       const configSource = createMockConfigSource({
         "test-mcp": TEST_SERVER,
@@ -236,8 +321,31 @@ describe("McpProxy", () => {
       const app = proxy.getApp();
 
       let fetchCount = 0;
-      globalThis.fetch = async () => {
+      globalThis.fetch = async (_input, init) => {
         fetchCount++;
+        const request = init?.body ? JSON.parse(String(init.body)) : {};
+        if (request.method === "initialize") {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 0,
+              result: {
+                protocolVersion: MCP_PROTOCOL_VERSION,
+                capabilities: { tools: {} },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                "Mcp-Session-Id": "cache-session",
+              },
+            },
+          );
+        }
+        if (request.method === "notifications/initialized") {
+          return new Response(null, { status: 202 });
+        }
         return new Response(
           JSON.stringify({
             jsonrpc: "2.0",
@@ -375,8 +483,9 @@ describe("McpProxy", () => {
       const app = proxy.getApp();
 
       let callCount = 0;
-      globalThis.fetch = async () => {
+      globalThis.fetch = async (_input, init) => {
         callCount++;
+        const request = init?.body ? JSON.parse(String(init.body)) : {};
         // The first call is the tool call that triggers the error.
         // After that, reinitializeSession sends initialize + notifications/initialized (2 calls).
         // Then the retry tool call is the 4th call.
@@ -387,7 +496,24 @@ describe("McpProxy", () => {
               id: 1,
               error: { code: -32000, message: "Server not initialized" },
             }),
-            { status: 200, headers: { "Content-Type": "application/json" } }
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (request.method === "initialize") {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 0,
+              result: {
+                protocolVersion: MCP_PROTOCOL_VERSION,
+                capabilities: { tools: {} },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                "Mcp-Session-Id": "reinitialized-session" } }
           );
         }
         // Re-init calls (initialize + notifications/initialized) and retry
@@ -591,7 +717,7 @@ describe("McpProxy", () => {
       const proxy = new McpProxy(configSource, {      });
       const app = proxy.getApp();
 
-      globalThis.fetch = async (url: string | URL | Request) => {
+      globalThis.fetch = async (url: string | URL | Request, init) => {
         const urlStr =
           typeof url === "string"
             ? url
@@ -601,6 +727,29 @@ describe("McpProxy", () => {
         const tools = urlStr.includes("upstream1")
           ? [{ name: "tool_a" }]
           : [{ name: "tool_b" }];
+        const request = init?.body ? JSON.parse(String(init.body)) : {};
+        if (request.method === "initialize") {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 0,
+              result: {
+                protocolVersion: MCP_PROTOCOL_VERSION,
+                capabilities: { tools: {} },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                "Mcp-Session-Id": `session-${urlStr}`,
+              },
+            },
+          );
+        }
+        if (request.method === "notifications/initialized") {
+          return new Response(null, { status: 202 });
+        }
         return new Response(
           JSON.stringify({
             jsonrpc: "2.0",
@@ -635,7 +784,7 @@ describe("McpProxy", () => {
       const proxy = new McpProxy(configSource, {      });
       const app = proxy.getApp();
 
-      globalThis.fetch = async (url: string | URL | Request) => {
+      globalThis.fetch = async (url: string | URL | Request, init) => {
         const urlStr =
           typeof url === "string"
             ? url
@@ -644,6 +793,29 @@ describe("McpProxy", () => {
               : url.url;
         if (urlStr.includes("bad-upstream")) {
           throw new Error("Connection refused");
+        }
+        const request = init?.body ? JSON.parse(String(init.body)) : {};
+        if (request.method === "initialize") {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 0,
+              result: {
+                protocolVersion: MCP_PROTOCOL_VERSION,
+                capabilities: { tools: {} },
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                "Mcp-Session-Id": "good-session",
+              },
+            },
+          );
+        }
+        if (request.method === "notifications/initialized") {
+          return new Response(null, { status: 202 });
         }
         return new Response(
           JSON.stringify({

--- a/packages/server/src/gateway/auth/mcp/proxy-forward.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-forward.ts
@@ -250,6 +250,7 @@ async function forwardRequest(
 		sessionId,
 		credentialToken,
 		httpServer.internal === true,
+		proxy.upstream.getProtocolVersion(sessionKey),
 	);
 
 	let response = await fetch(httpServer.upstreamUrl, {
@@ -286,6 +287,7 @@ async function forwardRequest(
 				sessionId,
 				credentialToken,
 				httpServer.internal === true,
+				proxy.upstream.getProtocolVersion(sessionKey),
 			);
 			response = await fetch(httpServer.upstreamUrl, {
 				method: c.req.method,

--- a/packages/server/src/gateway/auth/mcp/proxy-shared.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-shared.ts
@@ -1,4 +1,8 @@
-import { verifyWorkerToken, type WorkerTokenData } from "@lobu/core";
+import {
+	MCP_PROTOCOL_VERSION,
+	verifyWorkerToken,
+	type WorkerTokenData,
+} from "@lobu/core";
 import type { Context } from "hono";
 import { getOrgId, orgContext } from "../../../lobu/stores/org-context.js";
 import { getRevokedTokenStore } from "../revoked-token-store.js";
@@ -26,7 +30,7 @@ export const INITIALIZE_BODY = JSON.stringify({
 	jsonrpc: "2.0",
 	method: "initialize",
 	params: {
-		protocolVersion: "2024-11-05",
+		protocolVersion: MCP_PROTOCOL_VERSION,
 		capabilities: {},
 		clientInfo: { name: "lobu-gateway", version: "1.0.0" },
 	},
@@ -154,6 +158,7 @@ export function buildUpstreamHeaders(
 	sessionId: string | null,
 	credentialToken?: string,
 	internal?: boolean,
+	protocolVersion?: string | null,
 ): Record<string, string> {
 	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
@@ -174,6 +179,7 @@ export function buildUpstreamHeaders(
 
 	if (sessionId) {
 		headers["Mcp-Session-Id"] = sessionId;
+		headers["MCP-Protocol-Version"] = protocolVersion ?? MCP_PROTOCOL_VERSION;
 	}
 
 	return headers;

--- a/packages/server/src/gateway/auth/mcp/proxy-upstream.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-upstream.ts
@@ -1,4 +1,4 @@
-import { createLogger } from "@lobu/core";
+import { createLogger, MCP_PROTOCOL_VERSION } from "@lobu/core";
 import { isInternalUrl } from "../../proxy/ssrf-guard.js";
 import {
 	buildSessionKey,
@@ -6,6 +6,7 @@ import {
 	type HttpMcpServerConfig,
 	INITIALIZE_BODY,
 	INITIALIZED_NOTIFICATION_BODY,
+	parseJsonRpcResponse,
 	upstreamTimeoutSignal,
 } from "./proxy-shared.js";
 
@@ -57,7 +58,7 @@ export class McpUpstreamClient {
 	 */
 	private readonly sessions = new Map<
 		string,
-		{ sessionId: string; expiresAt: number }
+		{ sessionId: string; protocolVersion: string; expiresAt: number }
 	>();
 
 	getSession(key: string): string | null {
@@ -72,9 +73,16 @@ export class McpUpstreamClient {
 		return entry.sessionId;
 	}
 
-	setSession(key: string, sessionId: string): void {
+	getProtocolVersion(key: string): string | null {
+		const entry = this.sessions.get(key);
+		return entry && entry.expiresAt > Date.now() ? entry.protocolVersion : null;
+	}
+
+	setSession(key: string, sessionId: string, protocolVersion?: string): void {
 		this.sessions.set(key, {
 			sessionId,
+			protocolVersion:
+				protocolVersion ?? this.getProtocolVersion(key) ?? MCP_PROTOCOL_VERSION,
 			expiresAt: Date.now() + this.SESSION_TTL_SECONDS * 1000,
 		});
 	}
@@ -100,6 +108,7 @@ export class McpUpstreamClient {
 	): Promise<Response> {
 		const sessionKey = buildSessionKey(agentId, mcpId, scopeKey);
 		const sessionId = this.getSession(sessionKey);
+		const protocolVersion = this.getProtocolVersion(sessionKey);
 
 		// Internal MCPs (lobu-memory) live in the same Lobu process and accept
 		// the worker JWT directly.
@@ -112,6 +121,7 @@ export class McpUpstreamClient {
 			sessionId,
 			credentialToken,
 			httpServer.internal === true,
+			protocolVersion,
 		);
 		if (extraHeaders) {
 			for (const [key, value] of Object.entries(extraHeaders)) {
@@ -143,7 +153,7 @@ export class McpUpstreamClient {
 		scopeKey?: string,
 		directAuthToken?: string,
 	): Promise<Response> {
-		return this.sendUpstreamRequest(
+		const response = await this.sendUpstreamRequest(
 			httpServer,
 			agentId,
 			mcpId,
@@ -152,6 +162,27 @@ export class McpUpstreamClient {
 			scopeKey,
 			directAuthToken,
 		);
+		// Discovery deliberately treats an authentication challenge as an empty
+		// unauthenticated catalog. Preserve the raw response so the caller can
+		// inspect its status instead of trying to parse a non-JSON challenge body.
+		if (response.status === 401) return response;
+		const parsed = (await parseJsonRpcResponse(response.clone())) as {
+			result?: { protocolVersion?: unknown };
+			error?: { message?: string };
+		};
+		if (parsed.error) {
+			throw new Error(
+				`MCP initialize failed: ${parsed.error.message ?? "unknown error"}`,
+			);
+		}
+		const protocolVersion = parsed.result?.protocolVersion;
+		if (typeof protocolVersion !== "string" || protocolVersion.length === 0) {
+			throw new Error("MCP initialize response omitted protocolVersion");
+		}
+		const sessionKey = buildSessionKey(agentId, mcpId, scopeKey);
+		const sessionId = this.getSession(sessionKey);
+		if (sessionId) this.setSession(sessionKey, sessionId, protocolVersion);
+		return response;
 	}
 
 	/** Send the MCP `notifications/initialized` notification (best-effort). */

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -358,96 +358,96 @@ export class McpProxy {
 		const userId = tokenData?.userId;
 		const scopeKey = computeScopeKey(userId);
 
-		try {
-			// Clear any stale session before fresh tool discovery
+		const discoverOnce = async (): Promise<CachedMcpServer> => {
 			this.upstream.deleteSession(buildSessionKey(agentId, mcpId, scopeKey));
 
-			// Step 1: Send initialize to capture server instructions
-			let instructions: string | undefined;
-			try {
-				const initResponse = await this.upstream.sendInitialize(
-					httpServer,
-					agentId,
-					mcpId,
-					scopeKey,
-					workerToken,
-				);
+			const initResponse = await this.upstream.sendInitialize(
+				httpServer,
+				agentId,
+				mcpId,
+				scopeKey,
+				workerToken,
+			);
+			if (initResponse.status === 401) {
+				await initResponse.body?.cancel().catch(() => {
+					/* noop */
+				});
+				return { tools: [] };
+			}
 
-				// The only configured MCP server is the internal lobu-memory server,
-				// which accepts the worker JWT directly — a 401 here means discovery
-				// can't proceed, so degrade to an empty tool list.
-				if (initResponse.status === 401) {
-					await initResponse.body?.cancel().catch(() => {
-						/* noop */
-					});
-					return { tools: [] };
-				}
-
-				const initData = (await parseJsonRpcResponse(initResponse)) as {
-					result?: { instructions?: string };
-					error?: { code: number; message: string };
+			// `sendInitialize` already rejected a JSON-RPC error or a handshake
+			// without a negotiated protocolVersion, so this body is a result.
+			const initData = (await parseJsonRpcResponse(initResponse)) as {
+				result?: {
+					capabilities?: Record<string, unknown>;
+					instructions?: string;
 				};
-
-				if (initData?.result?.instructions) {
-					instructions = initData.result.instructions;
-					logger.info("Captured MCP server instructions", {
-						mcpId,
-						length: instructions.length,
-					});
-				}
-
-				// Step 2: Send initialized notification (required by MCP spec)
-				await this.upstream.sendInitializedNotification(
-					httpServer,
-					agentId,
+			};
+			const instructions = initData.result?.instructions;
+			if (instructions) {
+				logger.info("Captured MCP server instructions", {
 					mcpId,
-					scopeKey,
-					workerToken,
-				);
-			} catch (initError) {
-				logger.warn("MCP initialize failed (continuing with tools/list)", {
-					mcpId,
-					error:
-						getErrorMessage(initError),
+					length: instructions.length,
 				});
 			}
 
-			// Step 3: Fetch tools list
-			const jsonRpcBody = JSON.stringify({
-				jsonrpc: "2.0",
-				method: "tools/list",
-				params: {},
-				id: 1,
-			});
+			await this.upstream.sendInitializedNotification(
+				httpServer,
+				agentId,
+				mcpId,
+				scopeKey,
+				workerToken,
+			);
+
+			// A server that did not advertise the tools capability is valid and
+			// must not receive tools/list. Once tools are advertised, discovery
+			// errors are transport failures rather than an empty catalog.
+			if (!("tools" in (initData.result?.capabilities ?? {}))) {
+				return { tools: [], instructions };
+			}
 
 			const response = await this.upstream.sendUpstreamRequest(
 				httpServer,
 				agentId,
 				mcpId,
 				"POST",
-				jsonRpcBody,
+				JSON.stringify({
+					jsonrpc: "2.0",
+					method: "tools/list",
+					params: {},
+					id: 1,
+				}),
 				scopeKey,
 				workerToken,
 			);
-
 			if (response.status === 401) {
 				await response.body?.cancel().catch(() => {
 					/* noop */
 				});
-				return { tools: [] };
+				return { tools: [], instructions };
 			}
 
 			const data = (await parseJsonRpcResponse(response)) as JsonRpcResponse;
-			const tools: McpTool[] = data?.result?.tools || [];
-
-			const serverInfo: CachedMcpServer = { tools, instructions };
-			if (this.toolCache && tools.length > 0) {
+			if (data.error) {
+				throw new Error(`MCP tools/list failed: ${data.error.message}`);
+			}
+			if (!Array.isArray(data.result?.tools)) {
+				throw new Error("MCP tools/list response omitted tools");
+			}
+			return { tools: data.result.tools, instructions };
+		};
+		const cacheServerInfo = (serverInfo: CachedMcpServer) => {
+			if (this.toolCache && serverInfo.tools.length > 0) {
 				this.toolCache.setServerInfo(mcpId, serverInfo, agentId);
 			}
+		};
 
+		try {
+			const serverInfo = await discoverOnce();
+			cacheServerInfo(serverInfo);
 			return serverInfo;
 		} catch (error) {
-			logger.warn("Failed to fetch tools for MCP, retrying once", {
+			logger.warn("MCP discovery failed, retrying once", {
 				mcpId,
 				error: getErrorMessage(error),
 			});
@@ -455,38 +455,15 @@ export class McpProxy {
 			// Retry once after a short delay (upstream may still be starting)
 			await new Promise((r) => setTimeout(r, 2000));
 			try {
-				const retryBody = JSON.stringify({
-					jsonrpc: "2.0",
-					method: "tools/list",
-					params: {},
-					id: 1,
-				});
-				const retryResponse = await this.upstream.sendUpstreamRequest(
-					httpServer,
-					agentId,
+				const serverInfo = await discoverOnce();
+				cacheServerInfo(serverInfo);
+				logger.info("Retry succeeded for MCP discovery", {
 					mcpId,
-					"POST",
-					retryBody,
-					scopeKey,
-					workerToken,
-				);
-				const retryData = (await parseJsonRpcResponse(
-					retryResponse,
-				)) as JsonRpcResponse;
-				const retryTools: McpTool[] = retryData?.result?.tools || [];
-				if (retryTools.length > 0) {
-					const serverInfo: CachedMcpServer = { tools: retryTools };
-					if (this.toolCache) {
-						this.toolCache.setServerInfo(mcpId, serverInfo, agentId);
-					}
-					logger.info("Retry succeeded for MCP tool fetch", {
-						mcpId,
-						toolCount: retryTools.length,
-					});
-					return serverInfo;
-				}
+					toolCount: serverInfo.tools.length,
+				});
+				return serverInfo;
 			} catch (retryError) {
-				logger.error("Retry also failed for MCP tool fetch", {
+				logger.error("Retry also failed for MCP discovery", {
 					mcpId,
 					error:
 						retryError instanceof Error

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Env } from "@lobu/connector-sdk";
-import type { Context } from "hono";
+import type { Context, Next } from "hono";
 import { Hono } from "hono";
 import { compress } from "hono/compress";
 import { cors } from "hono/cors";
@@ -400,6 +400,24 @@ async function serveStaticFile(
 const app = new Hono<{ Bindings: Env }>();
 app.use("/*", compress({ threshold: 1024 }));
 
+// Browser-origin validation is a security boundary for Streamable HTTP MCP.
+// Generic CORS middleware only omits the allow-origin response header for a
+// hostile Origin, which still lets the authenticated request execute. Reject
+// it before auth/tool dispatch. Requests without Origin remain valid for
+// native MCP clients.
+const rejectUntrustedMcpOrigin = async (
+	c: Context<{ Bindings: Env }>,
+	next: Next,
+) => {
+	const origin = c.req.header("Origin");
+	if (origin && !isAllowedCorsOrigin(origin, c.env, c.req.url)) {
+		return c.json({ error: "forbidden", message: "Untrusted MCP Origin" }, 403);
+	}
+	return next();
+};
+app.use("/mcp", rejectUntrustedMcpOrigin);
+app.use("/mcp/*", rejectUntrustedMcpOrigin);
+
 // Enable CORS for MCP clients and frontend
 app.use(
 	"/*",
@@ -418,8 +436,16 @@ app.use(
 			"Authorization",
 			"X-MCP-Format",
 			"X-Lobu-Client",
+			"Mcp-Session-Id",
+			"MCP-Protocol-Version",
+			"Last-Event-ID",
 		],
-		exposeHeaders: ["Content-Type"],
+		exposeHeaders: [
+			"Content-Type",
+			"Mcp-Session-Id",
+			"MCP-Protocol-Version",
+			"WWW-Authenticate",
+		],
 		credentials: true, // Required for better-auth cookies
 	}),
 );
@@ -760,7 +786,8 @@ app.get("/legal", (c) => {
 
 /**
  * REST API endpoints for ChatGPT Custom Actions and lightweight wrappers.
- * MCP tools are exposed through the generic /api/:orgSlug/:toolName proxy.
+ * Agent and internal tools are exposed through the generic
+ * /api/:orgSlug/:toolName proxy; MCP Apps presentation tools stay MCP-only.
  */
 // Health check and worker endpoints must be before mcpAuth middleware
 app.get("/api/health", restHealth);
@@ -2700,7 +2727,7 @@ app.post("/api/connector/:connector/connection/claim", async (c) => {
 app.get("/api/:orgSlug/tools", mcpAuth, restListTools);
 
 /**
- * Generic tool proxy - forwards to any MCP tool
+ * Generic tool proxy for the REST dispatch tool surface.
  * POST /api/:orgSlug/:toolName with JSON body
  */
 app.post("/api/:orgSlug/:toolName", mcpAuth, async (c) => {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -11,6 +11,7 @@
  * so authenticated sessions can recover across restarts and replica hops.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomUUID } from 'node:crypto';
 import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -22,32 +23,39 @@ import {
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { Context } from 'hono';
-import { bindRequestAbortToStream, type AbortableStream } from './events/sse-abort-bridge';
 import { OAuthClientsStore } from './auth/oauth/clients';
-import { isPublicReadable, resolveMaxAccessLevel } from './auth/tool-access';
+import { buildMcpBearerChallenge, publicMcpRequestUrl } from './auth/oauth/resource-indicator';
+import {
+  getRequiredAccessLevel,
+  hasRequiredMcpScope,
+  isPublicReadable,
+  resolveMaxAccessLevel,
+} from './auth/tool-access';
 import { createDbClientFromEnv } from './db/client';
+import { type AbortableStream, bindRequestAbortToStream } from './events/sse-abort-bridge';
+import { formatToolResult } from './formatting/markdown-formatter';
 import type { Env } from './index';
 import {
   agentExistsInOrganization,
   isValidAgentId,
   touchAgentLastUsed,
 } from './lobu/stores/postgres-stores';
-import { readMcpAppBundle } from './utils/mcp-app-bundle';
-import { LOBU_SKILL_MARKDOWN } from './skills/lobu-skill.generated';
-import { McpSessionStore, type PersistedMcpSession } from './mcp-session-store';
 import {
   clearInMemoryMcpSessionsForTests as clearInMemoryMcpSessionsForTestsShared,
   mcpSessionMap,
 } from './mcp-session-state';
+import { McpSessionStore, type PersistedMcpSession } from './mcp-session-store';
+import { LOBU_SKILL_MARKDOWN } from './skills/lobu-skill.generated';
 import {
   type AuthContext,
   executeTool,
   extractAuthContext,
   isSoftErrorResult,
 } from './tools/execute';
+import { LOBU_INTERACTION_RESOURCE_URI } from './tools/mcp_app';
 import { getMcpTools, getTool } from './tools/registry';
 import { validateToolResult } from './tools/validate-args';
-import { formatToolResult } from './formatting/markdown-formatter';
+import { readMcpAppBundle } from './utils/mcp-app-bundle';
 import { resolvePublicOrigin } from './utils/public-origin';
 import { buildWorkspaceInstructions } from './utils/workspace-instructions';
 
@@ -56,6 +64,8 @@ import { buildWorkspaceInstructions } from './utils/workspace-instructions';
 // ---------------------------------------------------------------------------
 const SESSION_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 const SESSION_CLEANUP_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
+const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
+const MCP_APP_EXTENSION_ID = 'io.modelcontextprotocol/ui';
 // ---------------------------------------------------------------------------
 // Session store
 // ---------------------------------------------------------------------------
@@ -141,18 +151,16 @@ export async function revokeInMemoryMcpSessionsForClient(
 // Build a low-level Server wired to our tool registry + auth context
 // ---------------------------------------------------------------------------
 
-/** Shared mutable ref so handleMcp can signal the format to tool handlers. */
-const formatRef = { rawJson: false };
+/** Request-local response formatting; concurrent MCP sessions must never race. */
+const mcpRequestFormat = new AsyncLocalStorage<{ rawJson: boolean }>();
 
 /**
  * MCP Apps UI resources (interactive iframe payloads a host renders in a
  * sandboxed iframe). Keyed by `ui://` uri → the built bundle's app dir under
  * owletto's `dist-mcp-apps/`. Served over `resources/read` + the asset route;
- * our own SPA fetches the one bundle and streams it a `{title, blocks, actions}`
- * view it builds CLIENT-side. (Pointing an external MCP host at a bundle via a
- * tool result's `_meta.ui.resourceUri` needs the SERVER to author that view —
- * a deliberate follow-up, so we don't stamp it today.) Adding an app = one
- * entry + its owletto `src/mcp-apps/<dir>` build — no gateway change.
+ * the decoupled `render_lobu_view` tool links to the resource and supplies a
+ * server-authored LobuViewV1 in `structuredContent`. Adding an app = one entry
+ * plus its owletto `src/mcp-apps/<dir>` build — no gateway change.
  */
 const MCP_APP_RESOURCES: Record<
   string,
@@ -162,21 +170,27 @@ const MCP_APP_RESOURCES: Record<
     description: string;
     appDir: string;
     /**
-     * CSP the host should apply to the rendered iframe. The interaction bundle is
-     * postMessage-only (no fetch/XHR/import/remote assets; verified in
-     * `_shared/host.tsx` + `interaction-card.tsx`), so the policy is strict: no
-     * network, scripts/styles same-origin only. Tailwind's runtime style
-     * injection needs `'unsafe-inline'` on `style-src`.
+     * Domains the host should allow the rendered iframe to reach, in the MCP
+     * Apps `_meta.ui.csp` shape. The host owns the resulting policy; we only
+     * declare what the bundle needs. Empty lists mean "nothing beyond the
+     * bundle's own origin".
      */
-    csp: string;
+    csp: {
+      connectDomains: string[];
+      resourceDomains: string[];
+      frameDomains: string[];
+    };
+    prefersBorder: boolean;
   }
 > = {
-  'ui://lobu/interaction': {
+  [LOBU_INTERACTION_RESOURCE_URI]: {
     name: 'Interaction',
     description:
-      'Interactive approval/question/tool-grant cards rendered in a sandboxed iframe; actions ride a `tools/call` back to the host.',
+      'Interactive Lobu cards rendered in a sandboxed iframe; actions use standard MCP tool calls or host-mediated external links.',
     appDir: 'interaction',
-    csp: "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+    // postMessage-only: the app makes no network requests and embeds no frames.
+    csp: { connectDomains: [], resourceDomains: [], frameDomains: [] },
+    prefersBorder: true,
   },
 };
 
@@ -214,10 +228,19 @@ const MCP_SKILL_RESOURCES: Record<
   },
 };
 
+function supportsMcpApps(capabilities: Record<string, unknown> | null | undefined): boolean {
+  const extensions = capabilities?.extensions;
+  if (!extensions || typeof extensions !== 'object') return false;
+  const uiExtension = (extensions as Record<string, unknown>)[MCP_APP_EXTENSION_ID];
+  if (!uiExtension || typeof uiExtension !== 'object') return false;
+  const mimeTypes = (uiExtension as Record<string, unknown>).mimeTypes;
+  return Array.isArray(mimeTypes) && mimeTypes.includes(MCP_APP_MIME_TYPE);
+}
+
 function createServerForContext(
   env: Env,
   authCtx: SessionAuthContext,
-  resolvedOrigin: string
+  mcpAppsSupported: boolean
 ): Server {
   const server = new Server(
     { name: 'lobu-mcp', version: '0.2.0' },
@@ -236,13 +259,32 @@ function createServerForContext(
     const allTools = getMcpTools({
       publicOnly,
       maxAccessLevel,
-    }).map((t) => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: t.inputSchema,
-      ...(t.annotations && { annotations: t.annotations }),
-      ...(t.outputSchema && { outputSchema: t.outputSchema }),
-    }));
+    }).map((t) => {
+      const securitySchemes = t.securitySchemes
+        ? publicOnly
+          ? [{ type: 'noauth' as const }, ...t.securitySchemes]
+          : t.securitySchemes
+        : undefined;
+      const appMeta = mcpAppsSupported ? t._meta : undefined;
+      return {
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+        ...(t.annotations && { annotations: t.annotations }),
+        ...(t.outputSchema && { outputSchema: t.outputSchema }),
+        ...(securitySchemes && { securitySchemes }),
+        ...(appMeta || securitySchemes
+          ? {
+              _meta: {
+                ...(appMeta ?? {}),
+                // Legacy Apps hosts read OAuth declarations from `_meta`;
+                // current MCP clients use the top-level field above.
+                ...(securitySchemes && { securitySchemes }),
+              },
+            }
+          : {}),
+      };
+    });
 
     return { tools: allTools };
   });
@@ -255,13 +297,11 @@ function createServerForContext(
         uri,
         name: meta.name,
         description: meta.description,
-        mimeType: 'text/html',
+        mimeType: MCP_APP_MIME_TYPE,
         _meta: {
           ui: {
             csp: meta.csp,
-            // Origin the host should associate with this UI (the gateway that
-            // serves the bundle + brokers the `tools/call` actions).
-            domain: resolvedOrigin,
+            prefersBorder: meta.prefersBorder,
           },
         },
       })),
@@ -290,7 +330,14 @@ function createServerForContext(
       throw new Error(`MCP App bundle not built for ${uri} (run owletto build:mcp-apps)`);
     }
     return {
-      contents: [{ uri, mimeType: 'text/html', text: html }],
+      contents: [
+        {
+          uri,
+          mimeType: MCP_APP_MIME_TYPE,
+          text: html,
+          _meta: { ui: { csp: app.csp, prefersBorder: app.prefersBorder } },
+        },
+      ],
     };
   });
 
@@ -310,16 +357,9 @@ function createServerForContext(
         await touchAgentLastUsed(authCtx.organizationId, authCtx.agentId);
       }
 
-      const text = formatRef.rawJson
+      const text = mcpRequestFormat.getStore()?.rawJson
         ? JSON.stringify(result)
         : formatToolResult(name, result, { includeRawJson: false });
-      // NOTE: our own SPA renders interactions (incl. the pending agent-change
-      // approval) through the `ui://lobu/interaction` MCP App, but it builds the
-      // `{title, blocks, actions}` view CLIENT-side from the SSE card payload —
-      // it does not consume this tool result's `_meta`. Rendering for EXTERNAL
-      // MCP hosts (Slack/Claude) needs the SERVER to author that view and stamp
-      // it here; that is a deliberate follow-up. Until then we return plain text
-      // rather than pointing an external host at a bundle it can't feed.
       // When the tool declares an `outputSchema`, also return the result as
       // `structuredContent` (MCP spec: declaring outputSchema implies the result
       // is structured — and a spec-compliant client validates it against the
@@ -355,6 +395,29 @@ function createServerForContext(
         ...(softError ? { isError: true } : {}),
       };
     } catch (error: any) {
+      const tool = getTool(name);
+      const requiredAccess = tool
+        ? getRequiredAccessLevel(name, args ?? {}, tool.annotations?.readOnlyHint === true)
+        : null;
+      const requiredScope =
+        requiredAccess === 'read'
+          ? 'mcp:read'
+          : requiredAccess === 'write'
+            ? 'mcp:write'
+            : requiredAccess === 'admin'
+              ? 'mcp:admin'
+              : null;
+      const scopeChallenge =
+        requiredAccess &&
+        requiredScope &&
+        (authCtx.tokenType === 'oauth' || authCtx.tokenType === 'pat') &&
+        !hasRequiredMcpScope(requiredAccess, authCtx.scopes)
+          ? buildMcpBearerChallenge(authCtx.requestUrl, {
+              error: 'insufficient_scope',
+              errorDescription: error?.message ?? 'The token lacks the required MCP scope.',
+              scope: requiredScope,
+            })
+          : null;
       // Surface the structured taxonomy (lobu#2051 Item 2) when the thrown error
       // carries a code, so the client/agent gets a stable code + retryability +
       // per-call correlation id alongside the human message.
@@ -376,16 +439,12 @@ function createServerForContext(
         ],
         isError: true,
         ...(structuredError ? { structuredContent: { error: structuredError } } : {}),
+        ...(scopeChallenge ? { _meta: { 'mcp/www_authenticate': [scopeChallenge] } } : {}),
       };
     }
   });
 
   return server;
-}
-
-function getProtectedResourceUrl(req: Request): string {
-  const baseUrl = resolvePublicOrigin(req.url);
-  return `${baseUrl}/.well-known/oauth-protected-resource`;
 }
 
 function buildUnauthorizedResponse(req: Request, description: string): Response {
@@ -398,7 +457,7 @@ function buildUnauthorizedResponse(req: Request, description: string): Response 
       status: 401,
       headers: {
         'Content-Type': 'application/json',
-        'WWW-Authenticate': `Bearer realm="${getProtectedResourceUrl(req)}"`,
+        'WWW-Authenticate': buildMcpBearerChallenge(publicMcpRequestUrl(req)),
       },
     }
   );
@@ -521,9 +580,7 @@ async function refreshSessionState(
   lastAccessedAt: number = Date.now()
 ): Promise<boolean> {
   if (!sessionId) return true;
-  return mcpSessionStore.refreshSession(
-    buildPersistedSession(sessionId, authCtx, lastAccessedAt)
-  );
+  return mcpSessionStore.refreshSession(buildPersistedSession(sessionId, authCtx, lastAccessedAt));
 }
 
 async function deletePersistedSession(sessionId: string | null | undefined): Promise<void> {
@@ -819,7 +876,8 @@ async function handleAndMaybeConvert(
   req: Request,
   wantsSSE: boolean
 ): Promise<Response> {
-  const response = await transport.handleRequest(req);
+  const rawJson = req.headers.get('x-mcp-format')?.toLowerCase() === 'json';
+  const response = await mcpRequestFormat.run({ rawJson }, () => transport.handleRequest(req));
   if (!wantsSSE && response.headers.get('content-type')?.includes('text/event-stream')) {
     return sseToJson(response);
   }
@@ -838,6 +896,12 @@ async function resolveAuthWithInstructions(
   req?: Request
 ): Promise<AuthContext & { instructions?: string }> {
   const authCtx: AuthContext & { instructions?: string } = extractAuthContext(c);
+  const request = req ?? c.req.raw;
+  // `baseUrl` stays as extractAuthContext set it: empty means "no configured
+  // public origin", which is what makes `getPublicWebUrl` fall back to the
+  // hosted UI for backend-only self-hosters. Forcing the request origin here
+  // would point every MCP link at a host that serves no frontend.
+  authCtx.requestUrl = publicMcpRequestUrl(request);
   if (req) {
     const initialize = await readInitializeRequest(req);
     // Verified worker auth already supplies an agent. Only fall back to the
@@ -881,7 +945,7 @@ function createSessionTransport(
   env: Env,
   authCtx: SessionAuthContext,
   sessionIdGenerator: () => string,
-  resolvedOrigin: string
+  mcpAppsSupported: boolean
 ): { transport: WebStandardStreamableHTTPServerTransport; server: Server } {
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator,
@@ -904,7 +968,7 @@ function createSessionTransport(
       void deletePersistedSession(transport.sessionId);
     }
   };
-  const server = createServerForContext(env, authCtx, resolvedOrigin);
+  const server = createServerForContext(env, authCtx, mcpAppsSupported);
   return { transport, server };
 }
 
@@ -938,6 +1002,7 @@ async function initializeRecoveredSession(
       'content-type': 'application/json',
       accept: FULL_MCP_ACCEPT,
       'mcp-session-id': sessionId,
+      'mcp-protocol-version': MCP_PROTOCOL_VERSION,
     }),
     body: JSON.stringify({
       jsonrpc: '2.0',
@@ -955,7 +1020,6 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
   const wantsSSE = clientAcceptsSSE(c.req.raw);
   const req = normalizeAcceptHeader(c.req.raw);
   const sessionId = req.headers.get('mcp-session-id') ?? undefined;
-  formatRef.rawJson = req.headers.get('x-mcp-format')?.toLowerCase() === 'json';
 
   // Existing session → reuse
   if (sessionId && sessions.has(sessionId)) {
@@ -968,9 +1032,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
     // is deliberately a single atomic UPDATE rather than a check followed by an
     // upsert — a revoke committing between those two would be undone by the
     // write that follows it.
-    if (
-      !(await refreshSessionState(sessionId, session.authCtx, session.lastAccessedAt))
-    ) {
+    if (!(await refreshSessionState(sessionId, session.authCtx, session.lastAccessedAt))) {
       sessions.delete(sessionId);
       session.transport.close?.();
       return buildJsonRpcErrorResponse(
@@ -1067,9 +1129,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
     // the old binding. Persist the upgrade, but update-only: an upsert here
     // would re-INSERT a row deleted by a revoke that committed mid-request,
     // resurrecting exactly the session the refresh exists to catch.
-    if (
-      !(await refreshSessionState(sessionId, session.authCtx, session.lastAccessedAt))
-    ) {
+    if (!(await refreshSessionState(sessionId, session.authCtx, session.lastAccessedAt))) {
       clearSession();
       return buildJsonRpcErrorResponse(
         'MCP session expired or not recognized. Start a new session by sending an initialize request — spec-compliant clients re-initialize automatically on 404.',
@@ -1130,7 +1190,12 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
             c.env,
             recoveredAuthCtx,
             () => sessionId,
-            resolvePublicOrigin(req.url)
+            // The client's negotiated MCP Apps capability is not part of the
+            // persisted session row, so a recovered session cannot prove the
+            // host renders `ui://` bundles. Advertise the plain tool
+            // definition rather than a resource pointer the host may not
+            // understand; a client that re-initializes negotiates it again.
+            false
           );
           await server.connect(transport);
           await initializeRecoveredSession(transport, sessionId, req.url);
@@ -1211,7 +1276,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
       c.env,
       authCtx,
       () => randomUUID(),
-      resolvePublicOrigin(req.url)
+      supportsMcpApps(initialize?.capabilities)
     );
     await server.connect(transport);
     const response = await handleAndMaybeConvert(transport, req, wantsSSE);

--- a/packages/server/src/mcp-proxy/__tests__/probe-discovery.test.ts
+++ b/packages/server/src/mcp-proxy/__tests__/probe-discovery.test.ts
@@ -1,0 +1,242 @@
+import { MCP_PROTOCOL_VERSION } from '@lobu/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../credential-resolver', () => ({
+  resolveCredentials: vi.fn(async () => null),
+  resolveCredentialsByConnectionId: vi.fn(async () => null),
+}));
+
+import { callTool, discoverTools, probeMcpServer } from '../client';
+
+const jsonResponse = (body: unknown, sessionId?: string) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(sessionId ? { 'Mcp-Session-Id': sessionId } : {}),
+    },
+  });
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('probeMcpServer capability discovery', () => {
+  it('accepts a truly toolless server without calling tools/list', async () => {
+    const requests: Array<{ headers: Headers; body: Record<string, unknown> }> = [];
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      requests.push({ headers: new Headers(init?.headers), body });
+      if (body.method === 'initialize') {
+        return jsonResponse(
+          {
+            jsonrpc: '2.0',
+            id: 0,
+            result: {
+              protocolVersion: MCP_PROTOCOL_VERSION,
+              capabilities: { resources: {} },
+              serverInfo: { name: 'toolless', version: '1.0.0' },
+            },
+          },
+          'session-1'
+        );
+      }
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    const result = await probeMcpServer('https://mcp.example.com/rpc');
+    expect(result.tools).toEqual([]);
+    expect(requests.map((request) => request.body.method)).not.toContain('tools/list');
+    expect(requests[1]?.headers.get('mcp-protocol-version')).toBe(MCP_PROTOCOL_VERSION);
+  });
+
+  it('fails closed when a server advertises tools but tools/list fails', async () => {
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if (body.method === 'initialize') {
+        return jsonResponse(
+          {
+            jsonrpc: '2.0',
+            id: 0,
+            result: {
+              protocolVersion: MCP_PROTOCOL_VERSION,
+              capabilities: { tools: {} },
+              serverInfo: { name: 'broken-tools', version: '1.0.0' },
+            },
+          },
+          'session-2'
+        );
+      }
+      if (body.method === 'tools/list') {
+        return new Response('upstream unavailable', { status: 503 });
+      }
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    await expect(probeMcpServer('https://mcp.example.com/rpc')).rejects.toThrow(
+      /MCP server returned 503/
+    );
+  });
+
+  it('fails closed when a server advertises tools but omits the tools array', async () => {
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if (body.method === 'initialize') {
+        return jsonResponse(
+          {
+            jsonrpc: '2.0',
+            id: 0,
+            result: {
+              protocolVersion: MCP_PROTOCOL_VERSION,
+              capabilities: { tools: {} },
+              serverInfo: { name: 'malformed-tools', version: '1.0.0' },
+            },
+          },
+          'session-3'
+        );
+      }
+      if (body.method === 'tools/list') {
+        return jsonResponse({ jsonrpc: '2.0', id: 1, result: {} });
+      }
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    await expect(probeMcpServer('https://mcp.example.com/rpc')).rejects.toThrow(
+      /MCP tools\/list response omitted tools/
+    );
+  });
+});
+
+describe('discoverTools capability discovery', () => {
+  it('fails closed when an installed connector omits the negotiated tools array', async () => {
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if (body.method === 'initialize') {
+        return jsonResponse(
+          {
+            jsonrpc: '2.0',
+            id: 0,
+            result: {
+              protocolVersion: MCP_PROTOCOL_VERSION,
+              capabilities: { tools: {} },
+            },
+          },
+          'session-4'
+        );
+      }
+      if (body.method === 'tools/list') {
+        return jsonResponse({ jsonrpc: '2.0', id: 1, result: {} });
+      }
+      return jsonResponse({ jsonrpc: '2.0', id: null, result: {} });
+    }) as typeof fetch;
+
+    await expect(
+      discoverTools(
+        'malformed-tools-array',
+        {
+          upstream_url: 'https://mcp.example.com/rpc',
+          tool_prefix: 'malformed',
+        },
+        'test-org-malformed-tools'
+      )
+    ).rejects.toThrow(/MCP tools\/list response omitted tools/);
+  });
+});
+
+describe('callTool session recovery', () => {
+  const config = {
+    upstream_url: 'https://mcp.example.com/rpc',
+    tool_prefix: 'recovery',
+  };
+
+  /** initialize → session id + negotiated protocol version. */
+  const initializeResponse = (sessionId: string) =>
+    jsonResponse(
+      {
+        jsonrpc: '2.0',
+        id: 0,
+        result: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+        },
+      },
+      sessionId
+    );
+
+  it('rehandshakes when the upstream rejects a cached session id', async () => {
+    const sent: Array<{ method: unknown; sessionId: string | null }> = [];
+    const expired = new Set<string>();
+    let issued = 0;
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      const sessionId = new Headers(init?.headers).get('mcp-session-id');
+      sent.push({ method: body.method, sessionId });
+      if (body.method === 'initialize') {
+        issued += 1;
+        return initializeResponse(`session-live-${issued}`);
+      }
+      // MCP Streamable HTTP requires a 404 for a session id the upstream no
+      // longer knows. The tool never ran, so a replay cannot double-execute.
+      if (sessionId && expired.has(sessionId)) {
+        return new Response('Session not found', { status: 404 });
+      }
+      if (body.method === 'tools/call') {
+        // The upstream drops the session right after answering, so the next
+        // call arrives with a cached id it no longer recognizes.
+        if (sessionId) expired.add(sessionId);
+        return jsonResponse({
+          jsonrpc: '2.0',
+          id: 1,
+          result: { content: [{ type: 'text', text: 'ok' }], isError: false },
+        });
+      }
+      return jsonResponse({ jsonrpc: '2.0', id: null, result: {} });
+    }) as typeof fetch;
+
+    const first = await callTool(
+      'recovery-connector',
+      config,
+      'test-org-recovery',
+      'do_thing',
+      {},
+      991
+    );
+    expect(first.isError).toBe(false);
+
+    // Second call reuses the now-stale cached session and must recover.
+    const second = await callTool(
+      'recovery-connector',
+      config,
+      'test-org-recovery',
+      'do_thing',
+      {},
+      991
+    );
+    expect(second.content).toEqual([{ type: 'text', text: 'ok' }]);
+    expect(sent.filter((entry) => entry.method === 'initialize')).toHaveLength(2);
+    // One rejected attempt, then exactly one replay — never a blind retry loop.
+    expect(sent.filter((entry) => entry.method === 'tools/call')).toHaveLength(3);
+  });
+
+  it('never replays a tools/call after an ambiguous transport failure', async () => {
+    let toolCalls = 0;
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if (body.method === 'initialize') return initializeResponse('session-ambiguous');
+      if (body.method === 'tools/call') {
+        toolCalls += 1;
+        // The upstream may have executed the action before the response was
+        // lost, so this must surface rather than re-run the side effect.
+        return new Response('gateway timeout', { status: 504 });
+      }
+      return jsonResponse({ jsonrpc: '2.0', id: null, result: {} });
+    }) as typeof fetch;
+
+    await expect(
+      callTool('ambiguous-connector', config, 'test-org-ambiguous', 'charge_card', {}, 992)
+    ).rejects.toThrow(/Upstream MCP returned 504/);
+    expect(toolCalls).toBe(1);
+  });
+});

--- a/packages/server/src/mcp-proxy/client.ts
+++ b/packages/server/src/mcp-proxy/client.ts
@@ -21,6 +21,7 @@ import type { DiscoveredTool, JsonRpcResponse, McpProxyConfig } from './types';
 const FETCH_TIMEOUT_INIT_MS = 10_000;
 const FETCH_TIMEOUT_TOOL_MS = 30_000;
 const TOOL_CACHE_TTL_MS = 5 * 60 * 1000;
+const SESSION_TTL_MS = 30 * 60 * 1000;
 
 function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
   const controller = new AbortController();
@@ -33,7 +34,16 @@ function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Pr
  * accounts on the same connector never reuse each other's authenticated MCP
  * session. Discovery sessions use the connector-wide key.
  */
-const sessions = new Map<string, string>();
+type McpSessionState = { sessionId: string; protocolVersion: string };
+const sessions = new TtlCache<McpSessionState>(SESSION_TTL_MS);
+
+/**
+ * The upstream rejected the request because it does not recognize our session
+ * id (MCP Streamable HTTP: an unknown/expired session MUST get a 404). The
+ * upstream never reached the tool, so replaying after a fresh handshake cannot
+ * double-execute an action — unlike a timeout or a 5xx, which stay fatal.
+ */
+class McpSessionExpiredError extends Error {}
 
 function sessionKey(orgId: string, connectorKey: string, connectionId?: number): string {
   return connectionId === undefined
@@ -53,15 +63,16 @@ const toolCache = new TtlCache<DiscoveredTool[]>(TOOL_CACHE_TTL_MS);
  */
 function buildHeaders(
   credentials: ResolvedCredentials | null,
-  mcpSessionId: string | null
+  session: McpSessionState | null
 ): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json',
   };
 
-  if (mcpSessionId) {
-    headers['Mcp-Session-Id'] = mcpSessionId;
+  if (session) {
+    headers['Mcp-Session-Id'] = session.sessionId;
+    headers['MCP-Protocol-Version'] = session.protocolVersion;
   }
 
   if (credentials?.accessToken) {
@@ -88,8 +99,8 @@ async function sendRequest(
   // after the creation-time probe, so "validated at write time" is not enough.
   assertSafeUrl(upstreamUrl);
   const key = sessionKey(orgId, connectorKey, connectionId);
-  const mcpSessionId = sessions.get(key) ?? null;
-  const headers = buildHeaders(credentials, mcpSessionId);
+  const session = sessions.get(key) ?? null;
+  const headers = buildHeaders(credentials, session);
 
   const response = await fetchWithTimeout(
     upstreamUrl,
@@ -100,11 +111,18 @@ async function sendRequest(
   // Track session ID from response
   const newSessionId = response.headers.get('Mcp-Session-Id');
   if (newSessionId) {
-    sessions.set(key, newSessionId);
+    sessions.set(key, {
+      sessionId: newSessionId,
+      protocolVersion: session?.protocolVersion ?? MCP_PROTOCOL_VERSION,
+    });
   }
 
   if (!response.ok) {
     const text = await response.text();
+    if (response.status === 404 && session) {
+      sessions.delete(key);
+      throw new McpSessionExpiredError(`Upstream MCP returned 404: ${text}`);
+    }
     throw new Error(`Upstream MCP returned ${response.status}: ${text}`);
   }
 
@@ -121,7 +139,7 @@ async function initializeSession(
   orgId: string,
   connectorKey: string,
   connectionId?: number
-): Promise<void> {
+): Promise<Record<string, unknown>> {
   // Clear existing session
   const key = sessionKey(orgId, connectorKey, connectionId);
   sessions.delete(key);
@@ -150,6 +168,15 @@ async function initializeSession(
     throw new Error(`MCP initialize failed: ${initResponse.error.message}`);
   }
 
+  const protocolVersion = initResponse.result?.protocolVersion;
+  if (typeof protocolVersion !== 'string' || protocolVersion.length === 0) {
+    throw new Error('MCP initialize response omitted protocolVersion');
+  }
+  const initializedSession = sessions.get(key);
+  if (initializedSession) {
+    sessions.set(key, { ...initializedSession, protocolVersion });
+  }
+
   // Send initialized notification
   try {
     await sendRequest(
@@ -167,6 +194,8 @@ async function initializeSession(
   } catch {
     // Notification delivery is best-effort
   }
+
+  return initResponse.result?.capabilities ?? {};
 }
 
 /**
@@ -197,7 +226,21 @@ export async function discoverTools(
 
   try {
     // Initialize session first
-    await initializeSession(config.upstream_url, credentials, orgId, connectorKey);
+    const capabilities = await initializeSession(
+      config.upstream_url,
+      credentials,
+      orgId,
+      connectorKey
+    );
+
+    // A server that does not advertise tools is legitimately toolless. Once it
+    // advertises the capability, however, tools/list is part of the negotiated
+    // contract and discovery failures must fail the install instead of silently
+    // persisting a connector with zero operations.
+    if (!Object.hasOwn(capabilities, 'tools')) {
+      toolCache.set(cacheKey, []);
+      return [];
+    }
 
     // Fetch tools/list
     const response = await sendRequest(
@@ -215,11 +258,13 @@ export async function discoverTools(
     );
 
     if (response.error) {
-      logger.error({ connectorKey, error: response.error }, '[McpProxy] tools/list returned error');
-      return cached ?? [];
+      throw new Error(`MCP tools/list failed: ${response.error.message}`);
     }
 
-    const rawTools = response.result?.tools ?? [];
+    const rawTools = response.result?.tools;
+    if (!Array.isArray(rawTools)) {
+      throw new Error('MCP tools/list response omitted tools');
+    }
     const prefix = config.tool_prefix;
 
     const tools: DiscoveredTool[] = rawTools.map((t) => ({
@@ -245,7 +290,8 @@ export async function discoverTools(
       { connectorKey, url: config.upstream_url, error: errorMessage(error) },
       '[McpProxy] Tool discovery failed'
     );
-    return cached ?? [];
+    if (cached) return cached;
+    throw error;
   }
 }
 
@@ -263,26 +309,13 @@ export async function callTool(
 ): Promise<{ content: unknown[]; isError: boolean }> {
   const credentials = await resolveCredentialsByConnectionId(connectionId, orgId);
 
-  const jsonRpcBody = JSON.stringify({
-    jsonrpc: '2.0',
-    method: 'tools/call',
-    params: { name: originalToolName, arguments: args },
-    id: 1,
-  });
+  const key = sessionKey(orgId, connectorKey, connectionId);
 
-  let response: JsonRpcResponse;
-  try {
-    response = await sendRequest(
-      config.upstream_url,
-      credentials,
-      orgId,
-      connectorKey,
-      jsonRpcBody,
-      FETCH_TIMEOUT_TOOL_MS,
-      connectionId
-    );
-  } catch (_error) {
-    // If there's no session yet, initialize and retry
+  // Establish a session before the action call. A transport failure after a
+  // tools/call is ambiguous — the upstream may have executed the action before
+  // the response was lost — so it must never be interpreted as permission to
+  // initialize and replay a potentially destructive call.
+  if (!sessions.get(key)) {
     await initializeSession(
       config.upstream_url,
       credentials,
@@ -290,7 +323,17 @@ export async function callTool(
       connectorKey,
       connectionId
     );
-    response = await sendRequest(
+  }
+
+  const jsonRpcBody = JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'tools/call',
+    params: { name: originalToolName, arguments: args },
+    id: 1,
+  });
+
+  const send = (): Promise<JsonRpcResponse> =>
+    sendRequest(
       config.upstream_url,
       credentials,
       orgId,
@@ -299,6 +342,23 @@ export async function callTool(
       FETCH_TIMEOUT_TOOL_MS,
       connectionId
     );
+
+  let response: JsonRpcResponse;
+  try {
+    response = await send();
+  } catch (error) {
+    // A rejected session id means the call never ran upstream; every other
+    // transport failure is ambiguous and must surface rather than replay.
+    if (!(error instanceof McpSessionExpiredError)) throw error;
+    logger.info({ connectorKey, originalToolName }, '[McpProxy] Session rejected, reinitializing');
+    await initializeSession(
+      config.upstream_url,
+      credentials,
+      orgId,
+      connectorKey,
+      connectionId
+    );
+    response = await send();
   }
 
   // Stale session recovery: "not initialized" → reinitialize + retry once
@@ -311,15 +371,7 @@ export async function callTool(
       connectorKey,
       connectionId
     );
-    response = await sendRequest(
-      config.upstream_url,
-      credentials,
-      orgId,
-      connectorKey,
-      jsonRpcBody,
-      FETCH_TIMEOUT_TOOL_MS,
-      connectionId
-    );
+    response = await send();
   }
 
   if (response.error) {
@@ -392,13 +444,17 @@ export async function probeMcpServer(upstreamUrl: string): Promise<{
 }> {
   assertSafeUrl(upstreamUrl);
   let mcpSessionId: string | null = null;
+  let protocolVersion: string | null = null;
 
   const send = async (body: unknown): Promise<JsonRpcResponse> => {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       Accept: 'application/json',
     };
-    if (mcpSessionId) headers['Mcp-Session-Id'] = mcpSessionId;
+    if (mcpSessionId) {
+      headers['Mcp-Session-Id'] = mcpSessionId;
+      headers['MCP-Protocol-Version'] = protocolVersion ?? MCP_PROTOCOL_VERSION;
+    }
 
     const response = await fetchWithTimeout(
       upstreamUrl,
@@ -433,6 +489,14 @@ export async function probeMcpServer(upstreamUrl: string): Promise<{
     throw new Error(`MCP initialize failed: ${initResponse.error.message}`);
   }
 
+  if (
+    typeof initResponse.result?.protocolVersion !== 'string' ||
+    initResponse.result.protocolVersion.length === 0
+  ) {
+    throw new Error('MCP initialize response omitted protocolVersion');
+  }
+  protocolVersion = initResponse.result.protocolVersion;
+
   const serverInfo = initResponse.result?.serverInfo ?? { name: 'unknown', version: '0.0.0' };
   const instructions = initResponse.result?.instructions;
 
@@ -443,23 +507,30 @@ export async function probeMcpServer(upstreamUrl: string): Promise<{
     // best-effort
   }
 
-  // Discover tools
-  let tools: Array<{
+  const capabilities = initResponse.result?.capabilities ?? {};
+  if (!Object.hasOwn(capabilities, 'tools')) {
+    return { serverInfo, instructions, tools: [] };
+  }
+
+  // An advertised tools capability makes tools/list mandatory.
+  const toolsResponse = await send({
+    jsonrpc: '2.0',
+    method: 'tools/list',
+    params: {},
+    id: 1,
+  });
+  if (toolsResponse.error) {
+    throw new Error(`MCP tools/list failed: ${toolsResponse.error.message}`);
+  }
+  const tools = toolsResponse.result?.tools;
+  if (!Array.isArray(tools)) {
+    throw new Error('MCP tools/list response omitted tools');
+  }
+  const typedTools = tools as Array<{
     name: string;
     description?: string;
     inputSchema?: Record<string, unknown>;
-  }> = [];
-  try {
-    const toolsResponse = await send({
-      jsonrpc: '2.0',
-      method: 'tools/list',
-      params: {},
-      id: 1,
-    });
-    tools = toolsResponse.result?.tools ?? [];
-  } catch {
-    // Server may not support tools — that's fine
-  }
+  }>;
 
-  return { serverInfo, instructions, tools };
+  return { serverInfo, instructions, tools: typedTools };
 }

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -28,7 +28,12 @@ import {
 } from "./tools/execute";
 import { getContent } from "./tools/get_content";
 import { getBehavior } from "./tools/get_behavior";
-import { getAllTools, getTool, type ToolContext } from "./tools/registry";
+import {
+	getAllTools,
+	getTool,
+	isRestDispatchTool,
+	type ToolContext,
+} from "./tools/registry";
 import {
 	errorMessage,
 	ToolNotRegisteredError,
@@ -278,10 +283,10 @@ export async function restToolAction(
 
 /**
  * POST /api/:orgSlug/:toolName
- * Generic proxy endpoint that forwards to any MCP tool
+ * Generic proxy endpoint for the REST dispatch tool surface.
  *
- * This allows all MCP tools to be called via REST API without
- * needing individual wrapper functions for each tool
+ * Agent and internal tools can be called without individual wrappers. MCP Apps
+ * presentation tools remain MCP-only and are rejected here.
  */
 export async function restToolProxy(
 	c: Context<{ Bindings: Env }>,
@@ -292,6 +297,9 @@ export async function restToolProxy(
 		const toolName = explicitToolName ?? c.req.param("toolName");
 		if (!toolName) {
 			return c.json({ error: "Tool name is required" }, 400);
+		}
+		if (!isRestDispatchTool(toolName)) {
+			throw new ToolNotRegisteredError(toolName);
 		}
 		const args: Record<string, unknown> = explicitArgs ?? (await c.req.json());
 		const authCtx = extractAuthContext(c);
@@ -320,8 +328,9 @@ export async function restToolProxy(
 
 /**
  * GET /api/:orgSlug/tools
- * List the tool surface available to the caller — the same uniform set MCP
- * `tools/list` returns, filtered by the caller's access level (role × scope).
+ * List the REST dispatch surface available to the caller, filtered by the
+ * caller's access level (role × scope). MCP Apps presentation tools are not
+ * part of this surface.
  */
 export async function restListTools(c: Context<{ Bindings: Env }>) {
 	try {

--- a/packages/server/src/tools/admin/manage_behaviors/list.ts
+++ b/packages/server/src/tools/admin/manage_behaviors/list.ts
@@ -9,6 +9,7 @@ import {
 } from "@lobu/core/contracts/tools/manage-behaviors";
 import { getDb } from "../../../db/client";
 import type { Env } from "../../../index";
+import { canonicalizeBehaviorText } from "../../../utils/behavior-vocabulary";
 import logger from "../../../utils/logger";
 import {
 	buildBehaviorUrl,
@@ -224,9 +225,9 @@ export async function handleList(
 		// rows still hold the legacy string). Rewrite it at read time so the
 		// public projection never surfaces the internal vocabulary.
 		if (typeof (rest as Record<string, unknown>).behavior_run_error === "string") {
-			(rest as Record<string, unknown>).behavior_run_error = (
-				(rest as Record<string, unknown>).behavior_run_error as string
-			).replaceAll("client.watchers.", "client.behaviors.");
+			(rest as Record<string, unknown>).behavior_run_error = canonicalizeBehaviorText(
+				(rest as Record<string, unknown>).behavior_run_error as string,
+			);
 		}
 
 		if (!args.include_details) {

--- a/packages/server/src/tools/get_behavior.ts
+++ b/packages/server/src/tools/get_behavior.ts
@@ -40,6 +40,7 @@ import { formatDateISO, parseDateAlias } from '../utils/date-aliases';
 import { parseJsonObject } from '@lobu/core';
 import logger from '../utils/logger';
 import { ToolUserError } from '../utils/errors';
+import { canonicalizeBehaviorText } from '../utils/behavior-vocabulary';
 import {
   requireOrgReadAccess,
   requireReadAccess,
@@ -774,12 +775,13 @@ async function getBehaviorImpl(
 
     // Computed health (item 3, #2033) — pure derivation over the
     // already-selected schedule/run columns; no extra query.
+    const behaviorRunError = canonicalizeBehaviorText(watcherRow.watcher_run_error) ?? null;
     const behaviorHealth = computeBehaviorHealth({
       status: watcherRow.status,
       nextRunAt: watcherRow.next_run_at,
       latestRunStatus: watcherRow.watcher_run_status,
       latestRunCreatedAt: watcherRow.watcher_run_created_at,
-      latestRunError: watcherRow.watcher_run_error,
+      latestRunError: behaviorRunError,
       latestRunOutcome: watcherRow.watcher_run_outcome,
     });
 
@@ -820,7 +822,7 @@ async function getBehaviorImpl(
                 | 'agent_error'
                 | 'scoreable'
                 | undefined,
-              error_message: watcherRow.watcher_run_error ?? undefined,
+              error_message: behaviorRunError ?? undefined,
               created_at: watcherRow.watcher_run_created_at,
               completed_at: watcherRow.watcher_run_completed_at,
             }

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -1,0 +1,327 @@
+import { deepRedactSecrets, isSecretKey, REDACTED_SENTINEL } from '@lobu/core';
+import { type Static, Type } from '@sinclair/typebox';
+import type { Env } from '../index';
+import { ToolUserError } from '../utils/errors';
+import { buildResourcePermalink } from '../utils/url-builder';
+import { getContent } from './get_content';
+import type { ToolContext } from './registry';
+import { withValidatedArgs } from './validate-args';
+import { getOrgUrlContext } from './view-urls';
+
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v1';
+
+const TITLE_MAX_LENGTH = 200;
+const BLOCK_MAX_ITEMS = 100;
+const TEXT_LABEL_MAX_LENGTH = 120;
+const TEXT_VALUE_MAX_LENGTH = 20_000;
+const CODE_VALUE_MAX_LENGTH = 40_000;
+const DIFF_FIELD_MAX_ITEMS = 100;
+const ACTION_MAX_ITEMS = 10;
+const ACTION_ID_MAX_LENGTH = 80;
+const ACTION_LABEL_MAX_LENGTH = 120;
+const ACTION_HREF_MAX_LENGTH = 2_048;
+const DISPLAY_REDACTION = '[redacted]';
+
+const TextBlockSchema = Type.Object({
+  type: Type.Literal('text'),
+  label: Type.Optional(Type.String({ maxLength: TEXT_LABEL_MAX_LENGTH })),
+  value: Type.String({ maxLength: TEXT_VALUE_MAX_LENGTH }),
+  muted: Type.Optional(Type.Boolean()),
+});
+
+const CodeBlockSchema = Type.Object({
+  type: Type.Literal('code'),
+  value: Type.String({ maxLength: CODE_VALUE_MAX_LENGTH }),
+});
+
+const DiffBlockSchema = Type.Object({
+  type: Type.Literal('diff'),
+  fields: Type.Array(
+    Type.Object({
+      label: Type.String({ minLength: 1, maxLength: TEXT_LABEL_MAX_LENGTH }),
+      before: Type.Optional(Type.String({ maxLength: TEXT_VALUE_MAX_LENGTH })),
+      after: Type.String({ maxLength: TEXT_VALUE_MAX_LENGTH }),
+    }),
+    { maxItems: DIFF_FIELD_MAX_ITEMS }
+  ),
+});
+
+const LobuViewBlockSchema = Type.Union([TextBlockSchema, CodeBlockSchema, DiffBlockSchema]);
+
+const LinkActionSchema = Type.Object({
+  id: Type.String({ minLength: 1, maxLength: ACTION_ID_MAX_LENGTH }),
+  label: Type.String({ minLength: 1, maxLength: ACTION_LABEL_MAX_LENGTH }),
+  variant: Type.Optional(
+    Type.Union([
+      Type.Literal('primary'),
+      Type.Literal('outline'),
+      Type.Literal('ghost'),
+      Type.Literal('destructive'),
+    ])
+  ),
+  icon: Type.Optional(Type.Literal('external')),
+  terminal: Type.Optional(Type.Boolean()),
+  href: Type.String({
+    minLength: 1,
+    maxLength: ACTION_HREF_MAX_LENGTH,
+    pattern: '^https?://',
+  }),
+});
+
+export const LobuViewSchema = Type.Object({
+  version: Type.Literal(1),
+  title: Type.Optional(Type.String({ maxLength: TITLE_MAX_LENGTH })),
+  tone: Type.Optional(
+    Type.Union([Type.Literal('warning'), Type.Literal('default'), Type.Literal('bare')])
+  ),
+  blocks: Type.Array(LobuViewBlockSchema, { maxItems: BLOCK_MAX_ITEMS }),
+  actions: Type.Array(LinkActionSchema, { maxItems: ACTION_MAX_ITEMS }),
+});
+
+const RenderActionSchema = Type.Object({
+  action: Type.Literal('render', {
+    description:
+      'Render a compact final card from model-selected data. Call Lobu data tools first; do not use this for ordinary text answers.',
+  }),
+  title: Type.Optional(Type.String({ maxLength: TITLE_MAX_LENGTH })),
+  tone: Type.Optional(
+    Type.Union([Type.Literal('warning'), Type.Literal('default'), Type.Literal('bare')])
+  ),
+  blocks: Type.Array(LobuViewBlockSchema, {
+    minItems: 1,
+    maxItems: BLOCK_MAX_ITEMS,
+  }),
+});
+
+const ReviewApprovalActionSchema = Type.Object({
+  action: Type.Literal('review_approval', {
+    description:
+      'Render the server-authored review card for one pending Lobu approval run. The card opens Lobu for the human decision.',
+  }),
+  run_id: Type.Integer({ minimum: 1 }),
+});
+
+export const RenderLobuViewSchema = Type.Union([RenderActionSchema, ReviewApprovalActionSchema]);
+
+type RenderLobuViewArgs = Static<typeof RenderLobuViewSchema>;
+type LobuView = Static<typeof LobuViewSchema>;
+type LobuViewBlock = Static<typeof LobuViewBlockSchema>;
+
+const DIFF_ROUTING_KEYS = new Set([
+  'action',
+  'agent_id',
+  'base',
+  'behavior_id',
+  'entity_id',
+  'id',
+  'owner_user_id',
+  'reason',
+  'watcher_id',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  if (maxLength <= 1) return value.slice(0, maxLength);
+  return `${value.slice(0, maxLength - 1)}…`;
+}
+
+function displayRedacted(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replaceAll(REDACTED_SENTINEL, DISPLAY_REDACTION);
+  }
+  if (Array.isArray(value)) return value.map(displayRedacted);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, inner]) => [key, displayRedacted(inner)])
+  );
+}
+
+/**
+ * Approval metadata is stored for execution, not presentation. Redact by the
+ * field name before detaching a primitive value from its key, then deep-walk
+ * nested objects and URI userinfo using the shared Lobu secret classifier.
+ */
+function redactForDisplay(value: unknown, key?: string): unknown {
+  if (key && value != null && isSecretKey(key)) return DISPLAY_REDACTION;
+  return displayRedacted(deepRedactSecrets(value));
+}
+
+function displayValue(value: unknown, maxLength: number, key?: string): string {
+  if (value === undefined || value === null) return '';
+  const redacted = redactForDisplay(value, key);
+  let rendered: string;
+  if (typeof redacted === 'string') {
+    rendered = redacted;
+  } else {
+    try {
+      rendered = JSON.stringify(redacted, null, 2);
+    } catch {
+      rendered = String(redacted);
+    }
+  }
+  return truncate(rendered, maxLength);
+}
+
+function approvalBlocks(row: {
+  content: string | null;
+  interaction_input: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+}): LobuViewBlock[] {
+  const metadata = row.metadata ?? {};
+  const proposal = isRecord(metadata.proposal) ? metadata.proposal : null;
+  const current = isRecord(metadata.current) ? metadata.current : null;
+  const fields = isRecord(metadata.fields) ? metadata.fields : null;
+  const proposed = fields ?? proposal;
+
+  if (proposed) {
+    const diffFields = Object.entries(proposed)
+      .filter(([key, value]) => !DIFF_ROUTING_KEYS.has(key) && value !== undefined)
+      .slice(0, DIFF_FIELD_MAX_ITEMS)
+      .map(([key, value]) => ({
+        label: truncate(key || 'field', TEXT_LABEL_MAX_LENGTH),
+        ...(current && current[key] !== undefined
+          ? { before: displayValue(current[key], TEXT_VALUE_MAX_LENGTH, key) }
+          : {}),
+        after: displayValue(value, TEXT_VALUE_MAX_LENGTH, key),
+      }));
+    if (diffFields.length > 0) return [{ type: 'diff', fields: diffFields }];
+  }
+
+  if (row.interaction_input && Object.keys(row.interaction_input).length > 0) {
+    return [
+      {
+        type: 'code',
+        value: displayValue(row.interaction_input, CODE_VALUE_MAX_LENGTH),
+      },
+    ];
+  }
+
+  return [
+    {
+      type: 'text',
+      value: displayValue(row.content || 'Review this pending Lobu action.', TEXT_VALUE_MAX_LENGTH),
+      muted: true,
+    },
+  ];
+}
+
+function sanitizeBlocks(blocks: LobuViewBlock[]): LobuViewBlock[] {
+  return blocks.slice(0, BLOCK_MAX_ITEMS).map((block) => {
+    if (block.type === 'text') {
+      return {
+        ...block,
+        ...(block.label ? { label: truncate(block.label, TEXT_LABEL_MAX_LENGTH) } : {}),
+        value: displayValue(block.value, TEXT_VALUE_MAX_LENGTH, block.label),
+      };
+    }
+    if (block.type === 'code') {
+      return {
+        type: 'code',
+        value: displayValue(block.value, CODE_VALUE_MAX_LENGTH),
+      };
+    }
+    return {
+      type: 'diff',
+      fields: block.fields.slice(0, DIFF_FIELD_MAX_ITEMS).map((field) => ({
+        label: truncate(field.label, TEXT_LABEL_MAX_LENGTH),
+        ...(field.before !== undefined
+          ? {
+              before: displayValue(field.before, TEXT_VALUE_MAX_LENGTH, field.label),
+            }
+          : {}),
+        after: displayValue(field.after, TEXT_VALUE_MAX_LENGTH, field.label),
+      })),
+    };
+  });
+}
+
+type ApprovalContentItem = {
+  run_id: number;
+  title: string | null;
+  payload_text: string;
+  interaction_type: 'approval';
+  interaction_status: string | null;
+  interaction_input: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+};
+
+function isApprovalContentItem(value: unknown, runId: number): value is ApprovalContentItem {
+  if (!isRecord(value)) return false;
+  return value.run_id === runId && value.interaction_type === 'approval';
+}
+
+async function buildApprovalView(runId: number, env: Env, ctx: ToolContext): Promise<LobuView> {
+  // Reuse the canonical knowledge read so connection visibility, public-org
+  // rules, caller identity, and MCP scope checks cannot drift from the event
+  // surface. A direct current_event_records query here would be tenant-fenced
+  // but could bypass a private connection's ACL.
+  const result = await getContent(
+    { run_ids: [runId], limit: 50, sort_by: 'date', sort_order: 'desc' },
+    env,
+    ctx
+  );
+  const row = result.content.find((item) => isApprovalContentItem(item, runId));
+  if (!row) throw new ToolUserError(`Approval run ${runId} was not found`, 404);
+
+  const status = row.interaction_status ?? 'pending';
+  const baseTitle = displayValue(row.title ?? `Approval run ${runId}`, TITLE_MAX_LENGTH).replace(
+    /\s+—\s+pending approval$/i,
+    ''
+  );
+  const actions: LobuView['actions'] = [];
+  if (status === 'pending') {
+    const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
+    const href = buildResourcePermalink(ownerSlug, { kind: 'run', runId }, baseUrl);
+    if (!href || href.length > ACTION_HREF_MAX_LENGTH || !/^https?:\/\//i.test(href)) {
+      throw new ToolUserError('The Lobu review link is unavailable for this workspace.', 500);
+    }
+    actions.push({
+      id: 'review',
+      label: 'Review in Lobu',
+      variant: 'primary',
+      icon: 'external',
+      terminal: false,
+      href,
+    });
+  }
+
+  return {
+    version: 1,
+    title: truncate(
+      status === 'pending' ? baseTitle : `${baseTitle} · ${status}`,
+      TITLE_MAX_LENGTH
+    ),
+    tone: status === 'pending' ? 'warning' : 'default',
+    blocks: approvalBlocks({
+      content: row.payload_text,
+      interaction_input: row.interaction_input,
+      metadata: row.metadata,
+    }),
+    actions,
+  };
+}
+
+const renderLobuViewImpl = async (
+  args: RenderLobuViewArgs,
+  env: Env,
+  ctx: ToolContext
+): Promise<LobuView> => {
+  if (args.action === 'review_approval') return buildApprovalView(args.run_id, env, ctx);
+  return {
+    version: 1,
+    ...(args.title ? { title: displayValue(args.title, TITLE_MAX_LENGTH) } : {}),
+    ...(args.tone ? { tone: args.tone } : {}),
+    blocks: sanitizeBlocks(args.blocks),
+    actions: [],
+  };
+};
+
+export const renderLobuView = withValidatedArgs(
+  'render_lobu_view',
+  RenderLobuViewSchema,
+  renderLobuViewImpl
+);

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -24,18 +24,24 @@ import { ListMetricsSchema, listMetrics } from './admin/list_metrics';
 import { MetricSeriesSchema, metricSeries } from './admin/metric_series';
 import { QueryMetricSchema, queryMetric } from './admin/query_metric';
 import { QuerySqlSchema, querySql } from './admin/query_sql';
+import {
+  LOBU_INTERACTION_RESOURCE_URI,
+  LobuViewSchema,
+  RenderLobuViewSchema,
+  renderLobuView,
+} from './mcp_app';
 import { ListOrganizationsSchema } from './organizations';
-import { ResolvePathSchema, ResolvePathResultSchema, resolvePath } from './resolve_path';
+import { ResolvePathResultSchema, ResolvePathSchema, resolvePath } from './resolve_path';
 import { SaveContentSchema, saveContent } from './save_content';
-import { PublicSearchSchema, SearchSchema, UnifiedSearchResultSchema, search } from './search';
 import {
   QuerySchema,
-  RunSchema,
-  SdkScriptResultSchema,
   querySdkScript,
+  RunSchema,
   runSdkScript,
+  SdkScriptResultSchema,
 } from './sdk_run';
-import { SdkSearchSchema, SdkSearchResultSchema, sdkSearch } from './sdk_search';
+import { SdkSearchResultSchema, SdkSearchSchema, sdkSearch } from './sdk_search';
+import { PublicSearchSchema, SearchSchema, search, UnifiedSearchResultSchema } from './search';
 
 // ============================================
 // Tool Definitions
@@ -171,13 +177,26 @@ export interface ToolDefinition<T = any> {
    * same schema object here — one source of truth, no drift.
    */
   outputSchema?: any; // JSON Schema
+  /** OAuth scopes advertised to MCP hosts for this tool. */
+  securityScopes?: string[];
+  /** MCP extension metadata, such as an Apps UI resource linkage. */
+  mcpMeta?: Record<string, unknown>;
   handler: (args: T, env: Env, ctx: ToolContext) => Promise<any>;
 }
 
-const READ_ONLY = { readOnlyHint: true, idempotentHint: true } as const;
+const READ_ONLY = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  openWorldHint: false,
+  idempotentHint: true,
+} as const;
+
+const READ_ONLY_OPEN_WORLD = { ...READ_ONLY, openWorldHint: true } as const;
 
 const WRITE_WITHOUT_CONFIRM: ToolAnnotations = {
+  readOnlyHint: false,
   destructiveHint: false,
+  openWorldHint: false,
   idempotentHint: false,
 };
 
@@ -194,7 +213,10 @@ const AGENT_TOOLS: ToolDefinition[] = [
     // affordances. See search.ts → PublicSearchSchema.
     publicInputSchema: PublicSearchSchema,
     outputSchema: UnifiedSearchResultSchema,
-    annotations: { ...READ_ONLY, title: 'Search memory' },
+    // Search can query installed virtual feeds live, so it may read outside
+    // Lobu's persisted workspace even though it never mutates anything.
+    annotations: { ...READ_ONLY_OPEN_WORLD, title: 'Search memory' },
+    securityScopes: ['mcp:read'],
     handler: search,
   },
   {
@@ -203,6 +225,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
       'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
     inputSchema: SaveContentSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },
+    securityScopes: ['mcp:write'],
     handler: saveContent,
   },
   {
@@ -212,6 +235,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     inputSchema: SdkSearchSchema,
     outputSchema: SdkSearchResultSchema,
     annotations: { ...READ_ONLY, title: 'Search SDK docs' },
+    securityScopes: ['mcp:read'],
     handler: sdkSearch,
   },
   // ─── Power tools — TS scripting + raw SQL ─────────────────────────────────
@@ -221,7 +245,9 @@ const AGENT_TOOLS: ToolDefinition[] = [
       'Read workspace data through typed SDK methods. Query entities, relationships, feeds, operations, metrics, and more. Use this for lookups and searches that do not change data. (For writes: use run_sdk. To discover available methods: use search_sdk. For polling: use await ctx.sleep(ms) in your script.)',
     inputSchema: QuerySchema,
     outputSchema: SdkScriptResultSchema,
-    annotations: { ...READ_ONLY, title: 'Query SDK (read-only)' },
+    // Read-only SDK methods include connector-backed live feed reads.
+    annotations: { ...READ_ONLY_OPEN_WORLD, title: 'Query SDK (read-only)' },
+    securityScopes: ['mcp:read'],
     handler: querySdkScript,
   },
   {
@@ -230,6 +256,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
       'Run a paginated, sortable, searchable read-only SQL query (member-safe). Table references auto-scope to the bound org. SELECT FROM events reads persisted/synced content only; virtual feeds are live-only and must be read explicitly with feed or via query_sdk client.feeds.readMany. Results may include coverage.suggested_virtual_feeds. Prefer client.metrics.query for declared measures; use client.query in query_sdk for simple one-shot SQL. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects to another member org.',
     inputSchema: QuerySqlSchema,
     annotations: { ...READ_ONLY, title: 'Query SQL' },
+    securityScopes: ['mcp:read'],
     handler: querySql,
   },
   {
@@ -239,11 +266,40 @@ const AGENT_TOOLS: ToolDefinition[] = [
     inputSchema: RunSchema,
     outputSchema: SdkScriptResultSchema,
     annotations: {
+      readOnlyHint: false,
       destructiveHint: true,
+      openWorldHint: true,
       idempotentHint: false,
       title: 'Run SDK',
     },
+    securityScopes: ['mcp:write'],
     handler: runSdkScript,
+  },
+];
+
+/**
+ * Presentation tools listed only on MCP `tools/list`. They stay executable by
+ * name for MCP dispatch, but are absent from `AGENT_TOOL_NAMES`,
+ * `getAllTools`, `getRawDispatchTools`, and `REST_DISPATCH_TOOL_NAMES`, keeping
+ * them out of REST, OpenAPI, and the ClientSDK.
+ */
+const MCP_APP_TOOLS: ToolDefinition[] = [
+  {
+    name: 'render_lobu_view',
+    description:
+      'Render a compact Lobu card after data has been selected, or render the review card for one pending approval run. Use action="render" only when a visual card materially helps; first call Lobu data tools and pass only the final content. Use action="review_approval" with a run_id returned by a pending action. Text-only clients receive the same information as readable text.',
+    inputSchema: RenderLobuViewSchema,
+    outputSchema: LobuViewSchema,
+    annotations: { ...READ_ONLY, title: 'Render Lobu view' },
+    securityScopes: ['mcp:read'],
+    mcpMeta: {
+      ui: {
+        resourceUri: LOBU_INTERACTION_RESOURCE_URI,
+        visibility: ['model', 'app'],
+      },
+      'openai/outputTemplate': LOBU_INTERACTION_RESOURCE_URI,
+    },
+    handler: renderLobuView,
   },
 ];
 
@@ -298,12 +354,17 @@ const INTERNAL_DISPATCH_TOOLS: ToolDefinition[] = [
   },
 ];
 
+const ALL_MCP_TOOLS: ToolDefinition[] = [...AGENT_TOOLS, ...MCP_APP_TOOLS];
 const ALL_DISPATCH_TOOLS: ToolDefinition[] = [...AGENT_TOOLS, ...INTERNAL_DISPATCH_TOOLS];
+const ALL_EXECUTABLE_TOOLS: ToolDefinition[] = [...ALL_DISPATCH_TOOLS, ...MCP_APP_TOOLS];
 
 export const AGENT_TOOL_NAMES: ReadonlySet<string> = new Set(AGENT_TOOLS.map((tool) => tool.name));
 
 const INTERNAL_TOOL_NAMES: ReadonlySet<string> = new Set(
   INTERNAL_DISPATCH_TOOLS.map((tool) => tool.name)
+);
+const REST_DISPATCH_TOOL_NAMES: ReadonlySet<string> = new Set(
+  ALL_DISPATCH_TOOLS.map((tool) => tool.name)
 );
 
 // ============================================
@@ -311,7 +372,7 @@ const INTERNAL_TOOL_NAMES: ReadonlySet<string> = new Set(
 // ============================================
 
 const DISPATCH_BY_NAME: Map<string, ToolDefinition> = new Map(
-  ALL_DISPATCH_TOOLS.map((tool) => [tool.name, tool])
+  ALL_EXECUTABLE_TOOLS.map((tool) => [tool.name, tool])
 );
 
 /**
@@ -323,6 +384,10 @@ export function getTool(name: string): ToolDefinition | undefined {
 
 export function isInternalDispatchTool(name: string): boolean {
   return INTERNAL_TOOL_NAMES.has(name);
+}
+
+export function isRestDispatchTool(name: string): boolean {
+  return REST_DISPATCH_TOOL_NAMES.has(name);
 }
 
 /**
@@ -489,7 +554,7 @@ type ListedToolOptions = {
  * Agent-facing tools for MCP `tools/list` and external OpenAPI.
  */
 export function getMcpTools(options?: ListedToolOptions) {
-  return getListedTools(AGENT_TOOLS, options);
+  return getListedTools(ALL_MCP_TOOLS, options);
 }
 
 /**
@@ -544,7 +609,8 @@ export function getRawDispatchTools(): RawDispatchTool[] {
 function getListedTools(source: ToolDefinition[], options?: ListedToolOptions) {
   const publicOnly = options?.publicOnly ?? false;
   const maxAccessLevel = options?.maxAccessLevel ?? 'admin';
-  const cacheKey = `${source === AGENT_TOOLS ? 'mcp' : 'all'}:${publicOnly ? 1 : 0}:${maxAccessLevel}`;
+  const sourceKey = source === ALL_MCP_TOOLS ? 'mcp' : 'all';
+  const cacheKey = `${sourceKey}:${publicOnly ? 1 : 0}:${maxAccessLevel}`;
   let cached = listedToolsCache.get(cacheKey);
   if (!cached) {
     cached = computeListedTools(source, publicOnly, maxAccessLevel);
@@ -594,6 +660,10 @@ function computeListedTools(
         description: tool.description,
         inputSchema,
         ...(tool.annotations && { annotations: tool.annotations }),
+        ...(tool.securityScopes && {
+          securitySchemes: [{ type: 'oauth2' as const, scopes: tool.securityScopes }],
+        }),
+        ...(tool.mcpMeta && { _meta: tool.mcpMeta }),
         // outputSchema keeps its discriminated variants (no flattening, no
         // access-level filtering — those are input concerns) but the MCP spec
         // requires a tool's outputSchema to be an OBJECT schema. TypeBox

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -203,7 +203,12 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     // QUERYABLE_SCHEMA entry until the phase-2 migration.
     // Keyed by the QUERYABLE_SCHEMA entry name (`behaviors`), not the physical
     // table (`watchers`) — this map is indexed by `t.name` from that schema.
-    behaviors: new Set(['scheduler_client_id']),
+    behaviors: new Set([
+      'scheduler_client_id',
+      // Physical storage names replaced by public derived aliases below.
+      'source_watcher_id',
+      'watcher_group_id',
+    ]),
     user: new Set(['email', 'phoneNumber', 'phoneNumberVerified']),
   };
 
@@ -215,6 +220,7 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
   const DERIVED_COLUMNS: Record<string, Set<string>> = {
     // entities CTE JOINs entity_types and aliases et.slug AS entity_type.
     entities: new Set(['entity_type']),
+    behaviors: new Set(['source_behavior_id', 'behavior_group_id']),
   };
 
   /** relation name → physical column set, read once per drift test. */

--- a/packages/server/src/utils/behavior-vocabulary.ts
+++ b/packages/server/src/utils/behavior-vocabulary.ts
@@ -1,0 +1,6 @@
+/** Rewrite legacy persisted Behavior text into the public SDK vocabulary. */
+export function canonicalizeBehaviorText(
+  value: string | null | undefined
+): string | null | undefined {
+  return value?.replaceAll('client.watchers.', 'client.behaviors.');
+}

--- a/packages/server/src/utils/content-search/sql-fragments.ts
+++ b/packages/server/src/utils/content-search/sql-fragments.ts
@@ -66,7 +66,7 @@ const PARENT_ROOT_JOINS_SQL = `
 
 const BASE_COLUMNS_SQL = `f.id, f.entity_ids, f.connection_id, f.feed_id, f.feed_key, f.behavior_id, fd.display_name as feed_name, COALESCE(wv.name, 'Behavior #' || f.behavior_id) as behavior_name, f.payload_text, f.title, f.author_name, f.source_url, f.occurred_at, f.semantic_type,
           f.connector_key as platform, f.origin_id, f.origin_parent_id, f.score, f.metadata, f.payload_type, f.payload_data, f.payload_template, f.attachments, f.origin_type,
-          f.interaction_type, f.interaction_status, f.interaction_input_schema, f.interaction_input, f.interaction_output, f.interaction_error, f.supersedes_event_id`;
+          f.interaction_type, f.interaction_status, f.interaction_input_schema, f.interaction_input, f.interaction_output, f.interaction_error, f.supersedes_event_id, f.run_id`;
 
 const CLASSIFICATION_COLUMNS_SQL = `fcl_all.attribute_key as classifier_attribute_key,
           lc_all."values" as classifier_values,

--- a/packages/server/src/utils/openapi-generator.ts
+++ b/packages/server/src/utils/openapi-generator.ts
@@ -4,7 +4,7 @@
  * Dynamically generates OpenAPI specification from tool registry TypeBox schemas
  */
 
-import { getMcpTools, getRawDispatchTools } from '../tools/registry';
+import { AGENT_TOOL_NAMES, getMcpTools, getRawDispatchTools } from '../tools/registry';
 import { deepCopyStrict } from './schema-copy';
 
 /**
@@ -167,7 +167,10 @@ function truncateDescription(text: string, maxLength: number = 300): string {
  * Generates OpenAPI 3.1.0 spec from tool registry
  */
 export function generateOpenAPISpec(serverUrl: string) {
-  const tools = getMcpTools();
+  // `getMcpTools()` also lists the MCP-only presentation tools. Those exist to
+  // give an MCP host a `ui://` bundle to render; a REST/OpenAPI consumer has
+  // nothing to render them with, so the spec stays the agent data surface.
+  const tools = getMcpTools().filter((tool) => AGENT_TOOL_NAMES.has(tool.name));
   const paths: Record<string, any> = {};
 
   for (const tool of tools) {

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -19,8 +19,9 @@
  * NAMING: `name` here is the AGENT-FACING relation name, which is not always the
  * physical table. The agent-facing product name is Behavior, so the engine's
  * `watchers` / `watcher_versions` tables are exposed as `behaviors` /
- * `behavior_versions` (see {@link PHYSICAL_TABLE_BY_RELATION}); column
- * identifiers stay internal vocabulary (`watcher_id` remains the join key).
+ * `behavior_versions` (see {@link PHYSICAL_TABLE_BY_RELATION}). Stable
+ * foreign-key identifiers on other relations may remain physical join keys,
+ * while Behavior-owned lineage fields are exposed under public aliases below.
  * A column listed here MUST exist on the physical table: `buildColumnList`
  * emits an explicit projection into the generated CTE, so a stale name breaks
  * EVERY query against the relation — including ones that reference no column at
@@ -38,8 +39,10 @@ export interface ColumnDef {
   expr?: string;
 }
 
-function cols(...names: string[]): ColumnDef[] {
-  return names.map((name) => ({ name, type: 'text' }));
+function cols(...columns: Array<string | ColumnDef>): ColumnDef[] {
+  return columns.map((column) =>
+    typeof column === 'string' ? { name: column, type: 'text' } : column
+  );
 }
 
 /**
@@ -481,8 +484,16 @@ export const QUERYABLE_SCHEMA = {
         'reaction_script_compiled',
         'reaction_input_schema',
         'connection_id',
-        'source_watcher_id',
-        'watcher_group_id',
+        {
+          name: 'source_behavior_id',
+          type: 'text',
+          expr: `${ROW_REF}"source_watcher_id"`,
+        },
+        {
+          name: 'behavior_group_id',
+          type: 'text',
+          expr: `${ROW_REF}"watcher_group_id"`,
+        },
         // Scalar columns added in earlier features (device pinning, notification
         // routing, run rate-limiting) that were missing from this list — drift
         // test caught it.
@@ -778,10 +789,12 @@ export const QUERYABLE_TABLE_NAMES = new Set(QUERYABLE_SCHEMA.tables.map((t) => 
  * caller, so exposing the physical names both leaked the vocabulary and told the
  * agent that `behaviors` — the name every other tool uses — does not exist.
  *
- * Only the RELATION is renamed. Column identifiers stay internal
+ * Foreign-key columns that point AT a behavior keep the physical name
  * (`behavior_versions.watcher_id`, `event_classifications.watcher_id`) because
- * they are the real join keys and renaming them would desync the projection
- * from the physical row.
+ * they are the real join keys. Behavior-owned lineage columns on the
+ * `behaviors` relation itself are exposed under public aliases
+ * (`source_behavior_id`, `behavior_group_id`) via an explicit `expr`, so the
+ * projection still reads the physical column.
  *
  * Every entry must be consumed by the CTE builder in `execute-data-sources`;
  * a relation with no physical mapping falls through to the entity-type-slug
@@ -817,7 +830,8 @@ export const ADMIN_ONLY_QUERYABLE_TABLES: ReadonlySet<string> = new Set([
 ]);
 
 /** table name → column definitions for use in CTE SELECT.
- *  Columns with `expr` are derived from JSONB and need special handling. */
+ *  Columns with `expr` project a SQL expression instead of the bare column
+ *  (JSONB redaction, or a public alias over a physical column). */
 export const SAFE_COLUMN_DEFS = new Map<string, ColumnDef[]>(
   QUERYABLE_SCHEMA.tables.map((t) => [t.name, t.columns])
 );

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -2,6 +2,11 @@ import { verifyWorkerToken } from '@lobu/core';
 import { getAuthConfig as getAuthConfigFromEnv } from '../auth/config';
 import { createAuth } from '../auth/index';
 import { OAuthProvider } from '../auth/oauth/provider';
+import {
+  buildMcpBearerChallenge,
+  getMcpResourceForRequest,
+  publicMcpRequestUrl,
+} from '../auth/oauth/resource-indicator';
 import type { AuthInfo } from '../auth/oauth/types';
 import { PersonalAccessTokenService } from '../auth/tokens';
 import { isPublicReadable } from '../auth/tool-access';
@@ -130,6 +135,12 @@ export class MultiTenantProvider implements WorkspaceProvider {
     const baseUrl = getConfiguredPublicOrigin() ?? new URL(c.req.url).origin;
     const requestPath = new URL(c.req.url).pathname;
     const isMcpRoute = requestPath === '/mcp' || requestPath.startsWith('/mcp/');
+    const bearerChallenge = (error?: string) =>
+      isMcpRoute
+        ? buildMcpBearerChallenge(publicMcpRequestUrl(c.req.raw), error)
+        : `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"${
+            error ? `, error="${error}"` : ''
+          }`;
     // Routes that don't carry an org context resolve to "authenticated user,
     // no active org" instead of failing on a missing orgSlug. Two cases today:
     //   - the bare /mcp endpoint (MCP discovery / initialization)
@@ -273,7 +284,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
           { error: 'invalid_token', error_description: 'Invalid or expired worker token' },
           401,
           {
-            'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+            'WWW-Authenticate': bearerChallenge('invalid_token'),
           }
         );
       }
@@ -288,7 +299,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
           { error: 'invalid_token', error_description: 'Worker token missing agent context' },
           401,
           {
-            'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+            'WWW-Authenticate': bearerChallenge('invalid_token'),
           }
         );
       }
@@ -316,7 +327,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
           { error: 'invalid_token', error_description: 'Worker token missing admin-tools actor' },
           401,
           {
-            'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+            'WWW-Authenticate': bearerChallenge('invalid_token'),
           }
         );
       }
@@ -392,7 +403,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
             { error: 'invalid_token', error_description: 'Invalid or expired access token' },
             401,
             {
-              'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+              'WWW-Authenticate': bearerChallenge('invalid_token'),
             }
           );
         }
@@ -404,6 +415,23 @@ export class MultiTenantProvider implements WorkspaceProvider {
           { error: 'invalid_token', error_description: 'Token missing user context' },
           401
         );
+      }
+
+      // RFC 8707-bound OAuth tokens are valid only for the exact MCP resource
+      // named during authorization. Legacy unbound tokens remain accepted for
+      // the first-party device/CLI compatibility flow.
+      if (!isPat && authInfo.resource && isMcpRoute) {
+        const requestedResource = getMcpResourceForRequest(publicMcpRequestUrl(c.req.raw));
+        if (!requestedResource || authInfo.resource !== requestedResource) {
+          return c.json(
+            {
+              error: 'invalid_token',
+              error_description: 'Access token is bound to a different MCP resource',
+            },
+            401,
+            { 'WWW-Authenticate': bearerChallenge('invalid_token') }
+          );
+        }
       }
 
       let effectiveOrgId = requestedOrgId;
@@ -634,7 +662,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
         { error: 'invalid_token', error_description: 'Invalid or expired access token' },
         401,
         {
-          'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+          'WWW-Authenticate': bearerChallenge('invalid_token'),
         }
       );
     }
@@ -652,7 +680,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
           error_description: 'Authentication required. Use OAuth or API key.',
         },
         401,
-        { 'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource"` }
+        { 'WWW-Authenticate': bearerChallenge() }
       );
     }
 

--- a/scripts/__tests__/ui-review-command.test.ts
+++ b/scripts/__tests__/ui-review-command.test.ts
@@ -13,6 +13,7 @@ import { buildProofBody } from "../lib/ui-review-proof";
 const UI_REVIEW_SCRIPT = resolve(import.meta.dir, "..", "ui-review.ts");
 const BASE_POINTER = "1".repeat(40);
 const HEAD_POINTER = "2".repeat(40);
+const PRODUCT_POINTER = "4".repeat(40);
 const BASE_COMMIT = "a".repeat(40);
 
 interface MockState {
@@ -112,12 +113,25 @@ if (endpoint.includes("/contents/packages/owletto?ref=")) {
     : process.env.MOCK_HEAD_POINTER;
   output({ type: "submodule", sha });
 } else if (endpoint.includes("/commits/") && endpoint.endsWith("/pulls")) {
-  output([{
-    number: 712,
-    html_url: "https://github.com/lobu-ai/owletto/pull/712",
-    merge_commit_sha: process.env.MOCK_HEAD_POINTER,
-    merged_at: "2026-08-04T10:00:00Z",
-  }]);
+  const candidate = endpoint.split("/commits/")[1].split("/pulls")[0];
+  const squash = process.env.MOCK_FLUX_TAIL === "1"
+    ? process.env.MOCK_PRODUCT_POINTER
+    : process.env.MOCK_HEAD_POINTER;
+  output(candidate === squash ? [{
+      number: 712,
+      html_url: "https://github.com/lobu-ai/owletto/pull/712",
+      merge_commit_sha: squash,
+      merged_at: "2026-08-04T10:00:00Z",
+    }] : []);
+} else if (endpoint.includes("/commits/")) {
+  output({
+    commit: {
+      author: { email: "fluxcd@lobu.ai" },
+      message: "chore: update images",
+    },
+    files: [{ filename: "deploy/k8s/apps/lobu/base/helmrelease.yaml" }],
+    parents: [{ sha: process.env.MOCK_PRODUCT_POINTER }],
+  });
 } else if (endpoint.includes("/collaborators/") && endpoint.endsWith("/permission")) {
   output({ permission: "admin" });
 } else if (endpoint.includes("/statuses/") && method === "POST") {
@@ -176,6 +190,7 @@ function runUiReview(
       MOCK_HEAD_COMMIT: fixture.head,
       MOCK_BASE_POINTER: BASE_POINTER,
       MOCK_HEAD_POINTER: HEAD_POINTER,
+      MOCK_PRODUCT_POINTER: PRODUCT_POINTER,
       ...environment,
     },
     stdout: "pipe",
@@ -384,5 +399,22 @@ describe("ui-review command", () => {
     expect(status?.payload).toMatchObject({
       target_url: proof?.html_url,
     });
+  });
+
+  it("records exact-head proof on the product PR beneath a Flux-only tail", () => {
+    const fixture = createFixture();
+    const result = runUiReview(fixture, {
+      ARTIFACT: "https://claude.ai/code/artifact/flux-tail-proof",
+      MOCK_FLUX_TAIL: "1",
+    });
+
+    expectExit(result, 0);
+    const state = readState(fixture.stateFile);
+    const proof =
+      state.comments["repos/lobu-ai/owletto/issues/712/comments"]?.[0];
+    expect(proof?.body).toContain(HEAD_POINTER);
+    expect(proof?.body).toContain(
+      "https://claude.ai/code/artifact/flux-tail-proof"
+    );
   });
 });

--- a/scripts/__tests__/ui-review-proof.test.ts
+++ b/scripts/__tests__/ui-review-proof.test.ts
@@ -4,6 +4,7 @@ import {
   findProofComment,
   isHttpsArtifact,
   parseProof,
+  permittedFluxTailParent,
   proofMatches,
   selectOwlettoPullRequest,
   type UiReviewComment,
@@ -106,6 +107,49 @@ describe("UI review proof", () => {
 
     expect(selectOwlettoPullRequest(pulls, HEAD_SHA)?.number).toBe(712);
     expect(selectOwlettoPullRequest(pulls, BASE_SHA)).toBeNull();
+  });
+
+  it("walks only the exact deploy-only Flux image tail", () => {
+    const parent = "4".repeat(40);
+    expect(
+      permittedFluxTailParent({
+        commit: {
+          author: { email: "fluxcd@lobu.ai" },
+          message: "chore: update images",
+        },
+        files: [{ filename: "deploy/k8s/apps/lobu/base/helmrelease.yaml" }],
+        parents: [{ sha: parent }],
+      })
+    ).toBe(parent);
+
+    for (const candidate of [
+      {
+        commit: {
+          author: { email: "human@lobu.ai" },
+          message: "chore: update images",
+        },
+        files: [{ filename: "deploy/app.yaml" }],
+        parents: [{ sha: parent }],
+      },
+      {
+        commit: {
+          author: { email: "fluxcd@lobu.ai" },
+          message: "chore: update images later",
+        },
+        files: [{ filename: "deploy/app.yaml" }],
+        parents: [{ sha: parent }],
+      },
+      {
+        commit: {
+          author: { email: "fluxcd@lobu.ai" },
+          message: "chore: update images",
+        },
+        files: [{ filename: "src/app.ts" }],
+        parents: [{ sha: parent }],
+      },
+    ]) {
+      expect(permittedFluxTailParent(candidate)).toBeNull();
+    }
   });
 
   it("requires a hosted HTTPS artifact", () => {

--- a/scripts/lib/ui-review-proof.ts
+++ b/scripts/lib/ui-review-proof.ts
@@ -24,8 +24,19 @@ export interface OwlettoPullRequest {
   merged_at: string | null;
 }
 
+export interface OwlettoCommit {
+  commit: {
+    author: { email: string | null } | null;
+    message: string;
+  };
+  files?: Array<{ filename: string }>;
+  parents: Array<{ sha: string }>;
+}
+
 const PROOF_MARKER = "<!-- lobu-ui-review-proof ";
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const FLUX_AUTHOR_EMAIL = "fluxcd@lobu.ai";
+const FLUX_SUBJECT = "chore: update images";
 
 function isProof(value: unknown): value is UiReviewProof {
   if (typeof value !== "object" || value === null) return false;
@@ -131,4 +142,25 @@ export function selectOwlettoPullRequest(
       (pull) => pull.merged_at !== null && pull.merge_commit_sha === owlettoSha
     ) ?? null
   );
+}
+
+/**
+ * Mirrors submodule-drift.yml's narrow exemption. UI proof still binds to the
+ * exact parent pointer, but a deploy-only Flux tail is reviewed on the merged
+ * product PR immediately beneath it.
+ */
+export function permittedFluxTailParent(commit: OwlettoCommit): string | null {
+  const subject = commit.commit.message.split("\n", 1)[0];
+  const files = commit.files ?? [];
+  if (
+    commit.commit.author?.email !== FLUX_AUTHOR_EMAIL ||
+    subject !== FLUX_SUBJECT ||
+    commit.parents.length !== 1 ||
+    files.length === 0 ||
+    files.some((file) => !file.filename.startsWith("deploy/"))
+  ) {
+    return null;
+  }
+  const parent = commit.parents[0]?.sha;
+  return parent && SHA_PATTERN.test(parent) ? parent : null;
 }

--- a/scripts/ui-review.ts
+++ b/scripts/ui-review.ts
@@ -5,6 +5,7 @@ import {
   buildProofBody,
   findProofComment,
   isHttpsArtifact,
+  permittedFluxTailParent,
   type OwlettoPullRequest,
   parseProof,
   proofMatches,
@@ -187,6 +188,30 @@ function openPullRequest(url: string): void {
   }
 }
 
+function resolveOwlettoPullRequest(
+  repo: string,
+  headPointer: string
+): OwlettoPullRequest | null {
+  let candidate = headPointer;
+  // A short bounded walk handles consecutive Flux image bumps without ever
+  // treating arbitrary commits as visual-review proof for a product PR.
+  for (let depth = 0; depth < 20; depth += 1) {
+    const pulls = ghApi<OwlettoPullRequest[]>(
+      `repos/${repo}/commits/${candidate}/pulls`
+    );
+    const pull = selectOwlettoPullRequest(pulls, candidate);
+    if (pull) return pull;
+
+    const commit = ghApi<Parameters<typeof permittedFluxTailParent>[0]>(
+      `repos/${repo}/commits/${candidate}`
+    );
+    const parent = permittedFluxTailParent(commit);
+    if (!parent) return null;
+    candidate = parent;
+  }
+  return null;
+}
+
 function parentCommentBody(
   proof: UiReviewProof,
   proofUrl: string,
@@ -263,20 +288,17 @@ function main(): number {
     return 0;
   }
 
-  const pulls = ghApi<OwlettoPullRequest[]>(
-    `repos/${owlettoRepo}/commits/${headPointer}/pulls`
-  );
-  const owlettoPr = selectOwlettoPullRequest(pulls, headPointer);
+  const owlettoPr = resolveOwlettoPullRequest(owlettoRepo, headPointer);
   if (!owlettoPr) {
     postStatus(
       lobuRepo,
       localHead,
       "error",
-      "Owletto pointer is not an exact merged PR squash commit",
+      "Owletto pointer has no reviewable merged product PR",
       parentPr.url
     );
     throw new Error(
-      `Owletto ${headPointer} is not the squash commit of a merged ${owlettoRepo} PR`
+      `Owletto ${headPointer} is neither a merged ${owlettoRepo} PR squash commit nor a permitted Flux deploy-only tail`
     );
   }
 


### PR DESCRIPTION
## Summary

- upgrade MCP transport, OAuth audience binding, protocol negotiation, and per-session formatting isolation
- ship MCP Apps as the official mcp-app resource with a dedicated safe render tool, legacy host compatibility, and self-contained Owletto bridge
- redact secrets with key-aware context, enforce Lobu view bounds, preserve private-connection ACLs, and keep approvals link-only
- recover once from an expired upstream MCP session without replaying timeouts or 5xx side effects
- correct tool annotations and hide internal Behavior watcher vocabulary from public SQL
- pin Owletto 931c92d4, including the self-contained MCP App bundle; the only newer main commit is an exempt Flux deploy-image update

Supersedes #2606 and addresses every blocker from its Codex review. Do not merge #2606.

## Verification

- make pre-pr
- make test-unit
- make test-integration: 407 files, 3604 passed, 2 skipped, plus all serial gateway and subprocess lanes
- Owletto: 152 files, 1294 passed
- focused MCP App integration: 11 passed
- OAuth and MCP focused matrix: 53 passed, 2 skipped
- exact-head UI review and pi-review will be attached before merge

## Safety

- proposal/current/custom view data is secret-redacted before key context is lost
- insufficient-scope challenges retain the canonical forwarded public MCP resource URL
- no host-specific ui.domain is advertised
- stale sessions retry exactly once only on an existing-session 404
- no external approval actions are rendered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MCP App support for rendered views, approval cards, metadata, secure links, and secret redaction.
  - Added negotiated MCP protocol-version support for sessions and tool requests.
  - Added resource-aware OAuth authorization, discovery, token handling, and bearer challenges.

- **Bug Fixes**
  - Improved MCP session recovery and error handling without unsafe request replays.
  - Blocked untrusted browser origins and unauthorized resource access.
  - Standardized legacy behavior error names in API responses.
  - Kept MCP-only presentation tools out of REST and OpenAPI listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->