### PR TITLE
fix(server): publish complete MCP safety metadata

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -16,7 +16,7 @@ import {
   createTestUser,
   seedSystemEntityTypes,
 } from '../../setup/test-fixtures';
-import { mcpListTools, mcpToolsCall, post } from '../../setup/test-helpers';
+import { get, mcpListTools, mcpToolsCall, post } from '../../setup/test-helpers';
 
 describe('MCP query_sdk / run_sdk tool surface', () => {
   let token: string;
@@ -46,20 +46,40 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     const result = await mcpListTools({ token, orgSlug: ownerSlug });
     const byName = new Map<string, any>(result.tools.map((t: any) => [t.name, t]));
     expect(byName.has('execute')).toBe(false);
-    // Assert the behavior-relevant hints specifically (not the whole object) so
-    // adding display metadata like `title` doesn't couple this test to it.
-    expect(byName.get('query_sdk')?.annotations?.readOnlyHint).toBe(true);
+
+    const expectedSafetyHints = {
+      search_memory: [true, false, false],
+      search_sdk: [true, false, false],
+      query_sdk: [true, false, false],
+      query_sql: [true, false, false],
+      save_memory: [false, false, false],
+      run_sdk: [false, true, true],
+    } as const;
+
+    for (const [toolName, [readOnlyHint, openWorldHint, destructiveHint]] of Object.entries(
+      expectedSafetyHints
+    )) {
+      const annotations = byName.get(toolName)?.annotations;
+      expect(annotations?.readOnlyHint, `${toolName}.readOnlyHint`).toBe(readOnlyHint);
+      expect(annotations?.openWorldHint, `${toolName}.openWorldHint`).toBe(openWorldHint);
+      expect(annotations?.destructiveHint, `${toolName}.destructiveHint`).toBe(
+        destructiveHint
+      );
+    }
+
     expect(byName.get('query_sdk')?.annotations?.idempotentHint).toBe(true);
-    expect(byName.get('run_sdk')?.annotations?.destructiveHint).toBe(true);
     expect(byName.get('run_sdk')?.inputSchema?.properties?.dry_run).toBeTruthy();
-    expect(byName.get('search_memory')?.annotations?.readOnlyHint).toBe(true);
     expect(byName.get('search_memory')?.annotations?.idempotentHint).toBe(true);
-    expect(byName.get('save_memory')?.annotations?.destructiveHint).toBe(false);
     expect(byName.has('search_knowledge')).toBe(false);
     expect(byName.has('save_knowledge')).toBe(false);
     expect(byName.has('search')).toBe(false);
     expect(byName.has('query')).toBe(false);
     expect(byName.has('run')).toBe(false);
+  });
+
+  it('does not advertise the retired legacy ChatGPT plugin manifest', async () => {
+    const response = await get('/.well-known/ai-plugin.json');
+    expect(response.status).toBe(404);
   });
 
   it('surfaces outputSchema on structured tools', async () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2729,36 +2729,9 @@ app.get("/openapi.json", (c) => {
 	return c.json(spec);
 });
 
-/**
- * ChatGPT plugin manifest
- */
-app.get("/.well-known/ai-plugin.json", (c) => {
-	const baseUrl = new URL(c.req.url).origin;
-	const openApiUrl = new URL("/openapi.json", baseUrl).toString();
-	const logoUrl =
-		c.env.PUBLIC_LOGO_URL ?? new URL("/logo.png", baseUrl).toString();
-	const legalInfoUrl =
-		c.env.PUBLIC_LEGAL_URL ?? new URL("/legal", baseUrl).toString();
-	return c.json({
-		schema_version: "v1",
-		name_for_human: "Lobu",
-		name_for_model: "lobu",
-		description_for_human:
-			"Build searchable workspace knowledge from customer content across platforms",
-		description_for_model:
-			"Access workspace knowledge and customer content from Reddit, Trustpilot, App Stores, and other platforms. Search knowledge, retrieve saved knowledge, and get watchers and analytics.",
-		auth: {
-			type: "none",
-		},
-		api: {
-			type: "openapi",
-			url: openApiUrl,
-		},
-		logo_url: logoUrl,
-		contact_email: "support@example.com",
-		legal_info_url: legalInfoUrl,
-	});
-});
+// The pre-MCP ChatGPT plugin manifest is retired. Keep an explicit 404 so the
+// generic discovery fallback below cannot masquerade as a valid manifest.
+app.get("/.well-known/ai-plugin.json", (c) => c.notFound());
 
 /**
  * Apply MCP authentication middleware and Streamable HTTP transport handler.

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -174,9 +174,16 @@ export interface ToolDefinition<T = any> {
   handler: (args: T, env: Env, ctx: ToolContext) => Promise<any>;
 }
 
-const READ_ONLY = { readOnlyHint: true, idempotentHint: true } as const;
+const READ_ONLY = {
+  readOnlyHint: true,
+  openWorldHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+} as const;
 
 const WRITE_WITHOUT_CONFIRM: ToolAnnotations = {
+  readOnlyHint: false,
+  openWorldHint: false,
   destructiveHint: false,
   idempotentHint: false,
 };
@@ -239,6 +246,8 @@ const AGENT_TOOLS: ToolDefinition[] = [
     inputSchema: RunSchema,
     outputSchema: SdkScriptResultSchema,
     annotations: {
+      readOnlyHint: false,
+      openWorldHint: true,
       destructiveHint: true,
       idempotentHint: false,
       title: 'Run SDK',


### PR DESCRIPTION
## Summary
- publish explicit read-only, open-world, and destructive hints for every public Lobu MCP tool
- mark run_sdk as open-world and potentially destructive while keeping save_memory non-destructive
- retire the pre-MCP ChatGPT plugin manifest with an explicit 404

## Verification
- focused MCP integration test: 5 passed
- make pre-pr: all six gates clean
- local independent review attempted and failed closed because both configured reviewer providers are quota-limited; GitHub required checks must supply the final review gate

## Why
The ChatGPT and Codex plugin scanner consumes MCP tool metadata. Complete annotations make the public safety contract machine-readable, and the explicit tombstone prevents generic discovery from masquerading as the obsolete ai-plugin manifest.