### PR TITLE
fix(mcp): preserve Apps negotiation across replicas

### DIFF
--- a/db/migrations/20260809070000_mcp_sessions_apps_capability.sql
+++ b/db/migrations/20260809070000_mcp_sessions_apps_capability.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+ALTER TABLE mcp_sessions
+  ADD COLUMN IF NOT EXISTS supports_mcp_apps boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN mcp_sessions.supports_mcp_apps IS
+  'Whether the client negotiated the MCP Apps UI extension for this session';
+
+-- migrate:down
+ALTER TABLE mcp_sessions
+  DROP COLUMN IF EXISTS supports_mcp_apps;

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { getDb } from '../../../db/client';
+import { clearInMemoryMcpSessionsForTests } from '../../../mcp-handler';
 import { insertEvent } from '../../../utils/insert-event';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
@@ -227,6 +228,32 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
+  it('preserves negotiated Apps metadata after cross-replica session recovery', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    clearInMemoryMcpSessionsForTests();
+
+    const response = await post(`/mcp/${org.slug}`, {
+      body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      headers: {
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const tool = body.result?.tools?.find(
+      (entry: { name?: string }) => entry.name === 'render_lobu_view'
+    );
+    expect(tool?._meta?.ui).toEqual(
+      expect.objectContaining({
+        resourceUri: 'ui://lobu/interaction/v1',
+        visibility: ['model', 'app'],
+      })
+    );
+  });
+
   it('returns a validated LobuViewV1 with a safe text fallback', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
@@ -275,6 +302,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const sessionId = await initSession(`/mcp/${org.slug}`, {
       advertiseMcpApps: false,
     });
+    clearInMemoryMcpSessionsForTests();
     const response = await post(`/mcp/${org.slug}`, {
       body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
       headers: {

--- a/packages/server/src/__tests__/integration/mcp/session-refresh-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/session-refresh-atomicity.test.ts
@@ -48,6 +48,7 @@ describe('mcp session refresh is update-only', () => {
       requestedAgentId: null,
       isAuthenticated: true,
       scopedToOrg: false,
+      supportsMcpApps: true,
       lastAccessedAt: Date.now(),
       expiresAt: Date.now() + 3_600_000,
     };
@@ -61,6 +62,7 @@ describe('mcp session refresh is update-only', () => {
 
     const row = await store.getSession(session.sessionId);
     expect(row).not.toBeNull();
+    expect(row?.supportsMcpApps).toBe(true);
   });
 
   it('does NOT resurrect a row deleted by a concurrent revoke', async () => {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -82,7 +82,10 @@ interface SessionEntry {
 const sessions = mcpSessionMap as Map<string, SessionEntry>;
 const mcpSessionStore = new McpSessionStore();
 
-type SessionAuthContext = AuthContext & { instructions?: string };
+type SessionAuthContext = AuthContext & {
+  instructions?: string;
+  supportsMcpApps?: boolean;
+};
 
 export function hostConversationIdFromMeta(value: unknown): string | null {
   if (typeof value !== 'object' || value === null) return null;
@@ -552,6 +555,7 @@ function buildPersistedSession(
     requestedAgentId: authCtx.requestedAgentId,
     isAuthenticated: authCtx.isAuthenticated,
     scopedToOrg: authCtx.scopedToOrg,
+    supportsMcpApps: authCtx.supportsMcpApps ?? false,
     lastAccessedAt,
     expiresAt: lastAccessedAt + SESSION_MAX_AGE_MS,
   };
@@ -673,6 +677,7 @@ async function recoverSessionAuthContext(
     return null;
   }
   authCtx.requestedAgentId = persisted.requestedAgentId ?? authCtx.requestedAgentId;
+  authCtx.supportsMcpApps = persisted.supportsMcpApps;
   authCtx.instructions = authCtx.organizationId
     ? ((await buildWorkspaceInstructions(authCtx.organizationId)) ?? undefined)
     : undefined;
@@ -894,8 +899,8 @@ async function handleAndMaybeConvert(
 async function resolveAuthWithInstructions(
   c: Context<{ Bindings: Env }>,
   req?: Request
-): Promise<AuthContext & { instructions?: string }> {
-  const authCtx: AuthContext & { instructions?: string } = extractAuthContext(c);
+): Promise<SessionAuthContext> {
+  const authCtx: SessionAuthContext = extractAuthContext(c);
   const request = req ?? c.req.raw;
   // `baseUrl` stays as extractAuthContext set it: empty means "no configured
   // public origin", which is what makes `getPublicWebUrl` fall back to the
@@ -914,9 +919,7 @@ async function resolveAuthWithInstructions(
   return authCtx;
 }
 
-async function syncAgentBinding(
-  authCtx: AuthContext & { instructions?: string }
-): Promise<string | null> {
+async function syncAgentBinding(authCtx: SessionAuthContext): Promise<string | null> {
   const requestedAgentId = authCtx.requestedAgentId?.trim() || null;
   authCtx.agentId = null;
 
@@ -944,8 +947,7 @@ async function syncAgentBinding(
 function createSessionTransport(
   env: Env,
   authCtx: SessionAuthContext,
-  sessionIdGenerator: () => string,
-  mcpAppsSupported: boolean
+  sessionIdGenerator: () => string
 ): { transport: WebStandardStreamableHTTPServerTransport; server: Server } {
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator,
@@ -968,7 +970,7 @@ function createSessionTransport(
       void deletePersistedSession(transport.sessionId);
     }
   };
-  const server = createServerForContext(env, authCtx, mcpAppsSupported);
+  const server = createServerForContext(env, authCtx, authCtx.supportsMcpApps ?? false);
   return { transport, server };
 }
 
@@ -1189,13 +1191,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
           const { transport, server } = createSessionTransport(
             c.env,
             recoveredAuthCtx,
-            () => sessionId,
-            // The client's negotiated MCP Apps capability is not part of the
-            // persisted session row, so a recovered session cannot prove the
-            // host renders `ui://` bundles. Advertise the plain tool
-            // definition rather than a resource pointer the host may not
-            // understand; a client that re-initializes negotiates it again.
-            false
+            () => sessionId
           );
           await server.connect(transport);
           await initializeRecoveredSession(transport, sessionId, req.url);
@@ -1272,11 +1268,11 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
     // null, which would deny role-gated actions to a real owner/admin.
     await hydrateScopedMemberRole(c.env, authCtx);
     await recordMcpClientActivity(c.env, authCtx, req, initialize);
+    authCtx.supportsMcpApps = supportsMcpApps(initialize?.capabilities);
     const { transport, server } = createSessionTransport(
       c.env,
       authCtx,
-      () => randomUUID(),
-      supportsMcpApps(initialize?.capabilities)
+      () => randomUUID()
     );
     await server.connect(transport);
     const response = await handleAndMaybeConvert(transport, req, wantsSSE);

--- a/packages/server/src/mcp-session-store.ts
+++ b/packages/server/src/mcp-session-store.ts
@@ -9,6 +9,7 @@ export interface PersistedMcpSession {
   requestedAgentId: string | null;
   isAuthenticated: boolean;
   scopedToOrg: boolean;
+  supportsMcpApps: boolean;
   lastAccessedAt: number;
   expiresAt: number;
 }
@@ -45,6 +46,7 @@ export class McpSessionStore {
         requested_agent_id,
         is_authenticated,
         scoped_to_org,
+        supports_mcp_apps,
         last_accessed_at,
         expires_at
       ) VALUES (
@@ -56,6 +58,7 @@ export class McpSessionStore {
         ${session.requestedAgentId},
         ${session.isAuthenticated},
         ${session.scopedToOrg},
+        ${session.supportsMcpApps},
         ${new Date(session.lastAccessedAt)},
         ${new Date(session.expiresAt)}
       )
@@ -67,6 +70,7 @@ export class McpSessionStore {
         requested_agent_id = EXCLUDED.requested_agent_id,
         is_authenticated = EXCLUDED.is_authenticated,
         scoped_to_org = EXCLUDED.scoped_to_org,
+        supports_mcp_apps = EXCLUDED.supports_mcp_apps,
         last_accessed_at = EXCLUDED.last_accessed_at,
         expires_at = EXCLUDED.expires_at
     `;
@@ -94,6 +98,7 @@ export class McpSessionStore {
         requested_agent_id = ${session.requestedAgentId},
         is_authenticated = ${session.isAuthenticated},
         scoped_to_org = ${session.scopedToOrg},
+        supports_mcp_apps = ${session.supportsMcpApps},
         last_accessed_at = ${new Date(session.lastAccessedAt)},
         expires_at = ${new Date(session.expiresAt)}
       WHERE session_id = ${session.sessionId}
@@ -123,6 +128,7 @@ export class McpSessionStore {
       requestedAgentId: typeof row.requested_agent_id === 'string' ? row.requested_agent_id : null,
       isAuthenticated: fromBool(row.is_authenticated),
       scopedToOrg: fromBool(row.scoped_to_org),
+      supportsMcpApps: fromBool(row.supports_mcp_apps),
       lastAccessedAt: fromDate(row.last_accessed_at) ?? Date.now(),
       expiresAt: fromDate(row.expires_at) ?? Date.now(),
     };


### PR DESCRIPTION
## Summary
- persist negotiated MCP Apps support on the existing one-hour session row
- restore the capability when another replica recovers the session
- keep UI metadata absent for clients that did not negotiate Apps support
- store only a boolean capability flag; no user content or secrets

## Red to green
- before: Apps initialize followed by cleared in-memory state lost render_lobu_view `_meta.ui`
- after: the same forced recovery preserves `ui://lobu/interaction/v1`; text-only forced recovery still omits UI metadata

## Verification
- focused MCP/session integration: 15 passed
- migration format: 468 passed
- migration lint: 0 issues
- full unit suite: passed
- full integration target: passed, including 3,608 parallel cases plus serial gateway/server/scheduled/connector-worker lanes
- make pre-pr: passed all 6 gates
- REVIEWER_CLI=codex make review-fix: clean, no edits

## Release boundary
Database design was explicitly confirmed before implementation. Production release remains held pending exact-head reviews, required CI, squash merge, exact-SHA smoke, and live cross-replica Apps/text-only protocol proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP Apps support is now preserved when sessions recover or move between server replicas.
  * Supported clients continue receiving the appropriate app metadata after session recovery.
  * MCP session capabilities are retained across refreshes and restored sessions.

* **Bug Fixes**
  * Prevented MCP Apps capabilities from being lost during session restoration.
  * Non-MCP Apps clients continue to operate without UI metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->