### PR TITLE
feat(mcp): render rich tool results

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -185,7 +185,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(resource._meta?.ui?.domain).toBeUndefined();
   });
 
-  it('advertises a dedicated render tool with Apps, OAuth, and safety metadata', async () => {
+  it('advertises rich result UIs for every public data tool and an app-only approval tool', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
@@ -218,8 +218,41 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       })
     );
 
-    const runSdk = body.result?.tools?.find((entry: { name?: string }) => entry.name === 'run_sdk');
-    expect(runSdk?._meta?.ui).toBeUndefined();
+    for (const name of [
+      'search_memory',
+      'save_memory',
+      'search_sdk',
+      'query_sdk',
+      'query_sql',
+      'run_sdk',
+      'render_lobu_view',
+    ]) {
+      const richTool = body.result?.tools?.find(
+        (entry: { name?: string }) => entry.name === name
+      );
+      expect(richTool?._meta?.ui).toEqual(
+        expect.objectContaining({
+          resourceUri: 'ui://lobu/interaction/v1',
+          visibility: ['model', 'app'],
+        })
+      );
+      expect(richTool?._meta?.['openai/outputTemplate']).toBe(
+        'ui://lobu/interaction/v1'
+      );
+      expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
+    }
+
+    const resolveApproval = body.result?.tools?.find(
+      (entry: { name?: string }) => entry.name === 'resolve_lobu_approval'
+    );
+    expect(resolveApproval).toEqual(
+      expect.objectContaining({
+        securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
+        _meta: expect.objectContaining({
+          ui: expect.objectContaining({ visibility: ['app'] }),
+        }),
+      })
+    );
     for (const listed of body.result?.tools ?? []) {
       expect(listed.securitySchemes?.[0]?.type).toBe('oauth2');
       expect(listed.annotations?.readOnlyHint).toEqual(expect.any(Boolean));
@@ -319,9 +352,54 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toBeUndefined();
     expect(typeof tool?.description).toBe('string');
+    expect(
+      body.result?.tools?.some(
+        (entry: { name?: string }) => entry.name === 'resolve_lobu_approval'
+      )
+    ).toBe(false);
+
+    const [run] = await getDb()<{ id: number }>`
+      INSERT INTO runs (organization_id, run_type, status, approval_status)
+      VALUES (${org.id}, 'action', 'pending', 'pending')
+      RETURNING id
+    `;
+    const runId = Number(run.id);
+    await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: `mcp_app_non_app_approval_${runId}`,
+      title: 'Non-App review — pending approval',
+      content: 'This client must use the Lobu review page.',
+      semanticType: 'operation',
+      runId,
+      interactionType: 'approval',
+      interactionStatus: 'pending',
+    });
+    const renderResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'render_lobu_view',
+          arguments: { action: 'review_approval', run_id: runId },
+        },
+      },
+      headers: {
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      token,
+    });
+    const renderBody = await renderResponse.json();
+    expect(renderBody.result?.isError).not.toBe(true);
+    expect(renderBody.result?._meta?.['lobu/approval-capability']).toBeUndefined();
+    expect(renderBody.result?.structuredContent?.actions).toEqual([
+      expect.objectContaining({ id: 'review', href: expect.stringMatching(/^https?:\/\//) }),
+    ]);
   });
 
-  it('keeps an approval mutation text-only and renders a safe review link separately', async () => {
+  it('keeps an approval mutation text-only and resolves it only with the hidden app capability', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`, {
       agentId: actingAgent.agentId,
     });
@@ -381,15 +459,144 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const view = renderBody.result?.structuredContent;
     expect(view?.version).toBe(1);
     expect(view?.tone).toBe('warning');
-    expect(view?.actions).toEqual([
+    expect(view?.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'approve',
+          label: 'Approve',
+          tool: 'resolve_lobu_approval',
+          args: { run_id: runId, decision: 'approve' },
+        }),
+        expect.objectContaining({
+          id: 'reject',
+          label: 'Reject',
+          tool: 'resolve_lobu_approval',
+          args: { run_id: runId, decision: 'reject' },
+        }),
+        expect.objectContaining({
+          id: 'review',
+          label: 'Open in Lobu',
+          href: expect.stringMatching(/^https?:\/\//),
+        }),
+      ])
+    );
+    const capability = renderBody.result?._meta?.['lobu/approval-capability'];
+    expect(typeof capability).toBe('string');
+    expect(capability.length).toBeGreaterThan(40);
+    expect(JSON.stringify(view)).not.toContain(capability);
+    expect(renderBody.result?.content?.[0]?.text).not.toContain(capability);
+
+    const missingCapabilityResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 22,
+        method: 'tools/call',
+        params: {
+          name: 'resolve_lobu_approval',
+          arguments: { run_id: runId, decision: 'reject' },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const missingCapabilityBody = await missingCapabilityResponse.json();
+    expect(missingCapabilityBody.result?.isError).toBe(true);
+    expect(missingCapabilityBody.result?.content?.[0]?.text).toMatch(/approval capability/i);
+
+    const rejectResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 23,
+        method: 'tools/call',
+        params: {
+          name: 'resolve_lobu_approval',
+          arguments: { run_id: runId, decision: 'reject', reason: 'Not this time' },
+          _meta: { 'lobu/approval-capability': capability },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const rejectBody = await rejectResponse.json();
+    expect(rejectBody.result?.isError).not.toBe(true);
+    expect(rejectBody.result?.structuredContent).toEqual(
       expect.objectContaining({
-        id: 'review',
-        label: 'Review in Lobu',
-        href: expect.stringMatching(/^https?:\/\//),
-      }),
-    ]);
-    expect(view?.actions?.some((action: { id?: string }) => action.id === 'approve')).toBe(false);
-    expect(view?.actions?.some((action: { id?: string }) => action.id === 'reject')).toBe(false);
+        title: expect.stringMatching(/rejected/i),
+        actions: [],
+      })
+    );
+
+    const [settled] = await getDb()<{
+      approval_status: string;
+      status: string;
+      error_message: string | null;
+    }>`
+      SELECT approval_status, status, error_message
+      FROM runs
+      WHERE id = ${runId} AND organization_id = ${org.id}
+    `;
+    expect(settled).toMatchObject({
+      approval_status: 'rejected',
+      status: 'cancelled',
+      error_message: 'Not this time',
+    });
+
+    const replayResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 24,
+        method: 'tools/call',
+        params: {
+          name: 'resolve_lobu_approval',
+          arguments: { run_id: runId, decision: 'reject' },
+          _meta: { 'lobu/approval-capability': capability },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const replayBody = await replayResponse.json();
+    expect(replayBody.result?.isError).toBe(true);
+    expect(replayBody.result?.content?.[0]?.text).toMatch(/stale|pending/i);
+  });
+
+  it('returns structured SQL rows for the shared rich renderer', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 25,
+        method: 'tools/call',
+        params: {
+          name: 'query_sql',
+          arguments: {
+            sql: 'SELECT id, semantic_type AS name FROM events',
+            sort_by: 'id',
+            sort_order: 'desc',
+            limit: 1,
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    expect(body.result?.structuredContent).toEqual(
+      expect.objectContaining({
+        rows: [
+          {
+            id: expect.any(Number),
+            name: expect.any(String),
+          },
+        ],
+        columns: [
+          { name: 'id', type: expect.any(String) },
+          { name: 'name', type: expect.any(String) },
+        ],
+        total_count: expect.any(Number),
+      })
+    );
   });
 
   it('redacts approval secrets before key context is lost and enforces view limits', async () => {
@@ -410,6 +617,22 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       token: 'plaintext-old-token',
       apiKey: 'plaintext-old-api-key',
     };
+    const interactionInputSchema = {
+      type: 'object',
+      properties: {
+        api_key: {
+          type: 'string',
+          default: 'plaintext-schema-api-key',
+          description: 'Credential used for the request',
+        },
+        comment: { type: 'string' },
+      },
+      required: ['api_key'],
+    };
+    const interactionInput = {
+      api_key: 'plaintext-form-api-key',
+      comment: 'Safe existing note',
+    };
     for (let index = 0; index < 130; index += 1) {
       proposal[`field_${index}_${'x'.repeat(150)}`] = `value_${index}_${'y'.repeat(21_000)}`;
     }
@@ -423,6 +646,8 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       runId: Number(run.id),
       interactionType: 'approval',
       interactionStatus: 'pending',
+      interactionInputSchema,
+      interactionInput,
       metadata: { proposal, current },
     });
 
@@ -450,10 +675,29 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(serialized).not.toContain('plaintext-old-api-key');
     expect(serialized).not.toContain('plaintext-nested-authorization');
     expect(serialized).not.toContain('plaintext-uri-password');
+    expect(serialized).not.toContain('plaintext-schema-api-key');
+    expect(serialized).not.toContain('plaintext-form-api-key');
     expect(serialized).toContain('[redacted]');
     expect(view.title.length).toBeLessThanOrEqual(200);
     expect(view.blocks.length).toBeLessThanOrEqual(100);
     expect(view.actions.length).toBeLessThanOrEqual(10);
+    const form = view.blocks.find((block: any) => block.type === 'form');
+    expect(form).toEqual(
+      expect.objectContaining({
+        schema: expect.objectContaining({
+          properties: expect.objectContaining({
+            api_key: expect.objectContaining({
+              type: 'string',
+              format: 'password',
+              description: 'Credential used for the request',
+            }),
+          }),
+          required: ['api_key'],
+        }),
+        initialValues: { comment: 'Safe existing note' },
+      })
+    );
+    expect(form.schema.properties.api_key.default).toBeUndefined();
     const diffFields = view.blocks.flatMap((block: any) => block.fields ?? []);
     expect(diffFields.length).toBeLessThanOrEqual(100);
     for (const field of diffFields) {

--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -91,6 +91,8 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     // Tools that declare an outputSchema carry it through to the listing...
     expect(byName.get('search_sdk')?.outputSchema?.type).toBe('object');
     expect(byName.get('search_memory')?.outputSchema?.type).toBe('object');
+    expect(byName.get('save_memory')?.outputSchema?.type).toBe('object');
+    expect(byName.get('query_sql')?.outputSchema?.type).toBe('object');
     // ...including union-result tools: the MCP spec requires outputSchema to be
     // an OBJECT schema, so even a discriminated `Type.Union` result must carry
     // top-level `type: "object"` (a bare `anyOf` — TypeBox's default union
@@ -98,8 +100,6 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     // `anyOf` so the client can still tell which one applied.
     const querySdkOut = byName.get('query_sdk')?.outputSchema;
     expect(querySdkOut?.type).toBe('object');
-    // ...while tools without one (text-only results) omit it.
-    expect(byName.get('save_memory')?.outputSchema).toBeUndefined();
   });
 
   it('records query_sql audit rows in the append-only events ledger', async () => {

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -72,17 +72,20 @@ describe("tool registry split", () => {
 				"query_sdk",
 				"query_sql",
 				"render_lobu_view",
+				"resolve_lobu_approval",
 				"run_sdk",
 				"save_memory",
 				"search_memory",
 				"search_sdk",
 			].sort()
 		);
-		// The render helper is listed on MCP only: it stays out of
-		// AGENT_TOOL_NAMES, so it never reaches the generated OpenAPI/ClientSDK
-		// agent surface.
+		// Presentation helpers are listed on the MCP registry only: they stay out
+		// of AGENT_TOOL_NAMES, so they never reach generated OpenAPI/ClientSDK.
+		// The MCP handler additionally hides app-only entries from hosts that did
+		// not negotiate MCP Apps support.
 		expect(AGENT_TOOL_NAMES.size).toBe(6);
 		expect(isRestDispatchTool("render_lobu_view")).toBe(false);
+		expect(isRestDispatchTool("resolve_lobu_approval")).toBe(false);
 		expect(isRestDispatchTool("manage_connections")).toBe(true);
 	});
 

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -53,6 +53,7 @@ import {
   isSoftErrorResult,
 } from './tools/execute';
 import { LOBU_INTERACTION_RESOURCE_URI } from './tools/mcp_app';
+import { getMcpResultMeta } from './tools/mcp-result-meta';
 import { getMcpTools, getTool } from './tools/registry';
 import { validateToolResult } from './tools/validate-args';
 import { readMcpAppBundle } from './utils/mcp-app-bundle';
@@ -93,6 +94,14 @@ export function hostConversationIdFromMeta(value: unknown): string | null {
   if (typeof id !== 'string') return null;
   const trimmed = id.trim();
   return trimmed && trimmed.length <= 512 ? trimmed : null;
+}
+
+function approvalCapabilityFromMeta(value: unknown): string | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const token = (value as Record<string, unknown>)['lobu/approval-capability'];
+  if (typeof token !== 'string') return null;
+  const trimmed = token.trim();
+  return trimmed && trimmed.length <= 4_096 ? trimmed : null;
 }
 
 // Periodic cleanup of stale IN-MEMORY sessions. This must stay as a per-pod
@@ -262,32 +271,39 @@ function createServerForContext(
     const allTools = getMcpTools({
       publicOnly,
       maxAccessLevel,
-    }).map((t) => {
-      const securitySchemes = t.securitySchemes
-        ? publicOnly
-          ? [{ type: 'noauth' as const }, ...t.securitySchemes]
-          : t.securitySchemes
-        : undefined;
-      const appMeta = mcpAppsSupported ? t._meta : undefined;
-      return {
-        name: t.name,
-        description: t.description,
-        inputSchema: t.inputSchema,
-        ...(t.annotations && { annotations: t.annotations }),
-        ...(t.outputSchema && { outputSchema: t.outputSchema }),
-        ...(securitySchemes && { securitySchemes }),
-        ...(appMeta || securitySchemes
-          ? {
-              _meta: {
-                ...(appMeta ?? {}),
-                // MCP Apps 2025-11-25 retains `_meta.securitySchemes` as the
-                // compatibility mirror for hosts that predate the top-level field.
-                ...(securitySchemes && { securitySchemes }),
-              },
-            }
-          : {}),
-      };
-    });
+    })
+      .filter((t) => {
+        const visibility = (t._meta?.ui as { visibility?: unknown } | undefined)?.visibility;
+        return mcpAppsSupported || !(
+          Array.isArray(visibility) && visibility.length === 1 && visibility[0] === 'app'
+        );
+      })
+      .map((t) => {
+        const securitySchemes = t.securitySchemes
+          ? publicOnly
+            ? [{ type: 'noauth' as const }, ...t.securitySchemes]
+            : t.securitySchemes
+          : undefined;
+        const appMeta = mcpAppsSupported ? t._meta : undefined;
+        return {
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+          ...(t.annotations && { annotations: t.annotations }),
+          ...(t.outputSchema && { outputSchema: t.outputSchema }),
+          ...(securitySchemes && { securitySchemes }),
+          ...(appMeta || securitySchemes
+            ? {
+                _meta: {
+                  ...(appMeta ?? {}),
+                  // MCP Apps 2025-11-25 retains `_meta.securitySchemes` as the
+                  // compatibility mirror for hosts that predate the top-level field.
+                  ...(securitySchemes && { securitySchemes }),
+                },
+              }
+            : {}),
+        };
+      });
 
     return { tools: allTools };
   });
@@ -349,7 +365,9 @@ function createServerForContext(
     const { name, arguments: args } = request.params;
     const callAuthCtx = {
       ...authCtx,
+      mcpAppsSupported,
       mcpConversationId: hostConversationIdFromMeta(request.params._meta),
+      mcpAppApprovalCapability: approvalCapabilityFromMeta(request.params._meta),
     };
 
     // Regular tool execution
@@ -366,8 +384,8 @@ function createServerForContext(
       // When the tool declares an `outputSchema`, also return the result as
       // `structuredContent` (MCP spec: declaring outputSchema implies the result
       // is structured — and a spec-compliant client validates it against the
-      // declared schema). Tools without one (manage_agents, save_memory, ...)
-      // stay text-only — the schema is coupled to emission, never declared alone.
+      // declared schema). Tools without one stay text-only — the schema is
+      // coupled to emission, never declared alone.
       //
       // Validate + coerce the result against the schema before emitting: result
       // types are hand-authored TypeBox schemas but the values are assembled from
@@ -383,18 +401,21 @@ function createServerForContext(
       // turn `{ rows: [], error }` into a clean empty CSV result.
       const softError = isSoftErrorResult(result);
       const tool = getTool(name);
+      const resultMeta = getMcpResultMeta(result);
       if (tool?.outputSchema && result && typeof result === 'object') {
         const structured = validateToolResult(tool.outputSchema, result);
         if (structured !== null) {
           return {
             content: [{ type: 'text' as const, text }],
             structuredContent: structured as Record<string, unknown>,
+            ...(resultMeta ? { _meta: resultMeta } : {}),
             ...(softError ? { isError: true } : {}),
           };
         }
       }
       return {
         content: [{ type: 'text' as const, text }],
+        ...(resultMeta ? { _meta: resultMeta } : {}),
         ...(softError ? { isError: true } : {}),
       };
     } catch (error: any) {

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -112,6 +112,23 @@ function oidToTypeName(oid: number): string {
   return PG_OID_TYPE_MAP[oid] ?? 'unknown';
 }
 
+export const QuerySqlResultSchema = Type.Object({
+  rows: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+  columns: Type.Array(
+    Type.Object({
+      name: Type.String(),
+      type: Type.String(),
+    })
+  ),
+  total_count: Type.Integer(),
+  has_more: Type.Boolean(),
+  execution_time_ms: Type.Number(),
+  coverage: Type.Optional(Type.Unknown()),
+  error: Type.Optional(Type.String()),
+  error_code: Type.Optional(Type.String()),
+  retryable: Type.Optional(Type.Boolean()),
+});
+
 interface QuerySqlResult {
   rows: Record<string, unknown>[];
   columns: { name: string; type: string }[];

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -53,6 +53,10 @@ export interface AuthContext {
    * Audit rows carry it so a client's activity can be grouped per session.
    */
   mcpSessionId?: string | null;
+  /** Whether this MCP session negotiated the standard Apps UI extension. */
+  mcpAppsSupported?: boolean | null;
+  /** Host-only capability from an MCP App `tools/call` request. Never persisted. */
+  mcpAppApprovalCapability?: string | null;
   /** Host conversation correlation, separate from the transport session. */
   mcpConversationId?: string | null;
   instructions?: string;
@@ -385,6 +389,8 @@ export function toToolContext(authCtx: AuthContext): ToolContext {
     baseUrl: authCtx.baseUrl,
     applyId: authCtx.applyId ?? null,
     mcpSessionId: authCtx.mcpSessionId ?? null,
+    mcpAppsSupported: authCtx.mcpAppsSupported ?? false,
+    mcpAppApprovalCapability: authCtx.mcpAppApprovalCapability ?? null,
     mcpConversationId: authCtx.mcpConversationId ?? null,
     executionMode: authCtx.executionMode ?? null,
   };

--- a/packages/server/src/tools/mcp-result-meta.ts
+++ b/packages/server/src/tools/mcp-result-meta.ts
@@ -1,0 +1,27 @@
+const MCP_RESULT_META = Symbol('lobu.mcp-result-meta');
+
+type ResultWithMcpMeta = {
+  [MCP_RESULT_META]?: Record<string, unknown>;
+};
+
+/**
+ * Attach host-only MCP result metadata without making it part of the tool's
+ * structured result, formatted text, audit payload, or output-schema contract.
+ */
+export function attachMcpResultMeta<T extends object>(
+  result: T,
+  meta: Record<string, unknown>
+): T {
+  Object.defineProperty(result, MCP_RESULT_META, {
+    value: meta,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return result;
+}
+
+export function getMcpResultMeta(result: unknown): Record<string, unknown> | undefined {
+  if (!result || typeof result !== 'object') return undefined;
+  return (result as ResultWithMcpMeta)[MCP_RESULT_META];
+}

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -1,9 +1,17 @@
-import { deepRedactSecrets, isSecretKey, REDACTED_SENTINEL } from '@lobu/core';
+import {
+  decrypt,
+  deepRedactSecrets,
+  encrypt,
+  isSecretKey,
+  REDACTED_SENTINEL,
+} from '@lobu/core';
 import { type Static, Type } from '@sinclair/typebox';
 import type { Env } from '../index';
 import { ToolUserError } from '../utils/errors';
 import { buildResourcePermalink } from '../utils/url-builder';
 import { getContent } from './get_content';
+import { manageOperations } from './admin/manage_operations';
+import { attachMcpResultMeta } from './mcp-result-meta';
 import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
 import { getOrgUrlContext } from './view-urls';
@@ -20,7 +28,10 @@ const ACTION_MAX_ITEMS = 10;
 const ACTION_ID_MAX_LENGTH = 80;
 const ACTION_LABEL_MAX_LENGTH = 120;
 const ACTION_HREF_MAX_LENGTH = 2_048;
+const APPROVAL_CAPABILITY_MAX_LENGTH = 4_096;
+const APPROVAL_CAPABILITY_TTL_MS = 10 * 60 * 1_000;
 const DISPLAY_REDACTION = '[redacted]';
+const SECRET_SCHEMA_VALUE_KEYS = new Set(['const', 'default', 'enum', 'example', 'examples']);
 
 const TextBlockSchema = Type.Object({
   type: Type.Literal('text'),
@@ -46,7 +57,18 @@ const DiffBlockSchema = Type.Object({
   ),
 });
 
-const LobuViewBlockSchema = Type.Union([TextBlockSchema, CodeBlockSchema, DiffBlockSchema]);
+const FormBlockSchema = Type.Object({
+  type: Type.Literal('form'),
+  schema: Type.Record(Type.String(), Type.Unknown()),
+  initialValues: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+
+const LobuViewBlockSchema = Type.Union([
+  TextBlockSchema,
+  CodeBlockSchema,
+  DiffBlockSchema,
+  FormBlockSchema,
+]);
 
 const LinkActionSchema = Type.Object({
   id: Type.String({ minLength: 1, maxLength: ACTION_ID_MAX_LENGTH }),
@@ -68,6 +90,46 @@ const LinkActionSchema = Type.Object({
   }),
 });
 
+const ApprovalToolActionBaseFields = {
+  label: Type.String({ minLength: 1, maxLength: ACTION_LABEL_MAX_LENGTH }),
+  variant: Type.Optional(
+    Type.Union([
+      Type.Literal('primary'),
+      Type.Literal('outline'),
+      Type.Literal('ghost'),
+      Type.Literal('destructive'),
+    ])
+  ),
+  confirm: Type.Optional(Type.Boolean()),
+  confirmPrompt: Type.Optional(Type.String({ maxLength: TEXT_LABEL_MAX_LENGTH })),
+  terminal: Type.Optional(Type.Boolean()),
+  resolvedLabel: Type.Optional(Type.String({ maxLength: TEXT_LABEL_MAX_LENGTH })),
+} as const;
+
+const ApprovalToolActionSchema = Type.Union([
+  Type.Object({
+    ...ApprovalToolActionBaseFields,
+    id: Type.Literal('approve'),
+    icon: Type.Optional(Type.Literal('check')),
+    submitFormAs: Type.Optional(Type.Literal('input')),
+    tool: Type.Literal('resolve_lobu_approval'),
+    args: Type.Object({
+      run_id: Type.Integer({ minimum: 1 }),
+      decision: Type.Literal('approve'),
+    }),
+  }),
+  Type.Object({
+    ...ApprovalToolActionBaseFields,
+    id: Type.Literal('reject'),
+    icon: Type.Optional(Type.Literal('x')),
+    tool: Type.Literal('resolve_lobu_approval'),
+    args: Type.Object({
+      run_id: Type.Integer({ minimum: 1 }),
+      decision: Type.Literal('reject'),
+    }),
+  }),
+]);
+
 export const LobuViewSchema = Type.Object({
   version: Type.Literal(1),
   title: Type.Optional(Type.String({ maxLength: TITLE_MAX_LENGTH })),
@@ -75,7 +137,16 @@ export const LobuViewSchema = Type.Object({
     Type.Union([Type.Literal('warning'), Type.Literal('default'), Type.Literal('bare')])
   ),
   blocks: Type.Array(LobuViewBlockSchema, { maxItems: BLOCK_MAX_ITEMS }),
-  actions: Type.Array(LinkActionSchema, { maxItems: ACTION_MAX_ITEMS }),
+  actions: Type.Array(Type.Union([LinkActionSchema, ApprovalToolActionSchema]), {
+    maxItems: ACTION_MAX_ITEMS,
+  }),
+});
+
+export const ResolveLobuApprovalSchema = Type.Object({
+  run_id: Type.Integer({ minimum: 1 }),
+  decision: Type.Union([Type.Literal('approve'), Type.Literal('reject')]),
+  input: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  reason: Type.Optional(Type.String({ maxLength: 2_000 })),
 });
 
 const RenderActionSchema = Type.Object({
@@ -150,6 +221,63 @@ function redactForDisplay(value: unknown, key?: string): unknown {
   return displayRedacted(deepRedactSecrets(value));
 }
 
+function stripSecretSchemaValues(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripSecretSchemaValues);
+  if (!isRecord(value)) return redactForDisplay(value);
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => !SECRET_SCHEMA_VALUE_KEYS.has(key))
+      .map(([key, inner]) => [key, stripSecretSchemaValues(inner)])
+  );
+}
+
+function sanitizeFormFieldSchema(name: string, value: unknown): unknown {
+  const sanitized = sanitizeFormSchema(value);
+  if (!isSecretKey(name)) return sanitized;
+  if (!isRecord(sanitized)) return DISPLAY_REDACTION;
+
+  const field = stripSecretSchemaValues(sanitized) as Record<string, unknown>;
+  if (field.type === 'string' || field.type === undefined) field.format = 'password';
+  return field;
+}
+
+/** Preserve usable JSON Schema structure while removing secret-bearing values. */
+function sanitizeFormSchema(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeFormSchema);
+  if (!isRecord(value)) return redactForDisplay(value);
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, inner]) => {
+      if (key === 'properties' && isRecord(inner)) {
+        return [
+          key,
+          Object.fromEntries(
+            Object.entries(inner).map(([name, schema]) => [
+              name,
+              sanitizeFormFieldSchema(name, schema),
+            ])
+          ),
+        ];
+      }
+      return [key, sanitizeFormSchema(inner)];
+    })
+  );
+}
+
+function sanitizeFormInitialValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeFormInitialValue);
+  if (!isRecord(value)) return redactForDisplay(value);
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => !isSecretKey(key))
+      .map(([key, inner]) => [key, sanitizeFormInitialValue(inner)])
+  );
+}
+
+function sanitizeFormInitialValues(value: Record<string, unknown>): Record<string, unknown> {
+  return sanitizeFormInitialValue(value) as Record<string, unknown>;
+}
+
 function displayValue(value: unknown, maxLength: number, key?: string): string {
   if (value === undefined || value === null) return '';
   const redacted = redactForDisplay(value, key);
@@ -168,6 +296,7 @@ function displayValue(value: unknown, maxLength: number, key?: string): string {
 
 function approvalBlocks(row: {
   content: string | null;
+  interaction_input_schema: Record<string, unknown> | null;
   interaction_input: Record<string, unknown> | null;
   metadata: Record<string, unknown> | null;
 }): LobuViewBlock[] {
@@ -176,6 +305,7 @@ function approvalBlocks(row: {
   const current = isRecord(metadata.current) ? metadata.current : null;
   const fields = isRecord(metadata.fields) ? metadata.fields : null;
   const proposed = fields ?? proposal;
+  const blocks: LobuViewBlock[] = [];
 
   if (proposed) {
     const diffFields = Object.entries(proposed)
@@ -188,25 +318,34 @@ function approvalBlocks(row: {
           : {}),
         after: displayValue(value, TEXT_VALUE_MAX_LENGTH, key),
       }));
-    if (diffFields.length > 0) return [{ type: 'diff', fields: diffFields }];
+    if (diffFields.length > 0) blocks.push({ type: 'diff', fields: diffFields });
   }
 
-  if (row.interaction_input && Object.keys(row.interaction_input).length > 0) {
-    return [
-      {
-        type: 'code',
-        value: displayValue(row.interaction_input, CODE_VALUE_MAX_LENGTH),
-      },
-    ];
+  if (row.interaction_input_schema) {
+    blocks.push({
+      type: 'form',
+      schema: sanitizeFormSchema(row.interaction_input_schema) as Record<string, unknown>,
+      ...(row.interaction_input
+        ? {
+            initialValues: sanitizeFormInitialValues(row.interaction_input),
+          }
+        : {}),
+    });
+  } else if (row.interaction_input && Object.keys(row.interaction_input).length > 0) {
+    blocks.push({
+      type: 'code',
+      value: displayValue(row.interaction_input, CODE_VALUE_MAX_LENGTH),
+    });
   }
 
-  return [
-    {
+  if (blocks.length === 0) {
+    blocks.push({
       type: 'text',
       value: displayValue(row.content || 'Review this pending Lobu action.', TEXT_VALUE_MAX_LENGTH),
       muted: true,
-    },
-  ];
+    });
+  }
+  return blocks;
 }
 
 function sanitizeBlocks(blocks: LobuViewBlock[]): LobuViewBlock[] {
@@ -222,6 +361,17 @@ function sanitizeBlocks(blocks: LobuViewBlock[]): LobuViewBlock[] {
       return {
         type: 'code',
         value: displayValue(block.value, CODE_VALUE_MAX_LENGTH),
+      };
+    }
+    if (block.type === 'form') {
+      return {
+        type: 'form',
+        schema: sanitizeFormSchema(block.schema) as Record<string, unknown>,
+        ...(block.initialValues
+          ? {
+              initialValues: sanitizeFormInitialValues(block.initialValues),
+            }
+          : {}),
       };
     }
     return {
@@ -240,11 +390,13 @@ function sanitizeBlocks(blocks: LobuViewBlock[]): LobuViewBlock[] {
 }
 
 type ApprovalContentItem = {
+  id: number;
   run_id: number;
   title: string | null;
   payload_text: string;
   interaction_type: 'approval';
   interaction_status: string | null;
+  interaction_input_schema: Record<string, unknown> | null;
   interaction_input: Record<string, unknown> | null;
   metadata: Record<string, unknown> | null;
 };
@@ -254,7 +406,86 @@ function isApprovalContentItem(value: unknown, runId: number): value is Approval
   return value.run_id === runId && value.interaction_type === 'approval';
 }
 
-async function buildApprovalView(runId: number, env: Env, ctx: ToolContext): Promise<LobuView> {
+function belongsToApprovalWindow(row: ApprovalContentItem): boolean {
+  const windowId = row.metadata?.window_id;
+  return windowId !== undefined && windowId !== null;
+}
+
+type ApprovalCapability = {
+  v: 1;
+  runId: number;
+  eventId: number;
+  organizationId: string;
+  userId: string;
+  clientId: string;
+  sessionId: string;
+  expiresAt: number;
+};
+
+function isApprovalCapability(value: unknown): value is ApprovalCapability {
+  if (!isRecord(value)) return false;
+  return (
+    value.v === 1 &&
+    Number.isInteger(value.runId) &&
+    Number.isInteger(value.eventId) &&
+    typeof value.organizationId === 'string' &&
+    typeof value.userId === 'string' &&
+    typeof value.clientId === 'string' &&
+    typeof value.sessionId === 'string' &&
+    typeof value.expiresAt === 'number'
+  );
+}
+
+function canIssueApprovalCapability(
+  row: ApprovalContentItem,
+  status: string,
+  ctx: ToolContext
+): ctx is ToolContext & {
+  userId: string;
+  clientId: string;
+  mcpSessionId: string;
+} {
+  return (
+    status === 'pending' &&
+    ctx.mcpAppsSupported === true &&
+    ctx.tokenType === 'oauth' &&
+    Boolean(ctx.userId && ctx.clientId && ctx.mcpSessionId) &&
+    !belongsToApprovalWindow(row)
+  );
+}
+
+function issueApprovalCapability(row: ApprovalContentItem, ctx: ToolContext): string {
+  const payload: ApprovalCapability = {
+    v: 1,
+    runId: row.run_id,
+    eventId: row.id,
+    organizationId: ctx.organizationId,
+    userId: ctx.userId!,
+    clientId: ctx.clientId!,
+    sessionId: ctx.mcpSessionId!,
+    expiresAt: Date.now() + APPROVAL_CAPABILITY_TTL_MS,
+  };
+  return encrypt(JSON.stringify(payload));
+}
+
+function readApprovalCapability(token: string | null | undefined): ApprovalCapability {
+  if (!token || token.length > APPROVAL_CAPABILITY_MAX_LENGTH) {
+    throw new ToolUserError('A valid MCP App approval capability is required.', 403);
+  }
+  try {
+    const parsed: unknown = JSON.parse(decrypt(token));
+    if (!isApprovalCapability(parsed)) throw new Error('invalid payload');
+    return parsed;
+  } catch {
+    throw new ToolUserError('The MCP App approval capability is invalid or expired.', 403);
+  }
+}
+
+async function findApprovalRow(
+  runId: number,
+  env: Env,
+  ctx: ToolContext
+): Promise<ApprovalContentItem> {
   // Reuse the canonical knowledge read so connection visibility, public-org
   // rules, caller identity, and MCP scope checks cannot drift from the event
   // surface. A direct current_event_records query here would be tenant-fenced
@@ -266,6 +497,11 @@ async function buildApprovalView(runId: number, env: Env, ctx: ToolContext): Pro
   );
   const row = result.content.find((item) => isApprovalContentItem(item, runId));
   if (!row) throw new ToolUserError(`Approval run ${runId} was not found`, 404);
+  return row;
+}
+
+async function buildApprovalView(runId: number, env: Env, ctx: ToolContext): Promise<LobuView> {
+  const row = await findApprovalRow(runId, env, ctx);
 
   const status = row.interaction_status ?? 'pending';
   const baseTitle = displayValue(row.title ?? `Approval run ${runId}`, TITLE_MAX_LENGTH).replace(
@@ -279,17 +515,43 @@ async function buildApprovalView(runId: number, env: Env, ctx: ToolContext): Pro
     if (!href || href.length > ACTION_HREF_MAX_LENGTH || !/^https?:\/\//i.test(href)) {
       throw new ToolUserError('The Lobu review link is unavailable for this workspace.', 500);
     }
+    const appCanResolve = canIssueApprovalCapability(row, status, ctx);
+    if (appCanResolve) {
+      actions.push(
+        {
+          id: 'approve',
+          label: 'Approve',
+          variant: 'primary',
+          icon: 'check',
+          resolvedLabel: 'Approved.',
+          ...(row.interaction_input_schema ? { submitFormAs: 'input' as const } : {}),
+          tool: 'resolve_lobu_approval',
+          args: { run_id: runId, decision: 'approve' },
+        },
+        {
+          id: 'reject',
+          label: 'Reject',
+          variant: 'destructive',
+          icon: 'x',
+          confirm: true,
+          confirmPrompt: 'Reject this pending action?',
+          resolvedLabel: 'Rejected.',
+          tool: 'resolve_lobu_approval',
+          args: { run_id: runId, decision: 'reject' },
+        }
+      );
+    }
     actions.push({
       id: 'review',
-      label: 'Review in Lobu',
-      variant: 'primary',
+      label: 'Open in Lobu',
+      variant: appCanResolve ? 'outline' : 'primary',
       icon: 'external',
       terminal: false,
       href,
     });
   }
 
-  return {
+  const view: LobuView = {
     version: 1,
     title: truncate(
       status === 'pending' ? baseTitle : `${baseTitle} · ${status}`,
@@ -298,11 +560,18 @@ async function buildApprovalView(runId: number, env: Env, ctx: ToolContext): Pro
     tone: status === 'pending' ? 'warning' : 'default',
     blocks: approvalBlocks({
       content: row.payload_text,
+      interaction_input_schema: row.interaction_input_schema,
       interaction_input: row.interaction_input,
       metadata: row.metadata,
     }),
     actions,
   };
+  if (canIssueApprovalCapability(row, status, ctx)) {
+    return attachMcpResultMeta(view, {
+      'lobu/approval-capability': issueApprovalCapability(row, ctx),
+    });
+  }
+  return view;
 }
 
 const renderLobuViewImpl = async (
@@ -324,4 +593,61 @@ export const renderLobuView = withValidatedArgs(
   'render_lobu_view',
   RenderLobuViewSchema,
   renderLobuViewImpl
+);
+
+type ResolveLobuApprovalArgs = Static<typeof ResolveLobuApprovalSchema>;
+
+const resolveLobuApprovalImpl = async (
+  args: ResolveLobuApprovalArgs,
+  env: Env,
+  ctx: ToolContext
+): Promise<LobuView> => {
+  const capability = readApprovalCapability(ctx.mcpAppApprovalCapability);
+  if (
+    capability.runId !== args.run_id ||
+    ctx.mcpAppsSupported !== true ||
+    capability.organizationId !== ctx.organizationId ||
+    capability.userId !== ctx.userId ||
+    capability.clientId !== ctx.clientId ||
+    capability.sessionId !== ctx.mcpSessionId ||
+    capability.expiresAt <= Date.now()
+  ) {
+    throw new ToolUserError('The MCP App approval capability is stale or does not match.', 403);
+  }
+
+  const current = await findApprovalRow(args.run_id, env, ctx);
+  if (current.interaction_status !== 'pending' || current.id !== capability.eventId) {
+    throw new ToolUserError('This approval capability is stale; the run is no longer pending.', 409);
+  }
+  if (belongsToApprovalWindow(current)) {
+    throw new ToolUserError('Batched proposals must be reviewed in Lobu.', 409);
+  }
+
+  // The encrypted capability proves a signed-in OAuth user deliberately used
+  // this app surface. The canonical approval handler still performs its own
+  // membership and run-owner/admin authority checks; clear only the non-human
+  // transport identities after the capability has been fully revalidated.
+  const humanContext: ToolContext = {
+    ...ctx,
+    agentId: null,
+    clientId: null,
+    mcpAppApprovalCapability: null,
+  };
+  const result = await manageOperations(
+    args.decision === 'approve'
+      ? { action: 'approve', run_id: args.run_id, ...(args.input ? { input: args.input } : {}) }
+      : { action: 'reject', run_id: args.run_id, ...(args.reason ? { reason: args.reason } : {}) },
+    env,
+    humanContext
+  );
+  if ('error' in result && typeof result.error === 'string') {
+    throw new ToolUserError(result.error, 409);
+  }
+  return buildApprovalView(args.run_id, env, ctx);
+};
+
+export const resolveLobuApproval = withValidatedArgs(
+  'resolve_lobu_approval',
+  ResolveLobuApprovalSchema,
+  resolveLobuApprovalImpl
 );

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -23,16 +23,18 @@ import { ADMIN_TOOLS } from './admin';
 import { ListMetricsSchema, listMetrics } from './admin/list_metrics';
 import { MetricSeriesSchema, metricSeries } from './admin/metric_series';
 import { QueryMetricSchema, queryMetric } from './admin/query_metric';
-import { QuerySqlSchema, querySql } from './admin/query_sql';
+import { QuerySqlResultSchema, QuerySqlSchema, querySql } from './admin/query_sql';
 import {
   LOBU_INTERACTION_RESOURCE_URI,
   LobuViewSchema,
   RenderLobuViewSchema,
+  ResolveLobuApprovalSchema,
   renderLobuView,
+  resolveLobuApproval,
 } from './mcp_app';
 import { ListOrganizationsSchema } from './organizations';
 import { ResolvePathResultSchema, ResolvePathSchema, resolvePath } from './resolve_path';
-import { SaveContentSchema, saveContent } from './save_content';
+import { SaveContentResultSchema, SaveContentSchema, saveContent } from './save_content';
 import {
   QuerySchema,
   querySdkScript,
@@ -116,6 +118,10 @@ export interface ToolContext {
   applyId?: string | null;
   /** Persistent MCP session id driving this call; null off the MCP transport. */
   mcpSessionId?: string | null;
+  /** True only for an MCP session that negotiated the standard Apps UI extension. */
+  mcpAppsSupported?: boolean | null;
+  /** Host-only encrypted token supplied by the Lobu MCP App for one approval click. */
+  mcpAppApprovalCapability?: string | null;
   /**
    * Server-derived side-effect mode for the run driving these tool calls,
    * carried as a signed worker-token claim. `capture` marks an eval replay:
@@ -200,6 +206,14 @@ const WRITE_WITHOUT_CONFIRM: ToolAnnotations = {
   idempotentHint: false,
 };
 
+const RICH_RESULT_MCP_META = {
+  ui: {
+    resourceUri: LOBU_INTERACTION_RESOURCE_URI,
+    visibility: ['model', 'app'],
+  },
+  'openai/outputTemplate': LOBU_INTERACTION_RESOURCE_URI,
+} as const;
+
 /** Tools advertised on MCP `tools/list` and external OpenAPI. */
 const AGENT_TOOLS: ToolDefinition[] = [
   // ─── Memory hot path — read ───────────────────────────────────────────────
@@ -217,6 +231,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     // Lobu's persisted workspace even though it never mutates anything.
     annotations: { ...READ_ONLY_OPEN_WORLD, title: 'Search memory' },
     securityScopes: ['mcp:read'],
+    mcpMeta: RICH_RESULT_MCP_META,
     handler: search,
   },
   {
@@ -224,8 +239,10 @@ const AGENT_TOOLS: ToolDefinition[] = [
     description:
       'Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.',
     inputSchema: SaveContentSchema,
+    outputSchema: SaveContentResultSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },
     securityScopes: ['mcp:write'],
+    mcpMeta: RICH_RESULT_MCP_META,
     handler: saveContent,
   },
   {
@@ -236,6 +253,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     outputSchema: SdkSearchResultSchema,
     annotations: { ...READ_ONLY, title: 'Search SDK docs' },
     securityScopes: ['mcp:read'],
+    mcpMeta: RICH_RESULT_MCP_META,
     handler: sdkSearch,
   },
   // ─── Power tools — TS scripting + raw SQL ─────────────────────────────────
@@ -248,6 +266,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
     // Read-only SDK methods include connector-backed live feed reads.
     annotations: { ...READ_ONLY_OPEN_WORLD, title: 'Query SDK (read-only)' },
     securityScopes: ['mcp:read'],
+    mcpMeta: RICH_RESULT_MCP_META,
     handler: querySdkScript,
   },
   {
@@ -255,8 +274,10 @@ const AGENT_TOOLS: ToolDefinition[] = [
     description:
       'Run a paginated, sortable, searchable read-only SQL query (member-safe). Table references auto-scope to the bound org. SELECT FROM events reads persisted/synced content only; virtual feeds are live-only and must be read explicitly with feed or via query_sdk client.feeds.readMany. Results may include coverage.suggested_virtual_feeds. Prefer client.metrics.query for declared measures; use client.query in query_sdk for simple one-shot SQL. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects to another member org.',
     inputSchema: QuerySqlSchema,
+    outputSchema: QuerySqlResultSchema,
     annotations: { ...READ_ONLY, title: 'Query SQL' },
     securityScopes: ['mcp:read'],
+    mcpMeta: RICH_RESULT_MCP_META,
     handler: querySql,
   },
   {
@@ -273,6 +294,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
       title: 'Run SDK',
     },
     securityScopes: ['mcp:write'],
+    mcpMeta: RICH_RESULT_MCP_META,
     handler: runSdkScript,
   },
 ];
@@ -292,14 +314,31 @@ const MCP_APP_TOOLS: ToolDefinition[] = [
     outputSchema: LobuViewSchema,
     annotations: { ...READ_ONLY, title: 'Render Lobu view' },
     securityScopes: ['mcp:read'],
+    mcpMeta: RICH_RESULT_MCP_META,
+    handler: renderLobuView,
+  },
+  {
+    name: 'resolve_lobu_approval',
+    description:
+      'Resolve the exact pending approval represented by this Lobu MCP App. This tool is app-only and requires the hidden, session-bound capability delivered with the review card.',
+    inputSchema: ResolveLobuApprovalSchema,
+    outputSchema: LobuViewSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+      idempotentHint: false,
+      title: 'Resolve Lobu approval',
+    },
+    securityScopes: ['mcp:write'],
     mcpMeta: {
       ui: {
         resourceUri: LOBU_INTERACTION_RESOURCE_URI,
-        visibility: ['model', 'app'],
+        visibility: ['app'],
       },
       'openai/outputTemplate': LOBU_INTERACTION_RESOURCE_URI,
     },
-    handler: renderLobuView,
+    handler: resolveLobuApproval,
   },
 ];
 

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -191,6 +191,25 @@ type SaveContentArgs = Static<typeof SaveContentSchema>;
 // Result Type
 // ============================================
 
+export const SaveContentResultSchema = Type.Object({
+  id: Type.Integer(),
+  entity_ids: Type.Array(Type.Integer()),
+  title: Type.Union([Type.String(), Type.Null()]),
+  semantic_type: Type.String(),
+  created_at: Type.String(),
+  supersedes_event_id: Type.Optional(Type.Integer()),
+  view_url: Type.Optional(Type.String()),
+  durable_at: Type.String(),
+  indexing_status: Type.Union([Type.Literal('pending'), Type.Literal('completed')]),
+  searchable: Type.Boolean(),
+  created: Type.Boolean(),
+  metadata: Type.Record(Type.String(), Type.Unknown()),
+  exact_read: Type.Object({
+    method: Type.Literal('client.knowledge.read'),
+    content_ids: Type.Tuple([Type.Integer()]),
+  }),
+});
+
 interface SaveContentResult {
   id: number;
   entity_ids: number[];


### PR DESCRIPTION
## Summary

- Render rich MCP App results for SQL, SDK execution, entities, events, json_template, media, memory, docs, forms, and generic structured output.
- Add App-only resource negotiation, safe session recovery, and encrypted single-use approval capabilities bound to the caller and pending event.
- Preserve plain MCP client fallbacks while pointing embedded results at merged Owletto PR #766 (`f8d14e85f96f878de7efefce908e3835a7773b2b`).

## Red-to-green review evidence

The independent fixer added regression cases that initially failed in three places:

- numeric form input submitted `"2"` instead of native `2`; conversion now follows the JSON schema
- an untouched boolean rendered false but submitted `{}`; initial values now include schema-defined false
- secret fields lost their usable schema and redacted initial values could be resubmitted; schemas now retain password-shaped fields while defaults/examples/enums and secret initial values are removed

Post-fix focused suites are green: Owletto 13/13 and server MCP result/resource tests 18/18.

## Validation

- `make pre-pr` — clean (workspace build, self-contained MCP App bundle, strict types, dead-code, format, exposed-surface, gateway gates)
- full server MCP integration — 13 files, 129 passed, 2 skipped
- Owletto build and TypeScript project build — passed
- Owletto full parallel suite — 1,295 passed; six route/chat timeouts under load; the exact six files pass 97/97 serially
- cross-origin browser E2E — SQL table/paging, SDK success/failure/dry-run/logs/trace, entities, events/json_template/media, approval, and schema forms; zero console errors or warnings

## Visual proof

https://htmlpreview.github.io/?https://gist.githubusercontent.com/buremba/88b2e2594f70afe5469940a4812148b1/raw/400f14099ffa7c25157b45788b09b5549beedb79/mcp-app-rich-rendering-review.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added richer MCP App results with UI metadata, forms, and structured output schemas.
  - Added secure approval workflows with approve/reject actions, encrypted short-lived capabilities, and persisted run-state handling.
  - Added structured result schemas for memory, SQL, and content-saving tools.

- **Bug Fixes**
  - Improved secret redaction in interaction forms while preserving password-field behavior.
  - Limited App-only approval features to compatible MCP App connections.
  - Added validation for stale, invalid, or rejected approval requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->