### PR TITLE
fix(mcp): render embedded results reliably

### DIFF
--- a/packages/server/src/__tests__/integration/tools/query-sql-pagination.test.ts
+++ b/packages/server/src/__tests__/integration/tools/query-sql-pagination.test.ts
@@ -17,7 +17,6 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { Env } from '../../../index';
 import { querySql } from '../../../tools/admin/query_sql';
 import type { ToolContext } from '../../../tools/registry';
 import { cleanupTestDatabase } from '../../setup/test-db';
@@ -63,6 +62,20 @@ describe('query_sql internal-path pagination contract', () => {
     // The internal window column must never leak into rows or columns.
     expect(res.columns.map((c) => c.name)).not.toContain('__lobu_total_count__');
     expect(Object.keys(res.rows[0])).not.toContain('__lobu_total_count__');
+  });
+
+  it('does not bind an unused organization parameter for table-free reads', async () => {
+    const res = await querySql(
+      { sql: 'SELECT generate_series(1, 25) AS row_number', limit: 50 },
+      {},
+      ownerCtx
+    );
+
+    expect(res.error).toBeUndefined();
+    expect(res.rows).toHaveLength(25);
+    expect(res.total_count).toBe(25);
+    expect(res.rows[0]).toEqual({ row_number: 1 });
+    expect(res.rows[24]).toEqual({ row_number: 25 });
   });
 
   it('keeps total_count exact on an out-of-range offset (empty page fallback)', async () => {


### PR DESCRIPTION
## Summary
- pin Owletto to the merged MCP renderer sequence #767 through #772 at db8c9730
- retain the exact generate_series(1, 25) regression on top of the stronger tableless SQL implementation already merged in #2616
- keep the production ChatGPT failure and final deployment proof in one exact-head rollout

## User-visible behavior
- native ChatGPT MCP apps render SQL tables, SDK results, entities, events, json_template components, charts, actions, Markdown and media, failures, dry-run effects, logs, and traces
- stored Markdown-valued bindings preserve headings, lists, and host-brokered links; smart fields such as very_high render as human labels
- charts preserve mixed-sign geometry, pie styling and highlights, sparkline trends, stacked-area selection, bounded dimensions, local timestamps, and categorical or date-only labels
- the read-only SQL used for live verification returns 25 rows and paginates from page 1 of 3 to page 2 of 3

## Verification
- exact SQL regression through the supported embedded Postgres harness: 5/5
- stronger tableless MCP sorting and pagination coverage is already on main via #2616
- Owletto focused result renderer: 10/10 in default and Pacific time
- Owletto TypeScript, Biome, and complete production build: pass
- MCP app: 898,781 HTML bytes; 926,113 resources/read JSON bytes; gzip 250.11 KB; self-contained
- prior parent gates: related server suites 98 pass; schema and pagination 24/24; MCP suites 22/22; full database integration exit 0
- prior local AppBridge and PostMessageTransport browser E2E covered pagination, SDK entities and events, json_template charts, tables and actions, Markdown and media links, approval resolution, failures, and dry-run effects
- exact rebased-head root gates are rerunning

## Independent review
Exact-head reviews drove fixes for serialized resource size, unbounded charts, timezone and categorical labels, full-range selection, stored-template CSS coverage, duplicate pie style alignment, network-capable SVG paints, local timestamp parity, canonical Markdown bindings, and smart table labels. The final Owletto #772 exact-head review found no actionable regression.

## Production reproduction
- ChatGPT invoked Lobu but the previous 2,037,520-byte template failed before iframe startup with Failed to fetch template
- table-free SQL failed with could not determine data type of parameter $1; #2616 now lazily allocates context parameters and this PR keeps the exact 25-row regression

Live ChatGPT proof will be repeated in a fresh conversation against the deployed squash SHA before handoff.
