### PR TITLE
fix(server): support tableless query_sql SELECTs

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -18,6 +18,13 @@ import {
 } from '../../setup/test-fixtures';
 import { get, mcpListTools, mcpToolsCall, post } from '../../setup/test-helpers';
 
+interface QuerySqlResult {
+  rows: Array<Record<string, unknown>>;
+  columns: Array<{ name: string; type: string }>;
+  total_count: number;
+  has_more: boolean;
+}
+
 describe('MCP query_sdk / run_sdk tool surface', () => {
   let token: string;
   let ownerOrgId: string;
@@ -135,6 +142,42 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     expect(rows[0].payload_data.sql_sha256).toEqual(expect.any(String));
     expect(rows[0].payload_data.sql_preview_redacted).toContain('SELECT id');
     expect(rows[0].payload_data).not.toHaveProperty('rows');
+  });
+
+  it('executes tableless SQL with sorting and pagination through MCP', async () => {
+    const result = await mcpToolsCall<QuerySqlResult>(
+      'query_sql',
+      {
+        sql: 'SELECT generate_series(1, 25) AS row_number',
+        sort_by: 'row_number',
+        sort_order: 'desc',
+        limit: 5,
+        offset: 5,
+      },
+      { token, orgSlug: ownerSlug }
+    );
+
+    expect(result.rows.map((row) => row.row_number)).toEqual([20, 19, 18, 17, 16]);
+    expect(result.columns).toEqual([{ name: 'row_number', type: 'integer' }]);
+    expect(result.total_count).toBe(25);
+    expect(result.has_more).toBe(true);
+  });
+
+  it('executes searched tableless CTEs without shifting parameter indexes', async () => {
+    const result = await mcpToolsCall<QuerySqlResult>(
+      'query_sql',
+      {
+        sql: "WITH labels(label) AS (VALUES ('Alpha'), ('Beta'), ('Gamma')) SELECT label FROM labels",
+        search_term: 'et',
+        search_columns: ['label'],
+      },
+      { token, orgSlug: ownerSlug }
+    );
+
+    expect(result.rows).toEqual([{ label: 'Beta' }]);
+    expect(result.columns).toEqual([{ name: 'label', type: 'text' }]);
+    expect(result.total_count).toBe(1);
+    expect(result.has_more).toBe(false);
   });
 
   it('hides write tools from anonymous visitors on a public /mcp/{slug}', async () => {

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, inject, it } from 'vitest';
-import { validateAndScopeQuery } from '../execute-data-sources';
+import { buildScopedQuery, validateAndScopeQuery } from '../execute-data-sources';
 import {
   buildColumnList,
   physicalTableFor,
@@ -132,6 +132,76 @@ describe('validateAndScopeQuery', () => {
     expect(scoped.sql).toMatch(
       /public\.entity_relationship_types rt LEFT JOIN public\.organization o.*rt\.deleted_at IS NULL.*rt\.organization_id = \$1 OR o\.visibility = 'public'/
     );
+  });
+
+  it('does not bind an unused organization parameter for tableless SELECTs', () => {
+    const sql = 'SELECT generate_series(1, 25) AS row_number';
+    const scoped = validateAndScopeQuery(sql, 'org_test', {
+      safeColumns: SAFE_COLUMN_DEFS,
+    });
+
+    expect(scoped.tableRefs).toEqual([]);
+    expect(scoped.sql).toBe(sql);
+    expect(scoped.params).toEqual([]);
+  });
+
+  it('keeps tableless params empty when an unused entity context is present', () => {
+    const scoped = buildScopedQuery('SELECT 1 AS value', [], {
+      organizationId: 'org_test',
+      entityIds: [42],
+    });
+
+    expect(scoped.sql).toBe('SELECT 1 AS value');
+    expect(scoped.params).toEqual([]);
+  });
+
+  it('binds repeated tableless entity placeholders once with compiler casts', () => {
+    const scoped = buildScopedQuery(
+      'SELECT {{entityId}} AS first_id, {{entityId}} AS second_id',
+      [],
+      {
+        organizationId: 'org_test',
+        entityIds: [42],
+      }
+    );
+
+    expect(scoped.sql).toBe('SELECT $1::bigint AS first_id, $1::bigint AS second_id');
+    expect(scoped.params).toEqual([42]);
+  });
+
+  it('binds organization context only when a tableless query references it', () => {
+    const scoped = buildScopedQuery('SELECT {{organizationId}} AS organization_id', [], {
+      organizationId: 'org_test',
+    });
+
+    expect(scoped.sql).toBe('SELECT $1 AS organization_id');
+    expect(scoped.params).toEqual(['org_test']);
+  });
+
+  it('binds tableless query context values with text casts', () => {
+    const scoped = buildScopedQuery('SELECT {{query.name}} AS name', [], {
+      organizationId: 'org_test',
+      query: { name: 'Alpha' },
+    });
+
+    expect(scoped.sql).toBe('SELECT $1::text AS name');
+    expect(scoped.params).toEqual(['Alpha']);
+  });
+
+  it('rejects unresolved placeholders in tableless queries', () => {
+    expect(() =>
+      buildScopedQuery('SELECT {{unknown}} AS value', [], {
+        organizationId: 'org_test',
+      })
+    ).toThrow('Unknown context variables: {{unknown}}');
+  });
+
+  it('rejects raw positional parameters in tableless queries', () => {
+    expect(() =>
+      buildScopedQuery('SELECT $1 AS value', [], {
+        organizationId: 'org_test',
+      })
+    ).toThrow('Positional parameters ($1, $2, ...) are not allowed');
   });
 });
 

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -405,10 +405,57 @@ export function buildScopedQuery(
   const params: unknown[] = [];
   let idx = 0;
 
-  // $1 = organizationId
-  idx++;
-  params.push(context.organizationId);
-  const orgP = `$${idx}`;
+  // Organization scoping is mandatory for table-backed queries, but tableless
+  // SELECTs bind it only when the query explicitly references the context value.
+  // This keeps the normal placeholder contract without sending unused params to
+  // postgres, which cannot infer their types.
+  let organizationP: string | undefined;
+  const bindOrganization = (): string => {
+    if (!organizationP) {
+      idx++;
+      params.push(context.organizationId);
+      organizationP = `$${idx}`;
+    }
+    return organizationP;
+  };
+  if (tableRefs.length > 0) bindOrganization();
+
+  // Run every query through the same context-placeholder compiler. Parameter
+  // allocation stays lazy so tableless SELECTs bind only values they reference.
+  let processedQuery = userQuery;
+  if (context.entityIds && context.entityIds.length > 0) {
+    let entityP: string | undefined;
+    processedQuery = processedQuery.replace(/\{\{entityId\}\}/g, () => {
+      if (!entityP) {
+        idx++;
+        params.push(context.entityIds![0]);
+        entityP = `$${idx}::bigint`;
+      }
+      return entityP;
+    });
+  }
+
+  processedQuery = processedQuery.replace(/\{\{organizationId\}\}/g, () =>
+    bindOrganization()
+  );
+
+  processedQuery = processedQuery.replace(/\{\{query\.(\w+)\}\}/g, (_match, paramName: string) => {
+    idx++;
+    params.push(context.query?.[paramName] ?? null);
+    return `$${idx}::text`;
+  });
+
+  const remaining = processedQuery.match(/\{\{(\w+(?:\.\w+)?)\}\}/g);
+  if (remaining) {
+    throw new Error(`Unknown context variables: ${remaining.join(', ')}`);
+  }
+
+  if (/\$\d+/.test(userQuery)) {
+    throw new Error('Positional parameters ($1, $2, ...) are not allowed in data source queries');
+  }
+
+  if (tableRefs.length === 0) return { sql: processedQuery, params };
+  const orgP = bindOrganization();
 
   // Per-user connection visibility (S0). Applied to EVERY CTE on this seam that
   // exposes connection-sourced event content — `events`, `event_classifications`
@@ -485,42 +532,6 @@ export function buildScopedQuery(
   // owned by the requesting user (mirrors manage_connections CRUD).
   const connectionRowVisibility = (alias: string): string =>
     ` ${compileConnectionRowVisibility(scope, alias)}`;
-
-  // {{entityId}} substitution — only allocates a param when the query uses it
-  let processedQuery = userQuery;
-  if (context.entityIds && context.entityIds.length > 0) {
-    let entityP: string | undefined;
-    processedQuery = processedQuery.replace(/\{\{entityId\}\}/g, () => {
-      if (!entityP) {
-        idx++;
-        params.push(context.entityIds![0]);
-        entityP = `$${idx}::bigint`;
-      }
-      return entityP;
-    });
-  }
-
-  // Remove {{organizationId}} — scoping is now automatic via CTEs
-  processedQuery = processedQuery.replace(/\{\{organizationId\}\}/g, orgP);
-
-  // Substitute {{query.paramName}} with parameterized values (NULL if missing).
-  // Cast to ::text so PostgreSQL can determine the type even when the value is NULL.
-  processedQuery = processedQuery.replace(/\{\{query\.(\w+)\}\}/g, (_match, paramName: string) => {
-    idx++;
-    params.push(context.query?.[paramName] ?? null);
-    return `$${idx}::text`;
-  });
-
-  // Reject any remaining unknown placeholders
-  const remaining = processedQuery.match(/\{\{(\w+(?:\.\w+)?)\}\}/g);
-  if (remaining) {
-    throw new Error(`Unknown context variables: ${remaining.join(', ')}`);
-  }
-
-  // Reject user-provided positional parameters (would conflict with ours)
-  if (/\$\d+/.test(userQuery)) {
-    throw new Error('Positional parameters ($1, $2, ...) are not allowed in data source queries');
-  }
 
   // Build CTEs
   const ctes: string[] = [];


### PR DESCRIPTION
Fix query_sql failures for tableless SELECTs such as SELECT generate_series(1, 25). buildScopedQuery previously bound an unused organization parameter, which PostgreSQL rejected because its type could not be inferred. Tableless queries now bind only parameters they actually reference.

Regression coverage verifies the original query produces no scoped parameters.

Tests: bunx vitest run packages/server/src/utils/__tests__/table-schema.test.ts packages/server/src/tools/admin/__tests__/query_sql.test.ts (19 passed, 2 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved SQL queries that do not reference tables, including sorting, pagination, and common table expressions.
  - Added support for substituting repeated entity placeholders consistently in queries.

- **Bug Fixes**
  - Prevented unnecessary organization and entity parameters from being added to tableless queries.
  - Improved query result metadata for searched tableless queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->