### PR TITLE
fix(calendar): virtual reads + isolated Google OAuth grants

### DIFF
--- a/packages/connectors/src/__tests__/google_calendar.test.ts
+++ b/packages/connectors/src/__tests__/google_calendar.test.ts
@@ -24,11 +24,14 @@ interface CalPage {
 /** Fake http client whose `raw()` serves a queue of events.list pages. */
 function fakeHttp(pages: CalPage[]) {
   const calls: Array<string | null> = [];
+  const urls: string[] = [];
   let i = 0;
   return {
     calls,
+    urls,
     client: {
       raw: async (url: string) => {
+        urls.push(url);
         const u = new URL(url);
         calls.push(u.searchParams.get('pageToken'));
         const page = pages[i++] ?? { items: [] };
@@ -314,5 +317,102 @@ describe('GoogleCalendarConnector incremental sync', () => {
     expect(calls[0]?.syncToken).toBe('STALE');
     expect(result.events).toHaveLength(1);
     expect(result.checkpoint.sync_token).toBe('FRESH');
+  });
+});
+
+describe('GoogleCalendarConnector virtual events feed', () => {
+  test('events is virtual by default while changes remains collected', () => {
+    const connector = new GoogleCalendarConnector();
+    expect(connector.definition.version).toBe('1.1.0');
+    expect(connector.definition.feeds.events.virtual).toBe(true);
+    expect(connector.definition.feeds.changes.virtual ?? false).toBe(false);
+    expect(Object.keys(connector.definition.feeds.changes.eventKinds)).toContain('calendar_event');
+  });
+
+  test('query reads live state with Calendar-native time window, q, pagination and offset', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client, calls, urls } = fakeHttp([
+      {
+        items: [
+          calEvent('a', '2026-01-01T10:00:00Z'),
+          calEvent('b', '2026-01-02T10:00:00Z'),
+        ],
+        nextPageToken: 'p2',
+      },
+      { items: [calEvent('c', '2026-01-03T10:00:00Z')] },
+    ]);
+    connector.client = () => client;
+
+    const result = await connector.query({
+      feedKey: 'events',
+      query: 'project alpha',
+      config: {
+        calendar_id: 'team@example.com',
+        lookback_days: 7,
+        lookahead_days: 14,
+        max_results: 10,
+      },
+      credentials: { accessToken: 'tok' },
+      limit: 2,
+      offset: 1,
+      sort: { column: 'start_time', order: 'asc' },
+    });
+
+    expect(result.rows.map((row: Record<string, unknown>) => row.id)).toEqual(['b', 'c']);
+    expect(calls).toEqual([null, 'p2']);
+    const first = new URL(urls[0]);
+    expect(first.pathname).toContain('/calendars/team%40example.com/events');
+    expect(first.searchParams.get('q')).toBe('project alpha');
+    expect(first.searchParams.get('singleEvents')).toBe('true');
+    expect(first.searchParams.get('orderBy')).toBe('startTime');
+    expect(first.searchParams.get('timeMin')).toBeTruthy();
+    expect(first.searchParams.get('timeMax')).toBeTruthy();
+  });
+
+  test('search composes the stored feed query with recall terms', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client, urls } = fakeHttp([{ items: [calEvent('a', '2026-01-01T10:00:00Z')] }]);
+    connector.client = () => client;
+
+    await connector.search({
+      feedKey: 'events',
+      terms: ['alice', 'design'],
+      config: { query: 'team', max_results: 10 },
+      credentials: { accessToken: 'tok' },
+      limit: 5,
+      offset: 0,
+    });
+
+    expect(new URL(urls[0]).searchParams.get('q')).toBe('team alice design');
+  });
+});
+
+
+describe('GoogleCalendarConnector durable changes feed', () => {
+  test('preserves cancellations and timestamps them at the provider change time', async () => {
+    const connector = new GoogleCalendarConnector();
+    const changedAt = '2026-08-10T00:12:34.000Z';
+    const cancelled = {
+      ...calEvent('cancelled-1', '2026-08-12T10:00:00Z'),
+      status: 'cancelled',
+      summary: undefined,
+      updated: changedAt,
+    };
+    const { client } = fakeHttp([{ items: [cancelled], nextSyncToken: 'NEXT' }]);
+    connector.client = () => client;
+
+    const result = await connector.sync({
+      feedKey: 'changes',
+      config: { calendar_id: 'primary', max_results: 100 },
+      credentials: { accessToken: 'tok' },
+      checkpoint: null,
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.origin_id).toBe('cancelled-1');
+    expect(result.events[0]?.occurred_at.toISOString()).toBe(changedAt);
+    expect(result.events[0]?.metadata?.status).toBe('cancelled');
+    expect(result.events[0]?.metadata?.change_type).toBe('cancelled');
+    expect(result.checkpoint.sync_token).toBe('NEXT');
   });
 });

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -14,6 +14,9 @@ import {
   type EventEnvelope,
   type HttpClient,
   paginateByCursor,
+  type QueryContext,
+  type QueryResult,
+  type SearchContext,
   type SyncContext,
   type SyncResult,
 } from '@lobu/connector-sdk';
@@ -59,6 +62,30 @@ interface CalendarCheckpoint {
   last_sync_at?: string;
 }
 
+interface CalendarConfig extends Record<string, unknown> {
+  calendar_id?: string;
+  query?: string;
+  lookback_days?: number;
+  lookahead_days?: number;
+  max_results?: number;
+}
+
+const CALENDAR_EVENT_COLUMNS = [
+  { name: 'id', type: 'text' },
+  { name: 'summary', type: 'text' },
+  { name: 'description', type: 'text' },
+  { name: 'location', type: 'text' },
+  { name: 'status', type: 'text' },
+  { name: 'start_time', type: 'text' },
+  { name: 'end_time', type: 'text' },
+  { name: 'all_day', type: 'boolean' },
+  { name: 'organizer', type: 'text' },
+  { name: 'attendee_count', type: 'number' },
+  { name: 'created_at', type: 'text' },
+  { name: 'updated_at', type: 'text' },
+  { name: 'url', type: 'text' },
+] as const;
+
 /**
  * Does this events.list failure mean "the syncToken itself is no longer
  * usable" (as opposed to "your credentials are wrong")?
@@ -98,7 +125,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     key: 'google.calendar',
     name: 'Google Calendar',
     description: 'Syncs calendar events from Google Calendar and supports creating new events.',
-    version: '1.0.0',
+    version: '1.1.0',
     faviconDomain: 'calendar.google.com',
     authSchema: {
       methods: [
@@ -123,39 +150,80 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
         key: 'events',
         name: 'Events',
         requiredScopes: ['https://www.googleapis.com/auth/calendar.readonly'],
-        description: 'Syncs calendar events from Google Calendar.',
+        description:
+          'Live Google Calendar events (virtual by default); reads current state directly from Google without copying events into Lobu.',
+        virtual: true,
         configSchema: {
           type: 'object',
           properties: {
             calendar_id: {
               type: 'string',
               default: 'primary',
-              description: 'Calendar ID to sync (default: "primary").',
+              description: 'Calendar ID to read (default: "primary").',
+            },
+            query: {
+              type: 'string',
+              description: 'Optional Google Calendar free-text query applied to live reads.',
             },
             lookback_days: {
-              type: 'integer',
-              minimum: 1,
-              maximum: 365,
-              default: 30,
-              description: 'Number of days to look back on initial sync.',
+              type: 'integer', minimum: 1, maximum: 365, default: 30,
+              description: 'Number of past days included in live reads.',
+            },
+            lookahead_days: {
+              type: 'integer', minimum: 1, maximum: 730, default: 365,
+              description: 'Number of future days included in live reads.',
             },
             max_results: {
-              type: 'integer',
-              minimum: 1,
-              maximum: 2500,
-              default: 100,
-              description: 'Maximum events to fetch per sync.',
+              type: 'integer', minimum: 1, maximum: 2500, default: 100,
+              description: 'Maximum events returned per live read.',
             },
           },
         },
         eventKinds: {
-          // `calendar_event`, not `event`: microsoft_outlook and the apple.calendar
-          // device connector both emit this kind, and consumers filter on the shared
-          // vocabulary. This key and the `origin_type` in toEventEnvelope must stay
-          // identical — `event_kinds` is a closed allowlist once non-empty, so a
-          // one-sided rename makes the server reject every write from this feed.
           calendar_event: {
             description: 'A Google Calendar event',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                status: { type: 'string' },
+                location: { type: 'string' },
+                organizer: { type: 'string' },
+                attendee_count: { type: 'number' },
+                start_time: { type: 'string' },
+                end_time: { type: 'string' },
+                all_day: { type: 'boolean' },
+              },
+            },
+          },
+        },
+      },
+      changes: {
+        key: 'changes',
+        name: 'Calendar changes',
+        requiredScopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+        description:
+          'Durable incremental Google Calendar changes for Behaviors and event-driven workflows. Collected only when explicitly created.',
+        configSchema: {
+          type: 'object',
+          properties: {
+            calendar_id: {
+              type: 'string',
+              default: 'primary',
+              description: 'Calendar ID to watch (default: "primary").',
+            },
+            lookback_days: {
+              type: 'integer', minimum: 1, maximum: 365, default: 30,
+              description: 'Number of days to look back on initial collection.',
+            },
+            max_results: {
+              type: 'integer', minimum: 1, maximum: 2500, default: 100,
+              description: 'Maximum change events to persist per collection run.',
+            },
+          },
+        },
+        eventKinds: {
+          calendar_event: {
+            description: 'A Google Calendar event change',
             metadataSchema: {
               type: 'object',
               properties: {
@@ -242,7 +310,8 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       },
       get_event: {
         key: 'get_event',
-		kind: 'read',
+        kind: 'read',
+        requiresApproval: false,
         name: 'Get Event',
         description: 'Get full event details.',
         inputSchema: {
@@ -263,6 +332,121 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
   private readonly BASE_URL = 'https://www.googleapis.com/calendar/v3';
 
   // -------------------------------------------------------------------------
+  // Live pushdown (virtual events feed) — current state, never persisted.
+  // -------------------------------------------------------------------------
+
+  async query(ctx: QueryContext<CalendarConfig>): Promise<QueryResult> {
+    return this.liveRead(ctx, []);
+  }
+
+  async search(ctx: SearchContext<CalendarConfig>): Promise<QueryResult> {
+    return this.liveRead(ctx, ctx.terms ?? []);
+  }
+
+  private async liveRead(
+    ctx: QueryContext<CalendarConfig>,
+    terms: string[]
+  ): Promise<QueryResult> {
+    const token = ctx.credentials?.accessToken;
+    if (!token) {
+      throw new Error('Google Calendar virtual-feed reads require Google OAuth credentials.');
+    }
+    if (ctx.feedKey && ctx.feedKey !== 'events') {
+      throw new Error(
+        "Google Calendar live queries are only supported for the virtual events feed; got '" +
+          ctx.feedKey +
+          "'."
+      );
+    }
+    if (ctx.sort && !(ctx.sort.column === 'start_time' && ctx.sort.order === 'asc')) {
+      throw new Error(
+        "Google Calendar virtual feed only supports sort {column:'start_time', order:'asc'}."
+      );
+    }
+
+    const calendarId = ctx.config.calendar_id || 'primary';
+    const lookbackDays = ctx.config.lookback_days ?? 30;
+    const lookaheadDays = ctx.config.lookahead_days ?? 365;
+    const requestedLimit = Math.min(Math.max(Math.trunc(ctx.limit ?? 50), 1), 2500);
+    const configuredLimit = Math.min(
+      Math.max(Math.trunc(ctx.config.max_results ?? 100), 1),
+      2500
+    );
+    const limit = Math.min(requestedLimit, configuredLimit);
+    const offset = Math.max(Math.trunc(ctx.offset ?? 0), 0);
+    const want = offset + limit;
+    const maxReachable = 250 * 200;
+    if (want > maxReachable) {
+      throw new Error(
+        'Google Calendar virtual feed offset+limit (' +
+          want +
+          ') exceeds max reachable depth ' +
+          maxReachable +
+          '. Narrow the query or lower offset.'
+      );
+    }
+
+    const timeMin = new Date();
+    timeMin.setDate(timeMin.getDate() - lookbackDays);
+    const timeMax = new Date();
+    timeMax.setDate(timeMax.getDate() + lookaheadDays);
+
+    const baseQuery = (ctx.query || ctx.config.query || '').trim();
+    const queryParts = [baseQuery, ...terms.map((term) => term.trim())].filter(Boolean);
+    const q = queryParts.join(' ');
+    const http = this.client(token);
+    const rows: Record<string, unknown>[] = [];
+    let pageToken: string | undefined;
+    let pages = 0;
+
+    while (rows.length < want && pages < 200) {
+      pages += 1;
+      const params = new URLSearchParams({
+        maxResults: String(Math.min(250, Math.max(1, want - rows.length))),
+        orderBy: 'startTime',
+        singleEvents: 'true',
+        timeMin: timeMin.toISOString(),
+        timeMax: timeMax.toISOString(),
+      });
+      if (q) params.set('q', q);
+      if (pageToken) params.set('pageToken', pageToken);
+
+      const url =
+        this.BASE_URL +
+        '/calendars/' +
+        encodeURIComponent(calendarId) +
+        '/events?' +
+        params.toString();
+      const response = await http.raw(url);
+      if (!response.ok) {
+        throw new Error(
+          'Calendar events.list error (' + response.status + '): ' + (await response.text())
+        );
+      }
+      const data = (await response.json()) as CalendarEventListResponse;
+      for (const event of data.items ?? []) {
+        const row = this.calendarEventToRow(event);
+        if (row) rows.push(row);
+      }
+      if (!data.nextPageToken || (data.items ?? []).length === 0) break;
+      pageToken = data.nextPageToken;
+    }
+
+    if (rows.length < want && pageToken && pages >= 200) {
+      throw new Error(
+        'Google Calendar virtual feed pagination depth cap hit before offset+limit (' +
+          want +
+          '). Narrow the query or lower offset.'
+      );
+    }
+
+    return {
+      rows: rows.slice(offset, offset + limit),
+      columns: [...CALENDAR_EVENT_COLUMNS],
+    };
+  }
+
+  // -------------------------------------------------------------------------
   // sync
   // -------------------------------------------------------------------------
 
@@ -279,10 +463,17 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
     const checkpoint = (ctx.checkpoint ?? {}) as CalendarCheckpoint;
     const events: EventEnvelope[] = [];
+    const durableChanges = ctx.feedKey === 'changes';
 
     // Try incremental sync with syncToken first
     if (checkpoint.sync_token) {
-      const result = await this.syncWithToken(http, calendarId, checkpoint.sync_token, maxResults);
+      const result = await this.syncWithToken(
+        http,
+        calendarId,
+        checkpoint.sync_token,
+        maxResults,
+        durableChanges
+      );
       if (result) {
         return this.buildResult(result.events, result.nextSyncToken, result.events.length);
       }
@@ -348,7 +539,9 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     for await (const items of pages) {
       for (const calEvent of items) {
         if (events.length >= maxResults) break;
-        const envelope = this.calendarEventToEnvelope(calEvent);
+        const envelope = durableChanges
+          ? this.calendarEventToChangeEnvelope(calEvent)
+          : this.calendarEventToEnvelope(calEvent);
         if (envelope) events.push(envelope);
       }
     }
@@ -400,7 +593,8 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     http: HttpClient,
     calendarId: string,
     syncToken: string,
-    maxResults: number
+    maxResults: number,
+    durableChanges: boolean
   ): Promise<{ events: EventEnvelope[]; nextSyncToken?: string } | null> {
     const events: EventEnvelope[] = [];
     let nextSyncToken: string | undefined;
@@ -446,7 +640,9 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
     for await (const items of pages) {
       for (const calEvent of items) {
-        const envelope = this.calendarEventToEnvelope(calEvent);
+        const envelope = durableChanges
+          ? this.calendarEventToChangeEnvelope(calEvent)
+          : this.calendarEventToEnvelope(calEvent);
         if (envelope) events.push(envelope);
       }
     }
@@ -624,6 +820,65 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
+
+  private calendarEventToRow(calEvent: CalendarEvent): Record<string, unknown> | null {
+    if (calEvent.status === 'cancelled') return null;
+    const startTime = calEvent.start.dateTime || calEvent.start.date;
+    if (!startTime) return null;
+    const endTime = calEvent.end.dateTime || calEvent.end.date || '';
+    return {
+      id: calEvent.id,
+      summary: calEvent.summary || '(no title)',
+      description: calEvent.description || '',
+      location: calEvent.location || '',
+      status: calEvent.status,
+      start_time: startTime,
+      end_time: endTime,
+      all_day: !calEvent.start.dateTime,
+      organizer: calEvent.organizer?.displayName || calEvent.organizer?.email || '',
+      attendee_count: calEvent.attendees?.length ?? 0,
+      created_at: calEvent.created,
+      updated_at: calEvent.updated,
+      url: calEvent.htmlLink,
+    };
+  }
+
+  private calendarEventToChangeEnvelope(calEvent: CalendarEvent): EventEnvelope {
+    const startTime = calEvent.start?.dateTime || calEvent.start?.date;
+    const endTime = calEvent.end?.dateTime || calEvent.end?.date;
+    const changedAt = new Date(calEvent.updated || startTime || Date.now());
+    const occurredAt = Number.isNaN(changedAt.getTime()) ? new Date() : changedAt;
+    const isCancelled = calEvent.status === 'cancelled';
+
+    const parts: string[] = [];
+    if (calEvent.description) {
+      parts.push(calEvent.description);
+    }
+    if (calEvent.attendees && calEvent.attendees.length > 0) {
+      const attendeeList = calEvent.attendees.map((a) => a.displayName || a.email).join(', ');
+      parts.push(`Attendees: ${attendeeList}`);
+    }
+
+    return {
+      origin_id: calEvent.id,
+      title: calEvent.summary || (isCancelled ? '(cancelled calendar event)' : '(no title)'),
+      payload_text: parts.join('\n\n'),
+      author_name: calEvent.organizer?.displayName || calEvent.organizer?.email,
+      source_url: calEvent.htmlLink,
+      occurred_at: occurredAt,
+      origin_type: 'calendar_event',
+      metadata: {
+        status: calEvent.status,
+        change_type: isCancelled ? 'cancelled' : 'upserted',
+        ...(calEvent.location ? { location: calEvent.location } : {}),
+        ...(calEvent.organizer?.email ? { organizer: calEvent.organizer.email } : {}),
+        attendee_count: calEvent.attendees?.length ?? 0,
+        ...(startTime ? { start_time: startTime } : {}),
+        ...(endTime ? { end_time: endTime } : {}),
+        all_day: Boolean(startTime && !calEvent.start?.dateTime),
+      },
+    };
+  }
 
   private calendarEventToEnvelope(calEvent: CalendarEvent): EventEnvelope | null {
     if (calEvent.status === 'cancelled') return null;

--- a/packages/server/src/__tests__/integration/connectors/connection-visibility-oauth-callback.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-visibility-oauth-callback.test.ts
@@ -40,14 +40,19 @@ describe('OAuth callback downgrades a fresh personal connection to private (e2e)
     // Local fake OAuth provider: real HTTP endpoints the callback exchanges
     // against (no module mocking — safe under isolate:false).
     const provider = new Hono();
-    provider.post('/token', (c) =>
-      c.json({
-        access_token: 'fake-access-token',
-        refresh_token: 'fake-refresh-token',
+    provider.post('/token', async (c) => {
+      const body = await c.req.parseBody();
+      const code = String(body.code ?? '');
+      const calendar = code === 'calendar-code';
+      return c.json({
+        access_token: 'fake-access-token-' + code,
+        refresh_token: 'fake-refresh-token-' + code,
         expires_in: 3600,
-        scope: 'https://www.googleapis.com/auth/gmail.readonly',
-      })
-    );
+        scope: calendar
+          ? 'https://www.googleapis.com/auth/calendar.readonly'
+          : 'https://www.googleapis.com/auth/gmail.readonly',
+      });
+    });
     provider.get('/userinfo', (c) =>
       c.json({ email: 'owner@example.com', name: 'Owner D', id: 'acct-123' })
     );
@@ -152,4 +157,264 @@ describe('OAuth callback downgrades a fresh personal connection to private (e2e)
     delete process.env.CBOAUTH_CLIENT_ID;
     delete process.env.CBOAUTH_CLIENT_SECRET;
   });
+
+  it('keeps same-provider connector OAuth grants isolated for the same upstream account', async () => {
+    process.env.CBOAUTH_CLIENT_ID = 'env-id';
+    process.env.CBOAUTH_CLIENT_SECRET = 'env-secret';
+    const org = await createTestOrganization({ name: 'Grant Isolation Org' });
+    const user = await createTestUser({ name: 'Grant Isolation User' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const sql = getTestDb();
+
+    const grants = [
+      {
+        connectorKey: 'cb.calendar',
+        slug: 'calendar-account',
+        scope: 'https://www.googleapis.com/auth/calendar.readonly',
+        code: 'calendar-code',
+      },
+      {
+        connectorKey: 'cb.gmail',
+        slug: 'gmail-account',
+        scope: 'https://www.googleapis.com/auth/gmail.readonly',
+        code: 'gmail-code',
+      },
+    ];
+
+    for (const grant of grants) {
+      await createTestConnectorDefinition({
+        key: grant.connectorKey,
+        name: grant.connectorKey,
+        organization_id: org.id,
+        auth_schema: {
+          methods: [
+            {
+              type: 'oauth',
+              provider: 'cboauth',
+              requiredScopes: [grant.scope],
+              clientIdKey: 'CBOAUTH_CLIENT_ID',
+              clientSecretKey: 'CBOAUTH_CLIENT_SECRET',
+              tokenUrl: providerTokenUrl,
+              userinfoUrl: providerUserinfoUrl,
+            },
+          ],
+        },
+        feeds_schema: { items: {} },
+      });
+
+      const [connection] = (await sql`
+        INSERT INTO connections (
+          organization_id, connector_key, slug, display_name, status, visibility, created_by
+        )
+        VALUES (
+          ${org.id}, ${grant.connectorKey}, ${grant.connectorKey}, ${grant.connectorKey},
+          'pending_auth', 'org', ${user.id}
+        )
+        RETURNING id
+      `) as Array<{ id: number }>;
+
+      const tokenRow = await createConnectToken({
+        connectionId: connection.id,
+        organizationId: org.id,
+        connectorKey: grant.connectorKey,
+        authType: 'oauth',
+        createdBy: user.id,
+        authConfig: {
+          provider: 'cboauth',
+          clientIdKey: 'CBOAUTH_CLIENT_ID',
+          clientSecretKey: 'CBOAUTH_CLIENT_SECRET',
+          tokenUrl: providerTokenUrl,
+          userinfoUrl: providerUserinfoUrl,
+          requestedScopes: [grant.scope],
+          pendingProfileMeta: {
+            displayName: grant.connectorKey,
+            slug: grant.slug,
+            connectorKey: grant.connectorKey,
+            provider: 'cboauth',
+          },
+        },
+      });
+
+      const res = await connectRoutes.request(
+        '/oauth/callback?state=' + encodeURIComponent(tokenRow.token) + '&code=' + grant.code
+      );
+      expect(res.status).toBeGreaterThanOrEqual(200);
+      expect(res.status).toBeLessThan(400);
+    }
+
+    const accounts = (await sql`
+      SELECT
+        ap.connector_key,
+        ap.account_id,
+        a."accountId" AS provider_account_id,
+        a.scope,
+        a."accessToken" AS access_token
+      FROM auth_profiles ap
+      JOIN account a ON a.id = ap.account_id
+      WHERE ap.organization_id = ${org.id}
+        AND ap.connector_key IN ('cb.calendar', 'cb.gmail')
+      ORDER BY ap.connector_key
+    `) as Array<{
+      connector_key: string;
+      account_id: string;
+      provider_account_id: string;
+      scope: string | null;
+      access_token: string | null;
+    }>;
+
+    expect(accounts).toHaveLength(2);
+    expect(accounts[0]?.account_id).not.toBe(accounts[1]?.account_id);
+    for (const account of accounts) {
+      expect(account.provider_account_id.startsWith('lobu-connector:')).toBe(true);
+    }
+    expect(accounts.find((row) => row.connector_key === 'cb.calendar')?.scope).toBe(
+      'https://www.googleapis.com/auth/calendar.readonly'
+    );
+    expect(accounts.find((row) => row.connector_key === 'cb.gmail')?.scope).toBe(
+      'https://www.googleapis.com/auth/gmail.readonly'
+    );
+    expect(accounts.find((row) => row.connector_key === 'cb.calendar')?.access_token).toBe(
+      'fake-access-token-calendar-code'
+    );
+    expect(accounts.find((row) => row.connector_key === 'cb.gmail')?.access_token).toBe(
+      'fake-access-token-gmail-code'
+    );
+
+    delete process.env.CBOAUTH_CLIENT_ID;
+    delete process.env.CBOAUTH_CLIENT_SECRET;
+  });
+  it('migrates a legacy shared provider account to an isolated connector grant on reauth', async () => {
+    process.env.CBOAUTH_CLIENT_ID = 'env-id';
+    process.env.CBOAUTH_CLIENT_SECRET = 'env-secret';
+    const org = await createTestOrganization({ name: 'Legacy Grant Repair Org' });
+    const user = await createTestUser({ name: 'Legacy Grant Repair User' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const sql = getTestDb();
+    const calendarScope = 'https://www.googleapis.com/auth/calendar.readonly';
+
+    await createTestConnectorDefinition({
+      key: 'cb.calendar',
+      name: 'CB Calendar',
+      organization_id: org.id,
+      auth_schema: {
+        methods: [
+          {
+            type: 'oauth',
+            provider: 'cboauth',
+            requiredScopes: [calendarScope],
+            clientIdKey: 'CBOAUTH_CLIENT_ID',
+            clientSecretKey: 'CBOAUTH_CLIENT_SECRET',
+            tokenUrl: providerTokenUrl,
+            userinfoUrl: providerUserinfoUrl,
+          },
+        ],
+      },
+      feeds_schema: { items: {} },
+    });
+
+    const legacyAccountId = `legacy-google-${org.id}`;
+    await sql`
+      INSERT INTO account (
+        id, "accountId", "providerId", "userId",
+        "accessToken", "refreshToken", "accessTokenExpiresAt",
+        scope, "createdAt", "updatedAt"
+      ) VALUES (
+        ${legacyAccountId}, 'acct-123', 'cboauth', ${user.id},
+        'gmail-overwrite-token', 'gmail-overwrite-refresh',
+        ${new Date(Date.now() + 3600_000).toISOString()},
+        'https://www.googleapis.com/auth/gmail.readonly',
+        NOW(), NOW()
+      )
+    `;
+
+    const [profile] = (await sql`
+      INSERT INTO auth_profiles (
+        organization_id, slug, display_name, connector_key, profile_kind,
+        status, auth_data, account_id, provider, created_by
+      ) VALUES (
+        ${org.id}, 'legacy-calendar-account', 'Legacy Calendar', 'cb.calendar',
+        'oauth_account', 'active',
+        ${sql.json({
+          requested_scopes: [calendarScope],
+          granted_scopes: [calendarScope],
+          identity: { id: 'acct-123', email: 'owner@example.com' },
+        })},
+        ${legacyAccountId}, 'cboauth', ${user.id}
+      )
+      RETURNING id
+    `) as Array<{ id: number }>;
+
+    const [connection] = (await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status, visibility,
+        account_id, auth_profile_id, created_by
+      ) VALUES (
+        ${org.id}, 'cb.calendar', 'legacy-calendar', 'Legacy Calendar',
+        'active', 'private', ${legacyAccountId}, ${profile.id}, ${user.id}
+      )
+      RETURNING id
+    `) as Array<{ id: number }>;
+
+    const tokenRow = await createConnectToken({
+      authProfileId: profile.id,
+      organizationId: org.id,
+      connectorKey: 'cb.calendar',
+      authType: 'oauth',
+      createdBy: user.id,
+      authConfig: {
+        provider: 'cboauth',
+        clientIdKey: 'CBOAUTH_CLIENT_ID',
+        clientSecretKey: 'CBOAUTH_CLIENT_SECRET',
+        tokenUrl: providerTokenUrl,
+        userinfoUrl: providerUserinfoUrl,
+        requestedScopes: [calendarScope],
+      },
+    });
+
+    const res = await connectRoutes.request(
+      '/oauth/callback?state=' +
+        encodeURIComponent(tokenRow.token) +
+        '&code=calendar-code'
+    );
+    expect(res.status).toBeGreaterThanOrEqual(200);
+    expect(res.status).toBeLessThan(400);
+
+    const [after] = (await sql`
+      SELECT
+        ap.account_id,
+        a."accountId" AS provider_account_id,
+        a.scope,
+        a."accessToken" AS access_token,
+        c.account_id AS connection_account_id
+      FROM auth_profiles ap
+      JOIN account a ON a.id = ap.account_id
+      JOIN connections c ON c.auth_profile_id = ap.id
+      WHERE ap.id = ${profile.id}
+        AND c.id = ${connection.id}
+    `) as Array<{
+      account_id: string;
+      provider_account_id: string;
+      scope: string | null;
+      access_token: string | null;
+      connection_account_id: string | null;
+    }>;
+
+    expect(after.account_id).not.toBe(legacyAccountId);
+    expect(after.provider_account_id.startsWith('lobu-connector:')).toBe(true);
+    expect(after.scope).toBe(calendarScope);
+    expect(after.access_token).toBe('fake-access-token-calendar-code');
+    expect(after.connection_account_id).toBe(after.account_id);
+
+    const [legacy] = (await sql`
+      SELECT scope, "accessToken" AS access_token
+      FROM account
+      WHERE id = ${legacyAccountId}
+    `) as Array<{ scope: string | null; access_token: string | null }>;
+    expect(legacy.scope).toBe('https://www.googleapis.com/auth/gmail.readonly');
+    expect(legacy.access_token).toBe('gmail-overwrite-token');
+
+    delete process.env.CBOAUTH_CLIENT_ID;
+    delete process.env.CBOAUTH_CLIENT_SECRET;
+  });
+
 });

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -773,11 +773,34 @@ async function handleOAuthCallback(
   let resolvedAuthProfileId = tokenRow.auth_profile_id;
 
   await sql.begin(async (tx) => {
-    const tokenTarget = tokenRow.connection_id ?? tokenRow.auth_profile_id ?? Date.now();
-    const accountId = `connect_${tokenTarget}_${Date.now()}`;
+    const tokenTarget = tokenRow.connection_id ?? tokenRow.auth_profile_id ?? tokenRow.id;
+    const generatedAccountId = `connect_${tokenTarget}_${Date.now()}`;
     const expiresAt = tokens.expiresIn
       ? new Date(Date.now() + tokens.expiresIn * 1000).toISOString()
       : null;
+
+    // Connector OAuth grants are not social-login identities. Different Lobu
+    // connectors can authorize the same upstream user with different scopes and
+    // refresh tokens (for example Gmail and Calendar). Keying these rows by the
+    // provider's user id makes one connector overwrite another connector's grant.
+    // Reuse an already-isolated connector account on reauth; legacy shared rows
+    // are intentionally NOT reused so the next successful reauth repairs them.
+    let grantAccountIdentity: string | null = null;
+    if (resolvedAuthProfileId) {
+      const existingGrantRows = (await tx`
+        SELECT a."accountId"
+        FROM auth_profiles ap
+        JOIN account a ON a.id = ap.account_id
+        WHERE ap.id = ${resolvedAuthProfileId}
+          AND ap.organization_id = ${tokenRow.organization_id}
+        LIMIT 1
+      `) as Array<{ accountId: string }>;
+      const existingIdentity = existingGrantRows[0]?.accountId;
+      if (existingIdentity?.startsWith('lobu-connector:')) {
+        grantAccountIdentity = existingIdentity;
+      }
+    }
+    grantAccountIdentity ??= `lobu-connector:${tokenRow.organization_id}:${tokenRow.connector_key}:${tokenTarget}`;
 
     const upsertResult = await tx`
       INSERT INTO account (
@@ -785,8 +808,8 @@ async function handleOAuthCallback(
         "accessToken", "refreshToken", "accessTokenExpiresAt",
         scope, "createdAt", "updatedAt"
       ) VALUES (
-        ${accountId},
-        ${userInfo?.id ?? accountId},
+        ${generatedAccountId},
+        ${grantAccountIdentity},
         ${authConfig!.provider},
         ${actorUserId},
         ${tokens.accessToken},

--- a/packages/server/src/utils/oauth-connection-state.ts
+++ b/packages/server/src/utils/oauth-connection-state.ts
@@ -18,7 +18,7 @@ export async function syncOAuthConnectionsForAuthProfile(
   if (!authProfile.account_id) {
     await sql`
       UPDATE connections
-      SET status = 'pending_auth', updated_at = NOW()
+      SET status = 'pending_auth', account_id = NULL, updated_at = NOW()
       WHERE organization_id = ${organizationId}
         AND auth_profile_id = ${authProfileId}
         AND deleted_at IS NULL
@@ -141,7 +141,9 @@ export async function syncOAuthConnectionsForAuthProfile(
         : 'pending_auth';
     await sql`
       UPDATE connections
-      SET status = ${nextConnectionStatus}, updated_at = NOW()
+      SET status = ${nextConnectionStatus},
+          account_id = ${authProfile.account_id},
+          updated_at = NOW()
       WHERE id = ${row.id}
     `;
   }


### PR DESCRIPTION
## What changed
- make Google Calendar `events` virtual by default and query current state live from Google
- add explicit collected `changes` feed for durable Behavior/event-driven workflows
- preserve cancellations and timestamp durable changes at Google `updated` time
- bump Calendar connector to 1.1.0 so executable source is retained/deployed correctly
- isolate connector OAuth grants instead of keying mutable tokens by the shared upstream Google user id
- migrate legacy shared OAuth rows to connector-owned rows on reauth and keep bound connections in sync

## Root cause
Gmail and Calendar OAuth callbacks for the same Google identity were upserting the same Better Auth `account` row on `(providerId, accountId)`. A later Gmail grant could overwrite Calendar's access/refresh token and scope while Calendar auth-profile metadata still reported `calendar.readonly` as granted. Production timing matches this exactly: Calendar succeeded at 02:52, Gmail profile updated at 02:55, Calendar first failed with `ACCESS_TOKEN_SCOPE_INSUFFICIENT` at 04:52.

Production also still retains the old Google Calendar 1.0.0 executable source despite later source changes, because the connector version was never bumped.

## Validation
- Google Calendar connector tests: 12/12 pass
- OAuth callback integration against real Postgres: 3/3 pass, including cross-connector grant isolation and legacy-row migration
- server typecheck: pass
- Calendar-specific connector typecheck errors: none (package still has unrelated pre-existing errors in other connectors)
- `git diff --check`: clean
