### PR TITLE
fix(behaviors): bound SQL-backed context reads

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/behavior-mode-source-limit.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/behavior-mode-source-limit.test.ts
@@ -1,5 +1,6 @@
 /**
- * Behavior-mode `limit` must bound EVERY event source, not just the primary one.
+ * Behavior-mode `limit` must bound every SQL-backed source, not just the
+ * primary event source.
  *
  * `queryContentData` builds its page descriptor with a hardcoded
  * `sourceName: 'content'`, and `wrapQuery` used to apply the LIMIT only when
@@ -13,9 +14,9 @@
  * the output cap before the script could filter anything — `limit: 1` and
  * `limit: 5` failed identically.
  *
- * The guard: seed more rows than the limit into two distinct feeds, ask for
- * fewer, and require BOTH sources to be capped and to report their truncation
- * through `sources_page`.
+ * The guards cover both failure classes: secondary event sources and
+ * context-only SQL sources must be capped and report their truncation through
+ * `sources_page`.
  */
 
 import { beforeAll, describe, expect, it } from "vitest";
@@ -36,7 +37,7 @@ const ROWS_PER_FEED = 3;
 /** What the caller asks for. Below ROWS_PER_FEED on purpose. */
 const PAGE_LIMIT = 2;
 
-describe("behavior-mode limit bounds every event source", () => {
+describe("behavior-mode limit bounds every SQL-backed source", () => {
 	let owner: TestApiClient;
 	let orgId: string;
 	let agentId: string;
@@ -148,6 +149,51 @@ describe("behavior-mode limit bounds every event source", () => {
 			has_more: true,
 		});
 		expect(result.sources_page?.content).toEqual({
+			returned: PAGE_LIMIT,
+			limit: PAGE_LIMIT,
+			has_more: true,
+		});
+	});
+
+	it("caps context:true SQL sources and reports truncation", async () => {
+		const created = (await owner.behaviors.create({
+			entity_id: entityId,
+			slug: "context-source-limit",
+			name: "Context Source Limit",
+			prompt: "Summarize {{content}} with {{context_rows}}.",
+			agent_id: agentId,
+			sources: [
+				{ name: "content", query: `@feed:${primaryFeedId}` },
+				{
+					name: "context_rows",
+					query: "SELECT id, name, metadata FROM entities WHERE deleted_at IS NULL ORDER BY updated_at DESC",
+					context: true,
+				},
+			],
+		})) as { behavior_id: string };
+
+		// Add enough context entities to exceed PAGE_LIMIT. These ids are entity
+		// ids, not event ids — the exact reason context:true bypasses event paging.
+		for (let i = 0; i < ROWS_PER_FEED; i++) {
+			await createTestEntity({
+				name: `Context Entity ${i}`,
+				entity_type: "company",
+				organization_id: orgId,
+			});
+		}
+
+		const result = (await owner.knowledge.read({
+			behavior_id: created.behavior_id,
+			since: "today",
+			until: "today",
+			limit: PAGE_LIMIT,
+		})) as {
+			sources: Record<string, unknown[]>;
+			sources_page?: Record<string, { returned: number; limit: number; has_more: boolean }>;
+		};
+
+		expect(result.sources.context_rows).toHaveLength(PAGE_LIMIT);
+		expect(result.sources_page?.context_rows).toEqual({
 			returned: PAGE_LIMIT,
 			limit: PAGE_LIMIT,
 			has_more: true,

--- a/packages/server/src/tools/get_content/behavior-mode.ts
+++ b/packages/server/src/tools/get_content/behavior-mode.ts
@@ -105,23 +105,39 @@ async function queryContentData(
   const sqlSources = normalizedSources
     .filter((source) => source.kind !== 'metric')
     .map(({ name, query }) => ({ name, query }));
+  // Every SQL-backed source is part of the agent-facing knowledge.read payload,
+  // including context:true entity rows and streaming channel context. Bound all
+  // of them when this is a paged read so one large context source cannot turn a
+  // 25-row Behavior read into a six-figure-token model request. Metric sources
+  // are already aggregate outputs and bypass executeDataSources.
+  const boundedSourceNames = new Set(sqlSources.map((source) => source.name));
   const metricSources = normalizedSources.filter(isMetricSource);
 
   const results = await executeDataSources(sqlSources, queryContext, sql, {
-	throwOnError: params.throwOnSourceError,
+    throwOnError: params.throwOnSourceError,
     wrapQuery: page
       ? (scopedQuery, queryParams, sourceName) => {
-          // Bound EVERY event source, not just the cursor-bearing one. All of
-          // them land in `sources` on the response, and the sandbox counts
-          // every SDK result as it crosses the isolate boundary — an unbounded
-          // secondary source blows the output cap no matter what the script
-          // keeps. Only the primary source carries the keyset cursor; the rest
-          // are capped at the same page size and report truncation through
-          // `sources_page`, so a bounded read is never silent.
-          if (!eventSourceNames.has(sourceName)) return scopedQuery;
-          const isCursorSource = sourceName === page.sourceName;
-
+          const isEventSource = eventSourceNames.has(sourceName);
+          const isCursorSource = isEventSource && sourceName === page.sourceName;
           const nextParams = [...queryParams];
+
+          // Context sources do not share the event cursor contract (their id may
+          // be an entity id and they may not expose occurred_at). They still get
+          // the same row budget plus one sentinel so sources_page can state
+          // explicitly when the payload was truncated. Fingerprinting does not
+          // pass page, so skip_if_unchanged still sees the complete source state.
+          if (!isEventSource) {
+            nextParams.push(page.limit + 1);
+            const limitParam = `$${nextParams.length}`;
+            return {
+              // security-allowed: scopedQuery is an internally-built, already-scoped SQL fragment.
+              sql: `SELECT * FROM (${scopedQuery}) AS _watcher_context LIMIT ${limitParam}`,
+              params: nextParams,
+            };
+          }
+
+          // Event sources retain keyset pagination. Only the named primary source
+          // carries a cursor; every event source is still bounded.
           const where: string[] = [
             '_watcher_page.id IS NOT NULL',
             '_watcher_page.occurred_at IS NOT NULL',
@@ -207,14 +223,14 @@ async function queryContentData(
   }
 
   let pageResult: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } } | undefined;
-  // Per-source truncation. Every event source fetches `limit + 1` rows to
-  // detect overflow, so the sentinel row must be trimmed off the secondary
-  // sources too. Only the primary source gets a cursor; the rest report
-  // `has_more` so a caller can tell a truncated window from the whole one.
+  // Per-source truncation. Every SQL-backed source fetches `limit + 1` rows
+  // to detect overflow. Context sources have no event cursor, but sources_page
+  // still reports that they were capped instead of silently injecting the full
+  // result set into the model turn.
   const sourcesPage: Record<string, { returned: number; limit: number; has_more: boolean }> = {};
   if (page) {
-    for (const sourceName of eventSourceNames) {
-      if (sourceName === page.sourceName) continue;
+    for (const sourceName of boundedSourceNames) {
+      if (sourceName === page.sourceName && eventSourceNames.has(sourceName)) continue;
       const rows = results[sourceName] ?? [];
       const hasMore = rows.length > page.limit;
       if (hasMore) results[sourceName] = rows.slice(0, page.limit);
@@ -224,29 +240,36 @@ async function queryContentData(
         has_more: hasMore,
       };
     }
-    const rows = results[page.sourceName] ?? [];
-    const trimmed = rows.slice(0, page.limit);
-    const hasMore = rows.length > page.limit;
-    results[page.sourceName] = trimmed;
-    const last = trimmed[trimmed.length - 1] as Record<string, unknown> | undefined;
-    const lastOccurredAt = last?.occurred_at;
-    const lastId = Number(last?.id);
-    sourcesPage[page.sourceName] = {
-      returned: trimmed.length,
-      limit: page.limit,
-      has_more: hasMore,
-    };
-    pageResult = {
-      has_more: hasMore,
-      ...(hasMore && lastOccurredAt && Number.isFinite(lastId)
-        ? {
-            next_cursor: {
-              occurred_at: new Date(lastOccurredAt as string | Date).toISOString(),
-              id: Math.trunc(lastId),
-            },
-          }
-        : {}),
-    };
+
+    // Only an event source can carry the chronological keyset cursor. Some
+    // Behaviors deliberately name their primary event source something other
+    // than "content"; those sources are still bounded above and report
+    // sources_page.has_more, but no fake cursor row is synthesized.
+    if (eventSourceNames.has(page.sourceName)) {
+      const rows = results[page.sourceName] ?? [];
+      const trimmed = rows.slice(0, page.limit);
+      const hasMore = rows.length > page.limit;
+      results[page.sourceName] = trimmed;
+      const last = trimmed[trimmed.length - 1] as Record<string, unknown> | undefined;
+      const lastOccurredAt = last?.occurred_at;
+      const lastId = Number(last?.id);
+      sourcesPage[page.sourceName] = {
+        returned: trimmed.length,
+        limit: page.limit,
+        has_more: hasMore,
+      };
+      pageResult = {
+        has_more: hasMore,
+        ...(hasMore && lastOccurredAt && Number.isFinite(lastId)
+          ? {
+              next_cursor: {
+                occurred_at: new Date(lastOccurredAt as string | Date).toISOString(),
+                id: Math.trunc(lastId),
+              },
+            }
+          : {}),
+      };
+    }
   }
 
   const seen = new Set<number>();
@@ -657,8 +680,8 @@ export async function handleBehaviorMode(
     },
     extraction_schema: templateExtractionSchema ?? undefined,
     sources: sourcesContent as Record<string, ContentItem[]>,
-    // Per-source page state. Every event source is capped at `limit`, so this
-    // is how a caller tells a fully-read source from a truncated one.
+    // Per-source page state. Every SQL-backed source is capped at `limit`, so
+    // this is how a caller tells a fully-read source from a truncated one.
     sources_page: sourcesPage,
     entities: boundEntities.length > 0 ? boundEntities : undefined,
     classifiers: classifiers.length > 0 ? classifiers : undefined,

--- a/packages/server/src/tools/get_content/types.ts
+++ b/packages/server/src/tools/get_content/types.ts
@@ -113,10 +113,10 @@ export const GetContentResultSchema = Type.Object({
   extraction_schema: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
   sources: Type.Optional(Type.Record(Type.String(), Type.Array(Type.Unknown()))),
   /**
-   * Per-source page state, keyed by source name. Every event source is capped
-   * at the request's `limit`; this is how a caller distinguishes a fully-read
-   * source from a truncated one. Only the primary source carries a cursor (see
-   * `page.next_cursor`); the rest report `has_more` alone.
+   * Per-source page state, keyed by source name. Every SQL-backed source is
+   * capped at the request's `limit`; this is how a caller distinguishes a
+   * fully-read source from a truncated one. Only the primary event source
+   * carries a cursor (see `page.next_cursor`); the rest report `has_more` alone.
    */
   sources_page: Type.Optional(
     Type.Record(


### PR DESCRIPTION
## Summary
- bound every SQL-backed source in paged Behavior knowledge reads, including context:true entity sources
- expose per-source truncation through sources_page
- preserve full source state for skip_if_unchanged fingerprinting because fingerprint reads are unpaged

## Validation
- behavior-mode-source-limit: 3/3 passed before split; rerunning on this isolated branch
- full pre-pr passed on the combined branch before review split
- pre-reviewer corrected docs and removed an impossible guard