### PR TITLE
fix(personal-agent): skip invalid LinkedIn comment staging

### DIFF
--- a/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
+++ b/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
@@ -292,6 +292,27 @@ describe("social interest radar reaction", () => {
     });
   });
 
+  it("keeps a LinkedIn draft staged when the feed card has no canonical post permalink", async () => {
+    const fixture = clientWithRows({
+      drafts: [
+        {
+          id: 604,
+          payload_text: "Draft",
+          source_url: "https://www.linkedin.com/feed/",
+          metadata: draftMetadata,
+        },
+      ],
+      chrome: [{ id: 432 }],
+    });
+
+    await runReaction(context(), fixture.client);
+
+    expect(fixture.operations).toHaveLength(0);
+    expect(fixture.logs.join("\n")).toMatch(
+      /canonical post permalink|leaving it staged/i
+    );
+  });
+
   it("stages a persisted draft only once when the same reaction retries", async () => {
     const fixture = clientWithRows({
       drafts: [

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -136,6 +136,21 @@ function notificationBody(lines: string[]): string {
   return body.length <= 1000 ? body : `${body.slice(0, 997)}...`;
 }
 
+export function isCanonicalLinkedInPostUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname.toLowerCase();
+    if (hostname !== "linkedin.com" && hostname !== "www.linkedin.com") {
+      return false;
+    }
+    return /^\/feed\/update\/urn:li:(?:activity|share|ugcPost):\d+\/?$/.test(
+      url.pathname
+    );
+  } catch {
+    return false;
+  }
+}
+
 export default async (
   ctx: ReactionContext,
   client: ReactionClient
@@ -264,6 +279,14 @@ export default async (
         {
           draft_event_id: draft.id,
         }
+      );
+      continue;
+    }
+
+    if (platform === "linkedin" && !isCanonicalLinkedInPostUrl(sourceUrl)) {
+      client.log(
+        "LinkedIn draft has no canonical post permalink; leaving it staged without opening an invalid /feed/ comment action.",
+        { draft_event_id: draft.id, source_url: sourceUrl }
       );
       continue;
     }

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -136,7 +136,7 @@ function notificationBody(lines: string[]): string {
   return body.length <= 1000 ? body : `${body.slice(0, 997)}...`;
 }
 
-export function isCanonicalLinkedInPostUrl(value: string): boolean {
+function isCanonicalLinkedInPostUrl(value: string): boolean {
   try {
     const url = new URL(value);
     const hostname = url.hostname.toLowerCase();


### PR DESCRIPTION
## Summary
- only call LinkedIn prepare_comment when the saved draft has a canonical feed/update post permalink
- keep generic-feed drafts persisted and notified without firing a predictably invalid browser action
- preserve X staging and valid LinkedIn staging behavior

## Validation
- social-interest-radar reaction suite: 10/10 passed
- reaction plus LinkedIn connector suites: 114/114 passed
- format check passed
- TypeScript check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented actions from being opened for LinkedIn drafts with invalid or non-canonical post URLs.
  * Drafts with unsupported URLs now remain safely staged and provide a diagnostic message identifying the issue.
* **Tests**
  * Added regression coverage to verify invalid LinkedIn URLs are skipped without executing an operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->