### PR TITLE
fix(mcp): refresh ChatGPT app template

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -304,6 +304,7 @@
         "echarts": "^5.5.0",
         "elkjs": "^0.12.0",
         "lucide-react": "^0.469.0",
+        "pako": "^1.0.11",
         "qrcode.react": "^4.2.0",
         "radix-ui": "^1.6.0",
         "react": "^19.0.0",

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -131,7 +131,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v1' },
+        params: { uri: 'ui://lobu/interaction/v2' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -140,7 +140,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v1');
+    expect(content?.uri).toBe('ui://lobu/interaction/v2');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-interaction-stub');
     expect(content?._meta?.ui?.csp).toEqual({
@@ -167,7 +167,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v1'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v2'
     );
     expect(resource).toBeDefined();
     // description is a typed resource field surfaced in client browsers.
@@ -210,10 +210,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v1',
+            resourceUri: 'ui://lobu/interaction/v2',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v1',
+          'openai/outputTemplate': 'ui://lobu/interaction/v2',
         }),
       })
     );
@@ -232,12 +232,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v1',
+          resourceUri: 'ui://lobu/interaction/v2',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v1'
+        'ui://lobu/interaction/v2'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -281,7 +281,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v1',
+        resourceUri: 'ui://lobu/interaction/v2',
         visibility: ['model', 'app'],
       })
     );

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -16,7 +16,9 @@ import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
 import { getOrgUrlContext } from './view-urls';
 
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v1';
+// The URI is the host cache key for the immutable template. Bump it whenever
+// the shipped HTML changes; ChatGPT caches both successful and failed fetches.
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v2';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;


### PR DESCRIPTION
## What
- pin Owletto to merged #773, which transports the complete MCP App renderer in a 359 KB self-contained resource with native gzip and a legacy-browser fallback
- version the interaction resource from `ui://lobu/interaction/v1` to `/v2` so ChatGPT cannot reuse a cached failed template fetch
- lock the new build-time inflater dependency and update the MCP discovery/resource integration assertions

## Why
Production ChatGPT acceptance after #2613 reproduced `Failed to fetch template` before the iframe started. The v1 resource was valid and self-contained but its JSON-RPC envelope was still 926 KB and ChatGPT can cache failed resource loads by URI. This reduces the envelope to 358,822 bytes and changes the immutable cache key.

## Verification
- Owletto #773 merged at `d81b17e8481b161380a43115f3d8904eb108e626`
- `make pre-pr`
- database-backed `mcp-app-resources.test.ts`: 13/13
- Owletto full production build
- renderer/interaction tests: 13/13 UTC and 10/10 America/Los_Angeles
- sandboxed browser boot + MCP initialize/tool-result handshake on both native DecompressionStream and forced pako fallback paths
- independent exact-head Owletto review: no actionable findings

## Live acceptance
After merge/deploy, create a fresh ChatGPT conversation, attach Lobu, run the exact landing-page onboarding prompt, then run the read-only 25-row SQL prompt and verify the native app paginates without `Failed to fetch template`.