### PR TITLE
fix(behaviors): honor provider retry horizons

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/failed-run-advances-schedule.test.ts
@@ -7,6 +7,7 @@ import {
   advanceWatcherSchedule,
   deviceProviderQuotaResetNotBefore,
   parseProviderQuotaResetAt,
+  parseProviderRetryAfter,
   providerQuotaResetNotBefore,
 } from "../../../watchers/schedule-cursor";
 import { getTestDb } from "../../setup/test-db";
@@ -246,19 +247,40 @@ describe("provider quota reset parsing", () => {
     "Gemini returned an error: 429 status code (no body)",
     "429 Too Many Requests",
     "rate limit exceeded, retry shortly",
-    // Gemini's per-minute free-tier 429 reuses OpenAI's billing wording but
-    // names a retry horizon — the horizon is what marks it self-healing.
-    "429 You exceeded your current quota, please check your plan and billing details. Please retry in 26.5s.",
-    // Every spelling of a named horizon, including the quoted header form.
-    "429 insufficient quota; retryDelay: 26s",
-    "429 out of credits (Retry-After: 30)",
-  ])("does not park a self-healing rate limit (%s)", (message) => {
+  ])("leaves an undated self-healing rate limit on normal cadence (%s)", (message) => {
     const now = new Date("2026-08-05T10:00:00.000Z");
 
     expect(
       providerQuotaResetNotBefore(message, "PROVIDER_QUOTA_EXHAUSTED", now)
     ).toBeNull();
     expect(deviceProviderQuotaResetNotBefore(message, now)).toBeNull();
+  });
+
+  it.each([
+    [
+      "429 You exceeded your current quota. Please try again in 25.137s.",
+      "2026-08-05T10:00:26.137Z",
+    ],
+    [
+      "429 insufficient quota; retryDelay: 26s",
+      "2026-08-05T10:00:27.000Z",
+    ],
+    [
+      "429 out of credits (Retry-After: 30)",
+      "2026-08-05T10:00:31.000Z",
+    ],
+    [
+      "429 out of credits (Retry-After: Wed, 05 Aug 2026 10:00:30 GMT)",
+      "2026-08-05T10:00:31.000Z",
+    ],
+  ])("honors an explicit transient retry horizon (%s)", (message, expected) => {
+    const now = new Date("2026-08-05T10:00:00.000Z");
+
+    expect(parseProviderRetryAfter(message, now)?.toISOString()).toBe(expected);
+    expect(
+      providerQuotaResetNotBefore(message, "PROVIDER_QUOTA_EXHAUSTED", now)?.toISOString()
+    ).toBe(expected);
+    expect(deviceProviderQuotaResetNotBefore(message, now)?.toISOString()).toBe(expected);
   });
 
   it("still requires quota classification for balance wording", () => {
@@ -353,6 +375,40 @@ describe("a terminally failed Behavior run advances next_run_at", () => {
     const expectedNotBefore =
       Math.floor(resetAt.getTime() / 1000) * 1000 + 60_000;
     expect(after.getTime()).toBe(expectedNotBefore);
+  });
+
+  it("retries a scheduled transient quota failure before the next cron tick", async () => {
+    const { watcherId, runId } = await createDueWatcherWithDispatchedRun({
+      slug: "retry-transient-provider-limit",
+      messageId: "msg-provider-retry",
+    });
+    const before = Date.now();
+
+    const renderer = new ApiResponseRenderer({
+      broadcast() {},
+    } as unknown as ConstructorParameters<typeof ApiResponseRenderer>[0]);
+    await renderer.handleError(
+      {
+        messageId: "msg-provider-retry",
+        channelId: "api-provider-retry",
+        conversationId: "api-provider-retry",
+        userId: "watcher-test",
+        teamId: "api",
+        timestamp: Date.now(),
+        error: "Provider rate limited this turn.",
+        bookkeepingError:
+          "Rate limit reached for gpt-5.6-luna. Please try again in 25.137s.",
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+      }
+    );
+
+    const sql = getTestDb();
+    const [run] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    expect(run.status).toBe("failed");
+
+    const after = await cursorOf(watcherId);
+    expect(after.getTime()).toBeGreaterThanOrEqual(before + 26_000);
+    expect(after.getTime()).toBeLessThan(before + 60_000);
   });
 
   it("advances the cursor when the agent never calls complete_window", async () => {

--- a/packages/server/src/watchers/schedule-cursor.ts
+++ b/packages/server/src/watchers/schedule-cursor.ts
@@ -4,6 +4,8 @@ import { nextRunAt } from "../utils/cron";
 import logger from "../utils/logger";
 
 const PROVIDER_RESET_GRACE_MS = 60_000;
+const PROVIDER_RETRY_GRACE_MS = 1_000;
+const PROVIDER_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Extract the reset timestamp from provider quota errors such as:
@@ -90,6 +92,74 @@ export function parseProviderQuotaResetAt(
 }
 
 /**
+ * Extract an explicit short retry horizon from provider errors such as:
+ *
+ * - "Please try again in 25.137s"
+ * - "retryDelay: 26s"
+ * - "Retry-After: 30"
+ * - "Retry-After: Wed, 05 Aug 2026 10:00:30 GMT"
+ *
+ * Retry-After accepts either delta-seconds or an HTTP date. The one-second
+ * grace avoids retrying exactly on the provider boundary. Ignore implausibly
+ * long values: those belong to quota-reset / balance handling instead.
+ */
+export function parseProviderRetryAfter(
+	message: string,
+	now: Date = new Date()
+): Date | null {
+	const unitMatch =
+		message.match(
+			/\b(?:please\s+)?(?:try\s+again\s+in|retry(?:[-_ ]?(?:in|after|delay))?\s*:?)\s*(\d+(?:\.\d+)?)\s*(ms|milliseconds?|s|secs?|seconds?|m|mins?|minutes?)\b/i
+		) ?? null;
+	const headerMatch =
+		unitMatch == null
+			? message.match(/\bretry[-_ ]?after\s*:\s*(\d+(?:\.\d+)?)\b/i)
+			: null;
+	const headerDateMatch =
+		unitMatch == null && headerMatch == null
+			? message.match(
+					/\bretry[-_ ]?after\s*:\s*((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s+\d{2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT)\b/i
+				)
+			: null;
+	const match = unitMatch ?? headerMatch;
+	if (!match && !headerDateMatch) return null;
+
+	if (headerDateMatch) {
+		const rawBoundary = headerDateMatch[1].replace(/\s+/g, " ");
+		const boundaryMs = Date.parse(rawBoundary);
+		const delayMs = boundaryMs - now.getTime();
+		if (
+			!Number.isFinite(boundaryMs) ||
+			new Date(boundaryMs).toUTCString().toLowerCase() !==
+				rawBoundary.toLowerCase() ||
+			delayMs <= 0 ||
+			delayMs > PROVIDER_RETRY_MAX_MS
+		) {
+			return null;
+		}
+		return new Date(boundaryMs + PROVIDER_RETRY_GRACE_MS);
+	}
+	if (!match) return null;
+
+	const rawValue = Number(match[1]);
+	if (!Number.isFinite(rawValue) || rawValue <= 0) return null;
+
+	const unit = unitMatch?.[2]?.toLowerCase();
+	let delayMs: number;
+	if (unit === "ms" || unit?.startsWith("millisecond")) {
+		delayMs = rawValue;
+	} else if (unit === "m" || unit?.startsWith("min")) {
+		delayMs = rawValue * 60_000;
+	} else {
+		delayMs = rawValue * 1_000;
+	}
+	if (!Number.isFinite(delayMs) || delayMs > PROVIDER_RETRY_MAX_MS) {
+		return null;
+	}
+	return new Date(now.getTime() + delayMs + PROVIDER_RETRY_GRACE_MS);
+}
+
+/**
  * How long a depleted balance parks a schedule.
  *
  * A depleted balance is not a rate limit: it does not tick back on a timer, so
@@ -150,6 +220,7 @@ export function providerQuotaResetNotBefore(
 	}
 	return (
 		parseProviderQuotaResetAt(message, now) ??
+		parseProviderRetryAfter(message, now) ??
 		balanceExhaustedNotBefore(message, now)
 	);
 }
@@ -176,6 +247,7 @@ export function deviceProviderQuotaResetNotBefore(
 	if (!hasQuotaEvidence) return null;
 	return (
 		parseProviderQuotaResetAt(message, now) ??
+		parseProviderRetryAfter(message, now) ??
 		balanceExhaustedNotBefore(message, now)
 	);
 }
@@ -183,7 +255,8 @@ export function deviceProviderQuotaResetNotBefore(
 /**
  * Move a watcher's `next_run_at` forward without shortening its current park.
  *
- * The target is `nextRunAt(schedule, now)` unless the caller supplies a later
+ * The target is `nextRunAt(schedule, now)` unless a scheduled failure supplies
+ * an earlier transient retry boundary or any caller supplies a later
  * `notBefore` boundary. The write never moves an existing cursor backward, so
  * overlapping completions cannot erase a quota park.
  * (Basing it on `max(now, next_run_at)` instead compounded the schedule: each
@@ -211,7 +284,8 @@ export function deviceProviderQuotaResetNotBefore(
 export async function advanceWatcherSchedule(
 	sql: DbClient,
 	watcherId: number | null | undefined,
-	notBefore?: Date | null
+	notBefore?: Date | null,
+	allowBeforeNextTick = false
 ): Promise<void> {
 	if (watcherId == null) return;
 	const rows = await sql`
@@ -247,7 +321,7 @@ export async function advanceWatcherSchedule(
 	const target =
 		typeof notBeforeMs === "number" &&
 		Number.isFinite(notBeforeMs) &&
-		notBeforeMs > new Date(nextTick).getTime()
+		(allowBeforeNextTick || notBeforeMs > new Date(nextTick).getTime())
 			? new Date(notBeforeMs).toISOString()
 			: nextTick;
 
@@ -273,5 +347,12 @@ export async function advanceScheduleAfterTerminalFailure(
 	notBefore?: Date | null
 ): Promise<void> {
 	if (dispatchSource === "event" && notBefore == null) return;
-	await advanceWatcherSchedule(sql, watcherId, notBefore);
+	const scheduledDispatch =
+		dispatchSource == null || dispatchSource === "scheduled";
+	await advanceWatcherSchedule(
+		sql,
+		watcherId,
+		notBefore,
+		scheduledDispatch && notBefore != null
+	);
 }


### PR DESCRIPTION
## Summary
- parse explicit transient provider retry horizons, including retryDelay, delta-seconds Retry-After, HTTP-date Retry-After, and Please try again in N seconds
- retry scheduled Behavior windows at the provider boundary even when it is before the next cron tick
- keep event/manual cadence semantics and existing quota-reset/balance parking behavior

## Validation
- failed-run-advances-schedule: 42/42 passed before split; rerunning on this isolated branch
- reviewer-fix added HTTP-date coverage and corrected schedule semantics docs