### PR TITLE
fix(mcp): publish accurate tool annotations

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -201,10 +201,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(tool).toEqual(
       expect.objectContaining({
         annotations: expect.objectContaining({
-          readOnlyHint: true,
+          readOnlyHint: false,
           destructiveHint: false,
           openWorldHint: false,
-          idempotentHint: true,
+          idempotentHint: false,
         }),
         securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
         _meta: expect.objectContaining({
@@ -247,6 +247,13 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(resolveApproval).toEqual(
       expect.objectContaining({
+        annotations: expect.objectContaining({
+          readOnlyHint: false,
+          destructiveHint: true,
+          openWorldHint: true,
+          idempotentHint: false,
+        }),
+        outputSchema: expect.objectContaining({ type: 'object' }),
         securitySchemes: [{ type: 'oauth2', scopes: ['mcp:write'] }],
         _meta: expect.objectContaining({
           ui: expect.objectContaining({ visibility: ['app'] }),
@@ -258,6 +265,8 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       expect(listed.annotations?.readOnlyHint).toEqual(expect.any(Boolean));
       expect(listed.annotations?.destructiveHint).toEqual(expect.any(Boolean));
       expect(listed.annotations?.openWorldHint).toEqual(expect.any(Boolean));
+      expect(listed.annotations?.idempotentHint).toEqual(expect.any(Boolean));
+      expect(listed.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
   });
 

--- a/packages/server/src/__tests__/integration/mcp/member-write-access.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/member-write-access.test.ts
@@ -119,9 +119,17 @@ describe('MCP member write access', () => {
     expect(toolNames).not.toContain('save_memory');
     // manage_entity moved to the internal REST/CLI surface in #432; it's no
     // longer registered as an external MCP tool. Verify that read-only
-    // discovery surfaces (search_memory / search) are still visible.
-    expect(toolNames).toContain('search_memory');
-    expect(toolNames).toContain('search_sdk');
+    // discovery and data tools are still authorization-read-only even though
+    // their public OpenAI annotations disclose that Lobu appends audit records.
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        'search_memory',
+        'search_sdk',
+        'query_sdk',
+        'query_sql',
+        'render_lobu_view',
+      ])
+    );
   });
 
   it('returns an upgrade-path message for public-org non-member write attempts', async () => {

--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -55,14 +55,16 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     expect(byName.has('execute')).toBe(false);
 
     const expectedSafetyHints = {
-      // Both can reach installed virtual-feed connectors live, beyond Lobu's
-      // persisted workspace, so they must remain explicitly open-world.
-      search_memory: [true, true, false],
-      search_sdk: [true, false, false],
-      query_sdk: [true, true, false],
-      query_sql: [true, false, false],
+      // These operations do not change workspace content or external systems,
+      // but OAuth and PAT invocations append private audit/activity records.
+      // OpenAI's read-only and idempotent hints therefore both remain false.
+      search_memory: [false, false, false],
+      search_sdk: [false, false, false],
+      query_sdk: [false, false, false],
+      query_sql: [false, false, false],
       save_memory: [false, false, false],
       run_sdk: [false, true, true],
+      render_lobu_view: [false, false, false],
     } as const;
 
     for (const [toolName, [readOnlyHint, openWorldHint, destructiveHint]] of Object.entries(
@@ -76,9 +78,18 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
       );
     }
 
-    expect(byName.get('query_sdk')?.annotations?.idempotentHint).toBe(true);
+    for (const name of [
+      'search_memory',
+      'search_sdk',
+      'query_sdk',
+      'query_sql',
+      'render_lobu_view',
+    ]) {
+      expect(byName.get(name)?.annotations?.idempotentHint, `${name}.idempotentHint`).toBe(
+        false
+      );
+    }
     expect(byName.get('run_sdk')?.inputSchema?.properties?.dry_run).toBeTruthy();
-    expect(byName.get('search_memory')?.annotations?.idempotentHint).toBe(true);
     expect(byName.has('search_knowledge')).toBe(false);
     expect(byName.has('save_knowledge')).toBe(false);
     expect(byName.has('search')).toBe(false);

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -11,7 +11,12 @@ import { describe, expect, it } from 'vitest';
 import { ToolNotRegisteredError } from '../../utils/errors';
 import { routeAction } from '../../tools/admin/action-router';
 import { type AuthContext, checkToolAccess, extractAuthContext } from '../../tools/execute';
-import { getAllTools, getTool, type ToolContext } from '../../tools/registry';
+import {
+  getAllTools,
+  getTool,
+  isAuthorizationReadOnly,
+  type ToolContext,
+} from '../../tools/registry';
 import {
   getRequiredAccessLevel,
   hasRequiredMcpScope,
@@ -771,7 +776,7 @@ describe('pinned access matrix', () => {
       publicOnly: false,
       maxAccessLevel: 'admin',
     }).map((tool) => {
-      const readOnly = tool.annotations?.readOnlyHint === true;
+      const readOnly = isAuthorizationReadOnly(getTool(tool.name));
       const parts = [...(actionsOf(tool.inputSchema) ?? ['-']), '?'].map((action) => {
         const args = action === '-' ? {} : { action };
         const tier = getRequiredAccessLevel(tool.name, args, readOnly);

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -54,7 +54,7 @@ import {
 } from './tools/execute';
 import { LOBU_INTERACTION_RESOURCE_URI } from './tools/mcp_app';
 import { getMcpResultMeta } from './tools/mcp-result-meta';
-import { getMcpTools, getTool } from './tools/registry';
+import { getMcpTools, getTool, isAuthorizationReadOnly } from './tools/registry';
 import { validateToolResult } from './tools/validate-args';
 import { readMcpAppBundle } from './utils/mcp-app-bundle';
 import { resolvePublicOrigin } from './utils/public-origin';
@@ -421,7 +421,7 @@ function createServerForContext(
     } catch (error: any) {
       const tool = getTool(name);
       const requiredAccess = tool
-        ? getRequiredAccessLevel(name, args ?? {}, tool.annotations?.readOnlyHint === true)
+        ? getRequiredAccessLevel(name, args ?? {}, isAuthorizationReadOnly(tool))
         : null;
       const requiredScope =
         requiredAccess === 'read'

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -22,7 +22,13 @@ import { getConfiguredPublicOrigin } from '../utils/public-origin';
 import { enforceRoleScopeAccess } from './access-control';
 import { recordToolInvocationAudit } from './audit';
 import { listOrganizations } from './organizations';
-import { getTool, type TokenType, type ToolContext, type ToolSourceContext } from './registry';
+import {
+  getTool,
+  isAuthorizationReadOnly,
+  type TokenType,
+  type ToolContext,
+  type ToolSourceContext,
+} from './registry';
 
 export interface AuthContext {
   organizationId: string | null;
@@ -175,7 +181,7 @@ export function checkToolAccess(toolName: string, args: unknown, authCtx: AuthCo
     throw new ToolNotRegisteredError(toolName);
   }
 
-  const isReadOnly = tool.annotations?.readOnlyHint === true;
+  const isReadOnly = isAuthorizationReadOnly(tool);
   const { memberRole: role } = authCtx;
   const requiredAccess = getRequiredAccessLevel(toolName, args, isReadOnly);
 

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -54,11 +54,11 @@ import { PublicSearchSchema, SearchSchema, search, UnifiedSearchResultSchema } f
  * @see https://developers.openai.com/apps-sdk/reference#annotations
  */
 export interface ToolAnnotations {
-  /** Signal that the tool is read-only. ChatGPT can skip 'Are you sure?' prompts when true. */
+  /** Signal that the tool only retrieves or computes information without creating data outside the conversation. */
   readOnlyHint?: boolean;
-  /** Declare that the tool may delete or overwrite user data, requiring explicit approval. */
+  /** Declare that the tool may delete or overwrite user data. */
   destructiveHint?: boolean;
-  /** Declare that the tool publishes content or reaches outside the current user's account. */
+  /** Declare that the tool publishes content or reaches outside the caller's account. */
   openWorldHint?: boolean;
   /** Declare that calling the tool repeatedly with the same arguments has no additional effect. */
   idempotentHint?: boolean;
@@ -175,6 +175,12 @@ export interface ToolDefinition<T = any> {
   publicInputSchema?: any; // JSON Schema
   annotations?: ToolAnnotations;
   /**
+   * Internal access classification. This is deliberately separate from the
+   * public `readOnlyHint`: OAuth and PAT invocations append an audit/activity
+   * record, while these operations still require only `mcp:read`.
+   */
+  authorizationReadOnly?: boolean;
+  /**
    * JSON Schema describing the tool's structured result. When present, the
    * `tools/call` response carries matching `structuredContent` alongside the
    * text `content` (MCP spec: declaring `outputSchema` implies the result is
@@ -197,7 +203,12 @@ const READ_ONLY = {
   idempotentHint: true,
 } as const;
 
-const READ_ONLY_OPEN_WORLD = { ...READ_ONLY, openWorldHint: true } as const;
+const AUDITED_READ = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  openWorldHint: false,
+  idempotentHint: false,
+} as const;
 
 const WRITE_WITHOUT_CONFIRM: ToolAnnotations = {
   readOnlyHint: false,
@@ -220,16 +231,15 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'search_memory',
     description:
-      'Search saved workspace memory: entities, facts, decisions, preferences, observations, and notes. Use this to answer “what do we know?” Pair writes with `save_memory`; use `search_sdk` / `query_sdk` only when you need SDK capabilities or programmable reads.',
+      'Search saved workspace memory: entities, facts, decisions, preferences, observations, and notes. Use this to answer “what do we know?” Pair writes with `save_memory`; use `search_sdk` / `query_sdk` only when you need SDK capabilities or programmable reads. The search does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
     inputSchema: SearchSchema,
     // Advertise the narrower public schema: query_embedding (server pre-compute
     // optimization) and agent_id (auth-bound) are server-internal, not client
     // affordances. See search.ts → PublicSearchSchema.
     publicInputSchema: PublicSearchSchema,
     outputSchema: UnifiedSearchResultSchema,
-    // Search can query installed virtual feeds live, so it may read outside
-    // Lobu's persisted workspace even though it never mutates anything.
-    annotations: { ...READ_ONLY_OPEN_WORLD, title: 'Search memory' },
+    annotations: { ...AUDITED_READ, title: 'Search memory' },
+    authorizationReadOnly: true,
     securityScopes: ['mcp:read'],
     mcpMeta: RICH_RESULT_MCP_META,
     handler: search,
@@ -248,10 +258,11 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'search_sdk',
     description:
-      'Discover available SDK methods and runtime helpers. Search by method name, namespace (e.g. "entities", "connections", "behaviors"), or keyword. Returns documentation, signatures, and access requirements for each method. (Then call methods via query_sdk for reads or run_sdk for writes. Pass mode="read" to show only query_sdk-safe methods.)',
+      'Discover available SDK methods and runtime helpers. Search by method name, namespace (e.g. "entities", "connections", "behaviors"), or keyword. Returns documentation, signatures, and access requirements for each method. (Then call methods via query_sdk for reads or run_sdk for writes. Pass mode="read" to show only query_sdk-safe methods.) The search does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
     inputSchema: SdkSearchSchema,
     outputSchema: SdkSearchResultSchema,
-    annotations: { ...READ_ONLY, title: 'Search SDK docs' },
+    annotations: { ...AUDITED_READ, title: 'Search SDK docs' },
+    authorizationReadOnly: true,
     securityScopes: ['mcp:read'],
     mcpMeta: RICH_RESULT_MCP_META,
     handler: sdkSearch,
@@ -260,11 +271,12 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'query_sdk',
     description:
-      'Read workspace data through typed SDK methods. Query entities, relationships, feeds, operations, metrics, and more. Use this for lookups and searches that do not change data. (For writes: use run_sdk. To discover available methods: use search_sdk. For polling: use await ctx.sleep(ms) in your script.)',
+      'Read workspace data through typed SDK methods. Query entities, relationships, feeds, operations, metrics, and more. Use this for lookups and searches that do not change workspace content or external systems. (For writes: use run_sdk. To discover available methods: use search_sdk. For polling: use await ctx.sleep(ms) in your script.) Lobu appends a private audit/activity record for the invocation.',
     inputSchema: QuerySchema,
     outputSchema: SdkScriptResultSchema,
-    // Read-only SDK methods include connector-backed live feed reads.
-    annotations: { ...READ_ONLY_OPEN_WORLD, title: 'Query SDK (read-only)' },
+    // Private connector reads do not mutate an external/public system.
+    annotations: { ...AUDITED_READ, title: 'Query SDK (read-only)' },
+    authorizationReadOnly: true,
     securityScopes: ['mcp:read'],
     mcpMeta: RICH_RESULT_MCP_META,
     handler: querySdkScript,
@@ -272,10 +284,11 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'query_sql',
     description:
-      'Run a paginated, sortable, searchable read-only SQL query (member-safe). Table references auto-scope to the bound org. SELECT FROM events reads persisted/synced content only; virtual feeds are live-only and must be read explicitly with feed or via query_sdk client.feeds.readMany. Results may include coverage.suggested_virtual_feeds. Prefer client.metrics.query for declared measures; use client.query in query_sdk for simple one-shot SQL. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects to another member org.',
+      'Run a paginated, sortable, searchable read-only SQL query (member-safe). Table references auto-scope to the bound org. SELECT FROM events reads persisted/synced content only; virtual feeds are live-only and must be read explicitly with feed or via query_sdk client.feeds.readMany. Results may include coverage.suggested_virtual_feeds. Prefer client.metrics.query for declared measures; use client.query in query_sdk for simple one-shot SQL. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects to another member org. The query does not change workspace content or external systems, but Lobu appends a private audit/activity record for the invocation.',
     inputSchema: QuerySqlSchema,
     outputSchema: QuerySqlResultSchema,
-    annotations: { ...READ_ONLY, title: 'Query SQL' },
+    annotations: { ...AUDITED_READ, title: 'Query SQL' },
+    authorizationReadOnly: true,
     securityScopes: ['mcp:read'],
     mcpMeta: RICH_RESULT_MCP_META,
     handler: querySql,
@@ -309,10 +322,11 @@ const MCP_APP_TOOLS: ToolDefinition[] = [
   {
     name: 'render_lobu_view',
     description:
-      'Render a compact Lobu card after data has been selected, or render the review card for one pending approval run. Use action="render" only when a visual card materially helps; first call Lobu data tools and pass only the final content. Use action="review_approval" with a run_id returned by a pending action. Text-only clients receive the same information as readable text.',
+      'Render a compact Lobu card after data has been selected, or render the review card for one pending approval run. Use action="render" only when a visual card materially helps; first call Lobu data tools and pass only the final content. Use action="review_approval" with a run_id returned by a pending action. Text-only clients receive the same information as readable text. Rendering does not change workspace content or external systems. OAuth and PAT calls append a private audit/activity record.',
     inputSchema: RenderLobuViewSchema,
     outputSchema: LobuViewSchema,
-    annotations: { ...READ_ONLY, title: 'Render Lobu view' },
+    annotations: { ...AUDITED_READ, title: 'Render Lobu view' },
+    authorizationReadOnly: true,
     securityScopes: ['mcp:read'],
     mcpMeta: RICH_RESULT_MCP_META,
     handler: renderLobuView,
@@ -550,6 +564,10 @@ function accessLevelRank(level: 'read' | 'write' | 'admin'): number {
   return 3;
 }
 
+export function isAuthorizationReadOnly(tool: ToolDefinition | undefined): boolean {
+  return tool?.authorizationReadOnly ?? (tool?.annotations?.readOnlyHint === true);
+}
+
 function filterSchemaForAccessLevel(
   toolName: string,
   schema: any,
@@ -671,7 +689,7 @@ function computeListedTools(
       // server-supplied fields (e.g. embeddings, auth-bound filters) are
       // accepted at the handler boundary but never advertised to clients.
       let inputSchema = tool.publicInputSchema ?? tool.inputSchema;
-      const readOnlyHint = tool.annotations?.readOnlyHint === true;
+      const authorizationReadOnly = isAuthorizationReadOnly(tool);
 
       if (publicOnly) {
         inputSchema = filterSchemaForPublicActions(tool.name, inputSchema);
@@ -681,7 +699,7 @@ function computeListedTools(
       inputSchema = filterSchemaForAccessLevel(
         tool.name,
         inputSchema,
-        readOnlyHint,
+        authorizationReadOnly,
         maxAccessLevel
       );
       if (!inputSchema) return null;

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -58,7 +58,7 @@ export interface ToolAnnotations {
   readOnlyHint?: boolean;
   /** Declare that the tool may delete or overwrite user data. */
   destructiveHint?: boolean;
-  /** Declare that the tool publishes content or reaches outside the caller's account. */
+  /** Declare that the tool may change public internet state or an external third-party system. */
   openWorldHint?: boolean;
   /** Declare that calling the tool repeatedly with the same arguments has no additional effect. */
   idempotentHint?: boolean;
@@ -203,6 +203,9 @@ const READ_ONLY = {
   idempotentHint: true,
 } as const;
 
+// OpenAI Apps submission semantics reserve `openWorldHint` for tools that can
+// CHANGE public internet or third-party state. Live reads from a user's private
+// connectors remain closed-world even though they contact an external service.
 const AUDITED_READ = {
   readOnlyHint: false,
   destructiveHint: false,


### PR DESCRIPTION
## Summary
- publish implementation-accurate annotations for all ChatGPT-visible MCP tools
- keep audited reads on mcp:read through a separate internal authorization classification
- enforce complete annotations and object output schemas, including the app-only approval tool

## Verification
- make pre-pr
- 407 server test files: 3,623 passed, 2 skipped
- focused MCP integration: 47 passed
- access-control matrix: 64 passed
- pre-review fixer: no unresolved findings