### PR TITLE
fix(connectors): resolve active installed version

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/connector-version-org-isolation.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connector-version-org-isolation.test.ts
@@ -22,6 +22,7 @@ import type { ToolContext } from '../../../tools/registry';
 import {
   ensureConnectorInstalled,
   resolveConnectorCodeForKey,
+  upsertBundledConnectorForOrg,
 } from '../../../utils/ensure-connector-installed';
 
 const TEST_ENV = {
@@ -144,6 +145,49 @@ describe('connector_versions org isolation (#2045 read cutover)', () => {
       ctxB
     );
     expect('error' in rolled ? rolled.error : '').toContain("No retained version '3.0.0'");
+  });
+
+  it('resolves the active definition version before preferring an org-local artifact', async () => {
+    // Reproduce the production Calendar shape: an org retains an older private
+    // artifact, then the bundled catalog advances the active definition to a
+    // newer shared version. A no-version execution must follow the ACTIVE
+    // definition; org-local preference only applies within that exact version.
+    const KEY = 'hackernews';
+    const staleVersion = '0.0.1-stale-org';
+    const stale = await manageConnections(
+      {
+        action: 'install_connector',
+        source_code: sourceFor(KEY, staleVersion, 'STALE-ORG-CODE'),
+      },
+      TEST_ENV,
+      ctxA
+    );
+    expect('error' in stale ? stale.error : undefined).toBeUndefined();
+
+    const promoted = await upsertBundledConnectorForOrg({
+      organizationId: orgA,
+      connectorKey: KEY,
+    });
+    expect(promoted).not.toBeNull();
+    expect(promoted?.version).not.toBe(staleVersion);
+
+    const sql = getTestDb();
+    const [definition] = await sql`
+      SELECT version FROM connector_definitions
+      WHERE organization_id = ${orgA} AND key = ${KEY} AND status = 'active'
+      LIMIT 1
+    `;
+    expect(definition?.version).toBe(promoted?.version);
+
+    // This is the regression: old resolution picked the org-local stale row
+    // before considering the active definition's newer shared version.
+    const activeCode = await resolveConnectorCodeForKey(KEY, orgA);
+    expect(activeCode).not.toContain('STALE-ORG-CODE');
+
+    // Explicit historical-version resolution keeps rollback/debug semantics:
+    // within the requested version, the org-local artifact still wins.
+    const staleCode = await resolveConnectorCodeForKey(KEY, orgA, staleVersion);
+    expect(staleCode).toContain('STALE-ORG-CODE');
   });
 
   it('branching a bundled connector shadows it for the branching org only', async () => {

--- a/packages/server/src/utils/ensure-connector-installed.ts
+++ b/packages/server/src/utils/ensure-connector-installed.ts
@@ -109,8 +109,9 @@ export async function resolveConnectorCode(
 }
 
 /**
- * Fetch the stored artifact row for a connector (a specific `version`, or the
- * most recently created row when omitted) and resolve executable code from it.
+ * Fetch the stored artifact row for a connector. An explicit `version` resolves
+ * that retained version; when omitted, the org's active connector definition
+ * selects the version. Within that version, org-local code shadows shared code.
  * Shared by the pushdown / webhook / inline-operation paths, which don't carry
  * a version row of their own.
  */
@@ -120,11 +121,12 @@ export async function resolveConnectorCodeForKey(
   version?: string | null
 ): Promise<string> {
   const sql = getDb();
-  // Org-preferring resolution (#2045): the org's own artifact row shadows the
-  // shared bundled/legacy row for that org only; shared rows stay every org's
-  // fallback. The no-version variant prefers ANY org row over a newer shared
-  // row — an org that branched a bundled connector stays on its branch until
-  // it updates or rolls back.
+  // Org-preferring resolution (#2045) is scoped to ONE version. An org-local
+  // artifact shadows the shared bundled row only when both represent the same
+  // version. Without an explicit historical version, the org's ACTIVE
+  // connector_definitions.version is authoritative. Otherwise a retained stale
+  // org artifact can shadow a newly-promoted shared version (e.g. Calendar
+  // active=1.1.0 while an old org-local 1.0.0 row still exists).
   const rows = version
     ? await sql`
         SELECT id, version, compiled_code, compile_config_hash FROM connector_versions
@@ -134,10 +136,16 @@ export async function resolveConnectorCodeForKey(
         LIMIT 1
       `
     : await sql`
-        SELECT id, version, compiled_code, compile_config_hash FROM connector_versions
-        WHERE connector_key = ${connectorKey}
-          AND (organization_id = ${organizationId} OR organization_id IS NULL)
-        ORDER BY (organization_id IS NULL), created_at DESC
+        SELECT cv.id, cv.version, cv.compiled_code, cv.compile_config_hash
+        FROM connector_definitions cd
+        JOIN connector_versions cv
+          ON cv.connector_key = cd.key
+         AND cv.version = cd.version
+         AND (cv.organization_id = cd.organization_id OR cv.organization_id IS NULL)
+        WHERE cd.organization_id = ${organizationId}
+          AND cd.key = ${connectorKey}
+          AND cd.status = 'active'
+        ORDER BY cv.organization_id NULLS LAST
         LIMIT 1
       `;
   return resolveConnectorCode(connectorKey, (rows[0] as StoredConnectorVersion | undefined) ?? null);


### PR DESCRIPTION
Fix connector artifact resolution so no-version executions follow the org active connector definition version before applying org-local-over-shared preference. This fixes the production Calendar state where active 1.1.0 was shadowed by retained org-local 1.0.0. Explicit historical version resolution is unchanged. Regression reproduces stale org artifact plus newer shared active version. Validation: version isolation 4/4, source lifecycle 3/3, virtual feed surfaces 16/16, server typecheck pass, make pre-pr all six gates pass.