### PR TITLE
fix(mcp): serve lightweight external-asset app template

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
@@ -58,7 +58,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -143,7 +143,7 @@
     },
     "packages/client": {
       "name": "@lobu/client",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -152,7 +152,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -176,7 +176,7 @@
     },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
@@ -211,7 +211,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -232,7 +232,7 @@
     },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "dependencies": {
         "@hono/node-server": "^2.0.11",
         "@xenova/transformers": "^2.17.2",
@@ -304,7 +304,6 @@
         "echarts": "^5.5.0",
         "elkjs": "^0.12.0",
         "lucide-react": "^0.469.0",
-        "pako": "^1.0.11",
         "qrcode.react": "^4.2.0",
         "radix-ui": "^1.6.0",
         "react": "^19.0.0",
@@ -332,13 +331,12 @@
         "tailwindcss": "^4.1.17",
         "typescript": "^5.7.2",
         "vite": "^6.0.0",
-        "vite-plugin-singlefile": "^2.3.3",
         "vitest": "^2.1.8",
       },
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -346,7 +344,7 @@
     },
     "packages/plugin-api": {
       "name": "@lobu/plugin-api",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.41",
       },
@@ -371,7 +369,7 @@
     },
     "packages/plugin-host": {
       "name": "@lobu/plugin-host",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "dependencies": {
         "@lobu/plugin-api": "workspace:*",
       },
@@ -440,7 +438,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "14.18.0",
+      "version": "14.19.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",
@@ -3733,8 +3731,6 @@
     "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
-
-    "vite-plugin-singlefile": ["vite-plugin-singlefile@2.3.3", "", { "dependencies": { "micromatch": "^4.0.8" }, "peerDependencies": { "rollup": "^4.59.0", "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg=="],
 
     "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -21,7 +21,7 @@ import { get, post } from '../../setup/test-helpers';
 
 // Marker in the stub bundle so we can assert the served HTML is ours.
 const STUB_HTML =
-  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><script type="module" src="./assets/index-test.js"></script></head><body data-test="mcp-app-interaction-stub">interaction</body></html>';
+  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><script type="module" src="./assets/app.js"></script></head><body data-test="mcp-app-interaction-stub">interaction</body></html>';
 
 describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -49,7 +49,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     });
     writeFileSync(join(tmpRoot, 'dist-mcp-apps', 'interaction', 'index.html'), STUB_HTML);
     writeFileSync(
-      join(tmpRoot, 'dist-mcp-apps', 'interaction', 'assets', 'index-test.js'),
+      join(tmpRoot, 'dist-mcp-apps', 'interaction', 'assets', 'app.js'),
       'document.body.dataset.mcpAppAsset = "loaded";'
     );
     process.env.WEB_DIST_DIR = join(tmpRoot, 'dist');
@@ -166,19 +166,17 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(content?._meta?.ui?.domain).toBeUndefined();
   });
 
-  it('serves only registered content-hashed MCP App JS/CSS assets with cross-origin headers', async () => {
-    const response = await get('/mcp-apps/interaction/assets/index-test.js');
+  it('serves only registered stable MCP App JS/CSS assets with revalidation and cross-origin headers', async () => {
+    const response = await get('/mcp-apps/interaction/assets/app.js');
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('text/javascript');
-    expect(response.headers.get('cache-control')).toBe(
-      'public, max-age=31536000, immutable'
-    );
+    expect(response.headers.get('cache-control')).toBe('no-cache');
     expect(response.headers.get('access-control-allow-origin')).toBe('*');
     expect(response.headers.get('cross-origin-resource-policy')).toBe('cross-origin');
     expect(await response.text()).toContain('mcpAppAsset');
 
-    expect((await get('/mcp-apps/interaction/assets/index-test.txt')).status).toBe(404);
-    expect((await get('/mcp-apps/unknown/assets/index-test.js')).status).toBe(404);
+    expect((await get('/mcp-apps/interaction/assets/app.txt')).status).toBe(404);
+    expect((await get('/mcp-apps/unknown/assets/app.js')).status).toBe(404);
   });
 
   it('keeps retired Lobu interaction URIs readable for cached conversations', async () => {
@@ -229,7 +227,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(typeof resource.description).toBe('string');
     expect(resource.description.length).toBeGreaterThan(0);
     // CSP rides the current nested _meta.ui shape and allows only the serving
-    // origin to provide content-hashed JS/CSS assets. `ui.domain` is omitted:
+    // origin to provide stable JS/CSS assets. `ui.domain` is omitted:
     // that field asks the host for a dedicated sandbox origin, not an asset host.
     expect(resource.mimeType).toBe('text/html;profile=mcp-app');
     const resourceDomains = resource._meta?.ui?.csp?.resourceDomains;

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -17,11 +17,11 @@ import {
   createTestUser,
   seedSystemEntityTypes,
 } from '../../setup/test-fixtures';
-import { post } from '../../setup/test-helpers';
+import { get, post } from '../../setup/test-helpers';
 
 // Marker in the stub bundle so we can assert the served HTML is ours.
 const STUB_HTML =
-  '<!doctype html><html><body data-test="mcp-app-interaction-stub">interaction</body></html>';
+  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><script type="module" src="./assets/index-test.js"></script></head><body data-test="mcp-app-interaction-stub">interaction</body></html>';
 
 describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -44,7 +44,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'interaction'), {
       recursive: true,
     });
+    mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'interaction', 'assets'), {
+      recursive: true,
+    });
     writeFileSync(join(tmpRoot, 'dist-mcp-apps', 'interaction', 'index.html'), STUB_HTML);
+    writeFileSync(
+      join(tmpRoot, 'dist-mcp-apps', 'interaction', 'assets', 'index-test.js'),
+      'document.body.dataset.mcpAppAsset = "loaded";'
+    );
     process.env.WEB_DIST_DIR = join(tmpRoot, 'dist');
 
     await cleanupTestDatabase();
@@ -131,7 +138,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v2' },
+        params: { uri: 'ui://lobu/interaction/v3.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -140,19 +147,67 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v2');
+    expect(content?.uri).toBe('ui://lobu/interaction/v3.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-interaction-stub');
+    const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
+    expect(baseHref).toBeDefined();
+    const resourceOrigin = new URL(baseHref!).origin;
+    expect(content?.text).toContain(
+      `<base href="${resourceOrigin}/mcp-apps/interaction/" />`
+    );
+    expect(content?.text).not.toContain('__LOBU_MCP_APP_ORIGIN__');
     expect(content?._meta?.ui?.csp).toEqual({
       connectDomains: [],
-      resourceDomains: [],
+      resourceDomains: [resourceOrigin],
       frameDomains: [],
     });
     expect(content?._meta?.ui?.prefersBorder).toBe(true);
     expect(content?._meta?.ui?.domain).toBeUndefined();
   });
 
-  it('advertises description and CSP metadata on resources/list without claiming a dedicated app domain', async () => {
+  it('serves only registered content-hashed MCP App JS/CSS assets with cross-origin headers', async () => {
+    const response = await get('/mcp-apps/interaction/assets/index-test.js');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/javascript');
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=31536000, immutable'
+    );
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    expect(response.headers.get('cross-origin-resource-policy')).toBe('cross-origin');
+    expect(await response.text()).toContain('mcpAppAsset');
+
+    expect((await get('/mcp-apps/interaction/assets/index-test.txt')).status).toBe(404);
+    expect((await get('/mcp-apps/unknown/assets/index-test.js')).status).toBe(404);
+  });
+
+  it('keeps retired Lobu interaction URIs readable for cached conversations', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    for (const uri of ['ui://lobu/interaction/v1', 'ui://lobu/interaction/v2']) {
+      const response = await post(`/mcp/${org.slug}`, {
+        body: {
+          jsonrpc: '2.0',
+          id: uri,
+          method: 'resources/read',
+          params: { uri },
+        },
+        headers: { 'mcp-session-id': sessionId },
+        token,
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.result?.contents?.[0]).toEqual(
+        expect.objectContaining({
+          uri,
+          mimeType: 'text/html;profile=mcp-app',
+          text: expect.stringContaining('mcp-app-interaction-stub'),
+        })
+      );
+    }
+  });
+
+  it('advertises description and external-asset CSP without claiming a sandbox domain', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
@@ -167,18 +222,23 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v2'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v3.html'
     );
     expect(resource).toBeDefined();
     // description is a typed resource field surfaced in client browsers.
     expect(typeof resource.description).toBe('string');
     expect(resource.description.length).toBeGreaterThan(0);
-    // CSP rides the current nested _meta.ui shape. ui.domain is intentionally
-    // absent because it means a dedicated sandbox origin, not the MCP server.
+    // CSP rides the current nested _meta.ui shape and allows only the serving
+    // origin to provide content-hashed JS/CSS assets. `ui.domain` is omitted:
+    // that field asks the host for a dedicated sandbox origin, not an asset host.
     expect(resource.mimeType).toBe('text/html;profile=mcp-app');
+    const resourceDomains = resource._meta?.ui?.csp?.resourceDomains;
+    expect(resourceDomains).toHaveLength(1);
+    const resourceOrigin = resourceDomains[0];
+    expect(resourceOrigin).toMatch(/^https?:\/\//);
     expect(resource._meta?.ui?.csp).toEqual({
       connectDomains: [],
-      resourceDomains: [],
+      resourceDomains: [resourceOrigin],
       frameDomains: [],
     });
     expect(resource._meta?.ui?.prefersBorder).toBe(true);
@@ -210,10 +270,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v2',
+            resourceUri: 'ui://lobu/interaction/v3.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v2',
+          'openai/outputTemplate': 'ui://lobu/interaction/v3.html',
         }),
       })
     );
@@ -232,12 +292,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v2',
+          resourceUri: 'ui://lobu/interaction/v3.html',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v2'
+        'ui://lobu/interaction/v3.html'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -290,7 +350,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v2',
+        resourceUri: 'ui://lobu/interaction/v3.html',
         visibility: ['model', 'app'],
       })
     );

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -161,6 +161,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       connectDomains: [],
       resourceDomains: [resourceOrigin],
       frameDomains: [],
+      baseUriDomains: [resourceOrigin],
     });
     expect(content?._meta?.ui?.prefersBorder).toBe(true);
     expect(content?._meta?.ui?.domain).toBeUndefined();
@@ -238,6 +239,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       connectDomains: [],
       resourceDomains: [resourceOrigin],
       frameDomains: [],
+      baseUriDomains: [resourceOrigin],
     });
     expect(resource._meta?.ui?.prefersBorder).toBe(true);
     expect(resource._meta?.ui?.domain).toBeUndefined();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2775,9 +2775,10 @@ app.all("/mcp/:orgSlug", handleMcp);
 app.all("/mcp/:orgSlug/", handleMcp);
 
 // MCP App bundle — public asset delivery (NOT an approval endpoint). The small
-// HTML template is returned by `resources/read`; content-hashed JS/CSS is loaded
-// from this explicitly declared resource domain. There is no action logic here
-// — each action rides an MCP `tools/call` brokered by the host bridge.
+// HTML template is returned by `resources/read`; stable JS/CSS is loaded from
+// this explicitly declared resource domain and revalidated on every use. Stable
+// names keep cached templates working across mixed-replica rollouts. There is no
+// action logic here — each action rides an MCP `tools/call` brokered by the host bridge.
 app.get("/mcp-apps/:app/index.html", async (c) => {
 	const app_ = c.req.param("app");
 	// Only serve a bundle the MCP App registry declares — never an arbitrary
@@ -2802,7 +2803,7 @@ app.get("/mcp-apps/:app/assets/:asset", async (c) => {
 			? "text/javascript; charset=utf-8"
 			: "text/css; charset=utf-8",
 	);
-	c.header("Cache-Control", "public, max-age=31536000, immutable");
+	c.header("Cache-Control", "no-cache");
 	c.header("Access-Control-Allow-Origin", "*");
 	c.header("Cross-Origin-Resource-Policy", "cross-origin");
 	return c.body(Uint8Array.from(asset).buffer);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -120,13 +120,14 @@ import { entityLinkMatchSql } from "./utils/content-search";
 import { isValidFrameAncestor } from "./utils/csp";
 import { errorMessage } from "./utils/errors";
 import logger from "./utils/logger";
-import { readMcpAppBundle } from "./utils/mcp-app-bundle";
+import { readMcpAppAsset, readMcpAppBundle } from "./utils/mcp-app-bundle";
 import { generateOpenAPISpec } from "./utils/openapi-generator";
 import {
 	extractSubdomainOrg,
 	getCanonicalRedirectUrl,
 	getConfiguredPublicOrigin,
 	getSubdomainZone,
+	resolvePublicOrigin,
 } from "./utils/public-origin";
 import {
 	getClientIP,
@@ -2773,23 +2774,38 @@ app.all("/mcp/", handleMcp);
 app.all("/mcp/:orgSlug", handleMcp);
 app.all("/mcp/:orgSlug/", handleMcp);
 
-// MCP App bundle — asset-only static delivery (NOT an approval endpoint). Serves
-// the self-contained `ui://` iframe payload built by owletto `build:mcp-apps`
-// (dist-mcp-apps/interaction/index.html) so our own SPA can host every
-// interactive interaction (approval, question, tool grant, link) in a sandboxed
-// iframe. There is no action logic here — each action rides an MCP `tools/call`
-// brokered by the SPA host bridge. The same `readMcpAppBundle` resolver backs
-// the MCP `resources/read` path for external hosts.
+// MCP App bundle — public asset delivery (NOT an approval endpoint). The small
+// HTML template is returned by `resources/read`; content-hashed JS/CSS is loaded
+// from this explicitly declared resource domain. There is no action logic here
+// — each action rides an MCP `tools/call` brokered by the host bridge.
 app.get("/mcp-apps/:app/index.html", async (c) => {
 	const app_ = c.req.param("app");
 	// Only serve a bundle the MCP App registry declares — never an arbitrary
 	// path param.
 	if (!MCP_APP_DIRS.has(app_)) return c.notFound();
-	const html = await readMcpAppBundle(app_);
+	const html = await readMcpAppBundle(app_, resolvePublicOrigin(c.req.url));
 	if (html == null) return c.notFound();
 	c.header("Content-Type", "text/html; charset=utf-8");
 	c.header("Cache-Control", "no-cache");
 	return c.body(html);
+});
+
+app.get("/mcp-apps/:app/assets/:asset", async (c) => {
+	const app_ = c.req.param("app");
+	if (!MCP_APP_DIRS.has(app_)) return c.notFound();
+	const assetName = c.req.param("asset");
+	const asset = await readMcpAppAsset(app_, `assets/${assetName}`);
+	if (asset == null) return c.notFound();
+	c.header(
+		"Content-Type",
+		assetName.endsWith(".js")
+			? "text/javascript; charset=utf-8"
+			: "text/css; charset=utf-8",
+	);
+	c.header("Cache-Control", "public, max-age=31536000, immutable");
+	c.header("Access-Control-Allow-Origin", "*");
+	c.header("Cross-Origin-Resource-Policy", "cross-origin");
+	return c.body(Uint8Array.from(asset).buffer);
 });
 
 /**

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -67,6 +67,10 @@ const SESSION_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 const SESSION_CLEANUP_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
 const MCP_APP_EXTENSION_ID = 'io.modelcontextprotocol/ui';
+const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['ui://lobu/interaction/v1', LOBU_INTERACTION_RESOURCE_URI],
+  ['ui://lobu/interaction/v2', LOBU_INTERACTION_RESOURCE_URI],
+]);
 // ---------------------------------------------------------------------------
 // Session store
 // ---------------------------------------------------------------------------
@@ -200,7 +204,8 @@ const MCP_APP_RESOURCES: Record<
     description:
       'Interactive Lobu cards rendered in a sandboxed iframe; actions use standard MCP tool calls or host-mediated external links.',
     appDir: 'interaction',
-    // postMessage-only: the app makes no network requests and embeds no frames.
+    // App logic is postMessage-only. The serving origin is added dynamically as
+    // the sole resource domain for the content-hashed JS/CSS bundle.
     csp: { connectDomains: [], resourceDomains: [], frameDomains: [] },
     prefersBorder: true,
   },
@@ -247,6 +252,27 @@ function supportsMcpApps(capabilities: Record<string, unknown> | null | undefine
   if (!uiExtension || typeof uiExtension !== 'object') return false;
   const mimeTypes = (uiExtension as Record<string, unknown>).mimeTypes;
   return Array.isArray(mimeTypes) && mimeTypes.includes(MCP_APP_MIME_TYPE);
+}
+
+function mcpAppUiMeta(
+  authCtx: SessionAuthContext,
+  app: (typeof MCP_APP_RESOURCES)[string]
+): {
+  csp: {
+    connectDomains: string[];
+    resourceDomains: string[];
+    frameDomains: string[];
+  };
+  prefersBorder: boolean;
+} {
+  const publicOrigin = resolvePublicOrigin(authCtx.requestUrl);
+  return {
+    csp: {
+      ...app.csp,
+      resourceDomains: [...new Set([...app.csp.resourceDomains, publicOrigin])],
+    },
+    prefersBorder: app.prefersBorder,
+  };
 }
 
 function createServerForContext(
@@ -318,10 +344,7 @@ function createServerForContext(
         description: meta.description,
         mimeType: MCP_APP_MIME_TYPE,
         _meta: {
-          ui: {
-            csp: meta.csp,
-            prefersBorder: meta.prefersBorder,
-          },
+          ui: mcpAppUiMeta(authCtx, meta),
         },
       })),
       ...Object.entries(MCP_SKILL_RESOURCES).map(([uri, meta]) => ({
@@ -342,9 +365,13 @@ function createServerForContext(
         contents: [{ uri, mimeType: 'text/markdown', text: skill.text }],
       };
     }
-    const app = MCP_APP_RESOURCES[uri];
+    const canonicalUri = MCP_APP_RESOURCE_ALIASES.get(uri) ?? uri;
+    const app = MCP_APP_RESOURCES[canonicalUri];
     if (!app) throw new Error(`Unknown resource: ${uri}`);
-    const html = await readMcpAppBundle(app.appDir);
+    const html = await readMcpAppBundle(
+      app.appDir,
+      resolvePublicOrigin(authCtx.requestUrl)
+    );
     if (html == null) {
       throw new Error(`MCP App bundle not built for ${uri} (run owletto build:mcp-apps)`);
     }
@@ -354,7 +381,7 @@ function createServerForContext(
           uri,
           mimeType: MCP_APP_MIME_TYPE,
           text: html,
-          _meta: { ui: { csp: app.csp, prefersBorder: app.prefersBorder } },
+          _meta: { ui: mcpAppUiMeta(authCtx, app) },
         },
       ],
     };

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -262,6 +262,7 @@ function mcpAppUiMeta(
     connectDomains: string[];
     resourceDomains: string[];
     frameDomains: string[];
+    baseUriDomains: string[];
   };
   prefersBorder: boolean;
 } {
@@ -272,6 +273,7 @@ function mcpAppUiMeta(
     csp: {
       ...app.csp,
       resourceDomains: [...new Set([...app.csp.resourceDomains, publicOrigin])],
+      baseUriDomains: [publicOrigin],
     },
     prefersBorder: app.prefersBorder,
   };

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -266,6 +266,8 @@ function mcpAppUiMeta(
   prefersBorder: boolean;
 } {
   const publicOrigin = resolvePublicOrigin(authCtx.requestUrl);
+  // This is an asset origin only. Keep it in CSP resourceDomains; ui.domain
+  // requests a dedicated host sandbox origin and must not be populated here.
   return {
     csp: {
       ...app.csp,

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -205,7 +205,7 @@ const MCP_APP_RESOURCES: Record<
       'Interactive Lobu cards rendered in a sandboxed iframe; actions use standard MCP tool calls or host-mediated external links.',
     appDir: 'interaction',
     // App logic is postMessage-only. The serving origin is added dynamically as
-    // the sole resource domain for the content-hashed JS/CSS bundle.
+    // the sole resource domain for the stable, revalidated JS/CSS bundle.
     csp: { connectDomains: [], resourceDomains: [], frameDomains: [] },
     prefersBorder: true,
   },

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v2';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v3.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;

--- a/packages/server/src/utils/mcp-app-bundle.ts
+++ b/packages/server/src/utils/mcp-app-bundle.ts
@@ -73,7 +73,7 @@ export async function readMcpAppBundle(
 }
 
 /**
- * Read one content-hashed JS/CSS file referenced by an MCP App template.
+ * Read one stable JS/CSS file referenced by an MCP App template.
  * Callers must still validate `appDir` against the app registry; this function
  * separately rejects traversal and every unrecognized extension.
  */

--- a/packages/server/src/utils/mcp-app-bundle.ts
+++ b/packages/server/src/utils/mcp-app-bundle.ts
@@ -3,8 +3,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
- * Locate + read a built MCP App bundle (a self-contained `ui://` iframe payload
- * produced by owletto's `build:mcp-apps`, e.g.
+ * Locate + read a built MCP App bundle produced by owletto's `build:mcp-apps`,
+ * e.g.
  * `packages/owletto/dist-mcp-apps/<appDir>/index.html`).
  *
  * Path resolution mirrors `resolveWebDistDirectory` in `index.ts` (the owletto
@@ -15,9 +15,11 @@ import { fileURLToPath } from 'node:url';
 
 // packages/server dir (mirror of APP_ROOT in index.ts).
 const APP_ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const ORIGIN_PLACEHOLDER = '__LOBU_MCP_APP_ORIGIN__';
+const SAFE_ASSET_PATH = /^assets\/[A-Za-z0-9._-]+\.(?:css|js)$/;
 
-function bundleCandidates(appDir: string): string[] {
-  const rel = path.join('dist-mcp-apps', appDir, 'index.html');
+function bundleFileCandidates(appDir: string, filename: string): string[] {
+  const rel = path.join('dist-mcp-apps', appDir, filename);
   const webDist = process.env.WEB_DIST_DIR?.trim();
   return [
     webDist ? path.join(webDist, '..', rel) : undefined,
@@ -35,17 +37,60 @@ function bundleCandidates(appDir: string): string[] {
 // instead of serving 404 until the pod restarts. Every interactive interaction
 // now depends on this one bundle, so a sticky miss would break all of them.
 const bundleCache = new Map<string, string>();
+const assetCache = new Map<string, Uint8Array>();
 
-/** Read a built MCP App bundle's HTML. Returns null when no build is present. */
-export async function readMcpAppBundle(appDir: string): Promise<string | null> {
+/**
+ * Read a built MCP App template. `publicOrigin` stamps an absolute base URL and
+ * the matching defense-in-depth CSP into the small HTML snapshot returned to a
+ * remote MCP host. The raw form remains useful to tests with minimal stubs.
+ */
+export async function readMcpAppBundle(
+  appDir: string,
+  publicOrigin?: string
+): Promise<string | null> {
   const cached = bundleCache.get(appDir);
+  let html = cached;
+  if (html === undefined) {
+    for (const candidate of bundleFileCandidates(appDir, 'index.html')) {
+      try {
+        await stat(candidate);
+        html = await readFile(candidate, 'utf8');
+        bundleCache.set(appDir, html);
+        break;
+      } catch {
+        // candidate absent — try the next
+      }
+    }
+  }
+  if (html === undefined) return null;
+  if (!publicOrigin) return html;
+
+  const assetBase = `${publicOrigin}/mcp-apps/${encodeURIComponent(appDir)}/`;
+  const withBase = html.includes('<base ')
+    ? html
+    : html.replace('<head>', `<head>\n\t\t<base href="${assetBase}" />`);
+  return withBase.replaceAll(ORIGIN_PLACEHOLDER, publicOrigin);
+}
+
+/**
+ * Read one content-hashed JS/CSS file referenced by an MCP App template.
+ * Callers must still validate `appDir` against the app registry; this function
+ * separately rejects traversal and every unrecognized extension.
+ */
+export async function readMcpAppAsset(
+  appDir: string,
+  assetPath: string
+): Promise<Uint8Array | null> {
+  if (!SAFE_ASSET_PATH.test(assetPath)) return null;
+  const cacheKey = `${appDir}/${assetPath}`;
+  const cached = assetCache.get(cacheKey);
   if (cached !== undefined) return cached;
-  for (const candidate of bundleCandidates(appDir)) {
+  for (const candidate of bundleFileCandidates(appDir, assetPath)) {
     try {
       await stat(candidate);
-      const html = await readFile(candidate, 'utf8');
-      bundleCache.set(appDir, html);
-      return html;
+      const asset = await readFile(candidate);
+      assetCache.set(cacheKey, asset);
+      return asset;
     } catch {
       // candidate absent — try the next
     }


### PR DESCRIPTION
## Summary
- pin merged Owletto #774, #775, and #776 and advertise a documented `.html` v3 MCP App resource URI
- keep v1/v2 resources/read aliases for cached conversations
- declare the public origin only for resource and base-URI CSP; correctly omit the dedicated sandbox `ui.domain` field
- serve a stable app.js/app.css pair with CORS, CORP, and revalidation so cached templates survive mixed-replica and later deployments
- reduce the complete resources/read JSON response to 1,142 bytes

## Verification
- make pre-pr
- database-backed MCP App integration suite (15/15)
- Owletto vitest suite (1309/1309) and production build
- live Chrome MCP bridge handshake and SQL pagination (rows 1-10 -> 11-20)

Pins merged lobu-ai/owletto#774, lobu-ai/owletto#775, and lobu-ai/owletto#776.