### PR TITLE
fix(calendar): persist durable sync cursor

### DIFF
--- a/packages/connectors/src/__tests__/google_calendar.test.ts
+++ b/packages/connectors/src/__tests__/google_calendar.test.ts
@@ -323,7 +323,7 @@ describe('GoogleCalendarConnector incremental sync', () => {
 describe('GoogleCalendarConnector virtual events feed', () => {
   test('events is virtual by default while changes remains collected', () => {
     const connector = new GoogleCalendarConnector();
-    expect(connector.definition.version).toBe('1.1.0');
+    expect(connector.definition.version).toBe('1.1.1');
     expect(connector.definition.feeds.events.virtual).toBe(true);
     expect(connector.definition.feeds.changes.virtual ?? false).toBe(false);
     expect(Object.keys(connector.definition.feeds.changes.eventKinds)).toContain('calendar_event');
@@ -389,7 +389,7 @@ describe('GoogleCalendarConnector virtual events feed', () => {
 
 
 describe('GoogleCalendarConnector durable changes feed', () => {
-  test('preserves cancellations and timestamps them at the provider change time', async () => {
+  test('initial traversal uses sync-compatible parameters, captures cursor, and preserves cancellations', async () => {
     const connector = new GoogleCalendarConnector();
     const changedAt = '2026-08-10T00:12:34.000Z';
     const cancelled = {
@@ -398,12 +398,12 @@ describe('GoogleCalendarConnector durable changes feed', () => {
       summary: undefined,
       updated: changedAt,
     };
-    const { client } = fakeHttp([{ items: [cancelled], nextSyncToken: 'NEXT' }]);
+    const { client, urls } = fakeHttp([{ items: [cancelled], nextSyncToken: 'NEXT' }]);
     connector.client = () => client;
 
     const result = await connector.sync({
       feedKey: 'changes',
-      config: { calendar_id: 'primary', max_results: 100 },
+      config: { calendar_id: 'primary', max_results: 100, lookback_days: 30 },
       credentials: { accessToken: 'tok' },
       checkpoint: null,
     });
@@ -414,5 +414,65 @@ describe('GoogleCalendarConnector durable changes feed', () => {
     expect(result.events[0]?.metadata?.status).toBe('cancelled');
     expect(result.events[0]?.metadata?.change_type).toBe('cancelled');
     expect(result.checkpoint.sync_token).toBe('NEXT');
+
+    const first = new URL(urls[0]);
+    expect(first.searchParams.get('singleEvents')).toBe('true');
+    expect(first.searchParams.get('showDeleted')).toBe('true');
+    expect(first.searchParams.get('orderBy')).toBeNull();
+    expect(first.searchParams.get('timeMin')).toBeNull();
+    expect(first.searchParams.get('timeMax')).toBeNull();
+    expect(first.searchParams.get('syncToken')).toBeNull();
+  });
+
+  test('incremental traversal keeps sync-compatible parameters and never drops changes before advancing the token', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client, urls } = fakeHttp([
+      {
+        items: [
+          calEvent('changed-1', '2026-08-10T10:00:00Z'),
+          calEvent('changed-2', '2026-08-11T10:00:00Z'),
+        ],
+        nextSyncToken: 'FRESH',
+      },
+    ]);
+    connector.client = () => client;
+
+    const result = await connector.sync({
+      feedKey: 'changes',
+      config: { calendar_id: 'primary', max_results: 1 },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { sync_token: 'OLD' },
+    });
+
+    // max_results bounds only the historical bootstrap. Once a sync token
+    // exists, every returned change must be persisted before advancing it.
+    expect(
+      result.events.map((event: { origin_id: string }) => event.origin_id).sort()
+    ).toEqual(['changed-1', 'changed-2']);
+    expect(result.checkpoint.sync_token).toBe('FRESH');
+
+    const first = new URL(urls[0]);
+    expect(first.searchParams.get('syncToken')).toBe('OLD');
+    expect(first.searchParams.get('singleEvents')).toBe('true');
+    expect(first.searchParams.get('showDeleted')).toBe('true');
+    expect(first.searchParams.get('orderBy')).toBeNull();
+    expect(first.searchParams.get('timeMin')).toBeNull();
+    expect(first.searchParams.get('timeMax')).toBeNull();
+    expect(first.searchParams.get('maxResults')).toBe('250');
+  });
+
+  test('fails closed when a changes traversal completes without a durable sync token', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client } = fakeHttp([{ items: [calEvent('a', '2026-08-10T10:00:00Z')] }]);
+    connector.client = () => client;
+
+    await expect(
+      connector.sync({
+        feedKey: 'changes',
+        config: { calendar_id: 'primary', max_results: 100 },
+        credentials: { accessToken: 'tok' },
+        checkpoint: null,
+      })
+    ).rejects.toThrow(/sync token/i);
   });
 });

--- a/packages/connectors/src/__tests__/google_calendar.test.ts
+++ b/packages/connectors/src/__tests__/google_calendar.test.ts
@@ -389,7 +389,7 @@ describe('GoogleCalendarConnector virtual events feed', () => {
 
 
 describe('GoogleCalendarConnector durable changes feed', () => {
-  test('initial traversal uses sync-compatible parameters, captures cursor, and preserves cancellations', async () => {
+  test('initial traversal applies lookback, captures cursor, and preserves cancellations', async () => {
     const connector = new GoogleCalendarConnector();
     const changedAt = '2026-08-10T00:12:34.000Z';
     const cancelled = {
@@ -414,12 +414,13 @@ describe('GoogleCalendarConnector durable changes feed', () => {
     expect(result.events[0]?.metadata?.status).toBe('cancelled');
     expect(result.events[0]?.metadata?.change_type).toBe('cancelled');
     expect(result.checkpoint.sync_token).toBe('NEXT');
+    expect(result.checkpoint.param_version).toBe(1);
 
     const first = new URL(urls[0]);
     expect(first.searchParams.get('singleEvents')).toBe('true');
     expect(first.searchParams.get('showDeleted')).toBe('true');
     expect(first.searchParams.get('orderBy')).toBeNull();
-    expect(first.searchParams.get('timeMin')).toBeNull();
+    expect(first.searchParams.get('timeMin')).toBeTruthy();
     expect(first.searchParams.get('timeMax')).toBeNull();
     expect(first.searchParams.get('syncToken')).toBeNull();
   });
@@ -428,10 +429,11 @@ describe('GoogleCalendarConnector durable changes feed', () => {
     const connector = new GoogleCalendarConnector();
     const { client, urls } = fakeHttp([
       {
-        items: [
-          calEvent('changed-1', '2026-08-10T10:00:00Z'),
-          calEvent('changed-2', '2026-08-11T10:00:00Z'),
-        ],
+        items: [calEvent('changed-1', '2026-08-10T10:00:00Z')],
+        nextPageToken: 'p2',
+      },
+      {
+        items: [calEvent('changed-2', '2026-08-11T10:00:00Z')],
         nextSyncToken: 'FRESH',
       },
     ]);
@@ -441,15 +443,15 @@ describe('GoogleCalendarConnector durable changes feed', () => {
       feedKey: 'changes',
       config: { calendar_id: 'primary', max_results: 1 },
       credentials: { accessToken: 'tok' },
-      checkpoint: { sync_token: 'OLD' },
+      checkpoint: { sync_token: 'OLD', param_version: 1 },
     });
 
-    // max_results bounds only the historical bootstrap. Once a sync token
-    // exists, every returned change must be persisted before advancing it.
     expect(
       result.events.map((event: { origin_id: string }) => event.origin_id).sort()
     ).toEqual(['changed-1', 'changed-2']);
     expect(result.checkpoint.sync_token).toBe('FRESH');
+    expect(result.checkpoint.param_version).toBe(1);
+    expect(urls).toHaveLength(2);
 
     const first = new URL(urls[0]);
     expect(first.searchParams.get('syncToken')).toBe('OLD');
@@ -459,6 +461,42 @@ describe('GoogleCalendarConnector durable changes feed', () => {
     expect(first.searchParams.get('timeMin')).toBeNull();
     expect(first.searchParams.get('timeMax')).toBeNull();
     expect(first.searchParams.get('maxResults')).toBe('250');
+
+    const second = new URL(urls[1]);
+    expect(second.searchParams.get('syncToken')).toBe('OLD');
+    expect(second.searchParams.get('pageToken')).toBe('p2');
+    expect(second.searchParams.get('singleEvents')).toBe('true');
+    expect(second.searchParams.get('showDeleted')).toBe('true');
+  });
+
+  test('a legacy (unversioned) changes checkpoint rolls over with one full traversal instead of replaying its token', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client, urls } = fakeHttp([
+      { items: [calEvent('rolled-1', '2026-08-10T10:00:00Z')], nextSyncToken: 'V2' },
+    ]);
+    connector.client = () => client;
+
+    const result = await connector.sync({
+      feedKey: 'changes',
+      config: { calendar_id: 'primary', max_results: 100 },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { sync_token: 'LEGACY' },
+    });
+
+    const first = new URL(urls[0]);
+    expect(first.searchParams.get('syncToken')).toBeNull();
+    expect(first.searchParams.get('singleEvents')).toBe('true');
+    expect(first.searchParams.get('showDeleted')).toBe('true');
+    expect(first.searchParams.get('orderBy')).toBeNull();
+    expect(first.searchParams.get('timeMin')).toBeTruthy();
+    expect(first.searchParams.get('timeMax')).toBeNull();
+    expect(urls).toHaveLength(1);
+
+    expect(result.events.map((event: { origin_id: string }) => event.origin_id)).toEqual([
+      'rolled-1',
+    ]);
+    expect(result.checkpoint.sync_token).toBe('V2');
+    expect(result.checkpoint.param_version).toBe(1);
   });
 
   test('fails closed when a changes traversal completes without a durable sync token', async () => {
@@ -472,6 +510,21 @@ describe('GoogleCalendarConnector durable changes feed', () => {
         config: { calendar_id: 'primary', max_results: 100 },
         credentials: { accessToken: 'tok' },
         checkpoint: null,
+      })
+    ).rejects.toThrow(/sync token/i);
+  });
+
+  test('fails closed when an incremental changes traversal omits its replacement token', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client } = fakeHttp([{ items: [calEvent('a', '2026-08-10T10:00:00Z')] }]);
+    connector.client = () => client;
+
+    await expect(
+      connector.sync({
+        feedKey: 'changes',
+        config: { calendar_id: 'primary', max_results: 100 },
+        credentials: { accessToken: 'tok' },
+        checkpoint: { sync_token: 'OLD', param_version: 1 },
       })
     ).rejects.toThrow(/sync token/i);
   });

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -125,7 +125,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     key: 'google.calendar',
     name: 'Google Calendar',
     description: 'Syncs calendar events from Google Calendar and supports creating new events.',
-    version: '1.1.0',
+    version: '1.1.1',
     faviconDomain: 'calendar.google.com',
     authSchema: {
       methods: [
@@ -499,16 +499,23 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
     const pages = paginateByCursor<CalendarEvent, string>(
       async (pageToken) => {
-        // Always request a full page — `maxResults` is a soft cap on *stored*
-        // events, not a reason to shrink the request size (shrinking to 1 once
-        // the cap is hit would crawl a busy calendar one event per round-trip).
-        const params = new URLSearchParams({
-          maxResults: '250',
-          orderBy: 'startTime',
-          singleEvents: 'true',
-          timeMin: timeMin.toISOString(),
-          timeMax: timeMax.toISOString(),
-        });
+        // The durable changes feed establishes Google's incremental cursor.
+        // Keep that request sync-compatible: no order/time filters and include
+        // deleted rows. The legacy collected events feed keeps its bounded
+        // snapshot request for backwards compatibility.
+        const params = durableChanges
+          ? new URLSearchParams({
+              maxResults: '250',
+              singleEvents: 'true',
+              showDeleted: 'true',
+            })
+          : new URLSearchParams({
+              maxResults: '250',
+              orderBy: 'startTime',
+              singleEvents: 'true',
+              timeMin: timeMin.toISOString(),
+              timeMax: timeMax.toISOString(),
+            });
         if (pageToken) {
           params.set('pageToken', pageToken);
         }
@@ -544,6 +551,12 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
           : this.calendarEventToEnvelope(calEvent);
         if (envelope) events.push(envelope);
       }
+    }
+
+    if (durableChanges && !nextSyncToken) {
+      throw new Error(
+        'Google Calendar changes traversal completed without a durable sync token.'
+      );
     }
 
     return this.buildResult(events, nextSyncToken, events.length);
@@ -608,12 +621,20 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
     const pages = paginateByCursor<CalendarEvent, string>(
       async (pageToken) => {
-        const params = new URLSearchParams({
-          // Page size shrinks toward the remaining cap as events accumulate,
-          // matching the original dynamic sizing.
-          maxResults: String(Math.max(1, Math.min(250, maxResults - events.length))),
-          syncToken,
-        });
+        // Once the durable changes cursor exists, every provider change must be
+        // consumed before we advance the token. max_results only limits the
+        // historical bootstrap; it must never truncate an incremental window.
+        const params = durableChanges
+          ? new URLSearchParams({
+              maxResults: '250',
+              syncToken,
+              singleEvents: 'true',
+              showDeleted: 'true',
+            })
+          : new URLSearchParams({
+              maxResults: String(Math.max(1, Math.min(250, maxResults - events.length))),
+              syncToken,
+            });
         if (pageToken) {
           params.set('pageToken', pageToken);
         }
@@ -648,6 +669,11 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     }
 
     if (syncTokenRejected) return null;
+    if (durableChanges && !nextSyncToken) {
+      throw new Error(
+        'Google Calendar incremental changes traversal completed without a durable sync token.'
+      );
+    }
 
     return { events, nextSyncToken };
   }

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -57,8 +57,14 @@ interface CalendarEventListResponse {
 // Checkpoint
 // ---------------------------------------------------------------------------
 
+// Google binds allowed query parameters to a changes sync token. Unversioned
+// v1.1.0 checkpoints predate `showDeleted`, so roll them over without replaying
+// their tokens under the current query shape.
+const CHANGES_CURSOR_VERSION = 1;
+
 interface CalendarCheckpoint {
   sync_token?: string;
+  param_version?: number;
   last_sync_at?: string;
 }
 
@@ -217,7 +223,8 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
             },
             max_results: {
               type: 'integer', minimum: 1, maximum: 2500, default: 100,
-              description: 'Maximum change events to persist per collection run.',
+              description:
+                'Maximum events to persist during initial collection; incremental collections persist every change.',
             },
           },
         },
@@ -465,8 +472,11 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     const events: EventEnvelope[] = [];
     const durableChanges = ctx.feedKey === 'changes';
 
-    // Try incremental sync with syncToken first
-    if (checkpoint.sync_token) {
+    // Durable changes tokens are reusable only under the query shape that
+    // minted them. The legacy events feed retains its existing token behavior.
+    const tokenMintsCurrentShape =
+      !durableChanges || checkpoint.param_version === CHANGES_CURSOR_VERSION;
+    if (checkpoint.sync_token && tokenMintsCurrentShape) {
       const result = await this.syncWithToken(
         http,
         calendarId,
@@ -475,7 +485,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
         durableChanges
       );
       if (result) {
-        return this.buildResult(result.events, result.nextSyncToken, result.events.length);
+        return this.buildResult(result.events, result.nextSyncToken, durableChanges);
       }
       // The stored token was rejected (see isSyncTokenRejection). Fall through
       // to a full sync exactly once — no retry loop. The full sync below either
@@ -499,15 +509,14 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
     const pages = paginateByCursor<CalendarEvent, string>(
       async (pageToken) => {
-        // The durable changes feed establishes Google's incremental cursor.
-        // Keep that request sync-compatible: no order/time filters and include
-        // deleted rows. The legacy collected events feed keeps its bounded
-        // snapshot request for backwards compatibility.
+        // Google permits timeMin on the initial full sync but forbids it with
+        // syncToken. Other durable parameters remain stable across both paths.
         const params = durableChanges
           ? new URLSearchParams({
               maxResults: '250',
               singleEvents: 'true',
               showDeleted: 'true',
+              timeMin: timeMin.toISOString(),
             })
           : new URLSearchParams({
               maxResults: '250',
@@ -559,7 +568,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       );
     }
 
-    return this.buildResult(events, nextSyncToken, events.length);
+    return this.buildResult(events, nextSyncToken, durableChanges);
   }
 
   // -------------------------------------------------------------------------
@@ -621,9 +630,8 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
     const pages = paginateByCursor<CalendarEvent, string>(
       async (pageToken) => {
-        // Once the durable changes cursor exists, every provider change must be
-        // consumed before we advance the token. max_results only limits the
-        // historical bootstrap; it must never truncate an incremental window.
+        // Consume every incremental change before advancing the durable token;
+        // max_results limits only the historical bootstrap.
         const params = durableChanges
           ? new URLSearchParams({
               maxResults: '250',
@@ -951,7 +959,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
   private buildResult(
     events: EventEnvelope[],
     syncToken: string | undefined,
-    itemsFound: number
+    durableChanges: boolean
   ): SyncResult {
     // Sort events by occurred_at descending
     events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
@@ -962,6 +970,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     // the key is absent, and the next run correctly starts from a full sync.
     const newCheckpoint: CalendarCheckpoint = {
       ...(syncToken ? { sync_token: syncToken } : {}),
+      ...(durableChanges && syncToken ? { param_version: CHANGES_CURSOR_VERSION } : {}),
       last_sync_at: new Date().toISOString(),
     };
 
@@ -969,7 +978,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       events,
       checkpoint: newCheckpoint as Record<string, unknown>,
       metadata: {
-        items_found: itemsFound,
+        items_found: events.length,
       },
     };
   }


### PR DESCRIPTION
Make the collected Calendar changes feed use Google sync-token-compatible request parameters, include cancellations, persist every incremental change before advancing the token, fail closed if Google does not return a durable cursor, and bump google.calendar to 1.1.1.

Rolls over legacy v1.1.0 change tokens: the changes feed now sends `showDeleted`/`singleEvents`, which Google binds to the token minted at initial sync. Old checkpoints carry no `param_version`, so their tokens are discarded and one full traversal mints a fresh token under the new query shape before any incremental sync resumes.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] `make pre-pr-remote` Depot preflight passed
- [x] Tests run: `bun test packages/connectors/src/__tests__/google_calendar.test.ts` → 16/16; full connectors suite 335 pass
- [x] `make review` → bug_free 94, simplicity 93, bugs 0, 0 blockers
- [x] `make ui-review` → N/A (no Owletto pointer change)
- [x] Bug fix: red→fix→green below

### Red (legacy token replayed under new query shape)
```
bun test packages/connectors/src/__tests__/google_calendar.test.ts
  (fail) GoogleCalendarConnector durable changes feed > a legacy (unversioned)
         changes checkpoint rolls over with one full traversal instead of
         replaying its token [3.26ms]
  14 pass
  1 fail
error: expect(received).toBeNull()  Received: "LEGACY"
```

### Green
```
bun test packages/connectors/src/__tests__/google_calendar.test.ts
  16 pass
  0 fail
  72 expect() calls
Ran 16 tests across 1 file.
```

## Notes
The Owletto `check-drift` failure on the pre-rebase commit was resolved by rebasing onto current `origin/main`, which already carries the pointer bump.