### PR TITLE
fix(server): remove superseded REST window/execute routes

### DIFF
--- a/packages/server/src/__tests__/integration/behaviors/window-behavior-keys.test.ts
+++ b/packages/server/src/__tests__/integration/behaviors/window-behavior-keys.test.ts
@@ -1,19 +1,17 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../../../index";
+import { getBehavior } from "../../../tools/get_behavior";
 import { manageBehaviors } from "../../../tools/admin/manage_behaviors";
 import { initWorkspaceProvider } from "../../../workspace";
 import { cleanupTestDatabase } from "../../setup/test-db";
 import {
 	createCanvasWindow,
-	createTestAccessToken,
 	createTestAgent,
 	createTestEntity,
-	createTestOAuthClient,
 	seedOwnerContext,
 } from "../../setup/test-fixtures";
-import { get } from "../../setup/test-helpers";
 
-describe("REST behavior window vocabulary", () => {
+describe("Behavior window vocabulary", () => {
 	beforeAll(async () => {
 		await initWorkspaceProvider();
 	});
@@ -57,7 +55,7 @@ describe("REST behavior window vocabulary", () => {
 		const behaviorId = Number(created.behavior_id);
 		expect(Number.isFinite(behaviorId)).toBe(true);
 
-		const windowId = await createCanvasWindow({
+		await createCanvasWindow({
 			watcherId: behaviorId,
 			organizationId: org.id,
 			granularity: "day",
@@ -67,28 +65,19 @@ describe("REST behavior window vocabulary", () => {
 			extractedData: { summary: "window" },
 		});
 
-		const client = await createTestOAuthClient({ client_name: "Test" });
-		const login = await createTestAccessToken(
-			user.id,
-			org.id,
-			client.client_id,
-			{
-				scope: "mcp:read mcp:write",
-			},
+		const detail = await getBehavior(
+			{ behavior_id: String(behaviorId) },
+			{} as Env,
+			ctx,
 		);
+		expect(detail.windows).toHaveLength(1);
 
-		const response = await get(
-			`/api/${org.slug}/behaviors/windows/${windowId}`,
-			{ token: login.token },
-		);
-		expect(response.status).toBe(200);
-
-		const body = (await response.json()) as Record<string, unknown>;
-		expect(body).not.toHaveProperty("watcher_id");
-		expect(body).not.toHaveProperty("watcher_slug");
-		expect(body).not.toHaveProperty("watcher_name");
-		expect(String(body.behavior_id)).toBe(String(behaviorId));
-		expect(body.behavior_slug).toBe("window-vocab");
-		expect(body.behavior_name).toBe("Window vocab");
+		const window = detail.windows[0];
+		expect(window).not.toHaveProperty("watcher_id");
+		expect(window).not.toHaveProperty("watcher_slug");
+		expect(window).not.toHaveProperty("watcher_name");
+		expect(String(window.behavior_id)).toBe(String(behaviorId));
+		expect(window.behavior_name).toBe("Window vocab");
+		expect(detail.behavior?.slug).toBe("window-vocab");
 	});
 });

--- a/packages/server/src/__tests__/unit/http/rest-tool-routes.test.ts
+++ b/packages/server/src/__tests__/unit/http/rest-tool-routes.test.ts
@@ -183,6 +183,15 @@ describe("fixed-action REST route registrations", () => {
 		expect(indexSrc.match(/restToolAction\(/g)).toHaveLength(3);
 	});
 
+	it("no longer registers the superseded window/execute REST routes", () => {
+		// Both were replaced by the generic tool-dispatch surface
+		// (`get_behavior` via `/behaviors?behavior_id=…` and the
+		// `POST /:orgSlug/:toolName` proxy). Asserting the literals are gone
+		// names exactly what was deleted and stops a re-introduction.
+		expect(indexSrc).not.toContain("behaviors/windows/:windowId");
+		expect(indexSrc).not.toContain("actions/execute");
+	});
+
 	it("registers read-only proxy GETs from the declaration table", () => {
 		expect(indexSrc).toContain("for (const route of REST_TOOL_GET_ROUTES)");
 	});

--- a/packages/server/src/__tests__/unit/http/rest-tool-routes.test.ts
+++ b/packages/server/src/__tests__/unit/http/rest-tool-routes.test.ts
@@ -180,7 +180,7 @@ describe("fixed-action REST route registrations", () => {
 		const bareProxyCalls = indexSrc.match(/restToolProxy\(/g) ?? [];
 		expect(bareProxyCalls).toHaveLength(1);
 
-		expect(indexSrc.match(/restToolAction\(/g)).toHaveLength(4);
+		expect(indexSrc.match(/restToolAction\(/g)).toHaveLength(3);
 	});
 
 	it("registers read-only proxy GETs from the declaration table", () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1169,60 +1169,6 @@ app.patch(
 );
 app.get("/api/:orgSlug/behaviors", mcpAuth, restGetBehaviors);
 app.get("/api/:orgSlug/public/behaviors", publicRestGetBehaviors);
-app.get("/api/:orgSlug/behaviors/windows/:windowId", mcpAuth, async (c) => {
-	const sql = getDb();
-	const windowId = c.req.param("windowId");
-	const organizationId = c.var.organizationId;
-
-	try {
-		// Canvas-on-events: windowId is the canvas ROOT event id; canvas_windows
-		// resolves the chain (head payload + run provenance). Content links are
-		// counted off watcher_window_events.window_id (re-keyed to the root id).
-		const windowResult = await sql`
-      SELECT
-        iw.id,
-        iw.watcher_id AS behavior_id,
-        iw.granularity,
-        iw.window_start,
-        iw.window_end,
-        iw.version_id,
-        iw.created_at,
-        iw.extracted_data,
-        iw.content_analyzed,
-        iw.client_id,
-        iw.model_used,
-        iw.run_metadata,
-        i.entity_ids,
-        i.slug AS behavior_slug,
-        i.name AS behavior_name,
-        e.name as entity_name,
-        et.slug AS entity_type,
-        parent.name as parent_name,
-        CAST(COUNT(iwf.event_id) AS INTEGER) as content_count
-      FROM canvas_windows iw
-      JOIN watchers i ON i.id = iw.watcher_id
-      JOIN entities e ON e.id = ANY(i.entity_ids)
-      JOIN entity_types et ON et.id = e.entity_type_id
-      LEFT JOIN entities parent ON e.parent_id = parent.id
-      LEFT JOIN watcher_window_events iwf ON iwf.window_id = iw.id
-      WHERE iw.id = ${windowId}
-        AND e.organization_id = ${organizationId}
-        AND i.status = 'active'
-      GROUP BY iw.id, iw.watcher_id, iw.granularity, iw.window_start, iw.window_end,
-               iw.version_id, iw.created_at, iw.extracted_data, iw.content_analyzed,
-               iw.client_id, iw.model_used, iw.run_metadata,
-               i.entity_ids, i.slug, i.name, e.name, et.slug, parent.name
-    `;
-
-		if (windowResult.length === 0) {
-			return c.json({ error: "Window not found" }, 404);
-		}
-
-		return c.json(windowResult[0]);
-	} catch (error) {
-		return c.json({ error: errorMessage(error) }, 500);
-	}
-});
 
 async function handleContentDistribution(c: Context<{ Bindings: Env }>) {
 	const sql = getDb();
@@ -1300,12 +1246,6 @@ app.delete("/api/:orgSlug/connections/:id", mcpAuth, async (c) => {
 	return restToolAction(c, "manage_connections", "delete", {
 		connection_id: Number(c.req.param("id")),
 	});
-});
-
-// Actions
-app.post("/api/:orgSlug/actions/execute", mcpAuth, async (c) => {
-	const body = await c.req.json();
-	return restToolAction(c, "manage_operations", "execute", body);
 });
 
 function serializeEntityApprovalPolicy(policy: EntityApprovalPolicy) {


### PR DESCRIPTION
## Summary
Two REST routes were superseded by the generic tool-dispatch surface and had no consumers on `origin/main`:

- `GET /api/:orgSlug/behaviors/windows/:windowId` — its per-window fetch is served by `get_behavior` (via `GET /api/:orgSlug/behaviors?behavior_id=X`), which returns the same `canvas_windows` rows with pagination, reactions, classification stats, versions, and scoped read access (`requireWatcherReadAccess`). Deleted ~54 lines of inline SQL.
- `POST /api/:orgSlug/actions/execute` — a thin alias for `manage_operations: execute`, which the generic `POST /api/:orgSlug/:toolName` proxy and `restToolAction` already dispatch. `GET /api/:orgSlug/actions/available` (`list_available`) stays registered via `REST_TOOL_GET_ROUTES`.

The Behavior-vocabulary guarantee (windows expose `behavior_*` keys, never `watcher_*`) was only asserted against the deleted route. The test was retargeted at `get_behavior` directly — same guarantee, replacement surface. `public/behaviors` and the eval scaffold are untouched (the former is live; the latter has no route).

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] `bunx vitest run src/__tests__/integration/behaviors/window-behavior-keys.test.ts` → 1/1 pass against local PG18 `lobu_test` (retargeted vocabulary test)
- [x] `bun test src/__tests__/unit/http/rest-tool-routes.test.ts` → 16/16 pass (updated `restToolAction(` call-count 4→3 to match the removed route)
- [ ] `make test-integration` (CI)

## Notes
Review-fix pass (codex) caught the `restToolAction(` count assertion in `rest-tool-routes.test.ts` and cleaned up the test's leftover OAuth-route scaffolding. No DB, SDK, or MCP-tool surface changed — only two unused HTTP aliases are gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed the authenticated behavior-window detail endpoint.
  * Removed the authenticated REST action-execution endpoint.
* **Tests**
  * Updated window information checks to use behavior details.
  * Refined validation of window metadata and behavior identifiers.
  * Updated route coverage to reflect the removed endpoints.
  * Added safeguards confirming superseded REST routes are no longer registered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->