### PR TITLE
fix(mcp): stage app assets before v3 rollout

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -60,6 +60,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       join(tmpRoot, 'dist-mcp-apps', 'interaction', 'assets', 'app.js'),
       'document.body.dataset.mcpAppAsset = "loaded";'
     );
+    writeFileSync(
+      join(tmpRoot, 'dist-mcp-apps', 'interaction', 'assets', 'app.css'),
+      '[data-mcp-app] { display: block; }'
+    );
     process.env.WEB_DIST_DIR = join(tmpRoot, 'dist');
 
     await cleanupTestDatabase();
@@ -180,6 +184,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(assetResponse.headers.get('access-control-allow-origin')).toBe('*');
     expect(assetResponse.headers.get('cross-origin-resource-policy')).toBe('cross-origin');
     expect(await assetResponse.text()).toContain('mcpAppAsset');
+
+    const styleResponse = await get('/mcp-apps/interaction/assets/app.css');
+    expect(styleResponse.status).toBe(200);
+    expect(styleResponse.headers.get('content-type')).toContain('text/css');
+    expect(styleResponse.headers.get('cache-control')).toBe('no-cache');
+    expect(styleResponse.headers.get('access-control-allow-origin')).toBe('*');
+    expect(styleResponse.headers.get('cross-origin-resource-policy')).toBe('cross-origin');
+    expect(await styleResponse.text()).toContain('[data-mcp-app]');
 
     expect((await get('/mcp-apps/interaction/assets/app.txt')).status).toBe(404);
     expect((await get('/mcp-apps/unknown/assets/app.js')).status).toBe(404);

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -17,11 +17,12 @@ import {
   createTestUser,
   seedSystemEntityTypes,
 } from '../../setup/test-fixtures';
-import { post } from '../../setup/test-helpers';
+import { get, post } from '../../setup/test-helpers';
 
-// Marker in the stub bundle so we can assert the served HTML is ours.
-const STUB_HTML =
-  '<!doctype html><html><body data-test="mcp-app-interaction-stub">interaction</body></html>';
+const STUB_LEGACY_HTML =
+  '<!doctype html><html><body data-test="mcp-app-legacy-v2-stub">legacy v2</body></html>';
+const STUB_EXTERNAL_HTML =
+  '<!doctype html><html><head><script type="module" src="./assets/app.js"></script></head><body>external v3</body></html>';
 
 describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -44,7 +45,21 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'interaction'), {
       recursive: true,
     });
-    writeFileSync(join(tmpRoot, 'dist-mcp-apps', 'interaction', 'index.html'), STUB_HTML);
+    mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'interaction', 'assets'), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(tmpRoot, 'dist-mcp-apps', 'interaction', 'legacy-v2.html'),
+      STUB_LEGACY_HTML
+    );
+    writeFileSync(
+      join(tmpRoot, 'dist-mcp-apps', 'interaction', 'index.html'),
+      STUB_EXTERNAL_HTML
+    );
+    writeFileSync(
+      join(tmpRoot, 'dist-mcp-apps', 'interaction', 'assets', 'app.js'),
+      'document.body.dataset.mcpAppAsset = "loaded";'
+    );
     process.env.WEB_DIST_DIR = join(tmpRoot, 'dist');
 
     await cleanupTestDatabase();
@@ -142,7 +157,8 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const content = body.result?.contents?.[0];
     expect(content?.uri).toBe('ui://lobu/interaction/v2');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
-    expect(content?.text).toContain('mcp-app-interaction-stub');
+    expect(content?.text).toContain('mcp-app-legacy-v2-stub');
+    expect(content?.text).not.toContain('external v3');
     expect(content?._meta?.ui?.csp).toEqual({
       connectDomains: [],
       resourceDomains: [],
@@ -150,6 +166,23 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     });
     expect(content?._meta?.ui?.prefersBorder).toBe(true);
     expect(content?._meta?.ui?.domain).toBeUndefined();
+  });
+
+  it('stages stable assets without switching the v2 HTML route during phase 1', async () => {
+    const htmlResponse = await get('/mcp-apps/interaction/index.html');
+    expect(htmlResponse.status).toBe(200);
+    expect(await htmlResponse.text()).toContain('mcp-app-legacy-v2-stub');
+
+    const assetResponse = await get('/mcp-apps/interaction/assets/app.js');
+    expect(assetResponse.status).toBe(200);
+    expect(assetResponse.headers.get('content-type')).toContain('text/javascript');
+    expect(assetResponse.headers.get('cache-control')).toBe('no-cache');
+    expect(assetResponse.headers.get('access-control-allow-origin')).toBe('*');
+    expect(assetResponse.headers.get('cross-origin-resource-policy')).toBe('cross-origin');
+    expect(await assetResponse.text()).toContain('mcpAppAsset');
+
+    expect((await get('/mcp-apps/interaction/assets/app.txt')).status).toBe(404);
+    expect((await get('/mcp-apps/unknown/assets/app.js')).status).toBe(404);
   });
 
   it('advertises description and CSP metadata on resources/list without claiming a dedicated app domain', async () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -120,7 +120,7 @@ import { entityLinkMatchSql } from "./utils/content-search";
 import { isValidFrameAncestor } from "./utils/csp";
 import { errorMessage } from "./utils/errors";
 import logger from "./utils/logger";
-import { readMcpAppBundle } from "./utils/mcp-app-bundle";
+import { readMcpAppAsset, readMcpAppBundle } from "./utils/mcp-app-bundle";
 import { generateOpenAPISpec } from "./utils/openapi-generator";
 import {
 	extractSubdomainOrg,
@@ -2773,23 +2773,37 @@ app.all("/mcp/", handleMcp);
 app.all("/mcp/:orgSlug", handleMcp);
 app.all("/mcp/:orgSlug/", handleMcp);
 
-// MCP App bundle — asset-only static delivery (NOT an approval endpoint). Serves
-// the self-contained `ui://` iframe payload built by owletto `build:mcp-apps`
-// (dist-mcp-apps/interaction/index.html) so our own SPA can host every
-// interactive interaction (approval, question, tool grant, link) in a sandboxed
-// iframe. There is no action logic here — each action rides an MCP `tools/call`
-// brokered by the SPA host bridge. The same `readMcpAppBundle` resolver backs
-// the MCP `resources/read` path for external hosts.
+// MCP App rollout phase 1: keep serving the existing self-contained v2
+// template while staging the stable external assets on every replica. A later
+// release switches this HTML route and MCP discovery to the external template.
 app.get("/mcp-apps/:app/index.html", async (c) => {
 	const app_ = c.req.param("app");
 	// Only serve a bundle the MCP App registry declares — never an arbitrary
 	// path param.
 	if (!MCP_APP_DIRS.has(app_)) return c.notFound();
-	const html = await readMcpAppBundle(app_);
+	const html = await readMcpAppBundle(app_, "legacy-v2.html");
 	if (html == null) return c.notFound();
 	c.header("Content-Type", "text/html; charset=utf-8");
 	c.header("Cache-Control", "no-cache");
 	return c.body(html);
+});
+
+app.get("/mcp-apps/:app/assets/:asset", async (c) => {
+	const app_ = c.req.param("app");
+	if (!MCP_APP_DIRS.has(app_)) return c.notFound();
+	const assetName = c.req.param("asset");
+	const asset = await readMcpAppAsset(app_, `assets/${assetName}`);
+	if (asset == null) return c.notFound();
+	c.header(
+		"Content-Type",
+		assetName.endsWith(".js")
+			? "text/javascript; charset=utf-8"
+			: "text/css; charset=utf-8",
+	);
+	c.header("Cache-Control", "no-cache");
+	c.header("Access-Control-Allow-Origin", "*");
+	c.header("Cross-Origin-Resource-Policy", "cross-origin");
+	return c.body(Uint8Array.from(asset).buffer);
 });
 
 /**

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -344,7 +344,10 @@ function createServerForContext(
     }
     const app = MCP_APP_RESOURCES[uri];
     if (!app) throw new Error(`Unknown resource: ${uri}`);
-    const html = await readMcpAppBundle(app.appDir);
+    // Phase 1 of the external-asset rollout keeps discovery on the exact
+    // self-contained v2 template while the new asset endpoint reaches every
+    // replica. A later release switches discovery to index.html/v3.
+    const html = await readMcpAppBundle(app.appDir, 'legacy-v2.html');
     if (html == null) {
       throw new Error(`MCP App bundle not built for ${uri} (run owletto build:mcp-apps)`);
     }

--- a/packages/server/src/utils/mcp-app-bundle.ts
+++ b/packages/server/src/utils/mcp-app-bundle.ts
@@ -3,8 +3,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
- * Locate + read a built MCP App bundle (a self-contained `ui://` iframe payload
- * produced by owletto's `build:mcp-apps`, e.g.
+ * Locate + read a built MCP App artifact produced by owletto's
+ * `build:mcp-apps`, e.g.
  * `packages/owletto/dist-mcp-apps/<appDir>/index.html`).
  *
  * Path resolution mirrors `resolveWebDistDirectory` in `index.ts` (the owletto
@@ -15,9 +15,11 @@ import { fileURLToPath } from 'node:url';
 
 // packages/server dir (mirror of APP_ROOT in index.ts).
 const APP_ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const SAFE_BUNDLE_FILENAME = /^(?:index|legacy-v2)\.html$/;
+const SAFE_ASSET_PATH = /^assets\/[A-Za-z0-9._-]+\.(?:css|js)$/;
 
-function bundleCandidates(appDir: string): string[] {
-  const rel = path.join('dist-mcp-apps', appDir, 'index.html');
+function bundleFileCandidates(appDir: string, filename: string): string[] {
+  const rel = path.join('dist-mcp-apps', appDir, filename);
   const webDist = process.env.WEB_DIST_DIR?.trim();
   return [
     webDist ? path.join(webDist, '..', rel) : undefined,
@@ -35,17 +37,45 @@ function bundleCandidates(appDir: string): string[] {
 // instead of serving 404 until the pod restarts. Every interactive interaction
 // now depends on this one bundle, so a sticky miss would break all of them.
 const bundleCache = new Map<string, string>();
+const assetCache = new Map<string, Uint8Array>();
 
 /** Read a built MCP App bundle's HTML. Returns null when no build is present. */
-export async function readMcpAppBundle(appDir: string): Promise<string | null> {
-  const cached = bundleCache.get(appDir);
+export async function readMcpAppBundle(
+  appDir: string,
+  filename = 'index.html'
+): Promise<string | null> {
+  if (!SAFE_BUNDLE_FILENAME.test(filename)) return null;
+  const cacheKey = `${appDir}/${filename}`;
+  const cached = bundleCache.get(cacheKey);
   if (cached !== undefined) return cached;
-  for (const candidate of bundleCandidates(appDir)) {
+  for (const candidate of bundleFileCandidates(appDir, filename)) {
     try {
       await stat(candidate);
       const html = await readFile(candidate, 'utf8');
-      bundleCache.set(appDir, html);
+      bundleCache.set(cacheKey, html);
       return html;
+    } catch {
+      // candidate absent — try the next
+    }
+  }
+  return null;
+}
+
+/** Read one stable JS/CSS asset staged for the second rollout phase. */
+export async function readMcpAppAsset(
+  appDir: string,
+  assetPath: string
+): Promise<Uint8Array | null> {
+  if (!SAFE_ASSET_PATH.test(assetPath)) return null;
+  const cacheKey = `${appDir}/${assetPath}`;
+  const cached = assetCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+  for (const candidate of bundleFileCandidates(appDir, assetPath)) {
+    try {
+      await stat(candidate);
+      const asset = await readFile(candidate);
+      assetCache.set(cacheKey, asset);
+      return asset;
     } catch {
       // candidate absent — try the next
     }


### PR DESCRIPTION
## Summary
- deploy the stable MCP App JavaScript and CSS asset routes to every server replica
- keep MCP discovery and the public HTML route on the existing self-contained `ui://lobu/interaction/v2` document
- advance Owletto to the dual-build release so phase two can switch to the small external template only after this release is fully deployed

## Rollout safety
This is deliberately phase one of two. It does **not** advertise v3 and does **not** make the current template depend on the new route, so mixed old/new replicas cannot break ChatGPT template loading. Phase two will be opened only after this exact squash SHA is live on every production replica and the asset endpoints are verified publicly.

## Verification
- MCP resource integration suite: 14/14
- `make pre-pr`: clean
- exact-head independent review: 0 blockers, 0 bugs, low risk
- Owletto dual bundle: 771-byte external HTML; 358,298-byte legacy v2; stable `app.js`/`app.css`

Supersedes the phase-one portion of #2627; do not merge #2627.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving approved JavaScript and CSS assets for MCP Apps.
  * Added cross-origin headers and no-cache handling for app assets.
  * MCP App resource loading now supports the legacy v2 HTML bundle.

* **Bug Fixes**
  * Improved routing so legacy resources and external assets resolve correctly.
  * Invalid or unsupported asset paths now return a 404 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->