### PR TITLE
feat(behaviors): close the social draft decision loop

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -1314,6 +1314,12 @@ describe("LinkedInConnector home_feed", () => {
           parts: Record<string, unknown>;
         };
         author_control_label: { selector: string; attr: string };
+        post_url: {
+          take: string;
+          triggerSelector: string;
+          actionSelector: string;
+          actionText: string;
+        };
       };
     };
     // objectAll captures each anchor with its href + accessible name, so the
@@ -1324,6 +1330,12 @@ describe("LinkedInConnector home_feed", () => {
     expect(cfg.fields.author_control_label.selector).toContain(
       "control menu for post by"
     );
+    expect(cfg.fields.post_url).toMatchObject({
+      take: "clipboardAction",
+      triggerSelector: 'button[aria-label*="control menu for post by"]',
+      actionSelector: '[role="menuitem"]',
+      actionTextRegex: "^Copy link(?: to post)?$",
+    });
 
     expect(res.events).toHaveLength(2);
     expect(res.events[0].origin_id).toBe("li_home_tok1");
@@ -1814,7 +1826,8 @@ describe("prepare_comment helpers", () => {
     });
     expect(expr).toContain("lobu-handoff-banner");
     expect(expr).toContain("Lobu staged this comment");
-    expect(expr).toContain("Owletto side panel");
+    expect(expr).toContain("record the outcome in Lobu Activity");
+    expect(expr).toContain("reject it with a reason");
     expect(expr).toContain('Met them at \\"AI\\" meetup');
     expect(expr).not.toMatch(/click\(\)\s*;[\s\S]*Post|Post[\s\S]*\.click\(/);
     expect(expr).not.toContain("setTimeout");
@@ -1835,7 +1848,7 @@ describe("prepare_comment helpers", () => {
     expect(action?.inputSchema?.properties?.browser_connection_id?.type).toBe(
       "integer"
     );
-    expect(c.definition.version).toBe("3.7.0");
+    expect(c.definition.version).toBe("3.8.0");
     expect(String(action?.description ?? "")).toMatch(/NEVER submits/i);
   });
 

--- a/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
+++ b/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
@@ -85,12 +85,14 @@ function clientWithRows(options: {
   }>;
   chrome?: Array<{ id: number; slug?: string; device_online?: boolean }>;
   operationError?: Error;
+  reviewError?: Error;
 }) {
   const queries: string[] = [];
   const notifications: Record<string, unknown>[] = [];
   const operations: Record<string, unknown>[] = [];
   const operationResults = new Map<string, Record<string, unknown>>();
   const logs: string[] = [];
+  let reviewError = options.reviewError;
   const client = {
     query: async (sql: string) => {
       queries.push(sql);
@@ -114,6 +116,11 @@ function clientWithRows(options: {
     },
     notifications: {
       send: async (input: Record<string, unknown>) => {
+        if (input.input_schema && reviewError) {
+          const error = reviewError;
+          reviewError = undefined;
+          throw error;
+        }
         notifications.push(input);
         return {
           notified_count: 1,
@@ -289,6 +296,42 @@ describe("social interest radar reaction", () => {
       "LinkedIn draft not staged"
     );
     expect(fixture.logs.join("\n")).toContain("staging threw");
+  });
+
+  it("retries review creation after staging instead of completing without an answerable review", async () => {
+    const fixture = clientWithRows({
+      signals: [{ id: 501, author_name: "Ada", metadata: signalMetadata }],
+      drafts: [
+        {
+          id: 601,
+          payload_text: "Draft",
+          source_url:
+            "https://www.linkedin.com/feed/update/urn:li:activity:123",
+          metadata: draftMetadata,
+        },
+      ],
+      chrome: [{ id: 432 }],
+      reviewError: new Error("notification service unavailable"),
+    });
+
+    await expect(runReaction(context(), fixture.client)).rejects.toThrow(
+      "notification service unavailable"
+    );
+    expect(fixture.operations).toHaveLength(1);
+    expect(fixture.notifications).toHaveLength(0);
+
+    await runReaction(context(), fixture.client);
+
+    expect(fixture.operations).toHaveLength(1);
+    expect(fixture.notifications).toHaveLength(1);
+    expect(fixture.notifications[0]).toMatchObject({
+      title: "Review LinkedIn comment for Ada",
+      idempotency_key: "social-radar:review:601",
+      input_schema: {
+        type: "object",
+        required: ["outcome"],
+      },
+    });
   });
 
   it("names the author from the event column, not from a restated metadata copy", async () => {

--- a/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
+++ b/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
@@ -84,6 +84,7 @@ function clientWithRows(options: {
     metadata: typeof draftMetadata;
   }>;
   chrome?: Array<{ id: number; slug?: string; device_online?: boolean }>;
+  operationError?: Error;
 }) {
   const queries: string[] = [];
   const notifications: Record<string, unknown>[] = [];
@@ -114,11 +115,17 @@ function clientWithRows(options: {
     notifications: {
       send: async (input: Record<string, unknown>) => {
         notifications.push(input);
-        return { notified_count: 1 };
+        return {
+          notified_count: 1,
+          event_id: 700 + notifications.length,
+          url: `/buremba/memory?run_ids=${800 + notifications.length}`,
+          ...(input.input_schema ? { run_id: 800 + notifications.length } : {}),
+        };
       },
     },
     operations: {
       execute: async (input: Record<string, unknown>) => {
+        if (options.operationError) throw options.operationError;
         const idempotencyKey = input.idempotency_key;
         if (typeof idempotencyKey === "string") {
           const prior = operationResults.get(idempotencyKey);
@@ -138,7 +145,7 @@ function clientWithRows(options: {
 }
 
 describe("social interest radar reaction", () => {
-  it("links the notification to declaratively persisted source and reply events", async () => {
+  it("stages the LinkedIn draft and creates one answerable review instead of a duplicate FYI", async () => {
     const fixture = clientWithRows({
       signals: [{ id: 501, author_name: "Ada", metadata: signalMetadata }],
       drafts: [
@@ -157,12 +164,25 @@ describe("social interest radar reaction", () => {
     await runReaction(context(), fixture.client);
 
     expect(fixture.queries[0]).toContain("run_id = 88");
-    expect(fixture.notifications).toEqual([
-      expect.objectContaining({
-        resource_url: "/buremba/memory?content_ids=101,501,601",
-        idempotency_key: "social-radar:notification:run:88",
-      }),
-    ]);
+    expect(fixture.notifications).toHaveLength(1);
+    expect(fixture.notifications[0]).toMatchObject({
+      title: "Review LinkedIn comment for Ada",
+      idempotency_key: "social-radar:review:601",
+      behavior_source: { behavior_id: 71, window_id: 44 },
+      input_schema: {
+        type: "object",
+        required: ["outcome"],
+        properties: {
+          outcome: {
+            enum: ["posted_unchanged", "posted_edited"],
+          },
+        },
+      },
+    });
+    expect(fixture.notifications[0]).not.toHaveProperty("resource_url");
+    expect(String(fixture.notifications[0]?.body)).toContain(
+      "Durable state is the difference"
+    );
     expect(fixture.operations).toEqual([
       {
         connection_id: 410,
@@ -177,6 +197,98 @@ describe("social interest radar reaction", () => {
         behavior_source: { behavior_id: 71, window_id: 44 },
       },
     ]);
+  });
+
+  it("keeps unrelated signals in a digest when one LinkedIn signal becomes a review", async () => {
+    const otherMetadata = {
+      ...signalMetadata,
+      platform: "x",
+      source_event_id: 202,
+      why: "A separate launch signal.",
+    };
+    const fixture = clientWithRows({
+      signals: [
+        { id: 501, author_name: "Ada", metadata: signalMetadata },
+        { id: 502, author_name: "Grace", metadata: otherMetadata },
+      ],
+      drafts: [
+        {
+          id: 601,
+          payload_text: "A staged answer.",
+          source_url:
+            "https://www.linkedin.com/feed/update/urn:li:activity:123",
+          metadata: draftMetadata,
+        },
+      ],
+      chrome: [{ id: 432 }],
+    });
+
+    await runReaction(context(), fixture.client);
+
+    expect(fixture.notifications).toHaveLength(2);
+    expect(fixture.notifications[0]?.title).toBe(
+      "Review LinkedIn comment for Ada"
+    );
+    expect(fixture.notifications[1]).toMatchObject({
+      title: "Social interest radar",
+      idempotency_key: "social-radar:notification:run:88",
+    });
+    expect(String(fixture.notifications[1]?.body)).toContain("Grace");
+    expect(String(fixture.notifications[1]?.body)).not.toContain("Ada");
+    expect(String(fixture.notifications[1]?.resource_url)).toContain(
+      "content_ids=202,502"
+    );
+  });
+
+  it("does not create an impossible review or stage against the generic LinkedIn feed URL", async () => {
+    const fixture = clientWithRows({
+      signals: [{ id: 501, author_name: "Ada", metadata: signalMetadata }],
+      drafts: [
+        {
+          id: 601,
+          payload_text: "Draft",
+          source_url: "https://www.linkedin.com/feed/",
+          metadata: draftMetadata,
+        },
+      ],
+      chrome: [{ id: 432 }],
+    });
+
+    await runReaction(context(), fixture.client);
+
+    expect(fixture.operations).toHaveLength(0);
+    expect(fixture.notifications).toHaveLength(1);
+    expect(fixture.notifications[0]).not.toHaveProperty("input_schema");
+    expect(fixture.notifications[0]?.resource_url).toBe(
+      "/buremba/memory?content_ids=101,501,601"
+    );
+    expect(fixture.logs.join("\n")).toMatch(/permalink|feed URL/i);
+  });
+
+  it("still delivers the signal digest when browser staging throws", async () => {
+    const fixture = clientWithRows({
+      signals: [{ id: 501, author_name: "Ada", metadata: signalMetadata }],
+      drafts: [
+        {
+          id: 601,
+          payload_text: "Draft",
+          source_url:
+            "https://www.linkedin.com/feed/update/urn:li:activity:123",
+          metadata: draftMetadata,
+        },
+      ],
+      chrome: [{ id: 432 }],
+      operationError: new Error("idempotency conflict"),
+    });
+
+    await runReaction(context(), fixture.client);
+
+    expect(fixture.notifications).toHaveLength(1);
+    expect(fixture.notifications[0]?.title).toBe("Social interest radar");
+    expect(String(fixture.notifications[0]?.body)).toContain(
+      "LinkedIn draft not staged"
+    );
+    expect(fixture.logs.join("\n")).toContain("staging threw");
   });
 
   it("names the author from the event column, not from a restated metadata copy", async () => {

--- a/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
+++ b/examples/personal-agent/__tests__/social-interest-radar.reaction.test.ts
@@ -84,13 +84,14 @@ function clientWithRows(options: {
     metadata: typeof draftMetadata;
   }>;
   chrome?: Array<{ id: number; slug?: string; device_online?: boolean }>;
-  operationError?: Error;
+  operationSequence?: Array<Error | Record<string, unknown>>;
   reviewError?: Error;
 }) {
   const queries: string[] = [];
   const notifications: Record<string, unknown>[] = [];
   const operations: Record<string, unknown>[] = [];
   const operationResults = new Map<string, Record<string, unknown>>();
+  let operationCall = 0;
   const logs: string[] = [];
   let reviewError = options.reviewError;
   const client = {
@@ -132,15 +133,27 @@ function clientWithRows(options: {
     },
     operations: {
       execute: async (input: Record<string, unknown>) => {
-        if (options.operationError) throw options.operationError;
         const idempotencyKey = input.idempotency_key;
+        let result: Record<string, unknown> | undefined;
         if (typeof idempotencyKey === "string") {
-          const prior = operationResults.get(idempotencyKey);
-          if (prior) return prior;
+          result = operationResults.get(idempotencyKey);
         }
-        operations.push(input);
-        const result = { status: "completed", output: { prepared: true } };
-        if (typeof idempotencyKey === "string") {
+        if (!result) {
+          operations.push(input);
+          result = { status: "completed", output: { prepared: true } };
+          if (typeof idempotencyKey === "string") {
+            operationResults.set(idempotencyKey, result);
+          }
+        }
+        const sequencedResult =
+          options.operationSequence?.[
+            Math.min(operationCall, options.operationSequence.length - 1)
+          ];
+        operationCall += 1;
+        if (sequencedResult instanceof Error) throw sequencedResult;
+        if (sequencedResult) {
+          result = sequencedResult;
+        } else if (typeof idempotencyKey === "string") {
           operationResults.set(idempotencyKey, result);
         }
         return result;
@@ -272,7 +285,7 @@ describe("social interest radar reaction", () => {
     expect(fixture.logs.join("\n")).toMatch(/permalink|feed URL/i);
   });
 
-  it("still delivers the signal digest when browser staging throws", async () => {
+  it("still delivers the signal digest when browser staging reaches a terminal failure", async () => {
     const fixture = clientWithRows({
       signals: [{ id: 501, author_name: "Ada", metadata: signalMetadata }],
       drafts: [
@@ -285,7 +298,9 @@ describe("social interest radar reaction", () => {
         },
       ],
       chrome: [{ id: 432 }],
-      operationError: new Error("idempotency conflict"),
+      operationSequence: [
+        { status: "failed", error_message: "browser handoff failed" },
+      ],
     });
 
     await runReaction(context(), fixture.client);
@@ -295,7 +310,46 @@ describe("social interest radar reaction", () => {
     expect(String(fixture.notifications[0]?.body)).toContain(
       "LinkedIn draft not staged"
     );
-    expect(fixture.logs.join("\n")).toContain("staging threw");
+    expect(fixture.logs.join("\n")).toContain("Could not stage");
+  });
+
+  it("retries a persisted LinkedIn handoff until it completes before creating the review", async () => {
+    const fixture = clientWithRows({
+      signals: [{ id: 501, author_name: "Ada", metadata: signalMetadata }],
+      drafts: [
+        {
+          id: 601,
+          payload_text: "Draft",
+          source_url:
+            "https://www.linkedin.com/feed/update/urn:li:activity:123",
+          metadata: draftMetadata,
+        },
+      ],
+      chrome: [{ id: 432 }],
+      operationSequence: [
+        new Error("reaction tracking temporarily unavailable"),
+        { status: "in_progress" },
+        { status: "completed", output: { prepared: true } },
+      ],
+    });
+
+    await expect(runReaction(context(), fixture.client)).rejects.toThrow(
+      "reaction tracking temporarily unavailable"
+    );
+    await expect(runReaction(context(), fixture.client)).rejects.toThrow(
+      "still in progress"
+    );
+    expect(fixture.operations).toHaveLength(1);
+    expect(fixture.notifications).toHaveLength(0);
+
+    await runReaction(context(), fixture.client);
+
+    expect(fixture.operations).toHaveLength(1);
+    expect(fixture.notifications).toHaveLength(1);
+    expect(fixture.notifications[0]).toMatchObject({
+      title: "Review LinkedIn comment for Ada",
+      input_schema: { required: ["outcome"] },
+    });
   });
 
   it("retries review creation after staging instead of completing without an answerable review", async () => {

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -337,7 +337,7 @@ interface HomeFeedRow {
    * heuristic when present.
    */
   author_control_label?: string;
-  /** Exact post permalink when the rendered card exposes a feed/update anchor. */
+  /** Exact post permalink recovered from LinkedIn's own Copy link action. */
   post_url?: string;
   /** Rendered identifier containing LinkedIn's stable shareId / ugcPostId. */
   post_identity?: string;
@@ -387,11 +387,16 @@ const HOME_FEED_SCRAPE_CONFIG = {
       attr: "aria-label",
     },
     post_url: {
-      // The opaque componentkey cannot be converted back into an activity id,
-      // so capture a canonical link while the real rendered DOM is available.
-      selector: 'a[href*="/feed/update/"]',
-      take: "attr",
-      attr: "href",
+      // Current cards expose neither a permalink anchor nor a post URN. Their
+      // control menu still has LinkedIn's own "Copy link to post" action. The
+      // generic scraper intercepts clipboard.writeText BEFORE clicking it, so
+      // this reads the canonical URL without changing the user's clipboard.
+      take: "clipboardAction",
+      triggerSelector: 'button[aria-label*="control menu for post by"]',
+      actionSelector: '[role="menuitem"]',
+      actionTextRegex: "^Copy link(?: to post)?$",
+      actionTextRegexFlags: "i",
+      maxWaitMs: 1500,
     },
     post_identity: {
       // Current feed cards embed the durable id in a translatable-commentary
@@ -655,9 +660,9 @@ export function isHomeFeedNoise(body: string): boolean {
 }
 
 /**
- * Map cs_scrape home-feed rows to event envelopes. Prefer a /feed/update anchor
- * or stable activity id embedded in the card DOM; otherwise source_url falls
- * back to /feed/.
+ * Map cs_scrape home-feed rows to event envelopes. Prefer the permalink
+ * recovered from LinkedIn's Copy-link action or a stable activity id embedded
+ * in the card DOM; otherwise source_url falls back to /feed/.
  * Home-feed posts expose no reliable timestamp, so the caller stamps
  * occurred_at with the sync time.
  */
@@ -1122,7 +1127,7 @@ export function buildInjectHandoffBannerExpression(opts: {
 
   const foot = document.createElement('div');
   foot.style.cssText = 'color:#64748b;margin:4px 0 0;font-size:12px';
-  foot.textContent = 'Open the Owletto side panel for run details.';
+  foot.textContent = 'After posting or editing, record the outcome in Lobu Activity. You can also reject it with a reason.';
   body.appendChild(foot);
 
   const close = document.createElement('button');
@@ -2177,7 +2182,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
     name: "LinkedIn",
     description:
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files. prepare_comment stages a draft for the human to Post; verify_staged_comment checks whether that draft appeared as a comment.",
-    version: "3.7.0",
+    version: "3.8.0",
     faviconDomain: "linkedin.com",
     // Auth is `none`: every live feed authenticates implicitly through the
     // paired Owletto Chrome extension (the user's own signed-in linkedin.com

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -306,41 +306,42 @@ export default async (
   };
   const reviewedSourceEventIds = new Set<number>();
   for (const draft of deliveredDrafts) {
-    try {
-      const connectionId = Number(draft.metadata.source_connection_id);
-      const body = draft.payload_text?.trim();
-      const sourceUrl = draft.source_url?.trim();
-      const platform = draft.metadata.platform;
-      if (
-        !Number.isSafeInteger(connectionId) ||
-        connectionId <= 0 ||
-        !body ||
-        !sourceUrl ||
-        (platform !== "x" && platform !== "linkedin")
-      ) {
-        client.log(
-          "Saved social draft is missing a valid source connection, URL, or body.",
-          {
-            draft_event_id: draft.id,
-          }
-        );
-        deliveryNotes.push(
-          "Draft not staged: its saved handoff data is incomplete."
-        );
-        continue;
-      }
-      if (platform === "linkedin" && !isReviewableLinkedInPostUrl(sourceUrl)) {
-        client.log(
-          "Saved LinkedIn draft has only the generic feed URL; a durable post permalink is required before staging.",
-          { draft_event_id: draft.id, source_url: sourceUrl }
-        );
-        deliveryNotes.push(
-          "LinkedIn draft not staged: the post did not expose a durable link."
-        );
-        continue;
-      }
+    const connectionId = Number(draft.metadata.source_connection_id);
+    const body = draft.payload_text?.trim();
+    const sourceUrl = draft.source_url?.trim();
+    const platform = draft.metadata.platform;
+    if (
+      !Number.isSafeInteger(connectionId) ||
+      connectionId <= 0 ||
+      !body ||
+      !sourceUrl ||
+      (platform !== "x" && platform !== "linkedin")
+    ) {
+      client.log(
+        "Saved social draft is missing a valid source connection, URL, or body.",
+        {
+          draft_event_id: draft.id,
+        }
+      );
+      deliveryNotes.push(
+        "Draft not staged: its saved handoff data is incomplete."
+      );
+      continue;
+    }
+    if (platform === "linkedin" && !isReviewableLinkedInPostUrl(sourceUrl)) {
+      client.log(
+        "Saved LinkedIn draft has only the generic feed URL; a durable post permalink is required before staging.",
+        { draft_event_id: draft.id, source_url: sourceUrl }
+      );
+      deliveryNotes.push(
+        "LinkedIn draft not staged: the post did not expose a durable link."
+      );
+      continue;
+    }
 
-      const result = await client.operations.execute({
+    let result: Awaited<ReturnType<ReactionClient["operations"]["execute"]>>;
+    try {
+      result = await client.operations.execute({
         connection_id: connectionId,
         operation_key: platform === "x" ? "prepare_reply" : "prepare_comment",
         idempotency_key: `social-radar:draft:${draft.id}`,
@@ -360,51 +361,6 @@ export default async (
               },
         behavior_source: behaviorSource,
       });
-      if (result.status !== "completed") {
-        client.log(
-          "Could not stage the saved social draft in the interactive browser.",
-          {
-            draft_event_id: draft.id,
-            status: result.status,
-            error: result.error_message,
-          }
-        );
-        deliveryNotes.push(
-          `${platform === "linkedin" ? "LinkedIn" : "X"} draft not staged: the browser handoff failed.`
-        );
-        continue;
-      }
-
-      if (platform === "linkedin") {
-        const sourceEventId = Number(draft.metadata.source_event_id);
-        const matchingSignal = deliveredSignals.find(
-          (signal) => Number(signal.metadata.source_event_id) === sourceEventId
-        );
-        const author =
-          draft.author_name?.trim() ||
-          matchingSignal?.author_name?.trim() ||
-          "this post";
-        const reviewBody = notificationBody([
-          "Review the staged comment in LinkedIn. Record what you posted, or use Reject and explain why it was not relevant.",
-          "",
-          `Why it was suggested: ${draft.metadata.why ?? "Relevant social signal"}`,
-          "",
-          `Draft: ${body}`,
-          "",
-          `Post: ${sourceUrl}`,
-        ]);
-        await client.notifications.send({
-          title: `Review LinkedIn comment for ${author}`,
-          body: reviewBody,
-          recipients: "admins",
-          input_schema: LINKEDIN_REVIEW_SCHEMA,
-          idempotency_key: `social-radar:review:${draft.id}`,
-          behavior_source: behaviorSource,
-        });
-        if (Number.isSafeInteger(sourceEventId) && sourceEventId > 0) {
-          reviewedSourceEventIds.add(sourceEventId);
-        }
-      }
     } catch (error) {
       client.log(
         "Social draft staging threw; continuing with the signal digest.",
@@ -416,6 +372,55 @@ export default async (
       deliveryNotes.push(
         `${draft.metadata.platform === "linkedin" ? "LinkedIn" : "Social"} draft not staged: the browser handoff errored.`
       );
+      continue;
+    }
+    if (result.status !== "completed") {
+      client.log(
+        "Could not stage the saved social draft in the interactive browser.",
+        {
+          draft_event_id: draft.id,
+          status: result.status,
+          error: result.error_message,
+        }
+      );
+      deliveryNotes.push(
+        `${platform === "linkedin" ? "LinkedIn" : "X"} draft not staged: the browser handoff failed.`
+      );
+      continue;
+    }
+
+    if (platform === "linkedin") {
+      const sourceEventId = Number(draft.metadata.source_event_id);
+      const matchingSignal = deliveredSignals.find(
+        (signal) => Number(signal.metadata.source_event_id) === sourceEventId
+      );
+      const author =
+        draft.author_name?.trim() ||
+        matchingSignal?.author_name?.trim() ||
+        "this post";
+      const reviewBody = notificationBody([
+        "Review the staged comment in LinkedIn. Record what you posted, or use Reject and explain why it was not relevant.",
+        "",
+        `Why it was suggested: ${draft.metadata.why ?? "Relevant social signal"}`,
+        "",
+        `Draft: ${body}`,
+        "",
+        `Post: ${sourceUrl}`,
+      ]);
+      // Once staging succeeds, review creation is part of the durable contract.
+      // Let a transient send failure retry the reaction; both calls are
+      // idempotent, so the browser handoff will not be duplicated.
+      await client.notifications.send({
+        title: `Review LinkedIn comment for ${author}`,
+        body: reviewBody,
+        recipients: "admins",
+        input_schema: LINKEDIN_REVIEW_SCHEMA,
+        idempotency_key: `social-radar:review:${draft.id}`,
+        behavior_source: behaviorSource,
+      });
+      if (Number.isSafeInteger(sourceEventId) && sourceEventId > 0) {
+        reviewedSourceEventIds.add(sourceEventId);
+      }
     }
   }
 

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -114,6 +114,7 @@ interface PersistedSignal {
 
 interface PersistedDraft {
   id: number;
+  author_name?: string | null;
   payload_text: string;
   source_url: string;
   metadata: {
@@ -135,6 +136,48 @@ function notificationBody(lines: string[]): string {
   const body = lines.join("\n");
   return body.length <= 1000 ? body : `${body.slice(0, 997)}...`;
 }
+
+function isReviewableLinkedInPostUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase().replace(/^www\./, "");
+    return (
+      (host === "linkedin.com" || host.endsWith(".linkedin.com")) &&
+      /^\/feed\/update\/urn:li:(?:activity|share|ugcPost):\d+\/?$/i.test(
+        url.pathname
+      )
+    );
+  } catch {
+    return false;
+  }
+}
+
+const LINKEDIN_REVIEW_SCHEMA = {
+  type: "object",
+  properties: {
+    outcome: {
+      type: "string",
+      title: "Outcome",
+      enum: ["posted_unchanged", "posted_edited"],
+      description:
+        "Choose what you actually posted. Use Reject instead if the draft was not relevant or should not be posted.",
+    },
+    final_text: {
+      type: "string",
+      title: "Final text (if edited)",
+      description:
+        "If you changed the comment before posting, paste the final version so future suggestions can learn from the edit.",
+      maxLength: 3000,
+    },
+    note: {
+      type: "string",
+      title: "Optional note",
+      description: "Anything else the system should learn from your choice.",
+      maxLength: 1000,
+    },
+  },
+  required: ["outcome"],
+} as const;
 
 export default async (
   ctx: ReactionContext,
@@ -164,7 +207,7 @@ export default async (
      ORDER BY id`
   )) as PersistedSignal[];
   const deliveredDrafts = (await client.query(
-    `SELECT id, payload_text, source_url, metadata FROM events
+    `SELECT id, author_name, payload_text, source_url, metadata FROM events
      WHERE ${runPredicate}
        AND semantic_type = 'draft_reply'
        AND metadata->>'behavior_output' = 'drafts'
@@ -172,22 +215,29 @@ export default async (
      ORDER BY id`
   )) as PersistedDraft[];
 
-  const contentIds = deliveredSignals.flatMap((signal) => {
-    const sourceId = Number(signal.metadata.source_event_id);
-    return Number.isInteger(sourceId) && sourceId > 0
-      ? [sourceId, signal.id]
-      : [signal.id];
-  });
-  for (const draft of deliveredDrafts) contentIds.push(draft.id);
-  const body = notificationBody(
-    deliveredSignals.map(
+  const producerKey = producerRunKey(ctx);
+  const deliveryNotes: string[] = [];
+
+  const sendDigest = async (
+    signals: PersistedSignal[] = deliveredSignals,
+    includeDrafts = true
+  ): Promise<void> => {
+    if (signals.length === 0) return;
+    const contentIds = signals.flatMap((signal) => {
+      const sourceId = Number(signal.metadata.source_event_id);
+      return Number.isInteger(sourceId) && sourceId > 0
+        ? [sourceId, signal.id]
+        : [signal.id];
+    });
+    if (includeDrafts) {
+      for (const draft of deliveredDrafts) contentIds.push(draft.id);
+    }
+    const lines = signals.map(
       ({ author_name, metadata }) =>
         `[${metadata.priority ?? "normal"}] ${author_name ?? "Someone"} (${metadata.platform ?? "social"}) — ${metadata.why ?? "New signal"}`
-    )
-  );
-  const producerKey = producerRunKey(ctx);
-
-  if (deliveredSignals.length > 0) {
+    );
+    if (deliveryNotes.length > 0) lines.push("", ...deliveryNotes);
+    const body = notificationBody(lines);
     await client.notifications.send({
       title: "Social interest radar",
       body,
@@ -201,9 +251,12 @@ export default async (
         window_id: ctx.window.id,
       },
     });
-  }
+  };
 
-  if (deliveredDrafts.length === 0) return;
+  if (deliveredDrafts.length === 0) {
+    await sendDigest();
+    return;
+  }
 
   // This is intentionally a stable, human-selected pairing slug. Never pick an
   // arbitrary online Chrome connection: that can stage a draft in the wrong
@@ -240,6 +293,10 @@ export default async (
     client.log(
       "Interactive browser 'chrome-macbook' is not online; draft event was saved but no browser was guessed."
     );
+    deliveryNotes.push(
+      "Draft not staged: the pinned interactive Chrome is offline."
+    );
+    await sendDigest();
     return;
   }
 
@@ -247,56 +304,126 @@ export default async (
     behavior_id: ctx.behavior.id,
     window_id: ctx.window.id,
   };
+  const reviewedSourceEventIds = new Set<number>();
   for (const draft of deliveredDrafts) {
-    const connectionId = Number(draft.metadata.source_connection_id);
-    const body = draft.payload_text?.trim();
-    const sourceUrl = draft.source_url?.trim();
-    const platform = draft.metadata.platform;
-    if (
-      !Number.isSafeInteger(connectionId) ||
-      connectionId <= 0 ||
-      !body ||
-      !sourceUrl ||
-      (platform !== "x" && platform !== "linkedin")
-    ) {
+    try {
+      const connectionId = Number(draft.metadata.source_connection_id);
+      const body = draft.payload_text?.trim();
+      const sourceUrl = draft.source_url?.trim();
+      const platform = draft.metadata.platform;
+      if (
+        !Number.isSafeInteger(connectionId) ||
+        connectionId <= 0 ||
+        !body ||
+        !sourceUrl ||
+        (platform !== "x" && platform !== "linkedin")
+      ) {
+        client.log(
+          "Saved social draft is missing a valid source connection, URL, or body.",
+          {
+            draft_event_id: draft.id,
+          }
+        );
+        deliveryNotes.push(
+          "Draft not staged: its saved handoff data is incomplete."
+        );
+        continue;
+      }
+      if (platform === "linkedin" && !isReviewableLinkedInPostUrl(sourceUrl)) {
+        client.log(
+          "Saved LinkedIn draft has only the generic feed URL; a durable post permalink is required before staging.",
+          { draft_event_id: draft.id, source_url: sourceUrl }
+        );
+        deliveryNotes.push(
+          "LinkedIn draft not staged: the post did not expose a durable link."
+        );
+        continue;
+      }
+
+      const result = await client.operations.execute({
+        connection_id: connectionId,
+        operation_key: platform === "x" ? "prepare_reply" : "prepare_comment",
+        idempotency_key: `social-radar:draft:${draft.id}`,
+        input:
+          platform === "x"
+            ? {
+                tweet_url: sourceUrl,
+                body,
+                reason: draft.metadata.why,
+                browser_connection_id: browserConnectionId,
+              }
+            : {
+                post_url: sourceUrl,
+                body,
+                reason: draft.metadata.why,
+                browser_connection_id: browserConnectionId,
+              },
+        behavior_source: behaviorSource,
+      });
+      if (result.status !== "completed") {
+        client.log(
+          "Could not stage the saved social draft in the interactive browser.",
+          {
+            draft_event_id: draft.id,
+            status: result.status,
+            error: result.error_message,
+          }
+        );
+        deliveryNotes.push(
+          `${platform === "linkedin" ? "LinkedIn" : "X"} draft not staged: the browser handoff failed.`
+        );
+        continue;
+      }
+
+      if (platform === "linkedin") {
+        const sourceEventId = Number(draft.metadata.source_event_id);
+        const matchingSignal = deliveredSignals.find(
+          (signal) => Number(signal.metadata.source_event_id) === sourceEventId
+        );
+        const author =
+          draft.author_name?.trim() ||
+          matchingSignal?.author_name?.trim() ||
+          "this post";
+        const reviewBody = notificationBody([
+          "Review the staged comment in LinkedIn. Record what you posted, or use Reject and explain why it was not relevant.",
+          "",
+          `Why it was suggested: ${draft.metadata.why ?? "Relevant social signal"}`,
+          "",
+          `Draft: ${body}`,
+          "",
+          `Post: ${sourceUrl}`,
+        ]);
+        await client.notifications.send({
+          title: `Review LinkedIn comment for ${author}`,
+          body: reviewBody,
+          recipients: "admins",
+          input_schema: LINKEDIN_REVIEW_SCHEMA,
+          idempotency_key: `social-radar:review:${draft.id}`,
+          behavior_source: behaviorSource,
+        });
+        if (Number.isSafeInteger(sourceEventId) && sourceEventId > 0) {
+          reviewedSourceEventIds.add(sourceEventId);
+        }
+      }
+    } catch (error) {
       client.log(
-        "Saved social draft is missing a valid source connection, URL, or body.",
+        "Social draft staging threw; continuing with the signal digest.",
         {
           draft_event_id: draft.id,
+          error: error instanceof Error ? error.message : String(error),
         }
       );
-      continue;
-    }
-
-    const result = await client.operations.execute({
-      connection_id: connectionId,
-      operation_key: platform === "x" ? "prepare_reply" : "prepare_comment",
-      idempotency_key: `social-radar:draft:${draft.id}`,
-      input:
-        platform === "x"
-          ? {
-              tweet_url: sourceUrl,
-              body,
-              reason: draft.metadata.why,
-              browser_connection_id: browserConnectionId,
-            }
-          : {
-              post_url: sourceUrl,
-              body,
-              reason: draft.metadata.why,
-              browser_connection_id: browserConnectionId,
-            },
-      behavior_source: behaviorSource,
-    });
-    if (result.status !== "completed") {
-      client.log(
-        "Could not stage the saved social draft in the interactive browser.",
-        {
-          draft_event_id: draft.id,
-          status: result.status,
-          error: result.error_message,
-        }
+      deliveryNotes.push(
+        `${draft.metadata.platform === "linkedin" ? "LinkedIn" : "Social"} draft not staged: the browser handoff errored.`
       );
     }
   }
+
+  // The answerable review replaces the duplicate FYI for that LinkedIn signal,
+  // but unrelated signals from the same firing still get the normal digest.
+  const unreviewedSignals = deliveredSignals.filter(
+    (signal) =>
+      !reviewedSourceEventIds.has(Number(signal.metadata.source_event_id))
+  );
+  await sendDigest(unreviewedSignals, reviewedSourceEventIds.size === 0);
 };

--- a/examples/personal-agent/social-interest-radar.reaction.ts
+++ b/examples/personal-agent/social-interest-radar.reaction.ts
@@ -362,6 +362,13 @@ export default async (
         behavior_source: behaviorSource,
       });
     } catch (error) {
+      // A thrown execute call may have durably created the idempotent device
+      // run before an internal bookkeeping step failed. Retrying is the only
+      // safe way to distinguish that case from a handoff that never started;
+      // a terminal device failure is returned as a status below.
+      if (platform === "linkedin") {
+        throw error;
+      }
       client.log(
         "Social draft staging threw; continuing with the signal digest.",
         {
@@ -373,6 +380,11 @@ export default async (
         `${draft.metadata.platform === "linkedin" ? "LinkedIn" : "Social"} draft not staged: the browser handoff errored.`
       );
       continue;
+    }
+    if (result.status === "in_progress") {
+      throw new Error(
+        `Social draft staging is still in progress for saved draft ${draft.id}.`
+      );
     }
     if (result.status !== "completed") {
       client.log(

--- a/packages/connector-sdk/src/__tests__/reaction-client-types.test.ts
+++ b/packages/connector-sdk/src/__tests__/reaction-client-types.test.ts
@@ -10,28 +10,4 @@ describe("ReactionClient knowledge.read input", () => {
       client.knowledge.read({ content_ids: [42] });
     expect(typeof call).toBe("function");
   });
-
-  it("exposes ask results and run reads to Behavior reactions", () => {
-    const call = async (client: ReactionClient) => {
-      const sent = await client.notifications.send({
-        title: "Was this LinkedIn comment posted?",
-        input_schema: {
-          type: "object",
-          properties: {
-            outcome: { enum: ["posted_unchanged", "posted_edited"] },
-          },
-          required: ["outcome"],
-        },
-      });
-      const page = await client.operations.listRuns({
-        behavior_ids: [71],
-        run_types: ["internal", "action"],
-      });
-      const run = sent.run_id
-        ? await client.operations.getRun(sent.run_id)
-        : undefined;
-      return { page, run, eventId: sent.event_id };
-    };
-    expect(typeof call).toBe("function");
-  });
 });

--- a/packages/connector-sdk/src/__tests__/reaction-client-types.test.ts
+++ b/packages/connector-sdk/src/__tests__/reaction-client-types.test.ts
@@ -10,4 +10,28 @@ describe("ReactionClient knowledge.read input", () => {
       client.knowledge.read({ content_ids: [42] });
     expect(typeof call).toBe("function");
   });
+
+  it("exposes ask results and run reads to Behavior reactions", () => {
+    const call = async (client: ReactionClient) => {
+      const sent = await client.notifications.send({
+        title: "Was this LinkedIn comment posted?",
+        input_schema: {
+          type: "object",
+          properties: {
+            outcome: { enum: ["posted_unchanged", "posted_edited"] },
+          },
+          required: ["outcome"],
+        },
+      });
+      const page = await client.operations.listRuns({
+        behavior_ids: [71],
+        run_types: ["internal", "action"],
+      });
+      const run = sent.run_id
+        ? await client.operations.getRun(sent.run_id)
+        : undefined;
+      return { page, run, eventId: sent.event_id };
+    };
+    expect(typeof call).toBe("function");
+  });
 });

--- a/packages/connector-sdk/src/extension-dom-scrape.ts
+++ b/packages/connector-sdk/src/extension-dom-scrape.ts
@@ -46,12 +46,28 @@ interface ExtensionScrapeField {
    * capture a row's repeated structures (e.g. every profile link as
    * {href, name}) and disambiguate them by content rather than DOM position.
    */
-  take?: 'attr' | 'text' | 'html' | 'objectAll' | (string & {});
+  take?: 'attr' | 'text' | 'html' | 'objectAll' | 'clipboardAction' | (string & {});
   attr?: string;
   firstLine?: boolean;
   const?: unknown;
   /** Sub-spec for `objectAll`: the named parts to read off each matched element. */
   parts?: Record<string, ExtensionScrapePart>;
+  /**
+   * `clipboardAction` only: a row-local control that opens a menu/popover.
+   * The scraper intercepts clipboard.writeText before clicking, so the copied
+   * value is returned without changing the user's real clipboard.
+   */
+  triggerSelector?: string;
+  /** `clipboardAction` only: global selector for the opened action. */
+  actionSelector?: string;
+  /** `clipboardAction` only: exact visible text of the action to click. */
+  actionText?: string;
+  /** `clipboardAction` only: visible-text regex used when exact text varies. */
+  actionTextRegex?: string;
+  /** Optional flags for `actionTextRegex` (for example, `i`). */
+  actionTextRegexFlags?: string;
+  /** Maximum wait for the action/value (default 1500ms). */
+  maxWaitMs?: number;
 }
 
 /** The `.result` payload of a `cs_scrape` dispatch. */

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -250,6 +250,8 @@ export type {
   KnowledgeSaveResult,
   KnowledgeSearchInput,
   NotificationsSendInput,
+  NotificationsSendResult,
+  OperationsListRunsInput,
 } from './reaction-client-types.js';
 export type { Env } from './types.js';
 

--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -130,6 +130,41 @@ export interface NotificationsSendInput {
   data?: Record<string, unknown>;
   /** Attribution when sent from a behavior reaction. */
   behavior_source?: { behavior_id: number; window_id: number };
+  /**
+   * Turn the notification into a human question on the existing approval rail.
+   * `{}` is a binary Approve/Reject decision; a field-shaped schema renders a
+   * form. Rejection can carry a reason through the standard reject action.
+   */
+  input_schema?: Record<string, unknown>;
+}
+
+export interface NotificationsSendResult {
+  notified_count: number;
+  /** Durable notification event, including on an idempotent replay. */
+  event_id: number | null;
+  /** Server-produced notification permalink. */
+  url: string | null;
+  /** Present for input_schema asks; poll/read this run for the answer. */
+  run_id?: number;
+}
+
+export interface OperationsListRunsInput {
+  connection_id?: number;
+  connection_ids?: number[];
+  feed_ids?: number[];
+  device_worker_id?: string;
+  connector_key?: string;
+  operation_key?: string;
+  status?: string;
+  approval_status?: string;
+  run_types?: string[];
+  created_after?: string;
+  created_before?: string;
+  behavior_ids?: number[];
+  limit?: number;
+  offset?: number;
+  before_id?: number;
+  before_created_at?: string;
 }
 
 // ── Client ───────────────────────────────────────────────────────────────────
@@ -200,7 +235,7 @@ export interface ReactionClient {
      * org's active bot connections (Slack/Telegram). This is how a reaction
      * surfaces its digest to a chat channel.
      */
-    send(input: NotificationsSendInput): Promise<{ notified_count: number }>;
+    send(input: NotificationsSendInput): Promise<NotificationsSendResult>;
   };
 
   /**
@@ -216,6 +251,16 @@ export interface ReactionClient {
       connection_id?: number;
       entity_id?: number;
     }): Promise<unknown>;
+    /** Read operational runs, including questions and staged connector actions. */
+    listRuns(input?: OperationsListRunsInput): Promise<{
+      runs: Array<Record<string, unknown>>;
+      total: number;
+      limit: number;
+      offset: number;
+      has_more: boolean;
+    }>;
+    /** Read one durable run and its completed answer/rejection state. */
+    getRun(run_id: number): Promise<{ run: Record<string, unknown> }>;
     /** Execute one operation and wait for its result. */
     execute(input: {
       connection_id: number;

--- a/packages/server/src/__tests__/integration/notifications/agent-ask-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/agent-ask-e2e.test.ts
@@ -19,6 +19,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import type { Env } from "../../../index";
 import type { AuthContext } from "../../../tools/execute";
 import { executeTool } from "../../../tools/execute";
+import { getPastReactionsSummary } from "../../../utils/watcher-reactions";
 import { initWorkspaceProvider } from "../../../workspace";
 import { getTestDb } from "../../setup/test-db";
 import {
@@ -60,6 +61,9 @@ describe("notify input_schema — agent asks a human", () => {
 	let orgId: string;
 	let humanCtx: AuthContext;
 	let agentCtx: AuthContext;
+	let behaviorCtx: AuthContext;
+	let behaviorId: number;
+	let windowId: number;
 
 	const baseCtx = (
 		userId: string,
@@ -91,6 +95,40 @@ describe("notify input_schema — agent asks a human", () => {
 		await addUserToOrganization(owner.id, org.id, "owner");
 		humanCtx = baseCtx(owner.id, null);
 		agentCtx = baseCtx(owner.id, "asking-agent");
+		const sql = getTestDb();
+		const [behavior] = await sql`
+			WITH next_id AS (SELECT nextval('watchers_id_seq')::integer AS id)
+			INSERT INTO watchers (
+				id, watcher_group_id, organization_id, agent_id, created_by, name, slug
+			)
+			SELECT id, id, ${org.id}, 'asking-agent', ${owner.id},
+				'Ask provenance behavior', 'ask-provenance-behavior'
+			FROM next_id
+			RETURNING id
+		`;
+		behaviorId = Number(behavior.id);
+		const [window] = await sql`
+			INSERT INTO events (
+				organization_id, semantic_type, payload_type, payload_data,
+				metadata, occurred_at, created_at, created_by
+			) VALUES (
+				${org.id}, 'canvas_state', 'json_template', '{}'::jsonb,
+				${sql.json({
+					watcher_id: behaviorId,
+					granularity: "hour",
+					window_start: "2026-08-10T00:00:00.000Z",
+					window_end: "2026-08-10T01:00:00.000Z",
+				})},
+				NOW(), NOW(), ${owner.id}
+			)
+			RETURNING id
+		`;
+		windowId = Number(window.id);
+		behaviorCtx = {
+			...baseCtx(owner.id, null),
+			actingWatcherId: behaviorId,
+			actingWindowId: windowId,
+		};
 	});
 
 	async function send(args: Record<string, unknown>): Promise<SendResult> {
@@ -369,5 +407,63 @@ describe("notify input_schema — agent asks a human", () => {
 			SELECT approval_status FROM runs WHERE id = ${sent.run_id}
 		`;
 		expect(run.approval_status).toBe("pending");
+	});
+
+	it("binds a Behavior ask and its rejection reason back to the firing window", async () => {
+		const sent = (await executeTool(
+			"notify",
+			{
+				action: "send",
+				title: "Review the staged LinkedIn comment",
+				body: "Draft: Durable state makes this workflow dependable.",
+				input_schema: {
+					type: "object",
+					properties: {
+						outcome: {
+							enum: ["posted_unchanged", "posted_edited"],
+						},
+					},
+					required: ["outcome"],
+				},
+				behavior_source: {
+					behavior_id: behaviorId,
+					window_id: windowId,
+				},
+			},
+			TEST_ENV,
+			behaviorCtx,
+		)) as SendResult;
+
+		const sql = getTestDb();
+		const [run] = await sql`
+			SELECT watcher_id, window_id
+			FROM runs WHERE id = ${sent.run_id}
+		`;
+		expect(Number(run.watcher_id)).toBe(behaviorId);
+		expect(Number(run.window_id)).toBe(windowId);
+
+		const [reaction] = await sql`
+			SELECT run_id FROM watcher_reactions
+			WHERE watcher_id = ${behaviorId} AND window_id = ${windowId}
+			ORDER BY id DESC LIMIT 1
+		`;
+		expect(Number(reaction.run_id)).toBe(sent.run_id);
+
+		await executeTool(
+			"manage_operations",
+			{
+				action: "reject",
+				run_id: sent.run_id,
+				reason: "The tone is too promotional for this discussion.",
+			},
+			TEST_ENV,
+			humanCtx,
+		);
+		const summary = await getPastReactionsSummary(behaviorId);
+		expect(summary).toContain("Durable state makes this workflow dependable.");
+		expect(summary).toMatch(/rejected/i);
+		expect(summary).toContain(
+			"The tone is too promotional for this discussion."
+		);
 	});
 });

--- a/packages/server/src/__tests__/integration/notifications/agent-ask-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/agent-ask-e2e.test.ts
@@ -466,4 +466,102 @@ describe("notify input_schema — agent asks a human", () => {
 			"The tone is too promotional for this discussion."
 		);
 	});
+
+	it("repairs a missing Behavior feedback edge when an idempotent ask retries", async () => {
+		const sql = getTestDb();
+		const suffix = `${process.pid}_${Date.now()}`;
+		const sequenceName = `ask_reaction_fail_seq_${suffix}`;
+		const functionName = `ask_reaction_fail_fn_${suffix}`;
+		const triggerName = `ask_reaction_fail_trigger_${suffix}`;
+		await sql.unsafe(`CREATE SEQUENCE ${sequenceName}`);
+		await sql.unsafe(`
+			CREATE FUNCTION ${functionName}() RETURNS trigger AS $$
+			BEGIN
+				IF nextval('${sequenceName}') = 1 THEN
+					RAISE EXCEPTION 'forced watcher reaction failure';
+				END IF;
+				RETURN NEW;
+			END;
+			$$ LANGUAGE plpgsql
+		`);
+		await sql.unsafe(`
+			CREATE TRIGGER ${triggerName}
+			BEFORE INSERT ON watcher_reactions
+			FOR EACH ROW
+			WHEN (NEW.watcher_id = ${behaviorId} AND NEW.tool_name = 'notify')
+			EXECUTE FUNCTION ${functionName}()
+		`);
+
+		const idempotencyKey = `ask-reaction-repair:${suffix}`;
+		const args = {
+			action: "send",
+			title: "Was the staged LinkedIn comment relevant?",
+			body: "Draft: Durable state makes this workflow dependable.",
+			input_schema: {
+				type: "object",
+				properties: {
+					outcome: { enum: ["posted_unchanged", "posted_edited"] },
+				},
+				required: ["outcome"],
+			},
+			idempotency_key: idempotencyKey,
+		};
+
+		try {
+			await expect(
+				executeTool("notify", args, TEST_ENV, behaviorCtx)
+			).rejects.toThrow(/forced watcher reaction failure/i);
+
+			const notificationsAfterFailure = await sql`
+				SELECT id FROM events
+				WHERE organization_id = ${orgId}
+				  AND metadata->>'_lobu_idempotency_key' = ${idempotencyKey}
+			`;
+			expect(notificationsAfterFailure).toHaveLength(1);
+
+			const retry = (await executeTool(
+				"notify",
+				args,
+				TEST_ENV,
+				behaviorCtx
+			)) as SendResult;
+			expect(retry).toMatchObject({
+				notified_count: 0,
+				event_id: Number(notificationsAfterFailure[0]?.id),
+			});
+			expect(retry.run_id).toBeGreaterThan(0);
+
+			const reactions = await sql`
+				SELECT id FROM watcher_reactions
+				WHERE organization_id = ${orgId}
+				  AND watcher_id = ${behaviorId}
+				  AND window_id = ${windowId}
+				  AND run_id = ${retry.run_id}
+				  AND tool_name = 'notify'
+			`;
+			expect(reactions).toHaveLength(1);
+
+			await executeTool(
+				"manage_operations",
+				{
+					action: "reject",
+					run_id: retry.run_id,
+					reason: "This discussion was not relevant to our product.",
+				},
+				TEST_ENV,
+				humanCtx
+			);
+			const summary = await getPastReactionsSummary(behaviorId);
+			expect(summary).toContain("Was the staged LinkedIn comment relevant?");
+			expect(summary).toContain(
+				"This discussion was not relevant to our product."
+			);
+		} finally {
+			await sql.unsafe(
+				`DROP TRIGGER IF EXISTS ${triggerName} ON watcher_reactions`
+			);
+			await sql.unsafe(`DROP FUNCTION IF EXISTS ${functionName}()`);
+			await sql.unsafe(`DROP SEQUENCE IF EXISTS ${sequenceName}`);
+		}
+	});
 });

--- a/packages/server/src/__tests__/integration/notifications/agent-ask-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/agent-ask-e2e.test.ts
@@ -467,6 +467,71 @@ describe("notify input_schema — agent asks a human", () => {
 		);
 	});
 
+	it("cannot attach a caller-supplied ask to another organization's Behavior history", async () => {
+		const victimOrg = await createTestOrganization({ name: "ask provenance victim" });
+		const victimOwner = await createTestUser({
+			email: `ask-victim-${Date.now()}@test.com`,
+		});
+		await addUserToOrganization(victimOwner.id, victimOrg.id, "owner");
+		const sql = getTestDb();
+		const [victimBehavior] = await sql`
+			WITH next_id AS (SELECT nextval('watchers_id_seq')::integer AS id)
+			INSERT INTO watchers (
+				id, watcher_group_id, organization_id, agent_id, created_by, name, slug
+			)
+			SELECT id, id, ${victimOrg.id}, 'victim-agent', ${victimOwner.id},
+				'Victim behavior', ${`victim-behavior-${Date.now()}`}
+			FROM next_id
+			RETURNING id
+		`;
+		const victimBehaviorId = Number(victimBehavior.id);
+		const [victimWindow] = await sql`
+			INSERT INTO events (
+				organization_id, semantic_type, payload_type, payload_data,
+				metadata, occurred_at, created_at, created_by
+			) VALUES (
+				${victimOrg.id}, 'canvas_state', 'json_template', '{}'::jsonb,
+				${sql.json({ watcher_id: victimBehaviorId })},
+				NOW(), NOW(), ${victimOwner.id}
+			)
+			RETURNING id
+		`;
+		const victimWindowId = Number(victimWindow.id);
+
+		const sent = await send({
+			title: "Forged cross-org review",
+			body: "This must never enter the victim Behavior prompt.",
+			input_schema: { type: "object" },
+			behavior_source: {
+				behavior_id: victimBehaviorId,
+				window_id: victimWindowId,
+			},
+		});
+		const [run] = await sql`
+			SELECT watcher_id, window_id FROM runs WHERE id = ${sent.run_id}
+		`;
+		expect(run.watcher_id).toBeNull();
+		expect(run.window_id).toBeNull();
+		const linked = await sql`
+			SELECT id FROM watcher_reactions WHERE run_id = ${sent.run_id}
+		`;
+		expect(linked).toHaveLength(0);
+
+		// Historical malformed rows are filtered on read as well: a feedback row
+		// cannot borrow a run or Behavior from a different organization.
+		await sql`
+			INSERT INTO watcher_reactions (
+				organization_id, watcher_id, window_id, reaction_type,
+				tool_name, tool_args, run_id
+			) VALUES (
+				${orgId}, ${victimBehaviorId}, ${victimWindowId},
+				'notification_sent', 'notify',
+				${sql.json({ title: "Forged cross-org review" })}, ${sent.run_id}
+			)
+		`;
+		expect(await getPastReactionsSummary(victimBehaviorId)).toBeUndefined();
+	});
+
 	it("repairs a missing Behavior feedback edge when an idempotent ask retries", async () => {
 		const sql = getTestDb();
 		const suffix = `${process.pid}_${Date.now()}`;

--- a/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
@@ -7,6 +7,7 @@ import { createAuthProfile } from "../../utils/auth-profiles";
 import { initWorkspaceProvider } from "../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
+	createTestAgent,
 	createTestConnection,
 	createTestConnectorDefinition,
 	seedOwnerContext,
@@ -31,6 +32,8 @@ describe("operations.execute backend lifecycle", () => {
 	let mcpConnectionId: number;
 	let secondMcpConnectionId: number;
 	let httpConnectionId: number;
+	let behaviorId: number;
+	let windowId: number;
 	let failedTransportCallCount = 0;
 
 	beforeAll(async () => {
@@ -47,6 +50,10 @@ describe("operations.execute backend lifecycle", () => {
 		orgId = org.id;
 		userId = user.id;
 		ctx = ownerCtx;
+		const behaviorAgent = await createTestAgent({
+			organizationId: orgId,
+			ownerUserId: userId,
+		});
 
 		for (const [key, name] of [
 			[LOCAL, "Local backend"],
@@ -62,6 +69,28 @@ describe("operations.execute backend lifecycle", () => {
 		}
 
 		const sql = getTestDb();
+		const [behavior] = await sql`
+			WITH next_id AS (SELECT nextval('watchers_id_seq')::integer AS id)
+			INSERT INTO watchers (
+				id, watcher_group_id, organization_id, agent_id, created_by, name, slug
+			)
+			SELECT id, id, ${orgId}, ${behaviorAgent.agentId}, ${userId},
+				'Operation provenance behavior', 'operation-provenance-behavior'
+			FROM next_id
+			RETURNING id
+		`;
+		behaviorId = Number(behavior.id);
+		const [window] = await sql`
+			INSERT INTO events (
+				organization_id, semantic_type, payload_type, payload_data,
+				metadata, occurred_at, created_at, created_by
+			) VALUES (
+				${orgId}, 'canvas_state', 'json_template', '{}'::jsonb,
+				${sql.json({ watcher_id: behaviorId })}, NOW(), NOW(), ${userId}
+			)
+			RETURNING id
+		`;
+		windowId = Number(window.id);
 		await sql`
 			UPDATE connector_definitions
 			SET actions_schema = ${sql.json({
@@ -337,6 +366,34 @@ describe("operations.execute backend lifecycle", () => {
 			  AND action_idempotency_key = 'operation-backend-test:durable-once'
 		`;
 		expect(runs).toHaveLength(1);
+	});
+
+	it("binds an action and its feedback record to the trusted Behavior window", async () => {
+		const result = (await manageOperations(
+			{
+				action: "execute",
+				connection_id: localConnectionId,
+				operation_key: "echo",
+				input: { value: "behavior-provenance" },
+				idempotency_key: "operation-backend-test:behavior-provenance",
+			},
+			{} as Env,
+			{ ...ctx, actingWatcherId: behaviorId, actingWindowId: windowId },
+		)) as { run_id: number; status: string };
+
+		expect(result).toMatchObject({ status: "completed" });
+		const sql = getTestDb();
+		const [run] = await sql`
+			SELECT watcher_id, window_id FROM runs WHERE id = ${result.run_id}
+		`;
+		expect(Number(run.watcher_id)).toBe(behaviorId);
+		expect(Number(run.window_id)).toBe(windowId);
+		const [reaction] = await sql`
+			SELECT run_id FROM watcher_reactions
+			WHERE watcher_id = ${behaviorId} AND window_id = ${windowId}
+			ORDER BY id DESC LIMIT 1
+		`;
+		expect(Number(reaction.run_id)).toBe(result.run_id);
 	});
 
 	it("concurrent action retries converge and mismatched key reuse fails closed", async () => {

--- a/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
@@ -402,6 +402,80 @@ describe("operations.execute backend lifecycle", () => {
 		expect(Number(reactions[0]?.run_id)).toBe(result.run_id);
 	});
 
+	it("repairs a failed feedback link without stranding or repeating an inline action", async () => {
+		const sql = getTestDb();
+		await sql.unsafe(`
+			CREATE SEQUENCE operation_reaction_failure_seq;
+			CREATE FUNCTION fail_first_operation_reaction() RETURNS trigger AS $$
+			BEGIN
+				IF NEW.watcher_id = ${behaviorId}
+					AND NEW.tool_name = 'manage_operations'
+					AND nextval('operation_reaction_failure_seq') = 1 THEN
+					RAISE EXCEPTION 'forced operation reaction failure';
+				END IF;
+				RETURN NEW;
+			END;
+			$$ LANGUAGE plpgsql;
+			CREATE TRIGGER fail_first_operation_reaction_trigger
+				BEFORE INSERT ON watcher_reactions
+				FOR EACH ROW EXECUTE FUNCTION fail_first_operation_reaction();
+		`);
+
+		const execute = () =>
+			manageOperations(
+				{
+					action: "execute",
+					connection_id: localConnectionId,
+					operation_key: "echo",
+					input: { value: "repair-feedback" },
+					idempotency_key: "operation-backend-test:repair-feedback",
+				},
+				{} as Env,
+				{ ...ctx, actingWatcherId: behaviorId, actingWindowId: windowId },
+			);
+
+		try {
+			await expect(execute()).rejects.toThrow(
+				"forced operation reaction failure",
+			);
+			const [persisted] = await sql`
+				SELECT id, status, action_output FROM runs
+				WHERE organization_id = ${orgId}
+				  AND action_idempotency_key = 'operation-backend-test:repair-feedback'
+			`;
+			expect(persisted.status).toBe("completed");
+			expect(persisted.action_output).toMatchObject({
+				backend: "local_action",
+				value: "repair-feedback",
+			});
+
+			const replay = (await execute()) as { run_id: number; status: string };
+			expect(replay).toMatchObject({
+				run_id: Number(persisted.id),
+				status: "completed",
+			});
+			const runs = await sql`
+				SELECT id FROM runs
+				WHERE organization_id = ${orgId}
+				  AND action_idempotency_key = 'operation-backend-test:repair-feedback'
+			`;
+			expect(runs).toHaveLength(1);
+			const reactions = await sql`
+				SELECT run_id FROM watcher_reactions
+				WHERE watcher_id = ${behaviorId}
+				  AND window_id = ${windowId}
+				  AND run_id = ${Number(persisted.id)}
+			`;
+			expect(reactions).toHaveLength(1);
+		} finally {
+			await sql.unsafe(`
+				DROP TRIGGER IF EXISTS fail_first_operation_reaction_trigger ON watcher_reactions;
+				DROP FUNCTION IF EXISTS fail_first_operation_reaction();
+				DROP SEQUENCE IF EXISTS operation_reaction_failure_seq;
+			`);
+		}
+	});
+
 	it("concurrent action retries converge and mismatched key reuse fails closed", async () => {
 		const key = "operation-backend-test:concurrent";
 		const execute = (value: string) =>

--- a/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
@@ -369,31 +369,37 @@ describe("operations.execute backend lifecycle", () => {
 	});
 
 	it("binds an action and its feedback record to the trusted Behavior window", async () => {
-		const result = (await manageOperations(
-			{
+		const execute = () =>
+			manageOperations(
+				{
 				action: "execute",
 				connection_id: localConnectionId,
 				operation_key: "echo",
 				input: { value: "behavior-provenance" },
 				idempotency_key: "operation-backend-test:behavior-provenance",
-			},
-			{} as Env,
-			{ ...ctx, actingWatcherId: behaviorId, actingWindowId: windowId },
-		)) as { run_id: number; status: string };
+				},
+				{} as Env,
+				{ ...ctx, actingWatcherId: behaviorId, actingWindowId: windowId },
+			);
+		const result = (await execute()) as { run_id: number; status: string };
+		const replay = (await execute()) as { run_id: number; status: string };
 
 		expect(result).toMatchObject({ status: "completed" });
+		expect(replay.run_id).toBe(result.run_id);
 		const sql = getTestDb();
 		const [run] = await sql`
 			SELECT watcher_id, window_id FROM runs WHERE id = ${result.run_id}
 		`;
 		expect(Number(run.watcher_id)).toBe(behaviorId);
 		expect(Number(run.window_id)).toBe(windowId);
-		const [reaction] = await sql`
+		const reactions = await sql`
 			SELECT run_id FROM watcher_reactions
-			WHERE watcher_id = ${behaviorId} AND window_id = ${windowId}
-			ORDER BY id DESC LIMIT 1
+			WHERE watcher_id = ${behaviorId}
+			  AND window_id = ${windowId}
+			  AND run_id = ${result.run_id}
 		`;
-		expect(Number(reaction.run_id)).toBe(result.run_id);
+		expect(reactions).toHaveLength(1);
+		expect(Number(reactions[0]?.run_id)).toBe(result.run_id);
 	});
 
 	it("concurrent action retries converge and mismatched key reuse fails closed", async () => {

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -342,7 +342,13 @@ describe("method-metadata", () => {
 			["behaviors.setReactionScript", ["reaction_script: string"]],
 			[
 				"notifications.send",
-				["title: string", "body?: string", "'admins' | 'all' | string[]"],
+				[
+					"title: string",
+					"body?: string",
+					"'admins' | 'all' | string[]",
+					"input_schema?: object",
+					"run_id?: number",
+				],
 			],
 			["connections.update", ["display_name?: string"]],
 			["classifiers.classify", ["classifier_slug: string", "'llm' | 'user'"]],

--- a/packages/server/src/notifications/ask.ts
+++ b/packages/server/src/notifications/ask.ts
@@ -43,6 +43,8 @@ export const AGENT_ASK_ACTION_KEY = "agent_ask";
 /** What the agent asked, held in `runs.action_input` for the reviewer. */
 export interface AgentAskProposal {
 	question: string;
+	/** Reviewer context retained so future Behavior runs can interpret the answer. */
+	context?: string;
 	/**
 	 * JSON Schema for the answer. An EMPTY schema is meaningful and common: it
 	 * means "decide, no fields" — the binary yes/no that renders as inline
@@ -192,6 +194,7 @@ export async function queueAgentAsk(params: {
 	const sql = getDb();
 	const proposal: AgentAskProposal = {
 		question: params.question,
+		...(params.body ? { context: params.body } : {}),
 		input_schema: params.inputSchema,
 	};
 	const initiator = resolveRunInitiator(params.ctx);
@@ -199,11 +202,14 @@ export async function queueAgentAsk(params: {
 	const inserted = await sql`
     INSERT INTO runs (
       organization_id, run_type, action_key, action_input,
+      watcher_id, window_id,
       created_by_user_id, initiator_kind, initiator_ref,
       approval_status, status, created_at
     ) VALUES (
       ${params.ctx.organizationId}, 'internal', ${AGENT_ASK_ACTION_KEY},
       ${sql.json(proposal as unknown as Record<string, unknown>)},
+      ${params.ctx.actingWatcherId ?? null},
+      ${params.ctx.actingWindowId ?? null},
       ${initiator.createdByUserId},
       ${initiator.initiatorKind},
       ${sql.json(initiator.initiatorRef)},

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -1005,6 +1005,10 @@ export async function createConnectorOperationRun(params: {
   policyPrincipalId?: string | null;
   /** Trusted user who initiated the operation, used for downstream visibility checks. */
   createdByUserId?: string | null;
+  /** Trusted Behavior provenance from the executing ToolContext. */
+  watcherId?: number | null;
+  /** Trusted firing canvas/window id paired with watcherId. */
+  windowId?: number | null;
   /**
    * Optional transaction handle. When passed, the run INSERT (and its
    * connector-version read) execute on the caller's transaction instead of the
@@ -1058,6 +1062,7 @@ export async function createConnectorOperationRun(params: {
     INSERT INTO runs (
       organization_id, run_type, connection_id, connector_key, connector_version,
       action_key, action_input, approval_status, status,
+      watcher_id, window_id,
       policy_principal_kind, policy_principal_id, created_by_user_id,
       action_idempotency_key, created_at
     ) VALUES (
@@ -1065,6 +1070,7 @@ export async function createConnectorOperationRun(params: {
       ${params.connectorKey}, ${connectorVersion},
       ${params.operationKey}, ${sql.json(params.operationInput)},
       ${approvalStatus}, ${status},
+      ${params.watcherId ?? null}, ${params.windowId ?? null},
       ${params.policyPrincipalKind ?? null}, ${params.policyPrincipalId ?? null},
       ${params.createdByUserId ?? null},
       ${params.idempotencyKey ?? null},
@@ -1089,6 +1095,8 @@ export async function createConnectorOperationRun(params: {
       policy_principal_kind: string | null;
       policy_principal_id: string | null;
       created_by_user_id: string | null;
+      watcher_id: number | null;
+      window_id: number | null;
       status: string;
       approval_status: string;
       action_output: unknown;
@@ -1096,6 +1104,7 @@ export async function createConnectorOperationRun(params: {
     }>`
       SELECT id, connection_id, connector_key, action_key, action_input,
              policy_principal_kind, policy_principal_id, created_by_user_id,
+             watcher_id, window_id,
              status, approval_status, action_output, error_message
       FROM runs
       WHERE organization_id = ${params.organizationId}
@@ -1115,11 +1124,33 @@ export async function createConnectorOperationRun(params: {
       prior.policy_principal_kind === (params.policyPrincipalKind ?? null) &&
       prior.policy_principal_id === (params.policyPrincipalId ?? null) &&
       prior.created_by_user_id === (params.createdByUserId ?? null);
-    if (!sameRequest) {
+    const priorWatcherId = prior.watcher_id == null ? null : Number(prior.watcher_id);
+    const priorWindowId = prior.window_id == null ? null : Number(prior.window_id);
+    const requestedWatcherId = params.watcherId ?? null;
+    const requestedWindowId = params.windowId ?? null;
+    const compatibleProvenance =
+      (priorWatcherId == null || priorWatcherId === requestedWatcherId) &&
+      (priorWindowId == null || priorWindowId === requestedWindowId);
+    if (!sameRequest || !compatibleProvenance) {
       throw new ToolUserError(
         `Action idempotency key '${params.idempotencyKey}' is already bound to a different request.`,
         409
       );
+    }
+    // Runs created before Behavior action provenance was stamped can be safely
+    // hydrated on an exact idempotent replay. Never overwrite a non-null stamp:
+    // a key already bound to another window remains a conflict above.
+    if (
+      (priorWatcherId == null && requestedWatcherId != null) ||
+      (priorWindowId == null && requestedWindowId != null)
+    ) {
+      await sql`
+        UPDATE runs
+        SET watcher_id = COALESCE(watcher_id, ${requestedWatcherId}),
+            window_id = COALESCE(window_id, ${requestedWindowId})
+        WHERE id = ${Number(prior.id)}
+          AND organization_id = ${params.organizationId}
+      `;
     }
     return {
       runId: Number(prior.id),

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -494,10 +494,10 @@ export default async (_ctx, client) => {
 	},
 	"notifications.send": {
 		summary:
-			"Send a notification to org users. Writes an `agent_message` notification (in-app inbox) and fans it out to the org's active bot connections (Slack/Telegram) — the way a Behavior reaction surfaces its digest to a chat channel. Pass an optional `card` (a `chat` CardElement) for rich cross-platform rendering, and `behavior_source` when firing from a reaction.",
+			"Send a notification to org users. With `input_schema`, it becomes an answerable human question on the existing approval/rejection rail; the returned `run_id` can be read with `operations.getRun`, and Reject can carry a reason. Without `input_schema`, it writes an FYI `agent_message`. Both fan out to active bot connections. Pass `behavior_source` from a reaction for feedback attribution.",
 		access: "write",
 		signature:
-			"notifications.send(input: { title: string; body?: string; card?: CardElement; recipients?: 'admins' | 'all' | string[]; resource_url?: string; idempotency_key?: string; connection_id?: string; data?: object; behavior_source?: { behavior_id: number; window_id: number } }): Promise<{ notified_count: number }>",
+			"notifications.send(input: { title: string; body?: string; card?: CardElement; recipients?: 'admins' | 'all' | string[]; resource_url?: string; idempotency_key?: string; connection_id?: string; data?: object; input_schema?: object; behavior_source?: { behavior_id: number; window_id: number } }): Promise<{ notified_count: number; event_id: number | null; url: string | null; run_id?: number }>",
 		example:
 			"await client.notifications.send({ title: 'Weekly funnel digest', body: '3 new leads...', behavior_source: { behavior_id: ctx.window.behavior_id, window_id: ctx.window.id } });",
 		usageExample: `// Push a Behavior digest to the org's Slack/Telegram connections + inbox.

--- a/packages/server/src/sandbox/namespaces/notifications.ts
+++ b/packages/server/src/sandbox/namespaces/notifications.ts
@@ -9,6 +9,10 @@
  */
 
 import type { CardElement } from "chat";
+import type {
+	NotificationsSendInput as ReactionNotificationsSendInput,
+	NotificationsSendResult,
+} from "@lobu/connector-sdk";
 import type { Env } from "../../index";
 import { listNotifications, markAsRead } from "../../notifications/service";
 import { notify } from "../../tools/admin/notify";
@@ -16,32 +20,16 @@ import type { ToolContext } from "../../tools/registry";
 import { ToolUserError } from "../../utils/errors";
 import { createActionCaller, idArg } from "./action-call";
 
-export interface NotificationsSendInput {
-	/** Notification title (≤200 chars). */
-	title: string;
-	/** Body text (≤1000 chars). */
-	body?: string;
+export type NotificationsSendInput = Omit<
+	ReactionNotificationsSendInput,
+	"card"
+> & {
 	/**
 	 * Optional rich card (`chat` `CardElement`) for bot-connection delivery,
 	 * rendered to each platform's native format (Block Kit / Adaptive Cards / …).
 	 */
 	card?: CardElement;
-	/**
-	 * Who to notify. `"admins"` (default): org admins/owners. `"all"`: every
-	 * member. Or an array of specific user IDs.
-	 */
-	recipients?: "admins" | "all" | string[];
-	/** Relative URL the notification links to (e.g. `/acme/entities`). */
-	resource_url?: string;
-	/** Stable producer key used to collapse retried sends. */
-	idempotency_key?: string;
-	/** Deliver only through this specific bot connection (its id). */
-	connection_id?: string;
-	/** Arbitrary JSON payload appended to the body as formatted JSON. */
-	data?: Record<string, unknown>;
-	/** Attribution when sent from a watcher reaction — both ids are numeric. */
-	behavior_source?: { behavior_id: number; window_id: number };
-}
+};
 
 export interface NotificationsListInput {
 	/** Keyset cursor: return notifications with id strictly less than this. */
@@ -58,7 +46,7 @@ export interface NotificationsListResult {
 }
 
 export interface NotificationsNamespace {
-	send(input: NotificationsSendInput): Promise<{ notified_count: number }>;
+	send(input: NotificationsSendInput): Promise<NotificationsSendResult>;
 	list(input?: NotificationsListInput): Promise<NotificationsListResult>;
 	/**
 	 * Mark one of the caller's notifications as read. Accepts a positional id

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1399,8 +1399,6 @@ async function handleExecute(
 	}
 	const runId = claim.runId;
 
-	await trackOperationReaction(runId);
-
 	// Device-bound branch: the run is pending; a device worker (chrome
 	// extension, mac bridge, ...) will claim it via /api/workers/poll and
 	// post completion to /api/workers/complete-action. Poll runs.status
@@ -1412,6 +1410,7 @@ async function handleExecute(
 			ctx.organizationId,
 			ctx.abortSignal,
 		);
+		await trackOperationReaction(runId);
 		if (result.status === "completed") {
 			return {
 				action: "execute",
@@ -1446,6 +1445,7 @@ async function handleExecute(
 		env,
 		ctx.abortSignal,
 	);
+	await trackOperationReaction(runId);
 	if (result.status === "completed") {
 		return {
 			action: "execute",

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1130,10 +1130,10 @@ async function handleExecute(
 	}
 
 	const input = args.input ?? {};
-	const reactionBehaviorId =
-		ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
-	const reactionWindowId =
-		ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
+	// A caller-provided behavior_source is only an attribution hint. Durable
+	// feedback must follow the server-stamped Behavior execution context.
+	const reactionBehaviorId = ctx.actingWatcherId ?? null;
+	const reactionWindowId = ctx.actingWindowId ?? null;
 	const trackOperationReaction = async (runId: number): Promise<void> => {
 		if (reactionBehaviorId === null || reactionWindowId === null) return;
 		await trackWatcherReaction({

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1263,6 +1263,8 @@ async function handleExecute(
 				policyPrincipalKind: actor.kind,
 				policyPrincipalId: actor.id,
 				createdByUserId: ctx.userId,
+				watcherId: ctx.actingWatcherId,
+				windowId: ctx.actingWindowId,
 				idempotencyKey: args.idempotency_key,
 				db: tx,
 			});
@@ -1318,11 +1320,15 @@ async function handleExecute(
 
 		// Telemetry + notification run AFTER the run+event are durably committed,
 		// so they never reference a rolled-back run and stay off the hot path.
-		if (args.behavior_source) {
+		const reactionBehaviorId =
+			ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
+		const reactionWindowId =
+			ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
+		if (reactionBehaviorId !== null && reactionWindowId !== null) {
 			await trackWatcherReaction({
 				organizationId: ctx.organizationId,
-				watcherId: args.behavior_source.behavior_id,
-				windowId: args.behavior_source.window_id,
+				watcherId: reactionBehaviorId,
+				windowId: reactionWindowId,
 				reactionType: "action_executed",
 				toolName: "manage_operations",
 				toolArgs: {
@@ -1380,6 +1386,8 @@ async function handleExecute(
 		policyPrincipalKind: actor.kind,
 		policyPrincipalId: actor.id,
 		createdByUserId: ctx.userId,
+		watcherId: ctx.actingWatcherId,
+		windowId: ctx.actingWindowId,
 		idempotencyKey: args.idempotency_key,
 	});
 	if (!claim.created) {
@@ -1387,11 +1395,15 @@ async function handleExecute(
 	}
 	const runId = claim.runId;
 
-	if (args.behavior_source) {
+	const reactionBehaviorId =
+		ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
+	const reactionWindowId =
+		ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
+	if (reactionBehaviorId !== null && reactionWindowId !== null) {
 		await trackWatcherReaction({
 			organizationId: ctx.organizationId,
-			watcherId: args.behavior_source.behavior_id,
-			windowId: args.behavior_source.window_id,
+			watcherId: reactionBehaviorId,
+			windowId: reactionWindowId,
 			reactionType: "action_executed",
 			toolName: "manage_operations",
 			toolArgs: {
@@ -1611,7 +1623,7 @@ async function handleListRuns(
     pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
   }
   const query = sql`
-    SELECT r.id, r.run_type, r.watcher_id AS behavior_id, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
+    SELECT r.id, r.run_type, r.watcher_id AS behavior_id, r.window_id, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.items_collected, r.checkpoint,
            r.created_at, r.completed_at,
@@ -1652,7 +1664,7 @@ async function handleGetRun(
   // a run visible in the list is always fetchable here. Only the chat-message
   // transport lane (the list's default exclusion) stays unfetchable.
   const rows = await sql`
-    SELECT r.id, r.watcher_id AS behavior_id, r.connection_id, r.connector_key,
+    SELECT r.id, r.watcher_id AS behavior_id, r.window_id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.run_type,
            r.created_at, r.completed_at,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1130,6 +1130,26 @@ async function handleExecute(
 	}
 
 	const input = args.input ?? {};
+	const reactionBehaviorId =
+		ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
+	const reactionWindowId =
+		ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
+	const trackOperationReaction = async (runId: number): Promise<void> => {
+		if (reactionBehaviorId === null || reactionWindowId === null) return;
+		await trackWatcherReaction({
+			organizationId: ctx.organizationId,
+			watcherId: reactionBehaviorId,
+			windowId: reactionWindowId,
+			reactionType: "action_executed",
+			toolName: "manage_operations",
+			toolArgs: {
+				operation_key: args.operation_key,
+				connection_id: args.connection_id,
+				input,
+			},
+			runId,
+		});
+	};
 	const validationError = validateOperationInput(operation, input);
 	if (validationError) {
 		return {
@@ -1311,6 +1331,7 @@ async function handleExecute(
 			return { claim: createdRun, eventId: Number(event.id) };
 		});
 		if (!claim.created) {
+			await trackOperationReaction(claim.runId);
 			return replayExistingOperationRun(claim, operation.name, ctx);
 		}
 		if (eventId == null) {
@@ -1320,25 +1341,7 @@ async function handleExecute(
 
 		// Telemetry + notification run AFTER the run+event are durably committed,
 		// so they never reference a rolled-back run and stay off the hot path.
-		const reactionBehaviorId =
-			ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
-		const reactionWindowId =
-			ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
-		if (reactionBehaviorId !== null && reactionWindowId !== null) {
-			await trackWatcherReaction({
-				organizationId: ctx.organizationId,
-				watcherId: reactionBehaviorId,
-				windowId: reactionWindowId,
-				reactionType: "action_executed",
-				toolName: "manage_operations",
-				toolArgs: {
-					operation_key: args.operation_key,
-					connection_id: args.connection_id,
-					input,
-				},
-				runId,
-			});
-		}
+		await trackOperationReaction(runId);
 
 		const { ownerSlug: orgSlug, baseUrl } = await getOrgUrlContext(ctx);
 		// Run-scoped, not event-scoped: the pending event is superseded on
@@ -1391,29 +1394,12 @@ async function handleExecute(
 		idempotencyKey: args.idempotency_key,
 	});
 	if (!claim.created) {
+		await trackOperationReaction(claim.runId);
 		return replayExistingOperationRun(claim, operation.name, ctx);
 	}
 	const runId = claim.runId;
 
-	const reactionBehaviorId =
-		ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
-	const reactionWindowId =
-		ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
-	if (reactionBehaviorId !== null && reactionWindowId !== null) {
-		await trackWatcherReaction({
-			organizationId: ctx.organizationId,
-			watcherId: reactionBehaviorId,
-			windowId: reactionWindowId,
-			reactionType: "action_executed",
-			toolName: "manage_operations",
-			toolArgs: {
-				operation_key: args.operation_key,
-				connection_id: args.connection_id,
-				input,
-			},
-			runId,
-		});
-	}
+	await trackOperationReaction(runId);
 
 	// Device-bound branch: the run is pending; a device worker (chrome
 	// extension, mac bridge, ...) will claim it via /api/workers/poll and

--- a/packages/server/src/tools/admin/notify.ts
+++ b/packages/server/src/tools/admin/notify.ts
@@ -224,6 +224,26 @@ async function handleSend(
 
   const orgSlug = await getOrgSlug(ctx.organizationId);
 
+  // Prefer trusted execution provenance. behavior_source remains the
+  // compatibility/attribution hint for non-Behavior callers, but a running
+  // Behavior cannot be redirected onto another Behavior's feedback history.
+  const reactionBehaviorId =
+    ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
+  const reactionWindowId =
+    ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
+  const trackNotificationReaction = async (runId?: number): Promise<void> => {
+    if (reactionBehaviorId === null || reactionWindowId === null) return;
+    await trackWatcherReaction({
+      organizationId: ctx.organizationId,
+      watcherId: reactionBehaviorId,
+      windowId: reactionWindowId,
+      reactionType: 'notification_sent',
+      toolName: 'notify',
+      toolArgs: { title: args.title, recipients: args.recipients },
+      ...(runId != null ? { runId } : {}),
+    });
+  };
+
   // An idempotent repeat of an ASK must resolve before anything is queued: the
   // pending run + interaction event are durable, so queueing first and letting
   // the notification insert dedupe would strand an orphan pending run — and
@@ -236,6 +256,12 @@ async function handleSend(
     );
     if (prior !== null) {
       const priorRunId = await findAskRunForNotification(ctx.organizationId, prior);
+      if (priorRunId !== null) {
+        // The notification can commit before this feedback edge. A failed first
+        // attempt therefore reconciles here on retry instead of returning early
+        // forever with an ask the Behavior cannot learn from.
+        await trackNotificationReaction(priorRunId);
+      }
       return {
         notified_count: 0,
         event_id: prior,
@@ -321,27 +347,14 @@ async function handleSend(
     );
   }
 
-  // Prefer trusted execution provenance. behavior_source remains the
-  // compatibility/attribution hint for non-Behavior callers, but a running
-  // Behavior cannot be redirected onto another Behavior's feedback history.
-  const reactionBehaviorId =
-    ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
-  const reactionWindowId =
-    ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
-  if (
-    notification.created &&
-    reactionBehaviorId !== null &&
-    reactionWindowId !== null
-  ) {
-    await trackWatcherReaction({
-      organizationId: ctx.organizationId,
-      watcherId: reactionBehaviorId,
-      windowId: reactionWindowId,
-      reactionType: 'notification_sent',
-      toolName: 'notify',
-      toolArgs: { title: args.title, recipients: args.recipients },
-      ...(askRunId !== null ? { runId: askRunId } : {}),
-    }).catch((err) => {
+  if (askRunId !== null) {
+    // The ask-to-Behavior edge is required and idempotent: if it fails, surface
+    // the failure so the caller retries and the preflight above repairs it.
+    await trackNotificationReaction(askRunId);
+  } else if (notification.created) {
+    // Plain FYI notifications have no run handle to use as a durable dedupe
+    // key, so retain their historical best-effort tracking behavior.
+    await trackNotificationReaction().catch((err) => {
       logger.warn(
         { err, behaviorId: reactionBehaviorId, windowId: reactionWindowId },
         'trackWatcherReaction failed'

--- a/packages/server/src/tools/admin/notify.ts
+++ b/packages/server/src/tools/admin/notify.ts
@@ -224,13 +224,11 @@ async function handleSend(
 
   const orgSlug = await getOrgSlug(ctx.organizationId);
 
-  // Prefer trusted execution provenance. behavior_source remains the
-  // compatibility/attribution hint for non-Behavior callers, but a running
-  // Behavior cannot be redirected onto another Behavior's feedback history.
-  const reactionBehaviorId =
-    ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
-  const reactionWindowId =
-    ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
+  // Feedback is learned from server-stamped execution provenance only.
+  // `behavior_source` remains a validated canvas-attribution hint above, but
+  // caller input must never choose another Behavior's learning history.
+  const reactionBehaviorId = ctx.actingWatcherId ?? null;
+  const reactionWindowId = ctx.actingWindowId ?? null;
   const trackNotificationReaction = async (runId?: number): Promise<void> => {
     if (reactionBehaviorId === null || reactionWindowId === null) return;
     await trackWatcherReaction({

--- a/packages/server/src/tools/admin/notify.ts
+++ b/packages/server/src/tools/admin/notify.ts
@@ -305,26 +305,10 @@ async function handleSend(
     emit(ctx.organizationId, { keys: ['notifications', 'notifications-unread-count'] });
   }
 
-  // Track watcher reaction if attribution source is provided
-  if (notification.created && args.behavior_source) {
-    await trackWatcherReaction({
-      organizationId: ctx.organizationId,
-      watcherId: args.behavior_source.behavior_id,
-      windowId: args.behavior_source.window_id,
-      reactionType: 'notification_sent',
-      toolName: 'notify',
-      toolArgs: { title: args.title, recipients: args.recipients },
-    }).catch((err) => {
-      logger.warn({ err, behaviorSource: args.behavior_source }, 'trackWatcherReaction failed');
-    });
-  }
-
   // Two replicas can race past the idempotency preflight above; the loser's
   // notification insert resolves to the winner's event, so the run WE queued is
-  // an orphan nothing points at. Hand back the winner's run so the agent polls
-  // the question the human actually sees; the orphan stays pending and is
-  // closed by the pending-approval expiry sweep — its terminal path already —
-  // rather than a hand-rolled cleanup here.
+  // an orphan nothing points at. Resolve the delivered run before reaction
+  // tracking so watcher_reactions always points at the decision the human sees.
   let askRunId = ask?.runId ?? null;
   if (ask && !notification.created && notification.eventId !== null) {
     askRunId = await findAskRunForNotification(
@@ -335,6 +319,34 @@ async function handleSend(
       { orphanRunId: ask.runId, eventId: notification.eventId, askRunId },
       '[notify] Concurrent duplicate ask; returning the delivered run, orphan left to the approval expiry sweep'
     );
+  }
+
+  // Prefer trusted execution provenance. behavior_source remains the
+  // compatibility/attribution hint for non-Behavior callers, but a running
+  // Behavior cannot be redirected onto another Behavior's feedback history.
+  const reactionBehaviorId =
+    ctx.actingWatcherId ?? args.behavior_source?.behavior_id ?? null;
+  const reactionWindowId =
+    ctx.actingWindowId ?? args.behavior_source?.window_id ?? null;
+  if (
+    notification.created &&
+    reactionBehaviorId !== null &&
+    reactionWindowId !== null
+  ) {
+    await trackWatcherReaction({
+      organizationId: ctx.organizationId,
+      watcherId: reactionBehaviorId,
+      windowId: reactionWindowId,
+      reactionType: 'notification_sent',
+      toolName: 'notify',
+      toolArgs: { title: args.title, recipients: args.recipients },
+      ...(askRunId !== null ? { runId: askRunId } : {}),
+    }).catch((err) => {
+      logger.warn(
+        { err, behaviorId: reactionBehaviorId, windowId: reactionWindowId },
+        'trackWatcherReaction failed'
+      );
+    });
   }
 
   // The event id IS the notification id — there is no second identifier — so an

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -43,6 +43,12 @@ export interface AuthContext {
   userId: string | null;
   memberRole: string | null;
   agentId: string | null;
+  /** Trusted internal reaction provenance. Never populated from request input. */
+  actingWatcherId?: number | null;
+  /** Trusted internal reaction window. Never populated from request input. */
+  actingWindowId?: number | null;
+  /** Trusted internal reaction run. Never populated from request input. */
+  actingRunId?: number | null;
   requestedAgentId: string | null;
   sourceContext?: ToolSourceContext | null;
   isAuthenticated: boolean;
@@ -384,6 +390,9 @@ export function toToolContext(authCtx: AuthContext): ToolContext {
     userId: authCtx.userId,
     memberRole: authCtx.memberRole,
     agentId: authCtx.agentId,
+    actingWatcherId: authCtx.actingWatcherId ?? null,
+    actingWindowId: authCtx.actingWindowId ?? null,
+    actingRunId: authCtx.actingRunId ?? null,
     sourceContext: authCtx.sourceContext ?? null,
     isAuthenticated: authCtx.isAuthenticated,
     clientId: authCtx.clientId,

--- a/packages/server/src/utils/watcher-reactions.ts
+++ b/packages/server/src/utils/watcher-reactions.ts
@@ -152,7 +152,14 @@ export async function getPastReactionsSummary(
 }
 
 /**
- * Track a watcher reaction (fire-and-forget safe).
+ * Track a watcher reaction.
+ *
+ * A run-linked reaction is a durable feedback edge, not best-effort telemetry.
+ * Serialize concurrent retries for the same edge and insert only when it is
+ * missing. Callers that truly want fire-and-forget behavior can catch/log the
+ * propagated error at their own boundary. Entries without a run handle retain
+ * their historical best-effort behavior because they cannot be reconciled by a
+ * later idempotent replay.
  */
 export async function trackWatcherReaction(params: {
   organizationId: string;
@@ -166,6 +173,48 @@ export async function trackWatcherReaction(params: {
   runId?: number;
 }): Promise<void> {
   const sql = getDb();
+  if (params.runId != null) {
+    const lockKey = [
+      params.organizationId,
+      params.watcherId,
+      params.windowId,
+      params.reactionType,
+      params.toolName,
+      params.runId,
+    ].join(':');
+    await sql.begin(async (tx) => {
+      await tx`
+        SELECT pg_advisory_xact_lock(
+          hashtext('lobu:watcher-reaction'),
+          hashtext(${lockKey})
+        )
+      `;
+      await tx`
+        INSERT INTO watcher_reactions (
+          organization_id, watcher_id, window_id,
+          reaction_type, tool_name, tool_args, tool_result, entity_id, run_id
+        )
+        SELECT
+          ${params.organizationId}, ${params.watcherId}, ${params.windowId},
+          ${params.reactionType}, ${params.toolName},
+          ${tx.json(params.toolArgs)},
+          ${params.toolResult ? tx.json(params.toolResult) : null},
+          ${params.entityId ?? null},
+          ${params.runId}
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM watcher_reactions
+          WHERE organization_id = ${params.organizationId}
+            AND watcher_id = ${params.watcherId}
+            AND window_id = ${params.windowId}
+            AND reaction_type = ${params.reactionType}
+            AND tool_name = ${params.toolName}
+            AND run_id = ${params.runId}
+        )
+      `;
+    });
+    return;
+  }
   await sql`
     INSERT INTO watcher_reactions (
       organization_id, watcher_id, window_id,

--- a/packages/server/src/utils/watcher-reactions.ts
+++ b/packages/server/src/utils/watcher-reactions.ts
@@ -86,9 +86,18 @@ export async function getPastReactionsSummary(
   // view resolves the period (LEFT JOIN — tombstoned roots null).
   const reactions = await sql`
     SELECT wr.reaction_type, wr.tool_name, wr.tool_args, wr.created_at,
-           ww.window_start, ww.window_end
+           ww.window_start, ww.window_end,
+           decision.action_key AS decision_action_key,
+           decision.status AS decision_status,
+           decision.approval_status AS decision_approval_status,
+           decision.action_input AS decision_input,
+           decision.action_output AS decision_output,
+           decision.error_message AS decision_error
     FROM watcher_reactions wr
     LEFT JOIN canvas_windows ww ON ww.id = wr.window_id
+    LEFT JOIN runs decision
+      ON decision.id = wr.run_id
+     AND decision.organization_id = wr.organization_id
     WHERE wr.watcher_id = ${watcherId}
     ORDER BY wr.created_at DESC
     LIMIT ${limit}
@@ -103,7 +112,41 @@ export async function getPastReactionsSummary(
       : '?';
     const toolArgs = r.tool_args as Record<string, unknown> | null;
     const detail = toolArgs ? JSON.stringify(toolArgs) : '';
-    lines.push(`- Window ${date}: ${r.reaction_type} via ${r.tool_name} ${detail}`);
+    let decision = '';
+    if (r.decision_action_key === 'agent_ask') {
+      const proposal = r.decision_input as
+        | { question?: string; context?: string }
+        | null;
+      const question = String(proposal?.question ?? 'Human review');
+      const context = String(proposal?.context ?? '');
+      decision = ` — Asked: ${question}`;
+      if (context) {
+        decision += ` | Context: ${context.slice(0, 600)}${context.length > 600 ? '…' : ''}`;
+      }
+      const approval = String(r.decision_approval_status ?? '');
+      const status = String(r.decision_status ?? '');
+      if (approval === 'approved' && status === 'completed') {
+        const output = r.decision_output as
+          | { answer?: Record<string, unknown> }
+          | null;
+        const answer = output?.answer ?? {};
+        decision += ` — Human answered: ${JSON.stringify(answer)}`;
+        if (answer.outcome === 'posted_edited' && !answer.final_text) {
+          decision += ' (edited final text was not provided)';
+        }
+      } else if (approval === 'rejected') {
+        decision += ` — Human rejected: ${String(r.decision_error ?? 'Rejected by user')}`;
+      } else if (approval === 'expired') {
+        // Expiry means no decision. Keep it explicit so the model never learns
+        // an unattended question as negative preference feedback.
+        decision += ' — Question expired without a human decision (neutral)';
+      } else {
+        decision += ' — Awaiting human decision';
+      }
+    }
+    lines.push(
+      `- Window ${date}: ${r.reaction_type} via ${r.tool_name} ${detail}${decision}`
+    );
   }
   return lines.join('\n');
 }

--- a/packages/server/src/utils/watcher-reactions.ts
+++ b/packages/server/src/utils/watcher-reactions.ts
@@ -94,11 +94,23 @@ export async function getPastReactionsSummary(
            decision.action_output AS decision_output,
            decision.error_message AS decision_error
     FROM watcher_reactions wr
-    LEFT JOIN canvas_windows ww ON ww.id = wr.window_id
+    JOIN watchers owning_watcher
+      ON owning_watcher.id = wr.watcher_id
+     AND owning_watcher.organization_id = wr.organization_id
+    LEFT JOIN canvas_windows ww
+      ON ww.id = wr.window_id
+     AND ww.watcher_id = wr.watcher_id
+    LEFT JOIN runs linked_run
+      ON linked_run.id = wr.run_id
+     AND linked_run.organization_id = wr.organization_id
+     AND linked_run.watcher_id = wr.watcher_id
+     AND linked_run.window_id = wr.window_id
     LEFT JOIN runs decision
-      ON decision.id = wr.run_id
-     AND decision.organization_id = wr.organization_id
+      ON decision.id = linked_run.id
+     AND decision.run_type = 'internal'
+     AND decision.action_key = 'agent_ask'
     WHERE wr.watcher_id = ${watcherId}
+      AND (wr.run_id IS NULL OR linked_run.id IS NOT NULL)
     ORDER BY wr.created_at DESC
     LIMIT ${limit}
   `;
@@ -189,6 +201,18 @@ export async function trackWatcherReaction(params: {
           hashtext(${lockKey})
         )
       `;
+      const matchingRuns = await tx`
+        SELECT id
+        FROM runs
+        WHERE id = ${params.runId}
+          AND organization_id = ${params.organizationId}
+          AND watcher_id = ${params.watcherId}
+          AND window_id = ${params.windowId}
+        FOR KEY SHARE
+      `;
+      if (matchingRuns.length === 0) {
+        throw new Error('Run provenance does not match the Behavior feedback edge.');
+      }
       await tx`
         INSERT INTO watcher_reactions (
           organization_id, watcher_id, window_id,


### PR DESCRIPTION
## Summary

- teach the LinkedIn home-feed connector to capture and normalize the canonical post URL through the generic clipboard-backed scraper from Owletto PR 780
- reuse notifications.send with input_schema for the staged-comment decision: the user can record posted unchanged, posted edited with final text, or Reject with a reason
- preserve the original draft and rationale in the ask run so later Behavior runs can learn from the decision
- attribute operation and ask reactions to the trusted Behavior/window context and expose typed ask/run results to reaction authors
- keep ordinary signal delivery when staging is impossible, offline, or fails; never stage against a generic LinkedIn feed URL

## Design boundaries

- no new table, review entity, or parallel workflow
- no automatic submit or post action
- uses the existing Activity approval/rejection rail and existing watcher reaction history
- explicit Mac mini browser targeting remains required

## Dependency

- https://github.com/lobu-ai/owletto/pull/780 merged as 44ded33a81f590ffcb94f563028b96f860f373a4
- this PR pins that exact merged Owletto main revision

## Verification

- 118 focused connector, reaction, and SDK tests pass
- 24 sandbox metadata tests pass
- 22 database-backed ask and operation provenance tests pass
- 81 Owletto browser tests pass
- full Owletto build and Lobu pre-pr six-stage gate pass
- independent Claude Opus review completed; clipboard safety, replay provenance, error containment, and learning-context findings addressed

## Live reproduction

- Chrome connection 432 on the Mac mini is online and supports the needed operations
- LinkedIn connection 412 and Behavior 71 are healthy
- recent failures were caused by generic https://www.linkedin.com/feed/ source URLs
- a read-only Mac mini probe captured a canonical LinkedIn post link without modifying the real clipboard

Final end-to-end Mac mini proof will be run after deployment and will stage only; it will not submit a comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added answerable approval questions with responses, rejections, and review context.
  - Notifications now include event and run details; operation runs can be listed and inspected.
  - Activity and operation records retain watcher and window context for attribution.
  - Added LinkedIn post URL recovery and enhanced social-interest reviews and digests.

- **Bug Fixes**
  - Improved retries and duplicate prevention for notifications, reviews, and operations.
  - Invalid links and staging failures no longer interrupt unrelated notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->