### PR TITLE
fix(mcp): activate external v3 app template

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -22,7 +22,7 @@ import { get, post } from '../../setup/test-helpers';
 const STUB_LEGACY_HTML =
   '<!doctype html><html><body data-test="mcp-app-legacy-v2-stub">legacy v2</body></html>';
 const STUB_EXTERNAL_HTML =
-  '<!doctype html><html><head><script type="module" src="./assets/app.js"></script></head><body>external v3</body></html>';
+  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><link rel="stylesheet" href="./assets/app.css?v=css123"><script type="module" src="./assets/app.js?v=js123"></script></head><body data-test="mcp-app-external-v3-stub">external v3</body></html>';
 
 describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -150,7 +150,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v2' },
+        params: { uri: 'ui://lobu/interaction/v3.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -159,23 +159,35 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v2');
+    expect(content?.uri).toBe('ui://lobu/interaction/v3.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
-    expect(content?.text).toContain('mcp-app-legacy-v2-stub');
-    expect(content?.text).not.toContain('external v3');
+    expect(content?.text).toContain('mcp-app-external-v3-stub');
+    expect(content?.text).toContain('./assets/app.js?v=js123');
+    expect(content?.text).toContain('./assets/app.css?v=css123');
+    const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
+    expect(baseHref).toBeDefined();
+    const resourceOrigin = new URL(baseHref!).origin;
+    expect(content?.text).toContain(
+      `<base href="${resourceOrigin}/mcp-apps/interaction/" />`
+    );
+    expect(content?.text).not.toContain('__LOBU_MCP_APP_ORIGIN__');
     expect(content?._meta?.ui?.csp).toEqual({
       connectDomains: [],
-      resourceDomains: [],
+      resourceDomains: [resourceOrigin],
       frameDomains: [],
+      baseUriDomains: [resourceOrigin],
     });
     expect(content?._meta?.ui?.prefersBorder).toBe(true);
     expect(content?._meta?.ui?.domain).toBeUndefined();
   });
 
-  it('stages stable assets without switching the v2 HTML route during phase 1', async () => {
+  it('serves the stamped external template and registered stable assets', async () => {
     const htmlResponse = await get('/mcp-apps/interaction/index.html');
     expect(htmlResponse.status).toBe(200);
-    expect(await htmlResponse.text()).toContain('mcp-app-legacy-v2-stub');
+    const html = await htmlResponse.text();
+    expect(html).toContain('mcp-app-external-v3-stub');
+    expect(html).toContain('/mcp-apps/interaction/');
+    expect(html).not.toContain('__LOBU_MCP_APP_ORIGIN__');
 
     const assetResponse = await get('/mcp-apps/interaction/assets/app.js');
     expect(assetResponse.status).toBe(200);
@@ -197,6 +209,34 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect((await get('/mcp-apps/unknown/assets/app.js')).status).toBe(404);
   });
 
+  it('keeps v1 and v2 aliases on the packed, network-free template', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    for (const uri of ['ui://lobu/interaction/v1', 'ui://lobu/interaction/v2']) {
+      const response = await post(`/mcp/${org.slug}`, {
+        body: {
+          jsonrpc: '2.0',
+          id: uri,
+          method: 'resources/read',
+          params: { uri },
+        },
+        headers: { 'mcp-session-id': sessionId },
+        token,
+      });
+      expect(response.status).toBe(200);
+      const content = (await response.json()).result?.contents?.[0];
+      expect(content?.uri).toBe(uri);
+      expect(content?.mimeType).toBe('text/html;profile=mcp-app');
+      expect(content?.text).toContain('mcp-app-legacy-v2-stub');
+      expect(content?.text).not.toContain('mcp-app-external-v3-stub');
+      expect(content?._meta?.ui?.csp).toEqual({
+        connectDomains: [],
+        resourceDomains: [],
+        frameDomains: [],
+      });
+      expect(content?._meta?.ui?.domain).toBeUndefined();
+    }
+  });
+
   it('advertises description and CSP metadata on resources/list without claiming a dedicated app domain', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
@@ -212,19 +252,27 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v2'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v3.html'
     );
     expect(resource).toBeDefined();
+    expect(
+      body.result?.resources?.filter((r: { uri?: string }) =>
+        r.uri?.startsWith('ui://lobu/interaction/')
+      )
+    ).toHaveLength(1);
     // description is a typed resource field surfaced in client browsers.
     expect(typeof resource.description).toBe('string');
     expect(resource.description.length).toBeGreaterThan(0);
     // CSP rides the current nested _meta.ui shape. ui.domain is intentionally
     // absent because it means a dedicated sandbox origin, not the MCP server.
     expect(resource.mimeType).toBe('text/html;profile=mcp-app');
+    const [resourceOrigin] = resource._meta?.ui?.csp?.resourceDomains ?? [];
+    expect(resourceOrigin).toMatch(/^https?:\/\//);
     expect(resource._meta?.ui?.csp).toEqual({
       connectDomains: [],
-      resourceDomains: [],
+      resourceDomains: [resourceOrigin],
       frameDomains: [],
+      baseUriDomains: [resourceOrigin],
     });
     expect(resource._meta?.ui?.prefersBorder).toBe(true);
     expect(resource._meta?.ui?.domain).toBeUndefined();
@@ -255,10 +303,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v2',
+            resourceUri: 'ui://lobu/interaction/v3.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v2',
+          'openai/outputTemplate': 'ui://lobu/interaction/v3.html',
         }),
       })
     );
@@ -277,12 +325,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v2',
+          resourceUri: 'ui://lobu/interaction/v3.html',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v2'
+        'ui://lobu/interaction/v3.html'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -335,7 +383,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v2',
+        resourceUri: 'ui://lobu/interaction/v3.html',
         visibility: ['model', 'app'],
       })
     );

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -120,13 +120,14 @@ import { entityLinkMatchSql } from "./utils/content-search";
 import { isValidFrameAncestor } from "./utils/csp";
 import { errorMessage } from "./utils/errors";
 import logger from "./utils/logger";
-import { readMcpAppAsset, readMcpAppBundle } from "./utils/mcp-app-bundle";
+import { readMcpAppAsset, renderMcpAppTemplate } from "./utils/mcp-app-bundle";
 import { generateOpenAPISpec } from "./utils/openapi-generator";
 import {
 	extractSubdomainOrg,
 	getCanonicalRedirectUrl,
 	getConfiguredPublicOrigin,
 	getSubdomainZone,
+	resolvePublicOrigin,
 } from "./utils/public-origin";
 import {
 	getClientIP,
@@ -2773,15 +2774,18 @@ app.all("/mcp/", handleMcp);
 app.all("/mcp/:orgSlug", handleMcp);
 app.all("/mcp/:orgSlug/", handleMcp);
 
-// MCP App rollout phase 1: keep serving the existing self-contained v2
-// template while staging the stable external assets on every replica. A later
-// release switches this HTML route and MCP discovery to the external template.
+// MCP App public template. The same absolute origin and CSP contract is used by
+// `resources/read`; its content-versioned asset URLs remain safe across mixed
+// replica rollouts and downstream browser caches.
 app.get("/mcp-apps/:app/index.html", async (c) => {
 	const app_ = c.req.param("app");
 	// Only serve a bundle the MCP App registry declares — never an arbitrary
 	// path param.
 	if (!MCP_APP_DIRS.has(app_)) return c.notFound();
-	const html = await readMcpAppBundle(app_, "legacy-v2.html");
+	const html = await renderMcpAppTemplate(
+		app_,
+		resolvePublicOrigin(c.req.url),
+	);
 	if (html == null) return c.notFound();
 	c.header("Content-Type", "text/html; charset=utf-8");
 	c.header("Cache-Control", "no-cache");

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -56,7 +56,7 @@ import { LOBU_INTERACTION_RESOURCE_URI } from './tools/mcp_app';
 import { getMcpResultMeta } from './tools/mcp-result-meta';
 import { getMcpTools, getTool, isAuthorizationReadOnly } from './tools/registry';
 import { validateToolResult } from './tools/validate-args';
-import { readMcpAppBundle } from './utils/mcp-app-bundle';
+import { readMcpAppBundle, renderMcpAppTemplate } from './utils/mcp-app-bundle';
 import { resolvePublicOrigin } from './utils/public-origin';
 import { buildWorkspaceInstructions } from './utils/workspace-instructions';
 
@@ -67,6 +67,10 @@ const SESSION_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 const SESSION_CLEANUP_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
 const MCP_APP_EXTENSION_ID = 'io.modelcontextprotocol/ui';
+const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['ui://lobu/interaction/v1', LOBU_INTERACTION_RESOURCE_URI],
+  ['ui://lobu/interaction/v2', LOBU_INTERACTION_RESOURCE_URI],
+]);
 // ---------------------------------------------------------------------------
 // Session store
 // ---------------------------------------------------------------------------
@@ -200,7 +204,8 @@ const MCP_APP_RESOURCES: Record<
     description:
       'Interactive Lobu cards rendered in a sandboxed iframe; actions use standard MCP tool calls or host-mediated external links.',
     appDir: 'interaction',
-    // postMessage-only: the app makes no network requests and embeds no frames.
+    // App logic is postMessage-only. The serving origin is added dynamically as
+    // the sole resource domain for the external JS/CSS bundle.
     csp: { connectDomains: [], resourceDomains: [], frameDomains: [] },
     prefersBorder: true,
   },
@@ -247,6 +252,29 @@ function supportsMcpApps(capabilities: Record<string, unknown> | null | undefine
   if (!uiExtension || typeof uiExtension !== 'object') return false;
   const mimeTypes = (uiExtension as Record<string, unknown>).mimeTypes;
   return Array.isArray(mimeTypes) && mimeTypes.includes(MCP_APP_MIME_TYPE);
+}
+
+function mcpAppUiMeta(
+  authCtx: SessionAuthContext,
+  app: (typeof MCP_APP_RESOURCES)[string]
+): {
+  csp: {
+    connectDomains: string[];
+    resourceDomains: string[];
+    frameDomains: string[];
+    baseUriDomains: string[];
+  };
+  prefersBorder: boolean;
+} {
+  const publicOrigin = resolvePublicOrigin(authCtx.requestUrl);
+  return {
+    csp: {
+      ...app.csp,
+      resourceDomains: [...new Set([...app.csp.resourceDomains, publicOrigin])],
+      baseUriDomains: [publicOrigin],
+    },
+    prefersBorder: app.prefersBorder,
+  };
 }
 
 function createServerForContext(
@@ -318,10 +346,7 @@ function createServerForContext(
         description: meta.description,
         mimeType: MCP_APP_MIME_TYPE,
         _meta: {
-          ui: {
-            csp: meta.csp,
-            prefersBorder: meta.prefersBorder,
-          },
+          ui: mcpAppUiMeta(authCtx, meta),
         },
       })),
       ...Object.entries(MCP_SKILL_RESOURCES).map(([uri, meta]) => ({
@@ -342,12 +367,16 @@ function createServerForContext(
         contents: [{ uri, mimeType: 'text/markdown', text: skill.text }],
       };
     }
-    const app = MCP_APP_RESOURCES[uri];
+    const canonicalUri = MCP_APP_RESOURCE_ALIASES.get(uri) ?? uri;
+    const app = MCP_APP_RESOURCES[canonicalUri];
     if (!app) throw new Error(`Unknown resource: ${uri}`);
-    // Phase 1 of the external-asset rollout keeps discovery on the exact
-    // self-contained v2 template while the new asset endpoint reaches every
-    // replica. A later release switches discovery to index.html/v3.
-    const html = await readMcpAppBundle(app.appDir, 'legacy-v2.html');
+    const isLegacyAlias = canonicalUri !== uri;
+    const html = isLegacyAlias
+      ? await readMcpAppBundle(app.appDir, 'legacy-v2.html')
+      : await renderMcpAppTemplate(
+          app.appDir,
+          resolvePublicOrigin(authCtx.requestUrl)
+        );
     if (html == null) {
       throw new Error(`MCP App bundle not built for ${uri} (run owletto build:mcp-apps)`);
     }
@@ -357,7 +386,11 @@ function createServerForContext(
           uri,
           mimeType: MCP_APP_MIME_TYPE,
           text: html,
-          _meta: { ui: { csp: app.csp, prefersBorder: app.prefersBorder } },
+          _meta: {
+            ui: isLegacyAlias
+              ? { csp: app.csp, prefersBorder: app.prefersBorder }
+              : mcpAppUiMeta(authCtx, app),
+          },
         },
       ],
     };

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v2';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v3.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;

--- a/packages/server/src/utils/mcp-app-bundle.ts
+++ b/packages/server/src/utils/mcp-app-bundle.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 
 // packages/server dir (mirror of APP_ROOT in index.ts).
 const APP_ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const ORIGIN_PLACEHOLDER = '__LOBU_MCP_APP_ORIGIN__';
 const SAFE_BUNDLE_FILENAME = /^(?:index|legacy-v2)\.html$/;
 const SAFE_ASSET_PATH = /^assets\/[A-Za-z0-9._-]+\.(?:css|js)$/;
 
@@ -59,6 +60,25 @@ export async function readMcpAppBundle(
     }
   }
   return null;
+}
+
+/**
+ * Render the current external-asset template for a remote MCP host. The raw
+ * HTML stays cached by filename; request-specific origins are stamped only
+ * after the cache read so one tenant/request cannot contaminate another.
+ */
+export async function renderMcpAppTemplate(
+  appDir: string,
+  publicOrigin: string
+): Promise<string | null> {
+  const html = await readMcpAppBundle(appDir, 'index.html');
+  if (html == null) return null;
+
+  const assetBase = `${publicOrigin}/mcp-apps/${encodeURIComponent(appDir)}/`;
+  const withBase = html.includes('<base ')
+    ? html
+    : html.replace('<head>', `<head>\n\t\t<base href="${assetBase}" />`);
+  return withBase.replaceAll(ORIGIN_PLACEHOLDER, publicOrigin);
 }
 
 /** Read one stable JS/CSS asset staged for the second rollout phase. */


### PR DESCRIPTION
## Summary
- advertise `ui://lobu/interaction/v3.html` for every rich MCP tool
- serve the small origin-stamped external template with content-versioned JS/CSS assets
- keep cached v1/v2 conversations on the packed, network-free legacy template
- advance Owletto to merged cache-versioning prerequisite lobu-ai/owletto#781

This is phase two after #2631 and supersedes the combined rollout in #2627 once merged.

## Verification
- focused MCP integration: 15/15
- MCP bundle contract: 809-byte external HTML / 1,180-byte resources-read JSON / 358,298-byte legacy HTML
- Chrome host handshake + SQL pagination: rows 1-10, then 11-20 via Next
- `make pre-pr`
- Owletto prerequisite exact suite: 1,315/1,315
