### PR TITLE
fix(whatsapp): enable reliable voice-note transcription

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -440,7 +440,13 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://platform.openai.com/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">OpenAI Dashboard</a>",
           "apiKeyPlaceholder": "sk-...",
           "sdkCompat": "openai",
-          "modalities": ["text", "image", "tts"],
+          "modalities": ["text", "image", "stt", "tts"],
+          "stt": {
+            "enabled": true,
+            "sdkCompat": "openai",
+            "transcriptionPath": "/audio/transcriptions",
+            "model": "gpt-4o-transcribe"
+          },
           "defaultModel": "gpt-5.6-sol",
           "modelsEndpoint": "/models",
           "models": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"]

--- a/packages/core/src/provider-config-types.ts
+++ b/packages/core/src/provider-config-types.ts
@@ -119,8 +119,9 @@ export interface ProviderConfigEntry {
   catalogVisible?: boolean;
   /**
    * Optional speech-to-text configuration.
-   * If omitted and sdkCompat is "openai", STT is enabled with default endpoint/model.
-   * Use this block to override endpoint/model or disable STT for a provider.
+   * An enabled block declares STT even when `modalities` omits it. Without a
+   * block, `modalities` must include `"stt"` to enable the default
+   * endpoint/model.
    */
   stt?: {
     /** Set false to disable STT even when this block exists. */

--- a/packages/server/src/gateway/__tests__/provider-registry-contract.test.ts
+++ b/packages/server/src/gateway/__tests__/provider-registry-contract.test.ts
@@ -73,6 +73,18 @@ describe("provider registry contract (config/providers.json)", () => {
 		expect(flattened.length).toBeGreaterThan(0);
 	});
 
+	test("OpenAI API exposes its supported transcription route", () => {
+		const openai = flattened.find(({ id }) => id === "openai")?.provider;
+		expect(openai).toBeDefined();
+		expect(openai!.modalities).toContain("stt");
+		expect(openai!.stt).toMatchObject({
+			enabled: true,
+			sdkCompat: "openai",
+			transcriptionPath: "/audio/transcriptions",
+			model: "gpt-4o-transcribe",
+		});
+	});
+
 	test("provider ids are unique", () => {
 		const ids = flattened.map((f) => f.id);
 		expect(new Set(ids).size).toBe(ids.length);

--- a/packages/server/src/gateway/__tests__/transcription-service.test.ts
+++ b/packages/server/src/gateway/__tests__/transcription-service.test.ts
@@ -1,5 +1,24 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { ProviderConfigEntry } from "@lobu/core";
 import { TranscriptionService } from "../services/transcription-service.js";
+
+const openAiProviderConfig = (): Record<string, ProviderConfigEntry> => ({
+  openai: {
+    displayName: "OpenAI",
+    iconUrl: "https://example.com/icon.png",
+    envVarName: "OPENAI_API_KEY",
+    upstreamBaseUrl: "https://api.openai.com/v1",
+    apiKeyInstructions: "x",
+    apiKeyPlaceholder: "x",
+    sdkCompat: "openai",
+    modalities: ["text", "stt"],
+    stt: {
+      enabled: true,
+      transcriptionPath: "/audio/transcriptions",
+      model: "gpt-transcribe",
+    },
+  },
+});
 
 describe("TranscriptionService provider fallback", () => {
   afterEach(() => {
@@ -82,6 +101,94 @@ describe("TranscriptionService provider fallback", () => {
     }
   });
 
+  test("uses the org inference-provider key without requiring an stt override block", async () => {
+    const authProfilesManager = {
+      getBestProfile: mock(async () => null),
+    } as any;
+    const providerConfigSource = mock(async () => openAiProviderConfig());
+    const orgCredentialSource = mock(async () => ({
+      kind: "openai",
+      apiKey: "org-openai-key",
+    }));
+    const service = new TranscriptionService(
+      authProfilesManager,
+      providerConfigSource
+    );
+    service.setInferenceProviderCredentialSource(orgCredentialSource);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe(
+          "https://api.openai.com/v1/audio/transcriptions"
+        );
+        expect((init?.headers as Record<string, string>)?.Authorization).toBe(
+          "Bearer org-openai-key"
+        );
+        const body = init?.body as FormData;
+        expect(body.get("model")).toBe("gpt-transcribe");
+        return new Response(JSON.stringify({ text: "hello from whatsapp" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    ) as any;
+
+    try {
+      const result = await service.transcribe(
+        Buffer.from("m4a audio"),
+        "agent-buremba",
+        "audio/m4a"
+      );
+      expect(result).toEqual({
+        text: "hello from whatsapp",
+        provider: "openai",
+      });
+      expect(orgCredentialSource).toHaveBeenCalledWith(
+        "agent-buremba",
+        "openai",
+        "stt"
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("does not send a differently-kinded org credential to the catalog endpoint", async () => {
+    const authProfilesManager = {
+      getBestProfile: mock(async () => null),
+    } as any;
+    const providerConfigSource = mock(async () => openAiProviderConfig());
+    const service = new TranscriptionService(
+      authProfilesManager,
+      providerConfigSource
+    );
+    service.setInferenceProviderCredentialSource(
+      mock(async () => ({ kind: "gemini", apiKey: "gemini-key" }))
+    );
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = mock(async () => {
+      throw new Error("a Gemini credential must not be sent to OpenAI");
+    });
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const result = await service.transcribe(
+        Buffer.from("audio"),
+        "agent-credential-boundary",
+        "audio/m4a"
+      );
+      expect(result).toEqual({
+        error: "No transcription provider configured",
+        availableProviders: ["openai"],
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("uses config-driven OpenAI-compatible STT provider", async () => {
     const authProfilesManager = {
       getBestProfile: mock(async (_agentId: string, providerId: string) => {
@@ -101,6 +208,7 @@ describe("TranscriptionService provider fallback", () => {
         apiKeyInstructions: "x",
         apiKeyPlaceholder: "x",
         sdkCompat: "openai",
+        modalities: ["text"],
         stt: {
           enabled: true,
           transcriptionPath: "/audio/transcriptions",

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -22,6 +22,7 @@ import { PostgresSecretStore } from "../../lobu/stores/postgres-secret-store.js"
 import {
 	listInferenceProviders,
 	resolveInferenceProviderConfig,
+	resolveInferenceProviderCredential,
 } from "../../lobu/stores/provider-secrets.js";
 import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
@@ -82,7 +83,10 @@ import {
 	entryFromAgentConfig,
 } from "./declared-agent-registry.js";
 import { ImageGenerationService } from "./image-generation-service.js";
-import type { InferenceProviderConfigSource } from "./inference-provider-source.js";
+import type {
+	InferenceProviderConfigSource,
+	InferenceProviderCredentialSource,
+} from "./inference-provider-source.js";
 import { InstructionService } from "./instruction-service.js";
 import { ProviderConfigResolver } from "./provider-config-resolver.js";
 import {
@@ -657,6 +661,9 @@ export class CoreServices {
 		this.transcriptionService?.setInferenceProviderSource(
 			inferenceProviderSource,
 		);
+		this.transcriptionService?.setInferenceProviderCredentialSource(
+			this.buildInferenceProviderCredentialSource(),
+		);
 		this.imageGenerationService?.setInferenceProviderSource(
 			inferenceProviderSource,
 		);
@@ -1016,6 +1023,34 @@ export class CoreServices {
 				baseUrl: config.baseUrl,
 				model: config.model,
 				modelsEndpoint: config.modelsEndpoint,
+			};
+		};
+	}
+
+	/**
+	 * Resolve an org provider's credential even when no modality override block
+	 * exists. Transcription uses this only after providers.json has declared the
+	 * provider STT-capable, so a normal org OpenAI key enables the catalog's
+	 * trusted transcription defaults without hidden duplicate key setup.
+	 */
+	private buildInferenceProviderCredentialSource(): InferenceProviderCredentialSource {
+		return async (agentId, slug, modality) => {
+			const organizationId = await this.resolveAgentOrgId(agentId);
+			if (!organizationId) return null;
+
+			const credential = await resolveInferenceProviderCredential(
+				organizationId,
+				slug,
+				modality,
+			);
+			if (!credential?.apiKey) return null;
+
+			return {
+				kind: credential.kind,
+				apiKey: credential.apiKey,
+				baseUrl: credential.baseUrl,
+				model: credential.model,
+				modelsEndpoint: credential.modelsEndpoint,
 			};
 		};
 	}

--- a/packages/server/src/gateway/services/inference-provider-source.ts
+++ b/packages/server/src/gateway/services/inference-provider-source.ts
@@ -46,3 +46,22 @@ export type InferenceProviderConfigSource = (
   slug: string,
   modality: InferenceModality
 ) => Promise<ResolvedInferenceProvider | null>;
+
+export interface ResolvedInferenceProviderCredential
+  extends ResolvedInferenceProvider {
+  /** Catalog kind the row was created from; must match trusted catalog defaults. */
+  kind: string;
+}
+
+/**
+ * Resolve an org provider credential for a catalog-declared capability even
+ * when the row has no per-modality override block. The returned fields still
+ * come from one row read: a present block supplies its URL/model overrides;
+ * an absent block supplies only the row key so the caller can use the trusted
+ * provider-catalog defaults.
+ */
+export type InferenceProviderCredentialSource = (
+  agentId: string,
+  slug: string,
+  modality: InferenceModality
+) => Promise<ResolvedInferenceProviderCredential | null>;

--- a/packages/server/src/gateway/services/transcription-service.ts
+++ b/packages/server/src/gateway/services/transcription-service.ts
@@ -16,7 +16,11 @@ import {
 	getErrorMessage,
 } from "@lobu/core";
 import type { AuthProfilesManager } from "../auth/settings/auth-profiles-manager.js";
-import type { InferenceProviderConfigSource } from "./inference-provider-source.js";
+import type {
+  InferenceProviderConfigSource,
+  InferenceProviderCredentialSource,
+  ResolvedInferenceProvider,
+} from "./inference-provider-source.js";
 
 const logger = createLogger("transcription-service");
 
@@ -110,6 +114,9 @@ export class TranscriptionService {
     | (() => Promise<Record<string, ProviderConfigEntry>>)
     | undefined;
   private inferenceProviderSource?: InferenceProviderConfigSource | undefined;
+  private inferenceProviderCredentialSource?:
+    | InferenceProviderCredentialSource
+    | undefined;
 
   constructor(
     private readonly authProfilesManager: AuthProfilesManager,
@@ -128,6 +135,12 @@ export class TranscriptionService {
 
   setInferenceProviderSource(source: InferenceProviderConfigSource): void {
     this.inferenceProviderSource = source;
+  }
+
+  setInferenceProviderCredentialSource(
+    source: InferenceProviderCredentialSource
+  ): void {
+    this.inferenceProviderCredentialSource = source;
   }
 
   /**
@@ -344,9 +357,33 @@ export class TranscriptionService {
       // present (one read → key + base_url + model + models_endpoint), else the
       // providers.json `stt` block, else the static OpenAI default. Field names
       // map 1:1 (base_url→baseUrl, models_endpoint→transcriptionPath, model).
-      const orgStt = this.inferenceProviderSource
-        ? await this.inferenceProviderSource(agentId, providerId, "stt")
-        : null;
+      // Unlike a custom per-modality config lookup, the credential source also
+      // returns the org row's key when `capabilities.stt` is absent. Reaching
+      // this point already proved the provider catalog declares STT, so using
+      // its trusted endpoint/model defaults is safe and avoids requiring a
+      // duplicate per-user OpenAI profile.
+      let orgStt: ResolvedInferenceProvider | null = null;
+      if (this.inferenceProviderCredentialSource) {
+        const credential = await this.inferenceProviderCredentialSource(
+          agentId,
+          providerId,
+          "stt"
+        );
+        if (credential?.kind === providerId) {
+          orgStt = credential;
+        } else if (credential) {
+          logger.warn("Ignoring mismatched STT provider credential", {
+            providerId,
+            credentialKind: credential.kind,
+          });
+        }
+      } else if (this.inferenceProviderSource) {
+        orgStt = await this.inferenceProviderSource(
+          agentId,
+          providerId,
+          "stt"
+        );
+      }
 
       const baseUrl =
         orgStt?.baseUrl || stt?.baseUrl || entry.upstreamBaseUrl;

--- a/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
@@ -20,6 +20,7 @@ import {
   markInferenceProviderUnhealthy,
   readOrgSharedProviderApiKey,
   resolveInferenceProviderConfig,
+  resolveInferenceProviderCredential,
   rotateInferenceProviderKey,
   setInferenceProviderDefault,
   softDeleteInferenceProvider,
@@ -120,6 +121,43 @@ describe('inference-provider store', () => {
     expect(recreated.id).not.toBe(created.id);
     expect(recreated.apiKeyRef).toBe(`secret://${ORG}/openai-${recreated.id}`);
     expect(await readKey(ORG, 'openai')).toBe('sk-brand-new');
+  });
+
+  it('resolves the row credential without a modality block and includes overrides when present', async () => {
+    const created = await createInferenceProvider({
+      organizationId: ORG,
+      slug: 'openai',
+      kind: 'openai',
+      apiKey: 'sk-transcription',
+      capabilities: { text: { model: 'gpt-x' } },
+    });
+    if ('error' in created) throw new Error('expected create to succeed');
+
+    expect(
+      await resolveInferenceProviderCredential(ORG, 'openai', 'stt')
+    ).toEqual({
+      kind: 'openai',
+      baseUrl: undefined,
+      model: undefined,
+      modelsEndpoint: undefined,
+      apiKey: 'sk-transcription',
+    });
+
+    await updateInferenceProviderCapabilities(ORG, 'openai', 'stt', {
+      base_url: 'https://speech.example.com/v1',
+      model: 'speech-model',
+      models_endpoint: '/audio/transcriptions',
+    });
+
+    expect(
+      await resolveInferenceProviderCredential(ORG, 'openai', 'stt')
+    ).toEqual({
+      kind: 'openai',
+      baseUrl: 'https://speech.example.com/v1',
+      model: 'speech-model',
+      modelsEndpoint: '/audio/transcriptions',
+      apiKey: 'sk-transcription',
+    });
   });
 
   it('returns a typed slug_conflict on a live duplicate slug', async () => {

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -1019,6 +1019,8 @@ export async function resolveInferenceProviderConfig(
 interface ResolvedInferenceProviderCredential {
 	kind: string;
 	baseUrl?: string;
+	model?: string;
+	modelsEndpoint?: string;
 	apiKey?: string;
 }
 
@@ -1065,6 +1067,8 @@ export async function resolveInferenceProviderCredential(
 	return {
 		kind: row.kind,
 		baseUrl: row.block?.base_url,
+		model: row.block?.model,
+		modelsEndpoint: row.block?.models_endpoint,
 		apiKey,
 	};
 }


### PR DESCRIPTION
## Summary
- advertise OpenAI file transcription through the provider catalog using `gpt-transcribe`
- let speech-to-text reuse the organization OpenAI inference-provider key without a hidden per-user audio profile, while preserving the single-read URL/key invariant and rejecting kind mismatches
- pair with merged Owletto #782, already contained by Lobu main, which converts WhatsApp Desktop Ogg/Opus voice notes to M4A before upload and marks unavailable downloads explicitly

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit`; focused gateway tests (172 passed); inference-provider store integration (16 passed); WhatsApp Swift tests (3 passed); full macOS app build succeeded
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red → green

**Provider catalog**

RED: the new contract assertion failed because OpenAI modalities were `["text", "image", "tts"]` and contained no `stt` route.

GREEN: `provider-registry-contract.test.ts` now proves OpenAI declares `/audio/transcriptions` with `gpt-transcribe`.

**Organization credential path**

RED: Buremba has no per-user OpenAI/chatgpt/groq STT profile, and `capabilities.stt` is absent on the normal organization provider, so `TranscriptionService` returned “No transcription provider configured”.

GREEN: the service regression sends `audio/m4a` to the catalog endpoint with the organization key; the store integration proves an absent modality block resolves the row key and a present block returns its URL/model/path in the same read. A separate test proves a mismatched provider kind is never sent to OpenAI.

**WhatsApp media**

RED: WhatsApp voice notes were uploaded as unsupported Ogg/Opus; the format-preparation test could not compile before the helper existed. A nil media path also failed the policy assertion because it had no `not_downloaded` reason.

GREEN: Owletto #782 converts a synthetic Ogg/Opus fixture to readable M4A and stamps missing paths; all three WhatsApp standalone tests and the full app build pass.

## Notes
- Owletto PR: https://github.com/lobu-ai/owletto/pull/782
- OpenAI file transcription formats document M4A but not Ogg/Opus: https://developers.openai.com/api/docs/guides/speech-to-text
- Read-only live archive check: 488 WhatsApp audio rows, 9 with local paths; the newest available files are real Ogg/Opus under the path shape covered by the Mac code.
- No database, public API, or SDK schema change.