### PR TITLE
fix(mcp): restore historical ChatGPT app results

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -22,7 +22,7 @@ import { get, post } from '../../setup/test-helpers';
 const STUB_LEGACY_HTML =
   '<!doctype html><html><body data-test="mcp-app-legacy-v2-stub">legacy v2</body></html>';
 const STUB_EXTERNAL_HTML =
-  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><link rel="stylesheet" href="./assets/app.css?v=css123"><script type="module" src="./assets/app.js?v=js123"></script></head><body data-test="mcp-app-external-v3-stub">external v3</body></html>';
+  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><link rel="stylesheet" href="./assets/app.css?v=css123"><script type="module" src="./assets/app.js?v=js123"></script></head><body data-test="mcp-app-external-v4-stub">external v4</body></html>';
 
 describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -150,7 +150,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v3.html' },
+        params: { uri: 'ui://lobu/interaction/v4.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -159,9 +159,9 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v3.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v4.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
-    expect(content?.text).toContain('mcp-app-external-v3-stub');
+    expect(content?.text).toContain('mcp-app-external-v4-stub');
     expect(content?.text).toContain('./assets/app.js?v=js123');
     expect(content?.text).toContain('./assets/app.css?v=css123');
     const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
@@ -185,7 +185,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const htmlResponse = await get('/mcp-apps/interaction/index.html');
     expect(htmlResponse.status).toBe(200);
     const html = await htmlResponse.text();
-    expect(html).toContain('mcp-app-external-v3-stub');
+    expect(html).toContain('mcp-app-external-v4-stub');
     expect(html).toContain('/mcp-apps/interaction/');
     expect(html).not.toContain('__LOBU_MCP_APP_ORIGIN__');
 
@@ -227,7 +227,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       expect(content?.uri).toBe(uri);
       expect(content?.mimeType).toBe('text/html;profile=mcp-app');
       expect(content?.text).toContain('mcp-app-legacy-v2-stub');
-      expect(content?.text).not.toContain('mcp-app-external-v3-stub');
+      expect(content?.text).not.toContain('mcp-app-external-v4-stub');
       expect(content?._meta?.ui?.csp).toEqual({
         connectDomains: [],
         resourceDomains: [],
@@ -235,6 +235,37 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       });
       expect(content?._meta?.ui?.domain).toBeUndefined();
     }
+  });
+
+  it('keeps the v3 alias on the current external template', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const uri = 'ui://lobu/interaction/v3.html';
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: uri,
+        method: 'resources/read',
+        params: { uri },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const content = (await response.json()).result?.contents?.[0];
+    expect(content?.uri).toBe(uri);
+    expect(content?.mimeType).toBe('text/html;profile=mcp-app');
+    expect(content?.text).toContain('mcp-app-external-v4-stub');
+    expect(content?.text).not.toContain('mcp-app-legacy-v2-stub');
+    expect(content?.text).toContain('./assets/app.js?v=js123');
+    const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
+    const resourceOrigin = new URL(baseHref!).origin;
+    expect(content?._meta?.ui?.csp).toEqual({
+      connectDomains: [],
+      resourceDomains: [resourceOrigin],
+      frameDomains: [],
+      baseUriDomains: [resourceOrigin],
+    });
   });
 
   it('advertises description and CSP metadata on resources/list without claiming a dedicated app domain', async () => {
@@ -252,7 +283,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v3.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v4.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -303,10 +334,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v3.html',
+            resourceUri: 'ui://lobu/interaction/v4.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v3.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v4.html',
         }),
       })
     );
@@ -325,12 +356,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v3.html',
+          resourceUri: 'ui://lobu/interaction/v4.html',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v3.html'
+        'ui://lobu/interaction/v4.html'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -383,7 +414,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v3.html',
+        resourceUri: 'ui://lobu/interaction/v4.html',
         visibility: ['model', 'app'],
       })
     );

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -67,9 +67,22 @@ const SESSION_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 const SESSION_CLEANUP_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
 const MCP_APP_EXTENSION_ID = 'io.modelcontextprotocol/ui';
-const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<string, string> = new Map([
-  ['ui://lobu/interaction/v1', LOBU_INTERACTION_RESOURCE_URI],
-  ['ui://lobu/interaction/v2', LOBU_INTERACTION_RESOURCE_URI],
+const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
+  string,
+  { canonicalUri: string; template: 'legacy' | 'external' }
+> = new Map([
+  [
+    'ui://lobu/interaction/v1',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'legacy' },
+  ],
+  [
+    'ui://lobu/interaction/v2',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'legacy' },
+  ],
+  [
+    'ui://lobu/interaction/v3.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
 ]);
 // ---------------------------------------------------------------------------
 // Session store
@@ -367,10 +380,11 @@ function createServerForContext(
         contents: [{ uri, mimeType: 'text/markdown', text: skill.text }],
       };
     }
-    const canonicalUri = MCP_APP_RESOURCE_ALIASES.get(uri) ?? uri;
+    const alias = MCP_APP_RESOURCE_ALIASES.get(uri);
+    const canonicalUri = alias?.canonicalUri ?? uri;
     const app = MCP_APP_RESOURCES[canonicalUri];
     if (!app) throw new Error(`Unknown resource: ${uri}`);
-    const isLegacyAlias = canonicalUri !== uri;
+    const isLegacyAlias = alias?.template === 'legacy';
     const html = isLegacyAlias
       ? await readMcpAppBundle(app.appDir, 'legacy-v2.html')
       : await renderMcpAppTemplate(

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v3.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v4.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;


### PR DESCRIPTION
## Summary
- update the parent to Owletto `ea68a5ff`, containing merged #783 historical ChatGPT rehydration and #784 v4 bundle verification
- bump the immutable MCP App resource cache key from `v3.html` to `v4.html`
- keep v3 on the current external template so previously advertised cards can refetch the fixed app, while v1/v2 stay on the packed network-free legacy template
- cover current discovery, legacy compatibility, CSP, external assets, and tool metadata in integration tests

## User-visible fix
ChatGPT may recreate an MCP App iframe when a historical conversation is reopened without replaying the original standards result over the MCP Apps bridge. Owletto now initializes from the host-provided `window.openai.toolOutput` and `toolResponseMetadata`, listens for `openai:set_globals`, and preserves explicit clears without stale payloads. The standard MCP Apps bridge remains primary.

This restores native rendering for SQL rows, SDK results, entities, events, `json_template` tables/charts/actions, markdown/media, approvals, errors, dry runs, pagination, and other existing structured Lobu views after conversation reload.

## Compatibility and security
- no database, REST API, or SDK contract change
- v4 is the new immutable cache key because the shipped HTML/JS changed
- v3 remains external and receives current CSP/base-origin metadata
- v1/v2 remain packed and network-free
- host globals are parsed defensively; malformed/array metadata is rejected and the capability string is bounded to 4,096 characters

## Validation
- focused parent MCP resources: 16/16 passed on the settled merged head
- parent `make pre-pr`: clean after merging current `origin/main`
- Owletto focused host compatibility: 21/21 passed on #783 settled head
- full Owletto suite: 1,320/1,320 passed on #783 settled head
- scoped Owletto Biome lint: passed
- MCP App production build/check: 809 external HTML bytes; 1,180 v4 resources/read JSON bytes; 358,682 legacy v2 HTML bytes; content-versioned JS/CSS
- independent pre-review found and fixed the stale v3 verifier wording in #784
- parent diff check: clean; exact four-file scope

## Nested PRs
- https://github.com/lobu-ai/owletto/pull/783
- https://github.com/lobu-ai/owletto/pull/784

## Live acceptance plan
After exact-head checks and deployment, reopen the same ChatGPT conversation in the user Chrome session and verify the native SQL result remains visible after a full reload, then repeat pagination on a fresh v4 card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated MCP App interactions to use the latest external interaction template.
  * Added support for the `v3.html` compatibility alias while preserving legacy behavior for earlier versions.

* **Bug Fixes**
  * Improved resource handling so each alias serves the correct interaction template.
  * Updated resource metadata and integration coverage to reflect the latest template version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->