### PR TITLE
fix(mcp): rehydrate ChatGPT sandbox cards

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -22,7 +22,7 @@ import { get, post } from '../../setup/test-helpers';
 const STUB_LEGACY_HTML =
   '<!doctype html><html><body data-test="mcp-app-legacy-v2-stub">legacy v2</body></html>';
 const STUB_EXTERNAL_HTML =
-  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><link rel="stylesheet" href="./assets/app.css?v=css123"><script type="module" src="./assets/app.js?v=js123"></script></head><body data-test="mcp-app-external-v4-stub">external v4</body></html>';
+  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><link rel="stylesheet" href="./assets/app.css?v=css123"><script type="module" src="./assets/app.js?v=js123"></script></head><body data-test="mcp-app-external-v5-stub">external v5</body></html>';
 
 describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -150,7 +150,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v4.html' },
+        params: { uri: 'ui://lobu/interaction/v5.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -159,9 +159,9 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v4.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v5.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
-    expect(content?.text).toContain('mcp-app-external-v4-stub');
+    expect(content?.text).toContain('mcp-app-external-v5-stub');
     expect(content?.text).toContain('./assets/app.js?v=js123');
     expect(content?.text).toContain('./assets/app.css?v=css123');
     const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
@@ -185,7 +185,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const htmlResponse = await get('/mcp-apps/interaction/index.html');
     expect(htmlResponse.status).toBe(200);
     const html = await htmlResponse.text();
-    expect(html).toContain('mcp-app-external-v4-stub');
+    expect(html).toContain('mcp-app-external-v5-stub');
     expect(html).toContain('/mcp-apps/interaction/');
     expect(html).not.toContain('__LOBU_MCP_APP_ORIGIN__');
 
@@ -227,7 +227,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       expect(content?.uri).toBe(uri);
       expect(content?.mimeType).toBe('text/html;profile=mcp-app');
       expect(content?.text).toContain('mcp-app-legacy-v2-stub');
-      expect(content?.text).not.toContain('mcp-app-external-v4-stub');
+      expect(content?.text).not.toContain('mcp-app-external-v5-stub');
       expect(content?._meta?.ui?.csp).toEqual({
         connectDomains: [],
         resourceDomains: [],
@@ -237,35 +237,39 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('keeps the v3 alias on the current external template', async () => {
+  it('keeps v3 and v4 aliases on the current external template', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
-    const uri = 'ui://lobu/interaction/v3.html';
-    const response = await post(`/mcp/${org.slug}`, {
-      body: {
-        jsonrpc: '2.0',
-        id: uri,
-        method: 'resources/read',
-        params: { uri },
-      },
-      headers: { 'mcp-session-id': sessionId },
-      token,
-    });
+    for (const uri of [
+      'ui://lobu/interaction/v3.html',
+      'ui://lobu/interaction/v4.html',
+    ]) {
+      const response = await post(`/mcp/${org.slug}`, {
+        body: {
+          jsonrpc: '2.0',
+          id: uri,
+          method: 'resources/read',
+          params: { uri },
+        },
+        headers: { 'mcp-session-id': sessionId },
+        token,
+      });
 
-    expect(response.status).toBe(200);
-    const content = (await response.json()).result?.contents?.[0];
-    expect(content?.uri).toBe(uri);
-    expect(content?.mimeType).toBe('text/html;profile=mcp-app');
-    expect(content?.text).toContain('mcp-app-external-v4-stub');
-    expect(content?.text).not.toContain('mcp-app-legacy-v2-stub');
-    expect(content?.text).toContain('./assets/app.js?v=js123');
-    const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
-    const resourceOrigin = new URL(baseHref!).origin;
-    expect(content?._meta?.ui?.csp).toEqual({
-      connectDomains: [],
-      resourceDomains: [resourceOrigin],
-      frameDomains: [],
-      baseUriDomains: [resourceOrigin],
-    });
+      expect(response.status).toBe(200);
+      const content = (await response.json()).result?.contents?.[0];
+      expect(content?.uri).toBe(uri);
+      expect(content?.mimeType).toBe('text/html;profile=mcp-app');
+      expect(content?.text).toContain('mcp-app-external-v5-stub');
+      expect(content?.text).not.toContain('mcp-app-legacy-v2-stub');
+      expect(content?.text).toContain('./assets/app.js?v=js123');
+      const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
+      const resourceOrigin = new URL(baseHref!).origin;
+      expect(content?._meta?.ui?.csp).toEqual({
+        connectDomains: [],
+        resourceDomains: [resourceOrigin],
+        frameDomains: [],
+        baseUriDomains: [resourceOrigin],
+      });
+    }
   });
 
   it('advertises description and CSP metadata on resources/list without claiming a dedicated app domain', async () => {
@@ -283,7 +287,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v4.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v5.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -334,10 +338,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v4.html',
+            resourceUri: 'ui://lobu/interaction/v5.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v4.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v5.html',
         }),
       })
     );
@@ -356,12 +360,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v4.html',
+          resourceUri: 'ui://lobu/interaction/v5.html',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v4.html'
+        'ui://lobu/interaction/v5.html'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -414,7 +418,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v4.html',
+        resourceUri: 'ui://lobu/interaction/v5.html',
         visibility: ['model', 'app'],
       })
     );

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -83,6 +83,10 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
     'ui://lobu/interaction/v3.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
   ],
+  [
+    'ui://lobu/interaction/v4.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
 ]);
 // ---------------------------------------------------------------------------
 // Session store

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v4.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v5.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;


### PR DESCRIPTION
## Summary

- advance Owletto to the merged same-origin parent-frame compatibility fix and v5 bundle verifier
- advertise the immutable v5 MCP App resource while keeping v3 and v4 on the current external template for existing ChatGPT conversations
- verify the current resource, aliases, metadata, rich tool coverage, structured SQL output, approvals, and session isolation

## Why

Production v4 rendered a fresh native Lobu SQL card and paginated correctly, but a full reload of that same ChatGPT conversation restored only the empty shell. ChatGPT places the compatibility globals on the same-origin outer ASDK sandbox while Lobu runs in an inner about:blank frame. Owletto now reads and listens on both safe same-origin targets, with cross-origin fallback.

## Prerequisites

- lobu-ai/owletto#786: same-origin parent-frame hydration, merged at a8970d0f92dafb842952c5a11d55b5992cdde93b
- lobu-ai/owletto#787: v5 immutable bundle verifier, merged at 26a0bfac8698b4544d766ef2427513b04e14e14c

## Verification

- Owletto full suite: 156 files, 1,321 tests passed
- focused parent embedded-Postgres MCP resource suite: 16/16 passed on committed head
- make pre-pr: all six gates clean on committed head
- REVIEWER_CLI=codex make review-fix: no reviewer-grade defects; tree unchanged

## Post-deploy acceptance

Using the signed-in user Chrome and the read-only SQL prompt: create a fresh native Lobu card, paginate it, reload the same ChatGPT conversation, and confirm the rows remain rendered.