### PR TITLE
fix(mcp): ship reload-safe v6 app bundle

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -22,7 +22,7 @@ import { get, post } from '../../setup/test-helpers';
 const STUB_LEGACY_HTML =
   '<!doctype html><html><body data-test="mcp-app-legacy-v2-stub">legacy v2</body></html>';
 const STUB_EXTERNAL_HTML =
-  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><link rel="stylesheet" href="./assets/app.css?v=css123"><script type="module" src="./assets/app.js?v=js123"></script></head><body data-test="mcp-app-external-v5-stub">external v5</body></html>';
+  '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><link rel="stylesheet" href="./assets/app.css?v=css123"><script type="module" src="./assets/app.js?v=js123"></script></head><body data-test="mcp-app-external-stub">external</body></html>';
 
 describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -150,7 +150,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v5.html' },
+        params: { uri: 'ui://lobu/interaction/v6.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -159,9 +159,9 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v5.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v6.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
-    expect(content?.text).toContain('mcp-app-external-v5-stub');
+    expect(content?.text).toContain('mcp-app-external-stub');
     expect(content?.text).toContain('./assets/app.js?v=js123');
     expect(content?.text).toContain('./assets/app.css?v=css123');
     const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
@@ -185,7 +185,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const htmlResponse = await get('/mcp-apps/interaction/index.html');
     expect(htmlResponse.status).toBe(200);
     const html = await htmlResponse.text();
-    expect(html).toContain('mcp-app-external-v5-stub');
+    expect(html).toContain('mcp-app-external-stub');
     expect(html).toContain('/mcp-apps/interaction/');
     expect(html).not.toContain('__LOBU_MCP_APP_ORIGIN__');
 
@@ -227,7 +227,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       expect(content?.uri).toBe(uri);
       expect(content?.mimeType).toBe('text/html;profile=mcp-app');
       expect(content?.text).toContain('mcp-app-legacy-v2-stub');
-      expect(content?.text).not.toContain('mcp-app-external-v5-stub');
+      expect(content?.text).not.toContain('mcp-app-external-stub');
       expect(content?._meta?.ui?.csp).toEqual({
         connectDomains: [],
         resourceDomains: [],
@@ -237,11 +237,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('keeps v3 and v4 aliases on the current external template', async () => {
+  it('keeps v3 through v5 aliases on the current external template', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     for (const uri of [
       'ui://lobu/interaction/v3.html',
       'ui://lobu/interaction/v4.html',
+      'ui://lobu/interaction/v5.html',
     ]) {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
@@ -258,7 +259,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       const content = (await response.json()).result?.contents?.[0];
       expect(content?.uri).toBe(uri);
       expect(content?.mimeType).toBe('text/html;profile=mcp-app');
-      expect(content?.text).toContain('mcp-app-external-v5-stub');
+      expect(content?.text).toContain('mcp-app-external-stub');
       expect(content?.text).not.toContain('mcp-app-legacy-v2-stub');
       expect(content?.text).toContain('./assets/app.js?v=js123');
       const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
@@ -287,7 +288,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v5.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v6.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -338,10 +339,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v5.html',
+            resourceUri: 'ui://lobu/interaction/v6.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v5.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v6.html',
         }),
       })
     );
@@ -360,12 +361,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v5.html',
+          resourceUri: 'ui://lobu/interaction/v6.html',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v5.html'
+        'ui://lobu/interaction/v6.html'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -418,7 +419,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v5.html',
+        resourceUri: 'ui://lobu/interaction/v6.html',
         visibility: ['model', 'app'],
       })
     );

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -87,6 +87,10 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
     'ui://lobu/interaction/v4.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
   ],
+  [
+    'ui://lobu/interaction/v5.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
 ]);
 // ---------------------------------------------------------------------------
 // Session store

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v5.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v6.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;


### PR DESCRIPTION
## Summary
- advance the immutable Lobu interaction resource from v5 to v6
- retain v5 as an external-template compatibility alias for already-rendered clients
- point Lobu at Owletto #788, which persists display-safe ChatGPT widget snapshots so rich SQL, SDK, event, entity, and JSON-template cards can rehydrate after a full reload

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts` — 16/16 passed
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

## Red → green
- Red: production v5 rendered a 25-row SQL result and paginated to rows 11–20, but a full ChatGPT reload restored only the generic “Lobu result” shell.
- Green (component): Owletto focused compatibility/view suite passed 32/32; full suite passed 1,331/1,331; the production bundle verifier passed on the v6 URI.
- Green (parent): MCP resource integration tests passed 16/16, including v6 current-resource discovery and v3–v5 external aliases; `make pre-pr` passed twice on the settled diff.
- Live production reload verification will be gated on this PR’s squash SHA after deployment.

## Notes
- Owletto #788 merged as `c352e49619567656349ccdbe8354d7eb0440f1d3`.
- The snapshot is a per-rendered-widget, display-only reload fallback. Live tool output remains authoritative; approval capabilities and capability-gated controls are not persisted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the latest MCP interaction resource version.
  - Preserved compatibility with the previous interaction resource alias.
- **Bug Fixes**
  - Improved consistency when listing MCP resources and tool metadata.
  - Strengthened cross-replica recovery for MCP App interactions.
- **Tests**
  - Updated integration coverage to validate the latest resource version, external templates, aliases, and expected resource links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->