### PR TITLE
fix(mcp): serve self-contained v7 app resource

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -19,8 +19,8 @@ import {
 } from '../../setup/test-fixtures';
 import { get, post } from '../../setup/test-helpers';
 
-const STUB_LEGACY_HTML =
-  '<!doctype html><html><body data-test="mcp-app-legacy-v2-stub">legacy v2</body></html>';
+const STUB_EMBEDDED_HTML =
+  '<!doctype html><html><body data-test="mcp-app-embedded-stub">embedded</body></html>';
 const STUB_EXTERNAL_HTML =
   '<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="script-src __LOBU_MCP_APP_ORIGIN__"><link rel="stylesheet" href="./assets/app.css?v=css123"><script type="module" src="./assets/app.js?v=js123"></script></head><body data-test="mcp-app-external-stub">external</body></html>';
 
@@ -50,7 +50,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     });
     writeFileSync(
       join(tmpRoot, 'dist-mcp-apps', 'interaction', 'legacy-v2.html'),
-      STUB_LEGACY_HTML
+      STUB_EMBEDDED_HTML
     );
     writeFileSync(
       join(tmpRoot, 'dist-mcp-apps', 'interaction', 'index.html'),
@@ -143,14 +143,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     return sessionId!;
   }
 
-  it('serves the versioned Lobu interaction bundle over resources/read', async () => {
+  it('serves the self-contained v7 interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v6.html' },
+        params: { uri: 'ui://lobu/interaction/v7.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -159,23 +159,16 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v6.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v7.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
-    expect(content?.text).toContain('mcp-app-external-stub');
-    expect(content?.text).toContain('./assets/app.js?v=js123');
-    expect(content?.text).toContain('./assets/app.css?v=css123');
-    const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
-    expect(baseHref).toBeDefined();
-    const resourceOrigin = new URL(baseHref!).origin;
-    expect(content?.text).toContain(
-      `<base href="${resourceOrigin}/mcp-apps/interaction/" />`
-    );
-    expect(content?.text).not.toContain('__LOBU_MCP_APP_ORIGIN__');
+    expect(content?.text).toContain('mcp-app-embedded-stub');
+    expect(content?.text).not.toContain('mcp-app-external-stub');
+    expect(content?.text).not.toContain('./assets/');
+    expect(content?.text).not.toContain('<base ');
     expect(content?._meta?.ui?.csp).toEqual({
       connectDomains: [],
-      resourceDomains: [resourceOrigin],
+      resourceDomains: [],
       frameDomains: [],
-      baseUriDomains: [resourceOrigin],
     });
     expect(content?._meta?.ui?.prefersBorder).toBe(true);
     expect(content?._meta?.ui?.domain).toBeUndefined();
@@ -226,7 +219,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       const content = (await response.json()).result?.contents?.[0];
       expect(content?.uri).toBe(uri);
       expect(content?.mimeType).toBe('text/html;profile=mcp-app');
-      expect(content?.text).toContain('mcp-app-legacy-v2-stub');
+      expect(content?.text).toContain('mcp-app-embedded-stub');
       expect(content?.text).not.toContain('mcp-app-external-stub');
       expect(content?._meta?.ui?.csp).toEqual({
         connectDomains: [],
@@ -237,12 +230,13 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('keeps v3 through v5 aliases on the current external template', async () => {
+  it('keeps v3 through v6 aliases on the external template they originally referenced', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     for (const uri of [
       'ui://lobu/interaction/v3.html',
       'ui://lobu/interaction/v4.html',
       'ui://lobu/interaction/v5.html',
+      'ui://lobu/interaction/v6.html',
     ]) {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
@@ -260,7 +254,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       expect(content?.uri).toBe(uri);
       expect(content?.mimeType).toBe('text/html;profile=mcp-app');
       expect(content?.text).toContain('mcp-app-external-stub');
-      expect(content?.text).not.toContain('mcp-app-legacy-v2-stub');
+      expect(content?.text).not.toContain('mcp-app-embedded-stub');
       expect(content?.text).toContain('./assets/app.js?v=js123');
       const baseHref = content?.text?.match(/<base href="([^"]+)" \/>/)?.[1];
       const resourceOrigin = new URL(baseHref!).origin;
@@ -288,7 +282,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v6.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v7.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -302,13 +296,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     // CSP rides the current nested _meta.ui shape. ui.domain is intentionally
     // absent because it means a dedicated sandbox origin, not the MCP server.
     expect(resource.mimeType).toBe('text/html;profile=mcp-app');
-    const [resourceOrigin] = resource._meta?.ui?.csp?.resourceDomains ?? [];
-    expect(resourceOrigin).toMatch(/^https?:\/\//);
     expect(resource._meta?.ui?.csp).toEqual({
       connectDomains: [],
-      resourceDomains: [resourceOrigin],
+      resourceDomains: [],
       frameDomains: [],
-      baseUriDomains: [resourceOrigin],
     });
     expect(resource._meta?.ui?.prefersBorder).toBe(true);
     expect(resource._meta?.ui?.domain).toBeUndefined();
@@ -339,10 +330,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v6.html',
+            resourceUri: 'ui://lobu/interaction/v7.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v6.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v7.html',
         }),
       })
     );
@@ -361,12 +352,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v6.html',
+          resourceUri: 'ui://lobu/interaction/v7.html',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v6.html'
+        'ui://lobu/interaction/v7.html'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -419,7 +410,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v6.html',
+        resourceUri: 'ui://lobu/interaction/v7.html',
         visibility: ['model', 'app'],
       })
     );

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -69,15 +69,15 @@ const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
 const MCP_APP_EXTENSION_ID = 'io.modelcontextprotocol/ui';
 const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
   string,
-  { canonicalUri: string; template: 'legacy' | 'external' }
+  { canonicalUri: string; template: 'embedded' | 'external' }
 > = new Map([
   [
     'ui://lobu/interaction/v1',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'legacy' },
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
   ],
   [
     'ui://lobu/interaction/v2',
-    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'legacy' },
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
   ],
   [
     'ui://lobu/interaction/v3.html',
@@ -89,6 +89,10 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
   ],
   [
     'ui://lobu/interaction/v5.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
+  [
+    'ui://lobu/interaction/v6.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
   ],
 ]);
@@ -206,6 +210,8 @@ const MCP_APP_RESOURCES: Record<
     /** Surfaced on `resources/list` — clients show it in resource browsers. */
     description: string;
     appDir: string;
+    /** How resources/read delivers the current immutable host resource. */
+    template: 'embedded' | 'external';
     /**
      * Domains the host should allow the rendered iframe to reach, in the MCP
      * Apps `_meta.ui.csp` shape. The host owns the resulting policy; we only
@@ -225,8 +231,9 @@ const MCP_APP_RESOURCES: Record<
     description:
       'Interactive Lobu cards rendered in a sandboxed iframe; actions use standard MCP tool calls or host-mediated external links.',
     appDir: 'interaction',
-    // App logic is postMessage-only. The serving origin is added dynamically as
-    // the sole resource domain for the external JS/CSS bundle.
+    // Keep the host resource self-contained. The public /mcp-apps route still
+    // serves the external build for Lobu's own same-origin views and review.
+    template: 'embedded',
     csp: { connectDomains: [], resourceDomains: [], frameDomains: [] },
     prefersBorder: true,
   },
@@ -277,16 +284,20 @@ function supportsMcpApps(capabilities: Record<string, unknown> | null | undefine
 
 function mcpAppUiMeta(
   authCtx: SessionAuthContext,
-  app: (typeof MCP_APP_RESOURCES)[string]
+  app: (typeof MCP_APP_RESOURCES)[string],
+  template: 'embedded' | 'external' = app.template
 ): {
   csp: {
     connectDomains: string[];
     resourceDomains: string[];
     frameDomains: string[];
-    baseUriDomains: string[];
+    baseUriDomains?: string[];
   };
   prefersBorder: boolean;
 } {
+  if (template === 'embedded') {
+    return { csp: app.csp, prefersBorder: app.prefersBorder };
+  }
   const publicOrigin = resolvePublicOrigin(authCtx.requestUrl);
   return {
     csp: {
@@ -392,8 +403,8 @@ function createServerForContext(
     const canonicalUri = alias?.canonicalUri ?? uri;
     const app = MCP_APP_RESOURCES[canonicalUri];
     if (!app) throw new Error(`Unknown resource: ${uri}`);
-    const isLegacyAlias = alias?.template === 'legacy';
-    const html = isLegacyAlias
+    const template = alias?.template ?? app.template;
+    const html = template === 'embedded'
       ? await readMcpAppBundle(app.appDir, 'legacy-v2.html')
       : await renderMcpAppTemplate(
           app.appDir,
@@ -409,9 +420,7 @@ function createServerForContext(
           mimeType: MCP_APP_MIME_TYPE,
           text: html,
           _meta: {
-            ui: isLegacyAlias
-              ? { csp: app.csp, prefersBorder: app.prefersBorder }
-              : mcpAppUiMeta(authCtx, app),
+            ui: mcpAppUiMeta(authCtx, app, template),
           },
         },
       ],

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v6.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v7.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;


### PR DESCRIPTION
## What changed
- bump the immutable Lobu interaction resource to `ui://lobu/interaction/v7.html`
- serve v7 from the packed self-contained Owletto renderer merged in lobu-ai/owletto#790 (`bb9a036c`)
- preserve v3-v6 as external-template aliases and v1-v2 as embedded aliases
- advertise an empty resource CSP for the network-free current resource while retaining the public external review route

## Why
Live acceptance in the user Chrome showed ChatGPT refreshed to v6 but loaded only its external stylesheet; the cross-origin ES module did not execute and the widget stayed blank. v7 removes that dependency and uses the self-contained path that renders successfully in the same Chrome host.

## Verification
- `make pre-pr` passed all 6 gates
- server typecheck passed
- focused MCP integration: 16/16 passed
- Owletto full suite: 156 files, 1,333/1,333 passed
- Owletto production build and bundle tripwires passed
- v7 resources/read payload: 360,215 bytes, no external runtime URL
- packed renderer opened in the user Chrome and rendered the interaction card

Renderer review: https://gist.github.com/buremba/95a1ca4eb750d5e35d105e0254c755a0

After merge I will gate on the exact squash SHA, run production smoke, refresh the Lobu plugin in the user Chrome, and rerun pagination plus full-page reload acceptance in a new ChatGPT conversation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP app interactions can now be delivered as embedded, network-free templates.
  * Added support for selecting embedded or externally hosted resource templates.
  * Updated the Lobu interaction resource to the latest version.

* **Bug Fixes**
  * Improved resource metadata and content security policies to match each delivery method.
  * Preserved compatibility for earlier resource aliases and external templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->