### PR TITLE
feat(mcp): render and restore rich app results

### DIFF
--- a/db/migrations/20260810120000_mcp_app_result_snapshots.sql
+++ b/db/migrations/20260810120000_mcp_app_result_snapshots.sql
@@ -1,0 +1,39 @@
+-- migrate:up
+
+-- Encrypted, bounded copies of rich MCP tool results for host iframe reloads.
+-- These are derived UI artifacts, not durable workspace events: a reload may
+-- display the prior result, but must never rerun SQL, SDK code, or an action.
+-- Raw host conversation and JSON-RPC call ids are SHA-256 keyed by the server
+-- so they are neither exposed at rest nor large enough to overflow a btree key.
+CREATE TABLE IF NOT EXISTS public.mcp_app_result_snapshots (
+  organization_id text NOT NULL REFERENCES public.organization(id) ON DELETE CASCADE,
+  client_id text NOT NULL REFERENCES public.oauth_clients(id) ON DELETE CASCADE,
+  user_id text NOT NULL REFERENCES public."user"(id) ON DELETE CASCADE,
+  conversation_key text NOT NULL CHECK (length(conversation_key) = 64),
+  tool_call_key text NOT NULL CHECK (length(tool_call_key) = 64),
+  tool_name text NOT NULL CHECK (length(tool_name) BETWEEN 1 AND 120),
+  -- AES-256-GCM encrypted JSON: { version, toolName, data, viewState }.
+  body text NOT NULL,
+  plaintext_bytes bigint NOT NULL CHECK (plaintext_bytes BETWEEN 1 AND 524288),
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '30 days'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (
+    organization_id,
+    client_id,
+    user_id,
+    conversation_key,
+    tool_call_key
+  )
+);
+
+-- Exact restore and per-conversation cap both use the primary-key prefix. The
+-- expiry index is for the single-claimant retention sweep.
+-- squawk-ignore require-concurrent-index-creation -- table created immediately above; no existing rows or traffic
+CREATE INDEX IF NOT EXISTS mcp_app_result_snapshots_expiry
+  ON public.mcp_app_result_snapshots (expires_at);
+
+-- migrate:down
+
+-- squawk-ignore ban-drop-table -- derived, expiring UI artifacts introduced here
+DROP TABLE IF EXISTS public.mcp_app_result_snapshots;

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -143,14 +143,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     return sessionId!;
   }
 
-  it('serves the self-contained v7 interaction bundle over resources/read', async () => {
+  it('serves the self-contained v8 interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v7.html' },
+        params: { uri: 'ui://lobu/interaction/v8.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -159,7 +159,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v7.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v8.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-embedded-stub');
     expect(content?.text).not.toContain('mcp-app-external-stub');
@@ -170,6 +170,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       resourceDomains: [],
       frameDomains: [],
     });
+    expect(content?._meta?.ui?.permissions).toEqual({ clipboardWrite: {} });
     expect(content?._meta?.ui?.prefersBorder).toBe(true);
     expect(content?._meta?.ui?.domain).toBeUndefined();
   });
@@ -267,6 +268,25 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
+  it('keeps the v7 alias on the packed, network-free template', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'resources/read',
+        params: { uri: 'ui://lobu/interaction/v7.html' },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    expect(response.status).toBe(200);
+    const content = (await response.json()).result?.contents?.[0];
+    expect(content?.uri).toBe('ui://lobu/interaction/v7.html');
+    expect(content?.text).toContain('mcp-app-embedded-stub');
+    expect(content?.text).not.toContain('./assets/');
+  });
+
   it('advertises description and CSP metadata on resources/list without claiming a dedicated app domain', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
@@ -282,7 +302,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v7.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v8.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -330,10 +350,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v7.html',
+            resourceUri: 'ui://lobu/interaction/v8.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v7.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v8.html',
         }),
       })
     );
@@ -352,12 +372,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v7.html',
+          resourceUri: 'ui://lobu/interaction/v8.html',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v7.html'
+        'ui://lobu/interaction/v8.html'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -380,6 +400,20 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         }),
       })
     );
+    for (const name of ['restore_lobu_app_result', 'save_lobu_app_state']) {
+      const helper = body.result?.tools?.find(
+        (entry: { name?: string }) => entry.name === name
+      );
+      expect(helper).toEqual(
+        expect.objectContaining({
+          securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
+          _meta: expect.objectContaining({
+            ui: { visibility: ['app'] },
+          }),
+        })
+      );
+      expect(helper?._meta?.ui?.resourceUri).toBeUndefined();
+    }
     for (const listed of body.result?.tools ?? []) {
       expect(listed.securitySchemes?.[0]?.type).toBe('oauth2');
       expect(listed.annotations?.readOnlyHint).toEqual(expect.any(Boolean));
@@ -410,7 +444,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v7.html',
+        resourceUri: 'ui://lobu/interaction/v8.html',
         visibility: ['model', 'app'],
       })
     );
@@ -458,6 +492,97 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(body.result?.content?.[0]?.text).toContain('Release readiness');
     expect(body.result?.content?.[0]?.text).toContain('Ready for review\\.');
     expect(JSON.stringify(body.result)).not.toContain('must-not-render');
+  });
+
+  it('restores the exact rich result and UI state without rerunning the tool', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const conversationId = 'chatgpt-conversation-restore-test';
+    const queryResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'originating-call-77',
+        method: 'tools/call',
+        params: {
+          name: 'query_sql',
+          arguments: { sql: 'SELECT 1 AS row_number' },
+          _meta: { 'openai/session': conversationId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const queryBody = await queryResponse.json();
+    expect(queryBody.result?.structuredContent?.sql).toBe('SELECT 1 AS row_number');
+    expect(queryBody.result?.structuredContent?.rows).toEqual([{ row_number: 1 }]);
+
+    const restore = async (hostConversationId: string) => {
+      const response = await post(`/mcp/${org.slug}`, {
+        body: {
+          jsonrpc: '2.0',
+          id: `restore-${hostConversationId}`,
+          method: 'tools/call',
+          params: {
+            name: 'restore_lobu_app_result',
+            arguments: { tool_call_id: 'originating-call-77' },
+            _meta: { 'openai/session': hostConversationId },
+          },
+        },
+        headers: { 'mcp-session-id': sessionId },
+        token,
+      });
+      return (await response.json()).result?.structuredContent;
+    };
+
+    expect(await restore(`${conversationId}-wrong`)).toEqual({
+      found: false,
+      view_state: {},
+    });
+    const restored = await restore(conversationId);
+    expect(restored).toEqual({
+      found: true,
+      tool_name: 'query_sql',
+      data: queryBody.result.structuredContent,
+      view_state: {},
+    });
+
+    const saveResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'save-state-77',
+        method: 'tools/call',
+        params: {
+          name: 'save_lobu_app_state',
+          arguments: {
+            tool_call_id: 'originating-call-77',
+            view_state: { 'table.sql.page': 2, nested: { dropped: true } },
+          },
+          _meta: { 'openai/session': conversationId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    expect((await saveResponse.json()).result?.structuredContent).toEqual({ saved: true });
+    expect((await restore(conversationId))?.view_state).toEqual({ 'table.sql.page': 2 });
+
+    const [snapshot] = await getDb()<{
+      body: string;
+      conversation_key: string;
+      tool_call_key: string;
+    }>`SELECT body, conversation_key, tool_call_key
+       FROM public.mcp_app_result_snapshots
+       WHERE organization_id = ${org.id}`;
+    expect(snapshot.body).not.toContain('row_number');
+    expect(snapshot.conversation_key).not.toBe(conversationId);
+    expect(snapshot.tool_call_key).not.toBe('originating-call-77');
+
+    const helperAudits = await getDb()<{
+      tool_name: string;
+    }>`SELECT payload_data->>'tool_name' AS tool_name
+       FROM events
+       WHERE organization_id = ${org.id}
+         AND payload_data->>'tool_name' IN ('restore_lobu_app_result', 'save_lobu_app_state')`;
+    expect(helperAudits).toHaveLength(0);
   });
 
   it('keeps the text fallback when the client does not advertise MCP Apps support', async () => {

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -552,6 +552,16 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       view_state: {},
     });
 
+    const [snapshotBeforeSave] = await getDb()<{
+      expires_at: Date;
+    }>`SELECT expires_at
+       FROM public.mcp_app_result_snapshots
+       WHERE organization_id = ${org.id}
+         AND tool_name = 'query_sql'
+       ORDER BY updated_at DESC
+       LIMIT 1`;
+    expect(snapshotBeforeSave).toBeDefined();
+
     const saveState = async (toolName: string) => {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
@@ -580,13 +590,40 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     const [snapshot] = await getDb()<{
       body: string;
       conversation_key: string;
+      expires_at: Date;
       tool_call_key: string;
-    }>`SELECT body, conversation_key, tool_call_key
+    }>`SELECT body, conversation_key, expires_at, tool_call_key
        FROM public.mcp_app_result_snapshots
-       WHERE organization_id = ${org.id}`;
+       WHERE organization_id = ${org.id}
+         AND tool_name = 'query_sql'
+       ORDER BY updated_at DESC
+       LIMIT 1`;
+    expect(snapshot).toBeDefined();
     expect(snapshot.body).not.toContain('row_number');
     expect(snapshot.conversation_key).not.toBe(conversationId);
+    expect(snapshot.expires_at).toEqual(snapshotBeforeSave.expires_at);
     expect(snapshot.tool_call_key).not.toBe('originating-call-77');
+
+    const collidingResponse = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 'originating-call-77',
+        method: 'tools/call',
+        params: {
+          name: 'query_sql',
+          arguments: { sql: 'SELECT 2 AS row_number' },
+          _meta: { 'openai/session': conversationId },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+    const collidingBody = await collidingResponse.json();
+    expect(collidingBody.result?.structuredContent?.rows).toEqual([{ row_number: 2 }]);
+    expect(await restore(conversationId)).toEqual({
+      found: false,
+      view_state: {},
+    });
 
     const helperAudits = await getDb()<{
       tool_name: string;

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -515,7 +515,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(queryBody.result?.structuredContent?.sql).toBe('SELECT 1 AS row_number');
     expect(queryBody.result?.structuredContent?.rows).toEqual([{ row_number: 1 }]);
 
-    const restore = async (hostConversationId: string) => {
+    const restore = async (hostConversationId: string, toolName = 'query_sql') => {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
           jsonrpc: '2.0',
@@ -523,7 +523,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
           method: 'tools/call',
           params: {
             name: 'restore_lobu_app_result',
-            arguments: { tool_call_id: 'originating-call-77' },
+            arguments: {
+              tool_call_id: 'originating-call-77',
+              tool_name: toolName,
+            },
             _meta: { 'openai/session': hostConversationId },
           },
         },
@@ -537,6 +540,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       found: false,
       view_state: {},
     });
+    expect(await restore(conversationId, 'run_sdk')).toEqual({
+      found: false,
+      view_state: {},
+    });
     const restored = await restore(conversationId);
     expect(restored).toEqual({
       found: true,
@@ -545,24 +552,29 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       view_state: {},
     });
 
-    const saveResponse = await post(`/mcp/${org.slug}`, {
-      body: {
-        jsonrpc: '2.0',
-        id: 'save-state-77',
-        method: 'tools/call',
-        params: {
-          name: 'save_lobu_app_state',
-          arguments: {
-            tool_call_id: 'originating-call-77',
-            view_state: { 'table.sql.page': 2, nested: { dropped: true } },
+    const saveState = async (toolName: string) => {
+      const response = await post(`/mcp/${org.slug}`, {
+        body: {
+          jsonrpc: '2.0',
+          id: `save-state-77-${toolName}`,
+          method: 'tools/call',
+          params: {
+            name: 'save_lobu_app_state',
+            arguments: {
+              tool_call_id: 'originating-call-77',
+              tool_name: toolName,
+              view_state: { 'table.sql.page': 2, nested: { dropped: true } },
+            },
+            _meta: { 'openai/session': conversationId },
           },
-          _meta: { 'openai/session': conversationId },
         },
-      },
-      headers: { 'mcp-session-id': sessionId },
-      token,
-    });
-    expect((await saveResponse.json()).result?.structuredContent).toEqual({ saved: true });
+        headers: { 'mcp-session-id': sessionId },
+        token,
+      });
+      return (await response.json()).result?.structuredContent;
+    };
+    expect(await saveState('run_sdk')).toEqual({ saved: false });
+    expect(await saveState('query_sql')).toEqual({ saved: true });
     expect((await restore(conversationId))?.view_state).toEqual({ 'table.sql.page': 2 });
 
     const [snapshot] = await getDb()<{

--- a/packages/server/src/__tests__/unit/mcp-app-result-snapshots.test.ts
+++ b/packages/server/src/__tests__/unit/mcp-app-result-snapshots.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import {
+	boundedMcpAppViewState,
+	displaySafeMcpAppResult,
+	normalizeMcpAppToolCallId,
+} from "../../mcp-app-result-snapshots";
+
+describe("MCP App result snapshot boundaries", () => {
+	it("normalizes bounded JSON-RPC tool call ids", () => {
+		expect(normalizeMcpAppToolCallId(42)).toBe("42");
+		expect(normalizeMcpAppToolCallId("  call-42  ")).toBe("call-42");
+		expect(normalizeMcpAppToolCallId("")).toBeNull();
+		expect(normalizeMcpAppToolCallId("x".repeat(513))).toBeNull();
+		expect(normalizeMcpAppToolCallId(null)).toBeNull();
+	});
+
+	it("makes restored approval cards display-only without dropping safe links", () => {
+		expect(
+			displaySafeMcpAppResult({
+				version: 1,
+				actions: [
+					{ id: "approve", tool: "resolve_lobu_approval" },
+					{ id: "reject", tool: "resolve_lobu_approval" },
+					{ id: "review", href: "https://lobu.ai/runs/42" },
+				],
+			}),
+		).toEqual({
+			version: 1,
+			actions: [{ id: "review", href: "https://lobu.ai/runs/42" }],
+		});
+	});
+
+	it("accepts only bounded primitive UI state", () => {
+		expect(
+			boundedMcpAppViewState({
+				"table.sql.page": 2,
+				"details.raw.open": true,
+				label: "kept",
+				nested: { secret: "drop" },
+				array: [1, 2, 3],
+				tooLong: "x".repeat(501),
+			}),
+		).toEqual({
+			"table.sql.page": 2,
+			"details.raw.open": true,
+			label: "kept",
+		});
+	});
+});

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -74,6 +74,8 @@ describe("tool registry split", () => {
 				"render_lobu_view",
 				"resolve_lobu_approval",
 				"run_sdk",
+				"restore_lobu_app_result",
+				"save_lobu_app_state",
 				"save_memory",
 				"search_memory",
 				"search_sdk",
@@ -86,6 +88,8 @@ describe("tool registry split", () => {
 		expect(AGENT_TOOL_NAMES.size).toBe(6);
 		expect(isRestDispatchTool("render_lobu_view")).toBe(false);
 		expect(isRestDispatchTool("resolve_lobu_approval")).toBe(false);
+		expect(isRestDispatchTool("restore_lobu_app_result")).toBe(false);
+		expect(isRestDispatchTool("save_lobu_app_state")).toBe(false);
 		expect(isRestDispatchTool("manage_connections")).toBe(true);
 	});
 

--- a/packages/server/src/__tests__/unit/validate-args.test.ts
+++ b/packages/server/src/__tests__/unit/validate-args.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Type } from "@sinclair/typebox";
-import { getAllTools, getTool } from "../../tools/registry";
+import { getAllTools, getMcpTools, getTool } from "../../tools/registry";
 import {
   markAcceptedInternalFields,
   validateToolArgs,
@@ -324,8 +324,9 @@ describe("registry completeness", () => {
     // `list_organizations` is a throw-stub in the registry: executeTool
     // special-cases it and calls the (wrapped) listOrganizations directly.
     const exempt = new Set(["list_organizations"]);
-    const unwrapped = getAllTools()
+    const unwrapped = [...getAllTools(), ...getMcpTools()]
       .map((t) => t.name)
+      .filter((name, index, names) => names.indexOf(name) === index)
       .filter((name) => !exempt.has(name))
       .filter((name) => brandedName(getTool(name)?.handler) !== name);
     expect(unwrapped).toEqual([]);

--- a/packages/server/src/mcp-app-result-snapshots.ts
+++ b/packages/server/src/mcp-app-result-snapshots.ts
@@ -13,6 +13,7 @@ const MCP_APP_RESULT_MAX_BYTES = 512 * 1024;
 const MCP_APP_RESULT_RETENTION_DAYS = 30;
 const MCP_APP_RESULT_CONVERSATION_CAP = 50;
 const TOOL_CALL_ID_MAX_LENGTH = 512;
+const TOOL_NAME_MAX_LENGTH = 120;
 const VIEW_STATE_MAX_KEYS = 100;
 const VIEW_STATE_KEY_MAX_LENGTH = 120;
 const VIEW_STATE_STRING_MAX_LENGTH = 500;
@@ -173,7 +174,12 @@ export async function storeMcpAppResultSnapshot(args: {
 	data: UnknownRecord;
 }): Promise<boolean> {
 	const identity = snapshotIdentity(args.ctx, args.toolCallId);
-	if (!identity || !args.toolName || args.toolName.length > 120) return false;
+	if (
+		!identity ||
+		!args.toolName ||
+		args.toolName.length > TOOL_NAME_MAX_LENGTH
+	)
+		return false;
 	const data = displaySafeMcpAppResult(args.data);
 	if (!isRecord(data)) return false;
 	const serialized = serializeSnapshot({
@@ -231,6 +237,9 @@ export const RestoreMcpAppResultSchema = Type.Object({
 		Type.String({ minLength: 1, maxLength: TOOL_CALL_ID_MAX_LENGTH }),
 		Type.Number(),
 	]),
+	tool_name: Type.Optional(
+		Type.String({ minLength: 1, maxLength: TOOL_NAME_MAX_LENGTH }),
+	),
 });
 
 export const RestoreMcpAppResultOutputSchema = Type.Object({
@@ -244,7 +253,7 @@ export const RestoreMcpAppResultOutputSchema = Type.Object({
 });
 
 async function restoreMcpAppResultImpl(
-	args: { tool_call_id: string | number },
+	args: { tool_call_id: string | number; tool_name?: string },
 	_env: Env,
 	ctx: ToolContext,
 ) {
@@ -262,8 +271,10 @@ async function restoreMcpAppResultImpl(
 			AND expires_at > now()
 	`;
 	if (!row) return { found: false, view_state: {} };
+	if (args.tool_name && row.tool_name !== args.tool_name)
+		return { found: false, view_state: {} };
 	const snapshot = parseSnapshot(row.body);
-	if (!snapshot) {
+	if (!snapshot || snapshot.toolName !== row.tool_name) {
 		logger.warn(
 			{ toolName: row.tool_name },
 			"Discarded unreadable MCP App result snapshot",
@@ -289,13 +300,20 @@ export const SaveMcpAppStateSchema = Type.Object({
 		Type.String({ minLength: 1, maxLength: TOOL_CALL_ID_MAX_LENGTH }),
 		Type.Number(),
 	]),
+	tool_name: Type.Optional(
+		Type.String({ minLength: 1, maxLength: TOOL_NAME_MAX_LENGTH }),
+	),
 	view_state: Type.Record(Type.String(), Type.Unknown()),
 });
 
 export const SaveMcpAppStateOutputSchema = Type.Object({ saved: Type.Boolean() });
 
 async function saveMcpAppStateImpl(
-	args: { tool_call_id: string | number; view_state: UnknownRecord },
+	args: {
+		tool_call_id: string | number;
+		tool_name?: string;
+		view_state: UnknownRecord;
+	},
 	_env: Env,
 	ctx: ToolContext,
 ) {
@@ -316,8 +334,11 @@ async function saveMcpAppStateImpl(
 			FOR UPDATE
 		`;
 		if (!row) return { saved: false };
+		if (args.tool_name && row.tool_name !== args.tool_name)
+			return { saved: false };
 		const snapshot = parseSnapshot(row.body);
-		if (!snapshot) return { saved: false };
+		if (!snapshot || snapshot.toolName !== row.tool_name)
+			return { saved: false };
 		const serialized = serializeSnapshot({ ...snapshot, viewState });
 		if (!serialized) return { saved: false };
 		await tx`

--- a/packages/server/src/mcp-app-result-snapshots.ts
+++ b/packages/server/src/mcp-app-result-snapshots.ts
@@ -5,12 +5,13 @@ import { Type } from "@sinclair/typebox";
 import { getDb } from "./db/client";
 import type { Env } from "./index";
 import type { ToolContext } from "./tools/registry";
+import { withValidatedArgs } from "./tools/validate-args";
 
 const logger = createLogger("mcp-app-result-snapshots");
 
-export const MCP_APP_RESULT_MAX_BYTES = 512 * 1024;
-export const MCP_APP_RESULT_RETENTION_DAYS = 30;
-export const MCP_APP_RESULT_CONVERSATION_CAP = 50;
+const MCP_APP_RESULT_MAX_BYTES = 512 * 1024;
+const MCP_APP_RESULT_RETENTION_DAYS = 30;
+const MCP_APP_RESULT_CONVERSATION_CAP = 50;
 const TOOL_CALL_ID_MAX_LENGTH = 512;
 const VIEW_STATE_MAX_KEYS = 100;
 const VIEW_STATE_KEY_MAX_LENGTH = 120;
@@ -18,7 +19,7 @@ const VIEW_STATE_STRING_MAX_LENGTH = 500;
 const VIEW_STATE_MAX_BYTES = 8 * 1024;
 
 type UnknownRecord = Record<string, unknown>;
-export type McpAppViewState = Record<string, boolean | number | string>;
+type McpAppViewState = Record<string, boolean | number | string>;
 
 interface SnapshotPayload {
 	version: 1;
@@ -242,7 +243,7 @@ export const RestoreMcpAppResultOutputSchema = Type.Object({
 	),
 });
 
-export async function restoreMcpAppResult(
+async function restoreMcpAppResultImpl(
 	args: { tool_call_id: string | number },
 	_env: Env,
 	ctx: ToolContext,
@@ -277,6 +278,12 @@ export async function restoreMcpAppResult(
 	};
 }
 
+export const restoreMcpAppResult = withValidatedArgs(
+	"restore_lobu_app_result",
+	RestoreMcpAppResultSchema,
+	restoreMcpAppResultImpl,
+);
+
 export const SaveMcpAppStateSchema = Type.Object({
 	tool_call_id: Type.Union([
 		Type.String({ minLength: 1, maxLength: TOOL_CALL_ID_MAX_LENGTH }),
@@ -287,7 +294,7 @@ export const SaveMcpAppStateSchema = Type.Object({
 
 export const SaveMcpAppStateOutputSchema = Type.Object({ saved: Type.Boolean() });
 
-export async function saveMcpAppState(
+async function saveMcpAppStateImpl(
 	args: { tool_call_id: string | number; view_state: UnknownRecord },
 	_env: Env,
 	ctx: ToolContext,
@@ -328,6 +335,12 @@ export async function saveMcpAppState(
 		return { saved: true };
 	});
 }
+
+export const saveMcpAppState = withValidatedArgs(
+	"save_lobu_app_state",
+	SaveMcpAppStateSchema,
+	saveMcpAppStateImpl,
+);
 
 export async function cleanupExpiredMcpAppResultSnapshots(): Promise<number> {
 	const rows = await getDb()`

--- a/packages/server/src/mcp-app-result-snapshots.ts
+++ b/packages/server/src/mcp-app-result-snapshots.ts
@@ -205,10 +205,9 @@ export async function storeMcpAppResultSnapshot(args: {
 			ON CONFLICT (
 				organization_id, client_id, user_id, conversation_key, tool_call_key
 			) DO UPDATE SET
-				tool_name = EXCLUDED.tool_name,
-				body = EXCLUDED.body,
-				plaintext_bytes = EXCLUDED.plaintext_bytes,
-				expires_at = EXCLUDED.expires_at,
+				-- A host request ID is not guaranteed to be unique forever. Never let a
+				-- collision replace the historical card with a different result.
+				expires_at = now(),
 				updated_at = now()
 		`;
 		await tx`
@@ -345,7 +344,6 @@ async function saveMcpAppStateImpl(
 			UPDATE public.mcp_app_result_snapshots
 			SET body = ${serialized.body},
 				plaintext_bytes = ${serialized.plaintextBytes},
-				expires_at = now() + (${MCP_APP_RESULT_RETENTION_DAYS} * interval '1 day'),
 				updated_at = now()
 			WHERE organization_id = ${identity.organizationId}
 				AND client_id = ${identity.clientId}

--- a/packages/server/src/mcp-app-result-snapshots.ts
+++ b/packages/server/src/mcp-app-result-snapshots.ts
@@ -1,0 +1,337 @@
+import { createHash } from "node:crypto";
+import { Buffer } from "node:buffer";
+import { createLogger, decrypt, encrypt } from "@lobu/core";
+import { Type } from "@sinclair/typebox";
+import { getDb } from "./db/client";
+import type { Env } from "./index";
+import type { ToolContext } from "./tools/registry";
+
+const logger = createLogger("mcp-app-result-snapshots");
+
+export const MCP_APP_RESULT_MAX_BYTES = 512 * 1024;
+export const MCP_APP_RESULT_RETENTION_DAYS = 30;
+export const MCP_APP_RESULT_CONVERSATION_CAP = 50;
+const TOOL_CALL_ID_MAX_LENGTH = 512;
+const VIEW_STATE_MAX_KEYS = 100;
+const VIEW_STATE_KEY_MAX_LENGTH = 120;
+const VIEW_STATE_STRING_MAX_LENGTH = 500;
+const VIEW_STATE_MAX_BYTES = 8 * 1024;
+
+type UnknownRecord = Record<string, unknown>;
+export type McpAppViewState = Record<string, boolean | number | string>;
+
+interface SnapshotPayload {
+	version: 1;
+	toolName: string;
+	data: UnknownRecord;
+	viewState: McpAppViewState;
+}
+
+interface SnapshotIdentity {
+	organizationId: string;
+	clientId: string;
+	userId: string;
+	conversationKey: string;
+	toolCallKey: string;
+}
+
+interface SnapshotRow {
+	body: string;
+	tool_name: string;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function normalizeMcpAppToolCallId(value: unknown): string | null {
+	if (typeof value !== "string" && typeof value !== "number") return null;
+	if (typeof value === "number" && !Number.isFinite(value)) return null;
+	const normalized = String(value).trim();
+	return normalized && normalized.length <= TOOL_CALL_ID_MAX_LENGTH
+		? normalized
+		: null;
+}
+
+function hashIdentity(value: string): string {
+	return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function snapshotIdentity(
+	ctx: ToolContext,
+	toolCallId: unknown,
+): SnapshotIdentity | null {
+	const normalizedToolCallId = normalizeMcpAppToolCallId(toolCallId);
+	const conversationId = ctx.mcpConversationId?.trim();
+	if (
+		ctx.mcpAppsSupported !== true ||
+		ctx.tokenType !== "oauth" ||
+		!ctx.clientId ||
+		!ctx.userId ||
+		!conversationId ||
+		conversationId.length > 512 ||
+		!normalizedToolCallId
+	) {
+		return null;
+	}
+	return {
+		organizationId: ctx.organizationId,
+		clientId: ctx.clientId,
+		userId: ctx.userId,
+		conversationKey: hashIdentity(conversationId),
+		toolCallKey: hashIdentity(normalizedToolCallId),
+	};
+}
+
+/** Remove live approval mutations before a historical result is persisted. */
+export function displaySafeMcpAppResult(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(displaySafeMcpAppResult);
+	if (!isRecord(value)) return value;
+	return Object.fromEntries(
+		Object.entries(value).map(([key, inner]) => {
+			if (key === "actions" && Array.isArray(inner)) {
+				return [
+					key,
+					inner
+						.filter(
+							(action) =>
+								!isRecord(action) || action.tool !== "resolve_lobu_approval",
+						)
+						.map(displaySafeMcpAppResult),
+				];
+			}
+			return [key, displaySafeMcpAppResult(inner)];
+		}),
+	);
+}
+
+/** Accept only small primitive interaction state; result data never flows here. */
+export function boundedMcpAppViewState(value: unknown): McpAppViewState {
+	if (!isRecord(value)) return {};
+	const state: McpAppViewState = {};
+	for (const [key, inner] of Object.entries(value).slice(
+		0,
+		VIEW_STATE_MAX_KEYS,
+	)) {
+		if (!key || key.length > VIEW_STATE_KEY_MAX_LENGTH) continue;
+		if (
+			typeof inner !== "boolean" &&
+			!(typeof inner === "number" && Number.isFinite(inner)) &&
+			!(
+				typeof inner === "string" &&
+				inner.length <= VIEW_STATE_STRING_MAX_LENGTH
+			)
+		) {
+			continue;
+		}
+		const candidate = { ...state, [key]: inner as boolean | number | string };
+		if (Buffer.byteLength(JSON.stringify(candidate), "utf8") > VIEW_STATE_MAX_BYTES)
+			break;
+		state[key] = inner as boolean | number | string;
+	}
+	return state;
+}
+
+function parseSnapshot(body: string): SnapshotPayload | null {
+	try {
+		const parsed: unknown = JSON.parse(decrypt(body));
+		if (
+			!isRecord(parsed) ||
+			parsed.version !== 1 ||
+			typeof parsed.toolName !== "string" ||
+			!isRecord(parsed.data)
+		) {
+			return null;
+		}
+		return {
+			version: 1,
+			toolName: parsed.toolName,
+			data: parsed.data,
+			viewState: boundedMcpAppViewState(parsed.viewState),
+		};
+	} catch {
+		return null;
+	}
+}
+
+function serializeSnapshot(payload: SnapshotPayload): {
+	body: string;
+	plaintextBytes: number;
+} | null {
+	const plaintext = JSON.stringify(payload);
+	const plaintextBytes = Buffer.byteLength(plaintext, "utf8");
+	if (plaintextBytes === 0 || plaintextBytes > MCP_APP_RESULT_MAX_BYTES)
+		return null;
+	return { body: encrypt(plaintext), plaintextBytes };
+}
+
+export async function storeMcpAppResultSnapshot(args: {
+	ctx: ToolContext;
+	toolCallId: unknown;
+	toolName: string;
+	data: UnknownRecord;
+}): Promise<boolean> {
+	const identity = snapshotIdentity(args.ctx, args.toolCallId);
+	if (!identity || !args.toolName || args.toolName.length > 120) return false;
+	const data = displaySafeMcpAppResult(args.data);
+	if (!isRecord(data)) return false;
+	const serialized = serializeSnapshot({
+		version: 1,
+		toolName: args.toolName,
+		data,
+		viewState: {},
+	});
+	if (!serialized) return false;
+
+	const sql = getDb();
+	await sql.begin(async (tx) => {
+		await tx`
+			INSERT INTO public.mcp_app_result_snapshots (
+				organization_id, client_id, user_id, conversation_key,
+				tool_call_key, tool_name, body, plaintext_bytes, expires_at
+			) VALUES (
+				${identity.organizationId}, ${identity.clientId}, ${identity.userId},
+				${identity.conversationKey}, ${identity.toolCallKey}, ${args.toolName},
+				${serialized.body}, ${serialized.plaintextBytes},
+				now() + (${MCP_APP_RESULT_RETENTION_DAYS} * interval '1 day')
+			)
+			ON CONFLICT (
+				organization_id, client_id, user_id, conversation_key, tool_call_key
+			) DO UPDATE SET
+				tool_name = EXCLUDED.tool_name,
+				body = EXCLUDED.body,
+				plaintext_bytes = EXCLUDED.plaintext_bytes,
+				expires_at = EXCLUDED.expires_at,
+				updated_at = now()
+		`;
+		await tx`
+			DELETE FROM public.mcp_app_result_snapshots snapshot
+			WHERE snapshot.organization_id = ${identity.organizationId}
+				AND snapshot.client_id = ${identity.clientId}
+				AND snapshot.user_id = ${identity.userId}
+				AND snapshot.conversation_key = ${identity.conversationKey}
+				AND snapshot.tool_call_key NOT IN (
+					SELECT kept.tool_call_key
+					FROM public.mcp_app_result_snapshots kept
+					WHERE kept.organization_id = ${identity.organizationId}
+						AND kept.client_id = ${identity.clientId}
+						AND kept.user_id = ${identity.userId}
+						AND kept.conversation_key = ${identity.conversationKey}
+					ORDER BY kept.updated_at DESC, kept.tool_call_key
+					LIMIT ${MCP_APP_RESULT_CONVERSATION_CAP}
+				)
+		`;
+	});
+	return true;
+}
+
+export const RestoreMcpAppResultSchema = Type.Object({
+	tool_call_id: Type.Union([
+		Type.String({ minLength: 1, maxLength: TOOL_CALL_ID_MAX_LENGTH }),
+		Type.Number(),
+	]),
+});
+
+export const RestoreMcpAppResultOutputSchema = Type.Object({
+	found: Type.Boolean(),
+	tool_name: Type.Optional(Type.String()),
+	data: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+	view_state: Type.Record(
+		Type.String(),
+		Type.Union([Type.Boolean(), Type.Number(), Type.String()]),
+	),
+});
+
+export async function restoreMcpAppResult(
+	args: { tool_call_id: string | number },
+	_env: Env,
+	ctx: ToolContext,
+) {
+	const identity = snapshotIdentity(ctx, args.tool_call_id);
+	if (!identity) return { found: false, view_state: {} };
+	const sql = getDb();
+	const [row] = await sql<SnapshotRow>`
+		SELECT body, tool_name
+		FROM public.mcp_app_result_snapshots
+		WHERE organization_id = ${identity.organizationId}
+			AND client_id = ${identity.clientId}
+			AND user_id = ${identity.userId}
+			AND conversation_key = ${identity.conversationKey}
+			AND tool_call_key = ${identity.toolCallKey}
+			AND expires_at > now()
+	`;
+	if (!row) return { found: false, view_state: {} };
+	const snapshot = parseSnapshot(row.body);
+	if (!snapshot) {
+		logger.warn(
+			{ toolName: row.tool_name },
+			"Discarded unreadable MCP App result snapshot",
+		);
+		return { found: false, view_state: {} };
+	}
+	return {
+		found: true,
+		tool_name: snapshot.toolName,
+		data: snapshot.data,
+		view_state: snapshot.viewState,
+	};
+}
+
+export const SaveMcpAppStateSchema = Type.Object({
+	tool_call_id: Type.Union([
+		Type.String({ minLength: 1, maxLength: TOOL_CALL_ID_MAX_LENGTH }),
+		Type.Number(),
+	]),
+	view_state: Type.Record(Type.String(), Type.Unknown()),
+});
+
+export const SaveMcpAppStateOutputSchema = Type.Object({ saved: Type.Boolean() });
+
+export async function saveMcpAppState(
+	args: { tool_call_id: string | number; view_state: UnknownRecord },
+	_env: Env,
+	ctx: ToolContext,
+) {
+	const identity = snapshotIdentity(ctx, args.tool_call_id);
+	if (!identity) return { saved: false };
+	const viewState = boundedMcpAppViewState(args.view_state);
+	const sql = getDb();
+	return sql.begin(async (tx) => {
+		const [row] = await tx<SnapshotRow>`
+			SELECT body, tool_name
+			FROM public.mcp_app_result_snapshots
+			WHERE organization_id = ${identity.organizationId}
+				AND client_id = ${identity.clientId}
+				AND user_id = ${identity.userId}
+				AND conversation_key = ${identity.conversationKey}
+				AND tool_call_key = ${identity.toolCallKey}
+				AND expires_at > now()
+			FOR UPDATE
+		`;
+		if (!row) return { saved: false };
+		const snapshot = parseSnapshot(row.body);
+		if (!snapshot) return { saved: false };
+		const serialized = serializeSnapshot({ ...snapshot, viewState });
+		if (!serialized) return { saved: false };
+		await tx`
+			UPDATE public.mcp_app_result_snapshots
+			SET body = ${serialized.body},
+				plaintext_bytes = ${serialized.plaintextBytes},
+				expires_at = now() + (${MCP_APP_RESULT_RETENTION_DAYS} * interval '1 day'),
+				updated_at = now()
+			WHERE organization_id = ${identity.organizationId}
+				AND client_id = ${identity.clientId}
+				AND user_id = ${identity.userId}
+				AND conversation_key = ${identity.conversationKey}
+				AND tool_call_key = ${identity.toolCallKey}
+		`;
+		return { saved: true };
+	});
+}
+
+export async function cleanupExpiredMcpAppResultSnapshots(): Promise<number> {
+	const rows = await getDb()`
+		DELETE FROM public.mcp_app_result_snapshots WHERE expires_at <= now()
+	`;
+	return rows.count;
+}

--- a/packages/server/src/mcp-app-result-snapshots.ts
+++ b/packages/server/src/mcp-app-result-snapshots.ts
@@ -172,27 +172,27 @@ export async function storeMcpAppResultSnapshot(args: {
 	toolCallId: unknown;
 	toolName: string;
 	data: UnknownRecord;
-}): Promise<boolean> {
+}): Promise<void> {
 	const identity = snapshotIdentity(args.ctx, args.toolCallId);
 	if (
 		!identity ||
 		!args.toolName ||
 		args.toolName.length > TOOL_NAME_MAX_LENGTH
 	)
-		return false;
+		return;
 	const data = displaySafeMcpAppResult(args.data);
-	if (!isRecord(data)) return false;
+	if (!isRecord(data)) return;
 	const serialized = serializeSnapshot({
 		version: 1,
 		toolName: args.toolName,
 		data,
 		viewState: {},
 	});
-	if (!serialized) return false;
+	if (!serialized) return;
 
 	const sql = getDb();
-	await sql.begin(async (tx) => {
-		await tx`
+	const collided = await sql.begin(async (tx) => {
+		const [stored] = await tx<{ collided: boolean }>`
 			INSERT INTO public.mcp_app_result_snapshots (
 				organization_id, client_id, user_id, conversation_key,
 				tool_call_key, tool_name, body, plaintext_bytes, expires_at
@@ -209,6 +209,7 @@ export async function storeMcpAppResultSnapshot(args: {
 				-- collision replace the historical card with a different result.
 				expires_at = now(),
 				updated_at = now()
+			RETURNING expires_at <= now() AS collided
 		`;
 		await tx`
 			DELETE FROM public.mcp_app_result_snapshots snapshot
@@ -227,8 +228,14 @@ export async function storeMcpAppResultSnapshot(args: {
 					LIMIT ${MCP_APP_RESULT_CONVERSATION_CAP}
 				)
 		`;
+		return stored?.collided === true;
 	});
-	return true;
+	if (collided) {
+		logger.warn(
+			{ toolName: args.toolName },
+			"MCP App result snapshot key collision; historical restore disabled",
+		);
+	}
 }
 
 export const RestoreMcpAppResultSchema = Type.Object({

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -51,14 +51,17 @@ import {
   executeTool,
   extractAuthContext,
   isSoftErrorResult,
+  toToolContext,
 } from './tools/execute';
 import { LOBU_INTERACTION_RESOURCE_URI } from './tools/mcp_app';
 import { getMcpResultMeta } from './tools/mcp-result-meta';
 import { getMcpTools, getTool, isAuthorizationReadOnly } from './tools/registry';
 import { validateToolResult } from './tools/validate-args';
 import { readMcpAppBundle, renderMcpAppTemplate } from './utils/mcp-app-bundle';
+import logger from './utils/logger';
 import { resolvePublicOrigin } from './utils/public-origin';
 import { buildWorkspaceInstructions } from './utils/workspace-instructions';
+import { storeMcpAppResultSnapshot } from './mcp-app-result-snapshots';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -94,6 +97,10 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
   [
     'ui://lobu/interaction/v6.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'external' },
+  ],
+  [
+    'ui://lobu/interaction/v7.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
   ],
 ]);
 // ---------------------------------------------------------------------------
@@ -293,10 +300,15 @@ function mcpAppUiMeta(
     frameDomains: string[];
     baseUriDomains?: string[];
   };
+  permissions: { clipboardWrite: Record<string, never> };
   prefersBorder: boolean;
 } {
   if (template === 'embedded') {
-    return { csp: app.csp, prefersBorder: app.prefersBorder };
+    return {
+      csp: app.csp,
+      permissions: { clipboardWrite: {} },
+      prefersBorder: app.prefersBorder,
+    };
   }
   const publicOrigin = resolvePublicOrigin(authCtx.requestUrl);
   return {
@@ -305,6 +317,7 @@ function mcpAppUiMeta(
       resourceDomains: [...new Set([...app.csp.resourceDomains, publicOrigin])],
       baseUriDomains: [publicOrigin],
     },
+    permissions: { clipboardWrite: {} },
     prefersBorder: app.prefersBorder,
   };
 }
@@ -428,7 +441,7 @@ function createServerForContext(
   });
 
   // tools/call — access control + execution + formatting
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const { name, arguments: args } = request.params;
     const callAuthCtx = {
       ...authCtx,
@@ -472,6 +485,21 @@ function createServerForContext(
       if (tool?.outputSchema && result && typeof result === 'object') {
         const structured = validateToolResult(tool.outputSchema, result);
         if (structured !== null) {
+          if (tool.audit !== false) {
+            try {
+              await storeMcpAppResultSnapshot({
+                ctx: toToolContext(callAuthCtx),
+                toolCallId: extra.requestId,
+                toolName: name,
+                data: structured as Record<string, unknown>,
+              });
+            } catch (snapshotError) {
+              logger.warn(
+                { err: snapshotError },
+                '[mcp-app] result snapshot write failed',
+              );
+            }
+          }
           return {
             content: [{ type: 'text' as const, text }],
             structuredContent: structured as Record<string, unknown>,

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -11,6 +11,7 @@ import { runAclSyncTick } from '../authz/acl-sync';
 import type { CoreServices } from '../gateway/services/core-services';
 import { getChatInstanceManager } from '../lobu/gateway';
 import { cleanupExpiredMcpSessions } from '../mcp-handler';
+import { cleanupExpiredMcpAppResultSnapshots } from '../mcp-app-result-snapshots';
 import logger from '../utils/logger';
 import { runWatcherAutomationTick } from '../watchers/automation';
 import { checkStalledExecutions } from './check-stalled-executions';
@@ -138,6 +139,17 @@ function registerMaintenanceTasks(
     'mcp-session-cleanup',
     () => cleanupExpiredMcpSessions(),
     { cron: '*/10 * * * *' },
+  );
+
+  scheduler.register(
+    'mcp-app-result-snapshot-cleanup',
+    async () => {
+      const deleted = await cleanupExpiredMcpAppResultSnapshots();
+      if (deleted > 0) {
+        logger.info({ deleted }, '[task] expired MCP App result snapshots deleted');
+      }
+    },
+    { cron: '23 */6 * * *' },
   );
 
   // Hygiene sweep — drops expired rows from oauth_states, rate_limits,

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -113,6 +113,12 @@ function oidToTypeName(oid: number): string {
 }
 
 export const QuerySqlResultSchema = Type.Object({
+  sql: Type.Optional(
+    Type.String({
+      description:
+        'The original caller-supplied SQL statement. This is never the tenant-scoped SQL rewritten by Lobu and is absent for stored virtual-feed queries.',
+    })
+  ),
   rows: Type.Array(Type.Record(Type.String(), Type.Unknown())),
   columns: Type.Array(
     Type.Object({
@@ -130,6 +136,7 @@ export const QuerySqlResultSchema = Type.Object({
 });
 
 interface QuerySqlResult {
+  sql?: string;
   rows: Record<string, unknown>[];
   columns: { name: string; type: string }[];
   total_count: number;
@@ -521,6 +528,7 @@ export async function querySqlImpl(
           : undefined,
       });
       return {
+        sql: baseSql,
         rows: r.rows,
         columns: r.columns,
         total_count: r.total ?? r.rows.length,
@@ -672,6 +680,7 @@ export async function querySqlImpl(
       );
     }
     return {
+      sql: baseSql,
       rows,
       columns,
       total_count: totalCount,

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -323,18 +323,20 @@ export async function executeTool(
           shouldRetry: (err) => isRetryableToolError(err),
         })
       : await runHandler();
-    await recordToolInvocationAudit({
-      toolName,
-      args,
-      result,
-      durationMs: Date.now() - startTime,
-      ctx: toolContext,
-    });
-    await recordMcpConversationActivity({
-      ctx: toolContext,
-      toolName,
-      failed: isSoftErrorResult(result),
-    });
+    if (tool.audit !== false) {
+      await recordToolInvocationAudit({
+        toolName,
+        args,
+        result,
+        durationMs: Date.now() - startTime,
+        ctx: toolContext,
+      });
+      await recordMcpConversationActivity({
+        ctx: toolContext,
+        toolName,
+        failed: isSoftErrorResult(result),
+      });
+    }
     return result;
   } catch (error) {
     // Stamp the correlation id onto typed errors so the response boundaries can
@@ -342,18 +344,20 @@ export async function executeTool(
     if (error instanceof ToolError || error instanceof ToolUserError) {
       error.callId = callId;
     }
-    await recordToolInvocationAudit({
-      toolName,
-      args,
-      error,
-      durationMs: Date.now() - startTime,
-      ctx: toolContext,
-    });
-    await recordMcpConversationActivity({
-      ctx: toolContext,
-      toolName,
-      failed: true,
-    });
+    if (tool.audit !== false) {
+      await recordToolInvocationAudit({
+        toolName,
+        args,
+        error,
+        durationMs: Date.now() - startTime,
+        ctx: toolContext,
+      });
+      await recordMcpConversationActivity({
+        ctx: toolContext,
+        toolName,
+        failed: true,
+      });
+    }
     throw error;
   }
 }

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v7.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v8.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -201,7 +201,12 @@ export interface ToolDefinition<T = any> {
   securityScopes?: string[];
   /** MCP extension metadata, such as an Apps UI resource linkage. */
   mcpMeta?: Record<string, unknown>;
-  /** Derived app-state helpers opt out so pagination/reload never pollutes activity. */
+  /**
+   * Defaults to true. Setting it false suppresses BOTH the invocation
+   * audit/activity record and the MCP App result snapshot, so the derived
+   * app-state helpers neither pollute activity nor snapshot themselves over
+   * the originating result they were called to restore.
+   */
   audit?: boolean;
   handler: (args: T, env: Env, ctx: ToolContext) => Promise<any>;
 }
@@ -386,7 +391,17 @@ const MCP_APP_TOOLS: ToolDefinition[] = [
       'Save bounded pagination and disclosure state for the exact Lobu MCP App tool call. This app-only helper never changes workspace data.',
     inputSchema: SaveMcpAppStateSchema,
     outputSchema: SaveMcpAppStateOutputSchema,
-    annotations: { ...READ_ONLY, title: 'Save Lobu app state' },
+    // Persists a row, so it cannot claim `readOnlyHint` — the same bar that
+    // makes an audit-appending read `AUDITED_READ`. Repeating a save converges,
+    // so it stays idempotent, and `authorizationReadOnly` keeps it read-TIER
+    // (as for query_sql) so a member's app can save its own view state.
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      openWorldHint: false,
+      idempotentHint: true,
+      title: 'Save Lobu app state',
+    },
     authorizationReadOnly: true,
     securityScopes: ['mcp:read'],
     mcpMeta: { ui: { visibility: ['app'] } },

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -44,6 +44,14 @@ import {
 } from './sdk_run';
 import { SdkSearchResultSchema, SdkSearchSchema, sdkSearch } from './sdk_search';
 import { PublicSearchSchema, SearchSchema, search, UnifiedSearchResultSchema } from './search';
+import {
+  RestoreMcpAppResultOutputSchema,
+  RestoreMcpAppResultSchema,
+  SaveMcpAppStateOutputSchema,
+  SaveMcpAppStateSchema,
+  restoreMcpAppResult,
+  saveMcpAppState,
+} from '../mcp-app-result-snapshots';
 
 // ============================================
 // Tool Definitions
@@ -193,6 +201,8 @@ export interface ToolDefinition<T = any> {
   securityScopes?: string[];
   /** MCP extension metadata, such as an Apps UI resource linkage. */
   mcpMeta?: Record<string, unknown>;
+  /** Derived app-state helpers opt out so pagination/reload never pollutes activity. */
+  audit?: boolean;
   handler: (args: T, env: Env, ctx: ToolContext) => Promise<any>;
 }
 
@@ -356,6 +366,32 @@ const MCP_APP_TOOLS: ToolDefinition[] = [
       'openai/outputTemplate': LOBU_INTERACTION_RESOURCE_URI,
     },
     handler: resolveLobuApproval,
+  },
+  {
+    name: 'restore_lobu_app_result',
+    description:
+      'Restore the display-only snapshot for the exact Lobu MCP App tool call. This app-only tool never reruns the originating operation.',
+    inputSchema: RestoreMcpAppResultSchema,
+    outputSchema: RestoreMcpAppResultOutputSchema,
+    annotations: { ...READ_ONLY, title: 'Restore Lobu app result' },
+    authorizationReadOnly: true,
+    securityScopes: ['mcp:read'],
+    mcpMeta: { ui: { visibility: ['app'] } },
+    audit: false,
+    handler: restoreMcpAppResult,
+  },
+  {
+    name: 'save_lobu_app_state',
+    description:
+      'Save bounded pagination and disclosure state for the exact Lobu MCP App tool call. This app-only helper never changes workspace data.',
+    inputSchema: SaveMcpAppStateSchema,
+    outputSchema: SaveMcpAppStateOutputSchema,
+    annotations: { ...READ_ONLY, title: 'Save Lobu app state' },
+    authorizationReadOnly: true,
+    securityScopes: ['mcp:read'],
+    mcpMeta: { ui: { visibility: ['app'] } },
+    audit: false,
+    handler: saveMcpAppState,
   },
 ];
 


### PR DESCRIPTION
## Summary

- render SQL, SDK, entity, event, approval, and `json_template` results as compact interactive MCP Apps, including light/dark themes, TanStack tables, charts, disclosure controls, and display-safe approval cards
- serve the self-contained v8 MCP App resource while preserving legacy aliases and plain-text fallback clients
- persist encrypted, tenant/user/conversation/tool-call scoped display snapshots so cards can reload without rerunning SQL, SDK calls, or actions
- keep app-only restore/state helpers off the agent surface and activity feed, validate all helper arguments, strip live approval mutations, and bound retention, size, state, and per-conversation count
- pin merged Owletto PRs #791 and #792 at `bba77267cd90f5154ffd0ed90862036558348d3d`

## Security and data boundaries

- OAuth-only snapshot restore keyed by organization, OAuth client, user, conversation, and originating JSON-RPC tool-call ID
- restore and view-state writes are also bound to the originating tool name, preventing cross-tool card restoration if a host reuses a request ID after reconnect
- encrypted at rest; identities are hashed; results above 512 KiB are not stored
- maximum 50 snapshots per conversation, 30-day expiry, scheduled cleanup
- restore is display-only and never reruns the originating operation
- live approval-resolution actions are removed before persistence
- saved UI state accepts only bounded primitive values

## Validation

- Owletto: 1,341 tests across 156 files
- focused server units: 42 passed, including validation coverage for app-only tools
- MCP integration: 18 passed against fresh embedded Postgres, including cross-tool restore/state rejection
- full workspace package build and strict typechecks
- MCP current + legacy self-contained bundle verification
- migration lint
- `make pre-pr`
- independent exact-head review, with findings fixed and affected suites rerun
- local 11-case visual harness reviewed in light/dark mode and published as exact-pointer UI proof

## Red to green

- added accessible TanStack sorting coverage
- replaced boxed entity cards with one compact sortable entity table
- brought app-only restore/state helpers under the shared argument-validation boundary
- corrected the state-saving tool's read-only annotation while retaining read-tier authorization
- bound restored cards and state writes to the originating tool name as well as its call ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restoring rich tool results and interface state across sessions and server replicas.
  * Added secure, expiring storage with size limits, deduplication, and automatic cleanup.
  * Added the latest MCP interaction interface with clipboard permissions and backward compatibility.
  * Added tools for saving application state and restoring previous results.
  * SQL query results can now include the original submitted query when applicable.

* **Security & Reliability**
  * Approval actions are removed before saving, while restored state is safely scoped and filtered.
  * Non-audited application helpers avoid unnecessary audit activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->