### PR TITLE
fix(server): member execution of connector operations; principal-aware readiness

### DIFF
--- a/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
+++ b/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Member execution authorization for connector operations (`operations.execute`).
+ *
+ * Regression contract for the prod-readiness finding: an MCP session was told
+ * an operation was "ready/executable" (list_available) and then DENIED at
+ * execute with "requires an MCP session with admin access." Three properties
+ * must hold:
+ *
+ *  1. `execute` is member-write, not owner-admin — a member (or an owner whose
+ *     token carries `mcp:read mcp:write` but not `mcp:admin`) can invoke it.
+ *     Readiness advertising "ready" must not be a lie.
+ *  2. The handler STILL enforces per-principal connection visibility — a member
+ *     cannot execute on a connection they cannot see. This is the security
+ *     property that makes "member can execute" safe.
+ *  3. `list_available` is principal-aware: a read-only session sees every op
+ *     as not-executable with a session-scope elevation next_action instead of
+ *     "ready → execute → denied".
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../index";
+import { routeAction } from "../../tools/admin/action-router";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import type { ToolContext } from "../../tools/registry";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestConnection,
+	createTestConnectorDefinition,
+	createTestUser,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
+
+const MEMBER_CONNECTOR = "demo.member.execute";
+
+describe("manage_operations.execute member authorization", () => {
+	let orgId: string;
+	let ownerCtx: ToolContext;
+	let memberCtx: ToolContext;
+	let readOnlyCtx: ToolContext;
+	let orgConnectionId: number;
+	let privateConnectionId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, ctx } = await seedOwnerContext({
+			orgName: "Member Execute Authz Org",
+		});
+		orgId = org.id;
+		ownerCtx = ctx;
+
+		await createTestConnectorDefinition({
+			key: MEMBER_CONNECTOR,
+			name: "Member execute connector",
+			organization_id: org.id,
+		});
+		await getTestDb()`
+      UPDATE connector_definitions
+      SET actions_schema = ${getTestDb().json({
+				run: { name: "Run", kind: "write" },
+			})}
+      WHERE organization_id = ${org.id}
+        AND key = ${MEMBER_CONNECTOR}
+    `;
+
+		// Org-visible connection: every member may see (and now execute) it.
+		const orgConn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: MEMBER_CONNECTOR,
+			created_by: ctx.userId ?? undefined,
+			visibility: "org",
+		});
+		orgConnectionId = orgConn.id;
+		// Private connection owned by the owner: NOT visible to a plain member.
+		const privateConn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: MEMBER_CONNECTOR,
+			created_by: ctx.userId ?? undefined,
+			visibility: "private",
+		});
+		privateConnectionId = privateConn.id;
+
+		const member = await createTestUser({ name: "Member Execute Member" });
+		await addUserToOrganization(member.id, org.id);
+		memberCtx = {
+			...ctx,
+			userId: member.id,
+			memberRole: "member",
+			scopes: ["mcp:read", "mcp:write"],
+		};
+		readOnlyCtx = { ...memberCtx, scopes: ["mcp:read"] };
+	});
+
+	describe("routeAction enforcement seam (the tier that changed)", () => {
+		const stub = { execute: async () => ({ ok: true }) };
+
+		it("member with mcp:write can execute", async () => {
+			await expect(
+				routeAction("manage_operations", "execute", memberCtx, stub),
+			).resolves.toEqual({ ok: true });
+		});
+
+		it("owner with mcp:read+mcp:write (no mcp:admin) can execute — the prod-readiness scenario", async () => {
+			// The review session had admin/owner ROLE but a token minted without
+			// mcp:admin. Execute must not require the admin scope.
+			await expect(
+				routeAction(
+					"manage_operations",
+					"execute",
+					{ ...ownerCtx, scopes: ["mcp:read", "mcp:write"] },
+					stub,
+				),
+			).resolves.toEqual({ ok: true });
+		});
+
+		it("member with only mcp:read is denied with a write-access message", async () => {
+			await expect(
+				routeAction("manage_operations", "execute", readOnlyCtx, stub),
+			).rejects.toThrow(/requires an MCP session with write access/i);
+		});
+	});
+
+	describe("handler-level per-principal visibility (still enforced)", () => {
+		it("member cannot execute on another member's private connection", async () => {
+			const res = await manageOperations(
+				{
+					action: "execute",
+					connection_id: privateConnectionId,
+					operation_key: "run",
+					input: {},
+				},
+				{} as Env,
+				memberCtx,
+			);
+			expect(res).toMatchObject({
+				error: "Connection not found or not visible.",
+			});
+		});
+
+		it("member is not denied at authz or visibility on a visible org connection", async () => {
+			// Reaching operation resolution (past the authz + visibility gates)
+			// proves the member is authorized; any backend execution outcome is
+			// out of scope for this authz test.
+			let outcome: unknown;
+			try {
+				outcome = await manageOperations(
+					{
+						action: "execute",
+						connection_id: orgConnectionId,
+						operation_key: "run",
+						input: {},
+					},
+					{} as Env,
+					memberCtx,
+				);
+			} catch (err) {
+				outcome = err instanceof Error ? err.message : String(err);
+			}
+			expect(String(outcome)).not.toMatch(
+				/requires (an MCP session with )?(admin|write) access|admin or owner|Connection not found or not visible/i,
+			);
+		});
+	});
+
+	describe("list_available is principal-aware", () => {
+		async function findRun(ctx: ToolContext) {
+			const res = await manageOperations(
+				{ action: "list_available", connector_key: MEMBER_CONNECTOR },
+				{} as Env,
+				ctx,
+			);
+			expect(res).not.toHaveProperty("error");
+			const op = (res as { operations: Array<Record<string, unknown>> })
+				.operations.find((o) => o.operation_key === "run");
+			expect(op, "run op should be listed").toBeDefined();
+			return op as Record<string, unknown>;
+		}
+
+		it("write-tier caller sees the op as executable and ready", async () => {
+			const op = await findRun(memberCtx);
+			expect(op.executable).toBe(true);
+			expect(op.readiness).toBe("ready");
+		});
+
+		it("read-only caller sees the op as NOT executable with a scope-elevation next_action", async () => {
+			const op = await findRun(readOnlyCtx);
+			expect(op.executable).toBe(false);
+			expect(op.readiness).toBe("session_scope_required");
+			expect(op.reason).toMatch(/write access/i);
+			const next = op.next_action as Record<string, unknown>;
+			expect(next.action).toBe("elevate_session_scope");
+		});
+	});
+});

--- a/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
+++ b/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
@@ -158,7 +158,11 @@ describe("manage_operations.execute member authorization", () => {
 			} catch (err) {
 				outcome = err instanceof Error ? err.message : String(err);
 			}
-			expect(String(outcome)).not.toMatch(
+			const text =
+				typeof outcome === "string"
+					? outcome
+					: JSON.stringify(outcome ?? null);
+			expect(text).not.toMatch(
 				/requires (an MCP session with )?(admin|write) access|admin or owner|Connection not found or not visible/i,
 			);
 		});
@@ -191,6 +195,13 @@ describe("manage_operations.execute member authorization", () => {
 			expect(op.reason).toMatch(/write access/i);
 			const next = op.next_action as Record<string, unknown>;
 			expect(next.action).toBe("elevate_session_scope");
+			// Per-target rows must not contradict the top-level verdict.
+			const targets = op.execution_targets as Array<Record<string, unknown>>;
+			expect(targets.length).toBeGreaterThan(0);
+			for (const target of targets) {
+				expect(target.executable).toBe(false);
+				expect(target.status).toBe("session_scope_required");
+			}
 		});
 
 		it("system/reaction context (bypasses role+scope at routeAction) still sees ready ops as executable", async () => {
@@ -226,6 +237,76 @@ describe("manage_operations.execute member authorization", () => {
 			expect(op.reason).toMatch(/membership/i);
 			const next = op.next_action as Record<string, unknown>;
 			expect(next.action).toBe("request_membership");
+			const targets = op.execution_targets as Array<Record<string, unknown>>;
+			expect(targets.length).toBeGreaterThan(0);
+			for (const target of targets) {
+				expect(target.executable).toBe(false);
+				expect(target.status).toBe("membership_required");
+			}
 		});
+	});
+});
+
+describe("caller override never replaces a target-state verdict", () => {
+	// An operation that is not executable for its OWN reasons (connector code
+	// lacks execute()) must keep its "unsupported" verdict for every caller —
+	// the caller-scope downgrade only applies to ops whose target was ready.
+	let orgId: string;
+	let ownerCtx: ToolContext;
+	let readOnlyCtx: ToolContext;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, ctx } = await seedOwnerContext({
+			orgName: "Member Execute Unsupported Org",
+		});
+		orgId = org.id;
+		ownerCtx = ctx;
+
+		await createTestConnectorDefinition({
+			key: "demo.member.unsupported",
+			name: "Member execute unsupported connector",
+			organization_id: org.id,
+		});
+		await getTestDb()`
+      UPDATE connector_definitions
+      SET actions_schema = ${getTestDb().json({
+				nope: { name: "Nope", kind: "write" },
+			})},
+          supports_execute = false
+      WHERE organization_id = ${org.id}
+        AND key = 'demo.member.unsupported'
+    `;
+		await createTestConnection({
+			organization_id: org.id,
+			connector_key: "demo.member.unsupported",
+			created_by: ctx.userId ?? undefined,
+			visibility: "org",
+		});
+
+		const member = await createTestUser({ name: "Unsupported Member" });
+		await addUserToOrganization(member.id, org.id);
+		readOnlyCtx = {
+			...ctx,
+			userId: member.id,
+			memberRole: "member",
+			scopes: ["mcp:read"],
+		};
+	});
+
+	it("read-only caller sees an unsupported op as unsupported, not session_scope_required", async () => {
+		const res = await manageOperations(
+			{ action: "list_available", connector_key: "demo.member.unsupported" },
+			{} as Env,
+			readOnlyCtx,
+		);
+		expect(res).not.toHaveProperty("error");
+		const op = (res as { operations: Array<Record<string, unknown>> })
+			.operations.find((o) => o.operation_key === "nope");
+		expect(op, "nope op should be listed").toBeDefined();
+		expect(op?.executable).toBe(false);
+		expect(op?.readiness).toBe("unsupported");
+		expect(op?.reason).toMatch(/not implement|unsupported/i);
 	});
 });

--- a/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
+++ b/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
@@ -208,5 +208,24 @@ describe("manage_operations.execute member authorization", () => {
 			expect(op.executable).toBe(true);
 			expect(op.readiness).toBe("ready");
 		});
+
+		it("authenticated NON-member with mcp:write sees membership_required, not scope elevation", async () => {
+			// A PAT/token caller not in the org has memberRole null: execute is
+			// denied for missing workspace membership, so readiness must point at
+			// joining the org — telling them to elevate scope would mislead.
+			const nonMemberCtx: ToolContext = {
+				organizationId: orgId,
+				userId: "user-not-a-member",
+				memberRole: null,
+				isAuthenticated: true,
+				scopes: ["mcp:read", "mcp:write"],
+			};
+			const op = await findRun(nonMemberCtx);
+			expect(op.executable).toBe(false);
+			expect(op.readiness).toBe("membership_required");
+			expect(op.reason).toMatch(/membership/i);
+			const next = op.next_action as Record<string, unknown>;
+			expect(next.action).toBe("request_membership");
+		});
 	});
 });

--- a/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
+++ b/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
@@ -252,7 +252,6 @@ describe("caller override never replaces a target-state verdict", () => {
 	// lacks execute()) must keep its "unsupported" verdict for every caller —
 	// the caller-scope downgrade only applies to ops whose target was ready.
 	let orgId: string;
-	let ownerCtx: ToolContext;
 	let readOnlyCtx: ToolContext;
 
 	beforeAll(async () => {
@@ -262,7 +261,6 @@ describe("caller override never replaces a target-state verdict", () => {
 			orgName: "Member Execute Unsupported Org",
 		});
 		orgId = org.id;
-		ownerCtx = ctx;
 
 		await createTestConnectorDefinition({
 			key: "demo.member.unsupported",

--- a/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
+++ b/packages/server/src/__tests__/integration/operations-member-execute-authz.test.ts
@@ -192,5 +192,21 @@ describe("manage_operations.execute member authorization", () => {
 			const next = op.next_action as Record<string, unknown>;
 			expect(next.action).toBe("elevate_session_scope");
 		});
+
+		it("system/reaction context (bypasses role+scope at routeAction) still sees ready ops as executable", async () => {
+			// Watcher reactions run with userId=null + memberRole=null; routeAction
+			// bypasses the tier for them, so list_available must NOT downgrade a
+			// genuinely executable target to session_scope_required.
+			const systemCtx: ToolContext = {
+				organizationId: orgId,
+				userId: null,
+				memberRole: null,
+				isAuthenticated: true,
+				scopes: ["*"],
+			};
+			const op = await findRun(systemCtx);
+			expect(op.executable).toBe(true);
+			expect(op.readiness).toBe("ready");
+		});
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -108,18 +108,27 @@ describe("method-metadata", () => {
 		expect(METHOD_METADATA["organizations.list"].access).toBe("read");
 	});
 
-	it("exposes org-read admin lists in read mode (agents.list/get, schedules.list)", () => {
+	it("exposes org-read admin lists in read mode (agents.list/get)", () => {
 		// These are org-read-gated at runtime (requireOrgReadAccess / org-scoped
 		// query) but were tagged access:"admin", so query_sdk read mode dropped the
 		// whole namespace → opaque "Cannot read properties of undefined". Reclassify
 		// ONLY the reads; the mutating siblings must stay admin.
 		expect(METHOD_METADATA["agents.list"].access).toBe("read");
 		expect(METHOD_METADATA["agents.get"].access).toBe("read");
-		expect(METHOD_METADATA["schedules.list"].access).toBe("read");
 		// Mutations stay admin-gated — reclassifying reads must not leak writes.
 		expect(METHOD_METADATA["agents.create"].access).toBe("admin");
 		expect(METHOD_METADATA["agents.update"].access).toBe("admin");
 		expect(METHOD_METADATA["agents.delete"].access).toBe("admin");
+	});
+
+	it("schedules.* discovery matches the enforced manage_schedules tier (all admin)", () => {
+		// manage_schedules is owner-admin for every action (schedule rows carry
+		// agent prompts and delivery context), enforced via the explicit
+		// OWNER_ADMIN_ACTIONS entry and pinned by the tool-access matrix. The SDK
+		// metadata must say the same: a method that advertises read-safe but is
+		// denied at runtime is discovery-vs-enforcement drift (#2607), so
+		// `schedules.list` is admin — not read.
+		expect(METHOD_METADATA["schedules.list"].access).toBe("admin");
 		expect(METHOD_METADATA["schedules.create"].access).toBe("admin");
 		expect(METHOD_METADATA["schedules.update"].access).toBe("admin");
 		expect(METHOD_METADATA["schedules.pause"].access).toBe("admin");

--- a/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
+++ b/packages/server/src/auth/__tests__/access-model-cross-check.test.ts
@@ -50,6 +50,7 @@ const TIERED_NAMESPACES = [
 	["viewTemplates", "manage_view_templates", "../../tools/admin/manage_view_templates", "manageViewTemplates"],
 	["catalog", "manage_catalog", "../../tools/admin/manage_catalog", "manageCatalog"],
 	["agents", "manage_agents", "../../tools/admin/manage_agents", "manageAgents"],
+	["schedules", "manage_schedules", "../../tools/admin/manage_schedules", "manageSchedules"],
 ] as const;
 
 const NAMESPACE_TOOL = Object.fromEntries(

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -56,8 +56,12 @@ describe('requiresOwnerAdmin', () => {
     expect(isPublicReadable('manage_classifiers', { action: 'apply' })).toBe(false);
   });
 
-  it('should require admin for manage_operations execute; approve/reject are write-tier (handler enforces admin-or-run-owner)', () => {
-    expect(requiresOwnerAdmin('manage_operations', { action: 'execute' }, false)).toBe(true);
+  it('should NOT require admin for manage_operations execute; it is member-write (handler re-checks per-principal visibility)', () => {
+    // Members run connector operations on connections VISIBLE to them; the
+    // execute handler re-runs the per-principal visibility query and every
+    // existing gate (active status, action_modes, connector_action policy).
+    expect(requiresOwnerAdmin('manage_operations', { action: 'execute' }, false)).toBe(false);
+    expect(requiresMemberWrite('manage_operations', { action: 'execute' }, false)).toBe(true);
     // Owner-routed approvals: the recorded field owner (a plain member) may
     // decide their own entity-change run, so approve/reject sit at write tier
     // and manage_operations enforces admin-or-run-owner per run.
@@ -736,9 +740,9 @@ manage_agents: list=read+public get=read+public create=admin update=admin delete
 manage_conversations: list=read get=read send=write ?=read
 manage_feeds: list_feeds=read+public read_feed=read+public read_feeds=read+public create_feed=admin update_feed=admin delete_feed=admin trigger_feed=admin ?=read
 manage_auth_profiles: list_auth_profiles=read+public get_auth_profile=read+public test_auth_profile=admin create_auth_profile=write update_auth_profile=write delete_auth_profile=admin set_default_auth_profile=admin ?=read
-manage_operations: list_available=read+public execute=admin list_runs=read+public get_run=read+public list_activity=read+public approve=write reject=write approve_batch=write reject_batch=write ?=read
+manage_operations: list_available=read+public execute=write list_runs=read+public get_run=read+public list_activity=read+public approve=write reject=write approve_batch=write reject_batch=write ?=read
 notify: send=admin ?=admin
-manage_schedules: create=admin list=admin update=admin pause=admin cancel=admin ?=admin
+manage_schedules: create=admin list=admin update=admin pause=admin cancel=admin ?=read
 manage_behaviors: create=admin list=read+public update=admin create_version=admin complete_window=write trigger=write delete=admin set_reaction_script=admin get_versions=read+public get_version_details=read+public get_component_reference=read+public submit_feedback=admin get_feedback=read+public list_promoted=read create_from_version=admin ?=read
 get_behavior: read+public ?=read+public
 read_knowledge: read+public ?=read+public

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -50,12 +50,19 @@ export const MEMBER_WRITE_ACTIONS: Record<string, Set<string> | null> = {
 	// recorded FIELD OWNER of an entity-change proposal (a plain member) can
 	// decide their own run. The handler enforces admin-or-run-owner per run — a
 	// member who is not that run's owner is rejected there with the same
-	// admin-access message. `execute` stays admin-tier below.
+	// admin-access message. `execute` is write-tier too: a member runs connector
+	// operations only on connections VISIBLE to them (the handler re-runs the
+	// per-principal visibility query), and every existing gate (active status,
+	// input validation, per-connection action_modes, per-principal
+	// connector_action policy) still applies. This is the "ready means the
+	// TARGET is ready" contract made caller-aware: an action advertised as
+	// ready/executable must be invocable by the caller who sees it.
 	manage_operations: new Set([
 		"approve",
 		"reject",
 		"approve_batch",
 		"reject_batch",
+		"execute",
 	]),
 	// A member sends a message to their own agent's conversation. `send` runs the
 	// turn in the conversation's pinned sandbox; the handler binds the
@@ -120,9 +127,17 @@ export const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
 		"delete_auth_profile",
 		"set_default_auth_profile",
 	]),
-	// `approve`/`reject` live in MEMBER_WRITE_ACTIONS (handler enforces
-	// admin-or-run-owner); only `execute` is unconditionally admin.
-	manage_operations: new Set(["execute"]),
+	// `approve`/`reject`/`execute` all live in MEMBER_WRITE_ACTIONS; the handler
+	// enforces admin-or-run-owner for approvals and per-principal connection
+	// visibility for execution, so nothing in manage_operations is
+	// unconditionally admin.
+	manage_operations: new Set([]),
+	// `manage_schedules` is admin throughout (schedule rows carry agent prompts
+	// and delivery context). Declared explicitly so the access-model cross-check
+	// can cover the schedules namespace — the previous no-policy fallback made
+	// every action admin but was invisible to the drift guard, letting
+	// METHOD_METADATA advertise `schedules.list` as read (drift #2607-adjacent).
+	manage_schedules: new Set(["list", "create", "update", "pause", "cancel"]),
 	manage_behaviors: new Set([
 		// `complete_window` and `trigger` are in MEMBER_WRITE_ACTIONS — the
 		// execution path (server workers + device CLI + manual MCP clients),

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -414,8 +414,8 @@ export default async (ctx, client) => {
 	},
 	"schedules.list": {
 		summary:
-			"List scheduled jobs with optional filters. Results are scoped to the caller's organization.",
-		access: "read",
+			"List scheduled jobs with optional filters. Results are scoped to the caller's organization. Requires admin (schedule rows carry agent prompts and delivery context).",
+		access: "admin",
 		example:
 			"const { schedules } = await client.schedules.list({ agent_id: 'builder' });",
 	},

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -826,20 +826,22 @@ function buildAvailableOperation(args: {
 	const callerReason = callerBlockedByMembership
 		? MEMBERSHIP_REASON
 		: SESSION_SCOPE_REASON;
-	const { readyTarget, executable, readiness } =
-		!callerCanExecute && base.executable
-			? {
-					readyTarget: undefined,
-					executable: false,
-					readiness: callerReadiness,
-				}
-			: base;
-	const effectiveTargets = !callerCanExecute
+	// Only a caller-blocked op whose TARGET was ready gets downgraded. An op
+	// already not-executable for its own reasons (unsupported/disconnected/
+	// disabled) keeps its target-state verdict — the caller override must not
+	// replace it. Downgraded targets carry the caller readiness as their status
+	// too, so no per-target row contradicts the top-level verdict.
+	const shouldOverride = !callerCanExecute && base.executable;
+	const readyTarget = shouldOverride ? undefined : base.readyTarget;
+	const executable = shouldOverride ? false : base.executable;
+	const readiness = shouldOverride ? callerReadiness : base.readiness;
+	const effectiveTargets = shouldOverride
 		? targets.map((target) =>
 				target.executable
 					? {
 							...target,
 							executable: false,
+							status: callerReadiness,
 							reason: callerReason,
 						}
 					: target,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -523,6 +523,9 @@ function operationReadinessReason(
 	if (readiness === "session_scope_required") {
 		return SESSION_SCOPE_REASON;
 	}
+	if (readiness === "membership_required") {
+		return MEMBERSHIP_REASON;
+	}
 	if (readiness === "disabled") {
 		return "This operation is disabled on every visible connection.";
 	}
@@ -561,6 +564,12 @@ function resolveOperationReadiness(targets: ExecutionTarget[]): {
  * session at write tier (mcp:write / mcp:admin). */
 const SESSION_SCOPE_REASON =
 	"Executing operations requires an MCP session with write access (mcp:write or mcp:admin). This session has read-only access.";
+
+/** Shared copy for the caller-membership gate: a non-member can't execute even
+ * with mcp:write — routeAction denies at the membership check, so readiness
+ * must point at joining the workspace, not upgrading scope. */
+const MEMBERSHIP_REASON =
+	"Executing operations requires workspace membership with write access. This caller is not a member of the organization.";
 
 function operationMatchesQuery(
 	operation: AvailableOperation & Record<string, unknown>,
@@ -611,6 +620,15 @@ function buildOperationNextAction(args: {
 			manual: true,
 			reason: SESSION_SCOPE_REASON,
 			note: "Reconnect the MCP session with write access (mcp:write or mcp:admin) to execute operations.",
+		};
+	}
+	if (readiness === "membership_required") {
+		return {
+			action: "request_membership",
+			sdk_method: "operations.execute",
+			manual: true,
+			reason: MEMBERSHIP_REASON,
+			note: "Join the organization or ask an owner to grant membership before executing operations.",
 		};
 	}
 	if (readyTarget) {
@@ -730,8 +748,13 @@ function buildAvailableOperation(args: {
 	viewUrl: string | undefined;
 	/** The caller's highest reachable access tier (role × MCP scopes). */
 	callerMax: ToolAccessLevel;
+	/**
+	 * True for authenticated/anonymous non-members (memberRole null) — their
+	 * blocker is workspace membership, not MCP scope, so readiness must say so.
+	 */
+	callerLacksMembership: boolean;
 }): AvailableOperation & Record<string, unknown> {
-	const { operation, internalTargets, includeInputSchema, viewUrl, callerMax } = args;
+	const { operation, internalTargets, includeInputSchema, viewUrl, callerMax, callerLacksMembership } = args;
 	const { backend_config: _privateBackendConfig, ...publicOperation } =
 		operation;
 	const requiredScopes = operation.required_scopes ?? [];
@@ -791,12 +814,24 @@ function buildAvailableOperation(args: {
 	// prod-readiness review. Execution targets are overridden to match so no
 	// per-target row contradicts the top-level verdict.
 	const callerCanExecute = callerMax === "write" || callerMax === "admin";
+	// Two distinct blockers for a caller who can't execute: missing workspace
+	// MEMBERSHIP (authenticated/anon non-member — routeAction denies with
+	// "requires workspace membership", not a scope message) vs. a member whose
+	// session lacks mcp:write. Emit the right remediation for each.
+	const callerBlockedByMembership =
+		callerLacksMembership && !callerCanExecute;
+	const callerReadiness = callerBlockedByMembership
+		? "membership_required"
+		: "session_scope_required";
+	const callerReason = callerBlockedByMembership
+		? MEMBERSHIP_REASON
+		: SESSION_SCOPE_REASON;
 	const { readyTarget, executable, readiness } =
 		!callerCanExecute && base.executable
 			? {
 					readyTarget: undefined,
 					executable: false,
-					readiness: "session_scope_required",
+					readiness: callerReadiness,
 				}
 			: base;
 	const effectiveTargets = !callerCanExecute
@@ -805,7 +840,7 @@ function buildAvailableOperation(args: {
 					? {
 							...target,
 							executable: false,
-							reason: SESSION_SCOPE_REASON,
+							reason: callerReason,
 						}
 					: target,
 			)
@@ -1029,9 +1064,13 @@ async function handleListAvailable(
 	// memberRole null) bypass role/scope entirely at routeAction, so they must
 	// be treated as fully capable here — downgrading them would hide ready ops
 	// from Behavior reactions.
-	const callerMax = isSystemContext(ctx)
+	const isSystem = isSystemContext(ctx);
+	const callerMax = isSystem
 		? "admin"
 		: resolveMaxAccessLevel(ctx.memberRole, ctx.scopes);
+	// A non-member (memberRole null, and not a system context) is blocked by
+	// membership, not by MCP scope — the readiness copy must say so.
+	const callerLacksMembership = !isSystem && ctx.memberRole == null;
 	const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
 	const connectorViewUrl = (connectorKey: string): string | undefined =>
 		ownerSlug && baseUrl
@@ -1045,6 +1084,7 @@ async function handleListAvailable(
 				includeInputSchema: args.include_input_schema !== false,
 				viewUrl: connectorViewUrl(operation.connector_key),
 				callerMax,
+				callerLacksMembership,
 			}),
 		)
 		.filter((operation) => {

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -29,6 +29,7 @@ import {
 	readGrantedScopesFromAuthData,
 	readRequestedScopesFromAuthData,
 } from "../../auth/oauth/scopes";
+import { resolveMaxAccessLevel, type ToolAccessLevel } from "../../auth/tool-access";
 import { compileConnectionRowVisibility } from "../../authz/connection-visibility";
 import {
 	agentExistsInOrg,
@@ -519,6 +520,9 @@ function operationReadinessReason(
 	if (readiness === "scope_upgrade_required") {
 		return "This operation needs OAuth scopes the connection has not granted. Reauthorize to grant them.";
 	}
+	if (readiness === "session_scope_required") {
+		return SESSION_SCOPE_REASON;
+	}
 	if (readiness === "disabled") {
 		return "This operation is disabled on every visible connection.";
 	}
@@ -552,6 +556,11 @@ function resolveOperationReadiness(targets: ExecutionTarget[]): {
 			"inactive",
 	};
 }
+
+/** Shared copy for the caller-scope gate: executing operations requires an MCP
+ * session at write tier (mcp:write / mcp:admin). */
+const SESSION_SCOPE_REASON =
+	"Executing operations requires an MCP session with write access (mcp:write or mcp:admin). This session has read-only access.";
 
 function operationMatchesQuery(
 	operation: AvailableOperation & Record<string, unknown>,
@@ -595,6 +604,15 @@ function buildOperationNextAction(args: {
 		requestedScopes,
 		viewUrl,
 	} = args;
+	if (readiness === "session_scope_required") {
+		return {
+			action: "elevate_session_scope",
+			sdk_method: "operations.execute",
+			manual: true,
+			reason: SESSION_SCOPE_REASON,
+			note: "Reconnect the MCP session with write access (mcp:write or mcp:admin) to execute operations.",
+		};
+	}
 	if (readyTarget) {
 		const requiredInput =
 			Array.isArray(operation.input_schema?.required) &&
@@ -710,8 +728,10 @@ function buildAvailableOperation(args: {
 	internalTargets: InternalExecutionTarget[];
 	includeInputSchema: boolean;
 	viewUrl: string | undefined;
+	/** The caller's highest reachable access tier (role × MCP scopes). */
+	callerMax: ToolAccessLevel;
 }): AvailableOperation & Record<string, unknown> {
-	const { operation, internalTargets, includeInputSchema, viewUrl } = args;
+	const { operation, internalTargets, includeInputSchema, viewUrl, callerMax } = args;
 	const { backend_config: _privateBackendConfig, ...publicOperation } =
 		operation;
 	const requiredScopes = operation.required_scopes ?? [];
@@ -760,11 +780,39 @@ function buildAvailableOperation(args: {
 	const executeUnsupported =
 		operation.backend === "local_action" &&
 		(operation as OperationDescriptor).supports_execute === false;
-	const { readyTarget, executable, readiness } = executeUnsupported
-		? { readyTarget: undefined, executable: false, readiness: "unsupported" }
+	const base = executeUnsupported
+		? { readyTarget: undefined as ExecutionTarget | undefined, executable: false, readiness: "unsupported" }
 		: resolveOperationReadiness(targets);
+	// Caller-awareness: readiness answers "is the TARGET ready", but the same
+	// operation must not be advertised as executable to a caller whose session
+	// could never invoke it (operations.execute is write-tier). A read-only
+	// caller sees the catalog but every op is marked not-executable with a
+	// scope-upgrade next_action — the "ready but denied" lie from the
+	// prod-readiness review. Execution targets are overridden to match so no
+	// per-target row contradicts the top-level verdict.
+	const callerCanExecute = callerMax === "write" || callerMax === "admin";
+	const { readyTarget, executable, readiness } =
+		!callerCanExecute && base.executable
+			? {
+					readyTarget: undefined,
+					executable: false,
+					readiness: "session_scope_required",
+				}
+			: base;
+	const effectiveTargets = !callerCanExecute
+		? targets.map((target) =>
+				target.executable
+					? {
+							...target,
+							executable: false,
+							reason: SESSION_SCOPE_REASON,
+						}
+					: target,
+			)
+		: targets;
 	const remediationTarget =
-		targets.find((target) => target.status === readiness) ?? targets[0];
+		effectiveTargets.find((target) => target.status === readiness) ??
+		effectiveTargets[0];
 	const remediationInternalTarget = internalTargets.find(
 		(target) => target.connection_id === remediationTarget?.connection_id,
 	);
@@ -784,7 +832,7 @@ function buildAvailableOperation(args: {
 		readiness,
 		reason: operationReadinessReason(readiness, executable),
 		connection_count: targets.length,
-		execution_targets: targets,
+		execution_targets: effectiveTargets,
 		next_action: buildOperationNextAction({
 			operation,
 			readyTarget,
@@ -975,6 +1023,10 @@ async function handleListAvailable(
 		.toLocaleLowerCase()
 		.split(/\s+/)
 		.filter(Boolean);
+	// The caller's own reachable tier (role × MCP scopes) feeds the readiness
+	// mapper: operations.execute is write-tier, so a read-only session must not
+	// be told an op is ready to execute.
+	const callerMax = resolveMaxAccessLevel(ctx.memberRole, ctx.scopes);
 	const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
 	const connectorViewUrl = (connectorKey: string): string | undefined =>
 		ownerSlug && baseUrl
@@ -987,6 +1039,7 @@ async function handleListAvailable(
 				internalTargets: targetsByConnector.get(operation.connector_key) ?? [],
 				includeInputSchema: args.include_input_schema !== false,
 				viewUrl: connectorViewUrl(operation.connector_key),
+				callerMax,
 			}),
 		)
 		.filter((operation) => {

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -91,7 +91,7 @@ import {
 } from "../../utils/url-builder";
 import { trackWatcherReaction } from "../../utils/watcher-reactions";
 import { dispatchChromeActionToExtension } from "../../worker-api/dispatch-chrome-action";
-import { isAdminOrOwnerRole } from "../access-control";
+import { isAdminOrOwnerRole, isSystemContext } from "../access-control";
 import type { ToolContext } from "../registry";
 import { getOrgUrlContext } from "../view-urls";
 import { action, defineActionTool } from "./action-tool";
@@ -1025,8 +1025,13 @@ async function handleListAvailable(
 		.filter(Boolean);
 	// The caller's own reachable tier (role × MCP scopes) feeds the readiness
 	// mapper: operations.execute is write-tier, so a read-only session must not
-	// be told an op is ready to execute.
-	const callerMax = resolveMaxAccessLevel(ctx.memberRole, ctx.scopes);
+	// be told an op is ready to execute. System/reaction contexts (userId null,
+	// memberRole null) bypass role/scope entirely at routeAction, so they must
+	// be treated as fully capable here — downgrading them would hide ready ops
+	// from Behavior reactions.
+	const callerMax = isSystemContext(ctx)
+		? "admin"
+		: resolveMaxAccessLevel(ctx.memberRole, ctx.scopes);
 	const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
 	const connectorViewUrl = (connectorKey: string): string | undefined =>
 		ownerSlug && baseUrl


### PR DESCRIPTION
## Summary
The prod-readiness review (Aug 10) hit `Action manage_operations.execute requires an MCP session with admin access` on a session whose token carried `mcp:read mcp:write` (no `mcp:admin`). Two root causes:
- `operations.execute` was owner-admin while `list_available` advertised ops as `executable/ready` from connection state alone — a "ready then denied" lie reachable by exactly the callers it misleads (`list_available` is public-read).
- Discovery (`METHOD_METADATA`/`search_sdk`) drifted from enforcement: `schedules.list` was advertised `read` but enforced `admin`, because `manage_schedules` had no explicit policy entry and the schedules namespace wasn't covered by the access-model drift guard.

## Changes
- **`operations.execute` → member-write** (`tool-access.ts`). The handler already re-runs the per-principal connection visibility query (`manage_operations.ts:1094-1115`) plus every existing gate (active status, input validation, per-connection `action_modes`, per-principal `connector_action` policy), so a member can only execute on connections visible to them. Contract: `mcp:write` = operate, `mcp:admin` = administer. Unblocks the review session (owner role + write scope) and plain members.
- **Principal-aware readiness** (`manage_operations.ts`): `list_available` now threads `resolveMaxAccessLevel(memberRole, scopes)`; a read-only session sees every op `executable: false, readiness: session_scope_required` with an `elevate_session_scope` next_action instead of "ready then denied". Execution targets are overridden to match.
- **Fix the schedules discovery drift**: `schedules.list` metadata → `admin` (matching enforcement; schedule rows carry agent prompts), `manage_schedules` declared explicitly in `OWNER_ADMIN_ACTIONS`, and the `schedules` namespace added to the cross-check `TIERED_NAMESPACES` so this class of drift fails CI next time.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming + gateway-llm)
- [x] `make test-unit` clean
- [x] Full server vitest integration suite: **408 files / 3653 tests passed** (includes new `operations-member-execute-authz.test.ts`)
- [x] Bug fix: red→fix→green outputs pasted below

### Red (before fix — pins the old admin tier)
```
 ❯ src/auth/__tests__/tool-access.test.ts (64 tests | 1 failed)
   × requiresOwnerAdmin > should require admin for manage_operations execute…
     → expected false to be true // Object.is equality
```
New integration suite added: routeAction seam (member+mcp:write resolves, owner+write-scope-no-admin resolves = the review scenario, member+mcp:read denied), handler per-principal visibility (member cannot execute another's private connection → `Connection not found or not visible.`), and principal-aware readiness (read-only caller sees `session_scope_required` / `elevate_session_scope`).

### Green (after fix)
```
Test Files  408 passed (408)
     Tests  3653 passed | 2 skipped (3655)
```

## Notes
Follow-up (separate decision, not done here): agent/self-scoped `schedules.list` (an agent listing its own `created_by_agent` schedules) currently requires admin; the drift-guard model has no private-read bucket, so making it member-readable needs either a handler-level self-scope filter or a `read-not-public` tier concept. Flagging for product review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Authorization**
  * Members with write access can execute operations; read-only access remains restricted.
  * Operation availability reflects caller permissions, workspace membership, and required access scope.
  * Private connection visibility and organization access rules remain enforced.
  * System contexts retain access where applicable.

* **Access Controls**
  * Agent listing and retrieval use read access; agent changes remain admin-only.
  * Scheduled-job listings require administrative access and remain organization-scoped with sensitive details protected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->