### PR TITLE
feat(connectors): gmail person-relevant sync + declarative resolution policy

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -210,6 +210,20 @@ const person = defineEntityType({
       description: "WhatsApp chat the message belongs to.",
     },
   },
+  // Entity-resolution policy: a normalized email match auto-merges two persons
+  // (a normalized address is a strong unique key — the same human on LinkedIn,
+  // Gmail, X, etc.). Phone stays review-only: shared/work numbers collide too
+  // easily to merge without a human look. Declared here so `apply` folds it into
+  // the person type's metadata_schema and the duplicate-entity-resolution
+  // reaction's candidate submissions auto-merge on email.
+  resolutionPolicy: {
+    rules: [
+      { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+      { fields: ["emails"], normalizer: "email", onMatch: "auto_merge" },
+      { fields: ["phone"], normalizer: "phone", onMatch: "review" },
+      { fields: ["phones"], normalizer: "phone", onMatch: "review" },
+    ],
+  },
 });
 
 const company = defineEntityType({
@@ -913,6 +927,30 @@ const midasConnection = defineConnection({
   feeds: [{ feed: "assets", config: {} }],
 });
 
+// Gmail person-building, not mailbox mirroring. One narrow collected feed syncs
+// only person-relevant threads (human_senders_only) so the DB holds a small
+// high-signal set that drives person minting/merging — full email content stays
+// a live read via the connector's search/get_thread actions, never persisted.
+// Adopts the existing `gmail-buremba` slug so the OAuth grant already in place
+// is reused; the stale duplicate gmail connections/feeds in prod surface as
+// drift rows until cleaned up.
+const gmailConnection = defineConnection({
+  slug: "gmail-buremba",
+  connector: "google.gmail",
+  name: "Gmail",
+  feeds: [
+    {
+      feed: "threads",
+      config: {
+        human_senders_only: true,
+        labels: ["INBOX", "SENT"],
+        max_results: 500,
+        lookback_days: 365,
+      },
+    },
+  ],
+});
+
 // ── Relationships (only those the personal agent uses) ──────────
 // Tax-graph relationship types (account_contains, for_tax_year, …) belong in
 // examples/personal-finance — not here. With prune:true they are removed from
@@ -1223,5 +1261,6 @@ export default defineConfig({
     twitterTakeoutConnection,
     instagramTakeoutConnection,
     linkedinConnection,
+    gmailConnection,
   ],
 });

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -931,9 +931,8 @@ const midasConnection = defineConnection({
 // only person-relevant threads (human_senders_only) so the DB holds a small
 // high-signal set that drives person minting/merging — full email content stays
 // a live read via the connector's search/get_thread actions, never persisted.
-// Adopts the existing `gmail-buremba` slug so the OAuth grant already in place
-// is reused; the stale duplicate gmail connections/feeds in prod surface as
-// drift rows until cleaned up.
+// Adopts the existing `gmail-buremba` slug so the OAuth grant is reused; stale
+// duplicate gmail connections/feeds in prod surface as drift until cleaned up.
 const gmailConnection = defineConnection({
   slug: "gmail-buremba",
   connector: "google.gmail",

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -286,7 +286,7 @@ describe("ApplyClient — prune", () => {
     expect(types[0]?.backing).toEqual({ sql: "SELECT 1 AS x" });
   });
 
-  test("upsertEntityType POSTs backing:null for a stored type", async () => {
+  test("upsertEntityType sends backing:null only when the diff flagged the revert", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     const client = new ApplyClient(
       { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
@@ -296,10 +296,19 @@ describe("ApplyClient — prune", () => {
       }) as typeof fetch
     );
 
+    // A stored type with no diff flag: backing is omitted, so a fired update
+    // for an unrelated field never reverts out-of-band backing.
     await client.upsertEntityType({ slug: "company", name: "Company" });
+    expect(JSON.parse(String(calls[0]?.init?.body)).backing).toBeUndefined();
 
-    const body = JSON.parse(String(calls[0]?.init?.body));
-    expect(body.backing).toBeNull();
+    // Flagged revert (derived → stored): backing:null is sent.
+    await client.upsertEntityType(
+      { slug: "company", name: "Company" },
+      undefined,
+      undefined,
+      new Set(["backing"])
+    );
+    expect(JSON.parse(String(calls[1]?.init?.body)).backing).toBeNull();
   });
 
   test("upsertEntityType POSTs metrics_config for a metric type", async () => {
@@ -328,7 +337,7 @@ describe("ApplyClient — prune", () => {
     expect(body.metrics_config).toEqual(metrics);
   });
 
-  test("upsertEntityType POSTs metrics_config:null for a non-metric type", async () => {
+  test("upsertEntityType sends metrics_config:null only when the diff flagged the removal", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     const client = new ApplyClient(
       { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
@@ -339,12 +348,20 @@ describe("ApplyClient — prune", () => {
     );
 
     await client.upsertEntityType({ slug: "company", name: "Company" });
+    expect(
+      JSON.parse(String(calls[0]?.init?.body)).metrics_config
+    ).toBeUndefined();
 
-    const body = JSON.parse(String(calls[0]?.init?.body));
-    expect(body.metrics_config).toBeNull();
+    await client.upsertEntityType(
+      { slug: "company", name: "Company" },
+      undefined,
+      undefined,
+      new Set(["metrics"])
+    );
+    expect(JSON.parse(String(calls[1]?.init?.body)).metrics_config).toBeNull();
   });
 
-  test("upsertEntityType POSTs event_kinds for a type that declares kinds, null otherwise", async () => {
+  test("upsertEntityType sends event_kinds when declared, omits when not, clears when flagged", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     const client = new ApplyClient(
       { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
@@ -365,8 +382,19 @@ describe("ApplyClient — prune", () => {
       eventKinds
     );
 
+    // Not declared + not flagged → omitted, so an unrelated update never wipes
+    // out-of-band eventKinds. Flagged prune removal → null is sent.
     await client.upsertEntityType({ slug: "person", name: "Person" });
-    expect(JSON.parse(String(calls[1]?.init?.body)).event_kinds).toBeNull();
+    expect(
+      JSON.parse(String(calls[1]?.init?.body)).event_kinds
+    ).toBeUndefined();
+    await client.upsertEntityType(
+      { slug: "person", name: "Person" },
+      undefined,
+      undefined,
+      new Set(["eventKinds"])
+    );
+    expect(JSON.parse(String(calls[2]?.init?.body)).event_kinds).toBeNull();
   });
 
   test("listEntityTypes hoists event_kinds; null/empty stays undefined", async () => {
@@ -572,6 +600,38 @@ describe("ApplyClient — prune", () => {
         ],
       },
     });
+  });
+
+  test("a policy-only upsert omits undeclared facets instead of clearing them", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }) as typeof fetch
+    );
+
+    await client.upsertEntityType({
+      slug: "person",
+      resolutionPolicy: {
+        "x-lobu-resolution": {
+          rules: [
+            { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+          ],
+        },
+      },
+    });
+
+    const body = JSON.parse(String(calls[0]?.init?.body)) as Record<
+      string,
+      unknown
+    >;
+    // Facets the config does not own must not be sent at all — sending null
+    // would clear live eventKinds/backing/metrics on the server.
+    expect("event_kinds" in body).toBe(false);
+    expect("backing" in body).toBe(false);
+    expect("metrics_config" in body).toBe(false);
   });
 
   test("config-owned metadata_schema keys win over stale carried-forward ones", async () => {

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -634,6 +634,40 @@ describe("ApplyClient — prune", () => {
     expect("metrics_config" in body).toBe(false);
   });
 
+  test("a prune-flagged removal clears properties/required instead of preserving them", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }) as typeof fetch
+    );
+
+    await client.upsertEntityType(
+      {
+        slug: "person",
+        resolutionPolicy: {
+          "x-lobu-resolution": {
+            rules: [
+              { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+            ],
+          },
+        },
+      },
+      undefined,
+      {
+        properties: { email: { type: "string" } },
+        required: ["email"],
+      },
+      new Set(["properties", "required"])
+    );
+
+    const body = JSON.parse(String(calls[0]?.init?.body));
+    expect(body.metadata_schema.properties).toEqual({});
+    expect("required" in body.metadata_schema).toBe(false);
+  });
+
   test("config-owned metadata_schema keys win over stale carried-forward ones", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     const client = new ApplyClient(

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -393,13 +393,10 @@ describe("ApplyClient — prune", () => {
     expect(byKey.empty?.eventKinds).toBeUndefined();
   });
 
-  test("metadata_schema keys the config cannot express survive an apply round-trip", async () => {
-    // `x-lobu-resolution` is authored out-of-band (manage_entity_schema / UI /
-    // an agent) and read by the server's entity-resolution policy to decide
-    // whether duplicate entities auto-merge. `lobu.config.ts` has no way to
-    // declare it, and upsertEntityType rebuilds metadata_schema from the flat
-    // properties/required — so it must be carried forward or the next apply
-    // erases the dedupe rules with no diff row and no warning.
+  test("an undeclared metadata_schema extension survives an apply round-trip", async () => {
+    // A policy authored out-of-band is unmanaged when resolutionPolicy is
+    // omitted from config. Since upsert rebuilds metadata_schema from flat
+    // properties/required, the extension must ride along or apply erases it.
     const resolution = {
       rules: [
         {
@@ -440,7 +437,7 @@ describe("ApplyClient — prune", () => {
 
     const [person, company] = await client.listEntityTypes();
     expect(person?.schemaExtras).toEqual({ "x-lobu-resolution": resolution });
-    // A type with nothing but config-owned keys stays undefined (no churn).
+    // A type with nothing but hoisted core keys stays undefined (no churn).
     expect(company?.schemaExtras).toBeUndefined();
 
     // Re-apply a config that adds a field: properties come from config, the
@@ -526,12 +523,54 @@ describe("ApplyClient — prune", () => {
         },
       }
     );
-
     const body = JSON.parse(String(calls[0]?.init?.body));
     expect(body.metadata_schema["x-lobu-resolution"]).toEqual({
       rules: [
         { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
       ],
+    });
+  });
+
+  test("an extension-only type never wipes the live properties/required (remote core round-trips)", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }) as typeof fetch
+    );
+
+    // Config declares ONLY the resolution policy — no properties/required. The
+    // live type has a full schema, which must survive the rebuild verbatim.
+    await client.upsertEntityType(
+      {
+        slug: "person",
+        resolutionPolicy: {
+          "x-lobu-resolution": {
+            rules: [
+              { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+            ],
+          },
+        },
+      },
+      undefined,
+      {
+        properties: { email: { type: "string" }, handle: { type: "string" } },
+        required: ["email"],
+      }
+    );
+
+    const body = JSON.parse(String(calls[0]?.init?.body));
+    expect(body.metadata_schema).toEqual({
+      type: "object",
+      properties: { email: { type: "string" }, handle: { type: "string" } },
+      required: ["email"],
+      "x-lobu-resolution": {
+        rules: [
+          { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+        ],
+      },
     });
   });
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -668,6 +668,37 @@ describe("ApplyClient — prune", () => {
     expect("required" in body.metadata_schema).toBe(false);
   });
 
+  test("a prune-flagged resolutionPolicy removal drops x-lobu-resolution from the schema", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }) as typeof fetch
+    );
+
+    await client.upsertEntityType(
+      { slug: "person", name: "Person" },
+      {
+        "x-lobu-resolution": {
+          rules: [
+            { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+          ],
+        },
+      },
+      { properties: { email: { type: "string" } } },
+      new Set(["resolutionPolicy"])
+    );
+
+    const body = JSON.parse(String(calls[0]?.init?.body));
+    expect(body.metadata_schema["x-lobu-resolution"]).toBeUndefined();
+    // The live core round-trips; only the pruned extension is dropped.
+    expect(body.metadata_schema.properties).toEqual({
+      email: { type: "string" },
+    });
+  });
+
   test("config-owned metadata_schema keys win over stale carried-forward ones", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     const client = new ApplyClient(

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -469,6 +469,72 @@ describe("ApplyClient — prune", () => {
     });
   });
 
+  test("declared resolutionPolicy is folded into metadata_schema and wins over out-of-band extras", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }) as typeof fetch
+    );
+
+    await client.upsertEntityType(
+      {
+        slug: "person",
+        properties: { email: { type: "string" } },
+        resolutionPolicy: {
+          "x-lobu-resolution": {
+            rules: [
+              { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+            ],
+          },
+        },
+      },
+      // Remote out-of-band value differs — the declared policy must win.
+      { "x-lobu-resolution": { rules: [] } }
+    );
+
+    const body = JSON.parse(String(calls[0]?.init?.body));
+    expect(body.metadata_schema["x-lobu-resolution"]).toEqual({
+      rules: [
+        { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+      ],
+    });
+    expect(body.metadata_schema.properties).toEqual({
+      email: { type: "string" },
+    });
+  });
+
+  test("out-of-band resolution extras survive when no policy is declared", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }) as typeof fetch
+    );
+
+    await client.upsertEntityType(
+      { slug: "person", properties: { email: { type: "string" } } },
+      {
+        "x-lobu-resolution": {
+          rules: [
+            { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+          ],
+        },
+      }
+    );
+
+    const body = JSON.parse(String(calls[0]?.init?.body));
+    expect(body.metadata_schema["x-lobu-resolution"]).toEqual({
+      rules: [
+        { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+      ],
+    });
+  });
+
   test("config-owned metadata_schema keys win over stale carried-forward ones", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     const client = new ApplyClient(

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -438,6 +438,64 @@ describe("apply diff — memory schema", () => {
     expect(row?.changedFields).toContain("required");
   });
 
+  test("under prune, an already-cleared empty schema is a noop (converges on repeat apply)", async () => {
+    const desired: DesiredState = {
+      agents: [],
+      memorySchema: {
+        entityTypes: [
+          {
+            slug: "person",
+            name: "Person",
+            resolutionPolicy: {
+              "x-lobu-resolution": {
+                rules: [
+                  {
+                    fields: ["email"],
+                    normalizer: "email",
+                    onMatch: "auto_merge",
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        relationshipTypes: [],
+      },
+      watchers: [],
+      requiredSecrets: [],
+    };
+    // After the first prune apply cleared the live schema, a second apply sees
+    // `properties: {}` — that is not a removal, so it must be a noop.
+    const plan = computeDiff(
+      desired,
+      {
+        ...emptyRemote(),
+        entityTypes: [
+          {
+            slug: "person",
+            name: "Person",
+            properties: {},
+            schemaExtras: {
+              "x-lobu-resolution": {
+                rules: [
+                  {
+                    fields: ["email"],
+                    normalizer: "email",
+                    onMatch: "auto_merge",
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      { prune: true }
+    );
+    const row = plan.rows.find((r) => r.id === "person");
+    expect(row?.verb).toBe("noop");
+    expect(plan.counts.update).toBe(0);
+  });
+
   test("relationship-type rules are a noop when remote rules match (idempotency)", () => {
     // Regression: the rel-type `list` action omits rules, so apply hydrates
     // them (listRelationshipTypeRules) into the snapshot. When the hydrated

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -267,6 +267,81 @@ describe("apply diff — memory schema", () => {
     expect(plan.counts.update).toBe(0);
   });
 
+  test("declared resolutionPolicy diffs against the remote x-lobu-resolution", () => {
+    const declared = {
+      "x-lobu-resolution": {
+        rules: [
+          { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+        ],
+      },
+    };
+    const desired: DesiredState = {
+      agents: [],
+      memorySchema: {
+        entityTypes: [{ slug: "person", resolutionPolicy: declared }],
+        relationshipTypes: [],
+      },
+      watchers: [],
+      requiredSecrets: [],
+    };
+
+    // Match → noop.
+    const match = computeDiff(desired, {
+      ...emptyRemote(),
+      entityTypes: [{ slug: "person", schemaExtras: declared }],
+    });
+    expect(match.rows.find((r) => r.id === "person")?.verb).toBe("noop");
+
+    // Differs → update, flagged.
+    const mismatch = computeDiff(desired, {
+      ...emptyRemote(),
+      entityTypes: [
+        {
+          slug: "person",
+          schemaExtras: { "x-lobu-resolution": { rules: [] } },
+        },
+      ],
+    });
+    const row = mismatch.rows.find((r) => r.id === "person");
+    expect(row?.verb).toBe("update");
+    expect(row?.changedFields).toContain("resolutionPolicy");
+  });
+
+  test("omitted resolutionPolicy never churns an out-of-band policy", () => {
+    const desired: DesiredState = {
+      agents: [],
+      memorySchema: {
+        entityTypes: [{ slug: "person", name: "Person" }],
+        relationshipTypes: [],
+      },
+      watchers: [],
+      requiredSecrets: [],
+    };
+    const plan = computeDiff(desired, {
+      ...emptyRemote(),
+      entityTypes: [
+        {
+          slug: "person",
+          name: "Person",
+          schemaExtras: {
+            "x-lobu-resolution": {
+              rules: [
+                {
+                  fields: ["email"],
+                  normalizer: "email",
+                  onMatch: "auto_merge",
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+    const row = plan.rows.find((r) => r.id === "person");
+    expect(row?.verb).toBe("noop");
+    expect(plan.counts.update).toBe(0);
+  });
+
   test("relationship-type rules are a noop when remote rules match (idempotency)", () => {
     // Regression: the rel-type `list` action omits rules, so apply hydrates
     // them (listRelationshipTypeRules) into the snapshot. When the hydrated

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -342,6 +342,42 @@ describe("apply diff — memory schema", () => {
     expect(plan.counts.update).toBe(0);
   });
 
+  test("a policy-only declaration with a populated remote schema is noop on repeat apply", () => {
+    const declared = {
+      "x-lobu-resolution": {
+        rules: [
+          { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+        ],
+      },
+    };
+    const desired: DesiredState = {
+      agents: [],
+      memorySchema: {
+        entityTypes: [{ slug: "person", resolutionPolicy: declared }],
+        relationshipTypes: [],
+      },
+      watchers: [],
+      requiredSecrets: [],
+    };
+    // The live type has a full schema + the same policy. Omitted properties/
+    // required must be treated as unmanaged (never churn), so a second apply
+    // is a noop rather than a perpetual properties update.
+    const plan = computeDiff(desired, {
+      ...emptyRemote(),
+      entityTypes: [
+        {
+          slug: "person",
+          properties: { email: { type: "string" }, handle: { type: "string" } },
+          required: ["email"],
+          schemaExtras: declared,
+        },
+      ],
+    });
+    const row = plan.rows.find((r) => r.id === "person");
+    expect(row?.verb).toBe("noop");
+    expect(plan.counts.update).toBe(0);
+  });
+
   test("relationship-type rules are a noop when remote rules match (idempotency)", () => {
     // Regression: the rel-type `list` action omits rules, so apply hydrates
     // them (listRelationshipTypeRules) into the snapshot. When the hydrated

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -378,6 +378,66 @@ describe("apply diff — memory schema", () => {
     expect(plan.counts.update).toBe(0);
   });
 
+  test("under prune, omitting properties/required flags a removal (declarative fields stay pruneable)", async () => {
+    const desired: DesiredState = {
+      agents: [],
+      memorySchema: {
+        entityTypes: [
+          {
+            slug: "person",
+            name: "Person",
+            resolutionPolicy: {
+              "x-lobu-resolution": {
+                rules: [
+                  {
+                    fields: ["email"],
+                    normalizer: "email",
+                    onMatch: "auto_merge",
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        relationshipTypes: [],
+      },
+      watchers: [],
+      requiredSecrets: [],
+    };
+    // Prune treats the config as the source of truth: a live `required` schema
+    // the config no longer declares must be removed, not silently kept.
+    const plan = computeDiff(
+      desired,
+      {
+        ...emptyRemote(),
+        entityTypes: [
+          {
+            slug: "person",
+            name: "Person",
+            properties: { email: { type: "string" } },
+            required: ["email"],
+            schemaExtras: {
+              "x-lobu-resolution": {
+                rules: [
+                  {
+                    fields: ["email"],
+                    normalizer: "email",
+                    onMatch: "auto_merge",
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      { prune: true }
+    );
+    const row = plan.rows.find((r) => r.id === "person");
+    expect(row?.verb).toBe("update");
+    expect(row?.changedFields).toContain("properties");
+    expect(row?.changedFields).toContain("required");
+  });
+
   test("relationship-type rules are a noop when remote rules match (idempotency)", () => {
     // Regression: the rel-type `list` action omits rules, so apply hydrates
     // them (listRelationshipTypeRules) into the snapshot. When the hydrated

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -342,6 +342,50 @@ describe("apply diff — memory schema", () => {
     expect(plan.counts.update).toBe(0);
   });
 
+  test("under prune, omitting resolutionPolicy flags a removal, then converges to noop", () => {
+    const live = {
+      "x-lobu-resolution": {
+        rules: [
+          { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+        ],
+      },
+    };
+    const desired: DesiredState = {
+      agents: [],
+      memorySchema: {
+        entityTypes: [{ slug: "person", name: "Person" }],
+        relationshipTypes: [],
+      },
+      watchers: [],
+      requiredSecrets: [],
+    };
+
+    // First apply: remote policy present + prune → removal.
+    const removal = computeDiff(
+      desired,
+      {
+        ...emptyRemote(),
+        entityTypes: [{ slug: "person", name: "Person", schemaExtras: live }],
+      },
+      { prune: true }
+    );
+    const removalRow = removal.rows.find((r) => r.id === "person");
+    expect(removalRow?.verb).toBe("update");
+    expect(removalRow?.changedFields).toContain("resolutionPolicy");
+
+    // Second apply: policy already cleared → noop.
+    const converged = computeDiff(
+      desired,
+      {
+        ...emptyRemote(),
+        entityTypes: [{ slug: "person", name: "Person", properties: {} }],
+      },
+      { prune: true }
+    );
+    expect(converged.rows.find((r) => r.id === "person")?.verb).toBe("noop");
+    expect(converged.counts.update).toBe(0);
+  });
+
   test("a policy-only declaration with a populated remote schema is noop on repeat apply", () => {
     const declared = {
       "x-lobu-resolution": {

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -431,6 +431,55 @@ describe("mapProjectToDesiredState", () => {
     expect(byKey.person?.metrics).toBeUndefined();
   });
 
+  test("lowers a declared resolution policy to the raw x-lobu-resolution key; absent stays undefined", () => {
+    const person = defineEntityType({
+      key: "person",
+      name: "Person",
+      resolutionPolicy: {
+        rules: [
+          { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+          { fields: ["phone"], normalizer: "phone", onMatch: "review" },
+        ],
+      },
+    });
+    const company = defineEntityType({ key: "company", name: "Company" });
+    const state = mapProjectToDesiredState(
+      defineConfig({ agents: [], entities: [person, company] })
+    );
+    const byKey = Object.fromEntries(
+      state.memorySchema.entityTypes.map((e) => [e.slug, e])
+    );
+    expect(byKey.person?.resolutionPolicy).toEqual({
+      "x-lobu-resolution": {
+        rules: [
+          { fields: ["email"], normalizer: "email", onMatch: "auto_merge" },
+          { fields: ["phone"], normalizer: "phone", onMatch: "review" },
+        ],
+      },
+    });
+    // A type without a policy carries none — keeps the diff churn-free.
+    expect(byKey.company?.resolutionPolicy).toBeUndefined();
+  });
+
+  test("rejects malformed resolutionPolicy rules at load time", () => {
+    const bad = defineEntityType({
+      key: "person",
+      name: "Person",
+      resolutionPolicy: {
+        rules: [
+          {
+            fields: [],
+            normalizer: "email",
+            onMatch: "auto_merge",
+          },
+        ],
+      },
+    });
+    expect(() =>
+      mapProjectToDesiredState(defineConfig({ agents: [], entities: [bad] }))
+    ).toThrow(/invalid resolutionPolicy/i);
+  });
+
   test("rejects invalid metrics at load time (measure naming a missing eventSet)", () => {
     const bad = defineEntityType({
       key: "company",

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -480,6 +480,17 @@ describe("mapProjectToDesiredState", () => {
     ).toThrow(/invalid resolutionPolicy/i);
   });
 
+  test("rejects a resolutionPolicy without a rules array", () => {
+    const bad = defineEntityType({
+      key: "person",
+      name: "Person",
+      resolutionPolicy: {} as never,
+    });
+    expect(() =>
+      mapProjectToDesiredState(defineConfig({ agents: [], entities: [bad] }))
+    ).toThrow(/expected rules to be an array/i);
+  });
+
   test("rejects invalid metrics at load time (measure naming a missing eventSet)", () => {
     const bad = defineEntityType({
       key: "company",

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -807,7 +807,10 @@ export async function executePlan(
     // computeDiff already made against the ORG-OWNED types only; re-deriving it
     // from the raw snapshot would let a foreign public type of the same slug
     // shadow the owned one (see the ownership filter in computeDiff).
-    await ctx.client.upsertEntityType(row.desired, row.remote?.schemaExtras);
+    await ctx.client.upsertEntityType(row.desired, row.remote?.schemaExtras, {
+      properties: row.remote?.properties,
+      required: row.remote?.required,
+    });
     // View template is a separate, version-appending tool. Reconcile it only on
     // create (when declared) or a flagged change — never every run, so the
     // version history doesn't churn. Declared ⇒ set; omitted-under-prune ⇒ clear.

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -807,10 +807,15 @@ export async function executePlan(
     // computeDiff already made against the ORG-OWNED types only; re-deriving it
     // from the raw snapshot would let a foreign public type of the same slug
     // shadow the owned one (see the ownership filter in computeDiff).
-    await ctx.client.upsertEntityType(row.desired, row.remote?.schemaExtras, {
-      properties: row.remote?.properties,
-      required: row.remote?.required,
-    });
+    await ctx.client.upsertEntityType(
+      row.desired,
+      row.remote?.schemaExtras,
+      {
+        properties: row.remote?.properties,
+        required: row.remote?.required,
+      },
+      new Set(row.changedFields ?? [])
+    );
     // View template is a separate, version-appending tool. Reconcile it only on
     // create (when declared) or a flagged change — never every run, so the
     // version history doesn't churn. Declared ⇒ set; omitted-under-prune ⇒ clear.

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -689,7 +689,15 @@ export class ApplyClient {
     remoteSchemaCore?: {
       properties?: Record<string, unknown>;
       required?: string[];
-    }
+    },
+    /**
+     * Facet names the apply diff flagged for CLEARING (prune removal of
+     * out-of-band eventKinds, derived→stored backing revert, metric removal).
+     * Facets are declared-only otherwise: an update fired for an unrelated
+     * field must never wipe live values the config does not own, and the server
+     * clears a facet only when its key is present in the payload.
+     */
+    clearFacets?: ReadonlySet<string>
   ): Promise<UpsertEntityTypeResult> {
     // The server stores per-type fields as a single `metadata_schema` JSON
     // Schema (`{ type, properties, required }`) — it does NOT read top-level
@@ -744,22 +752,24 @@ export class ApplyClient {
           : {}),
       };
     }
-    // Event kinds sent on every upsert so it is deterministic: an object declares
-    // the type's kinds; `null` clears them. Stored verbatim in event_kinds.
-    payload.event_kinds = eventKinds ?? null;
-    // Backing is sent on every upsert so it is deterministic: `{ sql }` makes
-    // the type derived; `null` makes it stored (and reverts a previously-derived
-    // type). `connection` (a slug) is forwarded so the server can bind the view
-    // to an external database; the server resolves slug → connection at read time.
-    payload.backing = backing
-      ? {
-          sql: backing.sql,
-          ...(backing.connection ? { connection: backing.connection } : {}),
-        }
-      : null;
-    // Metrics sent on every upsert so it is deterministic: an object declares
-    // the type's metrics; `null` clears them. Stored verbatim in metrics_config.
-    payload.metrics_config = metrics ?? null;
+    // Facets are declared-only, with an explicit clear when the diff flagged
+    // them (prune removal / derived-revert / metric removal). Sending `null`
+    // unconditionally — the old behavior — wiped out-of-band values whenever
+    // ANY field changed; the server clears a facet only when its key is present.
+    if (eventKinds !== undefined || clearFacets?.has("eventKinds")) {
+      payload.event_kinds = eventKinds ?? null;
+    }
+    if (backing !== undefined || clearFacets?.has("backing")) {
+      payload.backing = backing
+        ? {
+            sql: backing.sql,
+            ...(backing.connection ? { connection: backing.connection } : {}),
+          }
+        : null;
+    }
+    if (metrics !== undefined || clearFacets?.has("metrics")) {
+      payload.metrics_config = metrics ?? null;
+    }
     return this.upsertSchemaResource("entity_type", payload);
   }
 

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -697,11 +697,16 @@ export class ApplyClient {
       eventKinds,
       backing,
       metrics,
+      resolutionPolicy,
     } = entity;
     const payload: Record<string, unknown> = { slug };
     if (name !== undefined) payload.name = name;
     if (description !== undefined) payload.description = description;
-    if (properties !== undefined || required !== undefined) {
+    if (
+      properties !== undefined ||
+      required !== undefined ||
+      resolutionPolicy !== undefined
+    ) {
       // Strip config-owned keys from the extras bag so config always wins —
       // spread order alone would let a stale `required` survive, because the
       // config's `required` is only spread when non-empty. (When the config
@@ -710,10 +715,15 @@ export class ApplyClient {
       const extras: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(schemaExtras ?? {})) {
         if (CONFIG_OWNED_SCHEMA_KEYS.has(key)) continue;
+        // The resolution policy is now config-owned when declared — the declared
+        // value wins over any out-of-band one.
+        if (resolutionPolicy !== undefined && key === "x-lobu-resolution")
+          continue;
         extras[key] = value;
       }
       payload.metadata_schema = {
         ...extras,
+        ...(resolutionPolicy ?? {}),
         type: "object",
         properties: properties ?? {},
         ...(required && required.length > 0 ? { required } : {}),

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -721,7 +721,9 @@ export class ApplyClient {
     if (
       properties !== undefined ||
       required !== undefined ||
-      resolutionPolicy !== undefined
+      resolutionPolicy !== undefined ||
+      clearFacets?.has("properties") ||
+      clearFacets?.has("required")
     ) {
       // Strip config-owned keys from the extras bag so config always wins —
       // spread order alone would let a stale `required` survive, because the
@@ -737,11 +739,22 @@ export class ApplyClient {
           continue;
         extras[key] = value;
       }
-      // Declared properties/required win; when the config omits them but still
-      // writes metadata_schema (extension-only type), fall back to the live
-      // core so an apply never silently clears the server's schema.
-      const effectiveProperties = properties ?? remoteSchemaCore?.properties;
-      const effectiveRequired = required ?? remoteSchemaCore?.required;
+      // Declared properties/required win. When the config omits them:
+      //   - diff flagged a prune removal → send an empty core to clear them;
+      //   - otherwise → fall back to the live core so a fired update for an
+      //     unrelated field never silently clears the server's schema.
+      const pruneClearProperties = clearFacets?.has("properties");
+      const pruneClearRequired = clearFacets?.has("required");
+      const effectiveProperties = properties
+        ? properties
+        : pruneClearProperties
+          ? {}
+          : remoteSchemaCore?.properties;
+      const effectiveRequired = required
+        ? required
+        : pruneClearRequired
+          ? undefined
+          : remoteSchemaCore?.required;
       payload.metadata_schema = {
         ...extras,
         ...(resolutionPolicy ?? {}),

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -723,7 +723,8 @@ export class ApplyClient {
       required !== undefined ||
       resolutionPolicy !== undefined ||
       clearFacets?.has("properties") ||
-      clearFacets?.has("required")
+      clearFacets?.has("required") ||
+      clearFacets?.has("resolutionPolicy")
     ) {
       // Strip config-owned keys from the extras bag so config always wins —
       // spread order alone would let a stale `required` survive, because the
@@ -733,9 +734,13 @@ export class ApplyClient {
       const extras: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(schemaExtras ?? {})) {
         if (HOISTED_SCHEMA_KEYS.has(key)) continue;
-        // The resolution policy is now config-owned when declared — the declared
-        // value wins over any out-of-band one.
-        if (resolutionPolicy !== undefined && key === "x-lobu-resolution")
+        // The resolution policy is config-owned when declared, and removed under
+        // prune — either way the declared/cleared value wins over out-of-band.
+        if (
+          (resolutionPolicy !== undefined ||
+            clearFacets?.has("resolutionPolicy")) &&
+          key === "x-lobu-resolution"
+        )
           continue;
         extras[key] = value;
       }

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -75,10 +75,9 @@ export interface RemoteEntityType {
   /** Declared metrics (mirrors {@link DesiredEntityType.metrics}); hoisted from the row's `metrics_config`. */
   metrics?: EntityMetrics;
   /**
-   * Top-level `metadata_schema` keys the config has NO way to express — today
-   * `x-lobu-resolution` (the entity-resolution rules the server reads to decide
-   * whether duplicate entities auto-merge), authored via `manage_entity_schema`
-   * / the UI / an agent rather than `lobu.config.ts`.
+   * Top-level `metadata_schema` extension keys not hoisted into dedicated remote
+   * fields. This includes `x-lobu-resolution`: apply compares it when config
+   * declares a policy and carries it forward untouched when config omits it.
    *
    * `upsertEntityType` REBUILDS `metadata_schema` from the config's flat
    * `properties`/`required` and the server stores what it is sent verbatim, so
@@ -251,11 +250,11 @@ function pickArray<T>(body: Record<string, unknown>, ...keys: string[]): T[] {
 }
 
 /**
- * The top-level `metadata_schema` keys `lobu.config.ts` owns. Anything else on
- * the stored schema is authored out-of-band and must survive an apply — see
- * {@link RemoteEntityType.schemaExtras}.
+ * Core JSON Schema keys hoisted to dedicated remote fields. Extension keys stay
+ * in {@link RemoteEntityType.schemaExtras} so apply can diff a declared owner or
+ * preserve an undeclared/out-of-band value.
  */
-const CONFIG_OWNED_SCHEMA_KEYS: ReadonlySet<string> = new Set([
+const HOISTED_SCHEMA_KEYS: ReadonlySet<string> = new Set([
   "type",
   "properties",
   "required",
@@ -268,10 +267,9 @@ const CONFIG_OWNED_SCHEMA_KEYS: ReadonlySet<string> = new Set([
  * `metadata_schema` to the row's top level. Mirrors `upsertEntityType`, which
  * folds the flat fields back into `metadata_schema` when writing.
  *
- * Every OTHER top-level key is collected into `schemaExtras` and handed back to
- * `upsertEntityType` so the rebuild preserves it. Narrowing the read without
- * that carry-forward is what made `lobu apply` silently drop out-of-band schema
- * keys such as `x-lobu-resolution`.
+ * Every other top-level key is collected into `schemaExtras`. The diff may own
+ * a declared extension such as `x-lobu-resolution`; otherwise upsert carries it
+ * forward so rebuilding the core schema cannot erase it silently.
  */
 function hoistEntityTypeSchema(
   row: RemoteEntityType & {
@@ -301,7 +299,7 @@ function hoistEntityTypeSchema(
     }
     const extras: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(schema)) {
-      if (CONFIG_OWNED_SCHEMA_KEYS.has(key)) continue;
+      if (HOISTED_SCHEMA_KEYS.has(key)) continue;
       extras[key] = value;
     }
     if (Object.keys(extras).length > 0) out.schemaExtras = extras;
@@ -674,14 +672,24 @@ export class ApplyClient {
     // DesiredEntityType); extra properties on the passed value are ignored.
     entity: Omit<DesiredEntityType, "metadata">,
     /**
-     * The live type's out-of-band `metadata_schema` keys
+     * The live type's `metadata_schema` extension keys
      * ({@link RemoteEntityType.schemaExtras}), from the remote snapshot this
-     * apply already fetched. Config-owned keys (`type`/`properties`/`required`)
-     * are stripped from this bag before merging, so config always wins on them
-     * while keys it cannot express (e.g. `x-lobu-resolution`) survive the
-     * rebuild.
+     * apply already fetched. Hoisted core keys are stripped before merging; a
+     * declared resolution policy overrides its live extension, while every
+     * undeclared extension survives the rebuild.
      */
-    schemaExtras?: Record<string, unknown>
+    schemaExtras?: Record<string, unknown>,
+    /**
+     * The live type's hoisted schema core (`properties`/`required`) when the
+     * config does not declare them itself. Required so a type that declares
+     * ONLY an extension (e.g. `resolutionPolicy`) does not wipe the server's
+     * complete metadata_schema by sending `properties: {}` — the config's
+     * declared value wins when present, the remote core round-trips otherwise.
+     */
+    remoteSchemaCore?: {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    }
   ): Promise<UpsertEntityTypeResult> {
     // The server stores per-type fields as a single `metadata_schema` JSON
     // Schema (`{ type, properties, required }`) — it does NOT read top-level
@@ -714,19 +722,26 @@ export class ApplyClient {
       // all — the server then leaves the stored one alone, extras included.)
       const extras: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(schemaExtras ?? {})) {
-        if (CONFIG_OWNED_SCHEMA_KEYS.has(key)) continue;
+        if (HOISTED_SCHEMA_KEYS.has(key)) continue;
         // The resolution policy is now config-owned when declared — the declared
         // value wins over any out-of-band one.
         if (resolutionPolicy !== undefined && key === "x-lobu-resolution")
           continue;
         extras[key] = value;
       }
+      // Declared properties/required win; when the config omits them but still
+      // writes metadata_schema (extension-only type), fall back to the live
+      // core so an apply never silently clears the server's schema.
+      const effectiveProperties = properties ?? remoteSchemaCore?.properties;
+      const effectiveRequired = required ?? remoteSchemaCore?.required;
       payload.metadata_schema = {
         ...extras,
         ...(resolutionPolicy ?? {}),
         type: "object",
-        properties: properties ?? {},
-        ...(required && required.length > 0 ? { required } : {}),
+        properties: effectiveProperties ?? {},
+        ...(effectiveRequired && effectiveRequired.length > 0
+          ? { required: effectiveRequired }
+          : {}),
       };
     }
     // Event kinds sent on every upsert so it is deterministic: an object declares

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -57,6 +57,13 @@ export interface DesiredEntityType {
    */
   eventKinds?: Record<string, unknown>;
   /**
+   * The `x-lobu-resolution` metadata_schema key, lowered from the config's
+   * `resolutionPolicy`. Present only when declared; folded into the upserted
+   * metadata_schema (config wins over any out-of-band value) and diffed against
+   * the remote `schemaExtras`.
+   */
+  resolutionPolicy?: Record<string, unknown>;
+  /**
    * Default view template (render-DSL root node) for this type's detail page.
    * Present only when declared. Applied via manage_view_templates set/clear and
    * diffed against the remote current default (which apply-cmd fetches per

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -383,22 +383,24 @@ function diffEntityType(
         changed: (d, r) => stringChanged(d.description, r.description),
       },
       {
+        // required — prune-aware, like eventKinds. Declared: diff and set on
+        // change. Omitted + prune: a present remote set is a removal (apply
+        // clears it). Omitted + no prune: unmanaged, never churns — so an
+        // extension-only declaration (e.g. resolutionPolicy) is a noop on
+        // repeat apply instead of a perpetual update that wipes the live core.
         name: "required",
         changed: (d, r) =>
           d.required !== undefined
             ? !deepEqual(d.required, r.required ?? [])
-            : false,
+            : prune && (r.required ?? []).length > 0,
       },
       {
-        // Declared-only: a config that omits `properties` does not own them, so
-        // they must not churn — otherwise an extension-only declaration (e.g.
-        // resolutionPolicy) re-reports a properties update on every apply while
-        // the upsert just round-trips the live core.
+        // properties — prune-aware, like eventKinds (see `required` above).
         name: "properties",
         changed: (d, r) =>
           d.properties !== undefined
             ? !deepEqual(d.properties, r.properties)
-            : false,
+            : prune && r.properties !== undefined,
       },
       {
         // Derived types store metadata_schema verbatim (no inferred superset),

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -396,11 +396,15 @@ function diffEntityType(
       },
       {
         // properties — prune-aware, like eventKinds (see `required` above).
+        // An already-cleared empty object is not a removal: flagging it would
+        // re-report an update on every apply instead of converging.
         name: "properties",
         changed: (d, r) =>
           d.properties !== undefined
             ? !deepEqual(d.properties, r.properties)
-            : prune && r.properties !== undefined,
+            : prune &&
+              r.properties !== undefined &&
+              Object.keys(r.properties).length > 0,
       },
       {
         // Derived types store metadata_schema verbatim (no inferred superset),

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -432,16 +432,20 @@ function diffEntityType(
             : prune && r.eventKinds !== undefined,
       },
       {
-        // Resolution policy — declared (config-owned) only. When declared, diff
-        // against the remote x-lobu-resolution and set on change. When omitted,
-        // never churns: an out-of-band authored policy is preserved (the server
-        // keeps it), matching the carry-forward in upsertEntityType.
+        // Resolution policy — prune-aware, like eventKinds. Declared: diff
+        // against the remote x-lobu-resolution and set on change. Omitted +
+        // prune: a present remote policy is a removal (apply clears it).
+        // Omitted + no prune: unmanaged, never churns — an out-of-band authored
+        // policy is preserved (the server keeps it), matching the carry-forward
+        // in upsertEntityType.
         name: "resolutionPolicy",
         changed: (d, r) => {
-          if (d.resolutionPolicy === undefined) return false;
-          const desired = d.resolutionPolicy["x-lobu-resolution"];
-          const remote = r.schemaExtras?.["x-lobu-resolution"];
-          return !deepEqual(desired, remote);
+          if (d.resolutionPolicy !== undefined) {
+            const desired = d.resolutionPolicy["x-lobu-resolution"];
+            const remote = r.schemaExtras?.["x-lobu-resolution"];
+            return !deepEqual(desired, remote);
+          }
+          return prune && r.schemaExtras?.["x-lobu-resolution"] !== undefined;
         },
       },
       {

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -416,6 +416,19 @@ function diffEntityType(
             : prune && r.eventKinds !== undefined,
       },
       {
+        // Resolution policy — declared (config-owned) only. When declared, diff
+        // against the remote x-lobu-resolution and set on change. When omitted,
+        // never churns: an out-of-band authored policy is preserved (the server
+        // keeps it), matching the carry-forward in upsertEntityType.
+        name: "resolutionPolicy",
+        changed: (d, r) => {
+          if (d.resolutionPolicy === undefined) return false;
+          const desired = d.resolutionPolicy["x-lobu-resolution"];
+          const remote = r.schemaExtras?.["x-lobu-resolution"];
+          return !deepEqual(desired, remote);
+        },
+      },
+      {
         // View template — prune-aware. Declared: diff against the remote current
         // default (apply sets on change). Omitted + prune: a present remote
         // template is a removal (apply clears it). Omitted + no prune: unmanaged

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -384,11 +384,21 @@ function diffEntityType(
       },
       {
         name: "required",
-        changed: (d, r) => !deepEqual(d.required ?? [], r.required ?? []),
+        changed: (d, r) =>
+          d.required !== undefined
+            ? !deepEqual(d.required, r.required ?? [])
+            : false,
       },
       {
+        // Declared-only: a config that omits `properties` does not own them, so
+        // they must not churn — otherwise an extension-only declaration (e.g.
+        // resolutionPolicy) re-reports a properties update on every apply while
+        // the upsert just round-trips the live core.
         name: "properties",
-        changed: (d, r) => !deepEqual(d.properties, r.properties),
+        changed: (d, r) =>
+          d.properties !== undefined
+            ? !deepEqual(d.properties, r.properties)
+            : false,
       },
       {
         // Derived types store metadata_schema verbatim (no inferred superset),

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -446,29 +446,31 @@ function mapEntityType(entity: EntityType): DesiredEntityType {
       );
     }
   }
-  // Fail loud on malformed resolution rules: the server silently ignores rules
-  // that fail its own shape check, which would silently downgrade the policy to
-  // the default (email/phone → review).
+  // Fail loud on malformed resolution rules: the server drops invalid rules,
+  // which can silently disable the intended matching policy.
   if (entity.resolutionPolicy) {
-    const ruleErrors = (entity.resolutionPolicy.rules ?? []).flatMap(
-      (rule, index) => {
-        const fields =
-          Array.isArray(rule.fields) &&
-          rule.fields.every((f) => typeof f === "string" && f.trim())
-            ? rule.fields
-            : null;
-        const normalizerOk =
-          rule.normalizer === "email" ||
-          rule.normalizer === "phone" ||
-          rule.normalizer === "exact";
-        const onMatchOk =
-          rule.onMatch === "auto_merge" || rule.onMatch === "review";
-        if (fields && fields.length > 0 && normalizerOk && onMatchOk) return [];
-        return [
-          `rule ${index}: expected { fields: string[], normalizer: "email"|"phone"|"exact", onMatch: "auto_merge"|"review" }`,
-        ];
-      }
-    );
+    if (!Array.isArray(entity.resolutionPolicy.rules)) {
+      throw new ValidationError(
+        `entity type "${entity.key}" has invalid resolutionPolicy: expected rules to be an array`
+      );
+    }
+    const ruleErrors = entity.resolutionPolicy.rules.flatMap((rule, index) => {
+      const fields =
+        Array.isArray(rule.fields) &&
+        rule.fields.every((f) => typeof f === "string" && f.trim())
+          ? rule.fields
+          : null;
+      const normalizerOk =
+        rule.normalizer === "email" ||
+        rule.normalizer === "phone" ||
+        rule.normalizer === "exact";
+      const onMatchOk =
+        rule.onMatch === "auto_merge" || rule.onMatch === "review";
+      if (fields && fields.length > 0 && normalizerOk && onMatchOk) return [];
+      return [
+        `rule ${index}: expected { fields: string[], normalizer: "email"|"phone"|"exact", onMatch: "auto_merge"|"review" }`,
+      ];
+    });
     if (ruleErrors.length > 0) {
       throw new ValidationError(
         `entity type "${entity.key}" has invalid resolutionPolicy: ${ruleErrors.join("; ")}`

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -446,6 +446,35 @@ function mapEntityType(entity: EntityType): DesiredEntityType {
       );
     }
   }
+  // Fail loud on malformed resolution rules: the server silently ignores rules
+  // that fail its own shape check, which would silently downgrade the policy to
+  // the default (email/phone → review).
+  if (entity.resolutionPolicy) {
+    const ruleErrors = (entity.resolutionPolicy.rules ?? []).flatMap(
+      (rule, index) => {
+        const fields =
+          Array.isArray(rule.fields) &&
+          rule.fields.every((f) => typeof f === "string" && f.trim())
+            ? rule.fields
+            : null;
+        const normalizerOk =
+          rule.normalizer === "email" ||
+          rule.normalizer === "phone" ||
+          rule.normalizer === "exact";
+        const onMatchOk =
+          rule.onMatch === "auto_merge" || rule.onMatch === "review";
+        if (fields && fields.length > 0 && normalizerOk && onMatchOk) return [];
+        return [
+          `rule ${index}: expected { fields: string[], normalizer: "email"|"phone"|"exact", onMatch: "auto_merge"|"review" }`,
+        ];
+      }
+    );
+    if (ruleErrors.length > 0) {
+      throw new ValidationError(
+        `entity type "${entity.key}" has invalid resolutionPolicy: ${ruleErrors.join("; ")}`
+      );
+    }
+  }
   return {
     slug: entity.key,
     ...(entity.name ? { name: entity.name } : {}),
@@ -456,6 +485,17 @@ function mapEntityType(entity: EntityType): DesiredEntityType {
     // on both sides and never churns the diff (mirrors `backing`/`metrics`).
     ...(entity.eventKinds && Object.keys(entity.eventKinds).length > 0
       ? { eventKinds: entity.eventKinds }
+      : {}),
+    // Resolution policy lowered to the raw metadata_schema key the server reads.
+    // Declared only when present so a type without one never churns the diff.
+    ...(entity.resolutionPolicy
+      ? {
+          resolutionPolicy: {
+            "x-lobu-resolution": {
+              rules: entity.resolutionPolicy.rules,
+            },
+          },
+        }
       : {}),
     // View template included only when declared so absence never churns the diff
     // (a no-prune apply leaves any UI-authored template untouched).

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -107,6 +107,23 @@ export interface EntityType {
    */
   eventKinds?: Record<string, EntityEventKind>;
   /**
+   * Entity-resolution policy (the `x-lobu-resolution` metadata_schema key the
+   * server reads to decide whether duplicate entities sharing a normalized
+   * identity auto-merge or queue human review). Declared here so the policy is
+   * git-audited like the rest of the schema; `lobu apply` folds it into the
+   * type's metadata_schema. A rule's `fields` are metadata keys or identity
+   * namespaces (e.g. `email`), `normalizer` is `email` | `phone` | `exact`, and
+   * `onMatch` is `auto_merge` | `review`. When the key is absent the server
+   * falls back to defaults (email/phone → review).
+   */
+  resolutionPolicy?: {
+    rules: Array<{
+      fields: string[];
+      normalizer: "email" | "phone" | "exact";
+      onMatch: "auto_merge" | "review";
+    }>;
+  };
+  /**
    * Default view template (render-DSL root node, optionally with a `data_sources`
    * key) for this entity type's detail page. Applied declaratively and
    * git-audited. Under `prune`, omitting it clears any existing template (the

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -113,8 +113,8 @@ export interface EntityType {
    * git-audited like the rest of the schema; `lobu apply` folds it into the
    * type's metadata_schema. A rule's `fields` are metadata keys or identity
    * namespaces (e.g. `email`), `normalizer` is `email` | `phone` | `exact`, and
-   * `onMatch` is `auto_merge` | `review`. When the key is absent the server
-   * falls back to defaults (email/phone → review).
+   * `onMatch` is `auto_merge` | `review`. When the key is absent, `person`
+   * falls back to email/phone review rules; other entity types have no rules.
    */
   resolutionPolicy?: {
     rules: Array<{

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -204,18 +204,23 @@ describe('Gmail person attribution rule', () => {
     expect(new GmailConnector().definition.version).toBe('1.0.4');
   });
 
-  test('autoCreate is on but gated on metadata.person_relevant — promotion is interaction/human driven', () => {
+  test('autoCreate is gated on person_relevant, with a legacy replied rule for pre-refresh payloads', () => {
     const connector = new GmailConnector();
     const rules = connector.definition.feeds.threads.eventKinds.thread.attributions;
-    expect(rules).toHaveLength(1);
-    const rule = rules[0];
-    expect(rule.role).toBe('authored_by');
-    expect(rule.autoCreate).toBe(true);
-    expect(rule.target.entityType).toBe('person');
-    expect(rule.target.createWhen).toEqual({ path: 'metadata.person_relevant', equals: true });
-    expect(rule.target.identities).toEqual([
-      { namespace: 'email', eventPath: 'metadata.from_email' },
-    ]);
+    expect(rules).toHaveLength(2);
+    const byGate = Object.fromEntries(
+      rules.map((rule) => [JSON.stringify(rule.target.createWhen), rule])
+    );
+    expect(byGate['{"path":"metadata.person_relevant","equals":true}']).toBeDefined();
+    expect(byGate['{"path":"metadata.replied","equals":true}']).toBeDefined();
+    for (const rule of rules) {
+      expect(rule.role).toBe('authored_by');
+      expect(rule.autoCreate).toBe(true);
+      expect(rule.target.entityType).toBe('person');
+      expect(rule.target.identities).toEqual([
+        { namespace: 'email', eventPath: 'metadata.from_email' },
+      ]);
+    }
   });
 });
 

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -6,12 +6,12 @@ mock.module('@lobu/connector-sdk', () => connectorSdkMock());
 // biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
 let GmailConnector: any;
 // biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
-let isHumanSender: any;
+let isPersonRelevantSender: any;
 
 beforeAll(async () => {
   const mod = await import('../google_gmail');
   GmailConnector = mod.default;
-  isHumanSender = mod.isHumanSender;
+  isPersonRelevantSender = mod.isPersonRelevantSender;
 });
 
 interface FakeMessage {
@@ -19,6 +19,9 @@ interface FakeMessage {
   labelIds?: string[];
   from?: string;
   to?: string;
+  cc?: string;
+  listId?: string;
+  precedence?: string;
   date?: string;
 }
 
@@ -32,11 +35,11 @@ interface FakeThread {
  * lookups from the given fixtures. Header values come from the per-message
  * `from`/`date` fields; snippets are constant.
  */
-function fakeHttp(threads: FakeThread[], onRequest?: () => void) {
+function fakeHttp(threads: FakeThread[], onRequest?: (url: string) => void) {
   const byId = new Map(threads.map((t) => [t.id, t]));
   return {
     raw: async (url: string) => {
-      onRequest?.();
+      onRequest?.(url);
       const u = new URL(url);
       const threadMatch = u.pathname.match(/\/threads\/([^/]+)$/);
       const body = threadMatch
@@ -69,6 +72,9 @@ function toThreadResponse(thread: FakeThread | undefined) {
           { name: 'Subject', value: `subject ${thread.id}` },
           { name: 'From', value: m.from ?? 'Some One <someone@example.com>' },
           ...(m.to ? [{ name: 'To', value: m.to }] : []),
+          ...(m.cc ? [{ name: 'Cc', value: m.cc }] : []),
+          ...(m.listId ? [{ name: 'List-Id', value: m.listId }] : []),
+          ...(m.precedence ? [{ name: 'Precedence', value: m.precedence }] : []),
           { name: 'Date', value: m.date ?? '2026-07-01T10:00:00Z' },
         ],
       },
@@ -103,6 +109,35 @@ test('the checkpoint precedes sync requests so messages arriving during sync rem
 
   expect(firstRequestAt).toBeFinite();
   expect(new Date(result.checkpoint.last_sync_at).getTime()).toBeLessThanOrEqual(firstRequestAt);
+});
+
+test('person-building sync requests its label union and attribution headers', async () => {
+  const urls: string[] = [];
+  const connector = new GmailConnector();
+  connector.createClient = () =>
+    fakeHttp(
+      [
+        {
+          id: 't-human',
+          messages: [
+            { id: 'm1', labelIds: ['INBOX'], from: 'Jane Doe <jane@acme.example>' },
+          ],
+        },
+      ],
+      (url) => urls.push(url)
+    );
+
+  await connector.sync({
+    config: { labels: [' INBOX ', 'SENT'], human_senders_only: true },
+    credentials: { accessToken: 'tok' },
+    checkpoint: {},
+  });
+
+  expect(new URL(urls[0]).searchParams.get('q')).toContain('{label:INBOX label:SENT}');
+  const threadUrl = urls.find((url) => url.includes('/threads/t-human')) ?? '';
+  for (const header of ['To', 'Cc', 'List-Id', 'Precedence']) {
+    expect(threadUrl).toContain(`metadataHeaders=${header}`);
+  }
 });
 
 describe('Gmail replied signal (promote-on-interaction)', () => {
@@ -153,6 +188,10 @@ describe('Gmail replied signal (promote-on-interaction)', () => {
 });
 
 describe('Gmail person attribution rule', () => {
+  test('bumps the connector version for the changed sync contract', () => {
+    expect(new GmailConnector().definition.version).toBe('1.0.4');
+  });
+
   test('autoCreate is on but gated on metadata.person_relevant — promotion is interaction/human driven', () => {
     const connector = new GmailConnector();
     const rules = connector.definition.feeds.threads.eventKinds.thread.attributions;
@@ -168,16 +207,17 @@ describe('Gmail person attribution rule', () => {
   });
 });
 
-describe('isHumanSender', () => {
-  test('replied threads are always human regardless of address shape', () => {
-    expect(isHumanSender('promo@brand.example', 'Brand', true)).toBe(true);
-    expect(isHumanSender('noreply@brand.example', 'No Reply', true)).toBe(true);
+describe('isPersonRelevantSender', () => {
+  test('a reply makes a non-role sender relevant but never turns a role mailbox into a person', () => {
+    expect(isPersonRelevantSender('promo@brand.example', 'Brand', true)).toBe(true);
+    expect(isPersonRelevantSender('noreply@brand.example', 'No Reply', true)).toBe(false);
   });
 
   test('automated / shared local-parts never pass on receipt alone', () => {
     for (const email of [
       'noreply@brand.example',
       'no-reply@brand.example',
+      'noreply+receipt@brand.example',
       'donotreply@brand.example',
       'bounce@mailer.example',
       'mailer-daemon@example.com',
@@ -191,28 +231,28 @@ describe('isHumanSender', () => {
       'team@acme.example',
       'newsletter@acme.example',
     ]) {
-      expect(isHumanSender(email, 'Acme', false)).toBe(false);
+      expect(isPersonRelevantSender(email, 'Acme', false)).toBe(false);
     }
   });
 
   test('consumer-mail domains pass even without a display name', () => {
-    expect(isHumanSender('jane.doe@gmail.com', null, false)).toBe(true);
-    expect(isHumanSender('bob@proton.me', '', false)).toBe(true);
+    expect(isPersonRelevantSender('jane.doe@gmail.com', null, false)).toBe(true);
+    expect(isPersonRelevantSender('bob@proton.me', '', false)).toBe(true);
   });
 
   test('a human-looking name passes a corporate domain', () => {
-    expect(isHumanSender('john.smith@acme.example', 'John Smith', false)).toBe(true);
+    expect(isPersonRelevantSender('john.smith@acme.example', 'John Smith', false)).toBe(true);
   });
 
   test('single-word brands and unnamed corporate addresses fail', () => {
-    expect(isHumanSender('team@linkedin.example', 'LinkedIn', false)).toBe(false);
-    expect(isHumanSender('john.smith@acme.example', null, false)).toBe(false);
+    expect(isPersonRelevantSender('team@linkedin.example', 'LinkedIn', false)).toBe(false);
+    expect(isPersonRelevantSender('john.smith@acme.example', null, false)).toBe(false);
   });
 
   test('missing / unparseable addresses are never human', () => {
-    expect(isHumanSender(null, 'John Smith', false)).toBe(false);
-    expect(isHumanSender('not-an-email', 'John Smith', false)).toBe(false);
-    expect(isHumanSender('', 'John Smith', false)).toBe(false);
+    expect(isPersonRelevantSender(null, 'John Smith', false)).toBe(false);
+    expect(isPersonRelevantSender('not-an-email', 'John Smith', false)).toBe(false);
+    expect(isPersonRelevantSender('', 'John Smith', false)).toBe(false);
   });
 });
 
@@ -281,6 +321,134 @@ describe('Gmail human_senders_only sync mode', () => {
     expect(events[0].metadata.person_relevant).toBe(true);
     expect(events[0].metadata.from_email).toBe('bob@example.com');
     expect(events[0].metadata.from_name).toBe('Bob Smith');
+  });
+
+  test('skips a role recipient and attributes a human beside it', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-mixed',
+          messages: [
+            {
+              id: 'm1',
+              labelIds: ['SENT'],
+              from: 'Me <me@example.com>',
+              to: 'support@vendor.example, Jane Doe <jane@acme.example>',
+            },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.from_email).toBe('jane@acme.example');
+  });
+
+  test('attributes a human reply instead of the automated sender that opened the thread', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-bot-first',
+          messages: [
+            {
+              id: 'm1',
+              labelIds: ['INBOX'],
+              from: 'Notifications <notifications@vendor.example>',
+            },
+            {
+              id: 'm2',
+              labelIds: ['INBOX'],
+              from: 'Jane Doe <jane@acme.example>',
+            },
+            {
+              id: 'm3',
+              labelIds: ['SENT'],
+              from: 'Me <me@example.com>',
+              to: 'Jane Doe <jane@acme.example>',
+            },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.from_email).toBe('jane@acme.example');
+  });
+
+  test('does not count a case-varying copy of the mailbox owner as a reply', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-self-copy',
+          messages: [
+            {
+              id: 'm1',
+              labelIds: ['SENT'],
+              from: 'Me <ME@example.com>',
+              to: 'Jane Doe <jane@acme.example>',
+            },
+            { id: 'm2', labelIds: ['INBOX'], from: 'me@EXAMPLE.com' },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.replied).toBe(false);
+    expect(events[0].metadata.from_email).toBe('jane@acme.example');
+  });
+
+  test('fails closed on outbound attribution when the mailbox address is unknown', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-no-self',
+          messages: [
+            {
+              id: 'm1',
+              labelIds: ['SENT'],
+              from: '',
+              to: 'Jane Doe <jane@acme.example>',
+            },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events).toHaveLength(0);
+  });
+
+  test('drops list threads and unreplied wide broadcasts', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-list',
+          messages: [
+            {
+              id: 'm1',
+              labelIds: ['SENT'],
+              from: 'Me <me@example.com>',
+              to: 'Jane Doe <jane@acme.example>',
+              listId: '<people.vendor.example>',
+            },
+          ],
+        },
+        {
+          id: 't-blast',
+          messages: [
+            {
+              id: 'm1',
+              labelIds: ['SENT'],
+              from: 'Me <me@example.com>',
+              to: 'Alice One <a@one.example>, Bob Two <b@two.example>',
+              cc: 'Carol Three <c@three.example>, David Four <d@four.example>',
+            },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events).toHaveLength(0);
   });
 
   test('default mode keeps replied semantics and stamps person_relevant = replied', async () => {

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -532,6 +532,55 @@ describe('Gmail human_senders_only sync mode', () => {
     expect(events).toHaveLength(0);
   });
 
+  test('attributes a human Cc recipient when the To is a role address', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-cc',
+          messages: [
+            {
+              id: 'm1',
+              labelIds: ['SENT'],
+              from: 'Me <me@example.com>',
+              to: 'support@vendor.example',
+              cc: 'Jane Doe <jane@acme.example>',
+            },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.from_email).toBe('jane@acme.example');
+  });
+
+  test('attributes a human recipient on a later sent message, not the first', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-later-sent',
+          messages: [
+            {
+              id: 'm1',
+              labelIds: ['SENT'],
+              from: 'Me <me@example.com>',
+              to: 'team@vendor.example',
+            },
+            {
+              id: 'm2',
+              labelIds: ['SENT'],
+              from: 'Me <me@example.com>',
+              to: 'Bob Smith <bob@example.com>',
+            },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.from_email).toBe('bob@example.com');
+  });
+
   test('failed thread GETs consume max_results (cap bounds API calls)', async () => {
     const connector = new GmailConnector();
     const urls: string[] = [];

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -5,16 +5,20 @@ mock.module('@lobu/connector-sdk', () => connectorSdkMock());
 
 // biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
 let GmailConnector: any;
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let isHumanSender: any;
 
 beforeAll(async () => {
   const mod = await import('../google_gmail');
   GmailConnector = mod.default;
+  isHumanSender = mod.isHumanSender;
 });
 
 interface FakeMessage {
   id: string;
   labelIds?: string[];
   from?: string;
+  to?: string;
   date?: string;
 }
 
@@ -64,6 +68,7 @@ function toThreadResponse(thread: FakeThread | undefined) {
         headers: [
           { name: 'Subject', value: `subject ${thread.id}` },
           { name: 'From', value: m.from ?? 'Some One <someone@example.com>' },
+          ...(m.to ? [{ name: 'To', value: m.to }] : []),
           { name: 'Date', value: m.date ?? '2026-07-01T10:00:00Z' },
         ],
       },
@@ -71,11 +76,11 @@ function toThreadResponse(thread: FakeThread | undefined) {
   };
 }
 
-async function syncThreads(threads: FakeThread[]) {
+async function syncThreads(threads: FakeThread[], config: Record<string, unknown> = {}) {
   const connector = new GmailConnector();
   connector.createClient = () => fakeHttp(threads);
   const result = await connector.sync({
-    config: {},
+    config,
     credentials: { accessToken: 'tok' },
     checkpoint: {},
   });
@@ -148,7 +153,7 @@ describe('Gmail replied signal (promote-on-interaction)', () => {
 });
 
 describe('Gmail person attribution rule', () => {
-  test('autoCreate is on but gated on metadata.replied — promotion is interaction-driven', () => {
+  test('autoCreate is on but gated on metadata.person_relevant — promotion is interaction/human driven', () => {
     const connector = new GmailConnector();
     const rules = connector.definition.feeds.threads.eventKinds.thread.attributions;
     expect(rules).toHaveLength(1);
@@ -156,10 +161,141 @@ describe('Gmail person attribution rule', () => {
     expect(rule.role).toBe('authored_by');
     expect(rule.autoCreate).toBe(true);
     expect(rule.target.entityType).toBe('person');
-    expect(rule.target.createWhen).toEqual({ path: 'metadata.replied', equals: true });
+    expect(rule.target.createWhen).toEqual({ path: 'metadata.person_relevant', equals: true });
     expect(rule.target.identities).toEqual([
       { namespace: 'email', eventPath: 'metadata.from_email' },
     ]);
+  });
+});
+
+describe('isHumanSender', () => {
+  test('replied threads are always human regardless of address shape', () => {
+    expect(isHumanSender('promo@brand.example', 'Brand', true)).toBe(true);
+    expect(isHumanSender('noreply@brand.example', 'No Reply', true)).toBe(true);
+  });
+
+  test('automated / shared local-parts never pass on receipt alone', () => {
+    for (const email of [
+      'noreply@brand.example',
+      'no-reply@brand.example',
+      'donotreply@brand.example',
+      'bounce@mailer.example',
+      'mailer-daemon@example.com',
+      'postmaster@example.com',
+      'info@acme.example',
+      'marketing@acme.example',
+      'support@acme.example',
+      'hello@acme.example',
+      'notifications@acme.example',
+      'alerts@acme.example',
+      'team@acme.example',
+      'newsletter@acme.example',
+    ]) {
+      expect(isHumanSender(email, 'Acme', false)).toBe(false);
+    }
+  });
+
+  test('consumer-mail domains pass even without a display name', () => {
+    expect(isHumanSender('jane.doe@gmail.com', null, false)).toBe(true);
+    expect(isHumanSender('bob@proton.me', '', false)).toBe(true);
+  });
+
+  test('a human-looking name passes a corporate domain', () => {
+    expect(isHumanSender('john.smith@acme.example', 'John Smith', false)).toBe(true);
+  });
+
+  test('single-word brands and unnamed corporate addresses fail', () => {
+    expect(isHumanSender('team@linkedin.example', 'LinkedIn', false)).toBe(false);
+    expect(isHumanSender('john.smith@acme.example', null, false)).toBe(false);
+  });
+
+  test('missing / unparseable addresses are never human', () => {
+    expect(isHumanSender(null, 'John Smith', false)).toBe(false);
+    expect(isHumanSender('not-an-email', 'John Smith', false)).toBe(false);
+    expect(isHumanSender('', 'John Smith', false)).toBe(false);
+  });
+});
+
+describe('Gmail human_senders_only sync mode', () => {
+  test('drops brand/automated threads and emits only person-relevant ones', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-brand',
+          messages: [
+            { id: 'm1', labelIds: ['INBOX'], from: 'Brand <promo@brand.example>' },
+          ],
+        },
+        {
+          id: 't-human',
+          messages: [
+            { id: 'm1', labelIds: ['INBOX'], from: 'Jane Doe <jane@acme.example>' },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events.map((e) => e.origin_id).sort()).toEqual(['t-human']);
+    expect(events[0].metadata.person_relevant).toBe(true);
+    expect(events[0].metadata.replied).toBe(false);
+    expect(events[0].metadata.from_email).toBe('jane@acme.example');
+  });
+
+  test('stamps person_relevant on replied threads and keeps them', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-alice',
+          messages: [
+            { id: 'm1', labelIds: ['INBOX'], from: 'Alice <alice@example.com>' },
+            { id: 'm2', labelIds: ['SENT'], from: 'Me <me@example.com>' },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.person_relevant).toBe(true);
+    expect(events[0].metadata.replied).toBe(true);
+  });
+
+  test('an outbound-only thread attributes the recipient via the To header', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-out',
+          messages: [
+            {
+              id: 'm1',
+              labelIds: ['SENT'],
+              from: 'Me <me@example.com>',
+              to: 'Bob Smith <bob@example.com>',
+            },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.replied).toBe(false);
+    expect(events[0].metadata.person_relevant).toBe(true);
+    expect(events[0].metadata.from_email).toBe('bob@example.com');
+    expect(events[0].metadata.from_name).toBe('Bob Smith');
+  });
+
+  test('default mode keeps replied semantics and stamps person_relevant = replied', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-alice',
+        messages: [
+          { id: 'm1', labelIds: ['INBOX'], from: 'Alice <alice@example.com>' },
+          { id: 'm2', labelIds: ['SENT'], from: 'Me <me@example.com>' },
+        ],
+      },
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.replied).toBe(true);
+    expect(events[0].metadata.person_relevant).toBe(true);
   });
 });
 

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -261,6 +261,11 @@ describe('isPersonRelevantSender', () => {
     expect(isPersonRelevantSender('john.smith@acme.example', null, false)).toBe(false);
   });
 
+  test('plural role local-parts are rejected too (newsletters, contacts)', () => {
+    expect(isPersonRelevantSender('newsletters@acme.example', 'Acme Newsletters', false)).toBe(false);
+    expect(isPersonRelevantSender('contacts@acme.example', 'Acme Contacts', false)).toBe(false);
+  });
+
   test('missing / unparseable addresses are never human', () => {
     expect(isPersonRelevantSender(null, 'John Smith', false)).toBe(false);
     expect(isPersonRelevantSender('not-an-email', 'John Smith', false)).toBe(false);

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -509,6 +509,29 @@ describe('Gmail human_senders_only sync mode', () => {
     expect(events).toHaveLength(0);
   });
 
+  test('a self-authored DRAFT is never attributed as the counterparty', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-draft',
+          messages: [
+            // Role-address INBOX message first, then an unsent self-authored draft.
+            { id: 'm1', labelIds: ['INBOX'], from: 'Support <support@vendor.example>' },
+            {
+              id: 'm2',
+              labelIds: ['DRAFT'],
+              from: 'Me <me@example.com>',
+              to: 'Jane Doe <jane@acme.example>',
+            },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    // The DRAFT is self-authored — no person-relevant counterparty exists.
+    expect(events).toHaveLength(0);
+  });
+
   test('failed thread GETs consume max_results (cap bounds API calls)', async () => {
     const connector = new GmailConnector();
     const urls: string[] = [];

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -33,15 +33,27 @@ interface FakeThread {
 /**
  * Fake Gmail HTTP client: serves threads.list (one page) and threads/<id>
  * lookups from the given fixtures. Header values come from the per-message
- * `from`/`date` fields; snippets are constant.
+ * `from`/`date` fields; snippets are constant. `failThreadIds` respond 404.
  */
-function fakeHttp(threads: FakeThread[], onRequest?: (url: string) => void) {
+function fakeHttp(
+  threads: FakeThread[],
+  onRequest?: (url: string) => void,
+  failThreadIds: ReadonlySet<string> = new Set()
+) {
   const byId = new Map(threads.map((t) => [t.id, t]));
   return {
     raw: async (url: string) => {
       onRequest?.(url);
       const u = new URL(url);
       const threadMatch = u.pathname.match(/\/threads\/([^/]+)$/);
+      if (threadMatch && failThreadIds.has(threadMatch[1])) {
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({}),
+          text: async () => '',
+        } as unknown as Response;
+      }
       const body = threadMatch
         ? toThreadResponse(byId.get(threadMatch[1]))
         : { threads: threads.map((t) => ({ id: t.id, historyId: '1', snippet: 's' })) };
@@ -464,6 +476,62 @@ describe('Gmail human_senders_only sync mode', () => {
     expect(events).toHaveLength(1);
     expect(events[0].metadata.replied).toBe(true);
     expect(events[0].metadata.person_relevant).toBe(true);
+  });
+
+  test('a Gmail plus-tag copy of the mailbox owner is never treated as external', async () => {
+    const events = await syncThreads(
+      [
+        {
+          id: 't-tag-self',
+          messages: [
+            { id: 'm1', labelIds: ['SENT'], from: 'Me <me+archive@example.com>' },
+            {
+              id: 'm2',
+              labelIds: ['INBOX'],
+              from: 'me@example.com',
+            },
+          ],
+        },
+      ],
+      { human_senders_only: true }
+    );
+    // The INBOX copy is the owner via a +tag alias, not a reply from a person.
+    expect(events).toHaveLength(0);
+  });
+
+  test('failed thread GETs consume max_results (cap bounds API calls)', async () => {
+    const connector = new GmailConnector();
+    const urls: string[] = [];
+    connector.createClient = () =>
+      fakeHttp(
+        [
+          {
+            id: 't-missing',
+            messages: [
+              { id: 'm1', labelIds: ['INBOX'], from: 'Bob <bob@acme.example>' },
+            ],
+          },
+          {
+            id: 't-ok',
+            messages: [
+              { id: 'm1', labelIds: ['INBOX'], from: 'Jane Doe <jane@acme.example>' },
+            ],
+          },
+        ],
+        (url) => urls.push(url),
+        new Set(['t-missing'])
+      );
+
+    await connector.sync({
+      config: { max_results: 1, human_senders_only: true },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    // max_results=1: the 404 consumes the cap, so only ONE thread GET runs.
+    const threadGets = urls.filter((url) => url.includes('/threads/'));
+    expect(threadGets).toHaveLength(1);
+    expect(threadGets[0]).toContain('t-missing');
   });
 });
 

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -1139,7 +1139,7 @@ const normalizeSelfEmail = (email: string | null | undefined): string => {
  * (info@, marketing@, support@, hello@, …). Matched against the lowercased
  * local part of the From address.
  */
-const AUTOMATED_LOCAL_PARTS = /^(?:no[._-]?reply|do[._-]?not[._-]?reply|donotreply|noreply|no\.reply|bounce|mailer[._-]?daemon|postmaster|abuse|notif(?:ications?)?|alert(?:s)?|support|team|info|news(?:letter)?|market(?:ing)?|contact|updates?|jobs|careers|press|media|events?|webmaster|automated|robot|hello|sales|billing|accounts|security|admin|root)$/;
+const AUTOMATED_LOCAL_PARTS = /^(?:no[._-]?reply|do[._-]?not[._-]?reply|donotreply|noreply|no\.reply|bounce|mailer[._-]?daemon|postmaster|abuse|notif(?:ications?|y)?|alert(?:s)?|support|team|info|news(?:letter)?s?|market(?:ing)?s?|contact(?:s)?|update(?:s)?|jobs|careers|press|media|event(?:s)?|webmaster|automated|robot|hello|sales|billing|accounts|security|admin|root)$/;
 
 /**
  * Consumer mail providers — a bare address here is overwhelmingly a personal

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -986,12 +986,28 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       ? inbound.find((sender) => isPersonRelevantSender(sender.email, sender.name, replied))
       : inbound[0];
 
-    if (!selected && humanSendersOnly && sentMessages[0] && hasKnownSelf) {
-      selected = this.parseAddressList(this.getHeader(sentMessages[0], 'To')).find(
-        (sender) =>
-          !isSelf(sender.email) &&
-          isPersonRelevantSender(sender.email, sender.name, false)
-      );
+    // Outbound-only fallback: no plausible human inbound sender, so look for a
+    // plausible human RECIPIENT across every sent message's To+Cc — the first
+    // sent message may target a role address while a human sits in Cc or on a
+    // later sent message. `selectedSentMessage` remembers which message carried
+    // the recipient so the broadcast-cap check counts that message, not the
+    // first sent one.
+    let selectedSentMessage: GmailMessage | undefined;
+    if (!selected && humanSendersOnly && hasKnownSelf) {
+      for (const sentMessage of sentMessages) {
+        const recipient = this.parseAddressList(
+          `${this.getHeader(sentMessage, 'To') ?? ''}, ${this.getHeader(sentMessage, 'Cc') ?? ''}`
+        ).find(
+          (sender) =>
+            !isSelf(sender.email) &&
+            isPersonRelevantSender(sender.email, sender.name, false)
+        );
+        if (recipient) {
+          selected = recipient;
+          selectedSentMessage = sentMessage;
+          break;
+        }
+      }
     }
 
     const fromEmail = selected?.email ?? null;
@@ -1001,7 +1017,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
         hasKnownSelf &&
         !this.isListThread(messages) &&
         (replied ||
-          this.externalRecipientCount(sentMessages[0], isSelf) <= BROADCAST_RECIPIENT_CAP)
+          this.externalRecipientCount(selectedSentMessage, isSelf) <= BROADCAST_RECIPIENT_CAP)
       : replied;
 
     return {

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -418,6 +418,9 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       // Fetch each thread with metadata format
       for (const threadStub of threads) {
         try {
+          // Count the GET attempt up front so failed/empty/malformed responses
+          // also consume max_results — the cap bounds API calls, not just events.
+          inspected++;
           const threadUrl = `${this.BASE_URL}/threads/${threadStub.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Cc&metadataHeaders=Date&metadataHeaders=List-Id&metadataHeaders=Precedence`;
           const threadResponse = await http.raw(threadUrl);
 
@@ -426,8 +429,6 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
           const thread = (await threadResponse.json()) as GmailThreadGetResponse;
 
           if (!thread.messages || thread.messages.length === 0) continue;
-
-          inspected++;
 
           const firstMessage = thread.messages[0];
           const attribution = this.resolvePersonAttribution(
@@ -473,10 +474,11 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
         } finally {
           // Filtering must not remove the per-thread API delay: a narrow feed
           // can reject most fetched threads and still has to respect Gmail.
+          // The cap check lives here too — a `continue` in the try (failed or
+          // filtered thread) must still consume max_results and halt.
           await sleep(this.RATE_LIMIT_MS);
+          if (inspected >= maxResults) break;
         }
-
-        if (inspected >= maxResults) break;
       }
 
       if (inspected >= maxResults) break;
@@ -931,11 +933,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     const selfAddresses = new Set(
       sentMessages
         .map((message) =>
-          normalizeEmail(this.parseFromHeader(this.getHeader(message, 'From') ?? '').email)
+          normalizeSelfEmail(this.parseFromHeader(this.getHeader(message, 'From') ?? '').email)
         )
         .filter(Boolean)
     );
-    const isSelf = (email: string): boolean => selfAddresses.has(normalizeEmail(email));
+    const isSelf = (email: string): boolean =>
+      selfAddresses.has(normalizeSelfEmail(email));
     const inbound = messages
       .filter((message) => !isSentMessage(message))
       .flatMap((message) => {
@@ -1116,6 +1119,19 @@ const isSentMessage = (message: GmailMessage): boolean =>
   (message.labelIds ?? []).includes('SENT');
 const normalizeEmail = (email: string | null | undefined): string =>
   (email ?? '').trim().toLowerCase();
+/**
+ * Canonicalize an address for SELF-detection (the mailbox owner): lowercase
+ * plus Gmail/Workspace `+tag` removal, so `me+archive@example.com` counts as
+ * the same mailbox as `me@example.com`. Only for self-vs-counterparty
+ * comparison — the event's from_email identity is kept verbatim.
+ */
+const normalizeSelfEmail = (email: string | null | undefined): string => {
+  const normalized = normalizeEmail(email);
+  const at = normalized.lastIndexOf('@');
+  if (at <= 0) return normalized;
+  const local = normalized.slice(0, at).split('+', 1)[0];
+  return `${local}@${normalized.slice(at + 1)}`;
+};
 
 /**
  * Local-parts that are almost never a human counterparty: automated/system

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -69,16 +69,15 @@ interface GmailCheckpoint {
 
 interface GmailConfig {
   label?: string;
-  /** Labels to union in the sync query (e.g. ["INBOX", "SENT"]). When set, overrides `label`. */
+  /** Non-empty labels to union in the sync query. Overrides `label`. */
   labels?: string[];
   max_results?: number;
   lookback_days?: number;
   /**
-   * Only emit threads whose counterparty is plausibly a human, and stamp every
-   * emitted thread `person_relevant`. Drives person minting/merging from a
-   * narrow, high-signal subset of the mailbox while everything else stays a
-   * virtual/live read. Receipt-only bulk senders (newsletters, no-reply,
-   * brand addresses) are dropped.
+   * Only emit person-relevant threads: replied non-role counterparties or
+   * unreplied senders/recipients that pass the human-address heuristic. Drives
+   * person minting/merging from a narrow subset of the mailbox while everything
+   * else stays a virtual/live read.
    */
   human_senders_only?: boolean;
 }
@@ -106,7 +105,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     name: 'Gmail',
     description:
       'Syncs Gmail threads, live-reads matching messages, and supports sending, drafts, and replies.',
-    version: '1.0.3',
+    version: '1.0.4',
     faviconDomain: 'mail.google.com',
     authSchema: {
       methods: [
@@ -139,7 +138,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
         name: 'Threads',
         requiredScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
         description:
-          'Collected feeds sync Gmail threads; virtual feeds return live matching messages. Collected sync powers contact promotion (replied attributions).',
+          'Collected feeds sync Gmail threads; virtual feeds return live matching messages. Collected sync powers person attribution.',
         // Collected remains the default: contact promotion + Behaviors need
         // durable events. Virtual is fully supported when the caller sets
         // virtual:true (query() / search() already implemented).
@@ -160,7 +159,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
               type: 'array',
               items: { type: 'string' },
               description:
-                'Labels to union in the sync query, e.g. ["INBOX", "SENT"]. When set, overrides `label` so outbound-initiated threads are covered.',
+                'Non-empty labels to union in the sync query, e.g. ["INBOX", "SENT"]. Overrides `label` so outbound-initiated threads are covered.',
             },
             max_results: {
               type: 'integer',
@@ -180,7 +179,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
               type: 'boolean',
               default: false,
               description:
-                'Emit only threads whose counterparty is plausibly a human sender (drives person building). Sets `person_relevant` and drops bulk/brand/auto threads.',
+                'Emit only person-relevant threads for person building: replied non-role counterparties or unreplied senders/recipients that pass the human-address heuristic.',
             },
           },
         },
@@ -198,12 +197,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
                 replied: {
                   type: 'boolean',
                   description:
-                    'True when the thread contains both a counterparty message and a mailbox-authored SENT-labeled message — the interaction signal that gates contact promotion.',
+                    'True when the thread contains both a non-self counterparty message and a mailbox-authored SENT-labeled message.',
                 },
                 person_relevant: {
                   type: 'boolean',
                   description:
-                    'True when the counterparty is plausibly a human sender (a replied thread, or a human-looking sender under human_senders_only). Gates person minting.',
+                    'True when the selected counterparty qualifies for person minting under the feed mode.',
                 },
               },
             },
@@ -214,14 +213,11 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
                 // is a sender — overwhelmingly brands, newsletters, and no-reply
                 // system addresses, all of which carry a from_name — so receipt
                 // alone must not mint a contact. The gate is `person_relevant`,
-                // computed by the connector: it is `replied` (a genuine
-                // bidirectional exchange) by default, and a "plausible human"
-                // heuristic when the feed opts into `human_senders_only`. Only
-                // person-relevant senders materialize a `person`; everything else
-                // still links to an existing contact on identity match. A thread
-                // replied to after its first sync re-syncs (the reply is a new
-                // message inside the `after:` window), so promotion follows the
-                // reply.
+                // computed by the connector: it is `replied` by default; the
+                // human_senders_only mode additionally admits human-looking
+                // unreplied counterparties and rejects role/list/broadcast noise.
+                // Only person-relevant senders materialize a `person`; everything
+                // else still links to an existing contact on identity match.
                 autoCreate: true,
                 target: {
                   entityType: 'person',
@@ -354,7 +350,9 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
 
     const label = ctx.config.label || 'INBOX';
     const labels = Array.isArray(ctx.config.labels)
-      ? ctx.config.labels.filter((l) => typeof l === 'string' && l.trim().length > 0)
+      ? ctx.config.labels
+          .filter((l) => typeof l === 'string' && l.trim().length > 0)
+          .map((l) => l.trim())
       : [];
     const maxResults = Math.min(ctx.config.max_results ?? 50, 500);
     const lookbackDays = ctx.config.lookback_days ?? 30;
@@ -379,18 +377,21 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     // threads — often the strongest "this is a real contact" signal — are covered.
     const query =
       labels.length > 0
-        ? `after:${afterEpochSeconds} (${labels.map((l) => `label:${l}`).join(' OR ')})`
+        ? `after:${afterEpochSeconds} {${labels.map((l) => `label:${l}`).join(' ')}}`
         : `after:${afterEpochSeconds} label:${label}`;
 
     const http = this.createClient(token);
     const events: EventEnvelope[] = [];
-    let totalCollected = 0;
+    // Bounds the threads FETCHED per run (each is an API call), independent of
+    // how many survive the person filter — a narrow feed must not scan the whole
+    // lookback just because most threads are rejected.
+    let inspected = 0;
 
     const pages = paginateByCursor<NonNullable<GmailThreadListResponse['threads']>[number], string>(
       async (pageToken) => {
         const params = new URLSearchParams({
           q: query,
-          maxResults: String(Math.min(100, maxResults - totalCollected)),
+          maxResults: String(Math.min(100, maxResults - inspected)),
         });
         if (pageToken) {
           params.set('pageToken', pageToken);
@@ -417,7 +418,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       // Fetch each thread with metadata format
       for (const threadStub of threads) {
         try {
-          const threadUrl = `${this.BASE_URL}/threads/${threadStub.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Date`;
+          const threadUrl = `${this.BASE_URL}/threads/${threadStub.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Cc&metadataHeaders=Date&metadataHeaders=List-Id&metadataHeaders=Precedence`;
           const threadResponse = await http.raw(threadUrl);
 
           if (!threadResponse.ok) continue;
@@ -426,22 +427,14 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
 
           if (!thread.messages || thread.messages.length === 0) continue;
 
+          inspected++;
+
           const firstMessage = thread.messages[0];
-          const isSent = (m: GmailMessage) => (m.labelIds ?? []).includes('SENT');
-          const sentMessage = thread.messages.find(isSent);
-          const inboundMessage = thread.messages.find((message) => !isSent(message));
-          // Prefer the first counterparty-authored message so an owner-started
-          // thread never promotes the mailbox owner's own address. When the
-          // thread is outbound-only (no reply yet), fall back to the sent
-          // message's To header so the recipient still surfaces.
-          const counterpartyMessage = inboundMessage ?? sentMessage;
+          const attribution = this.resolvePersonAttribution(
+            thread.messages,
+            humanSendersOnly
+          );
           const subject = this.getHeader(firstMessage, 'Subject') || '(no subject)';
-          const addressHeader =
-            counterpartyMessage === sentMessage
-              ? this.getHeader(counterpartyMessage, 'To')
-              : this.getHeader(counterpartyMessage, 'From');
-          const from = addressHeader || 'Unknown';
-          const { name: fromName, email: fromEmail } = this.parseFromHeader(from);
           const dateHeader = this.getHeader(firstMessage, 'Date');
           const occurredAt = dateHeader
             ? new Date(dateHeader)
@@ -449,29 +442,17 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
 
           if (Number.isNaN(occurredAt.getTime())) continue;
 
-          // A bidirectional exchange has at least one mailbox-authored message
-          // and one inbound counterparty message, regardless of who started it.
-          // An outbound-only thread (no reply yet) is NOT replied — the sent
-          // fallback exists so the recipient surfaces, not so it counts as an
-          // interaction.
-          const replied = inboundMessage !== undefined && sentMessage !== undefined;
-          // Person-relevance gates minting: `replied` by default; a "plausible
-          // human" heuristic when the feed opts into human_senders_only.
-          const personRelevant = humanSendersOnly
-            ? isHumanSender(fromEmail, fromName, replied)
-            : replied;
-
           // Under human_senders_only the sync is deliberately narrow — only
           // person-relevant threads are persisted (everything else stays a live
           // read), so the DB only holds the high-signal set that drives person
           // building.
-          if (humanSendersOnly && !personRelevant) continue;
+          if (humanSendersOnly && !attribution.personRelevant) continue;
 
           const event: EventEnvelope = {
             origin_id: thread.id,
             title: subject,
             payload_text: firstMessage.snippet || '',
-            author_name: from,
+            author_name: attribution.from,
             source_url: `https://mail.google.com/mail/u/0/#inbox/${thread.id}`,
             occurred_at: occurredAt,
             origin_type: 'thread',
@@ -479,23 +460,26 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
               message_count: thread.messages.length,
               label_ids: firstMessage.labelIds ?? [],
               snippet: firstMessage.snippet,
-              replied,
-              person_relevant: personRelevant,
-              ...(fromEmail ? { from_email: fromEmail } : {}),
-              ...(fromName ? { from_name: fromName } : {}),
+              replied: attribution.replied,
+              person_relevant: attribution.personRelevant,
+              ...(attribution.fromEmail ? { from_email: attribution.fromEmail } : {}),
+              ...(attribution.fromName ? { from_name: attribution.fromName } : {}),
             },
           };
 
           events.push(event);
-          totalCollected++;
-
-          await sleep(this.RATE_LIMIT_MS);
         } catch {
           /* skip individual thread failures */
+        } finally {
+          // Filtering must not remove the per-thread API delay: a narrow feed
+          // can reject most fetched threads and still has to respect Gmail.
+          await sleep(this.RATE_LIMIT_MS);
         }
+
+        if (inspected >= maxResults) break;
       }
 
-      if (totalCollected >= maxResults) break;
+      if (inspected >= maxResults) break;
     }
 
     // Sort by occurred_at descending
@@ -933,6 +917,122 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
   // Helpers
   // -------------------------------------------------------------------------
 
+  private resolvePersonAttribution(
+    messages: GmailMessage[],
+    humanSendersOnly: boolean
+  ): {
+    replied: boolean;
+    personRelevant: boolean;
+    from: string;
+    fromName: string | null;
+    fromEmail: string | null;
+  } {
+    const sentMessages = messages.filter(isSentMessage);
+    const selfAddresses = new Set(
+      sentMessages
+        .map((message) =>
+          normalizeEmail(this.parseFromHeader(this.getHeader(message, 'From') ?? '').email)
+        )
+        .filter(Boolean)
+    );
+    const isSelf = (email: string): boolean => selfAddresses.has(normalizeEmail(email));
+    const inbound = messages
+      .filter((message) => !isSentMessage(message))
+      .flatMap((message) => {
+        const from = this.getHeader(message, 'From') ?? 'Unknown';
+        const parsed = this.parseFromHeader(from);
+        return parsed.email ? [{ from, name: parsed.name, email: parsed.email }] : [];
+      })
+      .filter((sender) => !isSelf(sender.email));
+
+    // A SENT message with no parseable From leaves self-vs-counterparty
+    // unknowable. It may still be stored in default mode, but must not drive
+    // person creation or count a mailbox copy as a reply.
+    const hasKnownSelf = sentMessages.length === 0 || selfAddresses.size > 0;
+    const replied = sentMessages.length > 0 && hasKnownSelf && inbound.length > 0;
+    let selected = humanSendersOnly
+      ? inbound.find((sender) => isPersonRelevantSender(sender.email, sender.name, replied))
+      : inbound[0];
+
+    if (!selected && humanSendersOnly && sentMessages[0] && hasKnownSelf) {
+      selected = this.parseAddressList(this.getHeader(sentMessages[0], 'To')).find(
+        (sender) =>
+          !isSelf(sender.email) &&
+          isPersonRelevantSender(sender.email, sender.name, false)
+      );
+    }
+
+    const fromEmail = selected?.email ?? null;
+    const fromName = selected?.name ?? null;
+    const personRelevant = humanSendersOnly
+      ? !!selected &&
+        hasKnownSelf &&
+        !this.isListThread(messages) &&
+        (replied ||
+          this.externalRecipientCount(sentMessages[0], isSelf) <= BROADCAST_RECIPIENT_CAP)
+      : replied;
+
+    return {
+      replied,
+      personRelevant,
+      from: selected?.from ?? 'Unknown',
+      fromName,
+      fromEmail,
+    };
+  }
+
+  private isListThread(messages: GmailMessage[]): boolean {
+    return messages.some((message) => {
+      if ((this.getHeader(message, 'List-Id') ?? '').trim()) return true;
+      const precedence = (this.getHeader(message, 'Precedence') ?? '').trim().toLowerCase();
+      return BULK_PRECEDENCE.has(precedence);
+    });
+  }
+
+  private externalRecipientCount(
+    message: GmailMessage | undefined,
+    isSelf: (email: string) => boolean
+  ): number {
+    if (!message) return 0;
+    const recipients = [
+      ...this.parseAddressList(this.getHeader(message, 'To')),
+      ...this.parseAddressList(this.getHeader(message, 'Cc')),
+    ];
+    return new Set(
+      recipients
+        .map((recipient) => normalizeEmail(recipient.email))
+        .filter((email) => email && !isSelf(email))
+    ).size;
+  }
+
+  /** Split an RFC 5322 address list without splitting quoted display names. */
+  private parseAddressList(
+    raw: string | undefined
+  ): Array<{ from: string; name: string | null; email: string }> {
+    if (!raw?.trim()) return [];
+    const parts: string[] = [];
+    let current = '';
+    let inQuotes = false;
+    let inAngle = false;
+    for (const char of raw) {
+      if (char === '"') inQuotes = !inQuotes;
+      else if (char === '<' && !inQuotes) inAngle = true;
+      else if (char === '>' && !inQuotes) inAngle = false;
+      if (char === ',' && !inQuotes && !inAngle) {
+        parts.push(current);
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+    parts.push(current);
+    return parts.flatMap((part) => {
+      const from = part.trim();
+      const parsed = this.parseFromHeader(from);
+      return parsed.email ? [{ from, name: parsed.name, email: parsed.email }] : [];
+    });
+  }
+
   private getHeader(message: GmailMessage, name: string): string | undefined {
     const header = message.payload.headers.find((h) => h.name.toLowerCase() === name.toLowerCase());
     return header?.value;
@@ -1007,8 +1107,15 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
 }
 
 // ---------------------------------------------------------------------------
-// Human-sender heuristic (person-relevant sync mode)
+// Person-relevance heuristic
 // ---------------------------------------------------------------------------
+
+const BULK_PRECEDENCE = new Set(['bulk', 'list', 'junk']);
+const BROADCAST_RECIPIENT_CAP = 3;
+const isSentMessage = (message: GmailMessage): boolean =>
+  (message.labelIds ?? []).includes('SENT');
+const normalizeEmail = (email: string | null | undefined): string =>
+  (email ?? '').trim().toLowerCase();
 
 /**
  * Local-parts that are almost never a human counterparty: automated/system
@@ -1051,25 +1158,25 @@ const CONSUMER_MAIL_DOMAINS = new Set([
 const HUMAN_NAME_RE = /^[A-ZÀ-Ý][a-zà-ÿ]+(?:[ '\u2019-][A-ZÀ-Ý][a-zà-ÿ]+)+$/;
 
 /**
- * Whether a thread's counterparty is plausibly a human sender, deciding person
- * minting under `human_senders_only`. A replied thread is always human — the
- * mailbox owner's own engagement is the strongest signal — so it short-circuits
- * the address checks. An unreplied thread needs a non-automated address AND (a
- * consumer-mail domain OR a human-looking display name). Missing/unparseable
- * addresses are never human — there is nothing to attribute.
+ * Whether a thread's counterparty is eligible for person minting under
+ * `human_senders_only`. Role/system mailboxes never qualify. A replied
+ * non-role address qualifies directly; an unreplied address additionally needs
+ * a consumer-mail domain or a human-looking display name.
  */
-export function isHumanSender(
+export function isPersonRelevantSender(
   email: string | null | undefined,
   name: string | null | undefined,
   replied: boolean
 ): boolean {
-  if (replied) return true;
   if (!email) return false;
+  if (email.indexOf('@') !== email.lastIndexOf('@')) return false;
   const at = email.lastIndexOf('@');
   if (at <= 0) return false;
   const local = email.slice(0, at).trim().toLowerCase();
   const domain = email.slice(at + 1).trim().toLowerCase();
-  if (!local || !domain || AUTOMATED_LOCAL_PARTS.test(local)) return false;
+  const baseLocal = local.split('+', 1)[0];
+  if (!local || !domain || AUTOMATED_LOCAL_PARTS.test(baseLocal)) return false;
+  if (replied) return true;
   if (CONSUMER_MAIL_DOMAINS.has(domain)) return true;
   if (!name) return false;
   return HUMAN_NAME_RE.test(name.trim());

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -236,6 +236,32 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
                   },
                 },
               },
+              {
+                role: 'authored_by',
+                // Legacy gate for v1.0.3 run payloads, which carry `replied` but
+                // not `person_relevant`. Keep it until old in-flight runs/caches
+                // drain: the server loads the current definition by connector key,
+                // so a rolling deploy would otherwise silently skip person creation
+                // for a pre-refresh event. Both rules share the email identity, so
+                // the pipeline's first-writer-wins dedupes them for new payloads.
+                autoCreate: true,
+                target: {
+                  entityType: 'person',
+                  createWhen: { path: 'metadata.replied', equals: true },
+                  titlePath: 'metadata.from_name',
+                  identities: [{ namespace: 'email', eventPath: 'metadata.from_email' }],
+                },
+                traits: {
+                  from_name: {
+                    eventPath: 'metadata.from_name',
+                    behavior: 'prefer_non_empty',
+                  },
+                  last_email_at: {
+                    eventPath: 'occurred_at',
+                    behavior: 'overwrite',
+                  },
+                },
+              },
             ],
           },
         },

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -956,8 +956,10 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     fromEmail: string | null;
   } {
     const sentMessages = messages.filter(isSentMessage);
+    const draftMessages = messages.filter(isDraftMessage);
+    const selfMessages = [...sentMessages, ...draftMessages];
     const selfAddresses = new Set(
-      sentMessages
+      selfMessages
         .map((message) =>
           normalizeSelfEmail(this.parseFromHeader(this.getHeader(message, 'From') ?? '').email)
         )
@@ -966,7 +968,8 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     const isSelf = (email: string): boolean =>
       selfAddresses.has(normalizeSelfEmail(email));
     const inbound = messages
-      .filter((message) => !isSentMessage(message))
+      // DRAFTs are self-authored (unsent) — never inbound counterparties.
+      .filter((message) => !isSentMessage(message) && !isDraftMessage(message))
       .flatMap((message) => {
         const from = this.getHeader(message, 'From') ?? 'Unknown';
         const parsed = this.parseFromHeader(from);
@@ -1143,6 +1146,8 @@ const BULK_PRECEDENCE = new Set(['bulk', 'list', 'junk']);
 const BROADCAST_RECIPIENT_CAP = 3;
 const isSentMessage = (message: GmailMessage): boolean =>
   (message.labelIds ?? []).includes('SENT');
+const isDraftMessage = (message: GmailMessage): boolean =>
+  (message.labelIds ?? []).includes('DRAFT');
 const normalizeEmail = (email: string | null | undefined): string =>
   (email ?? '').trim().toLowerCase();
 /**

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -69,8 +69,18 @@ interface GmailCheckpoint {
 
 interface GmailConfig {
   label?: string;
+  /** Labels to union in the sync query (e.g. ["INBOX", "SENT"]). When set, overrides `label`. */
+  labels?: string[];
   max_results?: number;
   lookback_days?: number;
+  /**
+   * Only emit threads whose counterparty is plausibly a human, and stamp every
+   * emitted thread `person_relevant`. Drives person minting/merging from a
+   * narrow, high-signal subset of the mailbox while everything else stays a
+   * virtual/live read. Receipt-only bulk senders (newsletters, no-reply,
+   * brand addresses) are dropped.
+   */
+  human_senders_only?: boolean;
 }
 
 /** Stable column set returned by live `query()`/`search()` pushdown reads. */
@@ -146,6 +156,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
               default: 'INBOX',
               description: 'Gmail label to sync (e.g. "INBOX", "SENT", "STARRED").',
             },
+            labels: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Labels to union in the sync query, e.g. ["INBOX", "SENT"]. When set, overrides `label` so outbound-initiated threads are covered.',
+            },
             max_results: {
               type: 'integer',
               minimum: 1,
@@ -159,6 +175,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
               maximum: 365,
               default: 30,
               description: 'Number of days to look back on initial sync.',
+            },
+            human_senders_only: {
+              type: 'boolean',
+              default: false,
+              description:
+                'Emit only threads whose counterparty is plausibly a human sender (drives person building). Sets `person_relevant` and drops bulk/brand/auto threads.',
             },
           },
         },
@@ -178,24 +200,32 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
                   description:
                     'True when the thread contains both a counterparty message and a mailbox-authored SENT-labeled message — the interaction signal that gates contact promotion.',
                 },
+                person_relevant: {
+                  type: 'boolean',
+                  description:
+                    'True when the counterparty is plausibly a human sender (a replied thread, or a human-looking sender under human_senders_only). Gates person minting.',
+                },
               },
             },
             attributions: [
               {
                 role: 'authored_by',
-                // Promote on interaction, never on receipt. Every from-address is
-                // a sender — overwhelmingly brands, newsletters, and no-reply
+                // Promote on interaction, never on receipt alone. Every from-address
+                // is a sender — overwhelmingly brands, newsletters, and no-reply
                 // system addresses, all of which carry a from_name — so receipt
-                // alone must not mint a contact. `replied` (computed in sync from
-                // per-message SENT labels) marks a genuine bidirectional exchange.
-                // Only those senders materialize a `person`; everything else still
-                // links to an existing contact on identity match. A thread replied
-                // to after its first sync re-syncs (the reply is a new message
-                // inside the `after:` window), so promotion follows the reply.
+                // alone must not mint a contact. The gate is `person_relevant`,
+                // computed by the connector: it is `replied` (a genuine
+                // bidirectional exchange) by default, and a "plausible human"
+                // heuristic when the feed opts into `human_senders_only`. Only
+                // person-relevant senders materialize a `person`; everything else
+                // still links to an existing contact on identity match. A thread
+                // replied to after its first sync re-syncs (the reply is a new
+                // message inside the `after:` window), so promotion follows the
+                // reply.
                 autoCreate: true,
                 target: {
                   entityType: 'person',
-                  createWhen: { path: 'metadata.replied', equals: true },
+                  createWhen: { path: 'metadata.person_relevant', equals: true },
                   titlePath: 'metadata.from_name',
                   identities: [{ namespace: 'email', eventPath: 'metadata.from_email' }],
                 },
@@ -323,8 +353,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     }
 
     const label = ctx.config.label || 'INBOX';
+    const labels = Array.isArray(ctx.config.labels)
+      ? ctx.config.labels.filter((l) => typeof l === 'string' && l.trim().length > 0)
+      : [];
     const maxResults = Math.min(ctx.config.max_results ?? 50, 500);
     const lookbackDays = ctx.config.lookback_days ?? 30;
+    const humanSendersOnly = ctx.config.human_senders_only === true;
 
     const checkpoint = ctx.checkpoint ?? {}
 
@@ -341,7 +375,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     // precision. Using `YYYY/MM/DD` (day granularity, host timezone) meant every
     // sync within the same day re-fetched the whole day's threads as duplicates.
     const afterEpochSeconds = Math.floor(afterDate.getTime() / 1000);
-    const query = `after:${afterEpochSeconds} label:${label}`;
+    // `labels` unions multiple labels (e.g. INBOX + SENT) so outbound-initiated
+    // threads — often the strongest "this is a real contact" signal — are covered.
+    const query =
+      labels.length > 0
+        ? `after:${afterEpochSeconds} (${labels.map((l) => `label:${l}`).join(' OR ')})`
+        : `after:${afterEpochSeconds} label:${label}`;
 
     const http = this.createClient(token);
     const events: EventEnvelope[] = [];
@@ -378,7 +417,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       // Fetch each thread with metadata format
       for (const threadStub of threads) {
         try {
-          const threadUrl = `${this.BASE_URL}/threads/${threadStub.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date`;
+          const threadUrl = `${this.BASE_URL}/threads/${threadStub.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Date`;
           const threadResponse = await http.raw(threadUrl);
 
           if (!threadResponse.ok) continue;
@@ -389,11 +428,19 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
 
           const firstMessage = thread.messages[0];
           const isSent = (m: GmailMessage) => (m.labelIds ?? []).includes('SENT');
-          const counterpartyMessage = thread.messages.find((message) => !isSent(message));
+          const sentMessage = thread.messages.find(isSent);
+          const inboundMessage = thread.messages.find((message) => !isSent(message));
+          // Prefer the first counterparty-authored message so an owner-started
+          // thread never promotes the mailbox owner's own address. When the
+          // thread is outbound-only (no reply yet), fall back to the sent
+          // message's To header so the recipient still surfaces.
+          const counterpartyMessage = inboundMessage ?? sentMessage;
           const subject = this.getHeader(firstMessage, 'Subject') || '(no subject)';
-          const from = counterpartyMessage
-            ? this.getHeader(counterpartyMessage, 'From') || 'Unknown'
-            : 'Unknown';
+          const addressHeader =
+            counterpartyMessage === sentMessage
+              ? this.getHeader(counterpartyMessage, 'To')
+              : this.getHeader(counterpartyMessage, 'From');
+          const from = addressHeader || 'Unknown';
           const { name: fromName, email: fromEmail } = this.parseFromHeader(from);
           const dateHeader = this.getHeader(firstMessage, 'Date');
           const occurredAt = dateHeader
@@ -403,10 +450,22 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
           if (Number.isNaN(occurredAt.getTime())) continue;
 
           // A bidirectional exchange has at least one mailbox-authored message
-          // and one counterparty-authored message, regardless of who started it.
-          // Attribute the event to the first counterparty message so an
-          // owner-started thread never promotes the mailbox owner's own address.
-          const replied = counterpartyMessage !== undefined && thread.messages.some(isSent);
+          // and one inbound counterparty message, regardless of who started it.
+          // An outbound-only thread (no reply yet) is NOT replied — the sent
+          // fallback exists so the recipient surfaces, not so it counts as an
+          // interaction.
+          const replied = inboundMessage !== undefined && sentMessage !== undefined;
+          // Person-relevance gates minting: `replied` by default; a "plausible
+          // human" heuristic when the feed opts into human_senders_only.
+          const personRelevant = humanSendersOnly
+            ? isHumanSender(fromEmail, fromName, replied)
+            : replied;
+
+          // Under human_senders_only the sync is deliberately narrow — only
+          // person-relevant threads are persisted (everything else stays a live
+          // read), so the DB only holds the high-signal set that drives person
+          // building.
+          if (humanSendersOnly && !personRelevant) continue;
 
           const event: EventEnvelope = {
             origin_id: thread.id,
@@ -421,6 +480,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
               label_ids: firstMessage.labelIds ?? [],
               snippet: firstMessage.snippet,
               replied,
+              person_relevant: personRelevant,
               ...(fromEmail ? { from_email: fromEmail } : {}),
               ...(fromName ? { from_name: fromName } : {}),
             },
@@ -944,4 +1004,73 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
   private createClient(token: string): HttpClient {
     return createHttpClient({ token, errorPrefix: 'Gmail API' });
   }
+}
+
+// ---------------------------------------------------------------------------
+// Human-sender heuristic (person-relevant sync mode)
+// ---------------------------------------------------------------------------
+
+/**
+ * Local-parts that are almost never a human counterparty: automated/system
+ * addresses (no-reply, bounce, mailer-daemon) and shared brand inboxes
+ * (info@, marketing@, support@, hello@, …). Matched against the lowercased
+ * local part of the From address.
+ */
+const AUTOMATED_LOCAL_PARTS = /^(?:no[._-]?reply|do[._-]?not[._-]?reply|donotreply|noreply|no\.reply|bounce|mailer[._-]?daemon|postmaster|abuse|notif(?:ications?)?|alert(?:s)?|support|team|info|news(?:letter)?|market(?:ing)?|contact|updates?|jobs|careers|press|media|events?|webmaster|automated|robot|hello|sales|billing|accounts|security|admin|root)$/;
+
+/**
+ * Consumer mail providers — a bare address here is overwhelmingly a personal
+ * mailbox even without a display name or a replied thread.
+ */
+const CONSUMER_MAIL_DOMAINS = new Set([
+  'gmail.com',
+  'googlemail.com',
+  'outlook.com',
+  'hotmail.com',
+  'live.com',
+  'msn.com',
+  'icloud.com',
+  'me.com',
+  'mac.com',
+  'yahoo.com',
+  'ymail.com',
+  'proton.me',
+  'protonmail.com',
+  'fastmail.com',
+  'zoho.com',
+  'mail.com',
+  'aol.com',
+]);
+
+/**
+ * A display name that looks like a person's name: two or more capitalized
+ * words ("John Smith", "Ana-Maria O'Brien"). Single-word brands ("LinkedIn",
+ * "Spotify") and lowercase handles fail this, so a non-consumer corporate
+ * sender needs a human-looking name to clear the bar.
+ */
+const HUMAN_NAME_RE = /^[A-ZÀ-Ý][a-zà-ÿ]+(?:[ '\u2019-][A-ZÀ-Ý][a-zà-ÿ]+)+$/;
+
+/**
+ * Whether a thread's counterparty is plausibly a human sender, deciding person
+ * minting under `human_senders_only`. A replied thread is always human — the
+ * mailbox owner's own engagement is the strongest signal — so it short-circuits
+ * the address checks. An unreplied thread needs a non-automated address AND (a
+ * consumer-mail domain OR a human-looking display name). Missing/unparseable
+ * addresses are never human — there is nothing to attribute.
+ */
+export function isHumanSender(
+  email: string | null | undefined,
+  name: string | null | undefined,
+  replied: boolean
+): boolean {
+  if (replied) return true;
+  if (!email) return false;
+  const at = email.lastIndexOf('@');
+  if (at <= 0) return false;
+  const local = email.slice(0, at).trim().toLowerCase();
+  const domain = email.slice(at + 1).trim().toLowerCase();
+  if (!local || !domain || AUTOMATED_LOCAL_PARTS.test(local)) return false;
+  if (CONSUMER_MAIL_DOMAINS.has(domain)) return true;
+  if (!name) return false;
+  return HUMAN_NAME_RE.test(name.trim());
 }

--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -925,4 +925,28 @@ describe('gmail promote-on-interaction (real connector rule)', () => {
     expect(people.map((p) => p.name)).toEqual(['Alice']);
     expect((later.metadata as Record<string, unknown>).email).toBe('alice@example.com');
   });
+
+  it('a legacy v1.0.3 {replied:true} payload still mints a person under the new definition', async () => {
+    const { org, sql } = await setupGmailOrg();
+
+    // Pre-refresh run payloads carry `replied` but not `person_relevant`. The
+    // server loads the current definition by connector key, so the legacy rule
+    // must keep minting during a rolling deploy — otherwise in-flight old runs
+    // silently skip person creation.
+    await applyEventAttributions({
+      connectorKey: GMAIL_KEY,
+      feedKey: GMAIL_FEED,
+      orgId: org.id,
+      items: [
+        thread({
+          from_email: 'alice@example.com',
+          from_name: 'Alice',
+          replied: true,
+        }),
+      ],
+    });
+
+    const people = await personRows(sql, org.id);
+    expect(people.map((p) => p.name)).toEqual(['Alice']);
+  });
 });

--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -784,13 +784,13 @@ describe('applyEventAttributions', () => {
 });
 
 /**
-  * End-to-end promote-on-interaction (#1626) against the REAL Gmail connector
-  * rule — not a hand-built test rule — so a regression in the connector's
-  * declared gate (e.g. flipping autoCreate back on ungated) fails here, at the
-  * pipeline level where the raw-sender person flood would actually re-appear.
-  * The gate is `metadata.person_relevant` (the connector stamps it = replied in
-  * default mode; a plausible-human heuristic under human_senders_only).
-  */
+ * End-to-end promote-on-interaction (#1626) against the REAL Gmail connector
+ * rule — not a hand-built test rule — so a regression in the connector's
+ * declared gate (e.g. flipping autoCreate back on ungated) fails here, at the
+ * pipeline level where the raw-sender person flood would actually re-appear.
+ * The gate is `metadata.person_relevant` (replied in default mode; stricter
+ * counterparty selection under human_senders_only).
+ */
 describe('gmail promote-on-interaction (real connector rule)', () => {
   const GMAIL_KEY = 'google.gmail';
   const GMAIL_FEED = 'threads';

--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -784,11 +784,13 @@ describe('applyEventAttributions', () => {
 });
 
 /**
- * End-to-end promote-on-interaction (#1626) against the REAL Gmail connector
- * rule — not a hand-built test rule — so a regression in the connector's
- * declared gate (e.g. flipping autoCreate back on ungated) fails here, at the
- * pipeline level where the raw-sender person flood would actually re-appear.
- */
+  * End-to-end promote-on-interaction (#1626) against the REAL Gmail connector
+  * rule — not a hand-built test rule — so a regression in the connector's
+  * declared gate (e.g. flipping autoCreate back on ungated) fails here, at the
+  * pipeline level where the raw-sender person flood would actually re-appear.
+  * The gate is `metadata.person_relevant` (the connector stamps it = replied in
+  * default mode; a plausible-human heuristic under human_senders_only).
+  */
 describe('gmail promote-on-interaction (real connector rule)', () => {
   const GMAIL_KEY = 'google.gmail';
   const GMAIL_FEED = 'threads';
@@ -830,7 +832,7 @@ describe('gmail promote-on-interaction (real connector rule)', () => {
     `;
   }
 
-  it('promotes only replied-to counterparties: no raw-sender rows, bidirectional contact minted with metric aliases', async () => {
+  it('promotes only person-relevant counterparties: no raw-sender rows, bidirectional contact minted with metric aliases', async () => {
     const { org, sql } = await setupGmailOrg();
 
     await applyEventAttributions({
@@ -839,9 +841,19 @@ describe('gmail promote-on-interaction (real connector rule)', () => {
       orgId: org.id,
       items: [
         // Inbound-only brand blast — has a from_name, still must NOT mint.
-        thread({ from_email: 'promo@brand.example', from_name: 'Brand', replied: false }),
+        thread({
+          from_email: 'promo@brand.example',
+          from_name: 'Brand',
+          replied: false,
+          person_relevant: false,
+        }),
         // Genuine bidirectional exchange — promotes.
-        thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: true }),
+        thread({
+          from_email: 'alice@example.com',
+          from_name: 'Alice',
+          replied: true,
+          person_relevant: true,
+        }),
       ],
     });
 
@@ -861,7 +873,14 @@ describe('gmail promote-on-interaction (real connector rule)', () => {
 
   it('promotion is idempotent: re-syncing the same replied thread never duplicates the contact', async () => {
     const { org, sql } = await setupGmailOrg();
-    const items = [thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: true })];
+    const items = [
+      thread({
+        from_email: 'alice@example.com',
+        from_name: 'Alice',
+        replied: true,
+        person_relevant: true,
+      }),
+    ];
 
     await applyEventAttributions({ connectorKey: GMAIL_KEY, feedKey: GMAIL_FEED, orgId: org.id, items });
     await applyEventAttributions({ connectorKey: GMAIL_KEY, feedKey: GMAIL_FEED, orgId: org.id, items });
@@ -878,9 +897,21 @@ describe('gmail promote-on-interaction (real connector rule)', () => {
       connectorKey: GMAIL_KEY,
       feedKey: GMAIL_FEED,
       orgId: org.id,
-      items: [thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: true })],
+      items: [
+        thread({
+          from_email: 'alice@example.com',
+          from_name: 'Alice',
+          replied: true,
+          person_relevant: true,
+        }),
+      ],
     });
-    const later = thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: false });
+    const later = thread({
+      from_email: 'alice@example.com',
+      from_name: 'Alice',
+      replied: false,
+      person_relevant: false,
+    });
     await applyEventAttributions({
       connectorKey: GMAIL_KEY,
       feedKey: GMAIL_FEED,


### PR DESCRIPTION
## Summary

Gmail was not participating in entity/person building. Root causes found in prod (buremba org):

- Person minting was gated solely on `metadata.replied` — true for **1 of 880** synced thread events, because the connector only queried `INBOX` (outbound-initiated threads never surface) and `replied` requires the owner to have replied.
- The `person` type had no `x-lobu-resolution` policy, so even attached `email` identities were review-only and never auto-merged with LinkedIn/etc. contacts.

## Changes

**Connector (`packages/connectors/src/google_gmail.ts`)**
- New feed config: `human_senders_only` (bool) and `labels` (string[]). When `labels` is set, sync unions them (`INBOX OR SENT`) so outbound-initiated threads are covered.
- Outbound-only threads attribute the recipient via the sent message's `To` header.
- Every emitted event now carries `person_relevant`. The attribution gate moves from `metadata.replied` to `metadata.person_relevant` (default mode: `= replied`, so existing behavior is unchanged; under `human_senders_only` it uses a "plausible human" heuristic).
- `isHumanSender`: replied short-circuits; otherwise excludes automated/brand local-parts (`noreply`, `info@`, `marketing@`, …), passes consumer-mail domains bare, and requires a human-looking name on corporate domains.
- Under `human_senders_only` the sync emits only person-relevant threads, so the DB only stores a small high-signal set — the full mailbox stays a live read via the connector's `search`/`get_thread` actions.

**CLI (`packages/cli`)**
- `EntityType.resolutionPolicy` in `lobu.config.ts` is now declarative: it lowers to the `x-lobu-resolution` metadata_schema key, config wins over any out-of-band value, and is preserved when omitted (loud validation; prune-free diffing).

**Config (`examples/personal-agent/lobu.config.ts`)**
- `person` declares `resolutionPolicy`: email/emails → `auto_merge`, phone/phones → `review` (mirrors the server default but upgrades email).
- One config-owned `gmail-buremba` connection (adopts the existing prod slug so the OAuth grant is reused) syncs a `human_senders_only` INBOX+SENT feed (max_results 500, lookback 365). The stale duplicate gmail connections/feeds in prod surface as drift rows until cleaned up.

## Verification

- `make pre-pr` clean (build, typecheck, knip, biome, surface naming, LLM gate).
- Connector tests: `packages/connectors/src/__tests__/google_gmail.test.ts` (16 pass) — `isHumanSender` cases + `human_senders_only` sync mode incl. outbound `To` attribution.
- CLI: `client.test.ts`, `diff.test.ts`, `map-config.test.ts` (+ full CLI suite 508 pass).
- Server: `entity-link-upsert.test.ts` gmail promote-on-interaction suite updated to the new `person_relevant` gate (red→green: the 3 tests failed with the old `replied`-only metadata, updated, green), `gmail-virtual-pushdown.test.ts` unaffected.

## Not included / follow-ups

- The declarative `resolutionPolicy` is generic to any entity type; only `person` consumes it today.
- No gmail **virtual** feed row in config: a connection's feeds are diffed by feed key, so a single `threads` feed can't be both collected and virtual; live reads go through the connector's `search`/`get_thread` actions instead.
- Stale prod gmail connections (`gmail-buremba-2`, `google-gmail`, `gmail-7xf6…`) remain as drift; recommend manual cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable entity-resolution rules for email and phone matching, supporting automatic merges or review workflows.
  * Expanded Gmail syncing with label selection, human-sender filtering, date and result limits, and richer conversation metadata.
  * Gmail imports can now better identify relevant contacts and promote meaningful interactions.

* **Improvements**
  * Configuration updates preserve unmanaged schema settings and only remove fields when explicitly requested.
  * Added validation and reliable change detection for resolution policies and schema updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->