### PR TITLE
fix(mcp): restore app cards by host identity

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -143,14 +143,14 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     return sessionId!;
   }
 
-  it('serves the self-contained v8 interaction bundle over resources/read', async () => {
+  it('serves the self-contained v9 interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v8.html' },
+        params: { uri: 'ui://lobu/interaction/v9.html' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -159,7 +159,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v8.html');
+    expect(content?.uri).toBe('ui://lobu/interaction/v9.html');
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('mcp-app-embedded-stub');
     expect(content?.text).not.toContain('mcp-app-external-stub');
@@ -268,23 +268,28 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     }
   });
 
-  it('keeps the v7 alias on the packed, network-free template', async () => {
+  it('keeps the v7 and v8 aliases on the packed, network-free template', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
-    const response = await post(`/mcp/${org.slug}`, {
-      body: {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'resources/read',
-        params: { uri: 'ui://lobu/interaction/v7.html' },
-      },
-      headers: { 'mcp-session-id': sessionId },
-      token,
-    });
-    expect(response.status).toBe(200);
-    const content = (await response.json()).result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/interaction/v7.html');
-    expect(content?.text).toContain('mcp-app-embedded-stub');
-    expect(content?.text).not.toContain('./assets/');
+    for (const uri of [
+      'ui://lobu/interaction/v7.html',
+      'ui://lobu/interaction/v8.html',
+    ]) {
+      const response = await post(`/mcp/${org.slug}`, {
+        body: {
+          jsonrpc: '2.0',
+          id: uri,
+          method: 'resources/read',
+          params: { uri },
+        },
+        headers: { 'mcp-session-id': sessionId },
+        token,
+      });
+      expect(response.status).toBe(200);
+      const content = (await response.json()).result?.contents?.[0];
+      expect(content?.uri).toBe(uri);
+      expect(content?.text).toContain('mcp-app-embedded-stub');
+      expect(content?.text).not.toContain('./assets/');
+    }
   });
 
   it('advertises description and CSP metadata on resources/list without claiming a dedicated app domain', async () => {
@@ -302,7 +307,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     const resource = body.result?.resources?.find(
-      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v8.html'
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction/v9.html'
     );
     expect(resource).toBeDefined();
     expect(
@@ -350,10 +355,10 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
         _meta: expect.objectContaining({
           securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
           ui: expect.objectContaining({
-            resourceUri: 'ui://lobu/interaction/v8.html',
+            resourceUri: 'ui://lobu/interaction/v9.html',
             visibility: ['model', 'app'],
           }),
-          'openai/outputTemplate': 'ui://lobu/interaction/v8.html',
+          'openai/outputTemplate': 'ui://lobu/interaction/v9.html',
         }),
       })
     );
@@ -372,12 +377,12 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       );
       expect(richTool?._meta?.ui).toEqual(
         expect.objectContaining({
-          resourceUri: 'ui://lobu/interaction/v8.html',
+          resourceUri: 'ui://lobu/interaction/v9.html',
           visibility: ['model', 'app'],
         })
       );
       expect(richTool?._meta?.['openai/outputTemplate']).toBe(
-        'ui://lobu/interaction/v8.html'
+        'ui://lobu/interaction/v9.html'
       );
       expect(richTool?.outputSchema).toEqual(expect.objectContaining({ type: 'object' }));
     }
@@ -444,7 +449,7 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     );
     expect(tool?._meta?.ui).toEqual(
       expect.objectContaining({
-        resourceUri: 'ui://lobu/interaction/v8.html',
+        resourceUri: 'ui://lobu/interaction/v9.html',
         visibility: ['model', 'app'],
       })
     );
@@ -494,37 +499,41 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(JSON.stringify(body.result)).not.toContain('must-not-render');
   });
 
-  it('restores the exact rich result and UI state without rerunning the tool', async () => {
+  it('binds reused backend request ids to distinct host cards and restores exact state', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const conversationId = 'chatgpt-conversation-restore-test';
-    const queryResponse = await post(`/mcp/${org.slug}`, {
-      body: {
-        jsonrpc: '2.0',
-        id: 'originating-call-77',
-        method: 'tools/call',
-        params: {
-          name: 'query_sql',
-          arguments: { sql: 'SELECT 1 AS row_number' },
-          _meta: { 'openai/session': conversationId },
-        },
-      },
-      headers: { 'mcp-session-id': sessionId },
-      token,
-    });
-    const queryBody = await queryResponse.json();
-    expect(queryBody.result?.structuredContent?.sql).toBe('SELECT 1 AS row_number');
-    expect(queryBody.result?.structuredContent?.rows).toEqual([{ row_number: 1 }]);
-
-    const restore = async (hostConversationId: string, toolName = 'query_sql') => {
+    const runQuery = async (rowNumber: number) => {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
           jsonrpc: '2.0',
-          id: `restore-${hostConversationId}`,
+          // ChatGPT currently reuses this proxy-side id for several cards.
+          id: 'reused-backend-request-id',
+          method: 'tools/call',
+          params: {
+            name: 'query_sql',
+            arguments: { sql: `SELECT ${rowNumber} AS row_number` },
+            _meta: { 'openai/session': conversationId },
+          },
+        },
+        headers: { 'mcp-session-id': sessionId },
+        token,
+      });
+      return response.json();
+    };
+    const restore = async (
+      toolCallId: string,
+      hostConversationId = conversationId,
+      toolName = 'query_sql'
+    ) => {
+      const response = await post(`/mcp/${org.slug}`, {
+        body: {
+          jsonrpc: '2.0',
+          id: `restore-${toolCallId}`,
           method: 'tools/call',
           params: {
             name: 'restore_lobu_app_result',
             arguments: {
-              tool_call_id: 'originating-call-77',
+              tool_call_id: toolCallId,
               tool_name: toolName,
             },
             _meta: { 'openai/session': hostConversationId },
@@ -535,47 +544,27 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       });
       return (await response.json()).result?.structuredContent;
     };
-
-    expect(await restore(`${conversationId}-wrong`)).toEqual({
-      found: false,
-      view_state: {},
-    });
-    expect(await restore(conversationId, 'run_sdk')).toEqual({
-      found: false,
-      view_state: {},
-    });
-    const restored = await restore(conversationId);
-    expect(restored).toEqual({
-      found: true,
-      tool_name: 'query_sql',
-      data: queryBody.result.structuredContent,
-      view_state: {},
-    });
-
-    const [snapshotBeforeSave] = await getDb()<{
-      expires_at: Date;
-    }>`SELECT expires_at
-       FROM public.mcp_app_result_snapshots
-       WHERE organization_id = ${org.id}
-         AND tool_name = 'query_sql'
-       ORDER BY updated_at DESC
-       LIMIT 1`;
-    expect(snapshotBeforeSave).toBeDefined();
-
-    const saveState = async (toolName: string) => {
+    const bindCard = async (
+      toolCallId: string,
+      capability: string,
+      viewState: Record<string, unknown> = {}
+    ) => {
       const response = await post(`/mcp/${org.slug}`, {
         body: {
           jsonrpc: '2.0',
-          id: `save-state-77-${toolName}`,
+          id: `bind-${toolCallId}`,
           method: 'tools/call',
           params: {
             name: 'save_lobu_app_state',
             arguments: {
-              tool_call_id: 'originating-call-77',
-              tool_name: toolName,
-              view_state: { 'table.sql.page': 2, nested: { dropped: true } },
+              tool_call_id: toolCallId,
+              tool_name: 'query_sql',
+              view_state: viewState,
             },
-            _meta: { 'openai/session': conversationId },
+            _meta: {
+              'openai/session': conversationId,
+              'lobu/mcp-app-snapshot-capability': capability,
+            },
           },
         },
         headers: { 'mcp-session-id': sessionId },
@@ -583,16 +572,51 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
       });
       return (await response.json()).result?.structuredContent;
     };
-    expect(await saveState('run_sdk')).toEqual({ saved: false });
-    expect(await saveState('query_sql')).toEqual({ saved: true });
-    expect((await restore(conversationId))?.view_state).toEqual({ 'table.sql.page': 2 });
+
+    const firstBody = await runQuery(1);
+    expect(firstBody.result?.structuredContent?.rows).toEqual([{ row_number: 1 }]);
+    const firstCapability = firstBody.result?._meta?.['lobu/mcp-app-snapshot-capability'];
+    expect(firstCapability).toEqual(expect.any(String));
+    expect(await restore('host-card-1')).toEqual({ found: false, view_state: {} });
+    expect(
+      await bindCard('host-card-1', firstCapability, {
+        'table.sql.page': 2,
+        nested: { dropped: true },
+      })
+    ).toEqual({ saved: true });
+    expect(await restore('host-card-1', `${conversationId}-wrong`)).toEqual({
+      found: false,
+      view_state: {},
+    });
+    expect(await restore('host-card-1', conversationId, 'run_sdk')).toEqual({
+      found: false,
+      view_state: {},
+    });
+    expect(await restore('host-card-1')).toEqual({
+      found: true,
+      tool_name: 'query_sql',
+      data: firstBody.result.structuredContent,
+      view_state: { 'table.sql.page': 2 },
+    });
+    expect(
+      await bindCard('host-card-1', firstCapability, { 'table.sql.page': 3 })
+    ).toEqual({ saved: true });
+    expect((await restore('host-card-1'))?.view_state).toEqual({ 'table.sql.page': 3 });
+
+    const secondBody = await runQuery(2);
+    expect(secondBody.result?.structuredContent?.rows).toEqual([{ row_number: 2 }]);
+    const secondCapability = secondBody.result?._meta?.['lobu/mcp-app-snapshot-capability'];
+    expect(secondCapability).toEqual(expect.any(String));
+    expect(secondCapability).not.toBe(firstCapability);
+    expect(await bindCard('host-card-2', secondCapability)).toEqual({ saved: true });
+    expect((await restore('host-card-1'))?.data?.rows).toEqual([{ row_number: 1 }]);
+    expect((await restore('host-card-2'))?.data?.rows).toEqual([{ row_number: 2 }]);
 
     const [snapshot] = await getDb()<{
       body: string;
       conversation_key: string;
-      expires_at: Date;
       tool_call_key: string;
-    }>`SELECT body, conversation_key, expires_at, tool_call_key
+    }>`SELECT body, conversation_key, tool_call_key
        FROM public.mcp_app_result_snapshots
        WHERE organization_id = ${org.id}
          AND tool_name = 'query_sql'
@@ -601,29 +625,13 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(snapshot).toBeDefined();
     expect(snapshot.body).not.toContain('row_number');
     expect(snapshot.conversation_key).not.toBe(conversationId);
-    expect(snapshot.expires_at).toEqual(snapshotBeforeSave.expires_at);
-    expect(snapshot.tool_call_key).not.toBe('originating-call-77');
+    expect(snapshot.tool_call_key).not.toBe('host-card-2');
 
-    const collidingResponse = await post(`/mcp/${org.slug}`, {
-      body: {
-        jsonrpc: '2.0',
-        id: 'originating-call-77',
-        method: 'tools/call',
-        params: {
-          name: 'query_sql',
-          arguments: { sql: 'SELECT 2 AS row_number' },
-          _meta: { 'openai/session': conversationId },
-        },
-      },
-      headers: { 'mcp-session-id': sessionId },
-      token,
-    });
-    const collidingBody = await collidingResponse.json();
-    expect(collidingBody.result?.structuredContent?.rows).toEqual([{ row_number: 2 }]);
-    expect(await restore(conversationId)).toEqual({
-      found: false,
-      view_state: {},
-    });
+    const collidingBody = await runQuery(3);
+    const collidingCapability =
+      collidingBody.result?._meta?.['lobu/mcp-app-snapshot-capability'];
+    expect(await bindCard('host-card-2', collidingCapability)).toEqual({ saved: false });
+    expect((await restore('host-card-2'))?.data?.rows).toEqual([{ row_number: 2 }]);
 
     const helperAudits = await getDb()<{
       tool_name: string;

--- a/packages/server/src/mcp-app-result-snapshots.ts
+++ b/packages/server/src/mcp-app-result-snapshots.ts
@@ -27,6 +27,8 @@ interface SnapshotPayload {
 	toolName: string;
 	data: UnknownRecord;
 	viewState: McpAppViewState;
+	/** SHA-256 of the single-use capability; retained after binding for idempotency. */
+	bindingKey?: string;
 }
 
 interface SnapshotIdentity {
@@ -150,6 +152,10 @@ function parseSnapshot(body: string): SnapshotPayload | null {
 			toolName: parsed.toolName,
 			data: parsed.data,
 			viewState: boundedMcpAppViewState(parsed.viewState),
+			...(typeof parsed.bindingKey === "string" &&
+				/^[a-f0-9]{64}$/.test(parsed.bindingKey)
+				? { bindingKey: parsed.bindingKey }
+				: {}),
 		};
 	} catch {
 		return null;
@@ -170,25 +176,30 @@ function serializeSnapshot(payload: SnapshotPayload): {
 export async function storeMcpAppResultSnapshot(args: {
 	ctx: ToolContext;
 	toolCallId: unknown;
+	bindingCapability?: unknown;
 	toolName: string;
 	data: UnknownRecord;
-}): Promise<void> {
+}): Promise<boolean> {
 	const identity = snapshotIdentity(args.ctx, args.toolCallId);
 	if (
 		!identity ||
 		!args.toolName ||
 		args.toolName.length > TOOL_NAME_MAX_LENGTH
 	)
-		return;
+		return false;
+	const bindingCapability = normalizeMcpAppToolCallId(args.bindingCapability);
 	const data = displaySafeMcpAppResult(args.data);
-	if (!isRecord(data)) return;
+	if (!isRecord(data)) return false;
 	const serialized = serializeSnapshot({
 		version: 1,
 		toolName: args.toolName,
 		data,
 		viewState: {},
+		...(bindingCapability
+			? { bindingKey: hashIdentity(bindingCapability) }
+			: {}),
 	});
-	if (!serialized) return;
+	if (!serialized) return false;
 
 	const sql = getDb();
 	const collided = await sql.begin(async (tx) => {
@@ -236,6 +247,7 @@ export async function storeMcpAppResultSnapshot(args: {
 			"MCP App result snapshot key collision; historical restore disabled",
 		);
 	}
+	return !collided;
 }
 
 export const RestoreMcpAppResultSchema = Type.Object({
@@ -327,6 +339,86 @@ async function saveMcpAppStateImpl(
 	if (!identity) return { saved: false };
 	const viewState = boundedMcpAppViewState(args.view_state);
 	const sql = getDb();
+	const bindingIdentity = snapshotIdentity(
+		ctx,
+		ctx.mcpAppSnapshotCapability,
+	);
+	if (
+		bindingIdentity &&
+		bindingIdentity.toolCallKey !== identity.toolCallKey
+	) {
+		try {
+			return await sql.begin(async (tx) => {
+				const [candidate] = await tx<SnapshotRow>`
+					SELECT body, tool_name
+					FROM public.mcp_app_result_snapshots
+					WHERE organization_id = ${bindingIdentity.organizationId}
+						AND client_id = ${bindingIdentity.clientId}
+						AND user_id = ${bindingIdentity.userId}
+						AND conversation_key = ${bindingIdentity.conversationKey}
+						AND tool_call_key = ${bindingIdentity.toolCallKey}
+						AND expires_at > now()
+					FOR UPDATE
+				`;
+				const row =
+					candidate ??
+					(
+						await tx<SnapshotRow>`
+							SELECT body, tool_name
+							FROM public.mcp_app_result_snapshots
+							WHERE organization_id = ${identity.organizationId}
+								AND client_id = ${identity.clientId}
+								AND user_id = ${identity.userId}
+								AND conversation_key = ${identity.conversationKey}
+								AND tool_call_key = ${identity.toolCallKey}
+								AND expires_at > now()
+						`
+					)[0];
+				if (!row) return { saved: false };
+				if (args.tool_name && row.tool_name !== args.tool_name)
+					return { saved: false };
+				const snapshot = parseSnapshot(row.body);
+				if (
+					!snapshot ||
+					snapshot.toolName !== row.tool_name ||
+					snapshot.bindingKey !== bindingIdentity.toolCallKey
+				)
+					return { saved: false };
+				const serialized = serializeSnapshot({ ...snapshot, viewState });
+				if (!serialized) return { saved: false };
+				const sourceIdentity = candidate ? bindingIdentity : identity;
+				const updated = await tx`
+					UPDATE public.mcp_app_result_snapshots
+					SET tool_call_key = ${identity.toolCallKey},
+						body = ${serialized.body},
+						plaintext_bytes = ${serialized.plaintextBytes},
+						updated_at = now()
+					WHERE organization_id = ${sourceIdentity.organizationId}
+						AND client_id = ${sourceIdentity.clientId}
+						AND user_id = ${sourceIdentity.userId}
+						AND conversation_key = ${sourceIdentity.conversationKey}
+						AND tool_call_key = ${sourceIdentity.toolCallKey}
+				`;
+				return { saved: updated.count === 1 };
+			});
+		} catch (error) {
+			if (!isRecord(error) || error.code !== "23505") throw error;
+			await sql`
+				UPDATE public.mcp_app_result_snapshots
+				SET expires_at = now(), updated_at = now()
+				WHERE organization_id = ${bindingIdentity.organizationId}
+					AND client_id = ${bindingIdentity.clientId}
+					AND user_id = ${bindingIdentity.userId}
+					AND conversation_key = ${bindingIdentity.conversationKey}
+					AND tool_call_key = ${bindingIdentity.toolCallKey}
+			`;
+			logger.warn(
+				{ toolName: args.tool_name },
+				"MCP App host card key collision; candidate restore disabled",
+			);
+			return { saved: false };
+		}
+	}
 	return sql.begin(async (tx) => {
 		const [row] = await tx<SnapshotRow>`
 			SELECT body, tool_name

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -102,6 +102,10 @@ const MCP_APP_RESOURCE_ALIASES: ReadonlyMap<
     'ui://lobu/interaction/v7.html',
     { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
   ],
+  [
+    'ui://lobu/interaction/v8.html',
+    { canonicalUri: LOBU_INTERACTION_RESOURCE_URI, template: 'embedded' },
+  ],
 ]);
 // ---------------------------------------------------------------------------
 // Session store
@@ -138,6 +142,14 @@ function approvalCapabilityFromMeta(value: unknown): string | null {
   if (typeof token !== 'string') return null;
   const trimmed = token.trim();
   return trimmed && trimmed.length <= 4_096 ? trimmed : null;
+}
+
+function snapshotCapabilityFromMeta(value: unknown): string | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const token = (value as Record<string, unknown>)['lobu/mcp-app-snapshot-capability'];
+  if (typeof token !== 'string') return null;
+  const trimmed = token.trim();
+  return trimmed && trimmed.length <= 512 ? trimmed : null;
 }
 
 // Periodic cleanup of stale IN-MEMORY sessions. This must stay as a per-pod
@@ -441,13 +453,14 @@ function createServerForContext(
   });
 
   // tools/call — access control + execution + formatting
-  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
     const callAuthCtx = {
       ...authCtx,
       mcpAppsSupported,
       mcpConversationId: hostConversationIdFromMeta(request.params._meta),
       mcpAppApprovalCapability: approvalCapabilityFromMeta(request.params._meta),
+      mcpAppSnapshotCapability: snapshotCapabilityFromMeta(request.params._meta),
     };
 
     // Regular tool execution
@@ -485,14 +498,18 @@ function createServerForContext(
       if (tool?.outputSchema && result && typeof result === 'object') {
         const structured = validateToolResult(tool.outputSchema, result);
         if (structured !== null) {
+          let snapshotCapability: string | null = null;
           if (tool.audit !== false) {
             try {
-              await storeMcpAppResultSnapshot({
+              const capability = randomUUID();
+              const stored = await storeMcpAppResultSnapshot({
                 ctx: toToolContext(callAuthCtx),
-                toolCallId: extra.requestId,
+                toolCallId: capability,
+                bindingCapability: capability,
                 toolName: name,
                 data: structured as Record<string, unknown>,
               });
+              if (stored) snapshotCapability = capability;
             } catch (snapshotError) {
               logger.warn(
                 { err: snapshotError },
@@ -503,7 +520,16 @@ function createServerForContext(
           return {
             content: [{ type: 'text' as const, text }],
             structuredContent: structured as Record<string, unknown>,
-            ...(resultMeta ? { _meta: resultMeta } : {}),
+            ...(resultMeta || snapshotCapability
+              ? {
+                  _meta: {
+                    ...(resultMeta ?? {}),
+                    ...(snapshotCapability
+                      ? { 'lobu/mcp-app-snapshot-capability': snapshotCapability }
+                      : {}),
+                  },
+                }
+              : {}),
             ...(softError ? { isError: true } : {}),
           };
         }

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -69,6 +69,8 @@ export interface AuthContext {
   mcpAppsSupported?: boolean | null;
   /** Host-only capability from an MCP App `tools/call` request. Never persisted. */
   mcpAppApprovalCapability?: string | null;
+  /** Host-only single-use result-binding capability. Raw values are never persisted. */
+  mcpAppSnapshotCapability?: string | null;
   /** Host conversation correlation, separate from the transport session. */
   mcpConversationId?: string | null;
   instructions?: string;
@@ -410,6 +412,7 @@ export function toToolContext(authCtx: AuthContext): ToolContext {
     mcpSessionId: authCtx.mcpSessionId ?? null,
     mcpAppsSupported: authCtx.mcpAppsSupported ?? false,
     mcpAppApprovalCapability: authCtx.mcpAppApprovalCapability ?? null,
+    mcpAppSnapshotCapability: authCtx.mcpAppSnapshotCapability ?? null,
     mcpConversationId: authCtx.mcpConversationId ?? null,
     executionMode: authCtx.executionMode ?? null,
   };

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -18,7 +18,7 @@ import { getOrgUrlContext } from './view-urls';
 
 // The URI is the host cache key for the immutable template. Bump it whenever
 // the shipped HTML changes; ChatGPT caches both successful and failed fetches.
-export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v8.html';
+export const LOBU_INTERACTION_RESOURCE_URI = 'ui://lobu/interaction/v9.html';
 
 const TITLE_MAX_LENGTH = 200;
 const BLOCK_MAX_ITEMS = 100;
@@ -634,6 +634,7 @@ const resolveLobuApprovalImpl = async (
     agentId: null,
     clientId: null,
     mcpAppApprovalCapability: null,
+    mcpAppSnapshotCapability: null,
   };
   const result = await manageOperations(
     args.decision === 'approve'

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -130,6 +130,8 @@ export interface ToolContext {
   mcpAppsSupported?: boolean | null;
   /** Host-only encrypted token supplied by the Lobu MCP App for one approval click. */
   mcpAppApprovalCapability?: string | null;
+  /** Host-only single-use token that binds a result snapshot to its rendered app card. */
+  mcpAppSnapshotCapability?: string | null;
   /**
    * Server-derived side-effect mode for the run driving these tool calls,
    * carried as a signed worker-token claim. `capture` marks an eval replay:


### PR DESCRIPTION
## Summary
- store each structured MCP App result under a hidden single-use capability, then atomically bind it to the host card id supplied inside the iframe
- preserve tenant, OAuth client, user, conversation, and tool-name scoping while failing closed if two results claim one host card
- ship the updated packed app as immutable `ui://lobu/interaction/v9.html`, preserving v7/v8 aliases
- bump Owletto to merged [#793](https://github.com/lobu-ai/owletto/pull/793) (`487e5963`)

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: focused server integration 18/18; snapshot unit 3/3; configured Owletto Vitest suite; MCP renderer/host 22/22
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: not applicable

### Red evidence
`bunx vitest run src/mcp-apps/_shared/host.test.tsx` failed the new binding test: only `restore_lobu_app_result` was called; `save_lobu_app_state` never received the live result capability and host card id.

Production also reproduced the failure: ChatGPT reused one backend request id for `search_sdk`, `query_sql`, and `query_sdk`; the first snapshot collided with later calls, and a full page reload replaced the rich v8 chart card with an empty `Lobu result`.

### Green evidence
- `bunx vitest run src/__tests__/integration/mcp/mcp-app-resources.test.ts` — 18/18, including reused backend ids, distinct host cards, idempotent bind retry, exact restore, view state, cross-conversation/tool rejection, and collision fail-closed
- `bun test src/__tests__/unit/mcp-app-result-snapshots.test.ts` — 3/3
- `bunx vitest run --reporter=dot` in Owletto — configured full suite passed
- `bun run build:mcp-apps` — v9 packed resource 383,503-byte response, under the 450 KB limit, with no external asset dependency
- `make pre-pr` — clean after rebasing onto `9ace61a20`

## Notes
No new table, migration, or public SDK field. Raw capabilities are never persisted: only their SHA-256 key is stored inside the encrypted snapshot, and the response/request capability remains hidden in MCP `_meta`. The Claude fixer was quota-blocked and made no changes; an explicit nested Codex fixer was terminated before a verdict, so the settled diff was manually reviewed in this Codex task before the deterministic gates.