### PR TITLE
fix(server): block MCP sessions from approving operations

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -895,6 +895,98 @@ describe('MCP Authentication', () => {
     });
   });
 
+  describe('Human approval transport boundary', () => {
+    let approvalSession: Awaited<ReturnType<typeof createTestSession>>;
+
+    beforeAll(async () => {
+      const approvalOwner = await createTestUser({
+        email: 'mcp-session-approval-owner@test.example.com',
+      });
+      await addUserToOrganization(approvalOwner.id, org.id, 'owner');
+      approvalSession = await createTestSession(approvalOwner.id);
+    });
+
+    async function seedPendingApproval(): Promise<number> {
+      const [run] = await getTestDb()<[{ id: number }]>`
+        INSERT INTO runs (
+          organization_id, run_type, status, approval_status, action_key
+        ) VALUES (
+          ${org.id}, 'action', 'pending', 'pending', 'session_auth_reject_probe'
+        )
+        RETURNING id
+      `;
+      return Number(run.id);
+    }
+
+    async function approvalStatus(runId: number): Promise<string> {
+      const [run] = await getTestDb()<[{ approval_status: string }]>`
+        SELECT approval_status
+        FROM runs
+        WHERE id = ${runId} AND organization_id = ${org.id}
+      `;
+      return String(run?.approval_status ?? 'missing');
+    }
+
+    it('denies direct approve/reject sent through an unbound cookie-authenticated MCP session', async () => {
+      const approveRunId = await seedPendingApproval();
+      const rejectRunId = await seedPendingApproval();
+      const calls = [];
+      for (const arguments_ of [
+        { action: 'approve', run_id: approveRunId },
+        { action: 'reject', run_id: rejectRunId, reason: 'MCP must not decide' },
+      ]) {
+        calls.push(
+          await mcpRequest<{ content?: Array<{ text?: string }> }>(
+            'tools/call',
+            { name: 'manage_operations', arguments: arguments_ },
+            { cookie: approvalSession.cookieHeader, orgSlug: org.slug }
+          )
+        );
+      }
+
+      expect(await approvalStatus(approveRunId)).toBe('pending');
+      expect(await approvalStatus(rejectRunId)).toBe('pending');
+      for (const call of calls) {
+        expect(call.error).toBeUndefined();
+        expect(call.result?.content?.[0]?.text).toContain('human web session');
+      }
+    });
+
+    it('denies approve/reject through run_sdk on an unbound Better Auth session bearer', async () => {
+      const approveRunId = await seedPendingApproval();
+      const rejectRunId = await seedPendingApproval();
+      const result = await mcpRequest<{ content?: Array<{ text?: string }> }>(
+        'tools/call',
+        {
+          name: 'run_sdk',
+          arguments: {
+            script: `export default async (_ctx, client) => {
+              const message = async (call) => {
+                try {
+                  const value = await call();
+                  return JSON.stringify(value);
+                } catch (error) {
+                  return String(error && error.message ? error.message : error);
+                }
+              };
+              return {
+                approve: await message(() => client.operations.approve({ run_id: ${approveRunId} })),
+                reject: await message(() => client.operations.reject({ run_id: ${rejectRunId}, reason: 'MCP SDK must not decide' })),
+              };
+            };`,
+          },
+        },
+        { token: approvalSession.token, orgSlug: org.slug }
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(await approvalStatus(approveRunId)).toBe('pending');
+      expect(await approvalStatus(rejectRunId)).toBe('pending');
+      const text = result.result?.content?.[0]?.text ?? '';
+      expect(text.match(/human web session/g) ?? []).toHaveLength(2);
+    });
+  });
+
   describe('Personal Access Token Authentication', () => {
     it('should accept valid PAT (owl_pat_*)', async () => {
       const { token } = await createTestPAT(user.id, org.id);

--- a/packages/server/src/__tests__/integration/operations-approval-batch-scope.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-batch-scope.test.ts
@@ -23,14 +23,17 @@ import {
 	addUserToOrganization,
 	createTestConnection,
 	createTestConnectorDefinition,
+	createTestSession,
 	createTestUser,
 	seedOwnerContext,
 } from "../setup/test-fixtures";
+import { post } from "../setup/test-helpers";
 
 const APPROVAL_CONNECTOR = "demo.batch.approval";
 
 describe("manage_operations batch scope (connector-approval lane)", () => {
 	let orgId: string;
+	let orgSlug: string;
 	let ownerCtx: ToolContext;
 	let memberCtx: ToolContext;
 	let approvalConnectionId: number;
@@ -42,6 +45,7 @@ describe("manage_operations batch scope (connector-approval lane)", () => {
 			orgName: "Batch Scope Org",
 		});
 		orgId = org.id;
+		orgSlug = org.slug;
 		ownerCtx = ctx;
 		const member = await createTestUser({ name: "Batch Scope Member" });
 		await addUserToOrganization(member.id, org.id);
@@ -360,6 +364,63 @@ describe("manage_operations batch scope (connector-approval lane)", () => {
 		}
 
 		expect(await approvalStatusOf(pending)).toBe("pending");
+	});
+
+	it("rejects an otherwise-human caller whose request came through MCP", async () => {
+		const mcpCtx = {
+			...ownerCtx,
+			agentId: null,
+			clientId: null,
+			mcpSessionId: "unbound-human-session",
+			tokenType: "session",
+		} as ToolContext;
+		const attempts: Array<{ pending: number; result: { error?: string } }> = [];
+
+		for (const action of ["reject_batch", "approve_batch"] as const) {
+			const actionKey = `mcp_${action}`;
+			const pending = await seedPendingAction({
+				connectorKey: "github",
+				actionKey,
+			});
+			const result = (await manageOperations(
+				{
+					action,
+					scope: { connector_key: "github", action_key: actionKey },
+				},
+				{} as Env,
+				mcpCtx,
+			)) as { error?: string };
+			attempts.push({ pending, result });
+		}
+
+		for (const { pending } of attempts) {
+			expect(await approvalStatusOf(pending)).toBe("pending");
+		}
+		for (const { result } of attempts) {
+			expect(result.error).toContain("human web session");
+		}
+	});
+
+	it("keeps credentialed native REST approval working outside MCP", async () => {
+		const pending = await seedPendingAction({
+			connectionId: approvalConnectionId,
+			connectorKey: APPROVAL_CONNECTOR,
+			actionKey: "needs_approval",
+		});
+		const session = await createTestSession(ownerCtx.userId!);
+
+		const response = await post(`/api/${orgSlug}/manage_operations`, {
+			body: { action: "approve", run_id: pending },
+			cookie: session.cookieHeader,
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			action: "approve",
+			approved: true,
+			run_id: pending,
+		});
+		expect(await approvalStatusOf(pending)).toBe("approved");
 	});
 
 	it("rejects a caller with no verified human identity", async () => {

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -2431,15 +2431,16 @@ async function isPendingEntityRunOwner(
  * context runs with `userId=null` and NO client id, so it would slip past a
  * client-id-only guard AND past {@link isSystemContext}'s role bypass — letting
  * an automation approve a run it queued (sol review #3). We therefore require a
- * positive human identity: `userId` present, and no agent identity on the
- * context. Returns an error result (surfaced to the caller) or null when the
- * context is a genuine human. One gate, called by every approve/reject entry.
+ * positive human identity: `userId` present, and no agent, OAuth client, or MCP
+ * transport identity on the context. Returns an error result (surfaced to the
+ * caller) or null when the context is a genuine human. One gate, called by
+ * every approve/reject entry.
  */
 function requireHumanApprovalContext(
 	ctx: ToolContext,
 	verb: "approve" | "reject",
 ): { error: string } | null {
-	if (ctx.agentId || ctx.clientId) {
+	if (ctx.agentId || ctx.clientId || ctx.mcpSessionId) {
 		return {
 			error: `Operation ${verb === "approve" ? "approval" : "rejection"} requires a human web session. Agents cannot ${verb} operations.`,
 		};

--- a/packages/server/src/tools/mcp_app.ts
+++ b/packages/server/src/tools/mcp_app.ts
@@ -633,6 +633,7 @@ const resolveLobuApprovalImpl = async (
     ...ctx,
     agentId: null,
     clientId: null,
+    mcpSessionId: null,
     mcpAppApprovalCapability: null,
     mcpAppSnapshotCapability: null,
   };


### PR DESCRIPTION
## Summary

- Reject operation approvals and rejections whenever the call still carries an MCP transport session identity.
- Preserve the validated MCP App approval-capability path by clearing `mcpSessionId` only after its run/org/user/client/session/event/expiry checks pass.
- Cover direct MCP dispatch, `run_sdk`, batch decisions, native REST, Slack, and MCP App compatibility.

## Test plan

- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit`; full server integration Vitest; focused MCP/REST/Slack/MCP App suites
- [x] Bug fix: red→fix→green outputs pasted below
- [ ] If bot behavior: N/A

Red, before the production fix:

```text
FAIL Human approval transport boundary > direct cookie MCP
expected approval_status "pending", received "rejected"
FAIL Human approval transport boundary > run_sdk Better Auth bearer
expected approval_status "pending", received "rejected"
FAIL manage_operations batch scope > otherwise-human MCP context
expected approval_status "pending", received "rejected"

Test Files  2 failed (2)
Tests       3 failed | 59 skipped (62)
```

Green, after the fix and strengthened real-run assertions:

```text
Test Files  2 passed (2)
Tests       4 passed | 58 skipped (62)
```

Additional evidence:

- `make test-unit`: clean.
- Full server Vitest integration phase: 408/408 files passed; 3,664 passed, 2 skipped.
- The long serial gateway tail hit five unrelated 5-second setup-hook timeouts; all five exact files passed in isolation (79/79 tests).
- Rebased compatibility run: 100/100 Vitest tests passed (2 skipped) plus 6/6 Slack interaction-bridge tests.
- `make pre-pr`: all six gates clean on the rebased commit.

## Notes

The human-facing error keeps the existing `human web session` phrase asserted by compatibility tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Approval and rejection requests initiated through MCP sessions are now blocked and remain pending.
  - Responses clearly direct callers to use a signed-in human web session for approval actions.
  - Credentialed native REST approvals continue to work as expected.
  - Improved protection against automated or indirect approval of pending operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->