### PR TITLE
test(providers): enforce production protocol readiness

### DIFF
--- a/.github/workflows/providers-live.yml
+++ b/.github/workflows/providers-live.yml
@@ -9,10 +9,9 @@ name: Live Providers
 #   - keyless: probes every composed chat/models route against the real API
 #     (a wrong path 404s, a right path 401s) and checks each defaultModel
 #     against the public catalogs. Runs with NO secrets, every time.
-#   - keyed:   full models + chat + tool-call round-trip for each provider
-#     whose API key is present below; the rest skip cleanly. Add a repo
-#     secret named after the provider's env var (e.g. OPENAI_API_KEY) to
-#     light up its row — no code change needed.
+#   - keyed:   production-adapter streaming + tool-call round-trip. The required
+#     readiness tier fails closed when a credential is missing; extra provider
+#     secrets remain optional coverage.
 
 on:
   schedule:
@@ -56,13 +55,14 @@ jobs:
       - name: Validate providers (keyless + keyed)
         run: make test-providers-live
         env:
+          REQUIRED_LIVE_PROVIDERS: claude,openai,gemini,openrouter
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-          # z-ai: the live suite accepts either name; provide whichever exists.
-          Z_AI_API_KEY: ${{ secrets.Z_AI_API_KEY }}
-          ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}

--- a/.github/workflows/providers-live.yml
+++ b/.github/workflows/providers-live.yml
@@ -6,9 +6,9 @@ name: Live Providers
 # an endpoint, or changing its auth scheme surfaces here instead of in prod.
 #
 # Two tiers (both driven by `make test-providers-live`):
-#   - keyless: probes every composed chat/models route against the real API
-#     (a wrong path 404s, a right path 401s) and checks each defaultModel
-#     against the public catalogs. Runs with NO secrets, every time.
+#   - keyless: probes every protocol-correct completion/models route against
+#     the real API and checks each defaultModel against public catalogs. Runs
+#     with NO secrets, every time.
 #   - keyed:   production-adapter streaming + tool-call round-trip. The required
 #     readiness tier fails closed when a credential is missing; extra provider
 #     secrets remain optional coverage.

--- a/Makefile
+++ b/Makefile
@@ -208,12 +208,11 @@ test-e2e-cli:
 
 # Live provider validation — opt-in, networked, NOT part of the default gates.
 # Two tiers, both derived from config/providers.json:
-#   keyless — probes every composed chat/models route against the real APIs
-#             (wrong path 404s, right path 401s) and checks defaultModel
-#             against the public catalogs; needs NO keys, runs every time.
-#   keyed   — full models + chat + tool-call round-trip per provider whose API
-#             key is in the env; the rest skip cleanly. Replaces the manual
-#             provider pass. Pass keys via .env or the environment.
+#   keyless — probes every protocol-correct completion/models route against the
+#             real APIs and checks defaultModel against public catalogs.
+#   keyed   — production-adapter streaming + parsed tool-call round-trip per
+#             configured credential. REQUIRED_LIVE_PROVIDERS fails closed when
+#             a required credential is absent.
 #   make test-providers-live                      # keyless tier + whichever keys are set
 #   OPENAI_API_KEY=sk-... make test-providers-live
 test-providers-live:

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -388,6 +388,7 @@ describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
     expect(model.baseUrl).toBe(
       "http://localhost:8118/api/proxy/gemini/a/agent-1"
     );
+    expect(model.compat?.supportsStore).toBe(false);
   });
 
   test("uses the passed pi-ai api for non-openai protocols (generic)", () => {
@@ -401,6 +402,7 @@ describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
     expect(model.api).toBe("anthropic-messages");
     expect(model.provider).toBe("anthropic");
     expect(model.id).toBe("claude-opus-4-8");
+    expect(model.compat).toBeUndefined();
   });
 
   test("defaults to openai-completions when no api is passed", () => {
@@ -479,6 +481,19 @@ describe("resolveDynamicModelApi — real OpenAI uses the Responses API", () => 
   test("non-openai registry aliases resolve through the alias map", () => {
     expect(resolveDynamicModelApi("my-claude", "anthropic")).toBe(
       "anthropic-messages"
+    );
+  });
+
+  test("a dynamic official-OpenAI alias preserves its Responses protocol", () => {
+    const providerId = "test-openai-responses-alias";
+    registerDynamicProvider(providerId, {
+      sdkCompat: "openai-responses",
+      baseUrlEnvVar: "TEST_OPENAI_RESPONSES_BASE_URL",
+    });
+
+    expect(PROVIDER_REGISTRY_ALIASES[providerId]).toBe("openai");
+    expect(resolveDynamicModelApi(providerId, "openai")).toBe(
+      "openai-responses"
     );
   });
 });

--- a/packages/agent-worker/src/__tests__/provider-protocol-e2e.test.ts
+++ b/packages/agent-worker/src/__tests__/provider-protocol-e2e.test.ts
@@ -1,0 +1,498 @@
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import type { PiAiApi } from "@lobu/core";
+import { completeSimple, type Context, type Model } from "@mariozechner/pi-ai";
+import { buildDynamicOpenAIModel } from "../runtime/model-resolver";
+
+type Protocol =
+  | "anthropic-messages"
+  | "openai-responses"
+  | "openai-completions"
+  | "openai-codex-responses";
+
+interface CapturedRequest {
+  method: string | undefined;
+  path: string | undefined;
+  headers: IncomingMessage["headers"];
+  body: Record<string, unknown>;
+}
+
+interface StrictServer {
+  origin: string;
+  requests: CapturedRequest[];
+  close(): Promise<void>;
+}
+
+const servers: StrictServer[] = [];
+
+// Loading the real provider adapters can take several seconds on a cold Bun
+// process; the upstream itself is local and still has a short request timeout.
+setDefaultTimeout(20_000);
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+});
+
+function writeSse(
+  res: ServerResponse,
+  events: unknown[],
+  namedEvents = false
+): void {
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "close",
+  });
+  for (const event of events) {
+    if (namedEvents && typeof event === "object" && event !== null) {
+      const type = (event as { type?: unknown }).type;
+      if (typeof type === "string") res.write(`event: ${type}\n`);
+    }
+    res.write(`data: ${JSON.stringify(event)}\n\n`);
+  }
+  res.write("data: [DONE]\n\n");
+  res.end();
+}
+
+function openAIResponsesEvents(model: string): unknown[] {
+  const textItem = {
+    id: "msg_protocol_1",
+    type: "message",
+    role: "assistant",
+    content: [
+      {
+        type: "output_text",
+        text: "adapter-ok",
+        annotations: [],
+      },
+    ],
+    status: "completed",
+  };
+  const toolItem = {
+    id: "fc_protocol_1",
+    type: "function_call",
+    call_id: "call_protocol_1",
+    name: "get_weather",
+    arguments: '{"city":"Paris"}',
+    status: "completed",
+  };
+  return [
+    {
+      type: "response.created",
+      response: { id: "resp_protocol_1", model, status: "in_progress" },
+    },
+    {
+      type: "response.output_item.added",
+      item: { ...textItem, content: [], status: "in_progress" },
+    },
+    {
+      type: "response.content_part.added",
+      part: { type: "output_text", text: "", annotations: [] },
+    },
+    { type: "response.output_text.delta", delta: "adapter-ok" },
+    { type: "response.output_item.done", item: textItem },
+    {
+      type: "response.output_item.added",
+      item: { ...toolItem, arguments: "", status: "in_progress" },
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      delta: '{"city":"Paris"}',
+    },
+    {
+      type: "response.function_call_arguments.done",
+      arguments: '{"city":"Paris"}',
+    },
+    { type: "response.output_item.done", item: toolItem },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_protocol_1",
+        model,
+        status: "completed",
+        output: [textItem, toolItem],
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+          total_tokens: 2,
+          input_tokens_details: { cached_tokens: 0 },
+        },
+      },
+    },
+  ];
+}
+
+function anthropicEvents(model: string): unknown[] {
+  return [
+    {
+      type: "message_start",
+      message: {
+        id: "msg_protocol_1",
+        type: "message",
+        role: "assistant",
+        model,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "adapter-ok" },
+    },
+    { type: "content_block_stop", index: 0 },
+    {
+      type: "content_block_start",
+      index: 1,
+      content_block: {
+        type: "tool_use",
+        id: "toolu_protocol_1",
+        name: "get_weather",
+        input: {},
+      },
+    },
+    {
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "input_json_delta", partial_json: '{"city":"Paris"}' },
+    },
+    { type: "content_block_stop", index: 1 },
+    {
+      type: "message_delta",
+      delta: { stop_reason: "tool_use", stop_sequence: null },
+      usage: { output_tokens: 2 },
+    },
+    { type: "message_stop" },
+  ];
+}
+
+function openAICompletionEvents(model: string): unknown[] {
+  const base = {
+    id: "chatcmpl_protocol_1",
+    object: "chat.completion.chunk",
+    created: 1,
+    model,
+  };
+  return [
+    {
+      ...base,
+      choices: [
+        { index: 0, delta: { role: "assistant" }, finish_reason: null },
+      ],
+    },
+    {
+      ...base,
+      choices: [
+        { index: 0, delta: { content: "adapter-ok" }, finish_reason: null },
+      ],
+    },
+    {
+      ...base,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: "call_protocol_1",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: '{"city":"Paris"}',
+                },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      ...base,
+      choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  ];
+}
+
+async function startStrictServer(args: {
+  protocol: Protocol;
+  expectedPath: string;
+  model: string;
+}): Promise<StrictServer> {
+  const requests: CapturedRequest[] = [];
+  const server = createServer((req, res) => {
+    let rawBody = "";
+    req.on("data", (chunk) => {
+      rawBody += chunk;
+    });
+    req.on("end", () => {
+      if (req.method !== "POST" || req.url !== args.expectedPath) {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "unexpected protocol path" }));
+        return;
+      }
+
+      let body: Record<string, unknown>;
+      try {
+        body = JSON.parse(rawBody) as Record<string, unknown>;
+      } catch {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "invalid JSON" }));
+        return;
+      }
+      requests.push({
+        method: req.method,
+        path: req.url,
+        headers: req.headers,
+        body,
+      });
+
+      const events =
+        args.protocol === "anthropic-messages"
+          ? anthropicEvents(args.model)
+          : args.protocol === "openai-completions"
+            ? openAICompletionEvents(args.model)
+            : openAIResponsesEvents(args.model);
+      writeSse(res, events, args.protocol === "anthropic-messages");
+    });
+  });
+
+  const strictServer = await new Promise<StrictServer>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("strict provider server did not expose a TCP port"));
+        return;
+      }
+      resolve({
+        origin: `http://127.0.0.1:${address.port}`,
+        requests,
+        close: () =>
+          new Promise<void>((done, closeReject) => {
+            if (!server.listening) {
+              done();
+              return;
+            }
+            server.close((error) => (error ? closeReject(error) : done()));
+          }),
+      });
+    });
+  });
+  servers.push(strictServer);
+  return strictServer;
+}
+
+function dynamicModel(args: {
+  rawProvider: string;
+  registryProvider: string;
+  model: string;
+  api: PiAiApi;
+  baseUrl: string;
+}): Model<any> {
+  return buildDynamicOpenAIModel({
+    rawProvider: args.rawProvider,
+    registryProvider: args.registryProvider,
+    modelId: args.model,
+    providerBaseUrl: args.baseUrl,
+    api: args.api,
+  }) as Model<any>;
+}
+
+function fakeCodexToken(): string {
+  const encode = (value: unknown) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode({
+    "https://api.openai.com/auth": {
+      chatgpt_account_id: "acct_protocol_test",
+    },
+  })}.signature`;
+}
+
+const context: Context = {
+  systemPrompt: "Protocol conformance test",
+  messages: [
+    {
+      role: "user",
+      content: "Use get_weather for Paris.",
+      timestamp: 1,
+    },
+  ],
+  tools: [
+    {
+      name: "get_weather",
+      description: "Get the weather for a city",
+      parameters: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+        additionalProperties: false,
+      } as never,
+    },
+  ],
+};
+
+async function exercise(args: {
+  label: string;
+  protocol: Protocol;
+  rawProvider: string;
+  registryProvider: string;
+  api: PiAiApi;
+  model: string;
+  basePath: string;
+  endpointPath: string;
+  apiKey?: string;
+}): Promise<void> {
+  const strict = await startStrictServer({
+    protocol: args.protocol,
+    expectedPath: args.endpointPath,
+    model: args.model,
+  });
+  const baseUrl = `${strict.origin}${args.basePath}`;
+  const model = dynamicModel({
+    rawProvider: args.rawProvider,
+    registryProvider: args.registryProvider,
+    model: args.model,
+    api: args.api,
+    baseUrl,
+  });
+  const apiKey = args.apiKey ?? "protocol-test-secret";
+
+  const response = await completeSimple(model, context, {
+    apiKey,
+    cacheRetention: "none",
+    maxRetries: 0,
+    maxTokens: 128,
+    timeoutMs: 10_000,
+    ...(args.protocol === "openai-codex-responses"
+      ? { transport: "sse" as const }
+      : {}),
+  });
+
+  expect(response.stopReason, `${args.label}: parsed stop reason`).toBe(
+    "toolUse"
+  );
+  expect(
+    response.content.some(
+      (block) => block.type === "text" && block.text === "adapter-ok"
+    ),
+    `${args.label}: streamed text was parsed`
+  ).toBe(true);
+  expect(
+    response.content.find((block) => block.type === "toolCall"),
+    `${args.label}: streamed tool call was parsed`
+  ).toMatchObject({
+    type: "toolCall",
+    name: "get_weather",
+    arguments: { city: "Paris" },
+  });
+
+  expect(
+    strict.requests,
+    `${args.label}: exactly one upstream request`
+  ).toHaveLength(1);
+  const request = strict.requests[0]!;
+  expect(request.path).toBe(args.endpointPath);
+  expect(request.body.model).toBe(args.model);
+  expect(request.body.stream).toBe(true);
+  expect(Array.isArray(request.body.tools)).toBe(true);
+
+  if (args.protocol === "anthropic-messages") {
+    expect(request.headers["x-api-key"]).toBe(apiKey);
+    expect(request.body.messages).toBeArray();
+  } else {
+    expect(request.headers.authorization).toBe(`Bearer ${apiKey}`);
+  }
+  if (
+    args.protocol === "openai-responses" ||
+    args.protocol === "openai-codex-responses"
+  ) {
+    expect(request.body.input).toBeArray();
+  } else if (args.protocol === "openai-completions") {
+    expect(request.body.messages).toBeArray();
+    expect(
+      request.body.store,
+      `${args.label}: third-party compat payload must omit OpenAI-only store`
+    ).toBeUndefined();
+  }
+  if (args.protocol === "openai-codex-responses") {
+    expect(request.headers["chatgpt-account-id"]).toBe("acct_protocol_test");
+    expect(request.body.instructions).toBe("Protocol conformance test");
+  }
+}
+
+describe("production provider protocol adapters", () => {
+  test("Anthropic uses Messages with x-api-key and parses streamed tools", () =>
+    exercise({
+      label: "anthropic",
+      protocol: "anthropic-messages",
+      rawProvider: "claude",
+      registryProvider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-sonnet-5",
+      basePath: "",
+      endpointPath: "/v1/messages",
+    }));
+
+  test("OpenAI API uses Responses and parses streamed tools", () =>
+    exercise({
+      label: "openai",
+      protocol: "openai-responses",
+      rawProvider: "openai",
+      registryProvider: "openai",
+      api: "openai-responses",
+      model: "gpt-5.6-sol",
+      basePath: "/v1",
+      endpointPath: "/v1/responses",
+    }));
+
+  test("Gemini uses its OpenAI-compatible Chat Completions base", () =>
+    exercise({
+      label: "gemini",
+      protocol: "openai-completions",
+      rawProvider: "gemini",
+      registryProvider: "openai",
+      api: "openai-completions",
+      model: "gemini-2.5-pro",
+      basePath: "/v1beta/openai",
+      endpointPath: "/v1beta/openai/chat/completions",
+    }));
+
+  test("OpenRouter preserves vendor model namespaces over Chat Completions", () =>
+    exercise({
+      label: "openrouter",
+      protocol: "openai-completions",
+      rawProvider: "openrouter",
+      registryProvider: "openai",
+      api: "openai-completions",
+      model: "anthropic/claude-sonnet-5",
+      basePath: "/api/v1",
+      endpointPath: "/api/v1/chat/completions",
+    }));
+
+  test("ChatGPT subscription uses Codex Responses with account-bound auth", () =>
+    exercise({
+      label: "chatgpt",
+      protocol: "openai-codex-responses",
+      rawProvider: "openai-codex",
+      registryProvider: "openai-codex",
+      api: "openai-codex-responses",
+      model: "gpt-5.1-codex-max",
+      basePath: "/backend-api",
+      endpointPath: "/backend-api/codex/responses",
+      apiKey: fakeCodexToken(),
+    }));
+});

--- a/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
@@ -57,6 +57,16 @@ function makeClient(dispatcherUrl = "https://gw.example.com") {
 // ---------------------------------------------------------------------------
 
 describe("consumePendingConfigNotifications", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   test("returns empty array when no notifications are pending", () => {
     // Drain any notifications from earlier tests first
     consumePendingConfigNotifications();

--- a/packages/agent-worker/src/runtime/model-resolver.ts
+++ b/packages/agent-worker/src/runtime/model-resolver.ts
@@ -95,6 +95,9 @@ export const PIAI_API_BY_REGISTRY_ALIAS: Record<string, PiAiApi> =
       .map((p) => [p.registryAlias, p.api])
   );
 
+/** Exact adapters for dynamically registered provider slugs. */
+const PIAI_API_BY_DYNAMIC_PROVIDER: Record<string, PiAiApi> = {};
+
 /**
  * Resolve the pi-ai wire adapter for a DYNAMIC model entry (one not present in
  * pi-ai's static registry).
@@ -115,6 +118,8 @@ export function resolveDynamicModelApi(
   registryProvider: string
 ): PiAiApi | undefined {
   if (rawProvider === "openai") return "openai-responses";
+  const registeredApi = PIAI_API_BY_DYNAMIC_PROVIDER[rawProvider];
+  if (registeredApi) return registeredApi;
   return PIAI_API_BY_REGISTRY_ALIAS[registryProvider];
 }
 
@@ -129,6 +134,11 @@ export function registerDynamicProvider(
 ): void {
   const alreadyRegistered = !!DEFAULT_PROVIDER_BASE_URL_ENV[id];
 
+  const protocol = resolveSdkCompat(config.sdkCompat);
+  if (protocol && !PIAI_API_BY_DYNAMIC_PROVIDER[id]) {
+    PIAI_API_BY_DYNAMIC_PROVIDER[id] = protocol.api;
+  }
+
   if (!alreadyRegistered) {
     DEFAULT_PROVIDER_BASE_URL_ENV[id] = config.baseUrlEnvVar;
   }
@@ -141,8 +151,7 @@ export function registerDynamicProvider(
   // Map to model registry name: explicit alias, else the protocol's registry
   // alias (e.g. openai-compatible → "openai", anthropic → "anthropic").
   if (!PROVIDER_REGISTRY_ALIASES[id]) {
-    const alias =
-      config.registryAlias || resolveSdkCompat(config.sdkCompat)?.registryAlias;
+    const alias = config.registryAlias || protocol?.registryAlias;
     if (alias) {
       PROVIDER_REGISTRY_ALIASES[id] = alias;
     }
@@ -173,6 +182,9 @@ interface DynamicModel {
   };
   contextWindow: number;
   maxTokens: number;
+  compat?: {
+    supportsStore: boolean;
+  };
 }
 
 /**
@@ -221,6 +233,14 @@ export function buildDynamicOpenAIModel(args: {
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128000,
     maxTokens: 16384,
+    // pi-ai assumes Chat Completions endpoints accept OpenAI's `store` field.
+    // Third-party compat APIs such as Gemini reject it with a protocol-level
+    // 400 ("Unknown name 'store'"). Session setup applies the same defensive
+    // override to static models; put it on dynamic entries at construction too
+    // so every direct consumer gets the production-safe payload.
+    ...(api === "openai-completions" && !isRealOpenAI
+      ? { compat: { supportsStore: false } }
+      : {}),
   };
 }
 

--- a/packages/server/src/__tests__/live-providers/provider-keyless.test.ts
+++ b/packages/server/src/__tests__/live-providers/provider-keyless.test.ts
@@ -2,10 +2,10 @@
  * Keyless provider validation — network-gated, but needs NO API keys.
  *
  * The oracle is each provider's own live API, exploited through two facts:
- *   1. An unauthenticated request to a RIGHT path is rejected with 401/403
- *      (or 400 for malformed-body checks that run before auth); a WRONG path
- *      404s. So `status !== 404` validates every composed endpoint URL
- *      against reality with zero credentials — no pinned URL tables.
+ *   1. An unauthenticated request to the protocol-correct path is rejected
+ *      before inference. A 404/405 catches an upstream route that disappeared.
+ *      Exact protocol serialization is covered deterministically by the worker
+ *      adapter E2E; this network check only detects upstream drift.
  *   2. Some providers serve their model catalog publicly. When the models
  *      endpoint answers 200 with a non-empty list, the configured
  *      defaultModel must be in it — which catches model deprecations (this
@@ -14,8 +14,8 @@
  *      are skipped automatically, so nothing here is hardcoded per provider.
  *
  * Everything is derived from config/providers.json, mirroring production
- * composition: chat = `upstreamBaseUrl + /chat/completions` (what the
- * worker's OpenAI SDK + gateway proxy produce), models =
+ * composition: completion path comes from the production adapter protocol;
+ * models =
  * `upstreamBaseUrl + modelsEndpoint` (fetchModelsGeneric).
  *
  * Runs as part of `make test-providers-live` (this directory) — so even a
@@ -27,6 +27,8 @@ import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { SdkCompat } from "@lobu/core";
+import { providerCompletionUrl } from "./provider-protocol.js";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(thisDir, "../../../../..");
@@ -36,6 +38,7 @@ interface ProviderEntry {
 	upstreamBaseUrl: string;
 	defaultModel?: string;
 	modelsEndpoint?: string;
+	sdkCompat?: SdkCompat;
 }
 
 const registry = JSON.parse(
@@ -68,19 +71,20 @@ async function probe(
 
 for (const { id, provider } of flattened) {
 	const base = provider.upstreamBaseUrl.replace(/\/$/, "");
+	const completionUrl = providerCompletionUrl(id, provider);
 
 	describe(`keyless: ${id} (${provider.displayName})`, () => {
 		test(
-			"chat endpoint exists (route must not 404)",
+			"completion endpoint exists (route must not 404)",
 			async () => {
-				const { status } = await probe(`${base}/chat/completions`, {
+				const { status } = await probe(completionUrl, {
 					method: "POST",
 					headers: { "content-type": "application/json" },
 					body: "{}",
 				});
 				expect(
 					[404, 405].includes(status),
-					`${id} chat route ${base}/chat/completions answered ${status} — ` +
+					`${id} completion route ${completionUrl} answered ${status} — ` +
 						"the composed URL does not exist upstream",
 				).toBe(false);
 			},

--- a/packages/server/src/__tests__/live-providers/provider-protocol.ts
+++ b/packages/server/src/__tests__/live-providers/provider-protocol.ts
@@ -1,0 +1,50 @@
+import {
+	type PiAiApi,
+	type SdkCompat,
+	resolveSdkCompat,
+} from "@lobu/core";
+
+export type ProviderApi = PiAiApi | "openai-codex-responses";
+
+export interface ProtocolProviderEntry {
+	upstreamBaseUrl: string;
+	sdkCompat?: SdkCompat;
+}
+
+/** Resolve the same wire adapter the worker uses for a bundled provider. */
+export function resolveProviderApi(
+	id: string,
+	provider: ProtocolProviderEntry,
+): ProviderApi | null {
+	if (id === "chatgpt") return "openai-codex-responses";
+	if (id === "openai") return "openai-responses";
+	return resolveSdkCompat(provider.sdkCompat)?.api ?? null;
+}
+
+export function providerCompletionPath(api: ProviderApi): string {
+	switch (api) {
+		case "anthropic-messages":
+			return "/v1/messages";
+		case "openai-responses":
+			return "/responses";
+		case "openai-codex-responses":
+			return "/codex/responses";
+		case "openai-completions":
+			return "/chat/completions";
+		case "google-generative-ai":
+		case "bedrock-converse-stream":
+		case "mistral-conversations":
+			throw new Error(
+				`Live URL composition is not implemented for adapter ${api}`,
+			);
+	}
+}
+
+export function providerCompletionUrl(
+	id: string,
+	provider: ProtocolProviderEntry,
+): string {
+	const api = resolveProviderApi(id, provider);
+	if (!api) throw new Error(`${id} does not declare a routable model protocol`);
+	return `${provider.upstreamBaseUrl.replace(/\/$/, "")}${providerCompletionPath(api)}`;
+}

--- a/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
+++ b/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
@@ -1,49 +1,49 @@
 /**
- * Live provider smoke test — opt-in, key-gated, replaces the manual pass.
+ * Live provider smoke test — opt-in, credential-gated upstream validation.
  *
- * The internal plumbing (config parsing, proxy wiring, composed URLs) is
- * covered deterministically by provider-registry-contract.test.ts. What none
- * of that can tell you is the thing that breaks out from under you in prod:
- * "does provider X actually answer today?" — a model gets deprecated, an
- * endpoint moves, an auth scheme changes upstream.
+ * Unlike the deterministic protocol E2E, this suite answers the time-sensitive
+ * question: does the configured upstream, credential, and default model work
+ * today? It uses pi-ai's production adapters and consumes their real streaming
+ * responses, so Anthropic Messages, OpenAI Responses, ChatGPT Codex Responses,
+ * and OpenAI-compatible Chat Completions are serialized and parsed exactly as
+ * worker turns are.
  *
- * This suite walks EVERY provider in config/providers.json and, for each one
- * whose API key is present in the environment, performs a real round-trip:
- *   1. list models            — validates auth + the models endpoint
- *      (skipped for providers with no model-listing surface: z-ai)
- *   2. chat completion        — validates the OpenAI-compatible chat surface
- *   3. tool-calling (lenient) — validates the agent's primary capability,
- *                               warn-only since model support varies
- *
- * Providers with no key in env are cleanly skipped (describe.skipIf), so the
- * suite grows coverage automatically as keys are added to CI secrets. It does
- * NOT run in the default unit/integration/e2e gates — invoke it explicitly via
- * `make test-providers-live` (or `bun test` on this path).
- *
- * URL construction mirrors production exactly:
- *   - models: ApiKeyProviderModule.fetchModelsGeneric / fetchGeminiModels
- *   - chat:   `${upstreamBaseUrl}/chat/completions` — the worker's OpenAI SDK
- *     appends that path verbatim to its baseURL and the proxy forwards
- *     `upstreamBaseUrl + path` (validated keyless
- *     against the live APIs by provider-keyless.test.ts in this directory)
- * so a passing smoke means the real worker path works, not just some URL.
+ * REQUIRED_LIVE_PROVIDERS is a comma-separated readiness tier. Every listed
+ * provider must have a dedicated credential, answer a text turn, and return a
+ * forced tool call. Other configured credentials receive text coverage and a
+ * best-effort tool probe without becoming release blockers.
  */
 
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { SdkCompat } from "@lobu/core";
+import {
+	completeSimple,
+	type Context,
+	type Model,
+} from "@mariozechner/pi-ai";
+import {
+	type ProviderApi,
+	resolveProviderApi,
+} from "./provider-protocol.js";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
-// packages/server/src/__tests__/live-providers -> repo root is five levels up.
 const repoRoot = resolve(thisDir, "../../../../..");
 
 interface ProviderEntry {
 	displayName: string;
 	envVarName: string;
 	upstreamBaseUrl: string;
+	sdkCompat?: SdkCompat;
 	defaultModel?: string;
 	modelsEndpoint?: string;
+}
+
+interface Credential {
+	value: string;
+	kind: "api-key" | "oauth";
 }
 
 const registry = JSON.parse(
@@ -54,207 +54,335 @@ const flattened = registry.providers.flatMap((entry) =>
 	(entry.providers || []).map((provider) => ({ id: entry.id, provider })),
 );
 
-/**
- * Chat models for providers whose registry entry has no defaultModel.
- * Mirrors DEFAULT_PROVIDER_MODELS in agent-worker/src/runtime/model-resolver.ts
- * (not importable here — agent-worker is not a dependency of server).
- */
-const FALLBACK_CHAT_MODELS: Record<string, string> = {
-	"z-ai": "glm-4.7",
+const requiredIds = new Set(
+	(process.env.REQUIRED_LIVE_PROVIDERS || "")
+		.split(",")
+		.map((id) => id.trim())
+		.filter(Boolean),
+);
+
+const FALLBACK_MODELS: Record<string, string> = {
+	chatgpt: "gpt-5.1-codex-max",
 };
 
-/** Resolve the API key for a provider from env (with known aliases). */
-function resolveKey(id: string, envVarName: string): string | undefined {
-	const direct = process.env[envVarName];
-	if (direct) return direct;
-	// Historical alias: the memory-loop e2e harness uses ZAI_API_KEY, while the
-	// registry declares Z_AI_API_KEY. Accept both so one key covers z-ai.
-	if (id === "z-ai") return process.env.ZAI_API_KEY;
+// ZAI remains a supported catalog provider, but it is deliberately outside
+// this production-readiness lane. Do not let an unrelated local ZAI key turn a
+// Claude/OpenAI/Gemini/OpenRouter validation run into a ZAI billing check.
+const EXCLUDED_LIVE_PROVIDER_IDS = new Set(["z-ai"]);
+
+const TIMEOUT_MS = 60_000;
+setDefaultTimeout(120_000);
+
+function firstEnv(names: string[]): string | undefined {
+	for (const name of names) {
+		const value = process.env[name];
+		if (value) return value;
+	}
 	return undefined;
 }
 
-const TIMEOUT_MS = 30_000;
-setDefaultTimeout(60_000);
+/** Never let ChatGPT subscription silently reuse an OpenAI platform API key. */
+function resolveCredential(
+	id: string,
+	envVarName: string,
+): Credential | undefined {
+	if (EXCLUDED_LIVE_PROVIDER_IDS.has(id)) return undefined;
+	if (id === "claude") {
+		const oauth = firstEnv([
+			"ANTHROPIC_AUTH_TOKEN",
+			"CLAUDE_CODE_OAUTH_TOKEN",
+			"ANTHROPIC_OAUTH_TOKEN",
+		]);
+		if (oauth) return { value: oauth, kind: "oauth" };
+		const apiKey = process.env.ANTHROPIC_API_KEY;
+		return apiKey ? { value: apiKey, kind: "api-key" } : undefined;
+	}
+	if (id === "chatgpt") {
+		const oauth = firstEnv([
+			"CHATGPT_OAUTH_TOKEN",
+			"OPENAI_CODEX_OAUTH_TOKEN",
+		]);
+		return oauth ? { value: oauth, kind: "oauth" } : undefined;
+	}
+	const direct = process.env[envVarName];
+	return direct ? { value: direct, kind: "api-key" } : undefined;
+}
 
 async function fetchJson(
 	url: string,
 	init: RequestInit,
 ): Promise<{ status: number; body: unknown }> {
-	const res = await fetch(url, {
+	const response = await fetch(url, {
 		...init,
 		signal: AbortSignal.timeout(TIMEOUT_MS),
 	});
-	const text = await res.text();
+	const text = await response.text();
 	let body: unknown = text;
 	try {
 		body = JSON.parse(text);
 	} catch {
-		/* keep raw text for the error message */
+		// Keep raw text for the assertion message.
 	}
-	return { status: res.status, body };
+	return { status: response.status, body };
 }
 
-/** List model ids, mirroring the module's two model-fetching paths. */
 async function listModels(
 	id: string,
-	p: ProviderEntry,
-	key: string,
+	provider: ProviderEntry,
+	credential: Credential,
 ): Promise<string[]> {
 	if (id === "gemini") {
-		// Mirrors fetchGeminiModels: native models endpoint, key-in-query auth.
 		const url = new URL(
 			"https://generativelanguage.googleapis.com/v1beta/models",
 		);
-		url.searchParams.set("key", key);
+		url.searchParams.set("key", credential.value);
 		const { status, body } = await fetchJson(url.toString(), { method: "GET" });
 		expect(
 			status,
 			`gemini /models returned ${status}: ${JSON.stringify(body)}`,
 		).toBe(200);
-		const models = (body as { models?: Array<{ name?: string }> }).models ?? [];
-		return models
-			.map((m) => m.name?.replace(/^models\//, "").trim())
-			.filter((x): x is string => !!x);
+		return ((body as { models?: Array<{ name?: string }> }).models ?? [])
+			.map((model) => model.name?.replace(/^models\//, "").trim())
+			.filter((id): id is string => !!id);
 	}
 
-	const url = `${p.upstreamBaseUrl.replace(/\/$/, "")}${p.modelsEndpoint}`;
+	if (id === "claude") {
+		const headers: Record<string, string> = {
+			Accept: "application/json",
+			"anthropic-version": "2023-06-01",
+		};
+		if (credential.kind === "oauth") {
+			headers.Authorization = `Bearer ${credential.value}`;
+		} else {
+			headers["x-api-key"] = credential.value;
+		}
+		const { status, body } = await fetchJson(
+			`${provider.upstreamBaseUrl.replace(/\/$/, "")}/v1/models`,
+			{ method: "GET", headers },
+		);
+		expect(
+			status,
+			`claude /v1/models returned ${status}: ${JSON.stringify(body)}`,
+		).toBe(200);
+		return ((body as { data?: Array<{ id?: string }> }).data ?? [])
+			.map((model) => model.id?.trim())
+			.filter((id): id is string => !!id);
+	}
+
+	if (!provider.modelsEndpoint) return [];
+	const url = `${provider.upstreamBaseUrl.replace(/\/$/, "")}${provider.modelsEndpoint}`;
 	const { status, body } = await fetchJson(url, {
 		method: "GET",
-		headers: { Authorization: `Bearer ${key}` },
+		headers: { Authorization: `Bearer ${credential.value}` },
 	});
 	expect(
 		status,
 		`${id} models endpoint returned ${status}: ${JSON.stringify(body)}`,
 	).toBe(200);
-	const data = (body as { data?: Array<{ id?: string }> }).data ?? [];
-	return data.map((m) => m.id?.trim()).filter((x): x is string => !!x);
+	return ((body as { data?: Array<{ id?: string }> }).data ?? [])
+		.map((model) => model.id?.trim())
+		.filter((modelId): modelId is string => !!modelId);
 }
 
+function buildLiveModel(
+	id: string,
+	provider: ProviderEntry,
+	modelId: string,
+): Model<any> {
+	const api = resolveProviderApi(id, provider);
+	if (!api) throw new Error(`${id} has no production model adapter`);
+	const registryProvider =
+		api === "anthropic-messages"
+			? "anthropic"
+			: api === "openai-codex-responses"
+				? "openai-codex"
+				: "openai";
+	return {
+		id: modelId,
+		name: modelId,
+		api,
+		provider: registryProvider,
+		baseUrl: provider.upstreamBaseUrl,
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+		// Match the worker's production payload guard. Gemini's OpenAI-compatible
+		// endpoint returns 400 for OpenAI's `store` field.
+		...(api === "openai-completions"
+			? { compat: { supportsStore: false } }
+			: {}),
+	} as Model<any>;
+}
+
+function textContext(): Context {
+	return {
+		messages: [
+			{
+				role: "user",
+				content: "Reply with exactly the single word: pong",
+				timestamp: Date.now(),
+			},
+		],
+	};
+}
+
+function toolContext(): Context {
+	return {
+		messages: [
+			{
+				role: "user",
+				content: "Use get_weather for Paris.",
+				timestamp: Date.now(),
+			},
+		],
+		tools: [
+			{
+				name: "get_weather",
+				description: "Get the current weather for a city",
+				parameters: {
+					type: "object",
+					properties: { city: { type: "string" } },
+					required: ["city"],
+					additionalProperties: false,
+				} as never,
+			},
+		],
+	};
+}
+
+function forceWeatherTool(api: ProviderApi, payload: unknown): unknown {
+	if (typeof payload !== "object" || payload === null) return payload;
+	const body = payload as Record<string, unknown>;
+	if (api === "anthropic-messages") {
+		return { ...body, tool_choice: { type: "tool", name: "get_weather" } };
+	}
+	if (api === "openai-completions") {
+		return {
+			...body,
+			tool_choice: {
+				type: "function",
+				function: { name: "get_weather" },
+			},
+		};
+	}
+	return { ...body, tool_choice: { type: "function", name: "get_weather" } };
+}
+
+async function completeWithProductionAdapter(args: {
+	id: string;
+	provider: ProviderEntry;
+	credential: Credential;
+	modelId: string;
+	context: Context;
+	forceTool?: boolean;
+}) {
+	const api = resolveProviderApi(args.id, args.provider);
+	if (!api) throw new Error(`${args.id} has no production model adapter`);
+	return completeSimple(
+		buildLiveModel(args.id, args.provider, args.modelId),
+		args.context,
+		{
+			apiKey: args.credential.value,
+			cacheRetention: "none",
+			maxRetries: 0,
+			maxTokens: 1_024,
+			timeoutMs: TIMEOUT_MS,
+			...(api === "openai-codex-responses"
+				? { transport: "sse" as const }
+				: {}),
+			...(args.forceTool
+				? { onPayload: (payload: unknown) => forceWeatherTool(api, payload) }
+				: {}),
+		},
+	);
+}
+
+describe("required live-provider credentials", () => {
+	for (const id of requiredIds) {
+		test(`${id} has a dedicated credential`, () => {
+			const row = flattened.find((entry) => entry.id === id);
+			expect(row, `${id} is not present in config/providers.json`).toBeDefined();
+			expect(
+				row && resolveCredential(id, row.provider.envVarName),
+				`${id} is required but its live credential is missing`,
+			).toBeDefined();
+		});
+	}
+});
+
 const activeIds = flattened
-	.filter(({ id, provider }) => resolveKey(id, provider.envVarName))
+	.filter(({ id, provider }) => resolveCredential(id, provider.envVarName))
 	.map(({ id }) => id);
 if (activeIds.length === 0) {
 	console.warn(
-		"[live-providers] no provider keys in env — every provider skipped. " +
-			"Set e.g. OPENAI_API_KEY to exercise the live smoke.",
+		"[live-providers] no provider credentials in env — keyed provider turns skipped",
 	);
 } else {
 	console.info(`[live-providers] exercising: ${activeIds.join(", ")}`);
 }
 
 for (const { id, provider } of flattened) {
-	const key = resolveKey(id, provider.envVarName);
-	const canListModels = id === "gemini" || !!provider.modelsEndpoint;
+	const credential = resolveCredential(id, provider.envVarName);
+	const required = requiredIds.has(id);
+	const modelId = provider.defaultModel ?? FALLBACK_MODELS[id];
+	const canListModels = id === "claude" || id === "gemini" || !!provider.modelsEndpoint;
 
-	describe.skipIf(!key)(`live: ${id} (${provider.displayName})`, () => {
-		let discoveredModels: string[] = [];
-
-		test.skipIf(!canListModels)("lists models (auth + endpoint)", async () => {
-			discoveredModels = await listModels(id, provider, key!);
-			expect(
-				discoveredModels.length,
-				`${id} returned an empty model list`,
-			).toBeGreaterThan(0);
+	describe.skipIf(!credential)(`live: ${id} (${provider.displayName})`, () => {
+		test.skipIf(!canListModels)("lists models with production auth", async () => {
+			const models = await listModels(id, provider, credential!);
+			expect(models.length, `${id} returned an empty model list`).toBeGreaterThan(
+				0,
+			);
 		});
 
-		const chatModel = (): string | undefined =>
-			provider.defaultModel ?? FALLBACK_CHAT_MODELS[id] ?? discoveredModels[0];
-		const chatUrl = `${provider.upstreamBaseUrl.replace(/\/$/, "")}/chat/completions`;
-
-		test("answers a chat completion", async () => {
-			const model = chatModel();
-			if (!model) {
-				console.warn(`[live-providers] ${id}: no chat model — skipping`);
-				return;
-			}
-			const { status, body } = await fetchJson(chatUrl, {
-				method: "POST",
-				headers: {
-					"content-type": "application/json",
-					Authorization: `Bearer ${key}`,
-				},
-				body: JSON.stringify({
-					model,
-					messages: [
-						{
-							role: "user",
-							content: "Reply with exactly the single word: pong",
-						},
-					],
-					// Generous cap, not a target: reasoning-default models (gemini-2.5-*)
-					// spend "thinking" tokens from this budget before emitting text — at
-					// 16 they hit finish_reason=length with zero visible output.
-					max_tokens: 1024,
-					stream: false,
-				}),
+		test("answers a streamed production-adapter turn", async () => {
+			expect(modelId, `${id} has no configured live model`).toBeDefined();
+			const response = await completeWithProductionAdapter({
+				id,
+				provider,
+				credential: credential!,
+				modelId: modelId!,
+				context: textContext(),
 			});
 			expect(
-				status,
-				`${id} chat returned ${status}: ${JSON.stringify(body)}`,
-			).toBe(200);
-			const content = (
-				body as { choices?: Array<{ message?: { content?: string } }> }
-			).choices?.[0]?.message?.content;
+				response.stopReason,
+				`${id} turn failed: ${response.errorMessage ?? "unknown provider error"}`,
+			).not.toBe("error");
 			expect(
-				typeof content === "string" && content.trim().length > 0,
-				`${id} chat returned no assistant text: ${JSON.stringify(body)}`,
+				response.content.some(
+					(block) => block.type === "text" && block.text.trim().length > 0,
+				),
+				`${id} returned no assistant text`,
 			).toBe(true);
 		});
 
-		test("attempts a tool call (lenient — warn-only)", async () => {
-			const model = chatModel();
-			if (!model) return;
-			const { status, body } = await fetchJson(chatUrl, {
-				method: "POST",
-				headers: {
-					"content-type": "application/json",
-					Authorization: `Bearer ${key}`,
-				},
-				body: JSON.stringify({
-					model,
-					messages: [
-						{
-							role: "user",
-							content: "What is the weather in Paris? Use the tool.",
-						},
-					],
-					tools: [
-						{
-							type: "function",
-							function: {
-								name: "get_weather",
-								description: "Get the current weather for a city",
-								parameters: {
-									type: "object",
-									properties: { city: { type: "string" } },
-									required: ["city"],
-								},
-							},
-						},
-					],
-					tool_choice: "auto",
-					max_tokens: 1024,
-					stream: false,
-				}),
+		test("returns a parsed streamed tool call", async () => {
+			expect(modelId, `${id} has no configured live model`).toBeDefined();
+			const response = await completeWithProductionAdapter({
+				id,
+				provider,
+				credential: credential!,
+				modelId: modelId!,
+				context: toolContext(),
+				forceTool: required,
 			});
-
-			// Tool support varies by provider/model. A non-200 here usually means
-			// the provider rejected the optional `tools` payload, not that chat is
-			// broken (the chat test above is the hard auth/path assertion).
-			if (status !== 200) {
+			const toolCall = response.content.find(
+				(block) => block.type === "toolCall",
+			);
+			if (required) {
+				expect(
+					response.stopReason,
+					`${id} required tool turn failed: ${response.errorMessage ?? "unknown provider error"}`,
+				).toBe("toolUse");
+				expect(toolCall, `${id} returned no parsed tool call`).toMatchObject({
+					type: "toolCall",
+					name: "get_weather",
+				});
+			} else if (!toolCall) {
 				console.warn(
-					`[live-providers] ${id} (${model}) rejected tool_calls with ${status}: ` +
-						JSON.stringify(body),
-				);
-				return;
-			}
-			const toolCalls = (
-				body as { choices?: Array<{ message?: { tool_calls?: unknown[] } }> }
-			).choices?.[0]?.message?.tool_calls;
-			if (!toolCalls?.length) {
-				console.warn(
-					`[live-providers] ${id} (${model}) returned no tool_calls — ` +
-						"model may not support function calling.",
+					`[live-providers] ${id} (${modelId}) returned no tool call: ${response.errorMessage ?? response.stopReason}`,
 				);
 			}
 		});

--- a/packages/server/src/gateway/__tests__/provider-registry-contract.test.ts
+++ b/packages/server/src/gateway/__tests__/provider-registry-contract.test.ts
@@ -18,6 +18,8 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isSdkCompat } from "@lobu/core";
+import { providerCompletionUrl } from "../../__tests__/live-providers/provider-protocol.js";
 import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
 import { resolveProviderRegistryFromRaw } from "../services/provider-registry-service.js";
 
@@ -115,9 +117,7 @@ describe("provider registry contract (config/providers.json)", () => {
 
 			test("sdkCompat, when set, is a known protocol", () => {
 				if (provider.sdkCompat !== undefined) {
-					// Config-driven OpenAI-compat providers use "openai"; Claude's
-					// subscription entry uses "anthropic" (Messages API).
-					expect(["openai", "anthropic"]).toContain(provider.sdkCompat);
+					expect(isSdkCompat(provider.sdkCompat)).toBe(true);
 				}
 			});
 
@@ -186,11 +186,10 @@ describe("provider registry contract (config/providers.json)", () => {
 
 /**
  * Composed-URL invariant. Production composes provider URLs with NO
- * version-segment magic (verified by driving the real OpenAI SDK + the proxy
- * `forward()` with a mocked upstream):
- *   - chat   = `${upstreamBaseUrl}/chat/completions`
- *               (the worker's OpenAI SDK appends `/chat/completions` verbatim
- *                to its baseURL; the proxy forwards `upstreamBaseUrl + path`)
+ * version-segment magic (verified by the protocol-adapter E2E):
+ *   - completion = the adapter-specific path appended to upstreamBaseUrl
+ *                  (Anthropic Messages, OpenAI Responses, ChatGPT Codex
+ *                  Responses, or OpenAI-compatible Chat Completions)
  *   - models = `${upstreamBaseUrl}${modelsEndpoint}`
  *               (ApiKeyProviderModule.fetchModelsGeneric, direct fetch)
  *
@@ -205,8 +204,8 @@ describe("composed upstream URLs", () => {
 	const DOUBLED_VERSION = /\/v\d+\/v\d+\//;
 	for (const { id, provider } of flattened) {
 		test(`${id}: composed URLs have no doubled version segment`, () => {
+			expect(providerCompletionUrl(id, provider)).not.toMatch(DOUBLED_VERSION);
 			const base = provider.upstreamBaseUrl.replace(/\/$/, "");
-			expect(`${base}/chat/completions`).not.toMatch(DOUBLED_VERSION);
 			if (provider.modelsEndpoint) {
 				expect(`${base}${provider.modelsEndpoint}`).not.toMatch(DOUBLED_VERSION);
 			}

--- a/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
@@ -249,6 +249,32 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
     ]);
   });
 
+  test("an official OpenAI alias uses Responses, not Chat Completions", async () => {
+    registerCatalogModule(
+      "openai",
+      "openai",
+      "https://api.openai.com/v1"
+    );
+    const catalog = makeCatalog({
+      models: ["my-openai/gpt-5.6-sol"],
+      orgRows: [
+        customUpstreamRow("my-openai", {
+          kind: "openai",
+          capabilities: { text: { model: "gpt-5.6-sol" } },
+          hasCustomUpstream: false,
+        }),
+      ],
+      registerUpstream: () => {},
+    });
+
+    const modules = await catalog.getInstalledModules("agent-1", "org-1");
+    const mod = modules[0] as ApiKeyProviderModule;
+    expect(mod.getUpstreamConfig()?.upstreamBaseUrl).toBe(
+      "https://api.openai.com/v1"
+    );
+    expect(mod.getProviderMetadata()?.sdkCompat).toBe("openai-responses");
+  });
+
   test("an OAuth kind contributes NO fallback upstream", async () => {
     // An OAuth provider (chatgpt, claude) registers as a plain module, not an
     // ApiKeyProviderModule, so buildProviderCatalog() reports baseUrl "" for it

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -467,9 +467,22 @@ export class ProviderCatalogService {
         // OpenAI-compatible). An unknown kind contributes no baseUrl, so such a
         // row still routes only if it names its own upstream.
         const catalogEntry = catalogByKind?.get(row.kind);
+        // A catalog-backed alias of the official OpenAI provider must preserve
+        // OpenAI's Responses transport. `sdkCompat: "openai"` is the generic
+        // Chat Completions protocol for third-party compatible endpoints, but
+        // Lobu routes the official OpenAI provider through Responses so current
+        // reasoning models can use tools. Keep custom tenant upstreams on their
+        // declared compatibility protocol; only the trusted catalog fallback is
+        // known to be official OpenAI.
+        const sdkCompat =
+          row.kind === "openai" &&
+          !row.capabilities.text?.base_url &&
+          catalogEntry?.sdkCompat === "openai"
+            ? "openai-responses"
+            : catalogEntry?.sdkCompat ?? "openai";
         const synthesized = this.synthesizeOrgProviderModule(
           row,
-          catalogEntry?.sdkCompat ?? "openai",
+          sdkCompat,
           catalogEntry?.baseUrl
         );
         if (synthesized) modules.push(synthesized);


### PR DESCRIPTION
## Summary
- route official OpenAI aliases through Responses while preserving Chat Completions for third-party compatible providers
- add strict production-adapter E2E for Anthropic, OpenAI, Gemini, OpenRouter, and ChatGPT streaming plus parsed tool calls
- make live readiness protocol-correct and fail closed for required Claude, OpenAI, Gemini, and OpenRouter credentials; exclude ZAI from the keyed readiness lane

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests run: `make test-unit`; `make test-e2e-sdk`; `make test-e2e-error`; focused provider matrix
- [x] Bug fix: red to fix to green outputs pasted below
- [ ] If bot behavior: not applicable

Red before the routing fix: 79 pass, 2 fail. Dynamic official-OpenAI aliases resolved to `openai-completions` instead of `openai-responses`.

Green after the fix:
- focused provider suite: 285 pass, 0 fail
- post-review/rebase focused suite: 251 pass, 0 fail
- deterministic protocol adapters: 5 pass, 0 fail
- full unit suite: green
- SDK lifecycle E2E: passed through real gateway, apply, spawned worker, client streaming, connector sync, Behavior outputs, and idempotent re-apply
- provider error E2E: passed; upstream 429 and reset time surfaced verbatim

## Notes
Live upstream audit intentionally remains red with the current account state:
- OpenRouter: model listing, streamed text, and parsed tool call pass
- Claude: OAuth rejected because OAuth is not allowed for the organization
- Gemini: project monthly spending cap exceeded
- OpenAI: account has no API credits

The scheduled workflow now treats Claude, OpenAI, Gemini, and OpenRouter as required and will fail closed until those credentials/billing limits are corrected. ZAI is not part of the keyed readiness tier.