### PR TITLE
fix(server): consolidate sandbox output budgets into preview + per-message caps

### DIFF
--- a/packages/server/src/__tests__/integration/sandbox/namespace-dispatch.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/namespace-dispatch.test.ts
@@ -156,4 +156,10 @@ describe("ClientSDK namespace dispatch (read paths)", () => {
 		const rows = await sdk.query("SELECT COUNT(*)::int AS n FROM entities");
 		expect(Array.isArray(rows)).toBe(true);
 	});
+
+	it("query caps results at 5000 rows so a broad SELECT can't flood the host", async () => {
+		const rows = await sdk.query("SELECT generate_series(1, 10000) AS n");
+		expect(rows).toHaveLength(5000);
+		expect(rows[0]).toEqual({ n: 1 });
+	});
 });

--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -277,6 +277,23 @@ describe("sandbox output budgets", () => {
     );
   });
 
+  it("keeps the preview within a lowered output cap", async () => {
+    const result = await runScript({
+      source: "export default async () => 'a'.repeat(2000);",
+      sdk: stubSDK(),
+      limits: { outputBytes: 1024 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.returnValue).toBeUndefined();
+    expect(result.returnTruncated!.total_bytes).toBeGreaterThan(
+      result.returnTruncated!.kept_bytes,
+    );
+    expect(
+      Buffer.byteLength(result.returnValuePreview!, "utf8"),
+    ).toBeLessThanOrEqual(1024);
+  });
+
   it("hard-fails an oversized extracted schema instead of previewing it", async () => {
     const result = await runScript({
       source: [
@@ -334,6 +351,44 @@ describe("sandbox output budgets", () => {
     expect(result.returnTruncated).toBeUndefined();
     expect(result.logs).toHaveLength(1);
     expect(result.logs[0]?.message).toContain("console output truncated");
+  });
+
+  it("stops forwarding console calls after the log cap fills", async () => {
+    const result = await runScript({
+      source: [
+        "export default async () => {",
+        "  const line = 'x'.repeat(1024);",
+        "  for (let i = 0; i < 1000000; i++) console.log(line);",
+        "  return 'done';",
+        "};",
+      ].join("\n"),
+      sdk: stubSDK(),
+      limits: { timeoutMs: 1000 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.returnValue).toBe("done");
+    expect(result.logs).toHaveLength(65);
+    expect(result.logs.at(-1)?.message).toContain("console output truncated");
+  });
+
+  it("terminates a guest that bypasses the saturated console latch", async () => {
+    const result = await runScript({
+      source: [
+        "export default async () => {",
+        "  const line = 'x'.repeat(1024);",
+        "  for (let i = 0; i < 1000; i++) {",
+        "    try { __console_call.applySync(undefined, ['log', line]); } catch (e) {}",
+        "  }",
+        "  return 'done';",
+        "};",
+      ].join("\n"),
+      sdk: stubSDK(),
+      limits: { timeoutMs: 5000 },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe("OutputSizeExceeded");
   });
 
   it("does not let a large SDK call result evict a small return value", async () => {

--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -256,22 +256,28 @@ describe("sandbox output budgets", () => {
 
     expect(result.success).toBe(true);
     expect(Buffer.byteLength(JSON.stringify(result.returnValue), "utf8")).toBe(1_048_576);
+    expect(result.returnValuePreview).toBeUndefined();
     expect(result.returnTruncated).toBeUndefined();
   });
 
-  it("truncates return values that serialize to over 1 MB instead of failing", async () => {
+  it("replaces an oversized return with a bounded preview instead of shipping it", async () => {
     const result = await runScript({
       source: "export default async () => 'a'.repeat(1200000);",
       sdk: stubSDK(),
     });
 
     expect(result.success).toBe(true);
-    expect(typeof result.returnValue).toBe("string");
-    expect(result.returnValue).toMatch(/^a+\u2026 \[truncated\]$/);
-    expect(result.returnTruncated?.dropped_chars).toBeGreaterThan(0);
+    expect(result.returnValue).toBeUndefined();
+    expect(typeof result.returnValuePreview).toBe("string");
+    expect(result.returnValuePreview).toMatch(/^"a+\u2026 \[truncated\]$/);
+    expect(result.returnTruncated).toBeDefined();
+    expect(result.returnTruncated!.total_bytes).toBeGreaterThan(1_048_576);
+    expect(result.returnTruncated!.kept_bytes).toBe(
+      Buffer.byteLength(result.returnValuePreview!, "utf8"),
+    );
   });
 
-  it("hard-fails an oversized extracted schema instead of truncating it", async () => {
+  it("hard-fails an oversized extracted schema instead of previewing it", async () => {
     const result = await runScript({
       source: [
         "export const input = { type: 'string', description: 'x'.repeat(2000) };",
@@ -284,10 +290,10 @@ describe("sandbox output budgets", () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.name).toBe("OutputSizeExceeded");
-    expect(result.returnTruncated).toBeUndefined();
+    expect(result.returnValuePreview).toBeUndefined();
   });
 
-  it("keeps leading structure and reports the exact serialized size", async () => {
+  it("previews an oversized array as a text head and reports byte sizes", async () => {
     const result = await runScript({
       source: [
         "export default async () => {",
@@ -299,32 +305,15 @@ describe("sandbox output budgets", () => {
     });
 
     expect(result.success).toBe(true);
-    const kept = result.returnValue as unknown[];
-    expect(Array.isArray(kept)).toBe(true);
-    expect(kept[0]).toEqual({ id: 0, body: "x".repeat(60) });
-    expect(result.returnTruncated?.dropped_elements).toBeGreaterThan(0);
-    expect(result.returnTruncated?.kept_bytes).toBe(
-      Buffer.byteLength(JSON.stringify(result.returnValue), "utf8"),
+    expect(result.returnValue).toBeUndefined();
+    const preview = result.returnValuePreview!;
+    expect(preview.startsWith("[")).toBe(true);
+    expect(result.returnTruncated).toBeDefined();
+    expect(result.returnTruncated!.total_bytes).toBeGreaterThan(
+      result.returnTruncated!.kept_bytes,
     );
-  });
-
-  it("reports the exact kept size when an atomic object value cannot fit", async () => {
-    const result = await runScript({
-      source: [
-        "export default async () => {",
-        "  const obj = {};",
-        "  for (let i = 0; i < 100; i++) obj[String(i).padStart(3, '0')] = 123456789;",
-        "  return obj;",
-        "};",
-      ].join("\n"),
-      sdk: stubSDK(),
-      limits: { outputBytes: 1024 },
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.returnTruncated?.dropped_keys).toBeGreaterThan(0);
-    expect(result.returnTruncated?.kept_bytes).toBe(
-      Buffer.byteLength(JSON.stringify(result.returnValue), "utf8"),
+    expect(result.returnTruncated!.kept_bytes).toBe(
+      Buffer.byteLength(preview, "utf8"),
     );
   });
 
@@ -367,13 +356,13 @@ describe("sandbox output budgets", () => {
     expect(result.returnValue).toEqual({ count: 1_200_000 });
   });
 
-  it("hard-fails and latches an oversized SDK result crossing budget", async () => {
+  it("hard-fails a single oversized SDK result message", async () => {
     let hostCalls = 0;
     const sdk = stubSDK({
       entities: {
         list: async () => {
           hostCalls++;
-          return { rows: "x".repeat(1_000_000) };
+          return { rows: "x".repeat(5_000_000) };
         },
       } as never,
     });
@@ -387,12 +376,13 @@ describe("sandbox output budgets", () => {
         "};",
       ].join("\n"),
       sdk,
-      limits: { crossingBytes: 2_000_000 },
+      limits: { messageBytes: 65_536 },
     });
 
     expect(result.success).toBe(false);
     expect(result.error?.name).toBe("OutputSizeExceeded");
-    expect(hostCalls).toBe(2);
+    // Only the first result ran host work before the message cap terminated.
+    expect(hostCalls).toBe(1);
   });
 
   it("rejects an oversized SDK request payload before host work", async () => {
@@ -409,7 +399,7 @@ describe("sandbox output budgets", () => {
       source:
         "export default async (_ctx, client) => { await client.entities.list({ q: 'x'.repeat(70000) }); return 'done'; };",
       sdk,
-      limits: { crossingBytes: 65_536 },
+      limits: { messageBytes: 65_536 },
     });
 
     expect(result.success).toBe(false);
@@ -417,20 +407,7 @@ describe("sandbox output budgets", () => {
     expect(hostCalls).toBe(0);
   });
 
-  it("caps by serialized bytes, so escaped strings cannot exceed the budget", async () => {
-    const result = await runScript({
-      source: "export default async () => '\\n'.repeat(700000);",
-      sdk: stubSDK(),
-    });
-
-    expect(result.success).toBe(true);
-    const serialized = Buffer.byteLength(JSON.stringify(result.returnValue), "utf8");
-    expect(serialized).toBeLessThanOrEqual(1_048_576);
-    expect(result.returnTruncated?.dropped_chars).toBeGreaterThan(0);
-    expect(result.returnTruncated?.kept_bytes).toBe(serialized);
-  });
-
-  it("hard-fails an interactive return over the crossing budget before parsing", async () => {
+  it("hard-fails an interactive return over the message cap before parsing", async () => {
     const result = await runScript({
       source: "export default async () => 'x'.repeat(5000000);",
       sdk: stubSDK(),
@@ -438,59 +415,31 @@ describe("sandbox output budgets", () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.name).toBe("OutputSizeExceeded");
-    expect(result.returnTruncated).toBeUndefined();
+    expect(result.returnValuePreview).toBeUndefined();
   });
 
-  it("preserves an own __proto__ key when truncating", async () => {
-    const result = await runScript({
-      source: [
-        "export default async () => JSON.parse('{\"__proto__\":{\"a\":1},\"pad\":\"' + 'x'.repeat(1200000) + '\"}');",
-      ].join("\n"),
-      sdk: stubSDK(),
-    });
-
-    expect(result.success).toBe(true);
-    const value = result.returnValue as Record<string, unknown>;
-    expect(Object.hasOwn(value, "__proto__")).toBe(true);
-    expect((value["__proto__"] as Record<string, unknown>).a).toBe(1);
-    expect(result.returnTruncated?.dropped_chars).toBeGreaterThan(0);
-  });
-
-  it("does not split a UTF-16 surrogate pair at the string boundary", async () => {
+  it("does not split a UTF-16 surrogate pair at the preview boundary", async () => {
     const result = await runScript({
       source: "export default async () => '😀'.repeat(600000);",
       sdk: stubSDK(),
     });
 
     expect(result.success).toBe(true);
-    const value = result.returnValue as string;
+    const preview = result.returnValuePreview!;
     const suffix = "\u2026 [truncated]";
-    const prefix = value.slice(0, -suffix.length);
-    expect(value.endsWith(suffix)).toBe(true);
+    expect(preview.endsWith(suffix)).toBe(true);
+    const prefix = preview.slice(0, -suffix.length);
     expect(prefix.endsWith("😀")).toBe(true);
-    expect(result.returnTruncated?.dropped_chars).toBe(1_200_000 - prefix.length);
+    for (let i = 0; i < prefix.length; i++) {
+      const c = prefix.charCodeAt(i);
+      if (c >= 0xd800 && c <= 0xdbff) {
+        const next = prefix.charCodeAt(i + 1);
+        expect(next >= 0xdc00 && next <= 0xdfff).toBe(true);
+      }
+    }
   });
 
-  it("truncates key-heavy objects in linear time", async () => {
-    const result = await runScript({
-      source: [
-        "export default async () => {",
-        "  const obj = {};",
-        "  for (let i = 0; i < 150000; i++) obj['k' + i] = i;",
-        "  return obj;",
-        "};",
-      ].join("\n"),
-      sdk: stubSDK(),
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.returnTruncated?.dropped_keys).toBeGreaterThan(0);
-    expect(result.returnTruncated?.kept_bytes).toBe(
-      Buffer.byteLength(JSON.stringify(result.returnValue), "utf8"),
-    );
-  });
-
-  it("latches console saturation so later SDK work never starts", async () => {
+  it("terminates on console output over the message cap before any SDK work", async () => {
     let hostCalls = 0;
     const sdk = stubSDK({
       entities: {
@@ -505,7 +454,6 @@ describe("sandbox output budgets", () => {
         "export default async (_ctx, client) => {",
         "  console.log('x'.repeat(4200000));",
         "  try { await client.entities.list(); } catch (e) {}",
-        "  try { await client.entities.list(); } catch (e) {}",
         "  return 'done';",
         "};",
       ].join("\n"),
@@ -517,7 +465,33 @@ describe("sandbox output budgets", () => {
     expect(hostCalls).toBe(0);
   });
 
-  it("terminates a guest that keeps crossing after saturation", async () => {
+  it("makes quota exhaustion terminal (uncatchable)", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => [{ ok: true }],
+      } as never,
+    });
+    const started = Date.now();
+    const result = await runScript({
+      source: [
+        "export default async (_ctx, client) => {",
+        "  for (let i = 0; i < 300; i++) {",
+        "    try { await client.entities.list(); } catch (e) {}",
+        "  }",
+        "  return 'done';",
+        "};",
+      ].join("\n"),
+      sdk,
+      limits: { sdkCallQuota: 5, timeoutMs: 5000 },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe("QuotaExceeded");
+    // Terminated on quota exhaustion, not left spinning until the timeout.
+    expect(Date.now() - started).toBeLessThan(3000);
+  });
+
+  it("terminates a guest that loops dispatch with oversized payloads", async () => {
     const sdk = stubSDK({
       entities: {
         list: async () => [{ ok: true }],
@@ -533,13 +507,12 @@ describe("sandbox output budgets", () => {
         "};",
       ].join("\n"),
       sdk,
-      limits: { crossingBytes: 65_536, timeoutMs: 5000 },
+      limits: { messageBytes: 65_536, timeoutMs: 5000 },
     });
 
     expect(result.success).toBe(false);
-    // The guest was interrupted at saturation (well under the 5s timeout) —
-    // not left spinning crossing payloads until the wall-clock budget.
     expect(result.error?.name).toBe("OutputSizeExceeded");
+    // Interrupted at the first oversized payload, well under the 5s timeout.
     expect(Date.now() - started).toBeLessThan(3000);
   });
 });

--- a/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
+++ b/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
@@ -195,14 +195,12 @@ describe("run_sdk / query_sdk: script contract on the wire", () => {
 		const sample = {
 			success: false,
 			return_value: { anything: [1, "two", null] },
-			return_value_truncated: {
+			return_value_preview: '{"anything":[1,"two",nul… [truncated]',
+			return_truncated: {
 				total_bytes: 2_000_000,
 				kept_bytes: 1_048_576,
-				dropped_elements: 20,
-				dropped_keys: 3,
-				dropped_chars: 400,
 			},
-			logs: [{ level: "warn", message: "m", data: { k: 1 }, ts: 123 }],
+			logs: [{ level: "warn", message: "m", ts: 123 }],
 			error: { name: "TypeError", message: "boom", stack: "s", line: 3, column: 7 },
 			duration_ms: 42,
 			sdk_calls: 2,
@@ -237,8 +235,8 @@ describe("run_sdk / query_sdk: script contract on the wire", () => {
 			expect(script?.description?.includes("30000"), `${name} script must document the sleep limit`).toBe(true);
 			expect(script?.description?.includes("return_value"), `${name} script must document return_value`).toBe(true);
 			expect(
-				script?.description?.includes("return_value_truncated"),
-				`${name} script must document return_value_truncated`,
+				script?.description?.includes("return_value_preview"),
+				`${name} script must document return_value_preview`,
 			).toBe(true);
 			expect(script?.description?.includes("search_sdk"), `${name} script must point at search_sdk`).toBe(true);
 		}

--- a/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
+++ b/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
@@ -192,16 +192,15 @@ describe("run_sdk / query_sdk: script contract on the wire", () => {
 		// Mirrors the object assembled in sdk_run.ts runSandbox(). If this
 		// drifts (renamed field, changed type), structuredContent silently
 		// degrades to text-only — catch it here instead.
+		const preview = '{"anything":[1,"two",nul… [truncated]';
 		const sample = {
-			success: false,
-			return_value: { anything: [1, "two", null] },
-			return_value_preview: '{"anything":[1,"two",nul… [truncated]',
+			success: true,
+			return_value_preview: preview,
 			return_truncated: {
 				total_bytes: 2_000_000,
-				kept_bytes: 1_048_576,
+				kept_bytes: Buffer.byteLength(preview, "utf8"),
 			},
 			logs: [{ level: "warn", message: "m", ts: 123 }],
-			error: { name: "TypeError", message: "boom", stack: "s", line: 3, column: 7 },
 			duration_ms: 42,
 			sdk_calls: 2,
 			sdk_call_trace: [
@@ -214,10 +213,11 @@ describe("run_sdk / query_sdk: script contract on the wire", () => {
 			dry_run: true,
 		};
 		expect(validateToolResult(SdkScriptResultSchema, sample)).not.toBeNull();
-		// Success path: optional fields absent (undefined is dropped on the wire).
+		// Failure path: optional return fields absent (undefined is dropped on the wire).
 		const minimal = {
-			success: true,
+			success: false,
 			logs: [],
+			error: { name: "TypeError", message: "boom", stack: "s", line: 3, column: 7 },
 			duration_ms: 1,
 			sdk_calls: 0,
 			sdk_call_trace: [],

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -20,6 +20,15 @@ import {
 import { METHOD_METADATA } from "./method-metadata";
 import type { SDKMode } from "./sdk-manifest";
 
+/**
+ * Hard row ceiling on `client.query` results. `query_sql` paginates to at most
+ * 500 rows, but the sandbox `client.query` takes arbitrary SQL — without an
+ * outer LIMIT a script could `SELECT * FROM events` and materialize unbounded
+ * rows host-side. The sandbox per-message cap is a backstop; this stops the
+ * allocation at the source. Agents page with their own LIMIT/OFFSET.
+ */
+const CLIENT_QUERY_MAX_ROWS = 5000;
+
 export { enumerateSDKManifest, type SDKMode } from "./sdk-manifest";
 
 import {
@@ -243,11 +252,14 @@ export function buildClientSDK(
 						? undefined
 						: ADMIN_ONLY_QUERYABLE_TABLES,
 			});
+			// Outer LIMIT caps rows at the source so a broad SELECT can't
+			// materialize an unbounded result set host-side.
+			const boundedSql = `SELECT * FROM (${scoped.sql.replace(/;\s*$/, "")}) AS __q LIMIT ${CLIENT_QUERY_MAX_ROWS}`;
 			const rows = await raceAbort(
 				getDb().begin(async (tx) => {
 					await tx.unsafe("SET TRANSACTION READ ONLY");
 					await tx.unsafe("SET LOCAL statement_timeout = '5000'");
-					return tx.unsafe(scoped.sql, scoped.params as unknown[]);
+					return tx.unsafe(boundedSql, scoped.params as unknown[]);
 				}),
 				ctx.abortSignal
 			);

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -1,13 +1,15 @@
 /**
  * Compiles a TypeScript user-script via esbuild, runs it in a V8 isolate, and
- * bridges SDK calls back to the host. Output is budgeted per-purpose, not as
- * one combined counter: interactive return values are capped at 1 MB and
- * truncated with a `returnTruncated` report, console logs are capped at 64 KB
- * and dropped once full, and a 4 MB crossing guard accounts for cumulative
- * SDK payload/result and console traffic as the DoS backstop. Extracted named
- * exports keep the old hard-fail behavior because truncation could corrupt a
- * schema. Other caps: 200 SDK calls, 180s wall-clock max (device-bound
- * operations may wait up to ~155s), and 30s per `ctx.sleep()` call.
+ * bridges SDK calls back to the host. Output is bounded per-purpose: interactive
+ * return values are capped at 1 MB (an oversized value is replaced by a bounded
+ * `returnValuePreview` head plus a report, never shipped in full to the model),
+ * console logs are capped at 64 KB and dropped once full, and each single
+ * host↔guest bridge message (SDK payload, SDK result, or return envelope) is
+ * capped at 4 MB — a larger message, or exhausting the 200-call quota,
+ * terminates the run by disposing the isolate (uncatchable by the guest).
+ * Extracted named exports keep the old hard-fail behavior because a partial
+ * schema would be worse than none. Other caps: 180s wall-clock max
+ * (device-bound operations may wait up to ~155s), and 30s per `ctx.sleep()`.
  * `client.org()` is stateless — each guest call carries
  * `orgPath` so the host re-walks org swaps without holding refs.
  */
@@ -22,26 +24,18 @@ export interface RunLimits {
 	memoryMb?: number;
 	timeoutMs?: number;
 	sdkCallQuota?: number;
-	/** Serialization cap for interactive return values; extracted exports hard-fail instead of truncating. */
+	/** Serialization cap for interactive return values; extracted exports hard-fail instead of previewing. */
 	outputBytes?: number;
 	/** Cap for captured console logs; messages past it are dropped. */
 	logBytes?: number;
-	/** DoS guard on host↔guest copies across SDK call payloads/results and console output. */
-	crossingBytes?: number;
+	/** Single-message cap for host↔guest bridge traffic; a larger message terminates the run. */
+	messageBytes?: number;
 }
 
-/**
- * What the host dropped when a return value exceeded `outputBytes`. Returned
- * out-of-band so the truncated value itself stays shape-faithful (a truncated
- * array is still an array) and the agent can never mistake partial data for
- * complete output.
- */
-interface TruncatedValueInfo {
+/** What the host kept when a return value exceeded `outputBytes` and became a preview. */
+interface ReturnPreviewInfo {
 	total_bytes: number;
 	kept_bytes: number;
-	dropped_elements: number;
-	dropped_keys: number;
-	dropped_chars: number;
 }
 
 /**
@@ -115,7 +109,6 @@ export interface RunScriptOptions {
 interface LogEntry {
 	level: "log" | "warn" | "error";
 	message: string;
-	data?: Record<string, unknown>;
 	ts: number;
 }
 
@@ -130,8 +123,10 @@ interface SdkCallTraceEntry {
 interface RunScriptResult {
 	success: boolean;
 	returnValue?: unknown;
-	/** Present when the return value exceeded `outputBytes` and was truncated. */
-	returnTruncated?: TruncatedValueInfo;
+	/** UTF-8-safe head of the serialized return value when it exceeded `outputBytes`. */
+	returnValuePreview?: string;
+	/** Present with `returnValuePreview`: the original and kept byte sizes. */
+	returnTruncated?: ReturnPreviewInfo;
 	logs: LogEntry[];
 	sdkCallTrace: SdkCallTraceEntry[];
 	sideEffectPreview: SdkCallTraceEntry[];
@@ -153,7 +148,7 @@ const DEFAULT_LIMITS: Required<RunLimits> = {
 	sdkCallQuota: 200,
 	outputBytes: 1_048_576,
 	logBytes: 65_536,
-	crossingBytes: 4_194_304,
+	messageBytes: 4_194_304,
 };
 /** Device action waits allow 60s queue + 95s post-claim; sandbox must outlive that. */
 export const MAX_SCRIPT_TIMEOUT_MS = 180_000;
@@ -225,32 +220,22 @@ export function safeErrorDetails(value: unknown): unknown {
 	}
 }
 
-const TRUNCATE_SUFFIX = "\u2026 [truncated]";
-const MAX_TRUNCATE_DEPTH = 200;
-const SKIP = Symbol("truncate.skip");
+const RETURN_PREVIEW_BYTES = 262_144;
+const PREVIEW_SUFFIX = "\u2026 [truncated]";
 
 function jsonBytes(value: unknown): number {
 	const json = JSON.stringify(value);
 	return json === undefined ? 0 : Buffer.byteLength(json, "utf8");
 }
 
-/** Bytes of `value` as a JSON string literal, excluding the wrapping quotes. */
-function serializedStringBytes(value: string): number {
-	return jsonBytes(value) - 2;
-}
-
-/**
- * Longest prefix of `value` whose JSON-serialized byte size fits `maxBytes`
- * (not raw bytes — escaped characters such as `\n` or `"` serialize larger),
- * without splitting a UTF-16 surrogate pair.
- */
-function truncateStringToBytes(value: string, maxBytes: number): string {
-	if (serializedStringBytes(value) <= maxBytes) return value;
+/** Longest byte-bounded prefix of `value` that does not split a UTF-16 surrogate pair. */
+function byteBoundedPrefix(value: string, maxBytes: number): string {
+	if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
 	let lo = 0;
 	let hi = value.length;
 	while (lo < hi) {
 		const mid = (lo + hi + 1) >> 1;
-		if (serializedStringBytes(value.slice(0, mid)) <= maxBytes) lo = mid;
+		if (Buffer.byteLength(value.slice(0, mid), "utf8") <= maxBytes) lo = mid;
 		else hi = mid - 1;
 	}
 	if (lo > 0 && lo < value.length) {
@@ -260,135 +245,26 @@ function truncateStringToBytes(value: string, maxBytes: number): string {
 	return value.slice(0, lo);
 }
 
-interface TruncState {
-	budget: number;
-	used: number;
-	droppedElements: number;
-	droppedKeys: number;
-	droppedChars: number;
-}
-
 /**
- * Greedy bounded serializer: keep as much top-level structure as fits, then
- * report what was dropped. A kept entry that itself overflows (nested array,
- * object, string) is recursed into and truncated in place; `SKIP` marks a
- * value that could not be kept at all. `state.used` never exceeds `state.budget`.
+ * Build the preview for an oversized interactive return value: a UTF-8-safe
+ * head of the serialized JSON (a preview the model reads to decide what to
+ * query, never a value it could mistake for complete output) plus the byte
+ * sizes. Only called when the serialized value already exceeds `outputBytes`.
  */
-function encodeWithinBudget(value: unknown, state: TruncState, depth: number): unknown {
-	const full = jsonBytes(value);
-	if (state.used + full <= state.budget) {
-		state.used += full;
-		return value;
-	}
-	if (depth >= MAX_TRUNCATE_DEPTH) {
-		dropAtomic(value, state);
-		return SKIP;
-	}
-	if (Array.isArray(value)) {
-		if (state.used + 2 > state.budget) {
-			state.droppedElements += value.length;
-			return SKIP;
-		}
-		state.used += 2; // brackets
-		const out: unknown[] = [];
-		for (const item of value) {
-			const sep = out.length > 0 ? 1 : 0;
-			if (state.used + sep + 2 > state.budget) break;
-			const usedBeforeItem = state.used;
-			state.used += sep;
-			const encoded = encodeWithinBudget(item, state, depth + 1);
-			if (encoded === SKIP) {
-				state.used = usedBeforeItem;
-				break;
-			}
-			out.push(encoded);
-		}
-		state.droppedElements += value.length - out.length;
-		return out;
-	}
-	if (value !== null && typeof value === "object") {
-		if (state.used + 2 > state.budget) {
-			state.droppedKeys += Object.keys(value).length;
-			return SKIP;
-		}
-		state.used += 2; // braces
-		// Null prototype so an own `__proto__` key stays a data property instead
-		// of invoking the prototype setter (which would drop it from the output).
-		const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-		const entries = Object.entries(value as Record<string, unknown>);
-		let kept = 0;
-		for (const [key, child] of entries) {
-			const sep = kept > 0 ? 1 : 0;
-			const keyCost = jsonBytes(key);
-			if (state.used + sep + keyCost + 2 > state.budget) break;
-			const usedBeforeEntry = state.used;
-			state.used += sep + keyCost + 1; // comma + key + colon
-			const encoded = encodeWithinBudget(child, state, depth + 1);
-			if (encoded === SKIP) {
-				state.used = usedBeforeEntry;
-				break;
-			}
-			out[key] = encoded;
-			kept++;
-		}
-		state.droppedKeys += entries.length - kept;
-		return out;
-	}
-	if (typeof value === "string") {
-		const suffixBytes = jsonBytes(TRUNCATE_SUFFIX);
-		const avail = state.budget - state.used - suffixBytes;
-		if (avail <= 0) {
-			state.droppedChars += value.length;
-			return SKIP;
-		}
-		const kept = truncateStringToBytes(value, avail);
-		state.droppedChars += value.length - kept.length;
-		const out = kept + TRUNCATE_SUFFIX;
-		state.used += jsonBytes(out);
-		return out;
-	}
-	dropAtomic(value, state);
-	return SKIP;
-}
-
-function dropAtomic(value: unknown, state: TruncState): void {
-	if (typeof value === "string") state.droppedChars += value.length;
-	else if (Array.isArray(value)) state.droppedElements += value.length;
-	else if (value !== null && typeof value === "object")
-		state.droppedKeys += Object.keys(value).length;
-}
-
-/**
- * Truncate a return value to fit `budgetBytes`, preserving as much structure
- * as possible. Only called when the serialized value already exceeds the
- * budget, so `meta` always reports dropped content.
- */
-function truncateJsonValue(
-	value: unknown,
-	budgetBytes: number,
-): { value: unknown; meta: TruncatedValueInfo } {
-	const totalBytes = jsonBytes(value);
-	const state: TruncState = {
-		budget: budgetBytes,
-		used: 0,
-		droppedElements: 0,
-		droppedKeys: 0,
-		droppedChars: 0,
-	};
-	let out = encodeWithinBudget(value, state, 0);
-	if (out === SKIP) out = { __lobu_truncated: true };
-	if (jsonBytes(out) > budgetBytes) {
-		// Never emit more than the budget promised, even on a walker bug.
-		out = { __lobu_truncated: true, total_bytes: totalBytes };
-	}
+function buildReturnPreview(
+	valueJson: string,
+): { preview: string; info: ReturnPreviewInfo } {
+	const totalBytes = Buffer.byteLength(valueJson, "utf8");
+	const kept = byteBoundedPrefix(
+		valueJson,
+		RETURN_PREVIEW_BYTES - Buffer.byteLength(PREVIEW_SUFFIX, "utf8"),
+	);
+	const preview = `${kept}${PREVIEW_SUFFIX}`;
 	return {
-		value: out,
-		meta: {
+		preview,
+		info: {
 			total_bytes: totalBytes,
-			kept_bytes: jsonBytes(out),
-			dropped_elements: state.droppedElements,
-			dropped_keys: state.droppedKeys,
-			dropped_chars: state.droppedChars,
+			kept_bytes: Buffer.byteLength(preview, "utf8"),
 		},
 	};
 }
@@ -488,11 +364,11 @@ function clampLimits(limits?: RunLimits): Required<RunLimits> {
 			1024,
 			DEFAULT_LIMITS.logBytes,
 		),
-		crossingBytes: clampNumber(
-			limits?.crossingBytes,
-			DEFAULT_LIMITS.crossingBytes,
+		messageBytes: clampNumber(
+			limits?.messageBytes,
+			DEFAULT_LIMITS.messageBytes,
 			65_536,
-			DEFAULT_LIMITS.crossingBytes,
+			DEFAULT_LIMITS.messageBytes,
 		),
 	};
 }
@@ -825,43 +701,41 @@ export async function runScript(
 	const sdkCallTrace: SdkCallTraceEntry[] = [];
 	const sideEffectPreview: SdkCallTraceEntry[] = [];
 	let sdkCalls = 0;
-	// Internal host↔guest traffic guard (SDK payloads/results + console crossing).
-	// Distinct from the agent-facing return-value cap: this accounts for internal
-	// bridge traffic, not what the caller receives.
-	let crossingBytes = 0;
-	let crossingOversize = false;
-	// Captured console budget. Messages past it are dropped; pathological logging
-	// can still trip the broader crossing guard.
+	// Captured console budget. Messages past it are dropped, never a failure.
 	let logBytesUsed = 0;
 	let logFull = false;
-	// Assigned inside the try block below; hoisted so `saturateCrossing` can
-	// interrupt the guest when the crossing budget is exceeded.
+	// A terminal failure (message over the per-message cap, or quota exhausted)
+	// disposes the isolate so the guest cannot keep crossing bridge traffic.
+	// Hoisted because `isolate` is assigned inside the try block below.
 	let isolate: import("isolated-vm").Isolate | null = null;
+	const terminalState = { name: "", message: "" };
+	let terminated = false;
 
-	const crossingOversizeMessage =
-		`OutputSizeExceeded: sandbox exceeded the ${limits.crossingBytes}-byte crossing budget (SDK call payloads/results and console output)`;
-	const crossingOversizeError = () =>
-		new Error(crossingOversizeMessage);
-	const crossingOversizeEnvelope = () =>
-		JSON.stringify({
-			__lobu_sdk_dispatch: 1,
-			ok: false,
-			error: {
-				name: "OutputSizeExceeded",
-				message: crossingOversizeMessage,
-			},
-		});
+	const quotaMessage = `QuotaExceeded: SDK call quota of ${limits.sdkCallQuota} reached`;
+	const oversizeMessage = `OutputSizeExceeded: a single bridge message exceeded ${limits.messageBytes} bytes (SDK call payload/result or return value)`;
+	const terminalEnvelope = () =>
+		terminated
+			? JSON.stringify({
+					__lobu_sdk_dispatch: 1,
+					ok: false,
+					error: {
+						name: terminalState.name,
+						message: terminalState.message,
+					},
+				})
+			: null;
 
 	/**
-	 * Crossing saturation is terminal. A thrown error would not help — the guest
-	 * can catch it and loop, and every loop iteration still crosses a payload
-	 * across the isolate boundary. Only interrupting the guest guarantees the
-	 * budget holds, so terminate the isolate's execution (uncatchable by the
-	 * guest). The final `crossingOversize` check still reports the failure as
-	 * `OutputSizeExceeded` even if the isolate was already stopped.
+	 * Terminal failure: the guest is pathological (oversized single message or
+	 * quota exhaustion). A thrown error would not help — the guest can catch it
+	 * and loop, and every loop iteration still crosses a payload across the
+	 * isolate boundary. Only interrupting the guest guarantees the budget holds,
+	 * so dispose the isolate (uncatchable by the guest).
 	 */
-	function saturateCrossing(): void {
-		crossingOversize = true;
+	function terminateRun(name: string, message: string): void {
+		terminalState.name = name;
+		terminalState.message = message;
+		terminated = true;
 		try {
 			if (isolate && !isolate.isDisposed) {
 				// A guest parked on `await __sdk_dispatch` is NOT executing, so
@@ -872,18 +746,15 @@ export async function runScript(
 				isolate.dispose();
 			}
 		} catch {
-			// Isolate already finished; `crossingOversize` carries the failure.
+			// Isolate already finished; the terminal state carries the failure.
 		}
 	}
 
-	/** Charge one serialized SDK payload or result against the crossing guard. */
-	function chargeCrossing(json: string): boolean {
-		crossingBytes += Buffer.byteLength(json, "utf8");
-		if (crossingBytes > limits.crossingBytes) {
-			saturateCrossing();
-			return false;
-		}
-		return true;
+	/** True when the single message fits the per-message cap; otherwise the run is terminated. */
+	function guardMessage(json: string): boolean {
+		if (Buffer.byteLength(json, "utf8") <= limits.messageBytes) return true;
+		terminateRun("OutputSizeExceeded", oversizeMessage);
+		return false;
 	}
 
 	const ivm = await loadIsolatedVm();
@@ -949,24 +820,24 @@ export async function runScript(
 		await jail.set(
 			"__sdk_dispatch",
 			new ivm.Reference(async (path: string, payloadJson: string) => {
-				// Latch off once the crossing budget is saturated: don't run any
-				// more SDK work (DB/HTTP), just surface the oversize failure.
-				if (crossingOversize) {
-					return crossingOversizeEnvelope();
+				// Once terminated, don't run any more SDK work (DB/HTTP).
+				if (terminated) {
+					return terminalEnvelope();
 				}
 				sdkCalls++;
 				if (sdkCalls > limits.sdkCallQuota) {
-					throw new Error(
-						`QuotaExceeded: SDK call quota of ${limits.sdkCallQuota} reached`,
-					);
+					// Quota exhaustion is terminal (uncatchable) so a guest cannot
+					// catch the error and keep crossing payloads.
+					terminateRun("QuotaExceeded", quotaMessage);
+					return terminalEnvelope();
 				}
 				if (abortController.signal.aborted) {
 					throw new Error(
 						`TimeoutError: script exceeded ${limits.timeoutMs}ms wall-clock budget`,
 					);
 				}
-				if (!chargeCrossing(payloadJson)) {
-					return crossingOversizeEnvelope();
+				if (!guardMessage(payloadJson)) {
+					return terminalEnvelope();
 				}
 
 				const { args, orgPath } = JSON.parse(payloadJson) as {
@@ -1094,7 +965,7 @@ export async function runScript(
 								details: safeErrorDetails(error.result),
 							},
 						});
-						return chargeCrossing(json) ? json : crossingOversizeEnvelope();
+						return guardMessage(json) ? json : terminalEnvelope();
 					}
 					throw error;
 				}
@@ -1104,21 +975,15 @@ export async function runScript(
 					has_value: result !== undefined,
 					...(result === undefined ? {} : { value: result }),
 				});
-				return chargeCrossing(json) ? json : crossingOversizeEnvelope();
+				return guardMessage(json) ? json : terminalEnvelope();
 			}),
 		);
 
 		await jail.set(
 			"__console_call",
 			new ivm.Reference((level: "log" | "warn" | "error", message: string) => {
-				// Once saturated, stop processing console calls entirely and
-				// interrupt the guest so it cannot keep crossing messages.
-				if (crossingOversize) return;
-				crossingBytes += Buffer.byteLength(message, "utf8");
-				if (crossingBytes > limits.crossingBytes) {
-					saturateCrossing();
-					return;
-				}
+				// A single pathological message crosses the whole string; terminate.
+				if (!guardMessage(message)) return;
 				if (logFull) return;
 				const bytes = Buffer.byteLength(message, "utf8");
 				if (logBytesUsed + bytes > limits.logBytes) {
@@ -1163,8 +1028,8 @@ export async function runScript(
 			}) as Promise<string | null>,
 			limits.timeoutMs,
 		)) as string | null;
-		if (crossingOversize) {
-			throw crossingOversizeError();
+		if (terminated) {
+			throw new Error(terminalState.message);
 		}
 		if (returnJson) {
 			const envelopeBytes = Buffer.byteLength(returnJson, "utf8");
@@ -1176,11 +1041,10 @@ export async function runScript(
 				);
 			}
 			// An interactive return crosses the whole envelope to the host before
-			// truncation, so bound that copy BEFORE parsing: a huge return can
-			// otherwise force an arbitrarily large host JSON.parse. Returns up to
-			// the crossing budget are parsed and truncated; past it, hard-fail.
-			if (!options.extractExport && envelopeBytes > limits.crossingBytes) {
-				throw crossingOversizeError();
+			// previewing, so bound that copy BEFORE parsing: a huge return can
+			// otherwise force an arbitrarily large host JSON.parse.
+			if (!options.extractExport && envelopeBytes > limits.messageBytes) {
+				throw new Error(oversizeMessage);
 			}
 		}
 		const parsedResult = returnJson ? JSON.parse(returnJson) : null;
@@ -1216,26 +1080,26 @@ export async function runScript(
 			? parsedResult
 			: parsedResult.value;
 
-		// Interactive return values truncate to fit instead of failing the run:
-		// the agent works with partial data and is told exactly what was dropped.
-		let returnTruncated: TruncatedValueInfo | undefined;
-		let finalReturnValue = returnValue;
-		if (
-			!options.extractExport &&
-			jsonBytes(returnValue) > limits.outputBytes
-		) {
-			const truncated = truncateJsonValue(
-				returnValue,
-				limits.outputBytes,
-			);
-			finalReturnValue = truncated.value;
-			returnTruncated = truncated.meta;
+		// An oversized interactive return becomes a bounded preview, never the
+		// value: the model reads the head to decide what to query, and the
+		// `returnTruncated` report tells it the data is partial (query it, don't
+		// re-dump). extractExport keeps the full value (already hard-failed above).
+		let returnValuePreview: string | undefined;
+		let returnTruncated: ReturnPreviewInfo | undefined;
+		if (!options.extractExport) {
+			const valueJson = JSON.stringify(returnValue);
+			if (valueJson !== undefined && jsonBytes(returnValue) > limits.outputBytes) {
+				const built = buildReturnPreview(valueJson);
+				returnValuePreview = built.preview;
+				returnTruncated = built.info;
+			}
 		}
 
 		return {
 			success: true,
-			returnValue: finalReturnValue,
-			...(returnTruncated ? { returnTruncated } : {}),
+			...(returnValuePreview !== undefined
+				? { returnValuePreview, returnTruncated }
+				: { returnValue }),
 			logs,
 			durationMs: Date.now() - started,
 			sdkCalls,
@@ -1243,9 +1107,9 @@ export async function runScript(
 			sideEffectPreview,
 		};
 	} catch (err) {
-		// Crossing saturation terminates the isolate, which rejects with a raw
-		// termination error — report it as the OutputSizeExceeded it was.
-		const e = (crossingOversize ? crossingOversizeError() : err) as Error;
+		// A terminal failure disposes the isolate, which rejects with a raw
+		// termination error — report the terminal reason instead.
+		const e = (terminated ? new Error(terminalState.message) : err) as Error;
 		return {
 			success: false,
 			logs,

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -3,7 +3,8 @@
  * bridges SDK calls back to the host. Output is bounded per-purpose: interactive
  * return values are capped at 1 MB (an oversized value is replaced by a bounded
  * `returnValuePreview` head plus a report, never shipped in full to the model),
- * console logs are capped at 64 KB and dropped once full, and each single
+ * console logs are capped at 64 KB and the guest console bridge is disabled
+ * once full. Each single
  * host↔guest bridge message (SDK payload, SDK result, or return envelope) is
  * capped at 4 MB — a larger message, or exhausting the 200-call quota,
  * terminates the run by disposing the isolate (uncatchable by the guest).
@@ -24,7 +25,7 @@ export interface RunLimits {
 	memoryMb?: number;
 	timeoutMs?: number;
 	sdkCallQuota?: number;
-	/** Serialization cap for interactive return values; extracted exports hard-fail instead of previewing. */
+	/** Preview threshold and byte cap for interactive returns; extracted exports hard-fail instead. */
 	outputBytes?: number;
 	/** Cap for captured console logs; messages past it are dropped. */
 	logBytes?: number;
@@ -125,7 +126,7 @@ interface RunScriptResult {
 	returnValue?: unknown;
 	/** UTF-8-safe head of the serialized return value when it exceeded `outputBytes`. */
 	returnValuePreview?: string;
-	/** Present with `returnValuePreview`: the original and kept byte sizes. */
+	/** Present with `returnValuePreview`: original JSON and preview-string byte sizes. */
 	returnTruncated?: ReturnPreviewInfo;
 	logs: LogEntry[];
 	sdkCallTrace: SdkCallTraceEntry[];
@@ -220,13 +221,8 @@ export function safeErrorDetails(value: unknown): unknown {
 	}
 }
 
-const RETURN_PREVIEW_BYTES = 262_144;
+const MAX_RETURN_PREVIEW_BYTES = 262_144;
 const PREVIEW_SUFFIX = "\u2026 [truncated]";
-
-function jsonBytes(value: unknown): number {
-	const json = JSON.stringify(value);
-	return json === undefined ? 0 : Buffer.byteLength(json, "utf8");
-}
 
 /** Longest byte-bounded prefix of `value` that does not split a UTF-16 surrogate pair. */
 function byteBoundedPrefix(value: string, maxBytes: number): string {
@@ -253,11 +249,12 @@ function byteBoundedPrefix(value: string, maxBytes: number): string {
  */
 function buildReturnPreview(
 	valueJson: string,
+	totalBytes: number,
+	maxBytes: number,
 ): { preview: string; info: ReturnPreviewInfo } {
-	const totalBytes = Buffer.byteLength(valueJson, "utf8");
 	const kept = byteBoundedPrefix(
 		valueJson,
-		RETURN_PREVIEW_BYTES - Buffer.byteLength(PREVIEW_SUFFIX, "utf8"),
+		maxBytes - Buffer.byteLength(PREVIEW_SUFFIX, "utf8"),
 	);
 	const preview = `${kept}${PREVIEW_SUFFIX}`;
 	return {
@@ -601,10 +598,18 @@ function __makeClient(orgPath) {
 
 const client = __makeClient([]);
 
+let __console_enabled = true;
+function __emitConsole(level, args) {
+  if (!__console_enabled) return;
+  try {
+    const accepted = __console_call.applySync(undefined, [level, args.map(String).join(' ')]);
+    if (accepted === false) __console_enabled = false;
+  } catch (e) {}
+}
 const console = {
-  log: (...a) => { try { __console_call.applySync(undefined, ['log', a.map(String).join(' ')]); } catch (e) {} },
-  warn: (...a) => { try { __console_call.applySync(undefined, ['warn', a.map(String).join(' ')]); } catch (e) {} },
-  error: (...a) => { try { __console_call.applySync(undefined, ['error', a.map(String).join(' ')]); } catch (e) {} },
+  log: (...a) => __emitConsole('log', a),
+  warn: (...a) => __emitConsole('warn', a),
+  error: (...a) => __emitConsole('error', a),
 };
 
 const module = { exports: {} };
@@ -704,8 +709,8 @@ export async function runScript(
 	// Captured console budget. Messages past it are dropped, never a failure.
 	let logBytesUsed = 0;
 	let logFull = false;
-	// A terminal failure (message over the per-message cap, or quota exhausted)
-	// disposes the isolate so the guest cannot keep crossing bridge traffic.
+	// Terminal bridge failures dispose the isolate so the guest cannot keep
+	// crossing traffic after a message, call, or log budget is exhausted.
 	// Hoisted because `isolate` is assigned inside the try block below.
 	let isolate: import("isolated-vm").Isolate | null = null;
 	const terminalState = { name: "", message: "" };
@@ -713,6 +718,7 @@ export async function runScript(
 
 	const quotaMessage = `QuotaExceeded: SDK call quota of ${limits.sdkCallQuota} reached`;
 	const oversizeMessage = `OutputSizeExceeded: a single bridge message exceeded ${limits.messageBytes} bytes (SDK call payload/result or return value)`;
+	const consoleFloodMessage = `OutputSizeExceeded: console output continued after the ${limits.logBytes}-byte log cap`;
 	const terminalEnvelope = () =>
 		terminated
 			? JSON.stringify({
@@ -726,13 +732,13 @@ export async function runScript(
 			: null;
 
 	/**
-	 * Terminal failure: the guest is pathological (oversized single message or
-	 * quota exhaustion). A thrown error would not help — the guest can catch it
-	 * and loop, and every loop iteration still crosses a payload across the
-	 * isolate boundary. Only interrupting the guest guarantees the budget holds,
-	 * so dispose the isolate (uncatchable by the guest).
+	 * Terminal failure: the guest sent an oversized single message, exhausted
+	 * call quota, or bypassed a saturated console bridge. A thrown error would
+	 * not help — the guest can catch it and loop, and every loop iteration still
+	 * crosses a payload. Disposing the isolate makes the failure uncatchable.
 	 */
 	function terminateRun(name: string, message: string): void {
+		if (terminated) return;
 		terminalState.name = name;
 		terminalState.message = message;
 		terminated = true;
@@ -983,8 +989,13 @@ export async function runScript(
 			"__console_call",
 			new ivm.Reference((level: "log" | "warn" | "error", message: string) => {
 				// A single pathological message crosses the whole string; terminate.
-				if (!guardMessage(message)) return;
-				if (logFull) return;
+				if (!guardMessage(message)) return false;
+				if (logFull) {
+					// The normal guest console disables itself on the first false return.
+					// Reaching the host again means the script bypassed that latch.
+					terminateRun("OutputSizeExceeded", consoleFloodMessage);
+					return false;
+				}
 				const bytes = Buffer.byteLength(message, "utf8");
 				if (logBytesUsed + bytes > limits.logBytes) {
 					logFull = true;
@@ -993,10 +1004,11 @@ export async function runScript(
 						message: `[console output truncated: exceeded ${limits.logBytes} bytes]`,
 						ts: Date.now(),
 					});
-					return;
+					return false;
 				}
 				logBytesUsed += bytes;
 				logs.push({ level, message, ts: Date.now() });
+				return true;
 			}),
 		);
 
@@ -1088,10 +1100,17 @@ export async function runScript(
 		let returnTruncated: ReturnPreviewInfo | undefined;
 		if (!options.extractExport) {
 			const valueJson = JSON.stringify(returnValue);
-			if (valueJson !== undefined && jsonBytes(returnValue) > limits.outputBytes) {
-				const built = buildReturnPreview(valueJson);
-				returnValuePreview = built.preview;
-				returnTruncated = built.info;
+			if (valueJson !== undefined) {
+				const totalBytes = Buffer.byteLength(valueJson, "utf8");
+				if (totalBytes > limits.outputBytes) {
+					const built = buildReturnPreview(
+						valueJson,
+						totalBytes,
+						Math.min(MAX_RETURN_PREVIEW_BYTES, limits.outputBytes),
+					);
+					returnValuePreview = built.preview;
+					returnTruncated = built.info;
+				}
 			}
 		}
 

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -10,7 +10,7 @@ import { withValidatedArgs } from "./validate-args";
 const SCRIPT_FIELDS = {
   script: Type.String({
     description:
-      "TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. The script's return value comes back as `return_value` in the result; return values that exceed the output cap are truncated to fit and reported in `return_value_truncated`. Use `search_sdk` to discover SDK methods and `ctx.sleep`.",
+      "TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. The script's return value comes back as `return_value`; return it only for computed results and bounded samples. For bulk data prefer `client.query` / `query_sql` or paginated SDK reads — a return over the output cap is replaced by a `return_value_preview` head and a `return_truncated` report instead of shipping the full set to the model. Use `search_sdk` to discover SDK methods and `ctx.sleep`.",
     minLength: 1,
     maxLength: 100_000,
   }),
@@ -68,30 +68,26 @@ const SdkCallTraceEntrySchema = Type.Object({
 export const SdkScriptResultSchema = Type.Object({
   success: Type.Boolean({ description: "Whether the script ran to completion." }),
   return_value: Type.Optional(
-    Type.Unknown({ description: "The script's default-export return value." }),
+    Type.Unknown({ description: "The script's default-export return value. Omitted when the return exceeded the output cap (see return_value_preview)." }),
   ),
-  return_value_truncated: Type.Optional(
+  return_value_preview: Type.Optional(
+    Type.String({
+      description:
+        "UTF-8-safe head of the serialized return value when it exceeded the output cap; return_value is then omitted. This is a preview, not the value — the full data is still queryable: rerun with filtering / LIMIT / OFFSET, or pull slices with client.query / query_sql. Don't re-return the whole set.",
+    }),
+  ),
+  return_truncated: Type.Optional(
     Type.Object(
       {
         total_bytes: Type.Integer({
           description: "Serialized size of the original return value.",
         }),
         kept_bytes: Type.Integer({
-          description: "Serialized size of the truncated return value.",
-        }),
-        dropped_elements: Type.Integer({
-          description: "Array elements dropped from the tail.",
-        }),
-        dropped_keys: Type.Integer({
-          description: "Object keys dropped from the tail.",
-        }),
-        dropped_chars: Type.Integer({
-          description: "UTF-16 code units dropped from truncated string values.",
+          description: "Serialized size of the preview.",
         }),
       },
       {
-        description:
-          "Present when the script's return value exceeded the output cap and was truncated to fit. return_value is partial — paginate or filter the script and re-run for the rest.",
+        description: "Present with return_value_preview: the original and preview byte sizes.",
       },
     ),
   ),
@@ -99,7 +95,6 @@ export const SdkScriptResultSchema = Type.Object({
     Type.Object({
       level: Type.Union([Type.Literal("log"), Type.Literal("warn"), Type.Literal("error")]),
       message: Type.String(),
-      data: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
       ts: Type.Number(),
     }),
     { description: "console.log/warn/error output captured from the script." },
@@ -225,7 +220,8 @@ async function runSandbox(
   return {
     success: result.success,
     return_value: result.returnValue,
-    return_value_truncated: result.returnTruncated,
+    return_value_preview: result.returnValuePreview,
+    return_truncated: result.returnTruncated,
     logs: result.logs,
     error,
     duration_ms: result.durationMs,

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -68,12 +68,15 @@ const SdkCallTraceEntrySchema = Type.Object({
 export const SdkScriptResultSchema = Type.Object({
   success: Type.Boolean({ description: "Whether the script ran to completion." }),
   return_value: Type.Optional(
-    Type.Unknown({ description: "The script's default-export return value. Omitted when the return exceeded the output cap (see return_value_preview)." }),
+    Type.Unknown({
+      description:
+        "The script's default-export return value. Omitted when the return exceeded the output cap (see return_value_preview).",
+    }),
   ),
   return_value_preview: Type.Optional(
     Type.String({
       description:
-        "UTF-8-safe head of the serialized return value when it exceeded the output cap; return_value is then omitted. This is a preview, not the value — the full data is still queryable: rerun with filtering / LIMIT / OFFSET, or pull slices with client.query / query_sql. Don't re-return the whole set.",
+        "UTF-8-safe head of the serialized return value when it exceeded the output cap; return_value is then omitted. This is a preview, not the value — rerun with filtering / LIMIT / OFFSET, or pull slices with client.query / query_sql. Don't re-return the whole set.",
     }),
   ),
   return_truncated: Type.Optional(
@@ -83,7 +86,7 @@ export const SdkScriptResultSchema = Type.Object({
           description: "Serialized size of the original return value.",
         }),
         kept_bytes: Type.Integer({
-          description: "Serialized size of the preview.",
+          description: "UTF-8 size of the preview string.",
         }),
       },
       {


### PR DESCRIPTION
## Summary
Follow-up to #2645. A design consult (codex) flagged the three-budget model + recursive structure-preserving truncator as over-engineered for what they guarantee. This consolidates the sandbox output path:

- **Oversized interactive returns become a bounded `return_value_preview`** (UTF-8-safe JSON head, `min(256 KB, outputBytes)`) plus a `return_truncated` report; `return_value` is **omitted**. The model reads the head to decide what to query instead of getting a disguised partial value. Deletes the ~130-line truncation walker (`encodeWithinBudget`/`truncateJsonValue`, dropped_* meta).
- **Per-message caps replace the cumulative crossing counter**: any single SDK payload, SDK result, console message, or return envelope over 4 MB terminates the run by disposing the isolate. **Quota exhaustion is now terminal too** (uncatchable), so a guest can't catch the error and keep crossing.
- **Guest-side console latch**: the console bridge returns false when the log cap fills, disabling the guest console; a script bypassing the latch is terminated.
- **`client.query` applies an outer 5000-row LIMIT** — a broad `SELECT * FROM events` could previously materialize unbounded rows host-side (`query_sql` already paginates). Pinned by an integration test (`generate_series(1,10000)` → 5000).
- **Cut dead weight**: `crossingBytes`, `LogEntry.data` (never populated).
- **Wire schema**: `return_value_truncated` → `return_value_preview` + `return_truncated`; the tool description now steers agents to query bulk data (`client.query`/`query_sql`) instead of re-returning it.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests: `bun test src/__tests__/unit` → 1045 pass; sandbox integration (vitest) → 66 pass incl. preview contract, per-message cap, quota terminal, console latch, client.query LIMIT
- [x] `make review-fix` ran (codex) and its edits committed
- Rebased onto latest `origin/main` (2 commits ahead of base) with no conflicts

## Notes
- **Breaking wire change from #2645** (nothing shipped yet, no clients depend on `return_value_truncated`): `return_value` is now omitted for oversized returns, replaced by `return_value_preview` + `return_truncated`.
- **`client.query` behavior change**: results capped at 5000 rows; agents page with their own LIMIT/OFFSET.
- Prod-visible surface: `run_sdk`/`query_sdk` output + `client.query`. Rollout verification owed after merge (gate on squash commit vs deployed SHA).