### PR TITLE
fix(server): bound the SDK call trace so the model never gets a multi-MB trace

### DIFF
--- a/packages/client/src/generated/sdk.gen.ts
+++ b/packages/client/src/generated/sdk.gen.ts
@@ -240,7 +240,7 @@ export const searchSdk = <ThrowOnError extends boolean = false>(
 /**
  * Read workspace data through typed SDK methods
  *
- * Read workspace data through typed SDK methods. Query entities, relationships, feeds, operations, metrics, and more. Use this for lookups and searches that do not change data. (For writes: use run_sdk. To discover available methods: use search_sdk. For polling: use await ctx.sleep(ms) in your script.
+ * Read workspace data through typed SDK methods. Query entities, relationships, feeds, operations, metrics, and more. Use this for lookups and searches that do not change workspace content or external systems. (For writes: use run_sdk. To discover available methods: use search_sdk.
  */
 export const querySdk = <ThrowOnError extends boolean = false>(
   options: Options<QuerySdkData, ThrowOnError>,

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -331,7 +331,24 @@ export type SaveMemoryResponses = {
    * Successful response
    */
   200: {
-    [key: string]: unknown;
+    id: number;
+    entity_ids: Array<number>;
+    title: string | null;
+    semantic_type: string;
+    created_at: string;
+    supersedes_event_id?: number;
+    view_url?: string;
+    durable_at: string;
+    indexing_status: "pending" | "completed";
+    searchable: boolean;
+    created: boolean;
+    metadata: {
+      [key: string]: unknown;
+    };
+    exact_read: {
+      method: "client.knowledge.read";
+      content_ids: [unknown];
+    };
   };
 };
 
@@ -408,7 +425,7 @@ export type SearchSdkResponse = SearchSdkResponses[keyof SearchSdkResponses];
 export type QuerySdkData = {
   body: {
     /**
-     * TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. The script's return value comes back as `return_value` in the result. Use `search_sdk` to discover SDK methods and `ctx.sleep`.
+     * TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. The script's return value comes back as `return_value`; return it only for computed results and bounded samples. For bulk data prefer `client.query` / `query_sql` or paginated SDK reads — a return over the output cap is replaced by a `return_value_preview` head and a `return_truncated` report instead of shipping the full set to the model. Use `search_sdk` to discover SDK methods and `ctx.sleep`.
      */
     script: string;
     /**
@@ -453,18 +470,32 @@ export type QuerySdkResponses = {
      */
     success: boolean;
     /**
-     * The script's default-export return value.
+     * The script's default-export return value. Omitted when the return exceeded the output cap (see return_value_preview).
      */
     return_value?: unknown;
+    /**
+     * UTF-8-safe head of the serialized return value when it exceeded the output cap; return_value is then omitted. This is a preview, not the value — rerun with filtering / LIMIT / OFFSET, or pull slices with client.query / query_sql. Don't re-return the whole set.
+     */
+    return_value_preview?: string;
+    /**
+     * Present with return_value_preview: the original and preview byte sizes.
+     */
+    return_truncated?: {
+      /**
+       * Serialized size of the original return value.
+       */
+      total_bytes: number;
+      /**
+       * UTF-8 size of the preview string.
+       */
+      kept_bytes: number;
+    };
     /**
      * console.log/warn/error output captured from the script.
      */
     logs: Array<{
       level: "log" | "warn" | "error";
       message: string;
-      data?: {
-        [key: string]: unknown;
-      };
       ts: number;
     }>;
     /**
@@ -491,11 +522,15 @@ export type QuerySdkResponses = {
     };
     duration_ms: number;
     /**
-     * Number of SDK calls the script made.
+     * Number of SDK calls the script made (dispatched + skipped).
      */
     sdk_calls: number;
     /**
-     * Every SDK call the script made, in order.
+     * Total calls skipped because dry_run=true — the full dry-run surface, even when side_effect_preview is truncated.
+     */
+    skipped_calls: number;
+    /**
+     * Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap, the oldest entries are dropped and reported in sdk_call_trace_truncated — the last (usually failing) call is always kept.
      */
     sdk_call_trace: Array<{
       /**
@@ -520,7 +555,7 @@ export type QuerySdkResponses = {
       skipped: boolean;
     }>;
     /**
-     * Write/admin/external calls that were skipped because dry_run=true. This is a method-level side-effect preview, not proof that the skipped handler would accept the payload.
+     * Write/admin/external calls that were skipped because dry_run=true (skipped: true). Bounded like sdk_call_trace; see skipped_calls for the total. Method-level side-effect preview, not proof the skipped handler would accept the payload.
      */
     side_effect_preview: Array<{
       /**
@@ -544,6 +579,15 @@ export type QuerySdkResponses = {
        */
       skipped: boolean;
     }>;
+    /**
+     * Present when sdk_call_trace or side_effect_preview was truncated (oldest entries dropped).
+     */
+    sdk_call_trace_truncated?: {
+      /**
+       * Trace/preview entries dropped because the trace cap was exceeded.
+       */
+      dropped_entries: number;
+    };
     dry_run: boolean;
   };
 };
@@ -625,7 +669,24 @@ export type QuerySqlResponses = {
    * Successful response
    */
   200: {
-    [key: string]: unknown;
+    /**
+     * The original caller-supplied SQL statement. This is never the tenant-scoped SQL rewritten by Lobu and is absent for stored virtual-feed queries.
+     */
+    sql?: string;
+    rows: Array<{
+      [key: string]: unknown;
+    }>;
+    columns: Array<{
+      name: string;
+      type: string;
+    }>;
+    total_count: number;
+    has_more: boolean;
+    execution_time_ms: number;
+    coverage?: unknown;
+    error?: string;
+    error_code?: string;
+    retryable?: boolean;
   };
 };
 
@@ -634,7 +695,7 @@ export type QuerySqlResponse = QuerySqlResponses[keyof QuerySqlResponses];
 export type RunSdkData = {
   body: {
     /**
-     * TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. The script's return value comes back as `return_value` in the result. Use `search_sdk` to discover SDK methods and `ctx.sleep`.
+     * TypeScript source. Must `export default async (ctx, client) => { ... }` — `ctx` is `{ organization_id, user_id, mode, sleep(ms) }`, where `await ctx.sleep(ms)` provides a bounded, abort-aware 0–30000ms polling delay; unrestricted timer globals are unavailable. `client` is the ClientSDK. The script's return value comes back as `return_value`; return it only for computed results and bounded samples. For bulk data prefer `client.query` / `query_sql` or paginated SDK reads — a return over the output cap is replaced by a `return_value_preview` head and a `return_truncated` report instead of shipping the full set to the model. Use `search_sdk` to discover SDK methods and `ctx.sleep`.
      */
     script: string;
     /**
@@ -683,18 +744,32 @@ export type RunSdkResponses = {
      */
     success: boolean;
     /**
-     * The script's default-export return value.
+     * The script's default-export return value. Omitted when the return exceeded the output cap (see return_value_preview).
      */
     return_value?: unknown;
+    /**
+     * UTF-8-safe head of the serialized return value when it exceeded the output cap; return_value is then omitted. This is a preview, not the value — rerun with filtering / LIMIT / OFFSET, or pull slices with client.query / query_sql. Don't re-return the whole set.
+     */
+    return_value_preview?: string;
+    /**
+     * Present with return_value_preview: the original and preview byte sizes.
+     */
+    return_truncated?: {
+      /**
+       * Serialized size of the original return value.
+       */
+      total_bytes: number;
+      /**
+       * UTF-8 size of the preview string.
+       */
+      kept_bytes: number;
+    };
     /**
      * console.log/warn/error output captured from the script.
      */
     logs: Array<{
       level: "log" | "warn" | "error";
       message: string;
-      data?: {
-        [key: string]: unknown;
-      };
       ts: number;
     }>;
     /**
@@ -721,11 +796,15 @@ export type RunSdkResponses = {
     };
     duration_ms: number;
     /**
-     * Number of SDK calls the script made.
+     * Number of SDK calls the script made (dispatched + skipped).
      */
     sdk_calls: number;
     /**
-     * Every SDK call the script made, in order.
+     * Total calls skipped because dry_run=true — the full dry-run surface, even when side_effect_preview is truncated.
+     */
+    skipped_calls: number;
+    /**
+     * Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap, the oldest entries are dropped and reported in sdk_call_trace_truncated — the last (usually failing) call is always kept.
      */
     sdk_call_trace: Array<{
       /**
@@ -750,7 +829,7 @@ export type RunSdkResponses = {
       skipped: boolean;
     }>;
     /**
-     * Write/admin/external calls that were skipped because dry_run=true. This is a method-level side-effect preview, not proof that the skipped handler would accept the payload.
+     * Write/admin/external calls that were skipped because dry_run=true (skipped: true). Bounded like sdk_call_trace; see skipped_calls for the total. Method-level side-effect preview, not proof the skipped handler would accept the payload.
      */
     side_effect_preview: Array<{
       /**
@@ -774,6 +853,15 @@ export type RunSdkResponses = {
        */
       skipped: boolean;
     }>;
+    /**
+     * Present when sdk_call_trace or side_effect_preview was truncated (oldest entries dropped).
+     */
+    sdk_call_trace_truncated?: {
+      /**
+       * Trace/preview entries dropped because the trace cap was exceeded.
+       */
+      dropped_entries: number;
+    };
     dry_run: boolean;
   };
 };
@@ -3962,7 +4050,7 @@ export type NotifyData = {
       [key: string]: unknown;
     };
     /**
-     * Turn this notification into a QUESTION the recipient answers, instead of an FYI. JSON Schema for the answer. Pass {} for a plain yes/no decision (renders as Approve/Reject inline, in-app and in chat). Pass a single required enum property to offer one-click named options. Pass several properties to collect fields (the recipient gets a form; give each property a `title` — without one the form labels the field with its full `description`). Properties must be flat: nested objects do not render. Answering records the result and emits it — read it back with manage_operations get_run.
+     * Turn this notification into a QUESTION the recipient answers, instead of an FYI. Pass {} for a plain yes/no decision; a single required string-enum property for one-click options; or a flat object of primitive fields, scalar enums, string/scalar-enum arrays, and optional nullable anyOf wrappers for a form. Give each property a `title`. Nested objects, references, other combinators, constants, formats, patterns, and string/number/array constraints are unsupported and fail with HTTP 422 before a run is created. Read the answer with manage_operations get_run.
      */
     input_schema?: {
       [key: string]: unknown;

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -530,7 +530,7 @@ export type QuerySdkResponses = {
      */
     skipped_calls: number;
     /**
-     * Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap, the oldest entries are dropped and reported in sdk_call_trace_truncated — the last (usually failing) call is always kept.
+     * Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap the oldest entries are dropped and reported in sdk_call_trace_truncated; a single entry larger than the cap is dropped and counted too.
      */
     sdk_call_trace: Array<{
       /**
@@ -804,7 +804,7 @@ export type RunSdkResponses = {
      */
     skipped_calls: number;
     /**
-     * Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap, the oldest entries are dropped and reported in sdk_call_trace_truncated — the last (usually failing) call is always kept.
+     * Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap the oldest entries are dropped and reported in sdk_call_trace_truncated; a single entry larger than the cap is dropped and counted too.
      */
     sdk_call_trace: Array<{
       /**

--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -570,4 +570,131 @@ describe("sandbox output budgets", () => {
     // Interrupted at the first oversized payload, well under the 5s timeout.
     expect(Date.now() - started).toBeLessThan(3000);
   });
+
+  it("bounds the SDK call trace and keeps the tail", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => [{ id: 1 }],
+      } as never,
+    });
+    const result = await runScript({
+      source: [
+        "export default async (_ctx, client) => {",
+        "  for (let i = 0; i < 50; i++) {",
+        "    await client.entities.list({ big: 'x'.repeat(4000) });",
+        "  }",
+        "  return 'done';",
+        "};",
+      ].join("\n"),
+      sdk,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.returnValue).toBe("done");
+    const serialized = Buffer.byteLength(
+      JSON.stringify(result.sdkCallTrace),
+      "utf8",
+    );
+    expect(serialized).toBeLessThanOrEqual(131_072);
+    expect(result.sdkCallTrace.at(-1)?.path).toBe("entities.list");
+    expect(result.traceDropped).toBeGreaterThan(0);
+  });
+
+  it("keeps the failing call in the tail of a bounded trace", async () => {
+    let calls = 0;
+    const sdk = stubSDK({
+      entities: {
+        list: async () => {
+          calls++;
+          if (calls === 50) throw new Error("boom");
+          return [{ id: 1 }];
+        },
+      } as never,
+    });
+    const result = await runScript({
+      source: [
+        "export default async (_ctx, client) => {",
+        "  for (let i = 0; i < 50; i++) {",
+        "    await client.entities.list({ big: 'x'.repeat(4000) });",
+        "  }",
+        "  return 'done';",
+        "};",
+      ].join("\n"),
+      sdk,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe("ScriptError");
+    expect(result.error?.message).toContain("boom");
+    // The 50th (failing) call is the last trace entry and survives tail-keep.
+    expect(result.sdkCallTrace.at(-1)?.path).toBe("entities.list");
+    expect(result.traceDropped).toBeGreaterThan(0);
+  });
+
+  it("drops and counts a single trace entry over the cap", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => [],
+      } as never,
+    });
+    const result = await runScript({
+      source: [
+        "export default async (_ctx, client) => {",
+        "  await client.entities.list({ small: 1 });",
+        "  await client.entities.list({ big: 'x'.repeat(4000) });",
+        "  return 'done';",
+        "};",
+      ].join("\n"),
+      sdk,
+      limits: { traceBytes: 1024 },
+    });
+
+    expect(result.success).toBe(true);
+    // The big-arg entry alone exceeds the 1 KB cap -> dropped and counted.
+    expect(result.traceDropped).toBeGreaterThan(0);
+    // The small entry is retained.
+    expect(result.sdkCallTrace.length).toBeGreaterThan(0);
+  });
+
+  it("reports the total skipped calls even when the preview truncates", async () => {
+    const sdk = stubSDK({
+      entities: {
+        manage: async () => ({}),
+      } as never,
+    });
+    const result = await runScript({
+      source: [
+        "export default async (_ctx, client) => {",
+        "  for (let i = 0; i < 30; i++) {",
+        "    await client.entities.manage({ big: 'x'.repeat(4000) });",
+        "  }",
+        "  return 'done';",
+        "};",
+      ].join("\n"),
+      sdk,
+      sdkMode: "full",
+      dryRun: true,
+      limits: { traceBytes: 4096 },
+    });
+
+    expect(result.success).toBe(true);
+    // All 30 are skipped; the counter is independent of preview retention.
+    expect(result.skippedCalls).toBe(30);
+    // The preview is bounded and truncated.
+    expect(result.sideEffectPreview.length).toBeLessThan(30);
+    expect(result.traceDropped).toBeGreaterThan(0);
+  });
+
+  it("omits the truncation marker on a normal run", async () => {
+    const result = await runScript({
+      source:
+        "export default async (_ctx, client) => { await client.entities.list(); return 'ok'; };",
+      sdk: stubSDK({
+        entities: { list: async () => [] } as never,
+      }),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.traceDropped).toBe(0);
+  });
 });

--- a/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/run-script-runtime.test.ts
@@ -600,6 +600,35 @@ describe("sandbox output budgets", () => {
     expect(result.traceDropped).toBeGreaterThan(0);
   });
 
+  it("stays within traceBytes even at the 200-entry boundary", async () => {
+    const sdk = stubSDK({
+      entities: {
+        list: async () => [{ id: 1 }],
+      } as never,
+    });
+    const result = await runScript({
+      source: [
+        "export default async (_ctx, client) => {",
+        "  for (let i = 0; i < 200; i++) {",
+        "    await client.entities.list({ big: 'x'.repeat(600) });",
+        "  }",
+        "  return 'done';",
+        "};",
+      ].join("\n"),
+      sdk,
+    });
+
+    expect(result.success).toBe(true);
+    // Entry-byte sum alone is under the cap, but with commas/brackets the
+    // serialized array would exceed it — the strict bound must still hold.
+    const serialized = Buffer.byteLength(
+      JSON.stringify(result.sdkCallTrace),
+      "utf8",
+    );
+    expect(serialized).toBeLessThanOrEqual(131_072);
+    expect(result.traceDropped).toBeGreaterThan(0);
+  });
+
   it("keeps the failing call in the tail of a bounded trace", async () => {
     let calls = 0;
     const sdk = stubSDK({

--- a/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
+++ b/packages/server/src/__tests__/unit/manage-wire-schema.test.ts
@@ -203,9 +203,11 @@ describe("run_sdk / query_sdk: script contract on the wire", () => {
 			logs: [{ level: "warn", message: "m", ts: 123 }],
 			duration_ms: 42,
 			sdk_calls: 2,
+			skipped_calls: 2,
 			sdk_call_trace: [
 				{ path: "entities.list", orgPath: [], access: "read", args: [{}], skipped: false },
 			],
+			sdk_call_trace_truncated: { dropped_entries: 3 },
 			side_effect_preview: [
 				{ path: "entities.create", orgPath: ["acme"], access: "write", args: [{}], skipped: true },
 				{ path: "connections.connect", orgPath: ["acme"], access: "admin", args: [{}], skipped: true },
@@ -220,6 +222,7 @@ describe("run_sdk / query_sdk: script contract on the wire", () => {
 			error: { name: "TypeError", message: "boom", stack: "s", line: 3, column: 7 },
 			duration_ms: 1,
 			sdk_calls: 0,
+			skipped_calls: 0,
 			sdk_call_trace: [],
 			side_effect_preview: [],
 			dry_run: false,

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -29,6 +29,8 @@ export interface RunLimits {
 	outputBytes?: number;
 	/** Cap for captured console logs; messages past it are dropped. */
 	logBytes?: number;
+	/** Total serialized cap for `sdk_call_trace` and `side_effect_preview`; oldest entries are dropped past it. */
+	traceBytes?: number;
 	/** Single-message cap for host↔guest bridge traffic; a larger message terminates the run. */
 	messageBytes?: number;
 }
@@ -128,6 +130,10 @@ interface RunScriptResult {
 	returnValuePreview?: string;
 	/** Present with `returnValuePreview`: original JSON and preview-string byte sizes. */
 	returnTruncated?: ReturnPreviewInfo;
+	/** Total calls skipped under dry-run (independent of preview retention). */
+	skippedCalls: number;
+	/** Trace entries dropped because the `traceBytes` cap was exceeded. */
+	traceDropped: number;
 	logs: LogEntry[];
 	sdkCallTrace: SdkCallTraceEntry[];
 	sideEffectPreview: SdkCallTraceEntry[];
@@ -149,6 +155,7 @@ const DEFAULT_LIMITS: Required<RunLimits> = {
 	sdkCallQuota: 200,
 	outputBytes: 1_048_576,
 	logBytes: 65_536,
+	traceBytes: 131_072,
 	messageBytes: 4_194_304,
 };
 /** Device action waits allow 60s queue + 95s post-claim; sandbox must outlive that. */
@@ -158,6 +165,11 @@ const MAX_TRACE_ARGS_BYTES = 8192;
 const MAX_ERROR_DETAILS_BYTES = 16_384;
 const SENSITIVE_TRACE_KEY =
 	/(api[_-]?key|apikey|auth[_-]?data|auth[_-]?values|authorization|cookie|credential|password|private[_-]?key|secret|token)/i;
+
+function jsonBytes(value: unknown): number {
+	const json = JSON.stringify(value);
+	return json === undefined ? 0 : Buffer.byteLength(json, "utf8");
+}
 
 function redactTraceValue(
 	value: unknown,
@@ -360,6 +372,12 @@ function clampLimits(limits?: RunLimits): Required<RunLimits> {
 			DEFAULT_LIMITS.logBytes,
 			1024,
 			DEFAULT_LIMITS.logBytes,
+		),
+		traceBytes: clampNumber(
+			limits?.traceBytes,
+			DEFAULT_LIMITS.traceBytes,
+			1024,
+			DEFAULT_LIMITS.traceBytes,
 		),
 		messageBytes: clampNumber(
 			limits?.messageBytes,
@@ -706,6 +724,9 @@ export async function runScript(
 	const sdkCallTrace: SdkCallTraceEntry[] = [];
 	const sideEffectPreview: SdkCallTraceEntry[] = [];
 	let sdkCalls = 0;
+	// Total calls skipped under dry-run, independent of preview retention so a
+	// truncated preview never undercounts the dry-run surface.
+	let skippedCalls = 0;
 	// Captured console budget. Messages past it are dropped, never a failure.
 	let logBytesUsed = 0;
 	let logFull = false;
@@ -763,6 +784,36 @@ export async function runScript(
 		return false;
 	}
 
+	/**
+	 * Bounded trace appender: keeps a serialized-byte budget on a trace array by
+	 * dropping the OLDEST entries (failures are at the tail), and counts what it
+	 * drops. A single entry larger than the whole budget is dropped and counted.
+	 * Bound is on the sum of entry JSON bytes — array brackets/commas add at most
+	 * ~2 bytes per retained entry, negligible at this scale.
+	 */
+	function makeTraceAppender(budget: number) {
+		let used = 0;
+		let dropped = 0;
+		return {
+			dropped: () => dropped,
+			append(target: SdkCallTraceEntry[], entry: SdkCallTraceEntry): void {
+				const entryBytes = jsonBytes(entry);
+				if (entryBytes > budget) {
+					dropped++;
+					return;
+				}
+				target.push(entry);
+				used += entryBytes;
+				while (used > budget && target.length > 0) {
+					used -= jsonBytes(target.shift()!);
+					dropped++;
+				}
+			},
+		};
+	}
+	const appendTrace = makeTraceAppender(limits.traceBytes);
+	const appendPreview = makeTraceAppender(limits.traceBytes);
+
 	const ivm = await loadIsolatedVm();
 	if (!ivm) {
 		clearTimeout(abortTimer);
@@ -776,6 +827,8 @@ export async function runScript(
 			},
 			durationMs: Date.now() - started,
 			sdkCalls: 0,
+			skippedCalls: 0,
+			traceDropped: 0,
 			sdkCallTrace,
 			sideEffectPreview,
 		};
@@ -812,6 +865,8 @@ export async function runScript(
 			},
 			durationMs: Date.now() - started,
 			sdkCalls: 0,
+			skippedCalls: 0,
+			traceDropped: 0,
 			sdkCallTrace,
 			sideEffectPreview,
 		};
@@ -883,7 +938,7 @@ export async function runScript(
 							args[0] as string,
 							args[1] as Record<string, unknown> | undefined,
 						);
-						sdkCallTrace.push({
+						appendTrace.append(sdkCallTrace, {
 							path,
 							orgPath,
 							access: METHOD_METADATA[path]?.access ?? "unknown",
@@ -893,7 +948,7 @@ export async function runScript(
 						return undefined;
 					}
 					if (path === "query") {
-						sdkCallTrace.push({
+						appendTrace.append(sdkCallTrace, {
 							path,
 							orgPath,
 							access: METHOD_METADATA[path]?.access ?? "unknown",
@@ -946,11 +1001,14 @@ export async function runScript(
 							path,
 						}),
 					};
-					sdkCallTrace.push(trace);
+					// Skipped (dry-run) calls live only in `side_effect_preview`;
+					// dispatched calls only in `sdk_call_trace` — no double shipping.
 					if (trace.skipped) {
-						sideEffectPreview.push(trace);
+						skippedCalls++;
+						appendPreview.append(sideEffectPreview, trace);
 						return { dry_run: true, skipped_call: path, access };
 					}
+					appendTrace.append(sdkCallTrace, trace);
 					return namespace[method](...args);
 				})();
 
@@ -1083,6 +1141,8 @@ export async function runScript(
 					error: classifyRuntimeError(scriptError ?? {}),
 					durationMs: Date.now() - started,
 					sdkCalls,
+					skippedCalls,
+					traceDropped: appendTrace.dropped() + appendPreview.dropped(),
 					sdkCallTrace,
 					sideEffectPreview,
 				};
@@ -1122,6 +1182,8 @@ export async function runScript(
 			logs,
 			durationMs: Date.now() - started,
 			sdkCalls,
+			skippedCalls,
+			traceDropped: appendTrace.dropped() + appendPreview.dropped(),
 			sdkCallTrace,
 			sideEffectPreview,
 		};
@@ -1135,6 +1197,8 @@ export async function runScript(
 			error: classifyRuntimeError(e),
 			durationMs: Date.now() - started,
 			sdkCalls,
+			skippedCalls,
+			traceDropped: appendTrace.dropped() + appendPreview.dropped(),
 			sdkCallTrace,
 			sideEffectPreview,
 		};

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -785,27 +785,28 @@ export async function runScript(
 	}
 
 	/**
-	 * Bounded trace appender: keeps a serialized-byte budget on a trace array by
-	 * dropping the OLDEST entries (failures are at the tail), and counts what it
-	 * drops. A single entry larger than the whole budget is dropped and counted.
-	 * Bound is on the sum of entry JSON bytes — array brackets/commas add at most
-	 * ~2 bytes per retained entry, negligible at this scale.
+	 * Bounded trace appender: keeps a strict serialized-byte budget on a trace
+	 * array by dropping the OLDEST entries (failures are at the tail) and
+	 * counting what it drops. Brackets and commas are included so the retained
+	 * array can never serialize beyond the budget. A single entry that does not
+	 * fit even alone is dropped and counted.
 	 */
 	function makeTraceAppender(budget: number) {
-		let used = 0;
+		let used = 2; // JSON array brackets
 		let dropped = 0;
 		return {
 			dropped: () => dropped,
 			append(target: SdkCallTraceEntry[], entry: SdkCallTraceEntry): void {
 				const entryBytes = jsonBytes(entry);
-				if (entryBytes > budget) {
+				if (entryBytes + 2 > budget) {
 					dropped++;
 					return;
 				}
 				target.push(entry);
-				used += entryBytes;
+				used += entryBytes + (target.length > 1 ? 1 : 0); // comma
 				while (used > budget && target.length > 0) {
-					used -= jsonBytes(target.shift()!);
+					const removed = target.shift()!;
+					used -= jsonBytes(removed) + (target.length > 0 ? 1 : 0);
 					dropped++;
 				}
 			},

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -29,7 +29,7 @@ export interface RunLimits {
 	outputBytes?: number;
 	/** Cap for captured console logs; messages past it are dropped. */
 	logBytes?: number;
-	/** Total serialized cap for `sdk_call_trace` and `side_effect_preview`; oldest entries are dropped past it. */
+	/** Serialized cap for EACH of `sdk_call_trace` and `side_effect_preview`; oldest entries are dropped past it. */
 	traceBytes?: number;
 	/** Single-message cap for host↔guest bridge traffic; a larger message terminates the run. */
 	messageBytes?: number;

--- a/packages/server/src/tools/audit.ts
+++ b/packages/server/src/tools/audit.ts
@@ -139,9 +139,14 @@ function buildPayload(params: ToolInvocationAuditParams): Record<string, unknown
       side_effect_preview: Array.isArray(result.side_effect_preview)
         ? result.side_effect_preview
         : [],
-      side_effect_count: Array.isArray(result.side_effect_preview)
-        ? result.side_effect_preview.length
-        : 0,
+      // `skipped_calls` survives preview truncation; fall back to array length
+      // for older payloads.
+      side_effect_count:
+        typeof result.skipped_calls === 'number'
+          ? result.skipped_calls
+          : Array.isArray(result.side_effect_preview)
+            ? result.side_effect_preview.length
+            : 0,
       success: toolError ? false : result.success === true,
       error: toolError ?? resultError,
       duration_ms: params.durationMs,

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -133,14 +133,30 @@ export const SdkScriptResultSchema = Type.Object({
     ),
   ),
   duration_ms: Type.Number(),
-  sdk_calls: Type.Integer({ description: "Number of SDK calls the script made." }),
+  sdk_calls: Type.Integer({ description: "Number of SDK calls the script made (dispatched + skipped)." }),
+  skipped_calls: Type.Integer({
+    description: "Total calls skipped because dry_run=true — the full dry-run surface, even when side_effect_preview is truncated.",
+  }),
   sdk_call_trace: Type.Array(SdkCallTraceEntrySchema, {
-    description: "Every SDK call the script made, in order.",
+    description:
+      "Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap, the oldest entries are dropped and reported in sdk_call_trace_truncated — the last (usually failing) call is always kept.",
   }),
   side_effect_preview: Type.Array(SdkCallTraceEntrySchema, {
     description:
-      "Write/admin/external calls that were skipped because dry_run=true. This is a method-level side-effect preview, not proof that the skipped handler would accept the payload.",
+      "Write/admin/external calls that were skipped because dry_run=true (skipped: true). Bounded like sdk_call_trace; see skipped_calls for the total. Method-level side-effect preview, not proof the skipped handler would accept the payload.",
   }),
+  sdk_call_trace_truncated: Type.Optional(
+    Type.Object(
+      {
+        dropped_entries: Type.Integer({
+          description: "Trace/preview entries dropped because the trace cap was exceeded.",
+        }),
+      },
+      {
+        description: "Present when sdk_call_trace or side_effect_preview was truncated (oldest entries dropped).",
+      },
+    ),
+  ),
   dry_run: Type.Boolean(),
 });
 
@@ -229,8 +245,11 @@ async function runSandbox(
     error,
     duration_ms: result.durationMs,
     sdk_calls: result.sdkCalls,
+    skipped_calls: result.skippedCalls,
     sdk_call_trace: result.sdkCallTrace,
     side_effect_preview: result.sideEffectPreview,
+    sdk_call_trace_truncated:
+      result.traceDropped > 0 ? { dropped_entries: result.traceDropped } : undefined,
     dry_run: mode === "full" && "dry_run" in args && args.dry_run === true,
   };
 }

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -139,7 +139,7 @@ export const SdkScriptResultSchema = Type.Object({
   }),
   sdk_call_trace: Type.Array(SdkCallTraceEntrySchema, {
     description:
-      "Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap, the oldest entries are dropped and reported in sdk_call_trace_truncated — the last (usually failing) call is always kept.",
+      "Every dispatched SDK call, in order. Bounded (tail-kept): when the total exceeds the trace cap the oldest entries are dropped and reported in sdk_call_trace_truncated; a single entry larger than the cap is dropped and counted too.",
   }),
   side_effect_preview: Type.Array(SdkCallTraceEntrySchema, {
     description:


### PR DESCRIPTION
## Summary
`sdk_call_trace` was the last model-facing payload with no total-size bound: up to 200 calls × 8 KB of redacted args ≈ **1.6 MB on every run** (and `side_effect_preview` had the same hole). The plan was reviewed by codex first — it validated tail-keeping and flagged that deleting `side_effect_preview` would break `audit.ts` + the public client, so both fields stay.

- **Cap both arrays at `traceBytes` (128 KB)** with a tail-keeping appender: the **oldest** entries are dropped (failures are at the tail) and counted. A single entry larger than the whole budget is dropped + counted (orgPath isn't bounded by the per-entry 8 KB args cap).
- **Split the overlap**: skipped (dry-run) calls now live only in `side_effect_preview`; dispatched calls only in `sdk_call_trace` — no more double-shipping the same entries on the wire.
- **Wire**: new `skipped_calls` (total dry-run skips, independent of preview retention) and `sdk_call_trace_truncated: { dropped_entries }`.
- **audit.ts** derives `side_effect_count` from `skipped_calls` so a truncated preview can't undercount.
- Simpler than the first cut: bounded by sum of entry bytes (array brackets/commas ≈ 2 bytes/entry, negligible at this scale).

Model-facing worst case per run is now bounded: return preview 256 KB + logs 64 KB + trace 128 KB (×2 for MCP text+structuredContent) — never the old 1.6 MB trace.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] Tests: `bun test src/__tests__/unit` → 1045 pass; sandbox integration (vitest) → 71 pass incl. 5 new trace tests; `tool-invocation-audit.test.ts` → 21 pass
- [x] Plan reviewed by codex before implementation (tail-keep + `side_effect_preview` retention findings incorporated)

## Notes
- Behavior change: `sdk_call_trace` now contains **dispatched** calls only; skipped (dry-run) calls are in `side_effect_preview` (verified no consumer relies on skipped-in-trace).
- Prod-visible surface: `run_sdk`/`query_sdk` result shape (`skipped_calls`, `sdk_call_trace_truncated` are additive; no removed fields). Rollout verification owed after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SDK execution traces and side-effect previews now retain the most recent entries within configurable size limits.
  - Results report skipped calls and indicate when trace entries were dropped.
  - Failed calls remain visible in retained traces where possible.
  - Dry-run calls are reflected in side-effect previews without being mixed into dispatched-call traces.

- **Bug Fixes**
  - Audit reporting now accurately counts side effects, including when preview data is truncated.
  - Trace truncation indicators appear only when entries were actually dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->