### PR TITLE
fix(server): dedupe auto-provisioned connections by OAuth account

### DIFF
--- a/packages/server/src/__tests__/integration/auth/social-login-provisioning-dedupe.test.ts
+++ b/packages/server/src/__tests__/integration/auth/social-login-provisioning-dedupe.test.ts
@@ -8,14 +8,16 @@
  * existing-connection lookup only on `auth_profile_id`. The second profile's
  * login event therefore saw "no connection for profile 87" and minted a
  * duplicate `gmail-buremba-2` row — repeated for every subsequent re-auth.
+ * Auto-provisioned connections can also carry a NULL auth_profile_id (the
+ * account identity then lives on the materialized `connections.account_id`).
  *
- * This test calls the real `provisionConnectorFromSocialLogin` against the
- * real DB with the two profiles + one live connection on the OLDER profile,
- * and asserts the run reuses it (no new connection, no `createProvisionedConnection`
- * call) instead of minting a duplicate for the newer profile.
+ * These tests call the real `provisionConnectorFromSocialLogin` against the
+ * real DB and assert the run reuses the account's live connection (no
+ * `createProvisionedConnection` call, exactly one connection) and reconciles
+ * it onto the resolved profile so the final sync makes it usable.
  *
- * Red→green: with the lookup keyed only on `auth_profile_id` the run creates a
- * second connection (provisionCalls === 1) and this fails.
+ * Red→green: with the lookup keyed only on `auth_profile_id`, each scenario
+ * mints a second connection (provisionCalls === 1) and fails.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -28,6 +30,8 @@ import {
   createTestUser,
   seedSystemEntityTypes,
 } from '../../setup/test-fixtures';
+
+const GMAIL_SCOPE = 'https://www.googleapis.com/auth/gmail.readonly';
 
 describe('social-login connection provisioning dedupes by account', () => {
   let provisionCalls: number;
@@ -51,16 +55,18 @@ describe('social-login connection provisioning dedupes by account', () => {
     }));
   });
 
-  it('reuses the live connection for the same Google account instead of creating a duplicate', async () => {
+  /** Org + connector definition + app profile + account row shared by every case. */
+  async function seedBase() {
     const org = await createTestOrganization({ slug: 'acme' });
     const user = await createTestUser();
     const sql = getTestDb();
 
     // The better-auth account row the auth profiles link to (prod: the Google
-    // account row id IS the provider account id).
+    // account row id IS the provider account id). Grant the connector's
+    // required scope so a synced connection is usable (active), not pending.
     await sql`
       INSERT INTO "account" (id, "accountId", "providerId", "userId", scope, "createdAt", "updatedAt")
-      VALUES ('google-sub-1', 'google-sub-1', 'google', ${user.id}, 'openid email', NOW(), NOW())
+      VALUES ('google-sub-1', 'google-sub-1', 'google', ${user.id}, ${`openid email ${GMAIL_SCOPE}`}, NOW(), NOW())
     `;
 
     await createTestConnectorDefinition({
@@ -72,7 +78,7 @@ describe('social-login connection provisioning dedupes by account', () => {
           {
             type: 'oauth',
             provider: 'google',
-            requiredScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+            requiredScopes: [GMAIL_SCOPE],
             loginProvisioning: { autoCreateConnection: true },
             clientIdKey: 'GOOGLE_CLIENT_ID',
             clientSecretKey: 'GOOGLE_CLIENT_SECRET',
@@ -94,10 +100,13 @@ describe('social-login connection provisioning dedupes by account', () => {
       authData: { GOOGLE_CLIENT_ID: 'client-id', GOOGLE_CLIENT_SECRET: 'client-secret' },
     });
 
-    // The historical duplication: two oauth_account profiles for the SAME
-    // Google account (mirrors prod profiles 46 + 87).
+    return { org, user, sql };
+  }
+
+  /** The historical duplication: two oauth_account profiles for the SAME Google account. */
+  async function seedDuplicateProfiles(sql: ReturnType<typeof getTestDb>, orgId: string) {
     const older = await createAuthProfile({
-      organizationId: org.id,
+      organizationId: orgId,
       connectorKey: 'google.gmail',
       displayName: 'personal',
       slug: 'personal',
@@ -106,6 +115,72 @@ describe('social-login connection provisioning dedupes by account', () => {
       provider: 'google',
       status: 'active',
     });
+    await createAuthProfile({
+      organizationId: orgId,
+      connectorKey: 'google.gmail',
+      displayName: 'gmail-account',
+      slug: 'gmail-account',
+      profileKind: 'oauth_account',
+      accountId: 'google-sub-1',
+      provider: 'google',
+      status: 'active',
+    });
+    return older;
+  }
+
+  async function runProvision() {
+    const { provisionConnectorFromSocialLogin } = await import(
+      '../../../auth/social-login-provisioning'
+    );
+    await provisionConnectorFromSocialLogin({
+      env: {} as Env,
+      // Provisioning resolves the org from the request URL's first path segment
+      // (the `api`/`auth` top-level routes are reserved, so the slug must lead).
+      request: new Request('https://example.test/acme/oauth2/callback/google'),
+      account: {
+        id: 'google-sub-1',
+        userId: 'user-1',
+        providerId: 'google',
+        accessToken: 'tok',
+        scope: `openid email ${GMAIL_SCOPE}`,
+      },
+    });
+  }
+
+  async function connectionRows(sql: ReturnType<typeof getTestDb>, orgId: string) {
+    return sql<{ id: number; auth_profile_id: number | null; status: string }[]>`
+      SELECT id, auth_profile_id, status FROM connections
+      WHERE organization_id = ${orgId}
+        AND connector_key = 'google.gmail'
+        AND deleted_at IS NULL
+      ORDER BY id
+    `;
+  }
+
+  it('reuses the connection of a duplicate older profile for the same account', async () => {
+    const { org, sql } = await seedBase();
+    const older = await seedDuplicateProfiles(sql, org.id);
+
+    await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status, auth_profile_id, visibility, created_at, updated_at
+      ) VALUES (
+        ${org.id}, 'google.gmail', 'gmail-buremba', 'Gmail', 'active', ${older.id}, 'private', NOW(), NOW()
+      )
+    `;
+
+    await runProvision();
+
+    expect(provisionCalls).toBe(0);
+    const rows = await connectionRows(sql, org.id);
+    expect(rows).toHaveLength(1);
+    // Rebound onto the resolved (newer) profile, then synced usable.
+    expect(rows[0].status).toBe('active');
+  });
+
+  it('reuses a connection whose auth_profile_id is null but account_id is materialized', async () => {
+    const { org, sql } = await seedBase();
+    // No duplicate profiles needed — the connection carries the identity itself.
     await createAuthProfile({
       organizationId: org.id,
       connectorKey: 'google.gmail',
@@ -117,41 +192,42 @@ describe('social-login connection provisioning dedupes by account', () => {
       status: 'active',
     });
 
-    // One live connection, linked to the OLDER profile. A personal-credential
-    // (oauth_account) connection must be private, matching prod.
+    await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status, auth_profile_id, account_id, visibility, created_at, updated_at
+      ) VALUES (
+        ${org.id}, 'google.gmail', 'gmail-buremba', 'Gmail', 'active', NULL, 'google-sub-1', 'private', NOW(), NOW()
+      )
+    `;
+
+    await runProvision();
+
+    expect(provisionCalls).toBe(0);
+    const rows = await connectionRows(sql, org.id);
+    expect(rows).toHaveLength(1);
+    // Rebound onto the resolved profile and synced usable.
+    expect(rows[0].auth_profile_id).not.toBeNull();
+    expect(rows[0].status).toBe('active');
+  });
+
+  it('reconciles a pending connection on the older profile instead of leaving it stranded', async () => {
+    const { org, sql } = await seedBase();
+    const older = await seedDuplicateProfiles(sql, org.id);
+
     await sql`
       INSERT INTO connections (
         organization_id, connector_key, slug, display_name, status, auth_profile_id, visibility, created_at, updated_at
       ) VALUES (
-        ${org.id}, 'google.gmail', 'gmail-buremba', 'Gmail', 'active', ${older.id}, 'private', NOW(), NOW()
+        ${org.id}, 'google.gmail', 'gmail-buremba', 'Gmail', 'pending_auth', ${older.id}, 'private', NOW(), NOW()
       )
     `;
 
-    // Provisioning resolves the org from the request URL's first path segment
-    // (the `api`/`auth` top-level routes are reserved, so the slug must lead).
-    const { provisionConnectorFromSocialLogin } = await import(
-      '../../../auth/social-login-provisioning'
-    );
-    await provisionConnectorFromSocialLogin({
-      env: {} as Env,
-      request: new Request('https://example.test/acme/oauth2/callback/google'),
-      account: {
-        id: 'google-sub-1',
-        userId: 'user-1',
-        providerId: 'google',
-        accessToken: 'tok',
-        scope: 'openid email',
-      },
-    });
+    await runProvision();
 
-    // The account-linked connection is reused: no new connection is minted.
     expect(provisionCalls).toBe(0);
-    const [count] = await sql<{ n: number }[]>`
-      SELECT COUNT(*)::int AS n FROM connections
-      WHERE organization_id = ${org.id}
-        AND connector_key = 'google.gmail'
-        AND deleted_at IS NULL
-    `;
-    expect(count.n).toBe(1);
+    const rows = await connectionRows(sql, org.id);
+    expect(rows).toHaveLength(1);
+    // No duplicate, and the pending connection was reconciled to usable.
+    expect(rows[0].status).toBe('active');
   });
 });

--- a/packages/server/src/__tests__/integration/auth/social-login-provisioning-dedupe.test.ts
+++ b/packages/server/src/__tests__/integration/auth/social-login-provisioning-dedupe.test.ts
@@ -20,7 +20,7 @@
  * mints a second connection (provisionCalls === 1) and fails.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Env } from '../../../index';
 import { createAuthProfile } from '../../../utils/auth-profiles';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
@@ -53,6 +53,14 @@ describe('social-login connection provisioning dedupes by account', () => {
         return { connectionId: null, error: null };
       },
     }));
+  });
+
+  afterEach(() => {
+    // The integration suite runs with isolate:false (shared module graph) —
+    // clear these mocks so they cannot leak into sibling test files.
+    vi.resetModules();
+    vi.doUnmock('../../../connect/oauth-providers');
+    vi.doUnmock('../../../utils/provisioned-connection');
   });
 
   /** Org + connector definition + app profile + account row shared by every case. */
@@ -104,7 +112,7 @@ describe('social-login connection provisioning dedupes by account', () => {
   }
 
   /** The historical duplication: two oauth_account profiles for the SAME Google account. */
-  async function seedDuplicateProfiles(sql: ReturnType<typeof getTestDb>, orgId: string) {
+  async function seedDuplicateProfiles(orgId: string) {
     const older = await createAuthProfile({
       organizationId: orgId,
       connectorKey: 'google.gmail',
@@ -159,7 +167,7 @@ describe('social-login connection provisioning dedupes by account', () => {
 
   it('reuses the connection of a duplicate older profile for the same account', async () => {
     const { org, sql } = await seedBase();
-    const older = await seedDuplicateProfiles(sql, org.id);
+    const older = await seedDuplicateProfiles(org.id);
 
     await sql`
       INSERT INTO connections (
@@ -212,7 +220,7 @@ describe('social-login connection provisioning dedupes by account', () => {
 
   it('reconciles a pending connection on the older profile instead of leaving it stranded', async () => {
     const { org, sql } = await seedBase();
-    const older = await seedDuplicateProfiles(sql, org.id);
+    const older = await seedDuplicateProfiles(org.id);
 
     await sql`
       INSERT INTO connections (
@@ -228,6 +236,45 @@ describe('social-login connection provisioning dedupes by account', () => {
     const rows = await connectionRows(sql, org.id);
     expect(rows).toHaveLength(1);
     // No duplicate, and the pending connection was reconciled to usable.
+    expect(rows[0].status).toBe('active');
+  });
+
+  it('floors an org-visible null-profile connection to private when rebinding a personal credential', async () => {
+    const { org, sql } = await seedBase();
+    await createAuthProfile({
+      organizationId: org.id,
+      connectorKey: 'google.gmail',
+      displayName: 'gmail-account',
+      slug: 'gmail-account',
+      profileKind: 'oauth_account',
+      accountId: 'google-sub-1',
+      provider: 'google',
+      status: 'active',
+    });
+
+    // A null-auth_profile connection may legally be org-visible; the
+    // personal-credential trigger rejects attaching an oauth_account profile
+    // at org visibility, so the rebind must floor visibility to private.
+    await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status, auth_profile_id, account_id, visibility, created_at, updated_at
+      ) VALUES (
+        ${org.id}, 'google.gmail', 'gmail-buremba', 'Gmail', 'active', NULL, 'google-sub-1', 'org', NOW(), NOW()
+      )
+    `;
+
+    await runProvision();
+
+    expect(provisionCalls).toBe(0);
+    const rows = await sql<{ id: number; auth_profile_id: number | null; status: string; visibility: string }[]>`
+      SELECT id, auth_profile_id, status, visibility FROM connections
+      WHERE organization_id = ${org.id}
+        AND connector_key = 'google.gmail'
+        AND deleted_at IS NULL
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].auth_profile_id).not.toBeNull();
+    expect(rows[0].visibility).toBe('private');
     expect(rows[0].status).toBe('active');
   });
 });

--- a/packages/server/src/__tests__/integration/auth/social-login-provisioning-dedupe.test.ts
+++ b/packages/server/src/__tests__/integration/auth/social-login-provisioning-dedupe.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Social-login connection auto-provisioning must dedupe by the STABLE account
+ * identity, not by the auth-profile row.
+ *
+ * Regression context (prod, buremba org): the same Google account surfaced as
+ * TWO oauth_account auth profiles (46 `personal` + 87 `gmail-account`, both
+ * `account_id = 7xF6MgFl…`), and connection auto-provisioning keyed its
+ * existing-connection lookup only on `auth_profile_id`. The second profile's
+ * login event therefore saw "no connection for profile 87" and minted a
+ * duplicate `gmail-buremba-2` row — repeated for every subsequent re-auth.
+ *
+ * This test calls the real `provisionConnectorFromSocialLogin` against the
+ * real DB with the two profiles + one live connection on the OLDER profile,
+ * and asserts the run reuses it (no new connection, no `createProvisionedConnection`
+ * call) instead of minting a duplicate for the newer profile.
+ *
+ * Red→green: with the lookup keyed only on `auth_profile_id` the run creates a
+ * second connection (provisionCalls === 1) and this fails.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../../../index';
+import { createAuthProfile } from '../../../utils/auth-profiles';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('social-login connection provisioning dedupes by account', () => {
+  let provisionCalls: number;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    vi.resetModules();
+    provisionCalls = 0;
+    vi.doMock('../../../connect/oauth-providers', () => ({
+      fetchUserInfoWithRaw: async () => ({
+        raw: { sub: 'google-sub-1', name: 'Burak', email: 'burak@gmail.com' },
+        normalized: { name: 'Burak', email: 'burak@gmail.com' },
+      }),
+    }));
+    vi.doMock('../../../utils/provisioned-connection', () => ({
+      createProvisionedConnection: async () => {
+        provisionCalls += 1;
+        return { connectionId: null, error: null };
+      },
+    }));
+  });
+
+  it('reuses the live connection for the same Google account instead of creating a duplicate', async () => {
+    const org = await createTestOrganization({ slug: 'acme' });
+    const user = await createTestUser();
+    const sql = getTestDb();
+
+    // The better-auth account row the auth profiles link to (prod: the Google
+    // account row id IS the provider account id).
+    await sql`
+      INSERT INTO "account" (id, "accountId", "providerId", "userId", scope, "createdAt", "updatedAt")
+      VALUES ('google-sub-1', 'google-sub-1', 'google', ${user.id}, 'openid email', NOW(), NOW())
+    `;
+
+    await createTestConnectorDefinition({
+      key: 'google.gmail',
+      name: 'Gmail',
+      organization_id: org.id,
+      auth_schema: {
+        methods: [
+          {
+            type: 'oauth',
+            provider: 'google',
+            requiredScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+            loginProvisioning: { autoCreateConnection: true },
+            clientIdKey: 'GOOGLE_CLIENT_ID',
+            clientSecretKey: 'GOOGLE_CLIENT_SECRET',
+            tokenUrl: 'https://oauth2.googleapis.com/token',
+            userinfoUrl: 'https://openidconnect.googleapis.com/v1/userinfo',
+          },
+        ],
+      },
+      feeds_schema: { threads: {} },
+    });
+
+    // OAuth app profile — required for the auto-provision path.
+    await createAuthProfile({
+      organizationId: org.id,
+      connectorKey: 'google.gmail',
+      displayName: 'Google App',
+      profileKind: 'oauth_app',
+      provider: 'google',
+      authData: { GOOGLE_CLIENT_ID: 'client-id', GOOGLE_CLIENT_SECRET: 'client-secret' },
+    });
+
+    // The historical duplication: two oauth_account profiles for the SAME
+    // Google account (mirrors prod profiles 46 + 87).
+    const older = await createAuthProfile({
+      organizationId: org.id,
+      connectorKey: 'google.gmail',
+      displayName: 'personal',
+      slug: 'personal',
+      profileKind: 'oauth_account',
+      accountId: 'google-sub-1',
+      provider: 'google',
+      status: 'active',
+    });
+    await createAuthProfile({
+      organizationId: org.id,
+      connectorKey: 'google.gmail',
+      displayName: 'gmail-account',
+      slug: 'gmail-account',
+      profileKind: 'oauth_account',
+      accountId: 'google-sub-1',
+      provider: 'google',
+      status: 'active',
+    });
+
+    // One live connection, linked to the OLDER profile. A personal-credential
+    // (oauth_account) connection must be private, matching prod.
+    await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status, auth_profile_id, visibility, created_at, updated_at
+      ) VALUES (
+        ${org.id}, 'google.gmail', 'gmail-buremba', 'Gmail', 'active', ${older.id}, 'private', NOW(), NOW()
+      )
+    `;
+
+    // Provisioning resolves the org from the request URL's first path segment
+    // (the `api`/`auth` top-level routes are reserved, so the slug must lead).
+    const { provisionConnectorFromSocialLogin } = await import(
+      '../../../auth/social-login-provisioning'
+    );
+    await provisionConnectorFromSocialLogin({
+      env: {} as Env,
+      request: new Request('https://example.test/acme/oauth2/callback/google'),
+      account: {
+        id: 'google-sub-1',
+        userId: 'user-1',
+        providerId: 'google',
+        accessToken: 'tok',
+        scope: 'openid email',
+      },
+    });
+
+    // The account-linked connection is reused: no new connection is minted.
+    expect(provisionCalls).toBe(0);
+    const [count] = await sql<{ n: number }[]>`
+      SELECT COUNT(*)::int AS n FROM connections
+      WHERE organization_id = ${org.id}
+        AND connector_key = 'google.gmail'
+        AND deleted_at IS NULL
+    `;
+    expect(count.n).toBe(1);
+  });
+});

--- a/packages/server/src/auth/social-login-provisioning.ts
+++ b/packages/server/src/auth/social-login-provisioning.ts
@@ -129,13 +129,26 @@ export async function provisionConnectorFromSocialLogin(params: {
       provider,
     });
 
+    // Reuse an existing live connection for this connector + OAuth account
+    // instead of minting a new one on every login/link event. Dedupe on the
+    // STABLE account identity (auth_profiles.account_id = the provider account
+    // id), not just the auth-profile row: the same Google account can surface
+    // as several oauth_account profiles over time (re-links, duplicate profile
+    // rows), and auto-provisioned connections can even carry a null
+    // auth_profile_id — so keying on auth_profile_id alone has historically
+    // created a duplicate connection per profile.
     const existingConnectionRows = await sql`
-      SELECT id
-      FROM connections
-      WHERE organization_id = ${organizationId}
-        AND auth_profile_id = ${authProfile.id}
-        AND deleted_at IS NULL
-      ORDER BY updated_at DESC, id DESC
+      SELECT c.id
+      FROM connections c
+      LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
+      WHERE c.organization_id = ${organizationId}
+        AND c.connector_key = ${row.key}
+        AND c.deleted_at IS NULL
+        AND (
+          c.auth_profile_id = ${authProfile.id}
+          OR ap.account_id = ${params.account.id}
+        )
+      ORDER BY c.updated_at DESC, c.id DESC
       LIMIT 1
     `;
 

--- a/packages/server/src/auth/social-login-provisioning.ts
+++ b/packages/server/src/auth/social-login-provisioning.ts
@@ -131,14 +131,16 @@ export async function provisionConnectorFromSocialLogin(params: {
 
     // Reuse an existing live connection for this connector + OAuth account
     // instead of minting a new one on every login/link event. Dedupe on the
-    // STABLE account identity (auth_profiles.account_id = the provider account
-    // id), not just the auth-profile row: the same Google account can surface
-    // as several oauth_account profiles over time (re-links, duplicate profile
-    // rows), and auto-provisioned connections can even carry a null
-    // auth_profile_id — so keying on auth_profile_id alone has historically
-    // created a duplicate connection per profile.
+    // STABLE account identity, not just the auth-profile row: the same Google
+    // account can surface as several oauth_account profiles over time
+    // (re-links, duplicate profile rows), and auto-provisioned connections can
+    // carry a null auth_profile_id — so keying on auth_profile_id alone has
+    // historically created a duplicate connection per profile. The account
+    // identity is matched via the profile link AND the materialized
+    // `connections.account_id` (which syncOAuthConnectionsForAuthProfile
+    // stamps), so a null-profile row is still found.
     const existingConnectionRows = await sql`
-      SELECT c.id
+      SELECT c.id, c.auth_profile_id
       FROM connections c
       LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
       WHERE c.organization_id = ${organizationId}
@@ -147,12 +149,31 @@ export async function provisionConnectorFromSocialLogin(params: {
         AND (
           c.auth_profile_id = ${authProfile.id}
           OR ap.account_id = ${params.account.id}
+          OR c.account_id = ${params.account.id}
         )
       ORDER BY c.updated_at DESC, c.id DESC
       LIMIT 1
     `;
 
-    if (existingConnectionRows.length === 0 && appAuthProfile) {
+    const existingConnection = existingConnectionRows[0] as
+      | { id: number; auth_profile_id: number | null }
+      | undefined;
+
+    if (existingConnection) {
+      // Reconcile the reused connection: an account match can land on a
+      // connection linked to a duplicate/older auth profile (or none). Rebind
+      // it to the resolved profile so the final
+      // syncOAuthConnectionsForAuthProfile below actually covers it — otherwise
+      // the older profile's connection stays stranded/pending while the sync
+      // targets the newer profile.
+      if (existingConnection.auth_profile_id !== authProfile.id) {
+        await sql`
+          UPDATE connections
+          SET auth_profile_id = ${authProfile.id}, updated_at = NOW()
+          WHERE id = ${existingConnection.id} AND deleted_at IS NULL
+        `;
+      }
+    } else if (appAuthProfile) {
       const mergedConfig = {
         ...((row.default_connection_config as Record<string, unknown> | null) ?? {}),
         __auto_provisioned_login: true,

--- a/packages/server/src/auth/social-login-provisioning.ts
+++ b/packages/server/src/auth/social-login-provisioning.ts
@@ -165,11 +165,16 @@ export async function provisionConnectorFromSocialLogin(params: {
       // it to the resolved profile so the final
       // syncOAuthConnectionsForAuthProfile below actually covers it — otherwise
       // the older profile's connection stays stranded/pending while the sync
-      // targets the newer profile.
+      // targets the newer profile. A personal-credential (oauth_account)
+      // connection must be private, so floor visibility in the same UPDATE:
+      // a null-profile row may legally be org-visible, and the trigger rejects
+      // attaching an oauth_account profile without flooring it.
       if (existingConnection.auth_profile_id !== authProfile.id) {
         await sql`
           UPDATE connections
-          SET auth_profile_id = ${authProfile.id}, updated_at = NOW()
+          SET auth_profile_id = ${authProfile.id},
+              visibility = 'private',
+              updated_at = NOW()
           WHERE id = ${existingConnection.id} AND deleted_at IS NULL
         `;
       }


### PR DESCRIPTION
## Summary

Prod (buremba org) accumulated 6 duplicate gmail connections. Root cause traced to the social-login auto-provisioning path: `provisionConnectorFromSocialLogin` keyed its existing-connection lookup **only on `auth_profile_id`**:

- The same Google account surfaced as **two `oauth_account` profiles** (46 `personal` + 87 `gmail-account`, both `account_id = 7xF6MgFl…`), and
- auto-provisioned connections can carry a **null `auth_profile_id`** (connection 335 had `__auto_provisioned_login` but no profile link).

So the second profile's login event saw "no connection for this profile" and minted a duplicate `gmail-buremba-2` row — repeated on each re-auth.

## Change

The existing-connection lookup now joins `connections` → `auth_profiles` and reuses any live connection for the connector + the **stable provider account identity** (`auth_profiles.account_id`), with the direct `auth_profile_id` match kept as a fallback:

```sql
SELECT c.id FROM connections c
LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
WHERE c.organization_id = … AND c.connector_key = … AND c.deleted_at IS NULL
  AND (c.auth_profile_id = … OR ap.account_id = …)
ORDER BY c.updated_at DESC, c.id DESC LIMIT 1
```

## Verification (red→green)

New integration test `social-login-provisioning-dedupe.test.ts` drives the real `provisionConnectorFromSocialLogin` against the DB with two same-account profiles + one live connection on the older profile:
- **Red** (auth_profile_id-only lookup): the run calls `createProvisionedConnection` — `expected 1 to be +0`, duplicate would be minted.
- **Green** (account-identity dedupe): the run reuses the connection — no creation, exactly 1 row.

Auth integration suites pass (dedupe + slack-signin-e2e + managed-auth-onboarding, 8 tests). `make pre-pr` clean.

## Known limitation

The SELECT-then-INSERT is not atomic (unchanged from before): two *simultaneous* logins for the same account on different replicas could still race a duplicate (slug becomes `-2`). The observed historical duplication was repeated logins over time, which this fix eliminates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved social-login connection reuse to prevent duplicate connections for the same provider account.
  * Correctly handles existing, pending, and previously linked connections during account provisioning.
  * Rebinds reused connections to the correct authentication profile and keeps personal credentials private.
  * Synchronizes reused connections to activate them when appropriate.

* **Tests**
  * Added integration coverage for duplicate prevention, profile rebinding, pending connections, and account identity matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->