### PR TITLE
chore(examples): declare org relationship types in personal-agent config

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -974,6 +974,30 @@ const mentions = defineRelationshipType({
   description: "Auto-discovered content reference",
 });
 
+// Graph edges created in the org (and populated with live relationships) that
+// the config must declare — otherwise prune flags them "removed from config"
+// and the apply aborts: the server refuses to delete a relationship type that
+// still has relationship rows.
+const connectedWith = defineRelationshipType({
+  key: "connected_with",
+  name: "Connected With",
+  description:
+    "Social connection observed on a platform (LinkedIn connection, mutual follow). Symmetric.",
+});
+
+const founderOf = defineRelationshipType({
+  key: "founder_of",
+  name: "Founder Of",
+  description: "A person founded or co-founded a company.",
+});
+
+const sameAs = defineRelationshipType({
+  key: "same_as",
+  name: "Same As",
+  description:
+    "Maps a private person profile to its canonical public identity. The mapping and private profile remain visible only to this workspace.",
+});
+
 const voiceProfile = defineEntityType({
   key: "voice-profile",
   name: "Voice profile",
@@ -1246,7 +1270,14 @@ export default defineConfig({
     voiceProfile,
     socialSignal,
   ],
-  relationships: [worksAt, memberOf, mentions],
+  relationships: [
+    worksAt,
+    memberOf,
+    mentions,
+    connectedWith,
+    founderOf,
+    sameAs,
+  ],
   behaviors: [
     hourlyTaskCollaborator,
     duplicateEntityResolution,


### PR DESCRIPTION
## Summary

Live apply to the buremba org was blocked: `prune: true` flagged three relationship types as "removed from config", but the server **refuses to delete a relationship type that still has live rows**, so the apply aborted.

The types carry real graph data created out-of-band:

| type | live relationships |
|---|---|
| `connected_with` | 2,616 |
| `founder_of` | 529 |
| `same_as` | 9 |

## Change

Declare `connected_with`, `founder_of`, `same_as` in `examples/personal-agent/lobu.config.ts` (matching the org's key/name/description; no rules, like the existing `member_of`/`mentions`). Prune keeps them, the graph is preserved, and future applies proceed.

Verified live: with the declarations, the apply plan dropped from 4 deletes (3 blocked) to 1 (`topic`, 0 live entities), and the apply completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for defining connections, founder relationships, and equivalent identities in personal agent configurations.
  * Registered these relationship types alongside existing configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->