### PR TITLE
fix(cli): scope the apply view-template fetch to org-owned types

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 import { ApiError } from "../../../memory/_lib/errors.js";
 import {
   executePlan,
+  fetchRemoteSnapshot,
   locallyDeclaredConnectorKeys,
   pushProviderApiKeys,
   readBoundedBody,
@@ -337,6 +338,54 @@ describe("executePlan — entity-type schema fidelity", () => {
 
     expect(upsertEntityType).toHaveBeenCalledTimes(1);
     expect(upsertEntityType.mock.calls[0]?.[1]).toEqual(schemaExtras);
+  });
+});
+
+describe("fetchRemoteSnapshot — view-template fetch is org-scoped", () => {
+  test("does not fetch a template for a foreign public type whose slug is also config-declared", async () => {
+    const templateCalls: string[] = [];
+    const client = {
+      listAgents: async () => [],
+      listEntityTypes: async () => [
+        // Foreign public type (owned by another org) — same slug as a config type.
+        { slug: "company", organization_id: "org-market" },
+        // Org-owned type with a declared template.
+        { slug: "task", organization_id: "org-acme" },
+      ],
+      listRelationshipTypes: async () => [],
+      listBehaviors: async () => [],
+      listConnectors: async () => [],
+      listAuthProfiles: async () => [],
+      listConnections: async () => [],
+      listInferenceProviders: async () => [],
+      getEntityTypeViewTemplate: async (slug: string) => {
+        templateCalls.push(slug);
+        return { root: { type: "box" } };
+      },
+    } as unknown as ApplyClient;
+
+    const state: DesiredState = {
+      agents: [],
+      prune: true,
+      memorySchema: {
+        entityTypes: [
+          { slug: "company", viewTemplate: { root: { type: "box" } } },
+          { slug: "task", viewTemplate: { root: { type: "box" } } },
+        ],
+        relationshipTypes: [],
+      },
+      watchers: [],
+      connectors: { definitions: [], authProfiles: [], connections: [] },
+      providers: [],
+      requiredSecrets: [],
+    };
+
+    const remote = await fetchRemoteSnapshot(client, state, undefined, true, "org-acme");
+    expect(templateCalls).toEqual(["task"]);
+    expect(remote.entityTypes.find((e) => e.slug === "task")?.viewTemplate).toBeDefined();
+    // The foreign type's slug is still surfaced for visibility, but its template
+    // was never fetched (the org-local copy is absent/deleted and would 404).
+    expect(remote.entityTypes.find((e) => e.slug === "company")?.viewTemplate).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -380,12 +380,22 @@ describe("fetchRemoteSnapshot — view-template fetch is org-scoped", () => {
       requiredSecrets: [],
     };
 
-    const remote = await fetchRemoteSnapshot(client, state, undefined, true, "org-acme");
+    const remote = await fetchRemoteSnapshot(
+      client,
+      state,
+      undefined,
+      true,
+      "org-acme"
+    );
     expect(templateCalls).toEqual(["task"]);
-    expect(remote.entityTypes.find((e) => e.slug === "task")?.viewTemplate).toBeDefined();
+    expect(
+      remote.entityTypes.find((e) => e.slug === "task")?.viewTemplate
+    ).toBeDefined();
     // The foreign type's slug is still surfaced for visibility, but its template
     // was never fetched (the org-local copy is absent/deleted and would 404).
-    expect(remote.entityTypes.find((e) => e.slug === "company")?.viewTemplate).toBeUndefined();
+    expect(
+      remote.entityTypes.find((e) => e.slug === "company")?.viewTemplate
+    ).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -312,7 +312,8 @@ export async function fetchRemoteSnapshot(
   client: ApplyClient,
   state: DesiredState,
   only?: "agents" | "memory",
-  prune = false
+  prune = false,
+  orgId?: string
 ): Promise<RemoteSnapshot> {
   const agents: RemoteAgent[] =
     only === "memory" ? [] : await client.listAgents();
@@ -344,6 +345,17 @@ export async function fetchRemoteSnapshot(
     for (const remote of entityTypes) {
       const desired = desiredBySlug.get(remote.slug);
       if (!desired) continue;
+      // The list also surfaces public types owned by OTHER orgs. Fetch a
+      // template only for types this org owns: the fetch resolves by slug in
+      // THIS org, so a foreign public type whose local slug is absent (or
+      // soft-deleted) would 404 and abort the whole apply.
+      if (
+        orgId !== undefined &&
+        remote.organization_id !== undefined &&
+        remote.organization_id !== orgId
+      ) {
+        continue;
+      }
       if (desired.viewTemplate === undefined && !prune) continue;
       const tpl = await client.getEntityTypeViewTemplate(remote.slug);
       if (tpl) remote.viewTemplate = tpl;
@@ -1455,7 +1467,7 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   // this (current/stale) catalog — "create" when the key isn't installed,
   // "update" when it is. Connector defs are NOT installed here; that happens in
   // `executePlan`, AFTER plan confirmation.
-  const remote = await fetchRemoteSnapshot(client, state, opts.only, prune);
+  const remote = await fetchRemoteSnapshot(client, state, opts.only, prune, resolvedOrg?.id);
   resolveBehaviorConnectionRefs(
     state.watchers,
     new Map(

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -1467,7 +1467,13 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   // this (current/stale) catalog — "create" when the key isn't installed,
   // "update" when it is. Connector defs are NOT installed here; that happens in
   // `executePlan`, AFTER plan confirmation.
-  const remote = await fetchRemoteSnapshot(client, state, opts.only, prune, resolvedOrg?.id);
+  const remote = await fetchRemoteSnapshot(
+    client,
+    state,
+    opts.only,
+    prune,
+    resolvedOrg?.id
+  );
   resolveBehaviorConnectionRefs(
     state.watchers,
     new Map(


### PR DESCRIPTION
## Summary

Found live while applying the personal-agent config to buremba: the apply aborted with `Entity type 'company' not found`.

Root cause: `fetchRemoteSnapshot` fetches an entity type's view template for every remote type whose slug the config declares (under prune, for ALL config types). The entity-type list also surfaces **public types owned by other orgs** — the `market` org has a live public `company`. The template GET resolves by slug in THIS org, so buremba's soft-deleted `company` made the fetch 404 and abort the whole apply.

## Change

The snapshot template fetch now skips remote types whose `organization_id` differs from the target org — mirroring the diff's `ownsDefinition` filter (which already ignores foreign types for drift/prune).

## Verification

- Regression test: a foreign public `company` (market org) sharing a config slug no longer triggers a template fetch; the org-owned type's template still loads.
- Live: after the fix, the apply against buremba completed (20 create / 36 update / 1 delete).
- `make pre-pr` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented foreign public entity types with matching slugs from being treated as locally owned resources.
  * Ensured view templates are fetched only for entity types owned by the current organization.
  * Preserved visibility of compatible foreign public types during apply operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->