### PR TITLE
feat(server): record workspace-identity audit events for org/member/invitation lifecycle

### DIFF
--- a/packages/server/src/__tests__/integration/auth/personal-org-workspace-audit.test.ts
+++ b/packages/server/src/__tests__/integration/auth/personal-org-workspace-audit.test.ts
@@ -35,6 +35,21 @@ async function readWorkspaceEvents(organizationId: string) {
   `;
 }
 
+/** Audit writers are fire-and-forget; poll briefly for rows to land. */
+async function waitForEvents(
+	organizationId: string,
+	expectedCount: number,
+): Promise<unknown[]> {
+	const deadline = Date.now() + 2000;
+	let rows: unknown[] = [];
+	while (Date.now() < deadline) {
+		rows = await readWorkspaceEvents(organizationId);
+		if (rows.length >= expectedCount) return rows;
+		await new Promise((r) => setTimeout(r, 50));
+	}
+	return rows;
+}
+
 describe("personal org workspace audit events", () => {
 	beforeEach(async () => {
 		await cleanupTestDatabase();
@@ -51,7 +66,7 @@ describe("personal org workspace audit events", () => {
 		});
 		expect(res.created).toBe(true);
 
-		const rows = await readWorkspaceEvents(res.organizationId);
+		const rows = await waitForEvents(res.organizationId, 2);
 		expect(rows).toHaveLength(2);
 
 		const all = rows as unknown as Array<{
@@ -108,7 +123,7 @@ describe("personal org workspace audit events", () => {
 		});
 		expect(second.created).toBe(false);
 
-		const rows = await readWorkspaceEvents(first.organizationId);
+		const rows = await waitForEvents(first.organizationId, 2);
 		expect(rows).toHaveLength(2);
 	});
 });

--- a/packages/server/src/__tests__/integration/auth/personal-org-workspace-audit.test.ts
+++ b/packages/server/src/__tests__/integration/auth/personal-org-workspace-audit.test.ts
@@ -72,7 +72,12 @@ describe("personal org workspace audit events", () => {
 		const all = rows as unknown as Array<{
 			title: string;
 			semantic_type: string;
-			metadata: { resource_kind: string; op: string; category: string };
+			metadata: {
+				resource_kind: string;
+				op: string;
+				category: string;
+				_lobu_workspace_audit?: boolean;
+			};
 			payload_data: { state: Record<string, unknown> | null };
 			created_by: string;
 		}>;
@@ -85,6 +90,10 @@ describe("personal org workspace audit events", () => {
 
 		expect(orgRow!.semantic_type).toBe("change");
 		expect(orgRow!.metadata.category).toBe("workspace");
+		// Server-owned discriminator — exclusion predicates gate on this, not
+		// category alone. Emission must stamp it or visibility tests pass while
+		// real rows stay readable to ordinary members.
+		expect(orgRow!.metadata._lobu_workspace_audit).toBe(true);
 		expect(orgRow!.metadata.resource_kind).toBe("organization");
 		expect(orgRow!.metadata.op).toBe("created");
 		expect(orgRow!.title).toContain("Organization");
@@ -97,6 +106,7 @@ describe("personal org workspace audit events", () => {
 		expect(orgRow!.created_by).toBe(id);
 
 		expect(memberRow!.metadata.resource_kind).toBe("member");
+		expect(memberRow!.metadata._lobu_workspace_audit).toBe(true);
 		expect(memberRow!.metadata.op).toBe("created");
 		expect(memberRow!.title).toContain("joined as owner");
 		expect(

--- a/packages/server/src/__tests__/integration/auth/personal-org-workspace-audit.test.ts
+++ b/packages/server/src/__tests__/integration/auth/personal-org-workspace-audit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests for the workspace-identity audit trail emitted by
+ * personal-org provisioning: an `organization` created event and an `owner`
+ * member created event, both `semantic_type='change'` /
+ * `metadata.category='workspace'` with a redacted post-change state snapshot.
+ * These rows are what make "org created" / "member joined" visible in the
+ * All activity feed (the Deployments feed filters them out by category).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { generateSecureToken } from "../../../auth/oauth/utils";
+import { ensurePersonalOrganization } from "../../../auth/personal-org-provisioning";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+
+async function seedUser(): Promise<{ id: string; email: string }> {
+	const id = `user_${generateSecureToken(6)}`;
+	const email = `${id}@test.local`;
+	const sql = getTestDb();
+	await sql`
+    INSERT INTO "user" (id, name, email, username, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${id}, 'Audit Me', ${email}, null, true, NOW(), NOW())
+  `;
+	return { id, email };
+}
+
+async function readWorkspaceEvents(organizationId: string) {
+	const sql = getTestDb();
+	return sql`
+    SELECT title, semantic_type, metadata, payload_data, created_by
+    FROM events
+    WHERE organization_id = ${organizationId}
+      AND semantic_type = 'change'
+      AND metadata->>'category' = 'workspace'
+    ORDER BY id ASC
+  `;
+}
+
+describe("personal org workspace audit events", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("writes organization-created + owner-member-created audit events", async () => {
+		const { id, email } = await seedUser();
+
+		const res = await ensurePersonalOrganization({
+			id,
+			email,
+			name: "Audit Me",
+			username: null,
+		});
+		expect(res.created).toBe(true);
+
+		const rows = await readWorkspaceEvents(res.organizationId);
+		expect(rows).toHaveLength(2);
+
+		const all = rows as unknown as Array<{
+			title: string;
+			semantic_type: string;
+			metadata: { resource_kind: string; op: string; category: string };
+			payload_data: { state: Record<string, unknown> | null };
+			created_by: string;
+		}>;
+		// Fire-and-forget writers, so no insertion-order guarantee — resolve
+		// rows by kind instead of position.
+		const orgRow = all.find((r) => r.metadata.resource_kind === "organization");
+		const memberRow = all.find((r) => r.metadata.resource_kind === "member");
+		expect(orgRow).toBeDefined();
+		expect(memberRow).toBeDefined();
+
+		expect(orgRow!.semantic_type).toBe("change");
+		expect(orgRow!.metadata.category).toBe("workspace");
+		expect(orgRow!.metadata.resource_kind).toBe("organization");
+		expect(orgRow!.metadata.op).toBe("created");
+		expect(orgRow!.title).toContain("Organization");
+		expect(orgRow!.payload_data.state).toEqual({
+			id: res.organizationId,
+			name: "Audit Me",
+			slug: res.slug,
+			visibility: "private",
+		});
+		expect(orgRow!.created_by).toBe(id);
+
+		expect(memberRow!.metadata.resource_kind).toBe("member");
+		expect(memberRow!.metadata.op).toBe("created");
+		expect(memberRow!.title).toContain("joined as owner");
+		expect(
+			(memberRow!.payload_data.state as Record<string, unknown>).role,
+		).toBe("owner");
+		expect(memberRow!.created_by).toBe(id);
+	});
+
+	it("does not re-emit audit events for an existing personal org", async () => {
+		const { id, email } = await seedUser();
+		const first = await ensurePersonalOrganization({
+			id,
+			email,
+			name: "Audit Me",
+			username: null,
+		});
+		expect(first.created).toBe(true);
+
+		const second = await ensurePersonalOrganization({
+			id,
+			email,
+			name: "Audit Me",
+			username: null,
+		});
+		expect(second.created).toBe(false);
+
+		const rows = await readWorkspaceEvents(first.organizationId);
+		expect(rows).toHaveLength(2);
+	});
+});

--- a/packages/server/src/__tests__/integration/events/workspace-audit-insert-idempotency.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-insert-idempotency.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Connectionless audit inserts retry with the same origin_id. Without a unique
+ * (connection_id, origin_id) constraint, a bare re-insert after an ambiguous
+ * success would append a duplicate. insertConnectionlessAuditEvent reconciles
+ * first — this test pins that contract.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { insertConnectionlessAuditEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { createTestOrganization } from '../../setup/test-fixtures';
+
+describe('insertConnectionlessAuditEvent idempotency', () => {
+  let organizationId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Audit insert idempotency' });
+    organizationId = org.id;
+  });
+
+  it('a second call with the same origin_id reuses the first row', async () => {
+    const originId = `workspace_member_created_test_${Date.now()}_idem`;
+    const params = {
+      entityIds: [] as number[],
+      organizationId,
+      originId,
+      title: 'Member "a member" added',
+      semanticType: 'change',
+      originType: 'workspace_member_created',
+      payloadType: 'empty' as const,
+      payloadData: { state: { id: 'member_1', role: 'member' } },
+      metadata: {
+        category: 'workspace',
+        _lobu_workspace_audit: true,
+        resource_kind: 'member',
+        resource_id: 'member_1',
+        op: 'created',
+      },
+    };
+
+    const first = await insertConnectionlessAuditEvent(params);
+    const second = await insertConnectionlessAuditEvent(params);
+
+    expect(second.change).toBe('unchanged');
+    expect(second.id).toBe(first.id);
+
+    const sql = getDb();
+    const rows = await sql`
+      SELECT id FROM events
+      WHERE organization_id = ${organizationId}
+        AND origin_id = ${originId}
+        AND connection_id IS NULL
+    `;
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/server/src/__tests__/integration/events/workspace-audit-insert-idempotency.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-insert-idempotency.test.ts
@@ -50,8 +50,44 @@ describe('insertConnectionlessAuditEvent idempotency', () => {
     const rows = await sql`
       SELECT id FROM events
       WHERE organization_id = ${organizationId}
-        AND origin_id = ${originId}
-        AND connection_id IS NULL
+        AND metadata->>'_lobu_idempotency_key' = ${`audit:${originId}`}
+    `;
+    expect(rows).toHaveLength(1);
+  });
+
+  it('concurrent same-origin inserts resolve to a single row', async () => {
+    const originId = `workspace_member_created_test_${Date.now()}_race`;
+    const params = {
+      entityIds: [] as number[],
+      organizationId,
+      originId,
+      title: 'Member "racer" added',
+      semanticType: 'change',
+      originType: 'workspace_member_created',
+      payloadType: 'empty' as const,
+      payloadData: { state: { id: 'member_race', role: 'member' } },
+      metadata: {
+        category: 'workspace',
+        _lobu_workspace_audit: true,
+        resource_kind: 'member',
+        resource_id: 'member_race',
+        op: 'created',
+      },
+    };
+
+    const results = await Promise.all([
+      insertConnectionlessAuditEvent(params),
+      insertConnectionlessAuditEvent(params),
+      insertConnectionlessAuditEvent(params),
+    ]);
+    const ids = new Set(results.map((r) => r.id));
+    expect(ids.size).toBe(1);
+
+    const sql = getDb();
+    const rows = await sql`
+      SELECT id FROM events
+      WHERE organization_id = ${organizationId}
+        AND metadata->>'_lobu_idempotency_key' = ${`audit:${originId}`}
     `;
     expect(rows).toHaveLength(1);
   });

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -86,6 +86,20 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     } as ToolContext;
   }
 
+  function memberWriteCtx(): ToolContext {
+    // An ordinary member with write access (save_memory requires it).
+    return {
+      organizationId: org.id,
+      userId: alice.id,
+      memberRole: 'member',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read', 'mcp:write'],
+    } as ToolContext;
+  }
+
   async function listIds(ctx: ToolContext): Promise<Set<number>> {
     const result = await getContent(
       { entity_id: entity.id, limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
@@ -291,6 +305,33 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     expect(anon.has(spoofedCategoryEventId)).toBe(true);
   });
 
+  it('save_memory strips the server-owned _lobu_workspace_audit key from caller metadata', async () => {
+    const { saveContent } = await import('../../../tools/save_content');
+    const { getDb } = await import('../../../db/client');
+    const sql = getDb();
+
+    // A member tries to forge the audit discriminator via save_memory metadata.
+    await saveContent(
+      {
+        entity_ids: [entity.id],
+        content: 'forged-audit-attempt',
+        semantic_type: 'note',
+        metadata: { _lobu_workspace_audit: true, category: 'workspace' },
+      } as never,
+      {} as never,
+      memberWriteCtx()
+    );
+
+    const row = (await sql`
+      SELECT metadata FROM events
+      WHERE organization_id = ${org.id}
+        AND payload_text = 'forged-audit-attempt'
+      ORDER BY id DESC LIMIT 1
+    `) as unknown as Array<{ metadata: Record<string, unknown> }>;
+    expect(row).toHaveLength(1);
+    expect(row[0].metadata._lobu_workspace_audit).toBeUndefined();
+  });
+
   it('anonymous org-wide read excludes unbound workspace audit rows', async () => {
     const ids = await listOrgWideIds(unauthedCtx());
     expect(ids.has(orgWideWorkspaceAuditEventId)).toBe(false);
@@ -314,6 +355,19 @@ describe('workspace-identity audit events > public-read exclusion', () => {
         signedInOutsiderCtx()
       )
     ).rejects.toThrow(/workspace membership/);
+  });
+
+  it('ordinary member behavior_id read is NOT denied (membership gate only)', async () => {
+    // The membership gate must deny only NON-members. An ordinary member gets
+    // past the gate and fails on the (nonexistent) behavior lookup instead of
+    // a 403 — proving the gate no longer misapplies to members.
+    await expect(
+      getContent(
+        { behavior_id: 999999, limit: 100 } as never,
+        {} as never,
+        memberCtx()
+      )
+    ).rejects.toThrow(/Behavior/);
   });
 
   it('classification stats exclude workspace audit rows for non-members', async () => {

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -467,6 +467,39 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     expect((await bootstrapRecent(authedCtx())).has(orgWideWorkspaceAuditEventId)).toBe(true);
   });
 
+  it('owner of another org does not see this org workspace audit via bootstrap', async () => {
+    // memberRole is scoped to ctx.organizationId. An owner of org A resolving
+    // public org B must not inherit owner visibility on B's audit rows.
+    const otherOrg = await createTestOrganization({
+      visibility: 'private',
+      name: 'Other owner org',
+    });
+    await addUserToOrganization(alice.id, otherOrg.id, 'owner');
+
+    const { resolvePath } = await import('../../../tools/resolve_path');
+    const slug = (org as unknown as { slug: string }).slug;
+    const result = await resolvePath(
+      { path: `/${slug}`, include_bootstrap: true } as never,
+      {} as never,
+      {
+        organizationId: otherOrg.id,
+        userId: alice.id,
+        memberRole: 'owner',
+        isAuthenticated: true,
+        tokenType: 'oauth',
+        scopedToOrg: false,
+        allowCrossOrg: true,
+        scopes: ['mcp:read'],
+      } as ToolContext
+    );
+    const recentIds = new Set(
+      ((result.bootstrap as { recent_content?: Array<{ id: number }> })
+        ?.recent_content ?? []).map((c) => c.id)
+    );
+    expect(recentIds.has(orgWideWorkspaceAuditEventId)).toBe(false);
+    expect(recentIds.has(normalEventId)).toBe(true);
+  });
+
   it('anonymous content_ids exact-ID read excludes workspace audit but keeps ordinary events', async () => {
     const ids = await readExactIds(unauthedCtx(), [
       workspaceAuditEventId,

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -110,6 +110,25 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     return new Set((result.content ?? []).map((c) => c.id));
   }
 
+  async function readClassified(ctx: ToolContext, opts: { orgWide?: boolean } = {}): Promise<number> {
+    const result = await getContent(
+      {
+        ...(opts.orgWide ? {} : { entity_id: entity.id }),
+        limit: 100,
+        sort_by: 'date',
+        sort_order: 'desc',
+        include_classification: 'summary',
+      } as never,
+      {} as never,
+      ctx
+    );
+    const stats = result.classification_stats as Record<
+      string,
+      Record<string, number> | undefined
+    > | null;
+    return stats?.['audit-severity']?.['sensitive'] ?? 0;
+  }
+
   beforeAll(async () => {
     await initWorkspaceProvider();
     await cleanupTestDatabase();
@@ -168,6 +187,26 @@ describe('workspace-identity audit events > public-read exclusion', () => {
         },
       })
     ).id;
+
+    // Classify the workspace audit row so classification STATS (which are
+    // aggregated across all matching content) could leak its presence to
+    // non-members even when the row itself is filtered out.
+    const { getDb } = await import('../../../db/client');
+    const sql = getDb();
+    const facet = await sql`
+      INSERT INTO classify_facet (organization_id, slug, name, attribute_key, status,
+                                  created_by, entity_ids, attribute_values, min_similarity)
+      VALUES (${org.id}, 'audit-severity', 'Audit severity', 'severity', 'active', ${alice.id},
+              ARRAY[]::bigint[], ${sql.json({ sensitive: { description: 'S', examples: [] } })}, 0.7)
+      RETURNING id
+    `;
+    const facetId = Number(facet[0].id);
+    await sql`
+      INSERT INTO event_classifications (event_id, classifier_id, watcher_id, window_id,
+                                         "values", confidences, source, is_manual)
+      VALUES (${orgWideWorkspaceAuditEventId}, ${facetId}, NULL, NULL, ${'{sensitive}'}::text[],
+              ${sql.json({ sensitive: 1 })}, 'user', true)
+    `;
   });
 
   it('authenticated member sees the workspace audit event in the feed', async () => {
@@ -211,6 +250,17 @@ describe('workspace-identity audit events > public-read exclusion', () => {
         signedInOutsiderCtx()
       )
     ).rejects.toThrow(/workspace membership/);
+  });
+
+  it('classification stats exclude workspace audit rows for non-members', async () => {
+    // Anonymous and signed-in non-members must not see the 'sensitive' count
+    // that derives from the classified workspace-audit row (org-wide read).
+    expect(await readClassified(unauthedCtx(), { orgWide: true })).toBe(0);
+    expect(await readClassified(signedInOutsiderCtx(), { orgWide: true })).toBe(0);
+  });
+
+  it('classification stats include workspace audit rows for members', async () => {
+    expect(await readClassified(authedCtx(), { orgWide: true })).toBe(1);
   });
 
   it('anonymous content_ids exact-ID read excludes workspace audit but keeps ordinary events', async () => {

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -8,6 +8,7 @@
 
 import { beforeAll, describe, expect, it } from 'vitest';
 import { getContent } from '../../../tools/get_content';
+import { search } from '../../../tools/search';
 import type { ToolContext } from '../../../tools/registry';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase } from '../../setup/test-db';
@@ -23,9 +24,11 @@ import {
 describe('workspace-identity audit events > public-read exclusion', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
   let alice: Awaited<ReturnType<typeof createTestUser>>;
+  let outsider: Awaited<ReturnType<typeof createTestUser>>;
   let entity: Awaited<ReturnType<typeof createTestEntity>>;
   let workspaceAuditEventId: number;
   let normalEventId: number;
+  let orgWideWorkspaceAuditEventId: number;
 
   function authedCtx(): ToolContext {
     return {
@@ -52,9 +55,33 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     } as ToolContext;
   }
 
+  function signedInOutsiderCtx(): ToolContext {
+    // A signed-in user with NO membership in this public workspace — they can
+    // read public content, but must not see workspace-identity audit rows.
+    return {
+      organizationId: org.id,
+      userId: outsider.id,
+      memberRole: null,
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: true,
+      allowCrossOrg: false,
+      scopes: ['mcp:read'],
+    } as ToolContext;
+  }
+
   async function listIds(ctx: ToolContext): Promise<Set<number>> {
     const result = await getContent(
       { entity_id: entity.id, limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
+      {} as never,
+      ctx
+    );
+    return new Set(result.content.map((c) => c.id));
+  }
+
+  async function listOrgWideIds(ctx: ToolContext): Promise<Set<number>> {
+    const result = await getContent(
+      { limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
       {} as never,
       ctx
     );
@@ -70,6 +97,19 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     return new Set(result.content.map((c) => c.id));
   }
 
+  async function recallIds(ctx: ToolContext): Promise<Set<number>> {
+    const result = await search(
+      {
+        query: 'invitation',
+        include_content: true,
+        content_limit: 50,
+      } as never,
+      {} as never,
+      ctx
+    );
+    return new Set((result.content ?? []).map((c) => c.id));
+  }
+
   beforeAll(async () => {
     await initWorkspaceProvider();
     await cleanupTestDatabase();
@@ -78,6 +118,7 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     org = await createTestOrganization({ name: 'Workspace Audit Visibility Org' });
     alice = await createTestUser({ email: 'alice-workspace-audit@example.com' });
     await addUserToOrganization(alice.id, org.id, 'owner');
+    outsider = await createTestUser({ email: 'outsider-workspace-audit@example.com' });
 
     entity = await createTestEntity({
       name: 'Workspace Audit Entity',
@@ -109,6 +150,24 @@ describe('workspace-identity audit events > public-read exclusion', () => {
         },
       })
     ).id;
+
+    // Unbound (org-wide, no entity / connection) workspace audit row — the
+    // shape an anonymous or signed-in non-member could otherwise retrieve
+    // through an org-wide read of a public workspace.
+    orgWideWorkspaceAuditEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        title: 'Invitation sent to orgwide.member@example.com',
+        content: 'org-wide workspace audit event',
+        semantic_type: 'change',
+        metadata: {
+          category: 'workspace',
+          resource_kind: 'invitation',
+          resource_id: 'inv_xyz',
+          op: 'created',
+        },
+      })
+    ).id;
   });
 
   it('authenticated member sees the workspace audit event in the feed', async () => {
@@ -121,6 +180,24 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     const ids = await listIds(unauthedCtx());
     expect(ids.has(workspaceAuditEventId)).toBe(false);
     expect(ids.has(normalEventId)).toBe(true);
+  });
+
+  it('signed-in non-member does NOT see workspace audit events via org-wide read', async () => {
+    const ids = await listOrgWideIds(signedInOutsiderCtx());
+    expect(ids.has(orgWideWorkspaceAuditEventId)).toBe(false);
+    expect(ids.has(workspaceAuditEventId)).toBe(false);
+  });
+
+  it('anonymous org-wide read excludes unbound workspace audit rows', async () => {
+    const ids = await listOrgWideIds(unauthedCtx());
+    expect(ids.has(orgWideWorkspaceAuditEventId)).toBe(false);
+    expect(ids.has(normalEventId)).toBe(true);
+  });
+
+  it('signed-in non-member search_memory recall excludes workspace audit rows', async () => {
+    const ids = await recallIds(signedInOutsiderCtx());
+    expect(ids.has(orgWideWorkspaceAuditEventId)).toBe(false);
+    expect(ids.has(workspaceAuditEventId)).toBe(false);
   });
 
   it('anonymous content_ids exact-ID read excludes workspace audit but keeps ordinary events', async () => {

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -358,6 +358,29 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     expect(sawCancelled).toBe(true);
   });
 
+  it('org-home bootstrap hides workspace audit rows from non-owner/admin', async () => {
+    const { resolvePath } = await import('../../../tools/resolve_path');
+    const slug = (org as unknown as { slug: string }).slug;
+
+    async function bootstrapRecent(ctx: ToolContext) {
+      const result = await resolvePath(
+        { path: `/${slug}`, include_bootstrap: true } as never,
+        {} as never,
+        ctx
+      );
+      return new Set(
+        ((result.bootstrap as { recent_content?: Array<{ id: number }> })
+          ?.recent_content ?? []).map((c) => c.id)
+      );
+    }
+
+    // Anonymous and ordinary members do not see the org-wide workspace audit row.
+    expect((await bootstrapRecent(unauthedCtx())).has(orgWideWorkspaceAuditEventId)).toBe(false);
+    expect((await bootstrapRecent(memberCtx())).has(orgWideWorkspaceAuditEventId)).toBe(false);
+    // Owner does.
+    expect((await bootstrapRecent(authedCtx())).has(orgWideWorkspaceAuditEventId)).toBe(true);
+  });
+
   it('anonymous content_ids exact-ID read excludes workspace audit but keeps ordinary events', async () => {
     const ids = await readExactIds(unauthedCtx(), [
       workspaceAuditEventId,

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -61,6 +61,15 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     return new Set(result.content.map((c) => c.id));
   }
 
+  async function readExactIds(ctx: ToolContext, ids: number[]): Promise<Set<number>> {
+    const result = await getContent(
+      { entity_id: entity.id, content_ids: ids, limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    return new Set(result.content.map((c) => c.id));
+  }
+
   beforeAll(async () => {
     await initWorkspaceProvider();
     await cleanupTestDatabase();
@@ -110,6 +119,15 @@ describe('workspace-identity audit events > public-read exclusion', () => {
 
   it('anonymous public-workspace reader does NOT see the workspace audit event', async () => {
     const ids = await listIds(unauthedCtx());
+    expect(ids.has(workspaceAuditEventId)).toBe(false);
+    expect(ids.has(normalEventId)).toBe(true);
+  });
+
+  it('anonymous content_ids exact-ID read excludes workspace audit but keeps ordinary events', async () => {
+    const ids = await readExactIds(unauthedCtx(), [
+      workspaceAuditEventId,
+      normalEventId,
+    ]);
     expect(ids.has(workspaceAuditEventId)).toBe(false);
     expect(ids.has(normalEventId)).toBe(true);
   });

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -29,6 +29,7 @@ describe('workspace-identity audit events > public-read exclusion', () => {
   let workspaceAuditEventId: number;
   let normalEventId: number;
   let orgWideWorkspaceAuditEventId: number;
+  let spoofedCategoryEventId: number;
 
   function authedCtx(): ToolContext {
     return {
@@ -178,6 +179,7 @@ describe('workspace-identity audit events > public-read exclusion', () => {
         semantic_type: 'change',
         metadata: {
           category: 'workspace',
+          _lobu_workspace_audit: true,
           resource_kind: 'invitation',
           resource_id: 'inv_abc',
           op: 'created',
@@ -196,6 +198,7 @@ describe('workspace-identity audit events > public-read exclusion', () => {
         semantic_type: 'change',
         metadata: {
           category: 'workspace',
+          _lobu_workspace_audit: true,
           resource_kind: 'invitation',
           resource_id: 'inv_xyz',
           op: 'created',
@@ -222,6 +225,20 @@ describe('workspace-identity audit events > public-read exclusion', () => {
       VALUES (${orgWideWorkspaceAuditEventId}, ${facetId}, NULL, NULL, ${'{sensitive}'}::text[],
               ${sql.json({ sensitive: 1 })}, 'user', true)
     `;
+
+    // A NON-audit event whose caller supplied category='workspace' in metadata
+    // (save_memory accepts arbitrary metadata). The exclusion must gate on the
+    // server-owned _lobu_workspace_audit discriminator, NOT the category, so
+    // ordinary members retain access to this legitimate event.
+    spoofedCategoryEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        title: 'A normal note with spoofed category',
+        content: 'ordinary member should keep reading this',
+        metadata: { category: 'workspace' },
+      })
+    ).id;
   });
 
   it('authenticated member sees the workspace audit event in the feed', async () => {
@@ -257,6 +274,21 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     const recall = await recallIds(memberCtx());
     expect(recall.has(orgWideWorkspaceAuditEventId)).toBe(false);
     expect(recall.has(workspaceAuditEventId)).toBe(false);
+  });
+
+  it('ordinary member retains access to a NON-audit event that spoofs the workspace category', async () => {
+    // save_memory accepts caller metadata, so a member could legitimately save
+    // an event with category='workspace'. The exclusion gates on the
+    // server-owned _lobu_workspace_audit discriminator, NOT the category, so
+    // this event stays readable by everyone.
+    const listed = await listIds(memberCtx());
+    expect(listed.has(spoofedCategoryEventId)).toBe(true);
+
+    const exact = await readExactIds(memberCtx(), [spoofedCategoryEventId]);
+    expect(exact.has(spoofedCategoryEventId)).toBe(true);
+
+    const anon = await listOrgWideIds(unauthedCtx());
+    expect(anon.has(spoofedCategoryEventId)).toBe(true);
   });
 
   it('anonymous org-wide read excludes unbound workspace audit rows', async () => {

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration test: workspace-identity audit events (metadata.category=
+ * 'workspace') are visible to authenticated members in the All activity feed
+ * but are NEVER returned to anonymous public-workspace readers through the
+ * public read_knowledge path. These events carry member emails / invitation
+ * details, so public exposure is a privacy leak.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('workspace-identity audit events > public-read exclusion', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let alice: Awaited<ReturnType<typeof createTestUser>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+  let workspaceAuditEventId: number;
+  let normalEventId: number;
+
+  function authedCtx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: alice.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    } as ToolContext;
+  }
+
+  function unauthedCtx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: null,
+      memberRole: null,
+      isAuthenticated: false,
+      tokenType: 'anonymous',
+      scopedToOrg: true,
+      allowCrossOrg: false,
+    } as ToolContext;
+  }
+
+  async function listIds(ctx: ToolContext): Promise<Set<number>> {
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
+      {} as never,
+      ctx
+    );
+    return new Set(result.content.map((c) => c.id));
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Workspace Audit Visibility Org' });
+    alice = await createTestUser({ email: 'alice-workspace-audit@example.com' });
+    await addUserToOrganization(alice.id, org.id, 'owner');
+
+    entity = await createTestEntity({
+      name: 'Workspace Audit Entity',
+      organization_id: org.id,
+    });
+
+    normalEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        content: 'normal content event',
+      })
+    ).id;
+
+    // Mirrors what recordWorkspaceChangeEvent emits (minus embeddings, which
+    // are not needed for the chronological date-sort list path).
+    workspaceAuditEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        title: 'Invitation sent to new.member@example.com',
+        content: 'workspace audit event',
+        semantic_type: 'change',
+        metadata: {
+          category: 'workspace',
+          resource_kind: 'invitation',
+          resource_id: 'inv_abc',
+          op: 'created',
+        },
+      })
+    ).id;
+  });
+
+  it('authenticated member sees the workspace audit event in the feed', async () => {
+    const ids = await listIds(authedCtx());
+    expect(ids.has(workspaceAuditEventId)).toBe(true);
+    expect(ids.has(normalEventId)).toBe(true);
+  });
+
+  it('anonymous public-workspace reader does NOT see the workspace audit event', async () => {
+    const ids = await listIds(unauthedCtx());
+    expect(ids.has(workspaceAuditEventId)).toBe(false);
+    expect(ids.has(normalEventId)).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -263,6 +263,69 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     expect(await readClassified(authedCtx(), { orgWide: true })).toBe(1);
   });
 
+  it('deleting an invited member emits an invitation-cancelled audit event', async () => {
+    const { getEntityHooks } = await import('../../../utils/entity-hooks');
+    const { getDb } = await import('../../../db/client');
+    const sql = getDb();
+
+    // Insert a pending invitation directly (the $member beforeCreate hook
+    // does exactly this when a $member entity is created with an email).
+    await sql`
+      INSERT INTO invitation (id, "organizationId", email, role, status, "expiresAt", "inviterId", "createdAt")
+      VALUES (gen_random_uuid()::text, ${org.id}, 'cancel-me@example.com', 'member',
+              'pending', NOW() + interval '48 hours', ${alice.id}, NOW())
+    `;
+    const invRows = (await sql`
+      SELECT id FROM invitation
+      WHERE "organizationId" = ${org.id}
+        AND email = 'cancel-me@example.com'
+        AND status = 'pending'
+    `) as unknown as Array<{ id: string }>;
+    expect(invRows).toHaveLength(1);
+
+    // Deleting the member fires beforeDelete → cancels the invitation.
+    const hooks = getEntityHooks('$member');
+    expect(hooks?.beforeDelete).toBeDefined();
+    await hooks!.beforeDelete!(
+      {
+        id: 999999,
+        entity_type: '$member',
+        metadata: { email: 'cancel-me@example.com' },
+      },
+      { organizationId: org.id, userId: alice.id }
+    );
+
+    // The invitation is now canceled and the cancellation is audited.
+    const cancelledRows = (await sql`
+      SELECT status FROM invitation
+      WHERE "organizationId" = ${org.id}
+        AND email = 'cancel-me@example.com'
+    `) as unknown as Array<{ status: string }>;
+    expect(cancelledRows[0]?.status).toBe('canceled');
+
+    // Poll for the fire-and-forget audit row.
+    const deadline = Date.now() + 2000;
+    let sawCancelled = false;
+    while (Date.now() < deadline) {
+      const audit = await sql`
+        SELECT 1 FROM events
+        WHERE organization_id = ${org.id}
+          AND semantic_type = 'change'
+          AND metadata->>'category' = 'workspace'
+          AND metadata->>'resource_kind' = 'invitation'
+          AND metadata->>'op' = 'updated'
+          AND title ILIKE '%cancel-me@example.com%'
+        LIMIT 1
+      `;
+      if (audit.length > 0) {
+        sawCancelled = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(sawCancelled).toBe(true);
+  });
+
   it('anonymous content_ids exact-ID read excludes workspace audit but keeps ordinary events', async () => {
     const ids = await readExactIds(unauthedCtx(), [
       workspaceAuditEventId,

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -70,6 +70,21 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     } as ToolContext;
   }
 
+  function memberCtx(): ToolContext {
+    // An ordinary member (not owner/admin): can read the workspace, but must
+    // not see another member's invitation / email audit PII.
+    return {
+      organizationId: org.id,
+      userId: alice.id,
+      memberRole: 'member',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    } as ToolContext;
+  }
+
   async function listIds(ctx: ToolContext): Promise<Set<number>> {
     const result = await getContent(
       { entity_id: entity.id, limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
@@ -225,6 +240,23 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     const ids = await listOrgWideIds(signedInOutsiderCtx());
     expect(ids.has(orgWideWorkspaceAuditEventId)).toBe(false);
     expect(ids.has(workspaceAuditEventId)).toBe(false);
+  });
+
+  it('ordinary member does NOT see workspace audit PII (list / exact-ID / search)', async () => {
+    // List (entity-scoped)
+    const listed = await listIds(memberCtx());
+    expect(listed.has(workspaceAuditEventId)).toBe(false);
+    expect(listed.has(normalEventId)).toBe(true);
+
+    // Exact-ID
+    const exact = await readExactIds(memberCtx(), [workspaceAuditEventId, normalEventId]);
+    expect(exact.has(workspaceAuditEventId)).toBe(false);
+    expect(exact.has(normalEventId)).toBe(true);
+
+    // Search recall
+    const recall = await recallIds(memberCtx());
+    expect(recall.has(orgWideWorkspaceAuditEventId)).toBe(false);
+    expect(recall.has(workspaceAuditEventId)).toBe(false);
   });
 
   it('anonymous org-wide read excludes unbound workspace audit rows', async () => {

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -200,6 +200,19 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     expect(ids.has(workspaceAuditEventId)).toBe(false);
   });
 
+  it('non-member behavior_id read is denied (no workspace audit surface)', async () => {
+    // Behavior read mode executes a Behavior's authored sources; a public
+    // non-member must not be able to run it and surface workspace-identity
+    // audit rows. The denial happens before any behavior lookup.
+    await expect(
+      getContent(
+        { behavior_id: 999999, limit: 100 } as never,
+        {} as never,
+        signedInOutsiderCtx()
+      )
+    ).rejects.toThrow(/workspace membership/);
+  });
+
   it('anonymous content_ids exact-ID read excludes workspace audit but keeps ordinary events', async () => {
     const ids = await readExactIds(unauthedCtx(), [
       workspaceAuditEventId,

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -7,9 +7,13 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
 import { getContent } from '../../../tools/get_content';
+import { resolvePath } from '../../../tools/resolve_path';
+import { saveContent } from '../../../tools/save_content';
 import { search } from '../../../tools/search';
 import type { ToolContext } from '../../../tools/registry';
+import { getEntityHooks } from '../../../utils/entity-hooks';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
@@ -223,7 +227,6 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     // Classify the workspace audit row so classification STATS (which are
     // aggregated across all matching content) could leak its presence to
     // non-members even when the row itself is filtered out.
-    const { getDb } = await import('../../../db/client');
     const sql = getDb();
     const facet = await sql`
       INSERT INTO classify_facet (organization_id, slug, name, attribute_key, status,
@@ -306,8 +309,6 @@ describe('workspace-identity audit events > public-read exclusion', () => {
   });
 
   it('save_memory strips the server-owned _lobu_workspace_audit key from caller metadata', async () => {
-    const { saveContent } = await import('../../../tools/save_content');
-    const { getDb } = await import('../../../db/client');
     const sql = getDb();
 
     // A member tries to forge the audit discriminator via save_memory metadata.
@@ -382,8 +383,6 @@ describe('workspace-identity audit events > public-read exclusion', () => {
   });
 
   it('deleting an invited member emits an invitation-cancelled audit event', async () => {
-    const { getEntityHooks } = await import('../../../utils/entity-hooks');
-    const { getDb } = await import('../../../db/client');
     const sql = getDb();
 
     // Insert a pending invitation directly (the $member beforeCreate hook
@@ -445,7 +444,6 @@ describe('workspace-identity audit events > public-read exclusion', () => {
   });
 
   it('org-home bootstrap hides workspace audit rows from non-owner/admin', async () => {
-    const { resolvePath } = await import('../../../tools/resolve_path');
     const slug = (org as unknown as { slug: string }).slug;
 
     async function bootstrapRecent(ctx: ToolContext) {
@@ -476,7 +474,6 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     });
     await addUserToOrganization(alice.id, otherOrg.id, 'owner');
 
-    const { resolvePath } = await import('../../../tools/resolve_path');
     const slug = (org as unknown as { slug: string }).slug;
     const result = await resolvePath(
       { path: `/${slug}`, include_bootstrap: true } as never,

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -346,7 +346,7 @@ describe('workspace-identity audit events > public-read exclusion', () => {
           AND metadata->>'category' = 'workspace'
           AND metadata->>'resource_kind' = 'invitation'
           AND metadata->>'op' = 'updated'
-          AND title ILIKE '%cancel-me@example.com%'
+          AND metadata->>'resource_id' = ${invRows[0].id}
         LIMIT 1
       `;
       if (audit.length > 0) {

--- a/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-public-visibility.test.ts
@@ -104,6 +104,22 @@ describe('workspace-identity audit events > public-read exclusion', () => {
     } as ToolContext;
   }
 
+  function userlessOAuthCtx(): ToolContext {
+    // Authenticated, no user id, no membership — matches isSystemContext() but
+    // NOT isInProcessSystemCall() (tokenType is oauth, not session). Must not
+    // see workspace audit rows.
+    return {
+      organizationId: org.id,
+      userId: null,
+      memberRole: null,
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: true,
+      allowCrossOrg: false,
+      scopes: ['mcp:read'],
+    } as ToolContext;
+  }
+
   async function listIds(ctx: ToolContext): Promise<Set<number>> {
     const result = await getContent(
       { entity_id: entity.id, limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
@@ -267,6 +283,13 @@ describe('workspace-identity audit events > public-read exclusion', () => {
   it('anonymous public-workspace reader does NOT see the workspace audit event', async () => {
     const ids = await listIds(unauthedCtx());
     expect(ids.has(workspaceAuditEventId)).toBe(false);
+    expect(ids.has(normalEventId)).toBe(true);
+  });
+
+  it('userless OAuth token does NOT see workspace audit (not in-process system)', async () => {
+    const ids = await listOrgWideIds(userlessOAuthCtx());
+    expect(ids.has(workspaceAuditEventId)).toBe(false);
+    expect(ids.has(orgWideWorkspaceAuditEventId)).toBe(false);
     expect(ids.has(normalEventId)).toBe(true);
   });
 

--- a/packages/server/src/__tests__/integration/events/workspace-audit-slack-home.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-slack-home.test.ts
@@ -23,13 +23,27 @@ describe('workspace-identity audit events > Slack App Home', () => {
     const org = await createTestOrganization({ name: 'Slack Home Audit Org' });
     organizationId = org.id;
     normalTitle = `normal-home-event-${Date.now()}`;
+  });
+
+  it('excludes workspace audit rows from recent and capturedToday', async () => {
+    const empty = await resolveSlackHomeContext(organizationId);
+    expect(empty).not.toBeNull();
+    expect(empty!.capturedToday).toBe(0);
+    expect(empty!.recent).toHaveLength(0);
 
     await createTestEvent({
       organization_id: organizationId,
       content: normalTitle,
       title: normalTitle,
     });
+    const withNormal = await resolveSlackHomeContext(organizationId);
+    expect(withNormal!.capturedToday).toBe(1);
+    expect(
+      withNormal!.recent.some((r) => r.title.includes(normalTitle.slice(0, 20)))
+    ).toBe(true);
 
+    // Inserting a genuine workspace-audit row must NOT move the count or
+    // appear in recent — this fails closed if the exclusion predicate is dropped.
     await createTestEvent({
       organization_id: organizationId,
       content: 'workspace audit lifecycle row',
@@ -42,19 +56,11 @@ describe('workspace-identity audit events > Slack App Home', () => {
         op: 'created',
       },
     });
-  });
-
-  it('excludes workspace audit rows from recent and capturedToday', async () => {
-    const ctx = await resolveSlackHomeContext(organizationId);
-    expect(ctx).not.toBeNull();
-    expect(ctx!.recent.some((r) => r.title.includes('secret'))).toBe(false);
-    expect(ctx!.recent.some((r) => r.title.includes(normalTitle.slice(0, 20)))).toBe(
-      true
-    );
-    // At least the normal event from today; audit must not inflate the count.
-    expect(ctx!.capturedToday).toBeGreaterThanOrEqual(1);
-    // If only our two inserts exist for this org today, capturedToday is 1.
-    // Bound loosely so concurrent test noise cannot false-fail.
-    expect(ctx!.capturedToday).toBeLessThanOrEqual(50);
+    const withAudit = await resolveSlackHomeContext(organizationId);
+    expect(withAudit!.capturedToday).toBe(1);
+    expect(withAudit!.recent.some((r) => r.title.includes('secret'))).toBe(false);
+    expect(
+      withAudit!.recent.some((r) => r.title.includes(normalTitle.slice(0, 20)))
+    ).toBe(true);
   });
 });

--- a/packages/server/src/__tests__/integration/events/workspace-audit-slack-home.test.ts
+++ b/packages/server/src/__tests__/integration/events/workspace-audit-slack-home.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Slack App Home is org-scoped for any linked Slack user — it must never
+ * surface owner/admin-only workspace-identity audit rows in recent activity
+ * or the "captured today" count.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { resolveSlackHomeContext } from '../../../gateway/connections/chat-instance-manager';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  createTestEvent,
+  createTestOrganization,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('workspace-identity audit events > Slack App Home', () => {
+  let organizationId: string;
+  let normalTitle: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    const org = await createTestOrganization({ name: 'Slack Home Audit Org' });
+    organizationId = org.id;
+    normalTitle = `normal-home-event-${Date.now()}`;
+
+    await createTestEvent({
+      organization_id: organizationId,
+      content: normalTitle,
+      title: normalTitle,
+    });
+
+    await createTestEvent({
+      organization_id: organizationId,
+      content: 'workspace audit lifecycle row',
+      title: 'Member "secret" added',
+      semantic_type: 'change',
+      metadata: {
+        category: 'workspace',
+        _lobu_workspace_audit: true,
+        resource_kind: 'member',
+        op: 'created',
+      },
+    });
+  });
+
+  it('excludes workspace audit rows from recent and capturedToday', async () => {
+    const ctx = await resolveSlackHomeContext(organizationId);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.recent.some((r) => r.title.includes('secret'))).toBe(false);
+    expect(ctx!.recent.some((r) => r.title.includes(normalTitle.slice(0, 20)))).toBe(
+      true
+    );
+    // At least the normal event from today; audit must not inflate the count.
+    expect(ctx!.capturedToday).toBeGreaterThanOrEqual(1);
+    // If only our two inserts exist for this org today, capturedToday is 1.
+    // Bound loosely so concurrent test noise cannot false-fail.
+    expect(ctx!.capturedToday).toBeLessThanOrEqual(50);
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/behavior-mode-visibility-principal.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/behavior-mode-visibility-principal.test.ts
@@ -193,4 +193,79 @@ describe('Behavior private-connection visibility', () => {
       [ownerPrivate.id, orgVisible.id].sort((a, b) => a - b)
     );
   });
+
+  it('ordinary-member behavior reads exclude workspace-audit rows from content AND total_count', async () => {
+    const sql = getTestDb();
+    const dbClient = sql as unknown as DbClient;
+    const workspace = await TestWorkspace.create({
+      name: 'Behavior Audit Exclusion Org',
+    });
+    const entity = await createTestEntity({
+      name: 'Behavior Audit Exclusion Entity',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+    const agent = await createTestAgent({
+      organizationId: workspace.org.id,
+      ownerUserId: workspace.users.admin.id,
+      name: 'Behavior Audit Exclusion Agent',
+    });
+    const created = (await workspace.owner.behaviors.create({
+      entity_id: entity.id,
+      slug: 'behavior-audit-exclusion',
+      name: 'Behavior Audit Exclusion',
+      prompt: 'Summarize the visible content.',
+      agent_id: agent.agentId,
+      sources: [{ name: 'content', query: 'SELECT * FROM events' }],
+    })) as { behavior_id: string };
+    const behaviorId = Number(created.behavior_id);
+
+    // A genuine workspace-audit row (server-owned discriminator) and an
+    // ordinary org-visible event.
+    const auditEvent = await createTestEvent({
+      entity_id: entity.id,
+      organization_id: workspace.org.id,
+      connector_key: 'slack',
+      content: 'workspace audit lifecycle row',
+      occurred_at: occurredAt,
+      semantic_type: 'change',
+      metadata: { category: 'workspace', _lobu_workspace_audit: true },
+    });
+    const orgConnection = await createTestConnection({
+      organization_id: workspace.org.id,
+      connector_key: 'slack',
+      visibility: 'org',
+    });
+    const orgVisible = await createTestEvent({
+      entity_id: entity.id,
+      organization_id: workspace.org.id,
+      connection_id: orgConnection.id,
+      connector_key: 'slack',
+      content: 'Organization-visible content',
+      occurred_at: occurredAt,
+    });
+
+    // Ordinary member: behavior read content excludes the audit row.
+    const memberRead = await getContent(
+      { behavior_id: behaviorId, since, until },
+      env,
+      {
+        ...ownerToolContext(workspace.org.id, workspace.users.member.id),
+        memberRole: 'member',
+      }
+    );
+    expect(contentIds(memberRead)).toEqual([orgVisible.id]);
+
+    // Owner: sees both.
+    const ownerRead = await getContent(
+      { behavior_id: behaviorId, since, until },
+      env,
+      ownerToolContext(workspace.org.id, workspace.users.owner.id)
+    );
+    expect(contentIds(ownerRead)).toEqual([orgVisible.id, auditEvent.id].sort((a, b) => a - b));
+
+    // total_count agrees with content for the ordinary member (no audit leak).
+    const memberTotal = (memberRead as { total_count?: number }).total_count;
+    expect(memberTotal).toBe(1);
+  });
 });

--- a/packages/server/src/__tests__/integration/workspace/public-join-workspace-audit.test.ts
+++ b/packages/server/src/__tests__/integration/workspace/public-join-workspace-audit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration tests for workspace-identity audit events around membership:
+ * public-org join (ON CONFLICT race must emit exactly one audit row, keyed on
+ * the committed member id) and member removal (keyed on member.id, not the
+ * user id, keeping the audit trail's resource identity consistent with the
+ * create/update events).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { generateSecureToken } from "../../../auth/oauth/utils";
+import { ensurePersonalOrganization } from "../../../auth/personal-org-provisioning";
+import { joinPublicOrganization } from "../../../workspace/join-public";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+
+async function seedUser(name: string): Promise<{ id: string; email: string }> {
+	const id = `user_${generateSecureToken(6)}`;
+	const email = `${id}@test.local`;
+	const sql = getTestDb();
+	await sql`
+    INSERT INTO "user" (id, name, email, username, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${id}, ${name}, ${email}, null, true, NOW(), NOW())
+  `;
+	return { id, email };
+}
+
+async function readWorkspaceEvents(organizationId: string) {
+	const sql = getTestDb();
+	return sql`
+    SELECT title, metadata, payload_data
+    FROM events
+    WHERE organization_id = ${organizationId}
+      AND semantic_type = 'change'
+      AND metadata->>'category' = 'workspace'
+    ORDER BY id ASC
+  `;
+}
+
+describe("public workspace join audit events", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("emits exactly one member-created event for a double join", async () => {
+		const owner = await seedUser("Owner");
+		const org = await ensurePersonalOrganization({
+			id: owner.id,
+			email: owner.email,
+			name: "Owner",
+			username: null,
+		});
+		// Make the personal org public so a second user can self-join.
+		const sql = getTestDb();
+		await sql`
+      UPDATE "organization" SET visibility = 'public' WHERE id = ${org.organizationId}
+    `;
+
+		const joiner = await seedUser("Joiner");
+		const first = await joinPublicOrganization({
+			userId: joiner.id,
+			orgSlug: org.slug,
+		});
+		expect(first.status).toBe("joined");
+
+		// Second call — idempotent, must NOT re-emit an audit row.
+		const second = await joinPublicOrganization({
+			userId: joiner.id,
+			orgSlug: org.slug,
+		});
+		expect(second.status).toBe("already_member");
+
+		const rows = await readWorkspaceEvents(org.organizationId);
+		const joinerCreated = rows.filter(
+			(r) =>
+				(r.metadata as { resource_kind?: string }).resource_kind === "member" &&
+				(r.metadata as { op?: string }).op === "created" &&
+				(
+					(r as { payload_data?: { state?: Record<string, unknown> } })
+						.payload_data?.state as Record<string, unknown> | undefined
+				)?.user_id === joiner.id,
+		);
+		expect(joinerCreated).toHaveLength(1);
+		const state = (joinerCreated[0] as { payload_data?: { state?: Record<string, unknown> } })
+			.payload_data?.state;
+		// Keyed on the committed member id (the row that exists), and the actor
+		// is the joining member.
+		expect(state?.id).toBeTypeOf("string");
+		expect(state?.user_id).toBe(joiner.id);
+		expect(state?.role).toBe("member");
+	});
+});

--- a/packages/server/src/__tests__/integration/workspace/public-join-workspace-audit.test.ts
+++ b/packages/server/src/__tests__/integration/workspace/public-join-workspace-audit.test.ts
@@ -35,6 +35,21 @@ async function readWorkspaceEvents(organizationId: string) {
   `;
 }
 
+/** Audit writers are fire-and-forget; poll briefly for the row to land. */
+async function waitFor(
+	fn: () => Promise<unknown[]>,
+	timeoutMs = 2000,
+): Promise<unknown[]> {
+	const deadline = Date.now() + timeoutMs;
+	let rows: unknown[] = [];
+	while (Date.now() < deadline) {
+		rows = await fn();
+		if (rows.length > 0) return rows;
+		await new Promise((r) => setTimeout(r, 50));
+	}
+	return rows;
+}
+
 describe("public workspace join audit events", () => {
 	beforeEach(async () => {
 		await cleanupTestDatabase();
@@ -68,18 +83,25 @@ describe("public workspace join audit events", () => {
 		});
 		expect(second.status).toBe("already_member");
 
-		const rows = await readWorkspaceEvents(org.organizationId);
-		const joinerCreated = rows.filter(
-			(r) =>
-				(r.metadata as { resource_kind?: string }).resource_kind === "member" &&
-				(r.metadata as { op?: string }).op === "created" &&
-				(
-					(r as { payload_data?: { state?: Record<string, unknown> } })
-						.payload_data?.state as Record<string, unknown> | undefined
-				)?.user_id === joiner.id,
+		// Audit writers are fire-and-forget — poll until the joiner's
+		// member-created row lands.
+		const rows = await waitFor(() =>
+			readWorkspaceEvents(org.organizationId).then((all) => {
+				const matches = all.filter(
+					(r) =>
+						(r.metadata as { resource_kind?: string }).resource_kind ===
+							"member" &&
+						(r.metadata as { op?: string }).op === "created" &&
+						(
+							(r as { payload_data?: { state?: Record<string, unknown> } })
+								.payload_data?.state as Record<string, unknown> | undefined
+						)?.user_id === joiner.id,
+				);
+				return matches;
+			}),
 		);
-		expect(joinerCreated).toHaveLength(1);
-		const state = (joinerCreated[0] as { payload_data?: { state?: Record<string, unknown> } })
+		expect(rows).toHaveLength(1);
+		const state = (rows[0] as { payload_data?: { state?: Record<string, unknown> } })
 			.payload_data?.state;
 		// Keyed on the committed member id (the row that exists), and the actor
 		// is the joining member.

--- a/packages/server/src/__tests__/integration/workspace/public-join-workspace-audit.test.ts
+++ b/packages/server/src/__tests__/integration/workspace/public-join-workspace-audit.test.ts
@@ -109,4 +109,70 @@ describe("public workspace join audit events", () => {
 		expect(state?.user_id).toBe(joiner.id);
 		expect(state?.role).toBe("member");
 	});
+
+	it("already_member path still repairs $member projection and clears role cache", async () => {
+		// Simulates the post-insert repair path that concurrent ON CONFLICT
+		// losers also take: membership exists, but $member / role cache may
+		// not. A second join must repair without emitting another audit row.
+		const owner = await seedUser("Owner2");
+		const org = await ensurePersonalOrganization({
+			id: owner.id,
+			email: owner.email,
+			name: "Owner2",
+			username: null,
+		});
+		const sql = getTestDb();
+		await sql`
+      UPDATE "organization" SET visibility = 'public' WHERE id = ${org.organizationId}
+    `;
+
+		const joiner = await seedUser("Joiner2");
+		// Pre-insert the member row as if a concurrent winner already committed.
+		const memberId = `member_${generateSecureToken(6)}`;
+		await sql`
+      INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
+      VALUES (${memberId}, ${org.organizationId}, ${joiner.id}, 'member', NOW())
+    `;
+
+		const result = await joinPublicOrganization({
+			userId: joiner.id,
+			orgSlug: org.slug,
+		});
+		expect(result.status).toBe("already_member");
+		expect(result.role).toBe("member");
+
+		// $member entity + auth_user_id claim should exist after repair.
+		const claims = await waitFor(async () => {
+			const rows = await sql`
+        SELECT e.id
+        FROM entities e
+        JOIN entity_types et
+          ON et.id = e.entity_type_id AND et.organization_id = e.organization_id
+        JOIN entity_identities ei ON ei.entity_id = e.id
+        WHERE e.organization_id = ${org.organizationId}
+          AND et.slug = '$member'
+          AND e.deleted_at IS NULL
+          AND ei.namespace = 'auth_user_id'
+          AND ei.identifier = ${joiner.id}
+      `;
+			return rows as unknown[];
+		});
+		expect(claims.length).toBeGreaterThanOrEqual(1);
+
+		// No member-created audit for a path that did not insert. Brief wait so
+		// a fire-and-forget phantom write would have landed if mis-emitted.
+		await new Promise((r) => setTimeout(r, 200));
+		const auditAfter = await readWorkspaceEvents(org.organizationId).then((all) =>
+			all.filter(
+				(r) =>
+					(r.metadata as { resource_kind?: string }).resource_kind === "member" &&
+					(r.metadata as { op?: string }).op === "created" &&
+					(
+						(r as { payload_data?: { state?: Record<string, unknown> } })
+							.payload_data?.state as Record<string, unknown> | undefined
+					)?.user_id === joiner.id,
+			),
+		);
+		expect(auditAfter).toHaveLength(0);
+	});
 });

--- a/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
+++ b/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
@@ -134,7 +134,7 @@ describe('buildScopedQuery org scope — denormalized linked_org_ids seam', () =
     }, {
       excludeWorkspaceAudit: true,
     });
-    expect(sql).toContain("(ev.metadata->>'category') IS DISTINCT FROM 'workspace'");
+    expect(sql).toContain("NOT (ev.metadata ? '_lobu_workspace_audit')");
   });
 
   it('excludeWorkspaceAudit filters event_classifications CTE', () => {
@@ -144,7 +144,7 @@ describe('buildScopedQuery org scope — denormalized linked_org_ids seam', () =
       { organizationId: 'org_test', userId: 'user_a' },
       { excludeWorkspaceAudit: true }
     );
-    expect(sql).toContain("(ev.metadata->>'category') IS DISTINCT FROM 'workspace'");
+    expect(sql).toContain("NOT (ev.metadata ? '_lobu_workspace_audit')");
   });
 
   it('omits the workspace filter when the flag is absent (admin / system callers)', () => {
@@ -152,6 +152,6 @@ describe('buildScopedQuery org scope — denormalized linked_org_ids seam', () =
       organizationId: 'org_test',
       userId: 'user_a',
     });
-    expect(sql).not.toContain("IS DISTINCT FROM 'workspace'");
+    expect(sql).not.toContain("_lobu_workspace_audit");
   });
 });

--- a/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
+++ b/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
@@ -126,4 +126,32 @@ describe('buildScopedQuery org scope — denormalized linked_org_ids seam', () =
       delete process.env.LOBU_LINKED_ORG_SCOPE;
     }
   });
+
+  it('excludeWorkspaceAudit filters events CTE for ordinary members', () => {
+    const { sql } = buildScopedQuery('SELECT * FROM events', ['events'], {
+      organizationId: 'org_test',
+      userId: 'user_a',
+    }, {
+      excludeWorkspaceAudit: true,
+    });
+    expect(sql).toContain("(ev.metadata->>'category') IS DISTINCT FROM 'workspace'");
+  });
+
+  it('excludeWorkspaceAudit filters event_classifications CTE', () => {
+    const { sql } = buildScopedQuery(
+      'SELECT excerpts FROM event_classifications',
+      ['event_classifications'],
+      { organizationId: 'org_test', userId: 'user_a' },
+      { excludeWorkspaceAudit: true }
+    );
+    expect(sql).toContain("(ev.metadata->>'category') IS DISTINCT FROM 'workspace'");
+  });
+
+  it('omits the workspace filter when the flag is absent (admin / system callers)', () => {
+    const { sql } = buildScopedQuery('SELECT * FROM events', ['events'], {
+      organizationId: 'org_test',
+      userId: 'user_a',
+    });
+    expect(sql).not.toContain("IS DISTINCT FROM 'workspace'");
+  });
 });

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -608,7 +608,11 @@ export async function createAuth(
 							);
 						}
 					},
-					afterCancelInvitation: async ({ invitation, organization: org }) => {
+					afterCancelInvitation: async ({
+						invitation,
+						cancelledBy,
+						organization: org,
+					}) => {
 						// Cancellation is already committed. Audit first. Better Auth
 						// RETAINS the invitation row and flips its status to 'canceled'
 						// (it does not delete), so record that transition faithfully
@@ -626,6 +630,7 @@ export async function createAuth(
 							},
 							changedFields: ["status"],
 							actorSource: "ui",
+							createdBy: cancelledBy.id,
 						});
 						try {
 							await deleteMemberEntity(org.id, invitation.email);
@@ -636,7 +641,7 @@ export async function createAuth(
 							);
 						}
 					},
-					afterRejectInvitation: async ({ invitation, organization: org }) => {
+					afterRejectInvitation: async ({ invitation, user, organization: org }) => {
 						// Rejection is already committed. Audit first. Better Auth
 						// RETAINS the invitation row and flips its status to 'rejected'
 						// (it does not delete), so record that transition faithfully
@@ -654,6 +659,7 @@ export async function createAuth(
 							},
 							changedFields: ["status"],
 							actorSource: "ui",
+							createdBy: user.id,
 						});
 						try {
 							await deleteMemberEntity(org.id, invitation.email);

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -363,12 +363,11 @@ export async function createAuth(
 							resourceKind: "member",
 							resourceId: member.id,
 							op: "created",
-							summary: `Member "${user.name || user.email}" added`,
+							summary: `Member "${user.name || 'a member'}" added`,
 							state: {
 								id: member.id,
 								user_id: user.id,
 								role: member.role,
-								email: user.email ?? null,
 							},
 							changedFields: ["user_id", "role"],
 							actorSource: "ui",
@@ -391,7 +390,7 @@ export async function createAuth(
 								entityType: "member",
 								op: "created",
 								entityId: member.id,
-								summary: `Member "${user.name || user.email}" added`,
+								summary: `Member "${user.name || 'a member'}" added`,
 								extra: { user_id: user.id, role: member.role },
 							});
 						} catch (err) {
@@ -429,10 +428,9 @@ export async function createAuth(
 							resourceKind: "invitation",
 							resourceId: invitation.id,
 							op: "updated",
-							summary: `Invitation to ${invitation.email} accepted`,
+							summary: "Invitation accepted",
 							state: {
 								id: invitation.id,
-								email: invitation.email,
 								role: invitation.role,
 								status: invitation.status ?? "accepted",
 							},
@@ -445,12 +443,11 @@ export async function createAuth(
 							resourceKind: "member",
 							resourceId: member.id,
 							op: "created",
-							summary: `Member "${user.name || user.email}" joined`,
+							summary: `Member "${user.name || 'a member'}" joined`,
 							state: {
 								id: member.id,
 								user_id: user.id,
 								role: member.role,
-								email: user.email ?? null,
 							},
 							changedFields: ["user_id", "role"],
 							actorSource: "ui",
@@ -497,7 +494,7 @@ export async function createAuth(
 							resourceKind: "member",
 							resourceId: member.id,
 							op: "deleted",
-							summary: `Member "${user.name || user.email}" removed`,
+							summary: `Member "${user.name || 'a member'}" removed`,
 							state: null,
 							actorSource: "ui",
 						});
@@ -508,7 +505,7 @@ export async function createAuth(
 								entityType: "member",
 								op: "deleted",
 								entityId: user.id,
-								summary: `Member "${user.name || user.email}" removed`,
+								summary: `Member "${user.name || 'a member'}" removed`,
 							});
 							const { invalidateMembershipRoleCache } = await import(
 								"../workspace/multi-tenant"
@@ -533,7 +530,7 @@ export async function createAuth(
 							resourceKind: "member",
 							resourceId: member.id,
 							op: "updated",
-							summary: `Member "${user.name || user.email}" role set to ${member.role}`,
+							summary: `Member "${user.name || 'a member'}" role set to ${member.role}`,
 							state: {
 								id: member.id,
 								user_id: user.id,
@@ -571,14 +568,13 @@ export async function createAuth(
 							resourceKind: "invitation",
 							resourceId: invitation.id,
 							op: "created",
-							summary: `Invitation sent to ${invitation.email}`,
+							summary: "Invitation sent",
 							state: {
 								id: invitation.id,
-								email: invitation.email,
 								role: invitation.role,
 								status: invitation.status ?? "pending",
 							},
-							changedFields: ["email", "role", "status"],
+							changedFields: ["role", "status"],
 							actorSource: "ui",
 							createdBy: inviter.id,
 						});
@@ -622,10 +618,9 @@ export async function createAuth(
 							resourceKind: "invitation",
 							resourceId: invitation.id,
 							op: "updated",
-							summary: `Invitation to ${invitation.email} cancelled`,
+							summary: "Invitation cancelled",
 							state: {
 								id: invitation.id,
-								email: invitation.email,
 								status: invitation.status ?? "canceled",
 							},
 							changedFields: ["status"],
@@ -651,10 +646,9 @@ export async function createAuth(
 							resourceKind: "invitation",
 							resourceId: invitation.id,
 							op: "updated",
-							summary: `Invitation to ${invitation.email} rejected`,
+							summary: "Invitation rejected",
 							state: {
 								id: invitation.id,
-								email: invitation.email,
 								status: invitation.status ?? "rejected",
 							},
 							changedFields: ["status"],

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -414,6 +414,7 @@ export async function createAuth(
 						}
 					},
 					afterAcceptInvitation: async ({
+						invitation,
 						member,
 						user,
 						organization: org,
@@ -421,6 +422,24 @@ export async function createAuth(
 						// The accepted member row is already committed. Audit first so
 						// the acceptance is never lost to a projection failure. `user`
 						// IS the actor here — the invitee accepting their own invite.
+						// Better Auth retains the invitation and updates its status to
+						// 'accepted', so record that transition faithfully.
+						recordWorkspaceChangeEvent({
+							organizationId: org.id,
+							resourceKind: "invitation",
+							resourceId: invitation.id,
+							op: "updated",
+							summary: `Invitation to ${invitation.email} accepted`,
+							state: {
+								id: invitation.id,
+								email: invitation.email,
+								role: invitation.role,
+								status: invitation.status ?? "accepted",
+							},
+							changedFields: ["status"],
+							actorSource: "ui",
+							createdBy: user.id,
+						});
 						recordWorkspaceChangeEvent({
 							organizationId: org.id,
 							resourceKind: "member",
@@ -590,14 +609,22 @@ export async function createAuth(
 						}
 					},
 					afterCancelInvitation: async ({ invitation, organization: org }) => {
-						// Cancellation is already committed. Audit first.
+						// Cancellation is already committed. Audit first. Better Auth
+						// RETAINS the invitation row and flips its status to 'canceled'
+						// (it does not delete), so record that transition faithfully
+						// instead of a phantom delete.
 						recordWorkspaceChangeEvent({
 							organizationId: org.id,
 							resourceKind: "invitation",
 							resourceId: invitation.id,
-							op: "deleted",
+							op: "updated",
 							summary: `Invitation to ${invitation.email} cancelled`,
-							state: null,
+							state: {
+								id: invitation.id,
+								email: invitation.email,
+								status: invitation.status ?? "canceled",
+							},
+							changedFields: ["status"],
 							actorSource: "ui",
 						});
 						try {
@@ -610,14 +637,22 @@ export async function createAuth(
 						}
 					},
 					afterRejectInvitation: async ({ invitation, organization: org }) => {
-						// Rejection is already committed. Audit first.
+						// Rejection is already committed. Audit first. Better Auth
+						// RETAINS the invitation row and flips its status to 'rejected'
+						// (it does not delete), so record that transition faithfully
+						// instead of a phantom delete.
 						recordWorkspaceChangeEvent({
 							organizationId: org.id,
 							resourceKind: "invitation",
 							resourceId: invitation.id,
-							op: "deleted",
+							op: "updated",
 							summary: `Invitation to ${invitation.email} rejected`,
-							state: null,
+							state: {
+								id: invitation.id,
+								email: invitation.email,
+								status: invitation.status ?? "rejected",
+							},
+							changedFields: ["status"],
 							actorSource: "ui",
 						});
 						try {

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -22,7 +22,7 @@ import {
 import { WelcomeEmail, welcomeSubject } from "../email/templates/welcome";
 import type { Env } from "../index";
 import { notifyInvitationReceived } from "../notifications/triggers";
-import { recordLifecycleEvent } from "../utils/insert-event";
+import { recordLifecycleEvent, recordWorkspaceChangeEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
 import {
 	deleteMemberEntity,
@@ -312,6 +312,22 @@ export async function createAuth(
 					// their Lobu bridge gets a 403 on every poll.
 					afterCreateOrganization: async ({ organization: org, user }) => {
 						try {
+							recordWorkspaceChangeEvent({
+								organizationId: org.id,
+								resourceKind: "organization",
+								resourceId: org.id,
+								op: "created",
+								summary: `Organization "${org.name}" created`,
+								state: {
+									id: org.id,
+									name: org.name,
+									slug: org.slug,
+									visibility: org.visibility ?? null,
+								},
+								changedFields: ["id", "name", "slug", "visibility"],
+								actorSource: "ui",
+								createdBy: user.id,
+							});
 							if (org.visibility !== "private") return;
 							const sql = getDb();
 							const existing = await findExistingPersonalOrg(user.id, sql);
@@ -354,6 +370,22 @@ export async function createAuth(
 								summary: `Member "${user.name || user.email}" added`,
 								extra: { user_id: user.id, role: member.role },
 							});
+							recordWorkspaceChangeEvent({
+								organizationId: org.id,
+								resourceKind: "member",
+								resourceId: member.id,
+								op: "created",
+								summary: `Member "${user.name || user.email}" added`,
+								state: {
+									id: member.id,
+									user_id: user.id,
+									role: member.role,
+									email: user.email ?? null,
+								},
+								changedFields: ["user_id", "role"],
+								actorSource: "ui",
+								createdBy: user.id,
+							});
 						} catch (err) {
 							// A swallow here is how projection drift enters: the member
 							// row commits but its $member + auth:signup claim doesn't, so
@@ -394,6 +426,22 @@ export async function createAuth(
 								"../workspace/multi-tenant"
 							);
 							invalidateMembershipRoleCache(org.id, user.id);
+							recordWorkspaceChangeEvent({
+								organizationId: org.id,
+								resourceKind: "member",
+								resourceId: member.id,
+								op: "created",
+								summary: `Member "${user.name || user.email}" joined`,
+								state: {
+									id: member.id,
+									user_id: user.id,
+									role: member.role,
+									email: user.email ?? null,
+								},
+								changedFields: ["user_id", "role"],
+								actorSource: "ui",
+								createdBy: user.id,
+							});
 						} catch (err) {
 							// See afterAddMember: a swallow here leaves the accepted
 							// member without a resolvable claim → enforced channels
@@ -420,6 +468,16 @@ export async function createAuth(
 								entityId: user.id,
 								summary: `Member "${user.name || user.email}" removed`,
 							});
+							recordWorkspaceChangeEvent({
+								organizationId: org.id,
+								resourceKind: "member",
+								resourceId: user.id,
+								op: "deleted",
+								summary: `Member "${user.name || user.email}" removed`,
+								state: null,
+								actorSource: "ui",
+								createdBy: user.id,
+							});
 							const { invalidateMembershipRoleCache } = await import(
 								"../workspace/multi-tenant"
 							);
@@ -445,6 +503,21 @@ export async function createAuth(
 								"../workspace/multi-tenant"
 							);
 							invalidateMembershipRoleCache(org.id, user.id);
+							recordWorkspaceChangeEvent({
+								organizationId: org.id,
+								resourceKind: "member",
+								resourceId: member.id,
+								op: "updated",
+								summary: `Member "${user.name || user.email}" role set to ${member.role}`,
+								state: {
+									id: member.id,
+									user_id: user.id,
+									role: member.role,
+								},
+								changedFields: ["role"],
+								actorSource: "ui",
+								createdBy: user.id,
+							});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to update $member entity after updateMemberRole:",
@@ -476,6 +549,22 @@ export async function createAuth(
 								role: invitation.role,
 								status: "invited",
 							});
+							recordWorkspaceChangeEvent({
+								organizationId: org.id,
+								resourceKind: "invitation",
+								resourceId: invitation.id,
+								op: "created",
+								summary: `Invitation sent to ${invitation.email}`,
+								state: {
+									id: invitation.id,
+									email: invitation.email,
+									role: invitation.role,
+									status: invitation.status ?? "pending",
+								},
+								changedFields: ["email", "role", "status"],
+								actorSource: "ui",
+								createdBy: inviter.id,
+							});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to create $member entity after createInvitation:",
@@ -486,6 +575,15 @@ export async function createAuth(
 					afterCancelInvitation: async ({ invitation, organization: org }) => {
 						try {
 							await deleteMemberEntity(org.id, invitation.email);
+							recordWorkspaceChangeEvent({
+								organizationId: org.id,
+								resourceKind: "invitation",
+								resourceId: invitation.id,
+								op: "deleted",
+								summary: `Invitation to ${invitation.email} cancelled`,
+								state: null,
+								actorSource: "ui",
+							});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to delete $member entity after cancelInvitation:",
@@ -496,6 +594,15 @@ export async function createAuth(
 					afterRejectInvitation: async ({ invitation, organization: org }) => {
 						try {
 							await deleteMemberEntity(org.id, invitation.email);
+							recordWorkspaceChangeEvent({
+								organizationId: org.id,
+								resourceKind: "invitation",
+								resourceId: invitation.id,
+								op: "deleted",
+								summary: `Invitation to ${invitation.email} rejected`,
+								state: null,
+								actorSource: "ui",
+							});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to delete $member entity after rejectInvitation:",

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -311,23 +311,26 @@ export async function createAuth(
 					// in the device-worker auth middleware (index.ts:602-607), so
 					// their Lobu bridge gets a 403 on every poll.
 					afterCreateOrganization: async ({ organization: org, user }) => {
+						// The org row is already committed when this hook fires. Audit
+						// first so the creation trail survives a personal-org marker
+						// failure below. `user` IS the acting session user (creator).
+						recordWorkspaceChangeEvent({
+							organizationId: org.id,
+							resourceKind: "organization",
+							resourceId: org.id,
+							op: "created",
+							summary: `Organization "${org.name}" created`,
+							state: {
+								id: org.id,
+								name: org.name,
+								slug: org.slug,
+								visibility: org.visibility ?? null,
+							},
+							changedFields: ["id", "name", "slug", "visibility"],
+							actorSource: "ui",
+							createdBy: user.id,
+						});
 						try {
-							recordWorkspaceChangeEvent({
-								organizationId: org.id,
-								resourceKind: "organization",
-								resourceId: org.id,
-								op: "created",
-								summary: `Organization "${org.name}" created`,
-								state: {
-									id: org.id,
-									name: org.name,
-									slug: org.slug,
-									visibility: org.visibility ?? null,
-								},
-								changedFields: ["id", "name", "slug", "visibility"],
-								actorSource: "ui",
-								createdBy: user.id,
-							});
 							if (org.visibility !== "private") return;
 							const sql = getDb();
 							const existing = await findExistingPersonalOrg(user.id, sql);
@@ -349,6 +352,27 @@ export async function createAuth(
 						}
 					},
 					afterAddMember: async ({ member, user, organization: org }) => {
+						// The member row is already committed when this hook fires.
+						// Emit the audit trail BEFORE the fallible $member projection so
+						// a projection failure cannot suppress the durable audit row.
+						// Better Auth does not expose the acting session user here —
+						// `user` is the added member (the subject), not the actor — so
+						// createdBy stays null rather than misattributing.
+						recordWorkspaceChangeEvent({
+							organizationId: org.id,
+							resourceKind: "member",
+							resourceId: member.id,
+							op: "created",
+							summary: `Member "${user.name || user.email}" added`,
+							state: {
+								id: member.id,
+								user_id: user.id,
+								role: member.role,
+								email: user.email ?? null,
+							},
+							changedFields: ["user_id", "role"],
+							actorSource: "ui",
+						});
 						try {
 							await ensureMemberEntity({
 								organizationId: org.id,
@@ -369,22 +393,6 @@ export async function createAuth(
 								entityId: member.id,
 								summary: `Member "${user.name || user.email}" added`,
 								extra: { user_id: user.id, role: member.role },
-							});
-							recordWorkspaceChangeEvent({
-								organizationId: org.id,
-								resourceKind: "member",
-								resourceId: member.id,
-								op: "created",
-								summary: `Member "${user.name || user.email}" added`,
-								state: {
-									id: member.id,
-									user_id: user.id,
-									role: member.role,
-									email: user.email ?? null,
-								},
-								changedFields: ["user_id", "role"],
-								actorSource: "ui",
-								createdBy: user.id,
 							});
 						} catch (err) {
 							// A swallow here is how projection drift enters: the member
@@ -410,6 +418,25 @@ export async function createAuth(
 						user,
 						organization: org,
 					}) => {
+						// The accepted member row is already committed. Audit first so
+						// the acceptance is never lost to a projection failure. `user`
+						// IS the actor here — the invitee accepting their own invite.
+						recordWorkspaceChangeEvent({
+							organizationId: org.id,
+							resourceKind: "member",
+							resourceId: member.id,
+							op: "created",
+							summary: `Member "${user.name || user.email}" joined`,
+							state: {
+								id: member.id,
+								user_id: user.id,
+								role: member.role,
+								email: user.email ?? null,
+							},
+							changedFields: ["user_id", "role"],
+							actorSource: "ui",
+							createdBy: user.id,
+						});
 						try {
 							// Update existing invited entity to active, or create if missing
 							await updateMemberEntityStatus(org.id, user.email, "active");
@@ -426,22 +453,6 @@ export async function createAuth(
 								"../workspace/multi-tenant"
 							);
 							invalidateMembershipRoleCache(org.id, user.id);
-							recordWorkspaceChangeEvent({
-								organizationId: org.id,
-								resourceKind: "member",
-								resourceId: member.id,
-								op: "created",
-								summary: `Member "${user.name || user.email}" joined`,
-								state: {
-									id: member.id,
-									user_id: user.id,
-									role: member.role,
-									email: user.email ?? null,
-								},
-								changedFields: ["user_id", "role"],
-								actorSource: "ui",
-								createdBy: user.id,
-							});
 						} catch (err) {
 							// See afterAddMember: a swallow here leaves the accepted
 							// member without a resolvable claim → enforced channels
@@ -458,7 +469,19 @@ export async function createAuth(
 							);
 						}
 					},
-					afterRemoveMember: async ({ user, organization: org }) => {
+					afterRemoveMember: async ({ member, user, organization: org }) => {
+						// The member row is already deleted when this hook fires. Audit
+						// first so the removal survives projection drift. `user` is the
+						// removed member (subject), not the acting session user.
+						recordWorkspaceChangeEvent({
+							organizationId: org.id,
+							resourceKind: "member",
+							resourceId: member.id,
+							op: "deleted",
+							summary: `Member "${user.name || user.email}" removed`,
+							state: null,
+							actorSource: "ui",
+						});
 						try {
 							await deleteMemberEntity(org.id, user.email);
 							recordLifecycleEvent({
@@ -467,16 +490,6 @@ export async function createAuth(
 								op: "deleted",
 								entityId: user.id,
 								summary: `Member "${user.name || user.email}" removed`,
-							});
-							recordWorkspaceChangeEvent({
-								organizationId: org.id,
-								resourceKind: "member",
-								resourceId: user.id,
-								op: "deleted",
-								summary: `Member "${user.name || user.email}" removed`,
-								state: null,
-								actorSource: "ui",
-								createdBy: user.id,
 							});
 							const { invalidateMembershipRoleCache } = await import(
 								"../workspace/multi-tenant"
@@ -494,6 +507,22 @@ export async function createAuth(
 						user,
 						organization: org,
 					}) => {
+						// The role change is already committed. Audit first; `user` is
+						// the affected member (subject), not the acting session user.
+						recordWorkspaceChangeEvent({
+							organizationId: org.id,
+							resourceKind: "member",
+							resourceId: member.id,
+							op: "updated",
+							summary: `Member "${user.name || user.email}" role set to ${member.role}`,
+							state: {
+								id: member.id,
+								user_id: user.id,
+								role: member.role,
+							},
+							changedFields: ["role"],
+							actorSource: "ui",
+						});
 						try {
 							await updateMemberEntityAccess(org.id, user.email, {
 								role: member.role,
@@ -503,21 +532,6 @@ export async function createAuth(
 								"../workspace/multi-tenant"
 							);
 							invalidateMembershipRoleCache(org.id, user.id);
-							recordWorkspaceChangeEvent({
-								organizationId: org.id,
-								resourceKind: "member",
-								resourceId: member.id,
-								op: "updated",
-								summary: `Member "${user.name || user.email}" role set to ${member.role}`,
-								state: {
-									id: member.id,
-									user_id: user.id,
-									role: member.role,
-								},
-								changedFields: ["role"],
-								actorSource: "ui",
-								createdBy: user.id,
-							});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to update $member entity after updateMemberRole:",
@@ -530,6 +544,25 @@ export async function createAuth(
 						inviter,
 						organization: org,
 					}) => {
+						// The invitation row is already committed. Audit first so an
+						// invitee-placeholder projection failure cannot lose the trail.
+						// `inviter` IS the acting session user.
+						recordWorkspaceChangeEvent({
+							organizationId: org.id,
+							resourceKind: "invitation",
+							resourceId: invitation.id,
+							op: "created",
+							summary: `Invitation sent to ${invitation.email}`,
+							state: {
+								id: invitation.id,
+								email: invitation.email,
+								role: invitation.role,
+								status: invitation.status ?? "pending",
+							},
+							changedFields: ["email", "role", "status"],
+							actorSource: "ui",
+							createdBy: inviter.id,
+						});
 						try {
 							// Create the invitee's placeholder $member keyed on the
 							// INVITED email. Attribute authorship to the inviter via
@@ -549,22 +582,6 @@ export async function createAuth(
 								role: invitation.role,
 								status: "invited",
 							});
-							recordWorkspaceChangeEvent({
-								organizationId: org.id,
-								resourceKind: "invitation",
-								resourceId: invitation.id,
-								op: "created",
-								summary: `Invitation sent to ${invitation.email}`,
-								state: {
-									id: invitation.id,
-									email: invitation.email,
-									role: invitation.role,
-									status: invitation.status ?? "pending",
-								},
-								changedFields: ["email", "role", "status"],
-								actorSource: "ui",
-								createdBy: inviter.id,
-							});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to create $member entity after createInvitation:",
@@ -573,17 +590,18 @@ export async function createAuth(
 						}
 					},
 					afterCancelInvitation: async ({ invitation, organization: org }) => {
+						// Cancellation is already committed. Audit first.
+						recordWorkspaceChangeEvent({
+							organizationId: org.id,
+							resourceKind: "invitation",
+							resourceId: invitation.id,
+							op: "deleted",
+							summary: `Invitation to ${invitation.email} cancelled`,
+							state: null,
+							actorSource: "ui",
+						});
 						try {
 							await deleteMemberEntity(org.id, invitation.email);
-							recordWorkspaceChangeEvent({
-								organizationId: org.id,
-								resourceKind: "invitation",
-								resourceId: invitation.id,
-								op: "deleted",
-								summary: `Invitation to ${invitation.email} cancelled`,
-								state: null,
-								actorSource: "ui",
-							});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to delete $member entity after cancelInvitation:",
@@ -592,17 +610,18 @@ export async function createAuth(
 						}
 					},
 					afterRejectInvitation: async ({ invitation, organization: org }) => {
+						// Rejection is already committed. Audit first.
+						recordWorkspaceChangeEvent({
+							organizationId: org.id,
+							resourceKind: "invitation",
+							resourceId: invitation.id,
+							op: "deleted",
+							summary: `Invitation to ${invitation.email} rejected`,
+							state: null,
+							actorSource: "ui",
+						});
 						try {
 							await deleteMemberEntity(org.id, invitation.email);
-							recordWorkspaceChangeEvent({
-								organizationId: org.id,
-								resourceKind: "invitation",
-								resourceId: invitation.id,
-								op: "deleted",
-								summary: `Invitation to ${invitation.email} rejected`,
-								state: null,
-								actorSource: "ui",
-							});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to delete $member entity after rejectInvitation:",

--- a/packages/server/src/auth/personal-org-provisioning.ts
+++ b/packages/server/src/auth/personal-org-provisioning.ts
@@ -10,6 +10,7 @@
 import { slugify as slugifyBase } from "@lobu/core";
 import { getDb } from "../db/client";
 import { RESERVED_PATHS_SET } from "../utils/reserved";
+import { recordWorkspaceChangeEvent } from "../utils/insert-event";
 import { generateSecureToken } from "./oauth/utils";
 import { provisionMemberAndCoreIdentities } from "./subject-identities";
 import logger from "../utils/logger";
@@ -74,6 +75,9 @@ interface EnsureResult {
 	organizationId: string;
 	slug: string;
 	created: boolean;
+	/** Audit fields — populated only when `created` is true. */
+	memberId?: string;
+	orgName?: string;
 }
 
 export function personalOrgLockKey(userId: string): number {
@@ -150,7 +154,7 @@ export async function ensurePersonalOrganization(
       VALUES (${memberId}, ${user.id}, ${orgId}, 'owner', NOW())
     `;
 
-		result = { organizationId: orgId, slug, created: true };
+		result = { organizationId: orgId, slug, created: true, memberId, orgName };
 	});
 
 	const finalResult = result as EnsureResult | null;
@@ -158,6 +162,43 @@ export async function ensurePersonalOrganization(
 		throw new Error(
 			"Personal organization transaction did not produce a result",
 		);
+	}
+
+	// Org + owner membership audit trail (workspace category: appears in All
+	// activity, not the Deployments feed). Emitted AFTER the transaction
+	// commits — the events FK references the organization row, so the insert
+	// must not race the commit.
+	if (finalResult.created) {
+		const orgState = {
+			id: finalResult.organizationId,
+			name: finalResult.orgName ?? null,
+			slug: finalResult.slug,
+			visibility: 'private',
+		};
+		recordWorkspaceChangeEvent({
+			organizationId: finalResult.organizationId,
+			resourceKind: 'organization',
+			resourceId: finalResult.organizationId,
+			op: 'created',
+			summary: `Organization "${finalResult.orgName ?? finalResult.slug}" created`,
+			state: orgState,
+			changedFields: ['id', 'name', 'slug', 'visibility'],
+			actorSource: 'ui',
+			createdBy: user.id,
+		});
+		if (finalResult.memberId) {
+			recordWorkspaceChangeEvent({
+				organizationId: finalResult.organizationId,
+				resourceKind: 'member',
+				resourceId: finalResult.memberId,
+				op: 'created',
+				summary: `Member "${user.name || user.email}" joined as owner`,
+				state: { id: finalResult.memberId, user_id: user.id, role: 'owner' },
+				changedFields: ['user_id', 'role'],
+				actorSource: 'ui',
+				createdBy: user.id,
+			});
+		}
 	}
 
 	// Mirror the personal org slug onto the user's username when unset. The

--- a/packages/server/src/auth/personal-org-provisioning.ts
+++ b/packages/server/src/auth/personal-org-provisioning.ts
@@ -197,7 +197,7 @@ export async function ensurePersonalOrganization(
 			resourceKind: 'member',
 			resourceId: finalResult.memberId,
 			op: 'created',
-			summary: `Member "${user.name || user.email}" joined as owner`,
+			summary: `Member "${user.name || 'the owner'}" joined as owner`,
 			state: { id: finalResult.memberId, user_id: user.id, role: 'owner' },
 			changedFields: ['user_id', 'role'],
 			actorSource: 'ui',

--- a/packages/server/src/auth/personal-org-provisioning.ts
+++ b/packages/server/src/auth/personal-org-provisioning.ts
@@ -71,14 +71,20 @@ async function findAvailableSlug(base: string, sql: Sql): Promise<string> {
 		.replace(/[^a-z0-9]/g, "")}`;
 }
 
-interface EnsureResult {
-	organizationId: string;
-	slug: string;
-	created: boolean;
-	/** Audit fields — populated only when `created` is true. */
-	memberId?: string;
-	orgName?: string;
-}
+type EnsureResult =
+	| {
+			organizationId: string;
+			slug: string;
+			created: false;
+	  }
+	| {
+			organizationId: string;
+			slug: string;
+			created: true;
+			/** Audit fields — populated only on the created branch. */
+			memberId: string;
+			orgName: string;
+	  };
 
 export function personalOrgLockKey(userId: string): number {
 	let hash = 0x811c9dc5;
@@ -171,7 +177,7 @@ export async function ensurePersonalOrganization(
 	if (finalResult.created) {
 		const orgState = {
 			id: finalResult.organizationId,
-			name: finalResult.orgName ?? null,
+			name: finalResult.orgName,
 			slug: finalResult.slug,
 			visibility: 'private',
 		};
@@ -180,25 +186,23 @@ export async function ensurePersonalOrganization(
 			resourceKind: 'organization',
 			resourceId: finalResult.organizationId,
 			op: 'created',
-			summary: `Organization "${finalResult.orgName ?? finalResult.slug}" created`,
+			summary: `Organization "${finalResult.orgName}" created`,
 			state: orgState,
 			changedFields: ['id', 'name', 'slug', 'visibility'],
 			actorSource: 'ui',
 			createdBy: user.id,
 		});
-		if (finalResult.memberId) {
-			recordWorkspaceChangeEvent({
-				organizationId: finalResult.organizationId,
-				resourceKind: 'member',
-				resourceId: finalResult.memberId,
-				op: 'created',
-				summary: `Member "${user.name || user.email}" joined as owner`,
-				state: { id: finalResult.memberId, user_id: user.id, role: 'owner' },
-				changedFields: ['user_id', 'role'],
-				actorSource: 'ui',
-				createdBy: user.id,
-			});
-		}
+		recordWorkspaceChangeEvent({
+			organizationId: finalResult.organizationId,
+			resourceKind: 'member',
+			resourceId: finalResult.memberId,
+			op: 'created',
+			summary: `Member "${user.name || user.email}" joined as owner`,
+			state: { id: finalResult.memberId, user_id: user.id, role: 'owner' },
+			changedFields: ['user_id', 'role'],
+			actorSource: 'ui',
+			createdBy: user.id,
+		});
 	}
 
 	// Mirror the personal org slug onto the user's username when unset. The

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -97,7 +97,8 @@ function recentDisplayTitle(
   return "(untitled)";
 }
 
-async function resolveSlackHomeContext(
+/** Exported for workspace-audit visibility tests (Slack Home has no member role). */
+export async function resolveSlackHomeContext(
   organizationId: string,
 ): Promise<SlackHomeContext | null> {
   try {
@@ -111,11 +112,17 @@ async function resolveSlackHomeContext(
             AS entities_tracked,
           (SELECT count(*) FROM events
              WHERE organization_id = ${organizationId}
-               AND created_at >= date_trunc('day', now()))
+               AND created_at >= date_trunc('day', now())
+               -- Owner/admin-only workspace-identity audit rows (member /
+               -- invitation lifecycle). Slack App Home is shown to any
+               -- workspace-linked Slack user, so never count them here.
+               AND NOT (metadata ? '_lobu_workspace_audit'))
             AS captured_today
       `,
       // Mirrors the web "recent" feed (resolve_path.ts fetchRecentContent):
       // supersession-masked, internal corrections excluded, newest first.
+      // Also excludes server-owned workspace audit rows — same boundary as
+      // ordinary-member resolve_path bootstrap (not owner/admin).
       db`
         SELECT
           ev.title,
@@ -126,6 +133,7 @@ async function resolveSlackHomeContext(
         LEFT JOIN connections cn ON cn.id = ev.connection_id
         WHERE ev.organization_id = ${organizationId}
           AND ev.semantic_type <> 'correction'
+          AND NOT (ev.metadata ? '_lobu_workspace_audit')
         ORDER BY COALESCE(ev.occurred_at, ev.created_at) DESC
         LIMIT ${SLACK_HOME_RECENT_LIMIT}
       `,

--- a/packages/server/src/metrics/run-metric.ts
+++ b/packages/server/src/metrics/run-metric.ts
@@ -32,6 +32,12 @@ interface RunMetricInput {
    * jobs) — yields org-visible-only, fail-closed for private-connection data.
    */
   userId?: string | null;
+  /**
+   * Exclude workspace-identity audit events from the events CTE. Owner/admin
+   * and trusted system callers leave this false; ordinary members / public
+   * readers must set true so member/invitation lifecycle cannot move metrics.
+   */
+  excludeWorkspaceAudit?: boolean;
 }
 
 export async function runMetric(input: RunMetricInput): Promise<Record<string, unknown>[]> {
@@ -60,6 +66,7 @@ export async function runMetric(input: RunMetricInput): Promise<Record<string, u
   });
   const scoped = validateAndScopeQuery(rawSql, input.organizationId, {
     userId: input.userId ?? null,
+    excludeWorkspaceAudit: input.excludeWorkspaceAudit,
   });
 
   const rows = await sql.begin(async (tx: typeof sql) => {

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Env } from "../index";
-import { isAdminOrOwnerRole, isSystemContext } from "../tools/access-control";
+import { isAdminOrOwnerRole, isInProcessSystemCall, isSystemContext } from "../tools/access-control";
 import {
 	ADMIN_ONLY_QUERYABLE_TABLES,
 	SAFE_COLUMN_DEFS,
@@ -253,7 +253,7 @@ export function buildClientSDK(
 						: ADMIN_ONLY_QUERYABLE_TABLES,
 				// Workspace-identity audit rows are owner/admin-only; ordinary
 				// members running client.query must not surface them.
-				excludeWorkspaceAudit: !isSystemContext(ctx) && !isAdmin,
+				excludeWorkspaceAudit: !isInProcessSystemCall(ctx) && !isAdmin,
 			});
 			// Outer LIMIT caps rows at the source so a broad SELECT can't
 			// materialize an unbounded result set host-side.

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -251,6 +251,9 @@ export function buildClientSDK(
 					isSystemContext(ctx) || isAdmin
 						? undefined
 						: ADMIN_ONLY_QUERYABLE_TABLES,
+				// Workspace-identity audit rows are owner/admin-only; ordinary
+				// members running client.query must not surface them.
+				excludeWorkspaceAudit: !isSystemContext(ctx) && !isAdmin,
 			});
 			// Outer LIMIT caps rows at the source so a broad SELECT can't
 			// materialize an unbounded result set host-side.

--- a/packages/server/src/tools/access-control.ts
+++ b/packages/server/src/tools/access-control.ts
@@ -13,15 +13,32 @@ interface AccessControlContext {
   isAuthenticated: boolean;
   userId: string | null;
   memberRole: string | null;
+  /** Present on ToolContext; used to distinguish in-process system calls from tokens. */
+  tokenType?: string | null;
 }
 
 /**
  * Watcher reactions and other in-process system calls run with
  * `userId=null + isAuthenticated=true` and no member role. They bypass
  * role/scope policy checks at the handler boundary.
+ *
+ * Do NOT use this alone as a data-exposure boundary for owner/admin-only
+ * rows — see {@link isInProcessSystemCall}.
  */
 export function isSystemContext(ctx: AccessControlContext): boolean {
   return ctx.isAuthenticated === true && ctx.userId === null && ctx.memberRole === null;
+}
+
+/**
+ * True for a trusted in-process system call (watcher reaction and friends),
+ * which run with `userId: null` + `isAuthenticated: true` + `tokenType: 'session'`.
+ *
+ * `isSystemContext` alone also matches a userless OAuth/PAT token admitted to a
+ * public org (memberRole null). Requiring `tokenType === 'session'` excludes
+ * token callers while keeping reaction/system sessions.
+ */
+export function isInProcessSystemCall(ctx: AccessControlContext): boolean {
+  return isSystemContext(ctx) && ctx.tokenType === 'session';
 }
 
 /** True when the role grants admin-tier access (owner or admin). */

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -27,7 +27,7 @@ import {
   type DataSourceInput,
   executeDataSources,
 } from '../../utils/execute-data-sources';
-import { isAdminOrOwnerRole, isSystemContext } from '../access-control';
+import { isAdminOrOwnerRole, isInProcessSystemCall } from '../access-control';
 import { measureColumns } from '../../utils/infer-measures';
 import type { Env } from '../../index';
 import logger from '../../utils/logger';
@@ -434,7 +434,7 @@ async function etHandleGet(
     mapped.slug,
     ctx.organizationId,
     ctx.userId,
-    !isSystemContext(ctx) && !isAdminOrOwnerRole(ctx.memberRole)
+    !isInProcessSystemCall(ctx) && !isAdminOrOwnerRole(ctx.memberRole)
   );
 
   return { schema_type: 'entity_type', action: 'get', entity_type: mapped };

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -27,6 +27,7 @@ import {
   type DataSourceInput,
   executeDataSources,
 } from '../../utils/execute-data-sources';
+import { isAdminOrOwnerRole, isSystemContext } from '../access-control';
 import { measureColumns } from '../../utils/infer-measures';
 import type { Env } from '../../index';
 import logger from '../../utils/logger';
@@ -317,7 +318,9 @@ async function fetchTypeViewTemplates(
   // fetchTabs('entity_type', entityRow.entity_type)), NOT the numeric id.
   entityTypeSlug: string,
   organizationId: string,
-  userId: string | null
+  userId: string | null,
+  /** Exclude workspace-identity audit rows for ordinary-member / public reads. */
+  excludeWorkspaceAudit: boolean
 ): Promise<ViewTemplateTab[]> {
   const rows = await sql`
     SELECT
@@ -346,7 +349,9 @@ async function fetchTypeViewTemplates(
         const { data_sources: _dropped, ...rest } = jsonTemplate;
         cleanTemplate = rest;
         try {
-          templateData = await executeDataSources(dataSources, context, sql);
+          templateData = await executeDataSources(dataSources, context, sql, {
+            excludeWorkspaceAudit,
+          });
         } catch (err) {
           logger.warn(
             { err, tab: String(row.tab_name), entityTypeSlug },
@@ -422,11 +427,14 @@ async function etHandleGet(
   // Classify the view's measure columns on read (never persisted).
   if (mapped.backing_sql) mapped.measure_columns = measureColumns(mapped.backing_sql);
   // Authored type-level list-view templates, with their data_sources run live.
+  // Workspace-identity audit rows are owner/admin/system-only; type templates
+  // are org-scoped (no entityIds) so an events SELECT would otherwise leak them.
   mapped.view_templates = await fetchTypeViewTemplates(
     sql,
     mapped.slug,
     ctx.organizationId,
-    ctx.userId
+    ctx.userId,
+    !isSystemContext(ctx) && !isAdminOrOwnerRole(ctx.memberRole)
   );
 
   return { schema_type: 'entity_type', action: 'get', entity_type: mapped };

--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -31,7 +31,7 @@ import { ToolUserError } from '../../utils/errors';
 import logger from '../../utils/logger';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
-import { isAdminOrOwnerRole } from '../access-control';
+import { isAdminOrOwnerRole, isSystemContext } from '../access-control';
 
 export const MetricSeriesSchema = Type.Object({
   sql: Type.String({
@@ -177,9 +177,9 @@ async function metricSeriesImpl(
     // Charts are filtered to the requesting user's connection visibility, so a
     // member can't sparkline another user's private-connection events.
     userId: ctx.userId,
-    // Workspace-identity audit rows are owner/admin-only; ordinary members
-    // must not chart member/invitation lifecycle data via raw SQL.
-    excludeWorkspaceAudit: !isAdmin,
+    // Workspace-identity audit rows are owner/admin/system-only; ordinary
+    // members must not chart member/invitation lifecycle data via raw SQL.
+    excludeWorkspaceAudit: !isSystemContext(ctx) && !isAdmin,
   });
   const db = getDb();
 

--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -177,6 +177,9 @@ async function metricSeriesImpl(
     // Charts are filtered to the requesting user's connection visibility, so a
     // member can't sparkline another user's private-connection events.
     userId: ctx.userId,
+    // Workspace-identity audit rows are owner/admin-only; ordinary members
+    // must not chart member/invitation lifecycle data via raw SQL.
+    excludeWorkspaceAudit: !isAdmin,
   });
   const db = getDb();
 

--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -31,7 +31,7 @@ import { ToolUserError } from '../../utils/errors';
 import logger from '../../utils/logger';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
-import { isAdminOrOwnerRole, isSystemContext } from '../access-control';
+import { isAdminOrOwnerRole, isInProcessSystemCall } from '../access-control';
 
 export const MetricSeriesSchema = Type.Object({
   sql: Type.String({
@@ -179,7 +179,7 @@ async function metricSeriesImpl(
     userId: ctx.userId,
     // Workspace-identity audit rows are owner/admin/system-only; ordinary
     // members must not chart member/invitation lifecycle data via raw SQL.
-    excludeWorkspaceAudit: !isSystemContext(ctx) && !isAdmin,
+    excludeWorkspaceAudit: !isInProcessSystemCall(ctx) && !isAdmin,
   });
   const db = getDb();
 

--- a/packages/server/src/tools/admin/query_metric.ts
+++ b/packages/server/src/tools/admin/query_metric.ts
@@ -13,7 +13,7 @@
 import { type Static, Type } from '@sinclair/typebox';
 import type { Env } from '../../index';
 import { runMetric } from '../../metrics/run-metric';
-import { isAdminOrOwnerRole, isSystemContext } from '../access-control';
+import { isAdminOrOwnerRole, isInProcessSystemCall } from '../access-control';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 
@@ -55,7 +55,7 @@ async function queryMetricImpl(
     userId: ctx.userId,
     // Workspace-identity audit rows are owner/admin/system-only; ordinary
     // members must not move a declared metric by counting lifecycle events.
-    excludeWorkspaceAudit: !isSystemContext(ctx) && !isAdminOrOwnerRole(ctx.memberRole),
+    excludeWorkspaceAudit: !isInProcessSystemCall(ctx) && !isAdminOrOwnerRole(ctx.memberRole),
   });
   return { rows, row_count: rows.length };
 }

--- a/packages/server/src/tools/admin/query_metric.ts
+++ b/packages/server/src/tools/admin/query_metric.ts
@@ -13,6 +13,7 @@
 import { type Static, Type } from '@sinclair/typebox';
 import type { Env } from '../../index';
 import { runMetric } from '../../metrics/run-metric';
+import { isAdminOrOwnerRole, isSystemContext } from '../access-control';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 
@@ -52,6 +53,9 @@ async function queryMetricImpl(
     segment: args.segment,
     entityId: args.entity_id,
     userId: ctx.userId,
+    // Workspace-identity audit rows are owner/admin/system-only; ordinary
+    // members must not move a declared metric by counting lifecycle events.
+    excludeWorkspaceAudit: !isSystemContext(ctx) && !isAdminOrOwnerRole(ctx.memberRole),
   });
   return { rows, row_count: rows.length };
 }

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -559,6 +559,9 @@ export async function querySqlImpl(
       // PRIVATE-connection events only when org-visible. Cross-org reuses the
       // same global user id, re-validated against the target org above.
       userId: ctx.userId,
+      // Workspace-identity audit rows are owner/admin-only; ordinary members
+      // must not select their member/invitation lifecycle data via raw SQL.
+      excludeWorkspaceAudit: !callerIsAdmin,
     });
     scopedSql = scoped.sql;
     params = scoped.params;

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -19,7 +19,7 @@ import { getCachedMembershipRole, getCachedOrgBySlug } from '../../workspace/mul
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 import { SortOrderField } from './schemas/common-fields';
-import { isAdminOrOwnerRole } from '../access-control';
+import { isAdminOrOwnerRole, isSystemContext } from '../access-control';
 import { classifyToolError, getErrorMessage, isRetryable, type ToolErrorCode } from "@lobu/core";
 import { ToolUserError } from '../../utils/errors';
 
@@ -559,9 +559,9 @@ export async function querySqlImpl(
       // PRIVATE-connection events only when org-visible. Cross-org reuses the
       // same global user id, re-validated against the target org above.
       userId: ctx.userId,
-      // Workspace-identity audit rows are owner/admin-only; ordinary members
-      // must not select their member/invitation lifecycle data via raw SQL.
-      excludeWorkspaceAudit: !callerIsAdmin,
+      // Workspace-identity audit rows are owner/admin/system-only; ordinary
+      // members must not select their member/invitation lifecycle data via raw SQL.
+      excludeWorkspaceAudit: !isSystemContext(ctx) && !callerIsAdmin,
     });
     scopedSql = scoped.sql;
     params = scoped.params;

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -19,7 +19,7 @@ import { getCachedMembershipRole, getCachedOrgBySlug } from '../../workspace/mul
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 import { SortOrderField } from './schemas/common-fields';
-import { isAdminOrOwnerRole, isSystemContext } from '../access-control';
+import { isAdminOrOwnerRole, isInProcessSystemCall } from '../access-control';
 import { classifyToolError, getErrorMessage, isRetryable, type ToolErrorCode } from "@lobu/core";
 import { ToolUserError } from '../../utils/errors';
 
@@ -561,7 +561,7 @@ export async function querySqlImpl(
       userId: ctx.userId,
       // Workspace-identity audit rows are owner/admin/system-only; ordinary
       // members must not select their member/invitation lifecycle data via raw SQL.
-      excludeWorkspaceAudit: !isSystemContext(ctx) && !callerIsAdmin,
+      excludeWorkspaceAudit: !isInProcessSystemCall(ctx) && !callerIsAdmin,
     });
     scopedSql = scoped.sql;
     params = scoped.params;

--- a/packages/server/src/tools/get_content/behavior-mode.ts
+++ b/packages/server/src/tools/get_content/behavior-mode.ts
@@ -187,6 +187,7 @@ async function queryContentData(
           entityType: source.ref.entityType,
           measure: source.ref.measure,
           userId: params.userId,
+          excludeWorkspaceAudit: params.excludeWorkspaceAudit,
         });
       } catch (err) {
 		if (params.throwOnSourceError) throw err;

--- a/packages/server/src/tools/get_content/behavior-mode.ts
+++ b/packages/server/src/tools/get_content/behavior-mode.ts
@@ -62,6 +62,8 @@ interface ContentQueryParams {
    */
   behaviorId: number;
 	throwOnSourceError?: boolean;
+  /** Exclude workspace-identity audit rows for ordinary-member reads. */
+  excludeWorkspaceAudit?: boolean;
   page?: {
     sourceName: string;
     limit: number;
@@ -120,6 +122,7 @@ async function queryContentData(
 
   const results = await executeDataSources(sqlSources, queryContext, sql, {
     throwOnError: params.throwOnSourceError,
+    excludeWorkspaceAudit: params.excludeWorkspaceAudit,
     wrapQuery: page
       ? (scopedQuery, queryParams, sourceName) => {
           const isEventSource = eventSourceNames.has(sourceName);
@@ -414,6 +417,8 @@ export async function handleBehaviorMode(
     organizationId: string;
     /** Verified caller, or null when the read is a headless Behavior run. */
     userId: string | null;
+    /** Exclude workspace-identity audit rows for ordinary-member reads. */
+    excludeWorkspaceAudit?: boolean;
   }
 ): Promise<GetContentResult> {
   const { generateWindowToken } = await import('../../utils/jwt');
@@ -597,6 +602,7 @@ export async function handleBehaviorMode(
       ? { [triggerInputSourceName]: triggerContentIds.length }
       : undefined,
     behaviorId: Number(watcher.id),
+    excludeWorkspaceAudit: context.excludeWorkspaceAudit,
     page: {
       sourceName: 'content',
       limit: contentLimit,

--- a/packages/server/src/tools/get_content/behavior-mode.ts
+++ b/packages/server/src/tools/get_content/behavior-mode.ts
@@ -224,7 +224,11 @@ async function queryContentData(
         query: `SELECT COUNT(*)::int AS c, COALESCE(SUM(LENGTH(to_jsonb(${alias})->>'payload_text')), 0)::bigint AS ch FROM (${source.query}) AS ${alias}`,
       };
     });
-    const statsResults = await executeDataSources(statsSources, queryContext, sql, {});
+    const statsResults = await executeDataSources(statsSources, queryContext, sql, {
+      // Totals must respect the same workspace-audit boundary as the returned
+      // rows, else an ordinary member infers audit rows from the count.
+      excludeWorkspaceAudit: params.excludeWorkspaceAudit,
+    });
     for (const rows of Object.values(statsResults)) {
       const row = rows[0] as { c?: number; ch?: string | number } | undefined;
       if (row) {

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -12,6 +12,7 @@ import {
   resolveActingPrincipal,
 } from '../../authz/entity-policy';
 import { hasRequiredMcpScope } from '../../auth/tool-access';
+import { isSystemContext } from '../../tools/access-control';
 import { createDbClientFromEnv, getDb, pgBigintArray } from '../../db/client';
 import { BEHAVIOR_RUN_SOURCE } from '../../gateway/behavior-run-session';
 import { parseBehaviorRunConversationId } from '../../gateway/permissions/behavior-run-intent';
@@ -156,6 +157,13 @@ async function getContentImpl(
   if (isMcpTokenCaller && !hasRequiredMcpScope('read', ctx.scopes)) {
     throw new ToolUserError('read_knowledge requires an MCP session with read access.', 403);
   }
+
+  // Workspace-identity audit events carry member emails / invitation details.
+  // Exclude them for every non-member caller (anonymous AND signed-in
+  // outsiders of a public workspace), but NOT for in-process system contexts
+  // (behavior runs: userId=null, isAuthenticated=true) which are trusted.
+  const excludeWorkspaceAudit =
+    ctx.memberRole === null && !isSystemContext(ctx);
 
   // Dual client: PG for auth, PG for data
   const pgSql = createDbClientFromEnv(env);
@@ -484,7 +492,7 @@ async function getContentImpl(
         sql,
         organizationId: ctx.organizationId,
         visibilityScope,
-        excludeWorkspaceAudit: ctx.isAuthenticated === false,
+        excludeWorkspaceAudit,
         limit,
         offset,
       }));
@@ -500,7 +508,7 @@ async function getContentImpl(
         untilDate,
         visibilityScope,
         mcpSessionIds,
-        excludeWorkspaceAudit: ctx.isAuthenticated === false,
+        excludeWorkspaceAudit,
         limit,
         offset,
       }));
@@ -533,7 +541,7 @@ async function getContentImpl(
         ...(args.classification_source && { classification_source: args.classification_source }),
         ...(args.semantic_type && { semantic_type: args.semantic_type }),
         ...(args.interaction_status && { interaction_status: args.interaction_status }),
-        ...(ctx.isAuthenticated === false && {
+        ...(excludeWorkspaceAudit && {
           exclude_workspace_audit: true,
         }),
         visibility_scope: visibilityScope,
@@ -582,7 +590,7 @@ async function getContentImpl(
         interaction_status: args.interaction_status,
         // Workspace-identity audit events carry member emails / invitation
         // details; anonymous public-workspace readers must never retrieve them.
-        ...(ctx.isAuthenticated === false && {
+        ...(excludeWorkspaceAudit && {
           exclude_workspace_audit: true,
         }),
         limit,

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -159,11 +159,14 @@ async function getContentImpl(
   }
 
   // Workspace-identity audit events carry member emails / invitation details.
-  // Exclude them for every non-member caller (anonymous AND signed-in
-  // outsiders of a public workspace), but NOT for in-process system contexts
-  // (behavior runs: userId=null, isAuthenticated=true) which are trusted.
+  // Exclude them for everyone EXCEPT owners/admins and trusted in-process
+  // system contexts (behavior runs: userId=null, isAuthenticated=true).
+  // Ordinary members do not see another member's invitation PII — the $member
+  // read policy reserves that for owner/admin.
   const excludeWorkspaceAudit =
-    ctx.memberRole === null && !isSystemContext(ctx);
+    ctx.memberRole !== 'owner' &&
+    ctx.memberRole !== 'admin' &&
+    !isSystemContext(ctx);
 
   // Dual client: PG for auth, PG for data
   const pgSql = createDbClientFromEnv(env);

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -158,11 +158,11 @@ async function getContentImpl(
     throw new ToolUserError('read_knowledge requires an MCP session with read access.', 403);
   }
 
-  // Workspace-identity audit events carry member emails / invitation details.
-  // Exclude them for everyone EXCEPT owners/admins and trusted in-process
-  // system contexts (behavior runs: userId=null, isAuthenticated=true).
-  // Ordinary members do not see another member's invitation PII — the $member
-  // read policy reserves that for owner/admin.
+  // Workspace-identity audit events record member/invitation lifecycle
+  // (titles, member names, invitation status). Exclude them for everyone
+  // EXCEPT owners/admins and trusted in-process system contexts (behavior
+  // runs: userId=null, isAuthenticated=true) — the $member read policy
+  // reserves that lifecycle data for owner/admin.
   const excludeWorkspaceAudit =
     ctx.memberRole !== 'owner' &&
     ctx.memberRole !== 'admin' &&

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -531,6 +531,9 @@ async function getContentImpl(
         ...(args.classification_source && { classification_source: args.classification_source }),
         ...(args.semantic_type && { semantic_type: args.semantic_type }),
         ...(args.interaction_status && { interaction_status: args.interaction_status }),
+        ...(ctx.isAuthenticated === false && {
+          exclude_workspace_audit: true,
+        }),
         visibility_scope: visibilityScope,
       };
 
@@ -575,6 +578,11 @@ async function getContentImpl(
         semantic_type: args.semantic_type,
         entity_types: args.entity_types,
         interaction_status: args.interaction_status,
+        // Workspace-identity audit events carry member emails / invitation
+        // details; anonymous public-workspace readers must never retrieve them.
+        ...(ctx.isAuthenticated === false && {
+          exclude_workspace_audit: true,
+        }),
         limit,
         offset,
         // When a query is provided and no explicit sort_by, rank by combined_score

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -307,6 +307,17 @@ async function getContentImpl(
   try {
     // If behavior_id is provided, use behavior mode: fetch content for all sources and generate window_token
     if (args.behavior_id) {
+      // Behavior mode executes the Behavior's authored SQL sources (which may
+      // include `events` reads). Non-members of a public workspace have no
+      // legitimate reason to run another Behavior's source read, and doing so
+      // could surface workspace-identity audit rows. Deny rather than filter —
+      // this is an agent-execution path, not a public browse surface.
+      if (excludeWorkspaceAudit) {
+        throw new ToolUserError(
+          'Behavior read mode requires workspace membership.',
+          403
+        );
+      }
       return await handleBehaviorMode(args, env, sql, {
         organizationId: ctx.organizationId,
         // Interactive reads keep the caller's private-connection scope.

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -484,6 +484,7 @@ async function getContentImpl(
         sql,
         organizationId: ctx.organizationId,
         visibilityScope,
+        excludeWorkspaceAudit: ctx.isAuthenticated === false,
         limit,
         offset,
       }));
@@ -499,6 +500,7 @@ async function getContentImpl(
         untilDate,
         visibilityScope,
         mcpSessionIds,
+        excludeWorkspaceAudit: ctx.isAuthenticated === false,
         limit,
         offset,
       }));

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -699,6 +699,7 @@ async function getContentImpl(
         untilDate,
         visibilityScope,
         mcpSessionIds,
+        excludeWorkspaceAudit,
       });
     }
 

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -12,7 +12,7 @@ import {
   resolveActingPrincipal,
 } from '../../authz/entity-policy';
 import { hasRequiredMcpScope } from '../../auth/tool-access';
-import { isSystemContext } from '../../tools/access-control';
+import { isInProcessSystemCall } from '../../tools/access-control';
 import { createDbClientFromEnv, getDb, pgBigintArray } from '../../db/client';
 import { BEHAVIOR_RUN_SOURCE } from '../../gateway/behavior-run-session';
 import { parseBehaviorRunConversationId } from '../../gateway/permissions/behavior-run-intent';
@@ -166,7 +166,7 @@ async function getContentImpl(
   const excludeWorkspaceAudit =
     ctx.memberRole !== 'owner' &&
     ctx.memberRole !== 'admin' &&
-    !isSystemContext(ctx);
+    !isInProcessSystemCall(ctx);
 
   // Dual client: PG for auth, PG for data
   const pgSql = createDbClientFromEnv(env);
@@ -315,7 +315,7 @@ async function getContentImpl(
       // have no legitimate reason to run another Behavior's source read —
       // deny them outright. Ordinary members may read, but must not receive
       // workspace-audit rows (handled inside behavior mode).
-      if (ctx.memberRole === null && !isSystemContext(ctx)) {
+      if (ctx.memberRole === null && !isInProcessSystemCall(ctx)) {
         throw new ToolUserError(
           'Behavior read mode requires workspace membership.',
           403

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -311,11 +311,11 @@ async function getContentImpl(
     // If behavior_id is provided, use behavior mode: fetch content for all sources and generate window_token
     if (args.behavior_id) {
       // Behavior mode executes the Behavior's authored SQL sources (which may
-      // include `events` reads). Non-members of a public workspace have no
-      // legitimate reason to run another Behavior's source read, and doing so
-      // could surface workspace-identity audit rows. Deny rather than filter —
-      // this is an agent-execution path, not a public browse surface.
-      if (excludeWorkspaceAudit) {
+      // include `events` reads). Callers with NO membership in this workspace
+      // have no legitimate reason to run another Behavior's source read —
+      // deny them outright. Ordinary members may read, but must not receive
+      // workspace-audit rows (handled inside behavior mode).
+      if (ctx.memberRole === null && !isSystemContext(ctx)) {
         throw new ToolUserError(
           'Behavior read mode requires workspace membership.',
           403
@@ -329,6 +329,7 @@ async function getContentImpl(
         // otherwise a same-org worker could pass another Behavior's id and
         // inherit that author's private feeds.
         userId: resolveBehaviorVisibilityUserId(ctx, args.behavior_id),
+        excludeWorkspaceAudit,
       });
     }
 

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -259,7 +259,7 @@ export async function fetchByContentIds(opts: {
 
   const where = `${idFilter} ${orgScope}${entityFilter} ${visibility.sql}${
     excludeWorkspaceAudit
-      ? ` AND (f.metadata->>'category') IS DISTINCT FROM 'workspace'`
+      ? ` AND NOT (f.metadata ? '_lobu_workspace_audit')`
       : ''
   }`;
 
@@ -486,7 +486,7 @@ export async function fetchIncludeSuperseded(opts: {
     paramIndex += 1;
   }
   if (excludeWorkspaceAudit) {
-    conditions.push(`(e.metadata->>'category') IS DISTINCT FROM 'workspace'`);
+    conditions.push(`NOT (e.metadata ? '_lobu_workspace_audit')`);
   }
 
   // Visibility: events from connections the caller can't see drop out.
@@ -582,7 +582,7 @@ export async function fetchClassificationStats(opts: {
   let paramIndex = 1;
 
   if (excludeWorkspaceAudit) {
-    conditions.push(`(f.metadata->>'category') IS DISTINCT FROM 'workspace'`);
+    conditions.push(`NOT (f.metadata ? '_lobu_workspace_audit')`);
   }
 
   if (args.entity_id) {

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -562,6 +562,7 @@ export async function fetchClassificationStats(opts: {
   untilDate: Date | null;
   visibilityScope: VisibilityScope;
   mcpSessionIds: string[] | undefined;
+  excludeWorkspaceAudit?: boolean;
 }): Promise<NonNullable<GetContentResult['classification_stats']>> {
   const {
     args,
@@ -572,12 +573,17 @@ export async function fetchClassificationStats(opts: {
     untilDate,
     visibilityScope,
     mcpSessionIds,
+    excludeWorkspaceAudit,
   } = opts;
 
   // Build dynamic WHERE conditions using inline SQL
   const conditions: string[] = ['1=1'];
   const params: Array<string | number | null> = [];
   let paramIndex = 1;
+
+  if (excludeWorkspaceAudit) {
+    conditions.push(`(f.metadata->>'category') IS DISTINCT FROM 'workspace'`);
+  }
 
   if (args.entity_id) {
     // Use the trimmed UNION here too so the stats CTE doesn't pay for

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -209,10 +209,11 @@ export async function fetchByContentIds(opts: {
   sql: DbClient;
   organizationId: string;
   visibilityScope: VisibilityScope;
+  excludeWorkspaceAudit?: boolean;
   limit: number;
   offset: number;
 }): Promise<ListPageResult> {
-  const { args, sql, organizationId, visibilityScope, limit, offset } = opts;
+  const { args, sql, organizationId, visibilityScope, excludeWorkspaceAudit, limit, offset } = opts;
 
   // typebox validates content_ids as number[] at the tool boundary; the
   // caller only dispatches here when it is non-empty.
@@ -256,7 +257,11 @@ export async function fetchByContentIds(opts: {
   });
   queryParams.push(...visibility.params);
 
-  const where = `${idFilter} ${orgScope}${entityFilter} ${visibility.sql}`;
+  const where = `${idFilter} ${orgScope}${entityFilter} ${visibility.sql}${
+    excludeWorkspaceAudit
+      ? ` AND (f.metadata->>'category') IS DISTINCT FROM 'workspace'`
+      : ''
+  }`;
 
   // Read the full chain from `events` (not the masked view — superseded rows are
   // what we're here for). The list query JOINs resolved_ids so it can order by
@@ -331,6 +336,7 @@ export async function fetchIncludeSuperseded(opts: {
   untilDate: Date | null;
   visibilityScope: VisibilityScope;
   mcpSessionIds: string[] | undefined;
+  excludeWorkspaceAudit?: boolean;
   limit: number;
   offset: number;
 }): Promise<ListPageResult> {
@@ -345,6 +351,7 @@ export async function fetchIncludeSuperseded(opts: {
     untilDate,
     visibilityScope,
     mcpSessionIds,
+    excludeWorkspaceAudit,
     limit,
     offset,
   } = opts;
@@ -477,6 +484,9 @@ export async function fetchIncludeSuperseded(opts: {
     conditions.push(`e.interaction_status = $${paramIndex}`);
     queryParams.push(args.interaction_status);
     paramIndex += 1;
+  }
+  if (excludeWorkspaceAudit) {
+    conditions.push(`(e.metadata->>'category') IS DISTINCT FROM 'workspace'`);
   }
 
   // Visibility: events from connections the caller can't see drop out.

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -298,7 +298,8 @@ const BOOTSTRAP_RECENT_LIMIT = 8;
 async function processTemplateDataSources(
   jsonTemplate: Record<string, any> | null,
   context: DataSourceContext,
-  sql: DbClient
+  sql: DbClient,
+  options?: { excludeWorkspaceAudit?: boolean }
 ): Promise<{
   cleanTemplate: Record<string, any> | null;
   templateData: Record<string, unknown[]> | null;
@@ -309,7 +310,9 @@ async function processTemplateDataSources(
 
   const dataSources = jsonTemplate.data_sources as DataSourceInput;
   const { data_sources: _, ...cleanTemplate } = jsonTemplate;
-  const templateData = await executeDataSources(dataSources, context, sql);
+  const templateData = await executeDataSources(dataSources, context, sql, {
+    excludeWorkspaceAudit: options?.excludeWorkspaceAudit,
+  });
   return { cleanTemplate, templateData };
 }
 
@@ -319,14 +322,16 @@ async function processTemplateDataSources(
 async function processTabsDataSources(
   tabs: ViewTemplateTab[],
   context: DataSourceContext,
-  sql: DbClient
+  sql: DbClient,
+  options?: { excludeWorkspaceAudit?: boolean }
 ): Promise<ViewTemplateTab[]> {
   return Promise.all(
     tabs.map(async (tab) => {
       const { cleanTemplate, templateData } = await processTemplateDataSources(
         tab.json_template,
         context,
-        sql
+        sql,
+        options
       );
       return {
         ...tab,
@@ -405,12 +410,24 @@ async function _resolvePath(
     name: resolved.name,
   };
 
+  // memberRole is for ctx.organizationId only. resolve_path can target a
+  // different public workspace (e.g. owner of A browsing public B) — treat
+  // foreign-org roles as non-member so owner/admin privileges never cross.
+  const roleInResolvedWorkspace =
+    ctx.organizationId === workspace.id ? ctx.memberRole : null;
+  // Workspace-identity audit + template events: owner/admin of THIS workspace
+  // (or trusted system) only.
+  const excludeWorkspaceAudit =
+    !isSystemContext(ctx) && !isAdminOrOwnerRole(roleInResolvedWorkspace);
+
   const remaining = segments.slice(1);
   let entitySegments: string[];
 
   if (remaining.length === 0) {
     const [bootstrap, counts] = await Promise.all([
-      args.include_bootstrap ? fetchBootstrap(sql, ctx, workspace, null) : null,
+      args.include_bootstrap
+        ? fetchBootstrap(sql, ctx, workspace, null, excludeWorkspaceAudit)
+        : null,
       resolveWorkspaceCounts(sql, workspace, ctx.userId),
     ]);
     return emptyResult(workspace, bootstrap, counts);
@@ -610,13 +627,17 @@ async function _resolvePath(
                 AND i.status = 'active'`,
         fetchTabs(sql, 'entity', String(entityRow.id), workspace.id),
         fetchTabs(sql, 'entity_type', entityRow.entity_type, workspace.id),
-        processTemplateDataSources(entityRow.json_template, entityDataCtx, sql),
+        processTemplateDataSources(entityRow.json_template, entityDataCtx, sql, {
+          excludeWorkspaceAudit,
+        }),
       ])
     );
     const mergedTabs = mergeTabs(entityTabs, entityTypeTabs);
-    let processedEntityTabs = await processTabsDataSources(mergedTabs, entityDataCtx, sql);
+    let processedEntityTabs = await processTabsDataSources(mergedTabs, entityDataCtx, sql, {
+      excludeWorkspaceAudit,
+    });
     let redactedTemplateData = entityTemplateData;
-    if (entityRow.entity_type === MEMBER_ENTITY_TYPE_SLUG && !ctx.memberRole) {
+    if (entityRow.entity_type === MEMBER_ENTITY_TYPE_SLUG && !roleInResolvedWorkspace) {
       throw new ToolUserError(
         'Member details are only visible to members of this workspace. Join the workspace to see members.',
         403
@@ -624,7 +645,7 @@ async function _resolvePath(
     }
     const rawEntityMetadata = entityRow.metadata ?? {};
     let safeEntityMetadata = rawEntityMetadata;
-    const canSeeEmail = isAdminOrOwnerRole(ctx.memberRole);
+    const canSeeEmail = isAdminOrOwnerRole(roleInResolvedWorkspace);
     if (!canSeeEmail) {
       const schemaRow = await sql`
         SELECT metadata_schema FROM entity_types
@@ -682,7 +703,7 @@ async function _resolvePath(
   if (
     resolvedEntity &&
     !resolvedEntity.is_derived &&
-    isAdminOrOwnerRole(ctx.memberRole)
+    isAdminOrOwnerRole(roleInResolvedWorkspace)
   ) {
     const mergedRows = await sql<{
       id: number;
@@ -770,7 +791,9 @@ async function _resolvePath(
   }
 
   const [bootstrap, counts] = await Promise.all([
-    args.include_bootstrap ? fetchBootstrap(sql, ctx, workspace, resolvedEntity) : null,
+    args.include_bootstrap
+      ? fetchBootstrap(sql, ctx, workspace, resolvedEntity, excludeWorkspaceAudit)
+      : null,
     resolveWorkspaceCounts(sql, workspace, ctx.userId),
   ]);
 
@@ -960,7 +983,8 @@ async function fetchBootstrap(
   sql: DbClient,
   ctx: ToolContext,
   workspace: ResolvedWorkspace,
-  entity: ResolvedEntityDetails | null
+  entity: ResolvedEntityDetails | null,
+  excludeWorkspaceAudit: boolean
 ): Promise<ResolvePathBootstrap> {
   if (workspace.type !== 'organization') {
     return {
@@ -971,13 +995,6 @@ async function fetchBootstrap(
       connector_definitions: [],
     };
   }
-
-  // memberRole is for ctx.organizationId. resolve_path can target a different
-  // public workspace, so only honor owner/admin for the *resolved* org.
-  // System contexts (userId=null, authenticated) keep the trusted bypass.
-  const excludeWorkspaceAudit =
-    !isSystemContext(ctx) &&
-    !(ctx.organizationId === workspace.id && isAdminOrOwnerRole(ctx.memberRole));
 
   const [entityTypes, totalContent, recentContent, recentFeeds] = await Promise.all([
     listEntityTypes(sql, ctx),

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -1174,7 +1174,7 @@ async function fetchContentCount(
       AND ev.semantic_type <> 'correction'
       -- Workspace-identity audit rows record member/invitation lifecycle; only
       -- owner/admin and trusted system callers may see them.
-      ${excludeWorkspaceAudit ? sql`AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'` : sql``}
+      ${excludeWorkspaceAudit ? sql`AND NOT (ev.metadata ? '_lobu_workspace_audit')` : sql``}
   `;
   return Number((row as { total_content?: number } | undefined)?.total_content) || 0;
 }
@@ -1226,7 +1226,7 @@ async function fetchRecentContent(
       AND ev.semantic_type <> 'correction'
       -- Workspace-identity audit rows record member/invitation lifecycle; only
       -- owner/admin and trusted system callers may see them in bootstrap.
-      ${excludeWorkspaceAudit ? `AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'` : ''}
+      ${excludeWorkspaceAudit ? `AND NOT (ev.metadata ? '_lobu_workspace_audit')` : ''}
       ${entityFilter}
     ORDER BY COALESCE(ev.occurred_at, ev.created_at) DESC
     LIMIT $2

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -31,7 +31,7 @@ import { buildDefaultEntityTemplate } from '../utils/default-entity-template';
 import { measureColumns as inferMeasureColumns } from '../utils/infer-measures';
 import { RESERVED_PATHS_SET } from '../utils/reserved';
 import { getWorkspaceProvider } from '../workspace';
-import { isAdminOrOwnerRole } from './access-control';
+import { isAdminOrOwnerRole, isSystemContext } from './access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from './constants';
 import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
@@ -974,8 +974,20 @@ async function fetchBootstrap(
 
   const [entityTypes, totalContent, recentContent, recentFeeds] = await Promise.all([
     listEntityTypes(sql, ctx),
-    fetchContentCount(sql, workspace.id, entity),
-    fetchRecentContent(sql, workspace.id, entity?.id ?? null),
+    fetchContentCount(
+      sql,
+      workspace.id,
+      entity,
+      // Workspace-identity audit rows carry member/invitation emails; only
+      // owner/admin and trusted in-process system callers may see them.
+      !isAdminOrOwnerRole(ctx.memberRole) && !isSystemContext(ctx)
+    ),
+    fetchRecentContent(
+      sql,
+      workspace.id,
+      entity?.id ?? null,
+      !isAdminOrOwnerRole(ctx.memberRole) && !isSystemContext(ctx)
+    ),
     fetchRecentFeeds(sql, workspace.id, entity?.id ?? null),
   ]);
   const connectorDefinitions = await listWorkspaceConnectorDefinitions(
@@ -1149,7 +1161,8 @@ async function fetchWorkspaceCounts(
 async function fetchContentCount(
   sql: DbClient,
   organizationId: string,
-  entity: ResolvedEntityDetails | null
+  entity: ResolvedEntityDetails | null,
+  excludeWorkspaceAudit: boolean
 ): Promise<number> {
   if (entity) return entity.total_content;
 
@@ -1159,6 +1172,9 @@ async function fetchContentCount(
     WHERE ev.organization_id = ${organizationId}
       -- Exclude null-shaped internal events (P1 corrections) from the org content count.
       AND ev.semantic_type <> 'correction'
+      -- Workspace-identity audit rows carry member/invitation emails; only
+      -- owner/admin and trusted system callers may see them.
+      ${excludeWorkspaceAudit ? sql`AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'` : sql``}
   `;
   return Number((row as { total_content?: number } | undefined)?.total_content) || 0;
 }
@@ -1166,7 +1182,8 @@ async function fetchContentCount(
 async function fetchRecentContent(
   sql: DbClient,
   organizationId: string,
-  entityId: number | null
+  entityId: number | null,
+  excludeWorkspaceAudit: boolean
 ): Promise<BootstrapContentItem[]> {
   // Inline the entity-link match as raw SQL — this whole query is built as a
   // single sql.unsafe() statement rather than mixing sql.unsafe() fragments
@@ -1207,6 +1224,9 @@ async function fetchRecentContent(
     WHERE ev.organization_id = $1
       -- Exclude null-shaped internal events (P1 corrections) from the recent-content list.
       AND ev.semantic_type <> 'correction'
+      -- Workspace-identity audit rows carry member/invitation emails; only
+      -- owner/admin and trusted system callers may see them in bootstrap.
+      ${excludeWorkspaceAudit ? `AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'` : ''}
       ${entityFilter}
     ORDER BY COALESCE(ev.occurred_at, ev.created_at) DESC
     LIMIT $2

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -972,22 +972,17 @@ async function fetchBootstrap(
     };
   }
 
+  // memberRole is for ctx.organizationId. resolve_path can target a different
+  // public workspace, so only honor owner/admin for the *resolved* org.
+  // System contexts (userId=null, authenticated) keep the trusted bypass.
+  const excludeWorkspaceAudit =
+    !isSystemContext(ctx) &&
+    !(ctx.organizationId === workspace.id && isAdminOrOwnerRole(ctx.memberRole));
+
   const [entityTypes, totalContent, recentContent, recentFeeds] = await Promise.all([
     listEntityTypes(sql, ctx),
-    fetchContentCount(
-      sql,
-      workspace.id,
-      entity,
-      // Workspace-identity audit rows record member/invitation lifecycle; only
-      // owner/admin and trusted in-process system callers may see them.
-      !isAdminOrOwnerRole(ctx.memberRole) && !isSystemContext(ctx)
-    ),
-    fetchRecentContent(
-      sql,
-      workspace.id,
-      entity?.id ?? null,
-      !isAdminOrOwnerRole(ctx.memberRole) && !isSystemContext(ctx)
-    ),
+    fetchContentCount(sql, workspace.id, entity, excludeWorkspaceAudit),
+    fetchRecentContent(sql, workspace.id, entity?.id ?? null, excludeWorkspaceAudit),
     fetchRecentFeeds(sql, workspace.id, entity?.id ?? null),
   ]);
   const connectorDefinitions = await listWorkspaceConnectorDefinitions(

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -31,7 +31,7 @@ import { buildDefaultEntityTemplate } from '../utils/default-entity-template';
 import { measureColumns as inferMeasureColumns } from '../utils/infer-measures';
 import { RESERVED_PATHS_SET } from '../utils/reserved';
 import { getWorkspaceProvider } from '../workspace';
-import { isAdminOrOwnerRole, isSystemContext } from './access-control';
+import { isAdminOrOwnerRole, isInProcessSystemCall } from './access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from './constants';
 import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
@@ -418,7 +418,7 @@ async function _resolvePath(
   // Workspace-identity audit + template events: owner/admin of THIS workspace
   // (or trusted system) only.
   const excludeWorkspaceAudit =
-    !isSystemContext(ctx) && !isAdminOrOwnerRole(roleInResolvedWorkspace);
+    !isInProcessSystemCall(ctx) && !isAdminOrOwnerRole(roleInResolvedWorkspace);
 
   const remaining = segments.slice(1);
   let entitySegments: string[];

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -978,7 +978,7 @@ async function fetchBootstrap(
       sql,
       workspace.id,
       entity,
-      // Workspace-identity audit rows carry member/invitation emails; only
+      // Workspace-identity audit rows record member/invitation lifecycle; only
       // owner/admin and trusted in-process system callers may see them.
       !isAdminOrOwnerRole(ctx.memberRole) && !isSystemContext(ctx)
     ),
@@ -1172,7 +1172,7 @@ async function fetchContentCount(
     WHERE ev.organization_id = ${organizationId}
       -- Exclude null-shaped internal events (P1 corrections) from the org content count.
       AND ev.semantic_type <> 'correction'
-      -- Workspace-identity audit rows carry member/invitation emails; only
+      -- Workspace-identity audit rows record member/invitation lifecycle; only
       -- owner/admin and trusted system callers may see them.
       ${excludeWorkspaceAudit ? sql`AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'` : sql``}
   `;
@@ -1224,7 +1224,7 @@ async function fetchRecentContent(
     WHERE ev.organization_id = $1
       -- Exclude null-shaped internal events (P1 corrections) from the recent-content list.
       AND ev.semantic_type <> 'correction'
-      -- Workspace-identity audit rows carry member/invitation emails; only
+      -- Workspace-identity audit rows record member/invitation lifecycle; only
       -- owner/admin and trusted system callers may see them in bootstrap.
       ${excludeWorkspaceAudit ? `AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'` : ''}
       ${entityFilter}

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -513,7 +513,12 @@ async function saveContentImpl(
   // going through the preflight read or the unique-violation reconciliation,
   // surfacing a raw Postgres conflict on collision.
   const callerMetadata: Record<string, unknown> = { ...(args.metadata ?? {}) };
-  delete callerMetadata._lobu_idempotency_key;
+  // The `_lobu_` metadata namespace is server-owned: strip every reserved key
+  // from caller input so a member cannot forge audit discriminators
+  // (_lobu_workspace_audit) or idempotency keys by supplying them as metadata.
+  for (const key of Object.keys(callerMetadata)) {
+    if (key.startsWith('_lobu_')) delete callerMetadata[key];
+  }
   const eventMetadata: Record<string, unknown> = {
     ...callerMetadata,
     ...(args.idempotency_key ? { _lobu_idempotency_key: args.idempotency_key } : {}),

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -929,10 +929,10 @@ async function searchImpl(
             env,
             queryEmbedding: args.query_embedding,
             minSimilarity: args.min_similarity,
-            // Workspace-identity audit events carry member emails / invitation
-            // details; only owners/admins and in-process system contexts may
+            // Workspace-identity audit events record member/invitation
+            // lifecycle; only owners/admins and in-process system contexts may
             // recall them (ordinary members do not see another member's
-            // invitation PII — the $member read policy reserves that for
+            // invitation lifecycle — the $member read policy reserves that for
             // owner/admin).
             excludeWorkspaceAudit:
               ctx.memberRole !== 'owner' &&

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -9,6 +9,7 @@
 
 import { type Static, Type } from '@sinclair/typebox';
 import { hasRequiredMcpScope } from '../auth/tool-access';
+import { isSystemContext } from './access-control';
 import { evaluateEntityMutation, resolveActingPrincipal } from '../authz/entity-policy';
 import { type AuthzScope, authzScopeFromToolContext } from '../authz/scope';
 import { compileConnectionRowVisibility } from '../authz/connection-visibility';
@@ -372,12 +373,14 @@ async function fetchContentSnippets(
   env: Env,
   queryEmbedding?: number[],
   agentId?: string,
-  minSimilarity?: number
+  minSimilarity?: number,
+  excludeWorkspaceAudit?: boolean
 ): Promise<ContentSnippet[]> {
   const result = await searchContentByText(
     query,
     {
       organization_id: gate.organizationId,
+      ...(excludeWorkspaceAudit && { exclude_workspace_audit: true }),
       // Enforce the org/private-connection visibility boundary on the recall
       // path, exactly as get_content does. Without visibility_scope the
       // connection-visibility clause is skipped entirely, so search_memory
@@ -594,6 +597,9 @@ export interface RecallContext {
   /** Caller-supplied similarity floor for recalled content (schema 0.0-1.0,
    * default 0.3). Undefined means "use the documented default". */
   minSimilarity?: number;
+  /** Exclude workspace-identity audit events (metadata.category='workspace')
+   * for non-member readers of public workspaces. */
+  excludeWorkspaceAudit?: boolean;
 }
 
 /**
@@ -660,7 +666,8 @@ const knowledgeSource: RecallSource = {
       ctx.env,
       ctx.queryEmbedding,
       ctx.contentAgentId,
-      ctx.minSimilarity
+      ctx.minSimilarity,
+      ctx.excludeWorkspaceAudit
     );
     // ALWAYS emit the facet, even empty. An ABSENT `content` key and an empty
     // one are indistinguishable to an agent reading raw JSON, so omitting it on
@@ -922,6 +929,12 @@ async function searchImpl(
             env,
             queryEmbedding: args.query_embedding,
             minSimilarity: args.min_similarity,
+            // Workspace-identity audit events carry member emails / invitation
+            // details; non-member readers of public workspaces must never
+            // retrieve them through search_memory (system contexts stay
+            // allowed).
+            excludeWorkspaceAudit:
+              ctx.memberRole === null && !isSystemContext(ctx),
           }
         )
       : Promise.resolve({});

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -9,7 +9,7 @@
 
 import { type Static, Type } from '@sinclair/typebox';
 import { hasRequiredMcpScope } from '../auth/tool-access';
-import { isSystemContext } from './access-control';
+import { isInProcessSystemCall } from './access-control';
 import { evaluateEntityMutation, resolveActingPrincipal } from '../authz/entity-policy';
 import { type AuthzScope, authzScopeFromToolContext } from '../authz/scope';
 import { compileConnectionRowVisibility } from '../authz/connection-visibility';
@@ -937,7 +937,7 @@ async function searchImpl(
             excludeWorkspaceAudit:
               ctx.memberRole !== 'owner' &&
               ctx.memberRole !== 'admin' &&
-              !isSystemContext(ctx),
+              !isInProcessSystemCall(ctx),
           }
         )
       : Promise.resolve({});

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -930,11 +930,14 @@ async function searchImpl(
             queryEmbedding: args.query_embedding,
             minSimilarity: args.min_similarity,
             // Workspace-identity audit events carry member emails / invitation
-            // details; non-member readers of public workspaces must never
-            // retrieve them through search_memory (system contexts stay
-            // allowed).
+            // details; only owners/admins and in-process system contexts may
+            // recall them (ordinary members do not see another member's
+            // invitation PII — the $member read policy reserves that for
+            // owner/admin).
             excludeWorkspaceAudit:
-              ctx.memberRole === null && !isSystemContext(ctx),
+              ctx.memberRole !== 'owner' &&
+              ctx.memberRole !== 'admin' &&
+              !isSystemContext(ctx),
           }
         )
       : Promise.resolve({});

--- a/packages/server/src/utils/__tests__/config-redaction.test.ts
+++ b/packages/server/src/utils/__tests__/config-redaction.test.ts
@@ -75,6 +75,49 @@ describe('redactConfigState', () => {
     expect(out?.apiKey).toBe(REDACTED_SENTINEL);
     expect(out?.baseUrl).toBe('https://api.z.ai');
   });
+
+  it('passes workspace identity state through the denylist deep-walk', () => {
+    const org = redactConfigState('organization', {
+      id: 'org_abc',
+      name: 'Acme',
+      slug: 'acme',
+      visibility: 'private',
+      metadata: { api_key: 'must-not-persist' },
+    });
+    expect(org).toEqual({
+      id: 'org_abc',
+      name: 'Acme',
+      slug: 'acme',
+      visibility: 'private',
+      metadata: { api_key: REDACTED_SENTINEL },
+    });
+
+    const member = redactConfigState('member', {
+      id: 'member_abc',
+      user_id: 'user_abc',
+      role: 'owner',
+      email: 'owner@acme.test',
+    });
+    expect(member).toEqual({
+      id: 'member_abc',
+      user_id: 'user_abc',
+      role: 'owner',
+      email: 'owner@acme.test',
+    });
+
+    const invitation = redactConfigState('invitation', {
+      id: 'inv_abc',
+      email: 'invitee@acme.test',
+      role: 'member',
+      status: 'pending',
+    });
+    expect(invitation).toEqual({
+      id: 'inv_abc',
+      email: 'invitee@acme.test',
+      role: 'member',
+      status: 'pending',
+    });
+  });
 });
 
 /**

--- a/packages/server/src/utils/config-redaction.ts
+++ b/packages/server/src/utils/config-redaction.ts
@@ -1,9 +1,9 @@
 /**
- * Redaction for config-change audit snapshots (`metadata.category='config'`
- * events). Mutation payloads can carry resolved secret material — platform
- * config arrives from `lobu apply` with `$VAR`/`secret()` refs already
- * resolved to plaintext — so every state snapshot is passed through here
- * before it is persisted into `events.payload_data`.
+ * Redaction for state-change audit snapshots. Mutation payloads can carry
+ * resolved secret material — platform config arrives from `lobu apply` with
+ * `$VAR`/`secret()` refs already resolved to plaintext — so every state
+ * snapshot is passed through here before it is persisted into
+ * `events.payload_data`.
  *
  * The denylist walk and sentinel live in @lobu/core (`secret-redaction`),
  * shared with the CLI's manifest hashing; this module adds the per-kind
@@ -33,6 +33,14 @@ export type ConfigResourceKind =
   | 'inference-provider'
   | 'provider-key';
 
+/** Server-emitted workspace identity resources; never part of `lobu apply`. */
+export type WorkspaceAuditResourceKind =
+  | 'organization'
+  | 'member'
+  | 'invitation';
+
+export type AuditResourceKind = ConfigResourceKind | WorkspaceAuditResourceKind;
+
 /**
  * Redact a post-change state snapshot before persisting it.
  *
@@ -44,9 +52,12 @@ export type ConfigResourceKind =
  *  - `inference-provider`: `apiKey`/`api_key` (already denylisted; kept
  *    explicit as a guarantee, not a heuristic).
  *  - `provider-key`: never snapshotted — state is forced to null.
+ *  - `organization` / `member` / `invitation`: no additional hard rules;
+ *    ordinary identity fields remain visible while the denylist still strips
+ *    any unexpectedly nested secret material.
  */
 export function redactConfigState(
-  kind: ConfigResourceKind,
+  kind: AuditResourceKind,
   state: Record<string, unknown> | null
 ): Record<string, unknown> | null {
   if (state === null) return null;

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -257,7 +257,7 @@ async function buildFilterConditionsAndJoins(
 
   if (filters?.exclude_workspace_audit) {
     filterConditions.push(
-      `(f.metadata->>'category') IS DISTINCT FROM 'workspace'`
+      `NOT (f.metadata ? '_lobu_workspace_audit')`
     );
   }
 

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -50,6 +50,12 @@ interface NormalizedScoreFilters {
   semantic_type?: string | string[];
   interaction_status?: 'pending' | 'approved' | 'rejected' | 'completed' | 'failed';
   /**
+   * Exclude workspace-identity audit events (`metadata.category='workspace'`),
+   * which carry member emails / invitation details. Set for anonymous
+   * public-workspace readers so they never retrieve them.
+   */
+  exclude_workspace_audit?: boolean;
+  /**
    * Connection-visibility scope. Folds into the WHERE so events from
    * private connections the caller can't see don't appear in score-sorted
    * results. Mirrors the clause used by `listContentInternal` and the
@@ -247,6 +253,12 @@ async function buildFilterConditionsAndJoins(
   if (filters?.interaction_status) {
     params.push(filters.interaction_status);
     filterConditions.push(`f.interaction_status = $${paramIndex++}`);
+  }
+
+  if (filters?.exclude_workspace_audit) {
+    filterConditions.push(
+      `(f.metadata->>'category') IS DISTINCT FROM 'workspace'`
+    );
   }
 
   // Classification filters share the single version-ID-aware builder used by

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -362,6 +362,9 @@ export async function listContentInternal(
       baseParams.push(pgTextArray(types));
       baseConditions.push(buildSemanticTypeFilterSql('f', `$${baseParams.length}`));
     }
+    if (options.exclude_workspace_audit) {
+      baseConditions.push(`(f.metadata->>'category') IS DISTINCT FROM 'workspace'`);
+    }
     if (options.interaction_status) {
       baseParams.push(options.interaction_status);
       baseConditions.push(`f.interaction_status = $${baseParams.length}`);
@@ -534,6 +537,7 @@ export async function listContentInternal(
           AND ${connectionCondition}
           AND ${feedCondition}
           AND ${runCondition}
+          ${options.exclude_workspace_audit ? `AND (f.metadata->>'category') IS DISTINCT FROM 'workspace'` : ''}
           ${excludeClause.sql}
           ${producedFilterClause.sql}
           ${analyzedFilterClause.sql}

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -363,7 +363,7 @@ export async function listContentInternal(
       baseConditions.push(buildSemanticTypeFilterSql('f', `$${baseParams.length}`));
     }
     if (options.exclude_workspace_audit) {
-      baseConditions.push(`(f.metadata->>'category') IS DISTINCT FROM 'workspace'`);
+      baseConditions.push(`NOT (f.metadata ? '_lobu_workspace_audit')`);
     }
     if (options.interaction_status) {
       baseParams.push(options.interaction_status);
@@ -537,7 +537,7 @@ export async function listContentInternal(
           AND ${connectionCondition}
           AND ${feedCondition}
           AND ${runCondition}
-          ${options.exclude_workspace_audit ? `AND (f.metadata->>'category') IS DISTINCT FROM 'workspace'` : ''}
+          ${options.exclude_workspace_audit ? `AND NOT (f.metadata ? '_lobu_workspace_audit')` : ''}
           ${excludeClause.sql}
           ${producedFilterClause.sql}
           ${analyzedFilterClause.sql}

--- a/packages/server/src/utils/content-search/search-path.ts
+++ b/packages/server/src/utils/content-search/search-path.ts
@@ -203,6 +203,7 @@ export async function searchContentBySingleQuery(
           ${producedClause.sql}
           ${analyzedClause.sql}
           ${visibilityClause.sql}
+          ${options.exclude_workspace_audit ? `AND (f.metadata->>'category') IS DISTINCT FROM 'workspace'` : ''}
           ${orgScope.sql}${entityTypesClause.sql}`;
 
   const textDocumentExpr = buildSearchDocumentExpr('f');

--- a/packages/server/src/utils/content-search/search-path.ts
+++ b/packages/server/src/utils/content-search/search-path.ts
@@ -203,7 +203,7 @@ export async function searchContentBySingleQuery(
           ${producedClause.sql}
           ${analyzedClause.sql}
           ${visibilityClause.sql}
-          ${options.exclude_workspace_audit ? `AND (f.metadata->>'category') IS DISTINCT FROM 'workspace'` : ''}
+          ${options.exclude_workspace_audit ? `AND NOT (f.metadata ? '_lobu_workspace_audit')` : ''}
           ${orgScope.sql}${entityTypesClause.sql}`;
 
   const textDocumentExpr = buildSearchDocumentExpr('f');

--- a/packages/server/src/utils/content-search/types.ts
+++ b/packages/server/src/utils/content-search/types.ts
@@ -25,6 +25,13 @@ export interface ContentSearchOptions {
    * Events with `connection_id IS NULL` are always visible.
    */
   visibility_scope?: { organizationId: string; userId: string | null };
+  /**
+   * Exclude workspace-identity audit events (`metadata.category='workspace'`).
+   * These carry member emails / invitation details and are emitted for
+   * authenticated workspace activity; anonymous public-workspace readers must
+   * never retrieve them through the public read path.
+   */
+  exclude_workspace_audit?: boolean;
   window_id?: number; // Filter by watcher window ID
   /** Events linked in any window for this watcher (`watcher_window_events`). */
   analyzed_by_watcher_id?: number;

--- a/packages/server/src/utils/entity-hooks.ts
+++ b/packages/server/src/utils/entity-hooks.ts
@@ -13,6 +13,7 @@ import type { Env } from '../index';
 import { getDb } from '../db/client';
 import { resolveMemberSchemaFields } from './member-entity';
 import { getConfiguredPublicOrigin } from './public-origin';
+import { recordWorkspaceChangeEvent } from './insert-event';
 import type { CreatedEntity, EntityData } from './entity-management';
 import logger from './logger';
 
@@ -61,7 +62,7 @@ registerEntityHooks('$member', {
     if (email) {
       // Insert a Better Auth invitation (skip if one already pending)
       const sql = getDb();
-      await sql`
+      const inserted = (await sql`
         INSERT INTO invitation (id, "organizationId", email, role, status, "expiresAt", "inviterId", "createdAt")
         SELECT
           gen_random_uuid()::text,
@@ -78,7 +79,26 @@ registerEntityHooks('$member', {
             AND email = ${email}
             AND status = 'pending'
         )
-      `;
+        RETURNING id
+      `) as unknown as Array<{ id: string }>;
+      if (inserted.length > 0) {
+        recordWorkspaceChangeEvent({
+          organizationId: ctx.organizationId,
+          resourceKind: 'invitation',
+          resourceId: inserted[0].id,
+          op: 'created',
+          summary: `Invitation sent to ${email}`,
+          state: {
+            id: inserted[0].id,
+            email,
+            role: 'member',
+            status: 'pending',
+          },
+          changedFields: ['email', 'role', 'status'],
+          actorSource: 'ui',
+          createdBy: ctx.userId ?? null,
+        });
+      }
       meta.status = 'invited';
     } else {
       meta.status = meta.status ?? 'active';

--- a/packages/server/src/utils/entity-hooks.ts
+++ b/packages/server/src/utils/entity-hooks.ts
@@ -155,12 +155,39 @@ registerEntityHooks('$member', {
 
     // Cancel any pending invitation for this email
     const sql = getDb();
-    await sql`
+    const cancelled = (await sql`
       UPDATE invitation
       SET status = 'canceled'
       WHERE "organizationId" = ${ctx.organizationId}
         AND email = ${email}
         AND status = 'pending'
-    `;
+      RETURNING id, email, role, status
+    `) as unknown as Array<{
+      id: string;
+      email: string;
+      role: string | null;
+      status: string | null;
+    }>;
+    // The $member delete cancels every pending invite; record each
+    // cancellation so the invitation lifecycle audit (send → canceled) stays
+    // complete. Fire-and-forget — the update already committed.
+    for (const inv of cancelled) {
+      recordWorkspaceChangeEvent({
+        organizationId: ctx.organizationId,
+        resourceKind: 'invitation',
+        resourceId: inv.id,
+        op: 'updated',
+        summary: `Invitation to ${inv.email} cancelled`,
+        state: {
+          id: inv.id,
+          email: inv.email,
+          role: inv.role ?? 'member',
+          status: inv.status ?? 'canceled',
+        },
+        changedFields: ['status'],
+        actorSource: 'ui',
+        createdBy: ctx.userId ?? null,
+      });
+    }
   },
 });

--- a/packages/server/src/utils/entity-hooks.ts
+++ b/packages/server/src/utils/entity-hooks.ts
@@ -87,14 +87,13 @@ registerEntityHooks('$member', {
           resourceKind: 'invitation',
           resourceId: inserted[0].id,
           op: 'created',
-          summary: `Invitation sent to ${email}`,
+          summary: 'Invitation sent',
           state: {
             id: inserted[0].id,
-            email,
             role: 'member',
             status: 'pending',
           },
-          changedFields: ['email', 'role', 'status'],
+          changedFields: ['role', 'status'],
           actorSource: 'ui',
           createdBy: ctx.userId ?? null,
         });
@@ -161,10 +160,9 @@ registerEntityHooks('$member', {
       WHERE "organizationId" = ${ctx.organizationId}
         AND email = ${email}
         AND status = 'pending'
-      RETURNING id, email, role, status
+      RETURNING id, role, status
     `) as unknown as Array<{
       id: string;
-      email: string;
       role: string | null;
       status: string | null;
     }>;
@@ -177,10 +175,9 @@ registerEntityHooks('$member', {
         resourceKind: 'invitation',
         resourceId: inv.id,
         op: 'updated',
-        summary: `Invitation to ${inv.email} cancelled`,
+        summary: 'Invitation cancelled',
         state: {
           id: inv.id,
-          email: inv.email,
           role: inv.role ?? 'member',
           status: inv.status ?? 'canceled',
         },

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -334,6 +334,13 @@ export function validateAndScopeQuery(
      * yields org-visible-only (fail-closed for private data).
      */
     userId?: string | null;
+    /**
+     * Exclude workspace-identity audit events (metadata.category='workspace')
+     * from the events and event_classifications CTEs. These rows record
+     * member/invitation lifecycle and are owner/admin-only; ordinary members
+     * running query_sql / client.query must not surface them.
+     */
+    excludeWorkspaceAudit?: boolean;
   }
 ): { sql: string; params: unknown[]; tableRefs: string[] } {
   const trimmed = rawSql.trim();
@@ -400,7 +407,10 @@ export function buildScopedQuery(
   userQuery: string,
   tableRefs: string[],
   context: DataSourceContext,
-  options?: { safeColumns?: Map<string, ColumnDef[]> }
+  options?: {
+    safeColumns?: Map<string, ColumnDef[]>;
+    excludeWorkspaceAudit?: boolean;
+  }
 ): { sql: string; params: unknown[] } {
   const params: unknown[] = [];
   let idx = 0;
@@ -590,6 +600,12 @@ export function buildScopedQuery(
         `"${safeName}" AS (SELECT ${sel(table, 'ev')} FROM public.current_event_records ev ` +
         `WHERE ${eventOrgScope('ev')}`;
 
+      // Workspace-identity audit rows are owner/admin-only; ordinary members
+      // running raw SQL must not surface them.
+      if (options?.excludeWorkspaceAudit) {
+        eventsCte += ` AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'`;
+      }
+
       // Entity scoping: filter events to the watcher's entities
       if (context.entityIds && context.entityIds.length > 0) {
         const placeholders = context.entityIds.map((id) => {
@@ -685,6 +701,9 @@ export function buildScopedQuery(
         `"${safeName}" AS (SELECT ${sel(table, 'ec')} FROM public.event_classifications ec WHERE EXISTS (` +
           'SELECT 1 FROM public.current_event_records ev ' +
           `WHERE ev.id = ec.event_id AND ${eventOrgScope('ev')}` +
+          (options?.excludeWorkspaceAudit
+            ? ` AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'`
+            : '') +
           eventConnVisibility('ev') +
           eventResourceVisibility('ev') +
           '))'

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -603,7 +603,7 @@ export function buildScopedQuery(
       // Workspace-identity audit rows are owner/admin-only; ordinary members
       // running raw SQL must not surface them.
       if (options?.excludeWorkspaceAudit) {
-        eventsCte += ` AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'`;
+        eventsCte += ` AND NOT (ev.metadata ? '_lobu_workspace_audit')`;
       }
 
       // Entity scoping: filter events to the watcher's entities
@@ -702,7 +702,7 @@ export function buildScopedQuery(
           'SELECT 1 FROM public.current_event_records ev ' +
           `WHERE ev.id = ec.event_id AND ${eventOrgScope('ev')}` +
           (options?.excludeWorkspaceAudit
-            ? ` AND (ev.metadata->>'category') IS DISTINCT FROM 'workspace'`
+            ? ` AND NOT (ev.metadata ? '_lobu_workspace_audit')`
             : '') +
           eventConnVisibility('ev') +
           eventResourceVisibility('ev') +

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -960,6 +960,8 @@ export async function executeDataSources(
     throwOnError?: boolean;
     /** At save time, require unknown table refs to resolve to local or public entity types. */
     validateEntitySlugs?: boolean;
+    /** Exclude workspace-identity audit rows from the events/event_classifications CTEs. */
+    excludeWorkspaceAudit?: boolean;
   }
 ): Promise<Record<string, unknown[]>> {
   const results: Record<string, unknown[]> = {};
@@ -1037,6 +1039,7 @@ export async function executeDataSources(
         // their SELECT * — entity data is the template's intended payload.
         let { sql: scopedQuery, params } = buildScopedQuery(query, tableRefs, context, {
           safeColumns: SAFE_COLUMN_DEFS,
+          excludeWorkspaceAudit: options?.excludeWorkspaceAudit,
         });
 
         // Validate param count matches placeholders in scoped query

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -18,6 +18,7 @@ import {
   mergeEnrichedMetadata,
 } from './geo-enrichment';
 import logger from './logger';
+import { isUniqueViolation } from './pg-errors';
 
 /**
  * Single bounded retry for the fire-and-forget audit writers below
@@ -586,30 +587,46 @@ interface ChangeEventParams {
   clientId?: string | null;
 }
 
+const AUDIT_IDEMPOTENCY_INDEX = 'idx_events_org_idempotency_key';
+
 /**
- * Persist a connectionless audit/change event, reconciling first by
- * `(organization_id, origin_id)` where `connection_id IS NULL`.
+ * Persist a connectionless audit/change event with DB-enforced idempotency.
  *
  * Fire-and-forget writers retry with the same originId after a transient
- * failure. Connector-sourced rows are protected by a unique (connection_id,
- * origin_id) path; connectionless audit rows are not, so an ambiguous success
- * (insert committed, client saw timeout) would append a duplicate on retry.
- * Reconcile before insert so the second attempt is a no-op.
+ * failure. Connector-sourced rows use a unique (connection_id, origin_id)
+ * path; connectionless audit rows do not. Stamp the reserved
+ * `_lobu_idempotency_key` (unique per org via `idx_events_org_idempotency_key`)
+ * so a concurrent or retry insert after an ambiguous success resolves to the
+ * winner instead of appending a duplicate.
  */
 export async function insertConnectionlessAuditEvent(
   params: InsertEventParams
 ): Promise<InsertedEvent> {
-  const sql = getDb();
-  const existing = await sql`
-    SELECT id, entity_ids, origin_id, title, semantic_type, created_at
-    FROM events
-    WHERE organization_id = ${params.organizationId}
-      AND origin_id = ${params.originId}
-      AND connection_id IS NULL
-    ORDER BY id ASC
-    LIMIT 1
-  `;
-  if (existing[0]) {
+  const idempotencyKey = `audit:${params.originId}`;
+  const metadata: Record<string, unknown> = {
+    ...(params.metadata ?? {}),
+    _lobu_idempotency_key: idempotencyKey,
+  };
+
+  try {
+    return await insertEvent({
+      ...params,
+      connectionId: null,
+      metadata,
+    });
+  } catch (error) {
+    if (!isUniqueViolation(error, AUDIT_IDEMPOTENCY_INDEX)) throw error;
+    const sql = getDb();
+    const existing = await sql`
+      SELECT id, entity_ids, origin_id, title, semantic_type, created_at
+      FROM events
+      WHERE organization_id = ${params.organizationId}
+        AND metadata ? '_lobu_idempotency_key'
+        AND metadata->>'_lobu_idempotency_key' = ${idempotencyKey}
+      ORDER BY id ASC
+      LIMIT 1
+    `;
+    if (!existing[0]) throw error;
     const row = existing[0] as {
       id: number | string;
       entity_ids: number[] | null;
@@ -628,7 +645,6 @@ export async function insertConnectionlessAuditEvent(
       change: 'unchanged',
     };
   }
-  return insertEvent({ ...params, connectionId: null });
 }
 
 /**

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -732,6 +732,13 @@ function recordStateChangeEvent(
         payloadData: { state },
         metadata: {
           category,
+          // Server-owned discriminator for workspace-identity audit rows.
+          // `category` alone is NOT a safe gate: save_memory accepts caller
+          // metadata, so a member could stamp category='workspace' on a
+          // legitimate event and lose read access. `_lobu_` is the reserved
+          // server namespace callers cannot spoof — all exclusion predicates
+          // gate on this key, not the human-readable category.
+          ...(category === 'workspace' ? { _lobu_workspace_audit: true } : {}),
           resource_kind: params.resourceKind,
           resource_id: String(params.resourceId),
           op: params.op,

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -587,13 +587,59 @@ interface ChangeEventParams {
 }
 
 /**
+ * Persist a connectionless audit/change event, reconciling first by
+ * `(organization_id, origin_id)` where `connection_id IS NULL`.
+ *
+ * Fire-and-forget writers retry with the same originId after a transient
+ * failure. Connector-sourced rows are protected by a unique (connection_id,
+ * origin_id) path; connectionless audit rows are not, so an ambiguous success
+ * (insert committed, client saw timeout) would append a duplicate on retry.
+ * Reconcile before insert so the second attempt is a no-op.
+ */
+export async function insertConnectionlessAuditEvent(
+  params: InsertEventParams
+): Promise<InsertedEvent> {
+  const sql = getDb();
+  const existing = await sql`
+    SELECT id, entity_ids, origin_id, title, semantic_type, created_at
+    FROM events
+    WHERE organization_id = ${params.organizationId}
+      AND origin_id = ${params.originId}
+      AND connection_id IS NULL
+    ORDER BY id ASC
+    LIMIT 1
+  `;
+  if (existing[0]) {
+    const row = existing[0] as {
+      id: number | string;
+      entity_ids: number[] | null;
+      origin_id: string;
+      title: string | null;
+      semantic_type: string;
+      created_at: string;
+    };
+    return {
+      id: Number(row.id),
+      entity_ids: row.entity_ids,
+      origin_id: row.origin_id,
+      title: row.title,
+      semantic_type: row.semantic_type,
+      created_at: row.created_at,
+      change: 'unchanged',
+    };
+  }
+  return insertEvent({ ...params, connectionId: null });
+}
+
+/**
  * Record a change event for audit purposes.
  *
- * Fire-and-forget — never throws. Retries once after a short delay (the same
- * originId, so a retry can't double-write past a unique origin constraint);
- * if both attempts fail the dropped audit row is logged at ERROR with full
- * event context so it's visible in alerting rather than silently lost.
- * Used for entity updates, watcher archival, connection/feed deletion, etc.
+ * Fire-and-forget — never throws. Retries once after a short delay; the same
+ * originId is reconciled before re-insert so an ambiguous success cannot
+ * append a duplicate. If both attempts fail the dropped audit row is logged
+ * at ERROR with full event context so it's visible in alerting rather than
+ * silently lost. Used for entity updates, watcher archival, connection/feed
+ * deletion, etc.
  */
 export function recordChangeEvent(params: ChangeEventParams): void {
   if (params.entityIds.length === 0) return;
@@ -602,7 +648,7 @@ export function recordChangeEvent(params: ChangeEventParams): void {
 
   retryWithBackoff(
     () =>
-      insertEvent({
+      insertConnectionlessAuditEvent({
         entityIds: params.entityIds,
         organizationId: params.organizationId,
         originId: externalId,
@@ -721,7 +767,7 @@ function recordStateChangeEvent(
 
   retryWithBackoff(
     () =>
-      insertEvent({
+      insertConnectionlessAuditEvent({
         entityIds: [],
         organizationId: params.organizationId,
         originId: externalId,
@@ -777,13 +823,13 @@ export function recordWorkspaceChangeEvent(params: WorkspaceChangeEventParams): 
 export function recordLifecycleEvent(params: LifecycleEventParams): void {
   const externalId = `lifecycle_${params.entityType}_${params.op}_${params.entityId}_${Date.now()}`;
 
-  // Fire-and-forget with one bounded retry (same originId, so the retry is
-  // safe against duplicate writes). A doubly-failed write is an ERROR — these
-  // rows feed the dashboard metric_series, and a silent drop skews the
-  // cumulative counts forever.
+  // Fire-and-forget with one bounded retry. Same originId + connectionless
+  // reconcile so an ambiguous success cannot double-count. A doubly-failed
+  // write is an ERROR — these rows feed the dashboard metric_series, and a
+  // silent drop skews the cumulative counts forever.
   retryWithBackoff(
     () =>
-      insertEvent({
+      insertConnectionlessAuditEvent({
         entityIds: [],
         organizationId: params.organizationId,
         originId: externalId,

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -837,7 +837,9 @@ export function recordWorkspaceChangeEvent(params: WorkspaceChangeEventParams): 
 }
 
 export function recordLifecycleEvent(params: LifecycleEventParams): void {
-  const externalId = `lifecycle_${params.entityType}_${params.op}_${params.entityId}_${Date.now()}`;
+  // Include a random suffix so two same-entity/op lifecycle writes in the same
+  // millisecond get distinct originIds (and distinct audit: idempotency keys).
+  const externalId = `lifecycle_${params.entityType}_${params.op}_${params.entityId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
   // Fire-and-forget with one bounded retry. Same originId + connectionless
   // reconcile so an ambiguous success cannot double-count. A doubly-failed

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -7,7 +7,12 @@
 
 import { retryWithBackoff } from '@lobu/core';
 import { type DbClient, getDb } from '../db/client';
-import { type ConfigResourceKind, redactConfigState } from './config-redaction';
+import {
+  type AuditResourceKind,
+  type ConfigResourceKind,
+  redactConfigState,
+  type WorkspaceAuditResourceKind,
+} from './config-redaction';
 import {
   lookupGeoEnrichment,
   mergeEnrichedMetadata,
@@ -669,10 +674,9 @@ interface LifecycleEventParams {
 type ConfigOp = 'created' | 'updated' | 'deleted';
 type ConfigActorSource = 'cli' | 'ui' | 'api' | 'agent';
 
-interface ConfigChangeEventParams {
+interface StateChangeEventParams<ResourceKind extends AuditResourceKind> {
   organizationId: string;
-  /** DiffRow-kind slug (`agent`, `agent-settings`, `connection`, ...). */
-  resourceKind: ConfigResourceKind;
+  resourceKind: ResourceKind;
   resourceId: string | number;
   op: ConfigOp;
   /** Human-readable summary (e.g. "Agent 'Marketing' settings updated"). */
@@ -691,17 +695,28 @@ interface ConfigChangeEventParams {
   clientId?: string | null;
 }
 
+interface ConfigChangeEventParams extends StateChangeEventParams<ConfigResourceKind> {}
+
+interface WorkspaceChangeEventParams
+  extends StateChangeEventParams<WorkspaceAuditResourceKind> {}
+
 /**
- * Record a config mutation as a `semantic_type='change'` event with
- * `metadata.category='config'` and the full (redacted) post-change state in
- * `payload_data.state`. This is the settings audit trail behind the
+ * Record a state mutation as a `semantic_type='change'` event with the full
+ * redacted post-change state in `payload_data.state`. Config mutations use
+ * `metadata.category='config'`, the settings audit trail behind the
  * Deployments feed; distinct from `category='lifecycle'` rows, which carry no
  * state and feed dashboard metric_series — handlers that emit lifecycle
  * events dual-write this one. Fire-and-forget, same retry/ERROR contract as
  * the writers above.
+ *
+ * Workspace identity mutations use `metadata.category='workspace'`, keeping
+ * them out of the Deployments feed while still showing them in All activity.
  */
-export function recordConfigChangeEvent(params: ConfigChangeEventParams): void {
-  const externalId = `config_${params.resourceKind}_${params.op}_${params.resourceId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+function recordStateChangeEvent(
+  params: StateChangeEventParams<AuditResourceKind>,
+  category: 'config' | 'workspace'
+): void {
+  const externalId = `${category}_${params.resourceKind}_${params.op}_${params.resourceId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   const state = redactConfigState(params.resourceKind, params.state);
 
   retryWithBackoff(
@@ -712,11 +727,11 @@ export function recordConfigChangeEvent(params: ConfigChangeEventParams): void {
         originId: externalId,
         title: params.summary,
         semanticType: 'change',
-        originType: `config_${params.resourceKind}_${params.op}`,
+        originType: `${category}_${params.resourceKind}_${params.op}`,
         payloadType: 'empty',
         payloadData: { state },
         metadata: {
-          category: 'config',
+          category,
           resource_kind: params.resourceKind,
           resource_id: String(params.resourceId),
           op: params.op,
@@ -739,9 +754,17 @@ export function recordConfigChangeEvent(params: ConfigChangeEventParams): void {
         resourceId: String(params.resourceId),
         summary: params.summary,
       },
-      '[insert-event] config audit event DROPPED after retry — audit trail is missing this row'
+      `[insert-event] ${category} audit event DROPPED after retry — audit trail is missing this row`
     );
   });
+}
+
+export function recordConfigChangeEvent(params: ConfigChangeEventParams): void {
+  recordStateChangeEvent(params, 'config');
+}
+
+export function recordWorkspaceChangeEvent(params: WorkspaceChangeEventParams): void {
+  recordStateChangeEvent(params, 'workspace');
 }
 
 export function recordLifecycleEvent(params: LifecycleEventParams): void {

--- a/packages/server/src/workspace/join-public.ts
+++ b/packages/server/src/workspace/join-public.ts
@@ -114,7 +114,7 @@ export async function joinPublicOrganization({
     resourceKind: 'member',
     resourceId: committedMemberId,
     op: 'created',
-    summary: `Member "${user.name || user.email}" joined public workspace`,
+    summary: `Member "${user.name || 'a member'}" joined public workspace`,
     state: { id: committedMemberId, user_id: userId, role: 'member' },
     changedFields: ['user_id', 'role'],
     actorSource: 'ui',

--- a/packages/server/src/workspace/join-public.ts
+++ b/packages/server/src/workspace/join-public.ts
@@ -105,9 +105,10 @@ export async function joinPublicOrganization({
 
   invalidateMembershipRoleCache(organizationId, userId);
 
-  // The member row is committed; audit BEFORE the fallible projection so a
-  // drift failure cannot suppress the durable audit trail. `user` is the
-  // joining member — the actor of this self-service join.
+  // The member row is already committed above; the $member projection failure
+  // is caught and non-fatal, so emitting the audit trail here cannot be
+  // suppressed by it. `user` is the joining member — the actor of this
+  // self-service join.
   recordWorkspaceChangeEvent({
     organizationId,
     resourceKind: 'member',

--- a/packages/server/src/workspace/join-public.ts
+++ b/packages/server/src/workspace/join-public.ts
@@ -1,6 +1,7 @@
 import { generateSecureToken } from '../auth/oauth/utils';
 import { getDb } from '../db/client';
 import { ensureMemberEntity } from '../utils/member-entity';
+import { recordWorkspaceChangeEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
 import { invalidateMembershipRoleCache } from './multi-tenant';
 
@@ -95,6 +96,18 @@ export async function joinPublicOrganization({
   }
 
   invalidateMembershipRoleCache(organizationId, userId);
+
+  recordWorkspaceChangeEvent({
+    organizationId,
+    resourceKind: 'member',
+    resourceId: memberId,
+    op: 'created',
+    summary: `Member "${user.name || user.email}" joined public workspace`,
+    state: { id: memberId, user_id: userId, role: 'member' },
+    changedFields: ['user_id', 'role'],
+    actorSource: 'ui',
+    createdBy: userId,
+  });
 
   return { status: 'joined', organizationId, role: 'member' };
 }

--- a/packages/server/src/workspace/join-public.ts
+++ b/packages/server/src/workspace/join-public.ts
@@ -68,11 +68,19 @@ export async function joinPublicOrganization({
   const user = userRows[0];
 
   const memberId = `member_${generateSecureToken(8)}`;
-  await sql`
+  // ON CONFLICT DO NOTHING + RETURNING: when a concurrent request wins the
+  // race and already inserted this member, no row is returned and we must NOT
+  // emit an audit event for a phantom (never-inserted) member id.
+  const inserted = (await sql`
     INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
     VALUES (${memberId}, ${organizationId}, ${userId}, 'member', NOW())
     ON CONFLICT ("organizationId", "userId") DO NOTHING
-  `;
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  if (inserted.length === 0) {
+    return { status: 'already_member', organizationId, role: 'member' };
+  }
+  const committedMemberId = inserted[0].id;
 
   try {
     await ensureMemberEntity({
@@ -97,13 +105,16 @@ export async function joinPublicOrganization({
 
   invalidateMembershipRoleCache(organizationId, userId);
 
+  // The member row is committed; audit BEFORE the fallible projection so a
+  // drift failure cannot suppress the durable audit trail. `user` is the
+  // joining member — the actor of this self-service join.
   recordWorkspaceChangeEvent({
     organizationId,
     resourceKind: 'member',
-    resourceId: memberId,
+    resourceId: committedMemberId,
     op: 'created',
     summary: `Member "${user.name || user.email}" joined public workspace`,
-    state: { id: memberId, user_id: userId, role: 'member' },
+    state: { id: committedMemberId, user_id: userId, role: 'member' },
     changedFields: ['user_id', 'role'],
     actorSource: 'ui',
     createdBy: userId,

--- a/packages/server/src/workspace/join-public.ts
+++ b/packages/server/src/workspace/join-public.ts
@@ -41,19 +41,6 @@ export async function joinPublicOrganization({
   const { id: organizationId, visibility } = orgRows[0];
   if (visibility !== 'public') return { status: 'not_public' };
 
-  const existing = await sql<{ role: string }>`
-    SELECT role FROM "member"
-    WHERE "organizationId" = ${organizationId} AND "userId" = ${userId}
-    LIMIT 1
-  `;
-  if (existing.length > 0) {
-    return {
-      status: 'already_member',
-      organizationId,
-      role: existing[0].role,
-    };
-  }
-
   const userRows = await sql<{
     id: string;
     name: string;
@@ -67,48 +54,82 @@ export async function joinPublicOrganization({
   if (userRows.length === 0) return { status: 'not_found' };
   const user = userRows[0];
 
+  // $member projection + role cache must run whenever membership is known to
+  // exist — including already_member and concurrent ON CONFLICT paths. Across
+  // replicas the winner may have crashed after committing the member row; the
+  // loser (or a later retry) is the repair path. Only audit emission is gated
+  // on "this call inserted the row."
+  async function repairMemberProjection(role: string): Promise<void> {
+    try {
+      await ensureMemberEntity({
+        organizationId,
+        userId,
+        name: user.name || user.email,
+        email: user.email,
+        image: user.image ?? undefined,
+        role,
+        status: 'active',
+      });
+    } catch (err) {
+      // Drift risk: the member row is already committed, so a failure here
+      // leaves them without a resolvable $member claim and the authz gate hides
+      // every enforced channel from them. Structured to correlate with the drift
+      // detector; non-fatal so the join still succeeds.
+      logger.error(
+        { err, event: 'member_claim_drift', hook: 'joinPublicOrganization', organizationId, userId },
+        '[joinPublicOrganization] Failed to create $member entity',
+      );
+    }
+    invalidateMembershipRoleCache(organizationId, userId);
+  }
+
+  const existing = await sql<{ id: string; role: string }>`
+    SELECT id, role FROM "member"
+    WHERE "organizationId" = ${organizationId} AND "userId" = ${userId}
+    LIMIT 1
+  `;
+  if (existing.length > 0) {
+    await repairMemberProjection(existing[0].role);
+    return {
+      status: 'already_member',
+      organizationId,
+      role: existing[0].role,
+    };
+  }
+
   const memberId = `member_${generateSecureToken(8)}`;
   // ON CONFLICT DO NOTHING + RETURNING: when a concurrent request wins the
   // race and already inserted this member, no row is returned and we must NOT
-  // emit an audit event for a phantom (never-inserted) member id.
+  // emit an audit event for a phantom (never-inserted) member id. Projection
+  // repair + cache invalidation still run below for the losing replica.
   const inserted = (await sql`
     INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
     VALUES (${memberId}, ${organizationId}, ${userId}, 'member', NOW())
     ON CONFLICT ("organizationId", "userId") DO NOTHING
     RETURNING id
   `) as unknown as Array<{ id: string }>;
+
   if (inserted.length === 0) {
-    return { status: 'already_member', organizationId, role: 'member' };
-  }
-  const committedMemberId = inserted[0].id;
-
-  try {
-    await ensureMemberEntity({
+    const concurrent = await sql<{ id: string; role: string }>`
+      SELECT id, role FROM "member"
+      WHERE "organizationId" = ${organizationId} AND "userId" = ${userId}
+      LIMIT 1
+    `;
+    // Winner committed the row; if it is gone already treat as not found.
+    if (concurrent.length === 0) return { status: 'not_found' };
+    await repairMemberProjection(concurrent[0].role);
+    return {
+      status: 'already_member',
       organizationId,
-      userId,
-      name: user.name || user.email,
-      email: user.email,
-      image: user.image ?? undefined,
-      role: 'member',
-      status: 'active',
-    });
-  } catch (err) {
-    // Drift risk: the member row is already committed above, so a failure here
-    // leaves them without a resolvable $member claim and the authz gate hides
-    // every enforced channel from them. Structured to correlate with the drift
-    // detector; non-fatal so the join still succeeds.
-    logger.error(
-      { err, event: 'member_claim_drift', hook: 'joinPublicOrganization', organizationId, userId },
-      '[joinPublicOrganization] Failed to create $member entity',
-    );
+      role: concurrent[0].role,
+    };
   }
 
-  invalidateMembershipRoleCache(organizationId, userId);
+  const committedMemberId = inserted[0].id;
+  await repairMemberProjection('member');
 
-  // The member row is already committed above; the $member projection failure
-  // is caught and non-fatal, so emitting the audit trail here cannot be
-  // suppressed by it. `user` is the joining member — the actor of this
-  // self-service join.
+  // Only the inserting replica writes the audit trail — the concurrent loser
+  // must not invent a second "created" for a phantom id.
   recordWorkspaceChangeEvent({
     organizationId,
     resourceKind: 'member',


### PR DESCRIPTION
## Summary
Org creation, member add/join/remove/role, and invitation send/cancel/reject previously emitted **nothing** (or only a thin lifecycle row) into the `events` table — so "org created" / "member joined" never surfaced in the All activity feed. This closes the gap with `category='workspace'` change events (full redacted state snapshot + actor) at every chokepoint:

- `ensurePersonalOrganization`: org created + owner member created
- Better Auth org-plugin hooks: org created, member created/joined/removed/role-updated, invitation created/cancelled/rejected
- `joinPublicOrganization`: member created
- `$member` beforeCreate hook: invitation created

The new `recordWorkspaceChangeEvent` writer shares the `recordConfigChangeEvent` shape but stamps `metadata.category='workspace'`, so rows appear in **All activity** while staying out of the Deployments feed (which filters `category='config'`).

## Test plan
- [x] Intended files staged explicitly, then `make pre-pr-remote` clean (full Linux CI graph on Depot)
- [x] Targeted integration tests: `personal-org-workspace-audit.test.ts` (2), `personal-org-username`, `invitation-member-placeholder`, `install-operator`, deployment-routes (bun), config-redaction (44) — all green
- [x] `make pre-pr` clean (build, typecheck, knip, biome, naming, gateway-llm)
- [x] Typecheck clean

## Notes
No DB schema or API-surface changes — events rows only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit tracking for organization, member, and invitation changes, including creation, updates, removals, and invitation actions.
  * Added workspace audit events for personal organization provisioning and public organization joins.
  * Audit records now include change details, actor information, and safely redacted state snapshots.

* **Bug Fixes**
  * Prevented duplicate audit events during repeated provisioning and duplicate public-organization joins.
  * Improved protection of sensitive organization metadata in audit snapshots.
  * Restricted workspace audit events from content retrieval by non-members, including anonymous users, while preserving member access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->