### PR TITLE
refactor(connectors): drop changes-token param versioning

### DIFF
--- a/packages/connectors/src/__tests__/google_calendar.test.ts
+++ b/packages/connectors/src/__tests__/google_calendar.test.ts
@@ -414,7 +414,6 @@ describe('GoogleCalendarConnector durable changes feed', () => {
     expect(result.events[0]?.metadata?.status).toBe('cancelled');
     expect(result.events[0]?.metadata?.change_type).toBe('cancelled');
     expect(result.checkpoint.sync_token).toBe('NEXT');
-    expect(result.checkpoint.param_version).toBe(1);
 
     const first = new URL(urls[0]);
     expect(first.searchParams.get('singleEvents')).toBe('true');
@@ -443,14 +442,13 @@ describe('GoogleCalendarConnector durable changes feed', () => {
       feedKey: 'changes',
       config: { calendar_id: 'primary', max_results: 1 },
       credentials: { accessToken: 'tok' },
-      checkpoint: { sync_token: 'OLD', param_version: 1 },
+      checkpoint: { sync_token: 'OLD' },
     });
 
     expect(
       result.events.map((event: { origin_id: string }) => event.origin_id).sort()
     ).toEqual(['changed-1', 'changed-2']);
     expect(result.checkpoint.sync_token).toBe('FRESH');
-    expect(result.checkpoint.param_version).toBe(1);
     expect(urls).toHaveLength(2);
 
     const first = new URL(urls[0]);
@@ -467,36 +465,6 @@ describe('GoogleCalendarConnector durable changes feed', () => {
     expect(second.searchParams.get('pageToken')).toBe('p2');
     expect(second.searchParams.get('singleEvents')).toBe('true');
     expect(second.searchParams.get('showDeleted')).toBe('true');
-  });
-
-  test('a legacy (unversioned) changes checkpoint rolls over with one full traversal instead of replaying its token', async () => {
-    const connector = new GoogleCalendarConnector();
-    const { client, urls } = fakeHttp([
-      { items: [calEvent('rolled-1', '2026-08-10T10:00:00Z')], nextSyncToken: 'V2' },
-    ]);
-    connector.client = () => client;
-
-    const result = await connector.sync({
-      feedKey: 'changes',
-      config: { calendar_id: 'primary', max_results: 100 },
-      credentials: { accessToken: 'tok' },
-      checkpoint: { sync_token: 'LEGACY' },
-    });
-
-    const first = new URL(urls[0]);
-    expect(first.searchParams.get('syncToken')).toBeNull();
-    expect(first.searchParams.get('singleEvents')).toBe('true');
-    expect(first.searchParams.get('showDeleted')).toBe('true');
-    expect(first.searchParams.get('orderBy')).toBeNull();
-    expect(first.searchParams.get('timeMin')).toBeTruthy();
-    expect(first.searchParams.get('timeMax')).toBeNull();
-    expect(urls).toHaveLength(1);
-
-    expect(result.events.map((event: { origin_id: string }) => event.origin_id)).toEqual([
-      'rolled-1',
-    ]);
-    expect(result.checkpoint.sync_token).toBe('V2');
-    expect(result.checkpoint.param_version).toBe(1);
   });
 
   test('fails closed when a changes traversal completes without a durable sync token', async () => {
@@ -524,7 +492,7 @@ describe('GoogleCalendarConnector durable changes feed', () => {
         feedKey: 'changes',
         config: { calendar_id: 'primary', max_results: 100 },
         credentials: { accessToken: 'tok' },
-        checkpoint: { sync_token: 'OLD', param_version: 1 },
+        checkpoint: { sync_token: 'OLD' },
       })
     ).rejects.toThrow(/sync token/i);
   });

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -57,14 +57,8 @@ interface CalendarEventListResponse {
 // Checkpoint
 // ---------------------------------------------------------------------------
 
-// Google binds allowed query parameters to a changes sync token. Unversioned
-// v1.1.0 checkpoints predate `showDeleted`, so roll them over without replaying
-// their tokens under the current query shape.
-const CHANGES_CURSOR_VERSION = 1;
-
 interface CalendarCheckpoint {
   sync_token?: string;
-  param_version?: number;
   last_sync_at?: string;
 }
 
@@ -472,11 +466,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     const events: EventEnvelope[] = [];
     const durableChanges = ctx.feedKey === 'changes';
 
-    // Durable changes tokens are reusable only under the query shape that
-    // minted them. The legacy events feed retains its existing token behavior.
-    const tokenMintsCurrentShape =
-      !durableChanges || checkpoint.param_version === CHANGES_CURSOR_VERSION;
-    if (checkpoint.sync_token && tokenMintsCurrentShape) {
+    if (checkpoint.sync_token) {
       const result = await this.syncWithToken(
         http,
         calendarId,
@@ -485,7 +475,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
         durableChanges
       );
       if (result) {
-        return this.buildResult(result.events, result.nextSyncToken, durableChanges);
+        return this.buildResult(result.events, result.nextSyncToken);
       }
       // The stored token was rejected (see isSyncTokenRejection). Fall through
       // to a full sync exactly once — no retry loop. The full sync below either
@@ -568,7 +558,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       );
     }
 
-    return this.buildResult(events, nextSyncToken, durableChanges);
+    return this.buildResult(events, nextSyncToken);
   }
 
   // -------------------------------------------------------------------------
@@ -958,8 +948,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
   private buildResult(
     events: EventEnvelope[],
-    syncToken: string | undefined,
-    durableChanges: boolean
+    syncToken: string | undefined
   ): SyncResult {
     // Sort events by occurred_at descending
     events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
@@ -970,7 +959,6 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     // the key is absent, and the next run correctly starts from a full sync.
     const newCheckpoint: CalendarCheckpoint = {
       ...(syncToken ? { sync_token: syncToken } : {}),
-      ...(durableChanges && syncToken ? { param_version: CHANGES_CURSOR_VERSION } : {}),
       last_sync_at: new Date().toISOString(),
     };
 

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -466,6 +466,13 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     const events: EventEnvelope[] = [];
     const durableChanges = ctx.feedKey === 'changes';
 
+    // No cursor-version guard: v1.1.0 changes tokens (minted without
+    // showDeleted) were retired by a one-time migration that cleared any
+    // unversioned changes checkpoint. Hosted prod carried exactly one such feed
+    // and it was already versioned, so the migration was a no-op. Self-hosted
+    // installs upgrading from that release with a v1.1.0 changes token are out
+    // of migration reach and may see Google reject the token under the current
+    // query shape; their recovery is to clear the feed checkpoint.
     if (checkpoint.sync_token) {
       const result = await this.syncWithToken(
         http,


### PR DESCRIPTION
## Summary
Removes the `param_version` rollover machinery from the Google Calendar changes feed. The version gate existed only to retire v1.1.0 checkpoints whose tokens predated `showDeleted`. A prod migration confirmed zero such checkpoints remain (a single changes feed exists across all orgs and is already versioned; the one-time UPDATE clearing any unversioned changes token matched 0 rows), so the runtime rollover is dead code.

## Test plan
- [x] `make pre-pr` clean (build + typecheck + knip + lint + exposed-surface naming)
- [x] `make pre-pr-remote` — Depot run shows only pre-existing flaky server-integration/unit lanes failing (same `integration`+`integration-bun` lanes also failed on plain main at `9bb80218`, before this PR; `events_organization_id_fkey` FK + 5000ms hook/timeout flakes, all outside `packages/connectors/`)
- [x] Tests run: `bun test packages/connectors/src/__tests__/google_calendar.test.ts` → 15/15; full connectors suite 357 pass
- [x] Refactor red→green: updated incremental test (unversioned token must be reused) fails against old code (which rolled it over), passes after removal — outputs below

### Red (old code rolls over an unversioned token)
```
bun test packages/connectors/src/__tests__/google_calendar.test.ts
(fail) durable changes feed > incremental traversal keeps sync-compatible
       parameters and never drops changes before advancing the token
 14 pass
 1 fail
```

### Green (after removing version machinery)
```
bun test packages/connectors/src/__tests__/google_calendar.test.ts
 15 pass
 0 fail
```

## Notes
Prod migration (already applied, no-op): `UPDATE feeds SET checkpoint = checkpoint - 'sync_token' ... WHERE connector_key='google.calendar' AND feed_key='changes' AND checkpoint ? 'sync_token' AND checkpoint->>'param_version' IS DISTINCT FROM '1'` → `UPDATE 0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Calendar synchronization by consistently resuming incremental updates with stored sync tokens.
  * Removed outdated checkpoint version handling to provide more reliable initial and ongoing calendar syncs.
* **Tests**
  * Updated coverage to validate durable sync-token behavior during initial and incremental synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->