### PR TITLE
fix(server): make approval transitions atomic

### DIFF
--- a/packages/server/src/__tests__/integration/connection-delete-expires-pending-approvals.test.ts
+++ b/packages/server/src/__tests__/integration/connection-delete-expires-pending-approvals.test.ts
@@ -8,7 +8,15 @@
  * approval" notification with nothing to review.
  */
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { ChatInstanceManager } from "../../gateway/connections/chat-instance-manager";
+import { SecretStoreRegistry } from "../../gateway/secrets/index";
+import { __setChatInstanceManagerForTests } from "../../lobu/gateway";
+import { createPostgresAppInstallationStore } from "../../lobu/stores/app-installation-store";
+import { PostgresSecretStore } from "../../lobu/stores/postgres-secret-store";
+import { createPostgresAgentConnectionStore } from "../../lobu/stores/postgres-stores";
+import { upsertSlackInstallByTeam } from "../../lobu/stores/slack-installations";
 import { insertEvent } from "../../utils/insert-event";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
@@ -233,6 +241,365 @@ describe("connection delete expires pending approvals", () => {
 				DROP TRIGGER IF EXISTS test_fail_connection_delete_supersede_trg ON events;
 				DROP FUNCTION IF EXISTS test_fail_connection_delete_supersede();
 			`);
+		}
+	});
+
+	it("chat teardown failure leaves the connection visible with approvals still pending", async () => {
+		// A chat connection's teardown is a fallible EXTERNAL call. It must run
+		// BEFORE approval expiry: if it fails, the connection stays visible and
+		// its approvals stay reviewable so the reviewer can still decide (or the
+		// user can retry the delete). (RED today: approval expiry commits in a
+		// phase BEFORE the teardown, so a failed teardown strands a visible
+		// connection with expired approvals.)
+		const sql = getTestDb();
+		const org = await createTestOrganization({ name: "chat teardown org" });
+		const user = await createTestUser();
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: "slack",
+			created_by: user.id,
+		});
+		await sql`
+			UPDATE connections SET credential_mode = 'managed' WHERE id = ${conn.id}
+		`;
+		const runId = await seedPendingApprovalRun({
+			organizationId: org.id,
+			connectionId: conn.id,
+			connectorKey: "slack",
+			actionKey: "send_message",
+		});
+
+		const client = await TestApiClient.for({
+			organizationId: org.id,
+			userId: user.id,
+			memberRole: "owner",
+		});
+		// The chat-platform teardown fails (no chat manager in the test harness),
+		// and the delete surfaces that as an error result.
+		await expect(client.connections.delete(conn.id)).rejects.toThrow(
+			/chat/i,
+		);
+
+		const [row] = await sql`
+			SELECT approval_status, status FROM runs WHERE id = ${runId}
+		`;
+		expect(row.approval_status).toBe("pending");
+		expect(row.status).toBe("pending");
+		const [connection] = await sql`
+			SELECT deleted_at FROM connections WHERE id = ${conn.id}
+		`;
+		expect(connection.deleted_at).toBeNull();
+	});
+
+	it("tombstone write failure rolls back approval expiry (expiry must not precede the tombstone)", async () => {
+		// The durable connection tombstone and every pending run/card transition
+		// commit ATOMICALLY: if the tombstone write fails, the approvals must not
+		// have been expired either. (RED today: expiry commits in its own earlier
+		// phase, so a tombstone failure leaves a visible connection whose pending
+		// approvals were already burned.)
+		const sql = getTestDb();
+		const org = await createTestOrganization({ name: "tombstone atomicity org" });
+		const user = await createTestUser();
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: "apple.computer_use",
+			created_by: user.id,
+		});
+		const runId = await seedPendingApprovalRun({
+			organizationId: org.id,
+			connectionId: conn.id,
+			connectorKey: "apple.computer_use",
+			actionKey: "observe",
+		});
+
+		await sql.unsafe(`
+			CREATE OR REPLACE FUNCTION test_fail_connection_tombstone()
+				RETURNS trigger AS $fn$
+			BEGIN
+				IF NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL THEN
+					RAISE EXCEPTION 'simulated connection tombstone failure';
+				END IF;
+				RETURN NEW;
+			END;
+			$fn$ LANGUAGE plpgsql;
+			CREATE TRIGGER test_fail_connection_tombstone_trg
+				BEFORE UPDATE ON connections
+				FOR EACH ROW EXECUTE FUNCTION test_fail_connection_tombstone();
+		`);
+
+		try {
+			const client = await TestApiClient.for({
+				organizationId: org.id,
+				userId: user.id,
+				memberRole: "owner",
+			});
+			await expect(client.connections.delete(conn.id)).rejects.toThrow(
+				/tombstone failure/i,
+			);
+
+			const [connection] = await sql`
+				SELECT deleted_at FROM connections WHERE id = ${conn.id}
+			`;
+			expect(connection.deleted_at).toBeNull();
+
+			const [row] = await sql`
+				SELECT approval_status, status FROM runs WHERE id = ${runId}
+			`;
+			expect(row.approval_status).toBe("pending");
+			expect(row.status).toBe("pending");
+		} finally {
+			await sql.unsafe(`
+				DROP TRIGGER IF EXISTS test_fail_connection_tombstone_trg ON connections;
+				DROP FUNCTION IF EXISTS test_fail_connection_tombstone();
+			`);
+		}
+	});
+});
+
+describe("chat connection delete — teardown + tombstone/approval atomicity", () => {
+	// A REAL ChatInstanceManager wired to the Postgres connection/install/secret
+	// stores via the gateway test seam, so the actual teardown paths
+	// (revokeManagedConnection / removeConnection / deleteSlackInstall) run —
+	// the DELETE handler must not hide a chat connection in a separate commit
+	// BEFORE the tombstone + pending-approval expiry transaction.
+	let manager: ChatInstanceManager;
+	let installStore: ReturnType<typeof createPostgresAppInstallationStore>;
+	let secretStore: SecretStoreRegistry;
+
+	beforeAll(() => {
+		installStore = createPostgresAppInstallationStore();
+		const pss = new PostgresSecretStore();
+		secretStore = new SecretStoreRegistry(pss, { secret: pss });
+		manager = new ChatInstanceManager();
+		(manager as unknown as { connectionStore: unknown }).connectionStore =
+			createPostgresAgentConnectionStore();
+		(manager as unknown as { services: unknown }).services = {
+			getSecretStore: () => secretStore,
+			getAppInstallationStore: () => installStore,
+		};
+		// removeConnection's history cleanup goes through a fresh state adapter
+		// when no warm instance exists; a connected gateway state is out of scope
+		// for this delete-atomicity suite, so stub the seam with a no-op state.
+		(manager as unknown as { createStateAdapter: unknown }).createStateAdapter =
+			async () => ({
+				get: async () => null,
+				delete: async () => undefined,
+			});
+		__setChatInstanceManagerForTests(manager);
+	});
+
+	afterAll(() => {
+		__setChatInstanceManagerForTests(null);
+	});
+
+	async function seedManagedSlackConnection(
+		organizationId: string,
+	): Promise<number> {
+		const installRow = await upsertSlackInstallByTeam(
+			installStore,
+			secretStore,
+			organizationId,
+			`T-${randomUUID().slice(0, 8)}`,
+			{ teamName: "Atomic Managed", botToken: "xoxb-atomic-managed" },
+		);
+		const rows = await getTestDb()`
+			SELECT id FROM connections
+			WHERE organization_id = ${organizationId} AND slug = ${installRow.id}
+		`;
+		return Number(rows[0].id);
+	}
+
+	async function seedByoChatConnection(
+		organizationId: string,
+		userId: string,
+	): Promise<number> {
+		const conn = await createTestConnection({
+			organization_id: organizationId,
+			connector_key: "slack",
+			created_by: userId,
+		});
+		const runtimeId = `byo-atomic-${randomUUID().slice(0, 8)}`;
+		await getTestDb()`
+			UPDATE connections
+			SET credential_mode = 'byo', slug = ${`agentconn-${runtimeId}`}
+			WHERE id = ${conn.id}
+		`;
+		return conn.id;
+	}
+
+	/** Force ONLY the delete's approval-card supersede INSERT to fail. */
+	async function failDeleteSupersedeFor(
+		sql: ReturnType<typeof getTestDb>,
+		runId: number,
+	): Promise<void> {
+		await sql.unsafe(`
+			CREATE OR REPLACE FUNCTION test_fail_chat_delete_supersede()
+				RETURNS trigger AS $fn$
+			BEGIN
+				IF NEW.supersedes_event_id IS NOT NULL AND NEW.run_id = ${runId} THEN
+					RAISE EXCEPTION 'simulated chat-delete supersede failure';
+				END IF;
+				RETURN NEW;
+			END;
+			$fn$ LANGUAGE plpgsql;
+			CREATE TRIGGER test_fail_chat_delete_supersede_trg
+				BEFORE INSERT ON events
+				FOR EACH ROW EXECUTE FUNCTION test_fail_chat_delete_supersede();
+		`);
+	}
+
+	async function dropDeleteSupersedeTrigger(
+		sql: ReturnType<typeof getTestDb>,
+	): Promise<void> {
+		await sql.unsafe(`
+			DROP TRIGGER IF EXISTS test_fail_chat_delete_supersede_trg ON events;
+			DROP FUNCTION IF EXISTS test_fail_chat_delete_supersede();
+		`);
+	}
+
+	async function assertConnectionVisibleWithPendingApproval(
+		connectionId: number,
+		runId: number,
+		organizationId: string,
+	): Promise<void> {
+		const sql = getTestDb();
+		const [connection] = await sql`
+			SELECT deleted_at FROM connections WHERE id = ${connectionId}
+		`;
+		expect(connection.deleted_at).toBeNull();
+		const [row] = await sql`
+			SELECT approval_status, status FROM runs WHERE id = ${runId}
+		`;
+		expect(row.approval_status).toBe("pending");
+		expect(row.status).toBe("pending");
+		const [card] = await sql`
+			SELECT interaction_status FROM current_event_records
+			WHERE run_id = ${runId} AND organization_id = ${organizationId}
+			  AND interaction_type = 'approval'
+		`;
+		expect(card?.interaction_status).toBe("pending");
+	}
+
+	it("managed chat: a teardown success + forced approval-card failure leaves the connection visible with approvals pending", async () => {
+		// The managed teardown (deleteSlackInstall → revokeManagedConnection)
+		// must NOT soft-delete the `connections` row by itself: the tombstone has
+		// to commit atomically with the pending-approval expiry. RED today: the
+		// teardown tombstones first, so the approval-card failure leaves a hidden
+		// connection (deleted_at set) with its approvals still pending.
+		const sql = getTestDb();
+		const org = await createTestOrganization({ name: "managed chat atomicity" });
+		const user = await createTestUser();
+		const connectionId = await seedManagedSlackConnection(org.id);
+		const runId = await seedPendingApprovalRun({
+			organizationId: org.id,
+			connectionId,
+			connectorKey: "slack",
+			actionKey: "send_message",
+		});
+
+		await failDeleteSupersedeFor(sql, runId);
+		try {
+			const client = await TestApiClient.for({
+				organizationId: org.id,
+				userId: user.id,
+				memberRole: "owner",
+			});
+			await expect(client.connections.delete(connectionId)).rejects.toThrow(
+				/supersede failure/i,
+			);
+			await assertConnectionVisibleWithPendingApproval(
+				connectionId,
+				runId,
+				org.id,
+			);
+		} finally {
+			await dropDeleteSupersedeTrigger(sql);
+		}
+	});
+
+	it("managed chat: the same atomicity holds for a forced tombstone write failure", async () => {
+		// Tombstone-write failure variant: the connection must stay visible and
+		// its approval must stay pending — the teardown may not pre-hide it.
+		const sql = getTestDb();
+		const org = await createTestOrganization({ name: "managed chat tombstone" });
+		const user = await createTestUser();
+		const connectionId = await seedManagedSlackConnection(org.id);
+		const runId = await seedPendingApprovalRun({
+			organizationId: org.id,
+			connectionId,
+			connectorKey: "slack",
+			actionKey: "send_message",
+		});
+
+		await sql.unsafe(`
+			CREATE OR REPLACE FUNCTION test_fail_chat_delete_tombstone()
+				RETURNS trigger AS $fn$
+			BEGIN
+				IF NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL THEN
+					RAISE EXCEPTION 'simulated chat tombstone failure';
+				END IF;
+				RETURN NEW;
+			END;
+			$fn$ LANGUAGE plpgsql;
+			CREATE TRIGGER test_fail_chat_delete_tombstone_trg
+				BEFORE UPDATE ON connections
+				FOR EACH ROW EXECUTE FUNCTION test_fail_chat_delete_tombstone();
+		`);
+		try {
+			const client = await TestApiClient.for({
+				organizationId: org.id,
+				userId: user.id,
+				memberRole: "owner",
+			});
+			await expect(client.connections.delete(connectionId)).rejects.toThrow(
+				/tombstone failure/i,
+			);
+			await assertConnectionVisibleWithPendingApproval(
+				connectionId,
+				runId,
+				org.id,
+			);
+		} finally {
+			await sql.unsafe(`
+				DROP TRIGGER IF EXISTS test_fail_chat_delete_tombstone_trg ON connections;
+				DROP FUNCTION IF EXISTS test_fail_chat_delete_tombstone();
+			`);
+		}
+	});
+
+	it("byo chat: a teardown success + forced approval-card failure leaves the connection visible with approvals pending", async () => {
+		// BYO teardown (removeConnection) must likewise not soft-delete the
+		// `connections` row before the atomic phase. RED today: the teardown's
+		// connectionStore.deleteConnection tombstones first, so the approval-card
+		// failure leaves a hidden connection with its approvals still pending.
+		const sql = getTestDb();
+		const org = await createTestOrganization({ name: "byo chat atomicity" });
+		const user = await createTestUser();
+		const connectionId = await seedByoChatConnection(org.id, user.id);
+		const runId = await seedPendingApprovalRun({
+			organizationId: org.id,
+			connectionId,
+			connectorKey: "slack",
+			actionKey: "send_message",
+		});
+
+		await failDeleteSupersedeFor(sql, runId);
+		try {
+			const client = await TestApiClient.for({
+				organizationId: org.id,
+				userId: user.id,
+				memberRole: "owner",
+			});
+			await expect(client.connections.delete(connectionId)).rejects.toThrow(
+				/supersede failure/i,
+			);
+			await assertConnectionVisibleWithPendingApproval(
+				connectionId,
+				runId,
+				org.id,
+			);
+		} finally {
+			await dropDeleteSupersedeTrigger(sql);
 		}
 	});
 });

--- a/packages/server/src/__tests__/integration/connection-delete-expires-pending-approvals.test.ts
+++ b/packages/server/src/__tests__/integration/connection-delete-expires-pending-approvals.test.ts
@@ -139,4 +139,100 @@ describe("connection delete expires pending approvals", () => {
 		expect(row?.approval_status).toBe("pending");
 		expect(row?.status).toBe("pending");
 	});
+
+	it("rolls back the deletion and every expiry when one approval card cannot advance", async () => {
+		const sql = getTestDb();
+		const org = await createTestOrganization({ name: "Acme atomic delete" });
+		const user = await createTestUser();
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: "apple.computer_use",
+			created_by: user.id,
+		});
+		const firstRunId = await seedPendingApprovalRun({
+			organizationId: org.id,
+			connectionId: conn.id,
+			connectorKey: "apple.computer_use",
+			actionKey: "observe",
+		});
+		const failingRunId = await seedPendingApprovalRun({
+			organizationId: org.id,
+			connectionId: conn.id,
+			connectorKey: "apple.computer_use",
+			actionKey: "click",
+		});
+
+		await sql.unsafe(`
+			CREATE OR REPLACE FUNCTION test_fail_connection_delete_supersede()
+				RETURNS trigger AS $fn$
+			BEGIN
+				IF NEW.supersedes_event_id IS NOT NULL AND NEW.run_id = ${failingRunId} THEN
+					RAISE EXCEPTION 'simulated connection-delete supersede failure';
+				END IF;
+				RETURN NEW;
+			END;
+			$fn$ LANGUAGE plpgsql;
+			CREATE TRIGGER test_fail_connection_delete_supersede_trg
+				BEFORE INSERT ON events
+				FOR EACH ROW EXECUTE FUNCTION test_fail_connection_delete_supersede();
+		`);
+
+		try {
+			const client = await TestApiClient.for({
+				organizationId: org.id,
+				userId: user.id,
+				memberRole: "owner",
+			});
+			await expect(client.connections.delete(conn.id)).rejects.toThrow(
+				/supersede failure/i,
+			);
+
+			const [connection] = await sql`
+				SELECT deleted_at FROM connections WHERE id = ${conn.id}
+			`;
+			expect(connection?.deleted_at).toBeNull();
+
+			const runs = await sql`
+				SELECT id, approval_status, status
+				FROM runs
+				WHERE id IN (${firstRunId}, ${failingRunId})
+				ORDER BY id
+			`;
+			expect(runs).toEqual([
+				expect.objectContaining({
+					id: firstRunId,
+					approval_status: "pending",
+					status: "pending",
+				}),
+				expect.objectContaining({
+					id: failingRunId,
+					approval_status: "pending",
+					status: "pending",
+				}),
+			]);
+
+			const cards = await sql`
+				SELECT run_id, interaction_status
+				FROM current_event_records
+				WHERE run_id IN (${firstRunId}, ${failingRunId})
+				  AND interaction_type = 'approval'
+				ORDER BY run_id
+			`;
+			expect(cards).toEqual([
+				expect.objectContaining({
+					run_id: firstRunId,
+					interaction_status: "pending",
+				}),
+				expect.objectContaining({
+					run_id: failingRunId,
+					interaction_status: "pending",
+				}),
+			]);
+		} finally {
+			await sql.unsafe(`
+				DROP TRIGGER IF EXISTS test_fail_connection_delete_supersede_trg ON events;
+				DROP FUNCTION IF EXISTS test_fail_connection_delete_supersede();
+			`);
+		}
+	});
 });

--- a/packages/server/src/__tests__/integration/connection-delete-expires-pending-approvals.test.ts
+++ b/packages/server/src/__tests__/integration/connection-delete-expires-pending-approvals.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
+import { insertEvent } from "../../utils/insert-event";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
 	createTestConnection,
@@ -34,7 +35,22 @@ async function seedPendingApprovalRun(opts: {
 		)
 		RETURNING id
 	`;
-	return Number(run.id);
+	const runId = Number(run.id);
+	await insertEvent({
+		entityIds: [],
+		organizationId: opts.organizationId,
+		originId: `run_${runId}_pending`,
+		title: `${opts.actionKey} — pending approval`,
+		content: "Awaiting review",
+		semanticType: "operation",
+		connectorKey: opts.connectorKey,
+		connectionId: opts.connectionId,
+		runId,
+		interactionType: "approval",
+		interactionStatus: "pending",
+		metadata: { action_key: opts.actionKey, run_id: runId },
+	});
+	return runId;
 }
 
 describe("connection delete expires pending approvals", () => {
@@ -76,6 +92,15 @@ describe("connection delete expires pending approvals", () => {
 		expect(row?.approval_status).toBe("expired");
 		expect(row?.status).toBe("cancelled");
 		expect(row?.completed_at).not.toBeNull();
+		const [card] = await sql`
+			SELECT interaction_status, metadata
+			FROM current_event_records
+			WHERE organization_id = ${org.id}
+			  AND run_id = ${runId}
+			  AND interaction_type = 'approval'
+		`;
+		expect(card?.interaction_status).toBe("rejected");
+		expect(card?.metadata?.approval_status).toBe("expired");
 	});
 
 	it("leaves pending approvals on other connections untouched", async () => {

--- a/packages/server/src/__tests__/integration/operations-approval-batch-scope.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-batch-scope.test.ts
@@ -111,7 +111,21 @@ describe("manage_operations batch scope (connector-approval lane)", () => {
       )
       RETURNING id
     `;
-		return Number(rows[0].id);
+		const runId = Number(rows[0].id);
+		// Production queued approvals always carry their pending card (the #2033
+		// queue path writes run + card in one transaction), so a decided run must
+		// have one here too — the transition supersedes it.
+		const cardTitle = `${opts.actionKey} — pending approval`;
+		await sql`
+      INSERT INTO events (
+        organization_id, origin_id, title, payload_text, run_id,
+        semantic_type, interaction_type, interaction_status
+      ) VALUES (
+        ${orgId}, ${`run_${runId}_pending`}, ${cardTitle},
+        'Awaiting review', ${runId}, 'operation', 'approval', 'pending'
+      )
+    `;
+		return runId;
 	}
 
 	async function approvalStatusOf(runId: number): Promise<string> {

--- a/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
@@ -12,6 +12,7 @@
  * reads the event; they diverge).
  */
 
+import postgres from "postgres";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Context } from "hono";
 import type { Env } from "../../index";
@@ -31,6 +32,10 @@ import {
 	ownerToolContext,
 	seedOwnerContext,
 } from "../setup/test-fixtures";
+
+// Counts how many times the external POST /items mutation actually ran, so a
+// retry that re-executes the mutation is detectable (it must run exactly once).
+let postItemsCalls = 0;
 
 const CONNECTOR = "demo.ops.transition.atomic";
 
@@ -277,6 +282,7 @@ describe("approval-run transition atomicity", () => {
 						);
 					}
 					if (url === "https://api.example.test/items") {
+						postItemsCalls += 1;
 						return new Response(JSON.stringify({ created: true }), {
 							status: 200,
 							headers: { "content-type": "application/json" },
@@ -390,11 +396,112 @@ describe("approval-run transition atomicity", () => {
 		expect(run.status).not.toBe("completed");
 		expect(run.status).toBe("running");
 		expect(run.approval_status).toBe("approved");
-		expect(run.action_output).toBeNull();
+		// The successful apply result (the human's ANSWER) is the entire outcome
+		// of an agent_ask — it must have been persisted DURABLY before the
+		// terminalization attempt, so a failed card write cannot lose it.
+		// (RED today: it rolls back with the completed write and reads null.)
+		expect(run.action_output).toEqual({ answer: { decision: "ship it" } });
 
 		// Card is still the 'confirmed' claim — no completed card, no failed card.
 		expect((await currentApprovalCard(runId, orgId))?.interaction_status).toBe(
 			"approved",
+		);
+	});
+
+	it("agent_ask: a retry after a card-write failure completes the run without losing the answer", async () => {
+		const sql = getTestDb();
+		const runId = await seedAgentAskRun(orgId, userId);
+
+		await sql.unsafe(FAIL_COMPLETED_TRIGGER);
+		await expect(
+			manageOperations(
+				{ action: "approve", run_id: runId, input: { decision: "ship it" } },
+				{} as Env,
+				humanCtx,
+			),
+		).rejects.toThrow(/terminal approval-event write failure/);
+
+		// The run is stuck in the claimed state with the answer durably retained.
+		const [stuck] = await sql`
+			SELECT status, action_output FROM runs WHERE id = ${runId}
+		`;
+		expect(stuck.status).toBe("running");
+		expect(stuck.action_output).toEqual({ answer: { decision: "ship it" } });
+
+		// Drop the failure trigger; a re-approve must RECONCILE the stuck run —
+		// terminalize it from the durable output — instead of reporting "not
+		// pending approval" (RED today: the run can never be approved again).
+		await sql.unsafe(DROP_FAIL_TRIGGER);
+		const retried = (await manageOperations(
+			{ action: "approve", run_id: runId },
+			{} as Env,
+			humanCtx,
+		)) as { approved?: boolean; error?: string };
+		expect(retried.error).toBeUndefined();
+		expect(retried.approved).toBe(true);
+
+		const [run] = await sql`
+			SELECT status, action_output FROM runs WHERE id = ${runId}
+		`;
+		expect(run.status).toBe("completed");
+		expect(run.action_output).toEqual({ answer: { decision: "ship it" } });
+		expect((await currentApprovalCard(runId, orgId))?.interaction_status).toBe(
+			"completed",
+		);
+	});
+
+	it("inline action: a card-write failure retains the output and a retry completes WITHOUT re-executing the mutation", async () => {
+		const sql = getTestDb();
+		const postItemsBefore = postItemsCalls;
+		const queued = (await manageOperations(
+			{
+				action: "execute",
+				connection_id: connectionId,
+				operation_key: "create_item",
+				input: { body: { value: "retry-no-rexec" } },
+			},
+			{} as Env,
+			humanCtx,
+		)) as { run_id: number };
+		expect(queued.status).toBe("pending_approval");
+
+		await sql.unsafe(FAIL_COMPLETED_TRIGGER);
+		await expect(
+			manageOperations(
+				{ action: "approve", run_id: queued.run_id },
+				{} as Env,
+				humanCtx,
+			),
+		).rejects.toThrow(/terminal approval-event write failure/);
+
+		// The external POST ran exactly once and its result was retained.
+		expect(postItemsCalls).toBe(postItemsBefore + 1);
+		const [stuck] = await sql`
+			SELECT status, approval_status, action_output FROM runs WHERE id = ${queued.run_id}
+		`;
+		expect(stuck.status).toBe("running");
+		expect(stuck.approval_status).toBe("approved");
+		expect(stuck.action_output).toEqual({ body: { created: true } });
+
+		// Re-approve after the trigger is gone: the run completes from the
+		// durable output — the external mutation is NOT repeated.
+		await sql.unsafe(DROP_FAIL_TRIGGER);
+		const retried = (await manageOperations(
+			{ action: "approve", run_id: queued.run_id },
+			{} as Env,
+			humanCtx,
+		)) as { approved?: boolean; error?: string };
+		expect(retried.error).toBeUndefined();
+		expect(retried.approved).toBe(true);
+
+		expect(postItemsCalls).toBe(postItemsBefore + 1);
+		const [run] = await sql`
+			SELECT status, action_output FROM runs WHERE id = ${queued.run_id}
+		`;
+		expect(run.status).toBe("completed");
+		expect(run.action_output).toEqual({ body: { created: true } });
+		expect((await currentApprovalCard(queued.run_id, orgId))?.interaction_status).toBe(
+			"completed",
 		);
 	});
 
@@ -461,6 +568,84 @@ describe("approval-run transition atomicity", () => {
 		`;
 		expect(row.approval_status).toBe("pending");
 		expect(row.status).toBe("pending");
+	});
+
+	it("approval queueing is serialized against connection deletion (no approval lands in the gap)", async () => {
+		// A delete holds the exclusive connection-row lock across its tombstone +
+		// approval-expiry transaction. The queue path must take a SHARE lock on
+		// the same row before inserting a pending approval run, so an approval
+		// cannot commit into the gap between the delete's expiry scan and its
+		// tombstone. (RED today: the queue's run INSERT only serializes via the
+		// runs.connection_id FK, which lets the insert commit AFTER the tombstone
+		// — a pending approval hidden behind a deleted connection, never expired.)
+		const lockConn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: CONNECTOR,
+			created_by: userId,
+			visibility: "private",
+			config: { action_modes: { create_item: "approval" } },
+		});
+
+		const locker = postgres(process.env.DATABASE_URL as string, { max: 1 });
+		let executePromise: Promise<Record<string, unknown>> | undefined;
+		let outcome: Record<string, unknown> | undefined;
+		try {
+			await locker.begin(async (tx) => {
+				// Simulate an in-flight delete holding the exclusive lock.
+				await tx`
+					SELECT 1 FROM connections
+					WHERE id = ${lockConn.id} AND organization_id = ${orgId}
+						AND deleted_at IS NULL
+					FOR UPDATE
+				`;
+
+				// A queue request races the delete. It is NOT awaited inside the
+				// delete transaction: its connection-row lock (or the FK's
+				// key-share lock) blocks until the delete commits, and the delete
+				// must not wait on it or the pair deadlocks.
+				executePromise = manageOperations(
+					{
+						action: "execute",
+						connection_id: lockConn.id,
+						operation_key: "create_item",
+						input: { body: { value: "lock-gap" } },
+					},
+					{} as Env,
+					humanCtx,
+				).then(
+					(result) => ({ ok: result as Record<string, unknown> }),
+					(error) => ({ rejected: String((error as Error).message) }),
+				);
+
+				// Let the queue attempt to land while the delete holds its lock.
+				await new Promise((resolve) => setTimeout(resolve, 200));
+
+				// The delete commits its tombstone; only then may the queue
+				// proceed — and it must be refused because the connection is gone.
+				await tx`
+					UPDATE connections
+					SET deleted_at = NOW(), status = 'paused', updated_at = NOW()
+					WHERE id = ${lockConn.id}
+				`;
+			});
+			// locker.begin committed here: the FOR UPDATE is released and the
+			// queue either completed (RED) or was refused (GREEN).
+			outcome = await executePromise;
+		} finally {
+			await locker.end();
+		}
+		// The queue did NOT create a pending approval on the deleted connection:
+		// either an error result or a rejection is the accepted outcome.
+		const record = (outcome ?? {}) as Record<string, unknown>;
+		expect("rejected" in record || "error" in record).toBe(true);
+
+		const runs = await getTestDb()`
+			SELECT count(*)::int AS n FROM runs
+			WHERE connection_id = ${lockConn.id}
+				AND run_type = 'action'
+				AND approval_status = 'pending'
+		`;
+		expect(runs[0].n).toBe(0);
 	});
 });
 

--- a/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
+++ b/packages/server/src/__tests__/integration/operations-approval-transition-atomicity.test.ts
@@ -1,0 +1,662 @@
+/**
+ * Approval-run TRANSITION atomicity — a decision's `runs` write and its
+ * superseding card event must commit together.
+ *
+ * #2033 fixed the QUEUE path (run + pending approval event in one tx, see
+ * operations-approval-event-atomicity.test.ts). This covers the far end: when
+ * a human approves and the operation completes inline, the terminal
+ * `runs.status='completed'` write and the 'completed' card supersede must be
+ * atomic. Forced failure of the completed-event INSERT must roll the run's
+ * terminal state back too — today the runs write commits while the card stays
+ * at 'confirmed' (the agent reads `runs.action_output` via get_run; the UI card
+ * reads the event; they diverge).
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { Context } from "hono";
+import type { Env } from "../../index";
+import { queueAgentAsk } from "../../notifications/ask";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import type { ToolContext } from "../../tools/registry";
+import { createAuthProfile } from "../../utils/auth-profiles";
+import { insertEvent } from "../../utils/insert-event";
+import { completeActionRun } from "../../worker-api";
+import { failClaimedWorkerRun } from "../../worker-api/poll";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestConnection,
+	createTestConnectorDefinition,
+	createTestOrganization,
+	ownerToolContext,
+	seedOwnerContext,
+} from "../setup/test-fixtures";
+
+const CONNECTOR = "demo.ops.transition.atomic";
+
+// Force a REAL failure of ONLY the terminal 'completed' card INSERT. The
+// 'confirmed' event (the approval claim) writes `interaction_status='approved'`,
+// so it must still succeed — the failure is isolated to the terminal phase, the
+// exact divergence the two-phase atomicity fixes. This is a DB-level trigger,
+// not a module mock, so it works under this suite's `isolate:false` shared
+// registry.
+const FAIL_COMPLETED_TRIGGER = `
+CREATE OR REPLACE FUNCTION test_fail_terminal_approval_event() RETURNS trigger AS $fn$
+BEGIN
+  IF NEW.interaction_type = 'approval' AND NEW.interaction_status = 'completed' THEN
+    RAISE EXCEPTION 'simulated terminal approval-event write failure';
+  END IF;
+  RETURN NEW;
+END;
+$fn$ LANGUAGE plpgsql;
+CREATE TRIGGER test_fail_terminal_approval_event_trg
+  BEFORE INSERT ON events
+  FOR EACH ROW EXECUTE FUNCTION test_fail_terminal_approval_event();
+`;
+const DROP_FAIL_TRIGGER = `
+DROP TRIGGER IF EXISTS test_fail_terminal_approval_event_trg ON events;
+DROP FUNCTION IF EXISTS test_fail_terminal_approval_event();
+`;
+const FAIL_FAILED_TRIGGER = `
+CREATE OR REPLACE FUNCTION test_fail_failed_approval_event() RETURNS trigger AS $fn$
+BEGIN
+  IF NEW.interaction_type = 'approval' AND NEW.interaction_status = 'failed' THEN
+    RAISE EXCEPTION 'simulated failed approval-event write failure';
+  END IF;
+  RETURN NEW;
+END;
+$fn$ LANGUAGE plpgsql;
+CREATE TRIGGER test_fail_failed_approval_event_trg
+  BEFORE INSERT ON events
+  FOR EACH ROW EXECUTE FUNCTION test_fail_failed_approval_event();
+`;
+const DROP_FAIL_FAILED_TRIGGER = `
+DROP TRIGGER IF EXISTS test_fail_failed_approval_event_trg ON events;
+DROP FUNCTION IF EXISTS test_fail_failed_approval_event();
+`;
+
+// Force the QUEUE-path pending card INSERT to fail so the run INSERT + card
+// creation must commit atomically (or not at all).
+const FAIL_PENDING_TRIGGER = `
+CREATE OR REPLACE FUNCTION test_fail_pending_approval_event() RETURNS trigger AS $fn$
+BEGIN
+  IF NEW.interaction_type = 'approval' AND NEW.interaction_status = 'pending' THEN
+    RAISE EXCEPTION 'simulated pending approval-event write failure';
+  END IF;
+  RETURN NEW;
+END;
+$fn$ LANGUAGE plpgsql;
+CREATE TRIGGER test_fail_pending_approval_event_trg
+  BEFORE INSERT ON events
+  FOR EACH ROW EXECUTE FUNCTION test_fail_pending_approval_event();
+`;
+const DROP_FAIL_PENDING_TRIGGER = `
+DROP TRIGGER IF EXISTS test_fail_pending_approval_event_trg ON events;
+DROP FUNCTION IF EXISTS test_fail_pending_approval_event();
+`;
+
+/**
+ * Seed a pending agent-ask run + its pending approval card, exactly the shape
+ * `queueAgentAsk` produces (legacy ask: no input_schema_validation_version, so
+ * approve's validateInput passes without schema enforcement).
+ */
+async function seedAgentAskRun(
+	organizationId: string,
+	userId: string,
+): Promise<number> {
+	const sql = getTestDb();
+	const [run] = await sql`
+		INSERT INTO runs (
+			organization_id, run_type, action_key, action_input,
+			created_by_user_id, approval_status, status, created_at
+		) VALUES (
+			${organizationId}, 'internal', 'agent_ask',
+			${sql.json({
+				question: "Should we ship the staging change?",
+				input_schema: { type: "object" },
+			})},
+			${userId}, 'pending', 'pending', NOW()
+		)
+		RETURNING id
+	`;
+	const runId = Number(run.id);
+	await insertEvent({
+		entityIds: [],
+		organizationId,
+		originId: `run_${runId}_pending`,
+		title: "Should we ship the staging change?",
+		content: null,
+		semanticType: "operation",
+		runId,
+		interactionType: "approval",
+		interactionStatus: "pending",
+		interactionInputSchema: { type: "object" },
+		metadata: {
+			tool: "notify",
+			action_key: "agent_ask",
+			question: "Should we ship the staging change?",
+			status: "pending_approval",
+			run_id: runId,
+		},
+		authorName: "agent",
+	});
+	return runId;
+}
+
+/** Minimal worker context for driving the REAL completeActionRun handler. */
+function mockWorkerCtx(body: unknown): {
+	ctx: Context<{ Bindings: Env }>;
+	result: () => { body: unknown; status: number };
+} {
+	let captured: { body: unknown; status: number } = {
+		body: undefined,
+		status: 200,
+	};
+	const ctx = {
+		req: { json: async () => body },
+		var: {},
+		json: (b: unknown, status?: number) => {
+			captured = { body: b, status: status ?? 200 };
+			return captured as unknown as Response;
+		},
+	} as unknown as Context<{ Bindings: Env }>;
+	return { ctx, result: () => captured };
+}
+
+async function currentApprovalCard(
+	runId: number,
+	organizationId: string,
+): Promise<{ interaction_status: string } | undefined> {
+	const rows = await getTestDb()<{ interaction_status: string }>`
+		SELECT interaction_status FROM current_event_records
+		WHERE run_id = ${runId} AND organization_id = ${organizationId}
+			AND semantic_type = 'operation' AND interaction_type = 'approval'
+	`;
+	return rows[0];
+}
+
+describe("approval-run transition atomicity", () => {
+	let orgId: string;
+	let userId: string;
+	let humanCtx: ToolContext;
+	let connectionId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const { org, user } = await seedOwnerContext({
+			orgName: "Approval Transition Org",
+		});
+		orgId = org.id;
+		userId = user.id;
+		humanCtx = ownerToolContext(orgId, userId);
+		humanCtx.baseUrl = "https://gateway.test/lobu";
+
+		await createTestConnectorDefinition({
+			key: CONNECTOR,
+			name: "Approval Transition",
+			organization_id: orgId,
+			auth_schema: { methods: [{ type: "oauth", provider: "test" }] },
+		});
+
+		const sql = getTestDb();
+		await sql`
+			UPDATE connector_definitions
+			SET openapi_config = ${sql.json({
+				specUrl: "https://api.example.test/openapi.json",
+				serverUrl: "https://api.example.test",
+			})}
+			WHERE organization_id = ${orgId} AND key = ${CONNECTOR}
+		`;
+
+		const conn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: CONNECTOR,
+			created_by: userId,
+			visibility: "private",
+			config: { action_modes: { create_item: "approval" } },
+		});
+		connectionId = conn.id;
+
+		const accountId = `acct_${connectionId}_transition`;
+		await sql`
+			INSERT INTO "account" (
+			  id, "accountId", "providerId", "userId",
+			  "accessToken", "accessTokenExpiresAt", scope, "createdAt", "updatedAt"
+			) VALUES (
+			  ${accountId}, ${accountId}, 'test', ${userId},
+			  'tok', ${new Date(Date.now() + 3_600_000).toISOString()}, 'read write', NOW(), NOW()
+			)
+		`;
+		const profile = await createAuthProfile({
+			organizationId: orgId,
+			connectorKey: CONNECTOR,
+			displayName: "transition test OAuth",
+			profileKind: "oauth_account",
+			provider: "test",
+			accountId,
+			status: "active",
+			createdBy: userId,
+		});
+		await sql`
+			UPDATE connections
+			SET auth_profile_id = ${profile.id}
+			WHERE id = ${connectionId}
+		`;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async (input: string | URL | Request, init?: RequestInit) => {
+					const url = String(input);
+					if (url === "https://api.example.test/openapi.json") {
+						return new Response(
+							JSON.stringify({
+								openapi: "3.0.0",
+								servers: [{ url: "https://api.example.test" }],
+								paths: {
+									"/items": {
+										post: {
+											operationId: "create_item",
+											requestBody: {
+												content: {
+													"application/json": {
+														schema: { type: "object" },
+													},
+												},
+											},
+											responses: { "200": { description: "ok" } },
+										},
+									},
+								},
+							}),
+							{
+								status: 200,
+								headers: { "content-type": "application/json" },
+							},
+						);
+					}
+					if (url === "https://api.example.test/items") {
+						return new Response(JSON.stringify({ created: true }), {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						});
+					}
+					throw new Error(`Unexpected fetch: ${url}`);
+				},
+			),
+		);
+	});
+
+	afterEach(async () => {
+		// Always drop the failure triggers so they can't leak into other tests
+		// that share this DB under the suite's single-fork registry.
+		await getTestDb().unsafe(DROP_FAIL_TRIGGER);
+		await getTestDb().unsafe(DROP_FAIL_PENDING_TRIGGER);
+		await getTestDb().unsafe(DROP_FAIL_FAILED_TRIGGER);
+	});
+
+	afterAll(async () => {
+		await getTestDb().unsafe(DROP_FAIL_TRIGGER);
+		await getTestDb().unsafe(DROP_FAIL_PENDING_TRIGGER);
+		await getTestDb().unsafe(DROP_FAIL_FAILED_TRIGGER);
+		vi.unstubAllGlobals();
+	});
+
+	it("terminal event write failure rolls back the run's completed state", async () => {
+		const sql = getTestDb();
+		const queued = (await manageOperations(
+			{
+				action: "execute",
+				connection_id: connectionId,
+				operation_key: "create_item",
+				input: { body: { value: "transition-test" } },
+			},
+			{} as Env,
+			humanCtx,
+		)) as { run_id: number; status: string; event_id: number };
+		expect(queued.status).toBe("pending_approval");
+
+		// Before the approve, the card is pending (the queue path is already atomic).
+		const before = await sql`
+			SELECT interaction_status FROM current_event_records
+			WHERE run_id = ${queued.run_id} AND organization_id = ${orgId}
+				AND semantic_type = 'operation' AND interaction_type = 'approval'
+		`;
+		expect(before[0]?.interaction_status).toBe("pending");
+
+		// Force ONLY the terminal 'completed' card INSERT to fail; the 'confirmed'
+		// event must still write so the failure is isolated to the terminal phase.
+		await sql.unsafe(FAIL_COMPLETED_TRIGGER);
+
+		await expect(
+			manageOperations(
+				{ action: "approve", run_id: queued.run_id },
+				{} as Env,
+				humanCtx,
+			),
+		).rejects.toThrow(/terminal approval-event write failure/);
+
+		// RED today: the `runs.status='completed'` write commits before the card
+		// INSERT throws, so the run is left terminal-completed while the card is
+		// stuck at 'confirmed'. GREEN after the fix: both writes share one
+		// transaction, so the terminal state rolls back and the run is NOT
+		// completed (or failed) — it stays in the approved/running claim state.
+		const [run] = await sql`
+			SELECT approval_status, status, action_output
+			FROM runs
+			WHERE id = ${queued.run_id} AND organization_id = ${orgId}
+		`;
+		expect(run.status).not.toBe("completed");
+		expect(run.status).not.toBe("failed");
+		expect(run.approval_status).toBe("approved");
+
+		// No completed card was ever written; the card stays at the confirmed
+		// claim — consistent with a run that never reached terminal state.
+		const [card] = await sql`
+			SELECT interaction_status FROM current_event_records
+			WHERE run_id = ${queued.run_id} AND organization_id = ${orgId}
+				AND semantic_type = 'operation' AND interaction_type = 'approval'
+		`;
+		expect(card?.interaction_status).toBe("approved");
+	});
+
+	it("builder completion card failure does NOT convert a successful apply into a business failure", async () => {
+		const sql = getTestDb();
+		const runId = await seedAgentAskRun(orgId, userId);
+
+		// Force ONLY the terminal 'completed' card INSERT to fail; the 'confirmed'
+		// claim must still succeed so the failure lands in phase 2 (after apply).
+		await sql.unsafe(FAIL_COMPLETED_TRIGGER);
+
+		// The apply (agent-ask returns the human's answer) SUCCEEDED — only the
+		// terminal card persistence failed. The persistence error must propagate,
+		// not be re-recorded as a business 'failed' via failBuilderRun.
+		await expect(
+			manageOperations(
+				{ action: "approve", run_id: runId, input: { decision: "ship it" } },
+				{} as Env,
+				humanCtx,
+			),
+		).rejects.toThrow(/terminal approval-event write failure/);
+
+		const [run] = await sql`
+			SELECT approval_status, status, action_output
+			FROM runs WHERE id = ${runId} AND organization_id = ${orgId}
+		`;
+		// The claim committed (approved/running) and phase 2 rolled back: the run
+		// is NOT marked 'failed' (a false business failure) and NOT 'completed'.
+		expect(run.status).not.toBe("failed");
+		expect(run.status).not.toBe("completed");
+		expect(run.status).toBe("running");
+		expect(run.approval_status).toBe("approved");
+		expect(run.action_output).toBeNull();
+
+		// Card is still the 'confirmed' claim — no completed card, no failed card.
+		expect((await currentApprovalCard(runId, orgId))?.interaction_status).toBe(
+			"approved",
+		);
+	});
+
+	it("queueAgentAsk run + pending card commit atomically (card failure leaves no run)", async () => {
+		const sql = getTestDb();
+		const runsBefore = await sql`
+			SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}
+		`;
+		const eventsBefore = await sql`
+			SELECT count(*)::int AS n FROM events
+			WHERE organization_id = ${orgId} AND interaction_type = 'approval'
+		`;
+
+		await sql.unsafe(FAIL_PENDING_TRIGGER);
+		await expect(
+			queueAgentAsk({
+				ctx: humanCtx,
+				question: "Queue-path atomicity check",
+				body: null,
+				inputSchema: { type: "object" },
+			}),
+		).rejects.toThrow(/pending approval-event write failure/);
+
+		// The run INSERT shared the rolled-back transaction: no stranded pending
+		// run and no orphaned card.
+		const runsAfter = await sql`
+			SELECT count(*)::int AS n FROM runs WHERE organization_id = ${orgId}
+		`;
+		expect(runsAfter[0].n).toBe(runsBefore[0].n);
+		const eventsAfter = await sql`
+			SELECT count(*)::int AS n FROM events
+			WHERE organization_id = ${orgId} AND interaction_type = 'approval'
+		`;
+		expect(eventsAfter[0].n).toBe(eventsBefore[0].n);
+	});
+
+	it("reject on a run with no approval card fails closed — the cancelled run write rolls back", async () => {
+		const sql = getTestDb();
+		// Corruption case: a pending connector-operation run whose approval card
+		// was never written (bypasses the #2033 atomic queue). The reject must
+		// NOT commit the cancelled write without a card.
+		const [run] = await sql`
+			INSERT INTO runs (
+				organization_id, run_type, status, approval_status, action_key, created_at
+			) VALUES (
+				${orgId}, 'action', 'pending', 'pending', 'create_issue', NOW()
+			)
+			RETURNING id
+		`;
+		const runId = Number(run.id);
+
+		await expect(
+			manageOperations(
+				{ action: "reject", run_id: runId, reason: "no card" },
+				{} as Env,
+				humanCtx,
+			),
+		).rejects.toThrow(/approval card is missing/);
+
+		// The cancelled write shared the rolled-back transaction (the guard runs
+		// INSIDE it): the run is still pending/pending, not cancelled.
+		const [row] = await sql`
+			SELECT approval_status, status FROM runs WHERE id = ${runId}
+		`;
+		expect(row.approval_status).toBe("pending");
+		expect(row.status).toBe("pending");
+	});
+});
+
+describe("worker completeActionRun card atomicity", () => {
+	let orgId: string;
+	let connectionId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		const org = await createTestOrganization({ name: "complete action atomicity" });
+		orgId = org.id;
+		const [conn] = (await getTestDb()`
+			INSERT INTO connections (
+				organization_id, connector_key, status, visibility, slug,
+				created_at, updated_at
+			) VALUES (
+				${orgId}, 'chrome', 'active', 'org', 'complete-action-test', NOW(), NOW()
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: number }>;
+		connectionId = Number(conn.id);
+	});
+
+	afterEach(async () => {
+		await getTestDb().unsafe(DROP_FAIL_TRIGGER);
+		await getTestDb().unsafe(DROP_FAIL_FAILED_TRIGGER);
+	});
+
+	afterAll(async () => {
+		await getTestDb().unsafe(DROP_FAIL_TRIGGER);
+		await getTestDb().unsafe(DROP_FAIL_FAILED_TRIGGER);
+	});
+
+	async function seedClaimedRun(opts: {
+		approvalStatus: string;
+		withCard: boolean;
+	}): Promise<number> {
+		const sql = getTestDb();
+		const [run] = (await sql`
+			INSERT INTO runs (
+				organization_id, run_type, connection_id, connector_key,
+				connector_version, action_key, approval_status, status,
+				claimed_by, claimed_at, created_at
+			) VALUES (
+				${orgId}, 'action', ${connectionId}, 'chrome',
+				'0.2.0', 'navigate', ${opts.approvalStatus}, 'running',
+				'worker-complete-test', NOW(), NOW()
+			)
+			RETURNING id
+		`) as unknown as Array<{ id: number }>;
+		const runId = Number(run.id);
+		if (opts.withCard) {
+			await insertEvent({
+				entityIds: [],
+				organizationId: orgId,
+				originId: `run_${runId}_confirmed`,
+				title: "navigate — executing",
+				content: null,
+				semanticType: "operation",
+				connectorKey: "chrome",
+				runId,
+				interactionType: "approval",
+				interactionStatus: "approved",
+				interactionInputSchema: null,
+				metadata: {
+					action_key: "navigate",
+					status: "confirmed",
+					run_id: runId,
+				},
+				authorName: "agent",
+			});
+		}
+		return runId;
+	}
+
+	it("auto/no-approval run finalizes normally with no card (worker action preserved)", async () => {
+		const runId = await seedClaimedRun({
+			approvalStatus: "auto",
+			withCard: false,
+		});
+		const { ctx, result } = mockWorkerCtx({
+			run_id: runId,
+			worker_id: "worker-complete-test",
+			status: "success",
+			action_output: { ok: true },
+		});
+		await completeActionRun(ctx);
+		expect((result().body as { success?: boolean }).success).toBe(true);
+
+		const [run] = await getTestDb()`
+			SELECT status, action_output FROM runs WHERE id = ${runId}
+		`;
+		expect(run.status).toBe("completed");
+		expect(run.action_output).toEqual({ ok: true });
+	});
+
+	it("approval run terminal card write failure rolls the terminal state back", async () => {
+		const runId = await seedClaimedRun({
+			approvalStatus: "approved",
+			withCard: true,
+		});
+		await getTestDb().unsafe(FAIL_COMPLETED_TRIGGER);
+
+		const { ctx, result } = mockWorkerCtx({
+			run_id: runId,
+			worker_id: "worker-complete-test",
+			status: "success",
+			action_output: { ok: true },
+		});
+		await completeActionRun(ctx);
+		expect((result().body as { error?: string }).error).toMatch(
+			/terminal approval-event write failure/,
+		);
+		expect(result().status).toBe(500);
+
+		// The finalizeRun write shared the rolled-back transaction: the run is
+		// still running (not completed) and the card is untouched.
+		const [run] = await getTestDb()`
+			SELECT status FROM runs WHERE id = ${runId}
+		`;
+		expect(run.status).toBe("running");
+		expect((await currentApprovalCard(runId, orgId))?.interaction_status).toBe(
+			"approved",
+		);
+	});
+
+	it("approval run with a missing card fails closed (terminal state rolled back)", async () => {
+		// Corruption case: approval-gated run whose card was never written or was
+		// lost. The completion must NOT commit the terminal state without a card.
+		const runId = await seedClaimedRun({
+			approvalStatus: "approved",
+			withCard: false,
+		});
+		const { ctx, result } = mockWorkerCtx({
+			run_id: runId,
+			worker_id: "worker-complete-test",
+			status: "success",
+			action_output: { ok: true },
+		});
+		await completeActionRun(ctx);
+		expect((result().body as { error?: string }).error).toMatch(
+			/approval card is missing/,
+		);
+		expect(result().status).toBe(500);
+
+		const [run] = await getTestDb()`
+			SELECT status FROM runs WHERE id = ${runId}
+		`;
+		expect(run.status).toBe("running");
+	});
+
+	it("worker pre-dispatch failure supersedes the approved card atomically", async () => {
+		const runId = await seedClaimedRun({
+			approvalStatus: "approved",
+			withCard: true,
+		});
+
+		const changed = await failClaimedWorkerRun({
+			runId,
+			workerId: "worker-complete-test",
+			errorMessage: "connector code unavailable",
+		});
+
+		expect(changed).toBe(true);
+		const [run] = await getTestDb()`
+			SELECT status, error_message FROM runs WHERE id = ${runId}
+		`;
+		expect(run.status).toBe("failed");
+		expect(run.error_message).toBe("connector code unavailable");
+		expect((await currentApprovalCard(runId, orgId))?.interaction_status).toBe(
+			"failed",
+		);
+	});
+
+	it("worker pre-dispatch failure rolls back when the failed card write fails", async () => {
+		const runId = await seedClaimedRun({
+			approvalStatus: "approved",
+			withCard: true,
+		});
+		await getTestDb().unsafe(FAIL_FAILED_TRIGGER);
+
+		await expect(
+			failClaimedWorkerRun({
+				runId,
+				workerId: "worker-complete-test",
+				errorMessage: "connector code unavailable",
+			}),
+		).rejects.toThrow(/failed approval-event write failure/);
+
+		const [run] = await getTestDb()`
+			SELECT status, error_message FROM runs WHERE id = ${runId}
+		`;
+		expect(run.status).toBe("running");
+		expect(run.error_message).toBeNull();
+		expect((await currentApprovalCard(runId, orgId))?.interaction_status).toBe(
+			"approved",
+		);
+	});
+});

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -469,15 +469,20 @@ export async function updateChatConnection(input: {
 export async function deleteChatConnection(
 	organizationId: string,
 	connectionId: number,
+	opts?: { skipConnectionTombstone?: boolean },
 ): Promise<void> {
 	const row = await getChatConnectionRow(organizationId, connectionId);
 	if (!row) throw new Error("Chat connection not found");
 	const manager = requireManager();
 	if (row.credential_mode === "managed") {
-		await manager.revokeManagedConnection(connectionId);
+		await manager.revokeManagedConnection(connectionId, {
+			skipTombstone: opts?.skipConnectionTombstone,
+		});
 		return;
 	}
 	await orgContext.run({ organizationId }, () =>
-		manager.removeConnection(slugToRuntimeConnectionId(row.slug)),
+		manager.removeConnection(slugToRuntimeConnectionId(row.slug), {
+			skipTombstone: opts?.skipConnectionTombstone,
+		}),
 	);
 }

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -526,7 +526,10 @@ export class ChatInstanceManager {
     return connection;
   }
 
-  async removeConnection(id: string): Promise<void> {
+  async removeConnection(
+    id: string,
+    opts?: { skipTombstone?: boolean },
+  ): Promise<void> {
     const instance = await this.stopInstance(id);
 
     const conversationState =
@@ -541,7 +544,12 @@ export class ChatInstanceManager {
       this.services.getSecretStore(),
 			`connections/${id}/`,
     );
-    await this.connectionStore.deleteConnection(id);
+    // The delete path passes skipTombstone so the unified `connections` row is
+    // NOT hidden here: the tombstone must commit atomically with the pending
+    // run/card expiry in `handleDelete`, never in a separate earlier commit.
+    if (!opts?.skipTombstone) {
+      await this.connectionStore.deleteConnection(id);
+    }
 
     // Drop any lease row for this connection. `connection_claims` has no FK
     // cascade onto connections, so without this an exclusive connection's
@@ -565,6 +573,7 @@ export class ChatInstanceManager {
    */
   async revokeManagedConnection(
 		connectionId: number,
+    opts?: { skipTombstone?: boolean },
   ): Promise<{ revoked: true }> {
     const sql = getDb();
     const rows = await sql`
@@ -589,6 +598,7 @@ export class ChatInstanceManager {
         this.services.getAppInstallationStore(),
         this.services.getSecretStore(),
 				row.slug,
+        { skipConnectionTombstone: opts?.skipTombstone },
       );
     } else {
       throw new Error(
@@ -598,10 +608,15 @@ export class ChatInstanceManager {
 
     // Soft-delete the unified projection so the UI stops listing it. Past
     // events stay (append-only); only the connection record is tombstoned.
-    await sql`
-      UPDATE connections SET deleted_at = now(), updated_at = now()
-      WHERE id = ${connectionId} AND organization_id = ${row.organization_id}
-    `;
+    // The delete path passes skipTombstone so the row stays VISIBLE here: the
+    // tombstone must commit atomically with the pending run/card expiry in
+    // `handleDelete`, never in a separate earlier commit.
+    if (!opts?.skipTombstone) {
+      await sql`
+        UPDATE connections SET deleted_at = now(), updated_at = now()
+        WHERE id = ${connectionId} AND organization_id = ${row.organization_id}
+      `;
+    }
     logger.info(
       { connectionId, connectorKey: row.connector_key },
 			"Revoked managed connection",

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -702,11 +702,19 @@ export async function revokeSlackInstallsForUninstall(
   return [...toStop.keys()];
 }
 
-/** Delete a Slack install and purge its bot-token secret. */
+/** Delete a Slack install and purge its bot-token secret.
+ *
+ * @param opts.skipConnectionTombstone When true, skip soft-deleting the
+ *   unified `connections` projection. The delete path calls this from a
+ *   fallible pre-transaction phase and must leave the row visible so the
+ *   connection tombstone commits ATOMICALLY with the pending-approval expiry
+ *   in `handleDelete` — never in a separate earlier commit.
+ */
 export async function deleteSlackInstall(
   store: AppInstallationStore,
   secretStore: WritableSecretStore,
-  id: string
+  id: string,
+  opts?: { skipConnectionTombstone?: boolean }
 ): Promise<void> {
   // Resolve the org first: the token was stored under the install org's bucket,
   // so the prefix delete must run under that org context.
@@ -716,10 +724,12 @@ export async function deleteSlackInstall(
   // Soft-delete the connections projection so the runtime stops reading it (a
   // connections HIT would otherwise shadow the now-deleted install — the
   // read-fallback only covers a MISS). Slug-scoped: slackinst- ids are unique.
-  await getDb()`
-    UPDATE connections SET deleted_at = now(), updated_at = now()
-    WHERE slug = ${id} AND deleted_at IS NULL AND credential_mode = 'managed'
-  `;
+  if (!opts?.skipConnectionTombstone) {
+    await getDb()`
+      UPDATE connections SET deleted_at = now(), updated_at = now()
+      WHERE slug = ${id} AND deleted_at IS NULL AND credential_mode = 'managed'
+    `;
+  }
   const purge = () =>
     deleteSecretsByPrefix(secretStore, `installations/${id}/`);
   if (orgId) {

--- a/packages/server/src/notifications/ask.ts
+++ b/packages/server/src/notifications/ask.ts
@@ -64,55 +64,66 @@ export async function queueAgentAsk(params: {
 	};
 	const initiator = resolveRunInitiator(params.ctx);
 
-	const inserted = await sql`
-    INSERT INTO runs (
-      organization_id, run_type, action_key, action_input,
-      watcher_id, window_id,
-      created_by_user_id, initiator_kind, initiator_ref,
-      approval_status, status, created_at
-    ) VALUES (
-      ${params.ctx.organizationId}, 'internal', ${AGENT_ASK_ACTION_KEY},
-      ${sql.json(proposal as unknown as Record<string, unknown>)},
-      ${params.ctx.actingWatcherId ?? null},
-      ${params.ctx.actingWindowId ?? null},
-      ${initiator.createdByUserId},
-      ${initiator.initiatorKind},
-      ${sql.json(initiator.initiatorRef)},
-      'pending', 'pending', current_timestamp
-    )
-    RETURNING id
-  `;
-	const runId = Number((inserted[0] as { id: unknown }).id);
+	// Atomic: the pending run and its approval card commit together. If the card
+	// INSERT fails, the run must not exist — otherwise the ask is durably
+	// pending but the events-only approval surface shows nothing (the #2033
+	// divergence, same as the connector queue path).
+	return sql.begin(async (tx) => {
+		const inserted = await tx`
+			INSERT INTO runs (
+				organization_id, run_type, action_key, action_input,
+				watcher_id, window_id,
+				created_by_user_id, initiator_kind, initiator_ref,
+				approval_status, status, created_at
+			) VALUES (
+				${params.ctx.organizationId}, 'internal', ${AGENT_ASK_ACTION_KEY},
+				${tx.json(proposal as unknown as Record<string, unknown>)},
+				${params.ctx.actingWatcherId ?? null},
+				${params.ctx.actingWindowId ?? null},
+				${initiator.createdByUserId},
+				${initiator.initiatorKind},
+				${tx.json(initiator.initiatorRef)},
+				'pending', 'pending', current_timestamp
+			)
+			RETURNING id
+		`;
+		const runId = Number((inserted[0] as { id: unknown }).id);
 
-	const event = await insertEvent({
-		entityIds: [],
-		organizationId: params.ctx.organizationId,
-		originId: `run_${runId}_pending`,
-		title: params.question,
-		content: params.body,
-		semanticType: "operation",
-		runId,
-		interactionType: "approval",
-		interactionStatus: "pending",
-		interactionInputSchema: params.inputSchema,
-		metadata: {
-			tool: "notify",
-			action_key: AGENT_ASK_ACTION_KEY,
-			question: params.question,
-			status: "pending_approval",
-			run_id: runId,
-			initiator: {
-				kind: initiator.initiatorKind,
-				...initiator.initiatorRef,
+		const event = await insertEvent(
+			{
+				entityIds: [],
+				organizationId: params.ctx.organizationId,
+				originId: `run_${runId}_pending`,
+				title: params.question,
+				content: params.body,
+				semanticType: "operation",
+				runId,
+				interactionType: "approval",
+				interactionStatus: "pending",
+				interactionInputSchema: params.inputSchema,
+				metadata: {
+					tool: "notify",
+					action_key: AGENT_ASK_ACTION_KEY,
+					question: params.question,
+					status: "pending_approval",
+					run_id: runId,
+					initiator: {
+						kind: initiator.initiatorKind,
+						...initiator.initiatorRef,
+					},
+					...currentMcpActivityEventMetadata(params.ctx),
+				},
+				authorName: params.ctx.clientId ?? "agent",
+				// Interaction events are deliberately not connection-scoped. Authorization
+				// treats them as reviewable workflow records, not connector-synced content.
+				clientId:
+					params.ctx.tokenType === "oauth"
+						? (params.ctx.clientId ?? null)
+						: null,
 			},
-			...currentMcpActivityEventMetadata(params.ctx),
-		},
-		authorName: params.ctx.clientId ?? "agent",
-		// Interaction events are deliberately not connection-scoped. Authorization
-		// treats them as reviewable workflow records, not connector-synced content.
-		clientId:
-			params.ctx.tokenType === "oauth" ? (params.ctx.clientId ?? null) : null,
-	});
+			{ sql: tx },
+		);
 
-	return { runId, interactionEventId: Number(event.id) };
+		return { runId, interactionEventId: Number(event.id) };
+	});
 }

--- a/packages/server/src/operations/execute-http-operation.ts
+++ b/packages/server/src/operations/execute-http-operation.ts
@@ -11,7 +11,7 @@ export type HttpOperationExecutionResult =
 			output: Record<string, unknown>;
 			metadata?: Record<string, unknown>;
 	  }
-	| { status: "failed"; error_message: string };
+	| { status: "failed"; error_message: string; output?: Record<string, unknown> };
 
 export interface HttpOperationConnection {
 	id: number;
@@ -72,8 +72,11 @@ async function failRun(
 	runId: number,
 	organizationId: string,
 	errorMessage: string,
+	deferTerminalWrite = false,
 ): Promise<HttpOperationExecutionResult> {
-	await getDb()`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+	if (!deferTerminalWrite) {
+		await getDb()`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+	}
 	return { status: "failed", error_message: errorMessage };
 }
 
@@ -120,6 +123,7 @@ export async function executeHttpOperation(
 	operation: OperationDescriptor,
 	actionInput: Record<string, unknown>,
 	abortSignal?: AbortSignal,
+	deferTerminalWrite = false,
 ): Promise<HttpOperationExecutionResult> {
 	const sql = getDb();
 	if (operation.backend_config.backend !== "http_operation") {
@@ -127,6 +131,7 @@ export async function executeHttpOperation(
 			runId,
 			organizationId,
 			"Invalid HTTP operation backend config",
+			deferTerminalWrite,
 		);
 	}
 
@@ -140,6 +145,7 @@ export async function executeHttpOperation(
 				runId,
 				organizationId,
 				`No active OAuth credentials found for '${connection.connector_key}'.`,
+				deferTerminalWrite,
 			);
 		}
 
@@ -227,13 +233,22 @@ export async function executeHttpOperation(
 		if (!response.ok) {
 			const errorText =
 				typeof parsedBody === "string" ? parsedBody : `HTTP ${response.status}`;
-			await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), action_output = ${sql.json(output)}, error_message = ${errorText} WHERE id = ${runId} AND organization_id = ${organizationId}`;
-			return { status: "failed", error_message: errorText };
+			if (!deferTerminalWrite) {
+				await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), action_output = ${sql.json(output)}, error_message = ${errorText} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+			}
+			return { status: "failed", error_message: errorText, output };
 		}
 
-		await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+		if (!deferTerminalWrite) {
+			await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+		}
 		return { status: "completed", output, metadata };
 	} catch (error) {
-		return failRun(runId, organizationId, getErrorMessage(error));
+		return failRun(
+			runId,
+			organizationId,
+			getErrorMessage(error),
+			deferTerminalWrite,
+		);
 	}
 }

--- a/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
+++ b/packages/server/src/scheduled/__tests__/expire-pending-approvals.test.ts
@@ -82,7 +82,25 @@ async function seedApproval(opts: SeedApprovalOpts): Promise<number> {
 			opts.ageDays,
 		],
 	)) as unknown as Array<{ id: number | string }>;
-	return Number(rows[0].id);
+	const runId = Number(rows[0].id);
+	// Production queued approvals always carry their pending card (the #2033
+	// queue path writes run + card in one transaction), and the expiry sweep
+	// supersedes that card — so a seeded PENDING run must have one here too.
+	// Non-pending states (approved/rejected/auto) never go through the sweep,
+	// so they get no card.
+	if (opts.approvalStatus === "pending") {
+		await getDb()`
+      INSERT INTO events (
+        organization_id, origin_id, title, payload_text, run_id,
+        semantic_type, interaction_type, interaction_status
+      ) VALUES (
+        ${opts.organizationId ?? ORG_ID}, ${`run_${runId}_pending`},
+        'Pending approval', 'Awaiting review', ${runId},
+        'operation', 'approval', 'pending'
+      )
+    `;
+	}
+	return runId;
 }
 
 async function runStateOf(
@@ -260,21 +278,12 @@ describe("expirePendingApprovals", () => {
 			ageDays: TTL_DAYS + 2,
 		});
 		const sql = getDb();
-		await sql`
-      INSERT INTO events (
-        organization_id, origin_id, title, payload_text, run_id,
-        semantic_type, interaction_type, interaction_status
-      ) VALUES (
-        ${ORG_ID}, ${`run_${staleId}_pending`}, 'Pending approval',
-        'Awaiting review', ${staleId}, 'operation', 'approval', 'pending'
-      )
-    `;
 		failTriggerCleanupNeeded = true;
 		await sql.unsafe(`
       CREATE OR REPLACE FUNCTION test_fail_expiry_supersede()
         RETURNS trigger AS $fn$
       BEGIN
-        IF NEW.supersedes_event_id IS NOT NULL THEN
+        IF NEW.supersedes_event_id IS NOT NULL AND NEW.run_id = ${staleId} THEN
           RAISE EXCEPTION 'simulated expiry supersede failure';
         END IF;
         RETURN NEW;
@@ -342,13 +351,28 @@ describe("expirePendingApprovals — draining and cross-org fairness", () => {
 		ageDays: number,
 	): Promise<void> {
 		const sql = getDb();
+		// One statement: insert the runs AND each one's pending approval card in
+		// a single data-modifying CTE, scoped exactly to the rows this call
+		// inserted — repeated calls can never backfill (and duplicate) cards for
+		// runs seeded by earlier calls.
 		await sql.unsafe(
-			`INSERT INTO runs (
-         organization_id, run_type, status, approval_status, action_key, created_at
+			`WITH inserted AS (
+         INSERT INTO runs (
+           organization_id, run_type, status, approval_status, action_key, created_at
+         )
+         SELECT $1, 'action', 'pending', 'pending', 'send_message',
+                now() - ($3::int * interval '1 day') - (g * interval '1 second')
+         FROM generate_series(1, $2::int) AS g
+         RETURNING id, organization_id
        )
-       SELECT $1, 'action', 'pending', 'pending', 'send_message',
-              now() - ($3::int * interval '1 day') - (g * interval '1 second')
-       FROM generate_series(1, $2::int) AS g`,
+       INSERT INTO events (
+         organization_id, origin_id, title, payload_text, run_id,
+         semantic_type, interaction_type, interaction_status
+       )
+       SELECT organization_id, 'run_' || id || '_pending',
+              'Pending approval', 'Awaiting review', id,
+              'operation', 'approval', 'pending'
+       FROM inserted`,
 			[organizationId, count, ageDays],
 		);
 	}

--- a/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
+++ b/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
@@ -450,6 +450,81 @@ describe("reapStaleRuns — connector lanes", () => {
 		}
 	});
 
+	// A claimed run whose APPLY already succeeded durably (action_output is
+	// persisted on a running/approved run) is a "terminalization pending" row: the
+	// external mutation already happened and only the completed card write failed.
+	// The reaper must COMPLETE it from the durable output, never report a FALSE
+	// timeout that would mislabel an already-successful external mutation.
+	test("an approved action run with durable output is completed, not timed out", async () => {
+		const runId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "action",
+			approvalStatus: "approved",
+		});
+		await seedApprovedActionCard(runId);
+		await getDb()`
+			UPDATE runs SET action_output = ${getDb().json({ body: { created: true } })}
+			WHERE id = ${runId}
+		`;
+
+		const result = await reapStaleRuns();
+
+		expect(result.reaped).toBe(1);
+		// (RED today: the reaper marks it 'timeout' + the card 'failed'.)
+		expect(await statusOf(runId)).toBe("completed");
+		expect(await currentApprovalCardStatus(runId)).toBe("completed");
+		const [run] = (await getDb()`
+			SELECT action_output FROM runs WHERE id = ${runId}
+		`) as unknown as Array<{ action_output: Record<string, unknown> }>;
+		expect(run.action_output).toEqual({ body: { created: true } });
+	});
+
+	test("approved action output completion rolls back when the completed card write fails", async () => {
+		const runId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "action",
+			approvalStatus: "approved",
+		});
+		await seedApprovedActionCard(runId);
+		await getDb()`
+			UPDATE runs SET action_output = ${getDb().json({ body: { created: true } })}
+			WHERE id = ${runId}
+		`;
+		await getDb().unsafe(`
+      CREATE OR REPLACE FUNCTION test_fail_stale_completed_event()
+        RETURNS trigger AS $fn$
+      BEGIN
+        IF NEW.interaction_type = 'approval' AND NEW.interaction_status = 'completed' THEN
+          RAISE EXCEPTION 'simulated stale completed-event write failure';
+        END IF;
+        RETURN NEW;
+      END;
+      $fn$ LANGUAGE plpgsql;
+      CREATE TRIGGER test_fail_stale_completed_event_trg
+        BEFORE INSERT ON events
+        FOR EACH ROW EXECUTE FUNCTION test_fail_stale_completed_event();
+    `);
+
+		try {
+			const result = await reapStaleRuns();
+
+			// The failed completed-card write rolls the completion back; the run
+			// stays running (its durable output intact) for the next tick.
+			expect(result.reaped).toBe(0);
+			expect(await statusOf(runId)).toBe("running");
+			expect(await currentApprovalCardStatus(runId)).toBe("approved");
+		} finally {
+			await getDb().unsafe(`
+				DROP TRIGGER IF EXISTS test_fail_stale_completed_event_trg ON events;
+				DROP FUNCTION IF EXISTS test_fail_stale_completed_event();
+			`);
+		}
+	});
+
 	test("claimed rows that never sent any heartbeat are reaped via claimed_at", async () => {
 		const id = await seedRun({
 			status: "claimed",

--- a/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
+++ b/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
@@ -24,6 +24,10 @@ import { reapStaleRuns } from "../check-stalled-executions";
 
 const ORG_ID = "reaper-org";
 const STALE_THRESHOLD_SECONDS = 60;
+const DROP_FAILED_APPROVAL_EVENT_TRIGGER = `
+DROP TRIGGER IF EXISTS test_fail_stale_approval_event_trg ON events;
+DROP FUNCTION IF EXISTS test_fail_stale_approval_event();
+`;
 
 beforeAll(async () => {
 	await ensureDbForGatewayTests();
@@ -134,6 +138,41 @@ async function approvalStatusOf(runId: number): Promise<string> {
     SELECT approval_status FROM runs WHERE id = ${runId}
   `) as unknown as Array<{ approval_status: string }>;
 	return rows[0]?.approval_status ?? "missing";
+}
+
+async function seedApprovedActionCard(runId: number): Promise<void> {
+	const sql = getDb();
+	await sql`
+    UPDATE runs SET action_key = 'stale_action' WHERE id = ${runId}
+  `;
+	await sql`
+    INSERT INTO events (
+      organization_id, origin_id, title, payload_text, run_id,
+      semantic_type, interaction_type, interaction_status, metadata
+    ) VALUES (
+      ${ORG_ID}, ${`run_${runId}_confirmed`}, 'stale_action — executing',
+      'Operation confirmed: stale_action', ${runId}, 'operation',
+      'approval', 'approved', ${sql.json({
+			status: "confirmed",
+			action_key: "stale_action",
+			run_id: runId,
+		})}
+    )
+  `;
+}
+
+async function currentApprovalCardStatus(runId: number): Promise<string> {
+	const rows = await getDb()<{
+		interaction_status: string;
+	}>`
+    SELECT interaction_status
+    FROM current_event_records
+    WHERE organization_id = ${ORG_ID}
+      AND run_id = ${runId}
+      AND semantic_type = 'operation'
+      AND interaction_type = 'approval'
+  `;
+	return rows[0]?.interaction_status ?? "missing";
 }
 
 describe("reapStaleRuns — connector lanes", () => {
@@ -357,6 +396,58 @@ describe("reapStaleRuns — connector lanes", () => {
       SELECT error_message FROM runs WHERE id = ${staleId}
     `) as unknown as Array<{ error_message: string | null }>;
 		expect(reaped[0].error_message).toBe("worker_heartbeat_lost");
+	});
+
+	test("approved action timeout supersedes its card in the same transition", async () => {
+		const runId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "action",
+			approvalStatus: "approved",
+		});
+		await seedApprovedActionCard(runId);
+
+		const result = await reapStaleRuns();
+
+		expect(result.reaped).toBe(1);
+		expect(await statusOf(runId)).toBe("timeout");
+		expect(await currentApprovalCardStatus(runId)).toBe("failed");
+	});
+
+	test("approved action timeout rolls back when its card write fails", async () => {
+		const runId = await seedRun({
+			status: "running",
+			lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+			runType: "action",
+			approvalStatus: "approved",
+		});
+		await seedApprovedActionCard(runId);
+		await getDb().unsafe(`
+      CREATE OR REPLACE FUNCTION test_fail_stale_approval_event()
+        RETURNS trigger AS $fn$
+      BEGIN
+        IF NEW.interaction_type = 'approval' AND NEW.interaction_status = 'failed' THEN
+          RAISE EXCEPTION 'simulated stale approval-event write failure';
+        END IF;
+        RETURN NEW;
+      END;
+      $fn$ LANGUAGE plpgsql;
+      CREATE TRIGGER test_fail_stale_approval_event_trg
+        BEFORE INSERT ON events
+        FOR EACH ROW EXECUTE FUNCTION test_fail_stale_approval_event();
+    `);
+
+		try {
+			const result = await reapStaleRuns();
+
+			expect(result.reaped).toBe(0);
+			expect(await statusOf(runId)).toBe("running");
+			expect(await currentApprovalCardStatus(runId)).toBe("approved");
+		} finally {
+			await getDb().unsafe(DROP_FAILED_APPROVAL_EVENT_TRIGGER);
+		}
 	});
 
 	test("claimed rows that never sent any heartbeat are reaped via claimed_at", async () => {

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -45,6 +45,7 @@ import { feedBackoff } from '../connectors/feed-backoff';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { classifyRunOutcome } from '../runs/run-outcome';
+import { supersedeActionEvent } from '../tools/admin/approval-events';
 import { expireStaleConnectTokens } from '../utils/connect-tokens';
 import logger from '../utils/logger';
 import { reconcileWatcherRuns, sweepStaleWatcherRuns } from '../watchers/automation';
@@ -111,6 +112,79 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
       const backoffBaseMs = feedBackoff.baseMs;
       const backoffMaxMs = feedBackoff.maxMs;
       const pauseThreshold = feedBackoff.pauseThreshold;
+
+      // Approval-gated action runs have a durable card, so their timeout must
+      // supersede that card in the SAME transaction as the runs write. Process
+      // this rare lane separately from the bulk connector CTE below: one
+      // corrupt/missing card then rolls back only its own run and cannot block
+      // sync retries or other stale actions. The UPDATE reasserts the complete
+      // staleness predicate, so a worker heartbeat/completion that wins after
+      // the candidate read makes this a no-op rather than being overwritten.
+      const approvedActionCandidates = (await reserved`
+        SELECT id
+        FROM public.runs
+        WHERE ${reserved.unsafe(staleWhereSql)}
+          AND run_type = 'action'
+          AND approval_status = 'approved'
+        ORDER BY id
+      `) as unknown as Array<{ id: number | string }>;
+      let approvalActionsReaped = 0;
+      for (const candidate of approvedActionCandidates) {
+        const runId = Number(candidate.id);
+        try {
+          const didReap = await sql.begin(async (tx) => {
+            const rows = await tx.unsafe<{
+              organization_id: string;
+              action_key: string | null;
+            }>(
+              `UPDATE public.runs
+               SET status = 'timeout',
+                   outcome = $2,
+                   completed_at = current_timestamp,
+                   error_message = $3
+               WHERE id = $1
+                 AND run_type = 'action'
+                 AND approval_status = 'approved'
+                 AND ${staleWhereSql}
+               RETURNING organization_id, action_key`,
+              [
+                runId,
+                classifyRunOutcome({ status: 'timeout' }),
+                heartbeatErrorMessage,
+              ]
+            );
+            if (rows.length === 0) return false;
+
+            const actionKey = rows[0].action_key ?? 'Action';
+            const eventId = await supersedeActionEvent(
+              runId,
+              rows[0].organization_id,
+              'failed',
+              `${actionKey} — timed out`,
+              `Action timed out: ${actionKey} — ${heartbeatErrorMessage}`,
+              {
+                error_message: heartbeatErrorMessage,
+                run_status: 'timeout',
+              },
+              null,
+              tx
+            );
+            if (eventId === undefined) {
+              throw new Error(
+                `Cannot time out approval run ${runId}: its approval card is missing`
+              );
+            }
+            return true;
+          });
+          if (didReap) approvalActionsReaped += 1;
+        } catch (error) {
+          logger.error(
+            { run_id: runId, error: String(error) },
+            '[reaper] Failed to atomically time out approved action run'
+          );
+        }
+      }
+
       // Reap + recover in a single statement using CTEs. Claimed/running sync
       // rows get one fresh retry; never-claimed rows are finalized on the feed
       // without a retry because another pending row would only repeat the same
@@ -141,6 +215,7 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
           SELECT id, status AS stale_status
           FROM public.runs
           WHERE ${reserved.unsafe(staleWhereSql)}
+            AND NOT (run_type = 'action' AND approval_status = 'approved')
           FOR UPDATE SKIP LOCKED
         ),
         timed_out AS (
@@ -260,7 +335,8 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
       }>;
 
       const reapedRow = reaped[0];
-      const reapedCount = reapedRow?.reaped ?? 0;
+      const reapedCount =
+        approvalActionsReaped + (reapedRow?.reaped ?? 0);
       const retriesCreated = reapedRow?.retries_created ?? 0;
       const syncEligible = reapedRow?.sync_eligible ?? 0;
 
@@ -293,7 +369,12 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
       }
 
       logger.warn(
-        { reaped: reapedCount, retriesCreated, thresholdSeconds },
+        {
+          reaped: reapedCount,
+          approvalActionsReaped,
+          retriesCreated,
+          thresholdSeconds,
+        },
         '[reaper] Marked stale connector runs as timeout'
       );
 

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -45,7 +45,10 @@ import { feedBackoff } from '../connectors/feed-backoff';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { classifyRunOutcome } from '../runs/run-outcome';
-import { supersedeActionEvent } from '../tools/admin/approval-events';
+import {
+  supersedeActionEvent,
+  terminalizeApprovalRunCompleted,
+} from '../tools/admin/approval-events';
 import { expireStaleConnectTokens } from '../utils/connect-tokens';
 import logger from '../utils/logger';
 import { reconcileWatcherRuns, sweepStaleWatcherRuns } from '../watchers/automation';
@@ -121,17 +124,48 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
       // staleness predicate, so a worker heartbeat/completion that wins after
       // the candidate read makes this a no-op rather than being overwritten.
       const approvedActionCandidates = (await reserved`
-        SELECT id
+        SELECT id, organization_id, action_key, action_output
         FROM public.runs
         WHERE ${reserved.unsafe(staleWhereSql)}
           AND run_type = 'action'
           AND approval_status = 'approved'
         ORDER BY id
-      `) as unknown as Array<{ id: number | string }>;
+      `) as unknown as Array<{
+        id: number | string;
+        organization_id: string;
+        action_key: string | null;
+        action_output: Record<string, unknown> | null;
+      }>;
       let approvalActionsReaped = 0;
       for (const candidate of approvedActionCandidates) {
         const runId = Number(candidate.id);
         try {
+          // A claimed action run with a DURABLE action_output already persisted
+          // is a terminalization-PENDING row: the external mutation succeeded
+          // and only the 'completed' card write failed. Complete it from the
+          // durable output — reporting a FALSE timeout here would mislabel an
+          // already-successful mutation as a failure. The completion is guarded
+          // (status='running' AND approval_status='approved') and shares its tx
+          // with the card, so a concurrent human retry or another pod's reaper
+          // tick cannot double-finalize, and a card failure rolls it back for
+          // the next tick to retry.
+          if (candidate.action_output != null) {
+            const actionKey = candidate.action_key ?? 'Action';
+            const eventId = await terminalizeApprovalRunCompleted(
+              runId,
+              candidate.organization_id,
+              candidate.action_output,
+              {
+                title: `${actionKey} — completed`,
+                content: `Operation completed: ${actionKey}`,
+              },
+              null,
+              sql
+            );
+            if (eventId !== null) approvalActionsReaped += 1;
+            continue;
+          }
+
           const didReap = await sql.begin(async (tx) => {
             const rows = await tx.unsafe<{
               organization_id: string;

--- a/packages/server/src/scheduled/expire-pending-approvals.ts
+++ b/packages/server/src/scheduled/expire-pending-approvals.ts
@@ -41,7 +41,7 @@
 
 import { intervals } from "../config/intervals";
 import { getDb, pgTextArray } from "../db/client";
-import { supersedeActionEvent } from "../tools/admin/manage_operations";
+import { supersedeActionEvent } from "../tools/admin/approval-events";
 import logger from "../utils/logger";
 import { APPROVAL_RUN_TYPES } from "../utils/run-statuses";
 
@@ -165,7 +165,11 @@ export async function expirePendingApprovals(
 					// `events` stays append-only. interaction_status has no 'expired'
 					// member, so the card uses 'rejected' as its non-actionable UI state
 					// while run status and metadata retain the precise expiry reason.
-					await supersedeActionEvent(
+					// A pending approval always HAS a card (written at queue time), so a
+					// missing one means corruption — fail closed: roll the expiry back and
+					// leave the run pending for the next sweep rather than committing a
+					// terminal run with no card.
+					const eventId = await supersedeActionEvent(
 						Number(row.id),
 						row.organization_id,
 						"rejected",
@@ -175,6 +179,11 @@ export async function expirePendingApprovals(
 						null,
 						tx,
 					);
+					if (eventId === undefined) {
+						throw new Error(
+							`Cannot expire approval run ${Number(row.id)}: its approval card is missing`,
+						);
+					}
 					return true;
 				});
 				if (didExpire) expiredCount += 1;

--- a/packages/server/src/tools/admin/approval-events.ts
+++ b/packages/server/src/tools/admin/approval-events.ts
@@ -1,0 +1,119 @@
+import type { DbClient } from "../../db/client";
+import { getDb } from "../../db/client";
+import { insertEvent } from "../../utils/insert-event";
+
+/**
+ * The human who decided an approval. Threaded from the approve/reject handler
+ * into every event of the post-decision chain so each state records who
+ * authorized it. `null` denotes a later system-driven transition.
+ */
+export interface ApprovalReviewer {
+	userId: string;
+	name: string | null;
+}
+
+/**
+ * Append the next durable state of an approval card, optionally on the
+ * caller's transaction handle. Returns undefined when the run has no current
+ * approval card so managed transitions can fail closed before committing the
+ * matching `runs` write.
+ */
+export async function supersedeActionEvent(
+	runId: number,
+	organizationId: string,
+	status: string,
+	title: string,
+	content: string,
+	extraMetadata: Record<string, unknown> = {},
+	reviewer: ApprovalReviewer | null = null,
+	db: DbClient = getDb(),
+	interactionInput?: Record<string, unknown> | null,
+): Promise<number | undefined> {
+	const sql = db;
+	const originalEvent = await sql`
+    SELECT id, entity_ids, connection_id, connector_key, metadata, author_name, interaction_input_schema, interaction_input
+    FROM current_event_records
+    WHERE run_id = ${runId}
+      AND organization_id = ${organizationId}
+      AND semantic_type = 'operation'
+      AND interaction_type = 'approval'
+    LIMIT 1
+  `;
+	if (originalEvent.length === 0) return undefined;
+
+	const orig = originalEvent[0] as any;
+	// Carry the reviewer forward. A decision supplies one; later system
+	// transitions inherit the reviewer stamped on the prior state.
+	const priorMetadata = (orig.metadata ?? {}) as Record<string, unknown>;
+	const reviewedById =
+		reviewer?.userId ??
+		(priorMetadata.reviewed_by_id as string | undefined) ??
+		null;
+	const reviewedByName =
+		reviewer?.name ??
+		(priorMetadata.reviewed_by_name as string | undefined) ??
+		null;
+
+	const nextEvent = await insertEvent(
+		{
+			entityIds: Array.isArray(orig.entity_ids)
+				? orig.entity_ids.map(Number)
+				: [],
+			organizationId,
+			originId: `run_${runId}_${status}_${Date.now()}`,
+			title,
+			content,
+			semanticType: "operation",
+			connectorKey: orig.connector_key,
+			connectionId: orig.connection_id,
+			runId,
+			interactionType: "approval",
+			interactionStatus:
+				status === "confirmed"
+					? "approved"
+					: status === "rejected"
+						? "rejected"
+						: status === "completed"
+							? "completed"
+							: status === "failed"
+								? "failed"
+								: "pending",
+			interactionInputSchema:
+				(orig.interaction_input_schema as Record<string, unknown> | null) ??
+				null,
+			interactionInput:
+				interactionInput === undefined
+					? ((orig.interaction_input as Record<string, unknown> | null) ?? null)
+					: interactionInput,
+			interactionOutput:
+				((extraMetadata.output ?? extraMetadata.action_output) as
+					| Record<string, unknown>
+					| undefined) ?? null,
+			interactionError:
+				(extraMetadata.error_message as string | undefined) ?? null,
+			supersedesEventId: Number(orig.id),
+			createdBy: reviewedById,
+			metadata: {
+				...priorMetadata,
+				status,
+				...(reviewedById ? { reviewed_by_id: reviewedById } : {}),
+				...(reviewedByName ? { reviewed_by_name: reviewedByName } : {}),
+				...(extraMetadata.output
+					? { action_output: extraMetadata.output }
+					: {}),
+				...(extraMetadata.error_message
+					? { error_message: extraMetadata.error_message }
+					: {}),
+				...extraMetadata,
+				...(priorMetadata.resourceKind === "watcher" ||
+				extraMetadata.resourceKind === "watcher"
+					? { resourceKind: "behavior" }
+					: {}),
+			},
+			authorName: orig.author_name ?? null,
+		},
+		{ sql },
+	);
+
+	return Number(nextEvent.id);
+}

--- a/packages/server/src/tools/admin/approval-events.ts
+++ b/packages/server/src/tools/admin/approval-events.ts
@@ -13,6 +13,75 @@ export interface ApprovalReviewer {
 }
 
 /**
+ * Fail-closed guard for a managed approval DECISION's card. {@link
+ * supersedeActionEvent} returns `undefined` when the run has NO approval card
+ * (`current_event_records` has no matching `interaction_type='approval'` row) —
+ * which is legitimate only for auto/no-approval worker actions that never had a
+ * card. A managed approval DECISION (approve/reject/expire) must never commit
+ * its runs write without the card, or the run goes terminal while the timeline
+ * stays stuck at the prior card. Callers throw on `undefined` so the enclosing
+ * transaction rolls the runs write back.
+ */
+export function requireApprovalCard(
+	runId: number,
+	eventId: number | undefined,
+	transition: string,
+): asserts eventId is number {
+	if (eventId === undefined) {
+		throw new Error(
+			`Cannot transition approval run ${runId} to '${transition}': its approval card is missing`,
+		);
+	}
+}
+
+/**
+ * Atomically persist a claimed run's terminal 'completed' state AND its
+ * 'completed' card. The runs write is guarded (status='running' AND
+ * approval_status='approved'), so concurrent terminalizations — a human retry
+ * and the stale-run reaper — cannot double-finalize: exactly one UPDATE wins,
+ * the loser matches zero rows and writes no card. The card guard runs INSIDE
+ * the tx, so a missing card rolls the completed write back (fail-closed).
+ *
+ * Returns the completed card event id, or null when the run was no longer in
+ * the claimed state (already terminalized concurrently) — the caller returns a
+ * "decided concurrently" outcome instead of writing anything.
+ */
+export async function terminalizeApprovalRunCompleted(
+	runId: number,
+	organizationId: string,
+	output: Record<string, unknown>,
+	card: { title: string; content: string },
+	reviewer: ApprovalReviewer | null,
+	db: DbClient = getDb(),
+): Promise<number | null> {
+	return db.begin(async (tx) => {
+		const rows = await tx`
+			UPDATE runs
+			SET status = 'completed', completed_at = NOW(),
+				action_output = ${tx.json(output)}
+			WHERE id = ${runId}
+				AND organization_id = ${organizationId}
+				AND status = 'running'
+				AND approval_status = 'approved'
+			RETURNING id
+		`;
+		if (rows.length === 0) return null;
+		const cardId = await supersedeActionEvent(
+			runId,
+			organizationId,
+			"completed",
+			card.title,
+			card.content,
+			{ output },
+			reviewer,
+			tx,
+		);
+		requireApprovalCard(runId, cardId, "completed");
+		return cardId;
+	});
+}
+
+/**
  * Append the next durable state of an approval card, optionally on the
  * caller's transaction handle. Returns undefined when the run has no current
  * approval card so managed transitions can fail closed before committing the

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -680,54 +680,63 @@ async function queueWriteForApproval(
   }
 
   const initiatorColumns = resolveRunInitiator(ctx);
-  const inserted = await sql`
-    INSERT INTO runs (
-      organization_id, run_type, action_key, action_input,
-      created_by_user_id, initiator_kind, initiator_ref,
-      approval_status, status, created_at
-    ) VALUES (
-      ${ctx.organizationId}, 'internal', ${MANAGE_AGENTS_ACTION_KEY},
-      ${sql.json(proposal as unknown as Record<string, unknown>)},
-      ${initiatorColumns.createdByUserId},
-      ${initiatorColumns.initiatorKind},
-      ${sql.json(initiatorColumns.initiatorRef)},
-      'pending', 'pending', current_timestamp
-    )
-    RETURNING id
-  `;
-  const runId = Number((inserted[0] as { id: unknown }).id);
-
   const label = actionLabel(proposal.action, proposal.agent_id);
-  const event = await insertEvent({
-    entityIds: [],
-    organizationId: ctx.organizationId,
-    originId: `run_${runId}_pending`,
-    title: `${label} — pending approval`,
-    content: `Builder requested: ${label}`,
-    semanticType: 'operation',
-    runId,
-    interactionType: 'approval',
-    interactionStatus: 'pending',
-    interactionInput: proposal as unknown as Record<string, unknown>,
-    metadata: {
-      tool: 'manage_agents',
-      action_key: MANAGE_AGENTS_ACTION_KEY,
-      action: proposal.action,
-      agent_id: proposal.agent_id,
-      proposal,
-      current: current ?? null,
-      initiator: {
-        kind: initiatorColumns.initiatorKind,
-        ...initiatorColumns.initiatorRef,
+  // Atomic: the pending run and its approval card commit together. If the card
+  // INSERT fails, the run must not exist — otherwise the proposal is durably
+  // pending but the events-only approval surface shows nothing (the #2033
+  // divergence, same as the connector queue path).
+  const { runId, eventId } = await sql.begin(async (tx) => {
+    const inserted = await tx`
+      INSERT INTO runs (
+        organization_id, run_type, action_key, action_input,
+        created_by_user_id, initiator_kind, initiator_ref,
+        approval_status, status, created_at
+      ) VALUES (
+        ${ctx.organizationId}, 'internal', ${MANAGE_AGENTS_ACTION_KEY},
+        ${tx.json(proposal as unknown as Record<string, unknown>)},
+        ${initiatorColumns.createdByUserId},
+        ${initiatorColumns.initiatorKind},
+        ${tx.json(initiatorColumns.initiatorRef)},
+        'pending', 'pending', current_timestamp
+      )
+      RETURNING id
+    `;
+    const runId = Number((inserted[0] as { id: unknown }).id);
+
+    const event = await insertEvent(
+      {
+        entityIds: [],
+        organizationId: ctx.organizationId,
+        originId: `run_${runId}_pending`,
+        title: `${label} — pending approval`,
+        content: `Builder requested: ${label}`,
+        semanticType: 'operation',
+        runId,
+        interactionType: 'approval',
+        interactionStatus: 'pending',
+        interactionInput: proposal as unknown as Record<string, unknown>,
+        metadata: {
+          tool: 'manage_agents',
+          action_key: MANAGE_AGENTS_ACTION_KEY,
+          action: proposal.action,
+          agent_id: proposal.agent_id,
+          proposal,
+          current: current ?? null,
+          initiator: {
+            kind: initiatorColumns.initiatorKind,
+            ...initiatorColumns.initiatorRef,
+          },
+          status: 'pending_approval',
+          run_id: runId,
+          ...currentMcpActivityEventMetadata(ctx),
+        },
+        authorName: ctx.clientId ?? 'agent',
+        clientId: ctx.tokenType === 'oauth' ? (ctx.clientId ?? null) : null,
       },
-      status: 'pending_approval',
-      run_id: runId,
-      ...currentMcpActivityEventMetadata(ctx),
-    },
-    authorName: ctx.clientId ?? 'agent',
-    clientId: ctx.tokenType === 'oauth' ? (ctx.clientId ?? null) : null,
+      { sql: tx },
+    );
+    return { runId, eventId: Number(event.id) };
   });
-  const eventId = Number(event.id);
 
   const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
   // An `update` proposal is config-shaped (name/description/identity), so its

--- a/packages/server/src/tools/admin/manage_behaviors.ts
+++ b/packages/server/src/tools/admin/manage_behaviors.ts
@@ -706,63 +706,72 @@ async function queueWatcherWriteForApproval(
 
   const sql = getDb();
   const initiatorColumns = resolveRunInitiator(ctx);
-  const inserted = await sql`
-    INSERT INTO runs (
-      organization_id, run_type, action_key, action_input,
-      created_by_user_id, initiator_kind, initiator_ref,
-      approval_status, status, created_at
-    ) VALUES (
-      ${ctx.organizationId}, 'internal', ${MANAGE_BEHAVIORS_ACTION_KEY},
-      ${sql.json(proposal as unknown as Record<string, unknown>)},
-      ${initiatorColumns.createdByUserId},
-      ${initiatorColumns.initiatorKind},
-      ${sql.json(initiatorColumns.initiatorRef)},
-      'pending', 'pending', current_timestamp
-    )
-    RETURNING id
-  `;
-  const runId = Number((inserted[0] as { id: unknown }).id);
-
   const label = watcherActionLabel(args);
   // Flat display fields for the events-tab fallback card (ActionApprovalCard
   // only renders input when interactionInputSchema is present). Keep the
   // nested proposal in metadata for the apply path / history replay.
   const displayInput = pickWatcherApprovalDisplayFields(args);
   const inputSchema = buildWatcherApprovalInputSchema(displayInput);
-  const event = await insertEvent({
-    entityIds: args.entity_id != null ? [args.entity_id] : [],
-    organizationId: ctx.organizationId,
-    originId: `run_${runId}_pending`,
-    title: `${label} — pending approval`,
-    content: `Builder requested: ${label}`,
-    semanticType: 'operation',
-    runId,
-    interactionType: 'approval',
-    interactionStatus: 'pending',
-    interactionInputSchema: inputSchema,
-    interactionInput: displayInput,
-    metadata: {
-      tool: 'manage_behaviors',
-      action_key: MANAGE_BEHAVIORS_ACTION_KEY,
-      action: args.action,
-      resourceKind: InteractionResourceKind.Behavior,
-      watcher_id: args.behavior_id ?? null,
-      proposal,
-      current: current ?? null,
-      initiator: {
-        kind: initiatorColumns.initiatorKind,
-        ...initiatorColumns.initiatorRef,
+  // Atomic: the pending run and its approval card commit together. If the card
+  // INSERT fails, the run must not exist — otherwise the proposal is durably
+  // pending but the events-only approval surface shows nothing (the #2033
+  // divergence, same as the connector queue path).
+  const { runId, eventId } = await sql.begin(async (tx) => {
+    const inserted = await tx`
+      INSERT INTO runs (
+        organization_id, run_type, action_key, action_input,
+        created_by_user_id, initiator_kind, initiator_ref,
+        approval_status, status, created_at
+      ) VALUES (
+        ${ctx.organizationId}, 'internal', ${MANAGE_BEHAVIORS_ACTION_KEY},
+        ${tx.json(proposal as unknown as Record<string, unknown>)},
+        ${initiatorColumns.createdByUserId},
+        ${initiatorColumns.initiatorKind},
+        ${tx.json(initiatorColumns.initiatorRef)},
+        'pending', 'pending', current_timestamp
+      )
+      RETURNING id
+    `;
+    const runId = Number((inserted[0] as { id: unknown }).id);
+
+    const event = await insertEvent(
+      {
+        entityIds: args.entity_id != null ? [args.entity_id] : [],
+        organizationId: ctx.organizationId,
+        originId: `run_${runId}_pending`,
+        title: `${label} — pending approval`,
+        content: `Builder requested: ${label}`,
+        semanticType: 'operation',
+        runId,
+        interactionType: 'approval',
+        interactionStatus: 'pending',
+        interactionInputSchema: inputSchema,
+        interactionInput: displayInput,
+        metadata: {
+          tool: 'manage_behaviors',
+          action_key: MANAGE_BEHAVIORS_ACTION_KEY,
+          action: args.action,
+          resourceKind: InteractionResourceKind.Behavior,
+          watcher_id: args.behavior_id ?? null,
+          proposal,
+          current: current ?? null,
+          initiator: {
+            kind: initiatorColumns.initiatorKind,
+            ...initiatorColumns.initiatorRef,
+          },
+          status: 'pending_approval',
+          run_id: runId,
+          input_schema: inputSchema,
+          action_input: displayInput,
+          ...currentMcpActivityEventMetadata(ctx),
+        },
+        authorName: ctx.clientId ?? 'agent',
+        clientId: ctx.tokenType === 'oauth' ? (ctx.clientId ?? null) : null,
       },
-      status: 'pending_approval',
-      run_id: runId,
-      input_schema: inputSchema,
-      action_input: displayInput,
-      ...currentMcpActivityEventMetadata(ctx),
-    },
-    authorName: ctx.clientId ?? 'agent',
-    clientId: ctx.tokenType === 'oauth' ? (ctx.clientId ?? null) : null,
+      { sql: tx },
+    );
+    return { runId, eventId: Number(event.id) };
   });
-  const eventId = Number(event.id);
 
   const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
   // An `update` is config-shaped, so its review surface is the watcher edit form

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -118,6 +118,7 @@ import {
 	oauthAppSetupContinuation,
 } from "../../helpers/connect-setup-continuation";
 import { createConnectionSetupBundle } from "../../helpers/interactive-connection-setup";
+import { supersedeActionEvent } from "../../approval-events";
 
 // ============================================
 // handleListConnectorGroups
@@ -2088,17 +2089,65 @@ export async function handleDelete(
   // would be blind. Same terminal state as the pending-approval TTL sweep
   // (scheduled/expire-pending-approvals): approval_status='expired',
   // status='cancelled'.
-  await sql`
-    UPDATE runs
-    SET approval_status = 'expired',
-        status = 'cancelled',
-        error_message = 'Connection deleted before approval; approval expired.',
-        completed_at = NOW()
+  const approvalExpiryReason =
+    'Connection deleted before approval; approval expired.';
+  const pendingApprovals = await sql<{ id: number; action_key: string | null }>`
+    SELECT id, action_key
+    FROM runs
     WHERE organization_id = ${organizationId}
       AND connection_id = ${args.connection_id}
       AND approval_status = 'pending'
       AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
+    ORDER BY id
   `;
+  for (const pendingApproval of pendingApprovals) {
+    try {
+      await sql.begin(async (tx) => {
+        const expired = await tx<{ action_key: string | null }>`
+          UPDATE runs
+          SET approval_status = 'expired',
+              status = 'cancelled',
+              error_message = ${approvalExpiryReason},
+              completed_at = NOW()
+          WHERE id = ${pendingApproval.id}
+            AND organization_id = ${organizationId}
+            AND connection_id = ${args.connection_id}
+            AND approval_status = 'pending'
+            AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
+          RETURNING action_key
+        `;
+        if (expired.length === 0) return;
+
+        const actionKey = expired[0].action_key ?? 'Action';
+        const eventId = await supersedeActionEvent(
+          pendingApproval.id,
+          organizationId,
+          'rejected',
+          `${actionKey} — expired`,
+          approvalExpiryReason,
+          {
+            expiry_reason: approvalExpiryReason,
+            approval_status: 'expired',
+          },
+          null,
+          tx
+        );
+        if (eventId === undefined) {
+          throw new Error(
+            `Cannot expire approval run ${pendingApproval.id}: its approval card is missing`
+          );
+        }
+      });
+    } catch (error) {
+      // Leave only this run pending if its append-only card cannot advance.
+      // The long-horizon approval sweep can retry it; other approvals and the
+      // connection deletion are not blocked by one corrupt historical row.
+      logger.warn(
+        { run_id: pendingApproval.id, error: String(error) },
+        '[connections.delete] approval expiry rolled back after card failure'
+      );
+    }
+  }
 
   // Record change event in knowledge for audit trail
   const conn = deleted[0];

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -2051,38 +2051,6 @@ export async function handleDelete(
 		credential_mode: string | null;
 	};
 
-  // Tear down any provider webhook subscription BEFORE the soft-delete, while
-  // the connection row (with its stored externalId + credentials) is still
-  // readable. Best-effort: the helper logs + swallows failures so a provider
-  // hiccup never blocks the delete.
-	let deleted: Array<Record<string, unknown>>;
-	if (target.credential_mode !== null) {
-		try {
-			await deleteChatConnection(organizationId, args.connection_id);
-		} catch (error) {
-			return { error: getErrorMessage(error) };
-		}
-		deleted = [target];
-	} else {
-  await unregisterConnectorWebhook({
-    organizationId,
-    connectionId: args.connection_id,
-  });
-		deleted = await sql`
-    UPDATE connections
-    SET deleted_at = NOW(), status = 'paused', updated_at = NOW()
-    WHERE id = ${args.connection_id} AND organization_id = ${organizationId} AND deleted_at IS NULL
-    RETURNING id, slug, display_name, connector_key
-  `;
-  }
-
-  // Cancel any pending runs for this connection's feeds
-  await sql`
-    UPDATE runs SET status = 'cancelled', completed_at = NOW()
-    WHERE feed_id IN (SELECT id FROM feeds WHERE connection_id = ${args.connection_id})
-      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-  `;
-
   // Expire any undecided approval runs for this connection. Deleting a
   // connection makes its pending approvals unreviewable — the card disappears
   // from every content read (connection-visibility predicate), so approve/reject
@@ -2091,19 +2059,27 @@ export async function handleDelete(
   // status='cancelled'.
   const approvalExpiryReason =
     'Connection deleted before approval; approval expired.';
-  const pendingApprovals = await sql<{ id: number; action_key: string | null }>`
-    SELECT id, action_key
-    FROM runs
-    WHERE organization_id = ${organizationId}
-      AND connection_id = ${args.connection_id}
-      AND approval_status = 'pending'
-      AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
-    ORDER BY id
-  `;
-  for (const pendingApproval of pendingApprovals) {
-    try {
-      await sql.begin(async (tx) => {
-        const expired = await tx<{ action_key: string | null }>`
+  const expirePendingApprovalsBeforeDelete = async (
+    db: DbClient
+  ): Promise<void> => {
+    // The whole batch shares one transaction. If any append-only card cannot
+    // advance, every run stays pending and the caller must leave the connection
+    // visible so a reviewer can still act on those cards.
+    const pendingApprovals = await db<{
+      id: number;
+      action_key: string | null;
+    }>`
+      SELECT id, action_key
+      FROM runs
+      WHERE organization_id = ${organizationId}
+        AND connection_id = ${args.connection_id}
+        AND approval_status = 'pending'
+        AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
+      ORDER BY id
+      FOR UPDATE
+    `;
+    for (const pendingApproval of pendingApprovals) {
+      const expired = await db<{ action_key: string | null }>`
           UPDATE runs
           SET approval_status = 'expired',
               status = 'cancelled',
@@ -2116,38 +2092,68 @@ export async function handleDelete(
             AND run_type = ANY(${pgTextArray([...APPROVAL_RUN_TYPES])}::text[])
           RETURNING action_key
         `;
-        if (expired.length === 0) return;
+      if (expired.length === 0) continue;
 
-        const actionKey = expired[0].action_key ?? 'Action';
-        const eventId = await supersedeActionEvent(
-          pendingApproval.id,
-          organizationId,
-          'rejected',
-          `${actionKey} — expired`,
-          approvalExpiryReason,
-          {
-            expiry_reason: approvalExpiryReason,
-            approval_status: 'expired',
-          },
-          null,
-          tx
-        );
-        if (eventId === undefined) {
-          throw new Error(
-            `Cannot expire approval run ${pendingApproval.id}: its approval card is missing`
-          );
-        }
-      });
-    } catch (error) {
-      // Leave only this run pending if its append-only card cannot advance.
-      // The long-horizon approval sweep can retry it; other approvals and the
-      // connection deletion are not blocked by one corrupt historical row.
-      logger.warn(
-        { run_id: pendingApproval.id, error: String(error) },
-        '[connections.delete] approval expiry rolled back after card failure'
+      const actionKey = expired[0].action_key ?? 'Action';
+      const eventId = await supersedeActionEvent(
+        pendingApproval.id,
+        organizationId,
+        'rejected',
+        `${actionKey} — expired`,
+        approvalExpiryReason,
+        {
+          expiry_reason: approvalExpiryReason,
+          approval_status: 'expired',
+        },
+        null,
+        db
       );
+      if (eventId === undefined) {
+        throw new Error(
+          `Cannot expire approval run ${pendingApproval.id}: its approval card is missing`
+        );
+      }
     }
+
+  };
+
+  // Phase 1 is entirely durable and all-or-nothing. Nothing external and no
+  // connection tombstone happens until every pending run/card pair advances.
+  await sql.begin(expirePendingApprovalsBeforeDelete);
+
+  // Phase 2 may perform provider work, so it stays outside the approval
+  // transaction. At this point no pending approval can become hidden by the
+  // connection deletion, even if provider cleanup is slow or best-effort.
+  let deleted: Array<Record<string, unknown>>;
+	if (target.credential_mode !== null) {
+		try {
+			await deleteChatConnection(organizationId, args.connection_id);
+		} catch (error) {
+			return { error: getErrorMessage(error) };
+		}
+		deleted = [target];
+	} else {
+    await unregisterConnectorWebhook({
+      organizationId,
+      connectionId: args.connection_id,
+    });
+		deleted = await sql`
+      UPDATE connections
+      SET deleted_at = NOW(), status = 'paused', updated_at = NOW()
+      WHERE id = ${args.connection_id}
+        AND organization_id = ${organizationId}
+        AND deleted_at IS NULL
+      RETURNING id, slug, display_name, connector_key
+    `;
   }
+
+  // Preserve the existing lifecycle: feed work is cancelled only after the
+  // connection teardown succeeds.
+  await sql`
+    UPDATE runs SET status = 'cancelled', completed_at = NOW()
+    WHERE feed_id IN (SELECT id FROM feeds WHERE connection_id = ${args.connection_id})
+      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+  `;
 
   // Record change event in knowledge for audit trail
   const conn = deleted[0];

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -2117,27 +2117,40 @@ export async function handleDelete(
 
   };
 
-  // Phase 1 is entirely durable and all-or-nothing. Nothing external and no
-  // connection tombstone happens until every pending run/card pair advances.
-  await sql.begin(expirePendingApprovalsBeforeDelete);
-
-  // Phase 2 may perform provider work, so it stays outside the approval
-  // transaction. At this point no pending approval can become hidden by the
-  // connection deletion, even if provider cleanup is slow or best-effort.
-  let deleted: Array<Record<string, unknown>>;
-	if (target.credential_mode !== null) {
-		try {
-			await deleteChatConnection(organizationId, args.connection_id);
-		} catch (error) {
-			return { error: getErrorMessage(error) };
-		}
-		deleted = [target];
-	} else {
+  // Phase 1: fallible EXTERNAL teardown runs FIRST, while the connection is
+  // still visible with its approvals pending. A teardown failure (e.g. the chat
+  // platform rejects the removal) returns an error BEFORE any approval is
+  // expired — the connection stays live and its approvals stay reviewable, so a
+  // reviewer can still decide or the user can retry the delete. The chat
+  // teardown is told NOT to tombstone the `connections` row: it only purges the
+  // external/platform artifacts (install, secrets, history, claims). The
+  // durable tombstone lands in Phase 2 with every pending run/card transition,
+  // so a teardown success followed by a DB failure leaves the connection
+  // visible and its approvals pending (a safe retry re-runs the idempotent
+  // teardown, then the atomic phase).
+  if (target.credential_mode !== null) {
+    try {
+      await deleteChatConnection(organizationId, args.connection_id, {
+        skipConnectionTombstone: true,
+      });
+    } catch (error) {
+      return { error: getErrorMessage(error) };
+    }
+  } else {
     await unregisterConnectorWebhook({
       organizationId,
       connectionId: args.connection_id,
     });
-		deleted = await sql`
+  }
+
+  // Phase 2 (atomic): the durable connection tombstone, every pending run/card
+  // transition, and the active-run cancellation commit together. The tombstone
+  // UPDATE below takes FOR UPDATE on the connection row, which serializes
+  // against approval QUEUEING: the execute path takes FOR SHARE on the same row,
+  // so no pending approval can be inserted between this expiry scan and the
+  // tombstone commit.
+  const deleted = await sql.begin(async (tx) => {
+    const tombstoned = await tx`
       UPDATE connections
       SET deleted_at = NOW(), status = 'paused', updated_at = NOW()
       WHERE id = ${args.connection_id}
@@ -2145,15 +2158,23 @@ export async function handleDelete(
         AND deleted_at IS NULL
       RETURNING id, slug, display_name, connector_key
     `;
-  }
+    if (tombstoned.length === 0) return null; // concurrently deleted
 
-  // Preserve the existing lifecycle: feed work is cancelled only after the
-  // connection teardown succeeds.
-  await sql`
-    UPDATE runs SET status = 'cancelled', completed_at = NOW()
-    WHERE feed_id IN (SELECT id FROM feeds WHERE connection_id = ${args.connection_id})
-      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-  `;
+    await expirePendingApprovalsBeforeDelete(tx);
+
+    // Preserve the existing lifecycle: feed work is cancelled as part of the
+    // same atomic commit, so a deleted connection never leaves active runs.
+    await tx`
+      UPDATE runs SET status = 'cancelled', completed_at = NOW()
+      WHERE feed_id IN (SELECT id FROM feeds WHERE connection_id = ${args.connection_id})
+        AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+    `;
+
+    return tombstoned;
+  });
+  if (deleted === null) {
+    return { error: "Connection not found or already deleted" };
+  }
 
   // Record change event in knowledge for audit trail
   const conn = deleted[0];

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -97,10 +97,13 @@ import { getOrgUrlContext } from "../view-urls";
 import { action, defineActionTool } from "./action-tool";
 import {
 	type ApprovalReviewer,
+	requireApprovalCard,
 	supersedeActionEvent,
+	terminalizeApprovalRunCompleted,
 } from "./approval-events";
 export {
 	type ApprovalReviewer,
+	requireApprovalCard,
 	supersedeActionEvent,
 } from "./approval-events";
 // Lives in its own module so dispatch-chrome-action does not import this file
@@ -1434,6 +1437,26 @@ async function handleExecute(
 		// createConnectorOperationRun via its db param (which also carries its
 		// connector-version read into the same tx — safe, it is a read).
 		const { claim, eventId } = await sql.begin(async (tx) => {
+			// Serialize approval queueing against connection deletion: take a SHARE
+			// lock on the connection row and re-verify it is still live. A delete's
+			// tombstone+expiry tx holds FOR UPDATE on the same row, so an in-flight
+			// delete blocks this tx until it commits, then this predicate sees the
+			// tombstone and refuses — an approval can never commit into the gap
+			// between a delete's expiry scan and its tombstone. (The runs
+			// FK key-share lock alone would only serialize, not refuse.)
+			const liveConnection = await tx`
+				SELECT 1 FROM connections
+				WHERE id = ${connection.id}
+					AND organization_id = ${ctx.organizationId}
+					AND deleted_at IS NULL
+				FOR SHARE
+			`;
+			if (liveConnection.length === 0) {
+				throw new ToolUserError(
+					`Connection ${args.connection_id} was deleted while this operation was being queued.`,
+					409,
+				);
+			}
 			const createdRun = await createConnectorOperationRun({
 				organizationId: ctx.organizationId,
 				connectionId: connection.id,
@@ -1836,25 +1859,104 @@ async function handleGetRun(
 }
 
 /**
- * Fail-closed guard for managed approval transitions. {@link
- * supersedeActionEvent} returns `undefined` when the run has NO approval card
- * (`current_event_records` has no matching `interaction_type='approval'` row) —
- * which is legitimate only for auto/no-approval worker actions that never had a
- * card. A managed approval DECISION (approve/reject/expire) must never commit
- * its runs write without the card, or the run goes terminal while the timeline
- * stays stuck at the prior card. Callers throw on `undefined` so the enclosing
- * transaction rolls the runs write back.
+ * Durably persist a claimed run's apply/execution output in its OWN
+ * transaction, BEFORE the terminalization attempt. If the terminal card write
+ * then fails, only the terminal status rolls back — the only durable copy of a
+ * successful external result (for agent_ask, the human's answer) survives, and
+ * a retry can complete the run without re-running the mutation or losing the
+ * output. Idempotent: re-writing the same value on a retry is a no-op.
+ *
+ * The guard (status='running' AND approval_status='approved') scopes the write
+ * to the claimed state; a run reaped/terminalized concurrently is left alone.
  */
-function requireApprovalCard(
+async function persistDurableApplyOutput(
 	runId: number,
-	eventId: number | undefined,
-	transition: string,
-): asserts eventId is number {
-	if (eventId === undefined) {
-		throw new Error(
-			`Cannot transition approval run ${runId} to '${transition}': its approval card is missing`,
+	organizationId: string,
+	output: Record<string, unknown>,
+): Promise<void> {
+	const sql = getDb();
+	await sql`
+		UPDATE runs SET action_output = ${sql.json(output)}
+		WHERE id = ${runId}
+			AND organization_id = ${organizationId}
+			AND status = 'running'
+			AND approval_status = 'approved'
+	`;
+}
+
+/**
+ * Re-attempt terminalization of a run whose apply/execution already succeeded
+ * durably but whose 'completed' card write failed and rolled back. Detected by
+ * the durable claim state: approval_status='approved' + status='running' +
+ * action_output NOT NULL — only {@link persistDurableApplyOutput} sets
+ * action_output on a non-terminal run, so the signal is unambiguous.
+ *
+ * Returns a result when the run was reconciled (terminalized from its durable
+ * output, no apply re-run); null when the run is not in that state so the
+ * caller falls through to the normal pending paths.
+ */
+async function tryReconcileTerminalization(
+	args: Static<typeof ApproveAction>,
+	ctx: ToolContext,
+	reviewer: ApprovalReviewer | null,
+): Promise<ManageOperationsResult | null> {
+	const sql = getDb();
+	const rows = await sql`
+		SELECT run_type, action_key, action_input, action_output
+		FROM runs
+		WHERE id = ${args.run_id}
+			AND organization_id = ${ctx.organizationId}
+			AND approval_status = 'approved'
+			AND status = 'running'
+			AND action_output IS NOT NULL
+			AND run_type = ANY(${pgTextArray(["internal", "action"])}::text[])
+		LIMIT 1
+	`;
+	if (rows.length === 0) return null;
+	const row = rows[0] as {
+		run_type: string;
+		action_key: string;
+		action_input: unknown;
+		action_output: Record<string, unknown>;
+	};
+	const output = row.action_output;
+	let title: string;
+	let content: string;
+	let message: string;
+	if (row.run_type === "internal") {
+		const handler = getBuilderApprovalHandlers().find(
+			(candidate) => candidate.actionKey === row.action_key,
 		);
+		if (!handler) return null;
+		const desc = handler.describe(row.action_input);
+		title = `${handler.nounLabel}: ${desc} — completed`;
+		content = `Builder action completed: ${desc}`;
+		message = `${handler.nounLabel} ${desc} approved and applied.`;
+	} else {
+		title = `${row.action_key} — completed`;
+		content = `Operation completed: ${row.action_key}`;
+		message = "Operation approved and executed.";
 	}
+	const eventId = await terminalizeApprovalRunCompleted(
+		args.run_id,
+		ctx.organizationId,
+		output,
+		{ title, content },
+		reviewer,
+	);
+	if (eventId === null) {
+		return {
+			error:
+				"The approval was already decided while this request was in flight. Refresh before acting.",
+		};
+	}
+	return {
+		action: "approve",
+		approved: true,
+		run_id: args.run_id,
+		event_id: eventId,
+		message,
+	};
 }
 
 /**
@@ -2242,31 +2344,38 @@ async function tryApproveBuilderRun(
 		);
 	}
 
-	// Phase 2 (atomic): the terminal completed runs write + the 'completed'
-	// card supersede commit together. OUTSIDE the apply catch: if the card
-	// INSERT fails (or the card is missing — the guard runs INSIDE the tx, so
-	// the completed runs write rolls back too), the run is NOT left completed
-	// or marked 'failed' — it stays in its claimed approved/running state and
-	// the persistence failure propagates to the caller.
-	const eventId = await getDb().begin(async (tx) => {
-		await tx`
-			UPDATE runs SET status = 'completed', completed_at = NOW(),
-				action_output = ${tx.json(output as unknown as Record<string, unknown>)}
-			WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
-		`;
-		const cardId = await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"completed",
-			`${handler.nounLabel}: ${desc} — completed`,
-			`Builder action completed: ${desc}`,
-			{ output: output as unknown as Record<string, unknown> },
-			reviewer,
-			tx,
-		);
-		requireApprovalCard(args.run_id, cardId, "completed");
-		return cardId;
-	});
+	// Phase 2a (durable): persist the successful apply result BEFORE the
+	// terminalization attempt, in its own transaction. If the terminal card
+	// INSERT fails, only the completed status rolls back — the output (for
+	// agent_ask, the human's answer) is already durable, so a retry can complete
+	// the run without re-applying or losing the answer.
+	await persistDurableApplyOutput(
+		args.run_id,
+		ctx.organizationId,
+		output as unknown as Record<string, unknown>,
+	);
+
+	// Phase 2b (atomic): the terminal completed runs write + the 'completed'
+	// card supersede commit together. The card guard runs INSIDE the tx, so a
+	// missing card rolls the completed write back too. A failure here (the
+	// persistence failure propagated to the caller) leaves the run claimed with
+	// its output durable — the stale-run reaper or a re-approve reconciles it.
+	const eventId = await terminalizeApprovalRunCompleted(
+		args.run_id,
+		ctx.organizationId,
+		output as unknown as Record<string, unknown>,
+		{
+			title: `${handler.nounLabel}: ${desc} — completed`,
+			content: `Builder action completed: ${desc}`,
+		},
+		reviewer,
+	);
+	if (eventId === null) {
+		return {
+			error:
+				"The approval was already decided while this request was in flight. Refresh before acting.",
+		};
+	}
 	return {
 		action: "approve",
 		approved: true,
@@ -2916,6 +3025,15 @@ async function handleApprove(
 
 	const sql = getDb();
 
+	// A run whose apply already succeeded durably but whose terminal card write
+	// failed is stuck in the claimed state (approved/running + action_output).
+	// Re-approving reconciles it — completes the run from the durable output
+	// WITHOUT re-running the external mutation — instead of reporting "not
+	// pending approval" (which would strand the run until a reaper misfires).
+	const reviewer = await resolveReviewer(ctx);
+	const reconciled = await tryReconcileTerminalization(args, ctx, reviewer);
+	if (reconciled) return reconciled;
+
 	// Builder-gate runs (manage_agents / manage_behaviors create/update/delete)
 	// reuse this same durable approval path but have run_type='internal' + no
 	// connection. One generic path applies them via their registered handler
@@ -3087,8 +3205,6 @@ async function handleApprove(
 		};
 	}
 
-	const reviewer = await resolveReviewer(ctx);
-
 	// Phase 1 (atomic): claim the run (approval_status → approved) AND write the
 	// 'confirmed' card in ONE transaction. If the card INSERT fails (or the card
 	// is missing), the claim rolls back and the run stays pending — never an
@@ -3166,28 +3282,30 @@ async function handleApprove(
 	);
 
 	if (result.status === "completed") {
-		// Phase 2 (atomic): terminal completed runs write + 'completed' card.
+		// Phase 2a (durable): persist the execution output BEFORE the
+		// terminalization attempt so a failed completed-card write cannot lose
+		// the only durable record of an already-successful external mutation.
+		await persistDurableApplyOutput(args.run_id, ctx.organizationId, result.output);
+
+		// Phase 2b (atomic): terminal completed runs write + 'completed' card.
 		// The card guard runs INSIDE the tx so a missing card rolls the
 		// completed runs write back.
-		await sql.begin(async (tx) => {
-			await tx`
-				UPDATE runs SET status = 'completed', completed_at = NOW(),
-					action_output = ${tx.json(result.output)}
-				WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
-			`;
-			const cardId = await supersedeActionEvent(
-				args.run_id,
-				ctx.organizationId,
-				"completed",
-				`${run.action_key} — completed`,
-				`Operation completed: ${run.action_key}`,
-				{ output: result.output },
-				reviewer,
-				tx,
-			);
-			requireApprovalCard(args.run_id, cardId, "completed");
-			return cardId;
-		});
+		const terminalCardId = await terminalizeApprovalRunCompleted(
+			args.run_id,
+			ctx.organizationId,
+			result.output,
+			{
+				title: `${run.action_key} — completed`,
+				content: `Operation completed: ${run.action_key}`,
+			},
+			reviewer,
+		);
+		if (terminalCardId === null) {
+			return {
+				error:
+					"The approval was already decided while this request was in flight. Refresh before acting.",
+			};
+		}
 		return {
 			action: "approve",
 			approved: true,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -95,6 +95,14 @@ import { isAdminOrOwnerRole, isSystemContext } from "../access-control";
 import type { ToolContext } from "../registry";
 import { getOrgUrlContext } from "../view-urls";
 import { action, defineActionTool } from "./action-tool";
+import {
+	type ApprovalReviewer,
+	supersedeActionEvent,
+} from "./approval-events";
+export {
+	type ApprovalReviewer,
+	supersedeActionEvent,
+} from "./approval-events";
 // Lives in its own module so dispatch-chrome-action does not import this file
 // (breaks a circular init cycle that left MANAGE_BEHAVIORS_ACTION_KEY in TDZ).
 import { waitForDeviceActionRun } from "./device-action-wait";
@@ -137,7 +145,7 @@ type InlineExecutionResult =
 			output: Record<string, unknown>;
 			metadata?: Record<string, unknown>;
 	  }
-	| { status: "failed"; error_message: string };
+	| { status: "failed"; error_message: string; output?: Record<string, unknown> };
 
 type ConnectionRow = {
   id: number;
@@ -216,13 +224,19 @@ export { ManageOperationsResultSchema, ManageOperationsSchema };
 export const manageOperations = manageOperationsTool.run;
 
 // Update the run to failed status and return the error result in one call.
+// When `deferTerminalWrite` is set the runs write is skipped — the caller
+// (approve's phase 2) persists the terminal state AND the card event in one
+// transaction, so the executor must not commit the run terminal state first.
 async function failRunInline(
 	runId: number,
 	organizationId: string,
 	errorMsg: string,
+	deferTerminalWrite = false,
 ): Promise<InlineExecutionResult> {
-	const sql = getDb();
-	await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMsg} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+	if (!deferTerminalWrite) {
+		const sql = getDb();
+		await sql`UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMsg} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+	}
 	return { status: "failed", error_message: errorMsg };
 }
 
@@ -231,9 +245,12 @@ async function completeRunInline(
 	runId: number,
 	organizationId: string,
 	output: Record<string, unknown>,
+	deferTerminalWrite = false,
 ): Promise<InlineExecutionResult> {
-	const sql = getDb();
-	await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+	if (!deferTerminalWrite) {
+		const sql = getDb();
+		await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId}`;
+	}
 	return { status: "completed", output };
 }
 
@@ -266,6 +283,7 @@ async function executeLocalActionInline(
 	requesterUserId: string | null,
 	env: Env,
 	abortSignal?: AbortSignal,
+	deferTerminalWrite = false,
 ): Promise<InlineExecutionResult> {
 	const sql = getDb();
 
@@ -283,7 +301,12 @@ async function executeLocalActionInline(
 			connectorVersion ?? null,
 		);
 	} catch (err) {
-		return failRunInline(runId, organizationId, getErrorMessage(err));
+		return failRunInline(
+			runId,
+			organizationId,
+			getErrorMessage(err),
+			deferTerminalWrite,
+		);
 	}
 
 	const { credentials, connectionCredentials, sessionState } =
@@ -356,9 +379,19 @@ async function executeLocalActionInline(
 		if (result.mode !== "action") {
 			throw new Error(`Expected action result, got mode=${result.mode}`);
 		}
-		return completeRunInline(runId, organizationId, result.output);
+		return completeRunInline(
+			runId,
+			organizationId,
+			result.output,
+			deferTerminalWrite,
+		);
 	} catch (error) {
-		return failRunInline(runId, organizationId, getErrorMessage(error));
+		return failRunInline(
+			runId,
+			organizationId,
+			getErrorMessage(error),
+			deferTerminalWrite,
+		);
 	}
 }
 
@@ -368,6 +401,7 @@ async function executeMcpToolInline(
 	connection: ConnectionRow,
 	operation: OperationDescriptor,
 	actionInput: Record<string, unknown>,
+	deferTerminalWrite = false,
 ): Promise<InlineExecutionResult> {
 	if (operation.backend_config.backend !== "mcp_tool") {
 		return {
@@ -390,7 +424,12 @@ async function executeMcpToolInline(
 			connection.id,
   );
 	} catch (error) {
-		return failRunInline(runId, organizationId, getErrorMessage(error));
+		return failRunInline(
+			runId,
+			organizationId,
+			getErrorMessage(error),
+			deferTerminalWrite,
+		);
 	}
 
   if (result.isError) {
@@ -398,12 +437,35 @@ async function executeMcpToolInline(
       (result.content as Array<{ type: string; text?: string }>).find(
 				(item) => item?.type === "text",
 			)?.text ?? "Upstream MCP error";
-    return failRunInline(runId, organizationId, errorText);
+    return failRunInline(
+      runId,
+      organizationId,
+      errorText,
+      deferTerminalWrite,
+    );
   }
 
-	return completeRunInline(runId, organizationId, {
-		content: result.content,
-	} as Record<string, unknown>);
+	return completeRunInline(
+		runId,
+		organizationId,
+		{
+			content: result.content,
+		} as Record<string, unknown>,
+		deferTerminalWrite,
+	);
+}
+
+/**
+ * Options for {@link executeOperationInline}.
+ */
+interface InlineExecutionOptions {
+	/**
+	 * Skip the executor's terminal `runs` write. Used by approve's phase 2:
+	 * the terminal run state and its card event must commit together, so the
+	 * executor cannot commit the run terminal state on the pool first (that
+	 * would leave a terminal run with no card when the card INSERT fails).
+	 */
+	deferTerminalWrite?: boolean;
 }
 
 async function executeOperationInline(
@@ -415,19 +477,22 @@ async function executeOperationInline(
 	requesterUserId: string | null,
 	env: Env,
 	abortSignal?: AbortSignal,
+	options?: InlineExecutionOptions,
 ): Promise<InlineExecutionResult> {
+	const deferTerminalWrite = options?.deferTerminalWrite ?? false;
 	if (operation.backend === "local_action") {
-    return executeLocalActionInline(
-      runId,
-      organizationId,
-      connection,
-      operation,
-      actionInput,
+		return executeLocalActionInline(
+			runId,
+			organizationId,
+			connection,
+			operation,
+			actionInput,
 			requesterUserId,
-      env,
+			env,
 			abortSignal,
-    );
-  }
+			deferTerminalWrite,
+		);
+	}
 	if (operation.backend === "mcp_tool") {
 		return executeMcpToolInline(
 			runId,
@@ -435,8 +500,9 @@ async function executeOperationInline(
 			connection,
 			operation,
 			actionInput,
+			deferTerminalWrite,
 		);
-  }
+	}
 	return executeHttpOperation(
 		runId,
 		organizationId,
@@ -444,6 +510,7 @@ async function executeOperationInline(
 		operation,
 		actionInput,
 		abortSignal,
+		deferTerminalWrite,
 	);
 }
 
@@ -1769,126 +1836,25 @@ async function handleGetRun(
 }
 
 /**
- * The human who decided an approval. Threaded from the approve/reject handler
- * (a web session — `ctx.userId` is the acting user) into every event of the
- * post-decision chain (approved → completed/failed), so each state records who
- * authorized it. `null` for system-driven supersessions with no acting user
- * (e.g. a worker completing a device action it was told to run).
+ * Fail-closed guard for managed approval transitions. {@link
+ * supersedeActionEvent} returns `undefined` when the run has NO approval card
+ * (`current_event_records` has no matching `interaction_type='approval'` row) —
+ * which is legitimate only for auto/no-approval worker actions that never had a
+ * card. A managed approval DECISION (approve/reject/expire) must never commit
+ * its runs write without the card, or the run goes terminal while the timeline
+ * stays stuck at the prior card. Callers throw on `undefined` so the enclosing
+ * transaction rolls the runs write back.
  */
-export interface ApprovalReviewer {
-  userId: string;
-  /** Display name resolved at decision time; falls back to userId when unknown. */
-  name: string | null;
-}
-
-export async function supersedeActionEvent(
+function requireApprovalCard(
 	runId: number,
-	organizationId: string,
-	status: string,
-	title: string,
-	content: string,
-	extraMetadata: Record<string, unknown> = {},
-	reviewer: ApprovalReviewer | null = null,
-	db: DbClient = getDb(),
-	interactionInput?: Record<string, unknown> | null,
-): Promise<number | undefined> {
-  const sql = db;
-  const originalEvent = await sql`
-    SELECT id, entity_ids, connection_id, connector_key, metadata, author_name, interaction_input_schema, interaction_input
-    FROM current_event_records
-    WHERE run_id = ${runId}
-      AND organization_id = ${organizationId}
-      AND semantic_type = 'operation'
-      AND interaction_type = 'approval'
-    LIMIT 1
-  `;
-	if (originalEvent.length === 0) return undefined;
-
-	const orig = originalEvent[0] as any;
-	// Carry the reviewer forward. A decision (approve/reject) supplies one; the
-	// later system transitions (completed/failed) don't re-supply it, so inherit
-	// the reviewer already stamped on the prior state — the person who authorized
-	// the run owns its whole outcome in the audit trail.
-	const priorMetadata = (orig.metadata ?? {}) as Record<string, unknown>;
-	const reviewedById =
-		reviewer?.userId ??
-		(priorMetadata.reviewed_by_id as string | undefined) ??
-		null;
-	const reviewedByName =
-		reviewer?.name ??
-		(priorMetadata.reviewed_by_name as string | undefined) ??
-		null;
-
-	const nextEvent = await insertEvent(
-		{
-		entityIds: Array.isArray(orig.entity_ids)
-			? orig.entity_ids.map(Number)
-			: [],
-		organizationId,
-		originId: `run_${runId}_${status}_${Date.now()}`,
-		title,
-		content,
-		semanticType: "operation",
-		connectorKey: orig.connector_key,
-		connectionId: orig.connection_id,
-		runId,
-		interactionType: "approval",
-		interactionStatus:
-			status === "confirmed"
-				? "approved"
-				: status === "rejected"
-					? "rejected"
-					: status === "completed"
-						? "completed"
-						: status === "failed"
-							? "failed"
-							: "pending",
-		interactionInputSchema:
-				(orig.interaction_input_schema as Record<string, unknown> | null) ??
-				null,
-		interactionInput:
-			interactionInput === undefined
-				? ((orig.interaction_input as Record<string, unknown> | null) ?? null)
-				: interactionInput,
-		interactionOutput:
-			((extraMetadata.output ?? extraMetadata.action_output) as
-				| Record<string, unknown>
-				| undefined) ?? null,
-		interactionError:
-			(extraMetadata.error_message as string | undefined) ?? null,
-		supersedesEventId: Number(orig.id),
-		// The durable identity (FK → user); set on the first decision event and
-		// preserved down the chain.
-		createdBy: reviewedById,
-		metadata: {
-			...priorMetadata,
-			status,
-			...(reviewedById ? { reviewed_by_id: reviewedById } : {}),
-			...(reviewedByName ? { reviewed_by_name: reviewedByName } : {}),
-				...(extraMetadata.output
-					? { action_output: extraMetadata.output }
-					: {}),
-			...(extraMetadata.error_message
-				? { error_message: extraMetadata.error_message }
-				: {}),
-			...extraMetadata,
-			// Superseding copies the prior metadata forward, so a durable approval
-			// written before the Behaviors rename (#2034) would keep minting NEW
-			// rows carrying `resourceKind: "watcher"` every time it is resolved.
-			// Canonicalize on write: history keeps whatever it recorded, but nothing
-			// emitted from here reintroduces the pre-rename value. Must stay below
-			// both spreads so neither the prior row nor a caller can restore it.
-			...(priorMetadata.resourceKind === "watcher" ||
-			extraMetadata.resourceKind === "watcher"
-				? { resourceKind: "behavior" }
-				: {}),
-		},
-		authorName: orig.author_name ?? null,
-		},
-		{ sql },
-	);
-
-	return Number(nextEvent.id);
+	eventId: number | undefined,
+	transition: string,
+): asserts eventId is number {
+	if (eventId === undefined) {
+		throw new Error(
+			`Cannot transition approval run ${runId} to '${transition}': its approval card is missing`,
+		);
+	}
 }
 
 /**
@@ -2063,12 +2029,13 @@ async function claimBuilderRun(
 	organizationId: string,
 	decision: "approved" | "rejected",
 	rejectReason?: string,
+	db: DbClient = getDb(),
 ): Promise<{
 	handler: BuilderApprovalHandler;
 	proposal: unknown;
 	requesterUserId: string | null;
 } | null> {
-	const sql = getDb();
+	const sql = db;
 	const handlers = getBuilderApprovalHandlers();
 	const actionKeys = pgTextArray(handlers.map((h) => h.actionKey));
 	const rows =
@@ -2118,19 +2085,28 @@ async function failBuilderRun(
 	errorMessage: string,
 	reviewer: ApprovalReviewer | null,
 ): Promise<ManageOperationsResult> {
-	await getDb()`
-    UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage}
-    WHERE id = ${runId} AND organization_id = ${organizationId}
-  `;
-	const eventId = await supersedeActionEvent(
-		runId,
-		organizationId,
-		"failed",
-		`${handler.nounLabel}: ${desc} — failed`,
-		`Builder action failed: ${desc} — ${errorMessage}`,
-		{ error_message: errorMessage },
-		reviewer,
-	);
+	// Atomic: the failed runs write and the 'failed' card supersede commit
+	// together. The card guard runs INSIDE the transaction, so a missing card
+	// throws while the tx is open and rolls the runs write back — the run must
+	// never land terminal with no card.
+	const eventId = await getDb().begin(async (tx) => {
+		await tx`
+			UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage}
+			WHERE id = ${runId} AND organization_id = ${organizationId}
+		`;
+		const cardId = await supersedeActionEvent(
+			runId,
+			organizationId,
+			"failed",
+			`${handler.nounLabel}: ${desc} — failed`,
+			`Builder action failed: ${desc} — ${errorMessage}`,
+			{ error_message: errorMessage },
+			reviewer,
+			tx,
+		);
+		requireApprovalCard(runId, cardId, "failed");
+		return cardId;
+	});
 	return {
 		action: "approve",
 		approved: true,
@@ -2192,28 +2168,48 @@ async function tryApproveBuilderRun(
 	const refusal = await validateBuilderRunInput(args, ctx.organizationId);
 	if (refusal) return { error: refusal };
 
-	const claimed = await claimBuilderRun(
-		args.run_id,
-		ctx.organizationId,
-		"approved",
-	);
+	const reviewer = await resolveReviewer(ctx);
+
+	// Phase 1 (atomic): claim the run AND write the 'confirmed' card in ONE
+	// transaction. If the card INSERT fails (or the card is missing), the claim
+	// rolls back and the run stays pending — never an approved run with no card
+	// (or a card with no run).
+	const claimed = await getDb().begin(async (tx) => {
+		const claim = await claimBuilderRun(
+			args.run_id,
+			ctx.organizationId,
+			"approved",
+			undefined,
+			tx,
+		);
+		if (!claim) return null;
+		const desc = claim.handler.describe(claim.proposal);
+		const confirmedEventId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"confirmed",
+			`${claim.handler.nounLabel}: ${desc} — executing`,
+			`Builder action confirmed: ${desc}`,
+			{},
+			reviewer,
+			tx,
+		);
+		requireApprovalCard(args.run_id, confirmedEventId, "confirmed");
+		return { ...claim, desc };
+	});
 	if (!claimed) return null;
 
-	const { handler, proposal, requesterUserId } = claimed;
-	const desc = handler.describe(proposal);
-	const reviewer = await resolveReviewer(ctx);
-	await supersedeActionEvent(
-		args.run_id,
-		ctx.organizationId,
-		"confirmed",
-		`${handler.nounLabel}: ${desc} — executing`,
-		`Builder action confirmed: ${desc}`,
-		{},
-		reviewer,
-	);
+	const { handler, proposal, requesterUserId, desc } = claimed;
 
+	// Apply runs OUTSIDE any transaction — the family's write can be
+	// slow/network-bound and must not hold a DB transaction open. The catch
+	// scope is DELIBERATELY only apply + its soft-failure detection: a failure
+	// AFTER apply (the completed run/card transaction) is a PERSISTENCE
+	// failure, not a business failure, and must not be recorded as 'failed' via
+	// failBuilderRun.
+	let output: unknown;
 	try {
-		const output = await handler.apply(
+		output = await handler.apply(
 			proposal,
 			ctx,
 			env,
@@ -2234,27 +2230,6 @@ async function tryApproveBuilderRun(
 				reviewer,
 			);
 		}
-		await getDb()`
-      UPDATE runs SET status = 'completed', completed_at = NOW(),
-        action_output = ${getDb().json(output as unknown as Record<string, unknown>)}
-      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
-    `;
-		const eventId = await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"completed",
-			`${handler.nounLabel}: ${desc} — completed`,
-			`Builder action completed: ${desc}`,
-			{ output: output as unknown as Record<string, unknown> },
-			reviewer,
-		);
-		return {
-			action: "approve",
-			approved: true,
-			run_id: args.run_id,
-			event_id: eventId,
-			message: `${handler.nounLabel} ${desc} approved and applied.`,
-		};
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error);
 		return failBuilderRun(
@@ -2266,6 +2241,39 @@ async function tryApproveBuilderRun(
 			reviewer,
 		);
 	}
+
+	// Phase 2 (atomic): the terminal completed runs write + the 'completed'
+	// card supersede commit together. OUTSIDE the apply catch: if the card
+	// INSERT fails (or the card is missing — the guard runs INSIDE the tx, so
+	// the completed runs write rolls back too), the run is NOT left completed
+	// or marked 'failed' — it stays in its claimed approved/running state and
+	// the persistence failure propagates to the caller.
+	const eventId = await getDb().begin(async (tx) => {
+		await tx`
+			UPDATE runs SET status = 'completed', completed_at = NOW(),
+				action_output = ${tx.json(output as unknown as Record<string, unknown>)}
+			WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+		`;
+		const cardId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"completed",
+			`${handler.nounLabel}: ${desc} — completed`,
+			`Builder action completed: ${desc}`,
+			{ output: output as unknown as Record<string, unknown> },
+			reviewer,
+			tx,
+		);
+		requireApprovalCard(args.run_id, cardId, "completed");
+		return cardId;
+	});
+	return {
+		action: "approve",
+		approved: true,
+		run_id: args.run_id,
+		event_id: eventId,
+		message: `${handler.nounLabel} ${desc} approved and applied.`,
+	};
 }
 
 /**
@@ -2279,31 +2287,39 @@ async function tryRejectBuilderRun(
 	reason: string,
 	reviewer: ApprovalReviewer | null,
 ): Promise<ManageOperationsResult | null> {
-	const claimed = await claimBuilderRun(
-		args.run_id,
-		ctx.organizationId,
-		"rejected",
-		reason,
-	);
-	if (!claimed) return null;
+	// Atomic: the cancelled runs write and the 'rejected' card supersede commit
+	// together. If the card INSERT fails, the run stays pending — never a
+	// cancelled run with the timeline stuck at 'pending'.
+	return getDb().begin(async (tx) => {
+		const claimed = await claimBuilderRun(
+			args.run_id,
+			ctx.organizationId,
+			"rejected",
+			reason,
+			tx,
+		);
+		if (!claimed) return null;
 
-	const { handler, proposal } = claimed;
-	const desc = handler.describe(proposal);
-	const eventId = await supersedeActionEvent(
-		args.run_id,
-		ctx.organizationId,
-		"rejected",
-		`${handler.nounLabel}: ${desc} — rejected`,
-		`Builder action rejected: ${desc}${args.reason ? ` — ${args.reason}` : ""}`,
-		{ reason },
-		reviewer,
-	);
-	return {
-		action: "reject",
-		rejected: true,
-		run_id: args.run_id,
-		event_id: eventId,
-	};
+		const { handler, proposal } = claimed;
+		const desc = handler.describe(proposal);
+		const eventId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"rejected",
+			`${handler.nounLabel}: ${desc} — rejected`,
+			`Builder action rejected: ${desc}${args.reason ? ` — ${args.reason}` : ""}`,
+			{ reason },
+			reviewer,
+			tx,
+		);
+		requireApprovalCard(args.run_id, eventId, "rejected");
+		return {
+			action: "reject",
+			rejected: true,
+			run_id: args.run_id,
+			event_id: eventId,
+		};
+	});
 }
 
 /**
@@ -2505,7 +2521,7 @@ async function tryApproveEntityChangeRun(
 	): Promise<ManageOperationsResult> => {
 		const operation = entityChangeOperation(proposal);
 		const description = describeEntityChange(proposal);
-		await supersedeActionEvent(
+		const confirmedEventId = await supersedeActionEvent(
 			args.run_id,
 			ctx.organizationId,
 			"confirmed",
@@ -2519,6 +2535,7 @@ async function tryApproveEntityChangeRun(
 			reviewer,
 			db,
 		);
+		requireApprovalCard(args.run_id, confirmedEventId, "confirmed");
 
 		const result = await applyEntityChangeProposal(
 			proposal,
@@ -2568,6 +2585,7 @@ async function tryApproveEntityChangeRun(
 			reviewer,
 			db,
 		);
+		requireApprovalCard(args.run_id, eventId, "completed");
 		return {
 			action: "approve",
 			approved: true,
@@ -2651,32 +2669,41 @@ async function tryApproveEntityChangeRun(
 		// Apply failures here are often transient/situational (entity gained
 		// children before a non-force delete, schema changed, etc.). Put the run
 		// BACK to pending instead of burning the proposal on one errant click —
-		// the reviewer can retry after fixing the blocker, or reject it.
-		const reset = await sql`
-      UPDATE runs SET approval_status = 'pending', status = 'pending', error_message = ${errorMessage}
-      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
-		AND (
-		  (approval_status = 'approved' AND status = 'running')
-		  OR (approval_status = 'pending' AND status = 'pending')
-		)
-		RETURNING id
-    `;
-		if (reset.length === 0) {
+		// the reviewer can retry after fixing the blocker, or reject it. The
+		// reset and the 'apply_failed' card share one transaction so a card
+		// failure cannot leave a pending run with no card.
+		const reset = await sql.begin(async (tx) => {
+			const resetRows = await tx`
+				UPDATE runs SET approval_status = 'pending', status = 'pending', error_message = ${errorMessage}
+				WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+				AND (
+				  (approval_status = 'approved' AND status = 'running')
+				  OR (approval_status = 'pending' AND status = 'pending')
+				)
+				RETURNING id
+			`;
+			if (resetRows.length > 0) {
+				const eventId = await supersedeActionEvent(
+					args.run_id,
+					ctx.organizationId,
+					"apply_failed",
+					pendingOperation === "update"
+						? "entity_field_change — apply failed, still pending"
+						: `entity_${pendingOperation} — apply failed, still pending`,
+					`Applying the approved change failed: ${errorMessage}. The approval is pending again — fix the blocker and approve once more, or reject it.`,
+					{ error_message: errorMessage },
+					reviewer,
+					tx,
+				);
+				requireApprovalCard(args.run_id, eventId, "apply_failed");
+			}
+			return resetRows.length;
+		});
+		if (reset === 0) {
 			return {
 				error: `Failed to apply entity ${pendingOperation}: ${errorMessage}. The approval changed concurrently; refresh before retrying.`,
 			};
 		}
-		await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"apply_failed",
-			pendingOperation === "update"
-				? "entity_field_change — apply failed, still pending"
-				: `entity_${pendingOperation} — apply failed, still pending`,
-			`Applying the approved change failed: ${errorMessage}. The approval is pending again — fix the blocker and approve once more, or reject it.`,
-			{ error_message: errorMessage },
-			reviewer,
-		);
 		return {
 			error: `Failed to apply entity ${pendingOperation}: ${errorMessage}. The approval is back to pending — approve again after fixing the blocker, or reject it.`,
 		};
@@ -2697,7 +2724,7 @@ async function tryApproveEntityChangeRun(
 			RETURNING id
 		`;
 		if (cancelled.length === 0) return null;
-		await supersedeActionEvent(
+		const eventId = await supersedeActionEvent(
 			args.run_id,
 			ctx.organizationId,
 			"rejected",
@@ -2709,6 +2736,7 @@ async function tryApproveEntityChangeRun(
 			null,
 			db,
 		);
+		requireApprovalCard(args.run_id, eventId, "rejected");
 		return {
 			error:
 				"This duplicate candidate was already rejected. Refresh the Behavior run.",
@@ -2777,14 +2805,24 @@ async function tryApproveEntityChangeRun(
 		}
 	}
 
-	const claimed = await claimEntityChangeRun(
-		args.run_id,
-		ctx.organizationId,
-		"approved",
-	);
-	if (!claimed) return null;
 	try {
-		return await completeApproval(sql, claimed.proposal);
+		// The non-merge family runs claim + confirm + apply + terminal write +
+		// completed card in ONE transaction, exactly like the merge family
+		// above: `applyEntityChangeProposal` is DB-only (never network-bound),
+		// so no external work is held open across the tx. The claim inside the
+		// tx is authoritative — returning null falls through to the connector
+		// path, and a rollback leaves the run exactly as it was.
+		return await sql.begin(async (tx) => {
+			const claimedInTx = await claimEntityChangeRun(
+				args.run_id,
+				ctx.organizationId,
+				"approved",
+				undefined,
+				tx,
+			);
+			if (!claimedInTx) return null;
+			return await completeApproval(tx, claimedInTx.proposal);
+		});
 	} catch (error) {
 		return applyFailure(error);
 	}
@@ -2852,6 +2890,7 @@ async function tryRejectEntityChangeRun(
 			reviewer,
 			db,
 		);
+		requireApprovalCard(args.run_id, eventId, "rejected");
 		return {
 			action: "reject",
 			rejected: true,
@@ -2860,7 +2899,9 @@ async function tryRejectEntityChangeRun(
 		};
 	};
 
-	if (!pendingIsMerge) return reject(sql);
+	// Both families reject atomically: the cancelled runs write and the
+	// 'rejected' card supersede commit together (claimEntityChangeRun and
+	// supersedeActionEvent both run on the same tx handle).
 	return sql.begin(reject);
 }
 
@@ -2998,22 +3039,40 @@ async function handleApprove(
 				? `Operation '${pendingRun.action_key}' is now disabled on this connection.`
 				: `Policy now denies '${pendingRun.action_key}' for the requesting principal.`;
 		const reviewer = await resolveReviewer(ctx);
-		await sql`
-      UPDATE runs
-      SET approval_status = 'rejected', status = 'cancelled',
-          error_message = ${why}, completed_at = NOW()
-      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
-        AND approval_status = 'pending'
-    `;
-		await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"rejected",
-			`${pendingRun.action_key} — blocked by policy`,
-			why,
-			{ reason: why },
-			reviewer,
-		);
+		// The claim re-asserts `approval_status = 'pending'`, so a run approved
+		// concurrently (or otherwise no longer pending) matches ZERO rows. In
+		// that case the decision did not happen and the card must NOT be
+		// superseded — return an explicit changed-concurrently outcome instead
+		// of writing a 'rejected' card over a live approval.
+		const cancelled = await sql.begin(async (tx) => {
+			const rows = await tx`
+				UPDATE runs
+				SET approval_status = 'rejected', status = 'cancelled',
+					error_message = ${why}, completed_at = NOW()
+				WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+					AND approval_status = 'pending'
+				RETURNING id
+			`;
+			if (rows.length === 0) return false;
+			const eventId = await supersedeActionEvent(
+				args.run_id,
+				ctx.organizationId,
+				"rejected",
+				`${pendingRun.action_key} — blocked by policy`,
+				why,
+				{ reason: why },
+				reviewer,
+				tx,
+			);
+			requireApprovalCard(args.run_id, eventId, "rejected");
+			return true;
+		});
+		if (!cancelled) {
+			return {
+				error:
+					"The approval was already decided while this request was in flight. Refresh before acting.",
+			};
+		}
 		return { error: `${why} The approval was cancelled.` };
 	}
 
@@ -3028,20 +3087,50 @@ async function handleApprove(
 		};
 	}
 
-	const runRows = await sql`
-    UPDATE runs
-    SET approval_status = 'approved',
-        action_input = ${args.input ? sql.json(args.input) : sql`action_input`}
-    WHERE id = ${args.run_id}
-      AND organization_id = ${ctx.organizationId}
-      AND approval_status = 'pending'
-      AND run_type = 'action'
-    RETURNING id, connection_id, action_key, action_input, created_by_user_id
-  `;
-	if (runRows.length === 0) {
-		return { error: "Run not found or not pending approval" };
-	}
+	const reviewer = await resolveReviewer(ctx);
 
+	// Phase 1 (atomic): claim the run (approval_status → approved) AND write the
+	// 'confirmed' card in ONE transaction. If the card INSERT fails (or the card
+	// is missing), the claim rolls back and the run stays pending — never an
+	// approved run whose card the UI can't show.
+	//
+	// `local_action` runs are executed by a worker poll that claims
+	// `status='pending'` rows, so they keep status 'pending'. Every other
+	// backend executes inline below, so its status flips to 'running' IN the
+	// same transaction as the claim + confirmed card — there is no separate
+	// post-claim status write to race with the card.
+	const setRunning = resolved.operation.backend !== "local_action";
+	const claimed = await sql.begin(async (tx) => {
+		const statusSet = setRunning ? tx`, status = 'running'` : tx``;
+		const rows = await tx`
+			UPDATE runs
+			SET approval_status = 'approved'
+				${statusSet},
+				action_input = ${args.input ? tx.json(args.input) : tx`action_input`}
+			WHERE id = ${args.run_id}
+				AND organization_id = ${ctx.organizationId}
+				AND approval_status = 'pending'
+				AND run_type = 'action'
+			RETURNING id, connection_id, action_key, action_input, created_by_user_id
+		`;
+		if (rows.length === 0) return null;
+		// The confirmed card's event id is the run's approval identity for this
+		// decision; both terminal branches report it, exactly as before.
+		const confirmedEventId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"confirmed",
+			`${(rows[0] as { action_key: string }).action_key} — executing`,
+			`Operation confirmed: ${(rows[0] as { action_key: string }).action_key} — waiting for execution`,
+			args.input ? { approved_input: args.input } : {},
+			reviewer,
+			tx,
+		);
+		requireApprovalCard(args.run_id, confirmedEventId, "confirmed");
+		return { runRows: rows, eventId: confirmedEventId };
+	});
+	if (!claimed) return { error: "Run not found or not pending approval" };
+	const { runRows, eventId } = claimed;
 	const run = runRows[0] as {
 		id: number;
 		connection_id: number;
@@ -3050,18 +3139,8 @@ async function handleApprove(
 		created_by_user_id: string | null;
 	};
 
-	const reviewer = await resolveReviewer(ctx);
-	const eventId = await supersedeActionEvent(
-		args.run_id,
-		ctx.organizationId,
-		"confirmed",
-		`${run.action_key} — executing`,
-		`Operation confirmed: ${run.action_key} — waiting for execution`,
-		args.input ? { approved_input: args.input } : {},
-		reviewer,
-	);
-
 	if (resolved.operation.backend === "local_action") {
+		// Status stays 'pending' so the worker poll claims this run.
 		return {
 			action: "approve",
 			approved: true,
@@ -3071,7 +3150,9 @@ async function handleApprove(
 		};
 	}
 
-	await sql`UPDATE runs SET status = 'running' WHERE id = ${args.run_id}`;
+	// Execution runs OUTSIDE any transaction — it is network/connector work that
+	// must not hold a DB transaction open. The executor defers its terminal runs
+	// write so phase 2 below can pair it with the terminal card atomically.
 	const result = await executeOperationInline(
 		args.run_id,
 		ctx.organizationId,
@@ -3080,18 +3161,33 @@ async function handleApprove(
 		(run.action_input ?? {}) as Record<string, unknown>,
 		run.created_by_user_id,
 		env,
+		undefined,
+		{ deferTerminalWrite: true },
 	);
 
 	if (result.status === "completed") {
-		await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"completed",
-			`${run.action_key} — completed`,
-			`Operation completed: ${run.action_key}`,
-			{ output: result.output },
-			reviewer,
-		);
+		// Phase 2 (atomic): terminal completed runs write + 'completed' card.
+		// The card guard runs INSIDE the tx so a missing card rolls the
+		// completed runs write back.
+		await sql.begin(async (tx) => {
+			await tx`
+				UPDATE runs SET status = 'completed', completed_at = NOW(),
+					action_output = ${tx.json(result.output)}
+				WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+			`;
+			const cardId = await supersedeActionEvent(
+				args.run_id,
+				ctx.organizationId,
+				"completed",
+				`${run.action_key} — completed`,
+				`Operation completed: ${run.action_key}`,
+				{ output: result.output },
+				reviewer,
+				tx,
+			);
+			requireApprovalCard(args.run_id, cardId, "completed");
+			return cardId;
+		});
 		return {
 			action: "approve",
 			approved: true,
@@ -3101,15 +3197,29 @@ async function handleApprove(
 		};
 	}
 
-	await supersedeActionEvent(
-		args.run_id,
-		ctx.organizationId,
-		"failed",
-		`${run.action_key} — failed`,
-		`Operation failed: ${run.action_key}${result.error_message ? ` — ${result.error_message}` : ""}`,
-		{ error_message: result.error_message },
-		reviewer,
-	);
+	// Phase 2 (atomic): terminal failed runs write + 'failed' card. The card
+	// guard runs INSIDE the tx so a missing card rolls the failed runs write
+	// back.
+	await sql.begin(async (tx) => {
+		await tx`
+			UPDATE runs SET status = 'failed', completed_at = NOW(),
+				action_output = ${result.output ? tx.json(result.output) : null},
+				error_message = ${result.error_message}
+			WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+		`;
+		const cardId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"failed",
+			`${run.action_key} — failed`,
+			`Operation failed: ${run.action_key}${result.error_message ? ` — ${result.error_message}` : ""}`,
+			{ error_message: result.error_message },
+			reviewer,
+			tx,
+		);
+		requireApprovalCard(args.run_id, cardId, "failed");
+		return cardId;
+	});
 	return {
 		action: "approve",
 		approved: true,
@@ -3139,35 +3249,42 @@ async function handleReject(
 	const fieldChangeReject = await tryRejectEntityChangeRun(args, ctx);
 	if (fieldChangeReject) return fieldChangeReject;
 
-	const updated = await sql`
-    UPDATE runs
-    SET approval_status = 'rejected', status = 'cancelled', error_message = ${reason}, completed_at = NOW()
-    WHERE id = ${args.run_id}
-      AND organization_id = ${ctx.organizationId}
-      AND approval_status = 'pending'
-      AND run_type = 'action'
-    RETURNING id, action_key
-  `;
-	if (updated.length === 0) {
+	// Atomic: the cancelled runs write and the 'rejected' card commit together.
+	const outcome = await sql.begin(async (tx) => {
+		const updated = await tx`
+			UPDATE runs
+			SET approval_status = 'rejected', status = 'cancelled', error_message = ${reason}, completed_at = NOW()
+			WHERE id = ${args.run_id}
+				AND organization_id = ${ctx.organizationId}
+				AND approval_status = 'pending'
+				AND run_type = 'action'
+			RETURNING id, action_key
+		`;
+		if (updated.length === 0) return null;
+
+		const operationKey = (updated[0] as { action_key: string }).action_key;
+		const eventId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"rejected",
+			`${operationKey} — rejected`,
+			`Operation rejected: ${operationKey}${args.reason ? ` — ${args.reason}` : ""}`,
+			{ reason },
+			reviewer,
+			tx,
+		);
+		requireApprovalCard(args.run_id, eventId, "rejected");
+		return eventId;
+	});
+	if (outcome === null) {
 		return { error: "Run not found or not pending approval" };
 	}
-
-	const operationKey = (updated[0] as any).action_key;
-	const eventId = await supersedeActionEvent(
-		args.run_id,
-		ctx.organizationId,
-		"rejected",
-		`${operationKey} — rejected`,
-		`Operation rejected: ${operationKey}${args.reason ? ` — ${args.reason}` : ""}`,
-		{ reason },
-		reviewer,
-	);
 
 	return {
 		action: "reject",
 		rejected: true,
 		run_id: args.run_id,
-		event_id: eventId,
+		event_id: outcome,
 	};
 }
 

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -32,6 +32,7 @@ import { errorMessage } from '../utils/errors';
 import { resolveAuthCredentials } from '../utils/auth-credential-secrets';
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';
 import { stripServerOnlyExecutionConfig } from '../tools/admin/behavior-execution-config';
+import { supersedeActionEvent } from '../tools/admin/approval-events';
 import logger from '../utils/logger';
 import { recordLifecycleEvent } from '../utils/insert-event';
 import { isCloudMode } from '../utils/cloud-mode';
@@ -47,6 +48,60 @@ const DISPATCH_FAILURE_OUTCOME: RunOutcome = 'infra_error';
 const DUE_FEEDS_LOCK_KEY = 71001;
 const DUE_FEED_MATERIALIZE_COOLDOWN_MS = 5000;
 let lastDueFeedMaterializeAttemptAt = 0;
+
+/**
+ * Fail a run that this worker already claimed. Approval-gated actions also
+ * have a durable card, so the run failure and failed-card supersede share one
+ * short transaction. Other worker lanes have no approval card and retain the
+ * existing single-row terminal transition.
+ */
+export async function failClaimedWorkerRun(params: {
+  runId: number;
+  workerId: string;
+  errorMessage: string;
+}): Promise<boolean> {
+  const sql = getDb();
+  return sql.begin(async (tx) => {
+    const rows = await tx<{
+      organization_id: string;
+      run_type: string;
+      approval_status: string;
+      action_key: string | null;
+    }>`
+      UPDATE runs
+      SET status = 'failed',
+          outcome = ${DISPATCH_FAILURE_OUTCOME},
+          completed_at = current_timestamp,
+          error_message = ${params.errorMessage}
+      WHERE id = ${params.runId}
+        AND status = 'running'
+        AND claimed_by = ${params.workerId}
+      RETURNING organization_id, run_type, approval_status, action_key
+    `;
+    if (rows.length === 0) return false;
+
+    const row = rows[0];
+    if (row.run_type === 'action' && row.approval_status === 'approved') {
+      const actionKey = row.action_key ?? 'Action';
+      const eventId = await supersedeActionEvent(
+        params.runId,
+        row.organization_id,
+        'failed',
+        `${actionKey} — failed`,
+        `Action failed before worker dispatch: ${actionKey} — ${params.errorMessage}`,
+        { error_message: params.errorMessage },
+        null,
+        tx
+      );
+      if (eventId === undefined) {
+        throw new Error(
+          `Cannot fail approval run ${params.runId}: its approval card is missing`
+        );
+      }
+    }
+    return true;
+  });
+}
 
 /** jsonb columns arrive as objects, text columns as JSON strings — normalize to an object or null. */
 function parseClaimJson(raw: unknown): Record<string, unknown> | null {
@@ -756,14 +811,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       );
     } catch (err) {
       const message = errorMessage(err);
-      await sql`
-        UPDATE runs
-        SET status = 'failed',
-            outcome = ${DISPATCH_FAILURE_OUTCOME},
-            completed_at = current_timestamp,
-            error_message = ${message}
-        WHERE id = ${row.run_id}
-      `;
+      await failClaimedWorkerRun({
+        runId: row.run_id,
+        workerId: worker_id,
+        errorMessage: message,
+      });
       logger.error(
         { run_id: row.run_id, err },
         'Failed to resolve pinned Behavior skills for device dispatch'
@@ -859,14 +911,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       assertConnectorAllowedInCloud(row.connector_key);
     } catch (err) {
       const message = errorMessage(err);
-      await sql`
-        UPDATE runs
-        SET status = 'failed',
-            outcome = ${DISPATCH_FAILURE_OUTCOME},
-            completed_at = current_timestamp,
-            error_message = ${message}
-        WHERE id = ${row.run_id}
-      `;
+      await failClaimedWorkerRun({
+        runId: row.run_id,
+        workerId: worker_id,
+        errorMessage: message,
+      });
       logger.warn(
         { run_id: row.run_id, connector_key: row.connector_key },
         'Blocked cloud-restricted connector run under LOBU_CLOUD_MODE'
@@ -904,14 +953,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       });
     } catch (err) {
       const message = errorMessage(err);
-      await sql`
-        UPDATE runs
-        SET status = 'failed',
-            outcome = ${DISPATCH_FAILURE_OUTCOME},
-            completed_at = current_timestamp,
-            error_message = ${message}
-        WHERE id = ${row.run_id}
-      `;
+      await failClaimedWorkerRun({
+        runId: row.run_id,
+        workerId: worker_id,
+        errorMessage: message,
+      });
       logger.error(
         { run_id: row.run_id, connector_key: row.connector_key, err },
         'Failed to resolve connector code for claimed worker run'

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -36,7 +36,7 @@ import { emit } from "../events/emitter";
 import { parseJsonBody } from "../gateway/routes/shared/helpers";
 import type { Env } from "../index";
 import { notifyBrowserAuthExpired } from "../notifications/triggers";
-import { supersedeActionEvent } from "../tools/admin/manage_operations";
+import { supersedeActionEvent } from "../tools/admin/approval-events";
 import {
 	type AuthProfileKind,
 	getAuthProfileById,
@@ -1930,19 +1930,56 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 		const sql = getDb();
 
 		// Atomic terminal-state transition with the shared F2 guard (see
-		// finalizeRun), so a no-op (0 rows) means the row was already finalized by
-		// another path (e.g. waitForDeviceActionRun timed out and marked it
-		// 'timeout'). Without it a slow worker could overwrite a gateway-side
-		// timeout decision with success — and the caller has already returned
-		// timeout to its caller, so the action would double-finalize.
-		const updatedRuns = await finalizeRun(sql, {
-			runId: req.run_id,
-			workerId: req.worker_id,
-			status: req.status === "success" ? "completed" : "failed",
-			extraSet: sql`,
-          action_output = ${req.action_output ? sql.json(req.action_output) : null},
-          error_message = ${req.error_message ?? null}`,
-			returning: sql`organization_id, action_key`,
+		// finalizeRun) AND, for approval-gated runs, the card supersede in ONE
+		// transaction, so a card INSERT failure rolls the run terminal state
+		// back instead of leaving a terminal run whose timeline is stuck at the
+		// prior card. Auto/no-approval runs (`approval_status='auto'`) have no
+		// card and finalize normally — no supersede is attempted. A no-op (0
+		// rows) means the row was already finalized by another path (e.g.
+		// waitForDeviceActionRun timed out and marked it 'timeout'). Without it a
+		// slow worker could overwrite a gateway-side timeout decision with
+		// success — and the caller has already returned timeout to its caller, so
+		// the action would double-finalize.
+		const updatedRuns = await sql.begin(async (tx) => {
+			const rows = await finalizeRun(tx, {
+				runId: req.run_id,
+				workerId: req.worker_id,
+				status: req.status === "success" ? "completed" : "failed",
+				extraSet: tx`,
+					action_output = ${req.action_output ? tx.json(req.action_output) : null},
+					error_message = ${req.error_message ?? null}`,
+				returning: tx`organization_id, action_key, approval_status`,
+			});
+			if (rows.length === 0) return rows;
+
+			const organizationId = (rows[0] as any)?.organization_id;
+			const actionKey = (rows[0] as any)?.action_key ?? "Action";
+			if (
+				organizationId &&
+				(rows[0] as any)?.approval_status === "approved"
+			) {
+				const newStatus = req.status === "success" ? "completed" : "failed";
+				const eventId = await supersedeActionEvent(
+					req.run_id,
+					organizationId,
+					newStatus,
+					`${actionKey} — ${newStatus}`,
+					req.status === "success"
+						? `Action completed: ${actionKey}`
+						: `Action failed: ${actionKey}${req.error_message ? ` — ${req.error_message}` : ""}`,
+					req.status === "success"
+						? { action_output: req.action_output }
+						: { error_message: req.error_message },
+					null,
+					tx,
+				);
+				if (eventId === undefined) {
+					throw new Error(
+						`Cannot finalize approval run ${req.run_id} as '${newStatus}': its approval card is missing`,
+					);
+				}
+			}
+			return rows;
 		});
 		if (updatedRuns.length === 0) {
 			// Either the run was already finalized (timeout race) or the
@@ -1961,23 +1998,8 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 		}
 
 		const organizationId = (updatedRuns[0] as any)?.organization_id;
-		const actionKey = (updatedRuns[0] as any)?.action_key ?? "Action";
 
 		if (organizationId) {
-			const newStatus = req.status === "success" ? "completed" : "failed";
-			await supersedeActionEvent(
-				req.run_id,
-				organizationId,
-				newStatus,
-				`${actionKey} — ${newStatus}`,
-				req.status === "success"
-					? `Action completed: ${actionKey}`
-					: `Action failed: ${actionKey}${req.error_message ? ` — ${req.error_message}` : ""}`,
-				req.status === "success"
-					? { action_output: req.action_output }
-					: { error_message: req.error_message }
-			);
-
 			emit(organizationId, { keys: ["contents-filtered", "notifications"] });
 		}
 


### PR DESCRIPTION
## Summary

- make approval run/card transitions atomic across queueing, human decisions, inline execution, worker completion/failure, scheduled expiry, stale timeout, and connection deletion
- persist successful external-apply output before terminal card writes so reconciliation can finish without repeating the side effect or losing a human answer
- perform fallible external connection teardown first, then serialize the connection tombstone and all pending approval/card expiries in one database transaction
- fail closed when an approval card is missing while preserving auto/no-approval worker actions

## Blockers resolved

The first formal review found two deterministic partial-transition defects:

1. a successful external apply could lose its only durable output if the completed-card insert failed
2. connection approval expiry could commit before a later tombstone failure

The final commit adds durable output reconciliation and one-transaction tombstone/expiry transitions for managed and BYO chat connections.

## Validation

- OpenCode blocker remediation review completed
- fresh focused final run: 91 passed, 0 failed
  - approval transition + connection deletion + agent projection: 36
  - stale reaper + connection claim/lease suites: 55
- server TypeScript check passed
- pre-commit Biome and TypeScript checks passed
- final full remote preflight after rebase: 18/18 jobs passed
- `git diff --check` passed

## Design notes

- approval-card writes remain append-only supersessions
- external network/provider work is never held inside a database transaction
- terminal persistence after an external apply is idempotently reconcilable from durable run output
- a corrupt/missing approval card rolls back the entire database transition and leaves the connection reviewable
- queue-side connection guards prevent a new approval from being inserted across the tombstone decision
- `packages/server/src/tools/mcp_app.ts` is intentionally unchanged

No schema migration or public API contract is introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval requests now transition consistently with their associated cards, including completion, rejection, expiration, and failure states.
  * Failed connection deletions no longer leave partial cleanup behind; connections and pending approvals remain intact for retry.
  * Stale approved actions are now safely completed or timed out without duplicate external changes.
  * Missing approval cards prevent incomplete status transitions.
* **Reliability**
  * Approval creation, execution, worker failures, and connection cleanup now roll back atomically when related updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->